### PR TITLE
feat: apex landing page + agent-plugin download in Add-site

### DIFF
--- a/apps/landing/.gitignore
+++ b/apps/landing/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+dist-ssr
+*.local
+.DS_Store
+.vite

--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="theme-color" content="#1791A6" />
+
+    <title>WPMgr: Open-Source, Self-Hosted WordPress Fleet Management</title>
+    <meta
+      name="description"
+      content="Manage all your WordPress sites from one dashboard you own. Open source and self-hostable: scheduled backups, safe fleet updates, AVIF and WebP image optimization, uptime, and security, with a signed agent you can audit."
+    />
+    <link rel="canonical" href="https://wpmgr.app/" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://wpmgr.app/" />
+    <meta property="og:title" content="WPMgr: Open-Source, Self-Hosted WordPress Fleet Management" />
+    <meta
+      property="og:description"
+      content="All your WordPress sites, one dashboard you own. Backups, safe fleet updates, image optimization, uptime, and security, self-hosted with a signed agent you can audit."
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="WPMgr: Open-Source, Self-Hosted WordPress Fleet Management" />
+    <meta
+      name="twitter:description"
+      content="All your WordPress sites, one dashboard you own. Self-hostable WordPress fleet management with backups, updates, image optimization, uptime, and security."
+    />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+
+    <script>
+      // Apply a persisted theme before first paint to avoid a flash. Light is
+      // the default; dark is only applied when the visitor opted into it.
+      try {
+        if (localStorage.getItem("wpmgr-landing-theme") === "dark") {
+          document.documentElement.classList.add("dark");
+        }
+      } catch (e) {}
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@wpmgr/landing",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Marketing landing page for WPMgr (apex wpmgr.app). Standalone Vite + React + Tailwind v4, reuses the Impeccable design tokens.",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview --port 4173",
+    "typecheck": "tsc --noEmit",
+    "impeccable": "impeccable detect src/"
+  },
+  "dependencies": {
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.16.0",
+    "motion": "^12.40.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "tailwind-merge": "^3.6.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.3.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "impeccable": "^2.1.9",
+    "tailwindcss": "^4.3.0",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.5"
+  }
+}

--- a/apps/landing/pnpm-lock.yaml
+++ b/apps/landing/pnpm-lock.yaml
@@ -1,0 +1,2582 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^1.16.0
+        version: 1.17.0(react@19.2.6)
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.6(react@19.2.6)
+      tailwind-merge:
+        specifier: ^3.6.0
+        version: 3.6.0
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.3.0
+        version: 4.3.0(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.15)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0))
+      impeccable:
+        specifier: ^2.1.9
+        version: 2.3.2(typescript@5.9.3)
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.5
+        version: 6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)
+
+packages:
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@puppeteer/browsers@2.13.2':
+    resolution: {integrity: sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/node@4.3.0':
+    resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    resolution: {integrity: sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    resolution: {integrity: sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    resolution: {integrity: sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    resolution: {integrity: sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    resolution: {integrity: sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    resolution: {integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    resolution: {integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    resolution: {integrity: sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.0':
+    resolution: {integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.0':
+    resolution: {integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.15':
+    resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
+  bare-events@2.8.3:
+    resolution: {integrity: sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.9.1:
+    resolution: {integrity: sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.13.1:
+    resolution: {integrity: sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.3:
+    resolution: {integrity: sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==}
+
+  baseline-browser-mapping@2.10.33:
+    resolution: {integrity: sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
+    engines: {node: '>=10.0.0'}
+
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  chromium-bidi@14.0.0:
+    resolution: {integrity: sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==}
+    peerDependencies:
+      devtools-protocol: '*'
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  devtools-protocol@0.0.1608973:
+    resolution: {integrity: sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==}
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  electron-to-chromium@1.5.364:
+    resolution: {integrity: sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  enhanced-resolve@5.22.1:
+    resolution: {integrity: sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==}
+    engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  framer-motion@12.40.0:
+    resolution: {integrity: sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  impeccable@2.3.2:
+    resolution: {integrity: sha512-tfZzf1dzCT9HWSaNvw1TckZNhilnQYgB+J7Vqf6dsiWApXGDYWje3yI0IknuY0Pp8QJHxNkowQ9zCS5jg9O93g==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
+  lucide-react@1.17.0:
+    resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  motion-dom@12.40.0:
+    resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
+
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
+
+  motion@12.40.0:
+    resolution: {integrity: sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  netmask@2.1.1:
+    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
+    engines: {node: '>= 0.4.0'}
+
+  node-releases@2.0.46:
+    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
+    engines: {node: '>=18'}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  puppeteer-core@24.43.1:
+    resolution: {integrity: sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==}
+    engines: {node: '>=18'}
+
+  puppeteer@24.43.1:
+    resolution: {integrity: sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+    peerDependencies:
+      react: ^19.2.6
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  streamx@2.26.0:
+    resolution: {integrity: sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
+
+  tailwindcss@4.3.0:
+    resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typed-query-selector@2.12.2:
+    resolution: {integrity: sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  webdriver-bidi-protocol@0.4.1:
+    resolution: {integrity: sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@puppeteer/browsers@2.13.2':
+    dependencies:
+      debug: 4.4.3
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.5.0
+      semver: 7.8.1
+      tar-fs: 3.1.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    optional: true
+
+  '@tailwindcss/node@4.3.0':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.22.1
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.0
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.0':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-x64': 4.3.0
+      '@tailwindcss/oxide-freebsd-x64': 4.3.0
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.0
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.0
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.0
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
+
+  '@tailwindcss/vite@4.3.0(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
+      vite: 6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
+    optional: true
+
+  '@types/react-dom@19.2.3(@types/react@19.2.15)':
+    dependencies:
+      '@types/react': 19.2.15
+
+  '@types/react@19.2.15':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 25.9.1
+    optional: true
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  agent-base@7.1.4:
+    optional: true
+
+  ansi-regex@5.0.1:
+    optional: true
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+    optional: true
+
+  argparse@2.0.1:
+    optional: true
+
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  b4a@1.8.1:
+    optional: true
+
+  bare-events@2.8.3:
+    optional: true
+
+  bare-fs@4.7.1:
+    dependencies:
+      bare-events: 2.8.3
+      bare-path: 3.0.0
+      bare-stream: 2.13.1(bare-events@2.8.3)
+      bare-url: 2.4.3
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
+
+  bare-os@3.9.1:
+    optional: true
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.9.1
+    optional: true
+
+  bare-stream@2.13.1(bare-events@2.8.3):
+    dependencies:
+      streamx: 2.26.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.3
+    transitivePeerDependencies:
+      - react-native-b4a
+    optional: true
+
+  bare-url@2.4.3:
+    dependencies:
+      bare-path: 3.0.0
+    optional: true
+
+  baseline-browser-mapping@2.10.33: {}
+
+  basic-ftp@5.3.1:
+    optional: true
+
+  boolbase@1.0.0: {}
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.33
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.364
+      node-releases: 2.0.46
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-crc32@0.2.13:
+    optional: true
+
+  callsites@3.1.0:
+    optional: true
+
+  caniuse-lite@1.0.30001793: {}
+
+  chromium-bidi@14.0.0(devtools-protocol@0.0.1608973):
+    dependencies:
+      devtools-protocol: 0.0.1608973
+      mitt: 3.0.1
+      zod: 3.25.76
+    optional: true
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    optional: true
+
+  clsx@2.1.1: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+    optional: true
+
+  color-name@1.1.4:
+    optional: true
+
+  convert-source-map@2.0.0: {}
+
+  cosmiconfig@9.0.1(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.2.0
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css-what@6.2.2: {}
+
+  csstype@3.2.3: {}
+
+  data-uri-to-buffer@6.0.2:
+    optional: true
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+    optional: true
+
+  detect-libc@2.1.2: {}
+
+  devtools-protocol@0.0.1608973:
+    optional: true
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  electron-to-chromium@1.5.364: {}
+
+  emoji-regex@8.0.0:
+    optional: true
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+    optional: true
+
+  enhanced-resolve@5.22.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  entities@4.5.0: {}
+
+  entities@7.0.1: {}
+
+  env-paths@2.2.1:
+    optional: true
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
+    optional: true
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  escalade@3.2.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
+    optional: true
+
+  esprima@4.0.1:
+    optional: true
+
+  estraverse@5.3.0:
+    optional: true
+
+  esutils@2.0.3:
+    optional: true
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+    optional: true
+
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  fast-fifo@1.3.2:
+    optional: true
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
+    optional: true
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  framer-motion@12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      motion-dom: 12.40.0
+      motion-utils: 12.39.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5:
+    optional: true
+
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+    optional: true
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.3.1
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  graceful-fs@4.2.11: {}
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  impeccable@2.3.2(typescript@5.9.3):
+    dependencies:
+      css-select: 5.2.2
+      css-tree: 3.2.1
+      domutils: 3.2.2
+      htmlparser2: 10.1.0
+      marked: 16.4.2
+    optionalDependencies:
+      puppeteer: 24.43.1(typescript@5.9.3)
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+    optional: true
+
+  ip-address@10.2.0:
+    optional: true
+
+  is-arrayish@0.2.1:
+    optional: true
+
+  is-fullwidth-code-point@3.0.0:
+    optional: true
+
+  jiti@2.7.0: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+    optional: true
+
+  jsesc@3.1.0: {}
+
+  json-parse-even-better-errors@2.3.1:
+    optional: true
+
+  json5@2.2.3: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lines-and-columns@1.2.4:
+    optional: true
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  lru-cache@7.18.3:
+    optional: true
+
+  lucide-react@1.17.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  marked@16.4.2: {}
+
+  mdn-data@2.27.1: {}
+
+  mitt@3.0.1:
+    optional: true
+
+  motion-dom@12.40.0:
+    dependencies:
+      motion-utils: 12.39.0
+
+  motion-utils@12.39.0: {}
+
+  motion@12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      framer-motion: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
+
+  netmask@2.1.1:
+    optional: true
+
+  node-releases@2.0.46: {}
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+    optional: true
+
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.1.1
+    optional: true
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+    optional: true
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+    optional: true
+
+  pend@1.2.0:
+    optional: true
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  progress@2.0.3:
+    optional: true
+
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  proxy-from-env@1.1.0:
+    optional: true
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+    optional: true
+
+  puppeteer-core@24.43.1:
+    dependencies:
+      '@puppeteer/browsers': 2.13.2
+      chromium-bidi: 14.0.0(devtools-protocol@0.0.1608973)
+      debug: 4.4.3
+      devtools-protocol: 0.0.1608973
+      typed-query-selector: 2.12.2
+      webdriver-bidi-protocol: 0.4.1
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+    optional: true
+
+  puppeteer@24.43.1(typescript@5.9.3):
+    dependencies:
+      '@puppeteer/browsers': 2.13.2
+      chromium-bidi: 14.0.0(devtools-protocol@0.0.1608973)
+      cosmiconfig: 9.0.1(typescript@5.9.3)
+      devtools-protocol: 0.0.1608973
+      puppeteer-core: 24.43.1
+      typed-query-selector: 2.12.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - typescript
+      - utf-8-validate
+    optional: true
+
+  react-dom@19.2.6(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.27.0
+
+  react-refresh@0.17.0: {}
+
+  react@19.2.6: {}
+
+  require-directory@2.1.1:
+    optional: true
+
+  resolve-from@4.0.0:
+    optional: true
+
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      fsevents: 2.3.3
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  semver@7.8.1:
+    optional: true
+
+  smart-buffer@4.2.0:
+    optional: true
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.2.0
+      smart-buffer: 4.2.0
+    optional: true
+
+  source-map-js@1.2.1: {}
+
+  source-map@0.6.1:
+    optional: true
+
+  streamx@2.26.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+    optional: true
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+    optional: true
+
+  tailwind-merge@3.6.0: {}
+
+  tailwindcss@4.3.0: {}
+
+  tapable@2.3.3: {}
+
+  tar-fs@3.1.2:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.2.0
+    optionalDependencies:
+      bare-fs: 4.7.1
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+    optional: true
+
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.7.1
+      fast-fifo: 1.3.2
+      streamx: 2.26.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+    optional: true
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.26.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
+    optional: true
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tslib@2.8.1: {}
+
+  typed-query-selector@2.12.2:
+    optional: true
+
+  typescript@5.9.3: {}
+
+  undici-types@7.24.6:
+    optional: true
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.60.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.9.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+
+  webdriver-bidi-protocol@0.4.1:
+    optional: true
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+    optional: true
+
+  wrappy@1.0.2:
+    optional: true
+
+  ws@8.21.0:
+    optional: true
+
+  y18n@5.0.8:
+    optional: true
+
+  yallist@3.1.1: {}
+
+  yargs-parser@21.1.1:
+    optional: true
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+    optional: true
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
+    optional: true
+
+  zod@3.25.76:
+    optional: true

--- a/apps/landing/public/favicon.svg
+++ b/apps/landing/public/favicon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <!-- Fleet Hub favicon. At small sizes the satellites render as solid teal
+       dots so the one-to-many shape survives. -->
+  <rect x="11.5" y="11.5" width="9" height="9" rx="2.5" fill="#1791A6"/>
+  <g fill="#1791A6">
+    <circle cx="6.5" cy="6.5" r="2.6"/>
+    <circle cx="25.5" cy="6.5" r="2.6"/>
+    <circle cx="6.5" cy="25.5" r="2.6"/>
+    <circle cx="25.5" cy="25.5" r="2.6"/>
+  </g>
+  <g stroke="#1791A6" stroke-width="2" stroke-linecap="round">
+    <line x1="9" y1="9" x2="11.6" y2="11.6"/>
+    <line x1="23" y1="9" x2="20.4" y2="11.6"/>
+    <line x1="9" y1="23" x2="11.6" y2="20.4"/>
+    <line x1="23" y1="23" x2="20.4" y2="20.4"/>
+  </g>
+</svg>

--- a/apps/landing/scripts/check-copy.mjs
+++ b/apps/landing/scripts/check-copy.mjs
@@ -1,0 +1,56 @@
+// Copy-compliance gate for the landing page. Fails the build if any em dash,
+// en dash, or competitor product name slips into the source. Run before ship.
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = new URL("../src", import.meta.url).pathname;
+const BANNED_CHARS = [
+  { ch: "—", name: "em dash" },
+  { ch: "–", name: "en dash" },
+];
+// Named competitor products that must never appear in an open-source project.
+const BANNED_WORDS = [
+  "ManageWP",
+  "MainWP",
+  "WPvivid",
+  "FlyingPress",
+  "InfiniteWP",
+  "WP Remote",
+  "WPRemote",
+];
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) out.push(...walk(p));
+    else if (/\.(tsx?|css|html|mjs)$/.test(entry)) out.push(p);
+  }
+  return out;
+}
+
+let failures = 0;
+for (const file of walk(ROOT)) {
+  const text = readFileSync(file, "utf8");
+  const lines = text.split("\n");
+  lines.forEach((line, i) => {
+    for (const { ch, name } of BANNED_CHARS) {
+      if (line.includes(ch)) {
+        console.error(`${file}:${i + 1}  banned ${name}: ${line.trim().slice(0, 80)}`);
+        failures++;
+      }
+    }
+    for (const w of BANNED_WORDS) {
+      if (line.toLowerCase().includes(w.toLowerCase())) {
+        console.error(`${file}:${i + 1}  banned competitor name "${w}": ${line.trim().slice(0, 80)}`);
+        failures++;
+      }
+    }
+  });
+}
+
+if (failures > 0) {
+  console.error(`\ncheck-copy FAILED with ${failures} issue(s).`);
+  process.exit(1);
+}
+console.log("check-copy passed: no em dashes, en dashes, or competitor names.");

--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -1,0 +1,40 @@
+import { MotionConfig } from "motion/react";
+import {
+  Faq,
+  FeatureGrid,
+  FinalCta,
+  Footer,
+  Hero,
+  HowItWorks,
+  MediaHow,
+  MediaSpotlight,
+  NavBar,
+  OpenSource,
+  Security,
+  Stats,
+  TrustStrip,
+} from "@/sections";
+
+export function App() {
+  // reducedMotion="user" makes every motion animation honour the OS setting,
+  // pairing with the global CSS reduced-motion block for full coverage.
+  return (
+    <MotionConfig reducedMotion="user">
+      <NavBar />
+      <main>
+        <Hero />
+        <TrustStrip />
+        <FeatureGrid />
+        <MediaSpotlight />
+        <MediaHow />
+        <HowItWorks />
+        <Security />
+        <OpenSource />
+        <Stats />
+        <Faq />
+        <FinalCta />
+      </main>
+      <Footer />
+    </MotionConfig>
+  );
+}

--- a/apps/landing/src/components/before-after.tsx
+++ b/apps/landing/src/components/before-after.tsx
@@ -1,0 +1,139 @@
+import { motion } from "motion/react";
+import { CountUp } from "@/components/count-up";
+import { Card } from "@/components/cards";
+import { cn } from "@/lib/cn";
+
+const MB = (bytes: number) => `${(bytes / 1_000_000).toFixed(2)} MB`;
+
+type LibrarySegment = {
+  label: string;
+  pct: number;
+  tone: "success" | "warning" | "muted";
+};
+
+const SEG_FILL: Record<LibrarySegment["tone"], string> = {
+  success: "bg-[var(--success)]",
+  warning: "bg-[var(--warning-subtle-fg)]",
+  muted: "bg-muted-foreground/35",
+};
+const SEG_DOT: Record<LibrarySegment["tone"], string> = {
+  success: "bg-[var(--success)]",
+  warning: "bg-[var(--warning-subtle-fg)]",
+  muted: "bg-muted-foreground/45",
+};
+
+/** One byte bar. The dashed track is the original size; the solid fill scales
+ *  in from the left to the optimized ratio, so the dashed remainder reads as
+ *  trimmed bytes. Only transform animates. */
+function ByteBar({
+  label,
+  bytes,
+  ratio,
+  accent,
+}: {
+  label: string;
+  bytes: number;
+  ratio: number;
+  accent: "neutral" | "teal";
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-baseline justify-between">
+        <span className="font-mono text-xs font-medium text-muted-foreground">{label}</span>
+        <span
+          className="font-mono text-sm font-medium text-foreground"
+          style={{ fontVariantNumeric: "tabular-nums" }}
+        >
+          {MB(bytes)}
+        </span>
+      </div>
+      <div className="relative h-8 w-full overflow-hidden rounded-md border border-dashed border-border bg-background">
+        <motion.div
+          className={cn(
+            "absolute inset-y-0 left-0 w-full origin-left rounded-[5px]",
+            accent === "teal" ? "bg-primary" : "bg-muted-foreground/30",
+          )}
+          initial={{ scaleX: 0 }}
+          whileInView={{ scaleX: ratio }}
+          viewport={{ once: true, margin: "-60px" }}
+          transition={{ duration: 0.8, ease: [0.22, 1, 0.36, 1] }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function BeforeAfterCard({
+  caption,
+  originalLabel,
+  originalBytes,
+  optimizedLabel,
+  optimizedBytes,
+  library,
+}: {
+  caption: string;
+  originalLabel: string;
+  originalBytes: number;
+  optimizedLabel: string;
+  optimizedBytes: number;
+  library: LibrarySegment[];
+}) {
+  const ratio = optimizedBytes / originalBytes;
+  const savedBytes = originalBytes - optimizedBytes;
+  const savedPct = Math.round((savedBytes / originalBytes) * 100);
+
+  return (
+    <Card className="flex flex-col gap-6">
+      <div className="flex items-center justify-between gap-3 border-b border-border pb-4">
+        <span className="text-sm font-semibold text-foreground">Bytes saved on a sample upload</span>
+        <span className="font-mono text-xs text-muted-foreground">{caption}</span>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        <ByteBar label={originalLabel} bytes={originalBytes} ratio={1} accent="neutral" />
+        <ByteBar label={optimizedLabel} bytes={optimizedBytes} ratio={ratio} accent="teal" />
+      </div>
+
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 border-t border-border pt-4">
+        <CountUp
+          value={savedPct}
+          suffix="%"
+          format={(n) => `${Math.round(n)}`}
+          className="font-mono text-3xl font-semibold text-primary"
+        />
+        <span className="text-sm font-medium text-foreground">smaller on this sample,</span>
+        <CountUp
+          value={savedBytes / 1_000_000}
+          suffix=" MB"
+          format={(n) => n.toFixed(2)}
+          className="font-mono text-sm font-medium text-muted-foreground"
+        />
+        <span className="text-sm text-muted-foreground">lighter, full image and thumbnails counted.</span>
+      </div>
+
+      <div className="flex flex-col gap-2.5">
+        <span className="text-xs font-medium text-muted-foreground">Library coverage</span>
+        <div className="flex h-2.5 w-full overflow-hidden rounded-full bg-muted">
+          {library.map((seg) => (
+            <div
+              key={seg.label}
+              className={cn("h-full", SEG_FILL[seg.tone])}
+              style={{ width: `${seg.pct}%` }}
+            />
+          ))}
+        </div>
+        <div className="flex flex-wrap gap-x-5 gap-y-1.5">
+          {library.map((seg) => (
+            <span key={seg.label} className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span className={cn("h-2 w-2 rounded-full", SEG_DOT[seg.tone])} />
+              {seg.label}
+              <span className="font-mono" style={{ fontVariantNumeric: "tabular-nums" }}>
+                {seg.pct}%
+              </span>
+            </span>
+          ))}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/apps/landing/src/components/cards.tsx
+++ b/apps/landing/src/components/cards.tsx
@@ -1,0 +1,130 @@
+import { Icon } from "@/components/icon";
+import { cn } from "@/lib/cn";
+
+/** Soft hairline card. The ONLY bordered/rounded surface in a block; inner
+ *  content groups with spacing and dividers, never a second nested card. */
+export function Card({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={cn("rounded-xl border border-border bg-card p-6 shadow-sm", className)}>
+      {children}
+    </div>
+  );
+}
+
+/** Small teal-tinted icon holder. Sits beside a heading, never a big tile
+ *  stacked above it (impeccable boxed-icon-tile guard). Teal icon on a same-hue
+ *  teal-subtle fill, at --primary-pressed for a comfortable contrast margin. */
+export function IconChip({ name }: { name: string }) {
+  return (
+    <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-[var(--primary-subtle)] text-[var(--primary-pressed)]">
+      <Icon name={name} size={18} />
+    </span>
+  );
+}
+
+export function FeatureCard({
+  icon,
+  title,
+  desc,
+}: {
+  icon: string;
+  title: string;
+  desc: string;
+}) {
+  return (
+    <Card className="flex flex-col gap-3">
+      <div className="flex items-center gap-3">
+        <IconChip name={icon} />
+        <h3 className="text-lg font-semibold text-foreground">{title}</h3>
+      </div>
+      <p className="text-sm leading-relaxed text-muted-foreground">{desc}</p>
+    </Card>
+  );
+}
+
+export function StepCard({
+  n,
+  icon,
+  title,
+  desc,
+}: {
+  n: string;
+  icon: string;
+  title: string;
+  desc: string;
+}) {
+  return (
+    <Card className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <span
+          className="font-mono text-2xl font-medium text-primary"
+          style={{ fontVariantNumeric: "tabular-nums" }}
+        >
+          {n}
+        </span>
+        <Icon name={icon} size={20} className="text-muted-foreground" />
+      </div>
+      <h3 className="text-base font-semibold text-foreground">{title}</h3>
+      <p className="text-sm leading-relaxed text-muted-foreground">{desc}</p>
+    </Card>
+  );
+}
+
+/** Icon + mono value + supporting label. Used in trust, media, and open-source
+ *  proof rows. Single hairline surface. */
+export function ProofChip({
+  icon,
+  value,
+  label,
+}: {
+  icon: string;
+  value: string;
+  label: string;
+}) {
+  return (
+    <div className="flex items-start gap-3 rounded-[var(--radius)] border border-border bg-card p-4">
+      <span className="mt-0.5 text-primary">
+        <Icon name={icon} size={18} />
+      </span>
+      <div className="flex flex-col gap-0.5">
+        <span
+          className="font-mono text-sm font-medium text-foreground"
+          style={{ fontVariantNumeric: "tabular-nums" }}
+        >
+          {value}
+        </span>
+        <span className="text-xs leading-relaxed text-muted-foreground">{label}</span>
+      </div>
+    </div>
+  );
+}
+
+/** Bigger numeric proof for the day-one stats band. */
+export function StatChip({
+  icon,
+  value,
+  label,
+}: {
+  icon: string;
+  value: string;
+  label: string;
+}) {
+  return (
+    <Card className="flex flex-col gap-2">
+      <Icon name={icon} size={20} className="text-primary" />
+      <span
+        className="font-mono text-2xl font-medium text-foreground"
+        style={{ fontVariantNumeric: "tabular-nums" }}
+      >
+        {value}
+      </span>
+      <span className="text-sm leading-relaxed text-muted-foreground">{label}</span>
+    </Card>
+  );
+}

--- a/apps/landing/src/components/code-snippet.tsx
+++ b/apps/landing/src/components/code-snippet.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { Icon } from "@/components/icon";
+import { cn } from "@/lib/cn";
+
+/** A single shell command in IBM Plex Mono with a copy button. */
+export function CodeSnippet({
+  command,
+  className,
+}: {
+  command: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      // clipboard may be unavailable; the command is still selectable.
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-4 rounded-[var(--radius)] border border-border bg-card px-4 py-3",
+        className,
+      )}
+    >
+      <code className="font-mono text-sm text-foreground">
+        <span className="select-none text-muted-foreground">$ </span>
+        {command}
+      </code>
+      <button
+        type="button"
+        onClick={copy}
+        aria-label={copied ? "Copied" : "Copy command"}
+        className="inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors duration-[var(--duration-fast)] hover:bg-accent hover:text-accent-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+      >
+        <Icon name={copied ? "Check" : "Copy"} size={14} />
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}

--- a/apps/landing/src/components/count-up.tsx
+++ b/apps/landing/src/components/count-up.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef, useState } from "react";
+
+function prefersReducedMotion() {
+  return (
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+/**
+ * Counts up to `value` once it scrolls into view. Honours prefers-reduced-motion
+ * by rendering the final value immediately. Numbers render in mono tabular
+ * figures so the width never jitters during the count.
+ */
+export function CountUp({
+  value,
+  durationMs = 1100,
+  format = (n) => Math.round(n).toLocaleString("en-US"),
+  prefix = "",
+  suffix = "",
+  className,
+}: {
+  value: number;
+  durationMs?: number;
+  format?: (n: number) => string;
+  prefix?: string;
+  suffix?: string;
+  className?: string;
+}) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [display, setDisplay] = useState(() =>
+    prefersReducedMotion() ? value : 0,
+  );
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || prefersReducedMotion()) {
+      setDisplay(value);
+      return;
+    }
+    let raf = 0;
+    let start = 0;
+    let done = false;
+
+    const step = (t: number) => {
+      if (!start) start = t;
+      const p = Math.min(1, (t - start) / durationMs);
+      // ease-out-quint, matches the brand motion curve
+      const eased = 1 - Math.pow(1 - p, 5);
+      setDisplay(value * eased);
+      if (p < 1) raf = requestAnimationFrame(step);
+    };
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && !done) {
+          done = true;
+          raf = requestAnimationFrame(step);
+          io.disconnect();
+        }
+      },
+      { threshold: 0.4 },
+    );
+    io.observe(el);
+    return () => {
+      io.disconnect();
+      cancelAnimationFrame(raf);
+    };
+  }, [value, durationMs]);
+
+  return (
+    <span ref={ref} className={className} style={{ fontVariantNumeric: "tabular-nums" }}>
+      {prefix}
+      {format(display)}
+      {suffix}
+    </span>
+  );
+}

--- a/apps/landing/src/components/faq-item.tsx
+++ b/apps/landing/src/components/faq-item.tsx
@@ -1,0 +1,40 @@
+import { useId, useState } from "react";
+import { Icon } from "@/components/icon";
+
+/** Accordion row. The answer reveals via a grid-template-rows transition
+ *  (0fr to 1fr), which animates without touching height as a layout property,
+ *  and collapses to truly hidden so it stays keyboard and screen-reader sane. */
+export function FAQItem({ q, a }: { q: string; a: string }) {
+  const [open, setOpen] = useState(false);
+  const id = useId();
+
+  return (
+    <div className="border-b border-border last:border-b-0">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls={id}
+        className="flex w-full cursor-pointer items-center justify-between gap-4 py-5 text-left transition-colors duration-[var(--duration-fast)] hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+      >
+        <span className="text-base font-medium text-foreground">{q}</span>
+        <Icon
+          name="ChevronDown"
+          size={18}
+          className={`shrink-0 text-muted-foreground transition-transform duration-[var(--duration-base)] ease-[var(--ease-out-quint)] ${
+            open ? "rotate-180" : ""
+          }`}
+        />
+      </button>
+      <div
+        id={id}
+        className="grid transition-[grid-template-rows] duration-[var(--duration-base)] ease-[var(--ease-out-quint)]"
+        style={{ gridTemplateRows: open ? "1fr" : "0fr" }}
+      >
+        <div className="overflow-hidden">
+          <p className="pb-5 text-sm leading-relaxed text-muted-foreground">{a}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/landing/src/components/icon.tsx
+++ b/apps/landing/src/components/icon.tsx
@@ -1,0 +1,122 @@
+import {
+  Activity,
+  ArrowRight,
+  BadgeCheck,
+  Check,
+  ChevronDown,
+  Container as ContainerIcon,
+  Copy,
+  Cpu,
+  DatabaseBackup,
+  EyeOff,
+  FileBadge,
+  FileLock2,
+  FileScan,
+  FileSearch,
+  Globe,
+  HardDrive,
+  HelpCircle,
+  ImageDown,
+  Infinity as InfinityIcon,
+  KeyRound,
+  LayoutDashboard,
+  LockKeyhole,
+  Moon,
+  Network,
+  PlusCircle,
+  RefreshCw,
+  RotateCcw,
+  Scale,
+  ScrollText,
+  ServerCog,
+  ShieldAlert,
+  ShieldCheck,
+  ShieldOff,
+  Star,
+  Sun,
+  ToggleLeft,
+  Undo2,
+  Upload,
+  Users,
+  type LucideIcon,
+} from "lucide-react";
+
+// Explicit registry so icons are referenced by string from the content data
+// while staying tree-shakeable and type-checked. One stroke family, one weight.
+const REGISTRY: Record<string, LucideIcon> = {
+  Activity,
+  ArrowRight,
+  BadgeCheck,
+  Check,
+  ChevronDown,
+  ContainerIcon,
+  Copy,
+  Cpu,
+  DatabaseBackup,
+  EyeOff,
+  FileBadge,
+  FileLock2,
+  FileScan,
+  FileSearch,
+  Globe,
+  HardDrive,
+  HelpCircle,
+  ImageDown,
+  Infinity: InfinityIcon,
+  KeyRound,
+  LayoutDashboard,
+  LockKeyhole,
+  Moon,
+  Network,
+  PlusCircle,
+  RefreshCw,
+  RotateCcw,
+  Scale,
+  ScrollText,
+  ServerCog,
+  ShieldAlert,
+  ShieldCheck,
+  ShieldOff,
+  Star,
+  Sun,
+  ToggleLeft,
+  Undo2,
+  Upload,
+  Users,
+};
+
+export type IconName = keyof typeof REGISTRY;
+
+/** GitHub mark. lucide-react dropped brand glyphs, so the one brand icon we
+ *  genuinely need (an external link to the repo) is hand-carried here as a
+ *  filled glyph that inherits currentColor. */
+function GithubMark({ size = 20, className }: { size?: number; className?: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden
+    >
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23a11.5 11.5 0 0 1 3-.405c1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  );
+}
+
+export function Icon({
+  name,
+  size = 20,
+  className,
+  strokeWidth = 1.75,
+}: {
+  name: string;
+  size?: number;
+  className?: string;
+  strokeWidth?: number;
+}) {
+  if (name === "Github") return <GithubMark size={size} className={className} />;
+  const Cmp = REGISTRY[name] ?? HelpCircle;
+  return <Cmp size={size} strokeWidth={strokeWidth} className={className} aria-hidden />;
+}

--- a/apps/landing/src/components/logo.tsx
+++ b/apps/landing/src/components/logo.tsx
@@ -1,0 +1,70 @@
+import { cn } from "@/lib/cn";
+
+/**
+ * Fleet Hub mark. One filled center node (your dashboard) wired to four hollow
+ * satellite nodes (the sites you watch over) by short floating spokes. It reads
+ * as one self-hosted control center with several WordPress sites wired into it.
+ * Deliberately avoids any WordPress letterform or circle-W. Solid teal, no glow,
+ * no gradient. Color follows the current text color so it tracks the active
+ * theme's --primary when wrapped in a teal-colored element.
+ */
+export function FleetHubLogo({
+  size = 28,
+  className,
+}: {
+  size?: number;
+  className?: string;
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      fill="none"
+      role="img"
+      aria-label="WPMgr"
+      className={cn("text-primary", className)}
+    >
+      {/* Center node: the dashboard */}
+      <rect x="12" y="12" width="8" height="8" rx="2" fill="currentColor" />
+      {/* Four satellite sites: hollow rounded squares */}
+      <g stroke="currentColor" strokeWidth="1.75" fill="none">
+        <rect x="4.5" y="4.5" width="5" height="5" rx="1.5" />
+        <rect x="22.5" y="4.5" width="5" height="5" rx="1.5" />
+        <rect x="4.5" y="22.5" width="5" height="5" rx="1.5" />
+        <rect x="22.5" y="22.5" width="5" height="5" rx="1.5" />
+      </g>
+      {/* Floating spokes: remote control plus live monitoring */}
+      <g stroke="currentColor" strokeWidth="1.75" strokeLinecap="round">
+        <line x1="9.8" y1="9.8" x2="11.8" y2="11.8" />
+        <line x1="22.2" y1="9.8" x2="20.2" y2="11.8" />
+        <line x1="9.8" y1="22.2" x2="11.8" y2="20.2" />
+        <line x1="22.2" y1="22.2" x2="20.2" y2="20.2" />
+      </g>
+    </svg>
+  );
+}
+
+/** Wordmark: "wpmgr" in IBM Plex Mono, "wp" in ink and "mgr" in solid teal. */
+export function Wordmark({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "font-mono text-lg font-medium tracking-[-0.01em] text-foreground",
+        className,
+      )}
+    >
+      wp<span className="text-[oklch(48%_0.14_195)] dark:text-primary">mgr</span>
+    </span>
+  );
+}
+
+/** Lockup: mark beside the wordmark, separated by a gap about one "m" wide. */
+export function Logo({ className }: { className?: string }) {
+  return (
+    <span className={cn("inline-flex items-center gap-2.5", className)}>
+      <FleetHubLogo size={26} />
+      <Wordmark />
+    </span>
+  );
+}

--- a/apps/landing/src/components/theme-toggle.tsx
+++ b/apps/landing/src/components/theme-toggle.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { Icon } from "@/components/icon";
+
+/** Reads the current theme. Light is the default; dark is opt-in and persisted. */
+function getInitial(): "light" | "dark" {
+  if (typeof document === "undefined") return "light";
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
+}
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<"light" | "dark">(getInitial);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle("dark", theme === "dark");
+    try {
+      localStorage.setItem("wpmgr-landing-theme", theme);
+    } catch {
+      // storage may be blocked; the toggle still works for the session.
+    }
+  }, [theme]);
+
+  const next = theme === "dark" ? "light" : "dark";
+  return (
+    <button
+      type="button"
+      onClick={() => setTheme(next)}
+      aria-label={`Switch to ${next} mode`}
+      className="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-[var(--radius)] border border-border bg-card text-muted-foreground transition-colors duration-[var(--duration-fast)] hover:bg-accent hover:text-accent-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+    >
+      <Icon name={theme === "dark" ? "Sun" : "Moon"} size={17} />
+    </button>
+  );
+}

--- a/apps/landing/src/components/ui/button.tsx
+++ b/apps/landing/src/components/ui/button.tsx
@@ -1,0 +1,39 @@
+import { forwardRef } from "react";
+import { cn } from "@/lib/cn";
+
+type Variant = "primary" | "secondary" | "ghost";
+type Size = "md" | "lg";
+
+const base =
+  "inline-flex items-center justify-center gap-2 rounded-[var(--radius)] font-medium whitespace-nowrap cursor-pointer select-none transition-[background-color,color,border-color,box-shadow,transform] duration-[var(--duration-fast)] ease-[var(--ease-out-quint)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)] disabled:pointer-events-none disabled:opacity-55 active:translate-y-px";
+
+const variants: Record<Variant, string> = {
+  primary:
+    "bg-primary text-primary-foreground shadow-sm hover:bg-[var(--primary-hover)] active:bg-[var(--primary-pressed)]",
+  secondary:
+    "bg-card text-foreground border border-border hover:bg-accent hover:text-accent-foreground",
+  ghost: "bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
+};
+
+const sizes: Record<Size, string> = {
+  md: "h-10 px-4 text-sm",
+  lg: "h-12 px-6 text-base",
+};
+
+export interface ButtonProps
+  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  variant?: Variant;
+  size?: Size;
+}
+
+/** Anchor-styled CTA button. Landing CTAs are all links, so this renders an <a>. */
+export const Button = forwardRef<HTMLAnchorElement, ButtonProps>(
+  ({ variant = "primary", size = "md", className, ...props }, ref) => (
+    <a
+      ref={ref}
+      className={cn(base, variants[variant], sizes[size], className)}
+      {...props}
+    />
+  ),
+);
+Button.displayName = "Button";

--- a/apps/landing/src/components/ui/primitives.tsx
+++ b/apps/landing/src/components/ui/primitives.tsx
@@ -1,0 +1,127 @@
+import { motion } from "motion/react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+/** Max-width content rail with responsive gutters. */
+export function Container({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className={cn("mx-auto w-full max-w-6xl px-5 sm:px-6 lg:px-8", className)}>
+      {children}
+    </div>
+  );
+}
+
+/** A vertical section band. `tone` swaps the surface for alternating rhythm. */
+export function Section({
+  id,
+  tone = "base",
+  className,
+  children,
+}: {
+  id?: string;
+  tone?: "base" | "muted";
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section
+      id={id}
+      className={cn(
+        "scroll-mt-20 py-20 sm:py-24 lg:py-28",
+        tone === "muted" && "bg-muted/40",
+        className,
+      )}
+    >
+      {children}
+    </section>
+  );
+}
+
+/** Eyebrow label above a section heading. Solid teal text, no glow. */
+export function Eyebrow({ children }: { children: ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--eyebrow)]">
+      <span aria-hidden className="h-px w-6 bg-primary/60" />
+      {children}
+    </span>
+  );
+}
+
+/** Centered section header: eyebrow, title, optional lead paragraph. */
+export function SectionHeading({
+  eyebrow,
+  title,
+  lead,
+  align = "center",
+}: {
+  eyebrow?: string;
+  title: ReactNode;
+  lead?: ReactNode;
+  align?: "center" | "left";
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-4",
+        align === "center" ? "mx-auto max-w-2xl items-center text-center" : "items-start text-left",
+      )}
+    >
+      {eyebrow ? <Eyebrow>{eyebrow}</Eyebrow> : null}
+      <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">{title}</h2>
+      {lead ? (
+        <p className="text-lg leading-relaxed text-muted-foreground">{lead}</p>
+      ) : null}
+    </div>
+  );
+}
+
+/** Small pill badge. */
+export function Badge({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1 text-xs font-medium text-muted-foreground",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+/** Scroll-into-view reveal. Opacity + small rise only (no layout props, no
+ *  bounce) so it reads as calm and passes the impeccable motion checks. The
+ *  global MotionConfig honours prefers-reduced-motion. */
+export function Reveal({
+  children,
+  delay = 0,
+  className,
+}: {
+  children: ReactNode;
+  delay?: number;
+  className?: string;
+}) {
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, y: 14 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: "-80px" }}
+      transition={{ duration: 0.34, ease: [0.22, 1, 0.36, 1], delay }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/apps/landing/src/data/content.ts
+++ b/apps/landing/src/data/content.ts
@@ -1,0 +1,325 @@
+// Single source of truth for every word on the landing page. Keeping the copy
+// here (not inline in JSX) makes the no-em-dash and no-competitor sweeps a
+// one-file grep, and keeps section components purely about layout.
+//
+// House rules baked into this copy: no em dashes, no en dashes, no competitor
+// names. Use "to" for ranges. Verified by scripts/check-copy at build time.
+
+export const SITE = {
+  name: "WPMgr",
+  tagline: "All your WordPress sites, one dashboard you own.",
+  github: "https://github.com/mosamlife/wpmgr",
+  dashboard: "https://manage.wpmgr.app",
+  metaTitle: "WPMgr: Open-Source, Self-Hosted WordPress Fleet Management",
+  metaDescription:
+    "Manage all your WordPress sites from one dashboard you own. Open source and self-hostable: scheduled backups, safe fleet updates, AVIF and WebP image optimization, uptime, and security, with a signed agent you can audit.",
+} as const;
+
+export const NAV = {
+  links: [
+    { label: "Features", href: "#features" },
+    { label: "Media", href: "#media" },
+    { label: "How it works", href: "#how-it-works" },
+    { label: "Open source", href: "#open-source" },
+    { label: "FAQ", href: "#faq" },
+  ],
+};
+
+export const HERO = {
+  badge: "First public release, v0.12",
+  heading: "Run your whole WordPress fleet from one dashboard you actually own",
+  subhead:
+    "WPMgr is the open-source, self-hostable control panel for everyone managing one site or a hundred. Enroll, monitor, update, back up, optimize images, and lock down every site from a single screen, on infrastructure you control, with a signed agent you can audit line by line.",
+  bodyLines: [
+    "Add a site by URL, paste a one-time code into the plugin, and watch it flip from Awaiting to Connected with no page refresh.",
+    "Open source under AGPL with an MIT-licensed agent. Every message it exchanges is Ed25519-signed, so nothing happens to your sites you cannot verify.",
+  ],
+  trust: [
+    { icon: "BadgeCheck", title: "No per-site fees", desc: "Free to self-host, no paid tier" },
+    { icon: "ServerCog", title: "Your infrastructure", desc: "Fleet data never leaves your server" },
+    { icon: "FileSearch", title: "Auditable agent", desc: "Read every line before you run it" },
+  ],
+  ctas: [
+    { label: "Self-host it", href: SITE.github, variant: "primary" as const, icon: "Github" },
+    { label: "See the live dashboard", href: SITE.dashboard, variant: "secondary" as const, icon: "ArrowRight" },
+  ],
+};
+
+export const TRUST = {
+  eyebrow: "Why trust it",
+  heading: "Trust earned the honest way, not borrowed from logos",
+  subhead:
+    "No customer logos to show yet, because WPMgr just shipped its first public release. So we will earn your trust the open way instead.",
+  bodyLines: [
+    "Everything is open source under the AGPL, so you can read every line before you run it. The WordPress agent is MIT-licensed and every message it exchanges with the control plane is Ed25519-signed.",
+    "Self-host it on your own server and your fleet data, backups, and media never leave infrastructure you control. Browse the live dashboard to see exactly what you get, then read the code on GitHub and judge it for yourself.",
+  ],
+  chips: [
+    { icon: "Scale", value: "AGPL-3.0", label: "Read the whole control plane in the open" },
+    { icon: "FileBadge", value: "MIT", label: "The WordPress agent is permissively licensed" },
+    { icon: "KeyRound", value: "Ed25519", label: "Every agent message is cryptographically signed" },
+    { icon: "HardDrive", value: "Self-hosted", label: "Your data stays on infrastructure you run" },
+  ],
+  cta: { label: "Read the code on GitHub", href: SITE.github, icon: "ArrowRight" },
+};
+
+export const FEATURES = {
+  eyebrow: "The platform",
+  heading: "Everything you need to run a fleet, included",
+  subhead:
+    "Connect sites, back them up, update them safely, watch their health, and lock them down. One dashboard, no add-on sprawl.",
+  body:
+    "Each capability ships in the open release. Turn on what you need, leave the rest off, and manage one site or hundreds from the same screen.",
+  cards: [
+    {
+      icon: "Network",
+      title: "Fleet connection",
+      desc:
+        "Add a site by URL, paste a one-time code into the plugin, and it goes live with no refresh. One-click login into wp-admin with no shared passwords, plus live status dots that flip the moment a site goes up, slow, or offline.",
+    },
+    {
+      icon: "DatabaseBackup",
+      title: "Backups and restore",
+      desc:
+        "Schedule backups of your database and files, then restore the whole site, just the database, just files, or a single plugin, theme, or upload. Only changed files re-upload, the site stays live during a restore, and a failed restore never leaves it half-broken.",
+    },
+    {
+      icon: "RefreshCw",
+      title: "Fleet updates",
+      desc:
+        "Preview exactly which versions will change before anything updates. A snapshot is taken before each update and reverted automatically if the site fails its health check. Push to a group or a tag in one bulk run with live per-site progress.",
+    },
+    {
+      icon: "Activity",
+      title: "Monitoring and health",
+      desc:
+        "Uptime and response-time charts over 7, 30, and 90 days, plus a fleet-wide status overview. One alert when a site goes down and one when it recovers, by email or webhook, with TLS expiry warnings and PHP fatal-error tracking.",
+    },
+    {
+      icon: "ShieldCheck",
+      title: "Security",
+      desc:
+        "Scan core files against the official WordPress checksums and flag anything modified, missing, or injected. Block brute-force logins in escalating steps without locking out real admins, allow or deny by IP with a safety rail for your own IP, and whitelabel the login page.",
+    },
+    {
+      icon: "Users",
+      title: "Team and access",
+      desc:
+        "Four roles from owner to viewer, so each person gets exactly the access they need. Share one site with a collaborator who can never see the rest of your fleet, sign in with email, or with your company's single sign-on (OIDC), and keep a tamper-evident audit log of every action.",
+    },
+  ],
+};
+
+export const MEDIA = {
+  eyebrow: "Flagship feature",
+  heading: "Lighter images, no quality loss, fully reversible",
+  subhead:
+    "Turn on Media Optimization and WPMgr re-encodes your library to AVIF and WebP in the cloud. Every browser gets the format it supports, your originals stay safely archived on the site, and you can revert any image with one click.",
+  bodyLines: [
+    "WPMgr totals the bytes saved across every variant, including all the thumbnail sizes WordPress generates, plus a running count of images optimized, so the number on your dashboard reflects real files, not one hero image per upload.",
+    "No image bytes ever pass through WPMgr's control plane. Source files move from your site to your storage, and optimized files move from the encoder to your storage, using short-lived presigned URLs while WPMgr keeps only metadata.",
+  ],
+  chips: [
+    { icon: "ImageDown", value: "AVIF + WebP", label: "Modern formats served automatically, GIFs to animated WebP" },
+    { icon: "Undo2", value: "100%", label: "Reversible: originals archived on the site" },
+    { icon: "ShieldOff", value: "0 bytes", label: "Image data on the control plane, presigned URLs only" },
+    { icon: "ToggleLeft", value: "Opt-in", label: "Disabled until you turn it on, per site" },
+  ],
+  cta: { label: "See Media Optimization live", href: SITE.dashboard, icon: "ArrowRight" },
+  // BeforeAfterCard demo data. Byte figures are illustrative of a typical
+  // photo plus its thumbnail set, framed as "a sample upload" so nothing is
+  // overstated as a guaranteed result.
+  demo: {
+    caption: "A sample upload, full image plus its thumbnail set",
+    originalLabel: "Original JPEG",
+    originalBytes: 2_480_000,
+    optimizedLabel: "Optimized AVIF",
+    optimizedBytes: 712_000,
+    library: [
+      { label: "Optimized", pct: 72, tone: "success" as const },
+      { label: "Pending", pct: 18, tone: "warning" as const },
+      { label: "Unsupported", pct: 10, tone: "muted" as const },
+    ],
+  },
+};
+
+export const MEDIA_STEPS = {
+  eyebrow: "Under the hood",
+  heading: "How Media Optimization works, end to end",
+  subhead:
+    "Four steps, every one of them reversible. Auto-optimize runs on upload without slowing the editor.",
+  steps: [
+    {
+      n: "1",
+      icon: "Upload",
+      title: "Upload or pick",
+      desc:
+        "Flip on auto-optimize and every new upload gets queued the moment WordPress finishes generating its sizes. Already have a full library? Select existing images and send them in batches. No reformatting your workflow.",
+    },
+    {
+      n: "2",
+      icon: "Cpu",
+      title: "We re-encode safely",
+      desc:
+        "A dedicated cloud encoder reads each image by its real bytes, not a guessed file extension, and re-encodes the full image plus every thumbnail to AVIF or WebP. Animated GIFs become animated WebP. Your originals are renamed and archived on the site, never deleted.",
+    },
+    {
+      n: "3",
+      icon: "Globe",
+      title: "Browsers get the modern format",
+      desc:
+        "A small .htaccess rule checks what each visitor's browser actually supports and serves the modern format only when it will display, falling back to the original everywhere else. Pages get lighter with no broken images and no front-end plugin bloat.",
+    },
+    {
+      n: "4",
+      icon: "RotateCcw",
+      title: "Revert anytime",
+      desc:
+        "Changed your mind, or a single image looks off? Restore puts every archived original back, full image and all thumbnails, and rewrites the URLs in your content. Nothing about optimization is a one-way door.",
+    },
+  ],
+};
+
+export const ENROLL = {
+  eyebrow: "Getting started",
+  heading: "From zero to managed in under a minute",
+  subhead:
+    "No SSH, no FTP, no shared admin passwords. Three steps and the site is live on your dashboard.",
+  body:
+    "The agent is a lightweight PHP plugin that needs only PHP 8.1+ and WordPress 6.0+. Backups use a pure-PHP streaming dump and archiver, so they work even on managed hosts that lock down shell access and the mysqldump binary.",
+  steps: [
+    {
+      n: "1",
+      icon: "PlusCircle",
+      title: "Add the site by URL",
+      desc:
+        "Paste a site URL into the dashboard. WPMgr generates a one-time enrollment code and marks the site as Awaiting connection.",
+    },
+    {
+      n: "2",
+      icon: "KeyRound",
+      title: "Push the one-time code",
+      desc:
+        "Install the MIT-licensed agent plugin and paste the one-time code. The agent registers its signing key and the site flips from Awaiting to Connected with no page refresh.",
+    },
+    {
+      n: "3",
+      icon: "LayoutDashboard",
+      title: "Manage everything",
+      desc:
+        "Back up, update, monitor uptime, optimize images, and lock the site down, all from the single dashboard. Disconnect cleanly anytime, and reconnecting later keeps the full history.",
+    },
+  ],
+  cta: { label: "Self-host it", href: SITE.github, icon: "Github" },
+};
+
+export const SECURITY = {
+  eyebrow: "Security and privacy",
+  heading: "Built so a mistake can never lock you out of your own sites",
+  subhead:
+    "Integrity scanning, brute-force protection, and an IP firewall across the fleet, with sensitive controls fenced off and a tamper-evident record of every action.",
+  bodyLines: [
+    "Your data lives on the infrastructure you run WPMgr on, not ours. Backups can be client-side encrypted so the control plane only ever stores ciphertext and never holds a decryption key.",
+    "Image bytes move directly between your site and your storage, and the agent redacts emails, passwords, secrets, tokens, and salts before any diagnostics ever leave a site.",
+  ],
+  items: [
+    { icon: "FileScan", title: "Core file-integrity scanning", desc: "Compares WordPress core files against the official checksums and flags anything modified, missing, or injected." },
+    { icon: "LockKeyhole", title: "Brute-force protection", desc: "Blocks repeated failed logins in escalating steps across the fleet, without locking out legitimate admins." },
+    { icon: "ShieldAlert", title: "IP firewall with a safety rail", desc: "Allow or deny visitors by IP range, with a guard that keeps your own IP from ever being blocked." },
+    { icon: "FileLock2", title: "Client-side encrypted backups", desc: "Optional end-to-end encryption means the control plane stores only ciphertext and never holds a key to decrypt it." },
+    { icon: "EyeOff", title: "Redacted diagnostics", desc: "Emails, passwords, secrets, tokens, and salts are stripped before any diagnostics leave a site." },
+    { icon: "ScrollText", title: "Tamper-evident audit log", desc: "Every login, role change, and site action is recorded in an audit log you can review." },
+  ],
+};
+
+export const OPEN_SOURCE = {
+  eyebrow: "Open source",
+  heading: "Open source, self-hosted, and yours to keep",
+  subhead:
+    "Bring up the full stack with a few commands and your fleet runs entirely on infrastructure you own.",
+  bodyLines: [
+    "WPMgr is free to self-host with no paid tier or per-site fee. The control plane and dashboard are AGPL-3.0 and the WordPress agent plugin is MIT-licensed.",
+    "The bundled Docker Compose stack brings up the control plane, dashboard, database, and storage in a few commands, and prebuilt container images are published for production setups.",
+  ],
+  command: "docker compose up -d",
+  chips: [
+    { icon: "Scale", value: "AGPL-3.0", label: "Control plane and dashboard, open to read and audit" },
+    { icon: "FileBadge", value: "MIT", label: "The WordPress agent carries a permissive license" },
+    { icon: "ContainerIcon", value: "Compose", label: "Full system up in a few commands" },
+    { icon: "Infinity", value: "Unlimited", label: "Manage one site or hundreds, no per-site fee" },
+  ],
+  ctas: [
+    { label: "Star on GitHub", href: SITE.github, variant: "primary" as const, icon: "Star" },
+    { label: "See the live dashboard", href: SITE.dashboard, variant: "secondary" as const, icon: "ArrowRight" },
+  ],
+};
+
+export const STATS = {
+  eyebrow: "Day one",
+  heading: "What you get on day one",
+  subhead: "Concrete capabilities, not a roadmap.",
+  items: [
+    { icon: "ImageDown", value: "AVIF + WebP", label: "Modern formats delivered to browsers that support them, originals as fallback" },
+    { icon: "Undo2", value: "100%", label: "Reversible by design, restore reverts every variant" },
+    { icon: "ShieldOff", value: "0 bytes", label: "Image bytes on the control plane, presigned URLs only" },
+    { icon: "Activity", value: "7 / 30 / 90 days", label: "Response-time and uptime history with fleet-wide status" },
+    { icon: "Users", value: "4 roles", label: "From owner to viewer, plus single-site sharing" },
+    { icon: "KeyRound", value: "Ed25519", label: "Signed on every control-plane message between agent and control plane" },
+  ],
+};
+
+export const FAQ = {
+  eyebrow: "FAQ",
+  heading: "Questions, answered straight",
+  subhead: "The things people ask before they self-host.",
+  items: [
+    {
+      q: "Is WPMgr free?",
+      a: "Yes. WPMgr is open source and free to self-host. The control plane and dashboard are AGPL-3.0, and the WordPress agent plugin is MIT-licensed. There is no paid tier or per-site fee to run it yourself.",
+    },
+    {
+      q: "Do I have to self-host it?",
+      a: "Self-hosting is the way WPMgr is built to run today, and it is what keeps your data on infrastructure you own. The bundled Docker Compose stack brings up the full system (control plane, dashboard, database, and storage) with a few commands, and prebuilt container images are published for production setups.",
+    },
+    {
+      q: "Does it work on managed or locked-down WordPress hosts?",
+      a: "Yes. The agent is a lightweight PHP plugin that needs PHP 8.1+ and WordPress 6.0+, nothing more. Backups use a pure-PHP streaming dump and archiver with no shell access and no mysqldump binary, so they work even on hosts that lock those down.",
+    },
+    {
+      q: "Is my data private?",
+      a: "Your data lives on the infrastructure you run WPMgr on, not ours. Backups can be client-side encrypted so the control plane only ever stores ciphertext and never holds a decryption key, image bytes move directly between your site and your storage, and the agent redacts emails, passwords, secrets, tokens, and salts before any diagnostics ever leave a site.",
+    },
+    {
+      q: "How many sites can I manage?",
+      a: "There is no built-in site limit. WPMgr is designed as fleet management for one site or many, with a real-time sites list, multi-tenant organizations, role-based access, and per-site sharing so you can hand a collaborator exactly one site without exposing the rest.",
+    },
+    {
+      q: "How do backups work?",
+      a: "You set a schedule (hourly, daily, weekly, or monthly), and each backup streams a database dump and file archive, chunks and deduplicates them so only changed data re-uploads, and stores them in your chosen destination. Restore the whole site or a single plugin, theme, upload, or table, atomically, while the site stays online.",
+    },
+  ],
+};
+
+export const FINAL_CTA = {
+  heading: "Own your WordPress management. Self-host it in minutes.",
+  subhead:
+    "Bring up the full stack with a few commands, enroll your first site with a one-time code, and run your whole fleet from a dashboard that lives on infrastructure you control.",
+  body: "Free, open source, and no per-site fee. Read every line before you run it.",
+  ctas: [
+    { label: "Self-host it", href: SITE.github, variant: "primary" as const, icon: "Github" },
+    { label: "See the live dashboard", href: SITE.dashboard, variant: "secondary" as const, icon: "ArrowRight" },
+  ],
+};
+
+export const FOOTER = {
+  tagline: SITE.tagline,
+  bodyLines: [
+    "Open source under AGPL-3.0 (control plane and dashboard) and MIT (WordPress agent).",
+    "WordPress is a trademark of the WordPress Foundation. WPMgr is an independent, self-hostable project and is not endorsed by, affiliated with, or sponsored by the WordPress Foundation or Automattic.",
+  ],
+  links: [
+    { label: "GitHub", href: SITE.github, icon: "Github" },
+    { label: "Live dashboard", href: SITE.dashboard, icon: "LayoutDashboard" },
+    { label: "License", href: SITE.github + "/blob/main/LICENSE", icon: "Scale" },
+  ],
+};

--- a/apps/landing/src/lib/cn.ts
+++ b/apps/landing/src/lib/cn.ts
@@ -1,0 +1,7 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/** Merge Tailwind classes with conflict resolution. Mirrors apps/web. */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/landing/src/main.tsx
+++ b/apps/landing/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "@/App";
+import "@/styles/globals.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/landing/src/sections.tsx
+++ b/apps/landing/src/sections.tsx
@@ -1,0 +1,507 @@
+import { Button } from "@/components/ui/button";
+import {
+  Container,
+  Eyebrow,
+  Reveal,
+  Section,
+  SectionHeading,
+} from "@/components/ui/primitives";
+import { Icon } from "@/components/icon";
+import { FleetHubLogo, Logo, Wordmark } from "@/components/logo";
+import { ThemeToggle } from "@/components/theme-toggle";
+import { FeatureCard, IconChip, ProofChip, StatChip, StepCard } from "@/components/cards";
+import { BeforeAfterCard } from "@/components/before-after";
+import { CodeSnippet } from "@/components/code-snippet";
+import { FAQItem } from "@/components/faq-item";
+import {
+  ENROLL,
+  FAQ,
+  FEATURES,
+  FINAL_CTA,
+  FOOTER,
+  HERO,
+  MEDIA,
+  MEDIA_STEPS,
+  NAV,
+  OPEN_SOURCE,
+  SECURITY,
+  SITE,
+  STATS,
+  TRUST,
+} from "@/data/content";
+
+type Cta = { label: string; href: string; variant?: "primary" | "secondary" | "ghost"; icon?: string };
+
+/** CTA link. Trailing icons (ArrowRight) sit after the label; brand icons
+ *  (Github, Star) sit before it. External links open in a new tab. */
+function CTAButton({ cta, size = "md" }: { cta: Cta; size?: "md" | "lg" }) {
+  const trailing = cta.icon === "ArrowRight";
+  const external = cta.href.startsWith("http");
+  return (
+    <Button
+      href={cta.href}
+      variant={cta.variant ?? "primary"}
+      size={size}
+      {...(external ? { target: "_blank", rel: "noreferrer noopener" } : {})}
+    >
+      {cta.icon && !trailing ? <Icon name={cta.icon} size={size === "lg" ? 18 : 16} /> : null}
+      {cta.label}
+      {cta.icon && trailing ? <Icon name={cta.icon} size={size === "lg" ? 18 : 16} /> : null}
+    </Button>
+  );
+}
+
+/* ----------------------------------------------------------------- Nav --- */
+
+export function NavBar() {
+  return (
+    <header className="sticky top-0 z-50 border-b border-border bg-background/85 backdrop-blur-md">
+      <Container className="flex h-16 items-center justify-between gap-4">
+        <a href="#top" className="cursor-pointer" aria-label="WPMgr home">
+          <Logo />
+        </a>
+        <nav className="hidden items-center gap-7 md:flex">
+          {NAV.links.map((l) => (
+            <a
+              key={l.href}
+              href={l.href}
+              className="cursor-pointer text-sm font-medium text-muted-foreground transition-colors duration-[var(--duration-fast)] hover:text-foreground"
+            >
+              {l.label}
+            </a>
+          ))}
+        </nav>
+        <div className="flex items-center gap-2">
+          <a
+            href={SITE.github}
+            target="_blank"
+            rel="noreferrer noopener"
+            aria-label="WPMgr on GitHub"
+            className="hidden h-9 w-9 cursor-pointer items-center justify-center rounded-[var(--radius)] border border-border bg-card text-muted-foreground transition-colors duration-[var(--duration-fast)] hover:bg-accent hover:text-accent-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)] sm:inline-flex"
+          >
+            <Icon name="Github" size={17} />
+          </a>
+          <ThemeToggle />
+          <Button href={SITE.github} target="_blank" rel="noreferrer noopener" className="hidden sm:inline-flex">
+            Self-host it
+          </Button>
+        </div>
+      </Container>
+    </header>
+  );
+}
+
+/* --------------------------------------------------------------- Hero ---- */
+
+/** A div-built dashboard window. No screenshots: a stylized sites list that
+ *  mirrors what the product actually shows, using sample data labelled as such. */
+function HeroPreview() {
+  const rows = [
+    { dot: "var(--success)", site: "shop.example.com", chip: "Backed up 2h ago", chipTone: "success", meta: "v0.12.4", note: "3 updates", noteTone: "warning" },
+    { dot: "var(--success)", site: "blog.example.org", chip: "Backed up 1h ago", chipTone: "success", meta: "v0.12.4", note: "Up to date", noteTone: "muted" },
+    { dot: "var(--warning-subtle-fg)", site: "studio.example.net", chip: "Backing up", chipTone: "info", meta: "v0.12.4", note: "Online", noteTone: "muted" },
+  ] as const;
+
+  const toneBg: Record<string, string> = {
+    success: "bg-[var(--success-subtle)] text-[var(--success-subtle-fg)]",
+    warning: "bg-[var(--warning-subtle)] text-[var(--warning-subtle-fg)]",
+    info: "bg-[var(--info-subtle)] text-[var(--info-subtle-fg)]",
+    muted: "bg-muted text-muted-foreground",
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-4xl overflow-hidden rounded-xl border border-border bg-card shadow-lg">
+      <div className="flex items-center gap-2 border-b border-border bg-muted/50 px-4 py-3">
+        <span className="flex gap-1.5">
+          <span className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30" />
+          <span className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30" />
+          <span className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30" />
+        </span>
+        <span className="ml-2 inline-flex items-center gap-1.5 rounded-md bg-background px-2.5 py-1 font-mono text-xs text-muted-foreground">
+          <Icon name="LayoutDashboard" size={12} />
+          manage.wpmgr.app
+        </span>
+      </div>
+      <div className="flex items-center justify-between px-5 py-3.5">
+        <span className="text-sm font-semibold text-foreground">Sites</span>
+        <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+          <span className="h-1.5 w-1.5 rounded-full bg-[var(--success)]" />
+          3 connected
+        </span>
+      </div>
+      <div className="divide-y divide-border border-t border-border">
+        {rows.map((r) => (
+          <div key={r.site} className="flex items-center gap-3 px-5 py-3.5">
+            <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: r.dot }} />
+            <span className="flex-1 truncate font-mono text-sm text-foreground">{r.site}</span>
+            <span className={`hidden rounded-full px-2 py-0.5 text-2xs font-medium sm:inline ${toneBg[r.chipTone]}`}>
+              {r.chip}
+            </span>
+            <span className="hidden font-mono text-xs text-muted-foreground md:inline">{r.meta}</span>
+            <span className={`rounded-full px-2 py-0.5 text-2xs font-medium ${toneBg[r.noteTone]}`}>{r.note}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function Hero() {
+  return (
+    <section id="top" className="relative overflow-hidden">
+      <div aria-hidden className="dot-field pointer-events-none absolute inset-0 -z-10 opacity-70" />
+      <Container className="flex flex-col items-center gap-7 pt-20 pb-16 text-center sm:pt-24 lg:pt-28">
+        <Reveal>
+          <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 text-xs font-medium text-muted-foreground">
+            <span className="h-1.5 w-1.5 rounded-full bg-[var(--success)]" />
+            {HERO.badge}
+          </span>
+        </Reveal>
+        <Reveal delay={0.05}>
+          <h1 className="mx-auto max-w-3xl text-4xl font-semibold tracking-[-0.018em] text-foreground sm:text-5xl">
+            {HERO.heading}
+          </h1>
+        </Reveal>
+        <Reveal delay={0.1}>
+          <p className="mx-auto max-w-2xl text-lg leading-relaxed text-muted-foreground">{HERO.subhead}</p>
+        </Reveal>
+        <Reveal delay={0.15}>
+          <div className="flex flex-col items-center gap-3 sm:flex-row">
+            {HERO.ctas.map((c) => (
+              <CTAButton key={c.label} cta={c} size="lg" />
+            ))}
+          </div>
+        </Reveal>
+        <Reveal delay={0.2}>
+          <ul className="flex flex-col gap-x-8 gap-y-3 pt-2 sm:flex-row sm:items-center">
+            {HERO.trust.map((t) => (
+              <li key={t.title} className="flex items-center gap-2.5 text-left">
+                <Icon name={t.icon} size={18} className="shrink-0 text-primary" />
+                <span className="text-sm">
+                  <span className="font-medium text-foreground">{t.title}.</span>{" "}
+                  <span className="text-muted-foreground">{t.desc}</span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </Reveal>
+        <Reveal delay={0.25} className="w-full pt-6">
+          <HeroPreview />
+        </Reveal>
+      </Container>
+    </section>
+  );
+}
+
+/* ------------------------------------------------------------- Sections -- */
+
+export function TrustStrip() {
+  return (
+    <Section id="trust" tone="muted">
+      <Container className="flex flex-col gap-8">
+        <Reveal>
+          <SectionHeading align="left" eyebrow={TRUST.eyebrow} title={TRUST.heading} lead={TRUST.subhead} />
+        </Reveal>
+        <Reveal>
+          <div className="grid max-w-3xl gap-4 text-base leading-relaxed text-muted-foreground">
+            {TRUST.bodyLines.map((b) => (
+              <p key={b}>{b}</p>
+            ))}
+          </div>
+        </Reveal>
+        <Reveal>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {TRUST.chips.map((c) => (
+              <ProofChip key={c.value} icon={c.icon} value={c.value} label={c.label} />
+            ))}
+          </div>
+        </Reveal>
+        <Reveal>
+          <div>
+            <CTAButton cta={{ ...TRUST.cta, variant: "ghost" }} />
+          </div>
+        </Reveal>
+      </Container>
+    </Section>
+  );
+}
+
+export function FeatureGrid() {
+  return (
+    <Section id="features">
+      <Container className="flex flex-col gap-10">
+        <Reveal>
+          <SectionHeading align="left" eyebrow={FEATURES.eyebrow} title={FEATURES.heading} lead={FEATURES.subhead} />
+        </Reveal>
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {FEATURES.cards.map((c, i) => (
+            <Reveal key={c.title} delay={(i % 3) * 0.05}>
+              <FeatureCard icon={c.icon} title={c.title} desc={c.desc} />
+            </Reveal>
+          ))}
+        </div>
+      </Container>
+    </Section>
+  );
+}
+
+export function MediaSpotlight() {
+  return (
+    <Section id="media" tone="muted">
+      <Container className="grid items-center gap-12 lg:grid-cols-2">
+        <Reveal className="flex flex-col gap-6">
+          <Eyebrow>{MEDIA.eyebrow}</Eyebrow>
+          <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">{MEDIA.heading}</h2>
+          <p className="text-lg leading-relaxed text-muted-foreground">{MEDIA.subhead}</p>
+          <div className="grid gap-3 text-sm leading-relaxed text-muted-foreground">
+            {MEDIA.bodyLines.map((b) => (
+              <p key={b}>{b}</p>
+            ))}
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {MEDIA.chips.map((c) => (
+              <ProofChip key={c.value} icon={c.icon} value={c.value} label={c.label} />
+            ))}
+          </div>
+          <div>
+            <CTAButton cta={{ ...MEDIA.cta, variant: "secondary" }} />
+          </div>
+        </Reveal>
+        <Reveal delay={0.1}>
+          <BeforeAfterCard
+            caption={MEDIA.demo.caption}
+            originalLabel={MEDIA.demo.originalLabel}
+            originalBytes={MEDIA.demo.originalBytes}
+            optimizedLabel={MEDIA.demo.optimizedLabel}
+            optimizedBytes={MEDIA.demo.optimizedBytes}
+            library={MEDIA.demo.library}
+          />
+        </Reveal>
+      </Container>
+    </Section>
+  );
+}
+
+export function MediaHow() {
+  return (
+    <Section id="media-how">
+      <Container className="flex flex-col gap-10">
+        <Reveal>
+          <SectionHeading align="left" eyebrow={MEDIA_STEPS.eyebrow} title={MEDIA_STEPS.heading} lead={MEDIA_STEPS.subhead} />
+        </Reveal>
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+          {MEDIA_STEPS.steps.map((s, i) => (
+            <Reveal key={s.n} delay={(i % 4) * 0.05}>
+              <StepCard n={s.n} icon={s.icon} title={s.title} desc={s.desc} />
+            </Reveal>
+          ))}
+        </div>
+      </Container>
+    </Section>
+  );
+}
+
+export function HowItWorks() {
+  return (
+    <Section id="how-it-works" tone="muted">
+      <Container className="flex flex-col gap-10">
+        <Reveal>
+          <SectionHeading align="left" eyebrow={ENROLL.eyebrow} title={ENROLL.heading} lead={ENROLL.subhead} />
+        </Reveal>
+        <Reveal>
+          <p className="max-w-3xl text-base leading-relaxed text-muted-foreground">{ENROLL.body}</p>
+        </Reveal>
+        <div className="grid gap-5 sm:grid-cols-3">
+          {ENROLL.steps.map((s, i) => (
+            <Reveal key={s.n} delay={i * 0.05}>
+              <StepCard n={s.n} icon={s.icon} title={s.title} desc={s.desc} />
+            </Reveal>
+          ))}
+        </div>
+        <Reveal>
+          <div>
+            <CTAButton cta={ENROLL.cta} />
+          </div>
+        </Reveal>
+      </Container>
+    </Section>
+  );
+}
+
+export function Security() {
+  return (
+    <Section id="security">
+      <Container className="flex flex-col gap-10">
+        <Reveal>
+          <SectionHeading align="left" eyebrow={SECURITY.eyebrow} title={SECURITY.heading} lead={SECURITY.subhead} />
+        </Reveal>
+        <Reveal>
+          <div className="grid max-w-3xl gap-3 text-base leading-relaxed text-muted-foreground">
+            {SECURITY.bodyLines.map((b) => (
+              <p key={b}>{b}</p>
+            ))}
+          </div>
+        </Reveal>
+        <div className="grid gap-x-8 gap-y-7 sm:grid-cols-2 lg:grid-cols-3">
+          {SECURITY.items.map((it, i) => (
+            <Reveal key={it.title} delay={(i % 3) * 0.05}>
+              <div className="flex flex-col gap-2.5">
+                <div className="flex items-center gap-3">
+                  <IconChip name={it.icon} />
+                  <h3 className="text-base font-semibold text-foreground">{it.title}</h3>
+                </div>
+                <p className="text-sm leading-relaxed text-muted-foreground">{it.desc}</p>
+              </div>
+            </Reveal>
+          ))}
+        </div>
+      </Container>
+    </Section>
+  );
+}
+
+export function OpenSource() {
+  return (
+    <Section id="open-source" tone="muted">
+      <Container className="grid items-start gap-12 lg:grid-cols-2">
+        <Reveal className="flex flex-col gap-6">
+          <Eyebrow>{OPEN_SOURCE.eyebrow}</Eyebrow>
+          <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">{OPEN_SOURCE.heading}</h2>
+          <p className="text-lg leading-relaxed text-muted-foreground">{OPEN_SOURCE.subhead}</p>
+          <div className="grid gap-3 text-base leading-relaxed text-muted-foreground">
+            {OPEN_SOURCE.bodyLines.map((b) => (
+              <p key={b}>{b}</p>
+            ))}
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            {OPEN_SOURCE.ctas.map((c) => (
+              <CTAButton key={c.label} cta={c} />
+            ))}
+          </div>
+        </Reveal>
+        <Reveal delay={0.1} className="flex flex-col gap-5 rounded-xl border border-border bg-card p-6 shadow-sm">
+          <div className="flex flex-col gap-2">
+            <span className="text-sm font-semibold text-foreground">Get the stack running</span>
+            <CodeSnippet command={OPEN_SOURCE.command} />
+          </div>
+          <div className="flex flex-col">
+            {OPEN_SOURCE.chips.map((c) => (
+              <div key={c.value} className="flex items-start gap-3 border-t border-border py-3.5 first:border-t-0 first:pt-0">
+                <span className="mt-0.5 text-primary">
+                  <Icon name={c.icon} size={18} />
+                </span>
+                <div className="flex flex-col gap-0.5">
+                  <span className="font-mono text-sm font-medium text-foreground">{c.value}</span>
+                  <span className="text-xs leading-relaxed text-muted-foreground">{c.label}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </Reveal>
+      </Container>
+    </Section>
+  );
+}
+
+export function Stats() {
+  return (
+    <Section id="stats">
+      <Container className="flex flex-col gap-10">
+        <Reveal>
+          <SectionHeading align="left" eyebrow={STATS.eyebrow} title={STATS.heading} lead={STATS.subhead} />
+        </Reveal>
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {STATS.items.map((s, i) => (
+            <Reveal key={s.value + s.label} delay={(i % 3) * 0.05}>
+              <StatChip icon={s.icon} value={s.value} label={s.label} />
+            </Reveal>
+          ))}
+        </div>
+      </Container>
+    </Section>
+  );
+}
+
+export function Faq() {
+  return (
+    <Section id="faq" tone="muted">
+      <Container className="flex max-w-3xl flex-col gap-8">
+        <Reveal>
+          <SectionHeading align="left" eyebrow={FAQ.eyebrow} title={FAQ.heading} lead={FAQ.subhead} />
+        </Reveal>
+        <Reveal>
+          <div className="rounded-xl border border-border bg-card px-6 shadow-sm">
+            {FAQ.items.map((f) => (
+              <FAQItem key={f.q} q={f.q} a={f.a} />
+            ))}
+          </div>
+        </Reveal>
+      </Container>
+    </Section>
+  );
+}
+
+export function FinalCta() {
+  return (
+    <section id="get-started" className="relative overflow-hidden">
+      <div aria-hidden className="dot-field pointer-events-none absolute inset-0 -z-10 opacity-70" />
+      <Container className="flex flex-col items-center gap-6 py-20 text-center sm:py-24 lg:py-28">
+        <Reveal>
+          <h2 className="mx-auto max-w-2xl text-3xl font-semibold text-foreground sm:text-4xl">{FINAL_CTA.heading}</h2>
+        </Reveal>
+        <Reveal delay={0.05}>
+          <p className="mx-auto max-w-2xl text-lg leading-relaxed text-muted-foreground">{FINAL_CTA.subhead}</p>
+        </Reveal>
+        <Reveal delay={0.1}>
+          <div className="flex flex-col items-center gap-3 sm:flex-row">
+            {FINAL_CTA.ctas.map((c) => (
+              <CTAButton key={c.label} cta={c} size="lg" />
+            ))}
+          </div>
+        </Reveal>
+        <Reveal delay={0.15}>
+          <p className="text-sm text-muted-foreground">{FINAL_CTA.body}</p>
+        </Reveal>
+      </Container>
+    </section>
+  );
+}
+
+export function Footer() {
+  return (
+    <footer className="border-t border-border bg-background">
+      <Container className="flex flex-col gap-10 py-14">
+        <div className="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
+          <div className="flex max-w-md flex-col gap-3">
+            <span className="inline-flex items-center gap-2.5">
+              <FleetHubLogo size={24} />
+              <Wordmark />
+            </span>
+            <p className="text-sm text-muted-foreground">{FOOTER.tagline}</p>
+          </div>
+          <nav className="flex flex-wrap gap-x-10 gap-y-3">
+            {FOOTER.links.map((l) => (
+              <a
+                key={l.label}
+                href={l.href}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors duration-[var(--duration-fast)] hover:text-foreground"
+              >
+                <Icon name={l.icon} size={16} />
+                {l.label}
+              </a>
+            ))}
+          </nav>
+        </div>
+        <div className="flex flex-col gap-3 border-t border-border pt-6">
+          {FOOTER.bodyLines.map((b) => (
+            <p key={b} className="max-w-3xl text-xs leading-relaxed text-muted-foreground">
+              {b}
+            </p>
+          ))}
+        </div>
+      </Container>
+    </footer>
+  );
+}

--- a/apps/landing/src/styles/globals.css
+++ b/apps/landing/src/styles/globals.css
@@ -1,0 +1,189 @@
+@import "tailwindcss";
+
+@custom-variant dark (&:is(.dark *));
+
+/* ------------------------------------------------------------------ *
+ * Brand tokens. Copied verbatim from apps/web/src/styles/globals.css  *
+ * so the marketing site and the product share one source of truth:    *
+ * teal at hue 195, IBM Plex Sans + Mono, radius 0.5rem.               *
+ * ------------------------------------------------------------------ */
+:root {
+  --background:         oklch(99%   0.004 195);
+  --foreground:         oklch(18%   0.012 195);
+  --card:               oklch(100%  0     0);
+  --card-foreground:    oklch(18%   0.012 195);
+  --muted:              oklch(96%   0.006 195);
+  --muted-foreground:   oklch(48%   0.012 195);
+  --accent:             oklch(94%   0.012 195);
+  --accent-foreground:  oklch(22%   0.012 195);
+  --border:             oklch(91%   0.008 195);
+  --ring:               oklch(58%   0.12  195);
+
+  --primary:            oklch(58%   0.12  195);
+  --primary-foreground: oklch(99%   0.004 195);
+  --primary-hover:      oklch(53%   0.13  195);
+  --primary-pressed:    oklch(48%   0.14  195);
+  /* Teal-hued subtle fill for icon chips (replaces the blue info-subtle, which
+     clashed with the teal icon). And a darker light-mode-only teal for small
+     text (eyebrows) so it clears 4.5:1 without touching the shared --primary. */
+  --primary-subtle:     oklch(95%   0.025 195);
+  --eyebrow:            oklch(50%   0.13  195);
+
+  --success:            oklch(58% 0.14  155);
+  --success-subtle:     oklch(95% 0.025 155);
+  --success-subtle-fg:  oklch(32% 0.10  155);
+
+  --warning-subtle:     oklch(95% 0.04   75);
+  --warning-subtle-fg:  oklch(38% 0.10   75);
+
+  --info:               oklch(58% 0.10  235);
+  --info-subtle:        oklch(95% 0.02  235);
+  --info-subtle-fg:     oklch(35% 0.10  235);
+
+  --radius: 0.5rem;
+}
+
+.dark {
+  --background:         oklch(15%   0.012 195);
+  --foreground:         oklch(94%   0.008 195);
+  --card:               oklch(19%   0.014 195);
+  --card-foreground:    oklch(94%   0.008 195);
+  --muted:              oklch(22%   0.012 195);
+  --muted-foreground:   oklch(65%   0.014 195);
+  --accent:             oklch(26%   0.018 195);
+  --accent-foreground:  oklch(94%   0.008 195);
+  --border:             oklch(28%   0.014 195);
+  --ring:               oklch(68%   0.14  195);
+
+  --primary:            oklch(68%   0.14  195);
+  --primary-foreground: oklch(15%   0.012 195);
+  --primary-hover:      oklch(73%   0.14  195);
+  --primary-pressed:    oklch(78%   0.13  195);
+  /* Dark already passes for teal text, so the eyebrow reuses --primary; the
+     subtle chip fill stays a flat, glow-free teal band. */
+  --primary-subtle:     oklch(28%   0.07  195);
+  --eyebrow:            var(--primary);
+
+  --success:            oklch(68% 0.16  155);
+  --success-subtle:     oklch(28% 0.08  155);
+  --success-subtle-fg:  oklch(85% 0.10  155);
+
+  --warning-subtle:     oklch(32% 0.08   75);
+  --warning-subtle-fg:  oklch(86% 0.12   75);
+
+  --info:               oklch(68% 0.12  235);
+  --info-subtle:        oklch(28% 0.06  235);
+  --info-subtle-fg:     oklch(86% 0.08  235);
+}
+
+@theme inline {
+  --font-sans: "IBM Plex Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  --text-2xs:  0.6875rem; --text-2xs--line-height: 1rem;
+  --text-xs:   0.75rem;   --text-xs--line-height:  1.125rem;
+  --text-sm:   0.875rem;  --text-sm--line-height:  1.25rem;
+  --text-base: 1rem;      --text-base--line-height: 1.6rem;
+  --text-lg:   1.125rem;  --text-lg--line-height:  1.75rem;
+  --text-xl:   1.375rem;  --text-xl--line-height:  1.85rem;
+  --text-2xl:  1.75rem;   --text-2xl--line-height: 2.125rem;
+  --text-3xl:  2.25rem;   --text-3xl--line-height: 2.5rem;
+  --text-4xl:  2.875rem;  --text-4xl--line-height: 3.1rem;
+  --text-5xl:  3.5rem;    --text-5xl--line-height: 3.7rem;
+
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary-subtle: var(--primary-subtle);
+  --color-eyebrow: var(--eyebrow);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-border: var(--border);
+  --color-ring: var(--ring);
+  --color-success: var(--success);
+  --color-success-subtle: var(--success-subtle);
+  --color-success-subtle-fg: var(--success-subtle-fg);
+  --color-warning-subtle: var(--warning-subtle);
+  --color-warning-subtle-fg: var(--warning-subtle-fg);
+  --color-info: var(--info);
+  --color-info-subtle: var(--info-subtle);
+  --color-info-subtle-fg: var(--info-subtle-fg);
+
+  --radius-lg: var(--radius);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 12px);
+
+  --shadow-sm: 0 1px 2px 0 oklch(0% 0 0 / 0.05);
+  --shadow-md: 0 4px 12px -2px oklch(0% 0 0 / 0.08), 0 2px 4px -2px oklch(0% 0 0 / 0.04);
+  --shadow-lg: 0 12px 24px -8px oklch(0% 0 0 / 0.12), 0 4px 8px -4px oklch(0% 0 0 / 0.06);
+  --shadow-xl: 0 24px 48px -12px oklch(0% 0 0 / 0.16), 0 8px 16px -8px oklch(0% 0 0 / 0.08);
+
+  --duration-fast:   180ms;
+  --duration-base:   240ms;
+  --duration-slow:   340ms;
+  --ease-out-quint:  cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-out-expo:   cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@layer base {
+  * { border-color: var(--border); }
+
+  html {
+    font-family: var(--font-sans);
+    scroll-behavior: smooth;
+    -webkit-text-size-adjust: 100%;
+  }
+
+  body {
+    background: var(--background);
+    color: var(--foreground);
+    font-feature-settings: "cv11", "ss01", "ss03";
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+
+  code, kbd, pre, samp { font-family: var(--font-mono); }
+
+  ::selection {
+    background: var(--primary);
+    color: var(--primary-foreground);
+  }
+
+  :focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+  }
+
+  h1, h2, h3 {
+    text-wrap: balance;
+    letter-spacing: -0.018em;
+  }
+  p { text-wrap: pretty; }
+
+  @media (prefers-reduced-motion: reduce) {
+    html { scroll-behavior: auto; }
+    *, *::before, *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
+  }
+}
+
+/* Subtle dotted background field for hero and section bands. A flat, very low
+   contrast dot grid. No glow, no gradient text, no neon, so the impeccable
+   detector stays happy on the teal brand. */
+.dot-field {
+  background-image: radial-gradient(var(--border) 1px, transparent 1px);
+  background-size: 22px 22px;
+  background-position: -11px -11px;
+  -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 30%, #000 40%, transparent 78%);
+          mask-image: radial-gradient(ellipse 80% 60% at 50% 30%, #000 40%, transparent 78%);
+}

--- a/apps/landing/tsconfig.json
+++ b/apps/landing/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/apps/landing/vite.config.ts
+++ b/apps/landing/vite.config.ts
@@ -1,0 +1,19 @@
+import { fileURLToPath, URL } from "node:url";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+
+// Standalone marketing site for the apex domain (wpmgr.app). It is intentionally
+// decoupled from apps/web: no router, no API client, fully static output that
+// drops onto any static host (Cloudflare Pages, a bucket, etc.).
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  server: { port: 5180 },
+  preview: { port: 4173 },
+});

--- a/apps/web/src/features/sites/add-site-dialog.tsx
+++ b/apps/web/src/features/sites/add-site-dialog.tsx
@@ -6,6 +6,7 @@ import {
   Check,
   CircleCheck,
   Copy,
+  Download,
   Plus,
   RotateCw,
 } from "lucide-react";
@@ -23,6 +24,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { fade, scaleIn } from "@/lib/motion-presets";
+import { AGENT_PLUGIN_DOWNLOAD_URL } from "@/lib/links";
 import { useNow } from "@/lib/use-now";
 import { cn } from "@/lib/utils";
 import {
@@ -439,11 +441,22 @@ function AwaitingStep({
   return (
     <>
       <DialogBody>
-        <ol className="list-decimal space-y-1 rounded-md border border-border p-3 pl-7 text-sm text-muted-foreground">
-          <li>Install the WPMgr Agent plugin on your WordPress site.</li>
-          <li>Open the plugin settings and enter your control-plane URL.</li>
-          <li>Paste the enrollment code below and click Enroll.</li>
-        </ol>
+        <div className="space-y-2.5">
+          <ol className="list-decimal space-y-1 rounded-md border border-border p-3 pl-7 text-sm text-muted-foreground">
+            <li>Download the WPMgr Agent plugin and install it on your WordPress site.</li>
+            <li>Open the plugin settings and enter your control-plane URL.</li>
+            <li>Paste the enrollment code below and click Enroll.</li>
+          </ol>
+          {/* Direct download of the latest published agent plugin zip (GitHub
+              release asset). The browser downloads it as an attachment, so this
+              never navigates the dashboard away. */}
+          <Button asChild variant="outline" className="w-full">
+            <a href={AGENT_PLUGIN_DOWNLOAD_URL} download rel="noreferrer">
+              <Download aria-hidden="true" />
+              Download the plugin (.zip)
+            </a>
+          </Button>
+        </div>
 
         {expired ? (
           <ExpiredPanel

--- a/apps/web/src/lib/links.ts
+++ b/apps/web/src/lib/links.ts
@@ -1,0 +1,14 @@
+// Public, stable external links for the WPMgr project.
+
+/**
+ * Public download for the WPMgr Agent plugin zip. The `releases/latest/download`
+ * alias always resolves to the newest published GitHub release's asset
+ * (`wpmgr-agent.zip`, attached by the release workflow), so this never needs
+ * bumping per release. Self-hosters who fork can point this at their own fork's
+ * releases.
+ */
+export const AGENT_PLUGIN_DOWNLOAD_URL =
+  "https://github.com/mosamlife/wpmgr/releases/latest/download/wpmgr-agent.zip";
+
+/** The public source repository. */
+export const GITHUB_REPO_URL = "https://github.com/mosamlife/wpmgr";


### PR DESCRIPTION
## What

Two features from this session, now tracked in git (both already deployed to prod).

### 1. Apex marketing landing page (\`apps/landing/\`)
Standalone Vite + React 19 + Tailwind v4 site for \`wpmgr.app\`, reusing the Impeccable design tokens (teal hue 195, IBM Plex Sans/Mono) so it matches the product. 12 sections in plain WordPress-user language, the Media Optimizer as the flagship (animated before/after), the open-source/self-host story, and a Fleet Hub logo with the tagline "All your WordPress sites, one dashboard you own." Designed with the ui-ux-pro-max methodology, verified clean by \`impeccable detect\` (0 findings); no em dashes or competitor names. Deploys as static output to a public GCS bucket behind the existing HTTPS LB.

### 2. Agent-plugin download in the Add-site popup (\`apps/web\`)
A "Download the plugin (.zip)" button in the enrollment step, pointing at the latest published GitHub release asset, so users can grab the agent plugin without leaving the dialog.

## Deploy state
- Landing: live at https://wpmgr.app
- Web: deployed as \`web:v0.12.4-plugin-download\` (revision wpmgr-web-00069-2xf)

## Verification
- Landing: tsc clean, build green, impeccable 0 findings, adversarial review (13 fixes applied)
- Web: tsc clean, local build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)