### PR TITLE
v0.27.0: unified versioning + quarantine-aware media scan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,8 +104,10 @@ jobs:
 
       # make agent-zip builds vendor/ via a composer:2 container, then stages the
       # plugin under a stable wpmgr-agent/ folder (the WP slug) and zips it.
+      # VERSION is passed so the staged copy is stamped with the release tag
+      # (leading 'v' stripped inside agent-zip). The source file is not modified.
       - name: Build agent plugin zip
-        run: make agent-zip
+        run: make agent-zip VERSION=${{ steps.vars.outputs.version }}
 
       - name: Publish GitHub Release with the agent zip
         uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-06-08
+
+### Changed
+
+- Unified versioning: the open-source release tag, the api/web/media-encoder container images, and the WordPress agent plugin now all share one version number. The number jumps from 0.20.0 to 0.27.0 to land above the agent's prior 0.25.x line so the agent self-update applies cleanly. From this release forward a single tag controls what ships everywhere.
+
+### Fixed
+
+- Unused Image Cleaner: a re-scan no longer resurfaces attachments that are already in quarantine. Isolated items (files moved to quarantine, post still present) are excluded from scan candidates and reported as a separate quarantined count.
+
 ## [0.20.0] - 2026-06-08
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,19 @@ agent-zip: agent-vendor ## Package the WordPress agent plugin as a zip (with ifs
 		--exclude '.phpunit.result.cache' --exclude 'composer.lock' \
 		--exclude '.DS_Store' --exclude '*.zip' \
 		apps/agent/ release/wpmgr-agent/
+	# VERSION override: when VERSION is provided (e.g. from the release tag),
+	# strip any leading 'v' and stamp ONLY the staged copy — the source file is
+	# never modified. Two precise in-place sed replacements target exactly the
+	# plugin header "Version:" line and the WPMGR_AGENT_VERSION constant, leaving
+	# all other lines unchanged. When VERSION is unset the staged copy carries the
+	# source baseline unchanged, making this step a no-op.
+	@if [ -n "$(VERSION)" ]; then \
+		_v=$$(echo "$(VERSION)" | sed 's/^v//'); \
+		echo "agent-zip: stamping staged copy with version $$_v"; \
+		sed -i.bak -E "s/^( \* Version:[ \t]+)[0-9]+\.[0-9]+\.[0-9].*/\1$$_v/" release/wpmgr-agent/wpmgr-agent.php; \
+		sed -i.bak -E "s/^(define\('WPMGR_AGENT_VERSION', *')[^']+(')/\1$$_v\2/" release/wpmgr-agent/wpmgr-agent.php; \
+		rm -f release/wpmgr-agent/wpmgr-agent.php.bak; \
+	fi
 	cd release && zip -r wpmgr-agent.zip wpmgr-agent
 	rm -rf release/wpmgr-agent
 	@echo "agent zip: $$(du -sh release/wpmgr-agent.zip | cut -f1)"

--- a/apps/agent/includes/commands/class-media-clean-command.php
+++ b/apps/agent/includes/commands/class-media-clean-command.php
@@ -39,8 +39,13 @@
  *         }, ... ],
  *       "truncated": <bool>,            // true when library has more unused than SCAN_MAX
  *       "total_attachments": <int>,     // all attachment rows the walk visited
+ *                                       // (excludes quarantined IDs — they are out-of-scope)
  *       "referenced_count": <int>,      // count classified in-use among those visited
  *       "unused_count": <int>,          // == total (alias kept for backward compat)
+ *       "quarantined_count": <int>,     // attachment IDs excluded because they are
+ *                                       // already present in a quarantine manifest;
+ *                                       // those IDs are not walked, not counted in
+ *                                       // total_attachments, and not added to candidates.
  *       "referenced": [                 // in-use attachments among those visited
  *         {
  *           "id": <int>,
@@ -227,6 +232,11 @@ final class MediaCleanCommand implements CommandInterface
      * unused candidates), then applies offset/limit to the UNUSED list so that
      * offset=0&limit=N always returns the first N actual unused candidates.
      *
+     * Attachments whose IDs appear in any quarantine manifest on disk are excluded
+     * from the walk entirely — they are not counted in total_attachments, not tested
+     * for references, and not added to candidates. The count of excluded IDs is
+     * returned as quarantined_count.
+     *
      * @param array<string,mixed> $params
      * @return array<string,mixed>
      */
@@ -263,6 +273,15 @@ final class MediaCleanCommand implements CommandInterface
         $uploadDir   = wp_upload_dir();
         $uploadsBase = rtrim((string)($uploadDir['basedir'] ?? ''), '/\\');
 
+        // Load the set of attachment IDs that are already in a quarantine manifest.
+        // These are excluded from the scan: they are out-of-scope and must not
+        // resurface as fresh candidates after a prior isolation run.
+        // A missing or unreadable quarantine directory returns an empty set, which
+        // preserves the original scan behaviour when no quarantine has been created.
+        $quarantine        = $this->quarantine ?? new MediaQuarantine();
+        $quarantinedIds    = $quarantine->quarantinedAttachmentIds();
+        $quarantinedCount  = count($quarantinedIds);
+
         // Walk the FULL attachment library in batches, collecting unused candidates
         // until we have SCAN_MAX + 1 (the +1 lets us set the truncated flag).
         // We never apply offset/limit to the attachment walk — only to the UNUSED list.
@@ -271,7 +290,7 @@ final class MediaCleanCommand implements CommandInterface
         // is capped by SCAN_MAX).
         $allUnused        = [];
         $allReferenced    = []; // referenced entries to include in scan result
-        $totalAttachments = 0;  // diagnostic: total attachment rows walked
+        $totalAttachments = 0;  // diagnostic: total attachment rows walked (excludes quarantined)
         $scanCap          = self::SCAN_MAX + 1; // collect one extra to detect truncation
         $walkOffset       = 0;
         $walkBatch        = 200; // rows per DB round-trip
@@ -301,6 +320,13 @@ final class MediaCleanCommand implements CommandInterface
                 $id      = (int)($row['ID'] ?? 0);
                 $title   = (string)($row['post_title'] ?? '');
                 $guid    = (string)($row['guid'] ?? '');
+
+                // Skip attachments that are already quarantined. They are treated as
+                // out-of-scope: not counted in total_attachments, not tested for
+                // references, and not added to candidates or the referenced list.
+                if (isset($quarantinedIds[$id])) {
+                    continue;
+                }
 
                 $totalAttachments++; // count every attachment the walk actually visits
 
@@ -391,10 +417,11 @@ final class MediaCleanCommand implements CommandInterface
         // Log diagnostic summary to WP error_log for live investigation.
         // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
         error_log(sprintf(
-            '[wpmgr] media-clean scan: total_attachments=%d referenced=%d unused=%d truncated=%s',
+            '[wpmgr] media-clean scan: total_attachments=%d referenced=%d unused=%d quarantined=%d truncated=%s',
             $totalAttachments,
             $referencedCount,
             $unusedCount,
+            $quarantinedCount,
             $truncated ? 'true' : 'false'
         ));
         if (!empty($referencedEntries)) {
@@ -418,10 +445,11 @@ final class MediaCleanCommand implements CommandInterface
             'candidates'       => $candidates,
             'truncated'        => $truncated,
             // Diagnostic fields (always present; allows live re-scan diagnosis).
-            'total_attachments' => $totalAttachments,
-            'referenced_count'  => $referencedCount,
-            'unused_count'      => $unusedCount,
-            'referenced'        => $referencedEntries,
+            'total_attachments'  => $totalAttachments,
+            'referenced_count'   => $referencedCount,
+            'unused_count'       => $unusedCount,
+            'quarantined_count'  => $quarantinedCount,
+            'referenced'         => $referencedEntries,
         ];
     }
 

--- a/apps/agent/includes/media/class-media-quarantine.php
+++ b/apps/agent/includes/media/class-media-quarantine.php
@@ -101,7 +101,7 @@ final class MediaQuarantine
      */
     public function __construct(?string $contentDir = null)
     {
-        $base                  = $contentDir ?? WP_CONTENT_DIR;
+        $base                  = $contentDir ?? (defined('WP_CONTENT_DIR') ? WP_CONTENT_DIR : '');
         $this->quarantineRoot  = $base . '/' . self::QUARANTINE_DIR;
         $this->mediaRoot       = $this->quarantineRoot . '/' . self::MEDIA_SUBDIR;
         $this->manifestsRoot   = $this->quarantineRoot . '/' . self::MANIFESTS_SUBDIR;
@@ -438,6 +438,62 @@ final class MediaQuarantine
             'entries_processed' => count($results),
             'results'           => $results,
         ];
+    }
+
+    /**
+     * Return a set of all attachment IDs that are currently recorded in at
+     * least one quarantine manifest on disk. The returned array uses attachment
+     * ID as key with true as value, giving O(1) membership tests.
+     *
+     * Used by the scan action to exclude already-quarantined attachments from
+     * the candidate list so they do not resurface after a prior isolation run.
+     *
+     * A missing or unreadable manifests directory returns an empty array —
+     * no exclusions occur in that case, which preserves the original scan
+     * behaviour when no quarantine has ever been created.
+     *
+     * Corrupt or unreadable individual manifest files are silently skipped so
+     * a single bad file cannot break a full-library scan.
+     *
+     * @return array<int,true>
+     */
+    public function quarantinedAttachmentIds(): array
+    {
+        if (!is_dir($this->manifestsRoot)) {
+            return [];
+        }
+
+        $dirEntries = @scandir($this->manifestsRoot);
+        if ($dirEntries === false) {
+            return [];
+        }
+
+        $ids = [];
+
+        foreach ($dirEntries as $dirEntry) {
+            if ($dirEntry === '.' || $dirEntry === '..') {
+                continue;
+            }
+            if (!str_ends_with($dirEntry, '.json')) {
+                continue;
+            }
+
+            $manifestId = substr($dirEntry, 0, -5);
+            $manifest   = $this->loadManifest($manifestId);
+            if ($manifest === null) {
+                continue;
+            }
+
+            $entries = is_array($manifest['entries'] ?? null) ? $manifest['entries'] : [];
+            foreach ($entries as $entry) {
+                $attachmentId = (int)($entry['attachment_id'] ?? 0);
+                if ($attachmentId > 0) {
+                    $ids[$attachmentId] = true;
+                }
+            }
+        }
+
+        return $ids;
     }
 
     /**

--- a/apps/agent/tests/MediaCleanScanQuarantineExclusionTest.php
+++ b/apps/agent/tests/MediaCleanScanQuarantineExclusionTest.php
@@ -1,0 +1,457 @@
+<?php
+/**
+ * MediaCleanScanQuarantineExclusionTest — verifies that the scan action
+ * excludes attachments whose IDs are already recorded in a quarantine manifest
+ * from the candidate list, the total_attachments count, and the unused count.
+ *
+ * Three scenarios are covered:
+ *
+ *   1. Quarantined + unreferenced: an attachment that is both unreferenced and
+ *      present in a quarantine manifest must NOT appear in candidates; it must
+ *      NOT be counted in total_attachments or unused_count; quarantined_count
+ *      must reflect it.
+ *
+ *   2. Non-quarantined unreferenced (regression guard): an attachment that is
+ *      unreferenced and NOT in any manifest must still appear in candidates.
+ *
+ *   3. Empty / absent quarantine dir: quarantined_count must be 0 and the scan
+ *      must behave exactly as without any quarantine.
+ *
+ * The MediaQuarantine instance is injected via the constructor so filesystem I/O
+ * is fully in-process and isolated. The wpdb double mirrors the one used in
+ * MediaCleanScanPaginationTest.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Commands\MediaCleanCommand;
+use WPMgr\Agent\Media\MediaQuarantine;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Commands\MediaCleanCommand
+ * @covers \WPMgr\Agent\Media\MediaQuarantine
+ */
+final class MediaCleanScanQuarantineExclusionTest extends TestCase
+{
+    /** Temp directory that acts as wp-content for tests that write manifests. */
+    private string $wpContent = '';
+
+    /** Temp uploads dir (simulates wp-content/uploads). */
+    private string $uploadsDir = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        // Create an isolated temp tree per test.
+        $tmp = sys_get_temp_dir() . '/wpmgr-qex-' . bin2hex(random_bytes(6));
+        $this->wpContent  = $tmp . '/wp-content';
+        $this->uploadsDir = $this->wpContent . '/uploads';
+        mkdir($this->uploadsDir . '/2024/01', 0755, true);
+    }
+
+    protected function tear_down(): void
+    {
+        global $wpdb;
+        $wpdb = null; // @phpstan-ignore-line
+
+        $this->rrmdir(dirname($this->wpContent));
+
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $entries = @scandir($dir);
+        if ($entries === false) {
+            return;
+        }
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $entry;
+            is_dir($path) ? $this->rrmdir($path) : @unlink($path);
+        }
+        @rmdir($dir);
+    }
+
+    /**
+     * Build a MediaQuarantine instance backed by the test's isolated temp tree.
+     */
+    private function makeQuarantine(): MediaQuarantine
+    {
+        return new MediaQuarantine($this->wpContent);
+    }
+
+    /**
+     * Stub all WP functions required by MediaCleanCommand::handleScan and
+     * MediaReferenceIndex::build(). Mirrors the helper in
+     * MediaCleanScanPaginationTest.
+     *
+     * @param string $uploadsBase Absolute path to the fake uploads directory.
+     */
+    private function stubWpFunctions(string $uploadsBase): void
+    {
+        Functions\when('wp_upload_dir')->justReturn([
+            'baseurl' => 'https://example.com/wp-content/uploads',
+            'basedir' => $uploadsBase,
+        ]);
+
+        Functions\when('get_post_meta')->alias(
+            static function (int $id, string $key) {
+                if ($key === '_wp_attached_file') {
+                    return "tests/img{$id}.jpg";
+                }
+                return [];
+            }
+        );
+
+        Functions\when('wp_get_attachment_image_src')->justReturn(false);
+        Functions\when('get_option')->justReturn(false);
+        Functions\when('is_serialized')->justReturn(false);
+        Functions\when('esc_sql')->alias(static fn ($s) => addslashes((string)$s));
+        Functions\when('admin_url')->alias(static fn (string $path = '') => 'https://example.com/wp-admin/' . ltrim($path, '/'));
+        Functions\when('wp_json_encode')->alias(static fn ($data, int $flags = 0): string|false => json_encode($data, $flags));
+    }
+
+    /**
+     * Build a wpdb double that serves attachment rows and optionally marks IDs
+     * as referenced via _thumbnail_id. Mirrors makeWpdb() in
+     * MediaCleanScanPaginationTest.
+     *
+     * @param list<array<string,string>> $attachmentRows
+     * @param list<int>                  $referencedIds
+     */
+    private function makeWpdb(array $attachmentRows, array $referencedIds = []): object
+    {
+        return new class ($attachmentRows, $referencedIds) {
+            public string $posts    = 'wp_posts';
+            public string $postmeta = 'wp_postmeta';
+            public string $options  = 'wp_options';
+            public string $termmeta = 'wp_termmeta';
+            public string $usermeta = 'wp_usermeta';
+
+            /** @var list<array<string,string>> */
+            private array $rows;
+            /** @var list<int> */
+            private array $referencedIds;
+            private bool  $thumbnailColServed = false;
+
+            /**
+             * @param list<array<string,string>> $rows
+             * @param list<int>                  $referencedIds
+             */
+            public function __construct(array $rows, array $referencedIds)
+            {
+                $this->rows          = $rows;
+                $this->referencedIds = $referencedIds;
+            }
+
+            /** @return list<array<string,string>> */
+            public function get_results(string $sql, string $output): array
+            {
+                if (
+                    strpos($sql, '_thumbnail_id') !== false
+                    && strpos($sql, 'REGEXP') !== false
+                    && !$this->thumbnailColServed
+                ) {
+                    $this->thumbnailColServed = true;
+                    $rows = [];
+                    foreach ($this->referencedIds as $refId) {
+                        $rows[] = ['meta_value' => (string)$refId, 'post_id' => '0', 'post_title' => ''];
+                    }
+                    return $rows;
+                }
+
+                if (strpos($sql, '_product_image_gallery') !== false) {
+                    return [];
+                }
+
+                if (strpos($sql, "post_type = 'attachment'") !== false) {
+                    preg_match('/LIMIT\s+(\d+)\s+OFFSET\s+(\d+)/i', $sql, $m);
+                    $limit  = isset($m[1]) ? (int)$m[1] : count($this->rows);
+                    $offset = isset($m[2]) ? (int)$m[2] : 0;
+                    return array_slice($this->rows, $offset, $limit);
+                }
+
+                return [];
+            }
+
+            /** @return list<string> */
+            public function get_col(string $sql): array
+            {
+                return [];
+            }
+
+            public function get_var(string $sql): string
+            {
+                return '';
+            }
+
+            public function prepare(string $sql, mixed ...$args): string
+            {
+                foreach ($args as $arg) {
+                    $pos = strpos($sql, '%d');
+                    if ($pos !== false) {
+                        $sql = substr_replace($sql, (string)(int)$arg, $pos, 2);
+                        continue;
+                    }
+                    $pos = strpos($sql, '%s');
+                    if ($pos !== false) {
+                        $sql = substr_replace($sql, (string)$arg, $pos, 2);
+                    }
+                }
+                return $sql;
+            }
+
+            public function esc_like(string $text): string
+            {
+                return addcslashes($text, '_%\\');
+            }
+        };
+    }
+
+    // =========================================================================
+    // Scenario 1: quarantined + unreferenced attachment is excluded
+    // =========================================================================
+
+    /**
+     * Library: 3 attachments (IDs 1, 2, 3). None are referenced.
+     * ID 2 is quarantined (in a manifest on disk).
+     *
+     * Expected:
+     *   - candidates contains IDs 1 and 3 only.
+     *   - total = 2 (unused count).
+     *   - total_attachments = 2 (quarantined ID is not walked).
+     *   - unused_count = 2.
+     *   - quarantined_count = 1.
+     */
+    public function testQuarantinedUnreferencedAttachmentIsExcluded(): void
+    {
+        global $wpdb;
+
+        $allRows = [
+            ['ID' => '1', 'post_title' => 'Image 1', 'guid' => 'https://example.com/wp-content/uploads/img1.jpg'],
+            ['ID' => '2', 'post_title' => 'Image 2', 'guid' => 'https://example.com/wp-content/uploads/img2.jpg'],
+            ['ID' => '3', 'post_title' => 'Image 3', 'guid' => 'https://example.com/wp-content/uploads/img3.jpg'],
+        ];
+
+        $wpdb = $this->makeWpdb($allRows, []); // @phpstan-ignore-line
+        $this->stubWpFunctions($this->uploadsDir);
+
+        // Create a quarantine manifest that records attachment ID 2.
+        $q          = $this->makeQuarantine();
+        $manifestId = $q->beginManifest('job-excl-001');
+        // quarantineAttachment with an empty file list: ID is recorded in the manifest
+        // even when no files were physically moved (matches the real isolate behaviour
+        // for already-absent files).
+        $q->quarantineAttachment($manifestId, 2, '2024/01/img2.jpg', []);
+        $q->finaliseManifest($manifestId);
+
+        $cmd    = new MediaCleanCommand($q);
+        $result = $cmd->execute([], ['action' => 'scan', 'offset' => 0, 'limit' => 100]);
+
+        $this->assertTrue($result['ok'], 'Scan must succeed. Detail: ' . ($result['detail'] ?? '(none)'));
+
+        // quarantined_count must reflect the one excluded ID.
+        $this->assertSame(1, $result['quarantined_count'], 'quarantined_count must be 1.');
+
+        // ID 2 must NOT appear in candidates.
+        $candidateIds = array_column($result['candidates'], 'id');
+        $this->assertNotContains(2, $candidateIds, 'Quarantined ID 2 must not appear in candidates.');
+
+        // IDs 1 and 3 must appear in candidates.
+        $this->assertContains(1, $candidateIds, 'Non-quarantined ID 1 must appear in candidates.');
+        $this->assertContains(3, $candidateIds, 'Non-quarantined ID 3 must appear in candidates.');
+
+        // total / unused_count must be 2 (quarantined ID excluded from count).
+        $this->assertSame(2, $result['total'], 'total must be 2 (IDs 1 and 3).');
+        $this->assertSame(2, $result['unused_count'], 'unused_count must equal total (2).');
+
+        // total_attachments must be 2 (quarantined ID not walked).
+        $this->assertSame(2, $result['total_attachments'], 'total_attachments must be 2 (quarantined ID not counted).');
+    }
+
+    // =========================================================================
+    // Scenario 2: non-quarantined unreferenced attachment still appears
+    // =========================================================================
+
+    /**
+     * Library: 3 attachments (IDs 10, 11, 12). None are referenced.
+     * ID 10 is quarantined. IDs 11 and 12 are NOT quarantined.
+     *
+     * IDs 11 and 12 must still appear as candidates (regression guard).
+     */
+    public function testNonQuarantinedUnreferencedAttachmentStillAppears(): void
+    {
+        global $wpdb;
+
+        $allRows = [
+            ['ID' => '10', 'post_title' => 'Image 10', 'guid' => 'https://example.com/wp-content/uploads/img10.jpg'],
+            ['ID' => '11', 'post_title' => 'Image 11', 'guid' => 'https://example.com/wp-content/uploads/img11.jpg'],
+            ['ID' => '12', 'post_title' => 'Image 12', 'guid' => 'https://example.com/wp-content/uploads/img12.jpg'],
+        ];
+
+        $wpdb = $this->makeWpdb($allRows, []); // @phpstan-ignore-line
+        $this->stubWpFunctions($this->uploadsDir);
+
+        // Quarantine only ID 10.
+        $q          = $this->makeQuarantine();
+        $manifestId = $q->beginManifest('job-excl-002');
+        $q->quarantineAttachment($manifestId, 10, '2024/01/img10.jpg', []);
+        $q->finaliseManifest($manifestId);
+
+        $cmd    = new MediaCleanCommand($q);
+        $result = $cmd->execute([], ['action' => 'scan', 'offset' => 0, 'limit' => 100]);
+
+        $this->assertTrue($result['ok'], 'Scan must succeed.');
+
+        $candidateIds = array_column($result['candidates'], 'id');
+
+        // Non-quarantined IDs must appear.
+        $this->assertContains(11, $candidateIds, 'Non-quarantined ID 11 must appear as a candidate.');
+        $this->assertContains(12, $candidateIds, 'Non-quarantined ID 12 must appear as a candidate.');
+
+        // Quarantined ID must not appear.
+        $this->assertNotContains(10, $candidateIds, 'Quarantined ID 10 must not appear as a candidate.');
+
+        // quarantined_count reflects the one excluded ID.
+        $this->assertSame(1, $result['quarantined_count']);
+
+        // total / unused_count are 2.
+        $this->assertSame(2, $result['total']);
+        $this->assertSame(2, $result['unused_count']);
+    }
+
+    // =========================================================================
+    // Scenario 3: absent quarantine dir => quarantined_count 0, scan unchanged
+    // =========================================================================
+
+    /**
+     * Library: 4 attachments (IDs 20-23). No manifests on disk (quarantine dir
+     * does not exist). All four attachments are unreferenced.
+     *
+     * Expected:
+     *   - quarantined_count = 0.
+     *   - All 4 IDs appear in candidates.
+     *   - total = 4.
+     *   - total_attachments = 4.
+     *
+     * This confirms that a missing quarantine dir does not break the scan and
+     * produces no exclusions.
+     */
+    public function testAbsentQuarantineDirProducesZeroQuarantinedCount(): void
+    {
+        global $wpdb;
+
+        $allRows = [];
+        for ($i = 20; $i <= 23; $i++) {
+            $allRows[] = [
+                'ID'         => (string)$i,
+                'post_title' => "Image {$i}",
+                'guid'       => "https://example.com/wp-content/uploads/img{$i}.jpg",
+            ];
+        }
+
+        $wpdb = $this->makeWpdb($allRows, []); // @phpstan-ignore-line
+        $this->stubWpFunctions($this->uploadsDir);
+
+        // Build a MediaQuarantine pointing at a content dir that has NO quarantine
+        // sub-directory at all. quarantinedAttachmentIds() must return an empty array.
+        $q = $this->makeQuarantine();
+        // (Do NOT call beginManifest — the quarantine dir never gets created.)
+
+        $cmd    = new MediaCleanCommand($q);
+        $result = $cmd->execute([], ['action' => 'scan', 'offset' => 0, 'limit' => 100]);
+
+        $this->assertTrue($result['ok'], 'Scan must succeed even with no quarantine dir.');
+
+        // No exclusions.
+        $this->assertSame(0, $result['quarantined_count'], 'quarantined_count must be 0 when no manifests exist.');
+
+        // All 4 attachments must appear.
+        $candidateIds = array_column($result['candidates'], 'id');
+        sort($candidateIds);
+        $this->assertSame([20, 21, 22, 23], $candidateIds, 'All 4 non-quarantined attachments must appear.');
+
+        // Counts are unchanged from baseline.
+        $this->assertSame(4, $result['total'], 'total must be 4.');
+        $this->assertSame(4, $result['total_attachments'], 'total_attachments must be 4.');
+        $this->assertSame(4, $result['unused_count'], 'unused_count must be 4.');
+    }
+
+    // =========================================================================
+    // Bonus: multiple quarantined IDs across multiple manifests
+    // =========================================================================
+
+    /**
+     * Library: 6 attachments (IDs 30-35). None are referenced.
+     * Two manifests exist: one records IDs 31 and 33, another records ID 35.
+     *
+     * Expected:
+     *   - quarantined_count = 3.
+     *   - candidates contains IDs 30, 32, 34 only.
+     *   - total = total_attachments = unused_count = 3.
+     */
+    public function testMultipleQuarantinedIdsAcrossManifestsAreAllExcluded(): void
+    {
+        global $wpdb;
+
+        $allRows = [];
+        for ($i = 30; $i <= 35; $i++) {
+            $allRows[] = [
+                'ID'         => (string)$i,
+                'post_title' => "Image {$i}",
+                'guid'       => "https://example.com/wp-content/uploads/img{$i}.jpg",
+            ];
+        }
+
+        $wpdb = $this->makeWpdb($allRows, []); // @phpstan-ignore-line
+        $this->stubWpFunctions($this->uploadsDir);
+
+        $q = $this->makeQuarantine();
+
+        // First manifest: IDs 31 and 33.
+        $m1 = $q->beginManifest('job-multi-001');
+        $q->quarantineAttachment($m1, 31, '2024/01/img31.jpg', []);
+        $q->quarantineAttachment($m1, 33, '2024/01/img33.jpg', []);
+        $q->finaliseManifest($m1);
+
+        // Second manifest: ID 35.
+        $m2 = $q->beginManifest('job-multi-002');
+        $q->quarantineAttachment($m2, 35, '2024/01/img35.jpg', []);
+        $q->finaliseManifest($m2);
+
+        $cmd    = new MediaCleanCommand($q);
+        $result = $cmd->execute([], ['action' => 'scan', 'offset' => 0, 'limit' => 100]);
+
+        $this->assertTrue($result['ok'], 'Scan must succeed.');
+
+        $this->assertSame(3, $result['quarantined_count'], 'quarantined_count must be 3 (IDs 31, 33, 35).');
+
+        $candidateIds = array_column($result['candidates'], 'id');
+        sort($candidateIds);
+        $this->assertSame([30, 32, 34], $candidateIds, 'Only non-quarantined IDs 30, 32, 34 must appear.');
+
+        $this->assertSame(3, $result['total']);
+        $this->assertSame(3, $result['total_attachments']);
+        $this->assertSame(3, $result['unused_count']);
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.25.12
+ * Version:           0.27.0
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.25.12');
+define('WPMGR_AGENT_VERSION', '0.27.0');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 

--- a/apps/landing/src/data/content.ts
+++ b/apps/landing/src/data/content.ts
@@ -30,7 +30,7 @@ export const NAV = {
 };
 
 export const HERO = {
-  badge: "v0.20.0 / open source",
+  badge: "v0.27.0 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",


### PR DESCRIPTION
Brings main to the v0.27.0 release.

- Unified versioning: release tag = api/web/media-encoder images = agent plugin, all one number (agent self-update stamped from the tag).
- Unused Image Cleaner: re-scan excludes already-quarantined attachments.

See CHANGELOG [0.27.0].

🤖 Generated with [Claude Code](https://claude.com/claude-code)