### PR TITLE
fix(agent): Unix-socket DB_HOST backup support (issue #5) + v0.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.28.1] - 2026-06-08
+
+### Fixed
+
+- Backups on hosts that expose MySQL over a Unix socket (for example a `DB_HOST` of `localhost:/var/run/mysqld/mysqld.sock`). The database dumper now parses the host, port, and socket path from `DB_HOST` the same way WordPress core does, and connects over the socket instead of dropping the path and failing the dump. Sites that connect over TCP are unaffected.
+
 ## [0.28.0] - 2026-06-08
 
 ### Added

--- a/apps/agent/includes/backup/class-db-dumper.php
+++ b/apps/agent/includes/backup/class-db-dumper.php
@@ -84,8 +84,9 @@ final class DbDumper
 
     /**
      * @param array{host:string,user:string,password:string,name:string,prefix:string} $db
-     *      WordPress DB credentials. `host` may include a `:port` suffix
-     *      (we split it off — mysqli's constructor takes port as a separate arg).
+     *      WordPress DB credentials. `host` follows WordPress DB_HOST semantics:
+     *      may carry a `:port` suffix, a `:/path/to/socket` suffix, or both
+     *      (`host:port:/path/to/socket`). All forms are parsed by splitHostPort().
      * @param array<string,mixed> $opts Reserved.
      */
     public function __construct(array $db, array $opts = [])
@@ -224,7 +225,7 @@ final class DbDumper
      */
     private function connect(): \mysqli
     {
-        [$host, $port] = $this->splitHostPort($this->db['host']);
+        [$host, $port, $socket] = $this->splitHostPort($this->db['host']);
 
         // mysqli_report controls how mysqli surfaces errors. Be explicit:
         // throw exceptions (introduced default in PHP 8.1+ but worth pinning)
@@ -232,12 +233,18 @@ final class DbDumper
         mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
         try {
+            // mysqli constructor: ($host, $user, $pass, $db, $port, $socket).
+            // When a Unix socket path is provided, mysqli uses it for a local
+            // connection (the $host value is effectively ignored by the driver
+            // in that case, but we still pass whatever the caller gave us so
+            // MySQL grant scoping against 'localhost' is preserved).
             $mysqli = new \mysqli(
                 $host,
                 $this->db['user'],
                 $this->db['password'],
                 $this->db['name'],
-                $port ?? 3306
+                $port ?? 3306,
+                $socket ?? ''
             );
         } catch (\Throwable $e) {
             throw new \RuntimeException('connect failed');
@@ -504,22 +511,84 @@ final class DbDumper
     }
 
     /**
-     * @return array{0:string,1:?int} [host, port]. Splits only on the LAST
-     * colon and only if the suffix is all digits — defensive against IPv6 in
-     * brackets, though no WP host known to do that.
+     * Parse a WordPress DB_HOST value into its three components.
+     *
+     * WordPress DB_HOST accepts these forms (same semantics as wpdb):
+     *   hostname                          → host, no port, no socket
+     *   hostname:3306                     → host + numeric port
+     *   hostname:/path/to/mysqld.sock     → host + socket (no port)
+     *   hostname:3306:/path/to/mysql.sock → host + port + socket
+     *   :/path/to/mysqld.sock             → socket only (host stays as-is)
+     *   [::1]:3306                        → bracketed IPv6 + port
+     *
+     * Rule: a colon-delimited segment is a socket if it starts with `/` or
+     * `\` (an absolute path), a port if it is all-digits, and left alone
+     * (host kept intact, port/socket null) if neither condition matches — so
+     * an unrecognised colon-part never corrupts the host string.
+     *
+     * @return array{0:string,1:?int,2:?string} [host, port, socket]
      */
     private function splitHostPort(string $host): array
     {
-        $port = null;
-        if (str_contains($host, ':')) {
-            $pos = strrpos($host, ':');
-            $portPart = substr($host, $pos + 1);
-            if ($portPart !== '' && ctype_digit($portPart)) {
-                $port = (int) $portPart;
-                $host = substr($host, 0, $pos);
-            }
+        $port   = null;
+        $socket = null;
+
+        if (!str_contains($host, ':')) {
+            return [$host, $port, $socket];
         }
-        return [$host, $port];
+
+        // Bracketed IPv6 — e.g. [::1]:3306. A leading '[' means the host
+        // portion is everything up to and including the matching ']'. Only
+        // parse a port after the closing bracket; ignore anything else so we
+        // never mangle the address.
+        if (str_starts_with($host, '[')) {
+            $close = strpos($host, ']');
+            if ($close !== false) {
+                $bracket = substr($host, 0, $close + 1);
+                $rest    = substr($host, $close + 1); // e.g. ':3306' or ''
+                if (str_starts_with($rest, ':')) {
+                    $after = substr($rest, 1);
+                    if ($after !== '' && ctype_digit($after)) {
+                        return [$bracket, (int) $after, null];
+                    }
+                }
+            }
+            // Could not parse cleanly — leave host intact.
+            return [$host, null, null];
+        }
+
+        // Non-bracketed: split on ':' and classify each segment after the
+        // first as port or socket. WordPress core wpdb supports up to three
+        // colon-delimited parts: host, port, socket.
+        $parts = explode(':', $host, 3);
+
+        $rawHost = $parts[0];
+        $seg1    = $parts[1] ?? null; // port-or-socket
+        $seg2    = $parts[2] ?? null; // socket (only when seg1 was a port)
+
+        if ($seg1 !== null) {
+            if (ctype_digit($seg1) && $seg1 !== '') {
+                // Second segment is a numeric port.
+                $port = (int) $seg1;
+                $host = $rawHost;
+                if ($seg2 !== null && $seg2 !== '' && (str_starts_with($seg2, '/') || str_starts_with($seg2, '\\'))) {
+                    // Third segment is a socket path: host:port:socket
+                    $socket = $seg2;
+                }
+                // If seg2 exists but is not an absolute path, ignore it
+                // (leave socket null) rather than corrupt host.
+            } elseif ($seg2 === null && ($seg1 === '' || str_starts_with($seg1, '/') || str_starts_with($seg1, '\\'))) {
+                // Second segment is a socket path (no port): host:/path or :/path
+                $socket = $seg1 !== '' ? $seg1 : null;
+                $host   = $rawHost;
+                // :/path/to/sock → rawHost is '', leave it as '' so callers
+                // can treat empty-string as "localhost" if they wish.
+            }
+            // Any other pattern (non-digit, non-path) → leave host intact,
+            // port/socket null — do not guess.
+        }
+
+        return [$host, $port, $socket];
     }
 
     /**

--- a/apps/agent/tests/Backup/DbDumperTest.php
+++ b/apps/agent/tests/Backup/DbDumperTest.php
@@ -103,6 +103,136 @@ final class DbDumperTest extends TestCase
         $this->assertSame(0, $progressCalls, 'no-op replay must not emit progress');
     }
 
+    // -----------------------------------------------------------------------
+    // splitHostPort parser — unit coverage via reflection.
+    //
+    // The method is private (implementation detail), but the parsing contract
+    // is load-bearing (wrong parse → silent connection failure on every backup
+    // for affected hosts). Reflection is the right seam here: we test the
+    // behaviour, not the internal mechanism, and a rename would break these
+    // tests intentionally.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Build a DbDumper and call its private splitHostPort() via reflection.
+     *
+     * @return array{0:string,1:int|null,2:string|null}
+     */
+    private function parseHostPort(string $input): array
+    {
+        $dumper = new DbDumper([
+            'host'     => $input,
+            'user'     => 'u',
+            'password' => 'p',
+            'name'     => 'db',
+            'prefix'   => 'wp_',
+        ]);
+
+        $ref = new \ReflectionMethod(DbDumper::class, 'splitHostPort');
+        $ref->setAccessible(true);
+        /** @var array{0:string,1:int|null,2:string|null} */
+        return $ref->invoke($dumper, $input);
+    }
+
+    /**
+     * Plain IPv4 address — no port, no socket.
+     */
+    public function test_split_plain_ipv4(): void
+    {
+        [$host, $port, $socket] = $this->parseHostPort('127.0.0.1');
+        $this->assertSame('127.0.0.1', $host);
+        $this->assertNull($port);
+        $this->assertNull($socket);
+    }
+
+    /**
+     * IPv4 with explicit port.
+     */
+    public function test_split_ipv4_with_port(): void
+    {
+        [$host, $port, $socket] = $this->parseHostPort('127.0.0.1:3307');
+        $this->assertSame('127.0.0.1', $host);
+        $this->assertSame(3307, $port);
+        $this->assertNull($socket);
+    }
+
+    /**
+     * Hostname with Unix socket path (no port).
+     * This is the form used by managed hosts that run MySQL on a Unix socket
+     * (e.g. GridPane sets DB_HOST = 'localhost:/var/run/mysqld/mysqld.sock').
+     * The OLD code left host as the full string and socket as null, causing
+     * every backup to fail with a connect error.
+     *
+     * THIS IS THE REGRESSION TEST — it MUST fail on the old implementation
+     * and pass on the new one.
+     */
+    public function test_split_localhost_with_socket_gridpane_form(): void
+    {
+        [$host, $port, $socket] = $this->parseHostPort('localhost:/var/run/mysqld/mysqld.sock');
+        $this->assertSame('localhost', $host, 'host must be extracted before the colon');
+        $this->assertNull($port, 'no port in this form');
+        $this->assertSame('/var/run/mysqld/mysqld.sock', $socket, 'socket path must be captured');
+    }
+
+    /**
+     * Host + port + socket — all three components present.
+     */
+    public function test_split_host_port_and_socket(): void
+    {
+        [$host, $port, $socket] = $this->parseHostPort('db.example.com:3306:/tmp/mysql.sock');
+        $this->assertSame('db.example.com', $host);
+        $this->assertSame(3306, $port);
+        $this->assertSame('/tmp/mysql.sock', $socket);
+    }
+
+    /**
+     * Socket-only form (empty host segment before the colon).
+     * DB_HOST = ':/tmp/mysql.sock' means "use the socket, no TCP host".
+     */
+    public function test_split_socket_only_empty_host(): void
+    {
+        [$host, $port, $socket] = $this->parseHostPort(':/tmp/mysql.sock');
+        // rawHost is '' — callers may treat '' as 'localhost'; we just ensure
+        // the socket is captured and port is null.
+        $this->assertSame('', $host);
+        $this->assertNull($port);
+        $this->assertSame('/tmp/mysql.sock', $socket);
+    }
+
+    /**
+     * Bracketed IPv6 address with port.
+     * Defensive: the parser must not mangle the address.
+     */
+    public function test_split_bracketed_ipv6_with_port(): void
+    {
+        [$host, $port, $socket] = $this->parseHostPort('[::1]:3306');
+        $this->assertSame('[::1]', $host);
+        $this->assertSame(3306, $port);
+        $this->assertNull($socket);
+    }
+
+    /**
+     * Bracketed IPv6 with no port — address only.
+     */
+    public function test_split_bracketed_ipv6_no_port(): void
+    {
+        [$host, $port, $socket] = $this->parseHostPort('[::1]');
+        $this->assertSame('[::1]', $host);
+        $this->assertNull($port);
+        $this->assertNull($socket);
+    }
+
+    /**
+     * Plain hostname with no colon — no port, no socket.
+     */
+    public function test_split_plain_hostname(): void
+    {
+        [$host, $port, $socket] = $this->parseHostPort('db.internal');
+        $this->assertSame('db.internal', $host);
+        $this->assertNull($port);
+        $this->assertNull($socket);
+    }
+
     /**
      * Live MySQL integration smoke. Skipped unless WPMGR_TEST_MYSQL_DSN-style
      * env vars are present — keeps CI green on hosts without a DB.

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.28.0
+ * Version:           0.28.1
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.28.0');
+define('WPMGR_AGENT_VERSION', '0.28.1');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 


### PR DESCRIPTION
Fixes the GridPane Unix-socket DB_HOST backup blocker reported in #5. `splitHostPort()` now parses host/port/socket like WordPress core and connects over the socket. Adds 7 parser tests (incl. the GridPane case). Bumps the agent baseline to 0.28.1 with a CHANGELOG entry.

Closes the Bug 1 item in #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)