### PR TITLE
feat(api): degraded boot + validate-env + backup failure reason (issue #5) + v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-06-08
+
+### Added
+
+- `validate-env` command (also `make validate-env`) that checks your configuration and prints every problem at once before you start the stack, so you discover missing or invalid environment variables before the first container starts instead of one restart at a time.
+
+### Changed
+
+- The control plane no longer restart-loops when a required setting is missing or invalid. It stays up in a degraded state: `/healthz` keeps answering, and `/readyz` returns a 503 that names exactly which environment variables are misconfigured (names and reasons only, never values), so you can read the endpoint to diagnose the problem instead of watching a crash loop.
+
+### Fixed
+
+- A failed backup now shows the real reason in the dashboard (for example a database connection failure) instead of only a generic "stalled, no progress" message. The agent's failure detail is preserved on the snapshot so you can see what actually went wrong.
+
 ## [0.28.1] - 2026-06-08
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,10 @@ gen-secrets: ## Print the boot-critical self-host secrets as ready-to-paste env 
 	# own boot parsers before it is printed (see apps/api/cmd/wpmgr-cli).
 	cd apps/api && go run ./cmd/wpmgr-cli gen-secrets
 
+.PHONY: validate-env
+validate-env: ## Check the environment config and list every problem at once
+	cd apps/api && go run ./cmd/wpmgr-cli validate-env
+
 .PHONY: init-env
 init-env: ## Copy .env.example -> .env and inject fresh secrets (preserves existing .env)
 	./scripts/init-env.sh

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.28.1
+ * Version:           0.29.0
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.28.1');
+define('WPMGR_AGENT_VERSION', '0.29.0');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 

--- a/apps/api/cmd/wpmgr-cli/main.go
+++ b/apps/api/cmd/wpmgr-cli/main.go
@@ -4,6 +4,7 @@
 //
 //	wpmgr-cli migrate        # apply embedded versioned migrations
 //	wpmgr-cli gen-secrets    # mint the boot-critical secrets (KEY=VALUE lines)
+//	wpmgr-cli validate-env   # check the environment config and list every problem at once
 package main
 
 import (
@@ -33,6 +34,11 @@ func main() {
 			fmt.Fprintln(os.Stderr, "gen-secrets:", err)
 			os.Exit(1)
 		}
+	case "validate-env":
+		if err := validateEnv(os.Stdout); err != nil {
+			fmt.Fprintln(os.Stderr, "validate-env:", err)
+			os.Exit(1)
+		}
 	default:
 		usage()
 		os.Exit(2)
@@ -58,4 +64,5 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "wpmgr-cli — admin tooling")
 	fmt.Fprintln(os.Stderr, "  migrate        apply database migrations")
 	fmt.Fprintln(os.Stderr, "  gen-secrets    mint boot-critical secrets as KEY=VALUE lines")
+	fmt.Fprintln(os.Stderr, "  validate-env   check the environment config and list every problem at once")
 }

--- a/apps/api/cmd/wpmgr-cli/validateenv.go
+++ b/apps/api/cmd/wpmgr-cli/validateenv.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/config"
+)
+
+// validateEnv loads the configuration and runs the same aggregated checks that
+// the server's degraded-boot path runs. It prints a checklist to out (one line
+// per check: OK/FAIL + env-var name + reason) and returns a non-nil error if
+// any check failed so the caller can exit non-zero.
+//
+// It NEVER opens a database connection, a Redis connection, or an HTTP server —
+// this command is safe to run in any environment without network access.
+//
+// SECRET-LEAK INVARIANT: names and reasons only are printed; secret values,
+// DSN strings, and raw crypto errors are never surfaced.
+func validateEnv(out io.Writer) error {
+	cfg, err := config.Load(os.Getenv("WPMGR_CONFIG_FILE"))
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	issues := config.Validate(cfg)
+
+	// Build a fast lookup for which names have issues.
+	failed := make(map[string]string, len(issues))
+	for _, iss := range issues {
+		failed[iss.Name] = iss.Reason
+	}
+
+	// Ordered list of checks we surface (mirrors config.Validate order).
+	checks := []string{
+		"WPMGR_SESSION_SECRET",
+		"WPMGR_AGENT_SIGNING_PRIVATE_KEY",
+		"WPMGR_SITE_DEST_AGE_SECRET",
+	}
+
+	anyFail := false
+	for _, name := range checks {
+		if reason, bad := failed[name]; bad {
+			fmt.Fprintf(out, "FAIL  %s — %s\n", name, reason)
+			anyFail = true
+		} else {
+			fmt.Fprintf(out, "OK    %s\n", name)
+		}
+	}
+
+	if anyFail {
+		return fmt.Errorf("one or more config checks failed")
+	}
+	return nil
+}

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -73,16 +73,12 @@ import (
 var version = "0.0.0-dev"
 
 func main() {
-	if err := run(); err != nil {
-		slog.Error("fatal", slog.Any("error", err))
-		os.Exit(1)
-	}
-}
-
-func run() error {
+	// Load config and initialize the logger as early as possible so all boot
+	// paths have structured output.
 	cfg, err := config.Load(os.Getenv("WPMGR_CONFIG_FILE"))
 	if err != nil {
-		return err
+		slog.Error("fatal: config load failed", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	logger := newLogger(cfg)
@@ -90,6 +86,26 @@ func run() error {
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	// Aggregate ALL config issues before touching the DB or starting any server.
+	// On any issue we park in degraded mode (no crash-loop) so an operator can
+	// curl /readyz to read which env vars need fixing.
+	if issues := config.Validate(cfg); len(issues) > 0 {
+		if err := serveDegraded(ctx, cfg.HTTPAddr, issues); err != nil {
+			slog.Error("degraded server error", slog.Any("error", err))
+			os.Exit(1)
+		}
+		return
+	}
+
+	if err := run(ctx, cfg, logger); err != nil {
+		slog.Error("fatal", slog.Any("error", err))
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
+	slog.SetDefault(logger)
 
 	tp, err := telemetry.Init(ctx, telemetry.Config{
 		ServiceName:  cfg.OTel.ServiceName,
@@ -100,6 +116,10 @@ func run() error {
 	}
 	defer func() { _ = tp.Shutdown(context.Background()) }()
 
+	// Defense-in-depth: individual guards still run inside run() so any future
+	// caller of run() that skips the validateConfig pre-check still hard-fails
+	// cleanly rather than proceeding with a bad config.
+	//
 	// Refuse to boot with a weak/placeholder session secret.
 	if err := cfg.ValidateSessionSecret(); err != nil {
 		return err

--- a/apps/api/cmd/wpmgr/serveDegraded.go
+++ b/apps/api/cmd/wpmgr/serveDegraded.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/config"
+)
+
+// serveDegraded starts a minimal net/http server (no Gin, no DB, no River) on
+// cfg.HTTPAddr and parks until ctx is cancelled. It is called when
+// config.Validate reports one or more config issues so the container does NOT
+// crash-loop and an operator can curl /readyz to see which env vars are wrong.
+//
+// Endpoints:
+//
+//	GET /healthz → 200 {"status":"ok"}     — process is alive.
+//	GET /readyz  → 503 {"status":"degraded","checks":{<name>:<reason>,...}}
+//
+// SECRET-LEAK INVARIANT: the /readyz checks map and all slog output contain
+// ONLY the curated Issue.Name + Issue.Reason strings from config.Validate;
+// raw errors from crypto / DB paths are never surfaced here.
+func serveDegraded(ctx context.Context, addr string, issues []config.Issue) error {
+	// Build the checks map once — names + reasons only, no secret values.
+	checks := make(map[string]string, len(issues))
+	names := make([]string, 0, len(issues))
+	for _, iss := range issues {
+		checks[iss.Name] = iss.Reason
+		names = append(names, iss.Name)
+	}
+
+	slog.Error("degraded boot: config issues detected — /readyz will return 503 until fixed",
+		slog.Any("issues", names))
+
+	mux := http.NewServeMux()
+
+	// /healthz — process is alive.
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	// /readyz — degraded, lists config problems (names + safe reasons only).
+	readyzBody, _ := json.Marshal(map[string]any{
+		"status": "degraded",
+		"checks": checks,
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write(readyzBody)
+	})
+
+	srv := &http.Server{
+		Addr:         addr,
+		Handler:      mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+		IdleTimeout:  30 * time.Second,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		slog.Info("degraded http server listening", slog.String("addr", addr))
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		slog.Info("degraded: shutdown signal received")
+		shutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(shutCtx); err != nil {
+			slog.Warn("degraded: graceful shutdown error", slog.Any("error", err))
+		}
+		return nil
+	}
+}

--- a/apps/api/internal/backup/service.go
+++ b/apps/api/internal/backup/service.go
@@ -1761,9 +1761,33 @@ func (s *Service) RecordProgress(ctx context.Context, tenantID, snapshotID uuid.
 	if err != nil {
 		return nil, err
 	}
+
+	// When the agent reports "failed" (e.g. a PHP exception or out-of-disk
+	// mid-backup), extract the agent's reason and immediately mark the snapshot
+	// failed so the dashboard shows the real cause rather than waiting for the
+	// stall watchdog to stamp a generic "stalled" message.
+	//
+	// Guard: only call FailSnapshot when the snapshot is not already in a
+	// terminal state (failed/completed/cancelled). This prevents double-failing
+	// a row that was concurrently cancelled by the operator or already failed by
+	// the watchdog before this progress POST arrived.
+	if phase == "failed" && snap.Status != StatusFailed && snap.Status != StatusCompleted {
+		reason := agentFailReason(phaseDetail)
+		if reason != "" {
+			// Best-effort: if FailSnapshot errors (e.g. a race lost to the
+			// watchdog), log and continue — the progress JSON is already stored.
+			if _, ferr := s.FailSnapshot(ctx, tenantID, snapshotID, reason); ferr != nil {
+				slog.Warn("RecordProgress: agent-reported failure could not be persisted",
+					slog.String("snapshot_id", snapshotID.String()),
+					slog.String("tenant_id", tenantID.String()),
+					slog.Any("error", ferr))
+			}
+		}
+	}
+
 	// Fan out the validated progress to live SSE subscribers. The Status mirrors
-	// the snapshot's current status (the runner's "completed"/"failed" phase is
-	// only authoritative once the manifest is submitted / the worker marks it).
+	// the snapshot's status as returned by UpdateSnapshotProgress (the
+	// FailSnapshot call above, if it ran, publishes its own terminal SSE event).
 	s.publish(BackupEvent{
 		SnapshotID:  snapshotID,
 		Phase:       phase,
@@ -1779,6 +1803,30 @@ func (s *Service) RecordProgress(ctx context.Context, tenantID, snapshotID uuid.
 	}
 
 	return raw, nil
+}
+
+// agentFailReason extracts the operator-safe failure reason from a "failed"
+// phase_detail map. The agent sends the scrubbed reason under "message" (the
+// primary field); "error" is accepted as a fallback for older agents. Returns
+// an empty string when neither key is present or both are empty.
+func agentFailReason(phaseDetail map[string]any) string {
+	for _, key := range []string{"message", "error"} {
+		if v, ok := phaseDetail[key]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				// Defense in depth: the agent already scrubs and truncates this
+				// reason, but the CP must not rely on a (possibly compromised)
+				// agent honoring its own budget before persisting it to the
+				// snapshot.error text column. Clamp to a sane operator-readable
+				// length on a rune boundary.
+				const maxReasonLen = 512
+				if len(s) > maxReasonLen {
+					s = strings.ToValidUTF8(s[:maxReasonLen], "")
+				}
+				return s
+			}
+		}
+	}
+	return ""
 }
 
 // persistRestoreRunEvent is the best-effort restore-run event persistence

--- a/apps/api/internal/config/validate.go
+++ b/apps/api/internal/config/validate.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+// Issue describes a single configuration problem detected by Validate. Name is
+// the environment-variable name (safe to log and surface to operators); Reason
+// is a short, human-readable explanation that NEVER contains a secret value.
+type Issue struct {
+	Name   string
+	Reason string
+}
+
+// Validate aggregates ALL boot-critical configuration problems and returns them
+// as a slice of Issues. An empty slice means the configuration is valid.
+//
+// Checks performed (in order):
+//  1. WPMGR_SESSION_SECRET — empty, placeholder, or too short.
+//  2. WPMGR_AGENT_SIGNING_PRIVATE_KEY — production-only: known committed dev key.
+//  3. WPMGR_SITE_DEST_AGE_SECRET — production-only: must be present.
+//
+// The production guard mirrors the exact condition used during full boot: checks
+// 2 and 3 are skipped in non-production environments so the function is safe to
+// call in development without any secrets configured.
+//
+// SECRET-LEAK INVARIANT: every Reason string contains only the env-var name and
+// a short human description. Raw errors from crypto parsing, DSN construction,
+// or any other credential-wrapping path are NEVER included.
+func Validate(cfg Config) []Issue {
+	var issues []Issue
+
+	// 1. Session secret.
+	s := cfg.Auth.SessionSecret
+	switch {
+	case s == "":
+		issues = append(issues, Issue{
+			Name:   "WPMGR_SESSION_SECRET",
+			Reason: "empty — set a random secret of at least 32 bytes",
+		})
+	case strings.HasPrefix(s, "change-me"):
+		issues = append(issues, Issue{
+			Name:   "WPMGR_SESSION_SECRET",
+			Reason: "still holds the placeholder value — set a real random secret of at least 32 bytes",
+		})
+	case len(s) < 32:
+		issues = append(issues, Issue{
+			Name:   "WPMGR_SESSION_SECRET",
+			Reason: "too short — use at least 32 bytes",
+		})
+	}
+
+	// 2. Agent signing private key (production-only: known committed dev key).
+	if cfg.IsProduction() {
+		k := cfg.Agent.SigningPrivateKey
+		if k != "" {
+			for _, dev := range devAgentSigningPrivateKeys {
+				if k == dev {
+					issues = append(issues, Issue{
+						Name:   "WPMGR_AGENT_SIGNING_PRIVATE_KEY",
+						Reason: "holds a known committed dev key — generate a fresh control-plane Ed25519 keypair for production",
+					})
+					break
+				}
+			}
+		}
+	}
+
+	// 3. Site-destination age secret (production-only: must be present).
+	if cfg.IsProduction() {
+		if strings.TrimSpace(os.Getenv("WPMGR_SITE_DEST_AGE_SECRET")) == "" {
+			issues = append(issues, Issue{
+				Name:   "WPMGR_SITE_DEST_AGE_SECRET",
+				Reason: "required in production — an empty value uses an ephemeral key that orphans stored secrets on restart",
+			})
+		}
+	}
+
+	return issues
+}

--- a/apps/landing/src/data/content.ts
+++ b/apps/landing/src/data/content.ts
@@ -30,7 +30,7 @@ export const NAV = {
 };
 
 export const HERO = {
-  badge: "v0.28.0 / open source",
+  badge: "v0.29.0 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",
@@ -347,7 +347,7 @@ export const OPEN_SOURCE = {
     "WPMgr is open source first. Self-host it in minutes, read every line, open issues, submit PRs, and shape where it goes next.",
   bodyLines: [
     "The control plane and dashboard are AGPL-3.0. The WordPress agent is MIT-licensed. Both licenses are chosen so you can audit, fork, and deploy without restriction. There is no paid tier or per-site fee to run it yourself.",
-    "The bundled Docker Compose stack brings up the control plane, dashboard, database, and storage in a few commands. Prebuilt container images are published for production setups. Good-first-issue labels are kept current on GitHub so contributors have a clear on-ramp.",
+    "The bundled Docker Compose stack brings up the control plane, dashboard, database, and storage in a few commands. Prebuilt container images are published for production setups. A built-in startup check (`validate-env`) lists every misconfigured environment variable at once, and the control plane stays up in a degraded mode with a clear /readyz 503 if a setting is wrong, so you can diagnose the problem without watching a crash loop. Good-first-issue labels are kept current on GitHub so contributors have a clear on-ramp.",
   ],
   command: "docker compose up -d",
   chips: [


### PR DESCRIPTION
Fixes issue #5 Bugs 4/5/6 (CP-only). Degraded-boot health surface instead of crash-loop, a `validate-env` command that lists every config problem at once, and surfacing the real backup failure reason on the snapshot. Security-reviewed (no secret leakage, tenant-scoped, no boot regression). Bumps the unified line to v0.29.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – v0.29.0

* **New Features**
  * Added `validate-env` command to check environment configuration before startup
  * Control-plane now uses degraded mode for configuration issues, preventing restart loops

* **Bug Fixes**
  * Backup failures now display accurate failure reasons in the dashboard
  * Agent failure details are preserved on snapshots

* **Chores**
  * Version bumped to 0.29.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->