### PR TITLE
test(api): fix two stale integration tests (TestRetentionGC, media callback chain)

### DIFF
--- a/apps/api/tests/backup_integration_test.go
+++ b/apps/api/tests/backup_integration_test.go
@@ -319,9 +319,10 @@ func TestPresignNamespacing(t *testing.T) {
 	}
 }
 
-// TestRetentionGC: an expired snapshot is deleted, its chunks' refcounts are
-// decremented, orphaned chunks (refcount 0) are deleted from S3, and chunks
-// still shared with a surviving snapshot are retained.
+// TestRetentionGC: an expired snapshot is pruned; its unreachable chunks are
+// swept (object + row), and chunks still reachable from a surviving snapshot
+// are retained. Under ADR-050 mark-and-sweep, refcount is observability-only
+// ("origin refs") and is NEVER decremented on snapshot prune.
 func TestRetentionGC(t *testing.T) {
 	pool := startPostgres(t)
 	store := startBlobstore(t)
@@ -376,10 +377,13 @@ func TestRetentionGC(t *testing.T) {
 		t.Fatalf("shared chunk %s wrongly deleted from S3", h[2])
 	}
 
-	// h[2] retained with refcount 1 (only the new snapshot now).
+	// h[2] is retained because it is still reachable from the new snapshot.
+	// Refcount stays 2: origin refs across both manifest entries (old.php and
+	// new.php). ADR-050 mark-and-sweep never decrefs on snapshot prune; refcount
+	// is observability-only and is only ever incremented by RecordManifest.
 	existing, _ := repo.ExistingChunkHashes(context.Background(), tenant, h)
-	if c, ok := existing[h[2]]; !ok || c.Refcount != 1 {
-		t.Fatalf("shared chunk h2 refcount=%v (present=%v), want 1", existing[h[2]].Refcount, ok)
+	if c, ok := existing[h[2]]; !ok || c.Refcount != 2 {
+		t.Fatalf("shared chunk h2 refcount=%v (present=%v), want 2 (origin refs; never decremented under ADR-050 mark-and-sweep)", existing[h[2]].Refcount, ok)
 	}
 	if _, ok := existing[h[0]]; ok {
 		t.Fatalf("orphan chunk h0 row still present")

--- a/apps/api/tests/media_encode_service_integration_test.go
+++ b/apps/api/tests/media_encode_service_integration_test.go
@@ -160,10 +160,23 @@ func (e *captureEnqueuer) CancelEncodeJob(_ context.Context, _ int64) error { re
 
 // okAgent answers every media command OK (the dispatch transport is out of scope
 // for the orchestration test; the CGO test covers the real apply payload).
-type okAgent struct{ optimizeCalls int }
+// optimized is signalled once per MediaOptimize dispatch. StartOptimize fires the
+// dispatch in a DETACHED goroutine, so tests MUST await this signal before
+// reading optimizeCalls — reading it directly after StartOptimize returns would
+// race the goroutine and data-race the counter write.
+type okAgent struct {
+	optimizeCalls int
+	optimized     chan struct{}
+}
 
 func (a *okAgent) MediaOptimize(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.MediaOptimizeRequest) (agentcmd.MediaOptimizeResponse, error) {
 	a.optimizeCalls++
+	if a.optimized != nil {
+		select {
+		case a.optimized <- struct{}{}:
+		default:
+		}
+	}
 	return agentcmd.MediaOptimizeResponse{OK: true}, nil
 }
 func (a *okAgent) MediaSync(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.MediaSyncRequest) (agentcmd.MediaSyncResponse, error) {
@@ -212,7 +225,7 @@ func TestMediaOptimizeService_CallbackChain(t *testing.T) {
 	mediaRepo := repo.NewRepo(pool)
 	store := newTrackingStore()
 	enq := &captureEnqueuer{}
-	agent := &okAgent{}
+	agent := &okAgent{optimized: make(chan struct{}, 1)}
 	pub := &memPublisher{}
 
 	svc := mediaservice.NewService(
@@ -259,6 +272,13 @@ func TestMediaOptimizeService_CallbackChain(t *testing.T) {
 	}
 	if res.QueuedCount != 1 {
 		t.Fatalf("queued_count = %d, want 1", res.QueuedCount)
+	}
+	// StartOptimize dispatches the agent command in a detached goroutine; await
+	// the signal before reading the counter to avoid a data race.
+	select {
+	case <-agent.optimized:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for detached media_optimize dispatch")
 	}
 	if agent.optimizeCalls != 1 {
 		t.Fatalf("media_optimize dispatched %d times, want 1", agent.optimizeCalls)


### PR DESCRIPTION
Both pre-existing failures were root-caused as stale tests (production code correct). RetentionGC now expects refcount 2 (ADR-050 mark-and-sweep never decrefs; observability-only). The media callback-chain test now awaits the detached dispatch goroutine via a signal channel (-race clean). Only two _test.go files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)