### PR TITLE
Release 0.32.1: perf-config 500 hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.32.1] - 2026-06-09
+
+### Fixed
+
+- The Cache and Optimize settings pages failed to load with an internal server error for every site after 0.32.0. The font-subsetting change in 0.32.0 added three new per-site columns but the read and save queries for the performance config were not regenerated to match, so the database read returned more fields than the query selected and errored. Both queries are now aligned; loading and saving performance settings works again, and the font-subsetting toggle now persists correctly (it was silently not saving in 0.32.0). Control-plane only; no agent, migration, or data change.
+
 ## [0.32.0] - 2026-06-09
 
 ### Added

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -4,7 +4,7 @@ Tags: backup, restore, performance, cache, security
 Requires at least: 6.0
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.32.0
+Stable tag: 0.32.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -102,6 +102,12 @@ No other third-party libraries are bundled in the plugin zip. Image encoding and
 
 == Changelog ==
 
+= 0.32.1 =
+* Maintenance: version alignment with the control plane. No plugin functional changes (the fix in this release was control-plane only).
+
+= 0.32.0 =
+* Performance: self-hosted font subsetting (experimental, default off). Discovers fonts loaded via external stylesheets in addition to inline font-face rules, and reports per-font conversion progress to the control-plane dashboard. Subsetting and transcoding run on the control-plane service, not inside the plugin.
+
 = 0.31.1 =
 * Onboarding: cancel action hard-deletes a site that was never connected; Disconnected-sites empty-state panel now shows Reconnect and Remove actions.
 * Backup: incremental backup engine v1 with content-addressed chunk store (ADR-048); incremental chain restore (ADR-049).
@@ -110,6 +116,9 @@ No other third-party libraries are bundled in the plugin zip. Image encoding and
 * Fix: PHP and JS CI jobs green.
 
 == Upgrade Notice ==
+
+= 0.32.1 =
+Version alignment with the control plane. No plugin functional changes. Safe to update in place.
 
 = 0.31.1 =
 Adds incremental backup engine, WOFF2 font transcoding, and an onboarding cancel fix that hard-deletes never-connected sites. No database changes required. Safe to update in place.

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.32.0
+ * Version:           0.32.1
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.32.0');
+define('WPMGR_AGENT_VERSION', '0.32.1');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 

--- a/apps/api/internal/db/sqlc/perf.sql.go
+++ b/apps/api/internal/db/sqlc/perf.sql.go
@@ -289,7 +289,7 @@ func (q *Queries) GetFleetDbHealth(ctx context.Context, arg GetFleetDbHealthPara
 const getPerfConfig = `-- name: GetPerfConfig :one
 
 
-SELECT site_id, tenant_id, cache_enabled, cache_logged_in, cache_mobile, cache_refresh, cache_refresh_interval, cache_link_prefetch, cache_bypass_urls, cache_bypass_cookies, cache_include_queries, cache_include_cookies, css_js_minify, css_rucss, css_rucss_include_selectors, css_js_self_host_third_party, js_delay, js_delay_method, js_delay_excludes, js_delay_third_party, js_delay_third_party_excludes, fonts_display_swap, fonts_optimize_google, fonts_preload, lazy_load, lazy_load_exclusions, properly_size_images, youtube_placeholder, self_host_gravatars, cdn_enabled, cdn_url, cdn_file_types, cdn_provider, cdn_credentials_encrypted, db_auto_clean, db_auto_clean_interval, db_post_revisions, db_post_auto_drafts, db_post_trashed, db_comments_spam, db_comments_trashed, db_transients_expired, db_optimize_tables, next_db_clean_at, bloat_disable_block_css, bloat_disable_dashicons, bloat_disable_emojis, bloat_disable_jquery_migrate, bloat_disable_xml_rpc, bloat_disable_rss_feed, bloat_disable_oembeds, bloat_heartbeat_control, bloat_post_revisions_control, preload_concurrency, preload_delay_ms, preload_batch_size, preload_max_load, server_software, dropin_installed, wp_cache_constant_set, htaccess_managed, config_version, active_db_clean_job_id, active_db_clean_started, active_db_scan_job_id, active_db_scan_started, woo_cacheable_session, woo_theme_fragments_supported, fonts_transcode_woff2, created_at, updated_at FROM site_perf_config
+SELECT site_id, tenant_id, cache_enabled, cache_logged_in, cache_mobile, cache_refresh, cache_refresh_interval, cache_link_prefetch, cache_bypass_urls, cache_bypass_cookies, cache_include_queries, cache_include_cookies, css_js_minify, css_rucss, css_rucss_include_selectors, css_js_self_host_third_party, js_delay, js_delay_method, js_delay_excludes, js_delay_third_party, js_delay_third_party_excludes, fonts_display_swap, fonts_optimize_google, fonts_preload, lazy_load, lazy_load_exclusions, properly_size_images, youtube_placeholder, self_host_gravatars, cdn_enabled, cdn_url, cdn_file_types, cdn_provider, cdn_credentials_encrypted, db_auto_clean, db_auto_clean_interval, db_post_revisions, db_post_auto_drafts, db_post_trashed, db_comments_spam, db_comments_trashed, db_transients_expired, db_optimize_tables, next_db_clean_at, bloat_disable_block_css, bloat_disable_dashicons, bloat_disable_emojis, bloat_disable_jquery_migrate, bloat_disable_xml_rpc, bloat_disable_rss_feed, bloat_disable_oembeds, bloat_heartbeat_control, bloat_post_revisions_control, preload_concurrency, preload_delay_ms, preload_batch_size, preload_max_load, server_software, dropin_installed, wp_cache_constant_set, htaccess_managed, config_version, active_db_clean_job_id, active_db_clean_started, active_db_scan_job_id, active_db_scan_started, woo_cacheable_session, woo_theme_fragments_supported, fonts_transcode_woff2, fonts_subset, fonts_subset_mode, fonts_subset_range, created_at, updated_at FROM site_perf_config
 WHERE site_id = $1
 `
 
@@ -1210,7 +1210,8 @@ INSERT INTO site_perf_config (
     bloat_disable_jquery_migrate, bloat_disable_xml_rpc, bloat_disable_rss_feed,
     bloat_disable_oembeds, bloat_heartbeat_control, bloat_post_revisions_control,
     preload_concurrency, preload_delay_ms, preload_batch_size, preload_max_load,
-    config_version, woo_cacheable_session, fonts_transcode_woff2, updated_at
+    config_version, woo_cacheable_session, fonts_transcode_woff2,
+    fonts_subset, fonts_subset_mode, fonts_subset_range, updated_at
 ) VALUES (
     $1, $2,
     $3, $4, $5, $6,
@@ -1230,7 +1231,7 @@ INSERT INTO site_perf_config (
     $47, $48, $49,
     $50, $51, $52,
     $53, $54, $55, $56,
-    $57, $58, $59, now()
+    $57, $58, $59, $60, $61, $62, now()
 )
 ON CONFLICT (site_id) DO UPDATE SET
     cache_enabled                 = EXCLUDED.cache_enabled,
@@ -1290,8 +1291,11 @@ ON CONFLICT (site_id) DO UPDATE SET
     config_version                = EXCLUDED.config_version,
     woo_cacheable_session         = EXCLUDED.woo_cacheable_session,
     fonts_transcode_woff2         = EXCLUDED.fonts_transcode_woff2,
+    fonts_subset                  = EXCLUDED.fonts_subset,
+    fonts_subset_mode             = EXCLUDED.fonts_subset_mode,
+    fonts_subset_range            = EXCLUDED.fonts_subset_range,
     updated_at                    = now()
-RETURNING site_id, tenant_id, cache_enabled, cache_logged_in, cache_mobile, cache_refresh, cache_refresh_interval, cache_link_prefetch, cache_bypass_urls, cache_bypass_cookies, cache_include_queries, cache_include_cookies, css_js_minify, css_rucss, css_rucss_include_selectors, css_js_self_host_third_party, js_delay, js_delay_method, js_delay_excludes, js_delay_third_party, js_delay_third_party_excludes, fonts_display_swap, fonts_optimize_google, fonts_preload, lazy_load, lazy_load_exclusions, properly_size_images, youtube_placeholder, self_host_gravatars, cdn_enabled, cdn_url, cdn_file_types, cdn_provider, cdn_credentials_encrypted, db_auto_clean, db_auto_clean_interval, db_post_revisions, db_post_auto_drafts, db_post_trashed, db_comments_spam, db_comments_trashed, db_transients_expired, db_optimize_tables, next_db_clean_at, bloat_disable_block_css, bloat_disable_dashicons, bloat_disable_emojis, bloat_disable_jquery_migrate, bloat_disable_xml_rpc, bloat_disable_rss_feed, bloat_disable_oembeds, bloat_heartbeat_control, bloat_post_revisions_control, preload_concurrency, preload_delay_ms, preload_batch_size, preload_max_load, server_software, dropin_installed, wp_cache_constant_set, htaccess_managed, config_version, active_db_clean_job_id, active_db_clean_started, active_db_scan_job_id, active_db_scan_started, woo_cacheable_session, woo_theme_fragments_supported, fonts_transcode_woff2, created_at, updated_at
+RETURNING site_id, tenant_id, cache_enabled, cache_logged_in, cache_mobile, cache_refresh, cache_refresh_interval, cache_link_prefetch, cache_bypass_urls, cache_bypass_cookies, cache_include_queries, cache_include_cookies, css_js_minify, css_rucss, css_rucss_include_selectors, css_js_self_host_third_party, js_delay, js_delay_method, js_delay_excludes, js_delay_third_party, js_delay_third_party_excludes, fonts_display_swap, fonts_optimize_google, fonts_preload, lazy_load, lazy_load_exclusions, properly_size_images, youtube_placeholder, self_host_gravatars, cdn_enabled, cdn_url, cdn_file_types, cdn_provider, cdn_credentials_encrypted, db_auto_clean, db_auto_clean_interval, db_post_revisions, db_post_auto_drafts, db_post_trashed, db_comments_spam, db_comments_trashed, db_transients_expired, db_optimize_tables, next_db_clean_at, bloat_disable_block_css, bloat_disable_dashicons, bloat_disable_emojis, bloat_disable_jquery_migrate, bloat_disable_xml_rpc, bloat_disable_rss_feed, bloat_disable_oembeds, bloat_heartbeat_control, bloat_post_revisions_control, preload_concurrency, preload_delay_ms, preload_batch_size, preload_max_load, server_software, dropin_installed, wp_cache_constant_set, htaccess_managed, config_version, active_db_clean_job_id, active_db_clean_started, active_db_scan_job_id, active_db_scan_started, woo_cacheable_session, woo_theme_fragments_supported, fonts_transcode_woff2, fonts_subset, fonts_subset_mode, fonts_subset_range, created_at, updated_at
 `
 
 type UpsertPerfConfigParams struct {


### PR DESCRIPTION
## Production hotfix (0.32.1)

After the 0.32.0 font-subsetting release, `GET /api/v1/sites/{id}/perf/config` returned **500 for every site**, breaking the Cache and Optimize settings pages.

### Root cause
0.32.0 (m55) added three per-site columns (`fonts_subset`, `fonts_subset_mode`, `fonts_subset_range`) but the generated sqlc was **hand-edited instead of regenerated**. In `perf.sql.go`:
- `GetPerfConfig`: the `Scan` gained the 3 new destinations but the `SELECT` list did not → pgx `number of field descriptions must equal number of destinations` → 500.
- `UpsertPerfConfig`: same `RETURNING`/`Scan` mismatch, **plus** it bound `$60-$62` against a 59-placeholder statement and never wrote the columns, so the `fonts_subset` toggle silently never saved.

### Fix
Aligned both queries to exactly what `sqlc generate` would emit (the source `.sql` was already correct). Verified column/placeholder/scan parity (GetPerfConfig 74/74; Upsert INSERT 63 / VALUES 63 / args 62 / RETURNING 74 / Scan 74). `go build`/`vet`/`test` green.

### Shipped
- Prod: `api:0.32.1` deployed (rev `wpmgr-api-00158-vk5`), live `GET /perf/config` confirmed **200**, zero 500s on the new revision.
- This PR carries the code fix + unified version bump (agent + readme + CHANGELOG) for the OSS GHCR `v0.32.1` tag.

CP-only; no migration, web, or agent functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: Version 0.32.1

* **Bug Fixes**
  * Fixed internal server errors when loading Cache and Optimize settings pages
  * Fixed font-subsetting toggle not persisting after save

* **Chores**
  * Version bumped to 0.32.1 for control-plane alignment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->