### PR TITLE
fix(web): email tab first-run 404 + webhook LB routing (0.35.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.35.1] - 2026-06-10
+
+### Fixed
+
+- **Email tab showed "Could not load email configuration" on sites that had never set up email.** A site with no per-site email config and no org-wide default returns a 404 by design, but the dashboard rendered it as an error instead of the first-run setup state. The Email tab now shows the provider setup form with a short "not configured yet" hint when no config exists.
+- **Provider bounce and complaint webhooks could not reach the API behind the hosted load balancer.** The `/webhooks/*` path was not routed to the API service, so provider callbacks fell through to the web app. Self-hosters are unaffected (single service); the hosted load balancer now routes `/webhooks/*` to the API.
+
 ## [0.35.0] - 2026-06-10
 
 ### Added

--- a/apps/web/src/features/email/email-provider-config.tsx
+++ b/apps/web/src/features/email/email-provider-config.tsx
@@ -415,6 +415,14 @@ export function EmailProviderConfig({ siteId }: EmailProviderConfigProps) {
 
   return (
     <div className="space-y-6">
+      {/* First-run hint: no per-site row and no org default yet. */}
+      {!serverConfig ? (
+        <div className="rounded-[var(--radius)] border border-[var(--color-border)] bg-[var(--color-muted)]/40 px-4 py-3 text-sm text-[var(--color-muted-foreground)]">
+          Email is not configured for this site yet. Choose a provider below and
+          save to start routing this site&rsquo;s mail through it.
+        </div>
+      ) : null}
+
       {/* Provider selection */}
       <Card>
         <CardHeader>

--- a/apps/web/src/features/email/use-email.ts
+++ b/apps/web/src/features/email/use-email.ts
@@ -175,14 +175,21 @@ export function usePutOrgEmailConfig(): UseMutationResult<
  */
 export function useEmailConfig(
   siteId: string,
-): UseQueryResult<SiteEmailConfig, Error> {
+): UseQueryResult<SiteEmailConfig | null, Error> {
   return useQuery({
     queryKey: emailKeys.siteConfig(siteId),
     queryFn: async () => {
-      const { data, error } = await getSiteEmailConfig({
+      const { data, error, response } = await getSiteEmailConfig({
         path: { siteId },
       });
-      if (error) throw toError(error);
+      if (error) {
+        // A site with no per-site config row AND no org-wide default returns
+        // 404 (email_config_not_found). That is the "not configured yet"
+        // state, not a failure — surface it as a null config so the panels
+        // render their setup forms with empty defaults instead of an error.
+        if (response?.status === 404) return null;
+        throw toError(error);
+      }
       return data;
     },
     staleTime: 60_000,


### PR DESCRIPTION
## Summary

Two post-0.35.0 fixes surfaced while QA'ing the new per-site email feature on a real site.

### 1. Email tab showed a hard error on unconfigured sites (web)
`GET /sites/{id}/email/config` returns **404 by design** when a site has no per-site row and no org-wide default — i.e. every site until email is first configured. `useEmailConfig` threw on it, so the Email tab rendered "Could not load email configuration" instead of the setup state.

- Map the 404 → `null` config; the Provider/Routing panels render their setup forms with empty defaults.
- Add a first-run hint on the Provider panel.

### 2. Provider webhooks unreachable behind the hosted LB (infra)
The prod load-balancer url-map routed `/api/*`, `/agent/*`, `/auth/*`, `/rum/*` to the API but **not `/webhooks/*`**, so `POST /webhooks/email/...` fell through to the SPA (405). Added `/webhooks/*` → API backend in the hosted url-map. Self-hosters (single service) are unaffected.

## Test plan
- `tsc --noEmit` + `eslint` green.
- Prod: web `0.35.1` deployed (`wpmgr-web-00138-x6s`); LB url-map updated and verified to contain `/webhooks/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Email tab no longer displays a configuration error when email setup is incomplete; it now shows provider setup options with a "not configured yet" hint
- Provider bounce and complaint webhooks are now correctly routed to the API service in hosted environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->