### PR TITLE
v0.38.1: report generation + client navigation hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ### Fixed
 
+- **On-demand reports were stuck in pending forever.** The report job started but every status transition failed because the `generated_reports` table was missing its `updated_at` column (the m64 migration omitted it while all report mutations write it; the query compiler does not validate UPDATE SET column names, so it only surfaced at runtime). Migration m65 adds the column; stuck reports recover automatically on the job's next retry.
 - **Client rows were not clickable.** The Clients page listed clients with only Edit and Delete actions and no way to open a client's detail page (sites + reports). The client name is now a link, and the Client badge on the sites table also links to the client.
 
 ## [0.38.0] - 2026-06-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.38.1] - 2026-06-11
+
+### Fixed
+
+- **Client rows were not clickable.** The Clients page listed clients with only Edit and Delete actions and no way to open a client's detail page (sites + reports). The client name is now a link, and the Client badge on the sites table also links to the client.
+
 ## [0.38.0] - 2026-06-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 - **On-demand reports were stuck in pending forever.** The report job started but every status transition failed because the `generated_reports` table was missing its `updated_at` column (the m64 migration omitted it while all report mutations write it; the query compiler does not validate UPDATE SET column names, so it only surfaced at runtime). Migration m65 adds the column; stuck reports recover automatically on the job's next retry.
 - **Client rows were not clickable.** The Clients page listed clients with only Edit and Delete actions and no way to open a client's detail page (sites + reports). The client name is now a link, and the Client badge on the sites table also links to the client.
+- **Completed reports showed "Storage not configured" instead of download links.** The report list endpoint never minted presigned download URLs (only the per-report detail endpoint did), so the dashboard's report table had no HTML or PDF links to render even when object storage was configured and the artifacts were stored. The list endpoint now presigns URLs for every completed report (a local signing operation, no storage round trip).
 
 ## [0.38.0] - 2026-06-11
 

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -2382,6 +2382,10 @@ CREATE TABLE generated_reports (
     pdf_blob_key   text        NOT NULL DEFAULT '',
     error          text        NOT NULL DEFAULT '',
     created_at     timestamptz NOT NULL DEFAULT now(),
+    -- m65: updated_at was omitted from m64 while every report mutation writes
+    -- it (sqlc does not validate UPDATE SET columns, so this only failed at
+    -- runtime). Keep in lockstep with the migration.
+    updated_at     timestamptz NOT NULL DEFAULT now(),
     completed_at   timestamptz,
 
     CONSTRAINT generated_reports_pkey PRIMARY KEY (id),

--- a/apps/api/internal/db/sqlc/client_reports.sql.go
+++ b/apps/api/internal/db/sqlc/client_reports.sql.go
@@ -67,7 +67,7 @@ SET status        = 'completed',
     completed_at  = now(),
     updated_at    = now()
 WHERE id = $4 AND tenant_id = $5
-RETURNING id, tenant_id, client_id, schedule_id, period_start, period_end, status, data_snapshot, html_blob_key, pdf_blob_key, error, created_at, completed_at
+RETURNING id, tenant_id, client_id, schedule_id, period_start, period_end, status, data_snapshot, html_blob_key, pdf_blob_key, error, created_at, updated_at, completed_at
 `
 
 type CompleteReportParams struct {
@@ -100,6 +100,7 @@ func (q *Queries) CompleteReport(ctx context.Context, arg CompleteReportParams) 
 		&i.PdfBlobKey,
 		&i.Error,
 		&i.CreatedAt,
+		&i.UpdatedAt,
 		&i.CompletedAt,
 	)
 	return i, err
@@ -112,7 +113,7 @@ INSERT INTO generated_reports (
 ) VALUES (
     $1, $2, $3, $4, $5, 'pending'
 )
-RETURNING id, tenant_id, client_id, schedule_id, period_start, period_end, status, data_snapshot, html_blob_key, pdf_blob_key, error, created_at, completed_at
+RETURNING id, tenant_id, client_id, schedule_id, period_start, period_end, status, data_snapshot, html_blob_key, pdf_blob_key, error, created_at, updated_at, completed_at
 `
 
 type CreateReportParams struct {
@@ -148,6 +149,7 @@ func (q *Queries) CreateReport(ctx context.Context, arg CreateReportParams) (Gen
 		&i.PdfBlobKey,
 		&i.Error,
 		&i.CreatedAt,
+		&i.UpdatedAt,
 		&i.CompletedAt,
 	)
 	return i, err
@@ -178,7 +180,7 @@ SET status     = 'failed',
     error      = $1,
     updated_at = now()
 WHERE id = $2 AND tenant_id = $3
-RETURNING id, tenant_id, client_id, schedule_id, period_start, period_end, status, data_snapshot, html_blob_key, pdf_blob_key, error, created_at, completed_at
+RETURNING id, tenant_id, client_id, schedule_id, period_start, period_end, status, data_snapshot, html_blob_key, pdf_blob_key, error, created_at, updated_at, completed_at
 `
 
 type FailReportParams struct {
@@ -203,6 +205,7 @@ func (q *Queries) FailReport(ctx context.Context, arg FailReportParams) (Generat
 		&i.PdfBlobKey,
 		&i.Error,
 		&i.CreatedAt,
+		&i.UpdatedAt,
 		&i.CompletedAt,
 	)
 	return i, err
@@ -282,7 +285,7 @@ func (q *Queries) GetClientWithTimezone(ctx context.Context, arg GetClientWithTi
 }
 
 const getReport = `-- name: GetReport :one
-SELECT id, tenant_id, client_id, schedule_id, period_start, period_end, status, data_snapshot, html_blob_key, pdf_blob_key, error, created_at, completed_at FROM generated_reports
+SELECT id, tenant_id, client_id, schedule_id, period_start, period_end, status, data_snapshot, html_blob_key, pdf_blob_key, error, created_at, updated_at, completed_at FROM generated_reports
 WHERE id = $1 AND tenant_id = $2 AND client_id = $3
 `
 
@@ -308,6 +311,7 @@ func (q *Queries) GetReport(ctx context.Context, arg GetReportParams) (Generated
 		&i.PdfBlobKey,
 		&i.Error,
 		&i.CreatedAt,
+		&i.UpdatedAt,
 		&i.CompletedAt,
 	)
 	return i, err
@@ -503,7 +507,7 @@ func (q *Queries) ListDueReportSchedules(ctx context.Context, rowLimit int32) ([
 }
 
 const listReports = `-- name: ListReports :many
-SELECT id, tenant_id, client_id, schedule_id, period_start, period_end, status, data_snapshot, html_blob_key, pdf_blob_key, error, created_at, completed_at FROM generated_reports
+SELECT id, tenant_id, client_id, schedule_id, period_start, period_end, status, data_snapshot, html_blob_key, pdf_blob_key, error, created_at, updated_at, completed_at FROM generated_reports
 WHERE tenant_id  = $1
   AND client_id  = $2
   AND (
@@ -553,6 +557,7 @@ func (q *Queries) ListReports(ctx context.Context, arg ListReportsParams) ([]Gen
 			&i.PdfBlobKey,
 			&i.Error,
 			&i.CreatedAt,
+			&i.UpdatedAt,
 			&i.CompletedAt,
 		); err != nil {
 			return nil, err
@@ -570,7 +575,7 @@ UPDATE generated_reports
 SET status = 'generating',
     updated_at = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, client_id, schedule_id, period_start, period_end, status, data_snapshot, html_blob_key, pdf_blob_key, error, created_at, completed_at
+RETURNING id, tenant_id, client_id, schedule_id, period_start, period_end, status, data_snapshot, html_blob_key, pdf_blob_key, error, created_at, updated_at, completed_at
 `
 
 type MarkReportGeneratingParams struct {
@@ -594,6 +599,7 @@ func (q *Queries) MarkReportGenerating(ctx context.Context, arg MarkReportGenera
 		&i.PdfBlobKey,
 		&i.Error,
 		&i.CreatedAt,
+		&i.UpdatedAt,
 		&i.CompletedAt,
 	)
 	return i, err

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -337,6 +337,7 @@ type GeneratedReport struct {
 	PdfBlobKey   string             `json:"pdf_blob_key"`
 	Error        string             `json:"error"`
 	CreatedAt    time.Time          `json:"created_at"`
+	UpdatedAt    time.Time          `json:"updated_at"`
 	CompletedAt  pgtype.Timestamptz `json:"completed_at"`
 }
 

--- a/apps/api/internal/report/handler.go
+++ b/apps/api/internal/report/handler.go
@@ -252,7 +252,11 @@ func (h *Handler) listReports(c *gin.Context) {
 	}
 	items := make([]reportDTO, 0, len(result.Items))
 	for _, r := range result.Items {
-		items = append(items, toReportDTO(r, "", ""))
+		// The web list renders download links directly from this response, so
+		// completed rows must carry presigned URLs (presigning is local SigV4
+		// signing — no storage round trip per item).
+		htmlURL, pdfURL := h.svc.PresignReportURLs(c.Request.Context(), r)
+		items = append(items, toReportDTO(r, htmlURL, pdfURL))
 	}
 	c.JSON(http.StatusOK, reportListDTO{Items: items, NextCursor: result.NextCursor})
 }

--- a/apps/api/internal/report/report_test.go
+++ b/apps/api/internal/report/report_test.go
@@ -637,9 +637,49 @@ func TestReportRepoIsolation_GeneratedReportCarriesTenantID(t *testing.T) {
 	}
 }
 
+// TestPresignReportURLs_OnlyCompletedReportsGetURLs verifies the shared
+// presign helper used by both the list and detail endpoints: completed
+// reports with blob keys get URLs, everything else gets empty strings.
+func TestPresignReportURLs_OnlyCompletedReportsGetURLs(t *testing.T) {
+	svc := NewService(&stubRepo{}, &urlBlobStorer{})
+
+	completed := GeneratedReport{
+		Status:      StatusCompleted,
+		HTMLBlobKey: "reports/t/c/r.html",
+		PDFBlobKey:  "reports/t/c/r.pdf",
+	}
+	htmlURL, pdfURL := svc.PresignReportURLs(context.Background(), completed)
+	if htmlURL != "https://signed.example/reports/t/c/r.html" {
+		t.Fatalf("completed report html url = %q", htmlURL)
+	}
+	if pdfURL != "https://signed.example/reports/t/c/r.pdf" {
+		t.Fatalf("completed report pdf url = %q", pdfURL)
+	}
+
+	pending := GeneratedReport{Status: StatusPending, HTMLBlobKey: "k.html", PDFBlobKey: "k.pdf"}
+	htmlURL, pdfURL = svc.PresignReportURLs(context.Background(), pending)
+	if htmlURL != "" || pdfURL != "" {
+		t.Fatalf("non-completed report must not get urls, got %q / %q", htmlURL, pdfURL)
+	}
+
+	// nil blob store (object storage not configured) degrades to empty URLs.
+	noBlob := NewService(&stubRepo{}, nil)
+	htmlURL, pdfURL = noBlob.PresignReportURLs(context.Background(), completed)
+	if htmlURL != "" || pdfURL != "" {
+		t.Fatalf("nil blob store must yield empty urls, got %q / %q", htmlURL, pdfURL)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// urlBlobStorer returns a deterministic presigned URL for any key.
+type urlBlobStorer struct{ noopBlobStorer }
+
+func (u *urlBlobStorer) PresignGet(_ context.Context, key string, _ time.Duration) (string, error) {
+	return "https://signed.example/" + key, nil
+}
 
 // noopBlobStorer satisfies BlobStorer without doing anything.
 type noopBlobStorer struct{}

--- a/apps/api/internal/report/service.go
+++ b/apps/api/internal/report/service.go
@@ -203,16 +203,26 @@ func (s *Service) GetReportWithURLs(ctx context.Context, tenantID, clientID, rep
 	if err != nil {
 		return GeneratedReport{}, "", "", err
 	}
-	var htmlURL, pdfURL string
-	if rpt.Status == StatusCompleted && s.blob != nil {
-		if rpt.HTMLBlobKey != "" {
-			htmlURL, _ = s.blob.PresignGet(ctx, rpt.HTMLBlobKey, presignTTL)
-		}
-		if rpt.PDFBlobKey != "" {
-			pdfURL, _ = s.blob.PresignGet(ctx, rpt.PDFBlobKey, presignTTL)
-		}
-	}
+	htmlURL, pdfURL := s.PresignReportURLs(ctx, rpt)
 	return rpt, htmlURL, pdfURL, nil
+}
+
+// PresignReportURLs mints presigned download URLs for a completed report.
+// Returns empty strings when the report is not completed or object storage is
+// not configured. Presigning is local SigV4 computation (no round trip to the
+// storage backend), so calling this per list item is cheap.
+func (s *Service) PresignReportURLs(ctx context.Context, rpt GeneratedReport) (string, string) {
+	if rpt.Status != StatusCompleted || s.blob == nil {
+		return "", ""
+	}
+	var htmlURL, pdfURL string
+	if rpt.HTMLBlobKey != "" {
+		htmlURL, _ = s.blob.PresignGet(ctx, rpt.HTMLBlobKey, presignTTL)
+	}
+	if rpt.PDFBlobKey != "" {
+		pdfURL, _ = s.blob.PresignGet(ctx, rpt.PDFBlobKey, presignTTL)
+	}
+	return htmlURL, pdfURL
 }
 
 // DeleteReport deletes the DB row and best-effort deletes blob objects.

--- a/apps/api/migrations/20260628000000_m65_generated_reports_updated_at.sql
+++ b/apps/api/migrations/20260628000000_m65_generated_reports_updated_at.sql
@@ -1,0 +1,12 @@
+-- m65 — add the missing generated_reports.updated_at column.
+--
+-- m64 documented the project convention ("updated_at set by now() in queries,
+-- no trigger") and added the column to report_schedules, but omitted it from
+-- generated_reports. All three report mutations (MarkReportGenerating,
+-- CompleteReport, FailReport) write updated_at, so every status transition
+-- failed at runtime with SQLSTATE 42703 and on-demand reports sat in
+-- 'pending' forever (the River job retried into the same error). sqlc compiled
+-- the queries because its analyzer does not validate UPDATE SET column names.
+
+ALTER TABLE "public"."generated_reports"
+    ADD COLUMN IF NOT EXISTS "updated_at" timestamptz NOT NULL DEFAULT now();

--- a/apps/web/src/features/clients/clients-list.tsx
+++ b/apps/web/src/features/clients/clients-list.tsx
@@ -4,6 +4,7 @@
 // Mirrors destinations-list.tsx table pattern.
 
 import { useState } from "react";
+import { Link } from "@tanstack/react-router";
 import { Plus, Pencil, Trash2, Users } from "lucide-react";
 import type { AgencyClient } from "@wpmgr/api";
 
@@ -159,10 +160,14 @@ export function ClientsList() {
               {data.map((client) => (
                 <TableRow key={client.id}>
                   <TableCell>
-                    <div className="flex items-center gap-2">
+                    <Link
+                      to="/clients/$clientId"
+                      params={{ clientId: client.id }}
+                      className="flex items-center gap-2 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+                    >
                       <ColorDot color={client.color} />
                       <span className="font-medium">{client.name}</span>
-                    </div>
+                    </Link>
                   </TableCell>
                   <TableCell className="text-sm text-[var(--color-muted-foreground)]">
                     {client.company ?? (

--- a/apps/web/src/features/sites/sites-table.tsx
+++ b/apps/web/src/features/sites/sites-table.tsx
@@ -282,6 +282,7 @@ function buildColumns(
       size: COL_CLIENT_PX,
       cell: ({ row }) => {
         const name = row.original.site.client_name;
+        const clientId = row.original.site.client_id;
         if (!name) {
           return (
             <span
@@ -292,14 +293,27 @@ function buildColumns(
             </span>
           );
         }
-        return (
-          <div className="flex min-w-0 items-center gap-1.5">
+        const inner = (
+          <>
             <span
               aria-hidden="true"
               className="inline-block size-2 shrink-0 rounded-full border border-[var(--color-border)] bg-[var(--color-muted)]"
             />
             <span className="truncate text-sm">{name}</span>
-          </div>
+          </>
+        );
+        if (!clientId) {
+          return <div className="flex min-w-0 items-center gap-1.5">{inner}</div>;
+        }
+        return (
+          <Link
+            to="/clients/$clientId"
+            params={{ clientId }}
+            className="flex min-w-0 items-center gap-1.5 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {inner}
+          </Link>
         );
       },
     },


### PR DESCRIPTION
## Summary

Three fixes for issues found during live QA of the v0.38.0 white-label client reports:

- **Reports stuck in pending forever**: the m64 migration omitted `generated_reports.updated_at` while every report status mutation writes it, so each transition failed at runtime with SQLSTATE 42703 and the River job retried into the same error. Migration m65 adds the column; `db/schema.sql` kept in lockstep and sqlc regenerated (true no-op verified).
- **Completed reports showed "Storage not configured" instead of download links**: the report list endpoint never minted presigned URLs (only the per-report detail endpoint did), while the web table renders links straight from the list response. The list endpoint now presigns HTML/PDF URLs per completed row via a shared `PresignReportURLs` helper (local SigV4 signing, no storage round trip). Test added.
- **Client rows were not clickable**: the Clients page had no way to open a client's detail page; the client name now links to `/clients/$clientId`, and the Client badge on the sites table links there too.

## Testing

- `go build ./... && go test ./internal/report/...` green (29 + 1 new test)
- Verified live on prod: previously stuck report recovered, fresh report generated end to end, and both completed reports now show working HTML + PDF download links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed on-demand reports getting stuck in pending status
  * Completed reports now display download links in the reports list
  * Client names on the Clients page and Sites table are now clickable links to client details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->