### PR TITLE
fix: object cache engine actually connects (0.41.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.41.2] - 2026-06-11
+
+### Fixed
+
+- **Object cache: the engine's supporting classes now load at drop-in time.** The 0.41.1 drop-in located the engine correctly, but the engine file then loaded its config and connection classes through a plugin constant that does not exist that early in the WordPress boot, so it silently fell back to the in-memory array cache on every request and kept reporting itself idle. The engine now resolves its sibling class files from its own directory, which is always available. Agent-only fix.
+- **Object cache: the stamped engine path in the drop-in is honored.** The installer's placeholder replacement also rewrote the guard that detects an un-stamped stub, turning the stamped path into dead code; standard installs survived only via the content-directory fallback. The guard token is now built so stamping cannot touch it, and the drop-in version bump makes existing installs self-heal on the next agent heartbeat.
+
+Requires agent 0.41.2. No control plane or dashboard changes.
+
 ## [0.41.1] - 2026-06-11
 
 ### Fixed

--- a/apps/agent/assets/wpmgr-object-cache.php
+++ b/apps/agent/assets/wpmgr-object-cache.php
@@ -24,7 +24,7 @@
  * silenced.
  *
  * WPMgr Object Cache drop-in
- * Version: 1.1.0
+ * Version: 1.2.0
  *
  * @package WPMgr\Agent\ObjectCache
  */
@@ -62,8 +62,10 @@ if ( defined( 'WPMGR_OBJECT_CACHE_DISABLED' ) && WPMGR_OBJECT_CACHE_DISABLED ) {
 $wpmgr_oc_engine = '';
 
 // Probe 1: stamped absolute path (placeholder replaced at install time).
+// The comparison token is concatenated so the installer's str_replace of the
+// quoted placeholder cannot rewrite this guard into a self-comparison.
 $wpmgr_oc_stamped = '__WPMGR_OC_ENGINE_PATH__';
-if ( $wpmgr_oc_stamped !== '' && $wpmgr_oc_stamped !== '__WPMGR_OC_ENGINE_PATH__' ) {
+if ( $wpmgr_oc_stamped !== '' && $wpmgr_oc_stamped !== '__WPMGR' . '_OC_ENGINE_PATH__' ) {
 	if ( @is_file( $wpmgr_oc_stamped ) ) {
 		$wpmgr_oc_engine = $wpmgr_oc_stamped;
 	}

--- a/apps/agent/includes/object-cache/class-object-cache-engine.php
+++ b/apps/agent/includes/object-cache/class-object-cache-engine.php
@@ -18,30 +18,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // ---------------------------------------------------------------------------
-// Load supporting classes. The Composer autoloader may not be available at
-// drop-in load time (wp-settings.php includes object-cache.php before plugins),
-// so we require_once each file directly.
+// Load supporting classes. Neither the Composer autoloader nor any plugin
+// constant exists at drop-in load time (wp-settings.php includes
+// object-cache.php before plugins), so resolve the siblings from this file's
+// own directory: they always live next to the engine.
 // ---------------------------------------------------------------------------
 
-$wpmgr_oc_dir = defined( 'WPMGR_AGENT_DIR' )
-	? rtrim( (string) constant( 'WPMGR_AGENT_DIR' ), '/\\' ) . '/includes/object-cache/'
-	: '';
-
-if ( $wpmgr_oc_dir !== '' ) {
-	foreach (
-		[
-			'class-object-cache-config.php',
-			'class-redis-connection.php',
-		] as $wpmgr_oc_dep
-	) {
-		$wpmgr_oc_dep_path = $wpmgr_oc_dir . $wpmgr_oc_dep;
-		if ( @is_file( $wpmgr_oc_dep_path ) ) {
-			require_once $wpmgr_oc_dep_path; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath -- path is derived from WPMGR_AGENT_DIR constant, always absolute
-		}
+foreach (
+	[
+		'class-object-cache-config.php',
+		'class-redis-connection.php',
+	] as $wpmgr_oc_dep
+) {
+	$wpmgr_oc_dep_path = __DIR__ . '/' . $wpmgr_oc_dep;
+	if ( @is_file( $wpmgr_oc_dep_path ) ) {
+		require_once $wpmgr_oc_dep_path; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath -- __DIR__-anchored sibling, always absolute
 	}
 }
 
-unset( $wpmgr_oc_dir, $wpmgr_oc_dep, $wpmgr_oc_dep_path );
+unset( $wpmgr_oc_dep, $wpmgr_oc_dep_path );
 
 // ---------------------------------------------------------------------------
 // Boot the cache: try Redis, fall back to pure array on any Throwable.

--- a/apps/agent/tests/ObjectCache/ObjectCacheBugFixTest.php
+++ b/apps/agent/tests/ObjectCache/ObjectCacheBugFixTest.php
@@ -141,6 +141,16 @@ final class ObjectCacheBugFixTest extends TestCase
 			);
 		}
 
+		// Probe 1 regression: the un-stamped guard comparison must survive
+		// stamping (it is concatenated in the template precisely so that the
+		// installer's str_replace cannot rewrite it into a self-comparison,
+		// which would make the stamped path dead code).
+		$this->assertStringContainsString(
+			"'__WPMGR' . '_OC_ENGINE_PATH__'",
+			$installed,
+			'The guard comparison token must remain concatenated after stamping (probe 1 must stay live)'
+		);
+
 		// The installed file must be syntactically valid PHP.
 		$tmpOut = sys_get_temp_dir() . '/wpmgr_stub_lint_' . uniqid( '', true ) . '.php';
 		file_put_contents( $tmpOut, $installed );


### PR DESCRIPTION
## Summary

Two remaining dead-constant bugs from live QA on agent 0.41.1, both in the early-boot path where no plugin constants exist:

- The engine file loaded its config/connection sibling classes via WPMGR_AGENT_DIR (undefined at drop-in time), so boot() bailed to array mode on every request and the heartbeat forever reported idle. Siblings now load from __DIR__.
- The installer's placeholder replacement also rewrote the stub's un-stamped guard into a self-comparison, making the stamped path dead code. The guard token is now concatenated in the template; regression-asserted.
- Stub 1.1.0 -> 1.2.0 so field installs self-heal on the next heartbeat.

Agent-only; no CP/web changes. Suite 1438 green, phpcs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)