### PR TITLE
fix(agent): failback hardening + ownership alignment; E2E harness first full-green run (0.43.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.43.1] - 2026-06-12
+
+### Fixed
+
+- **Object cache: configuration files written by privileged command-line processes are now readable by the web server.** When WP-CLI provisioning ran as root, the 0600 configuration file was unreadable by the web server user. Web requests silently served the cache in array mode while command-line checks reported connected. The configuration and cool-down state writers now align file ownership with the owner of the WordPress core entry file. Caught by the new end-to-end harness.
+- **Object cache: a Redis write failure during PHP shutdown no longer arms a recovery flush.** A failure while the process is already shutting down is not an outage; previously it could persist an outage marker and schedule an unnecessary cache flush at the next boot.
+- **Object cache: the recovery flush deletes its marker before flushing**, closing a window where the flush removed its own coordination lock and a second request could flush again.
+- **Object cache: the cool-down side channel uses APCu only when it is actually enabled** in the running interpreter, fixing silent cool-down loss in command-line contexts.
+
+### Added
+
+- **The end-to-end Docker harness ran green for the first time across all eighteen stages**, including cross-request persistence, the boot recursion guard with descriptor counting, codec fallback against a runtime without igbinary, and the live debug header on a real front-end response. Stage fixes along the way: provisioning runs as the web user, config changes go through the engine writer so opcache is invalidated, and the teardown order respects the plugin autoloader.
+
+Agent 0.43.1 with drop-in 2.2.1; no control plane changes beyond 0.43.0.
+
 ## [0.43.0] - 2026-06-12
 
 ### Added

--- a/apps/agent/assets/wpmgr-object-cache-dropin.php
+++ b/apps/agent/assets/wpmgr-object-cache-dropin.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * WPMgr Object Cache drop-in
- * Version: 2.2.0
+ * Version: 2.2.1
  *
  * Self-contained object-cache.php drop-in for WordPress. All engine classes are
  * inlined; no external file resolution can fail after installation.
@@ -17,7 +17,7 @@ namespace {
 
 	// Breadcrumb: set immediately after ABSPATH guard so the heartbeat can detect
 	// whether the drop-in was executed at all and identify early-bail causes.
-	$GLOBALS['wpmgr_oc_stub'] = [ 'v' => '2.2.0', 'bail' => null ];
+	$GLOBALS['wpmgr_oc_stub'] = [ 'v' => '2.2.1', 'bail' => null ];
 
 	// PHP floor: the engine uses PHP 8.1 features.
 	if ( PHP_VERSION_ID < 80100 ) {
@@ -1178,7 +1178,7 @@ class WPMgr_Object_Cache
 	// -------------------------------------------------------------------------
 
 	/** Version of this engine class. Included in every heartbeat block. */
-	public const ENGINE_VERSION = '0.43.0';
+	public const ENGINE_VERSION = '0.43.1';
 
 	// -------------------------------------------------------------------------
 	// Feature advertisement (wp_cache_supports).
@@ -1310,6 +1310,16 @@ class WPMgr_Object_Cache
 
 	/** @var bool Whether we already ran the failback flush this boot. */
 	private bool $failbackFlushed = false;
+
+	/**
+	 * True once the PHP-shutdown path has entered shutdown().
+	 * A Redis failure that occurs during persistStats() at shutdown is not
+	 * an actionable outage — the process is dying. When this flag is set,
+	 * redisOp()'s error handler skips both markDegraded-side
+	 * persistOutageMarker() and the marker write, while still degrading
+	 * in-memory so the fallback path executes gracefully.
+	 */
+	private bool $inShutdown = false;
 
 	/** @var array<string,mixed> Loaded config array. */
 	private array $config = [];
@@ -2283,6 +2293,9 @@ class WPMgr_Object_Cache
 	 */
 	public function shutdown(): void
 	{
+		// Mark the shutdown path so that any Redis failure inside persistStats()
+		// does not write a spurious outage marker (the process is already dying).
+		$this->inShutdown = true;
 		try {
 			$this->persistStats();
 		} catch ( \Throwable $e ) {
@@ -2817,9 +2830,13 @@ class WPMgr_Object_Cache
 			$this->journalError( get_class( $e ), $e->getMessage() );
 
 			// H5: persist the outage marker immediately on first degradation.
+			// Exception: skip the marker write during PHP shutdown (process is
+			// dying; a Redis failure in persistStats is not an actionable outage).
 			if ( $this->connection !== null && ! $this->connection->isDegraded() ) {
 				$this->connection->markDegraded();
-				$this->persistOutageMarker();
+				if ( ! $this->inShutdown ) {
+					$this->persistOutageMarker();
+				}
 			} elseif ( $this->connection !== null ) {
 				$this->connection->markDegraded();
 			}
@@ -3208,6 +3225,14 @@ class WPMgr_Object_Cache
 	 */
 	private function persistOutageMarker(): void
 	{
+		// Skip during PHP shutdown: the process is dying and this is not an
+		// actionable outage. The guard in redisOp() prevents reaching here in
+		// the normal code path; this inner guard makes the contract testable
+		// even when the method is called directly (e.g. from reflection-based
+		// unit tests that set $inShutdown = true).
+		if ( $this->inShutdown ) {
+			return;
+		}
 		if ( ! function_exists( 'update_option' ) ) {
 			return;
 		}
@@ -3257,8 +3282,21 @@ class WPMgr_Object_Cache
 
 		$this->failbackFlushed = true;
 		try {
-			$this->executeFlush( 'all' );
+			// H5 FIX: delete the marker BEFORE flushing. FLUSHDB wipes the NX
+			// lock key written above; if the marker delete happened after the
+			// flush it would be racing against the now-absent lock, allowing a
+			// second healthy-boot request to see the marker and flush again.
 			delete_option( self::FAILBACK_MARKER_OPTION );
+			$this->executeFlush( 'all' );
+			// WP_DEBUG forensics: log when a failback flush actually fires so the
+			// E2E container log reveals whether and why a flush occurred.
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- WP_DEBUG-gated diagnostic journal; not shipped to end-users
+				error_log( sprintf(
+					'wpmgr-object-cache: failback flush executed (marker_ts=%s)',
+					is_string( $marker ) ? $marker : 'unknown'
+				) );
+			}
 		} catch ( \Throwable $e ) {
 			$this->journalError( 'failback_flush_failed', $e->getMessage() );
 		}

--- a/apps/agent/assets/wpmgr-object-cache-dropin.php
+++ b/apps/agent/assets/wpmgr-object-cache-dropin.php
@@ -266,29 +266,30 @@ final class ObjectCacheConfig
 			return false;
 		}
 
-		// Root-uid ownership alignment: when the process runs as root (e.g. a WP-CLI
-		// provisioning step in a Docker harness), the written file is owned by root
-		// and unreadable by the web server user (www-data). Align owner+group to
-		// match the containing directory so the web SAPI can read the config.
-		// Best-effort only — never fail the save over a chown error.
-		// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated -- posix_geteuid is the correct function; not deprecated
-		if ( function_exists( 'posix_geteuid' ) && posix_geteuid() === 0 ) {
-			try {
-				$parentDir = dirname( $this->filePath );
-				$dirOwner  = @fileowner( $parentDir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure means we skip chown
-				$dirGroup  = @filegroup( $parentDir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure means we skip chgrp
-				if ( $dirOwner !== false ) {
-					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chown,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort root-uid ownership alignment; never fatal
-					@chown( $this->filePath, $dirOwner );
+		// Ownership alignment: when a privileged process writes the config (a
+		// command line provisioning step), the 0600 file is unreadable by the web
+		// server user and the web SAPI silently runs the cache in array mode.
+		// The target owner is whoever owns the WordPress core entry file the web
+		// server demonstrably serves (ABSPATH/index.php), falling back to the
+		// containing directory. The chown attempt is unconditional: it only
+		// succeeds when this process is privileged, and fails silently otherwise.
+		try {
+			$refFile = defined( 'ABSPATH' ) ? constant( 'ABSPATH' ) . 'index.php' : '';
+			$ref     = ( $refFile !== '' && @is_file( $refFile ) ) ? $refFile : dirname( $this->filePath ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort reference probe
+			$owner   = @fileowner( $ref ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure means we skip chown
+			$group   = @filegroup( $ref ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure means we skip chgrp
+			$current = @fileowner( $this->filePath ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort current-owner probe
+			if ( $owner !== false && $owner !== 0 && $owner !== $current ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chown,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort ownership alignment; never fatal
+				@chown( $this->filePath, $owner );
+				if ( $group !== false ) {
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chgrp,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort group alignment; never fatal
+					@chgrp( $this->filePath, $group );
 				}
-				if ( $dirGroup !== false ) {
-					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chgrp,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort root-uid group alignment; never fatal
-					@chgrp( $this->filePath, $dirGroup );
-				}
-			} catch ( \Throwable $_ ) {
-				// Best-effort: chown/chgrp failed; the file remains root-owned but
-				// save() still succeeds so the config is written.
 			}
+		} catch ( \Throwable $_ ) {
+			// Best-effort: chown/chgrp failed; the file remains as written but
+			// save() still succeeds so the config is persisted.
 		}
 
 		// Invalidate opcache so a credential rotation is not silently served from
@@ -3163,26 +3164,27 @@ class WPMgr_Object_Cache
 		if ( $written !== false ) {
 			@rename( $tmp, $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic move; WP_Filesystem::move() is non-atomic
 
-			// Root-uid ownership alignment: match the containing directory's owner+group
-			// so a root-written state file remains readable by the web server user.
-			// Best-effort only — never block the state write over a chown error.
-			// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated -- posix_geteuid is the correct function; not deprecated
-			if ( function_exists( 'posix_geteuid' ) && posix_geteuid() === 0 ) {
-				try {
-					$parentDir = dirname( $path );
-					$dirOwner  = @fileowner( $parentDir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure skips chown
-					$dirGroup  = @filegroup( $parentDir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure skips chgrp
-					if ( $dirOwner !== false ) {
-						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chown,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort root-uid ownership alignment; never fatal
-						@chown( $path, $dirOwner );
+			// Ownership alignment: a privileged writer (command line provisioning)
+			// leaves the state file unreadable by the web server user. Target the
+			// owner of the WordPress core entry file the web server serves; the
+			// chown attempt only succeeds for privileged processes and fails
+			// silently otherwise. Never blocks the state write.
+			try {
+				$refFile = defined( 'ABSPATH' ) ? constant( 'ABSPATH' ) . 'index.php' : '';
+				$ref     = ( $refFile !== '' && @is_file( $refFile ) ) ? $refFile : dirname( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort reference probe
+				$owner   = @fileowner( $ref ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure skips chown
+				$group   = @filegroup( $ref ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure skips chgrp
+				$current = @fileowner( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort current-owner probe
+				if ( $owner !== false && $owner !== 0 && $owner !== $current ) {
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chown,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort ownership alignment; never fatal
+					@chown( $path, $owner );
+					if ( $group !== false ) {
+						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chgrp,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort group alignment; never fatal
+						@chgrp( $path, $group );
 					}
-					if ( $dirGroup !== false ) {
-						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chgrp,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort root-uid group alignment; never fatal
-						@chgrp( $path, $dirGroup );
-					}
-				} catch ( \Throwable $_ ) {
-					// Best-effort: chown/chgrp failed; state file still written.
 				}
+			} catch ( \Throwable $_ ) {
+				// Best-effort: chown/chgrp failed; state file still written.
 			}
 		} else {
 			@unlink( $tmp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- cleanup tmp file on failure

--- a/apps/agent/assets/wpmgr-object-cache-dropin.php
+++ b/apps/agent/assets/wpmgr-object-cache-dropin.php
@@ -266,6 +266,31 @@ final class ObjectCacheConfig
 			return false;
 		}
 
+		// Root-uid ownership alignment: when the process runs as root (e.g. a WP-CLI
+		// provisioning step in a Docker harness), the written file is owned by root
+		// and unreadable by the web server user (www-data). Align owner+group to
+		// match the containing directory so the web SAPI can read the config.
+		// Best-effort only — never fail the save over a chown error.
+		// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated -- posix_geteuid is the correct function; not deprecated
+		if ( function_exists( 'posix_geteuid' ) && posix_geteuid() === 0 ) {
+			try {
+				$parentDir = dirname( $this->filePath );
+				$dirOwner  = @fileowner( $parentDir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure means we skip chown
+				$dirGroup  = @filegroup( $parentDir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure means we skip chgrp
+				if ( $dirOwner !== false ) {
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chown,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort root-uid ownership alignment; never fatal
+					@chown( $this->filePath, $dirOwner );
+				}
+				if ( $dirGroup !== false ) {
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chgrp,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort root-uid group alignment; never fatal
+					@chgrp( $this->filePath, $dirGroup );
+				}
+			} catch ( \Throwable $_ ) {
+				// Best-effort: chown/chgrp failed; the file remains root-owned but
+				// save() still succeeds so the config is written.
+			}
+		}
+
 		// Invalidate opcache so a credential rotation is not silently served from
 		// stale bytecode on validate_timestamps=0 hosts (S7).
 		if ( function_exists( 'opcache_invalidate' ) ) {
@@ -3137,6 +3162,28 @@ class WPMgr_Object_Cache
 		umask( $prev );
 		if ( $written !== false ) {
 			@rename( $tmp, $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic move; WP_Filesystem::move() is non-atomic
+
+			// Root-uid ownership alignment: match the containing directory's owner+group
+			// so a root-written state file remains readable by the web server user.
+			// Best-effort only — never block the state write over a chown error.
+			// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated -- posix_geteuid is the correct function; not deprecated
+			if ( function_exists( 'posix_geteuid' ) && posix_geteuid() === 0 ) {
+				try {
+					$parentDir = dirname( $path );
+					$dirOwner  = @fileowner( $parentDir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure skips chown
+					$dirGroup  = @filegroup( $parentDir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure skips chgrp
+					if ( $dirOwner !== false ) {
+						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chown,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort root-uid ownership alignment; never fatal
+						@chown( $path, $dirOwner );
+					}
+					if ( $dirGroup !== false ) {
+						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chgrp,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort root-uid group alignment; never fatal
+						@chgrp( $path, $dirGroup );
+					}
+				} catch ( \Throwable $_ ) {
+					// Best-effort: chown/chgrp failed; state file still written.
+				}
+			}
 		} else {
 			@unlink( $tmp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- cleanup tmp file on failure
 		}

--- a/apps/agent/includes/object-cache/class-object-cache-config.php
+++ b/apps/agent/includes/object-cache/class-object-cache-config.php
@@ -219,6 +219,31 @@ final class ObjectCacheConfig
 			return false;
 		}
 
+		// Root-uid ownership alignment: when the process runs as root (e.g. a WP-CLI
+		// provisioning step in a Docker harness), the written file is owned by root
+		// and unreadable by the web server user (www-data). Align owner+group to
+		// match the containing directory so the web SAPI can read the config.
+		// Best-effort only — never fail the save over a chown error.
+		// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated -- posix_geteuid is the correct function; not deprecated
+		if ( function_exists( 'posix_geteuid' ) && posix_geteuid() === 0 ) {
+			try {
+				$parentDir = dirname( $this->filePath );
+				$dirOwner  = @fileowner( $parentDir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure means we skip chown
+				$dirGroup  = @filegroup( $parentDir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure means we skip chgrp
+				if ( $dirOwner !== false ) {
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chown,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort root-uid ownership alignment; never fatal
+					@chown( $this->filePath, $dirOwner );
+				}
+				if ( $dirGroup !== false ) {
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chgrp,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort root-uid group alignment; never fatal
+					@chgrp( $this->filePath, $dirGroup );
+				}
+			} catch ( \Throwable $_ ) {
+				// Best-effort: chown/chgrp failed; the file remains root-owned but
+				// save() still succeeds so the config is written.
+			}
+		}
+
 		// Invalidate opcache so a credential rotation is not silently served from
 		// stale bytecode on validate_timestamps=0 hosts (S7).
 		if ( function_exists( 'opcache_invalidate' ) ) {

--- a/apps/agent/includes/object-cache/class-object-cache-config.php
+++ b/apps/agent/includes/object-cache/class-object-cache-config.php
@@ -219,29 +219,30 @@ final class ObjectCacheConfig
 			return false;
 		}
 
-		// Root-uid ownership alignment: when the process runs as root (e.g. a WP-CLI
-		// provisioning step in a Docker harness), the written file is owned by root
-		// and unreadable by the web server user (www-data). Align owner+group to
-		// match the containing directory so the web SAPI can read the config.
-		// Best-effort only — never fail the save over a chown error.
-		// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated -- posix_geteuid is the correct function; not deprecated
-		if ( function_exists( 'posix_geteuid' ) && posix_geteuid() === 0 ) {
-			try {
-				$parentDir = dirname( $this->filePath );
-				$dirOwner  = @fileowner( $parentDir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure means we skip chown
-				$dirGroup  = @filegroup( $parentDir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure means we skip chgrp
-				if ( $dirOwner !== false ) {
-					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chown,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort root-uid ownership alignment; never fatal
-					@chown( $this->filePath, $dirOwner );
+		// Ownership alignment: when a privileged process writes the config (a
+		// command line provisioning step), the 0600 file is unreadable by the web
+		// server user and the web SAPI silently runs the cache in array mode.
+		// The target owner is whoever owns the WordPress core entry file the web
+		// server demonstrably serves (ABSPATH/index.php), falling back to the
+		// containing directory. The chown attempt is unconditional: it only
+		// succeeds when this process is privileged, and fails silently otherwise.
+		try {
+			$refFile = defined( 'ABSPATH' ) ? constant( 'ABSPATH' ) . 'index.php' : '';
+			$ref     = ( $refFile !== '' && @is_file( $refFile ) ) ? $refFile : dirname( $this->filePath ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort reference probe
+			$owner   = @fileowner( $ref ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure means we skip chown
+			$group   = @filegroup( $ref ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure means we skip chgrp
+			$current = @fileowner( $this->filePath ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort current-owner probe
+			if ( $owner !== false && $owner !== 0 && $owner !== $current ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chown,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort ownership alignment; never fatal
+				@chown( $this->filePath, $owner );
+				if ( $group !== false ) {
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chgrp,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort group alignment; never fatal
+					@chgrp( $this->filePath, $group );
 				}
-				if ( $dirGroup !== false ) {
-					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chgrp,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort root-uid group alignment; never fatal
-					@chgrp( $this->filePath, $dirGroup );
-				}
-			} catch ( \Throwable $_ ) {
-				// Best-effort: chown/chgrp failed; the file remains root-owned but
-				// save() still succeeds so the config is written.
 			}
+		} catch ( \Throwable $_ ) {
+			// Best-effort: chown/chgrp failed; the file remains as written but
+			// save() still succeeds so the config is persisted.
 		}
 
 		// Invalidate opcache so a credential rotation is not silently served from

--- a/apps/agent/includes/object-cache/class-object-cache-engine.php
+++ b/apps/agent/includes/object-cache/class-object-cache-engine.php
@@ -2562,26 +2562,27 @@ class WPMgr_Object_Cache
 		if ( $written !== false ) {
 			@rename( $tmp, $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic move; WP_Filesystem::move() is non-atomic
 
-			// Root-uid ownership alignment: match the containing directory's owner+group
-			// so a root-written state file remains readable by the web server user.
-			// Best-effort only — never block the state write over a chown error.
-			// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated -- posix_geteuid is the correct function; not deprecated
-			if ( function_exists( 'posix_geteuid' ) && posix_geteuid() === 0 ) {
-				try {
-					$parentDir = dirname( $path );
-					$dirOwner  = @fileowner( $parentDir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure skips chown
-					$dirGroup  = @filegroup( $parentDir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure skips chgrp
-					if ( $dirOwner !== false ) {
-						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chown,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort root-uid ownership alignment; never fatal
-						@chown( $path, $dirOwner );
+			// Ownership alignment: a privileged writer (command line provisioning)
+			// leaves the state file unreadable by the web server user. Target the
+			// owner of the WordPress core entry file the web server serves; the
+			// chown attempt only succeeds for privileged processes and fails
+			// silently otherwise. Never blocks the state write.
+			try {
+				$refFile = defined( 'ABSPATH' ) ? constant( 'ABSPATH' ) . 'index.php' : '';
+				$ref     = ( $refFile !== '' && @is_file( $refFile ) ) ? $refFile : dirname( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort reference probe
+				$owner   = @fileowner( $ref ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure skips chown
+				$group   = @filegroup( $ref ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure skips chgrp
+				$current = @fileowner( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort current-owner probe
+				if ( $owner !== false && $owner !== 0 && $owner !== $current ) {
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chown,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort ownership alignment; never fatal
+					@chown( $path, $owner );
+					if ( $group !== false ) {
+						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chgrp,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort group alignment; never fatal
+						@chgrp( $path, $group );
 					}
-					if ( $dirGroup !== false ) {
-						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chgrp,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort root-uid group alignment; never fatal
-						@chgrp( $path, $dirGroup );
-					}
-				} catch ( \Throwable $_ ) {
-					// Best-effort: chown/chgrp failed; state file still written.
 				}
+			} catch ( \Throwable $_ ) {
+				// Best-effort: chown/chgrp failed; state file still written.
 			}
 		} else {
 			@unlink( $tmp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- cleanup tmp file on failure

--- a/apps/agent/includes/object-cache/class-object-cache-engine.php
+++ b/apps/agent/includes/object-cache/class-object-cache-engine.php
@@ -2561,6 +2561,28 @@ class WPMgr_Object_Cache
 		umask( $prev );
 		if ( $written !== false ) {
 			@rename( $tmp, $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic move; WP_Filesystem::move() is non-atomic
+
+			// Root-uid ownership alignment: match the containing directory's owner+group
+			// so a root-written state file remains readable by the web server user.
+			// Best-effort only — never block the state write over a chown error.
+			// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated -- posix_geteuid is the correct function; not deprecated
+			if ( function_exists( 'posix_geteuid' ) && posix_geteuid() === 0 ) {
+				try {
+					$parentDir = dirname( $path );
+					$dirOwner  = @fileowner( $parentDir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure skips chown
+					$dirGroup  = @filegroup( $parentDir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort; failure skips chgrp
+					if ( $dirOwner !== false ) {
+						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chown,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort root-uid ownership alignment; never fatal
+						@chown( $path, $dirOwner );
+					}
+					if ( $dirGroup !== false ) {
+						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chgrp,WordPress.PHP.NoSilencedErrors.Discouraged -- headless agent; WP_Filesystem not initialised; best-effort root-uid group alignment; never fatal
+						@chgrp( $path, $dirGroup );
+					}
+				} catch ( \Throwable $_ ) {
+					// Best-effort: chown/chgrp failed; state file still written.
+				}
+			}
 		} else {
 			@unlink( $tmp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- cleanup tmp file on failure
 		}

--- a/apps/agent/includes/object-cache/class-object-cache-engine.php
+++ b/apps/agent/includes/object-cache/class-object-cache-engine.php
@@ -602,7 +602,7 @@ class WPMgr_Object_Cache
 	// -------------------------------------------------------------------------
 
 	/** Version of this engine class. Included in every heartbeat block. */
-	public const ENGINE_VERSION = '0.43.0';
+	public const ENGINE_VERSION = '0.43.1';
 
 	// -------------------------------------------------------------------------
 	// Feature advertisement (wp_cache_supports).
@@ -734,6 +734,16 @@ class WPMgr_Object_Cache
 
 	/** @var bool Whether we already ran the failback flush this boot. */
 	private bool $failbackFlushed = false;
+
+	/**
+	 * True once the PHP-shutdown path has entered shutdown().
+	 * A Redis failure that occurs during persistStats() at shutdown is not
+	 * an actionable outage — the process is dying. When this flag is set,
+	 * redisOp()'s error handler skips both markDegraded-side
+	 * persistOutageMarker() and the marker write, while still degrading
+	 * in-memory so the fallback path executes gracefully.
+	 */
+	private bool $inShutdown = false;
 
 	/** @var array<string,mixed> Loaded config array. */
 	private array $config = [];
@@ -1707,6 +1717,9 @@ class WPMgr_Object_Cache
 	 */
 	public function shutdown(): void
 	{
+		// Mark the shutdown path so that any Redis failure inside persistStats()
+		// does not write a spurious outage marker (the process is already dying).
+		$this->inShutdown = true;
 		try {
 			$this->persistStats();
 		} catch ( \Throwable $e ) {
@@ -2241,9 +2254,13 @@ class WPMgr_Object_Cache
 			$this->journalError( get_class( $e ), $e->getMessage() );
 
 			// H5: persist the outage marker immediately on first degradation.
+			// Exception: skip the marker write during PHP shutdown (process is
+			// dying; a Redis failure in persistStats is not an actionable outage).
 			if ( $this->connection !== null && ! $this->connection->isDegraded() ) {
 				$this->connection->markDegraded();
-				$this->persistOutageMarker();
+				if ( ! $this->inShutdown ) {
+					$this->persistOutageMarker();
+				}
 			} elseif ( $this->connection !== null ) {
 				$this->connection->markDegraded();
 			}
@@ -2632,6 +2649,14 @@ class WPMgr_Object_Cache
 	 */
 	private function persistOutageMarker(): void
 	{
+		// Skip during PHP shutdown: the process is dying and this is not an
+		// actionable outage. The guard in redisOp() prevents reaching here in
+		// the normal code path; this inner guard makes the contract testable
+		// even when the method is called directly (e.g. from reflection-based
+		// unit tests that set $inShutdown = true).
+		if ( $this->inShutdown ) {
+			return;
+		}
 		if ( ! function_exists( 'update_option' ) ) {
 			return;
 		}
@@ -2681,8 +2706,21 @@ class WPMgr_Object_Cache
 
 		$this->failbackFlushed = true;
 		try {
-			$this->executeFlush( 'all' );
+			// H5 FIX: delete the marker BEFORE flushing. FLUSHDB wipes the NX
+			// lock key written above; if the marker delete happened after the
+			// flush it would be racing against the now-absent lock, allowing a
+			// second healthy-boot request to see the marker and flush again.
 			delete_option( self::FAILBACK_MARKER_OPTION );
+			$this->executeFlush( 'all' );
+			// WP_DEBUG forensics: log when a failback flush actually fires so the
+			// E2E container log reveals whether and why a flush occurred.
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- WP_DEBUG-gated diagnostic journal; not shipped to end-users
+				error_log( sprintf(
+					'wpmgr-object-cache: failback flush executed (marker_ts=%s)',
+					is_string( $marker ) ? $marker : 'unknown'
+				) );
+			}
 		} catch ( \Throwable $e ) {
 			$this->journalError( 'failback_flush_failed', $e->getMessage() );
 		}

--- a/apps/agent/tests-e2e/assert.php
+++ b/apps/agent/tests-e2e/assert.php
@@ -508,12 +508,8 @@ PHP;
 // Stage: disable
 // ============================================================================
 if ($stage === 'disable') {
-    // 1. Deactivate and uninstall the plugin.
-    $exit = wp('plugin deactivate ' . escapeshellarg($pluginSlug), $out);
-    // Deactivate may fail if plugin name varies; tolerate.
-    pass('Plugin deactivated (or not found)');
-
-    // 2. Run the drop-in uninstaller via wp eval.
+    // 1. Run the drop-in uninstaller via wp eval WHILE the plugin is still
+    //    active (the installer class needs the plugin autoloader).
     $uninstallCode = <<<'PHP'
 $installer = new WPMgr\Agent\ObjectCache\ObjectCacheDropinInstaller();
 $result = $installer->uninstall();
@@ -527,6 +523,11 @@ PHP;
         fail('Uninstall returned not-uninstalled: ' . $out);
     }
     pass('Drop-in uninstalled');
+
+    // 2. Deactivate the plugin now that the uninstaller has run.
+    $exit = wp('plugin deactivate ' . escapeshellarg($pluginSlug), $out);
+    // Deactivate may fail if plugin name varies; tolerate.
+    pass('Plugin deactivated (or not found)');
 
     // 3. Assert object-cache.php is gone from wp-content.
     $dropinPath = '/var/www/html/wp-content/object-cache.php';

--- a/apps/agent/tests-e2e/assert.php
+++ b/apps/agent/tests-e2e/assert.php
@@ -489,6 +489,7 @@ PHP;
     $cause = $diagnosis['cause'] ?? '';
     $validCauses = [
         'early_definition',
+        'engine_replaced',
         'stale_opcache_suspected',
         'engine_not_loaded',
         'engine_boot_incomplete',

--- a/apps/agent/tests-e2e/assert.php
+++ b/apps/agent/tests-e2e/assert.php
@@ -16,7 +16,8 @@
  *   multisite-check  — (multisite container) switch_to_blog isolation + global group invariant.
  *   installing-check — WP_INSTALLING defined; assert wp_cache_set reaches Redis (H6).
  *   cli-uid-check    — non-owner uid wp cache flush returns non-zero + Redis key survives (H7).
- *   outage-failback  — sentinel key, stop redis, request, start redis, request; assert flush (H5).
+ *   outage-failback          — sentinel key, stop redis, request, start redis, request; assert flush (H5).
+ *   outage-failback-forensics — read DB marker state between outage requests; diagnostic only (non-fatal).
  *   fd-bomb          — boot on fresh worker; assert /proc/self/fd delta < 10 (FD-1/FD-2).
  *   codec-fallback   — push igbinary config into igbinary-less container; assert serializer_effective=php (FD-4).
  *   disable          — uninstall drop-in + config, assert clean (extended teardown asserts).
@@ -751,6 +752,51 @@ PHP;
 }
 
 // ============================================================================
+// Stage: outage-failback-forensics
+// ============================================================================
+if ($stage === 'outage-failback-forensics') {
+    // Cross-request persistence forensics: called from run.sh between request 1
+    // (which fires during the Redis outage) and request 2 (first healthy boot).
+    // Reads the DB directly via wp option get to report whether the outage marker
+    // is present, and emits a line that run.sh captures in the test log.
+    //
+    // This stage is intentionally non-fatal: it is purely diagnostic. The actual
+    // pass/fail for the cross-request persistence assertion lives in run.sh.
+    $markerReadCode = <<<'PHP'
+$markerOption = WPMgr_Object_Cache::FAILBACK_MARKER_OPTION;
+$marker = get_option($markerOption, false);
+echo json_encode([
+    'marker_present' => ($marker !== false),
+    'marker_value'   => is_string($marker) ? $marker : null,
+    'checked_at'     => microtime(true),
+]);
+PHP;
+    $exit = wp('eval ' . escapeshellarg($markerReadCode), $out);
+    if ($exit !== 0) {
+        // Non-fatal: print the failure and exit 0 so run.sh continues.
+        fwrite(STDERR, "WARN [outage-failback-forensics]: wp eval failed (exit={$exit}): {$out}\n");
+        echo json_encode(['marker_present' => null, 'error' => 'eval_failed']) . "\n";
+        exit(0);
+    }
+    $forensics = json_decode(trim($out), true);
+    if (!is_array($forensics)) {
+        echo json_encode(['marker_present' => null, 'raw' => $out]) . "\n";
+        exit(0);
+    }
+    echo json_encode($forensics) . "\n";
+    $present = $forensics['marker_present'] ?? null;
+    if ($present === true) {
+        pass(sprintf(
+            'outage-failback-forensics: outage marker IS present between requests (marker_ts=%s) — failback flush expected on next healthy boot',
+            $forensics['marker_value'] ?? 'unknown'
+        ));
+    } else {
+        pass('outage-failback-forensics: outage marker is absent between requests (no flush will fire)');
+    }
+    exit(0);
+}
+
+// ============================================================================
 // Stage: fd-bomb
 // ============================================================================
 if ($stage === 'fd-bomb') {
@@ -1079,5 +1125,5 @@ PHP;
 }
 
 // Unknown stage.
-fwrite(STDERR, "assert.php: unknown stage '{$stage}'. Valid stages: provision, assert-cli, cron-check, negative-check, multisite-check, installing-check, cli-uid-check, outage-failback, fd-bomb, codec-fallback, debug-header, disable\n");
+fwrite(STDERR, "assert.php: unknown stage '{$stage}'. Valid stages: provision, assert-cli, cron-check, negative-check, multisite-check, installing-check, cli-uid-check, outage-failback, outage-failback-forensics, fd-bomb, codec-fallback, debug-header, disable\n");
 exit(1);

--- a/apps/agent/tests-e2e/assert.php
+++ b/apps/agent/tests-e2e/assert.php
@@ -1023,6 +1023,11 @@ PHP;
         if ($exit !== 0 || strpos((string) $out, 'saved') === false) {
             fail('debug-header: config save via engine writer failed: ' . (string) $out);
         }
+        // The save ran in the CLI SAPI; the web SAPI's opcache revalidates the
+        // config file on its own clock (default 2s). Wait it out so the next
+        // front-end request reads the fresh config. Production is unaffected:
+        // real config pushes arrive via web requests in the same SAPI.
+        sleep(3);
     };
 
     // -----------------------------------------------------------------------

--- a/apps/agent/tests-e2e/assert.php
+++ b/apps/agent/tests-e2e/assert.php
@@ -886,41 +886,25 @@ if ($stage === 'codec-fallback') {
     //   2. serializer_effective = php (fallback confirmed).
     //   3. The site continues to serve HTTP 200.
 
-    // Read the current config path from WordPress constants.
-    $configPathCode = 'echo defined("WP_CONTENT_DIR") ? WP_CONTENT_DIR . "/.wpmgr-oc-config.json" : "";';
-    $configPathExit = wp('eval ' . escapeshellarg($configPathCode), $configPath);
-    $configPath = trim($configPath);
-    if ($configPathExit !== 0 || $configPath === '') {
-        fail('codec-fallback: could not resolve config path via WP_CONTENT_DIR');
-    }
-
-    // Read current config.
-    $readExit = run('cat ' . escapeshellarg($configPath), $currentConfig);
-    if ($readExit !== 0) {
-        // Config may not exist if Redis was never set up; treat as skip.
-        fwrite(STDERR, "SKIP [codec-fallback]: config file not found at {$configPath}; skipping (Redis not provisioned).\n");
+    // Read the current config via the engine loader, then write it back with
+    // serializer=igbinary through the engine writer (atomic + opcache invalidate).
+    $readConfigCode = '$cfg = new WPMgr\Agent\ObjectCache\ObjectCacheConfig(); echo json_encode($cfg->load());';
+    $readExit = wp('eval ' . escapeshellarg($readConfigCode), $currentConfig);
+    $config = json_decode(trim((string) $currentConfig), true);
+    if ($readExit !== 0 || !is_array($config) || $config === []) {
+        fwrite(STDERR, "SKIP [codec-fallback]: config not loadable; skipping (Redis not provisioned).\n");
         exit(0);
     }
 
-    $config = json_decode($currentConfig, true);
-    if (! is_array($config)) {
-        fwrite(STDERR, "SKIP [codec-fallback]: config not valid JSON; skipping.\n");
-        exit(0);
-    }
-
-    // Inject igbinary as the requested serializer.
     $originalSerializer = $config['serializer'] ?? 'php';
     $config['serializer'] = 'igbinary';
-    $patchedConfig = json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-
-    // Write patched config (0600, preserve owner).
-    $writeCmd = 'bash -c ' . escapeshellarg(
-        'echo ' . escapeshellarg($patchedConfig) . ' > ' . escapeshellarg($configPath) .
-        ' && chmod 600 ' . escapeshellarg($configPath)
-    );
-    $writeExit = run($writeCmd, $writeOut);
-    if ($writeExit !== 0) {
-        fail('codec-fallback: failed to write patched config: ' . $writeOut);
+    $b64 = base64_encode((string) json_encode($config));
+    $writeCode = '$cfg = new WPMgr\Agent\ObjectCache\ObjectCacheConfig();'
+        . '$c = json_decode(base64_decode("' . $b64 . '"), true);'
+        . 'echo $cfg->save($c) ? "saved" : "save-failed";';
+    $writeExit = wp('eval ' . escapeshellarg($writeCode), $writeOut);
+    if ($writeExit !== 0 || strpos((string) $writeOut, 'saved') === false) {
+        fail('codec-fallback: failed to write patched config via engine writer: ' . (string) $writeOut);
     }
 
     // Trigger a fresh boot by calling WP-CLI (new PHP worker = fresh static state).
@@ -933,7 +917,7 @@ if (! $oc instanceof WPMgr_Object_Cache) {
 }
 $stats = $oc->getHeartbeatStats();
 echo json_encode([
-    'status'               => $stats['status'] ?? 'unknown',
+    'status'               => $stats['state'] ?? 'unknown',
     'serializer_effective' => $stats['serializer_effective'] ?? 'unknown',
     'codec_fallback'       => $stats['codec_fallback'] ?? '',
     'is_array_mode'        => $oc->isArrayMode(),
@@ -943,12 +927,11 @@ PHP;
 
     // Restore original serializer regardless of outcome.
     $config['serializer'] = $originalSerializer;
-    $restoredConfig = json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-    $restoreCmd = 'bash -c ' . escapeshellarg(
-        'echo ' . escapeshellarg($restoredConfig) . ' > ' . escapeshellarg($configPath) .
-        ' && chmod 600 ' . escapeshellarg($configPath)
-    );
-    run($restoreCmd, $restoreOut);
+    $restoreB64 = base64_encode((string) json_encode($config));
+    $restoreCode = '$cfg = new WPMgr\Agent\ObjectCache\ObjectCacheConfig();'
+        . '$c = json_decode(base64_decode("' . $restoreB64 . '"), true);'
+        . 'echo $cfg->save($c) ? "saved" : "save-failed";';
+    wp('eval ' . escapeshellarg($restoreCode), $restoreOut);
 
     if ($hbExit !== 0) {
         fail('codec-fallback: WP-CLI eval failed after patching config: ' . $hbOut);
@@ -1026,13 +1009,20 @@ PHP;
         fail('debug-header: config JSON was not an array: ' . $configJson);
     }
 
-    // Helper: write the config with debug_header_enabled set to a given value.
+    // Helper: write the config through the engine's own writer so the change
+    // gets the production path: atomic write, 0600, ownership alignment, and
+    // opcache invalidation (a raw file write is served stale by opcache).
     $writeConfig = static function (array $cfg, bool $debugEnabled, string $configPath): void {
+        unset($configPath);
         $cfg['debug_header_enabled'] = $debugEnabled;
-        $phpArray = var_export($cfg, true);
-        $src = "<?php\ndefined( 'ABSPATH' ) || exit;\nreturn {$phpArray};\n";
-        file_put_contents($configPath, $src);
-        chmod($configPath, 0600);
+        $b64  = base64_encode((string) json_encode($cfg));
+        $code = '$cfg = new WPMgr\Agent\ObjectCache\ObjectCacheConfig();'
+              . '$c = json_decode(base64_decode("' . $b64 . '"), true);'
+              . 'echo $cfg->save($c) ? "saved" : "save-failed";';
+        $exit = wp('eval ' . escapeshellarg($code), $out);
+        if ($exit !== 0 || strpos((string) $out, 'saved') === false) {
+            fail('debug-header: config save via engine writer failed: ' . (string) $out);
+        }
     };
 
     // -----------------------------------------------------------------------

--- a/apps/agent/tests-e2e/run.sh
+++ b/apps/agent/tests-e2e/run.sh
@@ -184,6 +184,7 @@ if ( isset( $_GET['wpmgr_e2e_probe'] ) ) {
             'val'            => $val,
             'hit_count'      => $oc instanceof WPMgr_Object_Cache ? ( $oc->cache_hits ?? -1 ) : -1,
             'engine_state'   => $engineState,
+            'last_error'     => $oc instanceof WPMgr_Object_Cache ? ( $hbStats['last_error_class'] ?? '' ) : '',
             'marker_present' => $markerPresent,
         ] );
         exit;
@@ -198,6 +199,7 @@ if ( isset( $_GET['wpmgr_e2e_probe'] ) ) {
             'val'            => $val,
             'hit_count'      => $oc instanceof WPMgr_Object_Cache ? ( $oc->cache_hits ?? -1 ) : -1,
             'engine_state'   => $engineState,
+            'last_error'     => $oc instanceof WPMgr_Object_Cache ? ( $hbStats['last_error_class'] ?? '' ) : '',
             'marker_present' => $markerPresent,
         ] );
         exit;
@@ -227,10 +229,14 @@ echo "[e2e] Request 1 engine_state=${ENGINE_STATE_SET} marker_present=${MARKER_A
 # persistence is impossible and the root cause is an ownership/permissions problem on
 # the config file, not a flush issue.
 if [ "${ENGINE_STATE_SET}" != "connected" ]; then
-    echo "[e2e] ERROR: web SAPI engine not connected on request 1 (state=${ENGINE_STATE_SET})." >&2
-    echo "[e2e] The config file is likely unreadable by the web server user." >&2
-    echo "[e2e] Check ownership/permissions of wp-content/wpmgr-object-cache-config.php." >&2
-    echo "[e2e] (When WP-CLI runs as root the file is written 0600 root:root; www-data cannot read it.)" >&2
+    LAST_ERROR_SET="$(echo "${RESP1}" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(str(d.get("last_error","")))' 2>/dev/null || echo 'unknown')"
+    echo "[e2e] ERROR: web SAPI engine not connected on request 1 (state=${ENGINE_STATE_SET}, last_error=${LAST_ERROR_SET})." >&2
+    echo "[e2e] Forensics: wp-content file ownership and cool-down state:" >&2
+    docker compose -f "${COMPOSE_DIR}/docker-compose.yml" --project-name wpmgr-agent-e2e \
+        exec -T wordpress sh -c 'ls -la /var/www/html/wp-content/ | grep -iE "object-cache|wpmgr|oc-state"; echo "--- state file:"; cat /var/www/html/wp-content/.wpmgr-oc-state.json 2>/dev/null || echo "(no state file)"' >&2 || true
+    echo "[e2e] Last WordPress container log lines:" >&2
+    docker compose -f "${COMPOSE_DIR}/docker-compose.yml" --project-name wpmgr-agent-e2e \
+        logs --tail 25 wordpress >&2 || true
     exit 1
 fi
 

--- a/apps/agent/tests-e2e/run.sh
+++ b/apps/agent/tests-e2e/run.sh
@@ -154,27 +154,36 @@ PROBE_MU_PLUGIN="$(cat <<'MUEOF'
  * E2E cross-request persistence probe.
  * Responds to ?wpmgr_e2e_probe=1 with a JSON body.
  *
- * The response includes 'marker_present' so the harness can detect a spurious
- * outage marker written between requests (0.43.1 FIX 1 / FIX 3 forensics).
+ * The response includes:
+ *   - 'engine_state'   — live state from getHeartbeatStats()['state'] (connected/
+ *                        degraded/down/disabled). A non-connected state means the
+ *                        web SAPI booted in array mode (e.g. config_unreadable due
+ *                        to a root:root ownership trap) and persistence cannot work.
+ *   - 'marker_present' — whether the outage failback marker is set in wp-options
+ *                        (forensics for spurious flush between requests).
  */
 if ( isset( $_GET['wpmgr_e2e_probe'] ) ) {
     $action = sanitize_key( $_GET['wpmgr_e2e_probe'] );
-    $markerPresent = ( defined( 'WPMgr_Object_Cache::FAILBACK_MARKER_OPTION' ) || class_exists( 'WPMgr_Object_Cache' ) )
+    $oc = $GLOBALS['wp_object_cache'] ?? null;
+    $engineState = null;
+    if ( $oc instanceof WPMgr_Object_Cache ) {
+        $hbStats = $oc->getHeartbeatStats();
+        $engineState = $hbStats['state'] ?? null;
+    }
+    $markerPresent = class_exists( 'WPMgr_Object_Cache' )
         ? ( get_option( WPMgr_Object_Cache::FAILBACK_MARKER_OPTION, false ) !== false )
         : null;
     if ( $action === 'set' ) {
         wp_cache_set( 'e2e_persist', 'x', 'e2e', 300 );
         $found = false;
         $val   = wp_cache_get( 'e2e_persist', 'e2e', false, $found );
-        $stats = $GLOBALS['wp_object_cache'] instanceof WPMgr_Object_Cache
-            ? $GLOBALS['wp_object_cache']->getHeartbeatStats()
-            : [];
         header( 'Content-Type: application/json' );
         echo wp_json_encode( [
             'action'         => 'set',
             'found'          => $found,
             'val'            => $val,
-            'hit_count'      => $stats['hit_count'] ?? ( $GLOBALS['wp_object_cache']->cache_hits ?? -1 ),
+            'hit_count'      => $oc instanceof WPMgr_Object_Cache ? ( $oc->cache_hits ?? -1 ) : -1,
+            'engine_state'   => $engineState,
             'marker_present' => $markerPresent,
         ] );
         exit;
@@ -182,15 +191,13 @@ if ( isset( $_GET['wpmgr_e2e_probe'] ) ) {
     if ( $action === 'get' ) {
         $found = false;
         $val   = wp_cache_get( 'e2e_persist', 'e2e', false, $found );
-        $stats = $GLOBALS['wp_object_cache'] instanceof WPMgr_Object_Cache
-            ? $GLOBALS['wp_object_cache']->getHeartbeatStats()
-            : [];
         header( 'Content-Type: application/json' );
         echo wp_json_encode( [
             'action'         => 'get',
             'found'          => $found,
             'val'            => $val,
-            'hit_count'      => $GLOBALS['wp_object_cache']->cache_hits ?? -1,
+            'hit_count'      => $oc instanceof WPMgr_Object_Cache ? ( $oc->cache_hits ?? -1 ) : -1,
+            'engine_state'   => $engineState,
             'marker_present' => $markerPresent,
         ] );
         exit;
@@ -212,8 +219,21 @@ RESP1="$(docker compose -f "${COMPOSE_DIR}/docker-compose.yml" \
     exec -T wordpress curl -s 'http://localhost/?wpmgr_e2e_probe=set')"
 echo "[e2e] Probe set response: ${RESP1}"
 SET_FOUND="$(echo "${RESP1}" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(str(d.get("found","")).lower())' 2>/dev/null || echo 'error')"
+ENGINE_STATE_SET="$(echo "${RESP1}" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(str(d.get("engine_state","unknown")))' 2>/dev/null || echo 'unknown')"
 MARKER_AFTER_SET="$(echo "${RESP1}" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(str(d.get("marker_present","unknown")).lower())' 2>/dev/null || echo 'unknown')"
-echo "[e2e] Outage marker after request 1 (set): marker_present=${MARKER_AFTER_SET}"
+echo "[e2e] Request 1 engine_state=${ENGINE_STATE_SET} marker_present=${MARKER_AFTER_SET}"
+
+# Assert state=connected first: if the web engine is degraded/disabled, cross-request
+# persistence is impossible and the root cause is an ownership/permissions problem on
+# the config file, not a flush issue.
+if [ "${ENGINE_STATE_SET}" != "connected" ]; then
+    echo "[e2e] ERROR: web SAPI engine not connected on request 1 (state=${ENGINE_STATE_SET})." >&2
+    echo "[e2e] The config file is likely unreadable by the web server user." >&2
+    echo "[e2e] Check ownership/permissions of wp-content/wpmgr-object-cache-config.php." >&2
+    echo "[e2e] (When WP-CLI runs as root the file is written 0600 root:root; www-data cannot read it.)" >&2
+    exit 1
+fi
+
 if [ "${SET_FOUND}" != "true" ]; then
     echo "[e2e] ERROR: Set+get in same request must find the value; got found=${SET_FOUND}" >&2
     exit 1
@@ -235,13 +255,14 @@ RESP2="$(docker compose -f "${COMPOSE_DIR}/docker-compose.yml" \
 echo "[e2e] Probe get response: ${RESP2}"
 GET_FOUND="$(echo "${RESP2}" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(str(d.get("found","")).lower())' 2>/dev/null || echo 'error')"
 HIT_COUNT="$(echo "${RESP2}" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("hit_count",0))' 2>/dev/null || echo '0')"
+ENGINE_STATE_GET="$(echo "${RESP2}" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(str(d.get("engine_state","unknown")))' 2>/dev/null || echo 'unknown')"
 MARKER_AFTER_GET="$(echo "${RESP2}" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(str(d.get("marker_present","unknown")).lower())' 2>/dev/null || echo 'unknown')"
-echo "[e2e] Outage marker at request 2 (get): marker_present=${MARKER_AFTER_GET}"
+echo "[e2e] Request 2 engine_state=${ENGINE_STATE_GET} marker_present=${MARKER_AFTER_GET}"
 
 if [ "${GET_FOUND}" != "true" ]; then
-    echo "[e2e] ERROR: Cross-request persistence FAILED (FIX A regression): found=${GET_FOUND}." >&2
-    echo "[e2e] This means the failback flush fired between requests and wiped the cache." >&2
-    echo "[e2e] Forensics: marker_after_set=${MARKER_AFTER_SET} marker_after_get=${MARKER_AFTER_GET}" >&2
+    echo "[e2e] ERROR: value did not persist across requests (FIX A regression): found=${GET_FOUND}." >&2
+    echo "[e2e] Forensics: engine_state_req1=${ENGINE_STATE_SET} engine_state_req2=${ENGINE_STATE_GET}" >&2
+    echo "[e2e]            marker_after_set=${MARKER_AFTER_SET} marker_after_get=${MARKER_AFTER_GET}" >&2
     exit 1
 fi
 if [ "${HIT_COUNT}" -le 0 ] 2>/dev/null; then

--- a/apps/agent/tests-e2e/run.sh
+++ b/apps/agent/tests-e2e/run.sh
@@ -153,9 +153,15 @@ PROBE_MU_PLUGIN="$(cat <<'MUEOF'
 /**
  * E2E cross-request persistence probe.
  * Responds to ?wpmgr_e2e_probe=1 with a JSON body.
+ *
+ * The response includes 'marker_present' so the harness can detect a spurious
+ * outage marker written between requests (0.43.1 FIX 1 / FIX 3 forensics).
  */
 if ( isset( $_GET['wpmgr_e2e_probe'] ) ) {
     $action = sanitize_key( $_GET['wpmgr_e2e_probe'] );
+    $markerPresent = ( defined( 'WPMgr_Object_Cache::FAILBACK_MARKER_OPTION' ) || class_exists( 'WPMgr_Object_Cache' ) )
+        ? ( get_option( WPMgr_Object_Cache::FAILBACK_MARKER_OPTION, false ) !== false )
+        : null;
     if ( $action === 'set' ) {
         wp_cache_set( 'e2e_persist', 'x', 'e2e', 300 );
         $found = false;
@@ -165,10 +171,11 @@ if ( isset( $_GET['wpmgr_e2e_probe'] ) ) {
             : [];
         header( 'Content-Type: application/json' );
         echo wp_json_encode( [
-            'action'    => 'set',
-            'found'     => $found,
-            'val'       => $val,
-            'hit_count' => $stats['hit_count'] ?? ( $GLOBALS['wp_object_cache']->cache_hits ?? -1 ),
+            'action'         => 'set',
+            'found'          => $found,
+            'val'            => $val,
+            'hit_count'      => $stats['hit_count'] ?? ( $GLOBALS['wp_object_cache']->cache_hits ?? -1 ),
+            'marker_present' => $markerPresent,
         ] );
         exit;
     }
@@ -180,10 +187,11 @@ if ( isset( $_GET['wpmgr_e2e_probe'] ) ) {
             : [];
         header( 'Content-Type: application/json' );
         echo wp_json_encode( [
-            'action'    => 'get',
-            'found'     => $found,
-            'val'       => $val,
-            'hit_count' => $GLOBALS['wp_object_cache']->cache_hits ?? -1,
+            'action'         => 'get',
+            'found'          => $found,
+            'val'            => $val,
+            'hit_count'      => $GLOBALS['wp_object_cache']->cache_hits ?? -1,
+            'marker_present' => $markerPresent,
         ] );
         exit;
     }
@@ -204,10 +212,21 @@ RESP1="$(docker compose -f "${COMPOSE_DIR}/docker-compose.yml" \
     exec -T wordpress curl -s 'http://localhost/?wpmgr_e2e_probe=set')"
 echo "[e2e] Probe set response: ${RESP1}"
 SET_FOUND="$(echo "${RESP1}" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(str(d.get("found","")).lower())' 2>/dev/null || echo 'error')"
+MARKER_AFTER_SET="$(echo "${RESP1}" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(str(d.get("marker_present","unknown")).lower())' 2>/dev/null || echo 'unknown')"
+echo "[e2e] Outage marker after request 1 (set): marker_present=${MARKER_AFTER_SET}"
 if [ "${SET_FOUND}" != "true" ]; then
     echo "[e2e] ERROR: Set+get in same request must find the value; got found=${SET_FOUND}" >&2
     exit 1
 fi
+
+# Forensics: read the DB directly between request 1 and request 2 to surface
+# whether an outage marker was written by the request-1 shutdown path.
+# This is diagnostic only (non-fatal) — it explains a found=false failure.
+echo "[e2e] Forensics: reading outage marker state between requests..."
+docker compose -f "${COMPOSE_DIR}/docker-compose.yml" \
+    --project-name wpmgr-agent-e2e \
+    exec -T wordpress php /usr/local/bin/wpmgr-assert.php outage-failback-forensics \
+    || echo "[e2e] WARN: forensics stage returned non-zero (non-fatal)"
 
 # Request 2: get the value (cross-request persistence).
 RESP2="$(docker compose -f "${COMPOSE_DIR}/docker-compose.yml" \
@@ -216,10 +235,13 @@ RESP2="$(docker compose -f "${COMPOSE_DIR}/docker-compose.yml" \
 echo "[e2e] Probe get response: ${RESP2}"
 GET_FOUND="$(echo "${RESP2}" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(str(d.get("found","")).lower())' 2>/dev/null || echo 'error')"
 HIT_COUNT="$(echo "${RESP2}" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("hit_count",0))' 2>/dev/null || echo '0')"
+MARKER_AFTER_GET="$(echo "${RESP2}" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(str(d.get("marker_present","unknown")).lower())' 2>/dev/null || echo 'unknown')"
+echo "[e2e] Outage marker at request 2 (get): marker_present=${MARKER_AFTER_GET}"
 
 if [ "${GET_FOUND}" != "true" ]; then
     echo "[e2e] ERROR: Cross-request persistence FAILED (FIX A regression): found=${GET_FOUND}." >&2
     echo "[e2e] This means the failback flush fired between requests and wiped the cache." >&2
+    echo "[e2e] Forensics: marker_after_set=${MARKER_AFTER_SET} marker_after_get=${MARKER_AFTER_GET}" >&2
     exit 1
 fi
 if [ "${HIT_COUNT}" -le 0 ] 2>/dev/null; then

--- a/apps/agent/tests-e2e/run.sh
+++ b/apps/agent/tests-e2e/run.sh
@@ -124,7 +124,7 @@ done
 echo "[e2e] Step 5: provision..."
 docker compose -f "${COMPOSE_DIR}/docker-compose.yml" \
     --project-name wpmgr-agent-e2e \
-    exec -T wordpress php /usr/local/bin/wpmgr-assert.php provision
+    exec -T -u www-data wordpress php /usr/local/bin/wpmgr-assert.php provision
 
 # -----------------------------------------------------------------------
 # Step 6: assert-cli stage.
@@ -132,7 +132,7 @@ docker compose -f "${COMPOSE_DIR}/docker-compose.yml" \
 echo "[e2e] Step 6: assert-cli..."
 docker compose -f "${COMPOSE_DIR}/docker-compose.yml" \
     --project-name wpmgr-agent-e2e \
-    exec -T wordpress php /usr/local/bin/wpmgr-assert.php assert-cli
+    exec -T -u www-data wordpress php /usr/local/bin/wpmgr-assert.php assert-cli
 
 # -----------------------------------------------------------------------
 # Step 7: CROSS-REQUEST PERSISTENCE (FIX A direct regression net).
@@ -211,7 +211,7 @@ MUEOF
 # Write the mu-plugin inside the container.
 docker compose -f "${COMPOSE_DIR}/docker-compose.yml" \
     --project-name wpmgr-agent-e2e \
-    exec -T wordpress bash -c \
+    exec -T -u www-data wordpress bash -c \
     "mkdir -p /var/www/html/wp-content/mu-plugins && cat > /var/www/html/wp-content/mu-plugins/e2e-persist-probe.php" \
     <<< "${PROBE_MU_PLUGIN}"
 
@@ -251,7 +251,7 @@ fi
 echo "[e2e] Forensics: reading outage marker state between requests..."
 docker compose -f "${COMPOSE_DIR}/docker-compose.yml" \
     --project-name wpmgr-agent-e2e \
-    exec -T wordpress php /usr/local/bin/wpmgr-assert.php outage-failback-forensics \
+    exec -T -u www-data wordpress php /usr/local/bin/wpmgr-assert.php outage-failback-forensics \
     || echo "[e2e] WARN: forensics stage returned non-zero (non-fatal)"
 
 # Request 2: get the value (cross-request persistence).
@@ -279,7 +279,7 @@ echo "[e2e] PASS: Cross-request persistence: found=true, hit_count=${HIT_COUNT}"
 # Remove the probe mu-plugin.
 docker compose -f "${COMPOSE_DIR}/docker-compose.yml" \
     --project-name wpmgr-agent-e2e \
-    exec -T wordpress rm -f /var/www/html/wp-content/mu-plugins/e2e-persist-probe.php
+    exec -T -u www-data wordpress rm -f /var/www/html/wp-content/mu-plugins/e2e-persist-probe.php
 
 # -----------------------------------------------------------------------
 # Step 8: Drop-in freshness guard.

--- a/apps/agent/tests/ObjectCache/FailbackEpochTest.php
+++ b/apps/agent/tests/ObjectCache/FailbackEpochTest.php
@@ -8,6 +8,8 @@
  *   - NX loss (another process holds the lock) → no flush.
  *   - The mid-request degrade→recover trigger is absent from the engine source.
  *   - persistOutageMarker() is called on first degradation.
+ *   - 0.43.1: Redis failure during shutdown() does NOT write the outage marker.
+ *   - 0.43.1: delete_option(marker) is called BEFORE executeFlush in maybeFailbackFlushOnBoot.
  *
  * These tests run in array mode (no live Redis) and verify the H5 logic through
  * observable effects on $GLOBALS options and the engine source structure.
@@ -19,6 +21,8 @@ declare(strict_types=1);
 
 namespace WPMgr\Agent\Tests\ObjectCache;
 
+use Brain\Monkey;
+use Brain\Monkey\Functions;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
@@ -35,12 +39,37 @@ final class FailbackEpochTest extends TestCase
 	/** @var int Flush call counter. */
 	private int $flushCalls = 0;
 
+	/** @var array<string> Log of update_option keys written (for spy assertions). */
+	private array $updatedOptionKeys = [];
+
 	protected function set_up(): void
 	{
 		parent::set_up();
-		$this->options   = [];
-		$this->flushCalls = 0;
-		$this->oc        = \WPMgr_Object_Cache::boot();
+		Monkey\setUp();
+		$this->options           = [];
+		$this->flushCalls        = 0;
+		$this->updatedOptionKeys = [];
+		$this->oc                = \WPMgr_Object_Cache::boot();
+
+		// Wire up option store stubs so Brain Monkey intercepts these calls.
+		Functions\when( 'get_option' )->alias(
+			fn( $k, $d = false ) => $this->options[ $k ] ?? $d
+		);
+		Functions\when( 'update_option' )->alias( function ( $k, $v ) {
+			$this->options[ $k ]       = $v;
+			$this->updatedOptionKeys[] = $k;
+			return true;
+		} );
+		Functions\when( 'delete_option' )->alias( function ( $k ) {
+			unset( $this->options[ $k ] );
+			return true;
+		} );
+	}
+
+	protected function tear_down(): void
+	{
+		Monkey\tearDown();
+		parent::tear_down();
 	}
 
 	// -------------------------------------------------------------------------
@@ -182,6 +211,129 @@ final class FailbackEpochTest extends TestCase
 			'wpmgr_oc_outage_marker',
 			$content,
 			'Lifecycle ownedOptions() must include the failback marker option for clean uninstall (H5/H8)'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// 0.43.1 FIX 1: Redis failure during shutdown() must NOT persist outage marker
+	// -------------------------------------------------------------------------
+
+	/**
+	 * test_redis_failure_during_shutdown_does_not_persist_outage_marker
+	 *
+	 * When $inShutdown = true (set at the top of shutdown()) and a Redis-side
+	 * Throwable propagates through redisOp(), persistOutageMarker() must be
+	 * suppressed so that update_option(FAILBACK_MARKER_OPTION, ...) is never
+	 * called. The process is dying; writing a marker at that point would cause
+	 * a spurious failback flush on the very next healthy-boot request.
+	 *
+	 * Strategy: use ReflectionClass to forcibly set $inShutdown = true, then
+	 * invoke persistOutageMarker() directly. Assert the marker option key is
+	 * never written to the option store.
+	 */
+	public function test_redis_failure_during_shutdown_does_not_persist_outage_marker(): void
+	{
+		$oc  = \WPMgr_Object_Cache::boot();
+		$ref = new \ReflectionClass( $oc );
+
+		// Force $inShutdown = true, simulating that shutdown() has entered.
+		$shutdownProp = $ref->getProperty( 'inShutdown' );
+		$shutdownProp->setValue( $oc, true );
+
+		// Invoke persistOutageMarker() directly.
+		$markerMethod = $ref->getMethod( 'persistOutageMarker' );
+		$markerMethod->invoke( $oc );
+
+		// The marker option must NOT have been written.
+		$this->assertNotContains(
+			\WPMgr_Object_Cache::FAILBACK_MARKER_OPTION,
+			$this->updatedOptionKeys,
+			'persistOutageMarker() must not call update_option(FAILBACK_MARKER_OPTION) when $inShutdown is true'
+		);
+		$this->assertArrayNotHasKey(
+			\WPMgr_Object_Cache::FAILBACK_MARKER_OPTION,
+			$this->options,
+			'wpmgr_oc_outage_marker must not be present in the option store when called from shutdown path'
+		);
+	}
+
+	/**
+	 * Counterpart: outside the shutdown path ($inShutdown = false), persistOutageMarker()
+	 * MUST write the marker. Pins the non-regression of the normal (mid-request) path.
+	 */
+	public function test_non_shutdown_path_still_persists_outage_marker(): void
+	{
+		$oc  = \WPMgr_Object_Cache::boot();
+		$ref = new \ReflectionClass( $oc );
+
+		// $inShutdown defaults to false — do not set it; verify default is correct.
+		$shutdownProp = $ref->getProperty( 'inShutdown' );
+		$this->assertFalse(
+			$shutdownProp->getValue( $oc ),
+			'$inShutdown must default to false so the normal degradation path still writes the marker'
+		);
+
+		// Invoke persistOutageMarker() without entering shutdown.
+		$markerMethod = $ref->getMethod( 'persistOutageMarker' );
+		$markerMethod->invoke( $oc );
+
+		// The marker option MUST have been written.
+		$this->assertContains(
+			\WPMgr_Object_Cache::FAILBACK_MARKER_OPTION,
+			$this->updatedOptionKeys,
+			'persistOutageMarker() must call update_option(FAILBACK_MARKER_OPTION) when $inShutdown is false (normal path)'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// 0.43.1 FIX 2: delete_option(marker) happens BEFORE executeFlush in
+	// maybeFailbackFlushOnBoot — source ordering assertion
+	// -------------------------------------------------------------------------
+
+	/**
+	 * test_marker_deleted_before_flush_in_source
+	 *
+	 * FLUSHDB wipes the Redis NX lock that guards exactly-once semantics; if the
+	 * marker delete happened AFTER the flush, a concurrent healthy-boot request
+	 * that sees the marker before the delete could win a second NX lock and flush
+	 * again. The fix reverses the order: delete_option first, then executeFlush.
+	 *
+	 * This is a source-order assertion. We find the byte offsets of both calls
+	 * inside maybeFailbackFlushOnBoot and assert that delete_option precedes
+	 * executeFlush.
+	 */
+	public function test_marker_deleted_before_flush_in_source(): void
+	{
+		$enginePath = dirname( __DIR__, 2 ) . '/includes/object-cache/class-object-cache-engine.php';
+		$this->assertFileExists( $enginePath );
+		$content = (string) file_get_contents( $enginePath );
+
+		// Locate the maybeFailbackFlushOnBoot method body.
+		$methodStart = strpos( $content, 'private function maybeFailbackFlushOnBoot' );
+		$this->assertNotFalse(
+			$methodStart,
+			'maybeFailbackFlushOnBoot() must exist in the engine source'
+		);
+
+		// Find the next closing-brace at method depth to bound the search.
+		// A safe upper bound: look 3000 chars past the method start.
+		$methodBody = substr( $content, $methodStart, 3000 );
+
+		$deletePos = strpos( $methodBody, 'delete_option(' );
+		$flushPos  = strpos( $methodBody, 'executeFlush(' );
+
+		$this->assertNotFalse(
+			$deletePos,
+			'delete_option() must be present in maybeFailbackFlushOnBoot()'
+		);
+		$this->assertNotFalse(
+			$flushPos,
+			'executeFlush() must be present in maybeFailbackFlushOnBoot()'
+		);
+		$this->assertLessThan(
+			$flushPos,
+			$deletePos,
+			'delete_option(FAILBACK_MARKER_OPTION) must appear BEFORE executeFlush() in maybeFailbackFlushOnBoot() — marker must be cleared before the flush wipes the NX lock'
 		);
 	}
 }

--- a/apps/agent/tests/ObjectCache/ObjectCacheBugFixTest.php
+++ b/apps/agent/tests/ObjectCache/ObjectCacheBugFixTest.php
@@ -87,8 +87,8 @@ final class ObjectCacheBugFixTest extends TestCase
 	// =========================================================================
 
 	/**
-	 * The generated drop-in artifact must contain our SIGNATURE and Version: 2.2.0
-	 * within the first 200 bytes (stub version updated to 2.2.0 in 0.43.0 FD hotfix).
+	 * The generated drop-in artifact must contain our SIGNATURE and Version: 2.2.1
+	 * within the first 200 bytes (stub version updated to 2.2.1 in 0.43.1 shutdown-marker fix).
 	 */
 	public function test_generated_artifact_signature_and_version_in_first_200_bytes(): void
 	{
@@ -101,9 +101,9 @@ final class ObjectCacheBugFixTest extends TestCase
 			'SIGNATURE must be in the first 200 bytes of the generated artifact'
 		);
 		$this->assertStringContainsString(
-			'Version: 2.2.0',
+			'Version: 2.2.1',
 			$first200,
-			'Version: 2.2.0 must be in the first 200 bytes of the generated artifact (0.43.0 FD hotfix)'
+			'Version: 2.2.1 must be in the first 200 bytes of the generated artifact (0.43.1 shutdown-marker fix)'
 		);
 	}
 

--- a/apps/agent/tests/ObjectCache/ObjectCacheConfigOwnershipTest.php
+++ b/apps/agent/tests/ObjectCache/ObjectCacheConfigOwnershipTest.php
@@ -121,8 +121,8 @@ final class ObjectCacheConfigOwnershipTest extends TestCase
 	// -------------------------------------------------------------------------
 
 	/**
-	 * save() source must contain the root-uid (posix_geteuid() === 0) chown branch
-	 * that uses fileowner(dirname(...)) as the target owner.
+	 * save() source must contain the ownership-alignment chown branch
+	 * that targets the owner of the WordPress core entry file.
 	 *
 	 * The E2E harness (WP-CLI running as root) is the real behavioral proof; this
 	 * assertion ensures the branch is never accidentally removed by a refactor.
@@ -134,21 +134,15 @@ final class ObjectCacheConfigOwnershipTest extends TestCase
 		);
 
 		$this->assertStringContainsString(
-			'posix_geteuid',
+			"'index.php'",
 			$src,
-			'save() source must reference posix_geteuid for root-uid detection'
+			'save() source must reference the core entry file as the ownership target'
 		);
 
 		$this->assertStringContainsString(
 			'fileowner',
 			$src,
-			'save() source must call fileowner() to read the parent directory owner'
-		);
-
-		$this->assertStringContainsString(
-			'dirname( $this->filePath )',
-			$src,
-			'save() must derive the parent directory from $this->filePath for fileowner()'
+			'save() source must call fileowner() to read the reference owner'
 		);
 
 		$this->assertStringContainsString(
@@ -186,13 +180,8 @@ final class ObjectCacheConfigOwnershipTest extends TestCase
 		);
 
 		// Grab source from the method onwards (up to next public/private function).
-		$methodSrc = substr( $src, (int) $methodPos, 2000 );
+		$methodSrc = substr( $src, (int) $methodPos, 3500 );
 
-		$this->assertStringContainsString(
-			'posix_geteuid',
-			$methodSrc,
-			'writeCooldownState() must reference posix_geteuid for root-uid detection'
-		);
 
 		$this->assertStringContainsString(
 			'fileowner',
@@ -234,9 +223,9 @@ final class ObjectCacheConfigOwnershipTest extends TestCase
 		$src = (string) file_get_contents( $artifactPath );
 
 		$this->assertStringContainsString(
-			'posix_geteuid',
+			"'index.php'",
 			$src,
-			'Drop-in artifact must contain the posix_geteuid root-uid branch'
+			'Drop-in artifact must reference the core entry file as the ownership target'
 		);
 
 		$this->assertStringContainsString(

--- a/apps/agent/tests/ObjectCache/ObjectCacheConfigOwnershipTest.php
+++ b/apps/agent/tests/ObjectCache/ObjectCacheConfigOwnershipTest.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * ObjectCacheConfigOwnershipTest — root-uid ownership alignment for save() and
+ * writeCooldownState().
+ *
+ * The E2E harness provisions the object-cache config via WP-CLI running as root,
+ * so the config file ends up 0600 root:root. Apache (www-data) cannot read it,
+ * causing the web engine to boot in array mode (config_unreadable) while CLI is
+ * connected. This test pins the fix.
+ *
+ * Two-part design (running as non-root cannot exercise chown):
+ *
+ *   (a) Behavioral guard — save() and writeCooldownState() on a normal user still
+ *       succeed and the config/state files are 0600. Pins no regression.
+ *
+ *   (b) Source-structure assertion — the root-uid chown branch exists in save()
+ *       AND in writeCooldownState() with fileowner(dirname(...)) as the target.
+ *       The E2E harness (root provisioning) is the real behavioral proof.
+ *
+ * @package WPMgr\Agent\Tests\ObjectCache
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\ObjectCache;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\ObjectCache\ObjectCacheConfig;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\ObjectCache\ObjectCacheConfig::save
+ */
+final class ObjectCacheConfigOwnershipTest extends TestCase
+{
+	/** @var string Temporary directory for config file writes. */
+	private string $tmpDir;
+
+	protected function set_up(): void
+	{
+		parent::set_up();
+		Monkey\setUp();
+		Functions\when( 'update_option' )->justReturn( true );
+		$this->tmpDir = sys_get_temp_dir() . '/wpmgr_oc_own_test_' . uniqid( '', true );
+		mkdir( $this->tmpDir, 0755, true );
+	}
+
+	protected function tear_down(): void
+	{
+		$files = glob( $this->tmpDir . '/*' );
+		if ( is_array( $files ) ) {
+			foreach ( $files as $file ) {
+				@unlink( $file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test cleanup
+			}
+		}
+		@rmdir( $this->tmpDir );
+		Monkey\tearDown();
+		parent::tear_down();
+	}
+
+	// -------------------------------------------------------------------------
+	// Part (a): behavioral guard — save() works and is 0600 for normal users.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * save() must succeed and produce a 0600 config file when called as a
+	 * non-root user (the common case). This pins that the ownership branch
+	 * does not break normal operation.
+	 */
+	public function test_save_succeeds_and_is_0600_for_normal_user(): void
+	{
+		if ( PHP_OS_FAMILY === 'Windows' ) {
+			$this->markTestSkipped( 'POSIX permissions do not apply on Windows' );
+		}
+
+		$cfg    = new ObjectCacheConfig( $this->tmpDir );
+		$config = ObjectCacheConfig::fromParams( [ 'host' => '127.0.0.1', 'password' => 'secret' ] );
+
+		$result = $cfg->save( $config );
+		$this->assertTrue( $result, 'save() must return true on a writable directory' );
+
+		$path  = $this->tmpDir . '/' . ObjectCacheConfig::FILENAME;
+		$this->assertFileExists( $path );
+
+		$perms = fileperms( $path );
+		$this->assertNotFalse( $perms, 'fileperms() must succeed on the written config file' );
+		$this->assertSame(
+			0600,
+			$perms & 0777,
+			'config file must be 0600 regardless of the current umask or ownership path'
+		);
+	}
+
+	/**
+	 * save() must load back the same config it wrote (round-trip), confirming
+	 * the ownership alignment block does not corrupt the file content.
+	 */
+	public function test_save_round_trip_preserves_content(): void
+	{
+		$cfg    = new ObjectCacheConfig( $this->tmpDir );
+		$config = ObjectCacheConfig::fromParams( [
+			'host'   => '10.0.0.1',
+			'port'   => 6380,
+			'prefix' => 'mytest',
+		] );
+
+		$this->assertTrue( $cfg->save( $config ) );
+
+		// Use a fresh instance so the memoized load is not served.
+		$cfg2   = new ObjectCacheConfig( $this->tmpDir );
+		$loaded = $cfg2->load();
+
+		$this->assertSame( '10.0.0.1', $loaded['host'] );
+		$this->assertSame( 6380, $loaded['port'] );
+		$this->assertSame( 'mytest', $loaded['prefix'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Part (b): source-structure assertion — chown branch exists in both methods.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * save() source must contain the root-uid (posix_geteuid() === 0) chown branch
+	 * that uses fileowner(dirname(...)) as the target owner.
+	 *
+	 * The E2E harness (WP-CLI running as root) is the real behavioral proof; this
+	 * assertion ensures the branch is never accidentally removed by a refactor.
+	 */
+	public function test_save_source_contains_root_uid_chown_branch(): void
+	{
+		$src = (string) file_get_contents(
+			dirname( __DIR__, 2 ) . '/includes/object-cache/class-object-cache-config.php'
+		);
+
+		$this->assertStringContainsString(
+			'posix_geteuid',
+			$src,
+			'save() source must reference posix_geteuid for root-uid detection'
+		);
+
+		$this->assertStringContainsString(
+			'fileowner',
+			$src,
+			'save() source must call fileowner() to read the parent directory owner'
+		);
+
+		$this->assertStringContainsString(
+			'dirname( $this->filePath )',
+			$src,
+			'save() must derive the parent directory from $this->filePath for fileowner()'
+		);
+
+		$this->assertStringContainsString(
+			'chown',
+			$src,
+			'save() source must call chown() to align the config file owner'
+		);
+
+		$this->assertStringContainsString(
+			'chgrp',
+			$src,
+			'save() source must call chgrp() to align the config file group'
+		);
+	}
+
+	/**
+	 * writeCooldownState() source in the engine must contain the same root-uid
+	 * chown branch with fileowner(dirname(...)) as the target.
+	 *
+	 * The state file (.wpmgr-oc-state.json) is written by the same boot path and
+	 * can suffer the same ownership trap when the process runs as root.
+	 */
+	public function test_write_cooldown_state_source_contains_root_uid_chown_branch(): void
+	{
+		$src = (string) file_get_contents(
+			dirname( __DIR__, 2 ) . '/includes/object-cache/class-object-cache-engine.php'
+		);
+
+		// The chown block must be inside / near writeCooldownState. We locate
+		// the method definition and assert the key identifiers appear after it.
+		$methodPos = strpos( $src, 'function writeCooldownState' );
+		$this->assertNotFalse(
+			$methodPos,
+			'writeCooldownState() must be present in class-object-cache-engine.php'
+		);
+
+		// Grab source from the method onwards (up to next public/private function).
+		$methodSrc = substr( $src, (int) $methodPos, 2000 );
+
+		$this->assertStringContainsString(
+			'posix_geteuid',
+			$methodSrc,
+			'writeCooldownState() must reference posix_geteuid for root-uid detection'
+		);
+
+		$this->assertStringContainsString(
+			'fileowner',
+			$methodSrc,
+			'writeCooldownState() must call fileowner() to read the parent directory owner'
+		);
+
+		$this->assertStringContainsString(
+			'dirname(',
+			$methodSrc,
+			'writeCooldownState() must derive the parent directory from the state-file path'
+		);
+
+		$this->assertStringContainsString(
+			'chown',
+			$methodSrc,
+			'writeCooldownState() must call chown() to align the state file owner'
+		);
+
+		$this->assertStringContainsString(
+			'chgrp',
+			$methodSrc,
+			'writeCooldownState() must call chgrp() to align the state file group'
+		);
+	}
+
+	/**
+	 * The drop-in artifact must also contain the ownership branch, since
+	 * save() is inlined into it. This ensures the artifact rebuild
+	 * propagated the fix.
+	 */
+	public function test_dropin_artifact_contains_ownership_branch(): void
+	{
+		$artifactPath = dirname( __DIR__, 2 ) . '/assets/wpmgr-object-cache-dropin.php';
+		if ( ! is_file( $artifactPath ) ) {
+			$this->markTestSkipped( 'Drop-in artifact not found; run php tools/build-object-cache-dropin.php first' );
+		}
+
+		$src = (string) file_get_contents( $artifactPath );
+
+		$this->assertStringContainsString(
+			'posix_geteuid',
+			$src,
+			'Drop-in artifact must contain the posix_geteuid root-uid branch'
+		);
+
+		$this->assertStringContainsString(
+			'fileowner',
+			$src,
+			'Drop-in artifact must contain the fileowner() call for ownership alignment'
+		);
+	}
+}

--- a/apps/agent/tests/ObjectCache/ObjectCacheDropinBuildTest.php
+++ b/apps/agent/tests/ObjectCache/ObjectCacheDropinBuildTest.php
@@ -6,8 +6,8 @@
  *   1. Running the builder twice produces byte-identical output.
  *   2. The committed artifact matches a fresh build (same discipline as sqlc).
  *   3. The generated artifact is syntactically valid PHP.
- *   4. The SIGNATURE and Version: 2.2.0 appear within the first 200 bytes.
- *   5. The breadcrumb assignment is present and sets 'v' => '2.2.0'.
+ *   4. The SIGNATURE and Version: 2.2.1 appear within the first 200 bytes.
+ *   5. The breadcrumb assignment is present and sets 'v' => '2.2.1'.
  *   6. All bail gate strings are present (including H6: WP_SETUP_CONFIG + env kill-switch).
  *   7. No wp_installing() bail present (H6).
  *   8. try/finally blocks present for H4 OPT_SERIALIZER restoration.
@@ -138,7 +138,7 @@ final class ObjectCacheDropinBuildTest extends TestCase
 	}
 
 	/**
-	 * Version: 2.2.0 must be in the first 200 bytes.
+	 * Version: 2.2.1 must be in the first 200 bytes.
 	 */
 	public function test_version_in_first_200_bytes(): void
 	{
@@ -147,9 +147,9 @@ final class ObjectCacheDropinBuildTest extends TestCase
 		}
 		$first200 = substr( (string) file_get_contents( $this->artifactPath ), 0, 200 );
 		$this->assertStringContainsString(
-			'Version: 2.2.0',
+			'Version: 2.2.1',
 			$first200,
-			'Version: 2.2.0 must appear within the first 200 bytes'
+			'Version: 2.2.1 must appear within the first 200 bytes'
 		);
 	}
 
@@ -168,9 +168,9 @@ final class ObjectCacheDropinBuildTest extends TestCase
 			'Breadcrumb key wpmgr_oc_stub must be present'
 		);
 		$this->assertStringContainsString(
-			"'v' => '2.2.0'",
+			"'v' => '2.2.1'",
 			$content,
-			'Breadcrumb must set v => 2.1.0'
+			'Breadcrumb must set v => 2.2.1'
 		);
 	}
 

--- a/apps/agent/tests/ObjectCache/ObjectCacheFix415Test.php
+++ b/apps/agent/tests/ObjectCache/ObjectCacheFix415Test.php
@@ -388,7 +388,7 @@ final class ObjectCacheFix415Test extends TestCase
 	}
 
 	/**
-	 * R8b: Artifact must be Version: 2.2.0 (bumped in 0.43.0 FD hotfix).
+	 * R8b: Artifact must be Version: 2.2.1 (bumped in 0.43.1 shutdown-marker fix).
 	 */
 	public function test_artifact_is_version_202(): void
 	{
@@ -398,9 +398,9 @@ final class ObjectCacheFix415Test extends TestCase
 		}
 		$first200 = substr( (string) file_get_contents( $artifactPath ), 0, 200 );
 		$this->assertStringContainsString(
-			'Version: 2.2.0',
+			'Version: 2.2.1',
 			$first200,
-			'Artifact must be Version: 2.2.0 after the 0.43.0 FD hotfix bump'
+			'Artifact must be Version: 2.2.1 after the 0.43.1 shutdown-marker fix bump'
 		);
 	}
 

--- a/apps/agent/tests/ObjectCache/ObjectCacheFix416Test.php
+++ b/apps/agent/tests/ObjectCache/ObjectCacheFix416Test.php
@@ -245,7 +245,7 @@ final class ObjectCacheFix416Test extends TestCase
 	}
 
 	/**
-	 * C1: Artifact Version header must be 2.2.0 (updated from 2.1.0 in 0.43.0).
+	 * C1: Artifact Version header must be 2.2.1 (updated from 2.2.0 in 0.43.1).
 	 */
 	public function test_artifact_version_header_is_202(): void
 	{
@@ -254,14 +254,14 @@ final class ObjectCacheFix416Test extends TestCase
 		}
 		$first200 = substr( (string) file_get_contents( $this->artifactPath ), 0, 200 );
 		$this->assertStringContainsString(
-			'Version: 2.2.0',
+			'Version: 2.2.1',
 			$first200,
-			'Artifact Version header must be 2.2.0 after 0.43.0 FD hotfix bump'
+			'Artifact Version header must be 2.2.1 after 0.43.1 shutdown-marker fix bump'
 		);
 	}
 
 	/**
-	 * C2: Breadcrumb v tag must be '2.2.0' (updated from 2.1.0 in 0.43.0).
+	 * C2: Breadcrumb v tag must be '2.2.1' (updated from 2.2.0 in 0.43.1).
 	 */
 	public function test_artifact_breadcrumb_version_is_202(): void
 	{
@@ -270,14 +270,14 @@ final class ObjectCacheFix416Test extends TestCase
 		}
 		$content = (string) file_get_contents( $this->artifactPath );
 		$this->assertStringContainsString(
-			"'v' => '2.2.0'",
+			"'v' => '2.2.1'",
 			$content,
-			"Breadcrumb must set v => '2.2.0' after 0.43.0 FD hotfix bump"
+			"Breadcrumb must set v => '2.2.1' after 0.43.1 shutdown-marker fix bump"
 		);
 	}
 
 	/**
-	 * C3: ENGINE_VERSION constant in artifact must be '0.43.0' (updated from 0.42.0 in FD hotfix).
+	 * C3: ENGINE_VERSION constant in artifact must be '0.43.1' (updated from 0.43.0 in shutdown-marker fix).
 	 */
 	public function test_artifact_engine_version_is_0416(): void
 	{
@@ -286,9 +286,9 @@ final class ObjectCacheFix416Test extends TestCase
 		}
 		$content = (string) file_get_contents( $this->artifactPath );
 		$this->assertStringContainsString(
-			"ENGINE_VERSION = '0.43.0'",
+			"ENGINE_VERSION = '0.43.1'",
 			$content,
-			"ENGINE_VERSION constant must be '0.43.0' in the artifact (FD hotfix)"
+			"ENGINE_VERSION constant must be '0.43.1' in the artifact (0.43.1 shutdown-marker fix)"
 		);
 	}
 

--- a/apps/agent/tools/build-object-cache-dropin.php
+++ b/apps/agent/tools/build-object-cache-dropin.php
@@ -151,7 +151,7 @@ $fileHeader = <<<'HDR'
 <?php
 /**
  * WPMgr Object Cache drop-in
- * Version: 2.2.0
+ * Version: 2.2.1
  *
  * Self-contained object-cache.php drop-in for WordPress. All engine classes are
  * inlined; no external file resolution can fail after installation.
@@ -171,7 +171,7 @@ namespace {
 
 	// Breadcrumb: set immediately after ABSPATH guard so the heartbeat can detect
 	// whether the drop-in was executed at all and identify early-bail causes.
-	$GLOBALS['wpmgr_oc_stub'] = [ 'v' => '2.2.0', 'bail' => null ];
+	$GLOBALS['wpmgr_oc_stub'] = [ 'v' => '2.2.1', 'bail' => null ];
 
 	// PHP floor: the engine uses PHP 8.1 features.
 	if ( PHP_VERSION_ID < 80100 ) {

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.43.0
+ * Version:           0.43.1
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.43.0');
+define('WPMGR_AGENT_VERSION', '0.43.1');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 


### PR DESCRIPTION
## 0.43.1: failback hardening + the harness earns its keep

The E2E docker harness's maiden runs caught four real agent issues, each now fixed with its test:
- **Ownership trap**: root-CLI-written 0600 config unreadable by the web server → web SAPI silently in array mode while CLI reports connected (the exact class of bug that took three rounds to find on a live site last month). Config and state writers now align ownership with the WordPress core entry file's owner.
- **Shutdown-context outage marker**: a Redis failure while PHP is shutting down no longer arms a boot-time recovery flush.
- **Failback marker ordering**: marker deleted before the flush, since FLUSHDB wipes the flush's own NX lock.
- **APCu CLI trap**: cool-down side channel checks `apcu_enabled()`, not `function_exists` (CLI loads APCu disabled).

**Harness: all 18 stages green** including cross-request persistence, fd-bomb descriptor counting (delta=0), codec fallback (igbinary→php, connected), and the live debug header on a real front-end response (`state=connected; hits=165; misses=3; reads=22; writes=1; ms=0.08`). Stage fixes: www-data provisioning, config writes through the engine writer (opcache invalidation), forensics on failure, teardown ordering.

Agent 0.43.1 / drop-in 2.2.1; suite 1662 green; determinism gate clean; no CP changes beyond 0.43.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved file ownership and readability issues when cache configurations are written by privileged CLI operations
  * Prevented duplicate recovery flush operations during PHP shutdown
  * Ensured APCu is only activated when enabled in the running PHP interpreter

* **Tests**
  * Enhanced end-to-end test harness with improved diagnostic reporting across all stages
  * Added comprehensive test coverage for shutdown behavior and file permission alignment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->