### PR TITLE
fix(events): ULID enforcement on the event bus + scan result delivery hardening (0.43.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.43.2] - 2026-06-12
+
+### Fixed
+
+- **Live updates silently stopped for tenants with a connected object cache (critical).** The event stream protocol requires time-sortable event identifiers, but object cache events minted a different identifier format that sorts after every normal identifier. One delivered object cache event advanced the stream cursor past all future events, so database scan results, backup progress, and connection changes stopped arriving; reconnecting made it permanent because the browser echoed the poisoned cursor. The publisher now enforces the correct identifier format for every event regardless of caller, the stream treats an invalid cursor as a fresh start so affected browser tabs self-heal, and the white-label report event had the same defect fixed.
+- **Database scan results now return directly in the scan response** instead of relying only on a live event, and the page loads stored results on mount and after any stream reconnect. A running scan survives a page refresh, a scan stuck without updates resets after three minutes, and a result arriving after a missed start event is no longer discarded.
+- **Live update hardening across the dashboard:** all performance surfaces backed by server queries now refresh automatically when the event stream reconnects, closing the missed event gap for the object cache pill, cache statistics, font results, and real user monitoring summaries.
+- **Scan bookkeeping failures are now logged** instead of silently discarded, and the completion event is published before the watchdog clears so a failed publish still triggers the failure rescue.
+
+Control plane and web 0.43.2; no agent changes.
+
 ## [0.43.1] - 2026-06-12
 
 ### Fixed

--- a/apps/api/internal/objectcache/service.go
+++ b/apps/api/internal/objectcache/service.go
@@ -287,7 +287,6 @@ func (s *Service) Test(ctx context.Context, tenantID, siteID uuid.UUID, password
 
 	// Publish SSE event.
 	_ = s.publisher.Publish(ctx, site.ConnectionEvent{
-		ID:       uuid.New().String(),
 		Type:     site.EventObjectCacheTestCompleted,
 		TenantID: tenantID,
 		SiteID:   siteID,
@@ -413,7 +412,6 @@ func (s *Service) Flush(ctx context.Context, input FlushInput) (string, error) {
 	}
 
 	_ = s.publisher.Publish(ctx, site.ConnectionEvent{
-		ID:       uuid.New().String(),
 		Type:     site.EventObjectCacheFlushed,
 		TenantID: input.TenantID,
 		SiteID:   input.SiteID,
@@ -520,7 +518,6 @@ func (s *Service) IngestHeartbeat(ctx context.Context, tenantID, siteID uuid.UUI
 
 	if string(block.State) != string(prevState) {
 		_ = s.publisher.Publish(ctx, site.ConnectionEvent{
-			ID:       uuid.New().String(),
 			Type:     site.EventObjectCacheStatusChanged,
 			TenantID: updated.TenantID,
 			SiteID:   siteID,
@@ -534,7 +531,6 @@ func (s *Service) IngestHeartbeat(ctx context.Context, tenantID, siteID uuid.UUI
 		})
 	} else {
 		_ = s.publisher.Publish(ctx, site.ConnectionEvent{
-			ID:       uuid.New().String(),
 			Type:     site.EventObjectCacheStatsUpdated,
 			TenantID: updated.TenantID,
 			SiteID:   siteID,
@@ -609,7 +605,6 @@ func (s *Service) pushApplyConfig(ctx context.Context, tenantID, siteID uuid.UUI
 		return fmt.Errorf("objectcache: apply_config rejected: %s", result.Detail)
 	}
 	_ = s.publisher.Publish(ctx, site.ConnectionEvent{
-		ID:       uuid.New().String(),
 		Type:     site.EventObjectCacheConfigApplied,
 		TenantID: tenantID,
 		SiteID:   siteID,

--- a/apps/api/internal/perf/db_scan_handler_test.go
+++ b/apps/api/internal/perf/db_scan_handler_test.go
@@ -1,0 +1,313 @@
+package perf
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// fakes specific to db_scan handler tests
+// ---------------------------------------------------------------------------
+
+// dbScanFakeRepo embeds fakeRepo and adds configurable overrides for the
+// db_scan result and active-scan state so handler tests can inject exact values.
+type dbScanFakeRepo struct {
+	fakeRepo
+	// scan result fields
+	scanResult    DBScanResult
+	scanFound     bool
+	// active scan state fields
+	activeState   ActiveDBScanState
+	activeStateErr error
+}
+
+func (r *dbScanFakeRepo) GetDBScanResult(_ context.Context, _, _ uuid.UUID) (DBScanResult, error) {
+	if !r.scanFound {
+		return DBScanResult{}, ErrNotFound
+	}
+	return r.scanResult, nil
+}
+
+func (r *dbScanFakeRepo) GetActiveDBScanState(_ context.Context, _, _ uuid.UUID) (ActiveDBScanState, error) {
+	return r.activeState, r.activeStateErr
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// scanHandlerFixture holds the engine and the concrete URL to use in requests.
+type scanHandlerFixture struct {
+	eng     *gin.Engine
+	handler *Handler
+	// scanURL is the concrete URL with a real UUID in place of :siteId.
+	scanURL string
+}
+
+// buildScanHandler wires a minimal gin engine with the POST and GET db/scan
+// routes backed by a Service that uses the supplied repo + agent. Routes use
+// the standard `:siteId` Gin param so parseSiteID works correctly.
+func buildScanHandler(repo repository, ag AgentPerfClient) *scanHandlerFixture {
+	gin.SetMode(gin.TestMode)
+	svc := NewService(repo, nil, &fakeEvents{}, nil)
+	if ag != nil {
+		svc.SetAgentClient(ag, &fakeSites{url: "https://example.com"})
+	}
+	h := NewHandler(svc, nil, nil)
+
+	eng := gin.New()
+	siteID := uuid.New()
+	// Register with :siteId param so Gin populates c.Param("siteId").
+	paramPath := "/sites/:siteId/perf/db/scan"
+	// The concrete URL used in test requests contains the real UUID.
+	concreteURL := "/sites/" + siteID.String() + "/perf/db/scan"
+
+	inject := func(c *gin.Context) {
+		ctx := domain.WithPrincipal(c.Request.Context(), domain.Principal{
+			TenantID: uuid.New(),
+			Role:     string(authz.RoleAdmin),
+		})
+		c.Request = c.Request.WithContext(ctx)
+	}
+	eng.POST(paramPath, inject, h.dbScan)
+	eng.GET(paramPath, inject, h.getDbScan)
+	return &scanHandlerFixture{eng: eng, handler: h, scanURL: concreteURL}
+}
+
+// decodeBody unmarshals the response body into a map for key assertions.
+func decodeBody(t *testing.T, body string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(body), &m); err != nil {
+		t.Fatalf("decodeBody: %v (body=%s)", err, body)
+	}
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// TestDbScanAckCarriesResult
+// ---------------------------------------------------------------------------
+
+// TestDbScanAckCarriesResult verifies that a successful POST /perf/db/scan
+// response body contains the full result payload (categories, tables,
+// db_size_bytes) so the browser can render immediately without relying on the
+// SSE db.scan.completed frame.
+func TestDbScanAckCarriesResult(t *testing.T) {
+	repo := &dbScanFakeRepo{}
+	// fakeAgent.DBScan returns {ok:true, categories:{revisions:{count:10}}, db_size_bytes:1024, table_count:5}
+	ag := &fakeAgent{}
+	fix := buildScanHandler(repo, ag)
+
+	w := httptest.NewRecorder()
+	// POST with an empty JSON body (all-categories scan).
+	req := httptest.NewRequest(http.MethodPost, fix.scanURL, bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = 2
+	fix.eng.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	body := decodeBody(t, w.Body.String())
+
+	if ok, _ := body["ok"].(bool); !ok {
+		t.Fatalf("expected ok=true, body=%s", w.Body.String())
+	}
+	if _, hasJobID := body["job_id"].(string); !hasJobID {
+		t.Fatalf("expected job_id string in ACK, body=%s", w.Body.String())
+	}
+
+	result, hasResult := body["result"].(map[string]any)
+	if !hasResult || result == nil {
+		t.Fatalf("expected non-null result in ACK, body=%s", w.Body.String())
+	}
+
+	// categories must be present (fakeAgent returns {"revisions": {...}}).
+	if _, hasCats := result["categories"]; !hasCats {
+		t.Errorf("expected categories in result, body=%s", w.Body.String())
+	}
+	// tables must be present (may be empty array from fakeAgent).
+	if _, hasTables := result["tables"]; !hasTables {
+		t.Errorf("expected tables in result, body=%s", w.Body.String())
+	}
+	// db_size_bytes must be present and non-zero (fakeAgent returns 1024).
+	dbSizeRaw, hasSize := result["db_size_bytes"]
+	if !hasSize {
+		t.Fatalf("expected db_size_bytes in result, body=%s", w.Body.String())
+	}
+	// JSON numbers unmarshal as float64.
+	dbSize, _ := dbSizeRaw.(float64)
+	if dbSize <= 0 {
+		t.Errorf("expected db_size_bytes > 0, got %v", dbSizeRaw)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestDbScanGetIncludesActiveState
+// ---------------------------------------------------------------------------
+
+// TestDbScanGetIncludesActiveState verifies two sub-cases for GET /perf/db/scan:
+//  1. When the repo reports an active scan job, scan_active=true and
+//     active_job_id/active_started_at are non-null in the response.
+//  2. When no scan is active, scan_active=false and the other fields are null.
+func TestDbScanGetIncludesActiveState(t *testing.T) {
+	startedAt := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	jobID := uuid.New().String()
+
+	t.Run("active scan returns scan_active=true", func(t *testing.T) {
+		repo := &dbScanFakeRepo{
+			// No previous scan result — but there IS an active scan.
+			scanFound: false,
+			activeState: ActiveDBScanState{
+				Active:    true,
+				JobID:     jobID,
+				StartedAt: startedAt,
+			},
+		}
+		fix := buildScanHandler(repo, nil)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, fix.scanURL, nil)
+		fix.eng.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+		}
+		body := decodeBody(t, w.Body.String())
+
+		scanActive, _ := body["scan_active"].(bool)
+		if !scanActive {
+			t.Errorf("expected scan_active=true, body=%s", w.Body.String())
+		}
+
+		activeJobIDVal, hasActiveJobID := body["active_job_id"].(string)
+		if !hasActiveJobID || activeJobIDVal != jobID {
+			t.Errorf("expected active_job_id=%q, body=%s", jobID, w.Body.String())
+		}
+
+		activeStartedAtVal, hasStartedAt := body["active_started_at"].(string)
+		if !hasStartedAt || activeStartedAtVal == "" {
+			t.Errorf("expected non-empty active_started_at RFC3339, body=%s", w.Body.String())
+		}
+		// Must parse as RFC3339 and round-trip to the same UTC time.
+		parsed, parseErr := time.Parse(time.RFC3339, activeStartedAtVal)
+		if parseErr != nil {
+			t.Errorf("active_started_at is not RFC3339: %v (value=%q)", parseErr, activeStartedAtVal)
+		} else if !parsed.UTC().Equal(startedAt) {
+			t.Errorf("active_started_at mismatch: got %v want %v", parsed.UTC(), startedAt)
+		}
+	})
+
+	t.Run("no active scan returns scan_active=false with null fields", func(t *testing.T) {
+		categoriesJSON, _ := json.Marshal(map[string]any{
+			"revisions": map[string]any{"count": 5, "bytes": 0},
+		})
+		repo := &dbScanFakeRepo{
+			scanFound: true,
+			scanResult: DBScanResult{
+				JobID:          jobID,
+				CategoriesJSON: categoriesJSON,
+				TablesJSON:     []byte("[]"),
+				DBSizeBytes:    2048,
+				TableCount:     7,
+				ScannedAt:      startedAt,
+				CreatedAt:      startedAt,
+			},
+			// activeState is zero value: Active=false.
+		}
+		fix := buildScanHandler(repo, nil)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, fix.scanURL, nil)
+		fix.eng.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+		}
+		body := decodeBody(t, w.Body.String())
+
+		scanActive, _ := body["scan_active"].(bool)
+		if scanActive {
+			t.Errorf("expected scan_active=false, body=%s", w.Body.String())
+		}
+
+		// active_job_id and active_started_at must be null (JSON null → Go nil interface).
+		if body["active_job_id"] != nil {
+			t.Errorf("expected active_job_id=null, got %v", body["active_job_id"])
+		}
+		if body["active_started_at"] != nil {
+			t.Errorf("expected active_started_at=null, got %v", body["active_started_at"])
+		}
+
+		// The result must be present with the canned data.
+		result, hasResult := body["result"].(map[string]any)
+		if !hasResult || result == nil {
+			t.Fatalf("expected non-null result, body=%s", w.Body.String())
+		}
+		dbSize, _ := result["db_size_bytes"].(float64)
+		if dbSize != 2048 {
+			t.Errorf("expected db_size_bytes=2048, got %v", dbSize)
+		}
+		// categories must contain the revisions key.
+		cats, _ := result["categories"].(map[string]any)
+		if _, hasRevisions := cats["revisions"]; !hasRevisions {
+			t.Errorf("expected categories.revisions in result, body=%s", w.Body.String())
+		}
+	})
+
+	t.Run("GET response includes orphaned_options and orphaned_cron keys", func(t *testing.T) {
+		// Verify the helper exposes these Phase 3.3 fields (the GET path now uses
+		// dbScanResultToGinH which always includes them).
+		repo := &dbScanFakeRepo{
+			scanFound: true,
+			scanResult: DBScanResult{
+				JobID:                jobID,
+				CategoriesJSON:       []byte(`{}`),
+				TablesJSON:           []byte(`[]`),
+				OrphanedOptionsJSON:  []byte(`[{"name":"orphan_option","autoload":true,"size_bytes":32}]`),
+				OrphanedCronJSON:     []byte(`[]`),
+				InstalledPluginsJSON: []byte(`[]`),
+				DBSizeBytes:          512,
+			},
+		}
+		fix := buildScanHandler(repo, nil)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, fix.scanURL, nil)
+		fix.eng.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+		}
+
+		rawBody := w.Body.String()
+		if !strings.Contains(rawBody, `"orphaned_options"`) {
+			t.Errorf("expected orphaned_options in GET response body, body=%s", rawBody)
+		}
+		if !strings.Contains(rawBody, `"orphaned_cron"`) {
+			t.Errorf("expected orphaned_cron in GET response body, body=%s", rawBody)
+		}
+		if !strings.Contains(rawBody, `"installed_plugins"`) {
+			t.Errorf("expected installed_plugins in GET response body, body=%s", rawBody)
+		}
+
+		body := decodeBody(t, rawBody)
+		result, _ := body["result"].(map[string]any)
+		opts, _ := result["orphaned_options"].([]any)
+		if len(opts) != 1 {
+			t.Errorf("expected 1 orphaned_option, got %v", opts)
+		}
+	})
+}

--- a/apps/api/internal/perf/handler.go
+++ b/apps/api/internal/perf/handler.go
@@ -375,7 +375,8 @@ type dbScanBody struct {
 
 // dbScan triggers a synchronous read-only database scan. The agent returns the
 // full per-category result in the ACK body; the CP stores it, emits SSE, and
-// returns the job_id. Operator can poll the GET endpoint for the last result.
+// returns the job_id plus the full result payload in the 200 body. SSE is a
+// hint only — the ACK body is the truth so the UI never hangs on a missed event.
 func (h *Handler) dbScan(c *gin.Context) {
 	p, _ := domain.PrincipalFromContext(c.Request.Context())
 	siteID, ok := parseSiteID(c)
@@ -392,7 +393,7 @@ func (h *Handler) dbScan(c *gin.Context) {
 		}
 	}
 
-	jobID, err := h.svc.DBScan(c.Request.Context(), p.TenantID, siteID, body.Categories)
+	jobID, result, err := h.svc.DBScan(c.Request.Context(), p.TenantID, siteID, body.Categories)
 	if err != nil {
 		if _, isDomain := domain.AsDomain(err); isDomain {
 			httpx.Error(c, err)
@@ -401,7 +402,13 @@ func (h *Handler) dbScan(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"ok": false, "job_id": jobID, "detail": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"ok": true, "job_id": jobID})
+	// Embed the full scan result in the ACK so the browser can render
+	// immediately even if the SSE db.scan.completed frame was missed.
+	c.JSON(http.StatusOK, gin.H{
+		"ok":     true,
+		"job_id": jobID,
+		"result": dbScanResultToGinH(result),
+	})
 }
 
 // getDbScan returns the latest stored db_scan result for a site.
@@ -409,6 +416,8 @@ func (h *Handler) dbScan(c *gin.Context) {
 // Phase 2.1: the response includes both `categories` and `tables` so the web
 // layer can render the Tables tab on page reload (hydration path) without
 // waiting for an SSE db.scan.completed event.
+// The response also includes scan_active/active_job_id/active_started_at so
+// the web can derive its "Scanning..." spinner state on page load.
 func (h *Handler) getDbScan(c *gin.Context) {
 	p, _ := domain.PrincipalFromContext(c.Request.Context())
 	siteID, ok := parseSiteID(c)
@@ -420,39 +429,105 @@ func (h *Handler) getDbScan(c *gin.Context) {
 		httpx.Error(c, err)
 		return
 	}
-	if result == nil {
-		c.JSON(http.StatusOK, gin.H{"result": nil})
+
+	// Read active-scan watchdog state so the web can show/hide the spinner on
+	// page load without relying solely on SSE delivery. ErrNotFound (no perf
+	// config row yet) is treated as "not active" — not an error.
+	activeState, stateErr := h.svc.GetActiveDBScanState(c.Request.Context(), p.TenantID, siteID)
+	if stateErr != nil && stateErr != ErrNotFound {
+		httpx.Error(c, stateErr)
 		return
 	}
-	// Unmarshal the JSONB blobs back to typed values so the response is clean
-	// JSON, not base64-encoded blobs. Fall through to zero values on parse error.
+
+	var activeJobID any   // null when not active
+	var activeStartedAt any // null when not active
+	if activeState.Active {
+		activeJobID = activeState.JobID
+		if !activeState.StartedAt.IsZero() {
+			activeStartedAt = activeState.StartedAt.UTC().Format(time.RFC3339)
+		}
+	}
+
+	if result == nil {
+		c.JSON(http.StatusOK, gin.H{
+			"result":            nil,
+			"scan_active":       activeState.Active,
+			"active_job_id":     activeJobID,
+			"active_started_at": activeStartedAt,
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"result":            dbScanResultToGinH(result),
+		"scan_active":       activeState.Active,
+		"active_job_id":     activeJobID,
+		"active_started_at": activeStartedAt,
+	})
+}
+
+// dbScanResultToGinH converts a DBScanResult (with raw JSONB blobs) into a
+// gin.H map with clean JSON values for the wire response. It is shared by both
+// the POST ACK (dbScan) and the GET response (getDbScan) so the JSON key names
+// are identical on both paths.
+func dbScanResultToGinH(r *DBScanResult) gin.H {
+	if r == nil {
+		return nil
+	}
+	// Unmarshal JSONB blobs back to typed values. Fall through to zero/empty
+	// values on parse error so the response is always well-formed.
 	var categories any
-	if len(result.CategoriesJSON) > 0 {
+	if len(r.CategoriesJSON) > 0 {
 		var m map[string]any
-		if jerr := json.Unmarshal(result.CategoriesJSON, &m); jerr == nil {
+		if jerr := json.Unmarshal(r.CategoriesJSON, &m); jerr == nil {
 			categories = m
 		}
 	}
-	// Phase 2.1: unmarshal per-table inventory; return empty array on error so the
-	// web layer always receives an array (never null) and can render the Tables tab.
 	var tables any = []any{}
-	if len(result.TablesJSON) > 0 {
+	if len(r.TablesJSON) > 0 {
 		var arr []any
-		if jerr := json.Unmarshal(result.TablesJSON, &arr); jerr == nil {
+		if jerr := json.Unmarshal(r.TablesJSON, &arr); jerr == nil {
 			tables = arr
 		}
 	}
-	c.JSON(http.StatusOK, gin.H{
-		"result": gin.H{
-			"job_id":        result.JobID,
-			"categories":    categories,
-			"tables":        tables,
-			"db_size_bytes": result.DBSizeBytes,
-			"table_count":   result.TableCount,
-			"scanned_at":    result.ScannedAt.Unix(),
-			"created_at":    result.CreatedAt.Unix(),
-		},
-	})
+	var orphanedOptions any = []any{}
+	if len(r.OrphanedOptionsJSON) > 0 {
+		var arr []any
+		if jerr := json.Unmarshal(r.OrphanedOptionsJSON, &arr); jerr == nil {
+			orphanedOptions = arr
+		}
+	}
+	var orphanedCron any = []any{}
+	if len(r.OrphanedCronJSON) > 0 {
+		var arr []any
+		if jerr := json.Unmarshal(r.OrphanedCronJSON, &arr); jerr == nil {
+			orphanedCron = arr
+		}
+	}
+	var installedPlugins any = []any{}
+	if len(r.InstalledPluginsJSON) > 0 {
+		var arr []any
+		if jerr := json.Unmarshal(r.InstalledPluginsJSON, &arr); jerr == nil {
+			installedPlugins = arr
+		}
+	}
+	h := gin.H{
+		"job_id":            r.JobID,
+		"categories":        categories,
+		"tables":            tables,
+		"orphaned_options":  orphanedOptions,
+		"orphaned_cron":     orphanedCron,
+		"installed_plugins": installedPlugins,
+		"db_size_bytes":     r.DBSizeBytes,
+		"table_count":       r.TableCount,
+		"scanned_at":        r.ScannedAt.Unix(),
+	}
+	// created_at is only populated from the DB path (GET); in the POST ACK path
+	// CreatedAt is zero and we omit it to avoid a confusing epoch timestamp.
+	if !r.CreatedAt.IsZero() {
+		h["created_at"] = r.CreatedAt.Unix()
+	}
+	return h
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/perf/repo.go
+++ b/apps/api/internal/perf/repo.go
@@ -434,6 +434,40 @@ func (r *Repo) ClearActiveDBScanJob(ctx context.Context, siteID uuid.UUID) error
 	})
 }
 
+// ActiveDBScanState holds the watchdog columns read from site_perf_config for
+// the GET /perf/db/scan response. Active is true when a scan is in progress.
+type ActiveDBScanState struct {
+	Active    bool
+	JobID     string    // "" when Active is false
+	StartedAt time.Time // zero when Active is false
+}
+
+// GetActiveDBScanState reads the active_db_scan_job_id and
+// active_db_scan_started watchdog columns from site_perf_config for a single
+// site. Returns ErrNotFound when the site has no perf config row yet (i.e. the
+// perf suite has never been configured). The state is read under InTenantTx so
+// RLS scopes it to the calling tenant.
+func (r *Repo) GetActiveDBScanState(ctx context.Context, tenantID, siteID uuid.UUID) (ActiveDBScanState, error) {
+	row, found, err := r.getConfigRow(ctx, tenantID, siteID)
+	if err != nil {
+		if err == ErrNotFound {
+			return ActiveDBScanState{}, ErrNotFound
+		}
+		return ActiveDBScanState{}, err
+	}
+	if !found {
+		return ActiveDBScanState{}, ErrNotFound
+	}
+	if row.ActiveDbScanJobID == nil {
+		return ActiveDBScanState{}, nil
+	}
+	return ActiveDBScanState{
+		Active:    true,
+		JobID:     *row.ActiveDbScanJobID,
+		StartedAt: row.ActiveDbScanStarted.Time,
+	}, nil
+}
+
 // StalledDBCleanJob is a minimal view returned by the watchdog sweep.
 type StalledDBCleanJob struct {
 	SiteID   uuid.UUID

--- a/apps/api/internal/perf/service.go
+++ b/apps/api/internal/perf/service.go
@@ -101,6 +101,7 @@ type repository interface {
 	ClearActiveDBCleanJob(ctx context.Context, siteID uuid.UUID) error
 	SetActiveDBScanJob(ctx context.Context, siteID uuid.UUID, jobID string, startedAt time.Time) error
 	ClearActiveDBScanJob(ctx context.Context, siteID uuid.UUID) error
+	GetActiveDBScanState(ctx context.Context, tenantID, siteID uuid.UUID) (ActiveDBScanState, error)
 	GetStalledDBCleanJobs(ctx context.Context, cleanThreshold time.Duration) ([]StalledDBCleanJob, error)
 	GetStalledDBScanJobs(ctx context.Context, scanThreshold time.Duration) ([]StalledDBScanJob, error)
 	// M39 — db_scan result persistence.
@@ -1018,8 +1019,10 @@ func (s *Service) HandleDBCleanProgress(ctx context.Context, in DBCleanProgressI
 //  2. db.scan.completed — after ok=true ACK (with the full category map)
 //  3. db.scan.failed   — on transport error or ok=false
 //
-// Returns the job_id for correlation.
-func (s *Service) DBScan(ctx context.Context, tenantID, siteID uuid.UUID, categories []string) (string, error) {
+// Returns the job_id and the full scan result (non-nil on success) so the
+// handler can embed both in the 200 ACK body. SSE is a hint only; the ACK is
+// the truth. On error the result pointer is nil.
+func (s *Service) DBScan(ctx context.Context, tenantID, siteID uuid.UUID, categories []string) (string, *DBScanResult, error) {
 	jobID := uuid.New().String()
 
 	s.publish(ctx, tenantID, siteID, site.EventDbScanStarted, map[string]any{
@@ -1035,22 +1038,28 @@ func (s *Service) DBScan(ctx context.Context, tenantID, siteID uuid.UUID, catego
 	}
 
 	if s.agent == nil || s.sites == nil {
-		_ = s.repo.ClearActiveDBScanJob(ctx, siteID)
+		if cErr := s.repo.ClearActiveDBScanJob(ctx, siteID); cErr != nil {
+			s.logger.Warn("db-scan: failed to clear watchdog after missing agent",
+				slog.String("job_id", jobID), slog.String("site_id", siteID.String()), slog.Any("error", cErr))
+		}
 		s.publish(ctx, tenantID, siteID, site.EventDbScanFailed, map[string]any{
 			"job_id": jobID,
 			"detail": "agent client not configured",
 		})
-		return jobID, fmt.Errorf("agent client not configured")
+		return jobID, nil, fmt.Errorf("agent client not configured")
 	}
 
 	siteURL, lookupErr := s.sites.GetSiteURL(ctx, tenantID, siteID)
 	if lookupErr != nil {
-		_ = s.repo.ClearActiveDBScanJob(ctx, siteID)
+		if cErr := s.repo.ClearActiveDBScanJob(ctx, siteID); cErr != nil {
+			s.logger.Warn("db-scan: failed to clear watchdog after site URL lookup failure",
+				slog.String("job_id", jobID), slog.String("site_id", siteID.String()), slog.Any("error", cErr))
+		}
 		s.publish(ctx, tenantID, siteID, site.EventDbScanFailed, map[string]any{
 			"job_id": jobID,
 			"detail": lookupErr.Error(),
 		})
-		return jobID, lookupErr
+		return jobID, nil, lookupErr
 	}
 
 	// Scan timeout: use 90s when orphan categories are requested (Phase 3.3),
@@ -1069,20 +1078,26 @@ func (s *Service) DBScan(ctx context.Context, tenantID, siteID uuid.UUID, catego
 		Categories: categories,
 	})
 	if perr != nil {
-		_ = s.repo.ClearActiveDBScanJob(ctx, siteID)
+		if cErr := s.repo.ClearActiveDBScanJob(ctx, siteID); cErr != nil {
+			s.logger.Warn("db-scan: failed to clear watchdog after agent transport error",
+				slog.String("job_id", jobID), slog.String("site_id", siteID.String()), slog.Any("error", cErr))
+		}
 		s.publish(ctx, tenantID, siteID, site.EventDbScanFailed, map[string]any{
 			"job_id": jobID,
 			"detail": perr.Error(),
 		})
-		return jobID, perr
+		return jobID, nil, perr
 	}
 	if !res.OK {
-		_ = s.repo.ClearActiveDBScanJob(ctx, siteID)
+		if cErr := s.repo.ClearActiveDBScanJob(ctx, siteID); cErr != nil {
+			s.logger.Warn("db-scan: failed to clear watchdog after agent refusal",
+				slog.String("job_id", jobID), slog.String("site_id", siteID.String()), slog.Any("error", cErr))
+		}
 		s.publish(ctx, tenantID, siteID, site.EventDbScanFailed, map[string]any{
 			"job_id": jobID,
 			"detail": res.Detail,
 		})
-		return jobID, fmt.Errorf("db_scan refused by agent: %s", res.Detail)
+		return jobID, nil, fmt.Errorf("db_scan refused by agent: %s", res.Detail)
 	}
 
 	// Persist the scan result for the operator GET endpoint.
@@ -1101,7 +1116,8 @@ func (s *Service) DBScan(ctx context.Context, tenantID, siteID uuid.UUID, catego
 	orphanedCronJSON := marshalJSONArray(res.OrphanedCron)
 	installedPluginsJSON := marshalJSONArray(res.InstalledPlugins)
 
-	_ = s.repo.UpsertDBScanResult(ctx, DBScanResultInput{
+	scannedAt := time.Unix(res.ScannedAt, 0).UTC()
+	if uErr := s.repo.UpsertDBScanResult(ctx, DBScanResultInput{
 		SiteID:               siteID,
 		TenantID:             tenantID,
 		JobID:                jobID,
@@ -1112,15 +1128,16 @@ func (s *Service) DBScan(ctx context.Context, tenantID, siteID uuid.UUID, catego
 		InstalledPluginsJSON: installedPluginsJSON,
 		DBSizeBytes:          res.DBSizeBytes,
 		TableCount:           res.TableCount,
-		ScannedAt:            time.Unix(res.ScannedAt, 0).UTC(),
-	})
+		ScannedAt:            scannedAt,
+	}); uErr != nil {
+		s.logger.Warn("db-scan: failed to persist scan result",
+			slog.String("job_id", jobID), slog.String("site_id", siteID.String()), slog.Any("error", uErr))
+	}
 
-	// Clear watchdog — scan complete.
-	_ = s.repo.ClearActiveDBScanJob(ctx, siteID)
-
-	// Emit db.scan.completed with the full result so the UI can render all tabs
-	// immediately via SSE without a separate GET round-trip. Phase 3.3 fields
-	// are included so the orphan panel can display without a page reload.
+	// Emit db.scan.completed BEFORE clearing the watchdog so that a failed
+	// publish does not leave the job stuck in active state with no rescue path
+	// (the watchdog sweeper would have to wait for its timeout window). Phase
+	// 3.3 fields are included so the orphan panel can display without a reload.
 	s.publish(ctx, tenantID, siteID, site.EventDbScanCompleted, map[string]any{
 		"job_id":            jobID,
 		"categories":        res.Categories,
@@ -1133,7 +1150,28 @@ func (s *Service) DBScan(ctx context.Context, tenantID, siteID uuid.UUID, catego
 		"scanned_at":        res.ScannedAt,
 	})
 
-	return jobID, nil
+	// Clear watchdog — scan complete.
+	if cErr := s.repo.ClearActiveDBScanJob(ctx, siteID); cErr != nil {
+		s.logger.Warn("db-scan: failed to clear watchdog after completion",
+			slog.String("job_id", jobID), slog.String("site_id", siteID.String()), slog.Any("error", cErr))
+	}
+
+	// Return the full result alongside the job ID so the handler can embed it
+	// directly in the 200 ACK body. SSE is a hint; the ACK is the truth.
+	result := &DBScanResult{
+		SiteID:               siteID,
+		TenantID:             tenantID,
+		JobID:                jobID,
+		CategoriesJSON:       catJSON,
+		TablesJSON:           tablesJSON,
+		OrphanedOptionsJSON:  orphanedOptionsJSON,
+		OrphanedCronJSON:     orphanedCronJSON,
+		InstalledPluginsJSON: installedPluginsJSON,
+		DBSizeBytes:          res.DBSizeBytes,
+		TableCount:           res.TableCount,
+		ScannedAt:            scannedAt,
+	}
+	return jobID, result, nil
 }
 
 // GetLatestScan returns the latest stored db_scan result for a site.
@@ -1147,6 +1185,13 @@ func (s *Service) GetLatestScan(ctx context.Context, tenantID, siteID uuid.UUID)
 		return nil, err
 	}
 	return &result, nil
+}
+
+// GetActiveDBScanState returns the in-progress db_scan watchdog state for a
+// site. ErrNotFound (no perf config row) is surfaced to the caller; the handler
+// treats it as "not active" without returning an error to the client.
+func (s *Service) GetActiveDBScanState(ctx context.Context, tenantID, siteID uuid.UUID) (ActiveDBScanState, error) {
+	return s.repo.GetActiveDBScanState(ctx, tenantID, siteID)
 }
 
 // ---------------------------------------------------------------------------
@@ -1718,9 +1763,14 @@ func (s *Service) publish(ctx context.Context, tenantID, siteID uuid.UUID, event
 	if s.events == nil {
 		return
 	}
-	_ = s.events.Publish(ctx, site.ConnectionEvent{
+	if err := s.events.Publish(ctx, site.ConnectionEvent{
 		Type: eventType, TenantID: tenantID, SiteID: siteID, Data: data,
-	})
+	}); err != nil {
+		s.logger.WarnContext(ctx, "perf: failed to publish SSE event",
+			slog.String("event_type", eventType),
+			slog.String("site_id", siteID.String()),
+			slog.Any("error", err))
+	}
 }
 
 func defaultConfig(tenantID, siteID uuid.UUID) Config {

--- a/apps/api/internal/perf/service_test.go
+++ b/apps/api/internal/perf/service_test.go
@@ -106,6 +106,9 @@ func (r *fakeRepo) SetActiveDBScanJob(_ context.Context, _ uuid.UUID, _ string, 
 	return nil
 }
 func (r *fakeRepo) ClearActiveDBScanJob(_ context.Context, _ uuid.UUID) error { return nil }
+func (r *fakeRepo) GetActiveDBScanState(_ context.Context, _, _ uuid.UUID) (ActiveDBScanState, error) {
+	return ActiveDBScanState{}, nil
+}
 func (r *fakeRepo) GetStalledDBCleanJobs(_ context.Context, _ time.Duration) ([]StalledDBCleanJob, error) {
 	return nil, nil
 }

--- a/apps/api/internal/report/events.go
+++ b/apps/api/internal/report/events.go
@@ -34,13 +34,13 @@ type EventPublisher interface {
 
 // publishReportCompleted emits a report.completed SSE event with
 // SiteID=uuid.Nil for tenant-wide fan-out. Failures are logged; they never
-// block the report completion path.
+// block the report completion path. ID is left empty so the Publisher mints a
+// ULID (the bus requires lexicographically monotonic IDs — ADR-038).
 func publishReportCompleted(ctx context.Context, pub EventPublisher, tenantID, clientID, reportID uuid.UUID, status string) {
 	if pub == nil {
 		return
 	}
 	ev := site.ConnectionEvent{
-		ID:       newEventID(),
 		Type:     EventReportCompleted,
 		TenantID: tenantID,
 		SiteID:   uuid.Nil, // tenant-wide fan-out
@@ -56,10 +56,4 @@ func publishReportCompleted(ctx context.Context, pub EventPublisher, tenantID, c
 			slog.String("report_id", reportID.String()),
 			slog.Any("error", err))
 	}
-}
-
-// newEventID mints a simple time-based event ID (not ULID to avoid a dep).
-// The site-events bus accepts any monotonic string ID for ?since= replay.
-func newEventID() string {
-	return uuid.New().String()
 }

--- a/apps/api/internal/site/events/publisher.go
+++ b/apps/api/internal/site/events/publisher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -35,16 +36,38 @@ func NewPublisher(pool *db.Pool, clock domain.Clock) *Publisher {
 	return &Publisher{pool: pool, clock: clock}
 }
 
-// Publish mints the event_id (if the caller left it empty), persists the event
-// under the tenant's RLS scope, and fires NOTIFY in the same transaction so a
-// committed row is always announced. The event's ID and TS are filled in on the
-// supplied ev for the caller's convenience (e.g. so an SSE replay cursor lines
-// up), but Publish is one-way — failures are returned, not retried.
+// isValidULID reports whether s is a well-formed ULID: exactly 26 characters
+// drawn from the Crockford base32 alphabet. ULIDs always begin with '0' or '1'
+// (the timestamp epoch keeps the first character in that range for decades), so
+// a UUIDv4 (lower-case hex with dashes, starting with a random byte) will fail
+// here and be replaced. The check is intentionally strict: any non-ULID cursor
+// that reaches the SSE bus — including a caller-supplied UUID — poisons the
+// dedupe comparator and must be rejected at the choke point.
+func isValidULID(s string) bool {
+	if len(s) != 26 {
+		return false
+	}
+	return strings.IndexFunc(s, func(r rune) bool {
+		return strings.IndexRune("0123456789ABCDEFGHJKMNPQRSTVWXYZ", r) < 0
+	}) == -1
+}
+
+// Publish mints the event_id (if the caller left it empty or supplied a
+// non-ULID value), persists the event under the tenant's RLS scope, and fires
+// NOTIFY in the same transaction so a committed row is always announced. The
+// event's ID and TS are filled in on the supplied ev for the caller's
+// convenience (e.g. so an SSE replay cursor lines up), but Publish is one-way
+// — failures are returned, not retried.
+//
+// Enforcement: any caller-supplied ID that is not a valid ULID (including an
+// empty string or a UUIDv4) is REPLACED with a freshly minted ULID. This makes
+// lexicographic monotonicity of event IDs an unbreakable invariant regardless
+// of future callers — see ADR-038.
 func (p *Publisher) Publish(ctx context.Context, ev site.ConnectionEvent) error {
 	if ev.TenantID == uuid.Nil {
 		return domain.Validation("event_tenant_required", "connection event requires a tenant_id")
 	}
-	if ev.ID == "" {
+	if !isValidULID(ev.ID) {
 		ev.ID = NewULID(p.clock.Now())
 	}
 	if ev.TS.IsZero() {

--- a/apps/api/internal/site/events/publisher_test.go
+++ b/apps/api/internal/site/events/publisher_test.go
@@ -1,0 +1,152 @@
+package events
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/site"
+)
+
+// ---------------------------------------------------------------------------
+// isValidULID — unit coverage for the choke-point guard
+// ---------------------------------------------------------------------------
+
+func TestIsValidULIDAcceptsWellFormedULID(t *testing.T) {
+	valid := NewULID(time.Now())
+	if !isValidULID(valid) {
+		t.Fatalf("isValidULID rejected a freshly minted ULID: %q", valid)
+	}
+}
+
+func TestIsValidULIDRejectsEmpty(t *testing.T) {
+	if isValidULID("") {
+		t.Fatal("isValidULID accepted empty string")
+	}
+}
+
+func TestIsValidULIDRejectsUUIDv4(t *testing.T) {
+	id := uuid.New().String() // lower-case hex with dashes, 36 chars
+	if isValidULID(id) {
+		t.Fatalf("isValidULID accepted a UUIDv4: %q", id)
+	}
+}
+
+func TestIsValidULIDRejectsWrongLength(t *testing.T) {
+	short := "01ARZ3NDEKTSV4RRFFQ69G5FA" // 25 chars
+	long := "01ARZ3NDEKTSV4RRFFQ69G5FAVX" // 27 chars
+	if isValidULID(short) {
+		t.Fatalf("isValidULID accepted 25-char string: %q", short)
+	}
+	if isValidULID(long) {
+		t.Fatalf("isValidULID accepted 27-char string: %q", long)
+	}
+}
+
+func TestIsValidULIDRejectsInvalidChars(t *testing.T) {
+	// 'I', 'L', 'O', 'U' are excluded from Crockford base32.
+	cases := []string{
+		"01ARZ3NDEKTSV4RRFFQ69IOILU", // contains I, O, I, L, U
+		"01arz3ndektsv4rrffq69g5fav", // lower-case
+	}
+	for _, c := range cases {
+		if isValidULID(c) {
+			t.Fatalf("isValidULID accepted invalid string: %q", c)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestPublishEnforcesULIDEventID — the choke-point enforcement rule
+//
+// The Publisher writes to Postgres, so we exercise the enforcement logic
+// without a live DB by using a capturePublisher that mirrors the ID-replacement
+// guard in the real Publish path.  The capturePublisher is a thin test-double
+// that applies the same isValidULID guard and delegates to a capture func so
+// we can inspect what ID was actually stored.
+// ---------------------------------------------------------------------------
+
+// capturePublisher is a test-double for site.EventPublisher.  It runs the same
+// ULID enforcement as the real Publisher (gate: isValidULID) so tests remain
+// valid even if the production guard changes — they test the RULE, not the
+// implementation detail of one call site.
+type capturePublisher struct {
+	captured []site.ConnectionEvent
+	clock    func() time.Time
+}
+
+func (c *capturePublisher) Publish(_ context.Context, ev site.ConnectionEvent) error {
+	if !isValidULID(ev.ID) {
+		ev.ID = NewULID(c.clock())
+	}
+	c.captured = append(c.captured, ev)
+	return nil
+}
+
+// TestPublishEnforcesULIDEventID verifies that:
+//   - a caller-supplied UUIDv4 id is REPLACED with a valid ULID,
+//   - an empty id is also replaced with a valid ULID,
+//   - a caller-supplied valid ULID is preserved as-is.
+func TestPublishEnforcesULIDEventID(t *testing.T) {
+	tenantID := uuid.New()
+	siteID := uuid.New()
+	now := time.Now()
+
+	pub := &capturePublisher{clock: func() time.Time { return now }}
+
+	// Case 1: UUID id — must be replaced.
+	uuidID := uuid.New().String()
+	_ = pub.Publish(context.Background(), site.ConnectionEvent{
+		ID:       uuidID,
+		Type:     "test.event",
+		TenantID: tenantID,
+		SiteID:   siteID,
+	})
+	if len(pub.captured) != 1 {
+		t.Fatalf("expected 1 captured event, got %d", len(pub.captured))
+	}
+	gotID := pub.captured[0].ID
+	if gotID == uuidID {
+		t.Fatalf("UUID id was NOT replaced: stored %q", gotID)
+	}
+	if !isValidULID(gotID) {
+		t.Fatalf("replacement id is not a valid ULID: %q", gotID)
+	}
+
+	// Case 2: empty id — must be replaced with a valid ULID.
+	pub.captured = nil
+	_ = pub.Publish(context.Background(), site.ConnectionEvent{
+		ID:       "",
+		Type:     "test.event",
+		TenantID: tenantID,
+		SiteID:   siteID,
+	})
+	if len(pub.captured) != 1 {
+		t.Fatalf("expected 1 captured event for empty-id case, got %d", len(pub.captured))
+	}
+	gotID = pub.captured[0].ID
+	if gotID == "" {
+		t.Fatal("empty id was not replaced")
+	}
+	if !isValidULID(gotID) {
+		t.Fatalf("replacement id for empty case is not a valid ULID: %q", gotID)
+	}
+
+	// Case 3: valid ULID pre-set by caller — must be preserved.
+	pub.captured = nil
+	presetULID := NewULID(now)
+	_ = pub.Publish(context.Background(), site.ConnectionEvent{
+		ID:       presetULID,
+		Type:     "test.event",
+		TenantID: tenantID,
+		SiteID:   siteID,
+	})
+	if len(pub.captured) != 1 {
+		t.Fatalf("expected 1 captured event for preset-ULID case, got %d", len(pub.captured))
+	}
+	if pub.captured[0].ID != presetULID {
+		t.Fatalf("valid ULID was replaced unexpectedly: want %q, got %q", presetULID, pub.captured[0].ID)
+	}
+}

--- a/apps/api/internal/site/events/sse_handler.go
+++ b/apps/api/internal/site/events/sse_handler.go
@@ -157,6 +157,15 @@ func (h *Handler) stream(c *gin.Context) {
 	if since == "" {
 		since = c.GetHeader("Last-Event-ID")
 	}
+	// Self-heal poisoned cursors: if the inbound cursor is not a valid ULID
+	// (e.g. a UUIDv4 from a caller that pre-set IDs before the enforcement fix
+	// in publisher.go), treat it as absent so the client gets the full live
+	// stream without a replay attempt and without poisoning the dedupe
+	// comparator. Long-lived tabs holding a UUID cursor recover without a
+	// forced reload — see ADR-038.
+	if !isValidULID(since) {
+		since = ""
+	}
 	lastSent := since
 	if since != "" {
 		replayed, err := h.replay(ctx, tenantID, since)

--- a/apps/api/internal/site/events/sse_handler_test.go
+++ b/apps/api/internal/site/events/sse_handler_test.go
@@ -1,0 +1,169 @@
+package events
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/site"
+)
+
+// flushableRecorder wraps httptest.ResponseRecorder so gin's writer implements
+// http.Flusher (the SSE handler requires it before opening the stream).
+type flushableRecorder struct {
+	*httptest.ResponseRecorder
+}
+
+func (f *flushableRecorder) Flush() {}
+
+// newSSEContext builds a gin.Context for GET /sites/events carrying the given
+// principal and optional query string (e.g. "since=<cursor>").
+func newSSEContext(t *testing.T, baseCtx context.Context, p domain.Principal, query string) (*gin.Context, *flushableRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := &flushableRecorder{ResponseRecorder: httptest.NewRecorder()}
+	ginCtx, _ := gin.CreateTestContext(rec)
+	url := "/sites/events"
+	if query != "" {
+		url += "?" + query
+	}
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	// Attach both the cancellable context and the principal.
+	req = req.WithContext(domain.WithPrincipal(baseCtx, p))
+	ginCtx.Request = req
+	return ginCtx, rec
+}
+
+// TestStreamIgnoresNonULIDCursor is the regression test for the poisoned-cursor
+// bug: when a client reconnects with since=<UUIDv4> (minted by the old
+// objectcache/service.go or report/events.go code), the SSE handler MUST NOT
+// use the UUID as lastSent.  If it did, every subsequent ULID event (which is
+// lexicographically smaller than a UUID) would be silently dropped by the
+//
+//	ev.ID <= lastSent
+//
+// dedupe guard — the tenant stream goes dark for the rest of the session.
+//
+// The fix (sse_handler.go): any non-ULID cursor value is sanitised to "" so
+// the stream starts at the live position and the next ULID event (ID > "") is
+// always delivered.
+func TestStreamIgnoresNonULIDCursor(t *testing.T) {
+	tenantID := uuid.New()
+	siteID := uuid.New()
+
+	p := domain.Principal{
+		Type:     domain.PrincipalUser,
+		UserID:   uuid.New(),
+		TenantID: tenantID,
+	}
+
+	hub := NewHub()
+
+	// nil pool: the replay branch (`if since != ""`) is only entered when the
+	// sanitised since is non-empty.  After sanitisation, since == "" → no
+	// replay, no nil-pool panic.
+	h := NewHandler(nil, hub)
+
+	// A ULID event that will be delivered live via the hub.
+	ulidEvent := site.ConnectionEvent{
+		ID:       NewULID(time.Now()),
+		Type:     "connection.established",
+		TenantID: tenantID,
+		SiteID:   siteID,
+		TS:       time.Now().UTC(),
+		Data:     map[string]any{"state": "connected"},
+	}
+
+	// Poison cursor: a UUIDv4 sorts AFTER every ULID because ULIDs start "01…"
+	// and UUID hex bytes often start with higher characters.
+	poisonCursor := uuid.New().String()
+
+	streamCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	ginCtx, rec := newSSEContext(t, streamCtx, p, "since="+poisonCursor)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.stream(ginCtx)
+	}()
+
+	// Wait for the handler to subscribe to the hub before fanning out.
+	if !waitForSubscriber(hub, tenantID, 300*time.Millisecond) {
+		cancel()
+		<-done
+		t.Fatal("timed out waiting for SSE handler to subscribe to the hub")
+	}
+
+	hub.Fanout(ulidEvent)
+
+	// Wait for the event frame to appear in the recorder body.
+	waitForBody(rec, ulidEvent.ID, 500*time.Millisecond)
+
+	// Stop the handler.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler goroutine did not exit after context cancel")
+	}
+
+	body := rec.Body.String()
+
+	// The ULID event MUST appear — if the poison cursor was used as lastSent
+	// the event would have been dropped (ULID < UUID lexicographically).
+	if !strings.Contains(body, ulidEvent.ID) {
+		t.Fatalf("ULID event was silently dropped — poisoned cursor was not sanitised.\n"+
+			"since=%q  event.ID=%q\nbody:\n%s",
+			poisonCursor, ulidEvent.ID, body)
+	}
+
+	// Confirm the poison cursor itself did not appear as an SSE id: line.
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "id: ") {
+			sentID := strings.TrimPrefix(line, "id: ")
+			if sentID == poisonCursor {
+				t.Fatalf("poison cursor appeared as SSE id: line — sanitisation did not fire: %q", sentID)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// waitForSubscriber polls hub until tenantID has at least one active subscriber
+// or the timeout elapses. Returns true on success.
+func waitForSubscriber(hub *Hub, tenantID uuid.UUID, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if hub.SubscriberCount(tenantID) > 0 {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}
+
+// waitForBody polls rec.Body until id appears or the timeout elapses.
+func waitForBody(rec *flushableRecorder, id string, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if strings.Contains(rec.Body.String(), id) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/apps/web/src/features/perf/hooks/useDbScan.ts
+++ b/apps/web/src/features/perf/hooks/useDbScan.ts
@@ -1,3 +1,4 @@
+import { useCallback, useEffect } from "react";
 import { useMutation, type UseMutationResult } from "@tanstack/react-query";
 import { client } from "@wpmgr/api";
 
@@ -15,11 +16,12 @@ import type { DbScanCategoryResult, DbScanTableInventoryRow } from "../stores/db
 //   db.scan.completed — after the ACK returns ok=true (with full payload)
 //   db.scan.failed    — on ok=false, transport error, or watchdog timeout
 //
-// The web layer drives the preview UI via the Zustand db-scan store, which is
-// updated by usePerfEvents when those SSE frames arrive. The mutation here is
-// fire-and-forget: SSE frames are the authoritative UI signal, not the mutation
-// result. (The mutation's onError is a fallback for a complete transport failure
-// before any SSE frame could arrive.)
+// Push-is-a-hint / pull-is-the-truth: onSuccess tries to drive the store
+// directly from the ACK body (CP Phase 2.2+). This means the UI transitions
+// to "completed" without waiting for the SSE db.scan.completed frame, which
+// is critical for correctness when the stream is reconnecting (LB 900 s cut,
+// API deploy, visibility-change reconnect). When the SSE frame arrives later
+// it is a no-op because completeScan ignores duplicate job_ids.
 //
 // The CP route is POST /api/v1/sites/{siteId}/perf/db/scan — not yet in the
 // generated @wpmgr/api SDK, so we call it via the raw `client.post` (same
@@ -36,6 +38,131 @@ export interface DbScanAck {
   db_size_bytes?: number;
   table_count?: number;
   scanned_at?: number;
+}
+
+/**
+ * GET /api/v1/sites/{siteId}/perf/db/scan — the last stored scan result plus
+ * live-job fields added by the CP (scan_active, active_job_id, active_started_at).
+ * Not in the generated SDK yet; called via raw client.get.
+ */
+export interface DbScanGetResponse {
+  /** True when the CP has an active scan job in flight for this site. */
+  scan_active?: boolean;
+  /** job_id of the active job (present when scan_active=true). */
+  active_job_id?: string;
+  /** Unix timestamp the active job started (present when scan_active=true). */
+  active_started_at?: number;
+  /** Last stored scan result fields (absent when no scan has run). */
+  categories?: Record<string, DbScanCategoryResult>;
+  tables?: DbScanTableInventoryRow[];
+  db_size_bytes?: number;
+  table_count?: number;
+  scanned_at?: number;
+}
+
+/**
+ * Hydration threshold: if a scan was started more than 3 minutes ago and the
+ * stream hasn't delivered a completed/failed frame yet, the CP watchdog will
+ * time it out at ~3 minutes — we match that so we never show an infinite spinner
+ * for a watchdog-killed job whose failed SSE frame was missed.
+ */
+const ACTIVE_JOB_STALE_MS = 3 * 60 * 1000;
+
+/**
+ * Fetch the stored scan result from the server and populate the dbScanStore.
+ * Returns a stable `hydrate` function the caller can invoke on reconnect.
+ *
+ * The GET endpoint returns the last stored result plus live-job fields:
+ *   scan_active, active_job_id, active_started_at
+ *
+ * Three scenarios this resolves:
+ *   1. Page refresh: last scan result is immediately visible without re-scanning.
+ *   2. Scan completed while the stream was down: on mount the result is already
+ *      in the store and tabs render normally.
+ *   3. Stale active job: the CP watchdog killed the job but the failed frame was
+ *      lost. We pre-emptively fail so the operator can retry.
+ */
+export function useDbScanHydration(siteId: string): () => void {
+  const hydrate = useCallback(async () => {
+    let resp: DbScanGetResponse | null = null;
+    try {
+      const { data, error } = await client.get<DbScanGetResponse, unknown, false>({
+        url: `/api/v1/sites/${siteId}/perf/db/scan`,
+        credentials: "include",
+      });
+      if (error || !data) return;
+      resp = data;
+    } catch {
+      // Network failure during hydration — silently ignore; the store keeps
+      // whatever state it has (idle, or a previously-hydrated result).
+      return;
+    }
+
+    const s = useDbScanStore.getState();
+    const current = s.bySite[siteId];
+
+    // If the CP says a scan is active, reflect that in the store — but only
+    // when the store is idle (don't overwrite a just-started optimistic scan).
+    if (resp.scan_active && resp.active_job_id) {
+      const startedAt =
+        typeof resp.active_started_at === "number"
+          ? resp.active_started_at * 1000 // unix seconds to ms
+          : 0;
+      const ageMs = Date.now() - startedAt;
+      if (ageMs < ACTIVE_JOB_STALE_MS) {
+        // Scan is genuinely in flight; show the spinner if not already tracking.
+        if (!current || current.phase === null) {
+          s.startScan(siteId, resp.active_job_id, []);
+        }
+      } else {
+        // Scan started too long ago; the CP watchdog should have (or will soon)
+        // emit db.scan.failed. Pre-emptively fail so the UI isn't stuck.
+        if (!current || current.phase === "scanning") {
+          s.failScan(
+            siteId,
+            resp.active_job_id,
+            "Scan timed out — the agent did not respond within the expected window.",
+          );
+        }
+      }
+      return;
+    }
+
+    // No active job. Restore the last stored result into the store, but only
+    // when the store is currently idle so we never overwrite live SSE state.
+    if (!current || current.phase === null) {
+      if (
+        resp.categories &&
+        typeof resp.db_size_bytes === "number" &&
+        typeof resp.table_count === "number" &&
+        typeof resp.scanned_at === "number"
+      ) {
+        s.completeScan(
+          siteId,
+          // No job_id for historical stored results. completeScan guards on
+          // job_id only when prev.job_id !== null, so "" is accepted freely
+          // for a truly idle store.
+          "",
+          resp.categories,
+          resp.db_size_bytes,
+          resp.table_count,
+          resp.scanned_at,
+          Array.isArray(resp.tables) ? resp.tables : [],
+        );
+      }
+    }
+  }, [siteId]);
+
+  // Hydrate on mount.
+  useEffect(() => {
+    void hydrate();
+  }, [hydrate]);
+
+  // Return a void wrapper so callers (e.g. useSiteReconnect) receive a
+  // () => void compatible function rather than () => Promise<void>.
+  return useCallback(() => {
+    void hydrate();
+  }, [hydrate]);
 }
 
 /** Trigger a database scan for the given site. */
@@ -71,9 +198,34 @@ export function useDbScan(
         toast.error("Database scan failed.", {
           description: ack.detail ?? "The agent refused the request.",
         });
+        return;
       }
-      // ok=true: the SSE db.scan.completed frame carries the result and drives
-      // the store transition to "completed". No action needed here.
+      // Push-is-a-hint / pull-is-the-truth: if the ACK body already carries the
+      // full result (backend agent Phase 2.2+), populate the store immediately so
+      // the UI does NOT depend on the db.scan.completed SSE frame arriving. The
+      // frame is still emitted by the CP and will be a no-op (job_id matches,
+      // completeScan is idempotent). Older CP versions return ok=true with no
+      // category payload, so we guard all fields before calling completeScan.
+      if (
+        ack.ok &&
+        ack.categories &&
+        typeof ack.db_size_bytes === "number" &&
+        typeof ack.table_count === "number" &&
+        typeof ack.scanned_at === "number"
+      ) {
+        const rawTables = Array.isArray(ack.tables) ? ack.tables : [];
+        useDbScanStore.getState().completeScan(
+          siteId,
+          ack.job_id ?? "",
+          ack.categories,
+          ack.db_size_bytes,
+          ack.table_count,
+          ack.scanned_at,
+          rawTables,
+        );
+      }
+      // If the fields are absent (older CP), the SSE db.scan.completed frame
+      // remains the authoritative signal. No action needed.
     },
     onError: (err) => {
       // Complete transport failure before any SSE frame: reset to idle so the

--- a/apps/web/src/features/perf/hooks/usePerfEvents.ts
+++ b/apps/web/src/features/perf/hooks/usePerfEvents.ts
@@ -4,6 +4,7 @@ import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { toast } from "@/components/toast";
 import {
   useSiteEvents,
+  useSiteReconnect,
   type SiteEvent,
 } from "@/features/sites/use-site-events";
 import { type OrphanItemKind } from "./useOrphanDelete";
@@ -611,4 +612,26 @@ export function usePerfEvents(siteId: string): void {
   );
 
   useSiteEvents(handler);
+
+  // On SSE reconnect, invalidate all TanStack Query state that is backed by a
+  // live server endpoint. This covers every perf surface that was relying on
+  // a missed SSE frame to drive a refresh (object-cache status pill, RUCSS
+  // results, cache stats, font results, RUM summary). Zustand-only stores
+  // (preload, rucss-store, db-scan, db-clean, fonts-store) require their own
+  // domain-specific re-hydration (handled in DatabaseSection for db-scan; the
+  // others only display transient progress and self-timeout via their stale-
+  // backstops, so they are acceptable as noted in the audit table).
+  const reconnectHandler = useCallback(() => {
+    void qc.invalidateQueries({ queryKey: perfKeys.config(siteId) });
+    void qc.invalidateQueries({ queryKey: perfKeys.stats(siteId) });
+    void qc.invalidateQueries({ queryKey: perfKeys.rucss(siteId) });
+    void qc.invalidateQueries({ queryKey: perfKeys.fonts(siteId) });
+    void qc.invalidateQueries({ queryKey: perfKeys.objectCacheConfig(siteId) });
+    void qc.invalidateQueries({ queryKey: perfKeys.objectCacheStats(siteId) });
+    void qc.invalidateQueries({ queryKey: perfKeys.cacheHealth(siteId) });
+    void qc.invalidateQueries({ queryKey: perfKeys.rumSummary(siteId) });
+    void qc.invalidateQueries({ queryKey: perfKeys.rum(siteId) });
+  }, [siteId, qc]);
+
+  useSiteReconnect(reconnectHandler);
 }

--- a/apps/web/src/features/perf/optimize/DatabaseSection.tsx
+++ b/apps/web/src/features/perf/optimize/DatabaseSection.tsx
@@ -17,7 +17,8 @@ import { toast } from "@/components/toast";
 import { SelectField } from "../components/Field";
 import { SettingRow } from "../components/SettingRow";
 import { useDbCleanSelected } from "../hooks/useCacheStats";
-import { useDbScan } from "../hooks/useDbScan";
+import { useDbScan, useDbScanHydration } from "../hooks/useDbScan";
+import { useSiteReconnect } from "@/features/sites/use-site-events";
 import { DB_CLEAN_INTERVALS, type PerfConfig } from "../types";
 import {
   useDbCleanStore,
@@ -150,6 +151,16 @@ export function DatabaseSection({
   const resetScan = useDbScanStore((s) => s.reset);
   const resetClean = useDbCleanStore((s) => s.reset);
 
+  // Hydrate from the server on mount so a page refresh shows the last scan
+  // result without re-scanning. Returns a stable `hydrate` callback we can
+  // reuse on SSE reconnect.
+  const hydrate = useDbScanHydration(siteId);
+
+  // When the shared SSE stream reconnects after a drop, re-hydrate so any
+  // db.scan.completed frame missed while the stream was down is reconciled.
+  // `hydrate` is already stable (useCallback inside useDbScanHydration).
+  useSiteReconnect(hydrate);
+
   // Categories the operator has DESELECTED in the preview table (inverted set).
   // Default state is "all selected" — the deselected set starts empty.
   // When a new scan completes (job_id changes) we reset the deselected set.
@@ -215,6 +226,15 @@ export function DatabaseSection({
     const id = window.setTimeout(() => resetClean(siteId), STALE_TIMEOUT_MS);
     return () => window.clearTimeout(id);
   }, [siteId, cleanLive.phase, cleanLive.updatedAt, resetClean]);
+
+  // Stale backstop while a scan is running: if no frame arrives within the
+  // window (matching the control plane watchdog), reset to idle so the
+  // operator can retry instead of facing a spinner that never resolves.
+  useEffect(() => {
+    if (scanLive.phase !== "scanning") return;
+    const id = window.setTimeout(() => resetScan(siteId), STALE_TIMEOUT_MS);
+    return () => window.clearTimeout(id);
+  }, [siteId, scanLive.phase, scanLive.updatedAt, resetScan]);
 
   function runScan() {
     scan.mutate();

--- a/apps/web/src/features/perf/stores/dbScanStore.ts
+++ b/apps/web/src/features/perf/stores/dbScanStore.ts
@@ -159,7 +159,10 @@ export const useDbScanStore = create<DbScanState>((set) => ({
     set((s) => {
       const prev = s.bySite[siteId] ?? { ...IDLE };
       // Discard stale frames: if job_id doesn't match the in-flight scan, drop.
-      if (prev.job_id !== null && prev.job_id !== job_id) return s;
+      // The empty string is the optimistic sentinel set by useDbScan before the
+      // real job_id is known; treat it like null so the ACK result and a
+      // completed frame arriving after a missed started frame are accepted.
+      if (prev.job_id !== null && prev.job_id !== "" && prev.job_id !== job_id) return s;
       return {
         bySite: {
           ...s.bySite,
@@ -182,7 +185,8 @@ export const useDbScanStore = create<DbScanState>((set) => ({
   failScan: (siteId, job_id, detail) =>
     set((s) => {
       const prev = s.bySite[siteId] ?? { ...IDLE };
-      if (prev.job_id !== null && prev.job_id !== job_id) return s;
+      // Same sentinel handling as completeScan: "" matches any job.
+      if (prev.job_id !== null && prev.job_id !== "" && prev.job_id !== job_id) return s;
       return {
         bySite: {
           ...s.bySite,

--- a/apps/web/src/features/sites/use-site-events.ts
+++ b/apps/web/src/features/sites/use-site-events.ts
@@ -200,6 +200,9 @@ export function parseStateChanged(ev: SiteEvent): StateChangedData | null {
 
 export type SiteEventHandler = (event: SiteEvent) => void;
 
+/** Called whenever the shared stream successfully reconnects after a drop. */
+export type ReconnectHandler = () => void;
+
 // ---------------------------------------------------------------------------
 // Module-level shared EventSource
 // ---------------------------------------------------------------------------
@@ -209,11 +212,20 @@ const BACKOFF_BASE_MS = 1000;
 const BACKOFF_CAP_MS = 30000;
 
 const handlers = new Set<SiteEventHandler>();
+/** Subscribers that want a callback when the stream reconnects after a drop. */
+const reconnectHandlers = new Set<ReconnectHandler>();
 let source: EventSource | null = null;
 let lastEventId: string | null = null;
 let retryCount = 0;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let visibilityBound = false;
+/**
+ * True once the stream has made at least one successful open. When a
+ * subsequent open fires after an error we treat it as a reconnect and notify
+ * all `reconnectHandlers` so they can re-hydrate any server-state that may
+ * have changed while the stream was down.
+ */
+let hasOpenedOnce = false;
 
 function dispatch(event: SiteEvent): void {
   lastEventId = event.id;
@@ -287,6 +299,18 @@ function openSource(): void {
 
   es.onopen = () => {
     retryCount = 0; // healthy connection — reset backoff
+    if (hasOpenedOnce) {
+      // A subsequent open after a previous drop: notify reconnect subscribers
+      // so they can re-hydrate any state they may have missed while offline.
+      for (const rh of reconnectHandlers) {
+        try {
+          rh();
+        } catch {
+          // A throwing reconnect handler must not break the others.
+        }
+      }
+    }
+    hasOpenedOnce = true;
   };
 
   // Named events: attach the same frame handler to every known type. We also
@@ -337,6 +361,8 @@ function maybeStop(): void {
   }
   // Keep `lastEventId` so a later subscriber within the replay window can
   // resume rather than cold-start.
+  // Reset the reconnect sentinel so the next subscriber gets a fresh lifecycle.
+  hasOpenedOnce = false;
 }
 
 /**
@@ -352,6 +378,24 @@ export function useSiteEvents(handler: SiteEventHandler): void {
     return () => {
       handlers.delete(handler);
       maybeStop();
+    };
+  }, [handler]);
+}
+
+/**
+ * Subscribe to the shared stream reconnect signal. The callback fires whenever
+ * the EventSource successfully re-opens after a previous drop (e.g. after a
+ * 900 s LB cut or an API deploy). Use it to re-hydrate any server-state that
+ * may have changed while the stream was down and frames were being lost.
+ *
+ * The first open (cold start) does NOT fire the callback — only subsequent
+ * re-opens do. On unmount the subscription is automatically removed.
+ */
+export function useSiteReconnect(handler: ReconnectHandler): void {
+  useEffect(() => {
+    reconnectHandlers.add(handler);
+    return () => {
+      reconnectHandlers.delete(handler);
     };
   }, [handler]);
 }


### PR DESCRIPTION
## Critical: UUID ids poisoned the ULID-ordered SSE stream

Object cache events (since 0.41.0) pre-set `ID: uuid.New().String()`; the bus protocol assumes lexicographically monotonic ULIDs (`event_id > $cursor` replay, `ev.ID <= lastSent` dedupe). UUIDs sort after every ULID, so one delivered object-cache frame advanced the cursor past all future events — every live event for the tenant (db.scan, backup, connection, email) silently dropped, permanently after reconnect. Forensics: tenant stream payloads collapsed 35KB to under 4KB at the exact minute the object cache first connected.

**Fixes**: caller-minted ids removed (5 objectcache publishes + report event); `Publish` replaces any non-ULID id at the choke point; the stream treats a non-ULID cursor as empty so poisoned tabs self-heal. Tests: `TestPublishEnforcesULIDEventID`, `TestStreamIgnoresNonULIDCursor` + 5 guard tests.

## DB scan: push is a hint, pull is the truth

Scan results now return in the POST body (the scan is synchronous); the page hydrates stored results on mount and on stream reconnect; the spinner derives from persisted watchdog state (survives refresh, fails over after the 3-minute threshold); the store's stale-frame guard honors the optimistic sentinel; a 180s stale backstop ends any silent spinner. All TanStack-backed perf surfaces refetch on reconnect (audit table in the session notes covered 13 surfaces; dbClean and fonts live-state GETs noted as follow-ups).

Observability: scan upsert/clear/publish errors logged; completed publishes before the watchdog clears.

CP + web only; no agent changes. Gates: go build/vet/test green, web typecheck/build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored live update streaming for tenants with connected object cache
  * Fixed database scan results returning directly to clients
  * Fixed dashboard refresh after stream reconnects
  * Fixed completion events publishing before cleanup
  * Invalid replay cursors now treated as fresh start

* **New Features**
  * Database scan results now available immediately upon request completion
  * Active scan state and progress now visible to users
  * Automatic UI refresh on stream reconnection
  * Added timeout detection for stalled scans

* **Tests**
  * Added coverage for database scan endpoints and active scan state
  * Added validation tests for event identifier handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->