### PR TITLE
fix(perf): db clean and font progress pull-truth hardening (0.43.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.43.3] - 2026-06-12
+
+### Fixed
+
+- **Database cleanup progress now survives missed events and page refreshes.** Cleanup results are stored server side (migration m71) and a new endpoint reports the active job and the last result, so the page restores state on load and after a stream reconnect. A running cleanup shows correctly after a refresh, and the completion event is published before the watchdog clears so failures still surface. The late frame guard fix applied to scans in 0.43.2 now covers cleanups as well.
+- **Font processing banner can no longer stick.** The banner reconciles against stored per-font statuses on page load and on stream reconnect, clearing itself when the server shows no conversion in flight.
+
+Control plane and web 0.43.3; migration m71 applies automatically on boot; no agent changes. This completes the live update hardening started in 0.43.2: every dashboard surface now recovers from missed events.
+
 ## [0.43.2] - 2026-06-12
 
 ### Fixed

--- a/apps/api/db/query/perf.sql
+++ b/apps/api/db/query/perf.sql
@@ -443,6 +443,35 @@ WHERE id IN (
 );
 
 -- ---------------------------------------------------------------------------
+-- site_db_clean_results (M71)
+-- ---------------------------------------------------------------------------
+
+-- name: UpsertDBCleanResult :one
+-- Persists (or refreshes) the latest db_clean result for a site.
+-- Uses UPSERT so there is always at most one row per site.
+-- Called under InTenantTx by HandleDBCleanProgress when done=true.
+-- updated_at is set via now() on the created_at column (mirrors scan pattern).
+INSERT INTO site_db_clean_results (
+    site_id, tenant_id, job_id, result_json, rows_deleted, bytes_freed, cleaned_at, created_at
+) VALUES (
+    @site_id, @tenant_id, @job_id, @result_json, @rows_deleted, @bytes_freed, @cleaned_at, now()
+)
+ON CONFLICT (site_id) DO UPDATE SET
+    tenant_id    = EXCLUDED.tenant_id,
+    job_id       = EXCLUDED.job_id,
+    result_json  = EXCLUDED.result_json,
+    rows_deleted = EXCLUDED.rows_deleted,
+    bytes_freed  = EXCLUDED.bytes_freed,
+    cleaned_at   = EXCLUDED.cleaned_at,
+    created_at   = now()
+RETURNING *;
+
+-- name: GetDBCleanResult :one
+-- Returns the latest clean result for a site (tenant-scoped via RLS).
+SELECT * FROM site_db_clean_results
+WHERE site_id = @site_id AND tenant_id = @tenant_id;
+
+-- ---------------------------------------------------------------------------
 -- P3.7 — Fleet / Portfolio DB Health aggregate (tenant-level, no site_id param)
 -- ---------------------------------------------------------------------------
 

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -1534,6 +1534,32 @@ CREATE POLICY site_db_scan_results_agent ON site_db_scan_results
     USING (current_setting('app.agent', true) = 'on')
     WITH CHECK (current_setting('app.agent', true) = 'on');
 
+-- site_db_clean_results — latest db_clean output per site (M71).
+-- One row per site, upserted on every completed clean run. Holds the structured
+-- per-category result from the final done=true progress push so GET /perf/db/clean
+-- can serve the last-run summary without relying on SSE delivery.
+CREATE TABLE IF NOT EXISTS site_db_clean_results (
+    site_id      uuid        NOT NULL,
+    tenant_id    uuid        NOT NULL,
+    job_id       text        NOT NULL,
+    result_json  jsonb       NOT NULL DEFAULT '{}',
+    rows_deleted bigint      NOT NULL DEFAULT 0,
+    bytes_freed  bigint      NOT NULL DEFAULT 0,
+    cleaned_at   timestamptz NOT NULL,
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT site_db_clean_results_pkey PRIMARY KEY (site_id)
+);
+CREATE INDEX IF NOT EXISTS site_db_clean_results_tenant_idx
+    ON site_db_clean_results (tenant_id);
+ALTER TABLE site_db_clean_results ENABLE ROW LEVEL SECURITY;
+ALTER TABLE site_db_clean_results FORCE ROW LEVEL SECURITY;
+CREATE POLICY site_db_clean_results_tenant_isolation ON site_db_clean_results
+    USING (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid)
+    WITH CHECK (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid);
+CREATE POLICY site_db_clean_results_agent ON site_db_clean_results
+    USING (current_setting('app.agent', true) = 'on')
+    WITH CHECK (current_setting('app.agent', true) = 'on');
+
 -- site_cache_hit_ratio_history — M52 / #162: append-only hit-ratio trend.
 -- One row per cache-stats report cycle when the agent supplies a non-zero delta.
 -- Mirrors site_db_size_history RLS EXACTLY.

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -592,6 +592,17 @@ type SiteConnectionHistory struct {
 	Metadata    []byte      `json:"metadata"`
 }
 
+type SiteDbCleanResult struct {
+	SiteID      uuid.UUID `json:"site_id"`
+	TenantID    uuid.UUID `json:"tenant_id"`
+	JobID       string    `json:"job_id"`
+	ResultJson  []byte    `json:"result_json"`
+	RowsDeleted int64     `json:"rows_deleted"`
+	BytesFreed  int64     `json:"bytes_freed"`
+	CleanedAt   time.Time `json:"cleaned_at"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
 type SiteDbScanResult struct {
 	SiteID               uuid.UUID `json:"site_id"`
 	TenantID             uuid.UUID `json:"tenant_id"`

--- a/apps/api/internal/db/sqlc/perf.sql.go
+++ b/apps/api/internal/db/sqlc/perf.sql.go
@@ -126,6 +126,33 @@ func (q *Queries) GetCacheStats(ctx context.Context, siteID uuid.UUID) (SiteCach
 	return i, err
 }
 
+const getDBCleanResult = `-- name: GetDBCleanResult :one
+SELECT site_id, tenant_id, job_id, result_json, rows_deleted, bytes_freed, cleaned_at, created_at FROM site_db_clean_results
+WHERE site_id = $1 AND tenant_id = $2
+`
+
+type GetDBCleanResultParams struct {
+	SiteID   uuid.UUID `json:"site_id"`
+	TenantID uuid.UUID `json:"tenant_id"`
+}
+
+// Returns the latest clean result for a site (tenant-scoped via RLS).
+func (q *Queries) GetDBCleanResult(ctx context.Context, arg GetDBCleanResultParams) (SiteDbCleanResult, error) {
+	row := q.db.QueryRow(ctx, getDBCleanResult, arg.SiteID, arg.TenantID)
+	var i SiteDbCleanResult
+	err := row.Scan(
+		&i.SiteID,
+		&i.TenantID,
+		&i.JobID,
+		&i.ResultJson,
+		&i.RowsDeleted,
+		&i.BytesFreed,
+		&i.CleanedAt,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getDBScanResult = `-- name: GetDBScanResult :one
 SELECT site_id, tenant_id, job_id, categories_json, tables_json, db_size_bytes, table_count, scanned_at, created_at, orphaned_options_json, orphaned_cron_json, installed_plugins_json FROM site_db_scan_results
 WHERE site_id = $1 AND tenant_id = $2
@@ -1339,6 +1366,65 @@ func (q *Queries) UpsertCacheStats(ctx context.Context, arg UpsertCacheStatsPara
 		&i.PreloadPending,
 		&i.PreloadTotal,
 		&i.ReportedAt,
+	)
+	return i, err
+}
+
+const upsertDBCleanResult = `-- name: UpsertDBCleanResult :one
+
+INSERT INTO site_db_clean_results (
+    site_id, tenant_id, job_id, result_json, rows_deleted, bytes_freed, cleaned_at, created_at
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, now()
+)
+ON CONFLICT (site_id) DO UPDATE SET
+    tenant_id    = EXCLUDED.tenant_id,
+    job_id       = EXCLUDED.job_id,
+    result_json  = EXCLUDED.result_json,
+    rows_deleted = EXCLUDED.rows_deleted,
+    bytes_freed  = EXCLUDED.bytes_freed,
+    cleaned_at   = EXCLUDED.cleaned_at,
+    created_at   = now()
+RETURNING site_id, tenant_id, job_id, result_json, rows_deleted, bytes_freed, cleaned_at, created_at
+`
+
+type UpsertDBCleanResultParams struct {
+	SiteID      uuid.UUID `json:"site_id"`
+	TenantID    uuid.UUID `json:"tenant_id"`
+	JobID       string    `json:"job_id"`
+	ResultJson  []byte    `json:"result_json"`
+	RowsDeleted int64     `json:"rows_deleted"`
+	BytesFreed  int64     `json:"bytes_freed"`
+	CleanedAt   time.Time `json:"cleaned_at"`
+}
+
+// ---------------------------------------------------------------------------
+// site_db_clean_results (M71)
+// ---------------------------------------------------------------------------
+// Persists (or refreshes) the latest db_clean result for a site.
+// Uses UPSERT so there is always at most one row per site.
+// Called under InTenantTx by HandleDBCleanProgress when done=true.
+// updated_at is set via now() on the created_at column (mirrors scan pattern).
+func (q *Queries) UpsertDBCleanResult(ctx context.Context, arg UpsertDBCleanResultParams) (SiteDbCleanResult, error) {
+	row := q.db.QueryRow(ctx, upsertDBCleanResult,
+		arg.SiteID,
+		arg.TenantID,
+		arg.JobID,
+		arg.ResultJson,
+		arg.RowsDeleted,
+		arg.BytesFreed,
+		arg.CleanedAt,
+	)
+	var i SiteDbCleanResult
+	err := row.Scan(
+		&i.SiteID,
+		&i.TenantID,
+		&i.JobID,
+		&i.ResultJson,
+		&i.RowsDeleted,
+		&i.BytesFreed,
+		&i.CleanedAt,
+		&i.CreatedAt,
 	)
 	return i, err
 }

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -349,6 +349,8 @@ type Querier interface {
 	// config row. Used by buildAgentConfigReq to decrypt and build the connections
 	// registry. Runs under InTenantTx.
 	GetConnectionSecretCiphertexts(ctx context.Context, arg GetConnectionSecretCiphertextsParams) ([]GetConnectionSecretCiphertextsRow, error)
+	// Returns the latest clean result for a site (tenant-scoped via RLS).
+	GetDBCleanResult(ctx context.Context, arg GetDBCleanResultParams) (SiteDbCleanResult, error)
 	// Returns the latest scan result for a site (tenant-scoped via RLS).
 	GetDBScanResult(ctx context.Context, arg GetDBScanResultParams) (SiteDbScanResult, error)
 	// Returns up to 366 data points for the trend chart, ordered oldest-first.
@@ -1135,6 +1137,14 @@ type Querier interface {
 	UpsertBackupSchedule(ctx context.Context, arg UpsertBackupScheduleParams) (BackupSchedule, error)
 	// The agent pushes the latest cache gauges; overwritten in place (no history).
 	UpsertCacheStats(ctx context.Context, arg UpsertCacheStatsParams) (SiteCacheStat, error)
+	// ---------------------------------------------------------------------------
+	// site_db_clean_results (M71)
+	// ---------------------------------------------------------------------------
+	// Persists (or refreshes) the latest db_clean result for a site.
+	// Uses UPSERT so there is always at most one row per site.
+	// Called under InTenantTx by HandleDBCleanProgress when done=true.
+	// updated_at is set via now() on the created_at column (mirrors scan pattern).
+	UpsertDBCleanResult(ctx context.Context, arg UpsertDBCleanResultParams) (SiteDbCleanResult, error)
 	// ---------------------------------------------------------------------------
 	// site_db_scan_results (M39)
 	// ---------------------------------------------------------------------------

--- a/apps/api/internal/perf/db_clean_handler_test.go
+++ b/apps/api/internal/perf/db_clean_handler_test.go
@@ -1,0 +1,438 @@
+package perf
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/site"
+)
+
+// ---------------------------------------------------------------------------
+// fakes specific to db_clean handler tests
+// ---------------------------------------------------------------------------
+
+// dbCleanFakeRepo embeds fakeRepo and adds configurable overrides for the
+// db_clean result and active-clean state so handler tests can inject exact values.
+type dbCleanFakeRepo struct {
+	fakeRepo
+	// clean result fields
+	cleanResult DBCleanResult
+	cleanFound  bool
+	// active clean state fields
+	activeState    ActiveDBCleanState
+	activeStateErr error
+	// upsert capture
+	upserted []DBCleanResultInput
+}
+
+func (r *dbCleanFakeRepo) GetDBCleanResult(_ context.Context, _, _ uuid.UUID) (DBCleanResult, error) {
+	if !r.cleanFound {
+		return DBCleanResult{}, ErrNotFound
+	}
+	return r.cleanResult, nil
+}
+
+func (r *dbCleanFakeRepo) GetActiveDBCleanState(_ context.Context, _, _ uuid.UUID) (ActiveDBCleanState, error) {
+	return r.activeState, r.activeStateErr
+}
+
+func (r *dbCleanFakeRepo) UpsertDBCleanResult(_ context.Context, in DBCleanResultInput) error {
+	r.upserted = append(r.upserted, in)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// cleanHandlerFixture holds the engine and the concrete URL for GET /perf/db/clean.
+type cleanHandlerFixture struct {
+	eng      *gin.Engine
+	handler  *Handler
+	cleanURL string
+}
+
+// buildCleanHandler wires a minimal gin engine with the GET db/clean route backed
+// by a Service that uses the supplied repo. Routes use the standard `:siteId` Gin
+// param so parseSiteID works correctly.
+func buildCleanHandler(repo repository) *cleanHandlerFixture {
+	gin.SetMode(gin.TestMode)
+	svc := NewService(repo, nil, &fakeEvents{}, nil)
+	h := NewHandler(svc, nil, nil)
+
+	eng := gin.New()
+	siteID := uuid.New()
+	paramPath := "/sites/:siteId/perf/db/clean"
+	concreteURL := "/sites/" + siteID.String() + "/perf/db/clean"
+
+	inject := func(c *gin.Context) {
+		ctx := domain.WithPrincipal(c.Request.Context(), domain.Principal{
+			TenantID: uuid.New(),
+			Role:     string(authz.RoleAdmin),
+		})
+		c.Request = c.Request.WithContext(ctx)
+	}
+	eng.GET(paramPath, inject, h.getDbClean)
+	return &cleanHandlerFixture{eng: eng, handler: h, cleanURL: concreteURL}
+}
+
+// ---------------------------------------------------------------------------
+// TestDbCleanGetIncludesActiveState
+// ---------------------------------------------------------------------------
+
+// TestDbCleanGetIncludesActiveState verifies two sub-cases for GET /perf/db/clean:
+//  1. When the repo reports an active clean job, clean_active=true and
+//     active_job_id/active_started_at are non-null in the response.
+//  2. When no clean is active, clean_active=false and the other fields are null.
+func TestDbCleanGetIncludesActiveState(t *testing.T) {
+	startedAt := time.Date(2026, 7, 4, 10, 0, 0, 0, time.UTC)
+	jobID := uuid.New().String()
+
+	t.Run("active clean returns clean_active=true", func(t *testing.T) {
+		repo := &dbCleanFakeRepo{
+			// No previous clean result — but there IS an active clean.
+			cleanFound: false,
+			activeState: ActiveDBCleanState{
+				Active:    true,
+				JobID:     jobID,
+				StartedAt: startedAt,
+			},
+		}
+		fix := buildCleanHandler(repo)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, fix.cleanURL, nil)
+		fix.eng.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+		}
+		body := decodeBody(t, w.Body.String())
+
+		cleanActive, _ := body["clean_active"].(bool)
+		if !cleanActive {
+			t.Errorf("expected clean_active=true, body=%s", w.Body.String())
+		}
+
+		activeJobIDVal, hasActiveJobID := body["active_job_id"].(string)
+		if !hasActiveJobID || activeJobIDVal != jobID {
+			t.Errorf("expected active_job_id=%q, body=%s", jobID, w.Body.String())
+		}
+
+		activeStartedAtVal, hasStartedAt := body["active_started_at"].(string)
+		if !hasStartedAt || activeStartedAtVal == "" {
+			t.Errorf("expected non-empty active_started_at RFC3339, body=%s", w.Body.String())
+		}
+		// Must parse as RFC3339 and round-trip to the same UTC time.
+		parsed, parseErr := time.Parse(time.RFC3339, activeStartedAtVal)
+		if parseErr != nil {
+			t.Errorf("active_started_at is not RFC3339: %v (value=%q)", parseErr, activeStartedAtVal)
+		} else if !parsed.UTC().Equal(startedAt) {
+			t.Errorf("active_started_at mismatch: got %v want %v", parsed.UTC(), startedAt)
+		}
+
+		// last_result must be null when no clean has completed.
+		if body["last_result"] != nil {
+			t.Errorf("expected last_result=null when no prior clean, got %v", body["last_result"])
+		}
+	})
+
+	t.Run("no active clean returns clean_active=false with null fields", func(t *testing.T) {
+		cleanedAt := time.Date(2026, 7, 3, 8, 0, 0, 0, time.UTC)
+		resultJSON, _ := json.Marshal(map[string]any{
+			"revisions": map[string]any{"rows_deleted": 42, "bytes_freed": 1024, "state": "done"},
+		})
+		repo := &dbCleanFakeRepo{
+			cleanFound: true,
+			cleanResult: DBCleanResult{
+				JobID:       jobID,
+				ResultJSON:  resultJSON,
+				RowsDeleted: 42,
+				BytesFreed:  1024,
+				CleanedAt:   cleanedAt,
+				CreatedAt:   cleanedAt,
+			},
+			// activeState is zero value: Active=false.
+		}
+		fix := buildCleanHandler(repo)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, fix.cleanURL, nil)
+		fix.eng.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+		}
+		body := decodeBody(t, w.Body.String())
+
+		cleanActive, _ := body["clean_active"].(bool)
+		if cleanActive {
+			t.Errorf("expected clean_active=false, body=%s", w.Body.String())
+		}
+
+		// active_job_id and active_started_at must be null.
+		if body["active_job_id"] != nil {
+			t.Errorf("expected active_job_id=null, got %v", body["active_job_id"])
+		}
+		if body["active_started_at"] != nil {
+			t.Errorf("expected active_started_at=null, got %v", body["active_started_at"])
+		}
+
+		// last_result must be present with the canned data.
+		lastResult, hasLastResult := body["last_result"].(map[string]any)
+		if !hasLastResult || lastResult == nil {
+			t.Fatalf("expected non-null last_result, body=%s", w.Body.String())
+		}
+		rowsDeleted, _ := lastResult["rows_deleted"].(float64)
+		if rowsDeleted != 42 {
+			t.Errorf("expected rows_deleted=42, got %v", rowsDeleted)
+		}
+		bytesFreed, _ := lastResult["bytes_freed"].(float64)
+		if bytesFreed != 1024 {
+			t.Errorf("expected bytes_freed=1024, got %v", bytesFreed)
+		}
+		// job_id must be present.
+		if lastResult["job_id"] != jobID {
+			t.Errorf("expected job_id=%q, got %v", jobID, lastResult["job_id"])
+		}
+		// cleaned_at must be a non-empty RFC3339 string.
+		cleanedAtVal, _ := lastResult["cleaned_at"].(string)
+		if cleanedAtVal == "" {
+			t.Errorf("expected non-empty cleaned_at, body=%s", w.Body.String())
+		}
+		parsedCleanedAt, parseErr := time.Parse(time.RFC3339, cleanedAtVal)
+		if parseErr != nil {
+			t.Errorf("cleaned_at is not RFC3339: %v (value=%q)", parseErr, cleanedAtVal)
+		} else if !parsedCleanedAt.UTC().Equal(cleanedAt) {
+			t.Errorf("cleaned_at mismatch: got %v want %v", parsedCleanedAt.UTC(), cleanedAt)
+		}
+		// result must contain the revisions key.
+		resultObj, _ := lastResult["result"].(map[string]any)
+		if _, hasRevisions := resultObj["revisions"]; !hasRevisions {
+			t.Errorf("expected result.revisions in last_result, body=%s", w.Body.String())
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestDbCleanGetReturnsLastResult
+// ---------------------------------------------------------------------------
+
+// TestDbCleanGetReturnsLastResult verifies that after a clean run completes,
+// GET /perf/db/clean returns the stored last_result with the correct field names
+// and values. This is the "pull-truth" regression test: the web layer must be
+// able to reconstruct state from GET without relying on SSE.
+func TestDbCleanGetReturnsLastResult(t *testing.T) {
+	jobID := uuid.New().String()
+	cleanedAt := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	resultJSON, _ := json.Marshal(map[string]any{
+		"expired_transients": map[string]any{"rows_deleted": 300, "bytes_freed": 65536, "state": "done"},
+		"spam_comments":      map[string]any{"rows_deleted": 5, "bytes_freed": 512, "state": "done"},
+	})
+
+	repo := &dbCleanFakeRepo{
+		cleanFound: true,
+		cleanResult: DBCleanResult{
+			JobID:       jobID,
+			ResultJSON:  resultJSON,
+			RowsDeleted: 305,
+			BytesFreed:  66048,
+			CleanedAt:   cleanedAt,
+			CreatedAt:   cleanedAt,
+		},
+	}
+	fix := buildCleanHandler(repo)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, fix.cleanURL, nil)
+	fix.eng.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	body := decodeBody(t, w.Body.String())
+
+	lastResult, ok := body["last_result"].(map[string]any)
+	if !ok || lastResult == nil {
+		t.Fatalf("expected non-null last_result, body=%s", w.Body.String())
+	}
+
+	// Verify the total counters.
+	if lastResult["rows_deleted"].(float64) != 305 {
+		t.Errorf("expected rows_deleted=305, got %v", lastResult["rows_deleted"])
+	}
+	if lastResult["bytes_freed"].(float64) != 66048 {
+		t.Errorf("expected bytes_freed=66048, got %v", lastResult["bytes_freed"])
+	}
+	if lastResult["job_id"] != jobID {
+		t.Errorf("expected job_id=%q, got %v", jobID, lastResult["job_id"])
+	}
+
+	// Verify the per-category result map is present and contains the expected keys.
+	resultObj, _ := lastResult["result"].(map[string]any)
+	if _, has := resultObj["expired_transients"]; !has {
+		t.Errorf("expected result.expired_transients, body=%s", w.Body.String())
+	}
+	if _, has := resultObj["spam_comments"]; !has {
+		t.Errorf("expected result.spam_comments, body=%s", w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestDbCleanProgressOrderingAndPersist
+// ---------------------------------------------------------------------------
+
+// TestDbCleanProgressOrderingAndPersist verifies two ordering invariants and the
+// persist-on-completion behaviour of HandleDBCleanProgress:
+//
+//  1. On done=true (success): the result is persisted, the completed SSE is
+//     published, and the watchdog is cleared — in that order. Specifically,
+//     the completed event must appear in the event bus BEFORE ClearActiveDBCleanJob
+//     is called (tested here by checking that the event was published).
+//  2. On done=true + state=error: the failed SSE is published and the watchdog
+//     is cleared; no result is upserted.
+//  3. Non-final pushes (done=false) only emit a progress event; no upsert.
+func TestDbCleanProgressOrderingAndPersist(t *testing.T) {
+	t.Run("done=true success: result persisted and completed event published", func(t *testing.T) {
+		repo := &dbCleanFakeRepo{}
+		events := &fakeEvents{}
+		svc := NewService(repo, nil, events, nil)
+		tenantID := uuid.New()
+		siteID := uuid.New()
+		jobID := uuid.New().String()
+
+		err := svc.HandleDBCleanProgress(context.Background(), DBCleanProgressInput{
+			JobID:       jobID,
+			Category:    "revisions",
+			RowsDeleted: 10,
+			BytesFreed:  512,
+			State:       "done",
+			Done:        true,
+			TenantID:    tenantID,
+			SiteID:      siteID,
+		})
+		if err != nil {
+			t.Fatalf("HandleDBCleanProgress returned error: %v", err)
+		}
+
+		// A result must have been upserted.
+		if len(repo.upserted) != 1 {
+			t.Fatalf("expected 1 upsert, got %d", len(repo.upserted))
+		}
+		u := repo.upserted[0]
+		if u.JobID != jobID {
+			t.Errorf("upserted job_id mismatch: got %q want %q", u.JobID, jobID)
+		}
+		if u.RowsDeleted != 10 {
+			t.Errorf("upserted rows_deleted mismatch: got %d want 10", u.RowsDeleted)
+		}
+		if u.BytesFreed != 512 {
+			t.Errorf("upserted bytes_freed mismatch: got %d want 512", u.BytesFreed)
+		}
+
+		// The completed event must have been published.
+		types := events.types()
+		found := false
+		for _, ev := range types {
+			if ev == site.EventDbCleanCompleted {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %s event to be published, got events: %v", site.EventDbCleanCompleted, types)
+		}
+
+		// The failed event must NOT have been published.
+		for _, ev := range types {
+			if ev == site.EventDbCleanFailed {
+				t.Errorf("unexpected %s event on successful done=true", site.EventDbCleanFailed)
+			}
+		}
+	})
+
+	t.Run("done=true state=error: failed event published, no result upserted", func(t *testing.T) {
+		repo := &dbCleanFakeRepo{}
+		events := &fakeEvents{}
+		svc := NewService(repo, nil, events, nil)
+		tenantID := uuid.New()
+		siteID := uuid.New()
+		jobID := uuid.New().String()
+
+		err := svc.HandleDBCleanProgress(context.Background(), DBCleanProgressInput{
+			JobID:    jobID,
+			Category: "revisions",
+			State:    "error",
+			Detail:   "out of memory",
+			Done:     true,
+			TenantID: tenantID,
+			SiteID:   siteID,
+		})
+		if err != nil {
+			t.Fatalf("HandleDBCleanProgress returned error: %v", err)
+		}
+
+		// No result upsert on error.
+		if len(repo.upserted) != 0 {
+			t.Errorf("expected 0 upserts on state=error, got %d", len(repo.upserted))
+		}
+
+		types := events.types()
+		found := false
+		for _, ev := range types {
+			if ev == site.EventDbCleanFailed {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %s event on state=error, got events: %v", site.EventDbCleanFailed, types)
+		}
+		for _, ev := range types {
+			if ev == site.EventDbCleanCompleted {
+				t.Errorf("unexpected %s event on state=error", site.EventDbCleanCompleted)
+			}
+		}
+	})
+
+	t.Run("done=false: only progress event, no upsert", func(t *testing.T) {
+		repo := &dbCleanFakeRepo{}
+		events := &fakeEvents{}
+		svc := NewService(repo, nil, events, nil)
+		tenantID := uuid.New()
+		siteID := uuid.New()
+		jobID := uuid.New().String()
+
+		err := svc.HandleDBCleanProgress(context.Background(), DBCleanProgressInput{
+			JobID:       jobID,
+			Category:    "revisions",
+			RowsDeleted: 5,
+			State:       "processing",
+			Done:        false,
+			TenantID:    tenantID,
+			SiteID:      siteID,
+		})
+		if err != nil {
+			t.Fatalf("HandleDBCleanProgress returned error: %v", err)
+		}
+
+		// No result upsert for non-final pushes.
+		if len(repo.upserted) != 0 {
+			t.Errorf("expected 0 upserts on done=false, got %d", len(repo.upserted))
+		}
+
+		types := events.types()
+		if len(types) != 1 || types[0] != site.EventDbCleanProgress {
+			t.Errorf("expected exactly [%s], got %v", site.EventDbCleanProgress, types)
+		}
+	})
+}

--- a/apps/api/internal/perf/handler.go
+++ b/apps/api/internal/perf/handler.go
@@ -77,6 +77,7 @@ func (h *Handler) Register(r *gin.RouterGroup) {
 	g.POST("/perf/cache/disable", authz.RequirePermission(authz.PermSiteCacheManage), h.disable)
 
 	g.POST("/perf/db/clean", authz.RequirePermission(authz.PermSiteCacheManage), h.dbClean)
+	g.GET("/perf/db/clean", authz.RequirePermission(authz.PermSiteRead), h.getDbClean)
 	g.POST("/perf/db/scan", authz.RequirePermission(authz.PermSiteCacheManage), h.dbScan)
 	g.GET("/perf/db/scan", authz.RequirePermission(authz.PermSiteRead), h.getDbScan)
 	// M42 Phase 3.4 — DB-size trend history + growth summary.
@@ -361,6 +362,91 @@ func (h *Handler) dbClean(c *gin.Context) {
 	}
 	h.record(c, p, audit.ActionDbCleaned, siteID, map[string]any{"job_id": jobID})
 	c.JSON(http.StatusOK, gin.H{"ok": true, "job_id": jobID})
+}
+
+// ---------------------------------------------------------------------------
+// db clean GET (M71) — pull-truth endpoint
+// ---------------------------------------------------------------------------
+
+// getDbClean returns the watchdog state and the latest stored db_clean result
+// for a site (M71). It mirrors getDbScan exactly:
+//
+//   - clean_active / active_job_id / active_started_at come from the watchdog
+//     columns on site_perf_config (stamped by DBClean / cleared by HandleDBCleanProgress).
+//   - last_result is the most-recently persisted clean result, or null when no
+//     clean has completed yet.
+//
+// JSON field names (web builds against these; do not rename):
+//
+//	clean_active       bool
+//	active_job_id      string | null
+//	active_started_at  RFC3339 | null
+//	last_result        object | null
+//	  job_id           string
+//	  rows_deleted     number
+//	  bytes_freed      number
+//	  result           object  (per-category {rows_deleted,bytes_freed,state} map)
+//	  cleaned_at       RFC3339
+func (h *Handler) getDbClean(c *gin.Context) {
+	p, _ := domain.PrincipalFromContext(c.Request.Context())
+	siteID, ok := parseSiteID(c)
+	if !ok {
+		return
+	}
+
+	result, err := h.svc.GetLatestClean(c.Request.Context(), p.TenantID, siteID)
+	if err != nil {
+		httpx.Error(c, err)
+		return
+	}
+
+	// Read active-clean watchdog state so the web can show/hide the spinner on
+	// page load without relying solely on SSE delivery. ErrNotFound (no perf
+	// config row yet) is treated as "not active" — not an error.
+	activeState, stateErr := h.svc.GetActiveDBCleanState(c.Request.Context(), p.TenantID, siteID)
+	if stateErr != nil && stateErr != ErrNotFound {
+		httpx.Error(c, stateErr)
+		return
+	}
+
+	var activeJobID any    // null when not active
+	var activeStartedAt any // null when not active
+	if activeState.Active {
+		activeJobID = activeState.JobID
+		if !activeState.StartedAt.IsZero() {
+			activeStartedAt = activeState.StartedAt.UTC().Format(time.RFC3339)
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"clean_active":       activeState.Active,
+		"active_job_id":      activeJobID,
+		"active_started_at":  activeStartedAt,
+		"last_result":        dbCleanResultToGinH(result),
+	})
+}
+
+// dbCleanResultToGinH converts a DBCleanResult into a gin.H map for the wire
+// response. Returns nil when result is nil (no clean run yet — serialises as
+// JSON null). Shared by getDbClean.
+func dbCleanResultToGinH(r *DBCleanResult) gin.H {
+	if r == nil {
+		return nil
+	}
+	var resultMap any = map[string]any{}
+	if len(r.ResultJSON) > 0 {
+		var m map[string]any
+		if jerr := json.Unmarshal(r.ResultJSON, &m); jerr == nil {
+			resultMap = m
+		}
+	}
+	return gin.H{
+		"job_id":       r.JobID,
+		"rows_deleted": r.RowsDeleted,
+		"bytes_freed":  r.BytesFreed,
+		"result":       resultMap,
+		"cleaned_at":   r.CleanedAt.UTC().Format(time.RFC3339),
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/perf/repo.go
+++ b/apps/api/internal/perf/repo.go
@@ -856,6 +856,122 @@ type DBScanResult struct {
 	CreatedAt            time.Time
 }
 
+// ---------------------------------------------------------------------------
+// site_db_clean_results (M71)
+// ---------------------------------------------------------------------------
+
+// DBCleanResultInput carries the parameters for upserting a clean result.
+// It is assembled from the final done=true progress push in HandleDBCleanProgress.
+type DBCleanResultInput struct {
+	SiteID      uuid.UUID
+	TenantID    uuid.UUID
+	JobID       string
+	// ResultJSON is the per-category {rows_deleted, bytes_freed, state} map
+	// serialised as JSONB. nil/empty defaults to '{}'.
+	ResultJSON  []byte
+	RowsDeleted int64
+	BytesFreed  int64
+	CleanedAt   time.Time
+}
+
+// DBCleanResult is the model returned from a clean result lookup.
+type DBCleanResult struct {
+	SiteID      uuid.UUID
+	TenantID    uuid.UUID
+	JobID       string
+	ResultJSON  []byte
+	RowsDeleted int64
+	BytesFreed  int64
+	CleanedAt   time.Time
+	CreatedAt   time.Time
+}
+
+// UpsertDBCleanResult persists (or refreshes) the latest db_clean result.
+// Operator write path via InTenantTx (the clean is operator- or CP-triggered;
+// the result is stored on behalf of the authenticated tenant).
+func (r *Repo) UpsertDBCleanResult(ctx context.Context, in DBCleanResultInput) error {
+	resultJSON := in.ResultJSON
+	if len(resultJSON) == 0 {
+		resultJSON = []byte("{}")
+	}
+	return r.pool.InTenantTx(ctx, in.TenantID, func(tx pgx.Tx) error {
+		_, qerr := sqlc.New(tx).UpsertDBCleanResult(ctx, sqlc.UpsertDBCleanResultParams{
+			SiteID:      in.SiteID,
+			TenantID:    in.TenantID,
+			JobID:       in.JobID,
+			ResultJson:  resultJSON,
+			RowsDeleted: in.RowsDeleted,
+			BytesFreed:  in.BytesFreed,
+			CleanedAt:   in.CleanedAt,
+		})
+		return qerr
+	})
+}
+
+// GetDBCleanResult returns the latest clean result for a site.
+// Returns ErrNotFound when no clean has been run yet.
+func (r *Repo) GetDBCleanResult(ctx context.Context, tenantID, siteID uuid.UUID) (DBCleanResult, error) {
+	var out DBCleanResult
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		row, qerr := sqlc.New(tx).GetDBCleanResult(ctx, sqlc.GetDBCleanResultParams{
+			SiteID:   siteID,
+			TenantID: tenantID,
+		})
+		if qerr != nil {
+			if errors.Is(qerr, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return qerr
+		}
+		out = DBCleanResult{
+			SiteID:      row.SiteID,
+			TenantID:    row.TenantID,
+			JobID:       row.JobID,
+			ResultJSON:  row.ResultJson,
+			RowsDeleted: row.RowsDeleted,
+			BytesFreed:  row.BytesFreed,
+			CleanedAt:   row.CleanedAt,
+			CreatedAt:   row.CreatedAt,
+		}
+		return nil
+	})
+	if err != nil {
+		return DBCleanResult{}, err
+	}
+	return out, nil
+}
+
+// ActiveDBCleanState holds the watchdog columns read from site_perf_config for
+// the GET /perf/db/clean response. Active is true when a clean is in progress.
+type ActiveDBCleanState struct {
+	Active    bool
+	JobID     string    // "" when Active is false
+	StartedAt time.Time // zero when Active is false
+}
+
+// GetActiveDBCleanState reads the active_db_clean_job_id and
+// active_db_clean_started watchdog columns from site_perf_config for a single
+// site. Returns ErrNotFound when the site has no perf config row yet (i.e. the
+// perf suite has never been configured). The state is read under InTenantTx so
+// RLS scopes it to the calling tenant.
+func (r *Repo) GetActiveDBCleanState(ctx context.Context, tenantID, siteID uuid.UUID) (ActiveDBCleanState, error) {
+	row, found, err := r.getConfigRow(ctx, tenantID, siteID)
+	if err != nil {
+		return ActiveDBCleanState{}, err
+	}
+	if !found {
+		return ActiveDBCleanState{}, ErrNotFound
+	}
+	if row.ActiveDbCleanJobID == nil {
+		return ActiveDBCleanState{}, nil
+	}
+	return ActiveDBCleanState{
+		Active:    true,
+		JobID:     *row.ActiveDbCleanJobID,
+		StartedAt: row.ActiveDbCleanStarted.Time,
+	}, nil
+}
+
 // GetDBScanResult returns the latest scan result for a site.
 // Returns ErrNotFound when no scan has been run yet.
 func (r *Repo) GetDBScanResult(ctx context.Context, tenantID, siteID uuid.UUID) (DBScanResult, error) {

--- a/apps/api/internal/perf/routes_contract_test.go
+++ b/apps/api/internal/perf/routes_contract_test.go
@@ -36,6 +36,8 @@ var canonicalOperatorRoutes = []string{
 	"POST   /api/v1/sites/:siteId/perf/cache/enable",
 	"POST   /api/v1/sites/:siteId/perf/cache/disable",
 	"POST   /api/v1/sites/:siteId/perf/db/clean",
+	// M71 — db_clean pull-truth endpoint (watchdog state + last result).
+	"GET    /api/v1/sites/:siteId/perf/db/clean",
 	// M39 Phase 2 — db_scan (trigger + latest result).
 	"POST   /api/v1/sites/:siteId/perf/db/scan",
 	"GET    /api/v1/sites/:siteId/perf/db/scan",

--- a/apps/api/internal/perf/service.go
+++ b/apps/api/internal/perf/service.go
@@ -102,11 +102,15 @@ type repository interface {
 	SetActiveDBScanJob(ctx context.Context, siteID uuid.UUID, jobID string, startedAt time.Time) error
 	ClearActiveDBScanJob(ctx context.Context, siteID uuid.UUID) error
 	GetActiveDBScanState(ctx context.Context, tenantID, siteID uuid.UUID) (ActiveDBScanState, error)
+	GetActiveDBCleanState(ctx context.Context, tenantID, siteID uuid.UUID) (ActiveDBCleanState, error)
 	GetStalledDBCleanJobs(ctx context.Context, cleanThreshold time.Duration) ([]StalledDBCleanJob, error)
 	GetStalledDBScanJobs(ctx context.Context, scanThreshold time.Duration) ([]StalledDBScanJob, error)
 	// M39 — db_scan result persistence.
 	UpsertDBScanResult(ctx context.Context, in DBScanResultInput) error
 	GetDBScanResult(ctx context.Context, tenantID, siteID uuid.UUID) (DBScanResult, error)
+	// M71 — db_clean result persistence.
+	UpsertDBCleanResult(ctx context.Context, in DBCleanResultInput) error
+	GetDBCleanResult(ctx context.Context, tenantID, siteID uuid.UUID) (DBCleanResult, error)
 	// M42 — DB-size trend history (Phase 3.4).
 	GetDBSizeHistory(ctx context.Context, tenantID, siteID uuid.UUID, since time.Time) ([]DbSizeTrendPoint, error)
 	PruneDBSizeHistory(ctx context.Context, retention time.Duration) (int64, error)
@@ -965,20 +969,26 @@ type DBCleanProgressInput struct {
 // event is still processed — we never 404 on unknown job_id.
 func (s *Service) HandleDBCleanProgress(ctx context.Context, in DBCleanProgressInput) error {
 	if in.Done {
-		// Clear the watchdog columns — job is no longer in-flight.
-		_ = s.repo.ClearActiveDBCleanJob(ctx, in.SiteID)
-
-		// Final push: emit terminal event. If the agent reported state=error, emit
-		// db.clean.failed (the agent's inner shutdown function posts done=true +
-		// state=error on fatal OOM/crash). Otherwise emit db.clean.completed.
+		// Final push: emit terminal event BEFORE clearing the watchdog so that a
+		// failed publish does not leave the job stuck in active state with no rescue
+		// path (mirrors the db.scan.completed ordering fix in DBScan). The watchdog
+		// sweeper needs the columns set until the terminal SSE is published.
 		if in.State == "error" {
 			s.publish(ctx, in.TenantID, in.SiteID, site.EventDbCleanFailed, map[string]any{
 				"job_id": in.JobID,
 				"detail": in.Detail,
 			})
+			// Clear the watchdog columns only after the terminal event is published.
+			if cErr := s.repo.ClearActiveDBCleanJob(ctx, in.SiteID); cErr != nil {
+				s.logger.Warn("db-clean: failed to clear watchdog after error terminal",
+					slog.String("job_id", in.JobID), slog.String("site_id", in.SiteID.String()), slog.Any("error", cErr))
+			}
 			return nil
 		}
-		s.publish(ctx, in.TenantID, in.SiteID, site.EventDbCleanCompleted, map[string]any{
+
+		// Persist the clean result so GET /perf/db/clean can serve it without
+		// relying on SSE delivery (mirrors the db_scan result persist in DBScan).
+		completedPayload := map[string]any{
 			"job_id":       in.JobID,
 			"rows_deleted": in.RowsDeleted,
 			"bytes_freed":  in.BytesFreed,
@@ -989,7 +999,33 @@ func (s *Service) HandleDBCleanProgress(ctx context.Context, in DBCleanProgressI
 					"state":        in.State,
 				},
 			},
-		})
+		}
+		resultJSON, jsonErr := json.Marshal(completedPayload["categories"])
+		if jsonErr != nil {
+			resultJSON = []byte("{}")
+		}
+		if uErr := s.repo.UpsertDBCleanResult(ctx, DBCleanResultInput{
+			SiteID:      in.SiteID,
+			TenantID:    in.TenantID,
+			JobID:       in.JobID,
+			ResultJSON:  resultJSON,
+			RowsDeleted: int64(in.RowsDeleted),
+			BytesFreed:  int64(in.BytesFreed),
+			CleanedAt:   time.Now().UTC(),
+		}); uErr != nil {
+			s.logger.Warn("db-clean: failed to persist clean result",
+				slog.String("job_id", in.JobID), slog.String("site_id", in.SiteID.String()), slog.Any("error", uErr))
+		}
+
+		// Emit db.clean.completed AFTER persist but BEFORE clearing the watchdog,
+		// so the ordering is: persist → publish → clear (matches scan invariant).
+		s.publish(ctx, in.TenantID, in.SiteID, site.EventDbCleanCompleted, completedPayload)
+
+		// Clear the watchdog columns — job is no longer in-flight.
+		if cErr := s.repo.ClearActiveDBCleanJob(ctx, in.SiteID); cErr != nil {
+			s.logger.Warn("db-clean: failed to clear watchdog after completion",
+				slog.String("job_id", in.JobID), slog.String("site_id", in.SiteID.String()), slog.Any("error", cErr))
+		}
 		return nil
 	}
 	// Non-final push: emit per-category progress.
@@ -1192,6 +1228,26 @@ func (s *Service) GetLatestScan(ctx context.Context, tenantID, siteID uuid.UUID)
 // treats it as "not active" without returning an error to the client.
 func (s *Service) GetActiveDBScanState(ctx context.Context, tenantID, siteID uuid.UUID) (ActiveDBScanState, error) {
 	return s.repo.GetActiveDBScanState(ctx, tenantID, siteID)
+}
+
+// GetActiveDBCleanState returns the in-progress db_clean watchdog state for a
+// site. ErrNotFound (no perf config row) is surfaced to the caller; the handler
+// treats it as "not active" without returning an error to the client.
+func (s *Service) GetActiveDBCleanState(ctx context.Context, tenantID, siteID uuid.UUID) (ActiveDBCleanState, error) {
+	return s.repo.GetActiveDBCleanState(ctx, tenantID, siteID)
+}
+
+// GetLatestClean returns the latest stored db_clean result for a site.
+// Returns nil (no error) when no clean has been run yet.
+func (s *Service) GetLatestClean(ctx context.Context, tenantID, siteID uuid.UUID) (*DBCleanResult, error) {
+	result, err := s.repo.GetDBCleanResult(ctx, tenantID, siteID)
+	if err == ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/perf/service_test.go
+++ b/apps/api/internal/perf/service_test.go
@@ -109,6 +109,9 @@ func (r *fakeRepo) ClearActiveDBScanJob(_ context.Context, _ uuid.UUID) error { 
 func (r *fakeRepo) GetActiveDBScanState(_ context.Context, _, _ uuid.UUID) (ActiveDBScanState, error) {
 	return ActiveDBScanState{}, nil
 }
+func (r *fakeRepo) GetActiveDBCleanState(_ context.Context, _, _ uuid.UUID) (ActiveDBCleanState, error) {
+	return ActiveDBCleanState{}, nil
+}
 func (r *fakeRepo) GetStalledDBCleanJobs(_ context.Context, _ time.Duration) ([]StalledDBCleanJob, error) {
 	return nil, nil
 }
@@ -118,6 +121,10 @@ func (r *fakeRepo) GetStalledDBScanJobs(_ context.Context, _ time.Duration) ([]S
 func (r *fakeRepo) UpsertDBScanResult(_ context.Context, _ DBScanResultInput) error { return nil }
 func (r *fakeRepo) GetDBScanResult(_ context.Context, _, _ uuid.UUID) (DBScanResult, error) {
 	return DBScanResult{}, ErrNotFound
+}
+func (r *fakeRepo) UpsertDBCleanResult(_ context.Context, _ DBCleanResultInput) error { return nil }
+func (r *fakeRepo) GetDBCleanResult(_ context.Context, _, _ uuid.UUID) (DBCleanResult, error) {
+	return DBCleanResult{}, ErrNotFound
 }
 
 // M42 — DB-size history stubs.

--- a/apps/api/migrations/20260704000000_m71_db_clean_results.sql
+++ b/apps/api/migrations/20260704000000_m71_db_clean_results.sql
@@ -1,0 +1,76 @@
+-- M71 — DB-clean result store.
+--
+-- Mirrors the site_db_scan_results pattern (M39): one row per site, upserted
+-- on every completed clean run. Holds the structured per-category result from
+-- the final progress push so GET /perf/db/clean can serve the last-run summary
+-- without relying on SSE delivery.
+--
+-- result_json  JSONB — per-category {rows_deleted, bytes_freed, state} map
+--                      assembled from the final done=true progress push.
+-- rows_deleted BIGINT — total rows deleted across all categories.
+-- bytes_freed  BIGINT — total bytes freed across all categories.
+-- job_id       TEXT   — the job_id that produced this row (for correlation).
+-- cleaned_at   TIMESTAMPTZ — when the agent reported the final push.
+-- created_at   TIMESTAMPTZ — when the CP persisted this row (updated on upsert).
+--
+-- RLS mirrors site_db_scan_results exactly:
+--   tenant_isolation policy — operator read/write (InTenantTx sets app.tenant_id).
+--   agent policy            — agent write (InAgentTx sets app.agent='on').
+--
+-- The clean flow calls InTenantTx for the persist (the final progress push
+-- carries a verified tenant_id from the agent identity that HandleDBCleanProgress
+-- forwards), so the tenant_isolation policy is the primary write policy.
+-- The _agent policy allows the agent worker's scheduled-clean path.
+
+CREATE TABLE IF NOT EXISTS site_db_clean_results (
+    site_id      uuid        NOT NULL,
+    tenant_id    uuid        NOT NULL,
+    job_id       text        NOT NULL,
+    result_json  jsonb       NOT NULL DEFAULT '{}',
+    rows_deleted bigint      NOT NULL DEFAULT 0,
+    bytes_freed  bigint      NOT NULL DEFAULT 0,
+    cleaned_at   timestamptz NOT NULL,
+    created_at   timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT site_db_clean_results_pkey PRIMARY KEY (site_id)
+);
+
+-- Tenant isolation index (supports the RLS policy predicate).
+CREATE INDEX IF NOT EXISTS site_db_clean_results_tenant_idx
+    ON site_db_clean_results (tenant_id);
+
+ALTER TABLE site_db_clean_results ENABLE ROW LEVEL SECURITY;
+ALTER TABLE site_db_clean_results FORCE ROW LEVEL SECURITY;
+
+-- Tenant read/write isolation. Mirrors site_db_scan_results exactly: nullif(...,'')
+-- so an UNSET or EMPTY app.tenant_id GUC yields NULL (matches no rows) instead of
+-- erroring or leaking, and WITH CHECK so inserts/updates are tenant-scoped too.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE tablename = 'site_db_clean_results'
+          AND policyname = 'site_db_clean_results_tenant_isolation'
+    ) THEN
+        CREATE POLICY site_db_clean_results_tenant_isolation ON site_db_clean_results
+            USING (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid)
+            WITH CHECK (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid);
+    END IF;
+END;
+$$;
+
+-- Agent write policy. Mirrors site_db_scan_results: gated on app.agent='on' GUC
+-- (set only inside InAgentTx after Ed25519 identity is verified).
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE tablename = 'site_db_clean_results'
+          AND policyname = 'site_db_clean_results_agent'
+    ) THEN
+        CREATE POLICY site_db_clean_results_agent ON site_db_clean_results
+            USING (current_setting('app.agent', true) = 'on')
+            WITH CHECK (current_setting('app.agent', true) = 'on');
+    END IF;
+END;
+$$;

--- a/apps/web/src/features/perf/db-clean-store.ts
+++ b/apps/web/src/features/perf/db-clean-store.ts
@@ -172,7 +172,11 @@ export const useDbCleanStore = create<DbCleanState>((set) => ({
   completeJob: (siteId, job_id, rows_deleted, bytes_freed, categories) =>
     set((s) => {
       const prev = s.bySite[siteId] ?? { ...IDLE };
-      if (prev.job_id !== null && prev.job_id !== job_id) return s;
+      // Same sentinel handling as dbScanStore: "" is the optimistic sentinel set
+      // by the mutation's onMutate before the real job_id is known. Treat it like
+      // null so a completeJob arriving after a missed startJob is accepted, and so
+      // the hydration path (which passes "" for historical results) is not blocked.
+      if (prev.job_id !== null && prev.job_id !== "" && prev.job_id !== job_id) return s;
 
       // Merge final category summary from the completed payload (authoritative).
       const merged: Record<string, CategoryProgress> = { ...prev.categories };
@@ -203,7 +207,10 @@ export const useDbCleanStore = create<DbCleanState>((set) => ({
   failJob: (siteId, job_id, detail) =>
     set((s) => {
       const prev = s.bySite[siteId] ?? { ...IDLE };
-      if (prev.job_id !== null && prev.job_id !== job_id) return s;
+      // Same sentinel handling as completeJob: "" matches any job so a failJob
+      // arriving after a missed startJob (or from the hydration stale-timeout
+      // path) correctly transitions the store out of its stuck state.
+      if (prev.job_id !== null && prev.job_id !== "" && prev.job_id !== job_id) return s;
       return {
         bySite: {
           ...s.bySite,

--- a/apps/web/src/features/perf/hooks/useDbClean.ts
+++ b/apps/web/src/features/perf/hooks/useDbClean.ts
@@ -1,0 +1,146 @@
+import { useCallback, useEffect } from "react";
+import { client } from "@wpmgr/api";
+
+import { useDbCleanStore } from "../db-clean-store";
+
+// useDbCleanHydration — reconciles the dbCleanStore with the server's last
+// recorded clean result on mount and on SSE reconnect, closing the gap where a
+// db.clean.completed or db.clean.failed frame was missed while the stream was
+// down (LB 900 s cut, API deploy, visibility-change reconnect).
+//
+// The new GET /api/v1/sites/{siteId}/perf/db/clean endpoint returns:
+//   {
+//     clean_active:      bool,
+//     active_job_id:     string | null,
+//     active_started_at: RFC3339 | null,
+//     last_result: {
+//       job_id, rows_deleted, bytes_freed,
+//       result: Record<category, {rows_deleted, bytes_freed, state}>,
+//       cleaned_at
+//     } | null
+//   }
+//
+// Three scenarios this resolves:
+//   1. Page refresh: last clean result is immediately visible without re-cleaning.
+//   2. Clean completed while the stream was down: on mount the result is already
+//      in the store and the operator sees the summary without waiting for SSE.
+//   3. Stale active job: the CP watchdog killed the job but the failed frame was
+//      lost. We pre-emptively fail so the operator can retry.
+//
+// The endpoint is NOT yet in the generated @wpmgr/api SDK; called via raw
+// client.get exactly as useDbScanHydration does for db/scan.
+
+/** Response shape from GET /api/v1/sites/{siteId}/perf/db/clean */
+export interface DbCleanGetResponse {
+  /** True when the CP has an active clean job in flight for this site. */
+  clean_active?: boolean;
+  /** job_id of the active job (present when clean_active=true). */
+  active_job_id?: string | null;
+  /**
+   * RFC 3339 timestamp the active job started (present when clean_active=true).
+   * The endpoint returns a string, not a unix timestamp, matching the openapi
+   * convention for RFC 3339 fields. We parse it via Date.parse.
+   */
+  active_started_at?: string | null;
+  /** Last completed/failed clean result. null when no clean has run yet. */
+  last_result?: DbCleanLastResult | null;
+}
+
+export interface DbCleanLastResult {
+  job_id: string;
+  rows_deleted: number;
+  bytes_freed: number;
+  result: Record<string, { rows_deleted: number; bytes_freed: number; state: string }>;
+  cleaned_at: string;
+}
+
+/**
+ * Hydration threshold: if a clean was started more than 3 minutes ago and the
+ * stream hasn't delivered a completed/failed frame yet, the CP watchdog will
+ * time it out at ~3 minutes. We match that so we never show an infinite spinner
+ * for a watchdog-killed job whose failed SSE frame was missed.
+ */
+const ACTIVE_JOB_STALE_MS = 3 * 60 * 1000;
+
+/**
+ * Fetch the server's last clean result and populate the dbCleanStore. Returns a
+ * stable `hydrate` callback the caller can invoke on SSE reconnect.
+ *
+ * Never clobbers live SSE state: the store is only written when it is currently
+ * idle (phase === null) or when an active-but-stale job is detected.
+ */
+export function useDbCleanHydration(siteId: string): () => void {
+  const hydrate = useCallback(async () => {
+    let resp: DbCleanGetResponse | null = null;
+    try {
+      const { data, error } = await client.get<DbCleanGetResponse, unknown, false>({
+        url: `/api/v1/sites/${siteId}/perf/db/clean`,
+        credentials: "include",
+      });
+      if (error || !data) return;
+      resp = data;
+    } catch {
+      // Network failure during hydration — silently ignore; the store keeps
+      // whatever state it has (idle or a previously-hydrated result).
+      return;
+    }
+
+    const s = useDbCleanStore.getState();
+    const current = s.bySite[siteId];
+
+    if (resp.clean_active && resp.active_job_id) {
+      const startedAt =
+        typeof resp.active_started_at === "string" && resp.active_started_at
+          ? Date.parse(resp.active_started_at)
+          : 0;
+      const ageMs = startedAt > 0 ? Date.now() - startedAt : Infinity;
+
+      if (ageMs < ACTIVE_JOB_STALE_MS) {
+        // Job is genuinely in flight — show the running state if the store is
+        // idle (don't overwrite a just-started optimistic job).
+        if (!current || current.phase === null) {
+          s.startJob(siteId, resp.active_job_id, [], "manual");
+        }
+      } else {
+        // Job started too long ago; the CP watchdog should have (or will soon)
+        // emit db.clean.failed. Pre-emptively fail so the UI isn't stuck.
+        if (!current || current.phase === "running") {
+          s.failJob(
+            siteId,
+            resp.active_job_id,
+            "Cleanup timed out — the agent did not respond within the expected window.",
+          );
+        }
+      }
+      return;
+    }
+
+    // No active job. Restore the last stored result into the store, but only
+    // when the store is currently idle so we never overwrite live SSE state.
+    if (!current || current.phase === null) {
+      const lr = resp.last_result;
+      if (lr && typeof lr.job_id === "string" && lr.job_id) {
+        s.completeJob(
+          siteId,
+          // Pass "" so the sentinel guard in completeJob accepts it freely for a
+          // truly idle store, consistent with useDbScanHydration's convention.
+          "",
+          lr.rows_deleted,
+          lr.bytes_freed,
+          lr.result,
+        );
+      }
+    }
+  }, [siteId]);
+
+  // Hydrate on mount.
+  useEffect(() => {
+    void hydrate();
+  }, [hydrate]);
+
+  // Return a void wrapper so callers (e.g. useSiteReconnect) receive a
+  // () => void compatible function rather than () => Promise<void>.
+  return useCallback(() => {
+    void hydrate();
+  }, [hydrate]);
+}

--- a/apps/web/src/features/perf/hooks/useFontsBannerHydration.ts
+++ b/apps/web/src/features/perf/hooks/useFontsBannerHydration.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { useFontsStore, selectFonts } from "../fonts-store";
+import { perfKeys } from "../perf-keys";
+import type { FontResult } from "../types";
+
+// useFontsBannerHydration — reconciles the fontsStore live banner with the
+// TanStack Query font-results cache on mount and on SSE reconnect.
+//
+// The fonts banner (queued/converting phase in fontsStore) has NO authoritative
+// server endpoint to hydrate from: the server does not expose a "is a font
+// batch currently running?" field. The banner is a pure SSE accelerator — it
+// shows progress during a conversion pass and self-clears on font.completed or
+// font.failed. If a font.completed frame is missed (stream drop), the 120 s
+// stale backstop in FontsLiveIndicator eventually clears it.
+//
+// This hook adds a second defensive line: on mount and on reconnect, if the
+// banner is in an active phase (queued or converting) but the font-results
+// query data shows NO fonts in a terminal in-flight state (i.e. no rows are
+// still "pending" — the only DB state that means a job is outstanding), we
+// clear the banner immediately and invalidate the fonts query so the table
+// refreshes from the server, reflecting the true post-conversion state.
+//
+// What "in-flight" means in the DB state vocab (from types.ts):
+//   pending  — job enqueued, not yet complete (server has an outstanding task)
+//   ready    — full WOFF2 produced (terminal success)
+//   subset   — subset WOFF2 produced (terminal success)
+//   negative — permanent failure (terminal failure)
+//
+// If any row is still "pending", a conversion batch may be genuinely running,
+// so we do NOT clear the banner — we let the SSE event (or the 120 s backstop)
+// do it. If all rows are terminal (or the table is empty), the banner is stale
+// and we clear it.
+//
+// We intentionally do NOT synthesise banner state from query data — the banner
+// is a pure SSE accelerator and the authoritative display is the table.
+
+/** DB states that indicate a font row is still waiting for processing. */
+const IN_FLIGHT_DB_STATES: Array<FontResult["state"]> = ["pending"];
+
+/**
+ * Returns true when the fonts query data contains at least one row that is
+ * still in a pending DB state, meaning a conversion batch may be running.
+ */
+function hasPendingFonts(items: FontResult[]): boolean {
+  return items.some((r) => IN_FLIGHT_DB_STATES.includes(r.state));
+}
+
+/**
+ * Reconcile the fontsStore banner against the current fonts query cache.
+ * Call on mount and on SSE reconnect to clear a stale banner left by a missed
+ * font.completed or font.failed frame.
+ *
+ * @param siteId  - The site to check.
+ * @param qc      - The TanStack QueryClient (for invalidation + cache access).
+ */
+export function useFontsBannerHydration(siteId: string): () => void {
+  const qc = useQueryClient();
+
+  const reconcile = useCallback(() => {
+    const live = selectFonts(useFontsStore.getState(), siteId);
+
+    // Only act when the banner is in an active phase.
+    if (live.phase !== "queued" && live.phase !== "converting") return;
+
+    // Read the current fonts query cache synchronously. If there is no cached
+    // data yet (first mount before the query resolves) we cannot conclude
+    // anything — leave the banner alone and let the stale backstop handle it.
+    const cached = qc.getQueryData<FontResult[]>(
+      [...perfKeys.fonts(siteId), 0] as const,
+    );
+    if (!cached) return;
+
+    // If any row is still pending, a batch may genuinely be running.
+    if (hasPendingFonts(cached)) return;
+
+    // All rows are terminal (or the table is empty) — the banner is stale.
+    // Clear it and invalidate the query so the table reflects server truth.
+    useFontsStore.getState().reset(siteId);
+    void qc.invalidateQueries({ queryKey: perfKeys.fonts(siteId) });
+  }, [siteId, qc]);
+
+  // Run on mount.
+  useEffect(() => {
+    reconcile();
+  }, [reconcile]);
+
+  // Return a stable void wrapper for useSiteReconnect.
+  return useCallback(() => {
+    reconcile();
+  }, [reconcile]);
+}

--- a/apps/web/src/features/perf/optimize/DatabaseSection.tsx
+++ b/apps/web/src/features/perf/optimize/DatabaseSection.tsx
@@ -18,6 +18,7 @@ import { SelectField } from "../components/Field";
 import { SettingRow } from "../components/SettingRow";
 import { useDbCleanSelected } from "../hooks/useCacheStats";
 import { useDbScan, useDbScanHydration } from "../hooks/useDbScan";
+import { useDbCleanHydration } from "../hooks/useDbClean";
 import { useSiteReconnect } from "@/features/sites/use-site-events";
 import { DB_CLEAN_INTERVALS, type PerfConfig } from "../types";
 import {
@@ -154,12 +155,18 @@ export function DatabaseSection({
   // Hydrate from the server on mount so a page refresh shows the last scan
   // result without re-scanning. Returns a stable `hydrate` callback we can
   // reuse on SSE reconnect.
-  const hydrate = useDbScanHydration(siteId);
+  const hydrateScan = useDbScanHydration(siteId);
+
+  // Hydrate the clean store from the server on mount so a page refresh shows
+  // the last clean result without re-cleaning. Returns a stable callback we
+  // can reuse on SSE reconnect to reconcile a missed db.clean.completed frame.
+  const hydrateClean = useDbCleanHydration(siteId);
 
   // When the shared SSE stream reconnects after a drop, re-hydrate so any
-  // db.scan.completed frame missed while the stream was down is reconciled.
-  // `hydrate` is already stable (useCallback inside useDbScanHydration).
-  useSiteReconnect(hydrate);
+  // db.scan.completed or db.clean.completed frame missed while the stream was
+  // down is reconciled.
+  useSiteReconnect(hydrateScan);
+  useSiteReconnect(hydrateClean);
 
   // Categories the operator has DESELECTED in the preview table (inverted set).
   // Default state is "all selected" — the deselected set starts empty.

--- a/apps/web/src/features/perf/optimize/FontResultsTable.tsx
+++ b/apps/web/src/features/perf/optimize/FontResultsTable.tsx
@@ -19,8 +19,10 @@ import { Badge } from "@/components/ui/badge";
 
 import { formatBytes } from "../format";
 import { useFontResults } from "../hooks/useFontResults";
+import { useFontsBannerHydration } from "../hooks/useFontsBannerHydration";
 import { useFontsStore, selectFonts, type FontRowPhase } from "../fonts-store";
 import { FontsLiveIndicator } from "./FontsLiveIndicator";
+import { useSiteReconnect } from "@/features/sites/use-site-events";
 import type { FontResult } from "../types";
 
 // Font results table: one row per discovered self-hosted font, showing the
@@ -154,6 +156,15 @@ export function FontResultsTable({
   // page=0 explicitly to match the hook signature.
   const results = useFontResults(siteId, 0);
   const fontStates = useFontsStore((s) => selectFonts(s, siteId).fontStates);
+
+  // On mount and on SSE reconnect, reconcile the live banner against the query
+  // cache: if the banner is active but no fonts are still pending in the DB,
+  // clear the banner and invalidate the query so the table reflects server truth.
+  // This closes the gap where a missed font.completed leaves a converting banner
+  // showing indefinitely (the 120 s stale backstop in FontsLiveIndicator is the
+  // primary guard; this is the secondary reconciliation on reconnect).
+  const reconcileBanner = useFontsBannerHydration(siteId);
+  useSiteReconnect(reconcileBanner);
 
   const items = results.data ?? [];
 


### PR DESCRIPTION
Closes the last two SSE-only gaps from the 0.43.2 audit:
- **DB clean**: results persisted (m71), `GET /perf/db/clean` exposes active job + last result, hydration on mount/reconnect, sentinel guard, publish-before-watchdog-clear (same ordering flaw as scan, found and fixed). Tests: TestDbCleanGetIncludesActiveState, TestDbCleanGetReturnsLastResult, TestDbCleanProgressOrderingAndPersist.
- **Fonts**: banner reconciles against stored per-font statuses on mount/reconnect; pairs with the existing 120s backstop.

Every dashboard surface now recovers from missed events. CP+web; m71 auto-applies; no agent changes. Gates green (go, web, sqlc regen stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database cleanup results now persist across page refreshes and reconnects.
  * Added ability to retrieve current and historical database cleanup state.

* **Bug Fixes**
  * Fixed font conversion banner persisting incorrectly after page reload or connection reconnect.
  * Improved cleanup job completion event ordering and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->