### PR TITLE
docs: README refresh to v0.43.3 + wp.org submission fixes (esc_sql, zip excludes, plugincheck CI)

### DIFF
--- a/.github/workflows/plugincheck.yml
+++ b/.github/workflows/plugincheck.yml
@@ -43,9 +43,14 @@ jobs:
         run: make agent-zip-wporg VERSION="${{ inputs.version }}"
 
       - name: Run Plugin Check
+        # Runs the check runner directly against the zip built in the previous
+        # step (make agent-plugincheck would rebuild the vendor tree, which
+        # fights the composer cache on CI runners).
         # shell: bash enables pipefail so the tee cannot mask a failing check.
         shell: bash
-        run: make agent-plugincheck VERSION="${{ inputs.version }}" | tee plugincheck-report.txt
+        run: |
+          chmod +x tools/plugincheck/run.sh
+          PLUGIN_ZIP="$PWD/release/fleet-agent-for-wpmgr.zip" ./tools/plugincheck/run.sh | tee plugincheck-report.txt
 
       - name: Upload zip and report
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ agent-zip: agent-vendor ## Package the WordPress agent plugin as a zip (with ifs
 	# Staging under wpmgr-agent/ pins the slug regardless of the .zip filename,
 	# so every upload is recognised as an in-place update of the same plugin.
 	rsync -a --delete \
-		--exclude 'tests/' --exclude 'tools/' --exclude '*.dist' --exclude '.phpunit.cache/' \
+		--exclude 'tests/' --exclude 'tests-e2e/' --exclude 'tools/' --exclude '*.dist' --exclude '.phpunit.cache/' \
 		--exclude '.phpunit.result.cache' --exclude 'composer.lock' \
 		--exclude '.DS_Store' --exclude '*.zip' \
 		--exclude 'patchwork.json' \
@@ -151,7 +151,7 @@ agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip (fl
 	# excluded because wp.org rejects unexpected Markdown files (B4 / C8).
 	# Dev-only files mirror the existing agent-zip excludes.
 	rsync -a --delete \
-		--exclude 'tests/' --exclude 'tools/' --exclude '*.dist' --exclude '.phpunit.cache/' \
+		--exclude 'tests/' --exclude 'tests-e2e/' --exclude 'tools/' --exclude '*.dist' --exclude '.phpunit.cache/' \
 		--exclude '.phpunit.result.cache' --exclude 'composer.lock' \
 		--exclude '.DS_Store' --exclude '*.zip' \
 		--exclude 'phpstan.neon' --exclude 'phpstan-baseline.neon' \

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress sites from one dashboard — all running on infrastructure you control. The control plane is a Go binary with a React dashboard; a lightweight PHP plugin on each managed site handles the work. Everything between the agent and the control plane is Ed25519-signed.
 
+[![Latest release](https://img.shields.io/github/v/release/mosamlife/wpmgr?style=flat)](https://github.com/mosamlife/wpmgr/releases)
+[![License](https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat)](./LICENSE)
+[![CI](https://img.shields.io/github/actions/workflow/status/mosamlife/wpmgr/ci.yml?branch=main&label=CI&style=flat)](https://github.com/mosamlife/wpmgr/actions/workflows/ci.yml)
+
 [![WPMgr — run your whole WordPress fleet from one dashboard you own](docs/images/landing.png)](https://wpmgr.app)
 
 <p align="center">
@@ -12,7 +16,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
   <a href="https://wpmgr.app/docs/">API reference</a>
 </p>
 
-**v0.28.0** — open-source and production-usable for self-hosters.
+**v0.43.3** — open-source and production-usable for self-hosters.
 
 ---
 
@@ -23,13 +27,14 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 - **Live enrollment** — Add a site by URL; paste a one-time code into the agent plugin; the dashboard flips from "Awaiting" to "Connected" automatically, no refresh needed.
 - **Real-time connection state machine** — Six precise states (`pending_enrollment` → `connected` → `degraded` → `disconnected` → `revoked` → `archived`) replace a vague up/down flag. Every transition is written to auditable, hash-chained history.
 - **60 s heartbeat with auto-recovery** — A background sweeper degrades → disconnects silent sites within minutes. A returning agent auto-recovers without operator action.
-- **Fleet SSE stream** — One shared Server-Sent Events stream keeps the entire sites list live (status dots, last-seen counters) without polling. Cursor-based replay catches events missed while offline.
-- **One-click autologin to wp-admin** — Single-use, short-lived, audited EdDSA tokens; no shared passwords. Deep-links straight to Plugins or Themes, or log in as a specific user.
+- **Fleet SSE stream** — One shared Server-Sent Events stream keeps the entire sites list live (status dots, last-seen counters) without polling. Cursor-based replay catches events missed while offline; all performance and scan surfaces refresh automatically on reconnect.
+- **One-click autologin to wp-admin** — Single-use, short-lived, audited EdDSA tokens; no shared passwords. Deep-links straight to Plugins or Themes, or log in as a specific user. Bypasses common two-factor plugins.
 - **Signed dashboard-to-agent revoke** — Revoke from the dashboard; the agent verifies a signed token on its next heartbeat and self-destructs. A man-in-the-middle on the heartbeat response cannot forge the teardown.
 - **Signed last-will on deactivate/uninstall** — Agent disconnects itself on deactivation (3 s best-effort); the timeout sweeper is the safety net if it never arrives.
 - **Re-enrollment under a stable identity** — Re-connecting a site keeps the same `site_id`, preserving all backup history, scan runs, and lifecycle generations.
 - **Archive / restore soft-delete** — Retire sites from the active view without losing their history; restore them later.
 - **Per-site sharing** — Share exactly one site with a collaborator, enforced by both Gin middleware and Postgres RESTRICTIVE RLS, without exposing the rest of the fleet.
+- **Agent self-update channel** — Self-hosted control planes push signed agent releases to enrolled sites. The WordPress.org distribution ("Fleet Agent for WPMgr") is pending directory review; that build strips the self-updater and declares GPLv2.
 
 ### Backups & restore
 
@@ -109,9 +114,10 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 
 ### Performance
 
-- **Zero-DB page cache fast path** — An `advanced-cache.php` drop-in serves anonymous pages as pre-gzipped HTML straight from disk (`wp-content/cache/wpmgr`) before WordPress, plugins, or the theme load. A cache HIT makes zero DB or plugin calls and streams the `.html.gz` with a 304 Not-Modified short-circuit.
+- **Zero-DB page cache fast path** — An `advanced-cache.php` drop-in serves anonymous pages as pre-gzipped HTML straight from disk (`wp-content/cache/wpmgr`) before WordPress, plugins, or the theme load. A cache HIT makes zero DB or plugin calls and streams the `.html.gz` with a 304 Not-Modified short-circuit. Every cached response carries an `x-wpmgr-cache` header.
 - **Variant-aware cache key** — Pages cache separately per device (mobile UA), per logged-in role, per operator-included cookie, and per cache-varying query string (marketing params stripped). The drop-in's key algorithm is byte-identical to the PHP writer.
 - **Safe cacheability gates** — Never caches non-200, admin/login/AJAX/feed/sitemap paths, password-protected posts, or any request carrying a bypass cookie (WooCommerce/EDD cart + session, logged-in, comment-author). WooCommerce cart/checkout/account pages are excluded outright.
+- **WooCommerce cart-session shell caching** — Catalog pages (shop, category, home, blog) can be cached for shoppers who already have items in their cart; cart totals update live via WooCommerce's own cart-fragments mechanism. WPMgr auto-probes theme support across real storefront renders before surfacing the toggle, requiring three independent page confirmations before reporting support.
 - **Automatic server fast-path install** — Enabling the cache writes the `WP_CACHE` define, installs the drop-in, and adds an Apache `.htaccess` block that serves `.gz` without PHP. nginx gets a copy-paste `try_files` snippet; built-in handling for OpenLiteSpeed and WP Engine Atomic.
 - **Purge: all, per-URL, and auto on content change** — Manual purge of the whole cache or a single URL's variants, plus automatic invalidation on post/comment/product/template change that purges and re-warms the exact affected URL set (permalink, home, archives, every assigned + ancestor term).
 - **Host / edge-cache purge integrations** — Every purge fires `wpmgr_purge_*:before/:after` actions so managed-host and CDN edge caches (Varnish, Kinsta, WP Engine, etc.) clear in lockstep.
@@ -123,6 +129,8 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 - **CSS/JS minification** — Local same-site stylesheets and scripts are minified, content-addressed into a local asset cache, and tag URLs rewritten. Already-minified and external files are skipped.
 - **JavaScript delay (defer / interaction / idle)** — Defers first-party JS via the `defer` attribute, or rewrites scripts to `data-src` and runs them only on first interaction or `requestIdleCallback`. Structural scripts (ld+json, speculation rules) are never delayed.
 - **Font optimization** — `font-display:swap` injected into `@font-face` + Google Fonts links, optional self-hosting of Google Fonts stylesheets + woff2 files, and heuristic `rel=preload` for the first critical fonts.
+- **WOFF2 font transcoding** — Self-hosted TTF, OTF, and WOFF fonts are transcoded to WOFF2 by the media-encoder service (50–65% smaller for TTF/OTF, 20–30% for WOFF). The original serves until transcoding completes; any failure falls back to the original.
+- **Glyph subsetting** — When subsetting is enabled alongside WOFF2 transcoding, the encoder produces a latin-ext subset (U+0000–024F, U+1E00–1EFF) alongside the full WOFF2. Typical additional savings are 60–90% for body-text Latin fonts. Variable and icon fonts are detected and skipped. Per-font processing states (pending / converting / ready / subsetted / skipped / failed) are shown in a live table on the Optimize tab.
 - **Third-party asset self-hosting** — Downloads cross-origin CSS/JS to the local asset cache and rewrites tags to same-origin. Best-effort: failure leaves the external URL in place.
 - **Image markup optimization (CLS + lazy-load)** — Fills missing `width`/`height` from `getimagesize()` or the filename WxH suffix to prevent layout shift. Adds `loading=lazy` + `decoding=async` to below-the-fold images while keeping the first two eager; existing srcset preserved.
 - **YouTube facade + Gravatar self-host** — Replaces YouTube iframes with a click-to-load thumbnail facade (no YouTube JS until clicked) and downloads/self-hosts Gravatars to the local asset cache.
@@ -136,6 +144,35 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 - **Page-cache conflict + multi-currency/i18n detection** — Detects other active cache/optimization plugins (reported to the dashboard, never deactivated) and auto-derives the cache-varying cookies/queries that multi-language and multi-currency plugins need so language/currency variants cache separately.
 - **Portfolio bulk actions + presets** — Purge the cache across many sites at once, or apply a safe / balanced / aggressive optimization preset to a whole group in one run (each preset spreads a small toggle set without clobbering per-site lists).
 - **Page-source footprint marker** — Every cached response carries an HTML-comment footprint (with timestamp, and an `(optimized)` suffix when transformed) so operators can confirm via view-source that WPMgr wrote and optimized the page.
+
+### Redis object cache
+
+- **Per-site persistent object cache** — Full WordPress cache API surface (`add`/`get`/`set`/`replace`/`delete`, multi-key variants, `flush_group`, `flush_runtime`, `wp_cache_supports`, `switch_to_blog` for multisite). Accelerates logged-in users, admin screens, WooCommerce checkout, and every database round-trip the page cache cannot serve.
+- **Connect test before enable** — The agent dials the candidate config without persisting it, probes phpredis capabilities (igbinary serializer, lzf/lz4/zstd compression, TLS), reads the eviction policy, and returns a structured result. Enable is blocked until a test passes. Codec mismatch is caught up front and rejected with a clear message.
+- **Encrypted credentials** — The control plane age-encrypts (X25519) the connection credential and delivers it via the signed command channel to a 0600 file on the site. Plaintext never appears in GET responses, logs, SSE payloads, test results, heartbeats, or backups.
+- **Two-level graceful degradation** — A boot failure swaps in a pure in-memory array cache so the site never goes down. Mid-request Redis errors become cache misses with one reconnect attempt, then degrade for the rest of that request. A persisted reconnect cool-down (15 s, doubling to 5 min) stops a down Redis from being re-dialed on every request.
+- **Fully self-contained drop-in** — One generated file contains the complete engine, connection layer, and config loader — no runtime dependence on the plugin folder name or location. The agent invalidates the drop-in's opcache on every version change; an outdated stub self-heals on the next heartbeat.
+- **Configuration drift detection** — The agent reports the fingerprint of the configuration file it is actually reading; the dashboard flags divergence from saved settings.
+- **Live status + analytics** — Dashboard shows connected / degraded / down with a 10 s SSE-debounced update. Charts track hit ratio, used memory, average command latency, and ops/sec over the last 7 days with a 90-day daily downsample. A per-site-prefixed flush never touches another site's keys on a shared Redis.
+- **`x-wpmgr-object-cache` debug header** — When the "Debug response header" setting is on, front-end responses carry `x-wpmgr-object-cache: state=connected hits=42 misses=3 reads=45 writes=12 ms=1.4`. Administrators always receive it while logged in; visitor-side is opt-in. Pages served by the page cache do not carry the header because WordPress does not run on those responses.
+
+### Real user monitoring
+
+- **Web-vitals collection** — A tiny first-party collector script (injected into cached pages at cache-write time) beacons LCP, INP, CLS, FCP, and TTFB directly to the control plane. Versioned collector URL forces edge-cache revalidation on every agent update.
+- **CrUX-style p75 dashboard** — p75 per metric with a PageSpeed Insights-style good/needs-improvement/poor distribution bar, a 28-day trend chart with threshold lines drawn on, and per-URL and per-device breakdowns. Live updates stream over SSE.
+- **Postgres histogram rollups** — Hourly and daily, with ClickHouse available as an opt-in scale backend via the same boot-selection pattern as the uptime store.
+- **Privacy-first** — Off by default. No cookies, no cross-site identifiers. Page paths stored with query string stripped. Visitor IP used only transiently for coarse country lookup, then discarded. On a self-hosted control plane all RUM data stays on the operator's own infrastructure.
+
+### Per-site email
+
+- **Multi-provider sending** — Amazon SES, SendGrid, Mailgun, Postmark, or any generic SMTP server, configured per-site or inherited from an org-wide default. Org default propagates automatically to every inheriting connected site in parallel on save.
+- **Named connections with failover** — Define multiple named connections per site. Map FROM addresses to a specific connection; a fallback connection retries automatically on primary failure. The email log records which connection handled each send.
+- **Central cross-site email log** — Every outgoing email logged with full detail: to, from, subject, headers, status, provider response, retry count, and attachment names/sizes. Paginated with free-text and column-scoped search, status and date filters, per-row detail with previous/next navigation, single and bulk resend, and CSV/JSON export. Email bodies not stored by default; opt-in per tenant. Log entries prune after 14 days.
+- **HTML preview sandbox** — A logged email's body renders inside a locked-down sandboxed iframe (no scripts, no same-origin) with a strict CSP. Remote images and tracking pixels blocked by default with a per-message opt-in.
+- **Bounce and complaint suppression** — Connect a provider webhook (SES SNS, SendGrid, Mailgun, Postmark) and WPMgr automatically suppresses hard-bounced and complained addresses fleet-wide. Manual add/remove supported. Scoped per-site or org-wide.
+- **Fleet deliverability dashboard** — Cross-site sent/failed/bounced/complained counts in one view. Per-site deliverability charts on each site's Email tab. Live SSE updates.
+- **Failure alerts + digest** — Opt-in alerts sent to operator-chosen recipients when sends start failing (throttled; configurable 15 min–24 h). A separate weekly or monthly deliverability digest summarises sent, failed, and bounced counts per site with a top-failures list.
+- **Credentials encrypted at rest** — age (X25519); a `secret_set` flag is returned in place of the plaintext. A test-send button confirms delivery before saving.
 
 ### Media
 
@@ -158,13 +195,20 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 
 ### Site tools
 
-- **Database Cleaner (scan / preview / clean)** — Read-only scan estimates then bounded, batched cleanup across 14 categories: post revisions, auto-drafts, trashed posts, spam/trashed comments, expired transients, orphaned post/comment meta, orphaned term relationships, oEmbed cache, duplicate postmeta, Action Scheduler completed/failed, and OPTIMIZE TABLE on non-InnoDB tables. Per-category `{rows_deleted, bytes_freed, state}` results stream back over signed progress pushes.
+- **Database Cleaner (scan / preview / clean)** — Read-only scan estimates then bounded, batched cleanup across 14 categories: post revisions, auto-drafts, trashed posts, spam/trashed comments, expired transients, orphaned post/comment meta, orphaned term relationships, oEmbed cache, duplicate postmeta, Action Scheduler completed/failed, and OPTIMIZE TABLE on non-InnoDB tables. Per-category `{rows_deleted, bytes_freed, state}` results stream back over signed progress pushes. Cleanup results are stored server-side and restored on page load and stream reconnect so a running cleanup survives a refresh.
 - **Database Cleaner safety** — Each task deletes only the rows it targets; SELECT→DELETE batching in 2000-row chunks with a hard iteration cap, OPTIMIZE TABLE on a 12 h cooldown, and operator-level permission gate. WP core options/cron/tables and installed-plugin-attributable items are skipped.
-- **Per-table inventory + maintenance actions** — Every table listed with row count, size, storage engine, overhead, and a "Belongs to" label (WordPress core / active plugin or theme / orphan). Per-table actions: optimize, repair, analyze, convert to InnoDB, empty, delete — each gated by a typed confirmation. Orphaned options and cron events classified by corpus confidence level (exact / prefix / heuristic / unknown).
+- **Per-table inventory + maintenance actions** — Every table listed with row count, size, storage engine, overhead, and a "Belongs to" label (WordPress core / active plugin or theme / orphan). Per-table actions: optimize, repair, analyze, convert to InnoDB, empty, delete — each gated by a typed confirmation. Orphaned options and cron events classified by corpus confidence level (exact / prefix / heuristic / unknown) against a seed of ~120 high-orphan-risk plugins.
 - **Database Snapshots** — One-click local DB snapshot before a risky change and one-click revert. Dumps to gzipped SQL under `wp-content/wpmgr-snapshots/db/` (web-hardened, never uploaded), with create / list / revert / delete actions and a configurable retention cap (default 5, hard max 20, oldest pruned first).
 - **Snapshot revert safety** — Revert is a destructive whole-DB overwrite gated behind an exact `REVERT` confirmation token (constant-time compare). Before importing, auto-captures a pre-revert safety snapshot, then replays the dump into `tmp`-prefixed tables and atomically swaps each over the live table so WordPress stays readable throughout. A failed import leaves the live DB untouched.
 - **Search & Replace** — Operator-driven literal find-and-replace across the whole database (or a chosen table allowlist) for URL/domain migrations and string fixes. Mandatory dry-run preview returns tables-scanned / rows-matched counts before any write, then reports rows-changed on apply.
 - **Search & Replace safety** — Serialization-safe walker (PHP-serialized blobs are unserialized, rewritten, and re-serialized so `s:NN:` length prefixes are recomputed — never a naive `str_replace`). Minimum 3-char search guard; community migration table denylist; binary/blob columns and `posts.guid` always skipped; all values mysqli-escaped; an advisory `X-Backup-Warning` header fires on a live run with no recent backup.
+
+### Clients for agencies
+
+- **Client grouping** — Create, edit, and delete clients (name, company, contact email, phone, notes, brand color, logo URL). Assign one or many sites via bulk "Set client" on the fleet view; filter by client; jump to a per-client detail page. Clients are tenant-isolated with RLS; a database-level composite constraint makes cross-tenant assignment impossible.
+- **White-label reports** — Monthly or weekly schedule per client, with a "Generate now" button for any custom period up to 92 days. Aggregates uptime, backups, updates, Core Web Vitals p75, and email deliverability. Per-section on/off toggles; custom intro and closing text. Delivered as branded HTML email, print-optimized page, and server-side vector-chart PDF. The client's brand color and logo appear throughout; the "powered by" footer is removable on any plan.
+- **Read-only client portal** — Invite client users by email from the Portal access tab. Existing users added immediately; new addresses receive a tokenized invite (7-day expiry) with a copyable fallback link. Clients land at `/portal` with their logo and brand color applied, a softened-wording sites overview ("Monitoring active", "Needs attention"), per-site uptime and incident history, backup inventory, applied updates, Core Web Vitals field data, and completed report downloads. The `client` role ranks below viewer with zero permissions; access is revoked instantly on removal, client archive, or client delete.
+- **Live portal summary dashboard** — The portal landing shows a status banner, five animated headline counters (sites monitored, average uptime, backups, updates applied, speed rating), a month-at-a-glance section with fleet uptime trend and Core Web Vitals distribution, site cards with 30-day sparklines, and a day-grouped "Recent work" timeline. All data is strictly scoped to the client's own sites.
 
 ### Team & access
 
@@ -191,7 +235,7 @@ apps/web    — React 19 + TypeScript + Vite + TanStack dashboard
 apps/agent  — PHP 8.1+ WordPress agent plugin (MIT)
 ```
 
-**Data:** Postgres (primary + RLS) · Redis (sessions, cache, dedup) · S3-compatible object storage (backups, media) · on-disk page cache (`wp-content/cache/wpmgr`, pre-gzipped `.html.gz`) · ClickHouse (optional, uptime time-series)
+**Data:** Postgres (primary + RLS) · Redis (sessions, cache, dedup) · S3-compatible object storage (backups, media) · on-disk page cache (`wp-content/cache/wpmgr`, pre-gzipped `.html.gz`) · ClickHouse (optional, uptime + RUM time-series)
 
 **Agent ↔ CP auth:** Ed25519 signed requests (canonical `METHOD\nPATH\nTIMESTAMP\nNONCE\nsha256(body)`) with per-request nonce + timestamp for anti-replay. CP→agent commands are short-lived Ed25519-signed JWTs scoped to one site and one operation.
 
@@ -220,23 +264,22 @@ docker compose -f infra/docker-compose.yml --profile media up -d
 
 ### Prebuilt container images
 
-The `v0.28.0` control plane, dashboard, and (optional) media encoder are published on GitHub Container Registry — wire them into your own compose, Kubernetes, or Swarm for production:
+The control plane, dashboard, and (optional) media encoder are published on GitHub Container Registry as multi-arch (`linux/amd64` + `linux/arm64`) images — wire them into your own compose, Kubernetes, or Swarm for production:
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.28.0
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.28.0
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.28.0   # optional
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.43.3
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.43.3
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.43.3   # optional
 ```
 
-Or bring up the whole stack from the published images (no local build) with the
-pull-only Compose overlay:
+Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.28.0   # omit to track :latest
+export WPMGR_VERSION=v0.43.3   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 
-Images are `linux/amd64`. (arm64 multi-arch is a near-term follow-up.)
+Migrations apply automatically on boot. The `validate-env` command (`make validate-env`) checks your configuration and prints every problem at once before the stack starts.
 
 Full install guide, env reference, and production hardening: [docs/install.md](./docs/install.md).
 
@@ -264,6 +307,7 @@ The following are accepted architectural decisions with no implementation yet:
 - **CAPTCHA challenge on login block** — Login protection currently serves a static 403; no challenge/solve flow built.
 - **Plugin/theme content malware scanning** — The scan engine covers WordPress core checksums only; no signature or heuristic detection for wp-content files yet.
 - **Automatic restore rollback UI** — The `.wpmgr-old-files-<id>/` rollback directory is preserved; no operator-initiated rollback endpoint exposed.
+- **Redis Sentinel / Cluster** — Object cache v1 supports single instance or unix socket with TLS; the config schema reserves fields for both topologies.
 - **Helm chart / Terraform provider** — Stubs exist under `infra/`; not implemented.
 - **AI features** — `apps/api/internal/ai/` contains only a `.gitkeep` placeholder.
 

--- a/apps/agent/includes/email/class-email-log-reporter.php
+++ b/apps/agent/includes/email/class-email-log-reporter.php
@@ -210,6 +210,9 @@ final class EmailLogReporter {
 	 * @return array<int,array<string,mixed>>
 	 */
 	private function fetchBatch( object $wpdb, string $table, int $cursor ): array {
+		// Identifier defense in depth: $table is $wpdb->prefix plus a hard-coded
+		// constant, but escape it anyway so static analysis can verify the query.
+		$table = esc_sql( $table );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- plugin-owned table; keyset cursor reads must not be cached (stale data would permanently skip rows)
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(

--- a/apps/agent/includes/object-cache/class-object-cache-dropin-installer.php
+++ b/apps/agent/includes/object-cache/class-object-cache-dropin-installer.php
@@ -291,7 +291,9 @@ final class ObjectCacheDropinInstaller
 		}
 		$count = 0;
 
-		$optionsTable = $wpdb->options ?? '';
+		// Identifier defense in depth: $wpdb->options is a trusted core property,
+		// but escape it anyway so static analysis can verify the query.
+		$optionsTable = esc_sql( $wpdb->options ?? '' );
 		if ( $optionsTable !== '' ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- no WP API for bulk transient delete; anti-replay / transient purge; caching would defeat the purpose
 			$count += (int) $wpdb->query(

--- a/apps/agent/tests/wp-stubs.php
+++ b/apps/agent/tests/wp-stubs.php
@@ -317,3 +317,20 @@ if (!class_exists('Redis')) {
         public const FLUSHDB_ASYNC = true;
     }
 }
+
+if (!function_exists('esc_sql')) {
+    /**
+     * Escapes data for use in a MySQL query — passthrough stub for tests.
+     *
+     * Real WP delegates to $wpdb->_escape(); for test purposes the inputs are
+     * plugin-derived identifiers with no escapable characters, so returning
+     * the value unchanged preserves the behavior under test.
+     *
+     * @param string|array $data Data to escape.
+     * @return string|array
+     */
+    function esc_sql($data)
+    {
+        return $data;
+    }
+}


### PR DESCRIPTION
## What

- **README full refresh** — was stuck at 0.28.0; now covers every shipped feature through v0.43.3 (object cache + debug header, RUM, per-site email, Clients/portal), adds release/license/CI badges, corrects the multi-arch image note and stale roadmap items. Voice and structure of the original preserved.
- **wp.org submission fixes** — `esc_sql` identifier defense on the two remaining Plugin Check DB warnings (+ test stub so the suite stays green), `tests-e2e/` excluded from both agent zips, plugincheck workflow runs the checker directly against the built zip.

Plugin Check on the wporg build is green except the three expected `wp`-trademark warnings (slug already reserved as `fleet-agent-for-wpmgr`; ownership appeal in flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent self-update channel
  * Redis object cache support
  * Real user monitoring capabilities
  * Per-site email functionality
  * Database cleaner
  * Font optimization (WOFF2 transcoding and glyph subsetting)
  * ClickHouse time-series database integration

* **Bug Fixes**
  * Enhanced SQL query security with improved escaping

* **Documentation**
  * Updated to version v0.43.3 with expanded feature documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->