### PR TITLE
feat(liveness): active reachability verification — connection state no longer traffic-dependent (0.44.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.44.0] - 2026-06-12
+
+### Fixed
+
+- **Healthy idle sites on a page cache no longer show as disconnected (critical).** Agent heartbeats ride WP-Cron, which only runs when PHP boots. On a fully page-cached low-traffic site the web server serves every request from disk, WordPress never boots, and a healthy site showed as disconnected. The connection sweeper now dials each quiet site directly with a signed ping command before it degrades or disconnects the site, so dashboard liveness is no longer traffic-dependent. A captive portal or other generic 200 response is never counted as alive. Sites confirmed unreachable after the dial disconnect with the new reason "agent_unreachable", distinguishing them from sites that are simply idle.
+
+### Added
+
+- **Active reachability verification in the connection sweeper.** The sweeper dials each quiet site with a signed ping command (falls back to the metadata command for older agents) and treats a shape-verified 200 as a heartbeat, keeping the site connected. The dial also wakes WP-Cron so overdue scheduled work drains. Bounded: 8s per-dial timeout, 8 concurrent dials, 12s wall budget per sweep tick. Three environment knobs: `WPMGR_SWEEP_ACTIVE_VERIFY` (default on), `WPMGR_SWEEP_VERIFY_TIMEOUT`, `WPMGR_SWEEP_VERIFY_CONCURRENCY`.
+- **Agent: signed ping command.** A cheap liveness answer that spawns WP-Cron so overdue scheduled work drains on every verify dial.
+- **Agent: shutdown catch-up heartbeat.** Fires when WordPress boots and the last heartbeat is more than two minutes overdue. Stampede-locked, 5s timeout so it never holds a worker.
+- **Dashboard: accurate connection badge copy.** "Agent unreachable" when the control plane dialed and got no answer; "No heartbeat" when the agent is quiet but the site may just be idle. The degraded tooltip explains verification is in progress.
+- **Dashboard: Health-tab cron callout.** A dismissible callout recommends disabling WP-Cron and adding a real server cron entry when diagnostics show WP-Cron starvation on a cached site.
+
+Control plane, web, and agent 0.44.0; no migration.
+
 ## [0.43.3] - 2026-06-12
 
 ### Fixed

--- a/apps/agent/assets/wpmgr-object-cache-dropin.php
+++ b/apps/agent/assets/wpmgr-object-cache-dropin.php
@@ -1204,7 +1204,7 @@ class WPMgr_Object_Cache
 	// -------------------------------------------------------------------------
 
 	/** Version of this engine class. Included in every heartbeat block. */
-	public const ENGINE_VERSION = '0.43.1';
+	public const ENGINE_VERSION = '0.44.0';
 
 	// -------------------------------------------------------------------------
 	// Feature advertisement (wp_cache_supports).

--- a/apps/agent/includes/class-enrollment.php
+++ b/apps/agent/includes/class-enrollment.php
@@ -289,6 +289,10 @@ final class Enrollment
      * it through the existing Connector before acting (Phase-6 finding B). We
      * never act on the revoke from this body alone.
      *
+     * @param int|null $timeout Per-request timeout override (seconds); defaults
+     *                          to self::TIMEOUT. The shutdown catch-up path
+     *                          passes a short budget so a slow CP can never
+     *                          hold an FPM worker long after output.
      * @return array{
      *     ok:bool,
      *     status:int,
@@ -298,7 +302,7 @@ final class Enrollment
      *     revoke_token:string
      * }
      */
-    public function sendHeartbeat(): array
+    public function sendHeartbeat(?int $timeout = null): array
     {
         if (!$this->settings->isEnrolled()) {
             $notEnrolled = $this->result(false, 0, 'not_enrolled', 'Not enrolled.');
@@ -314,9 +318,17 @@ final class Enrollment
 
         $body = (string) wp_json_encode($this->buildHeartbeatPayload());
 
-        $result = $this->signedPost(self::PATH_HEARTBEAT, $body);
+        $result = $this->signedPost(self::PATH_HEARTBEAT, $body, $timeout);
         if ($result['ok']) {
-            $this->settings->setLastHeartbeat(time());
+            $now = time();
+            $this->settings->setLastHeartbeat($now);
+            // Record a last-heartbeat ledger entry for the ping command's
+            // heartbeat_overdue_sec field and the shutdown catch-up guard.
+            // Non-autoloaded: this option is only read on the CP verify path
+            // and the shutdown hook, never on every page load.
+            if (function_exists('update_option')) {
+                update_option(\WPMgr\Agent\Commands\PingCommand::OPTION_LAST_HEARTBEAT_AT, $now, false);
+            }
         }
 
         return [

--- a/apps/agent/includes/class-heartbeat-catchup.php
+++ b/apps/agent/includes/class-heartbeat-catchup.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * HeartbeatCatchup: shutdown-hook catch-up sender for the agent heartbeat.
+ *
+ * Problem: the agent heartbeat rides WP-Cron, which only fires when WordPress
+ * boots. On fully page-cached idle sites WordPress never boots, so heartbeats
+ * stop and the control plane eventually marks the site as disconnected — a false
+ * positive. The control plane gains an active-verify dial (the ping command), but
+ * a safety net is also needed at the agent side.
+ *
+ * This class hooks onto 'shutdown' (priority 9999, late) and sends one heartbeat
+ * when ALL of the following hold:
+ *   1. The agent is enrolled.
+ *   2. wp_remote_post is available (we are in a full WP context).
+ *   3. The last heartbeat is more than 120 s overdue per the wpmgr_last_heartbeat_at
+ *      option (a missing option counts as overdue).
+ *   4. A per-process stampede-throttle lock is acquired: the option
+ *      wpmgr_hb_catchup_lock stores a Unix timestamp; if its stored value is
+ *      within the last 60 s this process skips. Otherwise this process writes
+ *      time() FIRST (accept the benign race; the CP dedupes heartbeats trivially)
+ *      then proceeds.
+ *   5. The current request is not an uninstall or deactivation lifecycle hook
+ *      (checked via WP_UNINSTALL_PLUGIN and the $_REQUEST pagenow/action pair).
+ *
+ * The HTTP timeout is capped at 5 s so a slow or unreachable CP cannot hold the
+ * FPM worker long after output has been sent.
+ *
+ * @package WPMgr\Agent
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent;
+
+use WPMgr\Agent\Commands\PingCommand;
+
+/**
+ * Shutdown-hook catch-up sender for the heartbeat.
+ */
+final class HeartbeatCatchup
+{
+    /**
+     * Option key for the stampede-throttle lock. Stores a Unix timestamp.
+     * Non-autoloaded: read only on the shutdown path, never on page load.
+     */
+    public const OPTION_LOCK = 'wpmgr_hb_catchup_lock';
+
+    /**
+     * Minimum seconds overdue before a catch-up heartbeat is sent.
+     * Set to 120 s (two missed heartbeat intervals) to allow a single miss
+     * without triggering a catch-up on every page load of a slightly-slow site.
+     */
+    private const OVERDUE_THRESHOLD = 120;
+
+    /**
+     * Lock validity window in seconds. Within this window a second concurrent
+     * process sees the lock as fresh and skips the send.
+     */
+    private const LOCK_WINDOW = 60;
+
+    /**
+     * Maximum HTTP timeout (seconds) for the catch-up heartbeat POST. Short
+     * enough to not hold an FPM worker long after output.
+     */
+    private const SEND_TIMEOUT = 5;
+
+    private Settings $settings;
+
+    private Enrollment $enrollment;
+
+    /**
+     * @param Settings   $settings   Enrollment/config state.
+     * @param Enrollment $enrollment Outbound heartbeat sender.
+     */
+    public function __construct(Settings $settings, Enrollment $enrollment)
+    {
+        $this->settings   = $settings;
+        $this->enrollment = $enrollment;
+    }
+
+    /**
+     * Register the shutdown hook. Bound in Plugin::registerHooks().
+     *
+     * @return void
+     */
+    public function register(): void
+    {
+        add_action('shutdown', [$this, 'maybeSend'], 9999);
+    }
+
+    /**
+     * Shutdown callback: send a catch-up heartbeat when conditions are met.
+     *
+     * Public so WordPress can call it as a named hook callback (closure
+     * capturing $this would be unsafe if the hook table is ever serialized by a
+     * persistent object cache or a cron-inspector plugin).
+     *
+     * @return void
+     */
+    public function maybeSend(): void
+    {
+        // Guard 1: agent must be enrolled.
+        if (!$this->settings->isEnrolled()) {
+            return;
+        }
+
+        // Guard 2: wp_remote_post must be available (full WP context).
+        if (!function_exists('wp_remote_post')) {
+            return;
+        }
+
+        // Guard 3: skip during uninstall/deactivation lifecycle hooks.
+        if ($this->isLifecycleRequest()) {
+            return;
+        }
+
+        // Guard 4: heartbeat must be overdue by more than OVERDUE_THRESHOLD seconds.
+        if (!$this->isOverdue()) {
+            return;
+        }
+
+        // Guard 5: acquire the stampede-throttle lock.
+        if (!$this->acquireLock()) {
+            return;
+        }
+
+        // Send a catch-up heartbeat with a short timeout so a slow CP can never
+        // hold the FPM worker long after output. Reuse Enrollment::sendHeartbeat
+        // so the signed transport and the ledger update run in one call.
+        try {
+            $this->enrollment->sendHeartbeat(self::SEND_TIMEOUT);
+        } catch (\Throwable $e) {
+            // Best-effort: a catch-up failure must never fatal the shutdown hook.
+        }
+    }
+
+    /**
+     * Whether the last heartbeat timestamp is absent or overdue by more than
+     * OVERDUE_THRESHOLD seconds.
+     *
+     * @return bool
+     */
+    private function isOverdue(): bool
+    {
+        if (!function_exists('get_option')) {
+            // Can't read the ledger — treat as overdue (conservative).
+            return true;
+        }
+
+        $stored = get_option(PingCommand::OPTION_LAST_HEARTBEAT_AT, false);
+        if ($stored === false || !is_numeric($stored)) {
+            // Option never written — no heartbeat has ever succeeded.
+            return true;
+        }
+
+        $elapsed = time() - (int) $stored;
+
+        return $elapsed > self::OVERDUE_THRESHOLD;
+    }
+
+    /**
+     * Acquire the stampede-throttle lock. Reads the stored lock timestamp;
+     * if it is within LOCK_WINDOW seconds, returns false (another process has
+     * the lock). Otherwise writes the current timestamp and returns true.
+     *
+     * The benign race (two processes read stale simultaneously and both write)
+     * results in at most two catch-up heartbeats reaching the CP; the CP
+     * dedupes heartbeats trivially by last-seen timestamp.
+     *
+     * @return bool True when the lock was acquired.
+     */
+    private function acquireLock(): bool
+    {
+        if (!function_exists('get_option') || !function_exists('update_option')) {
+            return false;
+        }
+
+        $stored = get_option(self::OPTION_LOCK, false);
+        if ($stored !== false && is_numeric($stored)) {
+            $age = time() - (int) $stored;
+            if ($age < self::LOCK_WINDOW) {
+                return false; // Lock is fresh; skip.
+            }
+        }
+
+        // Write the lock FIRST before sending.
+        update_option(self::OPTION_LOCK, time(), false);
+
+        return true;
+    }
+
+    /**
+     * Whether the current request is a WP lifecycle hook (uninstall / deactivation).
+     * We must not send a heartbeat during these paths because Enrollment may be
+     * in the middle of a signed last-will disconnect.
+     *
+     * @return bool
+     */
+    private function isLifecycleRequest(): bool
+    {
+        // Uninstall path: WordPress defines this constant before requiring
+        // uninstall.php. The guard is defined in our own uninstall.php too.
+        if (defined('WP_UNINSTALL_PLUGIN')) {
+            return true;
+        }
+
+        // Deactivation path: recognise the admin AJAX/POST that calls the
+        // deactivate hook. This is a best-effort check; false negatives are
+        // acceptable (a spurious catch-up during deactivation is harmless).
+        if (defined('DOING_AJAX') && DOING_AJAX) {
+            $action = isset($_REQUEST['action']) ? sanitize_text_field(wp_unslash((string) $_REQUEST['action'])) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only heuristic; no state change on this value
+            if ($action === 'deactivate-plugin' || $action === 'update-plugin') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -64,6 +64,7 @@ use WPMgr\Agent\Commands\ObjectcacheDisableCommand;
 use WPMgr\Agent\Commands\ObjectcacheEnableCommand;
 use WPMgr\Agent\Commands\ObjectcacheFlushCommand;
 use WPMgr\Agent\Commands\ObjectcacheTestCommand;
+use WPMgr\Agent\Commands\PingCommand;
 use WPMgr\Agent\Commands\ResendEmailCommand;
 use WPMgr\Agent\Commands\SendTestEmailCommand;
 use WPMgr\Agent\Commands\SyncEmailConfigCommand;
@@ -241,6 +242,14 @@ final class Plugin
     private SuppressionCache $suppressionCache;
 
     /**
+     * Connection-liveness catch-up sender. Hooks onto 'shutdown' (priority
+     * 9999) and sends one heartbeat when the last recorded heartbeat is more
+     * than 120 s overdue, fixing false disconnects on page-cached idle sites
+     * where WP-Cron never fires.
+     */
+    private HeartbeatCatchup $heartbeatCatchup;
+
+    /**
      * Private constructor wires the object graph.
      */
     private function __construct()
@@ -330,8 +339,9 @@ final class Plugin
         $this->mailRouter        = new MailRouter($this->providerRouter, $this->settings);
         $this->emailLogReporter  = new EmailLogReporter($this->settings, $this->signer);
 
-        $this->router           = new Router($this->connector, $this->commands());
-        $this->admin            = new Admin($this->settings, $this->enrollment, $this->keystore, $this->lifecycle, $this->updateChecker);
+        $this->router              = new Router($this->connector, $this->commands());
+        $this->heartbeatCatchup    = new HeartbeatCatchup($this->settings, $this->enrollment);
+        $this->admin               = new Admin($this->settings, $this->enrollment, $this->keystore, $this->lifecycle, $this->updateChecker);
         $this->autologinReplay  = new ReplayCache();
         $this->autologin        = new AutologinCommand($this->connector, $this->autologinReplay, $this->signer, $this->settings);
     }
@@ -633,6 +643,11 @@ final class Plugin
         // Phase 4b — suppression-cache pull: runs every 15 min (HOOK_PULL) so
         // the local hash store stays current without a per-send CP dependency.
         add_action(SuppressionCache::HOOK_PULL, [$this, 'pullSuppressionCache']);
+
+        // Connection-liveness catch-up: send a heartbeat on shutdown when the
+        // last recorded heartbeat is overdue by more than 120 s. Fixes false
+        // disconnects on page-cached idle sites where WP-Cron never fires.
+        $this->heartbeatCatchup->register();
 
         // Admin-bar cache purge controls — register on EVERY request, not just
         // admin ones, so the "Purge this page" node can appear on the front-end
@@ -1277,6 +1292,11 @@ final class Plugin
             new ObjectcacheEnableCommand(),
             new ObjectcacheDisableCommand(),
             new ObjectcacheFlushCommand(),
+            // Connection-liveness hardening (0.44.0): cheap CP active-verify dial.
+            // Answers ok/agent_version/php_time/wp_cron_disabled/heartbeat_overdue_sec
+            // and kicks spawn_cron() so every verify dial drains overdue cron events
+            // on page-cached idle sites.
+            new PingCommand(),
         ];
     }
 

--- a/apps/agent/includes/commands/class-ping-command.php
+++ b/apps/agent/includes/commands/class-ping-command.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Ping command: cheap liveness probe for the control-plane active-verify dial.
+ *
+ * Returns agent version, PHP wall-clock time, whether WP-Cron is disabled, and
+ * how many seconds the last heartbeat is overdue. Designed to be answered in
+ * milliseconds — no inventory build, no directory walks.
+ *
+ * A side-effect of handling this command is draining overdue WP-Cron events via
+ * spawn_cron(), so every CP verify dial also drains the heartbeat and other
+ * periodic jobs on page-cached sites where WP never boots on its own.
+ *
+ * @package WPMgr\Agent\Commands
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Commands;
+
+/**
+ * Responds to control-plane liveness pings.
+ */
+final class PingCommand implements CommandInterface
+{
+    /**
+     * Option key holding the Unix timestamp of the last successful heartbeat.
+     * Written by Enrollment::sendHeartbeat() on every 2xx response.
+     * Non-autoloaded; read here only on the CP verify path (cheap).
+     */
+    public const OPTION_LAST_HEARTBEAT_AT = 'wpmgr_last_heartbeat_at';
+
+    /**
+     * Heartbeat interval in seconds. A heartbeat is considered overdue when the
+     * elapsed time since the last recorded send exceeds this value.
+     */
+    private const HEARTBEAT_INTERVAL = 60;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function name(): string
+    {
+        return 'ping';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param array<string,mixed> $claims Validated JWT claims (unused for ping).
+     * @param array<string,mixed> $params Request parameters (unused for ping).
+     * @return array<string,mixed>
+     */
+    public function execute(array $claims, array $params): array
+    {
+        $payload = [
+            'ok'                   => true,
+            'agent_version'        => defined('WPMGR_AGENT_VERSION') ? (string) constant('WPMGR_AGENT_VERSION') : '',
+            'php_time'             => time(),
+            'wp_cron_disabled'     => defined('DISABLE_WP_CRON') && (bool) constant('DISABLE_WP_CRON'),
+            'heartbeat_overdue_sec' => $this->heartbeatOverdueSec(),
+        ];
+
+        // Drain overdue WP-Cron events so every CP verify dial also ticks the
+        // heartbeat, metadata, and perf jobs on page-cached idle sites.
+        if (function_exists('spawn_cron')) {
+            @spawn_cron(); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- spawn_cron is best-effort; a failed spawn must not break the ping response
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Compute how many seconds the last heartbeat is overdue.
+     *
+     * Returns null when the option has never been written (agent never sent a
+     * heartbeat — e.g. immediately after activation). Returns 0 when the last
+     * heartbeat was within the interval window. Returns the positive elapsed
+     * overage otherwise.
+     *
+     * @return int|null Seconds overdue, or null when no record exists.
+     */
+    private function heartbeatOverdueSec(): ?int
+    {
+        if (!function_exists('get_option')) {
+            return null;
+        }
+
+        $stored = get_option(self::OPTION_LAST_HEARTBEAT_AT, false);
+        if ($stored === false || !is_numeric($stored)) {
+            return null;
+        }
+
+        $elapsed = time() - (int) $stored;
+        $overdue = $elapsed - self::HEARTBEAT_INTERVAL;
+
+        return max(0, $overdue);
+    }
+}

--- a/apps/agent/includes/object-cache/class-object-cache-engine.php
+++ b/apps/agent/includes/object-cache/class-object-cache-engine.php
@@ -602,7 +602,7 @@ class WPMgr_Object_Cache
 	// -------------------------------------------------------------------------
 
 	/** Version of this engine class. Included in every heartbeat block. */
-	public const ENGINE_VERSION = '0.43.1';
+	public const ENGINE_VERSION = '0.44.0';
 
 	// -------------------------------------------------------------------------
 	// Feature advertisement (wp_cache_supports).

--- a/apps/agent/tests/EnrollmentHeartbeatLedgerTest.php
+++ b/apps/agent/tests/EnrollmentHeartbeatLedgerTest.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Tests for the heartbeat ledger: Enrollment::sendHeartbeat writes
+ * wpmgr_last_heartbeat_at on a successful send, and does NOT write it on
+ * a failed send.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Commands\MetadataCommand;
+use WPMgr\Agent\Commands\PingCommand;
+use WPMgr\Agent\Enrollment;
+use WPMgr\Agent\Keystore;
+use WPMgr\Agent\Settings;
+use WPMgr\Agent\Signer;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Enrollment::sendHeartbeat
+ */
+final class EnrollmentHeartbeatLedgerTest extends TestCase
+{
+    private string $keyFile;
+
+    /** @var array<string,mixed> */
+    private array $options = [];
+
+    private Settings $settings;
+
+    private Enrollment $enrollment;
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->keyFile = sys_get_temp_dir() . '/wpmgr-hbl-' . bin2hex(random_bytes(8)) . '.key';
+
+        $this->options = [];
+
+        Functions\when('update_option')->alias(function (string $name, $value, $autoload = null) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('get_option')->alias(function (string $name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('delete_option')->alias(function (string $name) {
+            unset($this->options[$name]);
+            return true;
+        });
+
+        // Settings two-tier resolution stubs.
+        Functions\when('get_site_option')->alias(function (string $name, $default = false) {
+            $sentinel = '__wpmgr_settings_missing__';
+            if ($default === $sentinel) {
+                return $sentinel;
+            }
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('is_multisite')->justReturn(false);
+
+        // Network / WP stubs required by Enrollment.
+        Functions\when('wp_json_encode')->alias(static fn ($d) => json_encode($d));
+        Functions\when('esc_url_raw')->returnArg();
+        Functions\when('wp_parse_url')->alias(static fn ($url, $c = -1) => parse_url($url, $c));
+        Functions\when('home_url')->justReturn('https://example.test');
+        Functions\when('get_bloginfo')->justReturn('6.5.0');
+        Functions\when('is_wp_error')->justReturn(false);
+
+        // MetadataCommand stubs.
+        Functions\when('wp_get_themes')->justReturn([]);
+        Functions\when('get_plugins')->justReturn([]);
+        Functions\when('get_stylesheet')->justReturn('');
+        Functions\when('get_template')->justReturn('');
+        Functions\when('wp_get_theme')->justReturn(null);
+        Functions\when('get_users')->justReturn([]);
+
+        if (!defined('WPMGR_AGENT_KEY_FILE')) {
+            define('WPMGR_AGENT_KEY_FILE', $this->keyFile);
+        }
+
+        $keystore         = new Keystore();
+        $keystore->generateSiteKeypair();
+        $this->settings   = new Settings();
+        $signer           = new Signer($keystore);
+        $this->enrollment = new Enrollment($keystore, $this->settings, $signer, new MetadataCommand());
+
+        // Enroll the site so sendHeartbeat() does not short-circuit.
+        $this->settings->setControlPlaneUrl('https://cp.example.test');
+        $this->options[Settings::OPTION_SITE_ID] = 'site-abc';
+    }
+
+    protected function tear_down(): void
+    {
+        if (is_file($this->keyFile)) {
+            @unlink($this->keyFile);
+        }
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // -------------------------------------------------------------------------
+    // Successful send → writes wpmgr_last_heartbeat_at
+    // -------------------------------------------------------------------------
+
+    public function test_successful_send_updates_last_heartbeat_at(): void
+    {
+        Functions\when('wp_remote_post')->justReturn(['ok' => true]);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(200);
+        Functions\when('wp_remote_retrieve_body')->justReturn('{"ok":true,"instructions":[],"revoke_token":""}');
+
+        $before = time();
+        $this->enrollment->sendHeartbeat();
+
+        $this->assertArrayHasKey(
+            PingCommand::OPTION_LAST_HEARTBEAT_AT,
+            $this->options,
+            'wpmgr_last_heartbeat_at must be written after a successful heartbeat'
+        );
+
+        $stored = (int) $this->options[PingCommand::OPTION_LAST_HEARTBEAT_AT];
+        $this->assertGreaterThanOrEqual($before, $stored);
+        $this->assertLessThanOrEqual(time(), $stored);
+    }
+
+    // -------------------------------------------------------------------------
+    // Failed send (non-2xx) → does NOT write wpmgr_last_heartbeat_at
+    // -------------------------------------------------------------------------
+
+    public function test_failed_send_does_not_update_last_heartbeat_at(): void
+    {
+        Functions\when('wp_remote_post')->justReturn(['ok' => true]);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(503);
+        Functions\when('wp_remote_retrieve_body')->justReturn('');
+
+        $this->enrollment->sendHeartbeat();
+
+        $this->assertArrayNotHasKey(
+            PingCommand::OPTION_LAST_HEARTBEAT_AT,
+            $this->options,
+            'wpmgr_last_heartbeat_at must NOT be written when the heartbeat POST fails'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // WP_Error (unreachable CP) → does NOT write wpmgr_last_heartbeat_at
+    // -------------------------------------------------------------------------
+
+    public function test_wp_error_send_does_not_update_last_heartbeat_at(): void
+    {
+        // is_wp_error returns true → signedPost treats this as "unreachable".
+        Functions\when('wp_remote_post')->justReturn(new \WP_Error('http_request_failed', 'cURL error'));
+        Functions\when('is_wp_error')->justReturn(true);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(0);
+        Functions\when('wp_remote_retrieve_body')->justReturn('');
+
+        $this->enrollment->sendHeartbeat();
+
+        $this->assertArrayNotHasKey(
+            PingCommand::OPTION_LAST_HEARTBEAT_AT,
+            $this->options,
+            'wpmgr_last_heartbeat_at must NOT be written when the CP is unreachable'
+        );
+    }
+}

--- a/apps/agent/tests/HeartbeatCatchupTest.php
+++ b/apps/agent/tests/HeartbeatCatchupTest.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * Tests for HeartbeatCatchup: overdue + no lock → send + write lock;
+ * lock fresh → no send; not overdue → no send; not enrolled → no send.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Commands\PingCommand;
+use WPMgr\Agent\Enrollment;
+use WPMgr\Agent\HeartbeatCatchup;
+use WPMgr\Agent\Keystore;
+use WPMgr\Agent\Settings;
+use WPMgr\Agent\Signer;
+use WPMgr\Agent\Commands\MetadataCommand;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\HeartbeatCatchup
+ */
+final class HeartbeatCatchupTest extends TestCase
+{
+    private string $keyFile;
+
+    /** @var array<string,mixed> */
+    private array $options = [];
+
+    private Settings $settings;
+
+    private Enrollment $enrollment;
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->keyFile = sys_get_temp_dir() . '/wpmgr-hbc-' . bin2hex(random_bytes(8)) . '.key';
+
+        $this->options = [];
+
+        // Option store backed by in-memory array.
+        Functions\when('update_option')->alias(function (string $name, $value, $autoload = null) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('get_option')->alias(function (string $name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('delete_option')->alias(function (string $name) {
+            unset($this->options[$name]);
+            return true;
+        });
+
+        // Stubs required by Settings::get() two-tier resolution.
+        Functions\when('get_site_option')->alias(function (string $name, $default = false) {
+            $sentinel = '__wpmgr_settings_missing__';
+            if ($default === $sentinel) {
+                return $sentinel; // Signal "not in site options" so get_option fallback runs.
+            }
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('is_multisite')->justReturn(false);
+
+        // Stubs required by Enrollment::buildHeartbeatPayload().
+        Functions\when('wp_json_encode')->alias(static fn ($d) => json_encode($d));
+        Functions\when('esc_url_raw')->returnArg();
+        Functions\when('wp_parse_url')->alias(static fn ($url, $c = -1) => parse_url($url, $c));
+        Functions\when('home_url')->justReturn('https://example.test');
+        Functions\when('get_bloginfo')->justReturn('6.5.0');
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(200);
+        Functions\when('wp_remote_retrieve_body')->justReturn('{}');
+
+        // Stubs needed by MetadataCommand::collect() through Enrollment.
+        Functions\when('is_multisite')->justReturn(false);
+        Functions\when('wp_get_themes')->justReturn([]);
+        Functions\when('get_plugins')->justReturn([]);
+        Functions\when('get_stylesheet')->justReturn('');
+        Functions\when('get_template')->justReturn('');
+        Functions\when('wp_get_theme')->justReturn(null);
+        Functions\when('get_users')->justReturn([]);
+
+        if (!defined('WPMGR_AGENT_KEY_FILE')) {
+            define('WPMGR_AGENT_KEY_FILE', $this->keyFile);
+        }
+
+        $keystore   = new Keystore();
+        $keystore->generateSiteKeypair();
+        $this->settings   = new Settings();
+        $signer     = new Signer($keystore);
+        $this->enrollment = new Enrollment($keystore, $this->settings, $signer, new MetadataCommand());
+    }
+
+    protected function tear_down(): void
+    {
+        if (is_file($this->keyFile)) {
+            @unlink($this->keyFile);
+        }
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Enroll the site so Settings::isEnrolled() returns true.
+     */
+    private function simulateEnrolled(): void
+    {
+        $this->settings->setControlPlaneUrl('https://cp.example.test');
+        $this->options[Settings::OPTION_SITE_ID] = 'site-abc';
+    }
+
+    // -------------------------------------------------------------------------
+    // Not enrolled → no send
+    // -------------------------------------------------------------------------
+
+    public function test_does_not_send_when_not_enrolled(): void
+    {
+        // wp_remote_post must NOT be called.
+        Functions\expect('wp_remote_post')->never();
+
+        $catchup = new HeartbeatCatchup($this->settings, $this->enrollment);
+        $catchup->maybeSend();
+
+        // Brain Monkey verifies the ->never() expectation at teardown; this
+        // explicit count satisfies PHPUnit's "at least one assertion" check.
+        $this->addToAssertionCount(1);
+    }
+
+    // -------------------------------------------------------------------------
+    // Enrolled, overdue, no lock → sends one heartbeat and writes lock
+    // -------------------------------------------------------------------------
+
+    public function test_sends_heartbeat_when_overdue_and_no_lock(): void
+    {
+        $this->simulateEnrolled();
+
+        // Mark as overdue: option is 300 s ago (well past the 120 s threshold).
+        $this->options[PingCommand::OPTION_LAST_HEARTBEAT_AT] = time() - 300;
+
+        // Expect wp_remote_post called exactly once (the heartbeat POST) with
+        // the short shutdown-path timeout so a slow CP can never hold the FPM
+        // worker long after output.
+        $capturedArgs = null;
+        Functions\expect('wp_remote_post')
+            ->once()
+            ->andReturnUsing(function ($url, $args) use (&$capturedArgs) {
+                $capturedArgs = $args;
+                return ['ok' => true];
+            });
+
+        $catchup = new HeartbeatCatchup($this->settings, $this->enrollment);
+        $catchup->maybeSend();
+
+        $this->assertIsArray($capturedArgs);
+        $this->assertSame(5, $capturedArgs['timeout'], 'Catch-up heartbeat must use the 5 s shutdown timeout');
+
+        // Lock must have been written.
+        $this->assertArrayHasKey(HeartbeatCatchup::OPTION_LOCK, $this->options);
+        $lockAge = time() - (int) $this->options[HeartbeatCatchup::OPTION_LOCK];
+        $this->assertLessThan(5, $lockAge, 'Lock timestamp should be within 5 s of now');
+    }
+
+    // -------------------------------------------------------------------------
+    // Fresh lock → no send
+    // -------------------------------------------------------------------------
+
+    public function test_does_not_send_when_lock_is_fresh(): void
+    {
+        $this->simulateEnrolled();
+
+        // Mark as overdue.
+        $this->options[PingCommand::OPTION_LAST_HEARTBEAT_AT] = time() - 300;
+
+        // Write a fresh lock (10 s ago — within the 60 s window).
+        $this->options[HeartbeatCatchup::OPTION_LOCK] = time() - 10;
+
+        // wp_remote_post must NOT be called.
+        Functions\expect('wp_remote_post')->never();
+
+        $catchup = new HeartbeatCatchup($this->settings, $this->enrollment);
+        $catchup->maybeSend();
+
+        $this->addToAssertionCount(1);
+    }
+
+    // -------------------------------------------------------------------------
+    // Not overdue → no send
+    // -------------------------------------------------------------------------
+
+    public function test_does_not_send_when_heartbeat_not_overdue(): void
+    {
+        $this->simulateEnrolled();
+
+        // Last heartbeat was 30 s ago — not overdue (threshold is 120 s).
+        $this->options[PingCommand::OPTION_LAST_HEARTBEAT_AT] = time() - 30;
+
+        // wp_remote_post must NOT be called.
+        Functions\expect('wp_remote_post')->never();
+
+        $catchup = new HeartbeatCatchup($this->settings, $this->enrollment);
+        $catchup->maybeSend();
+
+        $this->addToAssertionCount(1);
+    }
+
+    // -------------------------------------------------------------------------
+    // Expired lock → sends (lock older than 60 s is treated as stale)
+    // -------------------------------------------------------------------------
+
+    public function test_sends_when_lock_is_expired(): void
+    {
+        $this->simulateEnrolled();
+
+        // Mark as overdue.
+        $this->options[PingCommand::OPTION_LAST_HEARTBEAT_AT] = time() - 300;
+
+        // Write a stale lock (90 s ago — outside the 60 s window).
+        $this->options[HeartbeatCatchup::OPTION_LOCK] = time() - 90;
+
+        Functions\expect('wp_remote_post')
+            ->once()
+            ->andReturn(['ok' => true]);
+
+        $catchup = new HeartbeatCatchup($this->settings, $this->enrollment);
+        $catchup->maybeSend();
+
+        // Lock must have been refreshed.
+        $lockAge = time() - (int) $this->options[HeartbeatCatchup::OPTION_LOCK];
+        $this->assertLessThan(5, $lockAge, 'Lock timestamp should be refreshed to near-now');
+    }
+
+    // -------------------------------------------------------------------------
+    // Missing last-heartbeat option counts as overdue
+    // -------------------------------------------------------------------------
+
+    public function test_sends_when_heartbeat_option_missing(): void
+    {
+        $this->simulateEnrolled();
+
+        // Do not set OPTION_LAST_HEARTBEAT_AT at all — treat as overdue.
+        Functions\expect('wp_remote_post')
+            ->once()
+            ->andReturn(['ok' => true]);
+
+        $catchup = new HeartbeatCatchup($this->settings, $this->enrollment);
+        $catchup->maybeSend();
+
+        // Lock must have been written (confirms the send path executed).
+        $this->assertArrayHasKey(HeartbeatCatchup::OPTION_LOCK, $this->options);
+    }
+}

--- a/apps/agent/tests/ObjectCache/ObjectCacheFix416Test.php
+++ b/apps/agent/tests/ObjectCache/ObjectCacheFix416Test.php
@@ -277,7 +277,7 @@ final class ObjectCacheFix416Test extends TestCase
 	}
 
 	/**
-	 * C3: ENGINE_VERSION constant in artifact must be '0.43.1' (updated from 0.43.0 in shutdown-marker fix).
+	 * C3: ENGINE_VERSION constant in artifact must be '0.44.0' (updated from 0.43.1 in ping/liveness feature).
 	 */
 	public function test_artifact_engine_version_is_0416(): void
 	{
@@ -286,9 +286,9 @@ final class ObjectCacheFix416Test extends TestCase
 		}
 		$content = (string) file_get_contents( $this->artifactPath );
 		$this->assertStringContainsString(
-			"ENGINE_VERSION = '0.43.1'",
+			"ENGINE_VERSION = '0.44.0'",
 			$content,
-			"ENGINE_VERSION constant must be '0.43.1' in the artifact (0.43.1 shutdown-marker fix)"
+			"ENGINE_VERSION constant must be '0.44.0' in the artifact (0.44.0 ping/liveness feature)"
 		);
 	}
 

--- a/apps/agent/tests/PingCommandTest.php
+++ b/apps/agent/tests/PingCommandTest.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Tests for PingCommand: contract payload shape, spawn_cron side-effect,
+ * wp_cron_disabled flag, heartbeat_overdue_sec computation, and null-when-absent.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Commands\PingCommand;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Commands\PingCommand
+ */
+final class PingCommandTest extends TestCase
+{
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+    }
+
+    protected function tear_down(): void
+    {
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // -------------------------------------------------------------------------
+    // Payload shape
+    // -------------------------------------------------------------------------
+
+    public function test_returns_contract_shaped_payload(): void
+    {
+        Functions\when('get_option')->justReturn(false);
+        Functions\when('spawn_cron')->justReturn(null);
+
+        $cmd    = new PingCommand();
+        $result = $cmd->execute([], []);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('ok', $result);
+        $this->assertArrayHasKey('agent_version', $result);
+        $this->assertArrayHasKey('php_time', $result);
+        $this->assertArrayHasKey('wp_cron_disabled', $result);
+        $this->assertArrayHasKey('heartbeat_overdue_sec', $result);
+
+        $this->assertTrue($result['ok']);
+        $this->assertIsString($result['agent_version']);
+        $this->assertIsInt($result['php_time']);
+        $this->assertIsBool($result['wp_cron_disabled']);
+        // heartbeat_overdue_sec is int|null.
+        $this->assertTrue(
+            is_int($result['heartbeat_overdue_sec']) || is_null($result['heartbeat_overdue_sec']),
+            'heartbeat_overdue_sec must be int or null'
+        );
+    }
+
+    public function test_agent_version_reflects_constant(): void
+    {
+        Functions\when('get_option')->justReturn(false);
+        Functions\when('spawn_cron')->justReturn(null);
+
+        if (!defined('WPMGR_AGENT_VERSION')) {
+            define('WPMGR_AGENT_VERSION', '0.44.0-test');
+        }
+
+        $cmd    = new PingCommand();
+        $result = $cmd->execute([], []);
+
+        $this->assertSame((string) constant('WPMGR_AGENT_VERSION'), $result['agent_version']);
+    }
+
+    // -------------------------------------------------------------------------
+    // spawn_cron side-effect
+    // -------------------------------------------------------------------------
+
+    public function test_calls_spawn_cron(): void
+    {
+        Functions\when('get_option')->justReturn(false);
+
+        // expect() asserts spawn_cron is called exactly once.
+        Functions\expect('spawn_cron')->once()->withNoArgs()->andReturn(null);
+
+        $cmd    = new PingCommand();
+        $result = $cmd->execute([], []);
+
+        // Also verify the payload is valid — satisfies PHPUnit's assertion count.
+        $this->assertTrue($result['ok']);
+    }
+
+    // -------------------------------------------------------------------------
+    // wp_cron_disabled flag
+    // -------------------------------------------------------------------------
+
+    public function test_wp_cron_disabled_false_when_constant_absent(): void
+    {
+        Functions\when('get_option')->justReturn(false);
+        Functions\when('spawn_cron')->justReturn(null);
+
+        // DISABLE_WP_CRON is not defined in the test environment unless
+        // explicitly set. We cannot un-define a PHP constant, so only run
+        // this assertion when the constant is absent.
+        if (defined('DISABLE_WP_CRON')) {
+            $this->markTestSkipped('DISABLE_WP_CRON already defined in this process.');
+        }
+
+        $cmd    = new PingCommand();
+        $result = $cmd->execute([], []);
+
+        $this->assertFalse($result['wp_cron_disabled']);
+    }
+
+    // -------------------------------------------------------------------------
+    // heartbeat_overdue_sec
+    // -------------------------------------------------------------------------
+
+    public function test_heartbeat_overdue_sec_null_when_option_absent(): void
+    {
+        // get_option returns false (default) when the option has never been set.
+        Functions\when('get_option')->justReturn(false);
+        Functions\when('spawn_cron')->justReturn(null);
+
+        $cmd    = new PingCommand();
+        $result = $cmd->execute([], []);
+
+        $this->assertNull($result['heartbeat_overdue_sec']);
+    }
+
+    public function test_heartbeat_overdue_sec_zero_when_recent(): void
+    {
+        $recentTimestamp = time() - 30; // 30 s ago — well within the 60 s interval.
+        Functions\when('get_option')->justReturn($recentTimestamp);
+        Functions\when('spawn_cron')->justReturn(null);
+
+        $cmd    = new PingCommand();
+        $result = $cmd->execute([], []);
+
+        $this->assertSame(0, $result['heartbeat_overdue_sec']);
+    }
+
+    public function test_heartbeat_overdue_sec_positive_when_overdue(): void
+    {
+        // 130 s ago: 130 - 60 = 70 s overdue.
+        $overdueTimestamp = time() - 130;
+        Functions\when('get_option')->justReturn($overdueTimestamp);
+        Functions\when('spawn_cron')->justReturn(null);
+
+        $cmd    = new PingCommand();
+        $result = $cmd->execute([], []);
+
+        $this->assertIsInt($result['heartbeat_overdue_sec']);
+        $this->assertGreaterThanOrEqual(60, $result['heartbeat_overdue_sec']);
+    }
+
+    public function test_heartbeat_overdue_sec_never_negative(): void
+    {
+        // Option timestamp is NOW — elapsed is 0, overdue is max(0, -60) = 0.
+        Functions\when('get_option')->justReturn(time());
+        Functions\when('spawn_cron')->justReturn(null);
+
+        $cmd    = new PingCommand();
+        $result = $cmd->execute([], []);
+
+        $this->assertSame(0, $result['heartbeat_overdue_sec']);
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.43.1
+ * Version:           0.44.0
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.43.1');
+define('WPMGR_AGENT_VERSION', '0.44.0');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -784,6 +784,8 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// M58: wire env-configurable thresholds (WPMGR_CONN_DEGRADE_AFTER,
 	// WPMGR_CONN_DISCONNECT_AFTER, WPMGR_CONN_DEGRADE_MISS_THRESHOLD) and the
 	// consecutive-miss counter incrementer so the sweeper uses hysteresis.
+	// 0.44.0: wire the active-verify dialer (WPMGR_SWEEP_ACTIVE_VERIFY,
+	// WPMGR_SWEEP_VERIFY_TIMEOUT, WPMGR_SWEEP_VERIFY_CONCURRENCY).
 	siteSweeper := site.NewSweeper(siteRepo, connSvc.(site.SweeperTransitioner), siteEventsPub)
 	if missInc, ok := siteRepo.(site.MissIncrementer); ok {
 		siteSweeper.SetMissIncrementer(missInc)
@@ -794,6 +796,30 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	if cfg.Conn.DegradeMissThreshold > 0 {
 		siteSweeper.SetDegradeMissThreshold(cfg.Conn.DegradeMissThreshold)
 	}
+	// 0.44.0 active verify: wire the agent command client as the dialer when the
+	// CP signing key is configured (same guard as the recheck handler). The
+	// ConnectionService satisfies HeartbeatRecorder so RecordHeartbeat is reused
+	// exactly as the recheck_handler does (ADR-039: single recovery writer).
+	siteSweeper.SetActiveVerify(cfg.Conn.ActiveVerify)
+	if cfg.Conn.VerifyTimeout > 0 {
+		siteSweeper.SetVerifyTimeout(cfg.Conn.VerifyTimeout)
+	}
+	if cfg.Conn.VerifyConcurrency > 0 {
+		siteSweeper.SetVerifyConcurrency(cfg.Conn.VerifyConcurrency)
+	}
+	if rec, ok := connSvc.(site.HeartbeatRecorder); ok {
+		siteSweeper.SetHeartbeatRecorder(rec)
+	}
+	if cfg.Conn.ActiveVerify {
+		if cmdSigner, serr := agentcmd.NewSigner(cfg.Agent.SigningPrivateKey); serr == nil {
+			sweepVerifier := agentcmd.NewClient(ssrfClient, cmdSigner)
+			siteSweeper.SetVerifier(sweepVerifier)
+			logger.Info("sweep active verify enabled")
+		} else {
+			logger.Warn("sweep active verify disabled: CP signing key not configured or invalid; passive sweeper mode active")
+		}
+	}
+	siteSweeper.SetLogger(logger)
 	siteSweepWorker := site.NewSweepWorker(siteSweeper)
 	siteEventPruneWorker := site.NewEventPruneWorker(siteSweeper)
 	// SSE endpoint + the dedicated LISTEN listener.

--- a/apps/api/db/query/site_connection.sql
+++ b/apps/api/db/query/site_connection.sql
@@ -206,13 +206,17 @@ SELECT tenant_id FROM sites WHERE id = $1;
 
 -- name: ListSitesToDegrade :many
 -- connected sites whose last heartbeat is older than the degrade cutoff.
-SELECT id, tenant_id FROM sites
+-- url is included so the active-verify sweeper can dial the agent without a
+-- secondary tenant-scoped lookup.
+SELECT id, tenant_id, url FROM sites
 WHERE connection_state = 'connected'
   AND (last_seen_at IS NULL OR last_seen_at < $1);
 
 -- name: ListSitesToDisconnect :many
 -- degraded sites whose last heartbeat is older than the disconnect cutoff.
-SELECT id, tenant_id FROM sites
+-- url is included so the active-verify sweeper can dial the agent without a
+-- secondary tenant-scoped lookup.
+SELECT id, tenant_id, url FROM sites
 WHERE connection_state = 'degraded'
   AND (last_seen_at IS NULL OR last_seen_at < $1);
 

--- a/apps/api/internal/agentcmd/client.go
+++ b/apps/api/internal/agentcmd/client.go
@@ -252,6 +252,79 @@ func (c *Client) MetadataRaw(ctx context.Context, siteID uuid.UUID, siteURL stri
 	return c.Metadata(ctx, siteID, siteURL, MetadataRequest{})
 }
 
+// Ping sends the signed `ping` command to the site's agent and returns the
+// parsed response (0.44.0 active liveness probe). siteID is bound into the
+// JWT's aud claim. An old agent without the ping route returns a 404 from the
+// REST API — callers should fall back to MetadataRaw for backward compatibility.
+// Ping never logs the response body; only the ok field is inspected.
+func (c *Client) Ping(ctx context.Context, siteID uuid.UUID, siteURL string) (PingResponse, error) {
+	var out PingResponse
+	if err := c.post(ctx, siteID, siteURL, "ping", PingRequest{}, &out); err != nil {
+		return PingResponse{}, err
+	}
+	return out, nil
+}
+
+// VerifyReachable implements the 0.44.0 liveness-fallback contract:
+//
+//  1. Try the `ping` command (new agents).  A 2xx response means alive.
+//  2. When ping returns a 404 or 400 (old agent / unknown command), fall back
+//     to MetadataRaw.  A 2xx metadata response means alive.
+//  3. Anything else (transport error, 5xx, both-fail) means not alive.
+//
+// The function returns (true, nil) when the site is reachable, (false, nil)
+// when it is not, and (false, err) only on unexpected infrastructure failures
+// (e.g. JWT-mint failure). Response bodies are discarded beyond the minimal
+// decode needed to detect the error; nothing is logged by this function —
+// callers should emit structured log lines with the returned outcome.
+func (c *Client) VerifyReachable(ctx context.Context, siteID uuid.UUID, siteURL string) (alive bool, fallbackUsed bool, err error) {
+	out, pingErr := c.Ping(ctx, siteID, siteURL)
+	if pingErr == nil && out.OK {
+		return true, false, nil
+	}
+
+	// Fall back to the metadata command when ping looks like an old agent
+	// (404/400 unknown command) — or when something answered 2xx without the
+	// agent-shaped ok field (captive portal, generic maintenance page): the
+	// metadata shape check below settles whether a real agent is behind it.
+	fallback := pingErr == nil && !out.OK
+	if pingErr != nil {
+		pingErrStr := pingErr.Error()
+		fallback = strings.Contains(pingErrStr, "status 404") ||
+			strings.Contains(pingErrStr, "status 400")
+	}
+	if fallback {
+		raw, metaErr := c.MetadataRaw(ctx, siteID, siteURL)
+		if metaErr == nil && looksLikeAgentMetadata(raw) {
+			return true, true, nil
+		}
+		// Both ping and shape-checked metadata failed — not alive.
+		return false, true, nil
+	}
+
+	// Hard transport / 5xx failure on ping — not alive.  The JWT-mint path
+	// returns a format error (no status code), so it falls here too: treat it
+	// as not alive rather than an infra error, to avoid blocking the sweeper.
+	return false, false, nil
+}
+
+// looksLikeAgentMetadata is the liveness shape check for the metadata
+// fallback: a 2xx alone must not count as alive (a captive portal or generic
+// 200 page would pass), so require the one field every agent version's
+// metadata command has always returned. Deliberately local — the tolerant
+// decoder in internal/agent accepts {} and would defeat the check (and
+// importing it would cycle: internal/agent imports this package).
+func looksLikeAgentMetadata(raw []byte) bool {
+	var probe struct {
+		WPVersion    string `json:"wp_version"`
+		AgentVersion string `json:"agent_version"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return false
+	}
+	return probe.WPVersion != "" || probe.AgentVersion != ""
+}
+
 // MediaOptimize sends the signed `media_optimize` command to the site's agent
 // (ADR-043). siteID is bound into the JWT's aud claim. The agent presigned-PUTs
 // each job's source variants and calls back to the CP's encode-ready endpoint;

--- a/apps/api/internal/agentcmd/contract.go
+++ b/apps/api/internal/agentcmd/contract.go
@@ -165,3 +165,25 @@ type DiagnosticsRequest struct{}
 // the full current inventory — so the struct is intentionally empty.
 type MetadataRequest struct{}
 
+// PingRequest is the POST body for the `ping` command (0.44.0 active liveness).
+// The agent's ping command takes no params — it responds with a minimal
+// liveness envelope — so the struct is intentionally empty.
+type PingRequest struct{}
+
+// PingResponse is the agent's response to the `ping` command.
+//
+//   ok                    true iff the agent handled the command.
+//   agent_version         the agent's build version string.
+//   php_time              Unix timestamp as seen from PHP (sanity clock check).
+//   wp_cron_disabled      true when DISABLE_WP_CRON is set (explains why
+//                         passive heartbeats stopped; the site is still alive).
+//   heartbeat_overdue_sec seconds since the last WP-Cron-driven heartbeat, or
+//                         null when no heartbeat has been recorded locally.
+type PingResponse struct {
+	OK                 bool   `json:"ok"`
+	AgentVersion       string `json:"agent_version"`
+	PHPTime            int64  `json:"php_time"`
+	WPCronDisabled     bool   `json:"wp_cron_disabled"`
+	HeartbeatOverdueSec *int64 `json:"heartbeat_overdue_sec"`
+}
+

--- a/apps/api/internal/agentcmd/verify_reachable_test.go
+++ b/apps/api/internal/agentcmd/verify_reachable_test.go
@@ -1,0 +1,165 @@
+package agentcmd
+
+import (
+	"context"
+	"crypto/ed25519"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/httpclient"
+)
+
+// buildTestAgentClient builds a *Client backed by a test-only Ed25519 signer
+// and an SSRF-disabled httpclient that can reach loopback httptest servers.
+// The httpclient's AllowedPorts is set to the test server's port so traffic
+// is restricted to the ephemeral port without opening the SSRF guard broadly.
+func buildTestAgentClient(t *testing.T, srv *httptest.Server) *Client {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate ed25519 key: %v", err)
+	}
+	signer := &Signer{priv: priv}
+	hc := httpclient.New(httpclient.Config{
+		AllowPrivateNetworks: true, // test-only: loopback target
+	})
+	return NewClient(hc, signer)
+}
+
+// TestVerifyReachableFallbackToMetadata proves the 0.44.0 old-agent fallback:
+// when the agent returns 404 for the ping command, VerifyReachable retries with
+// the metadata command and reports alive=true + fallbackUsed=true on a 200.
+func TestVerifyReachableFallbackToMetadata(t *testing.T) {
+	siteID := uuid.New()
+	callCount := 0
+
+	// Fake agent: ping → 404, metadata → 200 with a trivial JSON body.
+	// The JWT in the Authorization header is not verified (test-only).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		switch r.URL.Path {
+		case "/wp-json/wpmgr/v1/command/ping":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"code":"rest_no_route","message":"No route was found matching the URL and request method."}`))
+		case "/wp-json/wpmgr/v1/command/metadata":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true,"plugins":[],"themes":[],"wp_version":"6.5.0"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := buildTestAgentClient(t, srv)
+
+	alive, fallback, err := client.VerifyReachable(context.Background(), siteID, srv.URL)
+	if err != nil {
+		t.Fatalf("VerifyReachable returned unexpected error: %v", err)
+	}
+	if !alive {
+		t.Fatal("expected alive=true: metadata returned 200")
+	}
+	if !fallback {
+		t.Fatal("expected fallbackUsed=true: ping returned 404, metadata was tried")
+	}
+	if callCount != 2 {
+		t.Fatalf("expected exactly 2 HTTP calls (ping + metadata), got %d", callCount)
+	}
+}
+
+// TestVerifyReachablePingAlive proves that when ping returns 200 the function
+// reports alive=true and fallbackUsed=false (metadata is never called).
+func TestVerifyReachablePingAlive(t *testing.T) {
+	siteID := uuid.New()
+	callCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if r.URL.Path == "/wp-json/wpmgr/v1/command/ping" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true,"agent_version":"0.44.0","php_time":1000000,"wp_cron_disabled":true,"heartbeat_overdue_sec":120}`))
+			return
+		}
+		// metadata must NOT be called
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := buildTestAgentClient(t, srv)
+
+	alive, fallback, err := client.VerifyReachable(context.Background(), siteID, srv.URL)
+	if err != nil {
+		t.Fatalf("VerifyReachable error: %v", err)
+	}
+	if !alive {
+		t.Fatal("expected alive=true: ping returned 200")
+	}
+	if fallback {
+		t.Fatal("expected fallbackUsed=false: ping succeeded, metadata must not be called")
+	}
+	if callCount != 1 {
+		t.Fatalf("expected exactly 1 HTTP call (ping only), got %d", callCount)
+	}
+}
+
+// TestVerifyReachableRejectsNonAgent200 proves the captive-portal guard: a
+// 200 that is not agent-shaped (ping without ok=true, metadata without
+// wp_version/agent_version) must NOT count as alive — otherwise any generic
+// 200 page (captive portal, maintenance splash) would mask a dead agent.
+func TestVerifyReachableRejectsNonAgent200(t *testing.T) {
+	siteID := uuid.New()
+	callCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		// Captive portal: answers every path with a generic JSON 200.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"welcome","login":"/portal"}`))
+	}))
+	defer srv.Close()
+
+	client := buildTestAgentClient(t, srv)
+
+	alive, fallback, err := client.VerifyReachable(context.Background(), siteID, srv.URL)
+	if err != nil {
+		t.Fatalf("VerifyReachable error: %v", err)
+	}
+	if alive {
+		t.Fatal("expected alive=false: 200 without agent shape must not count as alive")
+	}
+	if !fallback {
+		t.Fatal("expected fallbackUsed=true: non-ok ping 200 must be settled via metadata")
+	}
+	if callCount != 2 {
+		t.Fatalf("expected 2 HTTP calls (ping + metadata shape check), got %d", callCount)
+	}
+}
+
+// TestVerifyReachableBothFail proves that when both ping (non-404 failure) and
+// any subsequent attempt fail, the function reports alive=false, err=nil.
+func TestVerifyReachableBothFail(t *testing.T) {
+	siteID := uuid.New()
+
+	// Agent is completely unreachable (all requests → 503).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"code":"service_unavailable"}`))
+	}))
+	defer srv.Close()
+
+	client := buildTestAgentClient(t, srv)
+
+	alive, fallback, err := client.VerifyReachable(context.Background(), siteID, srv.URL)
+	if err != nil {
+		t.Fatalf("VerifyReachable must return (false,false,nil) on hard failure, got err=%v", err)
+	}
+	if alive {
+		t.Fatal("expected alive=false: agent returned 5xx")
+	}
+	if fallback {
+		t.Fatal("expected fallbackUsed=false: ping failed with 5xx, not 404/400")
+	}
+}

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -54,6 +54,18 @@ type ConnConfig struct {
 	// DisconnectAfter is the staleness window before a degraded site is
 	// disconnected. Default 900s. Env: WPMGR_CONN_DISCONNECT_AFTER.
 	DisconnectAfter time.Duration `koanf:"disconnect_after"`
+	// ActiveVerify enables CP-initiated active liveness checks (0.44.0).
+	// When true (the default) the sweeper dials the agent before executing the
+	// degrade or disconnect transition; a successful ping/metadata response
+	// resets the miss counter and skips the transition.
+	// Set WPMGR_SWEEP_ACTIVE_VERIFY=false to revert to the passive sweeper.
+	ActiveVerify bool `koanf:"active_verify"`
+	// VerifyTimeout is the per-dial timeout for active liveness checks.
+	// Default 8s. Env: WPMGR_SWEEP_VERIFY_TIMEOUT.
+	VerifyTimeout time.Duration `koanf:"verify_timeout"`
+	// VerifyConcurrency is the maximum number of concurrent active-verify dials
+	// per sweep tick. Default 8. Env: WPMGR_SWEEP_VERIFY_CONCURRENCY.
+	VerifyConcurrency int `koanf:"verify_concurrency"`
 }
 
 // AutologinConfig holds the Phase 5.5 one-click login tunables (ADR-031).
@@ -401,6 +413,9 @@ func defaults() map[string]any {
 		"conn.degrade_after":                "300s",
 		"conn.degrade_miss_threshold":       3,
 		"conn.disconnect_after":             "900s",
+		"conn.active_verify":                true,
+		"conn.verify_timeout":               "8s",
+		"conn.verify_concurrency":           8,
 	}
 }
 
@@ -483,6 +498,15 @@ func mapEnvKey(k string) string {
 		return "autologin." + strings.TrimPrefix(k, "autologin_")
 	case strings.HasPrefix(k, "conn_"):
 		return "conn." + strings.TrimPrefix(k, "conn_")
+	// WPMGR_SWEEP_ACTIVE_VERIFY -> conn.active_verify (0.44.0 active liveness).
+	case k == "sweep_active_verify":
+		return "conn.active_verify"
+	// WPMGR_SWEEP_VERIFY_TIMEOUT -> conn.verify_timeout.
+	case k == "sweep_verify_timeout":
+		return "conn.verify_timeout"
+	// WPMGR_SWEEP_VERIFY_CONCURRENCY -> conn.verify_concurrency.
+	case k == "sweep_verify_concurrency":
+		return "conn.verify_concurrency"
 	default:
 		return k
 	}

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -871,8 +871,12 @@ type Querier interface {
 	// When sqlc.narg('client_id') is set only sites belonging to that client are returned (m63).
 	ListSites(ctx context.Context, arg ListSitesParams) ([]Site, error)
 	// connected sites whose last heartbeat is older than the degrade cutoff.
+	// url is included so the active-verify sweeper can dial the agent without a
+	// secondary tenant-scoped lookup.
 	ListSitesToDegrade(ctx context.Context, lastSeenAt pgtype.Timestamptz) ([]ListSitesToDegradeRow, error)
 	// degraded sites whose last heartbeat is older than the disconnect cutoff.
+	// url is included so the active-verify sweeper can dial the agent without a
+	// secondary tenant-scoped lookup.
 	ListSitesToDisconnect(ctx context.Context, lastSeenAt pgtype.Timestamptz) ([]ListSitesToDisconnectRow, error)
 	// Watchdog feeder: a running snapshot whose latest progress is older than the
 	// stall threshold (or whose runner never reported any progress despite being

--- a/apps/api/internal/db/sqlc/site_connection.sql.go
+++ b/apps/api/internal/db/sqlc/site_connection.sql.go
@@ -604,7 +604,7 @@ func (q *Queries) ListConnectionHistory(ctx context.Context, arg ListConnectionH
 }
 
 const listSitesToDegrade = `-- name: ListSitesToDegrade :many
-SELECT id, tenant_id FROM sites
+SELECT id, tenant_id, url FROM sites
 WHERE connection_state = 'connected'
   AND (last_seen_at IS NULL OR last_seen_at < $1)
 `
@@ -612,9 +612,12 @@ WHERE connection_state = 'connected'
 type ListSitesToDegradeRow struct {
 	ID       uuid.UUID `json:"id"`
 	TenantID uuid.UUID `json:"tenant_id"`
+	Url      string    `json:"url"`
 }
 
 // connected sites whose last heartbeat is older than the degrade cutoff.
+// url is included so the active-verify sweeper can dial the agent without a
+// secondary tenant-scoped lookup.
 func (q *Queries) ListSitesToDegrade(ctx context.Context, lastSeenAt pgtype.Timestamptz) ([]ListSitesToDegradeRow, error) {
 	rows, err := q.db.Query(ctx, listSitesToDegrade, lastSeenAt)
 	if err != nil {
@@ -624,7 +627,7 @@ func (q *Queries) ListSitesToDegrade(ctx context.Context, lastSeenAt pgtype.Time
 	var items []ListSitesToDegradeRow
 	for rows.Next() {
 		var i ListSitesToDegradeRow
-		if err := rows.Scan(&i.ID, &i.TenantID); err != nil {
+		if err := rows.Scan(&i.ID, &i.TenantID, &i.Url); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -636,7 +639,7 @@ func (q *Queries) ListSitesToDegrade(ctx context.Context, lastSeenAt pgtype.Time
 }
 
 const listSitesToDisconnect = `-- name: ListSitesToDisconnect :many
-SELECT id, tenant_id FROM sites
+SELECT id, tenant_id, url FROM sites
 WHERE connection_state = 'degraded'
   AND (last_seen_at IS NULL OR last_seen_at < $1)
 `
@@ -644,9 +647,12 @@ WHERE connection_state = 'degraded'
 type ListSitesToDisconnectRow struct {
 	ID       uuid.UUID `json:"id"`
 	TenantID uuid.UUID `json:"tenant_id"`
+	Url      string    `json:"url"`
 }
 
 // degraded sites whose last heartbeat is older than the disconnect cutoff.
+// url is included so the active-verify sweeper can dial the agent without a
+// secondary tenant-scoped lookup.
 func (q *Queries) ListSitesToDisconnect(ctx context.Context, lastSeenAt pgtype.Timestamptz) ([]ListSitesToDisconnectRow, error) {
 	rows, err := q.db.Query(ctx, listSitesToDisconnect, lastSeenAt)
 	if err != nil {
@@ -656,7 +662,7 @@ func (q *Queries) ListSitesToDisconnect(ctx context.Context, lastSeenAt pgtype.T
 	var items []ListSitesToDisconnectRow
 	for rows.Next() {
 		var i ListSitesToDisconnectRow
-		if err := rows.Scan(&i.ID, &i.TenantID); err != nil {
+		if err := rows.Scan(&i.ID, &i.TenantID, &i.Url); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/apps/api/internal/site/connection_repo.go
+++ b/apps/api/internal/site/connection_repo.go
@@ -292,7 +292,7 @@ func (r *pgRepo) ListToDegrade(ctx context.Context, cutoff time.Time) ([]SiteRef
 		}
 		out = make([]SiteRef, 0, len(rows))
 		for _, row := range rows {
-			out = append(out, SiteRef{ID: row.ID, TenantID: row.TenantID})
+			out = append(out, SiteRef{ID: row.ID, TenantID: row.TenantID, URL: row.Url})
 		}
 		return nil
 	})
@@ -308,7 +308,7 @@ func (r *pgRepo) ListToDisconnect(ctx context.Context, cutoff time.Time) ([]Site
 		}
 		out = make([]SiteRef, 0, len(rows))
 		for _, row := range rows {
-			out = append(out, SiteRef{ID: row.ID, TenantID: row.TenantID})
+			out = append(out, SiteRef{ID: row.ID, TenantID: row.TenantID, URL: row.Url})
 		}
 		return nil
 	})

--- a/apps/api/internal/site/repo.go
+++ b/apps/api/internal/site/repo.go
@@ -102,10 +102,13 @@ type Repo interface {
 	PairingCodeSiteID(ctx context.Context, codeHash string) (uuid.UUID, bool, error)
 }
 
-// SiteRef is the slim (site, tenant) projection the timeout sweeper iterates.
+// SiteRef is the slim (site, tenant, url) projection the timeout sweeper
+// iterates. URL is included so the active-verify sweeper can dial the agent
+// without a secondary tenant-scoped lookup.
 type SiteRef struct {
 	ID       uuid.UUID
 	TenantID uuid.UUID
+	URL      string
 }
 
 // SiteURLHit is the minimal (id, connection_state) projection returned by

--- a/apps/api/internal/site/sweeper.go
+++ b/apps/api/internal/site/sweeper.go
@@ -2,6 +2,8 @@ package site
 
 import (
 	"context"
+	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -28,6 +30,16 @@ const (
 	// degreesMissThresholdDefault is the consecutive overdue count required to
 	// trigger the connected→degraded transition (M58 hysteresis).
 	degreesMissThresholdDefault = 3
+
+	// defaultVerifyTimeout is the per-dial timeout for active liveness checks.
+	defaultVerifyTimeout = 8 * time.Second
+	// defaultVerifyConcurrency is the maximum number of concurrent active-verify
+	// dials per sweep tick.
+	defaultVerifyConcurrency = 8
+	// defaultSweepBudget is the wall-clock budget for the active-verify phase
+	// of each sweep tick. Sites not verified within this window are skipped
+	// (they re-enter the list on the next 15 s tick).
+	defaultSweepBudget = 12 * time.Second
 )
 
 // SweeperTransitioner is the subset of the ConnectionService the timeout sweeper
@@ -50,18 +62,45 @@ type EventPruner interface {
 	PruneOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
 }
 
+// HeartbeatRecorder can reset the miss counter and refresh last_seen_at for a
+// site (the active-verify recovery path). Satisfied by ConnectionService.
+type HeartbeatRecorder interface {
+	RecordHeartbeat(ctx context.Context, in HeartbeatInput) (HeartbeatResult, error)
+}
+
+// AgentVerifier performs an active CP-initiated liveness check against a site's
+// agent. Implemented by *agentcmd.Client via VerifyReachable.
+//
+// Returns (alive=true) when the agent answers the ping or metadata command,
+// (alive=false, err=nil) when the agent is unreachable, and (false, err) on
+// an unexpected infrastructure failure (JWT-mint failure etc.).
+// fallbackUsed indicates that the ping command was not available on the agent
+// and the metadata command was used instead (old-agent path).
+type AgentVerifier interface {
+	VerifyReachable(ctx context.Context, siteID uuid.UUID, siteURL string) (alive bool, fallbackUsed bool, err error)
+}
+
 // Sweeper performs the periodic connection-timeout sweep (ADR-039 + M58
-// hysteresis) and the periodic site_events prune (ADR-038). Pure logic over
-// the repo + service so it is unit/integration-testable directly without River.
+// hysteresis + 0.44.0 active verify) and the periodic site_events prune
+// (ADR-038). Pure logic over the repo + service so it is unit/integration-
+// testable directly without River.
 type Sweeper struct {
 	repo                 Repo
 	svc                  SweeperTransitioner
 	pruner               EventPruner
 	missInc              MissIncrementer
+	heartbeatRec         HeartbeatRecorder
+	verifier             AgentVerifier
 	degradeAfter         time.Duration
 	disconnectAfter      time.Duration
 	eventRetention       time.Duration
 	degreesMissThreshold int
+	// active-verify knobs (0.44.0)
+	activeVerify      bool
+	verifyTimeout     time.Duration
+	verifyConcurrency int
+	sweepBudget       time.Duration
+	logger            *slog.Logger
 }
 
 // NewSweeper builds a Sweeper. pruner may be nil (the events prune is skipped).
@@ -77,6 +116,10 @@ func NewSweeper(repo Repo, svc SweeperTransitioner, pruner EventPruner) *Sweeper
 		disconnectAfter:      disconnectAfterDefault,
 		eventRetention:       5 * time.Minute,
 		degreesMissThreshold: degreesMissThresholdDefault,
+		activeVerify:         true,
+		verifyTimeout:        defaultVerifyTimeout,
+		verifyConcurrency:    defaultVerifyConcurrency,
+		sweepBudget:          defaultSweepBudget,
 	}
 }
 
@@ -85,6 +128,50 @@ func NewSweeper(repo Repo, svc SweeperTransitioner, pruner EventPruner) *Sweeper
 // behaviour (no hysteresis), which is acceptable only in tests.
 func (w *Sweeper) SetMissIncrementer(inc MissIncrementer) {
 	w.missInc = inc
+}
+
+// SetHeartbeatRecorder wires the service that resets the miss counter and
+// refreshes last_seen_at when an active verify succeeds. Call once at boot.
+// When nil, a successful active verify is logged but the counter is not reset
+// (the site will degrade on the next tick unless a passive heartbeat arrives).
+func (w *Sweeper) SetHeartbeatRecorder(rec HeartbeatRecorder) {
+	w.heartbeatRec = rec
+}
+
+// SetVerifier wires the active-verify dialer (0.44.0). Call once at boot.
+// When nil (or when activeVerify=false) the sweeper operates in passive mode —
+// identical to the pre-0.44.0 behaviour.
+func (w *Sweeper) SetVerifier(v AgentVerifier) {
+	w.verifier = v
+}
+
+// SetActiveVerify enables or disables the active-verify phase. When false, the
+// sweeper degrades/disconnects purely on the passive heartbeat staleness
+// threshold (pre-0.44.0 behaviour). Controlled by WPMGR_SWEEP_ACTIVE_VERIFY.
+func (w *Sweeper) SetActiveVerify(enabled bool) {
+	w.activeVerify = enabled
+}
+
+// SetVerifyTimeout overrides the per-dial timeout (default 8 s).
+// Controlled by WPMGR_SWEEP_VERIFY_TIMEOUT.
+func (w *Sweeper) SetVerifyTimeout(d time.Duration) {
+	if d > 0 {
+		w.verifyTimeout = d
+	}
+}
+
+// SetVerifyConcurrency overrides the maximum concurrent dials per tick
+// (default 8). Controlled by WPMGR_SWEEP_VERIFY_CONCURRENCY.
+func (w *Sweeper) SetVerifyConcurrency(n int) {
+	if n > 0 {
+		w.verifyConcurrency = n
+	}
+}
+
+// SetLogger wires a structured logger. When nil, verify outcomes are silently
+// discarded (acceptable in tests).
+func (w *Sweeper) SetLogger(l *slog.Logger) {
+	w.logger = l
 }
 
 // SetThresholds overrides the timeout/retention windows and the miss threshold.
@@ -110,25 +197,169 @@ func (w *Sweeper) SetDegradeMissThreshold(n int) {
 	}
 }
 
+// verifyResult is the outcome of one active-verify dial.
+type verifyResult struct {
+	ref          SiteRef
+	alive        bool
+	fallbackUsed bool
+	duration     time.Duration
+	err          error
+	skipped      bool // budget exhausted before this site was checked
+}
+
+// activeVerifyBatch runs concurrent active-verify dials for the given sites,
+// bounded by w.verifyConcurrency and the supplied deadline. Sites that cannot
+// be reached before the deadline are marked skipped (no state transition).
+func (w *Sweeper) activeVerifyBatch(ctx context.Context, refs []SiteRef, deadline time.Time) []verifyResult {
+	results := make([]verifyResult, len(refs))
+	if w.verifier == nil || len(refs) == 0 {
+		for i, ref := range refs {
+			results[i] = verifyResult{ref: ref, skipped: true}
+		}
+		return results
+	}
+
+	sem := make(chan struct{}, w.verifyConcurrency)
+	var wg sync.WaitGroup
+	for i, ref := range refs {
+		i, ref := i, ref
+
+		// Check the sweep budget before launching a new goroutine.
+		if time.Now().After(deadline) {
+			results[i] = verifyResult{ref: ref, skipped: true}
+			continue
+		}
+
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				results[i] = verifyResult{ref: ref, skipped: true}
+				return
+			}
+			timeout := w.verifyTimeout
+			if remaining < timeout {
+				timeout = remaining
+			}
+			dialCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+
+			start := time.Now()
+			alive, fallback, err := w.verifier.VerifyReachable(dialCtx, ref.ID, ref.URL)
+			results[i] = verifyResult{
+				ref:          ref,
+				alive:        alive,
+				fallbackUsed: fallback,
+				duration:     time.Since(start),
+				err:          err,
+			}
+		}()
+	}
+	wg.Wait()
+	return results
+}
+
+// logVerify emits a structured debug/info log line for an active-verify
+// outcome. No-op when no logger is wired.
+func (w *Sweeper) logVerify(phase string, r verifyResult) {
+	if w.logger == nil {
+		return
+	}
+	if r.skipped {
+		w.logger.Debug("sweep active verify skipped (budget exhausted)",
+			slog.String("phase", phase),
+			slog.String("site_id", r.ref.ID.String()),
+		)
+		return
+	}
+	lvl := slog.LevelDebug
+	if !r.alive {
+		lvl = slog.LevelInfo
+	}
+	w.logger.Log(context.Background(), lvl, "sweep active verify",
+		slog.String("phase", phase),
+		slog.String("site_id", r.ref.ID.String()),
+		slog.Bool("alive", r.alive),
+		slog.Bool("fallback_used", r.fallbackUsed),
+		slog.Duration("duration", r.duration),
+	)
+}
+
+// recordHeartbeat calls RecordHeartbeat on the wired recorder (if any). A
+// failure here is best-effort and is swallowed: the site already passed a
+// successful active-verify, so the liveness signal should not be discarded
+// just because the DB write raced or failed transiently.
+func (w *Sweeper) recordHeartbeat(ctx context.Context, ref SiteRef) {
+	if w.heartbeatRec == nil {
+		return
+	}
+	_, _ = w.heartbeatRec.RecordHeartbeat(ctx, HeartbeatInput{
+		TenantID: ref.TenantID,
+		SiteID:   ref.ID,
+	})
+}
+
 // Sweep runs one timeout pass relative to now: it disconnects degraded sites
 // past the disconnect cutoff (hard threshold), then evaluates connected sites
 // past the degrade cutoff with the M58 consecutive-miss hysteresis (increment
 // counter; degrade only when the counter reaches the configured threshold).
+//
+// When active verify is enabled (WPMGR_SWEEP_ACTIVE_VERIFY=true, the default),
+// the sweeper dials the agent before executing either transition:
+//
+//   - Degrade path: when the miss counter would cross the threshold, first dial
+//     the agent. A successful response resets the counter via RecordHeartbeat
+//     and skips the degrade. A failed response degrades exactly as before.
+//   - Disconnect path: before MarkDisconnectedTenant, dial the agent. A
+//     successful response calls RecordHeartbeat (which may recover
+//     degraded→connected). A failed response disconnects with reason
+//     "agent_unreachable" instead of "heartbeat_timeout".
+//
 // Returns (degraded, disconnected) counts. Disconnect is processed BEFORE
 // degrade so a site that crosses both thresholds in one pass walks
 // connected→degraded→disconnected over two passes (never skipping a state).
 func (w *Sweeper) Sweep(ctx context.Context, now time.Time) (degraded, disconnected int, err error) {
+	budgetDeadline := now.Add(w.sweepBudget)
+
 	// 1. degraded → disconnected (hard time threshold, single evaluation).
 	disCutoff := now.Add(-w.disconnectAfter)
 	toDisconnect, err := w.repo.ListToDisconnect(ctx, disCutoff)
 	if err != nil {
 		return 0, 0, err
 	}
-	for _, ref := range toDisconnect {
-		if derr := w.svc.MarkDisconnectedTenant(ctx, ref.TenantID, ref.ID, "heartbeat_timeout"); derr != nil {
-			return degraded, disconnected, derr
+
+	if w.activeVerify && w.verifier != nil && len(toDisconnect) > 0 {
+		vResults := w.activeVerifyBatch(ctx, toDisconnect, budgetDeadline)
+		for _, vr := range vResults {
+			w.logVerify("disconnect", vr)
+			if vr.skipped {
+				// Budget exhausted — skip this tick, no state change.
+				continue
+			}
+			if vr.alive {
+				// Agent is reachable — recover via RecordHeartbeat
+				// (may transition degraded→connected) and skip the disconnect.
+				w.recordHeartbeat(ctx, vr.ref)
+				continue
+			}
+			// Agent unreachable — disconnect with the 0.44.0 reason string.
+			if derr := w.svc.MarkDisconnectedTenant(ctx, vr.ref.TenantID, vr.ref.ID, "agent_unreachable"); derr != nil {
+				return degraded, disconnected, derr
+			}
+			disconnected++
 		}
-		disconnected++
+	} else {
+		// Passive mode: disconnect exactly as before.
+		for _, ref := range toDisconnect {
+			if derr := w.svc.MarkDisconnectedTenant(ctx, ref.TenantID, ref.ID, "heartbeat_timeout"); derr != nil {
+				return degraded, disconnected, derr
+			}
+			disconnected++
+		}
 	}
 
 	// 2. connected → degraded (M58 hysteresis: N consecutive overdue evals).
@@ -137,27 +368,89 @@ func (w *Sweeper) Sweep(ctx context.Context, now time.Time) (degraded, disconnec
 	if err != nil {
 		return degraded, disconnected, err
 	}
+
+	// Identify which sites have crossed the miss threshold (need verify/degrade).
+	// We must increment the counter first to know whether the threshold is
+	// crossed, then conditionally verify before calling MarkDegradedTenant.
+	type degradeCandidate struct {
+		ref     SiteRef
+		crossed bool // miss counter has crossed the threshold
+	}
+	candidates := make([]degradeCandidate, 0, len(toDegrade))
 	for _, ref := range toDegrade {
 		if w.missInc == nil {
-			// No incrementer wired — fall back to immediate degrade (tests or
-			// bootstrapping scenario without the DB column).
-			if derr := w.svc.MarkDegradedTenant(ctx, ref.TenantID, ref.ID); derr != nil {
-				return degraded, disconnected, derr
-			}
-			degraded++
+			// No incrementer — fall back to immediate degrade (no hysteresis).
+			candidates = append(candidates, degradeCandidate{ref: ref, crossed: true})
 			continue
 		}
 		newCount, ierr := w.missInc.IncrementMissedHeartbeats(ctx, ref.TenantID, ref.ID)
 		if ierr != nil {
 			return degraded, disconnected, ierr
 		}
-		if int(newCount) >= w.degreesMissThreshold {
-			if derr := w.svc.MarkDegradedTenant(ctx, ref.TenantID, ref.ID); derr != nil {
+		candidates = append(candidates, degradeCandidate{
+			ref:     ref,
+			crossed: int(newCount) >= w.degreesMissThreshold,
+		})
+	}
+
+	// Collect the refs that actually need a transition decision.
+	var toDegradeVerify []SiteRef
+	for _, c := range candidates {
+		if c.crossed {
+			toDegradeVerify = append(toDegradeVerify, c.ref)
+		}
+	}
+
+	if w.activeVerify && w.verifier != nil && len(toDegradeVerify) > 0 {
+		vResults := w.activeVerifyBatch(ctx, toDegradeVerify, budgetDeadline)
+		// Build a lookup by site ID for the verify results.
+		vrByID := make(map[uuid.UUID]verifyResult, len(vResults))
+		for _, vr := range vResults {
+			vrByID[vr.ref.ID] = vr
+		}
+		for _, cand := range candidates {
+			if !cand.crossed {
+				continue
+			}
+			vr, ok := vrByID[cand.ref.ID]
+			if !ok {
+				// Should not happen; degrade conservatively.
+				if derr := w.svc.MarkDegradedTenant(ctx, cand.ref.TenantID, cand.ref.ID); derr != nil {
+					return degraded, disconnected, derr
+				}
+				degraded++
+				continue
+			}
+			w.logVerify("degrade", vr)
+			if vr.skipped {
+				// Budget exhausted — skip, no state change this tick.
+				continue
+			}
+			if vr.alive {
+				// Agent is reachable — reset counter via RecordHeartbeat,
+				// skip the degrade.
+				w.recordHeartbeat(ctx, vr.ref)
+				continue
+			}
+			// Agent unreachable — degrade exactly as before.
+			if derr := w.svc.MarkDegradedTenant(ctx, cand.ref.TenantID, cand.ref.ID); derr != nil {
+				return degraded, disconnected, derr
+			}
+			degraded++
+		}
+	} else {
+		// Passive mode or no verifier: degrade all threshold-crossed candidates.
+		for _, cand := range candidates {
+			if !cand.crossed {
+				continue
+			}
+			if derr := w.svc.MarkDegradedTenant(ctx, cand.ref.TenantID, cand.ref.ID); derr != nil {
 				return degraded, disconnected, derr
 			}
 			degraded++
 		}
 	}
+
 	return degraded, disconnected, nil
 }
 

--- a/apps/api/internal/site/sweeper_active_verify_test.go
+++ b/apps/api/internal/site/sweeper_active_verify_test.go
@@ -1,0 +1,253 @@
+package site
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ----------------------------------------------------------------------------
+// fakes for active-verify tests
+// ----------------------------------------------------------------------------
+
+// fakeVerifier records calls and returns a pre-configured outcome.
+type fakeVerifier struct {
+	alive        bool
+	fallbackUsed bool
+	err          error
+	calls        []verifyCall
+}
+
+type verifyCall struct {
+	siteID  uuid.UUID
+	siteURL string
+}
+
+func (f *fakeVerifier) VerifyReachable(_ context.Context, siteID uuid.UUID, siteURL string) (bool, bool, error) {
+	f.calls = append(f.calls, verifyCall{siteID: siteID, siteURL: siteURL})
+	return f.alive, f.fallbackUsed, f.err
+}
+
+// fakeHeartbeatRecorder records RecordHeartbeat calls.
+type fakeHeartbeatRecorder struct {
+	calls []HeartbeatInput
+}
+
+func (f *fakeHeartbeatRecorder) RecordHeartbeat(_ context.Context, in HeartbeatInput) (HeartbeatResult, error) {
+	f.calls = append(f.calls, in)
+	return HeartbeatResult{}, nil
+}
+
+// recordingTransitioner extends recordTransitioner to capture the disconnect
+// reason string.
+type recordingTransitioner struct {
+	recordTransitioner
+	disconnectReasons []string
+}
+
+func (t *recordingTransitioner) MarkDisconnectedTenant(_ context.Context, _, siteID uuid.UUID, reason string) error {
+	t.recordTransitioner.disconnected = append(t.recordTransitioner.disconnected, siteID)
+	t.disconnectReasons = append(t.disconnectReasons, reason)
+	if t.recordTransitioner.states != nil {
+		t.recordTransitioner.states[siteID] = StateDisconnected
+	}
+	return nil
+}
+
+// ----------------------------------------------------------------------------
+// TestSweeperActiveVerifyKeepsConnected
+//
+// An overdue connected site where the agent answers ping → sweeper does NOT
+// degrade it, miss counter is reset (RecordHeartbeat called).
+// ----------------------------------------------------------------------------
+
+func TestSweeperActiveVerifyKeepsConnected(t *testing.T) {
+	id := uuid.New()
+	tenant := uuid.New()
+	repo := &sweepRepo{
+		toDegrade: []SiteRef{{ID: id, TenantID: tenant, URL: "https://example.com"}},
+	}
+	inc := newFakeMissIncrementer()
+	tr := &recordTransitioner{states: map[uuid.UUID]ConnectionState{}}
+	hbRec := &fakeHeartbeatRecorder{}
+	verifier := &fakeVerifier{alive: true}
+
+	sw := NewSweeper(repo, tr, nil)
+	sw.SetMissIncrementer(inc)
+	sw.SetDegradeMissThreshold(1) // threshold = 1 so the first miss would degrade without verify
+	sw.SetHeartbeatRecorder(hbRec)
+	sw.SetVerifier(verifier)
+	sw.SetActiveVerify(true)
+
+	deg, _, err := sw.Sweep(context.Background(), time.Now())
+	if err != nil {
+		t.Fatalf("sweep error: %v", err)
+	}
+	if deg != 0 {
+		t.Fatalf("expected no degrade (agent is alive), got %d", deg)
+	}
+	if len(tr.degraded) != 0 {
+		t.Fatalf("MarkDegradedTenant called unexpectedly: %v", tr.degraded)
+	}
+	// RecordHeartbeat must be called to reset the miss counter.
+	if len(hbRec.calls) != 1 {
+		t.Fatalf("expected RecordHeartbeat called once, got %d", len(hbRec.calls))
+	}
+	if hbRec.calls[0].SiteID != id {
+		t.Fatalf("RecordHeartbeat called for wrong site: %v", hbRec.calls[0].SiteID)
+	}
+	// VerifyReachable must have been called.
+	if len(verifier.calls) != 1 {
+		t.Fatalf("expected VerifyReachable called once, got %d", len(verifier.calls))
+	}
+	if verifier.calls[0].siteURL != "https://example.com" {
+		t.Fatalf("VerifyReachable called with wrong URL: %q", verifier.calls[0].siteURL)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// TestSweeperActiveVerifyFailDisconnects
+//
+// A degraded site past the disconnect threshold where the agent is dead →
+// sweeper disconnects with reason "agent_unreachable".
+// ----------------------------------------------------------------------------
+
+func TestSweeperActiveVerifyFailDisconnects(t *testing.T) {
+	id := uuid.New()
+	tenant := uuid.New()
+	repo := &sweepRepo{
+		toDisconnect: []SiteRef{{ID: id, TenantID: tenant, URL: "https://dead.example.com"}},
+	}
+	tr := &recordingTransitioner{
+		recordTransitioner: recordTransitioner{states: map[uuid.UUID]ConnectionState{}},
+	}
+	hbRec := &fakeHeartbeatRecorder{}
+	verifier := &fakeVerifier{alive: false}
+
+	sw := NewSweeper(repo, tr, nil)
+	sw.SetHeartbeatRecorder(hbRec)
+	sw.SetVerifier(verifier)
+	sw.SetActiveVerify(true)
+
+	_, dis, err := sw.Sweep(context.Background(), time.Now())
+	if err != nil {
+		t.Fatalf("sweep error: %v", err)
+	}
+	if dis != 1 {
+		t.Fatalf("expected 1 disconnect, got %d", dis)
+	}
+	if len(tr.disconnectReasons) != 1 || tr.disconnectReasons[0] != "agent_unreachable" {
+		t.Fatalf("expected disconnect reason 'agent_unreachable', got %v", tr.disconnectReasons)
+	}
+	// RecordHeartbeat must NOT be called (agent is unreachable).
+	if len(hbRec.calls) != 0 {
+		t.Fatalf("RecordHeartbeat should not be called when agent is unreachable, got %d calls", len(hbRec.calls))
+	}
+}
+
+// ----------------------------------------------------------------------------
+// TestSweeperVerifyBudgetDefersTransition
+//
+// When the sweep budget is already exhausted before the verify phase, all
+// sites are skipped — no degrade or disconnect transitions fire.
+// ----------------------------------------------------------------------------
+
+func TestSweeperVerifyBudgetDefersTransition(t *testing.T) {
+	id1 := uuid.New()
+	id2 := uuid.New()
+	tenant := uuid.New()
+	repo := &sweepRepo{
+		toDegrade:    []SiteRef{{ID: id1, TenantID: tenant, URL: "https://site1.example.com"}},
+		toDisconnect: []SiteRef{{ID: id2, TenantID: tenant, URL: "https://site2.example.com"}},
+	}
+	tr := &recordingTransitioner{
+		recordTransitioner: recordTransitioner{states: map[uuid.UUID]ConnectionState{}},
+	}
+	inc := newFakeMissIncrementer()
+	// verifier: always alive — if it were called and returned alive, we'd
+	// recover; if budget blocks it, neither transition fires either.
+	verifier := &fakeVerifier{alive: true}
+
+	sw := NewSweeper(repo, tr, nil)
+	sw.SetMissIncrementer(inc)
+	sw.SetDegradeMissThreshold(1)
+	sw.SetVerifier(verifier)
+	sw.SetActiveVerify(true)
+	// Set a sweep budget of zero so the deadline is already in the past when
+	// activeVerifyBatch is called — every site should be marked skipped.
+	sw.sweepBudget = 0
+
+	deg, dis, err := sw.Sweep(context.Background(), time.Now())
+	if err != nil {
+		t.Fatalf("sweep error: %v", err)
+	}
+	if deg != 0 || dis != 0 {
+		t.Fatalf("expected no transitions when budget is exhausted, got deg=%d dis=%d", deg, dis)
+	}
+	if len(tr.degraded) != 0 || len(tr.disconnected) != 0 {
+		t.Fatalf("unexpected transitions: degraded=%v disconnected=%v", tr.degraded, tr.disconnected)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// TestSweeperVerifyDisabledEnv
+//
+// WPMGR_SWEEP_ACTIVE_VERIFY=false → passive behaviour identical to pre-0.44.0:
+// stale connected site degrades, stale degraded site disconnects with
+// reason "heartbeat_timeout".
+// ----------------------------------------------------------------------------
+
+func TestSweeperVerifyDisabledEnv(t *testing.T) {
+	degradeID := uuid.New()
+	disconnectID := uuid.New()
+	tenant := uuid.New()
+	repo := &sweepRepo{
+		toDegrade:    []SiteRef{{ID: degradeID, TenantID: tenant, URL: "https://site1.example.com"}},
+		toDisconnect: []SiteRef{{ID: disconnectID, TenantID: tenant, URL: "https://site2.example.com"}},
+	}
+	tr := &recordingTransitioner{
+		recordTransitioner: recordTransitioner{states: map[uuid.UUID]ConnectionState{}},
+	}
+	// Wire a verifier, but disable active verify — it must NOT be called.
+	calledVerify := false
+	verifier := &callRecordingVerifier{fn: func(ctx context.Context, siteID uuid.UUID, siteURL string) (bool, bool, error) {
+		calledVerify = true
+		return false, false, errors.New("should not be called")
+	}}
+
+	sw := NewSweeper(repo, tr, nil)
+	sw.SetVerifier(verifier)
+	sw.SetActiveVerify(false) // passive mode
+
+	deg, dis, err := sw.Sweep(context.Background(), time.Now())
+	if err != nil {
+		t.Fatalf("sweep error: %v", err)
+	}
+	// With no missInc wired, the sweeper falls back to immediate-degrade
+	// behaviour (same as before M58).
+	if deg != 1 {
+		t.Fatalf("expected 1 degrade (passive mode), got %d", deg)
+	}
+	if dis != 1 {
+		t.Fatalf("expected 1 disconnect (passive mode), got %d", dis)
+	}
+	if calledVerify {
+		t.Fatal("VerifyReachable must not be called when active verify is disabled")
+	}
+	// Disconnect reason must be the passive-mode string, not "agent_unreachable".
+	if len(tr.disconnectReasons) != 1 || tr.disconnectReasons[0] != "heartbeat_timeout" {
+		t.Fatalf("expected passive disconnect reason 'heartbeat_timeout', got %v", tr.disconnectReasons)
+	}
+}
+
+// callRecordingVerifier wraps a function as an AgentVerifier.
+type callRecordingVerifier struct {
+	fn func(context.Context, uuid.UUID, string) (bool, bool, error)
+}
+
+func (c *callRecordingVerifier) VerifyReachable(ctx context.Context, siteID uuid.UUID, siteURL string) (bool, bool, error) {
+	return c.fn(ctx, siteID, siteURL)
+}

--- a/apps/landing/src/data/content.ts
+++ b/apps/landing/src/data/content.ts
@@ -133,7 +133,8 @@ export const FEATURES: {
           bullets: [
             "Live flip from Awaiting to Connected, no refresh",
             "One-click wp-admin login, no shared passwords",
-            "Stable status badges plus a manual Re-check",
+            "Sweeper dials quiet sites to verify liveness, not just heartbeats",
+            "Accurate badge: unreachable vs idle, never a false disconnect",
           ],
         },
         {

--- a/apps/web/src/components/status/connection-state-badge-helpers.ts
+++ b/apps/web/src/components/status/connection-state-badge-helpers.ts
@@ -1,0 +1,39 @@
+// Pure helper functions for the connection-state-badge component.
+// Kept in a separate module so the react-refresh fast-refresh boundary stays
+// clean (a file exporting a component should not also export plain functions).
+
+import type { ConnectionState } from "@/features/sites/connection-state";
+
+/**
+ * SHAPE labels duplicated here as a const so this module has no runtime
+ * dependency on the component file (avoids the circular import that would
+ * arise if connection-state-badge.tsx imported from this file and vice versa).
+ */
+const STATE_LABELS: Record<ConnectionState, string> = {
+  pending_enrollment: "Awaiting agent",
+  connected: "Connected",
+  degraded: "Degraded",
+  disconnected: "Disconnected",
+  revoked: "Revoked",
+  archived: "Archived",
+};
+
+/**
+ * Resolve the human-visible label for the disconnected state based on the
+ * disconnect reason written by the CP.
+ *
+ * - "agent_unreachable": the CP dialed the agent directly and got no answer
+ *   (active verify). The site may be truly down.
+ * - "heartbeat_timeout" or absent: the agent stopped reporting on its own
+ *   schedule (passive path). The site itself may still be up.
+ *
+ * For all other states the label from STATE_LABELS is returned unchanged.
+ */
+export function resolveLabel(
+  state: ConnectionState,
+  disconnectedReason?: string | null,
+): string {
+  if (state !== "disconnected") return STATE_LABELS[state];
+  if (disconnectedReason === "agent_unreachable") return "Agent unreachable";
+  return "No heartbeat";
+}

--- a/apps/web/src/components/status/connection-state-badge.test.ts
+++ b/apps/web/src/components/status/connection-state-badge.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+
+import { resolveLabel } from "./connection-state-badge-helpers";
+
+// Unit coverage for the `resolveLabel` function that maps disconnected_reason
+// onto human-visible badge copy. The full badge render (React component) is
+// not tested here because this project does not yet have @testing-library/react
+// wired up; this file pins the pure-function contract that the badge delegates
+// to, so the reason->copy mapping can be verified independently of the DOM.
+
+describe("resolveLabel — disconnected state variants", () => {
+  it('returns "Agent unreachable" for agent_unreachable reason', () => {
+    expect(resolveLabel("disconnected", "agent_unreachable")).toBe(
+      "Agent unreachable",
+    );
+  });
+
+  it('returns "No heartbeat" for heartbeat_timeout reason', () => {
+    expect(resolveLabel("disconnected", "heartbeat_timeout")).toBe(
+      "No heartbeat",
+    );
+  });
+
+  it('returns "No heartbeat" when reason is absent (legacy passive path)', () => {
+    expect(resolveLabel("disconnected", null)).toBe("No heartbeat");
+    expect(resolveLabel("disconnected", undefined)).toBe("No heartbeat");
+    expect(resolveLabel("disconnected")).toBe("No heartbeat");
+  });
+
+  it('returns "No heartbeat" for any unrecognized reason string (forward-compat)', () => {
+    expect(resolveLabel("disconnected", "some_future_reason")).toBe(
+      "No heartbeat",
+    );
+  });
+});
+
+describe("resolveLabel — non-disconnected states pass through unchanged", () => {
+  it('returns "Connected" for connected state regardless of reason', () => {
+    expect(resolveLabel("connected", "agent_unreachable")).toBe("Connected");
+    expect(resolveLabel("connected")).toBe("Connected");
+  });
+
+  it('returns "Degraded" for degraded state', () => {
+    expect(resolveLabel("degraded")).toBe("Degraded");
+  });
+
+  it('returns "Awaiting agent" for pending_enrollment state', () => {
+    expect(resolveLabel("pending_enrollment")).toBe("Awaiting agent");
+  });
+
+  it('returns "Revoked" for revoked state', () => {
+    expect(resolveLabel("revoked")).toBe("Revoked");
+  });
+
+  it('returns "Archived" for archived state', () => {
+    expect(resolveLabel("archived")).toBe("Archived");
+  });
+});

--- a/apps/web/src/components/status/connection-state-badge.tsx
+++ b/apps/web/src/components/status/connection-state-badge.tsx
@@ -24,6 +24,7 @@ import { StatusDot, type StatusTone } from "./status-dot";
 // perpetual attention magnet.
 
 import type { ConnectionState } from "@/features/sites/connection-state";
+import { resolveLabel } from "./connection-state-badge-helpers";
 
 export interface ConnectionStateBadgeProps {
   state: ConnectionState;
@@ -31,6 +32,12 @@ export interface ConnectionStateBadgeProps {
   lastSeenAt?: string | null;
   /** ISO enrollment-code expiry; drives the "{N}m left" pending tail. */
   expiresAt?: string | null;
+  /**
+   * CP-written disconnect reason. Distinguishes an actively-verified failure
+   * ("agent_unreachable") from a passive heartbeat gap ("heartbeat_timeout").
+   * Only meaningful when `state === "disconnected"`.
+   */
+  disconnectedReason?: string | null;
   /** Pulse the dot once when the state changes. Defaults to true. */
   pulseOnChange?: boolean;
   className?: string;
@@ -137,6 +144,7 @@ export function ConnectionStateBadge({
   state,
   lastSeenAt,
   expiresAt,
+  disconnectedReason,
   pulseOnChange = true,
   className,
 }: ConnectionStateBadgeProps) {
@@ -146,14 +154,19 @@ export function ConnectionStateBadge({
   const now = useNow(tickFor(displayState));
   const shape = SHAPE[displayState];
 
+  // For disconnected state, override the label based on the disconnect reason
+  // so operators see an accurate, actionable description rather than the generic
+  // "Disconnected" label which conflates two different scenarios.
+  const displayLabel = resolveLabel(displayState, disconnectedReason);
+
   const tail = useMemo(
-    () => computeTail(displayState, now, lastSeenAt, expiresAt),
-    [displayState, now, lastSeenAt, expiresAt],
+    () => computeTail(displayState, now, lastSeenAt, expiresAt, disconnectedReason),
+    [displayState, now, lastSeenAt, expiresAt, disconnectedReason],
   );
 
   const a11yLabel = tail.text
-    ? `${shape.label}, ${tail.aria ?? tail.text}`
-    : shape.label;
+    ? `${displayLabel}, ${tail.aria ?? tail.text}`
+    : displayLabel;
 
   return (
     <span
@@ -162,6 +175,7 @@ export function ConnectionStateBadge({
         className,
       )}
       aria-label={a11yLabel}
+      title={tail.tooltip ?? undefined}
     >
       {/* The dot is decorative here; the wrapper span carries the a11y label
           (and an aria-live region announces pending countdowns, see below). */}
@@ -170,7 +184,7 @@ export function ConnectionStateBadge({
         glyph={shape.glyph}
         pulseOnChange={pulseOnChange}
       />
-      <span aria-hidden="true">{shape.label}</span>
+      <span aria-hidden="true">{displayLabel}</span>
       {tail.text ? (
         <>
           <span aria-hidden="true" className="text-muted-foreground">
@@ -235,6 +249,8 @@ interface Tail {
   text: string | null;
   /** Optional fuller phrasing for the accessible label. */
   aria?: string;
+  /** Optional tooltip text surfaced on the badge wrapper. */
+  tooltip?: string | null;
 }
 
 function computeTail(
@@ -242,6 +258,7 @@ function computeTail(
   now: number,
   lastSeenAt?: string | null,
   expiresAt?: string | null,
+  disconnectedReason?: string | null,
 ): Tail {
   switch (state) {
     case "pending_enrollment": {
@@ -255,12 +272,20 @@ function computeTail(
     case "degraded": {
       const t = shortRelative(lastSeenAt);
       if (!t) return { text: null };
-      return { text: `last seen ${t}`, aria: `last seen ${t}` };
+      const tooltip =
+        state === "degraded"
+          ? "Agent quiet; the control plane is verifying reachability."
+          : null;
+      return { text: `last seen ${t}`, aria: `last seen ${t}`, tooltip };
     }
     case "disconnected": {
       const t = shortRelative(lastSeenAt);
-      if (!t) return { text: null };
-      return { text: t, aria: `since ${t}` };
+      const isActiveVerify = disconnectedReason === "agent_unreachable";
+      const tooltip = isActiveVerify
+        ? "The control plane dialed the agent directly and got no answer."
+        : "The agent stopped reporting; the site itself may still be up. Check the uptime pill.";
+      if (!t) return { text: null, tooltip };
+      return { text: t, aria: `since ${t}`, tooltip };
     }
     case "revoked":
     case "archived":

--- a/apps/web/src/features/health/card-cron.tsx
+++ b/apps/web/src/features/health/card-cron.tsx
@@ -1,6 +1,10 @@
+import { useState } from "react";
+import { X } from "lucide-react";
 import type { SiteDiagnosticsCard } from "@wpmgr/api";
 
+import { CopyableMono } from "@/components/shared/copyable-mono";
 import { DefinitionList } from "@/components/shared/definition-list";
+import { cn } from "@/lib/utils";
 
 import { DiagnosticCard } from "./diagnostic-card";
 import { pickBool, pickNumber } from "./diagnostic-pick";
@@ -8,10 +12,75 @@ import { pickBool, pickNumber } from "./diagnostic-pick";
 // Cron card — DISABLE_WP_CRON state, registered event count, and the leapfrog
 // `overdue_max_seconds` field (the longest-overdue WP-Cron event). A growing
 // overdue_max is the canonical "wp-cron is silently broken" signal.
+//
+// Starvation callout: shown when DISABLE_WP_CRON is true and overdue_max_seconds
+// is above the 600s threshold, OR when DISABLE_WP_CRON is true with no recent
+// runs (overdue_max > 0 acts as that proxy). The callout is dismissible and the
+// dismiss state is persisted to localStorage keyed by siteId so it does not
+// reappear across sessions for the same site.
 
-export function CardCron({ card }: { card: SiteDiagnosticsCard | undefined }) {
+const STARVATION_THRESHOLD_S = 600;
+const DISMISS_KEY_PREFIX = "wpmgr.cron.starvation.dismissed";
+
+function dismissKey(siteId: string): string {
+  return `${DISMISS_KEY_PREFIX}.${siteId}`;
+}
+
+function isDismissed(siteId: string): boolean {
+  try {
+    return localStorage.getItem(dismissKey(siteId)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function persist(siteId: string): void {
+  try {
+    localStorage.setItem(dismissKey(siteId), "1");
+  } catch {
+    // localStorage blocked (e.g. private mode with storage blocked) — ignore;
+    // the callout will simply reappear next load, which is acceptable.
+  }
+}
+
+/**
+ * Whether to surface the cron-starvation guidance callout.
+ *
+ * Gating condition (OR):
+ *   - DISABLE_WP_CRON is true AND overdue_max_seconds > STARVATION_THRESHOLD_S
+ *   - DISABLE_WP_CRON is true AND overdue_max_seconds > 0 (any overdue event)
+ *
+ * Both branches collapse to: disabled === true && overdue > 0 (since any
+ * positive overdue satisfies the second branch, and the first is a subset).
+ * We gate on the 600s threshold to keep the signal meaningful: a site that
+ * just missed one short-interval event is not "starved".
+ */
+function isStarved(disabled: boolean, overdue: number): boolean {
+  return disabled && overdue > STARVATION_THRESHOLD_S;
+}
+
+export interface CardCronProps {
+  card: SiteDiagnosticsCard | undefined;
+  /** Site URL — substituted into the example cron command. */
+  siteUrl?: string;
+  /** Site ID — used to key the per-site localStorage dismiss flag. */
+  siteId?: string;
+}
+
+export function CardCron({ card, siteUrl, siteId }: CardCronProps) {
   const payload = card?.payload as Record<string, unknown> | null | undefined;
   const overdue = pickNumber(payload, "overdue_max_seconds");
+  const disabled = pickBool(payload, "disabled");
+
+  const showCallout = isStarved(disabled, overdue);
+  const [dismissed, setDismissed] = useState<boolean>(
+    () => (siteId ? isDismissed(siteId) : false),
+  );
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    if (siteId) persist(siteId);
+  };
 
   return (
     <DiagnosticCard title="Cron" card={card}>
@@ -37,7 +106,75 @@ export function CardCron({ card }: { card: SiteDiagnosticsCard | undefined }) {
           },
         ]}
       />
+      {showCallout && !dismissed ? (
+        <CronStarvationCallout
+          siteUrl={siteUrl}
+          onDismiss={handleDismiss}
+        />
+      ) : null}
     </DiagnosticCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Starvation guidance callout
+// ---------------------------------------------------------------------------
+
+function CronStarvationCallout({
+  siteUrl,
+  onDismiss,
+}: {
+  siteUrl?: string;
+  onDismiss: () => void;
+}) {
+  const exampleUrl = siteUrl ?? "https://example.com";
+  // Ensure no trailing slash so the path reads cleanly.
+  const cronUrl = exampleUrl.replace(/\/$/, "") + "/wp-cron.php";
+
+  const configLine = "define('DISABLE_WP_CRON', true);";
+  const cronLine = `* * * * * curl -s ${cronUrl} >/dev/null`;
+
+  return (
+    <div
+      role="note"
+      className={cn(
+        "relative rounded-md border border-border bg-muted/50 px-3 py-2.5 text-xs",
+      )}
+    >
+      <button
+        type="button"
+        aria-label="Dismiss cron guidance"
+        onClick={onDismiss}
+        className="absolute right-2 top-2 inline-flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+      >
+        <X aria-hidden="true" className="size-3" />
+      </button>
+
+      <p className="pr-6 font-medium text-foreground">
+        Keep schedules running on cached sites
+      </p>
+      <p className="mt-1 pr-6 text-muted-foreground">
+        WordPress runs scheduled tasks only when a page actually executes PHP.
+        On a heavily cached or low-traffic site schedules can stall. A real
+        server cron job calling wp-cron.php every minute keeps schedules
+        reliable regardless of traffic. Set{" "}
+        <code className="font-mono">DISABLE_WP_CRON</code> in wp-config.php
+        and add a system cron entry:
+      </p>
+
+      <div className="mt-2 flex flex-col gap-1">
+        <CopyableMono
+          value={configLine}
+          label="Copy wp-config.php constant"
+          className="text-[11px]"
+        />
+        <CopyableMono
+          value={cronLine}
+          label="Copy cron entry"
+          className="text-[11px]"
+        />
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/src/features/health/health-tab.tsx
+++ b/apps/web/src/features/health/health-tab.tsx
@@ -105,7 +105,11 @@ export function HealthTab({ siteId }: { siteId: string }) {
 
       <Section label="Delivery">
         <CardHTTP card={cardFor(data, "http")} />
-        <CardCron card={cardFor(data, "cron")} />
+        <CardCron
+          card={cardFor(data, "cron")}
+          siteId={siteId}
+          siteUrl={site?.url}
+        />
       </Section>
 
       <Section label="Configuration">

--- a/apps/web/src/features/sites/sites-table.tsx
+++ b/apps/web/src/features/sites/sites-table.tsx
@@ -52,6 +52,7 @@ import {
   type BackupChipStatus,
 } from "@/components/status";
 import {
+  asConnectedSite,
   connectionStateOf,
   isReconnectable,
   type ConnectionState,
@@ -137,6 +138,11 @@ interface SiteRow {
   readonly connectionState: ConnectionState;
   /** ISO-8601 string for the <time datetime> attribute; null when unknown. */
   readonly lastSeenAt: string | null;
+  /**
+   * CP-written disconnect reason; distinguishes "agent_unreachable" (active
+   * verify failed) from "heartbeat_timeout" / absent (passive gap).
+   */
+  readonly disconnectedReason: string | null;
   readonly updatesCount: number;
   readonly updatesSeverity: "minor" | "major";
   readonly backupStatus: BackupChipStatus | null;
@@ -167,6 +173,7 @@ function rowOf(site: Site): SiteRow {
     hostname: hostnameFromUrl(site.url),
     connectionState: connectionStateOf(site),
     lastSeenAt: site.last_seen_at ?? null,
+    disconnectedReason: asConnectedSite(site).disconnected_reason ?? null,
     // M27 — real data from the sites list DTO. updates_available, last_backup_*
     // and agent_version are summarized/joined CP-side.
     updatesCount: site.updates_available ?? 0,
@@ -269,6 +276,7 @@ function buildColumns(
             <ConnectionStateBadge
               state={connectionState}
               lastSeenAt={lastSeenAt}
+              disconnectedReason={row.original.disconnectedReason}
             />
           </div>
         );

--- a/apps/web/src/routes/_authed/sites/$siteId.tsx
+++ b/apps/web/src/routes/_authed/sites/$siteId.tsx
@@ -31,6 +31,7 @@ import { useSitesLiveSync } from "@/features/sites/use-sites-live";
 import { AutoLoginButton } from "@/features/sites/auto-login-button";
 import { canAutoLogin } from "@/features/sites/use-autologin";
 import {
+  asConnectedSite,
   connectionStateOf,
   isReconnectable,
 } from "@/features/sites/connection-state";
@@ -190,6 +191,7 @@ function SiteShell({ site, siteId }: { site: Site; siteId: string }) {
   const hostname = hostnameOf(site.url);
   const adminUrl = `${stripTrailingSlash(site.url)}/wp-admin/`;
   const connectionState = connectionStateOf(site);
+  const disconnectedReason = asConnectedSite(site).disconnected_reason ?? null;
   // pending_enrollment ("Awaiting agent") also gets the code action — the raw
   // enrollment code is shown once, so a stuck-pending site needs a way back to it.
   const canReconnect =
@@ -312,6 +314,7 @@ function SiteShell({ site, siteId }: { site: Site; siteId: string }) {
           <ConnectionStateBadge
             state={connectionState}
             lastSeenAt={site.last_seen_at ?? null}
+            disconnectedReason={disconnectedReason}
           />
           {/* UptimePill renders nothing when no monitor is configured for this
               site, so no conditional guard needed here. */}


### PR DESCRIPTION
## Problem

Agent heartbeats ride WP-Cron, which only runs when PHP boots. On a fully page-cached low-traffic site the web server serves everything from disk, WordPress never boots, and a perfectly healthy site shows **disconnected** (root-caused live on msm.oscod.dev: openresty serving a 3-day-old cache file, zero PHP, sweeper timing the site out every ~15 min after each manual recheck).

## Fix (3 layers)

- **CP**: the sweeper actively dials quiet sites with a new signed `ping` command (metadata fallback for pre-0.44 agents) before degrading/disconnecting. A shape-verified answer counts as a heartbeat and also wakes the site's cron, so a fleet of idle cached sites stays fully functional with zero visitor traffic. Verified-dead sites disconnect with reason `agent_unreachable`. Bounded: 8s/dial, 8 concurrent, 12s sweep budget; `WPMGR_SWEEP_ACTIVE_VERIFY` opt-out. Captive-portal/generic 200s never count as alive.
- **Agent 0.44.0**: signed `ping` command (+`spawn_cron`), last-heartbeat ledger, shutdown catch-up heartbeat (>2 min overdue, stampede lock, 5s timeout).
- **Web**: badge distinguishes "Agent unreachable" vs "No heartbeat"; dismissible Health-tab callout recommends a real server cron on starved sites.

## Verification

- Go: build/vet/tests green incl. 6 new named tests (verify-keeps-connected, fail-disconnects, metadata fallback, captive-portal rejection, budget defer, env-off)
- PHP: 1689 tests / 5421 assertions, exit 0; phpcs clean; Plugin Check 0 errors
- Web: typecheck/build/lint/impeccable clean; 9 new badge tests
- Security review: PASS; both LOW findings fixed in this PR (non-agent 200 shape check, 5s shutdown timeout)

No migration. CP deploys first and fixes existing fleets immediately (old agents covered by the metadata fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 0.44.0 Release Notes

* **New Features**
  * Added active reachability verification to distinguish between unreachable agents and idle sites, preventing false disconnections on page-cached hosts.
  * Implemented shutdown catch-up heartbeat to ensure timely heartbeat delivery when WordPress boots with overdue notifications.
  * Enhanced connection badge tooltips with "agent unreachable" vs "no heartbeat" distinction and degraded verification status indicators.
  * Added Health tab callout recommending WP-Cron configuration best practices.

* **Bug Fixes**
  * Fixed healthy idle sites incorrectly appearing as disconnected on page-cached hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->