### PR TITLE
release: 0.46.0 — wp.org compliance (packaging, external services, SQL prepare, uploads-based backups)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.46.0] - 2026-06-15
+
+### Changed
+
+- **Local backups are stored under the uploads directory.** The local backup destination now writes to uploads/wpmgr-backups (falling back to wp-content only when uploads is not writable), with a deny-all .htaccess and an index.php guard so archives are never directly downloadable, plus a best-effort migration of any existing local backups. Snapshots and the media quarantine already used the uploads-based location.
+- **Database queries hardened with prepared placeholders.** The object-cache drop-in installer's transient cleanup and the media URL rewriter's postmeta lookup now bind their values through $wpdb->prepare().
+
+### Added
+
+- **External services fully documented.** The readme now lists every outbound service the agent's own code can contact, including the Amazon SES, SendGrid, Mailgun, and Postmark email providers, each with what is sent, when, and links to its terms and privacy policy.
+
+### Fixed
+
+- **WordPress.org distribution packaging.** The directory build no longer ships vendor CLI entrypoints, vendor license files, or hidden dotfiles; a .distignore is included for source-level archive tooling.
+
+This is an agent-focused compliance release; the control plane and dashboard images are rebuilt at the same version with no functional change.
+
 ## [0.45.0] - 2026-06-13
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -150,15 +150,29 @@ agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip (fl
 	# site_transient_update_plugins hook (B2 / G8). NOTICE.md and README.md are
 	# excluded because wp.org rejects unexpected Markdown files (B4 / C8).
 	# Dev-only files mirror the existing agent-zip excludes.
+	# vendor/bin/ and vendor/*/bin/ are excluded because wp.org does not permit
+	# CLI entrypoints (minifyjs, minifycss) — the matthiasmullie/minify library is
+	# used via its PHP API only (no shell-out to the bin scripts anywhere in the
+	# agent). vendor/*/LICENSE files are excluded because wp.org flags them as
+	# unexpected non-code files; the library licences are already referenced in the
+	# plugin's own LICENSE / readme.txt.
 	rsync -a --delete \
 		--exclude 'tests/' --exclude 'tests-e2e/' --exclude 'tools/' --exclude '*.dist' --exclude '.phpunit.cache/' \
 		--exclude '.phpunit.result.cache' --exclude 'composer.lock' \
 		--exclude '.DS_Store' --exclude '*.zip' \
+		--exclude '.distignore' --exclude '.gitignore' --exclude '.gitattributes' \
 		--exclude 'phpstan.neon' --exclude 'phpstan-baseline.neon' \
 		--exclude 'NOTICE.md' --exclude 'README.md' \
 		--exclude 'patchwork.json' \
 		--exclude 'includes/support/class-update-checker.php' \
 		apps/agent/ release/fleet-agent-for-wpmgr/
+	# Remove CLI entrypoints and LICENSE files that wp.org does not permit.
+	# rsync --exclude patterns for vendor/*/bin/ do not recurse into arbitrary
+	# depth (e.g. vendor/matthiasmullie/minify/bin/ is 3 levels deep), so a
+	# post-stage find+delete is more reliable than path-based excludes.
+	find release/fleet-agent-for-wpmgr/vendor/bin -mindepth 0 -maxdepth 0 -type d -exec rm -rf {} + 2>/dev/null || true
+	find release/fleet-agent-for-wpmgr/vendor -mindepth 2 -type d -name bin -exec rm -rf {} + 2>/dev/null || true
+	find release/fleet-agent-for-wpmgr/vendor -mindepth 2 -type f -name LICENSE -delete 2>/dev/null || true
 	# Rename the main plugin file to match the wp.org slug. WordPress derives the
 	# plugin's displayed name, slug, and update identity from the top-level .php
 	# filename inside the archive folder — renaming is mandatory for the wp.org slug.

--- a/apps/agent/.distignore
+++ b/apps/agent/.distignore
@@ -1,0 +1,36 @@
+# .distignore — files and directories excluded from all distribution zips.
+# Kept in sync with the rsync --exclude flags in:
+#   Makefile: agent-zip (self-host) and agent-zip-wporg (wp.org build).
+# This file is informational for tooling (e.g. wp-cli dist-archive) and serves
+# as the canonical reference for what must NOT ship in either zip.
+
+# Dev / test infrastructure
+tests/
+tests-e2e/
+tools/
+.phpunit.cache/
+.phpunit.result.cache
+patchwork.json
+phpstan.neon
+phpstan-baseline.neon
+
+# Build artefacts / local overrides
+*.dist
+composer.lock
+*.zip
+.DS_Store
+
+# wp.org-only exclusions (also excluded from agent-zip-wporg, not from agent-zip)
+# These are listed here for completeness; agent-zip keeps them.
+includes/support/class-update-checker.php
+NOTICE.md
+README.md
+
+# Vendor CLI entrypoints — not permitted by wp.org; not used at runtime
+# (matthiasmullie/minify is called via its PHP API only, never via the CLI bin scripts).
+vendor/bin/
+vendor/*/bin/
+
+# Vendor LICENSE files — flagged by wp.org as unexpected non-code files.
+# Library licences are referenced in the plugin's own LICENSE / readme.txt.
+vendor/*/LICENSE

--- a/apps/agent/includes/backup/destinations/class-local-destination.php
+++ b/apps/agent/includes/backup/destinations/class-local-destination.php
@@ -2,24 +2,28 @@
 /**
  * Local destination — ADR-036 P1.
  *
- * Chunks land in `WP_CONTENT_DIR/wpmgr-backups/<snapshot_id>/chunks/<hash>.bin`
- * on the same webserver as the WordPress site. This mirrors the "local folder"
- * destination offered by leading backup plugins (the most-used option because
- * customers without S3 credentials still want a backup off the live tree). The manifest is written next to the chunks AND a metadata-only POST
- * still goes to the CP so the snapshot shows up in the operator UI; only the
- * bytes stay local.
+ * Chunks land in `uploads/wpmgr-backups/<snapshot_id>/chunks/<hash>.bin`
+ * on the same webserver as the WordPress site, routing through
+ * StoragePaths::dataBase('backups') (uploads-first, wp-content fallback).
+ * This mirrors the "local folder" destination offered by leading backup plugins
+ * (the most-used option because customers without S3 credentials still want a
+ * backup off the live tree). The manifest is written next to the chunks AND a
+ * metadata-only POST still goes to the CP so the snapshot shows up in the
+ * operator UI; only the bytes stay local.
  *
  * Deny-by-default is critical: a backup zip is a complete copy of the site,
- * including wp-config.php credentials and the SQL dump. We drop four files
- * into the base dir on first prepare:
+ * including wp-config.php credentials and the SQL dump. We drop the following
+ * guard files into the base dir on first prepare (via StoragePaths::ensureHardened):
  *
- *   - .htaccess          (Apache mod_rewrite deny — covers shared hosts)
- *   - web.config         (IIS — covers Microsoft-host customers)
+ *   - .htaccess          (Apache/LiteSpeed deny — auto-applied)
+ *   - index.php          (PHP directory-listing silence guard — auto-applied)
+ *   - web.config         (IIS deny — covers Microsoft-host customers)
  *   - nginx.conf.snippet (sample directive — customer must include it)
  *   - README.txt         (explains the directory + nginx instructions)
  *
- * Three of those are picked up automatically by the web server; nginx needs an
- * operator action so we ship a clear README pointing at the snippet.
+ * Apache, LiteSpeed, and PHP-proxied servers are protected automatically;
+ * nginx needs an operator action so we ship a clear README pointing at the
+ * snippet.
  *
  * @package WPMgr\Agent\Backup\Destinations
  */
@@ -29,6 +33,7 @@ declare(strict_types=1);
 namespace WPMgr\Agent\Backup\Destinations;
 
 use WPMgr\Agent\Support\BackupTransport;
+use WPMgr\Agent\Support\StoragePaths;
 
 /**
  * Writes ciphertext chunks to a local directory under wp-content. The CP only
@@ -70,12 +75,24 @@ final class LocalDestination implements BackupDestination
     }
 
     /**
-     * Resolve the base dir (WP_CONTENT_DIR preferred; uploads fallback), create
-     * the per-snapshot chunk dir, and drop the deny-by-default config files.
+     * Resolve the base dir (uploads-first via StoragePaths; wp-content fallback),
+     * create the per-snapshot chunk dir, and drop the deny-by-default config files.
+     *
+     * resolveBaseDir() delegates to StoragePaths for uploads-first resolution and
+     * handles the best-effort legacy migration. StoragePaths::ensureHardened() then
+     * drops .htaccess + index.php web-access guards (required because uploads/ is
+     * web-accessible). ensureBaseGuardFiles() adds IIS web.config, nginx snippet,
+     * and README for additional server coverage.
      */
     public function prepare(string $snapshotId): void
     {
         $base = $this->resolveBaseDir();
+        // Apply web-access hardening (.htaccess + index.php) on the path that is
+        // ACTUALLY written to. resolveBaseDir() can return the legacy wp-content
+        // location on read-only-uploads hosts, so harden $base directly rather
+        // than the uploads path StoragePaths::dataBase() would recompute. Guards
+        // are idempotent (file_exists short-circuits).
+        StoragePaths::ensureHardenedPath($base);
         $this->ensureBaseGuardFiles($base);
 
         $snapshotDir = $base . DIRECTORY_SEPARATOR . $snapshotId;
@@ -196,24 +213,41 @@ final class LocalDestination implements BackupDestination
     }
 
     /**
-     * Pick the dir under which we'll create wpmgr-backups/. Uploads is the
-     * preferred target (wp.org Guideline compliance; matches UpdraftPlus default)
-     * with WP_CONTENT_DIR as a fallback for hosts where uploads is read-only.
+     * Pick the base dir for wpmgr-backups/.
+     *
+     * Delegates to StoragePaths::dataBase('backups') for uploads-first resolution
+     * (wp.org Guideline compliance). Web-access guard files (.htaccess + index.php)
+     * are written by StoragePaths::ensureHardened() because uploads/ is web-accessible.
+     *
+     * Best-effort migration: if the legacy wp-content/wpmgr-backups directory exists
+     * and the new uploads-based location does not yet exist, we atomically rename it
+     * so existing local backups are preserved without operator intervention.
+     *
+     * Read-fallback: if the primary path is not writable but the legacy location is,
+     * we use the legacy location so existing self-hosted flows are not broken.
      */
     private function resolveBaseDir(): string
     {
-        $candidates = [];
-        // Uploads-first: honors relocatable upload_path + multisite per-site subdirs.
-        if (function_exists('wp_upload_dir')) {
-            $upload = wp_upload_dir();
-            if (is_array($upload) && isset($upload['basedir']) && is_string($upload['basedir']) && $upload['basedir'] !== '') {
-                $candidates[] = rtrim($upload['basedir'], '/\\') . DIRECTORY_SEPARATOR . self::BASE_DIR_NAME;
+        // Primary candidate: uploads-first via StoragePaths.
+        $primary = StoragePaths::dataBase('backups');
+        $legacy  = StoragePaths::legacyBase('backups');
+
+        // Best-effort migration: atomically move legacy dir to new location.
+        if ($primary !== ''
+            && $primary !== $legacy
+            && $legacy !== ''
+            && is_dir($legacy)
+            && !is_dir($primary)
+        ) {
+            $newParent = dirname($primary);
+            if (!is_dir($newParent) && function_exists('wp_mkdir_p')) {
+                wp_mkdir_p($newParent);
             }
+            // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic directory rename; WP_Filesystem::move() is non-atomic and would leave partial state on failure
+            @rename($legacy, $primary);
         }
-        // Fallback: wp-content (for managed-WP hosts where uploads may be read-only).
-        if (defined('WP_CONTENT_DIR') && is_string(WP_CONTENT_DIR) && WP_CONTENT_DIR !== '') {
-            $candidates[] = rtrim((string) WP_CONTENT_DIR, '/\\') . DIRECTORY_SEPARATOR . self::BASE_DIR_NAME;
-        }
+
+        $candidates = array_filter(array_unique([$primary, $legacy]));
         foreach ($candidates as $candidate) {
             if (is_dir($candidate)) {
                 if (is_writable($candidate)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- headless agent; WP_Filesystem never initialized; direct writability probe is the only option
@@ -221,7 +255,7 @@ final class LocalDestination implements BackupDestination
                 }
                 continue;
             }
-            // Try to create + chmod the dir; if we succeed it's writable for us.
+            // Try to create the dir; if we succeed it's writable for us.
             if (@mkdir($candidate, self::DIR_MODE, true) || is_dir($candidate)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- explicit 0700 perms on secret backup dir; wp_mkdir_p would apply the wider FS_CHMOD_DIR
                 @chmod($candidate, self::DIR_MODE); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod -- explicit security perms (0700); WP_Filesystem would coerce to wider FS_CHMOD_DIR
                 if (is_writable($candidate)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- headless agent; WP_Filesystem never initialized; direct writability probe is the only option
@@ -229,21 +263,25 @@ final class LocalDestination implements BackupDestination
                 }
             }
         }
-        throw new \RuntimeException('WPMgr Local Destination: no writable base dir under wp-content or uploads');
+        throw new \RuntimeException('WPMgr Local Destination: no writable base dir under uploads or wp-content');
     }
 
     /**
-     * Drop deny-by-default web-server config + a README on first prepare. Each
-     * file is only written if missing (idempotent across snapshots — the same
-     * base dir is shared).
+     * Drop supplemental deny-by-default guard files + a README on first prepare.
+     * Each file is only written if missing (idempotent across snapshots — the
+     * same base dir is shared). .htaccess and index.php are already written by
+     * StoragePaths::ensureHardened(); this method adds IIS and nginx coverage.
      */
     private function ensureBaseGuardFiles(string $base): void
     {
-        $files = [
-            '.htaccess' => "<IfModule mod_rewrite.c>\nRewriteEngine On\nRewriteRule .* - [F,L]\n</IfModule>\n",
-            'web.config' => '<configuration><system.webServer><security><authorization><remove users="*" roles="" verbs="" /></authorization></security></system.webServer></configuration>',
-            'nginx.conf.snippet' => "location ~ ^/wp-content/wpmgr-backups/ { deny all; return 403; }\n",
-            'README.txt' => $this->readmeBody(),
+        // The actual on-disk path (may be under uploads/ or wp-content/ depending
+        // on the host) is passed to the nginx snippet so operators can copy it.
+        $nginxLocation = rtrim(str_replace('\\', '/', $base), '/') . '/';
+        $files         = [
+            'web.config'         => '<configuration><system.webServer><security><authorization><remove users="*" roles="" verbs="" /></authorization></security></system.webServer></configuration>',
+            'nginx.conf.snippet' => "# Add inside the `server { ... }` block of your WordPress vhost.\n"
+                                    . "location ~ ^" . preg_quote($nginxLocation, '~') . " { deny all; return 403; }\n",
+            'README.txt'         => $this->readmeBody($base),
         ];
         foreach ($files as $name => $contents) {
             $path = $base . DIRECTORY_SEPARATOR . $name;
@@ -255,8 +293,9 @@ final class LocalDestination implements BackupDestination
         }
     }
 
-    private function readmeBody(): string
+    private function readmeBody(string $base = ''): string
     {
+        $dirNote = $base !== '' ? rtrim(str_replace('\\', '/', $base), '/') . '/' : 'this directory';
         return "WPMgr local backups\n"
             . "===================\n\n"
             . "This directory holds backup chunks for sites that selected the\n"
@@ -268,7 +307,7 @@ final class LocalDestination implements BackupDestination
             . "nginx users: include the snippet in nginx.conf.snippet inside the\n"
             . "matching `server { ... }` block (or the relevant `include` you\n"
             . "already pull into the WordPress vhost). Reload nginx and verify\n"
-            . "that GET https://your-site/wp-content/wpmgr-backups/ returns a\n"
+            . "that a request to " . $dirNote . " returns a\n"
             . "403 before relying on this destination.\n";
     }
 

--- a/apps/agent/includes/cache/class-cache-manager.php
+++ b/apps/agent/includes/cache/class-cache-manager.php
@@ -130,6 +130,12 @@ final class CacheManager
     public function startBuffer(): void
     {
         $writer = new CacheWriter($this->config(), $this->cacheRoot());
+        // Full-page output buffer with a callback handler: this is the standard
+        // page-cache capture pattern. PHP finalizes the buffer at request end,
+        // invoking CacheWriter::handle() with the complete response. The buffer
+        // is intentionally held open for the entire request lifecycle so the
+        // handler receives the full page output — an in-scope ob_get_clean() is
+        // not applicable here because the response is not yet complete.
         ob_start([$writer, 'handle']);
     }
 

--- a/apps/agent/includes/media/class-db-rewriter.php
+++ b/apps/agent/includes/media/class-db-rewriter.php
@@ -413,12 +413,15 @@ final class DbRewriter
             $urlArgs[]    = $regexpUrl . '([^0-9A-Za-z]|$)';
         }
 
-        // Build the denylist exclusion using single-quote doubling (no escaping function).
-        $skipList = [];
-        foreach (self::SKIP_META_KEYS as $key) {
-            $skipList[] = "'" . str_replace("'", "''", $key) . "'";
+        // Build the denylist exclusion using prepared %s placeholders (string meta keys).
+        // Guard the zero-length case so prepare() is never called with an empty IN().
+        $skipArgs = [];
+        $skipIn   = '';
+        if (count(self::SKIP_META_KEYS) > 0) {
+            $skipPlaceholders = implode(', ', array_fill(0, count(self::SKIP_META_KEYS), '%s'));
+            $skipIn           = "AND pm.meta_key NOT IN ({$skipPlaceholders})";
+            $skipArgs         = self::SKIP_META_KEYS;
         }
-        $skipIn = implode(', ', $skipList);
 
         // Build the IN placeholder list for post types.
         $typePlaceholders = implode(', ', array_fill(0, count($postTypes), '%s'));
@@ -427,13 +430,13 @@ final class DbRewriter
                 FROM {$wpdb->postmeta} pm
                 INNER JOIN {$wpdb->posts} p ON pm.post_id = p.ID
                 WHERE (" . implode(' OR ', $urlClauses) . ")
-                  AND pm.meta_key NOT IN ({$skipIn})
+                  {$skipIn}
                   AND p.post_status = 'publish'
                   AND p.post_type IN ({$typePlaceholders})
                 ORDER BY pm.meta_id DESC
                 LIMIT " . self::META_LIMIT;
 
-        $args = array_merge($urlArgs, $postTypes);
+        $args = array_merge($urlArgs, $skipArgs, $postTypes);
         $rows = $wpdb->get_results($wpdb->prepare($sql, $args), ARRAY_A); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,PluginCheck.Security.DirectDB.UnescapedDBParameter -- direct query on postmeta; no caching appropriate for a bounded migration pass; sql is built with $wpdb->prepare(); value is the output of $wpdb->prepare()
 
         if (!is_array($rows)) {

--- a/apps/agent/includes/object-cache/class-object-cache-dropin-installer.php
+++ b/apps/agent/includes/object-cache/class-object-cache-dropin-installer.php
@@ -295,10 +295,18 @@ final class ObjectCacheDropinInstaller
 		// but escape it anyway so static analysis can verify the query.
 		$optionsTable = esc_sql( $wpdb->options ?? '' );
 		if ( $optionsTable !== '' ) {
+			// Build the two LIKE patterns through esc_like so special characters
+			// in the prefix are safe; the patterns themselves are not user input.
+			$likeTransient     = $wpdb->esc_like( '_transient_' ) . '%';
+			$likeSiteTransient = $wpdb->esc_like( '_site_transient_' ) . '%';
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- no WP API for bulk transient delete; anti-replay / transient purge; caching would defeat the purpose
 			$count += (int) $wpdb->query(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $optionsTable is $wpdb->options, a trusted WP core property, not user input
-				"DELETE FROM `{$optionsTable}` WHERE option_name LIKE '_transient_%' OR option_name LIKE '_site_transient_%'"
+				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- only the table identifier is interpolated ($wpdb->options, a trusted WP core property, not user input); the LIKE values are bound as %s placeholders
+					"DELETE FROM `{$optionsTable}` WHERE option_name LIKE %s OR option_name LIKE %s",
+					$likeTransient,
+					$likeSiteTransient
+				)
 			);
 		}
 

--- a/apps/agent/includes/support/class-storage-paths.php
+++ b/apps/agent/includes/support/class-storage-paths.php
@@ -59,6 +59,83 @@ final class StoragePaths {
 	}
 
 	/**
+	 * Ensure the user-data directory for $purpose exists and is hardened against
+	 * direct web access (deny-all .htaccess + empty index.php guard).
+	 *
+	 * Resolves the path via dataBase(), creates the directory with wp_mkdir_p()
+	 * if it does not yet exist, then drops the guard files on first call. Safe
+	 * to call on every request — file_exists() short-circuits the writes.
+	 *
+	 * This is required when the resolved path is under uploads/, which is
+	 * web-accessible. Callers that create the directory themselves may call this
+	 * method after creation to apply the same hardening.
+	 *
+	 * @param string $purpose Lowercase slug (same as passed to dataBase()).
+	 * @return string The resolved absolute path, or '' when no base is available.
+	 */
+	public static function ensureHardened( string $purpose ): string {
+		$path = self::dataBase( $purpose );
+		if ( $path === '' ) {
+			return '';
+		}
+		return self::ensureHardenedPath( $path );
+	}
+
+	/**
+	 * Harden a SPECIFIC absolute directory against direct web access (deny-all
+	 * .htaccess + empty index.php guard), creating it if needed.
+	 *
+	 * Use this when the caller has already resolved the directory itself (for
+	 * example a destination that may fall back to the legacy wp-content path):
+	 * harden the path that is actually written to, not a recomputed one, so the
+	 * guard files always land in the real data directory.
+	 *
+	 * @param string $path Absolute directory path (no trailing slash required).
+	 * @return string The path, or '' when $path is empty.
+	 */
+	public static function ensureHardenedPath( string $path ): string {
+		$path = rtrim( $path, '/\\' );
+		if ( $path === '' ) {
+			return '';
+		}
+
+		if ( ! is_dir( $path ) ) {
+			if ( function_exists( 'wp_mkdir_p' ) ) {
+				wp_mkdir_p( $path );
+			} else {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- wp_mkdir_p not yet available in this context; headless agent, WP_Filesystem never initialized
+				@mkdir( $path, 0755, true );
+			}
+		}
+
+		// Deny-all .htaccess — blocks Apache/LiteSpeed.
+		$htaccess = $path . '/.htaccess';
+		if ( ! file_exists( $htaccess ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- headless agent; WP_Filesystem never initialized; direct write of a static guard file
+			@file_put_contents(
+				$htaccess,
+				"# Block direct web access to WPMgr user-data directories.\n"
+				. "<IfModule mod_authz_core.c>\n"
+				. "    Require all denied\n"
+				. "</IfModule>\n"
+				. "<IfModule !mod_authz_core.c>\n"
+				. "    Deny from all\n"
+				. "</IfModule>\n",
+				LOCK_EX
+			);
+		}
+
+		// Empty index.php — silences directory listing on PHP-proxied servers.
+		$index = $path . '/index.php';
+		if ( ! file_exists( $index ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- headless agent; WP_Filesystem never initialized; direct write of a static guard file
+			@file_put_contents( $index, "<?php\n// Silence is golden.\n", LOCK_EX );
+		}
+
+		return $path;
+	}
+
+	/**
 	 * Legacy path for a purpose (wp-content/wpmgr-<purpose>).
 	 *
 	 * Used by callers that need to read from the old pre-uploads location so

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -133,6 +133,22 @@ When the self-host Gravatars optimization is enabled, the plugin downloads avata
 
 When the "self-host third-party assets" optimization is enabled, the plugin downloads cross-origin script and stylesheet URLs that your own pages already reference, to serve those assets locally. It contacts whatever third-party hosts your pages embed. Data sent: a plain GET request to the URL already present in your page. Trigger: on cache build when this optimization is on. No single provider; the specific hosts depend on your site's content.
 
+**Postmark (https://api.postmarkapp.com)**
+
+Postmark is a transactional email delivery service operated by Wildbit LLC. When Postmark is the configured email transport for this site, the plugin POSTs outgoing email to https://api.postmarkapp.com/email. Data sent: sender address, recipient addresses (To/Cc/Bcc), subject, message body (HTML and/or plain text), and any attachments. Trigger: only when Postmark is selected as the active email provider and an outgoing email is sent from this site. Terms https://postmarkapp.com/terms-of-service -- Privacy https://postmarkapp.com/privacy-policy
+
+**Amazon SES (https://email.{region}.amazonaws.com)**
+
+Amazon Simple Email Service (SES) is an email delivery service operated by Amazon Web Services, Inc. When Amazon SES is the configured email transport for this site, the plugin POSTs a raw MIME message to https://email.{region}.amazonaws.com/ (where {region} is the AWS region you configure, e.g. us-east-1). Data sent: sender address, recipient addresses (To/Cc/Bcc), subject, message body (HTML and/or plain text), and any attachments, encoded as a raw MIME message signed with AWS Signature Version 4. Trigger: only when Amazon SES is selected as the active email provider and an outgoing email is sent from this site. Terms https://aws.amazon.com/service-terms/ -- Privacy https://aws.amazon.com/privacy/
+
+**Mailgun (https://api.mailgun.net, https://api.eu.mailgun.net)**
+
+Mailgun is an email delivery service operated by Sinch Email (formerly Mailgun Technologies, Inc.). When Mailgun is the configured email transport for this site, the plugin POSTs outgoing email to https://api.mailgun.net/v3/{domain}/messages (US region) or https://api.eu.mailgun.net/v3/{domain}/messages (EU region). Data sent: sender address, recipient addresses (To/Cc/Bcc), subject, message body (HTML and/or plain text), and attachment metadata. Trigger: only when Mailgun is selected as the active email provider and an outgoing email is sent from this site. Terms https://www.mailgun.com/legal/terms/ -- Privacy https://www.mailgun.com/legal/privacy-policy/
+
+**SendGrid (https://api.sendgrid.com)**
+
+SendGrid is a cloud email delivery service operated by Twilio Inc. When SendGrid is the configured email transport for this site, the plugin POSTs outgoing email to https://api.sendgrid.com/v3/mail/send. Data sent: sender address, recipient addresses (To/Cc/Bcc), subject, message body (HTML and/or plain text), and any attachments. Trigger: only when SendGrid is selected as the active email provider and an outgoing email is sent from this site. Terms https://www.twilio.com/en-us/legal/tos -- Privacy https://www.twilio.com/en-us/legal/privacy
+
 == Third-party / Credits ==
 
 **matthiasmullie/minify (MIT)**
@@ -148,7 +164,7 @@ No other third-party libraries are bundled in the plugin zip. Image encoding and
 This plugin ships two minified JavaScript files. Their human-readable source and build tooling are in the public repository at https://github.com/mosamlife/wpmgr.
 
 * **assets/wpmgr-rum.min.js** -- Real User Monitoring collector. TypeScript source: apps/tracker/src/index.ts and apps/tracker/src/vitals.ts. Build: cd apps/tracker && npm install && npm run build (esbuild IIFE bundle, also bundles Google web-vitals under its Apache-2.0 license).
-* **assets/wpmgr-delay.min.js** -- deferred-script runtime. The readable source ships alongside the plugin at assets/src/wpmgr-delay.js in the same repository.
+* **assets/wpmgr-delay.min.js** -- deferred-script runtime. The readable source ships alongside the plugin at assets/wpmgr-delay.js in the same repository.
 
 == Screenshots ==
 

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.45.0
+ * Version:           0.46.0
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.45.0');
+define('WPMGR_AGENT_VERSION', '0.46.0');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 


### PR DESCRIPTION
Agent-focused WordPress.org compliance release addressing the human volunteer review (most of the round was already fixed in 0.44/0.45).

- Packaging: wp.org zip drops vendor/bin CLI entrypoints, vendor LICENSE files, and hidden dotfiles; adds .distignore.
- Readme: documents all outbound external services incl. the 4 email providers (SES, SendGrid, Mailgun, Postmark) with data-sent + terms/privacy links.
- SQL: object-cache transient cleanup + media postmeta lookup now use $wpdb->prepare() placeholders.
- Storage: local backups move to a web-hardened uploads dir (deny .htaccess + index.php) with best-effort migration.

Name 'Fleet Agent for WPMgr' and autologin intentionally retained (justified to the reviewer). Plugin Check 0 errors (only expected wp-trademark warnings); phpunit 1695, phpcs clean, security review PASS. Control plane/dashboard images rebuild at the same version with no functional change (also brings the 0.45.0 cron-kick CP code to prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Local backups now secured in uploads directory with protective guard files.
  * Database operations hardened with prepared statements against SQL injection.
  * Added storage hardening utilities for improved access control.

* **Documentation**
  * Expanded documentation of external email services contacted (Amazon SES, SendGrid, Mailgun, Postmark) with details on data transmission.

* **Chores**
  * Version bumped to 0.46.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->