### PR TITLE
fix: fleet dashboard contract drift + table alignment (0.47.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.47.1] - 2026-06-15
+
+### Fixed
+
+- **Performance dashboard no longer errors out.** The fleet Core Web Vitals endpoint now returns the per-metric object and the daily trend the dashboard expects, so the page renders instead of showing "Something went wrong".
+- **Fleet uptime shows site names and latency again.** The fleet status endpoint field names now match the dashboard, so the Site column is populated and average latency reads correctly instead of "NaN ms".
+- **Fleet table columns line up.** The shared fleet table now pins column widths with a column group, so the sticky header and the rows align across the uptime, backup, and performance tables.
+
+Added JSON-shape contract tests for both fleet endpoints and defensive guards in the dashboards so a future field rename fails the build rather than reaching the browser. Control plane plus dashboard at 0.47.1; no migration, no agent change.
+
 ## [0.47.0] - 2026-06-15
 
 ### Added

--- a/apps/api/internal/perf/fleet_rum_contract_test.go
+++ b/apps/api/internal/perf/fleet_rum_contract_test.go
@@ -1,0 +1,41 @@
+package perf
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestFleetRumResponseJSONContract locks the JSON shape of the fleet RUM
+// aggregate to the web contract (apps/web/src/features/fleet/fleet-types.ts
+// FleetRumResponse). The 0.47.0 ship emitted a "metrics" map and no "trend",
+// while the dashboard read "per_metric" and "trend", white-screening the page on
+// trend.length. This test fails fast on any such drift.
+func TestFleetRumResponseJSONContract(t *testing.T) {
+	b, err := json.Marshal(FleetRumResponse{})
+	if err != nil {
+		t.Fatalf("marshal FleetRumResponse: %v", err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{
+		"sites_reporting", "sites_total", "fleet_pass_pct",
+		"per_metric", "worst_offenders", "trend",
+	} {
+		if _, ok := m[k]; !ok {
+			t.Errorf("FleetRumResponse JSON missing contract key %q", k)
+		}
+	}
+
+	// per_metric must carry the five fixed CWV keys the dashboard indexes.
+	var pm map[string]json.RawMessage
+	if err := json.Unmarshal(m["per_metric"], &pm); err != nil {
+		t.Fatalf("per_metric is not an object: %v", err)
+	}
+	for _, k := range []string{"lcp", "inp", "cls", "fcp", "ttfb"} {
+		if _, ok := pm[k]; !ok {
+			t.Errorf("per_metric JSON missing CWV key %q", k)
+		}
+	}
+}

--- a/apps/api/internal/perf/rum_results_handler.go
+++ b/apps/api/internal/perf/rum_results_handler.go
@@ -466,43 +466,59 @@ func emptyTrendResponse(windowDays, minSampleCount int) RumTrendResponse {
 // Fleet RUM aggregate  GET /api/v1/perf/rum/fleet
 // ---------------------------------------------------------------------------
 
-// FleetRumMetricSummary is the p75 + distribution for one Core Web Vital in
-// the fleet aggregate (device-collapsed, cross-site).
-type FleetRumMetricSummary struct {
-	Metric      string           `json:"metric"`
-	P75Ms       float64          `json:"p75_ms"`
-	SampleCount int64            `json:"sample_count"`
-	Rating      string           `json:"rating"`
-	Suppressed  bool             `json:"suppressed"`
-	GoodPct     int              `json:"good_pct"`
-	NiPct       int              `json:"ni_pct"`
-	PoorPct     int              `json:"poor_pct"`
-	Distribution *RumDistribution `json:"distribution,omitempty"`
+// fleetRumMetric is the per-metric summary in the fleet aggregate.
+// JSON field names are pinned to the frontend FleetRumMetric contract in
+// apps/web/src/features/fleet/fleet-types.ts.
+type fleetRumMetric struct {
+	P75         *float64 `json:"p75"`
+	GoodPct     *float64 `json:"good_pct"`
+	NiPct       *float64 `json:"ni_pct"`
+	PoorPct     *float64 `json:"poor_pct"`
+	SampleCount int64    `json:"sample_count"`
 }
 
-// FleetRumTrendPoint is one day's fleet aggregate p75.
-type FleetRumTrendPoint struct {
-	Day         string  `json:"day"`
-	P75Ms       float64 `json:"p75_ms"`
-	SampleCount int64   `json:"sample_count"`
-	Suppressed  bool    `json:"suppressed"`
+// fleetPerMetric is the fixed per_metric object in FleetRumResponse.
+// All five keys are always present (zero-value metric when no data).
+type fleetPerMetric struct {
+	LCP  fleetRumMetric `json:"lcp"`
+	INP  fleetRumMetric `json:"inp"`
+	CLS  fleetRumMetric `json:"cls"`
+	FCP  fleetRumMetric `json:"fcp"`
+	TTFB fleetRumMetric `json:"ttfb"`
 }
 
-// FleetRumWorstOffender is a site with a poor fleet CWV rating.
-type FleetRumWorstOffender struct {
-	SiteID uuid.UUID `json:"site_id"`
-	P75Ms  float64   `json:"p75_ms"`
-	Rating string    `json:"rating"`
+// fleetRumWorstOffender is a site with poor CWV p75 ratings.
+// JSON field names are pinned to the frontend FleetRumOffender contract.
+type fleetRumWorstOffender struct {
+	SiteID        uuid.UUID `json:"site_id"`
+	Name          string    `json:"name"`
+	URL           string    `json:"url"`
+	LCPP75        *float64  `json:"lcp_p75"`
+	INPP75        *float64  `json:"inp_p75"`
+	CLSP75        *float64  `json:"cls_p75"`
+	OverallRating string    `json:"overall_rating"`
+	SampleCount   int64     `json:"sample_count"`
+}
+
+// fleetRumTrendPoint is one day's fleet-level p75 values for the three
+// LWV Core metrics. JSON field names are pinned to FleetRumTrendPoint.
+type fleetRumTrendPoint struct {
+	Date   string   `json:"date"`
+	LCPP75 *float64 `json:"lcp_p75"`
+	INPP75 *float64 `json:"inp_p75"`
+	CLSP75 *float64 `json:"cls_p75"`
 }
 
 // FleetRumResponse is the response body for GET /api/v1/perf/rum/fleet.
+// JSON field names are pinned to the frontend FleetRumResponse contract in
+// apps/web/src/features/fleet/fleet-types.ts.
 type FleetRumResponse struct {
-	WindowDays     int                              `json:"window_days"`
-	SitesReporting int                              `json:"sites_reporting"`
-	SitesTotal     int                              `json:"sites_total"`
-	FleetPassPct   float64                          `json:"fleet_pass_pct"` // pct of sites with good LCP p75
-	Metrics        map[string]FleetRumMetricSummary `json:"metrics"`        // keyed by metric name
-	WorstOffenders []FleetRumWorstOffender          `json:"worst_offenders"`
+	SitesReporting int                    `json:"sites_reporting"`
+	SitesTotal     int                    `json:"sites_total"`
+	FleetPassPct   *float64               `json:"fleet_pass_pct"`
+	PerMetric      fleetPerMetric         `json:"per_metric"`
+	WorstOffenders []fleetRumWorstOffender `json:"worst_offenders"`
+	Trend          []fleetRumTrendPoint   `json:"trend"`
 }
 
 // rumFleet handles GET /api/v1/perf/rum/fleet.
@@ -511,6 +527,8 @@ type FleetRumResponse struct {
 //
 //	window_days — 1-365, default 28.
 //	device      — desktop | mobile | tablet | all (default all).
+//
+// Response shape is pinned to FleetRumResponse / fleet-types.ts.
 func (h *Handler) rumFleet(c *gin.Context) {
 	p, _ := domain.PrincipalFromContext(c.Request.Context())
 
@@ -523,16 +541,19 @@ func (h *Handler) rumFleet(c *gin.Context) {
 	}
 	deviceFilter := c.Query("device") // empty or "all" = no device filter
 
-	if h.rum == nil || h.rum.GetHourlyRollupsForSites == nil {
-		// Degrade gracefully when the RUM store is not wired.
-		c.JSON(http.StatusOK, FleetRumResponse{
-			WindowDays:     windowDays,
+	emptyResp := func(sitesTotal int) FleetRumResponse {
+		return FleetRumResponse{
 			SitesReporting: 0,
-			SitesTotal:     0,
-			FleetPassPct:   0,
-			Metrics:        map[string]FleetRumMetricSummary{},
-			WorstOffenders: []FleetRumWorstOffender{},
-		})
+			SitesTotal:     sitesTotal,
+			FleetPassPct:   nil,
+			PerMetric:      fleetPerMetric{},
+			WorstOffenders: []fleetRumWorstOffender{},
+			Trend:          []fleetRumTrendPoint{},
+		}
+	}
+
+	if h.rum == nil || h.rum.GetHourlyRollupsForSites == nil {
+		c.JSON(http.StatusOK, emptyResp(0))
 		return
 	}
 
@@ -551,64 +572,67 @@ func (h *Handler) rumFleet(c *gin.Context) {
 		return
 	}
 
+	if len(rollups) == 0 {
+		c.JSON(http.StatusOK, emptyResp(len(siteIDs)))
+		return
+	}
+
 	// Track which sites reported data.
 	reportingSites := make(map[uuid.UUID]struct{})
 	for _, r := range rollups {
 		reportingSites[r.SiteID] = struct{}{}
 	}
 
-	// Accumulate per-metric device-collapsed buckets across all sites.
-	// For the fleet aggregate we collapse both site and device (as the user
-	// can filter by device via the ?device= param but cross-site comparison
-	// needs a single p75 per metric).
-	type metricAcc struct {
+	// perSiteMetricAcc accumulates bucket histogram data per (siteID, metric).
+	type siteMetricKey struct {
+		siteID uuid.UUID
+		metric string
+	}
+	type bucketAcc struct {
 		counts      []int64
 		sampleCount int64
 		maxVal      int32
-		// bySite accumulates sums per site for worst-offenders (LCP only for now).
-		bySite map[uuid.UUID]*struct {
-			counts      []int64
-			sampleCount int64
-			maxVal      int32
-		}
 	}
-	acc := make(map[string]*metricAcc)
+
+	// Fleet-level acc per metric (all sites + devices collapsed).
+	fleetAcc := make(map[string]*bucketAcc)
+	// Per-site per-metric acc (for worst-offenders: we track all 3 CWV metrics).
+	siteAcc := make(map[siteMetricKey]*bucketAcc)
+	// Per-(metric, day) acc for trend (hourly rollups bucketed to UTC days).
+	type trendKey struct {
+		metric string
+		day    string // "YYYY-MM-DD"
+	}
+	trendAcc := make(map[trendKey]*bucketAcc)
 
 	for _, r := range rollups {
 		// Apply device filter.
 		if deviceFilter != "" && deviceFilter != "all" && r.Device != deviceFilter {
 			continue
 		}
-		ma, ok := acc[r.Metric]
+
+		// Fleet-level accumulation.
+		fa, ok := fleetAcc[r.Metric]
 		if !ok {
-			ma = &metricAcc{
-				counts: make([]int64, rum.NumBuckets),
-				bySite: make(map[uuid.UUID]*struct {
-					counts      []int64
-					sampleCount int64
-					maxVal      int32
-				}),
-			}
-			acc[r.Metric] = ma
+			fa = &bucketAcc{counts: make([]int64, rum.NumBuckets)}
+			fleetAcc[r.Metric] = fa
 		}
-		ma.sampleCount += r.SampleCount
-		if r.MaxValue > ma.maxVal {
-			ma.maxVal = r.MaxValue
+		fa.sampleCount += r.SampleCount
+		if r.MaxValue > fa.maxVal {
+			fa.maxVal = r.MaxValue
 		}
-		for i, c := range r.BucketCounts {
+		for i, cnt := range r.BucketCounts {
 			if i < rum.NumBuckets {
-				ma.counts[i] += int64(c)
+				fa.counts[i] += int64(cnt)
 			}
 		}
-		// Per-site accumulation for worst-offenders.
-		sa, ok := ma.bySite[r.SiteID]
+
+		// Per-site per-metric accumulation (worst-offenders need lcp/inp/cls).
+		smk := siteMetricKey{siteID: r.SiteID, metric: r.Metric}
+		sa, ok := siteAcc[smk]
 		if !ok {
-			sa = &struct {
-				counts      []int64
-				sampleCount int64
-				maxVal      int32
-			}{counts: make([]int64, rum.NumBuckets)}
-			ma.bySite[r.SiteID] = sa
+			sa = &bucketAcc{counts: make([]int64, rum.NumBuckets)}
+			siteAcc[smk] = sa
 		}
 		sa.sampleCount += r.SampleCount
 		if r.MaxValue > sa.maxVal {
@@ -619,91 +643,205 @@ func (h *Handler) rumFleet(c *gin.Context) {
 				sa.counts[i] += int64(cnt)
 			}
 		}
+
+		// Trend accumulation: bucket hourly rollups into UTC days.
+		// Only track the three trend metrics: lcp, inp, cls.
+		if r.Metric == "lcp" || r.Metric == "inp" || r.Metric == "cls" {
+			// r.HourBucket is already a time.Time from the rum.HourlyRollup.
+			// We extract the UTC date from BucketHour.
+			dayStr := r.BucketHour.UTC().Format("2006-01-02")
+			tk := trendKey{metric: r.Metric, day: dayStr}
+			ta, ok := trendAcc[tk]
+			if !ok {
+				ta = &bucketAcc{counts: make([]int64, rum.NumBuckets)}
+				trendAcc[tk] = ta
+			}
+			ta.sampleCount += r.SampleCount
+			if r.MaxValue > ta.maxVal {
+				ta.maxVal = r.MaxValue
+			}
+			for i, cnt := range r.BucketCounts {
+				if i < rum.NumBuckets {
+					ta.counts[i] += int64(cnt)
+				}
+			}
+		}
 	}
 
 	const minSampleCount = 30
-	metrics := make(map[string]FleetRumMetricSummary, len(acc))
-	var lcpGoodSites, lcpTotalSites int
 
-	for metric, ma := range acc {
-		suppressed := ma.sampleCount < int64(minSampleCount)
-		p75 := float64(0)
-		if !suppressed {
-			p75 = rum.InterpolateP75FromCounts(ma.counts, ma.sampleCount, ma.maxVal)
+	// buildMetric converts a fleet-level bucket accumulator to a fleetRumMetric.
+	buildMetric := func(metric string, fa *bucketAcc) fleetRumMetric {
+		if fa == nil || fa.sampleCount < int64(minSampleCount) {
+			return fleetRumMetric{SampleCount: 0}
 		}
-		ms := FleetRumMetricSummary{
-			Metric:      metric,
-			P75Ms:       p75,
-			SampleCount: ma.sampleCount,
-			Suppressed:  suppressed,
+		p75 := rum.InterpolateP75FromCounts(fa.counts, fa.sampleCount, fa.maxVal)
+		dist := foldBucketsIntoDistribution(metric, fa.counts)
+		var goodPct, niPct, poorPct *float64
+		if dist != nil {
+			gp := float64(dist.GoodPct)
+			np := float64(dist.NeedsImprovementPct)
+			pp := float64(dist.PoorPct)
+			goodPct = &gp
+			niPct = &np
+			poorPct = &pp
 		}
-		if !suppressed {
-			ms.Rating = cwvRating(metric, p75)
-			ms.Distribution = foldBucketsIntoDistribution(metric, ma.counts)
-			if ms.Distribution != nil {
-				ms.GoodPct = ms.Distribution.GoodPct
-				ms.NiPct = ms.Distribution.NeedsImprovementPct
-				ms.PoorPct = ms.Distribution.PoorPct
-			}
-		}
-		metrics[metric] = ms
-
-		// Fleet-pass-pct: fraction of reporting sites with "good" LCP p75.
-		if metric == "lcp" {
-			for siteID, sa := range ma.bySite {
-				if sa.sampleCount < int64(minSampleCount) {
-					continue
-				}
-				_ = siteID
-				lcpTotalSites++
-				siteP75 := rum.InterpolateP75FromCounts(sa.counts, sa.sampleCount, sa.maxVal)
-				if cwvRating("lcp", siteP75) == "good" {
-					lcpGoodSites++
-				}
-			}
+		return fleetRumMetric{
+			P75:         &p75,
+			GoodPct:     goodPct,
+			NiPct:       niPct,
+			PoorPct:     poorPct,
+			SampleCount: fa.sampleCount,
 		}
 	}
 
-	// Worst offenders: sites with poor LCP p75, sorted descending by p75.
-	var worstOffenders []FleetRumWorstOffender
-	if lcpAcc, ok := acc["lcp"]; ok {
-		for siteID, sa := range lcpAcc.bySite {
-			if sa.sampleCount < int64(minSampleCount) {
+	perMetric := fleetPerMetric{
+		LCP:  buildMetric("lcp", fleetAcc["lcp"]),
+		INP:  buildMetric("inp", fleetAcc["inp"]),
+		CLS:  buildMetric("cls", fleetAcc["cls"]),
+		FCP:  buildMetric("fcp", fleetAcc["fcp"]),
+		TTFB: buildMetric("ttfb", fleetAcc["ttfb"]),
+	}
+
+	// Fleet-pass-pct: fraction of reporting sites with "good" LCP p75.
+	var fleetPassPct *float64
+	var lcpGoodSites, lcpTotalSites int
+	for smk, sa := range siteAcc {
+		if smk.metric != "lcp" {
+			continue
+		}
+		if sa.sampleCount < int64(minSampleCount) {
+			continue
+		}
+		lcpTotalSites++
+		siteP75 := rum.InterpolateP75FromCounts(sa.counts, sa.sampleCount, sa.maxVal)
+		if cwvRating("lcp", siteP75) == "good" {
+			lcpGoodSites++
+		}
+	}
+	if lcpTotalSites > 0 {
+		v := float64(lcpGoodSites) / float64(lcpTotalSites) * 100
+		fleetPassPct = &v
+	}
+
+	// Worst offenders: collect unique sites with poor/needs-improvement LCP,
+	// joined with their inp/cls p75 values.
+	type offenderAcc struct {
+		lcpP75  float64
+		inpP75  *float64
+		clsP75  *float64
+		samples int64
+		rating  string
+	}
+	offenderMap := make(map[uuid.UUID]*offenderAcc)
+	for smk, sa := range siteAcc {
+		if smk.metric != "lcp" {
+			continue
+		}
+		if sa.sampleCount < int64(minSampleCount) {
+			continue
+		}
+		p75 := rum.InterpolateP75FromCounts(sa.counts, sa.sampleCount, sa.maxVal)
+		rating := cwvRating("lcp", p75)
+		// normalise: frontend expects "needs-improvement" (hyphen), not underscore
+		if rating == "needs_improvement" {
+			rating = "needs-improvement"
+		}
+		if rating == "poor" || rating == "needs-improvement" {
+			offenderMap[smk.siteID] = &offenderAcc{
+				lcpP75:  p75,
+				samples: sa.sampleCount,
+				rating:  rating,
+			}
+		}
+	}
+	// Enrich offenders with inp/cls p75 values.
+	for smk, sa := range siteAcc {
+		oa, isOffender := offenderMap[smk.siteID]
+		if !isOffender {
+			continue
+		}
+		if sa.sampleCount < int64(minSampleCount) {
+			continue
+		}
+		p75 := rum.InterpolateP75FromCounts(sa.counts, sa.sampleCount, sa.maxVal)
+		switch smk.metric {
+		case "inp":
+			oa.inpP75 = &p75
+		case "cls":
+			oa.clsP75 = &p75
+		}
+	}
+
+	worstOffenders := make([]fleetRumWorstOffender, 0, len(offenderMap))
+	for siteID, oa := range offenderMap {
+		lcpP75 := oa.lcpP75
+		worstOffenders = append(worstOffenders, fleetRumWorstOffender{
+			SiteID:        siteID,
+			Name:          "", // name/url not available without N+1 lookup; frontend tolerates empty
+			URL:           "",
+			LCPP75:        &lcpP75,
+			INPP75:        oa.inpP75,
+			CLSP75:        oa.clsP75,
+			OverallRating: oa.rating,
+			SampleCount:   oa.samples,
+		})
+	}
+	sort.Slice(worstOffenders, func(i, j int) bool {
+		// Sort by LCP p75 descending (worst first).
+		li, lj := float64(0), float64(0)
+		if worstOffenders[i].LCPP75 != nil {
+			li = *worstOffenders[i].LCPP75
+		}
+		if worstOffenders[j].LCPP75 != nil {
+			lj = *worstOffenders[j].LCPP75
+		}
+		return li > lj
+	})
+	if len(worstOffenders) > 10 {
+		worstOffenders = worstOffenders[:10]
+	}
+
+	// Build trend: one point per day with lcp_p75/inp_p75/cls_p75.
+	// Collect all days across the three trend metrics, then join.
+	trendDays := make(map[string]struct{})
+	for tk := range trendAcc {
+		trendDays[tk.day] = struct{}{}
+	}
+	sortedDays := make([]string, 0, len(trendDays))
+	for d := range trendDays {
+		sortedDays = append(sortedDays, d)
+	}
+	sort.Strings(sortedDays)
+
+	trend := make([]fleetRumTrendPoint, 0, len(sortedDays))
+	for _, day := range sortedDays {
+		pt := fleetRumTrendPoint{Date: day}
+		for _, metric := range []string{"lcp", "inp", "cls"} {
+			ta := trendAcc[trendKey{metric: metric, day: day}]
+			if ta == nil || ta.sampleCount < int64(minSampleCount) {
 				continue
 			}
-			siteP75 := rum.InterpolateP75FromCounts(sa.counts, sa.sampleCount, sa.maxVal)
-			rating := cwvRating("lcp", siteP75)
-			if rating == "poor" || rating == "needs_improvement" {
-				worstOffenders = append(worstOffenders, FleetRumWorstOffender{
-					SiteID: siteID,
-					P75Ms:  siteP75,
-					Rating: rating,
-				})
+			p75 := rum.InterpolateP75FromCounts(ta.counts, ta.sampleCount, ta.maxVal)
+			switch metric {
+			case "lcp":
+				pt.LCPP75 = &p75
+			case "inp":
+				pt.INPP75 = &p75
+			case "cls":
+				pt.CLSP75 = &p75
 			}
 		}
-		sort.Slice(worstOffenders, func(i, j int) bool {
-			return worstOffenders[i].P75Ms > worstOffenders[j].P75Ms
-		})
-		if len(worstOffenders) > 10 {
-			worstOffenders = worstOffenders[:10]
-		}
-	}
-	if worstOffenders == nil {
-		worstOffenders = []FleetRumWorstOffender{}
-	}
-
-	fleetPassPct := float64(0)
-	if lcpTotalSites > 0 {
-		fleetPassPct = float64(lcpGoodSites) / float64(lcpTotalSites) * 100
+		trend = append(trend, pt)
 	}
 
 	c.JSON(http.StatusOK, FleetRumResponse{
-		WindowDays:     windowDays,
 		SitesReporting: len(reportingSites),
 		SitesTotal:     len(siteIDs),
 		FleetPassPct:   fleetPassPct,
-		Metrics:        metrics,
+		PerMetric:      perMetric,
 		WorstOffenders: worstOffenders,
+		Trend:          trend,
 	})
 }
 

--- a/apps/api/internal/uptime/fleet_contract_test.go
+++ b/apps/api/internal/uptime/fleet_contract_test.go
@@ -1,0 +1,40 @@
+package uptime
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestFleetStatusItemJSONContract locks the JSON field names of the fleet
+// status item to the web contract (apps/web/src/features/fleet/fleet-types.ts
+// FleetStatusItem). A silent rename here (e.g. site_name instead of name) blanks
+// the Site column and produces "NaN ms" latency in the dashboard, which shipped
+// once in 0.47.0. This test fails fast on any such drift.
+func TestFleetStatusItemJSONContract(t *testing.T) {
+	b, err := json.Marshal(FleetStatusItem{})
+	if err != nil {
+		t.Fatalf("marshal FleetStatusItem: %v", err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Required keys the web client reads. Additive backend-only keys are allowed.
+	for _, k := range []string{
+		"site_id", "name", "url", "connection_state", "health_status",
+		"status", "up", "last_probe_at", "uptime_pct_7d", "avg_latency_ms",
+		"tls_expiry", "latency_sparkline",
+	} {
+		if _, ok := m[k]; !ok {
+			t.Errorf("FleetStatusItem JSON missing contract key %q (got keys %v)", k, keysOf(m))
+		}
+	}
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}

--- a/apps/api/internal/uptime/model.go
+++ b/apps/api/internal/uptime/model.go
@@ -84,19 +84,25 @@ type FleetStatusCounts struct {
 }
 
 // FleetStatusItem is the per-site row in the fleet status response.
+// JSON field names are pinned to the frontend FleetStatusItem contract in
+// apps/web/src/features/fleet/fleet-types.ts — do not rename without
+// updating both sides.
 type FleetStatusItem struct {
 	SiteID          uuid.UUID       `json:"site_id"`
-	SiteName        string          `json:"site_name"`
-	SiteURL         string          `json:"site_url"`
-	Status          FleetSiteStatus `json:"status"`
-	UptimePct7d     float64         `json:"uptime_pct_7d"`
-	AvgLatencyMs7d  float64         `json:"avg_latency_ms_7d"`
-	LatestTotalMs   *float64        `json:"latest_total_ms,omitempty"`
-	LastProbeAt     *time.Time      `json:"last_probe_at,omitempty"`
-	TLSExpiry       *time.Time      `json:"tls_expiry,omitempty"`
-	InIncident      bool            `json:"in_incident"`
+	Name            string          `json:"name"`
+	URL             string          `json:"url"`
 	ConnectionState string          `json:"connection_state"`
 	HealthStatus    string          `json:"health_status"`
+	Status          FleetSiteStatus `json:"status"`
+	Up              *bool           `json:"up"`
+	LastProbeAt     *time.Time      `json:"last_probe_at"`
+	UptimePct7d     float64         `json:"uptime_pct_7d"`
+	AvgLatencyMs    *float64        `json:"avg_latency_ms"`
+	TLSExpiry       *time.Time      `json:"tls_expiry"`
+	LatencySparkline []float64      `json:"latency_sparkline"`
+	// InIncident is kept for internal use (summary counting) but not needed
+	// by the frontend contract — retained for the service-layer logic.
+	InIncident bool `json:"in_incident"`
 }
 
 // FleetStatusResponse is the response body for GET /api/v1/fleet/status.

--- a/apps/api/internal/uptime/repo.go
+++ b/apps/api/internal/uptime/repo.go
@@ -256,17 +256,24 @@ ORDER BY s.name ASC
 				return domain.Internal("fleet_uptime_scan_failed", "failed to scan fleet uptime row").WithCause(err)
 			}
 			item := FleetStatusItem{
-				SiteID:          siteID,
-				SiteName:        siteName,
-				SiteURL:         siteURL,
-				ConnectionState: connectionState,
-				HealthStatus:    healthStatus,
-				UptimePct7d:     uptimePct7d,
-				AvgLatencyMs7d:  avgLatencyMs7d,
-				InIncident:      inIncident,
+				SiteID:           siteID,
+				Name:             siteName,
+				URL:              siteURL,
+				ConnectionState:  connectionState,
+				HealthStatus:     healthStatus,
+				UptimePct7d:      uptimePct7d,
+				InIncident:       inIncident,
+				LatencySparkline: []float64{},
+			}
+			// avg_latency_ms: null when no successful probe in the 7-day window
+			// (avgLatencyMs7d == 0.0 from COALESCE means no data), so only set
+			// a non-nil pointer when there is actual data.
+			if avgLatencyMs7d > 0 {
+				v := avgLatencyMs7d
+				item.AvgLatencyMs = &v
 			}
 			if upVal != nil {
-				item.LatestTotalMs = totalMs
+				item.Up = upVal
 				if probedAt.Valid {
 					t := probedAt.Time
 					item.LastProbeAt = &t

--- a/apps/web/src/features/fleet/FleetTable.tsx
+++ b/apps/web/src/features/fleet/FleetTable.tsx
@@ -54,6 +54,64 @@ function colMeta(raw: unknown): ColMeta {
 }
 
 // ---------------------------------------------------------------------------
+// Column width computation
+//
+// Given an ordered list of meta.width values (percentages like "28%" or
+// undefined), derive a resolved width per column so header and body always
+// share identical geometry under table-layout:fixed.
+//
+// Algorithm:
+//   1. Sum the explicit percentage widths.
+//   2. Distribute the remainder equally across columns that have no width.
+//   3. Return one string per column in the same order.
+// ---------------------------------------------------------------------------
+
+function resolveColWidths(rawWidths: Array<string | undefined>): string[] {
+  const total = rawWidths.length;
+  if (total === 0) return [];
+
+  let fixedSum = 0;
+  let freeCount = 0;
+
+  for (const w of rawWidths) {
+    if (w) {
+      // Accept "28%", "10%", etc.  Non-percentage values are passed through as-is
+      // and not counted against the free pool.
+      const pct = parseFloat(w);
+      if (!Number.isNaN(pct) && w.trim().endsWith("%")) {
+        fixedSum += pct;
+      }
+    } else {
+      freeCount++;
+    }
+  }
+
+  const freeShare =
+    freeCount > 0
+      ? Math.max(0, (100 - fixedSum) / freeCount)
+      : 0;
+
+  return rawWidths.map((w) => {
+    if (w) return w;
+    return `${freeShare.toFixed(4)}%`;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Module-level ref: the table component slot is stateless (Virtuoso creates it
+// once as a stable element type) so we thread column widths through a ref that
+// VirtuosoTable reads synchronously during render. This avoids prop-drilling
+// through the TableComponents slot API which does not support extra props.
+//
+// Assumption: React's synchronous render model guarantees that FleetTable
+// writes colWidthsRef.current before its VirtuosoTable child reads it in the
+// same render pass. The three fleet dashboards each render exactly one
+// FleetTable at a time, so there is no cross-instance collision.
+// ---------------------------------------------------------------------------
+
+const colWidthsRef: { current: string[] } = { current: [] };
+
+// ---------------------------------------------------------------------------
 // Virtuoso component slots (hoisted to avoid re-creation on parent render)
 // ---------------------------------------------------------------------------
 
@@ -73,14 +131,25 @@ const VirtuosoScroller = forwardRef<
 
 function VirtuosoTable({
   style,
+  children,
   ...props
 }: TableHTMLAttributes<HTMLTableElement>) {
+  const widths = colWidthsRef.current;
   return (
     <table
       {...props}
       style={{ ...style, borderCollapse: "collapse", tableLayout: "fixed" }}
       className="w-full min-w-[640px] text-sm"
-    />
+    >
+      {widths.length > 0 && (
+        <colgroup>
+          {widths.map((w, i) => (
+            <col key={i} style={{ width: w }} />
+          ))}
+        </colgroup>
+      )}
+      {children}
+    </table>
   );
 }
 
@@ -185,6 +254,16 @@ export function FleetTable<TData extends object>({
   const rows = table.getRowModel().rows;
 
   // ---------------------------------------------------------------------------
+  // Derive resolved column widths and write them to the module-level ref so
+  // VirtuosoTable can render the <colgroup> synchronously. This must happen
+  // before Virtuoso renders the table element on this cycle.
+  // ---------------------------------------------------------------------------
+
+  const leafColumns = table.getAllLeafColumns();
+  const rawWidths = leafColumns.map((col) => colMeta(col.columnDef.meta).width);
+  colWidthsRef.current = resolveColWidths(rawWidths);
+
+  // ---------------------------------------------------------------------------
   // Virtuoso slot components bound to current table instance. Hoisted into a
   // stable ref so Virtuoso doesn't see new component objects on each render.
   // ---------------------------------------------------------------------------
@@ -196,6 +275,11 @@ export function FleetTable<TData extends object>({
   // Virtuoso always sees the same function reference and does not unmount/remount
   // the sticky header on every parent re-render (which would cause scroll-to-top
   // flicker on sort).
+  //
+  // Width style is omitted from <th> because the <colgroup> already locks the
+  // geometry under table-layout:fixed. The colgroup is the single source of
+  // truth; th/td widths would only redundantly repeat it and could desync if
+  // the two lists diverged.
   const FixedHeader = useCallback(function FixedHeaderInner() {
     return (
       <thead className="bg-[var(--color-card)]">
@@ -217,7 +301,6 @@ export function FleetTable<TData extends object>({
                         ? "descending"
                         : undefined
                   }
-                  style={{ width: meta?.width }}
                   className={cn(
                     "px-3 py-2.5 text-left text-xs font-medium text-[var(--color-muted-foreground)]",
                     meta?.numeric && "text-right",
@@ -314,7 +397,6 @@ export function FleetTable<TData extends object>({
               return (
                 <td
                   key={cell.id}
-                  style={{ width: meta?.width }}
                   className={cn(
                     "px-3 py-2.5 text-sm text-[var(--color-foreground)]",
                     meta?.numeric && "text-right tabular-nums font-mono",

--- a/apps/web/src/routes/_authed/performance.tsx
+++ b/apps/web/src/routes/_authed/performance.tsx
@@ -515,9 +515,9 @@ function PerformancePage() {
         <HeadlineStrip sitesReporting={0} sitesTotal={0} fleetPassPct={null} loading />
       ) : isError ? null : (
         <HeadlineStrip
-          sitesReporting={data.sites_reporting}
-          sitesTotal={data.sites_total}
-          fleetPassPct={data.fleet_pass_pct}
+          sitesReporting={data.sites_reporting ?? 0}
+          sitesTotal={data.sites_total ?? 0}
+          fleetPassPct={data.fleet_pass_pct ?? null}
           loading={false}
         />
       )}
@@ -550,7 +550,7 @@ function PerformancePage() {
             onRetry={() => void refetch()}
             retryLabel="Reload RUM data"
           />
-        ) : data.sites_reporting === 0 ? (
+        ) : (data.sites_reporting ?? 0) === 0 ? (
           <div className="rounded-lg border border-[var(--color-border)] px-5 py-10 text-center">
             <Activity
               aria-hidden="true"
@@ -564,9 +564,9 @@ function PerformancePage() {
           </div>
         ) : (
           <FleetTable<FleetRumOffender>
-            data={data.worst_offenders}
+            data={data.worst_offenders ?? []}
             columns={offenderColumns}
-            height={Math.min(480, Math.max(200, data.worst_offenders.length * 52 + 44))}
+            height={Math.min(480, Math.max(200, (data.worst_offenders ?? []).length * 52 + 44))}
             ariaLabel="Worst CWV offenders"
             defaultSorting={[{ id: "lcp_p75", desc: true }]}
             emptyState={
@@ -578,14 +578,14 @@ function PerformancePage() {
         )}
 
         {/* 28-day trend — small multiples for LCP / INP / CLS */}
-        {!isPending && !isError && data.trend.length >= 2 && (
+        {!isPending && !isError && (data.trend ?? []).length >= 2 && (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
             {TREND_METRICS.map((m) => (
               <div
                 key={m}
                 className="rounded-lg border border-[var(--color-border)] bg-[var(--color-card)] px-4 py-3"
               >
-                <FleetCwvTrendChart trend={data.trend} metric={m} windowDays={windowDays} />
+                <FleetCwvTrendChart trend={data.trend ?? []} metric={m} windowDays={windowDays} />
               </div>
             ))}
           </div>


### PR DESCRIPTION
Hotfix for the 3 bugs reported on the 0.47.0 fleet dashboards, all caused by response-shape drift between the parallel backend and frontend builds.

- **Performance white-screen** (`TypeError: reading 'length'`): the fleet RUM endpoint emitted a `metrics` map and no `trend`; the dashboard reads `per_metric` + `trend`. Backend now emits `per_metric` (fixed lcp/inp/cls/fcp/ttfb) + `trend` (derived from hourly rollups); all slices non-nil.
- **Uptime blank Site + `NaN ms`**: `/fleet/status` emitted `site_name`/`site_url`/`avg_latency_ms_7d`; dashboard reads `name`/`url`/`avg_latency_ms`. Reconciled to the contract; `avg_latency_ms`/`up` null (not 0) with no probe; `latency_sparkline` always `[]`.
- **Misaligned table columns** (all 3): `FleetTable` had no `<colgroup>` under `table-layout: fixed`. Added one as the single source of column geometry.

**Hardening so it can't recur:** JSON-shape contract tests assert both fleet endpoints' field names match the web contract (a rename now fails the build), and the dashboards guard every API array/object access so a missing field shows an empty state instead of white-screening.

Gates: go build/vet/test green (incl. new contract tests); web typecheck/build/lint/impeccable clean. api+web only, no migration, no agent change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fleet dashboard performance metrics rendering errors when displaying Core Web Vitals data.
  * Fixed fleet uptime/status field alignment, eliminating NaN latency display issues.
  * Fixed fleet table column misalignment with proper pinned column group support.

* **Tests**
  * Added JSON contract tests to catch API breaking changes at build time and prevent dashboard rendering failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->