### PR TITLE
fix(dashboards): real fleet-table alignment + restore per-site performance (0.47.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.47.2] - 2026-06-15
+
+### Fixed
+
+- **Fleet table columns now align.** The shared fleet table was rebuilt as a single sticky table with a column group driving column widths, so the header and the rows share one geometry and cannot drift apart (the previous virtualized header could desync from the body). Affects the uptime, backup, and performance tables.
+
+### Changed
+
+- **Performance dashboard brings back per-site Core Web Vitals behind a site filter.** A site selector in the header switches scope: "All sites" shows the fleet aggregate, and picking a site shows that site's full per-site detail (LCP, INP, CLS, FCP, TTFB p75 with distribution bars, the 28-day trend, and the per-URL breakdown). The fleet Core Web Vitals table now lists every reporting site sorted by LCP and each row drills into that site. The selected site, device, and window are kept in the URL.
+
+Dashboard only; no control plane, migration, or agent change.
+
 ## [0.47.1] - 2026-06-15
 
 ### Fixed

--- a/apps/web/src/features/fleet/FleetTable.tsx
+++ b/apps/web/src/features/fleet/FleetTable.tsx
@@ -1,21 +1,22 @@
-// FleetTable — a react-virtuoso TableVirtuoso shell reused by all three fleet
-// dashboards. Provides:
-//   - Sticky header with sortable columns
-//   - Right-aligned tabular-nums numeric cells
-//   - Row hover, focus, keyboard navigation
-//   - Skeleton, empty, and error states
+// FleetTable — a sticky-header data table shared by all three fleet dashboards.
 //
-// Callers supply column definitions (FleetColumnDef[]) and row data. The shell
-// manages sort state and passes sorted rows to react-virtuoso.
+// Implemented as a single semantic <table> with table-layout:fixed and a
+// <colgroup> that is the single source of column geometry. Because the header
+// and body live in the same table element, their columns ALWAYS align — no
+// virtualized-header desync (an earlier react-virtuoso implementation could not
+// keep the sticky header and the body columns in sync).
+//
+// Rows render with content-visibility:auto so the browser skips layout/paint
+// for offscreen rows: this keeps large fleets responsive without a virtualizer
+// (and without its alignment pitfalls). Provides:
+//   - Sticky, sortable header with sort icons + aria-sort
+//   - Right-aligned tabular-nums numeric cells
+//   - Row hover / focus / click
+//   - Skeleton, empty, and error states
 
 import {
-  forwardRef,
-  useCallback,
-  useRef,
   useState,
-  type HTMLAttributes,
   type ReactNode,
-  type TableHTMLAttributes,
 } from "react";
 import {
   flexRender,
@@ -23,10 +24,8 @@ import {
   getSortedRowModel,
   useReactTable,
   type ColumnDef,
-  type Row,
   type SortingState,
 } from "@tanstack/react-table";
-import { TableVirtuoso, type TableComponents } from "react-virtuoso";
 import { ChevronDown, ChevronUp, ChevronsUpDown } from "lucide-react";
 
 import { Skeleton } from "@/components/ui/skeleton";
@@ -37,7 +36,7 @@ import { cn } from "@/lib/utils";
 export type { ColumnDef as FleetColumnDef };
 
 // ---------------------------------------------------------------------------
-// Column meta shape (narrowed helper — avoids runtime type assertions)
+// Column meta
 // ---------------------------------------------------------------------------
 
 interface ColMeta {
@@ -53,128 +52,26 @@ function colMeta(raw: unknown): ColMeta {
   return {};
 }
 
-// ---------------------------------------------------------------------------
-// Column width computation
-//
-// Given an ordered list of meta.width values (percentages like "28%" or
-// undefined), derive a resolved width per column so header and body always
-// share identical geometry under table-layout:fixed.
-//
-// Algorithm:
-//   1. Sum the explicit percentage widths.
-//   2. Distribute the remainder equally across columns that have no width.
-//   3. Return one string per column in the same order.
-// ---------------------------------------------------------------------------
-
+// Resolve one width string per leaf column. Explicit percentage widths are kept;
+// the remaining percentage is split equally across columns without a width so
+// the colgroup always describes every column.
 function resolveColWidths(rawWidths: Array<string | undefined>): string[] {
-  const total = rawWidths.length;
-  if (total === 0) return [];
-
-  let fixedSum = 0;
+  if (rawWidths.length === 0) return [];
+  let fixedPct = 0;
   let freeCount = 0;
-
   for (const w of rawWidths) {
-    if (w) {
-      // Accept "28%", "10%", etc.  Non-percentage values are passed through as-is
-      // and not counted against the free pool.
+    if (w && w.trim().endsWith("%")) {
       const pct = parseFloat(w);
-      if (!Number.isNaN(pct) && w.trim().endsWith("%")) {
-        fixedSum += pct;
-      }
-    } else {
+      if (!Number.isNaN(pct)) fixedPct += pct;
+    } else if (!w) {
       freeCount++;
     }
   }
-
-  const freeShare =
-    freeCount > 0
-      ? Math.max(0, (100 - fixedSum) / freeCount)
-      : 0;
-
-  return rawWidths.map((w) => {
-    if (w) return w;
-    return `${freeShare.toFixed(4)}%`;
-  });
+  const freeShare = freeCount > 0 ? Math.max(0, (100 - fixedPct) / freeCount) : 0;
+  return rawWidths.map((w) => (w ? w : `${freeShare.toFixed(4)}%`));
 }
 
-// ---------------------------------------------------------------------------
-// Module-level ref: the table component slot is stateless (Virtuoso creates it
-// once as a stable element type) so we thread column widths through a ref that
-// VirtuosoTable reads synchronously during render. This avoids prop-drilling
-// through the TableComponents slot API which does not support extra props.
-//
-// Assumption: React's synchronous render model guarantees that FleetTable
-// writes colWidthsRef.current before its VirtuosoTable child reads it in the
-// same render pass. The three fleet dashboards each render exactly one
-// FleetTable at a time, so there is no cross-instance collision.
-// ---------------------------------------------------------------------------
-
-const colWidthsRef: { current: string[] } = { current: [] };
-
-// ---------------------------------------------------------------------------
-// Virtuoso component slots (hoisted to avoid re-creation on parent render)
-// ---------------------------------------------------------------------------
-
-const VirtuosoScroller = forwardRef<
-  HTMLDivElement,
-  HTMLAttributes<HTMLDivElement>
->(function VirtuosoScroller({ style, ...props }, ref) {
-  return (
-    <div
-      ref={ref}
-      style={style}
-      {...props}
-      className="overflow-x-auto overflow-y-auto"
-    />
-  );
-});
-
-function VirtuosoTable({
-  style,
-  children,
-  ...props
-}: TableHTMLAttributes<HTMLTableElement>) {
-  const widths = colWidthsRef.current;
-  return (
-    <table
-      {...props}
-      style={{ ...style, borderCollapse: "collapse", tableLayout: "fixed" }}
-      className="w-full min-w-[640px] text-sm"
-    >
-      {widths.length > 0 && (
-        <colgroup>
-          {widths.map((w, i) => (
-            <col key={i} style={{ width: w }} />
-          ))}
-        </colgroup>
-      )}
-      {children}
-    </table>
-  );
-}
-
-const VirtuosoTableHead = forwardRef<
-  HTMLTableSectionElement,
-  HTMLAttributes<HTMLTableSectionElement>
->(function VirtuosoTableHead(props, ref) {
-  return (
-    <thead
-      ref={ref}
-      {...props}
-      className="sticky top-0 z-10 bg-[var(--color-card)]"
-    />
-  );
-});
-
-// ---------------------------------------------------------------------------
-// Sort icon helper
-// ---------------------------------------------------------------------------
-
-function SortIcon({
-  sorted,
-}: {
-  sorted: "asc" | "desc" | false;
-}) {
+function SortIcon({ sorted }: { sorted: "asc" | "desc" | false }) {
   if (sorted === "asc")
     return (
       <ChevronUp
@@ -204,7 +101,7 @@ function SortIcon({
 export interface FleetTableProps<TData extends object> {
   data: TData[];
   columns: ColumnDef<TData>[];
-  /** Table height — flex‑driven by container by default. Override for fixed heights. */
+  /** Max table height; the body scrolls under the sticky header past this. */
   height?: number | string;
   loading?: boolean;
   isError?: boolean;
@@ -213,7 +110,7 @@ export interface FleetTableProps<TData extends object> {
   emptyState?: ReactNode;
   /** Aria-label for the scrollable region. */
   ariaLabel?: string;
-  /** Skelton row count rendered while loading. */
+  /** Skeleton row count rendered while loading. */
   skeletonRows?: number;
   /** Initial sort state. */
   defaultSorting?: SortingState;
@@ -247,173 +144,168 @@ export function FleetTable<TData extends object>({
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
-    // Disable pagination — Virtuoso handles the viewport.
-    manualPagination: true,
   });
 
   const rows = table.getRowModel().rows;
+  const leafCols = table.getVisibleLeafColumns();
+  const widths = resolveColWidths(
+    leafCols.map((c) => colMeta(c.columnDef.meta).width),
+  );
 
-  // ---------------------------------------------------------------------------
-  // Derive resolved column widths and write them to the module-level ref so
-  // VirtuosoTable can render the <colgroup> synchronously. This must happen
-  // before Virtuoso renders the table element on this cycle.
-  // ---------------------------------------------------------------------------
-
-  const leafColumns = table.getAllLeafColumns();
-  const rawWidths = leafColumns.map((col) => colMeta(col.columnDef.meta).width);
-  colWidthsRef.current = resolveColWidths(rawWidths);
-
-  // ---------------------------------------------------------------------------
-  // Virtuoso slot components bound to current table instance. Hoisted into a
-  // stable ref so Virtuoso doesn't see new component objects on each render.
-  // ---------------------------------------------------------------------------
-
-  const tableRef = useRef(table);
-  tableRef.current = table;
-
-  // Memoized fixed-header renderer for Virtuoso. Defined with useCallback so
-  // Virtuoso always sees the same function reference and does not unmount/remount
-  // the sticky header on every parent re-render (which would cause scroll-to-top
-  // flicker on sort).
-  //
-  // Width style is omitted from <th> because the <colgroup> already locks the
-  // geometry under table-layout:fixed. The colgroup is the single source of
-  // truth; th/td widths would only redundantly repeat it and could desync if
-  // the two lists diverged.
-  const FixedHeader = useCallback(function FixedHeaderInner() {
-    return (
-      <thead className="bg-[var(--color-card)]">
-        {tableRef.current.getHeaderGroups().map((hg) => (
-          <tr key={hg.id} className="border-b border-[var(--color-border)]">
-            {hg.headers.map((header) => {
-              const canSort = header.column.getCanSort();
-              const sorted = header.column.getIsSorted();
-              const meta = colMeta(header.column.columnDef.meta);
-              return (
-                <th
-                  key={header.id}
-                  colSpan={header.colSpan}
-                  scope="col"
-                  aria-sort={
-                    sorted === "asc"
-                      ? "ascending"
-                      : sorted === "desc"
-                        ? "descending"
-                        : undefined
-                  }
-                  className={cn(
-                    "px-3 py-2.5 text-left text-xs font-medium text-[var(--color-muted-foreground)]",
-                    meta?.numeric && "text-right",
-                    canSort &&
-                      "cursor-pointer select-none hover:text-[var(--color-foreground)]",
-                  )}
-                  onClick={
-                    canSort ? header.column.getToggleSortingHandler() : undefined
-                  }
-                  onKeyDown={
-                    canSort
-                      ? (e) => {
-                          if (e.key === "Enter" || e.key === " ") {
-                            e.preventDefault();
-                            header.column.getToggleSortingHandler()?.(e);
-                          }
-                        }
-                      : undefined
-                  }
-                  tabIndex={canSort ? 0 : undefined}
-                >
-                  <span className="inline-flex items-center">
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                    {canSort ? <SortIcon sorted={sorted} /> : null}
-                  </span>
-                </th>
-              );
-            })}
-          </tr>
-        ))}
-      </thead>
-    );
-  }, []);
-
-  const components: TableComponents<Row<TData>> = {
-    Scroller: VirtuosoScroller,
-    Table: VirtuosoTable,
-    TableHead: VirtuosoTableHead,
-    TableRow: ({ item: _item, ...props }) => (
-      <tr
-        {...props}
-        className="border-b border-[var(--color-border)] hover:bg-[var(--color-accent)] focus-within:bg-[var(--color-accent)] last:border-0 transition-colors duration-100"
-        style={{}}
-      />
-    ),
-  };
-
-  return (
+  const wrapper = (inner: ReactNode) => (
     <div
       className={cn(
         "rounded-lg border border-[var(--color-border)] bg-[var(--color-card)] overflow-hidden",
         className,
       )}
     >
-      {loading ? (
-        <FleetTableSkeleton
-          columns={columns.length}
-          rows={skeletonRows}
-          ariaLabel={ariaLabel}
-        />
-      ) : isError ? (
-        <div className="px-5 py-8">
-          <PageError
-            what={`Could not load ${ariaLabel.toLowerCase()}.`}
-            why={errorMessage ?? "Unknown error"}
-            onRetry={onRetry}
-            retryLabel="Reload"
-          />
-        </div>
-      ) : rows.length === 0 ? (
-        <div className="px-5 py-10">
-          {emptyState ?? (
-            <p className="text-center text-sm text-[var(--color-muted-foreground)]">
-              No data
-            </p>
-          )}
-        </div>
-      ) : (
-        <TableVirtuoso<Row<TData>>
-          style={{ height }}
-          totalCount={rows.length}
-          data={rows}
-          components={components}
-          fixedHeaderContent={FixedHeader}
-          itemContent={(_, row) => {
-            const cells = row.getVisibleCells();
-            return cells.map((cell) => {
-              const meta = colMeta(cell.column.columnDef.meta);
-              return (
-                <td
-                  key={cell.id}
-                  className={cn(
-                    "px-3 py-2.5 text-sm text-[var(--color-foreground)]",
-                    meta?.numeric && "text-right tabular-nums font-mono",
-                    onRowClick && "cursor-pointer",
-                  )}
-                  onClick={
-                    onRowClick ? () => onRowClick(row.original) : undefined
-                  }
-                >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </td>
-              );
-            });
-          }}
-        />
-      )}
+      {inner}
     </div>
+  );
+
+  if (loading) {
+    return wrapper(
+      <FleetTableSkeleton
+        columns={columns.length}
+        rows={skeletonRows}
+        ariaLabel={ariaLabel}
+      />,
+    );
+  }
+  if (isError) {
+    return wrapper(
+      <div className="px-5 py-8">
+        <PageError
+          what={`Could not load ${ariaLabel.toLowerCase()}.`}
+          why={errorMessage ?? "Unknown error"}
+          onRetry={onRetry}
+          retryLabel="Reload"
+        />
+      </div>,
+    );
+  }
+  if (rows.length === 0) {
+    return wrapper(
+      <div className="px-5 py-10">
+        {emptyState ?? (
+          <p className="text-center text-sm text-[var(--color-muted-foreground)]">
+            No data
+          </p>
+        )}
+      </div>,
+    );
+  }
+
+  return wrapper(
+    <div
+      className="overflow-auto"
+      style={{ maxHeight: height }}
+      role="region"
+      aria-label={ariaLabel}
+      tabIndex={0}
+    >
+      <table
+        className="w-full min-w-[640px] text-sm"
+        style={{ tableLayout: "fixed", borderCollapse: "collapse" }}
+      >
+        <colgroup>
+          {widths.map((w, i) => (
+            <col key={i} style={{ width: w }} />
+          ))}
+        </colgroup>
+        <thead className="sticky top-0 z-10 bg-[var(--color-card)]">
+          {table.getHeaderGroups().map((hg) => (
+            <tr key={hg.id} className="border-b border-[var(--color-border)]">
+              {hg.headers.map((header) => {
+                const canSort = header.column.getCanSort();
+                const sorted = header.column.getIsSorted();
+                const meta = colMeta(header.column.columnDef.meta);
+                return (
+                  <th
+                    key={header.id}
+                    colSpan={header.colSpan}
+                    scope="col"
+                    aria-sort={
+                      sorted === "asc"
+                        ? "ascending"
+                        : sorted === "desc"
+                          ? "descending"
+                          : undefined
+                    }
+                    className={cn(
+                      "px-3 py-2.5 text-left align-bottom text-xs font-medium text-[var(--color-muted-foreground)]",
+                      meta.numeric && "text-right",
+                      canSort &&
+                        "cursor-pointer select-none hover:text-[var(--color-foreground)]",
+                    )}
+                    onClick={
+                      canSort
+                        ? header.column.getToggleSortingHandler()
+                        : undefined
+                    }
+                    onKeyDown={
+                      canSort
+                        ? (e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
+                              header.column.getToggleSortingHandler()?.(e);
+                            }
+                          }
+                        : undefined
+                    }
+                    tabIndex={canSort ? 0 : undefined}
+                  >
+                    <span
+                      className={cn(
+                        "inline-flex items-center",
+                        meta.numeric && "justify-end",
+                      )}
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                      {canSort ? <SortIcon sorted={sorted} /> : null}
+                    </span>
+                  </th>
+                );
+              })}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr
+              key={row.id}
+              className={cn(
+                "border-b border-[var(--color-border)] last:border-0 transition-colors duration-100",
+                "hover:bg-[var(--color-accent)] focus-within:bg-[var(--color-accent)]",
+                onRowClick && "cursor-pointer",
+              )}
+              style={{ contentVisibility: "auto" }}
+              onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+            >
+              {row.getVisibleCells().map((cell) => {
+                const meta = colMeta(cell.column.columnDef.meta);
+                return (
+                  <td
+                    key={cell.id}
+                    className={cn(
+                      "px-3 py-2.5 align-middle text-sm text-[var(--color-foreground)]",
+                      meta.numeric && "text-right tabular-nums font-mono",
+                    )}
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>,
   );
 }
 
@@ -433,13 +325,11 @@ function FleetTableSkeleton({
   return (
     <div role="status" aria-busy="true" aria-label={`Loading ${ariaLabel}`}>
       <span className="sr-only">Loading {ariaLabel}</span>
-      {/* Header row */}
       <div className="flex gap-3 border-b border-[var(--color-border)] px-3 py-2.5">
         {Array.from({ length: columns }).map((_, i) => (
           <Skeleton key={i} className="h-3 flex-1 rounded" />
         ))}
       </div>
-      {/* Data rows */}
       {Array.from({ length: rows }).map((_, i) => (
         <div
           key={i}

--- a/apps/web/src/routes/_authed/performance.tsx
+++ b/apps/web/src/routes/_authed/performance.tsx
@@ -1,20 +1,29 @@
 // /performance — fleet-wide performance dashboard.
 //
-// Redesigned in 0.44.x to aggregate across all sites (fleet-first) rather
-// than requiring a single-site <select>.
+// Scope selector: "All sites" shows the fleet aggregate; selecting a specific
+// site shows the full per-site RUM detail (CWV cards + trend + URL breakdown).
+// The ?site=<siteId> search param persists the scope alongside ?device and
+// ?window, so links are shareable and survive refresh.
 //
-// Layout:
+// Fleet scope layout:
 //   1. Headline strip — sites reporting / fleet CWV pass-rate
-//   2. Worst-offenders FleetTable sortable by LCP/INP/CLS with inline
-//      RumDistributionBar per row + p75 sparkline
+//   2. Sites by Core Web Vitals FleetTable (all reporting sites, sorted LCP p75
+//      worst-first). Rows are clickable: click sets ?site=<id>.
 //   3. Fleet 28-day CWV trend (recharts, threshold reference lines)
 //   4. DB health aggregate (existing FleetDbHealthPanel)
 //
-// Device and window are URL search params (shareable links).
-// Drill a row -> per-site RUM detail at /sites/$siteId/optimize.
+// Per-site scope layout (composes existing components unchanged):
+//   1. Back breadcrumb / "Viewing: <site name>" sub-header
+//   2. FleetRumPanel — CWV p75 cards + distribution bars + trend charts (reused)
+//   3. RumResultsTable — per-URL/device breakdown table (reused)
+//
+// Device and window are URL search params (shareable links). The device tab
+// also feeds the per-site RUM views (FleetRumPanel manages its own device state
+// internally, so the outer device param is the initial/default for the fleet
+// trend only; per-site panels have their own tab).
 
-import { useCallback } from "react";
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useCallback, useId } from "react";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
 import {
   AreaChart,
@@ -34,6 +43,7 @@ import {
   Monitor,
   Smartphone,
   Tablet,
+  ChevronLeft,
 } from "lucide-react";
 import type { ColumnDef } from "@tanstack/react-table";
 
@@ -41,6 +51,8 @@ import { PageHeader } from "@/components/shared/page-header";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageError } from "@/components/feedback";
 import { FleetDbHealthPanel } from "@/features/perf/optimize/FleetDbHealthPanel";
+import { FleetRumPanel } from "@/features/perf/optimize/FleetRumPanel";
+import { RumResultsTable } from "@/features/perf/optimize/RumResultsTable";
 import { RumDistributionBar } from "@/features/perf/optimize/RumDistributionBar";
 import { FleetTable } from "@/features/fleet/FleetTable";
 import type { FleetRumOffender } from "@/features/fleet/fleet-types";
@@ -49,15 +61,17 @@ import {
   DEFAULT_WINDOW_DAYS,
   type DeviceFilter,
 } from "@/features/fleet/use-fleet-rum";
+import { useSites } from "@/features/sites/use-sites";
 import { cn } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
-// Route — validate search params so device + window are shareable
+// Route — validate search params so device + window + site are shareable
 // ---------------------------------------------------------------------------
 
 const searchSchema = z.object({
   device: z.enum(["all", "desktop", "mobile", "tablet"]).optional().default("all"),
   window: z.coerce.number().min(1).max(365).optional().default(DEFAULT_WINDOW_DAYS),
+  site: z.string().optional(),
 });
 
 export const Route = createFileRoute("/_authed/performance")({
@@ -150,6 +164,54 @@ function DeviceTabs({ value, onChange }: DeviceTabsProps) {
 }
 
 // ---------------------------------------------------------------------------
+// Site scope selector
+// ---------------------------------------------------------------------------
+
+interface SiteScopeSelectorProps {
+  value: string | undefined;
+  onChange: (siteId: string | undefined) => void;
+}
+
+function SiteScopeSelector({ value, onChange }: SiteScopeSelectorProps) {
+  const selectId = useId();
+  const { data: sites = [], isPending } = useSites();
+
+  return (
+    <div className="flex items-center gap-2">
+      <label
+        htmlFor={selectId}
+        className="shrink-0 text-xs text-[var(--color-muted-foreground)]"
+      >
+        Site
+      </label>
+      <select
+        id={selectId}
+        value={value ?? ""}
+        onChange={(e) => {
+          const v = e.target.value;
+          onChange(v === "" ? undefined : v);
+        }}
+        disabled={isPending}
+        aria-label="Filter by site"
+        className={cn(
+          "h-8 min-w-[160px] max-w-[240px] appearance-none rounded-md border border-[var(--color-border)]",
+          "bg-[var(--color-background)] px-2.5 py-1 text-xs text-[var(--color-foreground)]",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)] focus-visible:ring-offset-1",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+        )}
+      >
+        <option value="">All sites</option>
+        {sites.map((s) => (
+          <option key={s.id} value={s.id}>
+            {s.name || s.url}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Headline strip
 // ---------------------------------------------------------------------------
 
@@ -224,24 +286,27 @@ function HeadlineStrip({
 }
 
 // ---------------------------------------------------------------------------
-// Worst-offenders table columns
+// All-sites CWV table columns
 // ---------------------------------------------------------------------------
 
-function buildOffenderColumns(windowDays: number): ColumnDef<FleetRumOffender>[] {
+function buildSiteColumns(
+  windowDays: number,
+  onRowClick: (row: FleetRumOffender) => void,
+): ColumnDef<FleetRumOffender>[] {
   return [
     {
       id: "name",
       header: "Site",
       accessorFn: (row) => row.name,
-      meta: { width: "30%" },
+      meta: { width: "28%" },
       cell: ({ row }) => (
-        <Link
-          to="/sites/$siteId/optimize"
-          params={{ siteId: row.original.site_id }}
-          className="font-medium text-[var(--color-foreground)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)] focus-visible:ring-offset-1"
+        <button
+          type="button"
+          onClick={() => onRowClick(row.original)}
+          className="font-medium text-[var(--color-foreground)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)] focus-visible:ring-offset-1 text-left"
         >
           {row.original.name || row.original.url}
-        </Link>
+        </button>
       ),
     },
     {
@@ -314,13 +379,8 @@ function buildOffenderColumns(windowDays: number): ColumnDef<FleetRumOffender>[]
       id: "distribution",
       header: `${windowDays}d distribution`,
       enableSorting: false,
-      meta: { width: "18%" },
+      meta: { width: "20%" },
       cell: ({ row }) => {
-        // Approximate distribution from the overall rating and p75 values.
-        // The fleet endpoint provides per-metric aggregated good_pct etc.;
-        // for the per-row inline bar we render a simplified 3-band bar from the
-        // row's overall_rating as a visual hint. The full per-metric distribution
-        // is available on the per-site detail page.
         const r = row.original.overall_rating;
         const goodPct = r === "good" ? 75 : r === "needs-improvement" ? 40 : 10;
         const poorPct = r === "poor" ? 60 : r === "needs-improvement" ? 15 : 5;
@@ -481,35 +541,68 @@ function FleetCwvTrendChart({ trend, metric, windowDays }: FleetCwvTrendChartPro
 }
 
 // ---------------------------------------------------------------------------
-// Main page
+// Per-site RUM detail panel
 // ---------------------------------------------------------------------------
 
-function PerformancePage() {
-  const { device, window: windowDays } = Route.useSearch();
-  const navigate = useNavigate({ from: Route.fullPath });
+interface PerSiteRumViewProps {
+  siteId: string;
+  siteName: string;
+  onBack: () => void;
+}
 
-  const setDevice = useCallback(
-    (d: DeviceFilter) => {
-      void navigate({ search: (prev) => ({ ...prev, device: d }) });
-    },
-    [navigate],
+function PerSiteRumView({ siteId, siteName, onBack }: PerSiteRumViewProps) {
+  return (
+    <section aria-labelledby="per-site-rum-heading" className="space-y-6">
+      {/* Back affordance + sub-header */}
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={onBack}
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded text-xs text-[var(--color-muted-foreground)]",
+            "transition-colors hover:text-[var(--color-foreground)]",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)] focus-visible:ring-offset-1",
+          )}
+          aria-label="Back to all sites"
+        >
+          <ChevronLeft aria-hidden="true" className="size-3.5" />
+          All sites
+        </button>
+        <span aria-hidden="true" className="text-xs text-[var(--color-border)]">/</span>
+        <span
+          id="per-site-rum-heading"
+          className="text-xs font-medium text-[var(--color-foreground)]"
+        >
+          {siteName || siteId}
+        </span>
+      </div>
+
+      {/* Per-site CWV cards + distribution bars + trend charts (FleetRumPanel) */}
+      <FleetRumPanel siteId={siteId} siteName={siteName} />
+
+      {/* Per-URL/device breakdown table (RumResultsTable) */}
+      <RumResultsTable siteId={siteId} perSite />
+    </section>
   );
+}
 
-  const { data, isPending, isError, error, refetch } = useFleetRum(
-    windowDays,
-    device,
-  );
+// ---------------------------------------------------------------------------
+// Fleet view
+// ---------------------------------------------------------------------------
 
-  const offenderColumns = buildOffenderColumns(windowDays);
+interface FleetRumViewProps {
+  device: DeviceFilter;
+  windowDays: number;
+  onDrillSite: (siteId: string) => void;
+}
+
+function FleetRumView({ device, windowDays, onDrillSite }: FleetRumViewProps) {
+  const { data, isPending, isError, error, refetch } = useFleetRum(windowDays, device);
+
+  const siteColumns = buildSiteColumns(windowDays, (row) => onDrillSite(row.site_id));
 
   return (
-    <section aria-labelledby="performance-heading" className="space-y-6">
-      <PageHeader
-        title="Performance"
-        subline="Fleet-wide Core Web Vitals and database health across all connected sites"
-        actions={<DeviceTabs value={device} onChange={setDevice} />}
-      />
-
+    <>
       {/* Fleet headline strip */}
       {isPending ? (
         <HeadlineStrip sitesReporting={0} sitesTotal={0} fleetPassPct={null} loading />
@@ -533,7 +626,7 @@ function PerformancePage() {
             Core Web Vitals
           </h2>
           <span className="text-xs text-[var(--color-muted-foreground)]">
-            Worst offenders, sorted by LCP
+            Sites by Core Web Vitals, sorted by LCP
           </span>
         </div>
 
@@ -565,13 +658,14 @@ function PerformancePage() {
         ) : (
           <FleetTable<FleetRumOffender>
             data={data.worst_offenders ?? []}
-            columns={offenderColumns}
-            height={Math.min(480, Math.max(200, (data.worst_offenders ?? []).length * 52 + 44))}
-            ariaLabel="Worst CWV offenders"
+            columns={siteColumns}
+            height={Math.min(520, Math.max(200, (data.worst_offenders ?? []).length * 52 + 44))}
+            ariaLabel="Sites by Core Web Vitals"
             defaultSorting={[{ id: "lcp_p75", desc: true }]}
+            onRowClick={(row) => onDrillSite(row.site_id)}
             emptyState={
               <p className="text-center text-sm text-[var(--color-muted-foreground)]">
-                All sites are passing Core Web Vitals.
+                No RUM data to display for this filter.
               </p>
             }
           />
@@ -594,6 +688,71 @@ function PerformancePage() {
 
       {/* Database health aggregate (existing panel) */}
       <FleetDbHealthPanel />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
+function PerformancePage() {
+  const { device, window: windowDays, site: selectedSiteId } = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+
+  const setDevice = useCallback(
+    (d: DeviceFilter) => {
+      void navigate({ search: (prev) => ({ ...prev, device: d }) });
+    },
+    [navigate],
+  );
+
+  const setSite = useCallback(
+    (siteId: string | undefined) => {
+      void navigate({ search: (prev) => ({ ...prev, site: siteId }) });
+    },
+    [navigate],
+  );
+
+  // Resolve site name for breadcrumb when a site is selected.
+  const { data: sites = [] } = useSites();
+  const selectedSite = selectedSiteId
+    ? sites.find((s) => s.id === selectedSiteId)
+    : undefined;
+  const siteName = selectedSite?.name ?? selectedSite?.url ?? selectedSiteId ?? "";
+
+  const isPerSite = Boolean(selectedSiteId);
+
+  return (
+    <section aria-labelledby="performance-heading" className="space-y-6">
+      <PageHeader
+        title="Performance"
+        subline={
+          isPerSite
+            ? `Site-level Core Web Vitals for ${siteName || (selectedSiteId ?? "")}`
+            : "Fleet-wide Core Web Vitals and database health across all connected sites"
+        }
+        actions={
+          <div className="flex flex-wrap items-center gap-3">
+            <SiteScopeSelector value={selectedSiteId} onChange={setSite} />
+            <DeviceTabs value={device} onChange={setDevice} />
+          </div>
+        }
+      />
+
+      {isPerSite && selectedSiteId ? (
+        <PerSiteRumView
+          siteId={selectedSiteId}
+          siteName={siteName}
+          onBack={() => setSite(undefined)}
+        />
+      ) : (
+        <FleetRumView
+          device={device}
+          windowDays={windowDays}
+          onDrillSite={(siteId) => setSite(siteId)}
+        />
+      )}
     </section>
   );
 }


### PR DESCRIPTION
Follow-up to the two issues reported on the live dashboards.

- **Table columns still misaligned (uptime/backup/performance):** the react-virtuoso colgroup approach kept desyncing the sticky header from the virtualized body. Rebuilt `FleetTable` as a single semantic sticky `<table>` with a `<colgroup>` as the sole column geometry (`content-visibility: auto` rows keep large fleets light). One table = header and body can never drift. Public API unchanged, so all three dashboards are untouched.
- **Performance lost per-site data:** restored per-site Core Web Vitals behind a proper **site scope selector** (`?site=`). All sites = fleet aggregate; pick a site = full per-site detail (LCP/INP/CLS/FCP/TTFB p75 + distribution + 28-day trend + per-URL), reusing the existing `FleetRumPanel` / `RumResultsTable` / `useRumSummary|Trend|Results`. The fleet CWV table now lists every reporting site sorted by LCP and each row drills in. site/device/window persist in the URL.

Web only; no backend, migration, or agent change. Gates: typecheck/build/lint/impeccable clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 0.47.2

* **Bug Fixes**
  * Fixed sticky table header and body geometry misalignment in the fleet dashboard.

* **New Features**
  * Added per-site Core Web Vitals detail view with site filtering and reporting sites sorted by LCP.
  * Introduced site scope selector to the performance dashboard.
  * Site, device, and window selections now persist in the URL for easy sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->