### PR TITLE
fix(backup): locked snapshot can no longer be manually deleted (0.48.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.48.1] - 2026-06-15
+
+### Fixed
+
+- **A locked backup can no longer be deleted.** Locking a snapshot already exempted it from retention pruning, but a manual delete still removed it, so the lock only protected against the auto-pruner. The delete path now refuses a locked snapshot ("this backup is locked; unlock it before deleting") the same way it already refuses an in-progress or chain-depended-on one. In the dashboard, deleting a locked backup opens a short explanation with an "Unlock to delete" action instead of failing at a server error, so a lock now genuinely protects the backup end to end.
+
+Control plane plus dashboard at 0.48.1; no migration, no agent change.
+
 ## [0.48.0] - 2026-06-15
 
 ### Added

--- a/apps/api/internal/backup/delete_cancel_test.go
+++ b/apps/api/internal/backup/delete_cancel_test.go
@@ -214,6 +214,26 @@ func TestDeleteSnapshotForUser_RunningRefused(t *testing.T) {
 	}
 }
 
+// A locked snapshot is exempt from manual delete just as it is from the auto-GC
+// (see gc.go: locked metas are pulled out of the deleteSet). The operator must
+// unlock first — that is what makes a lock a real protection, not just a hint.
+func TestDeleteSnapshotForUser_LockedRefused(t *testing.T) {
+	repo := newDeleteCancelFakeRepo()
+	svc := buildDeleteCancelSvc(repo)
+	tenantID := uuid.New()
+	snap := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: uuid.New(), Status: StatusCompleted, Locked: true}
+	repo.setSnapshot(snap)
+
+	err := svc.DeleteSnapshotForUser(context.Background(), tenantID, snap.ID)
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindValidation || de.Code != "snapshot_locked" {
+		t.Fatalf("err = %v, want Validation snapshot_locked", err)
+	}
+	if repo.deleted[snap.ID] {
+		t.Fatalf("locked snapshot must NOT be deleted")
+	}
+}
+
 // --- post-cancel late-submit rejection --------------------------------------
 
 func TestSubmitManifest_RejectsCanceledSnapshot(t *testing.T) {

--- a/apps/api/internal/backup/service.go
+++ b/apps/api/internal/backup/service.go
@@ -1699,6 +1699,14 @@ func (s *Service) DeleteSnapshotForUser(ctx context.Context, tenantID, snapshotI
 			"this backup is still running; cancel it before deleting")
 	}
 
+	// Lock guard (m49): a locked snapshot is exempt from retention GC AND from
+	// manual deletion. The operator must explicitly unlock before deleting, so a
+	// lock genuinely protects the backup (not just from the auto-pruner).
+	if snap.Locked {
+		return domain.Validation("snapshot_locked",
+			"this backup is locked; unlock it before deleting")
+	}
+
 	// Chain-safety: never orphan a dependent increment. If this snapshot anchors
 	// or sits mid-chain (i.e. a sibling exists at a HIGHER generation in the same
 	// chain), refuse — the dependents would become unrestorable.

--- a/apps/web/src/features/backups/backups-section.tsx
+++ b/apps/web/src/features/backups/backups-section.tsx
@@ -24,6 +24,14 @@ import { StatusChip } from "@/components/status/status-chip";
 import type { StatusTone } from "@/components/status/status-dot";
 import { DestructiveConfirm } from "@/components/dialogs/destructive-confirm";
 import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
   useBackups,
   useCreateBackup,
   useDeleteBackup,
@@ -691,6 +699,9 @@ function SnapshotLockToggle({
  *     chain-safe and refuses to delete a base/mid-chain increment that still has
  *     dependents, surfacing that as an inline error in the confirm dialog (we
  *     don't have the chain tip locally to pre-disable it — task #180).
+ *   - A LOCKED snapshot cannot be deleted (the server returns "snapshot_locked").
+ *     Clicking Delete on it opens a warning that explains the lock and offers to
+ *     unlock first, rather than dead-ending the operator at a server error.
  */
 function BackupRowActions({
   snapshot,
@@ -699,18 +710,23 @@ function BackupRowActions({
   snapshot: BackupSnapshot;
   siteId: string;
 }) {
-  const [confirm, setConfirm] = useState<null | "cancel" | "delete">(null);
+  const [confirm, setConfirm] = useState<null | "cancel" | "delete" | "locked">(
+    null,
+  );
   const del = useDeleteBackup(snapshot.id, siteId);
   const cancel = useCancelBackup(snapshot.id, siteId);
+  const unlock = useUnlockBackup(snapshot.id, siteId);
 
   const isInFlight =
     snapshot.status === "running" || snapshot.status === "pending";
+  const isLocked = snapshot.locked === true;
   const shortId = snapshot.id.slice(0, 8);
 
   function close() {
     setConfirm(null);
     del.reset();
     cancel.reset();
+    unlock.reset();
   }
 
   return (
@@ -728,7 +744,7 @@ function BackupRowActions({
           variant="outline"
           size="sm"
           className="text-destructive-subtle-fg"
-          onClick={() => setConfirm("delete")}
+          onClick={() => setConfirm(isLocked ? "locked" : "delete")}
         >
           Delete
         </Button>
@@ -774,6 +790,54 @@ function BackupRowActions({
         isPending={del.isPending}
         errorMessage={del.isError ? del.error.message : null}
       />
+
+      <Dialog
+        open={confirm === "locked"}
+        onClose={unlock.isPending ? () => {} : close}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>This backup is locked</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <p className="text-sm text-foreground">
+              A locked backup is protected: retention never prunes it and it
+              cannot be deleted. To remove it, unlock it first, then delete.
+            </p>
+            {unlock.isError ? (
+              <p
+                role="alert"
+                className="rounded-md border border-[var(--color-destructive)]/40 bg-[var(--color-destructive)]/10 p-2 text-sm text-[var(--color-destructive)]"
+              >
+                {unlock.error.message}
+              </p>
+            ) : null}
+          </DialogBody>
+          <DialogFooter className="pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={close}
+              disabled={unlock.isPending}
+            >
+              Keep locked
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="text-destructive-subtle-fg"
+              onClick={() =>
+                unlock.mutate(undefined, {
+                  onSuccess: () => setConfirm("delete"),
+                })
+              }
+              disabled={unlock.isPending}
+            >
+              {unlock.isPending ? "Unlocking…" : "Unlock to delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }


### PR DESCRIPTION
## What

A locked backup snapshot could still be deleted manually. Locking already exempted a snapshot from retention GC (`gc.go` pulls locked metas out of the deleteSet), but `DeleteSnapshotForUser` had no lock check, so the lock only protected against the auto-pruner, not an operator delete. This closes that gap so a lock genuinely protects a backup end to end.

## Changes

- **API** (`apps/api/internal/backup/service.go`): `DeleteSnapshotForUser` now refuses a locked snapshot with `Validation("snapshot_locked", "this backup is locked; unlock it before deleting")`, mirroring the existing in-progress and chain-dependent guards.
- **Test** (`delete_cancel_test.go`): `TestDeleteSnapshotForUser_LockedRefused` asserts the guard fires and the row is not deleted.
- **Web** (`backups-section.tsx`): deleting a locked backup opens a short "This backup is locked" dialog with an "Unlock to delete" action (unlock, then the delete confirm) instead of dead-ending at the server error.
- **CHANGELOG**: 0.48.1.

No migration, no agent change.

## Verification

- `go build ./...`, `go vet ./internal/backup/`, `go test ./internal/backup/` green
- web `pnpm typecheck`, `pnpm lint` (only the pre-existing FleetTable React-Compiler warning), `pnpm build` green
- Impeccable detector clean on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Locked backups can no longer be deleted and now display a dedicated dialog with an "Unlock to delete" action instead of a server error message.
  * Improved the backup deletion flow in the dashboard to provide clearer guidance for managing locked backups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->