### PR TITLE
feat(activity): integrity report explaining why the audit chain broke (0.48.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.48.3] - 2026-06-15
+
+### Added
+
+- **Activity log integrity report.** The "Chain break at seq N" badge is now a button that opens a report explaining why the tamper-evident audit chain failed to verify. The control plane classifies the break into one of four causes (missing events, a broken link between two entries, modified content, or a missing chain start) and the report states it in plain language, names the events involved, and shows the technical hash detail on demand. A chain break most often means older entries were pruned or cleared rather than tampering, and the report says so honestly instead of only flagging a number. A "Re-check" action re-runs verification.
+
+### Changed
+
+- **The `GET /activity/verify` response now includes a `break` object** when a chain break is found: the failing sequence, the cause classification, the prior verified sequence, the size of any sequence gap, the expected-versus-stored hashes, and the offending event. The existing `break_at_seq` field is unchanged.
+
+Control plane plus dashboard at 0.48.3; no migration, no agent change.
+
 ## [0.48.2] - 2026-06-15
 
 ### Fixed

--- a/apps/api/internal/activity/activity_test.go
+++ b/apps/api/internal/activity/activity_test.go
@@ -2,6 +2,7 @@ package activity
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -105,5 +106,246 @@ func TestVerifyDetectsBrokenPrevHash(t *testing.T) {
 	}
 	if res.BreakAtSeq == nil || *res.BreakAtSeq != 2 {
 		t.Fatalf("expected break at seq 2, got %v", res.BreakAtSeq)
+	}
+}
+
+// TestVerifyChain_ValidChain confirms a clean chain returns Valid true, Break nil.
+func TestVerifyChain_ValidChain(t *testing.T) {
+	rows := buildChain(t)
+	res := VerifyChain(rows)
+	if !res.Valid {
+		t.Fatalf("expected valid chain, got break at %v", res.BreakAtSeq)
+	}
+	if res.Break != nil {
+		t.Fatalf("expected Break nil on valid chain, got %+v", res.Break)
+	}
+	if res.Total != 3 {
+		t.Fatalf("expected total 3, got %d", res.Total)
+	}
+}
+
+// TestVerifyChain_ContentModified tampers a middle row's content so the
+// recomputed hash diverges from the stored this_hash while the prev link remains
+// intact. Expects kind=content_modified at seq 2, seq_gap=0, prior_seq=1.
+func TestVerifyChain_ContentModified(t *testing.T) {
+	rows := buildChain(t)
+	// Mutate seq 2's MetaRaw — the hash preimage source — without touching
+	// PrevHash or ThisHash, exactly as a direct DB row edit would look.
+	rows[1].MetaRaw = `{"ip":"192.168.0.1","severity":"low"}`
+
+	res := VerifyChain(rows)
+	if res.Valid {
+		t.Fatal("expected invalid chain")
+	}
+	if res.Break == nil {
+		t.Fatal("expected non-nil Break")
+	}
+	b := res.Break
+	if b.Kind != BreakContentModified {
+		t.Errorf("kind: got %q, want %q", b.Kind, BreakContentModified)
+	}
+	if b.Seq != 2 {
+		t.Errorf("seq: got %d, want 2", b.Seq)
+	}
+	if b.PriorSeq == nil || *b.PriorSeq != 1 {
+		t.Errorf("prior_seq: got %v, want 1", b.PriorSeq)
+	}
+	if b.SeqGap != 0 {
+		t.Errorf("seq_gap: got %d, want 0", b.SeqGap)
+	}
+	if res.BreakAtSeq == nil || *res.BreakAtSeq != 2 {
+		t.Errorf("BreakAtSeq: got %v, want 2", res.BreakAtSeq)
+	}
+	// ExpectedPrevHash must equal row[0].ThisHash (the verified chain head).
+	if b.ExpectedPrevHash != rows[0].ThisHash {
+		t.Errorf("expected_prev_hash mismatch")
+	}
+	// StoredPrevHash must equal row[1].PrevHash as stored (unchanged).
+	if b.StoredPrevHash != rows[1].PrevHash {
+		t.Errorf("stored_prev_hash mismatch")
+	}
+	// StoredThisHash must equal row[1].ThisHash as stored.
+	if b.StoredThisHash != rows[1].ThisHash {
+		t.Errorf("stored_this_hash mismatch")
+	}
+	// RecomputedThisHash must differ from StoredThisHash (that's the whole point).
+	if b.RecomputedThisHash == b.StoredThisHash {
+		t.Errorf("recomputed_this_hash should differ from stored when content was modified")
+	}
+}
+
+// TestVerifyChain_LinkMismatch sets a row's prev_hash to a garbage value
+// while keeping seqs contiguous. Expects kind=link_mismatch.
+func TestVerifyChain_LinkMismatch(t *testing.T) {
+	rows := buildChain(t)
+	// Break row[1]'s prev_hash while keeping the seq contiguous (seq 1, 2, 3).
+	rows[1].PrevHash = strings.Repeat("a", 64)
+
+	res := VerifyChain(rows)
+	if res.Valid {
+		t.Fatal("expected invalid chain")
+	}
+	if res.Break == nil {
+		t.Fatal("expected non-nil Break")
+	}
+	b := res.Break
+	if b.Kind != BreakLinkMismatch {
+		t.Errorf("kind: got %q, want %q", b.Kind, BreakLinkMismatch)
+	}
+	if b.Seq != 2 {
+		t.Errorf("seq: got %d, want 2", b.Seq)
+	}
+	if b.PriorSeq == nil || *b.PriorSeq != 1 {
+		t.Errorf("prior_seq: got %v, want 1", b.PriorSeq)
+	}
+	if b.SeqGap != 0 {
+		t.Errorf("seq_gap: got %d, want 0", b.SeqGap)
+	}
+	if b.StoredPrevHash != rows[1].PrevHash {
+		t.Errorf("stored_prev_hash mismatch")
+	}
+}
+
+// TestVerifyChain_MissingEvents removes a middle row so seq jumps from 1 to 3.
+// Expects kind=missing_events, seq_gap=1, prior_seq=1.
+func TestVerifyChain_MissingEvents(t *testing.T) {
+	rows := buildChain(t)
+	// Drop seq 2; remaining rows are seq 1 and seq 3. Seq 3's prev_hash was
+	// built against seq 2's this_hash so it will also fail the link check, but
+	// the gap is detected first.
+	trimmed := []Event{rows[0], rows[2]}
+
+	res := VerifyChain(trimmed)
+	if res.Valid {
+		t.Fatal("expected invalid chain")
+	}
+	if res.Break == nil {
+		t.Fatal("expected non-nil Break")
+	}
+	b := res.Break
+	if b.Kind != BreakMissingEvents {
+		t.Errorf("kind: got %q, want %q", b.Kind, BreakMissingEvents)
+	}
+	if b.Seq != 3 {
+		t.Errorf("seq: got %d, want 3", b.Seq)
+	}
+	if b.PriorSeq == nil || *b.PriorSeq != 1 {
+		t.Errorf("prior_seq: got %v, want 1", b.PriorSeq)
+	}
+	if b.SeqGap != 1 {
+		t.Errorf("seq_gap: got %d, want 1", b.SeqGap)
+	}
+}
+
+// TestVerifyChain_ChainStartMissing sets the first row's prev_hash to something
+// other than GenesisPrevHash. Expects kind=chain_start_missing, prior_seq nil.
+func TestVerifyChain_ChainStartMissing(t *testing.T) {
+	rows := buildChain(t)
+	// The first row's prev_hash should be genesis; override it so it looks like
+	// the oldest events have been deleted and the chain was rebased.
+	rows[0].PrevHash = strings.Repeat("f", 64)
+
+	res := VerifyChain(rows)
+	if res.Valid {
+		t.Fatal("expected invalid chain")
+	}
+	if res.Break == nil {
+		t.Fatal("expected non-nil Break")
+	}
+	b := res.Break
+	if b.Kind != BreakChainStartMissing {
+		t.Errorf("kind: got %q, want %q", b.Kind, BreakChainStartMissing)
+	}
+	if b.Seq != 1 {
+		t.Errorf("seq: got %d, want 1", b.Seq)
+	}
+	if b.PriorSeq != nil {
+		t.Errorf("prior_seq: got %v, want nil (no prior verified row)", b.PriorSeq)
+	}
+	if b.SeqGap != 0 {
+		t.Errorf("seq_gap: got %d, want 0", b.SeqGap)
+	}
+	if b.ExpectedPrevHash != GenesisPrevHash {
+		t.Errorf("expected_prev_hash: got %q, want GenesisPrevHash", b.ExpectedPrevHash)
+	}
+}
+
+// TestVerifyChain_JSONShape is the contract drift guard: marshal an
+// activityVerifyDTO with a fully-populated break and assert every required JSON
+// key is present by name. This catches field renames or omitempty accidentally
+// swallowing zero-value fields before the web layer sees them.
+func TestVerifyChain_JSONShape(t *testing.T) {
+	priorSeq := int64(1)
+	breakSeq := int64(2)
+	dto := activityVerifyDTO{
+		Valid:      false,
+		Total:      3,
+		BreakAtSeq: &breakSeq,
+		Break: &activityVerifyBreakDTO{
+			Seq:                2,
+			Kind:               string(BreakContentModified),
+			PriorSeq:           &priorSeq,
+			SeqGap:             0,
+			ExpectedPrevHash:   strings.Repeat("0", 64),
+			StoredPrevHash:     strings.Repeat("0", 64),
+			RecomputedThisHash: strings.Repeat("a", 64),
+			StoredThisHash:     strings.Repeat("b", 64),
+			Event: activityVerifyBreakEventDTO{
+				Summary:    "Plugin activated",
+				EventType:  "plugin.activated",
+				ActorLogin: "admin",
+				OccurredAt: "2026-05-29T10:00:00Z",
+			},
+		},
+	}
+
+	b, err := json.Marshal(dto)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+
+	// Top-level required keys.
+	for _, key := range []string{"valid", "total", "break_at_seq", "break"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("missing top-level key %q in JSON: %s", key, b)
+		}
+	}
+
+	breakObj, ok := m["break"].(map[string]any)
+	if !ok {
+		t.Fatalf("break is not an object: %s", b)
+	}
+
+	// break sub-object required keys.
+	for _, key := range []string{
+		"seq", "kind", "prior_seq", "seq_gap",
+		"expected_prev_hash", "stored_prev_hash",
+		"recomputed_this_hash", "stored_this_hash", "event",
+	} {
+		if _, ok := breakObj[key]; !ok {
+			t.Errorf("missing break key %q in JSON: %s", key, b)
+		}
+	}
+
+	eventObj, ok := breakObj["event"].(map[string]any)
+	if !ok {
+		t.Fatalf("break.event is not an object: %s", b)
+	}
+
+	// event sub-object required keys.
+	for _, key := range []string{"summary", "event_type", "actor_login", "occurred_at"} {
+		if _, ok := eventObj[key]; !ok {
+			t.Errorf("missing break.event key %q in JSON: %s", key, b)
+		}
+	}
+
+	// kind value must be exact.
+	if got, _ := breakObj["kind"].(string); got != string(BreakContentModified) {
+		t.Errorf("break.kind: got %q, want %q", got, BreakContentModified)
 	}
 }

--- a/apps/api/internal/activity/handler.go
+++ b/apps/api/internal/activity/handler.go
@@ -62,10 +62,30 @@ type activityListDTO struct {
 	NextCursor string             `json:"next_cursor,omitempty"`
 }
 
+type activityVerifyBreakEventDTO struct {
+	Summary    string `json:"summary"`
+	EventType  string `json:"event_type"`
+	ActorLogin string `json:"actor_login"`
+	OccurredAt string `json:"occurred_at"`
+}
+
+type activityVerifyBreakDTO struct {
+	Seq                int64                        `json:"seq"`
+	Kind               string                       `json:"kind"`
+	PriorSeq           *int64                       `json:"prior_seq"`
+	SeqGap             int64                        `json:"seq_gap"`
+	ExpectedPrevHash   string                       `json:"expected_prev_hash"`
+	StoredPrevHash     string                       `json:"stored_prev_hash"`
+	RecomputedThisHash string                       `json:"recomputed_this_hash"`
+	StoredThisHash     string                       `json:"stored_this_hash"`
+	Event              activityVerifyBreakEventDTO  `json:"event"`
+}
+
 type activityVerifyDTO struct {
-	Valid      bool   `json:"valid"`
-	BreakAtSeq *int64 `json:"break_at_seq"`
-	Total      int    `json:"total"`
+	Valid      bool                    `json:"valid"`
+	Total      int                     `json:"total"`
+	BreakAtSeq *int64                  `json:"break_at_seq"`
+	Break      *activityVerifyBreakDTO `json:"break"`
 }
 
 func toEventDTO(e Event) activityEventDTO {
@@ -159,9 +179,29 @@ func (h *Handler) verify(c *gin.Context) {
 		httpx.Error(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, activityVerifyDTO{
+	dto := activityVerifyDTO{
 		Valid:      res.Valid,
-		BreakAtSeq: res.BreakAtSeq,
 		Total:      res.Total,
-	})
+		BreakAtSeq: res.BreakAtSeq,
+	}
+	if res.Break != nil {
+		b := res.Break
+		dto.Break = &activityVerifyBreakDTO{
+			Seq:                b.Seq,
+			Kind:               string(b.Kind),
+			PriorSeq:           b.PriorSeq,
+			SeqGap:             b.SeqGap,
+			ExpectedPrevHash:   b.ExpectedPrevHash,
+			StoredPrevHash:     b.StoredPrevHash,
+			RecomputedThisHash: b.RecomputedThisHash,
+			StoredThisHash:     b.StoredThisHash,
+			Event: activityVerifyBreakEventDTO{
+				Summary:    b.Event.Summary,
+				EventType:  b.Event.EventType,
+				ActorLogin: b.Event.ActorLogin,
+				OccurredAt: b.Event.OccurredAt,
+			},
+		}
+	}
+	c.JSON(http.StatusOK, dto)
 }

--- a/apps/api/internal/activity/model.go
+++ b/apps/api/internal/activity/model.go
@@ -111,11 +111,69 @@ type ListFilter struct {
 	Cursor int64
 }
 
+// ChainBreakKind classifies the first broken link found by VerifyChain.
+type ChainBreakKind string
+
+const (
+	// BreakChainStartMissing means the very first stored event does not chain
+	// from genesis — the oldest events are gone or the chain was reset.
+	BreakChainStartMissing ChainBreakKind = "chain_start_missing"
+	// BreakMissingEvents means one or more seq numbers are absent between the
+	// last good row and the failing row (gap ≥ 1) — usually log cleanup /
+	// retention or direct deletion. Not by itself proof of tampering.
+	BreakMissingEvents ChainBreakKind = "missing_events"
+	// BreakLinkMismatch means the rows are contiguous but this row's
+	// prev_hash does not equal the prior row's this_hash — an event was
+	// inserted, removed, or reordered, or the prior event was altered.
+	BreakLinkMismatch ChainBreakKind = "link_mismatch"
+	// BreakContentModified means the prev link is intact but the recomputed
+	// this_hash no longer matches the stored this_hash — this event's content
+	// was edited after recording, or there is a hashing disagreement.
+	BreakContentModified ChainBreakKind = "content_modified"
+)
+
+// ChainBreakEvent is the offending event sub-struct carried in ChainBreak for
+// operator context. The web layer truncates hashes for display; the CP sends
+// the full 64-char hex.
+type ChainBreakEvent struct {
+	Summary    string `json:"summary"`
+	EventType  string `json:"event_type"`
+	ActorLogin string `json:"actor_login"`
+	OccurredAt string `json:"occurred_at"` // RFC3339
+}
+
+// ChainBreak describes the first broken link in a chain re-verification. It is
+// nil when the chain is intact.
+type ChainBreak struct {
+	// Seq is the seq of the event where verification failed.
+	Seq int64 `json:"seq"`
+	// Kind classifies the break (see BreakChainStartMissing etc.).
+	Kind ChainBreakKind `json:"kind"`
+	// PriorSeq is the seq of the last successfully-verified row, or nil when
+	// the break is at the first/genesis row (no prior was verified).
+	PriorSeq *int64 `json:"prior_seq"`
+	// SeqGap is the number of missing sequence numbers between PriorSeq and
+	// Seq. 0 when contiguous or when there is no prior row.
+	SeqGap int64 `json:"seq_gap"`
+	// ExpectedPrevHash is the verified chain head before this row (prior
+	// row's this_hash, or GenesisPrevHash if this is the first row).
+	ExpectedPrevHash string `json:"expected_prev_hash"`
+	// StoredPrevHash is the row's own prev_hash as stored.
+	StoredPrevHash string `json:"stored_prev_hash"`
+	// RecomputedThisHash is ComputeHashFromStored(ExpectedPrevHash, row).
+	RecomputedThisHash string `json:"recomputed_this_hash"`
+	// StoredThisHash is the row's own this_hash as stored.
+	StoredThisHash string `json:"stored_this_hash"`
+	// Event carries the offending event fields for operator context.
+	Event ChainBreakEvent `json:"event"`
+}
+
 // VerifyResult is the outcome of a full server-side chain re-verification.
 type VerifyResult struct {
-	Valid      bool   `json:"valid"`
-	BreakAtSeq *int64 `json:"break_at_seq"`
-	Total      int    `json:"total"`
+	Valid      bool        `json:"valid"`
+	BreakAtSeq *int64      `json:"break_at_seq"`
+	Total      int         `json:"total"`
+	Break      *ChainBreak `json:"break"`
 }
 
 // occurredAtCanonical formats the occurred_at exactly as the agent does in the
@@ -202,21 +260,72 @@ func ComputeHashFromStored(prevHash string, e Event) string {
 
 // VerifyChain folds a seq-ASC ordered slice of stored events from genesis,
 // recomputing each this_hash against the prior link, and reports the first
-// broken link. A row is a break when its prev_hash != the prior hash OR its
-// recomputed hash != its stored this_hash. This is the pure core of
-// Service.Verify (DB-free, so it is directly unit-testable).
+// broken link with a classified ChainBreak. A row is a break when its
+// prev_hash != the prior hash OR its recomputed hash != its stored this_hash.
+// This is the pure core of Service.Verify (DB-free, so it is directly
+// unit-testable).
 func VerifyChain(rows []Event) VerifyResult {
 	res := VerifyResult{Valid: true, Total: len(rows)}
 	prev := GenesisPrevHash
+	var priorSeq *int64 // nil until at least one row has been verified OK
 	for _, row := range rows {
 		recomputed := ComputeHashFromStored(prev, row)
-		if row.PrevHash != prev || recomputed != row.ThisHash {
+		linkOK := row.PrevHash == prev
+		hashOK := recomputed == row.ThisHash
+		if !linkOK || !hashOK {
 			seq := row.Seq
 			res.Valid = false
 			res.BreakAtSeq = &seq
+
+			// Compute seq gap: how many sequence numbers are missing between
+			// the last good row and this row.
+			var seqGap int64
+			if priorSeq != nil {
+				gap := row.Seq - *priorSeq - 1
+				if gap > 0 {
+					seqGap = gap
+				}
+			}
+
+			// Classify the break kind.
+			var kind ChainBreakKind
+			switch {
+			case priorSeq == nil && row.PrevHash != GenesisPrevHash:
+				// First row doesn't anchor to genesis — the chain root is gone.
+				kind = BreakChainStartMissing
+			case seqGap > 0:
+				// Gap in seq numbers — rows have been removed.
+				kind = BreakMissingEvents
+			case !linkOK:
+				// Contiguous seq but prev_hash is broken — insertion/removal/reorder.
+				kind = BreakLinkMismatch
+			default:
+				// prev link is intact but content hash diverges — content was edited.
+				kind = BreakContentModified
+			}
+
+			res.Break = &ChainBreak{
+				Seq:                seq,
+				Kind:               kind,
+				PriorSeq:           priorSeq,
+				SeqGap:             seqGap,
+				ExpectedPrevHash:   prev,
+				StoredPrevHash:     row.PrevHash,
+				RecomputedThisHash: recomputed,
+				StoredThisHash:     row.ThisHash,
+				Event: ChainBreakEvent{
+					Summary:    row.Summary,
+					EventType:  row.EventType,
+					ActorLogin: row.ActorLogin,
+					OccurredAt: row.OccurredAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+				},
+			}
 			return res
 		}
+		// Row verified OK — advance the chain head and record the last good seq.
 		prev = row.ThisHash
+		s := row.Seq
+		priorSeq = &s
 	}
 	return res
 }

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -677,12 +677,19 @@ func (s *ActivityVerifyResult) encodeFields(e *jx.Encoder) {
 		e.FieldStart("total")
 		e.Int(s.Total)
 	}
+	{
+		if s.Break.Set {
+			e.FieldStart("break")
+			s.Break.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfActivityVerifyResult = [3]string{
+var jsonFieldsNameOfActivityVerifyResult = [4]string{
 	0: "valid",
 	1: "break_at_seq",
 	2: "total",
+	3: "break",
 }
 
 // Decode decodes ActivityVerifyResult from json.
@@ -727,6 +734,16 @@ func (s *ActivityVerifyResult) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"total\"")
+			}
+		case "break":
+			if err := func() error {
+				s.Break.Reset()
+				if err := s.Break.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"break\"")
 			}
 		default:
 			return d.Skip()
@@ -11705,6 +11722,426 @@ func (s *CdnCredentials) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *CdnCredentials) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *ChainBreak) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *ChainBreak) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("seq")
+		e.Int64(s.Seq)
+	}
+	{
+		e.FieldStart("kind")
+		s.Kind.Encode(e)
+	}
+	{
+		if s.PriorSeq.Set {
+			e.FieldStart("prior_seq")
+			s.PriorSeq.Encode(e)
+		}
+	}
+	{
+		e.FieldStart("seq_gap")
+		e.Int64(s.SeqGap)
+	}
+	{
+		e.FieldStart("expected_prev_hash")
+		e.Str(s.ExpectedPrevHash)
+	}
+	{
+		e.FieldStart("stored_prev_hash")
+		e.Str(s.StoredPrevHash)
+	}
+	{
+		e.FieldStart("recomputed_this_hash")
+		e.Str(s.RecomputedThisHash)
+	}
+	{
+		e.FieldStart("stored_this_hash")
+		e.Str(s.StoredThisHash)
+	}
+	{
+		e.FieldStart("event")
+		s.Event.Encode(e)
+	}
+}
+
+var jsonFieldsNameOfChainBreak = [9]string{
+	0: "seq",
+	1: "kind",
+	2: "prior_seq",
+	3: "seq_gap",
+	4: "expected_prev_hash",
+	5: "stored_prev_hash",
+	6: "recomputed_this_hash",
+	7: "stored_this_hash",
+	8: "event",
+}
+
+// Decode decodes ChainBreak from json.
+func (s *ChainBreak) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ChainBreak to nil")
+	}
+	var requiredBitSet [2]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "seq":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Int64()
+				s.Seq = int64(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"seq\"")
+			}
+		case "kind":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				if err := s.Kind.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"kind\"")
+			}
+		case "prior_seq":
+			if err := func() error {
+				s.PriorSeq.Reset()
+				if err := s.PriorSeq.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"prior_seq\"")
+			}
+		case "seq_gap":
+			requiredBitSet[0] |= 1 << 3
+			if err := func() error {
+				v, err := d.Int64()
+				s.SeqGap = int64(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"seq_gap\"")
+			}
+		case "expected_prev_hash":
+			requiredBitSet[0] |= 1 << 4
+			if err := func() error {
+				v, err := d.Str()
+				s.ExpectedPrevHash = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"expected_prev_hash\"")
+			}
+		case "stored_prev_hash":
+			requiredBitSet[0] |= 1 << 5
+			if err := func() error {
+				v, err := d.Str()
+				s.StoredPrevHash = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"stored_prev_hash\"")
+			}
+		case "recomputed_this_hash":
+			requiredBitSet[0] |= 1 << 6
+			if err := func() error {
+				v, err := d.Str()
+				s.RecomputedThisHash = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"recomputed_this_hash\"")
+			}
+		case "stored_this_hash":
+			requiredBitSet[0] |= 1 << 7
+			if err := func() error {
+				v, err := d.Str()
+				s.StoredThisHash = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"stored_this_hash\"")
+			}
+		case "event":
+			requiredBitSet[1] |= 1 << 0
+			if err := func() error {
+				if err := s.Event.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode ChainBreak")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [2]uint8{
+		0b11111011,
+		0b00000001,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfChainBreak) {
+					name = jsonFieldsNameOfChainBreak[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *ChainBreak) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ChainBreak) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *ChainBreakEvent) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *ChainBreakEvent) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("summary")
+		e.Str(s.Summary)
+	}
+	{
+		e.FieldStart("event_type")
+		e.Str(s.EventType)
+	}
+	{
+		e.FieldStart("actor_login")
+		e.Str(s.ActorLogin)
+	}
+	{
+		e.FieldStart("occurred_at")
+		json.EncodeDateTime(e, s.OccurredAt)
+	}
+}
+
+var jsonFieldsNameOfChainBreakEvent = [4]string{
+	0: "summary",
+	1: "event_type",
+	2: "actor_login",
+	3: "occurred_at",
+}
+
+// Decode decodes ChainBreakEvent from json.
+func (s *ChainBreakEvent) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ChainBreakEvent to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "summary":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.Summary = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"summary\"")
+			}
+		case "event_type":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.EventType = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "actor_login":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.ActorLogin = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"actor_login\"")
+			}
+		case "occurred_at":
+			requiredBitSet[0] |= 1 << 3
+			if err := func() error {
+				v, err := json.DecodeDateTime(d)
+				s.OccurredAt = v
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"occurred_at\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode ChainBreakEvent")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00001111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfChainBreakEvent) {
+					name = jsonFieldsNameOfChainBreakEvent[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *ChainBreakEvent) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ChainBreakEvent) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ChainBreakKind as json.
+func (s ChainBreakKind) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ChainBreakKind from json.
+func (s *ChainBreakKind) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ChainBreakKind to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ChainBreakKind(v) {
+	case ChainBreakKindMissingEvents:
+		*s = ChainBreakKindMissingEvents
+	case ChainBreakKindLinkMismatch:
+		*s = ChainBreakKindLinkMismatch
+	case ChainBreakKindContentModified:
+		*s = ChainBreakKindContentModified
+	case ChainBreakKindChainStartMissing:
+		*s = ChainBreakKindChainStartMissing
+	default:
+		*s = ChainBreakKind(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ChainBreakKind) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ChainBreakKind) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -38953,6 +39390,55 @@ func (s OptNilBool) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptNilBool) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ChainBreak as json.
+func (o OptNilChainBreak) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	if o.Null {
+		e.Null()
+		return
+	}
+	o.Value.Encode(e)
+}
+
+// Decode decodes ChainBreak from json.
+func (o *OptNilChainBreak) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptNilChainBreak to nil")
+	}
+	if d.Next() == jx.Null {
+		if err := d.Null(); err != nil {
+			return err
+		}
+
+		var v ChainBreak
+		o.Value = v
+		o.Set = true
+		o.Null = true
+		return nil
+	}
+	o.Set = true
+	o.Null = false
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptNilChainBreak) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptNilChainBreak) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/apps/api/internal/api/gen/oas_response_decoders_gen.go
+++ b/apps/api/internal/api/gen/oas_response_decoders_gen.go
@@ -21351,6 +21351,15 @@ func decodeVerifySiteActivityResponse(resp *http.Response) (res *ActivityVerifyR
 				}
 				return res, err
 			}
+			// Validate response.
+			if err := func() error {
+				if err := response.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
 			return &response, nil
 		default:
 			return res, validate.InvalidContentType(ct)

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -198,9 +198,13 @@ type ActivityVerifyResult struct {
 	// True when the entire chain re-verifies intact.
 	Valid bool `json:"valid"`
 	// The seq of the first broken link, or null when the chain is intact.
+	// Kept for backward compatibility; equals break.seq when broken.
 	BreakAtSeq OptNilInt64 `json:"break_at_seq"`
 	// Total number of events folded during verification.
 	Total int `json:"total"`
+	// Null when the chain is intact. Describes the first broken link with
+	// enough detail for an operator to understand and act on the failure.
+	Break OptNilChainBreak `json:"break"`
 }
 
 // GetValid returns the value of Valid.
@@ -218,6 +222,11 @@ func (s *ActivityVerifyResult) GetTotal() int {
 	return s.Total
 }
 
+// GetBreak returns the value of Break.
+func (s *ActivityVerifyResult) GetBreak() OptNilChainBreak {
+	return s.Break
+}
+
 // SetValid sets the value of Valid.
 func (s *ActivityVerifyResult) SetValid(val bool) {
 	s.Valid = val
@@ -231,6 +240,11 @@ func (s *ActivityVerifyResult) SetBreakAtSeq(val OptNilInt64) {
 // SetTotal sets the value of Total.
 func (s *ActivityVerifyResult) SetTotal(val int) {
 	s.Total = val
+}
+
+// SetBreak sets the value of Break.
+func (s *ActivityVerifyResult) SetBreak(val OptNilChainBreak) {
+	s.Break = val
 }
 
 type AddClientMemberConflict Error
@@ -4193,6 +4207,235 @@ func (s *CdnCredentials) SetZoneID(val OptString) {
 // SetZone sets the value of Zone.
 func (s *CdnCredentials) SetZone(val OptString) {
 	s.Zone = val
+}
+
+// Ref: #/components/schemas/ChainBreak
+type ChainBreak struct {
+	// The seq of the event where verification failed.
+	Seq int64 `json:"seq"`
+	// Classifies the break:
+	// - missing_events: one or more seq numbers are absent (log cleanup / retention / deletion).
+	// - link_mismatch: contiguous seq but prev_hash broken (insertion/removal/reorder/prior alteration).
+	// - content_modified: prev link intact but recomputed hash diverges (content edited after recording).
+	// - chain_start_missing: first stored event does not chain from genesis (oldest events gone / chain
+	// reset).
+	Kind ChainBreakKind `json:"kind"`
+	// The seq of the last successfully-verified row. Null when the break is
+	// at the first/genesis row and no prior row was verified.
+	PriorSeq OptNilInt64 `json:"prior_seq"`
+	// Number of missing sequence numbers between prior_seq and seq.
+	// 0 when contiguous or when there is no prior row.
+	SeqGap int64 `json:"seq_gap"`
+	// The verified chain head before this row: the prior row's this_hash,
+	// or GenesisPrevHash (64 zero hex chars) if this is the first row.
+	ExpectedPrevHash string `json:"expected_prev_hash"`
+	// The row's own prev_hash as stored.
+	StoredPrevHash string `json:"stored_prev_hash"`
+	// ComputeHashFromStored(expected_prev_hash, row).
+	RecomputedThisHash string `json:"recomputed_this_hash"`
+	// The row's own this_hash as stored.
+	StoredThisHash string `json:"stored_this_hash"`
+	// The offending event fields for operator context.
+	Event ChainBreakEvent `json:"event"`
+}
+
+// GetSeq returns the value of Seq.
+func (s *ChainBreak) GetSeq() int64 {
+	return s.Seq
+}
+
+// GetKind returns the value of Kind.
+func (s *ChainBreak) GetKind() ChainBreakKind {
+	return s.Kind
+}
+
+// GetPriorSeq returns the value of PriorSeq.
+func (s *ChainBreak) GetPriorSeq() OptNilInt64 {
+	return s.PriorSeq
+}
+
+// GetSeqGap returns the value of SeqGap.
+func (s *ChainBreak) GetSeqGap() int64 {
+	return s.SeqGap
+}
+
+// GetExpectedPrevHash returns the value of ExpectedPrevHash.
+func (s *ChainBreak) GetExpectedPrevHash() string {
+	return s.ExpectedPrevHash
+}
+
+// GetStoredPrevHash returns the value of StoredPrevHash.
+func (s *ChainBreak) GetStoredPrevHash() string {
+	return s.StoredPrevHash
+}
+
+// GetRecomputedThisHash returns the value of RecomputedThisHash.
+func (s *ChainBreak) GetRecomputedThisHash() string {
+	return s.RecomputedThisHash
+}
+
+// GetStoredThisHash returns the value of StoredThisHash.
+func (s *ChainBreak) GetStoredThisHash() string {
+	return s.StoredThisHash
+}
+
+// GetEvent returns the value of Event.
+func (s *ChainBreak) GetEvent() ChainBreakEvent {
+	return s.Event
+}
+
+// SetSeq sets the value of Seq.
+func (s *ChainBreak) SetSeq(val int64) {
+	s.Seq = val
+}
+
+// SetKind sets the value of Kind.
+func (s *ChainBreak) SetKind(val ChainBreakKind) {
+	s.Kind = val
+}
+
+// SetPriorSeq sets the value of PriorSeq.
+func (s *ChainBreak) SetPriorSeq(val OptNilInt64) {
+	s.PriorSeq = val
+}
+
+// SetSeqGap sets the value of SeqGap.
+func (s *ChainBreak) SetSeqGap(val int64) {
+	s.SeqGap = val
+}
+
+// SetExpectedPrevHash sets the value of ExpectedPrevHash.
+func (s *ChainBreak) SetExpectedPrevHash(val string) {
+	s.ExpectedPrevHash = val
+}
+
+// SetStoredPrevHash sets the value of StoredPrevHash.
+func (s *ChainBreak) SetStoredPrevHash(val string) {
+	s.StoredPrevHash = val
+}
+
+// SetRecomputedThisHash sets the value of RecomputedThisHash.
+func (s *ChainBreak) SetRecomputedThisHash(val string) {
+	s.RecomputedThisHash = val
+}
+
+// SetStoredThisHash sets the value of StoredThisHash.
+func (s *ChainBreak) SetStoredThisHash(val string) {
+	s.StoredThisHash = val
+}
+
+// SetEvent sets the value of Event.
+func (s *ChainBreak) SetEvent(val ChainBreakEvent) {
+	s.Event = val
+}
+
+// The offending event fields for operator context.
+type ChainBreakEvent struct {
+	Summary    string    `json:"summary"`
+	EventType  string    `json:"event_type"`
+	ActorLogin string    `json:"actor_login"`
+	OccurredAt time.Time `json:"occurred_at"`
+}
+
+// GetSummary returns the value of Summary.
+func (s *ChainBreakEvent) GetSummary() string {
+	return s.Summary
+}
+
+// GetEventType returns the value of EventType.
+func (s *ChainBreakEvent) GetEventType() string {
+	return s.EventType
+}
+
+// GetActorLogin returns the value of ActorLogin.
+func (s *ChainBreakEvent) GetActorLogin() string {
+	return s.ActorLogin
+}
+
+// GetOccurredAt returns the value of OccurredAt.
+func (s *ChainBreakEvent) GetOccurredAt() time.Time {
+	return s.OccurredAt
+}
+
+// SetSummary sets the value of Summary.
+func (s *ChainBreakEvent) SetSummary(val string) {
+	s.Summary = val
+}
+
+// SetEventType sets the value of EventType.
+func (s *ChainBreakEvent) SetEventType(val string) {
+	s.EventType = val
+}
+
+// SetActorLogin sets the value of ActorLogin.
+func (s *ChainBreakEvent) SetActorLogin(val string) {
+	s.ActorLogin = val
+}
+
+// SetOccurredAt sets the value of OccurredAt.
+func (s *ChainBreakEvent) SetOccurredAt(val time.Time) {
+	s.OccurredAt = val
+}
+
+// Classifies the break:
+// - missing_events: one or more seq numbers are absent (log cleanup / retention / deletion).
+// - link_mismatch: contiguous seq but prev_hash broken (insertion/removal/reorder/prior alteration).
+// - content_modified: prev link intact but recomputed hash diverges (content edited after recording).
+// - chain_start_missing: first stored event does not chain from genesis (oldest events gone / chain
+// reset).
+type ChainBreakKind string
+
+const (
+	ChainBreakKindMissingEvents     ChainBreakKind = "missing_events"
+	ChainBreakKindLinkMismatch      ChainBreakKind = "link_mismatch"
+	ChainBreakKindContentModified   ChainBreakKind = "content_modified"
+	ChainBreakKindChainStartMissing ChainBreakKind = "chain_start_missing"
+)
+
+// AllValues returns all ChainBreakKind values.
+func (ChainBreakKind) AllValues() []ChainBreakKind {
+	return []ChainBreakKind{
+		ChainBreakKindMissingEvents,
+		ChainBreakKindLinkMismatch,
+		ChainBreakKindContentModified,
+		ChainBreakKindChainStartMissing,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ChainBreakKind) MarshalText() ([]byte, error) {
+	switch s {
+	case ChainBreakKindMissingEvents:
+		return []byte(s), nil
+	case ChainBreakKindLinkMismatch:
+		return []byte(s), nil
+	case ChainBreakKindContentModified:
+		return []byte(s), nil
+	case ChainBreakKindChainStartMissing:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ChainBreakKind) UnmarshalText(data []byte) error {
+	switch ChainBreakKind(data) {
+	case ChainBreakKindMissingEvents:
+		*s = ChainBreakKindMissingEvents
+		return nil
+	case ChainBreakKindLinkMismatch:
+		*s = ChainBreakKindLinkMismatch
+		return nil
+	case ChainBreakKindContentModified:
+		*s = ChainBreakKindContentModified
+		return nil
+	case ChainBreakKindChainStartMissing:
+		*s = ChainBreakKindChainStartMissing
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
 }
 
 // Ref: #/components/schemas/ClientInvitation
@@ -17389,6 +17632,69 @@ func (o OptNilBool) Get() (v bool, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptNilBool) Or(d bool) bool {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptNilChainBreak returns new OptNilChainBreak with value set to v.
+func NewOptNilChainBreak(v ChainBreak) OptNilChainBreak {
+	return OptNilChainBreak{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptNilChainBreak is optional nullable ChainBreak.
+type OptNilChainBreak struct {
+	Value ChainBreak
+	Set   bool
+	Null  bool
+}
+
+// IsSet returns true if OptNilChainBreak was set.
+func (o OptNilChainBreak) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptNilChainBreak) Reset() {
+	var v ChainBreak
+	o.Value = v
+	o.Set = false
+	o.Null = false
+}
+
+// SetTo sets value to v.
+func (o *OptNilChainBreak) SetTo(v ChainBreak) {
+	o.Set = true
+	o.Null = false
+	o.Value = v
+}
+
+// IsNull returns true if value is Null.
+func (o OptNilChainBreak) IsNull() bool { return o.Null }
+
+// SetToNull sets value to null.
+func (o *OptNilChainBreak) SetToNull() {
+	o.Set = true
+	o.Null = true
+	var v ChainBreak
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptNilChainBreak) Get() (v ChainBreak, ok bool) {
+	if o.Null {
+		return v, false
+	}
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptNilChainBreak) Or(d ChainBreak) ChainBreak {
 	if v, ok := o.Get(); ok {
 		return v
 	}

--- a/apps/api/internal/api/gen/oas_validators_gen.go
+++ b/apps/api/internal/api/gen/oas_validators_gen.go
@@ -138,6 +138,36 @@ func (s AcceptInvitationResponseScope) Validate() error {
 	}
 }
 
+func (s *ActivityVerifyResult) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if value, ok := s.Break.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "break",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *AddSuppressionRequest) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -2056,6 +2086,44 @@ func (s *BulkResendResponse) Validate() error {
 		return &validate.Error{Fields: failures}
 	}
 	return nil
+}
+
+func (s *ChainBreak) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Kind.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "kind",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s ChainBreakKind) Validate() error {
+	switch s {
+	case "missing_events":
+		return nil
+	case "link_mismatch":
+		return nil
+	case "content_modified":
+		return nil
+	case "chain_start_missing":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
 }
 
 func (s *ClientInvitation) Validate() error {

--- a/apps/web/src/features/activity/activity-integrity-report.tsx
+++ b/apps/web/src/features/activity/activity-integrity-report.tsx
@@ -1,0 +1,377 @@
+import { useState } from "react";
+import { ShieldAlert, Copy, Check, ChevronDown } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn, relativeTime } from "@/lib/utils";
+import { useQueryClient } from "@tanstack/react-query";
+import type { ChainBreak } from "@wpmgr/api";
+
+import { activityKeys } from "./use-activity";
+
+// Activity log integrity report dialog (ADR-037 Sprint 6).
+//
+// Opens when an operator clicks the "Chain break at seq N" badge in the
+// activity toolbar. Explains the break kind in plain language, shows the
+// offending event, and surfaces the raw hash values in a collapsible technical
+// detail block. Tone is factual: a break is most often pruned entries, not
+// tampering. No em dashes, no alarm language.
+
+export interface ActivityIntegrityReportProps {
+  open: boolean;
+  onClose: () => void;
+  siteId: string;
+  breakData: ChainBreak;
+  total: number;
+}
+
+export function ActivityIntegrityReport({
+  open,
+  onClose,
+  siteId,
+  breakData,
+  total,
+}: ActivityIntegrityReportProps) {
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [copied, setCopied] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  const copy = (label: string, value: string) => {
+    void navigator.clipboard.writeText(value).then(() => {
+      setCopied(label);
+      window.setTimeout(() => setCopied(null), 1500);
+    });
+  };
+
+  const recheck = () => {
+    void queryClient.invalidateQueries({
+      queryKey: activityKeys.verify(siteId),
+    });
+  };
+
+  const actor =
+    breakData.event.actor_login.length > 0
+      ? breakData.event.actor_login
+      : "system";
+  const rel = relativeTime(breakData.event.occurred_at) ?? "unknown time";
+
+  const prevHashDiffers =
+    breakData.expected_prev_hash !== breakData.stored_prev_hash;
+  const thisHashDiffers =
+    breakData.recomputed_this_hash !== breakData.stored_this_hash;
+
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogContent
+        ariaLabelledBy="integrity-report-title"
+        className="max-w-[600px]"
+      >
+        <DialogHeader>
+          <DialogTitle id="integrity-report-title">
+            Activity log integrity
+          </DialogTitle>
+        </DialogHeader>
+
+        <DialogBody className="space-y-5">
+          {/* Headline status */}
+          <div className="space-y-1">
+            <div className="inline-flex items-center gap-1.5 rounded bg-destructive-subtle px-2.5 py-1 text-sm font-medium text-destructive-subtle-fg">
+              <ShieldAlert aria-hidden="true" className="size-4 shrink-0" />
+              Verification failed at event #{breakData.seq}
+            </div>
+            <p className="text-xs text-muted-foreground tabular-nums">
+              {total} event{total !== 1 ? "s" : ""} checked
+            </p>
+          </div>
+
+          {/* Plain-language cause */}
+          <CauseBlock breakData={breakData} />
+
+          {/* Offending event */}
+          <div className="space-y-2">
+            <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Offending event
+            </h3>
+            <div className="rounded-lg border border-border px-4 py-3 space-y-2">
+              <p className="text-sm text-foreground">{breakData.event.summary}</p>
+              <div className="flex flex-wrap items-center gap-2 text-xs">
+                <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-muted-foreground">
+                  {breakData.event.event_type}
+                </span>
+                <span className="text-muted-foreground">
+                  Actor: <span className="font-medium text-foreground">{actor}</span>
+                </span>
+                <span
+                  className="text-muted-foreground tabular-nums"
+                  title={breakData.event.occurred_at}
+                >
+                  {rel}
+                  <span aria-hidden="true"> &middot; </span>
+                  <span className="font-mono">{breakData.event.occurred_at}</span>
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Technical detail — collapsible */}
+          <details
+            open={detailOpen}
+            onToggle={(e) => setDetailOpen(e.currentTarget.open)}
+            className="group"
+          >
+            <summary
+              className={cn(
+                "flex cursor-pointer select-none list-none items-center gap-1.5 text-xs font-medium text-muted-foreground",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded",
+                "hover:text-foreground transition-colors",
+              )}
+            >
+              <ChevronDown
+                aria-hidden="true"
+                className={cn(
+                  "size-3.5 transition-transform",
+                  detailOpen && "rotate-180",
+                )}
+              />
+              Technical detail
+            </summary>
+
+            <div className="mt-3 space-y-3">
+              {breakData.seq_gap > 0 ? (
+                <TechRow
+                  label="Sequence gap"
+                  value={String(breakData.seq_gap)}
+                  mono
+                />
+              ) : null}
+
+              {prevHashDiffers ? (
+                <>
+                  <HashTechRow
+                    label="Expected prev hash"
+                    value={breakData.expected_prev_hash}
+                    copied={copied === "expected_prev"}
+                    onCopy={() => copy("expected_prev", breakData.expected_prev_hash)}
+                  />
+                  <HashTechRow
+                    label="Stored prev hash"
+                    value={breakData.stored_prev_hash}
+                    copied={copied === "stored_prev"}
+                    onCopy={() => copy("stored_prev", breakData.stored_prev_hash)}
+                  />
+                </>
+              ) : null}
+
+              {thisHashDiffers || breakData.kind === "content_modified" ? (
+                <>
+                  <HashTechRow
+                    label="Recomputed hash"
+                    value={breakData.recomputed_this_hash}
+                    copied={copied === "recomputed_this"}
+                    onCopy={() =>
+                      copy("recomputed_this", breakData.recomputed_this_hash)
+                    }
+                  />
+                  <HashTechRow
+                    label="Stored hash"
+                    value={breakData.stored_this_hash}
+                    copied={copied === "stored_this"}
+                    onCopy={() => copy("stored_this", breakData.stored_this_hash)}
+                  />
+                </>
+              ) : null}
+            </div>
+          </details>
+        </DialogBody>
+
+        <DialogFooter className="mt-2">
+          <Button type="button" variant="ghost" onClick={recheck}>
+            Re-check
+          </Button>
+          <Button type="button" onClick={onClose}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Cause block — plain-language explanation keyed on break kind
+// ---------------------------------------------------------------------------
+
+function CauseBlock({ breakData }: { breakData: ChainBreak }) {
+  const { kind, seq, prior_seq, seq_gap } = breakData;
+
+  switch (kind) {
+    case "missing_events":
+      return (
+        <CauseSection
+          cause={
+            <>
+              <span className="tabular-nums">{seq_gap}</span> event
+              {seq_gap !== 1 ? "s" : ""} between #
+              <span className="tabular-nums">{prior_seq ?? "?"}</span> and #
+              <span className="tabular-nums">{seq}</span> are missing from this
+              site&apos;s log. The most common cause is routine log cleanup or
+              retention removing older entries, or a row deleted directly in the
+              database. On its own this is not proof of tampering.
+            </>
+          }
+          whatToDo="Confirm whether anyone cleared the log or pruned the activity table. If not, treat the gap as suspicious and review access to the site's database."
+        />
+      );
+
+    case "link_mismatch":
+      return (
+        <CauseSection
+          cause={
+            <>
+              Event #<span className="tabular-nums">{seq}</span> does not link
+              to event #{" "}
+              <span className="tabular-nums">{prior_seq ?? "?"}</span> the way
+              it should. An event may have been inserted, removed, or reordered,
+              or event #{" "}
+              <span className="tabular-nums">{prior_seq ?? "?"}</span> was
+              changed after it was recorded.
+            </>
+          }
+          whatToDo={`Review events around #${prior_seq ?? "?"} and #${seq} and check who had database or admin access at that time.`}
+        />
+      );
+
+    case "content_modified":
+      return (
+        <CauseSection
+          cause={
+            <>
+              Event #<span className="tabular-nums">{seq}</span>&apos;s stored
+              content no longer matches its signature. The entry was changed
+              after it was recorded, or, less often, the agent and control plane
+              disagree on how to hash it. This is the pattern most consistent
+              with tampering.
+            </>
+          }
+          whatToDo={`Review event #${seq} below and the actor and IP on nearby events. If this site was recently updated, a one-off agent or control-plane version mismatch can also cause this.`}
+        />
+      );
+
+    case "chain_start_missing":
+      return (
+        <CauseSection
+          cause="The start of the log is no longer present, so verification cannot begin from a trusted starting point. This usually means the oldest entries were removed by retention, or the agent reset its log."
+          whatToDo="If you did not reset the agent, confirm no one cleared the activity table."
+        />
+      );
+
+    default:
+      return null;
+  }
+}
+
+function CauseSection({
+  cause,
+  whatToDo,
+}: {
+  cause: React.ReactNode;
+  whatToDo: string;
+}) {
+  return (
+    <div className="space-y-2">
+      <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        What happened
+      </h3>
+      <p className="text-sm text-foreground leading-relaxed">{cause}</p>
+      <div className="space-y-1">
+        <p className="text-xs font-medium text-muted-foreground">What to do</p>
+        <p className="text-sm text-foreground leading-relaxed">{whatToDo}</p>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tech detail rows
+// ---------------------------------------------------------------------------
+
+function TechRow({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="grid grid-cols-[160px_1fr] gap-3 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span
+        className={cn(
+          "min-w-0 break-words text-foreground",
+          mono && "font-mono tabular-nums",
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function truncateHash(hash: string): string {
+  if (hash.length <= 24) return hash;
+  return `${hash.slice(0, 16)}...${hash.slice(-8)}`;
+}
+
+function HashTechRow({
+  label,
+  value,
+  copied,
+  onCopy,
+}: {
+  label: string;
+  value: string;
+  copied: boolean;
+  onCopy: () => void;
+}) {
+  return (
+    <div className="grid grid-cols-[160px_1fr] items-start gap-3 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <div className="flex items-start gap-2">
+        <code
+          className="min-w-0 flex-1 rounded bg-muted/50 px-2 py-1 font-mono text-xs text-foreground"
+          title={value}
+        >
+          {truncateHash(value)}
+        </code>
+        <Button
+          size="sm"
+          variant="ghost"
+          type="button"
+          onClick={onCopy}
+          aria-label={`Copy ${label}`}
+        >
+          {copied ? (
+            <>
+              <Check aria-hidden="true" className="size-3.5" />
+              Copied
+            </>
+          ) : (
+            <>
+              <Copy aria-hidden="true" className="size-3.5" />
+              Copy
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/activity/activity-table.tsx
+++ b/apps/web/src/features/activity/activity-table.tsx
@@ -8,10 +8,11 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { PageError } from "@/components/feedback";
 import { cn } from "@/lib/utils";
 import { fadeUp } from "@/lib/motion-presets";
-import type { SiteActivityEvent } from "@wpmgr/api";
+import type { SiteActivityEvent, ChainBreak } from "@wpmgr/api";
 
 import { ActivityRow } from "./activity-row";
 import { ActivityDetailDrawer } from "./activity-detail-drawer";
+import { ActivityIntegrityReport } from "./activity-integrity-report";
 import {
   useActivity,
   useActivityVerify,
@@ -44,6 +45,7 @@ export function ActivityTable({ siteId }: { siteId: string }) {
   const [objectType, setObjectType] = useState("");
   const [actorLogin, setActorLogin] = useState("");
   const [active, setActive] = useState<SiteActivityEvent | null>(null);
+  const [reportOpen, setReportOpen] = useState(false);
 
   const filters: ActivityFilters = { severity, objectType, actorLogin };
   const {
@@ -99,6 +101,8 @@ export function ActivityTable({ siteId }: { siteId: string }) {
             valid={verify.data?.valid ?? true}
             breakAtSeq={verify.data?.break_at_seq ?? null}
             pending={verify.isPending}
+            chainBreak={verify.data?.break ?? null}
+            onOpenReport={() => setReportOpen(true)}
           />
           <Button
             type="button"
@@ -218,6 +222,16 @@ export function ActivityTable({ siteId }: { siteId: string }) {
       )}
 
       <ActivityDetailDrawer event={active} onClose={() => setActive(null)} />
+
+      {reportOpen && verify.data?.break ? (
+        <ActivityIntegrityReport
+          open={reportOpen}
+          onClose={() => setReportOpen(false)}
+          siteId={siteId}
+          breakData={verify.data.break}
+          total={verify.data.total}
+        />
+      ) : null}
     </section>
   );
 }
@@ -376,10 +390,14 @@ function IntegrityBadge({
   valid,
   breakAtSeq,
   pending,
+  chainBreak,
+  onOpenReport,
 }: {
   valid: boolean;
   breakAtSeq: number | null;
   pending: boolean;
+  chainBreak: ChainBreak | null;
+  onOpenReport: () => void;
 }) {
   if (pending) {
     return (
@@ -396,6 +414,26 @@ function IntegrityBadge({
       </span>
     );
   }
+  if (chainBreak) {
+    return (
+      <button
+        type="button"
+        aria-haspopup="dialog"
+        onClick={onOpenReport}
+        className={cn(
+          "inline-flex cursor-pointer items-center gap-1.5 rounded bg-destructive-subtle px-2 py-0.5 text-xs font-medium text-destructive-subtle-fg",
+          "underline-offset-2 hover:underline",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+          "transition-opacity hover:opacity-90",
+        )}
+      >
+        <ShieldAlert aria-hidden="true" className="size-3.5" />
+        Chain break at seq{" "}
+        <span className="tabular-nums">{breakAtSeq ?? "?"}</span>
+      </button>
+    );
+  }
+  // break_at_seq is known but no break detail yet (should not occur in practice).
   return (
     <span className="inline-flex items-center gap-1.5 rounded bg-destructive-subtle px-2 py-0.5 text-xs font-medium text-destructive-subtle-fg">
       <ShieldAlert aria-hidden="true" className="size-3.5" />

--- a/packages/openapi-client/src/generated/index.ts
+++ b/packages/openapi-client/src/generated/index.ts
@@ -414,6 +414,7 @@ export {
   type CancelMediaResponse,
   type CancelMediaResponses,
   type CdnCredentials,
+  type ChainBreak,
   type CleanDatabaseData,
   type CleanDatabaseResponse,
   type CleanDatabaseResponses,

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -3862,11 +3862,103 @@ export const ActivityVerifyResultSchema = {
       format: "int64",
       nullable: true,
       description:
-        "The seq of the first broken link, or null when the chain is intact.\n",
+        "The seq of the first broken link, or null when the chain is intact.\nKept for backward compatibility; equals break.seq when broken.\n",
     },
     total: {
       type: "integer",
       description: "Total number of events folded during verification.",
+    },
+    break: {
+      nullable: true,
+      description:
+        "Null when the chain is intact. Describes the first broken link with\nenough detail for an operator to understand and act on the failure.\n",
+      allOf: [
+        {
+          $ref: "#/components/schemas/ChainBreak",
+        },
+      ],
+    },
+  },
+} as const;
+
+export const ChainBreakSchema = {
+  type: "object",
+  required: [
+    "seq",
+    "kind",
+    "seq_gap",
+    "expected_prev_hash",
+    "stored_prev_hash",
+    "recomputed_this_hash",
+    "stored_this_hash",
+    "event",
+  ],
+  properties: {
+    seq: {
+      type: "integer",
+      format: "int64",
+      description: "The seq of the event where verification failed.",
+    },
+    kind: {
+      type: "string",
+      enum: [
+        "missing_events",
+        "link_mismatch",
+        "content_modified",
+        "chain_start_missing",
+      ],
+      description:
+        "Classifies the break:\n- missing_events: one or more seq numbers are absent (log cleanup / retention / deletion).\n- link_mismatch: contiguous seq but prev_hash broken (insertion/removal/reorder/prior alteration).\n- content_modified: prev link intact but recomputed hash diverges (content edited after recording).\n- chain_start_missing: first stored event does not chain from genesis (oldest events gone / chain reset).\n",
+    },
+    prior_seq: {
+      type: "integer",
+      format: "int64",
+      nullable: true,
+      description:
+        "The seq of the last successfully-verified row. Null when the break is\nat the first/genesis row and no prior row was verified.\n",
+    },
+    seq_gap: {
+      type: "integer",
+      format: "int64",
+      description:
+        "Number of missing sequence numbers between prior_seq and seq.\n0 when contiguous or when there is no prior row.\n",
+    },
+    expected_prev_hash: {
+      type: "string",
+      description:
+        "The verified chain head before this row: the prior row's this_hash,\nor GenesisPrevHash (64 zero hex chars) if this is the first row.\n",
+    },
+    stored_prev_hash: {
+      type: "string",
+      description: "The row's own prev_hash as stored.",
+    },
+    recomputed_this_hash: {
+      type: "string",
+      description: "ComputeHashFromStored(expected_prev_hash, row).",
+    },
+    stored_this_hash: {
+      type: "string",
+      description: "The row's own this_hash as stored.",
+    },
+    event: {
+      type: "object",
+      required: ["summary", "event_type", "actor_login", "occurred_at"],
+      description: "The offending event fields for operator context.",
+      properties: {
+        summary: {
+          type: "string",
+        },
+        event_type: {
+          type: "string",
+        },
+        actor_login: {
+          type: "string",
+        },
+        occurred_at: {
+          type: "string",
+          format: "date-time",
+        },
+      },
     },
   },
 } as const;

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -2004,6 +2004,7 @@ export type ActivityVerifyResult = {
   valid: boolean;
   /**
    * The seq of the first broken link, or null when the chain is intact.
+   * Kept for backward compatibility; equals break.seq when broken.
    *
    */
   break_at_seq?: number;
@@ -2011,6 +2012,71 @@ export type ActivityVerifyResult = {
    * Total number of events folded during verification.
    */
   total: number;
+  /**
+   * Null when the chain is intact. Describes the first broken link with
+   * enough detail for an operator to understand and act on the failure.
+   *
+   */
+  break?: ChainBreak;
+};
+
+export type ChainBreak = {
+  /**
+   * The seq of the event where verification failed.
+   */
+  seq: number;
+  /**
+   * Classifies the break:
+   * - missing_events: one or more seq numbers are absent (log cleanup / retention / deletion).
+   * - link_mismatch: contiguous seq but prev_hash broken (insertion/removal/reorder/prior alteration).
+   * - content_modified: prev link intact but recomputed hash diverges (content edited after recording).
+   * - chain_start_missing: first stored event does not chain from genesis (oldest events gone / chain reset).
+   *
+   */
+  kind:
+    | "missing_events"
+    | "link_mismatch"
+    | "content_modified"
+    | "chain_start_missing";
+  /**
+   * The seq of the last successfully-verified row. Null when the break is
+   * at the first/genesis row and no prior row was verified.
+   *
+   */
+  prior_seq?: number;
+  /**
+   * Number of missing sequence numbers between prior_seq and seq.
+   * 0 when contiguous or when there is no prior row.
+   *
+   */
+  seq_gap: number;
+  /**
+   * The verified chain head before this row: the prior row's this_hash,
+   * or GenesisPrevHash (64 zero hex chars) if this is the first row.
+   *
+   */
+  expected_prev_hash: string;
+  /**
+   * The row's own prev_hash as stored.
+   */
+  stored_prev_hash: string;
+  /**
+   * ComputeHashFromStored(expected_prev_hash, row).
+   */
+  recomputed_this_hash: string;
+  /**
+   * The row's own this_hash as stored.
+   */
+  stored_this_hash: string;
+  /**
+   * The offending event fields for operator context.
+   */
+  event: {
+    summary: string;
+    event_type: string;
+    actor_login: string;
+    occurred_at: string;
+  };
 };
 
 export type SecurityThresholds = {

--- a/packages/openapi-client/src/index.ts
+++ b/packages/openapi-client/src/index.ts
@@ -356,6 +356,7 @@ export type {
   SiteActivityEvent,
   SiteActivityList,
   ActivityVerifyResult,
+  ChainBreak,
   ListSiteActivityData,
   ListSiteActivityResponse,
   VerifySiteActivityData,

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -9770,9 +9770,87 @@ components:
           nullable: true
           description: |
             The seq of the first broken link, or null when the chain is intact.
+            Kept for backward compatibility; equals break.seq when broken.
         total:
           type: integer
           description: Total number of events folded during verification.
+        break:
+          nullable: true
+          description: |
+            Null when the chain is intact. Describes the first broken link with
+            enough detail for an operator to understand and act on the failure.
+          allOf:
+            - $ref: "#/components/schemas/ChainBreak"
+    ChainBreak:
+      type: object
+      required:
+        - seq
+        - kind
+        - seq_gap
+        - expected_prev_hash
+        - stored_prev_hash
+        - recomputed_this_hash
+        - stored_this_hash
+        - event
+      properties:
+        seq:
+          type: integer
+          format: int64
+          description: The seq of the event where verification failed.
+        kind:
+          type: string
+          enum:
+            - missing_events
+            - link_mismatch
+            - content_modified
+            - chain_start_missing
+          description: |
+            Classifies the break:
+            - missing_events: one or more seq numbers are absent (log cleanup / retention / deletion).
+            - link_mismatch: contiguous seq but prev_hash broken (insertion/removal/reorder/prior alteration).
+            - content_modified: prev link intact but recomputed hash diverges (content edited after recording).
+            - chain_start_missing: first stored event does not chain from genesis (oldest events gone / chain reset).
+        prior_seq:
+          type: integer
+          format: int64
+          nullable: true
+          description: |
+            The seq of the last successfully-verified row. Null when the break is
+            at the first/genesis row and no prior row was verified.
+        seq_gap:
+          type: integer
+          format: int64
+          description: |
+            Number of missing sequence numbers between prior_seq and seq.
+            0 when contiguous or when there is no prior row.
+        expected_prev_hash:
+          type: string
+          description: |
+            The verified chain head before this row: the prior row's this_hash,
+            or GenesisPrevHash (64 zero hex chars) if this is the first row.
+        stored_prev_hash:
+          type: string
+          description: The row's own prev_hash as stored.
+        recomputed_this_hash:
+          type: string
+          description: ComputeHashFromStored(expected_prev_hash, row).
+        stored_this_hash:
+          type: string
+          description: The row's own this_hash as stored.
+        event:
+          type: object
+          required: [summary, event_type, actor_login, occurred_at]
+          description: The offending event fields for operator context.
+          properties:
+            summary:
+              type: string
+            event_type:
+              type: string
+            actor_login:
+              type: string
+            occurred_at:
+              type: string
+              format: date-time
     # ── S2 — Login Protection + IP store ───────────────────────────────────
     SecurityThresholds:
       type: object


### PR DESCRIPTION
## What

The activity log's red "Chain break at seq N" badge was a dead end — clicking it did nothing, and `/activity/verify` only returned a bare sequence number, so an operator had no way to know *why* the tamper-evident audit chain failed. This makes the badge actionable and explains the break.

## Changes (api + web, no agent/migration)

- **API:** `VerifyChain` now classifies the break — `missing_events` / `link_mismatch` / `content_modified` / `chain_start_missing` — and the verify response carries a structured `break` object: failing seq, prior verified seq, sequence-gap size, expected-vs-stored prev/this hashes, and the offending event. Additive; `break_at_seq` kept. OpenAPI spec + ogen server types + TS client regenerated from the spec.
- **Web:** the break badge is now a button opening an **Activity log integrity** dialog — plain-language cause + what-to-do, the offending event, collapsible hash detail with copy, and a Re-check action. A chain break most often means pruned/cleared entries (not tampering), and the copy says so honestly.

## Verification

- Activity package **13/13** (5 break-classification cases + a JSON-shape contract guard against drift).
- Gates: `go build/vet/test`, web `typecheck`/`lint`/`build`, Impeccable detector clean on the two changed web files.

No migration, no agent change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity log chain break indicators are now interactive buttons that open detailed integrity reports
  * Chain integrity reports provide plain-language explanations of verification failures with offending event details
  * Technical detail section displays hash comparisons and sequence information with copy-to-clipboard functionality
  * Added re-check action to reverify the audit chain from the report dialog

<!-- end of auto-generated comment: release notes by coderabbit.ai -->