### PR TITLE
fix(sites): table alignment on row selection (web 0.50.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.50.4] - 2026-06-16
+
+### Fixed
+
+- **Sites table no longer misaligns when rows are selected.** Selected rows used a relatively-positioned row with an absolute accent strip, which pulled the row out of the fixed table column grid so its cells drifted from the headers. Selection is now shown with a background tint that does not affect layout, so selected and unselected rows stay aligned.
+
+Dashboard only at 0.50.4; no control-plane, migration, or agent change.
+
 ## [0.50.3] - 2026-06-16
 
 ### Fixed

--- a/apps/web/src/features/sites/sites-table.tsx
+++ b/apps/web/src/features/sites/sites-table.tsx
@@ -614,12 +614,13 @@ export function SitesTable({
             style={{ ...style, height: rowHeight }}
             data-state={selected ? "selected" : undefined}
             className={cn(
-              "relative border-b border-border transition-colors duration-[80ms] hover:bg-muted",
-              selected && "bg-muted",
-              // 2px left ring on selected rows. Tailwind has no directional
-              // ring utility, so we paint a 2px strip via the `before:` pseudo.
-              selected &&
-                "before:absolute before:left-0 before:top-0 before:bottom-0 before:w-0.5 before:bg-primary before:content-['']",
+              "border-b border-border transition-colors duration-[80ms] hover:bg-muted",
+              // Selection is indicated by a background tint only. We deliberately
+              // do NOT use `position: relative` + an absolute `before:` strip on
+              // the row: a relatively-positioned table row with an abspos child
+              // drops out of the `table-layout: fixed` column grid, so selected
+              // rows would lose their column widths and drift from the header.
+              selected && "bg-primary/5",
             )}
           />
         );


### PR DESCRIPTION
Selected rows dropped out of the fixed-table column grid (positioned row + abspos strip). Selection is now a background tint only. Live in prod web 0.50.4.