### PR TITLE
fix(sites): mobile table column overlap (web 0.50.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.50.5] - 2026-06-16
+
+### Fixed
+
+- **Sites table no longer overlaps its columns on mobile.** The table's minimum width was smaller than the sum of its columns, so on a narrow screen the fixed layout squeezed every column together and the Site and Client headers overlapped. The minimum width now matches the columns, so on a small screen the table keeps its widths and scrolls sideways instead. The grid view remains the more compact option on a phone.
+
+Dashboard only at 0.50.5; no control-plane, migration, or agent change.
+
 ## [0.50.4] - 2026-06-16
 
 ### Fixed

--- a/apps/web/src/features/sites/sites-table.tsx
+++ b/apps/web/src/features/sites/sites-table.tsx
@@ -203,6 +203,18 @@ const COLUMN_WIDTHS_PX: ReadonlyArray<number | undefined> = [
   COL_ACTIONS_PX, // actions
 ];
 
+// Minimum table width = the sum of every column at its intended size (the
+// flexible Site column counted at a sensible minimum). When the viewport is
+// narrower than this (mobile), the table keeps these widths and the container
+// scrolls horizontally instead of squeezing the columns into each other — the
+// previous 860px floor was BELOW the fixed columns' total, so on mobile the
+// fixed-layout table compressed every column and the headers overlapped.
+const COL_SITE_MIN_PX = 260;
+const TABLE_MIN_WIDTH_PX = COLUMN_WIDTHS_PX.reduce<number>(
+  (sum, w) => sum + (w ?? COL_SITE_MIN_PX),
+  0,
+);
+
 // ---------------------------------------------------------------------------
 // Column definitions
 // ---------------------------------------------------------------------------
@@ -507,7 +519,7 @@ function VirtuosoTable({
   return (
     <table
       {...rest}
-      style={{ ...style, width: "100%", minWidth: "860px", tableLayout: "fixed" }}
+      style={{ ...style, width: "100%", minWidth: TABLE_MIN_WIDTH_PX, tableLayout: "fixed" }}
       className="border-collapse"
     >
       {/* Authoritative column geometry shared by the sticky header and the


### PR DESCRIPTION
Table min-width was below the column total, so mobile compressed columns into overlap. Min-width now matches the columns; the table scrolls horizontally on narrow screens. Live in prod web 0.50.5.