### PR TITLE
fix(ci): green CI (web lint + chromium-missing test determinism)

### DIFF
--- a/apps/api/internal/screenshot/capture/worker.go
+++ b/apps/api/internal/screenshot/capture/worker.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"math/rand/v2"
 	"net/http"
+	"os"
 	"os/exec"
 	"sync"
 	"time"
@@ -49,8 +50,19 @@ const (
 // scale2x is the pixel-ratio for the @2x retina thumbnail.
 const scale2x = 2.0
 
-// chromiumBin is the expected system Chromium binary path in the encoder image.
-const chromiumBin = "/usr/bin/chromium-browser"
+// defaultChromiumBin is the system Chromium path baked into the encoder image.
+const defaultChromiumBin = "/usr/bin/chromium-browser"
+
+// chromiumBinPath resolves the Chromium binary path at call time. It honors the
+// WPMGR_CHROMIUM_BIN override (for self-hosters whose Chromium lives elsewhere,
+// and for tests that must force the not-found path deterministically regardless
+// of what the host/CI runner happens to have installed).
+func chromiumBinPath() string {
+	if v := os.Getenv("WPMGR_CHROMIUM_BIN"); v != "" {
+		return v
+	}
+	return defaultChromiumBin
+}
 
 // Repo is the subset of the screenshot repo the worker needs.
 type Repo interface {
@@ -198,6 +210,7 @@ func (w *Worker) Work(ctx context.Context, job *river.Job[screenshot.CaptureArgs
 // This is the authoritative guard: Chromium never touches the network directly.
 func (w *Worker) capture(ctx context.Context, siteURL string) (img1x, img2x []byte, err error) {
 	// Fast-fail when Chromium is not installed (clear error message).
+	chromiumBin := chromiumBinPath()
 	if _, lookupErr := exec.LookPath(chromiumBin); lookupErr != nil {
 		return nil, nil, fmt.Errorf("chromium not found at %s: install chromium in the media-encoder image", chromiumBin)
 	}

--- a/apps/api/internal/screenshot/capture/worker_test.go
+++ b/apps/api/internal/screenshot/capture/worker_test.go
@@ -153,11 +153,17 @@ func TestWorker_Timeout(t *testing.T) {
 // TestWorker_MarksFailed_OnChromiumMissing verifies that when Chromium is not
 // found the worker marks the screenshot as failed (not a transient River error).
 func TestWorker_MarksFailed_OnChromiumMissing(t *testing.T) {
+	// Force the chromium-missing path deterministically: point the worker at a
+	// path that cannot exist. Without this the test relied on the ambient
+	// environment NOT having Chromium, which is false on CI runners (they ship
+	// /usr/bin/chromium-browser), so capture would succeed and MarkFailed never
+	// fired — the source of the CI flake.
+	t.Setenv("WPMGR_CHROMIUM_BIN", "/nonexistent/wpmgr-chromium-missing-test")
+
 	repo := &fakeRepo{}
 	store := &fakeStore{}
 	w := capture.NewWorker(repo, store, nil, 1, nil)
 
-	// Chromium will not be found in the test environment.
 	ctx := context.Background()
 	err := w.Work(ctx, &river.Job[screenshot.CaptureArgs]{
 		Args: screenshot.CaptureArgs{

--- a/apps/web/src/routes/2fa-challenge.tsx
+++ b/apps/web/src/routes/2fa-challenge.tsx
@@ -462,7 +462,7 @@ function WebAuthnView({
       // The server returns the standard `{ publicKey: {...} }` envelope already
       // (go-webauthn CredentialAssertion), so pass it straight through — wrapping
       // it again buries `rp`/`challenge` a level too deep ("Missing key" errors).
-      const credential = await get(options as unknown as Parameters<typeof get>[0]);
+      const credential = await get(options);
 
       // 3. Serialize the assertion back to JSON and base64-encode it for the server.
       // The contract says `assertion` is `[]byte` (base64-encoded raw JSON).


### PR DESCRIPTION
Two long-standing CI failures: an unnecessary TS cast (lint) and an environment-dependent screenshot worker test. Both fixed and verified locally.