### PR TITLE
docs(readme): fix release badge (static, avoids shields.io GitHub token-pool error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress sites from one dashboard — all running on infrastructure you control. The control plane is a Go binary with a React dashboard; a lightweight PHP plugin on each managed site handles the work. Everything between the agent and the control plane is Ed25519-signed.
 
-[![Latest release](https://img.shields.io/github/v/release/mosamlife/wpmgr?style=flat)](https://github.com/mosamlife/wpmgr/releases)
+[![Latest release](https://img.shields.io/badge/release-v0.50.5-blue?style=flat)](https://github.com/mosamlife/wpmgr/releases)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat)](./LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/mosamlife/wpmgr/ci.yml?branch=main&label=CI&style=flat)](https://github.com/mosamlife/wpmgr/actions/workflows/ci.yml)
 


### PR DESCRIPTION
## What

The README **release** badge was rendering `Unable to select next GitHub token from pool` instead of the version.

## Why

`img.shields.io/github/v/release/...` makes a live GitHub API call. When shields.io's GitHub token pool is rate-limited/exhausted on their side, the badge renders their server-side error string and caches it into the image. Our repo and releases are fine (GitHub's own `releases/latest` returns `v0.50.5`).

## Fix

Pin the badge to a static shields.io badge (`badge/release-v0.50.5-blue`) that renders from text alone, so it can never hit the GitHub API and can't reproduce the failure. Version is bumped on each release alongside the curated notes. CI badge left dynamic (currently healthy, and a live pass/fail is worth keeping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the release version badge to reference a specific release version (v0.50.5) instead of dynamically fetching the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->