### PR TITLE
Settings area + collapsible sidebar; relocate Destinations/Alerts (v0.51.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.51.1] - 2026-06-16
+
+### Changed
+
+- **Destinations and Alerts moved to their natural homes in the sidebar.** Destinations (where backups are stored: control-plane managed storage, a local folder, or an S3-compatible bucket) was previously under Settings but is not an account setting. It now lives at /destinations under the Operations group, next to Backups. Alerts (how the tenant is notified when monitored sites go down) was previously under Settings but is a monitoring concern. It now lives at /alerts under the Insights group, next to Uptime. Settings now holds only true account and organisation configuration: Account, Security, Organisation, API keys, Email / SMTP, and Members.
+
+Dashboard only at 0.51.1; no control-plane, migration, or agent change.
+
+## [0.51.0] - 2026-06-16
+
+### Changed
+
+- **Settings has a real page.** Visiting /settings now renders a dedicated Settings area with a left vertical side-menu listing every account and organisation settings section; the content fills the right panel. On mobile the side-menu collapses to a horizontal scroll strip. Visiting /settings lands on Account. Previously /settings rendered nothing.
+- **Main sidebar sections are collapsible.** The grouped navigation sections (Operations, Insights, Security) can now be opened and closed individually. They start collapsed to keep the sidebar short; the group that contains the page you are currently on auto-expands on load; manual open and close choices are stored and remembered across visits.
+- **Eight settings links in the sidebar became one.** The individual settings links (Account, Security, Organisation, API keys, Email / SMTP, Members, Destinations, Alerts) that occupied the sidebar separately are replaced by a single "Settings" entry that opens the settings area.
+
+Dashboard only at 0.51.0; no control-plane, migration, or agent change.
+
 ## [0.50.5] - 2026-06-16
 
 ### Fixed

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useId, useRef, useState, type ReactNode } from "react";
 import { Link, useLocation } from "@tanstack/react-router";
 import {
   Activity,
+  ChevronRight,
   Globe,
   LineChart,
   Mail,
@@ -14,7 +15,7 @@ import {
 
 import { FleetHubLogo, Wordmark } from "@/components/brand/logo";
 import { useShellState } from "@/components/layout/app-shell-context";
-import { useMe, isOrgScoped, isSuperadmin } from "@/features/auth/use-auth";
+import { useMe, isSuperadmin } from "@/features/auth/use-auth";
 import { useSites } from "@/features/sites/use-sites";
 import { cn } from "@/lib/utils";
 
@@ -24,16 +25,47 @@ import { cn } from "@/lib/utils";
 // Settings (bottom-aligned). Per-item: 8px / 12px padding, 6px radius,
 // active = accent + 2px left ring primary (DESIGN.md "Sidebar item").
 //
-// Routes that don't exist yet (migrations, uptime, performance,
-// vulnerabilities, audit, the /settings index) render as disabled items with
-// `aria-disabled` and a "Coming soon" tooltip. The brief allows this for
-// Sprint 1; Sprint 4 will fill them in.
+// COLLAPSIBLE GROUPS (Operations, Insights, Security): the group header is a
+// <button> that toggles open/closed. Default = collapsed, except the group
+// containing the active route auto-expands on first render. Manual toggles
+// persist to localStorage["wpmgr.sidebar.groups"] (label->boolean map).
+// Resolution rule: persisted map entry wins; otherwise open iff active route.
 //
-// Collapsed state (64px rail) shows icons only. Active items still highlight;
-// the active group's sub-items move into a flyout that opens on hover/focus
-// of the group icon. Tooltips on the icons use the native `title` attribute
-// - sufficient for the current shadcn primitive set (no Tooltip primitive
-// installed yet).
+// SETTINGS is now a single leaf link to /settings (the settings area owns its
+// own left-sidebar for the 8 sub-sections). The 8 inline sub-items and the
+// org-scoped filtering block are removed from the main sidebar.
+//
+// Collapsed state (64px rail): icons-only. Collapsible groups still show their
+// sub-items as hover/focus flyouts (unchanged). Settings leaf = icon link.
+
+const GROUPS_KEY = "wpmgr.sidebar.groups";
+
+/** Reads the persisted open-state map from localStorage. Safe in private mode. */
+function readGroupsMap(): Record<string, boolean> {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(GROUPS_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {};
+    return parsed as Record<string, boolean>;
+  } catch {
+    return {};
+  }
+}
+
+/** Writes an updated entry to the persisted map. Safe in private mode. */
+function writeGroupsMap(label: string, open: boolean): void {
+  try {
+    const current = readGroupsMap();
+    window.localStorage.setItem(
+      GROUPS_KEY,
+      JSON.stringify({ ...current, [label]: open }),
+    );
+  } catch {
+    // Private mode / quota denied — toggle still works for the session.
+  }
+}
 
 interface NavItem {
   label: string;
@@ -51,35 +83,35 @@ interface NavGroup {
   count?: number;
   todo?: boolean;
   items?: NavItem[];
+  /** When true this group is collapsible in expanded sidebar mode. */
+  collapsible?: boolean;
 }
 
 // Top groups (rendered above the bottom-aligned Settings entry).
 //
-// Counts are placeholders sourced from a hard-coded mock until the real
-// queries land (Sprint 2 onward). They use mono / tabular-nums so the
-// column reads cleanly even with multi-digit numbers.
+// Operations, Insights, Security are marked collapsible. Sites, Clients, Email,
+// and Shared with me are leaf links and are not collapsible.
 const TOP_GROUPS: ReadonlyArray<NavGroup> = [
   {
     label: "Sites",
     icon: Globe,
     to: "/sites",
-    // count is injected live from useSites() in <Sidebar>; see SITES_LABEL.
+    // count is injected live from useSites() in <Sidebar>; see below.
   },
   {
     label: "Operations",
     icon: Activity,
+    collapsible: true,
     items: [
-      // /backups index doesn't exist yet - only /backups/$snapshotId. Mark
-      // disabled until Sprint 4 adds the index.
       { label: "Backups", to: "/backups" },
       { label: "Updates", to: "/updates" },
-      // /migrations doesn't exist yet.
       { label: "Migrations", to: "/migrations" },
     ],
   },
   {
     label: "Insights",
     icon: LineChart,
+    collapsible: true,
     items: [
       { label: "Uptime", to: "/uptime" },
       { label: "Performance", to: "/performance" },
@@ -98,6 +130,7 @@ const TOP_GROUPS: ReadonlyArray<NavGroup> = [
   {
     label: "Security",
     icon: Shield,
+    collapsible: true,
     items: [
       { label: "Vulnerabilities", to: "/vulnerabilities" },
       { label: "Audit", to: "/audit" },
@@ -105,23 +138,12 @@ const TOP_GROUPS: ReadonlyArray<NavGroup> = [
   },
 ];
 
-const SETTINGS_GROUP: NavGroup = {
+// Settings is now a single leaf link. The 8 sub-sections live in the
+// /settings area (with its own left sidebar managed by Agent A).
+const SETTINGS_LEAF: NavGroup = {
   label: "Settings",
   icon: Settings,
-  // Settings is now a grouped section so the destinations sub-item (ADR-036 P1
-  // storage adapter) has a stable home. The group highlights and the API keys
-  // page is still the "first" target — Sprint 4 may add a real /settings index
-  // page later, at which point the `to` here can flip to that.
-  items: [
-    { label: "Account", to: "/settings/account" },
-    { label: "Security", to: "/settings/security" },
-    { label: "Organisation", to: "/settings/organization" },
-    { label: "API keys", to: "/settings/api-keys" },
-    { label: "Destinations", to: "/settings/destinations" },
-    { label: "Email / SMTP", to: "/settings/smtp" },
-    { label: "Alerts", to: "/settings/alerts" },
-    { label: "Members", to: "/settings/members" },
-  ],
+  to: "/settings",
 };
 
 const SHARED_WITH_ME_GROUP: NavGroup = {
@@ -130,8 +152,7 @@ const SHARED_WITH_ME_GROUP: NavGroup = {
   to: "/shared-with-me",
 };
 
-// Superadmin-only nav entry. Only mounted in the sidebar JSX when
-// me.user.is_superadmin === true (checked via isSuperadmin helper).
+// Superadmin-only nav entry. Only mounted when me.user.is_superadmin === true.
 const ADMIN_GROUP: NavGroup = {
   label: "Admin",
   icon: Shield,
@@ -143,28 +164,14 @@ export function Sidebar() {
   const location = useLocation();
   const pathname = location.pathname;
   const { data: me } = useMe();
-  const orgScoped = isOrgScoped(me);
   const superadmin = isSuperadmin(me);
 
   // Live "Sites" count for the nav badge (active, non-archived) — shares the
-  // sites-list query cache with the Sites page, so it's deduped. The other nav
-  // badges were hardcoded mocks and are intentionally dropped until each domain
-  // has a real count.
+  // sites-list query cache with the Sites page, so it's deduped.
   const { data: sitesData } = useSites();
   const sitesCount = sitesData?.length;
 
-  // Site-scoped collaborators only see a filtered settings group (Account only).
-  const settingsGroup: NavGroup = orgScoped
-    ? SETTINGS_GROUP
-    : {
-        ...SETTINGS_GROUP,
-        items: SETTINGS_GROUP.items?.filter((item) =>
-          item.to === "/settings/account",
-        ),
-      };
-
-  // Close the mobile drawer on route change so navigation always feels
-  // resolved. Effect, not in the click handler, so back/forward also close.
+  // Close the mobile drawer on route change so navigation always feels resolved.
   useEffect(() => {
     setMobileOpen(false);
   }, [pathname, setMobileOpen]);
@@ -199,12 +206,15 @@ export function Sidebar() {
 
         <div className="flex flex-1 flex-col overflow-y-auto px-2 py-3">
           {superadmin ? (
-            // Superadmin is monitoring-only: show ONLY the Admin area. They have
-            // no org and never manage sites/settings, so the rest of the nav is
-            // intentionally hidden.
+            // Superadmin is monitoring-only: show ONLY the Admin area. They
+            // have no org and never manage sites/settings.
             <ul className="flex flex-col gap-0.5">
               <li>
-                <NavGroupItem group={ADMIN_GROUP} pathname={pathname} collapsed={collapsed} />
+                <NavGroupItem
+                  group={ADMIN_GROUP}
+                  pathname={pathname}
+                  collapsed={collapsed}
+                />
               </li>
             </ul>
           ) : (
@@ -218,7 +228,11 @@ export function Sidebar() {
                       : group;
                   return (
                     <li key={group.label}>
-                      <NavGroupItem group={g} pathname={pathname} collapsed={collapsed} />
+                      <NavGroupItem
+                        group={g}
+                        pathname={pathname}
+                        collapsed={collapsed}
+                      />
                     </li>
                   );
                 })}
@@ -231,10 +245,11 @@ export function Sidebar() {
                   />
                 </li>
               </ul>
+              {/* Settings — single leaf link, bottom-aligned. */}
               <ul className="mt-auto flex flex-col gap-0.5 pt-3">
                 <li>
                   <NavGroupItem
-                    group={settingsGroup}
+                    group={SETTINGS_LEAF}
                     pathname={pathname}
                     collapsed={collapsed}
                   />
@@ -278,18 +293,12 @@ function NavGroupItem({ group, pathname, collapsed }: GroupProps) {
   const hasItems = !!group.items?.length;
 
   // Group is "active" when its own route or any sub-item route is the
-  // current pathname (or prefix). Sub-paths under e.g. /sites/$siteId still
-  // light up Sites.
+  // current pathname (or prefix).
   const selfActive = group.to ? isActive(pathname, group.to) : false;
   const childActive =
     hasItems &&
     group.items!.some((item) => item.to && isActive(pathname, item.to));
   const active = selfActive || childActive;
-
-  // Expanded sidebar: render the group as a row, and (when active OR has no
-  // items) render sub-items below.
-  // Collapsed sidebar: render the icon centered, with a hover flyout for
-  // sub-items.
 
   if (collapsed) {
     return (
@@ -297,7 +306,7 @@ function NavGroupItem({ group, pathname, collapsed }: GroupProps) {
     );
   }
 
-  // For leaf groups (Sites, Settings), the row itself is the link.
+  // Leaf groups (no sub-items): the row itself is the link.
   if (!hasItems) {
     return (
       <NavLeaf
@@ -312,11 +321,19 @@ function NavGroupItem({ group, pathname, collapsed }: GroupProps) {
     );
   }
 
-  // Group with sub-items. The header is a section label; the sub-items ALWAYS
-  // render below it so every route is reachable from the expanded sidebar.
-  // (Previously they were gated on `active`, which hid a group's children
-  // unless you were already inside that group — leaving Backups/Migrations/
-  // Uptime/Performance/Vulnerabilities/Audit unreachable from the nav.)
+  // Collapsible group with sub-items.
+  if (group.collapsible) {
+    return (
+      <CollapsibleGroup
+        group={group}
+        pathname={pathname}
+        active={active}
+        childActive={childActive}
+      />
+    );
+  }
+
+  // Non-collapsible group with sub-items (fallback, not currently used).
   return (
     <div>
       <GroupHeader group={group} active={active} />
@@ -338,14 +355,137 @@ function NavGroupItem({ group, pathname, collapsed }: GroupProps) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// CollapsibleGroup — the collapsible variant for expanded sidebar mode.
+// ---------------------------------------------------------------------------
+
+interface CollapsibleGroupProps {
+  group: NavGroup;
+  pathname: string;
+  active: boolean;
+  childActive: boolean;
+}
+
+function CollapsibleGroup({
+  group,
+  pathname,
+  active,
+  childActive,
+}: CollapsibleGroupProps) {
+  const regionId = useId();
+
+  // Determine initial open state:
+  //   1. If localStorage has an explicit entry for this group, use it.
+  //   2. Otherwise, open iff the active route is inside this group.
+  // This means the user's manual choices always win, but un-touched groups
+  // auto-expand when you navigate into them.
+  const [open, setOpen] = useState<boolean>(() => {
+    const map = readGroupsMap();
+    if (Object.prototype.hasOwnProperty.call(map, group.label)) {
+      return map[group.label] === true;
+    }
+    return childActive;
+  });
+
+  // When navigation lands the active route inside this group, always reveal it
+  // — even if the user previously collapsed it. Otherwise navigating via the
+  // URL bar, back/forward, or the command palette would hide the active page
+  // inside a closed group with no content visible. Persist so the next session
+  // starts consistent. Groups the user is NOT navigating into keep their
+  // remembered open/closed state.
+  const prevChildActive = useRef(childActive);
+  useEffect(() => {
+    if (childActive && !prevChildActive.current) {
+      setOpen(true);
+      writeGroupsMap(group.label, true);
+    }
+    prevChildActive.current = childActive;
+  }, [childActive, group.label]);
+
+  const toggle = () => {
+    setOpen((prev) => {
+      const next = !prev;
+      writeGroupsMap(group.label, next);
+      return next;
+    });
+  };
+
+  const Icon = group.icon;
+
+  return (
+    <div>
+      {/* Collapsible group header — a button so Enter/Space work natively. */}
+      <button
+        type="button"
+        id={`${regionId}-trigger`}
+        aria-expanded={open}
+        aria-controls={regionId}
+        onClick={toggle}
+        className={cn(
+          "flex w-full items-center gap-2 rounded-md px-3 py-2",
+          "text-xs uppercase tracking-[0.02em] font-medium",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          "hover:bg-muted/50",
+          active ? "text-foreground" : "text-muted-foreground",
+          // Left rail when the group (or a child) is active.
+          "border-l-2",
+          active ? "border-primary" : "border-transparent",
+        )}
+      >
+        <Icon aria-hidden="true" className="size-4 shrink-0" />
+        <span className="flex-1 truncate text-left">{group.label}</span>
+        {/* Chevron rotates 90deg when open. Respects prefers-reduced-motion
+            via the global CSS rule (transition-duration collapses to ~0ms). */}
+        <ChevronRight
+          aria-hidden="true"
+          className={cn(
+            "size-3.5 shrink-0 text-muted-foreground transition-transform duration-150",
+            open && "rotate-90",
+          )}
+        />
+      </button>
+
+      {/* Collapsible region. Uses the grid-rows [0fr]<->[1fr] technique to
+          animate height without animating height directly (DESIGN.md).
+          overflow-hidden on the inner div clips content during collapse.
+          prefers-reduced-motion: reduce collapses transitions globally via
+          the globals.css rule (duration → 0.01ms). */}
+      <div
+        id={regionId}
+        role="region"
+        aria-labelledby={`${regionId}-trigger`}
+        className={cn(
+          "grid transition-[grid-template-rows] duration-150",
+          open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+        )}
+      >
+        <div className="overflow-hidden">
+          <ul className="mt-0.5 flex flex-col gap-0.5 pb-0.5">
+            {group.items!.map((item) => (
+              <li key={item.label}>
+                <NavLeaf
+                  label={item.label}
+                  to={item.to}
+                  count={item.count}
+                  todo={item.todo}
+                  active={item.to ? isActive(pathname, item.to) : false}
+                  variant="sub"
+                />
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function GroupHeader({ group, active }: { group: NavGroup; active: boolean }) {
   const Icon = group.icon;
   return (
     <div
       className={cn(
         "flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium",
-        // Group headers don't act like links - they label the open section.
-        // Tracking matches the DESIGN.md caption rule for label rows.
         "text-xs uppercase tracking-[0.02em] text-muted-foreground",
         active && "text-foreground",
       )}
@@ -378,9 +518,6 @@ function NavLeaf({ label, to, icon: Icon, count, todo, active, variant }: LeafPr
     active
       ? "bg-accent text-accent-foreground"
       : "text-foreground hover:bg-muted/50",
-    // Left rail accent on active rows. Border on the left edge (Tailwind has
-    // no directional ring; the border is the established equivalent per the
-    // brief).
     "border-l-2",
     active ? "border-primary" : "border-transparent",
   );
@@ -418,6 +555,12 @@ function NavLeaf({ label, to, icon: Icon, count, todo, active, variant }: LeafPr
   );
 }
 
+// ---------------------------------------------------------------------------
+// CollapsedGroup — 64px rail mode. Preserved from the original implementation.
+// Collapsible groups still expose their sub-items as hover/focus flyouts.
+// The single Settings leaf is just an icon link (no flyout needed).
+// ---------------------------------------------------------------------------
+
 function CollapsedGroup({
   group,
   pathname,
@@ -430,13 +573,10 @@ function CollapsedGroup({
   const Icon = group.icon;
   const hasItems = !!group.items?.length;
   const [open, setOpen] = useState(false);
+  const flyoutId = useId();
 
-  // Single icon button - links straight through when the group has its own
-  // route, or opens a flyout on hover/focus when it groups sub-items. The
-  // active 2px primary left rail is rendered as a `before:` pseudo so the
-  // border utility doesn't share a line with `rounded-md` (Tailwind has no
-  // directional ring; per the brief either border-l-2 or `before:` is
-  // valid and the pseudo keeps the surface readable for static analysis).
+  // Single icon button. Active 2px primary left rail via `before:` pseudo so
+  // border-l-2 doesn't conflict with rounded-md (DESIGN.md pattern).
   const iconClass = cn(
     "relative flex h-9 w-full items-center justify-center rounded-md",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
@@ -447,7 +587,7 @@ function CollapsedGroup({
   );
 
   if (!hasItems) {
-    // Leaf group (Sites, Settings) in collapsed mode.
+    // Leaf group (Sites, Settings, etc.) in collapsed mode.
     if (!group.to || group.todo) {
       return (
         <span
@@ -489,14 +629,19 @@ function CollapsedGroup({
         type="button"
         title={group.label}
         aria-label={group.label}
-        aria-haspopup="menu"
         aria-expanded={open}
+        aria-controls={flyoutId}
         className={iconClass}
       >
         <Icon aria-hidden="true" className="size-5" />
       </button>
+      {/* Disclosure panel — a plain labelled list of links, NOT an ARIA menu.
+          A role="menu" here would promise arrow-key roving + Escape semantics
+          we don't implement; for a hover/focus rail flyout, regular links with
+          Tab order + focus-visible rings + aria-current are the correct,
+          fully accessible pattern. */}
       <div
-        role="menu"
+        id={flyoutId}
         aria-label={group.label}
         className={cn(
           "absolute left-full top-0 z-50 ml-1 min-w-[180px] rounded-md border border-border bg-popover p-1 text-popover-foreground transition-opacity duration-150",
@@ -508,7 +653,7 @@ function CollapsedGroup({
         </div>
         <ul className="mt-1 flex flex-col gap-0.5">
           {group.items!.map((item) => (
-            <li key={item.label} role="none">
+            <li key={item.label}>
               <FlyoutItem item={item} pathname={pathname} />
             </li>
           ))}
@@ -546,7 +691,7 @@ function FlyoutItem({
   if (!item.to || item.todo) {
     return (
       <span
-        role="menuitem"
+        role="link"
         aria-disabled="true"
         tabIndex={-1}
         title="Coming soon"
@@ -559,7 +704,6 @@ function FlyoutItem({
   return (
     <Link
       to={item.to}
-      role="menuitem"
       className={className}
       aria-current={active ? "page" : undefined}
     >

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -106,6 +106,9 @@ const TOP_GROUPS: ReadonlyArray<NavGroup> = [
       { label: "Backups", to: "/backups" },
       { label: "Updates", to: "/updates" },
       { label: "Migrations", to: "/migrations" },
+      // Backup storage targets (managed / local / S3) — a backup concern, not
+      // an account setting, so it lives with Operations.
+      { label: "Destinations", to: "/destinations" },
     ],
   },
   {
@@ -115,6 +118,9 @@ const TOP_GROUPS: ReadonlyArray<NavGroup> = [
     items: [
       { label: "Uptime", to: "/uptime" },
       { label: "Performance", to: "/performance" },
+      // Downtime-notification config — tied to uptime monitoring, not an
+      // account setting, so it lives with Insights.
+      { label: "Alerts", to: "/alerts" },
     ],
   },
   {

--- a/apps/web/src/features/command/command-palette.tsx
+++ b/apps/web/src/features/command/command-palette.tsx
@@ -240,7 +240,7 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
               Manage API keys
             </PaletteItem>
             <PaletteItem
-              onSelect={go("/settings/alerts")}
+              onSelect={go("/alerts")}
               icon={<SettingsIcon className="size-4" aria-hidden="true" />}
             >
               Configure alerts

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -28,7 +28,9 @@ import { Route as AuthedUptimeRouteImport } from './routes/_authed/uptime'
 import { Route as AuthedSharedWithMeRouteImport } from './routes/_authed/shared-with-me'
 import { Route as AuthedPerformanceRouteImport } from './routes/_authed/performance'
 import { Route as AuthedMigrationsRouteImport } from './routes/_authed/migrations'
+import { Route as AuthedDestinationsRouteImport } from './routes/_authed/destinations'
 import { Route as AuthedAuditRouteImport } from './routes/_authed/audit'
+import { Route as AuthedAlertsRouteImport } from './routes/_authed/alerts'
 import { Route as AuthedAdminRouteImport } from './routes/_authed/admin'
 import { Route as AuthedSettingsRouteRouteImport } from './routes/_authed/settings/route'
 import { Route as AuthedUpdatesIndexRouteImport } from './routes/_authed/updates/index'
@@ -44,9 +46,7 @@ import { Route as AuthedSettingsSmtpRouteImport } from './routes/_authed/setting
 import { Route as AuthedSettingsSecurityRouteImport } from './routes/_authed/settings/security'
 import { Route as AuthedSettingsOrganizationRouteImport } from './routes/_authed/settings/organization'
 import { Route as AuthedSettingsMembersRouteImport } from './routes/_authed/settings/members'
-import { Route as AuthedSettingsDestinationsRouteImport } from './routes/_authed/settings/destinations'
 import { Route as AuthedSettingsApiKeysRouteImport } from './routes/_authed/settings/api-keys'
-import { Route as AuthedSettingsAlertsRouteImport } from './routes/_authed/settings/alerts'
 import { Route as AuthedSettingsAccountRouteImport } from './routes/_authed/settings/account'
 import { Route as AuthedScheduleRunsRunIdRouteImport } from './routes/_authed/schedule-runs/$runId'
 import { Route as AuthedRestoresRestoreIdRouteImport } from './routes/_authed/restores/$restoreId'
@@ -164,9 +164,19 @@ const AuthedMigrationsRoute = AuthedMigrationsRouteImport.update({
   path: '/migrations',
   getParentRoute: () => AuthedRoute,
 } as any)
+const AuthedDestinationsRoute = AuthedDestinationsRouteImport.update({
+  id: '/destinations',
+  path: '/destinations',
+  getParentRoute: () => AuthedRoute,
+} as any)
 const AuthedAuditRoute = AuthedAuditRouteImport.update({
   id: '/audit',
   path: '/audit',
+  getParentRoute: () => AuthedRoute,
+} as any)
+const AuthedAlertsRoute = AuthedAlertsRouteImport.update({
+  id: '/alerts',
+  path: '/alerts',
   getParentRoute: () => AuthedRoute,
 } as any)
 const AuthedAdminRoute = AuthedAdminRouteImport.update({
@@ -245,20 +255,9 @@ const AuthedSettingsMembersRoute = AuthedSettingsMembersRouteImport.update({
   path: '/members',
   getParentRoute: () => AuthedSettingsRouteRoute,
 } as any)
-const AuthedSettingsDestinationsRoute =
-  AuthedSettingsDestinationsRouteImport.update({
-    id: '/destinations',
-    path: '/destinations',
-    getParentRoute: () => AuthedSettingsRouteRoute,
-  } as any)
 const AuthedSettingsApiKeysRoute = AuthedSettingsApiKeysRouteImport.update({
   id: '/api-keys',
   path: '/api-keys',
-  getParentRoute: () => AuthedSettingsRouteRoute,
-} as any)
-const AuthedSettingsAlertsRoute = AuthedSettingsAlertsRouteImport.update({
-  id: '/alerts',
-  path: '/alerts',
   getParentRoute: () => AuthedSettingsRouteRoute,
 } as any)
 const AuthedSettingsAccountRoute = AuthedSettingsAccountRouteImport.update({
@@ -396,7 +395,9 @@ export interface FileRoutesByFullPath {
   '/verify-email': typeof VerifyEmailRoute
   '/settings': typeof AuthedSettingsRouteRouteWithChildren
   '/admin': typeof AuthedAdminRoute
+  '/alerts': typeof AuthedAlertsRoute
   '/audit': typeof AuthedAuditRoute
+  '/destinations': typeof AuthedDestinationsRoute
   '/migrations': typeof AuthedMigrationsRoute
   '/performance': typeof AuthedPerformanceRoute
   '/shared-with-me': typeof AuthedSharedWithMeRoute
@@ -409,9 +410,7 @@ export interface FileRoutesByFullPath {
   '/restores/$restoreId': typeof AuthedRestoresRestoreIdRoute
   '/schedule-runs/$runId': typeof AuthedScheduleRunsRunIdRoute
   '/settings/account': typeof AuthedSettingsAccountRoute
-  '/settings/alerts': typeof AuthedSettingsAlertsRoute
   '/settings/api-keys': typeof AuthedSettingsApiKeysRoute
-  '/settings/destinations': typeof AuthedSettingsDestinationsRoute
   '/settings/members': typeof AuthedSettingsMembersRoute
   '/settings/organization': typeof AuthedSettingsOrganizationRoute
   '/settings/security': typeof AuthedSettingsSecurityRoute
@@ -455,7 +454,9 @@ export interface FileRoutesByTo {
   '/terms': typeof TermsRoute
   '/verify-email': typeof VerifyEmailRoute
   '/admin': typeof AuthedAdminRoute
+  '/alerts': typeof AuthedAlertsRoute
   '/audit': typeof AuthedAuditRoute
+  '/destinations': typeof AuthedDestinationsRoute
   '/migrations': typeof AuthedMigrationsRoute
   '/performance': typeof AuthedPerformanceRoute
   '/shared-with-me': typeof AuthedSharedWithMeRoute
@@ -467,9 +468,7 @@ export interface FileRoutesByTo {
   '/restores/$restoreId': typeof AuthedRestoresRestoreIdRoute
   '/schedule-runs/$runId': typeof AuthedScheduleRunsRunIdRoute
   '/settings/account': typeof AuthedSettingsAccountRoute
-  '/settings/alerts': typeof AuthedSettingsAlertsRoute
   '/settings/api-keys': typeof AuthedSettingsApiKeysRoute
-  '/settings/destinations': typeof AuthedSettingsDestinationsRoute
   '/settings/members': typeof AuthedSettingsMembersRoute
   '/settings/organization': typeof AuthedSettingsOrganizationRoute
   '/settings/security': typeof AuthedSettingsSecurityRoute
@@ -516,7 +515,9 @@ export interface FileRoutesById {
   '/verify-email': typeof VerifyEmailRoute
   '/_authed/settings': typeof AuthedSettingsRouteRouteWithChildren
   '/_authed/admin': typeof AuthedAdminRoute
+  '/_authed/alerts': typeof AuthedAlertsRoute
   '/_authed/audit': typeof AuthedAuditRoute
+  '/_authed/destinations': typeof AuthedDestinationsRoute
   '/_authed/migrations': typeof AuthedMigrationsRoute
   '/_authed/performance': typeof AuthedPerformanceRoute
   '/_authed/shared-with-me': typeof AuthedSharedWithMeRoute
@@ -529,9 +530,7 @@ export interface FileRoutesById {
   '/_authed/restores/$restoreId': typeof AuthedRestoresRestoreIdRoute
   '/_authed/schedule-runs/$runId': typeof AuthedScheduleRunsRunIdRoute
   '/_authed/settings/account': typeof AuthedSettingsAccountRoute
-  '/_authed/settings/alerts': typeof AuthedSettingsAlertsRoute
   '/_authed/settings/api-keys': typeof AuthedSettingsApiKeysRoute
-  '/_authed/settings/destinations': typeof AuthedSettingsDestinationsRoute
   '/_authed/settings/members': typeof AuthedSettingsMembersRoute
   '/_authed/settings/organization': typeof AuthedSettingsOrganizationRoute
   '/_authed/settings/security': typeof AuthedSettingsSecurityRoute
@@ -579,7 +578,9 @@ export interface FileRouteTypes {
     | '/verify-email'
     | '/settings'
     | '/admin'
+    | '/alerts'
     | '/audit'
+    | '/destinations'
     | '/migrations'
     | '/performance'
     | '/shared-with-me'
@@ -592,9 +593,7 @@ export interface FileRouteTypes {
     | '/restores/$restoreId'
     | '/schedule-runs/$runId'
     | '/settings/account'
-    | '/settings/alerts'
     | '/settings/api-keys'
-    | '/settings/destinations'
     | '/settings/members'
     | '/settings/organization'
     | '/settings/security'
@@ -638,7 +637,9 @@ export interface FileRouteTypes {
     | '/terms'
     | '/verify-email'
     | '/admin'
+    | '/alerts'
     | '/audit'
+    | '/destinations'
     | '/migrations'
     | '/performance'
     | '/shared-with-me'
@@ -650,9 +651,7 @@ export interface FileRouteTypes {
     | '/restores/$restoreId'
     | '/schedule-runs/$runId'
     | '/settings/account'
-    | '/settings/alerts'
     | '/settings/api-keys'
-    | '/settings/destinations'
     | '/settings/members'
     | '/settings/organization'
     | '/settings/security'
@@ -698,7 +697,9 @@ export interface FileRouteTypes {
     | '/verify-email'
     | '/_authed/settings'
     | '/_authed/admin'
+    | '/_authed/alerts'
     | '/_authed/audit'
+    | '/_authed/destinations'
     | '/_authed/migrations'
     | '/_authed/performance'
     | '/_authed/shared-with-me'
@@ -711,9 +712,7 @@ export interface FileRouteTypes {
     | '/_authed/restores/$restoreId'
     | '/_authed/schedule-runs/$runId'
     | '/_authed/settings/account'
-    | '/_authed/settings/alerts'
     | '/_authed/settings/api-keys'
-    | '/_authed/settings/destinations'
     | '/_authed/settings/members'
     | '/_authed/settings/organization'
     | '/_authed/settings/security'
@@ -896,11 +895,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedMigrationsRouteImport
       parentRoute: typeof AuthedRoute
     }
+    '/_authed/destinations': {
+      id: '/_authed/destinations'
+      path: '/destinations'
+      fullPath: '/destinations'
+      preLoaderRoute: typeof AuthedDestinationsRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/audit': {
       id: '/_authed/audit'
       path: '/audit'
       fullPath: '/audit'
       preLoaderRoute: typeof AuthedAuditRouteImport
+      parentRoute: typeof AuthedRoute
+    }
+    '/_authed/alerts': {
+      id: '/_authed/alerts'
+      path: '/alerts'
+      fullPath: '/alerts'
+      preLoaderRoute: typeof AuthedAlertsRouteImport
       parentRoute: typeof AuthedRoute
     }
     '/_authed/admin': {
@@ -1008,25 +1021,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedSettingsMembersRouteImport
       parentRoute: typeof AuthedSettingsRouteRoute
     }
-    '/_authed/settings/destinations': {
-      id: '/_authed/settings/destinations'
-      path: '/destinations'
-      fullPath: '/settings/destinations'
-      preLoaderRoute: typeof AuthedSettingsDestinationsRouteImport
-      parentRoute: typeof AuthedSettingsRouteRoute
-    }
     '/_authed/settings/api-keys': {
       id: '/_authed/settings/api-keys'
       path: '/api-keys'
       fullPath: '/settings/api-keys'
       preLoaderRoute: typeof AuthedSettingsApiKeysRouteImport
-      parentRoute: typeof AuthedSettingsRouteRoute
-    }
-    '/_authed/settings/alerts': {
-      id: '/_authed/settings/alerts'
-      path: '/alerts'
-      fullPath: '/settings/alerts'
-      preLoaderRoute: typeof AuthedSettingsAlertsRouteImport
       parentRoute: typeof AuthedSettingsRouteRoute
     }
     '/_authed/settings/account': {
@@ -1204,9 +1203,7 @@ const PortalRouteRouteWithChildren = PortalRouteRoute._addFileChildren(
 
 interface AuthedSettingsRouteRouteChildren {
   AuthedSettingsAccountRoute: typeof AuthedSettingsAccountRoute
-  AuthedSettingsAlertsRoute: typeof AuthedSettingsAlertsRoute
   AuthedSettingsApiKeysRoute: typeof AuthedSettingsApiKeysRoute
-  AuthedSettingsDestinationsRoute: typeof AuthedSettingsDestinationsRoute
   AuthedSettingsMembersRoute: typeof AuthedSettingsMembersRoute
   AuthedSettingsOrganizationRoute: typeof AuthedSettingsOrganizationRoute
   AuthedSettingsSecurityRoute: typeof AuthedSettingsSecurityRoute
@@ -1216,9 +1213,7 @@ interface AuthedSettingsRouteRouteChildren {
 
 const AuthedSettingsRouteRouteChildren: AuthedSettingsRouteRouteChildren = {
   AuthedSettingsAccountRoute: AuthedSettingsAccountRoute,
-  AuthedSettingsAlertsRoute: AuthedSettingsAlertsRoute,
   AuthedSettingsApiKeysRoute: AuthedSettingsApiKeysRoute,
-  AuthedSettingsDestinationsRoute: AuthedSettingsDestinationsRoute,
   AuthedSettingsMembersRoute: AuthedSettingsMembersRoute,
   AuthedSettingsOrganizationRoute: AuthedSettingsOrganizationRoute,
   AuthedSettingsSecurityRoute: AuthedSettingsSecurityRoute,
@@ -1286,7 +1281,9 @@ const AuthedSitesSiteIdRouteWithChildren =
 interface AuthedRouteChildren {
   AuthedSettingsRouteRoute: typeof AuthedSettingsRouteRouteWithChildren
   AuthedAdminRoute: typeof AuthedAdminRoute
+  AuthedAlertsRoute: typeof AuthedAlertsRoute
   AuthedAuditRoute: typeof AuthedAuditRoute
+  AuthedDestinationsRoute: typeof AuthedDestinationsRoute
   AuthedMigrationsRoute: typeof AuthedMigrationsRoute
   AuthedPerformanceRoute: typeof AuthedPerformanceRoute
   AuthedSharedWithMeRoute: typeof AuthedSharedWithMeRoute
@@ -1308,7 +1305,9 @@ interface AuthedRouteChildren {
 const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedSettingsRouteRoute: AuthedSettingsRouteRouteWithChildren,
   AuthedAdminRoute: AuthedAdminRoute,
+  AuthedAlertsRoute: AuthedAlertsRoute,
   AuthedAuditRoute: AuthedAuditRoute,
+  AuthedDestinationsRoute: AuthedDestinationsRoute,
   AuthedMigrationsRoute: AuthedMigrationsRoute,
   AuthedPerformanceRoute: AuthedPerformanceRoute,
   AuthedSharedWithMeRoute: AuthedSharedWithMeRoute,

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -30,8 +30,10 @@ import { Route as AuthedPerformanceRouteImport } from './routes/_authed/performa
 import { Route as AuthedMigrationsRouteImport } from './routes/_authed/migrations'
 import { Route as AuthedAuditRouteImport } from './routes/_authed/audit'
 import { Route as AuthedAdminRouteImport } from './routes/_authed/admin'
+import { Route as AuthedSettingsRouteRouteImport } from './routes/_authed/settings/route'
 import { Route as AuthedUpdatesIndexRouteImport } from './routes/_authed/updates/index'
 import { Route as AuthedSitesIndexRouteImport } from './routes/_authed/sites/index'
+import { Route as AuthedSettingsIndexRouteImport } from './routes/_authed/settings/index'
 import { Route as AuthedEmailIndexRouteImport } from './routes/_authed/email/index'
 import { Route as AuthedClientsIndexRouteImport } from './routes/_authed/clients/index'
 import { Route as AuthedBackupsIndexRouteImport } from './routes/_authed/backups/index'
@@ -172,6 +174,11 @@ const AuthedAdminRoute = AuthedAdminRouteImport.update({
   path: '/admin',
   getParentRoute: () => AuthedRoute,
 } as any)
+const AuthedSettingsRouteRoute = AuthedSettingsRouteRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => AuthedRoute,
+} as any)
 const AuthedUpdatesIndexRoute = AuthedUpdatesIndexRouteImport.update({
   id: '/updates/',
   path: '/updates/',
@@ -181,6 +188,11 @@ const AuthedSitesIndexRoute = AuthedSitesIndexRouteImport.update({
   id: '/sites/',
   path: '/sites/',
   getParentRoute: () => AuthedRoute,
+} as any)
+const AuthedSettingsIndexRoute = AuthedSettingsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AuthedSettingsRouteRoute,
 } as any)
 const AuthedEmailIndexRoute = AuthedEmailIndexRouteImport.update({
   id: '/email/',
@@ -213,46 +225,46 @@ const AuthedSitesSiteIdRoute = AuthedSitesSiteIdRouteImport.update({
   getParentRoute: () => AuthedRoute,
 } as any)
 const AuthedSettingsSmtpRoute = AuthedSettingsSmtpRouteImport.update({
-  id: '/settings/smtp',
-  path: '/settings/smtp',
-  getParentRoute: () => AuthedRoute,
+  id: '/smtp',
+  path: '/smtp',
+  getParentRoute: () => AuthedSettingsRouteRoute,
 } as any)
 const AuthedSettingsSecurityRoute = AuthedSettingsSecurityRouteImport.update({
-  id: '/settings/security',
-  path: '/settings/security',
-  getParentRoute: () => AuthedRoute,
+  id: '/security',
+  path: '/security',
+  getParentRoute: () => AuthedSettingsRouteRoute,
 } as any)
 const AuthedSettingsOrganizationRoute =
   AuthedSettingsOrganizationRouteImport.update({
-    id: '/settings/organization',
-    path: '/settings/organization',
-    getParentRoute: () => AuthedRoute,
+    id: '/organization',
+    path: '/organization',
+    getParentRoute: () => AuthedSettingsRouteRoute,
   } as any)
 const AuthedSettingsMembersRoute = AuthedSettingsMembersRouteImport.update({
-  id: '/settings/members',
-  path: '/settings/members',
-  getParentRoute: () => AuthedRoute,
+  id: '/members',
+  path: '/members',
+  getParentRoute: () => AuthedSettingsRouteRoute,
 } as any)
 const AuthedSettingsDestinationsRoute =
   AuthedSettingsDestinationsRouteImport.update({
-    id: '/settings/destinations',
-    path: '/settings/destinations',
-    getParentRoute: () => AuthedRoute,
+    id: '/destinations',
+    path: '/destinations',
+    getParentRoute: () => AuthedSettingsRouteRoute,
   } as any)
 const AuthedSettingsApiKeysRoute = AuthedSettingsApiKeysRouteImport.update({
-  id: '/settings/api-keys',
-  path: '/settings/api-keys',
-  getParentRoute: () => AuthedRoute,
+  id: '/api-keys',
+  path: '/api-keys',
+  getParentRoute: () => AuthedSettingsRouteRoute,
 } as any)
 const AuthedSettingsAlertsRoute = AuthedSettingsAlertsRouteImport.update({
-  id: '/settings/alerts',
-  path: '/settings/alerts',
-  getParentRoute: () => AuthedRoute,
+  id: '/alerts',
+  path: '/alerts',
+  getParentRoute: () => AuthedSettingsRouteRoute,
 } as any)
 const AuthedSettingsAccountRoute = AuthedSettingsAccountRouteImport.update({
-  id: '/settings/account',
-  path: '/settings/account',
-  getParentRoute: () => AuthedRoute,
+  id: '/account',
+  path: '/account',
+  getParentRoute: () => AuthedSettingsRouteRoute,
 } as any)
 const AuthedScheduleRunsRunIdRoute = AuthedScheduleRunsRunIdRouteImport.update({
   id: '/schedule-runs/$runId',
@@ -382,6 +394,7 @@ export interface FileRoutesByFullPath {
   '/reset-password': typeof ResetPasswordRoute
   '/terms': typeof TermsRoute
   '/verify-email': typeof VerifyEmailRoute
+  '/settings': typeof AuthedSettingsRouteRouteWithChildren
   '/admin': typeof AuthedAdminRoute
   '/audit': typeof AuthedAuditRoute
   '/migrations': typeof AuthedMigrationsRoute
@@ -409,6 +422,7 @@ export interface FileRoutesByFullPath {
   '/backups/': typeof AuthedBackupsIndexRoute
   '/clients/': typeof AuthedClientsIndexRoute
   '/email/': typeof AuthedEmailIndexRoute
+  '/settings/': typeof AuthedSettingsIndexRoute
   '/sites/': typeof AuthedSitesIndexRoute
   '/updates/': typeof AuthedUpdatesIndexRoute
   '/clients/$clientId/members': typeof AuthedClientsClientIdMembersRoute
@@ -465,6 +479,7 @@ export interface FileRoutesByTo {
   '/backups': typeof AuthedBackupsIndexRoute
   '/clients': typeof AuthedClientsIndexRoute
   '/email': typeof AuthedEmailIndexRoute
+  '/settings': typeof AuthedSettingsIndexRoute
   '/sites': typeof AuthedSitesIndexRoute
   '/updates': typeof AuthedUpdatesIndexRoute
   '/clients/$clientId/members': typeof AuthedClientsClientIdMembersRoute
@@ -499,6 +514,7 @@ export interface FileRoutesById {
   '/reset-password': typeof ResetPasswordRoute
   '/terms': typeof TermsRoute
   '/verify-email': typeof VerifyEmailRoute
+  '/_authed/settings': typeof AuthedSettingsRouteRouteWithChildren
   '/_authed/admin': typeof AuthedAdminRoute
   '/_authed/audit': typeof AuthedAuditRoute
   '/_authed/migrations': typeof AuthedMigrationsRoute
@@ -526,6 +542,7 @@ export interface FileRoutesById {
   '/_authed/backups/': typeof AuthedBackupsIndexRoute
   '/_authed/clients/': typeof AuthedClientsIndexRoute
   '/_authed/email/': typeof AuthedEmailIndexRoute
+  '/_authed/settings/': typeof AuthedSettingsIndexRoute
   '/_authed/sites/': typeof AuthedSitesIndexRoute
   '/_authed/updates/': typeof AuthedUpdatesIndexRoute
   '/_authed/clients/$clientId/members': typeof AuthedClientsClientIdMembersRoute
@@ -560,6 +577,7 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/terms'
     | '/verify-email'
+    | '/settings'
     | '/admin'
     | '/audit'
     | '/migrations'
@@ -587,6 +605,7 @@ export interface FileRouteTypes {
     | '/backups/'
     | '/clients/'
     | '/email/'
+    | '/settings/'
     | '/sites/'
     | '/updates/'
     | '/clients/$clientId/members'
@@ -643,6 +662,7 @@ export interface FileRouteTypes {
     | '/backups'
     | '/clients'
     | '/email'
+    | '/settings'
     | '/sites'
     | '/updates'
     | '/clients/$clientId/members'
@@ -676,6 +696,7 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/terms'
     | '/verify-email'
+    | '/_authed/settings'
     | '/_authed/admin'
     | '/_authed/audit'
     | '/_authed/migrations'
@@ -703,6 +724,7 @@ export interface FileRouteTypes {
     | '/_authed/backups/'
     | '/_authed/clients/'
     | '/_authed/email/'
+    | '/_authed/settings/'
     | '/_authed/sites/'
     | '/_authed/updates/'
     | '/_authed/clients/$clientId/members'
@@ -888,6 +910,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedAdminRouteImport
       parentRoute: typeof AuthedRoute
     }
+    '/_authed/settings': {
+      id: '/_authed/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof AuthedSettingsRouteRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/updates/': {
       id: '/_authed/updates/'
       path: '/updates'
@@ -901,6 +930,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/sites/'
       preLoaderRoute: typeof AuthedSitesIndexRouteImport
       parentRoute: typeof AuthedRoute
+    }
+    '/_authed/settings/': {
+      id: '/_authed/settings/'
+      path: '/'
+      fullPath: '/settings/'
+      preLoaderRoute: typeof AuthedSettingsIndexRouteImport
+      parentRoute: typeof AuthedSettingsRouteRoute
     }
     '/_authed/email/': {
       id: '/_authed/email/'
@@ -946,59 +982,59 @@ declare module '@tanstack/react-router' {
     }
     '/_authed/settings/smtp': {
       id: '/_authed/settings/smtp'
-      path: '/settings/smtp'
+      path: '/smtp'
       fullPath: '/settings/smtp'
       preLoaderRoute: typeof AuthedSettingsSmtpRouteImport
-      parentRoute: typeof AuthedRoute
+      parentRoute: typeof AuthedSettingsRouteRoute
     }
     '/_authed/settings/security': {
       id: '/_authed/settings/security'
-      path: '/settings/security'
+      path: '/security'
       fullPath: '/settings/security'
       preLoaderRoute: typeof AuthedSettingsSecurityRouteImport
-      parentRoute: typeof AuthedRoute
+      parentRoute: typeof AuthedSettingsRouteRoute
     }
     '/_authed/settings/organization': {
       id: '/_authed/settings/organization'
-      path: '/settings/organization'
+      path: '/organization'
       fullPath: '/settings/organization'
       preLoaderRoute: typeof AuthedSettingsOrganizationRouteImport
-      parentRoute: typeof AuthedRoute
+      parentRoute: typeof AuthedSettingsRouteRoute
     }
     '/_authed/settings/members': {
       id: '/_authed/settings/members'
-      path: '/settings/members'
+      path: '/members'
       fullPath: '/settings/members'
       preLoaderRoute: typeof AuthedSettingsMembersRouteImport
-      parentRoute: typeof AuthedRoute
+      parentRoute: typeof AuthedSettingsRouteRoute
     }
     '/_authed/settings/destinations': {
       id: '/_authed/settings/destinations'
-      path: '/settings/destinations'
+      path: '/destinations'
       fullPath: '/settings/destinations'
       preLoaderRoute: typeof AuthedSettingsDestinationsRouteImport
-      parentRoute: typeof AuthedRoute
+      parentRoute: typeof AuthedSettingsRouteRoute
     }
     '/_authed/settings/api-keys': {
       id: '/_authed/settings/api-keys'
-      path: '/settings/api-keys'
+      path: '/api-keys'
       fullPath: '/settings/api-keys'
       preLoaderRoute: typeof AuthedSettingsApiKeysRouteImport
-      parentRoute: typeof AuthedRoute
+      parentRoute: typeof AuthedSettingsRouteRoute
     }
     '/_authed/settings/alerts': {
       id: '/_authed/settings/alerts'
-      path: '/settings/alerts'
+      path: '/alerts'
       fullPath: '/settings/alerts'
       preLoaderRoute: typeof AuthedSettingsAlertsRouteImport
-      parentRoute: typeof AuthedRoute
+      parentRoute: typeof AuthedSettingsRouteRoute
     }
     '/_authed/settings/account': {
       id: '/_authed/settings/account'
-      path: '/settings/account'
+      path: '/account'
       fullPath: '/settings/account'
       preLoaderRoute: typeof AuthedSettingsAccountRouteImport
-      parentRoute: typeof AuthedRoute
+      parentRoute: typeof AuthedSettingsRouteRoute
     }
     '/_authed/schedule-runs/$runId': {
       id: '/_authed/schedule-runs/$runId'
@@ -1166,6 +1202,33 @@ const PortalRouteRouteWithChildren = PortalRouteRoute._addFileChildren(
   PortalRouteRouteChildren,
 )
 
+interface AuthedSettingsRouteRouteChildren {
+  AuthedSettingsAccountRoute: typeof AuthedSettingsAccountRoute
+  AuthedSettingsAlertsRoute: typeof AuthedSettingsAlertsRoute
+  AuthedSettingsApiKeysRoute: typeof AuthedSettingsApiKeysRoute
+  AuthedSettingsDestinationsRoute: typeof AuthedSettingsDestinationsRoute
+  AuthedSettingsMembersRoute: typeof AuthedSettingsMembersRoute
+  AuthedSettingsOrganizationRoute: typeof AuthedSettingsOrganizationRoute
+  AuthedSettingsSecurityRoute: typeof AuthedSettingsSecurityRoute
+  AuthedSettingsSmtpRoute: typeof AuthedSettingsSmtpRoute
+  AuthedSettingsIndexRoute: typeof AuthedSettingsIndexRoute
+}
+
+const AuthedSettingsRouteRouteChildren: AuthedSettingsRouteRouteChildren = {
+  AuthedSettingsAccountRoute: AuthedSettingsAccountRoute,
+  AuthedSettingsAlertsRoute: AuthedSettingsAlertsRoute,
+  AuthedSettingsApiKeysRoute: AuthedSettingsApiKeysRoute,
+  AuthedSettingsDestinationsRoute: AuthedSettingsDestinationsRoute,
+  AuthedSettingsMembersRoute: AuthedSettingsMembersRoute,
+  AuthedSettingsOrganizationRoute: AuthedSettingsOrganizationRoute,
+  AuthedSettingsSecurityRoute: AuthedSettingsSecurityRoute,
+  AuthedSettingsSmtpRoute: AuthedSettingsSmtpRoute,
+  AuthedSettingsIndexRoute: AuthedSettingsIndexRoute,
+}
+
+const AuthedSettingsRouteRouteWithChildren =
+  AuthedSettingsRouteRoute._addFileChildren(AuthedSettingsRouteRouteChildren)
+
 interface AuthedClientsClientIdRouteChildren {
   AuthedClientsClientIdMembersRoute: typeof AuthedClientsClientIdMembersRoute
   AuthedClientsClientIdReportsRoute: typeof AuthedClientsClientIdReportsRoute
@@ -1221,6 +1284,7 @@ const AuthedSitesSiteIdRouteWithChildren =
   AuthedSitesSiteIdRoute._addFileChildren(AuthedSitesSiteIdRouteChildren)
 
 interface AuthedRouteChildren {
+  AuthedSettingsRouteRoute: typeof AuthedSettingsRouteRouteWithChildren
   AuthedAdminRoute: typeof AuthedAdminRoute
   AuthedAuditRoute: typeof AuthedAuditRoute
   AuthedMigrationsRoute: typeof AuthedMigrationsRoute
@@ -1232,14 +1296,6 @@ interface AuthedRouteChildren {
   AuthedClientsClientIdRoute: typeof AuthedClientsClientIdRouteWithChildren
   AuthedRestoresRestoreIdRoute: typeof AuthedRestoresRestoreIdRoute
   AuthedScheduleRunsRunIdRoute: typeof AuthedScheduleRunsRunIdRoute
-  AuthedSettingsAccountRoute: typeof AuthedSettingsAccountRoute
-  AuthedSettingsAlertsRoute: typeof AuthedSettingsAlertsRoute
-  AuthedSettingsApiKeysRoute: typeof AuthedSettingsApiKeysRoute
-  AuthedSettingsDestinationsRoute: typeof AuthedSettingsDestinationsRoute
-  AuthedSettingsMembersRoute: typeof AuthedSettingsMembersRoute
-  AuthedSettingsOrganizationRoute: typeof AuthedSettingsOrganizationRoute
-  AuthedSettingsSecurityRoute: typeof AuthedSettingsSecurityRoute
-  AuthedSettingsSmtpRoute: typeof AuthedSettingsSmtpRoute
   AuthedSitesSiteIdRoute: typeof AuthedSitesSiteIdRouteWithChildren
   AuthedUpdatesRunIdRoute: typeof AuthedUpdatesRunIdRoute
   AuthedBackupsIndexRoute: typeof AuthedBackupsIndexRoute
@@ -1250,6 +1306,7 @@ interface AuthedRouteChildren {
 }
 
 const AuthedRouteChildren: AuthedRouteChildren = {
+  AuthedSettingsRouteRoute: AuthedSettingsRouteRouteWithChildren,
   AuthedAdminRoute: AuthedAdminRoute,
   AuthedAuditRoute: AuthedAuditRoute,
   AuthedMigrationsRoute: AuthedMigrationsRoute,
@@ -1261,14 +1318,6 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedClientsClientIdRoute: AuthedClientsClientIdRouteWithChildren,
   AuthedRestoresRestoreIdRoute: AuthedRestoresRestoreIdRoute,
   AuthedScheduleRunsRunIdRoute: AuthedScheduleRunsRunIdRoute,
-  AuthedSettingsAccountRoute: AuthedSettingsAccountRoute,
-  AuthedSettingsAlertsRoute: AuthedSettingsAlertsRoute,
-  AuthedSettingsApiKeysRoute: AuthedSettingsApiKeysRoute,
-  AuthedSettingsDestinationsRoute: AuthedSettingsDestinationsRoute,
-  AuthedSettingsMembersRoute: AuthedSettingsMembersRoute,
-  AuthedSettingsOrganizationRoute: AuthedSettingsOrganizationRoute,
-  AuthedSettingsSecurityRoute: AuthedSettingsSecurityRoute,
-  AuthedSettingsSmtpRoute: AuthedSettingsSmtpRoute,
   AuthedSitesSiteIdRoute: AuthedSitesSiteIdRouteWithChildren,
   AuthedUpdatesRunIdRoute: AuthedUpdatesRunIdRoute,
   AuthedBackupsIndexRoute: AuthedBackupsIndexRoute,

--- a/apps/web/src/routes/_authed/alerts.tsx
+++ b/apps/web/src/routes/_authed/alerts.tsx
@@ -8,7 +8,7 @@ import { AlertConfigForm } from "@/features/monitoring/alert-config-form";
 // alerts per-tenant. Needs an ogen regen once the backend route is wired.
 // Do not add it here until the OpenAPI spec is updated.
 
-export const Route = createFileRoute("/_authed/settings/alerts")({
+export const Route = createFileRoute("/_authed/alerts")({
   component: AlertSettingsPage,
 });
 

--- a/apps/web/src/routes/_authed/destinations.tsx
+++ b/apps/web/src/routes/_authed/destinations.tsx
@@ -14,7 +14,7 @@ import { useMe, canOperate } from "@/features/auth/use-auth";
 import { useSites } from "@/features/sites/use-sites";
 import { DestinationsList } from "@/features/destinations/destinations-list";
 
-export const Route = createFileRoute("/_authed/settings/destinations")({
+export const Route = createFileRoute("/_authed/destinations")({
   component: DestinationsSettingsPage,
 });
 

--- a/apps/web/src/routes/_authed/settings/index.tsx
+++ b/apps/web/src/routes/_authed/settings/index.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+// Redirect /settings → /settings/account so visiting the settings area root
+// always lands on a concrete section. The layout route (route.tsx) owns the
+// side-menu shell; this file just ensures the default child is Account.
+export const Route = createFileRoute("/_authed/settings/")({
+  beforeLoad: () => {
+    throw redirect({ to: "/settings/account" });
+  },
+});

--- a/apps/web/src/routes/_authed/settings/route.tsx
+++ b/apps/web/src/routes/_authed/settings/route.tsx
@@ -1,0 +1,141 @@
+import { createFileRoute, Link, Outlet, useLocation } from "@tanstack/react-router";
+import {
+  Bell,
+  Building2,
+  HardDrive,
+  KeyRound,
+  Mail,
+  ShieldCheck,
+  User,
+  Users,
+  type LucideIcon,
+} from "lucide-react";
+
+import { useMe, isOrgScoped } from "@/features/auth/use-auth";
+import { cn } from "@/lib/utils";
+
+export const Route = createFileRoute("/_authed/settings")({
+  component: SettingsLayout,
+});
+
+// ---------------------------------------------------------------------------
+// Nav item definitions — single source of truth for every settings section.
+// ---------------------------------------------------------------------------
+
+interface SettingsNavItem {
+  label: string;
+  to: string;
+  icon: LucideIcon;
+  /** When true, only org-scoped members see this item. */
+  orgOnly?: boolean;
+}
+
+export const SETTINGS_NAV_ITEMS: SettingsNavItem[] = [
+  { label: "Account",       to: "/settings/account",      icon: User },
+  { label: "Security",      to: "/settings/security",     icon: ShieldCheck,  orgOnly: true },
+  { label: "Organisation",  to: "/settings/organization", icon: Building2,    orgOnly: true },
+  { label: "API keys",      to: "/settings/api-keys",     icon: KeyRound,     orgOnly: true },
+  { label: "Destinations",  to: "/settings/destinations", icon: HardDrive,    orgOnly: true },
+  { label: "Email / SMTP",  to: "/settings/smtp",         icon: Mail,         orgOnly: true },
+  { label: "Alerts",        to: "/settings/alerts",       icon: Bell,         orgOnly: true },
+  { label: "Members",       to: "/settings/members",      icon: Users,        orgOnly: true },
+];
+
+// ---------------------------------------------------------------------------
+// Route component
+// ---------------------------------------------------------------------------
+
+function SettingsLayout() {
+  const { data: me } = useMe();
+  const orgScoped = isOrgScoped(me);
+  const location = useLocation();
+  const pathname = location.pathname;
+
+  // Site-scoped collaborators only see Account.
+  const visibleItems = SETTINGS_NAV_ITEMS.filter(
+    (item) => !item.orgOnly || orgScoped,
+  );
+
+  return (
+    // Constrain the entire settings area to a sensible max width so text
+    // columns stay readable on wide screens.
+    <div className="mx-auto w-full max-w-5xl">
+      {/*
+        Two layouts:
+        - Mobile (<md): stacked — horizontal scrollable strip then content below.
+        - Desktop (>=md): side-by-side — ~210px left nav column + flex-1 content.
+      */}
+      <div className="flex flex-col gap-6 md:flex-row md:gap-10">
+        {/* ------------------------------------------------------------------ */}
+        {/* Settings navigation                                                  */}
+        {/* ------------------------------------------------------------------ */}
+        <nav
+          aria-label="Settings"
+          // On mobile: horizontal scroll strip. On desktop: vertical column
+          // with a fixed width.
+          className={cn(
+            // Mobile: full-width horizontal strip (overflow-x-auto, no wrap).
+            "flex flex-row gap-1 overflow-x-auto pb-1",
+            "md:w-[210px] md:shrink-0 md:flex-col md:overflow-x-visible md:pb-0",
+          )}
+        >
+          {/* Compact "Settings" eyebrow label — only visible in the desktop
+              column. Hidden on mobile because screen space is tight. */}
+          <p
+            aria-hidden="true"
+            className="hidden select-none px-3 pb-1 text-xs font-medium uppercase tracking-[0.06em] text-muted-foreground md:block"
+          >
+            Settings
+          </p>
+
+          {visibleItems.map((item) => {
+            // A route is active when the pathname matches it exactly or starts
+            // with its path (handles future sub-routes).
+            const active =
+              pathname === item.to || pathname.startsWith(`${item.to}/`);
+            const Icon = item.icon;
+
+            return (
+              <Link
+                key={item.to}
+                // Cast to a registered path. The settings sub-routes are all
+                // registered through the file-based router; this avoids
+                // widening to `string`.
+                to={item.to as "/settings/account"}
+                aria-current={active ? "page" : undefined}
+                className={cn(
+                  // Base: flex row, icon + label, rounded, sized to content on
+                  // mobile (min-w-max prevents label wrapping in the scroll
+                  // strip), full-width on desktop.
+                  "relative flex min-w-max items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                  // The sanctioned active row visual: accent background + a 2px
+                  // primary rail. In the mobile horizontal strip the rail reads
+                  // as an underline (border-b); in the desktop column it's the
+                  // established left rail (border-l). Inactive: muted hover.
+                  "border-b-2 md:border-b-0 md:border-l-2",
+                  active
+                    ? "border-primary bg-accent text-accent-foreground"
+                    : "border-transparent text-foreground hover:bg-muted/50",
+                  // On mobile the items are inline; the full-width style only
+                  // makes sense in the desktop column.
+                  "md:w-full md:min-w-0",
+                )}
+              >
+                <Icon aria-hidden="true" className="size-4 shrink-0" />
+                <span className="truncate">{item.label}</span>
+              </Link>
+            );
+          })}
+        </nav>
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Page content rendered by the matched child route                    */}
+        {/* ------------------------------------------------------------------ */}
+        <main className="min-w-0 flex-1">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/_authed/settings/route.tsx
+++ b/apps/web/src/routes/_authed/settings/route.tsx
@@ -1,8 +1,6 @@
 import { createFileRoute, Link, Outlet, useLocation } from "@tanstack/react-router";
 import {
-  Bell,
   Building2,
-  HardDrive,
   KeyRound,
   Mail,
   ShieldCheck,
@@ -35,9 +33,7 @@ export const SETTINGS_NAV_ITEMS: SettingsNavItem[] = [
   { label: "Security",      to: "/settings/security",     icon: ShieldCheck,  orgOnly: true },
   { label: "Organisation",  to: "/settings/organization", icon: Building2,    orgOnly: true },
   { label: "API keys",      to: "/settings/api-keys",     icon: KeyRound,     orgOnly: true },
-  { label: "Destinations",  to: "/settings/destinations", icon: HardDrive,    orgOnly: true },
   { label: "Email / SMTP",  to: "/settings/smtp",         icon: Mail,         orgOnly: true },
-  { label: "Alerts",        to: "/settings/alerts",       icon: Bell,         orgOnly: true },
   { label: "Members",       to: "/settings/members",      icon: Users,        orgOnly: true },
 ];
 

--- a/docs/adr/ADR-037-wpmgr-feature-parity-roadmap.md
+++ b/docs/adr/ADR-037-wpmgr-feature-parity-roadmap.md
@@ -251,5 +251,5 @@ Diagnostic + fix is the next priority. ADR-037 implementation starts only after 
 - `blobstore.Registry` per-destination Store cache
 - age-encrypted secret storage
 - Migration `m7_site_destinations.sql` with RLS + partial unique index for `is_default`
-- New `/settings/destinations` route + per-provider form + test-connection (HeadBucket + PutObject + DeleteObject)
+- New `/destinations` route (under Operations, next to Backups) + per-provider form + test-connection (HeadBucket + PutObject + DeleteObject); moved out of Settings in 0.51.1
 - Sensitive-credential UX: `••••••••` placeholder + "Re-enter to save" amber warning

--- a/docs/adr/ADR-045-alert-channels-design.md
+++ b/docs/adr/ADR-045-alert-channels-design.md
@@ -20,7 +20,7 @@ Supersedes: nothing. Generalizes the M5/ADR-037 single-config, two-channel alert
 - Per-org (tenant) scoping under existing RLS, RBAC-gated, honoring site-scoped collaborators.
 - "Test fire" affordance reusing the real delivery path.
 - SSRF-hardened egress for user-supplied Telegram/Slack/webhook destinations.
-- Extend `/settings/alerts`, not a parallel UI.
+- Extend `/alerts` (under Insights, next to Uptime), not a parallel UI. (Originally drafted as `/settings/alerts`; moved out of Settings in 0.51.1.)
 
 **Non-goals (explicitly out of scope vs. Alertmanager)**
 - No recursive routing tree, no `continue`/match_re label matching engine.
@@ -41,7 +41,7 @@ The codebase already has the embryo of this system. The design reuses every seam
 | `uptime.Dispatcher` (`internal/uptime/alerts.go`) | Single fan-out point: `Fire()` (uptime down/recovery), `FireSecurityEvent()` (activity high-sev) | Becomes the **evaluator + fan-out over N channels**. Keep it as the only fan-out point; it loops over a tenant's matched channels instead of two hard-coded fields. |
 | `Mailer` / `WebhookPoster` interfaces (`internal/uptime/notify.go`) | `SMTPMailer`/`NoopMailer`, `SSRFWebhookPoster` (HMAC-SHA256, `X-WPMgr-Signature`) | Become two `Channel` implementations. The SMTP mailer and the SSRF webhook poster are reused verbatim under the new interface. |
 | `activity.SecurityAlerter` seam + `siteadapter.go` adapter | Activity ingest calls `NotifySecurity()` after tx commit | Stays as a seam, but the adapter now writes an `alert_event` (`event_type=security.<type>`) rather than calling `FireSecurityEvent` inline. Every NEW source (backup, scan, login-protection, php-error) gets the same thin adapter — no source package imports `uptime`. |
-| `/settings/alerts` (`apps/web/.../alerts.tsx`, `alert-config-form.tsx`) | Email recipients textarea + webhook URL only | Reframed into a multi-channel, multi-rule, delivery-log UI under a new `features/alerts` area. |
+| `/alerts` (`apps/web/.../alerts.tsx`, `alert-config-form.tsx`) | Email recipients textarea + webhook URL only | Reframed into a multi-channel, multi-rule, delivery-log UI under a new `features/alerts` area. Route moved from `/settings/alerts` to `/alerts` (Insights group) in 0.51.1. |
 | OpenAPI `/api/v1/alert-config` (`packages/openapi/openapi.yaml`) | `AlertConfig`/`AlertConfigUpdate` | Add `/api/v1/alert-channels`, `/alert-rules`, `/alert-deliveries`, `/alert-channels/{id}/test`. Regen ogen + hey-api per the codegen pipeline. |
 | `httpclient` (`internal/httpclient/httpclient.go`) | SSRF-hardened `*http.Client`, dial-time IP pinning via `code.dny.dev/ssrf`, `Do`/`DoOnce`, `IsSSRFBlocked` | The egress client for ALL channel sends. No new SSRF code. |
 | age-at-rest (`internal/sitedestination/service.go`, `AgeIdentity`) | `Encrypt/Decrypt` X25519, `*_enc bytea` columns | The secret-at-rest pattern for bot tokens / Slack tokens-or-URLs / webhook signing secrets. Extract `AgeIdentity` into a shared `internal/cryptbox` package so both `sitedestination` and `alerts` depend on it. |
@@ -276,16 +276,16 @@ The generic webhook URL is fully attacker-influenced; treat it as untrusted even
 
 ---
 
-## 10. UI — extend `/settings/alerts`
+## 10. UI — extend `/alerts`
 
-Relocate alert config from `features/monitoring` (uptime-coupled, page copy is "downtime alerts" only) into a new `features/alerts` area; reframe the page from uptime-only to **multi-channel, multi-event routing**. Follow existing settings conventions (PageHeader + shadcn Cards, rhf + zod + `zodResolver` cast where coerce/optional is used, `FormSection`/`FieldError`/`StickySaveBar`, `toast.*`, role gating via `canManage(me)`).
+Relocate alert config from `features/monitoring` (uptime-coupled, page copy is "downtime alerts" only) into a new `features/alerts` area; reframe the page from uptime-only to **multi-channel, multi-event routing**. Follow existing settings conventions (PageHeader + shadcn Cards, rhf + zod + `zodResolver` cast where coerce/optional is used, `FormSection`/`FieldError`/`StickySaveBar`, `toast.*`, role gating via `canManage(me)`). The route lives at `/alerts` under the Insights sidebar group (moved from `/settings/alerts` in 0.51.1).
 
-**`/settings/alerts` becomes three sections (Cards):**
+**`/alerts` becomes three sections (Cards):**
 1. **Channels** — table of `alert_channels` (type icon, name, redacted hint, `verified_at`, enabled toggle). Create/edit dialog per type with type-specific fields (§4.1). Secret fields are write-only with a masked placeholder ("•••• leave blank to keep"). A **"Send test"** button per channel hits the test endpoint and toasts the scrubbed result. Empty state prompts adding the first channel; the legacy backfilled email/webhook channels appear here automatically.
 2. **Rules** — list of `alert_rules` ordered by priority. Editor: name, event-type multiselect (grouped by domain: activity/security/logs/uptime/backup), `min_severity` select, scope (all sites / pick sites — site picker filtered by `canReadSite`), channel multiselect, throttle, optional digest window. A live **"this rule would notify: Slack + Email"** preview (the O(rules) routing is cheap to evaluate client-or-server-side).
 3. **Delivery log** — paginated `alert_deliveries` (event, channel, status badge `sent/failed/throttled/digested`, response code, time), with a manual re-send action and `is_test` filter. Gated like the activity log (bodies can contain sensitive detail).
 
-Sidebar/nav: keep the single `Alerts → /settings/alerts` entry. The page header copy changes from "Configure how this tenant is notified when monitored sites go down" to multi-event framing. New endpoints either get added to OpenAPI (regen ogen + `pnpm -C packages/openapi-client generate`) or use the hand-rolled raw-`client` hook pattern; new feature hooks live in `src/features/alerts/use-alerts.ts` mirroring `use-api-keys.ts`.
+Sidebar/nav: a single `Alerts → /alerts` entry under the Insights group (next to Uptime). The page header copy changes from "Configure how this tenant is notified when monitored sites go down" to multi-event framing. New endpoints either get added to OpenAPI (regen ogen + `pnpm -C packages/openapi-client generate`) or use the hand-rolled raw-`client` hook pattern; new feature hooks live in `src/features/alerts/use-alerts.ts` mirroring `use-api-keys.ts`.
 
 ---
 

--- a/docs/adr/ADR-045-email-auth-alerts.md
+++ b/docs/adr/ADR-045-email-auth-alerts.md
@@ -499,7 +499,7 @@ Admin invites a teammate by email → invitee receives a branded link, sets thei
 ### Phase 4 — Alert channels (LATER, m33+)
 
 **Deliverables (not built in 1–3)**
-`alert_channels`/`alert_rules`/`alert_deliveries` (+`alert_events`/`alert_state`) tables with dual RLS; `Channel` interface (Email/Webhook/Slack/Telegram) with per-channel render; `NotificationService` fan-out via River `alert_dispatch` jobs; secrets age-encrypted in `*_enc`; webhook egress via `httpclient` (SSRF) + HMAC signing; per-channel test-send + delivery log; backfill `alert_configs` → channels; wire `notify_security` end-to-end (fix `putAlertConfig` + OpenAPI + UI toggle) as the first proof; reframe `/settings/alerts` UI to multi-channel/multi-event.
+`alert_channels`/`alert_rules`/`alert_deliveries` (+`alert_events`/`alert_state`) tables with dual RLS; `Channel` interface (Email/Webhook/Slack/Telegram) with per-channel render; `NotificationService` fan-out via River `alert_dispatch` jobs; secrets age-encrypted in `*_enc`; webhook egress via `httpclient` (SSRF) + HMAC signing; per-channel test-send + delivery log; backfill `alert_configs` → channels; wire `notify_security` end-to-end (fix `putAlertConfig` + OpenAPI + UI toggle) as the first proof; reframe `/alerts` UI to multi-channel/multi-event (route moved from `/settings/alerts` to `/alerts` under Insights in 0.51.1; see ADR-045-alert-channels-design.md §10).
 
 **Definition of done**
 A tenant configures multiple channels + rules; events fan out durably with dedup/throttle, per-channel retry, and a delivery log; test-send validates each channel; webhook SSRF-guarded + signed; existing uptime/security alerts migrated with zero regression.

--- a/docs/adr/ADR-045-email-templates.md
+++ b/docs/adr/ADR-045-email-templates.md
@@ -710,7 +710,7 @@ In the templates below the shared boilerplate is written out **in full inside ea
         </td></tr>
 
         <tr><td class="px" style="padding:18px 40px 32px 40px;">
-          <p class="muted" style="margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;line-height:1.6;color:#6B7280;">You're receiving this because alert notifications are enabled for {{.OrgName}}. Manage alerts in <a href="{{.AlertSettingsURL}}" style="color:#0E7C8B;text-decoration:underline;">Settings → Alerts</a>.</p>
+          <p class="muted" style="margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;line-height:1.6;color:#6B7280;">You're receiving this because alert notifications are enabled for {{.OrgName}}. Manage alerts in <a href="{{.AlertSettingsURL}}" style="color:#0E7C8B;text-decoration:underline;">Alerts</a>.</p>
         </td></tr>
 
         <tr><td class="px hair" style="padding:24px 40px 28px 40px;border-top:1px solid #D8E2E1;">


### PR DESCRIPTION
Web-only dashboard UX, already live in prod (web 0.51.1) and being released as OSS v0.51.1.

## 0.51.0 — Dedicated Settings area + collapsible sidebar
- Real `/settings` layout with a left side-menu (Account, Security, Organisation, API keys, Email/SMTP, Members); `/settings` redirects to Account. Mobile: horizontal scroll strip.
- Main sidebar groups (Operations, Insights, Security) are now collapsible: default collapsed, the active group auto-expands, manual toggles persisted to localStorage.
- The 8 settings links collapsed into a single "Settings" sidebar entry.

## 0.51.1 — Information architecture fix
- **Destinations** (backup storage targets) moved out of Settings to `/destinations`, under Operations next to Backups.
- **Alerts** (downtime notifications) moved out of Settings to `/alerts`, under Insights next to Uptime.
- Route paths moved (not just labels) so they render full-width, not wrapped in the Settings side-menu.

## Verification
tsc clean, workspace lint 0 errors, 207/207 web unit tests, vite build (route tree regenerated). Reviewed for a11y (collapsible aria, reduced-motion), responsive, and design-system consistency.

No control-plane, migration, or agent change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)