### PR TITLE
fix(api): scheduled backups re-fire every ~5min (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+### Fixed
+
+- **Scheduled backups no longer re-fire every few minutes.** A schedule whose next-run time had slipped into the past (most often after being disabled and re-enabled) was re-triggered on every scheduler tick, producing many runs per night, overlapping runs, and a daily incremental chain climbing several generations in one night. Re-enabling or an already-overdue schedule now advances to the next future run slot; the scheduler claims and advances each due schedule in a single atomic step; only one backup per site can be in flight at a time; and any schedules already stuck in the past are healed automatically on startup. (#68)
+
 ## [0.51.2] - 2026-06-19
 
 ### Changed

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -524,6 +524,7 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 		restoreWorker = backup.NewRestoreWorker(backupSvc, backupCmd, auditRec, logger, cpBaseURL, backupJobTimeout)
 		gcWorker = backup.NewGCWorker(backupSvc, logger)
 		scheduleWorker = backup.NewScheduleWorker(backupSvc, logger)
+		scheduleWorker.SetPool(pool)
 		// M5.6 progress watchdog: 120s stall threshold (longest natural silent
 		// gap in the phpbu pipeline is age-encrypt for a multi-GB site).
 		progressWatchdog = backup.NewProgressWatchdogWorker(backupSvc, 120*time.Second, logger)
@@ -1246,6 +1247,12 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	siteH.SetRecheckLimiter(recheckLimiter)
 	if backupSvc != nil {
 		backupSvc.SetEnqueuer(backup.NewRiverEnqueuer(riverClient))
+		// Issue #68 — data-heal: run once at boot (non-blocking) to
+		// (a) reconcile duplicate in-flight snapshots so the partial-unique index
+		//     applied by migration m75 finds no conflicting rows, and
+		// (b) advance any overdue enabled schedules to their next future slot so
+		//     the scheduler does not immediately fire stale rows on the first tick.
+		go backupSvc.HealOverdueSchedulesAndSnapshots(context.Background(), logger)
 	}
 
 	// S3 scan: wire the River enqueuer into the service + worker now that River
@@ -2223,7 +2230,20 @@ func startRiver(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger, d 
 		periodics = append(periodics,
 			river.NewPeriodicJob(
 				river.PeriodicInterval(schedInterval),
-				func() (river.JobArgs, *river.InsertOpts) { return backup.ScheduleArgs{}, nil },
+				func() (river.JobArgs, *river.InsertOpts) {
+					return backup.ScheduleArgs{}, &river.InsertOpts{
+						// Deduplicate: at most one pending/running backup_scheduler job
+						// at a time across all CP instances. ByArgs keys on the (empty)
+						// ScheduleArgs JSON {}; ByPeriod caps one per schedInterval window.
+						// This prevents RunOnStart from enqueuing a second job while the
+						// previous tick is still running, and prevents rolling-deploy
+						// double-fires.
+						UniqueOpts: river.UniqueOpts{
+							ByArgs:   true,
+							ByPeriod: schedInterval,
+						},
+					}
+				},
 				&river.PeriodicJobOpts{RunOnStart: true},
 			),
 			river.NewPeriodicJob(

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -630,6 +630,11 @@ CREATE INDEX backup_snapshots_chain_gen_idx ON backup_snapshots (chain_id, gener
 -- m49: index for the GC locked-pin check.
 CREATE INDEX backup_snapshots_locked_idx ON backup_snapshots (tenant_id, locked)
     WHERE locked = true;
+-- m75 (issue #68): belt-and-suspenders guard against duplicate in-flight backups.
+-- At most one pending-or-running snapshot per site at a time. Partial so
+-- completed/failed rows are unconstrained and retention GC is unaffected.
+CREATE UNIQUE INDEX backup_snapshots_one_inflight_per_site ON backup_snapshots (site_id)
+    WHERE status IN ('pending', 'running');
 
 ALTER TABLE backup_snapshots ENABLE ROW LEVEL SECURITY;
 ALTER TABLE backup_snapshots FORCE ROW LEVEL SECURITY;

--- a/apps/api/internal/backup/fleet_security_test.go
+++ b/apps/api/internal/backup/fleet_security_test.go
@@ -160,6 +160,18 @@ func (r *secFleetRepo) StreamChainEffectiveFileIndex(_ context.Context, _, _ uui
 func (r *secFleetRepo) UpdateSnapshotCycleStats(_ context.Context, _, _ uuid.UUID, _ CycleStatsInput) error {
 	panic("secFleetRepo.UpdateSnapshotCycleStats not implemented")
 }
+func (r *secFleetRepo) ClaimAndAdvanceDueSchedules(_ context.Context, _ time.Time, _ map[uuid.UUID]time.Time) ([]Schedule, error) {
+	panic("secFleetRepo.ClaimAndAdvanceDueSchedules not implemented")
+}
+func (r *secFleetRepo) CountInFlightSnapshots(_ context.Context, _, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+func (r *secFleetRepo) HealOverdueSchedules(_ context.Context, _ time.Time, _ func(Schedule, time.Time) time.Time) (int, error) {
+	return 0, nil
+}
+func (r *secFleetRepo) ReconcileDuplicateInflightSnapshots(_ context.Context) (int, error) {
+	return 0, nil
+}
 
 // compile-time interface check.
 var _ Repo = (*secFleetRepo)(nil)

--- a/apps/api/internal/backup/gc_mark_sweep_test.go
+++ b/apps/api/internal/backup/gc_mark_sweep_test.go
@@ -353,6 +353,18 @@ func (r *gcFakeRepo) FleetListSnapshots(_ context.Context, _ db.ScopedPrincipal,
 func (r *gcFakeRepo) FleetBackupHealth(_ context.Context, _ db.ScopedPrincipal, _ uuid.UUID, _ []uuid.UUID) ([]FleetBackupHealthItem, error) {
 	panic("gcFakeRepo.FleetBackupHealth not implemented")
 }
+func (r *gcFakeRepo) ClaimAndAdvanceDueSchedules(_ context.Context, _ time.Time, _ map[uuid.UUID]time.Time) ([]Schedule, error) {
+	panic("gcFakeRepo.ClaimAndAdvanceDueSchedules not implemented")
+}
+func (r *gcFakeRepo) CountInFlightSnapshots(_ context.Context, _, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+func (r *gcFakeRepo) HealOverdueSchedules(_ context.Context, _ time.Time, _ func(Schedule, time.Time) time.Time) (int, error) {
+	return 0, nil
+}
+func (r *gcFakeRepo) ReconcileDuplicateInflightSnapshots(_ context.Context) (int, error) {
+	return 0, nil
+}
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/apps/api/internal/backup/incremental_service_test.go
+++ b/apps/api/internal/backup/incremental_service_test.go
@@ -270,6 +270,18 @@ func (r *fakeRepo) FleetListSnapshots(_ context.Context, _ db.ScopedPrincipal, _
 func (r *fakeRepo) FleetBackupHealth(_ context.Context, _ db.ScopedPrincipal, _ uuid.UUID, _ []uuid.UUID) ([]FleetBackupHealthItem, error) {
 	panic("fakeRepo.FleetBackupHealth not implemented")
 }
+func (r *fakeRepo) ClaimAndAdvanceDueSchedules(_ context.Context, _ time.Time, _ map[uuid.UUID]time.Time) ([]Schedule, error) {
+	panic("fakeRepo.ClaimAndAdvanceDueSchedules not implemented")
+}
+func (r *fakeRepo) CountInFlightSnapshots(_ context.Context, _, _ uuid.UUID) (int64, error) {
+	return 0, nil // default: no in-flight snapshots
+}
+func (r *fakeRepo) HealOverdueSchedules(_ context.Context, _ time.Time, _ func(Schedule, time.Time) time.Time) (int, error) {
+	return 0, nil
+}
+func (r *fakeRepo) ReconcileDuplicateInflightSnapshots(_ context.Context) (int, error) {
+	return 0, nil
+}
 
 // ---------------------------------------------------------------------------
 // fakeClock — deterministic clock for tests.

--- a/apps/api/internal/backup/repo.go
+++ b/apps/api/internal/backup/repo.go
@@ -8,12 +8,22 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
+
+// isUniqueViolation reports whether err is a Postgres UNIQUE constraint
+// violation (SQLSTATE 23505). Used to treat a partial-unique-index collision on
+// backup_snapshots(site_id) WHERE status IN ('pending','running') as an
+// already-in-flight signal rather than a hard error.
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
 
 // Repo is the tenant-scoped persistence for backup snapshots/manifests/chunks/
 // schedules, plus the cross-tenant scheduler enumeration. Every tenant-scoped
@@ -74,12 +84,36 @@ type Repo interface {
 	// ListDueSchedules enumerates enabled, due schedules across ALL tenants for
 	// the periodic scheduler (cross-tenant, under app.agent).
 	ListDueSchedules(ctx context.Context, now time.Time, limit int32) ([]Schedule, error)
+	// ClaimAndAdvanceDueSchedules atomically selects enabled, due schedules with
+	// FOR UPDATE SKIP LOCKED, advances each one's next_run_at to the supplied
+	// nextAt values, and returns the fired slots — all in a single agent transaction.
+	// The caller supplies a map from schedule ID to the already-computed next time
+	// (tz/jitter math stays in Go). Only schedules whose advance succeeded are
+	// returned: a row that cannot be locked (already held by another scheduler pass)
+	// is silently skipped, preventing duplicate fires across concurrent CP instances
+	// and RunOnStart re-fires.
+	ClaimAndAdvanceDueSchedules(ctx context.Context, now time.Time, nextAt map[uuid.UUID]time.Time) ([]Schedule, error)
 	// ListTenantsForGC enumerates tenants with completed snapshots across ALL
 	// tenants for the periodic retention GC (cross-tenant, under app.agent).
 	ListTenantsForGC(ctx context.Context) ([]uuid.UUID, error)
 	// AdvanceScheduleRun records an enqueued scheduled backup and advances
 	// next_run_at, tenant-scoped.
 	AdvanceScheduleRun(ctx context.Context, tenantID, scheduleID uuid.UUID, next time.Time) error
+	// CountInFlightSnapshots returns the count of pending/running snapshots for
+	// (tenantID, siteID). Used as a belt-and-suspenders guard before CreateSnapshot
+	// to skip duplicate fires that slip past the partial-unique index. Tenant-scoped.
+	CountInFlightSnapshots(ctx context.Context, tenantID, siteID uuid.UUID) (int64, error)
+	// HealOverdueSchedules advances every enabled schedule whose next_run_at is
+	// already <= now to the next future occurrence, using per-site tz/jitter math.
+	// Implemented as a Go loop over raw schedule rows (not a bulk SQL update) so
+	// nextOccurrence can apply DST-aware per-site timezone math. Cross-tenant —
+	// runs under app.agent. Called once at boot before the scheduler starts.
+	HealOverdueSchedules(ctx context.Context, now time.Time, compute func(sched Schedule, now time.Time) time.Time) (int, error)
+	// ReconcileDuplicateInflightSnapshots marks the older of any duplicate
+	// pending/running snapshots for the same site as failed with the reason
+	// "duplicate_in_flight_healed". Called once at boot before the partial-unique
+	// index migration is applied (or at migration time via Go boot task).
+	ReconcileDuplicateInflightSnapshots(ctx context.Context) (int, error)
 
 	// SetSnapshotLocked sets the locked flag on a snapshot (Track C, m49). When
 	// locked=true the retention GC will never auto-prune the snapshot; the
@@ -826,6 +860,7 @@ DO UPDATE SET
     enabled               = EXCLUDED.enabled,
     retention_days        = EXCLUDED.retention_days,
     monthly_archive_keep  = EXCLUDED.monthly_archive_keep,
+    next_run_at           = EXCLUDED.next_run_at,
     run_hour              = EXCLUDED.run_hour,
     run_minute            = EXCLUDED.run_minute,
     day_of_week           = EXCLUDED.day_of_week,
@@ -2199,4 +2234,192 @@ func (r *pgRepo) ListChainSnapshots(ctx context.Context, tenantID uuid.UUID, cha
 		return rows.Err()
 	})
 	return out, err
+}
+
+// ----------------------------------------------------------------------------
+// Scheduler: atomic claim-and-advance, in-flight guard, heal helpers (issue #68)
+// ----------------------------------------------------------------------------
+
+// ClaimAndAdvanceDueSchedules atomically claims all due schedules with FOR UPDATE
+// SKIP LOCKED, computes their next occurrence via the caller-supplied nextAt map,
+// advances next_run_at in the SAME transaction, and returns the fired slots. All
+// work runs under app.agent so cross-tenant schedule rows are visible.
+//
+// Schedules for which nextAt has no entry are skipped (the caller must compute
+// nextAt for every candidate before calling). A schedule whose lock is contended
+// (held by another CP instance) is silently skipped — SKIP LOCKED ensures it.
+func (r *pgRepo) ClaimAndAdvanceDueSchedules(ctx context.Context, now time.Time, nextAt map[uuid.UUID]time.Time) ([]Schedule, error) {
+	var out []Schedule
+	err := r.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
+		// 1. Lock all due, enabled rows — skip any already locked by a peer.
+		pgRows, err := tx.Query(ctx,
+			scheduleSelectColumns+` FROM backup_schedules
+			  WHERE enabled = true AND next_run_at <= $1
+			  ORDER BY next_run_at ASC
+			  FOR UPDATE SKIP LOCKED`,
+			now,
+		)
+		if err != nil {
+			return domain.Internal("backup_schedule_claim_failed", "failed to claim due schedules").WithCause(err)
+		}
+		defer pgRows.Close()
+		var candidates []Schedule
+		for pgRows.Next() {
+			s, serr := scanScheduleRow(pgRows)
+			if serr != nil {
+				return domain.Internal("backup_schedule_claim_scan_failed", "failed to scan schedule row").WithCause(serr)
+			}
+			candidates = append(candidates, s)
+		}
+		if err := pgRows.Err(); err != nil {
+			return domain.Internal("backup_schedule_claim_iter_failed", "iterator error claiming schedules").WithCause(err)
+		}
+
+		// 2. For each locked row, advance next_run_at using the pre-computed nextAt.
+		for _, sched := range candidates {
+			next, ok := nextAt[sched.ID]
+			if !ok {
+				// Caller did not supply a nextAt for this schedule: skip without
+				// advancing (it will be re-selected on the next tick).
+				continue
+			}
+			tag, uerr := tx.Exec(ctx,
+				`UPDATE backup_schedules
+				    SET next_run_at = $3, last_run_at = now(), updated_at = now()
+				  WHERE id = $1 AND tenant_id = $2`,
+				sched.ID, sched.TenantID, next,
+			)
+			if uerr != nil {
+				return domain.Internal("backup_schedule_advance_claim_failed", "failed to advance claimed schedule").WithCause(uerr)
+			}
+			if tag.RowsAffected() == 0 {
+				// Row disappeared between SELECT and UPDATE (deleted mid-tx): skip.
+				continue
+			}
+			out = append(out, sched)
+		}
+		return nil
+	})
+	return out, err
+}
+
+func (r *pgRepo) CountInFlightSnapshots(ctx context.Context, tenantID, siteID uuid.UUID) (int64, error) {
+	var count int64
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT count(*)
+			   FROM backup_snapshots
+			  WHERE tenant_id = $1 AND site_id = $2
+			    AND status IN ('pending', 'running')`,
+			tenantID, siteID,
+		).Scan(&count)
+	})
+	return count, err
+}
+
+// HealOverdueSchedules walks all enabled schedules with next_run_at <= now
+// cross-tenant and advances each to the next future occurrence via the caller's
+// compute function (which encapsulates nextOccurrence + per-site tz + jitter).
+// Returns the number of rows healed.
+func (r *pgRepo) HealOverdueSchedules(ctx context.Context, now time.Time, compute func(sched Schedule, now time.Time) time.Time) (int, error) {
+	// Read all overdue enabled schedules cross-tenant.
+	var overdueRows []Schedule
+	if err := r.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
+		pgRows, err := tx.Query(ctx,
+			scheduleSelectColumns+` FROM backup_schedules
+			  WHERE enabled = true AND next_run_at <= $1`,
+			now,
+		)
+		if err != nil {
+			return domain.Internal("backup_schedule_heal_list_failed", "failed to list overdue schedules").WithCause(err)
+		}
+		defer pgRows.Close()
+		for pgRows.Next() {
+			s, serr := scanScheduleRow(pgRows)
+			if serr != nil {
+				return domain.Internal("backup_schedule_heal_scan_failed", "failed to scan overdue schedule").WithCause(serr)
+			}
+			overdueRows = append(overdueRows, s)
+		}
+		return pgRows.Err()
+	}); err != nil {
+		return 0, err
+	}
+
+	healed := 0
+	for _, sched := range overdueRows {
+		next := compute(sched, now)
+		if err := r.pool.InTenantTx(ctx, sched.TenantID, func(tx pgx.Tx) error {
+			_, err := tx.Exec(ctx,
+				`UPDATE backup_schedules
+				    SET next_run_at = $3, updated_at = now()
+				  WHERE id = $1 AND tenant_id = $2 AND enabled = true AND next_run_at <= $4`,
+				sched.ID, sched.TenantID, next, now,
+			)
+			return err
+		}); err != nil {
+			// Log and continue: one site's tz failure must not block the others.
+			continue
+		}
+		healed++
+	}
+	return healed, nil
+}
+
+// ReconcileDuplicateInflightSnapshots marks the OLDER duplicate pending/running
+// snapshots as failed so the partial-unique index can be created cleanly. For
+// each (site_id) with more than one in-flight snapshot, all but the newest are
+// failed with "duplicate_in_flight_healed". Cross-tenant under app.agent for the
+// SELECT; per-tenant for each fail update.
+func (r *pgRepo) ReconcileDuplicateInflightSnapshots(ctx context.Context) (int, error) {
+	type dup struct {
+		id       uuid.UUID
+		tenantID uuid.UUID
+	}
+	var dups []dup
+
+	// Find the older in-flight duplicates across all tenants.
+	if err := r.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT id, tenant_id
+			  FROM backup_snapshots
+			 WHERE status IN ('pending', 'running')
+			   AND id NOT IN (
+			       SELECT DISTINCT ON (site_id) id
+			         FROM backup_snapshots
+			        WHERE status IN ('pending', 'running')
+			        ORDER BY site_id, created_at DESC
+			   )`)
+		if err != nil {
+			return domain.Internal("backup_dup_inflight_list_failed", "failed to list duplicate in-flight snapshots").WithCause(err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var d dup
+			if serr := rows.Scan(&d.id, &d.tenantID); serr != nil {
+				return domain.Internal("backup_dup_inflight_scan_failed", "failed to scan duplicate snapshot").WithCause(serr)
+			}
+			dups = append(dups, d)
+		}
+		return rows.Err()
+	}); err != nil {
+		return 0, err
+	}
+
+	failed := 0
+	for _, d := range dups {
+		_ = r.pool.InTenantTx(ctx, d.tenantID, func(tx pgx.Tx) error {
+			_, err := tx.Exec(ctx, `
+				UPDATE backup_snapshots
+				   SET status = 'failed', error = 'duplicate_in_flight_healed',
+				       finished_at = now(), updated_at = now()
+				 WHERE id = $1 AND tenant_id = $2
+				   AND status IN ('pending', 'running')`,
+				d.id, d.tenantID,
+			)
+			return err
+		})
+		failed++
+	}
+	return failed, nil
 }

--- a/apps/api/internal/backup/schedule_incremental_wiring_test.go
+++ b/apps/api/internal/backup/schedule_incremental_wiring_test.go
@@ -187,6 +187,18 @@ func (r *wiringRepo) FleetListSnapshots(_ context.Context, _ db.ScopedPrincipal,
 func (r *wiringRepo) FleetBackupHealth(_ context.Context, _ db.ScopedPrincipal, _ uuid.UUID, _ []uuid.UUID) ([]FleetBackupHealthItem, error) {
 	panic("wiringRepo.FleetBackupHealth not implemented")
 }
+func (r *wiringRepo) ClaimAndAdvanceDueSchedules(_ context.Context, _ time.Time, _ map[uuid.UUID]time.Time) ([]Schedule, error) {
+	panic("wiringRepo.ClaimAndAdvanceDueSchedules not implemented")
+}
+func (r *wiringRepo) CountInFlightSnapshots(_ context.Context, _, _ uuid.UUID) (int64, error) {
+	return 0, nil // default: no in-flight snapshots
+}
+func (r *wiringRepo) HealOverdueSchedules(_ context.Context, _ time.Time, _ func(Schedule, time.Time) time.Time) (int, error) {
+	return 0, nil
+}
+func (r *wiringRepo) ReconcileDuplicateInflightSnapshots(_ context.Context) (int, error) {
+	return 0, nil
+}
 
 // ---------------------------------------------------------------------------
 // recordingEnqueuer — records which enqueue method was called.

--- a/apps/api/internal/backup/scheduler_fix_test.go
+++ b/apps/api/internal/backup/scheduler_fix_test.go
@@ -1,0 +1,629 @@
+package backup
+
+// scheduler_fix_test.go — unit tests for issue #68 scheduler correctness fixes.
+//
+// Tests:
+//  1. PutSchedule re-enable heals: disabled→enabled with stale next_run_at
+//     → persisted next_run_at is strictly in the future.
+//  2. PutSchedule overdue self-heal: enabled+future schedule edited (non-timing)
+//     with overdue next_run_at → next_run_at advanced.
+//  3. Atomic claim exactly-once under concurrency: two goroutines calling
+//     ClaimDueSchedules on the same fake repo → only one advances the schedule.
+//  4. Advance/claim error surfaces → ClaimDueSchedules returns error and does
+//     NOT enqueue any job.
+//  5a. In-flight guard — EnqueueScheduledBackup is a no-op when a snapshot is
+//      in flight (pending OR running).
+//  5b. In-flight guard — CreateBackup returns a validation error when in flight.
+//  6. 24h simulation with 5-min ticks on a fixed daily schedule → exactly one
+//     snapshot created per 24-hour window.
+//
+// All tests use in-memory fakes and a deterministic fakeClock; no database.
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// schedulerTestRepo — in-memory Repo for scheduler tests.
+//
+// Methods exercised by the scheduler/in-flight guard paths are functional.
+// Methods not touched by these tests panic so unexpected calls are caught.
+// ---------------------------------------------------------------------------
+
+type schedulerTestRepo struct {
+	mu sync.Mutex
+
+	// schedule store keyed by schedule ID.
+	schedules map[uuid.UUID]*Schedule
+	// schedBySite for GetSchedule lookup.
+	schedBySite map[uuid.UUID]*Schedule
+
+	// in-flight counts per "tenantID/siteID".
+	inFlight map[string]int64
+
+	// CreateSnapshot call recorder: "tenantID/siteID" → count.
+	snapCreated map[string]int
+
+	// claim tracking: how many times each schedule ID was advanced.
+	claimedCount map[uuid.UUID]int
+
+	// ClaimAndAdvanceDueSchedules: when non-nil, returned instead of normal path.
+	claimErr error
+}
+
+func newSchedulerTestRepo() *schedulerTestRepo {
+	return &schedulerTestRepo{
+		schedules:    make(map[uuid.UUID]*Schedule),
+		schedBySite:  make(map[uuid.UUID]*Schedule),
+		inFlight:     make(map[string]int64),
+		snapCreated:  make(map[string]int),
+		claimedCount: make(map[uuid.UUID]int),
+	}
+}
+
+func (r *schedulerTestRepo) addSchedule(s Schedule) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := s
+	r.schedules[s.ID] = &cp
+	r.schedBySite[s.SiteID] = &cp
+}
+
+func (r *schedulerTestRepo) setInFlight(tenantID, siteID uuid.UUID, n int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.inFlight[tenantID.String()+"/"+siteID.String()] = n
+}
+
+func (r *schedulerTestRepo) snapCount(tenantID, siteID uuid.UUID) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.snapCreated[tenantID.String()+"/"+siteID.String()]
+}
+
+// --- Repo interface implementation ---
+
+func (r *schedulerTestRepo) GetSchedule(_ context.Context, _, siteID uuid.UUID) (Schedule, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	s, ok := r.schedBySite[siteID]
+	if !ok {
+		return Schedule{}, domain.NotFound("backup_schedule_not_found", "not found")
+	}
+	return *s, nil
+}
+
+func (r *schedulerTestRepo) UpsertSchedule(_ context.Context, in UpsertScheduleInput) (Schedule, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	s := Schedule{
+		ID:                 in.SiteID, // use site_id as fake schedule ID
+		TenantID:           in.TenantID,
+		SiteID:             in.SiteID,
+		Cadence:            in.Cadence,
+		Enabled:            in.Enabled,
+		RunHour:            in.RunHour,
+		RunMinute:          in.RunMinute,
+		DayOfWeek:          in.DayOfWeek,
+		DayOfMonth:         in.DayOfMonth,
+		FrequencyHours:     in.FrequencyHours,
+		NextRunAt:          in.NextRunAt,
+		RetentionDays:      in.RetentionDays,
+		MonthlyArchiveKeep: in.MonthlyArchiveKeep,
+		KeepLast:           in.KeepLast,
+		Kind:               in.Kind,
+	}
+	r.schedules[s.ID] = &s
+	r.schedBySite[s.SiteID] = &s
+	return s, nil
+}
+
+func (r *schedulerTestRepo) ListDueSchedules(_ context.Context, now time.Time, limit int32) ([]Schedule, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []Schedule
+	var count int32
+	for _, s := range r.schedules {
+		if s.Enabled && !s.NextRunAt.After(now) {
+			out = append(out, *s)
+			count++
+			if count >= limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+// ClaimAndAdvanceDueSchedules simulates FOR UPDATE SKIP LOCKED: under a mutex,
+// it selects due rows, advances them, and records the advance count.
+// When claimErr is set it returns that error instead.
+func (r *schedulerTestRepo) ClaimAndAdvanceDueSchedules(_ context.Context, now time.Time, nextAt map[uuid.UUID]time.Time) ([]Schedule, error) {
+	if r.claimErr != nil {
+		return nil, r.claimErr
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []Schedule
+	for _, s := range r.schedules {
+		if !s.Enabled || s.NextRunAt.After(now) {
+			continue
+		}
+		next, ok := nextAt[s.ID]
+		if !ok {
+			continue
+		}
+		fired := *s
+		s.NextRunAt = next
+		r.claimedCount[s.ID]++
+		out = append(out, fired)
+	}
+	return out, nil
+}
+
+func (r *schedulerTestRepo) CountInFlightSnapshots(_ context.Context, tenantID, siteID uuid.UUID) (int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.inFlight[tenantID.String()+"/"+siteID.String()], nil
+}
+
+func (r *schedulerTestRepo) CreateSnapshot(_ context.Context, in CreateSnapshotInput) (Snapshot, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := in.TenantID.String() + "/" + in.SiteID.String()
+	r.snapCreated[key]++
+	return Snapshot{
+		ID:       uuid.New(),
+		TenantID: in.TenantID,
+		SiteID:   in.SiteID,
+		Kind:     in.Kind,
+		Status:   StatusPending,
+	}, nil
+}
+
+// --- Remaining Repo methods: panic if unexpectedly called ---
+
+func (r *schedulerTestRepo) GetSnapshotScoped(_ context.Context, _ db.ScopedPrincipal, _, _ uuid.UUID) (Snapshot, error) {
+	panic("schedulerTestRepo.GetSnapshotScoped not expected")
+}
+func (r *schedulerTestRepo) GetSnapshot(_ context.Context, _, _ uuid.UUID) (Snapshot, error) {
+	panic("schedulerTestRepo.GetSnapshot not expected")
+}
+func (r *schedulerTestRepo) ListSnapshotsForSite(_ context.Context, _, _ uuid.UUID, _, _ int32) ([]Snapshot, error) {
+	panic("schedulerTestRepo.ListSnapshotsForSite not expected")
+}
+func (r *schedulerTestRepo) MarkSnapshotRunning(_ context.Context, _, _ uuid.UUID) (Snapshot, error) {
+	panic("schedulerTestRepo.MarkSnapshotRunning not expected")
+}
+func (r *schedulerTestRepo) CompleteSnapshot(_ context.Context, _, _ uuid.UUID, _, _ int64) (Snapshot, error) {
+	panic("schedulerTestRepo.CompleteSnapshot not expected")
+}
+func (r *schedulerTestRepo) FailSnapshot(_ context.Context, _, _ uuid.UUID, _ string) (Snapshot, error) {
+	return Snapshot{Status: StatusFailed}, nil
+}
+func (r *schedulerTestRepo) UpdateSnapshotProgress(_ context.Context, _, _ uuid.UUID, _ []byte) (Snapshot, error) {
+	panic("schedulerTestRepo.UpdateSnapshotProgress not expected")
+}
+func (r *schedulerTestRepo) ListStalledRunningSnapshots(_ context.Context, _ time.Duration) ([]StalledSnapshot, error) {
+	panic("schedulerTestRepo.ListStalledRunningSnapshots not expected")
+}
+func (r *schedulerTestRepo) GetLatestCompletedSnapshot(_ context.Context, _, _ uuid.UUID) (Snapshot, error) {
+	return Snapshot{}, domain.NotFound("not_found", "no completed snapshot")
+}
+func (r *schedulerTestRepo) ListManifest(_ context.Context, _, _ uuid.UUID) ([]ManifestEntry, error) {
+	panic("schedulerTestRepo.ListManifest not expected")
+}
+func (r *schedulerTestRepo) HasFilesList(_ context.Context, _, _ uuid.UUID) (bool, error) {
+	return false, nil
+}
+func (r *schedulerTestRepo) RecordManifest(_ context.Context, _ RecordManifestInput) (int64, int64, error) {
+	panic("schedulerTestRepo.RecordManifest not expected")
+}
+func (r *schedulerTestRepo) ExistingChunkHashes(_ context.Context, _ uuid.UUID, _ []string) (map[string]Chunk, error) {
+	panic("schedulerTestRepo.ExistingChunkHashes not expected")
+}
+func (r *schedulerTestRepo) ListTenantsForGC(_ context.Context) ([]uuid.UUID, error) {
+	panic("schedulerTestRepo.ListTenantsForGC not expected")
+}
+func (r *schedulerTestRepo) AdvanceScheduleRun(_ context.Context, _, _ uuid.UUID, _ time.Time) error {
+	return nil
+}
+func (r *schedulerTestRepo) SetSnapshotLocked(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ bool) (Snapshot, error) {
+	panic("schedulerTestRepo.SetSnapshotLocked not expected")
+}
+func (r *schedulerTestRepo) FleetListSnapshots(_ context.Context, _ db.ScopedPrincipal, _ uuid.UUID, _ FleetListFilter) (FleetSnapshotPage, error) {
+	panic("schedulerTestRepo.FleetListSnapshots not expected")
+}
+func (r *schedulerTestRepo) FleetBackupHealth(_ context.Context, _ db.ScopedPrincipal, _ uuid.UUID, _ []uuid.UUID) ([]FleetBackupHealthItem, error) {
+	panic("schedulerTestRepo.FleetBackupHealth not expected")
+}
+func (r *schedulerTestRepo) GetBackupSettings(_ context.Context, _, _ uuid.UUID) (SiteBackupSettings, error) {
+	return SiteBackupSettings{}, domain.NotFound("not_found", "no settings")
+}
+func (r *schedulerTestRepo) UpsertBackupSettings(_ context.Context, _ uuid.UUID, in SiteBackupSettings) (SiteBackupSettings, error) {
+	return in, nil
+}
+func (r *schedulerTestRepo) ListExpiredSnapshots(_ context.Context, _ uuid.UUID, _ time.Time) ([]Snapshot, error) {
+	panic("schedulerTestRepo.ListExpiredSnapshots not expected")
+}
+func (r *schedulerTestRepo) ListCompletedSnapshotsForSite(_ context.Context, _, _ uuid.UUID) ([]SnapshotMeta, error) {
+	panic("schedulerTestRepo.ListCompletedSnapshotsForSite not expected")
+}
+func (r *schedulerTestRepo) ListSiteIDsWithSnapshots(_ context.Context, _ uuid.UUID) ([]uuid.UUID, error) {
+	return nil, nil
+}
+func (r *schedulerTestRepo) SetSnapshotArchived(_ context.Context, _, _ uuid.UUID, _ bool) error {
+	panic("schedulerTestRepo.SetSnapshotArchived not expected")
+}
+func (r *schedulerTestRepo) DeleteSnapshot(_ context.Context, _, _ uuid.UUID) error {
+	panic("schedulerTestRepo.DeleteSnapshot not expected")
+}
+func (r *schedulerTestRepo) ListInFlightSnapshotFloor(_ context.Context, _ uuid.UUID) (time.Time, error) {
+	return time.Time{}, nil
+}
+func (r *schedulerTestRepo) DBNow(_ context.Context, _ uuid.UUID) (time.Time, error) {
+	return time.Now(), nil
+}
+func (r *schedulerTestRepo) SweepTenantChunks(_ context.Context, _ uuid.UUID, _ time.Time, acquired *bool, _ func(SweepChunk) (bool, error)) error {
+	*acquired = false
+	return nil
+}
+func (r *schedulerTestRepo) InsertFileIndexBatch(_ context.Context, _, _ uuid.UUID, _ []FileIndexEntry) error {
+	panic("schedulerTestRepo.InsertFileIndexBatch not expected")
+}
+func (r *schedulerTestRepo) CountFileIndex(_ context.Context, _, _ uuid.UUID) (int64, error) {
+	panic("schedulerTestRepo.CountFileIndex not expected")
+}
+func (r *schedulerTestRepo) StreamFileIndex(_ context.Context, _, _ uuid.UUID, _ func(FileIndexEntry) error) error {
+	panic("schedulerTestRepo.StreamFileIndex not expected")
+}
+func (r *schedulerTestRepo) StreamChainEffectiveFileIndex(_ context.Context, _, _ uuid.UUID, _ int, _ func(FileIndexEntry) error) error {
+	panic("schedulerTestRepo.StreamChainEffectiveFileIndex not expected")
+}
+func (r *schedulerTestRepo) UpdateSnapshotCycleStats(_ context.Context, _, _ uuid.UUID, _ CycleStatsInput) error {
+	return nil
+}
+func (r *schedulerTestRepo) CompleteIncrementalManifest(_ context.Context, _ CompleteIncrementalInput) (int64, int64, error) {
+	panic("schedulerTestRepo.CompleteIncrementalManifest not expected")
+}
+func (r *schedulerTestRepo) ListChainSnapshots(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ int) ([]Snapshot, error) {
+	return nil, nil
+}
+func (r *schedulerTestRepo) HealOverdueSchedules(_ context.Context, _ time.Time, _ func(Schedule, time.Time) time.Time) (int, error) {
+	return 0, nil
+}
+func (r *schedulerTestRepo) ReconcileDuplicateInflightSnapshots(_ context.Context) (int, error) {
+	return 0, nil
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: PutSchedule re-enable heals next_run_at
+// ---------------------------------------------------------------------------
+
+func TestPutSchedule_ReEnable_HealsNextRunAt(t *testing.T) {
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	past := now.Add(-48 * time.Hour)
+
+	tenantID, siteID := uuid.New(), uuid.New()
+
+	repo := newSchedulerTestRepo()
+	repo.addSchedule(Schedule{
+		ID:        siteID, // consistent with UpsertSchedule fake (schedID = siteID)
+		TenantID:  tenantID,
+		SiteID:    siteID,
+		Cadence:   CadenceDaily,
+		RunHour:   2,
+		RunMinute: 0,
+		Enabled:   false, // currently disabled
+		NextRunAt: past,
+	})
+
+	svc := &Service{
+		repo:  repo,
+		sites: fakeSites{info: SiteInfo{Enrolled: true, AgeRecipient: "age1test", WpTimezone: "UTC"}},
+		clock: fakeClock{t: now},
+	}
+
+	out, err := svc.PutSchedule(context.Background(), PutScheduleInput{
+		TenantID:  tenantID,
+		SiteID:    siteID,
+		Cadence:   CadenceDaily,
+		RunHour:   2,
+		RunMinute: 0,
+		Enabled:   true, // re-enabling
+	})
+	if err != nil {
+		t.Fatalf("PutSchedule re-enable: %v", err)
+	}
+	if !out.NextRunAt.After(now) {
+		t.Errorf("re-enable: next_run_at %v is not after now %v", out.NextRunAt, now)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: PutSchedule overdue self-heal (non-timing edit while enabled)
+// ---------------------------------------------------------------------------
+
+func TestPutSchedule_OverdueSelfHeal(t *testing.T) {
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	past := now.Add(-2 * time.Hour)
+
+	tenantID, siteID := uuid.New(), uuid.New()
+
+	repo := newSchedulerTestRepo()
+	repo.addSchedule(Schedule{
+		ID:            siteID,
+		TenantID:      tenantID,
+		SiteID:        siteID,
+		Cadence:       CadenceDaily,
+		RunHour:       2,
+		RunMinute:     0,
+		Enabled:       true,
+		NextRunAt:     past,
+		RetentionDays: 30,
+	})
+
+	svc := &Service{
+		repo:  repo,
+		sites: fakeSites{info: SiteInfo{Enrolled: true, AgeRecipient: "age1test", WpTimezone: "UTC"}},
+		clock: fakeClock{t: now},
+	}
+
+	// Non-timing edit: only RetentionDays changes; cadence/hour/minute stay the same.
+	out, err := svc.PutSchedule(context.Background(), PutScheduleInput{
+		TenantID:      tenantID,
+		SiteID:        siteID,
+		Cadence:       CadenceDaily,
+		RunHour:       2,
+		RunMinute:     0,
+		Enabled:       true,
+		RetentionDays: 60, // only this changed
+	})
+	if err != nil {
+		t.Fatalf("PutSchedule overdue self-heal: %v", err)
+	}
+	if !out.NextRunAt.After(now) {
+		t.Errorf("overdue self-heal: next_run_at %v is not after now %v", out.NextRunAt, now)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Atomic claim exactly-once under concurrency
+// ---------------------------------------------------------------------------
+
+func TestClaimDueSchedules_ExactlyOnceUnderConcurrency(t *testing.T) {
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	dueAt := now.Add(-time.Minute)
+
+	tenantID := uuid.New()
+	siteID := uuid.New()
+	schedID := uuid.New()
+
+	repo := newSchedulerTestRepo()
+	repo.addSchedule(Schedule{
+		ID:        schedID,
+		TenantID:  tenantID,
+		SiteID:    siteID,
+		Cadence:   CadenceDaily,
+		RunHour:   11,
+		RunMinute: 59,
+		Enabled:   true,
+		NextRunAt: dueAt,
+	})
+
+	svc := &Service{
+		repo:  repo,
+		sites: fakeSites{info: SiteInfo{Enrolled: true, AgeRecipient: "age1test", WpTimezone: "UTC"}},
+		clock: fakeClock{t: now},
+	}
+
+	// Two goroutines claim concurrently. The fake's mutex serialises
+	// ClaimAndAdvanceDueSchedules: the first call advances next_run_at to the
+	// future; the second call's ListDueSchedules finds no due rows (because the
+	// first goroutine's ListDueSchedules already ran before the advance, but
+	// ClaimAndAdvanceDueSchedules in the fake checks next_run_at again under
+	// the same lock, so the second goroutine's ClaimAndAdvanceDueSchedules call
+	// finds the row already advanced past now). Total claimed must be 1.
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	totalClaimed := 0
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			claimed, err := svc.ClaimDueSchedules(context.Background())
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			totalClaimed += len(claimed)
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	if totalClaimed != 1 {
+		t.Errorf("concurrent claim: total claimed = %d, want 1", totalClaimed)
+	}
+
+	repo.mu.Lock()
+	advCount := repo.claimedCount[schedID]
+	repo.mu.Unlock()
+	if advCount != 1 {
+		t.Errorf("schedule advanced %d times, want 1", advCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Claim error surfaces — ClaimDueSchedules returns error, no enqueue
+// ---------------------------------------------------------------------------
+
+func TestClaimDueSchedules_ClaimError_DoesNotEnqueue(t *testing.T) {
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	repo := newSchedulerTestRepo()
+	repo.addSchedule(Schedule{
+		ID:        uuid.New(),
+		TenantID:  uuid.New(),
+		SiteID:    uuid.New(),
+		Cadence:   CadenceDaily,
+		Enabled:   true,
+		NextRunAt: now.Add(-time.Minute),
+	})
+	repo.claimErr = fmt.Errorf("simulated DB error on claim")
+
+	enq := &recordingEnqueuer{}
+	svc := &Service{
+		repo:     repo,
+		sites:    fakeSites{info: SiteInfo{Enrolled: true, AgeRecipient: "age1test"}},
+		clock:    fakeClock{t: now},
+		enqueuer: enq,
+	}
+
+	_, err := svc.ClaimDueSchedules(context.Background())
+	if err == nil {
+		t.Fatal("expected ClaimDueSchedules to return error on claim failure, got nil")
+	}
+	if len(enq.plainCalls) > 0 || len(enq.chainCalls) > 0 {
+		t.Errorf("no enqueue expected when claim fails; got plain=%d chain=%d",
+			len(enq.plainCalls), len(enq.chainCalls))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 5a: In-flight guard — EnqueueScheduledBackup skips when in flight
+// ---------------------------------------------------------------------------
+
+func TestEnqueueScheduledBackup_InFlightGuard_Skips(t *testing.T) {
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	tenantID, siteID := uuid.New(), uuid.New()
+
+	repo := newSchedulerTestRepo()
+	repo.setInFlight(tenantID, siteID, 1)
+
+	enq := &recordingEnqueuer{}
+	svc := &Service{
+		repo:     repo,
+		sites:    fakeSites{info: SiteInfo{Enrolled: true, AgeRecipient: "age1test"}},
+		clock:    fakeClock{t: now},
+		enqueuer: enq,
+	}
+
+	sched := Schedule{
+		ID:       uuid.New(),
+		TenantID: tenantID,
+		SiteID:   siteID,
+		Cadence:  CadenceDaily,
+		Kind:     KindFull,
+	}
+	err := svc.EnqueueScheduledBackup(context.Background(), sched)
+	if err != nil {
+		t.Fatalf("EnqueueScheduledBackup with in-flight: unexpected error: %v", err)
+	}
+	if n := repo.snapCount(tenantID, siteID); n != 0 {
+		t.Errorf("in-flight guard: created %d snapshots, want 0", n)
+	}
+	if len(enq.plainCalls) > 0 || len(enq.chainCalls) > 0 {
+		t.Errorf("in-flight guard: enqueued plain=%d chain=%d, want 0",
+			len(enq.plainCalls), len(enq.chainCalls))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 5b: In-flight guard — CreateBackup returns validation error when in flight
+// ---------------------------------------------------------------------------
+
+func TestCreateBackup_InFlightGuard_RejectsSecond(t *testing.T) {
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	tenantID, siteID := uuid.New(), uuid.New()
+
+	repo := newSchedulerTestRepo()
+	repo.setInFlight(tenantID, siteID, 1)
+
+	svc := &Service{
+		repo:     repo,
+		sites:    fakeSites{info: SiteInfo{Enrolled: true, AgeRecipient: "age1test"}},
+		clock:    fakeClock{t: now},
+		enqueuer: &recordingEnqueuer{},
+	}
+
+	_, err := svc.CreateBackup(context.Background(), tenantID, siteID, uuid.New(), KindFull)
+	if err == nil {
+		t.Fatal("CreateBackup with in-flight: expected error, got nil")
+	}
+	var de *domain.Error
+	if !asError(err, &de) || de.Kind != domain.KindValidation {
+		t.Errorf("expected domain validation error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: 24h simulation — exactly one snapshot per daily schedule
+// ---------------------------------------------------------------------------
+
+func TestScheduler_24hSimulation_ExactlyOnePerDay(t *testing.T) {
+	start := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	tenantID := uuid.New()
+	// Use a fixed siteID whose first byte is 0x05: SiteJitter(siteID)=0 minutes,
+	// so nextOccurrence for daily-02:00 from 02:00 is exactly 02:00 next day
+	// (26h after sim-start), safely outside the 24h window.
+	siteID := uuid.UUID{0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	schedID := uuid.New()
+
+	repo := newSchedulerTestRepo()
+	repo.addSchedule(Schedule{
+		ID:        schedID,
+		TenantID:  tenantID,
+		SiteID:    siteID,
+		Cadence:   CadenceDaily,
+		RunHour:   2,
+		RunMinute: 0,
+		Enabled:   true,
+		// Placed at 02:00 so the first tick that crosses it fires exactly once.
+		NextRunAt: time.Date(2026, 1, 15, 2, 0, 0, 0, time.UTC),
+	})
+
+	enq := &recordingEnqueuer{}
+	svc := &Service{
+		repo:     repo,
+		sites:    fakeSites{info: SiteInfo{Enrolled: true, AgeRecipient: "age1test", WpTimezone: "UTC"}},
+		enqueuer: enq,
+	}
+
+	// 288 ticks × 5 min = 24 hours.
+	for tick := 0; tick < 288; tick++ {
+		tickTime := start.Add(time.Duration(tick) * 5 * time.Minute)
+		svc.clock = fakeClock{t: tickTime}
+
+		claimed, err := svc.ClaimDueSchedules(context.Background())
+		if err != nil {
+			t.Fatalf("tick %d (%v): ClaimDueSchedules: %v", tick, tickTime, err)
+		}
+		for _, sched := range claimed {
+			if eerr := svc.EnqueueScheduledBackup(context.Background(), sched); eerr != nil {
+				t.Logf("tick %d: EnqueueScheduledBackup skip: %v", tick, eerr)
+			}
+		}
+	}
+
+	if snapCount := repo.snapCount(tenantID, siteID); snapCount != 1 {
+		t.Errorf("24h simulation: got %d snapshots, want exactly 1", snapCount)
+	}
+
+	repo.mu.Lock()
+	advCount := repo.claimedCount[schedID]
+	repo.mu.Unlock()
+	if advCount != 1 {
+		t.Errorf("24h simulation: schedule advanced %d times, want 1", advCount)
+	}
+}

--- a/apps/api/internal/backup/service.go
+++ b/apps/api/internal/backup/service.go
@@ -165,6 +165,11 @@ func (s *Service) SetRestoreRunStore(rs RestoreRunStore) { s.restoreRuns = rs }
 // rows are silently skipped (graceful degradation).
 func (s *Service) SetScheduleRunStore(ss ScheduleRunStore) { s.scheduleRuns = ss }
 
+// logger returns the default structured logger for package-level service events.
+// The service does not carry an injected logger to keep NewService simple; it
+// uses the default slog logger which is configured at boot via slog.SetDefault.
+func (s *Service) logger() *slog.Logger { return slog.Default() }
+
 // publish is a nil-safe helper around hub.Publish.
 func (s *Service) publish(ev BackupEvent) {
 	if s.hub == nil {
@@ -225,6 +230,18 @@ func (s *Service) CreateBackup(ctx context.Context, tenantID, siteID, createdBy 
 		return Snapshot{}, domain.Validation("age_recipient_missing", "the site has no age recipient set; configure backup encryption (PUT the backup schedule with a recipient or set it on the site) before backing up")
 	}
 
+	// In-flight guard: reject a manual backup if one is already pending/running.
+	// This mirrors the scheduled path's belt check and is backed by the partial
+	// unique index (backup_snapshots_one_inflight_per_site) as the suspenders.
+	inFlight, ifErr := s.repo.CountInFlightSnapshots(ctx, tenantID, siteID)
+	if ifErr != nil {
+		return Snapshot{}, fmt.Errorf("in-flight guard check failed: %w", ifErr)
+	}
+	if inFlight > 0 {
+		return Snapshot{}, domain.Validation("backup_already_in_flight",
+			"a backup is already pending or running for this site; wait for it to complete before starting another")
+	}
+
 	// ADR-048 P5: run-now honours the same per-schedule incremental toggle as the
 	// scheduled path, so an operator can enable the toggle and then drive the
 	// base→increment→restore QA flow via run-now. A site with no schedule row (or
@@ -249,6 +266,10 @@ func (s *Service) CreateBackup(ctx context.Context, tenantID, siteID, createdBy 
 			Generation:       res.Generation,
 		})
 		if err != nil {
+			if isUniqueViolation(err) {
+				return Snapshot{}, domain.Validation("backup_already_in_flight",
+					"a backup is already pending or running for this site")
+			}
 			return Snapshot{}, err
 		}
 		if err := s.enqueuer.EnqueueBackupWithChain(ctx, snap); err != nil {
@@ -265,6 +286,10 @@ func (s *Service) CreateBackup(ctx context.Context, tenantID, siteID, createdBy 
 		AgeRecipient: si.AgeRecipient,
 	})
 	if err != nil {
+		if isUniqueViolation(err) {
+			return Snapshot{}, domain.Validation("backup_already_in_flight",
+				"a backup is already pending or running for this site")
+		}
 		return Snapshot{}, err
 	}
 	if err := s.enqueuer.EnqueueBackup(ctx, tenantID, snap.ID); err != nil {
@@ -2150,14 +2175,20 @@ func (s *Service) PutSchedule(ctx context.Context, in PutScheduleInput) (Schedul
 			dow, dom, fh,
 			jitter, loc)
 	} else {
-		// Existing row: recompute only when any timing field changed.
+		// Existing row: recompute when timing changed, when a disabled schedule is
+		// re-enabled (enableTransition), or when next_run_at is already in the past
+		// (overdue) — any of these cases means the stored slot is stale and the next
+		// future occurrence must be computed fresh (skip-missed policy: advance to
+		// the next slot, do NOT immediately run a backup).
 		timingChanged := existing.Cadence != cadence ||
 			existing.RunHour != in.RunHour ||
 			existing.RunMinute != in.RunMinute ||
 			!optInt32Equal(existing.DayOfWeek, in.DayOfWeek) ||
 			!optInt32Equal(existing.DayOfMonth, in.DayOfMonth) ||
 			!optInt32Equal(existing.FrequencyHours, in.FrequencyHours)
-		if timingChanged {
+		enableTransition := !existing.Enabled && in.Enabled
+		overdue := !existing.NextRunAt.After(s.clock.Now())
+		if timingChanged || enableTransition || (in.Enabled && overdue) {
 			jitter := SiteJitter(in.SiteID)
 			dow := optInt32ToInt(in.DayOfWeek)
 			dom := optInt32ToInt(in.DayOfMonth)
@@ -2167,7 +2198,8 @@ func (s *Service) PutSchedule(ctx context.Context, in PutScheduleInput) (Schedul
 				dow, dom, fh,
 				jitter, loc)
 		} else {
-			// Preserve the current next_run_at.
+			// A non-timing edit on an already-enabled, still-future schedule:
+			// preserve the current next_run_at so we do not push the run forward.
 			nextRunAt = existing.NextRunAt
 		}
 	}
@@ -2200,6 +2232,8 @@ func (s *Service) PutSchedule(ctx context.Context, in PutScheduleInput) (Schedul
 }
 
 // DueSchedules returns enabled, due schedules across all tenants (scheduler).
+// Kept for backward compatibility; new callers should use ClaimDueSchedules for
+// the atomic claim-and-advance path.
 func (s *Service) DueSchedules(ctx context.Context, limit int32) ([]Schedule, error) {
 	if limit <= 0 {
 		limit = 100
@@ -2207,44 +2241,125 @@ func (s *Service) DueSchedules(ctx context.Context, limit int32) ([]Schedule, er
 	return s.repo.ListDueSchedules(ctx, s.clock.Now(), limit)
 }
 
+// ClaimDueSchedules atomically selects due schedules, pre-computes their next
+// occurrence (tz-aware, jittered), advances next_run_at in the SAME DB
+// transaction (FOR UPDATE SKIP LOCKED), and returns the claimed slots. Schedules
+// locked by a concurrent CP pass are silently skipped — a schedule is claimed at
+// most once per tick regardless of how many CP instances are running.
+func (s *Service) ClaimDueSchedules(ctx context.Context) ([]Schedule, error) {
+	now := s.clock.Now()
+	// First enumerate candidates without locking so we can do the tz lookup
+	// (network call to sites service) outside the DB transaction.
+	candidates, err := s.repo.ListDueSchedules(ctx, now, 200)
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	// Pre-compute nextAt for each candidate using the site's tz.
+	nextAt := make(map[uuid.UUID]time.Time, len(candidates))
+	for _, sched := range candidates {
+		si, serr := s.sites.GetBackupSiteInfo(ctx, sched.TenantID, sched.SiteID)
+		if serr != nil {
+			// Site lookup failed: leave this schedule out of nextAt so the claim
+			// loop skips it (it stays due and will be retried next tick).
+			continue
+		}
+		loc := resolveLocation(si.WpTimezone, si.WpGmtOffset)
+		jitter := SiteJitter(sched.SiteID)
+		dow := optInt32ToInt(sched.DayOfWeek)
+		dom := optInt32ToInt(sched.DayOfMonth)
+		fh := optInt32ToInt(sched.FrequencyHours)
+		nextAt[sched.ID] = nextOccurrence(now, sched.Cadence,
+			int(sched.RunHour), int(sched.RunMinute),
+			dow, dom, fh,
+			jitter, loc)
+	}
+
+	// Atomic claim: FOR UPDATE SKIP LOCKED + advance in one tx.
+	return s.repo.ClaimAndAdvanceDueSchedules(ctx, now, nextAt)
+}
+
+// HealOverdueSchedulesAndSnapshots is the issue #68 boot-time data-heal task.
+// It runs two one-shot passes:
+//  1. Reconcile duplicate pending/running snapshots (mark older ones failed)
+//     so the partial-unique index added by migration m75 can be created.
+//  2. Advance every enabled schedule whose next_run_at is already past to its
+//     next future occurrence (per-site tz/jitter math via nextOccurrence).
+//
+// Called in a goroutine at boot, after River starts and the enqueuer is wired.
+// Errors are logged but never fatal — the scheduler still works without the heal
+// (the FOR UPDATE SKIP LOCKED and in-flight guard handle ongoing fires).
+func (s *Service) HealOverdueSchedulesAndSnapshots(ctx context.Context, logger interface {
+	Info(msg string, args ...any)
+	Warn(msg string, args ...any)
+}) {
+	// Step 1: reconcile duplicate in-flight snapshots.
+	failed, err := s.repo.ReconcileDuplicateInflightSnapshots(ctx)
+	if err != nil {
+		logger.Warn("backup issue#68 heal: reconcile duplicate in-flight snapshots failed", "error", err.Error())
+	} else if failed > 0 {
+		logger.Info("backup issue#68 heal: duplicate in-flight snapshots reconciled", "count", failed)
+	}
+
+	// Step 2: heal overdue enabled schedules.
+	now := s.clock.Now()
+	compute := func(sched Schedule, now time.Time) time.Time {
+		// Resolve tz from sites service; fall back to UTC on error.
+		si, serr := s.sites.GetBackupSiteInfo(ctx, sched.TenantID, sched.SiteID)
+		loc := time.UTC
+		if serr == nil {
+			loc = resolveLocation(si.WpTimezone, si.WpGmtOffset)
+		}
+		jitter := SiteJitter(sched.SiteID)
+		dow := optInt32ToInt(sched.DayOfWeek)
+		dom := optInt32ToInt(sched.DayOfMonth)
+		fh := optInt32ToInt(sched.FrequencyHours)
+		return nextOccurrence(now, sched.Cadence,
+			int(sched.RunHour), int(sched.RunMinute),
+			dow, dom, fh,
+			jitter, loc)
+	}
+	healed, herr := s.repo.HealOverdueSchedules(ctx, now, compute)
+	if herr != nil {
+		logger.Warn("backup issue#68 heal: advance overdue schedules failed", "error", herr.Error())
+	} else if healed > 0 {
+		logger.Info("backup issue#68 heal: overdue schedules advanced to next future slot", "count", healed)
+	}
+}
+
 // EnqueueScheduledBackup records a pending snapshot for a due schedule, enqueues
-// the backup job, advances the schedule's next_run_at, and (when the schedule
-// run store is wired) materializes the M17 schedule run row. Used by the
-// scheduler periodic job. It resolves the site's recipient at enqueue time.
+// the backup job, and (when the schedule run store is wired) materializes the M17
+// schedule run row. Used by the scheduler periodic job (ScheduleWorker.Work).
+//
+// IMPORTANT: next_run_at is NOT advanced here. The caller (ClaimDueSchedules /
+// ClaimAndAdvanceDueSchedules) already advanced it atomically via FOR UPDATE SKIP
+// LOCKED before calling this function. Any caller that bypasses ClaimDueSchedules
+// is responsible for advancing before calling EnqueueScheduledBackup.
 //
 // Transaction flow (M17):
-//  1. AgentUpsertScheduleRun(scheduled_for=sched.NextRunAt) → 'queued'
-//  2. CreateSnapshot (tenant-scoped)
-//  3. SetScheduleRunSnapshot (link run → snapshot)
-//  4. EnqueueBackup (River)
-//  5. AdvanceScheduleRun (next_run_at = nextOccurrence)
-//  6. Pre-insert next 'scheduled' run row
+//  1. In-flight guard: if a pending/running snapshot already exists → skip (no-op).
+//  2. AgentUpsertScheduleRun(scheduled_for=sched.NextRunAt) → 'queued'
+//  3. CreateSnapshot (tenant-scoped) — unique_violation treated as in-flight → skip.
+//  4. SetScheduleRunSnapshot (link run → snapshot)
+//  5. EnqueueBackup (River)
 //
-// Un-enrollable / no-recipient site → run marked 'skipped' (visible in history)
-// and schedule still advances (no busy-loop).
+// Un-enrollable / no-recipient site → run marked 'skipped' (visible in history).
 func (s *Service) EnqueueScheduledBackup(ctx context.Context, sched Schedule) error {
 	si, err := s.sites.GetBackupSiteInfo(ctx, sched.TenantID, sched.SiteID)
 	if err != nil {
 		return err
 	}
-	// Resolve the site's timezone for next-occurrence computation.
-	loc := resolveLocation(si.WpTimezone, si.WpGmtOffset)
-	jitter := SiteJitter(sched.SiteID)
-	dow := optInt32ToInt(sched.DayOfWeek)
-	dom := optInt32ToInt(sched.DayOfMonth)
-	fh := optInt32ToInt(sched.FrequencyHours)
-	nextAt := nextOccurrence(s.clock.Now(), sched.Cadence,
-		int(sched.RunHour), int(sched.RunMinute),
-		dow, dom, fh,
-		jitter, loc)
 
-	// Un-enrollable / no-recipient path: mark run skipped and advance.
+	// Un-enrollable / no-recipient path: record skip in history; schedule advance
+	// already happened in ClaimAndAdvanceDueSchedules.
 	if !si.Enrolled || si.AgeRecipient == "" {
 		reason := "site not enrolled"
 		if si.Enrolled && si.AgeRecipient == "" {
 			reason = "no age recipient configured"
 		}
-		skipReason := reason
 		if s.scheduleRuns != nil {
 			triggeredBy := "schedule"
 			_, _ = s.scheduleRuns.AgentUpsertScheduleRun(ctx, UpsertScheduleRunInput{
@@ -2256,43 +2371,32 @@ func (s *Service) EnqueueScheduledBackup(ctx context.Context, sched Schedule) er
 				Kind:         sched.Kind,
 				TriggeredBy:  &triggeredBy,
 			})
-			// Pre-insert next scheduled row.
-			_, _ = s.scheduleRuns.AgentUpsertScheduleRun(ctx, UpsertScheduleRunInput{
-				TenantID:     sched.TenantID,
-				SiteID:       sched.SiteID,
-				ScheduleID:   sched.ID,
-				ScheduledFor: nextAt,
-				Status:       ScheduleRunStatusScheduled,
-				Kind:         sched.Kind,
-				TriggeredBy:  &triggeredBy,
-			})
 		}
-		_ = s.repo.AdvanceScheduleRun(ctx, sched.TenantID, sched.ID, nextAt)
-		return fmt.Errorf("scheduled backup skipped: %s", skipReason)
+		return fmt.Errorf("scheduled backup skipped: %s", reason)
 	}
 
-	// Happy path. Advance next_run_at and pre-insert the next scheduled row
-	// FIRST so a crash mid-fire can never re-fire this same slot — worst case is
-	// one missed backup, never a duplicate storm. The firing row uses the slot
-	// we are firing (firingSlot) while the pre-insert uses nextAt; the
-	// UNIQUE(schedule_id, scheduled_for) keeps the two rows distinct.
+	// In-flight guard (belt): skip if a pending/running snapshot already exists.
+	// The partial-unique index is the suspenders; this is the belt.
+	inFlight, ifErr := s.repo.CountInFlightSnapshots(ctx, sched.TenantID, sched.SiteID)
+	if ifErr != nil {
+		// Log and skip — a broken guard must not block other schedules.
+		s.logger().Warn("backup_scheduler in-flight guard failed, skipping schedule",
+			"schedule_id", sched.ID.String(),
+			"site_id", sched.SiteID.String(),
+			"error", ifErr.Error())
+		return fmt.Errorf("in-flight guard failed: %w", ifErr)
+	}
+	if inFlight > 0 {
+		s.logger().Info("backup_scheduler skipping due schedule: snapshot already in flight",
+			"schedule_id", sched.ID.String(),
+			"site_id", sched.SiteID.String(),
+			"in_flight_count", inFlight)
+		return nil
+	}
+
+	// Materialize the run row for the slot we are firing.
 	triggeredBy := "schedule"
 	firingSlot := sched.NextRunAt
-	_ = s.repo.AdvanceScheduleRun(ctx, sched.TenantID, sched.ID, nextAt)
-	if s.scheduleRuns != nil {
-		_, _ = s.scheduleRuns.AgentUpsertScheduleRun(ctx, UpsertScheduleRunInput{
-			TenantID:     sched.TenantID,
-			SiteID:       sched.SiteID,
-			ScheduleID:   sched.ID,
-			ScheduledFor: nextAt,
-			Status:       ScheduleRunStatusScheduled,
-			Kind:         sched.Kind,
-			TriggeredBy:  &triggeredBy,
-		})
-	}
-
-	// Materialize the run row for the slot we are firing. An upsert error here
-	// is fatal: never create a snapshot with no linked run row to reconcile.
 	var runID uuid.UUID
 	if s.scheduleRuns != nil {
 		run, rerr := s.scheduleRuns.AgentUpsertScheduleRun(ctx, UpsertScheduleRunInput{
@@ -2343,6 +2447,15 @@ func (s *Service) EnqueueScheduledBackup(ctx context.Context, sched Schedule) er
 		})
 	}
 	if err != nil {
+		// A unique-constraint violation on (site_id) WHERE status IN ('pending','running')
+		// means a concurrent pass raced past the in-flight guard and won. Treat as
+		// a skip (already in flight), not an error.
+		if isUniqueViolation(err) {
+			s.logger().Info("backup_scheduler CreateSnapshot unique-violation: already in flight",
+				"schedule_id", sched.ID.String(),
+				"site_id", sched.SiteID.String())
+			return nil
+		}
 		return err
 	}
 
@@ -2352,10 +2465,7 @@ func (s *Service) EnqueueScheduledBackup(ctx context.Context, sched Schedule) er
 	}
 
 	// Enqueue the backup job. If this fails the snapshot exists but no worker
-	// will ever run it — mark the (now snapshot-linked) run failed so history
-	// does not stick on "queued". EnqueueBackupWithChain carries the snapshot's
-	// chain fields onto the job args; for a full-base snapshot they are all
-	// zero/nil so the worker behaves identically to EnqueueBackup.
+	// will ever run it — mark the run failed so history does not stick on "queued".
 	var enqueueErr error
 	if sched.IncrementalEnabled {
 		enqueueErr = s.enqueuer.EnqueueBackupWithChain(ctx, snap)

--- a/apps/api/internal/backup/worker.go
+++ b/apps/api/internal/backup/worker.go
@@ -10,10 +10,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
 	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 	"github.com/mosamlife/wpmgr/apps/api/internal/restore/sqlinspect"
 )
 
@@ -648,10 +650,30 @@ func (ScheduleArgs) Kind() string { return "backup_scheduler" }
 type ScheduleWorker struct {
 	river.WorkerDefaults[ScheduleArgs]
 	svc    *Service
+	pool   schedulerPool // for the per-pass advisory lock
 	logger *slog.Logger
 }
 
-// NewScheduleWorker builds the scheduler worker.
+// schedulerPool is the narrow pool interface needed by ScheduleWorker to acquire
+// a pinned connection for the pg_try_advisory_lock single-flight guard.
+type schedulerPool interface {
+	Acquire(ctx context.Context) (schedulerConn, error)
+}
+
+// schedulerConn is the narrow conn interface used by the advisory lock guard.
+type schedulerConn interface {
+	Exec(ctx context.Context, sql string, args ...any) (interface{ RowsAffected() int64 }, error)
+	QueryRow(ctx context.Context, sql string, args ...any) scannable
+	Release()
+}
+
+type scannable interface {
+	Scan(dest ...any) error
+}
+
+// NewScheduleWorker builds the scheduler worker. pool is used for the
+// cross-instance single-flight advisory lock; pass nil to skip the lock
+// (tests and environments where the pool is unavailable).
 func NewScheduleWorker(svc *Service, logger *slog.Logger) *ScheduleWorker {
 	if logger == nil {
 		logger = slog.Default()
@@ -659,16 +681,83 @@ func NewScheduleWorker(svc *Service, logger *slog.Logger) *ScheduleWorker {
 	return &ScheduleWorker{svc: svc, logger: logger}
 }
 
-// Work enqueues a backup for each due schedule and advances its next_run_at.
+// SetPool wires the db pool for the advisory single-flight guard.
+// Call once after NewScheduleWorker. Optional: when nil the lock is skipped.
+func (w *ScheduleWorker) SetPool(p *db.Pool) { w.pool = &dbPoolAdapter{p: p} }
+
+// dbPoolAdapter wraps *db.Pool to satisfy schedulerPool.
+type dbPoolAdapter struct{ p *db.Pool }
+
+func (a *dbPoolAdapter) Acquire(ctx context.Context) (schedulerConn, error) {
+	conn, err := a.p.Acquire(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return (*pgxPoolConnAdapter)(conn), nil
+}
+
+// pgxPoolConnAdapter adapts *pgxpool.Conn to schedulerConn.
+// pgxpool.Conn satisfies the Exec/QueryRow/Release shape but needs an adapter
+// because the return types differ from the narrow interface.
+type pgxPoolConnAdapter pgxpool.Conn
+
+func (c *pgxPoolConnAdapter) Exec(ctx context.Context, sql string, args ...any) (interface{ RowsAffected() int64 }, error) {
+	return (*pgxpool.Conn)(c).Exec(ctx, sql, args...)
+}
+func (c *pgxPoolConnAdapter) QueryRow(ctx context.Context, sql string, args ...any) scannable {
+	return (*pgxpool.Conn)(c).QueryRow(ctx, sql, args...)
+}
+func (c *pgxPoolConnAdapter) Release() { (*pgxpool.Conn)(c).Release() }
+
+// Work runs one scheduler pass. It takes a session-level advisory lock so at
+// most one scheduler pass runs at a time across concurrent CP instances
+// (including RunOnStart re-fires on rolling deploys). The atomic
+// ClaimDueSchedules path (FOR UPDATE SKIP LOCKED) inside svc is the inner
+// guard that handles any race that slips past the advisory lock window.
 func (w *ScheduleWorker) Work(ctx context.Context, _ *river.Job[ScheduleArgs]) error {
-	due, err := w.svc.DueSchedules(ctx, 200)
+	// Single-flight guard: take a session-level advisory lock on the scheduler
+	// namespace. Two CP instances racing on the same tick will both try to acquire;
+	// the loser skips the pass (returns nil). The winner proceeds.
+	if w.pool != nil {
+		conn, err := w.pool.Acquire(ctx)
+		if err != nil {
+			// Pool exhausted or shutting down: skip this pass rather than pile up.
+			w.logger.Warn("backup_scheduler: could not acquire pool connection for advisory lock, skipping pass",
+				slog.Any("error", err))
+			return nil
+		}
+		defer conn.Release()
+
+		var got bool
+		if serr := conn.QueryRow(ctx,
+			`SELECT pg_try_advisory_lock(hashtext('backup_scheduler'))`,
+		).Scan(&got); serr != nil {
+			w.logger.Warn("backup_scheduler: advisory lock query failed, proceeding without lock",
+				slog.Any("error", serr))
+			// Proceed without the lock — SKIP LOCKED is still the inner guard.
+		} else if !got {
+			// Another instance holds the lock; skip this pass.
+			w.logger.Info("backup_scheduler: advisory lock held by peer, skipping pass")
+			return nil
+		} else {
+			// Release the advisory lock when the pass finishes (session-level, so
+			// it must be explicitly released on the pinned conn, not left to GC).
+			defer func() {
+				_, _ = conn.Exec(ctx, `SELECT pg_advisory_unlock(hashtext('backup_scheduler'))`)
+			}()
+		}
+	}
+
+	// Atomic claim: select+lock+advance in one tx. Only claimed schedules are
+	// returned; concurrent passes see 0 rows via SKIP LOCKED.
+	claimed, err := w.svc.ClaimDueSchedules(ctx)
 	if err != nil {
 		return err
 	}
-	for _, sched := range due {
+	for _, sched := range claimed {
 		if eerr := w.svc.EnqueueScheduledBackup(ctx, sched); eerr != nil {
-			// Per-schedule error (e.g. site not enrolled): logged, schedule already
-			// advanced by EnqueueScheduledBackup; continue with the next.
+			// Per-schedule error (e.g. site not enrolled, in-flight guard): log
+			// and continue — the schedule was already advanced, next tick is fine.
 			w.logger.Info("backup schedule skipped",
 				slog.String("schedule_id", sched.ID.String()),
 				slog.Any("reason", eerr))

--- a/apps/api/migrations/20260708000000_m75_backup_scheduler_fix.sql
+++ b/apps/api/migrations/20260708000000_m75_backup_scheduler_fix.sql
@@ -1,0 +1,57 @@
+-- m75: backup scheduler correctness fixes (issue #68)
+--
+-- Two changes, both idempotent:
+--
+-- 1. RECONCILE duplicate in-flight snapshots first (data-heal).
+--    For each (site_id) with more than one pending/running snapshot, mark
+--    all but the newest as 'failed' so the unique index can be created.
+--    The RLS on backup_snapshots is enforced at runtime, not at DDL time, so
+--    this raw UPDATE is safe to run here under the migration role.
+--
+-- 2. PARTIAL UNIQUE INDEX: at most one pending-or-running snapshot per site.
+--    Belt-and-suspenders behind the Go-level in-flight guard in CreateSnapshot
+--    and EnqueueScheduledBackup. The index is partial (WHERE status IN (...))
+--    so completed/failed rows are unconstrained and retention GC is unaffected.
+--    Name: backup_snapshots_one_inflight_per_site (vendor-neutral, no PG prefix).
+
+-- -----------------------------------------------------------------------
+-- Step 1: reconcile duplicate in-flight snapshots
+-- -----------------------------------------------------------------------
+DO $$
+BEGIN
+    -- Mark older duplicates as failed so the unique index creation succeeds.
+    -- The subquery picks the NEWEST in-flight snapshot per site; the UPDATE
+    -- targets all other in-flight rows for the same site.
+    UPDATE backup_snapshots
+       SET status      = 'failed',
+           error       = 'duplicate_in_flight_healed',
+           finished_at = now(),
+           updated_at  = now()
+     WHERE status IN ('pending', 'running')
+       AND id NOT IN (
+           SELECT DISTINCT ON (site_id) id
+             FROM backup_snapshots
+            WHERE status IN ('pending', 'running')
+            ORDER BY site_id, created_at DESC
+       );
+END;
+$$;
+
+-- -----------------------------------------------------------------------
+-- Step 2: partial unique index — at most one in-flight snapshot per site
+-- -----------------------------------------------------------------------
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'public'
+           AND c.relname = 'backup_snapshots_one_inflight_per_site'
+           AND c.relkind = 'i'
+    ) THEN
+        CREATE UNIQUE INDEX backup_snapshots_one_inflight_per_site
+            ON backup_snapshots (site_id)
+         WHERE status IN ('pending', 'running');
+    END IF;
+END;
+$$;


### PR DESCRIPTION
Fixes #68 — scheduled backups re-fire every few minutes because the control-plane scheduler left `next_run_at` stuck in the past.

## Root cause (3 confirmed defects, code-traced)
1. **Re-enable preserved a stale past `next_run_at`** — `PutSchedule` only recomputed it on a *timing*-field change, and `UpsertSchedule`'s `ON CONFLICT` omitted the column entirely. Every 5-min tick then re-selected the overdue row forever.
2. **Non-atomic select-then-advance + swallowed errors** — `ListDueSchedules` and `AdvanceScheduleRun` ran in separate transactions with the advance error discarded → concurrent passes / `RunOnStart` / multi-instance double-fired.
3. **No in-flight guard** — overlapping runs collided → "same generation twice (Completed + Failed-stalled >2m)" and gen-5-in-a-night.

## Fix
- `PutSchedule` heals `next_run_at` on disabled→enabled or when already overdue (**skip-missed**: advances to next future slot, does not run immediately); `UpsertSchedule` now writes `next_run_at`.
- `ClaimAndAdvanceDueSchedules`: `FOR UPDATE SKIP LOCKED` claim that advances in the same tx; claim/advance errors logged + schedule skipped (never enqueued with an unpersisted advance).
- In-flight guard (`CountInFlightSnapshots`) on scheduled + manual paths + partial unique index `backup_snapshots_one_inflight_per_site` (m75); unique-violation = skip, not 500.
- Single-flight scheduler: pg advisory lock + periodic-job `UniqueOpts`.
- Boot heal recomputes `next_run_at` per-site (site tz) for already-stuck rows and reconciles duplicate in-flight snapshots before the index applies.

## Verification
`go build ./...` + full `apps/api` suite green (46 pkgs, +6 new scheduler tests: re-enable heal, overdue self-heal, atomic claim under concurrency, error-surfacing, in-flight guard, 24h-tick simulation = 1 run/day). sqlc regen no-op. No agent change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed scheduled backups from re-triggering on every scheduler tick when next-run time falls into the past
  * Overdue schedules now automatically advance to the next future run slot on startup
  * Enforced atomic scheduling to ensure only one backup per site can be in flight at a time
  * Added automatic reconciliation of duplicate in-flight backups on startup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->