### PR TITLE
docs: changelog 0.51.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.51.3] - 2026-06-19
+
 ### Fixed
 
 - **Scheduled backups no longer re-fire every few minutes.** A schedule whose next-run time had slipped into the past (most often after being disabled and re-enabled) was re-triggered on every scheduler tick, producing many runs per night, overlapping runs, and a daily incremental chain climbing several generations in one night. Re-enabling or an already-overdue schedule now advances to the next future run slot; the scheduler claims and advances each due schedule in a single atomic step; only one backup per site can be in flight at a time; and any schedules already stuck in the past are healed automatically on startup. (#68)


### PR DESCRIPTION
Marks the 0.51.3 release section (scheduler re-fire fix, #68). Code already on main via #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)