### PR TITLE
feat: security suite phase 1 — WP hardening + ban list (0.52.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.52.0] - 2026-06-20
+
+### Added
+
+- **Per-site WordPress hardening controls.** A new Security tab on every site lets operators push hardening settings directly from the control plane to the agent. Controls cover: disable the built-in file editor; XML-RPC (on, limited to pingbacks only, or fully off); REST API restriction; login identifier restriction (username, email, or both); force unique nicknames; block author-archive user enumeration; force SSL with HSTS; disable directory browsing; block PHP execution in uploads; and protect system files (wp-config.php, .htaccess, readme files). All controls are off by default and opt-in. The control plane and the operator's own session can never be locked out by a hardening rule.
+- **Per-site ban list.** A durable, operator-managed list of blocked IP addresses, CIDR ranges, and user agents, stored on the control plane and enforced in the agent at early-boot and at the web-server config level. Broad blocks covering all addresses and private/loopback ranges are rejected. The operator's own allow-list IPs always bypass the ban, so a misconfigured ban can never lock the operator out. The ban list is also default-off and opt-in.
+- **Site Security tab.** A dedicated Security area on each site in the dashboard surfaces hardening controls and the ban list in one place, gated to operators.
+
 ## [0.51.5] - 2026-06-20
 
 ### Fixed

--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -68,6 +68,8 @@ use WPMgr\Agent\Commands\PingCommand;
 use WPMgr\Agent\Commands\ResendEmailCommand;
 use WPMgr\Agent\Commands\SendTestEmailCommand;
 use WPMgr\Agent\Commands\SyncEmailConfigCommand;
+use WPMgr\Agent\Commands\SyncSecurityHardeningCommand;
+use WPMgr\Agent\Security\HardeningModule;
 use WPMgr\Agent\Email\EmailLogger;
 use WPMgr\Agent\Email\EmailLogReporter;
 use WPMgr\Agent\Email\Handlers\MailgunHandler;
@@ -250,6 +252,13 @@ final class Plugin
     private HeartbeatCatchup $heartbeatCatchup;
 
     /**
+     * Security hardening module. Receives the config from
+     * SyncSecurityHardeningCommand, persists it, and registers the WordPress
+     * hooks that enforce each enabled toggle on every subsequent request.
+     */
+    private HardeningModule $hardeningModule;
+
+    /**
      * Private constructor wires the object graph.
      */
     private function __construct()
@@ -290,6 +299,10 @@ final class Plugin
         // Login Whitelabel — cosmetic branding pushed from the CP. No external
         // dependencies; constructed here so sync_login_brand can hold a reference.
         $this->loginBrand = new LoginBrand();
+
+        // Security hardening module. Constructed BEFORE commands() so
+        // SyncSecurityHardeningCommand can hold a reference.
+        $this->hardeningModule = new HardeningModule();
 
         // ADR-042 Phase 2 — self-update checker. Shares the Signer, Settings,
         // Keystore, and a fresh ReplayCache (the autologin replay table — the
@@ -636,6 +649,12 @@ final class Plugin
         // only when at least one brand field is non-empty (self-gating). The
         // call is idempotent (static guard inside LoginBrand::install).
         $this->loginBrand->install();
+
+        // Security hardening — bind WP hooks for each enabled toggle (xmlrpc,
+        // REST restrict, login-identifier, author enum, force-ssl, ban filters).
+        // Only registers hooks for toggles that are actually on; an unconfigured
+        // site pays just a single get_option() read. Idempotent (static guard).
+        $this->hardeningModule->install();
 
         // ADR-042 Phase 2 — bind the CP self-update hooks. Self-gates on
         // isEnrolled() inside UpdateChecker::install(); idempotent (static guard).
@@ -1296,6 +1315,11 @@ final class Plugin
             new CachePreloadQueueRetryFailedCommand($this->cacheManager),
             new CachePreloadQueueClearCommand($this->cacheManager),
             new CachePreloadQueueTestRestCommand($this->cacheManager),
+            // Security hardening sync. The CP pushes the full config + ban list;
+            // the agent persists it atomically, applies the DISALLOW_FILE_EDIT
+            // define to wp-config, refreshes the .htaccess security block, and
+            // merges IP/range bans into the WAF mu-plugin's deny_cidrs.
+            new SyncSecurityHardeningCommand($this->hardeningModule),
             // Email (Phase 2) — per-site outgoing-mail configuration + test.
             // sync_email_config: receives the full provider config (including the
             //   DECRYPTED secret) from the CP and stores it in the agent keystore.

--- a/apps/agent/includes/commands/class-sync-security-hardening-command.php
+++ b/apps/agent/includes/commands/class-sync-security-hardening-command.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * SyncSecurityHardeningCommand — receives the hardening config + ban list from
+ * the control plane and atomically applies it on the WordPress site.
+ *
+ * Wire contract (CP -> agent):
+ *   POST /wp-json/wpmgr/v1/command/sync_security_hardening
+ *   Authorization: Bearer <Ed25519 JWT with cmd="sync_security_hardening", aud=<siteId>>
+ *   Content-Type: application/json
+ *   Body: {
+ *     "config": {
+ *       "disable_file_editor":        <bool>,
+ *       "xmlrpc_mode":                "on"|"off"|"limited",
+ *       "restrict_rest_api":          "default"|"restricted",
+ *       "restrict_login_identifier":  "username"|"email"|"both",
+ *       "force_unique_nickname":      <bool>,
+ *       "disable_author_archive_enum": <bool>,
+ *       "force_ssl":                  <bool>,
+ *       "disable_directory_browsing": <bool>,
+ *       "disable_php_in_uploads":     <bool>,
+ *       "protect_system_files":       <bool>
+ *     },
+ *     "bans": [
+ *       {"id":"<uuid>","type":"ip","value":"1.2.3.4","comment":"..."},
+ *       {"id":"<uuid>","type":"range","value":"10.0.0.0/8","comment":"..."},
+ *       {"id":"<uuid>","type":"user_agent","value":"badbot/1.0"}
+ *     ]
+ *   }
+ *
+ * Response (200 OK, wrapped by Router):
+ *   { "ok": true, "detail": "applied" }
+ *
+ * Auth: Router's permission_callback enforces the Ed25519 + anti-replay JWT
+ * contract (Connector::verifyCommand) before execute() is called.
+ *
+ * On every push the agent replaces its local hardening config + ban list
+ * ATOMICALLY (single update_option write). Missing toggles default to off for
+ * forward-compat (HardeningConfig::fromArray() handles this).
+ *
+ * @package WPMgr\Agent\Commands
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Commands;
+
+use WPMgr\Agent\Security\HardeningConfig;
+use WPMgr\Agent\Security\HardeningModule;
+
+/**
+ * Persists and applies the CP-pushed hardening config + ban list.
+ */
+final class SyncSecurityHardeningCommand implements CommandInterface
+{
+    private HardeningModule $module;
+
+    /**
+     * @param HardeningModule $module The shared hardening-module instance.
+     */
+    public function __construct(HardeningModule $module)
+    {
+        $this->module = $module;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function name(): string
+    {
+        return 'sync_security_hardening';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Accepts the full wire contract body described in the file docblock.
+     * Top-level validation is minimal: we require `config` to be an object (if
+     * present) and `bans` to be an array (if present). All per-field validation
+     * and safe-defaulting is delegated to HardeningConfig::fromArray() so this
+     * command can never brick the agent on a malformed push.
+     *
+     * @param array<string,mixed> $claims Validated JWT claims (unused; Router
+     *   already enforced aud + cmd binding before dispatch).
+     * @param array<string,mixed> $params Decoded JSON body from the CP.
+     * @return array{ok:bool,detail:string}
+     */
+    public function execute(array $claims, array $params): array
+    {
+        // 'config' key must be an object / associative array if provided.
+        if (array_key_exists('config', $params) && !is_array($params['config'])) {
+            return ['ok' => false, 'detail' => 'config must be an object'];
+        }
+
+        // 'bans' key must be an array if provided.
+        if (array_key_exists('bans', $params) && !is_array($params['bans'])) {
+            return ['ok' => false, 'detail' => 'bans must be an array'];
+        }
+
+        try {
+            // Build and validate the full config; safe defaults for any missing/
+            // invalid field (never throws, always returns a valid object).
+            $config = HardeningConfig::fromArray($params);
+
+            // Persist and apply. applyConfig() writes the wp-option atomically
+            // and refreshes the server-config block.
+            $persisted = $this->module->applyConfig($config);
+            if (!$persisted) {
+                return ['ok' => false, 'detail' => 'failed to persist hardening config'];
+            }
+
+            // Sync DISALLOW_FILE_EDIT in wp-config.php. Returns false when
+            // wp-config is not writable — we proceed anyway (runtime filter in
+            // HardeningModule::install() is the defence-in-depth fallback) and
+            // note it in the detail so the dashboard can surface the caveat.
+            $wpConfigOk = $this->module->syncWpConfigFileEdit($config);
+
+            // Merge IP/range bans into the WAF mu-plugin's deny_cidrs so
+            // they take effect at the earliest possible PHP boot point.
+            $this->module->syncWafDenyCidrs($config);
+        } catch (\Throwable $e) {
+            // Never let the config sync fatal the request.
+            return ['ok' => false, 'detail' => 'failed to apply hardening config'];
+        }
+
+        $detail = 'applied';
+        if ($config->disableFileEditor && !$wpConfigOk) {
+            $detail = 'applied; wp-config.php not writable — disable_file_editor via runtime filter only';
+        }
+
+        return ['ok' => true, 'detail' => $detail];
+    }
+}

--- a/apps/agent/includes/security/class-hardening-config.php
+++ b/apps/agent/includes/security/class-hardening-config.php
@@ -1,0 +1,365 @@
+<?php
+/**
+ * HardeningConfig — value object for the security-hardening config pushed by
+ * the control plane via sync_security_hardening.
+ *
+ * Every toggle defaults to OFF (false / 'on' / 'default' / 'both') so that a
+ * fresh push with missing fields never activates anything the operator did not
+ * explicitly choose. Missing toggles are treated as "off" for forward-compat.
+ *
+ * Wire contract (CP -> agent):
+ *   POST /wp-json/wpmgr/v1/command/sync_security_hardening
+ *   Body: {
+ *     "config": {
+ *       "disable_file_editor":        bool,
+ *       "xmlrpc_mode":                "on"|"off"|"limited",
+ *       "restrict_rest_api":          "default"|"restricted",
+ *       "restrict_login_identifier":  "username"|"email"|"both",
+ *       "force_unique_nickname":      bool,
+ *       "disable_author_archive_enum": bool,
+ *       "force_ssl":                  bool,
+ *       "disable_directory_browsing": bool,
+ *       "disable_php_in_uploads":     bool,
+ *       "protect_system_files":       bool
+ *     },
+ *     "bans": [
+ *       {"id":"<uuid>","type":"ip","value":"1.2.3.4","comment":"..."},
+ *       {"id":"<uuid>","type":"range","value":"10.0.0.0/8","comment":"..."},
+ *       {"id":"<uuid>","type":"user_agent","value":"badbot/1.0"}
+ *     ]
+ *   }
+ *
+ * @package WPMgr\Agent\Security
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Security;
+
+/**
+ * Immutable, validated value object for hardening config + ban list.
+ */
+final class HardeningConfig
+{
+    public const XMLRPC_ON      = 'on';
+    public const XMLRPC_OFF     = 'off';
+    public const XMLRPC_LIMITED = 'limited';
+
+    public const REST_DEFAULT    = 'default';
+    public const REST_RESTRICTED = 'restricted';
+
+    public const LOGIN_BOTH     = 'both';
+    public const LOGIN_USERNAME = 'username';
+    public const LOGIN_EMAIL    = 'email';
+
+    public const BAN_TYPE_IP         = 'ip';
+    public const BAN_TYPE_RANGE      = 'range';
+    public const BAN_TYPE_USER_AGENT = 'user_agent';
+
+    /** Toggle: add DISALLOW_FILE_EDIT to wp-config. */
+    public readonly bool $disableFileEditor;
+
+    /** One of: on|off|limited. */
+    public readonly string $xmlrpcMode;
+
+    /** One of: default|restricted. */
+    public readonly string $restrictRestApi;
+
+    /** One of: both|username|email. */
+    public readonly string $restrictLoginIdentifier;
+
+    /** Toggle: force nickname != user_login. */
+    public readonly bool $forceUniqueNickname;
+
+    /** Toggle: 404 ?author=N redirects + hide users from anon REST. */
+    public readonly bool $disableAuthorArchiveEnum;
+
+    /** Toggle: server-config http->https redirect + HSTS. */
+    public readonly bool $forceSsl;
+
+    /** Toggle: Options -Indexes in server config. */
+    public readonly bool $disableDirectoryBrowsing;
+
+    /** Toggle: block PHP execution in uploads dir. */
+    public readonly bool $disablePhpInUploads;
+
+    /** Toggle: block web access to wp-config.php, .htaccess, etc. */
+    public readonly bool $protectSystemFiles;
+
+    /**
+     * Validated ban list. Each entry has:
+     *   id:      string (uuid)
+     *   type:    "ip"|"range"|"user_agent"
+     *   value:   string
+     *   comment: string (optional)
+     *
+     * @var array<int,array{id:string,type:string,value:string,comment:string}>
+     */
+    public readonly array $bans;
+
+    /**
+     * @param bool   $disableFileEditor
+     * @param string $xmlrpcMode
+     * @param string $restrictRestApi
+     * @param string $restrictLoginIdentifier
+     * @param bool   $forceUniqueNickname
+     * @param bool   $disableAuthorArchiveEnum
+     * @param bool   $forceSsl
+     * @param bool   $disableDirectoryBrowsing
+     * @param bool   $disablePhpInUploads
+     * @param bool   $protectSystemFiles
+     * @param array<int,array{id:string,type:string,value:string,comment:string}> $bans
+     */
+    public function __construct(
+        bool $disableFileEditor,
+        string $xmlrpcMode,
+        string $restrictRestApi,
+        string $restrictLoginIdentifier,
+        bool $forceUniqueNickname,
+        bool $disableAuthorArchiveEnum,
+        bool $forceSsl,
+        bool $disableDirectoryBrowsing,
+        bool $disablePhpInUploads,
+        bool $protectSystemFiles,
+        array $bans
+    ) {
+        $this->disableFileEditor        = $disableFileEditor;
+        $this->xmlrpcMode               = $xmlrpcMode;
+        $this->restrictRestApi          = $restrictRestApi;
+        $this->restrictLoginIdentifier  = $restrictLoginIdentifier;
+        $this->forceUniqueNickname      = $forceUniqueNickname;
+        $this->disableAuthorArchiveEnum = $disableAuthorArchiveEnum;
+        $this->forceSsl                 = $forceSsl;
+        $this->disableDirectoryBrowsing = $disableDirectoryBrowsing;
+        $this->disablePhpInUploads      = $disablePhpInUploads;
+        $this->protectSystemFiles       = $protectSystemFiles;
+        $this->bans                     = $bans;
+    }
+
+    /**
+     * Build and validate a HardeningConfig from a raw decoded JSON payload
+     * (the 'config' + 'bans' keys of the wire contract). Missing/invalid fields
+     * fall back to safe off-defaults rather than throwing, so a malformed push
+     * can never brick the agent.
+     *
+     * @param array<string,mixed> $raw Top-level decoded JSON body.
+     * @return self
+     */
+    public static function fromArray(array $raw): self
+    {
+        $cfg  = isset($raw['config']) && is_array($raw['config']) ? $raw['config'] : [];
+        $bans = isset($raw['bans'])   && is_array($raw['bans'])   ? $raw['bans']   : [];
+
+        $xmlrpcMode = self::coerceEnum(
+            $cfg['xmlrpc_mode'] ?? 'on',
+            [self::XMLRPC_ON, self::XMLRPC_OFF, self::XMLRPC_LIMITED],
+            self::XMLRPC_ON
+        );
+
+        $restrictRestApi = self::coerceEnum(
+            $cfg['restrict_rest_api'] ?? 'default',
+            [self::REST_DEFAULT, self::REST_RESTRICTED],
+            self::REST_DEFAULT
+        );
+
+        $restrictLogin = self::coerceEnum(
+            $cfg['restrict_login_identifier'] ?? 'both',
+            [self::LOGIN_BOTH, self::LOGIN_USERNAME, self::LOGIN_EMAIL],
+            self::LOGIN_BOTH
+        );
+
+        $validatedBans = self::validateBans($bans);
+
+        return new self(
+            (bool) ($cfg['disable_file_editor']         ?? false),
+            $xmlrpcMode,
+            $restrictRestApi,
+            $restrictLogin,
+            (bool) ($cfg['force_unique_nickname']        ?? false),
+            (bool) ($cfg['disable_author_archive_enum']  ?? false),
+            (bool) ($cfg['force_ssl']                    ?? false),
+            (bool) ($cfg['disable_directory_browsing']   ?? false),
+            (bool) ($cfg['disable_php_in_uploads']       ?? false),
+            (bool) ($cfg['protect_system_files']         ?? false),
+            $validatedBans
+        );
+    }
+
+    /**
+     * Serialize to a compact array for wp-options storage.
+     *
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'config' => [
+                'disable_file_editor'        => $this->disableFileEditor,
+                'xmlrpc_mode'                => $this->xmlrpcMode,
+                'restrict_rest_api'          => $this->restrictRestApi,
+                'restrict_login_identifier'  => $this->restrictLoginIdentifier,
+                'force_unique_nickname'      => $this->forceUniqueNickname,
+                'disable_author_archive_enum' => $this->disableAuthorArchiveEnum,
+                'force_ssl'                  => $this->forceSsl,
+                'disable_directory_browsing' => $this->disableDirectoryBrowsing,
+                'disable_php_in_uploads'     => $this->disablePhpInUploads,
+                'protect_system_files'       => $this->protectSystemFiles,
+            ],
+            'bans' => $this->bans,
+        ];
+    }
+
+    /**
+     * Load the stored config from wp-options, falling back to defaults if
+     * the option is absent or malformed.
+     *
+     * @return self
+     */
+    public static function load(): self
+    {
+        if (!function_exists('get_option')) {
+            return self::defaults();
+        }
+
+        $raw = get_option(HardeningModule::OPTION_CONFIG, '');
+        if (!is_string($raw) || $raw === '') {
+            return self::defaults();
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            return self::defaults();
+        }
+
+        return self::fromArray($decoded);
+    }
+
+    /**
+     * Return the all-off default config (no toggles active, no bans).
+     *
+     * @return self
+     */
+    public static function defaults(): self
+    {
+        return new self(
+            false,
+            self::XMLRPC_ON,
+            self::REST_DEFAULT,
+            self::LOGIN_BOTH,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            []
+        );
+    }
+
+    /**
+     * Return only the IP/range bans (used by WAF early-gate integration).
+     *
+     * @return array<int,string>
+     */
+    public function ipRangeBans(): array
+    {
+        $out = [];
+        foreach ($this->bans as $ban) {
+            if (in_array($ban['type'], [self::BAN_TYPE_IP, self::BAN_TYPE_RANGE], true)) {
+                $out[] = $ban['value'];
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * Return only user-agent ban patterns.
+     *
+     * @return array<int,string>
+     */
+    public function userAgentBans(): array
+    {
+        $out = [];
+        foreach ($this->bans as $ban) {
+            if ($ban['type'] === self::BAN_TYPE_USER_AGENT) {
+                $out[] = $ban['value'];
+            }
+        }
+        return $out;
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Coerce a value to one of an allowed set; use $default when invalid.
+     *
+     * @param mixed          $value   Candidate value.
+     * @param array<string>  $allowed Allowed strings.
+     * @param string         $default Safe default.
+     * @return string
+     */
+    private static function coerceEnum(mixed $value, array $allowed, string $default): string
+    {
+        if (is_string($value) && in_array($value, $allowed, true)) {
+            return $value;
+        }
+        return $default;
+    }
+
+    /**
+     * Validate the raw bans array. Each entry must have id, type, value as
+     * non-empty strings. Unknown types, empty values, or non-string fields are
+     * silently dropped rather than causing an error.
+     *
+     * @param array<mixed> $rawBans
+     * @return array<int,array{id:string,type:string,value:string,comment:string}>
+     */
+    private static function validateBans(array $rawBans): array
+    {
+        $valid = [];
+        foreach ($rawBans as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+            $id      = is_string($entry['id'] ?? null)    ? trim($entry['id'])    : '';
+            $type    = is_string($entry['type'] ?? null)   ? trim($entry['type'])   : '';
+            $value   = is_string($entry['value'] ?? null)  ? trim($entry['value'])  : '';
+            $comment = is_string($entry['comment'] ?? null) ? trim($entry['comment']) : '';
+
+            if ($id === '' || $value === '') {
+                continue;
+            }
+            $allowedTypes = [self::BAN_TYPE_IP, self::BAN_TYPE_RANGE, self::BAN_TYPE_USER_AGENT];
+            if (!in_array($type, $allowedTypes, true)) {
+                continue;
+            }
+
+            // IP/range: validate the value is something inet_pton can parse
+            // (for ip), or has /prefix notation (for range). Silently skip junk.
+            if ($type === self::BAN_TYPE_IP) {
+                if (filter_var($value, FILTER_VALIDATE_IP) === false) {
+                    continue;
+                }
+            } elseif ($type === self::BAN_TYPE_RANGE) {
+                $parts = explode('/', $value, 2);
+                if (count($parts) !== 2
+                    || filter_var($parts[0], FILTER_VALIDATE_IP) === false
+                    || !ctype_digit($parts[1])
+                ) {
+                    continue;
+                }
+            }
+            // user_agent: no structural validation beyond non-empty.
+
+            $valid[] = [
+                'id'      => $id,
+                'type'    => $type,
+                'value'   => $value,
+                'comment' => $comment,
+            ];
+        }
+        return $valid;
+    }
+}

--- a/apps/agent/includes/security/class-hardening-config.php
+++ b/apps/agent/includes/security/class-hardening-config.php
@@ -351,7 +351,17 @@ final class HardeningConfig
                     continue;
                 }
             }
-            // user_agent: no structural validation beyond non-empty.
+
+            // BLOCKER 2: Drop any ban value that contains control characters
+            // (CR, LF, NUL, or any char < 0x20). Such values would allow
+            // injection of arbitrary Apache directives into the managed .htaccess
+            // block because preg_quote() does NOT neutralise newlines.
+            // Reject and drop — do not sanitize-and-keep.
+            if (preg_match('/[\x00-\x1F\x7F]/', $value) === 1) {
+                continue;
+            }
+
+            // user_agent: no structural validation beyond non-empty + above control-char check.
 
             $valid[] = [
                 'id'      => $id,

--- a/apps/agent/includes/security/class-hardening-module.php
+++ b/apps/agent/includes/security/class-hardening-module.php
@@ -446,20 +446,23 @@ final class HardeningModule
     }
 
     /**
-     * Feed IP/range bans from the hardening config into the existing WAF mu-plugin
-     * by merging them into the deny_cidrs list of wpmgr_security_config.
+     * Feed IP/range bans from the hardening config into the WAF mu-plugin's
+     * dedicated 'hardening_deny_cidrs' key in wpmgr_security_config.
      *
-     * The WAF mu-plugin reads wpmgr_security_config's deny_cidrs at boot time
-     * (before WP loads). We append the hardening bans to that list so they take
-     * effect at the earliest possible point (pre-WP mu-plugin boot), rather than
-     * waiting for the PHP 'init' action.
+     * The WAF mu-plugin reads wpmgr_security_config at boot time (before WP loads)
+     * and evaluates 'hardening_deny_cidrs' in ALL modes, independent of the
+     * login-protection 'mode' field. This is the ITEM 5 fix: explicit operator
+     * bans must always block, not only when brute-force protect mode is on.
+     *
+     * Keeping hardening bans in their own key ('hardening_deny_cidrs') instead of
+     * merging into 'deny_cidrs' keeps the two enforcement layers cleanly separated
+     * and makes removal on ban-list change trivial (overwrite the key, no diff needed).
+     *
+     * SAFETY: the WAF mu-plugin's allow_cidrs guard and private/loopback bypass
+     * both apply before the hardening_deny_cidrs check. No lock-out is possible
+     * for private IPs or allow-listed control-plane egress addresses.
      *
      * This is called by SyncSecurityHardeningCommand after persistence.
-     *
-     * SAFETY: loopback/private IPs and the control-plane allow_cidrs are never
-     * denied — the WAF mu-plugin itself enforces this with its isPrivate() check
-     * and the allow_cidrs guard. We do not validate private-ness here; we rely on
-     * the WAF gate (which is tested independently).
      *
      * @param HardeningConfig $config
      * @return void
@@ -481,38 +484,28 @@ final class HardeningModule
             return;
         }
 
-        // Existing deny_cidrs from the login-protection / WAF config.
-        $existingDeny = isset($wafConfig['deny_cidrs']) && is_array($wafConfig['deny_cidrs'])
-            ? $wafConfig['deny_cidrs']
+        // Write the hardening ban CIDRs into their own dedicated key so the WAF
+        // can evaluate them mode-independently (ITEM 5). The 'deny_cidrs' key
+        // remains owned solely by the login-protection / brute-force subsystem.
+        //
+        // Defence-in-depth: filter out broad/private CIDRs before persisting.
+        // The runtime WAF already bypasses private IPs, but the agent must not
+        // store a dangerous CIDR that it received from the CP (belt-and-braces).
+        // WafCidrGuard applies the same rules used by ServerConfigWriter at render
+        // time, ensuring a single source of truth for what counts as "unsafe".
+        $allowCidrs = isset($wafConfig['allow_cidrs']) && is_array($wafConfig['allow_cidrs'])
+            ? array_values(array_filter($wafConfig['allow_cidrs'], 'is_string'))
             : [];
-
-        // Strip any previously-synced hardening bans (identified by a marker comment
-        // convention in the value is NOT possible, so instead we store them separately
-        // and merge; we rebuild the list from scratch each sync).
-        // We store the hardening-ban CIDRs in a separate wp-option so we know which
-        // deny_cidrs to remove when the ban list changes.
-        $prevHardeningCidrs = get_option('wpmgr_hardening_waf_cidrs', []);
-        if (!is_array($prevHardeningCidrs)) {
-            $prevHardeningCidrs = [];
+        $rawBans           = $config->ipRangeBans();
+        $newHardeningCidrs = [];
+        foreach ($rawBans as $cidr) {
+            $cidr = trim((string) $cidr);
+            if (!WafCidrGuard::isUnsafe($cidr, $allowCidrs)) {
+                $newHardeningCidrs[] = $cidr;
+            }
         }
+        $wafConfig['hardening_deny_cidrs'] = array_values($newHardeningCidrs);
 
-        // Remove only the previously-synced hardening bans from existingDeny.
-        $cleanedDeny = array_values(array_filter(
-            $existingDeny,
-            static fn (mixed $cidr): bool => is_string($cidr) && !in_array($cidr, $prevHardeningCidrs, true)
-        ));
-
-        // New hardening bans.
-        $newHardeningCidrs = $config->ipRangeBans();
-
-        // Merged list.
-        $merged = array_values(array_unique(array_merge($cleanedDeny, $newHardeningCidrs)));
-
-        // Persist the new hardening CIDRs list so next sync knows what to remove.
-        update_option('wpmgr_hardening_waf_cidrs', $newHardeningCidrs, false);
-
-        // Write back the merged deny_cidrs into wpmgr_security_config.
-        $wafConfig['deny_cidrs'] = $merged;
         $encoded = wp_json_encode($wafConfig);
         if ($encoded !== false) {
             update_option('wpmgr_security_config', $encoded, false);

--- a/apps/agent/includes/security/class-hardening-module.php
+++ b/apps/agent/includes/security/class-hardening-module.php
@@ -1,0 +1,521 @@
+<?php
+/**
+ * HardeningModule — applies the WPMgr security hardening config to WordPress
+ * by binding the correct hooks for each enabled toggle.
+ *
+ * Design principles:
+ *   - Default OFF: every hook is only registered when its toggle is on.
+ *   - Idempotent: install() is guarded by a static flag; safe to call on every
+ *     boot (plugins_loaded).
+ *   - Non-breaking: no hook fatals the request; force_ssl and REST restrict
+ *     always exempt the agent's own REST routes (/wpmgr/v1/...).
+ *   - Server-config writes delegate entirely to ServerConfigWriter; this class
+ *     owns only the WP-PHP layer.
+ *
+ * @package WPMgr\Agent\Security
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Security;
+
+use WPMgr\Agent\Cache\WpConfigEditor;
+
+/**
+ * WordPress-hooks enforcer for the hardening config.
+ */
+final class HardeningModule
+{
+    /**
+     * wp-options key for the stored hardening config (JSON-encoded HardeningConfig::toArray()).
+     */
+    public const OPTION_CONFIG = 'wpmgr_hardening_config';
+
+    /** REST namespace the agent owns — never restricted. */
+    private const AGENT_REST_NAMESPACE = 'wpmgr/v1';
+
+    /** Autologin route path — never restricted. */
+    private const AGENT_AUTOLOGIN_PATH = '/autologin';
+
+    /**
+     * Persist a new config and install/refresh the server-config block.
+     *
+     * Called by SyncSecurityHardeningCommand::execute(). Returns true when
+     * persistence succeeded.
+     *
+     * @param HardeningConfig $config Validated config object.
+     * @return bool
+     */
+    public function applyConfig(HardeningConfig $config): bool
+    {
+        if (!function_exists('update_option')) {
+            return false;
+        }
+
+        $encoded = wp_json_encode($config->toArray());
+        if ($encoded === false) {
+            return false;
+        }
+
+        update_option(self::OPTION_CONFIG, $encoded, false);
+
+        // Refresh the server-config block immediately on sync.
+        $writer = new ServerConfigWriter();
+        if (!$writer->isNginx()) {
+            $hasAnyServerRule = $config->forceSsl
+                || $config->disableDirectoryBrowsing
+                || $config->disablePhpInUploads
+                || $config->protectSystemFiles
+                || $config->xmlrpcMode === HardeningConfig::XMLRPC_OFF
+                || $config->ipRangeBans() !== []
+                || $config->userAgentBans() !== [];
+
+            if ($hasAnyServerRule) {
+                $writer->install($config);
+            } else {
+                // All toggles off — remove any prior block cleanly.
+                $writer->uninstall();
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Register WP hooks for every enabled toggle. Call once on plugins_loaded.
+     * Safe to call on every boot: a static guard makes it idempotent.
+     *
+     * @return void
+     */
+    public function install(): void
+    {
+        static $installed = false;
+        if ($installed) {
+            return;
+        }
+        $installed = true;
+
+        $config = HardeningConfig::load();
+
+        $this->applyDisableFileEditor($config);
+        $this->applyXmlrpc($config);
+        $this->applyRestRestrict($config);
+        $this->applyLoginIdentifier($config);
+        $this->applyForceUniqueNickname($config);
+        $this->applyAuthorArchiveEnum($config);
+        $this->applyForceSsl($config);
+        $this->applyBanFilters($config);
+    }
+
+    // -------------------------------------------------------------------------
+    // Per-toggle appliers (all no-ops when the toggle is off)
+    // -------------------------------------------------------------------------
+
+    /**
+     * disable_file_editor: write DISALLOW_FILE_EDIT to wp-config. The runtime
+     * filter is also bound as a defence-in-depth fallback for sites where the
+     * wp-config write fails (e.g. immutable filesystem).
+     *
+     * @param HardeningConfig $config
+     * @return void
+     */
+    private function applyDisableFileEditor(HardeningConfig $config): void
+    {
+        if (!$config->disableFileEditor) {
+            return;
+        }
+
+        // Runtime filter (defence-in-depth / fallback).
+        add_filter('user_has_cap', static function (array $caps, array $cap): array {
+            if (in_array('edit_themes', $cap, true) || in_array('edit_plugins', $cap, true)) {
+                $caps['edit_themes']  = false;
+                $caps['edit_plugins'] = false;
+            }
+            return $caps;
+        }, 10, 2);
+    }
+
+    /**
+     * Enable wp-config write for DISALLOW_FILE_EDIT. Called by the command
+     * handler after persistence so the define lands in wp-config immediately.
+     * Also removes the define when the toggle is turned off.
+     *
+     * @param HardeningConfig $config
+     * @return bool
+     */
+    public function syncWpConfigFileEdit(HardeningConfig $config): bool
+    {
+        $editor = new WpConfigEditor();
+        if (!$editor->isWritable()) {
+            // Non-writable wp-config: runtime filter (registered by install()) is
+            // the fallback. Signal partial success to the caller.
+            return false;
+        }
+
+        if ($config->disableFileEditor) {
+            return $editor->setConstant('DISALLOW_FILE_EDIT', true);
+        } else {
+            return $editor->removeConstant('DISALLOW_FILE_EDIT');
+        }
+    }
+
+    /**
+     * xmlrpc_mode: off => add_filter('xmlrpc_enabled','__return_false');
+     *              limited => disable only pingback methods;
+     *              on => no-op.
+     *
+     * @param HardeningConfig $config
+     * @return void
+     */
+    private function applyXmlrpc(HardeningConfig $config): void
+    {
+        if ($config->xmlrpcMode === HardeningConfig::XMLRPC_OFF) {
+            add_filter('xmlrpc_enabled', '__return_false');
+            return;
+        }
+
+        if ($config->xmlrpcMode === HardeningConfig::XMLRPC_LIMITED) {
+            // Disable multicall amplification and pingback methods only.
+            add_filter(
+                'xmlrpc_methods',
+                static function (array $methods): array {
+                    unset(
+                        $methods['system.multicall'],
+                        $methods['pingback.ping'],
+                        $methods['pingback.extensions.getPingbacks']
+                    );
+                    return $methods;
+                }
+            );
+        }
+    }
+
+    /**
+     * restrict_rest_api: restricted => require auth for anon REST requests,
+     * excluding the agent's own namespace and a fixed allowlist of safe routes.
+     * default => no-op.
+     *
+     * @param HardeningConfig $config
+     * @return void
+     */
+    private function applyRestRestrict(HardeningConfig $config): void
+    {
+        if ($config->restrictRestApi !== HardeningConfig::REST_RESTRICTED) {
+            return;
+        }
+
+        add_filter(
+            'rest_authentication_errors',
+            static function ($result) {
+                // Already handled by another filter or already authenticated.
+                if ($result !== null) {
+                    return $result;
+                }
+
+                // Authenticated users (cookies, application passwords, etc.) pass.
+                if (is_user_logged_in()) {
+                    return null;
+                }
+
+                // Allowlist: oembed (needed for embeds), the agent's own routes.
+                // We read the current route from the REST server global.
+                $route = '';
+                if (isset($GLOBALS['wp']->query_vars['rest_route'])
+                    && is_string($GLOBALS['wp']->query_vars['rest_route'])
+                ) {
+                    $route = $GLOBALS['wp']->query_vars['rest_route'];
+                }
+
+                // Agent namespace always passes.
+                $agentPrefix = '/' . self::AGENT_REST_NAMESPACE . '/';
+                if (str_starts_with($route, $agentPrefix)
+                    || $route === '/' . self::AGENT_REST_NAMESPACE
+                ) {
+                    return null;
+                }
+
+                // oembed consumer route.
+                if (str_starts_with($route, '/oembed/1.0/')) {
+                    return null;
+                }
+
+                return new \WP_Error(
+                    'rest_not_logged_in',
+                    'REST API access requires authentication.',
+                    ['status' => 401]
+                );
+            }
+        );
+    }
+
+    /**
+     * restrict_login_identifier: disable the WordPress core email or username
+     * authentication filter so only the allowed identifier type works.
+     *
+     * WP core registers two filters on 'authenticate':
+     *   - wp_authenticate_username_password (priority 20) — username login
+     *   - wp_authenticate_email_password    (priority 20) — email login
+     *
+     * We remove whichever one the operator wants to disable.
+     *
+     * @param HardeningConfig $config
+     * @return void
+     */
+    private function applyLoginIdentifier(HardeningConfig $config): void
+    {
+        if ($config->restrictLoginIdentifier === HardeningConfig::LOGIN_BOTH) {
+            return;
+        }
+
+        // We must hook after plugins_loaded so the default filters exist.
+        add_action('init', static function () use ($config): void {
+            if ($config->restrictLoginIdentifier === HardeningConfig::LOGIN_USERNAME) {
+                // Allow only username login — remove email auth.
+                remove_filter('authenticate', 'wp_authenticate_email_password', 20);
+            } elseif ($config->restrictLoginIdentifier === HardeningConfig::LOGIN_EMAIL) {
+                // Allow only email login — remove username auth.
+                remove_filter('authenticate', 'wp_authenticate_username_password', 20);
+            }
+        });
+    }
+
+    /**
+     * force_unique_nickname: prevent saving a display name identical to the
+     * user's login name (username harvesting via author archives).
+     *
+     * @param HardeningConfig $config
+     * @return void
+     */
+    private function applyForceUniqueNickname(HardeningConfig $config): void
+    {
+        if (!$config->forceUniqueNickname) {
+            return;
+        }
+
+        add_action('user_profile_update_errors', static function (\WP_Error $errors, bool $update, \WP_User $user): void {
+            if (!$update) {
+                return;
+            }
+            $nickname = isset($_POST['nickname']) && is_string($_POST['nickname']) // phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- nonce verified by WP core's profile-update handler before this hook fires; sanitized on the next line
+                ? sanitize_text_field(wp_unslash($_POST['nickname'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing -- same as above
+                : '';
+            $userLogin = $user->user_login;
+            if ($nickname !== '' && $userLogin !== '' && $nickname === $userLogin) {
+                $errors->add(
+                    'wpmgr_nickname_conflict',
+                    esc_html__('Your display name must not match your login username.', 'wpmgr-agent')
+                );
+            }
+        }, 10, 3);
+    }
+
+    /**
+     * disable_author_archive_enum: 404 ?author=N probe redirects, hide user list
+     * from anonymous REST requests (/wp/v2/users).
+     *
+     * @param HardeningConfig $config
+     * @return void
+     */
+    private function applyAuthorArchiveEnum(HardeningConfig $config): void
+    {
+        if (!$config->disableAuthorArchiveEnum) {
+            return;
+        }
+
+        // Block ?author=N redirect (redirects to /author/username/, leaking names).
+        add_action('template_redirect', static function (): void {
+            $authorQuery = isset($_GET['author']) ? sanitize_text_field(wp_unslash($_GET['author'])) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no state change; reading query var for enumeration protection check
+            if ($authorQuery !== '' && !is_user_logged_in()) {
+                global $wp_query;
+                if (isset($wp_query) && $wp_query instanceof \WP_Query && $wp_query->is_author()) {
+                    $wp_query->set_404();
+                    status_header(404);
+                    nocache_headers();
+                }
+            }
+        });
+
+        // Hide user list from anon REST /wp/v2/users.
+        add_filter(
+            'rest_endpoints',
+            static function (array $endpoints): array {
+                if (is_user_logged_in()) {
+                    return $endpoints;
+                }
+                $usersRoute = '/wp/v2/users';
+                if (isset($endpoints[$usersRoute])) {
+                    unset($endpoints[$usersRoute]);
+                }
+                $meRoute = '/wp/v2/users/me';
+                if (isset($endpoints[$meRoute])) {
+                    unset($endpoints[$meRoute]);
+                }
+                return $endpoints;
+            }
+        );
+    }
+
+    /**
+     * force_ssl: redirect http -> https and send HSTS at the PHP layer (for
+     * non-Apache or when server-config write failed).
+     *
+     * SAFETY: never redirects requests that arrive on the agent's own REST route
+     * on port 443 (already https), and never redirects WP-Cron or CLI.
+     *
+     * @param HardeningConfig $config
+     * @return void
+     */
+    private function applyForceSsl(HardeningConfig $config): void
+    {
+        if (!$config->forceSsl) {
+            return;
+        }
+
+        // Also set FORCE_SSL_ADMIN so wp-admin is covered.
+        if (!defined('FORCE_SSL_ADMIN')) {
+            define('FORCE_SSL_ADMIN', true);
+        }
+
+        add_action('template_redirect', static function (): void {
+            if (is_ssl()) {
+                return;
+            }
+            if (defined('DOING_CRON') && DOING_CRON) {
+                return;
+            }
+            if (php_sapi_name() === 'cli') {
+                return;
+            }
+            if (isset($_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'])
+                && is_string($_SERVER['HTTP_HOST'])
+                && is_string($_SERVER['REQUEST_URI'])
+            ) {
+                $host = sanitize_text_field(wp_unslash($_SERVER['HTTP_HOST'])); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitized via sanitize_text_field(wp_unslash())
+                $uri  = sanitize_text_field(wp_unslash($_SERVER['REQUEST_URI'])); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitized via sanitize_text_field(wp_unslash())
+                wp_safe_redirect('https://' . $host . $uri, 301);
+                exit;
+            }
+        }, 1);
+
+        // HSTS header on every HTTPS response.
+        add_action('send_headers', static function (): void {
+            if (!is_ssl()) {
+                return;
+            }
+            if (!headers_sent()) {
+                header('Strict-Transport-Security: max-age=31536000; includeSubDomains');
+            }
+        });
+    }
+
+    /**
+     * Bind a PHP fallback for user-agent bans. The server-config (Apache) is the
+     * primary enforcement point; this fires for any request that reaches PHP
+     * (e.g. nginx sites or when .htaccess write failed).
+     *
+     * IP/range bans are fed into the existing WAF mu-plugin's deny_cidrs via the
+     * stored wpmgr_security_config option's deny_cidrs key — see syncWafDenyCidrs().
+     *
+     * @param HardeningConfig $config
+     * @return void
+     */
+    private function applyBanFilters(HardeningConfig $config): void
+    {
+        $uaBans = $config->userAgentBans();
+        if ($uaBans === []) {
+            return;
+        }
+
+        // PHP-layer UA ban: fires before most output is generated (priority 1 on init).
+        add_action('init', static function () use ($uaBans): void {
+            if (!isset($_SERVER['HTTP_USER_AGENT']) || !is_string($_SERVER['HTTP_USER_AGENT'])) {
+                return;
+            }
+            $ua = sanitize_text_field(wp_unslash($_SERVER['HTTP_USER_AGENT'])); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitized via sanitize_text_field(wp_unslash())
+            foreach ($uaBans as $pattern) {
+                if ($pattern !== '' && stripos($ua, $pattern) !== false) {
+                    if (!headers_sent()) {
+                        http_response_code(403);
+                        header('Content-Type: text/plain; charset=utf-8');
+                        header('Cache-Control: no-cache, no-store, must-revalidate');
+                    }
+                    exit('Access denied.');
+                }
+            }
+        }, 1);
+    }
+
+    /**
+     * Feed IP/range bans from the hardening config into the existing WAF mu-plugin
+     * by merging them into the deny_cidrs list of wpmgr_security_config.
+     *
+     * The WAF mu-plugin reads wpmgr_security_config's deny_cidrs at boot time
+     * (before WP loads). We append the hardening bans to that list so they take
+     * effect at the earliest possible point (pre-WP mu-plugin boot), rather than
+     * waiting for the PHP 'init' action.
+     *
+     * This is called by SyncSecurityHardeningCommand after persistence.
+     *
+     * SAFETY: loopback/private IPs and the control-plane allow_cidrs are never
+     * denied — the WAF mu-plugin itself enforces this with its isPrivate() check
+     * and the allow_cidrs guard. We do not validate private-ness here; we rely on
+     * the WAF gate (which is tested independently).
+     *
+     * @param HardeningConfig $config
+     * @return void
+     */
+    public function syncWafDenyCidrs(HardeningConfig $config): void
+    {
+        if (!function_exists('get_option') || !function_exists('update_option')) {
+            return;
+        }
+
+        $raw = get_option('wpmgr_security_config', '');
+        if (!is_string($raw) || $raw === '') {
+            // No WAF config yet — nothing to sync into.
+            return;
+        }
+
+        $wafConfig = json_decode($raw, true);
+        if (!is_array($wafConfig)) {
+            return;
+        }
+
+        // Existing deny_cidrs from the login-protection / WAF config.
+        $existingDeny = isset($wafConfig['deny_cidrs']) && is_array($wafConfig['deny_cidrs'])
+            ? $wafConfig['deny_cidrs']
+            : [];
+
+        // Strip any previously-synced hardening bans (identified by a marker comment
+        // convention in the value is NOT possible, so instead we store them separately
+        // and merge; we rebuild the list from scratch each sync).
+        // We store the hardening-ban CIDRs in a separate wp-option so we know which
+        // deny_cidrs to remove when the ban list changes.
+        $prevHardeningCidrs = get_option('wpmgr_hardening_waf_cidrs', []);
+        if (!is_array($prevHardeningCidrs)) {
+            $prevHardeningCidrs = [];
+        }
+
+        // Remove only the previously-synced hardening bans from existingDeny.
+        $cleanedDeny = array_values(array_filter(
+            $existingDeny,
+            static fn (mixed $cidr): bool => is_string($cidr) && !in_array($cidr, $prevHardeningCidrs, true)
+        ));
+
+        // New hardening bans.
+        $newHardeningCidrs = $config->ipRangeBans();
+
+        // Merged list.
+        $merged = array_values(array_unique(array_merge($cleanedDeny, $newHardeningCidrs)));
+
+        // Persist the new hardening CIDRs list so next sync knows what to remove.
+        update_option('wpmgr_hardening_waf_cidrs', $newHardeningCidrs, false);
+
+        // Write back the merged deny_cidrs into wpmgr_security_config.
+        $wafConfig['deny_cidrs'] = $merged;
+        $encoded = wp_json_encode($wafConfig);
+        if ($encoded !== false) {
+            update_option('wpmgr_security_config', $encoded, false);
+        }
+    }
+}

--- a/apps/agent/includes/security/class-server-config-writer.php
+++ b/apps/agent/includes/security/class-server-config-writer.php
@@ -208,16 +208,38 @@ final class ServerConfigWriter
         }
 
         // IP/range bans (capped to avoid unbounded .htaccess growth).
-        $ipBans = array_slice($config->ipRangeBans(), 0, self::MAX_SERVER_BAN_RULES);
-        if ($ipBans !== []) {
+        // BLOCKER 3: before emitting any deny rule, filter out CIDRs that would
+        // lock out the operator or control plane:
+        //   (a) All-address CIDRs (0.0.0.0/0, ::/0, IPv4 prefix < /8, IPv6 prefix < /16)
+        //       are dropped entirely — they would deny every request including the
+        //       signed command that would undo the ban.
+        //   (b) CIDRs that overlap private/loopback ranges are skipped at render time
+        //       (WAF mu-plugin also enforces this, belt-and-braces here).
+        //   (c) The configured allow_cidrs are read from wpmgr_security_config so
+        //       that a ban can never override an operator-level exemption.
+        // Safety filtering is delegated to WafCidrGuard so the same rules apply
+        // here and in HardeningModule::syncWafDenyCidrs() (single source of truth).
+        $rawIpBans  = array_slice($config->ipRangeBans(), 0, self::MAX_SERVER_BAN_RULES);
+        $allowCidrs = $this->readAllowCidrs();
+        $safeDenies = [];
+        foreach ($rawIpBans as $cidr) {
+            $cidr = trim($cidr);
+            if (WafCidrGuard::isUnsafe($cidr, $allowCidrs)) {
+                continue;
+            }
+            // Belt-and-braces BLOCKER 2: skip values containing control chars.
+            if (preg_match('/[\x00-\x1F\x7F]/', $cidr) === 1) {
+                continue;
+            }
+            $safeDenies[] = $cidr;
+        }
+
+        if ($safeDenies !== []) {
             $lines[] = '<IfModule mod_authz_core.c>';
             $lines[] = '    <RequireAll>';
             $lines[] = '        Require all granted';
-            foreach ($ipBans as $cidr) {
-                $cidr = trim($cidr);
-                if ($cidr !== '') {
-                    $lines[] = '        Require not ip ' . $cidr;
-                }
+            foreach ($safeDenies as $cidr) {
+                $lines[] = '        Require not ip ' . $cidr;
             }
             $lines[] = '    </RequireAll>';
             $lines[] = '</IfModule>';
@@ -225,30 +247,48 @@ final class ServerConfigWriter
             $lines[] = '<IfModule !mod_authz_core.c>';
             $lines[] = '    Order allow,deny';
             $lines[] = '    Allow from all';
-            foreach ($ipBans as $cidr) {
-                $cidr = trim($cidr);
-                if ($cidr !== '') {
-                    $lines[] = '    Deny from ' . $cidr;
-                }
+            foreach ($safeDenies as $cidr) {
+                $lines[] = '    Deny from ' . $cidr;
             }
             $lines[] = '</IfModule>';
         }
 
         // User-agent bans.
+        // BLOCKER 1 FIX: emit one positive RewriteCond per ban pattern, OR-combined,
+        // with the LAST condition NOT carrying [OR]. The RewriteRule ^ - [F,L]
+        // then fires only when the UA MATCHES at least one banned pattern.
+        //
+        // The old negated form (!pattern [NC] AND-chained) was inverted: Apache
+        // AND-combines all RewriteConds, so the rule fired when the UA matched
+        // NONE of the ban patterns — blocking every legitimate visitor and letting
+        // the banned bots through. This is the corrected, positive-match OR-chain.
         $uaBans = $config->userAgentBans();
         if ($uaBans !== []) {
-            $lines[] = '<IfModule mod_rewrite.c>';
-            $lines[] = '    RewriteEngine On';
+            // Pre-filter: drop empty values and values with control chars
+            // (belt-and-braces BLOCKER 2 guard at the render layer).
+            $safeUaBans = [];
             foreach ($uaBans as $ua) {
                 $ua = trim($ua);
-                if ($ua !== '') {
-                    // Escape special regex characters in the UA string.
-                    $escaped = preg_quote($ua, '!');
-                    $lines[] = '    RewriteCond %{HTTP_USER_AGENT} !' . $escaped . ' [NC]';
+                if ($ua !== '' && preg_match('/[\x00-\x1F\x7F]/', $ua) !== 1) {
+                    $safeUaBans[] = $ua;
                 }
             }
-            $lines[] = '    RewriteRule ^ - [F,L]';
-            $lines[] = '</IfModule>';
+
+            if ($safeUaBans !== []) {
+                $lastIdx = count($safeUaBans) - 1;
+                $lines[] = '<IfModule mod_rewrite.c>';
+                $lines[] = '    RewriteEngine On';
+                foreach ($safeUaBans as $idx => $ua) {
+                    $escaped = preg_quote($ua, '!');
+                    // Positive match per pattern. [OR] on every condition except the
+                    // last so Apache OR-combines them: the block fires when ANY single
+                    // pattern matches (banned UA detected).
+                    $flag    = ($idx < $lastIdx) ? ' [NC,OR]' : ' [NC]';
+                    $lines[] = '    RewriteCond %{HTTP_USER_AGENT} ' . $escaped . $flag;
+                }
+                $lines[] = '    RewriteRule ^ - [F,L]';
+                $lines[] = '</IfModule>';
+            }
         }
 
         if ($lines === []) {
@@ -313,5 +353,30 @@ final class ServerConfigWriter
             return '';
         }
         return rtrim($root, '/\\') . DIRECTORY_SEPARATOR . '.htaccess';
+    }
+
+    /**
+     * Read the operator-configured allow_cidrs from wpmgr_security_config.
+     * Used at render time to exempt allow-listed CIDRs from deny rules.
+     *
+     * Returns an empty array when the option is absent or unreadable.
+     *
+     * @return array<int,string>
+     */
+    private function readAllowCidrs(): array
+    {
+        if (!function_exists('get_option')) {
+            return [];
+        }
+        $raw = get_option('wpmgr_security_config', '');
+        if (!is_string($raw) || $raw === '') {
+            return [];
+        }
+        $cfg = json_decode($raw, true);
+        if (!is_array($cfg)) {
+            return [];
+        }
+        $allow = isset($cfg['allow_cidrs']) && is_array($cfg['allow_cidrs']) ? $cfg['allow_cidrs'] : [];
+        return array_values(array_filter($allow, 'is_string'));
     }
 }

--- a/apps/agent/includes/security/class-server-config-writer.php
+++ b/apps/agent/includes/security/class-server-config-writer.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * ServerConfigWriter — writes / removes the WPMgr Security managed blocks in
+ * the site-root .htaccess (Apache / LiteSpeed) and generates a display-only
+ * nginx snippet.
+ *
+ * Block structure mirrors the HtaccessManager pattern in the cache suite:
+ * delimited by exact BEGIN/END markers so blocks are cleanly replaceable and
+ * never duplicated.
+ *
+ * Apache is the only server type where we auto-write; nginx sites need operator
+ * action (the rules are shown in the dashboard as a snippet). The writer is
+ * completely idempotent: re-running with the same config is a no-op.
+ *
+ * @package WPMgr\Agent\Security
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Security;
+
+/**
+ * Manages the "# BEGIN WPMgr Security" / "# END WPMgr Security" block in
+ * the site-root .htaccess.
+ */
+final class ServerConfigWriter
+{
+    /** Opening marker — byte-exact for idempotency. */
+    public const BEGIN = '# BEGIN WPMgr Security';
+
+    /** Closing marker — byte-exact for idempotency. */
+    public const END = '# END WPMgr Security';
+
+    /**
+     * Maximum number of IP/range ban rules written to server config.
+     *
+     * Overflow entries are still enforced at the PHP (mu-plugin) layer; we cap
+     * here to keep .htaccess from growing unbounded on sites with large ban lists.
+     */
+    private const MAX_SERVER_BAN_RULES = 200;
+
+    /**
+     * Install / refresh the managed block. Returns false when the site is on
+     * nginx (no .htaccess auto-write), when the path is unresolvable, or when
+     * the file is not writable. Returns true when the block is in place (even
+     * if we skipped the write because content is already current).
+     *
+     * @param HardeningConfig $config Validated hardening config.
+     * @return bool Whether the block is (or was already) in place.
+     */
+    public function install(HardeningConfig $config): bool
+    {
+        if ($this->isNginx()) {
+            return false;
+        }
+
+        $path = $this->htaccessPath();
+        if ($path === '') {
+            return false;
+        }
+
+        $existing = '';
+        if (@is_file($path) && @is_readable($path)) {
+            $read = @file_get_contents($path);
+            if ($read !== false) {
+                $existing = $read;
+            }
+        }
+
+        $updated = $this->renderInto($existing, $config);
+        if ($updated === $existing) {
+            return true; // already current
+        }
+
+        if (!@is_writable($path) && !@is_writable(dirname($path))) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- headless agent; WP_Filesystem never initialized; direct writability probe is the only option
+            return false;
+        }
+
+        $result = @file_put_contents($path, $updated, LOCK_EX);
+        return $result !== false;
+    }
+
+    /**
+     * Remove the managed security block. Idempotent (absent => no-op true).
+     *
+     * @return bool
+     */
+    public function uninstall(): bool
+    {
+        $path = $this->htaccessPath();
+        if ($path === '' || !@is_file($path)) {
+            return true;
+        }
+
+        $content = @file_get_contents($path);
+        if ($content === false) {
+            return true;
+        }
+
+        $stripped = $this->stripBlock($content);
+        if ($stripped === $content) {
+            return true; // not present
+        }
+
+        if (!@is_writable($path) && !@is_writable(dirname($path))) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- headless agent; WP_Filesystem never initialized; direct writability probe is the only option
+            return false;
+        }
+
+        $result = @file_put_contents($path, $stripped, LOCK_EX);
+        return $result !== false;
+    }
+
+    /**
+     * Whether the site is using nginx (no .htaccess auto-write possible).
+     *
+     * @return bool
+     */
+    public function isNginx(): bool
+    {
+        if (!isset($_SERVER['SERVER_SOFTWARE']) || !is_string($_SERVER['SERVER_SOFTWARE'])) {
+            return false;
+        }
+        return str_contains(
+            strtolower(sanitize_text_field(wp_unslash($_SERVER['SERVER_SOFTWARE']))), // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitized via sanitize_text_field(wp_unslash())
+            'nginx'
+        );
+    }
+
+    /**
+     * Pure transform: render the block into $existing. Used by tests without
+     * disk access.
+     *
+     * @param string          $existing Current .htaccess content.
+     * @param HardeningConfig $config   Validated config.
+     * @return string
+     */
+    public function renderInto(string $existing, HardeningConfig $config): string
+    {
+        $body = $this->blockBody($config);
+
+        if ($body === '') {
+            // Nothing to write — strip any existing block and return.
+            return $this->stripBlock($existing);
+        }
+
+        $block = self::BEGIN . "\n" . $body . "\n" . self::END;
+        return $this->spliceBlock($existing, $block);
+    }
+
+    // -------------------------------------------------------------------------
+    // Private block-body builder
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build the directive body (everything between the markers). Returns '' when
+     * no toggles are active and there are no bans, so the block is cleanly
+     * removed when all features are disabled.
+     *
+     * @param HardeningConfig $config
+     * @return string
+     */
+    private function blockBody(HardeningConfig $config): string
+    {
+        $lines = [];
+
+        // SSL redirect (Apache) — redirect http:// -> https:// + HSTS header.
+        if ($config->forceSsl) {
+            $lines[] = '<IfModule mod_rewrite.c>';
+            $lines[] = '    RewriteEngine On';
+            $lines[] = '    RewriteCond %{HTTPS} off';
+            $lines[] = '    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]';
+            $lines[] = '</IfModule>';
+            $lines[] = '<IfModule mod_headers.c>';
+            $lines[] = '    Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"';
+            $lines[] = '</IfModule>';
+        }
+
+        // Directory browsing off.
+        if ($config->disableDirectoryBrowsing) {
+            $lines[] = 'Options -Indexes';
+        }
+
+        // Block PHP execution in uploads directory.
+        if ($config->disablePhpInUploads) {
+            $lines[] = '<IfModule mod_rewrite.c>';
+            $lines[] = '    RewriteEngine On';
+            $lines[] = '    RewriteCond %{REQUEST_URI} /wp-content/uploads/ [NC]';
+            $lines[] = '    RewriteRule \.php$ - [F,L]';
+            $lines[] = '</IfModule>';
+        }
+
+        // Protect system files.
+        if ($config->protectSystemFiles) {
+            $lines[] = '<FilesMatch "^(wp-config\.php|\.htaccess|\.htpasswd|readme\.html|readme\.txt|license\.txt|debug\.log)$">';
+            $lines[] = '    Require all denied';
+            $lines[] = '    Order deny,allow';
+            $lines[] = '    Deny from all';
+            $lines[] = '</FilesMatch>';
+        }
+
+        // XML-RPC off at server level.
+        if ($config->xmlrpcMode === HardeningConfig::XMLRPC_OFF) {
+            $lines[] = '<Files "xmlrpc.php">';
+            $lines[] = '    Require all denied';
+            $lines[] = '    Order deny,allow';
+            $lines[] = '    Deny from all';
+            $lines[] = '</Files>';
+        }
+
+        // IP/range bans (capped to avoid unbounded .htaccess growth).
+        $ipBans = array_slice($config->ipRangeBans(), 0, self::MAX_SERVER_BAN_RULES);
+        if ($ipBans !== []) {
+            $lines[] = '<IfModule mod_authz_core.c>';
+            $lines[] = '    <RequireAll>';
+            $lines[] = '        Require all granted';
+            foreach ($ipBans as $cidr) {
+                $cidr = trim($cidr);
+                if ($cidr !== '') {
+                    $lines[] = '        Require not ip ' . $cidr;
+                }
+            }
+            $lines[] = '    </RequireAll>';
+            $lines[] = '</IfModule>';
+            // Legacy Apache 2.2 fallback.
+            $lines[] = '<IfModule !mod_authz_core.c>';
+            $lines[] = '    Order allow,deny';
+            $lines[] = '    Allow from all';
+            foreach ($ipBans as $cidr) {
+                $cidr = trim($cidr);
+                if ($cidr !== '') {
+                    $lines[] = '    Deny from ' . $cidr;
+                }
+            }
+            $lines[] = '</IfModule>';
+        }
+
+        // User-agent bans.
+        $uaBans = $config->userAgentBans();
+        if ($uaBans !== []) {
+            $lines[] = '<IfModule mod_rewrite.c>';
+            $lines[] = '    RewriteEngine On';
+            foreach ($uaBans as $ua) {
+                $ua = trim($ua);
+                if ($ua !== '') {
+                    // Escape special regex characters in the UA string.
+                    $escaped = preg_quote($ua, '!');
+                    $lines[] = '    RewriteCond %{HTTP_USER_AGENT} !' . $escaped . ' [NC]';
+                }
+            }
+            $lines[] = '    RewriteRule ^ - [F,L]';
+            $lines[] = '</IfModule>';
+        }
+
+        if ($lines === []) {
+            return '';
+        }
+
+        return implode("\n", $lines);
+    }
+
+    // -------------------------------------------------------------------------
+    // Block splice helpers (mirror HtaccessManager pattern)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Strip the managed security block (BEGIN..END inclusive).
+     *
+     * @param string $content .htaccess content.
+     * @return string
+     */
+    private function stripBlock(string $content): string
+    {
+        $pattern = '/' . preg_quote(self::BEGIN, '/') . '.*?' . preg_quote(self::END, '/') . "\n?/s";
+        $result  = preg_replace($pattern, '', $content);
+        return $result ?? $content;
+    }
+
+    /**
+     * Splice the fresh block BEFORE the WordPress block (if present) or prepend
+     * it to the existing content. Strips any prior copy first.
+     *
+     * @param string $content Existing .htaccess content.
+     * @param string $block   Fully-formed BEGIN...END block.
+     * @return string
+     */
+    private function spliceBlock(string $content, string $block): string
+    {
+        $stripped = $this->stripBlock($content);
+        if (trim($stripped) === '') {
+            return $block . "\n";
+        }
+        return $block . "\n\n" . ltrim($stripped, "\n");
+    }
+
+    /**
+     * Resolve the site-root .htaccess path.
+     *
+     * @return string Absolute path, or '' when unresolvable.
+     */
+    private function htaccessPath(): string
+    {
+        $root = '';
+        if (function_exists('get_home_path')) {
+            $candidate = get_home_path();
+            if (is_string($candidate) && $candidate !== '') {
+                $root = $candidate;
+            }
+        }
+        if ($root === '' && defined('ABSPATH')) {
+            $root = (string) constant('ABSPATH');
+        }
+        if ($root === '') {
+            return '';
+        }
+        return rtrim($root, '/\\') . DIRECTORY_SEPARATOR . '.htaccess';
+    }
+}

--- a/apps/agent/includes/security/class-waf-cidr-guard.php
+++ b/apps/agent/includes/security/class-waf-cidr-guard.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * WafCidrGuard — shared CIDR safety helpers used by both ServerConfigWriter
+ * (render-time) and HardeningModule::syncWafDenyCidrs() (persist-time).
+ *
+ * Centralising these guards in one place ensures that the .htaccess writer and
+ * the WAF option writer always apply the same filtering rules, eliminating the
+ * risk of them diverging after a future edit.
+ *
+ * Rules applied before a CIDR is accepted as a deny entry:
+ *   1. isBroadAddress() — drops 0.0.0.0/0 / ::/0 and any IPv4 prefix < /8 or
+ *      IPv6 prefix < /16. Such a rule would deny every request, including the
+ *      signed command that would undo the ban.
+ *   2. overlapsProtected() — drops CIDRs that overlap private/loopback ranges
+ *      (RFC-1918, ::1, fc00::/7, fe80::/10, link-local) or any of the
+ *      operator-configured allow_cidrs. The runtime WAF also enforces the
+ *      private bypass, but the agent must not persist a dangerous CIDR even when
+ *      the runtime guard would catch it (defence-in-depth).
+ *
+ * @package WPMgr\Agent\Security
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Security;
+
+/**
+ * Pure-static helpers for CIDR safety validation.
+ */
+final class WafCidrGuard
+{
+    /**
+     * Private IPv4 ranges that must never appear in a deny rule.
+     * Covers loopback, private LAN, link-local, and shared-address space.
+     *
+     * @var array<int,string>
+     */
+    private const PRIVATE_IPV4_RANGES = [
+        '127.0.0.0/8',
+        '10.0.0.0/8',
+        '172.16.0.0/12',
+        '192.168.0.0/16',
+        '169.254.0.0/16',
+        '100.64.0.0/10',
+    ];
+
+    /**
+     * Private/loopback IPv6 ranges that must never appear in a deny rule.
+     *
+     * @var array<int,string>
+     */
+    private const PRIVATE_IPV6_RANGES = [
+        '::1/128',
+        'fc00::/7',
+        'fe80::/10',
+        '::ffff:0:0/96',
+    ];
+
+    /**
+     * Return true when a CIDR is so broad that emitting it as a deny rule would
+     * lock out every request (including the control plane).
+     *
+     * Drops:
+     *   - 0.0.0.0/0 and ::/0 (all-address catch-alls)
+     *   - IPv4 prefix < /8  (covering ≥ 16 M addresses)
+     *   - IPv6 prefix < /16 (covering an enormous range)
+     *
+     * @param string $cidr CIDR notation, already trimmed.
+     * @return bool
+     */
+    public static function isBroadAddress(string $cidr): bool
+    {
+        $parts = explode('/', $cidr, 2);
+        if (count($parts) !== 2) {
+            return false;
+        }
+        $base      = trim($parts[0]);
+        $prefixStr = trim($parts[1]);
+        if (!ctype_digit($prefixStr)) {
+            return false;
+        }
+        $prefix = (int) $prefixStr;
+
+        $isIpv4 = filter_var($base, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false;
+        $isIpv6 = filter_var($base, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
+
+        if ($isIpv4) {
+            // /0 through /7 covers ≥ 16 M addresses; /0 is the all-address wildcard.
+            return $prefix < 8;
+        }
+
+        if ($isIpv6) {
+            // /0 through /15 covers a vast range; /0 is the all-address wildcard.
+            return $prefix < 16;
+        }
+
+        return false;
+    }
+
+    /**
+     * Return true when a CIDR overlaps any private/loopback range or any of the
+     * operator-configured allow_cidrs. Such a deny rule could lock out the
+     * operator's own LAN or the control-plane egress IP.
+     *
+     * The check is conservative: if $cidr's base address falls inside a protected
+     * range, or a protected range's base address falls inside $cidr, we skip the
+     * deny rule. Full subnet-overlap arithmetic is not needed here — a simple
+     * "does either contain the other's base address" heuristic is sufficient and
+     * safe (false positives mean we skip a deny rule, not that we emit a wrong one).
+     *
+     * @param string            $cidr       The candidate deny CIDR.
+     * @param array<int,string> $allowCidrs Operator-configured allow list.
+     * @return bool
+     */
+    public static function overlapsProtected(string $cidr, array $allowCidrs): bool
+    {
+        $protected = array_merge(self::PRIVATE_IPV4_RANGES, self::PRIVATE_IPV6_RANGES, $allowCidrs);
+        foreach ($protected as $guard) {
+            if (self::cidrsOverlap($cidr, $guard)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Return true when a CIDR should be dropped before being stored or emitted as
+     * a deny rule. Combines the broad-address and overlaps-protected checks.
+     *
+     * @param string            $cidr       Candidate CIDR, already trimmed.
+     * @param array<int,string> $allowCidrs Operator allow-list (from waf config).
+     * @return bool True → drop this CIDR; false → safe to use.
+     */
+    public static function isUnsafe(string $cidr, array $allowCidrs = []): bool
+    {
+        if ($cidr === '') {
+            return true;
+        }
+        if (self::isBroadAddress($cidr)) {
+            return true;
+        }
+        if (self::overlapsProtected($cidr, $allowCidrs)) {
+            return true;
+        }
+        return false;
+    }
+
+    // -------------------------------------------------------------------------
+    // Private overlap helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Conservative CIDR overlap check. Returns true when either network's base
+     * address falls within the other network.
+     *
+     * @param string $a First CIDR.
+     * @param string $b Second CIDR.
+     * @return bool
+     */
+    private static function cidrsOverlap(string $a, string $b): bool
+    {
+        return self::cidrContainsBase($a, $b) || self::cidrContainsBase($b, $a);
+    }
+
+    /**
+     * Return true when $cidr contains the base address of $other.
+     *
+     * @param string $cidr  The network to test against.
+     * @param string $other The network whose base address is the probe.
+     * @return bool
+     */
+    private static function cidrContainsBase(string $cidr, string $other): bool
+    {
+        $parts = explode('/', $other, 2);
+        if (count($parts) < 1) {
+            return false;
+        }
+        $baseIp = trim($parts[0]);
+        return self::cidrMatchesIp($cidr, $baseIp);
+    }
+
+    /**
+     * Return true when $ip falls within $cidr. Pure PHP bit-comparison,
+     * no external dependencies.
+     *
+     * @param string $cidr CIDR notation.
+     * @param string $ip   IP address string (IPv4 or IPv6).
+     * @return bool
+     */
+    private static function cidrMatchesIp(string $cidr, string $ip): bool
+    {
+        $parts = explode('/', $cidr, 2);
+        if (count($parts) !== 2) {
+            return false;
+        }
+        [$base, $prefixStr] = $parts;
+
+        if (!ctype_digit(trim($prefixStr))) {
+            return false;
+        }
+        $prefix = (int) $prefixStr;
+
+        $ipBin   = @inet_pton(trim($ip));
+        $baseBin = @inet_pton(trim($base));
+
+        if ($ipBin === false || $baseBin === false || strlen($ipBin) !== strlen($baseBin)) {
+            return false;
+        }
+
+        $addrLen   = strlen($ipBin);
+        $maxPrefix = $addrLen * 8;
+
+        if ($prefix < 0 || $prefix > $maxPrefix) {
+            return false;
+        }
+
+        if ($prefix === 0) {
+            return true; // /0 matches everything
+        }
+
+        $fullBytes = intdiv($prefix, 8);
+        $remainder = $prefix % 8;
+
+        for ($i = 0; $i < $fullBytes; $i++) {
+            if (ord($ipBin[$i]) !== ord($baseBin[$i])) {
+                return false;
+            }
+        }
+
+        if ($remainder > 0 && $fullBytes < $addrLen) {
+            $mask = 0xFF & (0xFF << (8 - $remainder));
+            if ((ord($ipBin[$fullBytes]) & $mask) !== (ord($baseBin[$fullBytes]) & $mask)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/apps/agent/mu-plugin-loader/a-wpmgr-waf.php
+++ b/apps/agent/mu-plugin-loader/a-wpmgr-waf.php
@@ -227,8 +227,122 @@ function wpmgr_waf_client_ip(string $headerName, array $server): string
 }
 
 /**
- * Main WAF gate. Reads config from wp_options via $wpdb and, when protect mode
- * with a matching deny_cidrs entry is detected, sends a 403 and exits.
+ * Emit a 403 and exit. Centralised so all gate paths use identical headers.
+ *
+ * @return never
+ */
+function wpmgr_waf_deny(): void
+{
+    if (!headers_sent()) {
+        http_response_code(403);
+        header('Cache-Control: no-cache, no-store, must-revalidate');
+        header('Pragma: no-cache');
+        header('Expires: 0');
+        header('Content-Type: text/plain; charset=utf-8');
+    }
+    exit('Access denied.');
+}
+
+/**
+ * Pure gate-decision function — no side effects, no exit().
+ *
+ * Evaluates the two-layer deny logic against a pre-resolved config array and
+ * a pre-resolved client IP string. Returns true when the gate WOULD deny the
+ * request; false when it would pass.
+ *
+ * Layer order (must be preserved exactly — tests assert on this order):
+ *   (1) allow_cidrs match           → no-deny (always wins)
+ *   (2) private/loopback IP         → no-deny (operator lock-out guard)
+ *   (3) hardening_deny_cidrs        → deny    (all modes, mode-independent)
+ *   (4) mode != protect             → no-deny (brute-force gate is mode-gated)
+ *   (5) deny_cidrs in protect mode  → deny
+ *
+ * Extracting the decision into this pure function means:
+ *   - Tests `require_once` this file and call wpmgr_waf_should_deny() directly,
+ *     so any reordering of the layers above breaks the tests immediately.
+ *   - wpmgr_waf_gate() remains the only caller that executes the exit path.
+ *
+ * @param array<string,mixed> $config Decoded wpmgr_security_config array.
+ * @param string              $ip     Pre-resolved client IP (already sanitised).
+ * @param string              $mode   Login-protection mode from $config.
+ * @return bool True → should deny; false → should pass.
+ */
+function wpmgr_waf_should_deny(array $config, string $ip, string $mode): bool
+{
+    if ($ip === '') {
+        return false;
+    }
+
+    $denyCidrs = isset($config['deny_cidrs']) && is_array($config['deny_cidrs'])
+        ? $config['deny_cidrs']
+        : [];
+
+    $allowCidrs = isset($config['allow_cidrs']) && is_array($config['allow_cidrs'])
+        ? $config['allow_cidrs']
+        : [];
+
+    $hardeningCidrs = isset($config['hardening_deny_cidrs']) && is_array($config['hardening_deny_cidrs'])
+        ? $config['hardening_deny_cidrs']
+        : [];
+
+    // Fast path: nothing to deny in any list.
+    if ($denyCidrs === [] && $hardeningCidrs === []) {
+        return false;
+    }
+
+    // (1) allow_cidrs always wins — checked once, applies to ALL paths.
+    if ($allowCidrs !== [] && wpmgr_waf_matches_any_cidr($ip, $allowCidrs)) {
+        return false;
+    }
+
+    // (2) Private/loopback IPs are auto-bypassed in ALL paths.
+    if (wpmgr_waf_is_private($ip)) {
+        return false;
+    }
+
+    // (3) Operator hardening bans — enforced in ALL modes, mode-independent.
+    // ITEM 5 FIX: explicit operator bans must block regardless of login-protection
+    // mode. Stored under 'hardening_deny_cidrs' so they evaluate independently.
+    if ($hardeningCidrs !== [] && wpmgr_waf_matches_any_cidr($ip, $hardeningCidrs)) {
+        return true;
+    }
+
+    // (4) Brute-force protect gate — only active when mode == protect.
+    if ($mode !== 'protect') {
+        return false;
+    }
+
+    if ($denyCidrs === []) {
+        return false;
+    }
+
+    // (5) deny_cidrs in protect mode.
+    if (wpmgr_waf_matches_any_cidr($ip, $denyCidrs)) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Main WAF gate. Reads config from wp_options via $wpdb and applies two
+ * independent enforcement layers:
+ *
+ *   1. Operator hardening bans (deny_cidrs sourced from the hardening config via
+ *      syncWafDenyCidrs) — enforced in ALL modes, regardless of login-protection
+ *      mode. An explicit operator ban must always block (ITEM 5 FIX).
+ *
+ *   2. Brute-force protect gate (mode == "protect") — the original behaviour,
+ *      unchanged. Only active when the operator has explicitly enabled protect
+ *      mode for login protection.
+ *
+ * Safety invariants preserved in both paths:
+ *   - allow_cidrs always wins (checked before any deny).
+ *   - Private/loopback IPs are auto-bypassed.
+ *   - A DB failure or any exception NEVER blocks a real request (try/catch).
+ *
+ * The actual deny decision is delegated to wpmgr_waf_should_deny() so that
+ * tests can exercise the real logic without triggering exit().
  *
  * @return void
  */
@@ -260,50 +374,15 @@ function wpmgr_waf_gate(): void
         }
 
         $mode = isset($config['mode']) && is_string($config['mode']) ? $config['mode'] : 'protect';
-        if ($mode !== 'protect') {
-            return; // Only hard-gate in protect mode.
-        }
-
-        $denyCidrs  = isset($config['deny_cidrs']) && is_array($config['deny_cidrs'])
-            ? $config['deny_cidrs']
-            : [];
-        if ($denyCidrs === []) {
-            return; // Nothing to deny.
-        }
-
-        $allowCidrs = isset($config['allow_cidrs']) && is_array($config['allow_cidrs'])
-            ? $config['allow_cidrs']
-            : [];
 
         $ipHeader = isset($config['ip_header']) && is_string($config['ip_header']) && $config['ip_header'] !== ''
             ? strtoupper(trim($config['ip_header']))
             : 'REMOTE_ADDR';
 
         $ip = wpmgr_waf_client_ip($ipHeader, $_SERVER);
-        if ($ip === '') {
-            return;
-        }
 
-        // SAFETY RAIL: allow_cidrs always wins first.
-        if ($allowCidrs !== [] && wpmgr_waf_matches_any_cidr($ip, $allowCidrs)) {
-            return;
-        }
-
-        // Private/loopback IPs are auto-bypassed (LAN admin can never be locked out).
-        if (wpmgr_waf_is_private($ip)) {
-            return;
-        }
-
-        // If IP matches deny_cidrs → 403 and exit BEFORE WordPress boots.
-        if (wpmgr_waf_matches_any_cidr($ip, $denyCidrs)) {
-            if (!headers_sent()) {
-                http_response_code(403);
-                header('Cache-Control: no-cache, no-store, must-revalidate');
-                header('Pragma: no-cache');
-                header('Expires: 0');
-                header('Content-Type: text/plain; charset=utf-8');
-            }
-            exit('Access denied.');
+        if (wpmgr_waf_should_deny($config, $ip, $mode)) {
+            wpmgr_waf_deny();
         }
     } catch (\Throwable $e) {
         // A DB failure or any unexpected error must NEVER block a real request.
@@ -312,4 +391,10 @@ function wpmgr_waf_gate(): void
 }
 
 // Execute immediately — $wpdb is available at mu-plugin load time.
-wpmgr_waf_gate();
+// WPMGR_WAF_TESTING: when this constant is defined, the file is being included
+// by the test suite (require_once to load function definitions only). In that
+// case, skip the top-level wpmgr_waf_gate() call — $wpdb is not available in
+// the test environment and the gate would throw/exit anyway.
+if (!defined('WPMGR_WAF_TESTING')) {
+    wpmgr_waf_gate();
+}

--- a/apps/agent/tests/HardeningConfigTest.php
+++ b/apps/agent/tests/HardeningConfigTest.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * HardeningConfig unit tests: fromArray() validation, toArray() round-trip,
+ * safe defaults for missing/invalid fields, ban list validation, and the
+ * ipRangeBans / userAgentBans projections.
+ *
+ * Pure in-memory tests; no disk access, no WP function stubs needed.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use WPMgr\Agent\Security\HardeningConfig;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Security\HardeningConfig
+ */
+final class HardeningConfigTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // Defaults
+    // -------------------------------------------------------------------------
+
+    public function test_defaults_are_all_off(): void
+    {
+        $c = HardeningConfig::defaults();
+
+        $this->assertFalse($c->disableFileEditor);
+        $this->assertSame(HardeningConfig::XMLRPC_ON, $c->xmlrpcMode);
+        $this->assertSame(HardeningConfig::REST_DEFAULT, $c->restrictRestApi);
+        $this->assertSame(HardeningConfig::LOGIN_BOTH, $c->restrictLoginIdentifier);
+        $this->assertFalse($c->forceUniqueNickname);
+        $this->assertFalse($c->disableAuthorArchiveEnum);
+        $this->assertFalse($c->forceSsl);
+        $this->assertFalse($c->disableDirectoryBrowsing);
+        $this->assertFalse($c->disablePhpInUploads);
+        $this->assertFalse($c->protectSystemFiles);
+        $this->assertSame([], $c->bans);
+    }
+
+    // -------------------------------------------------------------------------
+    // fromArray() — valid full payload
+    // -------------------------------------------------------------------------
+
+    public function test_from_array_accepts_full_valid_payload(): void
+    {
+        $raw = [
+            'config' => [
+                'disable_file_editor'        => true,
+                'xmlrpc_mode'                => 'off',
+                'restrict_rest_api'          => 'restricted',
+                'restrict_login_identifier'  => 'email',
+                'force_unique_nickname'      => true,
+                'disable_author_archive_enum' => true,
+                'force_ssl'                  => true,
+                'disable_directory_browsing' => true,
+                'disable_php_in_uploads'     => true,
+                'protect_system_files'       => true,
+            ],
+            'bans' => [
+                ['id' => 'a1', 'type' => 'ip',         'value' => '1.2.3.4',      'comment' => 'bad'],
+                ['id' => 'a2', 'type' => 'range',      'value' => '10.0.0.0/8',   'comment' => ''],
+                ['id' => 'a3', 'type' => 'user_agent', 'value' => 'BadBot/1.0',   'comment' => 'scraper'],
+            ],
+        ];
+
+        $c = HardeningConfig::fromArray($raw);
+
+        $this->assertTrue($c->disableFileEditor);
+        $this->assertSame('off', $c->xmlrpcMode);
+        $this->assertSame('restricted', $c->restrictRestApi);
+        $this->assertSame('email', $c->restrictLoginIdentifier);
+        $this->assertTrue($c->forceUniqueNickname);
+        $this->assertTrue($c->disableAuthorArchiveEnum);
+        $this->assertTrue($c->forceSsl);
+        $this->assertTrue($c->disableDirectoryBrowsing);
+        $this->assertTrue($c->disablePhpInUploads);
+        $this->assertTrue($c->protectSystemFiles);
+        $this->assertCount(3, $c->bans);
+    }
+
+    // -------------------------------------------------------------------------
+    // fromArray() — missing keys default to off
+    // -------------------------------------------------------------------------
+
+    public function test_missing_config_key_defaults_to_off(): void
+    {
+        $c = HardeningConfig::fromArray([]);
+        $this->assertSame(HardeningConfig::defaults()->disableFileEditor, $c->disableFileEditor);
+        $this->assertSame(HardeningConfig::XMLRPC_ON, $c->xmlrpcMode);
+    }
+
+    public function test_empty_bans_array_is_accepted(): void
+    {
+        $c = HardeningConfig::fromArray(['bans' => []]);
+        $this->assertSame([], $c->bans);
+    }
+
+    // -------------------------------------------------------------------------
+    // fromArray() — enum coercion
+    // -------------------------------------------------------------------------
+
+    public function test_invalid_xmlrpc_mode_falls_back_to_on(): void
+    {
+        $c = HardeningConfig::fromArray(['config' => ['xmlrpc_mode' => 'garbage']]);
+        $this->assertSame(HardeningConfig::XMLRPC_ON, $c->xmlrpcMode);
+    }
+
+    public function test_invalid_rest_api_mode_falls_back_to_default(): void
+    {
+        $c = HardeningConfig::fromArray(['config' => ['restrict_rest_api' => 'nope']]);
+        $this->assertSame(HardeningConfig::REST_DEFAULT, $c->restrictRestApi);
+    }
+
+    public function test_invalid_login_identifier_falls_back_to_both(): void
+    {
+        $c = HardeningConfig::fromArray(['config' => ['restrict_login_identifier' => 'pin']]);
+        $this->assertSame(HardeningConfig::LOGIN_BOTH, $c->restrictLoginIdentifier);
+    }
+
+    // -------------------------------------------------------------------------
+    // Ban validation
+    // -------------------------------------------------------------------------
+
+    public function test_ban_with_empty_id_is_skipped(): void
+    {
+        $raw = ['bans' => [['id' => '', 'type' => 'ip', 'value' => '1.2.3.4']]];
+        $c   = HardeningConfig::fromArray($raw);
+        $this->assertSame([], $c->bans);
+    }
+
+    public function test_ban_with_empty_value_is_skipped(): void
+    {
+        $raw = ['bans' => [['id' => 'x', 'type' => 'ip', 'value' => '']]];
+        $c   = HardeningConfig::fromArray($raw);
+        $this->assertSame([], $c->bans);
+    }
+
+    public function test_ban_with_unknown_type_is_skipped(): void
+    {
+        $raw = ['bans' => [['id' => 'x', 'type' => 'hostname', 'value' => 'evil.com']]];
+        $c   = HardeningConfig::fromArray($raw);
+        $this->assertSame([], $c->bans);
+    }
+
+    public function test_ban_ip_invalid_value_is_skipped(): void
+    {
+        $raw = ['bans' => [['id' => 'x', 'type' => 'ip', 'value' => 'not-an-ip']]];
+        $c   = HardeningConfig::fromArray($raw);
+        $this->assertSame([], $c->bans);
+    }
+
+    public function test_ban_range_invalid_value_is_skipped(): void
+    {
+        $raw = ['bans' => [['id' => 'x', 'type' => 'range', 'value' => '10.0.0.0']]]; // missing prefix
+        $c   = HardeningConfig::fromArray($raw);
+        $this->assertSame([], $c->bans);
+    }
+
+    public function test_ban_range_valid_cidr_is_accepted(): void
+    {
+        $raw = ['bans' => [['id' => 'x', 'type' => 'range', 'value' => '192.168.1.0/24']]];
+        $c   = HardeningConfig::fromArray($raw);
+        $this->assertCount(1, $c->bans);
+        $this->assertSame('192.168.1.0/24', $c->bans[0]['value']);
+    }
+
+    public function test_non_array_ban_entry_is_skipped(): void
+    {
+        $raw = ['bans' => ['not-an-array']];
+        $c   = HardeningConfig::fromArray($raw);
+        $this->assertSame([], $c->bans);
+    }
+
+    // -------------------------------------------------------------------------
+    // Projections
+    // -------------------------------------------------------------------------
+
+    public function test_ip_range_bans_returns_only_ip_and_range_values(): void
+    {
+        $raw = [
+            'bans' => [
+                ['id' => '1', 'type' => 'ip',         'value' => '5.5.5.5'],
+                ['id' => '2', 'type' => 'range',      'value' => '10.0.0.0/8'],
+                ['id' => '3', 'type' => 'user_agent', 'value' => 'BadBot'],
+            ],
+        ];
+        $c = HardeningConfig::fromArray($raw);
+        $this->assertSame(['5.5.5.5', '10.0.0.0/8'], $c->ipRangeBans());
+    }
+
+    public function test_user_agent_bans_returns_only_ua_values(): void
+    {
+        $raw = [
+            'bans' => [
+                ['id' => '1', 'type' => 'ip',         'value' => '5.5.5.5'],
+                ['id' => '2', 'type' => 'user_agent', 'value' => 'EvilBot/2.0'],
+            ],
+        ];
+        $c = HardeningConfig::fromArray($raw);
+        $this->assertSame(['EvilBot/2.0'], $c->userAgentBans());
+    }
+
+    // -------------------------------------------------------------------------
+    // Round-trip
+    // -------------------------------------------------------------------------
+
+    public function test_to_array_round_trips_through_from_array(): void
+    {
+        $raw = [
+            'config' => [
+                'disable_file_editor'        => true,
+                'xmlrpc_mode'                => 'limited',
+                'restrict_rest_api'          => 'restricted',
+                'restrict_login_identifier'  => 'username',
+                'force_unique_nickname'      => false,
+                'disable_author_archive_enum' => true,
+                'force_ssl'                  => true,
+                'disable_directory_browsing' => false,
+                'disable_php_in_uploads'     => true,
+                'protect_system_files'       => true,
+            ],
+            'bans' => [
+                ['id' => 'b1', 'type' => 'ip', 'value' => '203.0.113.5', 'comment' => 'spammer'],
+            ],
+        ];
+
+        $original = HardeningConfig::fromArray($raw);
+        $exported  = $original->toArray();
+        $restored  = HardeningConfig::fromArray($exported);
+
+        $this->assertSame($original->disableFileEditor,        $restored->disableFileEditor);
+        $this->assertSame($original->xmlrpcMode,               $restored->xmlrpcMode);
+        $this->assertSame($original->restrictRestApi,          $restored->restrictRestApi);
+        $this->assertSame($original->restrictLoginIdentifier,  $restored->restrictLoginIdentifier);
+        $this->assertSame($original->forceUniqueNickname,      $restored->forceUniqueNickname);
+        $this->assertSame($original->disableAuthorArchiveEnum, $restored->disableAuthorArchiveEnum);
+        $this->assertSame($original->forceSsl,                 $restored->forceSsl);
+        $this->assertSame($original->disableDirectoryBrowsing, $restored->disableDirectoryBrowsing);
+        $this->assertSame($original->disablePhpInUploads,      $restored->disablePhpInUploads);
+        $this->assertSame($original->protectSystemFiles,       $restored->protectSystemFiles);
+        $this->assertSame($original->bans,                     $restored->bans);
+    }
+}

--- a/apps/agent/tests/ServerConfigWriterTest.php
+++ b/apps/agent/tests/ServerConfigWriterTest.php
@@ -174,10 +174,14 @@ final class ServerConfigWriterTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
-    // User-agent bans in server config
+    // User-agent bans — BLOCKER 1: correct positive-match OR-chain
     // -------------------------------------------------------------------------
 
-    public function test_ua_ban_emits_rewrite_condition(): void
+    /**
+     * A single UA ban must emit a positive RewriteCond (no leading '!') and the
+     * RewriteRule that 403s must follow it.
+     */
+    public function test_ua_ban_emits_positive_rewrite_condition(): void
     {
         $raw = [
             'bans' => [['id' => 'u', 'type' => 'user_agent', 'value' => 'EvilBot/2.0']],
@@ -186,6 +190,121 @@ final class ServerConfigWriterTest extends TestCase
         $out = $this->writer()->renderInto('', $cfg);
         $this->assertStringContainsString('HTTP_USER_AGENT', $out);
         $this->assertStringContainsString('EvilBot', $out);
+        // Must be a positive match (no leading '!') so the ban fires ON match.
+        $this->assertStringNotContainsString('!EvilBot', $out);
+        $this->assertStringContainsString('[F,L]', $out);
+    }
+
+    /**
+     * BLOCKER 1: a non-banned UA must NOT be blocked (no false positive).
+     * With one ban in place, a request from a completely different UA must pass.
+     * The old inverted logic blocked ALL UAs that did not match every ban pattern.
+     */
+    public function test_ua_ban_does_not_block_non_banned_ua_single_ban(): void
+    {
+        $raw = [
+            'bans' => [['id' => 'b1', 'type' => 'user_agent', 'value' => 'EvilBot/2.0']],
+        ];
+        $cfg = HardeningConfig::fromArray($raw);
+        $out = $this->writer()->renderInto('', $cfg);
+
+        // The generated .htaccess must contain exactly one RewriteCond.
+        // That condition must be a POSITIVE match for EvilBot (no leading '!'),
+        // so the [F,L] rule fires only when the UA is EvilBot — not for others.
+        $lines = explode("\n", $out);
+        $rewriteConds = array_filter($lines, static fn (string $l): bool => str_contains($l, 'RewriteCond %{HTTP_USER_AGENT}'));
+        $this->assertCount(1, $rewriteConds, 'Exactly one RewriteCond must be emitted for one ban');
+
+        foreach ($rewriteConds as $cond) {
+            // Must NOT be negated — positive match only.
+            $this->assertStringNotContainsString('!EvilBot', $cond, 'UA condition must be a positive match, not negated');
+            $this->assertStringContainsString('EvilBot', $cond, 'EvilBot pattern must appear in the condition');
+        }
+    }
+
+    /**
+     * BLOCKER 1: with TWO bans, verify the OR-chain: the last condition has no
+     * [OR] flag, all others carry [NC,OR]. A UA matching neither ban passes;
+     * a UA matching one ban is blocked.
+     */
+    public function test_ua_ban_two_bans_or_chain_correct(): void
+    {
+        $raw = [
+            'bans' => [
+                ['id' => 'b1', 'type' => 'user_agent', 'value' => 'EvilBot/2.0'],
+                ['id' => 'b2', 'type' => 'user_agent', 'value' => 'SpamCrawler'],
+            ],
+        ];
+        $cfg = HardeningConfig::fromArray($raw);
+        $out = $this->writer()->renderInto('', $cfg);
+
+        $lines = explode("\n", $out);
+        $rewriteConds = array_values(array_filter(
+            $lines,
+            static fn (string $l): bool => str_contains($l, 'RewriteCond %{HTTP_USER_AGENT}')
+        ));
+        $this->assertCount(2, $rewriteConds, 'Exactly two RewriteConds for two UA bans');
+
+        // First condition: must carry [NC,OR] (OR to the next condition).
+        $this->assertStringContainsString('[NC,OR]', $rewriteConds[0], 'First condition must carry [NC,OR]');
+        // Last condition: must NOT carry [OR] (terminates the OR chain).
+        $this->assertStringNotContainsString('[OR]', $rewriteConds[1], 'Last condition must not carry [OR]');
+        // Both must be positive matches (no leading '!').
+        $this->assertStringNotContainsString('!EvilBot',    $rewriteConds[0]);
+        $this->assertStringNotContainsString('!SpamCrawler', $rewriteConds[1]);
+        $this->assertStringContainsString('EvilBot',     $rewriteConds[0]);
+        $this->assertStringContainsString('SpamCrawler', $rewriteConds[1]);
+    }
+
+    // -------------------------------------------------------------------------
+    // BLOCKER 2: UA ban value with newlines must be dropped (injection guard)
+    // -------------------------------------------------------------------------
+
+    /**
+     * BLOCKER 2: a user_agent ban value containing an embedded newline must be
+     * silently dropped at the HardeningConfig validation stage. The injected text
+     * must never appear in the rendered .htaccess block.
+     */
+    public function test_ua_ban_with_newline_is_dropped_by_config(): void
+    {
+        $injection = "EvilBot\n    Require all denied";
+        $raw = [
+            'bans' => [
+                ['id' => 'bad', 'type' => 'user_agent', 'value' => $injection],
+                ['id' => 'ok',  'type' => 'user_agent', 'value' => 'SafeBot'],
+            ],
+        ];
+        $cfg = HardeningConfig::fromArray($raw);
+
+        // The injected value must be absent from the validated ban list.
+        $uaBans = $cfg->userAgentBans();
+        $this->assertNotContains($injection, $uaBans, 'Newline-containing value must be dropped by validateBans');
+        $this->assertContains('SafeBot', $uaBans, 'Clean value must still be accepted');
+
+        $out = $this->writer()->renderInto('', $cfg);
+        $this->assertStringNotContainsString('Require all denied', $out, 'Injected directive must not appear in .htaccess');
+        $this->assertStringNotContainsString("EvilBot\n", $out, 'Literal newline must not appear in .htaccess');
+    }
+
+    /**
+     * BLOCKER 2: belt-and-braces at the writer layer — even if a value with a
+     * control char somehow reaches renderInto, it must be skipped.
+     */
+    public function test_ua_ban_with_cr_lf_skipped_at_render_layer(): void
+    {
+        // Bypass validateBans to reach the writer directly via a crafted config.
+        // We use a value with a carriage-return embedded between two words.
+        // Because validateBans already drops these, we test the belt-and-braces
+        // path by directly verifying the output does not contain the control char.
+        $raw = [
+            'bans' => [
+                ['id' => 'x', 'type' => 'user_agent', 'value' => "Bot\rExtra"],
+            ],
+        ];
+        $cfg = HardeningConfig::fromArray($raw);
+        $out = $this->writer()->renderInto('', $cfg);
+        // validateBans drops the value; the block should be empty.
+        $this->assertStringNotContainsString(ServerConfigWriter::BEGIN, $out, 'Block must be absent when all UA bans are filtered');
     }
 
     // -------------------------------------------------------------------------
@@ -213,6 +332,82 @@ final class ServerConfigWriterTest extends TestCase
         $out = $this->writer()->renderInto('', $this->config(['force_ssl' => true]));
         $this->assertStringContainsString(ServerConfigWriter::BEGIN, $out);
         $this->assertStringContainsString(ServerConfigWriter::END, $out);
+    }
+
+    // -------------------------------------------------------------------------
+    // BLOCKER 3: all-address CIDRs must not emit any deny rule
+    // -------------------------------------------------------------------------
+
+    /**
+     * BLOCKER 3: 0.0.0.0/0 must never appear in a Require not ip directive.
+     * Emitting it would lock out every request, including the signed control-plane
+     * command that would undo the ban.
+     */
+    public function test_ipv4_all_address_cidr_produces_no_deny_rule(): void
+    {
+        $raw = [
+            'bans' => [['id' => 'x', 'type' => 'range', 'value' => '0.0.0.0/0']],
+        ];
+        $cfg = HardeningConfig::fromArray($raw);
+        $out = $this->writer()->renderInto('', $cfg);
+        $this->assertStringNotContainsString('Require not ip', $out, '0.0.0.0/0 must never emit a deny rule');
+        $this->assertStringNotContainsString('0.0.0.0/0', $out, '0.0.0.0/0 must be absent from .htaccess');
+    }
+
+    /**
+     * BLOCKER 3: ::/0 (IPv6 all-address) must never emit a deny rule.
+     */
+    public function test_ipv6_all_address_cidr_produces_no_deny_rule(): void
+    {
+        $raw = [
+            'bans' => [['id' => 'x', 'type' => 'range', 'value' => '::/0']],
+        ];
+        $cfg = HardeningConfig::fromArray($raw);
+        $out = $this->writer()->renderInto('', $cfg);
+        $this->assertStringNotContainsString('Require not ip', $out, '::/0 must never emit a deny rule');
+        $this->assertStringNotContainsString('::/0', $out, '::/0 must be absent from .htaccess');
+    }
+
+    /**
+     * BLOCKER 3: a normal public CIDR (not all-address, not private) MUST still
+     * emit a deny rule — the safety guard must not over-filter.
+     */
+    public function test_normal_public_cidr_emits_deny_rule(): void
+    {
+        $raw = [
+            'bans' => [['id' => 'x', 'type' => 'range', 'value' => '203.0.113.0/24']],
+        ];
+        $cfg = HardeningConfig::fromArray($raw);
+        $out = $this->writer()->renderInto('', $cfg);
+        $this->assertStringContainsString('Require not ip 203.0.113.0/24', $out, 'Public CIDR must produce a deny rule');
+    }
+
+    /**
+     * BLOCKER 3: a CIDR in the private range (10.0.0.0/8) must not emit a deny
+     * rule so a LAN admin can never be locked out via .htaccess.
+     */
+    public function test_private_cidr_does_not_emit_deny_rule(): void
+    {
+        $raw = [
+            'bans' => [['id' => 'x', 'type' => 'range', 'value' => '10.0.0.0/24']],
+        ];
+        $cfg = HardeningConfig::fromArray($raw);
+        $out = $this->writer()->renderInto('', $cfg);
+        $this->assertStringNotContainsString('Require not ip 10.0.0.0/24', $out, 'Private CIDR must not emit a deny rule');
+    }
+
+    /**
+     * BLOCKER 3: a specific private IP (loopback 127.0.0.1) must not emit a
+     * deny rule.
+     */
+    public function test_loopback_ip_does_not_emit_deny_rule(): void
+    {
+        $raw = [
+            'bans' => [['id' => 'x', 'type' => 'ip', 'value' => '127.0.0.1']],
+        ];
+        $cfg = HardeningConfig::fromArray($raw);
+        $out = $this->writer()->renderInto('', $cfg);
+        $this->assertStringNotContainsString('Require not ip 127.0.0.1', $out, 'Loopback IP must not emit a deny rule');
     }
 
     // -------------------------------------------------------------------------

--- a/apps/agent/tests/ServerConfigWriterTest.php
+++ b/apps/agent/tests/ServerConfigWriterTest.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * ServerConfigWriter tests: block generation, idempotency, toggle-specific
+ * directives, ban rules, block removal, and nginx detection.
+ *
+ * Pure in-memory tests on the renderInto() transform (no disk access). The
+ * isNginx() tests mutate $_SERVER.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use WPMgr\Agent\Security\HardeningConfig;
+use WPMgr\Agent\Security\ServerConfigWriter;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Security\ServerConfigWriter
+ */
+final class ServerConfigWriterTest extends TestCase
+{
+    protected function tear_down(): void
+    {
+        unset($_SERVER['SERVER_SOFTWARE']);
+        parent::tear_down();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function writer(): ServerConfigWriter
+    {
+        return new ServerConfigWriter();
+    }
+
+    /**
+     * Build a HardeningConfig with only the specified keys overriding defaults.
+     *
+     * @param array<string,mixed> $overrides
+     * @return HardeningConfig
+     */
+    private function config(array $overrides = []): HardeningConfig
+    {
+        return HardeningConfig::fromArray(['config' => $overrides]);
+    }
+
+    // -------------------------------------------------------------------------
+    // No-op when all toggles off
+    // -------------------------------------------------------------------------
+
+    public function test_empty_config_produces_no_block(): void
+    {
+        $existing = "# BEGIN WordPress\nRewriteRule . /index.php [L]\n# END WordPress\n";
+        $result   = $this->writer()->renderInto($existing, $this->config());
+        // Block should NOT appear when nothing is active.
+        $this->assertStringNotContainsString(ServerConfigWriter::BEGIN, $result);
+        $this->assertStringNotContainsString(ServerConfigWriter::END, $result);
+        // Original WordPress block is preserved.
+        $this->assertStringContainsString('# BEGIN WordPress', $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Idempotency
+    // -------------------------------------------------------------------------
+
+    public function test_block_is_idempotent(): void
+    {
+        $cfg      = $this->config(['disable_directory_browsing' => true]);
+        $writer   = $this->writer();
+        $existing = "# BEGIN WordPress\nRewriteRule . /index.php [L]\n# END WordPress\n";
+
+        $once  = $writer->renderInto($existing, $cfg);
+        $twice = $writer->renderInto($once, $cfg);
+
+        $this->assertSame(1, substr_count($twice, ServerConfigWriter::BEGIN));
+        $this->assertSame(1, substr_count($twice, ServerConfigWriter::END));
+        $this->assertSame($once, $twice, 'second render must equal the first');
+    }
+
+    // -------------------------------------------------------------------------
+    // force_ssl
+    // -------------------------------------------------------------------------
+
+    public function test_force_ssl_emits_redirect_and_hsts(): void
+    {
+        $out = $this->writer()->renderInto('', $this->config(['force_ssl' => true]));
+        $this->assertStringContainsString('RewriteCond %{HTTPS} off', $out);
+        $this->assertStringContainsString('https://%{HTTP_HOST}%{REQUEST_URI}', $out);
+        $this->assertStringContainsString('Strict-Transport-Security', $out);
+    }
+
+    // -------------------------------------------------------------------------
+    // disable_directory_browsing
+    // -------------------------------------------------------------------------
+
+    public function test_disable_directory_browsing_emits_options_indexes(): void
+    {
+        $out = $this->writer()->renderInto('', $this->config(['disable_directory_browsing' => true]));
+        $this->assertStringContainsString('Options -Indexes', $out);
+    }
+
+    // -------------------------------------------------------------------------
+    // disable_php_in_uploads
+    // -------------------------------------------------------------------------
+
+    public function test_disable_php_in_uploads_emits_rewrite_rule(): void
+    {
+        $out = $this->writer()->renderInto('', $this->config(['disable_php_in_uploads' => true]));
+        $this->assertStringContainsString('/wp-content/uploads/', $out);
+        $this->assertStringContainsString('\.php$', $out);
+        $this->assertStringContainsString('[F,L]', $out);
+    }
+
+    // -------------------------------------------------------------------------
+    // protect_system_files
+    // -------------------------------------------------------------------------
+
+    public function test_protect_system_files_blocks_known_filenames(): void
+    {
+        $out = $this->writer()->renderInto('', $this->config(['protect_system_files' => true]));
+        $this->assertStringContainsString('wp-config\.php', $out);
+        $this->assertStringContainsString('\.htaccess', $out);
+        $this->assertStringContainsString('readme\.html', $out);
+        $this->assertStringContainsString('debug\.log', $out);
+        $this->assertStringContainsString('Deny from all', $out);
+    }
+
+    // -------------------------------------------------------------------------
+    // xmlrpc_mode: off
+    // -------------------------------------------------------------------------
+
+    public function test_xmlrpc_off_blocks_xmlrpc_php(): void
+    {
+        $out = $this->writer()->renderInto('', $this->config(['xmlrpc_mode' => 'off']));
+        $this->assertStringContainsString('xmlrpc.php', $out);
+        $this->assertStringContainsString('Deny from all', $out);
+    }
+
+    public function test_xmlrpc_on_produces_no_xmlrpc_block(): void
+    {
+        $out = $this->writer()->renderInto('', $this->config(['xmlrpc_mode' => 'on']));
+        // 'on' is a no-op — do not emit a block just for this.
+        // (Other toggles are also off so the whole block is absent.)
+        $this->assertStringNotContainsString('xmlrpc.php', $out);
+    }
+
+    // -------------------------------------------------------------------------
+    // IP/range bans in server config
+    // -------------------------------------------------------------------------
+
+    public function test_ip_ban_emits_deny_rule(): void
+    {
+        $raw = [
+            'bans' => [['id' => 'x', 'type' => 'ip', 'value' => '203.0.113.5']],
+        ];
+        $cfg = HardeningConfig::fromArray($raw);
+        $out = $this->writer()->renderInto('', $cfg);
+        $this->assertStringContainsString('203.0.113.5', $out);
+        $this->assertStringContainsString('Require not ip 203.0.113.5', $out);
+    }
+
+    public function test_range_ban_emits_cidr_deny_rule(): void
+    {
+        $raw = [
+            'bans' => [['id' => 'x', 'type' => 'range', 'value' => '198.51.100.0/24']],
+        ];
+        $cfg = HardeningConfig::fromArray($raw);
+        $out = $this->writer()->renderInto('', $cfg);
+        $this->assertStringContainsString('198.51.100.0/24', $out);
+    }
+
+    // -------------------------------------------------------------------------
+    // User-agent bans in server config
+    // -------------------------------------------------------------------------
+
+    public function test_ua_ban_emits_rewrite_condition(): void
+    {
+        $raw = [
+            'bans' => [['id' => 'u', 'type' => 'user_agent', 'value' => 'EvilBot/2.0']],
+        ];
+        $cfg = HardeningConfig::fromArray($raw);
+        $out = $this->writer()->renderInto('', $cfg);
+        $this->assertStringContainsString('HTTP_USER_AGENT', $out);
+        $this->assertStringContainsString('EvilBot', $out);
+    }
+
+    // -------------------------------------------------------------------------
+    // Block removal when all toggles off
+    // -------------------------------------------------------------------------
+
+    public function test_all_toggles_off_removes_prior_block(): void
+    {
+        $existing = ServerConfigWriter::BEGIN . "\nOptions -Indexes\n" . ServerConfigWriter::END . "\n"
+            . "# BEGIN WordPress\nRewriteRule . /index.php [L]\n# END WordPress\n";
+
+        $result = $this->writer()->renderInto($existing, $this->config());
+        $this->assertStringNotContainsString(ServerConfigWriter::BEGIN, $result);
+        $this->assertStringNotContainsString(ServerConfigWriter::END, $result);
+        // WordPress block still there.
+        $this->assertStringContainsString('# BEGIN WordPress', $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Markers are always present when block is written
+    // -------------------------------------------------------------------------
+
+    public function test_markers_are_written_when_block_is_active(): void
+    {
+        $out = $this->writer()->renderInto('', $this->config(['force_ssl' => true]));
+        $this->assertStringContainsString(ServerConfigWriter::BEGIN, $out);
+        $this->assertStringContainsString(ServerConfigWriter::END, $out);
+    }
+
+    // -------------------------------------------------------------------------
+    // nginx detection
+    // -------------------------------------------------------------------------
+
+    public function test_is_nginx_detected(): void
+    {
+        $_SERVER['SERVER_SOFTWARE'] = 'nginx/1.24.0';
+        $this->assertTrue($this->writer()->isNginx());
+    }
+
+    public function test_apache_not_detected_as_nginx(): void
+    {
+        $_SERVER['SERVER_SOFTWARE'] = 'Apache/2.4.57 (Ubuntu)';
+        $this->assertFalse($this->writer()->isNginx());
+    }
+
+    public function test_no_server_software_not_detected_as_nginx(): void
+    {
+        unset($_SERVER['SERVER_SOFTWARE']);
+        $this->assertFalse($this->writer()->isNginx());
+    }
+}

--- a/apps/agent/tests/SyncSecurityHardeningCommandTest.php
+++ b/apps/agent/tests/SyncSecurityHardeningCommandTest.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * SyncSecurityHardeningCommand tests:
+ *   - command name is "sync_security_hardening"
+ *   - valid payload persists config + returns {ok:true,detail:"applied"}
+ *   - invalid 'config' type returns a clear error
+ *   - invalid 'bans' type returns a clear error
+ *   - missing keys are tolerated (all-off defaults)
+ *   - each mode for xmlrpc/rest/login-identifier is stored correctly
+ *   - bans are persisted in the stored option
+ *
+ * The HardeningModule is constructed with its wp-options calls stubbed via
+ * Brain Monkey. Server-config writes (ServerConfigWriter) are no-ops in tests
+ * because isNginx() short-circuits (no SERVER_SOFTWARE set).
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Commands\SyncSecurityHardeningCommand;
+use WPMgr\Agent\Security\HardeningModule;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Commands\SyncSecurityHardeningCommand
+ * @covers \WPMgr\Agent\Security\HardeningModule
+ * @covers \WPMgr\Agent\Security\HardeningConfig
+ */
+final class SyncSecurityHardeningCommandTest extends TestCase
+{
+    /** @var array<string,mixed> */
+    private array $optionStore = [];
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->optionStore = [];
+
+        Functions\when('get_option')->alias(fn ($k, $d = false) => $this->optionStore[$k] ?? $d);
+        Functions\when('update_option')->alias(function ($k, $v) {
+            $this->optionStore[$k] = $v;
+            return true;
+        });
+        Functions\when('delete_option')->alias(function ($k) {
+            unset($this->optionStore[$k]);
+            return true;
+        });
+        Functions\when('add_filter')->justReturn(true);
+        Functions\when('add_action')->justReturn(true);
+        Functions\when('remove_filter')->justReturn(true);
+        Functions\when('is_user_logged_in')->justReturn(false);
+        Functions\when('wp_json_encode')->alias(fn ($v) => json_encode($v));
+        Functions\when('sanitize_text_field')->alias(fn ($s) => $s);
+        Functions\when('wp_unslash')->alias(fn ($s) => $s);
+    }
+
+    protected function tear_down(): void
+    {
+        unset($_SERVER['SERVER_SOFTWARE']);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    private function command(): SyncSecurityHardeningCommand
+    {
+        return new SyncSecurityHardeningCommand(new HardeningModule());
+    }
+
+    // -------------------------------------------------------------------------
+    // Command contract
+    // -------------------------------------------------------------------------
+
+    public function test_command_name_is_sync_security_hardening(): void
+    {
+        $this->assertSame('sync_security_hardening', $this->command()->name());
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation errors
+    // -------------------------------------------------------------------------
+
+    public function test_config_must_be_array(): void
+    {
+        $result = $this->command()->execute([], ['config' => 'not-an-array']);
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('config', $result['detail']);
+    }
+
+    public function test_bans_must_be_array(): void
+    {
+        $result = $this->command()->execute([], ['bans' => 'not-an-array']);
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('bans', $result['detail']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path: full valid payload
+    // -------------------------------------------------------------------------
+
+    public function test_full_valid_payload_returns_ok_and_persists(): void
+    {
+        $params = [
+            'config' => [
+                'disable_file_editor'        => true,
+                'xmlrpc_mode'                => 'off',
+                'restrict_rest_api'          => 'restricted',
+                'restrict_login_identifier'  => 'email',
+                'force_unique_nickname'      => true,
+                'disable_author_archive_enum' => true,
+                'force_ssl'                  => false,
+                'disable_directory_browsing' => true,
+                'disable_php_in_uploads'     => true,
+                'protect_system_files'       => true,
+            ],
+            'bans' => [
+                ['id' => 'b1', 'type' => 'ip',    'value' => '203.0.113.5', 'comment' => 'spammer'],
+                ['id' => 'b2', 'type' => 'range',  'value' => '10.0.0.0/8',  'comment' => ''],
+            ],
+        ];
+
+        $result = $this->command()->execute([], $params);
+
+        $this->assertTrue($result['ok']);
+        $this->assertArrayHasKey('detail', $result);
+
+        // Option was stored.
+        $stored = $this->optionStore[HardeningModule::OPTION_CONFIG] ?? null;
+        $this->assertNotNull($stored, 'hardening option must be written');
+
+        $decoded = json_decode($stored, true);
+        $this->assertIsArray($decoded);
+        $this->assertTrue($decoded['config']['disable_file_editor']);
+        $this->assertSame('off', $decoded['config']['xmlrpc_mode']);
+        $this->assertSame('restricted', $decoded['config']['restrict_rest_api']);
+        $this->assertCount(2, $decoded['bans']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Missing keys: defaults to off
+    // -------------------------------------------------------------------------
+
+    public function test_missing_config_key_defaults_to_off(): void
+    {
+        $result = $this->command()->execute([], []);
+        $this->assertTrue($result['ok']);
+
+        $stored  = $this->optionStore[HardeningModule::OPTION_CONFIG] ?? '{}';
+        $decoded = json_decode($stored, true);
+        $this->assertFalse($decoded['config']['disable_file_editor']);
+        $this->assertSame('on', $decoded['config']['xmlrpc_mode']);
+    }
+
+    // -------------------------------------------------------------------------
+    // xmlrpc modes
+    // -------------------------------------------------------------------------
+
+    /** @dataProvider xmlrpcModeProvider */
+    public function test_xmlrpc_mode_stored_correctly(string $mode): void
+    {
+        $result = $this->command()->execute([], ['config' => ['xmlrpc_mode' => $mode]]);
+        $this->assertTrue($result['ok']);
+
+        $decoded = json_decode($this->optionStore[HardeningModule::OPTION_CONFIG], true);
+        $this->assertSame($mode, $decoded['config']['xmlrpc_mode']);
+    }
+
+    /**
+     * @return array<string,array<string>>
+     */
+    public static function xmlrpcModeProvider(): array
+    {
+        return [
+            'on'      => ['on'],
+            'off'     => ['off'],
+            'limited' => ['limited'],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // login identifier modes
+    // -------------------------------------------------------------------------
+
+    /** @dataProvider loginIdentifierProvider */
+    public function test_login_identifier_stored_correctly(string $mode): void
+    {
+        $result = $this->command()->execute([], ['config' => ['restrict_login_identifier' => $mode]]);
+        $this->assertTrue($result['ok']);
+
+        $decoded = json_decode($this->optionStore[HardeningModule::OPTION_CONFIG], true);
+        $this->assertSame($mode, $decoded['config']['restrict_login_identifier']);
+    }
+
+    /**
+     * @return array<string,array<string>>
+     */
+    public static function loginIdentifierProvider(): array
+    {
+        return [
+            'both'     => ['both'],
+            'username' => ['username'],
+            'email'    => ['email'],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // Bans: invalid entries dropped
+    // -------------------------------------------------------------------------
+
+    public function test_malformed_ban_entries_are_dropped(): void
+    {
+        $params = [
+            'bans' => [
+                ['id' => '',  'type' => 'ip',   'value' => '1.2.3.4'],    // empty id
+                ['id' => 'x', 'type' => 'ip',   'value' => 'not-an-ip'], // bad value
+                ['id' => 'y', 'type' => 'range', 'value' => '10.0.0.0'], // missing prefix
+                ['id' => 'z', 'type' => 'user_agent', 'value' => 'EvilBot'], // valid UA
+            ],
+        ];
+
+        $result = $this->command()->execute([], $params);
+        $this->assertTrue($result['ok']);
+
+        $decoded = json_decode($this->optionStore[HardeningModule::OPTION_CONFIG], true);
+        $this->assertCount(1, $decoded['bans'], 'only the valid UA ban should survive');
+        $this->assertSame('EvilBot', $decoded['bans'][0]['value']);
+    }
+
+    // -------------------------------------------------------------------------
+    // WAF deny_cidrs sync
+    // -------------------------------------------------------------------------
+
+    public function test_ip_bans_are_synced_into_waf_deny_cidrs(): void
+    {
+        // Pre-seed a minimal wpmgr_security_config (WAF config).
+        $this->optionStore['wpmgr_security_config'] = json_encode([
+            'mode'        => 'protect',
+            'deny_cidrs'  => ['5.5.5.5/32'],
+            'allow_cidrs' => [],
+        ]);
+
+        $params = [
+            'bans' => [
+                ['id' => 'b1', 'type' => 'ip',    'value' => '203.0.113.10'],
+                ['id' => 'b2', 'type' => 'range',  'value' => '198.51.100.0/24'],
+            ],
+        ];
+
+        $result = $this->command()->execute([], $params);
+        $this->assertTrue($result['ok']);
+
+        $wafRaw     = $this->optionStore['wpmgr_security_config'] ?? '{}';
+        $wafDecoded = json_decode($wafRaw, true);
+        $denyCidrs  = $wafDecoded['deny_cidrs'] ?? [];
+
+        $this->assertContains('5.5.5.5/32', $denyCidrs,      'original deny_cidrs preserved');
+        $this->assertContains('203.0.113.10', $denyCidrs,    'new IP ban synced');
+        $this->assertContains('198.51.100.0/24', $denyCidrs, 'new range ban synced');
+    }
+
+    // -------------------------------------------------------------------------
+    // No WAF config: sync is a no-op (does not create waf config)
+    // -------------------------------------------------------------------------
+
+    public function test_waf_sync_is_noop_when_no_waf_config_exists(): void
+    {
+        $params = [
+            'bans' => [['id' => 'b1', 'type' => 'ip', 'value' => '203.0.113.10']],
+        ];
+
+        $result = $this->command()->execute([], $params);
+        $this->assertTrue($result['ok']);
+
+        // wpmgr_security_config must NOT have been created from scratch.
+        $this->assertArrayNotHasKey('wpmgr_security_config', $this->optionStore);
+    }
+}

--- a/apps/agent/tests/SyncSecurityHardeningCommandTest.php
+++ b/apps/agent/tests/SyncSecurityHardeningCommandTest.php
@@ -236,8 +236,13 @@ final class SyncSecurityHardeningCommandTest extends TestCase
     // WAF deny_cidrs sync
     // -------------------------------------------------------------------------
 
-    public function test_ip_bans_are_synced_into_waf_deny_cidrs(): void
+    public function test_ip_bans_are_synced_into_waf_hardening_deny_cidrs(): void
     {
+        // ITEM 5 FIX: hardening bans now go into 'hardening_deny_cidrs' (their
+        // own key) rather than being merged into 'deny_cidrs'. This allows the
+        // WAF to evaluate them mode-independently: an explicit operator ban blocks
+        // regardless of whether login-protection protect mode is enabled.
+        //
         // Pre-seed a minimal wpmgr_security_config (WAF config).
         $this->optionStore['wpmgr_security_config'] = json_encode([
             'mode'        => 'protect',
@@ -257,11 +262,18 @@ final class SyncSecurityHardeningCommandTest extends TestCase
 
         $wafRaw     = $this->optionStore['wpmgr_security_config'] ?? '{}';
         $wafDecoded = json_decode($wafRaw, true);
-        $denyCidrs  = $wafDecoded['deny_cidrs'] ?? [];
 
-        $this->assertContains('5.5.5.5/32', $denyCidrs,      'original deny_cidrs preserved');
-        $this->assertContains('203.0.113.10', $denyCidrs,    'new IP ban synced');
-        $this->assertContains('198.51.100.0/24', $denyCidrs, 'new range ban synced');
+        // The brute-force deny_cidrs must be UNCHANGED — hardening bans no longer
+        // bleed into the brute-force deny list.
+        $denyCidrs = $wafDecoded['deny_cidrs'] ?? [];
+        $this->assertContains('5.5.5.5/32', $denyCidrs, 'original deny_cidrs must be preserved');
+        $this->assertNotContains('203.0.113.10', $denyCidrs, 'hardening ban must not be in deny_cidrs');
+        $this->assertNotContains('198.51.100.0/24', $denyCidrs, 'hardening range must not be in deny_cidrs');
+
+        // Hardening bans go into their own dedicated key so they enforce in all modes.
+        $hardeningCidrs = $wafDecoded['hardening_deny_cidrs'] ?? [];
+        $this->assertContains('203.0.113.10', $hardeningCidrs,    'new IP ban must be in hardening_deny_cidrs');
+        $this->assertContains('198.51.100.0/24', $hardeningCidrs, 'new range ban must be in hardening_deny_cidrs');
     }
 
     // -------------------------------------------------------------------------

--- a/apps/agent/tests/WafGateHardeningTest.php
+++ b/apps/agent/tests/WafGateHardeningTest.php
@@ -1,0 +1,441 @@
+<?php
+/**
+ * WafGateHardeningTest — exercises the real WAF gate decision function
+ * (wpmgr_waf_should_deny) extracted from the mu-plugin, and the
+ * HardeningModule::syncWafDenyCidrs() broad/private CIDR filter.
+ *
+ * FIX A (MEDIUM): the test now calls the REAL wpmgr_waf_should_deny() defined
+ * in a-wpmgr-waf.php rather than a hand-copied replica. Any reordering of the
+ * five gate layers inside the mu-plugin will immediately break these tests,
+ * making them a genuine regression guard.
+ *
+ * The mu-plugin file defines functions and ends with a WPMGR_WAF_TESTING-gated
+ * wpmgr_waf_gate() call. Defining the constant before require_once ensures we
+ * load the function definitions without triggering the top-level gate() call
+ * (which would fail in the test environment where $wpdb is not available).
+ *
+ * FIX B (LOW-1): test that syncWafDenyCidrs() drops broad/private CIDRs before
+ * persisting into hardening_deny_cidrs, while letting valid public CIDRs through.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Security\HardeningConfig;
+use WPMgr\Agent\Security\HardeningModule;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+// Guard: define the testing constant BEFORE requiring the mu-plugin so the
+// top-level wpmgr_waf_gate() call at the bottom of the file is skipped.
+// The constant must be defined at file-load time (before any test class is
+// instantiated) because require_once runs once per process.
+if (!defined('WPMGR_WAF_TESTING')) {
+    define('WPMGR_WAF_TESTING', true);
+}
+
+// Load the real mu-plugin — defines wpmgr_waf_should_deny() and its helpers.
+// function_exists() guard makes this idempotent if another test already loaded it.
+if (!function_exists('wpmgr_waf_should_deny')) {
+    require_once dirname(__DIR__) . '/mu-plugin-loader/a-wpmgr-waf.php';
+}
+
+/**
+ * @covers wpmgr_waf_should_deny
+ * @covers \WPMgr\Agent\Security\HardeningModule::syncWafDenyCidrs
+ */
+final class WafGateHardeningTest extends TestCase
+{
+    /** @var array<string,mixed> */
+    private array $optionStore = [];
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->optionStore = [];
+
+        Functions\when('get_option')->alias(fn ($k, $d = false) => $this->optionStore[$k] ?? $d);
+        Functions\when('update_option')->alias(function ($k, $v) {
+            $this->optionStore[$k] = $v;
+            return true;
+        });
+        Functions\when('wp_json_encode')->alias(fn ($v) => json_encode($v));
+    }
+
+    protected function tear_down(): void
+    {
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: call the REAL gate decision function (not a replica)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Thin helper so test bodies stay readable. Delegates entirely to the real
+     * wpmgr_waf_should_deny() loaded from a-wpmgr-waf.php above.
+     *
+     * @param array<string,mixed> $config  wpmgr_security_config structure.
+     * @param string              $ip      Client IP address to test.
+     * @return bool True → blocked, false → passed.
+     */
+    private function decide(array $config, string $ip): bool
+    {
+        $mode = isset($config['mode']) && is_string($config['mode']) ? $config['mode'] : 'protect';
+        return wpmgr_waf_should_deny($config, $ip, $mode);
+    }
+
+    // -------------------------------------------------------------------------
+    // FIX A: ITEM 5 — hardening bans enforce regardless of mode
+    // -------------------------------------------------------------------------
+
+    /**
+     * ITEM 5: a public IP that matches hardening_deny_cidrs must be blocked
+     * even when login-protection mode is 'disabled'.
+     */
+    public function test_hardening_ban_blocks_in_disabled_mode(): void
+    {
+        $config = [
+            'mode'                 => 'disabled',
+            'hardening_deny_cidrs' => ['203.0.113.0/24'],
+            'deny_cidrs'           => [],
+            'allow_cidrs'          => [],
+        ];
+        $this->assertTrue(
+            $this->decide($config, '203.0.113.50'),
+            'Hardening ban must block in disabled mode'
+        );
+    }
+
+    /**
+     * ITEM 5: a public IP that matches hardening_deny_cidrs must be blocked
+     * even when login-protection mode is 'audit'.
+     */
+    public function test_hardening_ban_blocks_in_audit_mode(): void
+    {
+        $config = [
+            'mode'                 => 'audit',
+            'hardening_deny_cidrs' => ['198.51.100.0/24'],
+            'deny_cidrs'           => [],
+            'allow_cidrs'          => [],
+        ];
+        $this->assertTrue(
+            $this->decide($config, '198.51.100.1'),
+            'Hardening ban must block in audit mode'
+        );
+    }
+
+    /**
+     * ITEM 5: a public IP that matches hardening_deny_cidrs must also block in
+     * protect mode (consistent across all modes).
+     */
+    public function test_hardening_ban_blocks_in_protect_mode(): void
+    {
+        $config = [
+            'mode'                 => 'protect',
+            'hardening_deny_cidrs' => ['203.0.113.0/24'],
+            'deny_cidrs'           => [],
+            'allow_cidrs'          => [],
+        ];
+        $this->assertTrue(
+            $this->decide($config, '203.0.113.99'),
+            'Hardening ban must block in protect mode'
+        );
+    }
+
+    /**
+     * A non-banned public IP must NOT be blocked by the hardening layer.
+     */
+    public function test_non_banned_ip_is_not_blocked_by_hardening(): void
+    {
+        $config = [
+            'mode'                 => 'disabled',
+            'hardening_deny_cidrs' => ['203.0.113.0/24'],
+            'deny_cidrs'           => [],
+            'allow_cidrs'          => [],
+        ];
+        $this->assertFalse(
+            $this->decide($config, '192.0.2.1'),
+            'Non-banned public IP must pass through in disabled mode'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Safety rails: allow_cidrs and private/loopback bypass in all modes
+    // -------------------------------------------------------------------------
+
+    /**
+     * An IP in allow_cidrs must bypass the hardening ban in protect mode.
+     * allow_cidrs always wins over any deny list (layer 1 of the gate).
+     */
+    public function test_allow_cidr_bypasses_hardening_ban(): void
+    {
+        $config = [
+            'mode'                 => 'protect',
+            'hardening_deny_cidrs' => ['203.0.113.0/24'],
+            'deny_cidrs'           => ['203.0.113.0/24'],
+            'allow_cidrs'          => ['203.0.113.50/32'],
+        ];
+        $this->assertFalse(
+            $this->decide($config, '203.0.113.50'),
+            'allow_cidrs must bypass hardening ban'
+        );
+    }
+
+    /**
+     * An IP in allow_cidrs must bypass the hardening ban in disabled mode too.
+     */
+    public function test_allow_cidr_bypasses_hardening_ban_in_disabled_mode(): void
+    {
+        $config = [
+            'mode'                 => 'disabled',
+            'hardening_deny_cidrs' => ['203.0.113.0/24'],
+            'deny_cidrs'           => [],
+            'allow_cidrs'          => ['203.0.113.50/32'],
+        ];
+        $this->assertFalse(
+            $this->decide($config, '203.0.113.50'),
+            'allow_cidrs must bypass hardening ban in disabled mode'
+        );
+    }
+
+    /**
+     * A private (RFC-1918) IP must bypass the hardening ban regardless of mode.
+     * LAN admin must never be locked out (gate layer 2).
+     */
+    public function test_private_ip_bypasses_hardening_ban_in_disabled_mode(): void
+    {
+        $config = [
+            'mode'                 => 'disabled',
+            'hardening_deny_cidrs' => ['10.0.0.0/8'],
+            'deny_cidrs'           => [],
+            'allow_cidrs'          => [],
+        ];
+        $this->assertFalse(
+            $this->decide($config, '10.1.2.3'),
+            'Private IP must bypass hardening ban in disabled mode'
+        );
+    }
+
+    /**
+     * Loopback (127.0.0.1) must bypass hardening ban in all modes.
+     */
+    public function test_loopback_bypasses_hardening_ban(): void
+    {
+        $config = [
+            'mode'                 => 'protect',
+            'hardening_deny_cidrs' => ['127.0.0.0/8'],
+            'deny_cidrs'           => [],
+            'allow_cidrs'          => [],
+        ];
+        $this->assertFalse(
+            $this->decide($config, '127.0.0.1'),
+            'Loopback must bypass hardening ban'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Brute-force protect gate: unchanged behaviour
+    // -------------------------------------------------------------------------
+
+    /**
+     * deny_cidrs (brute-force path) must still block in protect mode.
+     */
+    public function test_deny_cidrs_blocks_in_protect_mode(): void
+    {
+        $config = [
+            'mode'                 => 'protect',
+            'hardening_deny_cidrs' => [],
+            'deny_cidrs'           => ['203.0.113.0/24'],
+            'allow_cidrs'          => [],
+        ];
+        $this->assertTrue(
+            $this->decide($config, '203.0.113.7'),
+            'deny_cidrs must still block in protect mode'
+        );
+    }
+
+    /**
+     * deny_cidrs must NOT block in disabled mode — it is mode-gated.
+     * Only hardening_deny_cidrs is mode-independent (gate layer 3 vs 4-5).
+     */
+    public function test_deny_cidrs_does_not_block_in_disabled_mode(): void
+    {
+        $config = [
+            'mode'                 => 'disabled',
+            'hardening_deny_cidrs' => [],
+            'deny_cidrs'           => ['203.0.113.0/24'],
+            'allow_cidrs'          => [],
+        ];
+        $this->assertFalse(
+            $this->decide($config, '203.0.113.7'),
+            'deny_cidrs must not block in disabled mode (brute-force gate is mode-gated)'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // FIX B: syncWafDenyCidrs() broad/private CIDR filter
+    // -------------------------------------------------------------------------
+
+    /**
+     * A broad CIDR (IPv4 prefix < /8) handed to syncWafDenyCidrs() must NOT
+     * appear in hardening_deny_cidrs after sync.
+     */
+    public function test_sync_waf_deny_cidrs_drops_broad_ipv4_cidr(): void
+    {
+        $this->optionStore['wpmgr_security_config'] = (string) json_encode([
+            'mode'        => 'protect',
+            'deny_cidrs'  => [],
+            'allow_cidrs' => [],
+        ]);
+
+        $config = HardeningConfig::fromArray([
+            'bans' => [
+                ['id' => 'b1', 'type' => 'range', 'value' => '0.0.0.0/0', 'comment' => ''],
+                ['id' => 'b2', 'type' => 'range', 'value' => '1.0.0.0/7', 'comment' => ''],
+            ],
+        ]);
+
+        $module = new HardeningModule();
+        $module->syncWafDenyCidrs($config);
+
+        $wafDecoded = json_decode($this->optionStore['wpmgr_security_config'] ?? '{}', true);
+        $hardeningCidrs = $wafDecoded['hardening_deny_cidrs'] ?? [];
+
+        $this->assertNotContains('0.0.0.0/0', $hardeningCidrs, '0.0.0.0/0 (all-address) must be dropped');
+        $this->assertNotContains('1.0.0.0/7',  $hardeningCidrs, '/7 prefix (< /8) must be dropped');
+        $this->assertSame([], $hardeningCidrs, 'All broad CIDRs must be filtered out; result must be empty');
+    }
+
+    /**
+     * A broad CIDR (IPv6 prefix < /16) must be dropped before persisting.
+     */
+    public function test_sync_waf_deny_cidrs_drops_broad_ipv6_cidr(): void
+    {
+        $this->optionStore['wpmgr_security_config'] = (string) json_encode([
+            'mode'        => 'protect',
+            'deny_cidrs'  => [],
+            'allow_cidrs' => [],
+        ]);
+
+        $config = HardeningConfig::fromArray([
+            'bans' => [
+                ['id' => 'b1', 'type' => 'range', 'value' => '::/0',   'comment' => ''],
+                ['id' => 'b2', 'type' => 'range', 'value' => '2001::/15', 'comment' => ''],
+            ],
+        ]);
+
+        $module = new HardeningModule();
+        $module->syncWafDenyCidrs($config);
+
+        $wafDecoded = json_decode($this->optionStore['wpmgr_security_config'] ?? '{}', true);
+        $hardeningCidrs = $wafDecoded['hardening_deny_cidrs'] ?? [];
+
+        $this->assertNotContains('::/0',      $hardeningCidrs, '::/0 (all-address IPv6) must be dropped');
+        $this->assertNotContains('2001::/15', $hardeningCidrs, '/15 prefix (< /16) must be dropped');
+        $this->assertSame([], $hardeningCidrs, 'All broad IPv6 CIDRs must be filtered out; result must be empty');
+    }
+
+    /**
+     * A private (RFC-1918) CIDR must be dropped before persisting — even though
+     * the runtime WAF also enforces the private bypass, the agent must not store it.
+     */
+    public function test_sync_waf_deny_cidrs_drops_private_cidr(): void
+    {
+        $this->optionStore['wpmgr_security_config'] = (string) json_encode([
+            'mode'        => 'protect',
+            'deny_cidrs'  => [],
+            'allow_cidrs' => [],
+        ]);
+
+        $config = HardeningConfig::fromArray([
+            'bans' => [
+                ['id' => 'b1', 'type' => 'range', 'value' => '10.0.0.0/8',     'comment' => ''],
+                ['id' => 'b2', 'type' => 'range', 'value' => '192.168.0.0/16', 'comment' => ''],
+                ['id' => 'b3', 'type' => 'range', 'value' => '::1/128',        'comment' => ''],
+            ],
+        ]);
+
+        $module = new HardeningModule();
+        $module->syncWafDenyCidrs($config);
+
+        $wafDecoded = json_decode($this->optionStore['wpmgr_security_config'] ?? '{}', true);
+        $hardeningCidrs = $wafDecoded['hardening_deny_cidrs'] ?? [];
+
+        $this->assertNotContains('10.0.0.0/8',     $hardeningCidrs, 'RFC-1918 10/8 must be dropped');
+        $this->assertNotContains('192.168.0.0/16',  $hardeningCidrs, 'RFC-1918 192.168/16 must be dropped');
+        $this->assertNotContains('::1/128',          $hardeningCidrs, 'IPv6 loopback must be dropped');
+        $this->assertSame([], $hardeningCidrs, 'All private/loopback CIDRs must be filtered out');
+    }
+
+    /**
+     * A valid public CIDR must pass through syncWafDenyCidrs() and appear in
+     * hardening_deny_cidrs after sync. Broad/private filtering must not drop it.
+     */
+    public function test_sync_waf_deny_cidrs_keeps_valid_public_cidr(): void
+    {
+        $this->optionStore['wpmgr_security_config'] = (string) json_encode([
+            'mode'        => 'protect',
+            'deny_cidrs'  => [],
+            'allow_cidrs' => [],
+        ]);
+
+        $config = HardeningConfig::fromArray([
+            'bans' => [
+                ['id' => 'b1', 'type' => 'ip',    'value' => '203.0.113.10',   'comment' => ''],
+                ['id' => 'b2', 'type' => 'range',  'value' => '198.51.100.0/24', 'comment' => ''],
+            ],
+        ]);
+
+        $module = new HardeningModule();
+        $module->syncWafDenyCidrs($config);
+
+        $wafDecoded = json_decode($this->optionStore['wpmgr_security_config'] ?? '{}', true);
+        $hardeningCidrs = $wafDecoded['hardening_deny_cidrs'] ?? [];
+
+        $this->assertContains('203.0.113.10',    $hardeningCidrs, 'Valid public IP must survive the filter');
+        $this->assertContains('198.51.100.0/24', $hardeningCidrs, 'Valid public range must survive the filter');
+    }
+
+    /**
+     * Mixed list: broad/private CIDRs are dropped while valid public ones survive.
+     */
+    public function test_sync_waf_deny_cidrs_mixed_list_drops_bad_keeps_good(): void
+    {
+        $this->optionStore['wpmgr_security_config'] = (string) json_encode([
+            'mode'        => 'protect',
+            'deny_cidrs'  => [],
+            'allow_cidrs' => [],
+        ]);
+
+        $config = HardeningConfig::fromArray([
+            'bans' => [
+                ['id' => 'b1', 'type' => 'range', 'value' => '0.0.0.0/0',       'comment' => ''],  // broad — drop
+                ['id' => 'b2', 'type' => 'range', 'value' => '10.0.0.0/8',      'comment' => ''],  // private — drop
+                ['id' => 'b3', 'type' => 'ip',    'value' => '203.0.113.5',      'comment' => ''],  // public — keep
+                ['id' => 'b4', 'type' => 'range', 'value' => '198.51.100.0/24',  'comment' => ''],  // public — keep
+                ['id' => 'b5', 'type' => 'range', 'value' => '::1/128',          'comment' => ''],  // private — drop
+            ],
+        ]);
+
+        $module = new HardeningModule();
+        $module->syncWafDenyCidrs($config);
+
+        $wafDecoded = json_decode($this->optionStore['wpmgr_security_config'] ?? '{}', true);
+        $hardeningCidrs = $wafDecoded['hardening_deny_cidrs'] ?? [];
+
+        $this->assertNotContains('0.0.0.0/0',      $hardeningCidrs, 'Broad all-address must be dropped');
+        $this->assertNotContains('10.0.0.0/8',     $hardeningCidrs, 'Private 10/8 must be dropped');
+        $this->assertNotContains('::1/128',          $hardeningCidrs, 'IPv6 loopback must be dropped');
+        $this->assertContains('203.0.113.5',        $hardeningCidrs, 'Public IP must be kept');
+        $this->assertContains('198.51.100.0/24',    $hardeningCidrs, 'Public range must be kept');
+        $this->assertCount(2, $hardeningCidrs, 'Only the 2 public entries must survive');
+    }
+}

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -1561,6 +1561,10 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// `sync_security_config` command, ingests login events, and exposes an
 	// unblock-IP action. The agent client is wired when the commander supports
 	// the security command verbs (every real-mode build does).
+	//
+	// ADR-057 Phase 1: the same service also owns the hardening config + ban
+	// list. The hardening client is wired separately so each interface can be
+	// satisfied independently (the disabledCommander satisfies both or neither).
 	securityRepo := security.NewRepo(pool)
 	securitySvc := security.NewService(securityRepo)
 	securityH := security.NewHandler(securitySvc, auditRec)
@@ -1571,6 +1575,12 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 		logger.Info("security agent client wired")
 	} else {
 		logger.Warn("security agent client not wired: CP->agent commander unavailable (signing key empty?)")
+	}
+	if hardeningCmd, ok := commander.(security.AgentHardeningClient); ok {
+		securitySvc.SetHardeningClient(hardeningCmd, secSiteAdapter)
+		logger.Info("security hardening agent client wired")
+	} else {
+		logger.Warn("security hardening agent client not wired: CP->agent commander unavailable (signing key empty?)")
 	}
 
 	// M14 — Login Whitelabel. The loginbrand service stores per-site login brand
@@ -2566,6 +2576,10 @@ func (disabledCommander) SyncErrorConfig(_ context.Context, _ uuid.UUID, _ strin
 
 func (disabledCommander) SyncSecurityConfig(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.SecurityConfigRequest) (agentcmd.SecurityConfigResult, error) {
 	return agentcmd.SecurityConfigResult{}, fmt.Errorf("CP->agent commands are disabled: no signing key configured")
+}
+
+func (disabledCommander) SyncSecurityHardening(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.HardeningRequest) (agentcmd.HardeningResult, error) {
+	return agentcmd.HardeningResult{}, fmt.Errorf("CP->agent commands are disabled: no signing key configured")
 }
 
 func (disabledCommander) UnblockIP(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.UnblockIPRequest) (agentcmd.UnblockIPResult, error) {

--- a/apps/api/internal/agentcmd/client.go
+++ b/apps/api/internal/agentcmd/client.go
@@ -173,6 +173,22 @@ func (c *Client) UnblockIP(ctx context.Context, siteID uuid.UUID, siteURL string
 	return out, nil
 }
 
+// SyncSecurityHardening sends the signed `sync_security_hardening` command to
+// the site's agent, pushing the full per-site hardening config snapshot and the
+// current ban list (ADR-057 Phase 1). siteID is the target site's stable
+// enrollment UUID, bound into the JWT's aud claim. An ok=false response (HTTP
+// 200) is treated as an error with the agent's detail message.
+func (c *Client) SyncSecurityHardening(ctx context.Context, siteID uuid.UUID, siteURL string, req HardeningRequest) (HardeningResult, error) {
+	var out HardeningResult
+	if err := c.post(ctx, siteID, siteURL, "sync_security_hardening", req, &out); err != nil {
+		return HardeningResult{}, err
+	}
+	if !out.OK {
+		return out, fmt.Errorf("sync_security_hardening rejected by agent: %s", out.Detail)
+	}
+	return out, nil
+}
+
 // SyncLoginBrand sends the signed `sync_login_brand` command to the site's
 // agent, pushing the per-site login brand config (logo URL, logo link,
 // message). siteID is the target site's stable enrollment UUID, bound into the

--- a/apps/api/internal/agentcmd/hardening_contract.go
+++ b/apps/api/internal/agentcmd/hardening_contract.go
@@ -1,0 +1,90 @@
+package agentcmd
+
+// This file is the AUTHORITATIVE CP->agent command contract for the Security
+// Suite Phase 1 (ADR-057): per-site hardening toggles + durable ban list.
+// The wp-agent-engineer mirrors these shapes in the agent's command handler.
+// Field names are JSON wire names; do not rename without updating both sides.
+//
+// Transport — sync_security_hardening:
+//   POST {site_url}/wp-json/wpmgr/v1/command/sync_security_hardening
+//   Header: Authorization: Bearer <minted EdDSA JWT>
+//           cmd="sync_security_hardening", aud=<siteId>
+//   Body:   application/json — HardeningRequest below.
+//   Response: 200 with HardeningResult; ok=false = semantic failure (HTTP
+//             transport error OR ok=false at 200 is treated as an error by
+//             the CP, same as sync_security_config / sync_error_config).
+//
+// The agent applies the FULL config + ban list atomically on every push.
+// It does not diff against a previous state — the CP sends the canonical
+// current snapshot and the agent replaces its local copy.
+
+// HardeningConfig is the per-site hardening toggle block the CP sends to the
+// agent. Each field maps to one WordPress hardening technique that the agent
+// applies via its config-writer and mu-plugin.
+//
+// All toggles default false (off) so enabling is opt-in. The agent treats a
+// missing field as false (JSON zero value) to remain backward-compatible when
+// new toggles are added in future phases without a simultaneous agent update.
+//
+//	disable_file_editor          — write DISALLOW_FILE_EDIT to wp-config.
+//	xmlrpc_mode                  — "on" (leave as-is) | "off" (block) |
+//	                               "limited" (block system.multicall only).
+//	restrict_rest_api            — "default" | "restricted" (block anon access
+//	                               to sensitive routes: /users, /comments).
+//	restrict_login_identifier    — "username" | "email" | "both".
+//	force_unique_nickname        — enforce display_name != user_login.
+//	disable_author_archive_enum  — 404 for author archives with 0 posts.
+//	force_ssl                    — write FORCE_SSL_ADMIN to wp-config.
+//	disable_directory_browsing   — emit Options -Indexes server-config rule.
+//	disable_php_in_uploads       — block direct PHP execution in uploads/
+//	                               plugins/themes via server-config rules.
+//	protect_system_files         — deny readme.html / wp-config.php /
+//	                               install.php / .git/ via server-config.
+type HardeningConfig struct {
+	DisableFileEditor         bool   `json:"disable_file_editor"`
+	XMLRPCMode                string `json:"xmlrpc_mode"`
+	RestrictRESTAPI           string `json:"restrict_rest_api"`
+	RestrictLoginIdentifier   string `json:"restrict_login_identifier"`
+	ForceUniqueNickname       bool   `json:"force_unique_nickname"`
+	DisableAuthorArchiveEnum  bool   `json:"disable_author_archive_enum"`
+	ForceSSL                  bool   `json:"force_ssl"`
+	DisableDirectoryBrowsing  bool   `json:"disable_directory_browsing"`
+	DisablePHPInUploads       bool   `json:"disable_php_in_uploads"`
+	ProtectSystemFiles        bool   `json:"protect_system_files"`
+}
+
+// BanEntry is one durable ban entry in the ban list.
+//
+//	id          CP-assigned UUID (the agent uses it to detect list drift).
+//	type        "ip" | "range" | "user_agent".
+//	value       the banned value (IP, CIDR, or UA string).
+//	comment     optional operator note (informational; the agent may log it).
+type BanEntry struct {
+	ID      string `json:"id"`
+	Type    string `json:"type"`
+	Value   string `json:"value"`
+	Comment string `json:"comment,omitempty"`
+}
+
+// HardeningRequest is the POST body for the `sync_security_hardening` command.
+//
+//	config  the full hardening toggle snapshot.
+//	bans    the full current ban list for this site (IP/range/user-agent).
+//	        The agent REPLACES its local ban list with this snapshot on every
+//	        push; an empty slice means "no bans" (clear any local list).
+type HardeningRequest struct {
+	Config HardeningConfig `json:"config"`
+	Bans   []BanEntry      `json:"bans"`
+}
+
+// HardeningResult is the agent's response to the `sync_security_hardening`
+// command.
+//
+//	ok      whether the agent successfully applied the config + ban list.
+//	detail  short human-readable note ("applied", or an error description when
+//	        ok=false). The CP treats ok=false as an application-level error with
+//	        this message, even though the HTTP status is 200.
+type HardeningResult struct {
+	OK     bool   `json:"ok"`
+	Detail string `json:"detail"`
+}

--- a/apps/api/internal/authz/role.go
+++ b/apps/api/internal/authz/role.go
@@ -122,6 +122,13 @@ const (
 	// PermClientManage creates, updates, deletes, and assigns agency clients (m63).
 	// Operator+ — same tier as PermSiteWrite; includes the assignment flow.
 	PermClientManage Permission = "client:manage"
+
+	// PermSecurityManage reads and writes the per-site security hardening
+	// config and ban list (ADR-057, Security Suite Phase 1). Operator+ —
+	// same tier as PermSiteCacheManage and PermEmailManage; site-scoped so
+	// a collaborator with access to a site can manage that site's security
+	// hardening. Viewers get read access via PermSiteRead on the GET routes.
+	PermSecurityManage Permission = "site.security.manage"
 )
 
 // minRoleFor maps each permission to the minimum role that holds it. The matrix
@@ -163,6 +170,9 @@ var minRoleFor = map[Permission]Role{
 	// Agency Clients (m63). Read: viewer+; manage: operator+; org-scoped only.
 	PermClientRead:   RoleViewer,
 	PermClientManage: RoleOperator,
+	// Security Suite (ADR-057). Hardening config + ban list: operator+;
+	// site-write-class, mirrors PermSiteCacheManage and PermEmailManage.
+	PermSecurityManage: RoleOperator,
 }
 
 // Allows reports whether role r is permitted to perform p.

--- a/apps/api/internal/security/handler.go
+++ b/apps/api/internal/security/handler.go
@@ -20,10 +20,15 @@ import (
 // Handler serves the operator-facing security routes under
 // /api/v1/sites/{siteId}/security/...
 //
-//	GET  /security/login-protection          — get config
+//	GET  /security/login-protection          — get login-protection config
 //	PUT  /security/login-protection          — save config + push to agent
 //	POST /security/unblock-ip               — unblock an IP address
 //	GET  /security/login-events             — list login events
+//	GET  /security/hardening                — get hardening config (ADR-057)
+//	PUT  /security/hardening                — save hardening config + push
+//	GET  /security/bans                     — list ban entries
+//	POST /security/bans                     — create ban entry
+//	DELETE /security/bans/:banId            — delete ban entry
 type Handler struct {
 	svc   *Service
 	audit *audit.Recorder
@@ -39,12 +44,21 @@ func (h *Handler) Register(r *gin.RouterGroup) {
 	// RequireSiteAccess("siteId") is applied on the group so every sub-route
 	// inherits it. This enforces the site allowlist for site-scoped principals
 	// (belt-and-braces in front of the RLS policy on site_security_config /
-	// agent_login_events).
+	// agent_login_events / site_security_hardening_config / site_security_bans).
 	g := r.Group("/sites/:siteId/security", authz.RequireSiteAccess("siteId"))
+
+	// Login-protection (S2).
 	g.GET("/login-protection", authz.RequirePermission(authz.PermSiteRead), h.getConfig)
 	g.PUT("/login-protection", authz.RequirePermission(authz.PermSiteWrite), h.putConfig)
 	g.POST("/unblock-ip", authz.RequirePermission(authz.PermSiteWrite), h.unblockIP)
 	g.GET("/login-events", authz.RequirePermission(authz.PermSiteRead), h.listLoginEvents)
+
+	// Hardening config + ban list (ADR-057 Phase 1).
+	g.GET("/hardening", authz.RequirePermission(authz.PermSiteRead), h.getHardeningConfig)
+	g.PUT("/hardening", authz.RequirePermission(authz.PermSecurityManage), h.putHardeningConfig)
+	g.GET("/bans", authz.RequirePermission(authz.PermSiteRead), h.listBans)
+	g.POST("/bans", authz.RequirePermission(authz.PermSecurityManage), h.createBan)
+	g.DELETE("/bans/:banId", authz.RequirePermission(authz.PermSecurityManage), h.deleteBan)
 }
 
 // ---------------------------------------------------------------------------
@@ -339,4 +353,252 @@ func (h *Handler) listLoginEvents(c *gin.Context) {
 		items = append(items, dto)
 	}
 	c.JSON(http.StatusOK, loginEventListDTO{Items: items})
+}
+
+// ---------------------------------------------------------------------------
+// ADR-057 Phase 1 — hardening config DTOs + handlers
+// ---------------------------------------------------------------------------
+
+// hardeningConfigDTO is the JSON shape for GET/PUT /security/hardening.
+type hardeningConfigDTO struct {
+	DisableFileEditor        bool   `json:"disable_file_editor"`
+	XMLRPCMode               string `json:"xmlrpc_mode"`
+	RestrictRESTAPI          string `json:"restrict_rest_api"`
+	RestrictLoginIdentifier  string `json:"restrict_login_identifier"`
+	ForceUniqueNickname      bool   `json:"force_unique_nickname"`
+	DisableAuthorArchiveEnum bool   `json:"disable_author_archive_enum"`
+	ForceSSL                 bool   `json:"force_ssl"`
+	DisableDirectoryBrowsing bool   `json:"disable_directory_browsing"`
+	DisablePHPInUploads      bool   `json:"disable_php_in_uploads"`
+	ProtectSystemFiles       bool   `json:"protect_system_files"`
+	UpdatedAt                string `json:"updated_at,omitempty"`
+}
+
+func toHardeningDTO(cfg HardeningConfig) hardeningConfigDTO {
+	dto := hardeningConfigDTO{
+		DisableFileEditor:        cfg.DisableFileEditor,
+		XMLRPCMode:               string(cfg.XMLRPCMode),
+		RestrictRESTAPI:          string(cfg.RestrictRESTAPI),
+		RestrictLoginIdentifier:  string(cfg.RestrictLoginIdentifier),
+		ForceUniqueNickname:      cfg.ForceUniqueNickname,
+		DisableAuthorArchiveEnum: cfg.DisableAuthorArchiveEnum,
+		ForceSSL:                 cfg.ForceSSL,
+		DisableDirectoryBrowsing: cfg.DisableDirectoryBrowsing,
+		DisablePHPInUploads:      cfg.DisablePHPInUploads,
+		ProtectSystemFiles:       cfg.ProtectSystemFiles,
+	}
+	if !cfg.UpdatedAt.IsZero() {
+		dto.UpdatedAt = cfg.UpdatedAt.UTC().Format(time.RFC3339)
+	}
+	return dto
+}
+
+func fromHardeningDTO(dto hardeningConfigDTO, tenantID, siteID uuid.UUID) HardeningConfig {
+	return HardeningConfig{
+		TenantID:                tenantID,
+		SiteID:                  siteID,
+		DisableFileEditor:       dto.DisableFileEditor,
+		XMLRPCMode:              XMLRPCMode(dto.XMLRPCMode),
+		RestrictRESTAPI:         RESTAPIMode(dto.RestrictRESTAPI),
+		RestrictLoginIdentifier: LoginIdentifierMode(dto.RestrictLoginIdentifier),
+		ForceUniqueNickname:     dto.ForceUniqueNickname,
+		DisableAuthorArchiveEnum: dto.DisableAuthorArchiveEnum,
+		ForceSSL:                dto.ForceSSL,
+		DisableDirectoryBrowsing: dto.DisableDirectoryBrowsing,
+		DisablePHPInUploads:     dto.DisablePHPInUploads,
+		ProtectSystemFiles:      dto.ProtectSystemFiles,
+	}
+}
+
+func (h *Handler) getHardeningConfig(c *gin.Context) {
+	p, _ := domain.PrincipalFromContext(c.Request.Context())
+	siteID, err := uuid.Parse(c.Param("siteId"))
+	if err != nil {
+		httpx.Error(c, domain.Validation("invalid_site_id", "siteId is not a valid UUID"))
+		return
+	}
+	cfg, err := h.svc.GetHardeningConfig(c.Request.Context(), p.TenantID, siteID)
+	if err != nil {
+		httpx.Error(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, toHardeningDTO(cfg))
+}
+
+func (h *Handler) putHardeningConfig(c *gin.Context) {
+	p, _ := domain.PrincipalFromContext(c.Request.Context())
+	siteID, err := uuid.Parse(c.Param("siteId"))
+	if err != nil {
+		httpx.Error(c, domain.Validation("invalid_site_id", "siteId is not a valid UUID"))
+		return
+	}
+	var body hardeningConfigDTO
+	if err := bindJSON(c, &body); err != nil {
+		httpx.Error(c, err)
+		return
+	}
+	cfg := fromHardeningDTO(body, p.TenantID, siteID)
+
+	saved, saveErr := h.svc.SaveHardeningConfig(
+		c.Request.Context(), p.TenantID, siteID, cfg,
+		actorType(p), p.ActorID(),
+	)
+	if saveErr != nil {
+		if _, ok := domain.AsDomain(saveErr); ok {
+			httpx.Error(c, saveErr)
+			return
+		}
+		// Non-domain = agent push failed after successful store. Return 200 with
+		// stored config; surface the push warning in a header.
+		c.Header("X-Agent-Push-Warning", saveErr.Error())
+		c.JSON(http.StatusOK, toHardeningDTO(saved))
+		return
+	}
+
+	_, _ = h.audit.Record(c.Request.Context(), audit.Event{
+		TenantID:   p.TenantID,
+		ActorType:  actorType(p),
+		ActorID:    p.ActorID(),
+		Action:     "site_security_hardening.update",
+		TargetType: "site",
+		TargetID:   siteID.String(),
+		Metadata: map[string]any{
+			"disable_file_editor":  saved.DisableFileEditor,
+			"xmlrpc_mode":          string(saved.XMLRPCMode),
+			"restrict_rest_api":    string(saved.RestrictRESTAPI),
+			"force_ssl":            saved.ForceSSL,
+		},
+	})
+
+	c.JSON(http.StatusOK, toHardeningDTO(saved))
+}
+
+// ---------------------------------------------------------------------------
+// ADR-057 Phase 1 — ban list DTOs + handlers
+// ---------------------------------------------------------------------------
+
+// banDTO is the JSON shape for one ban entry (list + create response).
+type banDTO struct {
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	Value     string `json:"value"`
+	Comment   string `json:"comment"`
+	ActorType string `json:"actor_type"`
+	ActorID   string `json:"actor_id"`
+	CreatedAt string `json:"created_at"`
+}
+
+// createBanBody is the POST /security/bans request body.
+type createBanBody struct {
+	Type    string `json:"type"`
+	Value   string `json:"value"`
+	Comment string `json:"comment"`
+}
+
+type banListDTO struct {
+	Items []banDTO `json:"items"`
+}
+
+func toBanDTO(b Ban) banDTO {
+	return banDTO{
+		ID:        b.ID.String(),
+		Type:      string(b.Type),
+		Value:     b.Value,
+		Comment:   b.Comment,
+		ActorType: b.ActorType,
+		ActorID:   b.ActorID,
+		CreatedAt: b.CreatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+func (h *Handler) listBans(c *gin.Context) {
+	p, _ := domain.PrincipalFromContext(c.Request.Context())
+	siteID, err := uuid.Parse(c.Param("siteId"))
+	if err != nil {
+		httpx.Error(c, domain.Validation("invalid_site_id", "siteId is not a valid UUID"))
+		return
+	}
+	bans, err := h.svc.ListBans(c.Request.Context(), p.TenantID, siteID)
+	if err != nil {
+		httpx.Error(c, err)
+		return
+	}
+	items := make([]banDTO, 0, len(bans))
+	for _, b := range bans {
+		items = append(items, toBanDTO(b))
+	}
+	c.JSON(http.StatusOK, banListDTO{Items: items})
+}
+
+func (h *Handler) createBan(c *gin.Context) {
+	p, _ := domain.PrincipalFromContext(c.Request.Context())
+	siteID, err := uuid.Parse(c.Param("siteId"))
+	if err != nil {
+		httpx.Error(c, domain.Validation("invalid_site_id", "siteId is not a valid UUID"))
+		return
+	}
+	var body createBanBody
+	if err := bindJSON(c, &body); err != nil {
+		httpx.Error(c, err)
+		return
+	}
+
+	ban := Ban{
+		TenantID:  p.TenantID,
+		SiteID:    siteID,
+		Type:      BanType(strings.TrimSpace(body.Type)),
+		Value:     strings.TrimSpace(body.Value),
+		Comment:   body.Comment,
+		ActorType: actorType(p),
+		ActorID:   p.ActorID(),
+	}
+
+	saved, err := h.svc.CreateBan(c.Request.Context(), p.TenantID, siteID, ban)
+	if err != nil {
+		httpx.Error(c, err)
+		return
+	}
+
+	_, _ = h.audit.Record(c.Request.Context(), audit.Event{
+		TenantID:   p.TenantID,
+		ActorType:  actorType(p),
+		ActorID:    p.ActorID(),
+		Action:     "site_security_ban.create",
+		TargetType: "site",
+		TargetID:   siteID.String(),
+		Metadata:   map[string]any{"ban_id": saved.ID.String(), "type": string(saved.Type), "value": saved.Value},
+	})
+
+	c.JSON(http.StatusCreated, toBanDTO(saved))
+}
+
+func (h *Handler) deleteBan(c *gin.Context) {
+	p, _ := domain.PrincipalFromContext(c.Request.Context())
+	siteID, err := uuid.Parse(c.Param("siteId"))
+	if err != nil {
+		httpx.Error(c, domain.Validation("invalid_site_id", "siteId is not a valid UUID"))
+		return
+	}
+	banID, err := uuid.Parse(c.Param("banId"))
+	if err != nil {
+		httpx.Error(c, domain.Validation("invalid_ban_id", "banId is not a valid UUID"))
+		return
+	}
+
+	if err := h.svc.DeleteBan(c.Request.Context(), p.TenantID, siteID, banID); err != nil {
+		httpx.Error(c, err)
+		return
+	}
+
+	_, _ = h.audit.Record(c.Request.Context(), audit.Event{
+		TenantID:   p.TenantID,
+		ActorType:  actorType(p),
+		ActorID:    p.ActorID(),
+		Action:     "site_security_ban.delete",
+		TargetType: "site",
+		TargetID:   siteID.String(),
+		Metadata:   map[string]any{"ban_id": banID.String()},
+	})
+
+	c.Status(http.StatusNoContent)
 }

--- a/apps/api/internal/security/hardening_test.go
+++ b/apps/api/internal/security/hardening_test.go
@@ -1,0 +1,745 @@
+package security
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/server/httpx"
+)
+
+// ---------------------------------------------------------------------------
+// In-memory fake service (no DB, no RLS, tests service/DTO/handler logic)
+// ---------------------------------------------------------------------------
+
+// fakeHardeningService is a stand-in for *Service that keeps state in memory.
+// It validates the same business rules as the real service so the tests cover
+// the validation paths without a Postgres connection.
+type fakeHardeningService struct {
+	configs map[uuid.UUID]HardeningConfig // keyed by siteID
+	bans    map[uuid.UUID][]Ban           // keyed by siteID
+}
+
+func newFakeHardeningService() *fakeHardeningService {
+	return &fakeHardeningService{
+		configs: make(map[uuid.UUID]HardeningConfig),
+		bans:    make(map[uuid.UUID][]Ban),
+	}
+}
+
+func (s *fakeHardeningService) getHardeningConfig(_ context.Context, tenantID, siteID uuid.UUID) (HardeningConfig, error) {
+	if cfg, ok := s.configs[siteID]; ok {
+		return cfg, nil
+	}
+	return DefaultHardeningConfig(tenantID, siteID), nil
+}
+
+func (s *fakeHardeningService) saveHardeningConfig(_ context.Context, tenantID, siteID uuid.UUID, cfg HardeningConfig, actorType, actorID string) (HardeningConfig, error) {
+	if !validXMLRPCModes[cfg.XMLRPCMode] {
+		return HardeningConfig{}, domain.Validation("invalid_xmlrpc_mode",
+			"xmlrpc_mode must be on|off|limited")
+	}
+	if !validRESTAPIModes[cfg.RestrictRESTAPI] {
+		return HardeningConfig{}, domain.Validation("invalid_restrict_rest_api",
+			"restrict_rest_api must be default|restricted")
+	}
+	if !validLoginIdentifierModes[cfg.RestrictLoginIdentifier] {
+		return HardeningConfig{}, domain.Validation("invalid_restrict_login_identifier",
+			"restrict_login_identifier must be username|email|both")
+	}
+	cfg.TenantID = tenantID
+	cfg.SiteID = siteID
+	cfg.ActorType = actorType
+	cfg.ActorID = actorID
+	cfg.UpdatedAt = time.Now()
+	s.configs[siteID] = cfg
+	return cfg, nil
+}
+
+func (s *fakeHardeningService) listBans(_ context.Context, _, siteID uuid.UUID) ([]Ban, error) {
+	bans := s.bans[siteID]
+	if bans == nil {
+		return []Ban{}, nil
+	}
+	return bans, nil
+}
+
+func (s *fakeHardeningService) createBan(_ context.Context, tenantID, siteID uuid.UUID, ban Ban) (Ban, error) {
+	if !validBanTypes[ban.Type] {
+		return Ban{}, domain.Validation("invalid_ban_type",
+			"ban type must be ip|range|user_agent")
+	}
+	if strings.TrimSpace(ban.Value) == "" {
+		return Ban{}, domain.Validation("invalid_ban_value", "ban value is required")
+	}
+	switch ban.Type {
+	case BanTypeIP:
+		// simple inline check mirroring net.ParseIP validation
+		if !looksLikeIPAddr(ban.Value) {
+			return Ban{}, domain.Validation("invalid_ban_ip",
+				"not a valid IP address")
+		}
+	case BanTypeRange:
+		if !strings.Contains(ban.Value, "/") || !looksLikeIPAddr(strings.Split(ban.Value, "/")[0]) {
+			return Ban{}, domain.Validation("invalid_ban_cidr",
+				"not a valid CIDR block")
+		}
+	}
+	for _, existing := range s.bans[siteID] {
+		if existing.Type == ban.Type && existing.Value == ban.Value {
+			return Ban{}, domain.Conflict("ban_already_exists",
+				"a ban for this type/value already exists on this site")
+		}
+	}
+	ban.TenantID = tenantID
+	ban.SiteID = siteID
+	ban.ID = uuid.New()
+	ban.CreatedAt = time.Now()
+	s.bans[siteID] = append(s.bans[siteID], ban)
+	return ban, nil
+}
+
+func (s *fakeHardeningService) deleteBan(_ context.Context, _, siteID, banID uuid.UUID) error {
+	for i, b := range s.bans[siteID] {
+		if b.ID == banID {
+			s.bans[siteID] = append(s.bans[siteID][:i], s.bans[siteID][i+1:]...)
+			return nil
+		}
+	}
+	return domain.NotFound("ban_not_found", "security ban not found")
+}
+
+// looksLikeIPAddr is a minimal IP-plausibility check for the in-memory fake.
+// It does NOT replace the net.ParseIP validation in the real service; it just
+// avoids importing net in the test package while still catching obvious bad values.
+func looksLikeIPAddr(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) == 4 {
+		// IPv4 candidate: every octet must be digits 0-255.
+		for _, p := range parts {
+			if len(p) == 0 || len(p) > 3 {
+				return false
+			}
+			for _, c := range p {
+				if c < '0' || c > '9' {
+					return false
+				}
+			}
+		}
+		return true
+	}
+	// IPv6 candidate: must contain at least one colon and only hex digits/colons.
+	if strings.Contains(s, ":") {
+		for _, c := range s {
+			if !(c == ':' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// principalMiddleware returns a Gin middleware that injects a test principal.
+func principalMiddleware(tenantID uuid.UUID) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		p := domain.Principal{
+			Type:     domain.PrincipalUser,
+			UserID:   tenantID,
+			TenantID: tenantID,
+			Role:     "owner",
+		}
+		c.Request = c.Request.WithContext(domain.WithPrincipal(c.Request.Context(), p))
+		c.Next()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: defaults
+// ---------------------------------------------------------------------------
+
+// TestHardeningDefaultConfig verifies that a not-found site returns safe
+// defaults (all toggles off, permissive enum values).
+func TestHardeningDefaultConfig(t *testing.T) {
+	svc := newFakeHardeningService()
+	tenantID := uuid.New()
+	siteID := uuid.New()
+
+	cfg, err := svc.getHardeningConfig(context.Background(), tenantID, siteID)
+	if err != nil {
+		t.Fatalf("GetHardeningConfig: unexpected error: %v", err)
+	}
+	if cfg.DisableFileEditor {
+		t.Error("default: disable_file_editor should be false")
+	}
+	if cfg.XMLRPCMode != XMLRPCModeOn {
+		t.Errorf("default: xmlrpc_mode want 'on', got %q", cfg.XMLRPCMode)
+	}
+	if cfg.RestrictRESTAPI != RESTAPIModeDefault {
+		t.Errorf("default: restrict_rest_api want 'default', got %q", cfg.RestrictRESTAPI)
+	}
+	if cfg.RestrictLoginIdentifier != LoginIdentifierBoth {
+		t.Errorf("default: restrict_login_identifier want 'both', got %q", cfg.RestrictLoginIdentifier)
+	}
+	if cfg.ForceSSL {
+		t.Error("default: force_ssl should be false")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: save + get round-trip
+// ---------------------------------------------------------------------------
+
+func TestHardeningPutGetRoundTrip(t *testing.T) {
+	svc := newFakeHardeningService()
+	tenantID := uuid.New()
+	siteID := uuid.New()
+
+	input := HardeningConfig{
+		DisableFileEditor:        true,
+		XMLRPCMode:               XMLRPCModeOff,
+		RestrictRESTAPI:          RESTAPIModeRestricted,
+		RestrictLoginIdentifier:  LoginIdentifierEmail,
+		ForceUniqueNickname:      true,
+		DisableAuthorArchiveEnum: true,
+		ForceSSL:                 true,
+		DisableDirectoryBrowsing: true,
+		DisablePHPInUploads:      true,
+		ProtectSystemFiles:       true,
+	}
+	saved, err := svc.saveHardeningConfig(context.Background(), tenantID, siteID, input, "user", "u1")
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := svc.getHardeningConfig(context.Background(), tenantID, siteID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.XMLRPCMode != saved.XMLRPCMode {
+		t.Errorf("xmlrpc_mode round-trip: want %q got %q", saved.XMLRPCMode, got.XMLRPCMode)
+	}
+	if got.RestrictRESTAPI != RESTAPIModeRestricted {
+		t.Errorf("restrict_rest_api: want restricted, got %q", got.RestrictRESTAPI)
+	}
+	if !got.DisableFileEditor {
+		t.Error("disable_file_editor should be true after save")
+	}
+	if !got.ForceSSL {
+		t.Error("force_ssl should be true after save")
+	}
+	if got.TenantID != tenantID {
+		t.Errorf("tenant_id: want %s, got %s", tenantID, got.TenantID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: enum validation
+// ---------------------------------------------------------------------------
+
+func TestHardeningInvalidEnum(t *testing.T) {
+	svc := newFakeHardeningService()
+	tenantID := uuid.New()
+	siteID := uuid.New()
+
+	cases := []struct {
+		name string
+		cfg  HardeningConfig
+	}{
+		{
+			name: "invalid xmlrpc_mode",
+			cfg: HardeningConfig{
+				XMLRPCMode:              "bogus",
+				RestrictRESTAPI:         RESTAPIModeDefault,
+				RestrictLoginIdentifier: LoginIdentifierBoth,
+			},
+		},
+		{
+			name: "invalid restrict_rest_api",
+			cfg: HardeningConfig{
+				XMLRPCMode:              XMLRPCModeOn,
+				RestrictRESTAPI:         "open",
+				RestrictLoginIdentifier: LoginIdentifierBoth,
+			},
+		},
+		{
+			name: "invalid restrict_login_identifier",
+			cfg: HardeningConfig{
+				XMLRPCMode:              XMLRPCModeOn,
+				RestrictRESTAPI:         RESTAPIModeDefault,
+				RestrictLoginIdentifier: "phone",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.saveHardeningConfig(context.Background(), tenantID, siteID, tc.cfg, "user", "u1")
+			if err == nil {
+				t.Fatal("want validation error, got nil")
+			}
+			_, ok := domain.AsDomain(err)
+			if !ok {
+				t.Fatalf("want domain error, got %T: %v", err, err)
+			}
+			if domain.HTTPStatus(err) != http.StatusUnprocessableEntity {
+				t.Errorf("want 422, got %d", domain.HTTPStatus(err))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: tenant isolation at the service layer
+// ---------------------------------------------------------------------------
+
+// TestHardeningTenantIsolation verifies that the service stamps the correct
+// tenantID onto the saved row so the repo's tenant-scoped writes carry the
+// right tenant_id column value (and the RLS GUC then enforces isolation at the
+// DB layer in production).
+func TestHardeningTenantIsolation(t *testing.T) {
+	svc := newFakeHardeningService()
+	tenantA := uuid.New()
+	tenantB := uuid.New()
+	siteIDA := uuid.New()
+	siteIDB := uuid.New() // separate site IDs so in-memory map doesn't collide
+
+	cfgA := HardeningConfig{
+		XMLRPCMode:              XMLRPCModeOff,
+		RestrictRESTAPI:         RESTAPIModeDefault,
+		RestrictLoginIdentifier: LoginIdentifierBoth,
+		ForceSSL:                true,
+	}
+	savedA, err := svc.saveHardeningConfig(context.Background(), tenantA, siteIDA, cfgA, "user", "u-a")
+	if err != nil {
+		t.Fatalf("save A: %v", err)
+	}
+	if savedA.TenantID != tenantA {
+		t.Errorf("savedA.TenantID want %s got %s", tenantA, savedA.TenantID)
+	}
+
+	cfgB := HardeningConfig{
+		XMLRPCMode:              XMLRPCModeOn,
+		RestrictRESTAPI:         RESTAPIModeDefault,
+		RestrictLoginIdentifier: LoginIdentifierBoth,
+		ForceSSL:                false,
+	}
+	savedB, err := svc.saveHardeningConfig(context.Background(), tenantB, siteIDB, cfgB, "user", "u-b")
+	if err != nil {
+		t.Fatalf("save B: %v", err)
+	}
+	if savedB.TenantID != tenantB {
+		t.Errorf("savedB.TenantID want %s got %s", tenantB, savedB.TenantID)
+	}
+
+	// The row for site A must still carry tenant A's tenant_id.
+	gotA, _ := svc.getHardeningConfig(context.Background(), tenantA, siteIDA)
+	if gotA.TenantID != tenantA {
+		t.Errorf("got tenant_id for A: want %s, got %s", tenantA, gotA.TenantID)
+	}
+	if gotA.ForceSSL != true {
+		t.Error("tenant A force_ssl should still be true")
+	}
+	// The row for site B should be tenant B's config.
+	gotB, _ := svc.getHardeningConfig(context.Background(), tenantB, siteIDB)
+	if gotB.TenantID != tenantB {
+		t.Errorf("got tenant_id for B: want %s, got %s", tenantB, gotB.TenantID)
+	}
+	if gotB.ForceSSL {
+		t.Error("tenant B force_ssl should be false")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: ban create / list / delete
+// ---------------------------------------------------------------------------
+
+func TestBanCreateListDelete(t *testing.T) {
+	svc := newFakeHardeningService()
+	tenantID := uuid.New()
+	siteID := uuid.New()
+	ctx := context.Background()
+
+	// Empty list.
+	bans, err := svc.listBans(ctx, tenantID, siteID)
+	if err != nil {
+		t.Fatalf("list empty: %v", err)
+	}
+	if len(bans) != 0 {
+		t.Fatalf("expected empty list, got %d", len(bans))
+	}
+
+	// IP ban.
+	ipBan, err := svc.createBan(ctx, tenantID, siteID, Ban{
+		Type: BanTypeIP, Value: "1.2.3.4", Comment: "test",
+	})
+	if err != nil {
+		t.Fatalf("create ip ban: %v", err)
+	}
+	if ipBan.ID == uuid.Nil {
+		t.Error("created ban must have non-zero ID")
+	}
+
+	// CIDR ban.
+	_, err = svc.createBan(ctx, tenantID, siteID, Ban{
+		Type: BanTypeRange, Value: "192.168.1.0/24",
+	})
+	if err != nil {
+		t.Fatalf("create cidr ban: %v", err)
+	}
+
+	// UA ban.
+	_, err = svc.createBan(ctx, tenantID, siteID, Ban{
+		Type: BanTypeUserAgent, Value: "badbot/1.0",
+	})
+	if err != nil {
+		t.Fatalf("create ua ban: %v", err)
+	}
+
+	bans, _ = svc.listBans(ctx, tenantID, siteID)
+	if len(bans) != 3 {
+		t.Fatalf("want 3 bans, got %d", len(bans))
+	}
+
+	// Delete one.
+	if err := svc.deleteBan(ctx, tenantID, siteID, ipBan.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	bans, _ = svc.listBans(ctx, tenantID, siteID)
+	if len(bans) != 2 {
+		t.Fatalf("want 2 bans after delete, got %d", len(bans))
+	}
+}
+
+func TestBanDuplicateRejection(t *testing.T) {
+	svc := newFakeHardeningService()
+	tenantID := uuid.New()
+	siteID := uuid.New()
+	ctx := context.Background()
+
+	ban := Ban{Type: BanTypeIP, Value: "10.0.0.1"}
+	if _, err := svc.createBan(ctx, tenantID, siteID, ban); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	_, err := svc.createBan(ctx, tenantID, siteID, ban)
+	if err == nil {
+		t.Fatal("want Conflict error for duplicate, got nil")
+	}
+	_, ok := domain.AsDomain(err)
+	if !ok {
+		t.Fatalf("want domain error, got %T: %v", err, err)
+	}
+	if domain.HTTPStatus(err) != http.StatusConflict {
+		t.Errorf("want 409, got %d", domain.HTTPStatus(err))
+	}
+}
+
+func TestBanMalformedIPRejection(t *testing.T) {
+	svc := newFakeHardeningService()
+	tenantID := uuid.New()
+	siteID := uuid.New()
+	ctx := context.Background()
+
+	cases := []struct {
+		name  string
+		entry Ban
+	}{
+		{name: "bad IP", entry: Ban{Type: BanTypeIP, Value: "not-an-ip"}},
+		// "notacidr" has no slash, so looksLikeIPAddr on the host part fails and
+		// the slash-check catches it before even parsing the host.
+		{name: "bad CIDR no slash", entry: Ban{Type: BanTypeRange, Value: "notacidr"}},
+		{name: "bad type", entry: Ban{Type: "country", Value: "US"}},
+		{name: "empty value", entry: Ban{Type: BanTypeIP, Value: ""}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.createBan(ctx, tenantID, siteID, tc.entry)
+			if err == nil {
+				t.Fatalf("want validation error, got nil for %+v", tc.entry)
+			}
+			_, ok := domain.AsDomain(err)
+			if !ok {
+				t.Fatalf("want domain error, got %T: %v", err, err)
+			}
+			if domain.HTTPStatus(err) != http.StatusUnprocessableEntity && domain.HTTPStatus(err) != http.StatusConflict {
+				t.Errorf("want 422 or 409, got %d", domain.HTTPStatus(err))
+			}
+		})
+	}
+}
+
+func TestBanDeleteNotFound(t *testing.T) {
+	svc := newFakeHardeningService()
+	tenantID := uuid.New()
+	siteID := uuid.New()
+
+	err := svc.deleteBan(context.Background(), tenantID, siteID, uuid.New())
+	if err == nil {
+		t.Fatal("want NotFound error, got nil")
+	}
+	_, ok := domain.AsDomain(err)
+	if !ok {
+		t.Fatalf("want domain error, got %T: %v", err, err)
+	}
+	if domain.HTTPStatus(err) != http.StatusNotFound {
+		t.Errorf("want 404, got %d", domain.HTTPStatus(err))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: sync command wire contract
+// ---------------------------------------------------------------------------
+
+// TestHardeningSyncContractSerialization verifies that the wire contract types
+// round-trip through JSON with the exact field names documented in the ADR.
+func TestHardeningSyncContractSerialization(t *testing.T) {
+	req := agentcmd.HardeningRequest{
+		Config: agentcmd.HardeningConfig{
+			DisableFileEditor:        true,
+			XMLRPCMode:               "off",
+			RestrictRESTAPI:          "restricted",
+			RestrictLoginIdentifier:  "email",
+			ForceUniqueNickname:      true,
+			DisableAuthorArchiveEnum: true,
+			ForceSSL:                 true,
+			DisableDirectoryBrowsing: true,
+			DisablePHPInUploads:      true,
+			ProtectSystemFiles:       true,
+		},
+		Bans: []agentcmd.BanEntry{
+			{ID: "uuid-1", Type: "ip", Value: "1.2.3.4", Comment: "test"},
+			{ID: "uuid-2", Type: "range", Value: "10.0.0.0/8"},
+			{ID: "uuid-3", Type: "user_agent", Value: "badbot/1.0"},
+		},
+	}
+
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded agentcmd.HardeningRequest
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Top-level keys.
+	var m map[string]any
+	_ = json.Unmarshal(raw, &m)
+	if _, ok := m["config"]; !ok {
+		t.Error("wire JSON missing top-level 'config' key")
+	}
+	if _, ok := m["bans"]; !ok {
+		t.Error("wire JSON missing top-level 'bans' key")
+	}
+
+	// Config field names.
+	cfgMap, _ := m["config"].(map[string]any)
+	for _, key := range []string{
+		"disable_file_editor", "xmlrpc_mode", "restrict_rest_api",
+		"restrict_login_identifier", "force_unique_nickname",
+		"disable_author_archive_enum", "force_ssl",
+		"disable_directory_browsing", "disable_php_in_uploads",
+		"protect_system_files",
+	} {
+		if _, ok := cfgMap[key]; !ok {
+			t.Errorf("wire config JSON missing key %q", key)
+		}
+	}
+
+	// Ban entry field names.
+	bansRaw, _ := m["bans"].([]any)
+	if len(bansRaw) != 3 {
+		t.Fatalf("want 3 ban entries, got %d", len(bansRaw))
+	}
+	firstBan, _ := bansRaw[0].(map[string]any)
+	for _, key := range []string{"id", "type", "value", "comment"} {
+		if _, ok := firstBan[key]; !ok {
+			t.Errorf("ban entry missing key %q", key)
+		}
+	}
+
+	// Decoded value checks.
+	if !decoded.Config.DisableFileEditor {
+		t.Error("decoded disable_file_editor should be true")
+	}
+	if decoded.Config.XMLRPCMode != "off" {
+		t.Errorf("decoded xmlrpc_mode: want 'off', got %q", decoded.Config.XMLRPCMode)
+	}
+	if len(decoded.Bans) != 3 {
+		t.Fatalf("decoded: want 3 bans, got %d", len(decoded.Bans))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: DTO mapping
+// ---------------------------------------------------------------------------
+
+func TestHardeningDTOMapping(t *testing.T) {
+	tenantID := uuid.New()
+	siteID := uuid.New()
+
+	original := HardeningConfig{
+		TenantID:                tenantID,
+		SiteID:                  siteID,
+		DisableFileEditor:       true,
+		XMLRPCMode:              XMLRPCModeOff,
+		RestrictRESTAPI:         RESTAPIModeRestricted,
+		RestrictLoginIdentifier: LoginIdentifierEmail,
+		ForceUniqueNickname:     true,
+		DisableAuthorArchiveEnum: true,
+		ForceSSL:                true,
+		DisableDirectoryBrowsing: true,
+		DisablePHPInUploads:     true,
+		ProtectSystemFiles:      true,
+		UpdatedAt:               time.Now().UTC().Truncate(time.Second),
+	}
+	dto := toHardeningDTO(original)
+	roundTripped := fromHardeningDTO(dto, tenantID, siteID)
+
+	if roundTripped.XMLRPCMode != XMLRPCModeOff {
+		t.Errorf("xmlrpc_mode: want off, got %q", roundTripped.XMLRPCMode)
+	}
+	if roundTripped.RestrictRESTAPI != RESTAPIModeRestricted {
+		t.Errorf("restrict_rest_api: want restricted, got %q", roundTripped.RestrictRESTAPI)
+	}
+	if roundTripped.RestrictLoginIdentifier != LoginIdentifierEmail {
+		t.Errorf("restrict_login_identifier: want email, got %q", roundTripped.RestrictLoginIdentifier)
+	}
+	if !roundTripped.DisableFileEditor {
+		t.Error("disable_file_editor mismatch after round-trip")
+	}
+	if !roundTripped.ForceSSL {
+		t.Error("force_ssl mismatch after round-trip")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HTTP handler tests
+// ---------------------------------------------------------------------------
+
+// TestHandlerGetHardeningConfigReturnsDefault verifies the GET route returns
+// HTTP 200 with safe defaults for a site with no stored config.
+func TestHandlerGetHardeningConfigReturnsDefault(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tenantID := uuid.New()
+	siteID := uuid.New()
+	fSvc := newFakeHardeningService()
+
+	engine := gin.New()
+	engine.Use(principalMiddleware(tenantID))
+	engine.GET("/sites/:siteId/security/hardening", func(c *gin.Context) {
+		p, _ := domain.PrincipalFromContext(c.Request.Context())
+		sid, _ := uuid.Parse(c.Param("siteId"))
+		cfg, err := fSvc.getHardeningConfig(c.Request.Context(), p.TenantID, sid)
+		if err != nil {
+			httpx.Error(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, toHardeningDTO(cfg))
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet,
+		"/sites/"+siteID.String()+"/security/hardening", nil)
+	engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp hardeningConfigDTO
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.XMLRPCMode != "on" {
+		t.Errorf("default xmlrpc_mode: want 'on', got %q", resp.XMLRPCMode)
+	}
+	if resp.DisableFileEditor {
+		t.Error("default disable_file_editor should be false")
+	}
+}
+
+// TestHandlerCreateBanValidatesIP verifies that POST /security/bans with an
+// invalid IP returns 422.
+func TestHandlerCreateBanValidatesIP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tenantID := uuid.New()
+	siteID := uuid.New()
+	fSvc := newFakeHardeningService()
+
+	engine := gin.New()
+	engine.Use(principalMiddleware(tenantID))
+	engine.POST("/sites/:siteId/security/bans", func(c *gin.Context) {
+		p, _ := domain.PrincipalFromContext(c.Request.Context())
+		sid, _ := uuid.Parse(c.Param("siteId"))
+		var body createBanBody
+		if err := bindJSON(c, &body); err != nil {
+			httpx.Error(c, err)
+			return
+		}
+		ban := Ban{
+			TenantID: p.TenantID, SiteID: sid,
+			Type: BanType(strings.TrimSpace(body.Type)),
+			Value: strings.TrimSpace(body.Value),
+		}
+		saved, err := fSvc.createBan(c.Request.Context(), p.TenantID, sid, ban)
+		if err != nil {
+			httpx.Error(c, err)
+			return
+		}
+		c.JSON(http.StatusCreated, toBanDTO(saved))
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost,
+		"/sites/"+siteID.String()+"/security/bans",
+		strings.NewReader(`{"type":"ip","value":"not-an-ip"}`))
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("want 422 for bad IP, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandlerDeleteBanNotFound verifies that DELETE /security/bans/:banId for a
+// non-existent ID returns 404.
+func TestHandlerDeleteBanNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tenantID := uuid.New()
+	siteID := uuid.New()
+	fSvc := newFakeHardeningService()
+
+	engine := gin.New()
+	engine.Use(principalMiddleware(tenantID))
+	engine.DELETE("/sites/:siteId/security/bans/:banId", func(c *gin.Context) {
+		p, _ := domain.PrincipalFromContext(c.Request.Context())
+		sid, _ := uuid.Parse(c.Param("siteId"))
+		bid, _ := uuid.Parse(c.Param("banId"))
+		if err := fSvc.deleteBan(c.Request.Context(), p.TenantID, sid, bid); err != nil {
+			httpx.Error(c, err)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete,
+		"/sites/"+siteID.String()+"/security/bans/"+uuid.New().String(), nil)
+	engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404 for missing ban, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/apps/api/internal/security/hardening_test.go
+++ b/apps/api/internal/security/hardening_test.go
@@ -3,6 +3,7 @@ package security
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/ipprovider"
 	"github.com/mosamlife/wpmgr/apps/api/internal/server/httpx"
 )
 
@@ -78,7 +80,8 @@ func (s *fakeHardeningService) createBan(_ context.Context, tenantID, siteID uui
 		return Ban{}, domain.Validation("invalid_ban_type",
 			"ban type must be ip|range|user_agent")
 	}
-	if strings.TrimSpace(ban.Value) == "" {
+	ban.Value = strings.TrimSpace(ban.Value)
+	if ban.Value == "" {
 		return Ban{}, domain.Validation("invalid_ban_value", "ban value is required")
 	}
 	switch ban.Type {
@@ -93,6 +96,11 @@ func (s *fakeHardeningService) createBan(_ context.Context, tenantID, siteID uui
 			return Ban{}, domain.Validation("invalid_ban_cidr",
 				"not a valid CIDR block")
 		}
+	}
+	// Mirror the semantic safety rules from validateBan so the fake and real
+	// service behave consistently.
+	if err := validateBan(ban); err != nil {
+		return Ban{}, err
 	}
 	for _, existing := range s.bans[siteID] {
 		if existing.Type == ban.Type && existing.Value == ban.Value {
@@ -391,9 +399,9 @@ func TestBanCreateListDelete(t *testing.T) {
 		t.Error("created ban must have non-zero ID")
 	}
 
-	// CIDR ban.
+	// CIDR ban — use a public documentation range (RFC 5737 TEST-NET-3).
 	_, err = svc.createBan(ctx, tenantID, siteID, Ban{
-		Type: BanTypeRange, Value: "192.168.1.0/24",
+		Type: BanTypeRange, Value: "203.0.113.0/24",
 	})
 	if err != nil {
 		t.Fatalf("create cidr ban: %v", err)
@@ -428,7 +436,7 @@ func TestBanDuplicateRejection(t *testing.T) {
 	siteID := uuid.New()
 	ctx := context.Background()
 
-	ban := Ban{Type: BanTypeIP, Value: "10.0.0.1"}
+	ban := Ban{Type: BanTypeIP, Value: "203.0.113.42"}
 	if _, err := svc.createBan(ctx, tenantID, siteID, ban); err != nil {
 		t.Fatalf("first create: %v", err)
 	}
@@ -476,6 +484,228 @@ func TestBanMalformedIPRejection(t *testing.T) {
 				t.Errorf("want 422 or 409, got %d", domain.HTTPStatus(err))
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: ban safety validation (defense-in-depth rejections)
+// ---------------------------------------------------------------------------
+
+// TestBanSafetyRejections calls validateBan directly to assert that lock-out-
+// class and private-range bans are rejected at the service layer, independent of
+// any DB or agent interaction.
+func TestBanSafetyRejections(t *testing.T) {
+	cases := []struct {
+		name    string
+		ban     Ban
+		wantCode string // expected domain error code substring
+	}{
+		// --- range: all-addresses ---
+		{
+			name:     "all-addresses IPv4 (0.0.0.0/0)",
+			ban:      Ban{Type: BanTypeRange, Value: "0.0.0.0/0"},
+			wantCode: "ban_range_too_broad",
+		},
+		{
+			name:     "all-addresses IPv6 (::/0)",
+			ban:      Ban{Type: BanTypeRange, Value: "::/0"},
+			wantCode: "ban_range_too_broad",
+		},
+		// --- range: over-broad prefix ---
+		{
+			name:     "IPv4 over-broad /7 (straddles two /8 blocks)",
+			ban:      Ban{Type: BanTypeRange, Value: "10.0.0.0/7"},
+			wantCode: "ban_range_too_broad",
+		},
+		{
+			name:     "IPv6 over-broad /16",
+			ban:      Ban{Type: BanTypeRange, Value: "2001:db8::/16"},
+			wantCode: "ban_range_too_broad",
+		},
+		// --- range: private space ---
+		{
+			name:     "RFC-1918 10/8 private range",
+			ban:      Ban{Type: BanTypeRange, Value: "10.0.0.0/8"},
+			wantCode: "ban_range_private",
+		},
+		{
+			name:     "RFC-1918 172.16/12 private range",
+			ban:      Ban{Type: BanTypeRange, Value: "172.16.0.0/12"},
+			wantCode: "ban_range_private",
+		},
+		{
+			name:     "RFC-1918 192.168/16 private range",
+			ban:      Ban{Type: BanTypeRange, Value: "192.168.0.0/16"},
+			wantCode: "ban_range_private",
+		},
+		{
+			name:     "loopback range 127.0.0.0/8",
+			ban:      Ban{Type: BanTypeRange, Value: "127.0.0.0/8"},
+			wantCode: "ban_range_private",
+		},
+		{
+			// fc00::/7 would first be caught by the over-broad (/7 < /32) check;
+			// use fc00::/32 to isolate the private-range check specifically.
+			name:     "ULA IPv6 range fc00::/32 (not over-broad, but private)",
+			ban:      Ban{Type: BanTypeRange, Value: "fc00::/32"},
+			wantCode: "ban_range_private",
+		},
+		// --- ip: loopback ---
+		{
+			name:     "IPv4 loopback 127.0.0.1",
+			ban:      Ban{Type: BanTypeIP, Value: "127.0.0.1"},
+			wantCode: "ban_ip_private",
+		},
+		{
+			name:     "IPv6 loopback ::1",
+			ban:      Ban{Type: BanTypeIP, Value: "::1"},
+			wantCode: "ban_ip_private",
+		},
+		// --- ip: RFC-1918 private ---
+		{
+			name:     "private IPv4 10.x.x.x",
+			ban:      Ban{Type: BanTypeIP, Value: "10.0.0.1"},
+			wantCode: "ban_ip_private",
+		},
+		{
+			name:     "private IPv4 192.168.x.x",
+			ban:      Ban{Type: BanTypeIP, Value: "192.168.1.1"},
+			wantCode: "ban_ip_private",
+		},
+		{
+			name:     "private IPv4 172.16.x.x",
+			ban:      Ban{Type: BanTypeIP, Value: "172.16.5.5"},
+			wantCode: "ban_ip_private",
+		},
+		// --- ip: link-local and ULA ---
+		{
+			name:     "IPv4 link-local 169.254.1.1",
+			ban:      Ban{Type: BanTypeIP, Value: "169.254.1.1"},
+			wantCode: "ban_ip_private",
+		},
+		{
+			name:     "IPv6 ULA fc00::1",
+			ban:      Ban{Type: BanTypeIP, Value: "fc00::1"},
+			wantCode: "ban_ip_private",
+		},
+		{
+			name:     "IPv6 link-local fe80::1",
+			ban:      Ban{Type: BanTypeIP, Value: "fe80::1"},
+			wantCode: "ban_ip_private",
+		},
+		// --- user_agent: control characters ---
+		{
+			name:     "user_agent with newline",
+			ban:      Ban{Type: BanTypeUserAgent, Value: "badbot\nAnother-Header: injected"},
+			wantCode: "ban_ua_control_char",
+		},
+		{
+			// Trailing \r\n is stripped by TrimSpace before validateBan sees it;
+			// use CR/LF embedded in the middle to test mid-string injection.
+			name:     "user_agent with embedded CR+LF (mid-string injection)",
+			ban:      Ban{Type: BanTypeUserAgent, Value: "bad\r\nbot"},
+			wantCode: "ban_ua_control_char",
+		},
+		{
+			name:     "user_agent with null byte",
+			ban:      Ban{Type: BanTypeUserAgent, Value: "badbot\x00"},
+			wantCode: "ban_ua_control_char",
+		},
+		{
+			name:     "user_agent with tab (control char)",
+			ban:      Ban{Type: BanTypeUserAgent, Value: "bad\tbot"},
+			wantCode: "ban_ua_control_char",
+		},
+		// --- user_agent: over-length ---
+		{
+			name:     "user_agent over 512 bytes",
+			ban:      Ban{Type: BanTypeUserAgent, Value: strings.Repeat("A", banMaxUserAgentLen+1)},
+			wantCode: "ban_ua_too_long",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateBan(tc.ban)
+			if err == nil {
+				t.Fatalf("validateBan: want error for %+v, got nil", tc.ban)
+			}
+			de, ok := domain.AsDomain(err)
+			if !ok {
+				t.Fatalf("want domain error, got %T: %v", err, err)
+			}
+			if domain.HTTPStatus(err) != http.StatusUnprocessableEntity {
+				t.Errorf("want 422, got %d; err=%v", domain.HTTPStatus(err), err)
+			}
+			if de.Code != tc.wantCode {
+				t.Errorf("want domain code %q, got %q (msg: %s)", tc.wantCode, de.Code, err)
+			}
+		})
+	}
+}
+
+// TestBanSafetyAccepts verifies that normal public-facing values pass validateBan
+// so valid legitimate bans are not accidentally rejected.
+func TestBanSafetyAccepts(t *testing.T) {
+	cases := []struct {
+		name string
+		ban  Ban
+	}{
+		{name: "public IPv4", ban: Ban{Type: BanTypeIP, Value: "1.2.3.4"}},
+		{name: "public IPv4 (doc range)", ban: Ban{Type: BanTypeIP, Value: "203.0.113.42"}},
+		{name: "public IPv4 range /24", ban: Ban{Type: BanTypeRange, Value: "203.0.113.0/24"}},
+		{name: "public IPv4 range /16", ban: Ban{Type: BanTypeRange, Value: "203.0.0.0/16"}},
+		{name: "public IPv4 range at /8 boundary", ban: Ban{Type: BanTypeRange, Value: "203.0.0.0/8"}},
+		{name: "public IPv6 /48", ban: Ban{Type: BanTypeRange, Value: "2001:db8::/48"}},
+		{name: "public IPv6 /32 (minimum)", ban: Ban{Type: BanTypeRange, Value: "2001:db8::/32"}},
+		{name: "normal user agent", ban: Ban{Type: BanTypeUserAgent, Value: "BadBot/2.0"}},
+		{name: "user agent exactly at max len", ban: Ban{Type: BanTypeUserAgent, Value: strings.Repeat("A", banMaxUserAgentLen)}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateBan(tc.ban); err != nil {
+				t.Errorf("validateBan: unexpected rejection for %+v: %v", tc.ban, err)
+			}
+		})
+	}
+}
+
+// TestBanSafetyViaIPProviderConsistency cross-checks that every IP we claim is
+// "private/loopback/link-local" here is also considered non-global by
+// ipprovider.IsGlobalUnicast — the function we delegate to in validateBan.
+func TestBanSafetyViaIPProviderConsistency(t *testing.T) {
+	privateIPs := []string{
+		"127.0.0.1", "::1",
+		"10.0.0.1", "172.16.5.5", "192.168.1.1",
+		"169.254.1.1", "fc00::1", "fe80::1",
+	}
+	for _, ip := range privateIPs {
+		if ipprovider.IsGlobalUnicast(ip) {
+			t.Errorf("expected %q to be non-global-unicast, but IsGlobalUnicast returned true", ip)
+		}
+	}
+
+	publicIPs := []string{"1.2.3.4", "203.0.113.42", "8.8.8.8"}
+	for _, ip := range publicIPs {
+		if !ipprovider.IsGlobalUnicast(ip) {
+			t.Errorf("expected %q to be global-unicast, but IsGlobalUnicast returned false", ip)
+		}
+	}
+
+	// Also confirm the range base-address check works for private CIDRs.
+	privateCIDRs := []string{
+		"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16",
+		"127.0.0.0/8", "fc00::/7",
+	}
+	for _, cidr := range privateCIDRs {
+		_, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			t.Fatalf("ParseCIDR(%q): %v", cidr, err)
+		}
+		if ipprovider.IsGlobalUnicast(ipNet.IP.String()) {
+			t.Errorf("base of %q (%s) should not be global-unicast", cidr, ipNet.IP)
+		}
 	}
 }
 

--- a/apps/api/internal/security/model.go
+++ b/apps/api/internal/security/model.go
@@ -1,9 +1,9 @@
-// Package security implements the S2 Login Protection + IP store domain on the
-// control-plane side.
+// Package security implements the S2 Login Protection + IP store domain and the
+// Phase 1 hardening config + ban list (ADR-057) on the control-plane side.
 //
-// It stores per-site login-protection config, pushes it to the agent via the
-// signed `sync_security_config` command, ingests the agent's login-event batch
-// (POST /agent/v1/security/login-events), and exposes an unblock-IP action.
+// It stores per-site login-protection config and hardening config, pushes them
+// to the agent via signed commands, ingests the agent's login-event batch
+// (POST /agent/v1/security/login-events), and exposes unblock-IP and ban CRUD.
 package security
 
 import (
@@ -13,6 +13,102 @@ import (
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
 )
+
+// ---------------------------------------------------------------------------
+// Phase 1 — hardening config
+// ---------------------------------------------------------------------------
+
+// XMLRPCMode is the three-state XML-RPC control value.
+type XMLRPCMode string
+
+const (
+	XMLRPCModeOn      XMLRPCMode = "on"
+	XMLRPCModeOff     XMLRPCMode = "off"
+	XMLRPCModeLimited XMLRPCMode = "limited"
+)
+
+// RESTAPIMode is the two-state REST API restriction value.
+type RESTAPIMode string
+
+const (
+	RESTAPIModeDefault    RESTAPIMode = "default"
+	RESTAPIModeRestricted RESTAPIMode = "restricted"
+)
+
+// LoginIdentifierMode controls which credential forms the WP login accepts.
+type LoginIdentifierMode string
+
+const (
+	LoginIdentifierUsername LoginIdentifierMode = "username"
+	LoginIdentifierEmail    LoginIdentifierMode = "email"
+	LoginIdentifierBoth     LoginIdentifierMode = "both"
+)
+
+// HardeningConfig is the per-site hardening configuration stored in
+// site_security_hardening_config and pushed to the agent via
+// sync_security_hardening (ADR-057).
+type HardeningConfig struct {
+	TenantID                 uuid.UUID
+	SiteID                   uuid.UUID
+	DisableFileEditor        bool
+	XMLRPCMode               XMLRPCMode
+	RestrictRESTAPI          RESTAPIMode
+	RestrictLoginIdentifier  LoginIdentifierMode
+	ForceUniqueNickname      bool
+	DisableAuthorArchiveEnum bool
+	ForceSSL                 bool
+	DisableDirectoryBrowsing bool
+	DisablePHPInUploads      bool
+	ProtectSystemFiles       bool
+	UpdatedAt                time.Time
+	ActorType                string
+	ActorID                  string
+}
+
+// DefaultHardeningConfig returns the safe-default config (everything OFF,
+// permissive enum values) for a site that has no stored row yet.
+func DefaultHardeningConfig(tenantID, siteID uuid.UUID) HardeningConfig {
+	return HardeningConfig{
+		TenantID:                tenantID,
+		SiteID:                  siteID,
+		DisableFileEditor:       false,
+		XMLRPCMode:              XMLRPCModeOn,
+		RestrictRESTAPI:         RESTAPIModeDefault,
+		RestrictLoginIdentifier: LoginIdentifierBoth,
+		ForceUniqueNickname:     false,
+		DisableAuthorArchiveEnum: false,
+		ForceSSL:                false,
+		DisableDirectoryBrowsing: false,
+		DisablePHPInUploads:     false,
+		ProtectSystemFiles:      false,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 — ban list
+// ---------------------------------------------------------------------------
+
+// BanType is the kind of a ban entry.
+type BanType string
+
+const (
+	BanTypeIP        BanType = "ip"
+	BanTypeRange     BanType = "range"
+	BanTypeUserAgent BanType = "user_agent"
+)
+
+// Ban is one durable ban entry stored in site_security_bans.
+type Ban struct {
+	ID        uuid.UUID
+	TenantID  uuid.UUID
+	SiteID    uuid.UUID
+	Type      BanType
+	Value     string
+	Comment   string
+	ActorType string
+	ActorID   string
+	CreatedAt time.Time
+}
 
 // SecurityConfig is the per-site login-protection configuration stored in
 // site_security_config and pushed to the agent via the sync_security_config

--- a/apps/api/internal/security/repo.go
+++ b/apps/api/internal/security/repo.go
@@ -213,3 +213,227 @@ func itoa(n int) string {
 
 // keep errors import honest.
 var _ = errors.Is
+
+// ---------------------------------------------------------------------------
+// Hardening config (m76 — site_security_hardening_config)
+// ---------------------------------------------------------------------------
+
+// GetHardeningConfig returns the stored hardening config for (tenantID, siteID).
+// found=false (and no error) when no row exists yet; callers return the default.
+func (r *Repo) GetHardeningConfig(ctx context.Context, tenantID, siteID uuid.UUID) (HardeningConfig, bool, error) {
+	var out HardeningConfig
+	var found bool
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx,
+			`SELECT tenant_id, site_id,
+			        disable_file_editor, xmlrpc_mode, restrict_rest_api,
+			        restrict_login_identifier, force_unique_nickname,
+			        disable_author_archive_enum, force_ssl,
+			        disable_directory_browsing, disable_php_in_uploads,
+			        protect_system_files, updated_at, actor_type, actor_id
+			   FROM site_security_hardening_config
+			  WHERE tenant_id = $1 AND site_id = $2`,
+			tenantID, siteID,
+		)
+		var actorType, actorID *string
+		var xmlrpcMode, restrictREST, loginID string
+		if err := row.Scan(
+			&out.TenantID, &out.SiteID,
+			&out.DisableFileEditor, &xmlrpcMode, &restrictREST,
+			&loginID, &out.ForceUniqueNickname,
+			&out.DisableAuthorArchiveEnum, &out.ForceSSL,
+			&out.DisableDirectoryBrowsing, &out.DisablePHPInUploads,
+			&out.ProtectSystemFiles, &out.UpdatedAt, &actorType, &actorID,
+		); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil
+			}
+			return domain.Internal("security_hardening_get_failed",
+				"failed to get hardening config").WithCause(err)
+		}
+		out.XMLRPCMode = XMLRPCMode(xmlrpcMode)
+		out.RestrictRESTAPI = RESTAPIMode(restrictREST)
+		out.RestrictLoginIdentifier = LoginIdentifierMode(loginID)
+		if actorType != nil {
+			out.ActorType = *actorType
+		}
+		if actorID != nil {
+			out.ActorID = *actorID
+		}
+		found = true
+		return nil
+	})
+	return out, found, err
+}
+
+// UpsertHardeningConfig inserts or replaces the hardening config for
+// (tenantID, siteID). updated_at is refreshed on every upsert. Returns the
+// stored config.
+func (r *Repo) UpsertHardeningConfig(ctx context.Context, cfg HardeningConfig) (HardeningConfig, error) {
+	var out HardeningConfig
+	err := r.pool.InTenantTx(ctx, cfg.TenantID, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx,
+			`INSERT INTO site_security_hardening_config
+				(site_id, tenant_id, disable_file_editor, xmlrpc_mode,
+				 restrict_rest_api, restrict_login_identifier, force_unique_nickname,
+				 disable_author_archive_enum, force_ssl, disable_directory_browsing,
+				 disable_php_in_uploads, protect_system_files, updated_at,
+				 actor_type, actor_id)
+			 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,now(),$13,$14)
+			 ON CONFLICT (site_id) DO UPDATE
+			   SET disable_file_editor        = EXCLUDED.disable_file_editor,
+			       xmlrpc_mode                = EXCLUDED.xmlrpc_mode,
+			       restrict_rest_api          = EXCLUDED.restrict_rest_api,
+			       restrict_login_identifier  = EXCLUDED.restrict_login_identifier,
+			       force_unique_nickname       = EXCLUDED.force_unique_nickname,
+			       disable_author_archive_enum = EXCLUDED.disable_author_archive_enum,
+			       force_ssl                  = EXCLUDED.force_ssl,
+			       disable_directory_browsing = EXCLUDED.disable_directory_browsing,
+			       disable_php_in_uploads     = EXCLUDED.disable_php_in_uploads,
+			       protect_system_files       = EXCLUDED.protect_system_files,
+			       updated_at                 = now(),
+			       actor_type                 = EXCLUDED.actor_type,
+			       actor_id                   = EXCLUDED.actor_id
+			 RETURNING tenant_id, site_id,
+			           disable_file_editor, xmlrpc_mode, restrict_rest_api,
+			           restrict_login_identifier, force_unique_nickname,
+			           disable_author_archive_enum, force_ssl,
+			           disable_directory_browsing, disable_php_in_uploads,
+			           protect_system_files, updated_at, actor_type, actor_id`,
+			cfg.SiteID, cfg.TenantID,
+			cfg.DisableFileEditor, string(cfg.XMLRPCMode),
+			string(cfg.RestrictRESTAPI), string(cfg.RestrictLoginIdentifier),
+			cfg.ForceUniqueNickname, cfg.DisableAuthorArchiveEnum,
+			cfg.ForceSSL, cfg.DisableDirectoryBrowsing,
+			cfg.DisablePHPInUploads, cfg.ProtectSystemFiles,
+			cfg.ActorType, cfg.ActorID,
+		)
+		var actorType, actorID *string
+		var xmlrpcMode, restrictREST, loginID string
+		if err := row.Scan(
+			&out.TenantID, &out.SiteID,
+			&out.DisableFileEditor, &xmlrpcMode, &restrictREST,
+			&loginID, &out.ForceUniqueNickname,
+			&out.DisableAuthorArchiveEnum, &out.ForceSSL,
+			&out.DisableDirectoryBrowsing, &out.DisablePHPInUploads,
+			&out.ProtectSystemFiles, &out.UpdatedAt, &actorType, &actorID,
+		); err != nil {
+			return domain.Internal("security_hardening_upsert_failed",
+				"failed to upsert hardening config").WithCause(err)
+		}
+		out.XMLRPCMode = XMLRPCMode(xmlrpcMode)
+		out.RestrictRESTAPI = RESTAPIMode(restrictREST)
+		out.RestrictLoginIdentifier = LoginIdentifierMode(loginID)
+		if actorType != nil {
+			out.ActorType = *actorType
+		}
+		if actorID != nil {
+			out.ActorID = *actorID
+		}
+		return nil
+	})
+	return out, err
+}
+
+// ---------------------------------------------------------------------------
+// Ban list (m76 — site_security_bans)
+// ---------------------------------------------------------------------------
+
+// ListBans returns all bans for a site, ordered by created_at DESC, id DESC.
+func (r *Repo) ListBans(ctx context.Context, tenantID, siteID uuid.UUID) ([]Ban, error) {
+	var out []Ban
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx,
+			`SELECT id, tenant_id, site_id, type, value, comment,
+			        actor_type, actor_id, created_at
+			   FROM site_security_bans
+			  WHERE tenant_id = $1 AND site_id = $2
+			  ORDER BY created_at DESC, id DESC`,
+			tenantID, siteID,
+		)
+		if err != nil {
+			return domain.Internal("security_bans_list_failed",
+				"failed to list security bans").WithCause(err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var b Ban
+			var banType string
+			if err := rows.Scan(
+				&b.ID, &b.TenantID, &b.SiteID, &banType, &b.Value,
+				&b.Comment, &b.ActorType, &b.ActorID, &b.CreatedAt,
+			); err != nil {
+				return domain.Internal("security_bans_list_failed",
+					"failed to read security ban").WithCause(err)
+			}
+			b.Type = BanType(banType)
+			out = append(out, b)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+// InsertBan inserts a new ban entry. Returns domain.Conflict when the
+// (site_id, type, value) tuple already exists.
+func (r *Repo) InsertBan(ctx context.Context, ban Ban) (Ban, error) {
+	var out Ban
+	err := r.pool.InTenantTx(ctx, ban.TenantID, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx,
+			`INSERT INTO site_security_bans
+				(tenant_id, site_id, type, value, comment, actor_type, actor_id)
+			 VALUES ($1,$2,$3,$4,$5,$6,$7)
+			 RETURNING id, tenant_id, site_id, type, value, comment,
+			           actor_type, actor_id, created_at`,
+			ban.TenantID, ban.SiteID, string(ban.Type), ban.Value,
+			ban.Comment, ban.ActorType, ban.ActorID,
+		)
+		var banType string
+		if err := row.Scan(
+			&out.ID, &out.TenantID, &out.SiteID, &banType, &out.Value,
+			&out.Comment, &out.ActorType, &out.ActorID, &out.CreatedAt,
+		); err != nil {
+			// Postgres unique-violation code 23505.
+			if isUniqueViolation(err) {
+				return domain.Conflict("ban_already_exists",
+					"a ban for this type/value already exists on this site")
+			}
+			return domain.Internal("security_ban_insert_failed",
+				"failed to insert security ban").WithCause(err)
+		}
+		out.Type = BanType(banType)
+		return nil
+	})
+	return out, err
+}
+
+// DeleteBan removes the ban with the given id, scoped to (tenantID, siteID).
+// Returns domain.NotFound when no such row exists.
+func (r *Repo) DeleteBan(ctx context.Context, tenantID, siteID, banID uuid.UUID) error {
+	return r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx,
+			`DELETE FROM site_security_bans
+			  WHERE tenant_id = $1 AND site_id = $2 AND id = $3`,
+			tenantID, siteID, banID,
+		)
+		if err != nil {
+			return domain.Internal("security_ban_delete_failed",
+				"failed to delete security ban").WithCause(err)
+		}
+		if tag.RowsAffected() == 0 {
+			return domain.NotFound("ban_not_found", "security ban not found")
+		}
+		return nil
+	})
+}
+
+// isUniqueViolation reports whether the error is a Postgres unique-constraint
+// violation (SQLSTATE 23505). Avoids importing pgconn directly in service code.
+func isUniqueViolation(err error) bool {
+	type pgErr interface{ SQLState() string }
+	var pe pgErr
+	if errors.As(err, &pe) {
+		return pe.SQLState() == "23505"
+	}
+	return false
+}

--- a/apps/api/internal/security/service.go
+++ b/apps/api/internal/security/service.go
@@ -8,11 +8,13 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/google/uuid"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/ipprovider"
 )
 
 // AgentHardeningClient is the subset of agentcmd.Client the hardening service
@@ -341,6 +343,105 @@ var validBanTypes = map[BanType]bool{
 	BanTypeUserAgent: true,
 }
 
+// banMaxUserAgentLen is the maximum permitted length for a user_agent ban value.
+// Matches the web client's own input cap (512 bytes) and prevents oversized WAF
+// rules from being injected downstream.
+const banMaxUserAgentLen = 512
+
+// banMinIPv4Prefix is the minimum acceptable IPv4 prefix length for a range ban.
+// A prefix shorter than /8 (e.g. /7, /6, …, /0) covers more than a full /8
+// block — effectively a continent-scale or all-addresses block, which is either
+// a misconfig or an attempt to lock out virtually all traffic. The /8 boundary
+// is a widely accepted "broadest useful" single-ISP/network block.
+const banMinIPv4Prefix = 8
+
+// banMinIPv6Prefix is the minimum acceptable IPv6 prefix length for a range ban.
+// Prefixes shorter than /32 span entire regional internet registries (e.g. a /19
+// covers millions of hosts). /32 is the smallest allocation an ISP typically
+// receives and is a reasonable "broadest useful block" boundary for ban purposes.
+const banMinIPv6Prefix = 32
+
+// validateBan performs semantic safety checks on a ban entry AFTER the basic
+// type/syntax validation in CreateBan. It is a pure function with no DB access,
+// making it straightforward to unit-test in isolation.
+//
+// Rejected cases (all return domain.Validation errors):
+//
+//   - BanTypeRange: all-addresses ranges (0.0.0.0/0, ::/0), over-broad prefixes
+//     (IPv4 < /8, IPv6 < /32), and ranges that wholly contain loopback or
+//     RFC-1918/link-local/ULA private space (banning a private range is a no-op
+//     on public sites and risks self-lockout for shared-hosting operators).
+//
+//   - BanTypeIP: loopback, RFC-1918 private, link-local, and ULA addresses.
+//     Banning a private IP has no effect on inbound public traffic and is almost
+//     certainly a misconfig.
+//
+//   - BanTypeUserAgent: values containing ASCII control characters (including
+//     CR/LF), which could enable rule-injection in downstream WAF/agent
+//     configuration files. Also rejects values that are empty after trimming, or
+//     exceed banMaxUserAgentLen bytes.
+func validateBan(ban Ban) error {
+	switch ban.Type {
+	case BanTypeRange:
+		cidr := strings.TrimSpace(ban.Value)
+		// net.ParseCIDR already ran before validateBan; the parse here always succeeds.
+		_, ipNet, _ := net.ParseCIDR(cidr)
+		ones, bits := ipNet.Mask.Size()
+
+		// Reject all-addresses ranges explicitly for a clear error message.
+		if ones == 0 {
+			return domain.Validation("ban_range_too_broad",
+				"cannot ban an all-addresses range (0.0.0.0/0 or ::/0); use the security-config deny list for global blocks")
+		}
+
+		// Reject over-broad prefixes.
+		if bits == 32 && ones < banMinIPv4Prefix {
+			return domain.Validation("ban_range_too_broad",
+				fmt.Sprintf("IPv4 range ban prefix must be /%d or longer; /%d covers too large an address space", banMinIPv4Prefix, ones))
+		}
+		if bits == 128 && ones < banMinIPv6Prefix {
+			return domain.Validation("ban_range_too_broad",
+				fmt.Sprintf("IPv6 range ban prefix must be /%d or longer; /%d covers too large an address space", banMinIPv6Prefix, ones))
+		}
+
+		// Reject ranges that fully contain private/loopback/link-local/ULA space.
+		// We test by checking whether the network's base address itself is
+		// non-public; for a prefix that wholly covers private space (e.g. 10/8,
+		// 192.168/16, fc00::/7), the base address is not a global unicast address.
+		if !ipprovider.IsGlobalUnicast(ipNet.IP.String()) {
+			return domain.Validation("ban_range_private",
+				"cannot ban a private, loopback, or link-local address range; this has no effect on public traffic and may cause self-lockout")
+		}
+
+	case BanTypeIP:
+		ip := strings.TrimSpace(ban.Value)
+		// net.ParseIP already validated syntax; this check is semantic.
+		if !ipprovider.IsGlobalUnicast(ip) {
+			return domain.Validation("ban_ip_private",
+				"cannot ban a private, loopback, or link-local address; this has no effect on public traffic")
+		}
+
+	case BanTypeUserAgent:
+		ua := strings.TrimSpace(ban.Value)
+		if ua == "" {
+			return domain.Validation("invalid_ban_value", "ban value is required")
+		}
+		if len(ua) > banMaxUserAgentLen {
+			return domain.Validation("ban_ua_too_long",
+				fmt.Sprintf("user agent ban value must be %d characters or fewer", banMaxUserAgentLen))
+		}
+		// Reject any ASCII control character including CR (\r) and LF (\n).
+		// These can break downstream WAF/nginx configuration files via rule injection.
+		for _, r := range ua {
+			if r < 0x20 || r == unicode.MaxRune || unicode.IsControl(r) {
+				return domain.Validation("ban_ua_control_char",
+					"user agent must not contain control characters (including newlines and carriage returns)")
+			}
+		}
+	}
+	return nil
+}
+
 // ListBans returns all bans for a site.
 func (s *Service) ListBans(ctx context.Context, tenantID, siteID uuid.UUID) ([]Ban, error) {
 	return s.repo.ListBans(ctx, tenantID, siteID)
@@ -354,21 +455,26 @@ func (s *Service) CreateBan(ctx context.Context, tenantID, siteID uuid.UUID, ban
 		return Ban{}, domain.Validation("invalid_ban_type",
 			fmt.Sprintf("ban type must be ip|range|user_agent; got %q", ban.Type))
 	}
-	// --- value validation ---
+	// --- value validation: basic syntax ---
+	ban.Value = strings.TrimSpace(ban.Value)
 	if ban.Value == "" {
 		return Ban{}, domain.Validation("invalid_ban_value", "ban value is required")
 	}
 	switch ban.Type {
 	case BanTypeIP:
-		if net.ParseIP(strings.TrimSpace(ban.Value)) == nil {
+		if net.ParseIP(ban.Value) == nil {
 			return Ban{}, domain.Validation("invalid_ban_ip",
 				fmt.Sprintf("%q is not a valid IP address", ban.Value))
 		}
 	case BanTypeRange:
-		if _, _, err := net.ParseCIDR(strings.TrimSpace(ban.Value)); err != nil {
+		if _, _, err := net.ParseCIDR(ban.Value); err != nil {
 			return Ban{}, domain.Validation("invalid_ban_cidr",
 				fmt.Sprintf("%q is not a valid CIDR block", ban.Value))
 		}
+	}
+	// --- value validation: semantic safety (defense-in-depth) ---
+	if err := validateBan(ban); err != nil {
+		return Ban{}, err
 	}
 
 	ban.TenantID = tenantID

--- a/apps/api/internal/security/service.go
+++ b/apps/api/internal/security/service.go
@@ -15,6 +15,14 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
+// AgentHardeningClient is the subset of agentcmd.Client the hardening service
+// needs to push the hardening config + ban list to the agent. *agentcmd.Client
+// satisfies it via its SyncSecurityHardening method. Declared as an interface
+// so tests can substitute a fake without spinning up the SSRF transport.
+type AgentHardeningClient interface {
+	SyncSecurityHardening(ctx context.Context, siteID uuid.UUID, siteURL string, req agentcmd.HardeningRequest) (agentcmd.HardeningResult, error)
+}
+
 // AgentSecurityClient is the subset of agentcmd.Client the service needs to
 // push security config and issue IP unblocks. *agentcmd.Client satisfies it
 // via its SyncSecurityConfig and UnblockIP methods. Declared as an interface
@@ -30,11 +38,12 @@ type SiteLookup interface {
 	GetSiteURL(ctx context.Context, tenantID, siteID uuid.UUID) (string, error)
 }
 
-// Service orchestrates the security domain: repo + optional agentcmd client.
+// Service orchestrates the security domain: repo + optional agentcmd clients.
 type Service struct {
-	repo        *Repo
-	agentClient AgentSecurityClient
-	siteLookup  SiteLookup
+	repo               *Repo
+	agentClient        AgentSecurityClient
+	hardeningClient    AgentHardeningClient
+	siteLookup         SiteLookup
 }
 
 // NewService builds a Service.
@@ -42,12 +51,23 @@ func NewService(repo *Repo) *Service {
 	return &Service{repo: repo}
 }
 
-// SetAgentClient wires the agentcmd client for pushing config and unblocking
-// IPs. The SiteLookup is required alongside it so the service can resolve the
-// site URL without a hard dependency on the site package.
+// SetAgentClient wires the agentcmd client for pushing login-protection config
+// and unblocking IPs. The SiteLookup is required alongside it so the service
+// can resolve the site URL without a hard dependency on the site package.
 func (s *Service) SetAgentClient(client AgentSecurityClient, sites SiteLookup) {
 	s.agentClient = client
 	s.siteLookup = sites
+}
+
+// SetHardeningClient wires the agentcmd client for pushing the hardening config
+// + ban list. The SiteLookup is shared with SetAgentClient; call both or
+// supply the same adapter via both set methods. If SiteLookup is already set
+// (by SetAgentClient), it is not overwritten here.
+func (s *Service) SetHardeningClient(client AgentHardeningClient, sites SiteLookup) {
+	s.hardeningClient = client
+	if s.siteLookup == nil {
+		s.siteLookup = sites
+	}
 }
 
 // validModes are the three allowed protection modes.
@@ -190,6 +210,193 @@ func (s *Service) IngestLoginEvents(ctx context.Context, tenantID, siteID uuid.U
 // ListLoginEvents lists login events for a site.
 func (s *Service) ListLoginEvents(ctx context.Context, tenantID, siteID uuid.UUID, limit int, statusFilter *LoginEventStatus) ([]LoginEvent, error) {
 	return s.repo.ListLoginEvents(ctx, tenantID, siteID, limit, statusFilter)
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 — hardening config
+// ---------------------------------------------------------------------------
+
+// validXMLRPCModes is the set of accepted xmlrpc_mode values.
+var validXMLRPCModes = map[XMLRPCMode]bool{
+	XMLRPCModeOn:      true,
+	XMLRPCModeOff:     true,
+	XMLRPCModeLimited: true,
+}
+
+// validRESTAPIModes is the set of accepted restrict_rest_api values.
+var validRESTAPIModes = map[RESTAPIMode]bool{
+	RESTAPIModeDefault:    true,
+	RESTAPIModeRestricted: true,
+}
+
+// validLoginIdentifierModes is the set of accepted restrict_login_identifier values.
+var validLoginIdentifierModes = map[LoginIdentifierMode]bool{
+	LoginIdentifierUsername: true,
+	LoginIdentifierEmail:    true,
+	LoginIdentifierBoth:     true,
+}
+
+// GetHardeningConfig returns the stored hardening config, or the safe default
+// when no row exists yet.
+func (s *Service) GetHardeningConfig(ctx context.Context, tenantID, siteID uuid.UUID) (HardeningConfig, error) {
+	cfg, found, err := s.repo.GetHardeningConfig(ctx, tenantID, siteID)
+	if err != nil {
+		return HardeningConfig{}, err
+	}
+	if !found {
+		return DefaultHardeningConfig(tenantID, siteID), nil
+	}
+	return cfg, nil
+}
+
+// SaveHardeningConfig validates the incoming config, upserts it, and pushes it
+// to the agent together with the current ban list. Returns the stored config.
+// actorType and actorID are written to the row for audit tracing.
+func (s *Service) SaveHardeningConfig(ctx context.Context, tenantID, siteID uuid.UUID, cfg HardeningConfig, actorType, actorID string) (HardeningConfig, error) {
+	// --- enum validation ---
+	if !validXMLRPCModes[cfg.XMLRPCMode] {
+		return HardeningConfig{}, domain.Validation("invalid_xmlrpc_mode",
+			fmt.Sprintf("xmlrpc_mode must be on|off|limited; got %q", cfg.XMLRPCMode))
+	}
+	if !validRESTAPIModes[cfg.RestrictRESTAPI] {
+		return HardeningConfig{}, domain.Validation("invalid_restrict_rest_api",
+			fmt.Sprintf("restrict_rest_api must be default|restricted; got %q", cfg.RestrictRESTAPI))
+	}
+	if !validLoginIdentifierModes[cfg.RestrictLoginIdentifier] {
+		return HardeningConfig{}, domain.Validation("invalid_restrict_login_identifier",
+			fmt.Sprintf("restrict_login_identifier must be username|email|both; got %q", cfg.RestrictLoginIdentifier))
+	}
+
+	cfg.TenantID = tenantID
+	cfg.SiteID = siteID
+	cfg.ActorType = actorType
+	cfg.ActorID = actorID
+
+	saved, err := s.repo.UpsertHardeningConfig(ctx, cfg)
+	if err != nil {
+		return HardeningConfig{}, err
+	}
+
+	// Push config + current ban list to agent (best-effort).
+	pushErr := s.pushHardening(ctx, tenantID, siteID, saved)
+	if pushErr != nil {
+		return saved, fmt.Errorf("config stored but agent push failed: %w", pushErr)
+	}
+	return saved, nil
+}
+
+// pushHardening fetches the current ban list and sends the full config + ban
+// snapshot to the agent via sync_security_hardening. Best-effort: callers
+// surface push errors as warnings, not failures.
+func (s *Service) pushHardening(ctx context.Context, tenantID, siteID uuid.UUID, cfg HardeningConfig) error {
+	if s.hardeningClient == nil || s.siteLookup == nil {
+		return nil
+	}
+	siteURL, err := s.siteLookup.GetSiteURL(ctx, tenantID, siteID)
+	if err != nil {
+		return nil // site URL unavailable — skip push silently
+	}
+	bans, err := s.repo.ListBans(ctx, tenantID, siteID)
+	if err != nil {
+		return fmt.Errorf("load bans for push: %w", err)
+	}
+	banEntries := make([]agentcmd.BanEntry, 0, len(bans))
+	for _, b := range bans {
+		banEntries = append(banEntries, agentcmd.BanEntry{
+			ID:      b.ID.String(),
+			Type:    string(b.Type),
+			Value:   b.Value,
+			Comment: b.Comment,
+		})
+	}
+	req := agentcmd.HardeningRequest{
+		Config: agentcmd.HardeningConfig{
+			DisableFileEditor:        cfg.DisableFileEditor,
+			XMLRPCMode:               string(cfg.XMLRPCMode),
+			RestrictRESTAPI:          string(cfg.RestrictRESTAPI),
+			RestrictLoginIdentifier:  string(cfg.RestrictLoginIdentifier),
+			ForceUniqueNickname:      cfg.ForceUniqueNickname,
+			DisableAuthorArchiveEnum: cfg.DisableAuthorArchiveEnum,
+			ForceSSL:                 cfg.ForceSSL,
+			DisableDirectoryBrowsing: cfg.DisableDirectoryBrowsing,
+			DisablePHPInUploads:      cfg.DisablePHPInUploads,
+			ProtectSystemFiles:       cfg.ProtectSystemFiles,
+		},
+		Bans: banEntries,
+	}
+	if _, pushErr := s.hardeningClient.SyncSecurityHardening(ctx, siteID, siteURL, req); pushErr != nil {
+		return pushErr
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 — ban list
+// ---------------------------------------------------------------------------
+
+// validBanTypes is the set of accepted ban type values.
+var validBanTypes = map[BanType]bool{
+	BanTypeIP:        true,
+	BanTypeRange:     true,
+	BanTypeUserAgent: true,
+}
+
+// ListBans returns all bans for a site.
+func (s *Service) ListBans(ctx context.Context, tenantID, siteID uuid.UUID) ([]Ban, error) {
+	return s.repo.ListBans(ctx, tenantID, siteID)
+}
+
+// CreateBan validates the incoming ban entry, inserts it, and pushes the
+// updated config + ban list to the agent. Returns the stored ban.
+func (s *Service) CreateBan(ctx context.Context, tenantID, siteID uuid.UUID, ban Ban) (Ban, error) {
+	// --- type validation ---
+	if !validBanTypes[ban.Type] {
+		return Ban{}, domain.Validation("invalid_ban_type",
+			fmt.Sprintf("ban type must be ip|range|user_agent; got %q", ban.Type))
+	}
+	// --- value validation ---
+	if ban.Value == "" {
+		return Ban{}, domain.Validation("invalid_ban_value", "ban value is required")
+	}
+	switch ban.Type {
+	case BanTypeIP:
+		if net.ParseIP(strings.TrimSpace(ban.Value)) == nil {
+			return Ban{}, domain.Validation("invalid_ban_ip",
+				fmt.Sprintf("%q is not a valid IP address", ban.Value))
+		}
+	case BanTypeRange:
+		if _, _, err := net.ParseCIDR(strings.TrimSpace(ban.Value)); err != nil {
+			return Ban{}, domain.Validation("invalid_ban_cidr",
+				fmt.Sprintf("%q is not a valid CIDR block", ban.Value))
+		}
+	}
+
+	ban.TenantID = tenantID
+	ban.SiteID = siteID
+
+	saved, err := s.repo.InsertBan(ctx, ban)
+	if err != nil {
+		return Ban{}, err
+	}
+
+	// Push config + new ban list to agent (best-effort).
+	if cfg, cfgErr := s.GetHardeningConfig(ctx, tenantID, siteID); cfgErr == nil {
+		_ = s.pushHardening(ctx, tenantID, siteID, cfg)
+	}
+	return saved, nil
+}
+
+// DeleteBan removes a ban entry and re-pushes the config + ban list to the
+// agent. Returns domain.NotFound when no such ban exists.
+func (s *Service) DeleteBan(ctx context.Context, tenantID, siteID, banID uuid.UUID) error {
+	if err := s.repo.DeleteBan(ctx, tenantID, siteID, banID); err != nil {
+		return err
+	}
+	// Re-push updated ban list to agent (best-effort).
+	if cfg, cfgErr := s.GetHardeningConfig(ctx, tenantID, siteID); cfgErr == nil {
+		_ = s.pushHardening(ctx, tenantID, siteID, cfg)
+	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/migrations/20260709000000_m76_security_hardening.sql
+++ b/apps/api/migrations/20260709000000_m76_security_hardening.sql
@@ -1,0 +1,282 @@
+-- m76 — Security Suite Phase 1: per-site hardening config + durable ban list.
+--
+-- Adds two tenant-scoped tables:
+--
+--   site_security_hardening_config  — one row per site (PK = site_id). Typed
+--     boolean / text-enum columns for every Phase-1 hardening toggle. The CP
+--     is the source of truth; the agent mirrors it via the signed
+--     `sync_security_hardening` command on every save.
+--
+--   site_security_bans  — durable per-site ban entries (IP, CIDR, user-agent).
+--     Created/deleted by the operator; included in every `sync_security_hardening`
+--     push so the agent gets a consistent snapshot of config + bans together.
+--
+-- Column design:
+--   All hardening toggles default OFF so enabling is opt-in (no breaking change
+--   for sites that have not touched the panel). Enum columns use text + CHECK so
+--   invalid values are rejected at the DB layer without a custom type.
+--
+-- RLS: mirrors the m13 / m36 pattern exactly.
+--   ENABLE + FORCE row-level security on both tables.
+--   _tenant_isolation policy: USING + WITH CHECK via app.tenant_id GUC.
+--   _agent policy: USING + WITH CHECK via app.agent = 'on'.
+--   No _site_scope restrictive policy: collaborator gating is done in-app via
+--   authz.RequireSiteAccess(:siteId) on the routes (m13/m36 precedent).
+--
+-- updated_at is set by repo SQL (now()); there is no trigger (no set_updated_at()
+-- function in this schema — m36 comment).
+--
+-- Idempotency: every DDL statement is guarded with IF NOT EXISTS / IF NOT EXISTS
+-- checks; re-running this migration is safe.
+
+-- ===========================================================================
+-- site_security_hardening_config
+-- ===========================================================================
+
+DO $$
+BEGIN
+    CREATE TABLE IF NOT EXISTS "public"."site_security_hardening_config" (
+        -- tenant / site keys
+        "site_id"                      uuid PRIMARY KEY,
+        "tenant_id"                    uuid NOT NULL,
+
+        -- WordPress hardening toggles (all default OFF — opt-in, non-breaking)
+
+        -- Adds DISALLOW_FILE_EDIT to wp-config so the built-in template/plugin
+        -- editor is not available from the wp-admin dashboard.
+        "disable_file_editor"          boolean NOT NULL DEFAULT false,
+
+        -- Three-state XML-RPC control:
+        --   'on'      — XML-RPC is left as WordPress ships it (default).
+        --   'off'     — all XML-RPC requests are rejected at the mu-plugin layer.
+        --   'limited' — XML-RPC is allowed but system.multicall is blocked.
+        "xmlrpc_mode"                  text NOT NULL DEFAULT 'on'
+            CONSTRAINT "site_security_hardening_config_xmlrpc_mode_chk"
+            CHECK ("xmlrpc_mode" IN ('on', 'off', 'limited')),
+
+        -- Two-state REST API gating:
+        --   'default'    — REST API is left as WordPress ships it (default).
+        --   'restricted' — anonymous access to sensitive REST routes
+        --                  (users, comments listing) is blocked.
+        "restrict_rest_api"            text NOT NULL DEFAULT 'default'
+            CONSTRAINT "site_security_hardening_config_restrict_rest_api_chk"
+            CHECK ("restrict_rest_api" IN ('default', 'restricted')),
+
+        -- Controls which credential type the WordPress login form accepts:
+        --   'username' — only usernames are accepted (WP default).
+        --   'email'    — only email addresses are accepted.
+        --   'both'     — either username or email is accepted.
+        "restrict_login_identifier"    text NOT NULL DEFAULT 'both'
+            CONSTRAINT "site_security_hardening_config_login_id_chk"
+            CHECK ("restrict_login_identifier" IN ('username', 'email', 'both')),
+
+        -- Forces each user's display_name to differ from their user_login to
+        -- prevent username enumeration via public author profiles.
+        "force_unique_nickname"        boolean NOT NULL DEFAULT false,
+
+        -- Returns 404 for author archive URLs when the author has zero published
+        -- posts, preventing username enumeration via /?author=N probing.
+        "disable_author_archive_enum"  boolean NOT NULL DEFAULT false,
+
+        -- Adds FORCE_SSL_ADMIN to wp-config and ensures WordPress redirects
+        -- the admin panel over HTTPS.
+        "force_ssl"                    boolean NOT NULL DEFAULT false,
+
+        -- Adds Options -Indexes to the .htaccess / nginx deny rule so the web
+        -- server does not render directory listings.
+        "disable_directory_browsing"   boolean NOT NULL DEFAULT false,
+
+        -- Adds per-directory rules (RewriteRule / deny from all) to block direct
+        -- PHP execution from the uploads, plugins, and themes directories.
+        "disable_php_in_uploads"       boolean NOT NULL DEFAULT false,
+
+        -- Adds deny rules for sensitive files: readme.html, readme.txt,
+        -- wp-config.php, wp-admin/install.php, .git/, xmlrpc.php header deny.
+        "protect_system_files"         boolean NOT NULL DEFAULT false,
+
+        -- Audit / actor fields
+        "updated_at"                   timestamptz NOT NULL DEFAULT now(),
+        "actor_type"                   text,
+        "actor_id"                     text,
+
+        CONSTRAINT "site_security_hardening_config_tenant_fkey"
+            FOREIGN KEY ("tenant_id")
+            REFERENCES "public"."tenants" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+        CONSTRAINT "site_security_hardening_config_site_fkey"
+            FOREIGN KEY ("site_id")
+            REFERENCES "public"."sites" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+    );
+END;
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'public'
+           AND tablename  = 'site_security_hardening_config'
+           AND indexname  = 'site_security_hardening_config_tenant_idx'
+    ) THEN
+        CREATE INDEX "site_security_hardening_config_tenant_idx"
+            ON "public"."site_security_hardening_config" ("tenant_id");
+    END IF;
+END;
+$$;
+
+-- RLS — ENABLE + FORCE
+DO $$
+BEGIN
+    ALTER TABLE "public"."site_security_hardening_config" ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE "public"."site_security_hardening_config" FORCE ROW LEVEL SECURITY;
+END;
+$$;
+
+-- RLS — tenant isolation policy (operator / API path)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+         WHERE schemaname = 'public'
+           AND tablename  = 'site_security_hardening_config'
+           AND policyname = 'site_security_hardening_config_tenant_isolation'
+    ) THEN
+        CREATE POLICY "site_security_hardening_config_tenant_isolation"
+            ON "public"."site_security_hardening_config"
+            USING  ("tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid)
+            WITH CHECK ("tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid);
+    END IF;
+END;
+$$;
+
+-- RLS — agent policy (cross-tenant worker / agent path)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+         WHERE schemaname = 'public'
+           AND tablename  = 'site_security_hardening_config'
+           AND policyname = 'site_security_hardening_config_agent'
+    ) THEN
+        CREATE POLICY "site_security_hardening_config_agent"
+            ON "public"."site_security_hardening_config"
+            USING  (current_setting('app.agent', true) = 'on')
+            WITH CHECK (current_setting('app.agent', true) = 'on');
+    END IF;
+END;
+$$;
+
+-- ===========================================================================
+-- site_security_bans
+-- ===========================================================================
+
+DO $$
+BEGIN
+    CREATE TABLE IF NOT EXISTS "public"."site_security_bans" (
+        "id"         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        "tenant_id"  uuid NOT NULL,
+        "site_id"    uuid NOT NULL,
+
+        -- type: the kind of ban entry.
+        --   'ip'         — exact IPv4 or IPv6 address.
+        --   'range'      — IPv4 or IPv6 CIDR block.
+        --   'user_agent' — user-agent string (exact match; agent may also support
+        --                  substring / glob matching in a later phase).
+        "type"       text NOT NULL
+            CONSTRAINT "site_security_bans_type_chk"
+            CHECK ("type" IN ('ip', 'range', 'user_agent')),
+
+        -- value: the banned value. For type='ip' this is a dotted-decimal /
+        -- RFC5952 address; for type='range' a valid CIDR; for type='user_agent'
+        -- a plain string. Validated at write time in the service layer.
+        "value"      text NOT NULL,
+
+        -- comment: optional operator note explaining why this ban was added.
+        "comment"    text NOT NULL DEFAULT '',
+
+        -- actor tracking (operator or API key that created the ban).
+        "actor_type" text NOT NULL DEFAULT '',
+        "actor_id"   text NOT NULL DEFAULT '',
+
+        "created_at" timestamptz NOT NULL DEFAULT now(),
+
+        CONSTRAINT "site_security_bans_tenant_fkey"
+            FOREIGN KEY ("tenant_id")
+            REFERENCES "public"."tenants" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+        CONSTRAINT "site_security_bans_site_fkey"
+            FOREIGN KEY ("site_id")
+            REFERENCES "public"."sites" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+    );
+END;
+$$;
+
+-- Unique constraint: one entry per (site_id, type, value).
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'public'
+           AND tablename  = 'site_security_bans'
+           AND indexname  = 'site_security_bans_unique_entry_idx'
+    ) THEN
+        CREATE UNIQUE INDEX "site_security_bans_unique_entry_idx"
+            ON "public"."site_security_bans" ("site_id", "type", "value");
+    END IF;
+END;
+$$;
+
+-- Tenant query index: serves the ban list ordered by created_at DESC.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'public'
+           AND tablename  = 'site_security_bans'
+           AND indexname  = 'site_security_bans_tenant_site_idx'
+    ) THEN
+        CREATE INDEX "site_security_bans_tenant_site_idx"
+            ON "public"."site_security_bans" ("tenant_id", "site_id", "created_at" DESC);
+    END IF;
+END;
+$$;
+
+-- RLS — ENABLE + FORCE
+DO $$
+BEGIN
+    ALTER TABLE "public"."site_security_bans" ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE "public"."site_security_bans" FORCE ROW LEVEL SECURITY;
+END;
+$$;
+
+-- RLS — tenant isolation policy (operator / API path)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+         WHERE schemaname = 'public'
+           AND tablename  = 'site_security_bans'
+           AND policyname = 'site_security_bans_tenant_isolation'
+    ) THEN
+        CREATE POLICY "site_security_bans_tenant_isolation"
+            ON "public"."site_security_bans"
+            USING  ("tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid)
+            WITH CHECK ("tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid);
+    END IF;
+END;
+$$;
+
+-- RLS — agent policy (cross-tenant worker / agent path)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+         WHERE schemaname = 'public'
+           AND tablename  = 'site_security_bans'
+           AND policyname = 'site_security_bans_agent'
+    ) THEN
+        CREATE POLICY "site_security_bans_agent"
+            ON "public"."site_security_bans"
+            USING  (current_setting('app.agent', true) = 'on')
+            WITH CHECK (current_setting('app.agent', true) = 'on');
+    END IF;
+END;
+$$;

--- a/apps/landing/src/data/content.ts
+++ b/apps/landing/src/data/content.ts
@@ -344,12 +344,13 @@ export const FEATURES: {
       features: [
         {
           icon: "ShieldCheck",
-          title: "Security",
-          summary: "Integrity scanning, brute-force protection, and an IP firewall.",
+          title: "Site hardening and bans",
+          summary: "Per-site hardening controls and an IP ban list, pushed fleet-wide from the dashboard.",
           bullets: [
-            "Core files checked against official checksums",
-            "Escalating login blocks, admins never locked out",
-            "IP rules with a safety rail for your own IP",
+            "Disable file editor, restrict XML-RPC, REST API, and login IDs",
+            "Force SSL with HSTS, block PHP in uploads, protect system files",
+            "IP and CIDR ban list enforced at early-boot and web-server level",
+            "All controls opt-in and default-off",
           ],
         },
         {
@@ -621,15 +622,14 @@ export const SECURITY = {
   eyebrow: "Security and privacy",
   heading: "Built so a mistake can never lock you out of your own sites",
   subhead:
-    "Integrity scanning, brute-force protection, and an IP firewall across the fleet, with sensitive controls fenced off and a tamper-evident record of every action.",
+    "Per-site hardening, an IP ban list, and privacy-first data handling across the fleet, with sensitive controls fenced off and a tamper-evident record of every action.",
   bodyLines: [
     "Your data lives on the infrastructure you run WPMgr on, not ours. Backups can be client-side encrypted so the control plane only ever stores ciphertext and never holds a decryption key.",
     "Image bytes move directly between your site and your storage, and the agent redacts emails, passwords, secrets, tokens, and salts before any diagnostics ever leave a site.",
   ],
   items: [
-    { icon: "FileScan", title: "Core file-integrity scanning", desc: "Compares WordPress core files against the official checksums and flags anything modified, missing, or injected." },
-    { icon: "LockKeyhole", title: "Brute-force protection", desc: "Blocks repeated failed logins in escalating steps across the fleet, without locking out legitimate admins." },
-    { icon: "ShieldAlert", title: "IP firewall with a safety rail", desc: "Allow or deny visitors by IP range, with a guard that keeps your own IP from ever being blocked." },
+    { icon: "ShieldCheck", title: "WordPress hardening controls", desc: "Push hardening rules from the dashboard to any site: disable the file editor, restrict XML-RPC and the REST API, force SSL with HSTS, block PHP in uploads, and protect system files. All opt-in and default-off." },
+    { icon: "ShieldAlert", title: "IP and user-agent ban list", desc: "Block individual IPs, CIDR ranges, and user agents at early-boot and at the web-server level. The operator allow-list is always honoured so a ban can never lock out the operator." },
     { icon: "FileLock2", title: "Client-side encrypted backups", desc: "Optional end-to-end encryption means the control plane stores only ciphertext and never holds a key to decrypt it." },
     { icon: "EyeOff", title: "Redacted diagnostics", desc: "Emails, passwords, secrets, tokens, and salts are stripped before any diagnostics leave a site." },
     { icon: "ScrollText", title: "Tamper-evident audit log", desc: "Every login, role change, and site action is recorded in an audit log you can review." },

--- a/apps/web/src/features/security/ban-list-panel.tsx
+++ b/apps/web/src/features/security/ban-list-panel.tsx
@@ -1,0 +1,419 @@
+import { useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PageError } from "@/components/feedback";
+import { DestructiveConfirm } from "@/components/dialogs/destructive-confirm";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { toast } from "@/components/toast";
+import { relativeTime } from "@/lib/utils";
+
+import {
+  useBans,
+  useCreateBan,
+  useDeleteBan,
+  validateBanValue,
+  type BanType,
+  type Ban,
+} from "./use-hardening";
+
+// Security Suite Phase 1 — Ban list panel (per-site).
+//
+// Layout:
+//   [Add form row]  — type select + value input + comment input + Add button
+//   [Table]         — type badge | value | comment | added | delete
+//   [Empty state]   — when no bans exist
+//
+// Design rules:
+//   - Type badge uses a background tint that matches the semantic tone.
+//   - Client-side validation blocks invalid IPs / CIDRs before hitting the API.
+//   - Delete routes through DestructiveConfirm (irreversible action).
+//   - canWrite=false: add form and delete buttons are hidden (not just disabled)
+//     so the read-only view is unambiguous.
+
+export function BanListPanel({
+  siteId,
+  canWrite,
+}: {
+  siteId: string;
+  canWrite: boolean;
+}) {
+  const { data, isPending, isError, error, refetch } = useBans(siteId);
+
+  if (isPending) {
+    return <BanListSkeleton />;
+  }
+
+  if (isError) {
+    return (
+      <PageError
+        what="Could not load ban list."
+        why={error instanceof Error ? error.message : "Unknown error"}
+        onRetry={() => void refetch()}
+        retryLabel="Reload ban list"
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {canWrite ? (
+        <AddBanForm siteId={siteId} />
+      ) : null}
+
+      {data && data.length > 0 ? (
+        <BanTable bans={data} siteId={siteId} canWrite={canWrite} />
+      ) : (
+        <BanEmptyState />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Add form
+// ---------------------------------------------------------------------------
+
+const BAN_TYPE_OPTIONS: { value: BanType; label: string }[] = [
+  { value: "ip", label: "IP address" },
+  { value: "range", label: "IP range (CIDR)" },
+  { value: "user_agent", label: "User agent" },
+];
+
+function AddBanForm({ siteId }: { siteId: string }) {
+  const create = useCreateBan(siteId);
+
+  const [type, setType] = useState<BanType>("ip");
+  const [value, setValue] = useState("");
+  const [comment, setComment] = useState("");
+  const [valueError, setValueError] = useState<string | null>(null);
+
+  const placeholders: Record<BanType, string> = {
+    ip: "203.0.113.42",
+    range: "203.0.113.0/24",
+    user_agent: "BadBot/1.0",
+  };
+
+  function handleAdd() {
+    const trimmedValue = value.trim();
+    const validationError = validateBanValue(type, trimmedValue);
+    if (validationError) {
+      setValueError(validationError);
+      return;
+    }
+
+    setValueError(null);
+    create.mutate(
+      { type, value: trimmedValue, comment: comment.trim() },
+      {
+        onSuccess: (result) => {
+          setValue("");
+          setComment("");
+          const detail = result.detail;
+          if (detail) {
+            toast.success("Ban added.", { description: detail });
+          } else {
+            toast.success("Ban added.");
+          }
+        },
+        onError: (err: Error) => {
+          toast.error("Could not add ban.", { description: err.message });
+        },
+      },
+    );
+  }
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleAdd();
+      }}
+      noValidate
+      className="flex flex-col gap-3 rounded-lg border border-[var(--color-border)] p-4 sm:flex-row sm:items-start"
+      aria-label="Add a ban"
+    >
+      {/* Type select */}
+      <div className="shrink-0">
+        <label htmlFor="ban-type" className="sr-only">
+          Ban type
+        </label>
+        <select
+          id="ban-type"
+          value={type}
+          onChange={(e) => {
+            setType(e.target.value as BanType);
+            setValue("");
+            setValueError(null);
+          }}
+          disabled={create.isPending}
+          className="flex h-9 w-full rounded-md border border-[var(--color-input)] bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)] disabled:cursor-not-allowed disabled:opacity-50 sm:w-44"
+        >
+          {BAN_TYPE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Value input */}
+      <div className="flex-1 space-y-1">
+        <label htmlFor="ban-value" className="sr-only">
+          {type === "ip"
+            ? "IP address to ban"
+            : type === "range"
+              ? "CIDR range to ban"
+              : "User agent to ban"}
+        </label>
+        <Input
+          id="ban-value"
+          type="text"
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+            setValueError(null);
+          }}
+          placeholder={placeholders[type]}
+          disabled={create.isPending}
+          aria-invalid={valueError !== null}
+          aria-describedby={valueError ? "ban-value-error" : undefined}
+          className="font-mono text-sm"
+        />
+        {valueError ? (
+          <p
+            id="ban-value-error"
+            role="alert"
+            className="text-xs text-[var(--color-destructive)]"
+          >
+            {valueError}
+          </p>
+        ) : null}
+      </div>
+
+      {/* Comment input */}
+      <div className="flex-1">
+        <label htmlFor="ban-comment" className="sr-only">
+          Comment (optional)
+        </label>
+        <Input
+          id="ban-comment"
+          type="text"
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          placeholder="Optional note"
+          disabled={create.isPending}
+          className="text-sm"
+        />
+      </div>
+
+      {/* Add button */}
+      <Button
+        type="submit"
+        variant="outline"
+        size="sm"
+        disabled={create.isPending}
+        aria-busy={create.isPending}
+        className="shrink-0 self-start"
+      >
+        <Plus aria-hidden="true" className="size-3.5" />
+        {create.isPending ? "Adding..." : "Add ban"}
+      </Button>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Table
+// ---------------------------------------------------------------------------
+
+function BanTable({
+  bans,
+  siteId,
+  canWrite,
+}: {
+  bans: Ban[];
+  siteId: string;
+  canWrite: boolean;
+}) {
+  const [pendingDelete, setPendingDelete] = useState<Ban | null>(null);
+  const deleteBan = useDeleteBan(siteId);
+
+  function confirmDelete() {
+    if (!pendingDelete) return;
+    deleteBan.mutate(pendingDelete.id, {
+      onSuccess: () => {
+        setPendingDelete(null);
+        toast.success("Ban removed.");
+      },
+      onError: (err: Error) => {
+        toast.error("Could not remove ban.", { description: err.message });
+      },
+    });
+  }
+
+  return (
+    <>
+      <div className="rounded-lg border border-[var(--color-border)]">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-28">Type</TableHead>
+              <TableHead>Value</TableHead>
+              <TableHead className="hidden sm:table-cell">Comment</TableHead>
+              <TableHead className="hidden md:table-cell w-32">Added</TableHead>
+              {canWrite ? (
+                <TableHead className="w-12">
+                  <span className="sr-only">Actions</span>
+                </TableHead>
+              ) : null}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {bans.map((ban) => (
+              <TableRow key={ban.id}>
+                <TableCell>
+                  <BanTypeBadge type={ban.type} />
+                </TableCell>
+                <TableCell className="font-mono text-sm">
+                  {ban.value}
+                </TableCell>
+                <TableCell className="hidden text-sm text-[var(--color-muted-foreground)] sm:table-cell">
+                  {ban.comment || (
+                    <span className="italic text-[var(--color-muted-foreground)]/60">
+                      None
+                    </span>
+                  )}
+                </TableCell>
+                <TableCell className="hidden text-xs text-[var(--color-muted-foreground)] tabular-nums md:table-cell">
+                  {relativeTime(ban.created_at) ?? "–"}
+                </TableCell>
+                {canWrite ? (
+                  <TableCell>
+                    <button
+                      type="button"
+                      aria-label={`Remove ban for ${ban.value}`}
+                      onClick={() => setPendingDelete(ban)}
+                      className="inline-flex size-7 items-center justify-center rounded text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-destructive)]/10 hover:text-[var(--color-destructive)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+                    >
+                      <Trash2 aria-hidden="true" className="size-3.5" />
+                    </button>
+                  </TableCell>
+                ) : null}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {pendingDelete ? (
+        <DestructiveConfirm
+          open={pendingDelete !== null}
+          onClose={() => setPendingDelete(null)}
+          onConfirm={confirmDelete}
+          title={`Remove ban for ${pendingDelete.value}`}
+          resourceName={pendingDelete.value}
+          confirmLabel="Remove ban"
+          cancelLabel="Keep ban"
+          isPending={deleteBan.isPending}
+          errorMessage={deleteBan.isError ? deleteBan.error.message : null}
+          consequencesBody={
+            <p>
+              Removing this ban allows traffic from{" "}
+              <code className="font-mono text-sm">{pendingDelete.value}</code>{" "}
+              to reach the site again immediately.
+            </p>
+          }
+        />
+      ) : null}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// BanTypeBadge
+// ---------------------------------------------------------------------------
+
+const BAN_TYPE_LABEL: Record<BanType, string> = {
+  ip: "IP",
+  range: "CIDR",
+  user_agent: "User agent",
+};
+
+const BAN_TYPE_CLASS: Record<BanType, string> = {
+  ip: "bg-[var(--color-destructive)]/10 text-[var(--color-destructive)]",
+  range: "bg-[var(--color-warning)]/15 text-[var(--color-warning)]",
+  user_agent:
+    "bg-[var(--color-muted)] text-[var(--color-muted-foreground)]",
+};
+
+function BanTypeBadge({ type }: { type: BanType }) {
+  return (
+    <span
+      className={[
+        "inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium",
+        BAN_TYPE_CLASS[type],
+      ].join(" ")}
+    >
+      {BAN_TYPE_LABEL[type]}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+function BanEmptyState() {
+  return (
+    <div
+      role="status"
+      aria-label="No bans configured"
+      className="flex flex-col items-center gap-2 py-10 text-center"
+    >
+      <p className="text-sm text-[var(--color-muted-foreground)]">
+        No bans configured. Use the form above to block specific IPs, CIDR
+        ranges, or user agents.
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton
+// ---------------------------------------------------------------------------
+
+function BanListSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label="Loading ban list"
+      className="space-y-4"
+    >
+      <span className="sr-only">Loading ban list</span>
+      <Skeleton className="h-14 w-full rounded-lg" />
+      <div className="rounded-lg border border-[var(--color-border)]">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-4 border-b border-[var(--color-border)] px-4 py-3 last:border-0"
+          >
+            <Skeleton className="h-5 w-12 rounded-md" />
+            <Skeleton className="h-4 w-32 flex-1" />
+            <Skeleton className="h-4 w-24 hidden sm:block" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/security/hardening-panel.tsx
+++ b/apps/web/src/features/security/hardening-panel.tsx
@@ -1,0 +1,488 @@
+import { useState } from "react";
+import { AlertTriangle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PageError } from "@/components/feedback";
+import { toast } from "@/components/toast";
+
+import {
+  useHardeningConfig,
+  useUpdateHardeningConfig,
+  type HardeningConfig,
+  type XmlrpcMode,
+  type RestApiAccess,
+  type LoginIdentifier,
+} from "./use-hardening";
+
+// Security Suite Phase 1 — Hardening config panel.
+//
+// Layout strategy: each sub-section is a <section> with an ARIA label and a
+// plain-text sub-heading. Controls are disabled when `canWrite` is false
+// (viewer role). A single "Save hardening settings" button at the bottom is
+// shared across all sub-sections — avoiding per-section save buttons keeps the
+// form model simpler and avoids partial-save confusion.
+//
+// The PUT response may include an optional `detail` caveat string (e.g.
+// "wp-config.php not writable — runtime filter only"). This is surfaced as a
+// subtle inline amber notice below the save button.
+//
+// Shell pattern: HardeningPanel → HardeningLoaded (keyed on config fields).
+
+export function HardeningPanel({
+  siteId,
+  canWrite,
+}: {
+  siteId: string;
+  canWrite: boolean;
+}) {
+  const { data, isPending, isError, error, refetch } =
+    useHardeningConfig(siteId);
+
+  if (isPending) {
+    return <HardeningSkeleton />;
+  }
+
+  if (isError) {
+    return (
+      <PageError
+        what="Could not load hardening config."
+        why={error instanceof Error ? error.message : "Unknown error"}
+        onRetry={() => void refetch()}
+        retryLabel="Reload config"
+      />
+    );
+  }
+
+  if (!data) return null;
+
+  // Key on the full config so the form resets if a background refetch returns
+  // different server values (e.g. another operator changed the config).
+  const configKey = Object.entries(data.config)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}:${String(v)}`)
+    .join("|");
+
+  return (
+    <HardeningLoaded
+      key={configKey}
+      siteId={siteId}
+      initialConfig={data.config}
+      initialDetail={data.detail}
+      canWrite={canWrite}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loaded form
+// ---------------------------------------------------------------------------
+
+interface LoadedProps {
+  siteId: string;
+  initialConfig: HardeningConfig;
+  initialDetail?: string;
+  canWrite: boolean;
+}
+
+function HardeningLoaded({
+  siteId,
+  initialConfig,
+  initialDetail,
+  canWrite,
+}: LoadedProps) {
+  const update = useUpdateHardeningConfig(siteId);
+
+  const [config, setConfig] = useState<HardeningConfig>({ ...initialConfig });
+  const [saveDetail, setSaveDetail] = useState<string | undefined>(
+    initialDetail,
+  );
+
+  function toggle(field: keyof HardeningConfig) {
+    setConfig((prev) => ({ ...prev, [field]: !prev[field] }));
+  }
+
+  function setXmlrpc(mode: XmlrpcMode) {
+    setConfig((prev) => ({ ...prev, xmlrpc_mode: mode }));
+  }
+
+  function setRestApi(access: RestApiAccess) {
+    setConfig((prev) => ({ ...prev, restrict_rest_api: access }));
+  }
+
+  function setLoginId(id: LoginIdentifier) {
+    setConfig((prev) => ({ ...prev, restrict_login_identifier: id }));
+  }
+
+  function handleSave() {
+    setSaveDetail(undefined);
+    update.mutate(config, {
+      onSuccess: (result) => {
+        setSaveDetail(result.detail);
+        toast.success("Hardening settings saved.", {
+          description: result.detail
+            ? `Note: ${result.detail}`
+            : "Config applied to the site.",
+        });
+      },
+      onError: (err: Error) => {
+        toast.error("Could not save hardening settings.", {
+          description: err.message,
+        });
+      },
+    });
+  }
+
+  const disabled = !canWrite || update.isPending;
+
+  return (
+    <div className="space-y-8">
+      {/* ── File & content ────────────────────────────────────────────── */}
+      <SubSection id="hardening-file-content" title="File and content">
+        <ToggleRow
+          id="disable-file-editor"
+          label="Disable file editor"
+          help="Prevents editing plugin and theme files directly from wp-admin. Recommended for all production sites."
+          checked={config.disable_file_editor}
+          onChange={() => toggle("disable_file_editor")}
+          disabled={disabled}
+        />
+        <ToggleRow
+          id="disable-php-uploads"
+          label="Block PHP in uploads"
+          help="Prevents PHP scripts in the uploads directory from being executed — a common vector for uploaded shell injections."
+          checked={config.disable_php_in_uploads}
+          onChange={() => toggle("disable_php_in_uploads")}
+          disabled={disabled}
+        />
+        <ToggleRow
+          id="protect-system-files"
+          label="Protect system files"
+          help="Blocks direct HTTP access to wp-config.php, .htaccess, and similar files. Applied via server rules where possible; falls back to a runtime filter."
+          checked={config.protect_system_files}
+          onChange={() => toggle("protect_system_files")}
+          disabled={disabled}
+        />
+        <ToggleRow
+          id="disable-directory-browsing"
+          label="Disable directory browsing"
+          help="Prevents the web server from listing directory contents when no index file exists."
+          checked={config.disable_directory_browsing}
+          onChange={() => toggle("disable_directory_browsing")}
+          disabled={disabled}
+        />
+      </SubSection>
+
+      {/* ── XML-RPC ───────────────────────────────────────────────────── */}
+      <SubSection id="hardening-xmlrpc" title="XML-RPC">
+        <p className="mb-3 text-xs text-[var(--color-muted-foreground)]">
+          XML-RPC is a legacy remote-publishing interface. Keeping it fully
+          active exposes the site to amplification and brute-force attacks. Use
+          Limited mode if Jetpack or a mobile app requires it.
+        </p>
+        <SegmentedControl<XmlrpcMode>
+          id="xmlrpc-mode"
+          legend="XML-RPC mode"
+          options={[
+            { value: "on", label: "On" },
+            { value: "limited", label: "Limited" },
+            { value: "off", label: "Off" },
+          ]}
+          value={config.xmlrpc_mode}
+          onChange={setXmlrpc}
+          disabled={disabled}
+          helpText={{
+            on: "All XML-RPC methods are enabled (default WordPress behaviour).",
+            limited:
+              "Only basic ping and Jetpack system calls are allowed; brute-force methods are blocked.",
+            off: "XML-RPC endpoint is disabled entirely.",
+          }}
+        />
+      </SubSection>
+
+      {/* ── REST API ──────────────────────────────────────────────────── */}
+      <SubSection id="hardening-rest-api" title="REST API">
+        <p className="mb-3 text-xs text-[var(--color-muted-foreground)]">
+          The WordPress REST API is required by the block editor and many
+          plugins. Restricting it adds a layer of obscurity for unauthenticated
+          user enumeration endpoints.
+        </p>
+        <SegmentedControl<RestApiAccess>
+          id="rest-api-access"
+          legend="REST API access"
+          options={[
+            { value: "default", label: "Default" },
+            { value: "restricted", label: "Restricted" },
+          ]}
+          value={config.restrict_rest_api}
+          onChange={setRestApi}
+          disabled={disabled}
+          helpText={{
+            default:
+              "Unauthenticated access to all public REST endpoints is permitted.",
+            restricted:
+              "Unauthenticated requests to the /wp-json/ namespace are blocked; logged-in requests and the block editor are unaffected.",
+          }}
+        />
+      </SubSection>
+
+      {/* ── Login ─────────────────────────────────────────────────────── */}
+      <SubSection id="hardening-login" title="Login">
+        <div className="space-y-6">
+          <div>
+            <p className="mb-3 text-xs text-[var(--color-muted-foreground)]">
+              Control which identifiers are accepted on the login form to reduce
+              username enumeration risk.
+            </p>
+            <SegmentedControl<LoginIdentifier>
+              id="login-identifier"
+              legend="Login identifier"
+              options={[
+                { value: "username", label: "Username" },
+                { value: "email", label: "Email" },
+                { value: "both", label: "Both" },
+              ]}
+              value={config.restrict_login_identifier}
+              onChange={setLoginId}
+              disabled={disabled}
+              helpText={{
+                username: "Only usernames are accepted on the login form.",
+                email: "Only email addresses are accepted on the login form.",
+                both: "Both usernames and email addresses are accepted (WordPress default).",
+              }}
+            />
+          </div>
+
+          <ToggleRow
+            id="force-unique-nickname"
+            label="Require unique display names"
+            help="Prevents two users from sharing the same nickname, which blocks a technique where an attacker sets their display name to match an admin to cause confusion."
+            checked={config.force_unique_nickname}
+            onChange={() => toggle("force_unique_nickname")}
+            disabled={disabled}
+          />
+          <ToggleRow
+            id="disable-author-archive"
+            label="Disable author archive enumeration"
+            help="Blocks the ?author=N query string, which can reveal WordPress usernames to unauthenticated visitors."
+            checked={config.disable_author_archive_enum}
+            onChange={() => toggle("disable_author_archive_enum")}
+            disabled={disabled}
+          />
+        </div>
+      </SubSection>
+
+      {/* ── Transport ─────────────────────────────────────────────────── */}
+      <SubSection id="hardening-transport" title="Transport">
+        <ToggleRow
+          id="force-ssl"
+          label="Force HTTPS"
+          help="Redirects all HTTP requests to HTTPS and sets the HTTPS constant for WordPress. Only enable when an SSL certificate is active — enabling without a cert will lock you out."
+          checked={config.force_ssl}
+          onChange={() => toggle("force_ssl")}
+          disabled={disabled}
+        />
+      </SubSection>
+
+      {/* ── Caveat notice from last save ─────────────────────────────── */}
+      {saveDetail ? (
+        <div
+          role="status"
+          className="flex items-start gap-3 rounded-lg border border-[var(--color-warning)]/40 bg-[var(--color-warning)]/8 px-4 py-3"
+        >
+          <AlertTriangle
+            aria-hidden="true"
+            className="mt-0.5 size-4 shrink-0 text-[var(--color-warning)]"
+          />
+          <p className="text-sm text-[var(--color-foreground)]">{saveDetail}</p>
+        </div>
+      ) : null}
+
+      {/* ── Save ──────────────────────────────────────────────────────── */}
+      {canWrite ? (
+        <div className="flex items-center gap-3 border-t border-[var(--color-border)] pt-6">
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={update.isPending}
+            aria-busy={update.isPending}
+          >
+            {update.isPending ? "Saving..." : "Save hardening settings"}
+          </Button>
+        </div>
+      ) : (
+        <p className="text-xs text-[var(--color-muted-foreground)]">
+          You have read-only access. Contact an owner or admin to change these
+          settings.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SubSection — a titled section within the hardening form
+// ---------------------------------------------------------------------------
+
+function SubSection({
+  id,
+  title,
+  children,
+}: {
+  id: string;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section aria-labelledby={id}>
+      <h3
+        id={id}
+        className="mb-4 text-xs font-medium uppercase tracking-wide text-[var(--color-muted-foreground)]"
+      >
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ToggleRow — a labelled switch row
+// ---------------------------------------------------------------------------
+
+function ToggleRow({
+  id,
+  label,
+  help,
+  checked,
+  onChange,
+  disabled,
+}: {
+  id: string;
+  label: string;
+  help: string;
+  checked: boolean;
+  onChange: () => void;
+  disabled: boolean;
+}) {
+  const helpId = `${id}-help`;
+  return (
+    <div className="flex items-start justify-between gap-4 py-3 first:pt-0">
+      <div className="min-w-0 flex-1">
+        <label
+          htmlFor={id}
+          className="block text-sm font-medium text-[var(--color-foreground)]"
+        >
+          {label}
+        </label>
+        <p
+          id={helpId}
+          className="mt-0.5 text-xs text-[var(--color-muted-foreground)]"
+        >
+          {help}
+        </p>
+      </div>
+      <Switch
+        id={id}
+        checked={checked}
+        onCheckedChange={onChange}
+        disabled={disabled}
+        aria-describedby={helpId}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SegmentedControl — radio group rendered as pill buttons
+// ---------------------------------------------------------------------------
+
+function SegmentedControl<T extends string>({
+  id,
+  legend,
+  options,
+  value,
+  onChange,
+  disabled,
+  helpText,
+}: {
+  id: string;
+  legend: string;
+  options: { value: T; label: string }[];
+  value: T;
+  onChange: (v: T) => void;
+  disabled: boolean;
+  helpText?: Partial<Record<T, string>>;
+}) {
+  return (
+    <fieldset>
+      <legend className="sr-only">{legend}</legend>
+      <div className="flex flex-wrap gap-2">
+        {options.map((opt) => (
+          <label key={opt.value} className="cursor-pointer">
+            <input
+              type="radio"
+              name={id}
+              value={opt.value}
+              checked={value === opt.value}
+              onChange={() => onChange(opt.value)}
+              disabled={disabled}
+              className="sr-only"
+            />
+            <span
+              className={[
+                "inline-flex h-8 items-center rounded-md border px-3 text-sm font-medium transition-colors",
+                "focus-within:ring-2 focus-within:ring-[var(--color-ring)] focus-within:ring-offset-2",
+                disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+                value === opt.value
+                  ? "border-[var(--color-primary)] bg-[var(--color-primary)] text-white"
+                  : "border-[var(--color-border)] bg-[var(--color-background)] text-[var(--color-foreground)] hover:bg-[var(--color-muted)]/40",
+              ].join(" ")}
+            >
+              {opt.label}
+            </span>
+          </label>
+        ))}
+      </div>
+      {helpText?.[value] ? (
+        <p className="mt-2 text-xs text-[var(--color-muted-foreground)]">
+          {helpText[value]}
+        </p>
+      ) : null}
+    </fieldset>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton
+// ---------------------------------------------------------------------------
+
+function HardeningSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label="Loading hardening settings"
+      className="space-y-8"
+    >
+      <span className="sr-only">Loading hardening settings</span>
+      {/* Sub-section skeletons */}
+      {[5, 3, 2, 3, 1].map((rows, idx) => (
+        <div key={idx} className="space-y-4">
+          <Skeleton className="h-3 w-24" />
+          {Array.from({ length: rows }).map((_, i) => (
+            <div key={i} className="flex items-center justify-between py-2">
+              <div className="space-y-1.5">
+                <Skeleton className="h-3.5 w-40" />
+                <Skeleton className="h-3 w-64" />
+              </div>
+              <Skeleton className="h-5 w-9 rounded-full" />
+            </div>
+          ))}
+        </div>
+      ))}
+      <Skeleton className="h-9 w-48 rounded-md" />
+    </div>
+  );
+}

--- a/apps/web/src/features/security/use-hardening.test.ts
+++ b/apps/web/src/features/security/use-hardening.test.ts
@@ -1,0 +1,505 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import {
+  validateBanValue,
+  isValidIpv4,
+  isValidCidr,
+  isValidUserAgent,
+  type BanType,
+  type HardeningConfig,
+} from "./use-hardening";
+
+// ---------------------------------------------------------------------------
+// validateBanValue — client-side ban value validation
+// ---------------------------------------------------------------------------
+//
+// These tests assert the behaviour exported from use-hardening.ts that is
+// the first line of defence before a POST /api/v1/sites/{siteId}/security/bans
+// call is made. An invalid value must return a non-null error string; a valid
+// value must return null.
+//
+// The tests are pure-logic (no React, no HTTP) — mirroring the pattern in
+// use-site-connection.test.ts and use-bulk-backup.test.ts.
+
+describe("isValidIpv4", () => {
+  it("accepts a well-formed IPv4 address", () => {
+    expect(isValidIpv4("203.0.113.42")).toBe(true);
+    expect(isValidIpv4("192.168.1.1")).toBe(true);
+    expect(isValidIpv4("10.0.0.1")).toBe(true);
+    expect(isValidIpv4("255.255.255.255")).toBe(true);
+    expect(isValidIpv4("0.0.0.0")).toBe(true);
+  });
+
+  it("rejects IPs with out-of-range octets", () => {
+    expect(isValidIpv4("256.0.0.1")).toBe(false);
+    expect(isValidIpv4("192.168.999.1")).toBe(false);
+  });
+
+  it("rejects CIDR notation as an IPv4 address", () => {
+    expect(isValidIpv4("203.0.113.0/24")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isValidIpv4("")).toBe(false);
+  });
+
+  it("rejects non-IP strings", () => {
+    expect(isValidIpv4("not-an-ip")).toBe(false);
+    expect(isValidIpv4("localhost")).toBe(false);
+  });
+});
+
+describe("isValidCidr", () => {
+  it("accepts well-formed IPv4 CIDR blocks", () => {
+    expect(isValidCidr("203.0.113.0/24")).toBe(true);
+    expect(isValidCidr("10.0.0.0/8")).toBe(true);
+    expect(isValidCidr("192.168.1.0/32")).toBe(true);
+    expect(isValidCidr("0.0.0.0/0")).toBe(true);
+  });
+
+  it("rejects prefix out of range", () => {
+    expect(isValidCidr("203.0.113.0/33")).toBe(false);
+  });
+
+  it("rejects bare IPv4 without prefix", () => {
+    expect(isValidCidr("203.0.113.42")).toBe(false);
+  });
+
+  it("rejects out-of-range octets", () => {
+    expect(isValidCidr("256.0.0.0/24")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isValidCidr("")).toBe(false);
+  });
+});
+
+describe("isValidUserAgent", () => {
+  it("accepts a non-empty user-agent string", () => {
+    expect(isValidUserAgent("BadBot/1.0")).toBe(true);
+    expect(isValidUserAgent("Mozilla/5.0 (compatible)")).toBe(true);
+  });
+
+  it("rejects empty string", () => {
+    expect(isValidUserAgent("")).toBe(false);
+  });
+
+  it("rejects a string exceeding 512 characters", () => {
+    expect(isValidUserAgent("a".repeat(513))).toBe(false);
+  });
+
+  it("accepts a string of exactly 512 characters", () => {
+    expect(isValidUserAgent("a".repeat(512))).toBe(true);
+  });
+});
+
+describe("validateBanValue — ip type", () => {
+  it("returns null for a valid IPv4 address", () => {
+    expect(validateBanValue("ip", "203.0.113.42")).toBeNull();
+  });
+
+  it("returns an error for a CIDR when type is ip", () => {
+    expect(validateBanValue("ip", "203.0.113.0/24")).not.toBeNull();
+  });
+
+  it("returns an error for an empty value", () => {
+    expect(validateBanValue("ip", "")).not.toBeNull();
+    expect(validateBanValue("ip", "   ")).not.toBeNull();
+  });
+
+  it("returns an error string (not a boolean or null) so callers can render it", () => {
+    const result = validateBanValue("ip", "not-an-ip");
+    expect(typeof result).toBe("string");
+    expect(result!.length).toBeGreaterThan(0);
+  });
+
+  it("does NOT make any API call (pure validation — the critical guard)", () => {
+    // This test is structural: we call validateBanValue directly and assert it
+    // returns without touching the network. Because validateBanValue is a pure
+    // function with no side-effects, any API call mock would be unnecessary —
+    // the function signature itself enforces this contract.
+    const mockFetch = vi.fn();
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch;
+    try {
+      validateBanValue("ip", "999.999.999.999");
+      expect(mockFetch).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe("validateBanValue — range type", () => {
+  it("returns null for a valid CIDR block", () => {
+    expect(validateBanValue("range", "203.0.113.0/24")).toBeNull();
+  });
+
+  it("returns an error for a bare IP when type is range", () => {
+    expect(validateBanValue("range", "203.0.113.42")).not.toBeNull();
+  });
+
+  it("returns an error for empty value", () => {
+    expect(validateBanValue("range", "")).not.toBeNull();
+  });
+});
+
+describe("validateBanValue — user_agent type", () => {
+  it("returns null for a non-empty user agent", () => {
+    expect(validateBanValue("user_agent", "BadBot/1.0")).toBeNull();
+  });
+
+  it("returns an error for empty user agent", () => {
+    expect(validateBanValue("user_agent", "")).not.toBeNull();
+    expect(validateBanValue("user_agent", "   ")).not.toBeNull();
+  });
+
+  it("returns an error for a user agent exceeding 512 chars", () => {
+    expect(validateBanValue("user_agent", "x".repeat(513))).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// API call contract: hook function signatures
+//
+// These tests verify that the hooks in use-hardening.ts accept the right
+// parameter shapes. They import the functions but do NOT call them (calling
+// them requires a React context + QueryClient). The goal is to pin the public
+// API shape so a refactor that accidentally changes a parameter name or type
+// will fail here, not silently in a component.
+// ---------------------------------------------------------------------------
+
+describe("hardening hook exports — public API shape", () => {
+  it("useHardeningConfig is exported as a function accepting a siteId string", async () => {
+    const { useHardeningConfig } = await import("./use-hardening");
+    expect(typeof useHardeningConfig).toBe("function");
+    // The hook takes exactly one argument (siteId: string).
+    expect(useHardeningConfig.length).toBe(1);
+  });
+
+  it("useUpdateHardeningConfig is exported as a function accepting a siteId string", async () => {
+    const { useUpdateHardeningConfig } = await import("./use-hardening");
+    expect(typeof useUpdateHardeningConfig).toBe("function");
+    expect(useUpdateHardeningConfig.length).toBe(1);
+  });
+
+  it("useBans is exported as a function accepting a siteId string", async () => {
+    const { useBans } = await import("./use-hardening");
+    expect(typeof useBans).toBe("function");
+    expect(useBans.length).toBe(1);
+  });
+
+  it("useCreateBan is exported as a function accepting a siteId string", async () => {
+    const { useCreateBan } = await import("./use-hardening");
+    expect(typeof useCreateBan).toBe("function");
+    expect(useCreateBan.length).toBe(1);
+  });
+
+  it("useDeleteBan is exported as a function accepting a siteId string", async () => {
+    const { useDeleteBan } = await import("./use-hardening");
+    expect(typeof useDeleteBan).toBe("function");
+    expect(useDeleteBan.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hardeningKeys — cache key structure
+//
+// Mirrors the cache-key pin tests in use-site-connection.test.ts.
+// These assert the key shapes that mutation invalidations depend on.
+// ---------------------------------------------------------------------------
+
+describe("hardeningKeys — cache key factory", () => {
+  it("config key is specific to the siteId so only that site's config invalidates", async () => {
+    const { hardeningKeys } = await import("./use-hardening");
+    const key = hardeningKeys.config("site-abc");
+    expect(key).toContain("site-abc");
+    expect(key).toContain("config");
+  });
+
+  it("bans key is specific to the siteId so only that site's bans invalidate", async () => {
+    const { hardeningKeys } = await import("./use-hardening");
+    const key = hardeningKeys.bans("site-abc");
+    expect(key).toContain("site-abc");
+    expect(key).toContain("bans");
+  });
+
+  it("config key and bans key are distinct so invalidating one does not flush the other", async () => {
+    const { hardeningKeys } = await import("./use-hardening");
+    const configKey = hardeningKeys.config("site-abc");
+    const bansKey = hardeningKeys.bans("site-abc");
+    expect(configKey).not.toEqual(bansKey);
+  });
+
+  it("config keys for different sites are distinct", async () => {
+    const { hardeningKeys } = await import("./use-hardening");
+    const key1 = hardeningKeys.config("site-aaa");
+    const key2 = hardeningKeys.config("site-bbb");
+    expect(key1).not.toEqual(key2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HardeningConfig shape — all 10 fields present
+//
+// This is a type-level guard: we construct a complete HardeningConfig object
+// to ensure any future schema changes (adding/removing a field) surface as a
+// TypeScript compile error rather than a runtime omission.
+// ---------------------------------------------------------------------------
+
+describe("HardeningConfig shape — all 10 required fields are present in the type", () => {
+  it("a complete config object satisfies the HardeningConfig type", () => {
+    // Constructing this object exercises the TypeScript type at test compile
+    // time. At runtime, we only need it to be a plain object (no schema
+    // validation library required).
+    const config: HardeningConfig = {
+      disable_file_editor: true,
+      xmlrpc_mode: "off",
+      restrict_rest_api: "restricted",
+      restrict_login_identifier: "email",
+      force_unique_nickname: true,
+      disable_author_archive_enum: true,
+      force_ssl: true,
+      disable_directory_browsing: true,
+      disable_php_in_uploads: true,
+      protect_system_files: true,
+    };
+
+    expect(Object.keys(config)).toHaveLength(10);
+  });
+
+  it("xmlrpc_mode accepts only on / limited / off", () => {
+    const validModes = ["on", "limited", "off"] as const;
+    for (const mode of validModes) {
+      const config: HardeningConfig = {
+        disable_file_editor: false,
+        xmlrpc_mode: mode,
+        restrict_rest_api: "default",
+        restrict_login_identifier: "both",
+        force_unique_nickname: false,
+        disable_author_archive_enum: false,
+        force_ssl: false,
+        disable_directory_browsing: false,
+        disable_php_in_uploads: false,
+        protect_system_files: false,
+      };
+      expect(config.xmlrpc_mode).toBe(mode);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ban creation — API is called with the right body shape
+//
+// This is a dependency-injection test that follows the same pattern as
+// runBulkBackup in use-bulk-backup.test.ts. We extract the pure validation
+// logic (validateBanValue) and the URL construction (inlined here) to assert
+// that an invalid IP is BLOCKED before the POST fires.
+// ---------------------------------------------------------------------------
+
+describe("ban creation pre-flight — invalid IP is rejected without an API call", () => {
+  const SITE_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+
+  it("an invalid IP address fails client-side validation and does not reach the network", () => {
+    const mockPost = vi.fn();
+
+    // Simulate the exact guard in AddBanForm.handleAdd:
+    const type: BanType = "ip";
+    const value = "999.999.999.999";
+    const validationError = validateBanValue(type, value);
+
+    if (validationError) {
+      // Guard fires — API must NOT be called.
+      // (In the real component, this sets state and returns early.)
+    } else {
+      mockPost(SITE_ID, { type, value, comment: "" });
+    }
+
+    expect(validationError).not.toBeNull();
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("a valid IP address passes client-side validation and would reach the network", () => {
+    const mockPost = vi.fn();
+
+    const type: BanType = "ip";
+    const value = "203.0.113.42";
+    const validationError = validateBanValue(type, value);
+
+    if (!validationError) {
+      mockPost(SITE_ID, { type, value, comment: "" });
+    }
+
+    expect(validationError).toBeNull();
+    expect(mockPost).toHaveBeenCalledWith(SITE_ID, {
+      type: "ip",
+      value: "203.0.113.42",
+      comment: "",
+    });
+  });
+
+  it("a valid CIDR range passes validation and would reach the network", () => {
+    const mockPost = vi.fn();
+
+    const type: BanType = "range";
+    const value = "198.51.100.0/24";
+    const validationError = validateBanValue(type, value);
+
+    if (!validationError) {
+      mockPost(SITE_ID, { type, value, comment: "" });
+    }
+
+    expect(validationError).toBeNull();
+    expect(mockPost).toHaveBeenCalledWith(SITE_ID, {
+      type: "range",
+      value: "198.51.100.0/24",
+      comment: "",
+    });
+  });
+
+  it("a valid user agent passes validation and would reach the network", () => {
+    const mockPost = vi.fn();
+
+    const type: BanType = "user_agent";
+    const value = "EvilScraper/2.0";
+    const validationError = validateBanValue(type, value);
+
+    if (!validationError) {
+      mockPost(SITE_ID, { type, value, comment: "Known scraper bot" });
+    }
+
+    expect(validationError).toBeNull();
+    expect(mockPost).toHaveBeenCalledWith(SITE_ID, {
+      type: "user_agent",
+      value: "EvilScraper/2.0",
+      comment: "Known scraper bot",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Viewer role — write operations are not exposed
+//
+// The canWrite flag is derived from canOperate(me) in the route component.
+// These tests assert the logic of the exported validation helpers in a
+// viewer-equivalent scenario: validation still works (read-only view can still
+// show correct state), but the add-form code path is never reached.
+// ---------------------------------------------------------------------------
+
+describe("viewer role — validateBanValue is safe to call but form is gated upstream", () => {
+  it("validateBanValue returns the expected result regardless of role (pure function)", () => {
+    // A viewer calling validateBanValue gets the same result as an operator.
+    // The canWrite gate lives at the component render level, not inside the
+    // pure validation function. This test pins that the validator has no
+    // implicit role dependency.
+    expect(validateBanValue("ip", "10.0.0.1")).toBeNull();
+    expect(validateBanValue("ip", "not-an-ip")).not.toBeNull();
+  });
+
+  it("viewer flag false means the add form is not rendered (structural assertion)", () => {
+    // In BanListPanel, the AddBanForm is only rendered when canWrite is true.
+    // We simulate this gating logic here — the mock post function must NOT be
+    // called when canWrite is false.
+    const canWrite = false;
+    const mockMutate = vi.fn();
+
+    function simulateBanListPanelSubmit(canWriteFlag: boolean) {
+      if (!canWriteFlag) return; // guard matches the real component
+      mockMutate({ type: "ip", value: "10.0.0.1", comment: "" });
+    }
+
+    simulateBanListPanelSubmit(canWrite);
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("operator flag true means the mutation would be called", () => {
+    const canWrite = true;
+    const mockMutate = vi.fn();
+
+    function simulateBanListPanelSubmit(canWriteFlag: boolean) {
+      if (!canWriteFlag) return;
+      const type: BanType = "ip";
+      const value = "10.0.0.1";
+      const validationError = validateBanValue(type, value);
+      if (!validationError) {
+        mockMutate({ type, value, comment: "" });
+      }
+    }
+
+    simulateBanListPanelSubmit(canWrite);
+    expect(mockMutate).toHaveBeenCalledWith({
+      type: "ip",
+      value: "10.0.0.1",
+      comment: "",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hardening save — dirty-state tracking
+//
+// The hardening panel sends ALL 10 fields on save (no partial PATCH). These
+// tests pin that a change to one field produces a config object that differs
+// from the initial one in exactly the changed field.
+// ---------------------------------------------------------------------------
+
+describe("hardening config — single-field toggle produces correct payload", () => {
+  const BASE_CONFIG: HardeningConfig = {
+    disable_file_editor: false,
+    xmlrpc_mode: "on",
+    restrict_rest_api: "default",
+    restrict_login_identifier: "both",
+    force_unique_nickname: false,
+    disable_author_archive_enum: false,
+    force_ssl: false,
+    disable_directory_browsing: false,
+    disable_php_in_uploads: false,
+    protect_system_files: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("toggling disable_file_editor produces a config with that field flipped", () => {
+    // Simulate the toggle function in HardeningLoaded:
+    const updated = { ...BASE_CONFIG, disable_file_editor: true };
+    expect(updated.disable_file_editor).toBe(true);
+    // All other fields must remain unchanged.
+    const keys = Object.keys(BASE_CONFIG) as (keyof HardeningConfig)[];
+    for (const key of keys) {
+      if (key === "disable_file_editor") continue;
+      expect(updated[key]).toBe(BASE_CONFIG[key]);
+    }
+  });
+
+  it("changing xmlrpc_mode to off produces a config with mode=off", () => {
+    const updated: HardeningConfig = { ...BASE_CONFIG, xmlrpc_mode: "off" };
+    expect(updated.xmlrpc_mode).toBe("off");
+  });
+
+  it("the save payload always contains all 10 fields (no partial omission)", () => {
+    const payload: HardeningConfig = {
+      ...BASE_CONFIG,
+      force_ssl: true,
+    };
+
+    const mockPut = vi.fn();
+    mockPut(payload);
+
+    expect(mockPut).toHaveBeenCalledWith(
+      expect.objectContaining({
+        disable_file_editor: false,
+        xmlrpc_mode: "on",
+        restrict_rest_api: "default",
+        restrict_login_identifier: "both",
+        force_unique_nickname: false,
+        disable_author_archive_enum: false,
+        force_ssl: true,
+        disable_directory_browsing: false,
+        disable_php_in_uploads: false,
+        protect_system_files: false,
+      }),
+    );
+  });
+});

--- a/apps/web/src/features/security/use-hardening.ts
+++ b/apps/web/src/features/security/use-hardening.ts
@@ -1,0 +1,281 @@
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  type UseQueryResult,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { client } from "@wpmgr/api";
+
+import { toError } from "@/features/auth/use-auth";
+
+// Security Suite Phase 1 — hardening config + ban list data hooks.
+//
+// The hardening and ban-list endpoints are hand-rolled Gin routes (NOT in the
+// generated @wpmgr/api SDK). We call them via `client.get/put/post/delete`
+// from the configured Hey API client exactly as `use-scan.ts` does for the
+// integrity scan endpoints.
+//
+// The client is pre-configured (lib/api.ts):
+//   - baseUrl: ""   (same-origin; Vite dev proxy / nginx in prod)
+//   - credentials: "include"  (sends the HttpOnly wpmgr_session cookie)
+//
+// All paths begin with /api/v1 — the prefix the Vite proxy routes to the CP.
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+export type XmlrpcMode = "on" | "off" | "limited";
+export type RestApiAccess = "default" | "restricted";
+export type LoginIdentifier = "username" | "email" | "both";
+
+export interface HardeningConfig {
+  disable_file_editor: boolean;
+  xmlrpc_mode: XmlrpcMode;
+  restrict_rest_api: RestApiAccess;
+  restrict_login_identifier: LoginIdentifier;
+  force_unique_nickname: boolean;
+  disable_author_archive_enum: boolean;
+  force_ssl: boolean;
+  disable_directory_browsing: boolean;
+  disable_php_in_uploads: boolean;
+  protect_system_files: boolean;
+}
+
+export interface HardeningResponse {
+  config: HardeningConfig;
+  /** Optional caveat returned by the server (e.g. "wp-config.php not writable"). */
+  detail?: string;
+}
+
+export type BanType = "ip" | "range" | "user_agent";
+
+export interface Ban {
+  id: string;
+  type: BanType;
+  value: string;
+  comment: string;
+  created_at: string;
+}
+
+export interface BanList {
+  items: Ban[];
+}
+
+export interface BanCreate {
+  type: BanType;
+  value: string;
+  comment: string;
+}
+
+export interface BanCreateResponse {
+  ban: Ban;
+  /** Optional caveat (e.g. "server-level reload required for nginx"). */
+  detail?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Cache key family
+// ---------------------------------------------------------------------------
+
+export const hardeningKeys = {
+  all: ["hardening"] as const,
+  config: (siteId: string) => ["hardening", siteId, "config"] as const,
+  bans: (siteId: string) => ["hardening", siteId, "bans"] as const,
+};
+
+// ---------------------------------------------------------------------------
+// Low-level authenticated helpers (mirrors use-scan.ts pattern)
+// ---------------------------------------------------------------------------
+
+async function apiGet<T>(url: string): Promise<T> {
+  const result = await client.get({ url });
+  if (result.error !== undefined) throw toError(result.error);
+  return result.data as T;
+}
+
+async function apiPut<T>(url: string, body?: unknown): Promise<T> {
+  const result = await client.put({
+    url,
+    body,
+    headers: { "Content-Type": "application/json" },
+  });
+  if (result.error !== undefined) throw toError(result.error);
+  return result.data as T;
+}
+
+async function apiPost<T>(url: string, body?: unknown): Promise<T> {
+  const result = await client.post({
+    url,
+    body,
+    headers: { "Content-Type": "application/json" },
+  });
+  if (result.error !== undefined) throw toError(result.error);
+  return result.data as T;
+}
+
+async function apiDelete(url: string): Promise<void> {
+  const result = await client.delete({ url });
+  if (result.error !== undefined) throw toError(result.error);
+}
+
+// ---------------------------------------------------------------------------
+// useHardeningConfig — GET /api/v1/sites/{siteId}/security/hardening
+// ---------------------------------------------------------------------------
+
+export function useHardeningConfig(
+  siteId: string,
+): UseQueryResult<HardeningResponse, Error> {
+  return useQuery({
+    queryKey: hardeningKeys.config(siteId),
+    queryFn: async () =>
+      apiGet<HardeningResponse>(
+        `/api/v1/sites/${encodeURIComponent(siteId)}/security/hardening`,
+      ),
+    staleTime: 30_000,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useUpdateHardeningConfig — PUT /api/v1/sites/{siteId}/security/hardening
+// ---------------------------------------------------------------------------
+
+export function useUpdateHardeningConfig(
+  siteId: string,
+): UseMutationResult<HardeningResponse, Error, HardeningConfig> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (config: HardeningConfig) =>
+      apiPut<HardeningResponse>(
+        `/api/v1/sites/${encodeURIComponent(siteId)}/security/hardening`,
+        config,
+      ),
+    onSuccess: (updated) => {
+      queryClient.setQueryData<HardeningResponse>(
+        hardeningKeys.config(siteId),
+        updated,
+      );
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useBans — GET /api/v1/sites/{siteId}/security/bans
+// ---------------------------------------------------------------------------
+
+export function useBans(siteId: string): UseQueryResult<Ban[], Error> {
+  return useQuery({
+    queryKey: hardeningKeys.bans(siteId),
+    queryFn: async () => {
+      const data = await apiGet<BanList>(
+        `/api/v1/sites/${encodeURIComponent(siteId)}/security/bans`,
+      );
+      return data.items ?? [];
+    },
+    staleTime: 30_000,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useCreateBan — POST /api/v1/sites/{siteId}/security/bans
+// ---------------------------------------------------------------------------
+
+export function useCreateBan(
+  siteId: string,
+): UseMutationResult<BanCreateResponse, Error, BanCreate> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: BanCreate) =>
+      apiPost<BanCreateResponse>(
+        `/api/v1/sites/${encodeURIComponent(siteId)}/security/bans`,
+        body,
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: hardeningKeys.bans(siteId),
+      });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useDeleteBan — DELETE /api/v1/sites/{siteId}/security/bans/{banId}
+// ---------------------------------------------------------------------------
+
+export function useDeleteBan(
+  siteId: string,
+): UseMutationResult<void, Error, string> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (banId: string) =>
+      apiDelete(
+        `/api/v1/sites/${encodeURIComponent(siteId)}/security/bans/${encodeURIComponent(banId)}`,
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: hardeningKeys.bans(siteId),
+      });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers (exported for tests and components)
+// ---------------------------------------------------------------------------
+
+/** Returns true for a valid IPv4 address. */
+export function isValidIpv4(value: string): boolean {
+  const trimmed = value.trim();
+  return /^(\d{1,3}\.){3}\d{1,3}$/.test(trimmed) &&
+    trimmed.split(".").every((octet) => {
+      const n = parseInt(octet, 10);
+      return n >= 0 && n <= 255;
+    });
+}
+
+/** Returns true for a valid IPv4 CIDR block (e.g. 192.168.0.0/24). */
+export function isValidCidr(value: string): boolean {
+  const trimmed = value.trim();
+  const match = /^(\d{1,3}\.){3}\d{1,3}\/(\d{1,2})$/.exec(trimmed);
+  if (!match) return false;
+  const prefix = parseInt(match[2]!, 10);
+  const ip = trimmed.split("/")[0]!;
+  return (
+    prefix >= 0 &&
+    prefix <= 32 &&
+    ip.split(".").every((octet) => {
+      const n = parseInt(octet, 10);
+      return n >= 0 && n <= 255;
+    })
+  );
+}
+
+/** User-agent strings: non-empty, printable ASCII. */
+export function isValidUserAgent(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.length > 0 && trimmed.length <= 512;
+}
+
+/**
+ * Validates a ban value against its declared type.
+ * Returns null when valid, or a human-readable error string when invalid.
+ */
+export function validateBanValue(type: BanType, value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return "Value is required.";
+  if (type === "ip") {
+    if (!isValidIpv4(trimmed)) {
+      return "Enter a valid IPv4 address (e.g. 203.0.113.42).";
+    }
+  } else if (type === "range") {
+    if (!isValidCidr(trimmed)) {
+      return "Enter a valid IPv4 CIDR block (e.g. 203.0.113.0/24).";
+    }
+  } else if (type === "user_agent") {
+    if (!isValidUserAgent(trimmed)) {
+      return "Enter a non-empty user-agent string (max 512 characters).";
+    }
+  }
+  return null;
+}

--- a/apps/web/src/routes/_authed/sites/$siteId.security.tsx
+++ b/apps/web/src/routes/_authed/sites/$siteId.security.tsx
@@ -1,20 +1,36 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { useMe, canOperate } from "@/features/auth/use-auth";
 import { LoginProtectionPanel } from "@/features/security/login-protection-panel";
 import { LoginEventsTable } from "@/features/security/login-events-table";
 import { ScanPanel } from "@/features/security/scan-panel";
+import { HardeningPanel } from "@/features/security/hardening-panel";
+import { BanListPanel } from "@/features/security/ban-list-panel";
 
-// `/sites/$siteId/security` — three sections:
+// `/sites/$siteId/security` — five sections:
 //
-//   1. Login Protection (S2) — config panel + recent events table.
+//   1. Hardening (Phase 1) — 10 server-hardening toggles grouped into
+//      sub-sections (file/content, XML-RPC, REST API, login, transport).
+//      Backed by hand-rolled Gin: GET/PUT /api/v1/sites/{siteId}/security/hardening.
 //
-//   2. Vulnerabilities — WPScan-based vuln scan (future sprint stub).
+//   2. Ban list (Phase 1) — per-site IP / CIDR / user-agent ban table
+//      with inline add form and delete action.
+//      Backed by hand-rolled Gin: GET/POST/DELETE /api/v1/sites/{siteId}/security/bans.
+//
+//   3. Login Protection (S2) — config panel + recent events table.
+//
+//   4. Vulnerabilities — WPScan-based vuln scan (future sprint stub).
 //      Retained from prior batch. When the scan endpoint lands:
 //        - swap the empty state for an ErrorsTable-style table pattern
 //        - use VulnSeverityChip for severity cells
 //
-//   3. Integrity scan (S3) — core file integrity scan using WordPress.org
+//   5. Integrity scan (S3) — core file integrity scan using WordPress.org
 //      checksums. Powered by hand-rolled Gin endpoints (not in ogen client).
+//
+// Write access gates (PermSecurityManage = operator+):
+//   `canWrite` is derived from `canOperate(me)` which maps to owner/admin/operator.
+//   Viewer-role users see all panels in read-only mode (controls disabled or
+//   hidden, no mutation calls possible).
 
 export const Route = createFileRoute("/_authed/sites/$siteId/security")({
   component: SecurityTab,
@@ -22,10 +38,48 @@ export const Route = createFileRoute("/_authed/sites/$siteId/security")({
 
 function SecurityTab() {
   const { siteId } = Route.useParams();
+  const { data: me } = useMe();
+  const canWrite = canOperate(me);
 
   return (
     <div className="divide-y divide-[var(--color-border)]">
-      {/* ── Section 1: Login protection ── */}
+      {/* ── Section 1: Hardening ── */}
+      <section
+        aria-labelledby="hardening-heading"
+        className="space-y-6 px-4 pb-8 pt-6 sm:px-6"
+      >
+        <h2
+          id="hardening-heading"
+          className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+        >
+          Hardening
+        </h2>
+
+        <HardeningPanel siteId={siteId} canWrite={canWrite} />
+      </section>
+
+      {/* ── Section 2: Ban list ── */}
+      <section
+        aria-labelledby="ban-list-heading"
+        className="space-y-4 px-4 pb-8 pt-6 sm:px-6"
+      >
+        <div>
+          <h2
+            id="ban-list-heading"
+            className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+          >
+            Bans
+          </h2>
+          <p className="mt-1 text-xs text-[var(--color-muted-foreground)]">
+            Block specific IPs, CIDR ranges, or user agents from reaching the
+            site. Rules are applied at the application layer.
+          </p>
+        </div>
+
+        <BanListPanel siteId={siteId} canWrite={canWrite} />
+      </section>
+
+      {/* ── Section 3: Login protection ── */}
       <section
         aria-labelledby="login-protection-heading"
         className="space-y-6 px-4 pb-8 pt-6 sm:px-6"
@@ -45,7 +99,7 @@ function SecurityTab() {
         </div>
       </section>
 
-      {/* ── Section 2: Vulnerabilities (future-sprint stub) ── */}
+      {/* ── Section 4: Vulnerabilities (future-sprint stub) ── */}
       <section
         aria-labelledby="vulnerabilities-heading"
         className="px-4 pb-8 pt-6 sm:px-6"
@@ -70,7 +124,7 @@ function SecurityTab() {
         </div>
       </section>
 
-      {/* ── Section 3: Integrity scan (S3) ── */}
+      {/* ── Section 5: Integrity scan (S3) ── */}
       <section
         aria-labelledby="integrity-scan-heading"
         className="space-y-4 px-4 pb-8 pt-6 sm:px-6"

--- a/docs/adr/ADR-057-security-suite-foundation.md
+++ b/docs/adr/ADR-057-security-suite-foundation.md
@@ -1,0 +1,129 @@
+# ADR-057 — Security Suite Foundation: Per-Site Policy Model
+
+**Status:** Accepted  
+**Date:** 2026-06-20  
+**Phase:** 1 of 7 (hardening tweaks + ban list)
+
+---
+
+## Context
+
+WPMgr already ships a login-protection config (`site_security_config`, m13) and
+brute-force lockout via the `sync_security_config` signed command (S2). The
+security-suite plan adds six phases of new capabilities (hardening tweaks, full
+file-integrity, site-user 2FA + passwords, WAF/virtual-patching, cross-fleet IP
+reputation, geo-advanced auth) that all need the CP to store per-site policy and
+push it to the agent via signed commands.
+
+This ADR records the shared model that all six phases build on, plus the
+Phase 1-specific data decisions.
+
+---
+
+## Decision
+
+### 1. Per-site policy ownership
+
+The **control plane owns the canonical policy**. The agent is a stateless
+consumer: it applies whatever the CP sends via a signed command. The agent never
+independently stores or mutates the policy.
+
+The CP→agent transport is the existing signed-command channel: a JWT-bearing
+POST to `/wp-json/wpmgr/v1/command/<verb>` (Ed25519, single-use jti,
+`aud`=siteId). This is identical to how `sync_security_config`,
+`sync_error_config`, `perf_config_update`, and `sync_email_config` work.
+
+### 2. Extensibility across phases
+
+The policy is split across multiple narrowly-scoped tables (one per feature
+cluster) rather than a single fat config blob:
+
+| Phase | Table(s) | Sync command |
+|-------|----------|--------------|
+| 1 (current) | `site_security_hardening_config` + `site_security_bans` | `sync_security_hardening` |
+| 3 (site-user 2FA) | `site_security_auth_policy` (future) | `sync_security_auth_policy` (future) |
+| 4 (WAF rules) | `site_waf_rules` (future) | `sync_waf_rules` (future) |
+
+Each phase adds its own table and signed command. The agent accumulates them
+independently; they do not conflict.
+
+### 3. Sync trigger
+
+Config is pushed immediately on every successful write (same pattern as
+`sync_security_config` and `sync_perf_config`). The push is best-effort: a
+push failure is surfaced as an `X-Agent-Push-Warning` header with 200 OK so
+the UI can show a warning without discarding the stored config. The agent
+applies the LAST successfully pushed state; a failed push is retried the next
+time the operator saves.
+
+Ban-list changes (create/delete) each trigger a full re-push of the current
+config + ban list so the agent always receives a consistent snapshot.
+
+### 4. Per-site scope for v1
+
+All Phase 1 tables are keyed on `site_id`. Org-wide defaults (one row that
+propagates down to all sites) are deferred to a later enhancement and are not
+in scope for this ADR.
+
+### 5. Hardening config — typed columns (not JSONB)
+
+Phase 1 hardening toggles are stored as **typed boolean/enum columns** in
+`site_security_hardening_config`, NOT as a JSONB blob. Rationale:
+
+- Each toggle has a named semantic that is stable (the agent engineer maps it
+  to a specific hook or define). A typed column makes the contract explicit and
+  prevents drift between Go and PHP definitions.
+- Postgres enforces NOT NULL + DEFAULT at the column level, giving safe
+  defaults with no application-level unmarshalling.
+- Adding a new toggle is a migration + one column; removing a deprecated one
+  is a `DROP COLUMN IF EXISTS` — both are straightforward.
+- JSONB would give flexibility at the cost of correctness: a misspelled key
+  silently becomes a no-op rather than a compile/parse error.
+
+The enum columns (`xmlrpc_mode`, `restrict_rest_api`, `restrict_login_identifier`)
+are stored as `text` with a CHECK constraint, matching the existing `mode` column
+on `site_security_config`.
+
+### 6. Ban list table
+
+`site_security_bans` stores durable per-site IP/CIDR/user-agent bans. The
+ban list is included in the `sync_security_hardening` push so the agent receives
+both hardening config and bans in one atomic command.
+
+Design choice: `site_id` is NOT NULL (bans are per-site in v1). Fleet-wide
+bans are a Phase 5 / network-brute-force enhancement.
+
+IP/CIDR values are validated at write time (`net.ParseIP` / `net.ParseCIDR`).
+Duplicates (same `site_id`, `type`, `value`) are rejected with a `409 Conflict`
+domain error before reaching the DB.
+
+### 7. Agent-side follow-ups (out of scope for Phase 1 CP build)
+
+The following are action/report verbs — not config — and belong in the agent
+step:
+
+- **Salts regeneration** — one-time action, not a stored toggle; the agent
+  runs it and reports back.
+- **File permissions audit** — read-only scan; the agent runs it and pushes
+  the result.
+- **DB prefix change** — destructive DDL; orchestrated as a task, not config.
+
+These are noted as Phase 1 agent-side follow-ups and will be tracked in the
+agent specialist's brief.
+
+---
+
+## Consequences
+
+- Every Phase N table must follow the m13/m36 RLS template (ENABLE + FORCE +
+  `_tenant_isolation` policy + `_agent` policy + WITH CHECK on both).
+- The `sync_security_hardening` contract is the handoff point for the agent
+  engineer. The CP ships the contract definition; the agent implements the
+  receiver.
+- A new `PermSecurityManage` permission gates the hardening config and ban
+  list routes at `Operator+`, consistent with `PermSiteCacheManage` and
+  `PermEmailManage`.
+- The Phase 1 handler lives in the existing `internal/security` package
+  (handler.go, service.go, repo.go extensions) so the domain stays in one
+  place and the existing security handler's `Register` call site continues
+  to work.

--- a/docs/security/security-suite-plan.md
+++ b/docs/security/security-suite-plan.md
@@ -1,0 +1,286 @@
+# Security suite: feature-parity gap analysis + build plan
+
+> Built from a clean-room study of a leading commercial WordPress security plugin (GPLv2 reference kept OUTSIDE this repo, never committed or shipped). We replicate techniques and coverage with original code; we never copy the reference's source and never name it in shipped code.
+
+## Decisions locked (2026-06-20)
+- **Start:** Phase 1 (WordPress hardening tweaks + durable ban list) now — zero external-feed decisions, highest value/effort.
+- **Phase 4 vulnerability feed:** plan around **Wordfence Intelligence** (free vulnerability data); we author virtual-patch WAF rules for top CVEs ourselves. (Patchstack/WPScan remain paid upgrade options for turnkey vPatch rules.)
+- Build is CP-first, split across agent / control-plane / dashboard specialists, every feature ships its named test + docs DoD.
+
+## Gap counts
+**Totals (deduped across clusters — counting distinct the reference security features):** ~78 distinct features.
+
+- **HAVE (shipped today): 6** — early-IP WAF deny gate, sliding-window brute-force lockout, agent hash-chained activity log, CP append-only audit log + verify, WP.org core-checksum file-integrity scan, operator-dashboard 2FA (TOTP+passkeys). Plus self-contained infra (RLS/RBAC/superadmin, uptime+TLS monitoring, autologin) that has no direct the reference equivalent but covers the "remote management" role.
+- **PARTIAL (related capability, incomplete): ~18** — lockout→ban escalation, ban list, firewall engine (deny-only, no parameter rules), firewall lockout/logging, scheduled scans, security-check-pro probe (CP can probe), file-change engine (core-only), file-writing (perf suite writes config), online plugin-checksums infra, user-groups (CP RBAC only), notification center (CP alerts only), global settings, dashboard cards, server-config writer, geolocation (DB-IP ASN lib), CP operator TOTP/passkeys/backup-codes vs site-user, user action logging (activity log covers most), light DB backup (full backup suite).
+- **MISSING (not in WPMgr): ~54.**
+
+**Biggest missing clusters (by count and by value):**
+1. **Vulnerability + malware scanning (entire domain) — ~9 features missing, all P1/P2, all gated on a feed decision.** This is the largest single gap and the headline product capability.
+2. **WordPress hardening tweaks — ~13 features missing**, all self-contained, cheap, high parity-optics value (disable file editor, XML-RPC, REST restriction, SSL enforce, salts, db-prefix, admin-user, etc.).
+3. **WP-site-user 2FA + password security — ~13 features missing** (TOTP/email/backup for managed-site users, interstitial, onboarding, strong-pw, HIBP, requirements engine, expiration). WPMgr only has *operator* 2FA today.
+4. **Firewall parameter-rule engine + virtual patching — ~5 features**, P1, partly gated on the same feed.
+5. **Server-config hardening (system-tweaks, file-perms, hide-backend, ban-rules) — ~8 features**, self-contained, P2.
+6. **Pro advanced auth (passwordless/magic-link, site-user passkeys, fingerprinting/trusted-devices, restrict-by-country, version-mgmt) — ~9 features**, P3, several geo/feed-gated.
+
+**Replicability split of the missing/partial set:** ~75% self-contained (copy/reimplement, no service), ~15% needs-feed (free or buildable: HIBP, plugin checksums, IP reputation), ~10% needs a paid/operator service (vuln+malware feed, CAPTCHA, MaxMind paid tier).
+
+## Strategic recommendation
+## Strategic Recommendation
+
+**The honest shape of this:** ~75% of the reference plugin is plain GPL PHP you can re-implement with no service at all, and WPMgr is unusually well-positioned to host the rest because it's *already* a fleet manager with a Go control plane, centralized login-event ingestion, an SSRF-hardened outbound prober, a CP-signed updater, and a hash-chained audit log. So "bulletproof parity" is mostly a build-it problem, not a buy-it problem — with exactly **one** genuine buy-vs-build fork.
+
+**Quick parity (do first, no decisions needed):** the WordPress hardening tweaks (Phase 1) and full file-integrity (Phase 2) are cheap, self-contained, and immediately make WPMgr look like a real security product. These ~25 features carry the best value/effort ratio and should ship before anything feed-dependent. Site-user 2FA + password policy (Phase 3) is the next-best self-contained block and closes the most glaring gap (today only *operators* have 2FA; managed-site users have none).
+
+**The hard, service-dependent moat is the vulnerability + malware feed.** This is the only thing copying GPL code cannot give you. The WAF *engine* and the whole scan/scheduling/fixer pipeline are copyable; the *data* (which plugin version is vulnerable, the per-CVE virtual-patch rules) is a recurring feed cost. Everything the reference vendor charges for ultimately rides on this one hosted DB. There is no free-code substitute.
+
+**What WPMgr can own without any third party** (and should, because it's differentiating): cross-fleet IP reputation (you already ingest every site's login events — this is *better* positioned than the reference vendor' opt-in network), the SSL/proxy/real-IP-header probe (CP already probes sites), HIBP compromised-passwords (free public API), and WP.org checksums (already have core; plugins are free to add).
+
+**Build-first order:** Phase 1 (hardening) → Phase 2 (file integrity) → Phase 3 (site-user auth) — all parallelizable across agent/CP/dashboard specialists, all shippable before any feed contract. Then the scanner (Phase 4) once Gate 0 is decided.
+
+**Product decisions you must make before we start building the gated phases:**
+1. **Vulnerability feed: free vs paid.** Wordfence Intelligence is free and the most cost-effective vuln data source, but ships *no* WAF rules — you'd hand-author vPatch rules for top CVEs. Patchstack is paid but ships ready-made vPatch rules (closest to the reference's actual moat). WPScan is another paid option. Decide: free-vuln-data + self-authored-rules, or pay Patchstack for turnkey vPatch. This gates Phase 4.
+2. **Malware/blocklist verdicts.** Separate from vuln data. Google Safe Browsing (free-ish) / Sucuri / VirusTotal / your own crawler. Decide scope — or defer malware-content scanning to a later release and ship vuln-only first.
+3. **Geo feed.** Extend the existing offline DB-IP lib (free, you already own the asset) vs ship MaxMind GeoLite2 (license key). Gates Phase 6 only — low urgency.
+4. **CAPTCHA.** Confirm "operator brings their own keys" is acceptable (it is the only sane model) — pluggable reCAPTCHA/Turnstile/hCaptcha.
+5. **Network brute-force positioning.** Confirm we build the shared IP-reputation list *in-house* off existing event ingestion (recommended — it's a natural moat and needs no third party) rather than integrating AbuseIPDB.
+
+**Net take:** Greenlight Phases 1-3 immediately (no decisions, high parity optics, ~75% of the feature count). Make the vuln-feed decision in parallel so Phase 4 — the actual differentiator — can start the moment Phases 1-2 free up the specialists. Treat the IP-reputation and SSL-probe features as in-house wins to highlight, since WPMgr can do them *better* than the reference vendor by virtue of being the fleet itself.
+
+## What we cannot simply copy (data, not code)
+**Plain answer: the code is all copyable; the *data* and the *license/update plumbing* are not.**
+
+the reference plugin is GPLv2, so every line of its PHP — the lockout counters, ban list, hide-backend, the bundled Patchstack WAF *engine*, 2FA/TOTP/WebAuthn, password requirements, file-change hashing, server-config generators, hardening tweaks, the user-groups policy model, notification center — is legally and technically replicable. We can re-implement all of it agent-side and CP-side. Copying the GPL plugin gives you the *mechanics* of every feature.
+
+**What you do NOT get by copying code — three categories:**
+
+1. **Hosted DATA FEEDS (the actual moat).** These are populated and served by the reference vendor/Patchstack and carry the value:
+   - **`the reference's hosted vulnerability/malware feed`** — the Patchstack-sourced **vulnerability + malware + virtual-patch rule database**. The plugin only sends an inventory and renders the answer; the firewall has *zero rules* without this feed. This is the single biggest non-replicable dependency. Build-or-buy: license **Patchstack** or **WPScan** vulnerability API, or build CVE ingestion from **Wordfence Intelligence** (the free vuln feed — most cost-effective) + the WordPress.org `.well-known` plugin-vulnerabilities feed; the WAF executor engine itself is copyable so we'd author/import vPatch rules separately.
+   - **`the reference's hosted IP-reputation API`** — the **cross-fleet IP-reputation blocklist** for network brute force. Code gives you the client, not the shared list. **We can build this ourselves** — WPMgr already centrally ingests every managed site's login events, so the CP is a natural fleet-wide reputation aggregator. Optional augment: AbuseIPDB/StopForumSpam/Spamhaus.
+   - **MaxMind/GeoLite2** geolocation DB (for fingerprinting / restrict-by-country). A licensed binary data feed; we'd ship GeoLite2 or extend our existing offline DB-IP lib.
+
+2. **The LICENSE + UPDATE SERVER** (`the reference's license/update server` / `the reference's license/update server`). Gates which Pro modules load and delivers updates. A clone has no access. **Already solved** for WPMgr — we ship a CP-signed agent update manifest (ADR-042); the agent has no license gate.
+
+3. **Operator-keyed third-party SaaS** (CAPTCHA: reCAPTCHA/Turnstile/hCaptcha) — not replicable by code, but inherently pluggable: the operator supplies their own keys. That's acceptable, not a blocker.
+
+**Free/public feeds that look like dependencies but aren't a problem:** HIBP Pwned Passwords (free, k-anonymous, no key) and the WordPress.org core/plugin checksum + salt APIs (free, public) — we call them directly and cache in the CP.
+
+**Bottom line:** The only thing money/effort genuinely buys that copying GPL code cannot is the **vulnerability/malware feed**. Everything else is either self-buildable (IP reputation, SSL-proxy probe, release-dates), free-public (HIBP, WP.org checksums), operator-supplied (CAPTCHA), or already solved (our own updater).
+
+## External services + our replacement strategy
+## External Services the reference Depends On + WPMgr Replacement Strategy
+
+| # | Service / Endpoint | Purpose | Data sent | Returns | Auth | Free? | WPMgr replacement strategy |
+|---|---|---|---|---|---|---|---|
+| 1 | **the reference's hosted vulnerability/malware feed** `POST /api/scan` (Accept v1.1) | Master site scan: vuln + blocklist + malware | `{wordpress, plugins{slug:ver}, themes{slug:ver}, mutedIssues[]}` | `{entries:{vulnerabilities[]+firewall_rules, blacklist[], malware[]}}` | HMAC-SHA1 over body w/ license key (or X-SiteRegistration) | No (Patchstack/the reference vendor commercial) | **BUILD a CP-owned scanner orchestrator** that ingests a vulnerability feed (decision below) and matches agent-shipped software inventory. This is the moat — biggest decision. |
+| 2 | same host `GET /available-firewall-rules?ids[]` | Which vulns have a vPatch rule | ps-vuln-ids | subset of ids | license HMAC | No | Comes free if we license a feed that ships WAF rules (Patchstack); otherwise author our own vPatch rules. |
+| 3 | same host `POST /api/register-site` | Unlicensed sub-site verify handshake | `{url, keyPair, verifyTarget}` | `{key}` | — | No | **Not needed** — WPMgr CP↔agent is already a trusted Ed25519 channel. |
+| 4 | **the reference's hosted IP-reputation API** `?action=check-ip / report-ip / request-key / activate-key` | Cross-fleet brute-force IP reputation | `{apikey, behavior, ip, site, timestamp, login{details,agent}}` + HMAC | `{block, cache_ttl, report_ttl}` | apikey + HMAC-SHA1 secret | No (proprietary network) | **BUILD our own** — WPMgr already centrally ingests every managed site's login events (IngestLoginEvents). The CP is the natural cross-fleet reputation aggregator: serve a shared blocklist back to agents. Optional 3rd-party augment: AbuseIPDB / StopForumSpam / Spamhaus DROP. |
+| 5 | **api.pwnedpasswords.com** `GET /range/{5}` | Compromised-password check (HIBP) | first 5 hex of SHA1 (k-anonymity) | `SUFFIX:COUNT` lines | none | **YES (free, no key)** | **Call directly** — proxy through CP to cache the corpus fleet-wide, or call from agent. Optionally self-host the downloadable HIBP corpus (~25-40GB). |
+| 6 | **ssl-proxy-detect** `POST /` + `GET /config.json` | External callback to find real-IP `$_SERVER` header + TLS support | `{site, key:time:HMAC, pid}` | `{complete, remote_ip?, ssl_supported?}` | time-HMAC | No (their prober) | **BUILD in CP** — WPMgr api already makes outbound probes (uptime/TLS). Have CP POST a signed nonce then hit the site over http+https from CP IPs; agent reports which header held the CP's known IP. Zero third party. |
+| 7 | **api.wordpress.org/core/checksums/1.0/** | Official WP core file md5s | version+locale | `{checksums:{path:md5}}` | none | **YES** | **Already have** (apps/api/internal/scan/checksums.go, Postgres-cached 30d/6h). |
+| 8 | **downloads.wordpress.org/plugin-checksums/{slug}/{ver}.json** | Official .org plugin file md5s | (URL only) | `{files:{path:{md5}}}` | none | **YES** | **Wire it** — extend the CP checksum cache to plugins; agent verifies plugin files. |
+| 9 | **api.wordpress.org/plugins/info/1.0/** | Is slug a real .org plugin | `action=plugin_information, request=serialize({slug})` | plugin info | none | **YES** | Call from CP when deciding whether plugin-checksum verification applies. |
+| 10 | **api.wordpress.org/secret-key/1.1/salt/** | Fresh wp-config salts | none | 8 define() lines | none | **YES (fallback only)** | **Generate locally** in agent (crypto/rand / random_int) — no network needed. |
+| 11 | **s3.amazonaws.com/package-hash/** | the reference vendor' OWN product file hashes | package+version | `{path:md5}` | none | proprietary | **Not needed** — for our own first-party plugins, publish a signed checksum manifest (ADR-042 updater already does this). |
+| 12 | **s3.amazonaws.com/downloads/.../wordpress-release-dates.json** | WP version→release date for "outdated" age scoring | none | version→date map | none | proprietary-hosted but trivial | **Self-generate** a static JSON in CP. |
+| 13 | **geoip.maxmind.com/geoip/v2.1/city** + **download.maxmind.com geoip_download (GeoLite2)** + **ip-api.com/json** | IP→country/city/latlong for fingerprinting, restrict-admin, maps | IP | geo | MaxMind acct/key (ip-api free) | mixed | **Extend WPMgr's existing offline DB-IP lib** (already used for ASN/host detection) to city/country, or ship GeoLite2 mmdb in CP with a license key. Data-feed decision. |
+| 14 | **www.google.com/recaptcha/api/siteverify** · **hcaptcha.com/siteverify** · **challenges.cloudflare.com/turnstile/v0/siteverify** | CAPTCHA bot verdicts | token+secret+remoteip | success/score | operator keys | provider tiers | **Pluggable per-site** — agent calls whichever the operator configures with their own keys. Not replicable by code; that's fine. |
+| 15 | **qr-code** | TOTP enroll QR (fallback) | otpauth URI (incl username) | QR PNG | none | — | **Render locally** (GD / client-side JS QR). WPMgr operator TOTP already does this. |
+| 16 | **api.mapbox.com / api.mapquestapi.com** | Static map image of login IP in emails | latlong+key | PNG | operator key | provider tiers | Cosmetic — drop or pluggable with operator key. |
+| 17 | **vendor notices/news endpoints** | Vendor notices + dashboard news card | none | JSON | none | free | Drop (vendor marketing). WPMgr CP owns notices. |
+| 18 | **the reference's license/update server / the reference's license/update server (/updater)** | Pro license validation + Pro module delivery | PBKDF2 auth_token + packages | update package | license | proprietary | **Replaced** by WPMgr's CP-signed agent update manifest (ADR-042). |
+| 19 | **the reference's license/update server/app-passwords/...** | Cross-site settings-import app-password broker | OAuth-ish | app password | app_id | proprietary | Not needed — CP owns config; if cross-site import wanted, broker it ourselves. |
+
+**Net external-service picture:** Free/public and directly callable — HIBP (5), WP.org core+plugin checksums+info+salt (7-10). Build-in-CP (no third party) — IP reputation (4), SSL/proxy probe (6), release-dates (12). Genuine third-party with operator keys — CAPTCHA (14), MaxMind paid tier (13). The one strategic buy-vs-build — the **vulnerability+malware feed (1,2)**.
+
+## Feature matrix
+## the reference plugin — Full Feature Matrix vs WPMgr
+
+Status legend: **have** = shipped in WPMgr today · **partial** = related capability exists but incomplete · **missing** = not in WPMgr. Replicable: **self** = copyable from GPL code · **needs-feed** = code copyable but value needs a data feed · **needs-svc** = requires a third-party SaaS the operator configures. Priority P1 (table-stakes for "bulletproof") → P4 (cosmetic/optional). Effort in rough eng-weeks (agent+CP+dash combined).
+
+### Domain: Login attack protection
+| Feature | What it does | Technique | Layer | External service | WPMgr status | Replicable | Priority | Effort |
+|---|---|---|---|---|---|---|---|---|
+| Local brute-force lockout (per-IP + per-user) | Lock host/user after N fails in a window; optional instant 'admin' ban | authenticate@10000 + temp/lockouts COUNT-in-window | WP-PHP | none | **have** (sliding-window 3-tier in class-login-protection.php) | self | P1 | done |
+| Lockout→permanent-ban escalation | Repeated lockouts promote a host to a durable ban | create_lockout() blacklist threshold → bans | WP-PHP | none | **partial** (has per-IP temp block + global tier; no durable promote-to-ban list) | self | P1 | 0.5 |
+| Network brute-force (shared IP reputation) | Block IPs flagged across the fleet; report local offenders | HMAC-signed check-ip/report-ip to ipcheck-api | SaaS-call | the reference vendor IPCheck | **missing** (but WPMgr already ingests every site's login events centrally) | needs-svc OR self-build | P1 | 3 |
+| NBF key registration/activation | Self-service apikey+secret fetch | request-key/activate-key | SaaS-call | the reference vendor IPCheck | **n/a** (replaced by WPMgr CP auth) | self | P3 | incl. above |
+| Ban Users — durable IP/range ban list | Manual + auto IP/CIDR/user-agent bans | bans + Lib_IP_Tools intersect | WP-PHP | none | **partial** (deny_cidrs in config, no managed ban-list CRUD / comments / actor) | self | P1 | 1 |
+| Ban Users — server-config (.htaccess/nginx) ban rules | Push bans to web-server for pre-PHP block | config-generators emit Deny/deny | server-config | none | **missing** (WPMgr blocks at mu-plugin PHP layer only) | self | P2 | 1.5 |
+| Default blocklist (HackRepair bundled) | Static bad-bot/UA list | bundled .inc | server-config | none (bundled) | **missing** | self | P3 | 0.5 |
+| Ban custom user-agents | Deny operator-supplied UA strings | config-generators 403 rules | server-config | none | **missing** | self | P3 | 0.5 |
+| Hide Backend (secret login slug) | Move wp-login/wp-admin to secret slug + token | setup_theme request routing + token cookie | WP-PHP | none | **missing** | self | P2 | 1.5 |
+| Email confirmation state | Track confirmed/unconfirmed email | after_password_reset/profile_update meta | WP-PHP | none | **missing** | self | P4 | 0.5 |
+| Early-IP WAF deny gate | 403 deny_cidrs before WP boots | a-wpmgr-waf.php mu-plugin | WP-PHP | none | **have** | self | — | done |
+
+### Domain: Two-factor / strong auth (WP site side)
+| Feature | What it does | Technique | Layer | External | WPMgr status | Replicable | Priority | Effort |
+|---|---|---|---|---|---|---|---|---|
+| Pluggable 2FA provider architecture | Swappable TOTP/Email/Backup per-user | Two_Factor_Provider abstract + filters | WP-PHP | none | **missing** (WPMgr has OPERATOR 2FA, not managed-site-user 2FA) | self | P2 | 2 |
+| TOTP (authenticator app) | RFC-6238 codes, QR enroll | calc_totp + local GD QR | WP-PHP | qr-code (fallback only) | **partial** (CP operator TOTP exists; site-user TOTP missing) | self | P2 | incl. |
+| Email 2FA code | Mail a one-time code | wp_hash token + notification center | WP-PHP | none (site mailer) | **missing** | self | P2 | 1 |
+| Backup codes | 10 single-use recovery codes | wp_hash_password set in meta | WP-PHP | none | **partial** (operator recovery codes exist; site-user missing) | self | P3 | 0.5 |
+| Login interstitial enforcement | Demand 2FA after password | Login_Interstitial signed session | WP-PHP | none | **missing** | self | P2 | 1 |
+| 2FA onboarding + reminders | Guided setup, re-prompt cadence | interstitial + reminder notification | WP-PHP | none | **missing** | self | P3 | 1 |
+| Per-group enforcement + risk-based | Force 2FA by group / weak-pw / vuln-site | requirement_reason matcher | WP-PHP | none (vuln-site needs feed) | **missing** | self | P2 | 1 |
+| Remember-device (trusted, 30d) | Skip 2FA on known device | hashed cookie + fingerprint ≥85% | WP-PHP | none (needs fingerprint lib) | **missing** | partial | P3 | 1 |
+| Application Passwords hardening | Scope app-passwords REST/XML-RPC + RO/RW | wp_authenticate_application_password_errors | WP-PHP | none | **missing** | self | P3 | 1 |
+| Block XML-RPC for 2FA users | Reject pw-based XML-RPC for 2FA users | authenticate@100 | WP-PHP | none | **missing** | self | P3 | 0.25 |
+| CAPTCHA on auth forms | reCAPTCHA/Turnstile/hCaptcha | provider siteverify | SaaS-call | Google/CF/hCaptcha | **missing** | needs-svc | P3 | 1.5 |
+| the reference vendor Sync remote 2FA mgmt | Remote list/override 2FA | inbound sync verbs | SaaS-call | the reference vendor Sync | **n/a** (WPMgr CP is the replacement) | self | P4 | incl. CP |
+
+### Domain: Password security
+| Feature | What it does | Technique | Layer | External | WPMgr status | Replicable | Priority | Effort |
+|---|---|---|---|---|---|---|---|---|
+| Refuse compromised passwords (HIBP) | Reject breached passwords | k-anonymity SHA1 range query | WP-PHP+SaaS | api.pwnedpasswords.com (free) | **missing** | needs-feed (free) | P2 | 1 |
+| Strong password (zxcvbn 4) | Force strong pw on set/change | vendored zxcvbn-php server-side | WP-PHP | none | **missing** | self | P2 | 1 |
+| Strong-password admin scanner | Flag admins without strong pw | cached strength meta → REST issues | WP-PHP | none | **missing** | self | P3 | 0.5 |
+| Password requirements engine | Validate/reuse-block/last-changed/forced-change interstitial | hooks + meta registry | WP-PHP | none | **missing** | self | P2 | 1.5 |
+| Password age/expiration | Force change after N days | time math vs last-changed | WP-PHP | none | **missing** | self | P3 | 0.5 |
+
+### Domain: Firewall / WAF
+| Feature | What it does | Technique | Layer | External | WPMgr status | Replicable | Priority | Effort |
+|---|---|---|---|---|---|---|---|---|
+| Application firewall rule engine | Inspect request, BLOCK/LOG/REDIRECT/WHITELIST | vendored Patchstack Processor, mu-early | WP-PHP | none (engine) | **partial** (early-IP WAF deny only; no parameter-rule engine) | self | P1 | 3 |
+| Virtual-patching auto-ingest | Vuln→firewall rule auto-create/clean | Ingestor on vulnerability_was_seen | WP-PHP | scanner feed | **missing** | needs-feed | P1 | 1.5 |
+| Firewall rule SOURCE / remote feed | Per-vuln WAF rules pulled per-site | scan response firewall_rules[] | SaaS-call | site-scanner (Patchstack) | **missing** | needs-svc | P1 | gated |
+| User-defined firewall rules + REST | Operator CRUD custom rules | REST/Rules + Repository | WP-PHP | none | **missing** | self | P2 | 1 |
+| Firewall-triggered lockout | Rate-limit rule-hit IPs | type=lockout do_lockout | WP-PHP | none | **partial** (login lockout exists; not rule-hit) | self | P2 | 0.5 |
+| Firewall logging + Site Health | Record blocks + rule counts | Logs filters + add_action | WP-PHP | none | **partial** (activity log exists, no firewall events) | self | P2 | 0.5 |
+| Protect system files (.htaccess) | Deny readme/wp-config/install/.git | system-tweaks config-gen | server-config | none | **missing** | self | P2 | 1 |
+| Disable directory browsing | Options -Indexes | config-gen | server-config | none | **missing** | self | P3 | 0.25 |
+| Disable PHP exec in uploads/plugins/themes | Block direct .php execution | per-dir RewriteRule [F] | server-config | none | **missing** | self | P2 | 0.5 |
+| Server-config writer (Apache/LiteSpeed/nginx) | Materialize rules into config | Lib_Config_File marker blocks | server-config | none | **partial** (perf/cache suite already writes .htaccess/nginx) | self | P2 | 1 |
+
+### Domain: Vulnerability + malware scanning
+| Feature | What it does | Technique | Layer | External | WPMgr status | Replicable | Priority | Effort |
+|---|---|---|---|---|---|---|---|---|
+| Site Scan (master: vuln+blocklist+malware) | One scan → result code + issues | inventory POST, server returns findings | SaaS-call | site-scanner | **missing** | needs-svc | P1 | gated |
+| Known-vuln detection (plugin/theme/core) | List CVEs + severity + fixed_in | server-side slug+version match | SaaS-call | Patchstack feed | **missing** | needs-feed | P1 | gated |
+| Virtual-patch availability badge | Show which vulns are WAF-patchable | available-firewall-rules | SaaS-call | scanner | **missing** | needs-feed | P2 | incl. |
+| Domain blocklist check | Flag domain on reputation lists | server-side aggregate (incl Sucuri) | SaaS-call | scanner/Sucuri | **missing** | needs-svc | P2 | 2 |
+| Malware content scan | Detect site serving malware | external scan by URL | SaaS-call | scanner | **missing** | needs-svc | P1 | gated |
+| Sub-site verify handshake | Prove site ownership pre-scan | keyPair + REST verify | SaaS-call+WP | scanner | **n/a** (WPMgr CP↔agent already trusted) | self | P4 | incl. |
+| Vulnerability Fixer (auto-remediate) | One-click update to fixed version | WP upgrader gated by caps | WP-PHP | none (uses .org updates) | **missing** | self | P2 | 1 |
+| Scheduled/recurring scans | Auto-scan on schedule + retry/back-off | scheduler loop + exponential back-off | WP-PHP wrapping SaaS | scanner | **partial** (WPMgr has River scan orchestration for core-integrity) | partial | P2 | 1 |
+| Security Check Pro (proxy/IP-header + TLS probe) | External callback finds real-IP header + SSL | inbound HMAC callback | SaaS-call+WP | ssl-proxy-detect | **partial** (CP already probes sites for uptime/TLS — natural fit) | self (CP-side) | P2 | 1 |
+
+### Domain: File integrity + filesystem hardening
+| Feature | What it does | Technique | Layer | External | WPMgr status | Replicable | Priority | Effort |
+|---|---|---|---|---|---|---|---|---|
+| File-change detection (core engine) | Hash whole FS, diff vs baseline, report A/C/R | chunked resumable md5+mtime walker | WP-PHP | none | **partial** (CP-orchestrated CORE scan exists; no full-FS baseline/diff) | self | P2 | 1.5 |
+| Baseline + self-write expected-hashes | Store last-good + own writes to avoid FPs | Distributed_Storage + expected_hashes | WP-PHP | none | **missing** | self | P2 | 1 |
+| Online verify — WP.org CORE checksums | Compare core files to official md5 | core/checksums API | SaaS-call | api.wordpress.org (free) | **have** (checksums.go, Postgres-cached) | self | — | done |
+| Online verify — WP.org PLUGIN checksums | Verify .org plugin files | plugin-checksums json | SaaS-call | downloads.wordpress.org (free) | **missing** | needs-feed (free) | P2 | 1 |
+| Online verify — vendor S3 package hashes | Verify vendor's own products | s3 package-hash | SaaS-call | the reference vendor S3 (proprietary) | **partial** (WPMgr has ADR-042 signed-manifest updater for own agent) | self | P4 | incl. |
+| File-change notify + log + sync verb | Email + audit-log + remote read | notification center + Log | WP-PHP | none | **partial** (audit log exists) | self | P3 | 0.5 |
+| File permissions audit | List actual vs recommended perms | fileperms() read-only | WP-PHP | none | **missing** | self | P3 | 0.5 |
+| File writing (managed .htaccess/nginx/wp-config) | Write delimited managed blocks | Lib_Config_File update_* | server-config | none | **partial** (perf suite writes config; no wp-config block writer) | self | P2 | 1 |
+
+### Domain: WordPress hardening tweaks
+| Feature | What it does | Technique | Layer | External | WPMgr status | Replicable | Priority | Effort |
+|---|---|---|---|---|---|---|---|---|
+| Disable file editor | DISALLOW_FILE_EDIT | wp-config define | WP-PHP | none | **missing** | self | P2 | 0.25 |
+| XML-RPC control (disable/pingbacks) | 3-state XML-RPC control | filters + server-config deny | WP-PHP+config | none | **missing** | self | P2 | 0.5 |
+| Block XML-RPC multiauth | Stop system.multicall amplification | authenticate@0 405-die | WP-PHP | none | **missing** | self | P3 | 0.25 |
+| REST API restriction | Gate users/comments/etc anon access | rest_dispatch_request cap checks | WP-PHP | none | **missing** | self | P2 | 0.5 |
+| Login identifier restriction | Email/username/both only | remove authenticate filters | WP-PHP | none | **missing** | self | P3 | 0.25 |
+| Force unique nickname | Prevent username harvesting | profile_update hook | WP-PHP | none | **missing** | self | P3 | 0.25 |
+| Disable zero-post author archives | 404 author enum pages | template_redirect 404 | WP-PHP | none | **missing** | self | P3 | 0.25 |
+| Enforce SSL / force HTTPS | Redirect + FORCE_SSL_ADMIN + URL rewrite | wp-config + filters | WP-PHP | none | **missing** | self | P3 | 0.5 |
+| Regenerate salts/keys | Rotate 8 auth keys | wp-config rewrite, local CSPRNG | WP-PHP | api.wordpress.org salt (fallback) | **missing** | self | P3 | 0.5 |
+| Change DB table prefix | Rename wp_ + repoint options/meta | $wpdb DDL + wp-config | WP-PHP | none | **missing** (destructive, CP-orchestrated task) | self | P4 | 1 |
+| Change content directory | Rename wp-content | rename + defines | WP-PHP | none | **missing** (deprecated upstream) | self | P4 | 0.5 |
+| Change 'admin' username | Rename admin user | $wpdb UPDATE | WP-PHP | none | **missing** | self | P3 | 0.25 |
+| Change user ID 1 | Reassign first user off ID 1 | delete+reinsert+repoint FKs | WP-PHP | none | **missing** | self | P4 | 0.5 |
+
+### Domain: Policy, notifications, orchestration
+| Feature | What it does | Technique | Layer | External | WPMgr status | Replicable | Priority | Effort |
+|---|---|---|---|---|---|---|---|---|
+| User Groups policy model | Per-role/user feature gating (the backbone) | user_groups + Matcher | WP-PHP | none | **partial** (WPMgr has RBAC/RLS on CP side, not per-WP-user site policy) | self | P2 | 2 |
+| Notification Center | Unified security-email hub (recipients/schedule) | notifications registry + scheduler | WP-PHP | none (site mailer) | **partial** (CP has alerts/email pipeline) | self | P2 | 1.5 |
+| Security Check (free) | One-click apply recommended hardening | enforce_activation/setting walk | WP-PHP | none | **missing** | self | P2 | 1 |
+| Security Check Pro | Auto proxy/IP-header + SSL detection | hosted callback | SaaS-call+WP | ssl-proxy-detect | **partial** (CP can probe — build in-house) | self (CP) | P2 | incl. scanner |
+| Global settings (lockout policy/allow-list/proxy mode) | Site-wide policy knobs | Config_Settings + filters | WP-PHP | none | **partial** (security config exists, narrower) | self | P2 | 1 |
+| Usage telemetry opt-in | Anonymous analytics | StellarWP Telemetry | SaaS-call | telemetry.stellarwp.com | **n/a** (CP owns fleet telemetry) | self | P4 | — |
+| Core logging infra | Shared event/audit log + severities | Log db/file backend | WP-PHP | none | **have** (agent hash-chained log + CP append-only) | self | — | done |
+| Core module/settings framework | Registry + caps + actors REST | Modules + container | WP-PHP | none | **partial** (WPMgr has own module system) | self | P3 | — |
+| Security dashboard cards | At-a-glance widgets | dashboard REST + cards | WP-PHP+React | reference vendor news feed (cosmetic) | **partial** (WPMgr has fleet dashboards, no security cards) | self | P2 | 2 |
+| Light DB backup | Scheduled SQL dump + email | SHOW CREATE + INSERT batches | WP-PHP | none | **partial** (WPMgr has full backup suite) | self | P4 | — |
+| Privacy/GDPR tools | Exporter/eraser + policy text | wp_privacy hooks | WP-PHP | none | **missing** | self | P4 | 0.5 |
+
+### Domain: Pro premium tier
+| Feature | What it does | Technique | Layer | External | WPMgr status | Replicable | Priority | Effort |
+|---|---|---|---|---|---|---|---|---|
+| Passwordless / magic-link login | Email one-click or passkey login | opaque token via mailer | WP-PHP | none | **missing** | self | P3 | 1.5 |
+| Magic-link lockout bypass | Email link to bypass own lockout | OT_LOCKOUT_BYPASS token | WP-PHP | none | **missing** | self | P3 | 0.5 |
+| WebAuthn / passkeys (site users) | FIDO2 register+login | pure-PHP ceremony + DB creds | WP-PHP | none | **partial** (CP operator passkeys exist; site-user missing) | self | P3 | 2 |
+| Device fingerprinting + trusted devices | Detect unrecognized login, email approve | weighted IP+UA sources, geo distance | WP-PHP | geo feed (IP signal) | **missing** | needs-feed | P3 | 2 |
+| Session-hijacking protection | Destroy session on fingerprint flip | on_auth compare + destroy | WP-PHP | geo feed | **missing** | needs-feed | P3 | 0.5 |
+| Geolocation subsystem | IP→country/city/latlong + maps | MaxMind/GeoLite2/ip-api | SaaS-call | MaxMind/ip-api | **partial** (CP has offline DB-IP ASN lib — extend to city/country) | needs-feed | P3 | 1.5 |
+| Restrict admin by country | Block admin from disallowed countries | pipeline + CF-IPCOUNTRY + geo | WP-PHP | geo feed | **missing** | needs-feed | P3 | 1 |
+| Version management / auto-update policy | Update policy + vuln-driven auto-update + outdated scan | auto_update filters + transients | WP-PHP | scanner feed + release-dates JSON | **missing** | needs-feed | P2 | 2 |
+| Security headers (emit + verify) | CSP/XFO/XCTO/Referrer + self-verify | header provider + self-request | server-config | none (self-request) | **missing** | self | P2 | 1 |
+| User action logging | Login/post/plugin/theme events per group | hook fan-out → log | WP-PHP | none | **partial** (agent activity log covers most) | self | P3 | 0.5 |
+| Settings import/export (cross-site) | Export/import + cross-site connect | PclZip + Role/User map + app-pw broker | WP-PHP | the reference's license/update server (cross-site only) | **n/a** (CP owns config) | self | P4 | — |
+| Inactive-user / 2FA reminder check | Report stale users + nudge 2FA | scheduler + last-seen query | WP-PHP | none | **missing** | self | P4 | 0.5 |
+| Privilege escalation (temp role) | Temporary auto-expiring role grant | meta + plugins_loaded inject | WP-PHP | none | **missing** | self | P4 | 0.5 |
+| Pro dashboard widgets | Security profile/event widgets | REST cards + wp dashboard widget | WP-PHP | none | **partial** | self | P4 | — |
+| WP-CLI surface | CLI for all features | wp the reference subcommands | WP-PHP | none | **n/a** (WPMgr drives via CP) | self | P4 | — |
+| Remote messages/service status | Vendor notices + feature flags | scheduled remote get | SaaS-call | assets | **n/a** | self | P4 | — |
+| Pro license + update server | License check + Pro delivery | the reference's license/update server/updater | SaaS-call | the reference's license/update server | **n/a** (WPMgr CP-signed updater, ADR-042) | self | — | done |
+
+## Phased build plan
+## Phased Build Plan — CP-first to "Bulletproof" Parity
+
+Conventions per WPMgr: route to layer specialists (wp-agent-engineer / backend-architect / frontend-architect / security-reviewer / devops-engineer / docs-writer), CP-first, every feature deploys all touched layers, every fix ships its named test, docs + landing as DoD. Each phase: **goal · features · layer · deps**.
+
+### GATE 0 — External-data-feed decisions (BLOCKS Phases 4 & 5; nothing else)
+Two product decisions must be made before building the scanner / network-brute-force:
+- **Vulnerability+malware feed:** Wordfence Intelligence (free vuln feed) vs Patchstack API (paid, ships ready-made vPatch WAF rules) vs WPScan API vs self-ingest. Recommendation: start with **Wordfence Intelligence** (free) for vuln data; decide separately whether to license Patchstack for vPatch rules or hand-author top-CVE rules.
+- **Geo feed:** extend existing offline DB-IP lib to city/country vs ship GeoLite2 mmdb (license key). Only gates Phase 6.
+Everything in Phases 1-3 is buildable today with no feed decision.
+
+---
+
+### PHASE 1 — Hardening tweaks + ban-list (quick parity wins, zero feed)
+**Goal:** ship the broad, cheap, self-contained surface that makes WPMgr visibly "a security product." Highest value/effort ratio.
+- **Features:** durable IP/range/UA ban list with comments+actor (CP CRUD + agent enforce); lockout→ban escalation; server-config ban rules (.htaccess/nginx/litespeed); WP hardening toggles — disable file editor, XML-RPC control + multiauth block, REST API restriction, login-identifier restriction, force-unique-nickname, disable zero-post author archives, enforce SSL, regenerate salts (local CSPRNG), disable directory browsing, disable PHP exec in uploads/plugins/themes, protect system files; file permissions audit.
+- **Layer:** CP (policy store + signed push) → agent (apply via existing config-writer + wp-config block writer + mu-plugin) → dashboard (toggles UI).
+- **Deps:** reuse the existing perf-suite .htaccess/nginx config-writer; add a wp-config managed-block writer (agent-empty-base-path-guard rule applies). RLS on any new tenant tables.
+
+### PHASE 2 — Full file-integrity (extend the existing core scanner)
+**Goal:** go from core-only to full filesystem integrity, the natural extension of what already ships.
+- **Features:** full-FS chunked resumable baseline+diff (Added/Changed/Removed); self-write expected-hashes tracking; **plugin/theme integrity via free WP.org plugin-checksums** (downloads.wordpress.org) cached in CP; signed-manifest verify for first-party plugins; file-change notification + audit-log events + dashboard surface.
+- **Layer:** agent (extend ScanCommand hash walker) + CP (extend checksums.go cache to plugins; diff classifier) + dashboard (findings UI).
+- **Deps:** builds directly on internal/scan + checksums.go. Free feeds only.
+
+### PHASE 3 — WP-site-user auth hardening (2FA + passwords for managed sites)
+**Goal:** bring agency-managed-site *users* under 2FA + password policy (today only WPMgr operators have 2FA).
+- **Features:** pluggable 2FA provider arch (TOTP/email/backup) for site users; login interstitial enforcement; per-group enforcement; 2FA onboarding/reminders; strong-password (vendored zxcvbn) + HIBP compromised-password check (free) + password requirements engine (reuse-block, last-changed, forced-change interstitial) + expiration; block XML-RPC for 2FA users; Application Passwords scoping; hide-backend secret slug; CAPTCHA (pluggable, operator keys).
+- **Layer:** agent (all enforcement) + CP (policy config + HIBP proxy/cache + push) + dashboard (per-site/per-group policy UI).
+- **Deps:** port zxcvbn-php; reuse operator-2FA crypto patterns; HIBP via CP cache (Phase 0 not required — it's free).
+
+### PHASE 4 — Vulnerability scanner + virtual-patching firewall (THE moat) — GATED on Gate 0
+**Goal:** the headline capability — detect vulnerable plugins/themes/core and virtually-patch them.
+- **Features:** CP-owned scan orchestrator (agent ships inventory → CP matches vuln feed → findings); known-vuln detection w/ severity + fixed_in; Vulnerability Fixer (one-click WP-upgrader update — self-contained); scheduled scans + retry/back-off (extend River); the parameter-rule **WAF engine** in the agent (port the vendored Patchstack processor — copyable) with user-defined-rule REST/CRUD; **virtual-patch auto-ingest** (vuln→rule) and firewall-triggered lockout + firewall logging.
+- **Layer:** CP (vuln-feed ingest + matcher + scan worker + rule distribution) → agent (WAF engine + rule store + scan inventory + fixer) → dashboard (vuln list, fixer, firewall rules + logs).
+- **Deps:** **Gate 0 vuln-feed decision.** WAF engine is buildable now in parallel; only the *rule content* waits on the feed.
+
+### PHASE 5 — Network brute-force / cross-fleet IP reputation (build in-house) — soft-gated
+**Goal:** replicate Network Brute Force using WPMgr's own fleet, not a third party.
+- **Features:** CP aggregates failed-login reports across all managed sites (already ingested) → computes a shared blocklist → distributes to agents; first-attempt block of known-bad IPs; optional 3rd-party augment (AbuseIPDB/StopForumSpam).
+- **Layer:** CP (reputation aggregation + scoring + blocklist API) → agent (consume blocklist in login-protection + early WAF) → dashboard (reputation view).
+- **Deps:** builds on existing IngestLoginEvents; no external service needed (decide only whether to augment).
+
+### PHASE 6 — Geo-aware advanced auth (Pro tier) — GATED on geo feed
+**Goal:** device fingerprinting, trusted devices, restrict-admin-by-country, session-hijacking protection.
+- **Features:** device fingerprinting (IP+UA weighted, geo distance) + trusted-device email-approve; session-hijacking destroy-on-flip; restrict admin by country (+CF-IPCOUNTRY); version-management auto-update policy + vuln-driven auto-update (consumes Phase 4 feed); passwordless/magic-link login + magic-link lockout bypass; WebAuthn passkeys for site users.
+- **Layer:** agent (fingerprint/session/login flows) + CP (geo lookup + policy) + dashboard.
+- **Deps:** **Gate 0 geo decision**; version-management depends on Phase 4 feed.
+
+### PHASE 7 — Orchestration + operator surface (polish to "bulletproof")
+**Goal:** the glue that makes it feel like one product.
+- **Features:** per-site/per-group **security policy model** (CP analogue of User Groups); **Security Check** one-click "apply recommended hardening" wizard; **CP-side SSL/proxy + real-IP-header detection probe** (build in-house, replaces security-check-pro); security headers emit+verify; security dashboard cards (active blocks, scan status, file changes, vuln summary); notification/alerts for new security event types (extend CP alerts); user action logging gaps; malware/domain-blocklist verdicts (decide feed: Google Safe Browsing / Sucuri / VirusTotal or own crawler); privilege escalation, inactive-user check (low priority).
+- **Layer:** CP-heavy (policy, probe, alerts) + dashboard (cards, wizard, policy UI) + agent (headers, probe responder).
+- **Deps:** rides on all prior phases; the CP SSL/proxy probe reuses the existing uptime-probe client.


### PR DESCRIPTION
First phase of the WordPress security suite (docs/security/security-suite-plan.md). Clean-room build; no competitor named.

## What ships
- **Per-site WP hardening** (CP-pushed, agent-applied): disable file editor, XML-RPC on/limited/off, REST-API restriction, login-identifier restriction, force-unique-nickname, block author-archive enumeration, force-SSL+HSTS, disable directory browsing, block PHP-in-uploads, protect system files.
- **Durable ban list** (IP / CIDR / user-agent) enforced at the early-boot WAF + web-server config.
- **Per-site Security tab** UI, operator-gated. Everything default-off / opt-in.

## Layers
- **CP** (`7687623`): ADR-057, m76 (2 RLS tables), `sync_security_hardening` signed command, security domain + routes + `PermSecurityManage`.
- **Agent** (`597ed90`): hardening module + ban enforcement reusing the WAF + WpConfigEditor + managed `.htaccess` writer.
- **Web** (`d64fd2a`): hardening + ban-list UI.
- **Security fixes** (`b9e7f3b`): closes the security-review findings (inverted UA rule, .htaccess injection, `0.0.0.0/0` lock-out, CP ban validation) + 2 hardening items.

## Security review
DO-NOT-SHIP → 4 blockers fixed → re-reviewed → **closed**. The reviewer confirmed **no ban combination can lock out the operator or control plane** (allow-list + private/loopback bypass before every deny layer in all modes; CP rejects broad/private bans).

## Verification
api `go test ./...` green; agent phpunit **1784** green + phpcs 0; web typecheck/build/lint green; landing copy-check green. m76 auto-runs on boot; no breaking change (all toggles default off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-site security hardening controls including file editor restrictions, XML-RPC/REST API configuration, login identifier options, and SSL/system file protection.
  * Added per-site IP, CIDR range, and user-agent ban lists with early-boot and web-server enforcement.
  * Introduced Security tab in the dashboard consolidating hardening controls and ban management.
  * All controls are default-off and opt-in with operator safeguards against accidental lockout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->