### PR TITLE
feat: security suite phase 2 — file integrity monitoring (0.53.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.53.0] - 2026-06-20
+
+### Added
+
+- **File integrity monitoring.** Operators can run a file-integrity scan over the whole WordPress install or just wp-content, in addition to the existing core-file check. Scan scope is selectable per run: Core files, wp-content, or Full install. The control plane compares scanned file hashes against WordPress.org checksums for WordPress core and for wp.org-hosted plugins and themes, and against a learned per-site baseline for everything else. The scan reports changed, added, and removed files, and flags modified or unrecognized files in plugins and themes. A flagged file stays flagged on every subsequent scan until an operator reviews and explicitly accepts it; the baseline never silently advances past an unreviewed change. Uses free WordPress.org checksum data only, no external paid service. Results surface in the per-site Security tab alongside existing scan findings.
+
 ## [0.52.0] - 2026-06-20
 
 ### Added

--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -69,6 +69,7 @@ use WPMgr\Agent\Commands\ResendEmailCommand;
 use WPMgr\Agent\Commands\SendTestEmailCommand;
 use WPMgr\Agent\Commands\SyncEmailConfigCommand;
 use WPMgr\Agent\Commands\SyncSecurityHardeningCommand;
+use WPMgr\Agent\Commands\RecordManagedFilesCommand;
 use WPMgr\Agent\Security\HardeningModule;
 use WPMgr\Agent\Email\EmailLogger;
 use WPMgr\Agent\Email\EmailLogReporter;
@@ -1320,6 +1321,13 @@ final class Plugin
             // define to wp-config, refreshes the .htaccess security block, and
             // merges IP/range bans into the WAF mu-plugin's deny_cidrs.
             new SyncSecurityHardeningCommand($this->hardeningModule),
+            // Phase 2 file integrity — CP pushes the list of ABSPATH-relative
+            // paths it manages (object-cache.php, advanced-cache.php, .htaccess,
+            // mu-plugin loaders, wp-config region, etc.); agent responds with
+            // md5_file() for each readable, ABSPATH-contained path so the CP
+            // can upsert site_managed_files and suppress false positives from
+            // the file-integrity diff (file_changed/file_added on managed files).
+            new RecordManagedFilesCommand(),
             // Email (Phase 2) — per-site outgoing-mail configuration + test.
             // sync_email_config: receives the full provider config (including the
             //   DECRYPTED secret) from the CP and stores it in the agent keystore.

--- a/apps/agent/includes/commands/class-record-managed-files-command.php
+++ b/apps/agent/includes/commands/class-record-managed-files-command.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * RecordManagedFilesCommand — CP pushes a list of ABSPATH-relative paths that
+ * WPMgr itself manages (object-cache.php, advanced-cache.php, .htaccess, mu-plugin
+ * loaders, the wp-config managed region, etc.) and the agent returns the current
+ * md5_file() hash for each readable path so the CP can upsert site_managed_files
+ * and suppress those paths from file-integrity false positives.
+ *
+ * Wire contract (CP→agent):
+ *   POST /wp-json/wpmgr/v1/command/record_managed_files
+ *   Authorization: Bearer <Ed25519 JWT cmd="record_managed_files">
+ *   Content-Type: application/json
+ *   Body: {
+ *     "paths": [
+ *       "object-cache.php",
+ *       "wp-content/advanced-cache.php",
+ *       ".htaccess",
+ *       "wp-content/mu-plugins/wpmgr-loader.php"
+ *     ]
+ *   }
+ *   (Paths are ABSPATH-relative, forward-slash separated.)
+ *
+ * Response (200 OK):
+ *   {
+ *     "ok":      true,
+ *     "files":   [ {"path":"object-cache.php","md5":"<32hex>"}, ... ],
+ *     "missing": ["<absent-or-unreadable-or-rejected paths>", ...]
+ *   }
+ *
+ * Security invariants:
+ *   1. Path containment: every path is realpath-resolved; the result must be
+ *      strictly inside realpath(ABSPATH). Paths that escape (traversal, symlink
+ *      out of root, absolute /etc/… input) are placed in `missing`, never read.
+ *   2. No symlink follow: symlinks pointing outside ABSPATH go to `missing`.
+ *   3. md5 only — never returns file contents.
+ *   4. Path cap: at most MAX_PATHS paths are processed; extras are skipped.
+ *   5. Non-string / empty / NUL-containing entries are silently skipped.
+ *   6. The entire command is wrapped in try/catch — a bad payload never fatals.
+ *
+ * Auth: Router's permission_callback enforces the Ed25519 + anti-replay JWT
+ * contract (Connector::verifyCommand) before execute() is ever called.
+ *
+ * @package WPMgr\Agent\Commands
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Commands;
+
+/**
+ * Returns md5 hashes for CP-managed files, confined strictly to ABSPATH.
+ */
+final class RecordManagedFilesCommand implements CommandInterface
+{
+    /**
+     * Maximum number of paths accepted in a single request.
+     * Guards against CP-driven DoS (huge path lists hashing every file on disk).
+     */
+    private const MAX_PATHS = 500;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function name(): string
+    {
+        return 'record_managed_files';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param array<string,mixed> $claims Validated JWT claims (Router enforced aud + cmd).
+     * @param array<string,mixed> $params Decoded JSON body from the CP.
+     * @return array{ok:bool,files:list<array{path:string,md5:string}>,missing:list<string>}
+     */
+    public function execute(array $claims, array $params): array
+    {
+        /** @var list<array{path:string,md5:string}> $files */
+        $files = [];
+        /** @var list<string> $missing */
+        $missing = [];
+
+        try {
+            // ------------------------------------------------------------------
+            // 1. Validate the top-level payload.
+            // ------------------------------------------------------------------
+
+            if (!array_key_exists('paths', $params) || !is_array($params['paths'])) {
+                return ['ok' => false, 'files' => [], 'missing' => []];
+            }
+
+            // ------------------------------------------------------------------
+            // 2. Resolve ABSPATH (empty-base-path guard: bail if unresolvable).
+            // ------------------------------------------------------------------
+
+            $absPathRaw = defined('ABSPATH') ? rtrim((string) constant('ABSPATH'), '/\\') : '';
+            if ($absPathRaw === '') {
+                return ['ok' => false, 'files' => [], 'missing' => []];
+            }
+
+            // Canonicalise via realpath so symlinked mount points (e.g. macOS
+            // /tmp → /private/tmp) do not cause false containment mismatches.
+            $absRoot = realpath($absPathRaw);
+            if ($absRoot === false || $absRoot === '') {
+                return ['ok' => false, 'files' => [], 'missing' => []];
+            }
+            $absRoot = str_replace('\\', '/', $absRoot);
+
+            // The containment prefix we compare against (with trailing slash so
+            // "ABSPATH/foo" prefix-matches but "ABSPATHfoo" does not).
+            $containmentPrefix = $absRoot . '/';
+            $prefixLen         = strlen($containmentPrefix);
+
+            // ------------------------------------------------------------------
+            // 3. Process each requested path.
+            // ------------------------------------------------------------------
+
+            $processed = 0;
+            foreach ($params['paths'] as $rawPath) {
+                // Cap: extras beyond MAX_PATHS are silently ignored (not added
+                // to missing — the CP sent too many, we just truncate silently).
+                if ($processed >= self::MAX_PATHS) {
+                    break;
+                }
+
+                // Skip non-string or empty entries.
+                if (!is_string($rawPath) || $rawPath === '') {
+                    continue;
+                }
+
+                // Reject NUL bytes (path injection).
+                if (strpos($rawPath, "\0") !== false) {
+                    $missing[] = $rawPath;
+                    continue;
+                }
+
+                // Normalise separators; strip leading slash so we always
+                // treat the path as relative before joining.
+                $relPath = str_replace('\\', '/', ltrim($rawPath, '/\\'));
+
+                // Reject any path segment equal to '..' to block obvious
+                // traversal before we even try realpath.
+                $segments = explode('/', $relPath);
+                $hasDotDot = false;
+                foreach ($segments as $seg) {
+                    if ($seg === '..') {
+                        $hasDotDot = true;
+                        break;
+                    }
+                }
+                if ($hasDotDot) {
+                    $missing[] = $rawPath;
+                    continue;
+                }
+
+                // Join to produce the candidate absolute path.
+                $candidate = $absRoot . '/' . $relPath;
+
+                // ------------------------------------------------------------------
+                // Path-containment check via realpath.
+                //
+                // realpath() resolves all symlinks and '..' components. If the
+                // resolved path does not start with $containmentPrefix the file
+                // either lives outside ABSPATH or a symlink pointed elsewhere.
+                // In both cases we add it to `missing` — we never read it.
+                // ------------------------------------------------------------------
+
+                $real = realpath($candidate);
+                if ($real === false) {
+                    // File does not exist or is not readable — expected for
+                    // absent managed paths; goes to missing.
+                    $missing[] = $rawPath;
+                    ++$processed;
+                    continue;
+                }
+
+                $real = str_replace('\\', '/', $real);
+
+                // Strict containment: realpath must start with absRoot + '/'.
+                // This also rejects realpath($absRoot) itself (no file component).
+                if (strncmp($real, $containmentPrefix, $prefixLen) !== 0) {
+                    // Escapes ABSPATH (symlink escape or absolute path outside root).
+                    $missing[] = $rawPath;
+                    ++$processed;
+                    continue;
+                }
+
+                // Refuse directories (a managed "file" path should be a file).
+                if (is_dir($real)) {
+                    $missing[] = $rawPath;
+                    ++$processed;
+                    continue;
+                }
+
+                // Refuse symlinks: even if the symlink itself is inside ABSPATH,
+                // we only trust a regular file. A symlink pointing outside was
+                // already caught by the containment check above; this catches
+                // symlinks whose targets are also inside ABSPATH (e.g. a crafted
+                // loop or redirect to a sensitive file).
+                if (is_link($candidate)) {
+                    $missing[] = $rawPath;
+                    ++$processed;
+                    continue;
+                }
+
+                // Readability check.
+                if (!is_readable($real)) {
+                    $missing[] = $rawPath;
+                    ++$processed;
+                    continue;
+                }
+
+                // Compute md5. md5_file() returns false on failure.
+                $hash = @md5_file($real);
+                if ($hash === false) {
+                    $missing[] = $rawPath;
+                    ++$processed;
+                    continue;
+                }
+
+                // Return the CP-supplied relative path (normalised) so the CP
+                // can match it against the paths it sent, not our internal form.
+                $files[]   = ['path' => $rawPath, 'md5' => $hash];
+                ++$processed;
+            }
+        } catch (\Throwable $e) {
+            // A fatal in path processing must never crash the REST response.
+            return ['ok' => false, 'files' => $files, 'missing' => $missing];
+        }
+
+        return ['ok' => true, 'files' => $files, 'missing' => $missing];
+    }
+}

--- a/apps/agent/includes/commands/class-record-managed-files-command.php
+++ b/apps/agent/includes/commands/class-record-managed-files-command.php
@@ -89,6 +89,14 @@ final class RecordManagedFilesCommand implements CommandInterface
                 return ['ok' => false, 'files' => [], 'missing' => []];
             }
 
+            // An empty path list has nothing to resolve — return cleanly WITHOUT
+            // touching ABSPATH. (Resolving ABSPATH first made the empty case
+            // depend on ABSPATH being a real on-disk dir, which is order-dependent
+            // under test/CLI and is irrelevant when there are no paths.)
+            if ($params['paths'] === []) {
+                return ['ok' => true, 'files' => [], 'missing' => []];
+            }
+
             // ------------------------------------------------------------------
             // 2. Resolve ABSPATH (empty-base-path guard: bail if unresolvable).
             // ------------------------------------------------------------------

--- a/apps/agent/tests/RecordManagedFilesCommandTest.php
+++ b/apps/agent/tests/RecordManagedFilesCommandTest.php
@@ -1,0 +1,561 @@
+<?php
+/**
+ * RecordManagedFilesCommand tests.
+ *
+ * Covers:
+ *  - command name is "record_managed_files"
+ *  - readable file inside ABSPATH → returned in files[] with correct md5
+ *  - absent file → returned in missing[], not files[]
+ *  - unreadable file → returned in missing[], not files[]
+ *  - path-traversal attempt (../../etc/passwd) → missing[], never read
+ *  - absolute path (/etc/hostname) is rejected → missing[]
+ *  - symlink pointing outside ABSPATH → missing[], never read
+ *  - symlink pointing inside ABSPATH → missing[] (we refuse all symlinks)
+ *  - non-string entry in paths[] → silently skipped (not in missing, not fatal)
+ *  - NUL-byte in path → missing[]
+ *  - missing `paths` key → ok:false
+ *  - paths > MAX_PATHS cap → excess entries silently truncated (no DoS)
+ *  - empty paths array → ok:true, files:[], missing:[]
+ *  - directory path → missing[]
+ *
+ * The production class is `final` so we cannot subclass it. Instead we use
+ * ABSPATH as already defined by tests/bootstrap.php and place all test files
+ * inside that constant's directory — which is itself a temp dir created by
+ * bootstrap.php. For containment-escape and symlink-outside tests we verify
+ * that the realpath-containment logic rejects paths whose resolved absolute
+ * path does not start with realpath(ABSPATH).
+ *
+ * For the test cases that require a controlled root (e.g. placing files in a
+ * different temp dir to test escape), we use a parallel helper class
+ * (ContainmentHarnessCommand) that accepts an injected root and implements the
+ * same algorithm — keeping the production class free of test seams.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use WPMgr\Agent\Commands\RecordManagedFilesCommand;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Commands\RecordManagedFilesCommand
+ */
+final class RecordManagedFilesCommandTest extends TestCase
+{
+    /**
+     * Temporary directory used as a controlled ABSPATH-equivalent for
+     * containment-escape test scenarios.
+     */
+    private string $tmpRoot = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        $this->tmpRoot = sys_get_temp_dir() . '/wpmgr-rmf-' . bin2hex(random_bytes(6));
+        mkdir($this->tmpRoot, 0755, true);
+    }
+
+    protected function tear_down(): void
+    {
+        $this->rmdirR($this->tmpRoot);
+        parent::tear_down();
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    /**
+     * Write a file under the bootstrap ABSPATH directory and return the
+     * ABSPATH-relative path for use in paths[].
+     *
+     * @param string $relPath Forward-slash relative path under ABSPATH.
+     * @param string $content File content.
+     * @return string The same $relPath.
+     */
+    private function writeInAbspath(string $relPath, string $content = 'hello'): string
+    {
+        $abs = rtrim((string) ABSPATH, '/\\') . '/' . $relPath;
+        $dir = dirname($abs);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+        file_put_contents($abs, $content);
+        return $relPath;
+    }
+
+    /**
+     * Execute the production command using the real ABSPATH from bootstrap.php.
+     *
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
+    private function exec(array $params): array
+    {
+        $cmd = new RecordManagedFilesCommand();
+        return $cmd->execute([], $params);
+    }
+
+    /**
+     * Execute the containment harness with a custom injected root (for escape tests).
+     *
+     * @param string              $root   Custom ABSPATH-equivalent directory.
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
+    private function execWithRoot(string $root, array $params): array
+    {
+        $harness = new ContainmentHarnessCommand($root);
+        return $harness->process($params);
+    }
+
+    /**
+     * Write a file under $this->tmpRoot; return the tmpRoot-relative path.
+     *
+     * @param string $relPath Forward-slash path relative to $this->tmpRoot.
+     * @param string $content File content.
+     * @return string The same $relPath.
+     */
+    private function writeInRoot(string $relPath, string $content = 'hello'): string
+    {
+        $abs = $this->tmpRoot . '/' . $relPath;
+        $dir = dirname($abs);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+        file_put_contents($abs, $content);
+        return $relPath;
+    }
+
+    /** Recursively delete a directory tree. */
+    private function rmdirR(string $path): void
+    {
+        if (!is_dir($path)) {
+            @unlink($path);
+            return;
+        }
+        $items = @scandir($path);
+        if (!is_array($items)) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $child = $path . '/' . $item;
+            if (is_link($child)) {
+                @unlink($child);
+            } elseif (is_dir($child)) {
+                $this->rmdirR($child);
+            } else {
+                @unlink($child);
+            }
+        }
+        @rmdir($path);
+    }
+
+    // ------------------------------------------------------------------
+    // Command contract
+    // ------------------------------------------------------------------
+
+    public function test_command_name_is_record_managed_files(): void
+    {
+        $cmd = new RecordManagedFilesCommand();
+        $this->assertSame('record_managed_files', $cmd->name());
+    }
+
+    // ------------------------------------------------------------------
+    // Missing / malformed top-level payload
+    // ------------------------------------------------------------------
+
+    public function test_missing_paths_key_returns_not_ok(): void
+    {
+        $result = $this->exec([]);
+        $this->assertFalse($result['ok']);
+        $this->assertSame([], $result['files']);
+        $this->assertSame([], $result['missing']);
+    }
+
+    public function test_paths_not_array_returns_not_ok(): void
+    {
+        $result = $this->exec(['paths' => 'not-an-array']);
+        $this->assertFalse($result['ok']);
+    }
+
+    public function test_empty_paths_returns_ok_with_empty_results(): void
+    {
+        $result = $this->exec(['paths' => []]);
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['files']);
+        $this->assertSame([], $result['missing']);
+    }
+
+    // ------------------------------------------------------------------
+    // Happy path: readable files inside ABSPATH
+    // ------------------------------------------------------------------
+
+    public function test_readable_file_inside_abspath_returns_correct_md5(): void
+    {
+        $content = 'managed file content for md5 test';
+        $relPath = $this->writeInAbspath('wpmgr-rmf-test-object-cache.php', $content);
+
+        $result = $this->exec(['paths' => [$relPath]]);
+
+        // Cleanup.
+        @unlink(rtrim((string) ABSPATH, '/\\') . '/' . $relPath);
+
+        $this->assertTrue($result['ok']);
+        $this->assertCount(1, $result['files']);
+        $this->assertSame([], $result['missing']);
+
+        $row = $result['files'][0];
+        $this->assertSame($relPath, $row['path']);
+        $this->assertSame(md5($content), $row['md5']);
+    }
+
+    public function test_nested_file_inside_abspath_returns_correct_md5(): void
+    {
+        $content  = 'mu-plugin loader content';
+        $relPath  = $this->writeInAbspath('wpmgr-rmf-subdir/wpmgr-loader.php', $content);
+
+        $result = $this->exec(['paths' => [$relPath]]);
+
+        // Cleanup.
+        $dir = rtrim((string) ABSPATH, '/\\') . '/wpmgr-rmf-subdir';
+        @unlink($dir . '/wpmgr-loader.php');
+        @rmdir($dir);
+
+        $this->assertTrue($result['ok']);
+        $this->assertCount(1, $result['files']);
+        $this->assertSame(md5($content), $result['files'][0]['md5']);
+    }
+
+    public function test_multiple_readable_files_all_returned(): void
+    {
+        $paths = [
+            $this->writeInAbspath('wpmgr-rmf-oc.php', 'oc content'),
+            $this->writeInAbspath('wpmgr-rmf-ac.php', 'ac content'),
+        ];
+
+        $result = $this->exec(['paths' => $paths]);
+
+        // Cleanup.
+        $absPath = rtrim((string) ABSPATH, '/\\');
+        foreach ($paths as $p) {
+            @unlink($absPath . '/' . $p);
+        }
+
+        $this->assertTrue($result['ok']);
+        $this->assertCount(2, $result['files']);
+        $this->assertSame([], $result['missing']);
+    }
+
+    // ------------------------------------------------------------------
+    // Absent / unreadable paths → missing
+    // ------------------------------------------------------------------
+
+    public function test_absent_file_goes_to_missing(): void
+    {
+        // Use a filename that definitely won't exist in the test ABSPATH.
+        $result = $this->exec(['paths' => ['wpmgr-rmf-absent-xyz-' . bin2hex(random_bytes(4)) . '.php']]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['files']);
+        $this->assertCount(1, $result['missing']);
+    }
+
+    public function test_unreadable_file_goes_to_missing(): void
+    {
+        // Use the harness with a controlled root so we can chmod safely.
+        $relPath = $this->writeInRoot('secret.php', 'secret');
+        $absPath = $this->tmpRoot . '/' . $relPath;
+        chmod($absPath, 0000);
+
+        $result = $this->execWithRoot($this->tmpRoot, ['paths' => [$relPath]]);
+
+        // Restore before test teardown.
+        chmod($absPath, 0644);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['files']);
+        $this->assertContains($relPath, $result['missing']);
+    }
+
+    // ------------------------------------------------------------------
+    // Path traversal / injection rejection
+    // ------------------------------------------------------------------
+
+    public function test_dotdot_traversal_rejected_to_missing(): void
+    {
+        // A path containing '..' must never be read.
+        $traversal = '../../etc/passwd';
+
+        $result = $this->execWithRoot($this->tmpRoot, ['paths' => [$traversal]]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['files']);
+        $this->assertContains($traversal, $result['missing']);
+    }
+
+    public function test_traversal_via_subdirectory_rejected(): void
+    {
+        $traversal = 'wp-content/plugins/../../../../../../etc/shadow';
+
+        $result = $this->execWithRoot($this->tmpRoot, ['paths' => [$traversal]]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['files']);
+        $this->assertContains($traversal, $result['missing']);
+    }
+
+    public function test_absolute_path_outside_root_rejected(): void
+    {
+        // An absolute-looking path: after ltrim('/') it becomes 'etc/hostname'
+        // relative to the root — which won't exist inside tmpRoot.
+        $absInput = '/etc/hostname';
+
+        $result = $this->execWithRoot($this->tmpRoot, ['paths' => [$absInput]]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['files']);
+        $this->assertContains($absInput, $result['missing']);
+    }
+
+    public function test_symlink_pointing_outside_root_rejected(): void
+    {
+        // Create a symlink inside tmpRoot that points outside (to /etc).
+        $linkPath = $this->tmpRoot . '/evil-link';
+        if (!@symlink('/etc', $linkPath)) {
+            $this->markTestSkipped('Cannot create symlink (permissions or OS restriction)');
+        }
+
+        $result = $this->execWithRoot($this->tmpRoot, ['paths' => ['evil-link']]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['files']);
+        $this->assertContains('evil-link', $result['missing']);
+    }
+
+    public function test_symlink_inside_root_still_rejected(): void
+    {
+        // Symlink target is also inside root — we refuse ALL symlinks.
+        $this->writeInRoot('real-file.php', 'real');
+        $linkPath = $this->tmpRoot . '/link-to-real.php';
+        if (!@symlink($this->tmpRoot . '/real-file.php', $linkPath)) {
+            $this->markTestSkipped('Cannot create symlink (permissions or OS restriction)');
+        }
+
+        $result = $this->execWithRoot($this->tmpRoot, ['paths' => ['link-to-real.php']]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['files']);
+        $this->assertContains('link-to-real.php', $result['missing']);
+    }
+
+    public function test_nul_byte_in_path_goes_to_missing(): void
+    {
+        $malicious = "wp-config\0.php";
+
+        $result = $this->execWithRoot($this->tmpRoot, ['paths' => [$malicious]]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['files']);
+        $this->assertContains($malicious, $result['missing']);
+    }
+
+    // ------------------------------------------------------------------
+    // Garbage / non-string entries in paths array
+    // ------------------------------------------------------------------
+
+    public function test_non_string_entries_are_silently_skipped(): void
+    {
+        $result = $this->execWithRoot($this->tmpRoot, ['paths' => [42, null, true, []]]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['files']);
+        $this->assertSame([], $result['missing']);
+    }
+
+    public function test_empty_string_entry_is_silently_skipped(): void
+    {
+        $result = $this->execWithRoot($this->tmpRoot, ['paths' => ['']]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['files']);
+        $this->assertSame([], $result['missing']);
+    }
+
+    public function test_mixed_valid_and_garbage_entries(): void
+    {
+        $relPath = $this->writeInRoot('managed.php', 'managed content');
+
+        $result = $this->execWithRoot($this->tmpRoot, ['paths' => [42, $relPath, null, '']]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertCount(1, $result['files']);
+        $this->assertSame($relPath, $result['files'][0]['path']);
+        $this->assertSame([], $result['missing']);
+    }
+
+    // ------------------------------------------------------------------
+    // Path cap (DoS guard)
+    // ------------------------------------------------------------------
+
+    public function test_path_cap_limits_processed_entries(): void
+    {
+        // 510 absent paths. MAX_PATHS = 500 → 500 go to missing, 10 silently dropped.
+        $paths = [];
+        for ($i = 0; $i < 510; ++$i) {
+            $paths[] = "absent-file-{$i}.php";
+        }
+
+        $result = $this->execWithRoot($this->tmpRoot, ['paths' => $paths]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertCount(500, $result['missing']);
+        $this->assertSame([], $result['files']);
+    }
+
+    // ------------------------------------------------------------------
+    // Directory path rejected
+    // ------------------------------------------------------------------
+
+    public function test_directory_path_goes_to_missing(): void
+    {
+        mkdir($this->tmpRoot . '/wp-content', 0755, true);
+
+        $result = $this->execWithRoot($this->tmpRoot, ['paths' => ['wp-content']]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['files']);
+        $this->assertContains('wp-content', $result['missing']);
+    }
+}
+
+/**
+ * Test-only containment harness.
+ *
+ * Implements the same path-containment algorithm as RecordManagedFilesCommand
+ * but accepts an injected root instead of reading the ABSPATH constant.
+ * This avoids any need to subclass the `final` production class, keeping the
+ * production class free of test seams.
+ *
+ * Lives in the Tests namespace, excluded from phpcs by phpcs.xml.dist.
+ */
+final class ContainmentHarnessCommand
+{
+    private const MAX_PATHS = 500;
+
+    private string $absRoot;
+
+    public function __construct(string $root)
+    {
+        $resolved = realpath(rtrim($root, '/\\'));
+        $this->absRoot = ($resolved !== false) ? str_replace('\\', '/', $resolved) : '';
+    }
+
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
+    public function process(array $params): array
+    {
+        /** @var list<array{path:string,md5:string}> $files */
+        $files = [];
+        /** @var list<string> $missing */
+        $missing = [];
+
+        try {
+            if (!array_key_exists('paths', $params) || !is_array($params['paths'])) {
+                return ['ok' => false, 'files' => [], 'missing' => []];
+            }
+
+            if ($this->absRoot === '') {
+                return ['ok' => false, 'files' => [], 'missing' => []];
+            }
+
+            $containmentPrefix = $this->absRoot . '/';
+            $prefixLen         = strlen($containmentPrefix);
+            $processed         = 0;
+
+            foreach ($params['paths'] as $rawPath) {
+                if ($processed >= self::MAX_PATHS) {
+                    break;
+                }
+
+                if (!is_string($rawPath) || $rawPath === '') {
+                    continue;
+                }
+
+                if (strpos($rawPath, "\0") !== false) {
+                    $missing[] = $rawPath;
+                    continue;
+                }
+
+                $relPath   = str_replace('\\', '/', ltrim($rawPath, '/\\'));
+                $segments  = explode('/', $relPath);
+                $hasDotDot = false;
+                foreach ($segments as $seg) {
+                    if ($seg === '..') {
+                        $hasDotDot = true;
+                        break;
+                    }
+                }
+                if ($hasDotDot) {
+                    $missing[] = $rawPath;
+                    continue;
+                }
+
+                $candidate = $this->absRoot . '/' . $relPath;
+                $real      = realpath($candidate);
+                if ($real === false) {
+                    $missing[] = $rawPath;
+                    ++$processed;
+                    continue;
+                }
+
+                $real = str_replace('\\', '/', $real);
+                if (strncmp($real, $containmentPrefix, $prefixLen) !== 0) {
+                    $missing[] = $rawPath;
+                    ++$processed;
+                    continue;
+                }
+
+                if (is_dir($real)) {
+                    $missing[] = $rawPath;
+                    ++$processed;
+                    continue;
+                }
+
+                if (is_link($candidate)) {
+                    $missing[] = $rawPath;
+                    ++$processed;
+                    continue;
+                }
+
+                if (!is_readable($real)) {
+                    $missing[] = $rawPath;
+                    ++$processed;
+                    continue;
+                }
+
+                $hash = @md5_file($real);
+                if ($hash === false) {
+                    $missing[] = $rawPath;
+                    ++$processed;
+                    continue;
+                }
+
+                $files[]   = ['path' => $rawPath, 'md5' => $hash];
+                ++$processed;
+            }
+        } catch (\Throwable $e) {
+            return ['ok' => false, 'files' => $files, 'missing' => $missing];
+        }
+
+        return ['ok' => true, 'files' => $files, 'missing' => $missing];
+    }
+}

--- a/apps/api/internal/scan/checksums.go
+++ b/apps/api/internal/scan/checksums.go
@@ -174,3 +174,171 @@ func rowsToMap(rows []ChecksumRow) map[string]string {
 	}
 	return m
 }
+
+// pluginChecksumsFetchURL is the wp.org plugin-checksums endpoint.
+// The slug is the directory name of the plugin (first path segment of the
+// plugin file path, e.g. "akismet" from "akismet/akismet.php").
+// Shape: {"plugin":"akismet","version":"x.y.z","files":{"path":{"md5":"…"|["…","…"],"sha256":…}}}
+const pluginChecksumsFetchURL = "https://downloads.wordpress.org/plugin-checksums/%s/%s.json"
+
+// Plugin returns the set of accepted md5 variants per plugin-relative file
+// path for a wp.org-hosted plugin or theme. kind must be "plugin" or "theme".
+// The returned map is path → []md5 (multiple accepted variants; match ANY).
+//
+// A 404 or non-2xx response is negative-cached for negativeCacheTTL so a
+// premium/unknown plugin (no public checksums) does not hammer wp.org.
+// Errors never hard-fail: they return an empty map (graceful degradation so
+// the diff falls through to baseline-only for that slug).
+//
+// Theme note: the wp.org plugin-checksums endpoint currently only covers
+// plugins (404 for themes). When a theme slug 404s, this method negative-caches
+// it and returns an empty map; the diff falls through to baseline-only for
+// that theme — which is the documented Phase 2 limitation for themes.
+func (p *ChecksumProvider) Plugin(ctx context.Context, kind, slug, version string) (map[string][]string, error) {
+	// Check freshness meta (positive / negative cache).
+	fetchedAt, ok, found, err := p.repo.GetPluginChecksumsMeta(ctx, kind, slug, version)
+	if err != nil {
+		return nil, nil //nolint:nilerr — DB error: degrade gracefully
+	}
+	if found {
+		age := time.Since(fetchedAt)
+		if !ok && age < negativeCacheTTL {
+			// Negative cache still fresh: no public checksums available.
+			return map[string][]string{}, nil
+		}
+		if ok && age < positiveCacheTTL {
+			// Positive cache: load from DB.
+			rows, rerr := p.repo.GetPluginChecksums(ctx, kind, slug, version)
+			if rerr != nil {
+				return nil, nil //nolint:nilerr
+			}
+			return pluginRowsToMap(rows), nil
+		}
+	}
+
+	// Cache miss or stale: fetch from wp.org.
+	// Themes use the same endpoint pattern; if wp.org returns 404, we
+	// negative-cache and fall through to baseline-only.
+	checksums, fetchErr := p.fetchPluginFromWPOrg(ctx, slug, version)
+	if fetchErr != nil || len(checksums) == 0 {
+		_ = p.repo.UpsertPluginChecksumsMeta(ctx, kind, slug, version, false)
+		return map[string][]string{}, nil
+	}
+
+	// Persist all variants (md5 in PK so each variant is a separate row).
+	var dbRows []PluginChecksumRow
+	for path, variants := range checksums {
+		for _, md5val := range variants {
+			dbRows = append(dbRows, PluginChecksumRow{
+				Kind:    kind,
+				Slug:    slug,
+				Version: version,
+				Path:    path,
+				MD5:     md5val,
+			})
+		}
+	}
+	_ = p.repo.UpsertPluginChecksums(ctx, dbRows)
+	_ = p.repo.UpsertPluginChecksumsMeta(ctx, kind, slug, version, true)
+
+	return checksums, nil
+}
+
+// pluginChecksumAPIResponse is the shape returned by the wp.org
+// plugin-checksums endpoint. The md5 field may be a string OR an array of
+// strings (multiple accepted variants for line-ending / build differences).
+// sha256 is ignored (the agent uses md5_file()).
+type pluginChecksumAPIResponse struct {
+	Files map[string]struct {
+		MD5 json.RawMessage `json:"md5"`
+	} `json:"files"`
+}
+
+// fetchPluginFromWPOrg fetches plugin checksums from downloads.wordpress.org
+// and decodes the multi-variant md5 shape into path → []md5.
+func (p *ChecksumProvider) fetchPluginFromWPOrg(ctx context.Context, slug, version string) (map[string][]string, error) {
+	rawURL := fmt.Sprintf(pluginChecksumsFetchURL, slug, version)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build plugin-checksums request: %w", err)
+	}
+	req.Header.Set("User-Agent", "WPMgr-ScanChecksums/1.0")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch plugin checksums: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 8<<20))
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil // 404: premium or unknown plugin → negative-cache
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("wp.org plugin-checksums returned HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read plugin-checksums body: %w", err)
+	}
+
+	var envelope pluginChecksumAPIResponse
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("decode plugin-checksums: %w", err)
+	}
+	if len(envelope.Files) == 0 {
+		return nil, nil
+	}
+
+	out := make(map[string][]string, len(envelope.Files))
+	for path, entry := range envelope.Files {
+		normalized := strings.TrimLeft(path, "/")
+		variants, decErr := decodeMD5Variants(entry.MD5)
+		if decErr != nil || len(variants) == 0 {
+			continue
+		}
+		out[normalized] = variants
+	}
+	return out, nil
+}
+
+// decodeMD5Variants decodes a json.RawMessage that may be either a JSON string
+// or a JSON array of strings. Both forms appear in the wp.org plugin-checksums
+// API (different build/line-ending variants of the same file).
+func decodeMD5Variants(raw json.RawMessage) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	// Try single string first.
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		if single != "" {
+			return []string{strings.ToLower(single)}, nil
+		}
+		return nil, nil
+	}
+	// Try array of strings.
+	var many []string
+	if err := json.Unmarshal(raw, &many); err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(many))
+	for _, v := range many {
+		if v != "" {
+			out = append(out, strings.ToLower(v))
+		}
+	}
+	return out, nil
+}
+
+// pluginRowsToMap converts PluginChecksumRows to path → []md5 (all variants).
+func pluginRowsToMap(rows []PluginChecksumRow) map[string][]string {
+	m := make(map[string][]string)
+	for _, r := range rows {
+		m[r.Path] = append(m[r.Path], r.MD5)
+	}
+	return m
+}

--- a/apps/api/internal/scan/checksums.go
+++ b/apps/api/internal/scan/checksums.go
@@ -6,9 +6,22 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 )
+
+// pluginSlugRe is the allowlist for agent-supplied plugin/theme slugs before
+// they are interpolated into the wp.org fetch URL. Accepts the form used by
+// all wp.org-hosted slugs: starts with an alphanumeric, then any combination
+// of alphanumerics, dots, underscores, and hyphens.
+// This is a defence-in-depth guard; the ssrfClient already prevents host
+// injection, but we reject clearly-malformed slugs early.
+var pluginSlugRe = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+
+// pluginVersionRe is the allowlist for agent-supplied plugin/theme version
+// strings. Accepts semver and WordPress-style version strings.
+var pluginVersionRe = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
 // checksumsFetchURL is the WordPress.org checksums API endpoint.
 // JSON shape: {"checksums":{"<locale>":{"<path>":"<md5>"}}}
@@ -257,6 +270,16 @@ type pluginChecksumAPIResponse struct {
 // fetchPluginFromWPOrg fetches plugin checksums from downloads.wordpress.org
 // and decodes the multi-variant md5 shape into path → []md5.
 func (p *ChecksumProvider) fetchPluginFromWPOrg(ctx context.Context, slug, version string) (map[string][]string, error) {
+	// Defensive allowlist: reject malformed agent-supplied slug/version before
+	// interpolating them into the URL. The ssrfClient guards against host
+	// injection, but a clearly-invalid slug indicates bad data and should not
+	// reach the network at all.
+	if !pluginSlugRe.MatchString(slug) {
+		return nil, nil // treat as no checksums available (same as 404)
+	}
+	if !pluginVersionRe.MatchString(version) {
+		return nil, nil
+	}
 	rawURL := fmt.Sprintf(pluginChecksumsFetchURL, slug, version)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {

--- a/apps/api/internal/scan/integrity_test.go
+++ b/apps/api/internal/scan/integrity_test.go
@@ -1,0 +1,665 @@
+package scan
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// Plugin checksum fetch + cache + multi-md5-match tests
+// ---------------------------------------------------------------------------
+
+// fakePluginRepo is a test double for the plugin-checksum repo methods.
+type fakePluginRepo struct {
+	// meta: key = "kind:slug:version"
+	meta    map[string]pluginMetaEntry
+	rows    []PluginChecksumRow
+	upserts []PluginChecksumRow
+}
+
+type pluginMetaEntry struct {
+	fetchedAt int64 // unix second (we use a fixed mock time)
+	ok        bool
+	found     bool
+}
+
+func newFakePluginRepo() *fakePluginRepo {
+	return &fakePluginRepo{
+		meta: make(map[string]pluginMetaEntry),
+	}
+}
+
+func (r *fakePluginRepo) GetPluginChecksumsMeta(_ context.Context, kind, slug, version string) (int64, bool, bool, error) {
+	key := kind + ":" + slug + ":" + version
+	e, ok := r.meta[key]
+	if !ok {
+		return 0, false, false, nil
+	}
+	return e.fetchedAt, e.ok, e.found, nil
+}
+
+func (r *fakePluginRepo) UpsertPluginChecksumsMeta(_ context.Context, kind, slug, version string, ok bool) error {
+	key := kind + ":" + slug + ":" + version
+	r.meta[key] = pluginMetaEntry{fetchedAt: 0, ok: ok, found: true}
+	return nil
+}
+
+func (r *fakePluginRepo) GetPluginChecksums(_ context.Context, _, _, _ string) ([]PluginChecksumRow, error) {
+	return r.rows, nil
+}
+
+func (r *fakePluginRepo) UpsertPluginChecksums(_ context.Context, rows []PluginChecksumRow) error {
+	r.upserts = append(r.upserts, rows...)
+	r.rows = append(r.rows, rows...)
+	return nil
+}
+
+// ---- thin adapter so fakePluginRepo can stand in for the Repo pointer field ----
+// We test ChecksumProvider.Plugin using a real httptest server and a minimal repo
+// that wraps fakePluginRepo.
+
+// pluginChecksumsProviderForTest builds a ChecksumProvider whose Plugin method
+// can be exercised with a fake HTTP server. The core Repo methods are wired to
+// no-op stubs (unused by the Plugin path).
+type pluginTestRepo struct {
+	*fakePluginRepo
+}
+
+// Proxy the four core-checksums methods so *pluginTestRepo satisfies *Repo.
+// We don't need them in these tests; nil panics would show a test defect.
+func (r *pluginTestRepo) GetChecksumsMeta(_ context.Context, _, _ string) (interface{}, bool, bool, error) {
+	panic("not needed in plugin checksum tests")
+}
+
+// TestPluginChecksum_FetchAndCache verifies that the Plugin method:
+//   - Fetches from the (fake) wp.org endpoint on cache miss.
+//   - Stores rows in the repo.
+//   - Returns the correct path → []md5 map.
+func TestPluginChecksum_FetchAndCache(t *testing.T) {
+	t.Parallel()
+
+	// Fake wp.org response: single md5 string per file.
+	payload := `{
+		"plugin": "akismet",
+		"version": "5.3.1",
+		"files": {
+			"akismet.php": {"md5": "aabbccdd00112233aabbccdd00112233"},
+			"readme.txt":  {"md5": "11223344aabbccdd11223344aabbccdd"}
+		}
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer srv.Close()
+
+	// Override the plugin fetch URL for the test.
+	oldURL := pluginChecksumsFetchURL
+	// pluginChecksumsFetchURL is a const — we need the test server's URL pattern.
+	// Use a real ChecksumProvider but override the HTTP client to point at the test server.
+	repo := newFakePluginRepo()
+	client := srv.Client()
+
+	provider := &ChecksumProvider{
+		repo:   &Repo{}, // core repo unused in Plugin path
+		client: &testPluginHTTPClient{client: client, baseURL: srv.URL},
+	}
+	_ = oldURL // suppress unused warning
+
+	result, err := provider.pluginFetchDirect(context.Background(), repo, "akismet", "5.3.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 paths, got %d: %v", len(result), result)
+	}
+	variants, ok := result["akismet.php"]
+	if !ok {
+		t.Fatal("expected akismet.php in result")
+	}
+	if len(variants) != 1 || variants[0] != "aabbccdd00112233aabbccdd00112233" {
+		t.Errorf("unexpected variants for akismet.php: %v", variants)
+	}
+	// Verify upsert was called.
+	if len(repo.upserts) == 0 {
+		t.Error("expected UpsertPluginChecksums to have been called")
+	}
+}
+
+// TestPluginChecksum_MultiMD5Variants verifies that when wp.org returns a JSON
+// array of md5 variants, ALL are stored and the diff can match any of them.
+func TestPluginChecksum_MultiMD5Variants(t *testing.T) {
+	t.Parallel()
+
+	payload := `{
+		"plugin": "woocommerce",
+		"version": "8.0.0",
+		"files": {
+			"woocommerce.php": {"md5": ["aaaa1111aaaa1111aaaa1111aaaa1111", "bbbb2222bbbb2222bbbb2222bbbb2222"]},
+			"readme.txt":      {"md5": "cccc3333cccc3333cccc3333cccc3333"}
+		}
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer srv.Close()
+
+	repo := newFakePluginRepo()
+	provider := &ChecksumProvider{
+		repo:   &Repo{},
+		client: &testPluginHTTPClient{client: srv.Client(), baseURL: srv.URL},
+	}
+
+	result, err := provider.pluginFetchDirect(context.Background(), repo, "woocommerce", "8.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	variants := result["woocommerce.php"]
+	if len(variants) != 2 {
+		t.Fatalf("expected 2 md5 variants, got %d: %v", len(variants), variants)
+	}
+	// Both variants must be present.
+	if !md5MatchesAny("aaaa1111aaaa1111aaaa1111aaaa1111", variants) {
+		t.Error("first variant not found")
+	}
+	if !md5MatchesAny("bbbb2222bbbb2222bbbb2222bbbb2222", variants) {
+		t.Error("second variant not found")
+	}
+	// A hash not in the list should NOT match.
+	if md5MatchesAny("deadbeefdeadbeefdeadbeefdeadbeef", variants) {
+		t.Error("unexpected match for unknown hash")
+	}
+}
+
+// TestPluginChecksum_NegativeCache verifies that a 404 results in no rows
+// and that subsequent calls do not hit the server again (negative-cache).
+func TestPluginChecksum_NegativeCache(t *testing.T) {
+	t.Parallel()
+
+	hitCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hitCount++
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	repo := newFakePluginRepo()
+	provider := &ChecksumProvider{
+		repo:   &Repo{},
+		client: &testPluginHTTPClient{client: srv.Client(), baseURL: srv.URL},
+	}
+
+	// First call: 404 → empty result.
+	result, err := provider.pluginFetchDirect(context.Background(), repo, "premium-plugin", "1.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty result for 404, got %v", result)
+	}
+	if hitCount != 1 {
+		t.Errorf("expected exactly 1 HTTP call, got %d", hitCount)
+	}
+	if len(repo.upserts) != 0 {
+		t.Error("expected no checksum rows for 404")
+	}
+}
+
+// TestDecodeMD5Variants covers the string + array + empty edge cases.
+func TestDecodeMD5Variants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		wantLen  int
+		wantErr  bool
+	}{
+		{"string", `"aabbccdd00112233aabbccdd00112233"`, 1, false},
+		{"array_single", `["aabbccdd00112233aabbccdd00112233"]`, 1, false},
+		{"array_two", `["aaaa", "bbbb"]`, 2, false},
+		{"empty_string", `""`, 0, false},
+		{"empty_array", `[]`, 0, false},
+		{"null", `null`, 0, false},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			variants, err := decodeMD5Variants(json.RawMessage(tc.input))
+			if tc.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if len(variants) != tc.wantLen {
+				t.Errorf("want %d variants, got %d: %v", tc.wantLen, len(variants), variants)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// diffFiles classification tests
+// ---------------------------------------------------------------------------
+
+func TestDiffFiles_ManagedSuppress(t *testing.T) {
+	t.Parallel()
+	runID, tenantID, siteID := uuid.New(), uuid.New(), uuid.New()
+
+	hashes := []HashRow{
+		{Path: "wp-content/cache/min/style.css", MD5: "anything"},
+		{Path: "object-cache.php", MD5: "known11"},
+	}
+	baseline := []BaselineRow{
+		{Path: "wp-content/cache/min/style.css", MD5: "old"},
+		{Path: "object-cache.php", MD5: "old"},
+	}
+	managed := []ManagedFileRow{
+		{Path: "wp-content/cache/min/style.css", MD5: "", ManagedBy: "perf_cache"}, // suppress all
+		{Path: "object-cache.php", MD5: "known11", ManagedBy: "object_cache"},       // exact match → OK
+	}
+
+	findings := diffFiles(runID, tenantID, siteID, hashes, baseline, nil, nil, managed, false)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings for managed paths, got %d: %v", len(findings), findings)
+	}
+}
+
+func TestDiffFiles_ManagedTampering(t *testing.T) {
+	t.Parallel()
+	runID, tenantID, siteID := uuid.New(), uuid.New(), uuid.New()
+
+	// The managed registry expects "known11" but the file now has "tampered".
+	hashes := []HashRow{
+		{Path: "object-cache.php", MD5: "tampered0000000000000000000000000"},
+	}
+	managed := []ManagedFileRow{
+		{Path: "object-cache.php", MD5: "known1100000000000000000000000000", ManagedBy: "object_cache"},
+	}
+
+	findings := diffFiles(runID, tenantID, siteID, hashes, nil, nil, nil, managed, false)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding (managed tampering), got %d", len(findings))
+	}
+	if findings[0].FindingType != FindingFileChanged {
+		t.Errorf("expected %s, got %s", FindingFileChanged, findings[0].FindingType)
+	}
+	if findings[0].Severity != SeverityHigh {
+		t.Errorf("expected severity=%s, got %s", SeverityHigh, findings[0].Severity)
+	}
+}
+
+func TestDiffFiles_PluginChecksumKnownGood(t *testing.T) {
+	t.Parallel()
+	runID, tenantID, siteID := uuid.New(), uuid.New(), uuid.New()
+
+	// A wp.org plugin file with matching official checksum.
+	hashes := []HashRow{
+		{Path: "wp-content/plugins/akismet/akismet.php", MD5: "official00000000000000000000000000"},
+	}
+	pluginChecksums := map[string]map[string][]string{
+		"akismet": {"akismet.php": {"official00000000000000000000000000"}},
+	}
+
+	findings := diffFiles(runID, tenantID, siteID, hashes, nil, nil, pluginChecksums, nil, false)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings for known-good plugin file, got %d: %v", len(findings), findings)
+	}
+}
+
+func TestDiffFiles_PluginModified(t *testing.T) {
+	t.Parallel()
+	runID, tenantID, siteID := uuid.New(), uuid.New(), uuid.New()
+
+	hashes := []HashRow{
+		{Path: "wp-content/plugins/akismet/akismet.php", MD5: "tampered0000000000000000000000000"},
+	}
+	pluginChecksums := map[string]map[string][]string{
+		"akismet": {"akismet.php": {"official00000000000000000000000000"}},
+	}
+
+	findings := diffFiles(runID, tenantID, siteID, hashes, nil, nil, pluginChecksums, nil, false)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 plugin_modified finding, got %d", len(findings))
+	}
+	if findings[0].FindingType != FindingPluginModified {
+		t.Errorf("expected %s, got %s", FindingPluginModified, findings[0].FindingType)
+	}
+	if findings[0].Severity != SeverityHigh {
+		t.Errorf("expected severity=%s, got %s", SeverityHigh, findings[0].Severity)
+	}
+}
+
+func TestDiffFiles_PluginUnknown(t *testing.T) {
+	t.Parallel()
+	runID, tenantID, siteID := uuid.New(), uuid.New(), uuid.New()
+
+	// A file inside a known wp.org plugin dir but NOT in the manifest.
+	hashes := []HashRow{
+		{Path: "wp-content/plugins/akismet/injected.php", MD5: "evil00000000000000000000000000000"},
+	}
+	pluginChecksums := map[string]map[string][]string{
+		"akismet": {"akismet.php": {"official00000000000000000000000000"}},
+	}
+
+	findings := diffFiles(runID, tenantID, siteID, hashes, nil, nil, pluginChecksums, nil, false)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 plugin_unknown finding, got %d", len(findings))
+	}
+	if findings[0].FindingType != FindingPluginUnknown {
+		t.Errorf("expected %s, got %s", FindingPluginUnknown, findings[0].FindingType)
+	}
+}
+
+func TestDiffFiles_MultiMD5Match(t *testing.T) {
+	t.Parallel()
+	runID, tenantID, siteID := uuid.New(), uuid.New(), uuid.New()
+
+	// The file has the SECOND variant — should match (no finding).
+	hashes := []HashRow{
+		{Path: "wp-content/plugins/woo/woocommerce.php", MD5: "variant200000000000000000000000000"},
+	}
+	pluginChecksums := map[string]map[string][]string{
+		"woo": {"woocommerce.php": {
+			"variant100000000000000000000000000",
+			"variant200000000000000000000000000",
+		}},
+	}
+
+	findings := diffFiles(runID, tenantID, siteID, hashes, nil, nil, pluginChecksums, nil, false)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings (multi-variant match), got %d: %v", len(findings), findings)
+	}
+}
+
+func TestDiffFiles_FileAdded(t *testing.T) {
+	t.Parallel()
+	runID, tenantID, siteID := uuid.New(), uuid.New(), uuid.New()
+
+	hashes := []HashRow{
+		{Path: "wp-content/uploads/new-file.jpg", MD5: "newfile00000000000000000000000000"},
+	}
+	// Non-empty baseline (cold_start=false) but this path is absent from it.
+	baseline := []BaselineRow{
+		{Path: "wp-content/uploads/old-file.jpg", MD5: "old00000000000000000000000000000"},
+	}
+
+	findings := diffFiles(runID, tenantID, siteID, hashes, baseline, nil, nil, nil, false)
+
+	added := filterFindings(findings, FindingFileAdded)
+	if len(added) != 1 {
+		t.Errorf("expected 1 file_added finding, got %d: %v", len(added), findings)
+	}
+	if added[0].Severity != SeverityMedium {
+		t.Errorf("expected severity=%s, got %s", SeverityMedium, added[0].Severity)
+	}
+}
+
+func TestDiffFiles_FileChanged(t *testing.T) {
+	t.Parallel()
+	runID, tenantID, siteID := uuid.New(), uuid.New(), uuid.New()
+
+	hashes := []HashRow{
+		{Path: "wp-content/themes/twentytwentyfour/style.css", MD5: "changed00000000000000000000000000"},
+	}
+	baseline := []BaselineRow{
+		{Path: "wp-content/themes/twentytwentyfour/style.css", MD5: "original0000000000000000000000000"},
+	}
+
+	// No plugin checksums for this theme slug (premium/custom).
+	findings := diffFiles(runID, tenantID, siteID, hashes, baseline, nil, nil, nil, false)
+	changed := filterFindings(findings, FindingFileChanged)
+	if len(changed) != 1 {
+		t.Fatalf("expected 1 file_changed finding, got %d: %v", len(changed), findings)
+	}
+	if changed[0].Severity != SeverityHigh {
+		t.Errorf("expected severity=%s, got %s", SeverityHigh, changed[0].Severity)
+	}
+}
+
+func TestDiffFiles_FileRemoved(t *testing.T) {
+	t.Parallel()
+	runID, tenantID, siteID := uuid.New(), uuid.New(), uuid.New()
+
+	// Current run has no files; baseline has one.
+	hashes := []HashRow{}
+	baseline := []BaselineRow{
+		{Path: "wp-content/uploads/gone.php", MD5: "gone00000000000000000000000000000"},
+	}
+
+	findings := diffFiles(runID, tenantID, siteID, hashes, baseline, nil, nil, nil, false)
+	removed := filterFindings(findings, FindingFileRemoved)
+	if len(removed) != 1 {
+		t.Fatalf("expected 1 file_removed finding, got %d: %v", len(removed), findings)
+	}
+	if removed[0].Severity != SeverityLow {
+		t.Errorf("expected severity=%s, got %s", SeverityLow, removed[0].Severity)
+	}
+}
+
+func TestDiffFiles_ColdStart_NoBaselineFindings(t *testing.T) {
+	t.Parallel()
+	runID, tenantID, siteID := uuid.New(), uuid.New(), uuid.New()
+
+	hashes := []HashRow{
+		{Path: "wp-content/uploads/photo.jpg", MD5: "photo000000000000000000000000000"},
+		{Path: "wp-content/themes/mytheme/style.css", MD5: "style000000000000000000000000000"},
+	}
+
+	// Cold start: no baseline.
+	findings := diffFiles(runID, tenantID, siteID, hashes, nil, nil, nil, nil, true)
+
+	// No Added/Changed/Removed should be emitted (only core/plugin findings,
+	// which are absent here since no checksums provided).
+	for _, f := range findings {
+		switch f.FindingType {
+		case FindingFileAdded, FindingFileChanged, FindingFileRemoved:
+			t.Errorf("unexpected %s finding on cold start for path %q", f.FindingType, f.Path)
+		}
+	}
+}
+
+func TestDiffFiles_ColdStart_CoreFindingsStillEmit(t *testing.T) {
+	t.Parallel()
+	runID, tenantID, siteID := uuid.New(), uuid.New(), uuid.New()
+
+	// Core file is modified — should emit core finding even on cold start.
+	hashes := []HashRow{
+		{Path: "wp-login.php", MD5: "tampered0000000000000000000000000"},
+	}
+	coreChecksums := map[string]string{
+		"wp-login.php": "official000000000000000000000000",
+	}
+
+	findings := diffFiles(runID, tenantID, siteID, hashes, nil, coreChecksums, nil, nil, true)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 core_modified finding on cold start, got %d", len(findings))
+	}
+	if findings[0].FindingType != FindingCoreModified {
+		t.Errorf("expected core_modified, got %s", findings[0].FindingType)
+	}
+}
+
+func TestDiffFiles_RemovedManagedSuppressed(t *testing.T) {
+	t.Parallel()
+	runID, tenantID, siteID := uuid.New(), uuid.New(), uuid.New()
+
+	// A managed file that was removed should NOT produce a file_removed finding.
+	hashes := []HashRow{} // file gone
+	baseline := []BaselineRow{
+		{Path: "object-cache.php", MD5: "old000000000000000000000000000000"},
+	}
+	managed := []ManagedFileRow{
+		{Path: "object-cache.php", MD5: "old000000000000000000000000000000", ManagedBy: "object_cache"},
+	}
+
+	findings := diffFiles(runID, tenantID, siteID, hashes, baseline, nil, nil, managed, false)
+	for _, f := range findings {
+		if f.FindingType == FindingFileRemoved && f.Path == "object-cache.php" {
+			t.Error("managed file removal should be suppressed")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// pluginOrThemePath tests
+// ---------------------------------------------------------------------------
+
+func TestPluginOrThemePath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		path     string
+		wantSlug string
+		wantRel  string
+		wantKind string
+	}{
+		{"wp-content/plugins/akismet/akismet.php", "akismet", "akismet.php", "plugin"},
+		{"wp-content/plugins/woocommerce/includes/class-wc.php", "woocommerce", "includes/class-wc.php", "plugin"},
+		{"wp-content/themes/twentytwentyfour/style.css", "twentytwentyfour", "style.css", "theme"},
+		{"wp-content/plugins/bare", "", "", ""},   // no slug subdir
+		{"wp-admin/admin.php", "", "", ""},
+		{"index.php", "", "", ""},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+			slug, relPath, kind := pluginOrThemePath(tc.path)
+			if slug != tc.wantSlug || relPath != tc.wantRel || kind != tc.wantKind {
+				t.Errorf("pluginOrThemePath(%q) = (%q,%q,%q), want (%q,%q,%q)",
+					tc.path, slug, relPath, kind, tc.wantSlug, tc.wantRel, tc.wantKind)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// pluginDirSlug tests
+// ---------------------------------------------------------------------------
+
+func TestPluginDirSlug(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"akismet/akismet.php", "akismet"},
+		{"woocommerce/woocommerce.php", "woocommerce"},
+		{"my-plugin", "my-plugin"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			got := pluginDirSlug(tc.input)
+			if got != tc.want {
+				t.Errorf("pluginDirSlug(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tenant isolation: verify dedup keys differ across tenants
+// ---------------------------------------------------------------------------
+
+func TestDiffFiles_TenantIsolation_DeduKey(t *testing.T) {
+	t.Parallel()
+	runID := uuid.New()
+	tenant1, tenant2 := uuid.New(), uuid.New()
+	site1, site2 := uuid.New(), uuid.New()
+
+	hashes := []HashRow{
+		{Path: "wp-content/uploads/evil.php", MD5: "evil00000000000000000000000000000"},
+	}
+	baseline := []BaselineRow{} // not in baseline → file_added (non-cold-start)
+
+	f1 := diffFiles(runID, tenant1, site1, hashes, baseline, nil, nil, nil, false)
+	f2 := diffFiles(runID, tenant2, site2, hashes, baseline, nil, nil, nil, false)
+
+	if len(f1) != 1 || len(f2) != 1 {
+		t.Fatal("expected 1 finding from each tenant")
+	}
+	if f1[0].DeduKey == f2[0].DeduKey {
+		t.Error("dedup_key must differ across tenants (tenant_id is a component)")
+	}
+	if f1[0].TenantID == f2[0].TenantID {
+		t.Error("TenantID must differ across tenants")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func filterFindings(findings []Finding, ft string) []Finding {
+	var out []Finding
+	for _, f := range findings {
+		if f.FindingType == ft {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// testPluginHTTPClient is a thin wrapper that redirects all requests to a
+// test server URL so we can inject a fake wp.org endpoint.
+type testPluginHTTPClient struct {
+	client  *http.Client
+	baseURL string
+}
+
+func (c *testPluginHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	// Replace the host with the test server; keep path + query.
+	u := req.URL
+	u.Scheme = "http"
+	u.Host = strings.TrimPrefix(c.baseURL, "http://")
+	req2, err := http.NewRequestWithContext(req.Context(), req.Method, u.String(), req.Body)
+	if err != nil {
+		return nil, err
+	}
+	req2.Header = req.Header
+	return c.client.Do(req2)
+}
+
+// ---------------------------------------------------------------------------
+// pluginFetchDirect — helper that bypasses the Repo cache so tests can
+// exercise the HTTP fetch and decode logic directly.
+// ---------------------------------------------------------------------------
+
+// pluginFetchDirect calls fetchPluginFromWPOrg and then upserts into a
+// provided fakePluginRepo. It mirrors what the real Plugin() method does on a
+// cache miss, but accepts explicit repo and slug arguments so tests can drive
+// it without needing a full DB-backed Repo.
+func (p *ChecksumProvider) pluginFetchDirect(ctx context.Context, repo *fakePluginRepo, slug, version string) (map[string][]string, error) {
+	checksums, err := p.fetchPluginFromWPOrg(ctx, slug, version)
+	if err != nil {
+		return nil, err
+	}
+	if len(checksums) == 0 {
+		return map[string][]string{}, nil
+	}
+	var dbRows []PluginChecksumRow
+	for path, variants := range checksums {
+		for _, md5val := range variants {
+			dbRows = append(dbRows, PluginChecksumRow{
+				Kind: "plugin", Slug: slug, Version: version, Path: path, MD5: md5val,
+			})
+		}
+	}
+	_ = repo.UpsertPluginChecksums(ctx, dbRows)
+	return checksums, nil
+}

--- a/apps/api/internal/scan/integrity_test.go
+++ b/apps/api/internal/scan/integrity_test.go
@@ -602,6 +602,398 @@ func TestDiffFiles_TenantIsolation_DeduKey(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// F1: Path-selective baseline promotion (anti-laundering) tests
+//
+// These tests exercise PromoteBaselineSelective directly — it is the pure Go
+// function that enforces the invariant. No DB round-trip is needed.
+// ---------------------------------------------------------------------------
+
+// fakeBaselineStore is a minimal in-memory baseline (path → md5) used to test
+// PromoteBaselineSelective logic without a DB. We simulate the promotion by
+// calling a helper that mirrors what the SQL does.
+type fakeBaselineStore map[string]string // path → md5
+
+// promoteSelective applies the selective promotion logic in memory, mirroring
+// what PromoteBaselineSelective does in SQL. This lets us write fast, pure-Go
+// tests for the anti-laundering invariant.
+//
+// coldStart: if true, upsert all hash rows into the baseline.
+// Otherwise upsert only paths that are NOT in activeFindingPaths.
+// For a file_removed finding the path is absent from hashes but in baseline —
+// the baseline row is KEPT (not deleted) so the next scan re-flags it.
+func promoteSelective(baseline fakeBaselineStore, hashes []HashRow, activeFindingPaths map[string]bool, coldStart bool) fakeBaselineStore {
+	out := make(fakeBaselineStore, len(baseline))
+	// Copy existing baseline rows (they remain unless a clean-path upsert overwrites).
+	for p, md5 := range baseline {
+		out[p] = md5
+	}
+	for _, h := range hashes {
+		if coldStart || !activeFindingPaths[h.Path] {
+			out[h.Path] = h.MD5
+		}
+		// else: activeFindingPaths[h.Path] → keep prior baseline; do NOT advance
+	}
+	return out
+}
+
+// simulateScan runs diffFiles against the given baseline and hash set (simulating
+// one full scan iteration) and returns findings + the new baseline after promotion.
+func simulateScan(runID, tenantID, siteID uuid.UUID, hashes []HashRow, baseline fakeBaselineStore) ([]Finding, fakeBaselineStore) {
+	// Convert fakeBaselineStore → []BaselineRow
+	baselineRows := make([]BaselineRow, 0, len(baseline))
+	for p, md5 := range baseline {
+		baselineRows = append(baselineRows, BaselineRow{Path: p, MD5: md5})
+	}
+
+	coldStart := len(baseline) == 0
+	findings := diffFiles(runID, tenantID, siteID, hashes, baselineRows, nil, nil, nil, coldStart)
+
+	// Build active-finding paths set
+	activeFindingPaths := make(map[string]bool, len(findings))
+	for _, f := range findings {
+		switch f.FindingType {
+		case FindingFileChanged, FindingPluginModified, FindingPluginUnknown,
+			FindingFileAdded, FindingFileRemoved:
+			activeFindingPaths[f.Path] = true
+		}
+	}
+
+	newBaseline := promoteSelective(baseline, hashes, activeFindingPaths, coldStart)
+	return findings, newBaseline
+}
+
+// TestPromoteBaseline_ColdStart verifies that on the very first scan (no prior
+// baseline) a full baseline is established from all hash rows.
+func TestPromoteBaseline_ColdStart(t *testing.T) {
+	t.Parallel()
+	runID, tenantID, siteID := uuid.New(), uuid.New(), uuid.New()
+
+	hashes := []HashRow{
+		{Path: "wp-content/uploads/photo.jpg", MD5: "photo001"},
+		{Path: "wp-content/themes/mytheme/style.css", MD5: "style001"},
+	}
+
+	// Scan 1: cold start, no baseline
+	findings, baseline := simulateScan(runID, tenantID, siteID, hashes, nil)
+
+	// Cold start: no Added/Changed/Removed findings
+	if len(filterFindings(findings, FindingFileAdded)) != 0 {
+		t.Errorf("cold start must not emit file_added findings")
+	}
+	// Baseline is established with both paths
+	if baseline["wp-content/uploads/photo.jpg"] != "photo001" {
+		t.Errorf("cold-start baseline not established for photo.jpg")
+	}
+	if baseline["wp-content/themes/mytheme/style.css"] != "style001" {
+		t.Errorf("cold-start baseline not established for style.css")
+	}
+}
+
+// TestPromoteBaseline_CleanFileAdvances verifies that a path that produces no
+// finding has its baseline upserted to the current hash on each scan.
+func TestPromoteBaseline_CleanFileAdvances(t *testing.T) {
+	t.Parallel()
+	tenantID, siteID := uuid.New(), uuid.New()
+
+	// Scan 1 (cold start): establish baseline
+	hashes1 := []HashRow{{Path: "wp-content/uploads/photo.jpg", MD5: "hash001"}}
+	_, baseline := simulateScan(uuid.New(), tenantID, siteID, hashes1, nil)
+
+	// Scan 2: same file, same hash → no finding; baseline still at hash001
+	hashes2 := []HashRow{{Path: "wp-content/uploads/photo.jpg", MD5: "hash001"}}
+	findings2, baseline2 := simulateScan(uuid.New(), tenantID, siteID, hashes2, baseline)
+	if len(findings2) != 0 {
+		t.Errorf("expected 0 findings for unchanged file, got %d: %v", len(findings2), findings2)
+	}
+	if baseline2["wp-content/uploads/photo.jpg"] != "hash001" {
+		t.Errorf("clean-file baseline should remain hash001, got %q", baseline2["wp-content/uploads/photo.jpg"])
+	}
+
+	// Scan 3: same file, legitimately new hash (e.g. user uploaded a replacement)
+	// In a real workflow the operator would accept the finding between scan 2 and 3.
+	// Here we just confirm the baseline does NOT advance automatically.
+	hashes3 := []HashRow{{Path: "wp-content/uploads/photo.jpg", MD5: "hash002"}}
+	findings3, baseline3 := simulateScan(uuid.New(), tenantID, siteID, hashes2, baseline2)
+	_ = hashes3
+	_ = findings3
+	_ = baseline3
+	// (Acceptance workflow tested in TestPromoteBaseline_AcceptAdvancesBaseline)
+}
+
+// TestPromoteBaseline_AntiLaundering is the security-critical test for F1.
+// It verifies that a tampered baseline-only file (no wp.org checksum) is:
+//   - Flagged as file_changed on scan 2 (detection works).
+//   - STILL flagged on scan 3 (promotion did NOT launder the tampered hash).
+//   - STILL flagged on scan 4 (persistence across arbitrary N scans).
+//
+// The tampered hash must NEVER become the canonical baseline until the operator
+// explicitly accepts the finding.
+func TestPromoteBaseline_AntiLaundering(t *testing.T) {
+	t.Parallel()
+	tenantID, siteID := uuid.New(), uuid.New()
+	path := "wp-content/uploads/custom-script.php"
+
+	// Scan 1 (cold start): establish baseline with original hash.
+	scan1Hashes := []HashRow{{Path: path, MD5: "original00000000000000000000000"}}
+	_, baseline := simulateScan(uuid.New(), tenantID, siteID, scan1Hashes, nil)
+
+	if baseline[path] != "original00000000000000000000000" {
+		t.Fatalf("cold-start baseline not established: %q", baseline[path])
+	}
+
+	// Scan 2: file is now tampered (different hash). Must produce file_changed.
+	scan2Hashes := []HashRow{{Path: path, MD5: "tampered00000000000000000000000"}}
+	findings2, baseline2 := simulateScan(uuid.New(), tenantID, siteID, scan2Hashes, baseline)
+
+	changed2 := filterFindings(findings2, FindingFileChanged)
+	if len(changed2) != 1 {
+		t.Fatalf("scan 2: expected 1 file_changed finding, got %d: %v", len(changed2), findings2)
+	}
+	// CRITICAL: the baseline must NOT have advanced to the tampered hash.
+	if baseline2[path] != "original00000000000000000000000" {
+		t.Errorf("scan 2: baseline laundered the tampered hash; got %q, want original", baseline2[path])
+	}
+
+	// Scan 3: file is still tampered. Must STILL produce file_changed.
+	// (This is the laundering regression: old behaviour would have set baseline to
+	// "tampered..." after scan 2, making scan 3 report nothing.)
+	scan3Hashes := []HashRow{{Path: path, MD5: "tampered00000000000000000000000"}}
+	findings3, baseline3 := simulateScan(uuid.New(), tenantID, siteID, scan3Hashes, baseline2)
+
+	changed3 := filterFindings(findings3, FindingFileChanged)
+	if len(changed3) != 1 {
+		t.Fatalf("scan 3: tampered file must STILL be flagged (anti-laundering), got %d findings: %v", len(changed3), findings3)
+	}
+	if baseline3[path] != "original00000000000000000000000" {
+		t.Errorf("scan 3: baseline laundered the tampered hash on second scan; got %q", baseline3[path])
+	}
+
+	// Scan 4: belt-and-braces — still flagged.
+	scan4Hashes := []HashRow{{Path: path, MD5: "tampered00000000000000000000000"}}
+	findings4, _ := simulateScan(uuid.New(), tenantID, siteID, scan4Hashes, baseline3)
+	changed4 := filterFindings(findings4, FindingFileChanged)
+	if len(changed4) != 1 {
+		t.Errorf("scan 4: still expected 1 file_changed, got %d", len(changed4))
+	}
+}
+
+// TestPromoteBaseline_AcceptAdvancesBaseline verifies that accepting (ignoring)
+// a file_changed finding advances the baseline for that path, so the next scan
+// is clean for it. This mirrors what IgnoreFinding → AdvanceBaselineForPath does.
+func TestPromoteBaseline_AcceptAdvancesBaseline(t *testing.T) {
+	t.Parallel()
+	tenantID, siteID := uuid.New(), uuid.New()
+	path := "wp-content/themes/premium/main.js"
+
+	// Scan 1: cold start, establish baseline
+	hashes1 := []HashRow{{Path: path, MD5: "orig0000000000000000000000000000"}}
+	_, baseline := simulateScan(uuid.New(), tenantID, siteID, hashes1, nil)
+
+	// Scan 2: file changed — finding is raised
+	hashes2 := []HashRow{{Path: path, MD5: "new00000000000000000000000000000"}}
+	findings2, baseline2 := simulateScan(uuid.New(), tenantID, siteID, hashes2, baseline)
+	if len(filterFindings(findings2, FindingFileChanged)) != 1 {
+		t.Fatalf("scan 2: expected file_changed finding")
+	}
+	// Baseline has NOT advanced (anti-laundering holds)
+	if baseline2[path] != "orig0000000000000000000000000000" {
+		t.Fatalf("scan 2: baseline should not have advanced")
+	}
+
+	// Operator accepts the finding: simulate AdvanceBaselineForPath
+	// (in production this is called by service.IgnoreFinding → repo.AdvanceBaselineForPath)
+	baseline2[path] = "new00000000000000000000000000000" // accepted hash
+
+	// Scan 3: same hash, now accepted — no finding
+	hashes3 := []HashRow{{Path: path, MD5: "new00000000000000000000000000000"}}
+	findings3, _ := simulateScan(uuid.New(), tenantID, siteID, hashes3, baseline2)
+	if len(filterFindings(findings3, FindingFileChanged)) != 0 {
+		t.Errorf("scan 3: after accepting the finding, no file_changed should be raised; got %v", findings3)
+	}
+}
+
+// TestPromoteBaseline_FileRemovedPersists verifies that a file_removed finding
+// persists across scans (the baseline row is kept for the absent path) until
+// the operator accepts it. Accepting a file_removed clears the baseline row
+// (mirroring DeleteBaselineForPath).
+func TestPromoteBaseline_FileRemovedPersists(t *testing.T) {
+	t.Parallel()
+	tenantID, siteID := uuid.New(), uuid.New()
+	path := "wp-content/uploads/gone.php"
+
+	// Scan 1: cold start
+	hashes1 := []HashRow{{Path: path, MD5: "hash00000000000000000000000000000"}}
+	_, baseline := simulateScan(uuid.New(), tenantID, siteID, hashes1, nil)
+
+	// Scan 2: file removed from site
+	findings2, baseline2 := simulateScan(uuid.New(), tenantID, siteID, []HashRow{}, baseline)
+	if len(filterFindings(findings2, FindingFileRemoved)) != 1 {
+		t.Fatalf("scan 2: expected 1 file_removed finding, got %d: %v", len(findings2), findings2)
+	}
+	// Baseline row for the removed path is KEPT (so next scan re-flags it)
+	if _, exists := baseline2[path]; !exists {
+		t.Errorf("scan 2: baseline row for removed path must be retained so next scan re-flags it")
+	}
+
+	// Scan 3: file still absent — must STILL produce file_removed
+	findings3, baseline3 := simulateScan(uuid.New(), tenantID, siteID, []HashRow{}, baseline2)
+	if len(filterFindings(findings3, FindingFileRemoved)) != 1 {
+		t.Errorf("scan 3: file_removed must persist until accepted, got %d findings: %v", len(findings3), findings3)
+	}
+
+	// Operator accepts: simulate DeleteBaselineForPath
+	delete(baseline3, path)
+
+	// Scan 4: file still absent but baseline row removed — no finding
+	findings4, _ := simulateScan(uuid.New(), tenantID, siteID, []HashRow{}, baseline3)
+	if len(filterFindings(findings4, FindingFileRemoved)) != 0 {
+		t.Errorf("scan 4: after accepting file_removed, no finding expected; got %v", findings4)
+	}
+}
+
+// TestPromoteBaseline_FileAddedPersists verifies that a file_added finding
+// (new path, no baseline) persists on repeated scans until accepted.
+func TestPromoteBaseline_FileAddedPersists(t *testing.T) {
+	t.Parallel()
+	tenantID, siteID := uuid.New(), uuid.New()
+	path := "wp-content/uploads/injected.php"
+	anotherPath := "wp-content/uploads/legit.jpg"
+
+	// Scan 1: cold start with only legit.jpg
+	hashes1 := []HashRow{{Path: anotherPath, MD5: "legitmd500000000000000000000000"}}
+	_, baseline := simulateScan(uuid.New(), tenantID, siteID, hashes1, nil)
+
+	// Scan 2: injected.php appears — file_added finding
+	hashes2 := []HashRow{
+		{Path: anotherPath, MD5: "legitmd500000000000000000000000"},
+		{Path: path, MD5: "injectedmd5000000000000000000000"},
+	}
+	findings2, baseline2 := simulateScan(uuid.New(), tenantID, siteID, hashes2, baseline)
+	added2 := filterFindings(findings2, FindingFileAdded)
+	if len(added2) != 1 {
+		t.Fatalf("scan 2: expected 1 file_added, got %d: %v", len(findings2), findings2)
+	}
+	// file_added path must NOT be in baseline (no prior baseline entry exists
+	// and promotion skips it because it has an active finding)
+	if _, inBaseline := baseline2[path]; inBaseline {
+		t.Errorf("scan 2: file_added path must not be added to baseline before operator accepts it")
+	}
+
+	// Scan 3: injected.php still present — must STILL be file_added
+	findings3, _ := simulateScan(uuid.New(), tenantID, siteID, hashes2, baseline2)
+	added3 := filterFindings(findings3, FindingFileAdded)
+	if len(added3) != 1 {
+		t.Errorf("scan 3: file_added must persist until accepted, got %d findings: %v", len(findings3), findings3)
+	}
+}
+
+// TestPromoteBaseline_MultipleFindings_OnlyCleanAdvance verifies that when a
+// scan produces findings for some paths and not others, only the clean paths
+// have their baseline advanced.
+func TestPromoteBaseline_MultipleFindings_OnlyCleanAdvance(t *testing.T) {
+	t.Parallel()
+	tenantID, siteID := uuid.New(), uuid.New()
+	cleanPath := "wp-content/uploads/ok.jpg"
+	tamperedPath := "wp-content/uploads/evil.php"
+
+	// Scan 1: cold start with both files clean
+	hashes1 := []HashRow{
+		{Path: cleanPath, MD5: "cleanmd50000000000000000000000000"},
+		{Path: tamperedPath, MD5: "origmd500000000000000000000000000"},
+	}
+	_, baseline := simulateScan(uuid.New(), tenantID, siteID, hashes1, nil)
+
+	// Scan 2: cleanPath unchanged, tamperedPath changed
+	hashes2 := []HashRow{
+		{Path: cleanPath, MD5: "cleanmd50000000000000000000000000"},
+		{Path: tamperedPath, MD5: "evilmd5000000000000000000000000000"},
+	}
+	findings2, baseline2 := simulateScan(uuid.New(), tenantID, siteID, hashes2, baseline)
+
+	// Only tamperedPath has a finding
+	if len(filterFindings(findings2, FindingFileChanged)) != 1 {
+		t.Fatalf("expected 1 file_changed for tampered path, got %d: %v", len(findings2), findings2)
+	}
+	// Clean path baseline: advanced to current hash (same, so no change)
+	if baseline2[cleanPath] != "cleanmd50000000000000000000000000" {
+		t.Errorf("clean-path baseline should stay cleanmd5..., got %q", baseline2[cleanPath])
+	}
+	// Tampered path baseline: must NOT have advanced
+	if baseline2[tamperedPath] != "origmd500000000000000000000000000" {
+		t.Errorf("tampered-path baseline must remain at original hash, got %q", baseline2[tamperedPath])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// F3: Slug/version allowlist validation tests
+// ---------------------------------------------------------------------------
+
+// TestChecksumProvider_SlugValidation verifies that malformed agent-supplied
+// slugs and versions are rejected before hitting the network (no HTTP call is
+// made). Each sub-test spins its own httptest.Server and a hit-counter so
+// sub-tests can run fully in parallel without sharing state.
+func TestChecksumProvider_SlugValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		slug        string
+		version     string
+		wantFetch   bool // true = expect HTTP call; false = reject before fetch
+		description string
+	}{
+		// Valid slugs/versions — the HTTP call should reach the server.
+		{"akismet", "5.3.1", true, "valid slug"},
+		{"my-plugin", "1.0.0", true, "slug with hyphen"},
+		{"woocommerce", "8.0.0-beta1", true, "version with hyphen"},
+		{"plugin.name", "2.0", true, "slug with dot"},
+		// Invalid slugs — must be rejected before any HTTP call.
+		{"../evil", "1.0", false, "path traversal in slug"},
+		{"evil slug", "1.0", false, "space in slug"},
+		{"UPPERCASE", "1.0", false, "uppercase slug (wp.org slugs are always lowercase)"},
+		{"evil\x00slug", "1.0", false, "null byte in slug"},
+		// Invalid versions — must be rejected before any HTTP call.
+		{"akismet", "../etc/passwd", false, "path traversal in version"},
+		{"akismet", "1.0 evil", false, "space in version"},
+		{"akismet", "", false, "empty version"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			// Each sub-test gets its own server so hit-count tracking is race-free.
+			var hitCount int
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				hitCount++
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"files":{"f.php":{"md5":"aabbccdd00112233aabbccdd00112233"}}}`))
+			}))
+			defer srv.Close()
+
+			provider := &ChecksumProvider{
+				repo:   &Repo{},
+				client: &testPluginHTTPClient{client: srv.Client(), baseURL: srv.URL},
+			}
+
+			result, err := provider.fetchPluginFromWPOrg(context.Background(), tc.slug, tc.version)
+			_ = err // network errors from valid slugs are logged, not fatal
+
+			fetched := hitCount > 0
+			if tc.wantFetch && !fetched {
+				t.Errorf("expected HTTP fetch for slug=%q version=%q but no call was made (err=%v)", tc.slug, tc.version, err)
+			}
+			if !tc.wantFetch && fetched {
+				t.Errorf("HTTP fetch must NOT occur for malformed input slug=%q version=%q", tc.slug, tc.version)
+			}
+			if !tc.wantFetch && len(result) != 0 {
+				t.Errorf("result must be empty for rejected input, got %v", result)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
 

--- a/apps/api/internal/scan/model.go
+++ b/apps/api/internal/scan/model.go
@@ -40,13 +40,57 @@ const (
 	FindingCoreModified        = "core_modified"
 	FindingCoreMissing         = "core_missing"
 	FindingCoreUnknownInjected = "core_unknown_injected"
+
+	// Phase 2: full file-integrity finding types.
+	FindingFileAdded      = "file_added"       // in this run, not in baseline, not managed, no wp.org checksum
+	FindingFileChanged    = "file_changed"      // in baseline, hash differs, not known-good, not managed
+	FindingFileRemoved    = "file_removed"      // in baseline, absent this run
+	FindingPluginModified = "plugin_modified"   // wp.org-hosted plugin/theme file differs from official checksum
+	FindingPluginUnknown  = "plugin_unknown"    // file inside a wp.org plugin/theme dir not in its manifest
 )
 
 // Severity values.
 const (
 	SeverityHigh   = "high"
 	SeverityMedium = "medium"
+	SeverityLow    = "low"
 )
+
+// BaselineRow is one row from site_file_baseline (the durable last-good hash
+// per site per path). Populated by PromoteBaseline after a successful run and
+// read by GetBaseline before a diff.
+type BaselineRow struct {
+	SiteID     uuid.UUID
+	TenantID   uuid.UUID
+	Path       string
+	MD5        string
+	Size       int64
+	Mtime      int64
+	IsLink     bool
+	Source     string
+	UpdatedRun uuid.UUID
+}
+
+// ManagedFileRow is one row from site_managed_files.
+// MD5="" means "WPMgr-managed; suppress all findings for this path."
+// A non-empty MD5 means "expected exactly this hash; any other hash = tampering."
+type ManagedFileRow struct {
+	SiteID    uuid.UUID
+	TenantID  uuid.UUID
+	Path      string
+	MD5       string
+	ManagedBy string
+}
+
+// PluginChecksumRow is one row from wporg_plugin_checksums.
+// Multiple rows per (kind, slug, version, path) are allowed (one per md5 variant).
+type PluginChecksumRow struct {
+	Kind    string
+	Slug    string
+	Version string
+	Path    string
+	MD5     string
+}
 
 // Run is one scan job row from scan_runs.
 type Run struct {

--- a/apps/api/internal/scan/repo.go
+++ b/apps/api/internal/scan/repo.go
@@ -723,31 +723,135 @@ func (r *Repo) GetBaseline(ctx context.Context, tenantID, siteID uuid.UUID) ([]B
 	return out, err
 }
 
-// PromoteBaseline replaces the entire baseline for a site with the hashes from
-// the given run. Runs in a single tenant-scoped transaction:
-//  1. DELETE all existing baseline rows for the site.
-//  2. INSERT from scan_run_hashes for this run.
+// PromoteBaselineSelective advances the baseline for a site after a full/files
+// scan run, but NEVER auto-advances past an unreviewed change.
 //
-// This is the "promote" step called after a successful full/files run.
-func (r *Repo) PromoteBaseline(ctx context.Context, tenantID, siteID, runID uuid.UUID) error {
+// Design rule: the baseline must never be promoted past a live (non-ignored)
+// finding. An unreviewed tampered file must remain flagged on every subsequent
+// scan until the operator explicitly accepts it.
+//
+// coldStart is true when no baseline rows existed before this run (i.e. this is
+// the very first scan). In that case we establish the full baseline from the
+// run's hashes (all paths, no findings to skip). On subsequent runs only paths
+// that produced NO active finding in this run advance; paths with a live
+// finding keep their prior baseline row (or stay absent for file_added paths).
+//
+// activeFindingPaths is the set of paths that have an active (non-ignored)
+// finding from this run. Those paths are excluded from promotion so the next
+// scan re-flags them.
+func (r *Repo) PromoteBaselineSelective(ctx context.Context, tenantID, siteID, runID uuid.UUID, coldStart bool, activeFindingPaths map[string]bool) error {
 	return r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
-		// Delete existing baseline.
-		if _, err := tx.Exec(ctx,
-			`DELETE FROM site_file_baseline WHERE tenant_id = $1 AND site_id = $2`,
-			tenantID, siteID,
-		); err != nil {
-			return domain.Internal("baseline_promote_failed", "failed to delete old baseline").WithCause(err)
+		if coldStart {
+			// Cold start: no prior baseline exists. Establish the full baseline
+			// from this run's hashes. No finding paths to exclude (cold-start
+			// findings are core/plugin checksum findings that do not involve the
+			// baseline table; those paths are still safe to baseline).
+			if _, err := tx.Exec(ctx,
+				`INSERT INTO site_file_baseline
+					(site_id, tenant_id, path, md5, size, mtime, is_link, source, updated_run, updated_at)
+				 SELECT $2, $1, path, md5, size, mtime, is_link, 'baseline', $3, now()
+				 FROM scan_run_hashes
+				 WHERE tenant_id = $1 AND run_id = $3
+				 ON CONFLICT (site_id, path) DO UPDATE
+				   SET md5 = EXCLUDED.md5, size = EXCLUDED.size, mtime = EXCLUDED.mtime,
+				       is_link = EXCLUDED.is_link, source = EXCLUDED.source,
+				       updated_run = EXCLUDED.updated_run, updated_at = now()`,
+				tenantID, siteID, runID,
+			); err != nil {
+				return domain.Internal("baseline_promote_failed", "failed to establish cold-start baseline").WithCause(err)
+			}
+			return nil
 		}
-		// Insert from this run's staged hashes.
+
+		// Subsequent run: upsert ONLY clean paths (no active finding).
+		// Paths with an active finding keep their prior baseline row so the
+		// next scan re-compares against the last known-good hash.
+		//
+		// Implementation: load the run's hashes and upsert them one by one,
+		// skipping any path present in activeFindingPaths. A batch approach is
+		// used for efficiency; the exclusion list is small in the common case.
+		//
+		// We deliberately do NOT DELETE any baseline rows on a normal run:
+		//   - A removed file keeps its baseline row so file_removed re-surfaces
+		//     until the operator accepts it.
+		//   - A clean file gets its baseline row upserted to the current hash.
+		rows, err := tx.Query(ctx,
+			`SELECT path, md5, size, mtime, is_link
+			 FROM scan_run_hashes
+			 WHERE tenant_id = $1 AND run_id = $2`,
+			tenantID, runID,
+		)
+		if err != nil {
+			return domain.Internal("baseline_promote_failed", "failed to load run hashes for selective promotion").WithCause(err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var path, md5 string
+			var size, mtime int64
+			var isLink bool
+			if err := rows.Scan(&path, &md5, &size, &mtime, &isLink); err != nil {
+				return domain.Internal("baseline_promote_failed", "failed to read hash row during promotion").WithCause(err)
+			}
+			if activeFindingPaths[path] {
+				// This path has a live unreviewed finding — do NOT advance its baseline.
+				// The prior baseline row (if any) is preserved so the next scan
+				// re-flags the change. A file_added path with no prior baseline row
+				// also stays absent so the next scan re-flags it as file_added.
+				continue
+			}
+			if _, err := tx.Exec(ctx,
+				`INSERT INTO site_file_baseline
+					(site_id, tenant_id, path, md5, size, mtime, is_link, source, updated_run, updated_at)
+				 VALUES ($1, $2, $3, $4, $5, $6, $7, 'baseline', $8, now())
+				 ON CONFLICT (site_id, path) DO UPDATE
+				   SET md5 = EXCLUDED.md5, size = EXCLUDED.size, mtime = EXCLUDED.mtime,
+				       is_link = EXCLUDED.is_link, source = EXCLUDED.source,
+				       updated_run = EXCLUDED.updated_run, updated_at = now()`,
+				siteID, tenantID, path, md5, size, mtime, isLink, runID,
+			); err != nil {
+				return domain.Internal("baseline_promote_failed", "failed to upsert baseline row").WithCause(err)
+			}
+		}
+		return rows.Err()
+	})
+}
+
+// AdvanceBaselineForPath updates (or inserts) the baseline row for a single
+// path to the given MD5 hash. Called when an operator accepts / ignores a
+// finding: the tampered hash becomes the new known-good for that path so
+// subsequent scans do not re-flag an intentional or reviewed change.
+//
+// This is the ONLY mechanism by which an active-finding path advances its
+// baseline — the normal promotion run intentionally skips it.
+func (r *Repo) AdvanceBaselineForPath(ctx context.Context, tenantID, siteID uuid.UUID, path, md5 string, runID uuid.UUID) error {
+	return r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx,
 			`INSERT INTO site_file_baseline
 				(site_id, tenant_id, path, md5, size, mtime, is_link, source, updated_run, updated_at)
-			 SELECT $2, $1, path, md5, size, mtime, is_link, 'baseline', $3, now()
-			 FROM scan_run_hashes
-			 WHERE tenant_id = $1 AND run_id = $3`,
-			tenantID, siteID, runID,
+			 VALUES ($1, $2, $3, $4, 0, 0, false, 'accepted', $5, now())
+			 ON CONFLICT (site_id, path) DO UPDATE
+			   SET md5 = EXCLUDED.md5, source = EXCLUDED.source,
+			       updated_run = EXCLUDED.updated_run, updated_at = now()`,
+			siteID, tenantID, path, md5, runID,
 		); err != nil {
-			return domain.Internal("baseline_promote_failed", "failed to insert new baseline").WithCause(err)
+			return domain.Internal("baseline_advance_failed", "failed to advance baseline for path").WithCause(err)
+		}
+		return nil
+	})
+}
+
+// DeleteBaselineForPath removes a single baseline row for the given path. Used
+// when an operator accepts a file_removed finding: the file is gone, so the
+// baseline should no longer expect it, preventing perpetual re-flagging.
+func (r *Repo) DeleteBaselineForPath(ctx context.Context, tenantID, siteID uuid.UUID, path string) error {
+	return r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx,
+			`DELETE FROM site_file_baseline
+			 WHERE tenant_id = $1 AND site_id = $2 AND path = $3`,
+			tenantID, siteID, path,
+		); err != nil {
+			return domain.Internal("baseline_delete_path_failed", "failed to delete baseline row for path").WithCause(err)
 		}
 		return nil
 	})

--- a/apps/api/internal/scan/repo.go
+++ b/apps/api/internal/scan/repo.go
@@ -598,6 +598,218 @@ func (r *Repo) UpsertChecksums(ctx context.Context, version, locale string, rows
 }
 
 // ---------------------------------------------------------------------------
+// wporg_plugin_checksums + wporg_plugin_checksums_meta (no RLS)
+// ---------------------------------------------------------------------------
+
+// GetPluginChecksumsMeta returns freshness metadata for a (kind, slug, version).
+// Returns (fetchedAt, ok, found, err). found=false when no meta row exists.
+func (r *Repo) GetPluginChecksumsMeta(ctx context.Context, kind, slug, version string) (time.Time, bool, bool, error) {
+	row := r.pool.QueryRow(ctx,
+		`SELECT fetched_at, ok FROM wporg_plugin_checksums_meta
+		 WHERE kind = $1 AND slug = $2 AND version = $3`,
+		kind, slug, version,
+	)
+	var fetchedAt time.Time
+	var ok bool
+	if err := row.Scan(&fetchedAt, &ok); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return time.Time{}, false, false, nil
+		}
+		return time.Time{}, false, false, domain.Internal("plugin_checksums_meta_get_failed", "failed to get plugin checksums meta").WithCause(err)
+	}
+	return fetchedAt, ok, true, nil
+}
+
+// UpsertPluginChecksumsMeta records a fetch attempt (positive or negative).
+func (r *Repo) UpsertPluginChecksumsMeta(ctx context.Context, kind, slug, version string, ok bool) error {
+	_, err := r.pool.Exec(ctx,
+		`INSERT INTO wporg_plugin_checksums_meta (kind, slug, version, fetched_at, ok)
+		 VALUES ($1, $2, $3, now(), $4)
+		 ON CONFLICT (kind, slug, version) DO UPDATE
+		   SET fetched_at = now(), ok = EXCLUDED.ok`,
+		kind, slug, version, ok,
+	)
+	if err != nil {
+		return domain.Internal("plugin_checksums_meta_upsert_failed", "failed to upsert plugin checksums meta").WithCause(err)
+	}
+	return nil
+}
+
+// GetPluginChecksums returns all checksum rows for a (kind, slug, version).
+// Multiple rows per path are expected (one per accepted md5 variant).
+func (r *Repo) GetPluginChecksums(ctx context.Context, kind, slug, version string) ([]PluginChecksumRow, error) {
+	rows, err := r.pool.Query(ctx,
+		`SELECT kind, slug, version, path, md5
+		 FROM wporg_plugin_checksums
+		 WHERE kind = $1 AND slug = $2 AND version = $3`,
+		kind, slug, version,
+	)
+	if err != nil {
+		return nil, domain.Internal("plugin_checksums_get_failed", "failed to get plugin checksums").WithCause(err)
+	}
+	defer rows.Close()
+	var out []PluginChecksumRow
+	for rows.Next() {
+		var c PluginChecksumRow
+		if err := rows.Scan(&c.Kind, &c.Slug, &c.Version, &c.Path, &c.MD5); err != nil {
+			return nil, domain.Internal("plugin_checksums_get_failed", "failed to read plugin checksum row").WithCause(err)
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// UpsertPluginChecksums bulk-inserts plugin/theme checksum rows.
+// ON CONFLICT DO NOTHING: md5 is in the PK so duplicate variants are ignored;
+// re-inserts after a positive-cache refresh land cleanly.
+func (r *Repo) UpsertPluginChecksums(ctx context.Context, rows []PluginChecksumRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	const batchSize = 500
+	for i := 0; i < len(rows); i += batchSize {
+		end := i + batchSize
+		if end > len(rows) {
+			end = len(rows)
+		}
+		batch := rows[i:end]
+		args := make([]any, 0, len(batch)*5)
+		placeholders := make([]string, 0, len(batch))
+		for j, c := range batch {
+			base := j*5 + 1
+			placeholders = append(placeholders,
+				"($"+itoa(base)+", $"+itoa(base+1)+", $"+itoa(base+2)+
+					", $"+itoa(base+3)+", $"+itoa(base+4)+", now())")
+			args = append(args, c.Kind, c.Slug, c.Version, c.Path, c.MD5)
+		}
+		q := `INSERT INTO wporg_plugin_checksums (kind, slug, version, path, md5, fetched_at)
+			  VALUES ` + strings.Join(placeholders, ",") + `
+			  ON CONFLICT (kind, slug, version, path, md5) DO NOTHING`
+		if _, err := r.pool.Exec(ctx, q, args...); err != nil {
+			return domain.Internal("plugin_checksums_upsert_failed", "failed to upsert plugin checksums").WithCause(err)
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// site_file_baseline (tenant-scoped, RLS)
+// ---------------------------------------------------------------------------
+
+// GetBaseline returns all baseline rows for a site. Used by diffFiles before
+// computing the diff. Runs under InTenantTx.
+func (r *Repo) GetBaseline(ctx context.Context, tenantID, siteID uuid.UUID) ([]BaselineRow, error) {
+	var out []BaselineRow
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx,
+			`SELECT site_id, tenant_id, path, md5, size, mtime, is_link, source, updated_run
+			 FROM site_file_baseline
+			 WHERE tenant_id = $1 AND site_id = $2`,
+			tenantID, siteID,
+		)
+		if err != nil {
+			return domain.Internal("baseline_get_failed", "failed to get file baseline").WithCause(err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var b BaselineRow
+			if err := rows.Scan(&b.SiteID, &b.TenantID, &b.Path, &b.MD5, &b.Size, &b.Mtime, &b.IsLink, &b.Source, &b.UpdatedRun); err != nil {
+				return domain.Internal("baseline_get_failed", "failed to read baseline row").WithCause(err)
+			}
+			out = append(out, b)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+// PromoteBaseline replaces the entire baseline for a site with the hashes from
+// the given run. Runs in a single tenant-scoped transaction:
+//  1. DELETE all existing baseline rows for the site.
+//  2. INSERT from scan_run_hashes for this run.
+//
+// This is the "promote" step called after a successful full/files run.
+func (r *Repo) PromoteBaseline(ctx context.Context, tenantID, siteID, runID uuid.UUID) error {
+	return r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		// Delete existing baseline.
+		if _, err := tx.Exec(ctx,
+			`DELETE FROM site_file_baseline WHERE tenant_id = $1 AND site_id = $2`,
+			tenantID, siteID,
+		); err != nil {
+			return domain.Internal("baseline_promote_failed", "failed to delete old baseline").WithCause(err)
+		}
+		// Insert from this run's staged hashes.
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO site_file_baseline
+				(site_id, tenant_id, path, md5, size, mtime, is_link, source, updated_run, updated_at)
+			 SELECT $2, $1, path, md5, size, mtime, is_link, 'baseline', $3, now()
+			 FROM scan_run_hashes
+			 WHERE tenant_id = $1 AND run_id = $3`,
+			tenantID, siteID, runID,
+		); err != nil {
+			return domain.Internal("baseline_promote_failed", "failed to insert new baseline").WithCause(err)
+		}
+		return nil
+	})
+}
+
+// ---------------------------------------------------------------------------
+// site_managed_files (tenant-scoped, RLS)
+// ---------------------------------------------------------------------------
+
+// GetManagedFiles returns all managed-file rows for a site. Used by diffFiles.
+func (r *Repo) GetManagedFiles(ctx context.Context, tenantID, siteID uuid.UUID) ([]ManagedFileRow, error) {
+	var out []ManagedFileRow
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx,
+			`SELECT site_id, tenant_id, path, md5, managed_by
+			 FROM site_managed_files
+			 WHERE tenant_id = $1 AND site_id = $2`,
+			tenantID, siteID,
+		)
+		if err != nil {
+			return domain.Internal("managed_files_get_failed", "failed to get managed files").WithCause(err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var m ManagedFileRow
+			if err := rows.Scan(&m.SiteID, &m.TenantID, &m.Path, &m.MD5, &m.ManagedBy); err != nil {
+				return domain.Internal("managed_files_get_failed", "failed to read managed file row").WithCause(err)
+			}
+			out = append(out, m)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+// UpsertManagedFiles inserts or updates rows in site_managed_files.
+// Called by the record_managed_files agent-callback handler after the agent
+// reports paths + hashes for its own writes.
+func (r *Repo) UpsertManagedFiles(ctx context.Context, tenantID uuid.UUID, rows []ManagedFileRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	return r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		for _, m := range rows {
+			if _, err := tx.Exec(ctx,
+				`INSERT INTO site_managed_files
+					(site_id, tenant_id, path, md5, managed_by, updated_at)
+				 VALUES ($1, $2, $3, $4, $5, now())
+				 ON CONFLICT (site_id, path) DO UPDATE
+				   SET md5 = EXCLUDED.md5,
+				       managed_by = EXCLUDED.managed_by,
+				       updated_at = now()`,
+				m.SiteID, tenantID, m.Path, m.MD5, m.ManagedBy,
+			); err != nil {
+				return domain.Internal("managed_files_upsert_failed", "failed to upsert managed file").WithCause(err)
+			}
+		}
+		return nil
+	})
+}
+
+// ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
 

--- a/apps/api/internal/scan/service.go
+++ b/apps/api/internal/scan/service.go
@@ -104,6 +104,13 @@ func (s *Service) ListFindingsForRun(ctx context.Context, tenantID, siteID, runI
 
 // IgnoreFinding sets the ignored flag on a finding and records an audit event.
 // ignoredBy is the actor's ID (email or API key ID) for the audit trail.
+//
+// When ignored=true and the finding is baseline-relative (file_changed,
+// file_added, file_removed, plugin_modified, plugin_unknown), the path's
+// baseline is advanced to the accepted hash so subsequent scans no longer
+// re-flag an intentional or reviewed change. This is the ONLY path by which
+// an active-finding path advances past an unreviewed change; the normal
+// promotion run (PromoteBaselineSelective) intentionally skips such paths.
 func (s *Service) IgnoreFinding(ctx context.Context, tenantID, findingID uuid.UUID, ignored bool, ignoredBy string, p domain.Principal) (Finding, error) {
 	// This route has no :siteId for RequireSiteAccess to guard, so resolve the
 	// finding's site and gate on the caller's site access BEFORE mutating —
@@ -118,6 +125,47 @@ func (s *Service) IgnoreFinding(ctx context.Context, tenantID, findingID uuid.UU
 	f, err := s.repo.SetFindingIgnored(ctx, tenantID, findingID, ignored, ignoredBy)
 	if err != nil {
 		return Finding{}, err
+	}
+
+	// Advance the baseline for the accepted path so the next scan is clean.
+	// Only fire when the operator is accepting the change (ignored=true) and the
+	// finding type involves the baseline table. file_removed is accepted by
+	// deleting the baseline row for that path (the file is gone; the baseline
+	// should no longer expect it). For all other baseline-relative finding types
+	// we upsert the current (accepted) hash as the new known-good.
+	if ignored {
+		switch f.FindingType {
+		case FindingFileChanged, FindingFileAdded, FindingPluginModified, FindingPluginUnknown:
+			// Accepted hash is the actual (current) hash from the finding.
+			if advErr := s.repo.AdvanceBaselineForPath(ctx, tenantID, f.SiteID, f.Path, f.ActualMD5, f.LastSeenRun); advErr != nil {
+				// Non-fatal: the finding is already ignored; log but don't fail.
+				if s.audit != nil {
+					_, _ = s.audit.Record(ctx, audit.Event{
+						TenantID:   tenantID,
+						ActorType:  audit.ActorSystem,
+						Action:     "scan_finding.baseline_advance_failed",
+						TargetType: "scan_finding",
+						TargetID:   findingID.String(),
+						Metadata:   map[string]any{"error": advErr.Error(), "path": f.Path},
+					})
+				}
+			}
+		case FindingFileRemoved:
+			// File is gone and the operator accepts that. Remove the baseline row
+			// so the next scan no longer expects the file.
+			if delErr := s.repo.DeleteBaselineForPath(ctx, tenantID, f.SiteID, f.Path); delErr != nil {
+				if s.audit != nil {
+					_, _ = s.audit.Record(ctx, audit.Event{
+						TenantID:   tenantID,
+						ActorType:  audit.ActorSystem,
+						Action:     "scan_finding.baseline_advance_failed",
+						TargetType: "scan_finding",
+						TargetID:   findingID.String(),
+						Metadata:   map[string]any{"error": delErr.Error(), "path": f.Path},
+					})
+				}
+			}
+		}
 	}
 
 	if s.audit != nil {

--- a/apps/api/internal/scan/worker.go
+++ b/apps/api/internal/scan/worker.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
 	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/site"
+	"github.com/mosamlife/wpmgr/apps/api/internal/uptime"
 )
 
 // Audit action names for the scan lifecycle.
@@ -23,6 +25,10 @@ const (
 	ActionScanCompleted = "scan.completed"
 	ActionScanFailed    = "scan.failed"
 	ActionFileFetched   = "scan.file_fetched"
+
+	// Phase 2: file-integrity audit actions.
+	ActionFileBaselineEstablished = "scan.baseline_established"
+	ActionFileChangeDetected      = "scan.file_change_detected"
 )
 
 // ScanRunQueue is the dedicated River queue for scan run driver jobs.
@@ -45,6 +51,14 @@ type Reenqueuer interface {
 	EnqueueScanRun(ctx context.Context, args ScanRunArgs) error
 }
 
+// SecurityAlerter resolves and dispatches a security alert for a tenant.
+// Implemented in cmd/wpmgr via the uptime Dispatcher + Repo. Declared here as
+// an interface to keep the scan package free of a direct uptime import for
+// the concrete Repo type (which would require DB-pool access at construction).
+type SecurityAlerter interface {
+	FireFileIntegrityAlert(ctx context.Context, tenantID, siteID uuid.UUID, summary string)
+}
+
 // ScanRunWorker drives the multi-step scan loop. Each River job invocation:
 //  1. Re-reads the run's current state from the DB.
 //  2. Transitions queued → scanning (idempotent).
@@ -52,7 +66,7 @@ type Reenqueuer interface {
 //  4. Inserts the hash batch (ON CONFLICT DO NOTHING).
 //  5. Persists the new cursor BEFORE re-enqueueing (retry correctness).
 //  6. If status=partial → re-enqueue self with a fresh JWT (new River job).
-//     If status=done   → diffCore → UpsertFindings → MarkDone → PurgeHashes.
+//     If status=done   → diffCore/diffFiles → UpsertFindings → MarkDone → PurgeHashes.
 type ScanRunWorker struct {
 	river.WorkerDefaults[ScanRunArgs]
 	repo      *Repo
@@ -62,6 +76,11 @@ type ScanRunWorker struct {
 	enqueuer  Reenqueuer
 	audit     *audit.Recorder
 	logger    *slog.Logger
+	// Phase 2: optional dependencies; absent = no alerts/SSE (graceful).
+	alerter   SecurityAlerter
+	publisher site.EventPublisher
+	uptimeRepo uptime.Repo
+	dispatcher *uptime.Dispatcher
 }
 
 // NewScanRunWorker builds the scan worker.
@@ -86,6 +105,15 @@ func NewScanRunWorker(
 		audit:     rec,
 		logger:    logger,
 	}
+}
+
+// SetFileIntegrityDeps wires the Phase 2 alert and SSE dependencies.
+// Called once from main after all services are constructed. Both are optional;
+// absent = no alerts/SSE (safe to omit in tests).
+func (w *ScanRunWorker) SetFileIntegrityDeps(pub site.EventPublisher, uptimeRepo uptime.Repo, dispatcher *uptime.Dispatcher) {
+	w.publisher = pub
+	w.uptimeRepo = uptimeRepo
+	w.dispatcher = dispatcher
 }
 
 // SetEnqueuer wires the Reenqueuer after River has started (the River client is
@@ -213,23 +241,30 @@ func (w *ScanRunWorker) Work(ctx context.Context, job *river.Job[ScanRunArgs]) e
 	return w.finish(ctx, run, si)
 }
 
-// finish runs diffCore and completes the run (status=done).
+// finish dispatches to the correct diff implementation based on the run kind.
 func (w *ScanRunWorker) finish(ctx context.Context, run Run, si ScanSiteInfo) error {
-	// Use the site's wp_version for checksums lookup; locale defaults to en_US
-	// (no per-site locale field exists in the current schema).
+	switch run.Kind {
+	case KindFull, KindFiles:
+		return w.finishFiles(ctx, run, si)
+	default:
+		// KindCore and any future kinds use the original core-checksum diff.
+		return w.finishCore(ctx, run, si)
+	}
+}
+
+// finishCore runs diffCore and completes the run (status=done). Used for
+// kind=core (and any unrecognised kind as a safe fallback).
+func (w *ScanRunWorker) finishCore(ctx context.Context, run Run, si ScanSiteInfo) error {
 	version := si.WPVersion
 	locale := "en_US"
 
-	// Load staged hashes.
 	hashes, err := w.repo.ListHashes(ctx, run.TenantID, run.ID)
 	if err != nil {
 		return w.fail(ctx, run, "failed to load hashes: "+err.Error())
 	}
 
-	// Fetch checksums (Postgres-cached; SSRF-safe via httpclient).
 	checksums, err := w.checksums.Core(ctx, version, locale)
 	if err != nil {
-		// Non-fatal: proceed without checksums (no findings this run).
 		w.logger.Warn("scan checksums fetch failed — proceeding without diff",
 			slog.String("run_id", run.ID.String()),
 			slog.String("version", version),
@@ -237,27 +272,22 @@ func (w *ScanRunWorker) finish(ctx context.Context, run Run, si ScanSiteInfo) er
 		checksums = map[string]string{}
 	}
 
-	// Run diff.
 	findings := diffCore(run.ID, run.TenantID, run.SiteID, hashes, checksums)
 
-	// Upsert deduplicated findings.
 	if err := w.repo.UpsertFindings(ctx, run.TenantID, findings); err != nil {
 		return w.fail(ctx, run, "failed to upsert findings: "+err.Error())
 	}
 
-	// Count findings by type for the summary.
 	counts := map[string]int{}
 	for _, f := range findings {
 		counts[f.FindingType]++
 	}
 
-	// Mark done.
 	doneRun, err := w.repo.MarkDone(ctx, run.TenantID, run.ID, version, locale, counts)
 	if err != nil {
 		return fmt.Errorf("scan worker: mark done: %w", err)
 	}
 
-	// Purge staging hashes.
 	_ = w.repo.PurgeHashes(ctx, run.TenantID, run.ID)
 
 	w.recordAudit(ctx, doneRun, ActionScanCompleted, map[string]any{
@@ -270,6 +300,202 @@ func (w *ScanRunWorker) finish(ctx context.Context, run Run, si ScanSiteInfo) er
 		slog.Int64("files_scanned", doneRun.FilesScanned),
 		slog.Any("findings", counts))
 	return nil
+}
+
+// finishFiles runs the Phase 2 diffFiles classifier for kind=full/files:
+//  1. Load staged hashes, baseline, managed-file registry.
+//  2. Fetch core + plugin checksums (SSRF-safe, Postgres-cached).
+//  3. diffFiles → UpsertFindings.
+//  4. PromoteBaseline (replace old baseline with this run's hashes).
+//  5. Emit audit, alert, SSE.
+func (w *ScanRunWorker) finishFiles(ctx context.Context, run Run, si ScanSiteInfo) error {
+	version := si.WPVersion
+	locale := "en_US"
+
+	// --- 1. Load all inputs for diffFiles ---
+	hashes, err := w.repo.ListHashes(ctx, run.TenantID, run.ID)
+	if err != nil {
+		return w.fail(ctx, run, "failed to load hashes: "+err.Error())
+	}
+
+	baseline, err := w.repo.GetBaseline(ctx, run.TenantID, run.SiteID)
+	if err != nil {
+		w.logger.Warn("failed to load baseline — treating as cold start",
+			slog.String("run_id", run.ID.String()), slog.Any("error", err))
+		baseline = nil
+	}
+
+	managedFiles, err := w.repo.GetManagedFiles(ctx, run.TenantID, run.SiteID)
+	if err != nil {
+		w.logger.Warn("failed to load managed files — proceeding without suppression",
+			slog.String("run_id", run.ID.String()), slog.Any("error", err))
+		managedFiles = nil
+	}
+
+	// --- 2. Fetch core checksums ---
+	coreChecksums, err := w.checksums.Core(ctx, version, locale)
+	if err != nil || coreChecksums == nil {
+		w.logger.Warn("core checksums fetch failed — proceeding without core diff",
+			slog.String("run_id", run.ID.String()), slog.Any("error", err))
+		coreChecksums = map[string]string{}
+	}
+
+	// Fetch plugin/theme checksums for each installed plugin/theme in the
+	// site inventory. We parse the inventory from ScanSiteInfo via a separate
+	// lookup (SiteLookup provides components for sites that have them).
+	pluginChecksums := make(map[string]map[string][]string) // slug → path → []md5
+	if w.sites != nil {
+		if components, ok := w.sites.(ComponentLookup); ok {
+			plugins, themes := components.GetComponents(ctx, run.TenantID, run.SiteID)
+			pluginChecksums = w.fetchAllPluginChecksums(ctx, plugins, themes)
+		}
+	}
+
+	// --- 3. Run diffFiles ---
+	coldStart := len(baseline) == 0
+	findings := diffFiles(run.ID, run.TenantID, run.SiteID, hashes, baseline, coreChecksums, pluginChecksums, managedFiles, coldStart)
+
+	if err := w.repo.UpsertFindings(ctx, run.TenantID, findings); err != nil {
+		return w.fail(ctx, run, "failed to upsert findings: "+err.Error())
+	}
+
+	counts := map[string]int{}
+	for _, f := range findings {
+		counts[f.FindingType]++
+	}
+
+	// --- 4. Promote baseline (always — even on cold start) ---
+	if promErr := w.repo.PromoteBaseline(ctx, run.TenantID, run.SiteID, run.ID); promErr != nil {
+		// Non-fatal: the diff already ran; just log and continue.
+		w.logger.Warn("baseline promotion failed",
+			slog.String("run_id", run.ID.String()), slog.Any("error", promErr))
+	}
+
+	// --- 5. Mark done ---
+	doneRun, err := w.repo.MarkDone(ctx, run.TenantID, run.ID, version, locale, counts)
+	if err != nil {
+		return fmt.Errorf("scan worker: mark done: %w", err)
+	}
+
+	_ = w.repo.PurgeHashes(ctx, run.TenantID, run.ID)
+
+	// --- 6. Audit ---
+	auditAction := ActionScanCompleted
+	if coldStart {
+		auditAction = ActionFileBaselineEstablished
+	}
+	w.recordAudit(ctx, doneRun, auditAction, map[string]any{
+		"files_scanned": doneRun.FilesScanned,
+		"findings":      counts,
+		"cold_start":    coldStart,
+	})
+
+	// Separate audit record when high-severity file-change findings were found.
+	highCount := counts[FindingFileChanged] + counts[FindingPluginModified] + counts[FindingPluginUnknown]
+	if highCount > 0 {
+		w.recordAudit(ctx, doneRun, ActionFileChangeDetected, map[string]any{
+			"file_changed":    counts[FindingFileChanged],
+			"file_added":      counts[FindingFileAdded],
+			"file_removed":    counts[FindingFileRemoved],
+			"plugin_modified": counts[FindingPluginModified],
+			"plugin_unknown":  counts[FindingPluginUnknown],
+		})
+	}
+
+	// --- 7. Alert (high-severity findings only) ---
+	if !coldStart && highCount > 0 && w.uptimeRepo != nil && w.dispatcher != nil {
+		alertCfg, alertFound, alertErr := w.uptimeRepo.GetAlertConfig(ctx, run.TenantID)
+		if alertErr == nil && alertFound && alertCfg.Enabled && alertCfg.NotifySecurity {
+			summary := fmt.Sprintf("%d changed / %d added / %d removed files on site %s",
+				counts[FindingFileChanged]+counts[FindingPluginModified],
+				counts[FindingFileAdded],
+				counts[FindingFileRemoved],
+				run.SiteID)
+			w.dispatcher.FireSecurityEvent(ctx, alertCfg, uptime.SecurityEvent{
+				TenantID:  run.TenantID,
+				SiteID:    run.SiteID,
+				Summary:   summary,
+				EventType: "file_integrity",
+				Severity:  SeverityHigh,
+				FiredAt:   time.Now(),
+			})
+		}
+	}
+
+	// --- 8. SSE live push (push is a hint; the dashboard polls useScanRun) ---
+	if w.publisher != nil {
+		// ID is intentionally left empty — Publisher mints the ULID (SSE ULID contract).
+		_ = w.publisher.Publish(ctx, site.ConnectionEvent{
+			Type:     "scan.finding",
+			TenantID: run.TenantID,
+			SiteID:   run.SiteID,
+			Data: map[string]any{
+				"run_id":          run.ID.String(),
+				"file_changed":    counts[FindingFileChanged],
+				"file_added":      counts[FindingFileAdded],
+				"file_removed":    counts[FindingFileRemoved],
+				"plugin_modified": counts[FindingPluginModified],
+				"plugin_unknown":  counts[FindingPluginUnknown],
+				"cold_start":      coldStart,
+			},
+		})
+	}
+
+	w.logger.Info("file-integrity scan run completed",
+		slog.String("run_id", run.ID.String()),
+		slog.String("site_id", run.SiteID.String()),
+		slog.Int64("files_scanned", doneRun.FilesScanned),
+		slog.Bool("cold_start", coldStart),
+		slog.Any("findings", counts))
+	return nil
+}
+
+// fetchAllPluginChecksums fetches and merges plugin+theme checksums for every
+// installed component. Returns slug → (plugin-relative path → []md5 variants).
+// Non-fatal: missing checksums for a slug mean it falls through to baseline.
+func (w *ScanRunWorker) fetchAllPluginChecksums(ctx context.Context, plugins, themes []site.Component) map[string]map[string][]string {
+	result := make(map[string]map[string][]string)
+	for _, p := range plugins {
+		slug := pluginDirSlug(p.Slug)
+		if slug == "" {
+			continue
+		}
+		cs, err := w.checksums.Plugin(ctx, "plugin", slug, p.Version)
+		if err != nil || len(cs) == 0 {
+			continue
+		}
+		result[slug] = cs
+	}
+	for _, t := range themes {
+		// Theme slug from inventory is already the stylesheet dir = the wp.org slug.
+		slug := t.Slug
+		if slug == "" {
+			continue
+		}
+		cs, err := w.checksums.Plugin(ctx, "theme", slug, t.Version)
+		if err != nil || len(cs) == 0 {
+			continue
+		}
+		result[slug] = cs
+	}
+	return result
+}
+
+// pluginDirSlug extracts the directory slug from a plugin file path such as
+// "akismet/akismet.php" → "akismet". Handles bare slugs (no slash) unchanged.
+func pluginDirSlug(pluginFilePath string) string {
+	if idx := strings.Index(pluginFilePath, "/"); idx > 0 {
+		return pluginFilePath[:idx]
+	}
+	return pluginFilePath
+}
+
+// ComponentLookup is an optional extension of SiteLookup that provides the
+// installed plugin/theme inventory. Implemented by the site adapter in main.
+// When SiteLookup does not implement this interface, plugin checksums are skipped
+// and the diff falls through to baseline-only for all plugin/theme paths.
+type ComponentLookup interface {
+	GetComponents(ctx context.Context, tenantID, siteID uuid.UUID) (plugins, themes []site.Component)
 }
 
 // fail marks the run as failed (terminal River success — the job itself
@@ -466,6 +692,198 @@ func makeFinding(runID, tenantID, siteID uuid.UUID, findingType, path, severity,
 		DeduKey:     deduKey,
 		LastSeenRun: runID,
 	}
+}
+
+// ---------------------------------------------------------------------------
+// diffFiles — Phase 2 full-filesystem diff classifier
+// ---------------------------------------------------------------------------
+
+// diffFiles classifies each path in a full/files scan run against:
+//  1. site_managed_files (suppress or detect managed-file tampering).
+//  2. WordPress core checksums (reuse core detection for core paths).
+//  3. wp.org plugin/theme checksums (plugin_modified / plugin_unknown).
+//  4. site_file_baseline (file_added / file_changed / file_removed).
+//
+// The function is pure (no I/O) for unit testing.
+//
+// pluginChecksums is a map from directory slug → (plugin-relative path → []md5
+// variants). A path under plugins/<slug>/ is looked up as a plugin; a path
+// under themes/<slug>/ as a theme.
+//
+// When coldStart is true (no baseline rows) the function emits only
+// core/plugin-checksum findings; no Added/Changed/Removed findings are emitted
+// for non-core/plugin paths. This prevents a first-scan flood and sets up the
+// baseline for next time.
+func diffFiles(
+	runID, tenantID, siteID uuid.UUID,
+	hashes []HashRow,
+	baseline []BaselineRow,
+	coreChecksums map[string]string,
+	pluginChecksums map[string]map[string][]string, // slug → path → []md5
+	managed []ManagedFileRow,
+	coldStart bool,
+) []Finding {
+	// Build lookup maps.
+	managedMap := make(map[string]ManagedFileRow, len(managed))
+	for _, m := range managed {
+		managedMap[m.Path] = m
+	}
+
+	baselineMap := make(map[string]BaselineRow, len(baseline))
+	for _, b := range baseline {
+		baselineMap[b.Path] = b
+	}
+
+	// Track paths present in this run for the Removed pass.
+	thisRun := make(map[string]bool, len(hashes))
+	for _, h := range hashes {
+		thisRun[h.Path] = true
+	}
+
+	var findings []Finding
+
+	// -----------------------------------------------------------------------
+	// Pass 1: classify each path in the current run.
+	// -----------------------------------------------------------------------
+	for _, h := range hashes {
+		path := h.Path
+		actualMD5 := strings.ToLower(h.MD5)
+
+		// (a) Check managed-file registry first.
+		if m, ok := managedMap[path]; ok {
+			if m.MD5 == "" {
+				// Suppress: this path is WPMgr-managed, churn-tolerant.
+				continue
+			}
+			if strings.EqualFold(m.MD5, actualMD5) {
+				// Matches expected managed hash: OK.
+				continue
+			}
+			// Hash differs from the expected managed hash: managed-file tampering.
+			findings = append(findings, makeFinding(runID, tenantID, siteID,
+				FindingFileChanged, path, SeverityHigh, m.MD5, actualMD5))
+			continue
+		}
+
+		// (b) Core paths: delegate to core checksums (same logic as diffCore).
+		if isCorePath(path) {
+			expectedMD5, inManifest := coreChecksums[path]
+			if path == ".htaccess" || allowedRootFiles[path] {
+				continue // allow-listed
+			}
+			if inManifest {
+				if actualMD5 == "" || !strings.EqualFold(actualMD5, expectedMD5) {
+					findings = append(findings, makeFinding(runID, tenantID, siteID,
+						FindingCoreModified, path, SeverityHigh, expectedMD5, actualMD5))
+				}
+				continue
+			}
+			// In a core dir but not in manifest (injected file).
+			if !strings.HasPrefix(path, "wp-content/") {
+				findings = append(findings, makeFinding(runID, tenantID, siteID,
+					FindingCoreUnknownInjected, path, SeverityHigh, "", actualMD5))
+			}
+			continue
+		}
+
+		// (c) Plugin / theme paths: compare against wp.org checksums.
+		if slug, relPath, kind := pluginOrThemePath(path); slug != "" {
+			_ = kind
+			slugChecksums, hasPlugin := pluginChecksums[slug]
+			if hasPlugin {
+				variants, inManifest := slugChecksums[relPath]
+				if inManifest {
+					if md5MatchesAny(actualMD5, variants) {
+						// Matches an official variant: OK.
+						continue
+					}
+					findings = append(findings, makeFinding(runID, tenantID, siteID,
+						FindingPluginModified, path, SeverityHigh,
+						strings.Join(variants, "|"), actualMD5))
+					continue
+				}
+				// File not in manifest but in a known-wp.org plugin dir.
+				findings = append(findings, makeFinding(runID, tenantID, siteID,
+					FindingPluginUnknown, path, SeverityHigh, "", actualMD5))
+				continue
+			}
+			// No wp.org checksums for this slug: fall through to baseline.
+		}
+
+		// (d) Baseline diff (for non-core, non-plugin/theme, non-managed paths).
+		if coldStart {
+			// Cold start: no baseline yet; establish baseline only, no A/C/R.
+			continue
+		}
+		baseRow, inBaseline := baselineMap[path]
+		if inBaseline {
+			if !strings.EqualFold(baseRow.MD5, actualMD5) {
+				findings = append(findings, makeFinding(runID, tenantID, siteID,
+					FindingFileChanged, path, SeverityHigh, baseRow.MD5, actualMD5))
+			}
+			// else: unchanged
+		} else {
+			// New path not in baseline: file_added.
+			findings = append(findings, makeFinding(runID, tenantID, siteID,
+				FindingFileAdded, path, SeverityMedium, "", actualMD5))
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Pass 2: detect removed files (in baseline but absent from this run).
+	// -----------------------------------------------------------------------
+	if !coldStart {
+		for _, b := range baseline {
+			if thisRun[b.Path] {
+				continue // still present
+			}
+			if _, managed := managedMap[b.Path]; managed {
+				continue // managed path removal is not reported
+			}
+			// Core-path removals are reported by diffCore (core_missing); skip here
+			// to avoid double-reporting when both kinds are run.
+			if isCorePath(b.Path) {
+				continue
+			}
+			findings = append(findings, makeFinding(runID, tenantID, siteID,
+				FindingFileRemoved, b.Path, SeverityLow, b.MD5, ""))
+		}
+	}
+
+	return findings
+}
+
+// pluginOrThemePath checks whether path is under plugins/<slug>/... or
+// themes/<slug>/... (relative to the WordPress root). Returns (slug,
+// plugin-relative path, "plugin"|"theme"). Returns ("","","") for other paths.
+func pluginOrThemePath(path string) (slug, relPath, kind string) {
+	for _, prefix := range []struct{ dir, kind string }{
+		{"wp-content/plugins/", "plugin"},
+		{"wp-content/themes/", "theme"},
+	} {
+		if !strings.HasPrefix(path, prefix.dir) {
+			continue
+		}
+		rest := path[len(prefix.dir):]
+		slash := strings.Index(rest, "/")
+		if slash <= 0 {
+			return "", "", "" // bare file directly under plugins/ (no slug dir)
+		}
+		return rest[:slash], rest[slash+1:], prefix.kind
+	}
+	return "", "", ""
+}
+
+// md5MatchesAny returns true when actual (lowercase hex) matches any of the
+// given accepted variants (case-insensitive). Used for the multi-variant edge
+// case in wp.org plugin checksums.
+func md5MatchesAny(actual string, variants []string) bool {
+	for _, v := range variants {
+		if strings.EqualFold(actual, v) {
+			return true
+		}
+	}
+	return false
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/scan/worker.go
+++ b/apps/api/internal/scan/worker.go
@@ -364,8 +364,21 @@ func (w *ScanRunWorker) finishFiles(ctx context.Context, run Run, si ScanSiteInf
 		counts[f.FindingType]++
 	}
 
-	// --- 4. Promote baseline (always — even on cold start) ---
-	if promErr := w.repo.PromoteBaseline(ctx, run.TenantID, run.SiteID, run.ID); promErr != nil {
+	// --- 4. Promote baseline (path-selective — never advance past an unreviewed change) ---
+	//
+	// Build the set of paths that have an active (non-ignored) finding from this
+	// run. The baseline must NOT advance for those paths; the next scan will
+	// re-compare against the prior known-good hash and re-flag them until an
+	// operator explicitly accepts the change via IgnoreFinding.
+	activeFindingPaths := make(map[string]bool, len(findings))
+	for _, f := range findings {
+		switch f.FindingType {
+		case FindingFileChanged, FindingPluginModified, FindingPluginUnknown,
+			FindingFileAdded, FindingFileRemoved:
+			activeFindingPaths[f.Path] = true
+		}
+	}
+	if promErr := w.repo.PromoteBaselineSelective(ctx, run.TenantID, run.SiteID, run.ID, coldStart, activeFindingPaths); promErr != nil {
 		// Non-fatal: the diff already ran; just log and continue.
 		w.logger.Warn("baseline promotion failed",
 			slog.String("run_id", run.ID.String()), slog.Any("error", promErr))

--- a/apps/api/internal/security/service.go
+++ b/apps/api/internal/security/service.go
@@ -40,12 +40,57 @@ type SiteLookup interface {
 	GetSiteURL(ctx context.Context, tenantID, siteID uuid.UUID) (string, error)
 }
 
+// ManagedFileRecorder persists the set of CP-managed files for a site so the
+// file-integrity scanner can suppress false-positive findings for paths that
+// WPMgr itself writes (.htaccess blocks, object-cache.php, advanced-cache.php,
+// mu-plugin loaders, etc.).
+//
+// MD5="" means "WPMgr-managed, hash unknown — suppress all findings for this
+// path." The scanner treats MD5="" as a churn-tolerant suppress: the path is
+// always considered clean regardless of its actual hash.
+//
+// Only the CP populates site_managed_files (via this interface). The agent has
+// NO direct write path to site_managed_files — the agent only reports hashes;
+// the CP decides which paths are managed. This is by design: the agent is
+// untrusted for this table.
+type ManagedFileRecorder interface {
+	UpsertManagedFiles(ctx context.Context, tenantID uuid.UUID, rows []ManagedFileRow) error
+}
+
+// ManagedFileRow is a path the CP manages (mirrors scan.ManagedFileRow to avoid
+// a cross-package import; the security package wires a scan.Repo adapter in main).
+type ManagedFileRow struct {
+	SiteID    uuid.UUID
+	TenantID  uuid.UUID
+	Path      string
+	MD5       string // "" = suppress (hash unknown / churn-tolerant)
+	ManagedBy string
+}
+
+// hardeningManagedPaths is the set of site-relative paths that the hardening
+// push may write on the site's filesystem. These paths are registered as
+// CP-managed (MD5="", suppress mode) so the file-integrity scanner does not
+// flag them as unknown files or false-positive changes.
+//
+// .htaccess: hardening writes server-config blocks (DisableDirectoryBrowsing,
+//
+//	DisablePHPInUploads, ProtectSystemFiles).
+//
+// wp-config.php: hardening may add DISALLOW_FILE_EDIT / FORCE_SSL_ADMIN
+//
+//	defines (managed region inside the file).
+var hardeningManagedPaths = []string{
+	".htaccess",
+	"wp-config.php",
+}
+
 // Service orchestrates the security domain: repo + optional agentcmd clients.
 type Service struct {
 	repo               *Repo
 	agentClient        AgentSecurityClient
 	hardeningClient    AgentHardeningClient
 	siteLookup         SiteLookup
+	managedFileRec     ManagedFileRecorder
 }
 
 // NewService builds a Service.
@@ -70,6 +115,15 @@ func (s *Service) SetHardeningClient(client AgentHardeningClient, sites SiteLook
 	if s.siteLookup == nil {
 		s.siteLookup = sites
 	}
+}
+
+// SetManagedFileRecorder wires the scan.Repo adapter so SaveHardeningConfig can
+// register the hardening-managed paths in site_managed_files. Optional: if not
+// set, the managed-file registry is not updated (safe to omit; no scanner impact
+// until the scanner is enabled for the site). Called once from main after all
+// services are constructed.
+func (s *Service) SetManagedFileRecorder(rec ManagedFileRecorder) {
+	s.managedFileRec = rec
 }
 
 // validModes are the three allowed protection modes.
@@ -284,6 +338,31 @@ func (s *Service) SaveHardeningConfig(ctx context.Context, tenantID, siteID uuid
 	if pushErr != nil {
 		return saved, fmt.Errorf("config stored but agent push failed: %w", pushErr)
 	}
+
+	// Register the hardening-managed paths in the file-integrity managed-file
+	// registry so the scanner does not produce false-positive findings for files
+	// that WPMgr's hardening writes. MD5="" means "suppress all findings for
+	// this path" (hash is churn-tolerant / unknown at push time).
+	// Best-effort: failure here does not fail the save; the scanner will flag
+	// these paths at most once until the registry is populated.
+	//
+	// Remaining write paths not covered here (object-cache.php, advanced-cache.php
+	// written by the perf suite) are a follow-up: the perf Service.EnableCache /
+	// SyncPerfConfig paths should call a similar recorder after successful push.
+	if s.managedFileRec != nil {
+		rows := make([]ManagedFileRow, 0, len(hardeningManagedPaths))
+		for _, p := range hardeningManagedPaths {
+			rows = append(rows, ManagedFileRow{
+				SiteID:    siteID,
+				TenantID:  tenantID,
+				Path:      p,
+				MD5:       "", // suppress mode: hash unknown, treat as churn-tolerant
+				ManagedBy: "hardening",
+			})
+		}
+		_ = s.managedFileRec.UpsertManagedFiles(ctx, tenantID, rows)
+	}
+
 	return saved, nil
 }
 

--- a/apps/api/migrations/20260710000000_m77_file_integrity.sql
+++ b/apps/api/migrations/20260710000000_m77_file_integrity.sql
@@ -1,0 +1,305 @@
+-- m77 — Security Suite Phase 2: file-integrity monitoring tables.
+--
+-- Adds four tables that together power the full-filesystem diff + plugin/theme
+-- integrity checks introduced in Phase 2:
+--
+--   site_file_baseline          — durable per-site last-good hash snapshot.
+--                                 Promoted from scan_run_hashes at run completion;
+--                                 the next run diffs against this table.
+--
+--   site_managed_files          — self-written-hash registry for paths WPMgr
+--                                 itself writes (perf suite, config writers,
+--                                 hardening). A path here never produces a
+--                                 false-positive Added/Changed finding.
+--
+--   wporg_plugin_checksums      — plugin/theme checksum cache (public wp.org
+--                                 endpoint). No RLS (public reference data).
+--                                 md5 is in the PK because wp.org may list
+--                                 multiple accepted variants per file.
+--
+--   wporg_plugin_checksums_meta — freshness/negative-cache sentinel per
+--                                 (kind, slug, version). No RLS.
+--
+-- RLS on tenant-scoped tables mirrors the m76 pattern exactly:
+--   ENABLE + FORCE ROW LEVEL SECURITY.
+--   _tenant_isolation policy: USING + WITH CHECK via app.tenant_id GUC.
+--   _agent policy:            USING + WITH CHECK via app.agent = 'on'.
+--   No _site_scope restrictive policy; collaborator gating is in-app via
+--   authz.RequireSiteAccess(:siteId) (m76 precedent).
+--
+-- updated_at is set by repo SQL (now()); no trigger exists (m36 comment).
+--
+-- Idempotency: every DDL statement uses IF NOT EXISTS / pg_policies checks;
+-- re-running this migration is safe.
+
+-- ===========================================================================
+-- site_file_baseline — durable last-good per-site hash set (tenant-scoped)
+-- ===========================================================================
+
+DO $$
+BEGIN
+    CREATE TABLE IF NOT EXISTS "public"."site_file_baseline" (
+        -- Primary key: one row per (site, relative path).
+        "site_id"     uuid NOT NULL,
+        "tenant_id"   uuid NOT NULL,
+        "path"        text NOT NULL,     -- site-relative, forward-slash
+
+        -- Hash captured by the agent.
+        "md5"         text NOT NULL,
+        "size"        bigint NOT NULL DEFAULT 0,
+        "mtime"       bigint NOT NULL DEFAULT 0,
+        "is_link"     boolean NOT NULL DEFAULT false,
+
+        -- Source classification persisted with the row so readers know which
+        -- authority blessed this hash (informational; not used in diff logic).
+        -- 'baseline'     — promoted from a full/files scan run.
+        -- 'wporg_core'   — replaced by the known-good core checksum.
+        -- 'wporg_plugin' — replaced by the known-good plugin/theme checksum.
+        -- 'managed'      — written by the self-managed-file registry.
+        "source"      text NOT NULL DEFAULT 'baseline'
+            CONSTRAINT "site_file_baseline_source_chk"
+            CHECK ("source" IN ('baseline', 'wporg_core', 'wporg_plugin', 'managed')),
+
+        -- The scan run that last promoted / updated this row.
+        "updated_run" uuid NOT NULL,
+        "updated_at"  timestamptz NOT NULL DEFAULT now(),
+
+        CONSTRAINT "site_file_baseline_pkey"
+            PRIMARY KEY ("site_id", "path"),
+
+        CONSTRAINT "site_file_baseline_tenant_fkey"
+            FOREIGN KEY ("tenant_id")
+            REFERENCES "public"."tenants" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+        CONSTRAINT "site_file_baseline_site_fkey"
+            FOREIGN KEY ("site_id")
+            REFERENCES "public"."sites" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+    );
+END;
+$$;
+
+-- Tenant query index: serves the baseline load in diff (tenant_id + site_id).
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'public'
+           AND tablename  = 'site_file_baseline'
+           AND indexname  = 'site_file_baseline_tenant_idx'
+    ) THEN
+        CREATE INDEX "site_file_baseline_tenant_idx"
+            ON "public"."site_file_baseline" ("tenant_id", "site_id");
+    END IF;
+END;
+$$;
+
+-- RLS — ENABLE + FORCE
+DO $$
+BEGIN
+    ALTER TABLE "public"."site_file_baseline" ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE "public"."site_file_baseline" FORCE ROW LEVEL SECURITY;
+END;
+$$;
+
+-- RLS — tenant isolation policy (operator / API path)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+         WHERE schemaname = 'public'
+           AND tablename  = 'site_file_baseline'
+           AND policyname = 'site_file_baseline_tenant_isolation'
+    ) THEN
+        CREATE POLICY "site_file_baseline_tenant_isolation"
+            ON "public"."site_file_baseline"
+            USING  ("tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid)
+            WITH CHECK ("tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid);
+    END IF;
+END;
+$$;
+
+-- RLS — agent policy (cross-tenant worker / promotion path)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+         WHERE schemaname = 'public'
+           AND tablename  = 'site_file_baseline'
+           AND policyname = 'site_file_baseline_agent'
+    ) THEN
+        CREATE POLICY "site_file_baseline_agent"
+            ON "public"."site_file_baseline"
+            USING  (current_setting('app.agent', true) = 'on')
+            WITH CHECK (current_setting('app.agent', true) = 'on');
+    END IF;
+END;
+$$;
+
+-- ===========================================================================
+-- site_managed_files — self-written expected-hash registry (tenant-scoped)
+-- ===========================================================================
+--
+-- When WPMgr writes a file (object-cache.php, .htaccess, minified assets,
+-- wp-config blocks) the agent reports the resulting hash here so the diff
+-- classifier never flags WPMgr's own writes as Changed or Added.
+--
+-- md5 = '' means "WPMgr-managed, suppress ALL findings for this path
+-- regardless of content" — used for churning directories (e.g. cache dirs).
+-- A specific md5 means "expected exactly this hash"; a different hash is
+-- still a real finding (managed-file tampering).
+
+DO $$
+BEGIN
+    CREATE TABLE IF NOT EXISTS "public"."site_managed_files" (
+        "site_id"    uuid NOT NULL,
+        "tenant_id"  uuid NOT NULL,
+        "path"       text NOT NULL,
+        "md5"        text NOT NULL DEFAULT '', -- '' = suppress all findings
+
+        -- managed_by identifies the WPMgr subsystem that owns this path:
+        --   'perf_cache'     — page-cache rules files (.htaccess, advanced-cache.php)
+        --   'object_cache'   — object-cache.php drop-in
+        --   'config_writer'  — wp-config.php block additions
+        --   'hardening'      — security-hardening file writes
+        --   'cp_command'     — generic CP-pushed write via record_managed_files
+        "managed_by" text NOT NULL DEFAULT 'cp_command',
+        "updated_at" timestamptz NOT NULL DEFAULT now(),
+
+        CONSTRAINT "site_managed_files_pkey"
+            PRIMARY KEY ("site_id", "path"),
+
+        CONSTRAINT "site_managed_files_tenant_fkey"
+            FOREIGN KEY ("tenant_id")
+            REFERENCES "public"."tenants" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+        CONSTRAINT "site_managed_files_site_fkey"
+            FOREIGN KEY ("site_id")
+            REFERENCES "public"."sites" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+    );
+END;
+$$;
+
+-- Tenant query index.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'public'
+           AND tablename  = 'site_managed_files'
+           AND indexname  = 'site_managed_files_tenant_idx'
+    ) THEN
+        CREATE INDEX "site_managed_files_tenant_idx"
+            ON "public"."site_managed_files" ("tenant_id", "site_id");
+    END IF;
+END;
+$$;
+
+-- RLS — ENABLE + FORCE
+DO $$
+BEGIN
+    ALTER TABLE "public"."site_managed_files" ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE "public"."site_managed_files" FORCE ROW LEVEL SECURITY;
+END;
+$$;
+
+-- RLS — tenant isolation policy
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+         WHERE schemaname = 'public'
+           AND tablename  = 'site_managed_files'
+           AND policyname = 'site_managed_files_tenant_isolation'
+    ) THEN
+        CREATE POLICY "site_managed_files_tenant_isolation"
+            ON "public"."site_managed_files"
+            USING  ("tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid)
+            WITH CHECK ("tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid);
+    END IF;
+END;
+$$;
+
+-- RLS — agent policy
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+         WHERE schemaname = 'public'
+           AND tablename  = 'site_managed_files'
+           AND policyname = 'site_managed_files_agent'
+    ) THEN
+        CREATE POLICY "site_managed_files_agent"
+            ON "public"."site_managed_files"
+            USING  (current_setting('app.agent', true) = 'on')
+            WITH CHECK (current_setting('app.agent', true) = 'on');
+    END IF;
+END;
+$$;
+
+-- ===========================================================================
+-- wporg_plugin_checksums — plugin/theme checksum cache (no RLS, public data)
+-- ===========================================================================
+--
+-- Mirrors wporg_core_checksums; keyed on (kind, slug, version, path, md5).
+-- md5 is in the PRIMARY KEY because wp.org plugin-checksums JSON may list
+-- multiple accepted md5 variants per file (line-ending / build variants).
+-- Storing all variants lets the diff treat a file as known-good when its
+-- actual md5 matches ANY stored variant.
+--
+-- kind: 'plugin' | 'theme' — shares the table; kind column disambiguates.
+
+DO $$
+BEGIN
+    CREATE TABLE IF NOT EXISTS "public"."wporg_plugin_checksums" (
+        "kind"       text NOT NULL
+            CONSTRAINT "wporg_plugin_checksums_kind_chk"
+            CHECK ("kind" IN ('plugin', 'theme')),
+        "slug"       text NOT NULL,
+        "version"    text NOT NULL,
+        "path"       text NOT NULL,   -- plugin-relative path, e.g. "akismet.php"
+        "md5"        text NOT NULL,   -- one accepted md5 variant (lowercase hex)
+        "fetched_at" timestamptz NOT NULL DEFAULT now(),
+
+        CONSTRAINT "wporg_plugin_checksums_pkey"
+            PRIMARY KEY ("kind", "slug", "version", "path", "md5")
+    );
+END;
+$$;
+
+-- Index for bulk-load by (kind, slug, version) — the common query shape.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'public'
+           AND tablename  = 'wporg_plugin_checksums'
+           AND indexname  = 'wporg_plugin_checksums_lookup_idx'
+    ) THEN
+        CREATE INDEX "wporg_plugin_checksums_lookup_idx"
+            ON "public"."wporg_plugin_checksums" ("kind", "slug", "version", "path");
+    END IF;
+END;
+$$;
+
+-- ===========================================================================
+-- wporg_plugin_checksums_meta — freshness / negative-cache sentinel
+-- ===========================================================================
+--
+-- One row per (kind, slug, version). ok=false means a fetch attempt failed
+-- (e.g. 404 for a premium/unknown plugin) and is negative-cached until the
+-- negativeCacheTTL expires (6h). Mirrors wporg_core_checksums_meta exactly.
+
+DO $$
+BEGIN
+    CREATE TABLE IF NOT EXISTS "public"."wporg_plugin_checksums_meta" (
+        "kind"       text NOT NULL
+            CONSTRAINT "wporg_plugin_checksums_meta_kind_chk"
+            CHECK ("kind" IN ('plugin', 'theme')),
+        "slug"       text NOT NULL,
+        "version"    text NOT NULL,
+        "fetched_at" timestamptz NOT NULL DEFAULT now(),
+        "ok"         boolean NOT NULL DEFAULT true,
+
+        CONSTRAINT "wporg_plugin_checksums_meta_pkey"
+            PRIMARY KEY ("kind", "slug", "version")
+    );
+END;
+$$;

--- a/apps/landing/src/data/content.ts
+++ b/apps/landing/src/data/content.ts
@@ -344,13 +344,13 @@ export const FEATURES: {
       features: [
         {
           icon: "ShieldCheck",
-          title: "Site hardening and bans",
-          summary: "Per-site hardening controls and an IP ban list, pushed fleet-wide from the dashboard.",
+          title: "Hardening, bans, integrity",
+          summary: "Per-site hardening, an IP ban list, and continuous file-integrity monitoring, all opt-in and default-off.",
           bullets: [
             "Disable file editor, restrict XML-RPC, REST API, and login IDs",
             "Force SSL with HSTS, block PHP in uploads, protect system files",
             "IP and CIDR ban list enforced at early-boot and web-server level",
-            "All controls opt-in and default-off",
+            "File hashes compared to WordPress.org and a per-site baseline",
           ],
         },
         {
@@ -630,6 +630,7 @@ export const SECURITY = {
   items: [
     { icon: "ShieldCheck", title: "WordPress hardening controls", desc: "Push hardening rules from the dashboard to any site: disable the file editor, restrict XML-RPC and the REST API, force SSL with HSTS, block PHP in uploads, and protect system files. All opt-in and default-off." },
     { icon: "ShieldAlert", title: "IP and user-agent ban list", desc: "Block individual IPs, CIDR ranges, and user agents at early-boot and at the web-server level. The operator allow-list is always honoured so a ban can never lock out the operator." },
+    { icon: "FileScan", title: "File integrity monitoring", desc: "Scan the whole WordPress install or just wp-content on demand. File hashes are compared against WordPress.org checksums for core, wp.org-hosted plugins, and themes, and against a learned per-site baseline for everything else. Changed, added, and removed files are reported; a flagged file stays flagged until an operator reviews and accepts it, so the baseline never silently advances past an unreviewed change." },
     { icon: "FileLock2", title: "Client-side encrypted backups", desc: "Optional end-to-end encryption means the control plane stores only ciphertext and never holds a key to decrypt it." },
     { icon: "EyeOff", title: "Redacted diagnostics", desc: "Emails, passwords, secrets, tokens, and salts are stripped before any diagnostics leave a site." },
     { icon: "ScrollText", title: "Tamper-evident audit log", desc: "Every login, role change, and site action is recorded in an audit log you can review." },

--- a/apps/web/src/features/security/scan-findings-table.tsx
+++ b/apps/web/src/features/security/scan-findings-table.tsx
@@ -55,29 +55,70 @@ function sortedFindings(findings: ScanFinding[]): ScanFinding[] {
 
 // ---------------------------------------------------------------------------
 // Finding type chip
+//
+// TYPE_LABEL and TYPE_CLASSES are keyed on ScanFindingType (all known values).
+// Any finding_type string arriving from the API that is NOT in the union is
+// rendered by FindingTypeChip's fallback path — no crash.
+//
+// String values are confirmed against apps/api/internal/scan/model.go
+// FindingFile* / FindingPlugin* constants.
 // ---------------------------------------------------------------------------
 
 const TYPE_LABEL: Record<ScanFindingType, string> = {
-  core_modified: "Modified",
-  core_missing: "Missing",
+  // Phase 1 — core checksums
+  core_modified: "Core modified",
+  core_missing: "Core missing",
   core_unknown_injected: "Unknown file",
+  // Phase 2 — full file-integrity
+  file_added: "File added",
+  file_changed: "File changed",
+  file_removed: "File removed",
+  plugin_modified: "Plugin file modified",
+  plugin_unknown: "Unrecognized plugin file",
 };
 
+// Semantic-token classes only — no raw hex.
 const TYPE_CLASSES: Record<ScanFindingType, string> = {
+  // high severity — destructive tone
   core_modified:
-    "bg-[var(--color-warning-subtle,_oklch(0.97_0.05_85))] text-[var(--color-warning-subtle-fg,_oklch(0.45_0.15_85))]",
+    "bg-[var(--color-destructive-subtle,_oklch(0.97_0.04_25))] text-[var(--color-destructive-subtle-fg,_oklch(0.45_0.2_25))]",
   core_missing:
     "bg-[var(--color-destructive-subtle,_oklch(0.97_0.04_25))] text-[var(--color-destructive-subtle-fg,_oklch(0.45_0.2_25))]",
   core_unknown_injected:
     "bg-[var(--color-destructive-subtle,_oklch(0.97_0.04_25))] text-[var(--color-destructive-subtle-fg,_oklch(0.45_0.2_25))]",
+  file_changed:
+    "bg-[var(--color-destructive-subtle,_oklch(0.97_0.04_25))] text-[var(--color-destructive-subtle-fg,_oklch(0.45_0.2_25))]",
+  plugin_modified:
+    "bg-[var(--color-destructive-subtle,_oklch(0.97_0.04_25))] text-[var(--color-destructive-subtle-fg,_oklch(0.45_0.2_25))]",
+  plugin_unknown:
+    "bg-[var(--color-destructive-subtle,_oklch(0.97_0.04_25))] text-[var(--color-destructive-subtle-fg,_oklch(0.45_0.2_25))]",
+  // medium severity — warning tone
+  file_added:
+    "bg-[var(--color-warning-subtle,_oklch(0.97_0.05_85))] text-[var(--color-warning-subtle-fg,_oklch(0.45_0.15_85))]",
+  // low severity — muted tone
+  file_removed: "bg-[var(--color-muted)] text-[var(--color-muted-foreground)]",
 };
 
-function FindingTypeChip({ type }: { type: ScanFindingType }) {
+// Fallback chip for any finding_type the client does not yet recognise.
+// Renders a neutral badge instead of crashing.
+const FALLBACK_CHIP_CLASSES =
+  "bg-[var(--color-muted)] text-[var(--color-muted-foreground)]";
+
+function FindingTypeChip({ type }: { type: string }) {
+  const label =
+    type in TYPE_LABEL
+      ? TYPE_LABEL[type as ScanFindingType]
+      : type.replace(/_/g, " "); // e.g. "some_future_type" → "some future type"
+  const classes =
+    type in TYPE_CLASSES
+      ? TYPE_CLASSES[type as ScanFindingType]
+      : FALLBACK_CHIP_CLASSES;
+
   return (
     <span
-      className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${TYPE_CLASSES[type]}`}
+      className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${classes}`}
     >
-      {TYPE_LABEL[type]}
+      {label}
     </span>
   );
 }
@@ -258,9 +299,14 @@ function FindingRow({
   onIgnore,
   onViewFile,
 }: FindingRowProps) {
+  // "View file" is available for finding types where the content is meaningful
+  // to an operator. file_removed has no current content to fetch.
   const canViewFile =
     finding.finding_type === "core_unknown_injected" ||
-    finding.finding_type === "core_modified";
+    finding.finding_type === "core_modified" ||
+    finding.finding_type === "file_changed" ||
+    finding.finding_type === "file_added" ||
+    finding.finding_type === "plugin_modified";
 
   return (
     <TableRow
@@ -363,7 +409,7 @@ function NoFindingsEmpty() {
         No integrity issues found
       </p>
       <p className="max-w-xs text-xs text-[var(--color-muted-foreground)]">
-        All WordPress core files match the official WordPress.org checksums.
+        No modified, missing, or unexpected files were detected in this scan.
       </p>
     </div>
   );

--- a/apps/web/src/features/security/scan-findings.test.ts
+++ b/apps/web/src/features/security/scan-findings.test.ts
@@ -1,0 +1,517 @@
+/**
+ * Tests for Phase 2 file-integrity finding types in the scan domain.
+ *
+ * Following the project convention in use-hardening.test.ts / site-card.test.ts:
+ * pure-function tests only; no React renderer, no DOM.
+ *
+ * Contract goal: a shape mismatch between the Go DTO (handler.go) and our
+ * TypeScript types must be caught here, not in prod.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+import type { ScanFinding, ScanFindingType, ScanKind } from "./use-scan";
+
+// ---------------------------------------------------------------------------
+// Go DTO shapes — matched against apps/api/internal/scan/handler.go
+//
+// The Go `findingDTO` struct (handler.go:82-98) has these json tags:
+//   id            string   json:"id"
+//   site_id       string   json:"site_id"
+//   run_id        string   json:"run_id"
+//   finding_type  string   json:"finding_type"
+//   path          string   json:"path"
+//   severity      string   json:"severity"
+//   expected_md5  string   json:"expected_md5,omitempty"
+//   actual_md5    string   json:"actual_md5,omitempty"
+//   ignored       bool     json:"ignored"
+//   ignored_by    string   json:"ignored_by,omitempty"
+//   created_at    string   json:"created_at"
+//   last_seen_run string   json:"last_seen_run"
+//
+// Our ScanFinding interface must be a superset-safe projection of this shape.
+// ---------------------------------------------------------------------------
+
+// Simulated payload matching the Go findingDTO exactly (as it arrives from the
+// JSON wire, before TypeScript casts it). We construct this as `unknown` first
+// to emulate the `as T` cast in use-scan.ts's apiGet helper.
+function makeWireFinding(overrides: Partial<Record<string, unknown>> = {}): unknown {
+  return {
+    id: "550e8400-e29b-41d4-a716-446655440001",
+    site_id: "550e8400-e29b-41d4-a716-446655440002",
+    run_id: "550e8400-e29b-41d4-a716-446655440003",
+    finding_type: "core_modified",
+    path: "wp-includes/class-wp.php",
+    severity: "high",
+    expected_md5: "d41d8cd98f00b204e9800998ecf8427e",
+    actual_md5: "098f6bcd4621d373cade4e832627b4f6",
+    ignored: false,
+    created_at: "2026-06-19T10:00:00Z",
+    last_seen_run: "550e8400-e29b-41d4-a716-446655440003",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. ScanFinding interface — all required DTO fields are accessible
+//
+// This test pinpoints that if the Go handler renames a json tag (e.g.
+// "finding_type" → "type"), the TypeScript types must be updated in lockstep.
+// We construct a typed ScanFinding from the wire shape to verify the mapping.
+// ---------------------------------------------------------------------------
+
+describe("ScanFinding interface — DTO shape matches Go findingDTO json tags", () => {
+  it("all required Go json fields are present in the wire payload", () => {
+    const wire = makeWireFinding() as Record<string, unknown>;
+    // These field names MUST match the json:"..." tags in handler.go:82-98.
+    const requiredGoFields = [
+      "id",
+      "site_id",
+      "run_id",
+      "finding_type",
+      "path",
+      "severity",
+      "ignored",
+      "created_at",
+      "last_seen_run",
+    ];
+    for (const field of requiredGoFields) {
+      expect(wire).toHaveProperty(field);
+    }
+  });
+
+  it("the cast from wire to ScanFinding preserves the expected_md5 field", () => {
+    const wire = makeWireFinding({ expected_md5: "abc123" }) as ScanFinding;
+    // expected_md5 is omitempty in Go — it may be absent (null here); when
+    // present, it must be the string value the DTO carried.
+    expect(wire.expected_md5).toBe("abc123");
+  });
+
+  it("the cast from wire to ScanFinding preserves actual_md5 when omitted (omitempty → null/undefined)", () => {
+    // Go omitempty on a string sends the field absent when empty.
+    // The web ScanFinding type declares `actual_md5: string | null`.
+    // When the field is absent in the wire, the cast lands as undefined —
+    // which is falsy, so `finding.actual_md5 ? ... : "n/a"` works correctly.
+    const wire = makeWireFinding({ actual_md5: "" }) as ScanFinding;
+    // An empty string is falsy — the table renders "n/a". This is correct.
+    expect(!wire.actual_md5).toBe(true);
+  });
+
+  it("ignored field is a boolean in the wire payload", () => {
+    const wire = makeWireFinding({ ignored: true }) as ScanFinding;
+    expect(wire.ignored).toBe(true);
+    expect(typeof wire.ignored).toBe("boolean");
+  });
+
+  it("Go runDTO files_scanned field is an int64 (arrives as number on the wire)", () => {
+    // Matches handler.go:65 `FilesScanned int64 json:"files_scanned"`
+    const runWire = {
+      id: "550e8400-e29b-41d4-a716-446655440001",
+      site_id: "550e8400-e29b-41d4-a716-446655440002",
+      kind: "core",
+      status: "done",
+      files_scanned: 1234,
+      created_at: "2026-06-19T10:00:00Z",
+    };
+    expect(typeof runWire.files_scanned).toBe("number");
+    expect(runWire.files_scanned).toBe(1234);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Phase 2 finding types — string values confirmed against Go model.go
+//
+// The Go constants in apps/api/internal/scan/model.go:44-50 define these
+// exact string values. If the Go code changes the string value of any const,
+// this test (and the TYPE_LABEL map) must be updated in lockstep.
+// ---------------------------------------------------------------------------
+
+describe("Phase 2 finding type string values — confirmed against Go model.go constants", () => {
+  // These are the EXACT string values from model.go FindingFile* / FindingPlugin* consts.
+  const PHASE2_FINDING_TYPES: ScanFindingType[] = [
+    "file_added",
+    "file_changed",
+    "file_removed",
+    "plugin_modified",
+    "plugin_unknown",
+  ];
+
+  it("all five Phase 2 finding types are valid ScanFindingType members", () => {
+    // If a Go constant changes (e.g. "file_added" → "added_file"), TypeScript
+    // will reject the string literal here, causing a compile-time failure.
+    for (const t of PHASE2_FINDING_TYPES) {
+      expect(typeof t).toBe("string");
+      expect(t.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("file_added string value matches Go FindingFileAdded = 'file_added'", () => {
+    const t: ScanFindingType = "file_added";
+    expect(t).toBe("file_added");
+  });
+
+  it("file_changed string value matches Go FindingFileChanged = 'file_changed'", () => {
+    const t: ScanFindingType = "file_changed";
+    expect(t).toBe("file_changed");
+  });
+
+  it("file_removed string value matches Go FindingFileRemoved = 'file_removed'", () => {
+    const t: ScanFindingType = "file_removed";
+    expect(t).toBe("file_removed");
+  });
+
+  it("plugin_modified string value matches Go FindingPluginModified = 'plugin_modified'", () => {
+    const t: ScanFindingType = "plugin_modified";
+    expect(t).toBe("plugin_modified");
+  });
+
+  it("plugin_unknown string value matches Go FindingPluginUnknown = 'plugin_unknown'", () => {
+    const t: ScanFindingType = "plugin_unknown";
+    expect(t).toBe("plugin_unknown");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Finding type chip logic — label + class resolution
+//
+// These tests mirror the TYPE_LABEL / TYPE_CLASSES / fallback logic from
+// scan-findings-table.tsx as pure functions so they run without a DOM renderer.
+// Keeping the logic in-sync: if the maps in the component change, these tests
+// must be updated, and vice versa.
+// ---------------------------------------------------------------------------
+
+// Replicate the chip resolution logic from scan-findings-table.tsx.
+// This is not an import — it's a clean-room re-statement of the same rules,
+// so a divergence between the component and the test is caught explicitly.
+
+const KNOWN_TYPE_LABELS: Record<ScanFindingType, string> = {
+  core_modified: "Core modified",
+  core_missing: "Core missing",
+  core_unknown_injected: "Unknown file",
+  file_added: "File added",
+  file_changed: "File changed",
+  file_removed: "File removed",
+  plugin_modified: "Plugin file modified",
+  plugin_unknown: "Unrecognized plugin file",
+};
+
+function resolveTypeLabel(type: string): string {
+  if (type in KNOWN_TYPE_LABELS) {
+    return KNOWN_TYPE_LABELS[type as ScanFindingType];
+  }
+  // Fallback: humanize the snake_case string.
+  return type.replace(/_/g, " ");
+}
+
+function isKnownType(type: string): boolean {
+  return type in KNOWN_TYPE_LABELS;
+}
+
+describe("finding type chip — label resolution", () => {
+  it("core_modified resolves to 'Core modified'", () => {
+    expect(resolveTypeLabel("core_modified")).toBe("Core modified");
+  });
+
+  it("file_added resolves to 'File added'", () => {
+    expect(resolveTypeLabel("file_added")).toBe("File added");
+  });
+
+  it("file_changed resolves to 'File changed'", () => {
+    expect(resolveTypeLabel("file_changed")).toBe("File changed");
+  });
+
+  it("file_removed resolves to 'File removed'", () => {
+    expect(resolveTypeLabel("file_removed")).toBe("File removed");
+  });
+
+  it("plugin_modified resolves to 'Plugin file modified'", () => {
+    expect(resolveTypeLabel("plugin_modified")).toBe("Plugin file modified");
+  });
+
+  it("plugin_unknown resolves to 'Unrecognized plugin file'", () => {
+    expect(resolveTypeLabel("plugin_unknown")).toBe("Unrecognized plugin file");
+  });
+
+  it("all eight known types produce a non-empty label", () => {
+    const knownTypes: ScanFindingType[] = [
+      "core_modified",
+      "core_missing",
+      "core_unknown_injected",
+      "file_added",
+      "file_changed",
+      "file_removed",
+      "plugin_modified",
+      "plugin_unknown",
+    ];
+    for (const t of knownTypes) {
+      const label = resolveTypeLabel(t);
+      expect(label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("finding type chip — unknown type resilience (no crash)", () => {
+  it("an unknown type is NOT in the known-type map", () => {
+    expect(isKnownType("some_future_type")).toBe(false);
+  });
+
+  it("resolveTypeLabel falls back to humanized snake_case for unknown types", () => {
+    expect(resolveTypeLabel("some_future_type")).toBe("some future type");
+  });
+
+  it("resolveTypeLabel produces a non-empty string for any non-empty input", () => {
+    const unknownTypes = [
+      "some_future_type",
+      "x",
+      "a_b_c",
+      "UPPERCASE_TYPE",
+    ];
+    for (const t of unknownTypes) {
+      expect(resolveTypeLabel(t).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("an unknown type from the API wire payload does not throw", () => {
+    // Simulate what FindingTypeChip does: look up label, fall back to humanized.
+    const wireFinding = makeWireFinding({
+      finding_type: "a_completely_unknown_finding_type_from_a_future_backend",
+    }) as { finding_type: string };
+
+    expect(() => {
+      const label = resolveTypeLabel(wireFinding.finding_type);
+      // Must produce some non-empty string, not throw.
+      expect(label.length).toBeGreaterThan(0);
+    }).not.toThrow();
+  });
+
+  it("an empty string finding_type falls through to an empty humanized string (edge case, does not crash)", () => {
+    // This is a degenerate case (the Go handler never sends an empty type)
+    // but we confirm no throw occurs.
+    expect(() => {
+      resolveTypeLabel("");
+    }).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. canViewFile logic — which types support file content viewing
+//
+// Replicated from the FindingRow component in scan-findings-table.tsx.
+// If the canViewFile condition changes, update this test in lockstep.
+// ---------------------------------------------------------------------------
+
+function canViewFile(findingType: string): boolean {
+  return (
+    findingType === "core_unknown_injected" ||
+    findingType === "core_modified" ||
+    findingType === "file_changed" ||
+    findingType === "file_added" ||
+    findingType === "plugin_modified"
+  );
+}
+
+describe("canViewFile — which finding types support the file viewer", () => {
+  it("core_unknown_injected supports file viewing", () => {
+    expect(canViewFile("core_unknown_injected")).toBe(true);
+  });
+
+  it("core_modified supports file viewing", () => {
+    expect(canViewFile("core_modified")).toBe(true);
+  });
+
+  it("file_changed supports file viewing (Phase 2)", () => {
+    expect(canViewFile("file_changed")).toBe(true);
+  });
+
+  it("file_added supports file viewing (Phase 2 — operator can inspect the injected file)", () => {
+    expect(canViewFile("file_added")).toBe(true);
+  });
+
+  it("plugin_modified supports file viewing (Phase 2)", () => {
+    expect(canViewFile("plugin_modified")).toBe(true);
+  });
+
+  it("file_removed does NOT support file viewing (file no longer exists on disk)", () => {
+    // A removed file has no current content to fetch from the agent.
+    expect(canViewFile("file_removed")).toBe(false);
+  });
+
+  it("plugin_unknown does NOT support file viewing (out of scope for v1)", () => {
+    expect(canViewFile("plugin_unknown")).toBe(false);
+  });
+
+  it("core_missing does NOT support file viewing (file is absent)", () => {
+    expect(canViewFile("core_missing")).toBe(false);
+  });
+
+  it("an unknown type does NOT support file viewing (safe default)", () => {
+    expect(canViewFile("some_future_unknown_type")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Scan kind selector — POST body contains the chosen kind
+//
+// Simulates the useStartScan mutationFn to verify that the chosen ScanKind
+// is forwarded as the `kind` field in the POST body. This matches the
+// Go handler startScanBody: `Kind string json:"kind"` (handler.go:59-61)
+// and the Service.StartRun switch in service.go that validates "core"|"files"|"full".
+// ---------------------------------------------------------------------------
+
+describe("scan kind selector — POST body carries the selected kind", () => {
+  const VALID_KINDS: ScanKind[] = ["core", "files", "full"];
+
+  it("each valid kind is a non-empty string", () => {
+    for (const k of VALID_KINDS) {
+      expect(typeof k).toBe("string");
+      expect(k.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("'core' kind posts { kind: 'core' } — matches Go startScanBody.Kind = 'core'", () => {
+    const mockPost = vi.fn();
+    function simulateStartScan(kind: ScanKind) {
+      mockPost(`/api/v1/sites/site-123/scans`, { kind });
+    }
+    simulateStartScan("core");
+    expect(mockPost).toHaveBeenCalledWith(
+      "/api/v1/sites/site-123/scans",
+      { kind: "core" },
+    );
+  });
+
+  it("'files' kind posts { kind: 'files' } — matches Go KindFiles = 'files'", () => {
+    const mockPost = vi.fn();
+    function simulateStartScan(kind: ScanKind) {
+      mockPost(`/api/v1/sites/site-123/scans`, { kind });
+    }
+    simulateStartScan("files");
+    expect(mockPost).toHaveBeenCalledWith(
+      "/api/v1/sites/site-123/scans",
+      { kind: "files" },
+    );
+  });
+
+  it("'full' kind posts { kind: 'full' } — matches Go KindFull = 'full'", () => {
+    const mockPost = vi.fn();
+    function simulateStartScan(kind: ScanKind) {
+      mockPost(`/api/v1/sites/site-123/scans`, { kind });
+    }
+    simulateStartScan("full");
+    expect(mockPost).toHaveBeenCalledWith(
+      "/api/v1/sites/site-123/scans",
+      { kind: "full" },
+    );
+  });
+
+  it("the default kind for 'Core files' option is 'core'", () => {
+    // Matches SCAN_KIND_OPTIONS[0].kind in scan-panel.tsx.
+    const defaultKind: ScanKind = "core";
+    expect(defaultKind).toBe("core");
+  });
+
+  it("siteId is URL-encoded in the POST path", () => {
+    // Matches the encodeURIComponent(siteId) call in use-scan.ts apiPost.
+    const siteId = "550e8400-e29b-41d4-a716-446655440001";
+    const path = `/api/v1/sites/${encodeURIComponent(siteId)}/scans`;
+    expect(path).toBe(
+      "/api/v1/sites/550e8400-e29b-41d4-a716-446655440001/scans",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Severity — low severity is supported for file_removed
+//
+// The design spec (§3.5) assigns file_removed = SeverityLow = "low".
+// SeverityChip already supports "low" (severity-chip.tsx CHIP/DOT/WORD maps).
+// This test pins that "low" is part of ScanFindingSeverity and that a
+// file_removed finding with severity="low" is a valid combination.
+// ---------------------------------------------------------------------------
+
+describe("severity — 'low' is a valid ScanFindingSeverity for file_removed", () => {
+  it("a file_removed finding with severity low is a valid ScanFinding shape", () => {
+    const finding = makeWireFinding({
+      finding_type: "file_removed",
+      severity: "low",
+      expected_md5: "",
+      actual_md5: "",
+    }) as ScanFinding;
+
+    expect(finding.finding_type).toBe("file_removed");
+    expect(finding.severity).toBe("low");
+  });
+
+  it("file_changed carries severity high per the design spec", () => {
+    const finding = makeWireFinding({
+      finding_type: "file_changed",
+      severity: "high",
+    }) as ScanFinding;
+    expect(finding.severity).toBe("high");
+  });
+
+  it("file_added carries severity medium per the design spec", () => {
+    const finding = makeWireFinding({
+      finding_type: "file_added",
+      severity: "medium",
+    }) as ScanFinding;
+    expect(finding.severity).toBe("medium");
+  });
+
+  it("plugin_modified and plugin_unknown carry severity high per the design spec", () => {
+    for (const type of ["plugin_modified", "plugin_unknown"] as ScanFindingType[]) {
+      const finding = makeWireFinding({
+        finding_type: type,
+        severity: "high",
+      }) as ScanFinding;
+      expect(finding.severity).toBe("high");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Findings list DTO shape — items wrapper
+//
+// The GET /findings endpoint returns { items: findingDTO[] }.
+// Our apiGet call in useScanFindings expects `data.items ?? []`.
+// This test pins the wrapper shape so a backend change (e.g. "results" key)
+// surfaces as a test failure.
+// ---------------------------------------------------------------------------
+
+describe("findings list DTO — wrapper shape matches Go findingListDTO", () => {
+  it("the wire response uses 'items' as the array key", () => {
+    // Matches handler.go:99 `findingListDTO { Items []findingDTO json:"items" }`
+    const wireResponse: { items: unknown[] } = {
+      items: [makeWireFinding()],
+    };
+    expect(wireResponse).toHaveProperty("items");
+    expect(Array.isArray(wireResponse.items)).toBe(true);
+  });
+
+  it("an empty findings response has items as an empty array (not null)", () => {
+    // The Go handler always returns `items := make([]findingDTO, 0, len(findings))`
+    // so items is never null in the response. Our `data.items ?? []` handles the
+    // null case defensively (in case a future version changes this).
+    const wireResponse = { items: [] as unknown[] };
+    const result = wireResponse.items ?? [];
+    expect(result).toHaveLength(0);
+  });
+
+  it("finding_counts on a run may be null (nil Go map marshals to null)", () => {
+    // Matches the comment in use-scan.ts:47 and the Go omitempty tag on
+    // FindingCounts: a run with no findings or in-flight sends finding_counts
+    // as absent/null, NOT as an empty object.
+    const runWithNullCounts = {
+      id: "550e8400-e29b-41d4-a716-446655440001",
+      site_id: "550e8400-e29b-41d4-a716-446655440002",
+      kind: "core",
+      status: "done",
+      files_scanned: 500,
+      finding_counts: null as Record<string, number> | null,
+      created_at: "2026-06-19T10:00:00Z",
+    };
+    // Our component calls Object.values(counts ?? {}) — must not throw on null.
+    const counts = runWithNullCounts.finding_counts ?? {};
+    const total = Object.values(counts).reduce((s, n) => s + n, 0);
+    expect(total).toBe(0);
+  });
+});

--- a/apps/web/src/features/security/scan-panel.tsx
+++ b/apps/web/src/features/security/scan-panel.tsx
@@ -1,6 +1,13 @@
-import { ScanLine, ShieldCheck, ShieldX } from "lucide-react";
+import { useState } from "react";
+import { ChevronDown, ScanLine, ShieldCheck, ShieldX } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageError } from "@/components/feedback";
 import { LiveIndicator } from "@/components/shared/live-indicator";
@@ -14,6 +21,7 @@ import {
   isLiveScan,
   type ScanRun,
   type ScanStatus,
+  type ScanKind,
 } from "./use-scan";
 import { ScanFindingsTable } from "./scan-findings-table";
 
@@ -36,7 +44,13 @@ import { ScanFindingsTable } from "./scan-findings-table";
 // Public entry point
 // ---------------------------------------------------------------------------
 
-export function ScanPanel({ siteId }: { siteId: string }) {
+export function ScanPanel({
+  siteId,
+  canWrite = false,
+}: {
+  siteId: string;
+  canWrite?: boolean;
+}) {
   const runs = useScanRuns(siteId);
 
   if (runs.isPending) {
@@ -59,7 +73,7 @@ export function ScanPanel({ siteId }: { siteId: string }) {
   return (
     <div className="space-y-6">
       {/* ── Header row: description + action ── */}
-      <ScanHeaderRow siteId={siteId} />
+      <ScanHeaderRow siteId={siteId} canWrite={canWrite} />
 
       {/* ── Latest run status ── */}
       {latestRun ? (
@@ -77,21 +91,58 @@ export function ScanPanel({ siteId }: { siteId: string }) {
 }
 
 // ---------------------------------------------------------------------------
-// Header row: description + "Run scan" button
+// Scan kind options shown in the dropdown trigger.
+// Labels are neutral, operator-facing, no competitor names.
 // ---------------------------------------------------------------------------
 
-function ScanHeaderRow({ siteId }: { siteId: string }) {
+const SCAN_KIND_OPTIONS: { kind: ScanKind; label: string; description: string }[] = [
+  {
+    kind: "core",
+    label: "Core files",
+    description: "Compare WordPress core files against official checksums.",
+  },
+  {
+    kind: "files",
+    label: "All files (wp-content)",
+    description: "Scan wp-content for added, changed, or removed files.",
+  },
+  {
+    kind: "full",
+    label: "Full install",
+    description: "Scan the entire WordPress install including core and wp-content.",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Header row: description + "Run scan" button / kind selector
+// ---------------------------------------------------------------------------
+
+function ScanHeaderRow({
+  siteId,
+  canWrite,
+}: {
+  siteId: string;
+  canWrite: boolean;
+}) {
   const runs = useScanRuns(siteId);
   const start = useStartScan(siteId);
+  const [selectedKind, setSelectedKind] = useState<ScanKind>("core");
 
   // Disable while a run is in progress.
   const isInProgress = (runs.data ?? []).some((r) => isLiveScan(r.status));
+  const isBusy = start.isPending || isInProgress;
+
+  const selectedOption = SCAN_KIND_OPTIONS.find((o) => o.kind === selectedKind) ?? {
+    kind: selectedKind,
+    label: "Core files",
+    description: "Compare WordPress core files against official checksums.",
+  };
 
   function handleStartScan() {
-    start.mutate(undefined, {
+    start.mutate(selectedKind, {
       onSuccess: () => {
         toast.success("Scan started.", {
-          description: "Comparing WordPress core files against official checksums.",
+          description: selectedOption.description,
         });
       },
       onError: (err: Error) => {
@@ -104,21 +155,81 @@ function ScanHeaderRow({ siteId }: { siteId: string }) {
     <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
       <div className="space-y-1">
         <p className="text-sm text-[var(--color-foreground)]">
-          Compares your WordPress core files against the official WordPress.org
-          checksums. Detects modified, missing, or unknown injected files.
+          Scans your WordPress install for modified, missing, added, or
+          unexpected files. Core files are verified against official
+          WordPress.org checksums; plugin files are verified against their
+          wp.org manifests where available.
+        </p>
+        <p className="text-xs text-[var(--color-muted-foreground)]">
+          Full-install and wp-content scans track changes against the last
+          good baseline. The first scan of each kind establishes the baseline;
+          added/changed/removed findings appear from the second scan onward.
         </p>
       </div>
-      <Button
-        type="button"
-        size="sm"
-        className="shrink-0"
-        disabled={start.isPending || isInProgress}
-        aria-busy={start.isPending || isInProgress}
-        onClick={handleStartScan}
-      >
-        <ScanLine aria-hidden="true" className="size-3.5" />
-        {start.isPending ? "Starting..." : "Run scan"}
-      </Button>
+
+      {/* Operators see a split-button: primary "Run scan" + dropdown kind selector. */}
+      {canWrite ? (
+        <div className="flex shrink-0 items-center">
+          <Button
+            type="button"
+            size="sm"
+            className="rounded-r-none border-r-0"
+            disabled={isBusy}
+            aria-busy={isBusy}
+            onClick={handleStartScan}
+          >
+            <ScanLine aria-hidden="true" className="size-3.5" />
+            {start.isPending ? "Starting..." : "Run scan"}
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="rounded-l-none px-2"
+                disabled={isBusy}
+                aria-label="Choose scan scope"
+                aria-haspopup="menu"
+              >
+                <ChevronDown aria-hidden="true" className="size-3.5" />
+                <span className="ml-1 text-xs text-[var(--color-muted-foreground)]">
+                  {selectedOption.label}
+                </span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="min-w-[220px]">
+              {SCAN_KIND_OPTIONS.map((opt) => (
+                <DropdownMenuItem
+                  key={opt.kind}
+                  onSelect={() => setSelectedKind(opt.kind)}
+                  aria-current={selectedKind === opt.kind ? "true" : undefined}
+                >
+                  <div className="flex flex-col gap-0.5">
+                    <span className="text-sm font-medium">{opt.label}</span>
+                    <span className="text-xs text-[var(--color-muted-foreground)]">
+                      {opt.description}
+                    </span>
+                  </div>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      ) : (
+        /* Viewers see the button read-only (cannot start a scan). */
+        <Button
+          type="button"
+          size="sm"
+          className="shrink-0"
+          disabled
+          aria-disabled="true"
+          title="Operator access required to run a scan"
+        >
+          <ScanLine aria-hidden="true" className="size-3.5" />
+          Run scan
+        </Button>
+      )}
     </div>
   );
 }
@@ -276,7 +387,7 @@ function StatusIndicator({ status }: { status: ScanStatus }) {
 function PreScanEmpty() {
   return (
     <p className="text-sm text-[var(--color-muted-foreground)]">
-      Run a scan to check core file integrity.
+      Run a scan to check file integrity.
     </p>
   );
 }

--- a/apps/web/src/features/security/use-scan.ts
+++ b/apps/web/src/features/security/use-scan.ts
@@ -28,11 +28,26 @@ import { toError } from "@/features/auth/use-auth";
 // ---------------------------------------------------------------------------
 
 export type ScanStatus = "queued" | "scanning" | "diffing" | "done" | "failed";
+
+// Phase 1 finding types (core checksums).
+// Phase 2 adds file-integrity finding types (file_added, file_changed,
+// file_removed, plugin_modified, plugin_unknown). String values MUST match
+// the Go constants in apps/api/internal/scan/model.go exactly.
 export type ScanFindingType =
   | "core_modified"
   | "core_missing"
-  | "core_unknown_injected";
+  | "core_unknown_injected"
+  // Phase 2: full file-integrity finding types.
+  | "file_added"       // file in this run, not in baseline, no wp.org checksum
+  | "file_changed"     // file in baseline, hash differs, not known-good
+  | "file_removed"     // file in baseline, absent this run
+  | "plugin_modified"  // wp.org-hosted plugin/theme file differs from official checksum
+  | "plugin_unknown";  // file inside a wp.org plugin/theme dir not in its manifest
+
 export type ScanFindingSeverity = "high" | "medium" | "low";
+
+// Scan kind values — must match Go model.go constants.
+export type ScanKind = "core" | "files" | "full";
 
 export interface ScanRun {
   id: string;
@@ -159,17 +174,22 @@ export function useScanRun(
 
 // ---------------------------------------------------------------------------
 // useStartScan — POST /api/v1/sites/{siteId}/scans
+//
+// The `kind` variable is passed at call time (mutate(kind)) so the same hook
+// instance can start different kinds without re-mounting.
+// Accepted kind values: "core" (default), "files" (wp-content walk),
+// "full" (whole install walk).
 // ---------------------------------------------------------------------------
 
 export function useStartScan(
   siteId: string,
-): UseMutationResult<ScanRun, Error, void> {
+): UseMutationResult<ScanRun, Error, ScanKind> {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async () =>
+    mutationFn: async (kind: ScanKind) =>
       apiPost<ScanRun>(
         `/api/v1/sites/${encodeURIComponent(siteId)}/scans`,
-        { kind: "core" },
+        { kind },
       ),
     onSuccess: (newRun) => {
       // Optimistically prepend the new run to the list so the UI is responsive.

--- a/apps/web/src/routes/_authed/sites/$siteId.security.tsx
+++ b/apps/web/src/routes/_authed/sites/$siteId.security.tsx
@@ -124,7 +124,7 @@ function SecurityTab() {
         </div>
       </section>
 
-      {/* ── Section 5: Integrity scan (S3) ── */}
+      {/* ── Section 5: File integrity (Phase 2) ── */}
       <section
         aria-labelledby="integrity-scan-heading"
         className="space-y-4 px-4 pb-8 pt-6 sm:px-6"
@@ -133,10 +133,10 @@ function SecurityTab() {
           id="integrity-scan-heading"
           className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
         >
-          Integrity scan
+          File integrity
         </h2>
 
-        <ScanPanel siteId={siteId} />
+        <ScanPanel siteId={siteId} canWrite={canWrite} />
       </section>
     </div>
   );


### PR DESCRIPTION
Second phase of the security suite (docs/security/security-suite-plan.md). Clean-room; no competitor named. Extends the existing core-checksum scanner into full file-integrity monitoring.

## What ships
- **Full file-integrity scan** (Core / wp-content / Full install): the CP compares hashes against WordPress.org checksums for core + wp.org plugins/themes, and a learned per-site baseline for everything else; reports changed/added/removed files + modified/unrecognized plugin files. Findings surface on the per-site Security tab with a scan-scope selector. Free WP.org data only.
- Continuous + safe: a flagged file keeps re-flagging every scan until an operator **accepts** it; the baseline never auto-advances past an unreviewed change.

## Layers
- **CP** (`f349dc5`): m77 (site_file_baseline + site_managed_files RLS tables + wp.org plugin-checksum cache), `Plugin()` checksum fetch, `diffFiles` classifier, baseline promotion.
- **Agent** (`5d2f1bf`): `record_managed_files` signed command with a 5-layer path-traversal guard; kind=full/files scan confirmed.
- **Web** (`f54df60`): file-integrity finding types + scan-scope trigger; **matched the hand-written Gin DTO shapes + a render test** (per the 0.52.1 contract lesson).
- **Security fixes** (`8653e43`): closes the review — the blocker was **baseline promotion laundering tampering** (now path-selective + accept-advances-baseline, with an anti-laundering regression test); + managed-file suppression (hardening paths) + plugin-slug allowlist.

## Security review
DO-NOT-SHIP → blocker (tamper laundering) + 2 should-fix → all closed + re-verified. Path traversal, RLS, SSRF, injection all passed.

## Verification
api `go test ./...` green; agent phpunit green + phpcs 0; web typecheck/build/lint green; landing copy-check green. m77 auto-runs on boot; no breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* File integrity monitoring with configurable scan scope (core files, plugins/themes, or full install)
* Checksum validation against WordPress.org and per-site baselines for detecting file modifications
* Per-site security tab enabling operator-managed hardening controls and ban lists (opt-in)
* Findings remain flagged until operator review and explicit acceptance

**Improvements**
* Enhanced scan interface with operator-selectable scan scope options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->