### PR TITLE
fix(build): agent vendor strip permission failure in release.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,13 @@ agent-vendor: ## Build a clean prod-only vendor/ for the agent (no-dev, stripped
 	# container doesn't ship ext-mysqli/zip/zlib; those checks happen on the
 	# actual WP host at runtime, where the extensions are present).
 	cd apps/agent && rm -rf vendor composer.lock
-	docker run --rm -v "$(PWD)/apps/agent:/app" -w /app composer:2 install --no-dev --optimize-autoloader --classmap-authoritative --ignore-platform-reqs
+	# Run composer as the HOST user (not the container's root) so every extracted
+	# vendor file is owned by the invoking user. Otherwise, on a Linux CI runner,
+	# the bind-mounted files are created root-owned and the host-side strip step
+	# below fails with "Permission denied" on read-only package files (e.g. a
+	# dependency's README.md / phpstan.neon). COMPOSER_HOME points at a writable
+	# cache dir since the mapped UID has no entry in the container's /etc/passwd.
+	docker run --rm --user "$$(id -u):$$(id -g)" -e COMPOSER_HOME=/tmp/composer -v "$(PWD)/apps/agent:/app" -w /app composer:2 install --no-dev --optimize-autoloader --classmap-authoritative --ignore-platform-reqs
 	# Strip non-runtime files from the runtime vendors. Be conservative: only
 	# drop directories named exactly tests/Tests/doc/docs/examples/.git, plus
 	# CHANGELOG/UPGRADING/README .md files. Never touch *.php.


### PR DESCRIPTION
release.yml v0.54.0 failed packaging the agent zip: the host-side vendor strip hit Permission denied on root-owned read-only files from the new zxcvbn dependency. Run composer as the host user so vendor files are runner-owned. The v0.54.0 Release + asset were already published from the good local build; this repairs the pipeline for future tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)