### PR TITLE
fix(web): compact expanded Security panels (0.55.1)

### DIFF
--- a/apps/web/src/features/security/hardening-panel.tsx
+++ b/apps/web/src/features/security/hardening-panel.tsx
@@ -137,7 +137,7 @@ function HardeningLoaded({
   const disabled = !canWrite || update.isPending;
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-5">
       {/* ── File & content ────────────────────────────────────────────── */}
       <SubSection id="hardening-file-content" title="File and content">
         <ToggleRow
@@ -176,10 +176,9 @@ function HardeningLoaded({
 
       {/* ── XML-RPC ───────────────────────────────────────────────────── */}
       <SubSection id="hardening-xmlrpc" title="XML-RPC">
-        <p className="mb-3 text-xs text-[var(--color-muted-foreground)]">
-          XML-RPC is a legacy remote-publishing interface. Keeping it fully
-          active exposes the site to amplification and brute-force attacks. Use
-          Limited mode if Jetpack or a mobile app requires it.
+        <p className="mb-2 text-xs text-[var(--color-muted-foreground)]">
+          Legacy remote-publishing interface. Use Limited if Jetpack or a mobile
+          app requires it; otherwise disable.
         </p>
         <SegmentedControl<XmlrpcMode>
           id="xmlrpc-mode"
@@ -203,10 +202,9 @@ function HardeningLoaded({
 
       {/* ── REST API ──────────────────────────────────────────────────── */}
       <SubSection id="hardening-rest-api" title="REST API">
-        <p className="mb-3 text-xs text-[var(--color-muted-foreground)]">
-          The WordPress REST API is required by the block editor and many
-          plugins. Restricting it adds a layer of obscurity for unauthenticated
-          user enumeration endpoints.
+        <p className="mb-2 text-xs text-[var(--color-muted-foreground)]">
+          Required by the block editor and most plugins. Restricting it blocks
+          unauthenticated user-enumeration endpoints.
         </p>
         <SegmentedControl<RestApiAccess>
           id="rest-api-access"
@@ -229,9 +227,9 @@ function HardeningLoaded({
 
       {/* ── Login ─────────────────────────────────────────────────────── */}
       <SubSection id="hardening-login" title="Login">
-        <div className="space-y-6">
+        <div className="space-y-4">
           <div>
-            <p className="mb-3 text-xs text-[var(--color-muted-foreground)]">
+            <p className="mb-2 text-xs text-[var(--color-muted-foreground)]">
               Control which identifiers are accepted on the login form to reduce
               username enumeration risk.
             </p>
@@ -301,7 +299,7 @@ function HardeningLoaded({
 
       {/* ── Save ──────────────────────────────────────────────────────── */}
       {canWrite ? (
-        <div className="flex items-center gap-3 border-t border-[var(--color-border)] pt-6">
+        <div className="flex items-center gap-3 border-t border-[var(--color-border)] pt-4">
           <Button
             type="button"
             onClick={handleSave}
@@ -338,7 +336,7 @@ function SubSection({
     <section aria-labelledby={id}>
       <h3
         id={id}
-        className="mb-4 text-sm font-medium text-[var(--color-foreground)]"
+        className="mb-2 text-sm font-medium text-[var(--color-foreground)]"
       >
         {title}
       </h3>
@@ -368,7 +366,7 @@ function ToggleRow({
 }) {
   const helpId = `${id}-help`;
   return (
-    <div className="flex items-start justify-between gap-4 py-3 first:pt-0">
+    <div className="flex items-start justify-between gap-4 py-2 first:pt-0">
       <div className="min-w-0 flex-1">
         <label
           htmlFor={id}
@@ -464,7 +462,7 @@ function HardeningSkeleton() {
       role="status"
       aria-busy="true"
       aria-label="Loading hardening settings"
-      className="space-y-8"
+      className="space-y-5"
     >
       <span className="sr-only">Loading hardening settings</span>
       {/* Sub-section skeletons */}

--- a/apps/web/src/features/security/login-protection-panel.tsx
+++ b/apps/web/src/features/security/login-protection-panel.tsx
@@ -224,12 +224,12 @@ function LoginProtectionLoaded({ siteId, initialConfig }: LoadedProps) {
   const isProtecting = mode === "protect";
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-5">
       {/* ── Protect-mode enforcing banner ── */}
       {isProtecting && (
         <div
           role="status"
-          className="flex items-start gap-3 rounded-lg border border-[var(--color-warning)]/40 bg-[var(--color-warning)]/8 p-4"
+          className="flex items-start gap-2.5 rounded-lg border border-[var(--color-warning)]/40 bg-[var(--color-warning)]/8 px-3 py-2.5"
         >
           <ShieldAlert
             aria-hidden="true"
@@ -252,15 +252,15 @@ function LoginProtectionLoaded({ siteId, initialConfig }: LoadedProps) {
       <section aria-labelledby="lp-mode-heading">
         <h3
           id="lp-mode-heading"
-          className="mb-3 text-sm font-medium text-[var(--color-foreground)]"
+          className="mb-2 text-sm font-medium text-[var(--color-foreground)]"
         >
           Mode
         </h3>
-        <div className="space-y-2">
+        <div className="space-y-1.5">
           {MODES.map((m) => (
             <label
               key={m.value}
-              className="flex cursor-pointer items-start gap-3 rounded-lg border border-[var(--color-border)] p-3 transition-colors hover:bg-[var(--color-muted)]/40 has-[:checked]:border-[var(--color-ring)] has-[:checked]:bg-[var(--color-muted)]/20"
+              className="flex cursor-pointer items-center gap-3 rounded-md border border-[var(--color-border)] px-3 py-2 transition-colors hover:bg-[var(--color-muted)]/40 has-[:checked]:border-[var(--color-ring)] has-[:checked]:bg-[var(--color-muted)]/20"
             >
               <input
                 type="radio"
@@ -268,13 +268,13 @@ function LoginProtectionLoaded({ siteId, initialConfig }: LoadedProps) {
                 value={m.value}
                 checked={mode === m.value}
                 onChange={() => setMode(m.value)}
-                className="mt-0.5 accent-[var(--color-primary)]"
+                className="accent-[var(--color-primary)] shrink-0"
               />
-              <div className="min-w-0">
-                <span className="block text-sm font-medium text-[var(--color-foreground)]">
+              <div className="min-w-0 flex items-baseline gap-2 flex-wrap">
+                <span className="text-sm font-medium text-[var(--color-foreground)]">
                   {m.label}
                 </span>
-                <span className="block text-xs text-[var(--color-muted-foreground)]">
+                <span className="text-xs text-[var(--color-muted-foreground)]">
                   {m.description}
                 </span>
               </div>
@@ -291,18 +291,16 @@ function LoginProtectionLoaded({ siteId, initialConfig }: LoadedProps) {
         >
           Allow list (never blocked)
         </h3>
-        <p className="mb-3 text-xs text-[var(--color-muted-foreground)]">
-          IPs in this list bypass all login-protection checks entirely. This is
-          your lockout escape hatch — add your office or home CIDR here before
-          enabling Protect mode. When you switch to Protect with an empty list,
-          the server automatically adds your current IP.
+        <p className="mb-2 text-xs text-[var(--color-muted-foreground)]">
+          IPs in this list bypass all login-protection checks entirely. Add your
+          office or home CIDR here before enabling Protect mode.
         </p>
 
         {/* Chips */}
         {allowCidrs.length > 0 && (
           <ul
             aria-label="Allow list CIDRs"
-            className="mb-3 flex flex-wrap gap-2"
+            className="mb-2 flex flex-wrap gap-1.5"
           >
             {allowCidrs.map((cidr) => (
               <li key={cidr}>
@@ -368,11 +366,9 @@ function LoginProtectionLoaded({ siteId, initialConfig }: LoadedProps) {
           </Button>
         </div>
 
-        <p className="mt-2 flex items-start gap-1.5 text-xs text-[var(--color-muted-foreground)]">
-          <Info aria-hidden="true" className="mt-0.5 size-3.5 shrink-0" />
-          When switching to Protect with an empty list, the server
-          auto-adds your current operator IP. You&apos;ll see it reflected
-          here after saving.
+        <p className="mt-1.5 flex items-center gap-1.5 text-xs text-[var(--color-muted-foreground)]">
+          <Info aria-hidden="true" className="size-3.5 shrink-0" />
+          Switching to Protect with an empty list auto-adds your current IP.
         </p>
       </section>
 
@@ -384,16 +380,15 @@ function LoginProtectionLoaded({ siteId, initialConfig }: LoadedProps) {
         >
           Deny list (always blocked)
         </h3>
-        <p className="mb-3 text-xs text-[var(--color-muted-foreground)]">
-          IPs matching these CIDRs are denied immediately, before threshold
-          evaluation. Use for known bad actors or ranges you never want on your
-          login page.
+        <p className="mb-2 text-xs text-[var(--color-muted-foreground)]">
+          IPs matching these CIDRs are denied before threshold evaluation. Use
+          for known bad actors or ranges to permanently block.
         </p>
 
         {denyCidrs.length > 0 && (
           <ul
             aria-label="Deny list CIDRs"
-            className="mb-3 flex flex-wrap gap-2"
+            className="mb-2 flex flex-wrap gap-1.5"
           >
             {denyCidrs.map((cidr) => (
               <li key={cidr}>
@@ -461,87 +456,72 @@ function LoginProtectionLoaded({ siteId, initialConfig }: LoadedProps) {
       <section aria-labelledby="lp-thresholds-heading">
         <h3
           id="lp-thresholds-heading"
-          className="mb-3 text-sm font-medium text-[var(--color-foreground)]"
+          className="mb-1 text-sm font-medium text-[var(--color-foreground)]"
         >
           Brute-force thresholds
         </h3>
-        <p className="mb-4 text-xs text-[var(--color-muted-foreground)]">
-          Defaults: captcha after 3 failures, temporary block after 10, permanent
-          block after 100. Gaps reset the counter after 30 minutes (1800 s) of
-          inactivity.
+        <p className="mb-3 text-xs text-[var(--color-muted-foreground)]">
+          Defaults: CAPTCHA after 3 failures, temp block after 10, permanent
+          block after 100. Gaps reset the counter after inactivity.
         </p>
 
-        {/* Limits group */}
-        <fieldset className="mb-4">
-          <legend className="mb-2 text-xs font-medium text-[var(--color-foreground)]">
-            Failure limits
-          </legend>
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-            <ThresholdField
-              id="captcha-limit"
-              label="CAPTCHA after"
-              unit="failures"
-              value={thresholds.captcha_limit}
-              onChange={(v) => handleThreshold("captcha_limit", v)}
-              helpId="captcha-limit-help"
-              help="Show a CAPTCHA challenge after this many consecutive failures."
-            />
-            <ThresholdField
-              id="temp-block-limit"
-              label="Temporary block after"
-              unit="failures"
-              value={thresholds.temp_block_limit}
-              onChange={(v) => handleThreshold("temp_block_limit", v)}
-              helpId="temp-block-limit-help"
-              help="Apply a temporary IP block after this many consecutive failures."
-            />
-            <ThresholdField
-              id="block-all-limit"
-              label="Permanent block after"
-              unit="failures"
-              value={thresholds.block_all_limit}
-              onChange={(v) => handleThreshold("block_all_limit", v)}
-              helpId="block-all-limit-help"
-              help="Apply a permanent block after this many consecutive failures."
-            />
-          </div>
-        </fieldset>
-
-        {/* Gaps group */}
-        <fieldset>
-          <legend className="mb-2 text-xs font-medium text-[var(--color-foreground)]">
-            Reset gaps (seconds)
-          </legend>
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-            <ThresholdField
-              id="failed-login-gap"
-              label="Failed-login gap"
-              unit="seconds"
-              value={thresholds.failed_login_gap}
-              onChange={(v) => handleThreshold("failed_login_gap", v)}
-              helpId="failed-login-gap-help"
-              help="Seconds of inactivity that reset the consecutive failure counter."
-            />
-            <ThresholdField
-              id="success-login-gap"
-              label="Success-login gap"
-              unit="seconds"
-              value={thresholds.success_login_gap}
-              onChange={(v) => handleThreshold("success_login_gap", v)}
-              helpId="success-login-gap-help"
-              help="Seconds after a successful login before a new failure series begins."
-            />
-            <ThresholdField
-              id="all-blocked-gap"
-              label="Block duration"
-              unit="seconds"
-              value={thresholds.all_blocked_gap}
-              onChange={(v) => handleThreshold("all_blocked_gap", v)}
-              helpId="all-blocked-gap-help"
-              help="Seconds a permanent block remains active before auto-expiry."
-            />
-          </div>
-        </fieldset>
+        {/* Limits + gaps in a single compact grid */}
+        <div className="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3">
+          <ThresholdField
+            id="captcha-limit"
+            label="CAPTCHA after"
+            unit="failures"
+            value={thresholds.captcha_limit}
+            onChange={(v) => handleThreshold("captcha_limit", v)}
+            helpId="captcha-limit-help"
+            help="CAPTCHA challenge threshold."
+          />
+          <ThresholdField
+            id="temp-block-limit"
+            label="Temp block after"
+            unit="failures"
+            value={thresholds.temp_block_limit}
+            onChange={(v) => handleThreshold("temp_block_limit", v)}
+            helpId="temp-block-limit-help"
+            help="Temporary IP block threshold."
+          />
+          <ThresholdField
+            id="block-all-limit"
+            label="Permanent block after"
+            unit="failures"
+            value={thresholds.block_all_limit}
+            onChange={(v) => handleThreshold("block_all_limit", v)}
+            helpId="block-all-limit-help"
+            help="Permanent block threshold."
+          />
+          <ThresholdField
+            id="failed-login-gap"
+            label="Failed-login gap"
+            unit="seconds"
+            value={thresholds.failed_login_gap}
+            onChange={(v) => handleThreshold("failed_login_gap", v)}
+            helpId="failed-login-gap-help"
+            help="Inactivity window that resets failure count."
+          />
+          <ThresholdField
+            id="success-login-gap"
+            label="Success-login gap"
+            unit="seconds"
+            value={thresholds.success_login_gap}
+            onChange={(v) => handleThreshold("success_login_gap", v)}
+            helpId="success-login-gap-help"
+            help="Cooldown after a successful login."
+          />
+          <ThresholdField
+            id="all-blocked-gap"
+            label="Block duration"
+            unit="seconds"
+            value={thresholds.all_blocked_gap}
+            onChange={(v) => handleThreshold("all_blocked_gap", v)}
+            helpId="all-blocked-gap-help"
+            help="Seconds until a permanent block auto-expires."
+          />
+        </div>
       </section>
 
       {/* ── IP header ── */}
@@ -552,10 +532,9 @@ function LoginProtectionLoaded({ siteId, initialConfig }: LoadedProps) {
         >
           Real-IP header
         </h3>
-        <p className="mb-3 text-xs text-[var(--color-muted-foreground)]">
-          Only change this if your site is behind a trusted reverse proxy or CDN.
-          An incorrect value lets attackers spoof their IP by sending a forged
-          header.
+        <p className="mb-2 text-xs text-[var(--color-muted-foreground)]">
+          Only change if behind a trusted reverse proxy or CDN. An incorrect
+          value lets attackers spoof their IP.
         </p>
         <div className="max-w-sm">
           <label htmlFor="ip-header-select" className="sr-only">
@@ -589,7 +568,7 @@ function LoginProtectionLoaded({ siteId, initialConfig }: LoadedProps) {
       ) : null}
 
       {/* ── Save ── */}
-      <div className="flex items-center gap-3 border-t border-[var(--color-border)] pt-6">
+      <div className="flex items-center gap-3 border-t border-[var(--color-border)] pt-4">
         <Button
           type="button"
           onClick={handleSave}
@@ -639,14 +618,15 @@ function ThresholdField({
   help,
 }: ThresholdFieldProps) {
   return (
-    <div className="space-y-1.5">
+    <div className="space-y-1">
       <label
         htmlFor={id}
         className="block text-xs font-medium text-[var(--color-foreground)]"
+        title={help}
       >
         {label}
       </label>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1.5">
         <Input
           id={id}
           type="number"
@@ -654,13 +634,13 @@ function ThresholdField({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           aria-describedby={helpId}
-          className="w-24 tabular-nums font-mono text-sm"
+          className="w-20 tabular-nums font-mono text-sm"
         />
         <span className="text-xs text-[var(--color-muted-foreground)]">
           {unit}
         </span>
       </div>
-      <p id={helpId} className="text-xs text-[var(--color-muted-foreground)]">
+      <p id={helpId} className="text-[10px] leading-tight text-[var(--color-muted-foreground)]">
         {help}
       </p>
     </div>
@@ -677,7 +657,7 @@ function LoginProtectionSkeleton() {
       role="status"
       aria-busy="true"
       aria-label="Loading login protection config"
-      className="space-y-8"
+      className="space-y-5"
     >
       <span className="sr-only">Loading login protection config</span>
       {/* Mode skeleton */}

--- a/apps/web/src/features/security/policy-panel.tsx
+++ b/apps/web/src/features/security/policy-panel.tsx
@@ -241,7 +241,7 @@ function PolicyLoaded({ siteId, initialPolicy, canWrite, section }: LoadedProps)
   const disabled = !canWrite || update.isPending;
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-5">
       {/* ── Section 1: Two-factor authentication ─────────────────────── */}
       {show2FA ? <SubSection id="policy-2fa" title="Two-factor authentication">
         {/* Master toggle */}
@@ -273,7 +273,7 @@ function PolicyLoaded({ siteId, initialPolicy, canWrite, section }: LoadedProps)
         ) : null}
 
         {policy.two_factor_enabled ? (
-          <div className="space-y-6 pt-2">
+          <div className="space-y-4 pt-1">
             {/* Allowed methods */}
             <CheckboxGroup
               id="2fa-methods"
@@ -342,7 +342,7 @@ function PolicyLoaded({ siteId, initialPolicy, canWrite, section }: LoadedProps)
       {/* ── Section 2: Password policy ───────────────────────────────── */}
       {showPassword ? <SubSection id="policy-password" title="Password policy">
         {/* Min strength */}
-        <div className="py-3 first:pt-0">
+        <div className="py-2 first:pt-0">
           <div className="flex items-start justify-between gap-4">
             <div className="min-w-0 flex-1">
               <label
@@ -443,7 +443,7 @@ function PolicyLoaded({ siteId, initialPolicy, canWrite, section }: LoadedProps)
               toggleStringInList("password_expiry_roles", role)
             }
             disabled={disabled}
-            className="py-3"
+            className="py-2"
           />
         ) : null}
       </SubSection> : null}
@@ -591,7 +591,7 @@ function PolicyLoaded({ siteId, initialPolicy, canWrite, section }: LoadedProps)
 
       {/* ── Save / viewer notice ─────────────────────────────────────── */}
       {canWrite ? (
-        <div className="flex items-center gap-3 border-t border-[var(--color-border)] pt-6">
+        <div className="flex items-center gap-3 border-t border-[var(--color-border)] pt-4">
           <Button
             type="button"
             onClick={handleSave}
@@ -628,7 +628,7 @@ function SubSection({
     <section aria-labelledby={id}>
       <h3
         id={id}
-        className="mb-4 text-sm font-medium text-[var(--color-foreground)]"
+        className="mb-2 text-sm font-medium text-[var(--color-foreground)]"
       >
         {title}
       </h3>
@@ -658,7 +658,7 @@ function ToggleRow({
 }) {
   const helpId = `${id}-help`;
   return (
-    <div className="flex items-start justify-between gap-4 py-3 first:pt-0">
+    <div className="flex items-start justify-between gap-4 py-2 first:pt-0">
       <div className="min-w-0 flex-1">
         <label
           htmlFor={id}
@@ -780,7 +780,7 @@ function NumberField({
 }) {
   const helpId = `${id}-help`;
   return (
-    <div className="flex items-start justify-between gap-4 py-3 first:pt-0">
+    <div className="flex items-start justify-between gap-4 py-2 first:pt-0">
       <div className="min-w-0 flex-1">
         <label
           htmlFor={id}
@@ -838,7 +838,7 @@ function PolicySkeleton() {
       role="status"
       aria-busy="true"
       aria-label="Loading authentication policy"
-      className="space-y-8"
+      className="space-y-5"
     >
       <span className="sr-only">Loading authentication policy</span>
       {/* Three sub-section skeletons */}


### PR DESCRIPTION
Presentation-only: the expanded Security panels were too airy (login-protection ~1223px); tightened to ~600px so toggling a card doesn't balloon the page. No logic change. Gates green, impeccable clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing and layout consistency across security configuration panels (hardening, login protection, and policy settings).
  * Reorganized brute-force threshold section for better visual hierarchy.
  * Updated and clarified help text guidance throughout security features for enhanced user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->