### PR TITLE
fix(web): vuln feed empty-state points to the admin UI (0.57.2)

### DIFF
--- a/apps/web/src/features/security/vuln-panel.tsx
+++ b/apps/web/src/features/security/vuln-panel.tsx
@@ -508,11 +508,9 @@ function FeedNotConfiguredState() {
           Vulnerability feed not configured yet
         </p>
         <p className="max-w-sm text-xs text-[var(--color-muted-foreground)]">
-          An administrator needs to connect the Wordfence Intelligence feed by
-          setting the{" "}
-          <span className="font-mono">WPMGR_WORDFENCE_API_KEY</span>{" "}
-          environment variable on the control plane. Vulnerability scanning will
-          begin automatically once the feed is connected.
+          An administrator needs to connect the Wordfence Intelligence feed from
+          the Admin area, under Vulnerability feed. Vulnerability scanning begins
+          automatically once the feed is connected.
         </p>
       </div>
     </div>

--- a/apps/web/src/routes/_authed/vulnerabilities.tsx
+++ b/apps/web/src/routes/_authed/vulnerabilities.tsx
@@ -279,11 +279,9 @@ function FeedNotConfiguredState() {
           Vulnerability feed not configured yet
         </p>
         <p className="text-sm text-[var(--color-muted-foreground)]">
-          An administrator needs to connect the Wordfence Intelligence feed by
-          setting the{" "}
-          <span className="font-mono text-xs">WPMGR_WORDFENCE_API_KEY</span>{" "}
-          environment variable on the control plane. Vulnerability scanning will
-          begin automatically once the feed is connected.
+          An administrator needs to connect the Wordfence Intelligence feed from
+          the Admin area, under Vulnerability feed. Vulnerability scanning begins
+          automatically once the feed is connected.
         </p>
       </div>
     </div>


### PR DESCRIPTION
The 'feed not configured' empty state still told operators to set the WPMGR_WORDFENCE_API_KEY env var (stale since 0.57.0 made it UI-configurable). Now points to Admin -> Vulnerability feed. Ships alongside the 0.57.1 white-screen fix in this OSS release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)