### PR TITLE
fix(api): vuln feed upsert — "references" reserved word (m81 rename) + round-trip test (0.57.4)

### DIFF
--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -2979,3 +2979,120 @@ ALTER TABLE instance_settings FORCE ROW LEVEL SECURITY;
 CREATE POLICY instance_settings_agent ON instance_settings
     USING  (current_setting('app.agent', true) = 'on')
     WITH CHECK (current_setting('app.agent', true) = 'on');
+
+-- ---------------------------------------------------------------------------
+-- wordfence_vuln_feed  (m79 — global public vulnerability record cache)
+-- ---------------------------------------------------------------------------
+-- No RLS. Public reference data from the Wordfence Intelligence V3 feed.
+-- Written by the ingester via InAgentTx; read by inventory matching directly.
+-- reference_urls (renamed from "references" in m81 — "references" is a
+-- reserved keyword in PostgreSQL that causes SQLSTATE 42601 when unquoted).
+CREATE TABLE IF NOT EXISTS wordfence_vuln_feed (
+    vuln_id        text PRIMARY KEY,
+    title          text NOT NULL DEFAULT '',
+    cve            text,
+    cve_link       text,
+    cvss_score     numeric(3,1),
+    cvss_rating    text,
+    cwe            jsonb,
+    informational  boolean NOT NULL DEFAULT false,
+    reference_urls jsonb NOT NULL DEFAULT '[]',
+    published      timestamptz,
+    updated        timestamptz,
+    raw            jsonb NOT NULL DEFAULT '{}',
+    created_at     timestamptz NOT NULL DEFAULT now()
+);
+
+-- ---------------------------------------------------------------------------
+-- wordfence_vuln_software  (m79 — per-software index)
+-- ---------------------------------------------------------------------------
+-- No RLS. One row per software[] entry per vuln. Serves (kind, slug) lookup.
+CREATE TABLE IF NOT EXISTS wordfence_vuln_software (
+    vuln_id           text NOT NULL
+        REFERENCES wordfence_vuln_feed (vuln_id) ON DELETE CASCADE,
+    kind              text NOT NULL,
+    slug              text NOT NULL,
+    affected_versions jsonb NOT NULL,
+    patched           boolean NOT NULL DEFAULT false,
+    patched_versions  jsonb NOT NULL DEFAULT '[]',
+
+    CONSTRAINT wordfence_vuln_software_pkey
+        PRIMARY KEY (vuln_id, kind, slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wf_vuln_software_lookup
+    ON wordfence_vuln_software (kind, slug);
+
+-- ---------------------------------------------------------------------------
+-- wordfence_vuln_feed_meta  (m79 — freshness + attribution sentinel)
+-- ---------------------------------------------------------------------------
+-- No RLS. Single row (id=1). Freshness timestamp, attribution notices, error.
+CREATE TABLE IF NOT EXISTS wordfence_vuln_feed_meta (
+    id              integer PRIMARY KEY DEFAULT 1
+        CONSTRAINT wordfence_vuln_feed_meta_singleton_chk CHECK (id = 1),
+    fetched_at      timestamptz,
+    ok              boolean NOT NULL DEFAULT false,
+    record_count    integer NOT NULL DEFAULT 0,
+    defiant_notice  text,
+    defiant_license text,
+    mitre_notice    text,
+    last_error      text
+);
+
+-- ---------------------------------------------------------------------------
+-- site_vulnerabilities  (m79 — per-site matched findings, tenant-RLS)
+-- ---------------------------------------------------------------------------
+-- One row per (site_id, vuln_id, kind, slug). RLS mirrors m76/m77.
+CREATE TABLE IF NOT EXISTS site_vulnerabilities (
+    id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id         uuid NOT NULL,
+    site_id           uuid NOT NULL
+        REFERENCES sites (id) ON UPDATE NO ACTION ON DELETE CASCADE,
+    vuln_id           text NOT NULL,
+    kind              text NOT NULL,
+    slug              text NOT NULL,
+    name              text NOT NULL,
+    installed_version text NOT NULL,
+    fixed_version     text,
+    severity          text NOT NULL
+        CONSTRAINT site_vulnerabilities_severity_chk
+        CHECK (severity IN ('critical', 'high', 'medium', 'low')),
+    cvss_score        numeric(3,1),
+    cve               text,
+    title             text NOT NULL,
+    status            text NOT NULL DEFAULT 'open'
+        CONSTRAINT site_vulnerabilities_status_chk
+        CHECK (status IN ('open', 'dismissed', 'resolved')),
+    first_seen        timestamptz NOT NULL DEFAULT now(),
+    last_seen         timestamptz NOT NULL DEFAULT now(),
+    resolved_at       timestamptz,
+    dismissed_at      timestamptz,
+    dismissed_by      uuid,
+
+    CONSTRAINT site_vulnerabilities_tenant_fkey
+        FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE CASCADE,
+    CONSTRAINT site_vulnerabilities_uq
+        UNIQUE (site_id, vuln_id, kind, slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_site_vuln_site_open
+    ON site_vulnerabilities (site_id)
+    WHERE status = 'open';
+
+CREATE INDEX IF NOT EXISTS idx_site_vuln_tenant_sev
+    ON site_vulnerabilities (tenant_id, severity)
+    WHERE status = 'open';
+
+CREATE INDEX IF NOT EXISTS site_vulnerabilities_tenant_idx
+    ON site_vulnerabilities (tenant_id, site_id);
+
+ALTER TABLE site_vulnerabilities ENABLE ROW LEVEL SECURITY;
+ALTER TABLE site_vulnerabilities FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY site_vulnerabilities_tenant_isolation ON site_vulnerabilities
+    USING      (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid)
+    WITH CHECK (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid);
+
+CREATE POLICY site_vulnerabilities_agent ON site_vulnerabilities
+    USING      (current_setting('app.agent', true) = 'on')
+    WITH CHECK (current_setting('app.agent', true) = 'on');

--- a/apps/api/internal/vuln/repo.go
+++ b/apps/api/internal/vuln/repo.go
@@ -39,20 +39,20 @@ func (r *Repo) UpsertFeedRecord(ctx context.Context, tx pgx.Tx, rec FeedRecord) 
 	_, err := tx.Exec(ctx, `
 		INSERT INTO wordfence_vuln_feed
 			(vuln_id, title, cve, cve_link, cvss_score, cvss_rating, cwe,
-			 informational, references, published, updated, raw)
+			 informational, reference_urls, published, updated, raw)
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
 		ON CONFLICT (vuln_id) DO UPDATE SET
-			title         = EXCLUDED.title,
-			cve           = EXCLUDED.cve,
-			cve_link      = EXCLUDED.cve_link,
-			cvss_score    = EXCLUDED.cvss_score,
-			cvss_rating   = EXCLUDED.cvss_rating,
-			cwe           = EXCLUDED.cwe,
-			informational = EXCLUDED.informational,
-			references    = EXCLUDED.references,
-			published     = EXCLUDED.published,
-			updated       = EXCLUDED.updated,
-			raw           = EXCLUDED.raw`,
+			title          = EXCLUDED.title,
+			cve            = EXCLUDED.cve,
+			cve_link       = EXCLUDED.cve_link,
+			cvss_score     = EXCLUDED.cvss_score,
+			cvss_rating    = EXCLUDED.cvss_rating,
+			cwe            = EXCLUDED.cwe,
+			informational  = EXCLUDED.informational,
+			reference_urls = EXCLUDED.reference_urls,
+			published      = EXCLUDED.published,
+			updated        = EXCLUDED.updated,
+			raw            = EXCLUDED.raw`,
 		rec.VulnID, rec.Title, nilString(rec.CVE), nilString(rec.CVELink),
 		rec.CVSSScore, nilString(rec.CVSSRating), rec.CWE,
 		rec.Informational, rec.References, rec.Published, rec.Updated, rec.Raw,
@@ -192,7 +192,7 @@ func (r *Repo) LookupSoftware(ctx context.Context, kind, slug string) ([]VulnSof
 	querySlug := normSlug(slug)
 	rows, err := r.pool.Query(ctx, `
 		SELECT s.vuln_id, s.kind, s.slug, s.affected_versions, s.patched, s.patched_versions,
-		       f.title, f.cve, f.cve_link, f.cvss_score, f.cvss_rating, f.references
+		       f.title, f.cve, f.cve_link, f.cvss_score, f.cvss_rating, f.reference_urls
 		FROM wordfence_vuln_software s
 		JOIN wordfence_vuln_feed f USING (vuln_id)
 		WHERE s.kind = $1 AND s.slug = $2`, kind, querySlug)
@@ -307,7 +307,7 @@ func (r *Repo) ListOpenFindings(ctx context.Context, tenantID, siteID uuid.UUID)
 			       v.installed_version, v.fixed_version, v.severity, v.cvss_score,
 			       v.cve, v.title, v.status, v.first_seen, v.last_seen,
 			       v.resolved_at, v.dismissed_at, v.dismissed_by,
-			       f.cve_link, f.references
+			       f.cve_link, f.reference_urls
 			FROM site_vulnerabilities v
 			LEFT JOIN wordfence_vuln_feed f USING (vuln_id)
 			WHERE v.tenant_id = $1 AND v.site_id = $2 AND v.status = 'open'
@@ -347,7 +347,7 @@ func (r *Repo) GetFinding(ctx context.Context, tenantID, siteID, findingID uuid.
 			       v.installed_version, v.fixed_version, v.severity, v.cvss_score,
 			       v.cve, v.title, v.status, v.first_seen, v.last_seen,
 			       v.resolved_at, v.dismissed_at, v.dismissed_by,
-			       COALESCE(fd.cve_link,''), COALESCE(fd.references,'[]'::jsonb)
+			       COALESCE(fd.cve_link,''), COALESCE(fd.reference_urls,'[]'::jsonb)
 			FROM site_vulnerabilities v
 			LEFT JOIN wordfence_vuln_feed fd USING (vuln_id)
 			WHERE v.tenant_id = $1 AND v.site_id = $2 AND v.id = $3`,
@@ -455,7 +455,7 @@ func (r *Repo) FleetOpenFindings(ctx context.Context, tenantID uuid.UUID, limit 
 			       v.installed_version, v.fixed_version, v.severity, v.cvss_score,
 			       v.cve, v.title, v.status, v.first_seen, v.last_seen,
 			       v.resolved_at, v.dismissed_at, v.dismissed_by,
-			       COALESCE(f.cve_link,''), COALESCE(f.references,'[]'::jsonb),
+			       COALESCE(f.cve_link,''), COALESCE(f.reference_urls,'[]'::jsonb),
 			       s.name AS site_name, s.url AS site_url
 			FROM site_vulnerabilities v
 			LEFT JOIN wordfence_vuln_feed f USING (vuln_id)

--- a/apps/api/migrations/20260714000000_m81_vuln_feed_reference_urls.sql
+++ b/apps/api/migrations/20260714000000_m81_vuln_feed_reference_urls.sql
@@ -1,0 +1,30 @@
+-- m81 — Rename wordfence_vuln_feed.references → reference_urls.
+--
+-- "references" is a RESERVED KEYWORD in PostgreSQL (SQL:2003 and later).
+-- The column was defined quoted in CREATE TABLE, so the table was created
+-- successfully, but any unquoted use of "references" in INSERT column lists
+-- or ON CONFLICT SET clauses triggers SQLSTATE 42601 (syntax error at or
+-- near "references").  Because the feed ingester uses raw SQL with the
+-- unquoted name, UpsertFeedRecord fails for every record.
+--
+-- The table has had 0 rows ever committed (every upsert errored), so the
+-- rename carries no data-migration cost.  The JSON/API response field stays
+-- "references" (DTO/JSON tags unchanged).
+--
+-- Idempotency: the RENAME is guarded by a column-existence check so re-runs
+-- are safe.
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name   = 'wordfence_vuln_feed'
+          AND column_name  = 'references'
+    ) THEN
+        ALTER TABLE "public"."wordfence_vuln_feed"
+            RENAME COLUMN "references" TO "reference_urls";
+    END IF;
+END;
+$$;

--- a/apps/api/tests/vuln_feed_upsert_integration_test.go
+++ b/apps/api/tests/vuln_feed_upsert_integration_test.go
@@ -1,0 +1,176 @@
+// Integration test for the vulnerability feed upsert (m79 + m81 fix).
+//
+// This test reproduces the prod failure: UpsertFeedRecord failing for every
+// record with SQLSTATE 42601 ("syntax error at or near 'references'") because
+// the column was named after a PostgreSQL reserved keyword.
+//
+// The test:
+//   1. Starts a real Postgres with all migrations applied.
+//   2. Calls UpsertFeedRecord with a realistic record (non-empty reference_urls,
+//      CVE, CVSS, software row).
+//   3. Verifies the row persisted via a direct SELECT.
+//   4. Calls UpsertFeedRecord again with a changed title to prove the ON CONFLICT
+//      DO UPDATE path also works (this was the second site of the original error).
+//   5. Calls LookupSoftware to verify the reference_urls JOIN survives a read.
+//
+// This test must FAIL against the pre-fix schema (the "references" column name
+// causes 42601) and PASS after the m81 rename migration is applied.
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/vuln"
+)
+
+func TestUpsertFeedRecord_RoundTrip(t *testing.T) {
+	pool := startPostgres(t) // skips if Docker unavailable
+	ctx := context.Background()
+
+	score := 6.5
+	pub := time.Date(1998, 1, 9, 0, 0, 0, 0, time.UTC)
+	upd := time.Date(2022, 8, 5, 20, 14, 5, 0, time.UTC)
+
+	affectedVersions, _ := json.Marshal(map[string]any{
+		"1.0.0 - 1.2.3": map[string]any{
+			"from_version":  "1.0.0",
+			"from_inclusive": true,
+			"to_version":    "1.2.3",
+			"to_inclusive":  true,
+		},
+	})
+	patchedVersions, _ := json.Marshal([]string{"1.2.4"})
+	refURLs, _ := json.Marshal([]string{"https://www.wordfence.com/threat-intel/vulnerabilities/example"})
+	cwe, _ := json.Marshal(map[string]any{"id": 80, "name": "Basic XSS"})
+	raw, _ := json.Marshal(map[string]any{"_test": true})
+
+	rec := vuln.FeedRecord{
+		VulnID:        "848ccbdc-c6f1-480f-a272-cd459e706713",
+		Title:         "Example Plugin <= 1.2.3 - Stored XSS",
+		CVE:           "CVE-1998-1000",
+		CVELink:       "https://www.cve.org/CVERecord?id=CVE-1998-1000",
+		CVSSScore:     &score,
+		CVSSRating:    "Medium",
+		CWE:           cwe,
+		Informational: false,
+		References:    refURLs, // stored in reference_urls column after m81 rename
+		Published:     &pub,
+		Updated:       &upd,
+		Raw:           raw,
+		Software: []vuln.SoftwareRow{
+			{
+				Kind:             "plugin",
+				Slug:             "example",
+				AffectedVersions: affectedVersions,
+				Patched:          true,
+				PatchedVersions:  patchedVersions,
+			},
+		},
+	}
+
+	repo := vuln.NewRepo(pool)
+
+	// Step 1: INSERT path — this is the statement that was failing with SQLSTATE
+	// 42601 ("syntax error at or near 'references'") before the m81 rename.
+	t.Run("insert_succeeds", func(t *testing.T) {
+		tx, err := pool.Begin(ctx)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+		if _, err := tx.Exec(ctx, "SELECT set_config('app.agent','on',true)"); err != nil {
+			t.Fatalf("set agent guc: %v", err)
+		}
+		if err := repo.UpsertFeedRecord(ctx, tx, rec); err != nil {
+			t.Fatalf("UpsertFeedRecord (INSERT path) failed: %v", err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+	})
+
+	// Step 2: Verify the row persisted and reference_urls survived.
+	t.Run("row_persisted_with_reference_urls", func(t *testing.T) {
+		var title string
+		var refURLsOut []byte
+		err := pool.QueryRow(ctx,
+			`SELECT title, reference_urls FROM wordfence_vuln_feed WHERE vuln_id = $1`,
+			rec.VulnID,
+		).Scan(&title, &refURLsOut)
+		if err != nil {
+			t.Fatalf("SELECT after upsert: %v", err)
+		}
+		if title != rec.Title {
+			t.Errorf("title = %q; want %q", title, rec.Title)
+		}
+		var urls []string
+		if err := json.Unmarshal(refURLsOut, &urls); err != nil {
+			t.Fatalf("unmarshal reference_urls: %v", err)
+		}
+		if len(urls) != 1 || urls[0] != "https://www.wordfence.com/threat-intel/vulnerabilities/example" {
+			t.Errorf("reference_urls = %v; want [https://www.wordfence.com/...]", urls)
+		}
+	})
+
+	// Step 3: ON CONFLICT DO UPDATE path — the second query site of the original
+	// error was in the ON CONFLICT SET clause which also referenced the
+	// (unquoted) reserved keyword.
+	t.Run("on_conflict_update_succeeds", func(t *testing.T) {
+		updated := rec
+		updated.Title = "Example Plugin <= 1.2.3 - Stored XSS (updated)"
+
+		tx, err := pool.Begin(ctx)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+		if _, err := tx.Exec(ctx, "SELECT set_config('app.agent','on',true)"); err != nil {
+			t.Fatalf("set agent guc: %v", err)
+		}
+		if err := repo.UpsertFeedRecord(ctx, tx, updated); err != nil {
+			t.Fatalf("UpsertFeedRecord (ON CONFLICT path) failed: %v", err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+
+		// Verify the title was updated.
+		var gotTitle string
+		if err := pool.QueryRow(ctx,
+			`SELECT title FROM wordfence_vuln_feed WHERE vuln_id = $1`, rec.VulnID,
+		).Scan(&gotTitle); err != nil {
+			t.Fatalf("SELECT after ON CONFLICT update: %v", err)
+		}
+		if gotTitle != updated.Title {
+			t.Errorf("title after update = %q; want %q", gotTitle, updated.Title)
+		}
+	})
+
+	// Step 4: LookupSoftware — exercises the JOIN SELECT that uses reference_urls.
+	t.Run("lookup_software_returns_reference_urls", func(t *testing.T) {
+		rows, err := repo.LookupSoftware(ctx, "plugin", "example")
+		if err != nil {
+			t.Fatalf("LookupSoftware: %v", err)
+		}
+		if len(rows) != 1 {
+			t.Fatalf("LookupSoftware returned %d rows; want 1", len(rows))
+		}
+		r := rows[0]
+		if r.VulnID != rec.VulnID {
+			t.Errorf("VulnID = %q; want %q", r.VulnID, rec.VulnID)
+		}
+		if r.CVE != rec.CVE {
+			t.Errorf("CVE = %q; want %q", r.CVE, rec.CVE)
+		}
+		var urls []string
+		if err := json.Unmarshal(r.References, &urls); err != nil {
+			t.Fatalf("unmarshal References from LookupSoftware: %v", err)
+		}
+		if len(urls) != 1 {
+			t.Errorf("References len = %d; want 1", len(urls))
+		}
+	})
+}


### PR DESCRIPTION
After the parser fix let records parse, every UpsertFeedRecord failed with `syntax error at or near "references"` — `references` is a PG reserved word, used unquoted. Renamed the column to reference_urls (m81; JSON/API field unchanged), updated 5 SQL sites, backfilled schema.sql, and added a REAL Postgres round-trip test that executes the actual upsert (the missing test class — parse-only tests passed while the DB write was broken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vulnerability intelligence feed caching system for enhanced threat detection
  * Implemented site-level vulnerability tracking and management capabilities
  * Enhanced security with tenant-isolated vulnerability data storage and access controls

* **Database Updates**
  * Extended database schema to support vulnerability feed caching and site-scoped vulnerability matching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->