### PR TITLE
fix(api): vuln feed bulk ingest + 429-graceful (0.57.6)

### DIFF
--- a/apps/api/internal/vuln/repo.go
+++ b/apps/api/internal/vuln/repo.go
@@ -93,25 +93,130 @@ func (r *Repo) UpsertFeedRecord(ctx context.Context, tx pgx.Tx, rec FeedRecord) 
 	return nil
 }
 
+// BulkUpsertFeedRecords upserts all feed records in a single pgx Batch, sending
+// every INSERT ... ON CONFLICT DO UPDATE in one round-trip instead of one per record.
+// This replaces the O(N) per-record path that timed out on 13k-record full-dump ingest.
+func (r *Repo) BulkUpsertFeedRecords(ctx context.Context, tx pgx.Tx, recs []FeedRecord) error {
+	if len(recs) == 0 {
+		return nil
+	}
+
+	const upsertSQL = `
+		INSERT INTO wordfence_vuln_feed
+			(vuln_id, title, cve, cve_link, cvss_score, cvss_rating, cwe,
+			 informational, reference_urls, published, updated, raw)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+		ON CONFLICT (vuln_id) DO UPDATE SET
+			title          = EXCLUDED.title,
+			cve            = EXCLUDED.cve,
+			cve_link       = EXCLUDED.cve_link,
+			cvss_score     = EXCLUDED.cvss_score,
+			cvss_rating    = EXCLUDED.cvss_rating,
+			cwe            = EXCLUDED.cwe,
+			informational  = EXCLUDED.informational,
+			reference_urls = EXCLUDED.reference_urls,
+			published      = EXCLUDED.published,
+			updated        = EXCLUDED.updated,
+			raw            = EXCLUDED.raw`
+
+	batch := &pgx.Batch{}
+	for _, rec := range recs {
+		batch.Queue(upsertSQL,
+			rec.VulnID, rec.Title, nilString(rec.CVE), nilString(rec.CVELink),
+			rec.CVSSScore, nilString(rec.CVSSRating), rec.CWE,
+			rec.Informational, rec.References, rec.Published, rec.Updated, rec.Raw,
+		)
+	}
+
+	br := tx.SendBatch(ctx, batch)
+	defer func() { _ = br.Close() }()
+
+	for i := range recs {
+		if _, err := br.Exec(); err != nil {
+			return fmt.Errorf("bulk upsert feed record %d (%s): %w", i, recs[i].VulnID, err)
+		}
+	}
+	return br.Close()
+}
+
+// BulkReplaceAllSoftware replaces the software rows for every vuln_id in recs
+// using two set-based operations instead of per-record DELETE + INSERT loops:
+//
+//  1. A single DELETE that removes all existing software rows whose vuln_id is in
+//     the batch. This is one network round-trip regardless of how many vulns or
+//     software rows exist.
+//  2. A pgx CopyFrom that streams all new software rows to Postgres in a single
+//     COPY protocol frame.
+//
+// Together these replace the previous O(N×M) approach (13k vulns × per-vuln DELETE
+// + per-software-row INSERT) that triggered a context deadline on full-dump ingest.
+func (r *Repo) BulkReplaceAllSoftware(ctx context.Context, tx pgx.Tx, recs []FeedRecord) error {
+	if len(recs) == 0 {
+		return nil
+	}
+
+	// Collect all vuln_ids being replaced.
+	vulnIDs := make([]string, len(recs))
+	for i, rec := range recs {
+		vulnIDs[i] = rec.VulnID
+	}
+
+	// Step 1: delete all software rows for these vulns in one statement.
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM wordfence_vuln_software WHERE vuln_id = ANY($1::text[])`,
+		vulnIDs,
+	); err != nil {
+		return fmt.Errorf("bulk delete software rows: %w", err)
+	}
+
+	// Step 2: collect all new software rows and stream them via CopyFrom.
+	// Preallocate a reasonable capacity (average ~2 software rows per vuln).
+	rows := make([][]any, 0, len(recs)*2)
+	for _, rec := range recs {
+		for _, sw := range rec.Software {
+			slug := normSlug(sw.Slug)
+			if slug == "" {
+				continue
+			}
+			rows = append(rows, []any{
+				rec.VulnID,
+				sw.Kind,
+				slug,
+				sw.AffectedVersions,
+				sw.Patched,
+				sw.PatchedVersions,
+			})
+		}
+	}
+
+	if len(rows) == 0 {
+		return nil // nothing to copy (all vulns had no software — should not occur in practice)
+	}
+
+	cols := []string{"vuln_id", "kind", "slug", "affected_versions", "patched", "patched_versions"}
+	if _, err := tx.CopyFrom(ctx,
+		pgx.Identifier{"wordfence_vuln_software"},
+		cols,
+		pgx.CopyFromRows(rows),
+	); err != nil {
+		return fmt.Errorf("bulk copy software rows: %w", err)
+	}
+	return nil
+}
+
 // PruneMissingVulns deletes feed rows whose vuln_id is not in the provided set.
 // Called after a full-dump ingest to remove retracted vulnerabilities.
 func (r *Repo) PruneMissingVulns(ctx context.Context, tx pgx.Tx, knownIDs []string) error {
-	// Build a temporary table of known IDs for the NOT IN filter.
 	if len(knownIDs) == 0 {
 		// Safety: if the ingested set is empty (e.g. feed returned nothing) do NOT
 		// prune — something went wrong upstream.
 		return nil
 	}
-	ids := make([]any, len(knownIDs))
-	for i, id := range knownIDs {
-		ids[i] = id
-	}
-	// pgx parameterized ANY($1::text[]).
-	_, err := tx.Exec(ctx,
+	// pgx parameterized ANY($1::text[]): deletes every row NOT in the full set.
+	if _, err := tx.Exec(ctx,
 		`DELETE FROM wordfence_vuln_feed WHERE vuln_id != ALL($1::text[])`,
 		knownIDs,
-	)
-	if err != nil {
+	); err != nil {
 		return fmt.Errorf("prune missing vulns: %w", err)
 	}
 	return nil

--- a/apps/api/internal/vuln/worker.go
+++ b/apps/api/internal/vuln/worker.go
@@ -123,6 +123,15 @@ func NewFeedWorker(repo *Repo, pool *db.Pool, svc *Service, resolver APIKeyResol
 // once at boot after startRiver returns (the service needs the River client).
 func (w *FeedWorker) SetService(svc *Service) { w.svc = svc }
 
+// Timeout gives the feed refresh job 10 minutes. A full-dump ingest of ~13k
+// records via CopyFrom completes in seconds, but the two HTTP fetches + the
+// 2s inter-fetch delay + any Postgres latency under load consume real wall
+// time. 10 minutes is generous headroom well above the expected 30–60s wall
+// time and avoids the context deadline that previously killed the per-record loop.
+func (w *FeedWorker) Timeout(*river.Job[FeedRefreshArgs]) time.Duration {
+	return 10 * time.Minute
+}
+
 // Work performs the feed refresh.
 func (w *FeedWorker) Work(ctx context.Context, job *river.Job[FeedRefreshArgs]) error {
 	// Resolve the key at run-time so a UI-set key takes effect on the next job
@@ -208,26 +217,41 @@ func (w *FeedWorker) Work(ctx context.Context, job *river.Job[FeedRefreshArgs]) 
 	return nil
 }
 
-// ingestRecords writes all records and the meta row in one InAgentTx.
+// ingestRecords writes all records and the meta row in one transaction using
+// bulk operations. The previous per-record loop (13k × DELETE+INSERT round-trips)
+// exceeded the River context deadline; the bulk path replaces that with:
+//
+//  1. A pgx Batch that sends all feed-row upserts in a single round-trip.
+//  2. A set-based DELETE of software rows for every vuln_id in the batch, then
+//     a single CopyFrom that streams all new software rows to Postgres.
+//  3. PruneMissingVulns (single set-based DELETE of retracted vulns).
+//  4. StampFeedMeta (single UPDATE).
+//
+// The entire operation is one transaction — atomic, with no partial state.
 func (w *FeedWorker) ingestRecords(ctx context.Context, records map[string]FeedRecord, knownIDs []string, meta FeedMetaUpdate) error {
-	// Use raw pool Begin/Commit (global tables, no RLS; InAgentTx sets the GUC
-	// but the global tables don't need it — we use a direct pool transaction to
-	// avoid the GUC overhead and keep the import fast).
+	// Flatten the map into a slice for deterministic ordering (maps in Go are
+	// unordered; a slice makes the Batch and CopyFrom reproducible for debugging).
+	recs := make([]FeedRecord, 0, len(records))
+	for _, r := range records {
+		recs = append(recs, r)
+	}
+
 	tx, err := w.pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	// Set agent GUC anyway (in case a policy is added later).
+	// Set agent GUC (global tables have no RLS today; this is forward-compatible).
 	if _, err := tx.Exec(ctx, "SELECT set_config('app.agent','on',true)"); err != nil {
 		return fmt.Errorf("set agent guc: %w", err)
 	}
 
-	for _, rec := range records {
-		if err := w.repo.UpsertFeedRecord(ctx, tx, rec); err != nil {
-			return err
-		}
+	if err := w.repo.BulkUpsertFeedRecords(ctx, tx, recs); err != nil {
+		return err
+	}
+	if err := w.repo.BulkReplaceAllSoftware(ctx, tx, recs); err != nil {
+		return err
 	}
 	if err := w.repo.PruneMissingVulns(ctx, tx, knownIDs); err != nil {
 		return err

--- a/apps/api/internal/vuln/worker.go
+++ b/apps/api/internal/vuln/worker.go
@@ -61,6 +61,13 @@ const (
 	wfProductionURL = "https://www.wordfence.com/api/intelligence/v3/vulnerabilities/production"
 )
 
+// errRateLimited marks a 429 from the Wordfence feed. Wordfence documents no
+// Retry-After and no per-window number ("too many requests in a short period"),
+// so a 429 must NOT trigger River's aggressive retry — that just re-hits the
+// endpoint and keeps the rate-limit window warm. Instead we stamp the status and
+// succeed; the hourly periodic refresh is the natural, well-spaced retry.
+var errRateLimited = errors.New("wordfence feed rate limited (429)")
+
 // FeedHTTPDoer is the subset of httpclient.Client the feed worker needs.
 type FeedHTTPDoer interface {
 	Do(req *http.Request) (*http.Response, error)
@@ -149,9 +156,18 @@ func (w *FeedWorker) Work(ctx context.Context, job *river.Job[FeedRefreshArgs]) 
 	// Fetch the Scanner feed (required).
 	records, defiantNotice, defiantLicense, mitreNotice, err := w.fetchFeed(ctx, wfScannerURL, apiKey)
 	if err != nil {
+		// A 429 must NOT be retried by River: Wordfence rate-limits "too many
+		// requests in a short period" with no Retry-After, so aggressive retries
+		// keep the window warm and never recover. Stamp the status and SUCCEED;
+		// the hourly periodic refresh is the natural, well-spaced retry.
+		if errors.Is(err, errRateLimited) {
+			_ = w.repo.StampFeedError(ctx, "rate limited by Wordfence; will retry on the next scheduled refresh")
+			w.logger.Warn("vuln: scanner feed rate limited; skipping this cycle (no River retry)")
+			return nil
+		}
 		errMsg := fmt.Sprintf("scanner feed fetch failed: %v", err)
 		_ = w.repo.StampFeedError(ctx, errMsg)
-		return fmt.Errorf("vuln feed refresh: %w", err) // River will retry
+		return fmt.Errorf("vuln feed refresh: %w", err) // River will retry real failures
 	}
 
 	// Brief spacing between the two fetches reduces the chance of hitting the
@@ -304,7 +320,7 @@ func (w *FeedWorker) fetchFeed(ctx context.Context, feedURL, apiKey string) (map
 		// Single retry.
 		req2, rerr := http.NewRequestWithContext(ctx, http.MethodGet, feedURL, nil)
 		if rerr != nil {
-			return nil, "", "", "", fmt.Errorf("rate limited (429) fetching %s; will retry next cycle", feedURL)
+			return nil, "", "", "", fmt.Errorf("rate limited (429) fetching %s: %w", feedURL, errRateLimited)
 		}
 		req2.Header.Set("Authorization", "Bearer "+apiKey)
 		req2.Header.Set("Accept", "application/json")
@@ -314,7 +330,7 @@ func (w *FeedWorker) fetchFeed(ctx context.Context, feedURL, apiKey string) (map
 			if resp2 != nil {
 				_ = resp2.Body.Close()
 			}
-			return nil, "", "", "", fmt.Errorf("rate limited (429) fetching %s; will retry next cycle", feedURL)
+			return nil, "", "", "", fmt.Errorf("rate limited (429) fetching %s: %w", feedURL, errRateLimited)
 		}
 		// Swap to the retry response for decoding below.
 		_ = resp.Body.Close()

--- a/apps/api/tests/vuln_feed_upsert_integration_test.go
+++ b/apps/api/tests/vuln_feed_upsert_integration_test.go
@@ -1,25 +1,19 @@
-// Integration test for the vulnerability feed upsert (m79 + m81 fix).
+// Integration test for the vulnerability feed upsert (m79 + m81 fix) and the
+// bulk ingest path (timeout fix).
 //
-// This test reproduces the prod failure: UpsertFeedRecord failing for every
-// record with SQLSTATE 42601 ("syntax error at or near 'references'") because
-// the column was named after a PostgreSQL reserved keyword.
+// TestUpsertFeedRecord_RoundTrip reproduces the original prod failure: UpsertFeedRecord
+// failing with SQLSTATE 42601 ("syntax error at or near 'references'") because the
+// column was named after a PostgreSQL reserved keyword.
 //
-// The test:
-//   1. Starts a real Postgres with all migrations applied.
-//   2. Calls UpsertFeedRecord with a realistic record (non-empty reference_urls,
-//      CVE, CVSS, software row).
-//   3. Verifies the row persisted via a direct SELECT.
-//   4. Calls UpsertFeedRecord again with a changed title to prove the ON CONFLICT
-//      DO UPDATE path also works (this was the second site of the original error).
-//   5. Calls LookupSoftware to verify the reference_urls JOIN survives a read.
-//
-// This test must FAIL against the pre-fix schema (the "references" column name
-// causes 42601) and PASS after the m81 rename migration is applied.
+// TestBulkIngest_Scale proves the bulk ingest path (BulkUpsertFeedRecords +
+// BulkReplaceAllSoftware) that replaced the per-record loop scales to thousands
+// of records without timing out and upserts idempotently on a second run.
 package tests
 
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -172,5 +166,223 @@ func TestUpsertFeedRecord_RoundTrip(t *testing.T) {
 		if len(urls) != 1 {
 			t.Errorf("References len = %d; want 1", len(urls))
 		}
+	})
+}
+
+// TestBulkIngest_Scale exercises the bulk ingest path that fixed the prod timeout.
+//
+// The per-record loop (UpsertFeedRecord called 13k times in one tx) blew the
+// River job context deadline. BulkUpsertFeedRecords + BulkReplaceAllSoftware
+// replaced it with a single pgx Batch round-trip + one DELETE + one CopyFrom.
+//
+// This test:
+//   (a) generates 2,000 synthetic records with 2 software rows each (4,000 total),
+//   (b) runs the full bulk path (the same operations ingestRecords calls),
+//   (c) asserts row counts in both tables,
+//   (d) asserts timing is well under 10 seconds,
+//   (e) runs a second ingest with an overlapping set (1,800 of the original +
+//       200 new) and asserts the ON CONFLICT upsert is idempotent (no dup-key),
+//       the 200 new records landed, and the 200 removed ones were pruned by
+//       PruneMissingVulns.
+func TestBulkIngest_Scale(t *testing.T) {
+	pool := startPostgres(t) // skips if Docker unavailable
+	ctx := context.Background()
+	repo := vuln.NewRepo(pool)
+
+	const N = 2000 // number of synthetic records per run
+	const softwarePerRec = 2
+
+	// buildRecords generates n synthetic feed records. Each has two software rows
+	// (one plugin, one theme) so we exercise the CopyFrom path non-trivially.
+	buildRecords := func(n int, titlePrefix string) []vuln.FeedRecord {
+		avJSON, _ := json.Marshal(map[string]any{
+			"* - 1.0.0": map[string]any{
+				"from_version": "*", "from_inclusive": true,
+				"to_version": "1.0.0", "to_inclusive": true,
+			},
+		})
+		pvJSON, _ := json.Marshal([]string{"1.0.1"})
+		refJSON, _ := json.Marshal([]string{"https://example.com/vuln"})
+		rawJSON, _ := json.Marshal(map[string]any{"_test": true})
+		score := 7.5
+
+		recs := make([]vuln.FeedRecord, n)
+		for i := 0; i < n; i++ {
+			vulnID := fmt.Sprintf("00000000-0000-0000-0000-%012d", i)
+			recs[i] = vuln.FeedRecord{
+				VulnID:        vulnID,
+				Title:         fmt.Sprintf("%s record %d", titlePrefix, i),
+				CVE:           fmt.Sprintf("CVE-2026-%04d", i),
+				CVSSScore:     &score,
+				CVSSRating:    "High",
+				Informational: false,
+				References:    refJSON,
+				Raw:           rawJSON,
+				Software: []vuln.SoftwareRow{
+					{
+						Kind:             "plugin",
+						Slug:             fmt.Sprintf("plugin-%d", i),
+						AffectedVersions: avJSON,
+						Patched:          true,
+						PatchedVersions:  pvJSON,
+					},
+					{
+						Kind:             "theme",
+						Slug:             fmt.Sprintf("theme-%d", i),
+						AffectedVersions: avJSON,
+						Patched:          false,
+						PatchedVersions:  pvJSON,
+					},
+				},
+			}
+		}
+		return recs
+	}
+
+	// bulkIngest runs the same three operations that ingestRecords uses.
+	bulkIngest := func(t *testing.T, recs []vuln.FeedRecord) {
+		t.Helper()
+		tx, err := pool.Begin(ctx)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+		if _, err := tx.Exec(ctx, "SELECT set_config('app.agent','on',true)"); err != nil {
+			t.Fatalf("set agent guc: %v", err)
+		}
+		if err := repo.BulkUpsertFeedRecords(ctx, tx, recs); err != nil {
+			t.Fatalf("BulkUpsertFeedRecords: %v", err)
+		}
+		if err := repo.BulkReplaceAllSoftware(ctx, tx, recs); err != nil {
+			t.Fatalf("BulkReplaceAllSoftware: %v", err)
+		}
+		knownIDs := make([]string, len(recs))
+		for i, r := range recs {
+			knownIDs[i] = r.VulnID
+		}
+		if err := repo.PruneMissingVulns(ctx, tx, knownIDs); err != nil {
+			t.Fatalf("PruneMissingVulns: %v", err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+	}
+
+	countRows := func(t *testing.T, table string) int {
+		t.Helper()
+		var n int
+		if err := pool.QueryRow(ctx, "SELECT count(*) FROM "+table).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		return n
+	}
+
+	// --- First ingest: 2,000 records ---
+	t.Run("first_ingest_2000_records", func(t *testing.T) {
+		recs := buildRecords(N, "first")
+		start := time.Now()
+		bulkIngest(t, recs)
+		elapsed := time.Since(start)
+
+		feedCount := countRows(t, "wordfence_vuln_feed")
+		// The round-trip test may have left one extra row; allow for it.
+		if feedCount < N {
+			t.Errorf("wordfence_vuln_feed: got %d rows, want >= %d", feedCount, N)
+		}
+
+		swCount := countRows(t, "wordfence_vuln_software")
+		if swCount < N*softwarePerRec {
+			t.Errorf("wordfence_vuln_software: got %d rows, want >= %d", swCount, N*softwarePerRec)
+		}
+
+		// The bulk path should comfortably finish in under 10 seconds even on a
+		// container with limited I/O. The per-record path took 13k+ round-trips;
+		// the bulk path is 3 SQL operations.
+		if elapsed > 10*time.Second {
+			t.Errorf("bulk ingest of %d records took %v; want < 10s (bulk path should be fast)", N, elapsed)
+		}
+		t.Logf("first ingest: %d feed rows, %d software rows in %v", feedCount, swCount, elapsed)
+	})
+
+	// --- Second ingest: 1,800 overlapping + 200 new; 200 original removed ---
+	t.Run("second_ingest_overlap_and_prune", func(t *testing.T) {
+		const keep = 1800
+		const newCount = 200
+		// Overlap: first 1,800 records from the first batch (updated titles).
+		overlap := buildRecords(keep, "second-update")
+		// New: 200 brand-new records with IDs in the range [N, N+newCount).
+		newRecs := make([]vuln.FeedRecord, newCount)
+		avJSON, _ := json.Marshal(map[string]any{})
+		pvJSON, _ := json.Marshal([]string{})
+		refJSON, _ := json.Marshal([]string{"https://example.com/new"})
+		rawJSON, _ := json.Marshal(map[string]any{"_test": true})
+		score := 5.0
+		for i := 0; i < newCount; i++ {
+			idx := N + i
+			vulnID := fmt.Sprintf("00000000-0000-0000-0000-%012d", idx)
+			newRecs[i] = vuln.FeedRecord{
+				VulnID:        vulnID,
+				Title:         fmt.Sprintf("new record %d", idx),
+				CVSSScore:     &score,
+				CVSSRating:    "Medium",
+				References:    refJSON,
+				Raw:           rawJSON,
+				Software: []vuln.SoftwareRow{
+					{
+						Kind: "plugin", Slug: fmt.Sprintf("new-plugin-%d", idx),
+						AffectedVersions: avJSON, Patched: true, PatchedVersions: pvJSON,
+					},
+				},
+			}
+		}
+		recs := append(overlap, newRecs...)
+
+		bulkIngest(t, recs)
+
+		feedCount := countRows(t, "wordfence_vuln_feed")
+		wantFeed := keep + newCount
+		if feedCount != wantFeed {
+			t.Errorf("after second ingest: wordfence_vuln_feed = %d rows, want %d (keep=%d new=%d)",
+				feedCount, wantFeed, keep, newCount)
+		}
+
+		// Verify updated title for one of the overlap records.
+		var gotTitle string
+		if err := pool.QueryRow(ctx,
+			`SELECT title FROM wordfence_vuln_feed WHERE vuln_id = $1`,
+			fmt.Sprintf("00000000-0000-0000-0000-%012d", 0),
+		).Scan(&gotTitle); err != nil {
+			t.Fatalf("SELECT overlap title: %v", err)
+		}
+		if gotTitle != "second-update record 0" {
+			t.Errorf("overlap title = %q; want %q", gotTitle, "second-update record 0")
+		}
+
+		// Verify one of the new records landed.
+		var newTitle string
+		if err := pool.QueryRow(ctx,
+			`SELECT title FROM wordfence_vuln_feed WHERE vuln_id = $1`,
+			fmt.Sprintf("00000000-0000-0000-0000-%012d", N),
+		).Scan(&newTitle); err != nil {
+			t.Fatalf("SELECT new record title: %v", err)
+		}
+		if newTitle != fmt.Sprintf("new record %d", N) {
+			t.Errorf("new record title = %q; want %q", newTitle, fmt.Sprintf("new record %d", N))
+		}
+
+		// Verify one of the pruned records is gone (IDs [keep..N-1]).
+		var prunedCount int
+		if err := pool.QueryRow(ctx,
+			`SELECT count(*) FROM wordfence_vuln_feed WHERE vuln_id = $1`,
+			fmt.Sprintf("00000000-0000-0000-0000-%012d", keep),
+		).Scan(&prunedCount); err != nil {
+			t.Fatalf("SELECT pruned check: %v", err)
+		}
+		if prunedCount != 0 {
+			t.Errorf("pruned record still present after second ingest")
+		}
+
+		t.Logf("second ingest: %d feed rows (keep=%d new=%d pruned=%d)",
+			feedCount, keep, newCount, N-keep)
 	})
 }


### PR DESCRIPTION
Two fixes to make the vuln feed actually land + behave: (1) the per-record ingest of ~13k records timed out → bulk CopyFrom + batched upsert + set-based delete + a 10-minute job timeout (scale test: 2k records + 4k software rows in 70ms); (2) a 429 was returned as an error so River retried it aggressively and kept the rate-limit window warm → 429s are now a graceful skip (stamp status, return nil), and the hourly periodic refresh is the natural retry. Verified our parsing matches the official Wordfence v3 schema doc (dates YYYY-MM-DD hh:mm:ss, cvss object, affected_versions object + wildcard, references, MITRE attribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rate-limiting responses from the vulnerability feed provider
  * Fixed feed refresh timeout to prevent interruptions during large ingests

* **Performance**
  * Optimized vulnerability feed ingestion using bulk database operations for faster processing

* **Tests**
  * Added integration test validating bulk ingest performance and idempotent behavior with 2,000+ records

<!-- end of auto-generated comment: release notes by coderabbit.ai -->