### PR TITLE
fix(api): vuln feed software dedup before CopyFrom (0.57.7)

### DIFF
--- a/apps/api/internal/vuln/export_test.go
+++ b/apps/api/internal/vuln/export_test.go
@@ -22,3 +22,12 @@ func ParseFeedRecord(vulnID string, raw json.RawMessage) (FeedRecord, string, st
 
 // ErrNoUsableSoftware exposes errNoUsableSoftware so tests can assert the skip sentinel.
 var ErrNoUsableSoftware = errNoUsableSoftware
+
+// DedupSoftwareRows exposes dedupSoftwareRows for white-box unit tests.
+func DedupSoftwareRows(rows []SoftwareRow) []SoftwareRow { return dedupSoftwareRows(rows) }
+
+// MergeAffectedVersions exposes mergeAffectedVersions for unit tests.
+func MergeAffectedVersions(a, b []byte) []byte { return mergeAffectedVersions(a, b) }
+
+// MergePatchedVersions exposes mergePatchedVersions for unit tests.
+func MergePatchedVersions(a, b []byte) []byte { return mergePatchedVersions(a, b) }

--- a/apps/api/internal/vuln/repo.go
+++ b/apps/api/internal/vuln/repo.go
@@ -150,6 +150,21 @@ func (r *Repo) BulkUpsertFeedRecords(ctx context.Context, tx pgx.Tx, recs []Feed
 //
 // Together these replace the previous O(N×M) approach (13k vulns × per-vuln DELETE
 // + per-software-row INSERT) that triggered a context deadline on full-dump ingest.
+//
+// Duplicate handling: CopyFrom uses the COPY protocol which cannot express
+// ON CONFLICT DO UPDATE. Any duplicate (vuln_id, kind, slug) tuples in the
+// input batch would therefore violate the PK and abort the entire COPY.
+// Two real sources produce duplicates:
+//
+//   - A single feed record's software[] array listing the same (kind, slug) more
+//     than once (e.g. a plugin entry that appears with two different affected-version
+//     ranges).
+//   - Future expansion of mergeEnrichment to merge production software rows into
+//     scanner rows.
+//
+// Both are eliminated by dedupSoftwareRows, which merges rows sharing the same
+// normalised (vuln_id, kind, slug) key. A final map-based guard prevents any
+// residual duplicate from reaching CopyFrom regardless of feed quirks.
 func (r *Repo) BulkReplaceAllSoftware(ctx context.Context, tx pgx.Tx, recs []FeedRecord) error {
 	if len(recs) == 0 {
 		return nil
@@ -171,13 +186,24 @@ func (r *Repo) BulkReplaceAllSoftware(ctx context.Context, tx pgx.Tx, recs []Fee
 
 	// Step 2: collect all new software rows and stream them via CopyFrom.
 	// Preallocate a reasonable capacity (average ~2 software rows per vuln).
+	// Apply per-record dedup first (mergeSoftwareRows), then a final PK-level
+	// guard map to prevent any residual duplicate from reaching CopyFrom.
+	type pkKey struct{ vulnID, kind, slug string }
+	seen := make(map[pkKey]struct{}, len(recs)*2)
+
 	rows := make([][]any, 0, len(recs)*2)
 	for _, rec := range recs {
-		for _, sw := range rec.Software {
+		for _, sw := range dedupSoftwareRows(rec.Software) {
 			slug := normSlug(sw.Slug)
 			if slug == "" {
 				continue
 			}
+			pk := pkKey{rec.VulnID, sw.Kind, slug}
+			if _, dup := seen[pk]; dup {
+				// Should not reach here after dedupSoftwareRows, but guard anyway.
+				continue
+			}
+			seen[pk] = struct{}{}
 			rows = append(rows, []any{
 				rec.VulnID,
 				sw.Kind,
@@ -202,6 +228,143 @@ func (r *Repo) BulkReplaceAllSoftware(ctx context.Context, tx pgx.Tx, recs []Fee
 		return fmt.Errorf("bulk copy software rows: %w", err)
 	}
 	return nil
+}
+
+// dedupSoftwareRows collapses any SoftwareRow entries that share the same
+// normalised (kind, slug) key by merging their version data.  It is called
+// per-record inside BulkReplaceAllSoftware before building the CopyFrom batch.
+//
+// Merge semantics:
+//   - affected_versions: union of JSON object keys from all duplicate entries.
+//     Both the feed and the real Wordfence schema represent affected_versions as
+//     a JSON object keyed by a human-readable range label (e.g. "1.0.0 - 1.2.3").
+//     Merging their keys ensures the matcher sees every affected range.
+//   - patched: OR — true if any duplicate entry says patched=true (a fix exists
+//     even if only one feed variant lists patched_versions).
+//   - patched_versions: union of the two arrays, deduplicated.
+//
+// The function is a no-op (O(n) scan, no allocation) when every (kind, slug)
+// key is already unique, which is the common case.
+func dedupSoftwareRows(rows []SoftwareRow) []SoftwareRow {
+	if len(rows) <= 1 {
+		return rows
+	}
+
+	// Fast path: check whether there are any duplicates at all. If the set of
+	// normalised (kind, slug) keys has the same cardinality as the slice, return
+	// the slice unchanged (no allocation, no merge).
+	type key struct{ kind, slug string }
+	keySet := make(map[key]int, len(rows)) // maps key → first-seen index in result
+	hasDup := false
+	for _, sw := range rows {
+		k := key{sw.Kind, normSlug(sw.Slug)}
+		if _, exists := keySet[k]; exists {
+			hasDup = true
+			break
+		}
+		keySet[k] = 0
+	}
+	if !hasDup {
+		return rows
+	}
+
+	// Slow path: rebuild the slice, merging duplicates as we go.
+	type entry struct {
+		idx int // position in result slice
+		sw  SoftwareRow
+	}
+	result := make([]SoftwareRow, 0, len(rows))
+	indexByKey := make(map[key]int, len(rows)) // key → index in result
+
+	for _, sw := range rows {
+		k := key{sw.Kind, normSlug(sw.Slug)}
+		if idx, exists := indexByKey[k]; !exists {
+			indexByKey[k] = len(result)
+			result = append(result, sw)
+		} else {
+			// Merge into the existing entry.
+			existing := &result[idx]
+			existing.AffectedVersions = mergeAffectedVersions(existing.AffectedVersions, sw.AffectedVersions)
+			existing.Patched = existing.Patched || sw.Patched
+			existing.PatchedVersions = mergePatchedVersions(existing.PatchedVersions, sw.PatchedVersions)
+		}
+	}
+	return result
+}
+
+// mergeAffectedVersions unions two JSON objects keyed by range labels.
+// Both inputs are expected to be JSON objects (the Wordfence v3 schema).
+// If either is empty/null/not-an-object, the other is returned unchanged.
+// On any parse error the first input is returned as-is (defensive: don't lose data).
+func mergeAffectedVersions(a, b []byte) []byte {
+	if len(a) == 0 || string(a) == "null" || string(a) == "{}" {
+		if len(b) > 0 {
+			return b
+		}
+		return a
+	}
+	if len(b) == 0 || string(b) == "null" || string(b) == "{}" {
+		return a
+	}
+	// Both are non-empty: unmarshal as maps and union their keys.
+	var ma, mb map[string]json.RawMessage
+	if err := json.Unmarshal(a, &ma); err != nil {
+		return a // a is not an object; keep a and discard b
+	}
+	if err := json.Unmarshal(b, &mb); err != nil {
+		return a // b is not an object; keep a
+	}
+	for k, v := range mb {
+		if _, exists := ma[k]; !exists {
+			ma[k] = v
+		}
+	}
+	merged, err := json.Marshal(ma)
+	if err != nil {
+		return a
+	}
+	return merged
+}
+
+// mergePatchedVersions unions two JSON arrays of version strings, deduplicating.
+// Both inputs are expected to be JSON arrays.
+// If either is empty/null, the other is returned unchanged.
+func mergePatchedVersions(a, b []byte) []byte {
+	if len(a) == 0 || string(a) == "null" || string(a) == "[]" {
+		if len(b) > 0 {
+			return b
+		}
+		return a
+	}
+	if len(b) == 0 || string(b) == "null" || string(b) == "[]" {
+		return a
+	}
+	var va, vb []string
+	if err := json.Unmarshal(a, &va); err != nil {
+		return a
+	}
+	if err := json.Unmarshal(b, &vb); err != nil {
+		return a
+	}
+	seen := make(map[string]struct{}, len(va)+len(vb))
+	merged := make([]string, 0, len(va)+len(vb))
+	for _, v := range va {
+		if _, ok := seen[v]; !ok {
+			seen[v] = struct{}{}
+			merged = append(merged, v)
+		}
+	}
+	for _, v := range vb {
+		if _, ok := seen[v]; !ok {
+			seen[v] = struct{}{}
+			merged = append(merged, v)
+		}
+	}
+	out, err := json.Marshal(merged)
+	if err != nil {
+		return a
+	}
+	return out
 }
 
 // PruneMissingVulns deletes feed rows whose vuln_id is not in the provided set.

--- a/apps/api/tests/vuln_feed_upsert_integration_test.go
+++ b/apps/api/tests/vuln_feed_upsert_integration_test.go
@@ -8,6 +8,13 @@
 // TestBulkIngest_Scale proves the bulk ingest path (BulkUpsertFeedRecords +
 // BulkReplaceAllSoftware) that replaced the per-record loop scales to thousands
 // of records without timing out and upserts idempotently on a second run.
+//
+// TestBulkIngest_DuplicateSoftware reproduces the prod blocker: when a single
+// feed record's software[] array contains two entries with the same (kind, slug),
+// the BulkReplaceAllSoftware CopyFrom path was throwing SQLSTATE 23505
+// (duplicate key violates unique constraint "wordfence_vuln_software_pkey").
+// The fix: dedupSoftwareRows merges the duplicate entries before CopyFrom, unioning
+// affected_versions, OR-ing patched, and unioning patched_versions.
 package tests
 
 import (
@@ -384,5 +391,248 @@ func TestBulkIngest_Scale(t *testing.T) {
 
 		t.Logf("second ingest: %d feed rows (keep=%d new=%d pruned=%d)",
 			feedCount, keep, newCount, N-keep)
+	})
+}
+
+// TestBulkIngest_DuplicateSoftware reproduces the prod blocker
+// (SQLSTATE 23505 on CopyFrom) and verifies the fix: when a single feed
+// record's software[] array contains two entries with the same (kind, slug),
+// the dedup+merge path produces exactly one row in wordfence_vuln_software
+// with the union of both entries' affected_versions and patched_versions.
+//
+// Additionally, two DIFFERENT vulns sharing the same (kind, slug) must each
+// produce their own row (different vuln_id) and must NOT be collapsed.
+func TestBulkIngest_DuplicateSoftware(t *testing.T) {
+	pool := startPostgres(t) // skips if Docker unavailable
+	ctx := context.Background()
+	repo := vuln.NewRepo(pool)
+
+	// --- Case A: one record whose software[] has duplicate (kind, slug) ---
+	//
+	// Two software entries for (plugin, "akismet") with different affected_versions:
+	//   range1: "1.0.0 - 1.2.3"
+	//   range2: "1.5.0 - 1.6.0"
+	// Only range2 is patched; range2 also has patched_versions ["1.6.1"].
+	// After ingest we expect:
+	//   (a) NO error (no 23505)
+	//   (b) exactly ONE row for (vuln-dup-A, plugin, akismet)
+	//   (c) affected_versions contains BOTH range keys (no data lost)
+	//   (d) patched = true  (OR of false, true)
+	//   (e) patched_versions = ["1.6.1"] (union)
+
+	av1, _ := json.Marshal(map[string]any{
+		"1.0.0 - 1.2.3": map[string]any{
+			"from_version": "1.0.0", "from_inclusive": true,
+			"to_version": "1.2.3", "to_inclusive": true,
+		},
+	})
+	av2, _ := json.Marshal(map[string]any{
+		"1.5.0 - 1.6.0": map[string]any{
+			"from_version": "1.5.0", "from_inclusive": true,
+			"to_version": "1.6.0", "to_inclusive": true,
+		},
+	})
+	pv2, _ := json.Marshal([]string{"1.6.1"})
+	pvEmpty, _ := json.Marshal([]string{})
+	refJSON, _ := json.Marshal([]string{"https://example.com/vuln"})
+	rawJSON, _ := json.Marshal(map[string]any{"_test": true})
+	score := 6.5
+
+	dupRec := vuln.FeedRecord{
+		VulnID:        "dup-test-0000-0000-0000-000000000001",
+		Title:         "Akismet dup-software test",
+		CVE:           "CVE-2026-9001",
+		CVSSScore:     &score,
+		CVSSRating:    "Medium",
+		Informational: false,
+		References:    refJSON,
+		Raw:           rawJSON,
+		Software: []vuln.SoftwareRow{
+			// First entry: range1, not patched.
+			{Kind: "plugin", Slug: "akismet", AffectedVersions: av1, Patched: false, PatchedVersions: pvEmpty},
+			// Duplicate entry: same (kind, slug), different range, patched.
+			{Kind: "plugin", Slug: "akismet", AffectedVersions: av2, Patched: true, PatchedVersions: pv2},
+		},
+	}
+
+	// --- Case B: two DIFFERENT vulns sharing the same (kind, slug) ---
+	//
+	// Both affect "akismet" plugin but have different vuln_ids. The PK includes
+	// vuln_id, so both rows must survive — the dedup must NOT collapse across
+	// different vulns.
+	avB, _ := json.Marshal(map[string]any{
+		"* - 2.0.0": map[string]any{"from_version": "*", "from_inclusive": true, "to_version": "2.0.0", "to_inclusive": false},
+	})
+	pvB, _ := json.Marshal([]string{"2.0.1"})
+	scoreB := 8.0
+
+	recB1 := vuln.FeedRecord{
+		VulnID:        "dup-test-0000-0000-0000-000000000002",
+		Title:         "Akismet cross-vuln test 1",
+		CVSSScore:     &scoreB,
+		CVSSRating:    "High",
+		References:    refJSON,
+		Raw:           rawJSON,
+		Software: []vuln.SoftwareRow{
+			{Kind: "plugin", Slug: "akismet", AffectedVersions: avB, Patched: true, PatchedVersions: pvB},
+		},
+	}
+	recB2 := vuln.FeedRecord{
+		VulnID:        "dup-test-0000-0000-0000-000000000003",
+		Title:         "Akismet cross-vuln test 2",
+		CVSSScore:     &scoreB,
+		CVSSRating:    "High",
+		References:    refJSON,
+		Raw:           rawJSON,
+		Software: []vuln.SoftwareRow{
+			{Kind: "plugin", Slug: "akismet", AffectedVersions: avB, Patched: true, PatchedVersions: pvB},
+		},
+	}
+
+	allRecs := []vuln.FeedRecord{dupRec, recB1, recB2}
+
+	// Run the bulk ingest (the same operations ingestRecords uses).
+	t.Run("no_duplicate_key_error", func(t *testing.T) {
+		tx, err := pool.Begin(ctx)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+		if _, err := tx.Exec(ctx, "SELECT set_config('app.agent','on',true)"); err != nil {
+			t.Fatalf("set agent guc: %v", err)
+		}
+		if err := repo.BulkUpsertFeedRecords(ctx, tx, allRecs); err != nil {
+			t.Fatalf("BulkUpsertFeedRecords: %v", err)
+		}
+		// This is the call that previously threw SQLSTATE 23505.
+		if err := repo.BulkReplaceAllSoftware(ctx, tx, allRecs); err != nil {
+			t.Fatalf("BulkReplaceAllSoftware (duplicate software): %v", err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+	})
+
+	// (b) Exactly one row for Case A's duplicate (vuln_id, kind, slug).
+	t.Run("exactly_one_software_row_for_dup", func(t *testing.T) {
+		var count int
+		if err := pool.QueryRow(ctx,
+			`SELECT count(*) FROM wordfence_vuln_software WHERE vuln_id = $1 AND kind = 'plugin' AND slug = 'akismet'`,
+			dupRec.VulnID,
+		).Scan(&count); err != nil {
+			t.Fatalf("count query: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("wordfence_vuln_software rows for dup record = %d; want 1 (dedup must collapse to one)", count)
+		}
+	})
+
+	// (c) Merged affected_versions contains BOTH range keys — no data lost.
+	t.Run("merged_affected_versions_has_both_ranges", func(t *testing.T) {
+		var avOut []byte
+		if err := pool.QueryRow(ctx,
+			`SELECT affected_versions FROM wordfence_vuln_software WHERE vuln_id = $1 AND kind = 'plugin' AND slug = 'akismet'`,
+			dupRec.VulnID,
+		).Scan(&avOut); err != nil {
+			t.Fatalf("SELECT affected_versions: %v", err)
+		}
+		var avMap map[string]json.RawMessage
+		if err := json.Unmarshal(avOut, &avMap); err != nil {
+			t.Fatalf("unmarshal affected_versions: %v (raw: %s)", err, avOut)
+		}
+		if _, ok := avMap["1.0.0 - 1.2.3"]; !ok {
+			t.Errorf("affected_versions missing range key %q; full map: %v", "1.0.0 - 1.2.3", avMap)
+		}
+		if _, ok := avMap["1.5.0 - 1.6.0"]; !ok {
+			t.Errorf("affected_versions missing range key %q; full map: %v", "1.5.0 - 1.6.0", avMap)
+		}
+	})
+
+	// (d) patched = true (OR of false and true).
+	t.Run("merged_patched_is_true", func(t *testing.T) {
+		var patched bool
+		if err := pool.QueryRow(ctx,
+			`SELECT patched FROM wordfence_vuln_software WHERE vuln_id = $1 AND kind = 'plugin' AND slug = 'akismet'`,
+			dupRec.VulnID,
+		).Scan(&patched); err != nil {
+			t.Fatalf("SELECT patched: %v", err)
+		}
+		if !patched {
+			t.Error("patched = false; want true (OR of false and true from the two dup entries)")
+		}
+	})
+
+	// (e) patched_versions contains the merged version string.
+	t.Run("merged_patched_versions_union", func(t *testing.T) {
+		var pvOut []byte
+		if err := pool.QueryRow(ctx,
+			`SELECT patched_versions FROM wordfence_vuln_software WHERE vuln_id = $1 AND kind = 'plugin' AND slug = 'akismet'`,
+			dupRec.VulnID,
+		).Scan(&pvOut); err != nil {
+			t.Fatalf("SELECT patched_versions: %v", err)
+		}
+		var pvSlice []string
+		if err := json.Unmarshal(pvOut, &pvSlice); err != nil {
+			t.Fatalf("unmarshal patched_versions: %v (raw: %s)", err, pvOut)
+		}
+		found := false
+		for _, v := range pvSlice {
+			if v == "1.6.1" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("patched_versions = %v; want to contain %q", pvSlice, "1.6.1")
+		}
+	})
+
+	// Case B: two different vulns sharing (kind=plugin, slug=akismet) must
+	// produce TWO rows (one per vuln_id) — the dedup must NOT collapse across vulns.
+	t.Run("two_different_vulns_same_slug_produce_two_rows", func(t *testing.T) {
+		var count int
+		if err := pool.QueryRow(ctx,
+			`SELECT count(*) FROM wordfence_vuln_software WHERE vuln_id IN ($1, $2) AND kind = 'plugin' AND slug = 'akismet'`,
+			recB1.VulnID, recB2.VulnID,
+		).Scan(&count); err != nil {
+			t.Fatalf("count query: %v", err)
+		}
+		if count != 2 {
+			t.Errorf("software rows for two distinct vulns = %d; want 2 (dedup must NOT collapse across vuln_ids)", count)
+		}
+	})
+
+	// Idempotency: running the same ingest a second time must succeed (no errors,
+	// same row counts — the DELETE+CopyFrom pattern is inherently idempotent).
+	t.Run("second_ingest_is_idempotent", func(t *testing.T) {
+		tx, err := pool.Begin(ctx)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+		if _, err := tx.Exec(ctx, "SELECT set_config('app.agent','on',true)"); err != nil {
+			t.Fatalf("set agent guc: %v", err)
+		}
+		if err := repo.BulkUpsertFeedRecords(ctx, tx, allRecs); err != nil {
+			t.Fatalf("second BulkUpsertFeedRecords: %v", err)
+		}
+		if err := repo.BulkReplaceAllSoftware(ctx, tx, allRecs); err != nil {
+			t.Fatalf("second BulkReplaceAllSoftware: %v", err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			t.Fatalf("second commit: %v", err)
+		}
+
+		// Row counts must be identical after the second ingest.
+		var count int
+		if err := pool.QueryRow(ctx,
+			`SELECT count(*) FROM wordfence_vuln_software WHERE vuln_id = $1 AND kind = 'plugin' AND slug = 'akismet'`,
+			dupRec.VulnID,
+		).Scan(&count); err != nil {
+			t.Fatalf("count query after second ingest: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("after second ingest: rows = %d; want 1", count)
+		}
 	})
 }


### PR DESCRIPTION
The feed reached the software write and failed: duplicate key on (vuln_id,kind,slug) — a record can list the same (kind,slug) twice and CopyFrom can't ON CONFLICT. Now dedups per record (merging affected_versions ranges, OR-ing patched, unioning patched_versions) + a final cross-record PK guard. 7-sub-test real-Postgres test. This was the last code blocker; the only remaining issue is Wordfence's rate-limit penalty from repeated manual syncs (429 now skips gracefully, no retry storm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vulnerability feed processing to properly handle duplicate software entries without errors.
  * Enhanced deduplication and merging of software records during feed ingestion.

* **Tests**
  * Added integration test coverage for duplicate software entry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->