### PR TITLE
fix(agent): apply page-cache variant settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 ### Fixed
 
 - Backups now preserve plugin and theme vendor code in directories named `cache`, `upgrade`, or `upgrade-temp-backup` while still excluding runtime cache and update staging roots.
+- Advanced page-cache bypass and variant settings now reach the WordPress agent so saved URL, cookie, and query rules affect the rendered cache drop-in.
 
 ## [0.57.0] - 2026-06-21
 

--- a/apps/agent/assets/wpmgr-advanced-cache.php
+++ b/apps/agent/assets/wpmgr-advanced-cache.php
@@ -34,7 +34,7 @@
  * finds in the on-disk copy; a mismatch triggers a transparent reinstall so
  * existing sites always run the current drop-in logic without manual intervention.
  */
-define('WPMGR_PAGE_CACHE_DROPIN_VERSION', '0.45.0');
+define('WPMGR_PAGE_CACHE_DROPIN_VERSION', '0.45.1');
 
 if (!defined('ABSPATH')) {
     exit; // No direct access.
@@ -326,6 +326,24 @@ $wpmgr_path = preg_replace('#/+#', '/', $wpmgr_path);
 $wpmgr_path = preg_replace('#(\.\./|/\.\.)#', '', (string) $wpmgr_path);
 $wpmgr_path = '/' . ltrim((string) $wpmgr_path, '/');
 $wpmgr_path = rtrim($wpmgr_path, '/'); // '' for root
+
+// Bypass URLs: any configured substring in the request URI/path disables the
+// cache. This runs BEFORE locating an existing cache file so an already-warmed
+// file cannot be served for a URL the operator marked as non-cacheable.
+// Matches are case-insensitive substring containment, identical to the PHP
+// cacheability path, so the pre-WP fast path and the write layer agree.
+$wpmgr_bypass_urls = isset($wpmgr_config['bypass_urls']) && is_array($wpmgr_config['bypass_urls'])
+    ? $wpmgr_config['bypass_urls'] : array();
+if (!empty($wpmgr_bypass_urls) && $wpmgr_uri !== '') {
+    foreach ($wpmgr_bypass_urls as $wpmgr_bypass_url) {
+        if ($wpmgr_bypass_url === '') {
+            continue;
+        }
+        if (stripos($wpmgr_uri, (string) $wpmgr_bypass_url) !== false) {
+            return false;
+        }
+    }
+}
 
 $wpmgr_content = defined('WP_CONTENT_DIR') ? (string) WP_CONTENT_DIR : (dirname(__DIR__));
 $wpmgr_file = rtrim($wpmgr_content, '/\\')

--- a/apps/agent/includes/cache/class-cache-config.php
+++ b/apps/agent/includes/cache/class-cache-config.php
@@ -172,6 +172,10 @@ final class CacheConfig
             // three Woo cart/session patterns are moved to the ignore set so they
             // neither bypass nor key the cache.
             'bypass_cookies'        => Cacheability::effectiveBypassCookies($this->bypassCookies, $wooActive),
+            // URL substrings that bypass the cache. Inlined into the drop-in so the
+            // pre-WP fast path can reject already-warmed cache files for URLs the
+            // operator marked as non-cacheable.
+            'bypass_urls'           => $this->bypassUrls,
             'woo_ignore_cookies'    => $wooActive ? Cacheability::WOO_SESSION_COOKIES : [],
             'ignore_queries'        => MarketingParams::ignoreList(),
             'woo_cacheable_session' => $this->wooCacheableSession,

--- a/apps/agent/tests/AdvancedCacheDropinTest.php
+++ b/apps/agent/tests/AdvancedCacheDropinTest.php
@@ -32,6 +32,9 @@ final class AdvancedCacheDropinTest extends TestCase
     /** @var string */
     private string $tempDir;
 
+    /**
+     * Create an isolated temporary wp-content cache tree for each test.
+     */
     protected function set_up(): void
     {
         parent::set_up();
@@ -40,6 +43,9 @@ final class AdvancedCacheDropinTest extends TestCase
         @mkdir($this->tempDir . '/cache/wpmgr', 0o777, true);
     }
 
+    /**
+     * Remove the temporary tree created in set_up().
+     */
     protected function tear_down(): void
     {
         $this->rmdirRecursive($this->tempDir);

--- a/apps/agent/tests/AdvancedCacheDropinTest.php
+++ b/apps/agent/tests/AdvancedCacheDropinTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Advanced-cache drop-in fast-path tests.
+ *
+ * Proves the pre-WP drop-in honors configured bypass URLs before serving an
+ * already-warmed cache file. The drop-in is rendered with a real config and
+ * included against a temporary wp-content tree so it exercises the actual file
+ * without needing a full WordPress bootstrap.
+ *
+ * Each test that includes the drop-in runs in a separate process because the
+ * drop-in defines constants and reads superglobals that cannot be safely reset
+ * in a single PHPUnit process.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use WPMgr\Agent\Cache\CacheConfig;
+use WPMgr\Agent\Cache\DropinInstaller;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Cache\DropinInstaller
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class AdvancedCacheDropinTest extends TestCase
+{
+    /** @var string */
+    private string $tempDir;
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        $this->tempDir = sys_get_temp_dir() . '/wpmgr-dropin-test-' . uniqid('', true);
+        @mkdir($this->tempDir, 0o777, true);
+        @mkdir($this->tempDir . '/cache/wpmgr', 0o777, true);
+    }
+
+    protected function tear_down(): void
+    {
+        $this->rmdirRecursive($this->tempDir);
+        parent::tear_down();
+    }
+
+    /**
+     * Recursively remove a directory created by the test.
+     *
+     * @param string $dir Directory to remove.
+     */
+    private function rmdirRecursive(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $entries = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($entries as $entry) {
+            if ($entry->isDir()) {
+                @rmdir($entry->getRealPath());
+            } else {
+                @unlink($entry->getRealPath());
+            }
+        }
+        @rmdir($dir);
+    }
+
+    /**
+     * Render the drop-in into a temp file with the supplied config and include it
+     * in a controlled environment. Returns the value produced by the drop-in
+     * (false on bypass/miss, exits on hit).
+     *
+     * @param array<string,mixed> $config Drop-in config array.
+     * @param array<string,mixed> $server $_SERVER overrides.
+     * @return mixed
+     */
+    private function runDropin(array $config, array $server = [])
+    {
+        $template = dirname(__DIR__) . '/assets/wpmgr-advanced-cache.php';
+        $installer = new DropinInstaller($this->tempDir, $template);
+        $rendered  = $installer->render($config);
+        $this->assertNotEmpty($rendered);
+
+        $renderedPath = $this->tempDir . '/advanced-cache.php';
+        file_put_contents($renderedPath, $rendered);
+
+        // Plain-PHP guards the drop-in expects.
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', $this->tempDir . '/');
+        }
+        if (!defined('WP_CACHE')) {
+            define('WP_CACHE', true);
+        }
+        if (!defined('WP_CONTENT_DIR')) {
+            define('WP_CONTENT_DIR', $this->tempDir);
+        }
+
+        $_SERVER = array_merge([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI'    => '/',
+            'HTTP_HOST'      => 'example.com',
+            'HTTPS'          => 'on',
+        ], $server);
+        $_GET    = [];
+        $_COOKIE  = [];
+        $_POST    = [];
+
+        return include $renderedPath;
+    }
+
+    /**
+     * Warm a cache file for the given host/path and return its absolute path.
+     *
+     * @param string $host  Canonical host.
+     * @param string $path  URL path (no trailing slash for root).
+     * @param string $name  Cache file base name.
+     * @return string Absolute path to the warmed file.
+     */
+    private function warmCacheFile(string $host, string $path, string $name = 'index'): string
+    {
+        $dir = $this->tempDir . '/cache/wpmgr/' . $host . ($path === '' ? '' : $path);
+        if (!is_dir($dir)) {
+            @mkdir($dir, 0o777, true);
+        }
+        $file = $dir . '/' . $name . '.html.gz';
+        file_put_contents($file, gzencode('<html><body>cached</body></html>'));
+        return $file;
+    }
+
+    /**
+     * A request whose URI contains a configured bypass URL must return false
+     * BEFORE serving an existing cache file.
+     */
+    public function test_bypass_url_prevents_serving_existing_cache_file(): void
+    {
+        $this->warmCacheFile('example.com', '');
+
+        $config = (new CacheConfig(['bypass_urls' => ['/cart']]))->toDropinArray();
+        $result = $this->runDropin($config, ['REQUEST_URI' => '/cart/']);
+
+        $this->assertFalse($result, 'bypass URL must return false before serving a warmed cache file');
+    }
+
+    /**
+     * Case-insensitive substring containment: the bypass rule must match even
+     * when the casing differs.
+     */
+    public function test_bypass_url_match_is_case_insensitive(): void
+    {
+        $this->warmCacheFile('example.com', '/checkout');
+
+        $config = (new CacheConfig(['bypass_urls' => ['/CHECKOUT']]))->toDropinArray();
+        $result = $this->runDropin($config, ['REQUEST_URI' => '/checkout/']);
+
+        $this->assertFalse($result);
+    }
+
+}

--- a/apps/agent/tests/CacheCommandsTest.php
+++ b/apps/agent/tests/CacheCommandsTest.php
@@ -153,6 +153,43 @@ final class CacheCommandsTest extends TestCase
         $this->assertSame(['geo'], $stored['include_cookies']);
     }
 
+    public function test_perf_config_update_persists_unprefixed_cache_variant_keys(): void
+    {
+        $cmd = new PerfConfigUpdateCommand($this->manager());
+        $res = $cmd->execute([], [
+            'bypass_urls'      => ['/cart', '/checkout'],
+            'bypass_cookies'   => ['my_session'],
+            'include_queries'  => ['sort_dir'],
+            'include_cookies'  => ['geo'],
+        ]);
+        $this->assertTrue($res['ok']);
+
+        $stored = $this->optionStore[CacheManager::OPTION_CONFIG] ?? [];
+        $this->assertSame(['/cart', '/checkout'], $stored['bypass_urls']);
+        $this->assertSame(['my_session'], $stored['bypass_cookies']);
+        $this->assertSame(['sort_dir'], $stored['include_queries']);
+        $this->assertSame(['geo'], $stored['include_cookies']);
+    }
+
+    public function test_perf_config_update_ignores_prefixed_cache_variant_aliases(): void
+    {
+        $cmd = new PerfConfigUpdateCommand($this->manager());
+        $res = $cmd->execute([], [
+            'cache_bypass_urls'     => ['/cart'],
+            'cache_bypass_cookies'  => ['my_session'],
+            'cache_include_queries' => ['sort_dir'],
+            'cache_include_cookies' => ['geo'],
+        ]);
+        $this->assertFalse($res['ok']);
+        $this->assertStringContainsString('recognised', $res['detail']);
+
+        $stored = $this->optionStore[CacheManager::OPTION_CONFIG] ?? [];
+        $this->assertArrayNotHasKey('bypass_urls', $stored);
+        $this->assertArrayNotHasKey('bypass_cookies', $stored);
+        $this->assertArrayNotHasKey('include_queries', $stored);
+        $this->assertArrayNotHasKey('include_cookies', $stored);
+    }
+
     public function test_perf_config_update_clamps_absurd_refresh_interval(): void
     {
         $cmd = new PerfConfigUpdateCommand($this->manager());

--- a/apps/agent/tests/CacheCommandsTest.php
+++ b/apps/agent/tests/CacheCommandsTest.php
@@ -153,6 +153,10 @@ final class CacheCommandsTest extends TestCase
         $this->assertSame(['geo'], $stored['include_cookies']);
     }
 
+    /**
+     * The command stores the four page-cache variant lists under their
+     * unprefixed keys when the control plane sends them on the wire.
+     */
     public function test_perf_config_update_persists_unprefixed_cache_variant_keys(): void
     {
         $cmd = new PerfConfigUpdateCommand($this->manager());
@@ -171,6 +175,11 @@ final class CacheCommandsTest extends TestCase
         $this->assertSame(['geo'], $stored['include_cookies']);
     }
 
+    /**
+     * Prefixed cache_* names are not in the command whitelist, so a payload
+     * using them is rejected and nothing is persisted. Guards against silently
+     * accepting the old wire names again.
+     */
     public function test_perf_config_update_ignores_prefixed_cache_variant_aliases(): void
     {
         $cmd = new PerfConfigUpdateCommand($this->manager());

--- a/apps/agent/tests/CacheConfigAndRolesTest.php
+++ b/apps/agent/tests/CacheConfigAndRolesTest.php
@@ -71,7 +71,15 @@ final class CacheConfigAndRolesTest extends TestCase
         $this->assertContains('gclid', $arr['ignore_queries']);
         // The lean drop-in array must NOT carry server-only keys.
         $this->assertArrayNotHasKey('enabled', $arr);
-        $this->assertArrayNotHasKey('bypass_urls', $arr);
+    }
+
+    public function test_dropin_array_carries_bypass_urls_for_fast_path(): void
+    {
+        $c   = new CacheConfig(['bypass_urls' => ['/cart', '/checkout']]);
+        $arr = $c->toDropinArray();
+
+        $this->assertArrayHasKey('bypass_urls', $arr);
+        $this->assertSame(['/cart', '/checkout'], $arr['bypass_urls']);
     }
 
     /**

--- a/apps/agent/tests/CacheConfigAndRolesTest.php
+++ b/apps/agent/tests/CacheConfigAndRolesTest.php
@@ -60,6 +60,10 @@ final class CacheConfigAndRolesTest extends TestCase
         $this->assertSame(['/cart'], $out['bypass_urls']);
     }
 
+    /**
+     * The lean drop-in array carries the runtime ignore list and operator
+     * include-cookies, but omits server-only keys such as enabled.
+     */
     public function test_dropin_array_carries_ignore_list(): void
     {
         $c = new CacheConfig(['cache_mobile' => true, 'include_cookies' => ['geo']]);
@@ -73,6 +77,10 @@ final class CacheConfigAndRolesTest extends TestCase
         $this->assertArrayNotHasKey('enabled', $arr);
     }
 
+    /**
+     * The drop-in array exposes bypass_urls so the pre-WP fast path can skip
+     * serving a warmed cache file for URLs the operator marked non-cacheable.
+     */
     public function test_dropin_array_carries_bypass_urls_for_fast_path(): void
     {
         $c   = new CacheConfig(['bypass_urls' => ['/cart', '/checkout']]);

--- a/apps/api/internal/agentcmd/cache_contract.go
+++ b/apps/api/internal/agentcmd/cache_contract.go
@@ -39,10 +39,14 @@ type PerfConfigRequest struct {
 	CacheRefresh         bool     `json:"cache_refresh"`
 	CacheRefreshInterval string   `json:"cache_refresh_interval"`
 	CacheLinkPrefetch    bool     `json:"cache_link_prefetch"`
-	CacheBypassURLs      []string `json:"cache_bypass_urls"`
-	CacheBypassCookies   []string `json:"cache_bypass_cookies"`
-	CacheIncludeQueries  []string `json:"cache_include_queries"`
-	CacheIncludeCookies  []string `json:"cache_include_cookies"`
+	// Page-cache variant lists use the agent's persisted/drop-in config keys
+	// (unprefixed) on the wire, not the CP public/API field names. The agent
+	// stores and serves from bypass_urls, bypass_cookies, include_queries, and
+	// include_cookies; keeping these names aligned avoids silent ignore bugs.
+	CacheBypassURLs      []string `json:"bypass_urls"`
+	CacheBypassCookies   []string `json:"bypass_cookies"`
+	CacheIncludeQueries  []string `json:"include_queries"`
+	CacheIncludeCookies  []string `json:"include_cookies"`
 
 	// Preload (cache-warm) throttle (M37). Operator-tunable; the agent clamps
 	// each to the same bounds locally (concurrency 1..4, delay 0..10000 ms,

--- a/apps/api/internal/perf/beacon_push_test.go
+++ b/apps/api/internal/perf/beacon_push_test.go
@@ -11,6 +11,9 @@ package perf
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -93,6 +96,48 @@ func TestToPerfConfigRequest_omitsBeaconKeyOnSubsequentPush(t *testing.T) {
 	// But IngestURL is still set because RumEnabled=true.
 	if req.RumIngestURL == "" {
 		t.Error("RumIngestURL must be set when RumEnabled=true, even on unchanged push")
+	}
+}
+
+// TestToPerfConfigRequest_cacheVariantWireNames verifies that the four page-
+// cache variant lists marshal with the agent-side unprefixed keys
+// (bypass_urls, bypass_cookies, include_queries, include_cookies), not the CP
+// public/API prefixed names. This is a regression guard: if the wire names ever
+// revert to cache_*, the agent will silently ignore the lists.
+func TestToPerfConfigRequest_cacheVariantWireNames(t *testing.T) {
+	cfg := Config{
+		CacheBypassURLs:     []string{"/cart", "/checkout"},
+		CacheBypassCookies:  []string{"woocommerce", "my_session"},
+		CacheIncludeQueries: []string{"sort_dir", "filter_color"},
+		CacheIncludeCookies: []string{"geo", "currency"},
+	}
+
+	req := toPerfConfigRequest(cfg, "", "")
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	raw := string(data)
+
+	wantKeys := []string{"bypass_urls", "bypass_cookies", "include_queries", "include_cookies"}
+	for _, key := range wantKeys {
+		if !strings.Contains(raw, fmt.Sprintf("%q:", key)) {
+			t.Errorf("payload missing expected key %q; got %s", key, raw)
+		}
+	}
+
+	badKeys := []string{"cache_bypass_urls", "cache_bypass_cookies", "cache_include_queries", "cache_include_cookies"}
+	for _, key := range badKeys {
+		if strings.Contains(raw, fmt.Sprintf("%q:", key)) {
+			t.Errorf("payload must not use CP public field name %q; got %s", key, raw)
+		}
+	}
+
+	// Spot-check values are present so the test is not just key-name matching.
+	for _, val := range []string{"/cart", "woocommerce", "sort_dir", "geo"} {
+		if !strings.Contains(raw, fmt.Sprintf("%q", val)) {
+			t.Errorf("payload missing expected value %q; got %s", val, raw)
+		}
 	}
 }
 


### PR DESCRIPTION

## What
- Align the control plane `perf_config_update` payload for the four page-cache variant lists with the agent's persisted and drop-in config keys: `bypass_urls`, `bypass_cookies`, `include_queries`, and `include_cookies`. Public API and database field names are unchanged.
- Add a pre-lookup bypass URL guard to the `advanced-cache.php` drop-in so configured bypass rules prevent serving an already-warmed cache file.
- Include `bypass_urls` in the rendered drop-in config via `CacheConfig::toDropinArray()`.
- Add regression tests for payload wire names, agent command persistence of unprefixed keys, and drop-in fast-path bypass behavior.
- Bump the drop-in version to `0.45.1` so existing installs reinstall the updated drop-in on the next config push.
- Add a `CHANGELOG.md` `### Fixed` entry under `## [Unreleased]`.

## Why
The control plane stores advanced page-cache rules as `cache_bypass_urls`, `cache_bypass_cookies`, `cache_include_queries`, and `cache_include_cookies`, but the agent command whitelist and `CacheConfig` only recognized the unprefixed names. Saves appeared successful but the lists were silently ignored. The drop-in also did not enforce bypass URLs before serving an existing cache file, so a bypass rule could still return a cache HIT for a previously cached page.

**Risk:** This touches the page-cache serving fast path. The bypass URL check uses the same case-insensitive substring matching as the PHP `Cacheability` layer, applied to the request path, and runs after the existing method/cookie guards.

## Checklist
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] `make build` passes
- [x] OpenAPI updated (if endpoints changed) - no endpoint changes
- [x] Docs updated (if behavior changed) - changelog entry added; no other docs needed for this fix
- [x] Touches auth / crypto / agent protocol / RBAC / tenant isolation? Yes - agent protocol and the cache serving fast path. Flagging for security review; please take a look at the cache-bypass behavior.

## Testing
I ran the focused Go and agent suites plus PHPCS against the changed paths. I don't have the Docker-based `make agent-plugincheck` set up locally, so I'm relying on CI for the full lint/test/build and plugincheck gates.

- `go test ./internal/perf` (from `apps/api`): passes, including a new regression that fails if the cache variant lists ever marshal back to the `cache_*` names.
- Agent PHPUnit `CacheCommandsTest`, `CacheConfigAndRolesTest`, `CacheabilityTest`, and `AdvancedCacheDropinTest` (from `apps/agent`): 48 tests, 149 assertions, all passing.
- PHPCS clean on the changed agent files.
- `node apps/landing/scripts/check-copy.mjs --extra CHANGELOG.md` and `git diff --check`: clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed advanced page-cache bypass and cache variant settings not being properly delivered to the caching system. Configured URL bypass rules (including case-insensitive matching), cookie settings, and query include/exclude behavior now correctly influence which cached drop-ins are served.

* **Tests**
  * Added/expanded test coverage for bypass URL behavior, persistence of unprefixed variant keys, ignoring of prefixed aliases, and correct request payload key names sent from the performance config pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->