### PR TITLE
fix(selfhost): one-shot prod-images bootstrap + port/healthcheck fixes (#107, #108)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,8 +85,11 @@ WPMGR_AGENT_SIGNING_PUBLIC_KEY=gVvm9uqh097KXdYB0sO2lxF8WZIPRPVjLKYm0o0hbJ0=
 
 # Public base URL of THIS control plane, reachable by agents and embedded in
 # invite/reset/manifest/presign-callback links. Format: URL, no trailing slash.
-# e.g. https://wpmgr.example.com
-WPMGR_PUBLIC_BASE_URL=http://localhost:8080
+# NOTE: The API's host-facing port is WPMGR_API_PORT (default 8081, NOT 8080).
+# :8080 is the container-internal listen address (WPMGR_HTTP_ADDR); it is NOT
+# published to the host. Use the host-facing port (or your reverse-proxy URL)
+# here. e.g. http://YOUR_SERVER_IP:8081  or  https://wpmgr.example.com
+WPMGR_PUBLIC_BASE_URL=http://localhost:8081
 
 # S3-compatible object storage (self-host: SeaweedFS; managed: AWS S3). The agent
 # must be able to reach presigned URLs minted from WPMGR_S3_ENDPOINT — the
@@ -110,7 +113,10 @@ WPMGR_S3_FORCE_PATH_STYLE=true
 # =============================================================================
 
 # ---- Server ----
-# API listen address. Format: Go host:port. e.g. :8080
+# API container-internal listen address. The Go binary binds :8080 INSIDE the
+# container. The HOST-facing port is WPMGR_API_PORT below (default 8081) — that
+# is what you curl / put behind a reverse proxy. Do not confuse the two.
+# Format: Go host:port. e.g. :8080
 WPMGR_HTTP_ADDR=:8080
 # Log level. Format: debug|info|warn|error. e.g. info
 WPMGR_LOG_LEVEL=info
@@ -145,10 +151,15 @@ WPMGR_AUTH_IDLE_TIMEOUT=168h
 WPMGR_AUTH_ABSOLUTE_EXPIRY=720h
 # OIDC relying party (self-host via Dex). Empty issuer => email+password only.
 # A non-empty issuer that fails discovery HARD-FAILS boot. Format: URLs / strings.
+# NOTE: WPMGR_OIDC_REDIRECT_URL uses the HOST-facing port (WPMGR_API_PORT=8081),
+# not the container-internal port (:8080).
 WPMGR_OIDC_ISSUER=
 WPMGR_OIDC_CLIENT_ID=
 WPMGR_OIDC_CLIENT_SECRET=
-WPMGR_OIDC_REDIRECT_URL=http://localhost:8080/auth/oidc/callback
+# The OIDC callback is reached by the browser through the nginx web container
+# (WPMGR_WEB_PORT=8088 by default); nginx proxies /auth/* to the api internally.
+# Do NOT use port 8081 (direct API host port) or :8080 (container-internal).
+WPMGR_OIDC_REDIRECT_URL=http://localhost:8088/auth/oidc/callback
 
 # ---- Agent protocol tuning ----
 # Anti-replay signature skew, heartbeat-staleness threshold, health-job cadence.
@@ -270,5 +281,9 @@ WPMGR_DB_APP_PASSWORD=wpmgr-app-dev-secret
 # =============================================================================
 # [FRONTEND]  Baked into the web SPA at build time (Vite).
 # =============================================================================
-# API base URL the dashboard calls. Format: URL. e.g. http://localhost:8080
-VITE_API_BASE_URL=http://localhost:8080
+# API base URL the dashboard calls. For the prebuilt GHCR web image this is
+# baked in at build time and the dashboard SPA proxies via nginx — you do NOT
+# need to set this for the prod-images path. For local source builds override
+# to your host-facing URL (WPMGR_API_PORT=8081, NOT :8080 which is container-
+# internal). Format: URL. e.g. http://localhost:8081
+VITE_API_BASE_URL=http://localhost:8081

--- a/docs/install.md
+++ b/docs/install.md
@@ -126,7 +126,50 @@ sharing the bootstrap superuser; never set it in production.
 
 ## 2. Bring up the stack
 
-Build the images locally from source:
+### Quickstart: prebuilt images, no clone (recommended for first-time installs)
+
+The one-liner below fetches every required file, generates all secrets, and
+prints the exact `docker compose` command to start WPMgr — no repo clone, no
+manual editing:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mosamlife/wpmgr/main/scripts/quickstart-selfhost.sh | bash
+```
+
+Or, if you prefer to inspect the script first:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mosamlife/wpmgr/main/scripts/quickstart-selfhost.sh -o quickstart-selfhost.sh
+bash quickstart-selfhost.sh --hostname=https://wpmgr.example.com
+```
+
+Flags:
+- `--hostname=URL` — sets `WPMGR_PUBLIC_BASE_URL` non-interactively (recommended for servers).
+- `--version=vX.Y.Z` — pins a specific release tag; omit to use `:latest`.
+- `--dir=PATH` — writes everything into a custom directory (default: `./wpmgr`).
+
+The script downloads:
+
+| File | Why |
+|------|-----|
+| `infra/docker-compose.yml` | base stack |
+| `infra/docker-compose.prod.yml` | pull-only GHCR overlay |
+| `.env.example` + `scripts/init-env.sh` | env bootstrap |
+| `infra/seaweedfs/s3.json` | SeaweedFS S3 auth (bind-mounted) |
+| `infra/dex/config.yaml` | Dex OIDC config (bind-mounted) |
+| `infra/postgres/init/01-app-role.sh` | Postgres role init (bind-mounted) |
+| `infra/prometheus/prometheus.yml` + `infra/grafana/…` | observability profile |
+
+> **Port note:** the API listens on `:8080` *inside* the container, but is
+> published to the **host** on `:8081` (`WPMGR_API_PORT`). The dashboard nginx
+> is on **`:8088`** (`WPMGR_WEB_PORT`). These are the ports you curl and put
+> behind a reverse proxy. Neither is `:80` or `:8080` on the host — those are
+> deliberately avoided so first boot never needs root or collides with an
+> existing web server.
+
+### Or: build from source (clone path)
+
+If you have cloned the repo:
 
 ```bash
 docker compose -f infra/docker-compose.yml up -d
@@ -141,12 +184,12 @@ any of them in `.env` with the `WPMGR_*_PORT` vars (`WPMGR_WEB_PORT`,
 `WPMGR_API_PORT`, `WPMGR_S3_PORT`, `WPMGR_DEX_PORT`) — e.g. set
 `WPMGR_WEB_PORT=80` to serve the dashboard on the standard HTTP port.
 
-### Or: run the prebuilt GHCR images (no local build)
+### Prebuilt GHCR images (no local build)
 
 Pre-built `linux/amd64` images are published on GitHub Container Registry:
 `ghcr.io/mosamlife/wpmgr-api`, `-web`, and `-media-encoder` (each tagged
-`:vX.Y.Z` and `:latest`). Bring up the stack from them with the pull-only
-overlay:
+`:vX.Y.Z` and `:latest`). If you already have the compose files (via the
+quickstart or a clone), bring up the stack with the pull-only overlay:
 
 ```bash
 export WPMGR_VERSION=v0.19.0   # omit to track :latest
@@ -157,20 +200,27 @@ The overlay only swaps the three app services to `image:` + `pull_policy:
 always`; everything else (Postgres, Redis, SeaweedFS, ClickHouse, env, volumes)
 is inherited from the base file. Add `--profile media` for the encoder.
 
-> GHCR packages are private on first publish. The maintainer makes each
-> `wpmgr-*` package **Public** once (GitHub → Packages → package → Settings →
-> Change visibility → Public); after that `docker pull` needs no auth. arm64
-> multi-arch images are a near-term follow-up.
+> GHCR packages are public. `docker pull` needs no auth. arm64 multi-arch
+> images are a near-term follow-up.
 
 ## 3. Verify
 
 ```bash
-curl localhost:8081/healthz   # {"status":"ok"}  (default WPMGR_API_PORT=8081)
+# Direct to the API host port (WPMGR_API_PORT, default 8081 — NOT :8080):
+curl localhost:8081/healthz   # {"status":"ok"}
 curl localhost:8081/readyz    # 200 once DB/Redis/S3 are reachable
+
+# Or via the nginx web container (WPMGR_WEB_PORT, default 8088):
+curl localhost:8088/healthz   # proxied by nginx -> api:8080/healthz
 ```
 
 - `GET /healthz` — liveness (process is up).
 - `GET /readyz` — readiness (dependencies reachable).
+
+**Port disambiguation:** `:8080` is the container-internal listen address
+(`WPMGR_HTTP_ADDR`). It is **not** published to the host. What you `curl` is
+the **host** port — `8081` for the API directly, `8088` for the nginx web
+proxy. Both are overridable in `.env` via `WPMGR_API_PORT` and `WPMGR_WEB_PORT`.
 
 Open the dashboard at `http://localhost:8088` (the default `WPMGR_WEB_PORT`; the
 `web` service serves the built SPA via nginx and proxies to the API). Set

--- a/infra/dex/config.yaml
+++ b/infra/dex/config.yaml
@@ -38,12 +38,21 @@ oauth2:
   skipApprovalScreen: true
 
 # Static OIDC client for the WPMgr control plane.
+#
+# REDIRECT URI: The browser is redirected here after Dex login. For a standard
+# self-host stack the user reaches the control plane through the nginx web
+# container (WPMGR_WEB_PORT, default 8088), which proxies /auth/* to the api
+# container. So the redirect URI uses port 8088 (the nginx host port), NOT
+# the container-internal API port :8080 or the direct API host port 8081.
+#
+# If you override WPMGR_WEB_PORT in .env, update this URI to match.
+# WPMGR_OIDC_REDIRECT_URL in .env must equal this value.
 staticClients:
   - id: wpmgr
     name: WPMgr
     secret: wpmgr-oidc-dev-secret
     redirectURIs:
-      - http://localhost:8080/auth/oidc/callback
+      - http://localhost:8088/auth/oidc/callback
 
 # Local password database so the login flow is testable end to end without an
 # upstream IdP. Dev credentials below — DO NOT use in production.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -73,7 +73,9 @@ services:
       # regardless of the published host port). The seaweedfs:3.80 image ships
       # busybox (so `wget` is present), but we use CMD-SHELL with a busybox-wget
       # fallback so the probe is resilient even if the base image's applet set
-      # changes. A generous start_period covers the gateway's volume/filer warmup.
+      # changes. start_period is 120s: on a cold volume SeaweedFS initialises its
+      # filer + S3 gateway sequentially, which can take 90–120 s on a slow host.
+      # Retries (15 x 10 s = 150 s) cover any remaining warmup after start_period.
       test:
         - CMD-SHELL
         - >-
@@ -81,8 +83,8 @@ services:
           || busybox wget -q -O /dev/null http://127.0.0.1:8333/status
       interval: 10s
       timeout: 5s
-      retries: 12
-      start_period: 60s
+      retries: 15
+      start_period: 120s
 
   # One-shot init: create the wpmgr-backups bucket via the S3 gateway.
   seaweedfs-init:
@@ -117,11 +119,15 @@ services:
     volumes:
       - clickhouse-data:/var/lib/clickhouse
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:8123/ping"]
+      # ClickHouse exposes a plain HTTP /ping endpoint on port 8123 that returns
+      # "Ok." when the server is ready. A 30 s start_period covers the initial
+      # data directory setup on a cold volume; 8 retries (80 s) handle any
+      # remaining startup work.
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8123/ping | grep -q Ok"]
       interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 15s
+      retries: 8
+      start_period: 30s
 
   api:
     build:
@@ -165,7 +171,11 @@ services:
       WPMGR_OIDC_ISSUER: ${WPMGR_OIDC_ISSUER:-http://dex.localhost:5556/dex}
       WPMGR_OIDC_CLIENT_ID: ${WPMGR_OIDC_CLIENT_ID:-wpmgr}
       WPMGR_OIDC_CLIENT_SECRET: ${WPMGR_OIDC_CLIENT_SECRET:-wpmgr-oidc-dev-secret}
-      WPMGR_OIDC_REDIRECT_URL: ${WPMGR_OIDC_REDIRECT_URL:-http://localhost:8080/auth/oidc/callback}
+      # The OIDC callback URL must be reachable by the user's browser. In the
+      # compose stack the browser hits nginx (WPMGR_WEB_PORT, default 8088) and
+      # nginx proxies /auth/* to the api. So the redirect URL uses port 8088, not
+      # the container-internal :8080 or the direct api host port (WPMGR_API_PORT).
+      WPMGR_OIDC_REDIRECT_URL: ${WPMGR_OIDC_REDIRECT_URL:-http://localhost:8088/auth/oidc/callback}
       WPMGR_REDIS_ADDR: redis:6379
       # M5.6/ADR-033: presigned URLs the agent receives MUST be reachable from
       # OUTSIDE this Docker network — `seaweedfs:8333` (Docker service name)

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -4,22 +4,29 @@
 #
 # What it does:
 #   1. Copies .env.example -> .env (only if .env is absent, unless --force).
-#   2. Generates the four boot-critical secrets and injects them into .env,
-#      but only into keys that are still empty (existing secrets are preserved).
-#   3. Prints the next steps.
+#   2. Generates the four boot-critical cryptographic secrets and injects them
+#      into .env, but only into keys that are still empty (existing secrets are
+#      preserved).
+#   3. Randomizes the DB owner password, DB app password, and S3 secret key
+#      — and writes the SAME S3 secret into infra/seaweedfs/s3.json so the
+#      SeaweedFS auth and the .env value always match.
+#   4. Prompts for the public hostname (WPMGR_PUBLIC_BASE_URL) when it is still
+#      the placeholder; accepts a --hostname=<url> flag to skip the prompt.
+#   5. Prints the next steps with the CORRECT host ports.
 #
-# The four secrets are minted by `wpmgr-cli gen-secrets`, which produces them in
-# the EXACT formats the control plane validates at boot (and self-tests each one
-# through the server's own decode path). The generator is run via, in order of
-# preference: a local Go toolchain, then Docker Compose, then host openssl +
-# age-keygen as a last resort.
+# The four cryptographic secrets are minted by `wpmgr-cli gen-secrets`, which
+# produces them in the EXACT formats the control plane validates at boot (and
+# self-tests each one through the server's own decode path). The generator is
+# run via, in order of preference: a local Go toolchain, then Docker Compose,
+# then host openssl + age-keygen as a last resort.
 #
 # Idempotent and safe to re-run: an existing .env is never overwritten without
 # --force, and only EMPTY secret keys are filled.
 #
 # Usage:
-#   scripts/init-env.sh           # bootstrap (preserves an existing .env)
-#   scripts/init-env.sh --force   # overwrite .env from .env.example, then fill
+#   scripts/init-env.sh                              # bootstrap (preserves .env)
+#   scripts/init-env.sh --force                      # overwrite from .env.example
+#   scripts/init-env.sh --hostname=https://wpmgr.example.com
 #
 set -euo pipefail
 
@@ -30,8 +37,10 @@ cd "${ROOT_DIR}"
 
 ENV_FILE="${ROOT_DIR}/.env"
 ENV_EXAMPLE="${ROOT_DIR}/.env.example"
+S3_JSON="${ROOT_DIR}/infra/seaweedfs/s3.json"
 GEN_FILE=""
 FORCE=0
+HOSTNAME_OVERRIDE=""
 
 # The secret keys this script manages (filled when empty OR still the committed
 # DEV placeholder — see dev_sentinel below).
@@ -42,18 +51,28 @@ SECRET_KEYS=(
   WPMGR_SITE_DEST_AGE_SECRET
 )
 
+# Infra password keys that are randomized once on first init (not regenerated on
+# subsequent runs unless --force). Shared with compose init scripts.
+INFRA_PASSWORD_KEYS=(
+  WPMGR_DB_OWNER_PASSWORD
+  WPMGR_DB_APP_PASSWORD
+  WPMGR_S3_SECRET_KEY
+)
+
 # Committed DEV placeholders shipped in .env.example. These are PUBLIC and the
 # control plane rejects the agent private key in production, so a fresh install
 # must replace them. We treat them like an empty value (regenerate them).
 DEV_SENTINEL_WPMGR_AGENT_SIGNING_PRIVATE_KEY='aWuH1W3DSfBwuE/V/H9BEmV9IAJfK5d6F2RDfYSj/raBW+b26qHT3spd1gHSw7aXEXxZkg9E9WMspibSjSFsnQ=='
 DEV_SENTINEL_WPMGR_AGENT_SIGNING_PUBLIC_KEY='gVvm9uqh097KXdYB0sO2lxF8WZIPRPVjLKYm0o0hbJ0='
 
-log() { printf '==> %s\n' "$*"; }
+# Dev placeholder values for infra passwords shipped in .env.example.
+DEV_SENTINEL_WPMGR_DB_OWNER_PASSWORD='wpmgr'
+DEV_SENTINEL_WPMGR_DB_APP_PASSWORD='wpmgr-app-dev-secret'
+DEV_SENTINEL_WPMGR_S3_SECRET_KEY='wpmgr-dev-secret'
+
+log()  { printf '==> %s\n' "$*"; }
 warn() { printf 'WARN: %s\n' "$*" >&2; }
-die() {
-  printf 'ERROR: %s\n' "$*" >&2
-  exit 1
-}
+die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
 cleanup() { [ -n "${GEN_FILE}" ] && rm -f "${GEN_FILE}"; }
 trap cleanup EXIT
@@ -106,7 +125,16 @@ gen_with_docker() {
   log "Generating secrets via Docker (docker compose run api wpmgr-cli gen-secrets)"
   # The api image's entrypoint is the wpmgr server binary; override it to run the
   # bundled CLI. --no-deps avoids starting Postgres/Redis just to print keys.
-  docker compose -f infra/docker-compose.yml run --rm --no-deps \
+  # Try the prod overlay first (uses the prebuilt GHCR image — works in the
+  # no-clone quickstart context where no source tree is present). Fall back to
+  # the base compose (which has a build: stanza, only works with a source tree).
+  local compose_files=()
+  if [ -f "${ROOT_DIR}/infra/docker-compose.prod.yml" ]; then
+    compose_files=(-f "${ROOT_DIR}/infra/docker-compose.yml" -f "${ROOT_DIR}/infra/docker-compose.prod.yml")
+  else
+    compose_files=(-f "${ROOT_DIR}/infra/docker-compose.yml")
+  fi
+  docker compose "${compose_files[@]}" run --rm --no-deps \
     --entrypoint wpmgr-cli api gen-secrets >"${GEN_FILE}" 2>/dev/null
 }
 
@@ -135,20 +163,37 @@ gen_with_host_tools() {
 }
 
 print_next_steps() {
-  cat <<'EOF'
+  # Read the actual host ports from .env (fall back to compose defaults).
+  local api_port web_port
+  api_port="$(current_value WPMGR_API_PORT)"
+  api_port="${api_port:-8081}"
+  web_port="$(current_value WPMGR_WEB_PORT)"
+  web_port="${web_port:-8088}"
+
+  cat <<EOF
 
 Next steps:
-  1. Review .env — set WPMGR_PUBLIC_BASE_URL to a URL your agents can reach, and
-     (for production) set WPMGR_ENV=production and override the dev DB / S3
-     passwords. WPMGR_S3_ENDPOINT must be reachable by remote agents.
-  2. Bring up the stack:
-       docker compose -f infra/docker-compose.yml up -d        # build from source
-       # or, with the prebuilt GHCR images:
+  1. Edit .env if needed:
+       - Set WPMGR_PUBLIC_BASE_URL to a URL your agents can reach (already set
+         if you used --hostname= or answered the prompt above).
+       - Set WPMGR_S3_ENDPOINT to a URL reachable from your WordPress hosts
+         (the in-network default http://seaweedfs:8333 only works inside Docker).
+       - For production: set WPMGR_ENV=production.
+       - DB + S3 passwords were randomized above — they are consistent across
+         .env and infra/seaweedfs/s3.json; no hand-editing needed.
+
+  2. Bring up the stack (prebuilt GHCR images, no clone required):
        docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
-  3. Verify:
-       curl localhost:8080/healthz   # {"status":"ok"}
-       curl localhost:8080/readyz    # 200 once dependencies are reachable
-       open http://localhost          # the dashboard (nginx)
+
+     Or build from source:
+       docker compose -f infra/docker-compose.yml up -d
+
+  3. Verify (note: the host-facing port is ${api_port}, NOT :8080 — that is the
+     in-container listen address):
+       curl localhost:${api_port}/healthz   # {"status":"ok"}
+       curl localhost:${api_port}/readyz    # 200 once DB/Redis/S3 are reachable
+
+  4. Open the dashboard at http://localhost:${web_port}
 
 See docs/install.md for the full guide.
 EOF
@@ -160,8 +205,9 @@ EOF
 for arg in "$@"; do
   case "${arg}" in
     --force) FORCE=1 ;;
+    --hostname=*) HOSTNAME_OVERRIDE="${arg#--hostname=}" ;;
     -h | --help)
-      sed -n '3,24p' "${BASH_SOURCE[0]}" | sed 's/^#\{0,1\} \{0,1\}//'
+      sed -n '3,31p' "${BASH_SOURCE[0]}" | sed 's/^#\{0,1\} \{0,1\}//'
       exit 0
       ;;
     *)
@@ -252,6 +298,82 @@ done
 
 if [ "${#INJECTED[@]}" -gt 0 ]; then
   log "Injected fresh secrets: ${INJECTED[*]}"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Randomize infra passwords (DB owner, DB app, S3 secret key).
+#    Only replaces a value if it is still the committed dev placeholder.
+#    The S3 secret key is also written into infra/seaweedfs/s3.json so that
+#    the SeaweedFS auth config and .env always match.
+# ---------------------------------------------------------------------------
+INFRA_INJECTED=()
+for key in "${INFRA_PASSWORD_KEYS[@]}"; do
+  if needs_value "${key}"; then
+    new_pw="$(openssl rand -base64 24 | tr -d '/+=' | head -c 32)"
+    set_env_value "${key}" "${new_pw}"
+    INFRA_INJECTED+=("${key}")
+
+    # Keep DB_PASSWORD (the app-role password used at runtime) in sync with
+    # WPMGR_DB_APP_PASSWORD (the compose/init-script counterpart). Both are set
+    # from the same generated value so neither falls out of step.
+    if [ "${key}" = "WPMGR_DB_APP_PASSWORD" ]; then
+      set_env_value "WPMGR_DB_PASSWORD" "${new_pw}"
+      INFRA_INJECTED+=("WPMGR_DB_PASSWORD")
+    fi
+
+    # Propagate the new S3 secret into infra/seaweedfs/s3.json so SeaweedFS
+    # uses the identical credential. The json file is a simple template with
+    # exactly one "secretKey" field; we update it in-place with sed.
+    if [ "${key}" = "WPMGR_S3_SECRET_KEY" ] && [ -f "${S3_JSON}" ]; then
+      tmp_json="$(mktemp)"
+      esc_pw="$(printf '%s' "${new_pw}" | sed -e 's/[\\&|]/\\&/g')"
+      sed "s|\"secretKey\":.*|\"secretKey\": \"${esc_pw}\"|" "${S3_JSON}" >"${tmp_json}"
+      mv "${tmp_json}" "${S3_JSON}"
+      log "Wrote matching S3 secret to ${S3_JSON}"
+    fi
+  else
+    log "${key} already set to a non-placeholder value — left unchanged"
+  fi
+done
+
+if [ "${#INFRA_INJECTED[@]}" -gt 0 ]; then
+  log "Randomized infra passwords: ${INFRA_INJECTED[*]}"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Set WPMGR_PUBLIC_BASE_URL — prompt interactively if not already set and
+#    no --hostname flag was given.
+# ---------------------------------------------------------------------------
+current_pub="$(current_value WPMGR_PUBLIC_BASE_URL)"
+# Match both the old :8080 placeholder (pre-fix .env.example) and the new :8081.
+placeholder_pub_8080="http://localhost:8080"
+placeholder_pub_8081="http://localhost:8081"
+
+_is_placeholder_pub() {
+  [ -z "${current_pub}" ] \
+    || [ "${current_pub}" = "${placeholder_pub_8080}" ] \
+    || [ "${current_pub}" = "${placeholder_pub_8081}" ]
+}
+
+if [ -n "${HOSTNAME_OVERRIDE}" ]; then
+  set_env_value "WPMGR_PUBLIC_BASE_URL" "${HOSTNAME_OVERRIDE}"
+  log "Set WPMGR_PUBLIC_BASE_URL=${HOSTNAME_OVERRIDE}"
+elif _is_placeholder_pub; then
+  if [ -t 0 ]; then
+    # stdin is a terminal — prompt.
+    printf '\n==> What is the public URL of this control plane?\n'
+    printf '    (Agents use this to reach back; press Enter to keep %s)\n' "${current_pub:-http://localhost:8081}"
+    printf '    URL: '
+    read -r input_pub </dev/tty || true
+    if [ -n "${input_pub}" ] && [ "${input_pub}" != "${placeholder_pub_8081}" ] && [ "${input_pub}" != "${placeholder_pub_8080}" ]; then
+      set_env_value "WPMGR_PUBLIC_BASE_URL" "${input_pub}"
+      log "Set WPMGR_PUBLIC_BASE_URL=${input_pub}"
+    else
+      log "WPMGR_PUBLIC_BASE_URL left at ${current_pub:-http://localhost:8081} — update it before adding real sites"
+    fi
+  else
+    warn "WPMGR_PUBLIC_BASE_URL is '${current_pub}' (localhost). Set it to a URL your agents can reach."
+  fi
 fi
 
 print_next_steps

--- a/scripts/quickstart-selfhost.sh
+++ b/scripts/quickstart-selfhost.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+#
+# WPMgr self-host quickstart — one-shot bootstrap (no repo clone needed).
+#
+# Fetches every file the prod compose stack needs, generates all secrets,
+# and prints the exact command to start WPMgr.
+#
+# Usage (pipe from GitHub raw):
+#   curl -fsSL https://raw.githubusercontent.com/mosamlife/wpmgr/main/scripts/quickstart-selfhost.sh | bash
+#
+# Or, after cloning:
+#   ./scripts/quickstart-selfhost.sh [--hostname=https://wpmgr.example.com]
+#
+# Options:
+#   --hostname=URL   Set WPMGR_PUBLIC_BASE_URL non-interactively.
+#   --version=vX.Y.Z Pin a specific GHCR release tag (default: latest).
+#   --dir=PATH       Write all files into PATH (default: ./wpmgr).
+#   --force          Re-download files even if they already exist.
+#   -h / --help      Show this help.
+#
+# What it does:
+#   1. Creates the working directory (default: ./wpmgr).
+#   2. Downloads every file the compose stack bind-mounts from the host:
+#        infra/docker-compose.yml
+#        infra/docker-compose.prod.yml
+#        infra/seaweedfs/s3.json          <- SeaweedFS S3 auth
+#        infra/dex/config.yaml            <- Dex OIDC provider config
+#        infra/postgres/init/01-app-role.sh  <- Postgres role bootstrap
+#        .env.example
+#        scripts/init-env.sh
+#      The observability-profile files (prometheus.yml, grafana/) are also
+#      downloaded so the --profile observability option works without a clone.
+#   3. Runs scripts/init-env.sh, which:
+#        - copies .env.example -> .env
+#        - generates cryptographic secrets (session, agent signing, age)
+#        - randomises DB passwords and S3 secret, keeping s3.json in sync
+#        - optionally sets WPMGR_PUBLIC_BASE_URL
+#   4. Pins WPMGR_VERSION in .env if --version was given.
+#   5. Prints the exact `docker compose ... up -d` command and verify URLs.
+#
+# Host requirements:
+#   - Docker 24+ with the Compose plugin (docker compose)
+#   - curl or wget  (for downloading files)
+#   - openssl       (for secret generation fallback)
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults.
+# ---------------------------------------------------------------------------
+REPO_RAW="https://raw.githubusercontent.com/mosamlife/wpmgr/main"
+WPMGR_VERSION=""
+WORK_DIR="./wpmgr"
+HOSTNAME_OVERRIDE=""
+FORCE=0
+
+# ---------------------------------------------------------------------------
+# Parse args.
+# ---------------------------------------------------------------------------
+for arg in "$@"; do
+  case "${arg}" in
+    --hostname=*) HOSTNAME_OVERRIDE="${arg#--hostname=}" ;;
+    --version=*)  WPMGR_VERSION="${arg#--version=}" ;;
+    --dir=*)      WORK_DIR="${arg#--dir=}" ;;
+    --force)      FORCE=1 ;;
+    -h|--help)
+      sed -n '3,42p' "${BASH_SOURCE[0]}" | sed 's/^#\{0,1\} \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      printf 'quickstart-selfhost: unknown argument "%s" (try --help)\n' "${arg}" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+log()  { printf '\033[1;32m==>\033[0m %s\n' "$*"; }
+info() { printf '    %s\n' "$*"; }
+warn() { printf '\033[1;33mWARN:\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# fetch_file <relative-path> <destination>
+# Downloads from the repo's raw URL unless the destination already exists (or
+# --force was given).
+fetch_file() {
+  local rel_path="$1" dest="$2"
+  if [ -f "${dest}" ] && [ "${FORCE}" -eq 0 ]; then
+    info "already present: ${dest}"
+    return 0
+  fi
+  local url="${REPO_RAW}/${rel_path}"
+  mkdir -p "$(dirname "${dest}")"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "${url}" -o "${dest}" || die "failed to download ${url}"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "${dest}" "${url}" || die "failed to download ${url}"
+  else
+    die "neither curl nor wget found — install one and re-run."
+  fi
+  info "downloaded: ${dest}"
+}
+
+# set_env_value <key> <value> — portable in-place set in .env.
+set_env_value() {
+  local key="$1" value="$2" tmp esc
+  local env_file="${WORK_DIR}/.env"
+  tmp="$(mktemp)"
+  esc="$(printf '%s' "${value}" | sed -e 's/[\\&|]/\\&/g')"
+  if grep -q "^${key}=" "${env_file}"; then
+    sed "s|^${key}=.*|${key}=${esc}|" "${env_file}" >"${tmp}"
+  else
+    cp "${env_file}" "${tmp}"
+    printf '%s=%s\n' "${key}" "${value}" >>"${tmp}"
+  fi
+  mv "${tmp}" "${env_file}"
+}
+
+# ---------------------------------------------------------------------------
+# 0. Pre-flight checks.
+# ---------------------------------------------------------------------------
+if ! command -v docker >/dev/null 2>&1; then
+  die "docker not found. Install Docker 24+ with the Compose plugin and re-run.\n    See: https://docs.docker.com/engine/install/"
+fi
+if ! docker compose version >/dev/null 2>&1; then
+  die "'docker compose' (Compose plugin v2) not found.\n    Install it: https://docs.docker.com/compose/install/"
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Create working directory and enter it.
+# ---------------------------------------------------------------------------
+mkdir -p "${WORK_DIR}"
+log "Working directory: $(cd "${WORK_DIR}" && pwd)"
+cd "${WORK_DIR}"
+
+# ---------------------------------------------------------------------------
+# 2. Download every file the compose stack needs from the host.
+#
+# COMPLETE manifest — derived by grepping `- ./` bind mounts from both
+# docker-compose.yml and docker-compose.prod.yml:
+#
+#   docker-compose.yml bind mounts (from the infra/ directory context):
+#     ./postgres/init/01-app-role.sh          <- postgres service (always)
+#     ./seaweedfs/s3.json                     <- seaweedfs service (always)
+#     ./dex/config.yaml                       <- dex service (always)
+#     ./prometheus/prometheus.yml             <- otel-lgtm (observability profile)
+#     ./grafana/provisioning/...              <- otel-lgtm (observability profile)
+#     ./grafana/dashboards/...               <- otel-lgtm (observability profile)
+#
+# All base-stack files (postgres init, seaweedfs, dex) are downloaded
+# unconditionally. Observability files are downloaded so the
+# --profile observability option works without further setup.
+# ---------------------------------------------------------------------------
+log "Downloading compose files and config..."
+
+# Compose files (these live at the repo root and one level up from infra/).
+fetch_file "infra/docker-compose.yml"      "infra/docker-compose.yml"
+fetch_file "infra/docker-compose.prod.yml" "infra/docker-compose.prod.yml"
+fetch_file ".env.example"                  ".env.example"
+fetch_file "scripts/init-env.sh"           "scripts/init-env.sh"
+chmod +x "scripts/init-env.sh"
+
+# Postgres init (bind-mount is a directory; only one script today).
+fetch_file "infra/postgres/init/01-app-role.sh" "infra/postgres/init/01-app-role.sh"
+chmod +x "infra/postgres/init/01-app-role.sh"
+
+# SeaweedFS S3 auth config (always required — the compose file hard-mounts it).
+fetch_file "infra/seaweedfs/s3.json" "infra/seaweedfs/s3.json"
+
+# Dex OIDC config (always required — the compose file hard-mounts it).
+fetch_file "infra/dex/config.yaml" "infra/dex/config.yaml"
+
+# Observability profile (opt-in; downloaded so --profile observability works).
+fetch_file "infra/prometheus/prometheus.yml"                                  "infra/prometheus/prometheus.yml"
+fetch_file "infra/grafana/provisioning/dashboards/dashboards.yml"             "infra/grafana/provisioning/dashboards/dashboards.yml"
+fetch_file "infra/grafana/provisioning/datasources/datasources.yml"           "infra/grafana/provisioning/datasources/datasources.yml"
+fetch_file "infra/grafana/dashboards/wpmgr-api.json"                          "infra/grafana/dashboards/wpmgr-api.json"
+
+log "All required files present."
+
+# ---------------------------------------------------------------------------
+# 3. Bootstrap the .env — copies .env.example -> .env and generates secrets.
+#    Pass --hostname= through so init-env.sh can set WPMGR_PUBLIC_BASE_URL
+#    non-interactively.
+# ---------------------------------------------------------------------------
+log "Running init-env.sh to generate secrets and randomize passwords..."
+hostname_flag=""
+[ -n "${HOSTNAME_OVERRIDE}" ] && hostname_flag="--hostname=${HOSTNAME_OVERRIDE}"
+
+# init-env.sh resolves paths relative to the repo root (the directory that
+# contains scripts/). When running from a downloaded copy, that root is the
+# current working directory.
+bash scripts/init-env.sh ${hostname_flag:+"${hostname_flag}"}
+
+# ---------------------------------------------------------------------------
+# 4. Pin WPMGR_VERSION if --version was given.
+# ---------------------------------------------------------------------------
+if [ -n "${WPMGR_VERSION}" ]; then
+  set_env_value "WPMGR_VERSION" "${WPMGR_VERSION}"
+  log "Pinned WPMGR_VERSION=${WPMGR_VERSION} in .env"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Read back final port values for the summary.
+# ---------------------------------------------------------------------------
+# Source only the port vars we need; avoid eval of arbitrary .env content.
+api_port="$(grep '^WPMGR_API_PORT=' .env | head -n1 | cut -d= -f2-)"
+web_port="$(grep '^WPMGR_WEB_PORT=' .env | head -n1 | cut -d= -f2-)"
+api_port="${api_port:-8081}"
+web_port="${web_port:-8088}"
+ver_tag="${WPMGR_VERSION:-latest}"
+
+# ---------------------------------------------------------------------------
+# 6. Final instructions.
+# ---------------------------------------------------------------------------
+cat <<EOF
+
+${WPMGR_HEADER:-}
+WPMgr is ready to start. Run:
+
+  cd $(pwd)
+  docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
+
+To use the media optimizer (image encoding to WebP/AVIF), add --profile media:
+  docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml --profile media up -d
+
+Verify:
+  curl localhost:${api_port}/healthz    # {"status":"ok"}
+  curl localhost:${api_port}/readyz     # 200 once DB/Redis/S3 are ready
+
+Open the dashboard at:
+  http://localhost:${web_port}
+
+IMPORTANT:
+  - WPMGR_S3_ENDPOINT in .env must be a URL reachable by your WordPress hosts.
+    The default (http://seaweedfs:8333) only resolves inside Docker. For remote
+    WordPress sites, set it to a tunnel/public URL.
+  - Review docs/install.md for the full self-host guide.
+
+EOF


### PR DESCRIPTION
Fixes the self-host prod-images first-run reported in #107 and #108: a new no-clone one-shot bootstrap (`scripts/quickstart-selfhost.sh`) that fetches every host-mounted config file (the missing seaweedfs/s3.json + dex/config.yaml + postgres role-init were what broke dex/seaweedfs healthchecks and restart-looped the api), randomized DB/S3 passwords in init-env.sh, corrected host-facing ports (stale 8080 to 8081/8088) with a container-vs-host note, longer SeaweedFS start_period + a real ClickHouse readiness probe, and a clone-free Quickstart in install.md. Config/scripts/docs only, no image change. The '/admin only after login' tail of #108 was already fixed by #100 in v0.61.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a quickstart script to simplify self-hosted deployment with configurable hostname, version, and installation directory.
  * Enhanced secret and password generation with automatic randomization during setup.

* **Documentation**
  * Expanded installation guide with clearer setup instructions, port disambiguation, and verification steps.
  * Improved configuration examples and environment variable guidance.

* **Chores**
  * Updated port configurations for consistency across API and dashboard services.
  * Enhanced bootstrap scripts with improved configuration flags and credential management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->