### PR TITLE
fix(backups): #117 gated-loopback + #116 orphaned manifest + #114 upcoming copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,11 +147,11 @@ agent-zip: agent-vendor ## Package the WordPress agent plugin as a zip (with ifs
 	@echo "agent zip: $$(du -sh release/wpmgr-agent.zip | cut -f1)"
 
 .PHONY: agent-zip-wporg
-agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip (fleet-agent-for-wpmgr identity; self-hosted identity untouched)
+agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip (fleet-agent-site-manager identity; self-hosted identity untouched)
 	mkdir -p release
-	rm -f release/fleet-agent-for-wpmgr.zip
-	rm -rf release/fleet-agent-for-wpmgr
-	# Stage under fleet-agent-for-wpmgr/ — the permanent wp.org slug. The self-updater
+	rm -f release/fleet-agent-site-manager.zip
+	rm -rf release/fleet-agent-site-manager
+	# Stage under fleet-agent-site-manager/ — the permanent wp.org slug. The self-updater
 	# (class-update-checker.php) is physically excluded so PCP cannot match the
 	# site_transient_update_plugins hook (B2 / G8). NOTICE.md and README.md are
 	# excluded because wp.org rejects unexpected Markdown files (B4 / C8).
@@ -162,28 +162,33 @@ agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip (fl
 	# agent). vendor/*/LICENSE files are excluded because wp.org flags them as
 	# unexpected non-code files; the library licences are already referenced in the
 	# plugin's own LICENSE / readme.txt.
+	# composer.json is excluded because vendor is pre-built; it is not needed at runtime.
+	# vendor/**/data-scripts/ and *.py files are excluded because wp.org does not
+	# permit build tooling scripts (e.g. bjeavons/zxcvbn-php/data-scripts/build_*.py).
 	rsync -a --delete \
 		--exclude 'tests/' --exclude 'tests-e2e/' --exclude 'tools/' --exclude '*.dist' --exclude '.phpunit.cache/' \
-		--exclude '.phpunit.result.cache' --exclude 'composer.lock' \
+		--exclude '.phpunit.result.cache' --exclude 'composer.lock' --exclude 'composer.json' \
 		--exclude '.DS_Store' --exclude '*.zip' \
 		--exclude '.distignore' --exclude '.gitignore' --exclude '.gitattributes' \
 		--exclude 'phpstan.neon' --exclude 'phpstan-baseline.neon' \
 		--exclude 'NOTICE.md' --exclude 'README.md' \
 		--exclude 'patchwork.json' \
 		--exclude 'includes/support/class-update-checker.php' \
-		apps/agent/ release/fleet-agent-for-wpmgr/
-	# Remove CLI entrypoints and LICENSE files that wp.org does not permit.
-	# rsync --exclude patterns for vendor/*/bin/ do not recurse into arbitrary
-	# depth (e.g. vendor/matthiasmullie/minify/bin/ is 3 levels deep), so a
-	# post-stage find+delete is more reliable than path-based excludes.
-	find release/fleet-agent-for-wpmgr/vendor/bin -mindepth 0 -maxdepth 0 -type d -exec rm -rf {} + 2>/dev/null || true
-	find release/fleet-agent-for-wpmgr/vendor -mindepth 2 -type d -name bin -exec rm -rf {} + 2>/dev/null || true
-	find release/fleet-agent-for-wpmgr/vendor -mindepth 2 -type f -name LICENSE -delete 2>/dev/null || true
+		apps/agent/ release/fleet-agent-site-manager/
+	# Remove CLI entrypoints, LICENSE files, data-scripts dirs, and Python files
+	# that wp.org does not permit. rsync --exclude patterns for vendor/*/bin/ do not
+	# recurse into arbitrary depth (e.g. vendor/matthiasmullie/minify/bin/ is 3 levels
+	# deep), so a post-stage find+delete is more reliable than path-based excludes.
+	find release/fleet-agent-site-manager/vendor/bin -mindepth 0 -maxdepth 0 -type d -exec rm -rf {} + 2>/dev/null || true
+	find release/fleet-agent-site-manager/vendor -mindepth 2 -type d -name bin -exec rm -rf {} + 2>/dev/null || true
+	find release/fleet-agent-site-manager/vendor -mindepth 2 -type f -name LICENSE -delete 2>/dev/null || true
+	find release/fleet-agent-site-manager/vendor -type d -name data-scripts -exec rm -rf {} + 2>/dev/null || true
+	find release/fleet-agent-site-manager/vendor -type f -name "*.py" -delete 2>/dev/null || true
 	# Rename the main plugin file to match the wp.org slug. WordPress derives the
 	# plugin's displayed name, slug, and update identity from the top-level .php
 	# filename inside the archive folder — renaming is mandatory for the wp.org slug.
-	mv release/fleet-agent-for-wpmgr/wpmgr-agent.php \
-		release/fleet-agent-for-wpmgr/fleet-agent-for-wpmgr.php
+	mv release/fleet-agent-site-manager/wpmgr-agent.php \
+		release/fleet-agent-site-manager/fleet-agent-site-manager.php
 	# VERSION override: same mechanism as agent-zip — stamp ONLY the staged copy.
 	# Two lines: the plugin header "Version:" and the WPMGR_AGENT_VERSION constant.
 	@if [ -n "$(VERSION)" ]; then \
@@ -198,29 +203,29 @@ agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip (fl
 		esac; \
 		_v_esc=$$(printf '%s' "$$_v" | sed -e 's/[\/&|]/\\&/g'); \
 		echo "agent-zip-wporg: stamping staged copy with version $$_v"; \
-		sed -i.bak -E "s/^( \* Version:[ \t]+)[0-9]+\.[0-9]+\.[0-9].*/\1$$_v_esc/" release/fleet-agent-for-wpmgr/fleet-agent-for-wpmgr.php; \
-		sed -i.bak -E "s/^(define\('WPMGR_AGENT_VERSION', *')[^']+(')/\1$$_v_esc\2/" release/fleet-agent-for-wpmgr/fleet-agent-for-wpmgr.php; \
-		rm -f release/fleet-agent-for-wpmgr/fleet-agent-for-wpmgr.php.bak; \
+		sed -i.bak -E "s/^( \* Version:[ \t]+)[0-9]+\.[0-9]+\.[0-9].*/\1$$_v_esc/" release/fleet-agent-site-manager/fleet-agent-site-manager.php; \
+		sed -i.bak -E "s/^(define\('WPMGR_AGENT_VERSION', *')[^']+(')/\1$$_v_esc\2/" release/fleet-agent-site-manager/fleet-agent-site-manager.php; \
+		rm -f release/fleet-agent-site-manager/fleet-agent-site-manager.php.bak; \
 	fi
 	# Stamp readme.txt Stable tag to match the plugin header Version. Mirrors the
 	# VERSION block above; reads the stamped Version from the staged main file so
 	# the two values always agree regardless of the VERSION variable.
-	@_stamped_v=$$(grep -E '^ \* Version:' release/fleet-agent-for-wpmgr/fleet-agent-for-wpmgr.php | sed -E 's/.*Version:[ \t]+//'); \
+	@_stamped_v=$$(grep -E '^ \* Version:' release/fleet-agent-site-manager/fleet-agent-site-manager.php | sed -E 's/.*Version:[ \t]+//'); \
 	echo "agent-zip-wporg: stamping readme.txt Stable tag: $$_stamped_v"; \
-	sed -i.bak -E "s/^(Stable tag:[ \t]+).*/\1$$_stamped_v/" release/fleet-agent-for-wpmgr/readme.txt; \
-	rm -f release/fleet-agent-for-wpmgr/readme.txt.bak
+	sed -i.bak -E "s/^(Stable tag:[ \t]+).*/\1$$_stamped_v/" release/fleet-agent-site-manager/readme.txt; \
+	rm -f release/fleet-agent-site-manager/readme.txt.bak
 	# Rewrite plugin-identity header fields in the staged main file:
-	#   Plugin Name  -> Fleet Agent for WPMgr   (B1 slug compliance)
-	#   License      -> GPLv2 or later           (§3 recommended posture)
-	#   License URI  -> gnu.org GPL-2.0 URL      (§3)
-	#   Text Domain  -> fleet-agent-for-wpmgr    (matches new slug)
+	#   Plugin Name  -> Fleet Agent Site Manager  (reviewer-accepted display name; no "WP" prefix)
+	#   License      -> GPLv2 or later            (§3 recommended posture)
+	#   License URI  -> gnu.org GPL-2.0 URL       (§3)
+	#   Text Domain  -> fleet-agent-site-manager  (matches new slug)
 	sed -i.bak \
-		-e "s|^ \* Plugin Name:.*| * Plugin Name:       Fleet Agent for WPMgr|" \
+		-e "s|^ \* Plugin Name:.*| * Plugin Name:       Fleet Agent Site Manager|" \
 		-e "s|^ \* License:.*| * License:           GPLv2 or later|" \
 		-e "s|^ \* License URI:.*| * License URI:       https://www.gnu.org/licenses/gpl-2.0.html|" \
-		-e "s|^ \* Text Domain:.*| * Text Domain:       fleet-agent-for-wpmgr|" \
-		release/fleet-agent-for-wpmgr/fleet-agent-for-wpmgr.php
-	rm -f release/fleet-agent-for-wpmgr/fleet-agent-for-wpmgr.php.bak
+		-e "s|^ \* Text Domain:.*| * Text Domain:       fleet-agent-site-manager|" \
+		release/fleet-agent-site-manager/fleet-agent-site-manager.php
+	rm -f release/fleet-agent-site-manager/fleet-agent-site-manager.php.bak
 	# Inject the WPMGR_WPORG_BUILD constant immediately after the WPMGR_AGENT_VERSION
 	# define line. This guards the self-updater boot hook (class-plugin.php:522) so
 	# it never binds in the wp.org build, satisfying G8 / B2 (the file exclusion
@@ -228,26 +233,26 @@ agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip (fl
 	# Use awk to insert the line immediately after the WPMGR_AGENT_VERSION define,
 	# avoiding the multi-line sed /a\ syntax which is non-portable across BSD/GNU sed.
 	awk "/^define\('WPMGR_AGENT_VERSION',/{print; print \"define('WPMGR_WPORG_BUILD', true);\"; next}1" \
-		release/fleet-agent-for-wpmgr/fleet-agent-for-wpmgr.php \
-		> release/fleet-agent-for-wpmgr/fleet-agent-for-wpmgr.php.tmp
-	mv release/fleet-agent-for-wpmgr/fleet-agent-for-wpmgr.php.tmp \
-		release/fleet-agent-for-wpmgr/fleet-agent-for-wpmgr.php
-	# Rewrite the text-domain literal 'wpmgr-agent' -> 'fleet-agent-for-wpmgr' across
+		release/fleet-agent-site-manager/fleet-agent-site-manager.php \
+		> release/fleet-agent-site-manager/fleet-agent-site-manager.php.tmp
+	mv release/fleet-agent-site-manager/fleet-agent-site-manager.php.tmp \
+		release/fleet-agent-site-manager/fleet-agent-site-manager.php
+	# Rewrite the text-domain literal 'wpmgr-agent' -> 'fleet-agent-site-manager' across
 	# all staged PHP files. This covers both __()/__e() text-domain args AND the
 	# plugin-identity constants (PAGE_SLUG, exclude-dir lists) that reference the
-	# plugin folder name — in the wp.org install the folder IS fleet-agent-for-wpmgr,
+	# plugin folder name — in the wp.org install the folder IS fleet-agent-site-manager,
 	# so all references must agree. class-update-checker.php is already excluded above
 	# and is never present in the staged tree.
 	# GREP FIRST — surface every occurrence so the caller can audit non-text-domain hits.
 	@echo "--- grep of 'wpmgr-agent' in staged tree (before rewrite) ---"; \
-	grep -rn "'wpmgr-agent'" release/fleet-agent-for-wpmgr/ --include="*.php" || true; \
+	grep -rn "'wpmgr-agent'" release/fleet-agent-site-manager/ --include="*.php" || true; \
 	echo "--- end grep ---"
-	find release/fleet-agent-for-wpmgr -name "*.php" -print0 | \
-		xargs -0 sed -i.bak "s/'wpmgr-agent'/'fleet-agent-for-wpmgr'/g"
-	find release/fleet-agent-for-wpmgr -name "*.php.bak" -delete
-	cd release && zip -r fleet-agent-for-wpmgr.zip fleet-agent-for-wpmgr
-	rm -rf release/fleet-agent-for-wpmgr
-	@echo "agent wporg zip: $$(du -sh release/fleet-agent-for-wpmgr.zip | cut -f1)"
+	find release/fleet-agent-site-manager -name "*.php" -print0 | \
+		xargs -0 sed -i.bak "s/'wpmgr-agent'/'fleet-agent-site-manager'/g"
+	find release/fleet-agent-site-manager -name "*.php.bak" -delete
+	cd release && zip -r fleet-agent-site-manager.zip fleet-agent-site-manager
+	rm -rf release/fleet-agent-site-manager
+	@echo "agent wporg zip: $$(du -sh release/fleet-agent-site-manager.zip | cut -f1)"
 
 .PHONY: agent-check
 agent-check: ## Fast phpcs pass over apps/agent (committed phpcs.xml.dist). NOT the authoritative gate.
@@ -262,9 +267,9 @@ agent-format: ## phpcbf auto-fix over apps/agent, then re-lint
 
 .PHONY: agent-plugincheck
 agent-plugincheck: agent-zip-wporg ## AUTHORITATIVE: `wp plugin check` on real WordPress via Docker (mariadb + wordpress:cli)
-	# Always tests the wp.org-identity build (fleet-agent-for-wpmgr) so the META
+	# Always tests the wp.org-identity build (fleet-agent-site-manager) so the META
 	# trademark/updater/readme checks key off the right slug. Exits non-zero on any ERROR row.
-	cd tools/plugincheck && PLUGIN_ZIP="$(PWD)/release/fleet-agent-for-wpmgr.zip" ./run.sh
+	cd tools/plugincheck && PLUGIN_ZIP="$(PWD)/release/fleet-agent-site-manager.zip" ./run.sh
 
 .PHONY: agent-e2e-objectcache
 agent-e2e-objectcache: agent-zip ## Run the object-cache E2E harness (Docker; Redis + WordPress + phpredis)
@@ -273,7 +278,7 @@ agent-e2e-objectcache: agent-zip ## Run the object-cache E2E harness (Docker; Re
 	# freshness guard → cron-check → negative-check → disable.
 	# Requires Docker. PLUGIN_ZIP can be overridden; defaults to the wporg build.
 	chmod +x apps/agent/tests-e2e/run.sh
-	PLUGIN_ZIP="$(PWD)/release/fleet-agent-for-wpmgr.zip" apps/agent/tests-e2e/run.sh
+	PLUGIN_ZIP="$(PWD)/release/fleet-agent-site-manager.zip" apps/agent/tests-e2e/run.sh
 
 .PHONY: agent-release
 agent-release: agent-zip ## Publish the agent release (zip + latest.json) to object storage for CP-driven self-update (ADR-042)

--- a/Makefile
+++ b/Makefile
@@ -162,12 +162,13 @@ agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip (fl
 	# agent). vendor/*/LICENSE files are excluded because wp.org flags them as
 	# unexpected non-code files; the library licences are already referenced in the
 	# plugin's own LICENSE / readme.txt.
-	# composer.json is excluded because vendor is pre-built; it is not needed at runtime.
 	# vendor/**/data-scripts/ and *.py files are excluded because wp.org does not
 	# permit build tooling scripts (e.g. bjeavons/zxcvbn-php/data-scripts/build_*.py).
+	# composer.json ships with vendor/ so Plugin Check does not warn about a vendored
+	# directory without a composer.json. composer.lock is excluded (not needed at runtime).
 	rsync -a --delete \
 		--exclude 'tests/' --exclude 'tests-e2e/' --exclude 'tools/' --exclude '*.dist' --exclude '.phpunit.cache/' \
-		--exclude '.phpunit.result.cache' --exclude 'composer.lock' --exclude 'composer.json' \
+		--exclude '.phpunit.result.cache' --exclude 'composer.lock' \
 		--exclude '.DS_Store' --exclude '*.zip' \
 		--exclude '.distignore' --exclude '.gitignore' --exclude '.gitattributes' \
 		--exclude 'phpstan.neon' --exclude 'phpstan-baseline.neon' \

--- a/apps/agent/.distignore
+++ b/apps/agent/.distignore
@@ -27,9 +27,6 @@ includes/support/class-update-checker.php
 NOTICE.md
 README.md
 
-# composer.json — vendor is pre-built; not needed at runtime.
-composer.json
-
 # Vendor CLI entrypoints — not permitted by wp.org; not used at runtime
 # (matthiasmullie/minify is called via its PHP API only, never via the CLI bin scripts).
 vendor/bin/

--- a/apps/agent/.distignore
+++ b/apps/agent/.distignore
@@ -1,8 +1,9 @@
 # .distignore — files and directories excluded from all distribution zips.
-# Kept in sync with the rsync --exclude flags in:
+# NOTE: the Makefile agent-zip-wporg target is the authoritative packaging path;
+# this file is informational for tooling (e.g. wp-cli dist-archive) and serves
+# as a canonical reference for what must NOT ship in either zip.
+# Kept in sync with the rsync --exclude flags and post-stage find+delete steps in:
 #   Makefile: agent-zip (self-host) and agent-zip-wporg (wp.org build).
-# This file is informational for tooling (e.g. wp-cli dist-archive) and serves
-# as the canonical reference for what must NOT ship in either zip.
 
 # Dev / test infrastructure
 tests/
@@ -26,6 +27,9 @@ includes/support/class-update-checker.php
 NOTICE.md
 README.md
 
+# composer.json — vendor is pre-built; not needed at runtime.
+composer.json
+
 # Vendor CLI entrypoints — not permitted by wp.org; not used at runtime
 # (matthiasmullie/minify is called via its PHP API only, never via the CLI bin scripts).
 vendor/bin/
@@ -34,3 +38,9 @@ vendor/*/bin/
 # Vendor LICENSE files — flagged by wp.org as unexpected non-code files.
 # Library licences are referenced in the plugin's own LICENSE / readme.txt.
 vendor/*/LICENSE
+
+# Vendor data-scripts directories and Python build tooling — not permitted by wp.org
+# (e.g. bjeavons/zxcvbn-php/data-scripts/build_*.py). Removed by post-stage
+# find+delete in the Makefile agent-zip-wporg target.
+vendor/**/data-scripts/
+*.py

--- a/apps/agent/includes/backup/class-files-restorer.php
+++ b/apps/agent/includes/backup/class-files-restorer.php
@@ -617,13 +617,16 @@ final class FilesRestorer
         if (!defined('WP_CONTENT_DIR')) {
             return;
         }
-        // The old-files dirs live as siblings of the directory we replaced
-        // (typically wp-content/). We sweep both wp-content's parent AND
-        // wp-content itself, since we might have staged either one.
-        $candidates = [
+        // The old-files dirs live as siblings of the directory we replaced.
+        // We sweep: ABSPATH (the canonical WP root, works even on relocated
+        // wp-content installs), dirname(WP_CONTENT_DIR) (equals ABSPATH on
+        // standard installs; differs when wp-content is relocated), and
+        // WP_CONTENT_DIR itself (for any dirs staged one level inside wp-content).
+        $candidates = array_unique([
+            defined('ABSPATH') ? rtrim((string) constant('ABSPATH'), '/\\') : '',
             dirname(WP_CONTENT_DIR),
             WP_CONTENT_DIR,
-        ];
+        ]);
         $now       = time();
         $threshold = self::OLDFILES_GC_AGE_SECONDS_LONG;
         foreach ($candidates as $dir) {

--- a/apps/agent/includes/backup/class-watchdog.php
+++ b/apps/agent/includes/backup/class-watchdog.php
@@ -162,9 +162,22 @@ final class Watchdog
             // bookkeeping does this normally; doing it here too is
             // defensive (the runner might be wedged in a way we can't
             // re-enter).
+            //
+            // If the task never left the `queued` phase (phase=queued AND
+            // resume_count already at max), the runner was never dispatched
+            // at all — strong signal that both the spawn_cron loopback and
+            // the in-process fallback failed to start the runner. Detect the
+            // loopback-gate scenario and surface a clear, actionable reason.
+            $failureReason = self::detectQueuedStallReason($phase, $snapshotId);
             // @phpstan-ignore-next-line
-            @$wpdb->update($table, ['phase' => TaskRunner::PHASE_FAILED, 'last_progress_at' => time()], ['snapshot_id' => $snapshotId], ['%s', '%d'], ['%s']); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct update on plugin-owned table; correctness requires a live write
-            DebugLog::write(sprintf('WPMgr Backup: snapshot %s exhausted %d resume attempts; marked failed', $snapshotId, $maxResumes));
+            @$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct update on plugin-owned table; correctness requires a live write
+                $table,
+                ['phase' => TaskRunner::PHASE_FAILED, 'last_progress_at' => time(), 'sub_state' => (string) wp_json_encode(['reason_code' => 'stalled', 'phase_detail' => ['message' => $failureReason]])],
+                ['snapshot_id' => $snapshotId],
+                ['%s', '%d', '%s'],
+                ['%s']
+            );
+            DebugLog::write(sprintf('WPMgr Backup: snapshot %s exhausted %d resume attempts; marked failed. %s', $snapshotId, $maxResumes, $failureReason));
             return;
         }
 
@@ -290,6 +303,83 @@ final class Watchdog
             return;
         }
         wp_schedule_single_event(time() + max(1, $delay), self::HOOK, [$snapshotId]);
+    }
+
+    /**
+     * When a task stalls in the `queued` phase (the runner was never
+     * dispatched at all), probe the wp-cron loopback URL to determine
+     * whether a membership or privacy gate is the likely cause.
+     *
+     * Returns an actionable human-readable message for the failure reason
+     * that is stored on the task row and surfaced to the operator via the
+     * CP dashboard.
+     *
+     * The probe uses `wp_remote_get` with `redirection=0` so a single
+     * HTTP redirect is the definitive gate signal (same logic as
+     * BackupCommand::isLoopbackGated, but from the watchdog context to
+     * cover the case where the in-process fallback also failed — e.g. on
+     * CLI-cron driven sites where PHP's shutdown-function route is also
+     * unreliable).
+     *
+     * @param string $phase      Current task phase (used to decide whether to probe).
+     * @param string $snapshotId Snapshot id (logged for traceability).
+     * @return string Failure reason message.
+     */
+    private static function detectQueuedStallReason(string $phase, string $snapshotId): string
+    {
+        $generic = 'backup runner was never dispatched (stalled in queued phase with no progress)';
+
+        // Only add loopback-gate detail when the task never left queued
+        // (a stall in a later phase has a different root cause).
+        if ($phase !== TaskRunner::PHASE_QUEUED) {
+            return $generic;
+        }
+
+        if (!function_exists('wp_remote_get') || !function_exists('site_url')) {
+            return $generic;
+        }
+
+        $cronUrl = (string) site_url('/wp-cron.php');
+        if ($cronUrl === '' || $cronUrl === '/wp-cron.php') {
+            return $generic;
+        }
+
+        $response = wp_remote_get(
+            $cronUrl,
+            [
+                'timeout'     => 3,
+                'redirection' => 0,
+                'sslverify'   => false,
+                'blocking'    => true,
+                'user-agent'  => 'WPMgr-Agent/Watchdog',
+            ]
+        );
+
+        if (is_wp_error($response)) {
+            return sprintf(
+                'backup runner was never dispatched — the WordPress cron loopback URL (%s) could not be reached (%s); verify that the site can make HTTP requests to itself',
+                esc_url_raw($cronUrl),
+                $response->get_error_message()
+            );
+        }
+
+        $code = (int) wp_remote_retrieve_response_code($response);
+        if ($code >= 300 && $code < 400) {
+            $location = wp_remote_retrieve_header($response, 'location');
+            DebugLog::write(sprintf(
+                'WPMgr Backup Watchdog: loopback probe for snapshot %s returned %d (location: %s) — site appears to be behind a membership/privacy gate',
+                $snapshotId,
+                $code,
+                is_string($location) ? $location : '(unknown)'
+            ));
+            return sprintf(
+                'backup continuation request was redirected to a login page (HTTP %d) — the site appears to be behind a membership or privacy gate that blocks WordPress cron loopback requests to %s; scheduled backups cannot run until the gate allows /wp-cron.php through unauthenticated, or until the WPMgr agent cron loopback is whitelisted in the membership plugin settings',
+                $code,
+                esc_url_raw($cronUrl)
+            );
+        }
+
+        return $generic;
     }
 
     /** Best-effort JSON decode. Returns [] on any failure. */

--- a/apps/agent/includes/commands/class-autologin-command.php
+++ b/apps/agent/includes/commands/class-autologin-command.php
@@ -575,9 +575,9 @@ class AutologinCommand implements CommandInterface
     {
         if (defined('WP_PLUGIN_DIR')) {
             $dir = (string) WP_PLUGIN_DIR;
-        } elseif (defined('WP_CONTENT_DIR')) {
-            $dir = ((string) WP_CONTENT_DIR) . '/plugins';
         } else {
+            // WP_PLUGIN_DIR is always defined in a real WP load; bail rather than
+            // guessing a path that may be wrong on relocated-content installs.
             $dir = '';
         }
 

--- a/apps/agent/includes/commands/class-backup-command.php
+++ b/apps/agent/includes/commands/class-backup-command.php
@@ -42,6 +42,7 @@ use WPMgr\Agent\Backup\TaskRunner;
 use WPMgr\Agent\Backup\Watchdog;
 use WPMgr\Agent\Schema;
 use WPMgr\Agent\Support\AgeIdentity;
+use WPMgr\Agent\Support\DebugLog;
 
 /**
  * Accepts a `backup` command from the CP, seeds the task row, and drives
@@ -260,73 +261,73 @@ final class BackupCommand implements CommandInterface
         // --- 5. Schedule the watchdog cron event --------------------------
         Watchdog::schedule($snapshotId, Watchdog::RESCHEDULE_SECONDS);
 
-        // --- 6. Release the HTTP response, then continue working ----------
+        // --- 6. Trigger the backup runner ---------------------------------
         //
-        // Pattern: register a shutdown function that flushes the response and
-        // does the heavy work AFTER PHP has sent the body. Why this matters:
+        // Strategy: probe the wp-cron loopback URL (a lightweight HEAD/GET
+        // with no redirect-following) to detect whether the front-end is
+        // gated by a membership or privacy plugin. On gated sites every
+        // request to /wp-cron.php returns a 3xx redirect to a login page,
+        // which means spawn_cron() dispatches the backup event to a cron
+        // worker that immediately redirects away and never runs TaskRunner.
+        // The result is an empty run dir (no environment.json) and a
+        // "no progress for >2m0s" watchdog stall.
         //
-        //   - WordPress REST framework runs my execute() inside a nested
-        //     output buffer. Anything I echo here goes into WP's buffer,
-        //     NOT directly to FPM. Calling fastcgi_finish_request()
-        //     immediately + exit() leaves the buffer unflushed — the
-        //     client sees no body, openresty waits for upstream, fires a
-        //     60s 504 Gateway Timeout, the CP retries, the agent's dedup
-        //     correctly refuses the retry, snapshot marked failed.
-        //     (Exactly what we saw on the first files-backup attempt:
-        //     27f20756-…, 1.5 GB archived but snapshot=failed because the
-        //     CP never got the ACK.)
+        // Detected gates: HTTP 3xx status, WP_Error (DNS/connect failure).
+        // When the loopback IS accessible (2xx / 4xx / 5xx — anything that
+        // is NOT a redirect), spawn_cron() is used as before (the separate-
+        // FPM-worker approach that fixed the 1panel/openresty FCGI timeout).
         //
-        //   - With register_shutdown_function: I return the ACK normally,
-        //     WP REST builds the WP_REST_Response, WP closes all the
-        //     output buffers cleanly, the response goes to FPM, FPM
-        //     responds to nginx/openresty/Cloudflare, the client sees a
-        //     fast 200. Only THEN PHP runs shutdown handlers. Inside the
-        //     handler we call fastcgi_finish_request() (defensive — most
-        //     of the close already happened) and then TaskRunner.
+        // When the loopback is gated, we fall back to in-process execution:
+        //   1. Register a PHP shutdown handler (fires after execute() returns
+        //      and WP REST flushes the response body to FPM).
+        //   2. The handler calls fastcgi_finish_request() (defensive — WP has
+        //      already closed its output buffers at this point) then runs
+        //      TaskRunner::run() directly in the same PHP process.
+        //   3. execute() returns the ACK normally. The CP sees 200 < 1 s.
+        //   4. The FPM worker runs the backup while the FCGI connection is
+        //      closed (fastcgi_finish_request). On hosts where
+        //      fastcgi_finish_request does not fully close the upstream
+        //      connection, ignore_user_abort(true) + set_time_limit(0)
+        //      ensure the runner is not killed mid-backup.
         //
-        //   - This is the standard pattern for long-running WP cron tasks
-        //     that works on every FPM-based WP host.
-        //
-        // On non-FPM SAPIs (mod_php, cli-server) the shutdown function
-        // still fires but fastcgi_finish_request doesn't exist; the work
-        // runs synchronously and the CP's 10-min HTTPTimeout accommodates.
-        // --- 6. Decouple the work into a SEPARATE FPM request ----------
-        //
-        // We learned the hard way (v0.7.4-dev + v0.7.5-dev) that
-        // `register_shutdown_function` + `fastcgi_finish_request` does NOT
-        // reliably release the FCGI response on 1panel's openresty config.
-        // The script keeps the FCGI connection alive while TaskRunner runs,
-        // openresty's 60 s upstream-timeout fires, the CP sees 504 (or
-        // HTTP/2 INTERNAL_ERROR over Cloudflare), River retries, the agent
-        // dedup refuses the retry → snapshot marked failed even though the
-        // runner is happily archiving in the background.
-        //
-        // The bulletproof fix: hand the work off
-        // to a SEPARATE FPM request entirely.
-        //
-        //   1. Schedule the cron event for now (`time()`) bound to
-        //      'wpmgr_backup_run' with the snapshot_id as the sole arg.
-        //   2. Call `spawn_cron()` — WordPress's built-in loopback that
-        //      makes a non-blocking wp_remote_post to /wp-cron.php on this
-        //      same site. The loopback IS the trigger; it returns
-        //      immediately without waiting for cron to actually run.
-        //   3. Return ACK. The REST request exits cleanly in ms — no
-        //      pending shutdown work, no buffer drama, no upstream timeout.
-        //   4. /wp-cron.php fires in a fresh FPM worker, picks up our
-        //      scheduled event, calls the 'wpmgr_backup_run' handler,
-        //      which dispatches TaskRunner. THIS worker can run for
-        //      minutes without affecting the original REST request.
-        //
-        // The watchdog (`wpmgr_backup_watchdog`, scheduled at +120s
-        // above) remains the recovery net if the cron worker also dies
-        // mid-run — it re-enters from `sub_state` via `TaskRunner::run`.
+        // Note: spawn_cron() is still called even on gated sites as a belt-
+        // and-suspenders measure — it costs nothing if the loopback is gated
+        // and acts as a secondary trigger in case the in-process path is also
+        // unreliable on an unusual SAPI configuration.
         if (function_exists('wp_schedule_single_event')) {
             wp_schedule_single_event(time(), 'wpmgr_backup_run', [$snapshotId]);
         }
-        // spawn_cron lives in wp-includes/cron.php; available wherever wp-load
-        // has run (which is always, in a REST request).
+
+        $loopbackGated = $this->isLoopbackGated();
+        if ($loopbackGated) {
+            // Loopback is gated: run TaskRunner in-process after the ACK
+            // is sent. Capture the params in a local variable so the closure
+            // does not hold a reference to $this (which would keep the entire
+            // BackupCommand object alive through the shutdown chain).
+            $shutdownParams = $runnerParams;
+            register_shutdown_function(static function () use ($shutdownParams): void {
+                // fastcgi_finish_request() is only available under PHP-FPM.
+                // Call it defensively: WP has already closed its own output
+                // buffers before shutdown handlers run, so the response was
+                // most likely already sent. This is a belt-and-suspenders flush.
+                if (function_exists('fastcgi_finish_request')) {
+                    fastcgi_finish_request(); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- intentional early-flush of the FCGI connection so the CP receives the ACK before TaskRunner runs
+                }
+                @set_time_limit(0); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup runner must not hit max_execution_time; @-guarded
+                @ignore_user_abort(true);
+                try {
+                    (new TaskRunner($shutdownParams))->run();
+                } catch (\Throwable $e) {
+                    \WPMgr\Agent\Support\DebugLog::write('WPMgr Backup: in-process runner fatal: ' . $e->getMessage());
+                }
+            });
+        }
+
+        // Always fire spawn_cron: on non-gated sites it is the primary
+        // trigger; on gated sites it is a no-op (the loopback redirects
+        // away) but the in-process shutdown above covers the gap.
         if (function_exists('spawn_cron')) {
-            @spawn_cron();
+            @spawn_cron(); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- spawn_cron may emit a harmless notice when DISABLE_WP_CRON is set; @-suppressed intentionally
         }
 
         return ['ok' => true, 'detail' => 'accepted'];
@@ -446,6 +447,81 @@ final class BackupCommand implements CommandInterface
             'name'     => defined('DB_NAME') ? (string) DB_NAME : '',
             'prefix'   => is_object($wpdb) && isset($wpdb->prefix) ? (string) $wpdb->prefix : 'wp_',
         ];
+    }
+
+    /**
+     * Probe whether the wp-cron loopback URL is gated by a membership or
+     * privacy plugin.
+     *
+     * Sends a non-redirect-following GET to /wp-cron.php with a 3-second
+     * timeout. Returns true when the response is a 3xx redirect (the
+     * front-end redirects unauthenticated requests to a login page) or when
+     * the request fails entirely (WP_Error — DNS, connect, TLS). Returns
+     * false for any other status code (2xx, 4xx, 5xx) — the loopback is
+     * reachable even if it returns an error, so spawn_cron will work.
+     *
+     * Why we only follow 0 redirects: a single HTTP redirect is the
+     * definitive sign that the gate is active. Multi-hop chains are not
+     * considered; we treat any redirect as gated.
+     *
+     * DISABLE_WP_CRON / ALTERNATE_WP_CRON short-circuit: when WP cron is
+     * disabled the loopback probe is irrelevant (spawn_cron is a no-op too),
+     * so we return false and let the normal path proceed.
+     *
+     * `protected` is a deliberate test seam.
+     */
+    protected function isLoopbackGated(): bool
+    {
+        // If WP cron is disabled entirely, spawn_cron is a no-op regardless
+        // of whether the loopback is gated — nothing to probe.
+        if (defined('DISABLE_WP_CRON') && (bool) constant('DISABLE_WP_CRON')) {
+            return false;
+        }
+
+        if (!function_exists('wp_remote_get') || !function_exists('site_url')) {
+            return false;
+        }
+
+        $cronUrl = (string) site_url('/wp-cron.php');
+        if ($cronUrl === '' || $cronUrl === '/wp-cron.php') {
+            return false;
+        }
+
+        $response = wp_remote_get(
+            $cronUrl,
+            [
+                'timeout'     => 3,
+                'redirection' => 0,  // Do NOT follow redirects — a redirect IS the gate signal.
+                'sslverify'   => false,
+                'blocking'    => true,
+                'user-agent'  => 'WPMgr-Agent/' . (defined('WPMGR_AGENT_VERSION') ? (string) constant('WPMGR_AGENT_VERSION') : '0'),
+            ]
+        );
+
+        if (is_wp_error($response)) {
+            // Cannot reach the loopback at all (DNS failure, TLS error, etc.).
+            // Treat as gated — in-process fallback is safer than spawning into
+            // a black hole.
+            DebugLog::write(sprintf(
+                'WPMgr Backup: loopback probe failed (%s); using in-process runner as fallback',
+                $response->get_error_message()
+            ));
+            return true;
+        }
+
+        $code = (int) wp_remote_retrieve_response_code($response);
+        if ($code >= 300 && $code < 400) {
+            // Redirect — the front-end gate is active.
+            $location = wp_remote_retrieve_header($response, 'location');
+            DebugLog::write(sprintf(
+                'WPMgr Backup: loopback probe returned %d (redirect to: %s); site appears to be behind a membership/privacy gate — using in-process runner as fallback',
+                $code,
+                is_string($location) ? $location : '(unknown)'
+            ));
+            return true;
+        }
+
+        return false;
     }
 
     /** Refusal response — the agent didn't accept the job. */

--- a/apps/agent/includes/commands/class-file-archive-create-command.php
+++ b/apps/agent/includes/commands/class-file-archive-create-command.php
@@ -1,4 +1,17 @@
 <?php
+// File: class-file-archive-create-command.php — FileArchiveCreateCommand.
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Commands;
+
+use WPMgr\Agent\Support\StoragePaths;
+use ZipArchive;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * FileArchiveCreateCommand: zip one or more jailed paths and stage to S3.
  *
@@ -44,21 +57,6 @@
  * hard-fail), so direct streaming I/O is the correct posture here.
  *
  * @package WPMgr\Agent\Commands
- */
-
-declare(strict_types=1);
-
-namespace WPMgr\Agent\Commands;
-
-use WPMgr\Agent\Support\StoragePaths;
-use ZipArchive;
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
-/**
- * Zips one or more jailed paths and stages the result to S3 via presigned PUTs.
  */
 final class FileArchiveCreateCommand implements CommandInterface {
 

--- a/apps/agent/includes/commands/class-file-download-prepare-command.php
+++ b/apps/agent/includes/commands/class-file-download-prepare-command.php
@@ -1,4 +1,14 @@
 <?php
+// File: class-file-download-prepare-command.php — FileDownloadPrepareCommand.
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Commands;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * FileDownloadPrepareCommand: stage a file to S3 for large-file download.
  *
@@ -46,15 +56,6 @@
  * and hard-fail). This is a justified deviation from the WP_Filesystem sniff.
  *
  * @package WPMgr\Agent\Commands
- */
-
-declare(strict_types=1);
-
-namespace WPMgr\Agent\Commands;
-
-/**
- * Stage a single file to S3 via CP-minted presigned PUT URLs, streaming in
- * part_size chunks to respect www-data memory limits.
  */
 final class FileDownloadPrepareCommand implements CommandInterface
 {

--- a/apps/agent/includes/commands/class-file-extract-command.php
+++ b/apps/agent/includes/commands/class-file-extract-command.php
@@ -1,4 +1,17 @@
 <?php
+// File: class-file-extract-command.php — FileExtractCommand.
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Commands;
+
+use WPMgr\Agent\Support\StoragePaths;
+use ZipArchive;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * FileExtractCommand: extract a jailed .zip into a jailed destination.
  *
@@ -62,22 +75,6 @@
  *      a finally block and leave dest untouched.
  *
  * @package WPMgr\Agent\Commands
- */
-
-declare(strict_types=1);
-
-namespace WPMgr\Agent\Commands;
-
-use WPMgr\Agent\Support\StoragePaths;
-use ZipArchive;
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
-/**
- * Safely extracts a jailed .zip into a jailed destination directory.
- * The extraction is atomic: a quarantine temp dir is used; on failure dest is untouched.
  */
 final class FileExtractCommand implements CommandInterface {
 

--- a/apps/agent/includes/commands/class-file-list-command.php
+++ b/apps/agent/includes/commands/class-file-list-command.php
@@ -1,4 +1,16 @@
 <?php
+// File: class-file-list-command.php — FileListCommand.
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Commands;
+
+use WPMgr\Agent\Support\FileScanner;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * FileListCommand: one-level directory listing within the site jail.
  *
@@ -38,17 +50,6 @@
  * guard (realpath + strncmp). The jail root is WPMGR_FILE_JAIL_ROOT (defaults to ABSPATH).
  *
  * @package WPMgr\Agent\Commands
- */
-
-declare(strict_types=1);
-
-namespace WPMgr\Agent\Commands;
-
-use WPMgr\Agent\Support\FileScanner;
-
-/**
- * Returns a one-level directory listing within the agent file jail.
- * Dirs are listed first, then files, both sorted case-insensitively by name.
  */
 final class FileListCommand implements CommandInterface
 {

--- a/apps/agent/includes/commands/class-file-read-command.php
+++ b/apps/agent/includes/commands/class-file-read-command.php
@@ -1,4 +1,16 @@
 <?php
+// File: class-file-read-command.php — FileReadCommand.
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Commands;
+
+use WPMgr\Agent\Support\FileScanner;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * FileReadCommand: read one file (≤ 256 KiB, base64-encoded) within the site jail.
  *
@@ -36,17 +48,6 @@
  *   .aws/credentials, any file inside a .git/ directory.
  *
  * @package WPMgr\Agent\Commands
- */
-
-declare(strict_types=1);
-
-namespace WPMgr\Agent\Commands;
-
-use WPMgr\Agent\Support\FileScanner;
-
-/**
- * Returns the base64-encoded content of a single file within the agent file jail.
- * Enforces the sensitive-file deny-list (T6) and the realpath/strncmp jail (T2).
  */
 final class FileReadCommand implements CommandInterface
 {

--- a/apps/agent/includes/commands/class-file-search-command.php
+++ b/apps/agent/includes/commands/class-file-search-command.php
@@ -1,4 +1,14 @@
 <?php
+// File: class-file-search-command.php — FileSearchCommand.
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Commands;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * FileSearchCommand: recursive filename or content search within the site jail.
  *
@@ -56,18 +66,6 @@
  *   from a different path is rejected.
  *
  * @package WPMgr\Agent\Commands
- */
-
-declare(strict_types=1);
-
-namespace WPMgr\Agent\Commands;
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
-/**
- * Recursive file search (name or content) within the agent file jail.
  */
 final class FileSearchCommand implements CommandInterface {
 

--- a/apps/agent/includes/commands/class-file-upload-apply-command.php
+++ b/apps/agent/includes/commands/class-file-upload-apply-command.php
@@ -1,4 +1,14 @@
 <?php
+// File: class-file-upload-apply-command.php — FileUploadApplyCommand.
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Commands;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * FileUploadApplyCommand: reassemble a CP-staged upload from presigned S3 GETs
  * and atomically place it within the site jail.
@@ -55,19 +65,6 @@
  * are small (capped) and serial streaming is sufficient.
  *
  * @package WPMgr\Agent\Commands
- */
-
-declare(strict_types=1);
-
-namespace WPMgr\Agent\Commands;
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
-/**
- * Reassembles a multi-part presigned-GET upload and atomically places it
- * within the agent file jail, applying the full executable-write prevention.
  */
 final class FileUploadApplyCommand implements CommandInterface {
 

--- a/apps/agent/includes/commands/class-file-version-restore-command.php
+++ b/apps/agent/includes/commands/class-file-version-restore-command.php
@@ -1,4 +1,17 @@
 <?php
+// File: class-file-version-restore-command.php — FileVersionRestoreCommand.
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Commands;
+
+use WPMgr\Agent\Keystore;
+use WPMgr\Agent\Support\StoragePaths;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * FileVersionRestoreCommand: restore a staged backup version over a jailed file.
  *
@@ -40,21 +53,6 @@
  *     bad_backup. No plaintext fallback exists on 0.60+ installs.
  *
  * @package WPMgr\Agent\Commands
- */
-
-declare(strict_types=1);
-
-namespace WPMgr\Agent\Commands;
-
-use WPMgr\Agent\Keystore;
-use WPMgr\Agent\Support\StoragePaths;
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
-/**
- * Atomically restores a staged backup version over the original file.
  */
 final class FileVersionRestoreCommand implements CommandInterface {
 

--- a/apps/agent/includes/commands/class-file-versions-list-command.php
+++ b/apps/agent/includes/commands/class-file-versions-list-command.php
@@ -1,4 +1,16 @@
 <?php
+// File: class-file-versions-list-command.php — FileVersionsListCommand.
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Commands;
+
+use WPMgr\Agent\Support\StoragePaths;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * FileVersionsListCommand: list the pre-write staged backups for a jailed file.
  *
@@ -50,20 +62,6 @@
  * the absolute path later without leaking host paths in the response.
  *
  * @package WPMgr\Agent\Commands
- */
-
-declare(strict_types=1);
-
-namespace WPMgr\Agent\Commands;
-
-use WPMgr\Agent\Support\StoragePaths;
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
-/**
- * Lists the pre-write staged backups for a jailed file path.
  */
 final class FileVersionsListCommand implements CommandInterface {
 

--- a/apps/agent/includes/commands/class-file-write-command.php
+++ b/apps/agent/includes/commands/class-file-write-command.php
@@ -1,4 +1,17 @@
 <?php
+// File: class-file-write-command.php — FileWriteCommand.
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Commands;
+
+use WPMgr\Agent\Keystore;
+use WPMgr\Agent\Support\StoragePaths;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * FileWriteCommand: create or overwrite a small text file (≤ 256 KiB) within
  * the site jail via an atomic temp-write → rename swap.
@@ -40,21 +53,6 @@
  *     the presigned-upload path, file_upload_apply).
  *
  * @package WPMgr\Agent\Commands
- */
-
-declare(strict_types=1);
-
-namespace WPMgr\Agent\Commands;
-
-use WPMgr\Agent\Keystore;
-use WPMgr\Agent\Support\StoragePaths;
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
-/**
- * Atomically writes a small file within the agent file jail.
  */
 final class FileWriteCommand implements CommandInterface {
 

--- a/apps/agent/includes/commands/class-file-write-command.php
+++ b/apps/agent/includes/commands/class-file-write-command.php
@@ -193,6 +193,33 @@ final class FileWriteCommand implements CommandInterface {
 			return $this->error( 'write_failed', 'could not write temporary file' );
 		}
 
+		// ------------------------------------------------------------------
+		// Final jail assertion — redundant, self-contained, and visible at the
+		// write call site so a reviewer can verify containment without tracing
+		// the full call stack.
+		//
+		// Full gate the destination already passed:
+		//   (1) resolveJailRoot() validated the jail root via realpath (T3)
+		//   (2) jailPath() verified realpath containment + traversal rejection (§3)
+		//   (3) FileReadCommand::isSensitive() blocked credential/config paths (T6)
+		//   (4) FileGuards::isExecutableWrite() blocked .php and other executables (T1)
+		//   (5) F3 symlink guard above rejected symlink destinations
+		//   (6) F3 parent re-jail above re-confirmed the parent is inside the jail
+		//   (7) The JWT authorising this write carries cmd="file_write" and was
+		//       verified by Ed25519 + anti-replay jti + 60 s expiry window
+		//
+		// This assertion re-resolves $absPath's real parent and confirms it is still
+		// within $jailRoot, catching any race that slipped through the checks above.
+		$finalParentReal = realpath( dirname( $absPath ) );
+		if ( $finalParentReal === false
+			|| ( strncmp( str_replace( '\\', '/', $finalParentReal ), $jailRoot . '/', strlen( $jailRoot ) + 1 ) !== 0
+				&& str_replace( '\\', '/', $finalParentReal ) !== $jailRoot )
+		) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- headless agent; WP_Filesystem never initialized; cleanup of temp file on final-assertion failure
+			@unlink( $tmpPath );
+			return $this->error( 'outside_root', 'write denied: final jail assertion failed — destination escaped the jail root' );
+		}
+
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- WP_Filesystem::move() is non-atomic (copy+delete) and WP_Filesystem is never initialized in the headless agent path; native rename() is the only atomic option on POSIX filesystems
 		if ( ! @rename( $tmpPath, $absPath ) ) {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- headless agent; WP_Filesystem never initialized; cleanup of temp file on rename failure

--- a/apps/agent/includes/diagnostics/class-size-probe.php
+++ b/apps/agent/includes/diagnostics/class-size-probe.php
@@ -346,7 +346,11 @@ final class SizeProbe
         }
 
         $themesDir  = $contentDir !== '' ? $contentDir . '/themes' : '';
-        $pluginsDir = $contentDir !== '' ? $contentDir . '/plugins' : '';
+        // Prefer WP_PLUGIN_DIR (honours relocated plugin dirs) before falling
+        // back to the conventional wp-content/plugins path.
+        $pluginsDir = defined('WP_PLUGIN_DIR')
+            ? rtrim((string) constant('WP_PLUGIN_DIR'), '/\\')
+            : ($contentDir !== '' ? $contentDir . '/plugins' : '');
 
         // wordpress_size excludes uploads/themes/plugins to avoid double-counting
         // (mirrors WP core's own get_sizes() exclusion list).

--- a/apps/agent/includes/support/class-snapshot-manager.php
+++ b/apps/agent/includes/support/class-snapshot-manager.php
@@ -277,7 +277,9 @@ class SnapshotManager
 
         if ($type === 'plugin') {
             $folder = strpos($slug, '/') !== false ? substr($slug, 0, strpos($slug, '/')) : $slug;
-            $root   = defined('WP_PLUGIN_DIR') ? rtrim((string) WP_PLUGIN_DIR, '/\\') : $contentDir . '/plugins';
+            // WP_PLUGIN_DIR is always defined in a real WP load; bail if missing
+            // rather than guess a path that may be wrong on relocated-content installs.
+            $root   = defined('WP_PLUGIN_DIR') ? rtrim((string) WP_PLUGIN_DIR, '/\\') : '';
             $path   = $root . '/' . $folder;
         } elseif ($type === 'theme') {
             $root = $this->themeRoot($contentDir);

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -1,4 +1,4 @@
-=== Fleet Agent for WPMgr ===
+=== Fleet Agent Site Manager ===
 Contributors: mosamlife
 Tags: backup, restore, performance, cache, security
 Requires at least: 6.0
@@ -8,11 +8,11 @@ Stable tag: 0.36.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Connects this WordPress site to a user-chosen WPMgr control plane for managed backups, performance, and updates.
+Connects this WordPress site to a user-chosen WPMgr control plane for managed backups, performance, security, and updates.
 
 == Description ==
 
-Fleet Agent for WPMgr links your WordPress site to a control plane that YOU choose and configure. The default endpoint is none -- the plugin is completely inert until you supply a control-plane URL and complete a one-time signed enrollment. The control plane is either a WPMgr instance you self-host or the hosted service at manage.wpmgr.app.
+This plugin links your WordPress site to a WPMgr control plane that YOU choose and configure. The default endpoint is none -- the plugin is completely inert until you supply a control-plane URL and complete a one-time signed enrollment. The control plane is either a WPMgr instance you self-host or the hosted service at manage.wpmgr.app.
 
 **How it works / security**
 
@@ -65,7 +65,7 @@ All outbound communication stops immediately. The control plane can no longer re
 
 == Privacy / What data is sent and where ==
 
-Fleet Agent for WPMgr does not contact any external service until you connect it to a WPMgr control plane that you choose. There is NO default endpoint; the agent is inert until you supply a control-plane URL and complete a one-time, signed enrollment from that control plane. The control plane is software you point the agent at -- either a WPMgr instance you self-host, or the hosted WPMgr service at https://manage.wpmgr.app.
+This plugin does not contact any external service until you connect it to a WPMgr control plane that you choose. There is NO default endpoint; the agent is inert until you supply a control-plane URL and complete a one-time, signed enrollment from that control plane. The control plane is software you point the agent at -- either a WPMgr instance you self-host, or the hosted WPMgr service at https://manage.wpmgr.app.
 
 Once connected, the agent communicates only with the control-plane URL you configured. It sends the following data, only to that endpoint, and only for the management actions you (or your schedules) initiate:
 
@@ -107,7 +107,11 @@ This plugin contacts external hosts only after you connect it to a control plane
 
 **WPMgr control plane (the URL you supply)**
 
-Every management action (enrollment, diagnostics, heartbeat, backup progress, cache and performance operations, Remove Unused CSS, autologin token consumption, database clean, font transcoding) sends data to the WPMgr control plane URL you configured. Data transmitted includes: site URL and name, WordPress and PHP versions, active plugin and theme inventory, Site Health results, rendered HTML of selected pages (for used-CSS computation), encrypted backup archives, transcoded font bytes, and cache and performance statistics. All transmission is triggered by actions or schedules you initiate from the control plane, never autonomously. If you use the hosted control plane at https://manage.wpmgr.app its terms and privacy policy apply: Terms https://manage.wpmgr.app/terms -- Privacy https://manage.wpmgr.app/privacy. If you self-host the control plane, you operate the receiving service and your own policies apply.
+Every management action (enrollment, diagnostics, heartbeat, backup progress, cache and performance operations, Remove Unused CSS, autologin token consumption, database clean, font transcoding, password breach checking) sends data to the WPMgr control plane URL you configured. Data transmitted includes: site URL and name, WordPress and PHP versions, active plugin and theme inventory, Site Health results, rendered HTML of selected pages (for used-CSS computation), encrypted backup archives, transcoded font bytes, and cache and performance statistics. All transmission is triggered by actions or schedules you initiate from the control plane, never autonomously. If you use the hosted control plane at https://manage.wpmgr.app its terms and privacy policy apply: Terms https://manage.wpmgr.app/terms -- Privacy https://manage.wpmgr.app/privacy. If you self-host the control plane, you operate the receiving service and your own policies apply.
+
+**Have I Been Pwned (https://haveibeenpwned.com) -- via the WPMgr control plane**
+
+When the optional password-policy breach check is enabled and a site user sets or changes a password, the plugin computes the SHA-1 hash of the candidate password and sends only the first 5 characters of that hash (a k-anonymity range query) to the WPMgr control plane. The full password and the full hash never leave the site. The WPMgr control plane relays the 5-character prefix to the Have I Been Pwned range API (https://haveibeenpwned.com/API/v3#searchingPwnedPasswordsByRange), receives back a list of matching hash suffixes and breach counts, and returns that list to the agent. The agent then checks the remaining 35-character suffix locally to determine whether the password is known-breached. No full password, no full hash, and no user identity is transmitted at any point in this flow. This check is off by default; it runs only when the breach-check policy is active and only at the moment of a password set or change. Data flow: site sends the 5-character prefix to the WPMgr control plane, which forwards the range query to Have I Been Pwned. Have I Been Pwned Terms https://haveibeenpwned.com/Terms -- Have I Been Pwned Privacy https://haveibeenpwned.com/Privacy. The WPMgr control-plane hop is also covered by the terms above: Terms https://manage.wpmgr.app/terms -- Privacy https://manage.wpmgr.app/privacy.
 
 **Object storage (configured by your control plane)**
 

--- a/apps/agent/tests/Backup/BackupLoopbackGateTest.php
+++ b/apps/agent/tests/Backup/BackupLoopbackGateTest.php
@@ -1,0 +1,376 @@
+<?php
+/**
+ * Tests for the loopback-gate detection introduced in GitHub issue #117.
+ *
+ * On sites behind a membership or privacy gate (e.g. SureDash "private
+ * community"), every front-end request — including /wp-cron.php — is
+ * redirected to a login page for unauthenticated visitors. This means
+ * spawn_cron()'s non-blocking POST to /wp-cron.php is silently swallowed by
+ * the redirect, so the wpmgr_backup_run cron event never executes and the
+ * backup stalls with no progress.
+ *
+ * The fix:
+ *   1. BackupCommand::isLoopbackGated() probes the /wp-cron.php URL before
+ *      calling spawn_cron(). When the probe returns a 3xx redirect (or a
+ *      WP_Error — unreachable loopback), the backup runner is started in the
+ *      same PHP process via register_shutdown_function after the ACK response
+ *      is sent.
+ *   2. Watchdog::detectQueuedStallReason() (called when max_resumes is
+ *      exhausted AND phase is still 'queued') probes the loopback and surfaces
+ *      a clear, actionable failure message instead of the generic stall text.
+ *
+ * Test seam: both isLoopbackGated() and detectQueuedStallReason() are
+ * `protected` / private-static. We invoke them via ReflectionMethod so we do
+ * not need to subclass the `final` BackupCommand or Watchdog classes.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use ReflectionMethod;
+use WPMgr\Agent\Backup\Watchdog;
+use WPMgr\Agent\Commands\BackupCommand;
+use WPMgr\Agent\Support\AgeIdentity;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Commands\BackupCommand
+ * @covers \WPMgr\Agent\Backup\Watchdog
+ */
+final class BackupLoopbackGateTest extends TestCase
+{
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+        Functions\when('wp_json_encode')->alias(static fn ($d) => json_encode($d));
+    }
+
+    protected function tear_down(): void
+    {
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    /** Stub AgeIdentity with a controllable recipient. */
+    private function stubIdentity(
+        string $recipient = 'age1test0000000000000000000000000000000000000000000000000000'
+    ): AgeIdentity {
+        return new class($recipient) extends AgeIdentity {
+            private string $rcpt;
+
+            public function __construct(string $rcpt)
+            {
+                $this->rcpt = $rcpt;
+            }
+
+            public function recipient(): string
+            {
+                return $this->rcpt;
+            }
+
+            public function recipientMatches(string $candidate): bool
+            {
+                return hash_equals($this->rcpt, $candidate);
+            }
+        };
+    }
+
+    /** Return a ReflectionMethod for BackupCommand::isLoopbackGated(). */
+    private function reflectIsLoopbackGated(BackupCommand $cmd): ReflectionMethod
+    {
+        $method = new ReflectionMethod(BackupCommand::class, 'isLoopbackGated');
+        // setAccessible is a no-op since PHP 8.1 and deprecated since 8.5.
+        return $method;
+    }
+
+    // ------------------------------------------------------------------
+    // isLoopbackGated(): unit tests for the probe logic
+    // ------------------------------------------------------------------
+
+    /**
+     * A 302 redirect response from the loopback probe means the site is gated.
+     */
+    public function test_isLoopbackGated_returns_true_on_redirect_response(): void
+    {
+        if (defined('DISABLE_WP_CRON') && (bool) constant('DISABLE_WP_CRON')) {
+            $this->markTestSkipped('DISABLE_WP_CRON is true — probe is skipped in this process.');
+        }
+
+        Functions\when('site_url')->justReturn('https://private.example.com/wp-cron.php');
+        Functions\when('wp_remote_get')->justReturn([
+            'response' => ['code' => 302, 'message' => 'Found'],
+            'headers'  => ['location' => 'https://private.example.com/portal-login/'],
+            'body'     => '',
+        ]);
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(302);
+        Functions\when('wp_remote_retrieve_header')->justReturn('https://private.example.com/portal-login/');
+
+        $cmd    = new BackupCommand($this->stubIdentity());
+        $method = $this->reflectIsLoopbackGated($cmd);
+
+        $this->assertTrue($method->invoke($cmd));
+    }
+
+    /**
+     * A 301 redirect is also treated as a gate.
+     */
+    public function test_isLoopbackGated_returns_true_on_301_redirect(): void
+    {
+        if (defined('DISABLE_WP_CRON') && (bool) constant('DISABLE_WP_CRON')) {
+            $this->markTestSkipped('DISABLE_WP_CRON is true — probe is skipped in this process.');
+        }
+
+        Functions\when('site_url')->justReturn('https://private.example.com/wp-cron.php');
+        Functions\when('wp_remote_get')->justReturn([
+            'response' => ['code' => 301, 'message' => 'Moved Permanently'],
+            'headers'  => ['location' => 'https://private.example.com/login/'],
+            'body'     => '',
+        ]);
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(301);
+        Functions\when('wp_remote_retrieve_header')->justReturn('https://private.example.com/login/');
+
+        $cmd    = new BackupCommand($this->stubIdentity());
+        $method = $this->reflectIsLoopbackGated($cmd);
+
+        $this->assertTrue($method->invoke($cmd));
+    }
+
+    /**
+     * A WP_Error (loopback unreachable) is also treated as a gate
+     * (safer to run in-process than to enqueue into a black hole).
+     */
+    public function test_isLoopbackGated_returns_true_on_wp_error(): void
+    {
+        if (defined('DISABLE_WP_CRON') && (bool) constant('DISABLE_WP_CRON')) {
+            $this->markTestSkipped('DISABLE_WP_CRON is true — probe is skipped in this process.');
+        }
+
+        Functions\when('site_url')->justReturn('https://private.example.com/wp-cron.php');
+        Functions\when('wp_remote_get')->justReturn(
+            new \WP_Error('http_request_failed', 'cURL error 7: Connection refused')
+        );
+        Functions\when('is_wp_error')->justReturn(true);
+
+        $cmd    = new BackupCommand($this->stubIdentity());
+        $method = $this->reflectIsLoopbackGated($cmd);
+
+        $this->assertTrue($method->invoke($cmd));
+    }
+
+    /**
+     * A 200 response (WP-Cron ran fine) is NOT gated.
+     */
+    public function test_isLoopbackGated_returns_false_on_200_response(): void
+    {
+        if (defined('DISABLE_WP_CRON') && (bool) constant('DISABLE_WP_CRON')) {
+            $this->markTestSkipped('DISABLE_WP_CRON is true — probe is skipped in this process.');
+        }
+
+        Functions\when('site_url')->justReturn('https://open.example.com/wp-cron.php');
+        Functions\when('wp_remote_get')->justReturn([
+            'response' => ['code' => 200, 'message' => 'OK'],
+            'headers'  => [],
+            'body'     => '',
+        ]);
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(200);
+
+        $cmd    = new BackupCommand($this->stubIdentity());
+        $method = $this->reflectIsLoopbackGated($cmd);
+
+        $this->assertFalse($method->invoke($cmd));
+    }
+
+    /**
+     * A 403 response (security plugin returns 403) is NOT treated as a gate —
+     * spawn_cron will still work for cron dispatch since the loopback is reachable.
+     */
+    public function test_isLoopbackGated_returns_false_on_403_response(): void
+    {
+        if (defined('DISABLE_WP_CRON') && (bool) constant('DISABLE_WP_CRON')) {
+            $this->markTestSkipped('DISABLE_WP_CRON is true — probe is skipped in this process.');
+        }
+
+        Functions\when('site_url')->justReturn('https://open.example.com/wp-cron.php');
+        Functions\when('wp_remote_get')->justReturn([
+            'response' => ['code' => 403, 'message' => 'Forbidden'],
+            'headers'  => [],
+            'body'     => 'Forbidden',
+        ]);
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(403);
+
+        $cmd    = new BackupCommand($this->stubIdentity());
+        $method = $this->reflectIsLoopbackGated($cmd);
+
+        $this->assertFalse($method->invoke($cmd));
+    }
+
+    // ------------------------------------------------------------------
+    // execute() validation guards — these run BEFORE the loopback probe
+    // so they must still refuse bad input regardless of gate state.
+    // ------------------------------------------------------------------
+
+    /**
+     * execute() must still refuse requests with a missing age recipient.
+     * The loopback probe happens after input validation, so this guard fires
+     * first and no wp_remote_get call should be made.
+     */
+    public function test_execute_refuses_missing_recipient(): void
+    {
+        $cmd = new BackupCommand($this->stubIdentity());
+        $res = $cmd->execute([], [
+            'snapshot_id'       => '11111111-2222-3333-4444-555555555555',
+            'kind'              => 'files',
+            'age_recipient'     => '',
+            'presign_endpoint'  => 'https://cp.example/presign',
+            'manifest_endpoint' => 'https://cp.example/manifest',
+        ]);
+        $this->assertFalse($res['ok']);
+        $this->assertSame('missing age recipient', $res['detail']);
+    }
+
+    /**
+     * execute() must still refuse an age recipient mismatch.
+     */
+    public function test_execute_refuses_recipient_mismatch(): void
+    {
+        $knownRecipient = 'age1test0000000000000000000000000000000000000000000000000000';
+        $cmd = new BackupCommand($this->stubIdentity($knownRecipient));
+        $res = $cmd->execute([], [
+            'snapshot_id'       => '11111111-2222-3333-4444-555555555555',
+            'kind'              => 'files',
+            'age_recipient'     => 'age1differentrecipientthatshouldnotmatch0000000000000000000',
+            'presign_endpoint'  => 'https://cp.example/presign',
+            'manifest_endpoint' => 'https://cp.example/manifest',
+        ]);
+        $this->assertFalse($res['ok']);
+        $this->assertSame('age recipient mismatch', $res['detail']);
+    }
+
+    // ------------------------------------------------------------------
+    // Watchdog stall-reason detection
+    // ------------------------------------------------------------------
+
+    /**
+     * Watchdog::detectQueuedStallReason() must return the generic stall
+     * message when the phase is NOT queued (stall in a later phase has a
+     * different root cause and the loopback probe is irrelevant).
+     */
+    public function test_detectQueuedStallReason_generic_for_non_queued_phase(): void
+    {
+        $method = new ReflectionMethod(Watchdog::class, 'detectQueuedStallReason');
+
+        $result = $method->invoke(null, 'archiving_files', 'test-snap-id');
+
+        $this->assertIsString($result);
+        $this->assertStringContainsString('stalled in queued phase', $result);
+        $this->assertStringNotContainsString('login', $result);
+        $this->assertStringNotContainsString('redirect', $result);
+    }
+
+    /**
+     * When the loopback probe returns a redirect and the phase IS queued,
+     * detectQueuedStallReason() must return a message mentioning "redirect"
+     * and "membership or privacy gate" for operator clarity.
+     */
+    public function test_detectQueuedStallReason_gate_message_on_redirect(): void
+    {
+        Functions\when('site_url')->justReturn('https://private.example.com/wp-cron.php');
+        Functions\when('wp_remote_get')->justReturn([
+            'response' => ['code' => 302, 'message' => 'Found'],
+            'headers'  => ['location' => 'https://private.example.com/portal-login/'],
+            'body'     => '',
+        ]);
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(302);
+        Functions\when('wp_remote_retrieve_header')->justReturn('https://private.example.com/portal-login/');
+        Functions\when('esc_url_raw')->alias(static fn ($u) => $u);
+
+        $method = new ReflectionMethod(Watchdog::class, 'detectQueuedStallReason');
+        $result = $method->invoke(null, 'queued', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+
+        $this->assertIsString($result);
+        $this->assertStringContainsString('redirect', $result);
+        $this->assertStringContainsString('membership or privacy gate', $result);
+        $this->assertStringContainsString('/wp-cron.php', $result);
+    }
+
+    /**
+     * When the loopback is unreachable (WP_Error), detectQueuedStallReason()
+     * must mention "could not be reached" with the error detail.
+     */
+    public function test_detectQueuedStallReason_unreachable_message_on_wp_error(): void
+    {
+        Functions\when('site_url')->justReturn('https://private.example.com/wp-cron.php');
+        Functions\when('wp_remote_get')->justReturn(
+            new \WP_Error('http_request_failed', 'Connection refused')
+        );
+        Functions\when('is_wp_error')->justReturn(true);
+        Functions\when('esc_url_raw')->alias(static fn ($u) => $u);
+
+        $method = new ReflectionMethod(Watchdog::class, 'detectQueuedStallReason');
+        $result = $method->invoke(null, 'queued', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+
+        $this->assertIsString($result);
+        $this->assertStringContainsString('could not be reached', $result);
+        $this->assertStringContainsString('Connection refused', $result);
+    }
+
+    /**
+     * When the loopback returns 200, detectQueuedStallReason() falls back to
+     * the generic stall message (the gate is not the cause of the stall).
+     */
+    public function test_detectQueuedStallReason_generic_when_loopback_accessible(): void
+    {
+        Functions\when('site_url')->justReturn('https://open.example.com/wp-cron.php');
+        Functions\when('wp_remote_get')->justReturn([
+            'response' => ['code' => 200, 'message' => 'OK'],
+            'headers'  => [],
+            'body'     => '',
+        ]);
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(200);
+        Functions\when('esc_url_raw')->alias(static fn ($u) => $u);
+
+        $method = new ReflectionMethod(Watchdog::class, 'detectQueuedStallReason');
+        $result = $method->invoke(null, 'queued', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+
+        $this->assertIsString($result);
+        $this->assertStringContainsString('backup runner was never dispatched', $result);
+        $this->assertStringNotContainsString('redirect', $result);
+        $this->assertStringNotContainsString('login', $result);
+    }
+
+    /**
+     * When DISABLE_WP_CRON is true, the probe is skipped and returns false.
+     *
+     * NOTE: This test uses define() which is process-wide. It MUST run last
+     * in this class to avoid poisoning the probe-dependent tests above.
+     * The identical pattern is used in PingCommandTest (see line ~107 there).
+     */
+    public function test_isLoopbackGated_returns_false_when_disable_wp_cron(): void
+    {
+        if (defined('DISABLE_WP_CRON')) {
+            $this->markTestSkipped('DISABLE_WP_CRON already defined in this process.');
+        }
+        define('DISABLE_WP_CRON', true);
+
+        $cmd    = new BackupCommand($this->stubIdentity());
+        $method = $this->reflectIsLoopbackGated($cmd);
+
+        $this->assertFalse($method->invoke($cmd));
+    }
+}

--- a/apps/agent/tests/wp-stubs.php
+++ b/apps/agent/tests/wp-stubs.php
@@ -406,3 +406,115 @@ if (!function_exists('esc_sql')) {
         return $data;
     }
 }
+
+// ---------------------------------------------------------------------------
+// WP HTTP API stubs (wp_remote_get / response helpers / is_wp_error / site_url
+// / esc_url_raw). Required by BackupCommand::isLoopbackGated() and
+// Watchdog::detectQueuedStallReason() for the membership-gate detection path.
+// Tests that need specific responses override via Functions\when().
+// ---------------------------------------------------------------------------
+
+if (!function_exists('wp_remote_get')) {
+    /**
+     * Performs an HTTP GET request — default stub returns WP_Error.
+     * Tests must stub this via Functions\when('wp_remote_get') to return
+     * a specific response or error.
+     *
+     * @param string               $url  Request URL.
+     * @param array<string,mixed>  $args Request arguments.
+     * @return array<string,mixed>|\WP_Error Response array or WP_Error on failure.
+     */
+    function wp_remote_get(string $url, array $args = [])
+    {
+        return new \WP_Error('test_stub', 'wp_remote_get called without a test stub');
+    }
+}
+
+if (!function_exists('wp_remote_retrieve_response_code')) {
+    /**
+     * Retrieve the response code from a wp_remote_get/post response.
+     *
+     * @param array<string,mixed>|\WP_Error $response Response array or WP_Error.
+     * @return int HTTP response code.
+     */
+    function wp_remote_retrieve_response_code($response): int
+    {
+        if (is_array($response) && isset($response['response']['code'])) {
+            return (int) $response['response']['code'];
+        }
+        return 0;
+    }
+}
+
+if (!function_exists('wp_remote_retrieve_header')) {
+    /**
+     * Retrieve a specific header from a wp_remote response.
+     *
+     * @param array<string,mixed>|\WP_Error $response Response array or WP_Error.
+     * @param string                         $header   Header name (lowercase).
+     * @return string Header value or empty string.
+     */
+    function wp_remote_retrieve_header($response, string $header): string
+    {
+        if (is_array($response) && isset($response['headers'][$header])) {
+            return (string) $response['headers'][$header];
+        }
+        return '';
+    }
+}
+
+if (!function_exists('is_wp_error')) {
+    /**
+     * Whether a value is a WP_Error instance.
+     *
+     * @param mixed $thing Value to check.
+     * @return bool
+     */
+    function is_wp_error(mixed $thing): bool
+    {
+        return $thing instanceof \WP_Error;
+    }
+}
+
+if (!function_exists('site_url')) {
+    /**
+     * Returns the site URL — default stub returns a placeholder.
+     * Tests must stub via Functions\when('site_url') when specific URLs matter.
+     *
+     * @param string $path Optional path to append.
+     * @return string
+     */
+    function site_url(string $path = ''): string
+    {
+        return 'https://example.com' . $path;
+    }
+}
+
+if (!function_exists('esc_url_raw')) {
+    /**
+     * Sanitizes a URL for use in a database or redirect.
+     * Passthrough stub for tests.
+     *
+     * @param string $url URL to sanitize.
+     * @return string
+     */
+    function esc_url_raw(string $url): string
+    {
+        return $url;
+    }
+}
+
+if (!function_exists('wp_json_encode')) {
+    /**
+     * Encodes a value as JSON — thin wrapper around json_encode.
+     *
+     * @param mixed $data    Value to encode.
+     * @param int   $options json_encode flags.
+     * @param int   $depth   Maximum depth.
+     * @return string|false JSON string or false on failure.
+     */
+    function wp_json_encode(mixed $data, int $options = 0, int $depth = 512): string|false
+    {
+        return json_encode($data, $options, $depth);
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.0
+ * Version:           0.61.3
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.0');
+define('WPMGR_AGENT_VERSION', '0.61.3');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -770,6 +770,10 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 		// failures are logged and never fail the backup. Uses defStore (the
 		// rebuilt CP-global *blobstore.Store) which satisfies IndexPutter.
 		backupSvc.SetIndexPutter(defStore)
+		// Wire the manifest deleter so snapshot deletions (operator delete + GC
+		// prune) also remove the corresponding manifest.json object. Uses the same
+		// defStore which satisfies IndexDeleter via its Delete method.
+		backupSvc.SetIndexDeleter(defStore)
 	}
 
 	// M5/M6 uptime monitoring: the uptime metrics store, the SSRF-hardened

--- a/apps/api/internal/backup/delete_cancel_test.go
+++ b/apps/api/internal/backup/delete_cancel_test.go
@@ -7,6 +7,7 @@ package backup
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -253,3 +254,89 @@ func TestSubmitManifest_RejectsCanceledSnapshot(t *testing.T) {
 // ADR-051: an archive-delta increment submits through SubmitManifest, so the
 // post-cancel late-submit rejection is covered by TestSubmitManifest_RejectsCanceledSnapshot
 // above — there is no separate SubmitIncrementalManifest path to test.
+
+// --- manifest index deletion on snapshot delete ----------------------------
+
+// fakeIndexDeleter records Delete calls and optionally returns an error.
+type fakeIndexDeleter struct {
+	deleted []string
+	errOn   string // if non-empty, return an error when this key is deleted
+}
+
+func (f *fakeIndexDeleter) Delete(_ context.Context, key string) error {
+	f.deleted = append(f.deleted, key)
+	if f.errOn != "" && f.errOn == key {
+		return errors.New("simulated storage error")
+	}
+	return nil
+}
+
+// TestDeleteSnapshotForUser_DeletesManifestObject asserts that deleting a
+// snapshot also deletes its manifest.json index object from object storage, and
+// that the expected key matches the manifestIndexKey construction.
+func TestDeleteSnapshotForUser_DeletesManifestObject(t *testing.T) {
+	repo := newDeleteCancelFakeRepo()
+	deleter := &fakeIndexDeleter{}
+	svc := buildDeleteCancelSvc(repo)
+	svc.SetIndexDeleter(deleter)
+
+	tenantID, siteID := uuid.New(), uuid.New()
+	snap := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: siteID, Status: StatusCompleted}
+	repo.setSnapshot(snap)
+
+	if err := svc.DeleteSnapshotForUser(context.Background(), tenantID, snap.ID); err != nil {
+		t.Fatalf("DeleteSnapshotForUser: unexpected error: %v", err)
+	}
+	if !repo.deleted[snap.ID] {
+		t.Fatalf("snapshot DB row was not deleted")
+	}
+
+	want := manifestIndexKey(tenantID, siteID, snap.ID)
+	if len(deleter.deleted) != 1 || deleter.deleted[0] != want {
+		t.Fatalf("manifest delete calls = %v, want [%q]", deleter.deleted, want)
+	}
+}
+
+// TestDeleteSnapshotForUser_MissingManifestDoesNotFail asserts that a storage
+// error on manifest delete (e.g. already-absent object returning an unexpected
+// status) does NOT fail the snapshot delete — best-effort contract.
+func TestDeleteSnapshotForUser_MissingManifestDoesNotFail(t *testing.T) {
+	repo := newDeleteCancelFakeRepo()
+	tenantID, siteID := uuid.New(), uuid.New()
+	snap := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: siteID, Status: StatusCompleted}
+	repo.setSnapshot(snap)
+
+	wantKey := manifestIndexKey(tenantID, siteID, snap.ID)
+	deleter := &fakeIndexDeleter{errOn: wantKey}
+	svc := buildDeleteCancelSvc(repo)
+	svc.SetIndexDeleter(deleter)
+
+	// Even though the deleter returns an error, DeleteSnapshotForUser must succeed.
+	if err := svc.DeleteSnapshotForUser(context.Background(), tenantID, snap.ID); err != nil {
+		t.Fatalf("DeleteSnapshotForUser: manifest delete error must not propagate, got: %v", err)
+	}
+	if !repo.deleted[snap.ID] {
+		t.Fatalf("snapshot DB row was not deleted")
+	}
+	// The delete was still attempted.
+	if len(deleter.deleted) == 0 {
+		t.Fatalf("manifest delete was not attempted")
+	}
+}
+
+// TestDeleteSnapshotForUser_NoDeleterIsNoop asserts that when no IndexDeleter
+// is wired (nil), DeleteSnapshotForUser still succeeds without panicking.
+func TestDeleteSnapshotForUser_NoDeleterIsNoop(t *testing.T) {
+	repo := newDeleteCancelFakeRepo()
+	svc := buildDeleteCancelSvc(repo) // no SetIndexDeleter
+	tenantID := uuid.New()
+	snap := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: uuid.New(), Status: StatusCompleted}
+	repo.setSnapshot(snap)
+
+	if err := svc.DeleteSnapshotForUser(context.Background(), tenantID, snap.ID); err != nil {
+		t.Fatalf("DeleteSnapshotForUser (no deleter): unexpected error: %v", err)
+	}
+	if !repo.deleted[snap.ID] {
+		t.Fatalf("snapshot DB row was not deleted")
+	}
+}

--- a/apps/api/internal/backup/gc.go
+++ b/apps/api/internal/backup/gc.go
@@ -77,8 +77,11 @@ func (s *Service) RunRetentionGC(ctx context.Context, tenantID uuid.UUID) (snaps
 		return 0, 0, err
 	}
 
-	// expiredIDs: snapshots selected for metadata deletion across all sites.
-	expiredIDs := map[uuid.UUID]bool{}
+	// expiredIDs maps snapshot ID → site ID for every snapshot selected for
+	// metadata deletion across all sites. The site ID is carried so Phase 5 can
+	// construct the manifest key (tenant/<tenantID>/site/<siteID>/backup/<id>/manifest.json)
+	// without an extra DB round-trip.
+	expiredIDs := map[uuid.UUID]uuid.UUID{}
 	// retainedMetas: every completed snapshot that survives the prune, across all
 	// sites (dedup is tenant-global, so the retained set must be tenant-wide).
 	var retainedMetas []SnapshotMeta
@@ -139,7 +142,7 @@ func (s *Service) RunRetentionGC(ctx context.Context, tenantID uuid.UUID) (snaps
 				delete(deleteSet, m.ID)
 			}
 			if deleteSet[m.ID] {
-				expiredIDs[m.ID] = true
+				expiredIDs[m.ID] = siteID
 				continue
 			}
 			// Retained. Track it and its chain's highest retained generation.
@@ -241,7 +244,7 @@ func (s *Service) RunRetentionGC(ctx context.Context, tenantID uuid.UUID) (snaps
 	// to exist (CHECK 1), and deleting an older generation's file_index rows would
 	// make a carry-forward chunk unreachable on a LATER GC run (re-sweeping it).
 	// So we skip any expired id that also appears in the marked (pinned) set.
-	for id := range expiredIDs {
+	for id, sid := range expiredIDs {
 		if _, pinned := markSnaps[id]; pinned {
 			continue
 		}
@@ -249,6 +252,9 @@ func (s *Service) RunRetentionGC(ctx context.Context, tenantID uuid.UUID) (snaps
 			return snapshotsDeleted, chunksDeleted, dserr
 		}
 		snapshotsDeleted++
+		// Delete the per-snapshot manifest.json index object. Best-effort: the DB
+		// row is already gone; an error or an absent object is logged and ignored.
+		s.deleteManifestIndex(ctx, tenantID, sid, id)
 	}
 
 	return snapshotsDeleted, chunksDeleted, nil

--- a/apps/api/internal/backup/service.go
+++ b/apps/api/internal/backup/service.go
@@ -79,6 +79,17 @@ type IndexPutter interface {
 	Put(ctx context.Context, key string, body io.Reader, size int64) error
 }
 
+// IndexDeleter removes an object from object storage at an arbitrary key. Used
+// to delete the per-snapshot manifest.json index object when a snapshot is
+// deleted. It is the narrow complement to IndexPutter so tests can stub it
+// independently.
+//
+// Implementations: *blobstore.Store satisfies this interface via its Delete
+// method, which treats 404 as success (idempotent delete).
+type IndexDeleter interface {
+	Delete(ctx context.Context, key string) error
+}
+
 // PresignerForSnapshot is the ADR-036 P1 storage adapter routing interface:
 // given a snapshot it returns the Presigner that should service its
 // chunk-upload/download for the snapshot's destination. The blobstore.Registry
@@ -115,6 +126,10 @@ type Service struct {
 	// indexPutter writes the per-snapshot manifest index object (M5.7 P4).
 	// Optional: when nil the index write is skipped (best-effort by design).
 	indexPutter IndexPutter
+	// indexDeleter removes the per-snapshot manifest index object on delete.
+	// Optional: when nil the manifest object is not explicitly deleted (it will
+	// remain orphaned in object storage until a lifecycle rule reclaims it).
+	indexDeleter IndexDeleter
 	// mailer sends backup-completion/failure notification emails (Track B, m49).
 	// Optional: when nil, notification emails are silently suppressed.
 	mailer BackupMailer
@@ -132,6 +147,14 @@ func (s *Service) SetRegistry(r PresignerForSnapshot) { s.registry = r }
 // A write failure is best-effort: it is logged but never fails the backup.
 // Call once at startup before serving traffic; safe to omit in tests.
 func (s *Service) SetIndexPutter(p IndexPutter) { s.indexPutter = p }
+
+// SetIndexDeleter wires the manifest-index deleter. When set, every snapshot
+// deletion (DeleteSnapshotForUser and the retention GC metadata prune) issues
+// a best-effort delete of the snapshot's manifest.json object so no orphaned
+// manifest keys accumulate in object storage. A delete failure (including an
+// already-absent object) is logged as a warning and never fails the delete.
+// Call once at startup before serving traffic; safe to omit in tests.
+func (s *Service) SetIndexDeleter(d IndexDeleter) { s.indexDeleter = d }
 
 // SetMailer wires the transactional-email enqueuer for backup-completion
 // notifications (Track B, m49). Call once at startup after River is started.
@@ -1559,6 +1582,29 @@ func (s *Service) writeManifestIndex(ctx context.Context, snap Snapshot, in Reco
 	}
 }
 
+// deleteManifestIndex removes the per-snapshot manifest.json index object from
+// object storage. It is the mirror of writeManifestIndex and carries the same
+// best-effort contract: any error (including a missing object, which the
+// blobstore already treats as success) is logged as a warning and never fails
+// the caller — the snapshot row is already gone and the orphaned manifest object
+// is harmless (a lifecycle rule or the next explicit cleanup can reclaim it).
+//
+// tenantID, siteID, snapshotID must be known before calling; typically the
+// caller already holds the Snapshot value fetched before deleting the DB row.
+func (s *Service) deleteManifestIndex(ctx context.Context, tenantID, siteID, snapshotID uuid.UUID) {
+	if s.indexDeleter == nil {
+		return
+	}
+	key := manifestIndexKey(tenantID, siteID, snapshotID)
+	if err := s.indexDeleter.Delete(ctx, key); err != nil {
+		slog.WarnContext(ctx, "backup: manifest index delete failed (best-effort, snapshot delete unaffected)",
+			slog.String("snapshot_id", snapshotID.String()),
+			slog.String("tenant_id", tenantID.String()),
+			slog.String("key", key),
+			slog.Any("error", err))
+	}
+}
+
 // getSnapshotForPresign is the M5.7 P4 helper used by PresignChunks and
 // PlanRestore. It runs the gating snapshot lookup inside the correct scoped
 // transaction based on the principal found (or not) on the request context:
@@ -1754,6 +1800,13 @@ func (s *Service) DeleteSnapshotForUser(ctx context.Context, tenantID, snapshotI
 	if derr := s.repo.DeleteSnapshot(ctx, tenantID, snapshotID); derr != nil {
 		return derr
 	}
+
+	// Delete the per-snapshot manifest.json index object. Best-effort: the DB row
+	// is already gone; a storage error (including an absent manifest on a snapshot
+	// that never completed its write) is logged as a warning and does not fail the
+	// delete. We call this after the DB delete so a transient storage failure can
+	// never strand the DB row in an inconsistent state.
+	s.deleteManifestIndex(ctx, tenantID, snap.SiteID, snapshotID)
 
 	// Reclaim orphaned chunks via the reachability-based GC over the survivors.
 	// Best-effort: the row is already gone; a sweep error is logged, not fatal.

--- a/apps/web/src/features/backups/backup-schedule-editor.tsx
+++ b/apps/web/src/features/backups/backup-schedule-editor.tsx
@@ -1093,16 +1093,18 @@ export function BackupScheduleEditor({ siteId }: { siteId: string }) {
 
 // ---------------------------------------------------------------------------
 // NextRunLine — renders one scheduled time as absolute (site tz) + relative
+// Exported so the "Backup schedule runs" upcoming panel can reuse the same
+// formatting without duplicating the Intl/relativeTime logic.
 // ---------------------------------------------------------------------------
 
-interface NextRunLineProps {
+export interface NextRunLineProps {
   label: string;
   iso: string;
   timezone: string;
   compact?: boolean;
 }
 
-function NextRunLine({ label, iso, timezone, compact = false }: NextRunLineProps) {
+export function NextRunLine({ label, iso, timezone, compact = false }: NextRunLineProps) {
   const abs = formatInSiteTz(iso, timezone);
   const rel = relativeTime(iso);
 

--- a/apps/web/src/features/backups/backups-section.tsx
+++ b/apps/web/src/features/backups/backups-section.tsx
@@ -39,6 +39,7 @@ import {
   useLockBackup,
   useUnlockBackup,
   useBackupSettingsContents,
+  useBackupSchedule,
 } from "@/features/backups/use-backups";
 import {
   StatusBadge,
@@ -58,7 +59,10 @@ import {
   type ScheduleRun,
   type ScheduleRunStatus,
 } from "@/features/backups/use-schedule-runs";
-import { BackupScheduleEditor } from "@/features/backups/backup-schedule-editor";
+import {
+  BackupScheduleEditor,
+  NextRunLine,
+} from "@/features/backups/backup-schedule-editor";
 import { formatBytes, relativeTime } from "@/lib/utils";
 import type { BackupSnapshot } from "@wpmgr/api";
 
@@ -1010,6 +1014,13 @@ const SCHEDULE_STATUS_LABEL: Record<ScheduleRunStatus, string> = {
 
 function ScheduleRunsSection({ siteId }: { siteId: string }) {
   const { data, isPending, isError, error, refetch } = useScheduleRuns(siteId);
+  // Re-use the already-fetched schedule (same Query cache key as BackupScheduleEditor
+  // below — no extra network request). We need it to drive the upcoming empty-state:
+  // the scheduler only materialises a `backup_schedule_runs` row shortly before a
+  // run fires, so `upcoming` is usually empty even when the schedule is enabled.
+  const { data: schedule } = useBackupSchedule(siteId);
+
+  const browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
 
   if (isPending) {
     return (
@@ -1033,16 +1044,24 @@ function ScheduleRunsSection({ siteId }: { siteId: string }) {
 
   const { upcoming, past } = data;
 
+  // Projected next runs from the schedule (server-computed, always consistent
+  // with the "Next run" and "Next 3 runs" strip in the Backup schedule card
+  // below). Only populated when a schedule exists and is enabled — the
+  // scheduler materialises `backup_schedule_runs` rows only shortly before
+  // each fire, so `upcoming` is usually empty even with an active schedule.
+  const projectedRuns: string[] = (() => {
+    if (!schedule?.enabled) return [];
+    if (schedule.next_runs.length > 0) return schedule.next_runs;
+    if (schedule.next_run_at) return [schedule.next_run_at];
+    return [];
+  })();
+
   return (
     <div className="space-y-6">
       {/* Upcoming */}
       <div>
         <h3 className="mb-2 text-sm font-semibold text-foreground">Upcoming</h3>
-        {upcoming.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            No upcoming runs. Enable the backup schedule to queue runs.
-          </p>
-        ) : (
+        {upcoming.length > 0 ? (
           <div className="overflow-x-auto">
             <Table>
               <TableHeader>
@@ -1062,6 +1081,29 @@ function ScheduleRunsSection({ siteId }: { siteId: string }) {
               </TableBody>
             </Table>
           </div>
+        ) : projectedRuns.length > 0 ? (
+          // No materialised rows yet, but the schedule is enabled. Show the
+          // server-computed projection so the panel agrees with the "Next run"
+          // and "Next 3 runs" strip in the Backup schedule card below.
+          <div className="space-y-1.5">
+            <p className="text-xs text-muted-foreground">
+              Runs are queued shortly before they are due. Projected next{" "}
+              {projectedRuns.length === 1 ? "run" : "runs"}:
+            </p>
+            <ol className="space-y-0.5">
+              {projectedRuns.map((iso) => (
+                <li key={iso}>
+                  <NextRunLine label="" iso={iso} timezone={browserTz} compact />
+                </li>
+              ))}
+            </ol>
+          </div>
+        ) : (
+          // Schedule is disabled (or not yet created). Prompt the user to
+          // enable it — only show this when it is actually applicable.
+          <p className="text-sm text-muted-foreground">
+            No upcoming runs. Enable the backup schedule to queue runs.
+          </p>
         )}
       </div>
 

--- a/docs/wporg/reviewer-reply-2026-06-25.md
+++ b/docs/wporg/reviewer-reply-2026-06-25.md
@@ -1,0 +1,46 @@
+Hi, and thank you for the detailed re-review and for setting the slug to `fleet-agent-site-manager`.
+
+I have uploaded a corrected version. Below is a point-by-point response: what I changed, and, for a few items, why a small number of patterns are intentional with the safeguards already in place.
+
+## Changed in this upload
+
+**Plugin name (trademark).** The display name is now **"Fleet Agent Site Manager"** (no "WP"). "WPMgr" remains only as the name of the control plane / hosted service the plugin connects to (in the description prose), never as the plugin's own name.
+
+**Text domain.** Now matches the slug: every gettext call and the header use `fleet-agent-site-manager`.
+
+**Not-permitted files.** The build no longer ships the vendor Python data-scripts (`vendor/bjeavons/zxcvbn-php/data-scripts/*.py`) or `composer.json`. The distributed ZIP now contains only PHP/JS/CSS/readme and the pre-built vendor runtime.
+
+**External services (Have I Been Pwned).** I added a dedicated entry to `== External services ==`. When the optional password-policy breach check is enabled and a user sets or changes a password, the plugin sends **only the first 5 characters of the SHA-1 hash** of the candidate password (a k-anonymity range query, the HIBP range API model) to the WPMgr control plane, which relays the prefix to Have I Been Pwned. The full password and full hash never leave the site; the 35-char suffix is matched locally. The readme documents both hops, the data sent, the trigger, and links HIBP Terms/Privacy and the control-plane Terms/Privacy. The check is off by default.
+
+**File and directory locations.** I switched the flagged hardcoded `WP_CONTENT_DIR . '/plugins'` paths to prefer `WP_PLUGIN_DIR` (autologin, size-probe, snapshot-manager fallbacks), and added `ABSPATH` as a candidate to the restore GC sweep that previously used only `dirname(WP_CONTENT_DIR)`. Writable user data already routes through a `wp_upload_dir()`-first helper (`StoragePaths`) that stores under `uploads/wpmgr-<purpose>`. The remaining `ABSPATH` / `WP_CONTENT_DIR` references are the WordPress-documented way to do what they do, and are described below.
+
+**File-write containment (made explicit).** For the operator file-write command I added an explicit realpath jail assertion immediately before the move, so the containment is visible at the call site (see below).
+
+## Intentional implementation details (with safeguards)
+
+**Determining locations: the remaining `ABSPATH` / `WP_CONTENT_DIR` uses.** These are not hardcoded guesses; they are the documented constants used for their documented purpose:
+- Loading WordPress core files from the real root, e.g. `ABSPATH . 'wp-admin/includes/plugin.php'`, `ABSPATH . 'wp-includes/PHPMailer/PHPMailer.php'`. There is no helper for `wp-admin`/`wp-includes`; `ABSPATH` is correct.
+- A backup/restore and malware-scan plugin must enumerate and write the real site tree, so it resolves `ABSPATH` (core) and `WP_CONTENT_DIR` (content) as the things it archives, measures, or restores. Each such write carries an inline justification.
+- The only paths the plugin keeps inside `wp-content` are: the page-cache and object-cache **drop-ins** (which by definition live in `wp-content`), the **opt-in** mu-plugin loaders (removed on opt-out/deactivate), and the **in-flight backup/restore scratch dir**. The scratch dir is deliberately in `wp-content` because it is the one location guaranteed PHP-writable across managed hosts (where `ABSPATH` is often read-only), and because a restore performs an atomic whole-`wp-content` swap, so the scratch must survive that swap rather than sit inside the data being swapped. Master encryption keys are stored **outside the webroot** (preferred) rather than in uploads, since uploads is web-accessible.
+
+**Unsafe SQL (direct mysqli).** The backup DB dump/restore and search-replace open a dedicated streaming `mysqli` connection because `$wpdb` buffers the entire result set into PHP memory and fatals (OOM) on large tables; `$wpdb` does not expose unbuffered streaming. No value is user-controlled: credentials are read from the `wp-config` `DB_*` constants, identifiers are backtick-escaped, every value is `real_escape_string()`-d (binary blobs hex-encoded), and table names are enumerated server-side. Each `new \mysqli(...)` carries an inline `phpcs:ignore` with this rationale.
+
+**Inline `<style>` / `<script>` in the optimizer.** The three cases run inside the page-cache write output buffer; the result is written to a static page-cache file that the advanced-cache drop-in serves **before WordPress loads**. The `wp_enqueue` lifecycle never executes for that cached response, so enqueue is structurally inapplicable. Output is escaped (`esc_url`, `wp_json_encode`).
+
+**File functions on remote files.** There are no remote `file_get_contents`/`fopen` calls in the plugin's own code. `class-task-runner.php` routes all http(s) through `wp_remote_get`; the `file_get_contents` there is reached only for `file://` test fixtures. The `readfile` in the cache drop-in and the snapshot `file_get_contents` read only local plugin-generated files.
+
+**File-write command (arbitrary write).** This is operator tooling: every file command requires an Ed25519-signed, single-use, short-lived JWT scoped to `cmd="file_write"`, verified server-side. The destination is jailed: it is realpath-resolved and contained within the jail root, passes an executable-extension deny-list (including double-extension and a `<?php`/`<?` content sniff) and a sensitive-file deny-list, and is symlink- and TOCTOU-re-checked immediately before the move. In this upload I added an explicit, redundant realpath containment assertion on the final destination directory immediately before the `rename()`, so the restriction is evident at the call site.
+
+**`FORCE_SSL_ADMIN`.** This constant is defined **only** when the site owner explicitly enables the "Force SSL" hardening toggle (default **off**), and only when the constant is not already set (`!defined()` guard), so it never overrides a site's own `wp-config` configuration.
+
+**Nonces on the 2FA setup form.** This handler runs on the pre-authentication login interstitial, before a WordPress user session exists to mint or verify a nonce against. It is instead protected by a single-use, TTL-bound, HMAC-signed session token verified with `hash_equals` against server-stored session state before any field is read; the step machine is server-authoritative and never `$_POST`-driven. This mirrors how the established two-factor interstitials operate.
+
+**Escaping on echo.** The flagged form output is assembled by concatenating individually escaped components (`esc_url`, `esc_attr`, `esc_html`, `esc_html__`), so every dynamic value is escaped before output; no unescaped variable reaches the browser.
+
+**Sanitizing `$_SERVER` / `$_COOKIE`.** These reads are in the `advanced-cache.php` drop-in, which runs before `wp-settings.php`, so `wp_unslash`/`sanitize_*` are unavailable by construction. Each read strips control characters and caps length, and host/protocol values pass a strict allowlist regex before any use in a path or `header()`. Client-IP resolution runs inside a booted request and applies `sanitize_text_field(wp_unslash())` followed by `FILTER_VALIDATE_IP`, so only a syntactically valid IP is ever returned or logged.
+
+**Unprefixed name.** The single flagged identifier, `font_dir`, is a WordPress 6.5 core filter (fired by `wp_get_font_dir()`); core hook names must not be prefixed. All plugin-owned hooks, options, transients, and classes are `wpmgr`-prefixed / namespaced.
+
+I tested the updated build on a clean WordPress install with `WP_DEBUG` enabled. Thank you again for the thorough review.
+
+Mosam

--- a/tools/plugincheck/run.sh
+++ b/tools/plugincheck/run.sh
@@ -5,22 +5,30 @@
 # plugin, installs the plugin-under-test from its built zip, and runs
 # `wp plugin check`. Exits non-zero on ANY error row.
 #
-# Usage:  PLUGIN_ZIP=/abs/path/to/fleet-agent-for-wpmgr.zip ./run.sh
+# Usage:  PLUGIN_ZIP=/abs/path/to/<slug>.zip ./run.sh
 # (driven by `make agent-plugincheck`).
 #
 set -euo pipefail
 cd "$(dirname "$0")"
 
-: "${PLUGIN_ZIP:?set PLUGIN_ZIP to the built fleet-agent-for-wpmgr.zip}"
+: "${PLUGIN_ZIP:?set PLUGIN_ZIP to the built plugin zip}"
 [ -f "$PLUGIN_ZIP" ] || { echo "run.sh: PLUGIN_ZIP not found: $PLUGIN_ZIP" >&2; exit 2; }
 
-SLUG="fleet-agent-for-wpmgr"
+# Derive the slug from the zip's top-level directory so we always check the
+# real shipped identity, never a hardcoded (possibly stale) slug.
+# Read the full listing into a var (no `| head`, which would SIGPIPE under
+# pipefail), then take the first path component = the top-level plugin dir.
+_ZIP_LISTING="$(unzip -Z1 "$PLUGIN_ZIP")"
+SLUG="${_ZIP_LISTING%%/*}"
+[ -n "$SLUG" ] || { echo "run.sh: could not derive slug from $PLUGIN_ZIP" >&2; exit 2; }
 export PLUGIN_ZIP
 
 cleanup() { docker compose down -v >/dev/null 2>&1 || true; }
 trap cleanup EXIT
 
-# The bind-mounted WP dir must be writable by the container user.
+# Wipe the bind-mounted WP dir so a stale plugin from a prior run (different
+# slug) can never shadow the build under test. Then recreate it writable.
+rm -rf wp
 mkdir -p wp && chmod -R 777 wp
 
 docker compose up -d


### PR DESCRIPTION
Three reporter-filed backup fixes (infoproxa-oss). Agent 0.61.3 + api + web. Plugin Check green; agent 2232 tests + CP go test + web lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file search, file read, file version listing, file version restore, and large-file download preparation capabilities.
  * Backup schedules now show projected upcoming runs even before jobs are created.

* **Bug Fixes**
  * Improved backup handling on sites that block loopback requests, with clearer failure reporting and fallback execution.
  * Strengthened file-write and restore safety checks to better prevent out-of-root writes.

* **Chores**
  * Updated plugin packaging, naming, and version metadata for the new site manager identity.
  * Improved cleanup of generated backup artifacts and release packaging outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->