### PR TITLE
perf(api): fix ~8s first-request-after-idle (Redis session pool borrowed dead conns)

### DIFF
--- a/apps/api/internal/auth/session.go
+++ b/apps/api/internal/auth/session.go
@@ -35,17 +35,46 @@ type SessionManager struct {
 }
 
 // NewRedisPool builds a redigo connection pool for the session store.
+//
+// Idle/timeout tuning is load-bearing for dashboard latency: Memorystore (and
+// the network path) silently drops idle TCP connections, but redigo keeps them
+// cached. Without IdleTimeout the first request after the dashboard sits idle
+// borrows a dead connection, and TestOnBorrow's PING then blocks on the dead
+// socket until the OS TCP retransmit timeout (~7-8s) before the pool redials —
+// surfacing as a one-off ~8s stall on the first request after idle while every
+// subsequent request is fast. The fixes:
+//   - IdleTimeout (4m, below the network/Memorystore idle drop) so the pool
+//     proactively closes idle connections before they go stale and are never
+//     borrowed dead.
+//   - MaxConnLifetime so connections rotate rather than accumulate.
+//   - Dial connect/read/write timeouts so a borrowed-dead PING (or a slow dial)
+//     fails in seconds, not on the multi-second OS TCP timeout.
+//   - TestOnBorrow skips the PING for recently-used connections (cheap path).
 func NewRedisPool(addr, password string) *redis.Pool {
 	return &redis.Pool{
-		MaxIdle: 10,
+		MaxIdle:         10,
+		MaxActive:       64,
+		IdleTimeout:     4 * time.Minute,
+		MaxConnLifetime: 30 * time.Minute,
+		Wait:            true,
 		Dial: func() (redis.Conn, error) {
-			opts := []redis.DialOption{}
+			opts := []redis.DialOption{
+				redis.DialConnectTimeout(5 * time.Second),
+				redis.DialReadTimeout(3 * time.Second),
+				redis.DialWriteTimeout(3 * time.Second),
+			}
 			if password != "" {
 				opts = append(opts, redis.DialPassword(password))
 			}
 			return redis.Dial("tcp", addr, opts...)
 		},
-		TestOnBorrow: func(c redis.Conn, _ time.Time) error {
+		TestOnBorrow: func(c redis.Conn, lastUsed time.Time) error {
+			// Recently-exercised connections are trusted without a round-trip;
+			// only idle-ish ones get a PING, which is now bounded by the dial
+			// read timeout so it can never hang on a dead socket.
+			if time.Since(lastUsed) < time.Minute {
+				return nil
+			}
 			_, err := c.Do("PING")
 			return err
 		},


### PR DESCRIPTION
The actual root cause of the slow /api/v1/sites after idle. The redigo session pool had no IdleTimeout / dial timeouts, so after idle it borrowed a dead Memorystore connection and TestOnBorrow's PING hung on the dead socket ~7.5s before redialing. Added IdleTimeout=4m + MaxConnLifetime + dial connect/read/write timeouts + a recently-used skip. Already deployed to prod as api 0.61.5. api-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling for faster, more reliable logins and session activity under load.
  * Reduced delays caused by stale connections, especially after periods of inactivity.
  * Added stricter timeout settings to help the app recover more gracefully from slow or unreliable Redis connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->