### PR TITLE
perf(api): m86 probed_at index for uptime retention GC (CodeRabbit #121 follow-up)

### DIFF
--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -959,6 +959,11 @@ CREATE INDEX site_uptime_probes_agg_idx
 CREATE INDEX site_uptime_probes_tenant_time_idx
     ON site_uptime_probes (tenant_id, probed_at DESC);
 
+-- Retention GC delete (WHERE probed_at < cutoff) — leads on probed_at so the
+-- daily prune is an index range scan, not a full table scan (m86).
+CREATE INDEX site_uptime_probes_probed_at_idx
+    ON site_uptime_probes (probed_at);
+
 ALTER TABLE site_uptime_probes ENABLE ROW LEVEL SECURITY;
 ALTER TABLE site_uptime_probes FORCE ROW LEVEL SECURITY;
 CREATE POLICY site_uptime_probes_tenant_isolation ON site_uptime_probes

--- a/apps/api/migrations/20260719000000_m86_uptime_probes_retention_idx.sql
+++ b/apps/api/migrations/20260719000000_m86_uptime_probes_retention_idx.sql
@@ -1,0 +1,23 @@
+-- m86: probed_at index so the retention GC delete is index-driven, not a seq scan
+--
+-- The UptimeProbeGCWorker daily delete is:
+--   DELETE FROM site_uptime_probes
+--   WHERE id IN (SELECT id FROM site_uptime_probes WHERE probed_at < $1 LIMIT N)
+--
+-- After m85 the table's indexes lead on (site_id, ...) and (tenant_id, ...);
+-- NONE leads on probed_at. So a predicate on probed_at alone cannot use an
+-- index and Postgres sequentially scans the whole table to find the old rows.
+-- On a large table that daily full scan is wasteful AND evicts the hot pages
+-- the fleet-uptime query depends on from the shared buffer pool — which would
+-- re-introduce the cold-cache latency m85 just removed, once per day.
+--
+-- Fix: a plain btree index leading on probed_at lets the retention subquery do
+-- an index range scan over just the oldest rows. The write cost is one extra
+-- index maintained per probe insert, acceptable for a low-rate append table and
+-- far cheaper than the recurring full scan.
+--
+-- Plain CREATE INDEX (the migration runner wraps each migration in a tx, so
+-- CONCURRENTLY is unavailable — see m85); IF NOT EXISTS makes it re-run safe.
+
+CREATE INDEX IF NOT EXISTS site_uptime_probes_probed_at_idx
+    ON site_uptime_probes (probed_at);


### PR DESCRIPTION
Addresses CodeRabbit's valid Major finding on #121: the m85 retention DELETE (WHERE probed_at < cutoff) had no probed_at-leading index → full table scan that would evict the fleet-uptime cache pages daily. Adds a (probed_at) btree index. Already deployed as api 0.61.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved cleanup performance for uptime probe records, making older data removal faster and less likely to impact database load.
  * This should help keep the system responsive as probe history grows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->