### PR TITLE
fix(#127 critical): clear .maintenance on failed updates + retry post-update health probe

### DIFF
--- a/apps/agent/includes/commands/class-rollback-command.php
+++ b/apps/agent/includes/commands/class-rollback-command.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace WPMgr\Agent\Commands;
 
+use WPMgr\Agent\Support\Maintenance;
 use WPMgr\Agent\Support\SnapshotManager;
 use WPMgr\Agent\Support\UpdateRunner;
 
@@ -65,6 +66,13 @@ final class RollbackCommand implements CommandInterface
      */
     public function execute(array $claims, array $params): array
     {
+        // Heal a `.maintenance` flag left behind by a prior interrupted
+        // update/rollback before starting new work, and arm the shutdown
+        // backstop so a fatal error or a timeout mid-rollback still clears
+        // whatever flag THIS run may leave set.
+        Maintenance::healStaleIfPresent();
+        Maintenance::armShutdownGuard();
+
         $type       = isset($params['type']) && is_string($params['type']) ? $params['type'] : '';
         $rawSlug    = isset($params['slug']) && is_string($params['slug']) ? $params['slug'] : '';
         $snapshotId = isset($params['snapshot_id']) && is_string($params['snapshot_id']) ? $params['snapshot_id'] : '';
@@ -74,50 +82,59 @@ final class RollbackCommand implements CommandInterface
             return $this->fail('Invalid type.');
         }
 
-        if ($type === 'core') {
-            return $this->rollbackCore($snapshotId, $toVersion);
-        }
-
-        // plugin / theme
-        $slug = UpdateCommand::sanitizeSlug($rawSlug);
-        if ($slug === '' || $slug !== $rawSlug) {
-            return $this->fail('Invalid or unsafe slug.');
-        }
-        if ($snapshotId === '') {
-            return $this->fail('Missing snapshot_id.');
-        }
-
+        // GUARANTEE: this is precisely the reported incident — a rollback
+        // that itself fails (the new version is already active, the restore
+        // errors, etc.) must still clear maintenance mode. Everything from
+        // here on is wrapped so success, failure, or a thrown exception all
+        // reach the `finally`.
         try {
-            $restore = $this->snapshots->restore($type, $slug, $snapshotId);
-        } catch (\Throwable $e) {
-            return $this->fail('Restore error.');
-        }
+            if ($type === 'core') {
+                return $this->rollbackCore($snapshotId, $toVersion);
+            }
 
-        if (!$restore['ok']) {
+            // plugin / theme
+            $slug = UpdateCommand::sanitizeSlug($rawSlug);
+            if ($slug === '' || $slug !== $rawSlug) {
+                return $this->fail('Invalid or unsafe slug.');
+            }
+            if ($snapshotId === '') {
+                return $this->fail('Missing snapshot_id.');
+            }
+
+            try {
+                $restore = $this->snapshots->restore($type, $slug, $snapshotId);
+            } catch (\Throwable $e) {
+                return $this->fail('Restore error.');
+            }
+
+            if (!$restore['ok']) {
+                return [
+                    'ok'               => false,
+                    'restored_version' => '',
+                    'log'              => $restore['log'],
+                ];
+            }
+
+            // Determine the version after restore; prefer the recorded prior version.
+            $restoredVersion = $this->runner->currentVersion($type, $slug);
+            if ($restoredVersion === '') {
+                $restoredVersion = $this->snapshots->recordedVersion($snapshotId);
+            }
+            if ($restoredVersion === '' && $toVersion !== '') {
+                $restoredVersion = $toVersion;
+            }
+
+            // Snapshot consumed; remove it.
+            $this->snapshots->cleanup($snapshotId);
+
             return [
-                'ok'               => false,
-                'restored_version' => '',
+                'ok'               => true,
+                'restored_version' => $restoredVersion,
                 'log'              => $restore['log'],
             ];
+        } finally {
+            Maintenance::clear();
         }
-
-        // Determine the version after restore; prefer the recorded prior version.
-        $restoredVersion = $this->runner->currentVersion($type, $slug);
-        if ($restoredVersion === '') {
-            $restoredVersion = $this->snapshots->recordedVersion($snapshotId);
-        }
-        if ($restoredVersion === '' && $toVersion !== '') {
-            $restoredVersion = $toVersion;
-        }
-
-        // Snapshot consumed; remove it.
-        $this->snapshots->cleanup($snapshotId);
-
-        return [
-            'ok'               => true,
-            'restored_version' => $restoredVersion,
-            'log'              => $restore['log'],
-        ];
     }
 
     /**

--- a/apps/agent/includes/commands/class-update-command.php
+++ b/apps/agent/includes/commands/class-update-command.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace WPMgr\Agent\Commands;
 
+use WPMgr\Agent\Support\Maintenance;
 use WPMgr\Agent\Support\SnapshotManager;
 use WPMgr\Agent\Support\UpdateRunner;
 
@@ -70,6 +71,13 @@ final class UpdateCommand implements CommandInterface
      */
     public function execute(array $claims, array $params): array
     {
+        // Heal a `.maintenance` flag left behind by a prior interrupted
+        // update/rollback before starting new work, and arm the shutdown
+        // backstop so a fatal error or a timeout mid-update still clears
+        // whatever flag THIS run may leave set.
+        Maintenance::healStaleIfPresent();
+        Maintenance::armShutdownGuard();
+
         $dryRun   = isset($params['dry_run']) && (bool) $params['dry_run'];
         $snapshot = isset($params['snapshot']) && (bool) $params['snapshot'];
 
@@ -127,26 +135,34 @@ final class UpdateCommand implements CommandInterface
                 return $this->dryRun($type, $slug, $version, $fromVersion);
             }
 
-            // --- Optional pre-update snapshot. ---
-            $snapshotId = '';
-            $log        = '';
-            if ($snapshot) {
-                $snap        = $this->snapshots->capture($type, $slug, $fromVersion);
-                $snapshotId  = $snap['snapshot_id'];
-                $log        .= $snap['log'];
+            // GUARANTEE: whatever this item's snapshot/apply work does below —
+            // succeed, fail, or throw — a `finally` clears any `.maintenance`
+            // flag before we move on, so a failed item can never leave the
+            // whole site dark for the rest of the batch (or indefinitely).
+            try {
+                // --- Optional pre-update snapshot. ---
+                $snapshotId = '';
+                $log        = '';
+                if ($snapshot) {
+                    $snap        = $this->snapshots->capture($type, $slug, $fromVersion);
+                    $snapshotId  = $snap['snapshot_id'];
+                    $log        .= $snap['log'];
+                }
+
+                // --- Apply the update. ---
+                $applied = $this->runner->apply($type, $slug, $version);
+                $log    .= ($log !== '' ? "\n" : '') . $applied['log'];
+
+                $toVersion = $this->runner->currentVersion($type, $slug);
+
+                $status = $applied['ok']
+                    ? ($toVersion !== $fromVersion ? 'succeeded' : 'up_to_date')
+                    : 'failed';
+
+                return $this->result($type, $slug, $fromVersion, $toVersion, $status, $snapshotId, $log);
+            } finally {
+                Maintenance::clear();
             }
-
-            // --- Apply the update. ---
-            $applied = $this->runner->apply($type, $slug, $version);
-            $log    .= ($log !== '' ? "\n" : '') . $applied['log'];
-
-            $toVersion = $this->runner->currentVersion($type, $slug);
-
-            $status = $applied['ok']
-                ? ($toVersion !== $fromVersion ? 'succeeded' : 'up_to_date')
-                : 'failed';
-
-            return $this->result($type, $slug, $fromVersion, $toVersion, $status, $snapshotId, $log);
         } catch (\Throwable $e) {
             // Never leak internals; keep the per-item failure contained.
             return $this->result($type, $slug, '', '', 'failed', '', 'Update error.');

--- a/apps/agent/includes/support/class-maintenance.php
+++ b/apps/agent/includes/support/class-maintenance.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Maintenance: guarantees WordPress core's `<ABSPATH>/.maintenance` drop-file
+ * never survives an agent-driven update or rollback, on any terminal path.
+ *
+ * WordPress core's WP_Upgrader::maintenance_mode(true) (and, for core updates,
+ * update_core() in wp-admin/includes/update-core.php) writes `.maintenance` at
+ * the start of an upgrade and deletes it at the end — but core has several
+ * early-return paths between those two points that never reach the delete.
+ * When an update/rollback the agent triggers throws, times out, or is
+ * interrupted along one of those paths, `.maintenance` is orphaned and the
+ * ENTIRE site serves HTTP 503 to every visitor until someone deletes it by
+ * hand.
+ *
+ * This class is the single seam both UpdateRunner (which owns the actual
+ * upgrader calls) and the update/rollback commands (which own the overall
+ * request lifecycle) use to guarantee cleanup:
+ *   - clear() is called from a try/finally so success, failure, a thrown
+ *     exception, or an early return all reach it.
+ *   - armShutdownGuard() registers a belt-and-suspenders shutdown callback so
+ *     a PHP fatal error or a max_execution_time timeout — neither of which
+ *     unwinds try/finally — still clears the flag once the request tears down.
+ *   - healStaleIfPresent() proactively heals a `.maintenance` left behind by a
+ *     PRIOR failed run the next time a managed update/rollback starts, without
+ *     touching a fresh flag another in-flight process may legitimately own.
+ *
+ * @package WPMgr\Agent\Support
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Support;
+
+/**
+ * Clears and heals the WordPress core maintenance-mode drop-file.
+ */
+final class Maintenance
+{
+    /**
+     * A `.maintenance` file older than this is treated as orphaned rather
+     * than possibly owned by another in-flight update/rollback. WordPress
+     * upgrades of the sizes the agent handles complete in well under a
+     * minute; this stays comfortably above that while still healing quickly.
+     */
+    private const STALE_AFTER_SECONDS = 90;
+
+    /**
+     * Resolve the absolute path to WordPress's maintenance-mode drop-file.
+     *
+     * @return string Absolute path, or '' when ABSPATH is unavailable.
+     */
+    public static function path(): string
+    {
+        if (!defined('ABSPATH')) {
+            return '';
+        }
+
+        $abspath = rtrim((string) ABSPATH, '/\\');
+        if ($abspath === '') {
+            return '';
+        }
+
+        return $abspath . '/.maintenance';
+    }
+
+    /**
+     * Heal a STALE `.maintenance` left behind by a prior interrupted run,
+     * before starting a new managed update/rollback. A flag younger than
+     * STALE_AFTER_SECONDS is left alone — it may belong to another in-flight
+     * upgrade (ours or an operator's) that legitimately owns it right now.
+     *
+     * @return void
+     */
+    public static function healStaleIfPresent(): void
+    {
+        $file = self::path();
+        if ($file === '' || !file_exists($file)) {
+            return;
+        }
+
+        $mtime = @filemtime($file);
+        if ($mtime === false) {
+            return;
+        }
+
+        $age = time() - $mtime;
+        if ($age < self::STALE_AFTER_SECONDS) {
+            return;
+        }
+
+        DebugLog::write(
+            'WPMgr Agent: healing stale .maintenance flag (' . $age
+            . 's old) before starting a managed update/rollback.'
+        );
+
+        self::removeFile($file);
+    }
+
+    /**
+     * Clear maintenance mode. Intended to be called from a `finally` block
+     * wrapping every update/rollback code path, regardless of outcome.
+     *
+     * Prefers the WP-native upgrader call when an upgrader instance is
+     * available (it also drives the upgrader skin's feedback hooks), then
+     * unconditionally verifies the file itself is gone — the upgrader call
+     * relies on a WP_Filesystem connection that may be uninitialized or may
+     * itself have failed, so it is not trusted on its own.
+     *
+     * @param object|null $upgrader An upgrader instance exposing
+     *                              maintenance_mode(bool), when available.
+     * @return void
+     */
+    public static function clear(?object $upgrader = null): void
+    {
+        if ($upgrader !== null && method_exists($upgrader, 'maintenance_mode')) {
+            try {
+                $upgrader->maintenance_mode(false);
+            } catch (\Throwable $e) {
+                DebugLog::write(
+                    'WPMgr Agent: upgrader maintenance_mode(false) threw: ' . $e->getMessage()
+                );
+            }
+        }
+
+        $file = self::path();
+        if ($file !== '' && file_exists($file)) {
+            self::removeFile($file);
+        }
+    }
+
+    /**
+     * Register a shutdown-time backstop that clears maintenance mode even if
+     * a fatal error or a request timeout skips every try/finally (neither
+     * unwinds the call stack the way a thrown Throwable does). Safe to call
+     * more than once per request — PHP tolerates duplicate shutdown callbacks
+     * and a redundant clear() is a cheap, idempotent no-op when there is
+     * nothing left to remove.
+     *
+     * @return void
+     */
+    public static function armShutdownGuard(): void
+    {
+        register_shutdown_function(static function (): void {
+            self::clear();
+        });
+    }
+
+    /**
+     * Remove the maintenance file, preferring the WP-native helper.
+     *
+     * @param string $file Absolute path (already resolved via self::path()).
+     * @return void
+     */
+    private static function removeFile(string $file): void
+    {
+        if (function_exists('wp_delete_file')) {
+            wp_delete_file($file);
+        } else {
+            // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- wp_delete_file() is not yet loaded this early in some contexts; best-effort removal of WP core's own maintenance drop-file (not a plugin-owned file), never fatal on a permissions error
+            @unlink($file);
+        }
+
+        if (file_exists($file)) {
+            DebugLog::write('WPMgr Agent: failed to remove .maintenance flag at ' . $file . '.');
+        }
+    }
+}

--- a/apps/agent/includes/support/class-update-runner.php
+++ b/apps/agent/includes/support/class-update-runner.php
@@ -186,7 +186,16 @@ class UpdateRunner
         $offer->partial_version = '';
 
         $upgrader = new \Core_Upgrader(new \WP_Ajax_Upgrader_Skin());
-        $result   = $upgrader->upgrade($offer);
+        try {
+            $result = $upgrader->upgrade($offer);
+        } finally {
+            // GUARANTEE: whatever core's update_core()/maintenance_mode() did
+            // or failed to do internally, this run's maintenance flag is
+            // cleared on every terminal path — success, WP_Error, or a thrown
+            // exception. See Maintenance class doc for why core alone cannot
+            // be trusted to always reach its own cleanup line.
+            Maintenance::clear($upgrader);
+        }
 
         return $this->upgraderOutcome($result);
     }
@@ -312,7 +321,14 @@ class UpdateRunner
                 $wasNetworkActive = function_exists('is_plugin_active_for_network') ? \is_plugin_active_for_network($slug) : false;
 
                 $upgrader = new \Plugin_Upgrader(new \WP_Ajax_Upgrader_Skin());
-                $result   = $upgrader->upgrade($slug);
+                try {
+                    $result = $upgrader->upgrade($slug);
+                } finally {
+                    // GUARANTEE: clear maintenance mode on every terminal
+                    // path of THIS upgrade() call, independent of whether it
+                    // succeeded, returned a WP_Error, or threw.
+                    Maintenance::clear($upgrader);
+                }
                 $outcome  = $this->upgraderOutcome($result);
 
                 if ($outcome['ok'] && ($wasActive || $wasNetworkActive) && function_exists('activate_plugin')) {
@@ -338,7 +354,11 @@ class UpdateRunner
                     return ['ok' => false, 'log' => 'Upgrader API unavailable.'];
                 }
                 $upgrader = new \Theme_Upgrader(new \WP_Ajax_Upgrader_Skin());
-                $result   = $upgrader->upgrade($slug);
+                try {
+                    $result = $upgrader->upgrade($slug);
+                } finally {
+                    Maintenance::clear($upgrader);
+                }
 
                 return $this->upgraderOutcome($result);
 
@@ -391,7 +411,11 @@ class UpdateRunner
         }
 
         $upgrader = new \Core_Upgrader(new \WP_Ajax_Upgrader_Skin());
-        $result   = $upgrader->upgrade($offer);
+        try {
+            $result = $upgrader->upgrade($offer);
+        } finally {
+            Maintenance::clear($upgrader);
+        }
 
         return $this->upgraderOutcome($result);
     }

--- a/apps/agent/tests/MaintenanceTest.php
+++ b/apps/agent/tests/MaintenanceTest.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * Tests for the Maintenance helper: guaranteed `.maintenance` cleanup on
+ * every terminal path, and safe stale-flag healing.
+ *
+ * Strategy: ABSPATH is defined in bootstrap.php as
+ * sys_get_temp_dir()/wpmgr_wp_abspath/site/. This test writes the real
+ * `.maintenance` marker file directly under that directory (mirroring where
+ * WordPress core itself puts it) and asserts on its presence/absence.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use WPMgr\Agent\Support\Maintenance;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\Maintenance
+ */
+final class MaintenanceTest extends TestCase
+{
+    /** Absolute path to the ABSPATH directory used by the test suite. */
+    private string $abspathDir = '';
+
+    /** Absolute path to the `.maintenance` file under ABSPATH. */
+    private string $maintenanceFile = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $abspath = defined('ABSPATH') ? rtrim((string) constant('ABSPATH'), '/\\') : '';
+        $this->abspathDir = $abspath;
+        if ($abspath !== '' && !is_dir($abspath)) {
+            mkdir($abspath, 0755, true);
+        }
+        $this->maintenanceFile = $abspath . '/.maintenance';
+
+        // Never start a test with a stray marker from a previous test.
+        $this->removeIfExists($this->maintenanceFile);
+    }
+
+    protected function tear_down(): void
+    {
+        $this->removeIfExists($this->maintenanceFile);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    private function removeIfExists(string $file): void
+    {
+        if ($file !== '' && file_exists($file)) {
+            unlink($file); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only cleanup of a fixture file
+        }
+    }
+
+    /**
+     * @param int $ageSeconds How far in the past to backdate mtime.
+     */
+    private function writeMaintenanceFile(int $ageSeconds = 0): void
+    {
+        file_put_contents($this->maintenanceFile, '<?php $upgrading = ' . time() . '; ?>');
+        if ($ageSeconds > 0) {
+            touch($this->maintenanceFile, time() - $ageSeconds);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // path()
+    // -----------------------------------------------------------------
+
+    public function test_path_resolves_under_abspath(): void
+    {
+        $this->assertSame($this->maintenanceFile, Maintenance::path());
+    }
+
+    // -----------------------------------------------------------------
+    // clear()
+    // -----------------------------------------------------------------
+
+    public function test_clear_removes_an_existing_file_with_no_upgrader(): void
+    {
+        $this->writeMaintenanceFile();
+        $this->assertFileExists($this->maintenanceFile);
+
+        Maintenance::clear();
+
+        $this->assertFileDoesNotExist($this->maintenanceFile);
+    }
+
+    public function test_clear_is_a_safe_noop_when_no_file_is_present(): void
+    {
+        $this->assertFileDoesNotExist($this->maintenanceFile);
+
+        // Must not throw or warn.
+        Maintenance::clear();
+
+        $this->assertFileDoesNotExist($this->maintenanceFile);
+    }
+
+    public function test_clear_prefers_the_upgrader_native_call_when_available(): void
+    {
+        $this->writeMaintenanceFile();
+
+        $upgrader = new class ($this->maintenanceFile) {
+            /** @var array<int,bool> */
+            public array $calls = [];
+
+            public function __construct(private string $file)
+            {
+            }
+
+            public function maintenance_mode(bool $enable = false): void
+            {
+                $this->calls[] = $enable;
+                // Mirror WP_Upgrader::maintenance_mode(false): actually
+                // deletes the file itself.
+                if (file_exists($this->file)) {
+                    unlink($this->file); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test double
+                }
+            }
+        };
+
+        Maintenance::clear($upgrader);
+
+        $this->assertSame([false], $upgrader->calls, 'upgrader->maintenance_mode(false) must be invoked');
+        $this->assertFileDoesNotExist($this->maintenanceFile);
+    }
+
+    public function test_clear_still_removes_file_when_upgrader_call_is_a_noop(): void
+    {
+        $this->writeMaintenanceFile();
+
+        // Simulates a real-world failure mode: $wp_filesystem was never
+        // connected, so the upgrader's own maintenance_mode(false) silently
+        // does nothing. The direct-delete backstop must still run.
+        $upgrader = new class {
+            public function maintenance_mode(bool $enable = false): void
+            {
+                // Intentionally does nothing.
+            }
+        };
+
+        Maintenance::clear($upgrader);
+
+        $this->assertFileDoesNotExist($this->maintenanceFile);
+    }
+
+    public function test_clear_still_removes_file_when_upgrader_call_throws(): void
+    {
+        $this->writeMaintenanceFile();
+
+        $upgrader = new class {
+            public function maintenance_mode(bool $enable = false): void
+            {
+                throw new \RuntimeException('filesystem credentials unavailable');
+            }
+        };
+
+        // Must not propagate the upgrader's exception.
+        Maintenance::clear($upgrader);
+
+        $this->assertFileDoesNotExist($this->maintenanceFile);
+    }
+
+    public function test_clear_ignores_an_object_without_maintenance_mode(): void
+    {
+        $this->writeMaintenanceFile();
+
+        $notAnUpgrader = new class {
+        };
+
+        Maintenance::clear($notAnUpgrader);
+
+        $this->assertFileDoesNotExist($this->maintenanceFile, 'the file-based backstop must still run');
+    }
+
+    // -----------------------------------------------------------------
+    // healStaleIfPresent()
+    // -----------------------------------------------------------------
+
+    public function test_heal_removes_a_stale_flag(): void
+    {
+        // Well past the 90s staleness threshold.
+        $this->writeMaintenanceFile(200);
+        $this->assertFileExists($this->maintenanceFile);
+
+        Maintenance::healStaleIfPresent();
+
+        $this->assertFileDoesNotExist($this->maintenanceFile);
+    }
+
+    public function test_heal_does_not_touch_a_fresh_flag(): void
+    {
+        // Freshly written — well under the 90s threshold.
+        $this->writeMaintenanceFile();
+        $this->assertFileExists($this->maintenanceFile);
+
+        Maintenance::healStaleIfPresent();
+
+        $this->assertFileExists(
+            $this->maintenanceFile,
+            'a fresh flag may belong to another in-flight update/rollback and must not be deleted'
+        );
+    }
+
+    public function test_heal_is_a_safe_noop_when_no_file_is_present(): void
+    {
+        $this->assertFileDoesNotExist($this->maintenanceFile);
+
+        Maintenance::healStaleIfPresent();
+
+        $this->assertFileDoesNotExist($this->maintenanceFile);
+    }
+
+    // -----------------------------------------------------------------
+    // armShutdownGuard()
+    // -----------------------------------------------------------------
+
+    public function test_arm_shutdown_guard_does_not_throw(): void
+    {
+        // We cannot observe PHP's real shutdown sequence from within a
+        // running test, but registering the callback must never throw and
+        // must be safe to call repeatedly (every command execute() call
+        // arms it).
+        Maintenance::armShutdownGuard();
+        Maintenance::armShutdownGuard();
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/apps/agent/tests/RollbackCommandTest.php
+++ b/apps/agent/tests/RollbackCommandTest.php
@@ -21,14 +21,29 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 final class RollbackCommandTest extends TestCase
 {
+    /** Absolute path to the `.maintenance` marker under the test ABSPATH. */
+    private string $maintenanceFile = '';
+
     protected function set_up(): void
     {
         parent::set_up();
         Monkey\setUp();
+
+        $abspath = defined('ABSPATH') ? rtrim((string) constant('ABSPATH'), '/\\') : '';
+        if ($abspath !== '' && !is_dir($abspath)) {
+            mkdir($abspath, 0755, true);
+        }
+        $this->maintenanceFile = $abspath . '/.maintenance';
+        if (file_exists($this->maintenanceFile)) {
+            unlink($this->maintenanceFile); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        }
     }
 
     protected function tear_down(): void
     {
+        if ($this->maintenanceFile !== '' && file_exists($this->maintenanceFile)) {
+            unlink($this->maintenanceFile); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        }
         Monkey\tearDown();
         parent::tear_down();
     }
@@ -238,5 +253,122 @@ final class RollbackCommandTest extends TestCase
     public function test_command_name(): void
     {
         $this->assertSame('rollback', (new RollbackCommand())->name());
+    }
+
+    // ---- .maintenance guarantee (GitHub issue #127) ------------------------
+
+    /**
+     * Pre-create a `.maintenance` marker as if left behind by the earlier
+     * update this rollback is recovering from.
+     */
+    private function preCreateMaintenanceFlag(): void
+    {
+        file_put_contents($this->maintenanceFile, '<?php $upgrading = ' . time() . '; ?>');
+    }
+
+    public function test_maintenance_flag_is_removed_after_a_failed_plugin_rollback(): void
+    {
+        $this->preCreateMaintenanceFlag();
+
+        $cmd = new RollbackCommand($this->spySnapshots(false), $this->spyRunner());
+        $out = $cmd->execute([], [
+            'type'        => 'plugin',
+            'slug'        => 'akismet/akismet.php',
+            'snapshot_id' => 'snap_abc',
+        ]);
+
+        $this->assertFalse($out['ok']);
+        $this->assertFileDoesNotExist(
+            $this->maintenanceFile,
+            'a rollback that itself fails must not leave the site permanently in maintenance mode'
+        );
+    }
+
+    public function test_maintenance_flag_is_removed_after_a_successful_plugin_rollback(): void
+    {
+        $this->preCreateMaintenanceFlag();
+
+        $cmd = new RollbackCommand($this->spySnapshots(true), $this->spyRunner());
+        $out = $cmd->execute([], [
+            'type'        => 'plugin',
+            'slug'        => 'akismet/akismet.php',
+            'snapshot_id' => 'snap_abc',
+        ]);
+
+        $this->assertTrue($out['ok']);
+        $this->assertFileDoesNotExist($this->maintenanceFile);
+    }
+
+    public function test_maintenance_flag_is_removed_after_a_failed_core_rollback(): void
+    {
+        $this->preCreateMaintenanceFlag();
+
+        $runner = $this->spyRunner(false);
+        $cmd    = new RollbackCommand($this->spySnapshots(true), $runner);
+
+        $out = $cmd->execute([], [
+            'type'        => 'core',
+            'snapshot_id' => 'snap_core',
+            'to_version'  => '6.3.2',
+        ]);
+
+        $this->assertFalse($out['ok']);
+        $this->assertSame(['6.3.2'], $runner->forced);
+        $this->assertFileDoesNotExist(
+            $this->maintenanceFile,
+            'exactly the reported incident: rollback FAILED must not leave the site at 503'
+        );
+    }
+
+    public function test_maintenance_flag_is_removed_after_a_successful_core_rollback(): void
+    {
+        $this->preCreateMaintenanceFlag();
+
+        $runner = $this->spyRunner(true);
+        $runner->versions['core:core'] = '6.3.2';
+        $cmd = new RollbackCommand($this->spySnapshots(true), $runner);
+
+        $out = $cmd->execute([], [
+            'type'        => 'core',
+            'snapshot_id' => 'snap_core',
+            'to_version'  => '6.3.2',
+        ]);
+
+        $this->assertTrue($out['ok']);
+        $this->assertFileDoesNotExist($this->maintenanceFile);
+    }
+
+    public function test_stale_maintenance_flag_is_healed_even_for_a_rejected_request(): void
+    {
+        file_put_contents($this->maintenanceFile, '<?php $upgrading = ' . time() . '; ?>');
+        // Well past Maintenance's staleness threshold.
+        touch($this->maintenanceFile, time() - 200);
+
+        // An invalid type is rejected BEFORE the mutating try/finally runs,
+        // isolating the start-of-request healStaleIfPresent() proactive heal
+        // from the unconditional end-of-request clear().
+        $cmd = new RollbackCommand($this->spySnapshots(), $this->spyRunner());
+        $out = $cmd->execute([], ['type' => 'bogus', 'slug' => 'x', 'snapshot_id' => 'snap_a']);
+
+        $this->assertFalse($out['ok']);
+        $this->assertFileDoesNotExist(
+            $this->maintenanceFile,
+            'a stale flag from a prior interrupted run must be healed before new work starts'
+        );
+    }
+
+    public function test_fresh_maintenance_flag_is_not_touched_by_a_rejected_request(): void
+    {
+        file_put_contents($this->maintenanceFile, '<?php $upgrading = ' . time() . '; ?>');
+        // Freshly written — well under the staleness threshold.
+
+        $cmd = new RollbackCommand($this->spySnapshots(), $this->spyRunner());
+        $out = $cmd->execute([], ['type' => 'bogus', 'slug' => 'x', 'snapshot_id' => 'snap_a']);
+
+        $this->assertFalse($out['ok']);
+        $this->assertFileExists(
+            $this->maintenanceFile,
+            'a fresh flag may belong to another in-flight update/rollback and must not be deleted'
+        );
     }
 }

--- a/apps/agent/tests/UpdateCommandTest.php
+++ b/apps/agent/tests/UpdateCommandTest.php
@@ -22,14 +22,29 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 final class UpdateCommandTest extends TestCase
 {
+    /** Absolute path to the `.maintenance` marker under the test ABSPATH. */
+    private string $maintenanceFile = '';
+
     protected function set_up(): void
     {
         parent::set_up();
         Monkey\setUp();
+
+        $abspath = defined('ABSPATH') ? rtrim((string) constant('ABSPATH'), '/\\') : '';
+        if ($abspath !== '' && !is_dir($abspath)) {
+            mkdir($abspath, 0755, true);
+        }
+        $this->maintenanceFile = $abspath . '/.maintenance';
+        if (file_exists($this->maintenanceFile)) {
+            unlink($this->maintenanceFile); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        }
     }
 
     protected function tear_down(): void
     {
+        if ($this->maintenanceFile !== '' && file_exists($this->maintenanceFile)) {
+            unlink($this->maintenanceFile); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        }
         Monkey\tearDown();
         parent::tear_down();
     }
@@ -356,5 +371,92 @@ final class UpdateCommandTest extends TestCase
 
         $this->assertFalse($out['ok']);
         $this->assertSame('failed', $out['results'][0]['status']);
+    }
+
+    // ---- .maintenance guarantee (GitHub issue #127) ------------------------
+
+    /**
+     * A runner spy whose apply() mimics a real WP upgrader: it drops the
+     * `.maintenance` marker (as Plugin_Upgrader/Core_Upgrader do at the start
+     * of an upgrade) and then blows up before it would reach its own cleanup
+     * line — the exact failure mode that orphans the flag in production.
+     */
+    private function spyRunnerThatLeavesMaintenanceOnFailure(string $maintenanceFile): UpdateRunner
+    {
+        return new class ($maintenanceFile) extends UpdateRunner {
+            public function __construct(private string $maintenanceFile)
+            {
+            }
+
+            public function currentVersion(string $type, string $slug): string
+            {
+                return '5.0';
+            }
+
+            public function apply(string $type, string $slug, string $version): array
+            {
+                file_put_contents($this->maintenanceFile, '<?php $upgrading = ' . time() . '; ?>');
+                throw new \RuntimeException('upgrade interrupted mid-flight');
+            }
+        };
+    }
+
+    public function test_maintenance_flag_is_removed_after_a_failed_update(): void
+    {
+        $runner = $this->spyRunnerThatLeavesMaintenanceOnFailure($this->maintenanceFile);
+        $cmd    = new UpdateCommand($this->spySnapshots(), $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => '5.3']],
+        ]);
+
+        $this->assertSame('failed', $out['results'][0]['status']);
+        $this->assertFileDoesNotExist(
+            $this->maintenanceFile,
+            'a failed update must never leave the site permanently in maintenance mode'
+        );
+    }
+
+    public function test_stale_maintenance_flag_is_healed_before_a_dry_run_starts(): void
+    {
+        file_put_contents($this->maintenanceFile, '<?php $upgrading = ' . time() . '; ?>');
+        // Well past Maintenance's staleness threshold.
+        touch($this->maintenanceFile, time() - 200);
+
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:hello/hello.php'] = '1.7.2';
+        $cmd = new UpdateCommand($this->spySnapshots(), $runner);
+
+        // dry_run never calls Maintenance::clear() — this isolates the
+        // start-of-run healStaleIfPresent() proactive heal.
+        $cmd->execute([], [
+            'dry_run' => true,
+            'items'   => [['type' => 'plugin', 'slug' => 'hello/hello.php', 'version' => 'latest']],
+        ]);
+
+        $this->assertFileDoesNotExist(
+            $this->maintenanceFile,
+            'a stale flag from a prior interrupted run must be healed before new work starts'
+        );
+    }
+
+    public function test_fresh_maintenance_flag_is_not_touched_by_a_dry_run(): void
+    {
+        file_put_contents($this->maintenanceFile, '<?php $upgrading = ' . time() . '; ?>');
+        // Freshly written — well under the staleness threshold.
+
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:hello/hello.php'] = '1.7.2';
+        $cmd = new UpdateCommand($this->spySnapshots(), $runner);
+
+        $cmd->execute([], [
+            'dry_run' => true,
+            'items'   => [['type' => 'plugin', 'slug' => 'hello/hello.php', 'version' => 'latest']],
+        ]);
+
+        $this->assertFileExists(
+            $this->maintenanceFile,
+            'a fresh flag may belong to another in-flight update/rollback and must not be deleted'
+        );
     }
 }

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.5
+ * Version:           0.61.6
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.5');
+define('WPMGR_AGENT_VERSION', '0.61.6');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 

--- a/apps/api/internal/update/worker.go
+++ b/apps/api/internal/update/worker.go
@@ -97,6 +97,34 @@ type Worker struct {
 	// keeps the legacy behaviour (no post-update refresh).
 	refresher   RefreshEnqueuer
 	refreshSkip *RefreshDebouncer
+	// probeDelays overrides the default post-update health-probe backoff
+	// schedule (probeRetryDelays). Nil uses the default. Tests set this to a
+	// tiny schedule so the retry loop does not actually sleep ~21s.
+	probeDelays []time.Duration
+}
+
+// probeRetryDelays is the backoff schedule between post-update health-probe
+// attempts (see probeHealthWithRetry). A plugin/theme update — particularly a
+// major-version upgrade that runs a synchronous DB migration on activation
+// (e.g. SureMail 1.x -> 2.0.0) — can legitimately return a transient 503, or
+// be briefly unreachable, for several seconds while the migration runs. A
+// single immediate probe misclassifies that as a broken update and rolls back
+// a site that in fact updated successfully. Total worst-case retry window:
+// sum(probeRetryDelays) ~= 21s, on top of the first (immediate) attempt.
+var probeRetryDelays = []time.Duration{
+	3 * time.Second,
+	4 * time.Second,
+	6 * time.Second,
+	8 * time.Second,
+}
+
+// SetProbeRetryDelays overrides the post-update health-probe backoff
+// schedule. Exposed for tests so the retry loop does not actually sleep the
+// production ~21s window; production code should rely on the default
+// (probeRetryDelays). Passing nil restores the default; pass a non-nil empty
+// slice ([]time.Duration{}) to disable retries entirely (single probe).
+func (w *Worker) SetProbeRetryDelays(delays []time.Duration) {
+	w.probeDelays = delays
 }
 
 // NewWorker builds the update task worker.
@@ -196,18 +224,56 @@ func (w *Worker) runApply(ctx context.Context, task Task, siteURL string, item a
 		return w.finish(ctx, task, TaskSkipped, fromOr(res.FromVersion, task.FromVersion), res.ToVersion, "already up to date", "")
 	}
 
-	// Post-update health probe of the site homepage.
-	probe, perr := w.prober.Get(ctx, siteURL)
+	// Post-update health probe of the site homepage, retried with backoff
+	// before declaring the update unhealthy (see probeHealthWithRetry): a
+	// normal DB-migration 503 immediately after activation must not trigger an
+	// unnecessary rollback of a site that in fact updated successfully.
+	probe, perr, attempts := w.probeHealthWithRetry(ctx, siteURL)
 	if perr != nil {
-		// Could not even reach the site after the update — treat as unhealthy and
-		// roll back. (A transport/SSRF error here is conservatively a failure.)
-		return w.rollback(ctx, task, siteURL, item, res, fmt.Sprintf("post-update probe error: %v", perr))
+		// Still unreachable after retrying — treat as unhealthy and roll back.
+		return w.rollback(ctx, task, siteURL, item, res, fmt.Sprintf("post-update probe error after %d attempt(s): %v", attempts, perr))
 	}
 	if !probe.Healthy() {
-		return w.rollback(ctx, task, siteURL, item, res, fmt.Sprintf("post-update health failed: status=%d %s", probe.StatusCode, probe.Detail))
+		return w.rollback(ctx, task, siteURL, item, res, fmt.Sprintf("post-update health failed after %d attempt(s): status=%d %s", attempts, probe.StatusCode, probe.Detail))
 	}
 
 	return w.finish(ctx, task, TaskSucceeded, fromOr(res.FromVersion, task.FromVersion), res.ToVersion, "updated and healthy", "")
+}
+
+// probeHealthWithRetry probes siteURL and, if the site is unhealthy or
+// unreachable, retries with backoff (probeDelays, defaulting to
+// probeRetryDelays) before giving up. It returns as soon as any attempt
+// reports Healthy(); otherwise it returns the LAST probe result/error after
+// exhausting the schedule, plus the number of attempts made (folded into the
+// rollback reason so an operator can see the update was given a fair chance).
+//
+// A transient transport error (perr != nil) is retried the same as an
+// unhealthy-but-reachable response: during a post-update migration window a
+// momentary connect/timeout error is indistinguishable from — and no less
+// transient than — a 503. A permanent transport error (e.g. SSRF-blocked or
+// an invalid URL) will simply fail the same way on every attempt and still
+// exhausts within the same bounded window, so no separate classification is
+// required to stay conservative here.
+func (w *Worker) probeHealthWithRetry(ctx context.Context, siteURL string) (probe agentcmd.ProbeResult, perr error, attempts int) {
+	delays := probeRetryDelays
+	if w.probeDelays != nil {
+		delays = w.probeDelays
+	}
+	for i := 0; ; i++ {
+		attempts = i + 1
+		probe, perr = w.prober.Get(ctx, siteURL)
+		if perr == nil && probe.Healthy() {
+			return probe, nil, attempts
+		}
+		if i >= len(delays) {
+			return probe, perr, attempts
+		}
+		select {
+		case <-ctx.Done():
+			return probe, ctx.Err(), attempts
+		case <-time.After(delays[i]):
+		}
+	}
 }
 
 // rollback issues the signed rollback command and records the rolled_back state.

--- a/apps/api/internal/update/worker_test.go
+++ b/apps/api/internal/update/worker_test.go
@@ -1,0 +1,277 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
+)
+
+// probeFakeRepo is a minimal Repo implementation exercising only the methods
+// runApply's finish/rollback path touches (FinishTask, CountUnfinishedTasks,
+// SetRunStatus). Every other method panics if called, so an accidental new
+// dependency in the code under test fails loudly instead of silently no-op'ing.
+// (Named distinctly from handler_test.go's fakeRepo, which is scoped to the
+// events-handler tests and has different fake behaviour.)
+type probeFakeRepo struct {
+	finished []FinishTaskInput
+}
+
+func (f *probeFakeRepo) CreateRunWithTasks(context.Context, CreateRunInput, []NewTask) (Run, []Task, error) {
+	panic("not implemented")
+}
+func (f *probeFakeRepo) GetRun(context.Context, uuid.UUID, uuid.UUID) (Run, error) {
+	panic("not implemented")
+}
+func (f *probeFakeRepo) ListRuns(context.Context, uuid.UUID, int32, int32) ([]Run, error) {
+	panic("not implemented")
+}
+func (f *probeFakeRepo) ListRunSummaries(context.Context, uuid.UUID, int32, int32) ([]RunSummary, error) {
+	panic("not implemented")
+}
+func (f *probeFakeRepo) ListTasks(context.Context, uuid.UUID, uuid.UUID) ([]Task, error) {
+	panic("not implemented")
+}
+func (f *probeFakeRepo) GetTask(context.Context, uuid.UUID, uuid.UUID) (Task, error) {
+	panic("not implemented")
+}
+func (f *probeFakeRepo) MarkTaskRunning(context.Context, uuid.UUID, uuid.UUID) (Task, error) {
+	panic("not implemented")
+}
+
+func (f *probeFakeRepo) FinishTask(_ context.Context, in FinishTaskInput) (Task, error) {
+	f.finished = append(f.finished, in)
+	return Task{
+		ID:          in.TaskID,
+		TenantID:    in.TenantID,
+		Status:      in.Status,
+		FromVersion: in.FromVersion,
+		ToVersion:   in.ToVersion,
+		Detail:      in.Detail,
+		Error:       in.Error,
+	}, nil
+}
+
+func (f *probeFakeRepo) SetRunStatus(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ string) (Run, error) {
+	return Run{}, nil
+}
+
+func (f *probeFakeRepo) CountUnfinishedTasks(context.Context, uuid.UUID, uuid.UUID) (int64, error) {
+	// No other tasks outstanding: the run completes after this task finishes.
+	// runApply/finish do not depend on the result beyond this call succeeding.
+	return 0, nil
+}
+
+func (f *probeFakeRepo) CountRunningTasksForTenant(context.Context, uuid.UUID) (int64, error) {
+	panic("not implemented")
+}
+
+// fakeCommander records Rollback calls and never actually contacts an agent.
+type fakeCommander struct {
+	rollbackCalled bool
+	rollbackErr    error
+}
+
+func (c *fakeCommander) Update(context.Context, uuid.UUID, string, agentcmd.UpdateRequest) (agentcmd.UpdateResponse, error) {
+	panic("not implemented")
+}
+
+func (c *fakeCommander) Rollback(context.Context, uuid.UUID, string, agentcmd.RollbackRequest) (agentcmd.RollbackResponse, error) {
+	c.rollbackCalled = true
+	if c.rollbackErr != nil {
+		return agentcmd.RollbackResponse{}, c.rollbackErr
+	}
+	return agentcmd.RollbackResponse{OK: true, RestoredVersion: "1.9.9"}, nil
+}
+
+// scriptedProber returns a queued sequence of (ProbeResult, error) pairs, one
+// per call to Get; the last entry repeats once the queue is exhausted.
+type scriptedProber struct {
+	script []probeStep
+	calls  int
+}
+
+type probeStep struct {
+	result agentcmd.ProbeResult
+	err    error
+}
+
+func (p *scriptedProber) Get(context.Context, string) (agentcmd.ProbeResult, error) {
+	i := p.calls
+	if i >= len(p.script) {
+		i = len(p.script) - 1
+	}
+	p.calls++
+	step := p.script[i]
+	return step.result, step.err
+}
+
+func healthyStep() probeStep {
+	return probeStep{result: agentcmd.ProbeResult{StatusCode: 200}}
+}
+
+func unhealthyStep(status int) probeStep {
+	return probeStep{result: agentcmd.ProbeResult{StatusCode: status, Detail: fmt.Sprintf("server returned status %d", status)}}
+}
+
+// newTestWorker builds a Worker wired with fakes and a tiny, non-sleeping
+// probe-retry schedule so the tests run fast regardless of the production
+// ~21s backoff window.
+func newTestWorker(repo *probeFakeRepo, cmd *fakeCommander, prober HealthProber) *Worker {
+	w := NewWorker(repo, nil /* sites: unused by runApply */, cmd, prober, nil /* hub */, nil /* audit */, nil, 5)
+	w.SetProbeRetryDelays([]time.Duration{time.Millisecond, time.Millisecond, time.Millisecond, time.Millisecond})
+	return w
+}
+
+func testTask() Task {
+	return Task{
+		ID:          uuid.New(),
+		RunID:       uuid.New(),
+		TenantID:    uuid.New(),
+		SiteID:      uuid.New(),
+		TargetType:  TargetPlugin,
+		TargetSlug:  "suremail",
+		FromVersion: "1.9.9",
+		Status:      TaskRunning,
+	}
+}
+
+func updateItem() agentcmd.UpdateItem {
+	return agentcmd.UpdateItem{Type: TargetPlugin, Slug: "suremail", Version: "2.0.0"}
+}
+
+// TestRunApply_ProbeRetry_RecoversFromTransientMigration503 reproduces issue
+// #127 Defect 2: a plugin activation that runs a synchronous DB migration can
+// return 503 for a few seconds. The task must still succeed once the probe
+// recovers within the retry window — no rollback.
+func TestRunApply_ProbeRetry_RecoversFromTransientMigration503(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &fakeCommander{}
+	prober := &scriptedProber{script: []probeStep{
+		unhealthyStep(503), unhealthyStep(503), unhealthyStep(503), healthyStep(),
+	}}
+	w := newTestWorker(repo, cmd, prober)
+
+	task := testTask()
+	item := updateItem()
+	res := agentcmd.ItemResult{Type: item.Type, Slug: item.Slug, FromVersion: "1.9.9", ToVersion: "2.0.0", Status: agentcmd.ItemSucceeded}
+
+	// Exercise runApply's probe+decide tail directly via the same code path
+	// runApply uses, by calling the shared helper and asserting on its outcome,
+	// then confirm the finish() side effect via the repo.
+	probe, perr, attempts := w.probeHealthWithRetry(context.Background(), "https://example.test")
+	if perr != nil {
+		t.Fatalf("expected eventual success, got error: %v", perr)
+	}
+	if !probe.Healthy() {
+		t.Fatalf("expected healthy probe after retry, got %+v", probe)
+	}
+	if attempts != 4 {
+		t.Fatalf("expected 4 attempts (3 failures + 1 success), got %d", attempts)
+	}
+
+	if err := w.finish(context.Background(), task, TaskSucceeded, res.FromVersion, res.ToVersion, "updated and healthy", ""); err != nil {
+		t.Fatalf("finish: %v", err)
+	}
+	if cmd.rollbackCalled {
+		t.Fatalf("rollback must NOT be called when the probe recovers within the retry window")
+	}
+	if len(repo.finished) != 1 || repo.finished[0].Status != TaskSucceeded {
+		t.Fatalf("expected one TaskSucceeded finish, got %+v", repo.finished)
+	}
+}
+
+// TestRunApply_ProbeRetry_StillUnhealthyRollsBack asserts that a post-update
+// probe that NEVER recovers still rolls back, after exhausting the retry
+// schedule (not on the first failure).
+func TestRunApply_ProbeRetry_StillUnhealthyRollsBack(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &fakeCommander{}
+	prober := &scriptedProber{script: []probeStep{unhealthyStep(503)}} // repeats forever
+	w := newTestWorker(repo, cmd, prober)
+
+	task := testTask()
+	item := updateItem()
+	res := agentcmd.ItemResult{Type: item.Type, Slug: item.Slug, FromVersion: "1.9.9", ToVersion: "2.0.0", Status: agentcmd.ItemSucceeded}
+
+	probe, perr, attempts := w.probeHealthWithRetry(context.Background(), "https://example.test")
+	if perr != nil {
+		t.Fatalf("expected no transport error, got %v", perr)
+	}
+	if probe.Healthy() {
+		t.Fatalf("expected the probe to remain unhealthy")
+	}
+	wantAttempts := 1 + len(w.probeDelays) // initial + one per backoff step
+	if attempts != wantAttempts {
+		t.Fatalf("expected %d attempts (initial + %d retries), got %d", wantAttempts, len(w.probeDelays), attempts)
+	}
+
+	reason := fmt.Sprintf("post-update health failed after %d attempt(s): status=%d %s", attempts, probe.StatusCode, probe.Detail)
+	if err := w.rollback(context.Background(), task, "https://example.test", item, res, reason); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if !cmd.rollbackCalled {
+		t.Fatalf("expected rollback to be called after the probe never recovers")
+	}
+	if len(repo.finished) != 1 || repo.finished[0].Status != TaskRolledBack {
+		t.Fatalf("expected one TaskRolledBack finish, got %+v", repo.finished)
+	}
+}
+
+// TestRunApply_ProbeRetry_TransportErrorRetriedThenHeals covers a transient
+// transport error (not just an HTTP 5xx) recovering within the window.
+func TestRunApply_ProbeRetry_TransportErrorRetriedThenHeals(t *testing.T) {
+	prober := &scriptedProber{script: []probeStep{
+		{err: fmt.Errorf("dial tcp: connection refused")},
+		{err: fmt.Errorf("dial tcp: connection refused")},
+		healthyStep(),
+	}}
+	w := newTestWorker(&probeFakeRepo{}, &fakeCommander{}, prober)
+
+	probe, perr, attempts := w.probeHealthWithRetry(context.Background(), "https://example.test")
+	if perr != nil {
+		t.Fatalf("expected recovery, got error: %v", perr)
+	}
+	if !probe.Healthy() {
+		t.Fatalf("expected healthy probe after recovery, got %+v", probe)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts)
+	}
+}
+
+// TestRunApply_ProbeRetry_RespectsContextCancellation asserts the retry loop
+// bails promptly (does not hang) when ctx is cancelled mid-retry.
+func TestRunApply_ProbeRetry_RespectsContextCancellation(t *testing.T) {
+	prober := &scriptedProber{script: []probeStep{unhealthyStep(503)}}
+	w := newTestWorker(&probeFakeRepo{}, &fakeCommander{}, prober)
+	// A long delay schedule so the test would hang if ctx cancellation were not
+	// honored between attempts.
+	w.SetProbeRetryDelays([]time.Duration{50 * time.Millisecond, time.Hour})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(75 * time.Millisecond) // after attempt 1's backoff, before attempt 2's
+		cancel()
+	}()
+
+	done := make(chan struct{})
+	var perr error
+	go func() {
+		_, perr, _ = w.probeHealthWithRetry(ctx, "https://example.test")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("probeHealthWithRetry did not respect context cancellation")
+	}
+	if perr == nil {
+		t.Fatalf("expected a context error, got nil")
+	}
+}


### PR DESCRIPTION
Critical site-down fix. D1 (agent 0.61.6): guarantee WordPress .maintenance is cleared on every terminal update/rollback outcome (try/finally + shutdown backstop + stale-heal) so a failed update never leaves the site at 503. D2 (api): retry the post-update health probe so a transient migration 503 doesn't trigger a needless rollback. agent + api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)