### PR TITLE
fix(#126): bulk-update per-site intersection + agent skips not-applicable targets

### DIFF
--- a/apps/agent/includes/commands/class-update-command.php
+++ b/apps/agent/includes/commands/class-update-command.php
@@ -129,10 +129,36 @@ final class UpdateCommand implements CommandInterface
         }
 
         try {
+            // --- Not-applicable target: the plugin/theme isn't present on
+            // this site at all (a stale or mistargeted task). Report this as
+            // skipped, not failed, so it never pollutes the run's failure
+            // count — there is nothing here to have failed.
+            if (!$this->runner->isInstalled($type, $slug)) {
+                return $this->result($type, $slug, '', '', 'skipped', '', 'Not installed on this site.');
+            }
+
             $fromVersion = $this->runner->currentVersion($type, $slug);
 
             if ($dryRun) {
                 return $this->dryRun($type, $slug, $version, $fromVersion);
+            }
+
+            // --- Not-applicable target: installed but nothing to do (already
+            // at, or beyond, the requested/available version). Report this
+            // up front as up_to_date without running a snapshot+apply — both
+            // avoids needless work and keeps a target with no real update to
+            // apply from ever being able to surface as a failure.
+            $available = $this->runner->availableVersion($type, $slug, $version);
+            if (!self::isUpdatable($available, $fromVersion, $version)) {
+                return $this->result(
+                    $type,
+                    $slug,
+                    $fromVersion,
+                    $fromVersion,
+                    'up_to_date',
+                    '',
+                    'Already up to date; no update applied.'
+                );
             }
 
             // GUARANTEE: whatever this item's snapshot/apply work does below —
@@ -181,14 +207,31 @@ final class UpdateCommand implements CommandInterface
     private function dryRun(string $type, string $slug, string $requested, string $fromVersion): array
     {
         $available = $this->runner->availableVersion($type, $slug, $requested);
-
-        $updatable = $available !== '' && $available !== $fromVersion
-            && (version_compare($available, $fromVersion, '>') || $requested !== 'latest');
+        $updatable = self::isUpdatable($available, $fromVersion, $requested);
 
         $status = $updatable ? 'would_update' : 'up_to_date';
         $to     = $updatable ? $available : $fromVersion;
 
         return $this->result($type, $slug, $fromVersion, $to, $status, '', 'Dry run: no changes applied.');
+    }
+
+    /**
+     * Is there an actual update to apply?
+     *
+     * Shared by the dry-run report and the real-apply pre-check so both agree
+     * on what "nothing to do" means: no available version, the available
+     * version already matches what's installed, or (for a 'latest' request)
+     * the available version isn't actually newer.
+     *
+     * @param string $available   Version an update would move to ('' when none).
+     * @param string $fromVersion Currently installed version.
+     * @param string $requested   'latest' or an explicit x.y.z.
+     * @return bool
+     */
+    private static function isUpdatable(string $available, string $fromVersion, string $requested): bool
+    {
+        return $available !== '' && $available !== $fromVersion
+            && (version_compare($available, $fromVersion, '>') || $requested !== 'latest');
     }
 
     /**

--- a/apps/agent/includes/support/class-update-runner.php
+++ b/apps/agent/includes/support/class-update-runner.php
@@ -71,6 +71,63 @@ class UpdateRunner
     }
 
     /**
+     * Is this item actually present on the site?
+     *
+     * Used to distinguish a genuinely not-applicable update target (plugin/
+     * theme never installed here, e.g. a stale or mistargeted control-plane
+     * task) from a real upgrade failure. Core is always "installed". When the
+     * detection API itself is unavailable (e.g. `get_plugins()` not loaded in
+     * a constrained runtime), this fails OPEN — returns true — so we never
+     * misreport a genuine target as not-installed just because we couldn't
+     * check; a real failure downstream still surfaces as 'failed'.
+     *
+     * @param string $type plugin|theme|core.
+     * @param string $slug Sanitized slug (ignored for core).
+     * @return bool
+     */
+    public function isInstalled(string $type, string $slug): bool
+    {
+        switch ($type) {
+            case 'core':
+                return true;
+
+            case 'plugin':
+                $this->loadPluginApi();
+                if (!function_exists('get_plugins')) {
+                    return true;
+                }
+                $all = get_plugins();
+                if (!is_array($all)) {
+                    return true;
+                }
+                if (isset($all[$slug])) {
+                    return true;
+                }
+                // Allow a folder-only slug to match its "folder/..." basename.
+                foreach (array_keys($all) as $file) {
+                    if (is_string($file) && str_starts_with($file, $slug . '/')) {
+                        return true;
+                    }
+                }
+
+                return false;
+
+            case 'theme':
+                if (!function_exists('wp_get_themes')) {
+                    return true;
+                }
+                $themes = wp_get_themes();
+                if (!is_array($themes)) {
+                    return true;
+                }
+
+                return isset($themes[$slug]);
+        }
+
+        return true;
+    }
+
+    /**
      * Resolve the version that an update would move the item to.
      *
      * Used only by dry-run. For an explicit version request we return it as-is.

--- a/apps/agent/tests/UpdateCommandTest.php
+++ b/apps/agent/tests/UpdateCommandTest.php
@@ -61,10 +61,31 @@ final class UpdateCommandTest extends TestCase
             public array $versions = [];
             /** @var array<string,string> */
             public array $available = [];
+            /** @var array<string,bool> Explicit installed-state overrides, keyed "type:slug". */
+            public array $installedOverride = [];
+            /** Whether apply() should report success. */
+            public bool $applySucceeds = true;
 
             public function currentVersion(string $type, string $slug): string
             {
                 return $this->versions[$type . ':' . $slug] ?? '';
+            }
+
+            public function isInstalled(string $type, string $slug): bool
+            {
+                $key = $type . ':' . $slug;
+                if (array_key_exists($key, $this->installedOverride)) {
+                    return $this->installedOverride[$key];
+                }
+
+                // Default: known-installed only when the spy has been given a
+                // version for it. Deliberately does NOT fall back to the real
+                // UpdateRunner::isInstalled() here — that would consult the
+                // process-wide get_plugins()/wp_get_themes() stub state, which
+                // another test in this suite may have already redefined via
+                // Brain Monkey (those redefinitions are not un-done between
+                // tests), making this spy's behaviour depend on test order.
+                return array_key_exists($key, $this->versions);
             }
 
             public function availableVersion(string $type, string $slug, string $requested): string
@@ -75,6 +96,11 @@ final class UpdateCommandTest extends TestCase
             public function apply(string $type, string $slug, string $version): array
             {
                 $this->applied[] = [$type, $slug, $version];
+
+                if (!$this->applySucceeds) {
+                    return ['ok' => false, 'log' => 'upgrader reported failure'];
+                }
+
                 // Simulate a successful bump.
                 $this->versions[$type . ':' . $slug] = $version === 'latest' ? '9.9.9' : $version;
 
@@ -303,6 +329,85 @@ final class UpdateCommandTest extends TestCase
         $this->assertCount(2, $out['results']);
         $this->assertSame('failed', $out['results'][0]['status']);
         $this->assertSame('succeeded', $out['results'][1]['status']);
+    }
+
+    // ---- not-applicable targets (GitHub issue #126) ------------------------
+
+    public function test_not_installed_plugin_is_skipped_not_failed(): void
+    {
+        $runner = $this->spyRunner();
+        // No entry in $runner->versions AND explicitly marked absent — this
+        // slug was never installed on the site.
+        $runner->installedOverride['plugin:ghost/ghost.php'] = false;
+
+        $cmd = new UpdateCommand($this->spySnapshots(), $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'ghost/ghost.php', 'version' => 'latest']],
+        ]);
+
+        $r = $out['results'][0];
+        $this->assertSame('skipped', $r['status']);
+        $this->assertTrue($out['ok'], 'a skipped (not-applicable) item must not flip ok to false');
+        $this->assertSame([], $runner->applied, 'a not-installed target must never reach apply()');
+    }
+
+    public function test_not_installed_theme_is_skipped_not_failed(): void
+    {
+        $runner = $this->spyRunner();
+        $runner->installedOverride['theme:ghost-theme'] = false;
+
+        $cmd = new UpdateCommand($this->spySnapshots(), $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'theme', 'slug' => 'ghost-theme', 'version' => 'latest']],
+        ]);
+
+        $this->assertSame('skipped', $out['results'][0]['status']);
+        $this->assertSame([], $runner->applied);
+    }
+
+    public function test_installed_but_no_pending_update_reports_up_to_date_without_apply(): void
+    {
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php'] = '5.3';
+        $runner->installedOverride['plugin:akismet/akismet.php'] = true;
+        // Deliberately no 'available' entry => nothing pending for 'latest'.
+
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'snapshot' => true,
+            'items'    => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $r = $out['results'][0];
+        $this->assertSame('up_to_date', $r['status']);
+        $this->assertSame('5.3', $r['from_version']);
+        $this->assertSame('5.3', $r['to_version']);
+        $this->assertSame([], $runner->applied, 'nothing pending must never reach apply()');
+        $this->assertSame([], $snapshots->captured, 'nothing pending must never trigger a snapshot');
+        $this->assertTrue($out['ok']);
+    }
+
+    public function test_installed_with_pending_update_that_fails_to_apply_still_fails(): void
+    {
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php'] = '5.0';
+        $runner->available['plugin:akismet/akismet.php'] = '5.3';
+        $runner->applySucceeds                           = false;
+
+        $cmd = new UpdateCommand($this->spySnapshots(), $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $r = $out['results'][0];
+        $this->assertSame('failed', $r['status']);
+        $this->assertFalse($out['ok']);
+        $this->assertCount(1, $runner->applied, 'a genuine pending update must still be attempted');
     }
 
     public function test_command_name(): void

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.6
+ * Version:           0.61.7
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.6');
+define('WPMGR_AGENT_VERSION', '0.61.7');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 

--- a/apps/api/cmd/wpmgr/siteadapter.go
+++ b/apps/api/cmd/wpmgr/siteadapter.go
@@ -467,20 +467,41 @@ func (a *vulnSiteAdapter) ListAllSiteIDs(ctx context.Context, tenantID uuid.UUID
 
 var _ vuln.SiteLoader = (*vulnSiteAdapter)(nil)
 
+// toSiteInfo translates site.Site (with its JSONB component inventory,
+// including each item's own AvailableUpdate advisory and the optional core
+// update advisory) into update.SiteInfo. Carrying the per-site pending-update
+// signal through is what lets update.Service.planTasks intersect a run's
+// requested items against what THIS site actually has pending, instead of the
+// raw cross-product of the whole run's site/item selection (#126).
 func toSiteInfo(s site.Site) update.SiteInfo {
 	plugins, themes := s.ParsedComponents()
 	comps := make([]update.Component, 0, len(plugins)+len(themes))
 	for _, p := range plugins {
-		comps = append(comps, update.Component{Type: update.TargetPlugin, Slug: p.Slug, Version: p.Version})
+		comps = append(comps, toUpdateComponent(update.TargetPlugin, p))
 	}
 	for _, t := range themes {
-		comps = append(comps, update.Component{Type: update.TargetTheme, Slug: t.Slug, Version: t.Version})
+		comps = append(comps, toUpdateComponent(update.TargetTheme, t))
 	}
-	return update.SiteInfo{
+	info := update.SiteInfo{
 		ID:         s.ID,
 		URL:        s.URL,
 		Name:       s.Name,
 		Enrolled:   s.EnrolledAt != nil,
 		Components: comps,
 	}
+	if core := s.ParsedCoreUpdate(); core != nil && core.NewVersion != "" {
+		info.CoreUpdateAvailable = true
+		info.CoreCurrentVersion = core.CurrentVersion
+		info.CoreNewVersion = core.NewVersion
+	}
+	return info
+}
+
+func toUpdateComponent(typ string, c site.Component) update.Component {
+	out := update.Component{Type: typ, Slug: c.Slug, Version: c.Version}
+	if c.AvailableUpdate != nil && c.AvailableUpdate.NewVersion != "" {
+		out.UpdateAvailable = true
+		out.NewVersion = c.AvailableUpdate.NewVersion
+	}
+	return out
 }

--- a/apps/api/internal/update/service.go
+++ b/apps/api/internal/update/service.go
@@ -10,21 +10,39 @@ import (
 )
 
 // SiteInfo is the minimal site projection the update service needs to plan and
-// execute a run: identity, the agent target URL, and the current component
-// versions (used to seed from_version without a round-trip to the agent).
+// execute a run: identity, the agent target URL, the current component
+// versions (used to seed from_version without a round-trip to the agent), and
+// the site's OWN pending WordPress-core update advisory (CoreUpdateAvailable
+// etc). planTasks intersects a run's requested items against each site's own
+// pending set (Components[].UpdateAvailable / CoreUpdateAvailable) — see #126.
 type SiteInfo struct {
 	ID         uuid.UUID
 	URL        string
 	Name       string
 	Enrolled   bool
 	Components []Component
+
+	// CoreUpdateAvailable reports whether THIS site's own inventory advertises
+	// a pending WordPress core update. CoreCurrentVersion/CoreNewVersion carry
+	// the versions from that advisory when set.
+	CoreUpdateAvailable bool
+	CoreCurrentVersion  string
+	CoreNewVersion      string
 }
 
-// Component is one installed plugin/theme with its current version.
+// Component is one installed plugin/theme with its current version and its
+// OWN pending-update advisory (mirrors site.Component.AvailableUpdate).
+// UpdateAvailable/NewVersion are the per-site authority planTasks intersects
+// a run's requested items against (#126: a target requested because another
+// site in the run has it pending must not spawn a task on a site that does
+// not).
 type Component struct {
 	Type    string // "plugin" | "theme"
 	Slug    string
 	Version string
+
+	UpdateAvailable bool
+	NewVersion      string
 }
 
 // SiteLookup resolves the target sites for a run. Implemented by the site
@@ -128,18 +146,53 @@ func (s *Service) resolveSites(ctx context.Context, in CreateRunInput) ([]SiteIn
 	return s.sites.ListSiteInfoByTag(ctx, in.TenantID, in.Tag)
 }
 
-// planTasks expands (sites × items) into NewTask rows, seeding from_version from
-// the site's known component version where available.
+// planTasks expands (sites × items) into NewTask rows, INTERSECTED against
+// each site's own pending-update inventory (#126, the N×M task-explosion
+// bug): a default ("latest"/unset) item produces a task on a given site ONLY
+// when that site's own inventory reports the item as pending. A target that
+// is pending on some OTHER site in a multi-site run, but not on this one,
+// produces NO task here — never a task that is doomed to fail (or, with the
+// agent-side defensive fix, silently skip).
+//
+// An item carrying an EXPLICIT version pin (e.g. a deliberate downgrade, or a
+// vuln-remediation fix version the site's own WordPress update-check has not
+// yet caught up to reporting — see vuln.Service.Remediate) is a forced
+// operator/system action: it is applied wherever the target is installed on
+// the site, regardless of whether that site currently flags it as pending.
+//
+// from_version is always seeded from the SITE'S OWN known component version
+// (never another site's), whichever branch created the task.
 func (s *Service) planTasks(sites []SiteInfo, items []Item) []NewTask {
 	tasks := make([]NewTask, 0, len(sites)*len(items))
 	for _, site := range sites {
-		versions := indexVersions(site.Components)
+		installed := indexVersions(site.Components)
+		pending := indexPending(site)
 		for _, item := range items {
 			slug := item.Slug
 			if item.Type == TargetCore {
 				slug = "core"
 			}
-			from := versions[item.Type+"/"+slug]
+			key := item.Type + "/" + slug
+
+			from, hasInstalled := installed[key]
+			_, hasPending := pending[key]
+			if item.Type == TargetCore {
+				hasInstalled = true // core is always "installed"
+				from = site.CoreCurrentVersion
+			}
+
+			pinned := item.Version != "" && item.Version != "latest"
+			switch {
+			case pinned:
+				if !hasInstalled {
+					continue
+				}
+			default:
+				if !hasPending {
+					continue
+				}
+			}
+
 			desired := item.Version
 			if desired == "" {
 				desired = "latest"
@@ -154,6 +207,24 @@ func (s *Service) planTasks(sites []SiteInfo, items []Item) []NewTask {
 		}
 	}
 	return tasks
+}
+
+// indexPending returns the site's own pending-update set keyed by "type/slug"
+// ("core/core" for WordPress core), mapping to the version the site's own
+// inventory advertises as available. Only entries the site itself currently
+// reports as pending are present; this is the per-site authority planTasks
+// intersects a run's requested items against.
+func indexPending(site SiteInfo) map[string]string {
+	m := make(map[string]string, len(site.Components)+1)
+	for _, c := range site.Components {
+		if c.UpdateAvailable && c.NewVersion != "" {
+			m[c.Type+"/"+c.Slug] = c.NewVersion
+		}
+	}
+	if site.CoreUpdateAvailable && site.CoreNewVersion != "" {
+		m[TargetCore+"/core"] = site.CoreNewVersion
+	}
+	return m
 }
 
 // GetRun returns a run with its tasks.

--- a/apps/api/internal/update/service_test.go
+++ b/apps/api/internal/update/service_test.go
@@ -1,0 +1,306 @@
+package update
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// fakeSiteLookup is an in-memory SiteLookup keyed by site ID, used by the
+// planning-level CreateRun tests below (no DB needed).
+type fakeSiteLookup struct {
+	sites map[uuid.UUID]SiteInfo
+}
+
+func (f *fakeSiteLookup) GetSiteInfo(_ context.Context, _, siteID uuid.UUID) (SiteInfo, error) {
+	si, ok := f.sites[siteID]
+	if !ok {
+		return SiteInfo{}, domain.NotFound("site_not_found", "no such site")
+	}
+	return si, nil
+}
+
+func (f *fakeSiteLookup) ListSiteInfoByTag(_ context.Context, _ uuid.UUID, _ string) ([]SiteInfo, error) {
+	out := make([]SiteInfo, 0, len(f.sites))
+	for _, si := range f.sites {
+		out = append(out, si)
+	}
+	return out, nil
+}
+
+// fakeCreateRepo is a minimal Repo that only implements CreateRunWithTasks
+// (the only method Service.CreateRun's planning path reaches), assembling
+// Task rows from the NewTask rows planTasks produced so the test can assert
+// on the exact composed set. All other methods are unused by CreateRun.
+type fakeCreateRepo struct {
+	tenantID uuid.UUID
+}
+
+func (f *fakeCreateRepo) CreateRunWithTasks(_ context.Context, in CreateRunInput, tasks []NewTask) (Run, []Task, error) {
+	run := Run{ID: uuid.New(), TenantID: in.TenantID, Status: RunPending, DryRun: in.DryRun}
+	out := make([]Task, 0, len(tasks))
+	for _, nt := range tasks {
+		out = append(out, Task{
+			ID:             uuid.New(),
+			RunID:          run.ID,
+			TenantID:       in.TenantID,
+			SiteID:         nt.SiteID,
+			TargetType:     nt.TargetType,
+			TargetSlug:     nt.TargetSlug,
+			DesiredVersion: nt.DesiredVersion,
+			FromVersion:    nt.FromVersion,
+			Status:         TaskPending,
+		})
+	}
+	return run, out, nil
+}
+
+func (f *fakeCreateRepo) GetRun(context.Context, uuid.UUID, uuid.UUID) (Run, error) { panic("not used") }
+func (f *fakeCreateRepo) ListRuns(context.Context, uuid.UUID, int32, int32) ([]Run, error) {
+	panic("not used")
+}
+func (f *fakeCreateRepo) ListRunSummaries(context.Context, uuid.UUID, int32, int32) ([]RunSummary, error) {
+	panic("not used")
+}
+func (f *fakeCreateRepo) ListTasks(context.Context, uuid.UUID, uuid.UUID) ([]Task, error) {
+	panic("not used")
+}
+func (f *fakeCreateRepo) GetTask(context.Context, uuid.UUID, uuid.UUID) (Task, error) {
+	panic("not used")
+}
+func (f *fakeCreateRepo) MarkTaskRunning(context.Context, uuid.UUID, uuid.UUID) (Task, error) {
+	panic("not used")
+}
+func (f *fakeCreateRepo) FinishTask(context.Context, FinishTaskInput) (Task, error) {
+	panic("not used")
+}
+func (f *fakeCreateRepo) SetRunStatus(context.Context, uuid.UUID, uuid.UUID, string) (Run, error) {
+	panic("not used")
+}
+func (f *fakeCreateRepo) CountUnfinishedTasks(context.Context, uuid.UUID, uuid.UUID) (int64, error) {
+	panic("not used")
+}
+func (f *fakeCreateRepo) CountRunningTasksForTenant(context.Context, uuid.UUID) (int64, error) {
+	panic("not used")
+}
+
+// countingEnqueuer records how many tasks were enqueued without touching River.
+type countingEnqueuer struct{ n int }
+
+func (e *countingEnqueuer) EnqueueTask(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, bool) error {
+	e.n++
+	return nil
+}
+
+// TestCreateRunIntersectsPerSitePendingUpdates is the regression test for
+// #126 (Problem 1: the N×M task-explosion bug). Two sites are selected in one
+// run: site A has 3 of its own pending updates, site B has 20 (2 of which
+// overlap with A's). The operator's item selection is the UNION across both
+// sites (mirroring what the web wizard sends today). CreateRun must produce
+// tasks ONLY for the per-site INTERSECTION — never the raw (sites × items)
+// cross-product — and each task's from_version/desired_version must come from
+// the site whose task it is, not from another site's inventory.
+func TestCreateRunIntersectsPerSitePendingUpdates(t *testing.T) {
+	tenant := uuid.New()
+	siteA := uuid.New()
+	siteB := uuid.New()
+
+	// Site A: 3 pending updates (x, y, and the shared "shared-plugin").
+	infoA := SiteInfo{
+		ID: siteA, Enrolled: true,
+		Components: []Component{
+			{Type: TargetPlugin, Slug: "x", Version: "1.0.0", UpdateAvailable: true, NewVersion: "1.1.0"},
+			{Type: TargetPlugin, Slug: "y", Version: "2.0.0", UpdateAvailable: true, NewVersion: "2.1.0"},
+			{Type: TargetPlugin, Slug: "shared-plugin", Version: "3.0.0", UpdateAvailable: true, NewVersion: "3.1.0"},
+			// z is installed but NOT pending on A — must never produce a task on A.
+			{Type: TargetPlugin, Slug: "z", Version: "4.0.0"},
+		},
+	}
+
+	// Site B: 20 pending updates, including "shared-plugin" (at a DIFFERENT
+	// from_version than site A) and "z" (which A does not have pending).
+	bComponents := []Component{
+		{Type: TargetPlugin, Slug: "shared-plugin", Version: "3.0.0", UpdateAvailable: true, NewVersion: "3.2.0"},
+		{Type: TargetPlugin, Slug: "z", Version: "9.0.0", UpdateAvailable: true, NewVersion: "9.1.0"},
+	}
+	for i := 0; i < 18; i++ {
+		bComponents = append(bComponents, Component{
+			Type: TargetPlugin, Slug: "b-only-" + string(rune('a'+i)), Version: "1.0.0",
+			UpdateAvailable: true, NewVersion: "1.0.1",
+		})
+	}
+	infoB := SiteInfo{ID: siteB, Enrolled: true, Components: bComponents}
+
+	lookup := &fakeSiteLookup{sites: map[uuid.UUID]SiteInfo{siteA: infoA, siteB: infoB}}
+	repo := &fakeCreateRepo{tenantID: tenant}
+	enq := &countingEnqueuer{}
+	svc := NewService(repo, lookup, enq, domain.NewValidator(), domain.SystemClock{})
+
+	// The operator's selection is the UNION of everything with an update
+	// across both sites: x, y, z, shared-plugin, and the 18 b-only-* items —
+	// 22 distinct items total, exactly mirroring what the web wizard's
+	// componentOptions() union-builder sends today.
+	items := []Item{
+		{Type: "plugin", Slug: "x", Version: "latest"},
+		{Type: "plugin", Slug: "y", Version: "latest"},
+		{Type: "plugin", Slug: "z", Version: "latest"},
+		{Type: "plugin", Slug: "shared-plugin", Version: "latest"},
+	}
+	for i := 0; i < 18; i++ {
+		items = append(items, Item{Type: "plugin", Slug: "b-only-" + string(rune('a'+i)), Version: "latest"})
+	}
+
+	run, tasks, err := svc.CreateRun(context.Background(), CreateRunInput{
+		TenantID: tenant,
+		SiteIDs:  []uuid.UUID{siteA, siteB},
+		Items:    items,
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if run.TenantID != tenant {
+		t.Fatalf("run tenant = %s, want %s", run.TenantID, tenant)
+	}
+
+	// The cross-product would be 2 sites * 22 items = 44 tasks. The correct
+	// intersection is: A gets {x, y, shared-plugin} = 3, B gets
+	// {shared-plugin, z, 18x b-only} = 20. Total 23 — NOT 44, and NOT the
+	// literal "~22" from the issue's 2-site/3-vs-20 example because here the
+	// two sites additionally overlap on one item (shared-plugin), which
+	// rightly produces one task per site (each intersects independently).
+	wantTotal := 23
+	if len(tasks) != wantTotal {
+		t.Fatalf("want %d tasks (per-site intersection), got %d: %+v", wantTotal, len(tasks), tasks)
+	}
+
+	bySite := map[uuid.UUID][]Task{}
+	for _, tk := range tasks {
+		bySite[tk.SiteID] = append(bySite[tk.SiteID], tk)
+	}
+
+	if got := len(bySite[siteA]); got != 3 {
+		t.Fatalf("site A task count = %d, want 3 (its own pending set)", got)
+	}
+	if got := len(bySite[siteB]); got != 20 {
+		t.Fatalf("site B task count = %d, want 20 (its own pending set)", got)
+	}
+
+	// Site A must NEVER get a task for "z" — z is pending only on B.
+	for _, tk := range bySite[siteA] {
+		if tk.TargetSlug == "z" {
+			t.Fatalf("site A got a task for %q, which is only pending on site B (the N×M explosion bug)", tk.TargetSlug)
+		}
+	}
+	// Site B must NEVER get a task for "x" or "y" — those are pending only on A.
+	for _, tk := range bySite[siteB] {
+		if tk.TargetSlug == "x" || tk.TargetSlug == "y" {
+			t.Fatalf("site B got a task for %q, which is only pending on site A (the N×M explosion bug)", tk.TargetSlug)
+		}
+	}
+
+	// Each site's "shared-plugin" task must carry ITS OWN from_version, not
+	// the other site's — proves version data isn't cross-contaminated by the
+	// intersection logic.
+	fromVersionOn := func(site uuid.UUID, slug string) string {
+		for _, tk := range bySite[site] {
+			if tk.TargetSlug == slug {
+				return tk.FromVersion
+			}
+		}
+		t.Fatalf("no task for %q on site %s", slug, site)
+		return ""
+	}
+	if v := fromVersionOn(siteA, "shared-plugin"); v != "3.0.0" {
+		t.Fatalf("site A shared-plugin from_version = %q, want 3.0.0 (site A's own installed version)", v)
+	}
+	if v := fromVersionOn(siteB, "shared-plugin"); v != "3.0.0" {
+		t.Fatalf("site B shared-plugin from_version = %q, want 3.0.0 (site B's own installed version)", v)
+	}
+
+	if enq.n != wantTotal {
+		t.Fatalf("enqueued %d tasks, want %d (one enqueue per created task)", enq.n, wantTotal)
+	}
+}
+
+// TestCreateRunNoTasksWhenNothingPendingAnywhere: selecting an item that is
+// pending on NO targeted site must fail with a clear domain error rather than
+// silently creating doomed tasks.
+func TestCreateRunNoTasksWhenNothingPendingAnywhere(t *testing.T) {
+	tenant := uuid.New()
+	siteA := uuid.New()
+	// Site A has "akismet" installed but with NO pending update.
+	lookup := &fakeSiteLookup{sites: map[uuid.UUID]SiteInfo{
+		siteA: {
+			ID: siteA, Enrolled: true,
+			Components: []Component{{Type: TargetPlugin, Slug: "akismet", Version: "1.0.0"}},
+		},
+	}}
+	svc := NewService(&fakeCreateRepo{}, lookup, &countingEnqueuer{}, domain.NewValidator(), domain.SystemClock{})
+
+	_, _, err := svc.CreateRun(context.Background(), CreateRunInput{
+		TenantID: tenant,
+		SiteIDs:  []uuid.UUID{siteA},
+		Items:    []Item{{Type: "plugin", Slug: "akismet", Version: "latest"}},
+	})
+	if err == nil {
+		t.Fatal("want an error when the selection produces no tasks on any targeted site")
+	}
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindValidation {
+		t.Fatalf("want a KindValidation domain error, got %v", err)
+	}
+}
+
+// TestCreateRunExplicitPinAppliesRegardlessOfPendingFlag proves an explicit
+// version pin (e.g. vuln.Service.Remediate applying a fixed_version, or a
+// deliberate downgrade) still produces a task when the target is installed
+// on the site, even though the site's own inventory does not currently flag
+// it as pending an update — the #126 intersection only gates the DEFAULT
+// ("latest"/unset) case, not a forced explicit pin.
+func TestCreateRunExplicitPinAppliesRegardlessOfPendingFlag(t *testing.T) {
+	tenant := uuid.New()
+	siteID := uuid.New()
+	lookup := &fakeSiteLookup{sites: map[uuid.UUID]SiteInfo{
+		siteID: {
+			ID: siteID, Enrolled: true,
+			// Installed, but no AvailableUpdate is flagged — mirrors a vuln fix
+			// version WordPress's own update-check has not yet caught up to.
+			Components: []Component{{Type: TargetPlugin, Slug: "vulnerable-plugin", Version: "1.0.0"}},
+		},
+	}}
+	svc := NewService(&fakeCreateRepo{}, lookup, &countingEnqueuer{}, domain.NewValidator(), domain.SystemClock{})
+
+	_, tasks, err := svc.CreateRun(context.Background(), CreateRunInput{
+		TenantID: tenant,
+		SiteIDs:  []uuid.UUID{siteID},
+		Items:    []Item{{Type: "plugin", Slug: "vulnerable-plugin", Version: "1.0.1"}},
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("want 1 task for an explicit pin on an installed target, got %d", len(tasks))
+	}
+	if tasks[0].DesiredVersion != "1.0.1" {
+		t.Fatalf("desired_version = %q, want the pinned 1.0.1", tasks[0].DesiredVersion)
+	}
+	if tasks[0].FromVersion != "1.0.0" {
+		t.Fatalf("from_version = %q, want the site's own installed 1.0.0", tasks[0].FromVersion)
+	}
+
+	// The same pin against a site that does NOT have the target installed at
+	// all must produce no task.
+	otherSite := uuid.New()
+	lookup.sites[otherSite] = SiteInfo{ID: otherSite, Enrolled: true}
+	_, _, err = svc.CreateRun(context.Background(), CreateRunInput{
+		TenantID: tenant,
+		SiteIDs:  []uuid.UUID{otherSite},
+		Items:    []Item{{Type: "plugin", Slug: "vulnerable-plugin", Version: "1.0.1"}},
+	})
+	if err == nil {
+		t.Fatal("want an error: the pinned target is not installed on the site at all")
+	}
+}

--- a/apps/api/tests/update_integration_test.go
+++ b/apps/api/tests/update_integration_test.go
@@ -203,12 +203,27 @@ func toUpdateSiteInfo(s site.Site) update.SiteInfo {
 	plugins, themes := s.ParsedComponents()
 	comps := make([]update.Component, 0, len(plugins)+len(themes))
 	for _, p := range plugins {
-		comps = append(comps, update.Component{Type: update.TargetPlugin, Slug: p.Slug, Version: p.Version})
+		comps = append(comps, toUpdateComponentInfo(update.TargetPlugin, p))
 	}
 	for _, th := range themes {
-		comps = append(comps, update.Component{Type: update.TargetTheme, Slug: th.Slug, Version: th.Version})
+		comps = append(comps, toUpdateComponentInfo(update.TargetTheme, th))
 	}
-	return update.SiteInfo{ID: s.ID, URL: s.URL, Name: s.Name, Enrolled: s.EnrolledAt != nil, Components: comps}
+	info := update.SiteInfo{ID: s.ID, URL: s.URL, Name: s.Name, Enrolled: s.EnrolledAt != nil, Components: comps}
+	if core := s.ParsedCoreUpdate(); core != nil && core.NewVersion != "" {
+		info.CoreUpdateAvailable = true
+		info.CoreCurrentVersion = core.CurrentVersion
+		info.CoreNewVersion = core.NewVersion
+	}
+	return info
+}
+
+func toUpdateComponentInfo(typ string, c site.Component) update.Component {
+	out := update.Component{Type: typ, Slug: c.Slug, Version: c.Version}
+	if c.AvailableUpdate != nil && c.AvailableUpdate.NewVersion != "" {
+		out.UpdateAvailable = true
+		out.NewVersion = c.AvailableUpdate.NewVersion
+	}
+	return out
 }
 
 // genEd25519PrivBase64 returns a fresh Ed25519 private key as base64-std (the
@@ -231,6 +246,34 @@ type updateTestHarness struct {
 	worker  *update.Worker
 	client  *river.Client[pgx.Tx]
 	siteSvc *site.Service
+}
+
+// seedPendingPlugin records a plugin inventory entry with a pending update
+// advisory on the site, so update.Service.planTasks (#126: intersect a run's
+// requested items against each site's OWN pending set) actually produces a
+// task for it.
+func seedPendingPlugin(t *testing.T, h *updateTestHarness, tenant uuid.UUID, s site.Site, slug, from, to string) {
+	t.Helper()
+	_, err := h.siteSvc.ApplyMetadata(context.Background(), tenant, s.ID, site.Metadata{
+		Plugins: []site.Component{{
+			Slug: slug, Version: from,
+			AvailableUpdate: &site.AvailableUpdate{NewVersion: to},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("seed pending plugin: %v", err)
+	}
+}
+
+// seedPendingCore records a WordPress core update advisory on the site.
+func seedPendingCore(t *testing.T, h *updateTestHarness, tenant uuid.UUID, s site.Site, from, to string) {
+	t.Helper()
+	_, err := h.siteSvc.ApplyMetadata(context.Background(), tenant, s.ID, site.Metadata{
+		CoreUpdate: &site.CoreUpdate{CurrentVersion: from, NewVersion: to},
+	})
+	if err != nil {
+		t.Fatalf("seed pending core: %v", err)
+	}
 }
 
 // enrollFakeSite enrolls a site whose URL points at the fake agent.
@@ -357,6 +400,7 @@ func TestUpdateRunHappyPath(t *testing.T) {
 	h := buildHarness(t, pool, newTestCommander(t), newTestProber(t))
 	s := enrollFakeSite(t, pool, tenant, fa.url())
 	fa.setExpectAud(s.ID.String())
+	seedPendingPlugin(t, h, tenant, s, "akismet", "1.0.0", "1.1.0")
 
 	run, tasks, err := h.svc.CreateRun(context.Background(), update.CreateRunInput{
 		TenantID: tenant,
@@ -411,6 +455,7 @@ func TestUpdateAutoRollback(t *testing.T) {
 	h := buildHarness(t, pool, newTestCommander(t), newTestProber(t))
 	s := enrollFakeSite(t, pool, tenant, fa.url())
 	fa.setExpectAud(s.ID.String())
+	seedPendingPlugin(t, h, tenant, s, "broken-plugin", "1.0.0", "1.1.0")
 
 	run, _, err := h.svc.CreateRun(context.Background(), update.CreateRunInput{
 		TenantID: tenant,
@@ -456,6 +501,7 @@ func TestUpdateDryRunDoesNotMutate(t *testing.T) {
 	h := buildHarness(t, pool, newTestCommander(t), newTestProber(t))
 	s := enrollFakeSite(t, pool, tenant, fa.url())
 	fa.setExpectAud(s.ID.String())
+	seedPendingCore(t, h, tenant, s, "6.4", "6.5")
 
 	run, _, err := h.svc.CreateRun(context.Background(), update.CreateRunInput{
 		TenantID: tenant,

--- a/apps/api/tests/update_rls_integration_test.go
+++ b/apps/api/tests/update_rls_integration_test.go
@@ -35,6 +35,12 @@ func TestUpdateRunCreatesTasksAndEnqueues(t *testing.T) {
 
 	// A site enrolled (no live agent needed; we don't run tasks here).
 	s := enrollFakeSite(t, pool, tenant, "https://create.example.com")
+	if _, err := siteSvc.ApplyMetadata(ctx, tenant, s.ID, site.Metadata{
+		Plugins:    []site.Component{{Slug: "akismet", Version: "1.0.0", AvailableUpdate: &site.AvailableUpdate{NewVersion: "1.1.0"}}},
+		CoreUpdate: &site.CoreUpdate{CurrentVersion: "6.4", NewVersion: "6.5"},
+	}); err != nil {
+		t.Fatalf("seed pending updates: %v", err)
+	}
 
 	run, tasks, err := svc.CreateRun(ctx, update.CreateRunInput{
 		TenantID: tenant,
@@ -71,6 +77,11 @@ func TestUpdateRLSCrossTenantDenied(t *testing.T) {
 	svc := update.NewService(update.NewRepo(pool), &svcSiteLookup{svc: siteSvc}, &noopEnqueuer{}, domain.NewValidator(), domain.SystemClock{})
 
 	sA := enrollFakeSite(t, pool, tenantA, "https://rls-a.example.com")
+	if _, err := siteSvc.ApplyMetadata(ctx, tenantA, sA.ID, site.Metadata{
+		Plugins: []site.Component{{Slug: "akismet", Version: "1.0.0", AvailableUpdate: &site.AvailableUpdate{NewVersion: "1.1.0"}}},
+	}); err != nil {
+		t.Fatalf("seed pending update: %v", err)
+	}
 	runA, _, err := svc.CreateRun(ctx, update.CreateRunInput{
 		TenantID: tenantA,
 		SiteIDs:  []uuid.UUID{sA.ID},


### PR DESCRIPTION
Multi-site bulk update no longer fans the union of all targets to every site (N×M explosion). CP planTasks intersects each site's own pending updates (explicit pins still apply everywhere → vuln remediation preserved); agent classifies not-installed/no-pending as skipped/up_to_date instead of failed. api + agent 0.61.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)