### PR TITLE
fix: #131 agent update atomicity + recovery + CP dedup, #132 uptime WSOD detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,29 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
-### Added
+No unreleased changes.
 
-- **File Manager.** Operators can browse, edit, upload, download, and manage files on any managed WordPress site directly from the dashboard, under a new Files tab on each site, without needing SFTP or cPanel access. Browse the full file tree; preview text files inline or download binary files via presigned URL. A sensitive-file deny-list (wp-config.php, .env, key files) requires owner confirmation before access. A separate per-site write toggle (off by default) unlocks editing, uploading (drag-and-drop), creating folders, renaming, deleting (typed confirmation), and chmod (safe modes only). Write operations reject executable content (PHP files, any file containing `<?php`) and refuse to touch protected roots (wp-admin, wp-includes, WordPress core). Zip any file or folder and download the archive; extract a zip back into the site with zip-slip and zip-bomb protection. Search files by name or content across the tree. Every edit and overwrite auto-saves an encrypted prior version that operators can browse and restore from a per-file version history panel. The file manager is off by default per site, restricted to owner and admin roles, and every read, write, delete, upload, extract, restore, and denial is written to the operator audit log. The Audit page is now a filterable timeline with filter-by-action-group (including "File manager") and filter-by-site; a "View activity" link in the file manager jumps straight to that site's file trail.
+## [0.61.10] - 2026-07-02
 
-- **CloudPanel cache purge support in the agent.** On CloudPanel sites, WPMgr now clears its disk page cache and CloudPanel Varnish together: full-site purges send both host and cache-tag Varnish purges, per-URL purges clear the matching Varnish URLs, and full-site purges also clean up the host PageSpeed cache when writable. The optional CloudPanel WordPress plugin is not required.
+### Fixed
 
-### Changed
+- **Multi-site bulk update now only creates a task for a site that actually has the selected update pending.** Previously a bulk update created a task for every selected site regardless of whether that site had the chosen plugin, theme, or core update available, so a site without the update simply failed. A target that does not apply to a site is now reported as skipped, not failed. (#126)
 
-- **New marketing website.** The public site at wpmgr.app is now a multipage Next.js application with server-side rendering and static generation for SEO, replacing the previous single-page site. It adds a dedicated page for every feature, solution pages by audience and by job, pricing, a searchable changelog, a resources area with guides and articles, a desktop megamenu plus a mobile drawer, and a self-hosted API reference at /docs generated from the OpenAPI spec with no external network at runtime. Faster, fully crawlable, and easier to extend.
+## [0.61.9] - 2026-07-02
+
+### Fixed
+
+- **A failed plugin or theme update no longer leaves a site stuck in WordPress maintenance mode (critical).** The post-update health check treated a transient 503 from an in-progress database migration as a failure and rolled back an update that had actually succeeded, leaving the site's maintenance page (`.maintenance`) showing 503 to every visitor. The health check now tolerates a brief, migration-related 503 instead of rolling back a successful update. (#127)
+
+## [0.61.6] - 2026-07-02
+
+### Fixed
+
+- **Downtime email alerts now fire reliably.** A race in the alert state machine meant a sustained outage could go unalerted; alert state now transitions atomically so every qualifying outage sends its alert. (#124)
+- **The Notifications settings page now saves correctly**, including the daily email digest toggle, which previously did not persist. (#123)
+- **Fixed a slow first load of the Sites list after the dashboard had been idle.** A pooled database connection could be handed back to a request without being revalidated, and the 30-day uptime aggregate query was not using its covering index; both are fixed, so the first request after idle now loads at normal speed.
+
+## [0.61.3] - 2026-06-26
 
 ### Fixed
 
@@ -30,6 +44,19 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 - The Sites overview Uptime column now shows per-site uptime instead of staying blank.
 - "Open in wp-admin" for a multi-site selection now lists every selected site in a persistent panel with a per-site Open action, instead of a few auto-dismissing toasts.
 - A site's "Backup schedule runs" panel now shows past completed and failed runs that already exist instead of always reporting none.
+
+## [0.61.0] - 2026-06-23
+
+### Added
+
+- **File Manager.** Operators can browse, edit, upload, download, and manage files on any managed WordPress site directly from the dashboard, under a new Files tab on each site, without needing SFTP or cPanel access. Browse the full file tree; preview text files inline or download binary files via presigned URL. A sensitive-file deny-list (wp-config.php, .env, key files) requires owner confirmation before access. A separate per-site write toggle (off by default) unlocks editing, uploading (drag-and-drop), creating folders, renaming, deleting (typed confirmation), and chmod (safe modes only). Write operations reject executable content (PHP files, any file containing `<?php`) and refuse to touch protected roots (wp-admin, wp-includes, WordPress core). Zip any file or folder and download the archive; extract a zip back into the site with zip-slip and zip-bomb protection. Search files by name or content across the tree. Every edit and overwrite auto-saves an encrypted prior version that operators can browse and restore from a per-file version history panel. The file manager is off by default per site, restricted to owner and admin roles, and every read, write, delete, upload, extract, restore, and denial is written to the operator audit log. The Audit page is now a filterable timeline with filter-by-action-group (including "File manager") and filter-by-site; a "View activity" link in the file manager jumps straight to that site's file trail.
+- **CloudPanel cache purge support in the agent.** On CloudPanel sites, WPMgr now clears its disk page cache and CloudPanel Varnish together: full-site purges send both host and cache-tag Varnish purges, per-URL purges clear the matching Varnish URLs, and full-site purges also clean up the host PageSpeed cache when writable. The optional CloudPanel WordPress plugin is not required.
+
+## [0.57.7] - 2026-06-21
+
+### Changed
+
+- **New marketing website.** The public site at wpmgr.app is now a multipage Next.js application with server-side rendering and static generation for SEO, replacing the previous single-page site. It adds a dedicated page for every feature, solution pages by audience and by job, pricing, a searchable changelog, a resources area with guides and articles, a desktop megamenu plus a mobile drawer, and a self-hosted API reference at /docs generated from the OpenAPI spec with no external network at runtime. Faster, fully crawlable, and easier to extend.
 
 ## [0.57.0] - 2026-06-21
 

--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -116,7 +116,9 @@ use WPMgr\Agent\Support\ErrorMonitor;
 use WPMgr\Agent\Support\LoginBrand;
 use WPMgr\Agent\Support\LoginProtection;
 use WPMgr\Agent\Support\MuPluginInstaller;
+use WPMgr\Agent\Support\SnapshotManager;
 use WPMgr\Agent\Support\UpdateChecker;
+use WPMgr\Agent\Support\UpdateInFlight;
 use WPMgr\Agent\AutoOptimizeUpload;
 use WPMgr\Agent\Webhooks\MediaModalInjector;
 
@@ -565,6 +567,24 @@ final class Plugin
         // on cleanup; the handler sweeps anything older than 24 h.
         add_action('wpmgr_restore_oldfiles_gc', [FilesRestorer::class, 'gcOldFiles']);
 
+        // M1 (issue #131 adversarial review) — recurring GC backstop for the
+        // wpmgr-snapshots/ store UpdateCommand's pre-update snapshots live
+        // in. Bounds disk even for orphans the per-slug prune in
+        // SnapshotManager::capture() cannot reach (a since-uninstalled/
+        // renamed slug, a core meta-only snapshot, a crashed capture).
+        // Scheduled daily by SnapshotManager::scheduleGc() (activate() below
+        // + maybeRescheduleCron()'s self-heal).
+        add_action(SnapshotManager::HOOK_GC, [SnapshotManager::class, 'gcExpired']);
+
+        // S4 (issue #131 adversarial review) — recurring reconcile sweep for
+        // update-in-flight markers left stale by a PHP-FPM
+        // request_terminate_timeout hard-kill (the one case
+        // UpdateGuard's register_shutdown_function() backstop cannot catch).
+        // Scheduled hourly by UpdateInFlight::scheduleGc() (activate() below
+        // + maybeRescheduleCron()'s self-heal); see UpdateInFlight's class
+        // doc for the full design.
+        add_action(UpdateInFlight::HOOK_GC, [UpdateInFlight::class, 'gcSweep']);
+
         // Media Optimizer — WP attachment-deletion cleanup. When an attachment
         // is deleted (wp-admin, programmatic, WP-CLI, or REST), WordPress purges
         // ONLY the files it tracks in _wp_attachment_metadata; WPMgr's own
@@ -861,6 +881,15 @@ final class Plugin
         // Phase 4b — suppression-cache pull: 15-minute recurring event.
         SuppressionCache::schedule_pull($now);
 
+        // M1 (issue #131 adversarial review) — daily snapshot-store GC
+        // backstop (bounded disk for wpmgr-snapshots/).
+        SnapshotManager::scheduleGc($now);
+
+        // S4 (issue #131 adversarial review) — hourly update-in-flight
+        // reconcile sweep (recovers a PHP-FPM hard-killed apply that never
+        // reached UpdateGuard's own shutdown-function backstop).
+        UpdateInFlight::scheduleGc($now);
+
         // v0.9.13 — push diagnostics within ~30s of activation rather than
         // waiting out the jittered daily cron's 0..4h first-fire offset
         // (Scheduler::diagnosticsJitter). The single-event below fires the
@@ -986,6 +1015,10 @@ final class Plugin
             wp_clear_scheduled_hook(EmailLogger::HOOK_PRUNE);
             wp_clear_scheduled_hook(EmailLogReporter::HOOK_PUSH);
             wp_clear_scheduled_hook(SuppressionCache::HOOK_PULL);
+            // M1 / S4 (issue #131 adversarial review) — snapshot-store GC
+            // backstop + update-in-flight reconcile sweep.
+            wp_clear_scheduled_hook(SnapshotManager::HOOK_GC);
+            wp_clear_scheduled_hook(UpdateInFlight::HOOK_GC);
         }
 
         // Phase 3 — page-cache teardown. Cleanly reverse every server-side
@@ -1279,6 +1312,14 @@ final class Plugin
 
         // Phase 4b — suppression-cache pull — re-arm when missing.
         SuppressionCache::schedule_pull($now);
+
+        // M1 (issue #131 adversarial review) — snapshot-store GC backstop —
+        // re-arm when missing.
+        SnapshotManager::scheduleGc($now);
+
+        // S4 (issue #131 adversarial review) — update-in-flight reconcile
+        // sweep — re-arm when missing.
+        UpdateInFlight::scheduleGc($now);
     }
 
     /**

--- a/apps/agent/includes/commands/class-metadata-command.php
+++ b/apps/agent/includes/commands/class-metadata-command.php
@@ -133,7 +133,7 @@ final class MetadataCommand implements CommandInterface
             'is_atomic'    => defined('IS_ATOMIC') || defined('ATOMIC_SITE_ID'),
             'is_kinsta'    => defined('KINSTAMU_VERSION') || defined('KINSTA_CACHE_ZONE'),
             'is_flywheel'  => defined('FLYWHEEL_CONFIG_DIR') || defined('FLYWHEEL_PLUGIN_DIR'),
-            'is_runcloud'  => defined('RUNCLOUD') || is_dir('/var/lib/runcloud'),
+            'is_runcloud'  => defined('RUNCLOUD') || @is_dir('/var/lib/runcloud'),
             'is_cloudways' => defined('CLOUDWAYS') || isset($_SERVER['CW_HOSTNAME']),
         ];
     }

--- a/apps/agent/includes/commands/class-rollback-command.php
+++ b/apps/agent/includes/commands/class-rollback-command.php
@@ -25,6 +25,7 @@ namespace WPMgr\Agent\Commands;
 
 use WPMgr\Agent\Support\Maintenance;
 use WPMgr\Agent\Support\SnapshotManager;
+use WPMgr\Agent\Support\UpdateInFlight;
 use WPMgr\Agent\Support\UpdateRunner;
 
 /**
@@ -114,6 +115,17 @@ final class RollbackCommand implements CommandInterface
                     'log'              => $restore['log'],
                 ];
             }
+
+            // S4 (issue #131 adversarial review) — defensive cleanup: the CP
+            // may call RollbackCommand directly against a snapshot whose
+            // original `update` request was hard-killed severely enough that
+            // it never reached its own cleanup (so an UpdateInFlight marker
+            // for this type/slug could still be sitting around). This
+            // restore already handled recovery, so clear it now rather than
+            // leaving a stale marker for the reconcile sweep to needlessly
+            // re-restore later. Unconditionally safe — a no-op when no
+            // marker exists for this type/slug.
+            UpdateInFlight::clear($type, $slug);
 
             // Determine the version after restore; prefer the recorded prior version.
             $restoredVersion = $this->runner->currentVersion($type, $slug);

--- a/apps/agent/includes/commands/class-update-command.php
+++ b/apps/agent/includes/commands/class-update-command.php
@@ -11,12 +11,53 @@
  *
  * Execution strategy:
  *   - dry_run: never touches the filesystem; reports would_update / up_to_date.
- *   - snapshot=true (non-dry): a PRE-UPDATE snapshot is captured so RollbackCommand
- *     can restore. Plugin/theme directories are copied under
- *     wp-content/uploads/wpmgr-snapshots/<snapshot_id>/; core records its prior
- *     version (downgrade-by-version on rollback).
+ *   - Pre-update snapshot (GitHub issue #131): for plugin/theme items a
+ *     snapshot is ALWAYS captured before applying, regardless of the
+ *     request's `snapshot` flag — it is the precondition for the auto-restore
+ *     below, and a same-filesystem directory copy under
+ *     wp-content/uploads/wpmgr-snapshots/<snapshot_id>/ is cheap. `core` keeps
+ *     the original opt-in behavior (`snapshot=true` records the prior version
+ *     for RollbackCommand's downgrade-by-version; there is no directory to
+ *     snapshot for core, and no directory-level auto-restore — see D3 below).
  *   - apply: prefers WP-CLI when available, else falls back to the WordPress
  *     upgrader APIs under a quiet skin.
+ *   - Completeness check + auto-restore (GitHub issue #131): a version-header
+ *     bump alone does not prove an apply finished — WordPress's
+ *     install_package()/copy_dir() is a non-atomic recursive copy that clears
+ *     the destination first, so a hard resource kill mid-copy can leave a
+ *     half-written plugin/theme whose main file WAS replaced (so the version
+ *     reads as updated) while the rest of the tree is missing. Every apply is
+ *     re-verified via UpdateRunner::isComplete() (plugin: validate_plugin();
+ *     theme: a re-readable style.css `Name` header); an incomplete result is
+ *     automatically rolled back from the pre-update snapshot and reported as
+ *     `failed`, never `succeeded`. A WPMgr\Agent\Support\UpdateGuard, armed
+ *     via register_shutdown_function() before the apply call, is the backstop
+ *     for a kill severe enough that execution never returns from apply() at
+ *     all. For `core` (D3) this directory-level rollback is deliberately NOT
+ *     built — core relies on execute()'s resource guard (B1) plus WordPress's
+ *     own Core_Upgrader temp-backup mechanism.
+ *   - Out-of-band reconcile (S4, adversarial review of issue #131): the
+ *     shutdown guard above cannot run at all when PHP-FPM's own
+ *     `request_terminate_timeout` SIGTERMs the worker — that kill resets the
+ *     timeout handler to SIG_DFL and tears the process down with NO shutdown
+ *     functions invoked. WPMgr\Agent\Support\UpdateInFlight persists a small
+ *     marker before each guarded apply and reconciles (auto-restores +
+ *     clears) any marker left stale by exactly that kill, both at the start
+ *     of the next `update` command and via a recurring cron sweep — see its
+ *     class doc for the full design and the staleness-margin reasoning.
+ *   - Unprotected-apply refusal (S8, adversarial review): a plugin/theme item
+ *     whose pre-update snapshot capture FAILED is never applied unguarded —
+ *     execute() refuses the item outright (`failed`) rather than proceeding
+ *     without a guard, an in-flight marker, or anything to roll back to.
+ *   - Final-hardening round (issue #131 final-hardening review): the
+ *     UpdateInFlight marker written before each guarded apply is now paired
+ *     with an flock() liveness lock held for the apply's whole duration (B)
+ *     and reconciled only after verifying the live directory is genuinely
+ *     incomplete (F2) — see UpdateInFlight's own class doc for both. This
+ *     method also acquires/releases that lock ($inFlightLock, alongside the
+ *     marker in the `finally` below) and opportunistically invokes
+ *     SnapshotManager::gcExpired() (C) so orphaned snapshots/asides are
+ *     reclaimed even on a `DISABLE_WP_CRON`/dormant site, not cron-only.
  *
  * Every input is treated as untrusted: type is whitelisted, slug is sanitized to
  * reject path traversal, and snapshot paths are bounded to wp-content.
@@ -28,8 +69,11 @@ declare(strict_types=1);
 
 namespace WPMgr\Agent\Commands;
 
+use WPMgr\Agent\Support\DebugLog;
 use WPMgr\Agent\Support\Maintenance;
 use WPMgr\Agent\Support\SnapshotManager;
+use WPMgr\Agent\Support\UpdateGuard;
+use WPMgr\Agent\Support\UpdateInFlight;
 use WPMgr\Agent\Support\UpdateRunner;
 
 /**
@@ -39,6 +83,23 @@ final class UpdateCommand implements CommandInterface
 {
     /** Valid item types. */
     private const TYPES = ['plugin', 'theme', 'core'];
+
+    /**
+     * S4 (issue #131 adversarial review) — bounded-but-generous apply time
+     * limit. The original `set_time_limit(0)` (infinite) threw away the ONE
+     * timer whose fatal WOULD run register_shutdown_function() callbacks
+     * (max_execution_time) in favor of relying solely on PHP-FPM's own
+     * `request_terminate_timeout`, which does NOT run shutdown functions at
+     * all (SIGTERM resets the timeout handler to SIG_DFL and kills the
+     * worker immediately — see UpdateGuard's class doc). 900s (15 minutes)
+     * is generous for even a very large plugin/theme copy, while still
+     * giving a truly-hung apply a chance to hit PHP's own RECOVERABLE fatal
+     * before something else (FPM's timeout, when configured shorter) tears
+     * the process down with no recovery at all. See
+     * WPMgr\Agent\Support\UpdateInFlight for the out-of-band backstop that
+     * covers the case where FPM's own timeout IS shorter than this bound.
+     */
+    private const APPLY_TIME_LIMIT_SECONDS = 900;
 
     private SnapshotManager $snapshots;
 
@@ -71,12 +132,64 @@ final class UpdateCommand implements CommandInterface
      */
     public function execute(array $claims, array $params): array
     {
+        // B1 (GitHub issue #131) — survive the apply itself. UpdateRunner
+        // applies plugin/theme/core updates via WordPress's Plugin_Upgrader /
+        // Theme_Upgrader / Core_Upgrader INLINE in this REST request — there
+        // is no WP-CLI subprocess and no cron handoff. Their install_package()
+        // does a non-atomic recursive copy (clear destination, then copy new
+        // files in); the most likely cause of a half-written result is a hard
+        // resource kill (max_execution_time or a PHP-FPM
+        // request_terminate_timeout) partway through that copy. This mirrors
+        // BackupCommand's long-running-job guard.
+        //
+        // S4 (adversarial review) — bounded, not infinite: see
+        // APPLY_TIME_LIMIT_SECONDS's doc for why 0 (infinite) was itself part
+        // of the bug.
+        @set_time_limit(self::APPLY_TIME_LIMIT_SECONDS); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- bounded-but-generous cap so a hung apply hits a recoverable max_execution_time fatal rather than only an unrecoverable FPM hard-kill; @-guarded, no-op when disabled
+        if (function_exists('wp_raise_memory_limit')) {
+            wp_raise_memory_limit('admin');
+        }
+        @ignore_user_abort(true); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- keep applying even if the control plane's HTTP client disconnects mid-request; @-guarded
+
         // Heal a `.maintenance` flag left behind by a prior interrupted
         // update/rollback before starting new work, and arm the shutdown
         // backstop so a fatal error or a timeout mid-update still clears
         // whatever flag THIS run may leave set.
         Maintenance::healStaleIfPresent();
         Maintenance::armShutdownGuard();
+
+        // S4 (adversarial review) — reconcile any update-in-flight marker
+        // left stale by a prior request that was hard-killed severely enough
+        // that UpdateGuard's own shutdown hook never ran (see
+        // UpdateInFlight's class doc). This is the "next agent request" half
+        // of that recovery; HOOK_GC's recurring cron sweep is the other half,
+        // covering the case where no further `update` command ever arrives.
+        //
+        // F2 (final-hardening review) — pass THIS command's own injected
+        // $this->runner, not a fresh ad-hoc UpdateRunner, so the F2
+        // live-directory health check reconcile now performs uses exactly
+        // the same WP-CLI/upgrader-aware runner the rest of this command
+        // does (and so a test that injects a runner double controls this
+        // path too, rather than always hitting a real UpdateRunner).
+        UpdateInFlight::healStaleIfPresent($this->snapshots, $this->runner);
+
+        // C (issue #131 final-hardening review) — invoke the snapshot-store
+        // GC backstop OPPORTUNISTICALLY here too, not cron-only. WP-Cron is
+        // unreliable on `DISABLE_WP_CRON`/dormant sites (no visitor traffic
+        // ever fires the wp-cron.php pseudo-cron request), so an orphaned
+        // snapshot — a since-uninstalled/renamed slug, a crashed capture, or
+        // a stranded restore-failure aside (F4) — could otherwise sit
+        // unreclaimed indefinitely on such a site. Belt-and-suspenders,
+        // mirroring the same reasoning already applied to
+        // UpdateInFlight::healStaleIfPresent() immediately above (which is
+        // itself the opportunistic half of ITS OWN cron-bound counterpart,
+        // gcSweep() — already covered here via the injected $this->snapshots
+        // call above, so it is deliberately NOT invoked a second time
+        // through a fresh, non-injected SnapshotManager instance, which
+        // would both duplicate that work and bypass any snapshot test double
+        // a caller constructed this command with). Cheap: a bounded,
+        // mostly-no-op scandir() pass over a small, self-contained directory.
+        SnapshotManager::gcExpired();
 
         $dryRun   = isset($params['dry_run']) && (bool) $params['dry_run'];
         $snapshot = isset($params['snapshot']) && (bool) $params['snapshot'];
@@ -102,7 +215,9 @@ final class UpdateCommand implements CommandInterface
      *
      * @param array<string,mixed> $item     One request item.
      * @param bool                $dryRun   Whether to avoid mutation.
-     * @param bool                $snapshot Whether to capture a pre-update snapshot.
+     * @param bool                $snapshot Whether to capture a pre-update snapshot for a
+     *                                       `core` item. Ignored for plugin/theme, which
+     *                                       always snapshot — see class doc (D2, issue #131).
      * @return array{type:string,slug:string,from_version:string,to_version:string,status:string,snapshot_id:string,log:string}
      */
     private function processItem(array $item, bool $dryRun, bool $snapshot): array
@@ -127,6 +242,18 @@ final class UpdateCommand implements CommandInterface
                 return $this->result($type, $rawSlug, '', '', 'failed', '', 'Invalid or unsafe slug.');
             }
         }
+
+        // Declared here (rather than inside the inner try below) so the
+        // outer catch(\Throwable) can still see a snapshot that WAS captured
+        // — and a guard that WAS armed — before apply() threw, and fire the
+        // exact same restore path the synchronous incomplete-apply case uses.
+        $snapshotId = '';
+        $guard      = null;
+        // B (issue #131 final-hardening review) — the UpdateInFlight liveness
+        // lock returned by UpdateInFlight::mark(); released in the `finally`
+        // below alongside UpdateInFlight::clear(). See UpdateInFlight's class
+        // doc for why this must stay open for the whole apply.
+        $inFlightLock = null;
 
         try {
             // --- Not-applicable target: the plugin/theme isn't present on
@@ -166,32 +293,201 @@ final class UpdateCommand implements CommandInterface
             // flag before we move on, so a failed item can never leave the
             // whole site dark for the rest of the batch (or indefinitely).
             try {
-                // --- Optional pre-update snapshot. ---
-                $snapshotId = '';
-                $log        = '';
-                if ($snapshot) {
+                $log = '';
+
+                // --- Pre-update snapshot (D2, GitHub issue #131) -----------
+                // plugin/theme: ALWAYS captured, regardless of the request's
+                // `snapshot` flag — it is the precondition for the
+                // auto-restore below and a cheap same-filesystem copy under
+                // wpmgr-snapshots. `core` keeps the original opt-in behavior:
+                // there is no directory to snapshot/restore for core, and D3
+                // deliberately does not build one (see UpdateRunner::isComplete()).
+                $shouldSnapshot = $type === 'core' ? $snapshot : true;
+                if ($shouldSnapshot) {
                     $snap        = $this->snapshots->capture($type, $slug, $fromVersion);
                     $snapshotId  = $snap['snapshot_id'];
                     $log        .= $snap['log'];
+                }
+
+                // --- S8 (issue #131 adversarial review): refuse an
+                // unprotected apply --------------------------------------
+                // plugin/theme ALWAYS expects a snapshot (shouldSnapshot is
+                // unconditionally true above); a capture failure here (e.g.
+                // a disk-constrained host) previously fell straight through
+                // to an UNGUARDED apply() — no UpdateGuard armed, no
+                // in-flight marker, nothing to roll back to if the copy dies
+                // mid-write. Refuse the item instead: a host that cannot
+                // hold one snapshot copy is not a host we should risk an
+                // unrecoverable half-write on. `core` is exempt — D3 already
+                // gives it no directory-level snapshot/restore protection by
+                // design (it relies on B1 + WordPress's own Core_Upgrader
+                // temp-backup mechanism instead), so a core snapshot
+                // capture failure (only reachable when `snapshot=true` was
+                // requested at all) must not block a core apply that never
+                // depended on it.
+                if ($type !== 'core' && $snapshotId === '') {
+                    return $this->result(
+                        $type,
+                        $slug,
+                        $fromVersion,
+                        $fromVersion,
+                        'failed',
+                        '',
+                        $log . "\nCould not capture a pre-update snapshot; refusing to apply unprotected."
+                    );
+                }
+
+                // --- Arm the shutdown-time restore backstop (D2) -----------
+                // Only for plugin/theme with a successfully captured
+                // directory snapshot — core never gets one (D3). WordPress's
+                // Plugin_Upgrader/Theme_Upgrader apply via
+                // install_package()/copy_dir(), a NON-atomic recursive copy
+                // that clears the destination FIRST; a hard resource kill
+                // mid-copy tears the whole PHP process down without
+                // unwinding any try/catch/finally, so this registered
+                // shutdown callback is the only code that still runs
+                // afterwards. See UpdateGuard's class doc for the full
+                // arm/markClean/fire lifecycle.
+                if ($type !== 'core' && $snapshotId !== '') {
+                    $guard = new UpdateGuard($this->snapshots, $type, $slug, $snapshotId);
+                    $guard->arm();
+
+                    // S4 (adversarial review) — persist the out-of-band
+                    // reconcile marker BEFORE apply() so a kill severe
+                    // enough that the shutdown guard above never runs either
+                    // (a PHP-FPM request_terminate_timeout SIGTERM) is still
+                    // recoverable later. See UpdateInFlight's class doc.
+                    //
+                    // B (final-hardening review) — mark() also acquires and
+                    // returns the liveness lock this marker is paired with;
+                    // it MUST stay held (open) through apply() below and is
+                    // only released in this method's `finally`.
+                    $inFlightLock = UpdateInFlight::mark($type, $slug, $snapshotId);
                 }
 
                 // --- Apply the update. ---
                 $applied = $this->runner->apply($type, $slug, $version);
                 $log    .= ($log !== '' ? "\n" : '') . $applied['log'];
 
-                $toVersion = $this->runner->currentVersion($type, $slug);
+                // --- Post-apply verification (S7, issue #131 adversarial
+                // review) — currentVersion()/isComplete() run AFTER a
+                // successful apply() but before the guard is told the result
+                // is clean, still inside this same try/finally. A THROWN
+                // error here is evidence that VERIFICATION is broken, not
+                // that the apply itself was bad — rolling back a perfectly
+                // good update because the code checking it happened to throw
+                // would be strictly worse than keeping the update and
+                // logging a warning. Only an AFFIRMATIVE incomplete
+                // ($complete === false) may trigger the restore below; a
+                // throw is treated as inconclusive and the update is KEPT.
+                // The CP's own post-update health probe remains the backstop
+                // for a genuinely bad apply that happens to also break
+                // verification.
+                $toVersion = $fromVersion;
+                $complete  = false;
+                try {
+                    $toVersion = $this->runner->currentVersion($type, $slug);
+                    // Short-circuits on $applied['ok'] === false, matching
+                    // the original intent: a genuine upgrader failure never
+                    // pays for the extra WP API round trip isComplete() costs.
+                    $complete = $applied['ok'] && $this->runner->isComplete($type, $slug);
+                } catch (\Throwable $verifyError) {
+                    DebugLog::write(
+                        'WPMgr Agent: post-apply verification threw for ' . $type . ':' . $slug
+                        . ': ' . $verifyError->getMessage() . '.'
+                    );
+                    if ($applied['ok']) {
+                        // The apply ITSELF reported success; a throw while
+                        // verifying it afterward is evidence verification is
+                        // broken, not that the apply was bad — keep the
+                        // update rather than false-roll-it-back. Only an
+                        // AFFIRMATIVE incomplete (never a throw) may trigger
+                        // the restore below.
+                        $log     .= "\nPost-apply verification error; update KEPT (not rolled back) — verification itself failed, not the apply.";
+                        $complete = true;
+                    } else {
+                        // The apply had already reported failure on its own
+                        // terms — this still proceeds through the normal
+                        // incomplete/failed/restore path below; the throw
+                        // only means to_version could not be re-read here (it
+                        // may still be corrected below if a restore runs).
+                        $log .= "\nCould not re-read the installed version after a failed apply.";
+                    }
+                }
 
-                $status = $applied['ok']
-                    ? ($toVersion !== $fromVersion ? 'succeeded' : 'up_to_date')
-                    : 'failed';
+                if ($complete) {
+                    // Verified-good: tell the guard (if armed) not to
+                    // restore. MUST happen before returning — an un-cleared
+                    // guard would otherwise undo a perfectly good update if
+                    // this request is torn down by something unrelated later
+                    // in the same shutdown chain.
+                    if ($guard !== null) {
+                        $guard->markClean();
+                    }
 
-                return $this->result($type, $slug, $fromVersion, $toVersion, $status, $snapshotId, $log);
+                    $status = $toVersion !== $fromVersion ? 'succeeded' : 'up_to_date';
+
+                    return $this->result($type, $slug, $fromVersion, $toVersion, $status, $snapshotId, $log);
+                }
+
+                // Incomplete or failed apply: roll back synchronously right
+                // now rather than waiting on the shutdown backstop, so the
+                // directory is restored before we even respond to the
+                // control plane. fire() is idempotent, so a later real
+                // shutdown invocation of the same (already-fired) guard is
+                // always safe.
+                if ($guard !== null) {
+                    $restore = $guard->fire();
+                    if ($restore['fired']) {
+                        $log .= "\n" . ($restore['ok']
+                            ? 'Update incomplete; auto-restored the pre-update snapshot.'
+                            : 'Update incomplete; auto-restore FAILED: ' . $restore['log']);
+                        // Re-read the version now the directory should be
+                        // back to its pre-update state, so the response
+                        // reflects what is actually on disk.
+                        $toVersion = $this->runner->currentVersion($type, $slug);
+                    }
+                } else {
+                    $log .= "\nUpdate incomplete; no pre-update snapshot was available to auto-restore.";
+                }
+
+                return $this->result($type, $slug, $fromVersion, $toVersion, 'failed', $snapshotId, $log);
             } finally {
                 Maintenance::clear();
+
+                // S4 (adversarial review) — every SYNCHRONOUS outcome that
+                // reaches this `finally` (success, a synchronous
+                // incomplete-restore, or a throw about to be caught by the
+                // outer catch below) means this item's fate was resolved
+                // in-process, so the out-of-band reconcile marker is no
+                // longer needed. A marker survives past this point ONLY when
+                // the request never reached here at all — the exact hard-kill
+                // case UpdateInFlight::healStaleIfPresent() exists to recover
+                // later. Safe to call unconditionally even when mark() was
+                // never written for this item (e.g. type === 'core', or the
+                // S8 refusal above returned before arming anything) — clear()
+                // is a no-op when there is nothing to clear.
+                //
+                // B (final-hardening review) — release the liveness lock
+                // FIRST: by the time the marker is gone, its lock must
+                // already be free too. release() is a safe no-op when
+                // $inFlightLock is still null (mark() was never reached, or
+                // itself could not acquire the lock).
+                UpdateInFlight::release($inFlightLock);
+                UpdateInFlight::clear($type, $slug);
             }
         } catch (\Throwable $e) {
+            // A thrown exception mid-apply (rather than a returned
+            // ok:false) still needs the same rollback: fire the guard
+            // synchronously here — same idempotent method the completeness
+            // check above and the shutdown backstop both use — rather than
+            // only relying on the shutdown path.
+            if ($guard !== null) {
+                $guard->fire();
+            }
+
             // Never leak internals; keep the per-item failure contained.
-            return $this->result($type, $slug, '', '', 'failed', '', 'Update error.');
+            return $this->result($type, $slug, '', '', 'failed', $snapshotId, 'Update error.');
         }
     }
 

--- a/apps/agent/includes/support/class-snapshot-manager.php
+++ b/apps/agent/includes/support/class-snapshot-manager.php
@@ -27,6 +27,82 @@ class SnapshotManager
     private const DIR = 'wpmgr-snapshots';
 
     /**
+     * M1 (GitHub issue #131 adversarial review) — per-slug retention cap
+     * enforced at capture time, BEFORE the new snapshot for this apply is
+     * written. Every plugin/theme update now ALWAYS captures a full
+     * directory copy (see UpdateCommand's class doc, D2) and — until this
+     * fix — nothing ever deleted them: an install that updates the same
+     * plugin repeatedly accumulated one full copy per update forever, until
+     * disk filled up and took the site down.
+     *
+     * This is a HARD bound, not a courtesy cleanup, and it is deliberately
+     * scoped to never endanger the control plane's post-update health-probe
+     * window (~1 minute, including the #127 retry):
+     *   - pruneForSlug() (called from capture(), below) only ever considers
+     *     snapshots that ALREADY exist for $type/$slug — the snapshot THIS
+     *     capture() call is about to create does not exist yet when
+     *     pruneForSlug() runs, so it can never be pruned by its own capture.
+     *   - Keeping the most recent (MAX_SNAPSHOTS_PER_SLUG - 1) EXISTING
+     *     snapshots before adding the new one means the PREVIOUS update's
+     *     snapshot — the one a same-session CP rollback would target —
+     *     survives at least until the update AFTER NEXT for that same slug.
+     *     In practice that is always far past any single health-probe
+     *     window; two update cycles back-to-back on the same slug inside
+     *     ~1 minute is not a scenario the control plane produces.
+     * See gcExpired()'s doc below for the separate, age-only cron backstop
+     * that catches what this count-based prune cannot (a slug later
+     * uninstalled/renamed, a core meta-only snapshot, or a crashed capture
+     * that never got as far as writing a readable meta.json).
+     */
+    private const MAX_SNAPSHOTS_PER_SLUG = 2;
+
+    /**
+     * Belt (issue #131 final-hardening review) — a floor UNDER
+     * MAX_SNAPSHOTS_PER_SLUG's count cap: pruneForSlug() must never delete a
+     * snapshot younger than this, REGARDLESS of its rank or the capture-time
+     * TTL below. The count cap alone assumes updates for one slug are
+     * reasonably spaced out; it breaks down if the SAME slug is captured
+     * multiple times in quick succession — for example two concurrent
+     * `update` requests for the same site racing on the same plugin (a CP
+     * dedup bug is being fixed separately to prevent that race at the
+     * source, but the agent should not depend on the CP never sending it).
+     * In that race, a later capture()'s own prune pass could otherwise
+     * delete the snapshot an EARLIER, still-in-flight request's post-update
+     * health probe or rollback still needs. 10 minutes is comfortably longer
+     * than the CP's ~1-minute post-update health-probe window (including the
+     * #127 retry) while still being short enough that this floor never
+     * meaningfully weakens the disk bound MAX_SNAPSHOTS_PER_SLUG exists to
+     * enforce under normal, non-racing update cadence.
+     */
+    private const MIN_KEEP_AGE_SECONDS = 600; // 10 minutes
+
+    /**
+     * Capture-time TTL: an existing snapshot for a slug is pruned once it is
+     * older than this, even if it is still within the count-based cap above.
+     * 24h is two orders of magnitude larger than the ~1 minute CP
+     * health-probe window, so this can never race a legitimate in-flight
+     * rollback — it only ever removes snapshots from update cycles that
+     * finished, one way or another, the better part of a day ago.
+     */
+    private const CAPTURE_PRUNE_TTL_SECONDS = 86400; // 24h
+
+    /** Recurring cron hook name for the GC backstop (gcExpired()). */
+    public const HOOK_GC = 'wpmgr_snapshot_gc';
+
+    /**
+     * GC cron backstop age threshold. Sweeps ANY snapshot dir — regardless
+     * of type/slug — independent of the per-slug count cap in
+     * pruneForSlug(), so orphans the count-based prune cannot reach (a
+     * renamed/uninstalled slug that will never trigger another capture() for
+     * itself, a core meta-only snapshot, or a crashed capture that left a
+     * directory with no meta.json at all) are still hard-bounded. 72h is
+     * comfortably longer than the 24h capture-time TTL above (so the two
+     * never fight over the same snapshot under normal update cadence) and
+     * vastly longer than the ~1 minute CP health-probe window.
+     */
+    private const GC_BACKSTOP_TTL_SECONDS = 259200; // 72h
+
+    /**
      * Capture a pre-update snapshot for an item.
      *
      * For plugin/theme the live source directory is copied into the snapshot
@@ -46,6 +122,12 @@ class SnapshotManager
         }
 
         $this->protectBaseDir($base);
+
+        // M1 (issue #131) — bound disk BEFORE writing a new snapshot. See
+        // MAX_SNAPSHOTS_PER_SLUG's doc above for why this can never remove
+        // the snapshot this very call is about to create, nor one still
+        // needed for the CP's post-update health-probe window.
+        $this->pruneForSlug($base, $type, $slug);
 
         $dest = $base . '/' . $snapshotId;
 
@@ -105,18 +187,101 @@ class SnapshotManager
 
         $asideName = $live . '.wpmgr-old-' . $snapshotId;
 
+        // F1 (issue #131 final-hardening review) — heal a RE-INTERRUPTED
+        // restore for this EXACT snapshot before attempting to stage
+        // anything aside. If $asideName already exists here, a PRIOR
+        // restore() call for this exact snapshot id was itself hard-killed
+        // mid-copy: $asideName holds whatever was live right before that
+        // first attempt started, and $live (if it exists at all right now)
+        // holds only a partial copy() of $payload from the interrupted
+        // attempt — content that is never worth preserving, since the whole
+        // point of THIS call is to overwrite $live with $payload anyway.
+        //
+        // Without this heal, the rename() immediately below would hit an
+        // existing, NON-EMPTY $asideName and fail outright (ENOTEMPTY),
+        // wedging recovery permanently: every subsequent restore attempt for
+        // this snapshot — including a manual RollbackCommand retry, or the
+        // out-of-band UpdateInFlight reconcile — would bail the exact same
+        // way forever, with the good pre-update snapshot payload sitting
+        // right there, unreachable.
+        //
+        // Recover deterministically by discarding the partial $live and
+        // putting the prior aside back in its place, so this call resumes
+        // from precisely the clean starting state a never-interrupted
+        // restore() would have seen — then falls straight through into the
+        // normal stage-aside / copy-back flow below, i.e. this is a full,
+        // fresh retry, not a partial patch-up. The only unavoidable gap is
+        // the brief moment between deleteDir($live) and the rename() call
+        // succeeding (the same delete-then-rename shape already used by the
+        // mid-copy failure path further down); a rename() failure there is
+        // reported rather than silently swallowed, rather than risk ending
+        // this call with NEITHER live nor aside present.
+        if (is_dir($asideName)) {
+            if (is_dir($live)) {
+                $this->deleteDir($live);
+            }
+            if (!@rename($asideName, $live)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic same-filesystem recovery swap; WP_Filesystem::move() is copy+delete (non-atomic) and breaks crash/watchdog-resume safety
+                return [
+                    'ok'  => false,
+                    'log' => 'A prior interrupted restore left ' . $asideName
+                        . ' stranded and it could not be recovered automatically — manual recovery required.',
+                ];
+            }
+        }
+
         // Move the current live dir aside (if present).
-        if (is_dir($live) && !@rename($live, $asideName)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic same-filesystem swap; WP_Filesystem::move() is copy+delete (non-atomic) and breaks crash/watchdog-resume safety
-            return ['ok' => false, 'log' => 'Could not stage live directory aside.'];
+        if (is_dir($live)) {
+            if (!@rename($live, $asideName)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic same-filesystem swap; WP_Filesystem::move() is copy+delete (non-atomic) and breaks crash/watchdog-resume safety
+                return ['ok' => false, 'log' => 'Could not stage live directory aside.'];
+            }
+
+            // Fix 1 (issue #131 final-hardening review) — rename() PRESERVES
+            // the source's mtime; it does not reset it to "now". Without
+            // this, an aside carved from a plugin/theme directory whose
+            // CONTENTS happened to be untouched for longer than
+            // GC_BACKSTOP_TTL_SECONDS (72h) would be "born" already past the
+            // sweepStrandedAsides() age threshold, making it eligible for
+            // immediate GC sweep during the narrow window this very
+            // restore() call has it staged aside — i.e. while the copy-back
+            // below is in progress, or if it fails and the aside is the only
+            // remaining good copy. Stamping the mtime to the moment the
+            // aside was actually staged gives it the FULL 72h grace period,
+            // same as any other freshly created aside.
+            @touch($asideName); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_touch -- resets the aside's mtime to staging time so sweepStrandedAsides()'s age-based GC gets the full 72h grace; not a WP_Filesystem-eligible path (headless agent, no FTP context)
         }
 
         if (!$this->copyDir($payload, $live)) {
-            // Roll back the move so we don't leave the site without the dir.
-            if (is_dir($asideName) && !is_dir($live)) {
-                @rename($asideName, $live); // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic same-filesystem swap; WP_Filesystem::move() is copy+delete (non-atomic) and breaks crash/watchdog-resume safety
+            // S5 (issue #131 adversarial review) — copyDir() creates $live as
+            // its very first step (mkdir), so at this point $live almost
+            // always exists again as an empty or partially-populated
+            // directory even though the copy itself failed. The original
+            // `is_dir($asideName) && !is_dir($live)` guard therefore was
+            // false in the exact case it was meant to catch — a mid-copy
+            // failure — so the aside was never renamed back: the live dir
+            // was left half-written AND the good pre-restore original sat
+            // stranded forever at .wpmgr-old-<id>. Unconditionally clear
+            // whatever partial content is at $live (best effort) before
+            // restoring the set-aside original, rather than gating that
+            // restore on a check that copyDir()'s own behavior defeats.
+            if (is_dir($live)) {
+                $this->deleteDir($live);
             }
 
-            return ['ok' => false, 'log' => 'Restore copy failed; original retained.'];
+            if (is_dir($asideName)) {
+                $restored = @rename($asideName, $live); // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic same-filesystem rollback swap; WP_Filesystem::move() is copy+delete (non-atomic) and breaks crash/watchdog-resume safety
+
+                return [
+                    'ok'  => false,
+                    'log' => $restored
+                        ? 'Restore copy failed; rolled back to the pre-restore original.'
+                        : 'Restore copy failed; pre-restore original retained at ' . $asideName . ' but could not be renamed back — manual recovery required.',
+                ];
+            }
+
+            // Nothing was staged aside (the live directory did not exist
+            // before this restore attempt began) — there is no pre-existing
+            // original to roll back to.
+            return ['ok' => false, 'log' => 'Restore copy failed; no pre-existing directory to roll back to.'];
         }
 
         // Success: drop the set-aside copy.
@@ -157,6 +322,33 @@ class SnapshotManager
     }
 
     /**
+     * Whether a snapshot id still resolves to a real, on-disk snapshot
+     * directory.
+     *
+     * F2 (issue #131 final-hardening review) — used by
+     * UpdateInFlight::healStaleIfPresent() to verify a stale marker's
+     * referenced snapshot is still present BEFORE attempting a restore from
+     * it. The snapshot may already have been pruned (M1's per-slug cap or
+     * the gcExpired() backstop) or consumed by an earlier successful
+     * RollbackCommand call for the same marker; calling restore() on a
+     * vanished snapshot id would just fail with 'Invalid snapshot id.' after
+     * the fact — checking first lets the caller log a clear, specific reason
+     * and clear the marker without a doomed restore attempt.
+     *
+     * @param string $snapshotId Snapshot identifier.
+     * @return bool
+     */
+    public function snapshotExists(string $snapshotId): bool
+    {
+        $base = $this->snapshotBaseDir();
+        if ($base === '') {
+            return false;
+        }
+
+        return $this->resolveSnapshotDir($base, $snapshotId) !== '';
+    }
+
+    /**
      * Remove a snapshot directory and its contents.
      *
      * @param string $snapshotId Snapshot identifier.
@@ -174,6 +366,298 @@ class SnapshotManager
         }
 
         return $this->deleteDir($dir);
+    }
+
+    // ---------------------------------------------------------------------
+    // M1 (issue #131) — bounded snapshot GC
+    // ---------------------------------------------------------------------
+
+    /**
+     * Enforce the per-slug retention cap + capture-time TTL for $type/$slug,
+     * BEFORE a new snapshot for it is written. See MAX_SNAPSHOTS_PER_SLUG's
+     * class-level doc for the full reasoning and the CP health-probe-window
+     * safety argument; in short: this only ever touches snapshots that
+     * ALREADY exist for this exact type/slug pair, never the one this
+     * capture() call is about to create.
+     *
+     * @param string $base Absolute snapshot base directory.
+     * @param string $type plugin|theme|core.
+     * @param string $slug Sanitized slug.
+     * @return void
+     */
+    private function pruneForSlug(string $base, string $type, string $slug): void
+    {
+        $entries = $this->listSnapshotsForSlug($base, $type, $slug);
+        if ($entries === []) {
+            return;
+        }
+
+        // Newest first, so the rank check below keeps the MOST RECENT
+        // (MAX_SNAPSHOTS_PER_SLUG - 1) existing entries.
+        usort($entries, static function (array $a, array $b): int {
+            return $b['created_at'] <=> $a['created_at'];
+        });
+
+        $now = time();
+        foreach ($entries as $rank => $entry) {
+            $age = $now - $entry['created_at'];
+
+            // Belt (issue #131 final-hardening review) — the min-keep-age
+            // floor overrides everything below it: a snapshot younger than
+            // MIN_KEEP_AGE_SECONDS is NEVER pruned here, regardless of rank
+            // or the capture-time TTL. See MIN_KEEP_AGE_SECONDS's class-level
+            // doc for the concurrent-same-slug-capture race this guards.
+            if ($age < self::MIN_KEEP_AGE_SECONDS) {
+                continue;
+            }
+
+            // Reserve one slot for the snapshot capture() is about to create.
+            $withinCountCap = $rank < (self::MAX_SNAPSHOTS_PER_SLUG - 1);
+            $withinTtl      = $age < self::CAPTURE_PRUNE_TTL_SECONDS;
+            if ($withinCountCap && $withinTtl) {
+                // Kept: both recent enough by rank AND young enough by age.
+                continue;
+            }
+            $this->deleteDir($base . '/' . $entry['id']);
+        }
+    }
+
+    /**
+     * Scan the snapshot base for entries whose recorded meta matches
+     * $type/$slug. The base directory only ever holds a small, bounded
+     * number of entries per slug (this pruning is exactly what keeps it
+     * bounded), so a full scandir()+meta-read pass is cheap.
+     *
+     * @param string $base Absolute snapshot base directory.
+     * @param string $type plugin|theme|core.
+     * @param string $slug Sanitized slug.
+     * @return list<array{id:string,created_at:float}>
+     */
+    private function listSnapshotsForSlug(string $base, string $type, string $slug): array
+    {
+        $items = @scandir($base);
+        if (!is_array($items)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            if (preg_match('#^snap_[A-Za-z0-9_]+$#', $item) !== 1) {
+                continue;
+            }
+            $dir = $base . '/' . $item;
+            if (!is_dir($dir)) {
+                continue;
+            }
+            $meta = $this->readMeta($dir);
+            if ($meta === null) {
+                continue;
+            }
+            if (($meta['type'] ?? '') !== $type || ($meta['slug'] ?? '') !== $slug) {
+                continue;
+            }
+            $out[] = [
+                'id'         => $item,
+                'created_at' => isset($meta['created_at']) && is_numeric($meta['created_at']) ? (float) $meta['created_at'] : 0.0,
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Read a snapshot's meta.json as an associative array, or null when
+     * missing/unreadable.
+     *
+     * @param string $dir Absolute snapshot directory.
+     * @return array<string,mixed>|null
+     */
+    private function readMeta(string $dir): ?array
+    {
+        $metaFile = $dir . '/meta.json';
+        if (!is_file($metaFile)) {
+            return null;
+        }
+        $raw = @file_get_contents($metaFile);
+        if (!is_string($raw) || $raw === '') {
+            return null;
+        }
+        $meta = json_decode($raw, true);
+
+        return is_array($meta) ? $meta : null;
+    }
+
+    /**
+     * GC cron backstop — sweep the WHOLE snapshot store for any directory
+     * older than GC_BACKSTOP_TTL_SECONDS, independent of the per-slug prune
+     * in pruneForSlug() above. This is the safety net for what count-based
+     * pruning structurally cannot reach: a snapshot whose slug was later
+     * uninstalled or renamed (so it will never again be the target of a
+     * capture() call that would prune it), a core meta-only snapshot from a
+     * repeatedly-requested `snapshot=true` core update, or a crashed capture
+     * that left a directory behind with no readable meta.json at all.
+     * ALSO sweeps stranded `.wpmgr-old-<snap_id>` asides left behind in the
+     * live plugins/themes tree (F4, issue #131 final-hardening review) — see
+     * sweepStrandedAsides()'s doc. Bound to the `wpmgr_snapshot_gc` recurring
+     * cron event — see scheduleGc() — AND invoked opportunistically from the
+     * start of the `update` command (C, same review) since WP-Cron is
+     * unreliable on `DISABLE_WP_CRON`/dormant sites.
+     *
+     * `new static()`, not `new self()` — late static binding lets a test
+     * double subclass override strandedAsideRoots() and still exercise this
+     * exact production code path via `SubclassName::gcExpired()`, the same
+     * way `SnapshotManager::gcExpired()` behaves identically to a plain
+     * `new self()` for real callers.
+     *
+     * @return void
+     */
+    public static function gcExpired(): void
+    {
+        $mgr  = new static();
+        $base = $mgr->snapshotBaseDir();
+        if ($base !== '') {
+            $items = @scandir($base);
+            if (is_array($items)) {
+                $now = time();
+                foreach ($items as $item) {
+                    if ($item === '.' || $item === '..') {
+                        continue;
+                    }
+                    if (preg_match('#^snap_[A-Za-z0-9_]+$#', $item) !== 1) {
+                        continue;
+                    }
+                    $dir = $base . '/' . $item;
+                    if (!is_dir($dir)) {
+                        continue;
+                    }
+                    $age = $now - $mgr->snapshotAge($dir);
+                    if ($age < self::GC_BACKSTOP_TTL_SECONDS) {
+                        continue;
+                    }
+                    $mgr->deleteDir($dir);
+                }
+            }
+        }
+
+        $mgr->sweepStrandedAsides();
+    }
+
+    /**
+     * F4 (issue #131 final-hardening review) — sweep stranded
+     * `<slug>.wpmgr-old-<snap_id>` sibling directories left behind in the
+     * live plugins/themes tree by a restore() call whose FINAL
+     * rename-back-on-failure step itself failed (the "pre-restore original
+     * retained ... but could not be renamed back — manual recovery
+     * required" path in restore()'s doc — a disk-full/permissions edge
+     * case, not the common case). Left alone, a stranded aside is a full
+     * duplicate copy of a plugin/theme directory that wastes disk
+     * indefinitely and can surface in wp-admin's plugin/theme list as a
+     * bogus "ghost" entry on some configurations (WordPress enumerates
+     * every directory under the plugins root looking for a header). Swept
+     * on the SAME backstop TTL as the snapshot store itself, so both
+     * classes of #131 orphan are reclaimed on one cadence.
+     *
+     * @return void
+     */
+    private function sweepStrandedAsides(): void
+    {
+        $now = time();
+        foreach ($this->strandedAsideRoots() as $root) {
+            if ($root === '' || !is_dir($root)) {
+                continue;
+            }
+            $items = @scandir($root);
+            if (!is_array($items)) {
+                continue;
+            }
+            foreach ($items as $item) {
+                if ($item === '.' || $item === '..') {
+                    continue;
+                }
+                if (preg_match('#\.wpmgr-old-snap_[A-Za-z0-9_]+$#', $item) !== 1) {
+                    continue;
+                }
+                $path = $root . '/' . $item;
+                if (!is_dir($path) || is_link($path)) {
+                    continue;
+                }
+                $mtime = @filemtime($path);
+                $age   = $mtime !== false ? ($now - $mtime) : PHP_INT_MAX;
+                if ($age < self::GC_BACKSTOP_TTL_SECONDS) {
+                    continue;
+                }
+                $this->deleteDir($path);
+            }
+        }
+    }
+
+    /**
+     * Absolute roots that could hold a stranded `.wpmgr-old-<id>` aside:
+     * WP_PLUGIN_DIR (every plugin slug resolves to exactly one folder level
+     * under it — see liveDir()) and the active theme root. Both are the
+     * exact parents liveDir() resolves a plugin/theme's live directory
+     * under, i.e. exactly where restore() would have left an aside sibling.
+     * Protected (not private) so a test double can override it with a
+     * fully controlled path — mirrors liveDir()'s own testability seam —
+     * without depending on the real, process-global WP_PLUGIN_DIR/
+     * WP_CONTENT_DIR constants.
+     *
+     * @return list<string>
+     */
+    protected function strandedAsideRoots(): array
+    {
+        $roots = [];
+        if (defined('WP_PLUGIN_DIR')) {
+            $roots[] = rtrim((string) WP_PLUGIN_DIR, '/\\');
+        }
+        $contentDir = defined('WP_CONTENT_DIR') ? rtrim((string) WP_CONTENT_DIR, '/\\') : '';
+        if ($contentDir !== '') {
+            $roots[] = $this->themeRoot($contentDir);
+        }
+
+        return $roots;
+    }
+
+    /**
+     * Age reference for a snapshot directory: its recorded meta.json
+     * `created_at` when readable, else the directory's own filesystem mtime
+     * (covers a crashed capture that never got as far as writeMeta()).
+     *
+     * @param string $dir Absolute snapshot directory.
+     * @return int Unix timestamp.
+     */
+    private function snapshotAge(string $dir): int
+    {
+        $meta = $this->readMeta($dir);
+        if ($meta !== null && isset($meta['created_at']) && is_numeric($meta['created_at'])) {
+            return (int) $meta['created_at'];
+        }
+
+        $mtime = @filemtime($dir);
+
+        return $mtime !== false ? (int) $mtime : time();
+    }
+
+    /**
+     * Schedule the recurring GC backstop (gcExpired()). Safe to call on
+     * every activation / reschedule pass — a no-op when already scheduled.
+     * Mirrors EmailLogger::schedule_prune()'s idempotent-schedule shape.
+     *
+     * @param int $now Current time.
+     * @return void
+     */
+    public static function scheduleGc(int $now): void
+    {
+        if (!function_exists('wp_next_scheduled') || !function_exists('wp_schedule_event')) {
+            return;
+        }
+        if (wp_next_scheduled(self::HOOK_GC) !== false) {
+            return;
+        }
+        wp_schedule_event($now + 3600, 'daily', self::HOOK_GC);
     }
 
     // ---------------------------------------------------------------------
@@ -382,7 +866,17 @@ class SnapshotManager
             'type'         => $type,
             'slug'         => $slug,
             'from_version' => $fromVersion,
-            'created_at'   => time(),
+            // M1 (issue #131 adversarial review) — microtime(true), not
+            // time(): pruneForSlug() orders same-slug snapshots by this
+            // field to decide which to keep, and two captures for the same
+            // slug landing within the same wall-clock SECOND (plausible
+            // under rapid successive updates, or simply a fast disk) would
+            // otherwise tie under time()'s 1-second resolution, making the
+            // "keep the most recent" ordering fall back to arbitrary
+            // scandir() order — exactly the kind of ambiguity that could
+            // prune the wrong snapshot. Microsecond resolution makes a tie
+            // between two real capture() calls practically impossible.
+            'created_at'   => microtime(true),
         ];
         @file_put_contents($dir . '/meta.json', (string) json_encode($meta));
     }

--- a/apps/agent/includes/support/class-update-guard.php
+++ b/apps/agent/includes/support/class-update-guard.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * UpdateGuard: per-item shutdown-time backstop that restores a plugin/theme
+ * directory from its pre-update snapshot when an agent-driven update apply is
+ * interrupted by a hard resource kill.
+ *
+ * Background (GitHub issue #131): UpdateCommand applies plugin/theme updates
+ * via WordPress core's Plugin_Upgrader / Theme_Upgrader INLINE in the REST
+ * request — no WP-CLI subprocess, no cron handoff. Their underlying
+ * install_package() -> copy_dir() is a NON-atomic recursive copy that clears
+ * the destination directory FIRST, then copies the new files in. When
+ * something kills the PHP process mid-copy — max_execution_time or a
+ * PHP-FPM request_terminate_timeout are the most likely causes — the old
+ * directory is already gone and a half-written tree is left behind (e.g. a
+ * new vendor/vendor-prefixed/autoload.php present but composer/autoload_real.php
+ * missing), which fatal-errors the site the next time WordPress loads it.
+ *
+ * A hard resource kill of this kind does not throw a catchable \Throwable and
+ * does not unwind any try/catch/finally — it tears the whole request down.
+ * The ONLY code that still runs afterwards is a PHP shutdown function. This
+ * class is that shutdown callback, structured as a small stateful object
+ * (rather than a bare closure) so:
+ *   - UpdateCommand can synchronously call fire() itself from its own
+ *     try/catch when it detects a failure by normal means (an ok:false
+ *     return, a thrown exception, or a failed completeness check) — the
+ *     restore happens immediately instead of waiting on the request to tear
+ *     down, and fire() is idempotent so a later real shutdown invocation is
+ *     always safe to also occur.
+ *   - A test can construct one directly and call fire()/markClean() without
+ *     needing to trigger an actual PHP process shutdown.
+ *
+ * Mirrors WPMgr\Agent\Support\Maintenance::armShutdownGuard's "arm once, heal
+ * unconditionally unless told otherwise" shape, but restores a directory
+ * instead of clearing a drop-file, and uses an explicit markClean() rather
+ * than an age-based staleness heuristic — an update apply either was, or was
+ * not, verified good by the time processItem() finishes, so there is nothing
+ * to infer from elapsed time.
+ *
+ * @package WPMgr\Agent\Support
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Support;
+
+if (!defined('ABSPATH')) {
+    exit; // No direct access.
+}
+
+/**
+ * Restores a single plugin/theme directory from its pre-update snapshot
+ * unless the apply that owns this guard was confirmed good.
+ */
+final class UpdateGuard
+{
+    private SnapshotManager $snapshots;
+
+    private string $type;
+
+    private string $slug;
+
+    private string $snapshotId;
+
+    /**
+     * Set once the apply this guard covers has been verified good. While
+     * true, fire() is permanently a no-op — a completed, healthy update must
+     * never be rolled back retroactively by a later, unrelated shutdown.
+     */
+    private bool $clean = false;
+
+    /**
+     * Set the first time fire() actually performs (or attempts) a restore.
+     * Makes fire() idempotent: a synchronous call from UpdateCommand's own
+     * failure handling and a subsequent real-shutdown invocation of the same
+     * guard must never restore twice.
+     */
+    private bool $fired = false;
+
+    /**
+     * @param SnapshotManager $snapshots  Snapshot store used to perform the restore.
+     * @param string          $type       'plugin'|'theme' (never 'core' — see class doc / D3 in issue #131).
+     * @param string          $slug       Sanitized slug (already validated by UpdateCommand).
+     * @param string          $snapshotId Snapshot identifier captured before the apply.
+     */
+    public function __construct(SnapshotManager $snapshots, string $type, string $slug, string $snapshotId)
+    {
+        $this->snapshots  = $snapshots;
+        $this->type       = $type;
+        $this->slug       = $slug;
+        $this->snapshotId = $snapshotId;
+    }
+
+    /**
+     * Register this guard's fire() as a PHP shutdown callback. Safe to call
+     * more than once — PHP tolerates duplicate shutdown callbacks and a
+     * redundant fire() is a cheap, idempotent no-op.
+     *
+     * @return void
+     */
+    public function arm(): void
+    {
+        register_shutdown_function([$this, 'fire']);
+    }
+
+    /**
+     * Mark the apply this guard covers as verified-good. MUST be called
+     * before returning a 'succeeded' (or 'up_to_date') result — an armed
+     * guard that never learns the apply was good would otherwise undo it if
+     * the request is torn down by something unrelated later in the same
+     * shutdown chain.
+     *
+     * F2 (issue #131 final-hardening review) — ALSO clears this item's
+     * UpdateInFlight out-of-band reconcile marker immediately, rather than
+     * leaving that to UpdateCommand::processItem()'s `finally` alone. A
+     * marker written before apply() previously stayed on disk all the way
+     * to that `finally` even for a SUCCESSFUL apply; a hard kill landing in
+     * that narrow window (e.g. the exact PHP-FPM `request_terminate_timeout`
+     * case UpdateInFlight exists to cover) left a marker pointing at a now
+     * genuinely stale pre-update snapshot for an update that had already
+     * finished cleanly — a stale-but-healthy marker healStaleIfPresent()'s
+     * own F2 verify-before-restore fix already tolerates safely, but closing
+     * the window at the source here means it's never even created for the
+     * common case.
+     *
+     * @return void
+     */
+    public function markClean(): void
+    {
+        $this->clean = true;
+        UpdateInFlight::clear($this->type, $this->slug);
+    }
+
+    /**
+     * Restore the snapshot unless the apply was already confirmed clean, or
+     * this guard has already fired once. Safe to call from a real PHP
+     * shutdown handler (return value is simply unused there) or
+     * synchronously from UpdateCommand's own failure handling.
+     *
+     * Never lets a \Throwable escape: a shutdown-function context has
+     * nowhere useful to propagate one to, and a synchronous caller is
+     * already inside its own failure path.
+     *
+     * @return array{fired:bool,ok:bool,log:string} fired=false means this
+     *     call was a no-op (already clean or already fired); ok/log only
+     *     mean something when fired=true.
+     */
+    public function fire(): array
+    {
+        if ($this->clean || $this->fired) {
+            return ['fired' => false, 'ok' => true, 'log' => ''];
+        }
+        $this->fired = true;
+
+        try {
+            $result = $this->snapshots->restore($this->type, $this->slug, $this->snapshotId);
+        } catch (\Throwable $e) {
+            DebugLog::write(
+                'WPMgr Agent: update auto-restore threw for ' . $this->type . ':' . $this->slug
+                . ': ' . $e->getMessage()
+            );
+
+            return ['fired' => true, 'ok' => false, 'log' => 'Auto-restore error.'];
+        }
+
+        return ['fired' => true, 'ok' => (bool) $result['ok'], 'log' => (string) $result['log']];
+    }
+}

--- a/apps/agent/includes/support/class-update-inflight.php
+++ b/apps/agent/includes/support/class-update-inflight.php
@@ -1,0 +1,569 @@
+<?php
+/**
+ * UpdateInFlight: out-of-band reconcile for the ONE update-guard failure mode
+ * register_shutdown_function() cannot catch — a PHP-FPM
+ * `request_terminate_timeout` SIGTERM (GitHub issue #131 adversarial review, S4).
+ *
+ * @package WPMgr\Agent\Support
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Support;
+
+if (!defined('ABSPATH')) {
+    exit; // No direct access.
+}
+
+/*
+ * Background: UpdateGuard's shutdown-time restore only works because PHP runs
+ * registered shutdown functions when a request ends — including on a fatal
+ * error such as hitting `max_execution_time`. It does NOT run them when
+ * PHP-FPM's own `request_terminate_timeout` fires: FPM resets the process's
+ * timeout handler to SIG_DFL and SIGTERMs the worker immediately, tearing the
+ * whole PHP process down without unwinding anything — no try/catch/finally,
+ * no shutdown functions, nothing. If that kill lands mid-copy during a
+ * plugin/theme apply, the site is left with a half-written directory AND no
+ * in-process code ever runs again to fix it.
+ *
+ * This class is the out-of-band recovery path for exactly that case, mirroring
+ * WPMgr\Agent\Support\Maintenance's "persist a marker before risky work, heal
+ * a STALE one before starting new work" shape:
+ *   - mark() persists a small JSON marker {type, slug, snapshot_id, ts} to a
+ *     RANDOMLY named file (F5, final-hardening review — see keyFor()'s doc)
+ *     BEFORE UpdateCommand calls UpdateRunner::apply() — i.e. before the
+ *     window a hard kill could land in — and returns an exclusive, held
+ *     filesystem lock (B, same review) the caller must keep open for the
+ *     apply's duration.
+ *   - clear() removes it once the item's fate is resolved SYNCHRONOUSLY
+ *     within the same request (success, a synchronous incomplete-restore, or
+ *     a caught throw) — called from UpdateCommand::processItem()'s existing
+ *     `finally`, so it runs on every path that finishes normally. ALSO called
+ *     immediately from UpdateGuard::markClean() (F2, same review) the instant
+ *     an apply is confirmed good, closing the narrow window between that
+ *     confirmation and the `finally`.
+ *   - healStaleIfPresent() is the reconcile: called both at the START of the
+ *     next `update` command (mirrors Maintenance::healStaleIfPresent()) and
+ *     from a recurring cron sweep (HOOK_GC, mirrors the `wpmgr_restore_oldfiles_gc`
+ *     pattern), so recovery does not depend on the control plane ever sending
+ *     another `update` request for the SAME site. Two layers gate an actual
+ *     restore (F2 + B, final-hardening review):
+ *       1. B — the marker's paired lock file must be acquirable right now
+ *          (non-blocking). If it is still held, the apply that owns this
+ *          marker is GENUINELY still running (set_time_limit() bounds CPU
+ *          time, not wall time, so a slow I/O-bound apply can legitimately
+ *          outlive the age heuristic below) — skip it entirely.
+ *       2. F2 — once the lock is free, verify the live directory is not
+ *          ALREADY complete/healthy (a marker can survive a SUCCESSFUL apply
+ *          if the kill landed in the old markClean()-to-`finally` window;
+ *          that window is now closed at the source, but this stays as
+ *          defense in depth) and that the referenced snapshot still exists,
+ *          before ever calling restore(). Only a genuinely incomplete live
+ *          directory with a still-present snapshot triggers a restore.
+ *     A marker only ever survives to be found here when the request that
+ *     wrote it never reached its own `finally` — i.e. it really was torn
+ *     down mid-flight.
+ *
+ * Staleness threshold reasoning lives on STALE_AFTER_SECONDS below, not here.
+ *
+ * Multi-node assumption (doc-only, issue #131 final-review follow-up) — the
+ * flock() liveness signal this class's B fix relies on (see acquireLock()'s
+ * doc) is a SINGLE-NODE primitive: it is coherent only for processes sharing
+ * the same kernel file-lock table. On a multi-node WordPress install where
+ * `wp-content/uploads` (and therefore this class's marker/lock store, see
+ * PURPOSE below) is mounted over shared network storage (NFS/EFS/etc.),
+ * flock() is enforced PER NODE, not across the fleet — a lock a process on
+ * node A holds is invisible to a process on node B attempting
+ * acquireLock() for the same type/slug, so the "is the owning process still
+ * alive" check can spuriously report "free" for a marker whose owning apply
+ * is still genuinely running on a different node. This is a KNOWN,
+ * ACCEPTED limitation, not an oversight:
+ *   - The STALE_AFTER_SECONDS age gate (1200s) is the fallback in that
+ *     scenario — healStaleIfPresent() never even attempts the lock probe
+ *     for a marker younger than that threshold, so a cross-node false
+ *     "free" reading can only ever matter for a marker that has ALSO
+ *     already sat for 20 minutes, which is itself far longer than any
+ *     normal apply takes on any single node.
+ *   - The scenario this whole class exists for — a CONCURRENT apply of the
+ *     SAME plugin/theme racing against a reconcile that wrongly believes
+ *     the owning process is dead — is independently prevented upstream, at
+ *     the control plane, via cross-run dedup for a given site (so the CP
+ *     itself never fans the same update out to multiple concurrent runs in
+ *     the first place); this class's flock() check is defense-in-depth for
+ *     the single-node case, not the sole guard against that race.
+ *   - Net effect on shared-storage multi-node installs: reconcile degrades
+ *     gracefully to the age-only heuristic this class used BEFORE the B fix
+ *     — still correct, just without the tighter single-node liveness
+ *     precision flock() adds on top of it.
+ */
+
+/**
+ * Persists and reconciles a marker for an in-progress plugin/theme apply so a
+ * hard-killed request that UpdateGuard's shutdown hook could never see is
+ * still recovered — just later, out of band, rather than instantly in-process.
+ */
+final class UpdateInFlight
+{
+    /** Recurring cron hook name for the reconcile sweep. */
+    public const HOOK_GC = 'wpmgr_update_inflight_gc';
+
+    /** StoragePaths purpose slug — resolves to uploads/wpmgr-update-inflight/. */
+    private const PURPOSE = 'update-inflight';
+
+    /**
+     * A marker older than this is treated as orphaned (the request that
+     * wrote it was torn down without reaching its own cleanup) rather than
+     * possibly belonging to a still-running apply. UpdateCommand::execute()
+     * bounds an apply to a 900s (15 min) `set_time_limit()` specifically so
+     * a hung apply still hits PHP's own recoverable fatal well before this
+     * threshold; 1200s (20 min) leaves 5 minutes of margin beyond that bound
+     * for the in-process shutdown-guard path to have already fired and
+     * cleared the marker, so a legitimately (if unusually slowly) still-
+     * running apply is never reconciled out from under itself. In absolute
+     * terms this is still a short window: a truly hard-killed site self-heals
+     * on its own within about 20 minutes without requiring an operator or a
+     * new control-plane request to notice.
+     *
+     * B (issue #131 final-hardening review) — this is now only a SECONDARY
+     * backstop: set_time_limit() bounds CPU time, not wall time, so a slow
+     * I/O-bound apply CAN legitimately exceed this age while still running.
+     * The flock-based liveness check in healStaleIfPresent() is the PRIMARY
+     * signal (see acquireLock()'s doc); this age check is kept as a cheap
+     * first filter so the (slightly more expensive) lock probe only runs
+     * against markers that are already old enough to be suspicious.
+     */
+    private const STALE_AFTER_SECONDS = 1200;
+
+    /**
+     * Persist an in-flight marker for a plugin/theme apply that is about to
+     * start, and acquire the paired liveness lock for it. Must be called
+     * AFTER a snapshot has been successfully captured (there is nothing to
+     * reconcile TO otherwise) and BEFORE UpdateRunner::apply() is invoked.
+     * Best-effort: a failure to write the marker (or acquire the lock) must
+     * never block the apply itself — the shutdown-guard in-process path
+     * (UpdateGuard) still covers the recoverable-kill case regardless.
+     *
+     * B (issue #131 final-hardening review) — the CALLER MUST keep the
+     * returned lock handle open for the entire duration of the apply this
+     * marker covers, and release it (via release()) in the SAME `finally`
+     * that already calls clear() once the item's fate is resolved. The OS
+     * releases the lock automatically the instant this PHP process exits for
+     * ANY reason, including a SIGKILL/SIGTERM that skips every PHP-level
+     * cleanup — that is precisely what makes "can healStaleIfPresent()
+     * re-acquire this lock" an accurate, real-time liveness signal for
+     * "is the process that wrote this marker still alive right now",
+     * independent of how long the apply has actually been running.
+     *
+     * @param string $type       'plugin'|'theme'.
+     * @param string $slug       Sanitized slug.
+     * @param string $snapshotId Snapshot identifier captured before the apply.
+     * @return resource|null An open, held lock handle the caller must pass to
+     *     release(), or null when the marker/lock could not be set up.
+     */
+    public static function mark(string $type, string $slug, string $snapshotId)
+    {
+        $dir = StoragePaths::ensureHardened(self::PURPOSE);
+        if ($dir === '') {
+            return null;
+        }
+
+        // F5 (issue #131 final-hardening review) — remove any marker(s)
+        // already on disk for this exact type/slug before writing a fresh
+        // one. This preserves the old deterministic-path implementation's
+        // implicit "one marker per slug, latest wins" retry semantics now
+        // that the filename itself is randomized (see keyFor()'s doc) rather
+        // than derived from type/slug, so there is no longer a single fixed
+        // path a repeat mark() call would simply overwrite in place.
+        self::forgetMarkersFor($dir, $type, $slug);
+
+        $file = $dir . '/' . bin2hex(random_bytes(16)) . '.json';
+
+        $payload = [
+            'type'        => $type,
+            'slug'        => $slug,
+            'snapshot_id' => $snapshotId,
+            'ts'          => time(),
+        ];
+
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- headless agent; WP_Filesystem never initialized; direct write of a small, server-derived JSON marker
+        @file_put_contents($file, (string) wp_json_encode($payload), LOCK_EX);
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod -- explicit security perms (0600); WP_Filesystem would coerce to wider FS_CHMOD_FILE
+        @chmod($file, 0600);
+
+        return self::acquireLock($type, $slug);
+    }
+
+    /**
+     * Clear this item's in-flight marker(s). Safe to call unconditionally —
+     * including when mark() was never called for this type/slug (e.g. a
+     * snapshot was never captured) — since it is a no-op when no marker
+     * matches. Intended to be called from a `finally` block wrapping the
+     * same apply lifecycle mark() is called around (every SYNCHRONOUS
+     * outcome — success, a synchronous incomplete-restore, or a caught throw
+     * — removes the marker), AND from UpdateGuard::markClean() the instant
+     * an apply is confirmed good (F2, issue #131 final-hardening review) —
+     * see that method's doc for the success-window it closes. A marker
+     * survives past both of those call sites ONLY when the request never
+     * reached either one at all.
+     *
+     * @param string $type 'plugin'|'theme'.
+     * @param string $slug Sanitized slug.
+     * @return void
+     */
+    public static function clear(string $type, string $slug): void
+    {
+        $dir = StoragePaths::dataBase(self::PURPOSE);
+        if ($dir === '' || !is_dir($dir)) {
+            return;
+        }
+        self::forgetMarkersFor($dir, $type, $slug);
+    }
+
+    /**
+     * Release a lock handle returned by mark()/acquireLock(). Safe to call
+     * with null (a no-op) so callers that never successfully acquired one
+     * need no extra branching. Intended to be called from the SAME `finally`
+     * that calls clear().
+     *
+     * @param resource|null $handle Handle returned by mark(), or null.
+     * @return void
+     */
+    public static function release($handle): void
+    {
+        if ($handle === null || !is_resource($handle)) {
+            return;
+        }
+        flock($handle, LOCK_UN);
+        fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- releasing our own advisory lock handle on a small internal coordination file; WP_Filesystem has no flock()-equivalent API and is never initialized in this headless agent context
+    }
+
+    /**
+     * Reconcile any STALE in-flight marker: restore its recorded snapshot
+     * and remove the marker — but ONLY once verified (F2 + B, issue #131
+     * final-hardening review; see this class's doc for the two-layer gate).
+     * A marker younger than STALE_AFTER_SECONDS is skipped outright (cheap
+     * first filter); a marker whose liveness lock cannot be acquired is
+     * skipped (its owning apply is still genuinely running); a marker over a
+     * live directory that is ALREADY complete/healthy is cleared WITHOUT a
+     * restore; a marker whose referenced snapshot no longer exists is
+     * cleared WITHOUT attempting a doomed restore. Safe to call from both the
+     * start of a fresh `update` command (the "next agent request" path) and
+     * a recurring cron sweep (the "cron sweep" path, gcSweep() below) — both
+     * share this exact method so a test can exercise it directly with
+     * injected SnapshotManager/UpdateRunner doubles.
+     *
+     * @param SnapshotManager $snapshots Snapshot store used to perform the restore.
+     * @param UpdateRunner|null $runner  Used for the F2 live-directory health
+     *                                   check; defaults to a real instance.
+     * @return void
+     */
+    public static function healStaleIfPresent(SnapshotManager $snapshots, ?UpdateRunner $runner = null): void
+    {
+        $dir = StoragePaths::dataBase(self::PURPOSE);
+        if ($dir === '' || !is_dir($dir)) {
+            return;
+        }
+
+        $runner = $runner ?? new UpdateRunner();
+        $now    = time();
+
+        foreach (self::markerFiles($dir) as $file) {
+            $marker = self::readMarker($file);
+            if ($marker === null) {
+                // Unreadable/corrupt marker — cannot reconcile it to
+                // anything meaningful; remove it rather than leave a dead
+                // file behind forever.
+                wp_delete_file($file);
+                continue;
+            }
+
+            $ts = isset($marker['ts']) && is_numeric($marker['ts']) ? (int) $marker['ts'] : 0;
+            if ($ts === 0 || ($now - $ts) < self::STALE_AFTER_SECONDS) {
+                // Fresh (or unreadable timestamp, treated as fresh to be
+                // safe) — may still belong to a legitimately in-flight apply.
+                continue;
+            }
+
+            $type       = isset($marker['type']) && is_string($marker['type']) ? $marker['type'] : '';
+            $slug       = isset($marker['slug']) && is_string($marker['slug']) ? $marker['slug'] : '';
+            $snapshotId = isset($marker['snapshot_id']) && is_string($marker['snapshot_id']) ? $marker['snapshot_id'] : '';
+
+            if ($type === '' || $slug === '' || $snapshotId === '') {
+                wp_delete_file($file);
+                continue;
+            }
+
+            // B (issue #131 final-hardening review) — flock is the PRIMARY
+            // liveness signal; the age check above is only a cheap secondary
+            // filter. If this marker's lock cannot be acquired right now,
+            // its owning process is genuinely still alive — skip this marker
+            // entirely, without touching the marker file OR the snapshot,
+            // rather than reconcile a live apply out from under itself.
+            $lock = self::acquireLock($type, $slug);
+            if ($lock === null) {
+                continue;
+            }
+
+            try {
+                // F2 (issue #131 final-hardening review) — verify before
+                // restoring. Blindly restoring on every stale marker (the
+                // original behavior) could revert a perfectly good,
+                // already-finished update: a marker can legitimately survive
+                // to here if a kill landed in the narrow window between
+                // UpdateGuard::markClean() and UpdateCommand's own `finally`
+                // (now closed at the source — see markClean()'s own fix —
+                // this stays as defense in depth for any other path that
+                // could leave a marker behind a healthy live directory).
+                $healthy = false;
+                try {
+                    $healthy = $runner->isComplete($type, $slug);
+                } catch (\Throwable $verifyError) {
+                    // Inconclusive: unlike UpdateCommand's OWN synchronous S7
+                    // case (where $applied['ok'] is already known true), here
+                    // NOTHING is known about whether the apply that owned
+                    // this marker ever finished — fall through to a restore,
+                    // the same conservative default this method used before
+                    // F2 existed.
+                    DebugLog::write(
+                        'WPMgr Agent: stale-marker health verification threw for '
+                        . $type . ':' . $slug . ': ' . $verifyError->getMessage()
+                        . '; treating as unverified and proceeding to restore.'
+                    );
+                }
+
+                if ($healthy) {
+                    DebugLog::write(
+                        'WPMgr Agent: stale update-in-flight marker for ' . $type . ':' . $slug
+                        . ' (age ' . ($now - $ts) . 's) found the live directory already complete/healthy — '
+                        . 'the apply finished before the kill landed; clearing the marker without restoring.'
+                    );
+                    wp_delete_file($file);
+                    continue;
+                }
+
+                if (!$snapshots->snapshotExists($snapshotId)) {
+                    DebugLog::write(
+                        'WPMgr Agent: stale update-in-flight marker for ' . $type . ':' . $slug
+                        . ' references snapshot ' . $snapshotId . ' which no longer exists (already pruned or '
+                        . 'consumed) — clearing the marker without attempting a partial restore.'
+                    );
+                    wp_delete_file($file);
+                    continue;
+                }
+
+                DebugLog::write(
+                    'WPMgr Agent: reconciling stale update-in-flight marker for ' . $type . ':' . $slug
+                    . ' (age ' . ($now - $ts) . 's) — the apply that wrote it never reached its own cleanup, '
+                    . 'live directory verified incomplete; auto-restoring pre-update snapshot ' . $snapshotId . '.'
+                );
+                try {
+                    $snapshots->restore($type, $slug, $snapshotId);
+                } catch (\Throwable $e) {
+                    DebugLog::write(
+                        'WPMgr Agent: stale-marker auto-restore threw for ' . $type . ':' . $slug
+                        . ': ' . $e->getMessage()
+                    );
+                }
+
+                wp_delete_file($file);
+            } finally {
+                self::release($lock);
+            }
+        }
+    }
+
+    /**
+     * Cron-hook entry point (arg-less, unlike healStaleIfPresent() which
+     * takes injectable dependencies for testability). Bound to HOOK_GC.
+     *
+     * @return void
+     */
+    public static function gcSweep(): void
+    {
+        self::healStaleIfPresent(new SnapshotManager());
+    }
+
+    /**
+     * Schedule the recurring reconcile sweep (gcSweep()). Safe to call on
+     * every activation / reschedule pass — a no-op when already scheduled.
+     * Mirrors EmailLogger::schedule_prune()'s idempotent-schedule shape.
+     *
+     * @param int $now Current time.
+     * @return void
+     */
+    public static function scheduleGc(int $now): void
+    {
+        if (!function_exists('wp_next_scheduled') || !function_exists('wp_schedule_event')) {
+            return;
+        }
+        if (wp_next_scheduled(self::HOOK_GC) !== false) {
+            return;
+        }
+        wp_schedule_event($now + 300, 'hourly', self::HOOK_GC);
+    }
+
+    // ---------------------------------------------------------------------
+    // B (issue #131 final-hardening review) — flock-based liveness lock
+    // ---------------------------------------------------------------------
+
+    /**
+     * Acquire, non-blocking, the exclusive lock that marks a type/slug's
+     * apply as genuinely "in progress" right now. See mark()'s and this
+     * class's doc for the full rationale (flock is immune to the
+     * set_time_limit()-bounds-CPU-not-wall-time gap an age heuristic alone
+     * cannot close).
+     *
+     * Single-node assumption — this flock() is only lock-coherent for
+     * processes on the SAME node sharing the same kernel file-lock table. On
+     * a multi-node install with `wp-content/uploads` on shared NFS/EFS
+     * storage, a lock held by a process on one node is invisible to
+     * acquireLock() called from another node. This is intentional, accepted
+     * best-effort — see this class's top-of-file doc ("Multi-node
+     * assumption") for the full reasoning and the STALE_AFTER_SECONDS
+     * age-gate fallback that keeps reconcile safe (if less precise) in that
+     * topology.
+     *
+     * The lock filename is DELIBERATELY still derived deterministically from
+     * type/slug (keyFor()) — unlike the JSON marker filename (F5) — because
+     * it carries no sensitive payload at all (an empty coordination file),
+     * and healStaleIfPresent() needs to compute the SAME path mark() used
+     * from only the type/slug it just decoded out of a marker's (randomly
+     * named) JSON content, without that content needing to also carry a lock
+     * file path.
+     *
+     * @param string $type 'plugin'|'theme'.
+     * @param string $slug Sanitized slug.
+     * @return resource|null An open, LOCKED file handle the caller must
+     *     release via release(), or null when the lock could not be acquired
+     *     (already held elsewhere) or the lock file itself could not be
+     *     opened (best-effort — never blocks the caller's own work).
+     */
+    private static function acquireLock(string $type, string $slug)
+    {
+        $dir = StoragePaths::ensureHardened(self::PURPOSE);
+        if ($dir === '') {
+            return null;
+        }
+        $file = $dir . '/' . self::keyFor($type, $slug) . '.lock';
+
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- headless agent; WP_Filesystem has no flock()-equivalent API and is never initialized in this context; a small, server-derived, empty coordination file
+        $handle = @fopen($file, 'c');
+        if ($handle === false) {
+            return null;
+        }
+        @chmod($file, 0600); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod -- explicit security perms on our own coordination file; WP_Filesystem would coerce to wider FS_CHMOD_FILE
+
+        if (!flock($handle, LOCK_EX | LOCK_NB)) {
+            fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- releasing our own failed-lock-attempt handle, not a WP_Filesystem-managed resource
+            return null;
+        }
+
+        return $handle;
+    }
+
+    // ---------------------------------------------------------------------
+    // Marker storage
+    // ---------------------------------------------------------------------
+
+    /**
+     * Remove any marker file(s) matching this exact type/slug. Shared by
+     * mark() (purging a stale duplicate before writing a fresh one — the
+     * retry-overwrite semantics the old deterministic filename gave for
+     * free) and clear() (removing this item's marker once its fate is
+     * resolved).
+     *
+     * @param string $dir  Marker store directory.
+     * @param string $type 'plugin'|'theme'.
+     * @param string $slug Sanitized slug.
+     * @return void
+     */
+    private static function forgetMarkersFor(string $dir, string $type, string $slug): void
+    {
+        foreach (self::markerFiles($dir) as $file) {
+            $marker = self::readMarker($file);
+            if ($marker === null) {
+                // Leave a corrupt file for healStaleIfPresent() to clean up
+                // — it cannot be matched to this type/slug at all.
+                continue;
+            }
+            if (($marker['type'] ?? '') === $type && ($marker['slug'] ?? '') === $slug) {
+                wp_delete_file($file);
+            }
+        }
+    }
+
+    /**
+     * List every marker (`*.json`) file currently in the store directory.
+     *
+     * @param string $dir Marker store directory.
+     * @return list<string> Absolute file paths.
+     */
+    private static function markerFiles(string $dir): array
+    {
+        $items = @scandir($dir);
+        if (!is_array($items)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($items as $item) {
+            if (str_ends_with($item, '.json')) {
+                $out[] = $dir . '/' . $item;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Read and decode a single marker file.
+     *
+     * @param string $file Absolute marker file path.
+     * @return array<string,mixed>|null Decoded marker, or null when
+     *     unreadable/not a file/invalid JSON.
+     */
+    private static function readMarker(string $file): ?array
+    {
+        if (!is_file($file)) {
+            return null;
+        }
+        $raw = @file_get_contents($file);
+        if (!is_string($raw) || $raw === '') {
+            return null;
+        }
+        $marker = json_decode($raw, true);
+
+        return is_array($marker) ? $marker : null;
+    }
+
+    /**
+     * Derive a filesystem-safe, collision-resistant key for a type/slug pair,
+     * used ONLY for the lock file (never for the JSON marker — see F5 below).
+     *
+     * F5 (issue #131 final-hardening review) — the JSON marker filename is
+     * DELIBERATELY NOT derived from this key (or from type/slug at all)
+     * anymore. A deterministic sha256(type:slug) hash has no secret salt, so
+     * it is trivially recomputable by anyone who already knows a plugin or
+     * theme's PUBLIC slug; if this store directory were ever reachable over
+     * HTTP despite its .htaccess/index.php hardening (e.g. an nginx config
+     * that does not honor .htaccess at all), that meant an attacker could
+     * locate and read a marker's JSON body during the in-flight window and
+     * recover its `snapshot_id` — effectively a capability token for the
+     * pre-update snapshot payload's own storage path, a source-disclosure
+     * risk for a premium plugin/theme. mark() now writes the JSON marker to
+     * a RANDOM filename instead (see mark()'s own comment); healStaleIfPresent()
+     * already scans the whole directory rather than looking up a computed
+     * path, so nothing there needed to change to support this.
+     *
+     * The lock file is unaffected by this concern (it carries no payload at
+     * all — see acquireLock()'s doc for why it stays deterministic).
+     *
+     * @param string $type 'plugin'|'theme'.
+     * @param string $slug Sanitized slug.
+     * @return string 32 hex characters.
+     */
+    private static function keyFor(string $type, string $slug): string
+    {
+        return substr(hash('sha256', $type . ':' . $slug), 0, 32);
+    }
+}

--- a/apps/agent/includes/support/class-update-runner.php
+++ b/apps/agent/includes/support/class-update-runner.php
@@ -103,9 +103,12 @@ class UpdateRunner
                 if (isset($all[$slug])) {
                     return true;
                 }
-                // Allow a folder-only slug to match its "folder/..." basename.
+                // Allow a folder-only slug — or a full "folder/main-file.php"
+                // basename whose main file was since renamed (S6, issue
+                // #131) — to match by FOLDER. See pluginFolder()'s doc.
+                $folder = self::pluginFolder($slug);
                 foreach (array_keys($all) as $file) {
-                    if (is_string($file) && str_starts_with($file, $slug . '/')) {
+                    if (is_string($file) && str_starts_with($file, $folder . '/')) {
                         return true;
                     }
                 }
@@ -175,6 +178,194 @@ class UpdateRunner
         }
 
         return $this->applyViaUpgrader($type, $slug, $version);
+    }
+
+    /**
+     * Verify that a just-applied plugin/theme update produced a complete,
+     * loadable artifact rather than a half-written directory left by an
+     * aborted copy (GitHub issue #131).
+     *
+     * A version-header bump alone does not prove an apply finished: WordPress
+     * core's install_package()/copy_dir() is a non-atomic recursive copy that
+     * clears the destination directory FIRST, then copies files in; if the
+     * PHP process is killed mid-copy (max_execution_time, PHP-FPM
+     * request_terminate_timeout) the main plugin/theme file — which core
+     * copies early — can already be in place and report a new version while
+     * the rest of the tree (e.g. a `vendor/` autoloader) is still missing.
+     *
+     * Deliberately MINIMAL: this reuses WordPress's own definition of "valid"
+     * rather than inventing content hashing, file-count comparisons, or any
+     * other heuristic that could false-fail a legitimately unusual (but
+     * complete) plugin/theme layout.
+     *   - plugin: validate_plugin() — the same check core itself runs before
+     *     activating a plugin. It resolves the header via get_plugins() and
+     *     confirms the main file exists on disk; a WP_Error return means the
+     *     header could not be re-read (the half-write symptom).
+     *   - theme: the style.css `Name` header must still be present and
+     *     non-empty after the apply — the same signal WordPress treats as
+     *     "this is not a valid theme".
+     *   - core: always true. Core updates have no directory-level rollback
+     *     here by design (see UpdateCommand's class doc, D3) — recovery for
+     *     core relies on UpdateCommand::execute()'s resource guard (B1) plus
+     *     WordPress's own Core_Upgrader temp-backup mechanism.
+     *
+     * BLOCKER (issue #131 final-hardening review) — an earlier revision of
+     * this method ALSO flagged a plugin incomplete when its main file's
+     * source merely referenced the literal string `vendor/autoload.php` and
+     * that exact path was missing on disk (S3, original adversarial
+     * review). That check was too eager: a plain `str_contains()` over the
+     * first 8 KB of the main file cannot tell the near-universal DEFENSIVE
+     * idiom — `if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+     * require ...; }`, or even a bare comment mentioning the path — apart
+     * from an unconditional `require`. A legitimate plugin that references
+     * the path but genuinely ships WITHOUT a `vendor/` directory (a
+     * dev-only Composer dependency, a "lite" build, or a
+     * graceful-degradation pattern) would fail this check after a
+     * perfectly GOOD apply, triggering an automatic revert that reports the
+     * update as `failed` — and STICKILY so: every subsequent run would
+     * re-apply and immediately re-revert the same update, permanently
+     * un-updatable via the agent. Deleted entirely rather than trying to
+     * special-case the idiom (parsing PHP conditionals reliably is exactly
+     * the kind of heuristic this method's doc already warns against). The
+     * half-write symptom this was meant to catch — a good main file with a
+     * missing `vendor/` tree — is still caught by the control plane's
+     * post-update health probe (issue #132's wp_fatal detection), which was
+     * always the backstop for anything this method's necessarily-narrow
+     * checks miss.
+     *
+     * Net effect: isComplete() == validate_plugin() for plugin, the
+     * style.css `Name` re-read for theme, always true for core.
+     *
+     * Fails OPEN (returns true) whenever the detection API itself is
+     * unavailable, mirroring isInstalled()'s stance — a constrained runtime
+     * must never cause a false rollback of a genuinely good update; a real
+     * problem still surfaces through the normal apply()/currentVersion() path.
+     *
+     * @param string $type plugin|theme|core.
+     * @param string $slug Sanitized slug (ignored for core).
+     * @return bool
+     */
+    public function isComplete(string $type, string $slug): bool
+    {
+        return match ($type) {
+            'plugin' => $this->isPluginComplete($slug),
+            'theme'  => $this->isThemeComplete($slug),
+            default  => true,
+        };
+    }
+
+    /**
+     * Plugin half of isComplete(). See isComplete()'s doc for the rationale.
+     *
+     * @param string $slug Sanitized plugin basename or folder.
+     * @return bool
+     */
+    private function isPluginComplete(string $slug): bool
+    {
+        $this->loadPluginApi();
+        if (!function_exists('get_plugins') || !function_exists('validate_plugin')) {
+            return true;
+        }
+
+        if (function_exists('wp_clean_plugins_cache')) {
+            // The main plugin file may have just been rewritten; force a
+            // fresh header read rather than trusting a pre-apply cache.
+            wp_clean_plugins_cache(true);
+        }
+
+        $all = get_plugins();
+        if (!is_array($all)) {
+            return true;
+        }
+
+        $basename = isset($all[$slug]) ? $slug : '';
+        if ($basename === '') {
+            // S6 (issue #131 adversarial review) — resolve by FOLDER, not by
+            // re-appending '/' to $slug directly. The CP sends the FULL
+            // "folder/main-file.php" basename as the slug; when an update
+            // legitimately renames the plugin's bootstrap file, get_plugins()
+            // no longer has a "folder/oldmain.php" key at all, and the old
+            // fallback (`str_starts_with($file, $slug . '/')`) could never
+            // match anything either — $slug already ends in ".php", so it
+            // was checking for a key literally starting with
+            // "folder/oldmain.php/", which no installed plugin basename can
+            // ever be. That made a GOOD, differently-named update
+            // indistinguishable from a real half-write and triggered a
+            // false auto-rollback. Deriving the folder first lets a
+            // renamed-main-file plugin still resolve correctly.
+            $folder = self::pluginFolder($slug);
+            foreach (array_keys($all) as $file) {
+                if (is_string($file) && str_starts_with($file, $folder . '/')) {
+                    $basename = $file;
+                    break;
+                }
+            }
+        }
+
+        if ($basename === '') {
+            // get_plugins() no longer resolves this slug to any header at
+            // all — the classic half-written-main-file symptom.
+            return false;
+        }
+
+        $result = validate_plugin($basename);
+        if (is_wp_error($result)) {
+            return false;
+        }
+
+        // BLOCKER (issue #131 final-hardening review) — the S3
+        // vendor/autoload.php sub-check that previously lived here has been
+        // REMOVED entirely; see this method's class doc (isComplete()) for
+        // why. validate_plugin() succeeding is the whole signal.
+        return true;
+    }
+
+    /**
+     * Extract the plugin FOLDER component from a slug that may be a bare
+     * folder name ("akismet") or a full "folder/main-file.php" basename.
+     * Shared by the folder-prefix fallback in isInstalled(), pluginVersion(),
+     * and isPluginComplete() so a plugin whose main file was renamed by an
+     * update — the CP-supplied slug's exact basename no longer matching any
+     * installed key — still resolves by folder rather than failing to match
+     * at all (S6, GitHub issue #131).
+     *
+     * @param string $slug Sanitized plugin slug/basename.
+     * @return string Folder name (never contains a '/').
+     */
+    private static function pluginFolder(string $slug): string
+    {
+        $pos = strpos($slug, '/');
+
+        return $pos === false ? $slug : substr($slug, 0, $pos);
+    }
+
+    /**
+     * Theme half of isComplete(). See isComplete()'s doc for the rationale.
+     *
+     * @param string $slug Sanitized theme stylesheet.
+     * @return bool
+     */
+    private function isThemeComplete(string $slug): bool
+    {
+        if (!function_exists('wp_get_theme')) {
+            return true;
+        }
+
+        if (function_exists('wp_clean_themes_cache')) {
+            wp_clean_themes_cache();
+        }
+
+        $theme = wp_get_theme($slug);
+        if (!is_object($theme) || !method_exists($theme, 'get')) {
+            return true;
+        }
+
+        // A half-written theme (style.css truncated or its header block
+        // corrupted mid-copy) reads back with an empty Name — the same
+        // signal WordPress itself treats as "this is not a valid theme".
+        $name = (string) $theme->get('Name');
+
+        return $name !== '';
     }
 
     /**
@@ -353,6 +544,23 @@ class UpdateRunner
     {
         $this->loadUpgraderApi();
 
+        // B3 (GitHub issue #131) — harden the unpack directory. WordPress's
+        // own temp-directory resolution (get_temp_dir(), used by
+        // WP_Filesystem_*::unzip_file()/wp_tempnam() when WP_TEMP_DIR is
+        // undefined) falls through to sys_get_temp_dir() / upload_tmp_dir on
+        // a locked-down host, which can sit OUTSIDE open_basedir and fail
+        // silently there. wp-content/upgrade is always inside the site's own
+        // writable tree, so pin WP_TEMP_DIR to it explicitly rather than
+        // trusting that fallback.
+        $upgradeDir = defined('WP_CONTENT_DIR') ? rtrim((string) WP_CONTENT_DIR, '/\\') . '/upgrade' : '';
+        if ($upgradeDir !== '' && !is_dir($upgradeDir) && function_exists('wp_mkdir_p')) {
+            wp_mkdir_p($upgradeDir);
+        }
+        if ($upgradeDir !== '' && is_dir($upgradeDir) && !defined('WP_TEMP_DIR')) {
+            // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- WP_TEMP_DIR is a documented, overridable WordPress core constant (wp-admin/includes/file.php get_temp_dir()), not a constant of our own; it is simply missing from this sniff's hardcoded allowed_core_constants list
+            define('WP_TEMP_DIR', $upgradeDir);
+        }
+
         if (function_exists('wp_update_plugins') && $type === 'plugin') {
             wp_update_plugins();
         }
@@ -360,70 +568,88 @@ class UpdateRunner
             wp_update_themes();
         }
 
-        switch ($type) {
-            case 'plugin':
-                if (!class_exists('\Plugin_Upgrader') || !class_exists('\WP_Ajax_Upgrader_Skin')) {
-                    return ['ok' => false, 'log' => 'Upgrader API unavailable.'];
-                }
+        // Force a clean working directory for THIS upgrade only. A prior
+        // interrupted apply can leave a stale wp-content/upgrade/<slug>.<ver>/
+        // extraction directory behind (the reported orphaned
+        // upgrade/latepoint.5.6.4/); Plugin_Upgrader::install_package()
+        // otherwise reuses whatever it finds there instead of a fresh unpack.
+        // Added immediately before, and removed immediately after, this
+        // single upgrade() call so it never leaks into an unrelated
+        // concurrent upgrade running in a different request.
+        $forceCleanWorking = static function (array $options): array {
+            $options['clear_working'] = true;
+            return $options;
+        };
+        add_filter('upgrader_package_options', $forceCleanWorking);
 
-                // Capture active state BEFORE upgrade. WordPress's
-                // Plugin_Upgrader::upgrade() registers an upgrader_pre_install
-                // hook that calls deactivate_plugins($plugin, silent=true) and
-                // does NOT re-activate after the upgrade finishes. WP-CLI's
-                // `wp plugin update` preserves active state; we mirror that
-                // behaviour here so the PHP-fallback path doesn't strand an
-                // active plugin inactive after a successful upgrade.
-                $pluginsFilePath  = WPMGR_AGENT_DIR; // unused — silence linters about the var
-                $wasActive        = function_exists('is_plugin_active')             ? \is_plugin_active($slug) : false;
-                $wasNetworkActive = function_exists('is_plugin_active_for_network') ? \is_plugin_active_for_network($slug) : false;
-
-                $upgrader = new \Plugin_Upgrader(new \WP_Ajax_Upgrader_Skin());
-                try {
-                    $result = $upgrader->upgrade($slug);
-                } finally {
-                    // GUARANTEE: clear maintenance mode on every terminal
-                    // path of THIS upgrade() call, independent of whether it
-                    // succeeded, returned a WP_Error, or threw.
-                    Maintenance::clear($upgrader);
-                }
-                $outcome  = $this->upgraderOutcome($result);
-
-                if ($outcome['ok'] && ($wasActive || $wasNetworkActive) && function_exists('activate_plugin')) {
-                    // Refresh plugin caches before reactivating: the upgrade
-                    // may have changed the main plugin file (slug stays the
-                    // same but the metadata cache is stale).
-                    if (function_exists('wp_clean_plugins_cache')) {
-                        \wp_clean_plugins_cache(true);
+        try {
+            switch ($type) {
+                case 'plugin':
+                    if (!class_exists('\Plugin_Upgrader') || !class_exists('\WP_Ajax_Upgrader_Skin')) {
+                        return ['ok' => false, 'log' => 'Upgrader API unavailable.'];
                     }
-                    $activated = \activate_plugin($slug, '', $wasNetworkActive, true);
-                    if (\is_wp_error($activated)) {
-                        $outcome['log'] .= "\n[wpmgr] upgrade succeeded but reactivation failed: "
-                            . $activated->get_error_message();
-                        \WPMgr\Agent\Support\DebugLog::write('WPMgr Agent: post-upgrade reactivation failed for '
-                            . $slug . ': ' . $activated->get_error_message());
+
+                    // Capture active state BEFORE upgrade. WordPress's
+                    // Plugin_Upgrader::upgrade() registers an upgrader_pre_install
+                    // hook that calls deactivate_plugins($plugin, silent=true) and
+                    // does NOT re-activate after the upgrade finishes. WP-CLI's
+                    // `wp plugin update` preserves active state; we mirror that
+                    // behaviour here so the PHP-fallback path doesn't strand an
+                    // active plugin inactive after a successful upgrade.
+                    $pluginsFilePath  = WPMGR_AGENT_DIR; // unused — silence linters about the var
+                    $wasActive        = function_exists('is_plugin_active')             ? \is_plugin_active($slug) : false;
+                    $wasNetworkActive = function_exists('is_plugin_active_for_network') ? \is_plugin_active_for_network($slug) : false;
+
+                    $upgrader = new \Plugin_Upgrader(new \WP_Ajax_Upgrader_Skin());
+                    try {
+                        $result = $upgrader->upgrade($slug);
+                    } finally {
+                        // GUARANTEE: clear maintenance mode on every terminal
+                        // path of THIS upgrade() call, independent of whether it
+                        // succeeded, returned a WP_Error, or threw.
+                        Maintenance::clear($upgrader);
                     }
-                }
+                    $outcome  = $this->upgraderOutcome($result);
 
-                return $outcome;
+                    if ($outcome['ok'] && ($wasActive || $wasNetworkActive) && function_exists('activate_plugin')) {
+                        // Refresh plugin caches before reactivating: the upgrade
+                        // may have changed the main plugin file (slug stays the
+                        // same but the metadata cache is stale).
+                        if (function_exists('wp_clean_plugins_cache')) {
+                            \wp_clean_plugins_cache(true);
+                        }
+                        $activated = \activate_plugin($slug, '', $wasNetworkActive, true);
+                        if (\is_wp_error($activated)) {
+                            $outcome['log'] .= "\n[wpmgr] upgrade succeeded but reactivation failed: "
+                                . $activated->get_error_message();
+                            \WPMgr\Agent\Support\DebugLog::write('WPMgr Agent: post-upgrade reactivation failed for '
+                                . $slug . ': ' . $activated->get_error_message());
+                        }
+                    }
 
-            case 'theme':
-                if (!class_exists('\Theme_Upgrader') || !class_exists('\WP_Ajax_Upgrader_Skin')) {
-                    return ['ok' => false, 'log' => 'Upgrader API unavailable.'];
-                }
-                $upgrader = new \Theme_Upgrader(new \WP_Ajax_Upgrader_Skin());
-                try {
-                    $result = $upgrader->upgrade($slug);
-                } finally {
-                    Maintenance::clear($upgrader);
-                }
+                    return $outcome;
 
-                return $this->upgraderOutcome($result);
+                case 'theme':
+                    if (!class_exists('\Theme_Upgrader') || !class_exists('\WP_Ajax_Upgrader_Skin')) {
+                        return ['ok' => false, 'log' => 'Upgrader API unavailable.'];
+                    }
+                    $upgrader = new \Theme_Upgrader(new \WP_Ajax_Upgrader_Skin());
+                    try {
+                        $result = $upgrader->upgrade($slug);
+                    } finally {
+                        Maintenance::clear($upgrader);
+                    }
 
-            case 'core':
-                return $this->applyCoreUpgrade($version);
+                    return $this->upgraderOutcome($result);
+
+                case 'core':
+                    return $this->applyCoreUpgrade($version);
+            }
+
+            return ['ok' => false, 'log' => 'Unsupported type.'];
+        } finally {
+            remove_filter('upgrader_package_options', $forceCleanWorking);
         }
-
-        return ['ok' => false, 'log' => 'Unsupported type.'];
     }
 
     /**
@@ -541,12 +767,15 @@ class UpdateRunner
             return (string) $all[$slug]['Version'];
         }
 
-        // Allow a folder-only slug to match its "folder/..." basename.
+        // Allow a folder-only slug — or a full "folder/main-file.php"
+        // basename whose main file was since renamed (S6, issue #131) — to
+        // match by FOLDER. See pluginFolder()'s doc.
+        $folder = self::pluginFolder($slug);
         foreach ($all as $file => $meta) {
             if (!is_string($file) || !is_array($meta)) {
                 continue;
             }
-            if (str_starts_with($file, $slug . '/') && isset($meta['Version'])) {
+            if (str_starts_with($file, $folder . '/') && isset($meta['Version'])) {
                 return (string) $meta['Version'];
             }
         }

--- a/apps/agent/patchwork.json
+++ b/apps/agent/patchwork.json
@@ -1,3 +1,3 @@
 {
-  "redefinable-internals": ["headers_list"]
+  "redefinable-internals": ["headers_list", "set_time_limit"]
 }

--- a/apps/agent/tests/MetadataCommandTest.php
+++ b/apps/agent/tests/MetadataCommandTest.php
@@ -347,4 +347,132 @@ final class MetadataCommandTest extends TestCase
 
         $this->assertNull($data['core_update']);
     }
+
+    // ---- open_basedir log-flood guard (GitHub issue #131) -----------------
+
+    /**
+     * Reproduces the reported log flood: on a locked-down managed host with
+     * `open_basedir` restricting the PHP process to the webroot,
+     * `is_dir('/var/lib/runcloud')` — an absolute, out-of-webroot probe — used
+     * to raise an unsilenced E_WARNING on every single agent request. Fixed
+     * by `@`-guarding that one call site (class-metadata-command.php).
+     *
+     * `open_basedir` can only ever be TIGHTENED at runtime — PHP refuses to
+     * widen it back — so genuinely reproducing the restriction cannot be done
+     * inline: it would permanently break every later filesystem-touching test
+     * in this (single, non-isolated) PHPUnit process. Instead this spawns a
+     * disposable `php -d open_basedir=...` child process whose entire
+     * lifetime is the probe: it loads only the two source files hostFlags()
+     * needs (no WordPress dependency — the method is pure PHP), invokes it
+     * under a custom error handler, and reports what it saw as JSON. The
+     * restriction, and its irreversibility, are fully contained to that
+     * throwaway process.
+     */
+    public function test_host_flags_runcloud_probe_raises_no_warning_under_open_basedir(): void
+    {
+        if (!function_exists('exec')) {
+            $this->markTestSkipped('exec() is unavailable in this PHP configuration.');
+        }
+
+        $includesDir = dirname(__DIR__) . '/includes';
+        $tmpDir      = sys_get_temp_dir();
+
+        $probeScript = (string) tempnam($tmpDir, 'wpmgr-hostflags-');
+        file_put_contents($probeScript, self::hostFlagsProbeSource());
+
+        try {
+            $cmd = escapeshellarg(PHP_BINARY)
+                . ' -d ' . escapeshellarg('open_basedir=' . $includesDir . PATH_SEPARATOR . $tmpDir)
+                . ' -f ' . escapeshellarg($probeScript)
+                . ' -- ' . escapeshellarg($includesDir);
+
+            exec($cmd . ' 2>&1', $outputLines, $exitCode); // phpcs:ignore WordPress.PHP.DiscouragedFunctions.exec -- test-only: spawns a disposable subprocess to safely reproduce a runtime-irreversible open_basedir restriction; all inputs are internally generated absolute paths, none are request-derived
+        } finally {
+            @unlink($probeScript); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        }
+
+        $rawOutput = implode("\n", $outputLines);
+        $this->assertSame(0, $exitCode, 'probe subprocess must exit cleanly: ' . $rawOutput);
+
+        $result = json_decode($rawOutput, true);
+        $this->assertIsArray($result, 'probe subprocess must emit parseable JSON: ' . $rawOutput);
+        $this->assertSame(
+            [],
+            $result['warnings'] ?? ['<missing warnings key>'],
+            'hostFlags() must not leak an unsuppressed warning from the RunCloud filesystem probe under open_basedir'
+        );
+        $this->assertTrue($result['is_runcloud_is_bool'] ?? false, 'is_runcloud must remain a bool');
+    }
+
+    /**
+     * Source for the isolated open_basedir probe subprocess spawned by
+     * test_host_flags_runcloud_probe_raises_no_warning_under_open_basedir().
+     *
+     * Deliberately a standalone script with no Composer/WordPress bootstrap:
+     * hostFlags() is pure PHP (defined()/is_dir()/$_SERVER only), so loading
+     * just the command interface + class under test is sufficient. Takes the
+     * includes/ directory as argv[1] so it never hard-codes an absolute path
+     * that could drift from this test file's own location.
+     */
+    private static function hostFlagsProbeSource(): string
+    {
+        return <<<'PHP'
+<?php
+declare(strict_types=1);
+
+$includesDir = $argv[1] ?? '';
+require_once $includesDir . '/commands/interface-command-interface.php';
+require_once $includesDir . '/commands/class-metadata-command.php';
+
+$warnings = [];
+// Respect the standard @-operator convention: PHP still invokes a custom
+// error handler for a silenced expression, but the handler's
+// error_reporting() reads a reduced mask that excludes the silenced level —
+// AND-ing it against $errno is how a well-behaved handler tells "silenced"
+// apart from "a warning that actually escaped" (checking `=== 0` is NOT
+// reliable: PHP 8's @ mask still includes the always-fatal levels).
+set_error_handler(static function (int $errno, string $errstr) use (&$warnings): bool {
+    if ((error_reporting() & $errno) === 0) {
+        return true;
+    }
+    $warnings[] = $errstr;
+
+    return true;
+});
+
+$ref = new ReflectionMethod(\WPMgr\Agent\Commands\MetadataCommand::class, 'hostFlags');
+$flags = $ref->invoke(new \WPMgr\Agent\Commands\MetadataCommand());
+
+restore_error_handler();
+
+echo json_encode([
+    'warnings'            => $warnings,
+    'is_runcloud_is_bool' => is_bool($flags['is_runcloud']),
+]);
+PHP;
+    }
+
+    /**
+     * Durable, environment-independent regression guard: no matter what a
+     * future edit does to hostFlags() (or adds beside it), an absolute
+     * out-of-webroot filesystem probe like `/var/lib/runcloud` must never be
+     * called unsilenced. A static source check catches this even in an
+     * environment (or a future PHP) where the open_basedir-restriction test
+     * above cannot be exercised.
+     */
+    public function test_metadata_command_source_has_no_unsuppressed_var_lib_probe(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__) . '/includes/commands/class-metadata-command.php');
+
+        $this->assertMatchesRegularExpression(
+            "#@is_dir\\('/var/lib/runcloud'\\)#",
+            $source,
+            'the RunCloud probe must remain @-guarded'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            "#(?<!@)is_dir\\('/var/#",
+            $source,
+            'no unsuppressed is_dir() call against an absolute /var/... path may be reintroduced'
+        );
+    }
 }

--- a/apps/agent/tests/SnapshotManagerTest.php
+++ b/apps/agent/tests/SnapshotManagerTest.php
@@ -1,0 +1,792 @@
+<?php
+/**
+ * SnapshotManagerTest — adversarial-review fixes for GitHub issue #131 (agent
+ * update atomicity): M1 (bounded snapshot GC) and S5 (restore()'s dead
+ * rollback-on-failure code).
+ *
+ * All filesystem operations use an isolated temp directory per test, and
+ * SnapshotManager's `liveDir()` (protected) is overridden in an anonymous
+ * subclass wherever a test needs to control the "live" plugin/theme source
+ * path deterministically — this keeps every test in this file independent of
+ * ambient WP_CONTENT_DIR / WP_PLUGIN_DIR state that OTHER test files in this
+ * suite may have already frozen as global PHP constants (constants cannot be
+ * redefined once set, and several other test files legitimately do define
+ * them for their own purposes).
+ *
+ * Covers:
+ *   - M1: capture() prunes a slug's older snapshots beyond the count cap,
+ *     the most-recent-two survive across a capture cycle (the CP
+ *     post-update health-probe window guarantee), a TTL-expired snapshot is
+ *     pruned even while still within the count cap, and pruning one slug
+ *     never touches another slug's snapshots.
+ *   - M1: gcExpired() (the recurring cron backstop) sweeps any snapshot
+ *     directory older than the backstop TTL, including one with no readable
+ *     meta.json at all (mtime fallback), while leaving recent ones alone.
+ *   - S5: restore() rolls back to the pre-restore-attempt state (not the
+ *     misleading "original retained" no-op) when the copy-back fails
+ *     mid-write, correctly handles the case where there was nothing to roll
+ *     back to, and the happy path still works unchanged.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Support\SnapshotManager;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\SnapshotManager
+ */
+final class SnapshotManagerTest extends TestCase
+{
+    /** Temp root for this test run (removed in tear_down). */
+    private string $root = '';
+
+    /** Simulated wp-content/uploads dir. */
+    private string $uploadsDir = '';
+
+    /** wpmgr-snapshots store under $uploadsDir. */
+    private string $snapshotsBase = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->root          = sys_get_temp_dir() . '/wpmgr-snaptest-' . bin2hex(random_bytes(6));
+        $this->uploadsDir    = $this->root . '/uploads';
+        $this->snapshotsBase = $this->uploadsDir . '/wpmgr-snapshots';
+        mkdir($this->uploadsDir, 0755, true);
+
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $this->uploadsDir]);
+    }
+
+    protected function tear_down(): void
+    {
+        $this->rrmdir($this->root);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // =========================================================================
+    // Test doubles / helpers
+    // =========================================================================
+
+    /**
+     * A SnapshotManager whose liveDir() is fully test-controlled (never
+     * touches WP_CONTENT_DIR/WP_PLUGIN_DIR), and whose copyDir() can be
+     * forced to fail AFTER mimicking the real method's mkdir-destination-first
+     * side effect — the exact precondition S5's bug required.
+     */
+    private function manager(): object
+    {
+        return new class extends SnapshotManager {
+            public string $liveOverride = '';
+            public bool $failCopy       = false;
+
+            /**
+             * Optional hook invoked at the very start of copyDir() — lets a
+             * test observe on-disk state at the exact moment restore()'s
+             * copy-back step begins (the narrow "aside is staged, copy is
+             * about to run" window Fix 1 (issue #131 final-hardening review,
+             * asides not GC-safe) targets).
+             *
+             * @var (callable(): void)|null
+             */
+            public $onCopyDir = null;
+
+            protected function liveDir(string $type, string $slug): string
+            {
+                return $this->liveOverride;
+            }
+
+            protected function copyDir(string $src, string $dst): bool
+            {
+                if ($this->onCopyDir !== null) {
+                    ($this->onCopyDir)();
+                }
+
+                if ($this->failCopy) {
+                    // Mirror copyDir()'s real first step (mkdir the
+                    // destination) even though the copy is about to fail —
+                    // this is the exact precondition that defeated the
+                    // original `is_dir($live)` rollback guard (S5).
+                    if (!is_dir($dst)) {
+                        mkdir($dst, 0755, true);
+                    }
+                    return false;
+                }
+
+                return parent::copyDir($src, $dst);
+            }
+        };
+    }
+
+    /**
+     * A SnapshotManager whose liveDir() always returns '' (no live source) —
+     * isolates prune-at-capture behavior from any real directory copy.
+     */
+    private function managerWithNoLiveSource(): SnapshotManager
+    {
+        return new class extends SnapshotManager {
+            protected function liveDir(string $type, string $slug): string
+            {
+                return '';
+            }
+        };
+    }
+
+    /**
+     * Seed a snapshot directory directly on disk (bypassing capture()) with a
+     * controlled created_at, for prune/GC tests that need precise ages.
+     */
+    private function seedSnapshot(string $type, string $slug, int $createdAt): string
+    {
+        $id  = 'snap_' . bin2hex(random_bytes(12));
+        $dir = $this->snapshotsBase . '/' . $id;
+        mkdir($dir, 0755, true);
+        file_put_contents($dir . '/meta.json', (string) json_encode([
+            'type'         => $type,
+            'slug'         => $slug,
+            'from_version' => '1.0',
+            'created_at'   => $createdAt,
+        ]));
+
+        return $id;
+    }
+
+    /** Recursive delete used only for test fixture cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+
+    // =========================================================================
+    // M1 — prune-at-capture
+    // =========================================================================
+
+    public function test_repeated_capture_bounds_snapshot_count_and_keeps_the_most_recent_for_cp_rollback(): void
+    {
+        $source = $this->root . '/plugins-src/demo';
+        mkdir($source, 0755, true);
+        file_put_contents($source . '/demo.php', "<?php\n// v1\n");
+
+        $mgr               = $this->manager();
+        $mgr->liveOverride = $source;
+
+        // Two EXISTING entries for this slug from well-spaced-out prior
+        // update cycles — comfortably past MIN_KEEP_AGE_SECONDS (10 min) so
+        // the COUNT-based retention cap is what's under test here, not the
+        // min-age floor (a real back-to-back capture sequence within 10
+        // minutes is exactly the race the floor now protects against — see
+        // test_prune_never_removes_a_snapshot_younger_than_the_min_keep_age_floor_regardless_of_rank
+        // below for that case).
+        $r1 = $this->seedSnapshot('plugin', 'demo/demo.php', time() - 2400); // 40 min ago
+        $r2 = $this->seedSnapshot('plugin', 'demo/demo.php', time() - 1800); // 30 min ago
+
+        $r3 = $mgr->capture('plugin', 'demo/demo.php', '1.2');
+        $this->assertNotSame('', $r3['snapshot_id']);
+
+        // The THIRD capture's own prune pass must have removed the OLDEST
+        // (r1) — but never the two most recent (the CP's post-update
+        // health-probe window guarantee M1 exists for).
+        $this->assertFalse(
+            is_dir($this->snapshotsBase . '/' . $r1),
+            'M1: the oldest snapshot for this slug must be pruned once the per-slug count cap is exceeded'
+        );
+        $this->assertTrue(is_dir($this->snapshotsBase . '/' . $r2));
+        $this->assertTrue(is_dir($this->snapshotsBase . '/' . $r3['snapshot_id']));
+    }
+
+    public function test_prune_never_removes_a_snapshot_younger_than_the_min_keep_age_floor_regardless_of_rank(): void
+    {
+        $mgr = $this->managerWithNoLiveSource();
+        $mgr->capture('plugin', 'warmup/warmup.php', '1.0');
+
+        // Two EXISTING entries for the SAME slug, both well under the
+        // 10-minute floor — simulating a concurrent-update race (a second
+        // in-flight `update` request for the SAME slug capturing its own
+        // snapshot moments after the first; the CP's cross-run dedup for
+        // this is being fixed separately, but the agent must not depend on
+        // it). The count cap alone (keep newest 1 existing) would normally
+        // prune the older of the two right here; the floor must override
+        // that and keep BOTH regardless of rank.
+        $olderId = $this->seedSnapshot('plugin', 'racey/racey.php', time() - 5);
+        $newerId = $this->seedSnapshot('plugin', 'racey/racey.php', time() - 2);
+
+        $mgr->capture('plugin', 'racey/racey.php', '1.0');
+
+        $this->assertTrue(
+            is_dir($this->snapshotsBase . '/' . $olderId),
+            'belt: a snapshot younger than MIN_KEEP_AGE_SECONDS must never be pruned, even when it is past the per-slug count cap'
+        );
+        $this->assertTrue(
+            is_dir($this->snapshotsBase . '/' . $newerId),
+            'belt: a snapshot younger than MIN_KEEP_AGE_SECONDS must never be pruned'
+        );
+    }
+
+    public function test_capture_prunes_a_ttl_expired_slug_snapshot_even_within_the_count_cap(): void
+    {
+        $mgr = $this->managerWithNoLiveSource();
+
+        // Force-create the snapshot base directory.
+        $mgr->capture('plugin', 'warmup/warmup.php', '1.0');
+
+        // Only ONE existing entry for this slug — well within the count cap
+        // (MAX_SNAPSHOTS_PER_SLUG - 1 = 1) — but 25h old, past the 24h
+        // capture-time TTL.
+        $staleId = $this->seedSnapshot('plugin', 'stale/stale.php', time() - (25 * 3600));
+
+        $mgr->capture('plugin', 'stale/stale.php', '1.0');
+
+        $this->assertFalse(
+            is_dir($this->snapshotsBase . '/' . $staleId),
+            'M1: a slug snapshot past the 24h capture-time TTL must be pruned even though it is within the count cap'
+        );
+    }
+
+    public function test_capture_keeps_a_recent_slug_snapshot_within_both_bounds(): void
+    {
+        $mgr = $this->managerWithNoLiveSource();
+        $mgr->capture('plugin', 'warmup/warmup.php', '1.0');
+
+        $recentId = $this->seedSnapshot('plugin', 'recent/recent.php', time() - 60);
+
+        $mgr->capture('plugin', 'recent/recent.php', '1.0');
+
+        $this->assertTrue(
+            is_dir($this->snapshotsBase . '/' . $recentId),
+            'a snapshot within both the count cap and the TTL must survive pruning'
+        );
+    }
+
+    public function test_prune_never_touches_a_different_slugs_snapshots(): void
+    {
+        $mgr = $this->managerWithNoLiveSource();
+        $mgr->capture('plugin', 'warmup/warmup.php', '1.0');
+
+        // Ages kept comfortably past MIN_KEEP_AGE_SECONDS (10 min) so the
+        // per-slug isolation under test here isn't masked by the min-age
+        // floor (which would otherwise keep everything regardless of slug).
+        $idA1 = $this->seedSnapshot('plugin', 'alpha/alpha.php', time() - 900);
+        $idA2 = $this->seedSnapshot('plugin', 'alpha/alpha.php', time() - 800);
+        $idB1 = $this->seedSnapshot('plugin', 'beta/beta.php', time() - 700);
+
+        // Pruning triggered for 'alpha' only.
+        $mgr->capture('plugin', 'alpha/alpha.php', '1.0');
+
+        $this->assertFalse(is_dir($this->snapshotsBase . '/' . $idA1), 'alpha oldest must be pruned');
+        $this->assertTrue(is_dir($this->snapshotsBase . '/' . $idA2), 'alpha newest must survive');
+        $this->assertTrue(
+            is_dir($this->snapshotsBase . '/' . $idB1),
+            'M1: pruning one slug must never remove a DIFFERENT slug\'s snapshots'
+        );
+    }
+
+    public function test_prune_never_touches_snapshots_of_a_different_type_with_the_same_slug_name(): void
+    {
+        // A plugin folder and a theme stylesheet could coincidentally share
+        // the same slug string; type must be part of the match, not just slug.
+        // Two PLUGIN entries (so the plugin bucket genuinely exceeds the
+        // count cap and a real prune happens) plus one THEME entry sharing
+        // the same slug string proves type-isolation: if type were NOT part
+        // of the match, the combined "shared" bucket would already be at 3
+        // entries against a cap of 1, and the theme entry could be swept too.
+        $mgr = $this->managerWithNoLiveSource();
+        $mgr->capture('plugin', 'warmup/warmup.php', '1.0');
+
+        // Ages kept comfortably past MIN_KEEP_AGE_SECONDS (10 min) — see the
+        // comment on the alpha/beta test above for why.
+        $pluginOld = $this->seedSnapshot('plugin', 'shared', time() - 900);
+        $pluginNew = $this->seedSnapshot('plugin', 'shared', time() - 800);
+        $themeId   = $this->seedSnapshot('theme', 'shared', time() - 700);
+
+        $mgr->capture('plugin', 'shared', '1.0');
+
+        $this->assertFalse(is_dir($this->snapshotsBase . '/' . $pluginOld), 'the older plugin:shared snapshot must be pruned');
+        $this->assertTrue(is_dir($this->snapshotsBase . '/' . $pluginNew), 'the newer plugin:shared snapshot must survive');
+        $this->assertTrue(
+            is_dir($this->snapshotsBase . '/' . $themeId),
+            'M1: a theme:shared snapshot must never be pruned by a plugin:shared capture — type must be part of the match, not just slug'
+        );
+    }
+
+    // =========================================================================
+    // M1 — GC cron backstop (gcExpired())
+    // =========================================================================
+
+    public function test_gc_expired_sweeps_snapshots_older_than_the_backstop_ttl(): void
+    {
+        $mgr = $this->managerWithNoLiveSource();
+        $mgr->capture('plugin', 'warmup/warmup.php', '1.0');
+
+        $oldId    = $this->seedSnapshot('plugin', 'orphan/orphan.php', time() - (73 * 3600)); // > 72h
+        $recentId = $this->seedSnapshot('plugin', 'recent/recent.php', time() - 3600); // 1h
+
+        SnapshotManager::gcExpired();
+
+        $this->assertFalse(
+            is_dir($this->snapshotsBase . '/' . $oldId),
+            'M1: the GC backstop must sweep any snapshot older than 72h, independent of the per-slug prune'
+        );
+        $this->assertTrue(
+            is_dir($this->snapshotsBase . '/' . $recentId),
+            'a recent snapshot must survive the GC backstop sweep'
+        );
+    }
+
+    public function test_gc_expired_uses_mtime_fallback_for_a_snapshot_with_no_readable_meta(): void
+    {
+        $mgr = $this->managerWithNoLiveSource();
+        $mgr->capture('plugin', 'warmup/warmup.php', '1.0');
+
+        // Simulates a crashed capture that never got as far as writeMeta().
+        $orphan = $this->snapshotsBase . '/snap_' . bin2hex(random_bytes(12));
+        mkdir($orphan, 0755, true);
+        touch($orphan, time() - (73 * 3600));
+
+        SnapshotManager::gcExpired();
+
+        $this->assertFalse(
+            is_dir($orphan),
+            'a crashed-capture directory with no meta.json must still be swept via the mtime fallback'
+        );
+    }
+
+    public function test_gc_expired_never_touches_the_cp_health_probe_window(): void
+    {
+        $mgr               = $this->manager();
+        $source            = $this->root . '/plugins-src/live';
+        mkdir($source, 0755, true);
+        file_put_contents($source . '/live.php', "<?php\n");
+        $mgr->liveOverride = $source;
+
+        $r = $mgr->capture('plugin', 'live/live.php', '1.0');
+        $this->assertNotSame('', $r['snapshot_id']);
+
+        // Immediately run the GC backstop, simulating an unlucky cron tick
+        // landing right after a fresh capture.
+        SnapshotManager::gcExpired();
+
+        $this->assertTrue(
+            is_dir($this->snapshotsBase . '/' . $r['snapshot_id']),
+            'M1: a freshly captured snapshot must never be swept by the GC backstop — it is nowhere near the 72h TTL'
+        );
+    }
+
+    // =========================================================================
+    // F4 — stranded `.wpmgr-old-<id>` aside sweep (gcExpired())
+    // =========================================================================
+
+    /**
+     * A SnapshotManager subclass whose strandedAsideRoots() is fully
+     * test-controlled (never touches the real WP_PLUGIN_DIR/WP_CONTENT_DIR
+     * constants), exercised via `new static()` late static binding inside
+     * gcExpired() itself — see gcExpired()'s doc for why this works.
+     *
+     * The configured root is held in a STATIC property, not a constructor
+     * argument: gcExpired() constructs its own fresh instance internally via
+     * `new static()` (no args), so any per-instance constructor parameter
+     * would never reach that instance. A static property is shared by every
+     * instance of this same anonymous class, including that internal one.
+     *
+     * @return class-string<SnapshotManager>
+     */
+    private function managerClassWithPluginRoot(string $pluginsRoot): string
+    {
+        $class = new class extends SnapshotManager {
+            public static string $testPluginsRoot = '';
+
+            protected function strandedAsideRoots(): array
+            {
+                return [self::$testPluginsRoot];
+            }
+        };
+        $class::$testPluginsRoot = $pluginsRoot;
+
+        return get_class($class);
+    }
+
+    public function test_gc_expired_sweeps_a_stranded_wpmgr_old_aside_past_the_backstop_ttl(): void
+    {
+        $pluginsRoot = $this->root . '/plugins-root';
+        mkdir($pluginsRoot . '/demo', 0755, true);
+
+        $strandedAside = $pluginsRoot . '/demo.wpmgr-old-snap_' . bin2hex(random_bytes(12));
+        mkdir($strandedAside, 0755, true);
+        file_put_contents($strandedAside . '/marker.txt', 'stranded original');
+        touch($strandedAside, time() - (73 * 3600)); // > 72h backstop TTL
+
+        $recentAside = $pluginsRoot . '/other.wpmgr-old-snap_' . bin2hex(random_bytes(12));
+        mkdir($recentAside, 0755, true);
+        touch($recentAside, time() - 3600); // 1h — must survive
+
+        $class = $this->managerClassWithPluginRoot($pluginsRoot);
+        $class::gcExpired();
+
+        $this->assertFalse(
+            is_dir($strandedAside),
+            'F4: a stranded .wpmgr-old-<id> aside past the GC backstop TTL must be swept'
+        );
+        $this->assertTrue(is_dir($recentAside), 'a recent stranded aside must survive the sweep');
+        $this->assertTrue(
+            is_dir($pluginsRoot . '/demo'),
+            'F4 must never touch the LIVE plugin directory itself, only the stranded aside sibling'
+        );
+    }
+
+    public function test_gc_expired_ignores_a_directory_that_only_partially_matches_the_stranded_aside_pattern(): void
+    {
+        $pluginsRoot = $this->root . '/plugins-root2';
+        mkdir($pluginsRoot, 0755, true);
+
+        // A plain plugin folder that happens to contain the substring but
+        // does not END in the exact `.wpmgr-old-snap_<id>` suffix pattern —
+        // must never be swept.
+        $unrelated = $pluginsRoot . '/wpmgr-old-lookalike';
+        mkdir($unrelated, 0755, true);
+        touch($unrelated, time() - (73 * 3600));
+
+        $class = $this->managerClassWithPluginRoot($pluginsRoot);
+        $class::gcExpired();
+
+        $this->assertTrue(
+            is_dir($unrelated),
+            'F4 must only match the exact stranded-aside suffix pattern, never a lookalike plugin folder name'
+        );
+    }
+
+    // =========================================================================
+    // F1 — recovery from a re-interrupted restore (deterministic aside name)
+    // =========================================================================
+
+    public function test_restore_recovers_from_a_previously_interrupted_restore_for_the_same_snapshot(): void
+    {
+        $mgr  = $this->manager();
+        $live = $this->root . '/plugins-src/demo5';
+        mkdir($live, 0755, true);
+        file_put_contents($live . '/marker.txt', 'GOOD-PRE-UPDATE-CONTENT');
+        $mgr->liveOverride = $live;
+
+        // Capture while marker.txt holds the GOOD (pre-update) content — this
+        // is exactly what a correctly-completed restore must end up with.
+        $snap = $mgr->capture('plugin', 'demo5/demo5.php', '1.0');
+        $this->assertNotSame('', $snap['snapshot_id']);
+        $asideName = $live . '.wpmgr-old-' . $snap['snapshot_id'];
+
+        // Construct the exact end state a FIRST restore() call would leave
+        // behind if hard-killed mid-copy: $live was successfully moved aside
+        // (holding whatever the post-update/possibly-broken state was), and
+        // copyDir() got partway through writing the good payload back into a
+        // freshly (re)created $live before the process died. This is built
+        // directly here (mirroring restore()'s own rename()+copyDir()
+        // sequence) rather than via an actual kill, which cannot be
+        // deterministically triggered in a unit test.
+        rename($live, $asideName);
+        mkdir($live, 0755, true);
+        file_put_contents($live . '/partial.txt', 'PARTIAL-COPY-FROM-INTERRUPTED-RESTORE');
+        $this->assertTrue(is_dir($asideName), 'precondition: the interrupted first attempt left an aside behind');
+        $this->assertTrue(is_dir($live), 'precondition: the interrupted first attempt left a partial live dir behind');
+
+        // A SECOND restore() call for the SAME snapshot must recover cleanly
+        // — it must never bail with "Could not stage live directory aside"
+        // (the ENOTEMPTY wedge F1 fixes: rename() onto a non-empty existing
+        // $asideName fails outright) and must never leave the good pre-update
+        // snapshot payload stranded/unreachable.
+        $mgr->failCopy = false;
+        $result        = $mgr->restore('plugin', 'demo5/demo5.php', $snap['snapshot_id']);
+
+        $this->assertTrue($result['ok'], 'F1: a re-interrupted restore must recover, not wedge: ' . $result['log']);
+        $this->assertTrue(is_dir($live));
+        $this->assertSame(
+            'GOOD-PRE-UPDATE-CONTENT',
+            file_get_contents($live . '/marker.txt'),
+            'F1: the second restore attempt must end with the GOOD pre-update snapshot content actually in place — the live directory must be genuinely restored'
+        );
+        $this->assertFalse(
+            is_file($live . '/partial.txt'),
+            'F1: the partial/junk content from the interrupted first attempt must not survive'
+        );
+        $this->assertFalse(
+            is_dir($asideName),
+            'F1: no stranded aside may remain on disk after a successful recovery'
+        );
+    }
+
+    public function test_restore_second_attempt_is_not_wedged_even_when_the_first_attempts_aside_is_the_only_thing_left(): void
+    {
+        // A narrower variant: the interrupted first attempt died before
+        // copyDir() even got as far as (re)creating $live at all — only the
+        // aside survives, $live is entirely absent. The second attempt must
+        // still recover cleanly (this is really just the ordinary
+        // "live missing, aside present" case routed through the SAME heal
+        // branch, since is_dir($asideName) is checked unconditionally).
+        $mgr  = $this->manager();
+        $live = $this->root . '/plugins-src/demo6';
+        mkdir($live, 0755, true);
+        file_put_contents($live . '/marker.txt', 'GOOD-PRE-UPDATE-CONTENT');
+        $mgr->liveOverride = $live;
+
+        $snap = $mgr->capture('plugin', 'demo6/demo6.php', '1.0');
+        $this->assertNotSame('', $snap['snapshot_id']);
+        $asideName = $live . '.wpmgr-old-' . $snap['snapshot_id'];
+
+        rename($live, $asideName);
+        $this->assertFalse(is_dir($live));
+        $this->assertTrue(is_dir($asideName));
+
+        $result = $mgr->restore('plugin', 'demo6/demo6.php', $snap['snapshot_id']);
+
+        $this->assertTrue($result['ok'], 'F1: recovery must succeed even when only the aside survived: ' . $result['log']);
+        $this->assertSame('GOOD-PRE-UPDATE-CONTENT', file_get_contents($live . '/marker.txt'));
+        $this->assertFalse(is_dir($asideName));
+    }
+
+    // =========================================================================
+    // Fix 1 (issue #131 final-hardening review) — staged aside is GC-safe
+    // =========================================================================
+
+    public function test_restore_stamps_the_staged_asides_mtime_so_the_gc_backstop_cannot_reap_it_during_the_copy_back(): void
+    {
+        $mgr  = $this->manager();
+        $live = $this->root . '/plugins-src/demo7';
+        mkdir($live, 0755, true);
+        file_put_contents($live . '/marker.txt', 'GOOD-PRE-UPDATE-CONTENT');
+        $mgr->liveOverride = $live;
+
+        $snap = $mgr->capture('plugin', 'demo7/demo7.php', '1.0');
+        $this->assertNotSame('', $snap['snapshot_id']);
+        $asideName = $live . '.wpmgr-old-' . $snap['snapshot_id'];
+
+        // The LIVE directory's own mtime is already older than the GC
+        // backstop TTL (72h) BEFORE restore() ever runs — e.g. a plugin
+        // whose files simply have not changed recently. rename() (used to
+        // stage the aside) PRESERVES this old mtime, so without Fix 1's
+        // @touch() the aside would be "born" already past
+        // GC_BACKSTOP_TTL_SECONDS the instant it is carved out — eligible
+        // for sweepStrandedAsides() to reap it while this very restore() is
+        // still using it.
+        touch($live, time() - (73 * 3600));
+        clearstatcache(true, $live);
+
+        // Observe the aside's mtime at the exact moment restore()'s
+        // copy-back step (copyDir($payload, $live)) begins — this is the
+        // narrow window between staging the aside and the copy finishing
+        // (or failing) that Fix 1 protects.
+        $observedMtime = null;
+        $mgr->onCopyDir = function () use ($asideName, &$observedMtime): void {
+            $observedMtime = @filemtime($asideName);
+        };
+
+        $result = $mgr->restore('plugin', 'demo7/demo7.php', $snap['snapshot_id']);
+
+        $this->assertTrue($result['ok'], 'precondition: the happy-path restore must still succeed: ' . $result['log']);
+        $this->assertNotNull($observedMtime, 'precondition: the aside must already exist when the copy-back step starts');
+        $this->assertGreaterThanOrEqual(
+            time() - 5,
+            $observedMtime,
+            'Fix 1: restore() must stamp the staged aside\'s mtime to staging time (not inherit the old live-dir mtime via rename()), so sweepStrandedAsides()\'s age-based GC gives it the full 72h grace period even if interrupted right after staging'
+        );
+    }
+
+    public function test_a_freshly_staged_restore_aside_survives_a_gc_backstop_tick_mid_copy_even_when_the_live_dir_was_already_old(): void
+    {
+        // End-to-end variant of the mtime test above, exercised through the
+        // ACTUAL GC backstop sweep (gcExpired() -> sweepStrandedAsides()),
+        // using the same static-property seam as managerClassWithPluginRoot()
+        // so gcExpired()'s internal `new static()` instance (see gcExpired()'s
+        // doc) resolves the same stranded-aside root this test stages into.
+        //
+        // The copy-back is forced to FAIL so restore() must roll back to the
+        // staged aside — this is what actually proves the fix: without it,
+        // a GC tick landing mid-copy deletes the aside out from under the
+        // in-progress restore(), and the subsequent rollback attempt finds
+        // nothing to roll back to (data loss); with the fix, the aside's
+        // mtime was stamped fresh at staging time, so the very same GC tick
+        // leaves it alone and the rollback succeeds.
+        $class = new class extends SnapshotManager {
+            public static string $testPluginsRoot = '';
+            public string $liveOverride            = '';
+            public bool $failCopy                  = false;
+
+            /** @var (callable(): void)|null */
+            public $onCopyDir = null;
+
+            protected function liveDir(string $type, string $slug): string
+            {
+                return $this->liveOverride;
+            }
+
+            protected function copyDir(string $src, string $dst): bool
+            {
+                if ($this->onCopyDir !== null) {
+                    ($this->onCopyDir)();
+                }
+
+                if ($this->failCopy) {
+                    // Mirror copyDir()'s real first step (mkdir the
+                    // destination) even though the copy is about to fail —
+                    // the S5 precondition (see manager()'s helper above).
+                    if (!is_dir($dst)) {
+                        mkdir($dst, 0755, true);
+                    }
+                    return false;
+                }
+
+                return parent::copyDir($src, $dst);
+            }
+
+            protected function strandedAsideRoots(): array
+            {
+                return [self::$testPluginsRoot];
+            }
+        };
+
+        $pluginsRoot = $this->root . '/plugins-root3';
+        mkdir($pluginsRoot, 0755, true);
+        $class::$testPluginsRoot = $pluginsRoot;
+
+        $live = $pluginsRoot . '/demo8';
+        mkdir($live, 0755, true);
+        file_put_contents($live . '/marker.txt', 'SNAPSHOT-CONTENT');
+
+        $mgr               = new $class();
+        $mgr->liveOverride = $live;
+
+        $snap = $mgr->capture('plugin', 'demo8/demo8.php', '1.0');
+        $this->assertNotSame('', $snap['snapshot_id']);
+
+        // Mutate live to the pre-restore-attempt state, and age the
+        // directory past the GC backstop TTL BEFORE restore() ever runs —
+        // rename() (used to stage the aside) preserves this age onto the
+        // aside it carves out.
+        file_put_contents($live . '/marker.txt', 'PRE-RESTORE-ATTEMPT-CONTENT');
+        touch($live, time() - (73 * 3600));
+        clearstatcache(true, $live);
+
+        // Run the GC backstop from INSIDE the copy-back step — the exact
+        // "restore in progress" window — before the (forced) copy failure
+        // is even reported back to restore().
+        $mgr->failCopy  = true;
+        $mgr->onCopyDir = static function () use ($class): void {
+            $class::gcExpired();
+        };
+
+        $result = $mgr->restore('plugin', 'demo8/demo8.php', $snap['snapshot_id']);
+
+        $this->assertFalse($result['ok']);
+        $this->assertTrue(is_dir($live), 'the live directory must exist again — never left missing');
+        $this->assertSame(
+            'PRE-RESTORE-ATTEMPT-CONTENT',
+            file_get_contents($live . '/marker.txt'),
+            'Fix 1: a GC backstop tick landing mid-copy must never reap the staged aside — the rollback must still find it and restore the pre-restore-attempt state, not report "no pre-existing directory to roll back to"'
+        );
+        $this->assertStringContainsString('rolled back to the pre-restore original', $result['log']);
+    }
+
+    // =========================================================================
+    // S5 — restore()'s rollback-on-copy-failure
+    // =========================================================================
+
+    public function test_restore_rolls_back_to_the_pre_restore_state_when_copy_fails_mid_write(): void
+    {
+        $mgr  = $this->manager();
+        $live = $this->root . '/plugins-src/demo2';
+        mkdir($live, 0755, true);
+        file_put_contents($live . '/marker.txt', 'SNAPSHOT-CONTENT');
+        $mgr->liveOverride = $live;
+
+        // Capture while marker.txt still holds the "good" content.
+        $snap = $mgr->capture('plugin', 'demo2/demo2.php', '1.0');
+        $this->assertNotSame('', $snap['snapshot_id']);
+
+        // Mutate live to whatever is on disk right BEFORE the restore() call
+        // under test — this is the state a correctly-fixed failed restore
+        // must roll back TO.
+        file_put_contents($live . '/marker.txt', 'PRE-RESTORE-ATTEMPT-CONTENT');
+        $mgr->failCopy = true;
+
+        $result = $mgr->restore('plugin', 'demo2/demo2.php', $snap['snapshot_id']);
+
+        $this->assertFalse($result['ok']);
+        $this->assertTrue(is_dir($live), 'S5: the live directory must exist again — never left missing');
+        $this->assertSame(
+            'PRE-RESTORE-ATTEMPT-CONTENT',
+            file_get_contents($live . '/marker.txt'),
+            'S5: a mid-copy restore failure must roll back to the state that existed right before the restore attempt, not strand it aside nor leave a half-written directory'
+        );
+        $this->assertFalse(
+            is_dir($live . '.wpmgr-old-' . $snap['snapshot_id']),
+            'S5: the set-aside copy must be renamed back, not left stranded forever'
+        );
+        $this->assertStringContainsString('rolled back to the pre-restore original', $result['log']);
+    }
+
+    public function test_restore_reports_no_original_when_live_did_not_exist_before_the_attempt(): void
+    {
+        $mgr  = $this->manager();
+        $live = $this->root . '/plugins-src/demo3';
+        mkdir($live, 0755, true);
+        file_put_contents($live . '/marker.txt', 'v1');
+        $mgr->liveOverride = $live;
+
+        $snap = $mgr->capture('plugin', 'demo3/demo3.php', '1.0');
+        $this->assertNotSame('', $snap['snapshot_id']);
+
+        // Live directory removed entirely before the restore attempt begins
+        // — there is nothing for restore() to have moved aside.
+        $this->rrmdir($live);
+        $this->assertFalse(is_dir($live));
+
+        $mgr->failCopy = true;
+        $result = $mgr->restore('plugin', 'demo3/demo3.php', $snap['snapshot_id']);
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('no pre-existing directory to roll back to', $result['log']);
+    }
+
+    public function test_restore_succeeds_and_removes_the_set_aside_copy_on_the_happy_path(): void
+    {
+        $mgr  = $this->manager();
+        $live = $this->root . '/plugins-src/demo4';
+        mkdir($live, 0755, true);
+        file_put_contents($live . '/marker.txt', 'v1');
+        $mgr->liveOverride = $live;
+
+        $snap = $mgr->capture('plugin', 'demo4/demo4.php', '1.0');
+        $this->assertNotSame('', $snap['snapshot_id']);
+
+        // Simulate the "current" (post-update) live state.
+        file_put_contents($live . '/marker.txt', 'v2');
+
+        $result = $mgr->restore('plugin', 'demo4/demo4.php', $snap['snapshot_id']);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame('v1', file_get_contents($live . '/marker.txt'));
+        $this->assertFalse(is_dir($live . '.wpmgr-old-' . $snap['snapshot_id']));
+    }
+}

--- a/apps/agent/tests/UpdateCommandTest.php
+++ b/apps/agent/tests/UpdateCommandTest.php
@@ -14,6 +14,7 @@ use Brain\Monkey;
 use Brain\Monkey\Functions;
 use WPMgr\Agent\Commands\UpdateCommand;
 use WPMgr\Agent\Support\SnapshotManager;
+use WPMgr\Agent\Support\UpdateInFlight;
 use WPMgr\Agent\Support\UpdateRunner;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
@@ -65,6 +66,15 @@ final class UpdateCommandTest extends TestCase
             public array $installedOverride = [];
             /** Whether apply() should report success. */
             public bool $applySucceeds = true;
+            /**
+             * @var array<string,bool> Explicit isComplete() overrides, keyed
+             *     "type:slug". Absent = complete (true) — matches the
+             *     production fail-open default so tests that don't care about
+             *     the completeness check are unaffected.
+             */
+            public array $completeOverride = [];
+            /** @var array<int,array{string,string}> Args of each isComplete() call. */
+            public array $completeChecked = [];
 
             public function currentVersion(string $type, string $slug): string
             {
@@ -111,23 +121,52 @@ final class UpdateCommandTest extends TestCase
             {
                 return false;
             }
+
+            public function isComplete(string $type, string $slug): bool
+            {
+                $this->completeChecked[] = [$type, $slug];
+
+                return $this->completeOverride[$type . ':' . $slug] ?? true;
+            }
         };
     }
 
     /**
-     * A snapshot spy that records captures without writing to disk.
+     * A snapshot spy that records captures/restores without touching disk.
      */
     private function spySnapshots(): SnapshotManager
     {
         return new class extends SnapshotManager {
             /** @var array<int,array{string,string,string}> */
             public array $captured = [];
+            /** @var array<int,array{string,string,string}> Args of each restore() call. */
+            public array $restored = [];
+            /** Whether restore() should report success. */
+            public bool $restoreSucceeds = true;
 
             public function capture(string $type, string $slug, string $fromVersion): array
             {
                 $this->captured[] = [$type, $slug, $fromVersion];
 
                 return ['snapshot_id' => 'snap_test123', 'log' => 'captured'];
+            }
+
+            public function restore(string $type, string $slug, string $snapshotId): array
+            {
+                $this->restored[] = [$type, $slug, $snapshotId];
+
+                return $this->restoreSucceeds
+                    ? ['ok' => true, 'log' => 'restored']
+                    : ['ok' => false, 'log' => 'restore failed'];
+            }
+
+            public function snapshotExists(string $snapshotId): bool
+            {
+                // F2 (issue #131 final-hardening review) — these tests exercise
+                // the restore DECISION via the runner spy's completeOverride;
+                // always report the snapshot present so that gate never blocks
+                // a restore this test otherwise expects.
+                return true;
             }
         };
     }
@@ -563,5 +602,768 @@ final class UpdateCommandTest extends TestCase
             $this->maintenanceFile,
             'a fresh flag may belong to another in-flight update/rollback and must not be deleted'
         );
+    }
+
+    // ---- forced snapshot + auto-restore on incomplete apply (GitHub issue #131, D2/D3) ----
+
+    /**
+     * A runner spy whose apply() ALWAYS throws — mirrors a resource kill
+     * severe enough that install_package()/copy_dir() never returns.
+     */
+    private function spyRunnerThatThrowsOnApply(): UpdateRunner
+    {
+        return new class extends UpdateRunner {
+            public function currentVersion(string $type, string $slug): string
+            {
+                return '5.0';
+            }
+
+            public function isInstalled(string $type, string $slug): bool
+            {
+                return true;
+            }
+
+            public function availableVersion(string $type, string $slug, string $requested): string
+            {
+                return '5.3';
+            }
+
+            public function apply(string $type, string $slug, string $version): array
+            {
+                throw new \RuntimeException('simulated mid-copy resource kill');
+            }
+
+            public function wpCliAvailable(): bool
+            {
+                return false;
+            }
+        };
+    }
+
+    public function test_plugin_snapshot_is_captured_even_without_the_request_snapshot_flag(): void
+    {
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php']   = '5.0';
+        $runner->available['plugin:akismet/akismet.php']  = '5.3';
+
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            // 'snapshot' deliberately omitted (defaults false).
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $this->assertSame('succeeded', $out['results'][0]['status']);
+        $this->assertCount(
+            1,
+            $snapshots->captured,
+            'plugin/theme items must always snapshot before applying (D2), regardless of the request flag'
+        );
+    }
+
+    public function test_core_snapshot_still_respects_the_request_flag(): void
+    {
+        $runner = $this->spyRunner();
+        $runner->versions['core:core']  = '6.4';
+        $runner->available['core:core'] = '6.5';
+
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            // 'snapshot' omitted (defaults false) — core must NOT snapshot.
+            'items' => [['type' => 'core', 'slug' => '', 'version' => 'latest']],
+        ]);
+
+        $this->assertSame('succeeded', $out['results'][0]['status']);
+        $this->assertSame(
+            [],
+            $snapshots->captured,
+            'core keeps the original opt-in snapshot behavior (D3) — only plugin/theme are forced'
+        );
+    }
+
+    public function test_ok_false_apply_triggers_auto_restore_and_reports_failed(): void
+    {
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php']  = '5.0';
+        $runner->available['plugin:akismet/akismet.php'] = '5.3';
+        $runner->applySucceeds                           = false;
+
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $r = $out['results'][0];
+        $this->assertSame('failed', $r['status']);
+        $this->assertFalse($out['ok']);
+        $this->assertCount(1, $snapshots->restored, 'an ok:false apply must trigger an auto-restore');
+        $this->assertSame(['plugin', 'akismet/akismet.php', 'snap_test123'], $snapshots->restored[0]);
+    }
+
+    public function test_apply_throwing_fires_the_guard_and_restores(): void
+    {
+        $runner    = $this->spyRunnerThatThrowsOnApply();
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => '5.3']],
+        ]);
+
+        $this->assertSame('failed', $out['results'][0]['status']);
+        $this->assertCount(
+            1,
+            $snapshots->restored,
+            'a thrown apply() must still trigger the same restore path the shutdown guard uses'
+        );
+        $this->assertSame(['plugin', 'akismet/akismet.php', 'snap_test123'], $snapshots->restored[0]);
+    }
+
+    public function test_half_write_detected_by_completeness_check_is_restored_and_reported_failed(): void
+    {
+        // Mirrors the reported incident exactly: apply() bumps the version
+        // (the main plugin file WAS replaced) but the rest of the directory
+        // is missing, so the completeness check must catch what the old
+        // version-header-only test would have reported as 'succeeded'.
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:kadence-blocks/kadence-blocks.php']  = '3.2.0';
+        $runner->available['plugin:kadence-blocks/kadence-blocks.php'] = '3.2.1';
+        $runner->completeOverride['plugin:kadence-blocks/kadence-blocks.php'] = false;
+
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'kadence-blocks/kadence-blocks.php', 'version' => 'latest']],
+        ]);
+
+        $r = $out['results'][0];
+        $this->assertSame(
+            'failed',
+            $r['status'],
+            'a version bump alone must never be reported as succeeded when the completeness check fails'
+        );
+        $this->assertCount(1, $runner->completeChecked, 'the completeness check must run for an ok:true apply');
+        $this->assertCount(1, $snapshots->restored, 'a half-written apply must be auto-restored');
+    }
+
+    public function test_verified_good_apply_is_never_rolled_back(): void
+    {
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php']  = '5.0';
+        $runner->available['plugin:akismet/akismet.php'] = '5.3';
+        // completeOverride left unset => the spy's default (true), the same
+        // fail-open default UpdateRunner::isComplete() itself uses.
+
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $r = $out['results'][0];
+        $this->assertSame('succeeded', $r['status']);
+        $this->assertCount(1, $snapshots->captured, 'a snapshot is still taken up front (D2)');
+        $this->assertSame(
+            [],
+            $snapshots->restored,
+            'a genuinely good, verified-complete apply must never be rolled back — guard against false-rollback'
+        );
+    }
+
+    public function test_core_apply_failure_never_attempts_a_directory_restore(): void
+    {
+        // D3: core has no directory-level rollback here at all — even with
+        // snapshot=true (which only records the prior version for
+        // RollbackCommand's downgrade-by-version), a failed core apply must
+        // never call SnapshotManager::restore().
+        $runner = $this->spyRunner();
+        $runner->versions['core:core']  = '6.4';
+        $runner->available['core:core'] = '6.5';
+        $runner->applySucceeds          = false;
+
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'snapshot' => true,
+            'items'    => [['type' => 'core', 'slug' => '', 'version' => 'latest']],
+        ]);
+
+        $this->assertSame('failed', $out['results'][0]['status']);
+        $this->assertSame(
+            [],
+            $snapshots->restored,
+            'core relies on B1 (resource guard) + Core_Upgrader temp-backup, never a directory restore (D3)'
+        );
+    }
+
+    // ---- S8: unprotected-apply refusal on a failed snapshot capture (GitHub issue #131 adversarial review) ----
+
+    public function test_snapshot_capture_failure_refuses_the_apply_for_plugin_theme(): void
+    {
+        // S8 — a plugin/theme item whose pre-update snapshot capture FAILED
+        // must never fall through to an UNGUARDED apply(): no UpdateGuard
+        // armed, no in-flight marker, nothing to roll back to. execute()
+        // must refuse the item outright rather than attempt the apply.
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php']  = '5.0';
+        $runner->available['plugin:akismet/akismet.php'] = '5.3';
+
+        $snapshots = new class extends SnapshotManager {
+            /** @var array<int,array{string,string,string}> */
+            public array $restored = [];
+
+            public function capture(string $type, string $slug, string $fromVersion): array
+            {
+                return ['snapshot_id' => '', 'log' => 'Source directory not found; proceeding without snapshot.'];
+            }
+
+            public function restore(string $type, string $slug, string $snapshotId): array
+            {
+                $this->restored[] = [$type, $slug, $snapshotId];
+
+                return ['ok' => false, 'log' => 'unreachable'];
+            }
+        };
+        $cmd = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $r = $out['results'][0];
+        $this->assertSame('failed', $r['status']);
+        $this->assertStringContainsString('refusing to apply unprotected', $r['log']);
+        $this->assertSame(
+            [],
+            $runner->applied,
+            'S8: a snapshot capture failure must refuse the item outright — apply() must never be invoked unguarded'
+        );
+        $this->assertSame(
+            [],
+            $snapshots->restored,
+            'without a captured snapshot id there is nothing to restore from — the guard must never arm'
+        );
+    }
+
+    public function test_core_apply_proceeds_even_when_its_opt_in_snapshot_capture_fails(): void
+    {
+        // D3 exemption: core has no directory-level snapshot/restore
+        // protection by design, so S8's refusal must be scoped to
+        // plugin/theme only — a core snapshot capture failure (only
+        // reachable when `snapshot=true` was requested) must never block a
+        // core apply that never depended on it.
+        $runner = $this->spyRunner();
+        $runner->versions['core:core']  = '6.4';
+        $runner->available['core:core'] = '6.5';
+
+        $snapshots = new class extends SnapshotManager {
+            public function capture(string $type, string $slug, string $fromVersion): array
+            {
+                return ['snapshot_id' => '', 'log' => 'Snapshot store unavailable; proceeding without snapshot.'];
+            }
+        };
+        $cmd = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'snapshot' => true,
+            'items'    => [['type' => 'core', 'slug' => '', 'version' => 'latest']],
+        ]);
+
+        $this->assertSame('succeeded', $out['results'][0]['status']);
+        $this->assertCount(
+            1,
+            $runner->applied,
+            'S8: core must proceed to apply even when its opt-in snapshot capture fails (D3 exemption)'
+        );
+    }
+
+    // ---- S7: a THROW during post-apply verification must never false-rollback a good update ----
+
+    /**
+     * A runner spy whose currentVersion() returns the FROM version on its
+     * first call (the read at the top of processItem()) and then THROWS on
+     * every subsequent call — i.e. the post-apply re-read blows up.
+     */
+    private function spyRunnerThrowsOnSecondVersionRead(): UpdateRunner
+    {
+        return new class extends UpdateRunner {
+            public array $applied = [];
+            private int $versionCalls = 0;
+
+            public function isInstalled(string $type, string $slug): bool
+            {
+                return true;
+            }
+
+            public function availableVersion(string $type, string $slug, string $requested): string
+            {
+                return '5.3';
+            }
+
+            public function currentVersion(string $type, string $slug): string
+            {
+                $this->versionCalls++;
+                if ($this->versionCalls >= 2) {
+                    throw new \RuntimeException('simulated post-apply verification blow-up');
+                }
+
+                return '5.0';
+            }
+
+            public function apply(string $type, string $slug, string $version): array
+            {
+                $this->applied[] = [$type, $slug, $version];
+
+                return ['ok' => true, 'log' => 'applied'];
+            }
+
+            public function isComplete(string $type, string $slug): bool
+            {
+                return true;
+            }
+
+            public function wpCliAvailable(): bool
+            {
+                return false;
+            }
+        };
+    }
+
+    /**
+     * A runner spy whose apply() succeeds and currentVersion() correctly
+     * reports the bump, but isComplete() itself THROWS.
+     */
+    private function spyRunnerThrowsOnIsComplete(): UpdateRunner
+    {
+        return new class extends UpdateRunner {
+            public array $applied = [];
+            private int $versionCalls = 0;
+
+            public function isInstalled(string $type, string $slug): bool
+            {
+                return true;
+            }
+
+            public function availableVersion(string $type, string $slug, string $requested): string
+            {
+                return '5.3';
+            }
+
+            public function currentVersion(string $type, string $slug): string
+            {
+                $this->versionCalls++;
+
+                return $this->versionCalls === 1 ? '5.0' : '5.3';
+            }
+
+            public function apply(string $type, string $slug, string $version): array
+            {
+                $this->applied[] = [$type, $slug, $version];
+
+                return ['ok' => true, 'log' => 'applied'];
+            }
+
+            public function isComplete(string $type, string $slug): bool
+            {
+                throw new \RuntimeException('simulated isComplete() blow-up');
+            }
+
+            public function wpCliAvailable(): bool
+            {
+                return false;
+            }
+        };
+    }
+
+    public function test_iscomplete_throw_after_a_good_apply_keeps_the_update_succeeded_not_rolled_back(): void
+    {
+        $runner    = $this->spyRunnerThrowsOnIsComplete();
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $r = $out['results'][0];
+        $this->assertSame(
+            'succeeded',
+            $r['status'],
+            'S7: isComplete() throwing must be treated as inconclusive, not incomplete — the update is KEPT'
+        );
+        $this->assertSame('5.3', $r['to_version']);
+        $this->assertSame([], $snapshots->restored, 'S7: a throw during verification must never trigger a restore');
+        $this->assertStringContainsString('KEPT', $r['log']);
+    }
+
+    public function test_currentversion_throw_after_a_good_apply_never_triggers_a_false_rollback(): void
+    {
+        $runner    = $this->spyRunnerThrowsOnSecondVersionRead();
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $r = $out['results'][0];
+        // The exact reported status is secondary here — the post-apply
+        // version could not be re-read at all, so it conservatively falls
+        // back to from_version. The CONTRACT S7 guards is that a
+        // verification throw must NEVER be treated as an affirmative
+        // "incomplete" result and must NEVER trigger a restore of a
+        // genuinely good apply.
+        $this->assertNotSame('failed', $r['status']);
+        $this->assertSame([], $snapshots->restored, 'S7: a throw during verification must never trigger a restore');
+        $this->assertStringContainsString('KEPT', $r['log']);
+    }
+
+    public function test_verification_throw_after_a_genuinely_failed_apply_still_proceeds_to_restore(): void
+    {
+        // S7 must not be exploitable to KEEP a genuinely bad apply: when
+        // applied['ok'] is already false, a throw while trying to re-read
+        // the resulting version must still fall through to the normal
+        // incomplete/failed/restore path, not be upgraded to "complete".
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php']  = '5.0';
+        $runner->available['plugin:akismet/akismet.php'] = '5.3';
+        $runner->applySucceeds                           = false;
+
+        $throwingRunner = new class ($runner) extends UpdateRunner {
+            public function __construct(private UpdateRunner $inner)
+            {
+            }
+
+            public function isInstalled(string $type, string $slug): bool
+            {
+                return $this->inner->isInstalled($type, $slug);
+            }
+
+            public function availableVersion(string $type, string $slug, string $requested): string
+            {
+                return $this->inner->availableVersion($type, $slug, $requested);
+            }
+
+            public function apply(string $type, string $slug, string $version): array
+            {
+                return $this->inner->apply($type, $slug, $version);
+            }
+
+            public function currentVersion(string $type, string $slug): string
+            {
+                static $calls = 0;
+                $calls++;
+                if ($calls >= 2) {
+                    throw new \RuntimeException('simulated post-apply verification blow-up');
+                }
+
+                return $this->inner->currentVersion($type, $slug);
+            }
+
+            public function wpCliAvailable(): bool
+            {
+                return false;
+            }
+        };
+
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $throwingRunner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $r = $out['results'][0];
+        $this->assertSame(
+            'failed',
+            $r['status'],
+            'S7 must not mask a genuine upgrader failure: a throw AFTER an already-failed apply must still restore'
+        );
+        $this->assertCount(1, $snapshots->restored, 'a genuinely failed apply must still be auto-restored despite the verification throw');
+    }
+
+    // ---- S4: bounded apply time limit + out-of-band in-flight reconcile (GitHub issue #131 adversarial review) ----
+
+    public function test_apply_time_limit_is_bounded_not_infinite(): void
+    {
+        // The original bug (set_time_limit(0), infinite) is exactly what
+        // made the shutdown guard non-functional for an FPM hard-kill; the
+        // fix must set a finite, generous bound instead.
+        $seenLimit = null;
+        Functions\expect('set_time_limit')
+            ->once()
+            ->andReturnUsing(function (int $seconds) use (&$seenLimit): bool {
+                $seenLimit = $seconds;
+
+                return true;
+            });
+
+        $runner = $this->spyRunner();
+        $cmd    = new UpdateCommand($this->spySnapshots(), $runner);
+
+        $cmd->execute([], ['items' => []]);
+
+        $this->assertSame(900, $seenLimit, 'S4: the apply time limit must be bounded (900s), not infinite (0)');
+    }
+
+    public function test_stale_update_in_flight_marker_is_reconciled_at_the_start_of_a_fresh_run(): void
+    {
+        $tmp = sys_get_temp_dir() . '/wpmgr-s4-heal-' . bin2hex(random_bytes(6));
+        mkdir($tmp, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $tmp]);
+
+        UpdateInFlight::mark('plugin', 'ghost/ghost.php', 'snap_ghost');
+
+        // Age the marker well past the staleness threshold (1200s) so it is
+        // treated as orphaned by a prior hard-killed request, not a
+        // currently-running apply.
+        $markerFiles = glob($tmp . '/wpmgr-update-inflight/*.json') ?: [];
+        $this->assertCount(1, $markerFiles, 'precondition: mark() must have written exactly one marker file');
+        $data = json_decode((string) file_get_contents($markerFiles[0]), true);
+        $data['ts'] = time() - 1300;
+        file_put_contents($markerFiles[0], (string) json_encode($data));
+
+        $snapshots = $this->spySnapshots();
+        $runner    = $this->spyRunner();
+        // F2 (final-hardening review) — the reconcile only restores when the
+        // live directory is verified genuinely INCOMPLETE; this test's
+        // scenario (a hard-killed apply that never finished) is exactly that.
+        $runner->completeOverride['plugin:ghost/ghost.php'] = false;
+        $cmd = new UpdateCommand($snapshots, $runner);
+
+        // No items in THIS request — isolates the start-of-run reconcile
+        // from any per-item mark()/clear() this run might otherwise do.
+        $cmd->execute([], ['items' => []]);
+
+        $this->assertSame(
+            [['plugin', 'ghost/ghost.php', 'snap_ghost']],
+            $snapshots->restored,
+            'S4: a stale in-flight marker over a genuinely incomplete live directory must be auto-restored at the start of the next update command'
+        );
+        $this->assertCount(
+            0,
+            glob($tmp . '/wpmgr-update-inflight/*.json') ?: [],
+            'S4: a reconciled marker must be cleared so it is never reconciled twice'
+        );
+
+        $this->rrmdir($tmp);
+    }
+
+    public function test_stale_marker_over_a_complete_live_directory_is_cleared_without_restoring(): void
+    {
+        // F2 (issue #131 final-hardening review) — a marker can legitimately
+        // survive to the start of the NEXT run even for a SUCCESSFUL update
+        // (a kill landing in the old markClean()-to-`finally` window, now
+        // closed at the source — this integration test exercises the
+        // defense-in-depth backstop regardless). The live directory here is
+        // verified COMPLETE, so the reconcile must clear the marker WITHOUT
+        // ever calling restore() — blindly restoring here would revert a
+        // perfectly good, already-finished update.
+        $tmp = sys_get_temp_dir() . '/wpmgr-f2-healthy-' . bin2hex(random_bytes(6));
+        mkdir($tmp, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $tmp]);
+
+        UpdateInFlight::mark('plugin', 'healthy/healthy.php', 'snap_healthy');
+
+        $markerFiles = glob($tmp . '/wpmgr-update-inflight/*.json') ?: [];
+        $this->assertCount(1, $markerFiles, 'precondition: mark() must have written exactly one marker file');
+        $data = json_decode((string) file_get_contents($markerFiles[0]), true);
+        $data['ts'] = time() - 1300;
+        file_put_contents($markerFiles[0], (string) json_encode($data));
+
+        $snapshots = $this->spySnapshots();
+        $runner    = $this->spyRunner();
+        // Default completeOverride is TRUE (healthy) — see spyRunner()'s doc.
+        $cmd = new UpdateCommand($snapshots, $runner);
+
+        $cmd->execute([], ['items' => []]);
+
+        $this->assertSame(
+            [],
+            $snapshots->restored,
+            'F2: a stale marker over an already-healthy/complete live directory must NEVER trigger a restore'
+        );
+        $this->assertCount(
+            0,
+            glob($tmp . '/wpmgr-update-inflight/*.json') ?: [],
+            'F2: the marker must still be cleared even though no restore happened'
+        );
+
+        $this->rrmdir($tmp);
+    }
+
+    public function test_fresh_update_in_flight_marker_is_not_touched_by_the_reconcile(): void
+    {
+        $tmp = sys_get_temp_dir() . '/wpmgr-s4-fresh-' . bin2hex(random_bytes(6));
+        mkdir($tmp, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $tmp]);
+
+        // Freshly written — well under the staleness threshold. May belong
+        // to a still-running apply and must be left alone.
+        UpdateInFlight::mark('plugin', 'busy/busy.php', 'snap_busy');
+
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $this->spyRunner());
+
+        $cmd->execute([], ['items' => []]);
+
+        $this->assertSame(
+            [],
+            $snapshots->restored,
+            'S4: a fresh in-flight marker may belong to a still-running apply and must never be reconciled'
+        );
+        $this->assertCount(
+            1,
+            glob($tmp . '/wpmgr-update-inflight/*.json') ?: [],
+            'a fresh marker must not be removed either'
+        );
+
+        $this->rrmdir($tmp);
+    }
+
+    // ---- C: opportunistic snapshot-store GC (issue #131 final-hardening review) ----
+
+    public function test_snapshot_gc_backstop_runs_opportunistically_at_the_start_of_every_update_command(): void
+    {
+        $tmp = sys_get_temp_dir() . '/wpmgr-c-gc-' . bin2hex(random_bytes(6));
+        mkdir($tmp, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $tmp]);
+
+        $snapshotsBase = $tmp . '/wpmgr-snapshots';
+        mkdir($snapshotsBase, 0755, true);
+
+        // An orphaned snapshot well past the 72h GC backstop TTL — the exact
+        // class of orphan SnapshotManager::gcExpired() exists to reclaim
+        // (e.g. a since-uninstalled/renamed slug that will never again
+        // trigger the per-slug prune-at-capture path for itself). WP-Cron is
+        // unreliable on DISABLE_WP_CRON/dormant sites, so this must ALSO run
+        // opportunistically here, not cron-only.
+        $orphan = $snapshotsBase . '/snap_' . bin2hex(random_bytes(12));
+        mkdir($orphan, 0755, true);
+        file_put_contents($orphan . '/meta.json', (string) json_encode([
+            'type'         => 'plugin',
+            'slug'         => 'long-gone/long-gone.php',
+            'from_version' => '1.0',
+            'created_at'   => time() - (73 * 3600),
+        ]));
+
+        $cmd = new UpdateCommand($this->spySnapshots(), $this->spyRunner());
+
+        // No items in THIS request — isolates the opportunistic GC call from
+        // any per-item capture()/restore() this run might otherwise do.
+        $cmd->execute([], ['items' => []]);
+
+        $this->assertFalse(
+            is_dir($orphan),
+            'C: SnapshotManager::gcExpired() must run opportunistically at the start of every `update` command, not cron-only'
+        );
+
+        $this->rrmdir($tmp);
+    }
+
+    public function test_in_flight_marker_is_written_before_apply_and_cleared_after_a_synchronous_success(): void
+    {
+        $tmp = sys_get_temp_dir() . '/wpmgr-s4-lifecycle-' . bin2hex(random_bytes(6));
+        mkdir($tmp, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $tmp]);
+
+        $markerDir = $tmp . '/wpmgr-update-inflight';
+
+        // A runner whose apply() inspects the filesystem to prove the marker
+        // was written BEFORE apply() is invoked.
+        $runner = new class ($markerDir) extends UpdateRunner {
+            public bool $markerPresentDuringApply = false;
+            private bool $applied                 = false;
+
+            public function __construct(private string $markerDir)
+            {
+            }
+
+            public function isInstalled(string $type, string $slug): bool
+            {
+                return true;
+            }
+
+            public function currentVersion(string $type, string $slug): string
+            {
+                return $this->applied ? '5.3' : '5.0';
+            }
+
+            public function availableVersion(string $type, string $slug, string $requested): string
+            {
+                return '5.3';
+            }
+
+            public function apply(string $type, string $slug, string $version): array
+            {
+                $files = glob($this->markerDir . '/*.json') ?: [];
+                $this->markerPresentDuringApply = count($files) === 1;
+                $this->applied                  = true;
+
+                return ['ok' => true, 'log' => 'applied'];
+            }
+
+            public function isComplete(string $type, string $slug): bool
+            {
+                return true;
+            }
+
+            public function wpCliAvailable(): bool
+            {
+                return false;
+            }
+        };
+
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $this->assertTrue(
+            $runner->markerPresentDuringApply,
+            'S4: the in-flight marker must be written BEFORE apply() is invoked'
+        );
+        $this->assertSame('succeeded', $out['results'][0]['status']);
+        $this->assertCount(
+            0,
+            glob($markerDir . '/*.json') ?: [],
+            'S4: a synchronously successful item must clear its own in-flight marker before returning'
+        );
+
+        $this->rrmdir($tmp);
+    }
+
+    /** Recursive delete used only for test fixture cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
     }
 }

--- a/apps/agent/tests/UpdateGuardTest.php
+++ b/apps/agent/tests/UpdateGuardTest.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * UpdateGuardTest — direct unit coverage of WPMgr\Agent\Support\UpdateGuard,
+ * focused on the F2 fix (issue #131 final-hardening review): markClean() must
+ * ALSO clear this item's UpdateInFlight out-of-band reconcile marker
+ * immediately, closing the narrow window between "apply confirmed good" and
+ * UpdateCommand::processItem()'s own `finally` (where UpdateInFlight::clear()
+ * was previously the ONLY place a marker was ever removed on a success path).
+ *
+ * The arm()/fire()/idempotency lifecycle itself is exercised end-to-end via
+ * UpdateCommandTest.php's integration tests; this file isolates markClean()'s
+ * NEW side effect.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Support\SnapshotManager;
+use WPMgr\Agent\Support\UpdateGuard;
+use WPMgr\Agent\Support\UpdateInFlight;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\UpdateGuard
+ */
+final class UpdateGuardTest extends TestCase
+{
+    /** Temp root for this test run (removed in tear_down). */
+    private string $root = '';
+
+    /** Simulated wp-content/uploads dir. */
+    private string $uploadsDir = '';
+
+    /** UpdateInFlight marker store under $uploadsDir. */
+    private string $storeDir = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->root       = sys_get_temp_dir() . '/wpmgr-guard-' . bin2hex(random_bytes(6));
+        $this->uploadsDir = $this->root . '/uploads';
+        $this->storeDir   = $this->uploadsDir . '/wpmgr-update-inflight';
+        mkdir($this->uploadsDir, 0755, true);
+
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $this->uploadsDir]);
+    }
+
+    protected function tear_down(): void
+    {
+        $this->rrmdir($this->root);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /** Recursive delete used only for test fixture cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+
+    /** A SnapshotManager spy that records restore() calls without touching disk. */
+    private function spySnapshots(): SnapshotManager
+    {
+        return new class extends SnapshotManager {
+            /** @var array<int,array{string,string,string}> */
+            public array $restored = [];
+
+            public function restore(string $type, string $slug, string $snapshotId): array
+            {
+                $this->restored[] = [$type, $slug, $snapshotId];
+
+                return ['ok' => true, 'log' => 'restored'];
+            }
+        };
+    }
+
+    public function test_markClean_clears_this_items_update_inflight_marker_immediately(): void
+    {
+        $lock = UpdateInFlight::mark('plugin', 'foo/foo.php', 'snap_x');
+        $this->assertCount(1, glob($this->storeDir . '/*.json') ?: [], 'precondition: mark() wrote a marker');
+
+        $guard = new UpdateGuard($this->spySnapshots(), 'plugin', 'foo/foo.php', 'snap_x');
+        $guard->markClean();
+
+        $this->assertCount(
+            0,
+            glob($this->storeDir . '/*.json') ?: [],
+            'F2: markClean() must clear this type/slug\'s UpdateInFlight marker immediately, not wait for a later finally'
+        );
+
+        UpdateInFlight::release($lock);
+    }
+
+    public function test_markClean_is_a_safe_noop_when_no_marker_was_ever_written(): void
+    {
+        $guard = new UpdateGuard($this->spySnapshots(), 'plugin', 'never-marked/never-marked.php', 'snap_x');
+
+        // Must not throw or warn — clear() is a no-op when nothing matches.
+        $guard->markClean();
+
+        $this->assertCount(0, glob($this->storeDir . '/*.json') ?: []);
+    }
+
+    public function test_markClean_only_clears_the_marker_for_its_own_type_and_slug(): void
+    {
+        $lockA = UpdateInFlight::mark('plugin', 'foo/foo.php', 'snap_a');
+        $lockB = UpdateInFlight::mark('theme', 'bar', 'snap_b');
+        $this->assertCount(2, glob($this->storeDir . '/*.json') ?: []);
+
+        $guard = new UpdateGuard($this->spySnapshots(), 'plugin', 'foo/foo.php', 'snap_a');
+        $guard->markClean();
+
+        $this->assertCount(
+            1,
+            glob($this->storeDir . '/*.json') ?: [],
+            'markClean() must only clear ITS OWN type/slug marker, never an unrelated one'
+        );
+
+        UpdateInFlight::release($lockA);
+        UpdateInFlight::release($lockB);
+    }
+
+    public function test_fire_still_restores_when_never_marked_clean(): void
+    {
+        $snapshots = $this->spySnapshots();
+        $guard     = new UpdateGuard($snapshots, 'plugin', 'foo/foo.php', 'snap_x');
+
+        $result = $guard->fire();
+
+        $this->assertTrue($result['fired']);
+        $this->assertSame([['plugin', 'foo/foo.php', 'snap_x']], $snapshots->restored);
+    }
+
+    public function test_fire_is_a_noop_after_markClean(): void
+    {
+        $snapshots = $this->spySnapshots();
+        $guard     = new UpdateGuard($snapshots, 'plugin', 'foo/foo.php', 'snap_x');
+
+        $guard->markClean();
+        $result = $guard->fire();
+
+        $this->assertFalse($result['fired'], 'a verified-clean guard must never restore, even if fire() is later invoked');
+        $this->assertSame([], $snapshots->restored);
+    }
+
+    public function test_fire_is_idempotent(): void
+    {
+        $snapshots = $this->spySnapshots();
+        $guard     = new UpdateGuard($snapshots, 'plugin', 'foo/foo.php', 'snap_x');
+
+        $first  = $guard->fire();
+        $second = $guard->fire();
+
+        $this->assertTrue($first['fired']);
+        $this->assertFalse($second['fired'], 'a second fire() call must be a no-op, never a second restore');
+        $this->assertCount(1, $snapshots->restored);
+    }
+}

--- a/apps/agent/tests/UpdateInFlightTest.php
+++ b/apps/agent/tests/UpdateInFlightTest.php
@@ -1,0 +1,495 @@
+<?php
+/**
+ * UpdateInFlightTest — S4 (GitHub issue #131 adversarial review): the
+ * out-of-band reconcile for a plugin/theme apply hard-killed by PHP-FPM's
+ * `request_terminate_timeout` before UpdateGuard's own shutdown-function
+ * backstop could ever run. ALSO covers the final-hardening-review fixes
+ * layered on top of it:
+ *   - B: the flock() liveness lock mark() acquires/returns is the PRIMARY
+ *     signal healStaleIfPresent() uses to decide whether a marker's owning
+ *     apply is still genuinely running (skip) vs. safely reconcilable.
+ *   - F2: healStaleIfPresent() only ever restores when the live directory is
+ *     verified genuinely incomplete AND its referenced snapshot still
+ *     exists — never blindly on every stale marker.
+ *   - F5: the JSON marker filename is no longer derived from type/slug (see
+ *     test_repeated_mark_for_the_same_slug_leaves_exactly_one_marker for the
+ *     retry-overwrite semantics this preserves despite that).
+ *
+ * Covers the WPMgr\Agent\Support\UpdateInFlight class in isolation (the
+ * UpdateCommand integration — mark-before-apply, clear-in-finally, lock
+ * release, and the start-of-execute() reconcile call — is covered in
+ * UpdateCommandTest.php).
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Support\SnapshotManager;
+use WPMgr\Agent\Support\UpdateInFlight;
+use WPMgr\Agent\Support\UpdateRunner;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\UpdateInFlight
+ */
+final class UpdateInFlightTest extends TestCase
+{
+    /** Temp root for this test run (removed in tear_down). */
+    private string $root = '';
+
+    /** Simulated wp-content/uploads dir. */
+    private string $uploadsDir = '';
+
+    /** Marker store under $uploadsDir. */
+    private string $storeDir = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->root       = sys_get_temp_dir() . '/wpmgr-inflight-' . bin2hex(random_bytes(6));
+        $this->uploadsDir = $this->root . '/uploads';
+        $this->storeDir   = $this->uploadsDir . '/wpmgr-update-inflight';
+        mkdir($this->uploadsDir, 0755, true);
+
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $this->uploadsDir]);
+    }
+
+    protected function tear_down(): void
+    {
+        $this->rrmdir($this->root);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /** Recursive delete used only for test fixture cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+
+    /**
+     * A SnapshotManager spy that records restore() calls without touching
+     * disk. snapshotExists() always reports true — these tests exercise the
+     * restore DECISION itself (via the injected isComplete() verdict from
+     * healthOverrideRunner()); the snapshot-existence gate (F2) has its own
+     * dedicated test below with a purpose-built double.
+     */
+    private function spySnapshots(): SnapshotManager
+    {
+        return new class extends SnapshotManager {
+            /** @var array<int,array{string,string,string}> */
+            public array $restored = [];
+
+            public function restore(string $type, string $slug, string $snapshotId): array
+            {
+                $this->restored[] = [$type, $slug, $snapshotId];
+
+                return ['ok' => true, 'log' => 'restored'];
+            }
+
+            public function snapshotExists(string $snapshotId): bool
+            {
+                return true;
+            }
+        };
+    }
+
+    /**
+     * F2 (issue #131 final-hardening review) — an UpdateRunner double whose
+     * isComplete() reports a fixed, controllable health verdict, so tests can
+     * exercise both sides of healStaleIfPresent()'s verify-before-restore
+     * gate without depending on real get_plugins()/validate_plugin() stub
+     * state (which other test files in this suite may have already frozen
+     * process-wide).
+     */
+    private function healthOverrideRunner(bool $complete): UpdateRunner
+    {
+        return new class ($complete) extends UpdateRunner {
+            public function __construct(private bool $complete)
+            {
+            }
+
+            public function isComplete(string $type, string $slug): bool
+            {
+                return $this->complete;
+            }
+        };
+    }
+
+    /** Rewrite the sole marker file's `ts` field to simulate age. */
+    private function ageTheOnlyMarker(int $ts): void
+    {
+        $files = glob($this->storeDir . '/*.json') ?: [];
+        $this->assertCount(1, $files, 'precondition: exactly one marker file must exist');
+        $data = json_decode((string) file_get_contents($files[0]), true);
+        $data['ts'] = $ts;
+        file_put_contents($files[0], (string) json_encode($data));
+    }
+
+    // =========================================================================
+    // mark() / clear()
+    // =========================================================================
+
+    public function test_mark_then_clear_round_trip(): void
+    {
+        UpdateInFlight::mark('plugin', 'foo/foo.php', 'snap_abc');
+        $this->assertCount(1, glob($this->storeDir . '/*.json') ?: []);
+
+        UpdateInFlight::clear('plugin', 'foo/foo.php');
+        $this->assertCount(0, glob($this->storeDir . '/*.json') ?: []);
+    }
+
+    public function test_clear_is_a_safe_noop_when_nothing_was_ever_marked(): void
+    {
+        UpdateInFlight::clear('plugin', 'never-marked/never-marked.php');
+        $this->assertCount(0, glob($this->storeDir . '/*.json') ?: []);
+    }
+
+    public function test_mark_records_type_slug_and_snapshot_id(): void
+    {
+        UpdateInFlight::mark('theme', 'twentytwentyfour', 'snap_xyz');
+
+        $files = glob($this->storeDir . '/*.json') ?: [];
+        $this->assertCount(1, $files);
+        $data = json_decode((string) file_get_contents($files[0]), true);
+
+        $this->assertSame('theme', $data['type']);
+        $this->assertSame('twentytwentyfour', $data['slug']);
+        $this->assertSame('snap_xyz', $data['snapshot_id']);
+        $this->assertIsInt($data['ts']);
+    }
+
+    public function test_different_type_slug_pairs_do_not_collide(): void
+    {
+        UpdateInFlight::mark('plugin', 'foo/foo.php', 'snap_a');
+        UpdateInFlight::mark('theme', 'foo', 'snap_b');
+        UpdateInFlight::mark('plugin', 'bar/bar.php', 'snap_c');
+
+        $this->assertCount(3, glob($this->storeDir . '/*.json') ?: []);
+
+        UpdateInFlight::clear('plugin', 'foo/foo.php');
+        $this->assertCount(2, glob($this->storeDir . '/*.json') ?: [], 'clearing one key must not remove the others');
+    }
+
+    public function test_mark_returns_an_acquired_lock_handle(): void
+    {
+        $lock = UpdateInFlight::mark('plugin', 'foo/foo.php', 'snap_a');
+
+        $this->assertNotNull($lock, 'B: mark() must acquire and return the paired liveness lock');
+        $this->assertTrue(is_resource($lock));
+
+        UpdateInFlight::release($lock);
+    }
+
+    public function test_repeated_mark_for_the_same_slug_leaves_exactly_one_marker(): void
+    {
+        // F5 (issue #131 final-hardening review) — the marker filename is no
+        // longer deterministically derived from type/slug, so a repeat
+        // mark() call for the SAME type/slug can no longer simply overwrite
+        // a fixed path in place; mark() must instead explicitly purge any
+        // pre-existing marker(s) for this exact type/slug so retries still
+        // leave exactly one marker behind, not an ever-growing pile.
+        $lock1  = UpdateInFlight::mark('plugin', 'foo/foo.php', 'snap_first');
+        $files1 = glob($this->storeDir . '/*.json') ?: [];
+        $this->assertCount(1, $files1);
+
+        $lock2 = UpdateInFlight::mark('plugin', 'foo/foo.php', 'snap_second');
+        $files2 = glob($this->storeDir . '/*.json') ?: [];
+
+        $this->assertCount(
+            1,
+            $files2,
+            'F5: a repeat mark() for the same type/slug must leave exactly one marker on disk, not accumulate'
+        );
+        $data = json_decode((string) file_get_contents($files2[0]), true);
+        $this->assertSame(
+            'snap_second',
+            $data['snapshot_id'],
+            'the surviving marker must be the LATEST mark() call, not the first'
+        );
+
+        UpdateInFlight::release($lock1);
+        UpdateInFlight::release($lock2);
+    }
+
+    public function test_marker_filename_is_not_the_old_deterministic_slug_hash(): void
+    {
+        // F5 — pin that the filename is no longer sha256(type:slug)-derived
+        // (which had no secret salt and was trivially recomputable by
+        // anyone who already knew the public slug).
+        $lock = UpdateInFlight::mark('plugin', 'akismet/akismet.php', 'snap_a');
+
+        $files = glob($this->storeDir . '/*.json') ?: [];
+        $this->assertCount(1, $files);
+        $oldDeterministicName = substr(hash('sha256', 'plugin:akismet/akismet.php'), 0, 32) . '.json';
+
+        $this->assertNotSame(
+            $oldDeterministicName,
+            basename($files[0]),
+            'F5: the marker filename must not be the old deterministic sha256(type:slug) hash'
+        );
+
+        UpdateInFlight::release($lock);
+    }
+
+    // =========================================================================
+    // healStaleIfPresent()
+    // =========================================================================
+
+    public function test_fresh_marker_is_left_untouched(): void
+    {
+        UpdateInFlight::mark('plugin', 'foo/foo.php', 'snap_fresh');
+
+        $snapshots = $this->spySnapshots();
+        UpdateInFlight::healStaleIfPresent($snapshots);
+
+        $this->assertSame(
+            [],
+            $snapshots->restored,
+            'a fresh in-flight marker may belong to a still-running apply and must not be reconciled'
+        );
+        $this->assertCount(1, glob($this->storeDir . '/*.json') ?: []);
+    }
+
+    public function test_stale_marker_triggers_restore_with_the_recorded_arguments_and_is_cleared(): void
+    {
+        $lock = UpdateInFlight::mark('plugin', 'foo/foo.php', 'snap_stale');
+        UpdateInFlight::release($lock); // simulate the owning process having exited (B: lock must be free to reconcile)
+        $this->ageTheOnlyMarker(time() - 1300); // > STALE_AFTER_SECONDS (1200)
+
+        $snapshots = $this->spySnapshots();
+        // F2: the live directory must be verified genuinely INCOMPLETE for a
+        // restore to happen at all — this test's scenario is exactly that.
+        UpdateInFlight::healStaleIfPresent($snapshots, $this->healthOverrideRunner(false));
+
+        $this->assertSame(
+            [['plugin', 'foo/foo.php', 'snap_stale']],
+            $snapshots->restored,
+            'a stale marker over a genuinely incomplete live directory must trigger restore() with exactly its recorded type/slug/snapshot_id'
+        );
+        $this->assertCount(
+            0,
+            glob($this->storeDir . '/*.json') ?: [],
+            'a reconciled marker must be removed so it is never reconciled twice'
+        );
+    }
+
+    public function test_marker_exactly_at_the_staleness_boundary_is_left_alone(): void
+    {
+        // Boundary: strictly LESS than the threshold counts as fresh — this
+        // pins the "< STALE_AFTER_SECONDS" comparison direction.
+        UpdateInFlight::mark('plugin', 'foo/foo.php', 'snap_boundary');
+        $this->ageTheOnlyMarker(time() - 1199);
+
+        $snapshots = $this->spySnapshots();
+        UpdateInFlight::healStaleIfPresent($snapshots);
+
+        $this->assertSame([], $snapshots->restored);
+        $this->assertCount(1, glob($this->storeDir . '/*.json') ?: []);
+    }
+
+    public function test_corrupt_marker_is_removed_without_attempting_a_restore(): void
+    {
+        mkdir($this->storeDir, 0755, true);
+        file_put_contents($this->storeDir . '/deadbeef00000000000000000000000.json', 'not json');
+
+        $snapshots = $this->spySnapshots();
+        UpdateInFlight::healStaleIfPresent($snapshots);
+
+        $this->assertSame([], $snapshots->restored);
+        $this->assertCount(
+            0,
+            glob($this->storeDir . '/*.json') ?: [],
+            'an unreadable/corrupt marker cannot be reconciled to anything meaningful and must be removed'
+        );
+    }
+
+    public function test_restore_throwing_during_reconcile_still_removes_the_marker(): void
+    {
+        $lock = UpdateInFlight::mark('plugin', 'foo/foo.php', 'snap_stale');
+        UpdateInFlight::release($lock);
+        $this->ageTheOnlyMarker(time() - 1300);
+
+        $snapshots = new class extends SnapshotManager {
+            public function restore(string $type, string $slug, string $snapshotId): array
+            {
+                throw new \RuntimeException('simulated restore failure');
+            }
+
+            public function snapshotExists(string $snapshotId): bool
+            {
+                return true;
+            }
+        };
+
+        // Must not throw out of healStaleIfPresent() — a broken restore
+        // must not wedge the reconcile sweep for every OTHER marker.
+        UpdateInFlight::healStaleIfPresent($snapshots, $this->healthOverrideRunner(false));
+
+        $this->assertCount(
+            0,
+            glob($this->storeDir . '/*.json') ?: [],
+            'the marker must still be cleared even when the restore attempt itself throws'
+        );
+    }
+
+    public function test_multiple_stale_markers_are_each_reconciled_independently(): void
+    {
+        $lock1 = UpdateInFlight::mark('plugin', 'foo/foo.php', 'snap_foo');
+        $lock2 = UpdateInFlight::mark('theme', 'bar', 'snap_bar');
+        UpdateInFlight::release($lock1);
+        UpdateInFlight::release($lock2);
+        foreach (glob($this->storeDir . '/*.json') ?: [] as $file) {
+            $data = json_decode((string) file_get_contents($file), true);
+            $data['ts'] = time() - 1300;
+            file_put_contents($file, (string) json_encode($data));
+        }
+
+        $snapshots = $this->spySnapshots();
+        UpdateInFlight::healStaleIfPresent($snapshots, $this->healthOverrideRunner(false));
+
+        $this->assertCount(2, $snapshots->restored);
+        $this->assertCount(0, glob($this->storeDir . '/*.json') ?: []);
+    }
+
+    public function test_heal_is_a_safe_noop_when_the_store_directory_does_not_exist(): void
+    {
+        // Never called mark() — the store directory itself was never created.
+        $snapshots = $this->spySnapshots();
+        UpdateInFlight::healStaleIfPresent($snapshots);
+
+        $this->assertSame([], $snapshots->restored);
+    }
+
+    // =========================================================================
+    // F2 — verify before restoring
+    // =========================================================================
+
+    public function test_heal_clears_without_restoring_when_the_live_directory_is_already_healthy(): void
+    {
+        $lock = UpdateInFlight::mark('plugin', 'foo/foo.php', 'snap_healthy');
+        UpdateInFlight::release($lock);
+        $this->ageTheOnlyMarker(time() - 1300);
+
+        $snapshots = $this->spySnapshots();
+        // The apply actually finished cleanly before the kill landed — the
+        // live directory is reported COMPLETE.
+        UpdateInFlight::healStaleIfPresent($snapshots, $this->healthOverrideRunner(true));
+
+        $this->assertSame(
+            [],
+            $snapshots->restored,
+            'F2: a stale marker over an already-healthy/complete live directory must NEVER trigger a restore'
+        );
+        $this->assertCount(
+            0,
+            glob($this->storeDir . '/*.json') ?: [],
+            'F2: the marker must still be cleared even though no restore happened'
+        );
+    }
+
+    public function test_heal_clears_without_restoring_when_the_referenced_snapshot_no_longer_exists(): void
+    {
+        $lock = UpdateInFlight::mark('plugin', 'foo/foo.php', 'snap_vanished');
+        UpdateInFlight::release($lock);
+        $this->ageTheOnlyMarker(time() - 1300);
+
+        // Live directory verified genuinely INCOMPLETE (would normally
+        // restore) — but the referenced snapshot itself is gone (already
+        // pruned/consumed).
+        $snapshots = new class extends SnapshotManager {
+            /** @var array<int,array{string,string,string}> */
+            public array $restored = [];
+
+            public function restore(string $type, string $slug, string $snapshotId): array
+            {
+                $this->restored[] = [$type, $slug, $snapshotId];
+
+                return ['ok' => true, 'log' => 'restored'];
+            }
+
+            public function snapshotExists(string $snapshotId): bool
+            {
+                return false;
+            }
+        };
+
+        UpdateInFlight::healStaleIfPresent($snapshots, $this->healthOverrideRunner(false));
+
+        $this->assertSame(
+            [],
+            $snapshots->restored,
+            'F2: restore() must never be attempted once the referenced snapshot is confirmed gone'
+        );
+        $this->assertCount(
+            0,
+            glob($this->storeDir . '/*.json') ?: [],
+            'F2: the marker must still be cleared when its snapshot has vanished, not left behind forever'
+        );
+    }
+
+    // =========================================================================
+    // B — flock liveness lock gates reconcile
+    // =========================================================================
+
+    public function test_heal_skips_a_marker_whose_liveness_lock_is_still_held_and_reconciles_once_released(): void
+    {
+        $lock = UpdateInFlight::mark('plugin', 'locked/locked.php', 'snap_locked');
+        $this->assertNotNull($lock, 'precondition: mark() must acquire the liveness lock');
+        $this->ageTheOnlyMarker(time() - 1300);
+
+        $snapshots = $this->spySnapshots();
+        $runner    = $this->healthOverrideRunner(false); // not healthy -> would restore once reachable
+
+        // B: the lock is still held right now (simulating a still-running
+        // apply, immune to the age-only heuristic) -> the marker must be
+        // skipped entirely — no restore, no deletion.
+        UpdateInFlight::healStaleIfPresent($snapshots, $runner);
+        $this->assertSame(
+            [],
+            $snapshots->restored,
+            'B: a marker whose liveness lock is still held must be skipped — its apply is genuinely still running'
+        );
+        $this->assertCount(
+            1,
+            glob($this->storeDir . '/*.json') ?: [],
+            'a still-locked marker must not be removed either'
+        );
+
+        UpdateInFlight::release($lock);
+
+        // Now that the lock is free, reconcile proceeds normally.
+        UpdateInFlight::healStaleIfPresent($snapshots, $runner);
+        $this->assertSame(
+            [['plugin', 'locked/locked.php', 'snap_locked']],
+            $snapshots->restored,
+            'B: once the lock is released, the SAME stale marker must be reconciled normally'
+        );
+        $this->assertCount(0, glob($this->storeDir . '/*.json') ?: []);
+    }
+}

--- a/apps/agent/tests/UpdateRunnerCompletenessTest.php
+++ b/apps/agent/tests/UpdateRunnerCompletenessTest.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * UpdateRunnerCompletenessTest — S6 (GitHub issue #131 adversarial review)
+ * and the BLOCKER fix (issue #131 final-hardening review) for
+ * UpdateRunner::isComplete()'s plugin path.
+ *
+ * BLOCKER: isComplete() no longer contains ANY vendor/autoload.php
+ * sub-check (it was deleted entirely — see UpdateRunner::isComplete()'s
+ * class doc for why: it could not distinguish a defensive
+ * `if (file_exists(...)) require ...` idiom, or a bare comment, from an
+ * unconditional require, and false-reverted a legitimately good update that
+ * simply shipped without a `vendor/` directory). The tests below prove
+ * isComplete() is now governed purely by validate_plugin()/get_plugins(),
+ * regardless of what a plugin's main-file source references or what exists
+ * on disk under `vendor/`.
+ *
+ * S6: a plugin whose main file was renamed by an update must still resolve
+ * by FOLDER via isComplete()'s fallback — this needs no filesystem I/O at
+ * all (get_plugins()/validate_plugin() are Brain-Monkey-stubbed), so it is
+ * fully order-independent regardless of WP_PLUGIN_DIR's global state.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Support\UpdateRunner;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\UpdateRunner
+ */
+final class UpdateRunnerCompletenessTest extends TestCase
+{
+    /** Temp root for this test run (removed in tear_down). */
+    private string $root = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+        $this->root = sys_get_temp_dir() . '/wpmgr-completeness-' . bin2hex(random_bytes(6));
+        mkdir($this->root, 0755, true);
+    }
+
+    protected function tear_down(): void
+    {
+        $this->rrmdir($this->root);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /** Recursive delete used only for test fixture cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+
+    // =========================================================================
+    // BLOCKER — the vendor/autoload.php sub-check is gone; a defensive
+    // reference to it (or its absence on disk) must never revert a good update
+    // =========================================================================
+
+    public function test_isComplete_true_for_a_plugin_that_defensively_references_vendor_autoload_but_ships_without_it(): void
+    {
+        // The exact false-positive scenario the removed S3 check produced: a
+        // main file that references vendor/autoload.php only defensively
+        // (`if (file_exists(...)) { require ...; }`) and genuinely ships
+        // WITHOUT a vendor/ directory at all (a dev-only Composer
+        // dependency, a "lite" build, or a graceful-degradation pattern) —
+        // this is a perfectly GOOD, complete apply and must be reported
+        // complete, not reverted.
+        $dir = $this->root . '/defensive-vendor-plugin';
+        mkdir($dir, 0755, true);
+        $mainFile = $dir . '/main.php';
+        file_put_contents(
+            $mainFile,
+            "<?php\n"
+            . "// Defensive Composer autoload — this plugin ships without vendor/ in production.\n"
+            . "if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {\n"
+            . "    require __DIR__ . '/vendor/autoload.php';\n"
+            . "}\n"
+        );
+        // vendor/autoload.php deliberately NOT created — this must NOT be
+        // treated as a half-write; the sub-check that used to flag this no
+        // longer exists at all.
+        $this->assertFalse(is_dir($dir . '/vendor'), 'precondition: no vendor/ directory exists');
+
+        Functions\when('get_plugins')->justReturn([
+            'defensive-vendor-plugin/main.php' => ['Name' => 'Defensive Vendor Plugin', 'Version' => '2.0'],
+        ]);
+        Functions\when('validate_plugin')->justReturn(0);
+        Functions\when('wp_clean_plugins_cache')->justReturn(null);
+
+        $runner = new UpdateRunner();
+
+        $this->assertTrue(
+            $runner->isComplete('plugin', 'defensive-vendor-plugin/main.php'),
+            'BLOCKER: a plugin that defensively references vendor/autoload.php but ships without it must be reported COMPLETE, never auto-reverted'
+        );
+    }
+
+    public function test_isComplete_governed_purely_by_validate_plugin_regardless_of_vendor_autoload_references(): void
+    {
+        // Order-independent control: even a main file that UNCONDITIONALLY
+        // requires vendor/autoload.php, with the path genuinely missing,
+        // must now be judged solely by validate_plugin()/get_plugins() — the
+        // vendor sub-check is not merely narrowed, it is GONE.
+        Functions\when('get_plugins')->justReturn([
+            'demo/demo.php' => ['Name' => 'Demo', 'Version' => '2.0'],
+        ]);
+        Functions\when('validate_plugin')->justReturn(0);
+        Functions\when('wp_clean_plugins_cache')->justReturn(null);
+
+        $runner = new UpdateRunner();
+
+        $this->assertTrue($runner->isComplete('plugin', 'demo/demo.php'));
+    }
+
+    // =========================================================================
+    // S6 — renamed-main-file plugin resolves by folder
+    // =========================================================================
+
+    public function test_isComplete_resolves_a_renamed_main_file_by_folder_and_does_not_false_fail(): void
+    {
+        // The CP sends the FULL basename slug the site had installed BEFORE
+        // the update ("folder/oldmain.php"). The update renamed the
+        // bootstrap file to "folder/newmain.php" — a completely normal,
+        // GOOD outcome — so get_plugins() no longer has an "folder/oldmain.php"
+        // key at all.
+        Functions\when('get_plugins')->justReturn([
+            'kadence-blocks/kadence-blocks-main.php' => ['Name' => 'Kadence Blocks', 'Version' => '3.3.0'],
+        ]);
+        Functions\when('validate_plugin')->justReturn(0);
+        Functions\when('wp_clean_plugins_cache')->justReturn(null);
+
+        $runner = new UpdateRunner();
+
+        $this->assertTrue(
+            $runner->isComplete('plugin', 'kadence-blocks/kadence-blocks.php'),
+            'S6: a plugin whose main file was renamed by a GOOD update must resolve by folder, not be false-rolled-back'
+        );
+    }
+
+    public function test_isInstalled_also_resolves_a_renamed_main_file_by_folder(): void
+    {
+        // Same folder-derivation bug existed in isInstalled()'s identical
+        // fallback loop — fixed alongside isComplete() for consistency.
+        Functions\when('get_plugins')->justReturn([
+            'kadence-blocks/kadence-blocks-main.php' => ['Name' => 'Kadence Blocks', 'Version' => '3.3.0'],
+        ]);
+
+        $runner = new UpdateRunner();
+
+        $this->assertTrue($runner->isInstalled('plugin', 'kadence-blocks/kadence-blocks.php'));
+    }
+
+    public function test_currentVersion_also_resolves_a_renamed_main_file_by_folder(): void
+    {
+        // Same fallback loop, third call site.
+        Functions\when('get_plugins')->justReturn([
+            'kadence-blocks/kadence-blocks-main.php' => ['Name' => 'Kadence Blocks', 'Version' => '3.3.0'],
+        ]);
+
+        $runner = new UpdateRunner();
+
+        $this->assertSame('3.3.0', $runner->currentVersion('plugin', 'kadence-blocks/kadence-blocks.php'));
+    }
+
+    public function test_isComplete_false_when_the_slug_resolves_to_no_folder_at_all(): void
+    {
+        // The genuine half-write symptom must still be caught: no installed
+        // plugin under ANY folder matches.
+        Functions\when('get_plugins')->justReturn([
+            'unrelated/unrelated.php' => ['Name' => 'Unrelated', 'Version' => '1.0'],
+        ]);
+        Functions\when('wp_clean_plugins_cache')->justReturn(null);
+
+        $runner = new UpdateRunner();
+
+        $this->assertFalse($runner->isComplete('plugin', 'gone-plugin/gone-plugin.php'));
+    }
+
+    public function test_isComplete_true_for_an_exact_unchanged_basename_match(): void
+    {
+        // Control: the common case (main file NOT renamed) must be
+        // unaffected by the S6 fallback-folder change.
+        Functions\when('get_plugins')->justReturn([
+            'akismet/akismet.php' => ['Name' => 'Akismet', 'Version' => '5.3'],
+        ]);
+        Functions\when('validate_plugin')->justReturn(0);
+        Functions\when('wp_clean_plugins_cache')->justReturn(null);
+
+        $runner = new UpdateRunner();
+
+        $this->assertTrue($runner->isComplete('plugin', 'akismet/akismet.php'));
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.7
+ * Version:           0.61.8
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.7');
+define('WPMGR_AGENT_VERSION', '0.61.8');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -501,6 +501,16 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	uptimeProbeGCWorker := metrics.NewUptimeProbeGCWorker(pool, logger)
 
 	updateWorker := update.NewWorker(updateRepo, sitesLookup, commander, prober, updateHub, auditRec, logger, cfg.Update.PerTenantParallelism)
+	// #131 follow-up — periodic reaper for update_tasks stuck in pending/running
+	// past staleTaskThreshold (a worker crash mid-task, or a failed enqueue that
+	// leaves a task pending). Without this, such a task permanently occupies its
+	// (tenant, site, target_type, target_slug) slot in the
+	// update_tasks_inflight_target_idx partial unique index (m88), and every
+	// future update attempt for that target 409s targets_in_flight forever.
+	// Always wired: it reuses updateWorker's repo/hub/audit/logger, needs no
+	// signing key (it only reads/writes update_tasks), and reaping is itself the
+	// backstop for MF-1 (the m88 migration's pre-dedup) going forward.
+	updateReaperWorker := update.NewReaperWorker(updateWorker)
 	// Updates feature (Track B): the refresh-inventory worker dispatches signed
 	// CP->agent commands to re-pull a site's inventory. It satisfies River's
 	// JobArgs interface so the per-tenant queue shard bounds its concurrency
@@ -1285,6 +1295,7 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 		siteSweepWorker:        siteSweepWorker,
 		siteEventPruneWorker:   siteEventPruneWorker,
 		updateWorker:           updateWorker,
+		updateReaperWorker:     updateReaperWorker,
 		refreshWorker:          refreshWorker,
 		perTenantParallelism:   cfg.Update.PerTenantParallelism,
 		backupWorker:           backupWorker,
@@ -2284,7 +2295,10 @@ type riverDeps struct {
 	siteSweepWorker        *site.SweepWorker
 	siteEventPruneWorker   *site.EventPruneWorker
 	updateWorker           *update.Worker
-	refreshWorker          *update.RefreshInventoryWorker
+	// #131 follow-up — periodic reaper for update_tasks stuck in
+	// pending/running past the stale-task threshold (always wired).
+	updateReaperWorker *update.ReaperWorker
+	refreshWorker      *update.RefreshInventoryWorker
 	perTenantParallelism   int
 	backupWorker           *backup.BackupWorker
 	restoreWorker          *backup.RestoreWorker
@@ -2367,6 +2381,9 @@ func startRiver(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger, d 
 	workers := river.NewWorkers()
 	river.AddWorker(workers, site.NewHealthCheckWorker(d.healthChecker))
 	river.AddWorker(workers, d.updateWorker)
+	if d.updateReaperWorker != nil {
+		river.AddWorker(workers, d.updateReaperWorker)
+	}
 	if d.refreshWorker != nil {
 		river.AddWorker(workers, d.refreshWorker)
 	}
@@ -2429,6 +2446,22 @@ func startRiver(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger, d 
 			river.PeriodicInterval(time.Minute),
 			func() (river.JobArgs, *river.InsertOpts) { return site.EventPruneArgs{}, nil },
 			nil,
+		))
+	}
+
+	// #131 follow-up — periodic reaper for update_tasks stuck in pending/running
+	// past the stale-task threshold (45 min; see update.staleTaskThreshold).
+	// Always registered; cross-tenant, no signing key required. RunOnStart:
+	// true — unlike the perf watchdogs (which skip a fresh-boot false positive
+	// since nothing could be in flight yet), a task already stuck for 45+
+	// minutes should be reaped immediately on boot, not held for up to a full
+	// tick interval. 10-minute interval keeps the sweep cheap while unblocking
+	// a stuck (site, target) reasonably promptly.
+	if d.updateReaperWorker != nil {
+		periodics = append(periodics, river.NewPeriodicJob(
+			river.PeriodicInterval(10*time.Minute),
+			func() (river.JobArgs, *river.InsertOpts) { return update.ReapStaleTasksArgs{}, nil },
+			&river.PeriodicJobOpts{RunOnStart: true},
 		))
 	}
 

--- a/apps/api/db/query/updates.sql
+++ b/apps/api/db/query/updates.sql
@@ -9,11 +9,21 @@ VALUES ($1, $2, $3, $4, $5)
 RETURNING *;
 
 -- name: CreateUpdateTask :one
+-- ON CONFLICT targets the update_tasks_inflight_target_idx partial unique
+-- index (tenant_id, site_id, target_type, target_slug) WHERE status IN
+-- ('pending','running') — the authoritative cross-run dedup guard (#131
+-- hardening). If the same (site, target) already has an in-flight task from
+-- ANY OTHER run, the insert is a no-op and this returns zero rows (pgx
+-- surfaces that as ErrNoRows); the repo treats that as "already in flight",
+-- not an error, and skips creating the duplicate task.
 INSERT INTO update_tasks (
     run_id, tenant_id, site_id, target_type, target_slug, desired_version,
     from_version, status
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending')
+ON CONFLICT (tenant_id, site_id, target_type, target_slug)
+    WHERE status IN ('pending', 'running')
+    DO NOTHING
 RETURNING *;
 
 -- name: GetUpdateRun :one
@@ -100,6 +110,39 @@ WHERE run_id = $1 AND tenant_id = $2
 -- one tenant cannot saturate the worker pool. Runs in the tenant's RLS scope.
 SELECT count(*) FROM update_tasks
 WHERE tenant_id = $1 AND status = 'running';
+
+-- name: ListInFlightUpdateTargets :many
+-- Returns the (site_id, target_type, target_slug) of every task currently
+-- pending or running for the tenant, restricted to the given site_ids, across
+-- ANY run. Used by Service.planTasks to skip creating a duplicate task for a
+-- target that already has an update in flight from another run (#131
+-- hardening — see the update_tasks_inflight_target_idx partial unique index,
+-- which is the authoritative guard; this query is the service-level
+-- pre-check that avoids planning doomed tasks).
+SELECT DISTINCT site_id, target_type, target_slug
+FROM update_tasks
+WHERE tenant_id = @tenant_id
+  AND site_id = ANY(@site_ids::uuid[])
+  AND status IN ('pending', 'running');
+
+-- name: ListStaleUpdateTasks :many
+-- Returns update_tasks stuck in pending/running for longer than @threshold,
+-- across ALL tenants. Used by the periodic stale-task reaper (see
+-- update.ReaperWorker) to un-stick a target that would otherwise permanently
+-- occupy the update_tasks_inflight_target_idx partial unique index slot (m88)
+-- forever — e.g. a worker crash between MarkUpdateTaskRunning and
+-- FinishUpdateTask, or a failed EnqueueTask that leaves a task pending
+-- (service.go's best-effort enqueue after CreateRunWithTasks). updated_at is
+-- the staleness watermark: it is set at row creation and again by
+-- MarkUpdateTaskRunning/FinishUpdateTask, so it reflects the last real
+-- progress on the row. Capped at @row_limit per sweep so one periodic tick
+-- cannot be unbounded; any remainder is caught by the next sweep. Runs under
+-- app.agent (cross-tenant).
+SELECT * FROM update_tasks
+WHERE status IN ('pending', 'running')
+  AND updated_at < now() - @threshold::interval
+ORDER BY created_at ASC, id ASC
+LIMIT @row_limit;
 
 -- name: ListAppliedTasksForSite :many
 -- Returns successfully applied update tasks for one site, ordered newest first.

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -518,11 +518,42 @@ CREATE INDEX update_tasks_run_id_idx ON update_tasks (run_id);
 CREATE INDEX update_tasks_tenant_id_idx ON update_tasks (tenant_id);
 CREATE INDEX update_tasks_site_id_idx ON update_tasks (site_id);
 
+-- update_tasks_inflight_target_idx (m88) is the authoritative cross-run dedup
+-- guard: at most one pending/running task may exist per (tenant, site,
+-- target_type, target_slug) at a time, across ALL runs. Without it, a
+-- scheduled auto-update, an operator bulk "Update all", and a client-portal
+-- trigger can each create a task for the SAME (site, plugin) within the same
+-- ~1s window; the River queue only caps per-tenant concurrency, so several
+-- can run concurrently — racing the agent's own rollback-snapshot pruning (a
+-- task's own snapshot gets pruned by a sibling task, producing "rollback
+-- FAILED / Invalid snapshot id") and running concurrent WordPress
+-- Plugin_Upgrader instances against the same plugin directory (can corrupt
+-- wp-content/plugins/<slug>). CreateUpdateTask relies on this index as an ON
+-- CONFLICT ... DO NOTHING arbiter; the service-level ListInFlightUpdateTargets
+-- pre-check (planTasks) narrows the race further but cannot itself be atomic
+-- without this index. A task falls out of the partial index once it reaches a
+-- terminal status, so a sequential re-update after the prior run finished is
+-- unaffected. The versioned m88 migration additionally pre-dedups any
+-- pending/running rows a live database already accumulated under the
+-- pre-m88 bug before creating this index (schema.sql only carries the
+-- resulting end state; see the migration file for the one-time data fix).
+CREATE UNIQUE INDEX update_tasks_inflight_target_idx ON update_tasks
+    (tenant_id, site_id, target_type, target_slug)
+    WHERE status IN ('pending', 'running');
+
 ALTER TABLE update_tasks ENABLE ROW LEVEL SECURITY;
 ALTER TABLE update_tasks FORCE ROW LEVEL SECURITY;
 CREATE POLICY update_tasks_tenant_isolation ON update_tasks
     USING (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid)
     WITH CHECK (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid);
+-- update_tasks_agent (m89) lets the #131 stale-task reaper (ReaperWorker ->
+-- ListStaleUpdateTasks) read across ALL tenants in one sweep under InAgentTx.
+-- Added after the fact because M3 only shipped the tenant_isolation policy;
+-- every query against this table was tenant-scoped until the reaper's
+-- cross-tenant sweep needed it (same bug class as m84's backup_schedules fix).
+CREATE POLICY update_tasks_agent ON update_tasks
+    USING (current_setting('app.agent', true) = 'on')
+    WITH CHECK (current_setting('app.agent', true) = 'on');
 
 -- ---------------------------------------------------------------------------
 -- backup_chunks  (M4 — incremental, content-addressed dedup + GC)

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -193,6 +193,13 @@ type Querier interface {
 	// tenant_id is supplied explicitly for defense-in-depth; RLS additionally
 	// enforces it matches the current app.tenant_id setting.
 	CreateUpdateRun(ctx context.Context, arg CreateUpdateRunParams) (UpdateRun, error)
+	// ON CONFLICT targets the update_tasks_inflight_target_idx partial unique
+	// index (tenant_id, site_id, target_type, target_slug) WHERE status IN
+	// ('pending','running') — the authoritative cross-run dedup guard (#131
+	// hardening). If the same (site, target) already has an in-flight task from
+	// ANY OTHER run, the insert is a no-op and this returns zero rows (pgx
+	// surfaces that as ErrNoRows); the repo treats that as "already in flight",
+	// not an error, and skips creating the duplicate task.
 	CreateUpdateTask(ctx context.Context, arg CreateUpdateTaskParams) (UpdateTask, error)
 	CreateUser(ctx context.Context, arg CreateUserParams) (User, error)
 	// DEPRECATED (ADR-050): refcount is observability-only post-mark-and-sweep and
@@ -966,6 +973,14 @@ type Querier interface {
 	// min(markStart, inflightFloor) as the deletion horizon. Returns NULL when no
 	// in-flight snapshot exists (the caller then uses markStart alone).
 	ListInFlightSnapshotFloor(ctx context.Context, tenantID uuid.UUID) (time.Time, error)
+	// Returns the (site_id, target_type, target_slug) of every task currently
+	// pending or running for the tenant, restricted to the given site_ids, across
+	// ANY run. Used by Service.planTasks to skip creating a duplicate task for a
+	// target that already has an update in flight from another run (#131
+	// hardening — see the update_tasks_inflight_target_idx partial unique index,
+	// which is the authoritative guard; this query is the service-level
+	// pre-check that avoids planning doomed tasks).
+	ListInFlightUpdateTargets(ctx context.Context, arg ListInFlightUpdateTargetsParams) ([]ListInFlightUpdateTargetsRow, error)
 	// Pending + accepted + expired + revoked client invitations for a client,
 	// newest first. Mirrors ListInvitationsForSite. tenant_id filter is redundant
 	// with RLS but adds an explicit index hint for performance.
@@ -1053,6 +1068,19 @@ type Querier interface {
 	// deleting the row. Cross-tenant read path (InAgentTx / app.agent GUC).
 	// Capped at 500 rows per sweep to keep the pass short and idempotent.
 	ListStaleFileTransfers(ctx context.Context, cutoff time.Time) ([]ListStaleFileTransfersRow, error)
+	// Returns update_tasks stuck in pending/running for longer than @threshold,
+	// across ALL tenants. Used by the periodic stale-task reaper (see
+	// update.ReaperWorker) to un-stick a target that would otherwise permanently
+	// occupy the update_tasks_inflight_target_idx partial unique index slot (m88)
+	// forever — e.g. a worker crash between MarkUpdateTaskRunning and
+	// FinishUpdateTask, or a failed EnqueueTask that leaves a task pending
+	// (service.go's best-effort enqueue after CreateRunWithTasks). updated_at is
+	// the staleness watermark: it is set at row creation and again by
+	// MarkUpdateTaskRunning/FinishUpdateTask, so it reflects the last real
+	// progress on the row. Capped at @row_limit per sweep so one periodic tick
+	// cannot be unbounded; any remainder is caught by the next sweep. Runs under
+	// app.agent (cross-tenant).
+	ListStaleUpdateTasks(ctx context.Context, arg ListStaleUpdateTasksParams) ([]UpdateTask, error)
 	// Watchdog feeder: a running snapshot whose latest progress is older than the
 	// stall threshold (or whose runner never reported any progress despite being
 	// running for longer than the threshold). The new index

--- a/apps/api/internal/db/sqlc/updates.sql.go
+++ b/apps/api/internal/db/sqlc/updates.sql.go
@@ -93,6 +93,9 @@ INSERT INTO update_tasks (
     from_version, status
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending')
+ON CONFLICT (tenant_id, site_id, target_type, target_slug)
+    WHERE status IN ('pending', 'running')
+    DO NOTHING
 RETURNING id, run_id, tenant_id, site_id, target_type, target_slug, desired_version, from_version, to_version, status, detail, error, started_at, finished_at, created_at, updated_at
 `
 
@@ -106,6 +109,13 @@ type CreateUpdateTaskParams struct {
 	FromVersion    string    `json:"from_version"`
 }
 
+// ON CONFLICT targets the update_tasks_inflight_target_idx partial unique
+// index (tenant_id, site_id, target_type, target_slug) WHERE status IN
+// ('pending','running') — the authoritative cross-run dedup guard (#131
+// hardening). If the same (site, target) already has an in-flight task from
+// ANY OTHER run, the insert is a no-op and this returns zero rows (pgx
+// surfaces that as ErrNoRows); the repo treats that as "already in flight",
+// not an error, and skips creating the duplicate task.
 func (q *Queries) CreateUpdateTask(ctx context.Context, arg CreateUpdateTaskParams) (UpdateTask, error) {
 	row := q.db.QueryRow(ctx, createUpdateTask,
 		arg.RunID,
@@ -363,6 +373,114 @@ func (q *Queries) ListAppliedTasksForSites(ctx context.Context, arg ListAppliedT
 			&i.FromVersion,
 			&i.ToVersion,
 			&i.FinishedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listInFlightUpdateTargets = `-- name: ListInFlightUpdateTargets :many
+SELECT DISTINCT site_id, target_type, target_slug
+FROM update_tasks
+WHERE tenant_id = $1
+  AND site_id = ANY($2::uuid[])
+  AND status IN ('pending', 'running')
+`
+
+type ListInFlightUpdateTargetsParams struct {
+	TenantID uuid.UUID   `json:"tenant_id"`
+	SiteIds  []uuid.UUID `json:"site_ids"`
+}
+
+type ListInFlightUpdateTargetsRow struct {
+	SiteID     uuid.UUID `json:"site_id"`
+	TargetType string    `json:"target_type"`
+	TargetSlug string    `json:"target_slug"`
+}
+
+// Returns the (site_id, target_type, target_slug) of every task currently
+// pending or running for the tenant, restricted to the given site_ids, across
+// ANY run. Used by Service.planTasks to skip creating a duplicate task for a
+// target that already has an update in flight from another run (#131
+// hardening — see the update_tasks_inflight_target_idx partial unique index,
+// which is the authoritative guard; this query is the service-level
+// pre-check that avoids planning doomed tasks).
+func (q *Queries) ListInFlightUpdateTargets(ctx context.Context, arg ListInFlightUpdateTargetsParams) ([]ListInFlightUpdateTargetsRow, error) {
+	rows, err := q.db.Query(ctx, listInFlightUpdateTargets, arg.TenantID, arg.SiteIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListInFlightUpdateTargetsRow
+	for rows.Next() {
+		var i ListInFlightUpdateTargetsRow
+		if err := rows.Scan(&i.SiteID, &i.TargetType, &i.TargetSlug); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listStaleUpdateTasks = `-- name: ListStaleUpdateTasks :many
+SELECT id, run_id, tenant_id, site_id, target_type, target_slug, desired_version, from_version, to_version, status, detail, error, started_at, finished_at, created_at, updated_at FROM update_tasks
+WHERE status IN ('pending', 'running')
+  AND updated_at < now() - $1::interval
+ORDER BY created_at ASC, id ASC
+LIMIT $2
+`
+
+type ListStaleUpdateTasksParams struct {
+	Threshold pgtype.Interval `json:"threshold"`
+	RowLimit  int32           `json:"row_limit"`
+}
+
+// Returns update_tasks stuck in pending/running for longer than @threshold,
+// across ALL tenants. Used by the periodic stale-task reaper (see
+// update.ReaperWorker) to un-stick a target that would otherwise permanently
+// occupy the update_tasks_inflight_target_idx partial unique index slot (m88)
+// forever — e.g. a worker crash between MarkUpdateTaskRunning and
+// FinishUpdateTask, or a failed EnqueueTask that leaves a task pending
+// (service.go's best-effort enqueue after CreateRunWithTasks). updated_at is
+// the staleness watermark: it is set at row creation and again by
+// MarkUpdateTaskRunning/FinishUpdateTask, so it reflects the last real
+// progress on the row. Capped at @row_limit per sweep so one periodic tick
+// cannot be unbounded; any remainder is caught by the next sweep. Runs under
+// app.agent (cross-tenant).
+func (q *Queries) ListStaleUpdateTasks(ctx context.Context, arg ListStaleUpdateTasksParams) ([]UpdateTask, error) {
+	rows, err := q.db.Query(ctx, listStaleUpdateTasks, arg.Threshold, arg.RowLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []UpdateTask
+	for rows.Next() {
+		var i UpdateTask
+		if err := rows.Scan(
+			&i.ID,
+			&i.RunID,
+			&i.TenantID,
+			&i.SiteID,
+			&i.TargetType,
+			&i.TargetSlug,
+			&i.DesiredVersion,
+			&i.FromVersion,
+			&i.ToVersion,
+			&i.Status,
+			&i.Detail,
+			&i.Error,
+			&i.StartedAt,
+			&i.FinishedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/apps/api/internal/update/handler_test.go
+++ b/apps/api/internal/update/handler_test.go
@@ -71,6 +71,14 @@ func (f *fakeRepo) CountRunningTasksForTenant(context.Context, uuid.UUID) (int64
 	panic("not used")
 }
 
+func (f *fakeRepo) ListInFlightTargets(context.Context, uuid.UUID, []uuid.UUID) (map[InFlightKey]struct{}, error) {
+	panic("not used")
+}
+
+func (f *fakeRepo) ListStaleUpdateTasks(context.Context, time.Duration, int32) ([]Task, error) {
+	panic("not used")
+}
+
 // flushableRecorder wraps httptest.ResponseRecorder so gin's writer implements
 // http.Flusher (the events handler checks for it before opening the stream).
 type flushableRecorder struct {

--- a/apps/api/internal/update/repo.go
+++ b/apps/api/internal/update/repo.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -33,6 +34,38 @@ type Repo interface {
 	SetRunStatus(ctx context.Context, tenantID, runID uuid.UUID, status string) (Run, error)
 	CountUnfinishedTasks(ctx context.Context, tenantID, runID uuid.UUID) (int64, error)
 	CountRunningTasksForTenant(ctx context.Context, tenantID uuid.UUID) (int64, error)
+	// ListInFlightTargets returns the set of (site_id, target_type, target_slug)
+	// keys that currently have a pending or running task for the tenant, across
+	// ANY run, restricted to siteIDs. Used by Service.planTasks to skip creating
+	// a duplicate task for a target that already has an update in flight from
+	// another run (#131 hardening): without this, a scheduled auto-update, an
+	// operator bulk update, and a portal trigger can all create tasks for the
+	// SAME (site, plugin) within the same window, and several run concurrently —
+	// racing the agent's own rollback-snapshot pruning and running concurrent
+	// WordPress Plugin_Upgrader instances against the same plugin directory. The
+	// authoritative guard is the update_tasks_inflight_target_idx partial unique
+	// index (see CreateUpdateTask's ON CONFLICT); this pre-check just avoids
+	// planning doomed tasks and lets CreateRun report a clean "already in
+	// progress" error instead of a partially-empty run.
+	ListInFlightTargets(ctx context.Context, tenantID uuid.UUID, siteIDs []uuid.UUID) (map[InFlightKey]struct{}, error)
+	// ListStaleUpdateTasks returns tasks stuck in pending/running for longer
+	// than threshold, across ALL tenants, capped at limit rows. Used by the
+	// periodic reaper (see ReaperWorker) to terminalize a task a worker crash
+	// or a failed enqueue left permanently occupying its (tenant, site,
+	// target_type, target_slug) slot in the update_tasks_inflight_target_idx
+	// partial unique index (m88) — without this, every future update attempt
+	// for that target would 409 targets_in_flight forever.
+	ListStaleUpdateTasks(ctx context.Context, threshold time.Duration, limit int32) ([]Task, error)
+}
+
+// InFlightKey identifies one (site, target) pair that currently has a
+// pending/running update task, keyed the same way tasks are planned
+// ("site + type + slug"). Used by ListInFlightTargets/planTasks for the
+// cross-run dedup guard (#131 hardening).
+type InFlightKey struct {
+	SiteID     uuid.UUID
+	TargetType string
+	TargetSlug string
 }
 
 // NewTask is the slim per-(site,item) row to insert when creating a run.
@@ -101,9 +134,25 @@ func (r *pgRepo) CreateRunWithTasks(ctx context.Context, in CreateRunInput, task
 				FromVersion:    t.FromVersion,
 			})
 			if err != nil {
+				if errors.Is(err, pgx.ErrNoRows) {
+					// The update_tasks_inflight_target_idx partial unique index
+					// rejected this insert as a no-op (ON CONFLICT ... DO NOTHING):
+					// a sibling run's task for the same (site, target) became
+					// in-flight in the narrow window between the service's
+					// ListInFlightTargets pre-check and this insert (#131
+					// hardening). Skip it — a tight race is not a hard error.
+					continue
+				}
 				return domain.Internal("update_task_create_failed", "failed to create update task").WithCause(err)
 			}
 			outTasks = append(outTasks, toTask(taskRow))
+		}
+		if len(outTasks) == 0 {
+			// Every planned task lost the in-flight race to a concurrent run
+			// between the pre-check and this transaction: do not commit a run
+			// with zero tasks (it would otherwise sit "pending" forever, since
+			// nothing ever marks it completed).
+			return domain.Conflict("targets_in_flight", "the selected updates already have an update in progress in another run")
 		}
 		return nil
 	})
@@ -304,6 +353,55 @@ func (r *pgRepo) CountRunningTasksForTenant(ctx context.Context, tenantID uuid.U
 		return nil
 	})
 	return n, err
+}
+
+func (r *pgRepo) ListInFlightTargets(ctx context.Context, tenantID uuid.UUID, siteIDs []uuid.UUID) (map[InFlightKey]struct{}, error) {
+	out := map[InFlightKey]struct{}{}
+	if len(siteIDs) == 0 {
+		return out, nil
+	}
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		rows, err := sqlc.New(tx).ListInFlightUpdateTargets(ctx, sqlc.ListInFlightUpdateTargetsParams{
+			TenantID: tenantID,
+			SiteIds:  siteIDs,
+		})
+		if err != nil {
+			return domain.Internal("update_inflight_list_failed", "failed to list in-flight update targets").WithCause(err)
+		}
+		for _, row := range rows {
+			out[InFlightKey{SiteID: row.SiteID, TargetType: row.TargetType, TargetSlug: row.TargetSlug}] = struct{}{}
+		}
+		return nil
+	})
+	return out, err
+}
+
+// ListStaleUpdateTasks runs cross-tenant (InAgentTx) since a stuck task can
+// belong to any tenant and the reaper sweep must find all of them in one pass.
+func (r *pgRepo) ListStaleUpdateTasks(ctx context.Context, threshold time.Duration, limit int32) ([]Task, error) {
+	var out []Task
+	err := r.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
+		rows, err := sqlc.New(tx).ListStaleUpdateTasks(ctx, sqlc.ListStaleUpdateTasksParams{
+			Threshold: durationToInterval(threshold),
+			RowLimit:  limit,
+		})
+		if err != nil {
+			return domain.Internal("update_task_stale_list_failed", "failed to list stale update tasks").WithCause(err)
+		}
+		out = make([]Task, 0, len(rows))
+		for _, row := range rows {
+			out = append(out, toTask(row))
+		}
+		return nil
+	})
+	return out, err
+}
+
+// durationToInterval converts a time.Duration to a pgtype.Interval suitable
+// for an @threshold::interval parameter (pgtype.Interval stores microseconds
+// in the Microseconds field).
+func durationToInterval(d time.Duration) pgtype.Interval {
+	return pgtype.Interval{Microseconds: d.Microseconds(), Valid: true}
 }
 
 func toRun(r sqlc.UpdateRun) Run {

--- a/apps/api/internal/update/service.go
+++ b/apps/api/internal/update/service.go
@@ -107,8 +107,28 @@ func (s *Service) CreateRun(ctx context.Context, in CreateRunInput) (Run, []Task
 		return Run{}, nil, domain.Validation("no_target_sites", "no enrolled sites matched the selection")
 	}
 
-	tasks := s.planTasks(sites, in.Items)
+	// Cross-run dedup pre-check (#131 hardening): find every (site, target)
+	// among the resolved sites that already has a pending/running task from
+	// ANY OTHER run, so planTasks can skip creating a doomed duplicate instead
+	// of racing the agent's rollback-snapshot pruning / concurrent
+	// Plugin_Upgrader runs against the same plugin directory. The
+	// update_tasks_inflight_target_idx partial unique index (enforced inside
+	// CreateRunWithTasks) is the authoritative guard for the remaining race
+	// window between this check and the insert.
+	siteIDs := make([]uuid.UUID, 0, len(sites))
+	for _, si := range sites {
+		siteIDs = append(siteIDs, si.ID)
+	}
+	inFlight, err := s.repo.ListInFlightTargets(ctx, in.TenantID, siteIDs)
+	if err != nil {
+		return Run{}, nil, err
+	}
+
+	tasks, skippedInFlight := s.planTasks(sites, in.Items, inFlight)
 	if len(tasks) == 0 {
+		if skippedInFlight > 0 {
+			return Run{}, nil, domain.Conflict("targets_in_flight", "the selected updates already have an update in progress in another run")
+		}
 		return Run{}, nil, domain.Validation("no_tasks", "the selection produced no update tasks")
 	}
 
@@ -162,8 +182,18 @@ func (s *Service) resolveSites(ctx context.Context, in CreateRunInput) ([]SiteIn
 //
 // from_version is always seeded from the SITE'S OWN known component version
 // (never another site's), whichever branch created the task.
-func (s *Service) planTasks(sites []SiteInfo, items []Item) []NewTask {
+//
+// inFlight is the tenant's current cross-run in-flight-task set (#131
+// hardening — see Repo.ListInFlightTargets): a (site, target) pair already
+// present there has a pending/running task in ANOTHER run, so planTasks skips
+// it here rather than creating a duplicate task that would race the agent's
+// rollback-snapshot pruning or run a concurrent Plugin_Upgrader against the
+// same plugin directory. It returns the produced tasks plus how many
+// candidates were skipped for this reason, so CreateRun can distinguish
+// "nothing pending" from "everything is already in progress".
+func (s *Service) planTasks(sites []SiteInfo, items []Item, inFlight map[InFlightKey]struct{}) ([]NewTask, int) {
 	tasks := make([]NewTask, 0, len(sites)*len(items))
+	skippedInFlight := 0
 	for _, site := range sites {
 		installed := indexVersions(site.Components)
 		pending := indexPending(site)
@@ -193,6 +223,11 @@ func (s *Service) planTasks(sites []SiteInfo, items []Item) []NewTask {
 				}
 			}
 
+			if _, blocked := inFlight[InFlightKey{SiteID: site.ID, TargetType: item.Type, TargetSlug: slug}]; blocked {
+				skippedInFlight++
+				continue
+			}
+
 			desired := item.Version
 			if desired == "" {
 				desired = "latest"
@@ -206,7 +241,7 @@ func (s *Service) planTasks(sites []SiteInfo, items []Item) []NewTask {
 			})
 		}
 	}
-	return tasks
+	return tasks, skippedInFlight
 }
 
 // indexPending returns the site's own pending-update set keyed by "type/slug"

--- a/apps/api/internal/update/service_test.go
+++ b/apps/api/internal/update/service_test.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -31,19 +32,26 @@ func (f *fakeSiteLookup) ListSiteInfoByTag(_ context.Context, _ uuid.UUID, _ str
 	return out, nil
 }
 
-// fakeCreateRepo is a minimal Repo that only implements CreateRunWithTasks
-// (the only method Service.CreateRun's planning path reaches), assembling
+// fakeCreateRepo is a minimal Repo that implements CreateRunWithTasks and
+// ListInFlightTargets — the two methods Service.CreateRun's planning path
+// reaches (the latter added for the #131 cross-run dedup guard) — assembling
 // Task rows from the NewTask rows planTasks produced so the test can assert
 // on the exact composed set. All other methods are unused by CreateRun.
+//
+// tasks accumulates every task ever created across calls to
+// CreateRunWithTasks (mirroring the real update_tasks table across runs), so
+// ListInFlightTargets can compute the in-flight set the way the real
+// cross-run query (backed by update_tasks_inflight_target_idx) would.
 type fakeCreateRepo struct {
 	tenantID uuid.UUID
+	tasks    []Task
 }
 
 func (f *fakeCreateRepo) CreateRunWithTasks(_ context.Context, in CreateRunInput, tasks []NewTask) (Run, []Task, error) {
 	run := Run{ID: uuid.New(), TenantID: in.TenantID, Status: RunPending, DryRun: in.DryRun}
 	out := make([]Task, 0, len(tasks))
 	for _, nt := range tasks {
-		out = append(out, Task{
+		t := Task{
 			ID:             uuid.New(),
 			RunID:          run.ID,
 			TenantID:       in.TenantID,
@@ -53,9 +61,45 @@ func (f *fakeCreateRepo) CreateRunWithTasks(_ context.Context, in CreateRunInput
 			DesiredVersion: nt.DesiredVersion,
 			FromVersion:    nt.FromVersion,
 			Status:         TaskPending,
-		})
+		}
+		out = append(out, t)
+		f.tasks = append(f.tasks, t)
 	}
 	return run, out, nil
+}
+
+// completeTask marks every tracked task for (siteID, targetType, targetSlug)
+// as terminal (succeeded), simulating the real update_tasks_inflight_target_idx
+// partial index dropping the row once its status leaves pending/running — so
+// a SEQUENTIAL re-update after completion is no longer blocked.
+func (f *fakeCreateRepo) completeTask(siteID uuid.UUID, targetType, targetSlug string) {
+	for i := range f.tasks {
+		t := &f.tasks[i]
+		if t.SiteID == siteID && t.TargetType == targetType && t.TargetSlug == targetSlug {
+			t.Status = TaskSucceeded
+		}
+	}
+}
+
+func (f *fakeCreateRepo) ListInFlightTargets(_ context.Context, tenantID uuid.UUID, siteIDs []uuid.UUID) (map[InFlightKey]struct{}, error) {
+	allowed := make(map[uuid.UUID]struct{}, len(siteIDs))
+	for _, id := range siteIDs {
+		allowed[id] = struct{}{}
+	}
+	out := map[InFlightKey]struct{}{}
+	for _, t := range f.tasks {
+		if t.TenantID != tenantID {
+			continue
+		}
+		if _, ok := allowed[t.SiteID]; !ok {
+			continue
+		}
+		if t.Status != TaskPending && t.Status != TaskRunning {
+			continue
+		}
+		out[InFlightKey{SiteID: t.SiteID, TargetType: t.TargetType, TargetSlug: t.TargetSlug}] = struct{}{}
+	}
+	return out, nil
 }
 
 func (f *fakeCreateRepo) GetRun(context.Context, uuid.UUID, uuid.UUID) (Run, error) { panic("not used") }
@@ -84,6 +128,9 @@ func (f *fakeCreateRepo) CountUnfinishedTasks(context.Context, uuid.UUID, uuid.U
 	panic("not used")
 }
 func (f *fakeCreateRepo) CountRunningTasksForTenant(context.Context, uuid.UUID) (int64, error) {
+	panic("not used")
+}
+func (f *fakeCreateRepo) ListStaleUpdateTasks(context.Context, time.Duration, int32) ([]Task, error) {
 	panic("not used")
 }
 
@@ -302,5 +349,76 @@ func TestCreateRunExplicitPinAppliesRegardlessOfPendingFlag(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("want an error: the pinned target is not installed on the site at all")
+	}
+}
+
+// TestCreateRunSkipsDuplicateInFlightTarget is the regression test for the
+// #131 hardening: multiple update runs targeting the SAME (site, target) must
+// not be allowed to have concurrently in-flight tasks. A scheduled
+// auto-update, an operator bulk update, and a portal trigger for the same
+// (site, plugin) racing within the same window must produce exactly ONE
+// in-flight task — never two tasks the worker could run concurrently (which
+// would race the agent's rollback-snapshot pruning and could run concurrent
+// WordPress Plugin_Upgrader instances against the same plugin directory).
+//
+// A SEQUENTIAL re-update — a new run for the same target created AFTER the
+// prior run's task reached a terminal state — must still succeed; only
+// pending/running tasks block a duplicate.
+func TestCreateRunSkipsDuplicateInFlightTarget(t *testing.T) {
+	tenant := uuid.New()
+	siteID := uuid.New()
+	lookup := &fakeSiteLookup{sites: map[uuid.UUID]SiteInfo{
+		siteID: {
+			ID: siteID, Enrolled: true,
+			Components: []Component{
+				{Type: TargetPlugin, Slug: "akismet", Version: "1.0.0", UpdateAvailable: true, NewVersion: "1.1.0"},
+			},
+		},
+	}}
+	repo := &fakeCreateRepo{tenantID: tenant}
+	svc := NewService(repo, lookup, &countingEnqueuer{}, domain.NewValidator(), domain.SystemClock{})
+	items := []Item{{Type: "plugin", Slug: "akismet", Version: "latest"}}
+
+	// First run creates the (only) in-flight task for this target.
+	run1, tasks1, err := svc.CreateRun(context.Background(), CreateRunInput{
+		TenantID: tenant, SiteIDs: []uuid.UUID{siteID}, Items: items,
+	})
+	if err != nil {
+		t.Fatalf("first create run: %v", err)
+	}
+	if len(tasks1) != 1 {
+		t.Fatalf("first run task count = %d, want 1", len(tasks1))
+	}
+
+	// A second run for the SAME (site, target) while the first task is still
+	// pending/running must NOT create a duplicate task — it must be rejected.
+	_, _, err = svc.CreateRun(context.Background(), CreateRunInput{
+		TenantID: tenant, SiteIDs: []uuid.UUID{siteID}, Items: items,
+	})
+	if err == nil {
+		t.Fatal("want an error: the target already has an in-flight task from another run")
+	}
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindConflict {
+		t.Fatalf("want a KindConflict domain error, got %v", err)
+	}
+	if got := len(repo.tasks); got != 1 {
+		t.Fatalf("total tasks ever created = %d, want 1 (no duplicate in-flight task)", got)
+	}
+
+	// Once the first run's task reaches a terminal state, a NEW run for the
+	// same target is a legitimate sequential re-update and must succeed.
+	repo.completeTask(siteID, TargetPlugin, "akismet")
+	run2, tasks2, err := svc.CreateRun(context.Background(), CreateRunInput{
+		TenantID: tenant, SiteIDs: []uuid.UUID{siteID}, Items: items,
+	})
+	if err != nil {
+		t.Fatalf("create run after the prior task completed: %v", err)
+	}
+	if len(tasks2) != 1 {
+		t.Fatalf("post-completion run task count = %d, want 1", len(tasks2))
+	}
+	if run2.ID == run1.ID {
+		t.Fatal("the post-completion run must be a distinct run from the first")
 	}
 }

--- a/apps/api/internal/update/worker.go
+++ b/apps/api/internal/update/worker.go
@@ -442,6 +442,81 @@ func (w *Worker) recordAudit(ctx context.Context, task Task) {
 	})
 }
 
+// ----------------------------------------------------------------------------
+// ReapStaleTasksArgs — periodic stale-task reaper sweep (#131 follow-up)
+// ----------------------------------------------------------------------------
+
+// ReapStaleTasksArgs is the River job payload for the periodic stale-task
+// reaper sweep. No fields — it enumerates stale rows itself.
+type ReapStaleTasksArgs struct{}
+
+// Kind implements river.JobArgs.
+func (ReapStaleTasksArgs) Kind() string { return "update_task_reaper" }
+
+// staleTaskThreshold is how long a task may sit in pending/running before the
+// reaper terminalizes it. Comfortably longer than any real update, including
+// the post-update health-probe retry window (worst case ~21s, see
+// probeRetryDelays) and the per-tenant parallelism snooze backoff: a worker
+// crash between MarkTaskRunning and finish(), or an EnqueueTask failure that
+// leaves a task pending (Service.CreateRun's best-effort enqueue after
+// CreateRunWithTasks), would otherwise permanently occupy the
+// update_tasks_inflight_target_idx slot for that (tenant, site, target) —
+// every future update attempt for it 409s targets_in_flight forever (m88).
+const staleTaskThreshold = 45 * time.Minute
+
+// staleTaskReapLimit bounds how many stale tasks one sweep reaps, so an
+// unbounded backlog cannot make a single periodic tick unbounded; any
+// remainder is caught by the next sweep (see the periodic job interval, wired
+// in cmd/wpmgr/main.go).
+const staleTaskReapLimit = 500
+
+// ReaperWorker is the periodic River job that sweeps update_tasks for rows
+// stuck in pending/running past staleTaskThreshold and terminalizes them as
+// failed, freeing the (tenant, site, target_type, target_slug) slot the
+// update_tasks_inflight_target_idx partial unique index (m88) would otherwise
+// hold forever. It wraps the same Worker used to execute update tasks and
+// reuses Worker.finish, so a reaped task gets the exact same treatment as a
+// task the agent itself finished (publish to the SSE hub + audit record + the
+// run-completion check that would otherwise never re-run for an orphaned run
+// whose last outstanding task never called finish()).
+type ReaperWorker struct {
+	river.WorkerDefaults[ReapStaleTasksArgs]
+	w *Worker
+}
+
+// NewReaperWorker builds the stale-task reaper, backed by the same Worker
+// (and therefore the same repo/hub/audit/logger) used to execute update
+// tasks.
+func NewReaperWorker(w *Worker) *ReaperWorker {
+	return &ReaperWorker{w: w}
+}
+
+// Work runs one reaper sweep: list stale tasks and terminalize each one.
+// Errors are logged and swallowed — the reaper must not fail the periodic
+// River job (that would just retry the exact same stale rows sooner).
+func (rw *ReaperWorker) Work(ctx context.Context, _ *river.Job[ReapStaleTasksArgs]) error {
+	stale, err := rw.w.repo.ListStaleUpdateTasks(ctx, staleTaskThreshold, staleTaskReapLimit)
+	if err != nil {
+		rw.w.logger.Warn("update task reaper: failed to list stale tasks", slog.Any("error", err))
+		return nil
+	}
+	for _, task := range stale {
+		if ferr := rw.w.finish(ctx, task, TaskFailed, task.FromVersion, task.ToVersion,
+			"stale: task exceeded max runtime", "reaped by the periodic stale-task sweep after no progress within the threshold"); ferr != nil {
+			rw.w.logger.Warn("update task reaper: failed to terminalize stale task",
+				slog.String("task_id", task.ID.String()), slog.Any("error", ferr))
+			continue
+		}
+		rw.w.logger.Warn("update task reaper: terminalized stale task",
+			slog.String("task_id", task.ID.String()),
+			slog.String("run_id", task.RunID.String()),
+			slog.String("site_id", task.SiteID.String()),
+			slog.String("target", task.TargetType+"/"+task.TargetSlug),
+			slog.String("prior_status", task.Status))
+	}
+	return nil
+}
+
 func firstResult(rs []agentcmd.ItemResult) agentcmd.ItemResult {
 	if len(rs) == 0 {
 		return agentcmd.ItemResult{Status: agentcmd.ItemFailed, Log: "agent returned no item result"}

--- a/apps/api/internal/update/worker_test.go
+++ b/apps/api/internal/update/worker_test.go
@@ -70,6 +70,14 @@ func (f *probeFakeRepo) CountRunningTasksForTenant(context.Context, uuid.UUID) (
 	panic("not implemented")
 }
 
+func (f *probeFakeRepo) ListInFlightTargets(context.Context, uuid.UUID, []uuid.UUID) (map[InFlightKey]struct{}, error) {
+	panic("not implemented")
+}
+
+func (f *probeFakeRepo) ListStaleUpdateTasks(context.Context, time.Duration, int32) ([]Task, error) {
+	panic("not implemented")
+}
+
 // fakeCommander records Rollback calls and never actually contacts an agent.
 type fakeCommander struct {
 	rollbackCalled bool

--- a/apps/api/internal/uptime/alerts.go
+++ b/apps/api/internal/uptime/alerts.go
@@ -218,10 +218,23 @@ func renderEmail(a Alert) (subject, body string) {
 			name, a.SiteURL, a.FiredAt.UTC().Format(time.RFC3339))
 		return subject, body
 	}
-	subject = fmt.Sprintf("[WPMgr] DOWN: %s is unreachable", name)
+	// wp_fatal_error/wp_db_error (issue #132) are WordPress fatal-error pages
+	// served with HTTP 200 — the site DID respond, so "is unreachable" is
+	// misleading; give operators copy that matches what scanFatal actually
+	// found instead of a generic reachability message.
 	detail := a.Error
-	if detail == "" && a.HTTPStatus > 0 {
-		detail = fmt.Sprintf("HTTP %d", a.HTTPStatus)
+	switch a.Error {
+	case "wp_fatal_error":
+		subject = fmt.Sprintf("[WPMgr] DOWN: %s is serving a critical-error page (HTTP 200)", name)
+		detail = "WordPress critical error: the site returns HTTP 200 with a fatal-error page"
+	case "wp_db_error":
+		subject = fmt.Sprintf("[WPMgr] DOWN: %s has a database connection error", name)
+		detail = "Error establishing a database connection (site returns HTTP 200)"
+	default:
+		subject = fmt.Sprintf("[WPMgr] DOWN: %s is unreachable", name)
+		if detail == "" && a.HTTPStatus > 0 {
+			detail = fmt.Sprintf("HTTP %d", a.HTTPStatus)
+		}
 	}
 	body = fmt.Sprintf("Your site %s (%s) appears to be DOWN as of %s.\nDetail: %s",
 		name, a.SiteURL, a.FiredAt.UTC().Format(time.RFC3339), detail)

--- a/apps/api/internal/uptime/probe.go
+++ b/apps/api/internal/uptime/probe.go
@@ -10,12 +10,16 @@
 package uptime
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptrace"
+	"os"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/httpclient"
@@ -23,7 +27,13 @@ import (
 
 // maxProbeBody bounds how much of the response body the probe reads (we only
 // need TTFB + a small drain to complete the request and free the connection).
+// It also bounds how much scanFatal ever buffers/inspects — see the Probe
+// body-buffering comment below (issue #132 S1).
 const maxProbeBody = 64 << 10
+
+// wpFatalDetectEnv is the kill-switch env var for the wp-fatal-page scan.
+// Detection defaults ON; only "0" or "false" (case-insensitive) disables it.
+const wpFatalDetectEnv = "WPMGR_UPTIME_WPFATAL_DETECT"
 
 // ProbeResult is the measured outcome of a single site probe. All durations are
 // milliseconds. Up is the classification (2xx/3xx = up; 5xx/timeout/conn-error
@@ -50,17 +60,29 @@ type ProbeResult struct {
 // uses the client's underlying *http.Client (SSRF transport preserved) with a
 // per-probe httptrace to break down DNS/connect/TLS/TTFB.
 type Prober struct {
-	client  *httpclient.Client
-	timeout time.Duration
+	client        *httpclient.Client
+	timeout       time.Duration
+	wpFatalDetect bool
 }
 
 // NewProber builds a Prober around the SSRF-hardened client. timeout bounds a
-// single probe (defaults to 15s when non-positive).
+// single probe (defaults to 15s when non-positive). The wp-fatal-page scan
+// kill-switch (WPMGR_UPTIME_WPFATAL_DETECT) is read once here, not per-probe.
 func NewProber(client *httpclient.Client, timeout time.Duration) *Prober {
 	if timeout <= 0 {
 		timeout = 15 * time.Second
 	}
-	return &Prober{client: client, timeout: timeout}
+	return &Prober{client: client, timeout: timeout, wpFatalDetect: wpFatalDetectEnabled()}
+}
+
+// wpFatalDetectEnabled reads the WPMGR_UPTIME_WPFATAL_DETECT kill-switch.
+// Detection defaults ON; only "0" or "false" (case-insensitive) disables it.
+func wpFatalDetectEnabled() bool {
+	v := strings.TrimSpace(os.Getenv(wpFatalDetectEnv))
+	if v == "" {
+		return true
+	}
+	return v != "0" && !strings.EqualFold(v, "false")
 }
 
 // Probe issues a GET to targetURL and measures the connection phases. A
@@ -132,8 +154,19 @@ func (p *Prober) Probe(ctx context.Context, targetURL string) ProbeResult {
 		fillTimings(&res, start, dnsStart, dnsDone, connectStart, connectDone, tlsStart, tlsDone, firstByte)
 		return res
 	}
-	defer func() { _, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxProbeBody)); _ = resp.Body.Close() }()
-	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxProbeBody))
+	defer func() { _ = resp.Body.Close() }()
+	// Buffer up to maxProbeBody bytes for the wp-fatal-page scan below. A
+	// WordPress fatal error only reaches the client as HTTP 200 once headers
+	// have already been sent (WP can no longer switch to a 500 at that
+	// point), which means the wp_die/db-error document is appended AFTER
+	// whatever partial page had already flushed — a modern block theme can
+	// flush 30-80 KB of inline global-styles CSS in <head> alone. A small
+	// head-only scan window would miss the appended document entirely, so we
+	// keep everything already read up to the existing maxProbeBody read
+	// budget (nothing beyond it is ever read, so memory stays bounded) rather
+	// than discarding all but a small head fraction of it (issue #132 S1).
+	var bodyBuf bytes.Buffer
+	_, _ = io.Copy(&bodyBuf, io.LimitReader(resp.Body, maxProbeBody))
 	end := time.Now()
 
 	res := ProbeResult{
@@ -148,6 +181,15 @@ func (p *Prober) Probe(ctx context.Context, targetURL string) ProbeResult {
 	}
 	if !res.Up {
 		res.Error = fmt.Sprintf("http status %d", resp.StatusCode)
+	} else if p.wpFatalDetect {
+		// A WordPress critical-error or database-connection page is served
+		// with HTTP 200, so a status-only classification never catches it;
+		// scan the buffered window for its structural signature and
+		// reclassify as DOWN when it matches (issue #132).
+		if down, reason := scanFatal(bodyBuf.Bytes(), resp.Header.Get("Content-Type")); down {
+			res.Up = false
+			res.Error = reason
+		}
 	}
 	fillTimings(&res, start, dnsStart, dnsDone, connectStart, connectDone, tlsStart, tlsDone, firstByte)
 	res.TotalMs = msSince(start, end)
@@ -178,4 +220,122 @@ func msSince(start, end time.Time) float64 {
 		return 0
 	}
 	return float64(end.Sub(start).Microseconds()) / 1000.0
+}
+
+// fatalProximityBytes bounds the byte distance allowed between a structural
+// marker and its companion phrase for scanFatal to treat them as the same
+// rendered error document rather than two unrelated mentions scattered
+// across an unrelated page (issue #132 S2). WordPress's own templates place
+// the marker and the message immediately adjacent to one another — for the
+// critical-error screen, <body id="error-page"> is followed straight away by
+// <div class="wp-die-message">{message}</div> with no chrome in between; for
+// the db-error screen, the <title>Database Error</title> and the lone <h1>
+// message are only a few dozen bytes apart in a page that is otherwise just
+// a bare <html><head>...</head><body>...</body></html> skeleton. 1 KB gives
+// generous margin for that real shape while staying far too tight to bridge
+// an article's separate code sample and prose paragraphs.
+const fatalProximityBytes = 1024
+
+// criticalErrorPhrase is the hard-coded, non-translated English phrase WP
+// core's fatal-error catch emits (wp-includes/load.php) before it has had a
+// chance to load translations.
+const criticalErrorPhrase = "there has been a critical error on this website"
+
+// dbConnectionPhrase is the hard-coded, non-translated English phrase
+// wpdb::bail()/dead_db() emits before WordPress has loaded translations.
+const dbConnectionPhrase = "error establishing a database connection"
+
+// dbErrorTitleRe matches WP core's dead_db() default <title> element
+// verbatim: just "Database Error", with no site branding around it. A real
+// page's own <title> almost always carries the site name/tagline around any
+// prose mention of a database error (e.g. a "How to Fix the Error
+// Establishing a Database Connection in WordPress - My Blog" support
+// article), so requiring the tag's entire content to be exactly this phrase
+// is a structural signal a legitimate page will not produce incidentally.
+var dbErrorTitleRe = regexp.MustCompile(`<title[^>]*>\s*database error\s*</title>`)
+
+// scanFatal inspects the buffered response body (at most maxProbeBody bytes,
+// see Probe) for the signature of a WordPress fatal-error page served with
+// HTTP 200 — the wp_die()-rendered critical-error screen, or the classic
+// database connection failure screen (issue #132).
+//
+// It only scans text/html responses (JSON/XML/binary bodies are skipped
+// outright). Both checks require a structural marker AND its companion
+// phrase to co-occur WITHIN fatalProximityBytes of each other — true DOM
+// co-location, not mere presence anywhere in the buffered response. That is
+// what makes a false-DOWN on a healthy site (one that merely discusses the
+// error, or quotes its markup in an unrelated code sample far from where it
+// mentions the phrase) effectively impossible, while still catching the real
+// chrome-less error document wherever it lands in the buffered window
+// (including one appended after tens of KB of already-flushed theme output —
+// issue #132 S1).
+//
+// This is intentionally stricter than internal/agentcmd/client.go's
+// fatalSignatures ("fatal error", "uncaught error", ...): that loose list is
+// fine for the post-update self-probe of a site we just changed, but far too
+// loose for monitoring arbitrary public sites, whose legitimate content may
+// contain those substrings.
+func scanFatal(body []byte, contentType string) (down bool, reason string) {
+	if !isHTMLContentType(contentType) {
+		return false, ""
+	}
+	window := bytes.ToLower(body)
+
+	if markerNearPhrase(window, `id="error-page"`, criticalErrorPhrase, fatalProximityBytes) ||
+		markerNearPhrase(window, `class="wp-die-message"`, criticalErrorPhrase, fatalProximityBytes) {
+		return true, "wp_fatal_error"
+	}
+
+	if loc := dbErrorTitleRe.FindIndex(window); loc != nil {
+		lo, hi := windowAround(loc[0], loc[1], fatalProximityBytes, len(window))
+		if bytes.Contains(window[lo:hi], []byte(dbConnectionPhrase)) {
+			return true, "wp_db_error"
+		}
+	}
+
+	return false, ""
+}
+
+// markerNearPhrase reports whether any occurrence of the literal marker and
+// any occurrence of phrase fall within proximity bytes of each other in
+// window (see fatalProximityBytes for why proximity, not mere presence,
+// matters here).
+func markerNearPhrase(window []byte, marker, phrase string, proximity int) bool {
+	markerBytes, phraseBytes := []byte(marker), []byte(phrase)
+	for cursor := 0; ; {
+		idx := bytes.Index(window[cursor:], markerBytes)
+		if idx < 0 {
+			return false
+		}
+		pos := cursor + idx
+		lo, hi := windowAround(pos, pos+len(markerBytes), proximity, len(window))
+		if bytes.Contains(window[lo:hi], phraseBytes) {
+			return true
+		}
+		cursor = pos + 1
+	}
+}
+
+// windowAround returns the [lo, hi) slice bounds spanning [start, end)
+// expanded by proximity bytes on each side, clamped to [0, length).
+func windowAround(start, end, proximity, length int) (lo, hi int) {
+	lo = start - proximity
+	if lo < 0 {
+		lo = 0
+	}
+	hi = end + proximity
+	if hi > length {
+		hi = length
+	}
+	return lo, hi
+}
+
+// isHTMLContentType reports whether the response's Content-Type header names
+// text/html, ignoring parameters (charset, etc.) and case.
+func isHTMLContentType(contentType string) bool {
+	ct := contentType
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	return strings.EqualFold(strings.TrimSpace(ct), "text/html")
 }

--- a/apps/api/internal/uptime/probe_test.go
+++ b/apps/api/internal/uptime/probe_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/netip"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -134,4 +135,238 @@ func indexOf(s, sub string) int {
 		}
 	}
 	return -1
+}
+
+// --- issue #132: wp-fatal-page detection ------------------------------------
+
+// wpDieCriticalErrorHTML is a realistic rendering of WordPress core's
+// _default_wp_die_handler() output for the "critical error" screen: both
+// structural markers (id="error-page", class="wp-die-message") and the
+// English phrase co-occur, well within the 16 KB scan window.
+const wpDieCriticalErrorHTML = `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>WordPress &rsaquo; Error</title>
+<style type="text/css">body{background:#f1f1f1;}</style>
+</head>
+<body id="error-page">
+<div class="wp-die-message">There has been a critical error on this website.</div>
+<p><a href="https://wordpress.org/support/article/faq-troubleshooting/">Learn more about troubleshooting WordPress.</a></p>
+</body>
+</html>`
+
+// wpDbErrorHTML is the classic "Error establishing a database connection"
+// screen (wpdb::bail()), which WordPress renders before translations are
+// loaded, so it carries no wp_die structural markers.
+const wpDbErrorHTML = `<!DOCTYPE html>
+<html>
+<head><title>Database Error</title></head>
+<body>
+<h1>Error establishing a database connection</h1>
+</body>
+</html>`
+
+func htmlServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestProbeWpFatalErrorDetected asserts a real wp_die critical-error page
+// (structural marker + phrase, HTTP 200) is reclassified DOWN with reason
+// "wp_fatal_error".
+func TestProbeWpFatalErrorDetected(t *testing.T) {
+	srv := htmlServer(t, http.StatusOK, wpDieCriticalErrorHTML)
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if res.Up {
+		t.Fatalf("expected a wp_die critical-error page to be classified DOWN, got %+v", res)
+	}
+	if res.HTTPStatus != http.StatusOK {
+		t.Fatalf("expected the underlying HTTP status to still be 200, got %d", res.HTTPStatus)
+	}
+	if res.Error != "wp_fatal_error" {
+		t.Fatalf("expected Error=wp_fatal_error, got %q", res.Error)
+	}
+}
+
+// TestProbeWpDbErrorDetected asserts the "Error establishing a database
+// connection" screen (HTTP 200, no wp_die markers) is reclassified DOWN with
+// reason "wp_db_error".
+func TestProbeWpDbErrorDetected(t *testing.T) {
+	srv := htmlServer(t, http.StatusOK, wpDbErrorHTML)
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if res.Up {
+		t.Fatalf("expected a db-error page to be classified DOWN, got %+v", res)
+	}
+	if res.Error != "wp_db_error" {
+		t.Fatalf("expected Error=wp_db_error, got %q", res.Error)
+	}
+}
+
+// TestProbeWpFatalFalsePositiveGuard asserts a full-theme page (header/nav/
+// hero filler) that merely quotes the critical-error phrase, with no
+// structural wp_die marker anywhere in the document, stays UP: the
+// marker-AND-phrase co-occurrence requirement (not the size of the scanned
+// window) is what guards this case.
+func TestProbeWpFatalFalsePositiveGuard(t *testing.T) {
+	filler := strings.Repeat("<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. </p>\n", 400)
+	body := "<html><head><title>My Blog</title></head><body><header>Nav/hero chrome</header>" +
+		filler +
+		"<p>In this post we explain what it means when WordPress says " +
+		"\"there has been a critical error on this website\" and how to fix it.</p>" +
+		"</body></html>"
+	srv := htmlServer(t, http.StatusOK, body)
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if !res.Up {
+		t.Fatalf("expected a full-theme page quoting the phrase with no wp_die marker to stay UP, got %+v", res)
+	}
+}
+
+// TestProbeWpFatalNormalPage asserts an ordinary HTML 200 page (no fatal
+// signature at all) stays UP.
+func TestProbeWpFatalNormalPage(t *testing.T) {
+	srv := htmlServer(t, http.StatusOK, "<html><body><h1>Welcome to my site</h1></body></html>")
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if !res.Up {
+		t.Fatalf("expected a normal page to be UP, got %+v", res)
+	}
+}
+
+// TestProbeWpFatalPhraseWithoutMarkerStaysUp asserts the English phrase alone,
+// without either wp_die structural marker, does NOT trip detection: both are
+// required to co-occur.
+func TestProbeWpFatalPhraseWithoutMarkerStaysUp(t *testing.T) {
+	body := "<html><body><p>There has been a critical error on this website.</p></body></html>"
+	srv := htmlServer(t, http.StatusOK, body)
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if !res.Up {
+		t.Fatalf("expected phrase-without-marker to stay UP, got %+v", res)
+	}
+}
+
+// TestProbeWpFatalNonHTMLContentTypeSkipped asserts a JSON body containing the
+// markers/phrase is never scanned (wrong Content-Type), so it stays UP.
+func TestProbeWpFatalNonHTMLContentTypeSkipped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"error-page","class":"wp-die-message","msg":"there has been a critical error on this website"}`))
+	}))
+	defer srv.Close()
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if !res.Up {
+		t.Fatalf("expected a non-HTML content-type to skip the scan and stay UP, got %+v", res)
+	}
+}
+
+// TestProbeWpFatalKillSwitch asserts WPMGR_UPTIME_WPFATAL_DETECT=0 disables
+// the scan entirely, even against a real fatal page: the prober reads the
+// env var once at construction.
+func TestProbeWpFatalKillSwitch(t *testing.T) {
+	t.Setenv(wpFatalDetectEnv, "0")
+	srv := htmlServer(t, http.StatusOK, wpDieCriticalErrorHTML)
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if !res.Up {
+		t.Fatalf("expected detection disabled by the kill-switch to stay UP, got %+v", res)
+	}
+}
+
+// --- issue #132 re-verification: M2/S1/S2 ------------------------------------
+
+// TestProbeWpDbErrorPhraseAlonePageStaysUp asserts a healthy support/blog
+// article whose own title and content discuss "the error establishing a
+// database connection" (a very common WordPress how-to topic) is NOT
+// reclassified DOWN: the bare phrase alone, without WordPress core's
+// dead_db() <title>Database Error</title> structural marker, must not trip
+// wp_db_error (M2).
+func TestProbeWpDbErrorPhraseAlonePageStaysUp(t *testing.T) {
+	body := "<html><head><title>How to Fix the Error Establishing a Database Connection in WordPress - My Blog</title></head>" +
+		"<body><h1>How to Fix the Error Establishing a Database Connection in WordPress</h1>" +
+		"<p>If your site shows \"error establishing a database connection\", here is how to fix it: " +
+		"check your wp-config.php credentials and confirm the database server is reachable.</p>" +
+		"</body></html>"
+	srv := htmlServer(t, http.StatusOK, body)
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if !res.Up {
+		t.Fatalf("expected a healthy how-to article mentioning the db-error phrase to stay UP, got %+v", res)
+	}
+}
+
+// TestProbeWpDbErrorStructuralPageDetected asserts WordPress core's
+// chrome-less dead_db() page — <title>Database Error</title> co-located with
+// the lone <h1>Error establishing a database connection</h1> — is still
+// reclassified DOWN with wp_db_error now that the bare-phrase path is gated
+// behind a structural marker (M2 regression guard for the real case).
+func TestProbeWpDbErrorStructuralPageDetected(t *testing.T) {
+	srv := htmlServer(t, http.StatusOK, wpDbErrorHTML)
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if res.Up {
+		t.Fatalf("expected the real dead_db() structural page to be classified DOWN, got %+v", res)
+	}
+	if res.Error != "wp_db_error" {
+		t.Fatalf("expected Error=wp_db_error, got %q", res.Error)
+	}
+}
+
+// TestProbeWpFatalAppendedAfterFlushedHead asserts a wp_die critical-error
+// document appended AFTER ~30 KB of already-flushed theme head content
+// (simulating a modern block theme's inline global-styles CSS, the primary
+// real-world shape of a 200-status WordPress fatal) is still detected: the
+// scan must cover the full buffered read window, not just the first 16 KB
+// (S1).
+func TestProbeWpFatalAppendedAfterFlushedHead(t *testing.T) {
+	head := strings.Repeat("<div>Block theme inline global-styles CSS chrome. </div>\n", 600)
+	if len(head) <= 30<<10 {
+		t.Fatalf("test head filler too small to exceed 30KB: %d bytes", len(head))
+	}
+	body := "<html><head><title>My Site</title></head><body>" + head + wpDieCriticalErrorHTML + "</body></html>"
+	if len(body) >= maxProbeBody {
+		t.Fatalf("test body too large, exceeds maxProbeBody: %d bytes", len(body))
+	}
+	srv := htmlServer(t, http.StatusOK, body)
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if res.Up {
+		t.Fatalf("expected a wp_die doc appended after 30KB+ of flushed head content to be classified DOWN, got %+v", res)
+	}
+	if res.Error != "wp_fatal_error" {
+		t.Fatalf("expected Error=wp_fatal_error, got %q", res.Error)
+	}
+}
+
+// TestProbeWpFatalProximityGuard asserts a tutorial article that discusses
+// the critical-error phrase in its intro, then separately quotes the
+// id="error-page" marker in an unrelated <pre><code> markup sample several
+// KB later, stays UP: the marker and phrase must be DOM-co-located (within
+// fatalProximityBytes), not merely both present anywhere in the buffered
+// response (S2).
+func TestProbeWpFatalProximityGuard(t *testing.T) {
+	intro := "<p>WordPress sometimes shows a critical error page. In this article we explain what " +
+		"\"there has been a critical error on this website\" means and how to fix it.</p>\n"
+	filler := strings.Repeat("<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. </p>\n", 60)
+	if len(filler) <= fatalProximityBytes {
+		t.Fatalf("test filler too small to exceed fatalProximityBytes: %d bytes", len(filler))
+	}
+	codeSample := `<p>The error page markup looks like this:</p><pre><code>&lt;body id="error-page"&gt;...&lt;/body&gt;</code></pre>`
+	body := "<html><head><title>Understanding the WordPress Critical Error Screen</title></head><body>" +
+		intro + filler + codeSample + "</body></html>"
+	srv := htmlServer(t, http.StatusOK, body)
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if !res.Up {
+		t.Fatalf("expected a marker and phrase separated by unrelated article body to stay UP, got %+v", res)
+	}
 }

--- a/apps/api/migrations/20260721000000_m88_update_tasks_inflight_dedup.sql
+++ b/apps/api/migrations/20260721000000_m88_update_tasks_inflight_dedup.sql
@@ -1,0 +1,65 @@
+-- m88: cross-run dedup guard for update_tasks (#131 hardening)
+--
+-- Root cause: nothing prevented multiple update RUNS from creating tasks for
+-- the SAME (site, target) at the same time. planTasks/normalizeItems only
+-- dedup WITHIN one run, and the River queue caps concurrency per TENANT (not
+-- per site+target). So a scheduled auto-update, an operator "Update all", and
+-- a client-portal trigger firing within the same ~1s window for the same
+-- (site, plugin) could all create tasks, and up to perTenantLimit of them run
+-- concurrently. That (a) races the agent's own rollback-snapshot pruning — a
+-- task's own snapshot can be deleted by a sibling task's cleanup, producing
+-- "rollback FAILED / Invalid snapshot id" — and (b) runs concurrent
+-- WordPress Plugin_Upgrader instances against the same plugin directory,
+-- which can corrupt wp-content/plugins/<slug>.
+--
+-- Fix: a partial UNIQUE index on (tenant_id, site_id, target_type,
+-- target_slug) restricted to the in-flight statuses ('pending','running')
+-- means Postgres itself rejects a second in-flight task for the same target
+-- while one already exists — this is the authoritative, race-free guard (a
+-- service-level pre-check narrows the window further but cannot itself be
+-- atomic). Once a task reaches a terminal status (succeeded/failed/
+-- rolled_back/skipped) it falls out of the partial index automatically, so a
+-- legitimate SEQUENTIAL re-update after the prior one finished is unaffected.
+--
+-- Pre-dedup (ship-blocker fix): on a LIVE database that already ran the
+-- buggy pre-m88 code, multiple pending/running tasks can already exist for
+-- the same (tenant, site, target_type, target_slug) — that is the exact bug
+-- this migration fixes, and there is no reaper, so they persist indefinitely.
+-- CREATE UNIQUE INDEX below would then fail outright on the duplicate data,
+-- and since the migration runner wraps each migration in a tx and aborts
+-- boot on error (internal/db/migrate.go), that would hard-block the API from
+-- booting on prod and on every self-hoster who already has one of these
+-- collisions sitting in their table.
+--
+-- Terminalize all but the newest in-flight row per target as 'skipped' before
+-- the index is created, so CREATE UNIQUE INDEX always succeeds. "Newest" is
+-- (created_at, id) DESC — the same composite tiebreaker used elsewhere in the
+-- project for created_at-ordered comparisons, since a burst of same-instant
+-- inserts shares created_at and a bare created_at comparison would not
+-- totally order them. The UPDATE is naturally idempotent/safe to re-run: once
+-- no duplicates remain, the EXISTS predicate matches nothing and it is a
+-- no-op; wrapped in a DO $$ block to keep this migration's style consistent
+-- with the rest of the file (mirrors m36's idempotent-migration convention).
+DO $$
+BEGIN
+    UPDATE update_tasks u
+    SET status = 'skipped', finished_at = now(), updated_at = now(),
+        detail = 'skipped: superseded by a newer duplicate in-flight task for the same target (m88 dedup)'
+    WHERE u.status IN ('pending', 'running')
+      AND EXISTS (
+          SELECT 1 FROM update_tasks v
+          WHERE v.tenant_id = u.tenant_id
+            AND v.site_id = u.site_id
+            AND v.target_type = u.target_type
+            AND v.target_slug = u.target_slug
+            AND v.status IN ('pending', 'running')
+            AND (v.created_at, v.id) > (u.created_at, u.id)
+      );
+END $$;
+
+-- Plain CREATE INDEX (the migration runner wraps each migration in a tx, so
+-- CONCURRENTLY is unavailable — see m85); IF NOT EXISTS makes it re-run safe.
+
+CREATE UNIQUE INDEX IF NOT EXISTS update_tasks_inflight_target_idx ON update_tasks
+    (tenant_id, site_id, target_type, target_slug)
+    WHERE status IN ('pending', 'running');

--- a/apps/api/migrations/20260722000000_m89_update_tasks_agent_rls.sql
+++ b/apps/api/migrations/20260722000000_m89_update_tasks_agent_rls.sql
@@ -1,0 +1,34 @@
+-- m89: add the missing app.agent RLS policy on update_tasks (#131 follow-up)
+--
+-- Root cause: update_tasks was created (M3) with only
+-- update_tasks_tenant_isolation (the app.tenant_id operator-path policy) — no
+-- app.agent policy, unlike the m36-template tables that ship with both from
+-- day one. Every existing update_tasks query ran under InTenantTx, so this
+-- went unnoticed. The #131 stale-task reaper (ReaperWorker.Work ->
+-- Repo.ListStaleUpdateTasks) is the first CROSS-TENANT read against this
+-- table: it runs under InAgentTx (app.agent = 'on', app.tenant_id unset) to
+-- find stuck tasks belonging to ANY tenant in one sweep. Under FORCE ROW
+-- LEVEL SECURITY with only the tenant_isolation policy present, that context
+-- satisfies neither policy, so the SELECT silently returned zero rows on
+-- every sweep — the exact "FOR UPDATE / cross-tenant query returns nothing
+-- under app.agent" class of bug already fixed once for backup_schedules in
+-- m84.
+--
+-- Fix: add update_tasks_agent, mirroring the m36 template's paired policy
+-- convention. Idempotent: guarded CREATE POLICY inside a DO block, safe to
+-- re-run.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename  = 'update_tasks'
+          AND policyname = 'update_tasks_agent'
+    ) THEN
+        CREATE POLICY update_tasks_agent ON update_tasks
+            USING (current_setting('app.agent', true) = 'on')
+            WITH CHECK (current_setting('app.agent', true) = 'on');
+    END IF;
+END;
+$$;

--- a/apps/api/tests/update_m88_dedup_test.go
+++ b/apps/api/tests/update_m88_dedup_test.go
@@ -1,0 +1,327 @@
+package tests
+
+import (
+	"context"
+	"io/fs"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/migrations"
+)
+
+// m88MigrationVersion is the embedded migration filename (sans .sql) that adds
+// update_tasks_inflight_target_idx. The harness below stops short of applying
+// it so the test can seed the exact pre-m88 duplicate-row scenario the
+// migration must heal before creating the unique index.
+const m88MigrationVersion = "20260721000000_m88_update_tasks_inflight_dedup"
+
+// startPostgresBeforeM88 mirrors startPostgres's container bootstrap but
+// applies every embedded migration UP TO (not including) m88, using the
+// bootstrap superuser connection (matching cmd/wpmgr/main.go's real migration
+// DSN, which is also the owner/superuser). The caller seeds pre-m88 data, then
+// finishes the boot with pool.Migrate(ctx), which applies exactly m88 (and any
+// later migration, of which there are currently none).
+func startPostgresBeforeM88(t *testing.T) *db.Pool {
+	t.Helper()
+	ctx := context.Background()
+
+	container, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("wpmgr"),
+		tcpostgres.WithUsername("wpmgr"),
+		tcpostgres.WithPassword("wpmgr"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	pool, err := db.Connect(ctx, adminDSN)
+	if err != nil {
+		t.Fatalf("connect admin: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	applyMigrationsBefore(t, pool, m88MigrationVersion)
+	return pool
+}
+
+// applyMigrationsBefore re-implements the (unexported) Pool.Migrate loop from
+// internal/db/migrate.go so this test can stop short of one named version:
+// same embedded FS, same lexical ordering, same one-tx-per-migration +
+// schema_migrations bookkeeping. Fails the test if stopAt is not found among
+// the embedded migrations (a version rename would otherwise silently apply
+// everything and defeat the test).
+func applyMigrationsBefore(t *testing.T, pool *db.Pool, stopAt string) {
+	t.Helper()
+	ctx := context.Background()
+
+	if _, err := pool.Exec(ctx, `CREATE TABLE IF NOT EXISTS schema_migrations (
+		version    text        PRIMARY KEY,
+		applied_at timestamptz NOT NULL DEFAULT now()
+	)`); err != nil {
+		t.Fatalf("ensure schema_migrations: %v", err)
+	}
+
+	entries, err := fs.ReadDir(migrations.FS, ".")
+	if err != nil {
+		t.Fatalf("read embedded migrations: %v", err)
+	}
+	var versions []string
+	files := map[string]string{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".sql") {
+			continue
+		}
+		version := strings.TrimSuffix(name, ".sql")
+		versions = append(versions, version)
+		files[version] = name
+	}
+	sort.Strings(versions)
+
+	found := false
+	for _, version := range versions {
+		if version == stopAt {
+			found = true
+			break
+		}
+		body, err := fs.ReadFile(migrations.FS, files[version])
+		if err != nil {
+			t.Fatalf("read migration %s: %v", version, err)
+		}
+		err = pgx.BeginFunc(ctx, pool.Pool, func(tx pgx.Tx) error {
+			if _, err := tx.Exec(ctx, string(body)); err != nil {
+				return err
+			}
+			_, err := tx.Exec(ctx, "INSERT INTO schema_migrations (version) VALUES ($1)", version)
+			return err
+		})
+		if err != nil {
+			t.Fatalf("apply migration %s: %v", version, err)
+		}
+	}
+	if !found {
+		t.Fatalf("stopAt version %q not found among embedded migrations (renamed/removed?)", stopAt)
+	}
+}
+
+// TestM88MigrationDedupesPreexistingInFlightDuplicates is the ship-blocker
+// regression test: on a LIVE database that already ran the buggy pre-m88 code,
+// multiple pending/running update_tasks rows can already exist for the same
+// (tenant, site, target_type, target_slug) — that is the exact bug m88 fixes,
+// and prior to the reaper there was nothing to clean them up, so they persist
+// indefinitely. CREATE UNIQUE INDEX would fail outright on that duplicate
+// data, and since the migration runner wraps each migration in a tx and
+// aborts boot on error, that would hard-block the API from booting for every
+// affected deployment. This test seeds the exact collision, then proves the
+// migration heals it before creating the index.
+func TestM88MigrationDedupesPreexistingInFlightDuplicates(t *testing.T) {
+	pool := startPostgresBeforeM88(t)
+	ctx := context.Background()
+
+	tenant := seedTenant(t, pool, "m88-dedup")
+
+	var siteID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO sites (tenant_id, url, name) VALUES ($1, $2, $3) RETURNING id`,
+		tenant, "https://m88-dedup.example.com", "m88 dedup site",
+	).Scan(&siteID); err != nil {
+		t.Fatalf("seed site: %v", err)
+	}
+
+	var runID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO update_runs (tenant_id, status) VALUES ($1, 'running') RETURNING id`,
+		tenant,
+	).Scan(&runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+
+	// Seed THREE duplicate in-flight tasks for the SAME (tenant, site, target)
+	// — the exact pre-m88 bug (#131): a scheduled auto-update, an operator
+	// bulk "Update all", and a client-portal trigger could each create a task
+	// for the same (site, plugin) concurrently, since nothing before m88
+	// prevented it. Stagger created_at so "keep the newest" is unambiguous,
+	// and mix pending/running so the dedup statement's status IN (...) filter
+	// is exercised on both.
+	base := time.Now().Add(-time.Hour)
+	var newestID uuid.UUID
+	for i, status := range []string{"pending", "running", "pending"} {
+		createdAt := base.Add(time.Duration(i) * time.Minute)
+		var id uuid.UUID
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO update_tasks
+			   (run_id, tenant_id, site_id, target_type, target_slug, status, created_at, updated_at)
+			 VALUES ($1, $2, $3, 'plugin', 'akismet', $4, $5, $5)
+			 RETURNING id`,
+			runID, tenant, siteID, status, createdAt,
+		).Scan(&id); err != nil {
+			t.Fatalf("seed duplicate task %d: %v", i, err)
+		}
+		newestID = id // last iteration has the latest created_at
+	}
+
+	// A DIFFERENT target on the same site is not a duplicate and must survive
+	// the dedup statement untouched.
+	var unrelatedID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO update_tasks (run_id, tenant_id, site_id, target_type, target_slug, status)
+		 VALUES ($1, $2, $3, 'plugin', 'woocommerce', 'pending')
+		 RETURNING id`,
+		runID, tenant, siteID,
+	).Scan(&unrelatedID); err != nil {
+		t.Fatalf("seed unrelated task: %v", err)
+	}
+
+	// Finish the boot: this applies m88. It must succeed even though the
+	// table already carries the duplicate in-flight rows above.
+	if err := pool.Migrate(ctx); err != nil {
+		t.Fatalf("m88 migration failed on a table with pre-existing in-flight duplicates: %v", err)
+	}
+
+	// Exactly one in-flight (pending/running) row remains for the deduped
+	// target, and it is the newest of the three duplicates.
+	rows, err := pool.Query(ctx,
+		`SELECT id FROM update_tasks
+		 WHERE tenant_id = $1 AND site_id = $2 AND target_type = 'plugin' AND target_slug = 'akismet'
+		   AND status IN ('pending', 'running')`,
+		tenant, siteID)
+	if err != nil {
+		t.Fatalf("query survivors: %v", err)
+	}
+	var survivors []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan survivor: %v", err)
+		}
+		survivors = append(survivors, id)
+	}
+	rows.Close()
+	if len(survivors) != 1 {
+		t.Fatalf("want exactly 1 in-flight survivor, got %d: %v", len(survivors), survivors)
+	}
+	if survivors[0] != newestID {
+		t.Fatalf("survivor = %s, want the newest duplicate %s", survivors[0], newestID)
+	}
+
+	// The two superseded duplicates were terminalized (history preserved, not
+	// deleted) as 'skipped'.
+	var skippedCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM update_tasks
+		 WHERE tenant_id = $1 AND site_id = $2 AND target_type = 'plugin' AND target_slug = 'akismet'
+		   AND status = 'skipped'`,
+		tenant, siteID).Scan(&skippedCount); err != nil {
+		t.Fatalf("count skipped: %v", err)
+	}
+	if skippedCount != 2 {
+		t.Fatalf("want 2 skipped duplicates, got %d", skippedCount)
+	}
+
+	// The unrelated target is untouched.
+	var unrelatedStatus string
+	if err := pool.QueryRow(ctx, `SELECT status FROM update_tasks WHERE id = $1`, unrelatedID).
+		Scan(&unrelatedStatus); err != nil {
+		t.Fatalf("get unrelated task: %v", err)
+	}
+	if unrelatedStatus != "pending" {
+		t.Fatalf("unrelated task status = %q, want untouched pending", unrelatedStatus)
+	}
+
+	// The partial unique index now exists.
+	var idxCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM pg_indexes WHERE indexname = 'update_tasks_inflight_target_idx'`,
+	).Scan(&idxCount); err != nil {
+		t.Fatalf("check index: %v", err)
+	}
+	if idxCount != 1 {
+		t.Fatal("update_tasks_inflight_target_idx was not created")
+	}
+
+	// The index is actually enforcing going forward: a fresh duplicate insert
+	// for the same in-flight target now fails.
+	_, err = pool.Exec(ctx,
+		`INSERT INTO update_tasks (run_id, tenant_id, site_id, target_type, target_slug, status)
+		 VALUES ($1, $2, $3, 'plugin', 'akismet', 'pending')`,
+		runID, tenant, siteID)
+	if err == nil {
+		t.Fatal("expected the partial unique index to reject a second in-flight duplicate after m88")
+	}
+}
+
+// TestM88MigrationIsNoopWhenNoDuplicatesExist proves the common case (a
+// database with no pre-existing collisions, e.g. every fresh install and
+// every deployment that never hit the pre-m88 race) is unaffected: the
+// pre-dedup UPDATE touches nothing and the index is created normally.
+func TestM88MigrationIsNoopWhenNoDuplicatesExist(t *testing.T) {
+	pool := startPostgresBeforeM88(t)
+	ctx := context.Background()
+
+	tenant := seedTenant(t, pool, "m88-noop")
+	var siteID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO sites (tenant_id, url, name) VALUES ($1, $2, $3) RETURNING id`,
+		tenant, "https://m88-noop.example.com", "m88 noop site",
+	).Scan(&siteID); err != nil {
+		t.Fatalf("seed site: %v", err)
+	}
+	var runID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO update_runs (tenant_id, status) VALUES ($1, 'running') RETURNING id`,
+		tenant,
+	).Scan(&runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	var taskID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO update_tasks (run_id, tenant_id, site_id, target_type, target_slug, status)
+		 VALUES ($1, $2, $3, 'plugin', 'akismet', 'running')
+		 RETURNING id`,
+		runID, tenant, siteID,
+	).Scan(&taskID); err != nil {
+		t.Fatalf("seed single in-flight task: %v", err)
+	}
+
+	if err := pool.Migrate(ctx); err != nil {
+		t.Fatalf("m88 migration failed on a clean table: %v", err)
+	}
+
+	var status string
+	if err := pool.QueryRow(ctx, `SELECT status FROM update_tasks WHERE id = $1`, taskID).Scan(&status); err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if status != "running" {
+		t.Fatalf("single in-flight task status = %q, want untouched running", status)
+	}
+
+	var idxCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM pg_indexes WHERE indexname = 'update_tasks_inflight_target_idx'`,
+	).Scan(&idxCount); err != nil {
+		t.Fatalf("check index: %v", err)
+	}
+	if idxCount != 1 {
+		t.Fatal("update_tasks_inflight_target_idx was not created")
+	}
+}

--- a/apps/api/tests/update_reaper_test.go
+++ b/apps/api/tests/update_reaper_test.go
@@ -1,0 +1,182 @@
+package tests
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/update"
+)
+
+// TestUpdateReaperTerminalizesStaleTasks proves the #131 follow-up reaper: a
+// task stuck in pending/running past the stale-task threshold (a worker crash
+// between MarkTaskRunning and finish(), or a failed enqueue that leaves a task
+// pending) is terminalized as failed, its run completes if that was the last
+// outstanding task, and a task that is NOT yet stale is left untouched.
+func TestUpdateReaperTerminalizesStaleTasks(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "upd-reaper")
+	fa := newFakeAgent(t)
+	fa.setHomepage(http.StatusOK, "<html>ok</html>")
+
+	h := buildHarness(t, pool, newTestCommander(t), newTestProber(t))
+	s := enrollFakeSite(t, pool, tenant, fa.url())
+	fa.setExpectAud(s.ID.String())
+
+	// update_runs/update_tasks carry FORCE ROW LEVEL SECURITY: seeding rows
+	// directly (bypassing Service.CreateRun, which would run the update
+	// through the worker instead of leaving it "stuck") requires the
+	// superuser connection, same as any other out-of-band-tampering test.
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+
+	// --- Run A: one task stuck 'running' for 2 hours (well past the 45-minute
+	// stale-task threshold) — simulates a worker that crashed after
+	// MarkTaskRunning but before it ever called finish().
+	var staleRunID uuid.UUID
+	if err := admin.QueryRow(ctx,
+		`INSERT INTO update_runs (tenant_id, status) VALUES ($1, 'running') RETURNING id`,
+		tenant,
+	).Scan(&staleRunID); err != nil {
+		t.Fatalf("seed stale run: %v", err)
+	}
+	staleSince := time.Now().Add(-2 * time.Hour)
+	var staleTaskID uuid.UUID
+	if err := admin.QueryRow(ctx,
+		`INSERT INTO update_tasks
+		   (run_id, tenant_id, site_id, target_type, target_slug, status, started_at, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'plugin', 'stuck-plugin', 'running', $4, $4, $4)
+		 RETURNING id`,
+		staleRunID, tenant, s.ID, staleSince,
+	).Scan(&staleTaskID); err != nil {
+		t.Fatalf("seed stale task: %v", err)
+	}
+
+	// --- Run B: one task stuck 'pending' for 2 hours — simulates a failed
+	// EnqueueTask that left the row created but never picked up by a worker.
+	var stalePendingRunID uuid.UUID
+	if err := admin.QueryRow(ctx,
+		`INSERT INTO update_runs (tenant_id, status) VALUES ($1, 'pending') RETURNING id`,
+		tenant,
+	).Scan(&stalePendingRunID); err != nil {
+		t.Fatalf("seed stale-pending run: %v", err)
+	}
+	var stalePendingTaskID uuid.UUID
+	if err := admin.QueryRow(ctx,
+		`INSERT INTO update_tasks
+		   (run_id, tenant_id, site_id, target_type, target_slug, status, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'plugin', 'never-enqueued-plugin', 'pending', $4, $4)
+		 RETURNING id`,
+		stalePendingRunID, tenant, s.ID, staleSince,
+	).Scan(&stalePendingTaskID); err != nil {
+		t.Fatalf("seed stale-pending task: %v", err)
+	}
+
+	// --- Run C: one task 'running' with a RECENT updated_at (well inside the
+	// threshold) — must be left untouched by the sweep (no false positives).
+	var freshRunID uuid.UUID
+	if err := admin.QueryRow(ctx,
+		`INSERT INTO update_runs (tenant_id, status) VALUES ($1, 'running') RETURNING id`,
+		tenant,
+	).Scan(&freshRunID); err != nil {
+		t.Fatalf("seed fresh run: %v", err)
+	}
+	fresh := time.Now().Add(-1 * time.Minute)
+	var freshTaskID uuid.UUID
+	if err := admin.QueryRow(ctx,
+		`INSERT INTO update_tasks
+		   (run_id, tenant_id, site_id, target_type, target_slug, status, started_at, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'plugin', 'in-progress-plugin', 'running', $4, $4, $4)
+		 RETURNING id`,
+		freshRunID, tenant, s.ID, fresh,
+	).Scan(&freshTaskID); err != nil {
+		t.Fatalf("seed fresh task: %v", err)
+	}
+
+	// Run one reaper sweep directly (no need to wait for the 10-minute
+	// periodic interval).
+	reaper := update.NewReaperWorker(h.worker)
+	if err := reaper.Work(ctx, &river.Job[update.ReapStaleTasksArgs]{}); err != nil {
+		t.Fatalf("reaper sweep: %v", err)
+	}
+
+	// The stale 'running' task is terminalized as failed.
+	staleTask, err := h.repo.GetTask(ctx, tenant, staleTaskID)
+	if err != nil {
+		t.Fatalf("get stale task: %v", err)
+	}
+	if staleTask.Status != update.TaskFailed {
+		t.Fatalf("stale running task status = %s, want failed", staleTask.Status)
+	}
+	if staleTask.FinishedAt == nil {
+		t.Fatal("reaped task must have finished_at set")
+	}
+	if staleTask.Detail != "stale: task exceeded max runtime" {
+		t.Fatalf("stale task detail = %q, want the stale-reap reason", staleTask.Detail)
+	}
+
+	// The stale 'pending' task is ALSO terminalized (the reaper must catch
+	// both pending and running, per the failed-enqueue scenario).
+	stalePendingTask, err := h.repo.GetTask(ctx, tenant, stalePendingTaskID)
+	if err != nil {
+		t.Fatalf("get stale-pending task: %v", err)
+	}
+	if stalePendingTask.Status != update.TaskFailed {
+		t.Fatalf("stale pending task status = %s, want failed", stalePendingTask.Status)
+	}
+
+	// The fresh, still-in-progress task is untouched.
+	freshTask, err := h.repo.GetTask(ctx, tenant, freshTaskID)
+	if err != nil {
+		t.Fatalf("get fresh task: %v", err)
+	}
+	if freshTask.Status != update.TaskRunning {
+		t.Fatalf("fresh task status = %s, want still running (untouched)", freshTask.Status)
+	}
+
+	// Reaping the last outstanding task of a run must also complete that run
+	// (mirrors the normal Worker.finish behaviour) — otherwise the run would
+	// stay "running"/"pending" forever even after its only task terminalized.
+	staleRun, _, err := h.svc.GetRun(ctx, tenant, staleRunID)
+	if err != nil {
+		t.Fatalf("get stale run: %v", err)
+	}
+	if staleRun.Status != update.RunCompleted {
+		t.Fatalf("stale run status = %s, want completed", staleRun.Status)
+	}
+	stalePendingRun, _, err := h.svc.GetRun(ctx, tenant, stalePendingRunID)
+	if err != nil {
+		t.Fatalf("get stale-pending run: %v", err)
+	}
+	if stalePendingRun.Status != update.RunCompleted {
+		t.Fatalf("stale-pending run status = %s, want completed", stalePendingRun.Status)
+	}
+
+	// The fresh run must NOT have been marked completed.
+	freshRun, _, err := h.svc.GetRun(ctx, tenant, freshRunID)
+	if err != nil {
+		t.Fatalf("get fresh run: %v", err)
+	}
+	if freshRun.Status == update.RunCompleted {
+		t.Fatal("fresh run must not be completed by the reaper sweep")
+	}
+
+	// A second sweep is a no-op for the already-reaped tasks (idempotent):
+	// their status is now terminal so ListStaleUpdateTasks no longer selects
+	// them, regardless of how stale their (now-refreshed) updated_at is.
+	if err := reaper.Work(ctx, &river.Job[update.ReapStaleTasksArgs]{}); err != nil {
+		t.Fatalf("second reaper sweep: %v", err)
+	}
+	staleTaskAgain, err := h.repo.GetTask(ctx, tenant, staleTaskID)
+	if err != nil {
+		t.Fatalf("get stale task (second sweep): %v", err)
+	}
+	if staleTaskAgain.Status != update.TaskFailed {
+		t.Fatalf("stale task status after second sweep = %s, want unchanged failed", staleTaskAgain.Status)
+	}
+}

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,94 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.10",
+    date: "2026-07-02",
+    summary: "Bulk updates only touch sites that actually need them.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Multi-site bulk update now only creates a task for a site that actually has the selected update pending, instead of also creating a task, and then failing it, for every selected site that does not have that plugin, theme, or core update available. Sites the update does not apply to are now reported as skipped, not failed.",
+      },
+    ],
+  },
+  {
+    version: "0.61.9",
+    date: "2026-07-02",
+    summary: "A failed update no longer strands a site in maintenance mode.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "A failed plugin or theme update no longer leaves a site stuck showing WordPress's maintenance page to every visitor. The post-update health check now tolerates a brief, transient 503 from an in-progress database migration instead of treating it as a failure and rolling back an update that actually succeeded.",
+      },
+    ],
+  },
+  {
+    version: "0.61.6",
+    date: "2026-07-02",
+    summary: "Reliable downtime alerts and a faster Sites list.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Downtime email alerts now fire reliably. A race in the alert state machine could let a sustained outage go unalerted; alert state now transitions atomically so every qualifying outage sends its alert.",
+      },
+      {
+        tag: "Fixed",
+        text: "The Notifications settings page now saves correctly, including the daily email digest toggle.",
+      },
+      {
+        tag: "Fixed",
+        text: "Fixed a slow first load of the Sites list after the dashboard had been idle for a while.",
+      },
+    ],
+  },
+  {
+    version: "0.61.3",
+    date: "2026-06-26",
+    summary: "A batch of dashboard, backup, and update fixes.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Backups now correctly preserve plugin and theme vendor code that happens to live in a folder named cache or upgrade, while still excluding real runtime cache and update staging files.",
+      },
+      {
+        tag: "Fixed",
+        text: "The backup schedule form no longer rejects valid day-of-week, day-of-month, or hourly-interval selections, and update run history now shows accurate task counts and completion progress.",
+      },
+      {
+        tag: "Fixed",
+        text: "Closing any dialog no longer leaves the page unclickable, and bulk plugin and theme updates now default to only the items that actually have an update available.",
+      },
+    ],
+    featureLinks: [{ label: "Backups", href: "/features/backups/" }],
+  },
+  {
+    version: "0.61.0",
+    date: "2026-06-23",
+    summary: "File Manager for every managed site.",
+    items: [
+      {
+        tag: "Added",
+        text: "Browse, preview, edit, upload, download, zip, and restore prior versions of files on any managed WordPress site, right from the dashboard, no SFTP or cPanel required. A sensitive-file deny list and a separate write-access toggle keep it safe, and every action is written to the audit log. Off by default; only owners and admins can turn it on.",
+      },
+      {
+        tag: "Added",
+        text: "CloudPanel sites now get integrated cache purging: WPMgr clears its own page cache and CloudPanel's Varnish cache together, no separate plugin needed.",
+      },
+    ],
+    featureLinks: [{ label: "File Manager", href: "/features/file-manager/" }],
+  },
+  {
+    version: "0.57.7",
+    date: "2026-06-21",
+    summary: "New multipage marketing website.",
+    items: [
+      {
+        tag: "Changed",
+        text: "The public site at wpmgr.app is now a multipage, server-rendered site: a dedicated page for every feature, solution pages by audience and by job, pricing, this changelog, a resources area, and a self-hosted API reference generated from the OpenAPI spec. Faster, fully crawlable, and easier to extend.",
+      },
+    ],
+  },
+  {
     version: "0.57.0",
     date: "2026-06-21",
     summary: "Vulnerability feed configuration from the dashboard.",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.51.5 / open source",
+  badge: "v0.61.10 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",


### PR DESCRIPTION
Two infoproxa-oss bugs from the same RunCloud incident, hardened across 3 adversarial verification rounds + 2 security reviews.

**#131** — agent-driven updates half-wrote plugins on open_basedir hosts and left sites fatal/reported-succeeded. Fix: resource guards + open_basedir-safe temp; forced snapshot + synchronous auto-restore + flock-gated out-of-band reconcile; bounded snapshot GC; dropped the over-eager vendor check that false-reverted good updates; the @is_dir warning-flood one-liner. Plus CP-side: m88 cross-run dedup (partial unique index, pre-dedupes to stay boot-safe) so concurrent same-plugin updates can't race/corrupt, m89 update_tasks app.agent RLS, and a stale-task reaper. Agent 0.61.8.

**#132** — uptime prober was blind to WordPress's HTTP-200 critical-error page. Conservative body-signature detection (wp_die structural marker + phrase within 1024 bytes, full-64KB scan, default-on + kill-switch). No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer update handling so interrupted plugin/theme updates can recover automatically.
  * Added a background task to clear stuck update jobs and keep updates moving.
  * Improved uptime checks to detect WordPress fatal-error and database-connection pages.

* **Bug Fixes**
  * Fixed issues that could leave maintenance mode or update state stuck after failed updates.
  * Improved update reliability, rollback behavior, and duplicate task prevention.

* **Documentation**
  * Updated changelog and release listings with the latest published versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->