### PR TITLE
fix(api): #132 locale-independent WSOD uptime detection (German + all locales)

### DIFF
--- a/apps/api/internal/uptime/probe.go
+++ b/apps/api/internal/uptime/probe.go
@@ -236,14 +236,83 @@ func msSince(start, end time.Time) float64 {
 // an article's separate code sample and prose paragraphs.
 const fatalProximityBytes = 1024
 
-// criticalErrorPhrase is the hard-coded, non-translated English phrase WP
+// criticalErrorPhraseEN is the hard-coded, non-translated English phrase WP
 // core's fatal-error catch emits (wp-includes/load.php) before it has had a
 // chance to load translations.
-const criticalErrorPhrase = "there has been a critical error on this website"
+const criticalErrorPhraseEN = "there has been a critical error on this website"
+
+// criticalErrorPhrases is the SUPPLEMENTARY, precise detection layer for the
+// wp_die() critical-error screen (issue #132): each entry is matched near a
+// structural marker exactly like criticalErrorPhraseEN always was. It is not
+// the primary defense against non-English sites — bodyErrorPageRe below is,
+// because it keys on markup WP core hard-codes and never translates — but it
+// stays as a belt-and-suspenders layer for a hypothetical page that kept a
+// recognizable message string while altering the body-tag structure enough to
+// dodge bodyErrorPageRe. English plus the two German wp_die variants WP core
+// ships (informal "deiner"/formal "Ihrer" address) are listed because the
+// reporter's fleet is ~90% German; any other locale is still caught by the
+// structural signal without needing an entry here.
+var criticalErrorPhrases = []string{
+	criticalErrorPhraseEN,
+	"es gab einen kritischen fehler auf deiner website",
+	"es gab einen kritischen fehler auf ihrer website",
+}
 
 // dbConnectionPhrase is the hard-coded, non-translated English phrase
 // wpdb::bail()/dead_db() emits before WordPress has loaded translations.
 const dbConnectionPhrase = "error establishing a database connection"
+
+// bodyErrorPageRe matches WordPress core's _default_wp_die_handler() document
+// by its actual opening <body> tag: `id="error-page"` (single or double
+// quotes), allowing any other attributes before/around it. This tag, along
+// with the `class="wp-die-message"` wrapper around the message (checked
+// alongside it in scanFatal), is hard-coded in wp-includes/functions.php and
+// is NEVER translated — only the visible message text is — so this is the
+// locale-independent, primary signal for the critical-error screen: it
+// catches German, French, or any other locale with zero phrase-table
+// maintenance (issue #132).
+//
+// Keying on the BODY TAG specifically (not "error-page" appearing anywhere)
+// is what keeps this safe from false positives: a healthy themed page's real
+// <body> tag is body_class()-generated (e.g. `<body class="home page ...">`)
+// and never carries id="error-page", and a tutorial page that quotes this
+// exact markup in a code sample does so HTML-escaped (`&lt;body ...&gt;`),
+// which does not contain a literal "<body" and so cannot match this pattern.
+//
+// The attribute is required to be WHITESPACE-separated (`\s`, not a bare word
+// boundary `\b`): a real id attribute is always preceded by whitespace —
+// `<body id=...>` or `<body class="x" id=...>` — whereas `\b` also matches at
+// a hyphen (a non-word byte), so it let a contrived `<body data-id="error-page">`
+// or `<body my-id='error-page'>` match even though neither is WP core's
+// error-page body tag (issue #132 M2 regex-tightening fix).
+var bodyErrorPageRe = regexp.MustCompile(`<body[^>]*\sid=["']error-page["']`)
+
+// wpDieMessageClassLiteral is the companion structural marker checked near a
+// bodyErrorPageRe match (trigger 1 only): WP core wraps the (translated)
+// message in `<div class="wp-die-message">`, immediately following the
+// <body> tag with no theme chrome in between. A bare `class="wp-die-message"`
+// literal is safe here specifically because trigger 1 only ever checks it
+// alongside an ALREADY-matched real, unescaped bodyErrorPageRe tag — an
+// escaped code sample never gets this far, since bodyErrorPageRe itself
+// cannot match escaped markup (see its comment).
+const wpDieMessageClassLiteral = `class="wp-die-message"`
+
+// wpDieMessageDivLiteral is the companion structural marker for the
+// phrase-table path (trigger 2 in scanFatal): unlike wpDieMessageClassLiteral
+// above, trigger 2 has no already-matched real <body> tag to lean on, so its
+// own marker must itself require the REAL (unescaped) opening tag prefix,
+// `<div class="wp-die-message"`, not the bare `class="wp-die-message"`
+// attribute text. HTML-escaping rewrites `<`/`>` to `&lt;`/`&gt;` but leaves
+// `class="..."` byte sequences untouched inside a quoted code sample, so the
+// bare attribute text alone survives escaping and a tutorial article that
+// shows the wp_die markup as an escaped `<pre><code>` sample can supply it —
+// this is the exact false positive found in verification: a healthy German
+// how-to page whose code sample renders `&lt;body id="error-page"&gt;` /
+// `&lt;div class="wp-die-message"&gt;` within proximity of the German phrase
+// in its prose was misclassified DOWN. Requiring the `<div` tag prefix closes
+// that gap the same way bodyErrorPageRe already closes it for the body tag:
+// escaping the `<` breaks the literal, so an escaped sample can never match.
+const wpDieMessageDivLiteral = `<div class="wp-die-message"`
 
 // dbErrorTitleRe matches WP core's dead_db() default <title> element
 // verbatim: just "Database Error", with no site branding around it. A real
@@ -260,15 +329,36 @@ var dbErrorTitleRe = regexp.MustCompile(`<title[^>]*>\s*database error\s*</title
 // database connection failure screen (issue #132).
 //
 // It only scans text/html responses (JSON/XML/binary bodies are skipped
-// outright). Both checks require a structural marker AND its companion
-// phrase to co-occur WITHIN fatalProximityBytes of each other — true DOM
-// co-location, not mere presence anywhere in the buffered response. That is
-// what makes a false-DOWN on a healthy site (one that merely discusses the
-// error, or quotes its markup in an unrelated code sample far from where it
-// mentions the phrase) effectively impossible, while still catching the real
-// chrome-less error document wherever it lands in the buffered window
-// (including one appended after tens of KB of already-flushed theme output —
-// issue #132 S1).
+// outright). The critical-error screen is detected by TWO independent
+// triggers, either of which reclassifies the probe as DOWN with reason
+// "wp_fatal_error":
+//
+//  1. The locale-independent structural signal (primary): bodyErrorPageRe's
+//     <body id="error-page"> matched near the wp-die-message class wrapper.
+//     Both are hard-coded in WP core and never translated, so this alone
+//     catches the error screen on every locale — including the reporter's
+//     ~90%-German fleet — with no phrase-table maintenance.
+//  2. The localized phrase table (supplementary, precise layer): a REAL,
+//     unescaped structural marker — bodyErrorPageRe's <body id="error-page">
+//     tag, or the wpDieMessageDivLiteral <div class="wp-die-message"> tag
+//     prefix — co-occurring with one of criticalErrorPhrases. This exists for
+//     a hypothetical page that kept a recognizable message string while
+//     altering the body-tag structure enough to dodge trigger 1. Both markers
+//     require the real, unescaped tag prefix (not a bare attribute literal)
+//     for the same reason bodyErrorPageRe does: HTML-escaping rewrites `<`/`>`
+//     but leaves `id="..."`/`class="..."` byte sequences untouched, so a bare
+//     attribute literal alone would still match inside an escaped code-sample
+//     quote of the markup (issue #132 false-positive fix — a healthy how-to
+//     page's escaped `<pre><code>` sample was tripping this trigger).
+//
+// Every check requires a structural marker AND its companion signal to
+// co-occur WITHIN fatalProximityBytes of each other — true DOM co-location,
+// not mere presence anywhere in the buffered response. That is what makes a
+// false-DOWN on a healthy site (one that merely discusses the error, quotes
+// its markup HTML-escaped in a code sample, or renders its own themed <body>
+// tag) effectively impossible, while still catching the real chrome-less
+// error document wherever it lands in the buffered window (including one
+// appended after tens of KB of already-flushed theme output — issue #132 S1).
 //
 // This is intentionally stricter than internal/agentcmd/client.go's
 // fatalSignatures ("fatal error", "uncaught error", ...): that loose list is
@@ -281,9 +371,15 @@ func scanFatal(body []byte, contentType string) (down bool, reason string) {
 	}
 	window := bytes.ToLower(body)
 
-	if markerNearPhrase(window, `id="error-page"`, criticalErrorPhrase, fatalProximityBytes) ||
-		markerNearPhrase(window, `class="wp-die-message"`, criticalErrorPhrase, fatalProximityBytes) {
+	if markerRegexNearLiteral(window, bodyErrorPageRe, wpDieMessageClassLiteral, fatalProximityBytes) {
 		return true, "wp_fatal_error"
+	}
+
+	for _, phrase := range criticalErrorPhrases {
+		if markerRegexNearLiteral(window, bodyErrorPageRe, phrase, fatalProximityBytes) ||
+			markerNearPhrase(window, wpDieMessageDivLiteral, phrase, fatalProximityBytes) {
+			return true, "wp_fatal_error"
+		}
 	}
 
 	if loc := dbErrorTitleRe.FindIndex(window); loc != nil {
@@ -314,6 +410,25 @@ func markerNearPhrase(window []byte, marker, phrase string, proximity int) bool 
 		}
 		cursor = pos + 1
 	}
+}
+
+// markerRegexNearLiteral reports whether any match of re and any occurrence
+// of literal fall within proximity bytes of each other in window. This is
+// markerNearPhrase's counterpart for a structural marker that needs a regex
+// (bodyErrorPageRe's <body> tag can carry arbitrary other attributes) rather
+// than a fixed literal. literal is not necessarily another structural
+// marker — scanFatal's trigger 2 also calls this with a criticalErrorPhrases
+// entry as literal, to check a phrase's proximity to the regex-matched body
+// tag.
+func markerRegexNearLiteral(window []byte, re *regexp.Regexp, literal string, proximity int) bool {
+	literalBytes := []byte(literal)
+	for _, loc := range re.FindAllIndex(window, -1) {
+		lo, hi := windowAround(loc[0], loc[1], proximity, len(window))
+		if bytes.Contains(window[lo:hi], literalBytes) {
+			return true
+		}
+	}
+	return false
 }
 
 // windowAround returns the [lo, hi) slice bounds spanning [start, end)

--- a/apps/api/internal/uptime/probe_test.go
+++ b/apps/api/internal/uptime/probe_test.go
@@ -347,6 +347,139 @@ func TestProbeWpFatalAppendedAfterFlushedHead(t *testing.T) {
 	}
 }
 
+// --- issue #132 follow-up: non-English wp_die critical-error pages ---------
+
+// wpDieCriticalErrorGermanInformalHTML is a real wp_die() critical-error
+// document rendered in German using the informal "Du" address — one of the
+// two message variants WordPress core ships alongside the formal "Sie" form.
+// Both structural markers are identical to the English rendering (they are
+// hard-coded and never translated); only the message text differs.
+const wpDieCriticalErrorGermanInformalHTML = `<!DOCTYPE html>
+<html lang="de-DE">
+<head><meta charset="utf-8"><title>WordPress &rsaquo; Fehler</title>
+<style type="text/css">body{background:#f1f1f1;}</style>
+</head>
+<body id="error-page">
+<div class="wp-die-message">Es gab einen kritischen Fehler auf deiner Website.</div>
+<p><a href="https://wordpress.org/support/article/faq-troubleshooting/">Mehr &uuml;ber die Fehlerbehebung von WordPress erfahren.</a></p>
+</body>
+</html>`
+
+// wpDieCriticalErrorGermanFormalHTML is the same document rendered with the
+// formal "Sie" address (the other WP-shipped German variant).
+const wpDieCriticalErrorGermanFormalHTML = `<!DOCTYPE html>
+<html lang="de-DE">
+<head><meta charset="utf-8"><title>WordPress &rsaquo; Fehler</title>
+<style type="text/css">body{background:#f1f1f1;}</style>
+</head>
+<body id="error-page">
+<div class="wp-die-message">Es gab einen kritischen Fehler auf Ihrer Website.</div>
+</body>
+</html>`
+
+// wpDieCriticalErrorFrenchHTML is a real wp_die() critical-error document in
+// a locale that is NOT in criticalErrorPhrases — it exists specifically to
+// prove detection does not depend on the phrase table: only the structural
+// signal (bodyErrorPageRe + class="wp-die-message") can catch this one.
+const wpDieCriticalErrorFrenchHTML = `<!DOCTYPE html>
+<html lang="fr-FR">
+<head><meta charset="utf-8"><title>WordPress &rsaquo; Erreur</title>
+</head>
+<body id="error-page">
+<div class="wp-die-message">Une erreur critique est survenue sur ce site.</div>
+</body>
+</html>`
+
+// TestProbeWpFatalGermanInformalDetected asserts a real German (Du-form)
+// wp_die critical-error page, HTTP 200, is reclassified DOWN — proving the
+// structural signal (and the supplementary German phrase entry) catch the
+// reporter's ~90%-German fleet, not just English.
+func TestProbeWpFatalGermanInformalDetected(t *testing.T) {
+	srv := htmlServer(t, http.StatusOK, wpDieCriticalErrorGermanInformalHTML)
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if res.Up {
+		t.Fatalf("expected a German (Du-form) wp_die critical-error page to be classified DOWN, got %+v", res)
+	}
+	if res.Error != "wp_fatal_error" {
+		t.Fatalf("expected Error=wp_fatal_error, got %q", res.Error)
+	}
+}
+
+// TestProbeWpFatalGermanFormalDetected is the formal "Sie" address sibling of
+// TestProbeWpFatalGermanInformalDetected.
+func TestProbeWpFatalGermanFormalDetected(t *testing.T) {
+	srv := htmlServer(t, http.StatusOK, wpDieCriticalErrorGermanFormalHTML)
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if res.Up {
+		t.Fatalf("expected a German (Sie-form) wp_die critical-error page to be classified DOWN, got %+v", res)
+	}
+	if res.Error != "wp_fatal_error" {
+		t.Fatalf("expected Error=wp_fatal_error, got %q", res.Error)
+	}
+}
+
+// TestProbeWpFatalUntabledLocaleDetectedViaStructure asserts a wp_die
+// critical-error page in a locale that has NO entry in criticalErrorPhrases
+// (French, here) is still reclassified DOWN — proof that detection is
+// locale-independent rather than depending on maintaining a phrase per
+// language.
+func TestProbeWpFatalUntabledLocaleDetectedViaStructure(t *testing.T) {
+	srv := htmlServer(t, http.StatusOK, wpDieCriticalErrorFrenchHTML)
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if res.Up {
+		t.Fatalf("expected a French wp_die critical-error page (no phrase-table entry) to be classified DOWN via the structural signal, got %+v", res)
+	}
+	if res.Error != "wp_fatal_error" {
+		t.Fatalf("expected Error=wp_fatal_error, got %q", res.Error)
+	}
+}
+
+// TestProbeWpFatalGermanHealthyPageQuotingPhraseStaysUp is the German
+// counterpart of TestProbeWpFatalFalsePositiveGuard: a fully-themed, healthy
+// German page (real body_class()-style <body> tag, full nav/header chrome)
+// whose article body merely QUOTES the German critical-error phrase stays UP.
+// The phrase is present, but the real <body> tag is not id="error-page" and
+// the quote sits far from any structural marker.
+func TestProbeWpFatalGermanHealthyPageQuotingPhraseStaysUp(t *testing.T) {
+	filler := strings.Repeat("<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. </p>\n", 400)
+	body := `<html><head><title>Mein Blog</title></head><body class="home page-template-default">` +
+		"<header>Nav/hero chrome</header>" +
+		filler +
+		`<p>In diesem Beitrag erkl&auml;ren wir, was WordPress meint, wenn es hei&szlig;t ` +
+		`&quot;Es gab einen kritischen Fehler auf deiner Website&quot;, und wie man das behebt.</p>` +
+		"</body></html>"
+	srv := htmlServer(t, http.StatusOK, body)
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if !res.Up {
+		t.Fatalf("expected a healthy German page quoting the phrase with a real themed body tag to stay UP, got %+v", res)
+	}
+}
+
+// TestProbeWpFatalEscapedCodeSampleBodyTagStaysUp asserts a healthy page whose
+// real <body> tag is an ordinary themed one, but whose article separately
+// shows the wp_die markup as an HTML-escaped code sample (id="error-page"
+// text present, but only inside `&lt;body ...&gt;`, never as a literal
+// unescaped "<body" tag), stays UP. This is the case bodyErrorPageRe is
+// specifically designed not to match.
+func TestProbeWpFatalEscapedCodeSampleBodyTagStaysUp(t *testing.T) {
+	body := `<html><head><title>Understanding the WordPress Critical Error Screen</title></head>` +
+		`<body class="home page-template-default">` +
+		`<header>Nav/hero chrome</header>` +
+		`<p>The error page markup looks like this:</p>` +
+		`<pre><code>&lt;body id="error-page"&gt;&lt;div class="wp-die-message"&gt;...&lt;/div&gt;&lt;/body&gt;</code></pre>` +
+		`</body></html>`
+	srv := htmlServer(t, http.StatusOK, body)
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if !res.Up {
+		t.Fatalf("expected an escaped code-sample body tag (never a literal <body ...> tag) to stay UP, got %+v", res)
+	}
+}
+
 // TestProbeWpFatalProximityGuard asserts a tutorial article that discusses
 // the critical-error phrase in its intro, then separately quotes the
 // id="error-page" marker in an unrelated <pre><code> markup sample several
@@ -368,5 +501,89 @@ func TestProbeWpFatalProximityGuard(t *testing.T) {
 	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
 	if !res.Up {
 		t.Fatalf("expected a marker and phrase separated by unrelated article body to stay UP, got %+v", res)
+	}
+}
+
+// --- issue #132 re-verification: escaped-code-sample phrase-path false positive ---
+//
+// A verification pass found a real false positive: a HEALTHY tutorial page
+// (real themed <body>, an article explaining the critical-error message,
+// and a <pre><code> sample showing the wp_die markup HTML-ESCAPED) was
+// misclassified DOWN. The cause was scanFatal's phrase path (trigger 2)
+// keying on the BARE literals `id="error-page"` / `class="wp-die-message"`:
+// HTML-escaping only rewrites `<`/`>`, so those bare attribute byte
+// sequences survive untouched inside `&lt;body id="error-page"&gt;` /
+// `&lt;div class="wp-die-message"&gt;`, letting an escaped code sample
+// supply the "structural marker" the phrase path was checking proximity
+// against. The fix requires trigger 2's markers to include the real,
+// unescaped tag prefix (bodyErrorPageRe's `<body ...id="error-page"` or the
+// `<div class="wp-die-message"` literal), exactly like the structural
+// trigger 1 always did — so an escaped sample can never supply either
+// marker.
+
+// TestProbeWpFatalGermanTutorialEscapedCodeSampleStaysUp is the exact false
+// positive found in verification: a healthy German tutorial page — a real
+// themed <body> tag, an <article> whose heading/intro contains the German
+// critical-error phrase, and a <pre><code> block showing the wp_die markup
+// HTML-ESCAPED within a few hundred bytes of the phrase — must stay UP. This
+// test FAILS against the pre-fix code (the bare-literal phrase path treats
+// the escaped code sample's surviving `id="error-page"`/`class="wp-die-
+// message"` byte sequences as a real structural marker) and PASSES once
+// trigger 2 requires the real, unescaped tag prefix.
+func TestProbeWpFatalGermanTutorialEscapedCodeSampleStaysUp(t *testing.T) {
+	body := `<html><head><title>Wie man den kritischen WordPress-Fehler behebt</title></head>` +
+		`<body class="post-template-default single single-post">` +
+		`<article>` +
+		`<h1>Wie man den Fehler &quot;Es gab einen kritischen Fehler auf deiner Website&quot; behebt</h1>` +
+		`<p>Wenn dieser Fehler auftritt, rendert WordPress eine Seite mit folgendem HTML-Markup:</p>` +
+		`<pre><code>&lt;body id="error-page"&gt;&lt;div class="wp-die-message"&gt;Es gab einen kritischen Fehler auf deiner Website.&lt;/div&gt;&lt;/body&gt;</code></pre>` +
+		`<p>Um das Problem zu beheben, deaktiviere zun&auml;chst alle Plugins und aktiviere sie einzeln wieder.</p>` +
+		`</article></body></html>`
+	srv := htmlServer(t, http.StatusOK, body)
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if !res.Up {
+		t.Fatalf("expected a healthy German tutorial page with an escaped code sample near the phrase to stay UP, got %+v", res)
+	}
+}
+
+// TestProbeWpFatalEnglishTutorialEscapedCodeSampleStaysUp is the English
+// sibling of TestProbeWpFatalGermanTutorialEscapedCodeSampleStaysUp, proving
+// the fix is not locale-specific.
+func TestProbeWpFatalEnglishTutorialEscapedCodeSampleStaysUp(t *testing.T) {
+	body := `<html><head><title>How to Fix the WordPress Critical Error</title></head>` +
+		`<body class="post-template-default single single-post">` +
+		`<article>` +
+		`<h1>How to Fix "There Has Been a Critical Error on This Website"</h1>` +
+		`<p>When this happens, WordPress renders a page with the following HTML markup:</p>` +
+		`<pre><code>&lt;body id="error-page"&gt;&lt;div class="wp-die-message"&gt;There has been a critical error on this website.&lt;/div&gt;&lt;/body&gt;</code></pre>` +
+		`<p>To fix it, deactivate all plugins and reactivate them one at a time.</p>` +
+		`</article></body></html>`
+	srv := htmlServer(t, http.StatusOK, body)
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if !res.Up {
+		t.Fatalf("expected a healthy English tutorial page with an escaped code sample near the phrase to stay UP, got %+v", res)
+	}
+}
+
+// TestProbeWpFatalHyphenatedBodyAttributeStaysUp is the bodyErrorPageRe
+// regex-tightening guard: a contrived `<body data-id="error-page">` (a
+// hyphenated attribute, not a real `id` attribute) alongside a genuinely
+// real, unescaped `<div class="wp-die-message">` wrapper (containing
+// unrelated text, no critical-error phrase) must stay UP. Before the `\b`→
+// `\s` tightening, bodyErrorPageRe's word-boundary check matched at the
+// hyphen too, so this contrived body tag was wrongly treated as the real
+// WP core error-page tag and trigger 1 fired on the nearby real div wrapper.
+func TestProbeWpFatalHyphenatedBodyAttributeStaysUp(t *testing.T) {
+	body := `<html><head><title>My Site</title></head>` +
+		`<body data-id="error-page" class="custom-theme">` +
+		`<div class="wp-die-message">Welcome to my custom themed section.</div>` +
+		`</body></html>`
+	srv := htmlServer(t, http.StatusOK, body)
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if !res.Up {
+		t.Fatalf("expected a hyphenated data-id body attribute (not a real id=\"error-page\" tag) to stay UP, got %+v", res)
 	}
 }


### PR DESCRIPTION
Follow-up to #132: the WSOD detector was English-phrase-only, so a non-English (reporter: ~90% German) critical-error page rendered HTTP 200 stayed UP. Now keys on the locale-independent wp_die structure (real `<body id="error-page">` tag + `<div class="wp-die-message">` wrapper) so every language is caught, plus a German phrase table. Both paths require the real unescaped markup, so tutorials quoting the markup stay UP (an adversarial pass caught that FP in-market before ship). api-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WordPress uptime checks to better detect fatal-error pages across multiple languages.
  * Reduced false positives by requiring stronger HTML structure matches, including escaped code samples and similar-looking markup.
  * Tightened detection so non-matching page attributes no longer trigger downtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->