### PR TITLE
fix(agent/security): 2FA interstitial resume info-disclosure (browser-bind) — agent 0.61.9

### DIFF
--- a/apps/agent/includes/security/class-site-2fa-module.php
+++ b/apps/agent/includes/security/class-site-2fa-module.php
@@ -63,6 +63,28 @@
  * exactly mirroring the 2FA failure/success paths. A legitimate user who changes
  * their password successfully is NOT counted as a failure.
  *
+ * BROWSER-BINDING FIX (I1 fix -- wp.org review, 0.61.9):
+ * maybeResumeInterstitial() re-renders a pending session keyed purely on
+ * $_POST['wpmgr_2fa_user_id'] plus the existence of a server-side session --
+ * with no proof the caller is the browser that started the flow. For a pending
+ * SETUP session this let an unauthenticated caller who merely knows or guesses
+ * a user_id (e.g. 1) POST it to wp-login.php and have renderSetupScreen()
+ * disclose that user's pending TOTP secret/QR, undermining enrollment.
+ *
+ * Fix: every session minted by createSession() also mints a random "bind"
+ * token, stores only its SHA-256 hash in session['bind_hash'], and sets an
+ * HttpOnly/SameSite=Lax cookie (COOKIE_BIND) carrying the raw token, scoped to
+ * the login path and expiring with the session. maybeResumeInterstitial() now
+ * requires hasValidBindCookie() to hash_equals()-match BEFORE rendering ANY
+ * pending screen (setup, 2FA verify, or forced-change); a missing or
+ * mismatched cookie falls through to the normal login page instead of
+ * re-rendering anything. A session minted before this fix (no bind_hash key)
+ * is treated as unsafe to resume -- never as implicitly trusted -- the user
+ * simply logs in again to mint a bound session. The existing HMAC token on the
+ * verify/setup SUBMIT path (computeSessionHmac/verifySessionHmac) is
+ * unchanged: this adds the render-time browser binding the resume path was
+ * missing, it does not replace the HMAC.
+ *
  * LOCKOUT-PROOFING:
  * - If define('WPMGR_DISABLE_SITE_2FA', true) is in wp-config, 2FA and
  *   forced-change enforcement are fully disabled.
@@ -106,6 +128,18 @@ final class Site2faModule
     /** Cookie name for the trusted-device token. */
     public const COOKIE_DEVICE = 'wpmgr_2fa_device';
 
+    /**
+     * Cookie name for the browser-binding token minted alongside every
+     * interstitial session. Only the browser holding this HttpOnly cookie may
+     * resume a pending session's render on login_init -- see
+     * maybeResumeInterstitial() / hasValidBindCookie(). This closes an
+     * info-disclosure where an unauthenticated caller who merely knows or
+     * guesses a user_id could otherwise re-render a pending SETUP screen
+     * (which exposes the pending TOTP secret/QR) without ever having received
+     * the original form.
+     */
+    public const COOKIE_BIND = 'wpmgr_2fa_bind';
+
     /** Interstitial session TTL in seconds (1 hour). */
     private const SESSION_TTL = 3600;
 
@@ -120,6 +154,9 @@ final class Site2faModule
 
     /** Minimum cookie token length for trusted-device tokens. */
     private const DEVICE_TOKEN_BYTES = 32;
+
+    /** Byte length of the browser-binding token minted for interstitial sessions. */
+    private const BIND_TOKEN_BYTES = 32;
 
     /**
      * Interstitial session type identifier for the standard 2FA challenge.
@@ -639,8 +676,10 @@ final class Site2faModule
         }
 
         // Check if there is a pending session for a known user_id in POST/GET.
+        // This user_id alone proves nothing (it is attacker-guessable); the
+        // hasValidBindCookie() check below is what gates the actual render.
         $userId = isset($_POST['wpmgr_2fa_user_id']) // phpcs:ignore WordPress.Security.NonceVerification.Missing -- interstitial session uses its own HMAC signing, not WP nonces (see section 3.2: machine session, not browser nonce)
-            ? absint(wp_unslash($_POST['wpmgr_2fa_user_id'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing -- same; the HMAC token field validates session integrity
+            ? absint(wp_unslash($_POST['wpmgr_2fa_user_id'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing -- same
             : 0;
         if ($userId <= 0) {
             return;
@@ -653,6 +692,18 @@ final class Site2faModule
 
         $session = $this->loadSession($userId);
         if ($session === null) {
+            return;
+        }
+
+        // BROWSER-BINDING FIX (I1): only the browser that originated this
+        // session -- and therefore received the wpmgr_2fa_bind cookie when the
+        // session was created -- may resume ANY pending screen here. This
+        // path is reached with nothing but a guessable user_id and an
+        // existing session, so without a bind match we must not render
+        // anything: falling through to the normal login page, rather than
+        // re-rendering the setup screen (which can expose a pending TOTP
+        // secret/QR), the 2FA verify form, or the forced-change form.
+        if (!$this->hasValidBindCookie($session)) {
             return;
         }
 
@@ -1222,6 +1273,13 @@ final class Site2faModule
         $uuid    = bin2hex(random_bytes(16));
         $id      = bin2hex(random_bytes(16));
         $created = time();
+
+        // BROWSER-BINDING FIX (I1): mint a random token whose hash alone is
+        // stored server-side; the raw token is handed to the browser only via
+        // an HttpOnly cookie. Resuming this session's render later requires
+        // proving possession of that cookie (see hasValidBindCookie()).
+        $bindToken = bin2hex(random_bytes(self::BIND_TOKEN_BYTES));
+
         $session = [
             'id'          => $id,
             'uuid'        => $uuid,
@@ -1231,8 +1289,10 @@ final class Site2faModule
             'remember_me' => $rememberMe,
             'attempts'    => 0,
             'type'        => $type,
+            'bind_hash'   => hash('sha256', $bindToken),
         ];
         $this->storeSession($userId, $session);
+        $this->setBindCookie($bindToken);
         return $session;
     }
 
@@ -1288,6 +1348,110 @@ final class Site2faModule
         if (function_exists('delete_user_meta')) {
             delete_user_meta($userId, self::META_SESSION);
         }
+        $this->clearBindCookie();
+    }
+
+    // -------------------------------------------------------------------------
+    // Browser-binding cookie (I1 fix)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Check whether the current request carries a browser-binding cookie that
+     * hash-matches the given session's bind_hash.
+     *
+     * BACKWARD-COMPAT: a session minted before this fix carries no bind_hash
+     * key. That is treated as "cannot safely resume a session screen" -- NOT
+     * as implicitly trusted -- so this returns false rather than throwing or
+     * silently allowing the render. The user simply logs in again, which
+     * mints a fresh, bound session.
+     *
+     * @param array<string,mixed> $session
+     * @return bool
+     */
+    private function hasValidBindCookie(array $session): bool
+    {
+        if (!isset($session['bind_hash']) || !is_string($session['bind_hash']) || $session['bind_hash'] === '') {
+            return false;
+        }
+
+        if (!isset($_COOKIE[self::COOKIE_BIND]) || !is_string($_COOKIE[self::COOKIE_BIND])) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitized on the next line
+            return false;
+        }
+
+        $raw = sanitize_text_field(wp_unslash($_COOKIE[self::COOKIE_BIND]));
+        if ($raw === '' || strlen($raw) < self::BIND_TOKEN_BYTES * 2) {
+            return false;
+        }
+
+        return hash_equals($session['bind_hash'], hash('sha256', $raw));
+    }
+
+    /**
+     * Set the browser-binding cookie for a newly minted interstitial session.
+     * HttpOnly + SameSite=Lax + Secure-when-SSL; scoped to the login path and
+     * expiring alongside the session (SESSION_TTL).
+     *
+     * @param string $token Raw bind token (its hash is what session['bind_hash'] stores).
+     * @return void
+     */
+    private function setBindCookie(string $token): void
+    {
+        if (headers_sent()) {
+            return;
+        }
+        setcookie(
+            self::COOKIE_BIND,
+            $token,
+            [
+                'expires'  => time() + self::SESSION_TTL,
+                'path'     => $this->loginPath(),
+                'httponly' => true,
+                'secure'   => is_ssl(),
+                'samesite' => 'Lax',
+            ]
+        );
+    }
+
+    /**
+     * Clear the browser-binding cookie. Called whenever the interstitial
+     * session itself is cleared, so a stale bind token never outlives its
+     * session.
+     *
+     * @return void
+     */
+    private function clearBindCookie(): void
+    {
+        if (headers_sent()) {
+            return;
+        }
+        setcookie(
+            self::COOKIE_BIND,
+            '',
+            [
+                'expires'  => time() - self::SESSION_TTL,
+                'path'     => $this->loginPath(),
+                'httponly' => true,
+                'secure'   => is_ssl(),
+                'samesite' => 'Lax',
+            ]
+        );
+    }
+
+    /**
+     * Resolve the path component of the site's login URL, used to scope the
+     * browser-binding cookie so it is only ever sent back to wp-login.php.
+     *
+     * @return string
+     */
+    private function loginPath(): string
+    {
+        if (function_exists('wp_login_url') && function_exists('wp_parse_url')) {
+            $parsed = wp_parse_url(wp_login_url());
+            if (is_array($parsed) && isset($parsed['path']) && is_string($parsed['path']) && $parsed['path'] !== '') {
+                return $parsed['path'];
+            }
+        }
+        return '/wp-login.php';
     }
 
     /**

--- a/apps/agent/tests/Security/Site2faModuleTest.php
+++ b/apps/agent/tests/Security/Site2faModuleTest.php
@@ -1252,4 +1252,491 @@ final class Site2faModuleTest extends TestCase
             'N1 regression: cross-request check must still return true when no failures recorded'
         );
     }
+
+    // -------------------------------------------------------------------------
+    // I1: Browser-binding fix for maybeResumeInterstitial() (wp.org review, 0.61.9)
+    //
+    // THE VULNERABILITY: maybeResumeInterstitial() re-rendered ANY pending
+    // session (including SETUP, which displays a pending TOTP secret/QR) keyed
+    // only on $_POST['wpmgr_2fa_user_id'] plus the existence of a server-side
+    // session -- with no proof the caller was the browser that started the
+    // flow. An attacker who merely knew/guessed a user_id could disclose that
+    // user's pending TOTP secret while a setup session was live.
+    //
+    // THE FIX: createSession() now mints a random bind token, stores only its
+    // SHA-256 hash in session['bind_hash'], and hands the raw token to the
+    // browser via an HttpOnly cookie (COOKIE_BIND). maybeResumeInterstitial()
+    // requires hasValidBindCookie() to match BEFORE rendering ANY pending
+    // screen. The existing HMAC-token verification on the SUBMIT path
+    // (handleVerifySubmit -> verifySessionHmac) is untouched by this fix and
+    // is re-verified below to still function correctly.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Helper: build a SESSION_TYPE_2FA_SETUP session array bound to the given
+     * raw bind token, without going through createSession() (so the test
+     * controls the raw token value instead of a random one).
+     *
+     * @param int    $userId
+     * @param string $bindToken Raw bind token; session['bind_hash'] is its SHA-256.
+     * @param string $step      SETUP_STEP_* constant.
+     * @return array<string,mixed>
+     */
+    private function buildSetupSession(int $userId, string $bindToken, string $step = Site2faModule::SETUP_STEP_TOTP): array
+    {
+        return [
+            'id'          => bin2hex(random_bytes(16)),
+            'uuid'        => bin2hex(random_bytes(16)),
+            'user_id'     => $userId,
+            'created_at'  => time(),
+            'redirect_to' => '/wp-admin/',
+            'remember_me' => false,
+            'attempts'    => 0,
+            'type'        => Site2faModule::SESSION_TYPE_2FA_SETUP,
+            'setup_step'  => $step,
+            'bind_hash'   => hash('sha256', $bindToken),
+        ];
+    }
+
+    public function test_i1_createsession_mints_a_bind_hash_and_persists_it(): void
+    {
+        $policy = SecurityPolicy::fromArray(['policy' => ['two_factor_enabled' => true]]);
+        $module = $this->makeModule($policy);
+        $userId = 80;
+
+        $createRef = new \ReflectionMethod($module, 'createSession');
+        $session   = $createRef->invoke($module, $userId, '/wp-admin/', false, '2fa');
+
+        $this->assertArrayHasKey('bind_hash', $session, 'I1: createSession must mint a bind_hash');
+        $this->assertIsString($session['bind_hash'] ?? null);
+        $this->assertSame(64, strlen((string) $session['bind_hash']), 'I1: bind_hash must be a sha256 hex digest (64 chars)');
+
+        $stored = $this->userMeta[$userId][Site2faModule::META_SESSION] ?? null;
+        $this->assertIsArray($stored, 'I1: the session must be persisted to user-meta');
+        $this->assertSame($session['bind_hash'], $stored['bind_hash'] ?? null, 'I1: bind_hash must be part of the persisted session');
+    }
+
+    public function test_i1_hasvalidbindcookie_accepts_the_matching_raw_token(): void
+    {
+        $policy    = SecurityPolicy::fromArray(['policy' => ['two_factor_enabled' => true]]);
+        $module    = $this->makeModule($policy);
+        $bindToken = bin2hex(random_bytes(32));
+        $session   = $this->buildSetupSession(90, $bindToken);
+
+        $_COOKIE[Site2faModule::COOKIE_BIND] = $bindToken;
+
+        $ref    = new \ReflectionMethod($module, 'hasValidBindCookie');
+        $result = $ref->invoke($module, $session);
+
+        unset($_COOKIE[Site2faModule::COOKIE_BIND]);
+
+        $this->assertTrue($result, 'I1: a bind cookie whose hash matches session[bind_hash] must validate');
+    }
+
+    public function test_i1_hasvalidbindcookie_rejects_a_wrong_token(): void
+    {
+        $policy    = SecurityPolicy::fromArray(['policy' => ['two_factor_enabled' => true]]);
+        $module    = $this->makeModule($policy);
+        $bindToken = bin2hex(random_bytes(32));
+        $session   = $this->buildSetupSession(91, $bindToken);
+
+        // A different token entirely (e.g. an attacker's guess).
+        $_COOKIE[Site2faModule::COOKIE_BIND] = bin2hex(random_bytes(32));
+
+        $ref    = new \ReflectionMethod($module, 'hasValidBindCookie');
+        $result = $ref->invoke($module, $session);
+
+        unset($_COOKIE[Site2faModule::COOKIE_BIND]);
+
+        $this->assertFalse($result, 'I1: a non-matching bind cookie must be rejected');
+    }
+
+    public function test_i1_hasvalidbindcookie_rejects_when_cookie_is_absent(): void
+    {
+        $policy    = SecurityPolicy::fromArray(['policy' => ['two_factor_enabled' => true]]);
+        $module    = $this->makeModule($policy);
+        $bindToken = bin2hex(random_bytes(32));
+        $session   = $this->buildSetupSession(92, $bindToken);
+
+        unset($_COOKIE[Site2faModule::COOKIE_BIND]);
+
+        $ref    = new \ReflectionMethod($module, 'hasValidBindCookie');
+        $result = $ref->invoke($module, $session);
+
+        $this->assertFalse($result, 'I1: an absent bind cookie must be rejected, never treated as a pass');
+    }
+
+    public function test_i1_hasvalidbindcookie_backward_compat_rejects_pre_fix_session(): void
+    {
+        // Simulate a session minted before this fix: no bind_hash key at all.
+        // This must be treated as "cannot safely resume", never crash, and
+        // never be trusted even if the caller supplies SOME cookie value.
+        $policy    = SecurityPolicy::fromArray(['policy' => ['two_factor_enabled' => true]]);
+        $module    = $this->makeModule($policy);
+        $session   = $this->buildSetupSession(93, bin2hex(random_bytes(32)));
+        unset($session['bind_hash']);
+
+        $_COOKIE[Site2faModule::COOKIE_BIND] = 'attacker-supplied-value-of-any-length-00000000';
+
+        $ref    = new \ReflectionMethod($module, 'hasValidBindCookie');
+        $result = $ref->invoke($module, $session);
+
+        unset($_COOKIE[Site2faModule::COOKIE_BIND]);
+
+        $this->assertFalse($result, 'I1 backward-compat: a pre-fix session with no bind_hash must never be resumable');
+    }
+
+    public function test_i1_resume_setup_without_bind_cookie_never_generates_or_renders_the_totp_secret(): void
+    {
+        // THE VULNERABILITY, end to end: an attacker who only knows/guesses a
+        // user_id (no bind cookie at all) must not be able to trigger the
+        // setup interstitial's TOTP-secret screen via the bare resume path.
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+        $module = $this->makeModule($policy);
+        $userId = 94;
+        $user   = $this->makeUser($userId, ['administrator']);
+
+        $bindToken = bin2hex(random_bytes(32));
+        $session   = $this->buildSetupSession($userId, $bindToken, Site2faModule::SETUP_STEP_TOTP);
+
+        $storeRef = new \ReflectionMethod($module, 'storeSession');
+        $storeRef->invoke($module, $userId, $session);
+
+        Functions\when('get_userdata')->justReturn($user);
+
+        $renderReached = false;
+        Functions\when('login_header')->alias(function () use (&$renderReached) {
+            $renderReached = true;
+            // Should never fire; throwing makes a regression loud rather than
+            // silently rendering (and this test would then fail as an error).
+            throw new \RuntimeException('marker:setup_rendered_without_bind');
+        });
+
+        // Attacker request: only the (guessable) user_id, no wpmgr_2fa_bind cookie.
+        $_POST['wpmgr_2fa_user_id'] = (string) $userId;
+        unset($_COOKIE[Site2faModule::COOKIE_BIND]);
+
+        ob_start();
+        try {
+            $module->maybeResumeInterstitial();
+        } catch (\RuntimeException $e) {
+            ob_end_clean();
+            throw $e;
+        }
+        ob_end_clean();
+
+        unset($_POST['wpmgr_2fa_user_id']);
+
+        $this->assertFalse(
+            $renderReached,
+            'SECURITY (I1): the setup screen must never render for a caller with no valid bind cookie'
+        );
+        $this->assertArrayNotHasKey(
+            TotpProvider::META_PENDING_SECRET,
+            $this->userMeta[$userId] ?? [],
+            'SECURITY (I1): no TOTP secret may be generated/exposed when the bind cookie is absent'
+        );
+        // Fail-closed on the RENDER, not on the session: the pending session is
+        // left untouched so the legitimate browser (which does carry the
+        // cookie) can still resume it.
+        $this->assertArrayHasKey(
+            Site2faModule::META_SESSION,
+            $this->userMeta[$userId] ?? [],
+            'I1: the pending session itself is left intact when a resume is rejected'
+        );
+    }
+
+    public function test_i1_resume_setup_with_wrong_bind_cookie_never_renders_the_totp_secret(): void
+    {
+        // Same as above, but the caller presents SOME cookie -- just not the
+        // one minted with this session (e.g. a stale/foreign cookie).
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+        $module = $this->makeModule($policy);
+        $userId = 95;
+        $user   = $this->makeUser($userId, ['administrator']);
+
+        $bindToken = bin2hex(random_bytes(32));
+        $session   = $this->buildSetupSession($userId, $bindToken, Site2faModule::SETUP_STEP_TOTP);
+
+        $storeRef = new \ReflectionMethod($module, 'storeSession');
+        $storeRef->invoke($module, $userId, $session);
+
+        Functions\when('get_userdata')->justReturn($user);
+
+        $renderReached = false;
+        Functions\when('login_header')->alias(function () use (&$renderReached) {
+            $renderReached = true;
+            throw new \RuntimeException('marker:setup_rendered_with_wrong_bind');
+        });
+
+        $_POST['wpmgr_2fa_user_id']          = (string) $userId;
+        $_COOKIE[Site2faModule::COOKIE_BIND] = bin2hex(random_bytes(32));
+
+        ob_start();
+        try {
+            $module->maybeResumeInterstitial();
+        } catch (\RuntimeException $e) {
+            ob_end_clean();
+            throw $e;
+        }
+        ob_end_clean();
+
+        unset($_POST['wpmgr_2fa_user_id'], $_COOKIE[Site2faModule::COOKIE_BIND]);
+
+        $this->assertFalse(
+            $renderReached,
+            'SECURITY (I1): a mismatched bind cookie must not resume the setup screen either'
+        );
+        $this->assertArrayNotHasKey(
+            TotpProvider::META_PENDING_SECRET,
+            $this->userMeta[$userId] ?? [],
+            'SECURITY (I1): no TOTP secret may be generated/exposed with a mismatched bind cookie'
+        );
+    }
+
+    public function test_i1_resume_2fa_verify_session_without_bind_cookie_does_not_render(): void
+    {
+        // The gate applies uniformly to the plain 2FA verify interstitial too
+        // (no secret to leak there, but resuming it without proof of browser
+        // origin is still session confusion we should not allow).
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+        $module = $this->makeModule($policy);
+        $userId = 96;
+        $user   = $this->makeUser($userId, ['administrator']);
+
+        $bindToken = bin2hex(random_bytes(32));
+        $session   = [
+            'id'          => bin2hex(random_bytes(16)),
+            'uuid'        => bin2hex(random_bytes(16)),
+            'user_id'     => $userId,
+            'created_at'  => time(),
+            'redirect_to' => '/wp-admin/',
+            'remember_me' => false,
+            'attempts'    => 0,
+            'type'        => '2fa',
+            'bind_hash'   => hash('sha256', $bindToken),
+        ];
+
+        $storeRef = new \ReflectionMethod($module, 'storeSession');
+        $storeRef->invoke($module, $userId, $session);
+
+        Functions\when('get_userdata')->justReturn($user);
+
+        $renderReached = false;
+        Functions\when('login_header')->alias(function () use (&$renderReached) {
+            $renderReached = true;
+            throw new \RuntimeException('marker:2fa_rendered_without_bind');
+        });
+
+        $_POST['wpmgr_2fa_user_id'] = (string) $userId;
+        unset($_COOKIE[Site2faModule::COOKIE_BIND]);
+
+        ob_start();
+        try {
+            $module->maybeResumeInterstitial();
+        } catch (\RuntimeException $e) {
+            ob_end_clean();
+            throw $e;
+        }
+        ob_end_clean();
+
+        unset($_POST['wpmgr_2fa_user_id']);
+
+        $this->assertFalse(
+            $renderReached,
+            'I1: the plain 2FA verify interstitial must also not resume without a matching bind cookie'
+        );
+    }
+
+    public function test_i1_resume_with_matching_bind_cookie_still_renders_the_setup_screen(): void
+    {
+        // The legitimate flow: the SAME browser that received the bind cookie
+        // when the session was created presents it back. Resume must still
+        // work exactly as before this fix.
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+        $module = $this->makeModule($policy);
+        $userId = 97;
+        $user   = $this->makeUser($userId, ['administrator']);
+
+        $bindToken = bin2hex(random_bytes(32));
+        $session   = $this->buildSetupSession($userId, $bindToken, Site2faModule::SETUP_STEP_TOTP);
+
+        $storeRef = new \ReflectionMethod($module, 'storeSession');
+        $storeRef->invoke($module, $userId, $session);
+
+        Functions\when('get_userdata')->justReturn($user);
+        // buildSetupTotpHtml() calls get_bloginfo('name') for the QR issuer label.
+        Functions\when('get_bloginfo')->justReturn('Test Site');
+
+        $reachedEnd = false;
+        Functions\when('login_footer')->alias(function () use (&$reachedEnd) {
+            $reachedEnd = true;
+            throw new \RuntimeException('marker:setup_render_complete');
+        });
+
+        // Legitimate browser: presents the exact bind token minted with the session.
+        $_POST['wpmgr_2fa_user_id']          = (string) $userId;
+        $_COOKIE[Site2faModule::COOKIE_BIND] = $bindToken;
+
+        $threwCompletionMarker = false;
+        ob_start();
+        try {
+            $module->maybeResumeInterstitial();
+        } catch (\RuntimeException $e) {
+            if ($e->getMessage() === 'marker:setup_render_complete') {
+                $threwCompletionMarker = true;
+            } else {
+                ob_end_clean();
+                throw $e;
+            }
+        }
+        ob_end_clean();
+
+        unset($_POST['wpmgr_2fa_user_id'], $_COOKIE[Site2faModule::COOKIE_BIND]);
+
+        $this->assertTrue($reachedEnd, 'I1: a legitimate resume with a matching bind cookie must reach the full render');
+        $this->assertTrue($threwCompletionMarker, 'I1: rendering must run to completion for a valid bind cookie');
+        $this->assertArrayHasKey(
+            TotpProvider::META_PENDING_SECRET,
+            $this->userMeta[$userId] ?? [],
+            'I1: a legitimate resume must still generate/display the pending TOTP secret exactly as before this fix'
+        );
+    }
+
+    public function test_i1_handleverifysubmit_rejects_wrong_hmac_token_with_valid_session(): void
+    {
+        // The SUBMIT path's HMAC check (verifySessionHmac) is unchanged by this
+        // fix. Confirm it still rejects an incorrect token on an otherwise
+        // valid, live session.
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+        $module = $this->makeModule($policy);
+        $userId = 98;
+        $user   = $this->makeUser($userId, ['administrator']);
+
+        $createRef = new \ReflectionMethod($module, 'createSession');
+        $session   = $createRef->invoke($module, $userId, '/wp-admin/', false, '2fa');
+
+        Functions\when('get_userdata')->justReturn($user);
+
+        $_POST['wpmgr_2fa_user_id']    = (string) $userId;
+        $_POST['wpmgr_2fa_session_id'] = $session['id'];
+        $_POST['wpmgr_2fa_token']      = 'not-the-real-hmac-token';
+        $_POST['wpmgr_2fa_provider']   = 'email';
+
+        $threw = false;
+        try {
+            $module->handleVerifySubmit();
+        } catch (\RuntimeException $e) {
+            $threw = str_contains($e->getMessage(), 'Session expired or invalid');
+        }
+
+        unset(
+            $_POST['wpmgr_2fa_user_id'],
+            $_POST['wpmgr_2fa_session_id'],
+            $_POST['wpmgr_2fa_token'],
+            $_POST['wpmgr_2fa_provider']
+        );
+
+        $this->assertTrue($threw, 'I1 regression: handleVerifySubmit must still reject an incorrect HMAC token');
+        $this->assertArrayNotHasKey(
+            Site2faModule::META_SESSION,
+            $this->userMeta[$userId] ?? [],
+            'the invalid-token submit path must still clear the session'
+        );
+    }
+
+    public function test_i1_handleverifysubmit_accepts_correct_hmac_token_and_proceeds_past_the_session_gate(): void
+    {
+        // The SUBMIT path's HMAC check must still ACCEPT a correct token on a
+        // valid session and let processing continue (past the session/TTL/
+        // attempt gates, into provider handling) -- proving this fix did not
+        // regress the legitimate verify flow.
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+        $module = $this->makeModule($policy);
+        $userId = 99;
+        $user   = $this->makeUser($userId, ['administrator']);
+
+        $createRef = new \ReflectionMethod($module, 'createSession');
+        $session   = $createRef->invoke($module, $userId, '/wp-admin/', false, '2fa');
+
+        $hmacRef = new \ReflectionMethod($module, 'computeSessionHmac');
+        $hmac = $hmacRef->invoke($module, $userId, $session['id'], $session['created_at'], $session['uuid']);
+
+        Functions\when('get_userdata')->justReturn($user);
+        // renderInterstitial() falls back to the email provider, whose preRender()
+        // sends a code via wp_hash()/get_bloginfo()/wp_mail(); wp_mail is absent so
+        // sendCode() ultimately no-ops, but wp_hash()/get_bloginfo() are still called
+        // unconditionally beforehand.
+        Functions\when('wp_hash')->alias(fn (string $data) => hash('sha256', $data));
+        Functions\when('get_bloginfo')->justReturn('Test Site');
+        Functions\when('wp_mail')->justReturn(true);
+
+        $reachedProviderStage = false;
+        Functions\when('login_header')->alias(function () use (&$reachedProviderStage) {
+            $reachedProviderStage = true;
+            throw new \RuntimeException('marker:reached_provider_stage');
+        });
+
+        $_POST['wpmgr_2fa_user_id']    = (string) $userId;
+        $_POST['wpmgr_2fa_session_id'] = $session['id'];
+        $_POST['wpmgr_2fa_token']      = $hmac;
+        // An unknown provider key routes to renderInterstitial()'s "Invalid
+        // provider selected" branch -- reaching it proves the HMAC/TTL/attempt
+        // gates were all passed with a correctly computed token.
+        $_POST['wpmgr_2fa_provider']   = 'not-a-real-provider';
+
+        $threwMarker = false;
+        ob_start();
+        try {
+            $module->handleVerifySubmit();
+        } catch (\RuntimeException $e) {
+            if ($e->getMessage() === 'marker:reached_provider_stage') {
+                $threwMarker = true;
+            } else {
+                ob_end_clean();
+                throw $e;
+            }
+        }
+        ob_end_clean();
+
+        unset(
+            $_POST['wpmgr_2fa_user_id'],
+            $_POST['wpmgr_2fa_session_id'],
+            $_POST['wpmgr_2fa_token'],
+            $_POST['wpmgr_2fa_provider']
+        );
+
+        $this->assertTrue($reachedProviderStage, 'I1 regression: a correct HMAC token on a valid session must still pass the submit-path gate');
+        $this->assertTrue($threwMarker);
+    }
 }

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.8
+ * Version:           0.61.9
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.8');
+define('WPMGR_AGENT_VERSION', '0.61.9');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 

--- a/docs/wporg/reviewer-reply-2026-07-04.md
+++ b/docs/wporg/reviewer-reply-2026-07-04.md
@@ -1,0 +1,14 @@
+Thanks. This was an automated re-scan, so the per-item rationale for the intentional patterns is already in my previous reply in this thread and still applies: the streaming `mysqli` connection (needed because `$wpdb` buffers the whole result set and OOM-fatals on large-table backups), the backup/restore use of `ABSPATH`/`WP_CONTENT_DIR` (a backup tool has to resolve the real site tree; writable plugin data goes under `wp_upload_dir()`), the page-cache inline output (written to a static file served before WordPress loads, so `wp_enqueue` never runs for that response), and `FORCE_SSL_ADMIN` (defined only when the owner enables the Force-SSL toggle, behind a `!defined()` guard).
+
+One flagged item was a real one and I fixed it: the 2FA login interstitial's **resume** path now binds to the originating browser (an HttpOnly, session-scoped cookie verified before anything renders), so a pending setup screen can no longer be shown from a guessed user ID.
+
+On the other three:
+
+- **`.maintenance`** is WordPress core's own maintenance sentinel (`<?php $upgrading = …`), written only during an active restore to show the standard maintenance page, and removed on completion. It is the same file core writes during its own updates, not plugin code.
+- The operator **file-write / restore** commands write only inside a realpath jail (the resolved target must stay within the jail root, with an executable-extension deny-list and a `<?php` content sniff), and every command is gated by a single-use, short-lived Ed25519-signed token verified server-side.
+- The plugin **does not create users**. The login flow is an operator-initiated, one-click login into an existing administrator, carried by a single-use signed token; the 2FA step sets the auth cookie only after WordPress has already authenticated the user. This mirrors the established management plugins (MainWP Child, ManageWP Worker).
+
+Happy to clarify any specific line.
+
+Thanks,
+Mosam


### PR DESCRIPTION
The 2FA login interstitial resume path rendered pending setup screens (incl. the TOTP secret) keyed only on a POSTed user_id with no browser binding. Now bound to the originating browser via an HttpOnly per-session cookie verified before any render; fail-closed; HMAC submit-path untouched. Flagged by the wp.org auto-review; genuine info-disclosure. Security-reviewed SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)