### PR TITLE
fix(web): audit day-group headers as a visible sticky divider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.15] - 2026-07-04
+
+### Added
+
+- Audit log integrity re-baseline. A "Chain break" that predates the integrity-locking fix is a permanent artifact, because the audit log is append-only and its rows can never be altered. An owner can now acknowledge such a break, which moves the integrity anchor to the current point so verification runs forward from there. New tampering is still detected, the acknowledgment is itself recorded in the audit log, and no existing entries are ever removed.
+
+### Changed
+
+- Each audit row now shows its date, not just the time, so a row keeps its date when scrolled away from its day header.
+
+### Fixed
+
+- The audit log Reload button now visibly refreshes both the event list and the integrity check, with a spinner while it works.
+
 ## [0.61.14] - 2026-07-04
 
 ### Fixed

--- a/apps/web/src/routes/_authed/audit.tsx
+++ b/apps/web/src/routes/_authed/audit.tsx
@@ -553,8 +553,13 @@ function DayGroup({
 
   return (
     <div>
-      <div className="sticky top-0 z-10 border-b border-border bg-card/95 px-4 py-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground backdrop-blur supports-[backdrop-filter]:bg-card/80">
-        {label}
+      <div className="sticky top-0 z-10 flex items-center justify-between border-y border-border bg-muted/95 px-4 py-2 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-muted/80">
+        <span className="text-xs font-semibold uppercase tracking-wide text-foreground">
+          {label}
+        </span>
+        <span className="text-[11px] font-medium tabular-nums text-muted-foreground">
+          {entries.length}
+        </span>
       </div>
       <ul className="divide-y divide-border">
         {runs.map((run, index) => {


### PR DESCRIPTION
The sticky TODAY/YESTERDAY/date headers blended into the rows (muted text on a matching background) so they gave no orientation while scrolling. Restyled as a proper divider band with a distinct surface, stronger label, borders + lift shadow, and the day's event count. web-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an audit log integrity re-baseline workflow to acknowledge existing chain breaks while preserving audit history.
* **Bug Fixes**
  * Improved the audit log **Reload** action so it clearly refreshes the event list and integrity check, with a loading spinner during refresh.
* **Style**
  * Updated audit log day headers to show the date and entry count side by side, with a more prominent sticky header appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->