### PR TITLE
fix(uptime): TLS expiry never populated — capture cert from resp.TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.18] - 2026-07-05
+
+### Fixed
+
+- TLS certificate expiry now shows for monitored sites. The uptime prober only read the certificate during a fresh TLS handshake, but its keep-alive connection meant a fresh handshake almost never happened after the first probe, so the TLS column on the Uptime page, the per-site Uptime tab, and the sites-list SSL badge stayed empty from the start. The prober now reads the certificate from the response on every probe, fresh or reused connection. Values appear on their own within a minute of upgrading; no other changes needed.
+
 ## [0.61.17] - 2026-07-05
 
 ### Added

--- a/apps/api/internal/uptime/probe.go
+++ b/apps/api/internal/uptime/probe.go
@@ -94,18 +94,17 @@ func (p *Prober) Probe(ctx context.Context, targetURL string) ProbeResult {
 	defer cancel()
 
 	var (
-		start            = time.Now()
-		dnsStart         time.Time
-		dnsDone          time.Time
-		connectStart     time.Time
-		connectDone      time.Time
-		tlsStart         time.Time
-		tlsDone          time.Time
-		firstByte        time.Time
-		tlsExpiry        time.Time
-		tlsIssuer        string
-		tlsSubject       string
-		gotConnReusedTLS bool
+		start        = time.Now()
+		dnsStart     time.Time
+		dnsDone      time.Time
+		connectStart time.Time
+		connectDone  time.Time
+		tlsStart     time.Time
+		tlsDone      time.Time
+		firstByte    time.Time
+		tlsExpiry    time.Time
+		tlsIssuer    string
+		tlsSubject   string
 	)
 
 	trace := &httptrace.ClientTrace{
@@ -118,24 +117,18 @@ func (p *Prober) Probe(ctx context.Context, targetURL string) ProbeResult {
 		},
 		ConnectDone:       func(_, _ string, _ error) { connectDone = time.Now() },
 		TLSHandshakeStart: func() { tlsStart = time.Now() },
-		TLSHandshakeDone: func(cs tls.ConnectionState, err error) {
+		// This callback only measures the handshake PHASE TIMING (TLSMs). It
+		// NEVER fires on a reused keep-alive connection — the shared client
+		// (90s IdleConnTimeout, probes every 60s) reuses its connection to a
+		// site after the first probe, so relying on this callback for the
+		// certificate itself left tls_expiry permanently NULL from the second
+		// probe onward. The certificate fields are instead read from
+		// resp.TLS below, which is populated on both fresh AND reused
+		// connections.
+		TLSHandshakeDone: func(_ tls.ConnectionState, _ error) {
 			tlsDone = time.Now()
-			if err == nil && len(cs.PeerCertificates) > 0 {
-				// The leaf certificate is first; its NotAfter is the expiry the
-				// dashboard surfaces, and the Issuer/Subject CommonName is what
-				// the operator sees as "Let's Encrypt", "Cloudflare", etc.
-				leaf := cs.PeerCertificates[0]
-				tlsExpiry = leaf.NotAfter
-				tlsIssuer = leaf.Issuer.CommonName
-				tlsSubject = leaf.Subject.CommonName
-			}
 		},
 		GotFirstResponseByte: func() { firstByte = time.Now() },
-		GotConn: func(gci httptrace.GotConnInfo) {
-			// A reused (keep-alive) connection skips DNS/connect/TLS traces; note it
-			// so we don't report a misleadingly-zero handshake.
-			gotConnReusedTLS = gci.Reused
-		},
 	}
 
 	req, err := http.NewRequestWithContext(httptrace.WithClientTrace(ctx, trace), http.MethodGet, targetURL, nil)
@@ -155,6 +148,19 @@ func (p *Prober) Probe(ctx context.Context, targetURL string) ProbeResult {
 		return res
 	}
 	defer func() { _ = resp.Body.Close() }()
+	// resp.TLS is populated on the FINAL response — after following any
+	// redirects — for both a fresh handshake and a reused keep-alive
+	// connection, on HTTP/1.1 and HTTP/2 alike. It is the authoritative
+	// source for the certificate fields (TLSHandshakeDone above only ever
+	// fires on a fresh handshake, so a reused connection would otherwise
+	// never report an expiry). Plain-HTTP sites leave resp.TLS nil, which
+	// keeps TLSExpiry zero (recorded as NULL), unchanged from before.
+	if resp.TLS != nil && len(resp.TLS.PeerCertificates) > 0 {
+		leaf := resp.TLS.PeerCertificates[0]
+		tlsExpiry = leaf.NotAfter
+		tlsIssuer = leaf.Issuer.CommonName
+		tlsSubject = leaf.Subject.CommonName
+	}
 	// Buffer up to maxProbeBody bytes for the wp-fatal-page scan below. A
 	// WordPress fatal error only reaches the client as HTTP 200 once headers
 	// have already been sent (WP can no longer switch to a 500 at that
@@ -193,7 +199,6 @@ func (p *Prober) Probe(ctx context.Context, targetURL string) ProbeResult {
 	}
 	fillTimings(&res, start, dnsStart, dnsDone, connectStart, connectDone, tlsStart, tlsDone, firstByte)
 	res.TotalMs = msSince(start, end)
-	_ = gotConnReusedTLS
 	return res
 }
 

--- a/apps/api/internal/uptime/probe_test.go
+++ b/apps/api/internal/uptime/probe_test.go
@@ -96,6 +96,83 @@ func TestProbeTLSExpiry(t *testing.T) {
 	}
 }
 
+// TestProbe_TLSExpiryOnReusedConnection is the regression test for the bug
+// where tlsExpiry was populated ONLY inside the httptrace ClientTrace's
+// TLSHandshakeDone callback, which never fires on a reused keep-alive
+// connection. The uptime prober shares one *http.Client across every 60s
+// probe of a site (see internal/httpclient's 90s IdleConnTimeout), so after
+// the first probe every subsequent probe reused the connection and persisted
+// tls_expiry = NULL forever. This test drives TWO probes against the same
+// TLS server over the SAME shared client — the second reuses the
+// connection — and asserts BOTH results still carry a non-zero TLSExpiry
+// equal to the test certificate's NotAfter, because the fix reads the
+// certificate from resp.TLS (populated on fresh AND reused connections)
+// rather than solely from the trace callback.
+func TestProbe_TLSExpiryOnReusedConnection(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	wantExpiry := srv.Certificate().NotAfter
+
+	// One shared client/prober across both probes, exactly like the
+	// production Prober (constructed once in main.go, probed on a 60s
+	// ticker) reuses its keep-alive connection to a site.
+	tlsClient := httpclient.New(httpclient.Config{
+		Timeout:               5 * time.Second,
+		AllowPrivateNetworks:  true,
+		InsecureSkipTLSVerify: true,
+	})
+	prober := NewProber(tlsClient, 5*time.Second)
+
+	first := prober.Probe(context.Background(), srv.URL)
+	if !first.Up {
+		t.Fatalf("expected first probe up, got %+v", first)
+	}
+	if first.TLSExpiry.IsZero() {
+		t.Fatalf("expected a non-zero TLS expiry on the first (fresh-handshake) probe, got %+v", first)
+	}
+	if !first.TLSExpiry.Equal(wantExpiry) {
+		t.Fatalf("expected first probe TLSExpiry=%v, got %v", wantExpiry, first.TLSExpiry)
+	}
+
+	second := prober.Probe(context.Background(), srv.URL)
+	if !second.Up {
+		t.Fatalf("expected second probe up, got %+v", second)
+	}
+	// The second probe reuses the keep-alive connection: its TLSHandshakeDone
+	// trace callback never fires (TLSMs stays 0), which is exactly the
+	// condition that used to leave TLSExpiry at zero.
+	if second.TLSMs != 0 {
+		t.Fatalf("expected the second probe to reuse the connection (TLSMs==0), got %v — test is not exercising connection reuse", second.TLSMs)
+	}
+	if second.TLSExpiry.IsZero() {
+		t.Fatalf("expected a non-zero TLS expiry on the second (reused-connection) probe — this is the regression this test guards against, got %+v", second)
+	}
+	if !second.TLSExpiry.Equal(wantExpiry) {
+		t.Fatalf("expected second probe TLSExpiry=%v, got %v", wantExpiry, second.TLSExpiry)
+	}
+}
+
+// TestProbe_TLSExpiryPlainHTTPStaysZero asserts a plain-HTTP (non-TLS) probe
+// still yields a zero TLSExpiry (recorded as NULL), unaffected by reading the
+// certificate from resp.TLS.
+func TestProbe_TLSExpiryPlainHTTPStaysZero(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if !res.Up {
+		t.Fatalf("expected plain-HTTP probe up, got %+v", res)
+	}
+	if !res.TLSExpiry.IsZero() {
+		t.Fatalf("expected zero TLS expiry for a plain-HTTP probe, got %v", res.TLSExpiry)
+	}
+}
+
 // TestProbeSSRFBlocked asserts the production-posture SSRF guard refuses a
 // loopback (127.0.0.1) target: the probe records DOWN with an ssrf_blocked
 // error and never connects.


### PR DESCRIPTION
The probe only read the certificate inside the TLSHandshakeDone trace callback, which never fires on pooled connections — and 60s probes over a 90s-idle keep-alive transport guarantee pooling, so tls_expiry was NULL on essentially every probe since the feature shipped. Fleet TLS column, per-site Uptime tab, and Sites-list SSL badges were all empty. Fix: capture the leaf cert from resp.TLS (present on every HTTPS response, and always the final host's cert), keep the trace solely for handshake timing. Regression test proves fail-without/pass-with. api-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU