### PR TITLE
chore: CI vocabulary check for docs (no competitor names)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # House rule: competitor products are never named in docs or root markdown.
+      # Functional source references (conflict-detection slugs, plugin-signature
+      # seeds, compat handling) are out of scope, and ADR-055 is excluded because
+      # it documents plugin interop behavior that mirrors shipped code.
+      - name: Docs vocabulary check (no competitor names)
+        run: |
+          banned='flyingpress|flying-press|wpvivid|wp-rocket|wp rocket|wpremote|updraft|nitropack|perfmatters|managewp|mainwp|malcare'
+          hits=$(grep -rniE "$banned" --include='*.md' docs/ ./*.md 2>/dev/null | grep -v 'docs/adr/ADR-055' || true)
+          if [ -n "$hits" ]; then
+            echo "Competitor names found in markdown (house rule: describe techniques neutrally):"
+            echo "$hits"
+            exit 1
+          fi
+
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26"

--- a/PLAN.md
+++ b/PLAN.md
@@ -20,7 +20,7 @@ The original Phase 0-6 plan is complete and in production:
 
 ## In flight
 
-- [ ] **WordPress.org listing** — agent submitted as "Fleet Agent Site Manager"; passed the automated scans' real finding (2FA resume binding, fixed 0.61.9); awaiting human review. Crux item: autologin (MainWP/ManageWP precedent). Fallback if rejected: strip autologin + file-write from the wp.org build only.
+- [ ] **WordPress.org listing** — agent submitted as "Fleet Agent Site Manager"; passed the automated scans' real finding (2FA resume binding, fixed 0.61.9); awaiting human review. Crux item: autologin (established management-plugin precedent). Fallback if rejected: strip autologin + file-write from the wp.org build only.
 - [ ] **Patchstack decision** — research complete (docs/security/ internal). Recommended: Phase 0 provider abstraction + Phase 1a BYO App-API-key co-existence; paid feed/vPatch only via a for-Hosts contract. Awaiting go/no-go.
 
 ## Next up (priority order)


### PR DESCRIPTION
Makes the docs house rule structural: a Security-audit step fails CI on competitor names in markdown (functional source references excluded). Neutralizes one precedent mention in PLAN.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a documentation check to the CI process that flags restricted competitor/product names in markdown files and fails the build when found, with one documented exception.
* **Documentation**
  * Updated a planning note to use more general wording for the management-plugin precedent reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->