### PR TITLE
fix(web): admin billing panel crash — align frontend to real API shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.22] - 2026-07-06
+
+### Fixed
+
+- The superadmin billing admin panel could crash on load because the frontend read some response fields under names that did not match what the server sent. Aligned every field to the server shape and guarded optional values so a missing value renders as a placeholder instead of failing. Superadmin-only; no customer impact.
+
 ## [0.61.21] - 2026-07-06
 
 ### Added

--- a/apps/web/src/features/admin/admin-account-dialogs.tsx
+++ b/apps/web/src/features/admin/admin-account-dialogs.tsx
@@ -26,9 +26,15 @@ import {
   useAdminSuspendAccount,
   useAdminRestoreAccount,
   useAdminForceBillingState,
-  type AdminAccountDetail,
-  type AdminAccountMeter,
+  type AdminAccountUsage,
+  type AdminAccountTimelineEntry,
 } from "./use-admin-accounts";
+import {
+  buildAccountMeters,
+  bytesToWholeGB,
+  timelineActorLabel,
+  type AccountMeterRow,
+} from "./admin-accounts-format";
 
 // M16 Phase C1 — manual controls for a single account. Every mutation here
 // requires an operator-supplied reason (superadmin audit trail). Dialogs are
@@ -244,7 +250,7 @@ const OVERRIDE_ROWS: readonly OverrideRowConfig[] = [
 
 /** Best-effort lookup of "who last changed this override, and when" from the generic timeline — the pinned contract has no dedicated overrides-history field, so this degrades to nothing shown if the backend's event kind naming doesn't match. */
 function findLastOverrideEvent(
-  timeline: AdminAccountDetail["timeline"],
+  timeline: AdminAccountTimelineEntry[],
   field: string,
 ) {
   return timeline.find(
@@ -254,7 +260,7 @@ function findLastOverrideEvent(
   ) ?? timeline.find((e) => e.kind.toLowerCase().includes("override"));
 }
 
-function meterFor(meters: AdminAccountMeter[], key: string) {
+function meterFor(meters: AccountMeterRow[], key: string) {
   return meters.find((m) => m.key === key);
 }
 
@@ -262,17 +268,20 @@ export function OverridesEditorDialog({
   open,
   onClose,
   tenantId,
-  detail,
+  usage,
+  timeline,
 }: {
   open: boolean;
   onClose: () => void;
   tenantId: string;
-  detail: AdminAccountDetail;
+  usage: AdminAccountUsage;
+  timeline: AdminAccountTimelineEntry[];
 }) {
   const titleId = useId();
   const [values, setValues] = useState<Record<string, string>>({});
   const mutation = useAdminSetOverrides(tenantId);
   const [reason, setReason] = useState("");
+  const meters = buildAccountMeters(usage);
 
   if (useJustOpened(open)) {
     setValues({});
@@ -335,17 +344,25 @@ export function OverridesEditorDialog({
 
           <div className="space-y-3">
             {OVERRIDE_ROWS.map((row) => {
-              const meter = meterFor(detail.meters, row.meterKey);
+              const meter = meterFor(meters, row.meterKey);
               const touched = row.field in values;
               const cleared = touched && values[row.field] === "";
-              const lastEvent = findLastOverrideEvent(detail.timeline, row.field);
+              const lastEvent = findLastOverrideEvent(timeline, row.field);
+              // The storage_gb override is GB-denominated on the wire, but its
+              // usage meter (usage.storage_bytes_approx) is bytes — convert
+              // for display so "Effective" reads in the same unit as the input.
+              const effective = meter
+                ? row.field === "storage_gb"
+                  ? `${bytesToWholeGB(meter.cap).toLocaleString()} GB`
+                  : meter.cap.toLocaleString()
+                : "–";
 
               return (
                 <div key={row.field} className="rounded-md border border-border p-3">
                   <div className="flex items-center justify-between gap-2">
                     <Label htmlFor={`override-${row.field}`}>{row.label}</Label>
                     <span className="text-xs text-muted-foreground">
-                      Effective: {meter ? meter.cap.toLocaleString() : "–"}
+                      Effective: {effective}
                     </span>
                   </div>
                   <div className="mt-1.5 flex items-center gap-2">
@@ -389,8 +406,8 @@ export function OverridesEditorDialog({
                   </div>
                   {lastEvent ? (
                     <p className="mt-1.5 text-xs text-muted-foreground">
-                      Last set {lastEvent.actor ? `by ${lastEvent.actor} ` : ""}
-                      &middot; {new Date(lastEvent.at).toLocaleString()}
+                      Last set {timelineActorLabel(lastEvent) ? `by ${timelineActorLabel(lastEvent)} ` : ""}
+                      &middot; {new Date(lastEvent.occurred_at).toLocaleString()}
                     </p>
                   ) : null}
                 </div>

--- a/apps/web/src/features/admin/admin-account-ui.test.tsx
+++ b/apps/web/src/features/admin/admin-account-ui.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  AccountStatusBadge,
+  AdminMeterList,
+  PlanBadge,
+  SitesMeterChip,
+  StorageMeterChip,
+} from "./admin-account-ui";
+import { buildAccountMeters } from "./admin-accounts-format";
+
+// Regression guard for the exact prod crash class: "Cannot read properties of
+// undefined (reading 'toLocaleString')" in the /admin/accounts panel. These
+// components are shallow-rendered (react-dom/server, no jsdom needed) against
+// a MINIMAL backend payload — only required fields present, every omitempty
+// field genuinely absent — mirroring the real AdminAccountListItem /
+// AdminAccountUsage shapes in use-admin-accounts.ts. A future field-name drift
+// that reintroduces an unguarded `.toLocaleString()`/`.toLocaleDateString()`
+// on an absent field will throw here, not in a customer's browser.
+
+describe("admin-account-ui shallow render — minimal payload", () => {
+  it("AccountStatusBadge renders with no suspended_at (the omitempty case)", () => {
+    expect(() =>
+      renderToStaticMarkup(
+        <AccountStatusBadge account={{ plan_status: "none", suspended_at: undefined }} />,
+      ),
+    ).not.toThrow();
+  });
+
+  it("AccountStatusBadge renders when suspended_at IS present", () => {
+    expect(() =>
+      renderToStaticMarkup(
+        <AccountStatusBadge
+          account={{ plan_status: "active", suspended_at: "2026-07-01T00:00:00Z" }}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it("PlanBadge renders for the free plan with no overrides", () => {
+    expect(() =>
+      renderToStaticMarkup(<PlanBadge plan="free" comped={false} hasOverrides={false} />),
+    ).not.toThrow();
+  });
+
+  it("SitesMeterChip renders at 0/1 (a brand-new minimal account)", () => {
+    const html = renderToStaticMarkup(<SitesMeterChip used={0} cap={1} />);
+    expect(html).not.toContain("undefined");
+  });
+
+  it("StorageMeterChip renders when storage_cap_bytes is 0 (free tier: no CP-managed cap)", () => {
+    const html = renderToStaticMarkup(
+      <TooltipProvider>
+        <StorageMeterChip usedBytes={0} capBytes={0} />
+      </TooltipProvider>,
+    );
+    expect(html).not.toContain("undefined");
+    expect(html).toContain("no cap");
+  });
+
+  it("AdminMeterList renders the meters built from a minimal usage block (0/0 storage cap included)", () => {
+    const meters = buildAccountMeters({
+      sites: { used: 0, cap: 1 },
+      storage_bytes_approx: { used: 0, cap: 0 },
+    });
+    const html = renderToStaticMarkup(<AdminMeterList meters={meters} />);
+    expect(html).not.toContain("undefined");
+    expect(html).toContain("no cap");
+  });
+
+  it("AdminMeterList renders an empty meters array without throwing", () => {
+    expect(() => renderToStaticMarkup(<AdminMeterList meters={[]} />)).not.toThrow();
+  });
+});

--- a/apps/web/src/features/admin/admin-account-ui.tsx
+++ b/apps/web/src/features/admin/admin-account-ui.tsx
@@ -9,12 +9,13 @@ import {
   ACCOUNT_STATUS_LABEL,
   METER_TONE_TEXT_CLASS,
   accountDisplayStatus,
+  formatMeterValue,
   isOverCap,
   meterBarPercent,
   meterPercent,
   meterTone,
+  type AccountMeterRow,
 } from "./admin-accounts-format";
-import type { AdminAccountMeter, AdminAccountStorageUsage } from "./use-admin-accounts";
 
 // Shared, presentation-only building blocks for the Accounts table, the
 // account detail page, and the Revenue plan-distribution table. Kept
@@ -28,7 +29,7 @@ import type { AdminAccountMeter, AdminAccountStorageUsage } from "./use-admin-ac
 export function AccountStatusBadge({
   account,
 }: {
-  account: { plan_status: string; suspended: boolean };
+  account: { plan_status: string; suspended_at?: string | null };
 }) {
   const status = accountDisplayStatus(account);
   return (
@@ -103,8 +104,22 @@ export function SitesMeterChip({ used, cap }: { used: number; cap: number }) {
   );
 }
 
-export function StorageMeterChip({ storage }: { storage: AdminAccountStorageUsage }) {
-  const tone = meterTone(meterPercent(storage.used_bytes, storage.cap_bytes));
+/**
+ * `usedBytes`/`capBytes` map directly to the wire's flat
+ * `storage_used_bytes_approx`/`storage_cap_bytes` fields (there is no nested
+ * `storage` object, and no per-account `approximate` flag — the metric is
+ * ALWAYS an approximation, so the "~" prefix and tooltip are unconditional).
+ * `capBytes <= 0` means "no CP-managed cap to approach" (free tier,
+ * BYO-storage only), not zero capacity.
+ */
+export function StorageMeterChip({
+  usedBytes,
+  capBytes,
+}: {
+  usedBytes: number;
+  capBytes: number;
+}) {
+  const tone = meterTone(meterPercent(usedBytes, capBytes));
   const chip = (
     <span
       className={cn(
@@ -112,12 +127,10 @@ export function StorageMeterChip({ storage }: { storage: AdminAccountStorageUsag
         CHIP_TONE_CLASS[tone],
       )}
     >
-      {storage.approximate ? <span aria-hidden="true">~</span> : null}
-      {formatBytes(storage.used_bytes)} / {formatBytes(storage.cap_bytes)}
+      <span aria-hidden="true">~</span>
+      {formatBytes(usedBytes)} / {capBytes > 0 ? formatBytes(capBytes) : "no cap"}
     </span>
   );
-
-  if (!storage.approximate) return chip;
 
   return (
     <Tooltip content="Storage usage is computed periodically, not live.">
@@ -134,7 +147,7 @@ export function StorageMeterChip({ storage }: { storage: AdminAccountStorageUsag
 // "over cap" note that Phase B's UsageMeterList doesn't need.
 // ---------------------------------------------------------------------------
 
-export function AdminMeterList({ meters }: { meters: AdminAccountMeter[] }) {
+export function AdminMeterList({ meters }: { meters: AccountMeterRow[] }) {
   if (meters.length === 0) {
     return <p className="text-sm text-muted-foreground">No usage data.</p>;
   }
@@ -164,7 +177,8 @@ export function AdminMeterList({ meters }: { meters: AdminAccountMeter[] }) {
                 )}
               >
                 {meter.approximate ? "~" : ""}
-                {meter.used} / {meter.cap}
+                {formatMeterValue(meter.used, meter.unit)} /{" "}
+                {meter.cap > 0 ? formatMeterValue(meter.cap, meter.unit) : "no cap"}
               </span>
             </div>
             <div style={barStyle}>
@@ -175,7 +189,7 @@ export function AdminMeterList({ meters }: { meters: AdminAccountMeter[] }) {
             </div>
             {over ? (
               <p className="text-xs text-destructive">
-                Over cap by {(meter.used - meter.cap).toLocaleString()}.
+                Over cap by {formatMeterValue(meter.used - meter.cap, meter.unit)}.
               </p>
             ) : null}
           </div>

--- a/apps/web/src/features/admin/admin-accounts-format.test.ts
+++ b/apps/web/src/features/admin/admin-accounts-format.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
 
+import type {
+  AdminAccountListItem,
+  AdminAccountSubscription,
+  AdminAccountTimelineEntry,
+  AdminAccountUsage,
+  AdminPastDueRow,
+  AdminRevenueEvent,
+} from "./use-admin-accounts";
 import {
   ACCOUNT_STATUS_BADGE_CLASS,
   ACCOUNT_STATUS_FILTER_OPTIONS,
@@ -8,17 +16,25 @@ import {
   DEFAULT_ACCOUNTS_SORT,
   accountDisplayStatus,
   activeAccountsFilterCount,
+  buildAccountMeters,
   buildAccountsQuery,
+  buildEntitlementRows,
+  bytesToWholeGB,
   defaultAccountsFilters,
   formatAccountMrr,
   formatCents,
+  formatMeterValue,
   isIdle90d,
   isOverCap,
+  isWebhookStale,
   meterBarPercent,
   meterPercent,
   meterTone,
   sortEventsNewestFirst,
   sortPastDueOldestFirst,
+  timelineActorLabel,
+  timelineEntryLabel,
+  timelineReason,
   type AdminAccountsFilters,
 } from "./admin-accounts-format";
 
@@ -67,42 +83,60 @@ describe("formatAccountMrr", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Account display status — suspended overrides everything
+// Account display status — suspended_at (a timestamp, not a boolean) wins
 // ---------------------------------------------------------------------------
 
 describe("accountDisplayStatus", () => {
   it("maps active plan_status to 'active'", () => {
-    expect(accountDisplayStatus({ plan_status: "active", suspended: false })).toBe("active");
+    expect(accountDisplayStatus({ plan_status: "active", suspended_at: undefined })).toBe(
+      "active",
+    );
   });
 
   it("maps trialing plan_status to 'trialing'", () => {
-    expect(accountDisplayStatus({ plan_status: "trialing", suspended: false })).toBe("trialing");
+    expect(accountDisplayStatus({ plan_status: "trialing", suspended_at: null })).toBe(
+      "trialing",
+    );
   });
 
   it("maps past_due plan_status to 'past_due'", () => {
-    expect(accountDisplayStatus({ plan_status: "past_due", suspended: false })).toBe("past_due");
+    expect(accountDisplayStatus({ plan_status: "past_due", suspended_at: null })).toBe(
+      "past_due",
+    );
   });
 
   it("maps canceled/paused/none plan_status to 'canceled' (muted)", () => {
-    expect(accountDisplayStatus({ plan_status: "canceled", suspended: false })).toBe("canceled");
-    expect(accountDisplayStatus({ plan_status: "paused", suspended: false })).toBe("canceled");
-    expect(accountDisplayStatus({ plan_status: "none", suspended: false })).toBe("canceled");
+    expect(accountDisplayStatus({ plan_status: "canceled", suspended_at: null })).toBe("canceled");
+    expect(accountDisplayStatus({ plan_status: "paused", suspended_at: null })).toBe("canceled");
+    expect(accountDisplayStatus({ plan_status: "none", suspended_at: null })).toBe("canceled");
   });
 
   it("maps comped plan_status to 'comped'", () => {
-    expect(accountDisplayStatus({ plan_status: "comped", suspended: false })).toBe("comped");
+    expect(accountDisplayStatus({ plan_status: "comped", suspended_at: null })).toBe("comped");
   });
 
-  it("suspended overrides active plan_status", () => {
-    expect(accountDisplayStatus({ plan_status: "active", suspended: true })).toBe("suspended");
+  it("a non-null suspended_at overrides active plan_status", () => {
+    expect(
+      accountDisplayStatus({ plan_status: "active", suspended_at: "2026-07-01T00:00:00Z" }),
+    ).toBe("suspended");
   });
 
-  it("suspended overrides comped plan_status (the most surprising combination)", () => {
-    expect(accountDisplayStatus({ plan_status: "comped", suspended: true })).toBe("suspended");
+  it("a non-null suspended_at overrides comped plan_status (the most surprising combination)", () => {
+    expect(
+      accountDisplayStatus({ plan_status: "comped", suspended_at: "2026-07-01T00:00:00Z" }),
+    ).toBe("suspended");
   });
 
-  it("suspended overrides past_due plan_status", () => {
-    expect(accountDisplayStatus({ plan_status: "past_due", suspended: true })).toBe("suspended");
+  it("a non-null suspended_at overrides past_due plan_status", () => {
+    expect(
+      accountDisplayStatus({ plan_status: "past_due", suspended_at: "2026-07-01T00:00:00Z" }),
+    ).toBe("suspended");
+  });
+
+  it("an absent (undefined) suspended_at does not suspend — the omitempty case", () => {
+    expect(accountDisplayStatus({ plan_status: "active", suspended_at: undefined })).toBe(
+      "active",
+    );
   });
 
   it("every status has a label and a badge class (exhaustive UI coverage)", () => {
@@ -172,6 +206,16 @@ describe("isOverCap", () => {
   });
 });
 
+describe("formatMeterValue", () => {
+  it("formats a count meter as a plain locale number", () => {
+    expect(formatMeterValue(1234, "count")).toBe("1,234");
+  });
+
+  it("formats a bytes meter via formatBytes", () => {
+    expect(formatMeterValue(1_500_000, "bytes")).toBe("1.4 MB");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Idle detection
 // ---------------------------------------------------------------------------
@@ -179,7 +223,11 @@ describe("isOverCap", () => {
 describe("isIdle90d", () => {
   const NOW = Date.parse("2026-07-06T00:00:00Z");
 
-  it("is true when last_activity_at is null (never active)", () => {
+  it("is true when last_activity is undefined (omitempty — never active)", () => {
+    expect(isIdle90d(undefined, NOW)).toBe(true);
+  });
+
+  it("is true when last_activity is null", () => {
     expect(isIdle90d(null, NOW)).toBe(true);
   });
 
@@ -196,6 +244,155 @@ describe("isIdle90d", () => {
   it("boundary: exactly 90 days is not yet idle (uses strictly-greater-than)", () => {
     const exact = new Date(NOW - 90 * 24 * 60 * 60 * 1000).toISOString();
     expect(isIdle90d(exact, NOW)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Account detail — usage meters + entitlement rows (derived from the flat
+// `usage` block; there is no `meters`/`entitlements` array on the wire).
+// ---------------------------------------------------------------------------
+
+describe("buildAccountMeters", () => {
+  it("builds a sites (count) row and a storage (bytes, always approximate) row", () => {
+    const meters = buildAccountMeters({
+      sites: { used: 12, cap: 50 },
+      storage_bytes_approx: { used: 10_000_000_000, cap: 250_000_000_000 },
+    });
+    expect(meters).toEqual([
+      { key: "sites", label: "Sites", used: 12, cap: 50, unit: "count" },
+      {
+        key: "storage",
+        label: "Storage",
+        used: 10_000_000_000,
+        cap: 250_000_000_000,
+        unit: "bytes",
+        approximate: true,
+      },
+    ]);
+  });
+
+  it("handles a zero storage cap (free tier: no CP-managed cap, not zero capacity)", () => {
+    const meters = buildAccountMeters({
+      sites: { used: 0, cap: 3 },
+      storage_bytes_approx: { used: 0, cap: 0 },
+    });
+    const storage = meters.find((m) => m.key === "storage")!;
+    expect(storage.cap).toBe(0);
+  });
+});
+
+describe("bytesToWholeGB", () => {
+  it("converts a byte count to whole GB", () => {
+    expect(bytesToWholeGB(250_000_000_000)).toBe(233);
+  });
+
+  it("converts 0 bytes to 0 GB", () => {
+    expect(bytesToWholeGB(0)).toBe(0);
+  });
+});
+
+describe("buildEntitlementRows", () => {
+  it("formats floor seconds as a human duration and includes booleans as Included/empty", () => {
+    const rows = buildEntitlementRows({
+      probe_interval_floor_sec: 3600,
+      backup_cadence_floor_seconds: 60,
+      incremental_backups: true,
+      client_portal: false,
+    });
+    expect(rows).toEqual([
+      { label: "Uptime probe interval", value: "1h" },
+      { label: "Backup cadence floor", value: "1m" },
+      { label: "Incremental backups", value: "Included" },
+      { label: "Client portal", value: "" },
+    ]);
+  });
+
+  it("never throws on a zero-valued minimal entitlements block", () => {
+    const rows = buildEntitlementRows({
+      probe_interval_floor_sec: 0,
+      backup_cadence_floor_seconds: 0,
+      incremental_backups: false,
+      client_portal: false,
+    });
+    expect(rows.every((r) => typeof r.value === "string")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Timeline display derivation
+// ---------------------------------------------------------------------------
+
+describe("timelineEntryLabel", () => {
+  it("title-cases an underscore-separated billing_events.kind", () => {
+    expect(timelineEntryLabel("subscription_updated")).toBe("Subscription Updated");
+  });
+
+  it("title-cases a dotted audit_log.action", () => {
+    expect(timelineEntryLabel("admin.billing.suspend")).toBe("Admin Billing Suspend");
+  });
+
+  it("falls back to the raw kind for an empty string", () => {
+    expect(timelineEntryLabel("")).toBe("");
+  });
+});
+
+describe("timelineActorLabel", () => {
+  it("combines actor_type and actor_id when both are present", () => {
+    expect(timelineActorLabel({ actor_type: "admin", actor_id: "u_123" })).toBe("admin u_123");
+  });
+
+  it("falls back to actor_type alone", () => {
+    expect(timelineActorLabel({ actor_type: "stripe" })).toBe("stripe");
+  });
+
+  it("falls back to actor_id alone", () => {
+    expect(timelineActorLabel({ actor_id: "u_123" })).toBe("u_123");
+  });
+
+  it("is null when neither is present (both omitempty and absent)", () => {
+    expect(timelineActorLabel({})).toBeNull();
+  });
+});
+
+describe("timelineReason", () => {
+  it("pulls a string 'reason' key out of metadata", () => {
+    expect(timelineReason({ metadata: { reason: "manual comp" } })).toBe("manual comp");
+  });
+
+  it("is undefined when metadata is absent", () => {
+    expect(timelineReason({})).toBeUndefined();
+  });
+
+  it("is undefined when metadata has no 'reason' key", () => {
+    expect(timelineReason({ metadata: { other: "value" } })).toBeUndefined();
+  });
+
+  it("is undefined when 'reason' is present but not a string (never throws)", () => {
+    expect(timelineReason({ metadata: { reason: 42 } })).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Revenue page — webhook staleness (derived client-side; RevenueResponse has
+// no `webhook_stale` boolean on the wire, only the raw timestamp).
+// ---------------------------------------------------------------------------
+
+describe("isWebhookStale", () => {
+  const NOW = Date.parse("2026-07-06T00:00:00Z");
+
+  it("is true when the timestamp is missing (never received)", () => {
+    expect(isWebhookStale(undefined, NOW)).toBe(true);
+    expect(isWebhookStale(null, NOW)).toBe(true);
+  });
+
+  it("is false within the 25h freshness window", () => {
+    const recent = new Date(NOW - 2 * 60 * 60 * 1000).toISOString();
+    expect(isWebhookStale(recent, NOW)).toBe(false);
+  });
+
+  it("is true past the 25h threshold", () => {
+    const old = new Date(NOW - 26 * 60 * 60 * 1000).toISOString();
+    expect(isWebhookStale(old, NOW)).toBe(true);
   });
 });
 
@@ -373,16 +570,133 @@ describe("sortPastDueOldestFirst", () => {
 });
 
 describe("sortEventsNewestFirst", () => {
-  it("sorts by 'at' descending", () => {
+  it("sorts by 'occurred_at' descending", () => {
     const rows = [
-      { at: "2026-01-01T00:00:00Z", kind: "old" },
-      { at: "2026-06-01T00:00:00Z", kind: "newest" },
-      { at: "2026-03-01T00:00:00Z", kind: "middle" },
+      { occurred_at: "2026-01-01T00:00:00Z", kind: "old" },
+      { occurred_at: "2026-06-01T00:00:00Z", kind: "newest" },
+      { occurred_at: "2026-03-01T00:00:00Z", kind: "middle" },
     ];
     expect(sortEventsNewestFirst(rows).map((r) => r.kind)).toEqual([
       "newest",
       "middle",
       "old",
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression guard for the prod crash class: every derivation helper above
+// must run without throwing when fed a MINIMAL backend payload — only
+// required fields present, every omitempty field genuinely absent (not even
+// `null`, since Go's `json:",omitempty"` drops the key entirely for a zero
+// value). This is exactly the shape that crashed /admin/accounts in prod.
+// ---------------------------------------------------------------------------
+
+describe("minimal (all-omitempty-absent) payload survival", () => {
+  const MINIMAL_LIST_ITEM: AdminAccountListItem = {
+    tenant_id: "11111111-1111-1111-1111-111111111111",
+    org_name: "Acme",
+    org_slug: "acme",
+    // owner_email absent
+    plan: "free",
+    plan_status: "none",
+    // suspended_at absent
+    has_overrides: false,
+    mrr_cents: 0,
+    sites_used: 0,
+    sites_cap: 1,
+    storage_used_bytes_approx: 0,
+    storage_cap_bytes: 0,
+    near_limit: false,
+    created_at: "2026-01-01T00:00:00Z",
+    // last_activity absent
+  };
+
+  it("accountDisplayStatus + formatAccountMrr + isIdle90d never throw on a minimal list item", () => {
+    expect(() => accountDisplayStatus(MINIMAL_LIST_ITEM)).not.toThrow();
+    expect(() => formatAccountMrr(MINIMAL_LIST_ITEM)).not.toThrow();
+    expect(() => isIdle90d(MINIMAL_LIST_ITEM.last_activity)).not.toThrow();
+    expect(accountDisplayStatus(MINIMAL_LIST_ITEM)).toBe("canceled");
+  });
+
+  const MINIMAL_USAGE: AdminAccountUsage = {
+    sites: { used: 0, cap: 1 },
+    storage_bytes_approx: { used: 0, cap: 0 },
+    seats_used: 1,
+    restore_volume_bytes_approx: 0,
+    entitlements: {
+      probe_interval_floor_sec: 0,
+      backup_cadence_floor_seconds: 0,
+      incremental_backups: false,
+      client_portal: false,
+    },
+  };
+
+  it("buildAccountMeters + buildEntitlementRows never throw on a minimal usage block", () => {
+    expect(() => buildAccountMeters(MINIMAL_USAGE)).not.toThrow();
+    expect(() => buildEntitlementRows(MINIMAL_USAGE.entitlements)).not.toThrow();
+  });
+
+  const MINIMAL_SUBSCRIPTION: AdminAccountSubscription = {
+    // provider, provider_customer_id, provider_subscription_id, dashboard_url,
+    // current_period_end, grace_until, comp_reason, last_billing_event_at all
+    // absent — a free/no-subscription account.
+    cancel_at_period_end: false,
+    stale: false,
+  };
+
+  it("a minimal subscription block's optional fields are all safely undefined (no throw when read)", () => {
+    expect(() => {
+      const renews = MINIMAL_SUBSCRIPTION.current_period_end
+        ? new Date(MINIMAL_SUBSCRIPTION.current_period_end).toLocaleDateString()
+        : undefined;
+      return renews;
+    }).not.toThrow();
+  });
+
+  const MINIMAL_TIMELINE_ENTRY: AdminAccountTimelineEntry = {
+    source: "audit",
+    occurred_at: "2026-01-01T00:00:00Z",
+    kind: "account_created",
+    // actor_type, actor_id, metadata all absent
+  };
+
+  it("timelineEntryLabel + timelineActorLabel + timelineReason never throw on a minimal timeline entry", () => {
+    expect(() => timelineEntryLabel(MINIMAL_TIMELINE_ENTRY.kind)).not.toThrow();
+    expect(() => timelineActorLabel(MINIMAL_TIMELINE_ENTRY)).not.toThrow();
+    expect(() => timelineReason(MINIMAL_TIMELINE_ENTRY)).not.toThrow();
+    expect(timelineActorLabel(MINIMAL_TIMELINE_ENTRY)).toBeNull();
+    expect(timelineReason(MINIMAL_TIMELINE_ENTRY)).toBeUndefined();
+  });
+
+  const MINIMAL_PAST_DUE_ROW: AdminPastDueRow = {
+    tenant_id: "22222222-2222-2222-2222-222222222222",
+    org_name: "Beta",
+    org_slug: "beta",
+    // owner_email absent
+    amount_cents: 1900,
+    days_past_due: 5,
+    // grace_until, last_payment_failed_at absent
+  };
+
+  it("sortPastDueOldestFirst never throws on a minimal past-due row", () => {
+    expect(() => sortPastDueOldestFirst([MINIMAL_PAST_DUE_ROW])).not.toThrow();
+  });
+
+  const MINIMAL_REVENUE_EVENT: AdminRevenueEvent = {
+    id: "33333333-3333-3333-3333-333333333333",
+    occurred_at: "2026-01-01T00:00:00Z",
+    // org_name, org_slug, tenant_id absent
+    kind: "invoice_paid",
+    provider: "stripe",
+  };
+
+  it("sortEventsNewestFirst never throws on a minimal revenue event (no org_name)", () => {
+    expect(() => sortEventsNewestFirst([MINIMAL_REVENUE_EVENT])).not.toThrow();
+  });
+
+  it("isWebhookStale never throws when last_webhook_received_at is absent", () => {
+    expect(() => isWebhookStale(undefined)).not.toThrow();
+    expect(isWebhookStale(undefined)).toBe(true);
   });
 });

--- a/apps/web/src/features/admin/admin-accounts-format.ts
+++ b/apps/web/src/features/admin/admin-accounts-format.ts
@@ -1,3 +1,4 @@
+import { formatBytes } from "@/lib/utils";
 import type { BillingPlanId } from "@/features/billing/use-billing";
 
 // M16 Phase C1 — pure derivation + formatting logic for the superadmin Billing
@@ -74,15 +75,16 @@ export const ACCOUNT_STATUS_BADGE_CLASS: Record<AccountDisplayStatus, string> = 
 
 /**
  * Derives the single display status from the raw account fields.
- * `suspended` always wins — an account can be suspended while its underlying
- * subscription is still `active` (e.g. a manual admin suspension), and the
- * operator needs that to be unmissable regardless of billing state.
+ * `suspended_at` (a non-null timestamp) always wins — an account can be
+ * suspended while its underlying subscription is still `active` (e.g. a
+ * manual admin suspension), and the operator needs that to be unmissable
+ * regardless of billing state.
  */
 export function accountDisplayStatus(account: {
   plan_status: string;
-  suspended: boolean;
+  suspended_at?: string | null;
 }): AccountDisplayStatus {
-  if (account.suspended) return "suspended";
+  if (account.suspended_at != null) return "suspended";
   switch (account.plan_status) {
     case "comped":
       return "comped";
@@ -141,15 +143,151 @@ export const METER_TONE_TEXT_CLASS: Record<MeterTone, string> = {
 
 const IDLE_THRESHOLD_MS = 90 * 24 * 60 * 60 * 1000;
 
-/** True when `lastActivityAt` is null (never active) or more than 90 days old. */
+/** True when `lastActivityAt` is missing (omitempty on the wire — never active) or more than 90 days old. */
 export function isIdle90d(
-  lastActivityAt: string | null,
+  lastActivityAt: string | null | undefined,
   now: number = Date.now(),
 ): boolean {
   if (!lastActivityAt) return true;
   const then = Date.parse(lastActivityAt);
   if (Number.isNaN(then)) return true;
   return now - then > IDLE_THRESHOLD_MS;
+}
+
+// ---------------------------------------------------------------------------
+// Account detail — usage meters + entitlement rows, derived from the flat
+// `usage` block (AdminAccountUsage in use-admin-accounts.ts). There is no
+// `meters`/`entitlements` array on the wire — the pinned contract invented
+// those; this is view-model derivation, same pattern as accountDisplayStatus
+// above, kept dependency-free so it stays independently unit-testable.
+// ---------------------------------------------------------------------------
+
+export type AccountMeterUnit = "count" | "bytes";
+
+export interface AccountMeterRow {
+  key: string;
+  label: string;
+  used: number;
+  cap: number;
+  unit: AccountMeterUnit;
+  approximate?: boolean;
+}
+
+/** Formats a meter's used/cap value for its unit ("12" for a count, "1.2 GB" for bytes). */
+export function formatMeterValue(value: number, unit: AccountMeterUnit): string {
+  return unit === "bytes" ? formatBytes(value) : value.toLocaleString();
+}
+
+/** Builds the account-detail "Usage vs limits" meter rows from the flat `usage` block (usage.sites / usage.storage_bytes_approx). */
+export function buildAccountMeters(usage: {
+  sites: { used: number; cap: number };
+  storage_bytes_approx: { used: number; cap: number };
+}): AccountMeterRow[] {
+  return [
+    { key: "sites", label: "Sites", used: usage.sites.used, cap: usage.sites.cap, unit: "count" },
+    {
+      key: "storage",
+      label: "Storage",
+      used: usage.storage_bytes_approx.used,
+      cap: usage.storage_bytes_approx.cap,
+      unit: "bytes",
+      // storage_bytes_approx is ALWAYS an approximation on the wire (see
+      // AccountListItem.StorageUsedBytesApprox's doc comment in
+      // billing_dto.go) — not conditional on a per-account flag.
+      approximate: true,
+    },
+  ];
+}
+
+const BYTES_PER_GB = 1024 ** 3;
+
+/**
+ * Converts a byte count to whole GB, for display alongside the GB-denominated
+ * `storage_gb` override input (see SetOverridesInput) — the usage meter
+ * itself (usage.storage_bytes_approx) is bytes, a distinct unit from the
+ * override the operator types in.
+ */
+export function bytesToWholeGB(bytes: number): number {
+  return Math.round(bytes / BYTES_PER_GB);
+}
+
+function formatSecondsFloor(seconds: number): string {
+  if (seconds <= 0) return "–";
+  if (seconds % 3600 === 0) return `${seconds / 3600}h`;
+  if (seconds % 60 === 0) return `${seconds / 60}m`;
+  return `${seconds}s`;
+}
+
+/** Human display rows for the entitlement reference values (display-only; not enforced anywhere — see AccountEntitlementValues's doc comment in billing_dto.go). Empty string signals "not on this plan" to the caller. */
+export function buildEntitlementRows(entitlements: {
+  probe_interval_floor_sec: number;
+  backup_cadence_floor_seconds: number;
+  incremental_backups: boolean;
+  client_portal: boolean;
+}): Array<{ label: string; value: string }> {
+  return [
+    {
+      label: "Uptime probe interval",
+      value: formatSecondsFloor(entitlements.probe_interval_floor_sec),
+    },
+    {
+      label: "Backup cadence floor",
+      value: formatSecondsFloor(entitlements.backup_cadence_floor_seconds),
+    },
+    { label: "Incremental backups", value: entitlements.incremental_backups ? "Included" : "" },
+    { label: "Client portal", value: entitlements.client_portal ? "Included" : "" },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Account detail — timeline display derivation. The wire entry
+// (AdminAccountTimelineEntry) has no dedicated label/actor/reason fields —
+// those are derived here from kind/actor_type/actor_id/metadata.
+// ---------------------------------------------------------------------------
+
+/** Turns a raw billing_events.kind / audit_log.action string ("subscription_updated", "admin.billing.suspend") into a readable label. Falls back to a generalized transform for unknown kinds so a new backend event type never renders blank. */
+export function timelineEntryLabel(kind: string): string {
+  const words = kind.split(/[._]/).filter(Boolean);
+  if (words.length === 0) return kind;
+  return words.map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+}
+
+/** "Who" performed a timeline entry, derived from actor_type/actor_id (no dedicated field on the wire). Returns null when neither is present. */
+export function timelineActorLabel(entry: {
+  actor_type?: string;
+  actor_id?: string;
+}): string | null {
+  if (entry.actor_type && entry.actor_id) return `${entry.actor_type} ${entry.actor_id}`;
+  if (entry.actor_type) return entry.actor_type;
+  if (entry.actor_id) return entry.actor_id;
+  return null;
+}
+
+/** Best-effort human "reason" pulled from a timeline entry's free-form metadata (no dedicated field on the wire). */
+export function timelineReason(entry: {
+  metadata?: Record<string, unknown>;
+}): string | undefined {
+  const reason = entry.metadata?.["reason"];
+  return typeof reason === "string" && reason.length > 0 ? reason : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Revenue page — webhook staleness. RevenueResponse only exposes the raw
+// `last_webhook_received_at` timestamp (no boolean flag) — derive staleness
+// client-side, mirroring the same 25h threshold AccountSubscription.Stale
+// uses server-side (see billing_dto.go).
+// ---------------------------------------------------------------------------
+
+const WEBHOOK_STALE_THRESHOLD_MS = 25 * 60 * 60 * 1000;
+
+export function isWebhookStale(
+  lastReceivedAt: string | null | undefined,
+  now: number = Date.now(),
+): boolean {
+  if (!lastReceivedAt) return true;
+  const then = Date.parse(lastReceivedAt);
+  if (Number.isNaN(then)) return true;
+  return now - then > WEBHOOK_STALE_THRESHOLD_MS;
 }
 
 // ---------------------------------------------------------------------------
@@ -276,8 +414,8 @@ export function sortPastDueOldestFirst<T extends { days_past_due: number }>(
   return [...rows].sort((a, b) => b.days_past_due - a.days_past_due);
 }
 
-export function sortEventsNewestFirst<T extends { at: string }>(
+export function sortEventsNewestFirst<T extends { occurred_at: string }>(
   rows: readonly T[],
 ): T[] {
-  return [...rows].sort((a, b) => Date.parse(b.at) - Date.parse(a.at));
+  return [...rows].sort((a, b) => Date.parse(b.occurred_at) - Date.parse(a.occurred_at));
 }

--- a/apps/web/src/features/admin/use-admin-accounts.test.ts
+++ b/apps/web/src/features/admin/use-admin-accounts.test.ts
@@ -4,183 +4,356 @@ import {
   adminAccountsKeys,
   adminRevenueKeys,
   type AdminAccountDetail,
+  type AdminAccountListItem,
   type AdminAccountsListResponse,
   type AdminRevenueResponse,
 } from "./use-admin-accounts";
 import { defaultAccountsFilters } from "./admin-accounts-format";
 
 // ---------------------------------------------------------------------------
-// Fixtures — realistic payloads mirroring the pinned Go handler DTOs.
+// Fixtures — realistic payloads mirroring the REAL Go handler DTOs in
+// apps/api/internal/admin/billing_dto.go (field names, nesting, optionality).
+// This file's field names are the regression guard for the prod crash caused
+// by a previous fixture set that pinned an invented contract (nested
+// sites/storage objects, tiles.past_due/total, header/meters/entitlements,
+// etc.) instead of the real one.
 // ---------------------------------------------------------------------------
 
 const ACCOUNTS_LIST_FIXTURE: AdminAccountsListResponse = {
-  tiles: { mrr_cents: 590_000, active_subs: 120, past_due: 4, total: 200 },
-  accounts: [
+  tiles: { mrr_cents: 590_000, active_subs: 120, past_due_count: 4, accounts_total: 200 },
+  items: [
     {
       tenant_id: "11111111-1111-1111-1111-111111111111",
       org_name: "Acme Agency",
-      slug: "acme-agency",
+      org_slug: "acme-agency",
       owner_email: "owner@acme.test",
       plan: "agency",
       plan_status: "active",
-      suspended: false,
+      suspended_at: undefined,
       has_overrides: false,
       mrr_cents: 5900,
-      sites: { used: 12, cap: 50 },
-      storage: { used_bytes: 10_000_000_000, cap_bytes: 250_000_000_000, approximate: true },
+      sites_used: 12,
+      sites_cap: 50,
+      storage_used_bytes_approx: 10_000_000_000,
+      storage_cap_bytes: 250_000_000_000,
+      near_limit: false,
       created_at: "2025-01-01T00:00:00Z",
-      last_activity_at: "2026-07-01T00:00:00Z",
+      last_activity: "2026-07-01T00:00:00Z",
     },
   ],
   total: 200,
+  limit: 25,
+  offset: 0,
 };
 
 const ACCOUNT_DETAIL_FIXTURE: AdminAccountDetail = {
-  header: {
-    org_name: "Acme Agency",
-    slug: "acme-agency",
-    tenant_id: "11111111-1111-1111-1111-111111111111",
-    plan: "agency",
-    plan_status: "active",
-    suspended_at: null,
-    mrr_cents: 5900,
-    created_at: "2025-01-01T00:00:00Z",
-    owner_email: "owner@acme.test",
+  tenant_id: "11111111-1111-1111-1111-111111111111",
+  org_name: "Acme Agency",
+  org_slug: "acme-agency",
+  owner_email: "owner@acme.test",
+  plan: "agency",
+  plan_status: "active",
+  mrr_cents: 5900,
+  created_at: "2025-01-01T00:00:00Z",
+  suspended_at: undefined,
+  suspended_reason: undefined,
+  usage: {
+    sites: { used: 12, cap: 50 },
+    storage_bytes_approx: { used: 10_000_000_000, cap: 250_000_000_000 },
+    seats_used: 3,
+    restore_volume_bytes_approx: 0,
+    entitlements: {
+      probe_interval_floor_sec: 60,
+      backup_cadence_floor_seconds: 3600,
+      incremental_backups: true,
+      client_portal: true,
+    },
   },
-  meters: [
-    { key: "sites", label: "Sites", used: 12, cap: 50 },
-    { key: "storage", label: "Storage", used: 10, cap: 250, approximate: true },
-  ],
-  entitlements: [{ label: "Hourly backups", value: "Included" }],
   subscription: {
     provider: "stripe",
     provider_customer_id: "cus_123",
     provider_subscription_id: "sub_123",
-    stripe_dashboard_base: "https://dashboard.stripe.com",
+    dashboard_url: "https://dashboard.stripe.com/subscriptions/sub_123",
     current_period_end: "2026-08-01T00:00:00Z",
     cancel_at_period_end: false,
-    grace_until: null,
-    comp_reason: null,
-    last_event_at: "2026-07-01T00:00:00Z",
-    webhook_stale: false,
+    grace_until: undefined,
+    comp_reason: undefined,
+    last_billing_event_at: "2026-07-01T00:00:00Z",
+    stale: false,
   },
   timeline: [
-    { at: "2026-07-01T00:00:00Z", kind: "subscription_updated", label: "Subscription updated", actor: "stripe", source: "webhook" },
+    {
+      source: "billing_event",
+      occurred_at: "2026-07-01T00:00:00Z",
+      kind: "subscription_updated",
+      actor_type: "stripe",
+      actor_id: "webhook",
+    },
   ],
   members: [
     {
+      id: "44444444-4444-4444-4444-444444444444",
       email: "owner@acme.test",
       name: "Owner",
       role: "owner",
       status: "active",
       email_verified: true,
       last_login_at: "2026-07-05T00:00:00Z",
+      member_since: "2025-01-01T00:00:00Z",
     },
   ],
-  sites: [{ url: "https://example.com", connection_state: "connected", created_at: "2025-02-01T00:00:00Z" }],
+  sites: [
+    {
+      id: "55555555-5555-5555-5555-555555555555",
+      url: "https://example.com",
+      connection_state: "connected",
+      created_at: "2025-02-01T00:00:00Z",
+    },
+  ],
 };
 
 const REVENUE_FIXTURE: AdminRevenueResponse = {
   tiles: {
     mrr_cents: 590_000,
+    mrr_past_due_cents: 23_600,
     active_subs: 120,
-    trialing: 8,
+    trialing_subs: 8,
     past_due_count: 4,
     past_due_at_risk_cents: 23_600,
     new_this_month: 6,
     canceled_this_month: 2,
   },
-  plan_distribution: [{ plan: "agency", count: 40, mrr_share_cents: 236_000 }],
+  plan_distribution: [{ plan: "agency", count: 40, mrr_cents: 236_000 }],
+  comped: { count: 2, hypothetical_value_cents: 11_800 },
   past_due: [
     {
       tenant_id: "11111111-1111-1111-1111-111111111111",
       org_name: "Acme Agency",
+      org_slug: "acme-agency",
+      owner_email: "owner@acme.test",
       amount_cents: 5900,
       days_past_due: 12,
       grace_until: "2026-07-10T00:00:00Z",
-      last_failed_at: "2026-06-25T00:00:00Z",
-      owner_email: "owner@acme.test",
+      last_payment_failed_at: "2026-06-25T00:00:00Z",
     },
   ],
-  recent_events: [{ at: "2026-07-01T00:00:00Z", org_name: "Acme Agency", kind: "invoice_paid", source: "stripe" }],
-  last_webhook_at: "2026-07-05T12:00:00Z",
-  webhook_stale: false,
+  recent_events: [
+    {
+      id: "66666666-6666-6666-6666-666666666666",
+      occurred_at: "2026-07-01T00:00:00Z",
+      org_name: "Acme Agency",
+      org_slug: "acme-agency",
+      tenant_id: "11111111-1111-1111-1111-111111111111",
+      kind: "invoice_paid",
+      provider: "stripe",
+    },
+  ],
+  last_webhook_received_at: "2026-07-05T12:00:00Z",
 };
 
 // ---------------------------------------------------------------------------
-// DTO shape pins
+// DTO shape pins — real wire field names, nesting, and optionality
 // ---------------------------------------------------------------------------
 
 describe("AdminAccountsListResponse DTO shape", () => {
-  it("tiles has the four required numeric fields", () => {
+  it("tiles use past_due_count/accounts_total (NOT past_due/total)", () => {
     const t = ACCOUNTS_LIST_FIXTURE.tiles;
     expect(typeof t.mrr_cents).toBe("number");
     expect(typeof t.active_subs).toBe("number");
-    expect(typeof t.past_due).toBe("number");
-    expect(typeof t.total).toBe("number");
+    expect(typeof t.past_due_count).toBe("number");
+    expect(typeof t.accounts_total).toBe("number");
   });
 
-  it("each account row has sites and storage usage sub-objects", () => {
-    const a = ACCOUNTS_LIST_FIXTURE.accounts[0]!;
-    expect(a.sites).toEqual({ used: 12, cap: 50 });
-    expect(a.storage.approximate).toBe(true);
+  it("the list is `items`, not `accounts`", () => {
+    expect(Array.isArray(ACCOUNTS_LIST_FIXTURE.items)).toBe(true);
   });
 
-  it("suspended and has_overrides are booleans, independent of plan_status", () => {
-    const a = ACCOUNTS_LIST_FIXTURE.accounts[0]!;
-    expect(typeof a.suspended).toBe("boolean");
+  it("each row has FLAT sites_used/sites_cap and storage_used_bytes_approx/storage_cap_bytes (no nested sites/storage objects)", () => {
+    const a = ACCOUNTS_LIST_FIXTURE.items[0]!;
+    expect(a.sites_used).toBe(12);
+    expect(a.sites_cap).toBe(50);
+    expect(a.storage_used_bytes_approx).toBe(10_000_000_000);
+    expect(a.storage_cap_bytes).toBe(250_000_000_000);
+  });
+
+  it("has_overrides is a boolean; suspension is a nullable timestamp (suspended_at), not a boolean", () => {
+    const a = ACCOUNTS_LIST_FIXTURE.items[0]!;
     expect(typeof a.has_overrides).toBe("boolean");
+    expect(a.suspended_at).toBeUndefined();
+  });
+
+  it("response carries limit/offset alongside total", () => {
+    expect(ACCOUNTS_LIST_FIXTURE.limit).toBe(25);
+    expect(ACCOUNTS_LIST_FIXTURE.offset).toBe(0);
   });
 });
 
 describe("AdminAccountDetail DTO shape", () => {
-  it("has all six sections: header, meters, entitlements, subscription, timeline, members, sites", () => {
+  it("has no top-level header/meters/entitlements object — org_name/plan/etc. are flat top-level fields", () => {
     const d = ACCOUNT_DETAIL_FIXTURE;
-    expect(d.header).toBeDefined();
-    expect(Array.isArray(d.meters)).toBe(true);
-    expect(Array.isArray(d.entitlements)).toBe(true);
-    expect(d.subscription).toBeDefined();
-    expect(Array.isArray(d.timeline)).toBe(true);
-    expect(Array.isArray(d.members)).toBe(true);
-    expect(Array.isArray(d.sites)).toBe(true);
+    expect(d.org_name).toBe("Acme Agency");
+    expect(d.plan).toBe("agency");
+    expect((d as unknown as { header?: unknown }).header).toBeUndefined();
+    expect((d as unknown as { meters?: unknown }).meters).toBeUndefined();
   });
 
-  it("subscription.webhook_stale is a boolean the UI can branch on directly", () => {
-    expect(typeof ACCOUNT_DETAIL_FIXTURE.subscription.webhook_stale).toBe("boolean");
+  it("usage.storage_bytes_approx is the storage meter (used/cap), not usage.storage", () => {
+    expect(ACCOUNT_DETAIL_FIXTURE.usage.storage_bytes_approx).toEqual({
+      used: 10_000_000_000,
+      cap: 250_000_000_000,
+    });
   });
 
-  it("meters entries carry an optional 'approximate' flag", () => {
-    const storageMeter = ACCOUNT_DETAIL_FIXTURE.meters.find((m) => m.key === "storage");
-    expect(storageMeter?.approximate).toBe(true);
-    const sitesMeter = ACCOUNT_DETAIL_FIXTURE.meters.find((m) => m.key === "sites");
-    expect(sitesMeter?.approximate).toBeUndefined();
+  it("subscription uses dashboard_url/last_billing_event_at/stale (not stripe_dashboard_base/last_event_at/webhook_stale)", () => {
+    const s = ACCOUNT_DETAIL_FIXTURE.subscription;
+    expect(s.dashboard_url).toContain("stripe.com");
+    expect(s.last_billing_event_at).toBeTruthy();
+    expect(typeof s.stale).toBe("boolean");
   });
 
-  it("members carry role/status/email_verified/last_login_at for the Members card", () => {
+  it("timeline entries use occurred_at/kind/actor_type/actor_id/metadata (not at/label/actor/reason)", () => {
+    const entry = ACCOUNT_DETAIL_FIXTURE.timeline[0]!;
+    expect(entry.occurred_at).toBeTruthy();
+    expect(entry.kind).toBe("subscription_updated");
+    expect(entry.actor_type).toBe("stripe");
+  });
+
+  it("members carry role/status/email_verified/last_login_at/member_since", () => {
     const owner = ACCOUNT_DETAIL_FIXTURE.members[0]!;
     expect(owner.role).toBe("owner");
     expect(owner.email_verified).toBe(true);
+    expect(owner.member_since).toBeTruthy();
+  });
+
+  it("sites carry an id (used as the React key instead of url)", () => {
+    expect(ACCOUNT_DETAIL_FIXTURE.sites[0]!.id).toBeTruthy();
   });
 });
 
 describe("AdminRevenueResponse DTO shape", () => {
-  it("tiles use raw counts, not percentages (spec: raw counts not churn %)", () => {
+  it("tiles use trialing_subs (not trialing) and raw counts, not percentages", () => {
     const t = REVENUE_FIXTURE.tiles;
+    expect(Number.isInteger(t.trialing_subs)).toBe(true);
     expect(Number.isInteger(t.active_subs)).toBe(true);
     expect(Number.isInteger(t.past_due_count)).toBe(true);
     expect(Number.isInteger(t.new_this_month)).toBe(true);
     expect(Number.isInteger(t.canceled_this_month)).toBe(true);
   });
 
-  it("past_due rows carry everything the worklist needs: amount, days, grace, last-failed, owner", () => {
+  it("past_due rows carry last_payment_failed_at (not last_failed_at)", () => {
     const row = REVENUE_FIXTURE.past_due[0]!;
     expect(row.amount_cents).toBeGreaterThan(0);
     expect(row.days_past_due).toBeGreaterThan(0);
-    expect(row.owner_email).toContain("@");
+    expect(row.last_payment_failed_at).toBeTruthy();
   });
 
-  it("plan_distribution rows optionally carry comped_value_cents", () => {
-    expect(REVENUE_FIXTURE.plan_distribution[0]!.comped_value_cents).toBeUndefined();
+  it("plan_distribution rows carry mrr_cents (not mrr_share_cents) and no per-row comped value", () => {
+    const row = REVENUE_FIXTURE.plan_distribution[0]!;
+    expect(row.mrr_cents).toBe(236_000);
+    expect((row as unknown as { comped_value_cents?: unknown }).comped_value_cents).toBeUndefined();
+  });
+
+  it("comped is a separate top-level object, not a plan_distribution row", () => {
+    expect(REVENUE_FIXTURE.comped.count).toBe(2);
+    expect(REVENUE_FIXTURE.comped.hypothetical_value_cents).toBe(11_800);
+  });
+
+  it("recent_events use occurred_at/provider (not at/source), and no webhook_stale boolean exists on the response", () => {
+    const ev = REVENUE_FIXTURE.recent_events[0]!;
+    expect(ev.occurred_at).toBeTruthy();
+    expect(ev.provider).toBe("stripe");
+    expect((REVENUE_FIXTURE as unknown as { webhook_stale?: unknown }).webhook_stale).toBeUndefined();
+  });
+
+  it("last_webhook_received_at is top-level (not nested under tiles)", () => {
+    expect(REVENUE_FIXTURE.last_webhook_received_at).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Minimal-payload regression guard — only required fields present, every
+// omitempty field genuinely absent. This is the exact shape class that
+// crashed /admin/accounts in prod (a missing/undefined field read with
+// `.toLocaleString()`); the DTO types themselves must accept these shapes
+// without a TypeScript error, which is checked simply by this file
+// typechecking under `pnpm -C apps/web typecheck`.
+// ---------------------------------------------------------------------------
+
+describe("minimal (all-omitempty-absent) DTO shapes typecheck and hold real data", () => {
+  it("a minimal AdminAccountListItem (no owner_email/suspended_at/last_activity) is valid", () => {
+    const minimal: AdminAccountListItem = {
+      tenant_id: "aaaaaaaa-0000-0000-0000-000000000000",
+      org_name: "Minimal Org",
+      org_slug: "minimal-org",
+      plan: "free",
+      plan_status: "none",
+      has_overrides: false,
+      mrr_cents: 0,
+      sites_used: 0,
+      sites_cap: 1,
+      storage_used_bytes_approx: 0,
+      storage_cap_bytes: 0,
+      near_limit: false,
+      created_at: "2026-01-01T00:00:00Z",
+    };
+    expect(minimal.owner_email).toBeUndefined();
+    expect(minimal.suspended_at).toBeUndefined();
+    expect(minimal.last_activity).toBeUndefined();
+  });
+
+  it("a minimal AdminAccountDetail (no owner_email/suspended_at/suspended_reason, a bare subscription) is valid", () => {
+    const minimal: AdminAccountDetail = {
+      tenant_id: "aaaaaaaa-0000-0000-0000-000000000000",
+      org_name: "Minimal Org",
+      org_slug: "minimal-org",
+      plan: "free",
+      plan_status: "none",
+      mrr_cents: 0,
+      created_at: "2026-01-01T00:00:00Z",
+      usage: {
+        sites: { used: 0, cap: 1 },
+        storage_bytes_approx: { used: 0, cap: 0 },
+        seats_used: 1,
+        restore_volume_bytes_approx: 0,
+        entitlements: {
+          probe_interval_floor_sec: 0,
+          backup_cadence_floor_seconds: 0,
+          incremental_backups: false,
+          client_portal: false,
+        },
+      },
+      subscription: {
+        cancel_at_period_end: false,
+        stale: false,
+      },
+      timeline: [],
+      members: [],
+      sites: [],
+    };
+    expect(minimal.owner_email).toBeUndefined();
+    expect(minimal.suspended_at).toBeUndefined();
+    expect(minimal.subscription.provider).toBeUndefined();
+    expect(minimal.subscription.dashboard_url).toBeUndefined();
+  });
+
+  it("a minimal RevenueResponse (no comped accounts, no webhook ever received) is valid", () => {
+    const minimal: AdminRevenueResponse = {
+      tiles: {
+        mrr_cents: 0,
+        mrr_past_due_cents: 0,
+        active_subs: 0,
+        trialing_subs: 0,
+        past_due_count: 0,
+        past_due_at_risk_cents: 0,
+        new_this_month: 0,
+        canceled_this_month: 0,
+      },
+      plan_distribution: [],
+      comped: { count: 0, hypothetical_value_cents: 0 },
+      past_due: [],
+      recent_events: [],
+    };
+    expect(minimal.last_webhook_received_at).toBeUndefined();
   });
 });
 

--- a/apps/web/src/features/admin/use-admin-accounts.ts
+++ b/apps/web/src/features/admin/use-admin-accounts.ts
@@ -22,117 +22,124 @@ import { buildAccountsQuery, type AdminAccountsFilters } from "./admin-accounts-
 // generated `listAdminAccounts` / `getAdminAccount` / `getAdminRevenue` /
 // `compAdminAccount` etc. (re-exported from packages/openapi-client/src/index.ts)
 // once the SDK regenerates against the landed contract.
-
+//
+// IMPORTANT: the types below MUST track apps/api/internal/admin/billing_dto.go
+// field-for-field (names, nesting, optionality) until these endpoints move
+// into OpenAPI and this file is deleted in favor of a generated client. A
+// prior drift between this file and billing_dto.go (invented nesting like
+// `sites: {used,cap}` instead of the real flat `sites_used`/`sites_cap`,
+// `tiles.past_due`/`tiles.total` instead of `past_due_count`/`accounts_total`)
+// crashed the whole /admin/accounts panel in prod — read billing_dto.go, not
+// memory, before touching this file again. A future task should add
+// /admin/accounts* to packages/openapi/openapi.yaml so the client here is
+// generated instead of hand-rolled.
 // ---------------------------------------------------------------------------
-// Domain types — MUST exactly match the Go handler DTOs (pinned contract).
+// Domain types — wire DTOs only. View-model derivation (usage meters,
+// entitlement display rows, timeline labels) lives in admin-accounts-format.ts
+// alongside its other pure derivation helpers.
 // ---------------------------------------------------------------------------
 
 export interface AdminAccountTiles {
   mrr_cents: number;
   active_subs: number;
-  past_due: number;
-  total: number;
-}
-
-export interface AdminAccountSitesUsage {
-  used: number;
-  cap: number;
-}
-
-export interface AdminAccountStorageUsage {
-  used_bytes: number;
-  cap_bytes: number;
-  approximate: boolean;
+  past_due_count: number;
+  accounts_total: number;
 }
 
 export interface AdminAccountListItem {
   tenant_id: string;
   org_name: string;
-  slug: string;
-  owner_email: string;
+  org_slug: string;
+  owner_email?: string;
   plan: string;
   plan_status: string;
-  suspended: boolean;
+  suspended_at?: string;
   has_overrides: boolean;
   mrr_cents: number;
-  sites: AdminAccountSitesUsage;
-  storage: AdminAccountStorageUsage;
+  sites_used: number;
+  sites_cap: number;
+  storage_used_bytes_approx: number;
+  storage_cap_bytes: number;
+  near_limit: boolean;
   created_at: string;
-  last_activity_at: string | null;
+  last_activity?: string;
 }
 
 export interface AdminAccountsListResponse {
   tiles: AdminAccountTiles;
-  accounts: AdminAccountListItem[];
+  items: AdminAccountListItem[];
   total: number;
+  limit: number;
+  offset: number;
 }
 
-export interface AdminAccountHeader {
-  org_name: string;
-  slug: string;
-  tenant_id: string;
-  plan: string;
-  plan_status: string;
-  suspended_at: string | null;
-  mrr_cents: number;
-  created_at: string;
-  owner_email: string;
+export interface AdminAccountEntitlementValues {
+  probe_interval_floor_sec: number;
+  backup_cadence_floor_seconds: number;
+  incremental_backups: boolean;
+  client_portal: boolean;
 }
 
-export interface AdminAccountMeter {
-  key: string;
-  label: string;
-  used: number;
-  cap: number;
-  approximate?: boolean;
-}
-
-export interface AdminAccountEntitlement {
-  label: string;
-  value: string;
+export interface AdminAccountUsage {
+  sites: { used: number; cap: number };
+  storage_bytes_approx: { used: number; cap: number };
+  seats_used: number;
+  restore_volume_bytes_approx: number;
+  entitlements: AdminAccountEntitlementValues;
 }
 
 export interface AdminAccountSubscription {
-  provider: string | null;
-  provider_customer_id: string | null;
-  provider_subscription_id: string | null;
-  stripe_dashboard_base: string | null;
-  current_period_end: string | null;
+  provider?: string;
+  provider_customer_id?: string;
+  provider_subscription_id?: string;
+  dashboard_url?: string;
+  current_period_end?: string;
   cancel_at_period_end: boolean;
-  grace_until: string | null;
-  comp_reason: string | null;
-  last_event_at: string | null;
-  webhook_stale: boolean;
+  grace_until?: string;
+  comp_reason?: string;
+  last_billing_event_at?: string;
+  stale: boolean;
 }
 
 export interface AdminAccountTimelineEntry {
-  at: string;
+  source: "billing_event" | "audit";
+  occurred_at: string;
   kind: string;
-  label: string;
-  actor: string | null;
-  source: string;
-  reason?: string;
+  actor_type?: string;
+  actor_id?: string;
+  metadata?: Record<string, unknown>;
 }
 
 export interface AdminAccountMember {
+  id: string;
   email: string;
   name: string;
   role: string;
   status: string;
   email_verified: boolean;
-  last_login_at: string | null;
+  last_login_at?: string;
+  member_since: string;
 }
 
 export interface AdminAccountSite {
+  id: string;
   url: string;
   connection_state: string;
   created_at: string;
 }
 
 export interface AdminAccountDetail {
-  header: AdminAccountHeader;
-  meters: AdminAccountMeter[];
-  entitlements: AdminAccountEntitlement[];
+  tenant_id: string;
+  org_name: string;
+  org_slug: string;
+  owner_email?: string;
+  plan: string;
+  plan_status: string;
+  mrr_cents: number;
+  created_at: string;
+  suspended_at?: string;
+  suspended_reason?: string;
+  usage: AdminAccountUsage;
   subscription: AdminAccountSubscription;
   timeline: AdminAccountTimelineEntry[];
   members: AdminAccountMember[];
@@ -141,8 +148,9 @@ export interface AdminAccountDetail {
 
 export interface AdminRevenueTiles {
   mrr_cents: number;
+  mrr_past_due_cents: number;
   active_subs: number;
-  trialing: number;
+  trialing_subs: number;
   past_due_count: number;
   past_due_at_risk_cents: number;
   new_this_month: number;
@@ -152,34 +160,42 @@ export interface AdminRevenueTiles {
 export interface AdminPlanDistributionRow {
   plan: string;
   count: number;
-  mrr_share_cents: number;
-  comped_value_cents?: number;
+  mrr_cents: number;
+}
+
+export interface AdminCompedRow {
+  count: number;
+  hypothetical_value_cents: number;
 }
 
 export interface AdminPastDueRow {
   tenant_id: string;
   org_name: string;
+  org_slug: string;
+  owner_email?: string;
   amount_cents: number;
   days_past_due: number;
-  grace_until: string | null;
-  last_failed_at: string | null;
-  owner_email: string;
+  grace_until?: string;
+  last_payment_failed_at?: string;
 }
 
 export interface AdminRevenueEvent {
-  at: string;
-  org_name: string;
+  id: string;
+  occurred_at: string;
+  org_name?: string;
+  org_slug?: string;
+  tenant_id?: string;
   kind: string;
-  source: string;
+  provider: string;
 }
 
 export interface AdminRevenueResponse {
   tiles: AdminRevenueTiles;
   plan_distribution: AdminPlanDistributionRow[];
+  comped: AdminCompedRow;
   past_due: AdminPastDueRow[];
   recent_events: AdminRevenueEvent[];
-  last_webhook_at: string | null;
-  webhook_stale: boolean;
+  last_webhook_received_at?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/routes/_authed/admin/accounts/$tenantId.tsx
+++ b/apps/web/src/routes/_authed/admin/accounts/$tenantId.tsx
@@ -23,7 +23,15 @@ import {
   AdminMeterList,
   PlanBadge,
 } from "@/features/admin/admin-account-ui";
-import { formatCents } from "@/features/admin/admin-accounts-format";
+import {
+  buildAccountMeters,
+  buildEntitlementRows,
+  formatCents,
+  sortEventsNewestFirst,
+  timelineActorLabel,
+  timelineEntryLabel,
+  timelineReason,
+} from "@/features/admin/admin-accounts-format";
 import {
   CompAccountDialog,
   ExtendGraceDialog,
@@ -87,45 +95,64 @@ function AdminAccountDetailPage() {
     );
   }
 
-  const { header, meters, entitlements, subscription, timeline, members, sites } = data;
-  const isComped = header.plan_status === "comped";
+  const {
+    tenant_id,
+    org_name,
+    org_slug,
+    owner_email,
+    plan,
+    plan_status,
+    mrr_cents,
+    created_at,
+    suspended_at,
+    usage,
+    subscription,
+    timeline,
+    members,
+    sites,
+  } = data;
+  const isComped = plan_status === "comped";
   const hasActiveSubscription =
     subscription.provider_subscription_id != null &&
-    header.plan_status !== "canceled" &&
-    header.plan_status !== "none";
-  const isSuspended = header.suspended_at != null;
+    plan_status !== "canceled" &&
+    plan_status !== "none";
+  const isSuspended = suspended_at != null;
 
-  const timelineNewestFirst = [...timeline].sort(
-    (a, b) => Date.parse(b.at) - Date.parse(a.at),
-  );
+  const meters = buildAccountMeters(usage);
+  const entitlementRows = buildEntitlementRows(usage.entitlements);
+  const timelineNewestFirst = sortEventsNewestFirst(timeline);
 
   return (
     <section className="max-w-4xl space-y-6">
       <PageHeader
-        title={header.org_name}
-        copyable={header.tenant_id}
+        title={org_name}
+        copyable={tenant_id}
         backTo={{ to: "/admin/accounts", label: "Back to Accounts" }}
         badges={
           <>
-            <PlanBadge plan={header.plan} comped={isComped} hasOverrides={false} />
-            <AccountStatusBadge account={{ plan_status: header.plan_status, suspended: isSuspended }} />
+            <PlanBadge plan={plan} comped={isComped} hasOverrides={false} />
+            <AccountStatusBadge account={{ plan_status, suspended_at }} />
           </>
         }
         subline={
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-            <span className="font-mono text-xs">{header.slug}</span>
+            <span className="font-mono text-xs">{org_slug}</span>
+            {owner_email ? (
+              <>
+                <span aria-hidden="true">&middot;</span>
+                <a href={`mailto:${owner_email}`} className="inline-flex items-center gap-1 hover:underline">
+                  <Mail aria-hidden="true" className="size-3" />
+                  {owner_email}
+                </a>
+              </>
+            ) : null}
             <span aria-hidden="true">&middot;</span>
-            <a href={`mailto:${header.owner_email}`} className="inline-flex items-center gap-1 hover:underline">
-              <Mail aria-hidden="true" className="size-3" />
-              {header.owner_email}
-            </a>
-            <span aria-hidden="true">&middot;</span>
-            <span>MRR {formatCents(header.mrr_cents)}</span>
+            <span>MRR {formatCents(mrr_cents)}</span>
             <span aria-hidden="true">&middot;</span>
             <span>
               Created{" "}
-              <time dateTime={header.created_at} title={new Date(header.created_at).toLocaleString()}>
-                {relativeTime(header.created_at) ?? header.created_at}
+              <time dateTime={created_at} title={new Date(created_at).toLocaleString()}>
+                {relativeTime(created_at) ?? created_at}
               </time>
             </span>
           </div>
@@ -142,16 +169,14 @@ function AdminAccountDetailPage() {
         </CardHeader>
         <CardContent className="space-y-5">
           <AdminMeterList meters={meters} />
-          {entitlements.length > 0 ? (
-            <div className="border-t border-border pt-4">
-              <DefinitionList
-                rows={entitlements.map((e) => ({
-                  label: e.label,
-                  value: e.value || "Not on this plan",
-                }))}
-              />
-            </div>
-          ) : null}
+          <div className="border-t border-border pt-4">
+            <DefinitionList
+              rows={entitlementRows.map((e) => ({
+                label: e.label,
+                value: e.value || "Not on this plan",
+              }))}
+            />
+          </div>
         </CardContent>
       </Card>
 
@@ -178,7 +203,7 @@ function AdminAccountDetailPage() {
           </div>
         </CardHeader>
         <CardContent className="space-y-4">
-          {subscription.webhook_stale ? (
+          {subscription.stale ? (
             <p
               role="alert"
               className="flex items-center gap-2 rounded-md border border-[var(--color-warning)]/40 bg-warning-subtle px-3 py-2 text-sm text-warning-subtle-fg"
@@ -190,14 +215,14 @@ function AdminAccountDetailPage() {
 
           <DefinitionList
             rows={[
-              { label: "Provider", value: subscription.provider ?? undefined },
+              { label: "Provider", value: subscription.provider },
               {
                 label: "Customer id",
-                copyable: subscription.provider_customer_id ?? undefined,
+                copyable: subscription.provider_customer_id,
               },
               {
                 label: "Subscription id",
-                copyable: subscription.provider_subscription_id ?? undefined,
+                copyable: subscription.provider_subscription_id,
               },
               {
                 label: "Renews",
@@ -217,39 +242,28 @@ function AdminAccountDetailPage() {
               },
               {
                 label: "Comp reason",
-                value: subscription.comp_reason ?? undefined,
+                value: subscription.comp_reason,
               },
               {
                 label: "Last billing event",
-                value: subscription.last_event_at
-                  ? (relativeTime(subscription.last_event_at) ?? subscription.last_event_at)
+                value: subscription.last_billing_event_at
+                  ? (relativeTime(subscription.last_billing_event_at) ?? subscription.last_billing_event_at)
                   : undefined,
               },
             ]}
           />
 
-          {subscription.stripe_dashboard_base && subscription.provider_customer_id ? (
+          {subscription.dashboard_url ? (
             <div className="flex flex-wrap gap-3 border-t border-border pt-3">
               <a
-                href={`${subscription.stripe_dashboard_base}/customers/${subscription.provider_customer_id}`}
+                href={subscription.dashboard_url}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 text-sm text-foreground underline underline-offset-2 hover:no-underline"
               >
-                View customer in Stripe
+                View subscription in Stripe
                 <ExternalLink aria-hidden="true" className="size-3" />
               </a>
-              {subscription.provider_subscription_id ? (
-                <a
-                  href={`${subscription.stripe_dashboard_base}/subscriptions/${subscription.provider_subscription_id}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-sm text-foreground underline underline-offset-2 hover:no-underline"
-                >
-                  View subscription in Stripe
-                  <ExternalLink aria-hidden="true" className="size-3" />
-                </a>
-              ) : null}
             </div>
           ) : null}
         </CardContent>
@@ -265,25 +279,31 @@ function AdminAccountDetailPage() {
             <p className="text-sm text-muted-foreground">No events recorded yet.</p>
           ) : (
             <ul className="divide-y divide-border">
-              {timelineNewestFirst.map((entry, i) => (
-                <li key={`${entry.at}-${i}`} className="flex flex-col gap-0.5 py-2.5 text-sm">
-                  <div className="flex flex-wrap items-baseline gap-x-2">
-                    <time
-                      dateTime={entry.at}
-                      title={new Date(entry.at).toLocaleString()}
-                      className="text-xs text-muted-foreground"
-                    >
-                      {relativeTime(entry.at) ?? entry.at}
-                    </time>
-                    <span className="font-medium text-foreground">{entry.label}</span>
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    {entry.actor ? `${entry.actor} · ` : ""}
-                    {entry.source}
-                    {entry.reason ? ` · ${entry.reason}` : ""}
-                  </p>
-                </li>
-              ))}
+              {timelineNewestFirst.map((entry, i) => {
+                const who = timelineActorLabel(entry);
+                const reason = timelineReason(entry);
+                return (
+                  <li key={`${entry.occurred_at}-${i}`} className="flex flex-col gap-0.5 py-2.5 text-sm">
+                    <div className="flex flex-wrap items-baseline gap-x-2">
+                      <time
+                        dateTime={entry.occurred_at}
+                        title={new Date(entry.occurred_at).toLocaleString()}
+                        className="text-xs text-muted-foreground"
+                      >
+                        {relativeTime(entry.occurred_at) ?? entry.occurred_at}
+                      </time>
+                      <span className="font-medium text-foreground">
+                        {timelineEntryLabel(entry.kind)}
+                      </span>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {who ? `${who} · ` : ""}
+                      {entry.source === "billing_event" ? "Billing" : "Audit"}
+                      {reason ? ` · ${reason}` : ""}
+                    </p>
+                  </li>
+                );
+              })}
             </ul>
           )}
         </CardContent>
@@ -318,7 +338,7 @@ function AdminAccountDetailPage() {
                 </TableRow>
               ) : (
                 members.map((m) => (
-                  <TableRow key={m.email}>
+                  <TableRow key={m.id}>
                     <TableCell className="font-mono text-xs">{m.email}</TableCell>
                     <TableCell className={cn("text-sm", m.role === "owner" && "font-semibold text-foreground")}>
                       {m.role}
@@ -349,7 +369,7 @@ function AdminAccountDetailPage() {
           ) : (
             <ul className="divide-y divide-border text-sm">
               {sites.map((site) => (
-                <li key={site.url} className="flex flex-wrap items-center gap-x-3 gap-y-1 py-2">
+                <li key={site.id} className="flex flex-wrap items-center gap-x-3 gap-y-1 py-2">
                   <a
                     href={site.url}
                     target="_blank"
@@ -401,42 +421,43 @@ function AdminAccountDetailPage() {
       <CompAccountDialog
         open={openDialog === "comp"}
         onClose={() => setOpenDialog(null)}
-        tenantId={header.tenant_id}
+        tenantId={tenant_id}
         hasActiveSubscription={hasActiveSubscription}
       />
       <RevokeCompDialog
         open={openDialog === "revoke-comp"}
         onClose={() => setOpenDialog(null)}
-        tenantId={header.tenant_id}
+        tenantId={tenant_id}
       />
       <OverridesEditorDialog
         open={openDialog === "overrides"}
         onClose={() => setOpenDialog(null)}
-        tenantId={header.tenant_id}
-        detail={data}
+        tenantId={tenant_id}
+        usage={usage}
+        timeline={timeline}
       />
       <ExtendGraceDialog
         open={openDialog === "grace"}
         onClose={() => setOpenDialog(null)}
-        tenantId={header.tenant_id}
+        tenantId={tenant_id}
       />
       <ForceBillingStateDialog
         open={openDialog === "force-state"}
         onClose={() => setOpenDialog(null)}
-        tenantId={header.tenant_id}
-        currentPlan={header.plan}
+        tenantId={tenant_id}
+        currentPlan={plan}
       />
       <SuspendAccountDialog
         open={openDialog === "suspend"}
         onClose={() => setOpenDialog(null)}
-        tenantId={header.tenant_id}
-        orgSlug={header.slug}
+        tenantId={tenant_id}
+        orgSlug={org_slug}
       />
       <RestoreAccountDialog
         open={openDialog === "restore"}
         onClose={() => setOpenDialog(null)}
-        tenantId={header.tenant_id}
-        orgSlug={header.slug}
+        tenantId={tenant_id}
+        orgSlug={org_slug}
       />
     </section>
   );

--- a/apps/web/src/routes/_authed/admin/accounts/index.tsx
+++ b/apps/web/src/routes/_authed/admin/accounts/index.tsx
@@ -174,10 +174,10 @@ function AdminAccountsPage() {
         <Tile label="Active subs" value={tiles ? tiles.active_subs.toLocaleString() : "–"} />
         <Tile
           label="Past due"
-          value={tiles ? tiles.past_due.toLocaleString() : "–"}
-          tone={tiles && tiles.past_due > 0 ? "critical" : undefined}
+          value={tiles ? tiles.past_due_count.toLocaleString() : "–"}
+          tone={tiles && tiles.past_due_count > 0 ? "critical" : undefined}
         />
-        <Tile label="Accounts total" value={tiles ? tiles.total.toLocaleString() : "–"} />
+        <Tile label="Accounts total" value={tiles ? tiles.accounts_total.toLocaleString() : "–"} />
       </div>
 
       {/* Filters */}
@@ -303,7 +303,7 @@ function AdminAccountsPage() {
                   Loading accounts...
                 </TableCell>
               </TableRow>
-            ) : !data || data.accounts.length === 0 ? (
+            ) : !data || data.items.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={9} className="py-10 text-center text-sm text-muted-foreground">
                   {activeFilterCount > 0 || filters.search
@@ -312,7 +312,7 @@ function AdminAccountsPage() {
                 </TableCell>
               </TableRow>
             ) : (
-              data.accounts.map((account) => (
+              data.items.map((account) => (
                 <AccountRow key={account.tenant_id} account={account} />
               ))
             )}
@@ -492,7 +492,7 @@ function MultiSelectMenu<T extends string>({
 // ---------------------------------------------------------------------------
 
 function AccountRow({ account }: { account: AdminAccountListItem }) {
-  const idle = isIdle90d(account.last_activity_at);
+  const idle = isIdle90d(account.last_activity);
 
   return (
     <TableRow>
@@ -505,8 +505,10 @@ function AccountRow({ account }: { account: AdminAccountListItem }) {
           <span className="text-sm font-medium text-foreground hover:underline">
             {account.org_name}
           </span>
-          <span className="font-mono text-xs text-muted-foreground">{account.slug}</span>
-          <span className="text-xs text-muted-foreground">{account.owner_email}</span>
+          <span className="font-mono text-xs text-muted-foreground">{account.org_slug}</span>
+          {account.owner_email ? (
+            <span className="text-xs text-muted-foreground">{account.owner_email}</span>
+          ) : null}
         </Link>
       </TableCell>
       <TableCell>
@@ -523,10 +525,13 @@ function AccountRow({ account }: { account: AdminAccountListItem }) {
         {formatAccountMrr(account)}
       </TableCell>
       <TableCell>
-        <SitesMeterChip used={account.sites.used} cap={account.sites.cap} />
+        <SitesMeterChip used={account.sites_used} cap={account.sites_cap} />
       </TableCell>
       <TableCell>
-        <StorageMeterChip storage={account.storage} />
+        <StorageMeterChip
+          usedBytes={account.storage_used_bytes_approx}
+          capBytes={account.storage_cap_bytes}
+        />
       </TableCell>
       <TableCell className="text-xs text-muted-foreground">
         <time dateTime={account.created_at} title={new Date(account.created_at).toLocaleString()}>
@@ -534,12 +539,12 @@ function AccountRow({ account }: { account: AdminAccountListItem }) {
         </time>
       </TableCell>
       <TableCell className={cn("text-xs", idle ? "text-warning-subtle-fg" : "text-muted-foreground")}>
-        {account.last_activity_at ? (
+        {account.last_activity ? (
           <time
-            dateTime={account.last_activity_at}
-            title={new Date(account.last_activity_at).toLocaleString()}
+            dateTime={account.last_activity}
+            title={new Date(account.last_activity).toLocaleString()}
           >
-            {relativeTime(account.last_activity_at) ?? "–"}
+            {relativeTime(account.last_activity) ?? "–"}
             {idle ? " · idle" : ""}
           </time>
         ) : (

--- a/apps/web/src/routes/_authed/admin/revenue.tsx
+++ b/apps/web/src/routes/_authed/admin/revenue.tsx
@@ -18,6 +18,7 @@ import { relativeTime, cn } from "@/lib/utils";
 import { useAdminRevenue } from "@/features/admin/use-admin-accounts";
 import {
   formatCents,
+  isWebhookStale,
   sortEventsNewestFirst,
   sortPastDueOldestFirst,
 } from "@/features/admin/admin-accounts-format";
@@ -65,9 +66,10 @@ function AdminRevenuePage() {
     );
   }
 
-  const { tiles, plan_distribution, past_due, recent_events, last_webhook_at, webhook_stale } = data;
+  const { tiles, plan_distribution, comped, past_due, recent_events, last_webhook_received_at } = data;
   const pastDueSorted = sortPastDueOldestFirst(past_due);
   const eventsSorted = sortEventsNewestFirst(recent_events).slice(0, 20);
+  const webhookStale = isWebhookStale(last_webhook_received_at);
 
   return (
     <section className="max-w-4xl space-y-6">
@@ -89,7 +91,7 @@ function AdminRevenuePage() {
         <Tile
           label="Active subs"
           value={tiles.active_subs.toLocaleString()}
-          subline={`${tiles.trialing.toLocaleString()} trialing`}
+          subline={`${tiles.trialing_subs.toLocaleString()} trialing`}
         />
         <Tile
           label="Past due"
@@ -117,34 +119,45 @@ function AdminRevenuePage() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {plan_distribution.length === 0 ? (
+              {plan_distribution.length === 0 && comped.count === 0 ? (
                 <TableRow>
                   <TableCell colSpan={3} className="py-6 text-center text-sm text-muted-foreground">
                     No accounts yet.
                   </TableCell>
                 </TableRow>
               ) : (
-                plan_distribution.map((row) => (
-                  <TableRow key={row.plan}>
-                    <TableCell>
-                      <Link
-                        to="/admin/accounts"
-                        search={{ plan: [row.plan as BillingPlanId] }}
-                        className="text-sm font-medium capitalize text-foreground hover:underline"
-                      >
-                        {planLabel(row.plan)}
-                      </Link>
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums text-sm">
-                      {row.count.toLocaleString()}
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums text-sm">
-                      {row.comped_value_cents != null
-                        ? `${formatCents(row.comped_value_cents)} comped value`
-                        : formatCents(row.mrr_share_cents)}
-                    </TableCell>
-                  </TableRow>
-                ))
+                <>
+                  {plan_distribution.map((row) => (
+                    <TableRow key={row.plan}>
+                      <TableCell>
+                        <Link
+                          to="/admin/accounts"
+                          search={{ plan: [row.plan as BillingPlanId] }}
+                          className="text-sm font-medium capitalize text-foreground hover:underline"
+                        >
+                          {planLabel(row.plan)}
+                        </Link>
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums text-sm">
+                        {row.count.toLocaleString()}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums text-sm">
+                        {formatCents(row.mrr_cents)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                  {comped.count > 0 ? (
+                    <TableRow>
+                      <TableCell className="text-sm text-muted-foreground">Comped</TableCell>
+                      <TableCell className="text-right tabular-nums text-sm">
+                        {comped.count.toLocaleString()}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums text-sm text-muted-foreground">
+                        {formatCents(comped.hypothetical_value_cents)} hypothetical
+                      </TableCell>
+                    </TableRow>
+                  ) : null}
+                </>
               )}
             </TableBody>
           </Table>
@@ -186,13 +199,15 @@ function AdminRevenuePage() {
                         <span className="text-sm font-medium text-foreground hover:underline">
                           {row.org_name}
                         </span>
-                        <a
-                          href={`mailto:${row.owner_email}`}
-                          className="text-xs text-muted-foreground hover:underline"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          {row.owner_email}
-                        </a>
+                        {row.owner_email ? (
+                          <a
+                            href={`mailto:${row.owner_email}`}
+                            className="text-xs text-muted-foreground hover:underline"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            {row.owner_email}
+                          </a>
+                        ) : null}
                       </Link>
                     </TableCell>
                     <TableCell className="text-right tabular-nums text-sm">
@@ -205,8 +220,8 @@ function AdminRevenuePage() {
                       {row.grace_until ? new Date(row.grace_until).toLocaleDateString() : "–"}
                     </TableCell>
                     <TableCell className="text-xs text-muted-foreground">
-                      {row.last_failed_at
-                        ? (relativeTime(row.last_failed_at) ?? row.last_failed_at)
+                      {row.last_payment_failed_at
+                        ? (relativeTime(row.last_payment_failed_at) ?? row.last_payment_failed_at)
                         : "–"}
                     </TableCell>
                   </TableRow>
@@ -227,18 +242,18 @@ function AdminRevenuePage() {
             <p className="text-sm text-muted-foreground">No recent billing events.</p>
           ) : (
             <ul className="divide-y divide-border">
-              {eventsSorted.map((ev, i) => (
-                <li key={`${ev.at}-${i}`} className="flex flex-wrap items-baseline gap-x-2 py-2 text-sm">
+              {eventsSorted.map((ev) => (
+                <li key={ev.id} className="flex flex-wrap items-baseline gap-x-2 py-2 text-sm">
                   <time
-                    dateTime={ev.at}
-                    title={new Date(ev.at).toLocaleString()}
+                    dateTime={ev.occurred_at}
+                    title={new Date(ev.occurred_at).toLocaleString()}
                     className="text-xs text-muted-foreground"
                   >
-                    {relativeTime(ev.at) ?? ev.at}
+                    {relativeTime(ev.occurred_at) ?? ev.occurred_at}
                   </time>
-                  <span className="font-medium text-foreground">{ev.org_name}</span>
+                  <span className="font-medium text-foreground">{ev.org_name ?? "—"}</span>
                   <span className="text-muted-foreground">{ev.kind}</span>
-                  <span className="ml-auto text-xs text-muted-foreground">{ev.source}</span>
+                  <span className="ml-auto text-xs text-muted-foreground">{ev.provider}</span>
                 </li>
               ))}
             </ul>
@@ -247,12 +262,12 @@ function AdminRevenuePage() {
           <div
             className={cn(
               "flex items-center gap-2 border-t border-border pt-3 text-xs",
-              webhook_stale ? "text-warning-subtle-fg" : "text-muted-foreground",
+              webhookStale ? "text-warning-subtle-fg" : "text-muted-foreground",
             )}
           >
-            {webhook_stale ? <AlertTriangle aria-hidden="true" className="size-3.5 shrink-0" /> : null}
-            {last_webhook_at
-              ? `Last webhook received ${relativeTime(last_webhook_at) ?? last_webhook_at}`
+            {webhookStale ? <AlertTriangle aria-hidden="true" className="size-3.5 shrink-0" /> : null}
+            {last_webhook_received_at
+              ? `Last webhook received ${relativeTime(last_webhook_received_at) ?? last_webhook_received_at}`
               : "No webhook has ever been received."}
           </div>
         </CardContent>


### PR DESCRIPTION
Fixes the /admin/accounts crash (undefined.toLocaleString) caused by hand-rolled frontend DTOs drifting from the hand-rolled Gin handler's JSON. Reconciles every field across accounts/detail/revenue + guards optional fields + adds a minimal-payload render regression test. Web-only. Durable follow-up (moving admin endpoints into OpenAPI) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU