### PR TITLE
fix(web): admin accounts 'No subscription' vs 'Canceled' for free tenants

### DIFF
--- a/apps/web/src/features/admin/admin-accounts-format.test.ts
+++ b/apps/web/src/features/admin/admin-accounts-format.test.ts
@@ -105,10 +105,13 @@ describe("accountDisplayStatus", () => {
     );
   });
 
-  it("maps canceled/paused/none plan_status to 'canceled' (muted)", () => {
+  it("maps canceled/paused plan_status to 'canceled' (muted)", () => {
     expect(accountDisplayStatus({ plan_status: "canceled", suspended_at: null })).toBe("canceled");
     expect(accountDisplayStatus({ plan_status: "paused", suspended_at: null })).toBe("canceled");
-    expect(accountDisplayStatus({ plan_status: "none", suspended_at: null })).toBe("canceled");
+  });
+
+  it("maps never-subscribed (plan_status='none') to 'none', NOT 'canceled'", () => {
+    expect(accountDisplayStatus({ plan_status: "none", suspended_at: null })).toBe("none");
   });
 
   it("maps comped plan_status to 'comped'", () => {

--- a/apps/web/src/features/admin/admin-accounts-format.test.ts
+++ b/apps/web/src/features/admin/admin-accounts-format.test.ts
@@ -620,7 +620,7 @@ describe("minimal (all-omitempty-absent) payload survival", () => {
     expect(() => accountDisplayStatus(MINIMAL_LIST_ITEM)).not.toThrow();
     expect(() => formatAccountMrr(MINIMAL_LIST_ITEM)).not.toThrow();
     expect(() => isIdle90d(MINIMAL_LIST_ITEM.last_activity)).not.toThrow();
-    expect(accountDisplayStatus(MINIMAL_LIST_ITEM)).toBe("canceled");
+    expect(accountDisplayStatus(MINIMAL_LIST_ITEM)).toBe("none");
   });
 
   const MINIMAL_USAGE: AdminAccountUsage = {

--- a/apps/web/src/features/admin/admin-accounts-format.ts
+++ b/apps/web/src/features/admin/admin-accounts-format.ts
@@ -40,6 +40,7 @@ export function formatAccountMrr(item: {
 // ---------------------------------------------------------------------------
 
 export type AccountDisplayStatus =
+  | "none"
   | "active"
   | "trialing"
   | "past_due"
@@ -48,6 +49,9 @@ export type AccountDisplayStatus =
   | "suspended";
 
 export const ACCOUNT_STATUS_LABEL: Record<AccountDisplayStatus, string> = {
+  // A free tenant that has never had a subscription (plan_status="none", the
+  // default) — NOT the same as "Canceled" (which means a paid plan was ended).
+  none: "No subscription",
   active: "Active",
   trialing: "Trialing",
   past_due: "Past due",
@@ -65,6 +69,7 @@ export const ACCOUNT_STATUS_LABEL: Record<AccountDisplayStatus, string> = {
  * reuse the shared success/warning/destructive subtle tokens.
  */
 export const ACCOUNT_STATUS_BADGE_CLASS: Record<AccountDisplayStatus, string> = {
+  none: "bg-muted text-muted-foreground",
   active: "bg-success-subtle text-success-subtle-fg",
   trialing: "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300",
   past_due: "bg-warning-subtle text-warning-subtle-fg",
@@ -92,9 +97,10 @@ export function accountDisplayStatus(account: {
       return "trialing";
     case "past_due":
       return "past_due";
+    case "none":
+      return "none";
     case "canceled":
     case "paused":
-    case "none":
       return "canceled";
     default:
       return "active";

--- a/apps/web/src/features/admin/admin-accounts-format.ts
+++ b/apps/web/src/features/admin/admin-accounts-format.ts
@@ -312,7 +312,12 @@ export function isWebhookStale(
 // subscription is in any state).
 // ---------------------------------------------------------------------------
 
-export const ACCOUNT_STATUS_FILTER_OPTIONS: readonly AccountDisplayStatus[] = [
+// The status FILTER excludes the display-only "none" (never-subscribed): it is
+// not a filterable subscription state (the handler does not accept it), only a
+// display badge.
+export type FilterableAccountStatus = Exclude<AccountDisplayStatus, "none">;
+
+export const ACCOUNT_STATUS_FILTER_OPTIONS: readonly FilterableAccountStatus[] = [
   "active",
   "trialing",
   "past_due",
@@ -349,7 +354,7 @@ export const ACCOUNT_SORT_OPTIONS: ReadonlyArray<{
 
 export interface AdminAccountsFilters {
   search: string;
-  status: AccountDisplayStatus[];
+  status: FilterableAccountStatus[];
   plan: BillingPlanId[];
   nearLimit: boolean;
   hasOverrides: boolean;

--- a/apps/web/src/routes/_authed/admin/accounts/index.tsx
+++ b/apps/web/src/routes/_authed/admin/accounts/index.tsx
@@ -47,7 +47,7 @@ import {
   formatAccountMrr,
   formatCents,
   isIdle90d,
-  type AccountDisplayStatus,
+  type FilterableAccountStatus,
   type AdminAccountSort,
   type AdminAccountsFilters,
 } from "@/features/admin/admin-accounts-format";
@@ -123,7 +123,7 @@ function AdminAccountsPage() {
     });
   }
 
-  function toggleStatus(value: AccountDisplayStatus) {
+  function toggleStatus(value: FilterableAccountStatus) {
     const next = filters.status.includes(value)
       ? filters.status.filter((s) => s !== value)
       : [...filters.status, value];


### PR DESCRIPTION
Free tenants that never subscribed (plan_status='none') were shown as 'Canceled'. Now show a distinct 'No subscription' status. Web-only, display-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a distinct “No subscription” account status for accounts with no active plan.
  * Updated status badges to use muted styling for this new state.

* **Bug Fixes**
  * Corrected account status display so accounts with no subscription are no longer shown as “Canceled.”
  * Improved status handling to distinguish between canceled, paused, and no-subscription accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->