### PR TITLE
fix(agent): restore silently drops *db.php-named plugin files (GH #147, critical data-loss)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.25] - 2026-07-06
+
+### Fixed
+
+- Restore could silently drop plugin or theme files whose path contained a reserved drop-in name (for example a plugin's own `class-db.php`), leaving the site with a fatal error while the restore reported success. The restore now matches its protected-file exclusions by exact path instead of substring, so only genuine WordPress root drop-ins (`db.php`, `object-cache.php`, `advanced-cache.php`) and config files are held back and every other file is restored. This also stops a nested `.htaccess` from being dropped on restore. Affected agent updated to 0.61.10. Sites already broken by an earlier restore can recover by re-restoring from the same snapshot with the updated agent, or by reinstalling the affected plugin.
+
 ## [0.61.23] - 2026-07-06
 
 ### Fixed

--- a/apps/agent/includes/backup/class-files-restorer.php
+++ b/apps/agent/includes/backup/class-files-restorer.php
@@ -44,29 +44,65 @@ use ZipArchive;
 final class FilesRestorer
 {
     /**
-     * Files we never overwrite during a restore. Substring match (matches
-     * Historical substring-based pattern (so `notwp-config.php` is also a
-     * false positive but never a security hole).
+     * wp-content-ROOT drop-ins / config we never overwrite during a restore.
+     * Matched by EXACT full-path equality against the normalized entry name
+     * (i.e. the entry must sit at the top of the archive, with no directory
+     * prefix) — these filenames only carry drop-in/config semantics when
+     * WordPress finds them at the wp-content root. A same-named file nested
+     * inside a plugin/theme (e.g. `includes/modules/redirections/class-db.php`,
+     * or a bundled `redis-cache/includes/object-cache.php` template) is
+     * ordinary plugin content and MUST be restored — see GH #147, where a
+     * prior unanchored substring match dropped every nested `*db.php` file
+     * silently at extract time.
+     *
+     * `wp-config.php`, `.htaccess`, and `.user.ini` live in ABSPATH, OUTSIDE
+     * wp-content, so a well-formed wp-content archive should never contain
+     * them at all; they're listed here purely as belt-and-suspenders in case
+     * one ever appears at the root of a wp-content zip.
      *
      * @var list<string>
      */
-    private const EXCLUDE_SUBSTRINGS = [
+    private const EXCLUDE_EXACT_PATHS = [
         'wp-config.php',
         'db.php',
         'object-cache.php',
         'advanced-cache.php',
         '.htaccess',
         '.user.ini',
-        'wpmgr-agent/',
-        'wpmgr-snapshots/',
-        // Defensive — the agent's own plugin tree should not be replaced by a
-        // restore of a past wp-content.
+    ];
+
+    /**
+     * WPMgr's own scratch/secret asset names, excluded wherever they appear —
+     * matched by EXACT segment equality against ANY `/`-separated component
+     * of the normalized entry name (unlike EXCLUDE_EXACT_PATHS, depth doesn't
+     * matter here). Safe to match at any depth because these names are
+     * unique to the agent and never legitimately collide with third-party
+     * plugin/theme file or directory names.
+     *
+     * - `wpmgr-agent`      — the agent scratch + keystore root (either at the
+     *                        wp-content root, `wp-content/wpmgr-agent/`, or
+     *                        the plugin directory `plugins/wpmgr-agent/`).
+     * - `wpmgr-agent.php`  — the single-file plugin variant / main plugin
+     *                        file, wherever it lands in the tree.
+     * - `wpmgr-snapshots`  — UpdateCommand pre-update snapshot store; lives
+     *                        under `uploads/wpmgr-snapshots/` by default or
+     *                        the legacy `wp-content/wpmgr-snapshots/` on
+     *                        read-only-uploads hosts — either way it must
+     *                        never be restored from a stale backup.
+     * - `wpmgr-object-cache-config.php` — object-cache credentials file
+     *                        (plaintext Redis password); the live credential
+     *                        must remain intact across a restore.
+     * - `.wpmgr-oc-state.json` — FD-6 object-cache cool-down state; must not
+     *                        be restored so a stale window cannot suppress
+     *                        Redis on a healthy site.
+     *
+     * @var list<string>
+     */
+    private const EXCLUDE_SEGMENTS = [
+        'wpmgr-agent',
         'wpmgr-agent.php',
-        // Object-cache credentials file: never restore from a backup archive;
-        // the live credential must remain intact across a restore.
+        'wpmgr-snapshots',
         'wpmgr-object-cache-config.php',
-        // FD-6: Object-cache cool-down state file; must not be restored from
-        // a backup so a stale window cannot suppress Redis on a healthy site.
         '.wpmgr-oc-state.json',
     ];
 
@@ -95,12 +131,15 @@ final class FilesRestorer
     public const OLDFILES_GC_AGE_SECONDS_LONG = 86400;
 
     /**
-     * Path-prefix denylist applied at zip-extract time. Any entry whose
-     * normalized name starts with one of these prefixes is silently dropped
-     * before it reaches staging. This is the defense-in-depth twin of
-     * `EXCLUDE_SUBSTRINGS` (substring match) — a prefix match is stricter and
-     * catches the wpmgr-agent plugin tree even if a malicious zip tried to
-     * smuggle it past the substring check via path normalization tricks.
+     * Anchored path-prefix denylist applied at zip-extract time. Any entry
+     * whose normalized name starts with one of these prefixes is silently
+     * dropped before it reaches staging. This is a THIRD, belt-and-suspenders
+     * layer on top of `EXCLUDE_SEGMENTS` — the segment check above already
+     * catches these paths at any depth (a `wpmgr-agent` or `wpmgr-snapshots`
+     * segment anywhere in the tree), but an anchored prefix is stricter still
+     * for the specific top-level locations these trees are known to live at,
+     * so it keeps working even if a future change ever narrowed the segment
+     * list.
      *
      * Backslashes in entry names are normalized to `/` before matching so a
      * Windows-packed zip can't bypass the check with `plugins\wpmgr-agent\`.
@@ -110,6 +149,8 @@ final class FilesRestorer
     private const ENTRY_DENYLIST_PREFIXES = [
         'plugins/wpmgr-agent/',
         'plugins/wpmgr-agent.php',
+        'wpmgr-agent/',
+        'wpmgr-snapshots/',
     ];
 
     /**
@@ -121,10 +162,19 @@ final class FilesRestorer
      * are recursive for directories. Entries already present in staging are
      * NOT overwritten — only missing entries are pulled forward from live.
      *
+     * `db.php`, `object-cache.php`, and `advanced-cache.php` are excluded
+     * from staging entirely (see `EXCLUDE_EXACT_PATHS`) because a snapshot
+     * from a different host/config (e.g. a Memcached-era backup restored
+     * onto a Redis host) must not clobber the live drop-in — so staging will
+     * NEVER already contain them, and the entries below unconditionally pull
+     * the live copy forward across the swap (GH #147 fix — previously these
+     * were excluded from staging but NOT preserved-from-live, so a restore
+     * silently deleted the running drop-in with no replacement).
+     *
      * Note on scope: `swap()` operates on wp-content only, so `wp-config.php`,
      * `.htaccess`, and `.user.ini` (which live in ABSPATH, OUTSIDE wp-content)
      * are not in scope here. They're already filtered by the backup-side
-     * excludes + by `EXCLUDE_SUBSTRINGS` above; they were never written to
+     * excludes + by `EXCLUDE_EXACT_PATHS` above; they were never written to
      * staging to begin with, so they continue to live at their original
      * ABSPATH location across a restore.
      *
@@ -141,8 +191,12 @@ final class FilesRestorer
         // .wpmgr-agent-master.key (keystore). v0.9.7 swap_files destroyed
         // this dir; v0.9.9 explicitly preserves it from live → staging so the
         // dump file survives the swap and restore_db finds it. Same pattern
-        // Same pattern leading backup plugins use for their own scratch dirs.
+        // leading backup plugins use for their own scratch dirs.
         'wpmgr-agent',
+        // Host-state drop-ins: keep the LIVE copy across a restore — GH #147.
+        'db.php',
+        'object-cache.php',
+        'advanced-cache.php',
     ];
 
     /**
@@ -228,7 +282,8 @@ final class FilesRestorer
                         continue;
                     }
 
-                    // Drop-in / config exclude list — substring match.
+                    // Drop-in / config / WPMgr-scratch exclude list — anchored
+                    // match (exact path or exact segment; never substring).
                     if (self::isExcluded($entryName)) {
                         continue;
                     }
@@ -682,29 +737,56 @@ final class FilesRestorer
     }
 
     /**
-     * Whether an entry name should be skipped at extract time. Combines two
-     * filters:
+     * Whether an entry name should be skipped at extract time. GH #147:
+     * previously this used an UNANCHORED substring match
+     * (`strpos($entryName, $sub) !== false`), so `db.php` matched inside
+     * `.../class-db.php`, silently dropping unrelated plugin files at
+     * extract time — before extraction, so the loss was never even logged as
+     * a skip-with-reason. Every check below is now anchored (exact-path,
+     * exact-segment, or anchored-prefix — never a bare substring), mirroring
+     * the already-correct discipline in `FilesArchiver::isExcluded()`.
      *
-     *   1. EXCLUDE_SUBSTRINGS — historical substring match. Catches config
-     *      files + drop-ins anywhere in the path.
-     *   2. ENTRY_DENYLIST_PREFIXES — path-prefix match against the wp-content-
-     *      relative name. Stricter than substring match and explicitly guards
-     *      against the wpmgr-agent plugin tree being clobbered by a stale
-     *      backup. Backslashes are normalized to `/` first so a zip packed on
-     *      Windows (entries like `plugins\wpmgr-agent\foo.php`) is still
-     *      matched.
+     * Combines three anchored filters, most-specific first:
+     *
+     *   1. EXCLUDE_EXACT_PATHS — the normalized entry name must equal the
+     *      excluded value EXACTLY (i.e. the entry sits at the top of the
+     *      archive with no directory prefix). Catches wp-content-root
+     *      drop-ins/config without over-matching same-named nested files.
+     *   2. EXCLUDE_SEGMENTS — one `/`-separated segment of the normalized
+     *      entry name must equal the excluded value exactly, at any depth.
+     *      Reserved for WPMgr's own uniquely-named scratch/secret assets,
+     *      which never legitimately collide with third-party file names.
+     *   3. ENTRY_DENYLIST_PREFIXES — anchored-prefix match against the
+     *      normalized name. Belt-and-suspenders on top of (2) for the
+     *      specific top-level locations the wpmgr-agent tree and scratch
+     *      dirs are known to live at.
+     *
+     * Backslashes are normalized to `/` first (and any leading `/` is
+     * stripped) so a zip packed on Windows (entries like
+     * `plugins\wpmgr-agent\foo.php`) is still matched by all three checks.
      */
     private static function isExcluded(string $entryName): bool
     {
-        foreach (self::EXCLUDE_SUBSTRINGS as $sub) {
-            if (strpos($entryName, $sub) !== false) {
+        $normalized = str_replace('\\', '/', $entryName);
+        $normalized = ltrim($normalized, '/');
+        if ($normalized === '') {
+            return false;
+        }
+
+        // 1) Exact top-level path match.
+        if (in_array($normalized, self::EXCLUDE_EXACT_PATHS, true)) {
+            return true;
+        }
+
+        // 2) Exact segment match at any depth.
+        $segments = explode('/', $normalized);
+        foreach ($segments as $segment) {
+            if ($segment !== '' && in_array($segment, self::EXCLUDE_SEGMENTS, true)) {
                 return true;
             }
         }
-        // Prefix denylist — normalize Windows-style separators first so a
-        // zip packed on Windows can't slip past with `plugins\wpmgr-agent\`.
-        $normalized = str_replace('\\', '/', $entryName);
-        $normalized = ltrim($normalized, '/');
+
+        // 3) Anchored-prefix denylist.
         foreach (self::ENTRY_DENYLIST_PREFIXES as $prefix) {
             if (strncmp($normalized, $prefix, strlen($prefix)) === 0) {
                 return true;

--- a/apps/agent/tests/Backup/FilesRestorerExcludeAnchoringTest.php
+++ b/apps/agent/tests/Backup/FilesRestorerExcludeAnchoringTest.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * GH #147 regression: FilesRestorer::isExcluded() must use ANCHORED matching
+ * (exact path / exact segment / anchored prefix), never an unanchored
+ * substring match. The prior substring-based implementation matched
+ * `strpos($entryName, 'db.php') !== false`, so a nested file like
+ * `includes/modules/redirections/class-db.php` was silently dropped at
+ * extract time — before a single byte reached staging, so the file was gone
+ * after the swap with no error, no log line, and no way to notice until the
+ * plugin broke in production.
+ *
+ * This test exercises `isExcluded()` directly via reflection — the same
+ * pattern `ObjectCacheConfigRestoreExclusionTest` uses — because the bug and
+ * the fix both live entirely inside that one method: `stage()` calls
+ * `isExcluded()` BEFORE extraction (class-files-restorer.php), so whatever
+ * `isExcluded()` returns is exactly what would/would not land in staging and
+ * therefore exactly what would/would not survive the atomic swap.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use ReflectionClass;
+use ReflectionMethod;
+use WPMgr\Agent\Backup\FilesRestorer;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\FilesRestorer
+ */
+final class FilesRestorerExcludeAnchoringTest extends TestCase
+{
+    private static ReflectionMethod $isExcluded;
+
+    public static function set_up_before_class(): void
+    {
+        parent::set_up_before_class();
+        $rc               = new ReflectionClass(FilesRestorer::class);
+        self::$isExcluded = $rc->getMethod('isExcluded');
+        // setAccessible() is a no-op since PHP 8.1 and deprecated in 8.5.
+    }
+
+    private static function isExcluded(string $entryName): bool
+    {
+        return (bool) self::$isExcluded->invoke(null, $entryName);
+    }
+
+    /**
+     * Real-world nested `*db.php` plugin files (the exact GH #147 report:
+     * Rank Math SEO ships five files matching `class-db.php` under different
+     * module directories). None of these are the wp-content-root `db.php`
+     * drop-in — every one of them MUST be extracted/restored.
+     *
+     * @return array<string,array{0:string}>
+     */
+    public static function nestedDbPhpProvider(): array
+    {
+        return [
+            'rank-math helpers'             => ['plugins/seo-by-rank-math/includes/helpers/class-db.php'],
+            'rank-math 404-monitor module'  => ['plugins/seo-by-rank-math/includes/modules/404-monitor/class-db.php'],
+            'rank-math analytics module'    => ['plugins/seo-by-rank-math/includes/modules/analytics/class-db.php'],
+            'rank-math redirections module' => ['plugins/seo-by-rank-math/includes/modules/redirections/class-db.php'],
+            'rank-math schema module'       => ['plugins/seo-by-rank-math/includes/modules/schema/class-db.php'],
+            'instawp sync db class'         => ['plugins/instawp-connect/includes/sync/class-instawp-sync-db.php'],
+        ];
+    }
+
+    /**
+     * @dataProvider nestedDbPhpProvider
+     */
+    public function test_nested_db_php_variants_are_not_excluded(string $entryName): void
+    {
+        $this->assertFalse(
+            self::isExcluded($entryName),
+            "FilesRestorer::isExcluded must NOT exclude nested plugin file: {$entryName}"
+        );
+    }
+
+    /**
+     * A bundled `object-cache.php` TEMPLATE shipped inside a plugin's own
+     * directory (e.g. redis-cache ships one under includes/) is plugin
+     * content, not the live wp-content-root drop-in — it must be restored.
+     */
+    public function test_bundled_object_cache_template_is_not_excluded(): void
+    {
+        $this->assertFalse(
+            self::isExcluded('plugins/redis-cache/includes/object-cache.php'),
+            'FilesRestorer::isExcluded must not exclude a plugin-bundled object-cache.php template'
+        );
+    }
+
+    /**
+     * A nested `.htaccess` (e.g. the one WordPress core writes under
+     * uploads/ to block PHP execution) is content, not the ABSPATH-root
+     * config file — it must be restored.
+     */
+    public function test_nested_htaccess_is_not_excluded(): void
+    {
+        $this->assertFalse(
+            self::isExcluded('uploads/2026/.htaccess'),
+            'FilesRestorer::isExcluded must not exclude a nested uploads/.htaccess'
+        );
+    }
+
+    /**
+     * The wp-content-ROOT drop-ins/config MUST still be excluded — only when
+     * they appear with no path prefix (i.e. actually at the root of the
+     * archive).
+     *
+     * @return array<string,array{0:string}>
+     */
+    public static function rootDropInProvider(): array
+    {
+        return [
+            'db.php'              => ['db.php'],
+            'object-cache.php'    => ['object-cache.php'],
+            'advanced-cache.php'  => ['advanced-cache.php'],
+            'wp-config.php'       => ['wp-config.php'],
+            '.htaccess'           => ['.htaccess'],
+            '.user.ini'           => ['.user.ini'],
+        ];
+    }
+
+    /**
+     * @dataProvider rootDropInProvider
+     */
+    public function test_root_drop_ins_are_still_excluded(string $entryName): void
+    {
+        $this->assertTrue(
+            self::isExcluded($entryName),
+            "FilesRestorer::isExcluded must still exclude the wp-content-root drop-in/config: {$entryName}"
+        );
+    }
+
+    /**
+     * WPMgr secret/state files must still be excluded, at any depth —
+     * unchanged behavior, guarded here so a future refactor can't regress it
+     * alongside the anchoring fix.
+     */
+    public function test_wpmgr_secret_files_still_excluded_at_any_depth(): void
+    {
+        $this->assertTrue(
+            self::isExcluded('wpmgr-object-cache-config.php'),
+            'wpmgr-object-cache-config.php must be excluded at the wp-content root'
+        );
+        $this->assertTrue(
+            self::isExcluded('some/subdir/wpmgr-object-cache-config.php'),
+            'wpmgr-object-cache-config.php must be excluded when nested'
+        );
+        $this->assertTrue(
+            self::isExcluded('.wpmgr-oc-state.json'),
+            '.wpmgr-oc-state.json must be excluded'
+        );
+        $this->assertTrue(
+            self::isExcluded('wpmgr-agent/restores/abc123/database.sql.gz'),
+            'the wp-content-root wpmgr-agent scratch dir must still be excluded'
+        );
+        $this->assertTrue(
+            self::isExcluded('plugins/wpmgr-agent/wpmgr-agent.php'),
+            'the wpmgr-agent plugin tree must still be excluded'
+        );
+        $this->assertTrue(
+            self::isExcluded('uploads/wpmgr-snapshots/db/dump.sql'),
+            'wpmgr-snapshots must still be excluded even when nested under uploads/'
+        );
+    }
+
+    /**
+     * Ordinary plugin files must never be excluded (no regression on the
+     * happy path).
+     */
+    public function test_normal_plugin_file_is_not_excluded(): void
+    {
+        $this->assertFalse(
+            self::isExcluded('plugins/my-plugin/main.php'),
+            'FilesRestorer::isExcluded must not exclude normal plugin files'
+        );
+    }
+
+    /**
+     * Near-miss segments must NOT be excluded: the WPMgr segment/prefix guards
+     * match on an exact path COMPONENT, never a substring — so a third-party
+     * plugin whose name merely starts with or contains "wpmgr-agent" is restored.
+     * Locks in the anchoring so a future refactor to substring matching regresses
+     * loudly (GH #147 hardening).
+     */
+    public function test_near_miss_wpmgr_segments_are_not_excluded(): void
+    {
+        $this->assertFalse(
+            self::isExcluded('plugins/my-wpmgr-agent-helper/x.php'),
+            'a plugin dir CONTAINING wpmgr-agent as a substring must be restored'
+        );
+        $this->assertFalse(
+            self::isExcluded('plugins/wpmgr-agentx/x.php'),
+            'a plugin dir starting with wpmgr-agent but a different segment must be restored'
+        );
+        $this->assertFalse(
+            self::isExcluded('plugins/foo/wpmgr-snapshots-README.md'),
+            'a file whose name merely contains wpmgr-snapshots must be restored'
+        );
+    }
+
+    /**
+     * Path normalization must not let a drop-in slip through (or a good file be
+     * dropped): backslashes, leading slash, and a trailing-slash directory entry
+     * are normalized before anchored matching.
+     */
+    public function test_path_normalization_before_anchored_match(): void
+    {
+        // Backslash-separated + leading slash still resolves the root drop-in.
+        $this->assertTrue(
+            self::isExcluded('\\db.php'),
+            'a backslash/leading-slash root db.php drop-in must still be excluded'
+        );
+        $this->assertTrue(
+            self::isExcluded('/object-cache.php'),
+            'a leading-slash root object-cache.php drop-in must still be excluded'
+        );
+        // Backslash-separated nested plugin file must still be restored.
+        $this->assertFalse(
+            self::isExcluded('plugins\\seo-by-rank-math\\includes\\modules\\redirections\\class-db.php'),
+            'a backslash-separated nested class-db.php must be restored'
+        );
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.9
+ * Version:           0.61.10
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.9');
+define('WPMGR_AGENT_VERSION', '0.61.10');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 


### PR DESCRIPTION
CRITICAL: restore matched its drop-in exclude list by unanchored substring, so 'db.php' matched '.../class-db.php' and the file was skipped at extraction, silently corrupting plugins (Rank Math, InstaWP, bundled object-cache templates) into fatal sites while reporting success. Fix anchors the matcher to exact-path + exact-segment + anchored-prefix, preserves genuine root drop-ins from live across the swap, and closes a latent uploads/.htaccess security regression. Agent-only (CP verifiably clean). Regression test proven fail-without/pass-with; adversarial review SHIP; wp plugin check 0 errors. agent 0.61.10.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restore behavior so only the intended root drop-in and config files are skipped, preventing nested plugin files and nested `.htaccess` files from being dropped during restore.
  * Preserved key site drop-ins across restores, helping avoid broken sites after an earlier restore.

* **Tests**
  * Added regression coverage to confirm restore exclusions are exact and path-safe, including path normalization and nested-file edge cases.

* **Chores**
  * Updated the agent version to `0.61.10` and documented the restore fix and recovery guidance in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->