### PR TITLE
fix(uptime): alert emails via dashboard SMTP + honest audit outcome (GH #144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.26] - 2026-07-06
+
+### Fixed
+
+- Uptime downtime and recovery alert emails were silently skipped when SMTP was configured in the dashboard (Settings, Email/SMTP) but not also set as environment variables. The alert mailer only read the environment relay and ignored the saved dashboard relay that the "Send test email" button and backup notifications already use, so alerts were dropped even though a test email delivered. Uptime alerts now send through the same saved SMTP relay, resolved per send, with environment variables kept only as a fallback. This path is now SSRF-hardened like the rest of the mail system.
+- The audit log recorded "Emailed: Yes" for a downtime alert whenever recipients were configured, even when the send was skipped or failed, so operators could not tell that notifications were not being delivered. The audit entry now records the true outcome (Sent, Skipped, or Failed) with the reason, for both email and webhook delivery. Alert reasons never include SMTP hosts, credentials, or endpoint responses.
+
 ## [0.61.25] - 2026-07-06
 
 ### Fixed

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -909,14 +909,15 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	uptimeRepo := uptime.NewRepo(pool)
 	uptimeSiteAdapter := newUptimeSiteAdapter(siteSvc)
 	uptimeProber := uptime.NewProber(ssrfClient, cfg.Uptime.ProbeTimeout)
-	var uptimeMailer uptime.Mailer
-	if cfg.SMTP.Enabled() {
-		uptimeMailer = uptime.NewSMTPMailer(cfg.SMTP, logger)
-		logger.Info("uptime alert email enabled", slog.String("smtp_host", cfg.SMTP.Host))
-	} else {
-		uptimeMailer = uptime.NewNoopMailer(logger)
-		logger.Warn("WPMGR_SMTP_HOST is empty: uptime alert emails disabled (webhooks still fire)")
-	}
+	// GH #144: uptime/security alert emails resolve their SMTP transport
+	// per-send from mailerSvc (built above) — the same DB-row-first/env-
+	// fallback resolution every other transactional email uses — instead of a
+	// boot-time snapshot of WPMGR_SMTP_* env. The old wiring picked
+	// uptime.NewSMTPMailer/NewNoopMailer ONCE at boot from that env var, so
+	// dashboard-configured SMTP (the norm) never reached alert emails and they
+	// silently no-op'd forever via NoopMailer.
+	uptimeMailer := uptimeMailerAdapter{svc: mailerSvc}
+	logger.Info("uptime/security alert email resolves SMTP per-send from the DB-configured transport (env fallback)")
 	webhookPoster := uptime.NewSSRFWebhookPoster(ssrfClient)
 	uptimeDispatcher := uptime.NewDispatcher(uptimeMailer, webhookPoster, auditRec, logger)
 	uptimeWorker := uptime.NewProbeWorker(uptimeRepo, uptimeProber, metricsStore, uptimeDispatcher, uptimeSiteAdapter, logger, cfg.Uptime.ProbeConcurrency, cfg.Uptime.DownThreshold)

--- a/apps/api/cmd/wpmgr/uptime_mailer.go
+++ b/apps/api/cmd/wpmgr/uptime_mailer.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/mailer"
+	"github.com/mosamlife/wpmgr/apps/api/internal/uptime"
+)
+
+// uptimeMailerAdapter satisfies uptime.Mailer by delegating to the shared
+// ADR-045 transactional mailer (internal/mailer.Service), which resolves the
+// SMTP transport from the smtp_settings DB row (age-decrypting the stored
+// password, falling back to WPMGR_SMTP_* env) on EVERY send.
+//
+// GH #144: the previous wiring picked uptime.SMTPMailer or uptime.NoopMailer
+// ONCE at boot from WPMGR_SMTP_* env. Since SMTP is configured in the
+// dashboard (which writes the smtp_settings DB row, not env vars), that env
+// check almost always failed and froze the uptime alert mailer to NoopMailer
+// forever — every downtime/recovery/security alert email silently no-op'd,
+// while the audit log recorded "emailed: true" because it only checked
+// whether recipients were configured, not whether the send happened.
+type uptimeMailerAdapter struct {
+	svc *mailer.Service
+}
+
+// Send delegates to Service.SendMessage and maps its outcome onto
+// uptime.SendResult, the outcome type the alert audit trail persists.
+func (a uptimeMailerAdapter) Send(ctx context.Context, recipients []string, subject, body string) (uptime.SendResult, error) {
+	outcome, err := a.svc.SendMessage(ctx, recipients, subject, body)
+	return uptime.SendResult{Status: string(outcome.Status), Reason: outcome.Reason}, err
+}

--- a/apps/api/internal/mailer/mailer.go
+++ b/apps/api/internal/mailer/mailer.go
@@ -146,6 +146,63 @@ func (s *Service) Deliver(ctx context.Context, emailLogID uuid.UUID, recipients 
 	return nil
 }
 
+// SendStatus is the REAL outcome of a SendMessage call — as opposed to merely
+// "recipients were configured" (GH #144: the uptime alert dispatcher used to
+// record "emailed: true" in the audit log whenever recipients existed, even
+// though the send was never attempted — SMTP had been frozen to a boot-time
+// no-op mailer — or had failed).
+type SendStatus string
+
+const (
+	SendSent    SendStatus = "sent"
+	SendSkipped SendStatus = "skipped"
+	SendFailed  SendStatus = "failed"
+)
+
+// SendOutcome is the result of a SendMessage call: the real delivery status
+// plus a coarse, ALREADY-SCRUBBED reason set whenever Status != SendSent.
+type SendOutcome struct {
+	Status SendStatus
+	Reason string
+}
+
+// SendMessage sends a plain-text, unrendered message (no template) over the
+// resolved instance SMTP transport — the SAME per-send DB-first/env-fallback
+// resolution as Deliver/SendTest. It exists for callers that build their own
+// subject/body outside the template system (uptime/security alerts, GH #144)
+// and need the REAL delivery outcome instead of a fire-and-forget best-effort
+// send, so they can record an honest audit trail rather than "emailed:
+// configured". Logging to email_log is best-effort: a log-write failure never
+// blocks or fails the send.
+func (s *Service) SendMessage(ctx context.Context, recipients []string, subject, text string) (SendOutcome, error) {
+	if len(recipients) == 0 {
+		return SendOutcome{Status: SendSkipped, Reason: "no_recipients"}, nil
+	}
+	transport, ok, err := s.resolver.Resolve(ctx)
+	if err != nil {
+		s.logger.Error("mailer resolve failed", slog.String("err", err.Error()))
+		return SendOutcome{Status: SendFailed, Reason: "resolve_smtp"}, fmt.Errorf("resolve smtp transport: %w", err)
+	}
+	if !ok || !transport.Configured() {
+		s.logger.Warn("message skipped: smtp not configured", slog.String("subject", subject))
+		return SendOutcome{Status: SendSkipped, Reason: "smtp_not_configured"}, nil
+	}
+
+	logID := s.insertLog(ctx, uuid.Nil, recipients, subject, "uptime_alert")
+	if err := sendMail(ctx, transport, recipients, Email{Subject: subject, Text: text}); err != nil {
+		reason := scrubSMTPError(err)
+		if logID != uuid.Nil {
+			s.markFailed(ctx, logID, reason)
+		}
+		s.logger.Warn("message send failed", slog.String("subject", subject), slog.String("err", err.Error()))
+		return SendOutcome{Status: SendFailed, Reason: reason}, fmt.Errorf("send message: %w", err)
+	}
+	if logID != uuid.Nil {
+		s.markSent(ctx, logID)
+	}
+	return SendOutcome{Status: SendSent}, nil
+}
+
 // SendTest renders + sends the "test" template synchronously over an explicit
 // transport (the just-submitted or stored SMTP config). It returns a SCRUBBED
 // error suitable for showing the operator (no internal IPs/hostnames/timing),
@@ -243,9 +300,14 @@ func sendMail(ctx context.Context, t Transport, recipients []string, em Email) e
 	}
 	msg.Subject(em.Subject)
 	// Plaintext primary + HTML alternative -> multipart/alternative with the
-	// richer HTML part last, which is what clients prefer.
+	// richer HTML part last, which is what clients prefer. When there is no
+	// HTML part (e.g. SendMessage's unrendered alerts) skip the alternative
+	// entirely — an EMPTY HTML part would still be the "preferred" part of a
+	// multipart/alternative and could render blank in HTML-capable clients.
 	msg.SetBodyString(mail.TypeTextPlain, em.Text)
-	msg.AddAlternativeString(mail.TypeTextHTML, em.HTML)
+	if em.HTML != "" {
+		msg.AddAlternativeString(mail.TypeTextHTML, em.HTML)
+	}
 
 	port := t.Port
 	if port == 0 {

--- a/apps/api/internal/mailer/send_message_test.go
+++ b/apps/api/internal/mailer/send_message_test.go
@@ -1,0 +1,64 @@
+package mailer
+
+import (
+	"context"
+	"testing"
+)
+
+// stubResolver is a configurable Resolver for SendMessage tests. It never
+// touches Postgres, so these tests exercise the per-send transport resolution
+// (GH #144) without a live DB.
+type stubResolver struct {
+	transport Transport
+	ok        bool
+	err       error
+	called    bool
+}
+
+func (r *stubResolver) Resolve(context.Context) (Transport, bool, error) {
+	r.called = true
+	return r.transport, r.ok, r.err
+}
+
+// TestSendMessageSkipsWhenSMTPNotConfigured asserts SendMessage resolves the
+// transport ON EVERY CALL (not a boot-time snapshot) and reports "skipped"
+// rather than silently dropping the message when no DB row or env fallback is
+// configured — the GH #144 defect was that uptime alerts used a boot-time
+// snapshot instead of resolving per-send at all.
+func TestSendMessageSkipsWhenSMTPNotConfigured(t *testing.T) {
+	resolver := &stubResolver{ok: false}
+	svc := NewService(resolver, nil, nil, "https://manage.wpmgr.app", "support@wpmgr.app", nil)
+
+	outcome, err := svc.SendMessage(context.Background(), []string{"ops@example.com"}, "subject", "body")
+	if err != nil {
+		t.Fatalf("expected nil error on skip, got %v", err)
+	}
+	if !resolver.called {
+		t.Fatal("expected Resolve to be called (per-send resolution), but it was not")
+	}
+	if outcome.Status != SendSkipped {
+		t.Fatalf("expected status %q, got %q", SendSkipped, outcome.Status)
+	}
+	if outcome.Reason != "smtp_not_configured" {
+		t.Fatalf("expected reason %q, got %q", "smtp_not_configured", outcome.Reason)
+	}
+}
+
+// TestSendMessageSkipsWhenNoRecipients asserts SendMessage never dials SMTP
+// (and never calls Resolve) for an empty recipient list, and reports the
+// skip rather than a silent no-op.
+func TestSendMessageSkipsWhenNoRecipients(t *testing.T) {
+	resolver := &stubResolver{ok: true, transport: Transport{Host: "smtp.example.com", From: "alerts@example.com"}}
+	svc := NewService(resolver, nil, nil, "https://manage.wpmgr.app", "support@wpmgr.app", nil)
+
+	outcome, err := svc.SendMessage(context.Background(), nil, "subject", "body")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if resolver.called {
+		t.Fatal("expected Resolve NOT to be called for an empty recipient list")
+	}
+	if outcome.Status != SendSkipped || outcome.Reason != "no_recipients" {
+		t.Fatalf("expected {skipped,no_recipients}, got %+v", outcome)
+	}
+}

--- a/apps/api/internal/uptime/alerts.go
+++ b/apps/api/internal/uptime/alerts.go
@@ -72,18 +72,28 @@ func Evaluate(prev AlertState, up bool, threshold int, now time.Time) Transition
 	return t
 }
 
+// auditSink is the narrow slice of *audit.Recorder the Dispatcher needs. An
+// interface so Fire/FireSecurityEvent are unit-testable with a stub sink
+// instead of a live Postgres pool.
+type auditSink interface {
+	Record(ctx context.Context, e audit.Event) (audit.Entry, error)
+}
+
 // Dispatcher delivers fired alerts to a tenant's configured channels (email +
-// webhook) and records an audit event. Both channels are best-effort and
-// independent: one failing is logged but does not block the other.
+// webhook) and records an audit event carrying the REAL delivery outcome of
+// each channel (GH #144 — the audit trail used to record "emailed"/"webhooked"
+// as "a recipient/URL was configured", not "the send actually succeeded").
+// Both channels are best-effort and independent: one failing is logged but
+// does not block the other.
 type Dispatcher struct {
 	mailer  Mailer
 	webhook WebhookPoster
-	audit   *audit.Recorder
+	audit   auditSink
 	logger  *slog.Logger
 }
 
 // NewDispatcher builds an alert Dispatcher.
-func NewDispatcher(mailer Mailer, webhook WebhookPoster, rec *audit.Recorder, logger *slog.Logger) *Dispatcher {
+func NewDispatcher(mailer Mailer, webhook WebhookPoster, rec auditSink, logger *slog.Logger) *Dispatcher {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -91,37 +101,77 @@ func NewDispatcher(mailer Mailer, webhook WebhookPoster, rec *audit.Recorder, lo
 }
 
 // Fire delivers one alert to the tenant's channels and records it in the audit
-// log. Returns nil even when a channel errors (delivery is best-effort and the
-// transition has already been recorded by the caller); errors are logged.
+// log WITH the real delivery outcome of each channel (GH #144). Returns nil
+// even when a channel errors (delivery is best-effort and the transition has
+// already been recorded by the caller); errors are logged.
 func (d *Dispatcher) Fire(ctx context.Context, cfg AlertConfig, alert Alert) {
 	subject, body := renderEmail(alert)
-	if d.mailer != nil && len(cfg.EmailRecipients) > 0 {
-		if err := d.mailer.Send(ctx, cfg.EmailRecipients, subject, body); err != nil {
-			d.logger.Warn("uptime alert email failed",
-				slog.String("site_id", alert.SiteID.String()),
-				slog.String("kind", string(alert.Kind)),
-				slog.Any("error", err))
-		}
+	emailResult, emailErr := d.sendEmail(ctx, cfg.EmailRecipients, subject, body)
+	if emailErr != nil {
+		d.logger.Warn("uptime alert email failed",
+			slog.String("site_id", alert.SiteID.String()),
+			slog.String("kind", string(alert.Kind)),
+			slog.Any("error", emailErr))
 	}
-	if d.webhook != nil && cfg.WebhookURL != "" {
-		payload := WebhookPayload{
-			Event:      "uptime." + string(alert.Kind),
-			TenantID:   alert.TenantID.String(),
-			SiteID:     alert.SiteID.String(),
-			SiteURL:    alert.SiteURL,
-			SiteName:   alert.SiteName,
-			HTTPStatus: alert.HTTPStatus,
-			Error:      alert.Error,
-			FiredAt:    alert.FiredAt,
-		}
-		if err := d.webhook.Post(ctx, cfg.WebhookURL, cfg.WebhookSecret, payload); err != nil {
-			d.logger.Warn("uptime alert webhook failed",
-				slog.String("site_id", alert.SiteID.String()),
-				slog.String("kind", string(alert.Kind)),
-				slog.Any("error", err))
-		}
+
+	payload := WebhookPayload{
+		Event:      "uptime." + string(alert.Kind),
+		TenantID:   alert.TenantID.String(),
+		SiteID:     alert.SiteID.String(),
+		SiteURL:    alert.SiteURL,
+		SiteName:   alert.SiteName,
+		HTTPStatus: alert.HTTPStatus,
+		Error:      alert.Error,
+		FiredAt:    alert.FiredAt,
 	}
-	d.recordAudit(ctx, alert, len(cfg.EmailRecipients) > 0, cfg.WebhookURL != "")
+	webhookResult, webhookErr := d.sendWebhook(ctx, cfg.WebhookURL, cfg.WebhookSecret, payload)
+	if webhookErr != nil {
+		d.logger.Warn("uptime alert webhook failed",
+			slog.String("site_id", alert.SiteID.String()),
+			slog.String("kind", string(alert.Kind)),
+			slog.Any("error", webhookErr))
+	}
+
+	d.recordAudit(ctx, alert, emailResult, webhookResult)
+}
+
+// sendEmail sends the alert email over the dispatcher's mailer (when one is
+// wired and recipients are configured) and returns the REAL delivery outcome
+// — never "sent" merely because recipients exist (GH #144). The returned error
+// is the raw, unscrubbed error for server-side logging only; SendResult.Reason
+// is always safe to persist (the Mailer implementation is responsible for
+// scrubbing it, e.g. internal/mailer.Service via scrubSMTPError).
+func (d *Dispatcher) sendEmail(ctx context.Context, recipients []string, subject, body string) (SendResult, error) {
+	if d.mailer == nil || len(recipients) == 0 {
+		return SendResult{Status: SendResultSkipped, Reason: "no_recipients_configured"}, nil
+	}
+	res, err := d.mailer.Send(ctx, recipients, subject, body)
+	if err != nil {
+		if res.Status == "" {
+			res.Status = SendResultFailed
+		}
+		if res.Reason == "" {
+			res.Reason = "send_failed"
+		}
+		return res, err
+	}
+	if res.Status == "" {
+		res.Status = SendResultSent
+	}
+	return res, nil
+}
+
+// sendWebhook POSTs the alert webhook (when configured) and returns the REAL
+// delivery outcome, with a coarse/scrubbed reason on failure that NEVER
+// includes the endpoint's response body.
+func (d *Dispatcher) sendWebhook(ctx context.Context, url, secret string, payload WebhookPayload) (SendResult, error) {
+	if d.webhook == nil || url == "" {
+		return SendResult{Status: SendResultSkipped, Reason: "webhook_not_configured"}, nil
+	}
+	if err := d.webhook.Post(ctx, url, secret, payload); err != nil {
+		return SendResult{Status: SendResultFailed, Reason: classifyWebhookError(err)}, err
+	}
+	return SendResult{Status: SendResultSent}, nil
 }
 
 // FireSecurityEvent delivers a high-severity ADR-037 activity-log event to the
@@ -141,69 +191,84 @@ func (d *Dispatcher) FireSecurityEvent(ctx context.Context, cfg AlertConfig, ev 
 	body := fmt.Sprintf("Security event on %s: %s\n\nEvent: %s\nSeverity: %s\nDetected at: %s",
 		name, ev.Summary, ev.EventType, ev.Severity, ev.FiredAt.UTC().Format(time.RFC3339))
 
-	if d.mailer != nil && len(cfg.EmailRecipients) > 0 {
-		if err := d.mailer.Send(ctx, cfg.EmailRecipients, subject, body); err != nil {
-			d.logger.Warn("security alert email failed",
-				slog.String("site_id", ev.SiteID.String()),
-				slog.String("event_type", ev.EventType),
-				slog.Any("error", err))
-		}
+	emailResult, emailErr := d.sendEmail(ctx, cfg.EmailRecipients, subject, body)
+	if emailErr != nil {
+		d.logger.Warn("security alert email failed",
+			slog.String("site_id", ev.SiteID.String()),
+			slog.String("event_type", ev.EventType),
+			slog.Any("error", emailErr))
 	}
-	if d.webhook != nil && cfg.WebhookURL != "" {
-		payload := WebhookPayload{
-			Event:    "security." + ev.EventType,
-			TenantID: ev.TenantID.String(),
-			SiteID:   ev.SiteID.String(),
-			SiteURL:  ev.SiteURL,
-			SiteName: ev.SiteName,
-			Error:    ev.Summary,
-			FiredAt:  ev.FiredAt,
-		}
-		if err := d.webhook.Post(ctx, cfg.WebhookURL, cfg.WebhookSecret, payload); err != nil {
-			d.logger.Warn("security alert webhook failed",
-				slog.String("site_id", ev.SiteID.String()),
-				slog.String("event_type", ev.EventType),
-				slog.Any("error", err))
-		}
+
+	payload := WebhookPayload{
+		Event:    "security." + ev.EventType,
+		TenantID: ev.TenantID.String(),
+		SiteID:   ev.SiteID.String(),
+		SiteURL:  ev.SiteURL,
+		SiteName: ev.SiteName,
+		Error:    ev.Summary,
+		FiredAt:  ev.FiredAt,
 	}
+	webhookResult, webhookErr := d.sendWebhook(ctx, cfg.WebhookURL, cfg.WebhookSecret, payload)
+	if webhookErr != nil {
+		d.logger.Warn("security alert webhook failed",
+			slog.String("site_id", ev.SiteID.String()),
+			slog.String("event_type", ev.EventType),
+			slog.Any("error", webhookErr))
+	}
+
 	if d.audit != nil {
+		meta := channelMetadata(emailResult, webhookResult)
+		meta["kind"] = string(AlertSecurity)
+		meta["event_type"] = ev.EventType
+		meta["severity"] = ev.Severity
+		meta["summary"] = ev.Summary
+		meta["site_url"] = ev.SiteURL
 		_, _ = d.audit.Record(ctx, audit.Event{
 			TenantID:   ev.TenantID,
 			ActorType:  audit.ActorSystem,
 			Action:     ActionAlertSent,
 			TargetType: "site",
 			TargetID:   ev.SiteID.String(),
-			Metadata: map[string]any{
-				"kind":       string(AlertSecurity),
-				"event_type": ev.EventType,
-				"severity":   ev.Severity,
-				"summary":    ev.Summary,
-				"site_url":   ev.SiteURL,
-				"emailed":    len(cfg.EmailRecipients) > 0,
-				"webhooked":  cfg.WebhookURL != "",
-			},
+			Metadata:   meta,
 		})
 	}
 }
 
-func (d *Dispatcher) recordAudit(ctx context.Context, alert Alert, emailed, webhooked bool) {
+// channelMetadata builds the shared email/webhook outcome fields persisted on
+// every alert audit row: "email_status"/"webhook_status" always, plus
+// "email_reason"/"webhook_reason" ONLY when the corresponding channel did not
+// succeed (both are coarse, already-scrubbed codes — never raw SMTP/webhook
+// error detail, credentials, or response bodies).
+func channelMetadata(email, webhook SendResult) map[string]any {
+	meta := map[string]any{
+		"email_status":   email.Status,
+		"webhook_status": webhook.Status,
+	}
+	if email.Status != SendResultSent && email.Reason != "" {
+		meta["email_reason"] = email.Reason
+	}
+	if webhook.Status != SendResultSent && webhook.Reason != "" {
+		meta["webhook_reason"] = webhook.Reason
+	}
+	return meta
+}
+
+func (d *Dispatcher) recordAudit(ctx context.Context, alert Alert, email, webhook SendResult) {
 	if d.audit == nil {
 		return
 	}
+	meta := channelMetadata(email, webhook)
+	meta["kind"] = string(alert.Kind)
+	meta["site_url"] = alert.SiteURL
+	meta["http_status"] = alert.HTTPStatus
+	meta["error"] = alert.Error
 	_, _ = d.audit.Record(ctx, audit.Event{
 		TenantID:   alert.TenantID,
 		ActorType:  audit.ActorSystem,
 		Action:     ActionAlertSent,
 		TargetType: "site",
 		TargetID:   alert.SiteID.String(),
-		Metadata: map[string]any{
-			"kind":        string(alert.Kind),
-			"site_url":    alert.SiteURL,
-			"http_status": alert.HTTPStatus,
-			"error":       alert.Error,
-			"emailed":     emailed,
-			"webhooked":   webhooked,
-		},
+		Metadata:   meta,
 	})
 }
 

--- a/apps/api/internal/uptime/alerts_test.go
+++ b/apps/api/internal/uptime/alerts_test.go
@@ -1,8 +1,14 @@
 package uptime
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
 )
 
 // TestEvaluateTransitionDedupe exercises the alert state machine: N consecutive
@@ -66,5 +72,148 @@ func TestEvaluateThresholdOne(t *testing.T) {
 	tr := Evaluate(AlertState{LastStatus: StatusUnknown}, false, 1, time.Now())
 	if !tr.FireDown {
 		t.Fatalf("threshold=1: expected immediate down alert, got %+v", tr)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GH #144 — Fire must record the REAL email/webhook delivery outcome, not
+// merely "recipients/URL were configured". Every test below FAILS against the
+// pre-fix recordAudit (which set a bare "emailed"/"webhooked" bool from
+// len(cfg.EmailRecipients)>0 / cfg.WebhookURL!="" and never looked at the
+// mailer's actual return value): meta["email_status"] would be nil (absent),
+// never equal to "skipped"/"failed"/"sent", and the legacy "emailed" key
+// would be true even for a skipped/failed send.
+// ---------------------------------------------------------------------------
+
+// outcomeMailerStub is a configurable stub Mailer that reports a fixed
+// SendResult/error and records whether it was invoked.
+type outcomeMailerStub struct {
+	result SendResult
+	err    error
+	called bool
+}
+
+func (m *outcomeMailerStub) Send(context.Context, []string, string, string) (SendResult, error) {
+	m.called = true
+	return m.result, m.err
+}
+
+// captureAuditSink is a stub auditSink that records every Event passed to
+// Record, so Dispatcher tests can assert on the persisted metadata without a
+// live Postgres pool.
+type captureAuditSink struct {
+	events []audit.Event
+}
+
+func (s *captureAuditSink) Record(_ context.Context, e audit.Event) (audit.Entry, error) {
+	s.events = append(s.events, e)
+	return audit.Entry{}, nil
+}
+
+func testAlert() Alert {
+	return Alert{
+		Kind:       AlertDown,
+		TenantID:   uuid.New(),
+		SiteID:     uuid.New(),
+		SiteURL:    "https://site.example.com",
+		HTTPStatus: 503,
+		Error:      "http status 503",
+		FiredAt:    time.Now(),
+	}
+}
+
+// TestFireRecordsSkippedEmailOutcome: a mailer reporting a SKIPPED send (e.g.
+// SMTP not configured) must be recorded as skipped, never as a truthy "sent".
+func TestFireRecordsSkippedEmailOutcome(t *testing.T) {
+	mailer := &outcomeMailerStub{result: SendResult{Status: SendResultSkipped, Reason: "smtp_not_configured"}}
+	sink := &captureAuditSink{}
+	d := NewDispatcher(mailer, nil, sink, nil)
+
+	cfg := AlertConfig{TenantID: uuid.New(), EmailRecipients: []string{"ops@example.com"}}
+	d.Fire(context.Background(), cfg, testAlert())
+
+	if !mailer.called {
+		t.Fatal("expected the mailer to be called")
+	}
+	if len(sink.events) != 1 {
+		t.Fatalf("expected exactly one audit event, got %d", len(sink.events))
+	}
+	meta := sink.events[0].Metadata
+	if meta["email_status"] != SendResultSkipped {
+		t.Fatalf("expected email_status=%q, got %v (full metadata: %+v)", SendResultSkipped, meta["email_status"], meta)
+	}
+	if meta["email_reason"] != "smtp_not_configured" {
+		t.Fatalf("expected email_reason=%q, got %v", "smtp_not_configured", meta["email_reason"])
+	}
+	if v, ok := meta["emailed"]; ok {
+		t.Fatalf("expected no legacy 'emailed' key on new rows, got %v", v)
+	}
+}
+
+// TestFireRecordsFailedEmailOutcome asserts a mailer-reported failure is
+// recorded as "failed" with its reason, not "sent"/emailed.
+func TestFireRecordsFailedEmailOutcome(t *testing.T) {
+	mailer := &outcomeMailerStub{
+		result: SendResult{Status: SendResultFailed, Reason: "smtp_send_failed"},
+		err:    errors.New("smtp: 421 connection timed out"),
+	}
+	sink := &captureAuditSink{}
+	d := NewDispatcher(mailer, nil, sink, nil)
+
+	cfg := AlertConfig{TenantID: uuid.New(), EmailRecipients: []string{"ops@example.com"}}
+	d.Fire(context.Background(), cfg, testAlert())
+
+	meta := sink.events[0].Metadata
+	if meta["email_status"] != SendResultFailed {
+		t.Fatalf("expected email_status=%q, got %v", SendResultFailed, meta["email_status"])
+	}
+	if meta["email_reason"] != "smtp_send_failed" {
+		t.Fatalf("expected email_reason=%q, got %v", "smtp_send_failed", meta["email_reason"])
+	}
+}
+
+// TestFireRecordsSentEmailOutcome asserts a successful send is recorded as
+// "sent" with no email_reason key at all.
+func TestFireRecordsSentEmailOutcome(t *testing.T) {
+	mailer := &outcomeMailerStub{result: SendResult{Status: SendResultSent}}
+	sink := &captureAuditSink{}
+	d := NewDispatcher(mailer, nil, sink, nil)
+
+	cfg := AlertConfig{TenantID: uuid.New(), EmailRecipients: []string{"ops@example.com"}}
+	d.Fire(context.Background(), cfg, testAlert())
+
+	meta := sink.events[0].Metadata
+	if meta["email_status"] != SendResultSent {
+		t.Fatalf("expected email_status=%q, got %v", SendResultSent, meta["email_status"])
+	}
+	if _, ok := meta["email_reason"]; ok {
+		t.Fatalf("expected no email_reason key on a successful send, got %v", meta["email_reason"])
+	}
+}
+
+// TestFireNoRecipientsSkipsMailerAndRecordsSkipped is the no-recipients-
+// configured case: the mailer must NOT be called at all (there is nothing to
+// send to), and the audit row must show a skip with a distinguishing reason —
+// never a truthy "emailed" the way the pre-fix code recorded it.
+func TestFireNoRecipientsSkipsMailerAndRecordsSkipped(t *testing.T) {
+	mailer := &outcomeMailerStub{result: SendResult{Status: SendResultSent}} // would be a lie if ever called
+	sink := &captureAuditSink{}
+	d := NewDispatcher(mailer, nil, sink, nil)
+
+	cfg := AlertConfig{TenantID: uuid.New()} // no EmailRecipients, no WebhookURL
+	d.Fire(context.Background(), cfg, testAlert())
+
+	if mailer.called {
+		t.Fatal("expected the mailer NOT to be called when no recipients are configured")
+	}
+	meta := sink.events[0].Metadata
+	if meta["email_status"] != SendResultSkipped {
+		t.Fatalf("expected email_status=%q, got %v", SendResultSkipped, meta["email_status"])
+	}
+	if meta["email_reason"] != "no_recipients_configured" {
+		t.Fatalf("expected email_reason=%q, got %v", "no_recipients_configured", meta["email_reason"])
+	}
+	if meta["webhook_status"] != SendResultSkipped {
+		t.Fatalf("expected webhook_status=%q, got %v", SendResultSkipped, meta["webhook_status"])
 	}
 }

--- a/apps/api/internal/uptime/dispatcher_test.go
+++ b/apps/api/internal/uptime/dispatcher_test.go
@@ -25,13 +25,13 @@ type stubMailer struct {
 	subject    string
 }
 
-func (m *stubMailer) Send(_ context.Context, recipients []string, subject, _ string) error {
+func (m *stubMailer) Send(_ context.Context, recipients []string, subject, _ string) (SendResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.calls++
 	m.recipients = recipients
 	m.subject = subject
-	return nil
+	return SendResult{Status: SendResultSent}, nil
 }
 
 // TestDispatcherFiresBothChannels asserts the dispatcher calls the mailer with

--- a/apps/api/internal/uptime/notify.go
+++ b/apps/api/internal/uptime/notify.go
@@ -20,15 +20,40 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/httpclient"
 )
 
-// Mailer sends an alert email to recipients. An interface so the evaluator can
-// be tested with a stub sink and the SMTP transport stays swappable.
-type Mailer interface {
-	Send(ctx context.Context, recipients []string, subject, body string) error
+// SendResult is the REAL outcome of one Mailer.Send call — as opposed to
+// merely "recipients were configured" — so callers can record an honest audit
+// trail (GH #144: the uptime alert dispatcher used to record "emailed: true"
+// whenever recipients were configured, even though the send itself was never
+// attempted or had failed).
+type SendResult struct {
+	// Status is one of SendResultSent, SendResultSkipped, or SendResultFailed.
+	Status string
+	// Reason is set whenever Status != SendResultSent: a coarse, ALREADY-
+	// SCRUBBED code/message safe to persist in the audit log (never raw SMTP
+	// host/credential/error detail).
+	Reason string
 }
 
-// SMTPMailer delivers alert emails over the self-host SMTP relay via go-mail
-// (ADR-029). When SMTP is unconfigured it is replaced by NoopMailer in wiring;
-// this type assumes a configured host. SMTP credentials are NEVER logged.
+// SendResult.Status values.
+const (
+	SendResultSent    = "sent"
+	SendResultSkipped = "skipped"
+	SendResultFailed  = "failed"
+)
+
+// Mailer sends an alert email to recipients and reports the real delivery
+// outcome. An interface so the evaluator can be tested with a stub sink and
+// the SMTP transport stays swappable.
+type Mailer interface {
+	Send(ctx context.Context, recipients []string, subject, body string) (SendResult, error)
+}
+
+// SMTPMailer delivers email over a boot-time-configured SMTP relay via go-mail
+// (ADR-029). It is retained for the sharing/invitation legacy env-SMTP wiring
+// (cmd/wpmgr/main.go) — it is NOT used for uptime/security alerts, which
+// resolve their transport per-send from the DB-configured SMTP via
+// internal/mailer.Service (see cmd/wpmgr/uptime_mailer.go, GH #144). SMTP
+// credentials are NEVER logged.
 type SMTPMailer struct {
 	cfg    config.SMTPConfig
 	logger *slog.Logger
@@ -79,29 +104,6 @@ func (m *SMTPMailer) Send(ctx context.Context, recipients []string, subject, bod
 	if err := client.DialAndSendWithContext(ctx, msg); err != nil {
 		return fmt.Errorf("smtp send: %w", err)
 	}
-	return nil
-}
-
-// NoopMailer is used when SMTP is unconfigured: email alerts log and no-op so
-// webhook alerts still fire.
-type NoopMailer struct{ logger *slog.Logger }
-
-// NewNoopMailer builds a NoopMailer.
-func NewNoopMailer(logger *slog.Logger) *NoopMailer {
-	if logger == nil {
-		logger = slog.Default()
-	}
-	return &NoopMailer{logger: logger}
-}
-
-// Send logs that the email was skipped (no recipients are leaked at info level
-// beyond their count).
-func (m *NoopMailer) Send(_ context.Context, recipients []string, subject, _ string) error {
-	if len(recipients) == 0 {
-		return nil
-	}
-	m.logger.Info("smtp not configured: alert email skipped",
-		slog.Int("recipients", len(recipients)), slog.String("subject", subject))
 	return nil
 }
 
@@ -166,4 +168,25 @@ func (p *SSRFWebhookPoster) Post(ctx context.Context, url, secret string, payloa
 		return fmt.Errorf("webhook endpoint returned status %d", resp.StatusCode)
 	}
 	return nil
+}
+
+// classifyWebhookError maps a Post error onto a coarse, stable reason code
+// safe to persist in the audit log: NEVER the endpoint's response body, and
+// deliberately not the raw error text either (which can echo the resolved
+// destination host/IP from the SSRF-hardened dialer).
+func classifyWebhookError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "returned status"):
+		return "webhook_non_2xx_response"
+	case strings.Contains(msg, "marshal webhook payload"):
+		return "webhook_payload_marshal_failed"
+	case strings.Contains(msg, "build webhook request"):
+		return "webhook_request_build_failed"
+	default:
+		return "webhook_transport_failed"
+	}
 }

--- a/apps/api/tests/uptime_integration_test.go
+++ b/apps/api/tests/uptime_integration_test.go
@@ -34,13 +34,13 @@ type countingMailer struct {
 	recipients [][]string
 }
 
-func (m *countingMailer) Send(_ context.Context, recipients []string, _, _ string) error {
+func (m *countingMailer) Send(_ context.Context, recipients []string, _, _ string) (uptime.SendResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.calls++
 	cp := append([]string(nil), recipients...)
 	m.recipients = append(m.recipients, cp)
-	return nil
+	return uptime.SendResult{Status: uptime.SendResultSent}, nil
 }
 
 // nameLookup is a static SiteLookup for the probe worker.

--- a/apps/web/src/features/audit/audit-detail.tsx
+++ b/apps/web/src/features/audit/audit-detail.tsx
@@ -1,10 +1,13 @@
 import type { AuditEntry } from "@wpmgr/api";
 
-import { formatBytes, relativeTime } from "@/lib/utils";
+import { cn, formatBytes, relativeTime } from "@/lib/utils";
 import { DefinitionList, type KvRowProps } from "@/components/shared/definition-list";
 
 import {
   formatClockTime,
+  formatDeliveryStatus,
+  humanizeDeliveryReason,
+  humanizeDeliveryStatus,
   humanizeKey,
   humanizeReason,
   humanizeTargetType,
@@ -20,7 +23,17 @@ import {
 
 // Fields already surfaced elsewhere in the row (path in the target slot,
 // reason in the "why" callout) or too internal to repeat verbatim here.
-const HANDLED_KEYS = new Set(["path", "reason"]);
+// email_reason/webhook_reason are folded into their paired email_status/
+// webhook_status row (see DELIVERY_STATUS_REASON_KEYS below) instead of
+// rendering as their own separate line.
+const HANDLED_KEYS = new Set(["path", "reason", "email_reason", "webhook_reason"]);
+
+// Maps a delivery-status metadata key to the reason key that, when present,
+// explains a non-"sent" outcome.
+const DELIVERY_STATUS_REASON_KEYS: Record<string, string> = {
+  email_status: "email_reason",
+  webhook_status: "webhook_reason",
+};
 
 export function AuditEntryDetail({ entry }: { entry: AuditEntry }) {
   const denied = entry.action.endsWith(".denied");
@@ -31,11 +44,25 @@ export function AuditEntryDetail({ entry }: { entry: AuditEntry }) {
     ([key]) => !HANDLED_KEYS.has(key),
   );
 
-  const metaRows: KvRowProps[] = metaEntries.map(([key, value]) => ({
-    label: humanizeKey(key),
-    value: formatMetaValue(key, value),
-    mono: key.endsWith("_id") || key === "ip" || key === "user_agent",
-  }));
+  const metaRows: KvRowProps[] = metaEntries.map(([key, value]) => {
+    const reasonKey = DELIVERY_STATUS_REASON_KEYS[key];
+    if (reasonKey && typeof value === "string") {
+      return {
+        label: humanizeKey(key),
+        value: (
+          <DeliveryStatusValue
+            status={value}
+            reason={metaString(entry.metadata, reasonKey)}
+          />
+        ),
+      };
+    }
+    return {
+      label: humanizeKey(key),
+      value: formatMetaValue(key, value),
+      mono: key.endsWith("_id") || key === "ip" || key === "user_agent",
+    };
+  });
 
   return (
     <div className="space-y-3 border-t border-border bg-muted/20 px-4 py-3 text-sm">
@@ -69,6 +96,51 @@ export function AuditEntryDetail({ entry }: { entry: AuditEntry }) {
         ]}
       />
     </div>
+  );
+}
+
+// Tone for the email_status/webhook_status pill: success for "sent",
+// destructive for "failed", and the quiet muted default for "skipped" (and
+// any future/unknown status code) — a skip isn't an error, so it shouldn't
+// read as one.
+const DELIVERY_STATUS_TONE: Record<string, string> = {
+  sent: "bg-success-subtle text-success-subtle-fg",
+  failed: "bg-destructive-subtle text-destructive-subtle-fg",
+};
+const DELIVERY_STATUS_DEFAULT_TONE = "bg-muted text-muted-foreground";
+
+/** Renders an email_status/webhook_status value as a colored pill, with the
+ * paired reason (when the outcome isn't "sent") as plain text alongside it —
+ * e.g. a "Skipped" pill next to "(SMTP not configured)". Replaces the old
+ * "Emailed: Yes" line, which asserted delivery even when it was skipped or
+ * failed. */
+function DeliveryStatusValue({
+  status,
+  reason,
+}: {
+  status: string;
+  reason: string | null;
+}) {
+  const tone = DELIVERY_STATUS_TONE[status] ?? DELIVERY_STATUS_DEFAULT_TONE;
+  return (
+    <span
+      className="inline-flex flex-wrap items-center gap-1.5"
+      title={formatDeliveryStatus(status, reason)}
+    >
+      <span
+        className={cn(
+          "inline-flex w-fit items-center rounded px-1.5 py-0.5 text-[11px] font-medium",
+          tone,
+        )}
+      >
+        {humanizeDeliveryStatus(status)}
+      </span>
+      {status !== "sent" && reason ? (
+        <span className="text-xs text-muted-foreground">
+          ({humanizeDeliveryReason(reason)})
+        </span>
+      ) : null}
+    </span>
   );
 }
 

--- a/apps/web/src/features/audit/labels.ts
+++ b/apps/web/src/features/audit/labels.ts
@@ -235,7 +235,11 @@ const ACTION_LABELS: Record<string, string> = {
   "backup.schedule.changed": "Changed backup schedule",
 
   // Uptime & alerts
-  "uptime.alert.sent": "Sent downtime alert",
+  // Deliberately doesn't assert "Sent" — the row's email_status/webhook_status
+  // metadata (rendered in audit-detail.tsx) carries the actual sent/skipped/
+  // failed truth per channel; this action fires for down, recovery, AND
+  // security-event alerts alike.
+  "uptime.alert.sent": "Downtime alert",
   "alert.config.changed": "Changed alert settings",
 };
 

--- a/apps/web/src/features/audit/metadata.test.ts
+++ b/apps/web/src/features/audit/metadata.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for the audit metadata helpers, focused on the honest delivery-status
+ * rendering for uptime.alert.sent (GitHub #144): the control plane now emits
+ * email_status/webhook_status ("sent"/"skipped"/"failed") plus a reason code
+ * instead of a bare "emailed"/"webhooked" boolean that always read "Yes"
+ * regardless of whether delivery actually happened.
+ *
+ * Following the project convention (labels.test.ts, group-runs.test.ts):
+ * pure-function tests only; no React renderer, no DOM.
+ */
+import { describe, it, expect } from "vitest";
+
+import {
+  formatDeliveryStatus,
+  humanizeDeliveryReason,
+  humanizeDeliveryStatus,
+} from "./metadata";
+
+describe("humanizeDeliveryStatus", () => {
+  it("maps the three known status codes to sentence-case words", () => {
+    expect(humanizeDeliveryStatus("sent")).toBe("Sent");
+    expect(humanizeDeliveryStatus("skipped")).toBe("Skipped");
+    expect(humanizeDeliveryStatus("failed")).toBe("Failed");
+  });
+
+  it("falls back to sentence case for an unknown status code", () => {
+    expect(humanizeDeliveryStatus("throttled")).toBe("Throttled");
+  });
+});
+
+describe("humanizeDeliveryReason", () => {
+  it("maps the known reason codes to readable text", () => {
+    expect(humanizeDeliveryReason("smtp_not_configured")).toBe("SMTP not configured");
+    expect(humanizeDeliveryReason("no_recipients")).toBe("No recipients");
+    expect(humanizeDeliveryReason("no_recipients_configured")).toBe("No recipients");
+    expect(humanizeDeliveryReason("resolve_smtp")).toBe("SMTP lookup failed");
+  });
+
+  it("passes an unknown reason code through unchanged", () => {
+    expect(humanizeDeliveryReason("some_future_reason")).toBe("some_future_reason");
+  });
+});
+
+describe("formatDeliveryStatus", () => {
+  it("renders a sent outcome with no reason suffix", () => {
+    expect(formatDeliveryStatus("sent", null)).toBe("Sent");
+    // Even a stray reason on a "sent" row is ignored — only non-"sent"
+    // outcomes surface a reason.
+    expect(formatDeliveryStatus("sent", "smtp_not_configured")).toBe("Sent");
+  });
+
+  it("renders a skipped outcome with its known reason", () => {
+    expect(formatDeliveryStatus("skipped", "smtp_not_configured")).toBe(
+      "Skipped (SMTP not configured)",
+    );
+  });
+
+  it("renders a failed outcome with its known reason", () => {
+    expect(formatDeliveryStatus("failed", "resolve_smtp")).toBe(
+      "Failed (SMTP lookup failed)",
+    );
+  });
+
+  it("renders bare status word when no reason is present", () => {
+    expect(formatDeliveryStatus("skipped", null)).toBe("Skipped");
+  });
+
+  it("passes an unknown reason through unchanged inside the parens", () => {
+    expect(formatDeliveryStatus("failed", "some_future_reason")).toBe(
+      "Failed (some_future_reason)",
+    );
+  });
+});

--- a/apps/web/src/features/audit/metadata.ts
+++ b/apps/web/src/features/audit/metadata.ts
@@ -47,6 +47,55 @@ export function humanizeTargetType(targetType: string): string {
   return humanizeKey(targetType.replace(/_/g, " "));
 }
 
+// ---------------------------------------------------------------------------
+// Delivery status (uptime.alert.sent's email_status/webhook_status metadata)
+// ---------------------------------------------------------------------------
+//
+// New rows carry an honest email_status/webhook_status ("sent"/"skipped"/
+// "failed") plus a reason code when the outcome isn't "sent" — replacing the
+// old bare "emailed"/"webhooked" booleans that always read "Yes" whether or
+// not delivery actually happened. Historical rows still have the old
+// booleans and keep rendering through the generic formatMetaValue path in
+// audit-detail.tsx; this section only covers the new keys.
+
+const DELIVERY_STATUS_WORDS: Record<string, string> = {
+  sent: "Sent",
+  skipped: "Skipped",
+  failed: "Failed",
+};
+
+/** Human label for an email_status/webhook_status code; unknown codes fall
+ * back to sentence case rather than a raw lowercase token. */
+export function humanizeDeliveryStatus(status: string): string {
+  return DELIVERY_STATUS_WORDS[status] ?? humanizeKey(status);
+}
+
+const DELIVERY_REASON_LABELS: Record<string, string> = {
+  smtp_not_configured: "SMTP not configured",
+  no_recipients: "No recipients",
+  no_recipients_configured: "No recipients",
+  resolve_smtp: "SMTP lookup failed",
+};
+
+/** Human label for an email_reason/webhook_reason code; an unknown code
+ * passes through unchanged (the control plane already scrubs raw transport
+ * errors before they reach audit metadata). */
+export function humanizeDeliveryReason(reason: string): string {
+  return DELIVERY_REASON_LABELS[reason] ?? reason;
+}
+
+/**
+ * Full plain-text status line for a delivery outcome, e.g. "Sent",
+ * "Skipped (SMTP not configured)", "Failed (SMTP lookup failed)". Used as
+ * the rendered row's title/tooltip; the on-screen value additionally colors
+ * the leading word with a status pill (see audit-detail.tsx).
+ */
+export function formatDeliveryStatus(status: string, reason: string | null): string {
+  const word = humanizeDeliveryStatus(status);
+  if (status === "sent" || !reason) return word;
+  return `${word} (${humanizeDeliveryReason(reason)})`;
+}
+
 /** Absolute local clock time (HH:MM:SS) for a past-day timestamp (point 7:
  * only "today" uses a relative label; anything in an already-labeled day
  * bucket shows an unambiguous absolute time instead). */


### PR DESCRIPTION
Uptime alert emails were silently skipped when SMTP was configured in the dashboard but not as env vars (the mailer was a boot-time env snapshot, ignoring the saved DB relay everything else uses). And the audit log recorded 'Emailed: Yes' from recipients-configured, not the real send result. Fix routes uptime alerts through the shared per-send DB-SMTP mailer (env fallback, now SSRF-hardened) and records the true outcome (sent/skipped/failed + scrubbed reason) for email and webhook. CP-only, no migration. Security review SHIP; reasons are allowlist-scrubbed (no secret leak).

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU