### PR TITLE
fix(uptime+ui): incidents panel data + 4 UI flaws (GH #148, #150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.29] - 2026-07-07
+
+### Fixed
+
+- The Uptime page Incidents panel showed wrong information for an ongoing incident: a site that was down was labeled "Degraded", its duration read "NaNh", and the site name was blank. Incident rows now show the correct severity ("Down"), read "ongoing" while an incident is open, and always show the site name. Each row is also now labeled ("started ... ago", "for ...h") and links to the site so you can drill in.
+- Native dropdown menus were unreadable in dark mode because the expanded option list rendered on a light background. Native controls now follow the app theme in both light and dark mode.
+- Two breadcrumb links (Restores, Schedule runs) pointed at pages that do not exist and returned a 404 when clicked. Those segments are no longer clickable.
+- The "Open site" action in a site's row menu did nothing. It now opens the site's detail page, from both the list and grid views.
+
 ## [0.61.28] - 2026-07-07
 
 ### Added

--- a/apps/api/internal/uptime/fleet_incidents_contract_test.go
+++ b/apps/api/internal/uptime/fleet_incidents_contract_test.go
@@ -1,0 +1,116 @@
+package uptime
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TestFleetIncidentItemJSONContract locks the JSON field names of the fleet
+// incidents item to the web contract (apps/web/src/features/fleet incidents
+// panel, GH #148). Three drift classes previously shipped bad data to the
+// dashboard:
+//   - a missing `kind` field made every row render as "Degraded", even a
+//     down site (the client fell back on `inc.kind === "down" ? ... :
+//     "Degraded"` and saw undefined);
+//   - `duration_seconds`/`ended_at` used `omitempty`, so an OPEN incident
+//     OMITTED the key entirely instead of emitting `null`; the client's
+//     `=== null` check missed the omitted (`undefined`) key and rendered
+//     "NaNh";
+//   - `site_name`/`site_url` JSON tags did not match the `name`/`url` keys
+//     the web reads (the same drift class fixed for FleetStatusItem in
+//     0.47.1, see TestFleetStatusItemJSONContract).
+//
+// This test fails fast on any of the three regressing.
+func TestFleetIncidentItemJSONContract(t *testing.T) {
+	now := time.Now().UTC()
+	dur := int64(120)
+	totalMs := 842.5
+
+	open := FleetIncidentItem{
+		SiteID:          uuid.New(),
+		Kind:            "down",
+		SiteName:        "Example Site",
+		SiteURL:         "https://example.com",
+		StartedAt:       &now,
+		EndedAt:         nil,
+		DurationSeconds: nil,
+		Ongoing:         true,
+		LatestTotalMs:   &totalMs,
+	}
+	ended := now.Add(2 * time.Minute)
+	closed := FleetIncidentItem{
+		SiteID:          uuid.New(),
+		Kind:            "down",
+		SiteName:        "Example Site",
+		SiteURL:         "https://example.com",
+		StartedAt:       &now,
+		EndedAt:         &ended,
+		DurationSeconds: &dur,
+		Ongoing:         false,
+		LatestTotalMs:   &totalMs,
+	}
+
+	requiredKeys := []string{
+		"site_id", "kind", "name", "url", "started_at", "ended_at",
+		"duration_seconds", "ongoing",
+	}
+
+	t.Run("open incident", func(t *testing.T) {
+		b, err := json.Marshal(open)
+		if err != nil {
+			t.Fatalf("marshal open FleetIncidentItem: %v", err)
+		}
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(b, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		for _, k := range requiredKeys {
+			if _, ok := m[k]; !ok {
+				t.Errorf("open FleetIncidentItem JSON missing contract key %q (got keys %v)", k, keysOf(m))
+			}
+		}
+		if got := string(m["kind"]); got != `"down"` {
+			t.Errorf("open incident kind = %s, want \"down\"", got)
+		}
+		// The whole point of the fix: for an OPEN incident, ended_at and
+		// duration_seconds must be present and explicitly null, NOT omitted.
+		if raw, ok := m["ended_at"]; !ok {
+			t.Errorf("open FleetIncidentItem: ended_at key omitted entirely (want present + null)")
+		} else if string(raw) != "null" {
+			t.Errorf("open FleetIncidentItem: ended_at = %s, want null", raw)
+		}
+		if raw, ok := m["duration_seconds"]; !ok {
+			t.Errorf("open FleetIncidentItem: duration_seconds key omitted entirely (want present + null)")
+		} else if string(raw) != "null" {
+			t.Errorf("open FleetIncidentItem: duration_seconds = %s, want null", raw)
+		}
+	})
+
+	t.Run("closed incident", func(t *testing.T) {
+		b, err := json.Marshal(closed)
+		if err != nil {
+			t.Fatalf("marshal closed FleetIncidentItem: %v", err)
+		}
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(b, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		for _, k := range requiredKeys {
+			if _, ok := m[k]; !ok {
+				t.Errorf("closed FleetIncidentItem JSON missing contract key %q (got keys %v)", k, keysOf(m))
+			}
+		}
+		if got := string(m["kind"]); got != `"down"` {
+			t.Errorf("closed incident kind = %s, want \"down\"", got)
+		}
+		if string(m["ended_at"]) == "null" {
+			t.Errorf("closed FleetIncidentItem: ended_at should not be null")
+		}
+		if string(m["duration_seconds"]) == "null" {
+			t.Errorf("closed FleetIncidentItem: duration_seconds should not be null")
+		}
+	})
+}

--- a/apps/api/internal/uptime/model.go
+++ b/apps/api/internal/uptime/model.go
@@ -88,18 +88,18 @@ type FleetStatusCounts struct {
 // apps/web/src/features/fleet/fleet-types.ts — do not rename without
 // updating both sides.
 type FleetStatusItem struct {
-	SiteID          uuid.UUID       `json:"site_id"`
-	Name            string          `json:"name"`
-	URL             string          `json:"url"`
-	ConnectionState string          `json:"connection_state"`
-	HealthStatus    string          `json:"health_status"`
-	Status          FleetSiteStatus `json:"status"`
-	Up              *bool           `json:"up"`
-	LastProbeAt     *time.Time      `json:"last_probe_at"`
-	UptimePct7d     float64         `json:"uptime_pct_7d"`
-	AvgLatencyMs    *float64        `json:"avg_latency_ms"`
-	TLSExpiry       *time.Time      `json:"tls_expiry"`
-	LatencySparkline []float64      `json:"latency_sparkline"`
+	SiteID           uuid.UUID       `json:"site_id"`
+	Name             string          `json:"name"`
+	URL              string          `json:"url"`
+	ConnectionState  string          `json:"connection_state"`
+	HealthStatus     string          `json:"health_status"`
+	Status           FleetSiteStatus `json:"status"`
+	Up               *bool           `json:"up"`
+	LastProbeAt      *time.Time      `json:"last_probe_at"`
+	UptimePct7d      float64         `json:"uptime_pct_7d"`
+	AvgLatencyMs     *float64        `json:"avg_latency_ms"`
+	TLSExpiry        *time.Time      `json:"tls_expiry"`
+	LatencySparkline []float64       `json:"latency_sparkline"`
 	// InIncident is kept for internal use (summary counting) but not needed
 	// by the frontend contract — retained for the service-layer logic.
 	InIncident bool `json:"in_incident"`
@@ -131,13 +131,26 @@ type FleetSiteInfo struct {
 // recently-alerted sites (last_alert_at >= since). Calling code must treat
 // ended_at / duration_seconds as estimates (derived from updated_at on the
 // alert-state row, not from a true incident-close timestamp).
+//
+// JSON field names are pinned to the frontend contract consumed by the fleet
+// incidents panel (GH #148) — do not rename without updating both sides.
+// EndedAt and DurationSeconds intentionally do NOT use `omitempty`: an open
+// incident must marshal them as explicit `null`, not omit the key, so the web
+// client's `=== null` check can distinguish "ongoing" from a missing field
+// (an omitted key deserializes to `undefined`, not `null`, and produced
+// "NaNh" duration on open incidents).
 type FleetIncidentItem struct {
-	SiteID          uuid.UUID  `json:"site_id"`
-	SiteName        string     `json:"site_name"`
-	SiteURL         string     `json:"site_url"`
+	SiteID uuid.UUID `json:"site_id"`
+	// Kind is always "down": the alert state machine (see Evaluate in
+	// alerts.go) opens an incident only on a down-threshold crossing —
+	// "degraded" is a live fleet-status derivation (deriveFleetStatus) and is
+	// never persisted as an incident state.
+	Kind            string     `json:"kind"`
+	SiteName        string     `json:"name"`
+	SiteURL         string     `json:"url"`
 	StartedAt       *time.Time `json:"started_at,omitempty"`
-	EndedAt         *time.Time `json:"ended_at,omitempty"`
-	DurationSeconds *int64     `json:"duration_seconds,omitempty"`
+	EndedAt         *time.Time `json:"ended_at"`
+	DurationSeconds *int64     `json:"duration_seconds"`
 	Ongoing         bool       `json:"ongoing"`
 	LatestTotalMs   *float64   `json:"latest_total_ms,omitempty"`
 }

--- a/apps/api/internal/uptime/repo.go
+++ b/apps/api/internal/uptime/repo.go
@@ -356,6 +356,7 @@ LIMIT $4
 			}
 			item := FleetIncidentItem{
 				SiteID:        siteID,
+				Kind:          string(AlertDown),
 				SiteName:      siteName,
 				SiteURL:       siteURL,
 				Ongoing:       inIncident,

--- a/apps/web/src/components/layout/top-bar-helpers.test.ts
+++ b/apps/web/src/components/layout/top-bar-helpers.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+
+import { buildBreadcrumbCrumbs, humanize, ROUTELESS_SEGMENTS } from "./top-bar-helpers";
+
+// ---------------------------------------------------------------------------
+// GH #150 (#2 & #3) — breadcrumb 404 on routeless parents
+//
+// `/restores` and `/schedule-runs` have no index route (only `$restoreId`/
+// `$runId` detail routes), so linkifying the parent segment 404s. These tests
+// pin: (a) a routeless parent renders as a non-navigable crumb (`to: null`)
+// even though it isn't the last segment, (b) an ordinary parent segment is
+// still linkified, and (c) the humanize map covers both new labels.
+// ---------------------------------------------------------------------------
+
+describe("buildBreadcrumbCrumbs", () => {
+  it("returns a single Home crumb for the root path", () => {
+    expect(buildBreadcrumbCrumbs("/")).toEqual([{ label: "Home", to: null }]);
+  });
+
+  it("linkifies every non-last segment for an ordinary route", () => {
+    expect(buildBreadcrumbCrumbs("/sites/abc123")).toEqual([
+      { label: "Sites", to: "/sites" },
+      { label: "abc123", to: null },
+    ]);
+  });
+
+  it("does NOT linkify a routeless parent segment (restores)", () => {
+    expect(buildBreadcrumbCrumbs("/restores/rst_1")).toEqual([
+      { label: "Restores", to: null },
+      { label: "rst_1", to: null },
+    ]);
+  });
+
+  it("does NOT linkify a routeless parent segment (schedule-runs)", () => {
+    expect(buildBreadcrumbCrumbs("/schedule-runs/run_42")).toEqual([
+      { label: "Schedule runs", to: null },
+      { label: "run_42", to: null },
+    ]);
+  });
+
+  it("still linkifies a routeless segment's own ancestors normally", () => {
+    // Hypothetical deeper nesting under a routeless segment: only the
+    // routeless segment itself loses its link, ancestors before it are
+    // unaffected.
+    expect(buildBreadcrumbCrumbs("/sites/abc123/restores/rst_1")).toEqual([
+      { label: "Sites", to: "/sites" },
+      { label: "abc123", to: "/sites/abc123" },
+      { label: "Restores", to: null },
+      { label: "rst_1", to: null },
+    ]);
+  });
+
+  it("the last segment is always non-navigable regardless of the allowlist", () => {
+    const crumbs = buildBreadcrumbCrumbs("/settings");
+    const last = crumbs.at(-1);
+    expect(last?.to).toBeNull();
+  });
+});
+
+describe("humanize", () => {
+  it("maps restores to a title-cased human label", () => {
+    expect(humanize("restores")).toBe("Restores");
+  });
+
+  it("maps schedule-runs to a human label", () => {
+    expect(humanize("schedule-runs")).toBe("Schedule runs");
+  });
+
+  it("passes through an unmapped segment (e.g. a raw id) unchanged", () => {
+    expect(humanize("rst_01hxyz")).toBe("rst_01hxyz");
+  });
+});
+
+describe("ROUTELESS_SEGMENTS", () => {
+  it("contains exactly the known routeless parents", () => {
+    expect(ROUTELESS_SEGMENTS.has("restores")).toBe(true);
+    expect(ROUTELESS_SEGMENTS.has("schedule-runs")).toBe(true);
+    expect(ROUTELESS_SEGMENTS.has("sites")).toBe(false);
+  });
+});

--- a/apps/web/src/components/layout/top-bar-helpers.ts
+++ b/apps/web/src/components/layout/top-bar-helpers.ts
@@ -1,0 +1,70 @@
+// Pure helpers backing the app-shell top bar breadcrumb (see top-bar.tsx).
+// Extracted so the routeless-segment / humanize logic can be unit tested
+// without mounting the router or the DOM.
+
+export interface Crumb {
+  label: string;
+  /** Absolute pathname this crumb links to, or null when it has no
+   * navigable destination (the leaf, or a known-routeless parent segment). */
+  to: string | null;
+}
+
+/**
+ * Segments that are a path prefix in the URL but have NO navigable index
+ * route - only `$id` detail routes exist underneath them (e.g.
+ * `routes/_authed/restores/$restoreId.tsx`, there is no `restores/index.tsx`;
+ * same for `schedule-runs/$runId.tsx`). Linking to the bare segment 404s
+ * (GH #150). These render as plain text instead of a Link.
+ *
+ * This is a known-routeless allowlist rather than a route-table lookup
+ * because the breadcrumb builder is a pure pathname->label mapper with no
+ * access to the router's route manifest. Keep this set in sync with
+ * `src/routes/_authed/**`: any new parent path segment that has ONLY nested
+ * `$param` routes (no sibling `index.tsx`) must be added here too, or its
+ * breadcrumb crumb will silently 404 again.
+ */
+export const ROUTELESS_SEGMENTS = new Set(["restores", "schedule-runs"]);
+
+const TITLES: Record<string, string> = {
+  sites: "Sites",
+  updates: "Updates",
+  backups: "Backups",
+  migrations: "Migrations",
+  uptime: "Uptime",
+  performance: "Performance",
+  vulnerabilities: "Vulnerabilities",
+  audit: "Audit",
+  settings: "Settings",
+  alerts: "Alerts",
+  "api-keys": "API keys",
+  restores: "Restores",
+  "schedule-runs": "Schedule runs",
+};
+
+export function humanize(segment: string): string {
+  if (TITLES[segment]) return TITLES[segment];
+  // Path params arrive as raw values (e.g. an ID). Display them in mono via
+  // the consumer; here we just pass through.
+  return segment;
+}
+
+/**
+ * Build the breadcrumb crumb list for a pathname. Pure - no router or DOM
+ * access - so route registration state never affects this beyond the
+ * `ROUTELESS_SEGMENTS` allowlist above.
+ */
+export function buildBreadcrumbCrumbs(pathname: string): Crumb[] {
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length === 0) return [{ label: "Home", to: null }];
+  const crumbs: Crumb[] = [];
+  let acc = "";
+  segments.forEach((segment, i) => {
+    acc += `/${segment}`;
+    const isLast = i === segments.length - 1;
+    crumbs.push({
+      label: humanize(segment),
+      to: isLast || ROUTELESS_SEGMENTS.has(segment) ? null : acc,
+    });
+  });
+  return crumbs;
+}

--- a/apps/web/src/components/layout/top-bar.tsx
+++ b/apps/web/src/components/layout/top-bar.tsx
@@ -23,6 +23,10 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ThemeToggle } from "@/components/layout/theme-toggle";
 import { useShellState } from "@/components/layout/app-shell-context";
+import {
+  buildBreadcrumbCrumbs,
+  type Crumb,
+} from "@/components/layout/top-bar-helpers";
 import { useCommandPalette } from "@/features/command/use-command-palette";
 import { useLogout, useMe } from "@/features/auth/use-auth";
 import { useBulkAction } from "@/features/sites/use-bulk-action";
@@ -124,12 +128,8 @@ export function TopBar() {
 }
 
 // ── Breadcrumb ───────────────────────────────────────────────────────────────
-
-interface Crumb {
-  label: string;
-  /** Absolute pathname this crumb links to, or null for the leaf. */
-  to: string | null;
-}
+// Pure crumb-building logic (routeless-segment allowlist, humanize map) lives
+// in ./top-bar-helpers so it is unit-testable without mounting the router.
 
 /**
  * Derive a humanized breadcrumb from the current pathname. We don't (yet)
@@ -141,42 +141,7 @@ interface Crumb {
  * Separator is ">" (a `ChevronRight` icon), never an em dash.
  */
 function useBreadcrumb(pathname: string): Crumb[] {
-  return useMemo(() => {
-    const segments = pathname.split("/").filter(Boolean);
-    if (segments.length === 0) return [{ label: "Home", to: null }];
-    const crumbs: Crumb[] = [];
-    let acc = "";
-    segments.forEach((segment, i) => {
-      acc += `/${segment}`;
-      const isLast = i === segments.length - 1;
-      crumbs.push({
-        label: humanize(segment),
-        to: isLast ? null : acc,
-      });
-    });
-    return crumbs;
-  }, [pathname]);
-}
-
-const TITLES: Record<string, string> = {
-  sites: "Sites",
-  updates: "Updates",
-  backups: "Backups",
-  migrations: "Migrations",
-  uptime: "Uptime",
-  performance: "Performance",
-  vulnerabilities: "Vulnerabilities",
-  audit: "Audit",
-  settings: "Settings",
-  alerts: "Alerts",
-  "api-keys": "API keys",
-};
-
-function humanize(segment: string): string {
-  if (TITLES[segment]) return TITLES[segment];
-  // Path params arrive as raw values (e.g. an ID). Display them in mono via
-  // the consumer; here we just pass through.
-  return segment;
+  return useMemo(() => buildBreadcrumbCrumbs(pathname), [pathname]);
 }
 
 function Breadcrumb({ crumbs }: { crumbs: Crumb[] }) {

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -14,7 +14,15 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     <select
       ref={ref}
       className={cn(
-        "h-9 w-full appearance-none rounded-md border border-[var(--color-input)] bg-transparent px-3 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)] disabled:cursor-not-allowed disabled:opacity-50",
+        // Explicit bg/text (not "transparent") so the native option popup -
+        // which several browsers paint using the <select>'s own computed
+        // background/color rather than the ancestor surface - matches the
+        // app's popover surface in both themes instead of falling back to an
+        // unreadable OS default (GH #150). `color-scheme` itself (set on
+        // :root/.dark in globals.css, following the .dark class) is what
+        // makes Chromium/WebKit render the popup chrome as dark to begin
+        // with; this covers the browsers that also key off background/color.
+        "h-9 w-full appearance-none rounded-md border border-[var(--color-input)] bg-[var(--color-popover)] px-3 text-sm text-[var(--color-popover-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)] disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}

--- a/apps/web/src/features/fleet/incident-format.test.ts
+++ b/apps/web/src/features/fleet/incident-format.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+
+import { isIncidentOngoing, formatIncidentDuration } from "./incident-format";
+
+// ---------------------------------------------------------------------------
+// GH #148 — incidents panel hardening
+//
+// Bug: the panel used to decide "ongoing" from `duration_seconds === null`
+// and format duration unconditionally, which rendered "NaNh" whenever the
+// backend sent a non-finite (undefined/NaN) duration that wasn't exactly
+// `null`. These tests pin the hardened contract: `ongoing` boolean is the
+// source of truth, `Number.isFinite` is the backstop, and the formatter can
+// never emit "NaN" in any branch.
+// ---------------------------------------------------------------------------
+
+describe("isIncidentOngoing", () => {
+  it("is ongoing when the API says ongoing=true, regardless of duration", () => {
+    expect(isIncidentOngoing({ ongoing: true, duration_seconds: null })).toBe(true);
+    expect(isIncidentOngoing({ ongoing: true, duration_seconds: 42 })).toBe(true);
+  });
+
+  it("is not ongoing when ongoing=false and duration is a finite number", () => {
+    expect(isIncidentOngoing({ ongoing: false, duration_seconds: 531000 })).toBe(false);
+    expect(isIncidentOngoing({ ongoing: false, duration_seconds: 0 })).toBe(false);
+  });
+
+  it("falls back to ongoing when duration is null even if ongoing=false (defensive)", () => {
+    expect(isIncidentOngoing({ ongoing: false, duration_seconds: null })).toBe(true);
+  });
+
+  it("falls back to ongoing when duration is NaN/undefined (never trusts a bad payload)", () => {
+    expect(
+      isIncidentOngoing({
+        ongoing: false,
+        duration_seconds: Number.NaN,
+      }),
+    ).toBe(true);
+    expect(
+      isIncidentOngoing({
+        ongoing: false,
+        duration_seconds: undefined as unknown as number | null,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("formatIncidentDuration", () => {
+  it("returns null when ongoing (no duration to show)", () => {
+    expect(formatIncidentDuration(531000, true)).toBeNull();
+    expect(formatIncidentDuration(null, true)).toBeNull();
+  });
+
+  it("returns null (never NaN) when duration is not a finite number", () => {
+    expect(formatIncidentDuration(null, false)).toBeNull();
+    expect(formatIncidentDuration(Number.NaN, false)).toBeNull();
+    expect(formatIncidentDuration(undefined, false)).toBeNull();
+  });
+
+  it("formats sub-minute durations in seconds", () => {
+    expect(formatIncidentDuration(45, false)).toBe("45s");
+  });
+
+  it("formats sub-hour durations in whole minutes", () => {
+    expect(formatIncidentDuration(150, false)).toBe("3m");
+  });
+
+  it("formats hour-scale durations with one decimal (the reported 147.5h case)", () => {
+    expect(formatIncidentDuration(531_000, false)).toBe("147.5h");
+  });
+
+  it("formats a zero-second duration as 0s, not falsy-empty", () => {
+    expect(formatIncidentDuration(0, false)).toBe("0s");
+  });
+});

--- a/apps/web/src/features/fleet/incident-format.ts
+++ b/apps/web/src/features/fleet/incident-format.ts
@@ -1,0 +1,41 @@
+// Pure helpers for rendering a FleetIncident's ongoing/duration labels
+// (GH #148). Extracted from the /uptime IncidentList so the "is this
+// incident still open" decision and the duration formatting can be unit
+// tested without mounting the route.
+
+import type { FleetIncident } from "./fleet-types";
+
+/**
+ * Decide whether an incident should render as "ongoing".
+ *
+ * Trusts the reliable `ongoing` boolean from the pinned API contract first.
+ * Falls back to treating a non-finite `duration_seconds` (null, undefined,
+ * or NaN) as ongoing too — this is the hardening GH #148 asked for: never
+ * derive "ongoing" from `duration_seconds === null` alone, so a missing or
+ * malformed duration can never render as a completed incident (and can
+ * never produce "NaNh").
+ */
+export function isIncidentOngoing(
+  inc: Pick<FleetIncident, "ongoing" | "duration_seconds">,
+): boolean {
+  if (inc.ongoing) return true;
+  return !Number.isFinite(inc.duration_seconds);
+}
+
+/**
+ * Format a resolved incident's duration as a compact "Xs" / "Xm" / "X.Xh"
+ * label (no "for" prefix — callers add that so the sentence composes
+ * naturally). Returns null for an ongoing incident, or when the duration is
+ * not a finite number — defensive so this can never render "NaNh"/"NaNm".
+ */
+export function formatIncidentDuration(
+  durationSeconds: number | null | undefined,
+  ongoing: boolean,
+): string | null {
+  if (ongoing) return null;
+  if (!Number.isFinite(durationSeconds)) return null;
+  const seconds = durationSeconds as number;
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  return `${(seconds / 3600).toFixed(1)}h`;
+}

--- a/apps/web/src/features/sites/site-card.tsx
+++ b/apps/web/src/features/sites/site-card.tsx
@@ -129,6 +129,8 @@ export interface SiteCardProps {
   cardSize: CardSize;
   selectionCount: number;
   onOpenAutoLogin?: (site: Site) => void;
+  /** Opens the site's detail page — wired to the "Open site" menu action. */
+  onOpenDetail?: (site: Site) => void;
   onDisconnect?: (site: Site) => void;
   onReconnect?: (site: Site) => void;
 }
@@ -140,6 +142,7 @@ export function SiteCard({
   cardSize,
   selectionCount,
   onOpenAutoLogin,
+  onOpenDetail,
   onDisconnect,
   onReconnect,
 }: SiteCardProps) {
@@ -270,6 +273,7 @@ export function SiteCard({
               site={site}
               connectionState={connectionState}
               onOpenAutoLogin={onOpenAutoLogin}
+              onOpenDetail={onOpenDetail}
               onDisconnect={onDisconnect}
               onReconnect={onReconnect}
             />

--- a/apps/web/src/features/sites/sites-grid.tsx
+++ b/apps/web/src/features/sites/sites-grid.tsx
@@ -29,6 +29,8 @@ export interface SitesGridProps {
   sites: Site[];
   cardSize: CardSize;
   onOpenAutoLogin?: (site: Site) => void;
+  /** Opens the site's detail page — wired to the "Open site" menu action. */
+  onOpenDetail?: (site: Site) => void;
   onDisconnect?: (site: Site) => void;
   onReconnect?: (site: Site) => void;
 }
@@ -39,6 +41,7 @@ export function SitesGrid({
   sites,
   cardSize,
   onOpenAutoLogin,
+  onOpenDetail,
   onDisconnect,
   onReconnect,
 }: SitesGridProps) {
@@ -70,6 +73,7 @@ export function SitesGrid({
             cardSize={cardSize}
             selectionCount={selection.count}
             onOpenAutoLogin={onOpenAutoLogin}
+            onOpenDetail={onOpenDetail}
             onDisconnect={onDisconnect}
             onReconnect={onReconnect}
           />

--- a/apps/web/src/routes/_authed/sites/index.tsx
+++ b/apps/web/src/routes/_authed/sites/index.tsx
@@ -368,6 +368,16 @@ function SitesPage() {
     openAutoLoginRef.current = handleOpenAutoLogin;
   }, [handleOpenAutoLogin]);
 
+  // "Open site" menu action — navigates to the site's detail page. Wired here
+  // (rather than left as a prop the caller forgets to pass) so it works
+  // identically in both the grid (card) and table views (GH #150).
+  const handleOpenDetail = useCallback(
+    (site: Site) => {
+      void navigate({ to: "/sites/$siteId", params: { siteId: site.id } });
+    },
+    [navigate],
+  );
+
   // ── Disconnect / Undo / Reconnect ─────────────────────────────────────────
 
   const revoke = useRevokeSite();
@@ -643,6 +653,7 @@ function SitesPage() {
           {disconnectedSites ? (
             <DisconnectedSitesPanel
               sites={disconnectedSites}
+              onOpenDetail={handleOpenDetail}
               onReconnect={operate ? handleReconnect : undefined}
               onRemove={operate ? handleRemove : undefined}
             />
@@ -758,6 +769,7 @@ function SitesPage() {
               sites={visibleSites}
               cardSize={cardSize}
               onOpenAutoLogin={autoLogin ? handleOpenAutoLogin : undefined}
+              onOpenDetail={handleOpenDetail}
               onDisconnect={operate ? handleDisconnect : undefined}
               onReconnect={operate ? handleReconnect : undefined}
             />
@@ -768,6 +780,7 @@ function SitesPage() {
               selection={operate ? selection : undefined}
               densityState={densityState}
               onOpenAutoLogin={autoLogin ? handleOpenAutoLogin : undefined}
+              onOpenDetail={handleOpenDetail}
               onDisconnect={operate ? handleDisconnect : undefined}
               onReconnect={operate ? handleReconnect : undefined}
             />
@@ -969,10 +982,12 @@ function AddSitePlaceholder() {
  */
 function DisconnectedSitesPanel({
   sites,
+  onOpenDetail,
   onReconnect,
   onRemove,
 }: {
   sites: Site[];
+  onOpenDetail?: (site: Site) => void;
   onReconnect?: (site: Site) => void;
   onRemove?: (site: Site) => void;
 }) {
@@ -990,6 +1005,7 @@ function DisconnectedSitesPanel({
       <SitesTable
         sites={sites}
         isLoading={false}
+        onOpenDetail={onOpenDetail}
         onReconnect={onReconnect}
         onRemove={onRemove}
       />

--- a/apps/web/src/routes/_authed/uptime.tsx
+++ b/apps/web/src/routes/_authed/uptime.tsx
@@ -17,6 +17,8 @@ import {
   Globe,
   ShieldCheck,
   AlertCircle,
+  Clock,
+  Timer,
 } from "lucide-react";
 import type { ColumnDef } from "@tanstack/react-table";
 
@@ -40,6 +42,10 @@ import {
   useFleetStatus,
   useFleetIncidents,
 } from "@/features/fleet/use-fleet-uptime";
+import {
+  isIncidentOngoing,
+  formatIncidentDuration,
+} from "@/features/fleet/incident-format";
 import type {
   FleetStatusItem,
   FleetIncident,
@@ -353,8 +359,8 @@ function IncidentsPanel({
   isError: boolean;
   incidents: FleetIncident[];
 }) {
-  const open = incidents.filter((i) => i.ongoing);
-  const closed = incidents.filter((i) => !i.ongoing).slice(0, 10);
+  const open = incidents.filter((i) => isIncidentOngoing(i));
+  const closed = incidents.filter((i) => !isIncidentOngoing(i)).slice(0, 10);
 
   return (
     <section aria-labelledby="incidents-heading" className="space-y-3">
@@ -418,15 +424,13 @@ function IncidentList({ incidents }: { incidents: FleetIncident[] }) {
       className="divide-y divide-[var(--color-border)] rounded-lg border border-[var(--color-border)]"
     >
       {incidents.map((inc) => {
-        const durSeconds = inc.duration_seconds;
-        const durLabel =
-          durSeconds === null
-            ? "ongoing"
-            : durSeconds < 60
-              ? `${durSeconds}s`
-              : durSeconds < 3600
-                ? `${Math.round(durSeconds / 60)}m`
-                : `${(durSeconds / 3600).toFixed(1)}h`;
+        // Ongoing decision is hardened off the reliable `ongoing` boolean
+        // (falling back to a finite-duration check), NEVER off
+        // `duration_seconds === null` alone — a missing/malformed duration
+        // must never render as a fabricated "NaNh" (GH #148).
+        const ongoing = isIncidentOngoing(inc);
+        const durationLabel = formatIncidentDuration(inc.duration_seconds, ongoing);
+        const startedLabel = `started ${relativeTime(inc.started_at) ?? inc.started_at}`;
 
         return (
           <div
@@ -437,27 +441,43 @@ function IncidentList({ incidents }: { incidents: FleetIncident[] }) {
             <span
               className={cn(
                 "inline-flex items-center gap-1 font-medium",
-                inc.ongoing
+                ongoing
                   ? "text-[var(--color-destructive-subtle-fg)]"
                   : "text-[var(--color-muted-foreground)]",
               )}
             >
-              {inc.ongoing ? (
+              {ongoing ? (
                 <XCircle aria-hidden="true" className="size-3.5 shrink-0" />
               ) : (
                 <CheckCircle2 aria-hidden="true" className="size-3.5 shrink-0" />
               )}
               {inc.kind === "down" ? "Down" : "Degraded"}
             </span>
-            <span className="font-medium text-[var(--color-foreground)]">
+            {/* Lightweight drill-in: reuse the same Link-to-detail pattern as
+                the fleet Sites table's "Site" column (see buildColumns above)
+                so the name/url stays the click target and is keyboard/a11y
+                navigable — no modal (there's no persisted incident history
+                to show one). */}
+            <Link
+              to="/sites/$siteId"
+              params={{ siteId: inc.site_id }}
+              className="font-medium text-[var(--color-foreground)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+            >
               {inc.name || inc.url}
+            </Link>
+            {/* Both time values are labeled so they never read as two bare
+                unlabeled timestamps (GH #148): "started X ago[, ongoing]"
+                and, for resolved incidents only, "for Xh/Xm/Xs". */}
+            <span className="inline-flex items-center gap-1 text-[var(--color-muted-foreground)]">
+              <Clock aria-hidden="true" className="size-3 shrink-0" />
+              {ongoing ? `${startedLabel}, ongoing` : startedLabel}
             </span>
-            <span className="text-[var(--color-muted-foreground)]">
-              {relativeTime(inc.started_at) ?? inc.started_at}
-            </span>
-            <span className="ml-auto tabular-nums text-[var(--color-muted-foreground)]">
-              {durLabel}
-            </span>
+            {!ongoing && durationLabel ? (
+              <span className="ml-auto inline-flex items-center gap-1 tabular-nums text-[var(--color-muted-foreground)]">
+                <Timer aria-hidden="true" className="size-3 shrink-0" />
+                for {durationLabel}
+              </span>
+            ) : null}
           </div>
         );
       })}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -3,6 +3,14 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
+  /* Tells the UA which palette native controls should render with (select
+     option popups, date/time pickers, scrollbars, form-field chrome). Theme
+     is driven by the `.dark` class on <html> (see lib/theme-store.ts), so
+     this must be set here AND overridden in `.dark` below - without it a
+     native <select>'s expanded option list falls back to the OS light
+     default even when the rest of the app is dark (GH #150). */
+  color-scheme: light;
+
   /* Surfaces - tinted neutrals at hue 195, chroma 0.008 */
   --background:         oklch(99%   0.004 195);
   --foreground:         oklch(18%   0.012 195);
@@ -59,6 +67,8 @@
 }
 
 .dark {
+  color-scheme: dark;
+
   --background:         oklch(15%   0.012 195);
   --foreground:         oklch(94%   0.008 195);
   --card:               oklch(19%   0.014 195);


### PR DESCRIPTION
#148: incidents DTO contract fixes — add kind='down' (was always 'Degraded'), null duration for open incidents (was 'NaNh'), name/url tags (were site_name/site_url, blank name); + contract test; web hardens ongoing + labels the times + row links to the site. #150: dark-mode select options, breadcrumb 404s on routeless parents, dead 'Open site' action. api + web.

Closes #148
Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU