### PR TITLE
feat(uptime): persist incidents + incident-detail drill-in modal (GH #148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.30] - 2026-07-07
+
+### Added
+
+- Uptime incidents are now recorded and kept, so the Incidents panel shows real history: past incidents with accurate durations and a flapping indicator for sites that go down repeatedly. Previously the panel was derived from current state only and forgot an incident the moment a site recovered. Clicking an incident opens a detail view with the site's live status, the probe result sequence over the incident window, a timeline of what else happened on the site around that time (recent updates, backups, activity, and PHP errors), uptime over 7 and 30 days, and quick actions (log in to the site, re-check the connection, run diagnostics, and links to the site's Health, Backups, Updates, Activity, and Errors tabs). Incident history starts accruing from this release.
+
 ## [0.61.29] - 2026-07-07
 
 ### Fixed

--- a/apps/api/db/query/alerts.sql
+++ b/apps/api/db/query/alerts.sql
@@ -58,6 +58,62 @@ SET tenant_id        = EXCLUDED.tenant_id,
 RETURNING *;
 
 -- ---------------------------------------------------------------------------
+-- site_incidents (M94 — GH #148: persisted incident history, written
+-- alongside site_alert_state inside TransitionAlertState).
+-- ---------------------------------------------------------------------------
+
+-- name: OpenIncident :exec
+-- Opens a new incident row for a site. Called from TransitionAlertState
+-- (app.agent GUC) on a FireDown transition (started_at = now()), and
+-- defensively on the "adopt" path when the alert state is already in_incident
+-- but no open site_incidents row exists yet — e.g. a site that was already
+-- down when m94 shipped and is not covered by the migration's day-1 seed, or
+-- a lost FireDown (started_at = the state's last_alert_at in that case). The
+-- partial unique index site_incidents_one_open_per_site makes this
+-- idempotent: if an incident is already open for the site, the insert is a
+-- silent no-op.
+INSERT INTO site_incidents (tenant_id, site_id, started_at, peak_status, last_http_status, reason, opened_by)
+VALUES (@tenant_id, @site_id, @started_at, 'down', @last_http_status, @reason, 'probe')
+ON CONFLICT (site_id) WHERE ended_at IS NULL DO NOTHING;
+
+-- name: CloseIncident :exec
+-- Closes the open incident for a site on a FireRecovery transition
+-- (app.agent GUC, called from the same TransitionAlertState transaction as
+-- OpenIncident above). A no-op (0 rows affected) if no incident is open,
+-- which is defensive only — FireRecovery only ever fires when prev.InIncident
+-- was true, so a matching open row should already exist.
+UPDATE site_incidents
+SET ended_at = now(), last_http_status = @last_http_status, updated_at = now()
+WHERE site_id = @site_id AND ended_at IS NULL;
+
+-- name: GetIncidentByID :one
+-- Tenant-scoped read of one incident, joined with its site's name/url, for
+-- GET /api/v1/fleet/incidents/:incidentId (InTenantTx). RLS additionally
+-- scopes this by tenant_id; the explicit predicate here is defense-in-depth +
+-- index use (site_incidents_tenant_started_idx), matching project convention.
+SELECT
+    si.id,
+    si.site_id,
+    si.started_at,
+    si.ended_at,
+    si.peak_status,
+    si.last_http_status,
+    si.reason,
+    s.name AS site_name,
+    s.url  AS site_url
+FROM site_incidents si
+JOIN sites s ON s.id = si.site_id AND s.tenant_id = si.tenant_id
+WHERE si.id = @id AND si.tenant_id = @tenant_id;
+
+-- name: CountRecentIncidents :one
+-- 30-day flapping count for the incident-detail endpoint: how many incidents
+-- (open or closed) have STARTED for this site in the last 30 days, including
+-- the incident being viewed itself.
+SELECT count(*) FROM site_incidents
+WHERE site_id = @site_id AND tenant_id = @tenant_id
+  AND started_at >= now() - interval '30 days';
+
+-- ---------------------------------------------------------------------------
 -- Fleet uptime queries (implemented as raw SQL in uptime/repo.go because the
 -- LEFT JOIN LATERAL probe columns are nullable and sqlc cannot model that
 -- correctly for the bool/time.Time scalar columns; follows the GetFleetDbHealth
@@ -75,12 +131,15 @@ RETURNING *;
 --   WHERE s.tenant_id = $1 AND s.id = ANY($2::uuid[])
 --   ORDER BY s.name ASC;
 --
--- FleetUptimeIncidents (InTenantTx, tenant-scoped):
---   SELECT s.id, s.name, s.url, ast.last_status, ast.last_alert_at, ast.updated_at, p.total_ms
---   FROM site_alert_state ast
---   JOIN sites s ON s.id = ast.site_id AND s.tenant_id = ast.tenant_id
+-- GetFleetIncidents (InTenantTx, tenant-scoped) — reads site_incidents
+-- directly (M94), not site_alert_state: real persisted incident rows instead
+-- of an estimate derived from a single mutable transition-memory row.
+--   SELECT si.id, si.site_id, s.name, s.url, si.started_at, si.ended_at,
+--          si.last_http_status, (si.ended_at IS NULL) AS ongoing, p.total_ms
+--   FROM site_incidents si
+--   JOIN sites s ON s.id = si.site_id AND s.tenant_id = si.tenant_id
 --   LEFT JOIN LATERAL (latest probe) p ON true
---   WHERE ast.tenant_id = $1 AND s.id = ANY($2::uuid[])
---     AND (ast.in_incident = true OR ast.last_alert_at >= $3)
---   ORDER BY ast.last_alert_at DESC NULLS LAST LIMIT $4;
+--   WHERE si.tenant_id = $1 AND si.site_id = ANY($2::uuid[])
+--     AND (si.ended_at IS NULL OR si.started_at >= $3)
+--   ORDER BY si.started_at DESC LIMIT $4;
 -- ---------------------------------------------------------------------------

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -1307,6 +1307,85 @@ CREATE POLICY site_uptime_probes_agent ON site_uptime_probes
     WITH CHECK (current_setting('app.agent', true) = 'on');
 
 -- ---------------------------------------------------------------------------
+-- site_incidents  (M94 — GH #148: persisted incident history)
+-- ---------------------------------------------------------------------------
+-- One row PER INCIDENT (open or closed), keyed by its own uuid id — unlike
+-- site_alert_state above (which stores only the CURRENT transition memory),
+-- this table lets the fleet incidents list and the per-incident detail
+-- endpoint read real history instead of estimating ended_at/duration from a
+-- single mutable row. Written ALONGSIDE site_alert_state inside the same
+-- TransitionAlertState transaction (internal/uptime/repo.go); the state
+-- machine's de-dupe logic (Evaluate in alerts.go) is unchanged.
+--
+-- ended_at IS NULL means the incident is open/ongoing. tenant_id is
+-- denormalized (mirrors site_alert_state) for a join-free RLS policy and
+-- join-free tenant-scoped queries.
+CREATE TABLE site_incidents (
+    id               uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id        uuid        NOT NULL REFERENCES tenants (id) ON DELETE CASCADE,
+    site_id          uuid        NOT NULL REFERENCES sites   (id) ON DELETE CASCADE,
+    started_at       timestamptz NOT NULL DEFAULT now(),
+    ended_at         timestamptz,
+    -- peak_status is reserved for a future degraded-vs-down incident severity
+    -- distinction; the alert state machine only ever opens a 'down' incident
+    -- today, so this is always 'down' for now.
+    peak_status      text        NOT NULL DEFAULT 'down',
+    last_http_status integer     NOT NULL DEFAULT 0,
+    -- probe_count/down_count are reserved rollup counters, not yet populated.
+    probe_count      integer     NOT NULL DEFAULT 0,
+    down_count       integer     NOT NULL DEFAULT 0,
+    -- opened_by distinguishes a real probe-detected incident ('probe') from
+    -- the m94 day-1 backfill of already-open incidents ('seed').
+    opened_by        text        NOT NULL DEFAULT 'probe',
+    reason           text        NOT NULL DEFAULT '',
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX site_incidents_site_started_idx ON site_incidents (site_id, started_at DESC);
+CREATE INDEX site_incidents_tenant_started_idx ON site_incidents (tenant_id, started_at DESC);
+
+-- Race-safety guard: at most one OPEN incident per site (mirrors m75's
+-- backup_snapshots_one_inflight_per_site). The state machine only ever
+-- transitions one site's alert state under a row lock, so this is
+-- belt-and-suspenders, not the primary defense.
+CREATE UNIQUE INDEX site_incidents_one_open_per_site ON site_incidents (site_id)
+    WHERE ended_at IS NULL;
+
+ALTER TABLE site_incidents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE site_incidents FORCE ROW LEVEL SECURITY;
+CREATE POLICY site_incidents_tenant_isolation ON site_incidents
+    USING (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid)
+    WITH CHECK (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid);
+
+-- The probe worker opens/closes incidents cross-tenant inside the same
+-- TransitionAlertState transaction that writes site_alert_state (app.agent).
+CREATE POLICY site_incidents_agent ON site_incidents
+    USING (current_setting('app.agent', true) = 'on')
+    WITH CHECK (current_setting('app.agent', true) = 'on');
+
+-- m19 AS RESTRICTIVE collaborator site-scope policy (mirrors
+-- site_alert_state_site_scope verbatim — site_id is a direct column here too).
+CREATE POLICY site_incidents_site_scope ON site_incidents
+    AS RESTRICTIVE FOR ALL
+    USING (
+        coalesce(current_setting('app.site_scope', true), '') <> 'on'
+        OR site_id = ANY (
+            string_to_array(
+                nullif(current_setting('app.allowed_site_ids', true), ''), ','
+            )::uuid[]
+        )
+    )
+    WITH CHECK (
+        coalesce(current_setting('app.site_scope', true), '') <> 'on'
+        OR site_id = ANY (
+            string_to_array(
+                nullif(current_setting('app.allowed_site_ids', true), ''), ','
+            )::uuid[]
+        )
+    );
+
+-- ---------------------------------------------------------------------------
 -- autologin_tokens  (Phase 5.5 — One-Click Login)
 -- ---------------------------------------------------------------------------
 -- An operator-minted, single-use, short-TTL nonce that materializes as an

--- a/apps/api/internal/db/sqlc/alerts.sql.go
+++ b/apps/api/internal/db/sqlc/alerts.sql.go
@@ -7,10 +7,53 @@ package sqlc
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+const closeIncident = `-- name: CloseIncident :exec
+UPDATE site_incidents
+SET ended_at = now(), last_http_status = $1, updated_at = now()
+WHERE site_id = $2 AND ended_at IS NULL
+`
+
+type CloseIncidentParams struct {
+	LastHttpStatus int32     `json:"last_http_status"`
+	SiteID         uuid.UUID `json:"site_id"`
+}
+
+// Closes the open incident for a site on a FireRecovery transition
+// (app.agent GUC, called from the same TransitionAlertState transaction as
+// OpenIncident above). A no-op (0 rows affected) if no incident is open,
+// which is defensive only — FireRecovery only ever fires when prev.InIncident
+// was true, so a matching open row should already exist.
+func (q *Queries) CloseIncident(ctx context.Context, arg CloseIncidentParams) error {
+	_, err := q.db.Exec(ctx, closeIncident, arg.LastHttpStatus, arg.SiteID)
+	return err
+}
+
+const countRecentIncidents = `-- name: CountRecentIncidents :one
+SELECT count(*) FROM site_incidents
+WHERE site_id = $1 AND tenant_id = $2
+  AND started_at >= now() - interval '30 days'
+`
+
+type CountRecentIncidentsParams struct {
+	SiteID   uuid.UUID `json:"site_id"`
+	TenantID uuid.UUID `json:"tenant_id"`
+}
+
+// 30-day flapping count for the incident-detail endpoint: how many incidents
+// (open or closed) have STARTED for this site in the last 30 days, including
+// the incident being viewed itself.
+func (q *Queries) CountRecentIncidents(ctx context.Context, arg CountRecentIncidentsParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countRecentIncidents, arg.SiteID, arg.TenantID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
 
 const getAlertConfig = `-- name: GetAlertConfig :one
 
@@ -33,6 +76,60 @@ func (q *Queries) GetAlertConfig(ctx context.Context, tenantID uuid.UUID) (Alert
 		&i.NotifySecurity,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getIncidentByID = `-- name: GetIncidentByID :one
+SELECT
+    si.id,
+    si.site_id,
+    si.started_at,
+    si.ended_at,
+    si.peak_status,
+    si.last_http_status,
+    si.reason,
+    s.name AS site_name,
+    s.url  AS site_url
+FROM site_incidents si
+JOIN sites s ON s.id = si.site_id AND s.tenant_id = si.tenant_id
+WHERE si.id = $1 AND si.tenant_id = $2
+`
+
+type GetIncidentByIDParams struct {
+	ID       uuid.UUID `json:"id"`
+	TenantID uuid.UUID `json:"tenant_id"`
+}
+
+type GetIncidentByIDRow struct {
+	ID             uuid.UUID          `json:"id"`
+	SiteID         uuid.UUID          `json:"site_id"`
+	StartedAt      time.Time          `json:"started_at"`
+	EndedAt        pgtype.Timestamptz `json:"ended_at"`
+	PeakStatus     string             `json:"peak_status"`
+	LastHttpStatus int32              `json:"last_http_status"`
+	Reason         string             `json:"reason"`
+	SiteName       string             `json:"site_name"`
+	SiteUrl        string             `json:"site_url"`
+}
+
+// Tenant-scoped read of one incident, joined with its site's name/url, for
+// GET /api/v1/fleet/incidents/:incidentId (InTenantTx). RLS additionally
+// scopes this by tenant_id; the explicit predicate here is defense-in-depth +
+// index use (site_incidents_tenant_started_idx), matching project convention.
+func (q *Queries) GetIncidentByID(ctx context.Context, arg GetIncidentByIDParams) (GetIncidentByIDRow, error) {
+	row := q.db.QueryRow(ctx, getIncidentByID, arg.ID, arg.TenantID)
+	var i GetIncidentByIDRow
+	err := row.Scan(
+		&i.ID,
+		&i.SiteID,
+		&i.StartedAt,
+		&i.EndedAt,
+		&i.PeakStatus,
+		&i.LastHttpStatus,
+		&i.Reason,
+		&i.SiteName,
+		&i.SiteUrl,
 	)
 	return i, err
 }
@@ -123,6 +220,45 @@ func (q *Queries) ListAlertConfigsAllTenants(ctx context.Context) ([]AlertConfig
 		return nil, err
 	}
 	return items, nil
+}
+
+const openIncident = `-- name: OpenIncident :exec
+
+INSERT INTO site_incidents (tenant_id, site_id, started_at, peak_status, last_http_status, reason, opened_by)
+VALUES ($1, $2, $3, 'down', $4, $5, 'probe')
+ON CONFLICT (site_id) WHERE ended_at IS NULL DO NOTHING
+`
+
+type OpenIncidentParams struct {
+	TenantID       uuid.UUID `json:"tenant_id"`
+	SiteID         uuid.UUID `json:"site_id"`
+	StartedAt      time.Time `json:"started_at"`
+	LastHttpStatus int32     `json:"last_http_status"`
+	Reason         string    `json:"reason"`
+}
+
+// ---------------------------------------------------------------------------
+// site_incidents (M94 — GH #148: persisted incident history, written
+// alongside site_alert_state inside TransitionAlertState).
+// ---------------------------------------------------------------------------
+// Opens a new incident row for a site. Called from TransitionAlertState
+// (app.agent GUC) on a FireDown transition (started_at = now()), and
+// defensively on the "adopt" path when the alert state is already in_incident
+// but no open site_incidents row exists yet — e.g. a site that was already
+// down when m94 shipped and is not covered by the migration's day-1 seed, or
+// a lost FireDown (started_at = the state's last_alert_at in that case). The
+// partial unique index site_incidents_one_open_per_site makes this
+// idempotent: if an incident is already open for the site, the insert is a
+// silent no-op.
+func (q *Queries) OpenIncident(ctx context.Context, arg OpenIncidentParams) error {
+	_, err := q.db.Exec(ctx, openIncident,
+		arg.TenantID,
+		arg.SiteID,
+		arg.StartedAt,
+		arg.LastHttpStatus,
+		arg.Reason,
+	)
+	return err
 }
 
 const upsertAlertConfig = `-- name: UpsertAlertConfig :one

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -760,6 +760,22 @@ type SiteFileManager struct {
 	UpdatedAt         time.Time `json:"updated_at"`
 }
 
+type SiteIncident struct {
+	ID             uuid.UUID          `json:"id"`
+	TenantID       uuid.UUID          `json:"tenant_id"`
+	SiteID         uuid.UUID          `json:"site_id"`
+	StartedAt      time.Time          `json:"started_at"`
+	EndedAt        pgtype.Timestamptz `json:"ended_at"`
+	PeakStatus     string             `json:"peak_status"`
+	LastHttpStatus int32              `json:"last_http_status"`
+	ProbeCount     int32              `json:"probe_count"`
+	DownCount      int32              `json:"down_count"`
+	OpenedBy       string             `json:"opened_by"`
+	Reason         string             `json:"reason"`
+	CreatedAt      time.Time          `json:"created_at"`
+	UpdatedAt      time.Time          `json:"updated_at"`
+}
+
 type SiteObjectCacheConfig struct {
 	SiteID             uuid.UUID          `json:"site_id"`
 	TenantID           uuid.UUID          `json:"tenant_id"`

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -250,6 +250,12 @@ type Querier interface {
 	// two_factor_enabled is recomputed by the service after this call (it may
 	// remain true if WebAuthn credentials still exist).
 	ClearUserTOTPSecret(ctx context.Context, userID uuid.UUID) error
+	// Closes the open incident for a site on a FireRecovery transition
+	// (app.agent GUC, called from the same TransitionAlertState transaction as
+	// OpenIncident above). A no-op (0 rows affected) if no incident is open,
+	// which is defensive only — FireRecovery only ever fires when prev.InIncident
+	// was true, so a matching open row should already exist.
+	CloseIncident(ctx context.Context, arg CloseIncidentParams) error
 	CompleteBackupSnapshot(ctx context.Context, arg CompleteBackupSnapshotParams) (BackupSnapshot, error)
 	CompleteReport(ctx context.Context, arg CompleteReportParams) (GeneratedReport, error)
 	// Consume path (app.agent). Atomic single-shot UPDATE that wins exactly once
@@ -284,6 +290,10 @@ type Querier interface {
 	// (operator app.tenant_id OR public-enroll app.enroll) — see the function's
 	// own comment in schema.sql for the full rationale.
 	CountActiveSitesForBilling(ctx context.Context, tenantID uuid.UUID) (int64, error)
+	// 30-day flapping count for the incident-detail endpoint: how many incidents
+	// (open or closed) have STARTED for this site in the last 30 days, including
+	// the incident being viewed itself.
+	CountRecentIncidents(ctx context.Context, arg CountRecentIncidentsParams) (int64, error)
 	// Best-effort per-tenant in-flight task count, used by the parallelism guard so
 	// one tenant cannot saturate the worker pool. Runs in the tenant's RLS scope.
 	CountRunningTasksForTenant(ctx context.Context, tenantID uuid.UUID) (int64, error)
@@ -648,6 +658,11 @@ type Querier interface {
 	// Per-site stats for the digest [from, to] window. Returns top sites by failure
 	// count. Runs under InAgentTx.
 	GetFleetStatsBySite(ctx context.Context, arg GetFleetStatsBySiteParams) ([]GetFleetStatsBySiteRow, error)
+	// Tenant-scoped read of one incident, joined with its site's name/url, for
+	// GET /api/v1/fleet/incidents/:incidentId (InTenantTx). RLS additionally
+	// scopes this by tenant_id; the explicit predicate here is defense-in-depth +
+	// index use (site_incidents_tenant_started_idx), matching project convention.
+	GetIncidentByID(ctx context.Context, arg GetIncidentByIDParams) (GetIncidentByIDRow, error)
 	// By-id load for the per-site invitation management routes (revoke/regenerate).
 	// Tenant isolation is enforced by RLS; the handler additionally verifies
 	// site_id + scope against the path before mutating.
@@ -1498,6 +1513,20 @@ type Querier interface {
 	MarkUpdateTaskRunning(ctx context.Context, arg MarkUpdateTaskRunningParams) (UpdateTask, error)
 	// Activate + mark verified (used on self-serve activation and trusted bootstrap).
 	MarkUserEmailVerified(ctx context.Context, id uuid.UUID) error
+	// ---------------------------------------------------------------------------
+	// site_incidents (M94 — GH #148: persisted incident history, written
+	// alongside site_alert_state inside TransitionAlertState).
+	// ---------------------------------------------------------------------------
+	// Opens a new incident row for a site. Called from TransitionAlertState
+	// (app.agent GUC) on a FireDown transition (started_at = now()), and
+	// defensively on the "adopt" path when the alert state is already in_incident
+	// but no open site_incidents row exists yet — e.g. a site that was already
+	// down when m94 shipped and is not covered by the migration's day-1 seed, or
+	// a lost FireDown (started_at = the state's last_alert_at in that case). The
+	// partial unique index site_incidents_one_open_per_site makes this
+	// idempotent: if an incident is already open for the site, the insert is a
+	// silent no-op.
+	OpenIncident(ctx context.Context, arg OpenIncidentParams) error
 	// Enroll path (app.enroll GUC): resolve whether a presented code is site-bound
 	// (returns its site_id) WITHOUT consuming it, so /enroll can route between the
 	// site-first consume and the legacy create-at-enroll flow. Does not leak: only

--- a/apps/api/internal/metrics/metrics.go
+++ b/apps/api/internal/metrics/metrics.go
@@ -89,6 +89,17 @@ type Latest struct {
 	Found      bool
 }
 
+// ProbeSample is one raw probe result returned by QueryProbeWindow — the
+// per-incident probe timeline consumed by the fleet incident-detail endpoint
+// (GH #148 part 1).
+type ProbeSample struct {
+	ProbedAt   time.Time
+	Up         bool
+	HTTPStatus uint16
+	TotalMs    float64
+	Error      string
+}
+
 // FleetUptimeRow is the per-site aggregate returned by QueryFleetUptime.
 // All pointer fields are nil when the site has no probe data in the window.
 type FleetUptimeRow struct {
@@ -119,6 +130,15 @@ type Store interface {
 	// Always scoped to tenantID; siteIDs must belong to that tenant (the caller
 	// verifies ownership in Postgres before reaching this).
 	QueryFleetUptime(ctx context.Context, tenantID uuid.UUID, siteIDs []uuid.UUID, window time.Duration) (map[uuid.UUID]FleetUptimeRow, error)
+	// QueryProbeWindow returns up to limitN raw probe rows for one site within
+	// [from, to], most-recent-first — the probe timeline for the fleet
+	// incident-detail endpoint (GH #148 part 1). GRACEFUL DEGRADATION:
+	// returns an empty, non-nil slice (never an error) when the window has no
+	// data — retention-aged rows, a disabled ClickHouse backend, or a site
+	// with no probes in range — so the incident summary can still render
+	// without a timeline. Always scoped to tenantID; the caller verifies site
+	// ownership in Postgres before reaching this.
+	QueryProbeWindow(ctx context.Context, tenantID, siteID uuid.UUID, from, to time.Time, limitN int) ([]ProbeSample, error)
 }
 
 // chStore is the ClickHouse-backed metrics store (ADR-028). The original M5
@@ -405,6 +425,50 @@ GROUP BY site_id`, s.db),
 			row.AvgLatencyMs = avgLatency
 		}
 		out[siteID] = row
+	}
+	return out, rows.Err()
+}
+
+// QueryProbeWindow returns up to limitN raw probe rows for one site within
+// [from, to], most-recent-first (tenant-scoped). Returns an empty slice (no
+// error) when the store is disabled or the window has no data.
+func (s *chStore) QueryProbeWindow(ctx context.Context, tenantID, siteID uuid.UUID, from, to time.Time, limitN int) ([]ProbeSample, error) {
+	if !s.Enabled() {
+		return []ProbeSample{}, nil
+	}
+	if limitN <= 0 {
+		limitN = 40
+	}
+	rows, err := s.conn.Query(ctx, fmt.Sprintf(`
+SELECT checked_at, up, http_status, total_ms, error
+FROM %s.uptime_checks
+WHERE tenant_id = ? AND site_id = ? AND checked_at BETWEEN ? AND ?
+ORDER BY checked_at DESC
+LIMIT ?`, s.db), tenantID, siteID, chTime(from), chTime(to), limitN)
+	if err != nil {
+		return nil, fmt.Errorf("clickhouse probe window query: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]ProbeSample, 0, limitN)
+	for rows.Next() {
+		var (
+			checkedAt  time.Time
+			upU        uint8
+			httpStatus uint16
+			totalMs    float64
+			errStr     string
+		)
+		if err := rows.Scan(&checkedAt, &upU, &httpStatus, &totalMs, &errStr); err != nil {
+			return nil, fmt.Errorf("clickhouse probe window scan: %w", err)
+		}
+		out = append(out, ProbeSample{
+			ProbedAt:   checkedAt,
+			Up:         upU == 1,
+			HTTPStatus: httpStatus,
+			TotalMs:    totalMs,
+			Error:      errStr,
+		})
 	}
 	return out, rows.Err()
 }

--- a/apps/api/internal/metrics/postgres.go
+++ b/apps/api/internal/metrics/postgres.go
@@ -248,6 +248,52 @@ LEFT JOIN LATERAL (
 	return out, err
 }
 
+// QueryProbeWindow returns up to limitN raw probe rows for one site within
+// [from, to], most-recent-first (tenant-scoped, InAgentTx with an explicit
+// tenant_id predicate — same convention as every other pgStore method).
+// Returns an empty, non-nil slice (no error) when the window has no rows —
+// this is a plain SELECT, so zero matching rows is never a Postgres error;
+// the incident-detail service layer relies on this for graceful degradation.
+func (s *pgStore) QueryProbeWindow(ctx context.Context, tenantID, siteID uuid.UUID, from, to time.Time, limitN int) ([]ProbeSample, error) {
+	if limitN <= 0 {
+		limitN = 40
+	}
+	out := make([]ProbeSample, 0, limitN)
+	err := s.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+SELECT probed_at, up, http_status, total_ms, error_text
+FROM site_uptime_probes
+WHERE tenant_id = $1 AND site_id = $2 AND probed_at BETWEEN $3 AND $4
+ORDER BY probed_at DESC
+LIMIT $5`, tenantID, siteID, from, to, limitN)
+		if err != nil {
+			return fmt.Errorf("postgres probe window query: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var (
+				probedAt   time.Time
+				up         bool
+				httpStatus int32
+				totalMs    float64
+				errText    string
+			)
+			if err := rows.Scan(&probedAt, &up, &httpStatus, &totalMs, &errText); err != nil {
+				return fmt.Errorf("postgres probe window scan: %w", err)
+			}
+			out = append(out, ProbeSample{
+				ProbedAt:   probedAt,
+				Up:         up,
+				HTTPStatus: uint16(httpStatus),
+				TotalMs:    totalMs,
+				Error:      errText,
+			})
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
 // QuerySeries returns a downsampled per-bucket series for one site over the
 // window. Buckets are date_trunc-aligned: width = window/buckets rounded to
 // whole seconds (min 60s). We use to_timestamp(floor(extract(epoch))/W*W) to

--- a/apps/api/internal/site/uptime_cache.go
+++ b/apps/api/internal/site/uptime_cache.go
@@ -167,3 +167,10 @@ func (s *cachedMetricsStore) QueryFleetUptime(ctx context.Context, tenantID uuid
 	s.cache.set(key, result)
 	return result, nil
 }
+
+// QueryProbeWindow delegates unchanged (not cached — the incident-detail
+// endpoint is a low-traffic, single-incident lookup, not a repeated
+// dashboard-refresh path like QueryFleetUptime).
+func (s *cachedMetricsStore) QueryProbeWindow(ctx context.Context, tenantID, siteID uuid.UUID, from, to time.Time, limitN int) ([]metrics.ProbeSample, error) {
+	return s.inner.QueryProbeWindow(ctx, tenantID, siteID, from, to, limitN)
+}

--- a/apps/api/internal/site/uptime_cache_test.go
+++ b/apps/api/internal/site/uptime_cache_test.go
@@ -37,6 +37,9 @@ func (s *countingStore) QueryFleetUptime(_ context.Context, _ uuid.UUID, _ []uui
 	s.calls.Add(1)
 	return s.result, nil
 }
+func (s *countingStore) QueryProbeWindow(_ context.Context, _, _ uuid.UUID, _, _ time.Time, _ int) ([]metrics.ProbeSample, error) {
+	return nil, nil
+}
 
 func TestUptimeCache_Hit(t *testing.T) {
 	inner := &countingStore{result: map[uuid.UUID]metrics.FleetUptimeRow{}}

--- a/apps/api/internal/site/uptime_store_test.go
+++ b/apps/api/internal/site/uptime_store_test.go
@@ -51,6 +51,9 @@ func (s *uptimeStubStore) QuerySeries(_ context.Context, _, _ uuid.UUID, _ time.
 func (s *uptimeStubStore) QueryFleetUptime(_ context.Context, _ uuid.UUID, _ []uuid.UUID, _ time.Duration) (map[uuid.UUID]metrics.FleetUptimeRow, error) {
 	return s.uptimeMap, nil
 }
+func (s *uptimeStubStore) QueryProbeWindow(_ context.Context, _, _ uuid.UUID, _, _ time.Time, _ int) ([]metrics.ProbeSample, error) {
+	panic("site list must not call QueryProbeWindow")
+}
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/apps/api/internal/uptime/cron_kick_test.go
+++ b/apps/api/internal/uptime/cron_kick_test.go
@@ -33,7 +33,7 @@ func (r *fakeCronRepo) GetAlertState(_ context.Context, _ uuid.UUID) (AlertState
 func (r *fakeCronRepo) UpsertAlertState(_ context.Context, _ AlertState) error {
 	panic("CronKicker must not call UpsertAlertState")
 }
-func (r *fakeCronRepo) TransitionAlertState(_ context.Context, _, _ uuid.UUID, _ bool, _ int, _ time.Time) (Transition, error) {
+func (r *fakeCronRepo) TransitionAlertState(_ context.Context, _, _ uuid.UUID, _ bool, _ int, _ time.Time, _ int, _ string) (Transition, error) {
 	panic("CronKicker must not call TransitionAlertState")
 }
 func (r *fakeCronRepo) ListAlertConfigsAllTenants(_ context.Context) ([]AlertConfig, error) {
@@ -50,6 +50,12 @@ func (r *fakeCronRepo) GetFleetSiteInfo(_ context.Context, _ uuid.UUID, _ []uuid
 }
 func (r *fakeCronRepo) GetFleetIncidents(_ context.Context, _ uuid.UUID, _ []uuid.UUID, _ time.Time, _ int) ([]FleetIncidentItem, error) {
 	panic("CronKicker must not call GetFleetIncidents")
+}
+func (r *fakeCronRepo) GetIncidentByID(_ context.Context, _, _ uuid.UUID) (IncidentSummary, bool, error) {
+	panic("CronKicker must not call GetIncidentByID")
+}
+func (r *fakeCronRepo) CountRecentIncidents(_ context.Context, _, _ uuid.UUID) (int64, error) {
+	panic("CronKicker must not call CountRecentIncidents")
 }
 
 // TestCronKickFiresWPCronEndpoint verifies that the kicker fires a GET to

--- a/apps/api/internal/uptime/fleet_incidents_contract_test.go
+++ b/apps/api/internal/uptime/fleet_incidents_contract_test.go
@@ -30,6 +30,7 @@ func TestFleetIncidentItemJSONContract(t *testing.T) {
 	totalMs := 842.5
 
 	open := FleetIncidentItem{
+		ID:              uuid.New(),
 		SiteID:          uuid.New(),
 		Kind:            "down",
 		SiteName:        "Example Site",
@@ -42,6 +43,7 @@ func TestFleetIncidentItemJSONContract(t *testing.T) {
 	}
 	ended := now.Add(2 * time.Minute)
 	closed := FleetIncidentItem{
+		ID:              uuid.New(),
 		SiteID:          uuid.New(),
 		Kind:            "down",
 		SiteName:        "Example Site",
@@ -54,7 +56,7 @@ func TestFleetIncidentItemJSONContract(t *testing.T) {
 	}
 
 	requiredKeys := []string{
-		"site_id", "kind", "name", "url", "started_at", "ended_at",
+		"id", "site_id", "kind", "name", "url", "started_at", "ended_at",
 		"duration_seconds", "ongoing",
 	}
 

--- a/apps/api/internal/uptime/fleet_store_test.go
+++ b/apps/api/internal/uptime/fleet_store_test.go
@@ -31,7 +31,7 @@ func (r *stubRepo) GetAlertState(_ context.Context, _ uuid.UUID) (AlertState, bo
 	panic("not called")
 }
 func (r *stubRepo) UpsertAlertState(_ context.Context, _ AlertState) error { panic("not called") }
-func (r *stubRepo) TransitionAlertState(_ context.Context, _, _ uuid.UUID, _ bool, _ int, _ time.Time) (Transition, error) {
+func (r *stubRepo) TransitionAlertState(_ context.Context, _, _ uuid.UUID, _ bool, _ int, _ time.Time, _ int, _ string) (Transition, error) {
 	panic("not called")
 }
 func (r *stubRepo) ListAlertConfigsAllTenants(_ context.Context) ([]AlertConfig, error) {
@@ -47,6 +47,12 @@ func (r *stubRepo) GetFleetSiteInfo(_ context.Context, _ uuid.UUID, _ []uuid.UUI
 	return r.infos, nil
 }
 func (r *stubRepo) GetFleetIncidents(_ context.Context, _ uuid.UUID, _ []uuid.UUID, _ time.Time, _ int) ([]FleetIncidentItem, error) {
+	panic("not called")
+}
+func (r *stubRepo) GetIncidentByID(_ context.Context, _, _ uuid.UUID) (IncidentSummary, bool, error) {
+	panic("not called")
+}
+func (r *stubRepo) CountRecentIncidents(_ context.Context, _, _ uuid.UUID) (int64, error) {
 	panic("not called")
 }
 
@@ -72,6 +78,9 @@ func (s *stubStore) QuerySeries(_ context.Context, _, _ uuid.UUID, _ time.Durati
 }
 func (s *stubStore) QueryFleetUptime(_ context.Context, _ uuid.UUID, _ []uuid.UUID, _ time.Duration) (map[uuid.UUID]metrics.FleetUptimeRow, error) {
 	return s.uptimeMap, nil
+}
+func (s *stubStore) QueryProbeWindow(_ context.Context, _, _ uuid.UUID, _, _ time.Time, _ int) ([]metrics.ProbeSample, error) {
+	panic("not called")
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/uptime/handler.go
+++ b/apps/api/internal/uptime/handler.go
@@ -48,6 +48,10 @@ func (h *Handler) Register(r *gin.RouterGroup) {
 	// because site-scoped collaborators get a filtered view, not an error.
 	r.GET("/fleet/status", authz.RequirePermission(authz.PermSiteRead), h.fleetStatus)
 	r.GET("/fleet/incidents", authz.RequirePermission(authz.PermSiteRead), h.fleetIncidents)
+	// Incident detail: no :siteId param to gate via RequireSiteAccess, so a
+	// site-scoped principal's access is checked explicitly inside the handler
+	// (see incidentDetail) once the incident's site is known.
+	r.GET("/fleet/incidents/:incidentId", authz.RequirePermission(authz.PermSiteRead), h.incidentDetail)
 }
 
 func windowDuration(w string) (time.Duration, gen.UptimeStatusWindow) {
@@ -268,19 +272,14 @@ func (h *Handler) fleetStatus(c *gin.Context) {
 }
 
 // fleetIncidents handles GET /api/v1/fleet/incidents.
-// Returns open incidents and recently-alerted sites.
+// Returns open incidents and incidents that started within the requested
+// window, read from the persisted site_incidents table (M94, GH #148).
 //
 // Query params:
 //
 //	since — RFC 3339 timestamp; defaults to 7 days ago. Controls the
-//	         "recently-alerted" window for closed incidents.
+//	         "recently started" window for closed incidents.
 //	limit — max 100, default 100.
-//
-// NOTE: Full historical incident reconstruction is NOT possible from
-// site_alert_state, which stores only current transition memory. This endpoint
-// returns open incidents (in_incident=true) and derivable recoveries
-// (last_alert_at >= since). ended_at/duration_seconds are estimated from
-// updated_at, not from a true incident-close record.
 func (h *Handler) fleetIncidents(c *gin.Context) {
 	tenantID, ok := domain.TenantIDFromContext(c.Request.Context())
 	if !ok {
@@ -317,6 +316,49 @@ func (h *Handler) fleetIncidents(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"items": items})
+}
+
+// incidentDetail handles GET /api/v1/fleet/incidents/:incidentId (M94, GH
+// #148 part 1): the incident summary, a probe timeline over its window, and
+// its 30-day flapping count. The incident summary is fetched FIRST so a
+// site-scoped principal can be denied (404, to avoid leaking existence —
+// mirrors RequireSiteAccess's own not-found response) before any metrics-
+// store round-trip is spent building the rest of the response.
+func (h *Handler) incidentDetail(c *gin.Context) {
+	tenantID, ok := domain.TenantIDFromContext(c.Request.Context())
+	if !ok {
+		httpx.Error(c, domain.Forbidden("tenant_required", "a tenant context is required"))
+		return
+	}
+	incidentID, err := uuid.Parse(c.Param("incidentId"))
+	if err != nil {
+		httpx.Error(c, domain.Validation("invalid_incident_id", "incidentId is not a valid UUID"))
+		return
+	}
+
+	summary, err := h.svc.GetIncidentSummary(c.Request.Context(), tenantID, incidentID)
+	if err != nil {
+		httpx.Error(c, err)
+		return
+	}
+
+	// Site-scoped collaborators only see incidents for their granted sites
+	// (mirrors the summary handler's allowlist filter above); a denied lookup
+	// reads as not-found, never a different-error signal that would confirm
+	// the incident's existence.
+	if p, ok := domain.PrincipalFromContext(c.Request.Context()); ok && p.Scope == domain.ScopeSite {
+		if !p.CanAccessSite(summary.SiteID) {
+			httpx.Error(c, domain.NotFound("incident_not_found", "incident not found"))
+			return
+		}
+	}
+
+	detail, err := h.svc.GetIncidentDetail(c.Request.Context(), tenantID, summary)
+	if err != nil {
+		httpx.Error(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, detail)
 }
 
 // parseInt is a minimal helper for query-param int parsing in handler methods

--- a/apps/api/internal/uptime/incident_detail_contract_test.go
+++ b/apps/api/internal/uptime/incident_detail_contract_test.go
@@ -1,0 +1,136 @@
+package uptime
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TestIncidentDetailJSONContract locks the JSON field names + null-vs-omitted
+// discipline of the incident-detail response (GET
+// /api/v1/fleet/incidents/:incidentId, M94/GH #148 part 1) to the frontend
+// contract (apps/web/src/features/fleet/fleet-types.ts IncidentDetail). An
+// OPEN incident must marshal ended_at/duration_seconds as explicit `null`,
+// mirroring the FleetIncidentItem fix (see TestFleetIncidentItemJSONContract)
+// — the same omitted-vs-null bug class would otherwise recur here — and
+// probes must always be `[]`, never `null`, even when the metrics store
+// returned no data for the window (graceful degradation: an empty timeline
+// must not become an omitted/null key that breaks a `.map()` on the client).
+func TestIncidentDetailJSONContract(t *testing.T) {
+	started := time.Now().UTC().Add(-10 * time.Minute)
+
+	requiredKeys := []string{
+		"id", "site_id", "name", "url", "started_at", "ended_at",
+		"duration_seconds", "ongoing", "peak_status", "last_http_status",
+		"reason", "incident_count_30d", "probes", "probes_truncated",
+	}
+
+	t.Run("open incident", func(t *testing.T) {
+		open := IncidentDetail{
+			ID:               uuid.New(),
+			SiteID:           uuid.New(),
+			Name:             "Example Site",
+			URL:              "https://example.com",
+			StartedAt:        started,
+			EndedAt:          nil,
+			DurationSeconds:  nil,
+			Ongoing:          true,
+			PeakStatus:       "down",
+			LastHTTPStatus:   500,
+			Reason:           "http status 500",
+			IncidentCount30d: 3,
+			Probes:           []IncidentProbe{},
+			ProbesTruncated:  false,
+		}
+
+		b, err := json.Marshal(open)
+		if err != nil {
+			t.Fatalf("marshal open IncidentDetail: %v", err)
+		}
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(b, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		for _, k := range requiredKeys {
+			if _, ok := m[k]; !ok {
+				t.Errorf("open IncidentDetail JSON missing contract key %q (got keys %v)", k, keysOf(m))
+			}
+		}
+		if raw, ok := m["ended_at"]; !ok {
+			t.Errorf("open IncidentDetail: ended_at key omitted entirely (want present + null)")
+		} else if string(raw) != "null" {
+			t.Errorf("open IncidentDetail: ended_at = %s, want null", raw)
+		}
+		if raw, ok := m["duration_seconds"]; !ok {
+			t.Errorf("open IncidentDetail: duration_seconds key omitted entirely (want present + null)")
+		} else if string(raw) != "null" {
+			t.Errorf("open IncidentDetail: duration_seconds = %s, want null", raw)
+		}
+		if string(m["probes"]) != "[]" {
+			t.Errorf("open IncidentDetail: probes = %s, want [] (never null, even with an empty metrics window)", m["probes"])
+		}
+		if got := string(m["ongoing"]); got != "true" {
+			t.Errorf("open IncidentDetail: ongoing = %s, want true", got)
+		}
+	})
+
+	t.Run("closed incident", func(t *testing.T) {
+		ended := started.Add(5 * time.Minute)
+		dur := int64(300)
+		closed := IncidentDetail{
+			ID:               uuid.New(),
+			SiteID:           uuid.New(),
+			Name:             "Example Site",
+			URL:              "https://example.com",
+			StartedAt:        started,
+			EndedAt:          &ended,
+			DurationSeconds:  &dur,
+			Ongoing:          false,
+			PeakStatus:       "down",
+			LastHTTPStatus:   200,
+			Reason:           "",
+			IncidentCount30d: 1,
+			Probes: []IncidentProbe{
+				{ProbedAt: started, Up: false, HTTPStatus: 500, TotalMs: 120.5, Error: "http status 500"},
+				{ProbedAt: ended, Up: true, HTTPStatus: 200, TotalMs: 80.0},
+			},
+			ProbesTruncated: false,
+		}
+
+		b, err := json.Marshal(closed)
+		if err != nil {
+			t.Fatalf("marshal closed IncidentDetail: %v", err)
+		}
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(b, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		for _, k := range requiredKeys {
+			if _, ok := m[k]; !ok {
+				t.Errorf("closed IncidentDetail JSON missing contract key %q (got keys %v)", k, keysOf(m))
+			}
+		}
+		if string(m["ended_at"]) == "null" {
+			t.Errorf("closed IncidentDetail: ended_at should not be null")
+		}
+		if string(m["duration_seconds"]) == "null" {
+			t.Errorf("closed IncidentDetail: duration_seconds should not be null")
+		}
+
+		var probes []map[string]json.RawMessage
+		if err := json.Unmarshal(m["probes"], &probes); err != nil {
+			t.Fatalf("unmarshal probes: %v", err)
+		}
+		if len(probes) != 2 {
+			t.Fatalf("expected 2 probes, got %d", len(probes))
+		}
+		if _, ok := probes[0]["error"]; !ok {
+			t.Errorf("a down probe's non-empty error must be present, not omitted")
+		}
+		if _, ok := probes[1]["error"]; ok {
+			t.Errorf("a healthy probe's empty error must be omitted entirely, got %s", probes[1]["error"])
+		}
+	})
+}

--- a/apps/api/internal/uptime/model.go
+++ b/apps/api/internal/uptime/model.go
@@ -123,14 +123,10 @@ type FleetSiteInfo struct {
 	InIncident      bool
 }
 
-// FleetIncidentItem is one open or recently-closed incident for the incidents endpoint.
-// NOTE: Full historical incident reconstruction is NOT possible from site_alert_state:
-// site_alert_state stores only the CURRENT transition memory (last_status,
-// consecutive_down, in_incident, last_alert_at). Past closed incidents are not
-// persisted. This endpoint returns open incidents (in_incident=true) and
-// recently-alerted sites (last_alert_at >= since). Calling code must treat
-// ended_at / duration_seconds as estimates (derived from updated_at on the
-// alert-state row, not from a true incident-close timestamp).
+// FleetIncidentItem is one open or recently-started incident for the fleet
+// incidents endpoint, read from the persisted site_incidents table (M94, GH
+// #148) — real incident rows, not an estimate derived from site_alert_state's
+// single mutable transition-memory row.
 //
 // JSON field names are pinned to the frontend contract consumed by the fleet
 // incidents panel (GH #148) — do not rename without updating both sides.
@@ -140,6 +136,9 @@ type FleetSiteInfo struct {
 // (an omitted key deserializes to `undefined`, not `null`, and produced
 // "NaNh" duration on open incidents).
 type FleetIncidentItem struct {
+	// ID is the site_incidents row id — the web uses it to open the
+	// incident-detail modal (GET /api/v1/fleet/incidents/:incidentId).
+	ID     uuid.UUID `json:"id"`
 	SiteID uuid.UUID `json:"site_id"`
 	// Kind is always "down": the alert state machine (see Evaluate in
 	// alerts.go) opens an incident only on a down-threshold crossing —
@@ -153,6 +152,65 @@ type FleetIncidentItem struct {
 	DurationSeconds *int64     `json:"duration_seconds"`
 	Ongoing         bool       `json:"ongoing"`
 	LatestTotalMs   *float64   `json:"latest_total_ms,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// Incident detail (GET /api/v1/fleet/incidents/:incidentId, GH #148 part 1)
+// ---------------------------------------------------------------------------
+
+// IncidentSummary is the tenant-scoped site_incidents row (joined with its
+// site's name/url) returned by Repo.GetIncidentByID, WITHOUT the probe
+// timeline. The handler authorizes a site-scoped principal against
+// SiteID BEFORE spending a metrics-store round-trip building the full detail.
+type IncidentSummary struct {
+	ID             uuid.UUID
+	SiteID         uuid.UUID
+	SiteName       string
+	SiteURL        string
+	StartedAt      time.Time
+	EndedAt        *time.Time
+	PeakStatus     string
+	LastHTTPStatus int
+	Reason         string
+}
+
+// IncidentProbe is one raw probe result in the incident-detail timeline
+// (sourced from metrics.Store.QueryProbeWindow). JSON field names are PINNED
+// to the frontend incident-detail contract (GH #148) — do not rename without
+// updating both sides. Error omits when empty (a healthy probe carries none).
+type IncidentProbe struct {
+	ProbedAt   time.Time `json:"probed_at"`
+	Up         bool      `json:"up"`
+	HTTPStatus int       `json:"http_status"`
+	TotalMs    float64   `json:"total_ms"`
+	Error      string    `json:"error,omitempty"`
+}
+
+// IncidentDetail is the response body for
+// GET /api/v1/fleet/incidents/:incidentId. JSON field names are PINNED to the
+// frontend incident-detail contract (GH #148) — do not rename without
+// updating both sides. EndedAt/DurationSeconds do NOT use `omitempty`,
+// mirroring FleetIncidentItem: an ongoing incident must marshal explicit
+// `null`, not an omitted key (see FleetIncidentItem's doc comment for the
+// client-side bug class this avoids). Probes is never nil — a metrics-store
+// window with no data (retention-aged, disabled backend, or a site with no
+// probes yet) still yields an empty slice, not an omitted/null key, and the
+// incident summary is always present regardless (graceful degradation).
+type IncidentDetail struct {
+	ID               uuid.UUID       `json:"id"`
+	SiteID           uuid.UUID       `json:"site_id"`
+	Name             string          `json:"name"`
+	URL              string          `json:"url"`
+	StartedAt        time.Time       `json:"started_at"`
+	EndedAt          *time.Time      `json:"ended_at"`
+	DurationSeconds  *int64          `json:"duration_seconds"`
+	Ongoing          bool            `json:"ongoing"`
+	PeakStatus       string          `json:"peak_status"`
+	LastHTTPStatus   int             `json:"last_http_status"`
+	Reason           string          `json:"reason"`
+	IncidentCount30d int             `json:"incident_count_30d"`
+	Probes           []IncidentProbe `json:"probes"`
+	ProbesTruncated  bool            `json:"probes_truncated"`
 }
 
 // AlertKind distinguishes a downtime alert from a recovery alert.

--- a/apps/api/internal/uptime/repo.go
+++ b/apps/api/internal/uptime/repo.go
@@ -35,7 +35,15 @@ type Repo interface {
 	// the same site would each read the same stale ConsecutiveDown and never
 	// let it accumulate past 1, so the down threshold is never crossed and no
 	// alert ever fires — silently, with no error to log.
-	TransitionAlertState(ctx context.Context, siteID, tenantID uuid.UUID, up bool, threshold int, now time.Time) (Transition, error)
+	//
+	// It ALSO opens/closes the site's site_incidents row (M94, GH #148) in the
+	// SAME transaction as the alert-state write: a FireDown transition opens
+	// an incident, a FireRecovery transition closes it, and — defensively — a
+	// probe that observes the site already in_incident with neither flag set
+	// "adopts" (idempotently opens, a no-op if already open) an incident row
+	// in case one was somehow missed. httpStatus/reason carry the triggering
+	// probe's HTTP status and error text onto the incident row.
+	TransitionAlertState(ctx context.Context, siteID, tenantID uuid.UUID, up bool, threshold int, now time.Time, httpStatus int, reason string) (Transition, error)
 
 	// Evaluator path (app.agent GUC, cross-tenant).
 	ListAlertConfigsAllTenants(ctx context.Context) ([]AlertConfig, error)
@@ -53,9 +61,22 @@ type Repo interface {
 	// metrics.Store so both ClickHouse and Postgres deployments work correctly.
 	GetFleetSiteInfo(ctx context.Context, tenantID uuid.UUID, siteIDs []uuid.UUID) ([]FleetSiteInfo, error)
 
-	// GetFleetIncidents returns open incidents and recently-alerted sites.
-	// NOTE: full historical reconstruction is not possible — see FleetIncidentItem.
+	// GetFleetIncidents returns open incidents and incidents that started at or
+	// after `since`, read from the persisted site_incidents table (M94).
 	GetFleetIncidents(ctx context.Context, tenantID uuid.UUID, siteIDs []uuid.UUID, since time.Time, limit int) ([]FleetIncidentItem, error)
+
+	// GetIncidentByID returns one tenant-scoped incident (joined with its
+	// site's name/url) for the GET /api/v1/fleet/incidents/:incidentId detail
+	// endpoint. found=false (no error) when the id does not exist or belongs
+	// to another tenant (RLS + the explicit tenant_id predicate both enforce
+	// this — a foreign incident id reads as not-found, never a different
+	// tenant's data).
+	GetIncidentByID(ctx context.Context, tenantID, incidentID uuid.UUID) (IncidentSummary, bool, error)
+
+	// CountRecentIncidents returns how many incidents (open or closed) have
+	// started for siteID in the last 30 days — the "flapping" count surfaced
+	// on the incident-detail endpoint.
+	CountRecentIncidents(ctx context.Context, tenantID, siteID uuid.UUID) (int64, error)
 }
 
 type pgRepo struct {
@@ -136,7 +157,7 @@ func (r *pgRepo) UpsertAlertState(ctx context.Context, st AlertState) error {
 // transaction — so an overlapping sweep for the same site blocks on the SELECT
 // FOR UPDATE until this one commits, then observes the fresh state instead of
 // a stale one.
-func (r *pgRepo) TransitionAlertState(ctx context.Context, siteID, tenantID uuid.UUID, up bool, threshold int, now time.Time) (Transition, error) {
+func (r *pgRepo) TransitionAlertState(ctx context.Context, siteID, tenantID uuid.UUID, up bool, threshold int, now time.Time, httpStatus int, reason string) (Transition, error) {
 	var tr Transition
 	err := r.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
 		q := sqlc.New(tx)
@@ -170,6 +191,52 @@ func (r *pgRepo) TransitionAlertState(ctx context.Context, siteID, tenantID uuid
 			LastAlertAt:     toTimestamptz(tr.NewState.LastAlertAt),
 		}); err != nil {
 			return domain.Internal("uptime_upsert_state_failed", "failed to upsert site alert state").WithCause(err)
+		}
+
+		// M94 (GH #148): open/close the persisted site_incidents row in the
+		// SAME transaction as the alert-state write above, keyed off the
+		// Transition Evaluate already computed — never re-derive it here.
+		switch {
+		case tr.FireDown:
+			if err := q.OpenIncident(ctx, sqlc.OpenIncidentParams{
+				TenantID:       tenantID,
+				SiteID:         siteID,
+				StartedAt:      now,
+				LastHttpStatus: int32(httpStatus),
+				Reason:         reason,
+			}); err != nil {
+				return domain.Internal("uptime_open_incident_failed", "failed to open incident").WithCause(err)
+			}
+		case tr.FireRecovery:
+			if err := q.CloseIncident(ctx, sqlc.CloseIncidentParams{
+				SiteID:         siteID,
+				LastHttpStatus: int32(httpStatus),
+			}); err != nil {
+				return domain.Internal("uptime_close_incident_failed", "failed to close incident").WithCause(err)
+			}
+		case tr.NewState.InIncident:
+			// Adopt path: the state is already in_incident but neither flag
+			// fired on THIS probe (a steady-state down heartbeat, or a state
+			// this code never itself opened an incident row for — e.g. an
+			// alert-state row that predates m94 and fell outside the
+			// migration's day-1 seed window). started_at falls back to the
+			// state's LastAlertAt (the original down-alert timestamp) so an
+			// adopted incident's duration is accurate, not reset to now().
+			// OpenIncident's ON CONFLICT DO NOTHING makes this a safe no-op
+			// on every steady-state down probe once a row is already open.
+			startedAt := now
+			if tr.NewState.LastAlertAt != nil {
+				startedAt = *tr.NewState.LastAlertAt
+			}
+			if err := q.OpenIncident(ctx, sqlc.OpenIncidentParams{
+				TenantID:       tenantID,
+				SiteID:         siteID,
+				StartedAt:      startedAt,
+				LastHttpStatus: int32(httpStatus),
+				Reason:         reason,
+			}); err != nil {
+				return domain.Internal("uptime_adopt_incident_failed", "failed to adopt open incident").WithCause(err)
+			}
 		}
 		return nil
 	})
@@ -305,22 +372,23 @@ func deriveFleetStatus(up *bool, totalMs *float64, connectionState string) Fleet
 	return FleetStatusUp
 }
 
-// GetFleetIncidents returns open incidents and recently-alerted sites.
-// Open incidents: in_incident=true. Derivable recoveries: in_incident=false
-// AND last_alert_at >= since. Full historical incident logs are NOT stored;
-// ended_at is estimated from alert-state updated_at for closed incidents.
+// GetFleetIncidents returns open incidents (ended_at IS NULL) and incidents
+// that started at or after `since`, read directly from the persisted
+// site_incidents table (M94, GH #148) — real incident rows, not an estimate
+// derived from site_alert_state's single mutable transition-memory row.
 func (r *pgRepo) GetFleetIncidents(ctx context.Context, tenantID uuid.UUID, siteIDs []uuid.UUID, since time.Time, limit int) ([]FleetIncidentItem, error) {
 	const q = `
 SELECT
-    s.id,
+    si.id,
+    si.site_id,
     s.name,
     s.url,
-    ast.last_alert_at,
-    ast.updated_at,
-    ast.in_incident,
+    si.started_at,
+    si.ended_at,
+    (si.ended_at IS NULL) AS ongoing,
     p.total_ms
-FROM site_alert_state ast
-JOIN sites s ON s.id = ast.site_id AND s.tenant_id = ast.tenant_id
+FROM site_incidents si
+JOIN sites s ON s.id = si.site_id AND s.tenant_id = si.tenant_id
 LEFT JOIN LATERAL (
     SELECT total_ms
     FROM site_uptime_probes
@@ -328,10 +396,10 @@ LEFT JOIN LATERAL (
     ORDER BY probed_at DESC
     LIMIT 1
 ) p ON true
-WHERE ast.tenant_id = $1
-  AND s.id = ANY($2::uuid[])
-  AND (ast.in_incident = true OR ast.last_alert_at >= $3)
-ORDER BY ast.last_alert_at DESC NULLS LAST
+WHERE si.tenant_id = $1
+  AND si.site_id = ANY($2::uuid[])
+  AND (si.ended_at IS NULL OR si.started_at >= $3)
+ORDER BY si.started_at DESC
 LIMIT $4
 `
 	var out []FleetIncidentItem
@@ -343,39 +411,37 @@ LIMIT $4
 		defer rows.Close()
 		for rows.Next() {
 			var (
-				siteID      uuid.UUID
-				siteName    string
-				siteURL     string
-				lastAlertAt pgtype.Timestamptz
-				updatedAt   pgtype.Timestamptz
-				inIncident  bool
-				totalMs     *float64
+				id        uuid.UUID
+				siteID    uuid.UUID
+				siteName  string
+				siteURL   string
+				startedAt time.Time
+				endedAt   pgtype.Timestamptz
+				ongoing   bool
+				totalMs   *float64
 			)
-			if err := rows.Scan(&siteID, &siteName, &siteURL, &lastAlertAt, &updatedAt, &inIncident, &totalMs); err != nil {
+			if err := rows.Scan(&id, &siteID, &siteName, &siteURL, &startedAt, &endedAt, &ongoing, &totalMs); err != nil {
 				return domain.Internal("fleet_incidents_scan_failed", "failed to scan incident row").WithCause(err)
 			}
+			started := startedAt
 			item := FleetIncidentItem{
+				ID:            id,
 				SiteID:        siteID,
 				Kind:          string(AlertDown),
 				SiteName:      siteName,
 				SiteURL:       siteURL,
-				Ongoing:       inIncident,
+				StartedAt:     &started,
+				Ongoing:       ongoing,
 				LatestTotalMs: totalMs,
 			}
-			if lastAlertAt.Valid {
-				t := lastAlertAt.Time
-				item.StartedAt = &t
-			}
-			// For closed incidents, estimate ended_at from state updated_at.
-			if !inIncident && updatedAt.Valid {
-				t := updatedAt.Time
+			if !ongoing && endedAt.Valid {
+				t := endedAt.Time
 				item.EndedAt = &t
-				if item.StartedAt != nil {
-					dur := int64(t.Sub(*item.StartedAt).Seconds())
-					if dur >= 0 {
-						item.DurationSeconds = &dur
-					}
+				dur := int64(t.Sub(started).Seconds())
+				if dur < 0 {
+					dur = 0
 				}
+				item.DurationSeconds = &dur
 			}
 			out = append(out, item)
 		}
@@ -388,6 +454,63 @@ LIMIT $4
 		out = []FleetIncidentItem{}
 	}
 	return out, nil
+}
+
+// GetIncidentByID returns one tenant-scoped incident (joined with its site's
+// name/url) for the incident-detail endpoint. found=false when the id does
+// not exist, belongs to another tenant (RLS + the explicit tenant_id
+// predicate both enforce this), or was hard-deleted along with its site.
+func (r *pgRepo) GetIncidentByID(ctx context.Context, tenantID, incidentID uuid.UUID) (IncidentSummary, bool, error) {
+	var out IncidentSummary
+	var found bool
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		row, err := sqlc.New(tx).GetIncidentByID(ctx, sqlc.GetIncidentByIDParams{ID: incidentID, TenantID: tenantID})
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil
+			}
+			return domain.Internal("incident_get_failed", "failed to read incident").WithCause(err)
+		}
+		out = incidentSummaryFromRow(row)
+		found = true
+		return nil
+	})
+	return out, found, err
+}
+
+// CountRecentIncidents returns how many incidents (open or closed) have
+// started for siteID in the last 30 days — the incident-detail endpoint's
+// flapping count.
+func (r *pgRepo) CountRecentIncidents(ctx context.Context, tenantID, siteID uuid.UUID) (int64, error) {
+	var count int64
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		n, err := sqlc.New(tx).CountRecentIncidents(ctx, sqlc.CountRecentIncidentsParams{SiteID: siteID, TenantID: tenantID})
+		if err != nil {
+			return domain.Internal("incident_count_recent_failed", "failed to count recent incidents").WithCause(err)
+		}
+		count = n
+		return nil
+	})
+	return count, err
+}
+
+// incidentSummaryFromRow maps the sqlc join row to the domain type.
+func incidentSummaryFromRow(row sqlc.GetIncidentByIDRow) IncidentSummary {
+	out := IncidentSummary{
+		ID:             row.ID,
+		SiteID:         row.SiteID,
+		SiteName:       row.SiteName,
+		SiteURL:        row.SiteUrl,
+		StartedAt:      row.StartedAt,
+		PeakStatus:     row.PeakStatus,
+		LastHTTPStatus: int(row.LastHttpStatus),
+		Reason:         row.Reason,
+	}
+	if row.EndedAt.Valid {
+		t := row.EndedAt.Time
+		out.EndedAt = &t
+	}
+	return out
 }
 
 func alertConfigFromRow(row sqlc.AlertConfig) AlertConfig {

--- a/apps/api/internal/uptime/routes_contract_test.go
+++ b/apps/api/internal/uptime/routes_contract_test.go
@@ -22,6 +22,7 @@ var canonicalUptimeRoutes = []string{
 	// Fleet uptime status + incidents.
 	"GET    /api/v1/fleet/status",
 	"GET    /api/v1/fleet/incidents",
+	"GET    /api/v1/fleet/incidents/:incidentId",
 }
 
 func TestUptimeRoutesContract(t *testing.T) {

--- a/apps/api/internal/uptime/service.go
+++ b/apps/api/internal/uptime/service.go
@@ -251,6 +251,80 @@ func (s *Service) GetFleetIncidents(ctx context.Context, tenantID uuid.UUID, sit
 	return s.repo.GetFleetIncidents(ctx, tenantID, siteIDs, since, limit)
 }
 
+// incidentProbeWindowLimit bounds the number of raw probe rows the
+// incident-detail endpoint renders in its timeline.
+const incidentProbeWindowLimit = 40
+
+// GetIncidentSummary returns the tenant-scoped incident row (without the
+// probe timeline). The handler calls this FIRST so it can authorize a
+// site-scoped principal against SiteID before spending a metrics-store
+// round-trip on a request that may end up denied.
+func (s *Service) GetIncidentSummary(ctx context.Context, tenantID, incidentID uuid.UUID) (IncidentSummary, error) {
+	summary, found, err := s.repo.GetIncidentByID(ctx, tenantID, incidentID)
+	if err != nil {
+		return IncidentSummary{}, err
+	}
+	if !found {
+		return IncidentSummary{}, domain.NotFound("incident_not_found", "incident not found")
+	}
+	return summary, nil
+}
+
+// GetIncidentDetail assembles the full incident-detail DTO from an
+// already-authorized IncidentSummary: a probe timeline over the incident's
+// window (metrics.Store — degrades gracefully to an empty slice when the
+// window has no data) and the 30-day flapping count.
+func (s *Service) GetIncidentDetail(ctx context.Context, tenantID uuid.UUID, summary IncidentSummary) (IncidentDetail, error) {
+	to := time.Now()
+	if summary.EndedAt != nil {
+		to = *summary.EndedAt
+	}
+	samples, err := s.store.QueryProbeWindow(ctx, tenantID, summary.SiteID, summary.StartedAt, to, incidentProbeWindowLimit)
+	if err != nil {
+		return IncidentDetail{}, domain.Internal("incident_probe_window_failed", "failed to query incident probe timeline").WithCause(err)
+	}
+
+	count, err := s.repo.CountRecentIncidents(ctx, tenantID, summary.SiteID)
+	if err != nil {
+		return IncidentDetail{}, err
+	}
+
+	det := IncidentDetail{
+		ID:               summary.ID,
+		SiteID:           summary.SiteID,
+		Name:             summary.SiteName,
+		URL:              summary.SiteURL,
+		StartedAt:        summary.StartedAt,
+		EndedAt:          summary.EndedAt,
+		Ongoing:          summary.EndedAt == nil,
+		PeakStatus:       summary.PeakStatus,
+		LastHTTPStatus:   summary.LastHTTPStatus,
+		Reason:           summary.Reason,
+		IncidentCount30d: int(count),
+		Probes:           make([]IncidentProbe, 0, len(samples)),
+		// ProbesTruncated is set when the store returned a FULL page — there
+		// may be more probes in the window than we asked for/rendered.
+		ProbesTruncated: len(samples) >= incidentProbeWindowLimit,
+	}
+	if summary.EndedAt != nil {
+		dur := int64(summary.EndedAt.Sub(summary.StartedAt).Seconds())
+		if dur < 0 {
+			dur = 0
+		}
+		det.DurationSeconds = &dur
+	}
+	for _, p := range samples {
+		det.Probes = append(det.Probes, IncidentProbe{
+			ProbedAt:   p.ProbedAt,
+			Up:         p.Up,
+			HTTPStatus: int(p.HTTPStatus),
+			TotalMs:    p.TotalMs,
+			Error:      p.Error,
+		})
+	}
+	return det, nil
+}
+
 // SaveAlertConfig validates and upserts the tenant's alert config.
 func (s *Service) SaveAlertConfig(ctx context.Context, cfg AlertConfig) (AlertConfig, error) {
 	if len(cfg.EmailRecipients) > 50 {

--- a/apps/api/internal/uptime/worker.go
+++ b/apps/api/internal/uptime/worker.go
@@ -148,7 +148,7 @@ func (w *ProbeWorker) processSite(ctx context.Context, s EnrolledSite, res Probe
 	// transition in one transaction — see TransitionAlertState for why this
 	// must NOT be split into a separate get + upsert (lost-update race under
 	// overlapping sweeps).
-	tr, err := w.repo.TransitionAlertState(ctx, s.ID, s.TenantID, res.Up, w.threshold, now)
+	tr, err := w.repo.TransitionAlertState(ctx, s.ID, s.TenantID, res.Up, w.threshold, now, res.HTTPStatus, res.Error)
 	if err != nil {
 		w.logger.Warn("uptime: transition alert state failed", slog.String("site_id", s.ID.String()), slog.Any("error", err))
 		return

--- a/apps/api/migrations/20260727000000_m94_site_incidents.sql
+++ b/apps/api/migrations/20260727000000_m94_site_incidents.sql
@@ -1,0 +1,229 @@
+-- M94 — GH #148 (part 1): persisted incident history for the fleet incident-
+-- detail feature.
+--
+-- Problem: site_alert_state (M5) stores only the CURRENT transition memory
+-- (last_status/consecutive_down/in_incident/last_alert_at) — a single row per
+-- site with no history. GetFleetIncidents therefore could only report the
+-- ONE open incident (if any) plus a same-shape row for "recently alerted"
+-- sites, and closed-incident ended_at/duration_seconds were ESTIMATES derived
+-- from site_alert_state.updated_at, not a true incident-close record. There
+-- was also no way to open a per-incident detail view (no stable incident id,
+-- no persisted probe/flapping history per incident).
+--
+-- Fix: site_incidents is a new, append-style table — one row PER INCIDENT
+-- (open or closed), keyed by its own uuid id, so the fleet incidents list and
+-- the new GET /api/v1/fleet/incidents/:incidentId detail endpoint can both
+-- read real history instead of estimating it from a single mutable row.
+-- site_alert_state is UNCHANGED and continues to own the transition
+-- de-dupe/evaluator logic (see internal/uptime/alerts.go Evaluate) — this
+-- table is written ALONGSIDE it, inside the same TransitionAlertState
+-- transaction (internal/uptime/repo.go), never instead of it.
+--
+-- Columns:
+--   ended_at IS NULL      == the incident is open/ongoing (mirrors
+--                            backup_snapshots' pending/running convention).
+--   peak_status            reserved for a future "degraded vs down" incident
+--                            severity distinction; the alert state machine
+--                            only ever opens a 'down' incident today (see
+--                            FleetIncidentItem.Kind's doc comment), so this is
+--                            always 'down' for now.
+--   opened_by               'probe' for every incident the ProbeWorker opens
+--                            (the overwhelming common case) vs 'seed' for the
+--                            one-time day-1 backfill below — lets a future
+--                            audit distinguish real detections from the
+--                            migration's own bootstrap rows.
+--   probe_count/down_count  reserved counters for a future rollup (NOT
+--                            populated by this change — see M94 rollout
+--                            notes); default 0 keeps them well-defined.
+--
+-- tenant_id is denormalized onto this table (rather than joined through
+-- sites) for the SAME reason site_alert_state carries it: a join-free RLS
+-- policy and join-free tenant-scoped queries, mirroring that table exactly.
+--
+-- site_incidents_one_open_per_site is the race-safety guard: at most one OPEN
+-- incident (ended_at IS NULL) per site, modeled on
+-- backup_snapshots_one_inflight_per_site (m75) — the state machine only ever
+-- transitions one site's alert state under a row lock (GetSiteAlertStateForUpdate
+-- FOR UPDATE, see repo.go), so this is belt-and-suspenders rather than the
+-- primary defense, but it makes a double-open a hard DB-level impossibility
+-- instead of merely an application-logic invariant.
+--
+-- Idempotent throughout (DO $$ ... IF NOT EXISTS ... $$), mirrors m39/m93.
+
+DO $$
+BEGIN
+    CREATE TABLE IF NOT EXISTS "public"."site_incidents" (
+        "id"               uuid        NOT NULL DEFAULT gen_random_uuid(),
+        "tenant_id"        uuid        NOT NULL,
+        "site_id"          uuid        NOT NULL,
+        "started_at"       timestamptz NOT NULL DEFAULT now(),
+        "ended_at"         timestamptz,
+        "peak_status"      text        NOT NULL DEFAULT 'down',
+        "last_http_status" integer     NOT NULL DEFAULT 0,
+        "probe_count"      integer     NOT NULL DEFAULT 0,
+        "down_count"       integer     NOT NULL DEFAULT 0,
+        "opened_by"        text        NOT NULL DEFAULT 'probe',
+        "reason"           text        NOT NULL DEFAULT '',
+        "created_at"       timestamptz NOT NULL DEFAULT now(),
+        "updated_at"       timestamptz NOT NULL DEFAULT now(),
+        PRIMARY KEY ("id"),
+        CONSTRAINT "site_incidents_tenant_id_fkey" FOREIGN KEY ("tenant_id")
+            REFERENCES "public"."tenants" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+        CONSTRAINT "site_incidents_site_id_fkey" FOREIGN KEY ("site_id")
+            REFERENCES "public"."sites" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+    );
+END;
+$$;
+
+-- Per-site incident history, newest first (the detail/list read paths).
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename  = 'site_incidents'
+          AND indexname  = 'site_incidents_site_started_idx'
+    ) THEN
+        CREATE INDEX "site_incidents_site_started_idx"
+            ON "public"."site_incidents" ("site_id", "started_at" DESC);
+    END IF;
+END;
+$$;
+
+-- Tenant-wide incident history (fleet incidents list).
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename  = 'site_incidents'
+          AND indexname  = 'site_incidents_tenant_started_idx'
+    ) THEN
+        CREATE INDEX "site_incidents_tenant_started_idx"
+            ON "public"."site_incidents" ("tenant_id", "started_at" DESC);
+    END IF;
+END;
+$$;
+
+-- Race-safety guard: at most one OPEN incident per site (m75
+-- backup_snapshots_one_inflight_per_site precedent). CREATE UNIQUE INDEX
+-- supports IF NOT EXISTS directly (unlike CREATE POLICY below).
+CREATE UNIQUE INDEX IF NOT EXISTS "site_incidents_one_open_per_site"
+    ON "public"."site_incidents" ("site_id")
+    WHERE "ended_at" IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- Row-Level Security (mirrors site_alert_state exactly: tenant isolation +
+-- an app.agent policy for the probe worker's cross-tenant writes + the m19
+-- AS RESTRICTIVE site_scope policy every direct site-keyed table carries).
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+    ALTER TABLE "public"."site_incidents" ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE "public"."site_incidents" FORCE ROW LEVEL SECURITY;
+END;
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename  = 'site_incidents'
+          AND policyname = 'site_incidents_tenant_isolation'
+    ) THEN
+        CREATE POLICY "site_incidents_tenant_isolation" ON "public"."site_incidents"
+            USING ("tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid)
+            WITH CHECK ("tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid);
+    END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename  = 'site_incidents'
+          AND policyname = 'site_incidents_agent'
+    ) THEN
+        CREATE POLICY "site_incidents_agent" ON "public"."site_incidents"
+            USING (current_setting('app.agent', true) = 'on')
+            WITH CHECK (current_setting('app.agent', true) = 'on');
+    END IF;
+END;
+$$;
+
+-- site_scope (security review Finding 1, GH #148): mirrors m19's
+-- site_alert_state_site_scope verbatim (20260531050000_m19_orgs_sharing.sql,
+-- section 5g — "PK = site_id; use site_id directly"). site_id is a direct
+-- column on site_incidents (same shape as site_alert_state), so the
+-- RESTRICTIVE predicate uses it directly, no indirect join needed. This is
+-- AND-combined with every permissive policy above: when app.site_scope is NOT
+-- 'on' (the overwhelming default — normal members, service/agent paths) the
+-- first branch is a tautology and the policy is a no-op; when app.site_scope
+-- IS 'on' (the InScopedTenantTx collaborator path), only rows whose site_id
+-- is in app.allowed_site_ids pass. Not exploitable today — every current
+-- read of this table uses InTenantTx/InAgentTx, neither of which sets
+-- app.site_scope, and collaborator scoping is enforced in application code
+-- via Principal.CanAccessSite/AllowedSiteIDs — but RLS is the last line of
+-- defense, not the only one: the day a future read path uses
+-- InScopedTenantTx against this table, this policy is what keeps a
+-- site-scoped collaborator from seeing another site's incidents even if the
+-- application-code check is ever missed.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename  = 'site_incidents'
+          AND policyname = 'site_incidents_site_scope'
+    ) THEN
+        CREATE POLICY "site_incidents_site_scope" ON "public"."site_incidents"
+            AS RESTRICTIVE FOR ALL
+            USING (
+                coalesce(current_setting('app.site_scope', true), '') <> 'on'
+                OR "site_id" = ANY (
+                    string_to_array(
+                        nullif(current_setting('app.allowed_site_ids', true), ''), ','
+                    )::uuid[]
+                )
+            )
+            WITH CHECK (
+                coalesce(current_setting('app.site_scope', true), '') <> 'on'
+                OR "site_id" = ANY (
+                    string_to_array(
+                        nullif(current_setting('app.allowed_site_ids', true), ''), ','
+                    )::uuid[]
+                )
+            );
+    END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Day-1 seed: adopt every CURRENTLY-open incident (as tracked by
+-- site_alert_state) as an open site_incidents row, so a site already down at
+-- deploy time shows up in the new incidents list/detail immediately instead
+-- of waiting for its next down->recovery transition. started_at falls back
+-- to the alert state's last_alert_at (the timestamp the ORIGINAL down alert
+-- fired) rather than now(), so the incident's displayed duration is accurate
+-- from the moment this migration runs, not reset to zero.
+--
+-- ON CONFLICT targets the partial unique index above; safe to re-run — a
+-- second application of this migration (or the repo's own "adopt" path in
+-- TransitionAlertState, see internal/uptime/repo.go) is a silent no-op once a
+-- row is already open for that site.
+INSERT INTO "public"."site_incidents"
+    ("tenant_id", "site_id", "started_at", "ended_at", "peak_status", "reason", "opened_by")
+SELECT
+    "tenant_id",
+    "site_id",
+    COALESCE("last_alert_at", now()),
+    NULL,
+    'down',
+    '',
+    'seed'
+FROM "public"."site_alert_state"
+WHERE "in_incident" = true
+ON CONFLICT ("site_id") WHERE "ended_at" IS NULL DO NOTHING;

--- a/apps/api/tests/uptime_integration_test.go
+++ b/apps/api/tests/uptime_integration_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
@@ -201,7 +204,7 @@ func TestUptimeAlertStateTransitionRace(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		go func() {
 			defer wg.Done()
-			tr, err := repo.TransitionAlertState(ctx, s.ID, tenant, false, threshold, time.Now())
+			tr, err := repo.TransitionAlertState(ctx, s.ID, tenant, false, threshold, time.Now(), 500, "http status 500")
 			if err != nil {
 				t.Errorf("transition: %v", err)
 				return
@@ -259,7 +262,7 @@ func TestUptimeAlertStateTransitionRaceDeterministic(t *testing.T) {
 	// racing transactions increment an EXISTING row — the case a bare read +
 	// separate write can lose (the very-first insert is already race-safe via
 	// plain ON CONFLICT DO UPDATE).
-	if _, err := repo.TransitionAlertState(ctx, s.ID, tenant, false, 100, time.Now()); err != nil {
+	if _, err := repo.TransitionAlertState(ctx, s.ID, tenant, false, 100, time.Now(), 500, "http status 500"); err != nil {
 		t.Fatalf("seed transition: %v", err)
 	}
 
@@ -337,6 +340,296 @@ func TestUptimeAlertStateTransitionRaceDeterministic(t *testing.T) {
 	// update); the lock forces tx2 to read tx1's committed 2 and land on 3.
 	if final.ConsecutiveDown != 3 {
 		t.Fatalf("consecutive_down = %d, want 3 (FOR UPDATE failed to serialize the two transitions — lost update)", final.ConsecutiveDown)
+	}
+}
+
+// TestUptimeIncidentPersistedOnTransition proves the M94 (GH #148 part 1)
+// state-machine write points end to end against a real Postgres: a FireDown
+// transition opens a site_incidents row (ended_at NULL, last_http_status the
+// triggering probe's status), steady-state down probes do not create
+// duplicate rows (the de-duped Evaluate transitions plus OpenIncident's ON
+// CONFLICT DO NOTHING), and a FireRecovery transition closes that SAME row
+// (ended_at set, last_http_status refreshed to the recovery probe's status).
+func TestUptimeIncidentPersistedOnTransition(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "uptime-incident")
+
+	var status int32 = http.StatusOK
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(int(atomic.LoadInt32(&status)))
+	}))
+	defer srv.Close()
+	s := enrollFakeSite(t, pool, tenant, srv.URL)
+
+	repo := uptime.NewRepo(pool)
+	prober := uptime.NewProber(loopbackClient(), 5*time.Second)
+	disabledStore, _ := metrics.New(ctx, metrics.Config{Addr: ""}, nil)
+	// threshold=2, no dispatcher (alert delivery is not under test here).
+	w := uptime.NewProbeWorker(repo, prober, disabledStore, nil, nil, nil, 5, 2)
+
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+
+	// Bring the site DOWN. Sweep 1: below threshold, no incident yet.
+	atomic.StoreInt32(&status, http.StatusInternalServerError)
+	if _, err := w.Sweep(ctx, time.Now()); err != nil {
+		t.Fatalf("sweep 1: %v", err)
+	}
+	var preCount int
+	if err := admin.QueryRow(ctx, `SELECT count(*) FROM site_incidents WHERE site_id = $1`, s.ID).Scan(&preCount); err != nil {
+		t.Fatalf("count incidents after sweep 1: %v", err)
+	}
+	if preCount != 0 {
+		t.Fatalf("expected 0 site_incidents rows before the threshold crossing, got %d", preCount)
+	}
+
+	// Sweep 2: crosses the threshold — opens the incident.
+	if _, err := w.Sweep(ctx, time.Now()); err != nil {
+		t.Fatalf("sweep 2: %v", err)
+	}
+	// Sweep 3: steady-state down (already in incident) — must NOT create a
+	// second row (the "adopt" path's OpenIncident call is a no-op here).
+	if _, err := w.Sweep(ctx, time.Now()); err != nil {
+		t.Fatalf("sweep 3: %v", err)
+	}
+
+	var (
+		incidentID     uuid.UUID
+		endedAt        *time.Time
+		lastHTTPStatus int
+	)
+	if err := admin.QueryRow(ctx,
+		`SELECT id, ended_at, last_http_status FROM site_incidents WHERE site_id = $1`, s.ID,
+	).Scan(&incidentID, &endedAt, &lastHTTPStatus); err != nil {
+		t.Fatalf("read open incident: %v", err)
+	}
+	if endedAt != nil {
+		t.Fatalf("incident should be OPEN (ended_at NULL) while the site is still down, got %v", endedAt)
+	}
+	if lastHTTPStatus != http.StatusInternalServerError {
+		t.Fatalf("last_http_status = %d, want %d", lastHTTPStatus, http.StatusInternalServerError)
+	}
+	var openRowCount int
+	if err := admin.QueryRow(ctx,
+		`SELECT count(*) FROM site_incidents WHERE site_id = $1`, s.ID,
+	).Scan(&openRowCount); err != nil {
+		t.Fatalf("count incidents after steady-down: %v", err)
+	}
+	if openRowCount != 1 {
+		t.Fatalf("expected exactly 1 site_incidents row after 2 down + 1 steady-down sweep, got %d (adopt path must be idempotent)", openRowCount)
+	}
+
+	// Recover: the SAME row must close, not a new one.
+	atomic.StoreInt32(&status, http.StatusOK)
+	if _, err := w.Sweep(ctx, time.Now()); err != nil {
+		t.Fatalf("recovery sweep: %v", err)
+	}
+
+	var (
+		closedEndedAt  *time.Time
+		closedID       uuid.UUID
+		closedHTTPCode int
+	)
+	if err := admin.QueryRow(ctx,
+		`SELECT id, ended_at, last_http_status FROM site_incidents WHERE site_id = $1`, s.ID,
+	).Scan(&closedID, &closedEndedAt, &closedHTTPCode); err != nil {
+		t.Fatalf("read closed incident: %v", err)
+	}
+	if closedID != incidentID {
+		t.Fatalf("recovery closed a DIFFERENT incident row (got %s, want %s) — expected the same row to be reused", closedID, incidentID)
+	}
+	if closedEndedAt == nil {
+		t.Fatal("incident should be CLOSED (ended_at set) after recovery")
+	}
+	if closedHTTPCode != http.StatusOK {
+		t.Fatalf("last_http_status after recovery = %d, want %d", closedHTTPCode, http.StatusOK)
+	}
+
+	var finalCount int
+	if err := admin.QueryRow(ctx, `SELECT count(*) FROM site_incidents WHERE site_id = $1`, s.ID).Scan(&finalCount); err != nil {
+		t.Fatalf("final incident count: %v", err)
+	}
+	if finalCount != 1 {
+		t.Fatalf("expected exactly 1 total site_incidents row for the whole down->recovery cycle, got %d", finalCount)
+	}
+}
+
+// TestSiteIncidentsOneOpenPerSite proves the site_incidents_one_open_per_site
+// partial unique index is a REAL database-level guard, not merely an
+// application-logic invariant: repeated steady-state down transitions for an
+// already-open incident never create a second open row (the repo's own
+// ON CONFLICT DO NOTHING path), AND a raw INSERT that bypasses the
+// application entirely is rejected by Postgres with a unique_violation.
+func TestSiteIncidentsOneOpenPerSite(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "incident-unique")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	s := enrollFakeSite(t, pool, tenant, srv.URL)
+
+	repo := uptime.NewRepo(pool)
+	const threshold = 1 // fire the down alert immediately
+
+	if _, err := repo.TransitionAlertState(ctx, s.ID, tenant, false, threshold, time.Now(), 500, "http status 500"); err != nil {
+		t.Fatalf("opening transition: %v", err)
+	}
+	// Several more down probes while already in incident: the "adopt" branch
+	// runs OpenIncident again each time; it must stay a no-op.
+	for i := 0; i < 3; i++ {
+		if _, err := repo.TransitionAlertState(ctx, s.ID, tenant, false, threshold, time.Now(), 500, "http status 500"); err != nil {
+			t.Fatalf("steady-down transition %d: %v", i, err)
+		}
+	}
+
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	var openCount int
+	if err := admin.QueryRow(ctx,
+		`SELECT count(*) FROM site_incidents WHERE site_id = $1 AND ended_at IS NULL`, s.ID,
+	).Scan(&openCount); err != nil {
+		t.Fatalf("count open incidents: %v", err)
+	}
+	if openCount != 1 {
+		t.Fatalf("open incident count = %d, want 1 (repo-level idempotency)", openCount)
+	}
+
+	// Direct proof the DB-level constraint exists, independent of the repo's
+	// own ON CONFLICT clause: a raw second-open INSERT must be rejected.
+	_, err := admin.Exec(ctx,
+		`INSERT INTO site_incidents (tenant_id, site_id, started_at, ended_at) VALUES ($1, $2, now(), NULL)`,
+		tenant, s.ID)
+	if err == nil {
+		t.Fatal("expected a unique_violation inserting a second OPEN incident for the same site, got no error")
+	}
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "23505" {
+		t.Fatalf("expected Postgres unique_violation (23505) from site_incidents_one_open_per_site, got: %v", err)
+	}
+}
+
+// TestIncidentByIDTenantIsolation is IDOR gate (a) from the security review
+// (GH #148): a foreign tenant guessing/enumerating another tenant's incident
+// id must get a not-found, never the row. GetIncidentByID is the exact repo
+// method the GET /api/v1/fleet/incidents/:incidentId handler calls first
+// (before any site-scope check), and it maps found=false straight to the
+// handler's domain.NotFound("incident_not_found", ...) 404 — so this test
+// proves that mapping at the source: RLS (site_incidents_tenant_isolation)
+// PLUS the explicit tenant_id predicate in the query both agree that tenant
+// B simply has no such row.
+func TestIncidentByIDTenantIsolation(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenantA := seedTenant(t, pool, "incident-idor-tenant-a")
+	tenantB := seedTenant(t, pool, "incident-idor-tenant-b")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	s := enrollFakeSite(t, pool, tenantA, srv.URL)
+
+	repo := uptime.NewRepo(pool)
+	if _, err := repo.TransitionAlertState(ctx, s.ID, tenantA, false, 1, time.Now(), 500, "http status 500"); err != nil {
+		t.Fatalf("opening transition: %v", err)
+	}
+
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	var incidentID uuid.UUID
+	if err := admin.QueryRow(ctx, `SELECT id FROM site_incidents WHERE site_id = $1`, s.ID).Scan(&incidentID); err != nil {
+		t.Fatalf("read seeded incident id: %v", err)
+	}
+
+	// Tenant A (the owner) can read its own incident.
+	summary, found, err := repo.GetIncidentByID(ctx, tenantA, incidentID)
+	if err != nil {
+		t.Fatalf("tenant A get incident: %v", err)
+	}
+	if !found || summary.SiteID != s.ID {
+		t.Fatalf("tenant A should see its own incident: found=%v summary=%+v", found, summary)
+	}
+
+	// Tenant B — a wholly unrelated tenant, not a collaborator — must get
+	// found=false for tenant A's incident id, exactly the not-found the
+	// handler needs to 404 without leaking existence.
+	_, foundB, err := repo.GetIncidentByID(ctx, tenantB, incidentID)
+	if err != nil {
+		t.Fatalf("tenant B get incident: %v", err)
+	}
+	if foundB {
+		t.Fatal("tenant B must NOT see tenant A's incident by id (RLS/tenant-scope IDOR)")
+	}
+}
+
+// TestIncidentSiteScopeRestrictivePolicy is IDOR gate (b) from the security
+// review (Finding 1 + Finding 2, GH #148): it directly exercises the new
+// site_incidents_site_scope RESTRICTIVE policy under InScopedTenantTx (the
+// real GUC path a site-scoped collaborator's request runs under), proving it
+// actually filters — not just that application code (CanAccessSite) happens
+// to gate the handler today. Repo.GetIncidentByID always uses plain
+// InTenantTx (never sets app.site_scope), so this test intentionally goes
+// around the Repo interface and queries site_incidents directly under
+// InScopedTenantTx, mirroring the tests/portal_rls_integration_test.go style.
+func TestIncidentSiteScopeRestrictivePolicy(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "incident-idor-site-scope")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	// Distinct URLs so these are genuinely two different site rows: Enroll is
+	// idempotent-by-URL (GetSiteByURLForEnroll/AttachAgentToSite) — the SAME
+	// URL under the same tenant re-attaches to the EXISTING row instead of
+	// creating a second one, which would silently collapse siteA/siteB into
+	// one site and make this test pass for the wrong reason.
+	siteA := enrollFakeSite(t, pool, tenant, srv.URL+"/site-a")
+	siteB := enrollFakeSite(t, pool, tenant, srv.URL+"/site-b") // same tenant, a DIFFERENT site
+
+	repo := uptime.NewRepo(pool)
+	if _, err := repo.TransitionAlertState(ctx, siteA.ID, tenant, false, 1, time.Now(), 500, "http status 500"); err != nil {
+		t.Fatalf("opening transition: %v", err)
+	}
+
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	var incidentID uuid.UUID
+	if err := admin.QueryRow(ctx, `SELECT id FROM site_incidents WHERE site_id = $1`, siteA.ID).Scan(&incidentID); err != nil {
+		t.Fatalf("read seeded incident id: %v", err)
+	}
+
+	// A collaborator scoped ONLY to siteB (not siteA, the incident's own
+	// site) must not see siteA's incident row — this is the RESTRICTIVE
+	// site_scope policy doing the filtering.
+	var deniedCount int
+	err := pool.InScopedTenantTx(ctx, tenant, uuid.Nil, []uuid.UUID{siteB.ID}, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT count(*) FROM site_incidents WHERE id = $1`, incidentID).Scan(&deniedCount)
+	})
+	if err != nil {
+		t.Fatalf("scoped read (siteB only): %v", err)
+	}
+	if deniedCount != 0 {
+		t.Fatalf("collaborator scoped to a different site must not see this incident via RLS, got count=%d", deniedCount)
+	}
+
+	// Sanity check: the SAME collaborator, scoped to siteA (the incident's
+	// own site), DOES see it — proving the policy filters by site rather than
+	// blocking everything under app.site_scope='on'.
+	var allowedCount int
+	err = pool.InScopedTenantTx(ctx, tenant, uuid.Nil, []uuid.UUID{siteA.ID}, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT count(*) FROM site_incidents WHERE id = $1`, incidentID).Scan(&allowedCount)
+	})
+	if err != nil {
+		t.Fatalf("scoped read (siteA allowed): %v", err)
+	}
+	if allowedCount != 1 {
+		t.Fatalf("collaborator scoped to the incident's own site should see it, got count=%d", allowedCount)
 	}
 }
 

--- a/apps/web/src/features/fleet/fleet-keys.ts
+++ b/apps/web/src/features/fleet/fleet-keys.ts
@@ -6,6 +6,8 @@ export const fleetKeys = {
   status: () => [...fleetKeys.all, "status"] as const,
   incidents: (since?: string) =>
     [...fleetKeys.all, "incidents", since ?? ""] as const,
+  incidentDetail: (incidentId: string) =>
+    [...fleetKeys.all, "incidentDetail", incidentId] as const,
   // Backups
   backupHealth: (sites?: string) =>
     [...fleetKeys.all, "backupHealth", sites ?? "all"] as const,

--- a/apps/web/src/features/fleet/fleet-types.ts
+++ b/apps/web/src/features/fleet/fleet-types.ts
@@ -36,6 +36,7 @@ export interface FleetStatusResponse {
 }
 
 export interface FleetIncident {
+  id: string;
   site_id: string;
   name: string;
   url: string;
@@ -48,6 +49,41 @@ export interface FleetIncident {
 
 export interface FleetIncidentsResponse {
   items: FleetIncident[];
+}
+
+// ---------------------------------------------------------------------------
+// Incident detail (GH #148) — GET /api/v1/fleet/incidents/:incidentId
+// ---------------------------------------------------------------------------
+
+/**
+ * One probe result in an incident's probe window (`IncidentDetail.probes`).
+ * Named to match the pinned contract; despite the name this is a probe
+ * RECORD (timestamp + outcome), not an enum of status codes.
+ */
+export interface ProbeCode {
+  probed_at: string;
+  up: boolean;
+  http_status: number;
+  total_ms: number;
+  error?: string;
+}
+
+export interface IncidentDetail {
+  id: string;
+  site_id: string;
+  name: string;
+  url: string;
+  started_at: string;
+  ended_at: string | null;
+  duration_seconds: number | null;
+  ongoing: boolean;
+  peak_status: string;
+  last_http_status: number;
+  reason: string;
+  incident_count_30d: number;
+  /** Newest-first. May be `[]` when the incident is older than probe retention. */
+  probes: ProbeCode[];
+  probes_truncated: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/features/fleet/incident-detail-dialog.tsx
+++ b/apps/web/src/features/fleet/incident-detail-dialog.tsx
@@ -1,0 +1,542 @@
+import { useId, useMemo } from "react";
+import { Link } from "@tanstack/react-router";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  X,
+  RefreshCw,
+  DatabaseBackup,
+  Bug,
+  Activity as ActivityIcon,
+  Stethoscope,
+} from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PageError } from "@/components/feedback";
+import { TooltipProvider, Tooltip } from "@/components/ui/tooltip";
+import { DefinitionList } from "@/components/shared/definition-list";
+import { toast } from "@/components/toast";
+import { cn, relativeTime } from "@/lib/utils";
+
+import { AutoLoginButton } from "@/features/sites/auto-login-button";
+import {
+  useRecheckConnection,
+  AgentUnreachableError,
+} from "@/features/sites/use-site-connection";
+import { useRefreshDiagnostics } from "@/features/health/use-diagnostics";
+import { useSiteUptime, monitoringKeys } from "@/features/monitoring/use-uptime";
+import { useUpdateRuns } from "@/features/updates/use-updates";
+import { useBackups } from "@/features/backups/use-backups";
+import { useActivity } from "@/features/activity/use-activity";
+import { usePHPErrors } from "@/features/errors/use-errors";
+
+import { useIncidentDetail } from "./use-fleet-uptime";
+import type { FleetIncident, IncidentDetail, UptimeStatusKind } from "./fleet-types";
+import { STATUS_ICON, STATUS_LABEL, STATUS_COLOR_CLASS } from "./uptime-status";
+import {
+  isIncidentOngoing,
+  formatIncidentDuration,
+  humanizeIncidentReason,
+} from "./incident-format";
+import {
+  updateTasksToTimeline,
+  backupsToTimeline,
+  activityToTimeline,
+  phpErrorsToTimeline,
+  mergeIncidentTimeline,
+  type TimelineItem,
+} from "./incident-timeline";
+
+// Incident detail dialog (GH #148) — click-a-row drill-in on the fleet
+// Uptime page's incidents panel. Mirrors the EmailLogDetailDialog structure
+// (Dialog + DialogHeader/Title/Body, capped max-w, close X). The dialog only
+// mounts its data hooks (uptime windows, update/backup/activity/error
+// timelines, and the two action mutations) while an incident is selected —
+// `IncidentDetailBody` is only rendered when `incident !== null`, so closing
+// the dialog tears every one of those queries back down.
+
+export interface IncidentDetailDialogProps {
+  incident: FleetIncident | null;
+  onClose: () => void;
+}
+
+export function IncidentDetailDialog({
+  incident,
+  onClose,
+}: IncidentDetailDialogProps) {
+  const titleId = useId();
+
+  return (
+    <TooltipProvider>
+      <Dialog open={incident !== null} onClose={onClose}>
+        <DialogContent
+          ariaLabelledBy={titleId}
+          className="max-w-[min(720px,calc(100vw-2rem))]"
+        >
+          <DialogHeader>
+            <div className="flex items-center justify-between gap-2">
+              <DialogTitle id={titleId}>Incident detail</DialogTitle>
+              <button
+                type="button"
+                aria-label="Close detail"
+                onClick={onClose}
+                className="rounded text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+              >
+                <X aria-hidden="true" className="size-4" />
+              </button>
+            </div>
+          </DialogHeader>
+
+          <DialogBody>
+            {/* Keyed by incident.id so all internal query/mutation state
+                resets automatically when the operator switches incidents
+                without closing the dialog. */}
+            {incident ? (
+              <IncidentDetailBody key={incident.id} incident={incident} />
+            ) : null}
+          </DialogBody>
+        </DialogContent>
+      </Dialog>
+    </TooltipProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Body — all data hooks live here so they only run while the dialog is open
+// ---------------------------------------------------------------------------
+
+const TIMELINE_ICON: Record<TimelineItem["source"], typeof RefreshCw> = {
+  update: RefreshCw,
+  backup: DatabaseBackup,
+  activity: ActivityIcon,
+  php_error: Bug,
+};
+
+function IncidentDetailBody({ incident }: { incident: FleetIncident }) {
+  const siteId = incident.site_id;
+  const queryClient = useQueryClient();
+
+  const detail = useIncidentDetail(incident.id);
+
+  // Context: 7d + 30d uptime windows are distinct cached query keys.
+  const uptime7d = useSiteUptime(siteId, "7d");
+  const uptime30d = useSiteUptime(siteId, "30d");
+
+  // Events timeline sources — existing per-site hooks, reused as-is.
+  const updateRuns = useUpdateRuns();
+  const backups = useBackups(siteId);
+  const activity = useActivity(siteId, {
+    severity: "all",
+    objectType: "",
+    actorLogin: "",
+  });
+  const phpErrors = usePHPErrors(siteId, { showSilenced: false, limit: 50 });
+
+  // Footer actions.
+  const recheck = useRecheckConnection();
+  const refreshDiagnostics = useRefreshDiagnostics(siteId);
+
+  const updateItems = useMemo(
+    () =>
+      updateTasksToTimeline(
+        (updateRuns.data ?? []).flatMap((run) =>
+          (run.tasks ?? []).filter((task) => task.site_id === siteId),
+        ),
+      ),
+    [updateRuns.data, siteId],
+  );
+  const backupItems = useMemo(
+    () => backupsToTimeline(backups.data ?? []),
+    [backups.data],
+  );
+  const activityItems = useMemo(
+    () => activityToTimeline(activity.items),
+    [activity.items],
+  );
+  const phpErrorItems = useMemo(
+    () => phpErrorsToTimeline(phpErrors.items),
+    [phpErrors.items],
+  );
+
+  const timeline = useMemo(() => {
+    if (!detail.data) return [];
+    return mergeIncidentTimeline(
+      [updateItems, backupItems, activityItems, phpErrorItems],
+      { start: detail.data.started_at, end: detail.data.ended_at },
+    );
+  }, [updateItems, backupItems, activityItems, phpErrorItems, detail.data]);
+
+  if (detail.isPending) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-5 w-2/3" />
+        <Skeleton className="h-4 w-1/2" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-16 w-full" />
+      </div>
+    );
+  }
+
+  if (detail.isError) {
+    return (
+      <PageError
+        what="Could not load incident detail."
+        why={detail.error?.message}
+        onRetry={() => void detail.refetch()}
+      />
+    );
+  }
+
+  const d: IncidentDetail | undefined = detail.data;
+  if (!d) return null;
+
+  return (
+    <IncidentDetailContent
+      incident={incident}
+      detail={d}
+      timeline={timeline}
+      uptime7dPct={uptime7d.data?.uptime_pct ?? null}
+      uptime30dPct={uptime30d.data?.uptime_pct ?? null}
+      lastCheck={uptime7d.data?.last_check ?? uptime30d.data?.last_check ?? null}
+      onRecheck={() => {
+        recheck.mutate(
+          { siteId },
+          {
+            onSuccess: () => {
+              toast.success("Connection refreshed");
+              void queryClient.invalidateQueries({
+                queryKey: monitoringKeys.uptime(siteId, "7d"),
+              });
+              void queryClient.invalidateQueries({
+                queryKey: monitoringKeys.uptime(siteId, "30d"),
+              });
+            },
+            onError: (err) => {
+              if (err instanceof AgentUnreachableError) {
+                toast.info(err.message);
+              } else {
+                toast.error("Re-check failed", { description: err.message });
+              }
+            },
+          },
+        );
+      }}
+      recheckPending={recheck.isPending}
+      onRunDiagnostics={() => {
+        refreshDiagnostics.mutate(undefined, {
+          onSuccess: () => toast.success("Diagnostics refresh requested"),
+          onError: (err) => toast.info(err.message),
+        });
+      }}
+      diagnosticsPending={refreshDiagnostics.isPending}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Content — pure presentational split so the loading/error gates above stay
+// readable
+// ---------------------------------------------------------------------------
+
+interface IncidentDetailContentProps {
+  incident: FleetIncident;
+  detail: IncidentDetail;
+  timeline: TimelineItem[];
+  uptime7dPct: number | null;
+  uptime30dPct: number | null;
+  lastCheck: string | null;
+  onRecheck: () => void;
+  recheckPending: boolean;
+  onRunDiagnostics: () => void;
+  diagnosticsPending: boolean;
+}
+
+function IncidentDetailContent({
+  incident,
+  detail: d,
+  timeline,
+  uptime7dPct,
+  uptime30dPct,
+  lastCheck,
+  onRecheck,
+  recheckPending,
+  onRunDiagnostics,
+  diagnosticsPending,
+}: IncidentDetailContentProps) {
+  const siteId = d.site_id;
+  const ongoing = isIncidentOngoing(d);
+  const durationLabel = formatIncidentDuration(d.duration_seconds, ongoing);
+
+  // Prefer the freshest signal (peak_status from the detail DTO) when it's
+  // one of the two incident kinds; fall back to the row's kind (the detail
+  // contract has no `kind` field of its own).
+  const kind: "down" | "degraded" =
+    d.peak_status === "down" || d.peak_status === "degraded"
+      ? d.peak_status
+      : incident.kind;
+  const statusKind: UptimeStatusKind = ongoing ? kind : "up";
+  const StatusIcon = STATUS_ICON[statusKind];
+
+  return (
+    <div className="space-y-5">
+      {/* Header: identity + status */}
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <Link
+            to="/sites/$siteId"
+            params={{ siteId }}
+            className="font-medium text-[var(--color-foreground)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+          >
+            {d.name || d.url}
+          </Link>
+          <p className="truncate text-xs text-[var(--color-muted-foreground)]">
+            {d.url}
+          </p>
+        </div>
+        <Badge
+          variant="outline"
+          className={cn("shrink-0 gap-1", STATUS_COLOR_CLASS[statusKind])}
+        >
+          <StatusIcon aria-hidden="true" className="size-3.5" />
+          {ongoing ? STATUS_LABEL[statusKind] : "Recovered"}
+        </Badge>
+      </div>
+
+      {/* Incident timeline */}
+      <section aria-labelledby="incident-timeline-heading" className="space-y-2">
+        <h3
+          id="incident-timeline-heading"
+          className="text-xs font-medium uppercase tracking-wide text-[var(--color-muted-foreground)]"
+        >
+          Timeline
+        </h3>
+        <DefinitionList
+          rows={[
+            { label: "Started", value: relativeTime(d.started_at) ?? d.started_at },
+            {
+              label: "Ended",
+              value: ongoing
+                ? "Ongoing"
+                : d.ended_at
+                  ? (relativeTime(d.ended_at) ?? d.ended_at)
+                  : undefined,
+            },
+            {
+              label: "Duration",
+              value: ongoing ? "Ongoing" : (durationLabel ?? undefined),
+            },
+            { label: "Peak status", value: capitalize(d.peak_status) },
+            {
+              label: "Last HTTP code",
+              value:
+                d.last_http_status > 0 ? String(d.last_http_status) : "No response",
+              tabular: true,
+            },
+            { label: "Cause", value: humanizeIncidentReason(d.reason) },
+          ]}
+        />
+
+        {/* Probe window — newest-first compact chips. */}
+        <div className="space-y-1.5">
+          <p className="text-xs font-medium text-[var(--color-muted-foreground)]">
+            Probe window
+          </p>
+          {d.probes.length === 0 ? (
+            <p className="text-sm text-[var(--color-muted-foreground)]">
+              Probe detail unavailable (retention).
+            </p>
+          ) : (
+            <div className="flex gap-1.5 overflow-x-auto pb-1" role="list" aria-label="Probe results, newest first">
+              {d.probes.map((probe, idx) => (
+                <Tooltip
+                  key={`${probe.probed_at}-${idx}`}
+                  content={
+                    <div className="space-y-0.5">
+                      <p>{relativeTime(probe.probed_at) ?? probe.probed_at}</p>
+                      <p>{probe.total_ms} ms</p>
+                      {probe.error ? <p>{probe.error}</p> : null}
+                    </div>
+                  }
+                >
+                  <span
+                    role="listitem"
+                    className={cn(
+                      "inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-mono tabular-nums",
+                      probe.up
+                        ? "bg-[var(--color-success-subtle,oklch(95%_0.05_145))] text-[var(--color-success,oklch(50%_0.15_145))]"
+                        : "bg-[var(--color-destructive-subtle,oklch(95%_0.05_25))] text-[var(--color-destructive,oklch(50%_0.18_25))]",
+                    )}
+                  >
+                    {probe.http_status > 0 ? probe.http_status : probe.up ? "OK" : "ERR"}
+                  </span>
+                </Tooltip>
+              ))}
+            </div>
+          )}
+          {d.probes_truncated ? (
+            <p className="text-xs text-[var(--color-muted-foreground)]">
+              Showing the most recent probes only.
+            </p>
+          ) : null}
+        </div>
+      </section>
+
+      {/* Events timeline — client-composed from existing per-site hooks */}
+      <section aria-labelledby="incident-events-heading" className="space-y-2">
+        <h3
+          id="incident-events-heading"
+          className="text-xs font-medium uppercase tracking-wide text-[var(--color-muted-foreground)]"
+        >
+          What happened around this incident
+        </h3>
+        {timeline.length === 0 ? (
+          <p className="text-sm text-[var(--color-muted-foreground)]">
+            No update, backup, or error activity recorded near this window.
+          </p>
+        ) : (
+          <div
+            role="list"
+            aria-label="Events around this incident"
+            className="divide-y divide-[var(--color-border)] rounded-lg border border-[var(--color-border)]"
+          >
+            {timeline.map((item) => (
+              <TimelineRow key={`${item.source}-${item.id}`} item={item} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Context */}
+      <section aria-labelledby="incident-context-heading" className="space-y-2">
+        <h3
+          id="incident-context-heading"
+          className="text-xs font-medium uppercase tracking-wide text-[var(--color-muted-foreground)]"
+        >
+          Context
+        </h3>
+        <DefinitionList
+          rows={[
+            {
+              label: "Uptime (7d)",
+              value: uptime7dPct !== null ? `${uptime7dPct.toFixed(2)}%` : undefined,
+              tabular: true,
+            },
+            {
+              label: "Uptime (30d)",
+              value: uptime30dPct !== null ? `${uptime30dPct.toFixed(2)}%` : undefined,
+              tabular: true,
+            },
+            {
+              label: "Last check",
+              value: lastCheck ? relativeTime(lastCheck) : undefined,
+            },
+            {
+              label: "Flapping (30d)",
+              value: `${d.incident_count_30d} incident${d.incident_count_30d === 1 ? "" : "s"}`,
+            },
+          ]}
+        />
+      </section>
+
+      {/* Footer actions */}
+      <div className="flex flex-wrap items-center gap-2 border-t border-[var(--color-border)] pt-3">
+        <AutoLoginButton siteId={siteId} siteName={d.name || d.url} size="sm" />
+
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={recheckPending}
+          onClick={onRecheck}
+          className="gap-1.5"
+        >
+          <RefreshCw
+            aria-hidden="true"
+            className={cn("size-3.5", recheckPending && "animate-spin")}
+          />
+          Re-check connection
+        </Button>
+
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={diagnosticsPending}
+          onClick={onRunDiagnostics}
+          className="gap-1.5"
+        >
+          <Stethoscope aria-hidden="true" className="size-3.5" />
+          Run diagnostics
+        </Button>
+
+        <div className="ml-auto flex flex-wrap items-center gap-1">
+          <Button asChild variant="ghost" size="sm">
+            <Link to="/sites/$siteId/health" params={{ siteId }}>
+              Health
+            </Link>
+          </Button>
+          <Button asChild variant="ghost" size="sm">
+            <Link
+              to="/sites/$siteId/backups"
+              params={{ siteId }}
+              aria-label="Open backups — restore from a snapshot here"
+            >
+              Backups
+            </Link>
+          </Button>
+          <Button asChild variant="ghost" size="sm">
+            <Link to="/sites/$siteId/updates" params={{ siteId }}>
+              Updates
+            </Link>
+          </Button>
+          <Button asChild variant="ghost" size="sm">
+            <Link to="/sites/$siteId/activity" params={{ siteId }}>
+              Activity
+            </Link>
+          </Button>
+          <Button asChild variant="ghost" size="sm">
+            <Link to="/sites/$siteId/errors" params={{ siteId }}>
+              Errors
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TimelineRow({ item }: { item: TimelineItem }) {
+  const Icon = TIMELINE_ICON[item.source];
+  return (
+    <div role="listitem" className="flex items-start gap-2.5 px-3 py-2 text-xs">
+      <Icon
+        aria-hidden="true"
+        className="mt-0.5 size-3.5 shrink-0 text-[var(--color-muted-foreground)]"
+      />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-[var(--color-foreground)]">{item.label}</p>
+        {item.detail ? (
+          <p className="truncate text-[var(--color-muted-foreground)]">
+            {item.detail}
+          </p>
+        ) : null}
+      </div>
+      <span className="shrink-0 text-[var(--color-muted-foreground)]">
+        {relativeTime(item.timestamp) ?? ""}
+      </span>
+    </div>
+  );
+}
+
+function capitalize(value: string): string {
+  if (!value) return value;
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}

--- a/apps/web/src/features/fleet/incident-format.test.ts
+++ b/apps/web/src/features/fleet/incident-format.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 
-import { isIncidentOngoing, formatIncidentDuration } from "./incident-format";
+import {
+  isIncidentOngoing,
+  formatIncidentDuration,
+  humanizeIncidentReason,
+} from "./incident-format";
 
 // ---------------------------------------------------------------------------
 // GH #148 — incidents panel hardening
@@ -70,5 +74,74 @@ describe("formatIncidentDuration", () => {
 
   it("formats a zero-second duration as 0s, not falsy-empty", () => {
     expect(formatIncidentDuration(0, false)).toBe("0s");
+  });
+});
+
+describe("humanizeIncidentReason", () => {
+  it("maps the two fixed fatal-detection codes to readable copy", () => {
+    expect(humanizeIncidentReason("wp_fatal_error")).toBe(
+      "WordPress fatal error page",
+    );
+    expect(humanizeIncidentReason("wp_db_error")).toBe(
+      "Database connection error page",
+    );
+  });
+
+  it("is case-insensitive on the fixed codes", () => {
+    expect(humanizeIncidentReason("WP_FATAL_ERROR")).toBe(
+      "WordPress fatal error page",
+    );
+  });
+
+  it("extracts the status code from an 'http status NNN' reason", () => {
+    expect(humanizeIncidentReason("http status 500")).toBe(
+      "Site returned HTTP 500",
+    );
+    expect(humanizeIncidentReason("http status 503")).toBe(
+      "Site returned HTTP 503",
+    );
+  });
+
+  it("recognizes an ssrf_blocked prefix", () => {
+    expect(humanizeIncidentReason("ssrf_blocked: dial tcp 10.0.0.1:443")).toBe(
+      "Blocked by outbound security policy",
+    );
+  });
+
+  it("recognizes a timeout / deadline-exceeded transport error", () => {
+    expect(
+      humanizeIncidentReason("context deadline exceeded (Client.Timeout)"),
+    ).toBe("Connection timed out");
+    expect(humanizeIncidentReason("i/o timeout")).toBe("Connection timed out");
+  });
+
+  it("recognizes a connection-refused transport error", () => {
+    expect(
+      humanizeIncidentReason("dial tcp 127.0.0.1:443: connection refused"),
+    ).toBe("Connection refused");
+  });
+
+  it("recognizes a DNS failure", () => {
+    expect(
+      humanizeIncidentReason("dial tcp: lookup example.com: no such host"),
+    ).toBe("DNS lookup failed");
+  });
+
+  it("recognizes a TLS/certificate error", () => {
+    expect(
+      humanizeIncidentReason("x509: certificate has expired or is not yet valid"),
+    ).toBe("TLS certificate error");
+  });
+
+  it("falls back to the raw reason for anything unrecognized (never drops the signal)", () => {
+    expect(humanizeIncidentReason("some brand-new prober reason")).toBe(
+      "some brand-new prober reason",
+    );
+  });
+
+  it("returns a calm default for an empty/absent reason", () => {
+    expect(humanizeIncidentReason("")).toBe("No specific cause recorded");
+    expect(humanizeIncidentReason(null)).toBe("No specific cause recorded");
+    expect(humanizeIncidentReason(undefined)).toBe("No specific cause recorded");
   });
 });

--- a/apps/web/src/features/fleet/incident-format.ts
+++ b/apps/web/src/features/fleet/incident-format.ts
@@ -1,7 +1,8 @@
-// Pure helpers for rendering a FleetIncident's ongoing/duration labels
-// (GH #148). Extracted from the /uptime IncidentList so the "is this
-// incident still open" decision and the duration formatting can be unit
-// tested without mounting the route.
+// Pure helpers for rendering a FleetIncident's ongoing/duration labels, and
+// (GH #148 detail dialog) a fatal-reason-to-human-copy map. Extracted from
+// the /uptime IncidentList so the "is this incident still open" decision,
+// the duration formatting, and the reason humanizer can be unit tested
+// without mounting the route or the detail dialog.
 
 import type { FleetIncident } from "./fleet-types";
 
@@ -38,4 +39,48 @@ export function formatIncidentDuration(
   if (seconds < 60) return `${Math.round(seconds)}s`;
   if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
   return `${(seconds / 3600).toFixed(1)}h`;
+}
+
+/**
+ * Map a raw incident `reason` string (`IncidentDetail.reason`, GH #148 detail
+ * dialog) to a short, human-readable phrase.
+ *
+ * The uptime prober emits a mix of shapes in this field: two fixed codes
+ * ("wp_fatal_error", "wp_db_error" — see apps/api/internal/uptime/probe.go
+ * scanFatal), a formatted string ("http status 500"), an "ssrf_blocked: ..."
+ * prefix, and otherwise the raw Go transport error text (timeouts, DNS
+ * failures, connection refused, TLS errors). This never throws and always
+ * returns something renderable — falling back to the raw reason for
+ * anything it does not recognize, so a new/unmapped reason is still shown
+ * rather than silently dropped.
+ */
+export function humanizeIncidentReason(
+  reason: string | null | undefined,
+): string {
+  const raw = (reason ?? "").trim();
+  if (!raw) return "No specific cause recorded";
+
+  const lower = raw.toLowerCase();
+
+  if (lower === "wp_fatal_error") return "WordPress fatal error page";
+  if (lower === "wp_db_error") return "Database connection error page";
+
+  const httpStatusMatch = /^http status (\d{3})$/i.exec(raw);
+  if (httpStatusMatch) return `Site returned HTTP ${httpStatusMatch[1]}`;
+
+  if (lower.startsWith("ssrf_blocked"))
+    return "Blocked by outbound security policy";
+  if (lower.includes("deadline exceeded") || lower.includes("timeout"))
+    return "Connection timed out";
+  if (lower.includes("connection refused")) return "Connection refused";
+  if (lower.includes("no such host") || lower.includes("lookup"))
+    return "DNS lookup failed";
+  if (
+    lower.includes("certificate") ||
+    lower.includes("tls") ||
+    lower.includes("x509")
+  )
+    return "TLS certificate error";
+
+  return raw;
 }

--- a/apps/web/src/features/fleet/incident-timeline.test.ts
+++ b/apps/web/src/features/fleet/incident-timeline.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect } from "vitest";
+
+import type {
+  UpdateTask,
+  BackupSnapshot,
+  SiteActivityEvent,
+  PhpError,
+} from "@wpmgr/api";
+
+import {
+  updateTasksToTimeline,
+  backupsToTimeline,
+  activityToTimeline,
+  phpErrorsToTimeline,
+  mergeIncidentTimeline,
+  type TimelineItem,
+} from "./incident-timeline";
+
+// ---------------------------------------------------------------------------
+// Fixture factories — minimal required fields, override what a test cares
+// about. Keeps each test focused on the field(s) it is actually exercising.
+// ---------------------------------------------------------------------------
+
+function makeUpdateTask(overrides: Partial<UpdateTask> = {}): UpdateTask {
+  return {
+    id: "task-1",
+    run_id: "run-1",
+    tenant_id: "tenant-1",
+    site_id: "site-1",
+    target_type: "plugin",
+    target_slug: "akismet",
+    status: "succeeded",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeBackupSnapshot(
+  overrides: Partial<BackupSnapshot> = {},
+): BackupSnapshot {
+  return {
+    id: "snap-1",
+    tenant_id: "tenant-1",
+    site_id: "site-1",
+    kind: "full",
+    status: "completed",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeActivityEvent(
+  overrides: Partial<SiteActivityEvent> = {},
+): SiteActivityEvent {
+  return {
+    id: "evt-1",
+    seq: 1,
+    event_type: "plugin.activated",
+    object_type: "plugin",
+    object_id: "akismet",
+    object_label: "Akismet",
+    actor_user_id: 1,
+    actor_login: "admin",
+    actor_ip: "127.0.0.1",
+    summary: "Activated plugin Akismet",
+    meta: {},
+    severity: "low",
+    prev_hash: "0".repeat(64),
+    this_hash: "1".repeat(64),
+    chain_valid: true,
+    occurred_at: "2026-01-01T00:00:00Z",
+    received_at: "2026-01-01T00:00:01Z",
+    ...overrides,
+  };
+}
+
+function makePhpError(overrides: Partial<PhpError> = {}): PhpError {
+  return {
+    id: "err-1",
+    md5: "abc123",
+    code: 256,
+    severity: "fatal",
+    message: "Call to undefined function foo()",
+    file: "/wp-content/plugins/broken/broken.php",
+    line: 42,
+    request_path: "/",
+    first_seen_at: "2026-01-01T00:00:00Z",
+    last_seen_at: "2026-01-01T00:00:00Z",
+    occurrence_count: 1,
+    silenced: false,
+    backtrace: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-source mappers
+// ---------------------------------------------------------------------------
+
+describe("updateTasksToTimeline", () => {
+  it("labels a succeeded task as 'Updated <type> <slug>'", () => {
+    const item = updateTasksToTimeline([
+      makeUpdateTask({ status: "succeeded", target_type: "plugin", target_slug: "akismet" }),
+    ])[0]!;
+    expect(item.label).toBe("Updated plugin akismet");
+    expect(item.source).toBe("update");
+  });
+
+  it("labels a failed task distinctly", () => {
+    const item = updateTasksToTimeline([makeUpdateTask({ status: "failed" })])[0]!;
+    expect(item.label).toBe("Failed to update plugin akismet");
+  });
+
+  it("labels a rolled-back task distinctly", () => {
+    const item = updateTasksToTimeline([makeUpdateTask({ status: "rolled_back" })])[0]!;
+    expect(item.label).toBe("Rolled back plugin akismet update");
+  });
+
+  it("prefers finished_at, then started_at, then updated_at, then created_at for the timestamp", () => {
+    const withFinished = updateTasksToTimeline([
+      makeUpdateTask({
+        finished_at: "2026-01-02T00:00:00Z",
+        started_at: "2026-01-01T12:00:00Z",
+        created_at: "2026-01-01T00:00:00Z",
+      }),
+    ])[0]!;
+    expect(withFinished.timestamp).toBe("2026-01-02T00:00:00Z");
+
+    const withoutFinished = updateTasksToTimeline([
+      makeUpdateTask({
+        finished_at: undefined,
+        started_at: "2026-01-01T12:00:00Z",
+        created_at: "2026-01-01T00:00:00Z",
+      }),
+    ])[0]!;
+    expect(withoutFinished.timestamp).toBe("2026-01-01T12:00:00Z");
+  });
+
+  it("includes a from -> to version detail when both are present", () => {
+    const item = updateTasksToTimeline([
+      makeUpdateTask({ from_version: "5.0", to_version: "5.1" }),
+    ])[0]!;
+    expect(item.detail).toBe("5.0 to 5.1");
+  });
+
+  it("omits the detail when versions are absent", () => {
+    const item = updateTasksToTimeline([makeUpdateTask()])[0]!;
+    expect(item.detail).toBeUndefined();
+  });
+});
+
+describe("backupsToTimeline", () => {
+  it("labels a completed full backup", () => {
+    const item = backupsToTimeline([
+      makeBackupSnapshot({ kind: "full", status: "completed" }),
+    ])[0]!;
+    expect(item.label).toBe("Full backup completed");
+    expect(item.source).toBe("backup");
+  });
+
+  it("labels a failed database backup and carries the error as detail", () => {
+    const item = backupsToTimeline([
+      makeBackupSnapshot({ kind: "db", status: "failed", error: "disk full" }),
+    ])[0]!;
+    expect(item.label).toBe("Database backup failed");
+    expect(item.detail).toBe("disk full");
+  });
+
+  it("uses finished_at over created_at when present", () => {
+    const item = backupsToTimeline([
+      makeBackupSnapshot({
+        finished_at: "2026-01-02T00:00:00Z",
+        created_at: "2026-01-01T00:00:00Z",
+      }),
+    ])[0]!;
+    expect(item.timestamp).toBe("2026-01-02T00:00:00Z");
+  });
+});
+
+describe("activityToTimeline", () => {
+  it("maps summary/occurred_at/actor_login straight through", () => {
+    const item = activityToTimeline([
+      makeActivityEvent({ summary: "Updated theme Twenty Twenty-Five", actor_login: "jane" }),
+    ])[0]!;
+    expect(item.source).toBe("activity");
+    expect(item.label).toBe("Updated theme Twenty Twenty-Five");
+    expect(item.detail).toBe("jane");
+  });
+
+  it("omits detail for a system event with no actor login", () => {
+    const item = activityToTimeline([makeActivityEvent({ actor_login: "" })])[0]!;
+    expect(item.detail).toBeUndefined();
+  });
+});
+
+describe("phpErrorsToTimeline", () => {
+  it("labels with severity + message and details the file:line", () => {
+    const item = phpErrorsToTimeline([
+      makePhpError({
+        severity: "fatal",
+        message: "Call to undefined function foo()",
+        file: "/wp-content/plugins/broken/broken.php",
+        line: 42,
+      }),
+    ])[0]!;
+    expect(item.source).toBe("php_error");
+    expect(item.label).toBe("PHP fatal: Call to undefined function foo()");
+    expect(item.detail).toBe("/wp-content/plugins/broken/broken.php:42");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeIncidentTimeline — windowing + per-source limit + global sort
+// ---------------------------------------------------------------------------
+
+const ISO_START = "2026-06-01T12:00:00Z";
+const ISO_END = "2026-06-01T13:00:00Z";
+
+function item(source: TimelineItem["source"], id: string, timestamp: string): TimelineItem {
+  return { source, id, timestamp, label: `${source}-${id}` };
+}
+
+describe("mergeIncidentTimeline", () => {
+  it("keeps items inside the incident window and drops items far outside it", () => {
+    const inside = item("backup", "in", "2026-06-01T12:30:00Z");
+    const farBefore = item("backup", "before", "2026-06-01T09:00:00Z");
+    const farAfter = item("backup", "after", "2026-06-01T18:00:00Z");
+
+    const result = mergeIncidentTimeline(
+      [[inside, farBefore, farAfter]],
+      { start: ISO_START, end: ISO_END },
+    );
+
+    expect(result.map((r) => r.id)).toEqual(["in"]);
+  });
+
+  it("includes items within the context padding just outside the strict window", () => {
+    // 10 minutes before started_at — inside the default 15-minute padding.
+    const justBefore = item("backup", "just-before", "2026-06-01T11:50:00Z");
+    const result = mergeIncidentTimeline(
+      [[justBefore]],
+      { start: ISO_START, end: ISO_END },
+    );
+    expect(result.map((r) => r.id)).toEqual(["just-before"]);
+  });
+
+  it("excludes items outside the padded window", () => {
+    // 20 minutes before started_at — outside the default 15-minute padding.
+    const tooEarly = item("backup", "too-early", "2026-06-01T11:40:00Z");
+    const result = mergeIncidentTimeline(
+      [[tooEarly]],
+      { start: ISO_START, end: ISO_END },
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("treats a null end (ongoing incident) as extending to now", () => {
+    const recent = item("activity", "recent", new Date().toISOString());
+    const ancient = item("activity", "ancient", "2020-01-01T00:00:00Z");
+    const result = mergeIncidentTimeline(
+      [[recent, ancient]],
+      { start: "2026-01-01T00:00:00Z", end: null },
+    );
+    expect(result.map((r) => r.id)).toEqual(["recent"]);
+  });
+
+  it("sorts newest first within a single merged result", () => {
+    const older = item("update", "older", "2026-06-01T12:10:00Z");
+    const newer = item("update", "newer", "2026-06-01T12:50:00Z");
+    const result = mergeIncidentTimeline(
+      [[older, newer]],
+      { start: ISO_START, end: ISO_END },
+    );
+    expect(result.map((r) => r.id)).toEqual(["newer", "older"]);
+  });
+
+  it("caps each source list to perSourceLimit before merging", () => {
+    const items = Array.from({ length: 8 }, (_, i) =>
+      item("update", `u${i}`, `2026-06-01T12:${String(i * 5).padStart(2, "0")}:00Z`),
+    );
+    const result = mergeIncidentTimeline([items], { start: ISO_START, end: ISO_END }, {
+      perSourceLimit: 3,
+    });
+    expect(result).toHaveLength(3);
+    // Newest three of the eight: u7, u6, u5 (indices 7,6,5 have the latest timestamps).
+    expect(result.map((r) => r.id)).toEqual(["u7", "u6", "u5"]);
+  });
+
+  it("caps the final merged result to totalLimit across all sources", () => {
+    const backupItems = [item("backup", "b1", "2026-06-01T12:10:00Z")];
+    const updateItems = [item("update", "u1", "2026-06-01T12:20:00Z")];
+    const activityItems = [item("activity", "a1", "2026-06-01T12:30:00Z")];
+    const phpItems = [item("php_error", "p1", "2026-06-01T12:40:00Z")];
+
+    const result = mergeIncidentTimeline(
+      [backupItems, updateItems, activityItems, phpItems],
+      { start: ISO_START, end: ISO_END },
+      { totalLimit: 2 },
+    );
+    expect(result).toHaveLength(2);
+    // Newest two overall: p1 (12:40) then a1 (12:30).
+    expect(result.map((r) => r.id)).toEqual(["p1", "a1"]);
+  });
+
+  it("drops items with an unparseable timestamp instead of throwing", () => {
+    const bad = item("backup", "bad", "not-a-real-date");
+    const good = item("backup", "good", "2026-06-01T12:30:00Z");
+    const result = mergeIncidentTimeline(
+      [[bad, good]],
+      { start: ISO_START, end: ISO_END },
+    );
+    expect(result.map((r) => r.id)).toEqual(["good"]);
+  });
+
+  it("returns an empty array when every source list is empty", () => {
+    expect(
+      mergeIncidentTimeline([[], [], [], []], { start: ISO_START, end: ISO_END }),
+    ).toEqual([]);
+  });
+});

--- a/apps/web/src/features/fleet/incident-timeline.ts
+++ b/apps/web/src/features/fleet/incident-timeline.ts
@@ -1,0 +1,168 @@
+// Pure helpers for building the incident detail dialog's client-composed
+// "what happened around this incident" timeline (GH #148). The dialog pulls
+// from four existing hooks (update runs, backups, activity, PHP errors),
+// tags each row with a source kind, and merge-sorts everything newest-first
+// around the incident's `[started_at, ended_at]` window. Extracted here so
+// the merge/sort/window logic can be unit tested without mounting the
+// dialog or any of its four data hooks.
+
+import type {
+  UpdateTask,
+  BackupSnapshot,
+  SiteActivityEvent,
+  PhpError,
+} from "@wpmgr/api";
+
+export type TimelineSource = "update" | "backup" | "activity" | "php_error";
+
+export interface TimelineItem {
+  source: TimelineSource;
+  id: string;
+  /** ISO timestamp used for windowing and sort order. */
+  timestamp: string;
+  label: string;
+  detail?: string;
+}
+
+export interface IncidentWindow {
+  start: string;
+  /** `null` means the incident is still ongoing (window extends to "now"). */
+  end: string | null;
+}
+
+/** Context padding either side of the incident window, in milliseconds. */
+export const TIMELINE_WINDOW_PADDING_MS = 15 * 60 * 1000; // 15 minutes
+
+// ---------------------------------------------------------------------------
+// Per-source mappers — real SDK shapes -> the minimal TimelineItem shape
+// ---------------------------------------------------------------------------
+
+function backupKindLabel(kind: BackupSnapshot["kind"]): string {
+  switch (kind) {
+    case "files":
+      return "Files";
+    case "db":
+      return "Database";
+    case "full":
+      return "Full";
+    default:
+      return "Backup";
+  }
+}
+
+/** Update tasks, already filtered to the site the incident belongs to. */
+export function updateTasksToTimeline(tasks: UpdateTask[]): TimelineItem[] {
+  return tasks
+    .map((task): TimelineItem | null => {
+      const timestamp =
+        task.finished_at ?? task.started_at ?? task.updated_at ?? task.created_at;
+      if (!timestamp) return null;
+      const target = `${task.target_type} ${task.target_slug}`;
+      let label: string;
+      if (task.status === "failed") label = `Failed to update ${target}`;
+      else if (task.status === "rolled_back")
+        label = `Rolled back ${target} update`;
+      else if (task.status === "succeeded") label = `Updated ${target}`;
+      else label = `${target} update ${task.status}`;
+      const detail =
+        task.from_version && task.to_version
+          ? `${task.from_version} to ${task.to_version}`
+          : undefined;
+      return { source: "update", id: task.id, timestamp, label, detail };
+    })
+    .filter((item): item is TimelineItem => item !== null);
+}
+
+export function backupsToTimeline(snapshots: BackupSnapshot[]): TimelineItem[] {
+  return snapshots.map((snapshot): TimelineItem => {
+    const timestamp = snapshot.finished_at ?? snapshot.created_at;
+    const kindLabel = backupKindLabel(snapshot.kind);
+    let label: string;
+    if (snapshot.status === "completed") label = `${kindLabel} backup completed`;
+    else if (snapshot.status === "failed") label = `${kindLabel} backup failed`;
+    else label = `${kindLabel} backup ${snapshot.status}`;
+    return {
+      source: "backup",
+      id: snapshot.id,
+      timestamp,
+      label,
+      detail: snapshot.error,
+    };
+  });
+}
+
+export function activityToTimeline(
+  events: SiteActivityEvent[],
+): TimelineItem[] {
+  return events.map((event): TimelineItem => ({
+    source: "activity",
+    id: event.id,
+    timestamp: event.occurred_at,
+    label: event.summary,
+    detail: event.actor_login || undefined,
+  }));
+}
+
+export function phpErrorsToTimeline(errors: PhpError[]): TimelineItem[] {
+  return errors.map((err): TimelineItem => ({
+    source: "php_error",
+    id: err.id,
+    timestamp: err.last_seen_at,
+    label: `PHP ${err.severity}: ${err.message}`,
+    detail: `${err.file}:${err.line}`,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Window filter + merge-sort
+// ---------------------------------------------------------------------------
+
+function withinWindow(
+  timestamp: string,
+  window: IncidentWindow,
+  paddingMs: number,
+): boolean {
+  const t = Date.parse(timestamp);
+  if (!Number.isFinite(t)) return false;
+  const startMs = Date.parse(window.start) - paddingMs;
+  if (!Number.isFinite(startMs)) return false;
+  const endMs = (window.end ? Date.parse(window.end) : Date.now()) + paddingMs;
+  return t >= startMs && t <= endMs;
+}
+
+export interface MergeIncidentTimelineOptions {
+  /** Max items kept per source list after windowing (newest first). Default 5. */
+  perSourceLimit?: number;
+  /** Max items in the final merged result. Default 20. */
+  totalLimit?: number;
+  /** Context padding either side of the window, in ms. Default 15 minutes. */
+  paddingMs?: number;
+}
+
+/**
+ * Filter each source list to the incident window (plus context padding),
+ * keep the newest `perSourceLimit` per source, then merge and sort the
+ * whole set newest-first, capped at `totalLimit`.
+ */
+export function mergeIncidentTimeline(
+  sourceLists: TimelineItem[][],
+  window: IncidentWindow,
+  options?: MergeIncidentTimelineOptions,
+): TimelineItem[] {
+  const perSourceLimit = options?.perSourceLimit ?? 5;
+  const totalLimit = options?.totalLimit ?? 20;
+  const paddingMs = options?.paddingMs ?? TIMELINE_WINDOW_PADDING_MS;
+
+  const merged: TimelineItem[] = [];
+  for (const list of sourceLists) {
+    const filtered = list
+      .filter((item) => withinWindow(item.timestamp, window, paddingMs))
+      .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+      .slice(0, perSourceLimit);
+    merged.push(...filtered);
+  }
+
+  return merged
+    .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+    .slice(0, totalLimit);
+}

--- a/apps/web/src/features/fleet/uptime-status.ts
+++ b/apps/web/src/features/fleet/uptime-status.ts
@@ -1,0 +1,38 @@
+// Shared status -> icon/label/color-class maps for uptime status kinds
+// (up/degraded/down/unknown). Extracted from the /uptime route so both the
+// page itself and the incident detail dialog render the exact same
+// triple-encoded (colour + label + icon) status language (GH #148) for
+// accessibility, without the dialog importing across the router's
+// auto-code-split route boundary (route files are their own chunk; a
+// feature module importing from one would create an import cycle since the
+// route also imports the feature to mount it).
+
+import {
+  CheckCircle2,
+  AlertTriangle,
+  XCircle,
+  HelpCircle,
+} from "lucide-react";
+
+import type { UptimeStatusKind } from "./fleet-types";
+
+export const STATUS_ICON: Record<UptimeStatusKind, typeof CheckCircle2> = {
+  up: CheckCircle2,
+  degraded: AlertTriangle,
+  down: XCircle,
+  unknown: HelpCircle,
+};
+
+export const STATUS_LABEL: Record<UptimeStatusKind, string> = {
+  up: "Up",
+  degraded: "Degraded",
+  down: "Down",
+  unknown: "Unknown",
+};
+
+export const STATUS_COLOR_CLASS: Record<UptimeStatusKind, string> = {
+  up: "text-[var(--color-success-subtle-fg)]",
+  degraded: "text-[var(--color-warning-subtle-fg)]",
+  down: "text-[var(--color-destructive-subtle-fg)]",
+  unknown: "text-[var(--color-muted-foreground)]",
+};

--- a/apps/web/src/features/fleet/use-fleet-uptime.ts
+++ b/apps/web/src/features/fleet/use-fleet-uptime.ts
@@ -10,6 +10,7 @@ import { fleetKeys } from "./fleet-keys";
 import type {
   FleetStatusResponse,
   FleetIncidentsResponse,
+  IncidentDetail,
 } from "./fleet-types";
 
 const SLOW_THRESHOLD_MS = 2000;
@@ -58,6 +59,37 @@ export function useFleetIncidents(
     },
     refetchInterval: 60_000,
     staleTime: 30_000,
+  });
+}
+
+/**
+ * Fetch the detail for a single fleet incident (GH #148 detail drill-in):
+ * identity, timeline, peak status/last HTTP code/fatal reason, 30d flapping
+ * count, and the newest-first probe window.
+ *
+ * Mirrors `useFleetIncidents`: pass `null` (or an empty string) to disable —
+ * the incident-detail dialog only renders this hook's owning component while
+ * open, so it never fetches while the modal is closed.
+ */
+export function useIncidentDetail(
+  incidentId: string | null,
+): UseQueryResult<IncidentDetail, Error> {
+  return useQuery({
+    queryKey: fleetKeys.incidentDetail(incidentId ?? ""),
+    queryFn: async (): Promise<IncidentDetail> => {
+      const { data, error } = await client.get<IncidentDetail, false>({
+        url: `/api/v1/fleet/incidents/${encodeURIComponent(incidentId ?? "")}`,
+        credentials: "include",
+      });
+      if (error) throw toError(error);
+      if (!data) throw new Error("Empty response from fleet/incidents/:id");
+      return data;
+    },
+    enabled: incidentId !== null && incidentId !== "",
+    // Keep the probe window fresh while the incident is still open; a
+    // resolved incident's probes/reason/duration never change once closed,
+    // so there is nothing to poll for once `ongoing` flips false.
+    refetchInterval: (query) => (query.state.data?.ongoing ? 15_000 : false),
   });
 }
 

--- a/apps/web/src/routes/_authed/uptime.tsx
+++ b/apps/web/src/routes/_authed/uptime.tsx
@@ -46,10 +46,15 @@ import {
   isIncidentOngoing,
   formatIncidentDuration,
 } from "@/features/fleet/incident-format";
+import {
+  STATUS_ICON,
+  STATUS_LABEL,
+  STATUS_COLOR_CLASS,
+} from "@/features/fleet/uptime-status";
+import { IncidentDetailDialog } from "@/features/fleet/incident-detail-dialog";
 import type {
   FleetStatusItem,
   FleetIncident,
-  UptimeStatusKind,
 } from "@/features/fleet/fleet-types";
 import { cn, relativeTime } from "@/lib/utils";
 import { useNow } from "@/lib/use-now";
@@ -57,31 +62,6 @@ import { useNow } from "@/lib/use-now";
 export const Route = createFileRoute("/_authed/uptime")({
   component: UptimePage,
 });
-
-// ---------------------------------------------------------------------------
-// Status colour helpers — status by colour AND label AND icon (a11y)
-// ---------------------------------------------------------------------------
-
-const STATUS_ICON: Record<UptimeStatusKind, typeof CheckCircle2> = {
-  up: CheckCircle2,
-  degraded: AlertTriangle,
-  down: XCircle,
-  unknown: HelpCircle,
-};
-
-const STATUS_LABEL: Record<UptimeStatusKind, string> = {
-  up: "Up",
-  degraded: "Degraded",
-  down: "Down",
-  unknown: "Unknown",
-};
-
-const STATUS_COLOR_CLASS: Record<UptimeStatusKind, string> = {
-  up: "text-[var(--color-success-subtle-fg)]",
-  degraded: "text-[var(--color-warning-subtle-fg)]",
-  down: "text-[var(--color-destructive-subtle-fg)]",
-  unknown: "text-[var(--color-muted-foreground)]",
-};
 
 // ---------------------------------------------------------------------------
 // Tile definitions
@@ -354,10 +334,12 @@ function IncidentsPanel({
   loading,
   isError,
   incidents,
+  onSelect,
 }: {
   loading: boolean;
   isError: boolean;
   incidents: FleetIncident[];
+  onSelect: (incident: FleetIncident) => void;
 }) {
   const open = incidents.filter((i) => isIncidentOngoing(i));
   const closed = incidents.filter((i) => !isIncidentOngoing(i)).slice(0, 10);
@@ -399,7 +381,7 @@ function IncidentsPanel({
               <p className="mb-2 text-xs font-medium text-[var(--color-destructive-subtle-fg)]">
                 Ongoing ({open.length})
               </p>
-              <IncidentList incidents={open} />
+              <IncidentList incidents={open} onSelect={onSelect} />
             </div>
           )}
           {closed.length > 0 && (
@@ -407,7 +389,7 @@ function IncidentsPanel({
               <p className="mb-2 text-xs font-medium text-[var(--color-muted-foreground)]">
                 Recent resolved
               </p>
-              <IncidentList incidents={closed} />
+              <IncidentList incidents={closed} onSelect={onSelect} />
             </div>
           )}
         </div>
@@ -416,7 +398,13 @@ function IncidentsPanel({
   );
 }
 
-function IncidentList({ incidents }: { incidents: FleetIncident[] }) {
+function IncidentList({
+  incidents,
+  onSelect,
+}: {
+  incidents: FleetIncident[];
+  onSelect: (incident: FleetIncident) => void;
+}) {
   return (
     <div
       role="list"
@@ -433,51 +421,49 @@ function IncidentList({ incidents }: { incidents: FleetIncident[] }) {
         const startedLabel = `started ${relativeTime(inc.started_at) ?? inc.started_at}`;
 
         return (
-          <div
-            key={`${inc.site_id}-${inc.started_at}`}
-            role="listitem"
-            className="flex flex-wrap items-center gap-x-4 gap-y-1 px-4 py-2.5 text-xs"
-          >
-            <span
-              className={cn(
-                "inline-flex items-center gap-1 font-medium",
-                ongoing
-                  ? "text-[var(--color-destructive-subtle-fg)]"
-                  : "text-[var(--color-muted-foreground)]",
-              )}
+          <div key={inc.id} role="listitem">
+            {/* Each row opens the incident detail dialog (GH #148 drill-in).
+                Direct site navigation is still reachable via the header link
+                inside that dialog, so this row no longer needs its own
+                <Link> to the site page. */}
+            <button
+              type="button"
+              onClick={() => onSelect(inc)}
+              aria-label={`View incident detail for ${inc.name || inc.url}`}
+              className="flex w-full flex-wrap items-center gap-x-4 gap-y-1 px-4 py-2.5 text-left text-xs hover:bg-[var(--color-accent)]/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--color-ring)]"
             >
-              {ongoing ? (
-                <XCircle aria-hidden="true" className="size-3.5 shrink-0" />
-              ) : (
-                <CheckCircle2 aria-hidden="true" className="size-3.5 shrink-0" />
-              )}
-              {inc.kind === "down" ? "Down" : "Degraded"}
-            </span>
-            {/* Lightweight drill-in: reuse the same Link-to-detail pattern as
-                the fleet Sites table's "Site" column (see buildColumns above)
-                so the name/url stays the click target and is keyboard/a11y
-                navigable — no modal (there's no persisted incident history
-                to show one). */}
-            <Link
-              to="/sites/$siteId"
-              params={{ siteId: inc.site_id }}
-              className="font-medium text-[var(--color-foreground)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
-            >
-              {inc.name || inc.url}
-            </Link>
-            {/* Both time values are labeled so they never read as two bare
-                unlabeled timestamps (GH #148): "started X ago[, ongoing]"
-                and, for resolved incidents only, "for Xh/Xm/Xs". */}
-            <span className="inline-flex items-center gap-1 text-[var(--color-muted-foreground)]">
-              <Clock aria-hidden="true" className="size-3 shrink-0" />
-              {ongoing ? `${startedLabel}, ongoing` : startedLabel}
-            </span>
-            {!ongoing && durationLabel ? (
-              <span className="ml-auto inline-flex items-center gap-1 tabular-nums text-[var(--color-muted-foreground)]">
-                <Timer aria-hidden="true" className="size-3 shrink-0" />
-                for {durationLabel}
+              <span
+                className={cn(
+                  "inline-flex items-center gap-1 font-medium",
+                  ongoing
+                    ? "text-[var(--color-destructive-subtle-fg)]"
+                    : "text-[var(--color-muted-foreground)]",
+                )}
+              >
+                {ongoing ? (
+                  <XCircle aria-hidden="true" className="size-3.5 shrink-0" />
+                ) : (
+                  <CheckCircle2 aria-hidden="true" className="size-3.5 shrink-0" />
+                )}
+                {inc.kind === "down" ? "Down" : "Degraded"}
               </span>
-            ) : null}
+              <span className="font-medium text-[var(--color-foreground)]">
+                {inc.name || inc.url}
+              </span>
+              {/* Both time values are labeled so they never read as two bare
+                  unlabeled timestamps (GH #148): "started X ago[, ongoing]"
+                  and, for resolved incidents only, "for Xh/Xm/Xs". */}
+              <span className="inline-flex items-center gap-1 text-[var(--color-muted-foreground)]">
+                <Clock aria-hidden="true" className="size-3 shrink-0" />
+                {ongoing ? `${startedLabel}, ongoing` : startedLabel}
+              </span>
+              {!ongoing && durationLabel ? (
+                <span className="ml-auto inline-flex items-center gap-1 tabular-nums text-[var(--color-muted-foreground)]">
+                  <Timer aria-hidden="true" className="size-3 shrink-0" />
+                  for {durationLabel}
+                </span>
+              ) : null}
+            </button>
           </div>
         );
       })}
@@ -535,6 +521,13 @@ function UptimePage() {
 
   // Matrix cells — always show all sites (unfiltered), highlight selection.
   const [selectedSiteId, setSelectedSiteId] = useState<string | null>(null);
+
+  // Incident detail dialog (GH #148) — separate from the matrix's
+  // `selectedSiteId` filter state; opening a row's detail must never also
+  // filter the fleet table to that site.
+  const [detailIncident, setDetailIncident] = useState<FleetIncident | null>(
+    null,
+  );
 
   const matrixCells: MatrixCell[] = useMemo(
     () =>
@@ -707,6 +700,12 @@ function UptimePage() {
         loading={incidentsPending}
         isError={incidentsError}
         incidents={incidentsData?.items ?? []}
+        onSelect={setDetailIncident}
+      />
+
+      <IncidentDetailDialog
+        incident={detailIncident}
+        onClose={() => setDetailIncident(null)}
       />
     </section>
   );


### PR DESCRIPTION
Founds the incidents panel on a persisted site_incidents model (written atomically by the alert state machine) so it has real history, accurate durations, and flapping — previously it was live-derived and forgot incidents on recovery. Adds a click-a-row detail modal: identity+status, the incident's probe-code sequence, a merged events timeline (updates/backups/activity/errors), uptime 7/30d, and safe actions. New GET /fleet/incidents/:id (tenant-scoped + CanAccessSite). Security review SHIP (site_scope RESTRICTIVE policy + IDOR tests added). api + web, m94 auto-applies.

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added incident detail views for uptime incidents, including a timeline, probe history, uptime context, and quick actions.
  * Incidents can now be opened from the uptime page without leaving the list.
  * Uptime incidents now retain history across recoveries, with persistent tracking of repeated outages.
* **Bug Fixes**
  * Improved incident handling so repeated down events and recovery states display correctly.
  * Added better incident reason labels and clearer status presentation throughout the uptime experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->