### PR TITLE
feat(agent): post-restore health check + auto-rollback (GH #146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.31] - 2026-07-07
+
+### Added
+
+- Restore now verifies the site actually loads afterward and automatically rolls back if it does not, instead of reporting a broken restore as complete. After the files and database are swapped, a first check confirms the restored database is intact while the site is still in maintenance mode (so a bad database restore is reverted before anyone sees it); then, once the site is live again, a second check confirms it is not serving a fatal error. If either check finds a genuine failure, the restore reverts both the files and the database to their pre-restore state and reports the run as failed with the reason, rather than leaving the site down. A pre-restore database snapshot is captured before the swap and, together with the pre-restore files, is kept for the retention window so a manual rollback stays possible. The checks fail open on an unreachable or ambiguous response so a network blip can never roll back a good restore. Requires agent 0.61.12.
+
 ## [0.61.30] - 2026-07-07
 
 ### Added

--- a/apps/agent/includes/backup/class-files-restorer.php
+++ b/apps/agent/includes/backup/class-files-restorer.php
@@ -653,17 +653,181 @@ final class FilesRestorer
     }
 
     /**
-     * Garbage-collect `.wpmgr-old-files-*` dirs older than the GC age.
-     * Bound to the `wpmgr_restore_oldfiles_gc` cron action.
+     * GH #146 — reverse the whole-wp-content swap performed by `swap()`.
+     * Used by RestoreRunner's post-restore health-check rollback (and the
+     * RestoreGuard shutdown backstop) to undo a files swap that produced an
+     * unhealthy site.
      *
-     * Threshold note: under the 0.9.5 default policy the synchronous cleanup
-     * path in `RestoreRunner::runCleanup()` removes the rollback tree at the
-     * end of the restore, so this cron sweep is only relevant for the opt-in
-     * `keep_old_files=true` path (or for leftovers from a crashed run that
-     * never reached cleanup). We therefore sweep against the LONG threshold —
-     * the operator who opted in explicitly asked for a 24h rollback window,
-     * and we don't want to GC their rollback tree out from under them at the
-     * 1h SHORT threshold.
+     * Mirrors the same rename PRIMITIVE `swap()` itself uses for its own
+     * inline best-effort rollback (see `swap()`'s catch around the
+     * staging->target rename), but this variant runs AFTER a swap has
+     * already fully completed — so the live target dir is non-empty (it
+     * holds the just-restored, unhealthy tree) and must be moved aside
+     * first rather than rmdir'd.
+     *
+     * @param string $targetDir   Live wp-content dir (currently holds the
+     *                             unhealthy just-restored tree).
+     * @param string $oldFilesDir Absolute path recorded in
+     *                             `sub_state['swap_files']['old_files_dir']`.
+     * @param string $restoreId   Restore UUID (names the aside-moved bad tree).
+     * @return void
+     * @throws \RuntimeException When the rollback itself cannot complete —
+     *         the caller is expected to catch this and report it, never let
+     *         it propagate un-handled from a shutdown-function context.
+     */
+    public function revertSwap(string $targetDir, string $oldFilesDir, string $restoreId): void
+    {
+        $targetDir = rtrim($targetDir, DIRECTORY_SEPARATOR);
+        if ($oldFilesDir === '' || !is_dir($oldFilesDir)) {
+            throw new \RuntimeException('FilesRestorer::revertSwap: old_files_dir missing or not recorded: ' . esc_html($oldFilesDir)); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- thrown exception; message goes to log/SSE, not browser
+        }
+
+        if (!is_dir($targetDir)) {
+            // Nothing live to move aside — promote the old tree directly.
+            if (!@rename($oldFilesDir, $targetDir)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic same-filesystem rollback swap; WP_Filesystem::move() is copy+delete (non-atomic) and breaks crash/watchdog-resume safety
+                throw new \RuntimeException('FilesRestorer::revertSwap: cannot restore old tree: ' . esc_html($oldFilesDir) . ' -> ' . esc_html($targetDir)); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- thrown exception; message goes to log/SSE, not browser
+            }
+            return;
+        }
+
+        $parent = dirname($targetDir);
+        $short  = self::shortId($restoreId);
+        $failed = $parent . DIRECTORY_SEPARATOR . '.wpmgr-failed-files-' . $short;
+
+        // Move the bad, just-restored tree aside (never clobber an existing
+        // failed-tree dir from a previous rollback attempt on a watchdog
+        // re-entry of this same revert).
+        if (!is_dir($failed)) {
+            if (!@rename($targetDir, $failed)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic same-filesystem swap; WP_Filesystem::move() is copy+delete (non-atomic) and breaks crash/watchdog-resume safety
+                throw new \RuntimeException('FilesRestorer::revertSwap: cannot move bad tree aside: ' . esc_html($targetDir) . ' -> ' . esc_html($failed)); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- thrown exception; message goes to log/SSE, not browser
+            }
+        }
+
+        if (is_dir($targetDir) && @rmdir($targetDir) === false) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- removes an empty server-derived scratch dir; WP_Filesystem not initialized
+            throw new \RuntimeException('FilesRestorer::revertSwap: target dir reappeared and is not empty: ' . esc_html($targetDir)); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- thrown exception; message goes to log/SSE, not browser
+        }
+
+        if (!@rename($oldFilesDir, $targetDir)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic same-filesystem rollback swap; WP_Filesystem::move() is copy+delete (non-atomic) and breaks crash/watchdog-resume safety
+            // Best-effort: put the bad tree back rather than leave the site
+            // with NEITHER tree in place.
+            @rename($failed, $targetDir); // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic same-filesystem rollback swap; WP_Filesystem::move() is non-atomic
+            throw new \RuntimeException('FilesRestorer::revertSwap: cannot restore old tree: ' . esc_html($oldFilesDir) . ' -> ' . esc_html($targetDir)); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- thrown exception; message goes to log/SSE, not browser
+        }
+
+        // The abandoned bad tree is confirmed unhealthy (that's WHY we're
+        // here) — no forensic value in keeping it around like the
+        // retention-window `.wpmgr-old-files-*` dir, so reclaim it now.
+        self::rrmdir($failed);
+    }
+
+    /**
+     * GH #146 — reverse a per-component swap performed by
+     * `swapComponents()`. For each recorded component, moves the
+     * just-restored (bad) live subdir aside and renames the old-* dir back
+     * into place. The `wp-content` catch-all component reverses every
+     * `.wpmgr-old-wpcontent-<short>-*` sibling recorded during
+     * `swapComponents()`.
+     *
+     * @param string                $targetDir Live wp-content dir.
+     * @param array<string,string>  $oldDirs   `sub_state['swap_files']['old_dirs']`.
+     * @param string                $restoreId Restore UUID.
+     * @return void
+     */
+    public function revertSwapComponents(string $targetDir, array $oldDirs, string $restoreId): void
+    {
+        $targetDir = rtrim($targetDir, DIRECTORY_SEPARATOR);
+        $short     = self::shortId($restoreId);
+
+        foreach ($oldDirs as $comp => $oldAbs) {
+            if (!is_string($oldAbs) || $oldAbs === '') {
+                continue;
+            }
+
+            if ($comp === 'wp-content') {
+                // Catch-all: $oldAbs is the common NAMING PREFIX (never a
+                // real directory itself — only its `-<name>` siblings are).
+                $expectedPrefix = $targetDir . DIRECTORY_SEPARATOR . '.wpmgr-old-wpcontent-' . $short;
+                if ($oldAbs !== $expectedPrefix) {
+                    // Recorded prefix doesn't match this target dir/restore
+                    // id — refuse to glob-expand an unrelated/attacker-
+                    // controlled prefix.
+                    continue;
+                }
+                $hits = @glob($oldAbs . '-*');
+                if (!is_array($hits)) {
+                    continue;
+                }
+                foreach ($hits as $oldItem) {
+                    $name = substr(basename($oldItem), strlen(basename($oldAbs)) + 1);
+                    if ($name === '') {
+                        continue;
+                    }
+                    $liveItem = $targetDir . DIRECTORY_SEPARATOR . $name;
+                    $this->revertSingleItem($liveItem, $oldItem);
+                }
+                continue;
+            }
+
+            $subdir = self::COMPONENT_SUBDIRS[$comp] ?? '';
+            if ($subdir === '') {
+                continue;
+            }
+            $liveSub = $targetDir . DIRECTORY_SEPARATOR . $subdir;
+            $this->revertSingleItem($liveSub, $oldAbs);
+        }
+    }
+
+    /**
+     * Shared single-item reversal used by `revertSwapComponents()`: move
+     * whatever now lives at `$live` aside (best-effort discard — it's
+     * confirmed unhealthy), then rename `$old` back into `$live`'s place.
+     * Handles both directories and files (the wp-content catch-all can
+     * carry top-level files, e.g. `index.php`).
+     *
+     * Never throws — a single component failing to revert must not abort
+     * reverting the rest; failures are logged for the operator.
+     */
+    private function revertSingleItem(string $live, string $old): void
+    {
+        if (!is_dir($old) && !is_file($old) && !is_link($old)) {
+            // Nothing recorded to roll back to — leave live as-is.
+            return;
+        }
+
+        if (file_exists($live) || is_link($live)) {
+            $failed = $live . '.wpmgr-failed-' . bin2hex(random_bytes(4));
+            if (!@rename($live, $failed)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic same-filesystem swap; WP_Filesystem::move() is copy+delete (non-atomic) and breaks crash/watchdog-resume safety
+                \WPMgr\Agent\Support\DebugLog::write('WPMgr FilesRestorer: revert could not move aside: ' . $live);
+                return;
+            }
+            if (is_dir($failed)) {
+                self::rrmdir($failed);
+            } elseif (is_file($failed) || is_link($failed)) {
+                wp_delete_file($failed);
+            }
+        }
+
+        if (!@rename($old, $live)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic same-filesystem rollback swap; WP_Filesystem::move() is non-atomic
+            \WPMgr\Agent\Support\DebugLog::write('WPMgr FilesRestorer: revert could not restore: ' . $old . ' -> ' . $live);
+        }
+    }
+
+    /**
+     * Garbage-collect deferred restore rollback material: `.wpmgr-old-*`
+     * trees (whole-swap AND per-component), `.wpmgr-staging-*` leftovers,
+     * and their `.expires` markers. Bound to the `wpmgr_restore_oldfiles_gc`
+     * cron action.
+     *
+     * GH #146 changed `RestoreRunner::runCleanup()`'s DEFAULT
+     * (`keep_old_files=false`) path from a synchronous `rrmdir()` to a
+     * DEFERRED one: the rollback tree is left in place with a `<path>.expires`
+     * sidecar marker recording exactly when it becomes safe to remove
+     * (`OLDFILES_GC_AGE_SECONDS` from the default path, `_LONG` from the
+     * opt-in `keep_old_files=true` path) — this closes the window a
+     * post-restore health-check rollback needs the tree to still exist in.
+     * A dir WITHOUT a marker predates this scheme, or is a leftover from a
+     * run that crashed before ever reaching `runCleanup()` — those fall back
+     * to the original unconditional LONG-threshold mtime check.
      *
      * @return void
      */
@@ -682,42 +846,112 @@ final class FilesRestorer
             dirname(WP_CONTENT_DIR),
             WP_CONTENT_DIR,
         ]);
-        $now       = time();
-        $threshold = self::OLDFILES_GC_AGE_SECONDS_LONG;
+        $now = time();
+
         foreach ($candidates as $dir) {
             if (!is_dir($dir)) {
                 continue;
             }
-            $hits = @glob($dir . DIRECTORY_SEPARATOR . '.wpmgr-old-files-*');
-            if (!is_array($hits)) {
-                continue;
+
+            // GH #146: sweep every `.expires` marker found — its target may
+            // be a real directory (whole-swap or per-subdir-component old
+            // dir) or, for the wp-content catch-all, a naming PREFIX whose
+            // actual `-<name>` sibling dirs/files need a further glob
+            // expansion (detected at sweep time: the prefix itself is never
+            // a real directory).
+            $markers = @glob($dir . DIRECTORY_SEPARATOR . '.wpmgr-old-*.expires');
+            $markedTargets = [];
+            if (is_array($markers)) {
+                foreach ($markers as $marker) {
+                    $markedTargets[] = substr($marker, 0, -strlen('.expires'));
+                    self::sweepExpiryMarker($marker, $now);
+                }
             }
-            foreach ($hits as $old) {
-                if (!is_dir($old)) {
+
+            // Legacy fallback: dirs from before the marker scheme (or a
+            // crashed run that never reached runCleanup() at all) — sweep
+            // anything past the LONG threshold by raw mtime. Skip anything
+            // that HAS (or had) a marker; that's handled above.
+            foreach (['.wpmgr-old-files-*', '.wpmgr-old-plugins-*', '.wpmgr-old-themes-*', '.wpmgr-old-uploads-*'] as $pattern) {
+                $hits = @glob($dir . DIRECTORY_SEPARATOR . $pattern);
+                if (!is_array($hits)) {
                     continue;
                 }
-                $mtime = @filemtime($old);
-                if ($mtime === false || ($now - (int) $mtime) < $threshold) {
-                    continue;
+                foreach ($hits as $old) {
+                    if (!is_dir($old) || in_array($old, $markedTargets, true)) {
+                        continue;
+                    }
+                    self::gcByMtimeLongThreshold($old, $now);
                 }
-                self::rrmdir($old);
             }
-            // Same sweep for any leftover staging dirs from a crashed run.
+
+            // Same legacy sweep for any leftover staging dirs from a
+            // crashed run (never marker-based — staging dirs are only ever
+            // crash leftovers, not a recorded rollback source).
             $stages = @glob($dir . DIRECTORY_SEPARATOR . '.wpmgr-staging-*');
-            if (!is_array($stages)) {
-                continue;
-            }
-            foreach ($stages as $stage) {
-                if (!is_dir($stage)) {
-                    continue;
+            if (is_array($stages)) {
+                foreach ($stages as $stage) {
+                    if (!is_dir($stage)) {
+                        continue;
+                    }
+                    self::gcByMtimeLongThreshold($stage, $now);
                 }
-                $mtime = @filemtime($stage);
-                if ($mtime === false || ($now - (int) $mtime) < $threshold) {
-                    continue;
-                }
-                self::rrmdir($stage);
             }
         }
+    }
+
+    /**
+     * Reclaim a single `.expires`-marked rollback path once its window has
+     * elapsed. The marker's target may be a real directory or (the
+     * wp-content catch-all case) a naming prefix whose actual siblings are
+     * found via a `-*` glob expansion.
+     */
+    private static function sweepExpiryMarker(string $marker, int $now): void
+    {
+        $target = substr($marker, 0, -strlen('.expires'));
+        $raw    = @file_get_contents($marker);
+        $expiresAt = $raw !== false && trim($raw) !== '' ? (int) trim($raw) : 0;
+
+        if ($expiresAt <= 0) {
+            // Corrupt/unreadable marker — drop it so we don't retry forever,
+            // but leave the target alone (fail safe: never delete on
+            // ambiguity about WHEN it's safe to).
+            wp_delete_file($marker);
+            return;
+        }
+        if ($now < $expiresAt) {
+            return; // Not due yet.
+        }
+
+        if (is_dir($target)) {
+            self::rrmdir($target);
+        } else {
+            // Catch-all prefix: expand + remove its `-<name>` siblings.
+            $items = @glob($target . '-*');
+            if (is_array($items)) {
+                foreach ($items as $item) {
+                    if (is_dir($item)) {
+                        self::rrmdir($item);
+                    } elseif (is_file($item) || is_link($item)) {
+                        wp_delete_file($item);
+                    }
+                }
+            }
+        }
+        wp_delete_file($marker);
+    }
+
+    /**
+     * Legacy (marker-less) reclaim path: remove a dir once it is older than
+     * the LONG GC threshold.
+     */
+    private static function gcByMtimeLongThreshold(string $dir, int $now): void
+    {
+        $mtime = @filemtime($dir);
+        if ($mtime === false || ($now - (int) $mtime) < self::OLDFILES_GC_AGE_SECONDS_LONG) {
+            return;
+        }
+        self::rrmdir($dir);
     }
 
     // ==================================================================

--- a/apps/agent/includes/backup/class-restore-guard.php
+++ b/apps/agent/includes/backup/class-restore-guard.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * RestoreGuard: GH #146 — per-run shutdown-time backstop that performs the
+ * combined files+DB rollback if the PHP process driving a restore is hard-
+ * killed somewhere in the window between the destructive swap(s) completing
+ * and the post-restore health-check verdict being reached.
+ *
+ * Structurally a direct mirror of `WPMgr\Agent\Support\UpdateGuard` (see
+ * that class's doc for the full "why a shutdown-function object, not a bare
+ * closure" rationale) — two bool flags (`$clean`/`$fired`),
+ * `register_shutdown_function([$this,'fire'])`, idempotent, never lets a
+ * `\Throwable` escape `fire()`. The one structural difference: `fire()`
+ * invokes the supplied rollback callable (RestoreRunner's combined
+ * files+DB rollback) instead of `SnapshotManager::restore()`.
+ *
+ * V1 scope — deliberately narrow: a per-request, in-memory object. It
+ * protects the crash window of ONE `RestoreRunner::run()` invocation, from
+ * wherever `RestoreRunner` arms it (right before the first destructive
+ * rename) through `markClean()`. Full design notes (V1 scope limits,
+ * markClean() timing across GH #146's two health-check gates, and how a
+ * guard-fired rollback stays visitor-safe) live at the bottom of this file.
+ *
+ * @package WPMgr\Agent\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Backup;
+
+if (!defined('ABSPATH')) {
+    exit; // No direct access.
+}
+
+/**
+ * Fires a combined files+DB rollback on PHP shutdown unless the restore run
+ * this guard covers was confirmed healthy first.
+ */
+final class RestoreGuard
+{
+    /** @var callable():array{files:bool,db:bool,reason?:string} */
+    private $rollback;
+
+    /**
+     * Set once the restore this guard covers has been verified healthy.
+     * While true, fire() is permanently a no-op — a confirmed-good restore
+     * must never be rolled back retroactively by a later, unrelated
+     * shutdown.
+     */
+    private bool $clean = false;
+
+    /**
+     * Set the first time fire() actually performs (or attempts) a
+     * rollback. Makes fire() idempotent — a synchronous call from
+     * RestoreRunner's own health-check failure handling and a subsequent
+     * real-shutdown invocation of the same guard must never roll back
+     * twice.
+     */
+    private bool $fired = false;
+
+    /**
+     * @param callable():array{files:bool,db:bool,reason?:string} $rollback
+     *        Performs the combined files+DB rollback and reports which legs
+     *        completed (an optional `reason` explains a legs-skipped
+     *        outcome, e.g. `db_rollback_unavailable`). MUST NEVER throw — a
+     *        shutdown-function context has nowhere useful to propagate an
+     *        exception to; the caller's implementation catches internally.
+     */
+    public function __construct(callable $rollback)
+    {
+        $this->rollback = $rollback;
+    }
+
+    /**
+     * Register this guard's fire() as a PHP shutdown callback. Safe to
+     * call more than once — PHP tolerates duplicate shutdown callbacks and
+     * a redundant fire() is a cheap, idempotent no-op.
+     */
+    public function arm(): void
+    {
+        register_shutdown_function([$this, 'fire']);
+    }
+
+    /**
+     * Mark the restore this guard covers as verified-healthy. MUST be
+     * called before the LAST health-check gate returns a passing verdict —
+     * GH #146's two-gate restructure means that's `health_check_live`
+     * (Gate 2, the loopback WSOD probe on the real post-maintenance site),
+     * NOT `health_check` (Gate 1, the in-process DB probe) — an armed guard
+     * that never learns the restore was healthy would otherwise undo it if
+     * the request is torn down by something unrelated later in the same
+     * shutdown chain.
+     */
+    public function markClean(): void
+    {
+        $this->clean = true;
+    }
+
+    /**
+     * Perform the rollback unless the restore was already confirmed clean,
+     * or this guard has already fired once. Safe to call from a real PHP
+     * shutdown handler (return value unused there) or synchronously from
+     * RestoreRunner's own health-check failure handling.
+     *
+     * @return array{fired:bool,files:bool,db:bool,reason:string} fired=false
+     *     means this call was a no-op (already clean or already fired);
+     *     files/db/reason only mean something when fired=true.
+     */
+    public function fire(): array
+    {
+        if ($this->clean || $this->fired) {
+            return ['fired' => false, 'files' => false, 'db' => false, 'reason' => ''];
+        }
+        $this->fired = true;
+
+        try {
+            $result = ($this->rollback)();
+        } catch (\Throwable $e) {
+            \WPMgr\Agent\Support\DebugLog::write(
+                'WPMgr Agent: RestoreGuard rollback threw: ' . $e->getMessage()
+            );
+            return ['fired' => true, 'files' => false, 'db' => false, 'reason' => 'rollback_threw'];
+        }
+
+        return [
+            'fired'  => true,
+            'files'  => (bool) ($result['files'] ?? false),
+            'db'     => (bool) ($result['db'] ?? false),
+            'reason' => isset($result['reason']) && is_string($result['reason']) ? $result['reason'] : '',
+        ];
+    }
+}
+
+/*
+ * Design notes (referenced from the class docblock above; kept down here so
+ * the ABSPATH direct-access guard stays within the first ~50 lines of the
+ * file, which is what Plugin Check's Direct_File_Access_Check regex
+ * fallback scans).
+ *
+ * V1 scope limits: a hard kill landing BEFORE this guard is armed, or in a
+ * re-entry that resumes mid-flight without ever passing through the swap
+ * phases again in the SAME request, is NOT covered here — recovery for
+ * those falls back to RestoreWatchdog's existing stall-detection + resume
+ * path. A full out-of-band RestoreInFlight reconcile sweep (mirroring
+ * UpdateInFlight, which closes the equivalent gap for update-apply) would
+ * close that remaining window too, but is an explicit FAST-FOLLOW, not
+ * built here.
+ *
+ * markClean() timing across GH #146's two health-check gates: the guard
+ * stays armed across BOTH health_check (Gate 1, in-process DB probe, still
+ * under maintenance) and health_check_live (Gate 2, the loopback WSOD probe
+ * against the real post-maintenance site) — only Gate 2 passing calls
+ * markClean(), since Gate 2 is the last checkpoint before completed.
+ *
+ * Visitor-visibility during a guard-fired rollback: RestoreRunner::
+ * performRollback() (the rollback callable this guard invokes) wraps its
+ * OWN actual revert in maintenanceOn()/finally maintenanceOff()
+ * unconditionally — so a rollback fired by this guard, whether via a
+ * synchronous call from routeRollback() during either gate's own failure
+ * handling, or asynchronously via a real PHP shutdown, is uniformly
+ * protected, with no special-casing needed in this class.
+ */

--- a/apps/agent/includes/backup/class-restore-health-check-failed.php
+++ b/apps/agent/includes/backup/class-restore-health-check-failed.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * RestoreHealthCheckFailed: GH #146 — thrown by EITHER of RestoreRunner's
+ * two health-check gates (`runHealthCheck()` — Gate 1, in-process DB probe;
+ * `runHealthCheckLive()` — Gate 2, loopback WSOD probe on the real
+ * post-maintenance site) when a definitive fatal is found, AFTER the
+ * combined files+DB rollback has already been performed.
+ *
+ * Caught by `RestoreRunner::run()`'s existing top-level catch, which
+ * already reports `failed` + `last_error` + `failed_in` for every
+ * exception type (`failed_in` distinguishes which gate: `health_check` vs
+ * `health_check_live`); this subclass exists ONLY so that catch block can
+ * also attach the `rolled_back:{files,db,reason}` detail without
+ * inspecting message strings or re-deriving it. `reason` is one of
+ * `db_unhealthy_post_restore` (Gate 1), `wsod_post_restore` (Gate 2), or
+ * `db_rollback_unavailable` (either gate, when the DB was swapped but no
+ * rollback source exists — neither leg is touched in that case).
+ *
+ * @package WPMgr\Agent\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Backup;
+
+if (!defined('ABSPATH')) {
+    exit; // No direct access.
+}
+
+/**
+ * Carries which rollback legs actually completed alongside the standard
+ * RuntimeException message.
+ */
+final class RestoreHealthCheckFailed extends \RuntimeException
+{
+    /** @var array{files:bool,db:bool,reason?:string} */
+    private array $rolledBack;
+
+    /**
+     * @param string                              $message    Human-readable failure summary.
+     * @param array{files:bool,db:bool,reason?:string} $rolledBack Which rollback legs completed
+     *        (`reason` is set instead when neither leg was even attempted,
+     *        e.g. `db_rollback_unavailable`).
+     */
+    public function __construct(string $message, array $rolledBack)
+    {
+        parent::__construct($message);
+        $this->rolledBack = $rolledBack;
+    }
+
+    /**
+     * @return array{files:bool,db:bool,reason?:string}
+     */
+    public function rolledBack(): array
+    {
+        return $this->rolledBack;
+    }
+}

--- a/apps/agent/includes/backup/class-restore-health-check.php
+++ b/apps/agent/includes/backup/class-restore-health-check.php
@@ -1,0 +1,508 @@
+<?php
+/**
+ * RestoreHealthCheck: GH #146 — post-restore boot verification.
+ *
+ * `RestoreRunner`'s state machine reported `completed` the instant the file
+ * and/or DB swap renames succeeded, with nothing checking whether the
+ * swapped-in site actually BOOTS. This class is the check RestoreRunner runs
+ * (as the `health_check` phase, between `post_hooks` and `maintenance_off`)
+ * to close that gap, mirroring the fail-open discipline
+ * `UpdateRunner::isComplete()` / GitHub issue #131 already established: a
+ * constrained or ambiguous detection environment must NEVER cause a false
+ * rollback of a genuinely good restore. Two probes — see `checkDatabase()`
+ * (Probe A, DB, always runs, hard-fail-on-error) and `checkLoopback()`
+ * (Probe B, the loopback boot/WSOD gate, with a maintenance-mode-aware,
+ * fail-open classification — see that method's doc for the full rationale).
+ *
+ * Verdict: `ok = ProbeA.ok && (ProbeB.ok || ProbeB.inconclusive)`. The
+ * caller (`RestoreRunner::runHealthCheck()`) rolls back ONLY on a
+ * definitive fatal from either probe — never on an inconclusive/blocked
+ * result.
+ *
+ * @package WPMgr\Agent\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Backup;
+
+if (!defined('ABSPATH')) {
+    exit; // No direct access.
+}
+
+/**
+ * Stateless — every call to run() re-probes fresh. Holds no DB/HTTP
+ * collaborators of its own; talks to the live `global $wpdb` and the WP
+ * HTTP API directly, exactly like `RestoreCommand::preflightChecks()` does
+ * for its own DB ping. The one piece of state it accepts is the WP root
+ * path, so it can check for the runner's own `.maintenance` drop-file.
+ */
+final class RestoreHealthCheck
+{
+    /** Loopback HTTP probe timeout, seconds. */
+    private const LOOPBACK_TIMEOUT_SECONDS = 10;
+
+    /** Capped redirect-follow count for the loopback probes. */
+    private const LOOPBACK_MAX_REDIRECTS = 2;
+
+    /** User-Agent identifying these probes in server access logs. */
+    private const USER_AGENT = 'WPMgr-Agent-HealthCheck';
+
+    /**
+     * Case-insensitive substrings that, found anywhere in a probe response
+     * body, are treated as definitive proof of a fatal PHP error rendering
+     * to the browser (a "White Screen Of Death" the HTTP status code alone
+     * doesn't always signal — a fatal under `display_errors` still often
+     * returns 200).
+     *
+     * @var list<string>
+     */
+    private const FATAL_BODY_SIGNATURES = [
+        'Fatal error',
+        'There has been a critical error on this website',
+    ];
+
+    /**
+     * Case-insensitive markers that, found anywhere in a 2xx response body,
+     * count as "recognizable HTML" — a real rendered page, not a blank/
+     * truncated response a swallowed fatal (`display_errors=Off`) can leave
+     * behind under a 200 status.
+     *
+     * @var list<string>
+     */
+    private const HTML_MARKERS = ['<html', '<!doctype', '<body'];
+
+    /** Absolute WP root path — used only to check for `.maintenance`. */
+    private string $wpRoot;
+
+    /**
+     * @param string $wpRoot Absolute WP root (ABSPATH). Defaults to the real
+     *                       `ABSPATH` constant when not supplied.
+     */
+    public function __construct(string $wpRoot = '')
+    {
+        $this->wpRoot = $wpRoot !== '' ? $wpRoot : (defined('ABSPATH') ? (string) constant('ABSPATH') : '');
+    }
+
+    /**
+     * Run both probes and compute the combined verdict.
+     *
+     * @return array{ok:bool,failures:list<string>,warnings:list<string>}
+     */
+    public function run(): array
+    {
+        $failures = [];
+        $warnings = [];
+
+        $probeA = $this->checkDatabase();
+        if (!$probeA['ok']) {
+            $failures = array_merge($failures, $probeA['failures']);
+        }
+
+        $probeB = $this->checkLoopback();
+        if ($probeB['inconclusive']) {
+            $warnings[] = $probeB['detail'];
+        } elseif (!$probeB['ok']) {
+            $failures[] = $probeB['detail'];
+        }
+
+        $ok = $probeA['ok'] && ($probeB['ok'] || $probeB['inconclusive']);
+
+        return [
+            'ok'       => $ok,
+            'failures' => $failures,
+            'warnings' => $warnings,
+        ];
+    }
+
+    /**
+     * Probe B ONLY — same `{ok,failures,warnings}` shape as `run()`, for
+     * `RestoreRunner`'s Gate 2 (`health_check_live`), which runs the
+     * loopback probe AFTER Probe A already passed in Gate 1
+     * (`health_check`). `ok` follows the same fail-open rule as `run()`'s
+     * combined verdict: true on either a confident pass OR an inconclusive
+     * result — a destructive rollback fires only on a definitive fatal.
+     *
+     * @return array{ok:bool,failures:list<string>,warnings:list<string>}
+     */
+    public function checkLoopbackOnly(): array
+    {
+        $failures = [];
+        $warnings = [];
+
+        $probeB = $this->checkLoopback();
+        if ($probeB['inconclusive']) {
+            $warnings[] = $probeB['detail'];
+        } elseif (!$probeB['ok']) {
+            $failures[] = $probeB['detail'];
+        }
+
+        return [
+            'ok'       => $probeB['ok'] || $probeB['inconclusive'],
+            'failures' => $failures,
+            'warnings' => $warnings,
+        ];
+    }
+
+    // ==================================================================
+    // Probe A — in-process DB check (public: also used as the "quick
+    // re-check" RestoreRunner runs immediately after a rollback).
+    // ==================================================================
+
+    /**
+     * Assert the (post-swap) live tables exist and answer queries. Reads
+     * are made directly against `global $wpdb` — freshly, never through
+     * `get_option()`/the object cache, which could still hold a pre-swap
+     * cached value and mask a genuinely broken options table.
+     *
+     * @return array{ok:bool,failures:list<string>}
+     */
+    public function checkDatabase(): array
+    {
+        global $wpdb;
+        if (!is_object($wpdb)) {
+            return ['ok' => false, 'failures' => ['DB probe: $wpdb is not available']];
+        }
+
+        $failures = [];
+
+        // $wpdb's declared type here is bare `object` (a runtime interface,
+        // not a concrete class) — every property access below is guarded by
+        // isset()+is_string() first; PHPStan only needs an explicit ignore
+        // for the METHOD calls (get_var()) and the `last_error` property,
+        // which are never isset()-narrowed.
+        $prefix = isset($wpdb->prefix) && is_string($wpdb->prefix) ? $wpdb->prefix : 'wp_';
+
+        // siteurl — a fresh, uncached read straight off the live options
+        // table. A missing/empty value after a restore swap means the
+        // options table is either gone or the swap landed on the wrong
+        // tables entirely.
+        try {
+            $optionsTable = $prefix . 'options';
+            if (isset($wpdb->options) && is_string($wpdb->options) && $wpdb->options !== '') {
+                $optionsTable = $wpdb->options;
+            }
+            /** @phpstan-ignore-next-line — $wpdb is a runtime interface. */
+            $siteurl = $wpdb->get_var("SELECT option_value FROM {$optionsTable} WHERE option_name = 'siteurl' LIMIT 1"); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,PluginCheck.Security.DirectDB.UnescapedDBParameter -- $optionsTable is either the real $wpdb->options property or prefix+the literal 'options', never user input; a fresh uncached read of the just-swapped live table is the entire point of this probe
+            /** @phpstan-ignore-next-line — $wpdb is a runtime interface. */
+            $lastError = (string) $wpdb->last_error;
+            if ($lastError !== '') {
+                $failures[] = 'DB probe: siteurl query error: ' . substr($lastError, 0, 200);
+            } elseif (!is_string($siteurl) || trim($siteurl) === '') {
+                $failures[] = 'DB probe: siteurl is empty after the restore swap';
+            }
+        } catch (\Throwable $e) {
+            $failures[] = 'DB probe: siteurl query threw: ' . substr($e->getMessage(), 0, 200);
+        }
+
+        // users / posts — presence + answerability, not content
+        // correctness. A NULL/empty result is fine (an empty table is a
+        // legitimate site state); only a DB-level error (missing table,
+        // connection drop) is a failure.
+        foreach (['users', 'posts'] as $core) {
+            try {
+                $table = $prefix . $core;
+                if (isset($wpdb->{$core}) && is_string($wpdb->{$core}) && $wpdb->{$core} !== '') {
+                    $table = $wpdb->{$core};
+                }
+                /** @phpstan-ignore-next-line — $wpdb is a runtime interface. */
+                $wpdb->get_var("SELECT 1 FROM {$table} LIMIT 1"); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,PluginCheck.Security.DirectDB.UnescapedDBParameter -- $table is either the real $wpdb->users/$wpdb->posts property or prefix+a literal from the hardcoded ['users','posts'] loop, never user input; a fresh uncached read of the just-swapped live table is the entire point of this probe
+                /** @phpstan-ignore-next-line — $wpdb is a runtime interface. */
+                $lastError = (string) $wpdb->last_error;
+                if ($lastError !== '') {
+                    $failures[] = 'DB probe: ' . $core . ' table query error: ' . substr($lastError, 0, 200);
+                }
+            } catch (\Throwable $e) {
+                $failures[] = 'DB probe: ' . $core . ' table query threw: ' . substr($e->getMessage(), 0, 200);
+            }
+        }
+
+        return ['ok' => $failures === [], 'failures' => $failures];
+    }
+
+    // ==================================================================
+    // Probe B — loopback boot probe.
+    // ==================================================================
+
+    /**
+     * GH #146 two-gate note: `RestoreRunner` runs THIS probe only from Gate
+     * 2 (`health_check_live`), which is scheduled AFTER `maintenance_off` —
+     * so the `.maintenance`-aware downgrade below normally never triggers
+     * in production (the file is already gone by the time this runs). It's
+     * kept as harmless belt-and-suspenders: a caller that runs Probe B
+     * (directly, or via `run()`) while maintenance IS still active — e.g. a
+     * future call site, or a test — still gets the correct fail-open
+     * behavior rather than a false rollback trigger.
+     *
+     * @return array{ok:bool,inconclusive:bool,detail:string}
+     */
+    private function checkLoopback(): array
+    {
+        if (!function_exists('wp_remote_get')) {
+            return $this->inconclusive('loopback probe unavailable: wp_remote_get missing');
+        }
+
+        $targets = [];
+        if (function_exists('home_url')) {
+            $home = (string) home_url('/');
+            if ($home !== '') {
+                $targets['home'] = $home;
+            }
+        }
+        if (function_exists('admin_url')) {
+            $admin = (string) admin_url();
+            if ($admin !== '') {
+                $targets['admin'] = $admin;
+            }
+        }
+        if ($targets === []) {
+            return $this->inconclusive('loopback probe unavailable: home_url/admin_url missing');
+        }
+
+        // GH #146 review (CRITICAL 1): health_check runs BEFORE
+        // maintenance_off, deliberately — but that means `.maintenance` is
+        // present for the ENTIRE health-check window on every ordinary
+        // restore that reaches this phase, and WordPress answers every
+        // loopback request with its OWN 503 maintenance page for as long as
+        // that file exists. That 503 is core successfully rendering ITS OWN
+        // page — not evidence the restore broke anything — so a fatal
+        // classification is downgraded to inconclusive whenever the file is
+        // present; Probe A remains the destructive gate for this window.
+        $maintenanceActive = $this->isMaintenanceModeActive();
+
+        $connectFailures = 0;
+        $ambiguous       = [];
+        foreach ($targets as $label => $url) {
+            $result = $this->fetchOnce($url);
+            if ($result['connect_error']) {
+                $connectFailures++;
+                continue;
+            }
+
+            $verdict = $this->classify($result);
+
+            if ($verdict === 'fatal') {
+                if ($maintenanceActive) {
+                    return $this->inconclusive(
+                        $label . '_url probe: ' . $result['detail'] . ' — but .maintenance is active '
+                        . '(the runner\'s own maintenance-mode file); a maintenance-mode 5xx proves core booted '
+                        . 'far enough to render its own page and is not evidence of a broken restore. '
+                        . 'Probe A (DB) remains the destructive gate for this window.'
+                    );
+                }
+                return ['ok' => false, 'inconclusive' => false, 'detail' => $label . '_url probe: ' . $result['detail']];
+            }
+
+            if ($verdict === 'pass') {
+                // At least one target answered with a confident, recognizable
+                // response — the site is booting.
+                return ['ok' => true, 'inconclusive' => false, 'detail' => 'loopback probes passed'];
+            }
+
+            // 'ambiguous': a 2xx with no recognizable HTML marker. Not a
+            // confident pass — record it and keep checking the other target.
+            $ambiguous[] = $label . '_url probe: ' . $result['detail'] . ' (2xx but body has no recognizable HTML marker)';
+        }
+
+        if ($connectFailures === count($targets)) {
+            // GH #146 review (CRITICAL 2): a destructive rollback must fire
+            // ONLY on a POSITIVE fatal signal — never on mere unreachability.
+            // The wp-cron.php sentinel probe below is kept ONLY to enrich the
+            // diagnostic detail (whether the host structurally gates loopback
+            // requests, e.g. a membership plugin, vs. a plain connect
+            // failure) — its result no longer changes the verdict. The
+            // previous "sentinel succeeded -> definitive fatal" branch is
+            // deleted entirely: DISABLE_WP_CRON (extremely common on managed
+            // hosts) made `sentinelLoopbackGated()` unconditionally report
+            // "not gated" without even probing, which turned an ordinary
+            // transient connect blip into a destructive rollback on
+            // essentially any such host.
+            $detail = $this->sentinelLoopbackGated()
+                ? 'loopback unreachable on every probe target; reproduces against the wp-cron.php sentinel — '
+                    . 'the host structurally gates loopback requests (membership/firewall)'
+                : 'loopback unreachable on every probe target — treating as inconclusive; a destructive rollback '
+                    . 'requires a positive fatal signal (an actual 5xx or a fatal body signature), never mere '
+                    . 'unreachability';
+            return $this->inconclusive($detail);
+        }
+
+        if ($ambiguous !== []) {
+            return $this->inconclusive(
+                implode('; ', $ambiguous)
+                . ' — treating as inconclusive rather than risking a false rollback on a blank/marker-less 200'
+            );
+        }
+
+        // Every target either connect-failed or was ambiguous, with no
+        // clean pass and no fatal — fail open defensively.
+        return $this->inconclusive('loopback probe produced no confident signal');
+    }
+
+    /**
+     * @return array{ok:true,inconclusive:true,detail:string}
+     */
+    private function inconclusive(string $detail): array
+    {
+        return ['ok' => true, 'inconclusive' => true, 'detail' => $detail];
+    }
+
+    /**
+     * Whether the runner's own `.maintenance` drop-file (written by
+     * `RestoreRunner::maintenanceOn()`, cleared by `maintenanceOff()`) is
+     * currently present. Same path convention as those two methods.
+     */
+    private function isMaintenanceModeActive(): bool
+    {
+        if ($this->wpRoot === '') {
+            return false;
+        }
+        $path = rtrim($this->wpRoot, '/\\') . DIRECTORY_SEPARATOR . '.maintenance';
+        return is_file($path);
+    }
+
+    /**
+     * Single HTTP GET against a probe target with a capped timeout, capped
+     * redirects, and TLS verification off (mirrors the agent's other
+     * loopback-style probes — the target is the site's OWN URL, dodging a
+     * self-signed/staging cert should never itself fail health).
+     *
+     * @return array{connect_error:bool,code:int,body:string,detail:string}
+     */
+    private function fetchOnce(string $url): array
+    {
+        $response = wp_remote_get($url, [
+            'timeout'     => self::LOOPBACK_TIMEOUT_SECONDS,
+            'redirection' => self::LOOPBACK_MAX_REDIRECTS,
+            'sslverify'   => false,
+            'blocking'    => true,
+            'user-agent'  => self::USER_AGENT,
+        ]);
+
+        if (function_exists('is_wp_error') && is_wp_error($response)) {
+            // is_wp_error() already confirms $response is a WP_Error, which
+            // always exposes get_error_message() — no method_exists() guard needed.
+            $msg = (string) $response->get_error_message();
+            return [
+                'connect_error' => true,
+                'code'          => 0,
+                'body'          => '',
+                'detail'        => 'connect error: ' . substr($msg, 0, 160),
+            ];
+        }
+
+        $code = function_exists('wp_remote_retrieve_response_code')
+            ? (int) wp_remote_retrieve_response_code($response)
+            : 0;
+
+        $body = '';
+        if (function_exists('wp_remote_retrieve_body')) {
+            $body = (string) wp_remote_retrieve_body($response);
+        } elseif (is_array($response) && isset($response['body']) && is_string($response['body'])) {
+            $body = $response['body'];
+        }
+
+        return [
+            'connect_error' => false,
+            'code'          => $code,
+            'body'          => $body,
+            'detail'        => 'HTTP ' . $code,
+        ];
+    }
+
+    /**
+     * Classify a single (non-connect-error) probe result.
+     *
+     *   'fatal'     — HTTP 5xx, or a body carrying a fatal-error signature.
+     *   'ambiguous' — HTTP 2xx but the body is empty or has no recognizable
+     *                 HTML marker (a swallowed fatal under
+     *                 `display_errors=Off` can leave a blank 200 behind).
+     *   'pass'      — everything else: a 2xx with recognizable markup, or
+     *                 any 3xx/401/403/other non-5xx (login-walled or
+     *                 redirected still proves the web server is alive and
+     *                 running PHP for this site).
+     *
+     * @param array{connect_error:bool,code:int,body:string,detail:string} $result
+     */
+    private function classify(array $result): string
+    {
+        if ($result['code'] >= 500 && $result['code'] < 600) {
+            return 'fatal';
+        }
+        if ($result['body'] !== '') {
+            foreach (self::FATAL_BODY_SIGNATURES as $needle) {
+                if (stripos($result['body'], $needle) !== false) {
+                    return 'fatal';
+                }
+            }
+        }
+        if ($result['code'] >= 200 && $result['code'] < 300 && !$this->hasRecognizableMarkup($result['body'])) {
+            return 'ambiguous';
+        }
+        return 'pass';
+    }
+
+    /**
+     * Whether a response body contains at least one recognizable HTML
+     * marker. Empty/whitespace-only bodies never do.
+     */
+    private function hasRecognizableMarkup(string $body): bool
+    {
+        if (trim($body) === '') {
+            return false;
+        }
+        foreach (self::HTML_MARKERS as $marker) {
+            if (stripos($body, $marker) !== false) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Diagnostic-only mirror of `BackupCommand::isLoopbackGated()`: probes
+     * `/wp-cron.php` with zero redirects. A 3xx or a connect-level WP_Error
+     * means the host structurally gates loopback HTTP requests (a
+     * membership/privacy plugin, a firewall rule blocking self-requests).
+     *
+     * GH #146 review (CRITICAL 2): this result is used ONLY to enrich the
+     * inconclusive detail message in `checkLoopback()` — it must NEVER be
+     * used to promote an all-connect-refused result to a definitive fatal.
+     * `DISABLE_WP_CRON` (extremely common on managed hosts) makes this
+     * short-circuit to `false` WITHOUT actually probing anything, so
+     * treating that `false` as "the host does not gate loopback, therefore
+     * refusal is real" previously turned an ordinary transient connect blip
+     * into a destructive rollback on any such host.
+     */
+    private function sentinelLoopbackGated(): bool
+    {
+        if (defined('DISABLE_WP_CRON') && (bool) constant('DISABLE_WP_CRON')) {
+            return false;
+        }
+        if (!function_exists('wp_remote_get') || !function_exists('site_url')) {
+            return false;
+        }
+
+        $cronUrl = (string) site_url('/wp-cron.php');
+        if ($cronUrl === '' || $cronUrl === '/wp-cron.php') {
+            return false;
+        }
+
+        $response = wp_remote_get($cronUrl, [
+            'timeout'     => 5,
+            'redirection' => 0,
+            'sslverify'   => false,
+            'blocking'    => true,
+            'user-agent'  => self::USER_AGENT,
+        ]);
+
+        if (function_exists('is_wp_error') && is_wp_error($response)) {
+            return true;
+        }
+
+        $code = function_exists('wp_remote_retrieve_response_code')
+            ? (int) wp_remote_retrieve_response_code($response)
+            : 0;
+
+        return $code >= 300 && $code < 400;
+    }
+}

--- a/apps/agent/includes/backup/class-restore-runner.php
+++ b/apps/agent/includes/backup/class-restore-runner.php
@@ -21,11 +21,40 @@
  *                       -> post_hooks                 (kind == files)
  *   restore_db           -> swap_db                   (kind in {db, full})
  *   swap_db              -> post_hooks                (always)
- *   post_hooks           -> maintenance_off
- *   maintenance_off      -> cleanup
+ *   post_hooks           -> health_check               (always)
+ *   health_check         -> maintenance_off            (always, on a pass)
+ *   maintenance_off      -> health_check_live          (always)
+ *   health_check_live    -> cleanup                    (always, on a pass)
  *   cleanup              -> completed
  *
  *   completed | failed: terminal (re-entry is a no-op)
+ *
+ * GH #146 — TWO health-check gates, for two different reasons a restore can
+ * be broken:
+ *
+ *   Gate 1, `health_check` (Probe A / DB only) — runs right after
+ *   post_hooks, BEFORE maintenance_off, so a rollback it triggers happens
+ *   invisibly while the site is still in maintenance mode. Regardless of
+ *   kind — files-only, db-only, and full restores all converge on
+ *   post_hooks first, so this one gate covers all three.
+ *
+ *   Gate 2, `health_check_live` (Probe B / loopback WSOD) — runs right
+ *   AFTER maintenance_off, deliberately. A loopback probe run BEFORE
+ *   maintenance_off can only ever see WordPress's OWN `.maintenance` 503
+ *   page, which core renders before plugins are even loaded — it physically
+ *   CANNOT observe a files-side WSOD (a dropped required file fataling on
+ *   plugin load, the GitHub issue #147 class this feature exists to catch).
+ *   Gate 2 therefore runs the loopback probe against the REAL, live,
+ *   post-maintenance site. On a definitive fatal it re-enables maintenance
+ *   for the duration of the rollback (so visitors don't see the broken
+ *   site being reverted), then drops it again once the revert lands.
+ *
+ * Either gate's definitive fatal drives the same combined files+DB rollback
+ * and reports `failed` instead of ever reaching `completed`; see
+ * `RestoreHealthCheck` / `RestoreGuard` / `runHealthCheck()` /
+ * `runHealthCheckLive()`. The `RestoreGuard` shutdown backstop stays armed
+ * (not `markClean()`'d) across BOTH gates — only Gate 2 passing marks it
+ * clean, since Gate 2 is the last checkpoint before `completed`.
  *
  * V0 simplifications (deferred phases):
  *   - migrate_db (search-and-replace) is deferred. V0 is self-hosted single-
@@ -72,7 +101,13 @@ final class RestoreRunner
     public const PHASE_URL_REWRITE         = 'url_rewrite';
     public const PHASE_SWAP_DB             = 'swap_db';
     public const PHASE_POST_HOOKS          = 'post_hooks';
+    // GH #146: two-gate post-restore health check + auto-rollback — see
+    // class docblock. Gate 1 (DB-only) slots between post_hooks and
+    // maintenance_off; Gate 2 (loopback WSOD, on the real site) slots
+    // between maintenance_off and cleanup.
+    public const PHASE_HEALTH_CHECK        = 'health_check';
     public const PHASE_MAINTENANCE_OFF     = 'maintenance_off';
+    public const PHASE_HEALTH_CHECK_LIVE   = 'health_check_live';
     public const PHASE_CLEANUP             = 'cleanup';
     public const PHASE_COMPLETED           = 'completed';
     public const PHASE_FAILED              = 'failed';
@@ -132,6 +167,28 @@ final class RestoreRunner
     private const PREFLIGHT_ARTIFACT_MULTIPLIER = 1.5;
     private const PREFLIGHT_STAGING_MULTIPLIER  = 1.0;
 
+    /**
+     * GH #146 — third preflight leg: headroom for the forced pre-restore DB
+     * dump `runSwapDb()` captures before the destructive DROP. 1.2× the live
+     * DB's on-disk size (data_length + index_length) covers the gzip-
+     * compressed dump comfortably (SQL dumps compress well below 1×) with a
+     * margin for the INSERT statement overhead this dumper emits.
+     */
+    private const PREFLIGHT_DB_ROLLBACK_MULTIPLIER = 1.2;
+
+    /**
+     * GH #146 — default ceiling (bytes) above which the pre-restore DB dump
+     * is skipped rather than attempted. Overridable via the
+     * `WPMGR_RESTORE_DB_ROLLBACK_MAX_BYTES` constant. 2 GiB default: large
+     * enough that the vast majority of WP sites are covered, small enough
+     * that a genuinely huge DB doesn't turn every restore into a second full
+     * DB dump on top of the backup's own.
+     */
+    private const DEFAULT_DB_ROLLBACK_MAX_BYTES = 2 * 1024 * 1024 * 1024;
+
+    /** Filename of the forced pre-restore DB dump inside the restore's scratch dir. */
+    private const PRE_RESTORE_DB_DUMP_FILENAME = 'pre-restore-db.sql.gz';
+
     /** @var array<string,mixed> Runner params (see class docblock). */
     private array $params;
 
@@ -139,6 +196,16 @@ final class RestoreRunner
     private int $lastDbUpdate = 0;
 
     private ?ProgressClient $progressClient = null;
+
+    /**
+     * GH #146 — shutdown-time rollback backstop. Armed right before the
+     * first destructive rename (`swap_files`/`swap_db`), marked clean only
+     * once Gate 2 (`health_check_live`, the LAST health-check gate) passes
+     * — it stays armed across Gate 1 (`health_check`) too. Null until
+     * armed — a run that never reaches a destructive phase (e.g. a
+     * preflight failure) never arms one.
+     */
+    private ?RestoreGuard $guard = null;
 
     /**
      * Test seam: the sleeper invoked between download retry attempts. Tests
@@ -258,6 +325,10 @@ final class RestoreRunner
                         break;
 
                     case self::PHASE_SWAP_FILES:
+                        // GH #146: arm the shutdown-rollback backstop right
+                        // before the first destructive rename this run
+                        // performs.
+                        $this->armGuardOnce();
                         $subState = $this->runSwapFiles($subState);
                         $next     = $this->nextAfterSwapFiles();
                         $this->saveTaskState($next, $subState);
@@ -287,6 +358,11 @@ final class RestoreRunner
                         break;
 
                     case self::PHASE_SWAP_DB:
+                        // GH #146: arm the shutdown-rollback backstop right
+                        // before the first destructive rename this run
+                        // performs (idempotent — a no-op if swap_files
+                        // already armed it for a `full` restore).
+                        $this->armGuardOnce();
                         $subState = $this->runSwapDb($subState);
                         $next     = self::PHASE_POST_HOOKS;
                         $this->saveTaskState($next, $subState);
@@ -295,6 +371,21 @@ final class RestoreRunner
 
                     case self::PHASE_POST_HOOKS:
                         $subState = $this->runPostHooks($subState);
+                        $next     = self::PHASE_HEALTH_CHECK;
+                        $this->saveTaskState($next, $subState);
+                        $currentPhase = $next;
+                        break;
+
+                    case self::PHASE_HEALTH_CHECK:
+                        // GH #146 Gate 1: in-process DB probe, still under
+                        // maintenance. On a definitive fatal, runHealthCheck()
+                        // performs the combined files+DB rollback itself and
+                        // throws — caught by this method's own top-level
+                        // catch below, which reports `failed` with the
+                        // rollback detail. This phase NEVER falls through to
+                        // maintenance_off/health_check_live/cleanup/completed
+                        // on a fatal.
+                        $subState = $this->runHealthCheck($subState);
                         $next     = self::PHASE_MAINTENANCE_OFF;
                         $this->saveTaskState($next, $subState);
                         $currentPhase = $next;
@@ -302,6 +393,20 @@ final class RestoreRunner
 
                     case self::PHASE_MAINTENANCE_OFF:
                         $subState = $this->runMaintenanceOff($subState);
+                        $next     = self::PHASE_HEALTH_CHECK_LIVE;
+                        $this->saveTaskState($next, $subState);
+                        $currentPhase = $next;
+                        break;
+
+                    case self::PHASE_HEALTH_CHECK_LIVE:
+                        // GH #146 Gate 2: loopback WSOD probe against the
+                        // REAL, post-maintenance site (see class docblock for
+                        // why this can't run under maintenance). On a
+                        // definitive fatal, runHealthCheckLive() re-enables
+                        // maintenance, performs the combined rollback, drops
+                        // maintenance again, and throws — same top-level
+                        // catch handles it as Gate 1 does.
+                        $subState = $this->runHealthCheckLive($subState);
                         $next     = self::PHASE_CLEANUP;
                         $this->saveTaskState($next, $subState);
                         $currentPhase = $next;
@@ -319,7 +424,7 @@ final class RestoreRunner
             }
 
             // ---- Completion: cleanup + ack. ------------------------------
-            $this->cleanupOnCompleted();
+            $this->cleanupOnCompleted($subState);
             $this->postProgress(self::PHASE_COMPLETED, [
                 'ok'      => true,
                 'summary' => 'restore completed',
@@ -329,6 +434,13 @@ final class RestoreRunner
         } catch (\Throwable $e) {
             \WPMgr\Agent\Support\DebugLog::write('WPMgr RestoreRunner: phase ' . $currentPhase . ' failed: ' . $e->getMessage());
 
+            // GH #146: RestoreHealthCheckFailed carries which rollback legs
+            // already completed (runHealthCheck() performs the combined
+            // files+DB rollback BEFORE throwing) — surface it on the FAILED
+            // row/progress event so the operator sees the site was reverted,
+            // not just that the restore failed.
+            $rolledBack = $e instanceof RestoreHealthCheckFailed ? $e->rolledBack() : null;
+
             // Best-effort: mark failed, drop maintenance, try to clean up
             // tmp DB tables. Failures in the cleanup are swallowed.
             try {
@@ -337,17 +449,25 @@ final class RestoreRunner
             }
 
             try {
-                $this->saveTaskState(self::PHASE_FAILED, [
+                $failState = [
                     'last_error' => substr($e->getMessage(), 0, 240),
                     'failed_in'  => $currentPhase,
-                ]);
+                ];
+                if ($rolledBack !== null) {
+                    $failState['rolled_back'] = $rolledBack;
+                }
+                $this->saveTaskState(self::PHASE_FAILED, $failState);
             } catch (\Throwable $_) {
             }
             try {
-                $this->postProgress(self::PHASE_FAILED, [
+                $progressDetail = [
                     'stage'   => $currentPhase,
                     'message' => substr($e->getMessage(), 0, 240),
-                ]);
+                ];
+                if ($rolledBack !== null) {
+                    $progressDetail['rolled_back'] = $rolledBack;
+                }
+                $this->postProgress(self::PHASE_FAILED, $progressDetail);
             } catch (\Throwable $_) {
             }
 
@@ -395,7 +515,20 @@ final class RestoreRunner
         } else {
             $legStaging = (int) (FilesRestorer::estimateWpContentBytes($wpContent) * self::PREFLIGHT_STAGING_MULTIPLIER);
         }
-        $required    = max($legArtifact, $legStaging);
+        // GH #146 / §2 — Leg 3: headroom for the forced pre-restore DB dump
+        // `runSwapDb()` captures before the destructive DROP (see
+        // `capturePreRestoreDbDump()`). Only contributes to `$required` when
+        // it fits under the same ceiling that phase itself enforces — a DB
+        // over the ceiling skips the dump entirely, so no disk headroom is
+        // needed for it (and requiring it here would wrongly fail preflight
+        // for a large-DB restore that never attempts the dump at all).
+        $liveDbBytes = $this->estimateLiveDbBytes();
+        $dbRollbackCeiling = $this->dbRollbackMaxBytes();
+        $legDbRollback = ($liveDbBytes > 0 && $liveDbBytes <= $dbRollbackCeiling)
+            ? (int) ($liveDbBytes * self::PREFLIGHT_DB_ROLLBACK_MULTIPLIER)
+            : 0;
+
+        $required = max($legArtifact, $legStaging) + $legDbRollback;
 
         // Disk free on wp-content's volume. disk_free_space returns the
         // bytes free for the filesystem the path lives on.
@@ -1502,6 +1635,11 @@ final class RestoreRunner
 
     /**
      * swap_db: atomic per-table swap.
+     *
+     * GH #146: before the destructive DROP TABLE inside `DbRestorer::swap()`,
+     * captures a forced pre-restore DB dump — the rollback source a
+     * post-restore health-check failure (or the RestoreGuard shutdown
+     * backstop) replays to undo this swap. See `capturePreRestoreDbDump()`.
      */
     private function runSwapDb(array $subState): array
     {
@@ -1516,6 +1654,14 @@ final class RestoreRunner
         if ($tmpPrefix === '' || $targetPrefix === '') {
             throw new \RuntimeException('swap_db: missing tmp/target prefix');
         }
+
+        // GH #146 / §2: forced pre-restore DB dump, BEFORE the first DROP.
+        // Persisted immediately (not just returned) so a crash between the
+        // dump and the swap still leaves the rollback source recorded for a
+        // watchdog resume, the health-check rollback, or the RestoreGuard
+        // shutdown backstop to find.
+        $subState = $this->capturePreRestoreDbDump($subState, $targetPrefix);
+        $this->saveTaskState(self::PHASE_SWAP_DB, $subState);
 
         // Coerce to list<string>.
         $list = [];
@@ -1532,6 +1678,141 @@ final class RestoreRunner
 
         $subState['swap_db'] = ['done' => true, 'tables_swapped' => count($list)];
         return $subState;
+    }
+
+    /**
+     * GH #146 / §2: capture the live (pre-restore) database into a
+     * `pre-restore-db.sql.gz` dump inside this restore's scratch dir, using
+     * the same streaming `DbDumper` backups + Database Snapshots use.
+     * Idempotent — a watchdog resume that already captured (or already
+     * recorded as skipped/oversized) the dump does not redo it.
+     *
+     * ALWAYS-ON with a size ceiling (`WPMGR_RESTORE_DB_ROLLBACK_MAX_BYTES`,
+     * default 2 GiB): when the live DB exceeds it, the dump is skipped and
+     * `db_rollback.available=false` is recorded as a WARNING-carrying
+     * marker — never silently proceeding unprotected without a trace (S8,
+     * issue #131's discipline). A health-check failure downstream then
+     * rolls back files ONLY.
+     *
+     * @param array<string,mixed> $subState
+     * @return array<string,mixed>
+     */
+    private function capturePreRestoreDbDump(array $subState, string $targetPrefix): array
+    {
+        $existing = isset($subState['db_rollback']) && is_array($subState['db_rollback']) ? $subState['db_rollback'] : [];
+        if (!empty($existing['done'])) {
+            return $subState;
+        }
+
+        $scratch = $this->scratchDir();
+        if ($scratch === '' || !is_dir($scratch)) {
+            $subState['db_rollback'] = ['done' => true, 'available' => false, 'reason' => 'unavailable'];
+            $this->postProgress(self::PHASE_SWAP_DB, [
+                'db_rollback' => 'unavailable',
+                'reason'      => 'no scratch dir available for the pre-restore dump',
+            ]);
+            return $subState;
+        }
+
+        $maxBytes  = $this->dbRollbackMaxBytes();
+        $liveBytes = $this->estimateLiveDbBytes();
+        if ($maxBytes > 0 && $liveBytes > 0 && $liveBytes > $maxBytes) {
+            $subState['db_rollback'] = [
+                'done'       => true,
+                'available'  => false,
+                'reason'     => 'unavailable',
+                'live_bytes' => $liveBytes,
+                'max_bytes'  => $maxBytes,
+            ];
+            $this->postProgress(self::PHASE_SWAP_DB, [
+                'db_rollback' => 'unavailable',
+                'reason'      => 'live database exceeds WPMGR_RESTORE_DB_ROLLBACK_MAX_BYTES ceiling',
+                'live_bytes'  => $liveBytes,
+                'max_bytes'   => $maxBytes,
+            ]);
+            return $subState;
+        }
+
+        $dumpPath = $scratch . DIRECTORY_SEPARATOR . self::PRE_RESTORE_DB_DUMP_FILENAME;
+        try {
+            $dumper = new DbDumper($this->dbCreds());
+            // No incremental progress surfaced for this internal safety
+            // dump — it rides inside the swap_db phase's own progress
+            // budget; the noop callback keeps DbDumper's per-table
+            // checkpoint cheap.
+            $dumper->dump($dumpPath, [], static function (string $phase, array $detail): void {
+            });
+
+            $subState['db_rollback'] = [
+                'done'      => true,
+                'available' => true,
+                'dump_path' => $dumpPath,
+                'prefix'    => $targetPrefix,
+            ];
+            $this->postProgress(self::PHASE_SWAP_DB, [
+                'db_rollback' => 'captured',
+                'dump_bytes'  => @filesize($dumpPath) ?: 0,
+            ]);
+        } catch (\Throwable $e) {
+            // A failed safety dump must not block the restore itself — but
+            // it MUST be recorded (never silently proceed unprotected).
+            \WPMgr\Agent\Support\DebugLog::write(
+                'WPMgr RestoreRunner: pre-restore DB dump failed, proceeding without a DB rollback source: ' . $e->getMessage()
+            );
+            $subState['db_rollback'] = ['done' => true, 'available' => false, 'reason' => 'unavailable'];
+            $this->postProgress(self::PHASE_SWAP_DB, [
+                'db_rollback' => 'unavailable',
+                'reason'      => 'pre-restore dump failed: ' . substr($e->getMessage(), 0, 160),
+            ]);
+        }
+
+        return $subState;
+    }
+
+    /**
+     * GH #146: `WPMGR_RESTORE_DB_ROLLBACK_MAX_BYTES` override, else the
+     * 2 GiB default.
+     */
+    private function dbRollbackMaxBytes(): int
+    {
+        if (defined('WPMGR_RESTORE_DB_ROLLBACK_MAX_BYTES')) {
+            $configured = (int) constant('WPMGR_RESTORE_DB_ROLLBACK_MAX_BYTES');
+            if ($configured > 0) {
+                return $configured;
+            }
+        }
+        return self::DEFAULT_DB_ROLLBACK_MAX_BYTES;
+    }
+
+    /**
+     * GH #146: estimate the on-disk size (bytes) of the LIVE database via
+     * `information_schema.tables` — the same tables `capturePreRestoreDbDump()`
+     * is about to dump (swap_db hasn't renamed anything onto them yet).
+     * Returns 0 on any failure (conservative: treated as "small enough" by
+     * the caller so a broken size probe never blocks the safety dump).
+     */
+    private function estimateLiveDbBytes(): int
+    {
+        global $wpdb;
+        if (!is_object($wpdb)) {
+            return 0;
+        }
+        $dbName = $this->dbCreds()['name'] ?? '';
+        if ($dbName === '') {
+            return 0;
+        }
+        try {
+            /** @phpstan-ignore-next-line — $wpdb is a runtime interface. */
+            $prepared = $wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- already prepared on the preceding line
+                'SELECT SUM(data_length + index_length) FROM information_schema.tables WHERE table_schema = %s',
+                $dbName
+            );
+            /** @phpstan-ignore-next-line */
+            $bytes = $wpdb->get_var($prepared); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- information_schema size probe; no core helper exists; not a cacheable value (must reflect live size right before the dump)
+            return is_numeric($bytes) ? (int) $bytes : 0;
+        } catch (\Throwable $e) {
+            return 0;
+        }
     }
 
     /**
@@ -1559,6 +1840,303 @@ final class RestoreRunner
     }
 
     /**
+     * health_check (GH #146 Gate 1): in-process DB probe (Probe A ONLY —
+     * see class docblock for why Probe B/the loopback WSOD gate is deferred
+     * to Gate 2/`health_check_live`). Runs BEFORE maintenance_off, so a
+     * rollback it triggers happens invisibly while the site is still in
+     * maintenance mode. On a definitive fatal, performs the combined
+     * files+DB rollback (`performRollback()`, via `routeRollback()`) BEFORE
+     * throwing — this method must never return normally on a failing
+     * verdict, so the dispatch loop can never fall through to
+     * maintenance_off/health_check_live/cleanup/completed on an unhealthy
+     * restore.
+     *
+     * Does NOT call `markClean()` on a pass — Gate 2 (`health_check_live`)
+     * is the LAST checkpoint before `completed`, so the shutdown guard stays
+     * armed across both gates; only Gate 2 passing marks it clean.
+     *
+     * @param array<string,mixed> $subState
+     * @return array<string,mixed>
+     * @throws RestoreHealthCheckFailed On a definitive health failure,
+     *         AFTER the rollback has already been performed.
+     */
+    private function runHealthCheck(array $subState): array
+    {
+        $result = (new RestoreHealthCheck($this->wpRoot()))->checkDatabase();
+
+        $this->postProgress(self::PHASE_HEALTH_CHECK, [
+            'ok'       => $result['ok'],
+            'failures' => $result['failures'],
+        ]);
+
+        if ($result['ok']) {
+            $subState['health_check'] = ['done' => true, 'ok' => true];
+            return $subState;
+        }
+
+        // Definitive DB failure — roll back BEFORE throwing (invisibly,
+        // still under maintenance mode at this point in the phase order).
+        $rolledBack = $this->routeRollback($subState);
+        if ($rolledBack['reason'] === '') {
+            $rolledBack['reason'] = 'db_unhealthy_post_restore';
+        }
+
+        throw new RestoreHealthCheckFailed(
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- exception message, goes to server log/SSE, never browser output
+            'post-restore health check failed: ' . implode('; ', $result['failures']) . ' (' . $rolledBack['reason'] . ')',
+            $rolledBack // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- not output at all; the rollback-legs array the top-level catch persists to the task row
+        );
+    }
+
+    /**
+     * health_check_live (GH #146 Gate 2): the loopback WSOD probe (Probe B
+     * ONLY — Probe A already passed in Gate 1) against the REAL,
+     * post-maintenance site. Runs right AFTER maintenance_off — see class
+     * docblock for why a loopback probe run any earlier physically cannot
+     * observe a files-side WSOD (WordPress's own `.maintenance` 503 page
+     * renders before plugins even load).
+     *
+     * On a definitive fatal: re-enables maintenance for the duration of the
+     * rollback (so visitors don't see the broken site being reverted — see
+     * `performRollback()`'s own maintenance-toggle wrapper, which covers
+     * this uniformly for both the synchronous path here and a real
+     * shutdown-triggered `RestoreGuard::fire()`), then throws.
+     *
+     * On ok/inconclusive: marks the guard clean (this IS the last gate
+     * before `completed`) and proceeds to cleanup. The brief window a
+     * genuinely-broken restore was visitor-visible on the real site before
+     * THIS phase caught it is an accepted trade-off — strictly better than
+     * leaving it broken forever, and it never happens for a good restore.
+     *
+     * @param array<string,mixed> $subState
+     * @return array<string,mixed>
+     * @throws RestoreHealthCheckFailed On a definitive WSOD, AFTER the
+     *         rollback has already been performed.
+     */
+    private function runHealthCheckLive(array $subState): array
+    {
+        $result = (new RestoreHealthCheck($this->wpRoot()))->checkLoopbackOnly();
+
+        $this->postProgress(self::PHASE_HEALTH_CHECK_LIVE, [
+            'ok'       => $result['ok'],
+            'failures' => $result['failures'],
+            'warnings' => $result['warnings'],
+        ]);
+
+        if ($result['ok']) {
+            // Verified-good on the REAL site — the LAST gate before
+            // completed. Never let a later, unrelated shutdown roll back a
+            // confirmed-healthy restore (mirrors UpdateGuard::markClean()'s
+            // rationale exactly).
+            if ($this->guard !== null) {
+                $this->guard->markClean();
+            }
+            $subState['health_check_live'] = [
+                'done'     => true,
+                'ok'       => true,
+                'warnings' => $result['warnings'],
+            ];
+            return $subState;
+        }
+
+        // Definitive WSOD on the real, post-maintenance site (the GH #147
+        // class this gate exists to catch). performRollback() itself wraps
+        // the actual revert in maintenanceOn()/maintenanceOff() so visitors
+        // never see the broken site mid-revert.
+        $rolledBack = $this->routeRollback($subState);
+        if ($rolledBack['reason'] === '') {
+            $rolledBack['reason'] = 'wsod_post_restore';
+        }
+
+        throw new RestoreHealthCheckFailed(
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- exception message, goes to server log/SSE, never browser output
+            'post-restore health check failed: ' . implode('; ', $result['failures']) . ' (' . $rolledBack['reason'] . ')',
+            $rolledBack // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- not output at all; the rollback-legs array the top-level catch persists to the task row
+        );
+    }
+
+    /**
+     * GH #146 / Review MEDIUM-3: route a definitive health-check failure
+     * (from EITHER gate) through the shutdown-guard's `fire()` when one is
+     * armed, rather than calling `performRollback()` directly, so its
+     * documented `fired` idempotency actually engages. Without this, the
+     * guard's `fired` flag would stay false after a successful synchronous
+     * rollback, and a later REAL process-shutdown invocation of the same
+     * registered callback (`markClean()` is never called on a failing
+     * verdict) would attempt a SECOND, redundant rollback against
+     * already-consumed rollback material.
+     *
+     * @param array<string,mixed> $subState
+     * @return array{files:bool,db:bool,reason:string}
+     */
+    private function routeRollback(array $subState): array
+    {
+        if ($this->guard !== null) {
+            $fired = $this->guard->fire();
+            return ['files' => $fired['files'], 'db' => $fired['db'], 'reason' => $fired['reason']];
+        }
+        return $this->performRollback($subState);
+    }
+
+    /**
+     * GH #146 / §3+§4: combined files+DB rollback, shared by both gates'
+     * synchronous failure handling (via `routeRollback()`) and a real
+     * shutdown-triggered `RestoreGuard::fire()` (same closure,
+     * `armGuardOnce()`). Order: a mismatch guard first (see below), then
+     * DB, then files, then a quick Probe A re-check (informational only —
+     * its result is logged, never thrown). Never throws — every leg is
+     * independently try/catch-wrapped so one leg failing does not prevent
+     * the other from being attempted.
+     *
+     * Review MEDIUM-4: if the live DB WAS actually swapped as part of this
+     * restore (`swap_db` ran) but no rollback source is available (the dump
+     * was skipped over the size ceiling, or the dump itself failed),
+     * reverting FILES ALONE would run the pre-restore files against the
+     * NEW (post-restore) database — a worse, incoherent "Frankenstein"
+     * mismatch than simply leaving the as-restored (if unhealthy) site in
+     * place. In that specific case this method performs NEITHER leg (and
+     * skips the maintenance toggle below entirely — nothing is being
+     * mutated, so there is nothing to hide) and reports
+     * `reason: 'db_rollback_unavailable'` so the operator gets a coherent
+     * (if broken) site plus whatever rollback material does exist on disk
+     * to investigate by hand — never a mismatched one. This does NOT apply
+     * to a `files`-kind restore (no `swap_db` ever ran, so there is nothing
+     * for the files revert to mismatch against).
+     *
+     * GH #146 two-gate follow-up: the actual revert (DB + files) is wrapped
+     * in `maintenanceOn()` / `finally maintenanceOff()` UNCONDITIONALLY —
+     * this is what protects visitors during a Gate-2 (post-maintenance-off)
+     * rollback, and it's a harmless no-op re-enable/immediate-disable
+     * during a Gate-1 rollback (maintenance is already on there; the
+     * existing top-level `run()` catch drops it again regardless). Wrapping
+     * it HERE (rather than duplicating the toggle in both
+     * `runHealthCheckLive()` and `armGuardOnce()`'s closure) means a real
+     * shutdown-triggered `RestoreGuard::fire()` gets the SAME visitor
+     * protection as the synchronous path, with no separate handling needed.
+     *
+     * @param array<string,mixed> $subState Freshest known sub_state. The
+     *        synchronous health-check path passes the in-memory one;
+     *        `RestoreGuard`'s closure reloads fresh from the DB at
+     *        fire()-time since further phases may have run since arm().
+     * @return array{files:bool,db:bool,reason:string} Which legs actually
+     *         completed; `reason` is non-empty only when neither leg was
+     *         even attempted (the mismatch guard above).
+     */
+    private function performRollback(array $subState): array
+    {
+        $dbRollback   = isset($subState['db_rollback']) && is_array($subState['db_rollback']) ? $subState['db_rollback'] : [];
+        $dbWasSwapped = !empty($subState['swap_db']['done']);
+        $dumpPath     = (string) ($dbRollback['dump_path'] ?? '');
+        $dbRollbackAvailable = !empty($dbRollback['available']) && $dumpPath !== '' && is_file($dumpPath);
+
+        if ($dbWasSwapped && !$dbRollbackAvailable) {
+            \WPMgr\Agent\Support\DebugLog::write(
+                'WPMgr RestoreRunner: skipping rollback — the live DB was swapped but no rollback source is '
+                . 'available; reverting files alone would mismatch the pre-restore files against the new DB'
+            );
+            return ['files' => false, 'db' => false, 'reason' => 'db_rollback_unavailable'];
+        }
+
+        $dbOk    = false;
+        $filesOk = false;
+
+        // Protect visitors for the duration of the actual revert — dropped
+        // again in the finally below regardless of outcome. See method doc
+        // for why this is unconditional (both gates, sync AND async fire).
+        $this->maintenanceOn();
+        try {
+            // --- 1. DB revert ------------------------------------------------
+            if ($dbRollbackAvailable) {
+                $dbOk = $this->revertDb($dumpPath);
+            }
+
+            // --- 2. Files revert -----------------------------------------------
+            $swap = isset($subState['swap_files']) && is_array($subState['swap_files']) ? $subState['swap_files'] : [];
+            try {
+                $restorer = new FilesRestorer();
+                if (isset($swap['old_files_dir']) && is_string($swap['old_files_dir']) && $swap['old_files_dir'] !== '') {
+                    $restorer->revertSwap($this->wpContentPath(), $swap['old_files_dir'], $this->restoreId());
+                    $filesOk = true;
+                } elseif (isset($swap['old_dirs']) && is_array($swap['old_dirs']) && $swap['old_dirs'] !== []) {
+                    /** @var array<string,string> $oldDirs */
+                    $oldDirs = $swap['old_dirs'];
+                    $restorer->revertSwapComponents($this->wpContentPath(), $oldDirs, $this->restoreId());
+                    $filesOk = true;
+                }
+            } catch (\Throwable $e) {
+                \WPMgr\Agent\Support\DebugLog::write('WPMgr RestoreRunner: files rollback failed: ' . $e->getMessage());
+            }
+        } finally {
+            $this->maintenanceOff();
+        }
+
+        // --- 3. Quick Probe A re-check (informational only) ----------------
+        try {
+            $recheck = (new RestoreHealthCheck($this->wpRoot()))->checkDatabase();
+            if (!$recheck['ok']) {
+                \WPMgr\Agent\Support\DebugLog::write(
+                    'WPMgr RestoreRunner: post-rollback DB re-check still unhealthy: ' . implode('; ', $recheck['failures'])
+                );
+            }
+        } catch (\Throwable $_) {
+        }
+
+        return ['files' => $filesOk, 'db' => $dbOk, 'reason' => ''];
+    }
+
+    /**
+     * GH #146: replay the pre-restore dump exactly as
+     * `DbSnapshotCommand::actionRevert()` does — `new DbRestorer($creds)` ->
+     * `restore()` into a fresh tmp prefix -> `swap()` back onto the live
+     * prefix, `dropTmpTables()` on error. Same source/target prefix on
+     * purpose: the dump was taken FROM this site's own live tables, so
+     * reverting lands back onto those same tables.
+     */
+    private function revertDb(string $dumpPath): bool
+    {
+        $creds     = $this->dbCreds();
+        $srcPrefix = $this->targetPrefix();
+        $tmpPrefix = 'wpmrb' . substr(bin2hex(random_bytes(6)), 0, 10) . '_';
+        $restorer  = new DbRestorer($creds);
+        $noop      = static function (string $phase, array $detail): void {
+        };
+
+        try {
+            $tmpTables = $restorer->restore($dumpPath, $tmpPrefix, $srcPrefix, $noop);
+            $restorer->swap($tmpPrefix, $srcPrefix, $tmpTables, $noop);
+            return true;
+        } catch (\Throwable $e) {
+            \WPMgr\Agent\Support\DebugLog::write('WPMgr RestoreRunner: DB rollback failed: ' . $e->getMessage());
+            try {
+                $restorer->dropTmpTables($tmpPrefix);
+            } catch (\Throwable $_) {
+            }
+            return false;
+        }
+    }
+
+    /**
+     * GH #146 / §4: arm the RestoreGuard shutdown backstop exactly once per
+     * run() invocation, right before the first destructive rename
+     * (`swap_files`/`swap_db`). The rollback closure reloads sub_state
+     * fresh from the DB at fire()-time (not the value captured here) since
+     * later phases may have recorded MORE rollback material (e.g. the DB
+     * dump path, or the files old-dir) between arming and a crash.
+     */
+    private function armGuardOnce(): void
+    {
+        if ($this->guard !== null) {
+            return;
+        }
+        $this->guard = new RestoreGuard(function (): array {
+            $task     = $this->loadTask();
+            $subState = $task !== null ? $task['sub_state'] : [];
+            return $this->performRollback($subState);
+        });
+        $this->guard->arm();
+    }
+
+    /**
      * maintenance_off: drop the `.maintenance` file.
      */
     private function runMaintenanceOff(array $subState): array
@@ -1571,29 +2149,54 @@ final class RestoreRunner
 
     /**
      * cleanup: drop downloaded artifacts, then deal with the per-run
-     * `.wpmgr-old-files-<id>/` rollback tree.
+     * `.wpmgr-old-files-<id>/` rollback tree (+ the GH #146 pre-restore DB
+     * dump, if one was captured).
      *
      * The rollback tree is the live wp-content that swap_files moved aside.
      * Pre-0.9.5 we kept it for 24h on every restore, which routinely tipped
-     * small-VPS hosts into disk-red. 0.9.5 flips the default:
+     * small-VPS hosts into disk-red. 0.9.5 flipped the default to a
+     * synchronous immediate rrmdir. GH #146 flips it again — to DEFER:
      *
-     *   - `keep_old_files !== true` (DEFAULT): synchronously rrmdir the
-     *     exact dir recorded in sub_state during swap_files. No glob — two
-     *     concurrent restores on the same host would otherwise clobber each
-     *     other's rollback trees.
-     *   - `keep_old_files === true`: schedule the 24h GC the way pre-0.9.5
-     *     did, for operators who explicitly want a long manual-rollback
-     *     window.
+     *   - `keep_old_files !== true` (DEFAULT): defer via a `<path>.expires`
+     *     marker (`FilesRestorer::OLDFILES_GC_AGE_SECONDS`, ~1h) + a
+     *     `wpmgr_restore_oldfiles_gc` cron sweep, rather than synchronously
+     *     rrmdir-ing. The tree (and the pre-restore DB dump) must still
+     *     exist for a health-check-triggered rollback to act on in the few
+     *     minutes right after a restore reports its outcome — a synchronous
+     *     delete here would remove the ONLY rollback source before that
+     *     window even opens (health_check already runs BEFORE cleanup, so
+     *     in practice a health-check rollback always precedes this method,
+     *     but a manual/forensic revert shortly after `completed` needs the
+     *     same material).
+     *   - `keep_old_files === true`: unchanged — schedules the existing 24h
+     *     GC window for operators who explicitly want a long manual-
+     *     rollback window.
+     *
+     * Not a glob for the per-restore marker writes below — two concurrent
+     * restores on the same host each write their OWN `.expires` marker
+     * next to their OWN exact recorded path, so they never clobber each
+     * other.
      */
     private function runCleanup(array $subState): array
     {
-        // 1. Remove the downloaded artifacts from scratch.
+        // GH #146: the pre-restore DB dump (if captured) lives inside
+        // scratch — carve it (and its own `.expires` marker, written below)
+        // out of the artifact wipe so it survives the retention window.
+        $dbRollback = isset($subState['db_rollback']) && is_array($subState['db_rollback']) ? $subState['db_rollback'] : [];
+        $dumpPath   = (string) ($dbRollback['dump_path'] ?? '');
+        $dumpBase   = $dumpPath !== '' && is_file($dumpPath) ? basename($dumpPath) : '';
+
+        // 1. Remove the downloaded artifacts from scratch (keeping the
+        // pre-restore DB dump, if any).
         $scratch = $this->scratchDir();
         if ($scratch !== '' && is_dir($scratch)) {
             $items = @scandir($scratch);
             if ($items !== false) {
                 foreach ($items as $i) {
                     if ($i === '.' || $i === '..') {
+                        continue;
+                    }
+                    if ($dumpBase !== '' && ($i === $dumpBase || $i === $dumpBase . '.expires')) {
                         continue;
                     }
                     $p = $scratch . DIRECTORY_SEPARATOR . $i;
@@ -1604,7 +2207,11 @@ final class RestoreRunner
                     }
                 }
             }
-            @rmdir($scratch); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- removes an empty server-derived scratch dir; WP_Filesystem not initialized
+            // Only remove the scratch dir itself when nothing is left in
+            // it — the dump, if kept, still lives here.
+            if ($dumpBase === '' || !is_file($scratch . DIRECTORY_SEPARATOR . $dumpBase)) {
+                @rmdir($scratch); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- removes an empty server-derived scratch dir; WP_Filesystem not initialized
+            }
         }
 
         // 2. Old-files disposition. Track 5 — two shapes:
@@ -1617,50 +2224,35 @@ final class RestoreRunner
         $oldFilesDir = (string) ($swap['old_files_dir'] ?? '');
         $oldDirs     = isset($swap['old_dirs']) && is_array($swap['old_dirs']) ? $swap['old_dirs'] : [];
 
-        if ($keepOld) {
-            // Operator opted into the long-window manual-rollback path.
-            // Schedule a 24h GC + 60s grace to sweep the exact dir later.
-            if (function_exists('wp_next_scheduled') && function_exists('wp_schedule_single_event')) {
-                if (!wp_next_scheduled('wpmgr_restore_oldfiles_gc')) {
-                    wp_schedule_single_event(
-                        time() + FilesRestorer::OLDFILES_GC_AGE_SECONDS_LONG + 60,
-                        'wpmgr_restore_oldfiles_gc'
-                    );
-                }
+        $expiresAt = time() + ($keepOld ? FilesRestorer::OLDFILES_GC_AGE_SECONDS_LONG : FilesRestorer::OLDFILES_GC_AGE_SECONDS);
+
+        // GH #146: mark the files rollback tree(s) with an `.expires`
+        // sidecar recording exactly when `FilesRestorer::gcOldFiles()` may
+        // reclaim them, then leave them in place (DEFER — no synchronous
+        // rrmdir on either branch anymore).
+        if ($oldFilesDir !== '' && is_dir($oldFilesDir)) {
+            $this->writeGcExpiryMarker($oldFilesDir, $expiresAt);
+        }
+        foreach ($oldDirs as $comp => $abs) {
+            if (!is_string($abs) || $abs === '') {
+                continue;
             }
-        } else {
-            // Default path: synchronous rrmdir of the EXACT dirs recorded in
-            // sub_state. Not a glob — two concurrent restores on the same
-            // host would lose each other's rollback trees on a glob sweep.
-            if ($oldFilesDir !== '' && is_dir($oldFilesDir)) {
-                $this->rrmdir($oldFilesDir);
-            }
-            foreach ($oldDirs as $comp => $abs) {
-                if (!is_string($abs) || $abs === '') {
-                    continue;
-                }
-                if ($comp === 'wp-content') {
-                    // The catch-all component's rollback is a glob of
-                    // `.wpmgr-old-wpcontent-<short>-*` siblings — the marker
-                    // path recorded in sub_state is the common prefix; expand
-                    // it. This is the ONE place we use a glob, and it's
-                    // bounded to a per-restore prefix, so concurrent restores
-                    // don't clobber each other.
-                    $hits = @glob($abs . '-*');
-                    if (is_array($hits)) {
-                        foreach ($hits as $h) {
-                            if (is_dir($h)) {
-                                $this->rrmdir($h);
-                            } elseif (is_file($h) || is_link($h)) {
-                                wp_delete_file($h);
-                            }
-                        }
-                    }
-                    continue;
-                }
-                if (is_dir($abs)) {
-                    $this->rrmdir($abs);
-                }
+            // The 'wp-content' catch-all's $abs is a naming PREFIX (never a
+            // real directory itself — only its `-<name>` siblings are);
+            // gcOldFiles() detects this shape at sweep time and expands it.
+            $this->writeGcExpiryMarker($abs, $expiresAt);
+        }
+
+        // GH #146 / §5: keep the pre-restore DB dump for the SAME window as
+        // the files rollback tree, GC'd by the same cron sweep
+        // (RestoreRunner::gcPreRestoreDumps(), bound to the same hook).
+        if ($dumpBase !== '' && is_file($dumpPath)) {
+            $this->writeGcExpiryMarker($dumpPath, $expiresAt);
+        }
+
+        if (function_exists('wp_next_scheduled') && function_exists('wp_schedule_single_event')) {
+            if (!wp_next_scheduled('wpmgr_restore_oldfiles_gc')) {
+                wp_schedule_single_event($expiresAt + 60, 'wpmgr_restore_oldfiles_gc');
             }
         }
 
@@ -1992,11 +2584,42 @@ final class RestoreRunner
      * Best-effort cleanup of the per-run scratch dir + dedup row. Called on
      * COMPLETED.
      */
-    private function cleanupOnCompleted(): void
+    /**
+     * @param array<string,mixed> $subState Final sub_state, so the GH #146
+     *        pre-restore DB dump (deliberately kept for its retention
+     *        window by `runCleanup()`, which already ran as the preceding
+     *        phase) is not immediately wiped out again by this method's
+     *        own scratch-dir sweep.
+     */
+    private function cleanupOnCompleted(array $subState): void
     {
         $scratch = $this->scratchDir();
         if ($scratch !== '' && is_dir($scratch)) {
-            $this->rrmdir($scratch);
+            $dbRollback = isset($subState['db_rollback']) && is_array($subState['db_rollback']) ? $subState['db_rollback'] : [];
+            $dumpPath   = (string) ($dbRollback['dump_path'] ?? '');
+            if ($dumpPath !== '' && is_file($dumpPath)) {
+                // GH #146 / §5: the pre-restore dump (+ its `.expires`
+                // marker) was deliberately kept by runCleanup() for the
+                // retention window — leave the scratch dir (and just those
+                // two files) alone; the GC sweep reclaims both later.
+                $dumpBase = basename($dumpPath);
+                $items    = @scandir($scratch);
+                if ($items !== false) {
+                    foreach ($items as $i) {
+                        if ($i === '.' || $i === '..' || $i === $dumpBase || $i === $dumpBase . '.expires') {
+                            continue;
+                        }
+                        $p = $scratch . DIRECTORY_SEPARATOR . $i;
+                        if (is_file($p)) {
+                            wp_delete_file($p);
+                        } elseif (is_dir($p)) {
+                            $this->rrmdir($p);
+                        }
+                    }
+                }
+            } else {
+                $this->rrmdir($scratch);
+            }
         }
 
         global $wpdb;
@@ -2301,5 +2924,74 @@ final class RestoreRunner
             }
         }
         @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- removes an empty server-derived scratch/snapshot dir; WP_Filesystem not initialized
+    }
+
+    /**
+     * GH #146 / §5: write a `<targetPath>.expires` sidecar recording the
+     * unix timestamp after which `FilesRestorer::gcOldFiles()` (files) or
+     * `self::gcPreRestoreDumps()` (the DB dump) may reclaim it. Best-effort
+     * — a failed write just means the legacy mtime-vs-LONG-threshold
+     * fallback applies instead, which is still safe (only ever LATER than
+     * intended, never earlier).
+     */
+    private function writeGcExpiryMarker(string $targetPath, int $expiresAt): void
+    {
+        @file_put_contents($targetPath . '.expires', (string) $expiresAt, LOCK_EX);
+    }
+
+    /**
+     * GH #146 / §5: GC pre-restore DB dumps (+ their `.expires` markers)
+     * once their retention window elapses. Bound to the SAME
+     * `wpmgr_restore_oldfiles_gc` cron hook `FilesRestorer::gcOldFiles()`
+     * uses, so both halves of the rollback material (files tree + DB dump)
+     * age out on the same sweep.
+     *
+     * @return void
+     */
+    public static function gcPreRestoreDumps(): void
+    {
+        if (!defined('WP_CONTENT_DIR')) {
+            return;
+        }
+        $base = rtrim((string) WP_CONTENT_DIR, '/\\') . '/wpmgr-agent/restores';
+        if (!is_dir($base)) {
+            return;
+        }
+
+        $now  = time();
+        $dirs = @glob($base . DIRECTORY_SEPARATOR . '*', GLOB_ONLYDIR);
+        if (!is_array($dirs)) {
+            return;
+        }
+
+        foreach ($dirs as $dir) {
+            $markers = @glob($dir . DIRECTORY_SEPARATOR . '*.expires');
+            if (!is_array($markers) || $markers === []) {
+                continue;
+            }
+            foreach ($markers as $marker) {
+                $target = substr($marker, 0, -strlen('.expires'));
+                $raw    = @file_get_contents($marker);
+                $expiresAt = $raw !== false && trim($raw) !== '' ? (int) trim($raw) : 0;
+
+                if ($expiresAt <= 0) {
+                    wp_delete_file($marker);
+                    continue;
+                }
+                if ($now < $expiresAt) {
+                    continue;
+                }
+                if (is_file($target)) {
+                    wp_delete_file($target);
+                }
+                wp_delete_file($marker);
+            }
+
+            // Reclaim the now-empty per-restore scratch dir.
+            $remaining = @scandir($dir);
+            if (is_array($remaining) && count($remaining) <= 2) {
+                @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- removes an empty server-derived scratch dir; WP_Filesystem not initialized
+            }
+        }
     }
 }

--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace WPMgr\Agent;
 
 use WPMgr\Agent\Backup\FilesRestorer;
+use WPMgr\Agent\Backup\RestoreRunner;
 use WPMgr\Agent\Backup\RestoreWatchdog;
 use WPMgr\Agent\Backup\Watchdog;
 use WPMgr\Agent\Commands\AutologinCommand;
@@ -568,6 +569,12 @@ final class Plugin
         // operator has a manual-rollback window. Scheduled by RestoreRunner
         // on cleanup; the handler sweeps anything older than 24 h.
         add_action('wpmgr_restore_oldfiles_gc', [FilesRestorer::class, 'gcOldFiles']);
+
+        // GH #146 — same cron event also GCs the forced pre-restore DB dump
+        // (see RestoreRunner::capturePreRestoreDbDump()/runCleanup()) once
+        // its retention window elapses, so both halves of the health-check
+        // rollback material age out together.
+        add_action('wpmgr_restore_oldfiles_gc', [RestoreRunner::class, 'gcPreRestoreDumps']);
 
         // M1 (issue #131 adversarial review) — recurring GC backstop for the
         // wpmgr-snapshots/ store UpdateCommand's pre-update snapshots live

--- a/apps/agent/phpstan-baseline.neon
+++ b/apps/agent/phpstan-baseline.neon
@@ -117,7 +117,7 @@ parameters:
 		-
 			message: '#^Left side of && is always true\.$#'
 			identifier: booleanAnd.leftAlwaysTrue
-			count: 1
+			count: 2
 			path: includes/backup/class-files-restorer.php
 
 		-

--- a/apps/agent/tests/Backup/FakeRestoreRunnerWpdb.php
+++ b/apps/agent/tests/Backup/FakeRestoreRunnerWpdb.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Minimal in-memory $wpdb double for GH #146 RestoreRunner/RestoreHealthCheck
+ * tests. Supports exactly the surface those classes touch:
+ *
+ *   - RestoreHealthCheck::checkDatabase() — RAW interpolated get_var() reads
+ *     against `siteurl` / the users table / the posts table (no prepare()).
+ *   - RestoreRunner::loadTask()/saveTaskState() — prepare()+get_row() and
+ *     update() against an in-memory `wpmgr_restore_tasks` row, keyed by
+ *     "snapshot_id|restore_id".
+ *   - RestoreRunner::estimateLiveDbBytes() — prepare()+get_var() against
+ *     information_schema (returns null/unknown; harmless).
+ *   - RestoreRunner::cleanupOnCompleted() — delete().
+ *
+ * prepare() carries the query + bound args through as a JSON envelope
+ * (mirrors the existing tests/FakeWpdb.php trick) so get_row()/get_var() can
+ * recover the exact bound values without fragile SQL-text regexing.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+final class FakeRestoreRunnerWpdb
+{
+    public string $prefix = 'wp_';
+    public string $options = 'wp_options';
+    public string $users = 'wp_users';
+    public string $posts = 'wp_posts';
+    public string $last_error = '';
+
+    // --- Probe A canned answers (RestoreHealthCheck::checkDatabase()). ---
+    public ?string $siteurlValue = 'https://example.test';
+    public bool $siteurlErrors = false;
+    public bool $usersErrors = false;
+    public bool $postsErrors = false;
+
+    /**
+     * In-memory `wpmgr_restore_tasks` rows, keyed "snapshot_id|restore_id".
+     *
+     * @var array<string,array{phase:string,kind:string,sub_state:string,resume_count:int,max_resumes:int}>
+     */
+    public array $rows = [];
+
+    /** @var list<array{table:string,data:array<string,mixed>,where:array<string,mixed>}> */
+    public array $updates = [];
+
+    /** @var list<array{table:string,where:array<string,mixed>}> */
+    public array $deletes = [];
+
+    /**
+     * @param string $query SQL with %s/%d placeholders.
+     * @param mixed  ...$args Bound arguments.
+     */
+    public function prepare(string $query, ...$args): string
+    {
+        $flat = [];
+        foreach ($args as $a) {
+            if (is_array($a)) {
+                foreach ($a as $v) {
+                    $flat[] = $v;
+                }
+            } else {
+                $flat[] = $a;
+            }
+        }
+        return (string) json_encode(['sql' => $query, 'args' => $flat]);
+    }
+
+    /**
+     * @param string $prepared Output of prepare().
+     * @param mixed  $mode     Ignored (ARRAY_A in production).
+     * @return array<string,mixed>|null
+     */
+    public function get_row(string $prepared, $mode = null): ?array
+    {
+        $decoded = json_decode($prepared, true);
+        if (!is_array($decoded) || !isset($decoded['args']) || !is_array($decoded['args'])) {
+            return null;
+        }
+        $args = $decoded['args'];
+        $key  = ($args[0] ?? '') . '|' . ($args[1] ?? '');
+        return $this->rows[$key] ?? null;
+    }
+
+    /**
+     * Handles BOTH raw interpolated SELECTs (RestoreHealthCheck's Probe A)
+     * and prepared JSON-enveloped SELECTs (RestoreRunner::estimateLiveDbBytes()).
+     *
+     * @param string $sql
+     * @return string|null
+     */
+    public function get_var(string $sql): ?string
+    {
+        $decoded = json_decode($sql, true);
+        if (is_array($decoded) && isset($decoded['sql'])) {
+            // A prepared query — only estimateLiveDbBytes() prepares one in
+            // this class's surface. Return null (unknown size); harmless.
+            $this->last_error = '';
+            return null;
+        }
+
+        if (stripos($sql, 'siteurl') !== false) {
+            $this->last_error = $this->siteurlErrors ? 'simulated siteurl error' : '';
+            return $this->siteurlErrors ? null : $this->siteurlValue;
+        }
+        if (stripos($sql, $this->users) !== false) {
+            $this->last_error = $this->usersErrors ? 'simulated users table error' : '';
+            return $this->usersErrors ? null : '1';
+        }
+        if (stripos($sql, $this->posts) !== false) {
+            $this->last_error = $this->postsErrors ? 'simulated posts table error' : '';
+            return $this->postsErrors ? null : '1';
+        }
+
+        $this->last_error = '';
+        return null;
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     * @param array<string,mixed> $where
+     */
+    public function update(string $table, array $data, array $where, $format = null, $whereFormat = null): int
+    {
+        $this->updates[] = ['table' => $table, 'data' => $data, 'where' => $where];
+        $key = ($where['snapshot_id'] ?? '') . '|' . ($where['restore_id'] ?? '');
+        if (!isset($this->rows[$key])) {
+            return 0;
+        }
+        $this->rows[$key] = array_merge($this->rows[$key], $data);
+        return 1;
+    }
+
+    /**
+     * @param array<string,mixed> $where
+     */
+    public function delete(string $table, array $where, $format = null): int
+    {
+        $this->deletes[] = ['table' => $table, 'where' => $where];
+        return 1;
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     */
+    public function insert(string $table, array $data, $format = null): int
+    {
+        return 1;
+    }
+
+    public function query(string $prepared)
+    {
+        return 0;
+    }
+}

--- a/apps/agent/tests/Backup/RestoreGuardTest.php
+++ b/apps/agent/tests/Backup/RestoreGuardTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * RestoreGuardTest — direct unit coverage of
+ * WPMgr\Agent\Backup\RestoreGuard, mirroring tests/UpdateGuardTest.php's
+ * arm/markClean/fire lifecycle coverage for the update-apply guard.
+ *
+ * None of these tests call arm() — mirroring UpdateGuardTest, fire()/
+ * markClean() are exercised directly so the test suite never registers a
+ * REAL `register_shutdown_function()` callback (which would otherwise stay
+ * referenced — and potentially fire, against whatever `global $wpdb` a
+ * LATER, unrelated test happens to have left behind — for the rest of the
+ * PHPUnit process).
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use WPMgr\Agent\Backup\RestoreGuard;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\RestoreGuard
+ */
+final class RestoreGuardTest extends TestCase
+{
+    public function test_fire_invokes_the_rollback_callable_and_reports_its_result(): void
+    {
+        $calls  = 0;
+        $result = ['files' => true, 'db' => false];
+        $guard  = new RestoreGuard(function () use (&$calls, $result): array {
+            $calls++;
+            return $result;
+        });
+
+        $fired = $guard->fire();
+
+        $this->assertSame(1, $calls);
+        $this->assertTrue($fired['fired']);
+        $this->assertTrue($fired['files']);
+        $this->assertFalse($fired['db']);
+    }
+
+    public function test_fire_is_a_noop_after_markClean(): void
+    {
+        $calls = 0;
+        $guard = new RestoreGuard(function () use (&$calls): array {
+            $calls++;
+            return ['files' => true, 'db' => true];
+        });
+
+        $guard->markClean();
+        $fired = $guard->fire();
+
+        $this->assertSame(0, $calls, 'a verified-clean guard must never invoke the rollback callable');
+        $this->assertFalse($fired['fired']);
+        $this->assertFalse($fired['files']);
+        $this->assertFalse($fired['db']);
+    }
+
+    public function test_fire_is_idempotent(): void
+    {
+        $calls = 0;
+        $guard = new RestoreGuard(function () use (&$calls): array {
+            $calls++;
+            return ['files' => true, 'db' => true];
+        });
+
+        $first  = $guard->fire();
+        $second = $guard->fire();
+
+        $this->assertSame(1, $calls, 'a second fire() call must never invoke the rollback callable again');
+        $this->assertTrue($first['fired']);
+        $this->assertFalse($second['fired'], 'a second fire() call must be a no-op, never a second rollback');
+    }
+
+    /**
+     * markClean() called AFTER an in-flight fire() has already started is
+     * out of scope for this synchronous test harness (fire() completes
+     * atomically here) — but markClean() called before ANY fire() call,
+     * even after some unrelated delay, must still block it. This guards
+     * the exact ordering RestoreRunner::runHealthCheck() depends on: mark
+     * clean the INSTANT health_check passes, before maintenance_off runs.
+     */
+    public function test_markClean_before_any_fire_blocks_it_permanently(): void
+    {
+        $calls = 0;
+        $guard = new RestoreGuard(function () use (&$calls): array {
+            $calls++;
+            return ['files' => true, 'db' => true];
+        });
+
+        $guard->markClean();
+        $guard->fire();
+        $guard->fire();
+        $guard->fire();
+
+        $this->assertSame(0, $calls);
+    }
+
+    /**
+     * fire() must never let a \Throwable escape — a shutdown-function
+     * context has nowhere useful to propagate one to.
+     */
+    public function test_fire_swallows_a_throwing_rollback_callable(): void
+    {
+        $guard = new RestoreGuard(function (): array {
+            throw new \RuntimeException('simulated rollback failure');
+        });
+
+        $fired = $guard->fire();
+
+        $this->assertTrue($fired['fired']);
+        $this->assertFalse($fired['files']);
+        $this->assertFalse($fired['db']);
+    }
+
+    /**
+     * A missing/malformed rollback result (no 'files'/'db' keys) must
+     * degrade to false/false rather than throw or emit a PHP notice.
+     */
+    public function test_fire_tolerates_a_malformed_rollback_result(): void
+    {
+        $guard = new RestoreGuard(function (): array {
+            return [];
+        });
+
+        $fired = $guard->fire();
+
+        $this->assertTrue($fired['fired']);
+        $this->assertFalse($fired['files']);
+        $this->assertFalse($fired['db']);
+    }
+
+    public function test_arm_registers_a_shutdown_function_without_throwing(): void
+    {
+        // We only assert this doesn't throw — actually registering +
+        // exercising a real PHP shutdown callback is out of scope for a
+        // synchronous unit test (see class doc). markClean() immediately
+        // after neutralizes it so nothing fires at real process shutdown.
+        $guard = new RestoreGuard(static fn (): array => ['files' => false, 'db' => false]);
+        $guard->arm();
+        $guard->markClean();
+        $this->assertTrue(true);
+    }
+}

--- a/apps/agent/tests/Backup/RestoreHealthCheckLiveTest.php
+++ b/apps/agent/tests/Backup/RestoreHealthCheckLiveTest.php
@@ -1,0 +1,290 @@
+<?php
+/**
+ * RestoreHealthCheckLiveTest — GH #146 two-gate restructure: dedicated
+ * coverage of Gate 2 (`health_check_live`, the loopback WSOD probe on the
+ * REAL post-maintenance site).
+ *
+ * This is the GitHub issue #147 class this whole feature exists to catch:
+ * a dropped required file fataling on plugin load. Gate 1 (`health_check`,
+ * the in-process DB probe, still under maintenance) CANNOT see this at
+ * all — the DB is perfectly fine; only a real, post-maintenance HTTP
+ * request to the live site can observe a plugin-load fatal. Every test here
+ * drives the REAL `run()` dispatch loop, seeded at `health_check` (Gate 1)
+ * with Probe A passing by default, so `run()` actually crosses
+ * maintenance_off into `health_check_live` (Gate 2) — proving the phase
+ * ORDER, not just Gate 2's probe logic in isolation (that's
+ * RestoreHealthCheckTest's job).
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Backup\RestoreRunner;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\RestoreRunner
+ * @covers \WPMgr\Agent\Backup\RestoreHealthCheck
+ */
+final class RestoreHealthCheckLiveTest extends TestCase
+{
+    private const SNAPSHOT_ID = '55555555-5555-5555-5555-555555555555';
+    private const RESTORE_ID  = '66666666-6666-6666-6666-666666666666';
+
+    private string $root        = '';
+    private string $targetDir   = '';
+    private string $oldFilesDir = '';
+    private string $scratchDir  = '';
+    private string $wpRootDir   = '';
+    private string $dumpPath    = '';
+
+    private FakeRestoreRunnerWpdb $wpdb;
+
+    /** @var list<array{ts:int,hook:string}> */
+    private array $scheduled = [];
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->root        = sys_get_temp_dir() . '/wpmgr-hclive-' . bin2hex(random_bytes(6));
+        $this->targetDir   = $this->root . '/wp-content';
+        $this->oldFilesDir = $this->root . '/.wpmgr-old-files-666666666666';
+        $this->scratchDir  = $this->root . '/scratch';
+        $this->wpRootDir   = $this->root . '/wproot';
+
+        mkdir($this->targetDir, 0755, true);
+        mkdir($this->oldFilesDir, 0755, true);
+        mkdir($this->scratchDir, 0755, true);
+        mkdir($this->wpRootDir, 0755, true);
+
+        // The live target currently holds the just-restored tree — a
+        // FILES-side WSOD (the #147 class: e.g. a dropped required file)
+        // fatals on plugin load even though the DB is perfectly fine.
+        file_put_contents($this->targetDir . '/bad.txt', 'just-restored-content-with-a-broken-plugin');
+        file_put_contents($this->oldFilesDir . '/good.txt', 'pre-restore-working-content');
+
+        $this->dumpPath = $this->scratchDir . '/pre-restore-db.sql.gz';
+        file_put_contents($this->dumpPath, (string) gzencode("-- fake pre-restore dump\n"));
+
+        $this->wpdb = new FakeRestoreRunnerWpdb();
+        // Probe A (Gate 1) passes by default — the whole point of this
+        // files-WSOD class is that the DB is fine; only the real site (Gate
+        // 2) can see the plugin-load fatal.
+
+        $key = self::SNAPSHOT_ID . '|' . self::RESTORE_ID;
+        $this->wpdb->rows[$key] = [
+            'phase'     => RestoreRunner::PHASE_HEALTH_CHECK,
+            'kind'      => 'full',
+            'sub_state' => (string) json_encode([
+                'tmp_prefix' => 'tmpeeeeeeee_',
+                'swap_files' => [
+                    'done'          => true,
+                    'old_files_dir' => $this->oldFilesDir,
+                    'mode'          => 'legacy_whole',
+                ],
+                'db_rollback' => [
+                    'done'      => true,
+                    'available' => true,
+                    'dump_path' => $this->dumpPath,
+                    'prefix'    => 'wp_',
+                ],
+            ]),
+            'resume_count' => 0,
+            'max_resumes'  => 6,
+        ];
+        $GLOBALS['wpdb'] = $this->wpdb;
+
+        Functions\when('home_url')->alias(static fn (string $path = '/') => 'https://example.test' . $path);
+        Functions\when('admin_url')->alias(static fn (string $path = '') => 'https://example.test/wp-admin/' . $path);
+        Functions\when('wp_remote_retrieve_body')->alias(static fn ($r) => is_array($r) ? (string) ($r['body'] ?? '') : '');
+
+        Functions\when('wp_next_scheduled')->justReturn(false);
+        Functions\when('wp_schedule_single_event')->alias(function (int $ts, string $hook, array $args = []): bool {
+            $this->scheduled[] = ['ts' => $ts, 'hook' => $hook];
+            return true;
+        });
+    }
+
+    protected function tear_down(): void
+    {
+        $this->rrmdir($this->root);
+        unset($GLOBALS['wpdb']);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * The headline GH #147-class scenario: Gate 1 (DB) passes, but Gate 2
+     * (the real post-maintenance site) gets a definitive fatal (a real 5xx
+     * here — a fatal-body-signature case is covered in
+     * RestoreHealthCheckTest). Must roll back files+DB and report FAILED
+     * with reason wsod_post_restore — NEVER Completed.
+     */
+    public function test_files_wsod_on_the_real_site_rolls_back_and_reports_failed(): void
+    {
+        Functions\when('wp_remote_get')->alias(static fn (string $url, array $args = []) => [
+            'response' => ['code' => 500],
+            'body'     => 'Internal Server Error — Fatal error: Uncaught Error in wp-content/plugins/broken/broken.php',
+        ]);
+
+        $phase = $this->makeRunner()->run();
+
+        $this->assertSame(RestoreRunner::PHASE_FAILED, $phase, 'a files-WSOD restore must NEVER report Completed');
+
+        // --- Files ACTUALLY got reverted on disk. -------------------------
+        $this->assertFileExists($this->targetDir . '/good.txt', 'the pre-restore (working) tree must be back in place');
+        $this->assertFileDoesNotExist($this->targetDir . '/bad.txt', 'the WSOD-causing just-restored tree must be gone');
+        $this->assertDirectoryDoesNotExist($this->oldFilesDir, 'the rollback source dir is consumed by the revert');
+
+        // --- Task row reflects FAILED + the Gate-2-specific reason. --------
+        $finalSubState = $this->finalSubState();
+        $this->assertSame(RestoreRunner::PHASE_HEALTH_CHECK_LIVE, $finalSubState['failed_in']);
+        $this->assertNotEmpty($finalSubState['last_error']);
+        $this->assertTrue($finalSubState['rolled_back']['files'], 'files leg must be recorded as rolled back');
+        $this->assertFalse(
+            $finalSubState['rolled_back']['db'],
+            'the DB leg fails fast against the closed loopback port — recorded as attempted-but-failed, never silently true'
+        );
+        $this->assertSame(
+            'wsod_post_restore',
+            $finalSubState['rolled_back']['reason'],
+            'Gate 2 (loopback WSOD) failures tag the reason distinctly from Gate 1 (db_unhealthy_post_restore)'
+        );
+
+        $key = self::SNAPSHOT_ID . '|' . self::RESTORE_ID;
+        $this->assertSame(RestoreRunner::PHASE_FAILED, $this->wpdb->rows[$key]['phase']);
+    }
+
+    /**
+     * Same files-WSOD scenario, but via a fatal-body-signature 200 (a
+     * swallowed fatal under display_errors=Off) instead of a real 5xx —
+     * proves the body-signature classification path also drives the Gate-2
+     * rollback, not just a raw 5xx.
+     */
+    public function test_fatal_body_signature_on_the_real_site_rolls_back_and_reports_failed(): void
+    {
+        Functions\when('wp_remote_get')->alias(static fn (string $url, array $args = []) => [
+            'response' => ['code' => 200],
+            'body'     => '<b>Fatal error</b>: Uncaught Error: Class "Broken_Plugin" not found in wp-content/plugins/broken/broken.php',
+        ]);
+
+        $phase = $this->makeRunner()->run();
+
+        $this->assertSame(RestoreRunner::PHASE_FAILED, $phase);
+        $this->assertFileExists($this->targetDir . '/good.txt');
+        $this->assertFileDoesNotExist($this->targetDir . '/bad.txt');
+
+        $finalSubState = $this->finalSubState();
+        $this->assertSame(RestoreRunner::PHASE_HEALTH_CHECK_LIVE, $finalSubState['failed_in']);
+        $this->assertSame('wsod_post_restore', $finalSubState['rolled_back']['reason']);
+    }
+
+    /**
+     * GH #146 review CRITICAL-2 safety, exercised end-to-end through Gate
+     * 2: every loopback probe target connect-refuses (a transient blip,
+     * post-maintenance-off — the site is live, this isn't a maintenance-mode
+     * artifact) — this MUST be inconclusive/fail-open, proceeding all the
+     * way to Completed with NO rollback. Proves a blip after maintenance is
+     * lifted can never roll back a good restore.
+     */
+    public function test_connect_refused_on_the_real_site_is_inconclusive_completes_with_no_rollback(): void
+    {
+        Functions\when('wp_remote_get')->alias(static fn (string $url, array $args = []) => new \WP_Error('http_request_failed', 'Connection refused'));
+
+        $phase = $this->makeRunner()->run();
+
+        $this->assertSame(RestoreRunner::PHASE_COMPLETED, $phase, 'mere unreachability post-maintenance-off must never roll back a good restore');
+
+        // --- Nothing was reverted — the as-restored tree is untouched. -----
+        $this->assertFileExists($this->targetDir . '/bad.txt', 'the as-restored tree must be left exactly as-is');
+        $this->assertFileDoesNotExist($this->targetDir . '/good.txt');
+        // --- And the rollback material is still kept (deferred cleanup). --
+        $this->assertDirectoryExists($this->oldFilesDir);
+        $this->assertFileExists($this->oldFilesDir . '.expires');
+
+        $key = self::SNAPSHOT_ID . '|' . self::RESTORE_ID;
+        $this->assertSame(RestoreRunner::PHASE_COMPLETED, $this->wpdb->rows[$key]['phase']);
+    }
+
+    /**
+     * Same fail-open invariant, but for a blank/marker-less 200 (the
+     * Risk-2 hardening) rather than a connect failure — also must complete
+     * with no rollback.
+     */
+    public function test_blank_200_on_the_real_site_is_inconclusive_completes_with_no_rollback(): void
+    {
+        Functions\when('wp_remote_get')->alias(static fn (string $url, array $args = []) => ['response' => ['code' => 200], 'body' => '']);
+
+        $phase = $this->makeRunner()->run();
+
+        $this->assertSame(RestoreRunner::PHASE_COMPLETED, $phase);
+        $this->assertFileExists($this->targetDir . '/bad.txt');
+        $this->assertFileDoesNotExist($this->targetDir . '/good.txt');
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function finalSubState(): array
+    {
+        $key = self::SNAPSHOT_ID . '|' . self::RESTORE_ID;
+        $row = $this->wpdb->rows[$key] ?? null;
+        $this->assertIsArray($row);
+        $decoded = json_decode((string) $row['sub_state'], true);
+        $this->assertIsArray($decoded);
+        return $decoded;
+    }
+
+    private function makeRunner(): RestoreRunner
+    {
+        return new RestoreRunner([
+            'snapshot_id'       => self::SNAPSHOT_ID,
+            'restore_id'        => self::RESTORE_ID,
+            'kind'              => 'full',
+            'progress_endpoint' => '',
+            'scratch_dir'       => $this->scratchDir,
+            'wp_content_path'   => $this->targetDir,
+            'wp_root'           => $this->wpRootDir,
+            'db' => [
+                // Definitely-closed loopback port: DbRestorer::connect()
+                // fails fast (ECONNREFUSED) — no live MySQL needed, and no
+                // real network access either.
+                'host'     => '127.0.0.1:1',
+                'user'     => 'nouser',
+                'password' => 'nopass',
+                'name'     => 'no_such_db',
+                'prefix'   => 'wp_',
+            ],
+        ]);
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+}

--- a/apps/agent/tests/Backup/RestoreHealthCheckTest.php
+++ b/apps/agent/tests/Backup/RestoreHealthCheckTest.php
@@ -1,0 +1,395 @@
+<?php
+/**
+ * RestoreHealthCheckTest — unit coverage of GH #146's post-restore health
+ * check: `RestoreHealthCheck::checkDatabase()` (Probe A) in isolation, and
+ * the combined `run()` verdict (`ok = ProbeA.ok && (ProbeB.ok ||
+ * ProbeB.inconclusive)`) exercised through the WP HTTP API stubs.
+ *
+ * Includes the post-adversarial-review hardening:
+ *   - CRITICAL 1: a maintenance-mode 503 (the runner's OWN `.maintenance`
+ *     drop-file, present for the ENTIRE health_check window by design) must
+ *     downgrade to inconclusive, never hard-fail a DB-healthy restore.
+ *   - CRITICAL 2: an all-connect-refused Probe B is ALWAYS inconclusive —
+ *     never a hard failure — regardless of the wp-cron.php sentinel's
+ *     result or of `DISABLE_WP_CRON`'s state. These tests no longer need to
+ *     skip when `DISABLE_WP_CRON` leaks true from an earlier test in the
+ *     same process (see class doc on the old skip guard, removed).
+ *   - Risk-2 strengthening: a blank/marker-less 2xx body downgrades to
+ *     inconclusive rather than a confident pass.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Backup\RestoreHealthCheck;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\RestoreHealthCheck
+ */
+final class RestoreHealthCheckTest extends TestCase
+{
+    private FakeRestoreRunnerWpdb $wpdb;
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->wpdb = new FakeRestoreRunnerWpdb();
+        $GLOBALS['wpdb'] = $this->wpdb;
+
+        Functions\when('home_url')->alias(static fn (string $path = '/') => 'https://example.test' . $path);
+        Functions\when('admin_url')->alias(static fn (string $path = '') => 'https://example.test/wp-admin/' . $path);
+    }
+
+    protected function tear_down(): void
+    {
+        unset($GLOBALS['wpdb']);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // ==================================================================
+    // Probe A — in-process DB check.
+    // ==================================================================
+
+    public function test_probe_a_fails_when_wpdb_is_not_available(): void
+    {
+        unset($GLOBALS['wpdb']);
+        $result = (new RestoreHealthCheck())->checkDatabase();
+        $this->assertFalse($result['ok']);
+        $this->assertNotEmpty($result['failures']);
+    }
+
+    public function test_probe_a_fails_when_siteurl_is_empty_after_swap(): void
+    {
+        $this->wpdb->siteurlValue = '';
+        $result = (new RestoreHealthCheck())->checkDatabase();
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('siteurl', implode(' ', $result['failures']));
+    }
+
+    /**
+     * The GH #146 headline scenario: a table the swap should have produced
+     * no longer answers (missing / DB error) — must be a HARD failure.
+     */
+    public function test_probe_a_fails_on_missing_swapped_users_table(): void
+    {
+        $this->wpdb->usersErrors = true;
+        $result = (new RestoreHealthCheck())->checkDatabase();
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('users', implode(' ', $result['failures']));
+    }
+
+    public function test_probe_a_fails_on_missing_swapped_posts_table(): void
+    {
+        $this->wpdb->postsErrors = true;
+        $result = (new RestoreHealthCheck())->checkDatabase();
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('posts', implode(' ', $result['failures']));
+    }
+
+    public function test_probe_a_passes_when_all_reads_succeed(): void
+    {
+        $result = (new RestoreHealthCheck())->checkDatabase();
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['failures']);
+    }
+
+    // ==================================================================
+    // Combined verdict — Probe B via the WP HTTP API.
+    // ==================================================================
+
+    public function test_5xx_on_home_url_is_a_hard_failure(): void
+    {
+        Functions\when('wp_remote_get')->alias(static function (string $url, array $args = []) {
+            if (str_contains($url, 'wp-cron.php')) {
+                return ['response' => ['code' => 200]];
+            }
+            return ['response' => ['code' => 500], 'body' => 'Internal Server Error'];
+        });
+        Functions\when('wp_remote_retrieve_body')->alias(static fn ($r) => is_array($r) ? (string) ($r['body'] ?? '') : '');
+
+        // No .maintenance present (default ABSPATH from the test bootstrap
+        // has no such file) — a real, non-maintenance 5xx must still be a
+        // hard failure.
+        $result = (new RestoreHealthCheck())->run();
+
+        $this->assertFalse($result['ok']);
+        $this->assertNotEmpty($result['failures']);
+    }
+
+    public function test_fatal_error_body_signature_is_a_hard_failure_even_on_http_200(): void
+    {
+        // A WSOD often still returns HTTP 200 under display_errors — the
+        // status code alone must not be trusted.
+        Functions\when('wp_remote_get')->alias(static function (string $url, array $args = []) {
+            if (str_contains($url, 'wp-cron.php')) {
+                return ['response' => ['code' => 200]];
+            }
+            return ['response' => ['code' => 200], 'body' => '<b>Fatal error</b>: Uncaught Error in wp-content/...'];
+        });
+        Functions\when('wp_remote_retrieve_body')->alias(static fn ($r) => is_array($r) ? (string) ($r['body'] ?? '') : '');
+
+        $result = (new RestoreHealthCheck())->run();
+
+        $this->assertFalse($result['ok']);
+        $this->assertNotEmpty($result['failures']);
+    }
+
+    public function test_2xx_passes(): void
+    {
+        Functions\when('wp_remote_get')->alias(static fn (string $url, array $args = []) => ['response' => ['code' => 200], 'body' => '<html>ok</html>']);
+        Functions\when('wp_remote_retrieve_body')->alias(static fn ($r) => is_array($r) ? (string) ($r['body'] ?? '') : '');
+
+        $result = (new RestoreHealthCheck())->run();
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['failures']);
+    }
+
+    public function test_401_login_walled_passes(): void
+    {
+        Functions\when('wp_remote_get')->alias(static fn (string $url, array $args = []) => ['response' => ['code' => 401], 'body' => 'Unauthorized']);
+        Functions\when('wp_remote_retrieve_body')->alias(static fn ($r) => is_array($r) ? (string) ($r['body'] ?? '') : '');
+
+        $result = (new RestoreHealthCheck())->run();
+
+        $this->assertTrue($result['ok']);
+    }
+
+    public function test_403_forbidden_passes(): void
+    {
+        Functions\when('wp_remote_get')->alias(static fn (string $url, array $args = []) => ['response' => ['code' => 403], 'body' => 'Forbidden']);
+        Functions\when('wp_remote_retrieve_body')->alias(static fn ($r) => is_array($r) ? (string) ($r['body'] ?? '') : '');
+
+        $result = (new RestoreHealthCheck())->run();
+
+        $this->assertTrue($result['ok']);
+    }
+
+    /**
+     * Risk-2 strengthening: a swallowed fatal under `display_errors=Off`
+     * can leave a blank (or marker-less) 200 behind — that must NOT read as
+     * a confident pass. Downgrades to inconclusive (a warning), not a
+     * rollback trigger, and not silently treated as healthy either.
+     */
+    public function test_blank_200_body_is_inconclusive_not_a_confident_pass(): void
+    {
+        Functions\when('wp_remote_get')->alias(static fn (string $url, array $args = []) => ['response' => ['code' => 200], 'body' => '']);
+        Functions\when('wp_remote_retrieve_body')->alias(static fn ($r) => is_array($r) ? (string) ($r['body'] ?? '') : '');
+
+        $result = (new RestoreHealthCheck())->run();
+
+        $this->assertTrue($result['ok'], 'ambiguous must never itself roll back a DB-healthy restore');
+        $this->assertSame([], $result['failures']);
+        $this->assertNotEmpty($result['warnings'], 'a blank 200 must surface as a warning, not be silently treated as healthy');
+    }
+
+    public function test_200_body_without_html_marker_is_inconclusive(): void
+    {
+        Functions\when('wp_remote_get')->alias(static fn (string $url, array $args = []) => ['response' => ['code' => 200], 'body' => 'ok']);
+        Functions\when('wp_remote_retrieve_body')->alias(static fn ($r) => is_array($r) ? (string) ($r['body'] ?? '') : '');
+
+        $result = (new RestoreHealthCheck())->run();
+
+        $this->assertTrue($result['ok']);
+        $this->assertNotEmpty($result['warnings']);
+    }
+
+    /**
+     * Every probe target connect-fails AND the wp-cron.php sentinel ALSO
+     * fails (a redirect, mirroring BackupCommand::isLoopbackGated()'s own
+     * gate signal) — the host structurally blocks loopback HTTP. This MUST
+     * be inconclusive (a warning), never a rollback trigger. No longer
+     * needs a DISABLE_WP_CRON skip guard: the sentinel's result only
+     * enriches the diagnostic detail now, it never changes the verdict.
+     */
+    public function test_structurally_gated_loopback_is_inconclusive_not_a_failure(): void
+    {
+        Functions\when('wp_remote_get')->alias(static function (string $url, array $args = []) {
+            if (str_contains($url, 'wp-cron.php')) {
+                // Redirect -> BackupCommand::isLoopbackGated()'s own gate signal.
+                return ['response' => ['code' => 302], 'headers' => ['location' => 'https://example.test/login']];
+            }
+            return new \WP_Error('http_request_failed', 'Could not resolve host');
+        });
+
+        $result = (new RestoreHealthCheck())->run();
+
+        $this->assertTrue($result['ok'], 'a structurally-gated loopback must never fail the verdict');
+        $this->assertNotEmpty($result['warnings'], 'the gate must surface as a warning, not silently pass');
+        $this->assertSame([], $result['failures']);
+    }
+
+    /**
+     * GH #146 review CRITICAL 2: every probe target connect-fails, and the
+     * wp-cron.php sentinel SUCCEEDS. This is NO LONGER a hard failure — a
+     * destructive rollback must fire only on a POSITIVE fatal signal (an
+     * actual 5xx or a fatal body signature), never on mere unreachability.
+     * `DISABLE_WP_CRON` (extremely common on managed hosts) makes the
+     * sentinel short-circuit to "not gated" WITHOUT even probing, which
+     * previously turned this exact scenario into a destructive rollback on
+     * essentially any such host — the fix makes the verdict identical
+     * whether the sentinel is gated or not.
+     */
+    public function test_all_targets_refused_while_sentinel_succeeds_is_inconclusive_not_a_hard_failure(): void
+    {
+        Functions\when('wp_remote_get')->alias(static function (string $url, array $args = []) {
+            if (str_contains($url, 'wp-cron.php')) {
+                return ['response' => ['code' => 200]];
+            }
+            return new \WP_Error('http_request_failed', 'Connection refused');
+        });
+
+        $result = (new RestoreHealthCheck())->run();
+
+        $this->assertTrue($result['ok'], 'connect-refused must never itself roll back a DB-healthy restore, sentinel result notwithstanding');
+        $this->assertSame([], $result['failures']);
+        $this->assertNotEmpty($result['warnings']);
+    }
+
+    public function test_verdict_fails_when_probe_a_fails_even_if_probe_b_passes(): void
+    {
+        $this->wpdb->siteurlValue = '';
+        Functions\when('wp_remote_get')->alias(static fn (string $url, array $args = []) => ['response' => ['code' => 200], 'body' => '<html>ok</html>']);
+        Functions\when('wp_remote_retrieve_body')->alias(static fn ($r) => is_array($r) ? (string) ($r['body'] ?? '') : '');
+
+        $result = (new RestoreHealthCheck())->run();
+
+        $this->assertFalse($result['ok'], 'a broken DB must fail the verdict regardless of a booting front end');
+    }
+
+    // ==================================================================
+    // CRITICAL 1: maintenance-mode-aware Probe B.
+    // ==================================================================
+
+    /**
+     * The headline CRITICAL-1 regression: `health_check` runs BEFORE
+     * `maintenance_off` by design (so a rollback happens while the site is
+     * still in maintenance mode) — which means the runner's OWN
+     * `.maintenance` drop-file is present for the entire health-check
+     * window on EVERY ordinary restore, and WordPress answers every
+     * loopback probe with its own 503 maintenance page for as long as that
+     * file exists. That 503 must NOT hard-fail a DB-healthy restore.
+     */
+    public function test_maintenance_mode_503_does_not_hard_fail_a_db_healthy_restore(): void
+    {
+        $wpRoot = $this->makeMaintenanceWpRoot();
+
+        Functions\when('wp_remote_get')->alias(static function (string $url, array $args = []) {
+            if (str_contains($url, 'wp-cron.php')) {
+                return ['response' => ['code' => 503], 'body' => 'Briefly unavailable for scheduled maintenance.'];
+            }
+            return [
+                'response' => ['code' => 503],
+                'body'     => '<!DOCTYPE html><html><body>Briefly unavailable for scheduled maintenance. '
+                    . 'Check back in a minute.</body></html>',
+            ];
+        });
+        Functions\when('wp_remote_retrieve_body')->alias(static fn ($r) => is_array($r) ? (string) ($r['body'] ?? '') : '');
+
+        $result = (new RestoreHealthCheck($wpRoot))->run();
+
+        $this->assertTrue($result['ok'], 'a maintenance-mode 503 must never hard-fail a DB-healthy restore');
+        $this->assertSame([], $result['failures']);
+        $this->assertNotEmpty($result['warnings'], 'the maintenance override should still surface as a warning for operator visibility');
+
+        $this->rrmdir($wpRoot);
+    }
+
+    /**
+     * Same 503 body, but WITHOUT `.maintenance` present — proves the
+     * override is conditional (a genuine, non-maintenance 5xx is still a
+     * hard failure), not a blanket "5xx never fails" downgrade.
+     */
+    public function test_same_503_without_maintenance_file_is_still_a_hard_failure(): void
+    {
+        $wpRoot = sys_get_temp_dir() . '/wpmgr-hc-nomaint-' . bin2hex(random_bytes(6));
+        mkdir($wpRoot, 0755, true);
+
+        Functions\when('wp_remote_get')->alias(static function (string $url, array $args = []) {
+            if (str_contains($url, 'wp-cron.php')) {
+                return ['response' => ['code' => 200]];
+            }
+            return [
+                'response' => ['code' => 503],
+                'body'     => '<!DOCTYPE html><html><body>Briefly unavailable for scheduled maintenance.</body></html>',
+            ];
+        });
+        Functions\when('wp_remote_retrieve_body')->alias(static fn ($r) => is_array($r) ? (string) ($r['body'] ?? '') : '');
+
+        $result = (new RestoreHealthCheck($wpRoot))->run();
+
+        $this->assertFalse($result['ok'], 'without .maintenance present, a 503 must still be treated as a genuine fatal');
+        $this->assertNotEmpty($result['failures']);
+
+        $this->rrmdir($wpRoot);
+    }
+
+    /**
+     * Probe A alone must still be able to fail the verdict during
+     * maintenance mode — Probe A is unaffected by the maintenance page
+     * (it talks to `$wpdb` directly) and remains the destructive gate for
+     * this window, per CRITICAL-1's fix.
+     */
+    public function test_probe_a_still_fails_during_maintenance_mode(): void
+    {
+        $wpRoot = $this->makeMaintenanceWpRoot();
+        $this->wpdb->siteurlValue = '';
+
+        Functions\when('wp_remote_get')->alias(static fn (string $url, array $args = []) => [
+            'response' => ['code' => 503],
+            'body'     => '<!DOCTYPE html><html><body>Briefly unavailable for scheduled maintenance.</body></html>',
+        ]);
+        Functions\when('wp_remote_retrieve_body')->alias(static fn ($r) => is_array($r) ? (string) ($r['body'] ?? '') : '');
+
+        $result = (new RestoreHealthCheck($wpRoot))->run();
+
+        $this->assertFalse($result['ok'], 'Probe A must remain the destructive gate during the maintenance window');
+        $this->assertStringContainsString('siteurl', implode(' ', $result['failures']));
+
+        $this->rrmdir($wpRoot);
+    }
+
+    /**
+     * @return string Absolute path of a fresh temp dir with a `.maintenance`
+     *                 file, mirroring RestoreRunner::maintenanceOn()'s format.
+     */
+    private function makeMaintenanceWpRoot(): string
+    {
+        $wpRoot = sys_get_temp_dir() . '/wpmgr-hc-maint-' . bin2hex(random_bytes(6));
+        mkdir($wpRoot, 0755, true);
+        file_put_contents($wpRoot . '/.maintenance', "<?php\n\$upgrading = " . time() . ';');
+        return $wpRoot;
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+}

--- a/apps/agent/tests/Backup/RestoreHealthPassTest.php
+++ b/apps/agent/tests/Backup/RestoreHealthPassTest.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * RestoreHealthPassTest — GH #146 coverage of the health-check PASS path
+ * through BOTH gates: Gate 1 (`health_check`, Probe A / DB, via the
+ * FakeRestoreRunnerWpdb's default healthy answers) and Gate 2
+ * (`health_check_live`, Probe B / loopback, via the universal 200+html
+ * `wp_remote_get` mock below — Gate 1 never calls `wp_remote_get` at all
+ * under the two-gate restructure, so this one mock serves Gate 2 only).
+ * Drives all the way to `completed`, marks the guard clean (at Gate 2, the
+ * LAST gate — see `RestoreGuard::markClean()`'s doc), and confirms §5's
+ * deferred cleanup actually KEEPS the files rollback tree + the pre-restore
+ * DB dump (with `.expires` GC markers + a scheduled sweep), rather than the
+ * pre-#146 behavior of synchronously deleting them.
+ *
+ * Like RestoreRollbackTest, the task row is pre-seeded directly at
+ * `health_check` so this test exercises exactly post_hooks-onward without
+ * needing a full stage_files/swap_files/restore_db/swap_db replay. Gate
+ * 2's OWN failure path (the GitHub issue #147 files-WSOD class) has its
+ * dedicated coverage in RestoreHealthCheckLiveTest.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Backup\FilesRestorer;
+use WPMgr\Agent\Backup\RestoreRunner;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\RestoreRunner
+ * @covers \WPMgr\Agent\Backup\RestoreHealthCheck
+ */
+final class RestoreHealthPassTest extends TestCase
+{
+    private const SNAPSHOT_ID = '33333333-3333-3333-3333-333333333333';
+    private const RESTORE_ID  = '44444444-4444-4444-4444-444444444444';
+
+    private string $root        = '';
+    private string $targetDir   = '';
+    private string $oldFilesDir = '';
+    private string $scratchDir  = '';
+    private string $wpRootDir   = '';
+    private string $dumpPath    = '';
+
+    private FakeRestoreRunnerWpdb $wpdb;
+
+    /** @var list<array{ts:int,hook:string}> */
+    private array $scheduled = [];
+
+    /** Number of wp_remote_get() calls — proves Gate 2 actually probed. */
+    private int $loopbackCalls = 0;
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->root        = sys_get_temp_dir() . '/wpmgr-healthpass-' . bin2hex(random_bytes(6));
+        $this->targetDir   = $this->root . '/wp-content';
+        $this->oldFilesDir = $this->root . '/.wpmgr-old-files-444444444444';
+        $this->scratchDir  = $this->root . '/scratch';
+        $this->wpRootDir   = $this->root . '/wproot';
+
+        mkdir($this->targetDir, 0755, true);
+        mkdir($this->oldFilesDir, 0755, true);
+        mkdir($this->scratchDir, 0755, true);
+        mkdir($this->wpRootDir, 0755, true);
+
+        file_put_contents($this->targetDir . '/current.txt', 'the-now-healthy-live-tree');
+        file_put_contents($this->oldFilesDir . '/good.txt', 'pre-restore-tree');
+
+        $this->dumpPath = $this->scratchDir . '/pre-restore-db.sql.gz';
+        file_put_contents($this->dumpPath, (string) gzencode("-- fake pre-restore dump\n"));
+
+        $this->wpdb = new FakeRestoreRunnerWpdb();
+        // Probe A passes (defaults: siteurl set, no table errors).
+        $key = self::SNAPSHOT_ID . '|' . self::RESTORE_ID;
+        $this->wpdb->rows[$key] = [
+            'phase'     => RestoreRunner::PHASE_HEALTH_CHECK,
+            'kind'      => 'full',
+            'sub_state' => (string) json_encode([
+                'tmp_prefix' => 'tmpbbbbbbbb_',
+                'swap_files' => [
+                    'done'          => true,
+                    'old_files_dir' => $this->oldFilesDir,
+                    'mode'          => 'legacy_whole',
+                ],
+                'db_rollback' => [
+                    'done'      => true,
+                    'available' => true,
+                    'dump_path' => $this->dumpPath,
+                    'prefix'    => 'wp_',
+                ],
+            ]),
+            'resume_count' => 0,
+            'max_resumes'  => 6,
+        ];
+        $GLOBALS['wpdb'] = $this->wpdb;
+
+        Functions\when('home_url')->alias(static fn (string $path = '/') => 'https://example.test' . $path);
+        Functions\when('admin_url')->alias(static fn (string $path = '') => 'https://example.test/wp-admin/' . $path);
+        // Every loopback probe (home/admin) answers 2xx — Probe B passes
+        // outright. This mock ONLY serves Gate 2 (health_check_live) —
+        // Gate 1 (health_check) never calls wp_remote_get() at all under the
+        // two-gate restructure — so counting calls here doubles as proof
+        // Gate 2 actually ran (asserted below), not just Gate 1.
+        Functions\when('wp_remote_get')->alias(function (string $url, array $args = []): array {
+            $this->loopbackCalls++;
+            return ['response' => ['code' => 200], 'body' => '<html>ok</html>'];
+        });
+        Functions\when('wp_remote_retrieve_body')->alias(static fn ($r) => is_array($r) ? (string) ($r['body'] ?? '') : '');
+
+        Functions\when('wp_next_scheduled')->justReturn(false);
+        Functions\when('wp_schedule_single_event')->alias(function (int $ts, string $hook, array $args = []): bool {
+            $this->scheduled[] = ['ts' => $ts, 'hook' => $hook];
+            return true;
+        });
+    }
+
+    protected function tear_down(): void
+    {
+        $this->rrmdir($this->root);
+        unset($GLOBALS['wpdb']);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    public function test_health_check_pass_completes_and_keeps_rollback_material_for_the_retention_window(): void
+    {
+        $runner = new RestoreRunner([
+            'snapshot_id'       => self::SNAPSHOT_ID,
+            'restore_id'        => self::RESTORE_ID,
+            'kind'              => 'full',
+            'progress_endpoint' => '',
+            'scratch_dir'       => $this->scratchDir,
+            'wp_content_path'   => $this->targetDir,
+            'wp_root'           => $this->wpRootDir,
+            'db' => [
+                'host' => '', 'user' => '', 'password' => '', 'name' => '', 'prefix' => 'wp_',
+            ],
+        ]);
+
+        $phase = $runner->run();
+
+        $this->assertSame(RestoreRunner::PHASE_COMPLETED, $phase);
+
+        // --- The files rollback tree is KEPT (deferred, not rrmdir'd). -----
+        $this->assertDirectoryExists($this->oldFilesDir);
+        $this->assertFileExists($this->oldFilesDir . '/good.txt');
+        $this->assertFileExists($this->oldFilesDir . '.expires', 'gcOldFiles() needs this marker to know when it may reclaim the tree');
+        $this->assertGreaterThan(time(), (int) trim((string) file_get_contents($this->oldFilesDir . '.expires')));
+
+        // --- The pre-restore DB dump is ALSO kept, same window. -----------
+        $this->assertFileExists($this->dumpPath);
+        $this->assertFileExists($this->dumpPath . '.expires');
+        $this->assertGreaterThan(time(), (int) trim((string) file_get_contents($this->dumpPath . '.expires')));
+
+        // --- GC sweep was scheduled on the shared hook. --------------------
+        $this->assertNotEmpty($this->scheduled);
+        $this->assertSame('wpmgr_restore_oldfiles_gc', $this->scheduled[0]['hook']);
+        $this->assertGreaterThanOrEqual(
+            time() + FilesRestorer::OLDFILES_GC_AGE_SECONDS,
+            $this->scheduled[0]['ts'],
+            'the DEFAULT (non keep_old_files) path must schedule at least the SHORT window out, not the 24h LONG one'
+        );
+
+        // --- Task row reflects Completed. -----------------------------------
+        $key = self::SNAPSHOT_ID . '|' . self::RESTORE_ID;
+        $this->assertSame(RestoreRunner::PHASE_COMPLETED, $this->wpdb->rows[$key]['phase']);
+
+        // --- Gate 2 (health_check_live) actually ran the loopback probe. ---
+        // Gate 1 never calls wp_remote_get() at all under the two-gate
+        // restructure, so any call here proves Gate 2 executed (not just
+        // Gate 1) — and since PHASE_COMPLETED is only reachable if BOTH
+        // gates passed (runHealthCheckLive() throws on anything but
+        // ok/inconclusive), reaching Completed already proves Gate 1 passed.
+        $this->assertGreaterThan(0, $this->loopbackCalls, 'Gate 2 must have actually probed the loopback URLs');
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+}

--- a/apps/agent/tests/Backup/RestoreRollbackTest.php
+++ b/apps/agent/tests/Backup/RestoreRollbackTest.php
@@ -1,0 +1,386 @@
+<?php
+/**
+ * RestoreRollbackTest — GH #146 end-to-end coverage of RestoreRunner's
+ * Gate 1 (`health_check`, the in-process DB probe)-triggered combined
+ * files+DB rollback, driven through the REAL `run()` state machine dispatch
+ * loop (not just `performRollback()` in isolation) so the "never Completed,
+ * always reports FAILED with rolled_back detail" contract is proven at the
+ * actual phase-transition level. Gate 2 (`health_check_live`, the loopback
+ * WSOD probe on the real post-maintenance site)-triggered rollbacks — the
+ * GitHub issue #147 files-WSOD class this whole feature exists to catch —
+ * have their own dedicated coverage in RestoreHealthCheckLiveTest.
+ *
+ * The task row is pre-seeded directly at `health_check` (rather than
+ * driving preflight -> ... -> swap_db -> post_hooks first) so this test
+ * exercises exactly the phase under test without needing a working
+ * FilesRestorer::stage()/DbRestorer::restore() replay to GET there — those
+ * earlier phases have their own dedicated coverage elsewhere
+ * (FilesRestorerExcludeAnchoringTest, RestoreRunnerIncrementalTest, etc.).
+ *
+ * DB-revert SQL-replay correctness is DbRestorer's own responsibility and
+ * needs a live mysqli connection this suite doesn't have — mirrors
+ * DbSnapshotCommandTest's identical disclaimer for `actionRevert()`, which
+ * this class's `revertDb()` deliberately copies call-for-call. What THIS
+ * test proves is the ORCHESTRATION: the pre-restore dump is handed to a
+ * real DbRestorer (against a definitely-closed loopback port, so the
+ * attempt fails fast and deterministically with no live MySQL needed), the
+ * failure is caught (never aborts the files-side revert), and the
+ * thrown/persisted `rolled_back` detail is correct.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Backup\RestoreRunner;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\RestoreRunner
+ * @covers \WPMgr\Agent\Backup\RestoreHealthCheck
+ * @covers \WPMgr\Agent\Backup\FilesRestorer
+ */
+final class RestoreRollbackTest extends TestCase
+{
+    private const SNAPSHOT_ID = '11111111-1111-1111-1111-111111111111';
+    private const RESTORE_ID  = '22222222-2222-2222-2222-222222222222';
+
+    private string $root        = '';
+    private string $targetDir   = '';
+    private string $oldFilesDir = '';
+    private string $scratchDir  = '';
+    private string $wpRootDir   = '';
+    private string $dumpPath    = '';
+
+    private FakeRestoreRunnerWpdb $wpdb;
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->root        = sys_get_temp_dir() . '/wpmgr-rollback-' . bin2hex(random_bytes(6));
+        $this->targetDir   = $this->root . '/wp-content';
+        $this->oldFilesDir = $this->root . '/.wpmgr-old-files-222222222222';
+        $this->scratchDir  = $this->root . '/scratch';
+        $this->wpRootDir   = $this->root . '/wproot';
+
+        mkdir($this->targetDir, 0755, true);
+        mkdir($this->oldFilesDir, 0755, true);
+        mkdir($this->scratchDir, 0755, true);
+        mkdir($this->wpRootDir, 0755, true);
+
+        // The live target currently holds the just-restored (BAD) tree.
+        file_put_contents($this->targetDir . '/bad.txt', 'bad-new-content');
+        // The pre-restore (GOOD) tree swap_files moved aside.
+        file_put_contents($this->oldFilesDir . '/good.txt', 'good-old-content');
+
+        // A real (never actually read) gz file standing in for the
+        // pre-restore DB dump — DbRestorer::restore() fails at connect(),
+        // before it ever gzopen()s this.
+        $this->dumpPath = $this->scratchDir . '/pre-restore-db.sql.gz';
+        file_put_contents($this->dumpPath, (string) gzencode("-- fake pre-restore dump\n"));
+
+        $this->wpdb = new FakeRestoreRunnerWpdb();
+        // Probe A fails deterministically — the headline GH #146 scenario:
+        // siteurl reads back empty from the swapped live options table.
+        $this->wpdb->siteurlValue = '';
+
+        $key = self::SNAPSHOT_ID . '|' . self::RESTORE_ID;
+        $this->wpdb->rows[$key]  = [
+            'phase'     => RestoreRunner::PHASE_HEALTH_CHECK,
+            'kind'      => 'full',
+            'sub_state' => (string) json_encode([
+                'tmp_prefix' => 'tmpaaaaaaaa_',
+                'swap_files' => [
+                    'done'          => true,
+                    'old_files_dir' => $this->oldFilesDir,
+                    'mode'          => 'legacy_whole',
+                ],
+                'db_rollback' => [
+                    'done'      => true,
+                    'available' => true,
+                    'dump_path' => $this->dumpPath,
+                    'prefix'    => 'wp_',
+                ],
+            ]),
+            'resume_count' => 0,
+            'max_resumes'  => 6,
+        ];
+        $GLOBALS['wpdb'] = $this->wpdb;
+
+        Functions\when('home_url')->alias(static fn (string $path = '/') => 'https://example.test' . $path);
+        Functions\when('admin_url')->alias(static fn (string $path = '') => 'https://example.test/wp-admin/' . $path);
+    }
+
+    protected function tear_down(): void
+    {
+        $this->rrmdir($this->root);
+        unset($GLOBALS['wpdb']);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    public function test_health_check_failure_rolls_back_files_and_reports_failed_never_completed(): void
+    {
+        $runner = $this->makeRunner();
+
+        $phase = $runner->run();
+
+        $this->assertSame(RestoreRunner::PHASE_FAILED, $phase, 'an unhealthy restore must NEVER report Completed');
+
+        // --- Files ACTUALLY got reverted on disk. -------------------------
+        $this->assertFileExists($this->targetDir . '/good.txt', 'the pre-restore tree must be back in place');
+        $this->assertFileDoesNotExist($this->targetDir . '/bad.txt', 'the unhealthy just-restored tree must be gone');
+        $this->assertDirectoryDoesNotExist($this->oldFilesDir, 'the rollback source dir is consumed by the revert');
+
+        // --- Task row reflects FAILED + rolled_back detail. ----------------
+        $finalSubState = $this->finalSubState();
+        $this->assertSame(RestoreRunner::PHASE_HEALTH_CHECK, $finalSubState['failed_in']);
+        $this->assertNotEmpty($finalSubState['last_error']);
+        $this->assertIsArray($finalSubState['rolled_back']);
+        $this->assertTrue($finalSubState['rolled_back']['files'], 'files leg must be recorded as rolled back');
+        $this->assertFalse(
+            $finalSubState['rolled_back']['db'],
+            'the DB leg fails fast against the closed loopback port — recorded as attempted-but-failed, never silently true'
+        );
+        $this->assertSame(
+            'db_unhealthy_post_restore',
+            $finalSubState['rolled_back']['reason'],
+            'Gate 1 (DB probe) failures tag the reason distinctly from Gate 2 (wsod_post_restore)'
+        );
+
+        $key = self::SNAPSHOT_ID . '|' . self::RESTORE_ID;
+        $this->assertSame(RestoreRunner::PHASE_FAILED, $this->wpdb->rows[$key]['phase']);
+    }
+
+    /**
+     * Regression guard for double-rollback idempotency: RestoreGuard is
+     * NEVER armed in this scenario (the pre-seeded run starts AT
+     * health_check, bypassing the swap_files/swap_db dispatch cases that
+     * arm it), so `run()`'s SYNCHRONOUS rollback is the only one that can
+     * fire. Re-running against the already-reverted state must not throw
+     * or corrupt anything further (the old_files_dir is gone, so the files
+     * leg of a second rollback attempt is simply a no-op).
+     */
+    public function test_rerunning_after_a_rollback_does_not_throw(): void
+    {
+        $first = $this->makeRunner()->run();
+        $this->assertSame(RestoreRunner::PHASE_FAILED, $first);
+
+        // Re-seed the row back at health_check (simulating a watchdog
+        // re-entry after the FAILED terminal state — not a real production
+        // path since `failed` is terminal, but proves performRollback()
+        // itself tolerates being invoked with a stale/consumed old_files_dir).
+        $key = self::SNAPSHOT_ID . '|' . self::RESTORE_ID;
+        $this->wpdb->rows[$key]['phase'] = RestoreRunner::PHASE_HEALTH_CHECK;
+        $this->wpdb->rows[$key]['sub_state'] = (string) json_encode([
+            'tmp_prefix' => 'tmpaaaaaaaa_',
+            'swap_files' => [
+                'done'          => true,
+                'old_files_dir' => $this->oldFilesDir, // no longer exists on disk.
+                'mode'          => 'legacy_whole',
+            ],
+            'db_rollback' => ['done' => true, 'available' => false, 'reason' => 'unavailable'],
+        ]);
+
+        $second = $this->makeRunner()->run();
+
+        $this->assertSame(RestoreRunner::PHASE_FAILED, $second);
+        // Files leg: old_files_dir no longer exists, so revertSwap() throws
+        // (missing rollback source) — caught by performRollback()'s own
+        // try/catch, recorded as files=>false, no crash.
+        $finalSubState = $this->finalSubState();
+        $this->assertFalse($finalSubState['rolled_back']['files']);
+        // And critically: the already-reverted good tree from the FIRST
+        // rollback is left untouched — a second, consumed rollback attempt
+        // must never re-corrupt an already-healthy target.
+        $this->assertFileExists($this->targetDir . '/good.txt');
+    }
+
+    /**
+     * Review MEDIUM-4: the DB WAS swapped as part of this restore
+     * (`swap_db.done`) but no rollback source is available — reverting
+     * FILES ALONE would run the pre-restore files against the NEW
+     * (post-restore) database, a worse "Frankenstein" mismatch than simply
+     * leaving the as-restored (if unhealthy) site in place. Neither leg
+     * must be touched; the reason must be recorded.
+     */
+    public function test_db_rollback_unavailable_after_swap_db_skips_files_revert_too(): void
+    {
+        $key = self::SNAPSHOT_ID . '|' . self::RESTORE_ID;
+        $this->wpdb->rows[$key]['sub_state'] = (string) json_encode([
+            'tmp_prefix' => 'tmpaaaaaaaa_',
+            'swap_files' => [
+                'done'          => true,
+                'old_files_dir' => $this->oldFilesDir,
+                'mode'          => 'legacy_whole',
+            ],
+            'swap_db' => ['done' => true, 'tables_swapped' => 12],
+            'db_rollback' => ['done' => true, 'available' => false, 'reason' => 'unavailable'],
+        ]);
+
+        $phase = $this->makeRunner()->run();
+
+        $this->assertSame(RestoreRunner::PHASE_FAILED, $phase);
+
+        // Neither leg touched — the as-restored (if unhealthy) state is
+        // left coherent rather than mismatched.
+        $this->assertFileExists($this->targetDir . '/bad.txt', 'files must NOT be reverted when the DB has no rollback source');
+        $this->assertFileDoesNotExist($this->targetDir . '/good.txt');
+        $this->assertDirectoryExists($this->oldFilesDir, 'the untouched rollback tree is left in place for manual investigation');
+
+        $finalSubState = $this->finalSubState();
+        $this->assertFalse($finalSubState['rolled_back']['files']);
+        $this->assertFalse($finalSubState['rolled_back']['db']);
+        $this->assertSame('db_rollback_unavailable', $finalSubState['rolled_back']['reason']);
+    }
+
+    /**
+     * Review MEDIUM-3: the synchronous health-check failure path must
+     * route through `RestoreGuard::fire()` (not call `performRollback()`
+     * directly) when a guard is armed, so the guard's `fired` idempotency
+     * flag actually engages. Proven end-to-end: seed the row at
+     * `swap_files` (kind=files, so no live DB/mysqli is needed) and drive
+     * the REAL `run()` dispatch loop through `armGuardOnce()` -> a real
+     * `FilesRestorer::swap()` -> `post_hooks` -> a failing `health_check` ->
+     * the rollback. Afterward, reach into the runner's now-fired guard and
+     * confirm a SECOND `fire()` (simulating the eventual real
+     * process-shutdown invocation of the same registered callback) is a
+     * documented no-op — proof the synchronous path engaged the guard
+     * itself, not a bare `performRollback()` call that would leave `fired`
+     * false.
+     */
+    public function test_guard_armed_via_swap_files_engages_fired_idempotency_on_health_fail(): void
+    {
+        // Deliberately a DIFFERENT restore_id from self::RESTORE_ID: swap()'s
+        // `.wpmgr-old-files-<shortId(restoreId)>` sibling path is
+        // deterministic from the restore id, and set_up() already created
+        // `$this->oldFilesDir` (`.wpmgr-old-files-222222222222`, from
+        // self::RESTORE_ID) as a non-empty dir for the OTHER tests in this
+        // class — reusing that same id here would make swap() see an
+        // already-existing (unrelated) `.wpmgr-old-files-*` sibling and
+        // treat this as a watchdog-resume-mid-swap, which is not the
+        // scenario under test.
+        $guardRestoreId = '99999999-9999-9999-9999-999999999999';
+
+        $liveContentDir = $this->root . '/guard-live-wp-content';
+        $stagingDir     = $this->root . '/guard-staging';
+        mkdir($liveContentDir, 0755, true);
+        mkdir($stagingDir, 0755, true);
+        file_put_contents($liveContentDir . '/old-good.txt', 'pre-restore-content');
+        file_put_contents($stagingDir . '/new-bad.txt', 'just-restored-content');
+
+        $key = self::SNAPSHOT_ID . '|' . $guardRestoreId;
+        $this->wpdb->rows[$key] = [
+            'phase' => RestoreRunner::PHASE_SWAP_FILES,
+            'kind'  => 'files',
+            'sub_state' => (string) json_encode([
+                'tmp_prefix' => 'tmpddddddddd_',
+                'stage' => [
+                    'staging_dir'          => $stagingDir,
+                    'has_legacy_file_kind' => true,
+                    'components_present'   => [],
+                ],
+            ]),
+            'resume_count' => 0,
+            'max_resumes'  => 6,
+        ];
+
+        $runner = new RestoreRunner([
+            'snapshot_id'       => self::SNAPSHOT_ID,
+            'restore_id'        => $guardRestoreId,
+            'kind'              => 'files',
+            'progress_endpoint' => '',
+            'scratch_dir'       => $this->scratchDir,
+            'wp_content_path'   => $liveContentDir,
+            'wp_root'           => $this->wpRootDir,
+            'db' => ['host' => '', 'user' => '', 'password' => '', 'name' => '', 'prefix' => 'wp_'],
+        ]);
+
+        $phase = $runner->run();
+
+        $this->assertSame(RestoreRunner::PHASE_FAILED, $phase);
+
+        // The real swap_files -> armGuardOnce() -> health_check-fail ->
+        // guard->fire() -> performRollback() chain actually reverted files.
+        $this->assertFileExists($liveContentDir . '/old-good.txt');
+        $this->assertFileDoesNotExist($liveContentDir . '/new-bad.txt');
+
+        $rc    = new \ReflectionClass($runner);
+        $prop  = $rc->getProperty('guard');
+        $guard = $prop->getValue($runner);
+        $this->assertNotNull($guard, 'armGuardOnce() must have armed a guard via the swap_files dispatch case');
+
+        $secondFire = $guard->fire();
+        $this->assertFalse(
+            $secondFire['fired'],
+            'a second fire() must be a documented no-op — proves the synchronous rollback engaged the guard '
+            . '(not a bare performRollback() call that would leave `fired` false and risk a real shutdown-time '
+            . 'second rollback attempt)'
+        );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function finalSubState(): array
+    {
+        $key = self::SNAPSHOT_ID . '|' . self::RESTORE_ID;
+        $row = $this->wpdb->rows[$key] ?? null;
+        $this->assertIsArray($row);
+        $decoded = json_decode((string) $row['sub_state'], true);
+        $this->assertIsArray($decoded);
+        return $decoded;
+    }
+
+    private function makeRunner(): RestoreRunner
+    {
+        return new RestoreRunner([
+            'snapshot_id'       => self::SNAPSHOT_ID,
+            'restore_id'        => self::RESTORE_ID,
+            'kind'              => 'full',
+            'progress_endpoint' => '',
+            'scratch_dir'       => $this->scratchDir,
+            'wp_content_path'   => $this->targetDir,
+            'wp_root'           => $this->wpRootDir,
+            'db' => [
+                // Definitely-closed loopback port: DbRestorer::connect()
+                // fails fast (ECONNREFUSED) — no live MySQL needed, and no
+                // real network access either.
+                'host'     => '127.0.0.1:1',
+                'user'     => 'nouser',
+                'password' => 'nopass',
+                'name'     => 'no_such_db',
+                'prefix'   => 'wp_',
+            ],
+        ]);
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.11
+ * Version:           0.61.12
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.11');
+define('WPMGR_AGENT_VERSION', '0.61.12');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 


### PR DESCRIPTION
A restore that leaves the site fatal no longer reports Completed. Two-gate check: an in-process DB probe before maintenance-off (invisible rollback of a corrupt-DB restore) + a loopback WSOD probe on the real site after maintenance-off (catches the #147-class files-fatal → re-enable maintenance, roll back files+DB, report failed). Both probes fail OPEN so a blip/ambiguous response can never roll back a GOOD restore. Pre-restore files + a forced DB snapshot are kept for the retention window. Mirrors the #131 update pattern (RestoreGuard shutdown backstop). Adversarial review caught + fixed a version that would've rolled back nearly every good restore on its own maintenance 503. Agent-only, 0.61.12; plugin check 0 errors; 2395 tests green.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer restore handling with post-restore checks that verify the site loads before marking a restore complete.
  * Added automatic rollback if a real restore failure is detected, with preserved rollback material for a limited retention window.
  * Improved restore recovery to keep cleanup and rollback artifacts in sync with retention timing.

* **Bug Fixes**
  * Better handles unreachable or ambiguous site responses without undoing a successful restore.
  * Improved cleanup of failed restore leftovers and expired rollback data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->