### PR TITLE
fix(agent): daily GC for backup scratch dir wpmgr-agent/runs (GH #151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.32] - 2026-07-07
+
+### Fixed
+
+- The backup working directory (`wpmgr-agent/runs`) was only cleaned up after a successful backup, so a failed or interrupted backup run left its temporary files behind permanently, slowly consuming disk on the site (a small fleet had accumulated over a gigabyte this way). A daily janitor now removes the scratch directories of finished runs once they are safely past being active (older than six hours and not a currently-running backup), reclaiming that space. It never touches an in-progress backup and fails safe on anything it cannot read. Requires agent 0.61.13.
+
 ## [0.61.31] - 2026-07-07
 
 ### Added

--- a/apps/agent/includes/backup/class-backup-janitor.php
+++ b/apps/agent/includes/backup/class-backup-janitor.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * BackupJanitor: GH #151 — recurring GC backstop for the backup pipeline's
+ * per-run scratch directory, `wp-content/wpmgr-agent/runs/<snapshot_id>/`.
+ *
+ * TaskRunner::cleanupOnCompleted() removes that directory, but ONLY on the
+ * `completed` phase transition — the failure path deletes the
+ * `wpmgr_backup_tasks` row without cleaning scratch, leaking the DB dump,
+ * zip parts, and chunk files of every failed run forever. This class sweeps
+ * those leaked directories on an age-gated cadence. Full design rationale
+ * (the "a just-failed run has no task row" subtlety, the age-threshold
+ * reasoning, and the task-row veto) is in the design notes at the bottom of
+ * this file — kept there so the ABSPATH direct-access guard below stays
+ * within the first ~50 lines of the file, which is what Plugin Check's
+ * Direct_File_Access_Check regex fallback scans.
+ *
+ * @package WPMgr\Agent\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Backup;
+
+use WPMgr\Agent\Schema;
+
+if (!defined('ABSPATH')) {
+    exit; // No direct access.
+}
+
+/**
+ * Recurring GC backstop for the backup scratch directory
+ * (`wp-content/wpmgr-agent/runs/`). See the design notes at the bottom of
+ * this file for the full leak/age-gate/task-row-veto rationale.
+ *
+ * Not `final` — mirrors SnapshotManager's testability shape: a test
+ * subclass overrides runsBaseDir() (and, where needed, isActiveRun()) to
+ * fully control on-disk state without depending on ambient
+ * WP_CONTENT_DIR/$wpdb, and `new static()` inside gcRuns() (late static
+ * binding, not `new self()`) lets that subclass's overrides run through the
+ * exact same production code path a real `BackupJanitor::gcRuns()` call
+ * takes.
+ */
+class BackupJanitor
+{
+    /** Recurring cron hook name — bind via `add_action(self::HOOK_GC, …)`. */
+    public const HOOK_GC = 'wpmgr_backup_runs_gc';
+
+    /**
+     * GC age threshold. A `runs/<snapshot_id>/` directory is only ever
+     * considered for sweeping once it has been untouched (by mtime) for at
+     * least this long. See the design notes below for why 6h is
+     * comfortably clear of every legitimate in-flight window.
+     */
+    public const RUNS_GC_AGE_SECONDS = 21600; // 6h
+
+    /**
+     * Cron callback — sweep `runs/` for any old, inactive per-snapshot
+     * scratch directory. See the design notes at the bottom of this file
+     * for the full age-gate + task-row-veto design.
+     *
+     * `new static()`, not `new self()` — lets a test double subclass
+     * override runsBaseDir()/isActiveRun() and still exercise this exact
+     * production code path via `SubclassName::gcRuns()`.
+     *
+     * @return void
+     */
+    public static function gcRuns(): void
+    {
+        $j    = new static();
+        $base = $j->runsBaseDir();
+        if ($base === '' || !is_dir($base)) {
+            return;
+        }
+
+        $items = @scandir($base);
+        if (!is_array($items)) {
+            return;
+        }
+
+        $now = time();
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            // Run directories are named after BackupCommand's snapshot_id —
+            // a UUID. No path separators or traversal sequences can match
+            // this pattern, so there is no way for a crafted entry name to
+            // escape $base.
+            if (preg_match('/^[0-9a-fA-F-]{36}$/', $item) !== 1) {
+                continue;
+            }
+
+            $dir = $base . '/' . $item;
+            if (!is_dir($dir) || is_link($dir)) {
+                continue;
+            }
+
+            $mtime = @filemtime($dir);
+            if ($mtime === false) {
+                // Fail-safe: cannot determine age — retain rather than risk
+                // deleting a run that may still be live.
+                continue;
+            }
+            if (($now - $mtime) < self::RUNS_GC_AGE_SECONDS) {
+                continue; // Too fresh — could still be an active run.
+            }
+
+            if ($j->isActiveRun($item)) {
+                continue; // Belt-and-suspenders: the task row says it's still live.
+            }
+
+            $j->deleteDir($dir);
+        }
+    }
+
+    /**
+     * The absolute backup-runs scratch base directory:
+     * `wp-content/wpmgr-agent/runs`. Mirrors the exact literal
+     * BackupCommand::prepareScratchDir() pins. Overridable so tests never
+     * depend on the real, process-global WP_CONTENT_DIR constant.
+     *
+     * @return string Absolute path, or '' when WP_CONTENT_DIR is unavailable.
+     */
+    protected function runsBaseDir(): string
+    {
+        return defined('WP_CONTENT_DIR')
+            ? rtrim((string) WP_CONTENT_DIR, '/\\') . '/wpmgr-agent/runs'
+            : '';
+    }
+
+    /**
+     * Whether $snapshotId's `wpmgr_backup_tasks` row says the run is still
+     * live. This is a NO-ONLY veto: it can prevent a deletion the age gate
+     * in gcRuns() already decided to consider, but a missing row must never
+     * be treated as a "yes, delete" signal on its own — see the design
+     * notes below for the "just-failed run has no row" subtlety.
+     *
+     * Mirrors Watchdog::run()'s own terminal-row check (class-watchdog.php
+     * ~89-96): no row (completed and already cleaned up, OR the failure
+     * path's row DELETE already ran) => not active, defer entirely to the
+     * age gate; a terminal phase => not active; otherwise active only while
+     * `last_progress_at` is within Watchdog::STALL_THRESHOLD_SECONDS (the
+     * same staleness window the watchdog itself uses to decide whether a
+     * runner is still alive).
+     *
+     * @param string $snapshotId UUID of the run to check.
+     * @return bool
+     */
+    protected function isActiveRun(string $snapshotId): bool
+    {
+        global $wpdb;
+        if (!is_object($wpdb)) {
+            return false;
+        }
+
+        $table = $wpdb->prefix . Schema::BACKUP_TASKS_TABLE;
+        // @phpstan-ignore-next-line — dynamic wpdb.
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- direct read on plugin-owned task-state table; identifier is prefix+constant; live liveness check, not cacheable
+        $row = $wpdb->get_row($wpdb->prepare("SELECT phase, last_progress_at FROM {$table} WHERE snapshot_id = %s", $snapshotId), ARRAY_A);
+        if (!is_array($row)) {
+            // No row: either the run finished cleanly (already cleaned up)
+            // or it just FAILED (the failure path deletes the row without
+            // cleaning scratch — the exact bug this class fixes). Either
+            // way, this is never a "delete now" signal by itself — the age
+            // gate in gcRuns() is the sole decision-maker for this case.
+            return false;
+        }
+
+        $phase = (string) ($row['phase'] ?? '');
+        if ($phase === TaskRunner::PHASE_COMPLETED || $phase === TaskRunner::PHASE_FAILED) {
+            return false;
+        }
+
+        $lastProgressAt = (int) ($row['last_progress_at'] ?? 0);
+
+        return $lastProgressAt > 0 && (time() - $lastProgressAt) < Watchdog::STALL_THRESHOLD_SECONDS;
+    }
+
+    /**
+     * Recursively delete a directory. Self-contained (not shared with
+     * SnapshotManager) so this class has no cross-subsystem coupling.
+     * A file that won't unlink leaves the directory non-empty, so the
+     * trailing rmdir() fails and the directory is simply retained and
+     * retried on the next cron tick — never a crash.
+     *
+     * @param string $dir Directory to remove.
+     * @return bool
+     */
+    private function deleteDir(string $dir): bool
+    {
+        if (!is_dir($dir)) {
+            return false;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return false;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->deleteDir($path);
+            } else {
+                wp_delete_file($path);
+            }
+        }
+
+        return @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- removes an empty server-derived scratch dir; WP_Filesystem not initialized in the headless agent
+    }
+
+    /**
+     * Schedule the recurring GC backstop (gcRuns()). Safe to call on every
+     * activation / reschedule pass — a no-op when already scheduled.
+     * Mirrors SnapshotManager::scheduleGc()'s idempotent-schedule shape.
+     *
+     * @param int $now Current time.
+     * @return void
+     */
+    public static function scheduleGc(int $now): void
+    {
+        if (!function_exists('wp_next_scheduled') || !function_exists('wp_schedule_event')) {
+            return;
+        }
+        if (wp_next_scheduled(self::HOOK_GC) !== false) {
+            return;
+        }
+        wp_schedule_event($now + 3600, 'daily', self::HOOK_GC);
+    }
+}
+
+/*
+ * Design notes (referenced from the class docblock above; kept down here so
+ * the ABSPATH direct-access guard stays within the first ~50 lines of the
+ * file, which is what Plugin Check's Direct_File_Access_Check regex
+ * fallback scans — see class-restore-guard.php for the same convention).
+ *
+ * The leak (GitHub issue #151): BackupCommand::prepareScratchDir() creates
+ * `runs/<snapshot_id>/` for every backup run and writes the DB dump,
+ * per-component zip parts, chunk files, and checkpoint sidecars into it.
+ * TaskRunner::run()'s success path calls cleanupOnCompleted(), which removes
+ * that directory — but the `catch (\Throwable $e)` failure path only
+ * DELETEs the `wpmgr_backup_tasks` row and posts a `failed` progress event;
+ * it never calls cleanupOnCompleted(). Every failed run therefore leaks its
+ * entire scratch directory forever. Reporters observed 1.5GB and 287MB
+ * leaked this way.
+ *
+ * `runs/` is pure scratch, never archived (FilesArchiver::DEFAULT_EXCLUDES
+ * includes 'wpmgr-agent') and never read by restore (restore uses
+ * `restores/` scratch + fresh R2 pulls), so reclaiming it here is safe.
+ *
+ * CRITICAL subtlety this class is built around: a run that just FAILED has
+ * NO `wpmgr_backup_tasks` row (TaskRunner deletes it as part of the failure
+ * path) but its scratch dir is fresh. "No row" therefore must NEVER be read
+ * as "safe to delete right now" — a just-started run also briefly has no
+ * row (the row is seeded, but a race between mkdir and the INSERT is
+ * possible) and a resumed/watchdog-recovered run's row can also churn. The
+ * sweep is PRIMARILY age-based (RUNS_GC_AGE_SECONDS): only directories
+ * untouched for a long time are even considered. The task-row check
+ * (isActiveRun()) is an ADDITIONAL veto layered on top of the age gate — it
+ * can only ever say "no, keep this", never "yes, delete this" — so a
+ * missing row on an old-enough directory still falls through to deletion
+ * (the just-failed case this class exists to fix), while a stale-looking
+ * directory that a live/resuming task row says is still active is protected
+ * regardless of age.
+ *
+ * RUNS_GC_AGE_SECONDS (6h) is deliberately far larger than any legitimate
+ * in-flight window: 3x Watchdog::STALL_THRESHOLD_SECONDS's sibling hard
+ * re-entry ceiling (class-watchdog.php's 7200s/2h "refuse to re-enter an
+ * implausibly long-running task" guard) and roughly 12x the ~30-minute
+ * longest legitimate backup observed on a real WP host. No sweepable
+ * directory can therefore ever host a run that is still legitimately
+ * running.
+ */

--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace WPMgr\Agent;
 
+use WPMgr\Agent\Backup\BackupJanitor;
 use WPMgr\Agent\Backup\FilesRestorer;
 use WPMgr\Agent\Backup\RestoreRunner;
 use WPMgr\Agent\Backup\RestoreWatchdog;
@@ -594,6 +595,15 @@ final class Plugin
         // doc for the full design.
         add_action(UpdateInFlight::HOOK_GC, [UpdateInFlight::class, 'gcSweep']);
 
+        // GH #151 — recurring GC backstop for the backup pipeline's
+        // wpmgr-agent/runs/ scratch directory. TaskRunner's success path
+        // cleans this up on `completed`, but the failure path deletes the
+        // task row WITHOUT cleaning scratch — see BackupJanitor's class doc
+        // for the full leak + age-gate/task-row-veto design. Scheduled daily
+        // by BackupJanitor::scheduleGc() (activate() below + maybeRescheduleCron()'s
+        // self-heal).
+        add_action(BackupJanitor::HOOK_GC, [BackupJanitor::class, 'gcRuns']);
+
         // Media Optimizer — WP attachment-deletion cleanup. When an attachment
         // is deleted (wp-admin, programmatic, WP-CLI, or REST), WordPress purges
         // ONLY the files it tracks in _wp_attachment_metadata; WPMgr's own
@@ -913,6 +923,10 @@ final class Plugin
         // reached UpdateGuard's own shutdown-function backstop).
         UpdateInFlight::scheduleGc($now);
 
+        // GH #151 — daily GC backstop for the backup wpmgr-agent/runs/
+        // scratch directory (reclaims scratch a failed backup run leaks).
+        BackupJanitor::scheduleGc($now);
+
         // v0.9.13 — push diagnostics within ~30s of activation rather than
         // waiting out the jittered daily cron's 0..4h first-fire offset
         // (Scheduler::diagnosticsJitter). The single-event below fires the
@@ -1042,6 +1056,8 @@ final class Plugin
             // backstop + update-in-flight reconcile sweep.
             wp_clear_scheduled_hook(SnapshotManager::HOOK_GC);
             wp_clear_scheduled_hook(UpdateInFlight::HOOK_GC);
+            // GH #151 — backup runs/ scratch-dir GC backstop.
+            wp_clear_scheduled_hook(BackupJanitor::HOOK_GC);
         }
 
         // Phase 3 — page-cache teardown. Cleanly reverse every server-side
@@ -1343,6 +1359,9 @@ final class Plugin
         // S4 (issue #131 adversarial review) — update-in-flight reconcile
         // sweep — re-arm when missing.
         UpdateInFlight::scheduleGc($now);
+
+        // GH #151 — backup runs/ scratch-dir GC backstop — re-arm when missing.
+        BackupJanitor::scheduleGc($now);
     }
 
     /**

--- a/apps/agent/tests/Backup/BackupJanitorTest.php
+++ b/apps/agent/tests/Backup/BackupJanitorTest.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * BackupJanitorTest — GitHub issue #151 (backup scratch-dir leak on the
+ * runner FAILURE path): TaskRunner::cleanupOnCompleted() only runs on the
+ * `completed` phase transition, so a failed backup's whole
+ * `wpmgr-agent/runs/<snapshot_id>/` scratch directory (DB dump, zip parts,
+ * chunks) is never reclaimed. BackupJanitor is the age-gated GC backstop
+ * that reclaims it.
+ *
+ * All filesystem operations use an isolated temp directory per test.
+ * BackupJanitor::runsBaseDir() (protected) is overridden in an anonymous
+ * subclass so every test here is independent of ambient WP_CONTENT_DIR state
+ * other test files in this suite may have already frozen as a global PHP
+ * constant (constants cannot be redefined once set). `$GLOBALS['wpdb']` is a
+ * minimal, self-contained fake built fresh per test (no shared Patchwork
+ * redefinition) — it only implements the exact surface isActiveRun() touches
+ * (prepare()+get_row()).
+ *
+ * Covers:
+ *   - A stale run dir (past RUNS_GC_AGE_SECONDS) with no `wpmgr_backup_tasks`
+ *     row is swept — the just-failed-backup leak this class exists to fix.
+ *   - A stale run dir whose task row reports a live, recently-progressing
+ *     phase is NOT swept, even though it is past the age threshold — the
+ *     task-row veto is a belt-and-suspenders guard layered on top of, never
+ *     a substitute for, the age gate.
+ *   - A fresh run dir (under the age threshold) is kept regardless of the
+ *     task row.
+ *   - A non-run entry (neither a UUID-shaped file nor directory) is never
+ *     touched by the sweep.
+ *   - scheduleGc() is idempotent: an already-scheduled event is left alone.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Backup\BackupJanitor;
+use WPMgr\Agent\Backup\TaskRunner;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\BackupJanitor
+ */
+final class BackupJanitorTest extends TestCase
+{
+    /** Temp root for this test run (removed in tear_down). */
+    private string $root = '';
+
+    /** Simulated wp-content/wpmgr-agent/runs dir. */
+    private string $runsBase = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->root     = sys_get_temp_dir() . '/wpmgr-janitor-test-' . bin2hex(random_bytes(6));
+        $this->runsBase = $this->root . '/wpmgr-agent/runs';
+        mkdir($this->runsBase, 0755, true);
+
+        Functions\when('wp_delete_file')->alias(static function ($f) {
+            return @unlink($f); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        });
+    }
+
+    protected function tear_down(): void
+    {
+        $this->rrmdir($this->root);
+        unset($GLOBALS['wpdb']);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // =========================================================================
+    // Test doubles / helpers
+    // =========================================================================
+
+    /**
+     * A BackupJanitor subclass whose runsBaseDir() is fully test-controlled
+     * (never touches WP_CONTENT_DIR), exercised via `new static()` late
+     * static binding inside gcRuns() itself — the same mechanism
+     * SnapshotManagerTest uses for gcExpired().
+     *
+     * @return class-string<BackupJanitor>
+     */
+    private function janitorClassWithBase(string $base): string
+    {
+        $class = new class extends BackupJanitor {
+            public static string $testBase = '';
+
+            protected function runsBaseDir(): string
+            {
+                return self::$testBase;
+            }
+        };
+        $class::$testBase = $base;
+
+        return get_class($class);
+    }
+
+    /**
+     * Minimal in-memory $wpdb double supporting only the surface
+     * BackupJanitor::isActiveRun() touches: prepare() (passthrough envelope)
+     * + get_row() (returns the configured canned row, or null for "no row").
+     *
+     * @param array{phase:string,last_progress_at:int}|null $row
+     */
+    private function fakeWpdb(?array $row): object
+    {
+        return new class($row) {
+            public string $prefix = 'wp_';
+
+            /** @var array{phase:string,last_progress_at:int}|null */
+            private ?array $row;
+
+            /**
+             * @param array{phase:string,last_progress_at:int}|null $row
+             */
+            public function __construct(?array $row)
+            {
+                $this->row = $row;
+            }
+
+            /**
+             * @param mixed ...$args
+             */
+            public function prepare(string $query, ...$args): string
+            {
+                return (string) json_encode(['sql' => $query, 'args' => $args]);
+            }
+
+            /**
+             * @param mixed $mode
+             * @return array<string,mixed>|null
+             */
+            public function get_row(string $prepared, $mode = null): ?array
+            {
+                return $this->row;
+            }
+        };
+    }
+
+    /** Seed a run scratch dir with a representative artifact file. */
+    private function seedRunDir(string $id): string
+    {
+        $dir = $this->runsBase . '/' . $id;
+        mkdir($dir, 0700, true);
+        file_put_contents($dir . '/database.sql.gz', 'fixture-content');
+
+        return $dir;
+    }
+
+    /** A 36-character UUID-shaped snapshot id matching BackupJanitor's run-id regex. */
+    private function newSnapshotId(): string
+    {
+        return sprintf(
+            '%08x-%04x-%04x-%04x-%012x',
+            random_int(0, 0xffffffff),
+            random_int(0, 0xffff),
+            random_int(0, 0xffff),
+            random_int(0, 0xffff),
+            random_int(0, 0xffffffffffff)
+        );
+    }
+
+    /** Recursive delete used only for test fixture cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+
+    // =========================================================================
+    // gcRuns()
+    // =========================================================================
+
+    public function test_stale_run_with_no_task_row_is_swept(): void
+    {
+        $id  = $this->newSnapshotId();
+        $dir = $this->seedRunDir($id);
+        touch($dir, time() - (7 * 3600)); // past RUNS_GC_AGE_SECONDS (6h)
+        clearstatcache(true, $dir);
+
+        // No wpmgr_backup_tasks row — simulates the run having just FAILED
+        // (TaskRunner's failure path DELETEs the row without cleaning
+        // scratch) or having completed and already been cleaned up. Either
+        // way, a missing row must never be the reason for deletion by
+        // itself — but it must never BLOCK deletion once the age gate says
+        // this directory is old enough to consider.
+        $GLOBALS['wpdb'] = $this->fakeWpdb(null);
+
+        $class = $this->janitorClassWithBase($this->runsBase);
+        $class::gcRuns();
+
+        $this->assertFalse(
+            is_dir($dir),
+            'a run dir past RUNS_GC_AGE_SECONDS with no task row must be swept — this is the #151 failed-backup scratch leak'
+        );
+    }
+
+    public function test_active_run_is_not_swept_even_when_old(): void
+    {
+        $id  = $this->newSnapshotId();
+        $dir = $this->seedRunDir($id);
+        touch($dir, time() - (7 * 3600)); // past the age gate
+        clearstatcache(true, $dir);
+
+        // A live task row: non-terminal phase, progress posted just now —
+        // this is the belt-and-suspenders veto that must override the age
+        // gate.
+        $GLOBALS['wpdb'] = $this->fakeWpdb([
+            'phase'            => TaskRunner::PHASE_ARCHIVING_FILES,
+            'last_progress_at' => time(),
+        ]);
+
+        $class = $this->janitorClassWithBase($this->runsBase);
+        $class::gcRuns();
+
+        $this->assertTrue(
+            is_dir($dir),
+            'a task row reporting an active, recently-progressing phase must veto the sweep regardless of directory age'
+        );
+    }
+
+    public function test_fresh_dir_under_the_age_threshold_is_kept(): void
+    {
+        $id  = $this->newSnapshotId();
+        $dir = $this->seedRunDir($id);
+        touch($dir, time());
+        clearstatcache(true, $dir);
+
+        $GLOBALS['wpdb'] = $this->fakeWpdb(null);
+
+        $class = $this->janitorClassWithBase($this->runsBase);
+        $class::gcRuns();
+
+        $this->assertTrue(
+            is_dir($dir),
+            'a run dir younger than RUNS_GC_AGE_SECONDS must never be swept, task row or not'
+        );
+    }
+
+    public function test_non_run_entries_are_ignored(): void
+    {
+        file_put_contents($this->runsBase . '/notauuid', 'not a run directory');
+        mkdir($this->runsBase . '/restores', 0755, true);
+        touch($this->runsBase . '/notauuid', time() - (7 * 3600));
+        touch($this->runsBase . '/restores', time() - (7 * 3600));
+        clearstatcache(true, $this->runsBase);
+
+        $GLOBALS['wpdb'] = $this->fakeWpdb(null);
+
+        $class = $this->janitorClassWithBase($this->runsBase);
+        $class::gcRuns();
+
+        $this->assertTrue(
+            is_file($this->runsBase . '/notauuid'),
+            'an entry that does not match the strict UUID run-id pattern must never be touched by the sweep'
+        );
+        $this->assertTrue(
+            is_dir($this->runsBase . '/restores'),
+            'a sibling non-run directory (e.g. restores/) under the same base must never be touched'
+        );
+    }
+
+    // =========================================================================
+    // scheduleGc()
+    // =========================================================================
+
+    public function test_schedule_gc_is_idempotent(): void
+    {
+        Functions\when('wp_next_scheduled')->justReturn(time() + 3600);
+        Functions\expect('wp_schedule_event')->never();
+
+        BackupJanitor::scheduleGc(time());
+
+        // Brain Monkey verifies the ->never() expectation at teardown; this
+        // explicit count satisfies PHPUnit's "at least one assertion" check.
+        $this->addToAssertionCount(1);
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.12
+ * Version:           0.61.13
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.12');
+define('WPMGR_AGENT_VERSION', '0.61.13');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 


### PR DESCRIPTION
Failed/killed backup runs left their scratch (runs/<id>/ chunks+zips) behind forever (only success cleaned up). New BackupJanitor: a daily sweep deleting inactive run dirs older than 6h (age-primary gate + a veto-only live-task-row check + UUID-regex no-traversal + symlink skip + fail-safe). runs/ is pure scratch (excluded from archives, not read by restore). Agent-only, no schema, 5 tests, plugin check 0 errors. agent 0.61.13.

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU