### PR TITLE
fix(backup): local + S3 destinations actually run end-to-end (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.33] - 2026-07-07
+
+### Fixed
+
+- Backup destinations other than managed storage now actually work. You could configure a local folder or your own S3-compatible bucket as a backup destination and the "Test connection" check passed, but every backup still went to managed storage, because the control plane never told the site which destination to use. Backups (full and incremental) now run to the configured destination and restore reads back from it, for all three types: managed storage, a local folder on the server, and your own S3-compatible bucket. For your own bucket the control plane signs the uploads and downloads, so the site never holds your storage credentials. Requires agent 0.61.14.
+
 ## [0.61.32] - 2026-07-07
 
 ### Fixed

--- a/apps/agent/includes/backup/class-restore-runner.php
+++ b/apps/agent/includes/backup/class-restore-runner.php
@@ -72,6 +72,8 @@ declare(strict_types=1);
 
 namespace WPMgr\Agent\Backup;
 
+use WPMgr\Agent\Backup\Destinations\BackupDestination;
+use WPMgr\Agent\Backup\Destinations\DestinationResolver;
 use WPMgr\Agent\Keystore;
 use WPMgr\Agent\Phpbu\ProgressClient;
 use WPMgr\Agent\Schema;
@@ -566,30 +568,48 @@ final class RestoreRunner
     }
 
     /**
-     * download_artifacts: pull every chunk from its presigned URL into the
-     * per-artifact `<scratch>/<logical_path>` file. Idempotent — already
-     * downloaded artifacts are skipped on watchdog re-entry, and an artifact
-     * partially downloaded before a stall resumes at the first unwritten
-     * chunk (not chunk 0).
+     * download_artifacts: pull every chunk into the per-artifact
+     * `<scratch>/<logical_path>` file. Idempotent — already downloaded
+     * artifacts are skipped on watchdog re-entry, and an artifact partially
+     * downloaded before a stall resumes at the first unwritten chunk (not
+     * chunk 0).
      *
-     * Per-chunk GETs use the v0.8.6 retry-with-backoff policy: up to
-     * DOWNLOAD_CHUNK_MAX_ATTEMPTS attempts with exponential backoff. Network
-     * errors and 5xx/408/425/429 are retried; terminal 4xx (404, 403, 400)
-     * are not — they're fatal-by-construction (the URL is the same on every
-     * attempt). The error message attached on terminal failure carries the
-     * HTTP status, the host of the presigned URL, the body excerpt, and the
-     * attempt count, so the SSE `phase_detail.message` + the WP error_log are
-     * actually grep-able by the operator.
+     * ADR-036 P1 storage adapter: HOW a chunk's bytes are fetched depends on
+     * this restore's `destination_kind`. `local` chunks live on this same
+     * webserver's disk (no presigned_url in the manifest — see
+     * fetchLocalChunk() / LocalDestination::getChunk()); every other kind
+     * (`cp`, `s3_compat`, or absent = older CP builds) is unchanged: a
+     * presigned GET, same as today. A pure `local` restore never constructs
+     * the network transport at all (see the lazy `$transport` below).
+     *
+     * Per-chunk GETs (cp/s3_compat only) use the v0.8.6 retry-with-backoff
+     * policy: up to DOWNLOAD_CHUNK_MAX_ATTEMPTS attempts with exponential
+     * backoff. Network errors and 5xx/408/425/429 are retried; terminal 4xx
+     * (404, 403, 400) are not — they're fatal-by-construction (the URL is the
+     * same on every attempt). The error message attached on terminal failure
+     * carries the HTTP status, the host of the presigned URL, the body
+     * excerpt, and the attempt count, so the SSE `phase_detail.message` + the
+     * WP error_log are actually grep-able by the operator. Local disk reads
+     * have no such retry policy — none of the transient-network failure
+     * modes a presigned-URL GET over a tunnel has apply to a local fread.
      *
      * @param array<string,mixed> $subState
      * @return array<string,mixed>
      */
     private function runDownloadArtifacts(array $subState): array
     {
-        $transport = new BackupTransport(new Signer(new Keystore()));
-        $age       = new AgeIdentity(new Keystore());
-        $entries   = $this->chunkDownloads();
-        $total     = count($entries);
+        $destinationKind  = $this->destinationKind();
+        $localDestination = $destinationKind === 'local' ? $this->buildLocalDestination() : null;
+
+        // Presigned-URL transport + age-decrypt identity are only needed
+        // when at least one chunk is NOT served by the local destination —
+        // constructed lazily (on first use) so a pure `local` restore never
+        // pays for Keystore/Signer setup or touches the network.
+        $transport = null;
+        $age       = null;
+
+        $entries = $this->chunkDownloads();
+        $total   = count($entries);
         if ($total === 0) {
             throw new \RuntimeException('download_artifacts: no chunk_downloads supplied');
         }
@@ -680,16 +700,31 @@ final class RestoreRunner
                     if (!is_array($chunk)) {
                         throw new \RuntimeException('download_artifacts: malformed chunk at ' . $logical . '[' . $chunkIdx . ']');
                     }
-                    $url   = (string) ($chunk['presigned_url'] ?? $chunk['url'] ?? $chunk['get_url'] ?? '');
-                    $hash  = (string) ($chunk['hash'] ?? $chunk['blake3'] ?? '');
-                    if ($url === '' || $hash === '') {
-                        throw new \RuntimeException('download_artifacts: chunk missing url/hash at ' . $logical . '[' . $chunkIdx . ']');
+                    $hash = (string) ($chunk['hash'] ?? $chunk['blake3'] ?? '');
+                    if ($hash === '') {
+                        throw new \RuntimeException('download_artifacts: chunk missing hash at ' . $logical . '[' . $chunkIdx . ']');
                     }
 
-                    $bytes = $this->fetchChunkWithRetries($transport, $url, $hash, $logical, $chunkIdx);
+                    // ADR-036 P1: a 'local' snapshot's chunks live on this
+                    // same webserver's disk — read them by content hash
+                    // instead of an HTTP GET. cp/s3_compat chunks are
+                    // unchanged: presigned GET, same as today.
+                    if ($localDestination !== null) {
+                        $bytes = $this->fetchLocalChunk($localDestination, $hash, $logical, $chunkIdx);
+                    } else {
+                        $url = (string) ($chunk['presigned_url'] ?? $chunk['url'] ?? $chunk['get_url'] ?? '');
+                        if ($url === '') {
+                            throw new \RuntimeException('download_artifacts: chunk missing url at ' . $logical . '[' . $chunkIdx . ']');
+                        }
+                        if ($transport === null) {
+                            $transport = new BackupTransport(new Signer(new Keystore()));
+                        }
+                        $bytes = $this->fetchChunkWithRetries($transport, $url, $hash, $logical, $chunkIdx);
+                    }
 
                     // Verify blake3 over the CIPHERTEXT (matches the upload
-                    // pipeline's content-addressing scheme).
+                    // pipeline's content-addressing scheme) regardless of
+                    // which path the bytes came from.
                     $actual = Blake3::hashHex($bytes);
                     if (!hash_equals($hash, $actual)) {
                         throw new \RuntimeException('download_artifacts: blake3 mismatch on chunk ' . $hash);
@@ -700,7 +735,7 @@ final class RestoreRunner
                     // canonical signal — match it here so the .bin
                     // plaintext path (V0 default) just writes bytes.
                     $plain = EncryptAndUpload::ENCRYPT_CHUNKS
-                        ? $age->decryptChunk($bytes)
+                        ? ($age ??= new AgeIdentity(new Keystore()))->decryptChunk($bytes)
                         : $bytes;
 
                     $w = @fwrite($handle, $plain); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- incremental write into a streaming handle; WP_Filesystem put_contents is whole-buffer only
@@ -2366,6 +2401,87 @@ final class RestoreRunner
         // Cap at 240 chars to match the saveTaskState last_error column limit
         // and the postProgress phase_detail message budget.
         throw new \RuntimeException(esc_html(substr($msg, 0, 240)));
+    }
+
+    // ==================================================================
+    // ADR-036 P1 storage adapter — local destination chunk reads
+    // ==================================================================
+
+    /**
+     * This restore's `destination_kind` — 'cp' | 'local' | 's3_compat'.
+     * Defaults to 'cp' when absent/empty, matching BackupCommand /
+     * DestinationResolver's default (older CP builds never send the field).
+     */
+    private function destinationKind(): string
+    {
+        $kind = isset($this->params['destination_kind']) && is_string($this->params['destination_kind'])
+            ? $this->params['destination_kind']
+            : '';
+        return $kind === '' ? 'cp' : $kind;
+    }
+
+    /**
+     * Build the LocalDestination this restore reads chunks from. Only
+     * called once, when destinationKind() === 'local'.
+     *
+     * Constructs a real BackupTransport to satisfy DestinationResolver's
+     * factory signature (kept uniform with the backup-side wiring in
+     * EncryptAndUpload) — LocalDestination::getChunk()/prepare() never
+     * actually use it; only submitManifest() (a backup-only call) does.
+     *
+     * prepare() resolves (and, if the guard files are missing, re-hardens)
+     * the exact snapshot directory the matching backup wrote to. It is
+     * idempotent — every write it performs is file_exists()-guarded — so
+     * calling it here, on a read-only restore path, is safe.
+     */
+    private function buildLocalDestination(): BackupDestination
+    {
+        $config = isset($this->params['destination_config']) && is_array($this->params['destination_config'])
+            ? $this->params['destination_config']
+            : [];
+
+        $transport   = new BackupTransport(new Signer(new Keystore()));
+        $destination = DestinationResolver::resolve([
+            'snapshot_id'        => $this->snapshotId(),
+            'destination_kind'   => 'local',
+            'destination_config' => $config,
+            'manifest_endpoint'  => '',
+            'presign_endpoint'   => '',
+        ], $transport);
+        $destination->prepare($this->snapshotId());
+
+        return $destination;
+    }
+
+    /**
+     * Read one chunk from the local destination by content hash, instead of
+     * an HTTP GET against a presigned URL. Local snapshot chunks carry no
+     * presigned_url (they never leave the webserver) — the manifest only
+     * guarantees hash (+ size) for them.
+     *
+     * No retry-with-backoff policy here (unlike fetchChunkWithRetries): a
+     * local disk read has none of the transient-network failure modes a
+     * presigned-URL GET over a tunnel does. LocalDestination::getChunk()
+     * itself rejects a malformed hash (path-traversal defense) and returns
+     * null on any other failure (missing file, unreadable file), which we
+     * surface here as a structured, operator-grep-able message.
+     */
+    private function fetchLocalChunk(
+        BackupDestination $destination,
+        string $hash,
+        string $logical,
+        int $chunkIdx
+    ): string {
+        $bytes = $destination->getChunk($hash);
+        if ($bytes === null) {
+            throw new \RuntimeException(esc_html(sprintf(
+                'download_artifacts: local chunk %s[%d] hash=%s not found on local disk (destination_kind=local)',
+                $logical,
+                $chunkIdx,
+                substr($hash, 0, 12)
+            )));
+        }
+        return $bytes;
     }
 
     // ==================================================================

--- a/apps/agent/includes/backup/destinations/class-destination-resolver.php
+++ b/apps/agent/includes/backup/destinations/class-destination-resolver.php
@@ -51,13 +51,24 @@ final class DestinationResolver
             ? $params['presign_endpoint']
             : '';
 
-        $kind = isset($params['destination_kind']) && is_string($params['destination_kind'])
+        $kind = isset($params['destination_kind']) && is_string($params['destination_kind']) && $params['destination_kind'] !== ''
             ? $params['destination_kind']
             : 'cp';
 
+        $config = isset($params['destination_config']) && is_array($params['destination_config'])
+            ? $params['destination_config']
+            : [];
+        // The only field the wire contract defines today: an operator-chosen
+        // on-disk path (relative to wp-content) for the 'local' kind. Empty/
+        // absent means "use the agent's own uploads-first default" — see
+        // LocalDestination::resolveBaseDir().
+        $localPathPrefix = isset($config['local_path_prefix']) && is_string($config['local_path_prefix'])
+            ? $config['local_path_prefix']
+            : '';
+
         switch ($kind) {
             case 'local':
-                return new LocalDestination($transport, $snapshotId, $manifestEp);
+                return new LocalDestination($transport, $snapshotId, $manifestEp, $localPathPrefix);
             case 'cp':
             case 's3_compat':
                 // s3_compat reuses the CP transport because CP-issued presigned

--- a/apps/agent/includes/backup/destinations/class-local-destination.php
+++ b/apps/agent/includes/backup/destinations/class-local-destination.php
@@ -57,21 +57,35 @@ final class LocalDestination implements BackupDestination
     private string $snapshotDir = '';
 
     /**
+     * Sanitized `destination_config.local_path_prefix` (operator-configured
+     * on-disk path, relative to WP_CONTENT_DIR). Empty when the CP sent none
+     * (or sent a value that sanitized down to nothing) — resolveBaseDir()
+     * then falls back to the agent's own uploads-first default.
+     */
+    private string $localPathPrefix;
+
+    /**
      * @param BackupTransport $transport        For the metadata-only manifest POST
      *                                          (the agent still signs it with the
      *                                          existing Ed25519 transport so the
      *                                          CP authenticates the caller).
      * @param string          $snapshotId       In-flight snapshot UUID.
      * @param string          $manifestEndpoint CP /manifest URL (metadata only).
+     * @param string          $localPathPrefix  Optional operator-configured on-disk
+     *                                          path (relative to WP_CONTENT_DIR) from
+     *                                          `destination_config.local_path_prefix`.
+     *                                          Empty string = agent default.
      */
     public function __construct(
         BackupTransport $transport,
         string $snapshotId,
-        string $manifestEndpoint
+        string $manifestEndpoint,
+        string $localPathPrefix = ''
     ) {
         $this->transport        = $transport;
         $this->snapshotId       = $snapshotId;
         $this->manifestEndpoint = $manifestEndpoint;
+        $this->localPathPrefix  = self::sanitizePrefix($localPathPrefix);
     }
 
     /**
@@ -115,6 +129,9 @@ final class LocalDestination implements BackupDestination
      */
     public function putChunk(string $hash, string $ciphertext): bool
     {
+        if (!self::isValidHash($hash)) {
+            return false;
+        }
         $path = $this->chunkPath($hash);
         if (is_file($path)) {
             return true;
@@ -128,8 +145,22 @@ final class LocalDestination implements BackupDestination
         return true;
     }
 
+    /**
+     * Read one stored chunk back by content hash — used by the restore path
+     * (RestoreRunner::fetchLocalChunk) for a `destination_kind=local`
+     * snapshot, whose manifest chunks carry no presigned URL.
+     *
+     * Validates the hash shape BEFORE building a filesystem path from it
+     * (defense in depth: the hash arrives over the wire in a RestoreRequest,
+     * so — unlike the backup-side putChunk, whose hash is always this
+     * process's own Blake3::hashHex() output — it must be treated as
+     * untrusted input here).
+     */
     public function getChunk(string $hash): ?string
     {
+        if (!self::isValidHash($hash)) {
+            return null;
+        }
         $path = $this->chunkPath($hash);
         if (!is_file($path)) {
             return null;
@@ -173,10 +204,14 @@ final class LocalDestination implements BackupDestination
         @file_put_contents($manifestPath, $manifestJson, LOCK_EX);
         @chmod($manifestPath, self::CHUNK_MODE); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod -- explicit security perms (0640); WP_Filesystem would coerce to wider FS_CHMOD_FILE
 
-        // POST the SAME manifest shape to the CP. The CP records the snapshot
-        // as completed with `destination_kind='local'` (the destination_id
-        // travels in BackupRequest so the CP already knows). This is the
-        // metadata-only shipment: we send the manifest, not the chunks.
+        // POST the SAME manifest shape to the CP. The CP already knows this
+        // snapshot's destination_kind='local' + destination_config — it
+        // recorded them on the snapshot row when it enqueued the
+        // BackupRequest, and DestinationResolver used those exact same
+        // fields (from runner params) to build THIS LocalDestination
+        // instance. So this POST doesn't need to repeat the destination
+        // choice; it is purely the metadata-only shipment: we send the
+        // manifest (paths, chunk hashes/sizes), never the chunk bytes.
         return $this->transport->submitManifest(
             $this->manifestEndpoint,
             $this->snapshotId,
@@ -197,7 +232,7 @@ final class LocalDestination implements BackupDestination
             }
         }
         foreach ($hashes as $hash) {
-            if (!is_string($hash) || $hash === '') {
+            if (!is_string($hash) || !self::isValidHash($hash)) {
                 continue;
             }
             $path = $this->chunkPath($hash);
@@ -215,9 +250,13 @@ final class LocalDestination implements BackupDestination
     /**
      * Pick the base dir for wpmgr-backups/.
      *
-     * Delegates to StoragePaths::dataBase('backups') for uploads-first resolution
-     * (wp.org Guideline compliance). Web-access guard files (.htaccess + index.php)
-     * are written by StoragePaths::ensureHardened() because uploads/ is web-accessible.
+     * When the operator configured an explicit `local_path_prefix`
+     * (destination_config), that path wins outright — see
+     * resolveConfiguredBaseDir(). Otherwise this delegates to
+     * StoragePaths::dataBase('backups') for uploads-first resolution
+     * (wp.org Guideline compliance). Web-access guard files (.htaccess +
+     * index.php) are written by StoragePaths::ensureHardened() because
+     * uploads/ is web-accessible.
      *
      * Best-effort migration: if the legacy wp-content/wpmgr-backups directory exists
      * and the new uploads-based location does not yet exist, we atomically rename it
@@ -228,6 +267,10 @@ final class LocalDestination implements BackupDestination
      */
     private function resolveBaseDir(): string
     {
+        if ($this->localPathPrefix !== '') {
+            return $this->resolveConfiguredBaseDir();
+        }
+
         // Primary candidate: uploads-first via StoragePaths.
         $primary = StoragePaths::dataBase('backups');
         $legacy  = StoragePaths::legacyBase('backups');
@@ -264,6 +307,94 @@ final class LocalDestination implements BackupDestination
             }
         }
         throw new \RuntimeException('WPMgr Local Destination: no writable base dir under uploads or wp-content');
+    }
+
+    /**
+     * Resolve the operator-configured base dir: `WP_CONTENT_DIR/<localPathPrefix>`.
+     *
+     * Unlike resolveBaseDir()'s uploads-first default, an explicit
+     * local_path_prefix is an operator choice — we honor it outright rather
+     * than falling back to a different candidate on a writability failure
+     * (a silent fallback would mean "the operator picked path X but their
+     * backup landed on path Y", which is exactly the kind of surprise a
+     * storage-destination feature must not produce).
+     *
+     * $this->localPathPrefix was already sanitized in the constructor (no
+     * `..`, no absolute-path leader, no traversal-capable characters), so
+     * the join below cannot escape WP_CONTENT_DIR.
+     */
+    private function resolveConfiguredBaseDir(): string
+    {
+        if (!defined('WP_CONTENT_DIR') || !is_string(WP_CONTENT_DIR) || WP_CONTENT_DIR === '') {
+            throw new \RuntimeException('WPMgr Local Destination: WP_CONTENT_DIR is unavailable for the configured local_path_prefix');
+        }
+
+        $wpContent = rtrim(WP_CONTENT_DIR, '/\\');
+        $relative  = str_replace('/', DIRECTORY_SEPARATOR, $this->localPathPrefix);
+        $base      = $wpContent . DIRECTORY_SEPARATOR . $relative;
+
+        if (!is_dir($base)) {
+            if (!@mkdir($base, self::DIR_MODE, true) && !is_dir($base)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- explicit 0700 perms on operator-configured backup dir; wp_mkdir_p would apply the wider FS_CHMOD_DIR
+                throw new \RuntimeException('WPMgr Local Destination: cannot create configured local_path_prefix dir at ' . esc_html($base));
+            }
+            @chmod($base, self::DIR_MODE); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod -- explicit security perms (0700); WP_Filesystem would coerce to wider FS_CHMOD_DIR
+        }
+        if (!is_writable($base)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- headless agent; WP_Filesystem never initialized; direct writability probe is the only option
+            throw new \RuntimeException('WPMgr Local Destination: configured local_path_prefix dir not writable: ' . esc_html($base));
+        }
+
+        return $base;
+    }
+
+    /**
+     * Sanitize `destination_config.local_path_prefix` into a traversal-safe
+     * relative path. The CP is expected to validate this operator input
+     * before it ever reaches the agent, but the agent treats every wire
+     * field as untrusted (VALIDATE-early / SANITIZE-before-use) — especially
+     * one that is about to become part of a filesystem path.
+     *
+     * Splits on both `/` and `\`, drops empty/`.`/`..` segments outright
+     * (no traversal is possible even if every other segment were hostile),
+     * and strips each remaining segment down to a conservative
+     * `[A-Za-z0-9_.-]` charset (defeats NUL-byte injection, drive letters,
+     * and stray control characters). Returns '' — meaning "use the agent's
+     * own default" — when nothing safe survives.
+     */
+    private static function sanitizePrefix(string $prefix): string
+    {
+        $prefix = trim($prefix);
+        if ($prefix === '') {
+            return '';
+        }
+
+        $normalized = str_replace('\\', '/', $prefix);
+        $segments   = explode('/', $normalized);
+        $safe       = [];
+        foreach ($segments as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..') {
+                continue;
+            }
+            $clean = preg_replace('/[^A-Za-z0-9_.\-]/', '', $segment) ?? '';
+            if ($clean === '' || $clean === '.' || $clean === '..') {
+                continue;
+            }
+            $safe[] = $clean;
+        }
+
+        return implode('/', $safe);
+    }
+
+    /**
+     * Validate that $hash is shaped like a BLAKE3 hex digest (32 bytes ->
+     * 64 lowercase/uppercase hex chars) BEFORE it is used to build a
+     * filesystem path (chunkPath()). Guards putChunk/getChunk/deleteChunks
+     * against path traversal via a malformed hash — this matters most for
+     * getChunk(), whose $hash comes from a RestoreRequest chunk entry (wire
+     * input), not from this process's own Blake3::hashHex() output.
+     */
+    private static function isValidHash(string $hash): bool
+    {
+        return preg_match('/^[a-f0-9]{64}$/i', $hash) === 1;
     }
 
     /**

--- a/apps/agent/includes/commands/class-restore-command.php
+++ b/apps/agent/includes/commands/class-restore-command.php
@@ -25,6 +25,8 @@
  *     "restore_id":        "uuid",      // CP-generated; unique per restore run
  *     "kind":              "files"|"db"|"full",
  *     "progress_endpoint": "https://cp/.../progress",
+ *     "destination_kind":   "cp"|"local"|"s3_compat",  // ADR-036 P1; absent/empty = "cp"
+ *     "destination_config": { "local_path_prefix": "..." },  // only for "local"; omitempty
  *     "manifest": {
  *       "entries": [
  *         { "logical_path": "database.sql.gz",
@@ -36,6 +38,12 @@
  *     "chunk_bytes": 4194304   // hint only (presented in preflight telemetry)
  *   }
  *   response: { "ok": bool, "detail": string }
+ *
+ * ADR-036 P1 storage adapter: a `destination_kind=local` snapshot's chunks
+ * carry Hash + Size but NO presigned_url in the manifest above — they live on
+ * this same webserver's disk (written by the matching local-destination
+ * backup) and RestoreRunner reads them by content hash instead of an HTTP
+ * GET. `cp`/`s3_compat` chunks are unchanged: presigned GET, same as today.
  *
  * The agent's REPLY means "accepted & runner started". Completion happens
  * when RestoreRunner posts the `completed` progress event to /progress.
@@ -99,6 +107,17 @@ final class RestoreCommand implements CommandInterface
             ? (int) $params['chunk_bytes']
             : self::DEFAULT_CHUNK_BYTES;
 
+        // ADR-036 P1 storage adapter: mirrors BackupCommand's destination_kind
+        // / destination_config wiring. Absent/empty destination_kind means
+        // 'cp' — the existing presigned-URL restore path, bit-for-bit
+        // unchanged for every CP build that predates this feature.
+        $destinationKind = isset($params['destination_kind']) && is_string($params['destination_kind']) && $params['destination_kind'] !== ''
+            ? $params['destination_kind']
+            : 'cp';
+        $destinationConfig = isset($params['destination_config']) && is_array($params['destination_config'])
+            ? $params['destination_config']
+            : [];
+
         // --- 1. Input validation -------------------------------------------
         if ($snapshotId === '' || $restoreId === '') {
             return $this->refuse('missing snapshot_id or restore_id');
@@ -113,7 +132,7 @@ final class RestoreCommand implements CommandInterface
             return $this->refuse('invalid kind');
         }
 
-        $chunkDownloads = $this->parseChunkDownloads($params);
+        $chunkDownloads = $this->parseChunkDownloads($params, $destinationKind);
         if ($chunkDownloads === []) {
             return $this->refuse('no chunk_downloads / manifest entries supplied');
         }
@@ -183,6 +202,12 @@ final class RestoreCommand implements CommandInterface
             'wp_content_path'   => defined('WP_CONTENT_DIR') ? WP_CONTENT_DIR : '',
             'wp_root'           => defined('ABSPATH') ? ABSPATH : '',
             'db'                => $this->dbCreds(),
+            // ADR-036 P1 storage adapter: which destination RestoreRunner
+            // reads chunks from. 'local' chunks carry no presigned_url (see
+            // parseChunkDownloads) — the runner reads them off local disk by
+            // hash instead of an HTTP GET.
+            'destination_kind'   => $destinationKind,
+            'destination_config' => $destinationConfig,
             // P0 URL rewriter: target/source URLs for cross-env restore.
             'target_site_url'    => $targetSiteUrl,
             'target_home_url'    => $targetHomeUrl,
@@ -225,9 +250,14 @@ final class RestoreCommand implements CommandInterface
      *   - nested "manifest": { "entries": [ ... ] } per the wire contract
      *
      * @param array<string,mixed> $params
+     * @param string              $destinationKind 'cp' | 'local' | 's3_compat'
+     *                                              (already defaulted by the
+     *                                              caller). Only 'local' chunk
+     *                                              entries are allowed to omit
+     *                                              presigned_url.
      * @return list<array<string,mixed>>
      */
-    private function parseChunkDownloads(array $params): array
+    private function parseChunkDownloads(array $params, string $destinationKind): array
     {
         $candidates = [];
         if (isset($params['chunk_downloads']) && is_array($params['chunk_downloads'])) {
@@ -254,6 +284,12 @@ final class RestoreCommand implements CommandInterface
             // (`hash`, `presigned_url`). Accept either {hash, presigned_url}
             // or {blake3, url}/{blake3, get_url} for compatibility with the
             // M4 manifest shape.
+            //
+            // ADR-036 P1: a `destination_kind=local` snapshot's chunks live
+            // on this webserver's own disk (RestoreRunner reads them by
+            // hash — see fetchLocalChunk), so the CP never mints a
+            // presigned_url for them. Every other destination kind still
+            // requires one — a cp/s3_compat chunk with no URL is malformed.
             $norm = [];
             foreach ($chunks as $c) {
                 if (!is_array($c)) {
@@ -261,10 +297,16 @@ final class RestoreCommand implements CommandInterface
                 }
                 $hash = (string) ($c['hash'] ?? $c['blake3'] ?? '');
                 $url  = (string) ($c['presigned_url'] ?? $c['url'] ?? $c['get_url'] ?? '');
-                if ($hash === '' || $url === '') {
+                if ($hash === '') {
                     continue;
                 }
-                $row = ['hash' => $hash, 'presigned_url' => $url];
+                if ($url === '' && $destinationKind !== 'local') {
+                    continue;
+                }
+                $row = ['hash' => $hash];
+                if ($url !== '') {
+                    $row['presigned_url'] = $url;
+                }
                 if (isset($c['size']) && is_numeric($c['size'])) {
                     $row['size'] = (int) $c['size'];
                 }

--- a/apps/agent/tests/Backup/Destinations/LocalDestinationLocalPathPrefixTest.php
+++ b/apps/agent/tests/Backup/Destinations/LocalDestinationLocalPathPrefixTest.php
@@ -1,0 +1,388 @@
+<?php
+/**
+ * Tests for the ADR-036 P1 backup-destinations completeness fix (agent half,
+ * Phase 1): the `destination_config.local_path_prefix` wiring from
+ * DestinationResolver into LocalDestination, LocalDestination's
+ * traversal-safe sanitization of that operator-configured path, its
+ * default-fallback behaviour when the prefix is absent/empty/unsanitizable,
+ * and the hash-format guard that protects putChunk/getChunk/deleteChunks
+ * from a malformed (wire-supplied, therefore untrusted) hash.
+ *
+ * cp/s3_compat regression: DestinationResolver::resolve() must still route
+ * those kinds (and an absent/empty destination_kind, matching older CP
+ * builds) to CpDestination, completely unaffected by the local_path_prefix
+ * wiring — even when a destination_config happens to be present.
+ *
+ * All filesystem operations happen under a unique, per-test marker directory
+ * inside WP_CONTENT_DIR (never the whole content dir is touched or removed),
+ * so this file is independent of ambient WP_CONTENT_DIR state other test
+ * files in this suite may have already frozen as a global PHP constant
+ * (constants cannot be redefined once set) — see BackupJanitorTest /
+ * SnapshotManagerTest for the same documented landmine and mitigation.
+ *
+ * @package WPMgr\Agent\Tests\Backup\Destinations
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup\Destinations;
+
+use Brain\Monkey;
+use WPMgr\Agent\Backup\Destinations\CpDestination;
+use WPMgr\Agent\Backup\Destinations\DestinationResolver;
+use WPMgr\Agent\Backup\Destinations\LocalDestination;
+use WPMgr\Agent\Support\BackupTransport;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\Destinations\DestinationResolver
+ * @covers \WPMgr\Agent\Backup\Destinations\LocalDestination
+ */
+final class LocalDestinationLocalPathPrefixTest extends TestCase
+{
+    /** Unique per-test subdir name under WP_CONTENT_DIR (own cleanup only). */
+    private string $marker = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        if (!defined('WP_CONTENT_DIR')) {
+            define('WP_CONTENT_DIR', sys_get_temp_dir() . '/wpmgr-shared-wp-content');
+        }
+        if (!is_dir(WP_CONTENT_DIR)) {
+            mkdir(WP_CONTENT_DIR, 0755, true);
+        }
+
+        $this->marker = 'wpmgr-ldpt-' . bin2hex(random_bytes(6));
+    }
+
+    protected function tear_down(): void
+    {
+        // Only ever clean up subtrees THIS test created — never the shared
+        // WP_CONTENT_DIR itself, which other tests in this process may
+        // still rely on.
+        $this->rrmdir(WP_CONTENT_DIR . DIRECTORY_SEPARATOR . $this->marker);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // ==========================================================
+    // DestinationResolver routing
+    // ==========================================================
+
+    public function test_resolver_routes_local_kind_with_prefix_to_local_destination(): void
+    {
+        $snapshotId  = $this->uuid();
+        $destination = DestinationResolver::resolve([
+            'snapshot_id'        => $snapshotId,
+            'destination_kind'   => 'local',
+            'destination_config' => ['local_path_prefix' => $this->marker . '/custom-backups'],
+            'manifest_endpoint'  => '',
+            'presign_endpoint'   => '',
+        ], $this->stubTransport());
+
+        $this->assertInstanceOf(LocalDestination::class, $destination);
+        $this->assertSame('local', $destination->getKind());
+
+        $destination->prepare($snapshotId);
+        $hash = str_repeat('a', 64);
+        $this->assertTrue($destination->putChunk($hash, 'ciphertext-bytes'));
+
+        $expectedDir = WP_CONTENT_DIR . DIRECTORY_SEPARATOR . $this->marker . DIRECTORY_SEPARATOR . 'custom-backups';
+        $this->assertDirectoryExists($expectedDir);
+        $this->assertFileExists(
+            $expectedDir . DIRECTORY_SEPARATOR . $snapshotId . DIRECTORY_SEPARATOR . 'chunks' . DIRECTORY_SEPARATOR . $hash . '.bin'
+        );
+    }
+
+    /**
+     * @dataProvider cpLikeKindProvider
+     */
+    public function test_resolver_routes_cp_like_kinds_to_cp_destination(string $kindParam, string $expectedKind): void
+    {
+        $params = [
+            'snapshot_id'       => $this->uuid(),
+            'manifest_endpoint' => 'https://cp.test/manifest',
+            'presign_endpoint'  => 'https://cp.test/presign',
+        ];
+        if ($kindParam !== '') {
+            $params['destination_kind'] = $kindParam;
+        }
+        // Even when a destination_config happens to be present, cp/s3_compat
+        // must ignore it entirely — it is only meaningful for 'local'.
+        $params['destination_config'] = ['local_path_prefix' => 'should-be-ignored'];
+
+        $destination = DestinationResolver::resolve($params, $this->stubTransport());
+
+        $this->assertInstanceOf(CpDestination::class, $destination);
+        $this->assertSame($expectedKind, $destination->getKind());
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string}>
+     */
+    public static function cpLikeKindProvider(): array
+    {
+        return [
+            'absent (older CP builds)' => ['', 'cp'],
+            'cp'                       => ['cp', 'cp'],
+            's3_compat'                => ['s3_compat', 's3_compat'],
+        ];
+    }
+
+    // ==========================================================
+    // local_path_prefix sanitization (contract shape + traversal defense)
+    // ==========================================================
+
+    public function test_prefix_traversal_segments_are_stripped_not_escaped(): void
+    {
+        $destination = new LocalDestination(
+            $this->stubTransport(),
+            $this->uuid(),
+            '',
+            '../../../../' . $this->marker . '/escape-attempt'
+        );
+
+        $snapshotId = $this->uuid();
+        $destination->prepare($snapshotId);
+        $hash = str_repeat('b', 64);
+        $this->assertTrue($destination->putChunk($hash, 'x'));
+
+        // The '..' segments are dropped outright (never resolved against the
+        // filesystem) — the chunk must land INSIDE
+        // WP_CONTENT_DIR/<marker>/escape-attempt, never above WP_CONTENT_DIR.
+        $expectedDir = WP_CONTENT_DIR . DIRECTORY_SEPARATOR . $this->marker . DIRECTORY_SEPARATOR . 'escape-attempt'
+            . DIRECTORY_SEPARATOR . $snapshotId . DIRECTORY_SEPARATOR . 'chunks';
+        $this->assertFileExists($expectedDir . DIRECTORY_SEPARATOR . $hash . '.bin');
+    }
+
+    public function test_prefix_of_only_dotdot_segments_falls_back_to_default(): void
+    {
+        // A prefix that sanitizes down to nothing must not throw or resolve
+        // an empty/undefined path — it must fall back to the agent's own
+        // default (uploads-first / wp-content), exactly like an absent prefix.
+        $destination = new LocalDestination($this->stubTransport(), $this->uuid(), '', '../..');
+        $snapshotId  = $this->uuid();
+
+        $destination->prepare($snapshotId);
+        $hash = str_repeat('c', 64);
+        $this->assertTrue($destination->putChunk($hash, 'y'));
+
+        // wp_upload_dir() stub returns [] in this suite, so
+        // StoragePaths::dataBase() falls through to the WP_CONTENT_DIR
+        // candidate — the same default a truly-absent prefix would use.
+        $expected = WP_CONTENT_DIR . DIRECTORY_SEPARATOR . 'wpmgr-backups'
+            . DIRECTORY_SEPARATOR . $snapshotId . DIRECTORY_SEPARATOR . 'chunks'
+            . DIRECTORY_SEPARATOR . $hash . '.bin';
+        $this->assertFileExists($expected);
+
+        // This one lands under the SHARED default dir (not this test's
+        // marker) — clean up only this test's own snapshot subdir.
+        $this->rrmdir(WP_CONTENT_DIR . DIRECTORY_SEPARATOR . 'wpmgr-backups' . DIRECTORY_SEPARATOR . $snapshotId);
+    }
+
+    public function test_prefix_with_nul_byte_is_stripped(): void
+    {
+        $destination = new LocalDestination(
+            $this->stubTransport(),
+            $this->uuid(),
+            '',
+            $this->marker . "/nul\x00-attempt"
+        );
+        $snapshotId = $this->uuid();
+        $destination->prepare($snapshotId);
+        $hash = str_repeat('d', 64);
+        $this->assertTrue($destination->putChunk($hash, 'z'));
+
+        $expectedDir = WP_CONTENT_DIR . DIRECTORY_SEPARATOR . $this->marker . DIRECTORY_SEPARATOR . 'nul-attempt';
+        $this->assertDirectoryExists($expectedDir);
+    }
+
+    public function test_resolver_ignores_non_string_local_path_prefix(): void
+    {
+        // A malformed destination_config (e.g. local_path_prefix sent as an
+        // int) must not crash the resolver — it degrades to the default.
+        $snapshotId  = $this->uuid();
+        $destination = DestinationResolver::resolve([
+            'snapshot_id'        => $snapshotId,
+            'destination_kind'   => 'local',
+            'destination_config' => ['local_path_prefix' => 12345],
+            'manifest_endpoint'  => '',
+            'presign_endpoint'   => '',
+        ], $this->stubTransport());
+
+        $this->assertInstanceOf(LocalDestination::class, $destination);
+        // No exception preparing/using it with the default path.
+        $destination->prepare($snapshotId);
+        $this->rrmdir(WP_CONTENT_DIR . DIRECTORY_SEPARATOR . 'wpmgr-backups' . DIRECTORY_SEPARATOR . $snapshotId);
+        $this->addToAssertionCount(1);
+    }
+
+    // ==========================================================
+    // Local BACKUP: full prepare -> putChunk -> submitManifest under the
+    // configured path (files land + manifest, per the task's test list)
+    // ==========================================================
+
+    public function test_local_backup_writes_ciphertext_chunks_and_manifest_under_configured_path(): void
+    {
+        $snapshotId  = $this->uuid();
+        $destination = new LocalDestination(
+            $this->stubTransport(),
+            $snapshotId,
+            'https://cp.test/manifest',
+            $this->marker . '/manifest-check'
+        );
+
+        $destination->prepare($snapshotId);
+
+        $hashes = [str_repeat('1', 64), str_repeat('2', 64)];
+        foreach ($hashes as $i => $hash) {
+            $this->assertTrue($destination->putChunk($hash, 'chunk-bytes-' . $i));
+        }
+
+        $entries = [[
+            'path'       => 'database.sql.gz',
+            'entry_kind' => 'db',
+            'table_name' => '',
+            'mode'       => 0,
+            'size'       => 24,
+            'chunks'     => [
+                ['blake3' => $hashes[0], 'size' => 13],
+                ['blake3' => $hashes[1], 'size' => 13],
+            ],
+        ]];
+
+        $result = $destination->submitManifest($entries, ['age_recipient' => '']);
+        $this->assertTrue($result['ok']);
+
+        $baseDir = WP_CONTENT_DIR . DIRECTORY_SEPARATOR . $this->marker . DIRECTORY_SEPARATOR . 'manifest-check'
+            . DIRECTORY_SEPARATOR . $snapshotId;
+
+        foreach ($hashes as $hash) {
+            $this->assertFileExists($baseDir . DIRECTORY_SEPARATOR . 'chunks' . DIRECTORY_SEPARATOR . $hash . '.bin');
+        }
+        $manifestPath = $baseDir . DIRECTORY_SEPARATOR . 'manifest.json';
+        $this->assertFileExists($manifestPath);
+        $decoded = json_decode((string) file_get_contents($manifestPath), true);
+        $this->assertSame($snapshotId, $decoded['snapshot_id']);
+        $this->assertCount(1, $decoded['entries']);
+    }
+
+    // ==========================================================
+    // Hash-format guard (path-traversal-via-hash defense)
+    // ==========================================================
+
+    public function test_get_chunk_rejects_malformed_hash(): void
+    {
+        $snapshotId  = $this->uuid();
+        $destination = new LocalDestination($this->stubTransport(), $snapshotId, '', $this->marker . '/hashguard');
+        $destination->prepare($snapshotId);
+
+        $this->assertNull($destination->getChunk('../../../../etc/passwd'));
+        $this->assertNull($destination->getChunk(str_repeat('g', 64))); // 'g' is not hex
+        $this->assertNull($destination->getChunk('tooshort'));
+    }
+
+    public function test_put_chunk_rejects_malformed_hash(): void
+    {
+        $snapshotId  = $this->uuid();
+        $destination = new LocalDestination($this->stubTransport(), $snapshotId, '', $this->marker . '/hashguard2');
+        $destination->prepare($snapshotId);
+
+        $this->assertFalse($destination->putChunk('../../../../etc/passwd', 'x'));
+    }
+
+    public function test_delete_chunks_skips_malformed_hash_entries(): void
+    {
+        $snapshotId  = $this->uuid();
+        $destination = new LocalDestination($this->stubTransport(), $snapshotId, '', $this->marker . '/hashguard3');
+        $destination->prepare($snapshotId);
+
+        $validHash = str_repeat('e', 64);
+        $destination->putChunk($validHash, 'x');
+
+        // Must not throw or attempt to delete a path built from a malformed hash.
+        $destination->deleteChunks(['../../../../etc/passwd', $validHash]);
+
+        $chunkPath = WP_CONTENT_DIR . DIRECTORY_SEPARATOR . $this->marker . DIRECTORY_SEPARATOR . 'hashguard3'
+            . DIRECTORY_SEPARATOR . $snapshotId . DIRECTORY_SEPARATOR . 'chunks' . DIRECTORY_SEPARATOR . $validHash . '.bin';
+        $this->assertFileDoesNotExist($chunkPath, 'the VALID hash must still be deleted');
+    }
+
+    // ==========================================================
+    // Round-trip: what a backup writes, a restore reads back by hash
+    // ==========================================================
+
+    public function test_get_chunk_reads_back_exactly_what_put_chunk_wrote(): void
+    {
+        $snapshotId  = $this->uuid();
+        $destination = new LocalDestination($this->stubTransport(), $snapshotId, '', $this->marker . '/roundtrip');
+        $destination->prepare($snapshotId);
+
+        $hash  = hash('sha256', 'irrelevant-for-shape-only-test'); // 64 lowercase hex chars
+        $bytes = random_bytes(4096);
+        $this->assertTrue($destination->putChunk($hash, $bytes));
+
+        $this->assertSame($bytes, $destination->getChunk($hash));
+        $this->assertNull($destination->getChunk(str_repeat('0', 64)), 'a hash that was never written must read back null');
+    }
+
+    // ==========================================================
+    // Helpers
+    // ==========================================================
+
+    private function uuid(): string
+    {
+        return sprintf(
+            '%08x-%04x-%04x-%04x-%012x',
+            random_int(0, 0xffffffff),
+            random_int(0, 0xffff),
+            random_int(0, 0xffff),
+            random_int(0, 0xffff),
+            random_int(0, 0xffffffffffff)
+        );
+    }
+
+    private function stubTransport(): BackupTransport
+    {
+        return new class extends BackupTransport {
+            public function __construct()
+            {
+                // Intentionally skip parent::__construct — no real Signer is
+                // needed; this stub's submitManifest() never touches it, and
+                // getKind()/prepare()/putChunk()/getChunk() on LocalDestination
+                // never call into the transport at all.
+            }
+
+            public function submitManifest(string $endpoint, string $snapshotId, string $ageRecipient, array $entries): array
+            {
+                return ['ok' => true, 'chunk_count' => count($entries), 'stored_count' => count($entries)];
+            }
+        };
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . DIRECTORY_SEPARATOR . $item;
+            if (is_link($path) || is_file($path)) {
+                @unlink($path);
+            } elseif (is_dir($path)) {
+                $this->rrmdir($path);
+            }
+        }
+        @rmdir($dir);
+    }
+}

--- a/apps/agent/tests/Backup/RestoreRunnerLocalDestinationTest.php
+++ b/apps/agent/tests/Backup/RestoreRunnerLocalDestinationTest.php
@@ -1,0 +1,335 @@
+<?php
+/**
+ * ADR-036 P1 backup-destinations completeness fix (agent half, Phase 1) —
+ * the NEW gap this phase closes: a `destination_kind=local` RestoreRequest's
+ * chunks live on this same webserver's disk (no presigned_url in the
+ * manifest — see class-restore-command.php) and must be read by content
+ * hash instead of an HTTP GET.
+ *
+ * Covers:
+ *   - destinationKind() defaults to 'cp' when absent/empty, reads 'local'
+ *     when set (mirrors DestinationResolver's own default).
+ *   - fetchLocalChunk() reads back exactly the bytes a matching backup
+ *     wrote via LocalDestination::putChunk() — no HTTP involved.
+ *   - fetchLocalChunk() raises a structured, operator-grep-able error when
+ *     the chunk is missing on disk.
+ *   - runDownloadArtifacts() end-to-end for a destination_kind=local restore:
+ *     reads two chunks straight off local disk (real Blake3 verify, real
+ *     fwrite reassembly), never constructs the network transport, and the
+ *     reconstructed scratch-dir artifact byte-for-byte matches what a
+ *     matching backup would have produced.
+ *   - Regression: destination_kind='cp' (or absent) still REQUIRES a
+ *     presigned_url per chunk — a local-shaped (URL-less) chunk enter that
+ *     path and must fail fast, proving the branch decision itself (not just
+ *     the local path) is correct.
+ *
+ * We reach into RestoreRunner's private methods via reflection — same
+ * technique RestoreRunnerRetryTest uses for fetchChunkWithRetries() — so
+ * these tests need no live WordPress DB, progress client, or WP_CONTENT_DIR
+ * ambient state beyond a per-test scratch dir.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use ReflectionClass;
+use WPMgr\Agent\Backup\Destinations\LocalDestination;
+use WPMgr\Agent\Backup\RestoreRunner;
+use WPMgr\Agent\Support\BackupTransport;
+use WPMgr\Agent\Support\Blake3;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\RestoreRunner
+ */
+final class RestoreRunnerLocalDestinationTest extends TestCase
+{
+    /** Per-test scratch dir (removed in tear_down). */
+    private string $scratchDir = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        // Guard-define: WP_CONTENT_DIR may already be a frozen global PHP
+        // constant from another test file in this suite (constants cannot be
+        // redefined once set) — see BackupJanitorTest / SnapshotManagerTest
+        // for the same documented landmine. Every path this file resolves
+        // under WP_CONTENT_DIR uses a fresh, unique per-test prefix, so
+        // whichever directory the constant ends up pointing at is fine.
+        if (!defined('WP_CONTENT_DIR')) {
+            define('WP_CONTENT_DIR', sys_get_temp_dir() . '/wpmgr-shared-wp-content');
+        }
+        if (!is_dir(WP_CONTENT_DIR)) {
+            mkdir(WP_CONTENT_DIR, 0755, true);
+        }
+
+        $this->scratchDir = sys_get_temp_dir() . '/wpmgr-rrld-scratch-' . bin2hex(random_bytes(6));
+        mkdir($this->scratchDir, 0700, true);
+    }
+
+    protected function tear_down(): void
+    {
+        $this->rrmdir($this->scratchDir);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // ==========================================================
+    // destinationKind()
+    // ==========================================================
+
+    public function test_destination_kind_defaults_to_cp_when_absent(): void
+    {
+        $runner = $this->makeRunner([]);
+        $this->assertSame('cp', $this->callPrivate($runner, 'destinationKind'));
+    }
+
+    public function test_destination_kind_defaults_to_cp_when_empty_string(): void
+    {
+        $runner = $this->makeRunner(['destination_kind' => '']);
+        $this->assertSame('cp', $this->callPrivate($runner, 'destinationKind'));
+    }
+
+    public function test_destination_kind_reads_local(): void
+    {
+        $runner = $this->makeRunner(['destination_kind' => 'local']);
+        $this->assertSame('local', $this->callPrivate($runner, 'destinationKind'));
+    }
+
+    public function test_destination_kind_reads_s3_compat(): void
+    {
+        $runner = $this->makeRunner(['destination_kind' => 's3_compat']);
+        $this->assertSame('s3_compat', $this->callPrivate($runner, 'destinationKind'));
+    }
+
+    // ==========================================================
+    // fetchLocalChunk()
+    // ==========================================================
+
+    public function test_fetch_local_chunk_reads_bytes_a_backup_wrote(): void
+    {
+        $snapshotId = $this->uuid();
+        $prefix     = 'wpmgr-rrld-' . bin2hex(random_bytes(6));
+        $destination = new LocalDestination($this->stubTransport(), $snapshotId, '', $prefix);
+        $destination->prepare($snapshotId);
+
+        $bytes = random_bytes(2048);
+        $hash  = Blake3::hashHex($bytes);
+        $this->assertTrue($destination->putChunk($hash, $bytes));
+
+        $runner = $this->makeRunner(['destination_kind' => 'local']);
+        $result = $this->callPrivate($runner, 'fetchLocalChunk', [$destination, $hash, 'database.sql.gz', 0]);
+
+        $this->assertSame($bytes, $result);
+
+        $this->rrmdir(WP_CONTENT_DIR . DIRECTORY_SEPARATOR . $prefix);
+    }
+
+    public function test_fetch_local_chunk_throws_structured_error_when_missing(): void
+    {
+        $snapshotId  = $this->uuid();
+        $prefix      = 'wpmgr-rrld-missing-' . bin2hex(random_bytes(6));
+        $destination = new LocalDestination($this->stubTransport(), $snapshotId, '', $prefix);
+        $destination->prepare($snapshotId);
+
+        $runner   = $this->makeRunner(['destination_kind' => 'local']);
+        $hash     = str_repeat('f', 64);
+
+        try {
+            $this->callPrivate($runner, 'fetchLocalChunk', [$destination, $hash, 'wp-content.part001.zip', 3]);
+            $this->fail('expected RuntimeException for a missing local chunk');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('wp-content.part001.zip', $e->getMessage());
+            $this->assertStringContainsString('not found on local disk', $e->getMessage());
+        }
+
+        $this->rrmdir(WP_CONTENT_DIR . DIRECTORY_SEPARATOR . $prefix);
+    }
+
+    // ==========================================================
+    // runDownloadArtifacts() end-to-end for destination_kind=local — the
+    // "prove the local-restore path non-vacuous" test.
+    // ==========================================================
+
+    public function test_run_download_artifacts_reads_local_chunks_and_reassembles_without_network(): void
+    {
+        $snapshotId = $this->uuid();
+        $prefix     = 'wpmgr-rrld-e2e-' . bin2hex(random_bytes(6));
+
+        // Seed local disk exactly as a matching local-destination BACKUP
+        // would have: two content-addressed chunk files under
+        // <prefix>/<snapshotId>/chunks/<hash>.bin.
+        $seed = new LocalDestination($this->stubTransport(), $snapshotId, '', $prefix);
+        $seed->prepare($snapshotId);
+
+        $part1 = random_bytes(1024);
+        $part2 = random_bytes(777);
+        $hash1 = Blake3::hashHex($part1);
+        $hash2 = Blake3::hashHex($part2);
+        $this->assertTrue($seed->putChunk($hash1, $part1));
+        $this->assertTrue($seed->putChunk($hash2, $part2));
+
+        // Deliberately NO presigned_url on either chunk — a 'local' snapshot's
+        // manifest never carries one (see class-restore-command.php). If the
+        // runner's branch logic mistakenly fell through to the cp/s3 path,
+        // this would throw "chunk missing url" instead of reassembling.
+        $runner = $this->makeRunner([
+            'destination_kind'   => 'local',
+            'destination_config' => ['local_path_prefix' => $prefix],
+            'snapshot_id'        => $snapshotId,
+            'chunk_downloads'    => [
+                [
+                    'logical_path' => 'database.sql.gz',
+                    'chunks'       => [
+                        ['hash' => $hash1, 'size' => strlen($part1)],
+                        ['hash' => $hash2, 'size' => strlen($part2)],
+                    ],
+                ],
+            ],
+        ]);
+
+        $subState = $this->callPrivate($runner, 'runDownloadArtifacts', [[]]);
+
+        $this->assertTrue($subState['download']['done']);
+        $this->assertSame(strlen($part1) + strlen($part2), $subState['download']['bytes_downloaded']);
+
+        $artifactPath = $this->scratchDir . DIRECTORY_SEPARATOR . 'database.sql.gz';
+        $this->assertFileExists($artifactPath);
+        $this->assertSame($part1 . $part2, (string) file_get_contents($artifactPath));
+
+        $this->rrmdir(WP_CONTENT_DIR . DIRECTORY_SEPARATOR . $prefix);
+    }
+
+    // ==========================================================
+    // Regression: non-local destination_kind still requires presigned_url
+    // (proves the branch decision, not just the local path, is correct)
+    // ==========================================================
+
+    public function test_run_download_artifacts_cp_destination_kind_requires_presigned_url(): void
+    {
+        $runner = $this->makeRunner([
+            'destination_kind' => 'cp',
+            'chunk_downloads'  => [
+                [
+                    'logical_path' => 'database.sql.gz',
+                    'chunks'       => [
+                        ['hash' => str_repeat('a', 64), 'size' => 10],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/chunk missing url/');
+        $this->callPrivate($runner, 'runDownloadArtifacts', [[]]);
+    }
+
+    public function test_run_download_artifacts_absent_destination_kind_requires_presigned_url(): void
+    {
+        $runner = $this->makeRunner([
+            // destination_kind omitted entirely — must default to 'cp'.
+            'chunk_downloads' => [
+                [
+                    'logical_path' => 'database.sql.gz',
+                    'chunks'       => [
+                        ['hash' => str_repeat('b', 64), 'size' => 10],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/chunk missing url/');
+        $this->callPrivate($runner, 'runDownloadArtifacts', [[]]);
+    }
+
+    // ==========================================================
+    // Helpers
+    // ==========================================================
+
+    /**
+     * @param array<string,mixed> $extraParams
+     */
+    private function makeRunner(array $extraParams): RestoreRunner
+    {
+        $defaults = [
+            'snapshot_id'       => $this->uuid(),
+            'restore_id'        => $this->uuid(),
+            'kind'              => 'full',
+            'progress_endpoint' => '',
+            'chunk_downloads'   => [],
+            'scratch_dir'       => $this->scratchDir,
+            'wp_content_path'   => $this->scratchDir,
+            'wp_root'           => sys_get_temp_dir(),
+            'db'                => ['host' => '', 'user' => '', 'password' => '', 'name' => '', 'prefix' => 'wp_'],
+        ];
+        return new RestoreRunner(array_merge($defaults, $extraParams));
+    }
+
+    /**
+     * Invoke a private RestoreRunner method via reflection. setAccessible()
+     * is not called — a no-op since PHP 8.1 and deprecated since PHP 8.5;
+     * private methods are directly accessible via ReflectionMethod::invoke()
+     * on PHP 8.1+.
+     *
+     * @param list<mixed> $args
+     */
+    private function callPrivate(RestoreRunner $runner, string $method, array $args = []): mixed
+    {
+        $m = (new ReflectionClass($runner))->getMethod($method);
+        return $m->invokeArgs($runner, $args);
+    }
+
+    private function stubTransport(): BackupTransport
+    {
+        return new class extends BackupTransport {
+            public function __construct()
+            {
+                // Intentionally skip parent::__construct — LocalDestination
+                // never calls into the transport for prepare()/putChunk()/
+                // getChunk(), only for the (backup-only) submitManifest().
+            }
+        };
+    }
+
+    private function uuid(): string
+    {
+        return sprintf(
+            '%08x-%04x-%04x-%04x-%012x',
+            random_int(0, 0xffffffff),
+            random_int(0, 0xffff),
+            random_int(0, 0xffff),
+            random_int(0, 0xffff),
+            random_int(0, 0xffffffffffff)
+        );
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . DIRECTORY_SEPARATOR . $item;
+            if (is_link($path) || is_file($path)) {
+                @unlink($path);
+            } elseif (is_dir($path)) {
+                $this->rrmdir($path);
+            }
+        }
+        @rmdir($dir);
+    }
+}

--- a/apps/agent/tests/RestoreCommandTest.php
+++ b/apps/agent/tests/RestoreCommandTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace WPMgr\Agent\Tests;
 
 use Brain\Monkey;
+use Brain\Monkey\Functions;
 use WPMgr\Agent\Commands\RestoreCommand;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
@@ -95,5 +96,115 @@ final class RestoreCommandTest extends TestCase
         ]);
         $this->assertFalse($res['ok']);
         $this->assertStringContainsString('chunk_downloads', $res['detail']);
+    }
+
+    // ==========================================================
+    // ADR-036 P1 backup-destinations completeness fix (Phase 1): a
+    // destination_kind=local snapshot's chunks carry hash + size but NO
+    // presigned_url (see class-restore-command.php docblock). Every other
+    // destination_kind still requires one — this is the contract-shape
+    // parsing test for RestoreCommand::parseChunkDownloads().
+    // ==========================================================
+
+    /**
+     * A url-less chunk entry under destination_kind=local must NOT be
+     * dropped by parseChunkDownloads() — proven by observing that the
+     * request gets PAST the "no chunk_downloads / manifest entries
+     * supplied" refusal.
+     *
+     * Depending on ambient WP_CONTENT_DIR / $wpdb state left behind by other
+     * test files sharing this PHPUnit process, execute() may sail all the
+     * way through preflight/dedup/scratch-dir/scheduling — so the WP cron
+     * functions at the very end of the happy path are mocked defensively
+     * (this test does not care whether the request ultimately succeeds; it
+     * only asserts the "not dropped" property).
+     */
+    public function test_local_destination_kind_accepts_chunk_without_presigned_url(): void
+    {
+        Functions\when('wp_schedule_single_event')->justReturn(true);
+        Functions\when('spawn_cron')->justReturn(true);
+
+        $snapshotId = '11111111-1111-1111-1111-111111111111';
+        $restoreId  = '22222222-2222-2222-2222-222222222222';
+
+        $cmd = new RestoreCommand();
+        $res = $cmd->execute([], [
+            'snapshot_id'      => $snapshotId,
+            'restore_id'       => $restoreId,
+            'kind'             => 'full',
+            'destination_kind' => 'local',
+            'chunk_downloads'  => [
+                [
+                    'logical_path' => 'database.sql.gz',
+                    'chunks'       => [
+                        ['hash' => str_repeat('a', 64), 'size' => 1024],
+                    ],
+                ],
+            ],
+        ]);
+        $this->assertNotSame(
+            'no chunk_downloads / manifest entries supplied',
+            $res['detail'],
+            'a destination_kind=local chunk with no presigned_url must not be dropped'
+        );
+
+        // Best-effort: if the request reached prepareScratchDir() (ambient
+        // WP_CONTENT_DIR was already defined by another test in this shared
+        // process), clean up the exact scratch dir these fixed IDs produce.
+        if (defined('WP_CONTENT_DIR') && is_string(WP_CONTENT_DIR) && WP_CONTENT_DIR !== '') {
+            $shortRestoreId = substr(preg_replace('/[^a-f0-9]/i', '', $restoreId) ?? '', 0, 12);
+            $this->rrmdir(WP_CONTENT_DIR . '/wpmgr-agent/restores/' . $snapshotId . '-' . $shortRestoreId);
+        }
+    }
+
+    /**
+     * Regression: the SAME url-less chunk shape under a cp/absent
+     * destination_kind must still be dropped (a cp/s3_compat chunk with no
+     * presigned_url is malformed) — the request refuses with the exact
+     * "no chunk_downloads" message once every chunk has been filtered out.
+     */
+    public function test_non_local_destination_kind_still_requires_presigned_url(): void
+    {
+        $cmd = new RestoreCommand();
+        $res = $cmd->execute([], [
+            'snapshot_id'     => '11111111-1111-1111-1111-111111111111',
+            'restore_id'      => '22222222-2222-2222-2222-222222222222',
+            'kind'            => 'full',
+            // destination_kind omitted entirely -> defaults to 'cp'.
+            'chunk_downloads' => [
+                [
+                    'logical_path' => 'database.sql.gz',
+                    'chunks'       => [
+                        ['hash' => str_repeat('a', 64), 'size' => 1024],
+                    ],
+                ],
+            ],
+        ]);
+        $this->assertFalse($res['ok']);
+        $this->assertSame('no chunk_downloads / manifest entries supplied', $res['detail']);
+    }
+
+    /** Recursive rmdir for best-effort test cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . DIRECTORY_SEPARATOR . $item;
+            if (is_link($path) || is_file($path)) {
+                @unlink($path);
+            } elseif (is_dir($path)) {
+                $this->rrmdir($path);
+            }
+        }
+        @rmdir($dir);
     }
 }

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.13
+ * Version:           0.61.14
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.13');
+define('WPMGR_AGENT_VERSION', '0.61.14');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -8,6 +8,7 @@ import (
 	crand "crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -864,6 +865,11 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 		}
 		registry = blobstore.NewRegistry(defStore, siteDestSvc)
 		backupSvc.SetRegistry(&registryAdapter{r: registry})
+		// ADR-036 P1 (GH #146): resolve a site's default destination at
+		// backup-creation time, and an already-chosen destination's kind/
+		// local-path at dispatch/restore time. Wired alongside SetRegistry so
+		// the two never drift out of sync.
+		backupSvc.SetDestinationLookup(&destLookupAdapter{svc: siteDestSvc})
 		// M5.7 P4: wire the manifest index writer so SubmitManifest writes
 		// tenant/<tenantID>/site/<siteID>/backup/<snapshotID>/manifest.json
 		// via the same CP-global store used for presigning. Best-effort:
@@ -2173,6 +2179,42 @@ func (a *registryAdapter) PresignerForSnapshot(ctx context.Context, snap backup.
 		return nil, nil
 	}
 	return store, nil
+}
+
+// destLookupAdapter bridges sitedestination.Service into the backup.
+// DestinationLookup interface so CreateBackup/EnqueueScheduledBackup can
+// resolve a site's default destination, and the backup worker/restore planner
+// can resolve an already-chosen destination's kind + local-path metadata,
+// without the backup package importing sitedestination directly (ADR-036 P1
+// wiring; mirrors registryAdapter).
+type destLookupAdapter struct {
+	svc *sitedestination.Service
+}
+
+// DefaultDestinationForSite resolves the site's default destination id, or
+// uuid.Nil (no error) when none is configured — the overwhelmingly common
+// case for any site that hasn't opted into a destination.
+func (a *destLookupAdapter) DefaultDestinationForSite(ctx context.Context, tenantID, siteID uuid.UUID) (uuid.UUID, error) {
+	d, err := a.svc.GetDefaultForSite(ctx, tenantID, siteID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.Nil, nil
+		}
+		return uuid.Nil, err
+	}
+	return d.ID, nil
+}
+
+// DestinationInfo resolves the kind + local-path metadata for an already-
+// chosen (non-nil) destination id. backup.Service never calls this for
+// snap.DestinationID == uuid.Nil (the managed/legacy path short-circuits
+// before ever reaching destLookup — see backup.Service.DestinationInfoForSnapshot).
+func (a *destLookupAdapter) DestinationInfo(ctx context.Context, tenantID, destinationID uuid.UUID) (backup.DestinationInfo, error) {
+	d, err := a.svc.GetByID(ctx, tenantID, destinationID)
+	if err != nil {
+		return backup.DestinationInfo{}, err
+	}
+	return backup.DestinationInfo{ID: d.ID, Kind: string(d.Kind), PathPrefix: d.PathPrefix}, nil
 }
 
 // disabledAutologinSigner refuses to mint when no CP signing key is

--- a/apps/api/db/query/backups.sql
+++ b/apps/api/db/query/backups.sql
@@ -6,8 +6,11 @@
 -- ---------------------------------------------------------------------------
 
 -- name: CreateBackupSnapshot :one
-INSERT INTO backup_snapshots (tenant_id, site_id, created_by, kind, status, age_recipient)
-VALUES ($1, $2, $3, $4, 'pending', $5)
+-- destination_id (M7 / ADR-036 P1): NULL routes to the legacy CP-managed
+-- bucket; a non-null value is the site_destinations row the caller already
+-- resolved (the site's configured default) before creating the snapshot.
+INSERT INTO backup_snapshots (tenant_id, site_id, created_by, kind, status, age_recipient, destination_id)
+VALUES ($1, $2, $3, $4, 'pending', $5, $6)
 RETURNING *;
 
 -- name: GetBackupSnapshot :one

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -891,6 +891,82 @@ CREATE POLICY backup_chunks_agent ON backup_chunks
     USING (current_setting('app.agent', true) = 'on');
 
 -- ---------------------------------------------------------------------------
+-- site_destinations  (M7 / ADR-036 P1 storage adapter)
+-- ---------------------------------------------------------------------------
+-- Where a site's backup chunks should land: the WPMgr-managed CP bucket
+-- (kind=cp, the historical default), a per-site Local folder on the agent host
+-- (kind=local), or a customer-owned S3-compatible bucket (kind=s3_compat).
+-- backup_snapshots.destination_id (below) references the row a given snapshot
+-- was taken against; NULL means the legacy CP-global bucket.
+--
+-- Threat model: secret_key_enc is age-encrypted at rest with the CP's shared
+-- identity (internal/cryptbox); the plaintext customer S3 secret never sits on
+-- disk in clear. RLS isolates rows per tenant; the partial unique index
+-- enforces at most one default destination per (tenant_id, site_id).
+CREATE TABLE site_destinations (
+    id               uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id        uuid        NOT NULL REFERENCES tenants (id) ON DELETE CASCADE,
+    -- site_id is nullable so a future flow can introduce tenant-wide defaults;
+    -- V1 always writes a non-null site_id.
+    site_id          uuid        REFERENCES sites (id) ON DELETE CASCADE,
+    kind             text        NOT NULL CHECK (kind IN ('cp', 'local', 's3_compat')),
+    label            text        NOT NULL,
+    endpoint         text        NOT NULL DEFAULT '',
+    region           text        NOT NULL DEFAULT '',
+    bucket           text        NOT NULL DEFAULT '',
+    path_prefix      text        NOT NULL DEFAULT '',
+    access_key_id    text        NOT NULL DEFAULT '',
+    secret_key_enc   bytea,
+    force_path_style boolean     NOT NULL DEFAULT false,
+    is_default       boolean     NOT NULL DEFAULT false,
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX site_destinations_site_idx ON site_destinations (site_id)
+    WHERE site_id IS NOT NULL;
+
+-- Exactly one default per (tenant, site). NULL site_id rows can't have a
+-- default yet (and V1 never creates any) — the partial filter scopes the
+-- uniqueness correctly.
+CREATE UNIQUE INDEX site_destinations_default_idx ON site_destinations (tenant_id, site_id)
+    WHERE is_default = true AND site_id IS NOT NULL;
+
+ALTER TABLE site_destinations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE site_destinations FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY site_destinations_tenant_isolation ON site_destinations
+    USING (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid)
+    WITH CHECK (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid);
+
+-- The agent-facing presign routing reads destinations under the agent GUC when
+-- no tenant is set; the agent path always knows the tenant from the verified
+-- Ed25519 identity though, so this stays SELECT-only defence-in-depth for
+-- cross-tenant maintenance jobs (mirrors backup_chunks_agent).
+CREATE POLICY site_destinations_agent ON site_destinations
+    FOR SELECT
+    USING (current_setting('app.agent', true) = 'on');
+
+-- m19 AS RESTRICTIVE collaborator site-scope policy (per-site sharing): a
+-- site-scoped principal may only see destinations for a site they were
+-- explicitly granted. site_id is nullable so the ANY check is skipped safely
+-- for a (V1-unused) tenant-wide NULL-site_id row.
+CREATE POLICY site_destinations_site_scope ON site_destinations
+    AS RESTRICTIVE FOR ALL
+    USING (
+        coalesce(current_setting('app.site_scope', true), '') <> 'on'
+        OR site_id = ANY (
+            string_to_array(nullif(current_setting('app.allowed_site_ids', true), ''), ',')::uuid[]
+        )
+    )
+    WITH CHECK (
+        coalesce(current_setting('app.site_scope', true), '') <> 'on'
+        OR site_id = ANY (
+            string_to_array(nullif(current_setting('app.allowed_site_ids', true), ''), ',')::uuid[]
+        )
+    );
+
+-- ---------------------------------------------------------------------------
 -- backup_snapshots  (M4)
 -- ---------------------------------------------------------------------------
 -- One backup of a site: files, db, or full. The manifest (ordered per-path
@@ -919,6 +995,11 @@ CREATE TABLE backup_snapshots (
     -- locked: operator pin (m49). When true, the retention GC MUST skip this
     -- snapshot regardless of retention_days/keep_last. Explicit unlock required.
     locked        boolean     NOT NULL DEFAULT false,
+    -- destination_id (M7 / ADR-036 P1): which site_destinations row this
+    -- snapshot's chunks were stored against. NULL = the legacy CP-managed
+    -- bucket — the value every pre-P1 snapshot carries and still the default
+    -- for a site with no configured destination.
+    destination_id uuid       REFERENCES site_destinations (id) ON DELETE SET NULL,
     -- progress: phpbu-engine real-time progress (M5.6 / ADR-032). Latest phase
     -- payload posted by the agent runner. Shape:
     --   {"phase": "uploading", "phase_detail": {"chunks_done": 17, ...}}
@@ -966,6 +1047,9 @@ CREATE INDEX backup_snapshots_locked_idx ON backup_snapshots (tenant_id, locked)
 -- completed/failed rows are unconstrained and retention GC is unaffected.
 CREATE UNIQUE INDEX backup_snapshots_one_inflight_per_site ON backup_snapshots (site_id)
     WHERE status IN ('pending', 'running');
+-- M7 / ADR-036 P1: presign routing + destination-CRUD cascade lookups.
+CREATE INDEX backup_snapshots_destination_id_idx ON backup_snapshots (destination_id)
+    WHERE destination_id IS NOT NULL;
 
 ALTER TABLE backup_snapshots ENABLE ROW LEVEL SECURITY;
 ALTER TABLE backup_snapshots FORCE ROW LEVEL SECURITY;

--- a/apps/api/internal/agentcmd/backup_contract.go
+++ b/apps/api/internal/agentcmd/backup_contract.go
@@ -98,6 +98,52 @@ const (
 // and stored.
 const ChunkBytes = 4 << 20
 
+// ============================================================================
+// ADR-036 P1 storage adapter (GH #146) — destination-routing wire contract.
+// The CP decides WHERE a snapshot's chunks live and tells the agent via
+// DestinationKind + DestinationConfig on BackupRequest/IncrementalBackupRequest
+// (backup) and RestoreRequest (restore). Both sides (Go CP + PHP agent) use
+// these field names and values verbatim. DO NOT rename without bumping both.
+// ============================================================================
+
+// Destination kind wire values.
+const (
+	// DestinationKindCP is the WPMgr-managed CP-global bucket — the historical
+	// default. Absent/empty DestinationKind on an older CP build (or a
+	// snapshot with no destination configured) means "cp".
+	DestinationKindCP = "cp"
+	// DestinationKindLocal means the agent writes ciphertext chunks straight
+	// to disk (wp-content/wpmgr-backups by default, or DestinationConfig.
+	// local_path_prefix when set) instead of uploading anywhere. The CP mints
+	// NO presigned URLs for a local-kind backup/restore.
+	DestinationKindLocal = "local"
+	// DestinationKindS3Compat is a customer-owned S3-compatible bucket (AWS
+	// S3, Wasabi, B2, DO Spaces, MinIO, …). The CP still presigns PUT/GET URLs
+	// via the EXACT SAME PresignEndpoint/ManifestEndpoint/chunk-URL transport
+	// as "cp" — just against the customer's bucket instead of the CP's — so
+	// the agent needs no extra config for it and NEVER sees the customer's S3
+	// credentials (the CP holds them, age-encrypted at rest).
+	DestinationKindS3Compat = "s3_compat"
+)
+
+// DestinationConfig carries the per-destination-kind data the agent needs
+// beyond DestinationKind itself. Only the fields relevant to the kind are
+// populated; every other field stays zero/empty.
+//
+//   - DestinationKind == "cp" or "s3_compat": DestinationConfig is entirely
+//     empty. The CP presigns PUT/GET (against the CP bucket or the customer's
+//     bucket respectively) via the same transport as always; the agent needs
+//     no additional configuration and, for s3_compat, never sees the
+//     customer's credentials.
+//   - DestinationKind == "local": LocalPathPrefix carries the on-disk path
+//     (relative to the site's wp-content directory) the agent writes
+//     ciphertext chunks under / reads them back from, instead of uploading
+//     them anywhere. Empty means the agent's own default
+//     ("wp-content/wpmgr-backups").
+type DestinationConfig struct {
+	LocalPathPrefix string `json:"local_path_prefix,omitempty"`
+}
+
 // BackupRequest is the POST body for the `backup` command.
 //
 //	snapshot_id   the CP-assigned snapshot UUID the agent reports the manifest
@@ -157,6 +203,14 @@ type BackupRequest struct {
 	// ExcludeFileSizeMB, when > 0, instructs the agent to skip files strictly
 	// larger than this value (MiB). 0 = no filter (agent default).
 	ExcludeFileSizeMB int32 `json:"exclude_file_size_mb,omitempty"`
+
+	// DestinationKind + DestinationConfig (ADR-036 P1 storage adapter, GH
+	// #146): which backend the agent should land ciphertext chunks against.
+	// Absent/empty DestinationKind means "cp" — an older CP build, or a
+	// snapshot with no destination configured, behaves exactly as before this
+	// field existed.
+	DestinationKind   string            `json:"destination_kind,omitempty"`
+	DestinationConfig DestinationConfig `json:"destination_config,omitempty"`
 }
 
 // BackupResponse is the agent's immediate ack of the `backup` command. The
@@ -363,6 +417,17 @@ type RestoreRequest struct {
 	// any syscall (see tombstone-path-safety rules). Empty when IsChainRestore is
 	// false OR when no files were deleted across the chain.
 	TombstonePaths []string `json:"tombstone_paths,omitempty"`
+
+	// DestinationKind + DestinationConfig (ADR-036 P1 storage adapter, GH
+	// #146): which backend the agent should READ chunks from. "local" carries
+	// NO chunk URLs in Manifest — RestoreChunk.Hash/Size are still populated
+	// (so the agent can locate + verify the chunk file) but URL is empty; the
+	// agent reads the chunk from its own local disk (DestinationConfig.
+	// local_path_prefix) instead. Absent/empty DestinationKind means "cp" —
+	// an older CP build, or a snapshot with no destination configured,
+	// behaves exactly as before this field existed.
+	DestinationKind   string            `json:"destination_kind,omitempty"`
+	DestinationConfig DestinationConfig `json:"destination_config,omitempty"`
 }
 
 // RestoreResponse is the agent's response to the `restore` command.
@@ -425,4 +490,9 @@ type IncrementalBackupRequest struct {
 	ExcludePaths      []string `json:"exclude_paths,omitempty"`
 	ExcludeExtensions []string `json:"exclude_extensions,omitempty"`
 	ExcludeFileSizeMB int32    `json:"exclude_file_size_mb,omitempty"`
+
+	// DestinationKind + DestinationConfig (ADR-036 P1 storage adapter, GH
+	// #146) — same semantics as BackupRequest.
+	DestinationKind   string            `json:"destination_kind,omitempty"`
+	DestinationConfig DestinationConfig `json:"destination_config,omitempty"`
 }

--- a/apps/api/internal/backup/destination_routing_test.go
+++ b/apps/api/internal/backup/destination_routing_test.go
@@ -1,0 +1,492 @@
+package backup
+
+// destination_routing_test.go — ADR-036 P1 (GH #146) unit tests: default-
+// destination resolution at backup-creation time (CreateBackup /
+// EnqueueScheduledBackup), destination-kind/config threading on backup
+// dispatch (BackupWorker.Work), and destination-aware restore planning
+// (PlanRestore) — local skips presign, and the managed (cp/nil) path is
+// provably byte-for-byte unchanged, including when destLookup is never wired.
+//
+// White-box, in-memory fakes; no database or network required.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// fakeDestLookup — in-memory DestinationLookup double.
+// ---------------------------------------------------------------------------
+
+type fakeDestLookup struct {
+	defaultBySite map[uuid.UUID]uuid.UUID // siteID -> destination id (absent = none configured)
+	infoByID      map[uuid.UUID]DestinationInfo
+}
+
+func newFakeDestLookup() *fakeDestLookup {
+	return &fakeDestLookup{
+		defaultBySite: map[uuid.UUID]uuid.UUID{},
+		infoByID:      map[uuid.UUID]DestinationInfo{},
+	}
+}
+
+func (f *fakeDestLookup) DefaultDestinationForSite(_ context.Context, _, siteID uuid.UUID) (uuid.UUID, error) {
+	return f.defaultBySite[siteID], nil
+}
+
+func (f *fakeDestLookup) DestinationInfo(_ context.Context, _, destinationID uuid.UUID) (DestinationInfo, error) {
+	info, ok := f.infoByID[destinationID]
+	if !ok {
+		return DestinationInfo{}, domain.NotFound("site_destination_not_found", "not found")
+	}
+	return info, nil
+}
+
+// ---------------------------------------------------------------------------
+// (a)/(c) — CreateBackup / EnqueueScheduledBackup stamp the resolved default
+// destination id, or uuid.Nil when none is configured / destLookup is unwired.
+// ---------------------------------------------------------------------------
+
+func TestCreateBackup_DefaultDestination_Stamped(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	destID := uuid.New()
+	dl := newFakeDestLookup()
+	dl.defaultBySite[siteID] = destID
+
+	repo := &wiringRepo{}
+	enq := &recordingEnqueuer{}
+	svc := buildWiringSvc(repo, enq, time.Now())
+	svc.destLookup = dl
+
+	if _, err := svc.CreateBackup(context.Background(), tenantID, siteID, uuid.New(), KindFull); err != nil {
+		t.Fatalf("CreateBackup error: %v", err)
+	}
+	if len(repo.createInputs) != 1 {
+		t.Fatalf("expected 1 CreateSnapshot call, got %d", len(repo.createInputs))
+	}
+	if repo.createInputs[0].DestinationID != destID {
+		t.Errorf("DestinationID = %v, want %v", repo.createInputs[0].DestinationID, destID)
+	}
+}
+
+func TestCreateBackup_NoDefaultDestination_Nil(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	dl := newFakeDestLookup() // no default configured for any site
+
+	repo := &wiringRepo{}
+	enq := &recordingEnqueuer{}
+	svc := buildWiringSvc(repo, enq, time.Now())
+	svc.destLookup = dl
+
+	if _, err := svc.CreateBackup(context.Background(), tenantID, siteID, uuid.New(), KindFull); err != nil {
+		t.Fatalf("CreateBackup error: %v", err)
+	}
+	if repo.createInputs[0].DestinationID != uuid.Nil {
+		t.Errorf("DestinationID = %v, want uuid.Nil (managed/legacy path)", repo.createInputs[0].DestinationID)
+	}
+}
+
+func TestCreateBackup_DestLookupUnwired_Nil(t *testing.T) {
+	// destLookup is never set (nil) — the byte-for-byte pre-feature behaviour.
+	repo := &wiringRepo{}
+	enq := &recordingEnqueuer{}
+	svc := buildWiringSvc(repo, enq, time.Now())
+
+	if _, err := svc.CreateBackup(context.Background(), uuid.New(), uuid.New(), uuid.New(), KindFull); err != nil {
+		t.Fatalf("CreateBackup error: %v", err)
+	}
+	if repo.createInputs[0].DestinationID != uuid.Nil {
+		t.Errorf("DestinationID = %v, want uuid.Nil when destLookup is unwired", repo.createInputs[0].DestinationID)
+	}
+}
+
+func TestEnqueueScheduledBackup_DefaultDestination_Stamped(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	destID := uuid.New()
+	dl := newFakeDestLookup()
+	dl.defaultBySite[siteID] = destID
+
+	repo := &wiringRepo{}
+	enq := &recordingEnqueuer{}
+	svc := buildWiringSvc(repo, enq, time.Now())
+	svc.destLookup = dl
+
+	sched := Schedule{
+		ID:        uuid.New(),
+		TenantID:  tenantID,
+		SiteID:    siteID,
+		Cadence:   CadenceDaily,
+		Kind:      KindFull,
+		NextRunAt: time.Now(),
+	}
+	if err := svc.EnqueueScheduledBackup(context.Background(), sched); err != nil {
+		t.Fatalf("EnqueueScheduledBackup error: %v", err)
+	}
+	if len(repo.createInputs) != 1 || repo.createInputs[0].DestinationID != destID {
+		t.Errorf("DestinationID = %v (creates=%d), want %v", repo.createInputs[0].DestinationID, len(repo.createInputs), destID)
+	}
+}
+
+func TestEnqueueScheduledBackup_NoDefaultDestination_Nil(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	dl := newFakeDestLookup()
+
+	repo := &wiringRepo{}
+	enq := &recordingEnqueuer{}
+	svc := buildWiringSvc(repo, enq, time.Now())
+	svc.destLookup = dl
+
+	sched := Schedule{
+		ID:        uuid.New(),
+		TenantID:  tenantID,
+		SiteID:    siteID,
+		Cadence:   CadenceDaily,
+		Kind:      KindFull,
+		NextRunAt: time.Now(),
+	}
+	if err := svc.EnqueueScheduledBackup(context.Background(), sched); err != nil {
+		t.Fatalf("EnqueueScheduledBackup error: %v", err)
+	}
+	if repo.createInputs[0].DestinationID != uuid.Nil {
+		t.Errorf("DestinationID = %v, want uuid.Nil (managed/legacy path)", repo.createInputs[0].DestinationID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BackupWorker.Work — DestinationKind/DestinationConfig threading onto the
+// CP->agent BackupRequest.
+// ---------------------------------------------------------------------------
+
+func TestBackupWorker_DestinationKindLocal_DispatchesConfig(t *testing.T) {
+	repo := &fakeWorkerRepo{fakeRepo: newFakeRepo()}
+	cmd := &fakeCommander{ok: true}
+	tenantID := uuid.New()
+	snapshotID := uuid.New()
+	destID := uuid.New()
+
+	snap := Snapshot{
+		ID:            snapshotID,
+		TenantID:      tenantID,
+		SiteID:        uuid.New(),
+		Kind:          KindFull,
+		Status:        StatusPending,
+		AgeRecipient:  "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p",
+		DestinationID: destID,
+	}
+	repo.setSnapshot(snap)
+
+	dl := newFakeDestLookup()
+	dl.infoByID[destID] = DestinationInfo{ID: destID, Kind: DestinationKindLocal, PathPrefix: "wpmgr-backups-custom"}
+
+	svc := &Service{repo: repo, sites: fakeWorkerSiteLookup{}, clock: fakeClock{t: time.Now()}, destLookup: dl}
+	worker := NewBackupWorker(svc, cmd, nil, nil, "https://cp.example.com", 0)
+	job := &river.Job[BackupArgs]{Args: BackupArgs{TenantID: tenantID, SnapshotID: snapshotID}}
+
+	if err := worker.Work(context.Background(), job); err != nil {
+		t.Fatalf("Work() error: %v", err)
+	}
+	if cmd.lastBackup == nil {
+		t.Fatal("expected Backup to be called")
+	}
+	if cmd.lastBackup.DestinationKind != DestinationKindLocal {
+		t.Errorf("DestinationKind = %q, want %q", cmd.lastBackup.DestinationKind, DestinationKindLocal)
+	}
+	if cmd.lastBackup.DestinationConfig.LocalPathPrefix != "wpmgr-backups-custom" {
+		t.Errorf("LocalPathPrefix = %q, want wpmgr-backups-custom", cmd.lastBackup.DestinationConfig.LocalPathPrefix)
+	}
+}
+
+func TestBackupWorker_ManagedDestination_EmitsCPKind(t *testing.T) {
+	repo := &fakeWorkerRepo{fakeRepo: newFakeRepo()}
+	cmd := &fakeCommander{ok: true}
+	tenantID := uuid.New()
+	snapshotID := uuid.New()
+
+	snap := Snapshot{
+		ID:           snapshotID,
+		TenantID:     tenantID,
+		SiteID:       uuid.New(),
+		Kind:         KindFull,
+		Status:       StatusPending,
+		AgeRecipient: "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p",
+		// DestinationID intentionally zero (uuid.Nil) — the managed/legacy path.
+	}
+	repo.setSnapshot(snap)
+
+	// destLookup intentionally NOT wired — proves the managed dispatch never
+	// depends on it.
+	svc := &Service{repo: repo, sites: fakeWorkerSiteLookup{}, clock: fakeClock{t: time.Now()}}
+	worker := NewBackupWorker(svc, cmd, nil, nil, "https://cp.example.com", 0)
+	job := &river.Job[BackupArgs]{Args: BackupArgs{TenantID: tenantID, SnapshotID: snapshotID}}
+
+	if err := worker.Work(context.Background(), job); err != nil {
+		t.Fatalf("Work() error: %v", err)
+	}
+	if cmd.lastBackup == nil {
+		t.Fatal("expected Backup to be called")
+	}
+	if cmd.lastBackup.DestinationKind != DestinationKindCP {
+		t.Errorf("DestinationKind = %q, want %q (managed/legacy default)", cmd.lastBackup.DestinationKind, DestinationKindCP)
+	}
+	if cmd.lastBackup.DestinationConfig.LocalPathPrefix != "" {
+		t.Errorf("expected empty DestinationConfig for the managed destination, got %+v", cmd.lastBackup.DestinationConfig)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PlanRestore (non-chain path) — destination-aware chunk fetch.
+// ---------------------------------------------------------------------------
+
+func TestPlanRestore_LocalDestination_SkipsPresign(t *testing.T) {
+	tenantID := uuid.New()
+	siteID := uuid.New()
+	snapID := uuid.New()
+	destID := uuid.New()
+
+	repo := &fakeWorkerRepo{fakeRepo: newFakeRepo(), workerManifests: map[uuid.UUID][]ManifestEntry{}}
+	snap := Snapshot{
+		ID:            snapID,
+		TenantID:      tenantID,
+		SiteID:        siteID,
+		Kind:          KindFull,
+		Status:        StatusCompleted,
+		AgeRecipient:  "age1test",
+		DestinationID: destID,
+	}
+	repo.setSnapshot(snap)
+	repo.workerManifests[snapID] = []ManifestEntry{
+		{Path: "wp-content/plugins/foo/foo.php", EntryKind: EntryKindFile, ChunkHashes: []string{"aaa"}, Size: 100},
+	}
+
+	dl := newFakeDestLookup()
+	dl.infoByID[destID] = DestinationInfo{ID: destID, Kind: DestinationKindLocal, PathPrefix: "custom/backups"}
+
+	svc := &Service{
+		repo:       repo,
+		sites:      &fakeSiteLookup{},
+		clock:      fakeClock{t: time.Now()},
+		presignTTL: time.Hour,
+		destLookup: dl,
+	}
+
+	plan, _, _, err := svc.PlanRestore(context.Background(), tenantID, snapID, RestoreSelection{Full: true}, "restore-local", "https://cp.test/progress")
+	if err != nil {
+		t.Fatalf("PlanRestore error: %v", err)
+	}
+	if plan.DestinationKind != DestinationKindLocal {
+		t.Errorf("DestinationKind = %q, want %q", plan.DestinationKind, DestinationKindLocal)
+	}
+	if plan.DestinationConfig.LocalPathPrefix != "custom/backups" {
+		t.Errorf("LocalPathPrefix = %q, want custom/backups", plan.DestinationConfig.LocalPathPrefix)
+	}
+	if len(plan.Manifest.Entries) != 1 || len(plan.Manifest.Entries[0].Chunks) != 1 {
+		t.Fatalf("expected 1 entry/1 chunk, got %+v", plan.Manifest.Entries)
+	}
+	chunk := plan.Manifest.Entries[0].Chunks[0]
+	if chunk.Hash != "aaa" {
+		t.Errorf("chunk hash = %q, want aaa", chunk.Hash)
+	}
+	if chunk.URL != "" {
+		t.Errorf("expected NO presigned URL for a local destination, got %q", chunk.URL)
+	}
+}
+
+// TestPlanRestore_ManagedDestination_Unchanged is the CRITICAL regression
+// proof: a snapshot with DestinationID == uuid.Nil AND an unwired destLookup
+// presigns via the legacy s.store path exactly as it did before ADR-036 P1 —
+// one presign call, a non-empty URL, and DestinationKind reported as "cp".
+func TestPlanRestore_ManagedDestination_Unchanged(t *testing.T) {
+	tenantID := uuid.New()
+	siteID := uuid.New()
+	snapID := uuid.New()
+
+	repo := &fakeWorkerRepo{fakeRepo: newFakeRepo(), workerManifests: map[uuid.UUID][]ManifestEntry{}}
+	snap := Snapshot{
+		ID:           snapID,
+		TenantID:     tenantID,
+		SiteID:       siteID,
+		Kind:         KindFull,
+		Status:       StatusCompleted,
+		AgeRecipient: "age1test",
+		// DestinationID intentionally zero (uuid.Nil).
+	}
+	repo.setSnapshot(snap)
+	repo.workerManifests[snapID] = []ManifestEntry{
+		{Path: "wp-content/plugins/foo/foo.php", EntryKind: EntryKindFile, ChunkHashes: []string{"aaa"}, Size: 100},
+	}
+
+	fp := &fakePresigner{}
+	svc := &Service{
+		repo:       repo,
+		sites:      &fakeSiteLookup{},
+		store:      &tenantPresigner{tenantID: tenantID, inner: fp},
+		clock:      fakeClock{t: time.Now()},
+		presignTTL: time.Hour,
+		// destLookup intentionally NOT wired (nil) — proves the managed path
+		// never depends on it.
+	}
+
+	plan, _, _, err := svc.PlanRestore(context.Background(), tenantID, snapID, RestoreSelection{Full: true}, "restore-managed", "https://cp.test/progress")
+	if err != nil {
+		t.Fatalf("PlanRestore error: %v", err)
+	}
+	if plan.DestinationKind != DestinationKindCP {
+		t.Errorf("DestinationKind = %q, want %q (managed/legacy)", plan.DestinationKind, DestinationKindCP)
+	}
+	if plan.DestinationConfig.LocalPathPrefix != "" {
+		t.Errorf("expected empty LocalPathPrefix for the managed destination, got %q", plan.DestinationConfig.LocalPathPrefix)
+	}
+	if len(plan.Manifest.Entries) != 1 || len(plan.Manifest.Entries[0].Chunks) != 1 {
+		t.Fatalf("expected 1 entry/1 chunk, got %+v", plan.Manifest.Entries)
+	}
+	chunk := plan.Manifest.Entries[0].Chunks[0]
+	if chunk.URL == "" {
+		t.Error("expected a presigned URL for the managed (cp) destination")
+	}
+	if fp.calls != 1 {
+		t.Errorf("expected exactly 1 presign call, got %d", fp.calls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PresignParentFilesList (ADR-051 incremental diff-source) — the PARENT
+// snapshot's OWN destination must drive routing, not the increment currently
+// being dispatched.
+// ---------------------------------------------------------------------------
+
+// fakeRegistry is a minimal PresignerForSnapshot double: it returns a distinct
+// Presigner keyed by DestinationID (uuid.Nil routes to defaultStore), so a
+// test can prove a call routed to the destination-specific presigner and NOT
+// the CP-global default — the same routing contract blobstore.Registry
+// implements in production (see internal/blobstore/registry_test.go for the
+// real bucket-selection proof).
+type fakeRegistry struct {
+	byDestination map[uuid.UUID]Presigner
+	defaultStore  Presigner
+}
+
+func (r *fakeRegistry) PresignerForSnapshot(_ context.Context, snap Snapshot) (Presigner, error) {
+	if snap.DestinationID == uuid.Nil {
+		return r.defaultStore, nil
+	}
+	if p, ok := r.byDestination[snap.DestinationID]; ok {
+		return p, nil
+	}
+	return r.defaultStore, nil
+}
+
+func TestPresignParentFilesList_S3CompatParent_RoutesToCustomerPresigner(t *testing.T) {
+	tenantID := uuid.New()
+	siteID := uuid.New()
+	parentID := uuid.New()
+	destID := uuid.New()
+	flHash := "abc123def456abc123def456abc123def456abc123def456abc123def456abcd"
+
+	repo := &fakeWorkerRepo{fakeRepo: newFakeRepo(), workerManifests: map[uuid.UUID][]ManifestEntry{}}
+	repo.setSnapshot(Snapshot{
+		ID:            parentID,
+		TenantID:      tenantID,
+		SiteID:        siteID,
+		Kind:          KindFull,
+		Status:        StatusCompleted,
+		AgeRecipient:  "age1test",
+		DestinationID: destID,
+	})
+	repo.workerManifests[parentID] = []ManifestEntry{
+		{Path: "files.list", EntryKind: EntryKindFilesList, ChunkHashes: []string{flHash}, Size: 200},
+	}
+
+	defaultFP := &fakePresigner{}
+	customerFP := &fakePresigner{}
+	registry := &fakeRegistry{
+		defaultStore: &tenantPresigner{tenantID: tenantID, inner: defaultFP},
+		byDestination: map[uuid.UUID]Presigner{
+			destID: &tenantPresigner{tenantID: tenantID, inner: customerFP},
+		},
+	}
+
+	dl := newFakeDestLookup()
+	dl.infoByID[destID] = DestinationInfo{ID: destID, Kind: DestinationKindS3Compat}
+
+	svc := &Service{
+		repo:       repo,
+		sites:      &fakeSiteLookup{},
+		store:      &tenantPresigner{tenantID: tenantID, inner: defaultFP}, // legacy fallback; must NOT be used
+		registry:   registry,
+		clock:      fakeClock{t: time.Now()},
+		presignTTL: time.Hour,
+		destLookup: dl,
+	}
+
+	chunks, err := svc.PresignParentFilesList(context.Background(), tenantID, parentID)
+	if err != nil {
+		t.Fatalf("PresignParentFilesList error: %v", err)
+	}
+	if len(chunks) != 1 || chunks[0].Hash != flHash {
+		t.Fatalf("expected 1 chunk %q, got %+v", flHash, chunks)
+	}
+	if chunks[0].URL == "" {
+		t.Error("expected a presigned URL for an s3_compat parent")
+	}
+	if customerFP.calls != 1 {
+		t.Errorf("expected exactly 1 presign call on the CUSTOMER presigner, got %d", customerFP.calls)
+	}
+	if defaultFP.calls != 0 {
+		t.Errorf("expected the CP-global default presigner NOT to be called, got %d calls", defaultFP.calls)
+	}
+}
+
+func TestPresignParentFilesList_LocalParent_SkipsPresign(t *testing.T) {
+	tenantID := uuid.New()
+	siteID := uuid.New()
+	parentID := uuid.New()
+	destID := uuid.New()
+	flHash := "def456abc123def456abc123def456abc123def456abc123def456abc123def4"
+
+	repo := &fakeWorkerRepo{fakeRepo: newFakeRepo(), workerManifests: map[uuid.UUID][]ManifestEntry{}}
+	repo.setSnapshot(Snapshot{
+		ID:            parentID,
+		TenantID:      tenantID,
+		SiteID:        siteID,
+		Kind:          KindFull,
+		Status:        StatusCompleted,
+		AgeRecipient:  "age1test",
+		DestinationID: destID,
+	})
+	repo.workerManifests[parentID] = []ManifestEntry{
+		{Path: "files.list", EntryKind: EntryKindFilesList, ChunkHashes: []string{flHash}, Size: 200},
+	}
+
+	dl := newFakeDestLookup()
+	dl.infoByID[destID] = DestinationInfo{ID: destID, Kind: DestinationKindLocal, PathPrefix: "custom/backups"}
+
+	// registry/store intentionally nil — a local parent must never need
+	// either (StoreForSnapshot would hard-error for a local destination).
+	svc := &Service{
+		repo:       repo,
+		sites:      &fakeSiteLookup{},
+		clock:      fakeClock{t: time.Now()},
+		presignTTL: time.Hour,
+		destLookup: dl,
+	}
+
+	chunks, err := svc.PresignParentFilesList(context.Background(), tenantID, parentID)
+	if err != nil {
+		t.Fatalf("PresignParentFilesList error: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if chunks[0].Hash != flHash {
+		t.Errorf("Hash = %q, want %q", chunks[0].Hash, flHash)
+	}
+	if chunks[0].URL != "" {
+		t.Errorf("expected NO presigned URL for a local parent, got %q", chunks[0].URL)
+	}
+}

--- a/apps/api/internal/backup/repo.go
+++ b/apps/api/internal/backup/repo.go
@@ -267,6 +267,11 @@ type CreateSnapshotInput struct {
 	BaseSnapshotID   *uuid.UUID
 	ChainID          *uuid.UUID
 	Generation       int
+	// DestinationID (M7 / ADR-036 P1): the site_destinations row this snapshot's
+	// chunks should be stored against. uuid.Nil (the zero value) routes to the
+	// legacy CP-managed bucket — the pre-existing, always-managed-storage
+	// behaviour for every caller that does not resolve a destination.
+	DestinationID uuid.UUID
 }
 
 // CycleStatsInput is the set of incremental telemetry counters stamped at
@@ -403,12 +408,17 @@ func (r *pgRepo) CreateSnapshot(ctx context.Context, in CreateSnapshotInput) (Sn
 		if in.CreatedBy != uuid.Nil {
 			createdBy = pgtype.UUID{Bytes: in.CreatedBy, Valid: true}
 		}
+		var destinationID pgtype.UUID
+		if in.DestinationID != uuid.Nil {
+			destinationID = pgtype.UUID{Bytes: in.DestinationID, Valid: true}
+		}
 		row, err := sqlc.New(tx).CreateBackupSnapshot(ctx, sqlc.CreateBackupSnapshotParams{
-			TenantID:     in.TenantID,
-			SiteID:       in.SiteID,
-			CreatedBy:    createdBy,
-			Kind:         in.Kind,
-			AgeRecipient: in.AgeRecipient,
+			TenantID:      in.TenantID,
+			SiteID:        in.SiteID,
+			CreatedBy:     createdBy,
+			Kind:          in.Kind,
+			AgeRecipient:  in.AgeRecipient,
+			DestinationID: destinationID,
 		})
 		if err != nil {
 			return domain.Internal("backup_snapshot_create_failed", "failed to create snapshot").WithCause(err)
@@ -1642,6 +1652,9 @@ func toSnapshot(s sqlc.BackupSnapshot) Snapshot {
 		id := uuid.UUID(s.CreatedBy.Bytes)
 		out.CreatedBy = &id
 	}
+	if s.DestinationID.Valid {
+		out.DestinationID = uuid.UUID(s.DestinationID.Bytes)
+	}
 	if s.StartedAt.Valid {
 		t := s.StartedAt.Time
 		out.StartedAt = &t
@@ -1797,13 +1810,13 @@ const snapshotSelectColumns = `SELECT id, tenant_id, site_id, created_by, kind, 
         started_at, finished_at, created_at, updated_at,
         is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation,
         cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded,
-        locked`
+        locked, destination_id`
 
 // scanSnapshotWithChainFields scans a row that includes the ADR-048 chain
-// columns (is_incremental … cycle_bytes_uploaded) plus the m49 locked column.
-// The SELECT must project all standard snapshot columns plus the four chain UUID
-// columns, the four cycle counter columns, and locked — in the exact order
-// listed here.
+// columns (is_incremental … cycle_bytes_uploaded) plus the m49 locked column
+// and the M7 / ADR-036 P1 destination_id column. The SELECT must project all
+// standard snapshot columns plus the four chain UUID columns, the four cycle
+// counter columns, locked, and destination_id — in the exact order listed here.
 func scanSnapshotWithChainFields(row rowScanner) (Snapshot, error) {
 	var (
 		s               Snapshot
@@ -1814,6 +1827,7 @@ func scanSnapshotWithChainFields(row rowScanner) (Snapshot, error) {
 		parentID        pgtype.UUID
 		baseID          pgtype.UUID
 		chainID         pgtype.UUID
+		destinationID   pgtype.UUID
 	)
 	err := row.Scan(
 		&s.ID, &s.TenantID, &s.SiteID, &createdBy, &s.Kind, &s.Status,
@@ -1822,7 +1836,7 @@ func scanSnapshotWithChainFields(row rowScanner) (Snapshot, error) {
 		&s.CreatedAt, &s.UpdatedAt,
 		&s.IsIncremental, &parentID, &baseID, &chainID, &s.Generation,
 		&s.CycleFilesScanned, &s.CycleFilesChanged, &s.CycleFilesDeleted, &s.CycleBytesUploaded,
-		&s.Locked,
+		&s.Locked, &destinationID,
 	)
 	if err != nil {
 		return Snapshot{}, err
@@ -1830,6 +1844,9 @@ func scanSnapshotWithChainFields(row rowScanner) (Snapshot, error) {
 	if createdBy.Valid {
 		id := uuid.UUID(createdBy.Bytes)
 		s.CreatedBy = &id
+	}
+	if destinationID.Valid {
+		s.DestinationID = uuid.UUID(destinationID.Bytes)
 	}
 	if startedAt.Valid {
 		t := startedAt.Time

--- a/apps/api/internal/backup/service.go
+++ b/apps/api/internal/backup/service.go
@@ -99,6 +99,46 @@ type PresignerForSnapshot interface {
 	PresignerForSnapshot(ctx context.Context, snap Snapshot) (Presigner, error)
 }
 
+// Destination kind wire values (GH #146 / ADR-036 P1). Mirrored from
+// sitedestination.Kind as plain strings so this package does not import
+// sitedestination directly — see DestinationLookup.
+const (
+	DestinationKindCP       = "cp"
+	DestinationKindLocal    = "local"
+	DestinationKindS3Compat = "s3_compat"
+)
+
+// DestinationInfo is the destination-routing metadata resolved for an
+// already-chosen (non-nil) destination id: the wire Kind ("cp" | "local" |
+// "s3_compat") and, for "local", the operator-configured on-disk path prefix
+// the agent should write/read chunks under. cp/s3_compat destinations leave
+// PathPrefix empty on the wire — the CP still presigns PUT/GET for both via
+// the registry, so the agent needs no extra config for them (and, critically,
+// never sees the s3_compat customer's credentials).
+type DestinationInfo struct {
+	ID         uuid.UUID
+	Kind       string
+	PathPrefix string
+}
+
+// DestinationLookup bridges the ADR-036 P1 site-destination domain into the
+// backup service without an import cycle (sitedestination has no reason to
+// import backup, but keeping the dependency direction explicit and narrow
+// keeps both packages independently testable — mirrors PresignerForSnapshot).
+// Wired via SetDestinationLookup; nil is a fully supported, tested state:
+// every call site treats a nil destLookup exactly like "no destination
+// configured", i.e. every new snapshot's DestinationID stays uuid.Nil and
+// every backup/restore dispatch reports DestinationKind="cp" — the
+// pre-existing, always-managed-storage behaviour, byte for byte.
+type DestinationLookup interface {
+	// DefaultDestinationForSite resolves the site's default destination id, or
+	// uuid.Nil (no error) when the site has none configured — the common case.
+	DefaultDestinationForSite(ctx context.Context, tenantID, siteID uuid.UUID) (uuid.UUID, error)
+	// DestinationInfo resolves the kind + local-path metadata for an already-
+	// chosen (non-nil) destination id.
+	DestinationInfo(ctx context.Context, tenantID, destinationID uuid.UUID) (DestinationInfo, error)
+}
+
 // Service holds the backup orchestration logic.
 type Service struct {
 	repo     Repo
@@ -133,6 +173,12 @@ type Service struct {
 	// mailer sends backup-completion/failure notification emails (Track B, m49).
 	// Optional: when nil, notification emails are silently suppressed.
 	mailer BackupMailer
+	// destLookup resolves ADR-036 P1 site-destination routing metadata: the
+	// site's configured default destination at backup-creation time, and an
+	// already-chosen destination's kind/local-path at dispatch/restore time.
+	// Optional: see DestinationLookup's doc for the graceful-degradation
+	// contract when nil.
+	destLookup DestinationLookup
 }
 
 // SetRegistry wires the ADR-036 P1 storage-adapter router. Calling this AFTER
@@ -160,6 +206,13 @@ func (s *Service) SetIndexDeleter(d IndexDeleter) { s.indexDeleter = d }
 // notifications (Track B, m49). Call once at startup after River is started.
 // When not called, backup email notifications are silently suppressed.
 func (s *Service) SetMailer(m BackupMailer) { s.mailer = m }
+
+// SetDestinationLookup wires the ADR-036 P1 site-destination resolver. Call
+// once at startup (after NewService), before serving traffic — alongside
+// SetRegistry, which routes the actual presigns once a destination is chosen.
+// Optional: when never called, every backup/restore uses the managed (cp)
+// destination exactly as before this feature existed.
+func (s *Service) SetDestinationLookup(d DestinationLookup) { s.destLookup = d }
 
 // Config tunes the service.
 type Config struct {
@@ -227,6 +280,128 @@ func NewService(repo Repo, sites SiteLookup, enqueuer Enqueuer, store Presigner,
 	}
 }
 
+// resolveDefaultDestination resolves the site's default destination id for a
+// NEW backup run. Returns uuid.Nil (never an error) when destLookup is not
+// wired, the site has no default configured, or the lookup itself fails — a
+// destination-routing hiccup must never block a backup from being created; it
+// simply falls back to the managed bucket exactly as every snapshot did
+// before this feature existed. A lookup failure is logged so the degrade is
+// visible to operators.
+func (s *Service) resolveDefaultDestination(ctx context.Context, tenantID, siteID uuid.UUID) uuid.UUID {
+	if s.destLookup == nil {
+		return uuid.Nil
+	}
+	id, err := s.destLookup.DefaultDestinationForSite(ctx, tenantID, siteID)
+	if err != nil {
+		slog.WarnContext(ctx, "backup: default destination lookup failed; falling back to managed storage",
+			slog.String("tenant_id", tenantID.String()),
+			slog.String("site_id", siteID.String()),
+			slog.Any("error", err))
+		return uuid.Nil
+	}
+	return id
+}
+
+// DestinationInfoForSnapshot resolves the wire-facing destination kind (and,
+// for "local", the path-prefix config) for an ALREADY-CREATED snapshot.
+//
+// CRITICAL INVARIANT: snap.DestinationID == uuid.Nil short-circuits to
+// {Kind: DestinationKindCP} WITHOUT ever calling destLookup. This is what
+// keeps the managed backup/restore path completely ungated by destLookup
+// wiring or errors — every snapshot created before this feature, and every
+// snapshot for a site with no configured destination, always takes this
+// branch and behaves exactly as it did before ADR-036 P1 shipped.
+func (s *Service) DestinationInfoForSnapshot(ctx context.Context, snap Snapshot) (DestinationInfo, error) {
+	if snap.DestinationID == uuid.Nil {
+		return DestinationInfo{Kind: DestinationKindCP}, nil
+	}
+	if s.destLookup == nil {
+		// A destination_id is stamped on the row but no resolver is wired. This
+		// should not happen operationally (SetDestinationLookup is wired
+		// alongside SetRegistry) — degrade to the managed kind rather than error.
+		return DestinationInfo{Kind: DestinationKindCP}, nil
+	}
+	return s.destLookup.DestinationInfo(ctx, snap.TenantID, snap.DestinationID)
+}
+
+// presignerForSnapshot resolves the Presigner that should mint URLs for a
+// snapshot's chunks: the ADR-036 P1 per-destination registry route when
+// wired, falling back to the legacy single CP-global Store. Shared by the
+// backup-upload path (PresignChunks) and every restore-download path so a
+// destination-routed snapshot presigns consistently on both sides — an
+// s3_compat snapshot always presigns against ITS OWN bucket, never the CP's.
+func (s *Service) presignerForSnapshot(ctx context.Context, snap Snapshot) (Presigner, error) {
+	presigner := s.store
+	if s.registry != nil {
+		p, err := s.registry.PresignerForSnapshot(ctx, snap)
+		if err != nil {
+			return nil, domain.Internal("backup_presign_route_failed", "failed to resolve presigner for snapshot").WithCause(err)
+		}
+		if p != nil {
+			presigner = p
+		}
+	}
+	return presigner, nil
+}
+
+// restoreDestinationRoute resolves how a restore should fetch a snapshot's
+// chunks: the wire DestinationKind to report to the agent, the local path
+// prefix (kind=="local" only — empty otherwise), and the Presigner to mint GET
+// URLs with (nil for kind=="local": the agent reads its own local disk
+// instead, so no GET is ever minted for those chunks).
+//
+// CRITICAL INVARIANT: snap.DestinationID == uuid.Nil is the managed/legacy
+// path — DestinationInfoForSnapshot short-circuits for it without touching
+// destLookup, so this function's behaviour for every snapshot created before
+// this feature (and every site with no configured destination) is IDENTICAL
+// to calling presignerForSnapshot alone: kind="cp", no local prefix, a
+// registry-or-store presigner. destLookup being unwired or erroring can never
+// gate that path.
+func (s *Service) restoreDestinationRoute(ctx context.Context, snap Snapshot) (kind, localPathPrefix string, presigner Presigner, err error) {
+	info, ierr := s.DestinationInfoForSnapshot(ctx, snap)
+	if ierr != nil {
+		return "", "", nil, ierr
+	}
+	kind = info.Kind
+	if kind == "" {
+		kind = DestinationKindCP
+	}
+	if kind == DestinationKindLocal {
+		// The agent reads its own local disk; no presign is possible (or
+		// needed) for a local destination.
+		return kind, info.PathPrefix, nil, nil
+	}
+	presigner, err = s.presignerForSnapshot(ctx, snap)
+	return kind, "", presigner, err
+}
+
+// mintRestoreChunks resolves the GET-able agentcmd.RestoreChunk for every
+// stored chunk in `chunks`. When presigner is nil (destination kind ==
+// "local") no presign is attempted at all — the agent reads the chunk from
+// its own local disk keyed by hash, so only Hash+Size are populated and URL
+// stays empty. Otherwise a presigned GET is minted after verifying the stored
+// s3_key sits inside this tenant's content-addressed prefix (defense-in-
+// depth: a presign can never address another tenant's chunk).
+func (s *Service) mintRestoreChunks(ctx context.Context, tenantID uuid.UUID, presigner Presigner, chunks map[string]Chunk) (map[string]agentcmd.RestoreChunk, error) {
+	out := make(map[string]agentcmd.RestoreChunk, len(chunks))
+	for h, c := range chunks {
+		if presigner == nil {
+			out[h] = agentcmd.RestoreChunk{Hash: h, Size: c.Size}
+			continue
+		}
+		expected := chunkS3Key(tenantID, h)
+		if c.S3Key != expected {
+			return nil, domain.Internal("backup_chunk_key_mismatch", "stored chunk key is outside the tenant prefix")
+		}
+		url, perr := presigner.PresignGet(ctx, c.S3Key, s.presignTTL)
+		if perr != nil {
+			return nil, domain.Internal("backup_presign_get_failed", "failed to presign chunk").WithCause(perr)
+		}
+		out[h] = agentcmd.RestoreChunk{Hash: h, URL: url, Size: c.Size}
+	}
+	return out, nil
+}
+
 // CreateBackup validates the request, records a pending snapshot, and enqueues a
 // background backup job. The site MUST be enrolled and have an age recipient set
 // (a backup the operator could never decrypt is useless).
@@ -265,6 +440,12 @@ func (s *Service) CreateBackup(ctx context.Context, tenantID, siteID, createdBy 
 			"a backup is already pending or running for this site; wait for it to complete before starting another")
 	}
 
+	// ADR-036 P1: resolve the site's configured default destination ONCE up
+	// front so both the incremental and full paths below stamp it identically.
+	// uuid.Nil (destLookup unwired, no default configured, or a lookup
+	// failure) routes to the legacy CP-managed bucket — unchanged behaviour.
+	destinationID := s.resolveDefaultDestination(ctx, tenantID, siteID)
+
 	// ADR-048 P5: run-now honours the same per-schedule incremental toggle as the
 	// scheduled path, so an operator can enable the toggle and then drive the
 	// base→increment→restore QA flow via run-now. A site with no schedule row (or
@@ -287,6 +468,7 @@ func (s *Service) CreateBackup(ctx context.Context, tenantID, siteID, createdBy 
 			BaseSnapshotID:   res.BaseSnapshotID,
 			ChainID:          res.ChainID,
 			Generation:       res.Generation,
+			DestinationID:    destinationID,
 		})
 		if err != nil {
 			if isUniqueViolation(err) {
@@ -302,11 +484,12 @@ func (s *Service) CreateBackup(ctx context.Context, tenantID, siteID, createdBy 
 	}
 
 	snap, err := s.repo.CreateSnapshot(ctx, CreateSnapshotInput{
-		TenantID:     tenantID,
-		SiteID:       siteID,
-		CreatedBy:    createdBy,
-		Kind:         kind,
-		AgeRecipient: si.AgeRecipient,
+		TenantID:      tenantID,
+		SiteID:        siteID,
+		CreatedBy:     createdBy,
+		Kind:          kind,
+		AgeRecipient:  si.AgeRecipient,
+		DestinationID: destinationID,
 	})
 	if err != nil {
 		if isUniqueViolation(err) {
@@ -558,21 +741,18 @@ func (s *Service) PlanRestore(ctx context.Context, tenantID, snapshotID uuid.UUI
 		return agentcmd.RestoreRequest{}, Snapshot{}, SiteInfo{}, err
 	}
 
-	// Mint a presigned GET per distinct chunk (deduped across entries).
-	getURLs := make(map[string]agentcmd.RestoreChunk, len(chunks))
-	for h, c := range chunks {
-		// Defense-in-depth: the s3 key MUST be namespaced to this tenant. The
-		// content-addressed key the repo stored is chunks/<tenant>/<blake3>;
-		// never presign a key outside this tenant's prefix.
-		expected := chunkS3Key(tenantID, h)
-		if c.S3Key != expected {
-			return agentcmd.RestoreRequest{}, Snapshot{}, SiteInfo{}, domain.Internal("backup_chunk_key_mismatch", "stored chunk key is outside the tenant prefix")
-		}
-		url, perr := s.store.PresignGet(ctx, c.S3Key, s.presignTTL)
-		if perr != nil {
-			return agentcmd.RestoreRequest{}, Snapshot{}, SiteInfo{}, domain.Internal("backup_presign_get_failed", "failed to presign chunk").WithCause(perr)
-		}
-		getURLs[h] = agentcmd.RestoreChunk{Hash: h, URL: url, Size: c.Size}
+	// ADR-036 P1: resolve destination routing BEFORE minting any chunk URL.
+	// destKind=="local" skips presigning entirely (the agent reads its own
+	// local disk instead); every other kind (cp — the pre-existing default —
+	// or s3_compat) mints a GET exactly as before, routed to the CUSTOMER
+	// bucket for s3_compat via the registry.
+	destKind, destLocalPrefix, presigner, drerr := s.restoreDestinationRoute(ctx, snap)
+	if drerr != nil {
+		return agentcmd.RestoreRequest{}, Snapshot{}, SiteInfo{}, drerr
+	}
+	getURLs, err := s.mintRestoreChunks(ctx, tenantID, presigner, chunks)
+	if err != nil {
+		return agentcmd.RestoreRequest{}, Snapshot{}, SiteInfo{}, err
 	}
 
 	// Derive the agent-wire `kind` from the requested components (M6 / Track 2).
@@ -609,6 +789,11 @@ func (s *Service) PlanRestore(ctx context.Context, tenantID, snapshotID uuid.UUI
 		SourceHomeURL:    snap.SourceHomeURL,
 		SourceContentURL: snap.SourceContentURL,
 		SourceUploadURL:  snap.SourceUploadURL,
+		// ADR-036 P1 storage adapter (GH #146): tells the agent which backend
+		// to read chunks from. "local" carries no chunk URLs (see
+		// mintRestoreChunks) — the agent reads its own disk instead.
+		DestinationKind:   destKind,
+		DestinationConfig: agentcmd.DestinationConfig{LocalPathPrefix: destLocalPrefix},
 	}
 	for _, e := range selected {
 		re := agentcmd.RestoreEntry{LogicalPath: e.Path}
@@ -966,18 +1151,15 @@ func (s *Service) planRestoreChainOverlay(ctx context.Context, tenantID uuid.UUI
 		}
 	}
 
-	// STEP 6 — presign chunk GET URLs.
-	getURLs := make(map[string]agentcmd.RestoreChunk, len(chunks))
-	for h, c := range chunks {
-		expected := chunkS3Key(tenantID, h)
-		if c.S3Key != expected {
-			return agentcmd.RestoreRequest{}, Snapshot{}, SiteInfo{}, domain.Internal("backup_chunk_key_mismatch", "stored chunk key is outside the tenant prefix")
-		}
-		url, perr := s.store.PresignGet(ctx, c.S3Key, s.presignTTL)
-		if perr != nil {
-			return agentcmd.RestoreRequest{}, Snapshot{}, SiteInfo{}, domain.Internal("backup_presign_get_failed", "failed to presign chunk").WithCause(perr)
-		}
-		getURLs[h] = agentcmd.RestoreChunk{Hash: h, URL: url, Size: c.Size}
+	// STEP 6 — ADR-036 P1 destination routing + chunk GET URLs (skipped for a
+	// local destination — the agent reads its own local disk instead).
+	destKind, destLocalPrefix, presigner, drerr := s.restoreDestinationRoute(ctx, snap)
+	if drerr != nil {
+		return agentcmd.RestoreRequest{}, Snapshot{}, SiteInfo{}, drerr
+	}
+	getURLs, err := s.mintRestoreChunks(ctx, tenantID, presigner, chunks)
+	if err != nil {
+		return agentcmd.RestoreRequest{}, Snapshot{}, SiteInfo{}, err
 	}
 
 	// CP-side tombstone path sanitization (defense-in-depth; agent re-sanitizes).
@@ -1020,6 +1202,10 @@ func (s *Service) planRestoreChainOverlay(ctx context.Context, tenantID uuid.UUI
 		TargetGeneration: targetGen,
 		EstimatedBytes:   estimatedBytes,
 		TombstonePaths:   tombstonePaths,
+		// ADR-036 P1 storage adapter (GH #146): see PlanRestore's non-chain
+		// path for the field contract.
+		DestinationKind:   destKind,
+		DestinationConfig: agentcmd.DestinationConfig{LocalPathPrefix: destLocalPrefix},
 	}
 
 	// OVERLAY ORDER — append each generation's parts ASCENDING by generation so a
@@ -1158,18 +1344,15 @@ func (s *Service) planRestoreChainFileIndex(ctx context.Context, tenantID uuid.U
 		}
 	}
 
-	// STEP 7 — presign chunk GET URLs.
-	getURLs := make(map[string]agentcmd.RestoreChunk, len(chunks))
-	for h, c := range chunks {
-		expected := chunkS3Key(tenantID, h)
-		if c.S3Key != expected {
-			return agentcmd.RestoreRequest{}, Snapshot{}, SiteInfo{}, domain.Internal("backup_chunk_key_mismatch", "stored chunk key is outside the tenant prefix")
-		}
-		url, perr := s.store.PresignGet(ctx, c.S3Key, s.presignTTL)
-		if perr != nil {
-			return agentcmd.RestoreRequest{}, Snapshot{}, SiteInfo{}, domain.Internal("backup_presign_get_failed", "failed to presign chunk").WithCause(perr)
-		}
-		getURLs[h] = agentcmd.RestoreChunk{Hash: h, URL: url, Size: c.Size}
+	// STEP 7 — ADR-036 P1 destination routing + chunk GET URLs (skipped for a
+	// local destination — the agent reads its own local disk instead).
+	destKind, destLocalPrefix, presigner, drerr := s.restoreDestinationRoute(ctx, snap)
+	if drerr != nil {
+		return agentcmd.RestoreRequest{}, Snapshot{}, SiteInfo{}, drerr
+	}
+	getURLs, err := s.mintRestoreChunks(ctx, tenantID, presigner, chunks)
+	if err != nil {
+		return agentcmd.RestoreRequest{}, Snapshot{}, SiteInfo{}, err
 	}
 
 	// STEP 8 — assemble RestoreRequest.
@@ -1212,6 +1395,10 @@ func (s *Service) planRestoreChainFileIndex(ctx context.Context, tenantID uuid.U
 		TargetGeneration: targetGen,
 		EstimatedBytes:   estimatedBytes,
 		TombstonePaths:   tombstonePaths,
+		// ADR-036 P1 storage adapter (GH #146): see PlanRestore's non-chain
+		// path for the field contract.
+		DestinationKind:   destKind,
+		DestinationConfig: agentcmd.DestinationConfig{LocalPathPrefix: destLocalPrefix},
 	}
 
 	// File entries from winMap (non-tombstone, each as a RestoreEntry).
@@ -1341,15 +1528,9 @@ func (s *Service) PresignChunks(ctx context.Context, tenantID, snapshotID uuid.U
 	// the per-destination Store when the snapshot carries a non-nil
 	// DestinationID; otherwise it falls back to the CP-global Store. When no
 	// registry is wired we keep the legacy single-store path verbatim.
-	presigner := s.store
-	if s.registry != nil {
-		p, perr := s.registry.PresignerForSnapshot(ctx, snap)
-		if perr != nil {
-			return nil, domain.Internal("backup_presign_route_failed", "failed to resolve presigner for snapshot").WithCause(perr)
-		}
-		if p != nil {
-			presigner = p
-		}
+	presigner, perr := s.presignerForSnapshot(ctx, snap)
+	if perr != nil {
+		return nil, perr
 	}
 	uploads := map[string]string{}
 	for _, h := range hashes {
@@ -1473,6 +1654,17 @@ func (s *Service) SubmitManifest(ctx context.Context, tenantID, snapshotID uuid.
 // route. Returns an error when the parent carries no files-list (a chain that
 // can't be diffed) or a chunk is no longer stored, so the worker can surface a
 // retryable infra failure rather than silently re-pack the whole tree.
+//
+// ADR-036 P1 (GH #146): the files-list chunks were stored under the PARENT
+// snapshot's OWN destination — routing must key off the PARENT's
+// destination_id, not the increment currently being dispatched (in practice a
+// chain shares one destination, but this is correct even if it doesn't).
+// restoreDestinationRoute is reused here even though this isn't a restore: it
+// is exactly the same operation — reading already-stored chunks back — so the
+// same cp/local/s3_compat routing decision applies. For a "local" parent no
+// presign is minted (mirrors the restore path): the agent reads the parent's
+// files-list from its own local disk, keyed by hash, using the returned
+// Hash/Size (URL empty).
 func (s *Service) PresignParentFilesList(ctx context.Context, tenantID, parentSnapshotID uuid.UUID) ([]agentcmd.RestoreChunk, error) {
 	entries, err := s.repo.ListManifest(ctx, tenantID, parentSnapshotID)
 	if err != nil {
@@ -1492,23 +1684,29 @@ func (s *Service) PresignParentFilesList(ctx context.Context, tenantID, parentSn
 	if err != nil {
 		return nil, err
 	}
+
+	parentSnap, err := s.repo.GetSnapshot(ctx, tenantID, parentSnapshotID)
+	if err != nil {
+		return nil, err
+	}
+	_, _, presigner, drerr := s.restoreDestinationRoute(ctx, parentSnap)
+	if drerr != nil {
+		return nil, drerr
+	}
+	urls, err := s.mintRestoreChunks(ctx, tenantID, presigner, chunks)
+	if err != nil {
+		return nil, err
+	}
+
 	out := make([]agentcmd.RestoreChunk, 0, len(hashes))
 	// Preserve chunk order (a files.list is a stream; concat order matters).
 	for _, h := range hashes {
-		c, ok := chunks[h]
+		rc, ok := urls[h]
 		if !ok {
 			return nil, domain.Internal("parent_files_list_chunk_missing",
 				"a files-list chunk for the parent snapshot is no longer stored")
 		}
-		expected := chunkS3Key(tenantID, h)
-		if c.S3Key != expected {
-			return nil, domain.Internal("backup_chunk_key_mismatch", "stored chunk key is outside the tenant prefix")
-		}
-		url, perr := s.store.PresignGet(ctx, c.S3Key, s.presignTTL)
-		if perr != nil {
-			return nil, domain.Internal("backup_presign_get_failed", "failed to presign files-list chunk").WithCause(perr)
-		}
-		out = append(out, agentcmd.RestoreChunk{Hash: h, URL: url, Size: c.Size})
+		out = append(out, rc)
 	}
 	return out, nil
 }
@@ -2795,6 +2993,11 @@ func (s *Service) EnqueueScheduledBackup(ctx context.Context, sched Schedule) er
 		runID = run.ID
 	}
 
+	// ADR-036 P1: resolve the site's configured default destination ONCE up
+	// front so both branches below stamp it identically (see CreateBackup for
+	// the identical run-now-path rationale).
+	destinationID := s.resolveDefaultDestination(ctx, sched.TenantID, sched.SiteID)
+
 	// ADR-048 P5: when the schedule opts into incremental backups, consult the
 	// auto-base chain rule and stamp the snapshot's chain fields. When the toggle
 	// is OFF this takes the existing full path (zero-value CreateSnapshotInput +
@@ -2818,13 +3021,15 @@ func (s *Service) EnqueueScheduledBackup(ctx context.Context, sched Schedule) er
 			BaseSnapshotID:   res.BaseSnapshotID,
 			ChainID:          res.ChainID,
 			Generation:       res.Generation,
+			DestinationID:    destinationID,
 		})
 	} else {
 		snap, err = s.repo.CreateSnapshot(ctx, CreateSnapshotInput{
-			TenantID:     sched.TenantID,
-			SiteID:       sched.SiteID,
-			Kind:         sched.Kind,
-			AgeRecipient: si.AgeRecipient,
+			TenantID:      sched.TenantID,
+			SiteID:        sched.SiteID,
+			Kind:          sched.Kind,
+			AgeRecipient:  si.AgeRecipient,
+			DestinationID: destinationID,
 		})
 	}
 	if err != nil {

--- a/apps/api/internal/backup/snapshot_read_chain_test.go
+++ b/apps/api/internal/backup/snapshot_read_chain_test.go
@@ -111,6 +111,7 @@ func TestIncrementalSnapshotReadRoundTrip(t *testing.T) {
 		int64(1),                                  // cycle_files_deleted
 		int64(2048),                               // cycle_bytes_uploaded
 		false,                                     // locked (m49 Track C)
+		pgtype.UUID{},                             // destination_id (null; M7/ADR-036 P1)
 	}}
 
 	snap, err := scanSnapshotWithChainFields(row)
@@ -191,6 +192,7 @@ func TestFullSnapshotReadRoundTrip(t *testing.T) {
 		int64(0),             // cycle_files_deleted
 		int64(0),             // cycle_bytes_uploaded
 		false,                // locked (m49 Track C)
+		pgtype.UUID{},        // destination_id (null; M7/ADR-036 P1)
 	}}
 
 	snap, err := scanSnapshotWithChainFields(row)

--- a/apps/api/internal/backup/worker.go
+++ b/apps/api/internal/backup/worker.go
@@ -139,6 +139,24 @@ func (w *BackupWorker) Work(ctx context.Context, job *river.Job[BackupArgs]) err
 	// new fields are omitempty on the wire).
 	scope := w.svc.scheduleBackupScope(ctx, a.TenantID, snap.SiteID)
 
+	// ADR-036 P1 storage adapter (GH #146): resolve which backend the agent
+	// should land this snapshot's chunks against. snap.DestinationID == Nil
+	// (the overwhelming common case) short-circuits inside
+	// DestinationInfoForSnapshot to {Kind: "cp"} without touching destLookup —
+	// see its doc for the invariant this preserves.
+	destInfo, derr := w.svc.DestinationInfoForSnapshot(ctx, snap)
+	if derr != nil {
+		return w.fail(ctx, snap, "destination unresolved: "+derr.Error())
+	}
+	destKind := destInfo.Kind
+	if destKind == "" {
+		destKind = DestinationKindCP
+	}
+	var destCfg agentcmd.DestinationConfig
+	if destKind == DestinationKindLocal {
+		destCfg.LocalPathPrefix = destInfo.PathPrefix
+	}
+
 	// ADR-048/ADR-051: when the job was enqueued as incremental, build an
 	// IncrementalBackupRequest; otherwise use the existing BackupRequest.
 	// A no-parent gen-0 base-increment also takes the incremental path: its
@@ -184,6 +202,9 @@ func (w *BackupWorker) Work(ctx context.Context, job *river.Job[BackupArgs]) err
 			ExcludePaths:      scope.ExcludePaths,
 			ExcludeExtensions: scope.ExcludeExtensions,
 			ExcludeFileSizeMB: scope.ExcludeFileSizeMB,
+			// ADR-036 P1 storage adapter (GH #146).
+			DestinationKind:   destKind,
+			DestinationConfig: destCfg,
 		}
 		resp, err = w.cmd.IncrementalBackup(ctx, snap.SiteID, si.URL, incReq)
 	} else {
@@ -203,6 +224,9 @@ func (w *BackupWorker) Work(ctx context.Context, job *river.Job[BackupArgs]) err
 			ExcludePaths:      scope.ExcludePaths,
 			ExcludeExtensions: scope.ExcludeExtensions,
 			ExcludeFileSizeMB: scope.ExcludeFileSizeMB,
+			// ADR-036 P1 storage adapter (GH #146).
+			DestinationKind:   destKind,
+			DestinationConfig: destCfg,
 		}
 		resp, err = w.cmd.Backup(ctx, snap.SiteID, si.URL, req)
 	}

--- a/apps/api/internal/backup/worker_incremental_test.go
+++ b/apps/api/internal/backup/worker_incremental_test.go
@@ -184,6 +184,18 @@ func TestBackupWorker_DispatchesIncrementalRequest(t *testing.T) {
 		Generation:       1,
 	}
 	repo.setSnapshot(snap)
+	// ADR-036 P1 (GH #146): PresignParentFilesList now loads the parent
+	// snapshot's own row to resolve ITS destination routing — register a
+	// completed parent (DestinationID zero == managed/cp, same as the
+	// increment above) so the lookup succeeds.
+	repo.setSnapshot(Snapshot{
+		ID:           parentID,
+		TenantID:     tenantID,
+		SiteID:       snap.SiteID,
+		Kind:         KindFull,
+		Status:       StatusCompleted,
+		AgeRecipient: snap.AgeRecipient,
+	})
 	// ADR-051: the parent must carry a files-list manifest entry so the dispatch
 	// can presign its chunks for the agent's prev-map.
 	flHash := "abc123def456abc123def456abc123def456abc123def456abc123def456abcd"

--- a/apps/api/internal/blobstore/blobstore.go
+++ b/apps/api/internal/blobstore/blobstore.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -38,13 +39,22 @@ type Config struct {
 	AccessKey      string
 	SecretKey      string
 	ForcePathStyle bool
+	// PathPrefix, when set, is applied to every object key this Store
+	// touches (Put/Get/Head/Delete/List/PresignPut/PresignGet) — ADR-036 P1
+	// (GH #146): an operator-configured s3_compat destination may set a key
+	// prefix so multiple sites/tenants can share one customer bucket under
+	// separate namespaces. Leading/trailing slashes are normalised; empty
+	// (the default) means "bucket root", the pre-existing behaviour for the
+	// CP-global Store.
+	PathPrefix string
 }
 
 // Store is the S3-compatible object-store handle.
 type Store struct {
-	client    *s3.Client
-	presigner *s3.PresignClient
-	bucket    string
+	client     *s3.Client
+	presigner  *s3.PresignClient
+	bucket     string
+	pathPrefix string
 }
 
 // New builds a Store from static credentials and a (possibly custom) endpoint.
@@ -80,14 +90,43 @@ func New(cfg Config) (*Store, error) {
 	}
 	client := s3.New(s3.Options{}, opts...)
 	return &Store{
-		client:    client,
-		presigner: s3.NewPresignClient(client),
-		bucket:    cfg.Bucket,
+		client:     client,
+		presigner:  s3.NewPresignClient(client),
+		bucket:     cfg.Bucket,
+		pathPrefix: strings.Trim(cfg.PathPrefix, "/"),
 	}, nil
 }
 
 // Bucket returns the configured bucket name.
 func (s *Store) Bucket() string { return s.bucket }
+
+// PathPrefix returns the configured (normalised, no leading/trailing slash)
+// key prefix, or "" when this Store addresses the bucket root.
+func (s *Store) PathPrefix() string { return s.pathPrefix }
+
+// prefixedKey returns the key this Store actually addresses in the bucket:
+// PathPrefix (if any) + key. EVERY S3 API call this Store makes MUST route
+// its key through this method so a destination's configured prefix applies
+// consistently across Put/Get/Head/Delete/List/PresignPut/PresignGet — a
+// backup PUT and its matching restore GET always agree on the same
+// effective key.
+func (s *Store) prefixedKey(key string) string {
+	if s.pathPrefix == "" {
+		return key
+	}
+	return s.pathPrefix + "/" + strings.TrimPrefix(key, "/")
+}
+
+// unprefixedKey strips this Store's PathPrefix (if any) back off a key
+// returned by the S3 API (List/ListWithModified), so callers always see the
+// same logical/canonical key they would pass to Head/Get/Delete — regardless
+// of whether this Store has a configured PathPrefix.
+func (s *Store) unprefixedKey(key string) string {
+	if s.pathPrefix == "" {
+		return key
+	}
+	return strings.TrimPrefix(key, s.pathPrefix+"/")
+}
 
 // EnsureBucket attempts to create the configured bucket if it doesn't exist.
 // Best-effort + non-fatal: an error here does NOT abort startup. The bucket
@@ -229,7 +268,7 @@ func (s *Store) GetViaPresign(ctx context.Context, key string) (io.ReadCloser, e
 func (s *Store) Head(ctx context.Context, key string) (exists bool, size int64, err error) {
 	out, herr := s.client.HeadObject(ctx, &s3.HeadObjectInput{
 		Bucket: aws.String(s.bucket),
-		Key:    aws.String(key),
+		Key:    aws.String(s.prefixedKey(key)),
 	})
 	if herr != nil {
 		if isNotFound(herr) {
@@ -254,7 +293,7 @@ func (s *Store) Head(ctx context.Context, key string) (exists bool, size int64, 
 func (s *Store) Delete(ctx context.Context, key string) error {
 	url, err := s.presigner.PresignDeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(s.bucket),
-		Key:    aws.String(key),
+		Key:    aws.String(s.prefixedKey(key)),
 	}, s3.WithPresignExpires(60*time.Second))
 	if err != nil {
 		return fmt.Errorf("blobstore: presign delete %q: %w", key, err)
@@ -281,7 +320,7 @@ func (s *Store) List(ctx context.Context, prefix string) ([]string, error) {
 	var keys []string
 	p := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
 		Bucket: aws.String(s.bucket),
-		Prefix: aws.String(prefix),
+		Prefix: aws.String(s.prefixedKey(prefix)),
 	})
 	for p.HasMorePages() {
 		page, err := p.NextPage(ctx)
@@ -290,7 +329,7 @@ func (s *Store) List(ctx context.Context, prefix string) ([]string, error) {
 		}
 		for _, o := range page.Contents {
 			if o.Key != nil {
-				keys = append(keys, *o.Key)
+				keys = append(keys, s.unprefixedKey(*o.Key))
 			}
 		}
 	}
@@ -312,7 +351,7 @@ func (s *Store) ListWithModified(ctx context.Context, prefix string) ([]ObjectIn
 	var out []ObjectInfo
 	p := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
 		Bucket: aws.String(s.bucket),
-		Prefix: aws.String(prefix),
+		Prefix: aws.String(s.prefixedKey(prefix)),
 	})
 	for p.HasMorePages() {
 		page, err := p.NextPage(ctx)
@@ -323,7 +362,7 @@ func (s *Store) ListWithModified(ctx context.Context, prefix string) ([]ObjectIn
 			if o.Key == nil {
 				continue
 			}
-			info := ObjectInfo{Key: *o.Key}
+			info := ObjectInfo{Key: s.unprefixedKey(*o.Key)}
 			if o.LastModified != nil {
 				info.LastModified = *o.LastModified
 			}
@@ -339,7 +378,7 @@ func (s *Store) ListWithModified(ctx context.Context, prefix string) ([]ObjectIn
 func (s *Store) PresignPut(ctx context.Context, key string, ttl time.Duration) (string, error) {
 	req, err := s.presigner.PresignPutObject(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(s.bucket),
-		Key:    aws.String(key),
+		Key:    aws.String(s.prefixedKey(key)),
 	}, s3.WithPresignExpires(ttl))
 	if err != nil {
 		return "", fmt.Errorf("blobstore: presign put %q: %w", key, err)
@@ -353,7 +392,7 @@ func (s *Store) PresignPut(ctx context.Context, key string, ttl time.Duration) (
 func (s *Store) PresignGet(ctx context.Context, key string, ttl time.Duration) (string, error) {
 	req, err := s.presigner.PresignGetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),
-		Key:    aws.String(key),
+		Key:    aws.String(s.prefixedKey(key)),
 	}, s3.WithPresignExpires(ttl))
 	if err != nil {
 		return "", fmt.Errorf("blobstore: presign get %q: %w", key, err)

--- a/apps/api/internal/blobstore/blobstore_test.go
+++ b/apps/api/internal/blobstore/blobstore_test.go
@@ -1,0 +1,92 @@
+package blobstore
+
+// blobstore_test.go — ADR-036 P1 (GH #146 security review) unit tests for
+// Store.PathPrefix: an s3_compat destination's configured key prefix must be
+// applied CONSISTENTLY to both the backup PUT and the restore GET presign, so
+// the two sides always agree on the same effective object key. Presigning is
+// computed entirely offline (SigV4 needs no network round trip), so these
+// tests need no real S3 endpoint.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStore_PresignPutAndGet_ApplyPathPrefixConsistently(t *testing.T) {
+	store, err := New(Config{
+		Bucket:         "test-bucket",
+		Endpoint:       "http://127.0.0.1:9000",
+		ForcePathStyle: true,
+		AccessKey:      "test-access-key",
+		SecretKey:      "test-secret-key",
+		Region:         "us-east-1",
+		PathPrefix:     "/clientA/backups/",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if store.PathPrefix() != "clientA/backups" {
+		t.Fatalf("PathPrefix() = %q, want %q (leading/trailing slashes normalised)", store.PathPrefix(), "clientA/backups")
+	}
+
+	putURL, err := store.PresignPut(context.Background(), "chunks/tenant-x/hash123", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("PresignPut: %v", err)
+	}
+	getURL, err := store.PresignGet(context.Background(), "chunks/tenant-x/hash123", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("PresignGet: %v", err)
+	}
+
+	const wantSegment = "/test-bucket/clientA/backups/chunks/tenant-x/hash123"
+	if !strings.Contains(putURL, wantSegment) {
+		t.Errorf("PresignPut URL = %s, want to contain %q", putURL, wantSegment)
+	}
+	if !strings.Contains(getURL, wantSegment) {
+		t.Errorf("PresignGet URL = %s, want to contain %q", getURL, wantSegment)
+	}
+
+	// Backup PUT and restore GET must agree on the SAME effective key (the
+	// path component; the query string legitimately differs — different verb,
+	// different signature/expiry).
+	putPath := strings.SplitN(putURL, "?", 2)[0]
+	getPath := strings.SplitN(getURL, "?", 2)[0]
+	if putPath != getPath {
+		t.Errorf("PUT and GET presign paths differ: put=%q get=%q", putPath, getPath)
+	}
+}
+
+func TestStore_PresignPut_NoPathPrefix_BucketRootUnchanged(t *testing.T) {
+	store, err := New(Config{
+		Bucket:         "test-bucket",
+		Endpoint:       "http://127.0.0.1:9000",
+		ForcePathStyle: true,
+		AccessKey:      "test-access-key",
+		SecretKey:      "test-secret-key",
+		Region:         "us-east-1",
+		// PathPrefix intentionally empty — the CP-global default Store's
+		// pre-existing, unchanged behaviour.
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if store.PathPrefix() != "" {
+		t.Fatalf("PathPrefix() = %q, want empty (managed/legacy default)", store.PathPrefix())
+	}
+
+	url, err := store.PresignPut(context.Background(), "chunks/tenant-x/hash123", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("PresignPut: %v", err)
+	}
+	const wantSegment = "/test-bucket/chunks/tenant-x/hash123"
+	if !strings.Contains(url, wantSegment) {
+		t.Errorf("PresignPut URL = %s, want to contain %q (bucket-root, no prefix)", url, wantSegment)
+	}
+	// The prefixed segment (with any client-side prefix) must NOT appear —
+	// belt-and-suspenders against an accidental leading-slash double segment.
+	if strings.Contains(url, "//chunks") {
+		t.Errorf("PresignPut URL has a spurious double slash: %s", url)
+	}
+}

--- a/apps/api/internal/blobstore/registry.go
+++ b/apps/api/internal/blobstore/registry.go
@@ -30,16 +30,32 @@ type DestinationLookup interface {
 	DecryptSecret(d sitedestination.SiteDestination) (string, error)
 }
 
+// storeCacheKey scopes the Store cache by BOTH tenant and destination id.
+// Defense-in-depth (security review, GH #146 Phase 1): destination_id is
+// globally unique and every row is always same-tenant today, so keying by
+// destination id alone was not exploitable — but a future feature that let a
+// snapshot carry a cross-tenant destination_id (e.g. a snapshot clone/copy, or
+// an admin re-point) would otherwise let a cache HIT hand back the WRONG
+// tenant's bucket Store, since only the cache-MISS path re-validates the
+// tenant via GetByID's InTenantTx + tenant_id filter. Keying by (tenantID,
+// destID) makes a cross-tenant hit structurally impossible: it can only ever
+// be a miss, which re-runs the tenant-scoped lookup.
+type storeCacheKey struct {
+	tenantID uuid.UUID
+	destID   uuid.UUID
+}
+
 // Registry caches per-destination Stores so each customer-owned S3 bucket gets
-// exactly one *Store across the process. The cache is keyed by destination ID
-// (a stable UUID) and built lazily on first use.
+// exactly one *Store across the process. The cache is keyed by
+// (tenantID, destinationID) — see storeCacheKey — and built lazily on first
+// use.
 //
 // The default Store is the CP-global bucket the API was booted with — every
 // snapshot whose destination_id is uuid.Nil routes there, matching the legacy
 // 0.9.6 behaviour.
 type Registry struct {
 	mu     sync.RWMutex
-	stores map[uuid.UUID]*Store
+	stores map[storeCacheKey]*Store
 
 	repo         DestinationLookup
 	defaultStore *Store
@@ -51,7 +67,7 @@ type Registry struct {
 // DestinationID or StoreForSnapshot will error.
 func NewRegistry(defaultStore *Store, repo DestinationLookup) *Registry {
 	return &Registry{
-		stores:       make(map[uuid.UUID]*Store),
+		stores:       make(map[storeCacheKey]*Store),
 		repo:         repo,
 		defaultStore: defaultStore,
 	}
@@ -77,9 +93,13 @@ func (r *Registry) StoreForSnapshot(ctx context.Context, snap SnapshotLike) (*St
 	}
 
 	// Cached path: avoid the DB round-trip + S3 client construction on every
-	// presign. We hold a RWMutex so concurrent reads don't serialise.
+	// presign. We hold a RWMutex so concurrent reads don't serialise. Keyed by
+	// (tenantID, destinationID) — see storeCacheKey — so a cache HIT can never
+	// cross a tenant boundary; only a cache MISS reaches GetByID, which is the
+	// tenant-scoped re-validation.
+	cacheKey := storeCacheKey{tenantID: snap.TenantID, destID: snap.DestinationID}
 	r.mu.RLock()
-	if store, ok := r.stores[snap.DestinationID]; ok {
+	if store, ok := r.stores[cacheKey]; ok {
 		r.mu.RUnlock()
 		return store, nil
 	}
@@ -112,6 +132,14 @@ func (r *Registry) StoreForSnapshot(ctx context.Context, snap SnapshotLike) (*St
 		return nil, fmt.Errorf("blobstore registry: decrypt secret: %w", err)
 	}
 
+	// PathPrefix (GH #146 security review, functional gap): apply the
+	// operator-configured key prefix to the Store itself so every PUT/GET
+	// this Store mints — backup upload AND restore download alike — lands
+	// under the SAME <path_prefix>/chunks/<tenant>/<hash> key, consistently.
+	// backup_chunks.s3_key stays the bare canonical key regardless (dedup +
+	// the tenant-scope assertion in mintRestoreChunks operate on that
+	// unprefixed layer); the Store applies its prefix transparently at the
+	// object-storage transport layer, so no caller needs to know about it.
 	store, err := New(Config{
 		Endpoint:       d.Endpoint,
 		Region:         d.Region,
@@ -119,6 +147,7 @@ func (r *Registry) StoreForSnapshot(ctx context.Context, snap SnapshotLike) (*St
 		AccessKey:      d.AccessKeyID,
 		SecretKey:      secret,
 		ForcePathStyle: d.ForcePathStyle,
+		PathPrefix:     d.PathPrefix,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("blobstore registry: build store: %w", err)
@@ -128,19 +157,21 @@ func (r *Registry) StoreForSnapshot(ctx context.Context, snap SnapshotLike) (*St
 	// between our read-unlock and this write-lock; resolve that by checking
 	// once more under the write lock and reusing whichever Store landed first.
 	r.mu.Lock()
-	if existing, ok := r.stores[d.ID]; ok {
+	if existing, ok := r.stores[cacheKey]; ok {
 		r.mu.Unlock()
 		return existing, nil
 	}
-	r.stores[d.ID] = store
+	r.stores[cacheKey] = store
 	r.mu.Unlock()
 	return store, nil
 }
 
 // Invalidate evicts a destination's cached Store. Called after the operator
 // updates the credentials so the next presign re-fetches with the new key.
-func (r *Registry) Invalidate(id uuid.UUID) {
+// tenantID must be the destination's own tenant — the cache is keyed by
+// (tenantID, destinationID), see storeCacheKey.
+func (r *Registry) Invalidate(tenantID, id uuid.UUID) {
 	r.mu.Lock()
-	delete(r.stores, id)
+	delete(r.stores, storeCacheKey{tenantID: tenantID, destID: id})
 	r.mu.Unlock()
 }

--- a/apps/api/internal/blobstore/registry_test.go
+++ b/apps/api/internal/blobstore/registry_test.go
@@ -1,0 +1,247 @@
+package blobstore
+
+// registry_test.go — ADR-036 P1 (GH #146) unit tests for the presign-routing
+// Registry: an s3_compat destination must route to a Store built against the
+// CUSTOMER's own bucket (never the CP-managed default), a nil/cp destination
+// must route to the default Store, and a local destination must error (the
+// agent writes chunks to disk itself; the CP never presigns for it).
+//
+// blobstore.New performs no network I/O, so these tests need no real S3
+// endpoint — only a fake DestinationLookup.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/sitedestination"
+)
+
+// fakeDestLookup is a minimal DestinationLookup double: GetByID/GetDefaultForSite
+// return a canned row per id; DecryptSecret returns a fixed plaintext without
+// touching age at all (blobstore.New never performs network I/O, so no real
+// credentials are required to prove routing picked the right bucket).
+type fakeDestLookup struct {
+	byID map[uuid.UUID]sitedestination.SiteDestination
+}
+
+var errFakeNotFound = errors.New("fake destination lookup: not found")
+
+// GetByID mirrors the real Repo.GetByID's tenant scoping (RLS + an explicit
+// `WHERE id=$1 AND tenant_id=$2`): a row only resolves when BOTH the id AND
+// the requested tenantID match. This is load-bearing for
+// TestRegistry_StoreForSnapshot_CacheIsTenantScoped — a fake that ignored
+// tenantID here would never be able to prove the cache-miss path re-validates
+// the tenant.
+func (f *fakeDestLookup) GetByID(_ context.Context, tenantID, id uuid.UUID) (sitedestination.SiteDestination, error) {
+	d, ok := f.byID[id]
+	if !ok || d.TenantID != tenantID {
+		return sitedestination.SiteDestination{}, errFakeNotFound
+	}
+	return d, nil
+}
+
+func (f *fakeDestLookup) GetDefaultForSite(_ context.Context, _, _ uuid.UUID) (sitedestination.SiteDestination, error) {
+	return sitedestination.SiteDestination{}, errFakeNotFound
+}
+
+func (f *fakeDestLookup) DecryptSecret(_ sitedestination.SiteDestination) (string, error) {
+	return "plaintext-secret", nil
+}
+
+func TestRegistry_StoreForSnapshot_S3CompatRoutesToCustomerBucket(t *testing.T) {
+	defaultStore, err := New(Config{Bucket: "cp-managed-bucket"})
+	if err != nil {
+		t.Fatalf("default store: %v", err)
+	}
+	tenantID := uuid.New()
+	destID := uuid.New()
+	lookup := &fakeDestLookup{byID: map[uuid.UUID]sitedestination.SiteDestination{
+		destID: {
+			ID:          destID,
+			TenantID:    tenantID,
+			Kind:        sitedestination.KindS3Compat,
+			Bucket:      "customer-owned-bucket",
+			Region:      "us-east-1",
+			AccessKeyID: "AKIAEXAMPLE",
+		},
+	}}
+	registry := NewRegistry(defaultStore, lookup)
+
+	store, err := registry.StoreForSnapshot(context.Background(), SnapshotLike{
+		TenantID:      tenantID,
+		SiteID:        uuid.New(),
+		DestinationID: destID,
+	})
+	if err != nil {
+		t.Fatalf("StoreForSnapshot: %v", err)
+	}
+	if store == defaultStore {
+		t.Fatal("expected the customer-specific store, got the default (CP-managed) store")
+	}
+	if store.Bucket() != "customer-owned-bucket" {
+		t.Errorf("Bucket() = %q, want %q", store.Bucket(), "customer-owned-bucket")
+	}
+
+	// A second call for the same destination must hit the cache (same *Store),
+	// not rebuild — StoreForSnapshot's doc promises exactly one Store per
+	// destination ID across the process.
+	store2, err := registry.StoreForSnapshot(context.Background(), SnapshotLike{
+		TenantID: tenantID, SiteID: uuid.New(), DestinationID: destID,
+	})
+	if err != nil {
+		t.Fatalf("StoreForSnapshot (cached): %v", err)
+	}
+	if store2 != store {
+		t.Error("expected the cached Store on a second call for the same destination id")
+	}
+}
+
+func TestRegistry_StoreForSnapshot_NilDestinationUsesDefault(t *testing.T) {
+	defaultStore, err := New(Config{Bucket: "cp-managed-bucket"})
+	if err != nil {
+		t.Fatalf("default store: %v", err)
+	}
+	registry := NewRegistry(defaultStore, &fakeDestLookup{byID: map[uuid.UUID]sitedestination.SiteDestination{}})
+
+	store, err := registry.StoreForSnapshot(context.Background(), SnapshotLike{
+		TenantID:      uuid.New(),
+		SiteID:        uuid.New(),
+		DestinationID: uuid.Nil,
+	})
+	if err != nil {
+		t.Fatalf("StoreForSnapshot: %v", err)
+	}
+	if store != defaultStore {
+		t.Error("expected the default store for a nil destination id")
+	}
+}
+
+func TestRegistry_StoreForSnapshot_CPKindUsesDefault(t *testing.T) {
+	defaultStore, err := New(Config{Bucket: "cp-managed-bucket"})
+	if err != nil {
+		t.Fatalf("default store: %v", err)
+	}
+	tenantID := uuid.New()
+	destID := uuid.New()
+	lookup := &fakeDestLookup{byID: map[uuid.UUID]sitedestination.SiteDestination{
+		destID: {ID: destID, TenantID: tenantID, Kind: sitedestination.KindCP},
+	}}
+	registry := NewRegistry(defaultStore, lookup)
+
+	store, err := registry.StoreForSnapshot(context.Background(), SnapshotLike{
+		TenantID: tenantID, SiteID: uuid.New(), DestinationID: destID,
+	})
+	if err != nil {
+		t.Fatalf("StoreForSnapshot: %v", err)
+	}
+	if store != defaultStore {
+		t.Error("expected the default store for a kind=cp destination row")
+	}
+}
+
+func TestRegistry_StoreForSnapshot_LocalErrors(t *testing.T) {
+	defaultStore, err := New(Config{Bucket: "cp-managed-bucket"})
+	if err != nil {
+		t.Fatalf("default store: %v", err)
+	}
+	tenantID := uuid.New()
+	destID := uuid.New()
+	lookup := &fakeDestLookup{byID: map[uuid.UUID]sitedestination.SiteDestination{
+		destID: {ID: destID, TenantID: tenantID, Kind: sitedestination.KindLocal},
+	}}
+	registry := NewRegistry(defaultStore, lookup)
+
+	if _, err := registry.StoreForSnapshot(context.Background(), SnapshotLike{
+		TenantID: tenantID, SiteID: uuid.New(), DestinationID: destID,
+	}); err == nil {
+		t.Fatal("expected an error for a local destination (agent writes to disk; the CP never presigns for it)")
+	}
+}
+
+// TestRegistry_StoreForSnapshot_CacheIsTenantScoped is the security-review
+// (GH #146 Phase 1, LOW defense-in-depth) regression proof: the Store cache
+// is keyed by (tenantID, destinationID), so a cache HIT can never cross a
+// tenant boundary — only a cache MISS is possible for an unfamiliar tenant,
+// and a miss always re-runs the tenant-scoped GetByID. destination_id is
+// globally unique and always same-tenant today, so this scenario (the same
+// destID requested under two different tenants) cannot occur via the real
+// repo — this test simulates it directly against the Registry to prove the
+// cache key itself enforces the invariant, independent of whether the
+// scenario is reachable today.
+func TestRegistry_StoreForSnapshot_CacheIsTenantScoped(t *testing.T) {
+	defaultStore, err := New(Config{Bucket: "cp-managed-bucket"})
+	if err != nil {
+		t.Fatalf("default store: %v", err)
+	}
+	tenantA := uuid.New()
+	tenantB := uuid.New()
+	destID := uuid.New()
+
+	// The fake lookup only recognises destID under tenantA — mirroring the
+	// real GetByID's tenant-scoped WHERE clause (a destination row belongs to
+	// exactly one tenant).
+	lookup := &fakeDestLookup{byID: map[uuid.UUID]sitedestination.SiteDestination{
+		destID: {ID: destID, TenantID: tenantA, Kind: sitedestination.KindS3Compat, Bucket: "tenant-a-bucket", AccessKeyID: "AKIA"},
+	}}
+	registry := NewRegistry(defaultStore, lookup)
+
+	// First call, tenantA: resolves + caches under (tenantA, destID).
+	storeA, err := registry.StoreForSnapshot(context.Background(), SnapshotLike{
+		TenantID: tenantA, SiteID: uuid.New(), DestinationID: destID,
+	})
+	if err != nil {
+		t.Fatalf("StoreForSnapshot (tenantA): %v", err)
+	}
+	if storeA.Bucket() != "tenant-a-bucket" {
+		t.Fatalf("Bucket() = %q, want tenant-a-bucket", storeA.Bucket())
+	}
+
+	// Second call, the SAME destID but tenantB. If the cache were keyed by
+	// destID alone, this would return storeA (tenantA's bucket!) WITHOUT ever
+	// re-checking the tenant — the exact gap the security review flagged.
+	// Keyed by (tenantID, destID), this MUST miss the cache and re-run
+	// GetByID, which fails for tenantB (the fake correctly models the
+	// destination belonging only to tenantA).
+	if _, err := registry.StoreForSnapshot(context.Background(), SnapshotLike{
+		TenantID: tenantB, SiteID: uuid.New(), DestinationID: destID,
+	}); err == nil {
+		t.Fatal("expected an error for tenantB (destination belongs to tenantA) — the cache must not leak tenantA's store across the tenant boundary")
+	}
+}
+
+// TestRegistry_StoreForSnapshot_PathPrefixApplied is the functional-gap fix
+// proof: an s3_compat destination's configured path_prefix must be applied to
+// the Store it builds, so every key the Store touches lands under
+// <path_prefix>/<key> instead of the bucket root.
+func TestRegistry_StoreForSnapshot_PathPrefixApplied(t *testing.T) {
+	defaultStore, err := New(Config{Bucket: "cp-managed-bucket"})
+	if err != nil {
+		t.Fatalf("default store: %v", err)
+	}
+	tenantID := uuid.New()
+	destID := uuid.New()
+	lookup := &fakeDestLookup{byID: map[uuid.UUID]sitedestination.SiteDestination{
+		destID: {
+			ID:          destID,
+			TenantID:    tenantID,
+			Kind:        sitedestination.KindS3Compat,
+			Bucket:      "customer-owned-bucket",
+			PathPrefix:  "/clientA/backups/",
+			AccessKeyID: "AKIAEXAMPLE",
+		},
+	}}
+	registry := NewRegistry(defaultStore, lookup)
+
+	store, err := registry.StoreForSnapshot(context.Background(), SnapshotLike{
+		TenantID: tenantID, SiteID: uuid.New(), DestinationID: destID,
+	})
+	if err != nil {
+		t.Fatalf("StoreForSnapshot: %v", err)
+	}
+	if store.PathPrefix() != "clientA/backups" {
+		t.Errorf("PathPrefix() = %q, want %q (leading/trailing slashes normalised)", store.PathPrefix(), "clientA/backups")
+	}
+}

--- a/apps/api/internal/db/sqlc/backups.sql.go
+++ b/apps/api/internal/db/sqlc/backups.sql.go
@@ -72,7 +72,7 @@ SET status = 'completed',
     finished_at = now(),
     updated_at = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, progress, progress_updated_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at
+RETURNING id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, destination_id, progress, progress_updated_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at
 `
 
 type CompleteBackupSnapshotParams struct {
@@ -103,6 +103,7 @@ func (q *Queries) CompleteBackupSnapshot(ctx context.Context, arg CompleteBackup
 		&i.Error,
 		&i.Archived,
 		&i.Locked,
+		&i.DestinationID,
 		&i.Progress,
 		&i.ProgressUpdatedAt,
 		&i.StartedAt,
@@ -125,17 +126,18 @@ func (q *Queries) CompleteBackupSnapshot(ctx context.Context, arg CompleteBackup
 const createBackupSnapshot = `-- name: CreateBackupSnapshot :one
 
 
-INSERT INTO backup_snapshots (tenant_id, site_id, created_by, kind, status, age_recipient)
-VALUES ($1, $2, $3, $4, 'pending', $5)
-RETURNING id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, progress, progress_updated_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at
+INSERT INTO backup_snapshots (tenant_id, site_id, created_by, kind, status, age_recipient, destination_id)
+VALUES ($1, $2, $3, $4, 'pending', $5, $6)
+RETURNING id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, destination_id, progress, progress_updated_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at
 `
 
 type CreateBackupSnapshotParams struct {
-	TenantID     uuid.UUID   `json:"tenant_id"`
-	SiteID       uuid.UUID   `json:"site_id"`
-	CreatedBy    pgtype.UUID `json:"created_by"`
-	Kind         string      `json:"kind"`
-	AgeRecipient string      `json:"age_recipient"`
+	TenantID      uuid.UUID   `json:"tenant_id"`
+	SiteID        uuid.UUID   `json:"site_id"`
+	CreatedBy     pgtype.UUID `json:"created_by"`
+	Kind          string      `json:"kind"`
+	AgeRecipient  string      `json:"age_recipient"`
+	DestinationID pgtype.UUID `json:"destination_id"`
 }
 
 // M4 backup queries. Every statement is tenant-scoped both explicitly
@@ -143,6 +145,9 @@ type CreateBackupSnapshotParams struct {
 // ---------------------------------------------------------------------------
 // backup_snapshots
 // ---------------------------------------------------------------------------
+// destination_id (M7 / ADR-036 P1): NULL routes to the legacy CP-managed
+// bucket; a non-null value is the site_destinations row the caller already
+// resolved (the site's configured default) before creating the snapshot.
 func (q *Queries) CreateBackupSnapshot(ctx context.Context, arg CreateBackupSnapshotParams) (BackupSnapshot, error) {
 	row := q.db.QueryRow(ctx, createBackupSnapshot,
 		arg.TenantID,
@@ -150,6 +155,7 @@ func (q *Queries) CreateBackupSnapshot(ctx context.Context, arg CreateBackupSnap
 		arg.CreatedBy,
 		arg.Kind,
 		arg.AgeRecipient,
+		arg.DestinationID,
 	)
 	var i BackupSnapshot
 	err := row.Scan(
@@ -165,6 +171,7 @@ func (q *Queries) CreateBackupSnapshot(ctx context.Context, arg CreateBackupSnap
 		&i.Error,
 		&i.Archived,
 		&i.Locked,
+		&i.DestinationID,
 		&i.Progress,
 		&i.ProgressUpdatedAt,
 		&i.StartedAt,
@@ -310,7 +317,7 @@ SET status = 'failed',
     finished_at = now(),
     updated_at = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, progress, progress_updated_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at
+RETURNING id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, destination_id, progress, progress_updated_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at
 `
 
 type FailBackupSnapshotParams struct {
@@ -335,6 +342,7 @@ func (q *Queries) FailBackupSnapshot(ctx context.Context, arg FailBackupSnapshot
 		&i.Error,
 		&i.Archived,
 		&i.Locked,
+		&i.DestinationID,
 		&i.Progress,
 		&i.ProgressUpdatedAt,
 		&i.StartedAt,
@@ -771,7 +779,7 @@ func (q *Queries) GetBackupSiteInfo(ctx context.Context, arg GetBackupSiteInfoPa
 }
 
 const getBackupSnapshot = `-- name: GetBackupSnapshot :one
-SELECT id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, progress, progress_updated_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at FROM backup_snapshots
+SELECT id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, destination_id, progress, progress_updated_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at FROM backup_snapshots
 WHERE id = $1 AND tenant_id = $2
 `
 
@@ -796,6 +804,7 @@ func (q *Queries) GetBackupSnapshot(ctx context.Context, arg GetBackupSnapshotPa
 		&i.Error,
 		&i.Archived,
 		&i.Locked,
+		&i.DestinationID,
 		&i.Progress,
 		&i.ProgressUpdatedAt,
 		&i.StartedAt,
@@ -912,7 +921,7 @@ func (q *Queries) ListBackupSiteIDsForTenant(ctx context.Context, tenantID uuid.
 }
 
 const listBackupSnapshotsForSite = `-- name: ListBackupSnapshotsForSite :many
-SELECT id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, progress, progress_updated_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at FROM backup_snapshots
+SELECT id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, destination_id, progress, progress_updated_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at FROM backup_snapshots
 WHERE tenant_id = $1 AND site_id = $2
 ORDER BY created_at DESC
 LIMIT $3 OFFSET $4
@@ -952,6 +961,7 @@ func (q *Queries) ListBackupSnapshotsForSite(ctx context.Context, arg ListBackup
 			&i.Error,
 			&i.Archived,
 			&i.Locked,
+			&i.DestinationID,
 			&i.Progress,
 			&i.ProgressUpdatedAt,
 			&i.StartedAt,
@@ -1094,7 +1104,7 @@ func (q *Queries) ListDueBackupSchedules(ctx context.Context, arg ListDueBackupS
 }
 
 const listExpiredBackupSnapshots = `-- name: ListExpiredBackupSnapshots :many
-SELECT id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, progress, progress_updated_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at FROM backup_snapshots
+SELECT id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, destination_id, progress, progress_updated_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at FROM backup_snapshots
 WHERE tenant_id = $1
   AND status = 'completed'
   AND archived = false
@@ -1132,6 +1142,7 @@ func (q *Queries) ListExpiredBackupSnapshots(ctx context.Context, arg ListExpire
 			&i.Error,
 			&i.Archived,
 			&i.Locked,
+			&i.DestinationID,
 			&i.Progress,
 			&i.ProgressUpdatedAt,
 			&i.StartedAt,
@@ -1361,7 +1372,7 @@ const markBackupSnapshotRunning = `-- name: MarkBackupSnapshotRunning :one
 UPDATE backup_snapshots
 SET status = 'running', started_at = now(), updated_at = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, progress, progress_updated_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at
+RETURNING id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, destination_id, progress, progress_updated_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at
 `
 
 type MarkBackupSnapshotRunningParams struct {
@@ -1385,6 +1396,7 @@ func (q *Queries) MarkBackupSnapshotRunning(ctx context.Context, arg MarkBackupS
 		&i.Error,
 		&i.Archived,
 		&i.Locked,
+		&i.DestinationID,
 		&i.Progress,
 		&i.ProgressUpdatedAt,
 		&i.StartedAt,
@@ -1427,7 +1439,7 @@ SET progress = $3,
     progress_updated_at = now(),
     updated_at = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, progress, progress_updated_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at
+RETURNING id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, destination_id, progress, progress_updated_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at
 `
 
 type UpdateBackupSnapshotProgressParams struct {
@@ -1458,6 +1470,7 @@ func (q *Queries) UpdateBackupSnapshotProgress(ctx context.Context, arg UpdateBa
 		&i.Error,
 		&i.Archived,
 		&i.Locked,
+		&i.DestinationID,
 		&i.Progress,
 		&i.ProgressUpdatedAt,
 		&i.StartedAt,

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -187,6 +187,7 @@ type BackupSnapshot struct {
 	Error              string             `json:"error"`
 	Archived           bool               `json:"archived"`
 	Locked             bool               `json:"locked"`
+	DestinationID      pgtype.UUID        `json:"destination_id"`
 	Progress           []byte             `json:"progress"`
 	ProgressUpdatedAt  pgtype.Timestamptz `json:"progress_updated_at"`
 	StartedAt          pgtype.Timestamptz `json:"started_at"`
@@ -674,6 +675,24 @@ type SiteDbSizeHistory struct {
 	TableCount  int32     `json:"table_count"`
 	ScannedAt   time.Time `json:"scanned_at"`
 	CreatedAt   time.Time `json:"created_at"`
+}
+
+type SiteDestination struct {
+	ID             uuid.UUID   `json:"id"`
+	TenantID       uuid.UUID   `json:"tenant_id"`
+	SiteID         pgtype.UUID `json:"site_id"`
+	Kind           string      `json:"kind"`
+	Label          string      `json:"label"`
+	Endpoint       string      `json:"endpoint"`
+	Region         string      `json:"region"`
+	Bucket         string      `json:"bucket"`
+	PathPrefix     string      `json:"path_prefix"`
+	AccessKeyID    string      `json:"access_key_id"`
+	SecretKeyEnc   []byte      `json:"secret_key_enc"`
+	ForcePathStyle bool        `json:"force_path_style"`
+	IsDefault      bool        `json:"is_default"`
+	CreatedAt      time.Time   `json:"created_at"`
+	UpdatedAt      time.Time   `json:"updated_at"`
 }
 
 type SiteEmailConfig struct {

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -312,6 +312,9 @@ type Querier interface {
 	// ---------------------------------------------------------------------------
 	// backup_snapshots
 	// ---------------------------------------------------------------------------
+	// destination_id (M7 / ADR-036 P1): NULL routes to the legacy CP-managed
+	// bucket; a non-null value is the site_destinations row the caller already
+	// resolved (the site's configured default) before creating the snapshot.
 	CreateBackupSnapshot(ctx context.Context, arg CreateBackupSnapshotParams) (BackupSnapshot, error)
 	CreateClient(ctx context.Context, arg CreateClientParams) (Client, error)
 	// Upsert: ON CONFLICT DO NOTHING so the caller detects "already a member" by


### PR DESCRIPTION
The destinations feature was config+agent complete but the CP never sent the chosen destination to a backup run, so backups always went to managed storage regardless of what you configured. Now: persist destination_id, resolve the site default at backup time, thread the destination to the agent (full/incremental/restore), route presign per-destination (incl the incremental parent + the restore reads, which bypassed the registry → wrong bucket), tenant-scope the Store cache, apply the s3 path_prefix. Agent gains the restore-from-local-disk path + hash-traversal hardening. Managed path byte-for-byte unchanged; S3 secrets never leave the CP; no cross-tenant bucket. Security review SHIP. api + agent, no migration. agent 0.61.14.

Part 1 of destinations completeness (Phase 2 = free-plan gate, deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for choosing where backups are stored and restored from, including managed storage, local folders, and S3-compatible buckets.
  * Restores now read directly from the selected destination, improving flexibility for different storage setups.

* **Bug Fixes**
  * Fixed backup destinations that previously did not work correctly for managed storage, local storage, and S3-compatible buckets.
  * Improved restore handling so S3-compatible uploads/downloads are signed securely without exposing storage credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->