### PR TITLE
feat(billing): gate managed backup storage behind a paid plan (M16 Phase B, dark)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.34] - 2026-07-07
+
+### Added
+
+- Hosted service only: managed backup storage is now a paid-plan feature. On a paid plan, backups can use WPMgr's managed storage as before; on the free plan, backups must target your own storage (a local folder or your own S3-compatible bucket, configured under Destinations). This is inactive by default, ships behind the hosted-billing switch, and does not affect self-hosted installs, which always keep managed storage. Restoring an existing backup is never restricted, even after a plan change, and tenants that already exist when the gate is enabled keep their managed storage.
+
 ## [0.61.33] - 2026-07-07
 
 ### Fixed

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -870,6 +870,12 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 		// local-path at dispatch/restore time. Wired alongside SetRegistry so
 		// the two never drift out of sync.
 		backupSvc.SetDestinationLookup(&destLookupAdapter{svc: siteDestSvc})
+		// M16 Phase B: gate a NEW run against the CP-managed destination
+		// behind the managed-backup-storage entitlement. billingSvc.Enabled()
+		// being false (WPMGR_HOSTED off) makes CheckManagedBackupStorage a
+		// permanent no-op, so this wiring is safe to leave on unconditionally
+		// exactly like siteSvc.SetBillingGate above.
+		backupSvc.SetBillingGate(billingSvc)
 		// M5.7 P4: wire the manifest index writer so SubmitManifest writes
 		// tenant/<tenantID>/site/<siteID>/backup/<snapshotID>/manifest.json
 		// via the same CP-global store used for presigning. Best-effort:
@@ -2043,6 +2049,10 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	authH := auth.NewHandler(authSvc, sessions, oidcProvider, newTenant)
 	authH.SetSecureCookies(cfg.IsProduction())
 	authH.SetHosted(cfg.Hosted.Enabled)
+	// M16 Phase B: Me.managed_storage_allowed. billingSvc.ManagedStorageAllowed
+	// no-ops to true when WPMGR_HOSTED is off, so this wiring is safe to leave
+	// on unconditionally, exactly like SetHosted above.
+	authH.SetManagedStorageResolver(billingSvc)
 
 	filesH := files.NewHandler(filesSvc, auditRec)
 

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -43304,9 +43304,15 @@ func (s *Me) encodeFields(e *jx.Encoder) {
 			s.Hosted.Encode(e)
 		}
 	}
+	{
+		if s.ManagedStorageAllowed.Set {
+			e.FieldStart("managed_storage_allowed")
+			s.ManagedStorageAllowed.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfMe = [7]string{
+var jsonFieldsNameOfMe = [8]string{
 	0: "user",
 	1: "memberships",
 	2: "active_tenant_id",
@@ -43314,6 +43320,7 @@ var jsonFieldsNameOfMe = [7]string{
 	4: "role",
 	5: "portal",
 	6: "hosted",
+	7: "managed_storage_allowed",
 }
 
 // Decode decodes Me from json.
@@ -43402,6 +43409,16 @@ func (s *Me) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"hosted\"")
+			}
+		case "managed_storage_allowed":
+			if err := func() error {
+				s.ManagedStorageAllowed.Reset()
+				if err := s.ManagedStorageAllowed.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"managed_storage_allowed\"")
 			}
 		default:
 			return d.Skip()

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -15521,6 +15521,14 @@ type Me struct {
 	// every self-hosted deployment and on any hosted instance before M16 Phase B billing ships. The
 	// frontend uses this to gate billing/plan UI.
 	Hosted OptBool `json:"hosted"`
+	// Whether the active tenant's plan currently permits routing a NEW backup to CP-managed storage (M16
+	// Phase B). Always true on a self-hosted or hosted-billing-disabled instance, and true for every
+	// paid plan; false only for a free-plan tenant under WPMGR_HOSTED. This is a coarse, role-safe
+	// display signal for the operator-facing /destinations page (which any operator can view, unlike the
+	// owner-only /billing summary) — it is NOT the authoritative gate; the backup-run endpoints
+	// enforce the real check server-side and return 402 byo_destination_required when denied.
+	// Restoring/downloading an existing backup is never gated by this or any other check.
+	ManagedStorageAllowed OptBool `json:"managed_storage_allowed"`
 }
 
 // GetUser returns the value of User.
@@ -15558,6 +15566,11 @@ func (s *Me) GetHosted() OptBool {
 	return s.Hosted
 }
 
+// GetManagedStorageAllowed returns the value of ManagedStorageAllowed.
+func (s *Me) GetManagedStorageAllowed() OptBool {
+	return s.ManagedStorageAllowed
+}
+
 // SetUser sets the value of User.
 func (s *Me) SetUser(val User) {
 	s.User = val
@@ -15591,6 +15604,11 @@ func (s *Me) SetPortal(val OptMePortal) {
 // SetHosted sets the value of Hosted.
 func (s *Me) SetHosted(val OptBool) {
 	s.Hosted = val
+}
+
+// SetManagedStorageAllowed sets the value of ManagedStorageAllowed.
+func (s *Me) SetManagedStorageAllowed(val OptBool) {
+	s.ManagedStorageAllowed = val
 }
 
 func (*Me) getMeRes()        {}

--- a/apps/api/internal/auth/handler.go
+++ b/apps/api/internal/auth/handler.go
@@ -23,6 +23,19 @@ import (
 // the tenant package, keeping the dependency one-directional.
 type TenantCreator func(ctx context.Context, name, slug string) (uuid.UUID, error)
 
+// ManagedStorageResolver reports whether a tenant's CURRENT plan permits
+// routing a new backup to CP-managed storage (M16 Phase B). Implemented by
+// *internal/billing.Service (wired in cmd/wpmgr) via its ManagedStorageAllowed
+// accessor; a nil value disables the check and every Me response reports true
+// — mirrors billing.Service's own !enabled short-circuit (Unlimited().
+// ManagedBackupStorage) so self-host and any test that does not wire this
+// never see a spuriously-false signal. This local interface keeps the auth
+// package free of a direct billing import (mirrors site.BillingGate /
+// backup.BillingGate).
+type ManagedStorageResolver interface {
+	ManagedStorageAllowed(ctx context.Context, tenantID uuid.UUID) (bool, error)
+}
+
 // Handler serves the authentication endpoints (/auth/*).
 type Handler struct {
 	svc       *Service
@@ -36,6 +49,10 @@ type Handler struct {
 	// response so the frontend can gate billing/plan UI. Set after
 	// construction via SetHosted.
 	hosted bool
+	// managedStorage resolves Me.managed_storage_allowed (M16 Phase B).
+	// Optional: nil makes every Me response report true. Set after
+	// construction via SetManagedStorageResolver.
+	managedStorage ManagedStorageResolver
 }
 
 // NewHandler builds an auth Handler.
@@ -55,6 +72,33 @@ func (h *Handler) SetSecureCookies(secure bool) {
 // startup.
 func (h *Handler) SetHosted(hosted bool) {
 	h.hosted = hosted
+}
+
+// SetManagedStorageResolver wires the M16 Phase B managed_storage_allowed
+// signal on every Me response. Call this after NewHandler, before serving.
+// Optional: when never called, every Me response reports
+// managed_storage_allowed=true (matches the resolver-nil / hosted-disabled
+// default exactly).
+func (h *Handler) SetManagedStorageResolver(r ManagedStorageResolver) {
+	h.managedStorage = r
+}
+
+// managedStorageAllowed resolves Me.managed_storage_allowed for tenantID.
+// Fails OPEN (true) on a nil resolver, a nil tenant (unauthenticated/no
+// active org yet), or a resolution error — this is a coarse DISPLAY signal
+// only (see ManagedStorageResolver's doc comment); the authoritative gate is
+// internal/backup's server-side enforcement, which must never be bypassed by
+// a Me-response hiccup, and conversely a hiccup here must never wrongly show
+// an operator a blocked-storage banner they cannot act on correctly.
+func (h *Handler) managedStorageAllowed(ctx context.Context, tenantID uuid.UUID) bool {
+	if h.managedStorage == nil || tenantID == uuid.Nil {
+		return true
+	}
+	allowed, err := h.managedStorage.ManagedStorageAllowed(ctx, tenantID)
+	if err != nil {
+		return true
+	}
+	return allowed
 }
 
 // Register mounts the auth routes on the root engine group.
@@ -131,7 +175,7 @@ func (h *Handler) login(c *gin.Context) {
 					httpx.Error(c, domain.Internal("session_failed", "failed to establish session").WithCause(err))
 					return
 				}
-				out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted)
+				out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant))
 				c.JSON(http.StatusOK, &out)
 				return
 			}
@@ -148,7 +192,7 @@ func (h *Handler) login(c *gin.Context) {
 	if !h.issueSessionOrChallenge(c, res, "") {
 		return
 	}
-	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted)
+	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant))
 	c.JSON(http.StatusOK, &out)
 }
 
@@ -191,7 +235,7 @@ func (h *Handler) register(c *gin.Context) {
 		if !h.issueSessionOrChallenge(c, res, "") {
 			return
 		}
-		out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted)
+		out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant))
 		c.JSON(http.StatusCreated, &out)
 		return
 	}
@@ -287,7 +331,7 @@ func (h *Handler) verifyEmail(c *gin.Context) {
 	if !h.issueSessionOrChallenge(c, res, "") {
 		return
 	}
-	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted)
+	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant))
 	c.JSON(http.StatusOK, &out)
 }
 
@@ -344,7 +388,7 @@ func (h *Handler) me(c *gin.Context) {
 		httpx.Error(c, err)
 		return
 	}
-	out := toMe(u, memberships, p.TenantID, h.hosted)
+	out := toMe(u, memberships, p.TenantID, h.hosted, h.managedStorageAllowed(c.Request.Context(), p.TenantID))
 	// m66 — portal principal: enrich Me with scope, role, and portal branding.
 	enrichMePortal(c.Request.Context(), &out, p, h.svc.repo)
 	c.JSON(http.StatusOK, &out)
@@ -373,7 +417,7 @@ func (h *Handler) updateProfile(c *gin.Context) {
 		httpx.Error(c, err)
 		return
 	}
-	out := toMe(u, memberships, p.TenantID, h.hosted)
+	out := toMe(u, memberships, p.TenantID, h.hosted, h.managedStorageAllowed(c.Request.Context(), p.TenantID))
 	c.JSON(http.StatusOK, &out)
 }
 
@@ -508,12 +552,17 @@ func (h *Handler) oidcCallback(c *gin.Context) {
 		return
 	}
 	// Non-2FA path: session was issued; redirect the browser to the SPA home.
-	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted)
+	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant))
 	c.JSON(http.StatusOK, &out)
 }
 
-func toMe(u User, memberships []Membership, active uuid.UUID, hosted bool) gen.Me {
-	me := gen.Me{User: toAPIUser(u), Memberships: toAPIMemberships(memberships), Hosted: gen.NewOptBool(hosted)}
+func toMe(u User, memberships []Membership, active uuid.UUID, hosted, managedStorageAllowed bool) gen.Me {
+	me := gen.Me{
+		User:                  toAPIUser(u),
+		Memberships:           toAPIMemberships(memberships),
+		Hosted:                gen.NewOptBool(hosted),
+		ManagedStorageAllowed: gen.NewOptBool(managedStorageAllowed),
+	}
 	if active != uuid.Nil {
 		me.ActiveTenantID = gen.NewOptUUID(active)
 	}

--- a/apps/api/internal/auth/managed_storage_test.go
+++ b/apps/api/internal/auth/managed_storage_test.go
@@ -1,0 +1,83 @@
+package auth
+
+// managed_storage_test.go — M16 Phase B Me.managed_storage_allowed tests.
+//
+// White-box, in-memory; no database. Mirrors the fail-open contract every
+// other billing-adjacent optional dependency in this codebase uses (nil
+// resolver / nil tenant / resolver error all resolve to true, matching
+// Unlimited().ManagedBackupStorage's self-host default).
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// fakeManagedStorageResolver is an in-memory ManagedStorageResolver double.
+type fakeManagedStorageResolver struct {
+	allowed bool
+	err     error
+	calls   []uuid.UUID
+}
+
+func (f *fakeManagedStorageResolver) ManagedStorageAllowed(_ context.Context, tenantID uuid.UUID) (bool, error) {
+	f.calls = append(f.calls, tenantID)
+	return f.allowed, f.err
+}
+
+func TestManagedStorageAllowed_NilResolverIsTrue(t *testing.T) {
+	h := &Handler{}
+	if !h.managedStorageAllowed(context.Background(), uuid.New()) {
+		t.Fatal("expected true when no ManagedStorageResolver is wired")
+	}
+}
+
+func TestManagedStorageAllowed_NilTenantIsTrue(t *testing.T) {
+	resolver := &fakeManagedStorageResolver{allowed: false}
+	h := &Handler{managedStorage: resolver}
+	if !h.managedStorageAllowed(context.Background(), uuid.Nil) {
+		t.Fatal("expected true for a nil (no active org yet) tenant, regardless of the resolver's answer")
+	}
+	if len(resolver.calls) != 0 {
+		t.Fatal("expected the resolver to never be called for a nil tenant")
+	}
+}
+
+func TestManagedStorageAllowed_ResolverErrorFailsOpen(t *testing.T) {
+	resolver := &fakeManagedStorageResolver{err: errors.New("boom")}
+	h := &Handler{managedStorage: resolver}
+	if !h.managedStorageAllowed(context.Background(), uuid.New()) {
+		t.Fatal("expected true (fail open) when the resolver errors — this is a display signal, never a gate")
+	}
+}
+
+func TestManagedStorageAllowed_PropagatesResolverAnswer(t *testing.T) {
+	tenantID := uuid.New()
+	resolver := &fakeManagedStorageResolver{allowed: false}
+	h := &Handler{managedStorage: resolver}
+	if h.managedStorageAllowed(context.Background(), tenantID) {
+		t.Fatal("expected false to propagate from the resolver for a real, resolvable tenant")
+	}
+	if len(resolver.calls) != 1 || resolver.calls[0] != tenantID {
+		t.Fatalf("expected exactly 1 resolver call for tenant %v, got %v", tenantID, resolver.calls)
+	}
+}
+
+// ---- toMe --------------------------------------------------------------
+
+func TestToMe_SetsManagedStorageAllowed(t *testing.T) {
+	me := toMe(User{}, nil, uuid.New(), true, false)
+	if !me.Hosted.Value {
+		t.Fatal("expected Hosted to propagate through toMe")
+	}
+	if !me.ManagedStorageAllowed.Set || me.ManagedStorageAllowed.Value {
+		t.Fatalf("expected ManagedStorageAllowed = false (set), got %+v", me.ManagedStorageAllowed)
+	}
+
+	me2 := toMe(User{}, nil, uuid.New(), true, true)
+	if !me2.ManagedStorageAllowed.Set || !me2.ManagedStorageAllowed.Value {
+		t.Fatalf("expected ManagedStorageAllowed = true (set), got %+v", me2.ManagedStorageAllowed)
+	}
+}

--- a/apps/api/internal/auth/twofa_handler.go
+++ b/apps/api/internal/auth/twofa_handler.go
@@ -127,7 +127,7 @@ func (h *Handler) twoFATOTPComplete(c *gin.Context) {
 	}
 
 	remaining, _ := h.svc.CountRecoveryCodes(c.Request.Context(), res.User.ID)
-	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted)
+	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant))
 	c.JSON(http.StatusOK, gin.H{
 		"me":                        out,
 		"recovery_codes_remaining":  remaining,
@@ -175,7 +175,7 @@ func (h *Handler) twoFARecoveryComplete(c *gin.Context) {
 		h.issueDeviceCookieWithLabel(c, res, label)
 	}
 
-	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted)
+	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant))
 	c.JSON(http.StatusOK, gin.H{
 		"me":                       out,
 		"recovery_codes_remaining": remaining,
@@ -256,7 +256,7 @@ func (h *Handler) twoFAWebAuthnFinish(c *gin.Context) {
 		h.issueDeviceCookieWithLabel(c, res, label)
 	}
 
-	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted)
+	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant))
 	c.JSON(http.StatusOK, &out)
 }
 

--- a/apps/api/internal/backup/billing_gate_test.go
+++ b/apps/api/internal/backup/billing_gate_test.go
@@ -1,0 +1,330 @@
+package backup
+
+// billing_gate_test.go — M16 Phase B managed-backup-storage gate tests.
+//
+// White-box, in-memory fakes; no database. The CRITICAL regression guard here
+// is TestPlanRestore_NeverConsultsBillingGate: a customer must always be able
+// to get existing data back, even after losing the managed-storage
+// entitlement, so restore/download must never call BillingGate at all.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// fakeBillingGate is an in-memory backup.BillingGate double. err (if set) is
+// returned by every CheckManagedBackupStorage call; calls records every
+// tenantID the gate was invoked with, so a test can assert it was (or was
+// NOT) consulted at all.
+type fakeBillingGate struct {
+	err   error
+	calls []uuid.UUID
+}
+
+func (f *fakeBillingGate) CheckManagedBackupStorage(_ context.Context, tenantID uuid.UUID) error {
+	f.calls = append(f.calls, tenantID)
+	return f.err
+}
+
+var errGateDenied = domain.PaymentRequired("byo_destination_required", "Free plan backups must go to your own storage.")
+
+// TestServiceSetBillingGate_Wires proves SetBillingGate lands the gate on the
+// Service's own `billing` field (unlike site.SetBillingGate, backup.Service
+// has no second repo instance to double-wire — see BillingGate's doc comment
+// for why that concern doesn't apply here).
+func TestServiceSetBillingGate_Wires(t *testing.T) {
+	svc := &Service{}
+	gate := &fakeBillingGate{}
+	svc.SetBillingGate(gate)
+	if svc.billing != BillingGate(gate) {
+		t.Fatal("SetBillingGate did not wire the gate onto the service")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// destinationIsManaged
+// ---------------------------------------------------------------------------
+
+func TestDestinationIsManaged(t *testing.T) {
+	tenantID := uuid.New()
+	cpDestID := uuid.New()
+	localDestID := uuid.New()
+	s3DestID := uuid.New()
+	missingDestID := uuid.New()
+
+	dl := newFakeDestLookup()
+	dl.infoByID[cpDestID] = DestinationInfo{ID: cpDestID, Kind: DestinationKindCP}
+	dl.infoByID[localDestID] = DestinationInfo{ID: localDestID, Kind: DestinationKindLocal}
+	dl.infoByID[s3DestID] = DestinationInfo{ID: s3DestID, Kind: DestinationKindS3Compat}
+	// missingDestID intentionally absent from dl.infoByID -> DestinationInfo errors.
+
+	svc := &Service{destLookup: dl}
+
+	tests := []struct {
+		name string
+		dest uuid.UUID
+		want bool
+	}{
+		{"nil destination id is the managed default", uuid.Nil, true},
+		{"explicit cp destination is managed", cpDestID, true},
+		{"local destination is BYO, not managed", localDestID, false},
+		{"s3_compat destination is BYO, not managed", s3DestID, false},
+		{"a lookup failure fails open (gate skipped)", missingDestID, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := svc.destinationIsManaged(context.Background(), tenantID, tt.dest)
+			if got != tt.want {
+				t.Errorf("destinationIsManaged(%v) = %v, want %v", tt.dest, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDestinationIsManaged_NoDestLookupWired_NonNilID_NotManaged(t *testing.T) {
+	// Cannot happen operationally (SetDestinationLookup pairs with
+	// SetBillingGate) but must degrade safely: a non-nil destination id with
+	// no destLookup wired is treated as "not managed" (gate skipped), not
+	// "managed" (which would incorrectly block the run).
+	svc := &Service{}
+	if svc.destinationIsManaged(context.Background(), uuid.New(), uuid.New()) {
+		t.Fatal("expected false (gate skipped) when destLookup is unwired for a non-nil destination id")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// checkManagedBackupStorageGate
+// ---------------------------------------------------------------------------
+
+func TestCheckManagedBackupStorageGate_NilBillingGate_Allowed(t *testing.T) {
+	svc := &Service{}
+	if err := svc.checkManagedBackupStorageGate(context.Background(), uuid.New(), uuid.Nil); err != nil {
+		t.Fatalf("expected nil with no billing gate wired, got %v", err)
+	}
+}
+
+func TestCheckManagedBackupStorageGate_BYODestination_GateNeverCalled(t *testing.T) {
+	tenantID := uuid.New()
+	destID := uuid.New()
+	dl := newFakeDestLookup()
+	dl.infoByID[destID] = DestinationInfo{ID: destID, Kind: DestinationKindLocal}
+	gate := &fakeBillingGate{err: errGateDenied}
+	svc := &Service{destLookup: dl, billing: gate}
+
+	if err := svc.checkManagedBackupStorageGate(context.Background(), tenantID, destID); err != nil {
+		t.Fatalf("a BYO destination must never be gated, got %v", err)
+	}
+	if len(gate.calls) != 0 {
+		t.Fatalf("expected the billing gate to never be called for a BYO destination, got %d calls", len(gate.calls))
+	}
+}
+
+func TestCheckManagedBackupStorageGate_ManagedDestination_CallsGate(t *testing.T) {
+	tenantID := uuid.New()
+	gate := &fakeBillingGate{err: errGateDenied}
+	svc := &Service{billing: gate}
+
+	err := svc.checkManagedBackupStorageGate(context.Background(), tenantID, uuid.Nil)
+	if err != errGateDenied {
+		t.Fatalf("expected the gate's error to propagate, got %v", err)
+	}
+	if len(gate.calls) != 1 || gate.calls[0] != tenantID {
+		t.Fatalf("expected exactly 1 gate call for tenant %v, got %v", tenantID, gate.calls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreateBackup (manual/run-now)
+// ---------------------------------------------------------------------------
+
+func TestCreateBackup_ManagedDestinationGateDenied_Returns402(t *testing.T) {
+	repo := &wiringRepo{}
+	enq := &recordingEnqueuer{}
+	svc := buildWiringSvc(repo, enq, time.Now())
+	gate := &fakeBillingGate{err: errGateDenied}
+	svc.billing = gate
+
+	_, err := svc.CreateBackup(context.Background(), uuid.New(), uuid.New(), uuid.New(), KindFull)
+	if err != errGateDenied {
+		t.Fatalf("expected the gate error to propagate, got %v", err)
+	}
+	if len(repo.createInputs) != 0 {
+		t.Fatalf("expected NO snapshot to be created when the managed-storage gate denies, got %d", len(repo.createInputs))
+	}
+}
+
+func TestCreateBackup_BYODestination_AllowedEvenWhenGateWouldDeny(t *testing.T) {
+	siteID := uuid.New()
+	destID := uuid.New()
+	dl := newFakeDestLookup()
+	dl.defaultBySite[siteID] = destID
+	dl.infoByID[destID] = DestinationInfo{ID: destID, Kind: DestinationKindS3Compat}
+
+	repo := &wiringRepo{}
+	enq := &recordingEnqueuer{}
+	svc := buildWiringSvc(repo, enq, time.Now())
+	svc.destLookup = dl
+	gate := &fakeBillingGate{err: errGateDenied}
+	svc.billing = gate
+
+	if _, err := svc.CreateBackup(context.Background(), uuid.New(), siteID, uuid.New(), KindFull); err != nil {
+		t.Fatalf("a BYO destination must never be gated, got %v", err)
+	}
+	if len(repo.createInputs) != 1 || repo.createInputs[0].DestinationID != destID {
+		t.Fatalf("expected 1 snapshot with DestinationID=%v, got %+v", destID, repo.createInputs)
+	}
+	if len(gate.calls) != 0 {
+		t.Fatal("expected the billing gate to never be called for a BYO destination")
+	}
+}
+
+func TestCreateBackup_NilBillingGate_Allowed(t *testing.T) {
+	repo := &wiringRepo{}
+	enq := &recordingEnqueuer{}
+	svc := buildWiringSvc(repo, enq, time.Now())
+	// billing intentionally left nil (self-host / not-yet-wired) — the
+	// zero-value default from buildWiringSvc.
+
+	if _, err := svc.CreateBackup(context.Background(), uuid.New(), uuid.New(), uuid.New(), KindFull); err != nil {
+		t.Fatalf("expected no error with a nil billing gate, got %v", err)
+	}
+	if len(repo.createInputs) != 1 {
+		t.Fatalf("expected 1 snapshot to be created, got %d", len(repo.createInputs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EnqueueScheduledBackup (scheduled path) — gated run records 'skipped', never throws
+// ---------------------------------------------------------------------------
+
+func TestEnqueueScheduledBackup_ManagedDestinationGateDenied_RecordsSkippedNotError(t *testing.T) {
+	tenantID, siteID, scheduleID := uuid.New(), uuid.New(), uuid.New()
+	repo := &wiringRepo{}
+	enq := &recordingEnqueuer{}
+	runStore := &fakeScheduleRunStore{}
+	gate := &fakeBillingGate{err: errGateDenied}
+
+	svc := &Service{
+		repo:         repo,
+		enqueuer:     enq,
+		sites:        fakeSites{info: SiteInfo{Enrolled: true, AgeRecipient: "age1test"}},
+		clock:        fakeClock{t: time.Now()},
+		scheduleRuns: runStore,
+		billing:      gate,
+	}
+
+	sched := Schedule{
+		ID:        scheduleID,
+		TenantID:  tenantID,
+		SiteID:    siteID,
+		Cadence:   CadenceDaily,
+		Kind:      KindFull,
+		NextRunAt: time.Now(),
+	}
+
+	if err := svc.EnqueueScheduledBackup(context.Background(), sched); err != nil {
+		t.Fatalf("EnqueueScheduledBackup must not return an error on a gated scheduled run (must record skipped instead), got %v", err)
+	}
+	if len(repo.createInputs) != 0 {
+		t.Fatalf("expected NO snapshot to be created for a gated scheduled run, got %d", len(repo.createInputs))
+	}
+	if len(enq.plainCalls) != 0 || len(enq.chainCalls) != 0 {
+		t.Fatal("expected no enqueue call for a gated scheduled run")
+	}
+	if len(runStore.rows) != 1 {
+		t.Fatalf("expected exactly 1 schedule_run row, got %d", len(runStore.rows))
+	}
+	if runStore.rows[0].Status != ScheduleRunStatusSkipped {
+		t.Fatalf("schedule run status = %q, want %q", runStore.rows[0].Status, ScheduleRunStatusSkipped)
+	}
+	if len(gate.calls) != 1 {
+		t.Fatalf("expected exactly 1 gate call, got %d", len(gate.calls))
+	}
+}
+
+func TestEnqueueScheduledBackup_BYODestination_Allowed(t *testing.T) {
+	tenantID, siteID, scheduleID := uuid.New(), uuid.New(), uuid.New()
+	destID := uuid.New()
+	dl := newFakeDestLookup()
+	dl.defaultBySite[siteID] = destID
+	dl.infoByID[destID] = DestinationInfo{ID: destID, Kind: DestinationKindLocal, PathPrefix: "wpmgr-backups"}
+	gate := &fakeBillingGate{err: errGateDenied}
+
+	repo := &wiringRepo{}
+	enq := &recordingEnqueuer{}
+	runStore := &fakeScheduleRunStore{}
+	svc := &Service{
+		repo:         repo,
+		enqueuer:     enq,
+		sites:        fakeSites{info: SiteInfo{Enrolled: true, AgeRecipient: "age1test"}},
+		clock:        fakeClock{t: time.Now()},
+		scheduleRuns: runStore,
+		billing:      gate,
+		destLookup:   dl,
+	}
+
+	sched := Schedule{ID: scheduleID, TenantID: tenantID, SiteID: siteID, Cadence: CadenceDaily, Kind: KindFull, NextRunAt: time.Now()}
+	if err := svc.EnqueueScheduledBackup(context.Background(), sched); err != nil {
+		t.Fatalf("EnqueueScheduledBackup: %v", err)
+	}
+	if len(repo.createInputs) != 1 {
+		t.Fatalf("expected 1 snapshot created for a BYO destination even with a denying gate, got %d", len(repo.createInputs))
+	}
+	if len(gate.calls) != 0 {
+		t.Fatalf("expected the gate to never be called for a BYO destination, got %d calls", len(gate.calls))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Restore is NEVER gated — the core business invariant.
+// ---------------------------------------------------------------------------
+
+// TestPlanRestore_NeverConsultsBillingGate is the CRITICAL regression guard:
+// a customer must always be able to get an existing backup back, even after
+// losing the managed-storage entitlement. A managed (uuid.Nil destination)
+// snapshot restore must succeed even when a wired billing gate would deny
+// EVERY call, and the gate must never be invoked at all.
+func TestPlanRestore_NeverConsultsBillingGate(t *testing.T) {
+	tenantID := uuid.New()
+	siteID := uuid.New()
+	snapID := uuid.New()
+
+	repo := &fakeWorkerRepo{fakeRepo: newFakeRepo(), workerManifests: map[uuid.UUID][]ManifestEntry{}}
+	snap := Snapshot{
+		ID:           snapID,
+		TenantID:     tenantID,
+		SiteID:       siteID,
+		Kind:         KindFull,
+		Status:       StatusCompleted,
+		AgeRecipient: "age1test",
+		// DestinationID intentionally zero (uuid.Nil) — the managed path,
+		// exactly the case a CREATE-time gate would fire on.
+	}
+	repo.setSnapshot(snap)
+	repo.workerManifests[snapID] = []ManifestEntry{
+		{Path: "wp-content/plugins/foo/foo.php", EntryKind: EntryKindFile, ChunkHashes: []string{"aaa"}, Size: 100},
+	}
+
+	fp := &fakePresigner{}
+	gate := &fakeBillingGate{err: errGateDenied} // would deny EVERY call if ever consulted
+	svc := &Service{
+		repo:       repo,
+		sites:      &fakeSiteLookup{},
+		store:      &tenantPresigner{tenantID: tenantID, inner: fp},
+		clock:      fakeClock{t: time.Now()},
+		presignTTL: time.Hour,
+		billing:    gate,
+	}
+
+	if _, _, _, err := svc.PlanRestore(context.Background(), tenantID, snapID, RestoreSelection{Full: true}, "restore-regression", "https://cp.test/progress"); err != nil {
+		t.Fatalf("PlanRestore must succeed for a managed snapshot even with a denying billing gate wired, got %v", err)
+	}
+	if len(gate.calls) != 0 {
+		t.Fatalf("PlanRestore must NEVER consult the managed-backup-storage billing gate — restore is never gated — got %d calls", len(gate.calls))
+	}
+}

--- a/apps/api/internal/backup/destination_routing_test.go
+++ b/apps/api/internal/backup/destination_routing_test.go
@@ -239,6 +239,72 @@ func TestBackupWorker_ManagedDestination_EmitsCPKind(t *testing.T) {
 	}
 }
 
+// TestBackupWorker_DestinationLookupError_FailsClosed_NeverFallsBackToManaged
+// pins a load-bearing security invariant (M16 Phase B security review):
+// the CREATE-time managed-storage billing gate's destinationIsManaged fails
+// OPEN (skips the gate) when a destination lookup errors — see
+// billing_gate_test.go's "a lookup failure fails open" case — and that is
+// only safe because the EXECUTE-time path here fails CLOSED instead. For a
+// non-Nil destination_id, Work() calls DestinationInfoForSnapshot; if THAT
+// errors it must call w.fail (terminal FailSnapshot) and must NEVER fall
+// through to dispatching the backup to the agent at all — in particular it
+// must never silently default to the CP-managed destination kind. If a
+// future refactor ever made this path fall back to managed storage on a
+// lookup error, it would turn the create-time fail-open into a real
+// free-tier storage bypass. This test is non-vacuous: destLookup and the
+// commander are both wired so a CP fallback, if it ever happened, would be
+// directly observable (cmd.lastBackup would be non-nil with
+// DestinationKind=="cp").
+func TestBackupWorker_DestinationLookupError_FailsClosed_NeverFallsBackToManaged(t *testing.T) {
+	repo := &fakeWorkerRepo{fakeRepo: newFakeRepo()}
+	cmd := &fakeCommander{ok: true}
+	tenantID := uuid.New()
+	snapshotID := uuid.New()
+	destID := uuid.New()
+
+	snap := Snapshot{
+		ID:            snapshotID,
+		TenantID:      tenantID,
+		SiteID:        uuid.New(),
+		Kind:          KindFull,
+		Status:        StatusPending,
+		AgeRecipient:  "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p",
+		DestinationID: destID, // non-Nil: DestinationInfoForSnapshot will actually consult destLookup.
+	}
+	repo.setSnapshot(snap)
+
+	// destLookup is wired but has NO entry for destID, so DestinationInfo
+	// errors (domain.NotFound) — mirrors a destination row deleted/corrupted
+	// between CreateBackup and dispatch.
+	dl := newFakeDestLookup()
+
+	svc := &Service{repo: repo, sites: fakeWorkerSiteLookup{}, clock: fakeClock{t: time.Now()}, destLookup: dl}
+	worker := NewBackupWorker(svc, cmd, nil, nil, "https://cp.example.com", 0)
+	job := &river.Job[BackupArgs]{Args: BackupArgs{TenantID: tenantID, SnapshotID: snapshotID}}
+
+	if err := worker.Work(context.Background(), job); err != nil {
+		t.Fatalf("Work() error: %v (fail() should record the terminal failure and return nil so River does not retry)", err)
+	}
+
+	// The run must end FAILED (w.fail -> FailSnapshot), not completed/running.
+	failed, ok := repo.snapshots[snapshotID]
+	if !ok {
+		t.Fatal("snapshot vanished from the fake repo")
+	}
+	if failed.Status != StatusFailed {
+		t.Fatalf("snapshot status = %q, want %q (destination lookup failure must fail the run, not proceed)", failed.Status, StatusFailed)
+	}
+
+	// The agent must NEVER have been dispatched — proves no fallback to the
+	// CP-managed default (or any destination) occurred.
+	if cmd.lastBackup != nil {
+		t.Fatalf("Backup must never be dispatched to the agent after a destination lookup failure, got %+v (DestinationKind=%q)", cmd.lastBackup, cmd.lastBackup.DestinationKind)
+	}
+	if cmd.lastIncrementalBackup != nil {
+		t.Fatalf("IncrementalBackup must never be dispatched to the agent after a destination lookup failure, got %+v", cmd.lastIncrementalBackup)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // PlanRestore (non-chain path) — destination-aware chunk fetch.
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/backup/service.go
+++ b/apps/api/internal/backup/service.go
@@ -121,6 +121,23 @@ type DestinationInfo struct {
 	PathPrefix string
 }
 
+// BillingGate gates a backup RUN (manual or scheduled) that resolves to the
+// CP-managed destination behind the M16 Phase B managed-backup-storage
+// entitlement. Implemented by *internal/billing.Service (wired in
+// cmd/wpmgr); a nil value disables the gate entirely (self-host / back-compat
+// / any test that does not wire it) and every call site treats that exactly
+// like an unlimited plan — mirrors site.BillingGate's nil-disables-the-gate
+// convention exactly. This local interface keeps the backup package free of a
+// direct billing import.
+//
+// It is deliberately NOT consulted on any restore/download path: a customer
+// must always be able to get existing data back, even after losing the
+// entitlement (see DestinationInfoForSnapshot's restore-routing callers,
+// which never call this gate).
+type BillingGate interface {
+	CheckManagedBackupStorage(ctx context.Context, tenantID uuid.UUID) error
+}
+
 // DestinationLookup bridges the ADR-036 P1 site-destination domain into the
 // backup service without an import cycle (sitedestination has no reason to
 // import backup, but keeping the dependency direction explicit and narrow
@@ -179,7 +196,17 @@ type Service struct {
 	// Optional: see DestinationLookup's doc for the graceful-degradation
 	// contract when nil.
 	destLookup DestinationLookup
+	// billing is the M16 Phase B managed-backup-storage gate. Optional: nil
+	// disables the gate (self-host / not-yet-wired tests), matching
+	// BillingGate's doc-comment contract exactly.
+	billing BillingGate
 }
+
+// SetBillingGate wires the M16 Phase B managed-backup-storage gate. Call once
+// at startup (after NewService), alongside SetDestinationLookup. Optional:
+// when never called, every backup run is ungated exactly as before this
+// feature existed.
+func (s *Service) SetBillingGate(b BillingGate) { s.billing = b }
 
 // SetRegistry wires the ADR-036 P1 storage-adapter router. Calling this AFTER
 // NewService routes every subsequent presign through the registry; callers
@@ -300,6 +327,55 @@ func (s *Service) resolveDefaultDestination(ctx context.Context, tenantID, siteI
 		return uuid.Nil
 	}
 	return id
+}
+
+// destinationIsManaged reports whether destinationID routes a NEW run to the
+// CP-managed bucket — either because no destination is configured (uuid.Nil,
+// the legacy default-fallback resolved by resolveDefaultDestination) or
+// because an explicitly-chosen destination is itself of kind "cp". Mirrors
+// DestinationInfoForSnapshot's resolution rule, but is called BEFORE a
+// snapshot exists (at run-creation time in CreateBackup/EnqueueScheduledBackup),
+// so it takes the destination id directly rather than a Snapshot.
+//
+// A destLookup failure degrades to "not managed" (the gate is skipped) rather
+// than "managed" (the gate would fire): mirrors resolveDefaultDestination's
+// identical fail-open rationale — a destination-routing hiccup must never
+// block a backup from being created. This is a soft billing gate, not a
+// security boundary, so failing open here is the right trade.
+func (s *Service) destinationIsManaged(ctx context.Context, tenantID, destinationID uuid.UUID) bool {
+	if destinationID == uuid.Nil {
+		return true
+	}
+	if s.destLookup == nil {
+		// A destination_id somehow resolved without a lookup wired — cannot
+		// happen operationally (SetDestinationLookup pairs with
+		// SetBillingGate), but degrade to "not managed" (gate skipped) per
+		// this function's fail-open rationale above.
+		return false
+	}
+	info, err := s.destLookup.DestinationInfo(ctx, tenantID, destinationID)
+	if err != nil {
+		slog.WarnContext(ctx, "backup: destination-kind lookup failed for the managed-storage billing gate; skipping the gate",
+			slog.String("tenant_id", tenantID.String()),
+			slog.String("destination_id", destinationID.String()),
+			slog.Any("error", err))
+		return false
+	}
+	return info.Kind == DestinationKindCP
+}
+
+// checkManagedBackupStorageGate enforces the M16 Phase B managed-storage
+// entitlement for a NEW run resolving to destinationID. No-op (nil error)
+// when no billing gate is wired, or when destinationID does not route to
+// managed storage (a BYO local/s3_compat destination is always plan-agnostic).
+func (s *Service) checkManagedBackupStorageGate(ctx context.Context, tenantID, destinationID uuid.UUID) error {
+	if s.billing == nil {
+		return nil
+	}
+	if !s.destinationIsManaged(ctx, tenantID, destinationID) {
+		return nil
+	}
+	return s.billing.CheckManagedBackupStorage(ctx, tenantID)
 }
 
 // DestinationInfoForSnapshot resolves the wire-facing destination kind (and,
@@ -445,6 +521,14 @@ func (s *Service) CreateBackup(ctx context.Context, tenantID, siteID, createdBy 
 	// uuid.Nil (destLookup unwired, no default configured, or a lookup
 	// failure) routes to the legacy CP-managed bucket — unchanged behaviour.
 	destinationID := s.resolveDefaultDestination(ctx, tenantID, siteID)
+
+	// M16 Phase B: a free-plan tenant may not create a NEW run against the
+	// CP-managed destination — no-op when unwired/self-host/BYO destination
+	// (see checkManagedBackupStorageGate). Checked before either CreateSnapshot
+	// branch below so a gated manual backup never mints a pending snapshot row.
+	if err := s.checkManagedBackupStorageGate(ctx, tenantID, destinationID); err != nil {
+		return Snapshot{}, err
+	}
 
 	// ADR-048 P5: run-now honours the same per-schedule incremental toggle as the
 	// scheduled path, so an operator can enable the toggle and then drive the
@@ -2997,6 +3081,31 @@ func (s *Service) EnqueueScheduledBackup(ctx context.Context, sched Schedule) er
 	// front so both branches below stamp it identically (see CreateBackup for
 	// the identical run-now-path rationale).
 	destinationID := s.resolveDefaultDestination(ctx, sched.TenantID, sched.SiteID)
+
+	// M16 Phase B: a free-plan tenant may not create a NEW run against the
+	// CP-managed destination. Unlike CreateBackup's manual path, a scheduled
+	// run must NEVER throw — the schedule's own advance already happened in
+	// ClaimAndAdvanceDueSchedules, so an error here would just look like an
+	// unexplained scheduler failure in logs. Instead flip the just-materialized
+	// 'queued' run row to 'skipped' with a caller-actionable reason, exactly
+	// like the un-enrollable/no-recipient skip path above, so the gap is
+	// visible in the site's run history rather than a silent no-op.
+	if gerr := s.checkManagedBackupStorageGate(ctx, sched.TenantID, destinationID); gerr != nil {
+		if s.scheduleRuns != nil && runID != uuid.Nil {
+			msg := "byo_destination_required: " + gerr.Error()
+			_, _ = s.scheduleRuns.SetScheduleRunStatusByID(ctx, SetScheduleRunStatusInput{
+				TenantID:    sched.TenantID,
+				RunID:       runID,
+				Status:      ScheduleRunStatusSkipped,
+				Error:       &msg,
+				SetFinished: true,
+			})
+		}
+		s.logger().Info("backup_scheduler skipping due schedule: managed backup storage requires a paid plan",
+			"schedule_id", sched.ID.String(),
+			"site_id", sched.SiteID.String())
+		return nil
+	}
 
 	// ADR-048 P5: when the schedule opts into incremental backups, consult the
 	// auto-base chain rule and stamp the snapshot's chain fields. When the toggle

--- a/apps/api/internal/billing/entitlements.go
+++ b/apps/api/internal/billing/entitlements.go
@@ -107,6 +107,17 @@ type Entitlements struct {
 	// carries no functional risk until/unless an enforcement point is added.
 	IncrementalBackups bool
 	ClientPortal       bool
+
+	// ManagedBackupStorage is ENFORCED (M16 Phase B, CheckManagedBackupStorage):
+	// false on the free tier means a tenant may not route a backup RUN to the
+	// CP-managed bucket — it must configure a local-folder or S3-compatible
+	// destination (internal/sitedestination) instead. Restore/download of a
+	// snapshot that already lives in managed storage is NEVER gated by this
+	// flag (a customer must always be able to get existing data back, even
+	// after losing the entitlement) — only the CREATE-time destination choice
+	// is enforced. true on every paid tier and on self-host/hosted-disabled
+	// (Unlimited()).
+	ManagedBackupStorage bool
 }
 
 const (
@@ -133,6 +144,7 @@ var planLadder = map[Tier]Entitlements{
 		MonthlyPriceCents:           0,
 		IncrementalBackups:          false,
 		ClientPortal:                false,
+		ManagedBackupStorage:        false, // BYO-storage only
 	},
 	TierStarter: {
 		Plan:                        TierStarter,
@@ -148,6 +160,7 @@ var planLadder = map[Tier]Entitlements{
 		MonthlyPriceCents:           1500,
 		IncrementalBackups:          true,
 		ClientPortal:                false,
+		ManagedBackupStorage:        true,
 	},
 	TierAgency: {
 		Plan:                        TierAgency,
@@ -163,6 +176,7 @@ var planLadder = map[Tier]Entitlements{
 		MonthlyPriceCents:           5900,
 		IncrementalBackups:          true,
 		ClientPortal:                true,
+		ManagedBackupStorage:        true,
 	},
 	TierScale: {
 		Plan:                        TierScale,
@@ -178,6 +192,7 @@ var planLadder = map[Tier]Entitlements{
 		MonthlyPriceCents:           16900,
 		IncrementalBackups:          true,
 		ClientPortal:                true,
+		ManagedBackupStorage:        true,
 	},
 }
 
@@ -215,6 +230,13 @@ func Unlimited() Entitlements {
 		RestoreEgressAllowanceBytes: math.MaxInt64,
 		RUMEventsPerMonth:           math.MaxInt64,
 		ProbeRetentionDays:          math.MaxInt32,
+		// ManagedBackupStorage is ENFORCED (unlike the display-only booleans
+		// above, which the omit-pattern here leaves at their zero value):
+		// Unlimited() is what a WPMGR_HOSTED-disabled Service resolves to, so
+		// self-host must NOT come back false here or it would wrongly deny
+		// managed backup storage on every self-hosted install. See
+		// TestUnlimitedAllowsManagedBackupStorage.
+		ManagedBackupStorage: true,
 	}
 }
 
@@ -239,6 +261,16 @@ type overrides struct {
 	RestoreEgressAllowanceBytes *int64 `json:"restore_egress_allowance_bytes"`
 	RUMEventsPerMonth           *int64 `json:"rum_events_per_month"`
 	ProbeRetentionDays          *int   `json:"probe_retention_days"`
+
+	// ManagedBackupStorage is the M16 Phase B grandfather override: a pointer
+	// (not a plain bool) so "absent" means "use the ladder base" rather than
+	// "force false" — a plain bool would be indistinguishable from an
+	// explicit false and could not express "no override" for an ENFORCED
+	// field. Written by the m95 grandfather migration for every tenant that
+	// existed before this gate shipped (see that migration's comment), and by
+	// the superadmin billing panel for a manual comp. Applied AFTER the
+	// ladder base in resolve(), so an explicit override always wins.
+	ManagedBackupStorage *bool `json:"managed_backup_storage"`
 }
 
 func (o overrides) apply(e *Entitlements) {
@@ -268,6 +300,9 @@ func (o overrides) apply(e *Entitlements) {
 	}
 	if o.ProbeRetentionDays != nil {
 		e.ProbeRetentionDays = *o.ProbeRetentionDays
+	}
+	if o.ManagedBackupStorage != nil {
+		e.ManagedBackupStorage = *o.ManagedBackupStorage
 	}
 }
 

--- a/apps/api/internal/billing/entitlements_test.go
+++ b/apps/api/internal/billing/entitlements_test.go
@@ -155,6 +155,83 @@ func TestUnlimitedHasNoEffectiveCap(t *testing.T) {
 	}
 }
 
+// TestUnlimitedAllowsManagedBackupStorage is the CRITICAL regression guard
+// called out in ManagedBackupStorage's doc comment: unlike the other
+// display-only booleans, this field is enforced, so Unlimited() (what every
+// WPMGR_HOSTED-disabled/self-host Service resolves to) MUST report true —
+// otherwise self-host would wrongly deny managed backup storage.
+func TestUnlimitedAllowsManagedBackupStorage(t *testing.T) {
+	if !Unlimited().ManagedBackupStorage {
+		t.Fatal("Unlimited().ManagedBackupStorage must be true — self-host/hosted-disabled must never be denied managed storage")
+	}
+}
+
+// ---- ManagedBackupStorage ladder + override ------------------------------
+
+func TestManagedBackupStorageLadder(t *testing.T) {
+	tests := []struct {
+		plan string
+		want bool
+	}{
+		{"free", false},
+		{"starter", true},
+		{"agency", true},
+		{"scale", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.plan, func(t *testing.T) {
+			row := tenantBillingRow{Plan: tt.plan, PlanStatus: "active"}
+			ent, err := resolve(row, time.Now())
+			if err != nil {
+				t.Fatalf("resolve: %v", err)
+			}
+			if ent.ManagedBackupStorage != tt.want {
+				t.Fatalf("ManagedBackupStorage = %v, want %v for plan %q", ent.ManagedBackupStorage, tt.want, tt.plan)
+			}
+		})
+	}
+}
+
+// TestManagedBackupStorageOverrideOnFreeTenant is the grandfather-override
+// resolution test: an explicit plan_overrides.managed_backup_storage=true
+// must win over the free-tier ladder base of false.
+func TestManagedBackupStorageOverrideOnFreeTenant(t *testing.T) {
+	row := tenantBillingRow{
+		Plan:          "free",
+		PlanStatus:    "none",
+		PlanOverrides: []byte(`{"managed_backup_storage": true}`),
+	}
+	ent, err := resolve(row, time.Now())
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !ent.ManagedBackupStorage {
+		t.Fatal("an explicit managed_backup_storage override must win over the free-tier ladder base")
+	}
+	// Untouched ladder fields survive the override unchanged.
+	if ent.MaxSites != 3 {
+		t.Fatalf("MaxSites = %d, want the untouched free-tier ladder value 3 (override must not clobber other fields)", ent.MaxSites)
+	}
+}
+
+// TestManagedBackupStorageOverrideCanDenyPaidTenant proves the override is a
+// true two-way delta, not a one-way "grant" special-case: false wins over a
+// paid tier's ladder true just as reliably as true wins over free's false.
+func TestManagedBackupStorageOverrideCanDenyPaidTenant(t *testing.T) {
+	row := tenantBillingRow{
+		Plan:          "starter",
+		PlanStatus:    "active",
+		PlanOverrides: []byte(`{"managed_backup_storage": false}`),
+	}
+	ent, err := resolve(row, time.Now())
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if ent.ManagedBackupStorage {
+		t.Fatal("an explicit managed_backup_storage=false override must win over the starter-tier ladder base of true")
+	}
+}
+
 // ---- Entitlements()/CheckSiteCreate() no-op when hosted billing is off ---
 
 func TestServiceDisabledIsANoOpWithoutAnyIO(t *testing.T) {

--- a/apps/api/internal/billing/managed_backup_storage_test.go
+++ b/apps/api/internal/billing/managed_backup_storage_test.go
@@ -1,0 +1,106 @@
+package billing
+
+// managed_backup_storage_test.go — M16 Phase B gate tests: the DB-free
+// decision function (mirrors resolve()'s testability), CheckManagedBackupStorage's
+// disabled-is-a-no-op fast path (mirrors TestServiceDisabledIsANoOpWithoutAnyIO
+// for CheckSiteCreate), and ManagedStorageAllowed's disabled/enabled behaviour.
+//
+// White-box, in-memory; no database (CheckManagedBackupStorage's DB-touching
+// branch, like CheckSiteCreate's, is exercised in production via
+// internal/backup's wiring tests with a fake BillingGate — see
+// internal/backup/billing_gate_test.go).
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---- managedBackupStorageDecision (DB-free) -------------------------------
+
+func TestManagedBackupStorageDecision_FreeTenantDenied(t *testing.T) {
+	err := managedBackupStorageDecision(Entitlements{Plan: TierFree, ManagedBackupStorage: false})
+	if err == nil {
+		t.Fatal("expected a 402 error for a free-tier entitlement with ManagedBackupStorage=false")
+	}
+	de, ok := domain.AsDomain(err)
+	if !ok {
+		t.Fatalf("expected a *domain.Error, got %T", err)
+	}
+	if de.Kind != domain.KindPaymentRequired {
+		t.Fatalf("Kind = %v, want KindPaymentRequired", de.Kind)
+	}
+	if de.Code != "byo_destination_required" {
+		t.Fatalf("Code = %q, want byo_destination_required", de.Code)
+	}
+	if de.Details["plan"] != "free" {
+		t.Fatalf("Details[plan] = %v, want %q", de.Details["plan"], "free")
+	}
+	if de.Details["has_byo_destination"] != false {
+		t.Fatalf("Details[has_byo_destination] = %v, want false", de.Details["has_byo_destination"])
+	}
+}
+
+func TestManagedBackupStorageDecision_PaidTenantAllowed(t *testing.T) {
+	for _, tier := range []Tier{TierStarter, TierAgency, TierScale} {
+		t.Run(string(tier), func(t *testing.T) {
+			err := managedBackupStorageDecision(Entitlements{Plan: tier, ManagedBackupStorage: true})
+			if err != nil {
+				t.Fatalf("expected nil for a paid tier with ManagedBackupStorage=true, got %v", err)
+			}
+		})
+	}
+}
+
+// TestManagedBackupStorageDecision_GrandfatheredFreeTenantAllowed ties the
+// m95 grandfather override directly to the gate's allow/deny outcome: a
+// free-plan tenant with the migration's plan_overrides.managed_backup_storage
+// override resolves to an ALLOWED decision, exactly as if it were on a paid
+// plan.
+func TestManagedBackupStorageDecision_GrandfatheredFreeTenantAllowed(t *testing.T) {
+	row := tenantBillingRow{
+		Plan:          "free",
+		PlanStatus:    "none",
+		PlanOverrides: []byte(`{"managed_backup_storage": true}`),
+	}
+	ent, err := resolve(row, time.Now())
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := managedBackupStorageDecision(ent); err != nil {
+		t.Fatalf("expected a grandfathered free tenant to be allowed managed storage, got %v", err)
+	}
+}
+
+// ---- CheckManagedBackupStorage: disabled is a no-op without any I/O -------
+
+// TestCheckManagedBackupStorageDisabledIsANoOp mirrors
+// TestServiceDisabledIsANoOpWithoutAnyIO's CheckSiteCreate assertion: a nil
+// pool proves the disabled path never dials the database.
+func TestCheckManagedBackupStorageDisabledIsANoOp(t *testing.T) {
+	svc := New(nil, nil, false, fixedClock{}, slog.Default())
+	if err := svc.CheckManagedBackupStorage(context.Background(), uuid.New()); err != nil {
+		t.Fatalf("CheckManagedBackupStorage on a disabled Service should always return nil, got %v", err)
+	}
+}
+
+// ---- ManagedStorageAllowed -------------------------------------------------
+
+// TestManagedStorageAllowedDisabledIsTrueWithoutAnyIO proves the Me-response
+// accessor matches Unlimited().ManagedBackupStorage exactly when hosted
+// billing is off, without touching Postgres or Redis (both nil here).
+func TestManagedStorageAllowedDisabledIsTrueWithoutAnyIO(t *testing.T) {
+	svc := New(nil, nil, false, fixedClock{}, slog.Default())
+	allowed, err := svc.ManagedStorageAllowed(context.Background(), uuid.New())
+	if err != nil {
+		t.Fatalf("ManagedStorageAllowed: %v", err)
+	}
+	if !allowed {
+		t.Fatal("ManagedStorageAllowed must be true when hosted billing is disabled")
+	}
+}

--- a/apps/api/internal/billing/service.go
+++ b/apps/api/internal/billing/service.go
@@ -176,6 +176,87 @@ func (s *Service) CheckSiteCreate(ctx context.Context, tx pgx.Tx, tenantID uuid.
 	return nil
 }
 
+// CheckManagedBackupStorage enforces the M16 Phase B managed-backup-storage
+// entitlement: a FREE-plan tenant may not route a backup RUN to the CP-
+// managed bucket (restore-egress margin cost) — it must configure a
+// local-folder or S3-compatible destination instead (internal/sitedestination).
+// This is a plan-agnostic gate: it MUST only be called by the caller when the
+// run's resolved destination is actually the managed one; a BYO destination
+// never reaches this method at all (see internal/backup.Service's
+// destinationIsManaged routing check).
+//
+// Unlike CheckSiteCreate this is a boolean gate with no count to race, so no
+// advisory lock or in-tx read is needed — it resolves entitlements FRESH (not
+// through the Redis cache) so a stale cache entry can never let an
+// already-downgraded tenant slip a managed-storage run through the gate
+// during the up-to-5-minute cache TTL window (mirrors CheckSiteCreate's
+// stale-cache rationale exactly, just without the tx/lock machinery that
+// exists there only for the count race).
+//
+// Returns nil immediately when hosted billing is disabled (self-host / any
+// WPMGR_HOSTED-off deployment) — this is what makes the whole feature ship
+// dark. RESTORE/DOWNLOAD OF AN EXISTING SNAPSHOT IS NEVER GATED by this or any
+// other method: a customer must always be able to get their data back, even
+// after losing the entitlement — see internal/backup's restore paths, which
+// never call this method.
+func (s *Service) CheckManagedBackupStorage(ctx context.Context, tenantID uuid.UUID) error {
+	if !s.enabled {
+		return nil
+	}
+	row, err := fetchTenantBilling(ctx, s.pool, tenantID)
+	if err != nil {
+		return domain.Internal("billing_tenant_lookup_failed", "failed to load tenant billing state").WithCause(err)
+	}
+	ent, err := resolve(row, s.clock.Now())
+	if err != nil {
+		return err
+	}
+	return managedBackupStorageDecision(ent)
+}
+
+// managedBackupStorageDecision maps a resolved Entitlements to the
+// CheckManagedBackupStorage verdict: nil when the plan permits managed
+// storage, a 402 domain.Error (code "byo_destination_required") otherwise.
+// Kept DB-free (pure function of an already-resolved Entitlements, mirroring
+// resolve() itself) so it is directly unit-testable without a pool/tx — see
+// entitlements_test.go.
+func managedBackupStorageDecision(ent Entitlements) error {
+	if ent.ManagedBackupStorage {
+		return nil
+	}
+	return domain.PaymentRequired("byo_destination_required",
+		"Free plan backups must go to your own storage. Add a local folder or S3 bucket under Destinations, or upgrade your plan.").
+		WithDetails(map[string]any{
+			"plan":                string(ent.Plan),
+			"has_byo_destination": false,
+		})
+}
+
+// ManagedStorageAllowed is a coarse, non-authoritative accessor for the
+// operator-facing Me response (internal/auth): whether the tenant's CURRENT
+// plan permits managed backup storage at all, without the fresh-resolve /
+// stale-cache-avoidance guarantees CheckManagedBackupStorage provides (this is
+// a display signal for the /destinations UI, not a gate — the RUN-time check
+// in internal/backup is the only authoritative enforcement point). Uses the
+// cached Entitlements() path deliberately: a Me response is fetched far more
+// often than a backup is created, and a few minutes of staleness on a purely
+// informational banner is an acceptable trade against hitting Postgres on
+// every page load.
+//
+// Returns true, without touching the database, when hosted billing is
+// disabled — matching Unlimited().ManagedBackupStorage exactly, so self-host
+// and pre-Phase-B hosted deployments always see the unrestricted signal.
+func (s *Service) ManagedStorageAllowed(ctx context.Context, tenantID uuid.UUID) (bool, error) {
+	if !s.enabled {
+		return true, nil
+	}
+	ent, err := s.Entitlements(ctx, tenantID)
+	if err != nil {
+		return false, err
+	}
+	return ent.ManagedBackupStorage, nil
+}
+
 // fetchTenantBilling loads the plan-resolution fields via any DBTX (the pool
 // for the uncached general path, or a tx for the locked CheckSiteCreate
 // path) and maps them to the DB-free tenantBillingRow shape.

--- a/apps/api/migrations/20260728000000_m95_managed_backup_storage_grandfather.sql
+++ b/apps/api/migrations/20260728000000_m95_managed_backup_storage_grandfather.sql
@@ -1,0 +1,34 @@
+-- M95 — managed-backup-storage grandfather (M16 Phase B).
+--
+-- Ships DARK behind WPMGR_HOSTED (default false): self-host and current prod
+-- see ZERO behavior change until the flag is turned on AND
+-- internal/backup.Service.SetBillingGate's caller actually resolves a
+-- managed destination for a run. This migration only ever writes a
+-- plan_overrides delta key; it never itself gates anything.
+--
+-- internal/billing.Entitlements.ManagedBackupStorage is false on the free
+-- tier (a free-plan tenant must configure a local-folder or S3-compatible
+-- backup destination instead of the CP-managed bucket, per
+-- internal/backup.Service.CheckManagedBackupStorage). Applied with no
+-- grandfather, that rule would silently cut off every EXISTING free-plan
+-- tenant's managed backups the instant WPMGR_HOSTED is turned on for M16
+-- Phase B — including tenants who have relied on managed storage for months
+-- with no BYO destination configured. Grandfathering (mirrors m91's max_sites
+-- backfill exactly): every tenant that exists AT MIGRATION TIME gets an
+-- explicit plan_overrides.managed_backup_storage = true, so nobody loses
+-- capability they already had; the gate only ever applies to NEW growth — a
+-- tenant created AFTER this migration runs with no override, so a free-plan
+-- newcomer is correctly gated the moment Phase B activates.
+--
+-- Non-destructive / idempotent: jsonb_set with the "NOT (plan_overrides ?
+-- 'managed_backup_storage')" guard merges the new key into whatever
+-- plan_overrides already holds (e.g. a m91 max_sites override survives
+-- untouched) and makes a second run of this migration (or a fresh apply
+-- against a re-migrated dev DB) a no-op once the key is set.
+--
+-- Vendor-neutral: no payment-provider or competitor naming, matching every
+-- other billing migration in this tree.
+
+UPDATE "public"."tenants"
+SET "plan_overrides" = jsonb_set(plan_overrides, '{managed_backup_storage}', 'true'::jsonb, true)
+WHERE NOT (plan_overrides ? 'managed_backup_storage');

--- a/apps/api/tests/billing_hosted_test.go
+++ b/apps/api/tests/billing_hosted_test.go
@@ -494,8 +494,17 @@ func TestGrandfatherBackfill_OverCapTenantKeepsOperating(t *testing.T) {
 }
 
 // TestGrandfatherBackfill_IsNoopUnderCap proves the common case (a tenant at
-// or under the free cap when m91 lands) is unaffected: no override is
-// written, so future growth is still gated by the real ladder cap (3).
+// or under the free cap when m91 lands) is unaffected: no max_sites override
+// is written, so future growth is still gated by the real ladder cap (3).
+//
+// pool.Migrate applies every embedded migration, not just m91 — including m95
+// (M16 Phase B), which unconditionally grandfathers
+// plan_overrides.managed_backup_storage=true onto EVERY tenant that exists at
+// migration time, regardless of site count. That is a deliberate, unrelated
+// backfill (see m95's own migration comment) and is asserted for explicitly
+// below; it does not make this tenant's max_sites backfill any less of a
+// no-op, so the assertion checks for the ABSENCE of a max_sites key rather
+// than requiring the whole plan_overrides document to be empty.
 func TestGrandfatherBackfill_IsNoopUnderCap(t *testing.T) {
 	pool := startPostgresBeforeM91(t)
 	ctx := context.Background()
@@ -511,14 +520,24 @@ func TestGrandfatherBackfill_IsNoopUnderCap(t *testing.T) {
 	}
 
 	if err := pool.Migrate(ctx); err != nil {
-		t.Fatalf("m91 migration failed: %v", err)
+		t.Fatalf("migrate failed: %v", err)
 	}
 
 	var overridesJSON []byte
 	if err := pool.QueryRow(ctx, `SELECT plan_overrides FROM tenants WHERE id = $1`, tenant).Scan(&overridesJSON); err != nil {
 		t.Fatalf("read plan_overrides: %v", err)
 	}
-	if string(overridesJSON) != "{}" {
-		t.Fatalf("plan_overrides = %s, want the untouched default {} for an under-cap tenant", overridesJSON)
+	var overrides map[string]any
+	if err := json.Unmarshal(overridesJSON, &overrides); err != nil {
+		t.Fatalf("unmarshal plan_overrides: %v", err)
+	}
+	if _, hasMaxSites := overrides["max_sites"]; hasMaxSites {
+		t.Fatalf("plan_overrides = %s, want no max_sites key for an under-cap tenant", overridesJSON)
+	}
+	// m95 (M16 Phase B) grandfather: every pre-existing tenant, capped or not,
+	// gets managed_backup_storage=true so nobody loses managed-storage access
+	// the instant the gate activates.
+	if managed, ok := overrides["managed_backup_storage"].(bool); !ok || !managed {
+		t.Fatalf("plan_overrides = %s, want managed_backup_storage=true (m95 grandfather)", overridesJSON)
 	}
 }

--- a/apps/api/tests/managed_backup_storage_hosted_test.go
+++ b/apps/api/tests/managed_backup_storage_hosted_test.go
@@ -1,0 +1,89 @@
+// managed_backup_storage_hosted_test.go — M16 Phase B integration tests:
+// CheckManagedBackupStorage against a real Postgres schema (migrations + RLS),
+// complementing internal/backup/billing_gate_test.go's fake-based unit tests
+// with end-to-end proof that entitlement resolution actually reads the
+// seeded tenants row correctly. Requires Docker; skips if unavailable (see
+// startPostgres).
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// TestManagedBackupStorage_FreeTenantDenied proves CheckManagedBackupStorage
+// returns the 402 byo_destination_required shape for a fresh (i.e. NOT
+// grandfathered by m95 — it is created after startPostgres's boot-time
+// Migrate call) free-plan tenant under WPMGR_HOSTED.
+func TestManagedBackupStorage_FreeTenantDenied(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "mbs-free")
+
+	svc := newHostedBillingService(pool, true)
+	err := svc.CheckManagedBackupStorage(ctx, tenant)
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindPaymentRequired {
+		t.Fatalf("want a 402 byo_destination_required error, got: %v", err)
+	}
+	if de.Code != "byo_destination_required" {
+		t.Fatalf("Code = %q, want byo_destination_required", de.Code)
+	}
+	if de.Details["plan"] != "free" {
+		t.Fatalf("Details[plan] = %v, want free", de.Details["plan"])
+	}
+}
+
+// TestManagedBackupStorage_PaidTenantAllowed proves a starter-plan (or
+// higher) tenant is never gated.
+func TestManagedBackupStorage_PaidTenantAllowed(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "mbs-paid")
+
+	if _, err := pool.Exec(ctx, `UPDATE tenants SET plan = 'starter', plan_status = 'active' WHERE id = $1`, tenant); err != nil {
+		t.Fatalf("upgrade tenant: %v", err)
+	}
+
+	svc := newHostedBillingService(pool, true)
+	if err := svc.CheckManagedBackupStorage(ctx, tenant); err != nil {
+		t.Fatalf("expected a paid tenant to be allowed managed storage, got %v", err)
+	}
+}
+
+// TestManagedBackupStorage_GrandfatheredOverrideAllowed proves an explicit
+// plan_overrides.managed_backup_storage=true override (the exact shape m95
+// writes) allows an otherwise-free tenant.
+func TestManagedBackupStorage_GrandfatheredOverrideAllowed(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "mbs-grandfathered")
+
+	if _, err := pool.Exec(ctx,
+		`UPDATE tenants SET plan_overrides = jsonb_set(plan_overrides, '{managed_backup_storage}', 'true'::jsonb, true) WHERE id = $1`,
+		tenant,
+	); err != nil {
+		t.Fatalf("apply override: %v", err)
+	}
+
+	svc := newHostedBillingService(pool, true)
+	if err := svc.CheckManagedBackupStorage(ctx, tenant); err != nil {
+		t.Fatalf("expected a grandfathered free tenant to be allowed, got %v", err)
+	}
+}
+
+// TestManagedBackupStorage_HostedDisabled_Uncapped proves the whole gate is a
+// no-op when hosted billing is off — this is what makes M16 Phase B ship
+// dark for every current self-hosted/pre-Phase-B deployment.
+func TestManagedBackupStorage_HostedDisabled_Uncapped(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "mbs-disabled")
+
+	svc := newHostedBillingService(pool, false)
+	if err := svc.CheckManagedBackupStorage(ctx, tenant); err != nil {
+		t.Fatalf("expected no error when hosted billing is disabled, got %v", err)
+	}
+}

--- a/apps/web/src/components/dialogs/backup-destination-required-prompt.tsx
+++ b/apps/web/src/components/dialogs/backup-destination-required-prompt.tsx
@@ -1,0 +1,78 @@
+import { Link } from "@tanstack/react-router";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { planLabel } from "@/features/billing/plan-catalog";
+
+// BackupDestinationRequiredPrompt — the ONE consistent surface for the 402
+// byo_destination_required shape (see lib/api.ts's
+// extractByoDestinationRequired, the sibling of the site-limit interceptor).
+// A manual backup run that resolves to CP-managed storage on a plan that
+// doesn't permit it renders this instead of a raw error string.
+//
+// Any operator can add a destination themselves (the /destinations page has
+// no owner gate), so that action is always offered. Only the billing action
+// is owner-only + hosted-only, mirroring UpgradePrompt's canUpgrade gate.
+
+export interface BackupDestinationRequiredPromptProps {
+  open: boolean;
+  onClose: () => void;
+  plan: string;
+  /** True only for an owner on a hosted instance — the only principal who can act on billing. */
+  canUpgrade: boolean;
+}
+
+export function BackupDestinationRequiredPrompt({
+  open,
+  onClose,
+  plan,
+  canUpgrade,
+}: BackupDestinationRequiredPromptProps) {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      {open ? (
+        <DialogContent ariaLabelledBy="backup-destination-required-title">
+          <DialogHeader>
+            <DialogTitle id="backup-destination-required-title">
+              Add a backup destination
+            </DialogTitle>
+          </DialogHeader>
+
+          <DialogBody>
+            <p className="text-sm text-[var(--color-foreground)]">
+              Your {planLabel(plan)} plan does not include managed backup
+              storage. Add a local folder or your own S3-compatible bucket
+              under Destinations to run backups, or upgrade your plan.
+            </p>
+            {!canUpgrade ? (
+              <p className="text-sm text-[var(--color-muted-foreground)]">
+                Ask your organisation owner to upgrade.
+              </p>
+            ) : null}
+          </DialogBody>
+
+          <DialogFooter className="pt-2">
+            <Button type="button" variant="outline" onClick={onClose}>
+              Close
+            </Button>
+            <Button asChild variant="outline" onClick={onClose}>
+              <Link to="/destinations">Add destination</Link>
+            </Button>
+            {canUpgrade ? (
+              <Button asChild onClick={onClose}>
+                <Link to="/settings/billing">View plans</Link>
+              </Button>
+            ) : null}
+          </DialogFooter>
+        </DialogContent>
+      ) : null}
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/backups/backups-section.tsx
+++ b/apps/web/src/features/backups/backups-section.tsx
@@ -48,6 +48,7 @@ import { PageError } from "@/components/feedback";
 import { StatusChip } from "@/components/status/status-chip";
 import type { StatusTone } from "@/components/status/status-dot";
 import { DestructiveConfirm } from "@/components/dialogs/destructive-confirm";
+import { BackupDestinationRequiredPrompt } from "@/components/dialogs/backup-destination-required-prompt";
 import {
   Dialog,
   DialogBody,
@@ -56,6 +57,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { ByoDestinationRequiredError } from "@/lib/api";
+import { useMe, activeRole } from "@/features/auth/use-auth";
 import {
   useBackups,
   useCreateBackup,
@@ -178,8 +181,24 @@ function BackupNowControl({ siteId }: { siteId: string }) {
   // they are resolved server-side from site_backup_settings.
   const { data: contents } = useBackupSettingsContents(siteId);
 
+  // 402 byo_destination_required (M16 Phase B backup-destinations Phase 2):
+  // swap to the shared BackupDestinationRequiredPrompt instead of rendering
+  // it as a generic inline error below — the two are never shown stacked.
+  const { data: me } = useMe();
+  const [destinationRequired, setDestinationRequired] =
+    useState<ByoDestinationRequiredError | null>(null);
+
   function onBackup() {
-    create.mutate({}, { onError: () => {} });
+    create.mutate(
+      {},
+      {
+        onError: (err) => {
+          if (err instanceof ByoDestinationRequiredError) {
+            setDestinationRequired(err);
+          }
+        },
+      },
+    );
   }
 
   const hasComponents =
@@ -188,6 +207,11 @@ function BackupNowControl({ siteId }: { siteId: string }) {
   const contentsNote = hasComponents
     ? `Uses saved contents settings (${contents!.backup_components!.join(", ")}).`
     : "Uses your saved backup contents settings (full backup by default).";
+
+  const genericError =
+    create.isError && !(create.error instanceof ByoDestinationRequiredError)
+      ? create.error.message
+      : null;
 
   return (
     <div className="flex shrink-0 flex-col items-end gap-1.5">
@@ -198,9 +222,9 @@ function BackupNowControl({ siteId }: { siteId: string }) {
         <Info aria-hidden className="size-3 shrink-0" />
         {contentsNote}
       </p>
-      {create.isError ? (
+      {genericError ? (
         <p role="alert" className="text-xs text-destructive-subtle-fg">
-          {create.error.message}
+          {genericError}
         </p>
       ) : null}
       {create.isSuccess ? (
@@ -208,6 +232,12 @@ function BackupNowControl({ siteId }: { siteId: string }) {
           Backup started. It appears below as it progresses.
         </p>
       ) : null}
+      <BackupDestinationRequiredPrompt
+        open={destinationRequired !== null}
+        onClose={() => setDestinationRequired(null)}
+        plan={destinationRequired?.plan ?? "free"}
+        canUpgrade={Boolean(me?.hosted) && activeRole(me) === "owner"}
+      />
     </div>
   );
 }

--- a/apps/web/src/features/backups/use-backups.ts
+++ b/apps/web/src/features/backups/use-backups.ts
@@ -26,6 +26,7 @@ import {
   type BackupScheduleUpdate,
 } from "@wpmgr/api";
 
+import { extractByoDestinationRequired } from "@/lib/api";
 import { toError } from "@/features/auth/use-auth";
 import { isStreamLive, subscribeLiveStreams } from "./use-backup-stream";
 
@@ -187,6 +188,16 @@ export function useCreateBackup(
         path: { siteId },
         body,
       });
+      // 402 byo_destination_required (M16 Phase B backup-destinations Phase
+      // 2): the resolved destination is CP-managed storage and the tenant's
+      // plan does not permit it. Run through the shared interceptor so
+      // callers can swap to BackupDestinationRequiredPrompt instead of a raw
+      // error string.
+      const destinationRequired = extractByoDestinationRequired(
+        response?.status,
+        error,
+      );
+      if (destinationRequired) throw destinationRequired;
       if (response?.status === 422) {
         throw toError(error ?? { message: "Validation failed" });
       }

--- a/apps/web/src/features/destinations/destination-form.tsx
+++ b/apps/web/src/features/destinations/destination-form.tsx
@@ -3,6 +3,7 @@
 // affordance on the secret field once a destination is persisted.
 
 import { useState } from "react";
+import { Link } from "@tanstack/react-router";
 import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -12,6 +13,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
+import { useMe, activeRole } from "@/features/auth/use-auth";
+import { cn } from "@/lib/utils";
 import type { SiteDestination, SiteDestinationKind } from "@wpmgr/api";
 
 import {
@@ -133,6 +136,14 @@ export function DestinationForm({
   const editing = !!initial;
   const hasStoredSecret = !!initial?.has_secret;
 
+  // M16 Phase B backup-destinations Phase 2: `managed_storage_allowed` is
+  // `undefined` on an older API in front (fail-open, no behavior change) and
+  // `true` everywhere today (self-host, paid, or hosted-billing-disabled).
+  // It only goes `false` for a free-plan tenant once hosted billing is on.
+  const { data: me } = useMe();
+  const managedStorageAllowed = me?.managed_storage_allowed !== false;
+  const canUpgrade = Boolean(me?.hosted) && activeRole(me) === "owner";
+
   const {
     register,
     handleSubmit,
@@ -144,7 +155,7 @@ export function DestinationForm({
   } = useForm<Values>({
     resolver: zodResolver(createSchema) as never,
     defaultValues: {
-      kind: initial?.kind ?? "cp",
+      kind: initial?.kind ?? (managedStorageAllowed ? "cp" : "s3_compat"),
       label: initial?.label ?? "",
       endpoint: initial?.endpoint ?? "",
       region: initial?.region ?? "",
@@ -242,30 +253,59 @@ export function DestinationForm({
         <div className="mt-2 grid gap-2 sm:grid-cols-3">
           {(
             [
-              { id: "cp", label: "CP storage", hint: "WPMgr-managed bucket (default)" },
+              {
+                id: "cp",
+                label: "CP storage",
+                hint: managedStorageAllowed
+                  ? "WPMgr-managed bucket (default)"
+                  : "WPMgr-managed bucket",
+              },
               { id: "local", label: "Local folder", hint: "wp-content/wpmgr-backups on this site" },
               { id: "s3_compat", label: "S3-compatible", hint: "Your bucket (AWS / Wasabi / B2 / ...)" },
             ] satisfies { id: SiteDestinationKind; label: string; hint: string }[]
-          ).map((opt) => (
-            <label
-              key={opt.id}
-              className="flex cursor-pointer items-start gap-3 rounded-md border border-[var(--color-border)] p-3 text-sm hover:bg-[var(--color-muted)]/50"
-            >
-              <input
-                type="radio"
-                value={opt.id}
-                {...register("kind")}
-                disabled={editing}
-                className="mt-0.5"
-              />
-              <span>
-                <span className="block font-medium">{opt.label}</span>
-                <span className="block text-xs text-[var(--color-muted-foreground)]">
-                  {opt.hint}
+          ).map((opt) => {
+            const managedDisabled = opt.id === "cp" && !managedStorageAllowed;
+            return (
+              <label
+                key={opt.id}
+                className={cn(
+                  "flex items-start gap-3 rounded-md border border-[var(--color-border)] p-3 text-sm",
+                  managedDisabled
+                    ? "cursor-not-allowed opacity-60"
+                    : "cursor-pointer hover:bg-[var(--color-muted)]/50",
+                )}
+              >
+                <input
+                  type="radio"
+                  value={opt.id}
+                  {...register("kind")}
+                  disabled={editing || managedDisabled}
+                  className="mt-0.5"
+                />
+                <span>
+                  <span className="block font-medium">{opt.label}</span>
+                  <span className="block text-xs text-[var(--color-muted-foreground)]">
+                    {opt.hint}
+                  </span>
+                  {managedDisabled ? (
+                    <span className="mt-1 block text-xs text-warning-subtle-fg">
+                      Managed storage needs a paid plan.{" "}
+                      {canUpgrade ? (
+                        <Link
+                          to="/settings/billing"
+                          className="underline underline-offset-4"
+                        >
+                          Upgrade
+                        </Link>
+                      ) : (
+                        "Ask your organisation owner to upgrade."
+                      )}
+                    </span>
+                  ) : null}
                 </span>
-              </span>
-            </label>
-          ))}
+              </label>
+            );
+          })}
         </div>
         {editing ? (
           <p className="mt-1 text-xs text-[var(--color-muted-foreground)]">

--- a/apps/web/src/features/destinations/destinations-list.tsx
+++ b/apps/web/src/features/destinations/destinations-list.tsx
@@ -4,6 +4,7 @@
 // form inline / destructive confirm dialog.
 
 import { useState } from "react";
+import { Link } from "@tanstack/react-router";
 import { Trash2, Pencil, Plus, Server, HardDrive, Cloud, Database } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -20,6 +21,7 @@ import { DestructiveConfirm } from "@/components/dialogs/destructive-confirm";
 import { PageError } from "@/components/feedback";
 import { CopyableMono } from "@/components/shared/copyable-mono";
 import { StatusChip } from "@/components/status";
+import { useMe, activeRole } from "@/features/auth/use-auth";
 import type { SiteDestination, SiteDestinationKind } from "@wpmgr/api";
 
 import {
@@ -73,6 +75,15 @@ export function DestinationsList({ siteId }: DestinationsListProps) {
     isRefetching,
   } = useDestinations(siteId);
   const del = useDeleteDestination(siteId);
+
+  // M16 Phase B backup-destinations Phase 2: `managed_storage_allowed` is
+  // `undefined` on an older API in front (fail-open) and `true` everywhere
+  // today; it only goes `false` for a free-plan tenant once hosted billing
+  // is on. Any operator can see this restriction; only an owner on a hosted
+  // instance can act on it (mirrors UpgradePrompt's canUpgrade gate).
+  const { data: me } = useMe();
+  const managedStorageAllowed = me?.managed_storage_allowed !== false;
+  const canUpgrade = Boolean(me?.hosted) && activeRole(me) === "owner";
 
   const [editing, setEditing] = useState<SiteDestination | null>(null);
   const [adding, setAdding] = useState(false);
@@ -136,7 +147,10 @@ export function DestinationsList({ siteId }: DestinationsListProps) {
           isRetrying={isRefetching}
         />
       ) : data.length === 0 ? (
-        <EmptyState />
+        <EmptyState
+          managedStorageAllowed={managedStorageAllowed}
+          canUpgrade={canUpgrade}
+        />
       ) : (
         <div className="rounded-xl border border-[var(--color-border)]">
           <Table>
@@ -231,7 +245,13 @@ export function DestinationsList({ siteId }: DestinationsListProps) {
   );
 }
 
-function EmptyState() {
+function EmptyState({
+  managedStorageAllowed,
+  canUpgrade,
+}: {
+  managedStorageAllowed: boolean;
+  canUpgrade: boolean;
+}) {
   return (
     <div
       role="status"
@@ -247,10 +267,28 @@ function EmptyState() {
         <p className="text-balance text-sm font-medium text-[var(--color-foreground)]">
           No destinations configured.
         </p>
-        <p className="text-balance text-sm text-[var(--color-muted-foreground)]">
-          WPMgr ships backups to managed storage by default. Add a destination
-          to send them elsewhere too.
-        </p>
+        {managedStorageAllowed ? (
+          <p className="text-balance text-sm text-[var(--color-muted-foreground)]">
+            WPMgr ships backups to managed storage by default. Add a destination
+            to send them elsewhere too.
+          </p>
+        ) : (
+          <>
+            <p className="text-balance text-sm text-[var(--color-muted-foreground)]">
+              Your plan does not include managed backup storage. Add a local
+              folder or your own S3-compatible bucket below to run backups on
+              this site.
+            </p>
+            {canUpgrade ? (
+              <Link
+                to="/settings/billing"
+                className="inline-block text-sm font-medium text-[var(--color-primary)] underline-offset-4 hover:underline"
+              >
+                View plans
+              </Link>
+            ) : null}
+          </>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 
-import { extractSiteLimitReached, SiteLimitReachedError } from "./api";
+import {
+  extractSiteLimitReached,
+  SiteLimitReachedError,
+  extractByoDestinationRequired,
+  ByoDestinationRequiredError,
+} from "./api";
 
 // Named test: "the 402 interceptor mapping". `extractSiteLimitReached` is the
 // shared handler every site-create mutation error path runs through (Add Site
@@ -76,5 +81,87 @@ describe("SiteLimitReachedError", () => {
     expect(err.limit).toBe(50);
     expect(err.usage).toBe(47);
     expect(err.plan).toBe("agency");
+  });
+});
+
+// Named test: "the 402 byo_destination_required interceptor mapping"
+// (backup-destinations Phase 2). `extractByoDestinationRequired` is the
+// shared handler a manual backup-create mutation error path runs through
+// before falling back to a generic error — see use-backups.ts's
+// useCreateBackup.
+
+describe("extractByoDestinationRequired", () => {
+  const validBody = {
+    code: "byo_destination_required",
+    message: "Free plan backups must go to your own storage.",
+    details: { plan: "free", has_byo_destination: false },
+  };
+
+  it("recognizes the 402 byo_destination_required shape and returns a typed error", () => {
+    const err = extractByoDestinationRequired(402, validBody);
+    expect(err).toBeInstanceOf(ByoDestinationRequiredError);
+    expect(err?.plan).toBe("free");
+    expect(err?.hasByoDestination).toBe(false);
+  });
+
+  it("returns null for a non-402 status even with a matching body (e.g. a 422)", () => {
+    expect(extractByoDestinationRequired(422, validBody)).toBeNull();
+  });
+
+  it("returns null for a 402 with a different error code", () => {
+    expect(
+      extractByoDestinationRequired(402, {
+        ...validBody,
+        code: "some_other_code",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when details are missing entirely", () => {
+    expect(
+      extractByoDestinationRequired(402, {
+        code: "byo_destination_required",
+        message: "x",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when a details field has the wrong type", () => {
+    expect(
+      extractByoDestinationRequired(402, {
+        code: "byo_destination_required",
+        message: "x",
+        details: { plan: "free", has_byo_destination: "false" },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for a non-object error body", () => {
+    expect(extractByoDestinationRequired(402, "some string error")).toBeNull();
+    expect(extractByoDestinationRequired(402, null)).toBeNull();
+    expect(extractByoDestinationRequired(402, undefined)).toBeNull();
+  });
+
+  it("returns null when status is undefined (transport error, no response)", () => {
+    expect(extractByoDestinationRequired(undefined, validBody)).toBeNull();
+  });
+});
+
+describe("ByoDestinationRequiredError", () => {
+  it("is an instance of Error so it propagates through TanStack Query's onError", () => {
+    const err = new ByoDestinationRequiredError("free", false);
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("has a predictable name and code for narrowing", () => {
+    const err = new ByoDestinationRequiredError("free", false);
+    expect(err.name).toBe("ByoDestinationRequiredError");
+    expect(err.code).toBe("byo_destination_required");
+  });
+
+  it("carries the plan/has_byo_destination the prompt needs", () => {
+    const err = new ByoDestinationRequiredError("free", true);
+    expect(err.plan).toBe("free");
+    expect(err.hasByoDestination).toBe(true);
   });
 });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -88,3 +88,68 @@ export function extractSiteLimitReached(
   }
   return new SiteLimitReachedError(details.limit, details.usage, details.plan);
 }
+
+// ---------------------------------------------------------------------------
+// 402 byo_destination_required interceptor (M16 Phase B backup-destinations
+// Phase 2) — sibling of the site-limit interceptor above. A manual backup
+// run that resolves to CP-managed storage on a tenant whose plan does not
+// permit it is rejected with this 402 shape instead of being enqueued.
+//
+// Contract (apps/api/internal/billing/service.go managedBackupStorageDecision):
+// a 402 with body { code: "byo_destination_required", message,
+// details: { plan, has_byo_destination } }. Only ever returned when hosted
+// billing is enabled AND the active tenant's plan does not include managed
+// backup storage; self-hosted installs and every paid plan never see this
+// shape. Restoring or downloading an existing backup is never gated.
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown by a backup-create mutation when the resolved destination is
+ * CP-managed storage and the tenant's plan does not permit it. Carries the
+ * details `BackupDestinationRequiredPrompt` needs so no call site has to
+ * re-parse the error body itself.
+ */
+export class ByoDestinationRequiredError extends Error {
+  readonly code = "byo_destination_required" as const;
+  readonly plan: string;
+  readonly hasByoDestination: boolean;
+
+  constructor(plan: string, hasByoDestination: boolean) {
+    super(
+      "Free plan backups must go to your own storage. Add a local folder or S3 bucket under Destinations, or upgrade your plan.",
+    );
+    this.name = "ByoDestinationRequiredError";
+    this.plan = plan;
+    this.hasByoDestination = hasByoDestination;
+  }
+}
+
+/**
+ * Recognizes the 402 `byo_destination_required` shape from a backup-create
+ * error body and returns a typed `ByoDestinationRequiredError`, or `null`
+ * when the response doesn't match. Pure (no network, no React) so it is
+ * fully unit-testable in isolation — see lib/api.test.ts.
+ */
+export function extractByoDestinationRequired(
+  status: number | undefined,
+  error: unknown,
+): ByoDestinationRequiredError | null {
+  if (status !== 402) return null;
+  if (typeof error !== "object" || error === null) return null;
+  const body = error as Record<string, unknown>;
+  if (body.code !== "byo_destination_required") return null;
+  const details =
+    typeof body.details === "object" && body.details !== null
+      ? (body.details as Record<string, unknown>)
+      : null;
+  if (
+    typeof details?.plan !== "string" ||
+    typeof details?.has_byo_destination !== "boolean"
+  ) {
+    return null;
+  }
+  return new ByoDestinationRequiredError(
+    details.plan,
+    details.has_byo_destination,
+  );
+}

--- a/apps/web/src/routes/_authed/backups/index.tsx
+++ b/apps/web/src/routes/_authed/backups/index.tsx
@@ -13,7 +13,7 @@
 //   NOTE: No download button — deferred per the spec.
 
 import { useMemo } from "react";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
 import {
   CheckCircle2,
@@ -55,6 +55,7 @@ import type {
 import { useCreateBackup } from "@/features/backups/use-backups";
 import { toast } from "@/components/toast";
 import { cn, relativeTime, formatBytes } from "@/lib/utils";
+import { ByoDestinationRequiredError } from "@/lib/api";
 
 // ---------------------------------------------------------------------------
 // Route
@@ -165,6 +166,7 @@ function countByStatus(items: BackupHealthItem[]): Record<BackupHealthStatus, nu
 
 function RunBackupAction({ siteId }: { siteId: string }) {
   const mutation = useCreateBackup(siteId);
+  const navigate = useNavigate();
   return (
     <button
       type="button"
@@ -175,7 +177,23 @@ function RunBackupAction({ siteId }: { siteId: string }) {
           { kind: "full" },
           {
             onSuccess: () => toast.success("Backup started"),
-            onError: (err) => toast.error(err.message),
+            onError: (err) => {
+              // 402 byo_destination_required (M16 Phase B backup-destinations
+              // Phase 2): point straight at Destinations instead of a bare
+              // error string — there's no room for the full
+              // BackupDestinationRequiredPrompt in a table row action.
+              if (err instanceof ByoDestinationRequiredError) {
+                toast.error("This plan needs your own backup storage", {
+                  description: err.message,
+                  action: {
+                    label: "Add destination",
+                    onClick: () => void navigate({ to: "/destinations" }),
+                  },
+                });
+                return;
+              }
+              toast.error(err.message);
+            },
           },
         );
       }}

--- a/apps/web/src/routes/_authed/destinations.tsx
+++ b/apps/web/src/routes/_authed/destinations.tsx
@@ -45,7 +45,11 @@ function DestinationsSettingsPage() {
     >
       <PageHeader
         title="Backup destinations"
-        subline="Pick a site, then choose where its backup chunks should land — managed storage (default), a folder on the same server, or your own S3-compatible bucket."
+        subline={
+          me?.managed_storage_allowed !== false
+            ? "Pick a site, then choose where its backup chunks should land — managed storage (default), a folder on the same server, or your own S3-compatible bucket."
+            : "Pick a site, then choose where its backup chunks should land. Your plan does not include managed storage, so add a local folder or your own S3-compatible bucket to run backups."
+        }
       />
 
       {!operate ? (

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -1146,6 +1146,11 @@ export const MeSchema = {
       description:
         "Whether this instance runs with hosted-billing entitlements (WPMGR_HOSTED) turned on. False on every self-hosted deployment and on any hosted instance before M16 Phase B billing ships. The frontend uses this to gate billing/plan UI.\n",
     },
+    managed_storage_allowed: {
+      type: "boolean",
+      description:
+        "Whether the active tenant's plan currently permits routing a NEW backup to CP-managed storage (M16 Phase B). Always true on a self-hosted or hosted-billing-disabled instance, and true for every paid plan; false only for a free-plan tenant under WPMGR_HOSTED. This is a coarse, role-safe display signal for the operator-facing /destinations page (which any operator can view, unlike the owner-only /billing summary) — it is NOT the authoritative gate; the backup-run endpoints enforce the real check server-side and return 402 byo_destination_required when denied. Restoring/downloading an existing backup is never gated by this or any other check.\n",
+    },
   },
 } as const;
 

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -613,6 +613,11 @@ export type Me = {
    *
    */
   hosted?: boolean;
+  /**
+   * Whether the active tenant's plan currently permits routing a NEW backup to CP-managed storage (M16 Phase B). Always true on a self-hosted or hosted-billing-disabled instance, and true for every paid plan; false only for a free-plan tenant under WPMGR_HOSTED. This is a coarse, role-safe display signal for the operator-facing /destinations page (which any operator can view, unlike the owner-only /billing summary) — it is NOT the authoritative gate; the backup-run endpoints enforce the real check server-side and return 402 byo_destination_required when denied. Restoring/downloading an existing backup is never gated by this or any other check.
+   *
+   */
+  managed_storage_allowed?: boolean;
 };
 
 /**

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -9564,6 +9564,20 @@ components:
             (WPMGR_HOSTED) turned on. False on every self-hosted deployment and
             on any hosted instance before M16 Phase B billing ships. The
             frontend uses this to gate billing/plan UI.
+        managed_storage_allowed:
+          type: boolean
+          description: >
+            Whether the active tenant's plan currently permits routing a NEW
+            backup to CP-managed storage (M16 Phase B). Always true on a
+            self-hosted or hosted-billing-disabled instance, and true for
+            every paid plan; false only for a free-plan tenant under
+            WPMGR_HOSTED. This is a coarse, role-safe display signal for the
+            operator-facing /destinations page (which any operator can view,
+            unlike the owner-only /billing summary) — it is NOT the
+            authoritative gate; the backup-run endpoints enforce the real
+            check server-side and return 402 byo_destination_required when
+            denied. Restoring/downloading an existing backup is never gated
+            by this or any other check.
 
     PrincipalRole:
       type: string


### PR DESCRIPTION
Hosted-only, ships DARK behind WPMGR_HOSTED. Free-plan tenants must back up to their own storage (local/S3); managed storage is a paid feature. Entitlement ManagedBackupStorage (Unlimited()=true so self-host is never denied) + a grandfather override; authoritative gate at the backup RUN (manual -> 402 byo_destination_required, scheduled -> skipped); restore is NEVER gated (tested); /auth/me.managed_storage_allowed drives the /destinations UX (disabled managed + 402 prompt), all guarded so the allowed path is unchanged; m95 grandfathers existing tenants. Security review SHIP, no high/critical (gate covers every run path, fail-open bounded + pinned, cross-tenant clean, dark-safe). api + web.

Phase 2 of destinations completeness (Phase 1 = v0.61.33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plan-aware backup destination guidance, including a prompt to add a destination or review plans when managed storage isn’t available.
  * Exposed managed storage availability in the app so backup and destination screens can adjust messaging and defaults.

* **Bug Fixes**
  * New backup runs now clearly fail with a dedicated “BYO destination required” message on unsupported plans.
  * Scheduled backups skip cleanly when managed storage is blocked, while existing backup restores remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->