### PR TITLE
fix(web): wire the Vulnerabilities + Performance tiles on the site Health tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.35] - 2026-07-07
+
+### Fixed
+
+- The Vulnerabilities and Performance tiles on a site's Health tab were placeholders that always read "Not scanned yet" and "Not measured yet" regardless of the real data. They now show live results: the Vulnerabilities tile shows the open-vulnerability count and worst severity (or that the feed is not configured, or that no known vulnerabilities were found), and the Performance tile shows the site's Core Web Vitals (LCP p75) from real-user monitoring. Each tile links through to the full view (the Security tab and the Performance dashboard). A site that has not been scanned yet, or has no visitor data yet, shows an honest empty state instead of a fabricated number.
+
 ## [0.61.34] - 2026-07-07
 
 ### Added

--- a/apps/web/src/features/perf/rum-tile.test.ts
+++ b/apps/web/src/features/perf/rum-tile.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  findAggregateMetric,
+  formatLcpP75,
+  RUM_RATING_LABEL,
+  RUM_RATING_CLASS,
+} from "./rum-tile";
+import type { RumMetricSummary, RumSummary } from "./types";
+
+// ---------------------------------------------------------------------------
+// findAggregateMetric — must match the CP's all-devices sentinel exactly
+//
+// apps/api/internal/perf/rum_results_handler.go builds an "all-devices" row
+// per metric with device:"" (country-collapsed too). A frontend contract
+// mismatch here (e.g. expecting device:"all" instead of "") would silently
+// drop the aggregate row and make the tile show "No visitor data yet" even
+// though the site has plenty of RUM samples — the same class of bug fixed by
+// the Go-side "All tab No data" regression test.
+//
+// The generated SDK type narrows `device` to "desktop" | "mobile" | "tablet"
+// (it does not model the "" wire sentinel), the same generated-type gap
+// FleetRumPanel works around with its own `RawMetricRow` cast. `wireRow`
+// mirrors that same workaround for fixture construction here.
+// ---------------------------------------------------------------------------
+
+function wireRow(row: {
+  metric: NonNullable<RumMetricSummary["metric"]>;
+  device?: string;
+  p75_ms: number;
+  sample_count: number;
+  rating?: NonNullable<RumMetricSummary["rating"]>;
+  suppressed: boolean;
+}): RumMetricSummary {
+  return { ...row, device: row.device as RumMetricSummary["device"] };
+}
+
+function makeSummary(metrics: RumSummary["metrics"]): RumSummary {
+  return { window_days: 28, min_sample_count: 30, metrics };
+}
+
+describe("findAggregateMetric", () => {
+  it("finds the device:\"\" aggregate row for the requested metric", () => {
+    const summary = makeSummary([
+      wireRow({ metric: "lcp", device: "desktop", p75_ms: 1800, sample_count: 40, rating: "good", suppressed: false }),
+      wireRow({ metric: "lcp", device: "mobile", p75_ms: 2600, sample_count: 60, rating: "needs_improvement", suppressed: false }),
+      wireRow({ metric: "lcp", device: "", p75_ms: 2300, sample_count: 100, rating: "needs_improvement", suppressed: false }),
+    ]);
+    const row = findAggregateMetric(summary, "lcp");
+    expect(row).toBeDefined();
+    expect(row?.device).toBe("");
+    expect(row?.sample_count).toBe(100);
+  });
+
+  it("also matches a row where device is entirely absent (undefined)", () => {
+    const summary = makeSummary([
+      wireRow({ metric: "lcp", p75_ms: 2100, sample_count: 50, rating: "good", suppressed: false }),
+    ]);
+    const row = findAggregateMetric(summary, "lcp");
+    expect(row).toBeDefined();
+    expect(row?.p75_ms).toBe(2100);
+  });
+
+  it("does not match a per-device row (desktop/mobile/tablet) as the aggregate", () => {
+    const summary = makeSummary([
+      wireRow({ metric: "lcp", device: "desktop", p75_ms: 1800, sample_count: 40, rating: "good", suppressed: false }),
+    ]);
+    expect(findAggregateMetric(summary, "lcp")).toBeUndefined();
+  });
+
+  it("returns undefined when the metric has no rows at all", () => {
+    const summary = makeSummary([
+      wireRow({ metric: "inp", device: "", p75_ms: 150, sample_count: 40, rating: "good", suppressed: false }),
+    ]);
+    expect(findAggregateMetric(summary, "lcp")).toBeUndefined();
+  });
+
+  it("returns undefined when metrics is missing entirely", () => {
+    const summary: RumSummary = { window_days: 28, min_sample_count: 30 };
+    expect(findAggregateMetric(summary, "lcp")).toBeUndefined();
+  });
+
+  it("returns a suppressed row as-is — callers must check .suppressed before showing a p75", () => {
+    const summary = makeSummary([
+      wireRow({ metric: "lcp", device: "", p75_ms: 0, sample_count: 5, suppressed: true }),
+    ]);
+    const row = findAggregateMetric(summary, "lcp");
+    expect(row).toBeDefined();
+    expect(row?.suppressed).toBe(true);
+  });
+
+  it("picks the row matching the requested metric among several metrics", () => {
+    const summary = makeSummary([
+      wireRow({ metric: "lcp", device: "", p75_ms: 2000, sample_count: 80, rating: "good", suppressed: false }),
+      wireRow({ metric: "inp", device: "", p75_ms: 150, sample_count: 80, rating: "good", suppressed: false }),
+      wireRow({ metric: "cls", device: "", p75_ms: 50, sample_count: 80, rating: "good", suppressed: false }),
+    ]);
+    expect(findAggregateMetric(summary, "inp")?.p75_ms).toBe(150);
+    expect(findAggregateMetric(summary, "cls")?.p75_ms).toBe(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLcpP75 — display formatting
+// ---------------------------------------------------------------------------
+
+describe("formatLcpP75", () => {
+  it("formats sub-1000ms values in milliseconds", () => {
+    expect(formatLcpP75(850)).toBe("850 ms");
+  });
+
+  it("rounds fractional milliseconds", () => {
+    expect(formatLcpP75(849.6)).toBe("850 ms");
+  });
+
+  it("formats 1000ms and above in seconds with two decimals", () => {
+    expect(formatLcpP75(1000)).toBe("1.00 s");
+    expect(formatLcpP75(2456)).toBe("2.46 s");
+  });
+
+  it("formats zero as 0 ms (never shown for a suppressed row by the caller, but the formatter itself is total)", () => {
+    expect(formatLcpP75(0)).toBe("0 ms");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RUM_RATING_LABEL / RUM_RATING_CLASS — every rating band has a label + class
+// ---------------------------------------------------------------------------
+
+describe("RUM_RATING_LABEL and RUM_RATING_CLASS", () => {
+  it("cover all three CWV rating bands", () => {
+    expect(RUM_RATING_LABEL.good).toBe("Good");
+    expect(RUM_RATING_LABEL.needs_improvement).toBe("Needs work");
+    expect(RUM_RATING_LABEL.poor).toBe("Poor");
+  });
+
+  it("every rating has a non-empty color class", () => {
+    for (const rating of ["good", "needs_improvement", "poor"] as const) {
+      expect(RUM_RATING_CLASS[rating].length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/web/src/features/perf/rum-tile.ts
+++ b/apps/web/src/features/perf/rum-tile.ts
@@ -1,0 +1,51 @@
+import type { RumMetricSummary, RumSummary } from "./types";
+
+// Pure helpers for a single-metric CWV headline (the Health tab's Performance
+// tile). LCP is the headline metric — first among the three core CWV metrics
+// in FleetRumPanel / RumResultsTable, and the metric most commonly cited as
+// the primary "loading experience" signal.
+//
+// The all-devices aggregate row is device:"" per the CP handler
+// (apps/api/internal/perf/rum_results_handler.go — see
+// "All-devices aggregate (device=\"\" sentinel)"), mirrored here exactly the
+// same way FleetRumPanel.extractSlice matches it.
+
+/**
+ * Finds the all-devices aggregate row for the given metric in a RUM summary.
+ * Returns undefined when no row exists for that metric at all (not just when
+ * suppressed — callers must check `.suppressed` separately since a suppressed
+ * row is still a real row that must not show a p75 value).
+ */
+export function findAggregateMetric(
+  summary: RumSummary,
+  metric: NonNullable<RumMetricSummary["metric"]>,
+): RumMetricSummary | undefined {
+  return (summary.metrics ?? []).find(
+    (m) => m.metric === metric && (!m.device || m.device === ("" as string)),
+  );
+}
+
+export const RUM_RATING_LABEL: Record<
+  NonNullable<RumMetricSummary["rating"]>,
+  string
+> = {
+  good: "Good",
+  needs_improvement: "Needs work",
+  poor: "Poor",
+};
+
+export const RUM_RATING_CLASS: Record<
+  NonNullable<RumMetricSummary["rating"]>,
+  string
+> = {
+  good: "text-green-700 dark:text-green-400",
+  needs_improvement: "text-amber-700 dark:text-amber-400",
+  poor: "text-red-700 dark:text-red-400",
+};
+
+/** Formats a p75 value in milliseconds for display (LCP/INP/FCP/TTFB units). */
+export function formatLcpP75(p75Ms: number): string {
+  return p75Ms >= 1000
+    ? `${(p75Ms / 1000).toFixed(2)} s`
+    : `${Math.round(p75Ms)} ms`;
+}

--- a/apps/web/src/features/perf/types.ts
+++ b/apps/web/src/features/perf/types.ts
@@ -179,7 +179,7 @@ export type { FontResult } from "@wpmgr/api";
  * keyed by (metric, device, country). When suppressed=true on a row, render
  * "insufficient samples" rather than a p75 number.
  */
-export type { RumSummary, RumResult } from "@wpmgr/api";
+export type { RumSummary, RumResult, RumMetricSummary } from "@wpmgr/api";
 
 /**
  * Distribution of pageviews across the three CWV rating bands for one metric

--- a/apps/web/src/features/security/use-vuln.test.ts
+++ b/apps/web/src/features/security/use-vuln.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
   isHighRisk,
   countHighRisk,
+  worstSeverity,
   safeExternalHref,
   vulnKeys,
   type VulnFinding,
@@ -394,6 +395,46 @@ describe("countHighRisk", () => {
       status: "dismissed",
     };
     expect(countHighRisk([dismissed])).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// worstSeverity — used by the Health tab's Vulnerabilities tile
+// ---------------------------------------------------------------------------
+
+describe("worstSeverity", () => {
+  it("returns undefined for an empty list", () => {
+    expect(worstSeverity([])).toBeUndefined();
+  });
+
+  it("returns critical when a critical finding is present among mixed severities", () => {
+    const findings = [MEDIUM_CORE_FINDING, CRITICAL_PLUGIN_FINDING, HIGH_THEME_FINDING];
+    expect(worstSeverity(findings)).toBe("critical");
+  });
+
+  it("returns high when high is the worst present (no critical)", () => {
+    const findings = [MEDIUM_CORE_FINDING, HIGH_THEME_FINDING, LOW_DISMISSED_FINDING];
+    expect(worstSeverity(findings)).toBe("high");
+  });
+
+  it("returns medium when only medium and low are present", () => {
+    const low: VulnFinding = { ...LOW_DISMISSED_FINDING, status: "open" };
+    expect(worstSeverity([MEDIUM_CORE_FINDING, low])).toBe("medium");
+  });
+
+  it("returns low when only low findings are present", () => {
+    const low: VulnFinding = { ...LOW_DISMISSED_FINDING, status: "open" };
+    expect(worstSeverity([low])).toBe("low");
+  });
+
+  it("a single critical finding among all four severities still wins", () => {
+    const all = [
+      LOW_DISMISSED_FINDING,
+      MEDIUM_CORE_FINDING,
+      HIGH_THEME_FINDING,
+      CRITICAL_PLUGIN_FINDING,
+    ];
+    expect(worstSeverity(all)).toBe("critical");
   });
 });
 

--- a/apps/web/src/features/security/use-vuln.ts
+++ b/apps/web/src/features/security/use-vuln.ts
@@ -346,6 +346,24 @@ export function countHighRisk(findings: VulnFinding[]): number {
   ).length;
 }
 
+/** Severity ranked worst-first, for picking the single worst severity to display. */
+const SEVERITY_RANK: VulnSeverity[] = ["critical", "high", "medium", "low"];
+
+/**
+ * Returns the worst (highest-priority) severity among the given findings, or
+ * `undefined` when the list is empty. Used by summary tiles (e.g. the Health
+ * tab's Vulnerabilities tile) that show one representative severity rather
+ * than the full findings table.
+ */
+export function worstSeverity(
+  findings: VulnFinding[],
+): VulnSeverity | undefined {
+  for (const severity of SEVERITY_RANK) {
+    if (findings.some((f) => f.severity === severity)) return severity;
+  }
+  return undefined;
+}
+
 /**
  * Validates a feed-supplied URL before it is placed in an <a href>.
  *

--- a/apps/web/src/routes/_authed/sites/$siteId.health.tsx
+++ b/apps/web/src/routes/_authed/sites/$siteId.health.tsx
@@ -1,11 +1,22 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link, type LinkProps } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 
-import { BackupChip } from "@/components/status";
+import { BackupChip, VulnSeverityChip } from "@/components/status";
 import { Sparkline } from "@/components/charts";
 import { useBackups } from "@/features/backups/use-backups";
 import { useSiteUptime } from "@/features/monitoring/use-uptime";
 import { HealthTab as DiagnosticsHealth } from "@/features/health/health-tab";
+import {
+  useSiteVulnerabilities,
+  worstSeverity,
+} from "@/features/security/use-vuln";
+import { useRumSummary } from "@/features/perf/hooks/useRumSummary";
+import {
+  findAggregateMetric,
+  formatLcpP75,
+  RUM_RATING_CLASS,
+  RUM_RATING_LABEL,
+} from "@/features/perf/rum-tile";
 import { formatBytes, relativeTime, cn } from "@/lib/utils";
 
 // `/sites/$siteId/health` — the Health tab (ADR-037 Impeccable, Batch 1).
@@ -14,9 +25,14 @@ import { formatBytes, relativeTime, cn } from "@/lib/utils";
 //   1. The headline summary band: ONE card split into four tiles
 //      (Uptime / Last backup / Vulnerabilities / Performance). Per DESIGN.md
 //      ("Don't nest cards.") the tiles share one bordered card, divided by
-//      internal borders rather than four sibling cards. The two unwired tiles
-//      render an HONEST empty ("Not scanned yet" / "Not measured yet") instead
-//      of a fabricated "0 findings".
+//      internal borders rather than four sibling cards. Vulnerabilities reads
+//      the Security Suite vuln scanner (useSiteVulnerabilities) and
+//      Performance reads the RUM Core Web Vitals summary (useRumSummary) —
+//      both tiles render an HONEST empty when there is genuinely no data yet
+//      (feed not configured / no visitor samples) rather than a fabricated
+//      "0 findings" or score. Both tiles link out to the page that owns their
+//      action (Rescan / the Performance dashboard), since the Health tab
+//      itself has no trigger for either.
 //   2. The diagnostics surface (HealthTab from features/health): a header
 //      ribbon + grouped sections. The ribbon owns the page <h2>, the host
 //      identity, and the single "Re-run all checks" action.
@@ -39,8 +55,8 @@ function HealthTab() {
         >
           <UptimeTile siteId={siteId} />
           <LastBackupTile siteId={siteId} />
-          <VulnerabilitiesTile />
-          <PerformanceTile />
+          <VulnerabilitiesTile siteId={siteId} />
+          <PerformanceTile siteId={siteId} />
         </div>
       </div>
 
@@ -56,14 +72,21 @@ function Tile({
   value,
   sub,
   children,
+  linkTo,
 }: {
   title: string;
   value: ReactNode;
   sub?: ReactNode;
   children?: ReactNode;
+  /**
+   * When present, the whole tile becomes a typed router Link to the page that
+   * owns the action for this tile (the Health tab itself has no trigger for
+   * a vuln rescan or a Performance drill-down).
+   */
+  linkTo?: Pick<LinkProps, "to" | "params" | "search">;
 }) {
-  return (
-    <div className="flex min-w-0 flex-col gap-2 p-6">
+  const body = (
+    <>
       <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
         {title}
       </div>
@@ -74,8 +97,23 @@ function Tile({
         <div className="text-xs tabular-nums text-muted-foreground">{sub}</div>
       ) : null}
       {children ? <div className="pt-1">{children}</div> : null}
-    </div>
+    </>
   );
+
+  if (linkTo) {
+    return (
+      <Link
+        to={linkTo.to}
+        params={linkTo.params}
+        search={linkTo.search}
+        className="flex min-w-0 flex-col gap-2 p-6 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+      >
+        {body}
+      </Link>
+    );
+  }
+
+  return <div className="flex min-w-0 flex-col gap-2 p-6">{body}</div>;
 }
 
 function UptimeTile({ siteId }: { siteId: string }) {
@@ -130,14 +168,149 @@ function LastBackupTile({ siteId }: { siteId: string }) {
   );
 }
 
-function VulnerabilitiesTile() {
-  // Not yet wired to a scan endpoint. Render an honest empty rather than a
-  // fabricated "0 findings" — asserting zero vulnerabilities would be a false
-  // fact when no scan has run.
-  return <Tile title="Vulnerabilities" value="–" sub="Not scanned yet" />;
+// ── Vulnerabilities tile ─────────────────────────────────────────────────────
+//
+// Reads the Security Suite vuln scanner (same data as the Security tab's
+// VulnPanel / vulnStatus()). SiteVulnsResponse has no aggregate count field,
+// so the open-finding count and worst severity are derived from `items[]`
+// here, exactly like vulnStatus() does in $siteId.security.tsx. worstSeverity
+// is exported from use-vuln.ts (next to isHighRisk/countHighRisk) and tested
+// in use-vuln.test.ts.
+
+function VulnerabilitiesTile({ siteId }: { siteId: string }) {
+  const { data, isPending, isError } = useSiteVulnerabilities(siteId);
+  // The Health tab has no rescan trigger of its own — the whole tile links to
+  // the Security tab, where "Rescan now" and the findings table live.
+  const linkTo: Pick<LinkProps, "to" | "params"> = {
+    to: "/sites/$siteId/security",
+    params: { siteId },
+  };
+
+  if (isPending) {
+    return (
+      <Tile title="Vulnerabilities" value="…" sub="Loading" linkTo={linkTo} />
+    );
+  }
+  if (isError || !data) {
+    return (
+      <Tile
+        title="Vulnerabilities"
+        value="–"
+        sub="Could not load scan results"
+        linkTo={linkTo}
+      />
+    );
+  }
+  // The instance has no Wordfence Intelligence feed connected. Render a
+  // neutral "not configured" state — never imply the site was scanned and
+  // found clean when no scan can run at all.
+  if (!data.feed_ok) {
+    return (
+      <Tile
+        title="Vulnerabilities"
+        value="–"
+        sub="Feed not configured"
+        linkTo={linkTo}
+      />
+    );
+  }
+
+  const openFindings = (data.items ?? []).filter((f) => f.status === "open");
+  if (openFindings.length === 0) {
+    return (
+      <Tile
+        title="Vulnerabilities"
+        value="0"
+        sub="No known vulnerabilities"
+        linkTo={linkTo}
+      />
+    );
+  }
+
+  const worst = worstSeverity(openFindings);
+  return (
+    <Tile
+      title="Vulnerabilities"
+      value={String(openFindings.length)}
+      sub="Open vulnerabilities"
+      linkTo={linkTo}
+    >
+      {worst ? <VulnSeverityChip severity={worst} /> : null}
+    </Tile>
+  );
 }
 
-function PerformanceTile() {
-  // Not yet wired to a performance endpoint. Honest empty, same reasoning.
-  return <Tile title="Performance" value="–" sub="Not measured yet" />;
+// ── Performance tile ─────────────────────────────────────────────────────────
+//
+// Reads the RUM Core Web Vitals summary (same endpoint as the fleet
+// Performance dashboard's FleetRumPanel). LCP is the headline metric — first
+// among the three core CWV metrics in FleetRumPanel / RumResultsTable.
+// findAggregateMetric / formatLcpP75 / RUM_RATING_* live in
+// features/perf/rum-tile.ts (tested in rum-tile.test.ts), where the device:""
+// aggregate-row contract with apps/api/internal/perf/rum_results_handler.go
+// is pinned.
+
+function PerformanceTile({ siteId }: { siteId: string }) {
+  const { data, isPending, isError } = useRumSummary(siteId);
+  // The Health tab has no drill-down of its own — the whole tile links to the
+  // fleet Performance dashboard, pre-scoped to this site.
+  const linkTo: Pick<LinkProps, "to" | "search"> = {
+    to: "/performance",
+    search: { site: siteId },
+  };
+
+  if (isPending) {
+    return <Tile title="Performance" value="…" sub="Loading" linkTo={linkTo} />;
+  }
+  if (isError || !data) {
+    return (
+      <Tile
+        title="Performance"
+        value="–"
+        sub="Could not load Core Web Vitals"
+        linkTo={linkTo}
+      />
+    );
+  }
+
+  const hasSamples = (data.metrics ?? []).length > 0;
+  if (!hasSamples) {
+    // RUM is off by default and stays passive even when enabled — a fresh or
+    // low-traffic site has no visitor measurements yet. Expected, not an error.
+    return (
+      <Tile
+        title="Performance"
+        value="–"
+        sub="No visitor data yet"
+        linkTo={linkTo}
+      />
+    );
+  }
+
+  const lcp = findAggregateMetric(data, "lcp");
+  if (!lcp || lcp.suppressed || !lcp.rating || lcp.p75_ms === undefined) {
+    // Some other metric has samples but LCP itself is below the site's
+    // min_sample_count floor. Never show a p75 for a suppressed slice.
+    return (
+      <Tile
+        title="Performance"
+        value="–"
+        sub="Not enough samples yet"
+        linkTo={linkTo}
+      />
+    );
+  }
+
+  return (
+    <Tile
+      title="Performance"
+      value={
+        <span className={RUM_RATING_CLASS[lcp.rating]}>
+          {formatLcpP75(lcp.p75_ms)}
+        </span>
+      }
+      sub={`LCP p75 · ${RUM_RATING_LABEL[lcp.rating]}`}
+      linkTo={linkTo}
+    />
+  );
 }


### PR DESCRIPTION
Both tiles were hardcoded placeholders ("Not scanned yet" / "Not measured yet") that read no data — while the vuln scanner (m79) + per-site RUM CWV are fully shipped and surfaced elsewhere. Now: VulnerabilitiesTile -> useSiteVulnerabilities (count + severity, or honest 'feed not configured' / 'no known vulnerabilities'); PerformanceTile -> useRumSummary (LCP p75 rating, or honest 'no visitor data yet'). Each links to the full view. No fabricated zeros/scores; honest empties. No backend change. web-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Health page now shows live Vulnerabilities and Performance tiles instead of placeholders.
  * These tiles now link directly to the full Security and Performance views.

* **Bug Fixes**
  * Added clearer empty states when data isn’t available, including pending loads, missing feeds, no visitor samples, and insufficient performance data.
  * Vulnerability severity is now summarized more accurately, and performance values are displayed with cleaner formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->