### PR TITLE
fix(backup): retention GC no longer deletes a within-retention parent files-list chunk (GH #168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.36] - 2026-07-07
+
+### Fixed
+
+- Fixed a backup-integrity bug where an incremental backup could fail with a "stalled" error because retention cleanup had deleted a parent snapshot's file-list data chunk while it was still well within the retention window, permanently breaking the incremental chain. The cause was that the internal reachability check which decides what to keep could be confused by duplicate snapshot rows at the same chain position (left behind by failed retries), letting a failed attempt shadow the real completed snapshot and drop its chunk from the "keep" set. Retention now always protects the completed snapshot at each chain position, and as a ground-truth safety net it never deletes a data chunk that any surviving snapshot still references, so a reachability mistake can never again cause silent data loss. A broken incremental chain now fails fast with a clear "run a full backup" message instead of stalling silently for two minutes. A migration de-duplicates any existing same-position snapshots and adds a constraint that prevents recurrence.
+
 ## [0.61.35] - 2026-07-07
 
 ### Fixed

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -1050,6 +1050,14 @@ CREATE UNIQUE INDEX backup_snapshots_one_inflight_per_site ON backup_snapshots (
 -- M7 / ADR-036 P1: presign routing + destination-CRUD cascade lookups.
 CREATE INDEX backup_snapshots_destination_id_idx ON backup_snapshots (destination_id)
     WHERE destination_id IS NOT NULL;
+-- m96 (GH #168): at most one COMPLETED row per (chain_id, generation). A
+-- failed/pending/running retry that reused a generation is unconstrained —
+-- only two COMPLETED rows at the same slot are rejected. Closes the
+-- duplicate-row gap that let a retention-GC reachability computation lose
+-- track of a within-retention chunk (see the m96 migration for the full
+-- root-cause writeup).
+CREATE UNIQUE INDEX backup_snapshots_chain_gen_completed_uidx ON backup_snapshots (chain_id, generation)
+    WHERE status = 'completed';
 
 ALTER TABLE backup_snapshots ENABLE ROW LEVEL SECURITY;
 ALTER TABLE backup_snapshots FORCE ROW LEVEL SECURITY;
@@ -1129,6 +1137,10 @@ CREATE TABLE backup_manifest_entries (
 
 CREATE INDEX backup_manifest_entries_snapshot_idx ON backup_manifest_entries (snapshot_id);
 CREATE INDEX backup_manifest_entries_tenant_id_idx ON backup_manifest_entries (tenant_id);
+-- m96 (GH #168 P2): serves the retention GC's ground-truth guard
+-- (ChunkStillReferenced: "is this hash still referenced by ANY manifest row
+-- for the tenant?") via an index scan instead of a sequential scan.
+CREATE INDEX backup_manifest_entries_chunk_hashes_gin ON backup_manifest_entries USING gin (chunk_hashes);
 
 ALTER TABLE backup_manifest_entries ENABLE ROW LEVEL SECURITY;
 ALTER TABLE backup_manifest_entries FORCE ROW LEVEL SECURITY;

--- a/apps/api/internal/backup/delete_cancel_test.go
+++ b/apps/api/internal/backup/delete_cancel_test.go
@@ -63,6 +63,18 @@ func (r *deleteCancelFakeRepo) ListChainSnapshots(_ context.Context, _ uuid.UUID
 	return out, nil
 }
 
+// ListCompletedChainSnapshots mirrors ListChainSnapshots filtered to
+// status==completed, matching the real repo's GH #168 hardened variant.
+func (r *deleteCancelFakeRepo) ListCompletedChainSnapshots(_ context.Context, _ uuid.UUID, chainID uuid.UUID, maxGen int) ([]Snapshot, error) {
+	var out []Snapshot
+	for _, s := range r.chains[chainID] {
+		if s.Generation <= maxGen && s.Status == StatusCompleted {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+
 func (r *deleteCancelFakeRepo) FailSnapshot(_ context.Context, _, snapshotID uuid.UUID, msg string) (Snapshot, error) {
 	r.failed[snapshotID] = msg
 	s := r.snapshots[snapshotID]
@@ -135,7 +147,7 @@ func (r *deleteCancelFakeRepo) DBNow(_ context.Context, _ uuid.UUID) (time.Time,
 func (r *deleteCancelFakeRepo) ListInFlightSnapshotFloor(_ context.Context, _ uuid.UUID) (time.Time, error) {
 	return time.Time{}, nil
 }
-func (r *deleteCancelFakeRepo) SweepTenantChunks(_ context.Context, _ uuid.UUID, _ time.Time, acquired *bool, _ func(SweepChunk) (bool, error)) error {
+func (r *deleteCancelFakeRepo) SweepTenantChunks(_ context.Context, _ uuid.UUID, _ time.Time, acquired *bool, _ func(SweepChunk, func() (bool, error)) (bool, error)) error {
 	*acquired = true
 	return nil
 }

--- a/apps/api/internal/backup/fleet_security_test.go
+++ b/apps/api/internal/backup/fleet_security_test.go
@@ -136,7 +136,7 @@ func (r *secFleetRepo) ListInFlightSnapshotFloor(_ context.Context, _ uuid.UUID)
 func (r *secFleetRepo) DBNow(_ context.Context, _ uuid.UUID) (time.Time, error) {
 	panic("secFleetRepo.DBNow not implemented")
 }
-func (r *secFleetRepo) SweepTenantChunks(_ context.Context, _ uuid.UUID, _ time.Time, _ *bool, _ func(SweepChunk) (bool, error)) error {
+func (r *secFleetRepo) SweepTenantChunks(_ context.Context, _ uuid.UUID, _ time.Time, _ *bool, _ func(SweepChunk, func() (bool, error)) (bool, error)) error {
 	panic("secFleetRepo.SweepTenantChunks not implemented")
 }
 func (r *secFleetRepo) CompleteIncrementalManifest(_ context.Context, _ CompleteIncrementalInput) (int64, int64, error) {
@@ -144,6 +144,9 @@ func (r *secFleetRepo) CompleteIncrementalManifest(_ context.Context, _ Complete
 }
 func (r *secFleetRepo) ListChainSnapshots(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ int) ([]Snapshot, error) {
 	panic("secFleetRepo.ListChainSnapshots not implemented")
+}
+func (r *secFleetRepo) ListCompletedChainSnapshots(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ int) ([]Snapshot, error) {
+	panic("secFleetRepo.ListCompletedChainSnapshots not implemented")
 }
 func (r *secFleetRepo) InsertFileIndexBatch(_ context.Context, _, _ uuid.UUID, _ []FileIndexEntry) error {
 	panic("secFleetRepo.InsertFileIndexBatch not implemented")

--- a/apps/api/internal/backup/gc.go
+++ b/apps/api/internal/backup/gc.go
@@ -19,6 +19,18 @@ import (
 // SWEEP has its own, stricter grace floor (min(markStart, in-flight floor)).
 const gcSafetyHorizon = time.Hour
 
+// gcDetachTimeout bounds a delete-triggered RunRetentionGC call that has been
+// detached from the request context (GH #168 P3; see DeleteSnapshotForUser /
+// BulkDeleteSnapshots). RunRetentionGC pins a pooled connection for a
+// per-tenant advisory lock across the WHOLE chunk sweep (gc.go's sweepChunks
+// doc), so letting a client disconnect / request timeout cancel it mid-pass
+// could abort a full tenant-wide reclamation partway through. Detaching avoids
+// that, but a genuinely wedged sweep must still eventually give up rather than
+// leak the goroutine/connection forever — 10 minutes is comfortably above any
+// real tenant's sweep duration (the periodic GCWorker has no such bound and is
+// the authoritative backstop regardless).
+const gcDetachTimeout = 10 * time.Minute
+
 // RunRetentionGCAllTenants runs the retention GC for every tenant that has
 // completed snapshots. Used by the periodic GC job. Per-tenant errors are
 // returned aggregated as the first failure; the caller logs and continues on
@@ -60,17 +72,37 @@ func (s *Service) RunRetentionGCAllTenants(ctx context.Context) (totalSnapshots,
 //     generation stays reachable under a live tip.
 //  3. MARK — liveSet := union of reachableChunks(retainedMaxGen) over the
 //     retained set. FAIL-CLOSED: any error aborts the sweep (delete nothing).
-//  4. SWEEP — under a per-tenant SESSION advisory lock, stream every chunk
+//  4. METADATA PRUNE — delete the expired snapshot rows (cascade file_index +
+//     manifest); no object delete, no refcount decref. GH #168: this now runs
+//     BEFORE the chunk sweep (swapped from the original 4/5 order) DELIBERATELY
+//     so Phase 5's P2 ground-truth guard can trust backup_manifest_entries: by
+//     the time it queries that table, every remaining row genuinely belongs to
+//     a SURVIVING snapshot, because an expired-and-pruned snapshot's manifest
+//     rows are already gone via the FK cascade. Without this ordering, a
+//     not-yet-pruned expired snapshot's manifest row would make the P2 guard
+//     see a false "still referenced" positive and keep a genuinely dead chunk
+//     forever (this was caught by TestGC_CrossSiteSharedChunk during review).
+//     PRUNE's OWN inputs (expiredIDs + markSnaps from Phase 0/2) do not depend
+//     on SWEEP, so the swap is safe in that direction; it is SWEEP's P2 guard
+//     that now depends on PRUNE having already run.
+//  5. SWEEP — under a per-tenant SESSION advisory lock, stream every chunk
 //     (short per-page txns; object deletes outside any tx); delete (object
 //     FIRST, then row) each chunk NOT in liveSet AND
 //     GREATEST(created_at, last_referenced_at) < effectiveFloor. The
 //     last_referenced_at term protects an OLD chunk an in-flight backup
-//     re-references via tenant-global dedup (the dedup oracle bumped it).
-//  5. METADATA PRUNE — delete the expired snapshot rows (cascade file_index +
-//     manifest); no object delete, no refcount decref.
+//     re-references via tenant-global dedup (the dedup oracle bumped it). The
+//     P2 ground-truth guard (the stillReferenced closure sweepChunks receives
+//     per candidate) additionally re-checks every unreachable candidate
+//     against live backup_manifest_entries, on the SAME pinned connection,
+//     before ever deleting it — see sweepChunks' doc.
 //
 // Returns the number of snapshots deleted and chunk objects swept.
 func (s *Service) RunRetentionGC(ctx context.Context, tenantID uuid.UUID) (snapshotsDeleted, chunksDeleted int, err error) {
+	// GH #168 P6: every pass gets a correlation id so a chunk deletion (or a P2
+	// guard trip) can be tied back to the specific run that made the decision —
+	// without this, a swept chunk left no trail explaining WHY it was gone.
+	gcRunID := uuid.NewString()
+
 	// --- Phase 0: SELECTION (per site) ----------------------------------------
 	siteIDs, err := s.repo.ListSiteIDsWithSnapshots(ctx, tenantID)
 	if err != nil {
@@ -180,7 +212,11 @@ func (s *Service) RunRetentionGC(ctx context.Context, tenantID uuid.UUID) (snaps
 	// We collect the distinct snapshots to mark (by ID) to avoid double work.
 	markSnaps := map[uuid.UUID]Snapshot{}
 	for chainID, maxGen := range chainMaxRetainedGen {
-		chainSnaps, cerr := s.repo.ListChainSnapshots(ctx, tenantID, chainID, maxGen)
+		// GH #168 P1b: completed-only, same rationale as reachableChunks — a
+		// failed/aborted duplicate-generation row must never enter the mark set
+		// (it would otherwise trigger a redundant, and pre-fix misleading,
+		// reachableChunks call for that row's own generation).
+		chainSnaps, cerr := s.repo.ListCompletedChainSnapshots(ctx, tenantID, chainID, maxGen)
 		if cerr != nil {
 			slog.WarnContext(ctx, "backup gc: chain expansion failed — aborting sweep (delete nothing)",
 				slog.String("tenant_id", tenantID.String()),
@@ -231,14 +267,7 @@ func (s *Service) RunRetentionGC(ctx context.Context, tenantID uuid.UUID) (snaps
 		}
 	}
 
-	// --- Phase 4: SWEEP (under per-tenant advisory lock) ----------------------
-	swept, swerr := s.sweepChunks(ctx, tenantID, liveSet, effectiveFloor)
-	chunksDeleted += swept
-	if swerr != nil {
-		return snapshotsDeleted, chunksDeleted, swerr
-	}
-
-	// --- Phase 5: METADATA PRUNE ----------------------------------------------
+	// --- Phase 4: METADATA PRUNE (GH #168: now runs BEFORE the chunk sweep) ---
 	// A generation that the chain-aware expansion pinned under a live tip must
 	// NOT be metadata-pruned: planRestoreChain requires every generation 0..tip
 	// to exist (CHECK 1), and deleting an older generation's file_index rows would
@@ -256,6 +285,22 @@ func (s *Service) RunRetentionGC(ctx context.Context, tenantID uuid.UUID) (snaps
 		// row is already gone; an error or an absent object is logged and ignored.
 		s.deleteManifestIndex(ctx, tenantID, sid, id)
 	}
+
+	// --- Phase 5: SWEEP (under per-tenant advisory lock) ----------------------
+	swept, swerr := s.sweepChunks(ctx, tenantID, gcRunID, liveSet, effectiveFloor)
+	chunksDeleted += swept
+	if swerr != nil {
+		return snapshotsDeleted, chunksDeleted, swerr
+	}
+
+	// GH #168 P6: a per-tenant summary line ties the run id to its outcome —
+	// without this a swept chunk (or its absence) was undiagnosable after the
+	// fact.
+	slog.InfoContext(ctx, "backup gc: run complete",
+		slog.String("gc_run_id", gcRunID),
+		slog.String("tenant_id", tenantID.String()),
+		slog.Int("snapshots_deleted", snapshotsDeleted),
+		slog.Int("chunks_deleted", chunksDeleted))
 
 	return snapshotsDeleted, chunksDeleted, nil
 }
@@ -285,13 +330,61 @@ func (s *Service) RunRetentionGC(ctx context.Context, tenantID uuid.UUID) (snaps
 //
 // Returns the number of chunks swept; a false advisory-lock acquisition skips
 // the tenant (returns 0, nil).
-func (s *Service) sweepChunks(ctx context.Context, tenantID uuid.UUID, liveSet map[string]struct{}, floor time.Time) (int, error) {
+//
+// GH #168 P2: before consulting the caller-computed liveSet's absence as
+// grounds for deletion, this ALSO independently asks the repo's ground truth
+// (stillReferenced: does any backup_manifest_entries row for the tenant still
+// list this hash?) for every candidate the liveSet marked unreachable. If the
+// database itself still references the hash, the chunk is kept and a WARNING
+// is logged — this is the signal that the liveSet computation has a bug —
+// even though the caller's liveSet said "safe to delete". This converts any
+// future reachability-computation defect (of the same class as #168's byGen
+// last-wins bug) into a safe skip instead of a silent chunk/data loss: ground
+// truth (the manifest tables) always outranks the computed liveSet proxy.
+//
+// stillReferenced is called LAZILY — only when the (cheap, in-memory) liveSet
+// check didn't already decide — and it is a closure the repo binds to the
+// SAME pinned connection/tx sweepOneChunk already holds the chunk's row-level
+// FOR UPDATE lock under (repo.go), never a second pooled connection. An
+// earlier version of this guard called a standalone Repo.ChunkStillReferenced
+// method that opened its own InTenantTx (a SECOND pool connection) while del
+// ran INSIDE the pinned-connection critical section — under concurrent
+// cross-tenant sweeps (the advisory lock only serializes same-tenant) that
+// could exhaust a small connection pool (e.g. Cloud SQL db-g1-small) and
+// freeze the whole instance. The lazy-closure design (repo.go's sweepOneChunk)
+// eliminates the second acquire entirely.
+//
+// TOCTOU: any concurrent manifest submission that would reference this chunk
+// (RecordManifest / CompleteIncrementalManifest) ALWAYS increments the
+// chunk's refcount / last_referenced_at in the SAME transaction as its
+// manifest-entry insert — so that whole transaction is blocked from
+// committing until sweepOneChunk releases the row lock, which means it
+// cannot yet be visible to stillReferenced's read either (a same-tx read is
+// exactly as unable to see it as a separate-connection read would be — the
+// row lock, not the connection, is what closes the race). A concurrent
+// submission racing the sweep therefore fails safe (keep).
+func (s *Service) sweepChunks(ctx context.Context, tenantID uuid.UUID, gcRunID string, liveSet map[string]struct{}, floor time.Time) (int, error) {
 	var (
 		swept    int
 		acquired bool
 	)
-	err := s.repo.SweepTenantChunks(ctx, tenantID, floor, &acquired, func(c SweepChunk) (bool, error) {
+	err := s.repo.SweepTenantChunks(ctx, tenantID, floor, &acquired, func(c SweepChunk, stillReferenced func() (bool, error)) (bool, error) {
 		if _, live := liveSet[c.Blake3]; live {
+			return false, nil
+		}
+		// P2 ground-truth guard — independent of, and stronger than, the liveSet
+		// check above. Only evaluated here (lazily) since the liveSet check above
+		// didn't already decide to keep the chunk.
+		referenced, rerr := stillReferenced()
+		if rerr != nil {
+			return false, rerr
+		}
+		if referenced {
+			slog.WarnContext(ctx, "backup gc: P2 guard kept a chunk the computed live-set marked unreachable — a manifest still references it (the reachability computation likely has a bug)",
+				slog.String("gc_run_id", gcRunID),
+				slog.String("tenant_id", tenantID.String()),
+				slog.String("blake3", c.Blake3),
+				slog.String("s3_key", c.S3Key))
 			return false, nil
 		}
 		// Use the newest of created_at / last_referenced_at as the liveness
@@ -311,6 +404,14 @@ func (s *Service) sweepChunks(ctx context.Context, tenantID uuid.UUID, liveSet m
 			return false, derr
 		}
 		swept++
+		// GH #168 P6: log every deletion (not merely a sample) — the reported bug
+		// was undiagnosable precisely because nothing recorded which chunks the
+		// sweep removed.
+		slog.InfoContext(ctx, "backup gc: swept chunk",
+			slog.String("gc_run_id", gcRunID),
+			slog.String("tenant_id", tenantID.String()),
+			slog.String("blake3", c.Blake3),
+			slog.String("s3_key", c.S3Key))
 		return true, nil
 	})
 	if !acquired {

--- a/apps/api/internal/backup/gc_mark_sweep_test.go
+++ b/apps/api/internal/backup/gc_mark_sweep_test.go
@@ -58,6 +58,12 @@ func (s *gcStore) Delete(_ context.Context, key string) error {
 type gcFakeRepo struct {
 	// snapshots by ID.
 	snaps map[uuid.UUID]Snapshot
+	// snapOrder records addSnap insertion order (a plain Go map has no stable
+	// iteration order, so ListCompletedChainSnapshots — GH #168 — replays THIS
+	// order for a chain's rows to give the P1a/P1b tests a deterministic,
+	// reproducible physical-scan-order stand-in, rather than depending on Go's
+	// randomized map iteration).
+	snapOrder []uuid.UUID
 	// chunks: blake3 -> (s3_key, created_at).
 	chunks map[string]gcChunk
 	// fileIndex: snapshotID -> rows.
@@ -104,7 +110,12 @@ func newGCFakeRepo(now time.Time) *gcFakeRepo {
 	}
 }
 
-func (r *gcFakeRepo) addSnap(s Snapshot) { r.snaps[s.ID] = s }
+func (r *gcFakeRepo) addSnap(s Snapshot) {
+	if _, exists := r.snaps[s.ID]; !exists {
+		r.snapOrder = append(r.snapOrder, s.ID)
+	}
+	r.snaps[s.ID] = s
+}
 func (r *gcFakeRepo) addChunk(hash string, created time.Time) {
 	// last_referenced_at defaults to created_at (the m47 backfill semantics): an
 	// untouched chunk's liveness boundary is just its creation time.
@@ -178,6 +189,45 @@ func (r *gcFakeRepo) ListChainSnapshots(_ context.Context, _ uuid.UUID, chainID 
 	return out, nil
 }
 
+// ListCompletedChainSnapshots is the GH #168 hardened variant real gc.go /
+// reachableChunks now call exclusively: status=='completed' only, replaying
+// snapOrder (insertion order) rather than Go's randomized map iteration so a
+// duplicate-generation regression test is reproducible instead of flaky.
+func (r *gcFakeRepo) ListCompletedChainSnapshots(_ context.Context, _ uuid.UUID, chainID uuid.UUID, maxGen int) ([]Snapshot, error) {
+	var out []Snapshot
+	for _, id := range r.snapOrder {
+		s := r.snaps[id]
+		if s.ChainID != nil && *s.ChainID == chainID && s.Generation <= maxGen && s.Status == StatusCompleted {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+
+// chunkStillReferenced is the GH #168 P2 guard's ground truth in this fake:
+// mirrors the real repo exactly — r.manifest (backup_manifest_entries) ONLY,
+// for any snapshot still present in r.snaps (a metadata-pruned snapshot's
+// manifest rows are gone too, mirroring the real FK cascade). Deliberately
+// does NOT consult r.fileIndex (backup_file_index): see chunkStillReferencedOnTx
+// (repo.go) for why that table's per-file HISTORY rows (a still-retained
+// generation can legitimately carry a SUPERSEDED path version) would make the
+// guard unsound — TestGC_CarryForwardOrigin_KeepsOldChunk's "g0only" is
+// exactly such a superseded-but-still-present row, and must remain sweepable.
+// Called via the lazy closure SweepTenantChunks hands to del below, mirroring
+// how the real repo binds it to the pinned tx instead of a second connection.
+func (r *gcFakeRepo) chunkStillReferenced(blake3 string) (bool, error) {
+	for snapID := range r.snaps {
+		for _, e := range r.manifest[snapID] {
+			for _, h := range e.ChunkHashes {
+				if h == blake3 {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
+}
+
 func (r *gcFakeRepo) GetSnapshot(_ context.Context, _, snapshotID uuid.UUID) (Snapshot, error) {
 	if s, ok := r.snaps[snapshotID]; ok {
 		return s, nil
@@ -223,7 +273,7 @@ func (r *gcFakeRepo) DeleteSnapshot(_ context.Context, _, snapshotID uuid.UUID) 
 	return nil
 }
 
-func (r *gcFakeRepo) SweepTenantChunks(_ context.Context, _ uuid.UUID, floor time.Time, acquired *bool, del func(SweepChunk) (bool, error)) error {
+func (r *gcFakeRepo) SweepTenantChunks(_ context.Context, _ uuid.UUID, floor time.Time, acquired *bool, del func(SweepChunk, func() (bool, error)) (bool, error)) error {
 	if r.lockHeld {
 		*acquired = false
 		return nil
@@ -265,9 +315,14 @@ func (r *gcFakeRepo) SweepTenantChunks(_ context.Context, _ uuid.UUID, floor tim
 		}
 		// Still deletable under the lock: del consults the live set + floor on the
 		// FRESH projection and does the object delete while the row is "locked".
+		// stillReferenced is a lazy closure (mirrors the real repo's pinned-tx
+		// binding — this fake has no connection to pin, but the CALL CONTRACT
+		// — evaluated only if/when del needs it — is what matters here).
+		hashCopy := hash
+		stillReferenced := func() (bool, error) { return r.chunkStillReferenced(hashCopy) }
 		remove, err := del(SweepChunk{
 			Blake3: hash, S3Key: c.s3Key, CreatedAt: c.createdAt, LastReferencedAt: c.lastReferencedAt,
-		})
+		}, stillReferenced)
 		if err != nil {
 			return err
 		}

--- a/apps/api/internal/backup/gh168_chain_gc_test.go
+++ b/apps/api/internal/backup/gh168_chain_gc_test.go
@@ -1,0 +1,293 @@
+package backup
+
+// gh168_chain_gc_test.go — GH #168 CRITICAL regression coverage: a retention-GC
+// reachability computation lost track of a within-retention parent files-list
+// chunk (because a failed/aborted incremental retry reused a (chain_id,
+// generation) pair) and permanently broke an incremental chain. These are the
+// white-box (in-memory gcFakeRepo, no DB) counterparts to the real-Postgres
+// integration tests in tests/backup_gh168_integration_test.go:
+//
+//   - P1a (chainGenWinner): the deterministic byGen tiebreak, tested both as a
+//     pure function and end-to-end through reachableChunks.
+//   - P2 (sweepChunks' ground-truth guard): proven independent of P1 by
+//     directly injecting a wrong/incomplete liveSet.
+//
+// The "no orphan leak" (T5) property is already exercised by the EXISTING
+// TestGC_CarryForwardOrigin_KeepsOldChunk ("g0only") and
+// TestGC_CrossSiteSharedChunk ("a_only") in gc_mark_sweep_test.go — both
+// still correctly sweep a genuinely-dead chunk with every GH #168 fix
+// (including the P2 guard) fully wired in; see backup_bulk_delete/gh168
+// integration tests for the real-Postgres equivalent.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// P1a: chainGenWinner — pure-function unit tests (order-independent by
+// construction, no fake repo / no map-iteration involved).
+// ---------------------------------------------------------------------------
+
+// TestChainGenWinner_CompletedBeatsNonCompleted proves a completed row always
+// wins over a non-completed one, regardless of which is passed as `existing`
+// vs `candidate` (i.e. regardless of scan/iteration order).
+func TestChainGenWinner_CompletedBeatsNonCompleted(t *testing.T) {
+	completed := Snapshot{ID: uuid.New(), Status: StatusCompleted}
+	failed := Snapshot{ID: uuid.New(), Status: StatusFailed}
+
+	if got := chainGenWinner(completed, failed); got.ID != completed.ID {
+		t.Errorf("chainGenWinner(completed, failed) = %s, want the completed row %s", got.ID, completed.ID)
+	}
+	if got := chainGenWinner(failed, completed); got.ID != completed.ID {
+		t.Errorf("chainGenWinner(failed, completed) = %s, want the completed row %s (a completed snapshot must never be shadowed)", got.ID, completed.ID)
+	}
+}
+
+// TestChainGenWinner_TwoCompletedStableLowestID proves that between two
+// completed rows sharing a generation (the narrow legacy/race case the m96
+// partial unique index closes going forward), the LOWEST snapshot ID wins,
+// deterministically, regardless of argument order.
+func TestChainGenWinner_TwoCompletedStableLowestID(t *testing.T) {
+	a := Snapshot{ID: uuid.New(), Status: StatusCompleted}
+	b := Snapshot{ID: uuid.New(), Status: StatusCompleted}
+	if bytes.Compare(a.ID[:], b.ID[:]) > 0 {
+		a, b = b, a
+	}
+	// a.ID < b.ID now.
+	if got := chainGenWinner(a, b); got.ID != a.ID {
+		t.Errorf("chainGenWinner(a, b) = %s, want the lower id %s", got.ID, a.ID)
+	}
+	if got := chainGenWinner(b, a); got.ID != a.ID {
+		t.Errorf("chainGenWinner(b, a) = %s, want the lower id %s (stable regardless of argument order)", got.ID, a.ID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// P1a + P1b end-to-end through reachableChunks (the real oracle GC/restore
+// share), via gcFakeRepo.
+// ---------------------------------------------------------------------------
+
+// buildArchiveDeltaChain seeds a completed ADR-051 archive-delta chain 0..maxGen
+// in repo: each generation carries a files-list entry (hash "fl<gen>") and one
+// wp-content zip-part entry (hash "part<gen>"), and both chunks are registered
+// as stored. Returns the per-generation Snapshot values (index == generation).
+func buildArchiveDeltaChain(repo *gcFakeRepo, tenantID, siteID, chainID uuid.UUID, maxGen int, createdAt time.Time) []Snapshot {
+	snaps := make([]Snapshot, maxGen+1)
+	for gen := 0; gen <= maxGen; gen++ {
+		s := gcSnap(tenantID, siteID, chainID, gen, gen > 0, createdAt)
+		repo.addSnap(s)
+		fl := fmt.Sprintf("fl%d", gen)
+		part := fmt.Sprintf("part%d", gen)
+		repo.manifest[s.ID] = []ManifestEntry{
+			{Path: "files.list", EntryKind: EntryKindFilesList, ChunkHashes: []string{fl}},
+			{Path: fmt.Sprintf("wp-content.part%03d.zip", gen), EntryKind: EntryKindWPContent, ChunkHashes: []string{part}},
+		}
+		repo.addChunk(fl, createdAt)
+		repo.addChunk(part, createdAt)
+		snaps[gen] = s
+	}
+	return snaps
+}
+
+// TestReachableChunks_FailedDuplicateGenerationDoesNotShadowCompleted is the
+// white-box counterpart of the GH #168 regression: a failed retry reused
+// generation 4 (empty manifest) AFTER the real completed gen-4 row. Pre-P1b
+// (raw ListChainSnapshots, no status filter) this could shadow the completed
+// row's real manifest in byGen[4] depending on scan order; post-fix the
+// completed-only SQL variant excludes the failed row outright, so this MUST
+// pass regardless of insertion order — proven by running both orders.
+func TestReachableChunks_FailedDuplicateGenerationDoesNotShadowCompleted(t *testing.T) {
+	for _, name := range []string{"failed_inserted_after_completed", "failed_inserted_before_completed"} {
+		t.Run(name, func(t *testing.T) {
+			now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+			tenantID, siteID, chainID := uuid.New(), uuid.New(), uuid.New()
+			old := now.Add(-24 * time.Hour)
+
+			repo := newGCFakeRepo(now)
+
+			dupFailed := gcSnap(tenantID, siteID, chainID, 4, true, now.Add(-time.Hour))
+			dupFailed.Status = StatusFailed
+			// dupFailed's manifest is intentionally left unset (nil == empty) —
+			// exactly the #168 scenario (a failed retry with no real manifest).
+
+			var chain []Snapshot
+			if name == "failed_inserted_before_completed" {
+				repo.addSnap(dupFailed)
+				chain = buildArchiveDeltaChain(repo, tenantID, siteID, chainID, 4, old)
+			} else {
+				chain = buildArchiveDeltaChain(repo, tenantID, siteID, chainID, 4, old)
+				repo.addSnap(dupFailed)
+			}
+
+			svc := buildGCSvc(repo, newGCStore(), now)
+			reach, err := svc.reachableChunks(context.Background(), tenantID, chain[4], 4)
+			if err != nil {
+				t.Fatalf("reachableChunks error: %v", err)
+			}
+			for gen := 0; gen <= 4; gen++ {
+				for _, want := range []string{fmt.Sprintf("fl%d", gen), fmt.Sprintf("part%d", gen)} {
+					if _, ok := reach[want]; !ok {
+						t.Errorf("reachableChunks missing %q — the failed gen-4 duplicate shadowed the completed row's real manifest", want)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestReachableChunks_TwoCompletedDuplicateGenerationsResolveToLowestID
+// exercises P1a specifically: TWO rows at generation 4 are BOTH status=
+// completed (the SQL completed-only filter alone cannot disambiguate this —
+// only the m96 partial unique index prevents it going forward, and only
+// chainGenWinner's Go-side tiebreak makes existing/legacy duplicate data safe
+// to read). The lower-id row carries the REAL manifest; the higher-id row is
+// an empty-manifest duplicate. The real row must win regardless of which one
+// was inserted (and therefore iterated) first.
+func TestReachableChunks_TwoCompletedDuplicateGenerationsResolveToLowestID(t *testing.T) {
+	for _, insertBadFirst := range []bool{false, true} {
+		t.Run(fmt.Sprintf("insertBadFirst=%v", insertBadFirst), func(t *testing.T) {
+			now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+			tenantID, siteID, chainID := uuid.New(), uuid.New(), uuid.New()
+			old := now.Add(-24 * time.Hour)
+
+			repo := newGCFakeRepo(now)
+			buildArchiveDeltaChain(repo, tenantID, siteID, chainID, 3, old)
+
+			good := gcSnap(tenantID, siteID, chainID, 4, true, now.Add(-time.Hour))
+			bad := gcSnap(tenantID, siteID, chainID, 4, true, now.Add(-time.Hour))
+			if bytes.Compare(good.ID[:], bad.ID[:]) > 0 {
+				good.ID, bad.ID = bad.ID, good.ID
+			}
+			repo.manifest[good.ID] = []ManifestEntry{
+				{Path: "files.list", EntryKind: EntryKindFilesList, ChunkHashes: []string{"fl4"}},
+				{Path: "wp-content.part004.zip", EntryKind: EntryKindWPContent, ChunkHashes: []string{"part4"}},
+			}
+			// bad.manifest is intentionally left unset (empty duplicate).
+			repo.addChunk("fl4", old)
+			repo.addChunk("part4", old)
+
+			if insertBadFirst {
+				repo.addSnap(bad)
+				repo.addSnap(good)
+			} else {
+				repo.addSnap(good)
+				repo.addSnap(bad)
+			}
+
+			svc := buildGCSvc(repo, newGCStore(), now)
+			reach, err := svc.reachableChunks(context.Background(), tenantID, good, 4)
+			if err != nil {
+				t.Fatalf("reachableChunks error: %v", err)
+			}
+			for _, want := range []string{"fl4", "part4"} {
+				if _, ok := reach[want]; !ok {
+					t.Errorf("insertBadFirst=%v: reachableChunks missing %q — the higher-id empty duplicate shadowed the lower-id completed row", insertBadFirst, want)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// P2: sweepChunks' ground-truth guard, tested INDEPENDENTLY of P1 by directly
+// injecting a wrong/incomplete liveSet (simulating any future reachability-
+// computation regression, not specifically #168's).
+// ---------------------------------------------------------------------------
+
+// TestSweepChunks_P2GuardKeepsManifestReferencedChunk proves the guard keeps a
+// chunk the (deliberately wrong, empty) liveSet marked unreachable, because a
+// retained snapshot's manifest still references it — and that it logs a WARN
+// carrying the gc_run_id, so the regression is diagnosable (P6).
+func TestSweepChunks_P2GuardKeepsManifestReferencedChunk(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	tenantID, siteID := uuid.New(), uuid.New()
+
+	snap := gcSnap(tenantID, siteID, uuid.New(), 0, false, now.Add(-24*time.Hour))
+	snap.ChainID = nil // a non-chained, manifest-only full backup.
+
+	repo := newGCFakeRepo(now)
+	repo.addSnap(snap)
+	repo.manifest[snap.ID] = []ManifestEntry{
+		{Path: "full.zip", EntryKind: EntryKindFile, ChunkHashes: []string{"keep-me"}},
+	}
+	ancient := now.Add(-90 * 24 * time.Hour) // well past any grace floor.
+	repo.addChunk("keep-me", ancient)
+
+	store := newGCStore()
+	svc := buildGCSvc(repo, store, now)
+
+	var buf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(prevLogger)
+
+	// The caller's liveSet is EMPTY — simulating ANY reachability-computation
+	// bug (independent of #168's specific root cause) that failed to mark
+	// "keep-me" as reachable even though a retained manifest still needs it.
+	liveSet := map[string]struct{}{}
+	floor := now
+
+	swept, err := svc.sweepChunks(context.Background(), tenantID, "test-gc-run-id", liveSet, floor)
+	if err != nil {
+		t.Fatalf("sweepChunks error: %v", err)
+	}
+	if swept != 0 {
+		t.Fatalf("swept = %d, want 0 — the P2 guard must keep a manifest-referenced chunk regardless of what liveSet said", swept)
+	}
+	if _, ok := repo.chunks["keep-me"]; !ok {
+		t.Fatal("P2 guard failed: the chunk ROW was deleted despite still being manifest-referenced")
+	}
+	if store.deleted[chunkS3Key(uuid.Nil, "keep-me")] {
+		t.Fatal("P2 guard failed: the chunk OBJECT was deleted despite still being manifest-referenced")
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "P2 guard kept a chunk") {
+		t.Errorf("expected a P2 guard WARN log line, got: %s", logged)
+	}
+	if !strings.Contains(logged, "test-gc-run-id") {
+		t.Errorf("expected the WARN log to carry the gc_run_id for diagnosability (P6), got: %s", logged)
+	}
+	if !strings.Contains(logged, "keep-me") {
+		t.Errorf("expected the WARN log to name the blake3 hash, got: %s", logged)
+	}
+}
+
+// TestSweepChunks_P2GuardDoesNotBlockGenuinelyUnreachableChunk is the
+// adversarial counterpart (T5-class): a chunk that is BOTH absent from
+// liveSet AND not referenced by any manifest must still be swept — the P2
+// guard must never degrade GC into a no-op / storage leak.
+func TestSweepChunks_P2GuardDoesNotBlockGenuinelyUnreachableChunk(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	tenantID := uuid.New()
+
+	repo := newGCFakeRepo(now)
+	ancient := now.Add(-90 * 24 * time.Hour)
+	repo.addChunk("truly-orphaned", ancient)
+	// No snapshot / manifest entry anywhere references "truly-orphaned".
+
+	store := newGCStore()
+	svc := buildGCSvc(repo, store, now)
+
+	liveSet := map[string]struct{}{}
+	swept, err := svc.sweepChunks(context.Background(), tenantID, "test-gc-run-id", liveSet, now)
+	if err != nil {
+		t.Fatalf("sweepChunks error: %v", err)
+	}
+	if swept != 1 {
+		t.Fatalf("swept = %d, want 1 — a genuinely orphaned chunk must still be reclaimed (P2 must not leak storage)", swept)
+	}
+	if _, ok := repo.chunks["truly-orphaned"]; ok {
+		t.Error("genuinely orphaned chunk row should have been swept")
+	}
+	if !store.deleted[chunkS3Key(uuid.Nil, "truly-orphaned")] {
+		t.Error("genuinely orphaned chunk object should have been deleted")
+	}
+}

--- a/apps/api/internal/backup/incremental_service_test.go
+++ b/apps/api/internal/backup/incremental_service_test.go
@@ -229,7 +229,7 @@ func (r *fakeRepo) ListInFlightSnapshotFloor(_ context.Context, _ uuid.UUID) (ti
 func (r *fakeRepo) DBNow(_ context.Context, _ uuid.UUID) (time.Time, error) {
 	panic("fakeRepo.DBNow not implemented")
 }
-func (r *fakeRepo) SweepTenantChunks(_ context.Context, _ uuid.UUID, _ time.Time, _ *bool, _ func(SweepChunk) (bool, error)) error {
+func (r *fakeRepo) SweepTenantChunks(_ context.Context, _ uuid.UUID, _ time.Time, _ *bool, _ func(SweepChunk, func() (bool, error)) (bool, error)) error {
 	panic("fakeRepo.SweepTenantChunks not implemented")
 }
 func (r *fakeRepo) CompleteIncrementalManifest(_ context.Context, in CompleteIncrementalInput) (int64, int64, error) {
@@ -255,6 +255,9 @@ func (r *fakeRepo) CompleteIncrementalManifest(_ context.Context, in CompleteInc
 }
 func (r *fakeRepo) ListChainSnapshots(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ int) ([]Snapshot, error) {
 	panic("fakeRepo.ListChainSnapshots not implemented")
+}
+func (r *fakeRepo) ListCompletedChainSnapshots(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ int) ([]Snapshot, error) {
+	panic("fakeRepo.ListCompletedChainSnapshots not implemented")
 }
 func (r *fakeRepo) SetSnapshotLocked(_ context.Context, _, id uuid.UUID, locked bool) (Snapshot, error) {
 	r.mu.Lock()

--- a/apps/api/internal/backup/repo.go
+++ b/apps/api/internal/backup/repo.go
@@ -179,12 +179,27 @@ type Repo interface {
 	// and streams every chunk keyset-paged by (created_at, blake3) using SHORT
 	// per-page transactions, so no pooled connection is pinned across object-store
 	// I/O (avoiding Cloud SQL's idle_in_transaction_session_timeout). For each
-	// chunk it invokes del(SweepChunk) OUTSIDE any transaction — del does the
-	// object-FIRST delete and returns true when the row should now be removed; the
-	// repo then removes those rows in a SHORT delete tx, re-checking
-	// GREATEST(created_at, last_referenced_at) < floor at the DB. The session lock
-	// keeps the per-tenant sweep exclusive across the whole pass. Tenant-scoped.
-	SweepTenantChunks(ctx context.Context, tenantID uuid.UUID, floor time.Time, acquired *bool, del func(c SweepChunk) (bool, error)) error
+	// chunk it invokes del(SweepChunk, stillReferenced) INSIDE the per-chunk
+	// FOR UPDATE critical section (on the SAME pinned connection) — del does the
+	// object-FIRST delete and returns true when the row should now be removed;
+	// the repo then removes those rows in the SAME short-lived tx, re-checking
+	// GREATEST(created_at, last_referenced_at) < floor at the DB. The session
+	// lock keeps the per-tenant sweep exclusive across the whole pass.
+	//
+	// stillReferenced is the GH #168 P2 ground-truth guard, LAZILY evaluated:
+	// calling it runs "does any backup_manifest_entries row for the tenant still
+	// list this hash?" on the SAME pinned connection/tx sweepOneChunk already
+	// holds the row's FOR UPDATE lock under — never a second pooled connection
+	// (a second Acquire from inside an already-pinned-connection critical
+	// section risks pool exhaustion under concurrent sweeps; see gc.go's
+	// sweepChunks for why del calls it only when the liveSet check didn't
+	// already decide). Deliberately scoped to backup_manifest_entries only (NOT
+	// backup_file_index — see chunkStillReferencedOnTx's doc for why that
+	// table's per-file HISTORY rows would make the check unsound). If it
+	// reports true, del should skip the delete regardless of what the
+	// (possibly buggy) liveSet computation concluded — ground truth always
+	// outranks the computed liveSet proxy. Tenant-scoped.
+	SweepTenantChunks(ctx context.Context, tenantID uuid.UUID, floor time.Time, acquired *bool, del func(c SweepChunk, stillReferenced func() (bool, error)) (bool, error)) error
 
 	// CompleteIncrementalManifest atomically records an incremental submission:
 	// it inserts the backup_file_index rows, optionally records the DB-dump
@@ -225,6 +240,21 @@ type Repo interface {
 	// its own ID. Tenant-scoped. Returns an empty slice (not an error) when no
 	// rows match.
 	ListChainSnapshots(ctx context.Context, tenantID uuid.UUID, chainID uuid.UUID, maxGeneration int) ([]Snapshot, error)
+
+	// ListCompletedChainSnapshots is the GH #168 hardened variant of
+	// ListChainSnapshots: it applies "AND status='completed'" IN SQL so a
+	// failed/aborted retry that reused a (chain_id, generation) pair (no unique
+	// constraint covers terminal rows pre-m96) can never be returned in place of
+	// the real completed row for that generation. reachableChunks (the shared
+	// GC-mark/restore reachability oracle) uses this instead of ListChainSnapshots
+	// so a duplicate-generation row is filtered at the SQL layer, independent of
+	// the Go-side byGen dedup (chainGenWinner) — two independent layers protecting
+	// the same invariant. Ordered by generation ASC, id ASC: the id tiebreak
+	// makes the (rare, pre-migration-only) case of two genuinely completed rows
+	// at the same generation deterministic rather than depending on physical scan
+	// order. Tenant-scoped. Returns an empty slice (not an error) when no rows
+	// match.
+	ListCompletedChainSnapshots(ctx context.Context, tenantID uuid.UUID, chainID uuid.UUID, maxGeneration int) ([]Snapshot, error)
 
 	// ADR-048 incremental backup file index.
 
@@ -1267,7 +1297,7 @@ func (r *pgRepo) DBNow(ctx context.Context, tenantID uuid.UUID) (time.Time, erro
 	return out, err
 }
 
-func (r *pgRepo) SweepTenantChunks(ctx context.Context, tenantID uuid.UUID, floor time.Time, acquired *bool, del func(c SweepChunk) (bool, error)) (err error) {
+func (r *pgRepo) SweepTenantChunks(ctx context.Context, tenantID uuid.UUID, floor time.Time, acquired *bool, del func(c SweepChunk, stillReferenced func() (bool, error)) (bool, error)) (err error) {
 	*acquired = false
 
 	// 1. PIN ONE pooled connection for the WHOLE sweep pass. The per-tenant GC
@@ -1409,7 +1439,7 @@ func (r *pgRepo) SweepTenantChunks(ctx context.Context, tenantID uuid.UUID, floo
 // crash after the object delete but before COMMIT rolls the tx back, leaving the
 // row present with its object gone — the dangling-row case the next sweep heals
 // idempotently. A missing row (already swept by a prior partial pass) is a no-op.
-func (r *pgRepo) sweepOneChunk(ctx context.Context, conn sweepConn, tenantID uuid.UUID, c SweepChunk, floor time.Time, del func(SweepChunk) (bool, error)) error {
+func (r *pgRepo) sweepOneChunk(ctx context.Context, conn sweepConn, tenantID uuid.UUID, c SweepChunk, floor time.Time, del func(SweepChunk, func() (bool, error)) (bool, error)) error {
 	return r.inTenantTxOnConn(ctx, conn, tenantID, func(tx pgx.Tx) error {
 		// 1. Lock the row and re-read the fresh liveness boundary.
 		fresh := SweepChunk{Blake3: c.Blake3}
@@ -1440,18 +1470,64 @@ func (r *pgRepo) sweepOneChunk(ctx context.Context, conn sweepConn, tenantID uui
 
 		// 3. del consults the live set + floor on the FRESH projection and, when the
 		//    chunk is still deletable, deletes the OBJECT while we hold the lock.
-		remove, ferr := del(fresh)
+		//    stillReferenced (GH #168 P2) is a LAZY closure bound to THIS pinned tx
+		//    — del calls it only if it needs to (the liveSet check is cheap and
+		//    usually short-circuits first), and when called it runs the EXISTS
+		//    query on the SAME connection/tx already holding the FOR UPDATE lock,
+		//    never acquiring a second pooled connection.
+		stillReferenced := func() (bool, error) {
+			return chunkStillReferencedOnTx(ctx, tx, tenantID, c.Blake3)
+		}
+		remove, ferr := del(fresh, stillReferenced)
 		if ferr != nil {
 			return ferr
 		}
 		if !remove {
-			return nil // del decided to keep (live, or re-checked floor).
+			return nil // del decided to keep (live, still-referenced, or re-checked floor).
 		}
 
 		// 4. Row-SECOND: delete the row, still under the held lock and re-checking
 		//    GREATEST(...) < floor at the DB (defense-in-depth).
 		return r.deleteSweptChunkOnTx(ctx, tx, tenantID, c.Blake3, floor)
 	})
+}
+
+// chunkStillReferencedOnTx is the GH #168 P2 ground-truth guard's query,
+// runnable on ANY transaction (the pinned sweep tx, via sweepOneChunk's lazy
+// closure). It checks backup_manifest_entries ONLY — deliberately NOT
+// backup_file_index. backup_manifest_entries rows are per-generation, and for
+// every model that writes them (ADR-051 archive-delta parts/files-list/
+// tombstones, and legacy full/DB-dump manifests) every row belonging to a
+// still-retained (non-metadata-pruned) snapshot is, by construction, part of
+// what a retained generation needs — there is no "superseded-but-still-
+// present" row in that table. backup_file_index is different: it is an
+// ADR-048 per-file HISTORY table, and a still-retained (e.g. carry-forward-
+// pinned) generation's rows can legitimately include paths that were later
+// SUPERSEDED by a newer generation's version of the same path — those rows'
+// chunk_hashes are genuinely dead even though the row itself persists. Treating
+// "any backup_file_index row mentions this hash" as ground truth would make
+// GC permanently retain every historical version of every file for as long as
+// its owning generation survives, defeating retention for the legacy model
+// entirely — the opposite failure mode from #168 (leak, not loss). Uses the
+// array-containment operator (`@>`) rather than `= ANY(...)` so the m96 GIN
+// index on chunk_hashes can serve the lookup instead of a sequential scan; the
+// tenant_id index narrows the row set either way. The caller is responsible
+// for tenant scoping (the query includes an explicit tenant_id filter, but —
+// unlike the rest of this package — this does NOT run inside InTenantTx/RLS,
+// since it executes on a caller-supplied tx that is already tenant-scoped).
+func chunkStillReferencedOnTx(ctx context.Context, tx pgx.Tx, tenantID uuid.UUID, blake3 string) (bool, error) {
+	var referenced bool
+	row := tx.QueryRow(ctx,
+		`SELECT EXISTS (
+		   SELECT 1 FROM backup_manifest_entries
+		    WHERE tenant_id = $1 AND chunk_hashes @> ARRAY[$2]::text[]
+		 )`,
+		tenantID, blake3,
+	)
+	if err := row.Scan(&referenced); err != nil {
+		return false, domain.Internal("backup_chunk_still_referenced_failed", "failed to check whether a chunk is still manifest-referenced").WithCause(err)
+	}
+	return referenced, nil
 }
 
 // sweepConn is the minimal pinned-connection surface the sweep needs: just the
@@ -2329,6 +2405,41 @@ func (r *pgRepo) ListChainSnapshots(ctx context.Context, tenantID uuid.UUID, cha
 		)
 		if err != nil {
 			return domain.Internal("backup_chain_snapshots_list_failed", "failed to list chain snapshots").WithCause(err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			s, serr := scanSnapshotWithChainFields(rows)
+			if serr != nil {
+				return domain.Internal("backup_chain_snapshots_scan_failed", "failed to scan chain snapshot row").WithCause(serr)
+			}
+			out = append(out, s)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+// ListCompletedChainSnapshots is the GH #168 hardened variant of
+// ListChainSnapshots: identical predicate plus "AND status='completed'", so a
+// failed/aborted retry that reused a (chain_id, generation) pair is never
+// returned. `, id ASC` is an additional deterministic tiebreak (belt-and-
+// suspenders alongside the m96 partial unique index) for the narrow window
+// before that index exists / on a not-yet-migrated self-host database where two
+// completed rows could still share a generation.
+func (r *pgRepo) ListCompletedChainSnapshots(ctx context.Context, tenantID uuid.UUID, chainID uuid.UUID, maxGeneration int) ([]Snapshot, error) {
+	var out []Snapshot
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx,
+			snapshotSelectColumns+` FROM backup_snapshots
+			  WHERE tenant_id = $1
+			    AND chain_id  = $2
+			    AND generation <= $3
+			    AND status = 'completed'
+			  ORDER BY generation ASC, id ASC`,
+			tenantID, chainID, maxGeneration,
+		)
+		if err != nil {
+			return domain.Internal("backup_chain_snapshots_list_failed", "failed to list completed chain snapshots").WithCause(err)
 		}
 		defer rows.Close()
 		for rows.Next() {

--- a/apps/api/internal/backup/restore_chain_test.go
+++ b/apps/api/internal/backup/restore_chain_test.go
@@ -73,6 +73,25 @@ func (r *chainFakeRepo) ListChainSnapshots(_ context.Context, _ uuid.UUID, chain
 	return out, nil
 }
 
+// ListCompletedChainSnapshots mirrors ListChainSnapshots filtered to
+// status==completed (GH #168), matching the real repo's hardened variant that
+// reachableChunks uses. Every fixture snapshot in this file's tests is built
+// via mkSnap (always StatusCompleted), so this is behaviourally identical to
+// ListChainSnapshots for the existing chain-restore suite; TC-6 deliberately
+// constructs a non-completed row but exercises PlanRestore's OWN separate
+// ListChainSnapshots call (CHECK 1/2), which runs and errors out BEFORE
+// reachableChunks (and therefore this method) is ever reached.
+func (r *chainFakeRepo) ListCompletedChainSnapshots(_ context.Context, _ uuid.UUID, chainID uuid.UUID, maxGeneration int) ([]Snapshot, error) {
+	all := r.chainSnaps[chainID]
+	var out []Snapshot
+	for _, s := range all {
+		if s.Generation <= maxGeneration && s.Status == StatusCompleted {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+
 // StreamChainEffectiveFileIndex mirrors the pgRepo merge over the fake's chain
 // bookkeeping: walk generations 0..maxGeneration ascending, apply
 // latest-version-wins (tombstone => delete), then emit surviving entries sorted

--- a/apps/api/internal/backup/schedule_incremental_wiring_test.go
+++ b/apps/api/internal/backup/schedule_incremental_wiring_test.go
@@ -151,7 +151,7 @@ func (r *wiringRepo) ListInFlightSnapshotFloor(_ context.Context, _ uuid.UUID) (
 	panic("unused")
 }
 func (r *wiringRepo) DBNow(_ context.Context, _ uuid.UUID) (time.Time, error) { panic("unused") }
-func (r *wiringRepo) SweepTenantChunks(_ context.Context, _ uuid.UUID, _ time.Time, _ *bool, _ func(SweepChunk) (bool, error)) error {
+func (r *wiringRepo) SweepTenantChunks(_ context.Context, _ uuid.UUID, _ time.Time, _ *bool, _ func(SweepChunk, func() (bool, error)) (bool, error)) error {
 	panic("unused")
 }
 func (r *wiringRepo) InsertFileIndexBatch(_ context.Context, _, _ uuid.UUID, _ []FileIndexEntry) error {
@@ -170,6 +170,9 @@ func (r *wiringRepo) CompleteIncrementalManifest(_ context.Context, _ CompleteIn
 	panic("unused")
 }
 func (r *wiringRepo) ListChainSnapshots(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ int) ([]Snapshot, error) {
+	panic("unused")
+}
+func (r *wiringRepo) ListCompletedChainSnapshots(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ int) ([]Snapshot, error) {
 	panic("unused")
 }
 func (r *wiringRepo) SetSnapshotLocked(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ bool) (Snapshot, error) {

--- a/apps/api/internal/backup/scheduler_fix_test.go
+++ b/apps/api/internal/backup/scheduler_fix_test.go
@@ -285,7 +285,7 @@ func (r *schedulerTestRepo) ListInFlightSnapshotFloor(_ context.Context, _ uuid.
 func (r *schedulerTestRepo) DBNow(_ context.Context, _ uuid.UUID) (time.Time, error) {
 	return time.Now(), nil
 }
-func (r *schedulerTestRepo) SweepTenantChunks(_ context.Context, _ uuid.UUID, _ time.Time, acquired *bool, _ func(SweepChunk) (bool, error)) error {
+func (r *schedulerTestRepo) SweepTenantChunks(_ context.Context, _ uuid.UUID, _ time.Time, acquired *bool, _ func(SweepChunk, func() (bool, error)) (bool, error)) error {
 	*acquired = false
 	return nil
 }
@@ -308,6 +308,9 @@ func (r *schedulerTestRepo) CompleteIncrementalManifest(_ context.Context, _ Com
 	panic("schedulerTestRepo.CompleteIncrementalManifest not expected")
 }
 func (r *schedulerTestRepo) ListChainSnapshots(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ int) ([]Snapshot, error) {
+	return nil, nil
+}
+func (r *schedulerTestRepo) ListCompletedChainSnapshots(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ int) ([]Snapshot, error) {
 	return nil, nil
 }
 func (r *schedulerTestRepo) HealOverdueSchedules(_ context.Context, _ time.Time, _ func(Schedule, time.Time) time.Time) (int, error) {

--- a/apps/api/internal/backup/service.go
+++ b/apps/api/internal/backup/service.go
@@ -934,7 +934,15 @@ func (s *Service) reachableChunks(ctx context.Context, tenantID uuid.UUID, snap 
 	if retainedMaxGen < 0 {
 		retainedMaxGen = 0
 	}
-	chainSnaps, err := s.repo.ListChainSnapshots(ctx, tenantID, chainID, retainedMaxGen)
+	// GH #168 P1b: fetch COMPLETED rows only. A failed/aborted incremental retry
+	// can reuse a (chain_id, generation) pair (generation is derived from
+	// GetLatestCompletedSnapshot, so a retry after a failure doesn't know the
+	// failed attempt already claimed that generation — see the m96 migration
+	// doc), leaving more than one row per generation with no unique constraint
+	// covering terminal statuses pre-m96. Filtering in SQL means the byGen walk
+	// below never even SEES a non-completed duplicate, independent of the P1a
+	// Go-side tiebreak (chainGenWinner) two paragraphs down.
+	chainSnaps, err := s.repo.ListCompletedChainSnapshots(ctx, tenantID, chainID, retainedMaxGen)
 	if err != nil {
 		return nil, err
 	}
@@ -942,12 +950,25 @@ func (s *Service) reachableChunks(ctx context.Context, tenantID uuid.UUID, snap 
 	// Index by generation so the walk is robust to gaps (the GC may have already
 	// pruned an older non-pinned generation; the mark pass only needs the
 	// generations that survive). We walk in ascending generation order.
+	//
+	// GH #168 P1a: chainGenWinner is a defense-in-depth tiebreak for the (now
+	// rare, SQL-filtered-out-in-the-common-case) event that MORE THAN ONE
+	// completed row still shares a generation — a legacy pre-m96 duplicate, or a
+	// narrow race window before the m96 partial unique index applies. Without
+	// this, whichever row happened to be LAST in the (unordered-by-tiebreak)
+	// scan would silently win byGen[gen], and if that loser's manifest were
+	// empty/partial, every hash the REAL generation's files-list/parts reference
+	// would be missing from the reachable set — exactly the #168 data-loss bug.
 	byGen := map[int]Snapshot{}
 	maxGen := -1
 	for _, cs := range chainSnaps {
-		byGen[cs.Generation] = cs
 		if cs.Generation > maxGen {
 			maxGen = cs.Generation
+		}
+		if existing, ok := byGen[cs.Generation]; ok {
+			byGen[cs.Generation] = chainGenWinner(existing, cs)
+		} else {
+			byGen[cs.Generation] = cs
 		}
 	}
 
@@ -1064,6 +1085,31 @@ func (s *Service) reachableChunks(ctx context.Context, tenantID uuid.UUID, snap 
 	}
 
 	return out, nil
+}
+
+// chainGenWinner is the GH #168 P1a deterministic tiebreak for two snapshot
+// rows sharing one (chain_id, generation): a completed row ALWAYS wins over a
+// non-completed one (only a completed snapshot's manifest/file-index is a
+// real, fully-written artifact — a failed/aborted retry's manifest may be
+// empty or partial). Between two completed rows (the narrow legacy/race case
+// the m96 partial unique index closes going forward) the LOWEST snapshot ID
+// wins, so the choice is stable and reproducible regardless of which order the
+// caller's query happened to return them in — never a function of physical
+// scan/iteration order. A completed snapshot must never be shadowed by a
+// non-completed one.
+func chainGenWinner(existing, candidate Snapshot) Snapshot {
+	existingDone := existing.Status == StatusCompleted
+	candidateDone := candidate.Status == StatusCompleted
+	if existingDone != candidateDone {
+		if candidateDone {
+			return candidate
+		}
+		return existing
+	}
+	if bytes.Compare(candidate.ID[:], existing.ID[:]) < 0 {
+		return candidate
+	}
+	return existing
 }
 
 // planRestoreChain is the ADR-049 chain-planner path for PlanRestore. It runs
@@ -2065,7 +2111,15 @@ func (s *Service) DeleteSnapshotForUser(ctx context.Context, tenantID, snapshotI
 
 	// Reclaim orphaned chunks via the reachability-based GC over the survivors.
 	// Best-effort: the row is already gone; a sweep error is logged, not fatal.
-	if _, _, gerr := s.RunRetentionGC(ctx, tenantID); gerr != nil {
+	//
+	// GH #168 P3: detach from the request context. RunRetentionGC pins a pooled
+	// connection under a per-tenant advisory lock for the WHOLE sweep pass; a
+	// client disconnect or request timeout cancelling ctx mid-pass would abort a
+	// full tenant-wide reclamation partway through instead of merely failing this
+	// one HTTP response. Bounded so a genuinely wedged sweep still gives up.
+	gcCtx, gcCancel := context.WithTimeout(context.WithoutCancel(ctx), gcDetachTimeout)
+	defer gcCancel()
+	if _, _, gerr := s.RunRetentionGC(gcCtx, tenantID); gerr != nil {
 		slog.WarnContext(ctx, "backup delete: post-delete GC sweep failed (orphans reclaimed on next periodic GC)",
 			slog.String("tenant_id", tenantID.String()),
 			slog.String("snapshot_id", snapshotID.String()), slog.Any("error", gerr))
@@ -2407,8 +2461,14 @@ func (s *Service) BulkDeleteSnapshots(ctx context.Context, tenantID, siteID uuid
 
 	// Retention GC runs exactly ONCE for the whole batch, and only when the
 	// batch actually deleted something and we are NOT in dry-run mode.
+	//
+	// GH #168 P3: detach from the request context — see DeleteSnapshotForUser's
+	// identical rationale. A bulk delete's sweep is at least as long-running as
+	// the single-delete case, so the same protection applies here.
 	if !dryRun && out.Deleted > 0 {
-		if _, _, gerr := s.RunRetentionGC(ctx, tenantID); gerr != nil {
+		gcCtx, gcCancel := context.WithTimeout(context.WithoutCancel(ctx), gcDetachTimeout)
+		defer gcCancel()
+		if _, _, gerr := s.RunRetentionGC(gcCtx, tenantID); gerr != nil {
 			slog.WarnContext(ctx, "bulk backup delete: post-delete GC sweep failed (orphans reclaimed on next periodic GC)",
 				slog.String("tenant_id", tenantID.String()),
 				slog.Int("deleted", out.Deleted), slog.Any("error", gerr))

--- a/apps/api/internal/backup/worker.go
+++ b/apps/api/internal/backup/worker.go
@@ -16,8 +16,21 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
 	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 	"github.com/mosamlife/wpmgr/apps/api/internal/restore/sqlinspect"
 )
+
+// chainBrokenErrorCodes are the two domain codes PresignParentFilesList
+// returns when the incremental chain itself is broken (the parent's
+// files-list manifest entry is missing, or one of its chunks is no longer in
+// object storage — GH #168) rather than when some transient infra call
+// failed. These are the ONLY codes BackupWorker.Work treats as terminal for a
+// dispatch failure; every other error (ListManifest/GetSnapshot/
+// ExistingChunkHashes/mint/restoreDestinationRoute failures) stays retryable.
+var chainBrokenErrorCodes = map[string]bool{
+	"parent_files_list_missing":       true,
+	"parent_files_list_chunk_missing": true,
+}
 
 // Audit action names for the backup/restore lifecycle.
 const (
@@ -172,6 +185,20 @@ func (w *BackupWorker) Work(ctx context.Context, job *river.Job[BackupArgs]) err
 		if a.ParentSnapshotID != uuid.Nil {
 			prevChunks, err = w.svc.PresignParentFilesList(ctx, a.TenantID, a.ParentSnapshotID)
 			if err != nil {
+				// GH #168 P4: a chain-broken parent (its files-list manifest entry is
+				// missing, or one of its chunks is no longer stored) is a TERMINAL
+				// failure, not a retryable one. Pre-fix this fell through to the
+				// generic retryable branch below: River retried forever, the
+				// snapshot sat "running" until the watchdog eventually stamped a
+				// generic "stalled — no progress" error, giving the operator no
+				// actionable signal. Every OTHER PresignParentFilesList error
+				// (ListManifest/GetSnapshot/ExistingChunkHashes/mint/destination-route
+				// failures) is transient infra and MUST stay retryable — narrowly
+				// gating on these two codes is what keeps a genuine infra blip from
+				// being mistaken for a broken chain.
+				if de, ok := domain.AsDomain(err); ok && chainBrokenErrorCodes[de.Code] {
+					return w.fail(ctx, snap, "incremental chain broken: parent files-list chunk missing — run a full backup")
+				}
 				// A missing/un-presignable parent files-list is a retryable infra
 				// error: the agent can't diff without it, so don't silently fall
 				// back to a full re-pack (which would be the 24-min QA bug).

--- a/apps/api/internal/backup/worker_incremental_test.go
+++ b/apps/api/internal/backup/worker_incremental_test.go
@@ -5,6 +5,8 @@ package backup
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -476,3 +478,179 @@ func TestBackupWorker_SelectiveComponents_IncludeDB(t *testing.T) {
 // ADR-051: the agent-facing GET /file-index NDJSON endpoint + its soft-cap are
 // RETIRED (change detection now rides on the parent's presigned files-list
 // chunks). The endpoint streaming tests that exercised them have been removed.
+
+// ---------------------------------------------------------------------------
+// GH #168 P4 — a chain-broken parent (missing files-list entry, or one of its
+// chunks no longer stored) must TERMINAL-FAIL the snapshot with an actionable
+// message via w.fail, NOT bubble up as a retryable error. Every OTHER
+// PresignParentFilesList failure (a transient infra error) must still stay
+// retryable so River keeps retrying it.
+// ---------------------------------------------------------------------------
+
+// missingChunkWorkerRepo overrides ExistingChunkHashes to report NO hashes as
+// existing, simulating a files-list chunk the retention GC already swept
+// (the "parent_files_list_chunk_missing" trigger).
+type missingChunkWorkerRepo struct {
+	*fakeWorkerRepo
+}
+
+func (r *missingChunkWorkerRepo) ExistingChunkHashes(_ context.Context, _ uuid.UUID, _ []string) (map[string]Chunk, error) {
+	return map[string]Chunk{}, nil
+}
+
+// buildChainBrokenJob wires the common fixture (a gen-1 increment with a
+// completed parent) both terminal-fail tests share, returning the pieces each
+// test asserts against.
+func buildChainBrokenJob(t *testing.T, repo *fakeWorkerRepo) (uuid.UUID, uuid.UUID, *river.Job[BackupArgs]) {
+	t.Helper()
+	tenantID := uuid.New()
+	snapshotID := uuid.New()
+	parentID := uuid.New()
+	baseID := uuid.New()
+	chainID := uuid.New()
+
+	snap := Snapshot{
+		ID:               snapshotID,
+		TenantID:         tenantID,
+		SiteID:           uuid.New(),
+		Kind:             KindFull,
+		Status:           StatusPending,
+		AgeRecipient:     "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p",
+		IsIncremental:    true,
+		ParentSnapshotID: &parentID,
+		BaseSnapshotID:   &baseID,
+		ChainID:          &chainID,
+		Generation:       1,
+	}
+	repo.setSnapshot(snap)
+	repo.setSnapshot(Snapshot{
+		ID:           parentID,
+		TenantID:     tenantID,
+		SiteID:       snap.SiteID,
+		Kind:         KindFull,
+		Status:       StatusCompleted,
+		AgeRecipient: snap.AgeRecipient,
+	})
+
+	job := &river.Job[BackupArgs]{Args: BackupArgs{
+		TenantID:         tenantID,
+		SnapshotID:       snapshotID,
+		IsIncremental:    true,
+		ParentSnapshotID: parentID,
+		BaseSnapshotID:   baseID,
+		ChainID:          chainID,
+		Generation:       1,
+	}}
+	return tenantID, parentID, job
+}
+
+// TestBackupWorker_ParentFilesListMissing_TerminalFails: the parent carries NO
+// files-list manifest entry at all -> domain.Validation("parent_files_list_missing").
+func TestBackupWorker_ParentFilesListMissing_TerminalFails(t *testing.T) {
+	inner := &fakeWorkerRepo{fakeRepo: newFakeRepo(), workerManifests: map[uuid.UUID][]ManifestEntry{}}
+	cmd := &fakeCommander{ok: true}
+	tenantID, parentID, job := buildChainBrokenJob(t, inner)
+	inner.workerManifests[parentID] = nil // no files-list entry.
+
+	svc := &Service{
+		repo:       inner,
+		sites:      fakeWorkerSiteLookup{},
+		store:      &tenantPresigner{tenantID: tenantID, inner: &fakePresigner{}},
+		clock:      fakeClock{t: time.Now()},
+		presignTTL: time.Hour,
+	}
+	worker := NewBackupWorker(svc, cmd, nil, nil, "https://cp.example.com", 0)
+
+	if err := worker.Work(context.Background(), job); err != nil {
+		t.Fatalf("Work() returned an error (should terminal-fail via w.fail instead, so River does not retry forever): %v", err)
+	}
+	if cmd.lastIncrementalBackup != nil {
+		t.Error("the agent must never be dispatched once the chain is known to be broken")
+	}
+	got := inner.snapshots[job.Args.SnapshotID]
+	if got.Status != StatusFailed {
+		t.Fatalf("snapshot status = %q, want failed", got.Status)
+	}
+	if !strings.Contains(got.Error, "incremental chain broken") {
+		t.Errorf("snapshot error = %q, want it to mention the broken chain", got.Error)
+	}
+}
+
+// TestBackupWorker_ParentFilesListChunkMissing_TerminalFails: the parent DOES
+// carry a files-list entry, but its chunk is no longer in object storage ->
+// domain.Internal("parent_files_list_chunk_missing").
+func TestBackupWorker_ParentFilesListChunkMissing_TerminalFails(t *testing.T) {
+	base := &fakeWorkerRepo{fakeRepo: newFakeRepo(), workerManifests: map[uuid.UUID][]ManifestEntry{}}
+	repo := &missingChunkWorkerRepo{fakeWorkerRepo: base}
+	cmd := &fakeCommander{ok: true}
+	tenantID, parentID, job := buildChainBrokenJob(t, base)
+
+	flHash := "abc123def456abc123def456abc123def456abc123def456abc123def456abcd"
+	base.workerManifests[parentID] = []ManifestEntry{
+		{Path: "files.list", EntryKind: EntryKindFilesList, ChunkHashes: []string{flHash}, Size: 200},
+	}
+
+	svc := &Service{
+		repo:       repo,
+		sites:      fakeWorkerSiteLookup{},
+		store:      &tenantPresigner{tenantID: tenantID, inner: &fakePresigner{}},
+		clock:      fakeClock{t: time.Now()},
+		presignTTL: time.Hour,
+	}
+	worker := NewBackupWorker(svc, cmd, nil, nil, "https://cp.example.com", 0)
+
+	if err := worker.Work(context.Background(), job); err != nil {
+		t.Fatalf("Work() returned an error (should terminal-fail via w.fail instead, so River does not retry forever): %v", err)
+	}
+	if cmd.lastIncrementalBackup != nil {
+		t.Error("the agent must never be dispatched once the chain is known to be broken")
+	}
+	got := base.snapshots[job.Args.SnapshotID]
+	if got.Status != StatusFailed {
+		t.Fatalf("snapshot status = %q, want failed", got.Status)
+	}
+	if !strings.Contains(got.Error, "incremental chain broken") {
+		t.Errorf("snapshot error = %q, want it to mention the broken chain", got.Error)
+	}
+}
+
+// TestBackupWorker_TransientPresignError_StaysRetryable proves a genuine infra
+// failure (ListManifest erroring with a plain, non-domain error) is NOT
+// mistaken for a broken chain: Work() must return the error (so River
+// retries) and must NOT terminal-fail the snapshot.
+type transientErrWorkerRepo struct {
+	*fakeWorkerRepo
+	errSnapshotID uuid.UUID
+}
+
+func (r *transientErrWorkerRepo) ListManifest(ctx context.Context, tenantID, snapshotID uuid.UUID) ([]ManifestEntry, error) {
+	if snapshotID == r.errSnapshotID {
+		return nil, errors.New("simulated transient database error")
+	}
+	return r.fakeWorkerRepo.ListManifest(ctx, tenantID, snapshotID)
+}
+
+func TestBackupWorker_TransientPresignError_StaysRetryable(t *testing.T) {
+	base := &fakeWorkerRepo{fakeRepo: newFakeRepo(), workerManifests: map[uuid.UUID][]ManifestEntry{}}
+	_, parentID, job := buildChainBrokenJob(t, base)
+	repo := &transientErrWorkerRepo{fakeWorkerRepo: base, errSnapshotID: parentID}
+	cmd := &fakeCommander{ok: true}
+
+	svc := &Service{repo: repo, sites: fakeWorkerSiteLookup{}, clock: fakeClock{t: time.Now()}}
+	worker := NewBackupWorker(svc, cmd, nil, nil, "https://cp.example.com", 0)
+
+	err := worker.Work(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected a retryable error for a transient ListManifest failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "resolve parent files-list for increment") {
+		t.Errorf("error = %v, want it to wrap the retryable dispatch-resolution message", err)
+	}
+	if cmd.lastIncrementalBackup != nil {
+		t.Error("the agent must never be dispatched when parent resolution fails")
+	}
+	got := base.snapshots[job.Args.SnapshotID]
+	if got.Status == StatusFailed {
+		t.Error("a transient error must NOT terminal-fail the snapshot — River needs to retry it")
+	}
+}

--- a/apps/api/migrations/20260729000000_m96_backup_chain_gen_completed_uidx.sql
+++ b/apps/api/migrations/20260729000000_m96_backup_chain_gen_completed_uidx.sql
@@ -1,0 +1,93 @@
+-- m96: GH #168 CRITICAL fix — close the (chain_id, generation) duplicate-row
+-- gap that let a retention-GC reachability computation lose track of a
+-- within-retention parent files-list chunk and break an incremental chain.
+--
+-- Root cause: the CP derives an incremental backup's generation from
+-- GetLatestCompletedSnapshot (completed-only). If an incremental attempt at
+-- generation N fails or is aborted partway (e.g. the agent crashes, or the
+-- run is superseded by ReconcileDuplicateInflightSnapshots), the NEXT retry
+-- still sees the last COMPLETED generation as N-1 and reuses generation N —
+-- nothing before this migration prevented more than one row from sharing a
+-- (chain_id, generation) pair (the existing backup_snapshots_chain_gen_idx is
+-- a plain, non-unique index; the only uniqueness guard,
+-- backup_snapshots_one_inflight_per_site (m75), covers pending/running rows
+-- only). ListChainSnapshots returns every status with no tie-break beyond
+-- "ORDER BY generation ASC", so the reachability walk's byGen[generation]
+-- map ended up holding whichever same-generation row happened to be LAST in
+-- the (unordered-by-tiebreak) scan. When a FAILED duplicate with an empty or
+-- partial manifest won that slot, the COMPLETED row's real files-list/part
+-- chunk hashes were silently excluded from the retention GC's live set for
+-- every retained snapshot — and Phase 5 (now Phase 4 — see gc.go) swept them
+-- as "unreachable", permanently breaking the incremental chain.
+--
+-- The Go-side fix (chainGenWinner in service.go, and the ListCompletedChain-
+-- Snapshots SQL variant reachableChunks/gc.go now call exclusively) makes
+-- this deterministic and closes the class of bug going forward. This
+-- migration adds the DATABASE-level invariant that makes a duplicate
+-- COMPLETED row at the same (chain_id, generation) impossible to create in
+-- the first place: a partial unique index scoped to status='completed' (a
+-- failed/pending/running row is unconstrained, so a legitimate in-flight
+-- retry is never blocked — only two COMPLETED rows at the same slot are
+-- rejected).
+--
+-- Pre-dedup (ship-blocker, mirrors m88's identical precedent exactly): a
+-- LIVE database that already ran the pre-#168-fix code may already have more
+-- than one COMPLETED row for the same (chain_id, generation) — that is
+-- precisely the bug this migration protects against, and there is no reaper,
+-- so such duplicates would persist indefinitely. CREATE UNIQUE INDEX below
+-- would then fail outright on the duplicate data, and since the migration
+-- runner wraps each migration in a transaction and aborts boot on error
+-- (internal/db/migrate.go), that would hard-block the API from booting on
+-- prod and on every self-hoster who already has one of these collisions.
+--
+-- Terminalize every completed row EXCEPT the lowest-id one in each
+-- (chain_id, generation) group as 'failed' before the index is created, so
+-- CREATE UNIQUE INDEX always succeeds. "Lowest id" mirrors chainGenWinner's
+-- own stable tiebreak exactly (service.go), so the row this migration keeps
+-- completed is the SAME row the application-level fix would have picked
+-- regardless. A terminalized duplicate's own chunks are NOT deleted here —
+-- they simply stop being counted as reachable by the next retention GC pass,
+-- which reclaims any that are not ALSO referenced by the surviving row (the
+-- normal, already-idempotent sweep behaviour). The UPDATE is naturally
+-- idempotent: once no group has more than one completed row, the EXISTS
+-- predicate matches nothing and it is a no-op; wrapped in a DO $$ block to
+-- keep this migration's style consistent with the rest of the file (mirrors
+-- m36/m88's idempotent-migration convention).
+DO $$
+BEGIN
+    UPDATE backup_snapshots losers
+    SET status      = 'failed',
+        error       = 'superseded duplicate completed snapshot at the same chain generation (m96 dedup)',
+        finished_at = COALESCE(finished_at, now()),
+        updated_at  = now()
+    WHERE losers.status = 'completed'
+      AND losers.chain_id IS NOT NULL
+      AND EXISTS (
+          SELECT 1 FROM backup_snapshots winners
+           WHERE winners.chain_id   = losers.chain_id
+             AND winners.generation = losers.generation
+             AND winners.status     = 'completed'
+             AND winners.id         < losers.id
+      );
+END $$;
+
+-- Plain CREATE UNIQUE INDEX (the migration runner wraps each migration in a
+-- tx, so CONCURRENTLY is unavailable — see m85/m88); IF NOT EXISTS makes it
+-- re-run safe. Scoped to status='completed' only: pending/running/failed
+-- rows are unconstrained, so a legitimate in-flight retry after a failure is
+-- never blocked by this index — only two COMPLETED rows at the same slot are
+-- rejected, which is exactly the invariant GC/restore reachability depends on.
+CREATE UNIQUE INDEX IF NOT EXISTS backup_snapshots_chain_gen_completed_uidx
+    ON backup_snapshots (chain_id, generation)
+    WHERE status = 'completed';
+
+-- GH #168 P2: a GIN index on backup_manifest_entries.chunk_hashes so the
+-- retention GC's ground-truth guard (ChunkStillReferenced — "is this hash
+-- still referenced by ANY manifest row for the tenant?", checked for every
+-- sweep candidate the computed live-set marks unreachable) can use an index
+-- scan (chunk_hashes @> ARRAY[hash]) instead of a sequential scan across the
+-- tenant's manifest rows. Deliberately NOT added to backup_file_index: the
+-- P2 guard never queries that table (see ChunkStillReferenced's doc for why
+-- checking it would be unsound for the legacy per-file incremental model).
+CREATE INDEX IF NOT EXISTS backup_manifest_entries_chunk_hashes_gin
+    ON backup_manifest_entries USING gin (chunk_hashes);

--- a/apps/api/tests/backup_gh168_integration_test.go
+++ b/apps/api/tests/backup_gh168_integration_test.go
@@ -1,0 +1,289 @@
+package tests
+
+// backup_gh168_integration_test.go — GH #168 CRITICAL regression: a retention-
+// GC reachability computation lost track of a within-retention parent
+// files-list chunk (because a failed/aborted incremental retry reused a
+// (chain_id, generation) pair) and permanently broke an incremental chain.
+// Runs against a REAL Postgres (testcontainers) so the actual m96 migration,
+// the real ListCompletedChainSnapshots/chunkStillReferencedOnTx SQL, and the
+// real RLS-scoped repo methods are exercised — not just an in-memory fake. See
+// internal/backup/gh168_chain_gc_test.go for the white-box (no-DB) coverage
+// of the same properties (chainGenWinner, the P2 guard in isolation).
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
+	"github.com/mosamlife/wpmgr/apps/api/internal/backup"
+	"github.com/mosamlife/wpmgr/apps/api/internal/blobstore"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// gh168Entry is one backup_manifest_entries row to seed for a GH #168 fixture
+// snapshot.
+type gh168Entry struct {
+	path      string
+	entryKind string
+	hashes    []string
+}
+
+// seedGH168Chunk inserts a backup_chunks row (idempotent — ON CONFLICT DO
+// NOTHING, since a test may reference the same hash from more than one call
+// site) and its matching placeholder object in the blobstore, mirroring
+// putChunkObjects' convention.
+func seedGH168Chunk(t *testing.T, pool *db.Pool, store *blobstore.Store, tenant uuid.UUID, hash string, createdAt time.Time) {
+	t.Helper()
+	key := "chunks/" + tenant.String() + "/" + hash
+	err := pool.InTenantTx(context.Background(), tenant, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO backup_chunks (tenant_id, blake3, s3_key, size, refcount, created_at, updated_at, last_referenced_at)
+			VALUES ($1, $2, $3, 4, 1, $4, $4, $4)
+			ON CONFLICT (tenant_id, blake3) DO NOTHING`,
+			tenant, hash, key, createdAt,
+		)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("seed gh168 chunk %s: %v", hash, err)
+	}
+	if err := store.Put(context.Background(), key, strings.NewReader("ct"), 2); err != nil {
+		t.Fatalf("put gh168 chunk object %s: %v", hash, err)
+	}
+}
+
+// seedGH168Snapshot inserts a backup_snapshots row directly with explicit id/
+// status/chain fields, plus its backup_manifest_entries rows (if any). This is
+// the raw-SQL fixture builder — NOT the real submission pipeline — because the
+// whole point of this test is to construct the EXACT duplicate-generation DB
+// state #168 left behind (a real completed row plus a failed/aborted retry
+// that reused its generation), which the real SubmitManifest/CompleteBackup
+// flow has no way to reach directly.
+func seedGH168Snapshot(t *testing.T, pool *db.Pool, tenant, siteID, id, chainID uuid.UUID, generation int, status string, isIncremental bool, entries []gh168Entry, createdAt time.Time) {
+	t.Helper()
+	err := pool.InTenantTx(context.Background(), tenant, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(context.Background(), `
+			INSERT INTO backup_snapshots
+				(id, tenant_id, site_id, kind, status, age_recipient,
+				 is_incremental, chain_id, generation, created_at, finished_at)
+			VALUES ($1,$2,$3,'files',$4,$5,$6,$7,$8,$9,$9)`,
+			id, tenant, siteID, status, testRecipient, isIncremental, chainID, generation, createdAt,
+		); err != nil {
+			return err
+		}
+		for _, e := range entries {
+			if _, err := tx.Exec(context.Background(), `
+				INSERT INTO backup_manifest_entries (snapshot_id, tenant_id, path, entry_kind, chunk_hashes, size)
+				VALUES ($1,$2,$3,$4,$5,$6)`,
+				id, tenant, e.path, e.entryKind, e.hashes, int64(len(e.hashes))*4,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed gh168 snapshot (gen %d, status %s): %v", generation, status, err)
+	}
+}
+
+// archiveDeltaEntries returns the standard [files-list, wp-content-part]
+// manifest entries for one ADR-051 archive-delta generation.
+func archiveDeltaEntries(gen int, flHash, partHash string) []gh168Entry {
+	return []gh168Entry{
+		{path: "files.list", entryKind: backup.EntryKindFilesList, hashes: []string{flHash}},
+		{path: "wp-content.partNNN.zip", entryKind: backup.EntryKindWPContent, hashes: []string{partHash}},
+	}
+}
+
+// TestRetentionGC_GH168_DuplicateGenerationDoesNotOrphanFilesListChunk is the
+// exact reported regression: a completed 5-generation (0-4) archive-delta
+// chain, PLUS a failed duplicate at generation 4 (empty manifest — a retry
+// that reused the generation after the real gen-4 attempt had already
+// completed) and a failed generation 5 (the tip attempt that ultimately
+// failed). Deleting the failed gen-5 snapshot fires a synchronous
+// RunRetentionGC (DeleteSnapshotForUser). Pre-fix, the reachability walk could
+// let the failed gen-4 duplicate shadow the real completed gen-4 row's
+// manifest in byGen[4] — silently excluding its files-list/part chunk hashes
+// from the live set for every retained snapshot, so Phase 5 (now Phase 4 —
+// gc.go) swept them as "unreachable", permanently breaking the incremental
+// chain. Post-fix (P1a/P1b + the P2 ground-truth guard), they MUST survive.
+func TestRetentionGC_GH168_DuplicateGenerationDoesNotOrphanFilesListChunk(t *testing.T) {
+	pool := startPostgres(t)
+	store := startBlobstore(t)
+	tenant := seedTenant(t, pool, "gh168-dupgen")
+	siteID := seedSite(t, pool, tenant, "https://gh168.example.com")
+
+	svc := newBackupService(t, pool, store, stubSiteLookup{info: enrolledSiteInfo(siteID, "https://gh168.example.com")}, &stubEnqueuer{})
+
+	now := time.Now()
+	gen0ID := uuid.New()
+	chainID := gen0ID // base's chain_id is its own id, by project convention.
+	genIDs := []uuid.UUID{gen0ID, uuid.New(), uuid.New(), uuid.New(), uuid.New()}
+
+	// Seed the completed chain, generations 0..4, each with a files-list +
+	// wp-content-part chunk. All well within the default 30-day retention
+	// window, so ordinary age-based expiry never touches them — isolating the
+	// duplicate-generation defect as the ONLY variable under test.
+	for gen := 0; gen <= 4; gen++ {
+		fl := "fl-gen" + string(rune('0'+gen))
+		part := "part-gen" + string(rune('0'+gen))
+		seedGH168Chunk(t, pool, store, tenant, fl, now)
+		seedGH168Chunk(t, pool, store, tenant, part, now)
+		seedGH168Snapshot(t, pool, tenant, siteID, genIDs[gen], chainID, gen, backup.StatusCompleted, gen > 0,
+			archiveDeltaEntries(gen, fl, part), now)
+	}
+
+	// The exact #168 scenario: a FAILED duplicate at generation 4 (a retry
+	// that reused the generation after the real gen-4 attempt had already
+	// completed), with an EMPTY manifest, plus a failed generation 5 (the
+	// eventual tip attempt that failed and is the target of the user's
+	// delete). Both inserted AFTER their same/lower-generation completed
+	// siblings.
+	gen4DupID := uuid.New()
+	gen5ID := uuid.New()
+	seedGH168Snapshot(t, pool, tenant, siteID, gen4DupID, chainID, 4, backup.StatusFailed, true, nil, now.Add(time.Second))
+	seedGH168Snapshot(t, pool, tenant, siteID, gen5ID, chainID, 5, backup.StatusFailed, true, nil, now.Add(2*time.Second))
+
+	// Delete the failed gen-5 snapshot — this fires a synchronous
+	// RunRetentionGC (DeleteSnapshotForUser), exactly as the reporter's chain
+	// broke.
+	if err := svc.DeleteSnapshotForUser(context.Background(), tenant, gen5ID); err != nil {
+		t.Fatalf("DeleteSnapshotForUser(gen5 failed): %v", err)
+	}
+
+	// --- THE core #168 assertion -------------------------------------------
+	// The completed gen-4 snapshot row itself must still exist (it is nowhere
+	// near expiry).
+	if got := countSnapshotRows(t, pool, tenant, []uuid.UUID{genIDs[4]}); got != 1 {
+		t.Fatalf("completed gen-4 snapshot row missing after GC (found %d), want 1", got)
+	}
+	// Its files-list AND wp-content-part chunks — the ones a broken chain
+	// would have permanently lost — must survive in BOTH the DB row and the
+	// object store.
+	for _, hash := range []string{"fl-gen4", "part-gen4"} {
+		key := "chunks/" + tenant.String() + "/" + hash
+		if exists, _, _ := store.Head(context.Background(), key); !exists {
+			t.Errorf("REGRESSION (GH #168): gen-4's %q chunk object was swept — the incremental chain is now broken", hash)
+		}
+		existing, err := backup.NewRepo(pool).ExistingChunkHashes(context.Background(), tenant, []string{hash})
+		if err != nil {
+			t.Fatalf("existing chunk hashes: %v", err)
+		}
+		if _, ok := existing[hash]; !ok {
+			t.Errorf("REGRESSION (GH #168): gen-4's %q chunk ROW was swept — the incremental chain is now broken", hash)
+		}
+	}
+	// Every earlier generation's chunks must ALSO have survived — the bug
+	// class is not specific to generation 4.
+	for gen := 0; gen <= 3; gen++ {
+		for _, hash := range []string{"fl-gen" + string(rune('0'+gen)), "part-gen" + string(rune('0'+gen))} {
+			key := "chunks/" + tenant.String() + "/" + hash
+			if exists, _, _ := store.Head(context.Background(), key); !exists {
+				t.Errorf("gen-%d's %q chunk object was wrongly swept", gen, hash)
+			}
+		}
+	}
+
+	// --- BONUS: restore-oracle parity ---------------------------------------
+	// reachableChunks is the SAME oracle GC and PlanRestore share. Clean up
+	// the lingering failed gen-4 DUPLICATE (a separate, cosmetic anomaly:
+	// PlanRestore's own strict chain-integrity CHECK 1 correctly refuses to
+	// restore over ANY duplicate-generation layout, by design, regardless of
+	// this fix) so the chain is a clean 0..4 with one row per generation, then
+	// prove a full restore plan for gen-4 still resolves every chunk.
+	if err := svc.DeleteSnapshotForUser(context.Background(), tenant, gen4DupID); err != nil {
+		t.Fatalf("DeleteSnapshotForUser(gen4 failed duplicate): %v", err)
+	}
+	plan, _, _, err := svc.PlanRestore(context.Background(), tenant, genIDs[4],
+		backup.RestoreSelection{Full: true}, "restore-gh168", "")
+	if err != nil {
+		t.Fatalf("PlanRestore(gen4) after cleanup: unexpected error: %v", err)
+	}
+	gotHashes := map[string]bool{}
+	for _, e := range plan.Manifest.Entries {
+		for _, c := range e.Chunks {
+			gotHashes[c.Hash] = true
+			if c.URL == "" {
+				t.Errorf("restore chunk %q missing a presigned GET URL", c.Hash)
+			}
+		}
+	}
+	for gen := 0; gen <= 4; gen++ {
+		part := "part-gen" + string(rune('0'+gen))
+		if !gotHashes[part] {
+			t.Errorf("restore plan missing gen-%d's part chunk %q — GC/restore reachability disagree", gen, part)
+		}
+	}
+}
+
+// TestRetentionGC_GH168_GenuineOrphanStillSwept is the adversarial (T5-class)
+// counterpart, run against the SAME real-Postgres path: a chunk that belongs
+// ONLY to a snapshot that genuinely expires (age-based retention, no
+// duplicate-generation entanglement) must still be reclaimed even with the
+// P2 ground-truth guard fully wired in. Proves the GH #168 hardening did not
+// turn the retention GC into a no-op / storage leak. (TestRetentionGC in
+// backup_integration_test.go already covers this exact property against the
+// same real-Postgres path; this is a GH #168-scoped restatement kept
+// alongside the duplicate-generation regression test above for traceability.)
+func TestRetentionGC_GH168_GenuineOrphanStillSwept(t *testing.T) {
+	pool := startPostgres(t)
+	store := startBlobstore(t)
+	tenant := seedTenant(t, pool, "gh168-orphan")
+	siteID := seedSite(t, pool, tenant, "https://gh168-orphan.example.com")
+
+	// MonthlyArchiveKeep=0 isolates the rolling-window prune from the monthly-
+	// archive rule (mirrors TestRetentionGC in backup_integration_test.go) —
+	// otherwise the 60d-old snapshot below would be flagged as the newest
+	// backup in its calendar month and exempted from pruning, which is a
+	// different rule than the one under test here.
+	svc := backup.NewService(backup.NewRepo(pool), stubSiteLookup{info: enrolledSiteInfo(siteID, "https://gh168-orphan.example.com")}, &stubEnqueuer{}, store, domain.SystemClock{}, backup.Config{
+		PresignTTL:         10 * time.Minute,
+		RetentionDays:      30,
+		MonthlyArchiveKeep: 0,
+	})
+
+	h := chunkHashes(3)
+	putChunkObjects(t, store, tenant, h)
+
+	// Old snapshot (60d, > the default 30d retention window) references
+	// h[0], h[1], h[2] — a genuine, non-chained full backup with no
+	// duplicate-generation entanglement whatsoever.
+	oldSnap := seedBackupSnapshotAt(t, pool, tenant, siteID, time.Now().Add(-60*24*time.Hour))
+	submitManifest(t, svc, tenant, oldSnap, []agentcmd.ManifestEntry{
+		{Path: "old.php", EntryKind: "file", Size: 12, Chunks: refs(h[0], h[1], h[2])},
+	})
+	// Recent, retained snapshot references h[2] only (shared with the old one).
+	newSnap, err := svc.CreateBackup(context.Background(), tenant, siteID, uuid.Nil, "files")
+	if err != nil {
+		t.Fatalf("create new snapshot: %v", err)
+	}
+	submitManifest(t, svc, tenant, newSnap.ID, []agentcmd.ManifestEntry{
+		{Path: "new.php", EntryKind: "file", Size: 4, Chunks: refs(h[2])},
+	})
+
+	snaps, chunks, err := svc.RunRetentionGC(context.Background(), tenant)
+	if err != nil {
+		t.Fatalf("RunRetentionGC: %v", err)
+	}
+	if snaps != 1 {
+		t.Fatalf("snapshots deleted = %d, want 1 (the genuinely expired old snapshot)", snaps)
+	}
+	if chunks != 2 {
+		t.Fatalf("chunks deleted = %d, want 2 (h0,h1 genuinely orphaned; h2 shared+retained) — the P2 guard must not leak storage", chunks)
+	}
+	for _, gone := range []string{h[0], h[1]} {
+		if exists, _, _ := store.Head(context.Background(), "chunks/"+tenant.String()+"/"+gone); exists {
+			t.Errorf("genuinely orphaned chunk %s still in S3 — GH #168 hardening must not turn GC into a no-op", gone)
+		}
+	}
+	if exists, _, _ := store.Head(context.Background(), "chunks/"+tenant.String()+"/"+h[2]); !exists {
+		t.Error("shared, still-referenced chunk h2 was wrongly deleted from S3")
+	}
+}

--- a/apps/api/tests/backup_m96_migration_test.go
+++ b/apps/api/tests/backup_m96_migration_test.go
@@ -1,0 +1,347 @@
+package tests
+
+// backup_m96_migration_test.go — ship-blocker regression test for the m96
+// migration's data-mutating dedup UPDATE (GH #168 P1c). Mirrors
+// update_m88_dedup_test.go's pattern exactly: boot a container, apply every
+// embedded migration UP TO (not including) m96, seed the EXACT pre-m96
+// duplicate-row scenario the migration must heal before creating the unique
+// index, then finish the boot and assert the outcome. Without this test the
+// dedup UPDATE branch is a no-op in CI (every other GH #168 fixture only ever
+// creates ONE completed row per generation), so a regression in the dedup
+// logic itself would never be caught.
+
+import (
+	"context"
+	"io/fs"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/backup"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/migrations"
+)
+
+// m96MigrationVersion is the embedded migration filename (sans .sql) that
+// adds backup_snapshots_chain_gen_completed_uidx. The harness below stops
+// short of applying it so the test can seed the exact pre-m96 duplicate-row
+// scenario the migration must heal before creating the unique index.
+const m96MigrationVersion = "20260729000000_m96_backup_chain_gen_completed_uidx"
+
+// startPostgresBeforeM96 mirrors startPostgresBeforeM88's container bootstrap
+// but stops short of m96, using the bootstrap superuser connection (same
+// convention as the m88 harness — this test is about migration/dedup
+// correctness, not RLS).
+func startPostgresBeforeM96(t *testing.T) *db.Pool {
+	t.Helper()
+	ctx := context.Background()
+
+	container, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("wpmgr"),
+		tcpostgres.WithUsername("wpmgr"),
+		tcpostgres.WithPassword("wpmgr"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	pool, err := db.Connect(ctx, adminDSN)
+	if err != nil {
+		t.Fatalf("connect admin: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	applyMigrationsBeforeM96(t, pool, m96MigrationVersion)
+	return pool
+}
+
+// applyMigrationsBeforeM96 is a local copy of update_m88_dedup_test.go's
+// applyMigrationsBefore (same package, but kept local rather than shared so
+// this file has no compile-order dependency on that one — both re-implement
+// the same embedded-FS walk internal/db/migrate.go uses).
+func applyMigrationsBeforeM96(t *testing.T, pool *db.Pool, stopAt string) {
+	t.Helper()
+	ctx := context.Background()
+
+	if _, err := pool.Exec(ctx, `CREATE TABLE IF NOT EXISTS schema_migrations (
+		version    text        PRIMARY KEY,
+		applied_at timestamptz NOT NULL DEFAULT now()
+	)`); err != nil {
+		t.Fatalf("ensure schema_migrations: %v", err)
+	}
+
+	entries, err := fs.ReadDir(migrations.FS, ".")
+	if err != nil {
+		t.Fatalf("read embedded migrations: %v", err)
+	}
+	var versions []string
+	files := map[string]string{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".sql") {
+			continue
+		}
+		version := strings.TrimSuffix(name, ".sql")
+		versions = append(versions, version)
+		files[version] = name
+	}
+	sort.Strings(versions)
+
+	found := false
+	for _, version := range versions {
+		if version == stopAt {
+			found = true
+			break
+		}
+		body, err := fs.ReadFile(migrations.FS, files[version])
+		if err != nil {
+			t.Fatalf("read migration %s: %v", version, err)
+		}
+		err = pgx.BeginFunc(ctx, pool.Pool, func(tx pgx.Tx) error {
+			if _, err := tx.Exec(ctx, string(body)); err != nil {
+				return err
+			}
+			_, err := tx.Exec(ctx, "INSERT INTO schema_migrations (version) VALUES ($1)", version)
+			return err
+		})
+		if err != nil {
+			t.Fatalf("apply migration %s: %v", version, err)
+		}
+	}
+	if !found {
+		t.Fatalf("stopAt version %q not found among embedded migrations (renamed/removed?)", stopAt)
+	}
+}
+
+// seedSiteOnAdminPool inserts an enrolled site row directly on the caller's
+// pool. Unlike the shared seedSite helper (backup_integration_test.go), this
+// does NOT go through connectAdmin — startPostgresBeforeM96 (like
+// startPostgresBeforeM88) already returns the bootstrap SUPERUSER connection
+// directly, with nothing recorded in the adminDSNs map connectAdmin reads.
+func seedSiteOnAdminPool(t *testing.T, pool *db.Pool, tenant uuid.UUID, url string) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	var siteID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO sites (tenant_id, url, name, age_recipient, enrolled_at)
+		 VALUES ($1, $2, $3, $4, now())
+		 RETURNING id`,
+		tenant, url, "m96 test site", testRecipient,
+	).Scan(&siteID); err != nil {
+		t.Fatalf("seed site: %v", err)
+	}
+	return siteID
+}
+
+// TestM96MigrationDedupesPreexistingCompletedDuplicates is the ship-blocker
+// regression test: on a LIVE database that already ran the pre-#168-fix code,
+// TWO status='completed' rows can already exist for the same (chain_id,
+// generation) — that is precisely the bug m96's unique index closes, and
+// prior to this migration there was nothing to clean them up, so they persist
+// indefinitely. CREATE UNIQUE INDEX would fail outright on that duplicate
+// data, and since the migration runner wraps each migration in a tx and
+// aborts boot on error, that would hard-block the API from booting for every
+// affected deployment. This test seeds the exact collision, proves the
+// migration heals it deterministically (lowest id survives, mirroring
+// chainGenWinner's own tiebreak), and proves the surviving chain still
+// resolves end-to-end via PlanRestore.
+func TestM96MigrationDedupesPreexistingCompletedDuplicates(t *testing.T) {
+	pool := startPostgresBeforeM96(t)
+	store := startBlobstore(t)
+	ctx := context.Background()
+
+	tenant := seedTenant(t, pool, "m96-dedup")
+	siteID := seedSiteOnAdminPool(t, pool, tenant, "https://m96-dedup.example.com")
+
+	now := time.Now()
+	gen0ID := uuid.New()
+	chainID := gen0ID // base's chain_id is its own id, by project convention.
+
+	// gen0: the chain base (completed, non-incremental), carrying a files-list
+	// entry so the chain is archive-delta (ADR-051).
+	seedGH168Chunk(t, pool, store, tenant, "fl0", now)
+	seedGH168Chunk(t, pool, store, tenant, "part0", now)
+	seedGH168Snapshot(t, pool, tenant, siteID, gen0ID, chainID, 0, backup.StatusCompleted, false,
+		archiveDeltaEntries(0, "fl0", "part0"), now)
+
+	// TWO completed rows at generation 1 — the exact pre-m96 collision. idA and
+	// idB both carry a REAL, resolvable manifest (a genuine race between two
+	// submissions completing for the same generation, not a failed/empty
+	// retry — that scenario is already covered by the GH #168 regression test
+	// and by P1a/P1b; this test is specifically about the MIGRATION's dedup of
+	// two live completed rows). idB's manifest is deliberately DIFFERENT
+	// (distinct chunk hashes) so the assertions can tell which row's data the
+	// post-migration chain actually resolves through.
+	idA := uuid.New()
+	idB := uuid.New()
+	if idA.String() > idB.String() {
+		idA, idB = idB, idA
+	}
+	// idA now has the LOWER id — the survivor chainGenWinner/m96 both pick.
+	seedGH168Chunk(t, pool, store, tenant, "fl1-a", now)
+	seedGH168Chunk(t, pool, store, tenant, "part1-a", now)
+	seedGH168Snapshot(t, pool, tenant, siteID, idA, chainID, 1, backup.StatusCompleted, true,
+		archiveDeltaEntries(1, "fl1-a", "part1-a"), now.Add(time.Second))
+
+	seedGH168Chunk(t, pool, store, tenant, "fl1-b", now)
+	seedGH168Chunk(t, pool, store, tenant, "part1-b", now)
+	seedGH168Snapshot(t, pool, tenant, siteID, idB, chainID, 1, backup.StatusCompleted, true,
+		archiveDeltaEntries(1, "fl1-b", "part1-b"), now.Add(2*time.Second))
+
+	// Finish the boot: this applies m96. It must succeed even though the table
+	// already carries the duplicate completed rows above.
+	if err := pool.Migrate(ctx); err != nil {
+		t.Fatalf("m96 migration failed on a table with pre-existing completed duplicates: %v", err)
+	}
+
+	// idA (lower id) is untouched — still completed.
+	var statusA, statusB, errA, errB string
+	if err := pool.QueryRow(ctx, `SELECT status, error FROM backup_snapshots WHERE id = $1`, idA).Scan(&statusA, &errA); err != nil {
+		t.Fatalf("get idA: %v", err)
+	}
+	if statusA != backup.StatusCompleted {
+		t.Fatalf("idA (lower id, should survive) status = %q, want completed", statusA)
+	}
+	if errA != "" {
+		t.Fatalf("idA (survivor) error = %q, want untouched empty string", errA)
+	}
+
+	// idB (higher id) was demoted to failed, with the m96 dedup marker message.
+	if err := pool.QueryRow(ctx, `SELECT status, error FROM backup_snapshots WHERE id = $1`, idB).Scan(&statusB, &errB); err != nil {
+		t.Fatalf("get idB: %v", err)
+	}
+	if statusB != backup.StatusFailed {
+		t.Fatalf("idB (higher id, should be demoted) status = %q, want failed", statusB)
+	}
+	if !strings.Contains(errB, "superseded duplicate completed snapshot at the same chain generation (m96 dedup)") {
+		t.Fatalf("idB error = %q, want it to carry the m96 dedup marker message", errB)
+	}
+
+	// Exactly one completed row remains at (chainID, generation=1).
+	var completedCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM backup_snapshots WHERE chain_id = $1 AND generation = 1 AND status = 'completed'`,
+		chainID).Scan(&completedCount); err != nil {
+		t.Fatalf("count completed at gen1: %v", err)
+	}
+	if completedCount != 1 {
+		t.Fatalf("completed rows at (chainID, gen1) = %d, want exactly 1 after dedup", completedCount)
+	}
+
+	// The partial unique index now exists.
+	var idxCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM pg_indexes WHERE indexname = 'backup_snapshots_chain_gen_completed_uidx'`,
+	).Scan(&idxCount); err != nil {
+		t.Fatalf("check index: %v", err)
+	}
+	if idxCount != 1 {
+		t.Fatal("backup_snapshots_chain_gen_completed_uidx was not created")
+	}
+
+	// The index is actually enforcing going forward: a fresh completed
+	// duplicate insert at the same (chain_id, generation) now fails.
+	_, err := pool.Exec(ctx,
+		`INSERT INTO backup_snapshots (tenant_id, site_id, kind, status, age_recipient, is_incremental, chain_id, generation)
+		 VALUES ($1, $2, 'files', 'completed', $3, true, $4, 1)`,
+		tenant, siteID, testRecipient, chainID)
+	if err == nil {
+		t.Fatal("expected the partial unique index to reject a second completed row at (chain_id, generation) after m96")
+	}
+
+	// The surviving chain still resolves end-to-end: PlanRestore for idA (the
+	// chain tip) must succeed and resolve idA's OWN chunks — never idB's
+	// (now-demoted) manifest data. planRestoreChain's OWN strict chain-
+	// integrity CHECK 1 counts EVERY row regardless of status, so the
+	// now-failed idB row (still physically present — the migration demotes,
+	// never deletes) must be cleaned up first, exactly like an operator would
+	// after m96 flags a duplicate: this is the SAME chain_has_dependents-safe
+	// delete path GH #168's own regression test exercises, not something
+	// special-cased for this test.
+	svc := newBackupService(t, pool, store, stubSiteLookup{info: enrolledSiteInfo(siteID, "https://m96-dedup.example.com")}, &stubEnqueuer{})
+	if err := svc.DeleteSnapshotForUser(ctx, tenant, idB); err != nil {
+		t.Fatalf("DeleteSnapshotForUser(idB, demoted duplicate): %v", err)
+	}
+	plan, _, _, err := svc.PlanRestore(ctx, tenant, idA, backup.RestoreSelection{Full: true}, "restore-m96", "")
+	if err != nil {
+		t.Fatalf("PlanRestore(idA) after m96 dedup + duplicate cleanup: unexpected error: %v", err)
+	}
+	gotHashes := map[string]bool{}
+	for _, e := range plan.Manifest.Entries {
+		for _, c := range e.Chunks {
+			gotHashes[c.Hash] = true
+		}
+	}
+	for _, want := range []string{"part0", "part1-a"} {
+		if !gotHashes[want] {
+			t.Errorf("restore plan missing %q — the surviving (lower-id) chain member's data", want)
+		}
+	}
+	for _, unwanted := range []string{"part1-b"} {
+		if gotHashes[unwanted] {
+			t.Errorf("restore plan resolved %q — the DEMOTED (higher-id, non-completed) duplicate's data leaked into the surviving chain", unwanted)
+		}
+	}
+}
+
+// TestM96MigrationIsNoopWhenNoDuplicatesExist proves the common case (a
+// database with no pre-existing (chain_id, generation) collisions, i.e. every
+// fresh install and every deployment that never hit the pre-#168 race) is
+// unaffected: the dedup UPDATE touches nothing and the index is created
+// normally.
+func TestM96MigrationIsNoopWhenNoDuplicatesExist(t *testing.T) {
+	pool := startPostgresBeforeM96(t)
+	store := startBlobstore(t)
+	ctx := context.Background()
+
+	tenant := seedTenant(t, pool, "m96-noop")
+	siteID := seedSiteOnAdminPool(t, pool, tenant, "https://m96-noop.example.com")
+
+	now := time.Now()
+	gen0ID := uuid.New()
+	chainID := gen0ID
+	seedGH168Chunk(t, pool, store, tenant, "noop-fl0", now)
+	seedGH168Chunk(t, pool, store, tenant, "noop-part0", now)
+	seedGH168Snapshot(t, pool, tenant, siteID, gen0ID, chainID, 0, backup.StatusCompleted, false,
+		archiveDeltaEntries(0, "noop-fl0", "noop-part0"), now)
+
+	if err := pool.Migrate(ctx); err != nil {
+		t.Fatalf("m96 migration failed on a clean table: %v", err)
+	}
+
+	var status string
+	if err := pool.QueryRow(ctx, `SELECT status FROM backup_snapshots WHERE id = $1`, gen0ID).Scan(&status); err != nil {
+		t.Fatalf("get gen0: %v", err)
+	}
+	if status != backup.StatusCompleted {
+		t.Fatalf("single completed snapshot status = %q, want untouched completed", status)
+	}
+
+	var idxCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM pg_indexes WHERE indexname = 'backup_snapshots_chain_gen_completed_uidx'`,
+	).Scan(&idxCount); err != nil {
+		t.Fatalf("check index: %v", err)
+	}
+	if idxCount != 1 {
+		t.Fatal("backup_snapshots_chain_gen_completed_uidx was not created")
+	}
+}


### PR DESCRIPTION
CRITICAL backup-integrity fix. Incremental chains broke because retention GC deleted a within-retention parent files-list chunk. The reported interrupted-sweep cause was refuted; real cause is reachableChunks collapsing duplicate same-generation snapshots (a failed retry shadows the completed row, dropping its chunk from the keep set). Fix: completed-only/deterministic reachability + unique index (P1), a manifest-referential ground-truth guard so a chunk any live snapshot references is never swept (P2, on the pinned tx; required prune-before-sweep), detached delete-triggered GC (P3), fail-fast with an actionable message instead of a 120s stall (P4), sweep logging (P6). Data-integrity review SHIP; real-Postgres repro + no-orphan-leak + migration-dedup tests. CP-only.

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup reliability so incremental chains are no longer broken by cleanup or duplicate snapshot records.
  * Retention cleanup now preserves referenced data more safely and avoids removing chunks still needed for restores.
  * Broken incremental chains now fail fast with a clearer message to run a full backup.
  * Restore and backup flows are more consistent when duplicate snapshot generations exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->