### PR TITLE
fix(security): repair the hide-login feature — false sync error + login-form lockout (GH #170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.37] - 2026-07-07
+
+### Fixed
+
+- Fixed the "hide login" security feature, which had two bugs. First, turning it on showed a scary "policy stored but agent push failed" error even though the policy was actually saved and applied correctly. That error was a harmless mismatch (an empty value was sent as an array instead of an object) and is now gone; the control plane also tolerates both shapes so an older agent can't trip it. Second, and more seriously, the secret login URL did not actually show a login form (it bounced to the home page), which could leave you unable to log in through the browser. The secret URL now serves the login form correctly while the default wp-login.php stays hidden (returns 404). The fix also closes two smaller security gaps found in review: the secret URL is no longer exposed in ordinary page links to logged-out visitors, and the internal access cookie is now signed so it can't be forged. Requires agent 0.61.15.
+
 ## [0.61.36] - 2026-07-07
 
 ### Fixed

--- a/apps/agent/includes/commands/class-db-scan-command.php
+++ b/apps/agent/includes/commands/class-db-scan-command.php
@@ -198,7 +198,11 @@ final class DbScanCommand implements CommandInterface
             'ok'            => true,
             'job_id'        => $jobId,
             'detail'        => '',
-            'categories'    => $wireCategories,
+            // Cast to object: an empty PHP array json_encodes as `[]`, which the
+            // CP cannot unmarshal into its Go map[string]CategoryResult field
+            // (categories is a keyed map on the wire; tables below is a slice
+            // and stays an array).
+            'categories'    => (object) $wireCategories,
             'db_size_bytes' => (int) ($scanResult['db_size_bytes'] ?? 0),
             'table_count'   => (int) ($scanResult['table_count'] ?? 0),
             'scanned_at'    => (int) ($scanResult['scanned_at'] ?? time()),

--- a/apps/agent/includes/commands/class-sync-security-policy-command.php
+++ b/apps/agent/includes/commands/class-sync-security-policy-command.php
@@ -40,6 +40,9 @@
  *       }
  *     }
  *   }
+ *   per_role serializes as {} (a JSON object, never a bare []) when there is
+ *   nothing to report — e.g. 2FA is off — so the CP can always unmarshal it
+ *   into map[string]RoleEnrollment.
  *
  * Auth: Router's permission_callback enforces Ed25519 + anti-replay JWT
  * before execute() is called (Connector::verifyCommand).
@@ -177,57 +180,56 @@ final class SyncSecurityPolicyCommand implements CommandInterface
      */
     private function buildEnrollmentSummary(SecurityPolicy $policy): array
     {
-        $summary = ['per_role' => []];
+        $perRole = [];
 
-        if (!$policy->twoFactorEnabled || !function_exists('get_users')) {
-            return $summary;
-        }
-
-        // Collect all roles that appear in the required list or in groups with require_2fa=true.
-        $requiredRoles = $policy->twoFactorRequiredRoles;
-        foreach ($policy->groups as $group) {
-            if ($group['require_2fa'] === true && !in_array($group['role'], $requiredRoles, true)) {
-                $requiredRoles[] = $group['role'];
-            }
-        }
-
-        if ($requiredRoles === []) {
-            return $summary;
-        }
-
-        foreach ($requiredRoles as $role) {
-            // Fetch users with this role (bounded by WordPress default limit).
-            $users = get_users([
-                'role'   => $role,
-                'fields' => ['ID'],
-                'number' => 500, // cap for performance
-            ]);
-
-            if (!is_array($users)) {
-                continue;
-            }
-
-            $total    = count($users);
-            $enrolled = 0;
-
-            foreach ($users as $userRow) {
-                $uid = is_object($userRow) && isset($userRow->ID)
-                    ? (int) $userRow->ID
-                    : (int) $userRow;
-
-                if ($this->isEnrolled($uid)) {
-                    $enrolled++;
+        if ($policy->twoFactorEnabled && function_exists('get_users')) {
+            // Collect all roles that appear in the required list or in groups with require_2fa=true.
+            $requiredRoles = $policy->twoFactorRequiredRoles;
+            foreach ($policy->groups as $group) {
+                if ($group['require_2fa'] === true && !in_array($group['role'], $requiredRoles, true)) {
+                    $requiredRoles[] = $group['role'];
                 }
             }
 
-            $summary['per_role'][$role] = [
-                'enrolled' => $enrolled,
-                'required' => $total,
-                'total'    => $total,
-            ];
+            foreach ($requiredRoles as $role) {
+                // Fetch users with this role (bounded by WordPress default limit).
+                $users = get_users([
+                    'role'   => $role,
+                    'fields' => ['ID'],
+                    'number' => 500, // cap for performance
+                ]);
+
+                if (!is_array($users)) {
+                    continue;
+                }
+
+                $total    = count($users);
+                $enrolled = 0;
+
+                foreach ($users as $userRow) {
+                    $uid = is_object($userRow) && isset($userRow->ID)
+                        ? (int) $userRow->ID
+                        : (int) $userRow;
+
+                    if ($this->isEnrolled($uid)) {
+                        $enrolled++;
+                    }
+                }
+
+                $perRole[$role] = [
+                    'enrolled' => $enrolled,
+                    'required' => $total,
+                    'total'    => $total,
+                ];
+            }
         }
 
-        return $summary;
+        // Cast to object: an empty PHP array json_encodes as `[]`, which the CP
+        // cannot unmarshal into its Go map[string]RoleEnrollment field. Casting
+        // makes the empty case serialize as `{}` while the populated case is
+        // unaffected (the inner per-role arrays are always non-empty assoc
+        // arrays and already encode as JSON objects).
+        return ['per_role' => (object) $perRole];
     }
 
     /**

--- a/apps/agent/includes/security/class-hide-backend-module.php
+++ b/apps/agent/includes/security/class-hide-backend-module.php
@@ -5,10 +5,21 @@
  * When enabled, this module:
  *  1. Intercepts at setup_theme (before WP routes to wp-login.php/wp-admin).
  *  2. Compares the request path against hide_backend_slug:
- *       path == slug → set a short-lived access cookie, internally load wp-login.php.
+ *       path == slug → set a short-lived access cookie, then defer to
+ *         wp_loaded to require() wp-login.php in place so the request is
+ *         served AS a real wp-login.php hit (login form, lost-password,
+ *         registration, logout — the full multi-request login dance).
  *       canonical wp-login/wp-admin for logged-out un-tokened visitors → 404 or redirect.
  *  3. Bails for REST/cron/CLI/WP_INSTALLING so the agent's own wpmgr/v1 routes
  *     and the autologin path remain fully reachable.
+ *  4. Filters login_url/logout_url/lostpassword_url/site_url so the login
+ *     form's own rendered links point at the secret slug instead of the
+ *     literal /wp-login.php path — but ONLY while this request is actually
+ *     serving the hidden login form (see $servingLoginForm below). On every
+ *     other request (a normal front-end page render, a comment form, a theme
+ *     nav "Log in" link, etc.) these filters are inert no-ops, so a
+ *     logged-out visitor browsing the site never sees the secret slug in
+ *     any rendered HTML.
  *
  * LOCKOUT-PROOFING:
  *  - define('WPMGR_DISABLE_HIDE_BACKEND', true) disables this entirely.
@@ -18,7 +29,9 @@
  *  - /wp-cron.php, CLI, WP_INSTALLING all bail.
  *  - The cookie doubles as an access token: once the slug is visited and the
  *    cookie is set, all subsequent wp-login.php requests in that browser session
- *    are allowed (multi-request login dance).
+ *    are allowed (multi-request login dance). The cookie value is an HMAC of
+ *    the configured slug (not a guessable constant), so it can only be minted
+ *    by someone who already reached the slug.
  *
  * @package WPMgr\Agent\Security
  */
@@ -39,6 +52,15 @@ final class HideBackendModule
     private const COOKIE_TTL = 3600;
 
     private SecurityPolicy $policy;
+
+    /**
+     * True only while this request is actively serving the hidden login form
+     * (set by serveLoginForm() on a slug match). Gates the login_url/
+     * logout_url/lostpassword_url/site_url rewrite filters so they NEVER fire
+     * on a normal front-end page render — only the login form's own rendered
+     * links get pointed at the secret slug.
+     */
+    private bool $servingLoginForm = false;
 
     /**
      * @param SecurityPolicy $policy Active site policy.
@@ -73,6 +95,17 @@ final class HideBackendModule
         // Intercept at setup_theme — earliest WP hook after plugins are loaded
         // and before wp-login.php / wp-admin routing takes effect.
         add_action('setup_theme', [$this, 'interceptRequest']);
+
+        // Keep the login form's own rendered links (lost-password, register,
+        // logout, the form's POST action) pointed at the secret slug rather
+        // than the literal /wp-login.php path. Registered unconditionally,
+        // but each callback is gated on isServingHiddenLoginForm() so they
+        // are inert on every other request — a normal front-end page render
+        // never leaks the slug.
+        add_filter('login_url', [$this, 'rewriteLoginLinkUrl']);
+        add_filter('logout_url', [$this, 'rewriteLoginLinkUrl']);
+        add_filter('lostpassword_url', [$this, 'rewriteLoginLinkUrl']);
+        add_filter('site_url', [$this, 'rewriteSiteUrl'], 10, 2);
     }
 
     /**
@@ -91,11 +124,10 @@ final class HideBackendModule
         $slug    = $this->policy->hideBackendSlug;
         $request = $this->getRequestPath();
 
-        // Slug match: set the access cookie and route to wp-login.php.
+        // Slug match: set the access cookie and serve wp-login.php in place.
         if ($this->matchesSlug($request, $slug)) {
             $this->setAccessCookie();
-            // Let WP process wp-login.php by setting the SERVER path variables
-            // so the login dance (including lost-password etc.) continues to work.
+            $this->serveLoginForm();
             return;
         }
 
@@ -131,6 +163,124 @@ final class HideBackendModule
     // -------------------------------------------------------------------------
     // Private helpers
     // -------------------------------------------------------------------------
+
+    /**
+     * Present the current request AS wp-login.php and defer the actual
+     * require() to wp_loaded.
+     *
+     * setup_theme runs too early to load wp-login.php directly — the login
+     * screen depends on init/login_init/login_enqueue_scripts firing first,
+     * exactly as they would for a real /wp-login.php hit. Deferring to
+     * wp_loaded (which fires after init) lets that full sequence run, then
+     * requires wp-login.php and exits, so this request never falls through
+     * to normal template routing (which would 404/redirect the secret slug).
+     *
+     * @return void
+     */
+    private function serveLoginForm(): void
+    {
+        if (!defined('ABSPATH') || !file_exists(ABSPATH . 'wp-login.php')) {
+            return;
+        }
+
+        // From this point on, the login/logout/lostpassword/site_url rewrite
+        // filters are allowed to rewrite THIS request's own links to the
+        // secret slug — see isServingHiddenLoginForm().
+        $this->servingLoginForm = true;
+
+        global $pagenow;
+        // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- deliberately presenting this request AS wp-login.php; no core API exists to spoof $pagenow for a plugin-served login screen.
+        $pagenow = 'wp-login.php';
+
+        if (isset($_SERVER['SCRIPT_NAME']) && is_string($_SERVER['SCRIPT_NAME'])) {
+            $scriptName             = sanitize_text_field(wp_unslash($_SERVER['SCRIPT_NAME']));
+            $rewrittenScriptName    = dirname($scriptName) . '/wp-login.php';
+            $_SERVER['SCRIPT_NAME'] = $rewrittenScriptName;
+            $_SERVER['PHP_SELF']    = $rewrittenScriptName;
+        }
+
+        add_action('wp_loaded', static function (): void {
+            require ABSPATH . 'wp-login.php';
+            exit;
+        }, 0);
+    }
+
+    /**
+     * Rewrite a login/logout/lost-password URL to point at the secret slug
+     * instead of the literal /wp-login.php path.
+     *
+     * Registered against the login_url, logout_url, and lostpassword_url
+     * core filters, each of which passes the built URL as the first argument.
+     * A no-op unless this request is actively serving the hidden login form
+     * (isServingHiddenLoginForm()) — otherwise a normal front-end page render
+     * (Meta widget, comment form, theme nav "Log in" link, etc.) would leak
+     * the secret slug to every logged-out visitor.
+     *
+     * @param string $url The URL WordPress built (e.g. via wp_login_url()).
+     * @return string
+     */
+    public function rewriteLoginLinkUrl(string $url): string
+    {
+        if ($this->policy->hideBackendSlug === '' || !$this->isServingHiddenLoginForm()) {
+            return $url;
+        }
+        return $this->swapLoginPathForSlug($url);
+    }
+
+    /**
+     * Rewrite site_url('wp-login.php...') calls to point at the secret slug.
+     *
+     * Registered against the site_url core filter. Only touches URLs built
+     * from a wp-login.php path (e.g. the login form's own POST action target,
+     * or wp_registration_url()) while this request is actively serving the
+     * hidden login form (isServingHiddenLoginForm()); every other site_url()
+     * call — including wp-login.php paths built during a normal front-end
+     * render — passes through untouched.
+     *
+     * @param string $url  The fully assembled URL.
+     * @param string $path The raw path argument passed to site_url().
+     * @return string
+     */
+    public function rewriteSiteUrl(string $url, string $path = ''): string
+    {
+        if ($this->policy->hideBackendSlug === ''
+            || !$this->isServingHiddenLoginForm()
+            || !str_starts_with($path, 'wp-login.php')
+        ) {
+            return $url;
+        }
+        return $this->swapLoginPathForSlug($url);
+    }
+
+    /**
+     * Whether this request is actively serving the hidden login form.
+     *
+     * Primary signal is the instance flag set by serveLoginForm() (only
+     * reached on a slug match). $GLOBALS['pagenow'] is checked as a
+     * defensive secondary signal: WordPress core itself sets $pagenow to
+     * 'wp-login.php' for a genuine, already-authorized (cookie or logged-in)
+     * direct hit on /wp-login.php, and never for a front-end page — so this
+     * can only ever narrow the front-end leak surface further, never widen it.
+     *
+     * @return bool
+     */
+    private function isServingHiddenLoginForm(): bool
+    {
+        return $this->servingLoginForm || (($GLOBALS['pagenow'] ?? '') === 'wp-login.php');
+    }
+
+    /**
+     * Replace the literal /wp-login.php path segment in a URL with the
+     * configured secret slug, preserving any query string.
+     *
+     * @param string $url
+     * @return string
+     */
+    private function swapLoginPathForSlug(string $url): string
+    {
+        $replaced = preg_replace('#/wp-login\.php#', '/' . $this->policy->hideBackendSlug, $url, 1);
+        return is_string($replaced) ? $replaced : $url;
+    }
 
     /**
      * Determine whether we should bail (not interfere).
@@ -253,7 +403,7 @@ final class HideBackendModule
         }
         setcookie(
             self::COOKIE_ACCESS,
-            '1',
+            $this->accessCookieValue(),
             [
                 'expires'  => time() + self::COOKIE_TTL,
                 'path'     => '/',
@@ -267,10 +417,32 @@ final class HideBackendModule
     /**
      * Whether the current request has a valid access cookie.
      *
+     * The presented cookie value is compared with hash_equals() against the
+     * HMAC recomputed for the CURRENTLY configured slug, so a cookie can only
+     * be minted by someone who already reached the slug (setAccessCookie() is
+     * only ever called from the slug-match branch) — a guessable static value
+     * (e.g. the literal digit "1") no longer bypasses the canonical block,
+     * and a cookie minted for a different/previous slug is rejected too.
+     *
      * @return bool
      */
     private function hasAccessCookie(): bool
     {
-        return isset($_COOKIE[self::COOKIE_ACCESS]) && $_COOKIE[self::COOKIE_ACCESS] === '1'; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- constant value comparison; no user-controlled data used downstream
+        if (!isset($_COOKIE[self::COOKIE_ACCESS]) || !is_string($_COOKIE[self::COOKIE_ACCESS])) {
+            return false;
+        }
+        $presented = sanitize_text_field(wp_unslash($_COOKIE[self::COOKIE_ACCESS]));
+        return hash_equals($this->accessCookieValue(), $presented);
+    }
+
+    /**
+     * The expected access-cookie value: an HMAC of the configured slug, keyed
+     * by the site's own auth salt so it cannot be forged or reused across sites.
+     *
+     * @return string
+     */
+    private function accessCookieValue(): string
+    {
+        return hash_hmac('sha256', $this->policy->hideBackendSlug, wp_salt('auth'));
     }
 }

--- a/apps/agent/tests/DbScanCommandTest.php
+++ b/apps/agent/tests/DbScanCommandTest.php
@@ -81,7 +81,10 @@ final class DbScanCommandTest extends TestCase
         $this->assertArrayHasKey('db_size_bytes', $result);
         $this->assertArrayHasKey('table_count', $result);
         $this->assertArrayHasKey('scanned_at', $result);
-        $this->assertIsArray($result['categories']);
+        // categories is cast to an object at the wire boundary so an empty
+        // result serializes as `{}` (not `[]`) — the CP decodes this field
+        // into a Go map[string]CategoryResult.
+        $this->assertIsObject($result['categories']);
         $this->assertIsInt($result['db_size_bytes']);
         $this->assertIsInt($result['table_count']);
         $this->assertIsInt($result['scanned_at']);
@@ -94,7 +97,8 @@ final class DbScanCommandTest extends TestCase
             'categories' => [],
         ]);
         $this->assertTrue($result['ok']);
-        $this->assertCount(14, $result['categories']);
+        $categories = (array) $result['categories'];
+        $this->assertCount(14, $categories);
     }
 
     public function test_categories_subset_filters_correctly(): void
@@ -104,9 +108,10 @@ final class DbScanCommandTest extends TestCase
             'categories' => ['revisions', 'trashed_posts'],
         ]);
         $this->assertTrue($result['ok']);
-        $this->assertCount(2, $result['categories']);
-        $this->assertArrayHasKey('revisions', $result['categories']);
-        $this->assertArrayHasKey('trashed_posts', $result['categories']);
+        $categories = (array) $result['categories'];
+        $this->assertCount(2, $categories);
+        $this->assertArrayHasKey('revisions', $categories);
+        $this->assertArrayHasKey('trashed_posts', $categories);
     }
 
     public function test_unknown_categories_are_ignored(): void
@@ -116,9 +121,10 @@ final class DbScanCommandTest extends TestCase
             'categories' => ['revisions', 'not_a_real_category'],
         ]);
         $this->assertTrue($result['ok']);
-        $this->assertCount(1, $result['categories']);
-        $this->assertArrayHasKey('revisions', $result['categories']);
-        $this->assertArrayNotHasKey('not_a_real_category', $result['categories']);
+        $categories = (array) $result['categories'];
+        $this->assertCount(1, $categories);
+        $this->assertArrayHasKey('revisions', $categories);
+        $this->assertArrayNotHasKey('not_a_real_category', $categories);
     }
 
     public function test_category_entries_have_count_and_bytes(): void
@@ -127,12 +133,34 @@ final class DbScanCommandTest extends TestCase
             'job_id'     => 'uuid-entries',
             'categories' => ['revisions', 'spam_comments'],
         ]);
-        foreach ($result['categories'] as $id => $entry) {
+        foreach ((array) $result['categories'] as $id => $entry) {
             $this->assertArrayHasKey('count', $entry, "Missing count for {$id}");
             $this->assertArrayHasKey('bytes', $entry, "Missing bytes for {$id}");
             $this->assertIsInt($entry['count']);
             $this->assertIsInt($entry['bytes']);
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // BUG 1 sibling: categories must serialize as `{}` (object), never `[]`
+    // (array), when the engine produces no category entries at all — a Go
+    // map[string]CategoryResult field cannot be unmarshaled from a JSON array.
+    // -------------------------------------------------------------------------
+
+    public function test_wire_categories_serializes_as_object_when_engine_returns_no_categories(): void
+    {
+        // A DbCleanup constructed with no wpdb short-circuits scan() to the
+        // zero-result structure with categories=[] (see DbCleanup::scan()'s
+        // no-wpdb guard, exercised the same way in OptimizerDbScanTest).
+        $cleanup = new DbCleanup(new PerfConfig([]), null);
+        $cmd     = new DbScanCommand($cleanup);
+        $result  = $cmd->execute([], ['job_id' => 'uuid-empty-cats']);
+
+        $this->assertTrue($result['ok']);
+        $this->assertInstanceOf(\stdClass::class, $result['categories']);
+        $encoded = wp_json_encode($result);
+        $this->assertIsString($encoded);
+        $this->assertStringContainsString('"categories":{}', $encoded);
     }
 
     // -------------------------------------------------------------------------
@@ -174,7 +202,8 @@ final class DbScanCommandTest extends TestCase
             'categories' => ['optimize_tables'],
         ]);
         $this->assertTrue($result['ok']);
-        $entry = $result['categories']['optimize_tables'];
+        $categories = (array) $result['categories'];
+        $entry      = $categories['optimize_tables'];
         $this->assertArrayHasKey('tables', $entry);
         $this->assertCount(1, $entry['tables']);
         $this->assertSame('wp_posts', $entry['tables'][0]['name']);

--- a/apps/agent/tests/Security/HideBackendModuleTest.php
+++ b/apps/agent/tests/Security/HideBackendModuleTest.php
@@ -10,6 +10,17 @@
  *   - isLoginOrAdminPath() detects canonical wp-login and wp-admin paths
  *   - hasAccessCookie() detects the access cookie
  *   - interceptRequest() is a no-op for logged-in users
+ *   - BUG 2 (GH #170): serveLoginForm() sets $pagenow='wp-login.php' and
+ *     defers the actual require()/exit to a single wp_loaded action, WITHOUT
+ *     exiting itself (so the slug branch of interceptRequest() actually
+ *     serves a reachable login form instead of falling through to a 404)
+ *   - BUG 2: rewriteLoginLinkUrl()/rewriteSiteUrl() point login/logout/
+ *     lostpassword/site_url('wp-login.php...') links at the secret slug
+ *     WHILE the hidden login form is being served, and are a no-op on a
+ *     normal front-end request (security-review Finding 1: no slug leak)
+ *   - security-review Finding 2: hasAccessCookie() rejects a forged static
+ *     cookie value and a cookie minted for a different slug; only the HMAC
+ *     for the CURRENT slug is accepted
  *
  * @package WPMgr\Agent\Tests\Security
  */
@@ -35,20 +46,29 @@ final class HideBackendModuleTest extends TestCase
         Monkey\setUp();
 
         Functions\when('get_option')->justReturn('');
-        Functions\when('add_action')->justReturn(true);
-        Functions\when('add_filter')->justReturn(true);
+        // add_action()/add_filter() are deliberately NOT stubbed here with
+        // when() — Brain Monkey cannot route a real call to a later
+        // Functions\expect() on the same function name once when() has
+        // already bound a stub redefinition for it. Tests that need
+        // add_action()/add_filter() to be callable set up their own
+        // Functions\expect()/Functions\when() as needed.
         Functions\when('esc_url_raw')->alias(fn ($u) => $u);
         Functions\when('is_ssl')->justReturn(false);
         Functions\when('is_user_logged_in')->justReturn(false);
         Functions\when('esc_html__')->alias(fn ($t, $d = '') => $t);
         Functions\when('wp_unslash')->alias(fn ($v) => $v);
         Functions\when('sanitize_text_field')->alias(fn ($v) => $v);
+        Functions\when('wp_salt')->justReturn('test-fixed-auth-salt-value');
     }
 
     protected function tear_down(): void
     {
         unset($_SERVER['REQUEST_URI']);
         unset($_COOKIE[HideBackendModule::COOKIE_ACCESS]);
+        // $GLOBALS['pagenow'] is a real WordPress global some tests mutate to
+        // exercise isServingHiddenLoginForm()'s defensive secondary signal —
+        // never let it leak into a later test in this same process.
+        unset($GLOBALS['pagenow']);
         Monkey\tearDown();
         parent::tear_down();
     }
@@ -69,9 +89,65 @@ final class HideBackendModuleTest extends TestCase
         return new HideBackendModule($policy);
     }
 
+    /** Force the private $servingLoginForm flag so rewrite tests can exercise the "serving" branch directly. */
+    private function setServing(HideBackendModule $mod, bool $value): void
+    {
+        $ref = new \ReflectionProperty($mod, 'servingLoginForm');
+        $ref->setAccessible(true);
+        $ref->setValue($mod, $value);
+    }
+
+    /** Compute the current expected access-cookie HMAC via reflection. */
+    private function cookieValueFor(HideBackendModule $mod): string
+    {
+        $ref = new \ReflectionMethod($mod, 'accessCookieValue');
+        $ref->setAccessible(true);
+        return $ref->invoke($mod);
+    }
+
     // -------------------------------------------------------------------------
     // install() no-op cases
     // -------------------------------------------------------------------------
+
+    /**
+     * install() uses a function-local `static $installed` idempotency latch
+     * (the same convention as every other security module's install()) that
+     * persists for the lifetime of the PHP process, not per-instance. Other
+     * tests in this file (and this file alone calls install() more than
+     * once) would otherwise silently short-circuit this test depending on
+     * execution order — run it in its own process so the latch starts fresh.
+     *
+     * @runInSeparateProcess
+     */
+    public function test_install_registers_intercept_and_url_filters_when_enabled(): void
+    {
+        $policy = $this->makePolicy(true, 'my-secret-login');
+        $mod    = $this->module($policy);
+
+        Functions\expect('add_action')
+            ->once()
+            ->with('setup_theme', [$mod, 'interceptRequest']);
+
+        Functions\expect('add_filter')
+            ->once()
+            ->with('login_url', [$mod, 'rewriteLoginLinkUrl']);
+        Functions\expect('add_filter')
+            ->once()
+            ->with('logout_url', [$mod, 'rewriteLoginLinkUrl']);
+        Functions\expect('add_filter')
+            ->once()
+            ->with('lostpassword_url', [$mod, 'rewriteLoginLinkUrl']);
+        Functions\expect('add_filter')
+            ->once()
+            ->with('site_url', [$mod, 'rewriteSiteUrl'], 10, 2);
+
+        $mod->install();
+
+        // Brain Monkey's Functions\expect() assertions are verified in
+        // tearDown() via Mockery::close(), not via a PHPUnit assertion here —
+        // record one explicitly so this test isn't flagged risky.
+        $this->addToAssertionCount(1);
+    }
 
     public function test_install_noop_when_disabled(): void
     {
@@ -145,7 +221,7 @@ final class HideBackendModuleTest extends TestCase
         $policy = $this->makePolicy();
         $mod    = $this->module($policy);
 
-        $_COOKIE[HideBackendModule::COOKIE_ACCESS] = '1';
+        $_COOKIE[HideBackendModule::COOKIE_ACCESS] = $this->cookieValueFor($mod);
 
         $ref = new \ReflectionMethod($mod, 'hasAccessCookie');
         $ref->setAccessible(true);
@@ -163,6 +239,58 @@ final class HideBackendModuleTest extends TestCase
         $ref = new \ReflectionMethod($mod, 'hasAccessCookie');
         $ref->setAccessible(true);
         $this->assertFalse($ref->invoke($mod));
+    }
+
+    // -------------------------------------------------------------------------
+    // security-review Finding 2 (GH #170): the access cookie is an HMAC of
+    // the slug, not a guessable static value — a forged "1" cookie, or one
+    // minted for a different slug, must be rejected.
+    // -------------------------------------------------------------------------
+
+    public function test_has_access_cookie_rejects_forged_static_value(): void
+    {
+        $policy = $this->makePolicy(true, 'my-secret-login');
+        $mod    = $this->module($policy);
+
+        // Pre-fix, the literal digit "1" was a valid cookie value — anyone
+        // reading the OSS source could forge it without knowing the slug.
+        $_COOKIE[HideBackendModule::COOKIE_ACCESS] = '1';
+
+        $ref = new \ReflectionMethod($mod, 'hasAccessCookie');
+        $ref->setAccessible(true);
+        $this->assertFalse($ref->invoke($mod), 'a forged static "1" cookie must be rejected');
+
+        unset($_COOKIE[HideBackendModule::COOKIE_ACCESS]);
+    }
+
+    public function test_has_access_cookie_accepts_hmac_for_current_slug(): void
+    {
+        $policy = $this->makePolicy(true, 'my-secret-login');
+        $mod    = $this->module($policy);
+
+        $_COOKIE[HideBackendModule::COOKIE_ACCESS] = $this->cookieValueFor($mod);
+
+        $ref = new \ReflectionMethod($mod, 'hasAccessCookie');
+        $ref->setAccessible(true);
+        $this->assertTrue($ref->invoke($mod), 'the HMAC minted for the current slug must be accepted');
+
+        unset($_COOKIE[HideBackendModule::COOKIE_ACCESS]);
+    }
+
+    public function test_has_access_cookie_rejects_hmac_minted_for_a_different_slug(): void
+    {
+        $modForSlugA = $this->module($this->makePolicy(true, 'my-secret-login'));
+        $modForSlugB = $this->module($this->makePolicy(true, 'a-totally-different-slug'));
+
+        // A cookie minted while visiting slug A must not grant access under
+        // a policy configured with a different slug B.
+        $_COOKIE[HideBackendModule::COOKIE_ACCESS] = $this->cookieValueFor($modForSlugA);
+
+        $ref = new \ReflectionMethod($modForSlugB, 'hasAccessCookie');
+        $ref->setAccessible(true);
+        $this->assertFalse($ref->invoke($modForSlugB), 'a cookie minted for a different slug must be rejected');
+
+        unset($_COOKIE[HideBackendModule::COOKIE_ACCESS]);
     }
 
     // -------------------------------------------------------------------------
@@ -300,5 +428,175 @@ final class HideBackendModuleTest extends TestCase
         $this->assertFalse($ref->invoke($mod, '/some-page'), 'isLoginOrAdminPath: non-login page must not match');
         $this->assertFalse($ref->invoke($mod, '/my-secret-login'), 'isLoginOrAdminPath: custom slug must not match');
         $this->assertFalse($ref->invoke($mod, '/wp-content/uploads/file.php'), 'isLoginOrAdminPath: wp-content must not match');
+    }
+
+    // -------------------------------------------------------------------------
+    // BUG 2 (GH #170): the secret slug must actually serve a login form —
+    // serveLoginForm() presents the request AS wp-login.php and defers the
+    // real require()/exit to a single wp_loaded action so init/login_init/
+    // login_enqueue_scripts fire exactly as a real wp-login.php hit would.
+    // -------------------------------------------------------------------------
+
+    public function test_bug2_serve_login_form_sets_pagenow_and_defers_require_without_exiting(): void
+    {
+        // serveLoginForm() only proceeds past its file_exists() guard when
+        // ABSPATH/wp-login.php exists; the file's contents never matter here
+        // because the require() lives inside the deferred wp_loaded closure,
+        // which this test never invokes.
+        if (!is_dir(ABSPATH)) {
+            mkdir(ABSPATH, 0755, true);
+        }
+        $loginFile = ABSPATH . 'wp-login.php';
+        file_put_contents($loginFile, "<?php\n// placeholder wp-login.php for HideBackendModuleTest\n");
+
+        $policy = $this->makePolicy(true, 'my-secret-login');
+        $mod    = $this->module($policy);
+
+        unset($GLOBALS['pagenow']);
+        $_SERVER['SCRIPT_NAME'] = '/my-secret-login';
+
+        Functions\expect('add_action')
+            ->once()
+            ->with('wp_loaded', \Mockery::type('callable'), 0);
+
+        $ref = new \ReflectionMethod($mod, 'serveLoginForm');
+        $ref->setAccessible(true);
+        // If serveLoginForm() reached the require()/exit itself (instead of
+        // deferring it), PHPUnit's process would terminate here and this
+        // assertion would never run.
+        $ref->invoke($mod);
+
+        $this->assertSame(
+            'wp-login.php',
+            $GLOBALS['pagenow'] ?? null,
+            'serveLoginForm() must set $pagenow so WP treats this request as wp-login.php'
+        );
+
+        unset($_SERVER['SCRIPT_NAME']);
+        @unlink($loginFile);
+    }
+
+    public function test_bug2_serve_login_form_noop_when_wp_login_missing(): void
+    {
+        // Ensure no wp-login.php exists at ABSPATH (leftover from a previous
+        // test, or absent by default) so the file_exists() guard is hit.
+        @unlink(ABSPATH . 'wp-login.php');
+
+        $policy = $this->makePolicy(true, 'my-secret-login');
+        $mod    = $this->module($policy);
+
+        Functions\expect('add_action')->never();
+
+        $ref = new \ReflectionMethod($mod, 'serveLoginForm');
+        $ref->setAccessible(true);
+        $ref->invoke($mod);
+
+        $this->assertTrue(true, 'serveLoginForm() must return quietly when wp-login.php does not exist');
+    }
+
+    // -------------------------------------------------------------------------
+    // BUG 2: login/logout/lostpassword/site_url links point at the secret
+    // slug instead of the literal /wp-login.php path — but ONLY while the
+    // hidden login form is actually being served (security-review Finding 1).
+    // -------------------------------------------------------------------------
+
+    public function test_rewrite_login_link_url_swaps_wp_login_path_for_slug_while_serving_form(): void
+    {
+        $policy = $this->makePolicy(true, 'my-secret-login');
+        $mod    = $this->module($policy);
+        $this->setServing($mod, true);
+
+        $this->assertSame(
+            'https://example.com/my-secret-login?action=lostpassword',
+            $mod->rewriteLoginLinkUrl('https://example.com/wp-login.php?action=lostpassword')
+        );
+    }
+
+    public function test_rewrite_login_link_url_is_noop_when_slug_empty(): void
+    {
+        $policy = $this->makePolicy(false, '');
+        $mod    = $this->module($policy);
+        $this->setServing($mod, true);
+
+        $url = 'https://example.com/wp-login.php';
+        $this->assertSame($url, $mod->rewriteLoginLinkUrl($url));
+    }
+
+    public function test_rewrite_site_url_only_touches_wp_login_paths_while_serving_form(): void
+    {
+        $policy = $this->makePolicy(true, 'my-secret-login');
+        $mod    = $this->module($policy);
+        $this->setServing($mod, true);
+
+        $this->assertSame(
+            'https://example.com/my-secret-login',
+            $mod->rewriteSiteUrl('https://example.com/wp-login.php', 'wp-login.php')
+        );
+
+        $this->assertSame(
+            'https://example.com/my-secret-login?action=register',
+            $mod->rewriteSiteUrl('https://example.com/wp-login.php?action=register', 'wp-login.php?action=register')
+        );
+
+        // Unrelated site_url() calls must pass through untouched, even while serving.
+        $unrelated = 'https://example.com/wp-json/wpmgr/v1/ping';
+        $this->assertSame(
+            $unrelated,
+            $mod->rewriteSiteUrl($unrelated, 'wp-json/wpmgr/v1/ping')
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // security-review Finding 1 (GH #170, MEDIUM): a normal front-end request
+    // (NOT serving the hidden login form) must NEVER have its login/logout/
+    // lostpassword/site_url links rewritten to the secret slug — otherwise the
+    // Meta widget, a comment form, or a theme nav "Log in" link leaks the
+    // slug to every logged-out visitor, defeating hide-login entirely.
+    // -------------------------------------------------------------------------
+
+    public function test_rewrite_login_link_url_is_noop_on_normal_front_end_request(): void
+    {
+        $policy = $this->makePolicy(true, 'my-secret-login');
+        $mod    = $this->module($policy);
+        // Not serving: $servingLoginForm defaults false, and pagenow reflects
+        // a normal front-end request (never 'wp-login.php').
+        $GLOBALS['pagenow'] = 'index.php';
+
+        $url = 'https://example.com/wp-login.php?action=lostpassword';
+        $this->assertSame(
+            $url,
+            $mod->rewriteLoginLinkUrl($url),
+            'a normal front-end render must not leak the secret slug via login_url/logout_url/lostpassword_url'
+        );
+    }
+
+    public function test_rewrite_site_url_is_noop_on_normal_front_end_request(): void
+    {
+        $policy = $this->makePolicy(true, 'my-secret-login');
+        $mod    = $this->module($policy);
+        $GLOBALS['pagenow'] = 'index.php';
+
+        $url = 'https://example.com/wp-login.php';
+        $this->assertSame(
+            $url,
+            $mod->rewriteSiteUrl($url, 'wp-login.php'),
+            'a normal front-end render must not leak the secret slug via site_url()'
+        );
+    }
+
+    public function test_rewrite_login_link_url_applies_when_core_pagenow_is_wp_login_even_without_flag(): void
+    {
+        // Defensive secondary signal: a genuine, already-authorized direct
+        // hit on /wp-login.php has $pagenow set to 'wp-login.php' by
+        // WordPress core itself (not by serveLoginForm()) — the rewrite must
+        // still apply there so the login screen's own links stay consistent.
+        $policy = $this->makePolicy(true, 'my-secret-login');
+        $mod    = $this->module($policy);
+        $GLOBALS['pagenow'] = 'wp-login.php';
+
+        $this->assertSame(
+            'https://example.com/my-secret-login',
+            $mod->rewriteLoginLinkUrl('https://example.com/wp-login.php')
+        );
     }
 }

--- a/apps/agent/tests/Security/SyncSecurityPolicyCommandTest.php
+++ b/apps/agent/tests/Security/SyncSecurityPolicyCommandTest.php
@@ -230,9 +230,13 @@ final class SyncSecurityPolicyCommandTest extends TestCase
         $this->assertTrue($result['ok']);
         $summary = $result['enrollment_summary'] ?? [];
         $this->assertArrayHasKey('per_role', $summary);
-        $this->assertArrayHasKey('administrator', $summary['per_role']);
+        // per_role is cast to an object on the way out (see BUG 1 fix) so it
+        // serializes as `{}` rather than `[]` when empty; convert back to an
+        // array here to inspect the populated case.
+        $perRole = (array) $summary['per_role'];
+        $this->assertArrayHasKey('administrator', $perRole);
 
-        $roleData = $summary['per_role']['administrator'];
+        $roleData = $perRole['administrator'];
         $this->assertSame(1, $roleData['total']);
         $this->assertSame(0, $roleData['enrolled'], 'user with no 2FA meta is not enrolled');
     }
@@ -263,8 +267,79 @@ final class SyncSecurityPolicyCommandTest extends TestCase
         $result = $this->command()->execute([], $params);
         $this->assertTrue($result['ok']);
 
-        $summary = $result['enrollment_summary']['per_role']['administrator'] ?? [];
+        $perRole = (array) $result['enrollment_summary']['per_role'];
+        $summary = $perRole['administrator'] ?? [];
         $this->assertSame(1, $summary['enrolled'], 'user with totp secret is enrolled');
+    }
+
+    // -------------------------------------------------------------------------
+    // BUG 1: per_role must serialize as `{}` (object), never `[]` (array),
+    // when it has no entries — a Go map[string]RoleEnrollment field cannot be
+    // unmarshaled from a JSON array. Both the 2FA-off case and the 2FA-on but
+    // zero-required-roles case must round-trip through wp_json_encode as `{}`.
+    // -------------------------------------------------------------------------
+
+    public function test_build_enrollment_summary_serializes_empty_per_role_as_object_when_2fa_off(): void
+    {
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled' => false,
+                'hide_backend_enabled' => true,
+                'hide_backend_slug' => 'secret-login',
+            ],
+        ]);
+
+        $ref = new \ReflectionMethod($this->command(), 'buildEnrollmentSummary');
+        $ref->setAccessible(true);
+        $result = $ref->invoke($this->command(), $policy);
+
+        $this->assertInstanceOf(\stdClass::class, $result['per_role']);
+        $this->assertSame('{"per_role":{}}', wp_json_encode($result));
+    }
+
+    public function test_build_enrollment_summary_serializes_empty_per_role_as_object_when_2fa_on_no_roles(): void
+    {
+        // 2FA is enabled but hide_backend toggled alone in the real bug —
+        // here we exercise the "2FA on, zero required roles" branch directly:
+        // no required roles and no groups with require_2fa=true.
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => [],
+            ],
+            'groups' => [],
+        ]);
+
+        $ref = new \ReflectionMethod($this->command(), 'buildEnrollmentSummary');
+        $ref->setAccessible(true);
+        $result = $ref->invoke($this->command(), $policy);
+
+        $this->assertInstanceOf(\stdClass::class, $result['per_role']);
+        $this->assertSame('{"per_role":{}}', wp_json_encode($result));
+    }
+
+    public function test_build_enrollment_summary_populated_case_serializes_as_nested_object(): void
+    {
+        $adminRow     = new \stdClass();
+        $adminRow->ID = 5;
+
+        Functions\when('get_users')->alias(function (array $args) use ($adminRow) {
+            return $args['role'] === 'administrator' ? [$adminRow] : [];
+        });
+
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+
+        $ref = new \ReflectionMethod($this->command(), 'buildEnrollmentSummary');
+        $ref->setAccessible(true);
+        $result = $ref->invoke($this->command(), $policy);
+
+        $encoded = wp_json_encode($result);
+        $this->assertStringContainsString('"administrator":{"enrolled":0,"required":1,"total":1}', $encoded);
     }
 
     // -------------------------------------------------------------------------

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.14
+ * Version:           0.61.15
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.14');
+define('WPMGR_AGENT_VERSION', '0.61.15');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 

--- a/apps/api/internal/agentcmd/cache_contract.go
+++ b/apps/api/internal/agentcmd/cache_contract.go
@@ -1,5 +1,10 @@
 package agentcmd
 
+import (
+	"bytes"
+	"encoding/json"
+)
+
 // This file is the AUTHORITATIVE CP->agent command contract for the Performance
 // Suite (ADR-046, Phase 6). The wp-agent-engineer mirrors these shapes in the
 // agent's command handlers. Field names are JSON wire names; do not rename
@@ -323,13 +328,13 @@ type DBScanTableDetail struct {
 // compatibility — agents < 0.16.0 omit them and the zero value (nil slice)
 // is safe; the CP defaults the corresponding columns to '[]'.
 type DBScanResult struct {
-	OK          bool                            `json:"ok"`
-	JobID       string                          `json:"job_id"`
-	Detail      string                          `json:"detail,omitempty"`
-	Categories  map[string]DBScanCategoryResult `json:"categories,omitempty"`
-	DBSizeBytes int64                           `json:"db_size_bytes"`
-	TableCount  int                             `json:"table_count"`
-	ScannedAt   int64                           `json:"scanned_at"`
+	OK          bool                `json:"ok"`
+	JobID       string              `json:"job_id"`
+	Detail      string              `json:"detail,omitempty"`
+	Categories  dbScanCategoriesMap `json:"categories,omitempty"`
+	DBSizeBytes int64               `json:"db_size_bytes"`
+	TableCount  int                 `json:"table_count"`
+	ScannedAt   int64               `json:"scanned_at"`
 	// Tables is the full per-table inventory added in Phase 2.1.
 	// Each element is classified with owner_type: core|plugin|theme|orphan|unknown.
 	Tables []DBScanTableInventoryRow `json:"tables,omitempty"`
@@ -346,6 +351,27 @@ type DBScanResult struct {
 	// plugin at scan time. Foundation for the P3.8 safety gate.
 	// Omitted by agents < 0.16.0.
 	InstalledPlugins []InstalledPluginItem `json:"installed_plugins,omitempty"`
+}
+
+// dbScanCategoriesMap tolerates a JSON array [] (PHP json_encode of an empty
+// associative array) or null, decoding either as an empty map — same
+// defense-in-depth technique as agentcmd.perRoleMap (GH #170, same class as
+// #148). The agent-built categories map rarely empties in practice, but this
+// keeps the CP decode robust regardless of agent version.
+type dbScanCategoriesMap map[string]DBScanCategoryResult
+
+func (m *dbScanCategoriesMap) UnmarshalJSON(data []byte) error {
+	t := bytes.TrimSpace(data)
+	if len(t) == 0 || string(t) == "null" || string(t) == "[]" {
+		*m = dbScanCategoriesMap{}
+		return nil
+	}
+	var raw map[string]DBScanCategoryResult
+	if err := json.Unmarshal(t, &raw); err != nil {
+		return err
+	}
+	*m = raw
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/agentcmd/cache_contract_test.go
+++ b/apps/api/internal/agentcmd/cache_contract_test.go
@@ -1,0 +1,103 @@
+package agentcmd
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestDBScanResultCategoriesEmptyTolerance is the sibling of the GH #170
+// per_role regression, applied to DBScanResult.Categories: the same agent
+// class of bug (PHP json_encode of an empty associative array serializing as
+// `[]` instead of `{}`) could in principle hit any agent-built response map.
+// Categories rarely empties in practice, but the decode must stay robust
+// regardless of agent version — same defense-in-depth as perRoleMap.
+func TestDBScanResultCategoriesEmptyTolerance(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		wantLen int
+	}{
+		{
+			name:    "categories empty array (PHP empty-assoc encoding)",
+			payload: `{"ok":true,"job_id":"j1","categories":[]}`,
+			wantLen: 0,
+		},
+		{
+			name:    "categories empty object",
+			payload: `{"ok":true,"job_id":"j1","categories":{}}`,
+			wantLen: 0,
+		},
+		{
+			name:    "categories null",
+			payload: `{"ok":true,"job_id":"j1","categories":null}`,
+			wantLen: 0,
+		},
+		{
+			name:    "categories omitted",
+			payload: `{"ok":true,"job_id":"j1"}`,
+			wantLen: 0,
+		},
+		{
+			name:    "categories populated (unchanged control)",
+			payload: `{"ok":true,"job_id":"j1","categories":{"revisions":{"count":4,"bytes":1024}}}`,
+			wantLen: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var decoded DBScanResult
+			if err := json.Unmarshal([]byte(tc.payload), &decoded); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if !decoded.OK {
+				t.Error("decoded ok should be true")
+			}
+			if got := len(decoded.Categories); got != tc.wantLen {
+				t.Errorf("Categories len: want %d, got %d (%+v)", tc.wantLen, got, decoded.Categories)
+			}
+			if tc.wantLen == 1 {
+				rev := decoded.Categories["revisions"]
+				if rev.Count != 4 || rev.Bytes != 1024 {
+					t.Errorf("category values mismatch: %+v", rev)
+				}
+			}
+		})
+	}
+}
+
+// TestPerRoleMapUnmarshalJSON directly exercises perRoleMap's custom decode
+// (white-box; same package) for the exact set of shapes an agent can emit.
+func TestPerRoleMapUnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		wantLen int
+		wantErr bool
+	}{
+		{name: "array", payload: `[]`, wantLen: 0},
+		{name: "object empty", payload: `{}`, wantLen: 0},
+		{name: "null", payload: `null`, wantLen: 0},
+		{name: "populated", payload: `{"administrator":{"enrolled":1,"required":2,"total":3}}`, wantLen: 1},
+		{name: "malformed", payload: `"not-a-map-or-array"`, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var m perRoleMap
+			err := m.UnmarshalJSON([]byte(tc.payload))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if len(m) != tc.wantLen {
+				t.Errorf("len: want %d, got %d (%+v)", tc.wantLen, len(m), m)
+			}
+		})
+	}
+}

--- a/apps/api/internal/agentcmd/security_policy_contract.go
+++ b/apps/api/internal/agentcmd/security_policy_contract.go
@@ -1,5 +1,10 @@
 package agentcmd
 
+import (
+	"bytes"
+	"encoding/json"
+)
+
 // This file is the AUTHORITATIVE CP->agent command contract for the Security
 // Suite Phase 3 (ADR-059): per-site user 2FA + password policy + hide-backend.
 // The wp-agent-engineer mirrors these shapes in the agent's command handler.
@@ -137,7 +142,26 @@ type SecurityPolicyResult struct {
 // EnrollmentSummary carries per-role 2FA enrollment counts. No user identity or
 // secret leaves the site; only aggregate counts are transmitted.
 type EnrollmentSummary struct {
-	PerRole map[string]RoleEnrollment `json:"per_role"`
+	PerRole perRoleMap `json:"per_role"`
+}
+
+// perRoleMap tolerates a JSON array [] (PHP json_encode of an empty associative
+// array) or null, decoding either as an empty map — defense-in-depth alongside
+// the agent-side object-cast emitter fix (GH #170, same class as #148).
+type perRoleMap map[string]RoleEnrollment
+
+func (m *perRoleMap) UnmarshalJSON(data []byte) error {
+	t := bytes.TrimSpace(data)
+	if len(t) == 0 || string(t) == "null" || string(t) == "[]" {
+		*m = perRoleMap{}
+		return nil
+	}
+	var raw map[string]RoleEnrollment
+	if err := json.Unmarshal(t, &raw); err != nil {
+		return err
+	}
+	*m = raw
+	return nil
 }
 
 // RoleEnrollment is the 2FA enrollment count for one WP role.

--- a/apps/api/internal/security/policy_test.go
+++ b/apps/api/internal/security/policy_test.go
@@ -693,6 +693,67 @@ func TestSecurityPolicyResultSerialization(t *testing.T) {
 	}
 }
 
+// TestSecurityPolicyResultPerRoleEmptyTolerance is the GH #170 regression: an
+// agent-serialized empty enrollment_summary.per_role can arrive as a JSON
+// array `[]` (PHP json_encode of an empty associative array), an empty
+// object `{}`, or be omitted entirely as `null`. All three must decode
+// cleanly to an empty (non-nil-panicking) map — same defense-in-depth class
+// as GH #148 — and a populated map must still decode unchanged.
+func TestSecurityPolicyResultPerRoleEmptyTolerance(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		wantLen int
+	}{
+		{
+			// The EXACT #170 payload: an older/pre-fix agent's PHP json_encode
+			// of an empty associative array for per_role.
+			name:    "per_role empty array (exact #170 payload)",
+			payload: `{"ok":true,"detail":"applied","enrollment_summary":{"per_role":[]}}`,
+			wantLen: 0,
+		},
+		{
+			name:    "per_role empty object",
+			payload: `{"ok":true,"detail":"applied","enrollment_summary":{"per_role":{}}}`,
+			wantLen: 0,
+		},
+		{
+			name:    "per_role null",
+			payload: `{"ok":true,"detail":"applied","enrollment_summary":{"per_role":null}}`,
+			wantLen: 0,
+		},
+		{
+			name:    "per_role populated (unchanged control)",
+			payload: `{"ok":true,"detail":"applied","enrollment_summary":{"per_role":{"administrator":{"enrolled":2,"required":2,"total":3}}}}`,
+			wantLen: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var decoded agentcmd.SecurityPolicyResult
+			if err := json.Unmarshal([]byte(tc.payload), &decoded); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if !decoded.OK {
+				t.Error("decoded ok should be true")
+			}
+			if decoded.EnrollmentSummary == nil {
+				t.Fatal("decoded enrollment_summary should not be nil")
+			}
+			if got := len(decoded.EnrollmentSummary.PerRole); got != tc.wantLen {
+				t.Errorf("PerRole len: want %d, got %d (%+v)", tc.wantLen, got, decoded.EnrollmentSummary.PerRole)
+			}
+			if tc.wantLen == 1 {
+				admin := decoded.EnrollmentSummary.PerRole["administrator"]
+				if admin.Enrolled != 2 || admin.Required != 2 || admin.Total != 3 {
+					t.Errorf("enrollment counts mismatch: %+v", admin)
+				}
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Tests: HIBP proxy — cache hit/miss + fail-open + only-prefix-sent
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Two bugs. BUG 1 (reported, cosmetic): empty per_role serialized as [] broke the CP response decode → false 'policy stored but agent push failed' (policy was actually applied). Fix: agent emits {} via (object) cast + CP tolerant decode (#148 pattern). BUG 2 (the serious one): the hide-login secret slug served NO login form (code claimed in a comment was never written) → operator locked out of browser login. Fix: serveLoginForm() serves wp-login.php at the slug + URL link rewrites. Security review SHIP + fixed two more it found: the URL rewrites leaked the secret slug into front-end links (now scoped to only when serving the form) and the access cookie was a forgeable static '1' (now HMAC-signed). api + agent, no migration. 2440 agent tests + plugin check 0 errors. agent 0.61.15.

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the hidden login experience so the secret login URL now reliably shows the login form while the default login page stays hidden.
  * Prevented the secret login link from appearing in normal logged-out page links.
  * Hardened access to the hidden login flow so it can’t be bypassed with a forged cookie.
  * Fixed compatibility issues in security and scan data handling, reducing errors during sync and scan responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->