### PR TITLE
docs(marketing): support 3 payment providers (Razorpay, Stripe, Paddle) across pricing + legal

### DIFF
--- a/apps/marketing/app/(marketing)/legal/page.tsx
+++ b/apps/marketing/app/(marketing)/legal/page.tsx
@@ -27,7 +27,7 @@ const LEGAL_ITEMS = [
     icon: "ScrollText",
     title: "Terms of Service",
     description:
-      "Terms governing use of the WPMgr hosted service at manage.wpmgr.app, including subscription billing through Paddle. The self-hosted control plane and MIT-licensed agent are governed by their respective open-source licenses (AGPL-3.0 / MIT).",
+      "Terms governing use of the WPMgr hosted service at manage.wpmgr.app, including subscription billing through your chosen provider. The self-hosted control plane and MIT-licensed agent are governed by their respective open-source licenses (AGPL-3.0 / MIT).",
     href: "/terms/",
     external: false,
     cta: "View terms",
@@ -36,7 +36,7 @@ const LEGAL_ITEMS = [
     icon: "LockKeyhole",
     title: "Privacy Policy",
     description:
-      "How WPMgr collects, uses, and stores data from hosted service users, including our sub-processors, Google Cloud Platform and Paddle. The agent is privacy-first and off-by-default.",
+      "How WPMgr collects, uses, and stores data from hosted service users, including our sub-processors, Google Cloud Platform, Stripe, Razorpay, and Paddle. The agent is privacy-first and off-by-default.",
     href: "/privacy/",
     external: false,
     cta: "View privacy policy",
@@ -45,7 +45,7 @@ const LEGAL_ITEMS = [
     icon: "Undo2",
     title: "Refund Policy",
     description:
-      "Cancel a monthly subscription anytime. First-time subscribers are covered by a 14-day money-back guarantee, refunded through Paddle to your original payment method.",
+      "Cancel a monthly subscription anytime. First-time subscribers are covered by a 14-day money-back guarantee, refunded through your original payment provider.",
     href: "/refunds/",
     external: false,
     cta: "View refund policy",

--- a/apps/marketing/app/(marketing)/pricing/page.tsx
+++ b/apps/marketing/app/(marketing)/pricing/page.tsx
@@ -72,7 +72,8 @@ export default function PricingPage() {
             <p className="mt-6 text-lg leading-relaxed text-[var(--muted-foreground)]">
               Start free with 3 sites, forever. Upgrade when you need more sites, more managed
               backup storage, or more frequent backups. Every plan gets the full feature set, no
-              tier locks a capability behind a higher price. Billed monthly through Paddle.
+              tier locks a capability behind a higher price. Choose Razorpay, Stripe, or Paddle at
+              checkout; billed monthly.
             </p>
             <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
               <Link
@@ -211,13 +212,13 @@ export default function PricingPage() {
       <FAQ
         eyebrow="FAQ"
         heading="Pricing questions answered"
-        subhead="Common questions about plans, billing through Paddle, and self-hosting."
+        subhead="Common questions about plans, billing, and self-hosting."
         items={PRICING_FAQ}
       />
 
       <CTABand
         heading="Start free today. Upgrade only when you need to."
-        subhead="No credit card required for the Free plan. Paid plans are billed monthly through Paddle and can be cancelled anytime."
+        subhead="No credit card required for the Free plan. Paid plans are billed monthly through your chosen payment provider and can be cancelled anytime."
         ctas={PRICING_CTAS}
       />
 

--- a/apps/marketing/app/(marketing)/privacy/page.tsx
+++ b/apps/marketing/app/(marketing)/privacy/page.tsx
@@ -3,12 +3,12 @@ import { buildMetadata, buildBreadcrumbLd } from "@/lib/seo";
 import { JsonLd } from "@/lib/json-ld";
 import { LegalPage } from "@/components/templates/legal-page";
 import { SITE_CONFIG } from "@/lib/site";
-import { COMPANY, LEGAL_EFFECTIVE_DATE, LEGAL_CONTACT_HREF, PADDLE } from "@/lib/content/legal";
+import { COMPANY, LEGAL_EFFECTIVE_DATE, LEGAL_CONTACT_HREF, PADDLE, STRIPE, RAZORPAY } from "@/lib/content/legal";
 
 export const metadata: Metadata = buildMetadata({
   title: "Privacy Policy | WPMgr",
   description:
-    "How WPMgr collects, uses, and protects data for the hosted service at manage.wpmgr.app, including our sub-processors, Google Cloud and Paddle.",
+    "How WPMgr collects, uses, and protects data for the hosted service at manage.wpmgr.app, including our sub-processors, Google Cloud Platform, Stripe, Razorpay, and Paddle.",
   canonical: "/privacy/",
 });
 
@@ -90,7 +90,8 @@ export default function PrivacyPage() {
                 <p>
                   <strong className="font-semibold text-foreground">Billing information.</strong>{" "}
                   We do not collect or store your card details. Payment information is collected and
-                  processed directly by Paddle, our merchant of record; see section 3.
+                  processed by whichever payment provider you choose at checkout: Razorpay, Stripe,
+                  or Paddle. See section 3.
                 </p>
                 <p>
                   <strong className="font-semibold text-foreground">Operational logs.</strong>{" "}
@@ -134,12 +135,22 @@ export default function PrivacyPage() {
                     hosts the control plane, database, and managed backup storage.
                   </li>
                   <li>
+                    <strong className="font-semibold text-foreground">{STRIPE.legalName}</strong>{" "}
+                    and{" "}
+                    <strong className="font-semibold text-foreground">{RAZORPAY.legalName}</strong>{" "}
+                    are payment processors for payments made through those providers. For those
+                    payments, {COMPANY.legalName} is the seller, and Stripe or Razorpay processes
+                    the payment on our behalf. Each receives the billing and contact data needed to
+                    process your payment and acts as an independent data controller for that
+                    billing data under its own privacy policy.
+                  </li>
+                  <li>
                     <strong className="font-semibold text-foreground">{PADDLE.legalName}</strong>{" "}
-                    is our payment processor and merchant of record for all paid subscriptions.
-                    Paddle receives the billing and contact data needed to process your payment,
-                    calculate tax, issue invoices and receipts, and process refunds. Paddle acts as
-                    an independent data controller for that billing data under its own privacy
-                    policy.
+                    is our payment processor and merchant of record for sales it processes. Paddle
+                    receives the billing and contact data needed to process your payment, calculate
+                    tax, issue invoices and receipts, and process refunds for Paddle-processed
+                    sales. Paddle acts as an independent data controller for that billing data under
+                    its own privacy policy.
                   </li>
                   <li>A transactional email provider, used solely to deliver account emails.</li>
                 </ul>
@@ -152,10 +163,10 @@ export default function PrivacyPage() {
             body: (
               <p>
                 Hosted-service data is stored on Google Cloud Platform infrastructure. Where data is
-                transferred across borders, for example to Paddle for payment processing, we rely
-                on the sub-processor&apos;s own safeguards, such as standard contractual clauses,
-                for that transfer. Contact us at {mail} if you need details about a specific
-                transfer.
+                transferred across borders, for example to Stripe, Razorpay, or Paddle for payment
+                processing, we rely on the sub-processor&apos;s own safeguards, such as standard
+                contractual clauses, for that transfer. Contact us at {mail} if you need details
+                about a specific transfer.
               </p>
             ),
           },

--- a/apps/marketing/app/(marketing)/refunds/page.tsx
+++ b/apps/marketing/app/(marketing)/refunds/page.tsx
@@ -2,12 +2,12 @@ import type { Metadata } from "next";
 import { buildMetadata, buildBreadcrumbLd, buildFAQPageLd } from "@/lib/seo";
 import { JsonLd } from "@/lib/json-ld";
 import { LegalPage } from "@/components/templates/legal-page";
-import { COMPANY, LEGAL_EFFECTIVE_DATE, LEGAL_CONTACT_HREF, PADDLE } from "@/lib/content/legal";
+import { COMPANY, LEGAL_EFFECTIVE_DATE, LEGAL_CONTACT_HREF, PADDLE, STRIPE, RAZORPAY } from "@/lib/content/legal";
 
 export const metadata: Metadata = buildMetadata({
   title: "Refund Policy | WPMgr",
   description:
-    "WPMgr refund policy: cancel a monthly subscription anytime, plus a 14-day money-back guarantee on your first paid payment, processed through Paddle.",
+    "WPMgr refund policy: cancel a monthly subscription anytime, plus a 14-day money-back guarantee on your first paid payment, refunded through your original payment provider.",
   canonical: "/refunds/",
 });
 
@@ -31,6 +31,28 @@ const paddleLink = (
   </a>
 );
 
+const stripeLink = (
+  <a
+    href={STRIPE.website}
+    target="_blank"
+    rel="noreferrer noopener"
+    className="font-medium text-[var(--primary)] underline underline-offset-4 hover:opacity-80 transition-opacity"
+  >
+    {STRIPE.legalName}
+  </a>
+);
+
+const razorpayLink = (
+  <a
+    href={RAZORPAY.website}
+    target="_blank"
+    rel="noreferrer noopener"
+    className="font-medium text-[var(--primary)] underline underline-offset-4 hover:opacity-80 transition-opacity"
+  >
+    {RAZORPAY.legalName}
+  </a>
+);
+
 const REFUND_FAQ = [
   {
     q: "Do I need to cancel my Free plan?",
@@ -42,7 +64,7 @@ const REFUND_FAQ = [
   },
   {
     q: "What if I subscribed by mistake or the plan doesn't fit?",
-    a: "If this is your first paid payment on your account, you are covered by the 14-day money-back guarantee: contact us within 14 days of that payment and we will arrange a full refund through Paddle.",
+    a: "If this is your first paid payment on your account, you are covered by the 14-day money-back guarantee: contact us within 14 days of that payment and we will arrange a full refund back through whichever payment provider processed it: Razorpay, Stripe, or Paddle.",
   },
 ];
 
@@ -66,8 +88,10 @@ export default function RefundsPage() {
         intro={
           <>
             This Refund Policy applies to paid WPMgr subscriptions on the hosted service at
-            manage.wpmgr.app. All payments are processed by {paddleLink}, our merchant of record, and
-            refunds are issued through Paddle to your original payment method.
+            manage.wpmgr.app. At checkout, you choose the payment provider that processes your
+            payment: {razorpayLink}, {stripeLink}, or {paddleLink}. Refunds are issued back
+            through whichever provider processed the original payment, to your original payment
+            method.
           </>
         }
         sections={[
@@ -99,10 +123,11 @@ export default function RefundsPage() {
               <p>
                 If you are new to paid WPMgr plans, your first paid subscription payment is covered
                 by a 14-day money-back guarantee. If the Service is not right for you, contact us
-                within 14 days of that first payment and we will arrange a full refund through
-                Paddle, no detailed justification required. This guarantee applies once per customer
-                and covers only the first paid payment; it does not apply to subsequent renewal
-                payments or to a later resubscription after a previous refund.
+                within 14 days of that first payment and we will arrange a full refund back through
+                the payment provider that processed it, no detailed justification required. This
+                guarantee applies once per customer and covers only the first paid payment; it does
+                not apply to subsequent renewal payments or to a later resubscription after a
+                previous refund.
               </p>
             ),
           },
@@ -111,9 +136,10 @@ export default function RefundsPage() {
             body: (
               <p>
                 Email {mail} with your account email address and the date of the payment you would
-                like refunded. You can also reach out through Paddle&apos;s own support channels,
-                since Paddle processed the original transaction and appears on your statement.
-                We aim to respond to every refund request within two business days.
+                like refunded. If your payment was processed through Paddle, you can also reach out
+                through Paddle&apos;s own support channels, since Paddle processed that transaction
+                and appears on your statement. We aim to respond to every refund request within two
+                business days.
               </p>
             ),
           },
@@ -121,9 +147,12 @@ export default function RefundsPage() {
             heading: "5. How refunds are processed",
             body: (
               <p>
-                Approved refunds are processed by Paddle back to the original payment method used
-                for the purchase. Depending on your bank or card issuer, a refund can take several
-                business days to appear on your statement after Paddle issues it. We are not able to
+                Approved refunds are issued back through whichever payment provider processed the
+                original payment, to the original payment method used for the purchase. For
+                payments processed through Stripe or Razorpay, {COMPANY.legalName} issues the
+                refund directly. For payments processed through Paddle, Paddle issues the refund on
+                our behalf. Depending on your bank or card issuer, a refund can take several
+                business days to appear on your statement after it is issued. We are not able to
                 refund to a different payment method or account than the one that made the original
                 payment.
               </p>

--- a/apps/marketing/app/(marketing)/terms/page.tsx
+++ b/apps/marketing/app/(marketing)/terms/page.tsx
@@ -3,12 +3,12 @@ import { buildMetadata, buildBreadcrumbLd } from "@/lib/seo";
 import { JsonLd } from "@/lib/json-ld";
 import { LegalPage } from "@/components/templates/legal-page";
 import { SITE_CONFIG } from "@/lib/site";
-import { COMPANY, LEGAL_EFFECTIVE_DATE, LEGAL_CONTACT_HREF, PADDLE } from "@/lib/content/legal";
+import { COMPANY, LEGAL_EFFECTIVE_DATE, LEGAL_CONTACT_HREF, PADDLE, STRIPE, RAZORPAY } from "@/lib/content/legal";
 
 export const metadata: Metadata = buildMetadata({
   title: "Terms of Service | WPMgr",
   description:
-    "Terms of Service for the WPMgr hosted service at manage.wpmgr.app, including subscription billing through Paddle as merchant of record.",
+    "Terms of Service for the WPMgr hosted service at manage.wpmgr.app, including subscription billing and your choice of payment provider at checkout.",
   canonical: "/terms/",
 });
 
@@ -40,6 +40,28 @@ const paddleLink = (
     className="font-medium text-[var(--primary)] underline underline-offset-4 hover:opacity-80 transition-opacity"
   >
     {PADDLE.legalName}
+  </a>
+);
+
+const stripeLink = (
+  <a
+    href={STRIPE.website}
+    target="_blank"
+    rel="noreferrer noopener"
+    className="font-medium text-[var(--primary)] underline underline-offset-4 hover:opacity-80 transition-opacity"
+  >
+    {STRIPE.legalName}
+  </a>
+);
+
+const razorpayLink = (
+  <a
+    href={RAZORPAY.website}
+    target="_blank"
+    rel="noreferrer noopener"
+    className="font-medium text-[var(--primary)] underline underline-offset-4 hover:opacity-80 transition-opacity"
+  >
+    {RAZORPAY.legalName}
   </a>
 );
 
@@ -121,22 +143,34 @@ export default function TermsPage() {
             ),
           },
           {
-            heading: "4. Subscription plans and billing through Paddle",
+            heading: "4. Subscription plans and billing",
             body: (
               <>
                 <p>
-                  Paid plans are billed monthly. Our order process and payment collection are
-                  conducted by our online reseller and merchant of record, {paddleLink}. Paddle sells
-                  the WPMgr subscription to you as the authorized reseller, is responsible for
+                  Paid plans are billed monthly. At checkout, you choose the payment provider used
+                  to process your payment: {razorpayLink}, {stripeLink}, or {paddleLink}.
+                </p>
+                <p>
+                  For payments processed through Stripe or Razorpay, {COMPANY.legalName} is the
+                  seller and merchant of record. We are responsible for invoicing, calculating and
+                  remitting applicable tax (including GST on Razorpay-processed payments in India),
+                  and processing refunds directly to you under our Refund Policy. Stripe and
+                  Razorpay act solely as payment processors for these transactions and do not
+                  appear as the merchant on your statement.
+                </p>
+                <p>
+                  For payments processed through Paddle, Paddle is the merchant of record. Paddle
+                  sells the WPMgr subscription to you as our authorized reseller, is responsible for
                   processing your payment, and appears as the merchant on your card or bank
                   statement. Paddle is also responsible for invoicing, calculating and remitting
                   applicable sales tax, VAT, or GST, and processing refunds on our behalf under our
-                  Refund Policy.
+                  Refund Policy for Paddle-processed sales. By subscribing through Paddle, you also
+                  agree to Paddle&apos;s buyer terms and privacy policy, which govern that payment
+                  transaction.
                 </p>
                 <p>
-                  By subscribing, you also agree to Paddle&apos;s buyer terms and privacy policy,
-                  which govern the payment transaction itself. Your subscription renews
-                  automatically each billing period until you cancel. We will provide reasonable
+                  Your subscription renews automatically each billing period until you cancel,
+                  regardless of which provider processed your payment. We will provide reasonable
                   advance notice before any price change takes effect for your account.
                 </p>
               </>

--- a/apps/marketing/lib/content/legal.ts
+++ b/apps/marketing/lib/content/legal.ts
@@ -22,14 +22,42 @@ export const LEGAL_EFFECTIVE_DATE = "June 1, 2026";
 export const LEGAL_CONTACT_HREF = `mailto:${COMPANY.supportEmail}`;
 
 /**
- * Paddle.com Market Ltd is the Merchant of Record for every paid WPMgr
- * subscription. Paddle is the seller on the customer's card statement and
- * handles billing, invoicing, tax collection and remittance, and refunds.
- * WPMgr is the merchant of record for nothing billing-related; Paddle is.
+ * WPMgr offers three payment providers, chosen by the customer at checkout:
+ * Razorpay, Stripe, and Paddle. The merchant-of-record role differs by
+ * provider:
+ *
+ * - Stripe and Razorpay process payments on behalf of {@link COMPANY}, which
+ *   is the seller and merchant of record for those sales. WPMgr handles its
+ *   own tax collection and invoicing for these payments (Razorpay covers
+ *   Indian GST and INR billing; Stripe covers international card payments)
+ *   and issues refunds directly to the original payment method.
+ * - Paddle.com Market Ltd remains the merchant of record for sales it
+ *   processes. Paddle is the seller on the customer's card statement for
+ *   those sales and handles billing, invoicing, tax collection and
+ *   remittance, and refunds for them.
+ *
+ * Stripe and Razorpay are payment processors only; they are not merchants of
+ * record.
  */
 export const PADDLE = {
   legalName: "Paddle.com Market Ltd",
   shortName: "Paddle",
   role: "Merchant of Record",
   website: "https://www.paddle.com",
+} as const;
+
+/** Payment processor for Stripe-processed sales; not the merchant of record. */
+export const STRIPE = {
+  legalName: "Stripe, Inc.",
+  shortName: "Stripe",
+  role: "Payment processor",
+  website: "https://stripe.com",
+} as const;
+
+/** Payment processor for Razorpay-processed sales; not the merchant of record. */
+export const RAZORPAY = {
+  legalName: "Razorpay Software Private Limited",
+  shortName: "Razorpay",
+  role: "Payment processor",
+  website: "https://razorpay.com",
 } as const;

--- a/apps/marketing/lib/content/pricing.ts
+++ b/apps/marketing/lib/content/pricing.ts
@@ -108,7 +108,7 @@ export const PRICING_FAQ: FaqItem[] = [
   },
   {
     q: "What payment methods do you accept?",
-    a: "All paid plans are billed through Paddle, our payment processor and merchant of record. Paddle accepts major credit and debit cards and a range of local payment methods depending on your country, and it handles invoicing and tax automatically.",
+    a: "You choose your payment provider at checkout: Razorpay, Stripe, or Paddle. For Razorpay and Stripe, WPMgr is the seller and handles its own invoicing and tax directly (Razorpay covers Indian GST and INR, Stripe covers international cards). For Paddle, Paddle is the merchant of record and handles invoicing and tax for that sale. All three accept major credit and debit cards, and Razorpay and Paddle also support a range of local payment methods.",
   },
   {
     q: "What is your refund policy?",


### PR DESCRIPTION
Billing now offers a provider choice at checkout. Updated pricing + terms + privacy + refunds + legal index for the per-provider merchant-of-record model: company is seller of record for Stripe/Razorpay (self tax/invoicing, direct refunds); Paddle stays MoR scoped to Paddle sales. Added STRIPE/RAZORPAY constants; Stripe+Razorpay added to privacy sub-processors. No price/plan/guarantee changes. check-copy + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU