### PR TITLE
fix(admin): reachable 2FA settings, full-width layout, working Accounts pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.41] - 2026-07-08
+
+### Fixed
+
+- Admin panel improvements. Two-factor authentication settings are now reachable for every account: they were hidden for any account without an organization (including the instance superadmin), and a "Security" shortcut was added to the account menu so it is one click away. The instance-admin console is now full width with a single, cleaner sidebar navigation instead of the previous boxed, narrow layout with a wasted gutter. And the Accounts list pagination now advances correctly, the Next and Previous controls were resetting back to the first page on every click.
+
 ## [0.61.40] - 2026-07-08
 
 ### Fixed

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -2,6 +2,8 @@ import { useEffect, useId, useRef, useState, type ReactNode } from "react";
 import { Link, useLocation } from "@tanstack/react-router";
 import {
   Activity,
+  ArrowLeft,
+  Building2,
   ChevronRight,
   Globe,
   LineChart,
@@ -9,6 +11,8 @@ import {
   Settings,
   Share2,
   Shield,
+  ShieldAlert,
+  TrendingUp,
   Users,
   type LucideIcon,
 } from "lucide-react";
@@ -85,6 +89,14 @@ interface NavGroup {
   items?: NavItem[];
   /** When true this group is collapsible in expanded sidebar mode. */
   collapsible?: boolean;
+  /**
+   * When true, this leaf only lights up on an EXACT pathname match, never a
+   * sub-route prefix match. Needed for a top-level index route that has
+   * sibling leaves sharing its prefix (Admin's "Users" leaf lives at
+   * `/admin`, and would otherwise also light up on `/admin/accounts`,
+   * `/admin/revenue`, etc. via the default prefix-match `isActive`).
+   */
+  exactMatch?: boolean;
 }
 
 // Top groups (rendered above the bottom-aligned Settings entry).
@@ -158,11 +170,25 @@ const SHARED_WITH_ME_GROUP: NavGroup = {
   to: "/shared-with-me",
 };
 
-// Superadmin-only nav entry. Only mounted when me.user.is_superadmin === true.
-const ADMIN_GROUP: NavGroup = {
-  label: "Admin",
-  icon: Shield,
-  to: "/admin",
+// Superadmin-only nav entries — promoted directly into the primary sidebar
+// (Option A, GH admin-layout fix) rather than living inside a second, nested
+// "Instance Admin" left-nav inside the /admin route layout. Only mounted when
+// me.user.is_superadmin === true. "Users" is the /admin index route, so it
+// carries `exactMatch` — otherwise its prefix-matching `isActive` check would
+// also light it up on every other /admin/* leaf below it.
+const ADMIN_NAV_GROUPS: ReadonlyArray<NavGroup> = [
+  { label: "Users", icon: Users, to: "/admin", exactMatch: true },
+  { label: "Accounts", icon: Building2, to: "/admin/accounts" },
+  { label: "Revenue", icon: TrendingUp, to: "/admin/revenue" },
+  { label: "Vulnerability feed", icon: ShieldAlert, to: "/admin/vuln-feed" },
+];
+
+// Bottom-aligned app-switcher leaf, mirroring how the tenant sidebar
+// bottom-aligns its single Settings leaf.
+const BACK_TO_SITES_LEAF: NavGroup = {
+  label: "Back to Sites",
+  icon: ArrowLeft,
+  to: "/sites",
 };
 
 export function Sidebar() {
@@ -214,15 +240,30 @@ export function Sidebar() {
           {superadmin ? (
             // Superadmin is monitoring-only: show ONLY the Admin area. They
             // have no org and never manage sites/settings.
-            <ul className="flex flex-col gap-0.5">
-              <li>
-                <NavGroupItem
-                  group={ADMIN_GROUP}
-                  pathname={pathname}
-                  collapsed={collapsed}
-                />
-              </li>
-            </ul>
+            <>
+              <ul className="flex flex-col gap-0.5">
+                {ADMIN_NAV_GROUPS.map((group) => (
+                  <li key={group.label}>
+                    <NavGroupItem
+                      group={group}
+                      pathname={pathname}
+                      collapsed={collapsed}
+                    />
+                  </li>
+                ))}
+              </ul>
+              {/* Back to Sites — bottom-aligned, mirrors the tenant
+                  sidebar's bottom-aligned Settings leaf. */}
+              <ul className="mt-auto flex flex-col gap-0.5 pt-3">
+                <li>
+                  <NavGroupItem
+                    group={BACK_TO_SITES_LEAF}
+                    pathname={pathname}
+                    collapsed={collapsed}
+                  />
+                </li>
+              </ul>
+            </>
           ) : (
             <>
               <ul className="flex flex-col gap-0.5">
@@ -299,8 +340,13 @@ function NavGroupItem({ group, pathname, collapsed }: GroupProps) {
   const hasItems = !!group.items?.length;
 
   // Group is "active" when its own route or any sub-item route is the
-  // current pathname (or prefix).
-  const selfActive = group.to ? isActive(pathname, group.to) : false;
+  // current pathname (or prefix). `exactMatch` opts a leaf out of the
+  // prefix-match behavior (see the NavGroup interface doc above).
+  const selfActive = group.to
+    ? group.exactMatch
+      ? pathname === group.to
+      : isActive(pathname, group.to)
+    : false;
   const childActive =
     hasItems &&
     group.items!.some((item) => item.to && isActive(pathname, item.to));

--- a/apps/web/src/components/layout/top-bar.tsx
+++ b/apps/web/src/components/layout/top-bar.tsx
@@ -9,6 +9,7 @@ import {
   PanelLeftClose,
   PanelLeftOpen,
   Search,
+  ShieldCheck,
   UserRound,
 } from "lucide-react";
 
@@ -257,7 +258,10 @@ function NotificationsBell() {
 
 // ── User menu ────────────────────────────────────────────────────────────────
 
-function UserMenu() {
+// Exported (not just used locally) so a render test can mount it in
+// isolation without pulling in the rest of TopBar's provider surface
+// (command palette, bulk-action context, org switcher, etc).
+export function UserMenu() {
   const { data: me } = useMe();
   const logout = useLogout();
   const navigate = useNavigate();
@@ -298,6 +302,16 @@ function UserMenu() {
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
           <Link to="/settings/account">Account settings</Link>
+        </DropdownMenuItem>
+        {/* Two-factor auth / passkeys lives at /settings/security. It's a
+            per-user setting (no org guard), so it belongs here — one click
+            from anywhere, including the superadmin's /admin console, which
+            has no Settings entry in the primary sidebar. */}
+        <DropdownMenuItem asChild>
+          <Link to="/settings/security">
+            <ShieldCheck aria-hidden="true" className="size-4" />
+            <span>Security</span>
+          </Link>
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem

--- a/apps/web/src/routes/_authed/admin/accounts/$tenantId.tsx
+++ b/apps/web/src/routes/_authed/admin/accounts/$tenantId.tsx
@@ -67,7 +67,7 @@ function AdminAccountDetailPage() {
 
   if (isPending) {
     return (
-      <section className="max-w-4xl space-y-6">
+      <section className="space-y-6">
         <PageHeader
           title="Loading account..."
           backTo={{ to: "/admin/accounts", label: "Back to Accounts" }}
@@ -80,7 +80,7 @@ function AdminAccountDetailPage() {
 
   if (isError || !data) {
     return (
-      <section className="max-w-4xl space-y-6">
+      <section className="space-y-6">
         <PageHeader
           title="Account"
           backTo={{ to: "/admin/accounts", label: "Back to Accounts" }}
@@ -123,7 +123,7 @@ function AdminAccountDetailPage() {
   const timelineNewestFirst = sortEventsNewestFirst(timeline);
 
   return (
-    <section className="max-w-4xl space-y-6">
+    <section className="space-y-6">
       <PageHeader
         title={org_name}
         copyable={tenant_id}

--- a/apps/web/src/routes/_authed/admin/accounts/-index.test.tsx
+++ b/apps/web/src/routes/_authed/admin/accounts/-index.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+
+import { createTestQueryClient, renderWithProviders } from "@/test/render";
+import { mockQueryResult } from "@/test/query-mocks";
+import { authKeys } from "@/features/auth/use-auth";
+import type { Me } from "@wpmgr/api";
+
+import { Route as AdminAccountsRoute } from "./index";
+import {
+  useAdminAccountsList,
+  type AdminAccountsListResponse,
+} from "@/features/admin/use-admin-accounts";
+
+// Regression test for the Accounts pager bug: `patchSearch`'s literal
+// `offset: 0` used to be spread AFTER `...patch`, so it clobbered the
+// Next/Previous handlers' own computed `offset` on every single click — the
+// pager was permanently stuck on page 1. Fixed by reordering to
+// `{ ...prev, offset: 0, ...patch }` (routes/_authed/admin/accounts/index.tsx).
+//
+// This mounts the REAL route component (not a stand-in), because the bug
+// lives in how the component's own `patchSearch` merges search params — a
+// test that stubs navigation would test the stub, not the bug. The page
+// reads/writes the URL via `Route.useSearch()` / `useNavigate({ from:
+// Route.fullPath })`, both bound to the file's own exported `Route`
+// singleton, so the test router below re-attaches that EXACT singleton to a
+// throwaway root route (mirroring what the generated routeTree.gen.ts does
+// at boot via `Route.update({ id, path, getParentRoute })` — see that file's
+// `AuthedAdminAccountsIndexRoute` block) rather than rendering the component
+// as an inert child of a generic wrapper route, which would leave the
+// exported `Route` never `.init()`-ed and `Route.useSearch()` unable to
+// resolve anything. See src/test/render.tsx's module doc for why a full app
+// routeTree is deliberately not used elsewhere in this suite either.
+
+vi.mock("@/features/admin/use-admin-accounts", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/features/admin/use-admin-accounts")>();
+  return { ...actual, useAdminAccountsList: vi.fn() };
+});
+
+const mockedUseAdminAccountsList = vi.mocked(useAdminAccountsList);
+
+// A large `total` relative to the default page size (25) lets both Next and
+// Previous be exercised without needing a second fixture page. `items: []`
+// is deliberate — this test proves the URL-search reducer, not row
+// rendering, and empty rows sidestep needing a `/admin/accounts/$tenantId`
+// child route registered on the throwaway test router (AccountRow links
+// there).
+const FIXTURE: AdminAccountsListResponse = {
+  tiles: { mrr_cents: 590_000, active_subs: 80, past_due_count: 3, accounts_total: 100 },
+  items: [],
+  total: 100,
+  limit: 25,
+  offset: 0,
+};
+
+/**
+ * Attaches the route file's actual exported `Route` singleton to a fresh,
+ * isolated root route and returns a router mounted at `initialPath`. This is
+ * the same post-hoc wiring `routeTree.gen.ts` performs for every file route
+ * (`Route.update({ id, path, getParentRoute })`), just scoped to a throwaway
+ * root instead of the real `_authed`/`admin` parent chain — so the `_authed`
+ * session guard never runs, matching every other render test in this suite.
+ *
+ * `Route.update`'s public type only accepts already-declared updatable
+ * fields (component/loader/etc), not the creation-time `id`/`path`/
+ * `getParentRoute` triple the codegen assigns post hoc — the generated file
+ * casts through `any` for this exact call. We route through `unknown`
+ * instead so this test file's own `@typescript-eslint/no-explicit-any: error`
+ * rule stays clean.
+ */
+function buildAccountsRouter(initialPath: string) {
+  const rootRoute = createRootRoute({});
+  type UpdateOptions = Parameters<typeof AdminAccountsRoute.update>[0];
+  const accountsRoute = AdminAccountsRoute.update({
+    id: "/admin/accounts",
+    path: "/admin/accounts",
+    getParentRoute: () => rootRoute,
+  } as unknown as UpdateOptions);
+  const routeTree = rootRoute.addChildren([accountsRoute]);
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+  });
+}
+
+// A minimal but fully valid `Me` — every field the type requires is present,
+// so no type assertion is needed to hand it to the query cache.
+const ME_FIXTURE: Me = {
+  user: {
+    id: "00000000-0000-0000-0000-000000000099",
+    email: "superadmin@wpmgr.test",
+    name: "Superadmin",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    is_superadmin: true,
+  },
+  memberships: [],
+  hosted: true,
+};
+
+function renderAccountsPage(initialPath = "/admin/accounts") {
+  const queryClient = createTestQueryClient();
+  // `useMe()` is a real TanStack Query hook the page calls for the
+  // `hosted` banner gate only — pre-seed the cache instead of mocking the
+  // whole auth module, so an accidental real `getMe()` network call never
+  // fires in this jsdom environment.
+  queryClient.setQueryData(authKeys.me, ME_FIXTURE);
+  const router = buildAccountsRouter(initialPath);
+  renderWithProviders(<RouterProvider router={router} />, { queryClient });
+  return router;
+}
+
+beforeEach(() => {
+  mockedUseAdminAccountsList.mockReturnValue(
+    mockQueryResult<AdminAccountsListResponse>({ data: FIXTURE }),
+  );
+});
+
+describe("Admin Accounts pager — patchSearch offset regression", () => {
+  it("Next advances the URL search offset to `limit` and Previous returns it to 0 (non-vacuous: the pre-fix spread order always clobbers offset back to 0)", async () => {
+    const router = renderAccountsPage();
+
+    const nextButton = await screen.findByRole("button", { name: "Next" });
+    expect(router.state.location.search.offset).toBeUndefined();
+
+    fireEvent.click(nextButton);
+    await waitFor(() => {
+      expect(router.state.location.search.offset).toBe(25);
+    });
+    // Also visible in the rendered pager text, for good measure.
+    expect(await screen.findByText("26-50 of 100")).toBeInTheDocument();
+
+    const prevButton = screen.getByRole("button", { name: "Previous" });
+    fireEvent.click(prevButton);
+    await waitFor(() => {
+      expect(router.state.location.search.offset).toBe(0);
+    });
+    expect(await screen.findByText("1-25 of 100")).toBeInTheDocument();
+  });
+
+  it("applying a filter resets the offset back to page 1 while keeping the filter", async () => {
+    const router = renderAccountsPage();
+
+    const nextButton = await screen.findByRole("button", { name: "Next" });
+    fireEvent.click(nextButton);
+    await waitFor(() => {
+      expect(router.state.location.search.offset).toBe(25);
+    });
+
+    // "Past due" is a plain toggle chip (not a Radix popover), so it exercises
+    // the exact same `patchSearch` path as the Status multi-select filter
+    // without needing to drive a portal-rendered menu open in jsdom.
+    const pastDueChip = screen.getByRole("button", { name: "Past due" });
+    fireEvent.click(pastDueChip);
+
+    await waitFor(() => {
+      expect(router.state.location.search.offset).toBe(0);
+    });
+    expect(router.state.location.search.status).toEqual(["past_due"]);
+  });
+});

--- a/apps/web/src/routes/_authed/admin/accounts/index.tsx
+++ b/apps/web/src/routes/_authed/admin/accounts/index.tsx
@@ -117,8 +117,13 @@ function AdminAccountsPage() {
     useAdminAccountsList(filters);
 
   function patchSearch(patch: Partial<AccountsSearch>) {
+    // `offset: 0` must come BEFORE `...patch`, not after: a filter patch
+    // (search/status/plan/sort — none of which carry an `offset`) should
+    // reset to page 1, but a pager patch (Next/Previous, which DOES carry an
+    // explicit `offset`) must win over that reset. Spreading `patch` last
+    // lets it override the `offset: 0` default when present.
     void navigate({
-      search: (prev: AccountsSearch) => ({ ...prev, ...patch, offset: 0 }),
+      search: (prev: AccountsSearch) => ({ ...prev, offset: 0, ...patch }),
       replace: true,
     });
   }

--- a/apps/web/src/routes/_authed/admin/index.tsx
+++ b/apps/web/src/routes/_authed/admin/index.tsx
@@ -103,7 +103,7 @@ function AdminUsersPage() {
 
       {/* Stats strip */}
       {stats ? (
-        <div className="grid grid-cols-3 gap-4">
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
           {(
             [
               { label: "Users", value: stats.users },

--- a/apps/web/src/routes/_authed/admin/revenue.tsx
+++ b/apps/web/src/routes/_authed/admin/revenue.tsx
@@ -40,7 +40,7 @@ function AdminRevenuePage() {
 
   if (isPending) {
     return (
-      <section className="max-w-4xl space-y-6">
+      <section className="space-y-6">
         <PageHeader title="Revenue" subline="Instance-wide billing health." />
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-5">
           {Array.from({ length: 5 }).map((_, i) => (
@@ -54,7 +54,7 @@ function AdminRevenuePage() {
 
   if (isError || !data) {
     return (
-      <section className="max-w-4xl space-y-6">
+      <section className="space-y-6">
         <PageHeader title="Revenue" subline="Instance-wide billing health." />
         <PageError
           what="Could not load revenue data."
@@ -72,7 +72,7 @@ function AdminRevenuePage() {
   const webhookStale = isWebhookStale(last_webhook_received_at);
 
   return (
-    <section className="max-w-4xl space-y-6">
+    <section className="space-y-6">
       <PageHeader title="Revenue" subline="Instance-wide billing health." />
 
       {!hosted ? (

--- a/apps/web/src/routes/_authed/admin/route.tsx
+++ b/apps/web/src/routes/_authed/admin/route.tsx
@@ -1,23 +1,21 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
-import { createFileRoute, Link, Outlet, redirect, useLocation } from "@tanstack/react-router";
+import { createFileRoute, Link, Outlet, redirect } from "@tanstack/react-router";
 // The admin billing pages render Tooltip components (approximate-storage marker,
 // overrides dot, etc.). The app has no global TooltipProvider — each feature
 // provides its own — so the admin layout provides one for every /admin page.
 import { TooltipProvider } from "@/components/ui/tooltip";
-import {
-  ArrowLeft,
-  Building2,
-  ShieldCheck,
-  TrendingUp,
-  Users,
-  type LucideIcon,
-} from "lucide-react";
 
 import { ensureMe, isSuperadmin } from "@/features/auth/use-auth";
-import { cn } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
-// Superadmin layout route — wraps all /admin/* sub-pages with a left nav.
+// Superadmin layout route.
+//
+// The four admin sections (Users, Accounts, Revenue, Vulnerability feed) live
+// in the PRIMARY sidebar's superadmin branch (components/layout/sidebar.tsx),
+// not in a second, nested left-nav here — this layout used to duplicate that
+// navigation in a ~210px column capped at max-w-5xl, which both boxed in
+// every admin page AND doubled up the navigation surface. This layout is now
+// just the error boundary + the shared TooltipProvider, full-width.
 //
 // Auth gate: beforeLoad checks isSuperadmin and redirects non-superadmins to
 // /sites. This gate runs on every navigation into any /admin/* route, including
@@ -103,113 +101,20 @@ class AdminErrorBoundary extends Component<
 }
 
 // ---------------------------------------------------------------------------
-// Nav item definitions — add new admin sections here only.
-// ---------------------------------------------------------------------------
-
-type AdminNavPath =
-  | "/admin"
-  | "/admin/accounts"
-  | "/admin/revenue"
-  | "/admin/vuln-feed";
-
-interface AdminNavItem {
-  label: string;
-  to: AdminNavPath;
-  icon: LucideIcon;
-}
-
-const ADMIN_NAV_ITEMS: AdminNavItem[] = [
-  { label: "Users", to: "/admin", icon: Users },
-  { label: "Accounts", to: "/admin/accounts", icon: Building2 },
-  { label: "Revenue", to: "/admin/revenue", icon: TrendingUp },
-  { label: "Vulnerability feed", to: "/admin/vuln-feed", icon: ShieldCheck },
-];
-
-// ---------------------------------------------------------------------------
-// Layout component
+// Layout component — full-width, no boxed max-width column. Navigation into
+// the four admin sections lives in the primary sidebar (see the module doc
+// above); this layout only supplies the shared TooltipProvider (see the
+// import comment) and the error boundary around the matched sub-page.
 // ---------------------------------------------------------------------------
 
 function AdminLayout() {
-  const location = useLocation();
-  const pathname = location.pathname;
-
   return (
     <TooltipProvider>
-    <div className="mx-auto w-full max-w-5xl">
-      <div className="flex flex-col gap-6 md:flex-row md:gap-10">
-        {/* Left navigation — mirrors the Settings area side-menu pattern. */}
-        <nav
-          aria-label="Admin"
-          className={cn(
-            "flex flex-row gap-1 overflow-x-auto pb-1",
-            "md:w-[210px] md:shrink-0 md:flex-col md:overflow-x-visible md:pb-0",
-          )}
-        >
-          <p
-            aria-hidden="true"
-            className="hidden select-none px-3 pb-1 text-xs font-medium uppercase tracking-[0.06em] text-muted-foreground md:block"
-          >
-            Instance Admin
-          </p>
-
-          {ADMIN_NAV_ITEMS.map((item) => {
-            // Exact match for the index (/admin) so it does not also light up
-            // for /admin/vuln-feed; prefix match for sub-routes of the others.
-            const active =
-              item.to === "/admin"
-                ? pathname === "/admin"
-                : pathname === item.to || pathname.startsWith(`${item.to}/`);
-
-            const Icon = item.icon;
-            return (
-              <Link
-                key={item.to}
-                to={item.to}
-                aria-current={active ? "page" : undefined}
-                className={cn(
-                  "relative flex min-w-max items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                  "border-b-2 md:border-b-0 md:border-l-2",
-                  active
-                    ? "border-primary bg-accent text-accent-foreground"
-                    : "border-transparent text-foreground hover:bg-muted/50",
-                  "md:w-full md:min-w-0",
-                )}
-              >
-                <Icon aria-hidden="true" className="size-4 shrink-0" />
-                <span className="truncate">{item.label}</span>
-              </Link>
-            );
-          })}
-
-          {/* App-switcher: back to the tenant app. Superadmins can access
-              /sites directly when they have an org — this provides a quick
-              return path when navigating out of the admin area. */}
-          <div className="mt-2 hidden border-t border-border pt-2 md:block">
-            <Link
-              to="/sites"
-              className={cn(
-                "flex min-w-max items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-colors",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                "border-transparent text-muted-foreground hover:text-foreground hover:bg-muted/50",
-                "md:w-full md:min-w-0",
-              )}
-            >
-              <ArrowLeft aria-hidden="true" className="size-4 shrink-0" />
-              <span className="truncate">Back to Sites</span>
-            </Link>
-          </div>
-        </nav>
-
-        {/* Page content — wrapped in an error boundary so a failed admin
-            chunk import never propagates up to the tenant app routes. */}
-        <main className="min-w-0 flex-1">
-          <AdminErrorBoundary>
-            <Outlet />
-          </AdminErrorBoundary>
-        </main>
+      <div className="w-full min-w-0 space-y-6">
+        <AdminErrorBoundary>
+          <Outlet />
+        </AdminErrorBoundary>
       </div>
-    </div>
     </TooltipProvider>
   );
 }

--- a/apps/web/src/routes/_authed/settings/-route.test.tsx
+++ b/apps/web/src/routes/_authed/settings/-route.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import type { Me } from "@wpmgr/api";
+
+import { renderWithProviders } from "@/test/render";
+import { mockQueryResult } from "@/test/query-mocks";
+import { UserMenu } from "@/components/layout/top-bar";
+
+import { Route, SETTINGS_NAV_ITEMS } from "./route";
+
+// Rendered via `Route.options.component` rather than a dedicated named
+// export of the layout function: TanStack Router's vite plugin auto-splits
+// each route's `component` into its own chunk, and adding a second named
+// export of that same function for testability purposes would opt it back
+// out of that split (the plugin warns "will not be code-split and will
+// increase your bundle size" the moment such an export exists) — `Route` is
+// already exported for route registration, so reading `.options.component`
+// off it is free.
+const SettingsLayout = Route.options.component!;
+
+// GH nav-gap fix: the 2FA suite at /settings/security was fully built and
+// worked by direct URL, but was unreachable for a superadmin — the Security
+// item carried `orgOnly: true`, and a seeded superadmin has no membership
+// (isOrgScoped(me) is false), so `SETTINGS_NAV_ITEMS`'s filter silently
+// dropped it, and nothing linked to it from /admin or the user menu either.
+// Fixed by (a) removing `orgOnly` from the Security item (it's a PERSONAL,
+// per-user /auth/2fa/* setting, not an org setting) and (b) adding a direct
+// link in the top-bar user menu.
+
+vi.mock("@/features/auth/use-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/auth/use-auth")>();
+  return { ...actual, useMe: vi.fn() };
+});
+
+const { useMe } = await import("@/features/auth/use-auth");
+const mockedUseMe = vi.mocked(useMe);
+
+// A superadmin with NO membership — the exact shape that made this bug
+// invisible: `isOrgScoped(me)` is false (no `memberships` entry matching
+// `active_tenant_id`, and `active_tenant_id` itself is absent), so any item
+// still marked `orgOnly` would be filtered out for this principal.
+const SUPERADMIN_ME: Me = {
+  user: {
+    id: "00000000-0000-0000-0000-000000000001",
+    email: "superadmin@wpmgr.test",
+    name: "Superadmin",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    is_superadmin: true,
+  },
+  memberships: [],
+};
+
+beforeEach(() => {
+  mockedUseMe.mockReturnValue(mockQueryResult<Me | null>({ data: SUPERADMIN_ME }));
+});
+
+describe("SETTINGS_NAV_ITEMS — Security is not orgOnly (regression guard)", () => {
+  it("Security does not carry orgOnly (this exact flag is what filtered it out for a superadmin)", () => {
+    const security = SETTINGS_NAV_ITEMS.find((item) => item.label === "Security");
+    expect(security).toBeDefined();
+    expect(security?.to).toBe("/settings/security");
+    expect(security?.orgOnly).not.toBe(true);
+  });
+
+  it("still marks genuinely org-scoped items as orgOnly (this fix did not remove ALL gating)", () => {
+    const organisation = SETTINGS_NAV_ITEMS.find((item) => item.label === "Organisation");
+    expect(organisation?.orgOnly).toBe(true);
+  });
+});
+
+describe("SettingsLayout — Security renders for a superadmin with no membership", () => {
+  it("renders a Security link for a superadmin (is_superadmin, isOrgScoped false), and still hides Organisation", async () => {
+    renderWithProviders(<SettingsLayout />, {
+      withRouter: true,
+      initialPath: "/settings/account",
+    });
+
+    const securityLink = await screen.findByRole("link", { name: "Security" });
+    expect(securityLink).toHaveAttribute("href", "/settings/security");
+
+    // Sanity check: a genuinely org-scoped item is still absent for this
+    // principal, proving the fix didn't just remove every filter.
+    expect(screen.queryByRole("link", { name: "Organisation" })).not.toBeInTheDocument();
+  });
+});
+
+describe("Top bar user menu — direct Security link (GH nav-gap fix)", () => {
+  it("renders a Security item routed to /settings/security, one click from anywhere including /admin", async () => {
+    renderWithProviders(<UserMenu />, {
+      withRouter: true,
+      initialPath: "/admin",
+    });
+
+    // First query after mount must be async (`findBy*`) — RouterProvider's
+    // first paint resolves in a microtask, per src/test/render.tsx's module
+    // doc; a bare `getByRole` here races an empty DOM.
+    const trigger = await screen.findByRole("button", {
+      name: "Account menu for Superadmin",
+    });
+    // The dropdown opens on pointerdown OR Enter/Space (Radix
+    // DropdownMenuTrigger); Enter is the more deterministic path in jsdom.
+    fireEvent.keyDown(trigger, { key: "Enter" });
+
+    const securityItem = await screen.findByRole("menuitem", { name: /security/i });
+    expect(securityItem).toHaveAttribute("href", "/settings/security");
+  });
+});

--- a/apps/web/src/routes/_authed/settings/route.tsx
+++ b/apps/web/src/routes/_authed/settings/route.tsx
@@ -35,7 +35,11 @@ interface SettingsNavItem {
 
 export const SETTINGS_NAV_ITEMS: SettingsNavItem[] = [
   { label: "Account",       to: "/settings/account",      icon: User },
-  { label: "Security",      to: "/settings/security",     icon: ShieldCheck,  orgOnly: true },
+  // Security (2FA) is a PERSONAL account setting backed by per-user
+  // /auth/2fa/* endpoints — it must render for every authenticated principal
+  // (superadmin, site-scoped collaborator, org member), not just org-scoped
+  // members. Do NOT add `orgOnly` back here.
+  { label: "Security",      to: "/settings/security",     icon: ShieldCheck },
   { label: "Organisation",  to: "/settings/organization", icon: Building2,    orgOnly: true },
   // Billing is owner-only (like the audit re-baseline) AND only ever
   // meaningful on a hosted instance — self-hosted installs never see it.


### PR DESCRIPTION
Three admin-panel frontend fixes from a research workflow: (1) 2FA settings were hidden for accounts without an org (incl the superadmin) - un-gated + added a Security shortcut to the account menu; (2) boxed layout - full-width + admin nav promoted into the primary sidebar (Option A), TooltipProvider preserved; (3) Accounts pagination one-line bug (offset:0 spread after patch clobbered the pager) reordered. Each with a non-vacuous test. web-only. 905 tests green, lint/typecheck/impeccable clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible **Security** entry in the account menu and settings navigation for easier access to 2FA/security options.
  * Updated the admin console layout to use a full-width, cleaner navigation experience.

* **Bug Fixes**
  * Fixed admin accounts pagination so **Next** and **Previous** move between pages correctly.
  * Improved admin account filtering so changing filters resets paging as expected.
  * Removed unnecessary width constraints from admin pages for better display on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->