### PR TITLE
fix(admin): let the superadmin reach their own 2FA/account settings (complete v0.61.41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.42] - 2026-07-08
+
+### Fixed
+
+- Completed the admin two-factor-access fix from the previous release: the instance superadmin was still redirected back to the admin area when opening the Security (2FA) settings. Superadmin accounts are intentionally kept out of the tenant-scoped app, but that route guard also blocked their own personal account pages. The superadmin can now reach their own Account and Security settings (to enable 2FA) while still being kept out of the tenant-scoped screens.
+
 ## [0.61.41] - 2026-07-08
 
 ### Fixed

--- a/apps/web/src/features/auth/use-auth.test.ts
+++ b/apps/web/src/features/auth/use-auth.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { isSuperadminAllowedPath } from "./use-auth";
+
+// A superadmin has no org and is pinned to /admin by the _authed gate, EXCEPT
+// their own per-user account settings (profile + 2FA) — otherwise they can
+// never enable their own 2FA (GH admin-panel report).
+describe("isSuperadminAllowedPath", () => {
+  it("allows the admin area and its children", () => {
+    expect(isSuperadminAllowedPath("/admin")).toBe(true);
+    expect(isSuperadminAllowedPath("/admin/accounts")).toBe(true);
+    expect(isSuperadminAllowedPath("/admin/accounts/abc123")).toBe(true);
+  });
+
+  it("allows the superadmin's own personal account + security settings", () => {
+    expect(isSuperadminAllowedPath("/settings/account")).toBe(true);
+    expect(isSuperadminAllowedPath("/settings/security")).toBe(true);
+  });
+
+  it("still keeps the superadmin OUT of the tenant-scoped shell", () => {
+    expect(isSuperadminAllowedPath("/")).toBe(false);
+    expect(isSuperadminAllowedPath("/sites")).toBe(false);
+    expect(isSuperadminAllowedPath("/uptime")).toBe(false);
+    // org-scoped settings pages must stay blocked (they'd 403 with no org)
+    expect(isSuperadminAllowedPath("/settings/organization")).toBe(false);
+    expect(isSuperadminAllowedPath("/settings/billing")).toBe(false);
+    expect(isSuperadminAllowedPath("/settings/members")).toBe(false);
+  });
+});

--- a/apps/web/src/features/auth/use-auth.ts
+++ b/apps/web/src/features/auth/use-auth.ts
@@ -418,6 +418,22 @@ export function isSuperadmin(me: Me | null | undefined): boolean {
 }
 
 /**
+ * Paths a superadmin (who has no org) may visit outside the Admin area. The
+ * _authed gate keeps superadmins out of the tenant-scoped shell (which would
+ * 403 or bounce them to the create-org screen), but their OWN personal account
+ * settings — profile and 2FA/security — are per-user, not tenant-scoped, so
+ * they must be reachable (otherwise a superadmin can never enable their own
+ * 2FA). Everything else outside /admin stays redirected to /admin.
+ */
+export function isSuperadminAllowedPath(pathname: string): boolean {
+  return (
+    pathname.startsWith("/admin") ||
+    pathname === "/settings/account" ||
+    pathname === "/settings/security"
+  );
+}
+
+/**
  * Active role of the user in their active tenant.
  *
  * FIXED (M5.7): no longer falls back to memberships[0] — that was unsafe

--- a/apps/web/src/routes/_authed.tsx
+++ b/apps/web/src/routes/_authed.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 
 import { AppShell } from "@/components/layout/app-shell";
-import { ensureMe, useMe, isSuperadmin } from "@/features/auth/use-auth";
+import { ensureMe, useMe, isSuperadmin, isSuperadminAllowedPath } from "@/features/auth/use-auth";
 import { BulkActionProvider } from "@/features/sites/bulk-action-drawer";
 import { NoOrgScreen } from "@/features/orgs/no-org-screen";
 
@@ -28,8 +28,9 @@ export const Route = createFileRoute("/_authed")({
     // Superadmins are monitoring-only: they have no org and never manage sites,
     // so keep them inside the Admin area and out of the tenant-scoped shell
     // (which would 403 / bounce them to the create-org screen). They still reach
-    // /admin and any future /admin/* routes.
-    if (isSuperadmin(me) && !location.pathname.startsWith("/admin")) {
+    // /admin and any future /admin/* routes, PLUS their own per-user account
+    // settings (profile + 2FA/security) so they can secure their own login.
+    if (isSuperadmin(me) && !isSuperadminAllowedPath(location.pathname)) {
       throw redirect({ to: "/admin" });
     }
   },


### PR DESCRIPTION
v0.61.41 un-gated the Security nav item but the superadmin still could not open it: the _authed beforeLoad pins superadmins to /admin, so /settings/security bounced back. Added isSuperadminAllowedPath allowing /admin/* + the per-user /settings/account and /settings/security, keeping superadmins out of the tenant-scoped shell otherwise. Unit test covers allow vs block. web-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU