### PR TITLE
feat(billing): Razorpay as a second payment provider (dual-currency, Checkout.js) [dark]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.43] - 2026-07-08
+
+### Added
+
+- Razorpay as a second payment provider for hosted billing, alongside Stripe (behind WPMGR_HOSTED, so self-hosted installations are unaffected and billing stays disabled). It supports dual-currency subscriptions (USD for international customers, INR for India), an in-app Razorpay Checkout.js payment modal, subscription cancellation at the end of the billing period, and a signature-verified webhook that activates the plan. Customers choose their payment provider at checkout. The adapter is hand-rolled on the standard library (no third-party SDK), the webhook is the sole authority that changes a plan (raw-body HMAC-SHA256, constant-time), and tenant attribution is server-stamped so a payment can never affect another account.
+
 ## [0.61.42] - 2026-07-08
 
 ### Fixed

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/autologin"
 	"github.com/mosamlife/wpmgr/apps/api/internal/backup"
 	"github.com/mosamlife/wpmgr/apps/api/internal/billing"
+	billingrazorpay "github.com/mosamlife/wpmgr/apps/api/internal/billing/razorpay"
 	billingstripe "github.com/mosamlife/wpmgr/apps/api/internal/billing/stripe"
 	"github.com/mosamlife/wpmgr/apps/api/internal/blobstore"
 	clientpkg "github.com/mosamlife/wpmgr/apps/api/internal/client"
@@ -468,6 +469,8 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// when its five WPMGR_BILLING_STRIPE_* variables are ALL present
 	// (StripeConfig.Configured — config.Validate refuses a PARTIAL Stripe
 	// config at boot, so by the time we get here it is always all-or-nothing).
+	// Razorpay (India pricing, dual-currency) mirrors this exactly: registered
+	// ONLY when all nine WPMGR_BILLING_RAZORPAY_* variables are present.
 	var billingProviders []billing.Provider
 	stripeCfg := billingstripe.Config{
 		SecretKey:       cfg.Billing.Stripe.SecretKey,
@@ -480,7 +483,23 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	if stripeCfg.Configured() {
 		billingProviders = append(billingProviders, billingstripe.New(stripeCfg))
 		logger.Info("billing: Stripe provider registered")
-	} else if cfg.Hosted.Enabled {
+	}
+	razorpayCfg := billingrazorpay.Config{
+		KeyID:          cfg.Billing.Razorpay.KeyID,
+		KeySecret:      cfg.Billing.Razorpay.KeySecret,
+		WebhookSecret:  cfg.Billing.Razorpay.WebhookSecret,
+		PlanStarterUSD: cfg.Billing.Razorpay.PlanStarterUSD,
+		PlanStarterINR: cfg.Billing.Razorpay.PlanStarterINR,
+		PlanAgencyUSD:  cfg.Billing.Razorpay.PlanAgencyUSD,
+		PlanAgencyINR:  cfg.Billing.Razorpay.PlanAgencyINR,
+		PlanScaleUSD:   cfg.Billing.Razorpay.PlanScaleUSD,
+		PlanScaleINR:   cfg.Billing.Razorpay.PlanScaleINR,
+	}
+	if razorpayCfg.Configured() {
+		billingProviders = append(billingProviders, billingrazorpay.New(razorpayCfg))
+		logger.Info("billing: Razorpay provider registered")
+	}
+	if len(billingProviders) == 0 && cfg.Hosted.Enabled {
 		logger.Warn("billing: hosted billing is enabled but no payment provider is configured — checkout/portal will return 503")
 	}
 	billingSvc.SetProviders(billing.NewRegistry(billingProviders...), "stripe")

--- a/apps/api/internal/billing/checkout.go
+++ b/apps/api/internal/billing/checkout.go
@@ -37,11 +37,18 @@ func validPurchasableTier(t Tier) bool {
 }
 
 // CreateCheckout starts a hosted checkout session for tenantID targeting
-// tier. The caller (the HTTP handler) supplies customerEmail (best-effort
-// prefill, may be empty) and the success/cancel redirect URLs — the price
-// itself is resolved SERVER-SIDE by the provider adapter's tier->price map;
-// nothing the caller supplies can select a price directly.
-func (s *Service) CreateCheckout(ctx context.Context, tenantID uuid.UUID, tier Tier, customerEmail, successURL, cancelURL string, actor Actor) (CheckoutSession, error) {
+// tier. requestedProvider is the caller's preferred provider ("stripe" |
+// "razorpay"; empty defers to whatever this tenant is already pinned to, then
+// this instance's configured default — see the "one tenant = one provider"
+// resolution below). currency is meaningful ONLY to a provider whose
+// CreateCheckout resolves a price/plan PER (tier, currency) — e.g. Razorpay's
+// dual-currency plan model; Stripe ignores it entirely (its own Price already
+// encodes a currency). The caller (the HTTP handler) supplies customerEmail
+// (best-effort prefill, may be empty) and the success/cancel redirect URLs —
+// the price itself is resolved SERVER-SIDE by the provider adapter's
+// tier(+currency)->price map; nothing the caller supplies can select a price
+// directly.
+func (s *Service) CreateCheckout(ctx context.Context, tenantID uuid.UUID, tier Tier, requestedProvider, currency, customerEmail, successURL, cancelURL string, actor Actor) (CheckoutSession, error) {
 	if !validPurchasableTier(tier) {
 		return CheckoutSession{}, domain.Validation("billing_invalid_tier", "tier must be one of: starter, agency, scale")
 	}
@@ -57,7 +64,17 @@ func (s *Service) CreateCheckout(ctx context.Context, tenantID uuid.UUID, tier T
 		return CheckoutSession{}, err
 	}
 
+	// "One tenant = one provider at a time (set at first checkout)": an
+	// already-pinned provider ALWAYS wins over the caller's request — a
+	// returning customer's checkout can never accidentally split their
+	// subscription across two providers. requestedProvider is only consulted
+	// on a tenant's first-ever checkout; s.defaultProvider (configured at
+	// boot, today always "stripe") is the final fallback, so an omitted
+	// "provider" field in the request keeps working exactly as before.
 	providerName := profile.BillingProvider
+	if providerName == "" {
+		providerName = requestedProvider
+	}
 	if providerName == "" {
 		providerName = s.defaultProvider
 	}
@@ -70,6 +87,7 @@ func (s *Service) CreateCheckout(ctx context.Context, tenantID uuid.UUID, tier T
 	sess, err := provider.CreateCheckout(ctx, CheckoutInput{
 		TenantID:           tenantID,
 		Plan:               tier,
+		Currency:           currency,
 		CustomerEmail:      customerEmail,
 		ProviderCustomerID: profile.ProviderCustomerID,
 		SuccessURL:         successURL,
@@ -95,6 +113,45 @@ func (s *Service) CreateCheckout(ctx context.Context, tenantID uuid.UUID, tier T
 	})
 
 	return sess, nil
+}
+
+// VerifyCheckoutCallback authenticates a browser-returned checkout-completion
+// callback for tenantID's CURRENT billing provider (e.g. Razorpay's
+// Checkout.js onSuccess payload: razorpay_payment_id/razorpay_subscription_id/
+// razorpay_signature). This is ONLY a UX confirmation that the client-side
+// modal succeeded — it NEVER mutates tenants.plan/plan_status itself; the
+// frontend is expected to poll GetBillingSummary afterward and wait for the
+// webhook (Service.ProcessWebhook) to actually flip the plan, exactly like
+// Stripe's existing redirect-then-poll success flow.
+//
+// Returns a "billing_callback_not_supported" error for a provider that has no
+// such callback to verify (Stripe's redirect-based Checkout Session has no
+// equivalent) — see CheckoutCallbackVerifier's doc comment.
+func (s *Service) VerifyCheckoutCallback(ctx context.Context, tenantID uuid.UUID, payload map[string]string) error {
+	if !s.enabled {
+		return domain.Unavailable("billing_disabled", "hosted billing is not enabled on this instance")
+	}
+	profile, err := s.getBillingProfile(ctx, tenantID)
+	if err != nil {
+		return err
+	}
+	if profile.BillingProvider == "" {
+		return domain.Conflict("billing_no_customer",
+			"start a checkout before verifying a checkout callback — this workspace has no billing provider yet")
+	}
+	if s.registry == nil {
+		return domain.ServiceUnavailable("billing_not_configured", "no payment provider is configured on this instance yet")
+	}
+	provider, ok := s.registry.Provider(profile.BillingProvider)
+	if !ok {
+		return domain.ServiceUnavailable("billing_provider_unavailable",
+			"the configured payment provider for this workspace is not available")
+	}
+	verifier, ok := provider.(CheckoutCallbackVerifier)
+	if !ok {
+		return domain.Unavailable("billing_callback_not_supported", "this payment provider has no browser checkout callback to verify")
+	}
+	return verifier.VerifyCheckoutCallback(payload)
 }
 
 // CreatePortalSession mints a short-lived billing-management portal session
@@ -133,6 +190,59 @@ func (s *Service) CreatePortalSession(ctx context.Context, tenantID uuid.UUID, a
 	})
 
 	return sess, nil
+}
+
+// CancelSubscription tells tenantID's CURRENT billing provider to cancel its
+// live subscription — the provider-agnostic backend for the dashboard's
+// "Cancel subscription" action. Every provider is reachable through this ONE
+// method regardless of whether it also has a hosted portal: Razorpay tenants
+// (HasPortal()==false) have NO other way to cancel; Stripe tenants may use
+// either this or the portal.
+//
+// Cancellation is scheduled for the END of the current billing period by
+// every adapter (see Provider.CancelSubscription's doc comment) — the
+// customer keeps paid access through what they already paid for.
+//
+// This method NEVER mutates tenants.plan/plan_status itself: "push is a
+// hint, pull is the truth" applies here exactly as it does to every other
+// billing mutation in this package — the provider's own cancellation webhook
+// is what actually drives the non-destructive downgrade, through the EXACT
+// SAME ProcessWebhook/state-machine path as any other event. Callers must
+// not assume the plan has changed the instant this call returns; the
+// frontend should poll GetBillingSummary afterward, same as the checkout
+// success flow.
+//
+// Returns a clean "billing_no_subscription" error when the tenant has no
+// live provider subscription to cancel (never checked out, or a provider
+// name is set with no subscription id on file).
+func (s *Service) CancelSubscription(ctx context.Context, tenantID uuid.UUID, actor Actor) error {
+	if !s.enabled {
+		return domain.Unavailable("billing_disabled", "hosted billing is not enabled on this instance")
+	}
+	profile, err := s.getBillingProfile(ctx, tenantID)
+	if err != nil {
+		return err
+	}
+	if profile.BillingProvider == "" || profile.ProviderSubscriptionID == "" {
+		return domain.Conflict("billing_no_subscription", "this workspace has no active subscription to cancel")
+	}
+	if s.registry == nil {
+		return domain.ServiceUnavailable("billing_not_configured", "no payment provider is configured on this instance yet")
+	}
+	provider, ok := s.registry.Provider(profile.BillingProvider)
+	if !ok {
+		return domain.ServiceUnavailable("billing_provider_unavailable",
+			"the configured payment provider for this workspace is not available")
+	}
+
+	if err := provider.CancelSubscription(ctx, profile.ProviderSubscriptionID); err != nil {
+		return err
+	}
+
+	s.recordAudit(ctx, tenantID, actor.Type, actor.ID, "billing.subscription.cancel_requested", map[string]any{
+		"provider": profile.BillingProvider,
+	})
+	return nil
 }
 
 // SiteMeter is a single usage/limit pair for the Billing page's meters block.
@@ -187,6 +297,19 @@ func (s *Service) GetBillingSummary(ctx context.Context, tenantID uuid.UUID) (Su
 		return Summary{}, domain.Internal("billing_usage_count_failed", "failed to count active sites").WithCause(txErr)
 	}
 
+	// PortalAvailable defaults to "has a provider customer at all" and is only
+	// suppressed when the tenant's OWN provider is registered and positively
+	// reports HasPortal()==false (e.g. Razorpay). An unresolvable provider
+	// (registry nil/not-yet-registered) errs toward the prior, simpler
+	// behavior rather than hiding a legitimate Stripe portal link over an
+	// unrelated lookup gap.
+	portalAvailable := profile.ProviderCustomerID != ""
+	if portalAvailable && s.registry != nil {
+		if provider, ok := s.registry.Provider(profile.BillingProvider); ok && !provider.HasPortal() {
+			portalAvailable = false
+		}
+	}
+
 	return Summary{
 		Plan:             profile.Plan,
 		PlanStatus:       profile.Status,
@@ -196,7 +319,7 @@ func (s *Service) GetBillingSummary(ctx context.Context, tenantID uuid.UUID) (Su
 		Meters: Meters{
 			Sites: SiteMeter{Used: int(used), Limit: ent.MaxSites},
 		},
-		PortalAvailable: profile.ProviderCustomerID != "",
+		PortalAvailable: portalAvailable,
 	}, nil
 }
 

--- a/apps/api/internal/billing/checkout_test.go
+++ b/apps/api/internal/billing/checkout_test.go
@@ -18,7 +18,7 @@ func TestCreateCheckout_RejectsNonPurchasableTier(t *testing.T) {
 
 	tests := []Tier{TierFree, Tier(""), Tier("enterprise"), Tier("price_agency_123")}
 	for _, tier := range tests {
-		_, err := svc.CreateCheckout(context.Background(), uuid.New(), tier, "", "", "", Actor{})
+		_, err := svc.CreateCheckout(context.Background(), uuid.New(), tier, "", "", "", "", "", Actor{})
 		de, ok := domain.AsDomain(err)
 		if !ok || de.Kind != domain.KindValidation {
 			t.Errorf("tier %q: want a KindValidation error, got %v", tier, err)
@@ -41,7 +41,7 @@ func TestCreateCheckout_AcceptsEveryPaidTier(t *testing.T) {
 
 func TestCreateCheckout_DisabledReturnsUnavailable(t *testing.T) {
 	svc := New(nil, nil, false, domain.SystemClock{}, nil) // hosted billing OFF
-	_, err := svc.CreateCheckout(context.Background(), uuid.New(), TierStarter, "", "", "", Actor{})
+	_, err := svc.CreateCheckout(context.Background(), uuid.New(), TierStarter, "", "", "", "", "", Actor{})
 	de, ok := domain.AsDomain(err)
 	if !ok || de.Kind != domain.KindUnavailable {
 		t.Fatalf("want KindUnavailable when hosted billing is disabled, got %v", err)
@@ -52,7 +52,7 @@ func TestCreateCheckout_NoProviderRegisteredReturnsServiceUnavailable(t *testing
 	svc := New(nil, nil, true, domain.SystemClock{}, nil)
 	svc.SetProviders(NewRegistry(), "stripe") // registry built, but empty
 
-	_, err := svc.CreateCheckout(context.Background(), uuid.New(), TierStarter, "", "", "", Actor{})
+	_, err := svc.CreateCheckout(context.Background(), uuid.New(), TierStarter, "", "", "", "", "", Actor{})
 	de, ok := domain.AsDomain(err)
 	if !ok || de.Kind != domain.KindServiceUnavailable {
 		t.Fatalf("want KindServiceUnavailable when no provider is configured, got %v", err)
@@ -62,6 +62,24 @@ func TestCreateCheckout_NoProviderRegisteredReturnsServiceUnavailable(t *testing
 func TestCreatePortalSession_DisabledReturnsUnavailable(t *testing.T) {
 	svc := New(nil, nil, false, domain.SystemClock{}, nil)
 	_, err := svc.CreatePortalSession(context.Background(), uuid.New(), Actor{})
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindUnavailable {
+		t.Fatalf("want KindUnavailable when hosted billing is disabled, got %v", err)
+	}
+}
+
+func TestVerifyCheckoutCallback_DisabledReturnsUnavailable(t *testing.T) {
+	svc := New(nil, nil, false, domain.SystemClock{}, nil)
+	err := svc.VerifyCheckoutCallback(context.Background(), uuid.New(), map[string]string{})
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindUnavailable {
+		t.Fatalf("want KindUnavailable when hosted billing is disabled, got %v", err)
+	}
+}
+
+func TestCancelSubscription_DisabledReturnsUnavailable(t *testing.T) {
+	svc := New(nil, nil, false, domain.SystemClock{}, nil)
+	err := svc.CancelSubscription(context.Background(), uuid.New(), Actor{})
 	de, ok := domain.AsDomain(err)
 	if !ok || de.Kind != domain.KindUnavailable {
 		t.Fatalf("want KindUnavailable when hosted billing is disabled, got %v", err)

--- a/apps/api/internal/billing/handler.go
+++ b/apps/api/internal/billing/handler.go
@@ -51,7 +51,9 @@ func (h *Handler) Register(r *gin.RouterGroup) {
 	g := r.Group("/billing", authz.RequireOrgScope())
 	g.GET("", authz.RequirePermission(authz.PermBillingManage), h.getBilling)
 	g.POST("/checkout", authz.RequirePermission(authz.PermBillingManage), h.createCheckout)
+	g.POST("/checkout/verify", authz.RequirePermission(authz.PermBillingManage), h.verifyCheckoutCallback)
 	g.POST("/portal", authz.RequirePermission(authz.PermBillingManage), h.createPortal)
+	g.POST("/cancel", authz.RequirePermission(authz.PermBillingManage), h.cancelSubscription)
 }
 
 func (h *Handler) getBilling(c *gin.Context) {
@@ -69,15 +71,35 @@ func (h *Handler) getBilling(c *gin.Context) {
 }
 
 // checkoutRequest is the POST /billing/checkout body. tier is the ONLY
-// caller-supplied selector — the request never names a provider price id
-// directly; Service.CreateCheckout validates tier against the paid ladder and
-// the provider adapter resolves it to a price server-side.
+// caller-supplied selector for the PRICE — the request never names a
+// provider price id directly; Service.CreateCheckout validates tier against
+// the paid ladder and the provider adapter resolves it to a price
+// server-side. provider ("stripe" | "razorpay") lets the customer choose a
+// payment provider at checkout; empty defaults to "stripe" (back-comfort for
+// every caller written before Razorpay existed) UNLESS this tenant already
+// has a pinned provider, which always wins (see CreateCheckout's "one tenant
+// = one provider" resolution). currency ("USD" | "INR") is required when
+// provider is "razorpay" — Razorpay has no single multi-currency price the
+// way Stripe does, so the adapter resolves a plan PER (tier, currency); it is
+// ignored for every other provider.
 type checkoutRequest struct {
-	Tier string `json:"tier"`
+	Tier     string `json:"tier"`
+	Provider string `json:"provider"`
+	Currency string `json:"currency"`
 }
 
+// checkoutResponse is the wire shape of a successful POST /billing/checkout.
+// Exactly one of url/razorpay is populated, mirroring billing.CheckoutSession
+// exactly:
+//
+//   - Stripe: {"url": "https://checkout.stripe.com/..."}
+//   - Razorpay: {"razorpay": {"subscription_id": "...", "key_id": "...",
+//     "currency": "USD", "amount": 1500}} — the frontend hands this straight
+//     to Razorpay's Checkout.js modal ("key", "subscription_id", "amount",
+//     "currency" options).
 type checkoutResponse struct {
-	URL string `json:"url"`
+	URL      string                `json:"url,omitempty"`
+	Razorpay *RazorpayCheckoutData `json:"razorpay,omitempty"`
 }
 
 func (h *Handler) createCheckout(c *gin.Context) {
@@ -103,12 +125,54 @@ func (h *Handler) createCheckout(c *gin.Context) {
 	cancelURL := h.publicBaseURL + "/billing?checkout=cancel"
 	actor := Actor{Type: actorTypeFor(p.Type == domain.PrincipalAPIKey), ID: p.ActorID()}
 
-	sess, err := h.svc.CreateCheckout(c.Request.Context(), p.TenantID, Tier(body.Tier), email, successURL, cancelURL, actor)
+	sess, err := h.svc.CreateCheckout(c.Request.Context(), p.TenantID, Tier(body.Tier), body.Provider, body.Currency, email, successURL, cancelURL, actor)
 	if err != nil {
 		httpx.Error(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, checkoutResponse{URL: sess.URL})
+	c.JSON(http.StatusOK, checkoutResponse{URL: sess.URL, Razorpay: sess.Razorpay})
+}
+
+// checkoutCallbackRequest is the POST /billing/checkout/verify body: the
+// EXACT field names Razorpay's Checkout.js onSuccess handler hands the
+// browser (razorpay_payment_id/razorpay_subscription_id/razorpay_signature),
+// passed through verbatim so the frontend never has to rename them.
+type checkoutCallbackRequest struct {
+	RazorpayPaymentID      string `json:"razorpay_payment_id"`
+	RazorpaySubscriptionID string `json:"razorpay_subscription_id"`
+	RazorpaySignature      string `json:"razorpay_signature"`
+}
+
+type checkoutCallbackResponse struct {
+	Verified bool `json:"verified"`
+}
+
+// verifyCheckoutCallback verifies a browser-returned checkout-completion
+// callback — a UX confirmation ONLY (see Service.VerifyCheckoutCallback's
+// doc comment: the webhook remains the sole source of truth for granting a
+// plan). Tenant-scoped: the callback is verified against the CALLER's own
+// tenant's pinned provider, never a caller-supplied provider/tenant.
+func (h *Handler) verifyCheckoutCallback(c *gin.Context) {
+	p, ok := domain.PrincipalFromContext(c.Request.Context())
+	if !ok {
+		httpx.Error(c, domain.Unauthorized("unauthenticated", "authentication required"))
+		return
+	}
+	var body checkoutCallbackRequest
+	if err := bindJSON(c, &body); err != nil {
+		httpx.Error(c, err)
+		return
+	}
+	payload := map[string]string{
+		"razorpay_payment_id":      body.RazorpayPaymentID,
+		"razorpay_subscription_id": body.RazorpaySubscriptionID,
+		"razorpay_signature":       body.RazorpaySignature,
+	}
+	if err := h.svc.VerifyCheckoutCallback(c.Request.Context(), p.TenantID, payload); err != nil {
+		httpx.Error(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, checkoutCallbackResponse{Verified: true})
 }
 
 type portalResponse struct {
@@ -128,6 +192,35 @@ func (h *Handler) createPortal(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, portalResponse{URL: sess.URL})
+}
+
+// cancelResponse is the wire shape of a successful POST /billing/cancel.
+// PINNED contract: {"ok": true} — the ONLY signal the frontend gets back
+// synchronously. Cancellation itself is scheduled for the end of the current
+// billing period (see Service.CancelSubscription); the actual plan/status
+// change lands later via the provider's webhook, exactly like the checkout
+// success flow — the frontend should poll GET /billing afterward rather than
+// expect this response to carry the new plan state.
+type cancelResponse struct {
+	OK bool `json:"ok"`
+}
+
+// cancelSubscription is the provider-agnostic backend for the dashboard's
+// "Cancel subscription" action — the ONLY cancellation path for a provider
+// with no hosted portal (Razorpay; see billing.Provider.HasPortal). Tenant-
+// scoped + owner-gated exactly like every other /billing route.
+func (h *Handler) cancelSubscription(c *gin.Context) {
+	p, ok := domain.PrincipalFromContext(c.Request.Context())
+	if !ok {
+		httpx.Error(c, domain.Unauthorized("unauthenticated", "authentication required"))
+		return
+	}
+	actor := Actor{Type: actorTypeFor(p.Type == domain.PrincipalAPIKey), ID: p.ActorID()}
+	if err := h.svc.CancelSubscription(c.Request.Context(), p.TenantID, actor); err != nil {
+		httpx.Error(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, cancelResponse{OK: true})
 }
 
 func bindJSON(c *gin.Context, dst any) error {

--- a/apps/api/internal/billing/provider.go
+++ b/apps/api/internal/billing/provider.go
@@ -34,6 +34,14 @@ const (
 type CheckoutInput struct {
 	TenantID uuid.UUID
 	Plan     Tier
+	// Currency is an ISO 4217 currency code (e.g. "USD", "INR"), meaningful
+	// ONLY to a provider whose CreateCheckout resolves a price/plan PER
+	// (tier, currency) — e.g. Razorpay's dual-currency plan model (one
+	// Razorpay Plan per currency per tier, since Razorpay has no single
+	// multi-currency price object the way Stripe does). Stripe's own Price
+	// already encodes its currency and ignores this field entirely. Empty is
+	// legal for any provider that does not need it.
+	Currency string
 	// CustomerEmail prefills the checkout form. Best-effort: may be empty.
 	CustomerEmail string
 	// ProviderCustomerID reuses an existing provider customer record when the
@@ -44,10 +52,42 @@ type CheckoutInput struct {
 	CancelURL          string
 }
 
-// CheckoutSession is the result of starting a hosted checkout: a URL the
-// caller redirects the browser to.
+// RazorpayCheckoutData is the data WPMgr's in-app Checkout.js modal needs to
+// open a Razorpay subscription checkout — Razorpay has no hosted Checkout
+// Session object (unlike Stripe's redirect URL), so the CP must create the
+// Subscription server-side and hand the browser just enough to open the
+// modal itself. Declared here (in the core billing package, not
+// internal/billing/razorpay) so CheckoutSession's shape — and therefore the
+// HTTP wire contract the frontend depends on — never requires importing the
+// razorpay adapter package.
+type RazorpayCheckoutData struct {
+	// SubscriptionID is the just-created Razorpay subscription id
+	// (Checkout.js's "subscription_id" option).
+	SubscriptionID string `json:"subscription_id"`
+	// KeyID is Razorpay's PUBLIC key id (Checkout.js's "key" option) — never
+	// the key secret.
+	KeyID string `json:"key_id"`
+	// Currency is the resolved plan's ISO 4217 currency code, echoing back
+	// in.Currency for display.
+	Currency string `json:"currency"`
+	// AmountMinor is the per-billing-cycle charge amount in the currency's
+	// smallest unit (paise for INR, cents for USD) — the exact shape
+	// Checkout.js's own "amount" option expects, read authoritatively off the
+	// Razorpay Plan (never computed/guessed CP-side, so it can never drift
+	// from what Razorpay will actually charge).
+	AmountMinor int64 `json:"amount"`
+}
+
+// CheckoutSession is the result of starting a hosted checkout. Exactly one of
+// URL or Razorpay is populated, depending on the provider's checkout style:
+//
+//   - A hosted-redirect provider (Stripe) sets URL and leaves Razorpay nil —
+//     the caller redirects the browser to URL.
+//   - An in-app-modal provider (Razorpay) sets Razorpay and leaves URL empty —
+//     the caller hands Razorpay to the frontend's Checkout.js modal.
 type CheckoutSession struct {
-	URL string
+	URL      string                `json:"url,omitempty"`
+	Razorpay *RazorpayCheckoutData `json:"razorpay,omitempty"`
 }
 
 // PortalSession is the result of minting a billing-management portal session:
@@ -133,6 +173,23 @@ type Provider interface {
 	// session for an existing provider customer.
 	CreatePortalSession(ctx context.Context, providerCustomerID string) (PortalSession, error)
 
+	// CancelSubscription tells the provider to cancel providerSubscriptionID.
+	// Both adapters cancel AT THE END OF THE CURRENT BILLING PERIOD, never
+	// immediately — the customer keeps paid-tier access through what they
+	// already paid for, matching the state machine's existing
+	// non-destructive-downgrade intent (state_machine.go's StatusCanceled
+	// case just downgrades to free; it never deletes anything).
+	//
+	// This method NEVER mutates a tenant's stored plan/status itself —
+	// "push is a hint, pull is the truth" applies here exactly as it does to
+	// every other billing mutation: the resulting subscription.cancelled (or
+	// Stripe's customer.subscription.updated with cancel_at_period_end=true)
+	// webhook is what actually drives the downgrade, through the EXACT SAME
+	// ProcessWebhook/state-machine path as any other event. Callers
+	// (Service.CancelSubscription) must not assume the plan has changed the
+	// instant this call returns.
+	CancelSubscription(ctx context.Context, providerSubscriptionID string) error
+
 	// GetSubscription fetches a subscription's CURRENT state from the
 	// provider. This is the sole source of truth the state machine acts on.
 	GetSubscription(ctx context.Context, providerSubscriptionID string) (Subscription, error)
@@ -147,6 +204,38 @@ type Provider interface {
 	// (_, false) when the price is not one this control plane's config maps
 	// to a tier (see the "unknown price" no-op path).
 	MapPriceToPlan(priceID string) (Tier, bool)
+
+	// HasPortal reports whether this provider offers a hosted self-service
+	// billing-management portal (Stripe: yes. Razorpay: no — Razorpay has no
+	// equivalent of Stripe's Billing Portal; its CreatePortalSession returns a
+	// domain KindUnavailable error rather than fabricating a URL). Callers
+	// (GetBillingSummary's PortalAvailable, the billing Handler) use this to
+	// decide whether to advertise/attempt a portal link at all, rather than
+	// discovering "not supported" only after calling CreatePortalSession.
+	HasPortal() bool
+}
+
+// CheckoutCallbackVerifier is an OPTIONAL capability a Provider may implement
+// when its checkout flow returns a browser-side completion callback that
+// needs its own signature check — e.g. Razorpay's Checkout.js onSuccess
+// handler, which hands the browser {razorpay_payment_id,
+// razorpay_subscription_id, razorpay_signature} that must be HMAC-verified
+// before the frontend trusts "the modal succeeded". Stripe's redirect-based
+// Checkout Session has no equivalent and does not implement this interface.
+//
+// Declared as a SEPARATE, optional interface (type-asserted by
+// Service.VerifyCheckoutCallback) rather than folded into Provider itself:
+// a browser-callback-verify step is not a capability every payment provider
+// needs, so widening the core Provider interface for it would force every
+// adapter (including test doubles) to carry a method most of them never use.
+//
+// CRITICAL: this is ONLY a UX confirmation that the client-side modal
+// succeeded. The webhook (Service.ProcessWebhook) remains the SOLE source of
+// truth for granting a plan change — an implementation of this method must
+// NEVER be treated as authorization to mutate a tenant's billing state, and
+// none of the callers in this codebase do.
+type CheckoutCallbackVerifier interface {
+	VerifyCheckoutCallback(payload map[string]string) error
 }
 
 // Registry is the set of payment providers wired at boot (from config). A

--- a/apps/api/internal/billing/razorpay/client.go
+++ b/apps/api/internal/billing/razorpay/client.go
@@ -1,0 +1,254 @@
+package razorpay
+
+// client.go — a minimal, hand-rolled Razorpay REST client. Deliberately does
+// NOT use github.com/razorpay/razorpay-go: every one of that SDK's request
+// methods (Get/Post/Patch/...) returns (map[string]interface{}, error) —
+// there is no typed-response escape hatch — so using it here would only add
+// an untyped round trip in front of the typed structs below, for no benefit.
+// (Its own signature-verification helpers, in the sibling "utils" package,
+// were also passed over: that file is NOT test-gated — it is a plain
+// production .go file that unconditionally imports "testing" and
+// github.com/stretchr/testify, which would drag a test-assertion library into
+// this control plane's production binary for a ~10-line HMAC compare. The
+// stdlib crypto/hmac equivalent, in signature.go, is byte-for-byte the same
+// algorithm.)
+//
+// Auth is HTTP Basic (key_id / key_secret) — https://razorpay.com/docs/api/.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// defaultBaseURL is Razorpay's production API base. Overridable (Config.BaseURL)
+// for tests only.
+const defaultBaseURL = "https://api.razorpay.com/v1"
+
+// defaultHTTPTimeout bounds every Razorpay API call this adapter makes.
+const defaultHTTPTimeout = 15 * time.Second
+
+// restClient is the tiny typed-JSON HTTP client every Razorpay REST call in
+// this package goes through.
+type restClient struct {
+	baseURL    string
+	keyID      string
+	keySecret  string
+	httpClient *http.Client
+}
+
+func newRestClient(cfg Config) *restClient {
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	return &restClient{baseURL: baseURL, keyID: cfg.KeyID, keySecret: cfg.KeySecret, httpClient: httpClient}
+}
+
+// apiError is a Razorpay API error response (https://razorpay.com/docs/errors/).
+type apiError struct {
+	StatusCode  int
+	Code        string
+	Description string
+}
+
+func (e *apiError) Error() string {
+	return fmt.Sprintf("razorpay API error (HTTP %d, code=%s): %s", e.StatusCode, e.Code, e.Description)
+}
+
+// razorpayErrorEnvelope is Razorpay's standard error response body shape:
+// {"error": {"code": "...", "description": "...", ...}}.
+type razorpayErrorEnvelope struct {
+	Error struct {
+		Code        string `json:"code"`
+		Description string `json:"description"`
+	} `json:"error"`
+}
+
+// maxResponseBodyBytes bounds every Razorpay API response read. Subscription
+// and Plan entities are small (well under a few KB even fully populated);
+// 1 MiB is generous headroom against a misbehaving/compromised endpoint.
+const maxResponseBodyBytes = 1 << 20
+
+// do performs one Razorpay REST call. body is JSON-marshaled as the request
+// body when non-nil (nil for a GET); out is JSON-unmarshaled from a
+// successful (2xx) response body when non-nil. A non-2xx response is parsed
+// into *apiError (best-effort — a malformed error body still yields a usable
+// status-only error).
+func (c *restClient) do(ctx context.Context, method, path string, body, out any) error {
+	var reqBody io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("encode razorpay request body: %w", err)
+		}
+		reqBody = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	if err != nil {
+		return fmt.Errorf("build razorpay request: %w", err)
+	}
+	req.SetBasicAuth(c.keyID, c.keySecret)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("razorpay request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodyBytes))
+	if err != nil {
+		return fmt.Errorf("read razorpay response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var env razorpayErrorEnvelope
+		_ = json.Unmarshal(respBody, &env) // best-effort; a non-JSON error body still yields a status-only apiError
+		return &apiError{StatusCode: resp.StatusCode, Code: env.Error.Code, Description: env.Error.Description}
+	}
+
+	if out != nil {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return fmt.Errorf("decode razorpay response: %w", err)
+		}
+	}
+	return nil
+}
+
+// --- Typed request/response shapes -----------------------------------------
+//
+// Only the fields this adapter actually reads/writes are declared — Razorpay
+// entities carry many more fields than this control plane needs.
+
+// subscriptionCreateRequest is the POST /subscriptions body.
+// https://razorpay.com/docs/api/payments/subscriptions/create-subscription/
+type subscriptionCreateRequest struct {
+	PlanID string `json:"plan_id"`
+	// TotalCount is REQUIRED by Razorpay's Subscriptions API — there is no
+	// open-ended/"until cancelled" subscription the way Stripe's Checkout
+	// Session subscription mode has. subscriptionTotalCycles picks a large
+	// number so the subscription is, in practice, perpetual until explicitly
+	// cancelled (see that constant's doc comment).
+	TotalCount int `json:"total_count"`
+	// CustomerNotify is set to 0 (false): the CP owns all customer comms
+	// (mirrors the Stripe adapter never delegating email to the provider).
+	CustomerNotify int `json:"customer_notify"`
+	// Notes carries tenant attribution (wpmgr_tenant_id) — Razorpay has no
+	// checkout-session client_reference_id equivalent, so this is the ONLY
+	// place a subscription is stamped with which tenant it belongs to.
+	Notes map[string]string `json:"notes,omitempty"`
+}
+
+// subscriptionEntity is a Razorpay Subscription
+// (https://razorpay.com/docs/api/payments/subscriptions/subscription-entity/),
+// trimmed to the fields this adapter reads. current_end/current_start/
+// charge_at/created_at are Unix epoch seconds.
+type subscriptionEntity struct {
+	ID         string            `json:"id"`
+	PlanID     string            `json:"plan_id"`
+	CustomerID string            `json:"customer_id"`
+	Status     string            `json:"status"`
+	CurrentEnd int64             `json:"current_end"`
+	Notes      map[string]string `json:"notes"`
+}
+
+// planItem is the pricing sub-object of a Razorpay Plan entity.
+type planItem struct {
+	Amount   int64  `json:"amount"`
+	Currency string `json:"currency"`
+}
+
+// planEntity is a Razorpay Plan
+// (https://razorpay.com/docs/api/payments/subscriptions/plans/), trimmed to
+// the fields this adapter reads (the authoritative amount+currency for the
+// Checkout.js "amount"/"currency" options — never computed/guessed CP-side).
+type planEntity struct {
+	ID   string   `json:"id"`
+	Item planItem `json:"item"`
+}
+
+// subscriptionCancelRequest is the POST /subscriptions/:id/cancel body.
+// https://razorpay.com/docs/api/payments/subscriptions/cancel-subscription/
+type subscriptionCancelRequest struct {
+	// CancelAtCycleEnd, when 1, schedules cancellation for the END of the
+	// current billing cycle instead of immediately — the customer keeps
+	// access through what they already paid for. ALWAYS 1 in this adapter
+	// (see cancelSubscription): matches the state machine's existing
+	// non-destructive-downgrade intent, and mirrors the Stripe adapter's own
+	// cancel_at_period_end=true choice exactly.
+	CancelAtCycleEnd int `json:"cancel_at_cycle_end"`
+}
+
+// subscriptionTotalCycles is the total_count Razorpay requires on every
+// subscription create call. Razorpay has no concept of an open-ended
+// recurring subscription (unlike Stripe's Checkout Session subscription
+// mode): 1200 MONTHLY cycles is 100 years — functionally perpetual until the
+// customer or CP explicitly cancels it.
+const subscriptionTotalCycles = 1200
+
+// createSubscription calls POST /subscriptions.
+func (p *Provider) createSubscription(ctx context.Context, in subscriptionCreateRequest) (subscriptionEntity, error) {
+	var sub subscriptionEntity
+	if err := p.rest.do(ctx, http.MethodPost, "/subscriptions", in, &sub); err != nil {
+		return subscriptionEntity{}, wrapErr("razorpay_subscription_create_failed", "failed to create the Razorpay subscription", err)
+	}
+	return sub, nil
+}
+
+// fetchSubscription calls GET /subscriptions/{id}.
+func (p *Provider) fetchSubscription(ctx context.Context, id string) (subscriptionEntity, error) {
+	var sub subscriptionEntity
+	if err := p.rest.do(ctx, http.MethodGet, "/subscriptions/"+id, nil, &sub); err != nil {
+		return subscriptionEntity{}, wrapErr("razorpay_subscription_fetch_failed", "failed to fetch the Razorpay subscription", err)
+	}
+	return sub, nil
+}
+
+// cancelSubscription calls POST /subscriptions/:id/cancel with
+// cancel_at_cycle_end=1 (see subscriptionCancelRequest's doc comment).
+func (p *Provider) cancelSubscription(ctx context.Context, id string) error {
+	var sub subscriptionEntity
+	if err := p.rest.do(ctx, http.MethodPost, "/subscriptions/"+id+"/cancel",
+		subscriptionCancelRequest{CancelAtCycleEnd: 1}, &sub); err != nil {
+		return wrapErr("razorpay_subscription_cancel_failed", "failed to cancel the Razorpay subscription", err)
+	}
+	return nil
+}
+
+// fetchPlan calls GET /plans/{id} — used by CreateCheckout to read the
+// authoritative per-cycle amount/currency for the Checkout.js modal.
+func (p *Provider) fetchPlan(ctx context.Context, id string) (planEntity, error) {
+	var plan planEntity
+	if err := p.rest.do(ctx, http.MethodGet, "/plans/"+id, nil, &plan); err != nil {
+		return planEntity{}, wrapErr("razorpay_plan_fetch_failed", "failed to fetch the Razorpay plan", err)
+	}
+	return plan, nil
+}
+
+// wrapErr maps a Razorpay API/transport error to a domain error. A
+// *apiError's Description is user-safe (Razorpay's own documented error
+// shape); anything else (network/timeout/decode) is wrapped as an opaque
+// Internal error so no transport detail leaks.
+func wrapErr(code, msg string, err error) error {
+	var ae *apiError
+	if errors.As(err, &ae) {
+		return domain.Internal(code, fmt.Sprintf("%s: %s", msg, ae.Description)).WithCause(err)
+	}
+	return domain.Internal(code, msg).WithCause(err)
+}

--- a/apps/api/internal/billing/razorpay/provider.go
+++ b/apps/api/internal/billing/razorpay/provider.go
@@ -1,0 +1,329 @@
+// Package razorpay implements billing.Provider for Razorpay — the SECOND
+// payment provider (alongside internal/billing/stripe), added for India
+// pricing. Nothing outside this package (and cmd/wpmgr/main.go's boot wiring)
+// ever imports a Razorpay-specific type — the core internal/billing package,
+// its state machine, and its HTTP handlers know only the billing.Provider
+// interface (plus the two small optional capability interfaces this adapter
+// also implements: billing.CheckoutCallbackVerifier, and HasPortal() as part
+// of billing.Provider itself).
+//
+// Two things make this adapter shaped differently from Stripe's:
+//
+//  1. DUAL-CURRENCY plans: Razorpay has no single multi-currency price object
+//     the way Stripe does, so this control plane maintains ONE Razorpay Plan
+//     PER CURRENCY PER TIER (USD for international, INR for India) — see
+//     Config's six Plan* fields and (Provider).planID.
+//  2. IN-APP CHECKOUT: Razorpay has no hosted Checkout Session/redirect URL.
+//     CreateCheckout creates a Razorpay Subscription server-side and returns
+//     just enough data (billing.RazorpayCheckoutData) for the frontend's
+//     Checkout.js modal to open in-app.
+package razorpay
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/billing"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// Currency codes this adapter accepts. Exported so callers (and tests)
+// building a CheckoutInput/checkout request never have to spell out the
+// literal strings themselves.
+const (
+	CurrencyUSD = "USD"
+	CurrencyINR = "INR"
+)
+
+// Config is the Razorpay adapter's construction-time configuration, sourced
+// from config.BillingConfig.Razorpay (WPMGR_BILLING_RAZORPAY_*).
+type Config struct {
+	// KeyID is Razorpay's PUBLIC key id — safe to hand to the browser
+	// (Checkout.js's "key" option).
+	KeyID string
+	// KeySecret is Razorpay's secret API key: used for HTTP Basic Auth on
+	// every Subscriptions/Plans REST call, AND to verify the browser checkout
+	// callback's signature (VerifyCheckoutCallback) — DISTINCT from
+	// WebhookSecret.
+	KeySecret string
+	// WebhookSecret is the Razorpay webhook signing secret used to verify
+	// POST /webhooks/billing/razorpay (X-Razorpay-Signature). DISTINCT from
+	// KeySecret.
+	WebhookSecret string
+
+	// PlanStarterUSD/PlanStarterINR/PlanAgencyUSD/PlanAgencyINR/
+	// PlanScaleUSD/PlanScaleINR are the six Razorpay Plan ids — ONE PER
+	// (tier, currency) pair — created once in the Razorpay Dashboard/API.
+	// This control plane never creates Plans itself.
+	PlanStarterUSD string
+	PlanStarterINR string
+	PlanAgencyUSD  string
+	PlanAgencyINR  string
+	PlanScaleUSD   string
+	PlanScaleINR   string
+
+	// BaseURL overrides the Razorpay API base URL. Empty uses the real
+	// production API (https://api.razorpay.com/v1). Exposed for tests only.
+	BaseURL string
+	// HTTPClient overrides the default *http.Client (timeout etc). Nil uses a
+	// sane default. Exposed for tests — never used to change TLS/security
+	// behavior.
+	HTTPClient *http.Client
+}
+
+// Configured reports whether cfg has everything this adapter needs to
+// operate: the three credentials, and all SIX dual-currency plan ids.
+// cmd/wpmgr/main.go only registers this provider in the billing.Registry when
+// Configured() is true — a partially-set Razorpay config is refused at boot
+// by internal/config.Validate, never silently half-wired into a Provider
+// that would fail confusingly on first checkout/webhook in whichever
+// currency was left unconfigured.
+func (c Config) Configured() bool {
+	return c.KeyID != "" && c.KeySecret != "" && c.WebhookSecret != "" &&
+		c.PlanStarterUSD != "" && c.PlanStarterINR != "" &&
+		c.PlanAgencyUSD != "" && c.PlanAgencyINR != "" &&
+		c.PlanScaleUSD != "" && c.PlanScaleINR != ""
+}
+
+// planKey indexes Provider.planIndex by (tier, currency).
+type planKey struct {
+	tier     billing.Tier
+	currency string
+}
+
+// Provider implements billing.Provider (and billing.CheckoutCallbackVerifier)
+// for Razorpay.
+type Provider struct {
+	keyID         string
+	keySecret     string
+	webhookSecret string
+	rest          *restClient
+
+	// planIndex resolves (tier, currency) -> Razorpay plan id (CreateCheckout).
+	planIndex map[planKey]string
+	// planToPlan resolves a Razorpay plan id -> tier (MapPriceToPlan), built
+	// as the reverse of planIndex over all six configured plan ids.
+	planToTier map[string]billing.Tier
+}
+
+// New builds a Razorpay Provider. Callers should check cfg.Configured()
+// first (or rely on the registry-building code in cmd/wpmgr/main.go, which
+// already does).
+func New(cfg Config) *Provider {
+	planIndex := map[planKey]string{
+		{billing.TierStarter, CurrencyUSD}: cfg.PlanStarterUSD,
+		{billing.TierStarter, CurrencyINR}: cfg.PlanStarterINR,
+		{billing.TierAgency, CurrencyUSD}:  cfg.PlanAgencyUSD,
+		{billing.TierAgency, CurrencyINR}:  cfg.PlanAgencyINR,
+		{billing.TierScale, CurrencyUSD}:   cfg.PlanScaleUSD,
+		{billing.TierScale, CurrencyINR}:   cfg.PlanScaleINR,
+	}
+	planToTier := make(map[string]billing.Tier, len(planIndex))
+	for k, planID := range planIndex {
+		if planID != "" {
+			planToTier[planID] = k.tier
+		}
+	}
+	return &Provider{
+		keyID:         cfg.KeyID,
+		keySecret:     cfg.KeySecret,
+		webhookSecret: cfg.WebhookSecret,
+		rest:          newRestClient(cfg),
+		planIndex:     planIndex,
+		planToTier:    planToTier,
+	}
+}
+
+// Name implements billing.Provider.
+func (p *Provider) Name() string { return "razorpay" }
+
+// HasPortal implements billing.Provider: Razorpay has no hosted
+// billing-management portal — see CreatePortalSession.
+func (p *Provider) HasPortal() bool { return false }
+
+// MapPriceToPlan implements billing.Provider: resolves a Razorpay plan id to
+// a tier over ALL SIX configured (tier, currency) plan ids — a USD and an
+// INR plan for the same tier both resolve to that same Tier.
+func (p *Provider) MapPriceToPlan(planID string) (billing.Tier, bool) {
+	t, ok := p.planToTier[planID]
+	return t, ok
+}
+
+// planID resolves (tier, currency) to a configured Razorpay plan id.
+// ok=false when no plan is configured for that exact pair (e.g. a currency
+// this instance never wired for that tier).
+func (p *Provider) planID(tier billing.Tier, currency string) (string, bool) {
+	id, ok := p.planIndex[planKey{tier, currency}]
+	return id, ok && id != ""
+}
+
+// CreateCheckout implements billing.Provider. Razorpay has NO Checkout
+// Session object — this creates a Razorpay SUBSCRIPTION server-side and
+// returns the data the frontend's IN-APP Checkout.js modal needs to open it
+// (billing.RazorpayCheckoutData), rather than a redirect URL.
+//
+// in.ProviderCustomerID/in.CustomerEmail are NOT used by this adapter:
+// unlike Stripe's Checkout Session (which takes an existing Customer id or an
+// email to prefill), Razorpay's Subscription Create API resolves/creates the
+// customer during the Checkout.js authorization flow itself, not as a create
+// parameter. This is a deliberate no-op, not an oversight.
+func (p *Provider) CreateCheckout(ctx context.Context, in billing.CheckoutInput) (billing.CheckoutSession, error) {
+	currency := strings.ToUpper(strings.TrimSpace(in.Currency))
+	if currency != CurrencyUSD && currency != CurrencyINR {
+		return billing.CheckoutSession{}, domain.Validation("billing_invalid_currency",
+			"currency must be USD or INR for a Razorpay checkout")
+	}
+
+	planID, ok := p.planID(in.Plan, currency)
+	if !ok {
+		return billing.CheckoutSession{}, domain.Validation("billing_unknown_tier",
+			fmt.Sprintf("no Razorpay plan is configured for tier %q in currency %q", in.Plan, currency))
+	}
+
+	// Read the plan's authoritative amount/currency for the Checkout.js
+	// modal — never computed/guessed CP-side, so it can never drift from
+	// what Razorpay will actually charge.
+	plan, err := p.fetchPlan(ctx, planID)
+	if err != nil {
+		return billing.CheckoutSession{}, err
+	}
+
+	tenantID := in.TenantID.String()
+	sub, err := p.createSubscription(ctx, subscriptionCreateRequest{
+		PlanID:         planID,
+		TotalCount:     subscriptionTotalCycles,
+		CustomerNotify: 0,
+		Notes:          map[string]string{tenantNotesKey: tenantID},
+	})
+	if err != nil {
+		return billing.CheckoutSession{}, err
+	}
+
+	return billing.CheckoutSession{
+		Razorpay: &billing.RazorpayCheckoutData{
+			SubscriptionID: sub.ID,
+			KeyID:          p.keyID,
+			Currency:       plan.Item.Currency,
+			AmountMinor:    plan.Item.Amount,
+		},
+	}, nil
+}
+
+// CreatePortalSession implements billing.Provider: Razorpay has no hosted
+// billing-management portal (unlike Stripe's Billing Portal). Returns a
+// clear domain KindUnavailable (HTTP 501) error rather than fabricating a
+// URL — see billing.Provider.HasPortal, which lets a caller avoid this call
+// entirely and show a cancel action instead of a portal link.
+func (p *Provider) CreatePortalSession(ctx context.Context, providerCustomerID string) (billing.PortalSession, error) {
+	return billing.PortalSession{}, domain.Unavailable("billing_portal_not_supported",
+		"Razorpay has no hosted billing-management portal — manage or cancel the subscription from the WPMgr dashboard instead")
+}
+
+// CancelSubscription implements billing.Provider: schedules cancellation for
+// the END of the current billing cycle (cancel_at_cycle_end=1) rather than
+// immediately — the customer keeps access through what they already paid
+// for, matching the state machine's non-destructive-downgrade intent (and
+// mirroring the Stripe adapter's cancel_at_period_end=true choice exactly).
+// Since Razorpay has no hosted portal (HasPortal()==false), THIS is the
+// tenant's only way to cancel — see billing.Service.CancelSubscription,
+// which is the backend for the dashboard's "Cancel subscription" action.
+//
+// The tenant's stored plan/status is NEVER mutated here: the resulting
+// subscription.cancelled (or, for a scheduled cancel-at-cycle-end,
+// subscription.completed at the cycle boundary) webhook drives the
+// downgrade, through the exact same ProcessWebhook path as any other event.
+func (p *Provider) CancelSubscription(ctx context.Context, providerSubscriptionID string) error {
+	return p.cancelSubscription(ctx, providerSubscriptionID)
+}
+
+// GetSubscription implements billing.Provider — the sole source of truth the
+// state machine acts on ("pull is the truth").
+func (p *Provider) GetSubscription(ctx context.Context, providerSubscriptionID string) (billing.Subscription, error) {
+	sub, err := p.fetchSubscription(ctx, providerSubscriptionID)
+	if err != nil {
+		return billing.Subscription{}, err
+	}
+	return p.toSubscription(sub), nil
+}
+
+// toSubscription normalizes a Razorpay subscriptionEntity to billing.Subscription.
+func (p *Provider) toSubscription(sub subscriptionEntity) billing.Subscription {
+	out := billing.Subscription{
+		ID:         sub.ID,
+		CustomerID: sub.CustomerID,
+		Status:     mapStatus(sub.Status),
+	}
+	if sub.CurrentEnd > 0 {
+		out.CurrentPeriodEnd = time.Unix(sub.CurrentEnd, 0).UTC()
+	}
+	if tier, ok := p.planToTier[sub.PlanID]; ok {
+		out.Plan = tier
+		out.PlanResolved = true
+	}
+	return out
+}
+
+// mapStatus normalizes Razorpay's subscription status vocabulary
+// (https://razorpay.com/docs/api/payments/subscriptions/subscription-entity/#subscription-status)
+// to the project's provider-agnostic billing.Status.
+//
+//   - active maps directly.
+//   - pending (a payment attempt is retrying) maps to past_due — grace, do
+//     NOT revoke (mirrors Stripe's past_due).
+//   - halted (Razorpay's retry schedule is exhausted — mirrors Stripe's
+//     "unpaid") ALSO maps to past_due: the existing grace-window logic in
+//     state_machine.go (anchored off the FIRST past_due transition) decides
+//     if/when this eventually downgrades to free, exactly as it already
+//     does for Stripe's "unpaid".
+//   - cancelled AND completed (a fixed total_count subscription ran its full
+//     course — should not occur in practice given subscriptionTotalCycles,
+//     but handled defensively) both map to canceled (non-destructive
+//     downgrade to free — see state_machine.go).
+//   - paused maps directly.
+//   - created and authenticated (the mandate is set up/authorized but not
+//     yet a live, charging subscription) and anything unrecognized map to
+//     StatusNone — mirrors Stripe's "incomplete" treatment.
+func mapStatus(s string) billing.Status {
+	switch s {
+	case "active":
+		return billing.StatusActive
+	case "pending":
+		return billing.StatusPastDue
+	case "halted":
+		return billing.StatusPastDue
+	case "cancelled", "completed":
+		return billing.StatusCanceled
+	case "paused":
+		return billing.StatusPaused
+	default: // created, authenticated, or any future/unrecognized value.
+		return billing.StatusNone
+	}
+}
+
+// VerifyCheckoutCallback implements billing.CheckoutCallbackVerifier: checks
+// the signature Razorpay's Checkout.js onSuccess handler hands the browser —
+// HMAC-SHA256 of "razorpay_payment_id|razorpay_subscription_id", keyed by the
+// API KEY SECRET (NOT the webhook secret), hex-compared to
+// payload["razorpay_signature"].
+// https://razorpay.com/docs/payments/subscriptions/verify-signature/
+//
+// This is ONLY a UX confirmation that the client-side modal succeeded — see
+// the interface doc comment. It never mutates any billing state itself.
+func (p *Provider) VerifyCheckoutCallback(payload map[string]string) error {
+	paymentID := payload["razorpay_payment_id"]
+	subscriptionID := payload["razorpay_subscription_id"]
+	signature := payload["razorpay_signature"]
+	if paymentID == "" || subscriptionID == "" || signature == "" {
+		return domain.Validation("billing_callback_invalid",
+			"missing razorpay_payment_id, razorpay_subscription_id, or razorpay_signature")
+	}
+	message := paymentID + "|" + subscriptionID
+	if !verifyHMACSHA256Hex([]byte(message), signature, p.keySecret) {
+		return domain.Unauthorized("billing_callback_signature_invalid",
+			"razorpay checkout callback signature verification failed")
+	}
+	return nil
+}

--- a/apps/api/internal/billing/razorpay/provider_test.go
+++ b/apps/api/internal/billing/razorpay/provider_test.go
@@ -1,0 +1,599 @@
+package razorpay
+
+// provider_test.go — fast, pure unit tests plus a couple of httptest.Server
+// -backed REST round-trip tests (CreateCheckout/GetSubscription). Webhook and
+// checkout-callback signature tests sign independently with stdlib
+// crypto/hmac (NOT by calling the adapter's own verifyHMACSHA256Hex), so a
+// forged/wrong-secret signature genuinely exercises the rejection path rather
+// than trivially agreeing with itself.
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/billing"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+func testConfig() Config {
+	return Config{
+		KeyID:          "rzp_test_123",
+		KeySecret:      "test_key_secret",
+		WebhookSecret:  "test_webhook_secret",
+		PlanStarterUSD: "plan_starter_usd",
+		PlanStarterINR: "plan_starter_inr",
+		PlanAgencyUSD:  "plan_agency_usd",
+		PlanAgencyINR:  "plan_agency_inr",
+		PlanScaleUSD:   "plan_scale_usd",
+		PlanScaleINR:   "plan_scale_inr",
+	}
+}
+
+// signHex independently computes what a genuine Razorpay signature would be
+// — deliberately NOT calling verifyHMACSHA256Hex — so a test using the WRONG
+// secret/body here proves the adapter's rejection path is real, not vacuous.
+func signHex(body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func buildEnvelope(event string, createdAt int64, payloadJSON string) []byte {
+	return []byte(fmt.Sprintf(`{"entity":"event","event":%q,"contains":[],"payload":%s,"created_at":%d}`, event, payloadJSON, createdAt))
+}
+
+func webhookHeaders(body []byte, secret, eventID string) http.Header {
+	h := http.Header{}
+	h.Set(signatureHeader, signHex(body, secret))
+	if eventID != "" {
+		h.Set(eventIDHeader, eventID)
+	}
+	return h
+}
+
+// ---------------------------------------------------------------------------
+// Config.Configured
+// ---------------------------------------------------------------------------
+
+func TestConfigConfigured(t *testing.T) {
+	if (Config{}).Configured() {
+		t.Fatal("an all-empty Config should not be Configured")
+	}
+	if !testConfig().Configured() {
+		t.Fatal("a fully-populated Config should be Configured")
+	}
+	partial := testConfig()
+	partial.PlanScaleINR = ""
+	if partial.Configured() {
+		t.Fatal("a partially-populated Config should NOT be Configured")
+	}
+}
+
+func TestNameAndHasPortal(t *testing.T) {
+	p := New(testConfig())
+	if p.Name() != "razorpay" {
+		t.Fatalf("Name() = %q, want razorpay", p.Name())
+	}
+	if p.HasPortal() {
+		t.Fatal("HasPortal() should be false — Razorpay has no hosted portal")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MapPriceToPlan / status mapping — over BOTH currencies.
+// ---------------------------------------------------------------------------
+
+func TestMapPriceToPlan(t *testing.T) {
+	p := New(testConfig())
+	tests := []struct {
+		planID string
+		want   billing.Tier
+		wantOK bool
+	}{
+		{"plan_starter_usd", billing.TierStarter, true},
+		{"plan_starter_inr", billing.TierStarter, true},
+		{"plan_agency_usd", billing.TierAgency, true},
+		{"plan_agency_inr", billing.TierAgency, true},
+		{"plan_scale_usd", billing.TierScale, true},
+		{"plan_scale_inr", billing.TierScale, true},
+		{"plan_does_not_exist", "", false},
+	}
+	for _, tt := range tests {
+		got, ok := p.MapPriceToPlan(tt.planID)
+		if ok != tt.wantOK || (ok && got != tt.want) {
+			t.Errorf("MapPriceToPlan(%q) = (%q, %v), want (%q, %v)", tt.planID, got, ok, tt.want, tt.wantOK)
+		}
+	}
+}
+
+func TestMapStatus_FullMatrix(t *testing.T) {
+	tests := []struct {
+		in   string
+		want billing.Status
+	}{
+		{"active", billing.StatusActive},
+		{"pending", billing.StatusPastDue},
+		{"halted", billing.StatusPastDue},
+		{"cancelled", billing.StatusCanceled},
+		{"completed", billing.StatusCanceled},
+		{"paused", billing.StatusPaused},
+		{"created", billing.StatusNone},
+		{"authenticated", billing.StatusNone},
+		{"some_future_status", billing.StatusNone},
+	}
+	for _, tt := range tests {
+		if got := mapStatus(tt.in); got != tt.want {
+			t.Errorf("mapStatus(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestToSubscription_UnknownPlanIsUnresolved(t *testing.T) {
+	p := New(testConfig())
+	got := p.toSubscription(subscriptionEntity{ID: "sub_x", Status: "active", PlanID: "plan_not_configured"})
+	if got.PlanResolved {
+		t.Fatal("expected PlanResolved=false for a plan id not in the tier map")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreateCheckout — currency validation + (tier,currency) resolution.
+// ---------------------------------------------------------------------------
+
+func TestCreateCheckout_RejectsInvalidCurrency(t *testing.T) {
+	p := New(testConfig())
+	for _, cur := range []string{"", "EUR", "usd-x"} {
+		_, err := p.CreateCheckout(context.Background(), billing.CheckoutInput{
+			TenantID: uuid.New(), Plan: billing.TierStarter, Currency: cur,
+		})
+		de, ok := domain.AsDomain(err)
+		if !ok || de.Kind != domain.KindValidation {
+			t.Errorf("currency %q: want KindValidation, got %v", cur, err)
+		}
+	}
+}
+
+func TestCreateCheckout_UnconfiguredTierCurrencyCombo(t *testing.T) {
+	cfg := testConfig()
+	cfg.PlanScaleINR = "" // deliberately leave one (tier,currency) pair unconfigured
+	p := New(cfg)
+
+	_, err := p.CreateCheckout(context.Background(), billing.CheckoutInput{
+		TenantID: uuid.New(), Plan: billing.TierScale, Currency: "INR",
+	})
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindValidation {
+		t.Fatalf("want KindValidation for an unconfigured (tier,currency) pair, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreateCheckout / GetSubscription — REST round trips against an
+// httptest.Server standing in for the Razorpay API.
+// ---------------------------------------------------------------------------
+
+func TestCreateCheckout_Success(t *testing.T) {
+	var gotUser, gotPass string
+	var gotSubscriptionBody []byte
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/plans/plan_starter_usd", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"plan_starter_usd","item":{"amount":1500,"currency":"USD"}}`)
+	})
+	mux.HandleFunc("/subscriptions", func(w http.ResponseWriter, r *http.Request) {
+		gotUser, gotPass, _ = r.BasicAuth()
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read subscription create request body: %v", err)
+		}
+		gotSubscriptionBody = b
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"sub_new_1","plan_id":"plan_starter_usd","status":"created"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BaseURL = srv.URL
+	p := New(cfg)
+
+	tenantID := uuid.New()
+	sess, err := p.CreateCheckout(context.Background(), billing.CheckoutInput{
+		TenantID: tenantID,
+		Plan:     billing.TierStarter,
+		Currency: "usd", // lower-case, exercises the ToUpper normalization
+	})
+	if err != nil {
+		t.Fatalf("CreateCheckout: %v", err)
+	}
+	if sess.URL != "" {
+		t.Errorf("URL should be empty for a Razorpay checkout, got %q", sess.URL)
+	}
+	if sess.Razorpay == nil {
+		t.Fatal("expected non-nil Razorpay checkout data")
+	}
+	if sess.Razorpay.SubscriptionID != "sub_new_1" {
+		t.Errorf("SubscriptionID = %q, want sub_new_1", sess.Razorpay.SubscriptionID)
+	}
+	if sess.Razorpay.KeyID != cfg.KeyID {
+		t.Errorf("KeyID = %q, want %q", sess.Razorpay.KeyID, cfg.KeyID)
+	}
+	if sess.Razorpay.Currency != "USD" || sess.Razorpay.AmountMinor != 1500 {
+		t.Errorf("Currency/AmountMinor = %s/%d, want USD/1500", sess.Razorpay.Currency, sess.Razorpay.AmountMinor)
+	}
+	if gotUser != cfg.KeyID || gotPass != cfg.KeySecret {
+		t.Errorf("basic auth = %s/%s, want %s/%s", gotUser, gotPass, cfg.KeyID, cfg.KeySecret)
+	}
+
+	var reqBody map[string]any
+	if err := json.Unmarshal(gotSubscriptionBody, &reqBody); err != nil {
+		t.Fatalf("decode subscription create request body: %v", err)
+	}
+	if reqBody["plan_id"] != "plan_starter_usd" {
+		t.Errorf("plan_id = %v, want plan_starter_usd", reqBody["plan_id"])
+	}
+	notes, _ := reqBody["notes"].(map[string]any)
+	if notes == nil || notes[tenantNotesKey] != tenantID.String() {
+		t.Errorf("notes.%s = %v, want %s", tenantNotesKey, notes, tenantID)
+	}
+}
+
+func TestGetSubscription_MapsStatusAndResolvesPlan(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/subscriptions/sub_1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"sub_1","plan_id":"plan_agency_inr","customer_id":"cust_1","status":"active","current_end":1700003600}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BaseURL = srv.URL
+	p := New(cfg)
+
+	sub, err := p.GetSubscription(context.Background(), "sub_1")
+	if err != nil {
+		t.Fatalf("GetSubscription: %v", err)
+	}
+	if sub.ID != "sub_1" || sub.CustomerID != "cust_1" {
+		t.Fatalf("unexpected id/customer: %+v", sub)
+	}
+	if sub.Status != billing.StatusActive {
+		t.Errorf("Status = %q, want active", sub.Status)
+	}
+	if !sub.PlanResolved || sub.Plan != billing.TierAgency {
+		t.Errorf("Plan/PlanResolved = %q/%v, want agency/true", sub.Plan, sub.PlanResolved)
+	}
+	want := time.Unix(1700003600, 0).UTC()
+	if !sub.CurrentPeriodEnd.Equal(want) {
+		t.Errorf("CurrentPeriodEnd = %v, want %v", sub.CurrentPeriodEnd, want)
+	}
+}
+
+func TestGetSubscription_APIErrorWrapsCleanly(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/subscriptions/sub_missing", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":{"code":"BAD_REQUEST_ERROR","description":"subscription not found"}}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BaseURL = srv.URL
+	p := New(cfg)
+
+	_, err := p.GetSubscription(context.Background(), "sub_missing")
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindInternal {
+		t.Fatalf("want a wrapped KindInternal domain error, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CancelSubscription — cancel-at-cycle-end, never immediate.
+// ---------------------------------------------------------------------------
+
+func TestCancelSubscription_Success(t *testing.T) {
+	var gotMethod string
+	var gotBody []byte
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/subscriptions/sub_cancel_1/cancel", func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read cancel request body: %v", err)
+		}
+		gotBody = b
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"sub_cancel_1","status":"active"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BaseURL = srv.URL
+	p := New(cfg)
+
+	if err := p.CancelSubscription(context.Background(), "sub_cancel_1"); err != nil {
+		t.Fatalf("CancelSubscription: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %s, want POST", gotMethod)
+	}
+
+	var reqBody map[string]any
+	if err := json.Unmarshal(gotBody, &reqBody); err != nil {
+		t.Fatalf("decode cancel request body: %v", err)
+	}
+	// cancel_at_cycle_end=1 (NOT immediate) — the customer keeps access
+	// through what they already paid for.
+	if v, _ := reqBody["cancel_at_cycle_end"].(float64); v != 1 {
+		t.Errorf("cancel_at_cycle_end = %v, want 1 (cancel at cycle end, not immediate)", reqBody["cancel_at_cycle_end"])
+	}
+}
+
+func TestCancelSubscription_APIErrorWrapsCleanly(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/subscriptions/sub_missing/cancel", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":{"code":"BAD_REQUEST_ERROR","description":"subscription not found"}}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BaseURL = srv.URL
+	p := New(cfg)
+
+	err := p.CancelSubscription(context.Background(), "sub_missing")
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindInternal {
+		t.Fatalf("want a wrapped KindInternal domain error, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreatePortalSession — always "not supported".
+// ---------------------------------------------------------------------------
+
+func TestCreatePortalSession_NotSupported(t *testing.T) {
+	p := New(testConfig())
+	_, err := p.CreatePortalSession(context.Background(), "cust_1")
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindUnavailable {
+		t.Fatalf("want KindUnavailable (no hosted portal), got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VerifyWebhook — signature verification.
+// ---------------------------------------------------------------------------
+
+func TestVerifyWebhook_ValidSignature_UnhandledEventType(t *testing.T) {
+	p := New(testConfig())
+	body := buildEnvelope("customer.created", 1700000000, `{}`)
+	headers := webhookHeaders(body, testConfig().WebhookSecret, "evt_1")
+
+	ev, err := p.VerifyWebhook(body, headers)
+	if err != nil {
+		t.Fatalf("VerifyWebhook: %v", err)
+	}
+	if ev.ProviderEventID != "evt_1" {
+		t.Errorf("ProviderEventID = %q, want evt_1", ev.ProviderEventID)
+	}
+	if ev.ProviderEventType != "customer.created" {
+		t.Errorf("ProviderEventType = %q", ev.ProviderEventType)
+	}
+	if ev.Handled {
+		t.Fatal("an event type not in the acted-on list should not be Handled")
+	}
+}
+
+func TestVerifyWebhook_ForgedSignature(t *testing.T) {
+	p := New(testConfig())
+	body := buildEnvelope("subscription.activated", 1700000000, `{}`)
+	// Signed with the WRONG secret — a forged webhook attempt.
+	headers := webhookHeaders(body, "attacker_secret", "evt_forged")
+
+	if _, err := p.VerifyWebhook(body, headers); err == nil {
+		t.Fatal("expected an error for a signature computed with the wrong secret")
+	}
+}
+
+func TestVerifyWebhook_TamperedBody(t *testing.T) {
+	p := New(testConfig())
+	body := buildEnvelope("subscription.activated", 1700000000, `{}`)
+	headers := webhookHeaders(body, testConfig().WebhookSecret, "evt_tampered")
+
+	// Tamper with the body AFTER signing — the signature no longer matches.
+	tampered := append(append([]byte{}, body...), '{')
+	if _, err := p.VerifyWebhook(tampered, headers); err == nil {
+		t.Fatal("expected an error for a body that does not match its signature")
+	}
+}
+
+func TestVerifyWebhook_MissingSignatureHeader(t *testing.T) {
+	p := New(testConfig())
+	body := buildEnvelope("subscription.activated", 1700000000, `{}`)
+	h := http.Header{}
+	h.Set(eventIDHeader, "evt_1")
+
+	if _, err := p.VerifyWebhook(body, h); err == nil {
+		t.Fatal("expected an error when the X-Razorpay-Signature header is absent")
+	}
+}
+
+func TestVerifyWebhook_MissingEventIDHeader(t *testing.T) {
+	p := New(testConfig())
+	body := buildEnvelope("subscription.activated", 1700000000, `{}`)
+	h := http.Header{}
+	h.Set(signatureHeader, signHex(body, testConfig().WebhookSecret))
+
+	if _, err := p.VerifyWebhook(body, h); err == nil {
+		t.Fatal("expected an error when the X-Razorpay-Event-Id header is absent")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VerifyWebhook — event normalization + tenant attribution.
+// ---------------------------------------------------------------------------
+
+func TestVerifyWebhook_SubscriptionCharged_AttributesTenant(t *testing.T) {
+	p := New(testConfig())
+	tenantID := uuid.New()
+	payload := fmt.Sprintf(`{
+		"subscription": {"entity": {
+			"id": "sub_1", "plan_id": "plan_starter_usd", "customer_id": "cust_1",
+			"status": "active", "current_end": 1700003600,
+			"notes": {"wpmgr_tenant_id": %q}
+		}},
+		"payment": {"entity": {"id": "pay_1"}}
+	}`, tenantID)
+	body := buildEnvelope("subscription.charged", 1700000000, payload)
+	headers := webhookHeaders(body, testConfig().WebhookSecret, "evt_charged")
+
+	ev, err := p.VerifyWebhook(body, headers)
+	if err != nil {
+		t.Fatalf("VerifyWebhook: %v", err)
+	}
+	if !ev.Handled {
+		t.Fatal("subscription.charged should be Handled")
+	}
+	if ev.Kind != billing.EventPaymentSucceeded {
+		t.Errorf("Kind = %q, want payment_succeeded", ev.Kind)
+	}
+	if ev.TenantID != tenantID {
+		t.Errorf("TenantID = %s, want %s", ev.TenantID, tenantID)
+	}
+	if ev.ProviderSubscriptionID != "sub_1" {
+		t.Errorf("ProviderSubscriptionID = %q", ev.ProviderSubscriptionID)
+	}
+	if ev.ProviderCustomerID != "cust_1" {
+		t.Errorf("ProviderCustomerID = %q", ev.ProviderCustomerID)
+	}
+}
+
+func TestVerifyWebhook_SubscriptionPending_MapsToPastDue(t *testing.T) {
+	p := New(testConfig())
+	body := buildEnvelope("subscription.pending", 1700000000, `{"subscription":{"entity":{"id":"sub_2","status":"pending"}}}`)
+	headers := webhookHeaders(body, testConfig().WebhookSecret, "evt_pending")
+
+	ev, err := p.VerifyWebhook(body, headers)
+	if err != nil {
+		t.Fatalf("VerifyWebhook: %v", err)
+	}
+	if ev.Kind != billing.EventPastDue {
+		t.Errorf("Kind = %q, want past_due", ev.Kind)
+	}
+}
+
+func TestVerifyWebhook_SubscriptionHalted_MapsToPastDue(t *testing.T) {
+	p := New(testConfig())
+	body := buildEnvelope("subscription.halted", 1700000000, `{"subscription":{"entity":{"id":"sub_3","status":"halted"}}}`)
+	headers := webhookHeaders(body, testConfig().WebhookSecret, "evt_halted")
+
+	ev, err := p.VerifyWebhook(body, headers)
+	if err != nil {
+		t.Fatalf("VerifyWebhook: %v", err)
+	}
+	if ev.Kind != billing.EventPastDue {
+		t.Errorf("Kind = %q, want past_due", ev.Kind)
+	}
+}
+
+func TestVerifyWebhook_SubscriptionCancelled_MapsToCanceled(t *testing.T) {
+	p := New(testConfig())
+	body := buildEnvelope("subscription.cancelled", 1700000000, `{"subscription":{"entity":{"id":"sub_4","status":"cancelled"}}}`)
+	headers := webhookHeaders(body, testConfig().WebhookSecret, "evt_cancelled")
+
+	ev, err := p.VerifyWebhook(body, headers)
+	if err != nil {
+		t.Fatalf("VerifyWebhook: %v", err)
+	}
+	if ev.Kind != billing.EventCanceled {
+		t.Errorf("Kind = %q, want canceled", ev.Kind)
+	}
+}
+
+func TestVerifyWebhook_PaymentFailed_FallsBackToPaymentEntity(t *testing.T) {
+	p := New(testConfig())
+	tenantID := uuid.New()
+	payload := fmt.Sprintf(`{"payment":{"entity":{"id":"pay_2","subscription_id":"sub_5","notes":{"wpmgr_tenant_id":%q}}}}`, tenantID)
+	body := buildEnvelope("payment.failed", 1700000000, payload)
+	headers := webhookHeaders(body, testConfig().WebhookSecret, "evt_payfail")
+
+	ev, err := p.VerifyWebhook(body, headers)
+	if err != nil {
+		t.Fatalf("VerifyWebhook: %v", err)
+	}
+	if ev.Kind != billing.EventPaymentFailed {
+		t.Errorf("Kind = %q, want payment_failed", ev.Kind)
+	}
+	if ev.ProviderSubscriptionID != "sub_5" {
+		t.Errorf("ProviderSubscriptionID = %q, want sub_5 (read from the payment entity, no sibling subscription object)", ev.ProviderSubscriptionID)
+	}
+	if ev.TenantID != tenantID {
+		t.Errorf("TenantID = %s, want %s", ev.TenantID, tenantID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VerifyCheckoutCallback — the browser Checkout.js onSuccess callback.
+// ---------------------------------------------------------------------------
+
+func TestVerifyCheckoutCallback_Valid(t *testing.T) {
+	p := New(testConfig())
+	paymentID, subscriptionID := "pay_1", "sub_1"
+	sig := signHex([]byte(paymentID+"|"+subscriptionID), testConfig().KeySecret)
+
+	err := p.VerifyCheckoutCallback(map[string]string{
+		"razorpay_payment_id":      paymentID,
+		"razorpay_subscription_id": subscriptionID,
+		"razorpay_signature":       sig,
+	})
+	if err != nil {
+		t.Fatalf("VerifyCheckoutCallback: %v", err)
+	}
+}
+
+func TestVerifyCheckoutCallback_ForgedSignature(t *testing.T) {
+	p := New(testConfig())
+	// Signed with the wrong secret (the webhook secret, not the key secret) —
+	// a forged/mismatched callback.
+	sig := signHex([]byte("pay_1|sub_1"), testConfig().WebhookSecret)
+
+	err := p.VerifyCheckoutCallback(map[string]string{
+		"razorpay_payment_id":      "pay_1",
+		"razorpay_subscription_id": "sub_1",
+		"razorpay_signature":       sig,
+	})
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindUnauthorized {
+		t.Fatalf("want KindUnauthorized for a forged callback signature, got %v", err)
+	}
+}
+
+func TestVerifyCheckoutCallback_MissingFields(t *testing.T) {
+	p := New(testConfig())
+	err := p.VerifyCheckoutCallback(map[string]string{})
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindValidation {
+		t.Fatalf("want KindValidation for missing callback fields, got %v", err)
+	}
+}

--- a/apps/api/internal/billing/razorpay/signature.go
+++ b/apps/api/internal/billing/razorpay/signature.go
@@ -1,0 +1,37 @@
+package razorpay
+
+// signature.go — the two HMAC-SHA256 signature checks this adapter performs,
+// both hex-encoded and constant-time compared, per
+// https://razorpay.com/docs/webhooks/validate-test/ and
+// https://razorpay.com/docs/payments/subscriptions/verify-signature/:
+//
+//  1. verifyHMACSHA256Hex: the webhook body signature (X-Razorpay-Signature),
+//     keyed by the WEBHOOK secret.
+//  2. the browser checkout-callback signature (razorpay_signature), keyed by
+//     the API KEY SECRET — see VerifyCheckoutCallback in provider.go.
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// verifyHMACSHA256Hex reports whether hexSignature is the correct
+// HMAC-SHA256(body, secret), hex-encoded, compared in constant time. body
+// MUST be the exact raw bytes being authenticated — for a webhook this means
+// the raw request body BEFORE any JSON unmarshal (re-marshaling a decoded
+// struct can reorder keys/whitespace and silently break verification).
+func verifyHMACSHA256Hex(body []byte, hexSignature, secret string) bool {
+	if hexSignature == "" || secret == "" {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	expected := mac.Sum(nil)
+
+	sig, err := hex.DecodeString(hexSignature)
+	if err != nil {
+		return false
+	}
+	return hmac.Equal(expected, sig)
+}

--- a/apps/api/internal/billing/razorpay/webhook.go
+++ b/apps/api/internal/billing/razorpay/webhook.go
@@ -1,0 +1,199 @@
+package razorpay
+
+// webhook.go — Provider.VerifyWebhook: signature verification (raw body,
+// BEFORE any JSON unmarshal) + normalization of Razorpay's webhook envelope
+// to billing.Event. https://razorpay.com/docs/webhooks/subscriptions/ /
+// https://razorpay.com/docs/webhooks/validate-test/
+//
+// Razorpay's webhook envelope shape:
+//
+//	{
+//	  "entity": "event",
+//	  "event": "subscription.charged",
+//	  "contains": ["subscription", "payment"],
+//	  "payload": {
+//	    "subscription": {"entity": { ...subscription fields... }},
+//	    "payment":      {"entity": { ...payment fields...      }}
+//	  },
+//	  "created_at": 1700000000
+//	}
+//
+// Unlike Stripe, Razorpay does not carry a stable event id in the JSON body
+// itself — the dedup key rides the X-Razorpay-Event-Id HEADER instead (see
+// eventIDHeader below).
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/billing"
+)
+
+const (
+	signatureHeader = "X-Razorpay-Signature"
+	eventIDHeader   = "X-Razorpay-Event-Id"
+
+	// tenantNotesKey is the Razorpay subscription/payment "notes" key this
+	// adapter stamps with the tenant id at CreateCheckout time (Razorpay has
+	// no client_reference_id/metadata equivalent — notes is the ONLY place
+	// tenant attribution can ride).
+	tenantNotesKey = "wpmgr_tenant_id"
+)
+
+// webhookEnvelope is Razorpay's top-level webhook body.
+type webhookEnvelope struct {
+	Entity    string          `json:"entity"`
+	Event     string          `json:"event"`
+	Contains  []string        `json:"contains"`
+	Payload   json.RawMessage `json:"payload"`
+	CreatedAt int64           `json:"created_at"`
+}
+
+// entityContainer is the {"entity": {...}} wrapper Razorpay puts around each
+// named entity (payload.subscription, payload.payment, ...) inside payload.
+type entityContainer struct {
+	Entity json.RawMessage `json:"entity"`
+}
+
+// webhookPayload is the envelope's "payload" object, decoded just enough to
+// reach the subscription/payment entities this adapter needs.
+type webhookPayload struct {
+	Subscription *entityContainer `json:"subscription"`
+	Payment      *entityContainer `json:"payment"`
+}
+
+// paymentEntity is trimmed to the fields VerifyWebhook needs from a
+// payment.* event when no sibling "subscription" entity is present in the
+// same payload (Razorpay recurring-payment webhooks usually include both;
+// this is the defensive fallback).
+type paymentEntity struct {
+	ID             string            `json:"id"`
+	SubscriptionID string            `json:"subscription_id"`
+	Notes          map[string]string `json:"notes"`
+}
+
+// VerifyWebhook implements billing.Provider: verifies the
+// X-Razorpay-Signature header (HMAC-SHA256 of the EXACT raw body, keyed by
+// the configured webhook secret) BEFORE touching the body's contents in any
+// way, then normalizes the event. Returns an error on ANY signature failure —
+// the caller (Service.ProcessWebhook) maps that to HTTP 401 without this
+// function having touched the database.
+func (p *Provider) VerifyWebhook(rawBody []byte, headers http.Header) (billing.Event, error) {
+	sig := headers.Get(signatureHeader)
+	if sig == "" {
+		return billing.Event{}, errors.New("razorpay: missing " + signatureHeader + " header")
+	}
+	// Signature check happens BEFORE any json.Unmarshal of rawBody — the raw
+	// bytes are what was signed; re-marshaling a decoded value first would
+	// silently change key order/whitespace and break verification.
+	if !verifyHMACSHA256Hex(rawBody, sig, p.webhookSecret) {
+		return billing.Event{}, errors.New("razorpay: webhook signature verification failed")
+	}
+
+	eventID := headers.Get(eventIDHeader)
+	if eventID == "" {
+		// Real Razorpay deliveries always carry this header; its absence
+		// means we cannot dedup this delivery safely against
+		// billing_events.provider_event_id — fail loud rather than risk
+		// treating two distinct events (both with an empty id) as the same
+		// delivery.
+		return billing.Event{}, errors.New("razorpay: missing " + eventIDHeader + " header")
+	}
+
+	var env webhookEnvelope
+	if err := json.Unmarshal(rawBody, &env); err != nil {
+		return billing.Event{}, errors.New("razorpay: malformed webhook body: " + err.Error())
+	}
+
+	out := billing.Event{
+		ProviderEventID:   eventID,
+		ProviderEventType: env.Event,
+		OccurredAt:        time.Unix(env.CreatedAt, 0).UTC(),
+		Raw:               rawBody,
+	}
+
+	// Handled/Kind: a best-effort ledger label. The ACTUAL state transition
+	// never trusts this — Service.ProcessWebhook always re-fetches the
+	// subscription's current truth via GetSubscription before mutating
+	// anything (mirrors the Stripe adapter exactly).
+	switch env.Event {
+	case "subscription.activated":
+		out.Handled = true
+		out.Kind = billing.EventActivated
+	case "subscription.charged":
+		out.Handled = true
+		out.Kind = billing.EventPaymentSucceeded
+	case "subscription.pending":
+		// Razorpay is mid-retry on a failed charge; do NOT revoke — mirrors
+		// Stripe's past_due grace window.
+		out.Handled = true
+		out.Kind = billing.EventPastDue
+	case "subscription.halted":
+		// Razorpay's retry schedule is exhausted (mirrors Stripe's
+		// "unpaid"). Still normalized to EventPastDue — there is no separate
+		// "terminal past_due" EventKind; the ACTUAL grace-window/downgrade
+		// decision is made by nextBillingState from the re-fetched Status,
+		// not from this ledger label.
+		out.Handled = true
+		out.Kind = billing.EventPastDue
+	case "subscription.cancelled", "subscription.completed":
+		out.Handled = true
+		out.Kind = billing.EventCanceled
+	case "subscription.paused":
+		out.Handled = true
+		out.Kind = billing.EventPaused
+	case "subscription.resumed":
+		out.Handled = true
+		out.Kind = billing.EventResumed
+	case "payment.failed":
+		out.Handled = true
+		out.Kind = billing.EventPaymentFailed
+	default:
+		out.Handled = false
+	}
+
+	// Attribution: parsed best-effort. A malformed/absent payload sub-object
+	// still leaves the event correctly ledgered (ProviderEventID/Type/Kind
+	// above) — it just cannot be reconciled against a tenant, exactly like
+	// the "unknown customer" path in Service.ProcessWebhook.
+	var payload webhookPayload
+	if len(env.Payload) > 0 {
+		_ = json.Unmarshal(env.Payload, &payload)
+	}
+
+	if payload.Subscription != nil && len(payload.Subscription.Entity) > 0 {
+		var sub subscriptionEntity
+		if err := json.Unmarshal(payload.Subscription.Entity, &sub); err == nil {
+			out.ProviderSubscriptionID = sub.ID
+			out.ProviderCustomerID = sub.CustomerID
+			out.TenantID = tenantIDFromNotes(sub.Notes)
+		}
+	} else if payload.Payment != nil && len(payload.Payment.Entity) > 0 {
+		var pay paymentEntity
+		if err := json.Unmarshal(payload.Payment.Entity, &pay); err == nil {
+			out.ProviderSubscriptionID = pay.SubscriptionID
+			out.TenantID = tenantIDFromNotes(pay.Notes)
+		}
+	}
+
+	return out, nil
+}
+
+// tenantIDFromNotes parses billing.Event.TenantID from a Razorpay entity's
+// "notes" map. Returns uuid.Nil when absent/unparseable — the caller then
+// falls back to the (provider, provider_customer_id) lookup, same as Stripe.
+func tenantIDFromNotes(notes map[string]string) uuid.UUID {
+	if notes == nil {
+		return uuid.Nil
+	}
+	if v, ok := notes[tenantNotesKey]; ok && v != "" {
+		if parsed, err := uuid.Parse(v); err == nil {
+			return parsed
+		}
+	}
+	return uuid.Nil
+}

--- a/apps/api/internal/billing/stripe/provider.go
+++ b/apps/api/internal/billing/stripe/provider.go
@@ -98,6 +98,10 @@ func New(cfg Config) *Provider {
 // Name implements billing.Provider.
 func (p *Provider) Name() string { return "stripe" }
 
+// HasPortal implements billing.Provider: Stripe's Billing Portal is always
+// available once a customer exists.
+func (p *Provider) HasPortal() bool { return true }
+
 // MapPriceToPlan implements billing.Provider.
 func (p *Provider) MapPriceToPlan(priceID string) (billing.Tier, bool) {
 	t, ok := p.priceToPlan[priceID]
@@ -157,6 +161,32 @@ func (p *Provider) CreatePortalSession(ctx context.Context, providerCustomerID s
 		return billing.PortalSession{}, wrapErr("stripe_portal_create_failed", "failed to create Stripe billing portal session", err)
 	}
 	return billing.PortalSession{URL: sess.URL}, nil
+}
+
+// CancelSubscription implements billing.Provider: schedules cancellation at
+// the END of the current billing period (cancel_at_period_end=true) rather
+// than an immediate delete — the customer keeps access through what they
+// already paid for, and the tenant's own downgrade-to-free happens later,
+// driven by the resulting customer.subscription.updated webhook through the
+// normal ProcessWebhook path (never mutated directly here). Stripe customers
+// can also reach this same effect via the Billing Portal
+// (CreatePortalSession); this method is the programmatic equivalent for a
+// provider (like Razorpay) that has no portal at all.
+func (p *Provider) CancelSubscription(ctx context.Context, providerSubscriptionID string) error {
+	if _, err := p.client.V1Subscriptions.Update(ctx, providerSubscriptionID, cancelSubscriptionParams()); err != nil {
+		return wrapErr("stripe_subscription_cancel_failed", "failed to schedule Stripe subscription cancellation", err)
+	}
+	return nil
+}
+
+// cancelSubscriptionParams builds the SubscriptionUpdateParams
+// CancelSubscription sends. Extracted as a pure function (mirrors
+// toSubscription/mapStatus below) so the cancel-at-period-end — NEVER
+// immediate — choice is unit-testable without a live Stripe API call.
+func cancelSubscriptionParams() *stripesdk.SubscriptionUpdateParams {
+	return &stripesdk.SubscriptionUpdateParams{
+		CancelAtPeriodEnd: stripesdk.Bool(true),
+	}
 }
 
 // GetSubscription implements billing.Provider — the sole source of truth the

--- a/apps/api/internal/billing/stripe/provider_test.go
+++ b/apps/api/internal/billing/stripe/provider_test.go
@@ -259,6 +259,17 @@ func TestVerifyWebhook_ChargeRefunded_NoSubscriptionReference(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// CancelSubscription — cancel at period end, never immediate.
+// ---------------------------------------------------------------------------
+
+func TestCancelSubscriptionParams_CancelsAtPeriodEndNotImmediately(t *testing.T) {
+	params := cancelSubscriptionParams()
+	if params.CancelAtPeriodEnd == nil || !*params.CancelAtPeriodEnd {
+		t.Fatal("CancelAtPeriodEnd must be true — cancellation is scheduled for the end of the current billing period, never immediate")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // MapPriceToPlan / subscription-state mapping.
 // ---------------------------------------------------------------------------
 

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -46,7 +46,8 @@ type Config struct {
 // Validate's billing checks below), matching Phase A's "hosted with zero
 // providers is legal" behavior.
 type BillingConfig struct {
-	Stripe StripeConfig `koanf:"stripe"`
+	Stripe   StripeConfig   `koanf:"stripe"`
+	Razorpay RazorpayConfig `koanf:"razorpay"`
 }
 
 // StripeConfig holds the Stripe adapter's credentials and tier->price
@@ -66,6 +67,38 @@ type StripeConfig struct {
 	PriceStarter string `koanf:"price_starter"`
 	PriceAgency  string `koanf:"price_agency"`
 	PriceScale   string `koanf:"price_scale"`
+}
+
+// RazorpayConfig holds the Razorpay adapter's credentials and its
+// DUAL-CURRENCY tier->plan mapping: one Razorpay Plan per currency per tier
+// (Razorpay has no single multi-currency price object the way Stripe does).
+// All nine fields are required TOGETHER once ANY one of them is set (see
+// Validate/validateRazorpayConfig) — a partially-configured Razorpay is
+// refused at boot rather than silently registering a broken provider.
+type RazorpayConfig struct {
+	// KeyID is Razorpay's PUBLIC key id, also handed to the frontend's
+	// Checkout.js modal. Env: WPMGR_BILLING_RAZORPAY_KEY_ID.
+	KeyID string `koanf:"key_id"`
+	// KeySecret is Razorpay's secret API key (used for the Subscriptions/Plans
+	// REST API's Basic Auth, and for verifying the browser checkout callback's
+	// signature). Env: WPMGR_BILLING_RAZORPAY_KEY_SECRET.
+	KeySecret string `koanf:"key_secret"`
+	// WebhookSecret is the Razorpay webhook signing secret, DISTINCT from
+	// KeySecret, used to verify POST /webhooks/billing/razorpay. Env:
+	// WPMGR_BILLING_RAZORPAY_WEBHOOK_SECRET.
+	WebhookSecret string `koanf:"webhook_secret"`
+	// PlanStarterUSD/PlanStarterINR/... are the Razorpay recurring Plan ids
+	// for the three paid tiers, ONE PER CURRENCY (created once in the
+	// Razorpay Dashboard/API — this control plane never creates plans
+	// itself). Env: WPMGR_BILLING_RAZORPAY_PLAN_STARTER_USD /
+	// _PLAN_STARTER_INR / _PLAN_AGENCY_USD / _PLAN_AGENCY_INR /
+	// _PLAN_SCALE_USD / _PLAN_SCALE_INR.
+	PlanStarterUSD string `koanf:"plan_starter_usd"`
+	PlanStarterINR string `koanf:"plan_starter_inr"`
+	PlanAgencyUSD  string `koanf:"plan_agency_usd"`
+	PlanAgencyINR  string `koanf:"plan_agency_inr"`
+	PlanScaleUSD   string `koanf:"plan_scale_usd"`
+	PlanScaleINR   string `koanf:"plan_scale_inr"`
 }
 
 // HostedConfig gates the M16 Phase A hosted-billing entitlement substrate
@@ -446,69 +479,78 @@ func defaults() map[string]any {
 		"auth.absolute_expiry":     "720h", // 30 days hard cap
 		// ADR-056: WebAuthn relying party defaults (hosted instance).
 		// Self-hosted operators override via WPMGR_AUTH_WEBAUTHN_RPID etc.
-		"auth.webauthn_rpid":            "manage.wpmgr.app",
-		"auth.webauthn_rp_origins":      "https://manage.wpmgr.app",
-		"auth.webauthn_rp_display_name": "WPMgr",
-		"oidc.issuer":                   "",
-		"oidc.client_id":                "",
-		"oidc.client_secret":            "",
-		"oidc.redirect_url":             "",
-		"otel.exporter_otlp_endpoint":   "",
-		"otel.service_name":             "wpmgr-api",
-		"shutdown.timeout":              "15s",
-		"agent.signing_private_key":     "",
-		"agent.signing_public_key":      "",
-		"agent.signature_skew":          "5m",
-		"agent.stale_after":             "10m", // ~2 missed 5-min heartbeats
-		"agent.health_interval":         "5m",
-		"update.per_tenant_parallelism": 5,
-		"update.http_timeout":           "30s",
-		"update.http_retries":           2,
-		"s3.endpoint":                   "",
-		"s3.region":                     "us-east-1",
-		"s3.bucket":                     "",
-		"s3.access_key":                 "",
-		"s3.secret_key":                 "",
-		"s3.force_path_style":           true,
-		"backup.presign_ttl":            "1h",
-		"backup.retention_days":         30,
-		"backup.monthly_archive_keep":   12,
-		"backup.schedule_interval":      "5m",
-		"backup.gc_interval":            "1h",
-		"backup.http_timeout":           "10m",
-		"clickhouse.addr":               "",
-		"clickhouse.db":                 "wpmgr_metrics",
-		"clickhouse.username":           "default",
-		"clickhouse.password":           "",
-		"smtp.host":                     "",
-		"smtp.port":                     587,
-		"smtp.username":                 "",
-		"smtp.password":                 "",
-		"smtp.from":                     "",
-		"smtp.tls_mode":                 "starttls",
-		"uptime.probe_interval":         "60s",
-		"uptime.probe_timeout":          "15s",
-		"uptime.probe_concurrency":      10,
-		"uptime.alert_interval":         "60s",
-		"uptime.down_threshold":         2,
-		"uptime.cron_kick_enabled":      true,
-		"uptime.cron_kick_interval":     "5m",
-		"uptime.cron_kick_timeout":      "5s",
-		"uptime.cron_kick_concurrency":  10,
-		"river.media_schema":            "",
-		"autologin.require_2fa_step_up": false,
-		"conn.degrade_after":            "300s",
-		"conn.degrade_miss_threshold":   3,
-		"conn.disconnect_after":         "900s",
-		"conn.active_verify":            true,
-		"conn.verify_timeout":           "8s",
-		"conn.verify_concurrency":       8,
-		"hosted.enabled":                false,
-		"billing.stripe.secret_key":     "",
-		"billing.stripe.webhook_secret": "",
-		"billing.stripe.price_starter":  "",
-		"billing.stripe.price_agency":   "",
-		"billing.stripe.price_scale":    "",
+		"auth.webauthn_rpid":                "manage.wpmgr.app",
+		"auth.webauthn_rp_origins":          "https://manage.wpmgr.app",
+		"auth.webauthn_rp_display_name":     "WPMgr",
+		"oidc.issuer":                       "",
+		"oidc.client_id":                    "",
+		"oidc.client_secret":                "",
+		"oidc.redirect_url":                 "",
+		"otel.exporter_otlp_endpoint":       "",
+		"otel.service_name":                 "wpmgr-api",
+		"shutdown.timeout":                  "15s",
+		"agent.signing_private_key":         "",
+		"agent.signing_public_key":          "",
+		"agent.signature_skew":              "5m",
+		"agent.stale_after":                 "10m", // ~2 missed 5-min heartbeats
+		"agent.health_interval":             "5m",
+		"update.per_tenant_parallelism":     5,
+		"update.http_timeout":               "30s",
+		"update.http_retries":               2,
+		"s3.endpoint":                       "",
+		"s3.region":                         "us-east-1",
+		"s3.bucket":                         "",
+		"s3.access_key":                     "",
+		"s3.secret_key":                     "",
+		"s3.force_path_style":               true,
+		"backup.presign_ttl":                "1h",
+		"backup.retention_days":             30,
+		"backup.monthly_archive_keep":       12,
+		"backup.schedule_interval":          "5m",
+		"backup.gc_interval":                "1h",
+		"backup.http_timeout":               "10m",
+		"clickhouse.addr":                   "",
+		"clickhouse.db":                     "wpmgr_metrics",
+		"clickhouse.username":               "default",
+		"clickhouse.password":               "",
+		"smtp.host":                         "",
+		"smtp.port":                         587,
+		"smtp.username":                     "",
+		"smtp.password":                     "",
+		"smtp.from":                         "",
+		"smtp.tls_mode":                     "starttls",
+		"uptime.probe_interval":             "60s",
+		"uptime.probe_timeout":              "15s",
+		"uptime.probe_concurrency":          10,
+		"uptime.alert_interval":             "60s",
+		"uptime.down_threshold":             2,
+		"uptime.cron_kick_enabled":          true,
+		"uptime.cron_kick_interval":         "5m",
+		"uptime.cron_kick_timeout":          "5s",
+		"uptime.cron_kick_concurrency":      10,
+		"river.media_schema":                "",
+		"autologin.require_2fa_step_up":     false,
+		"conn.degrade_after":                "300s",
+		"conn.degrade_miss_threshold":       3,
+		"conn.disconnect_after":             "900s",
+		"conn.active_verify":                true,
+		"conn.verify_timeout":               "8s",
+		"conn.verify_concurrency":           8,
+		"hosted.enabled":                    false,
+		"billing.stripe.secret_key":         "",
+		"billing.stripe.webhook_secret":     "",
+		"billing.stripe.price_starter":      "",
+		"billing.stripe.price_agency":       "",
+		"billing.stripe.price_scale":        "",
+		"billing.razorpay.key_id":           "",
+		"billing.razorpay.key_secret":       "",
+		"billing.razorpay.webhook_secret":   "",
+		"billing.razorpay.plan_starter_usd": "",
+		"billing.razorpay.plan_starter_inr": "",
+		"billing.razorpay.plan_agency_usd":  "",
+		"billing.razorpay.plan_agency_inr":  "",
+		"billing.razorpay.plan_scale_usd":   "",
+		"billing.razorpay.plan_scale_inr":   "",
 	}
 }
 
@@ -622,6 +664,12 @@ func mapEnvKey(k string) string {
 	// WPMGR_BILLING_STRIPE_* -> billing.stripe.* (M16 Phase B).
 	case strings.HasPrefix(k, "billing_stripe_"):
 		return "billing.stripe." + strings.TrimPrefix(k, "billing_stripe_")
+	// WPMGR_BILLING_RAZORPAY_* -> billing.razorpay.* (M16 Phase B, Razorpay
+	// adapter). Without this case every WPMGR_BILLING_RAZORPAY_* variable is
+	// silently dropped by koanf's env provider (falls through to the default
+	// passthrough below, which unmarshal simply ignores).
+	case strings.HasPrefix(k, "billing_razorpay_"):
+		return "billing.razorpay." + strings.TrimPrefix(k, "billing_razorpay_")
 	default:
 		return k
 	}

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -237,6 +237,88 @@ func TestValidateStripeConfig_NotHostedNeverValidated(t *testing.T) {
 	}
 }
 
+// TestValidateHostedWithFullRazorpayConfigIsLegal proves a completely-filled-
+// in Razorpay config (all 3 credentials + all 6 dual-currency plan ids)
+// passes cleanly.
+func TestValidateHostedWithFullRazorpayConfigIsLegal(t *testing.T) {
+	cfg := Config{Auth: AuthConfig{SessionSecret: strings.Repeat("a", 32)}}
+	cfg.Hosted.Enabled = true
+	cfg.Billing.Razorpay = RazorpayConfig{
+		KeyID: "rzp_live_x", KeySecret: "secret_x", WebhookSecret: "whsec_x",
+		PlanStarterUSD: "plan_su", PlanStarterINR: "plan_si",
+		PlanAgencyUSD: "plan_au", PlanAgencyINR: "plan_ai",
+		PlanScaleUSD: "plan_scu", PlanScaleINR: "plan_sci",
+	}
+	if issues := Validate(cfg); len(issues) != 0 {
+		t.Fatalf("Validate() with a fully-configured Razorpay returned issues: %+v", issues)
+	}
+}
+
+// TestValidateHostedWithPartialRazorpayConfigIsRejected mirrors the Stripe
+// partial-config guard: an operator who has started configuring Razorpay
+// (ANY one of the nine fields set) but left the rest blank must be refused
+// at boot, one Issue per unset field.
+func TestValidateHostedWithPartialRazorpayConfigIsRejected(t *testing.T) {
+	cfg := Config{Auth: AuthConfig{SessionSecret: strings.Repeat("a", 32)}}
+	cfg.Hosted.Enabled = true
+	cfg.Billing.Razorpay = RazorpayConfig{KeyID: "rzp_live_x"} // only one of nine fields set
+
+	issues := Validate(cfg)
+	if len(issues) != 8 {
+		t.Fatalf("Validate() with a partial Razorpay config returned %d issues, want 8 (the eight unset fields): %+v", len(issues), issues)
+	}
+	for _, is := range issues {
+		if is.Name == "WPMGR_BILLING_RAZORPAY_KEY_ID" {
+			t.Fatalf("the ONE field that IS set should not itself be reported as an issue: %+v", issues)
+		}
+	}
+}
+
+// TestValidateRazorpayConfig_NotHostedNeverValidated proves the Razorpay
+// checks are skipped entirely when hosted billing is off, even with a
+// partial config present.
+func TestValidateRazorpayConfig_NotHostedNeverValidated(t *testing.T) {
+	cfg := Config{Auth: AuthConfig{SessionSecret: strings.Repeat("a", 32)}}
+	cfg.Hosted.Enabled = false
+	cfg.Billing.Razorpay = RazorpayConfig{KeyID: "rzp_live_x"} // partial, but hosted is off
+
+	if issues := Validate(cfg); len(issues) != 0 {
+		t.Fatalf("Validate() should skip Razorpay checks entirely when Hosted.Enabled is false, got: %+v", issues)
+	}
+}
+
+// TestLoadRazorpayEnvMapping proves every WPMGR_BILLING_RAZORPAY_* variable
+// resolves through mapEnvKey to billing.razorpay.* — without that mapping
+// case, koanf's env provider silently drops every one of these vars (they'd
+// fall through to the default passthrough key, which Unmarshal simply
+// ignores), and Razorpay would appear permanently unconfigured no matter what
+// an operator sets.
+func TestLoadRazorpayEnvMapping(t *testing.T) {
+	t.Setenv("WPMGR_BILLING_RAZORPAY_KEY_ID", "rzp_live_x")
+	t.Setenv("WPMGR_BILLING_RAZORPAY_KEY_SECRET", "secret_x")
+	t.Setenv("WPMGR_BILLING_RAZORPAY_WEBHOOK_SECRET", "whsec_x")
+	t.Setenv("WPMGR_BILLING_RAZORPAY_PLAN_STARTER_USD", "plan_su")
+	t.Setenv("WPMGR_BILLING_RAZORPAY_PLAN_STARTER_INR", "plan_si")
+	t.Setenv("WPMGR_BILLING_RAZORPAY_PLAN_AGENCY_USD", "plan_au")
+	t.Setenv("WPMGR_BILLING_RAZORPAY_PLAN_AGENCY_INR", "plan_ai")
+	t.Setenv("WPMGR_BILLING_RAZORPAY_PLAN_SCALE_USD", "plan_scu")
+	t.Setenv("WPMGR_BILLING_RAZORPAY_PLAN_SCALE_INR", "plan_sci")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := RazorpayConfig{
+		KeyID: "rzp_live_x", KeySecret: "secret_x", WebhookSecret: "whsec_x",
+		PlanStarterUSD: "plan_su", PlanStarterINR: "plan_si",
+		PlanAgencyUSD: "plan_au", PlanAgencyINR: "plan_ai",
+		PlanScaleUSD: "plan_scu", PlanScaleINR: "plan_sci",
+	}
+	if cfg.Billing.Razorpay != want {
+		t.Fatalf("Billing.Razorpay = %+v, want %+v", cfg.Billing.Razorpay, want)
+	}
+}
+
 // TestPrivilegeProbeGate verifies that the two-DSN gate logic (MigrationDSN != "")
 // correctly identifies when the privilege probe should run. In single-DSN mode
 // (MigrationDSN empty) the app connects as the migration runner, so the probe is

--- a/apps/api/internal/config/validate.go
+++ b/apps/api/internal/config/validate.go
@@ -151,6 +151,7 @@ func Validate(cfg Config) []Issue {
 	// fails confusingly on first checkout/webhook.
 	if cfg.Hosted.Enabled {
 		issues = append(issues, validateStripeConfig(cfg.Billing.Stripe)...)
+		issues = append(issues, validateRazorpayConfig(cfg.Billing.Razorpay)...)
 	}
 
 	return issues
@@ -184,6 +185,47 @@ func validateStripeConfig(s StripeConfig) []Issue {
 			issues = append(issues, Issue{
 				Name:   name,
 				Reason: "Stripe billing is partially configured — every WPMGR_BILLING_STRIPE_* variable is required once any one of them is set",
+			})
+		}
+	}
+	return issues
+}
+
+// validateRazorpayConfig checks internal consistency of the nine Razorpay
+// fields (3 credentials + 6 dual-currency plan ids): either all empty
+// (Razorpay simply is not configured on this instance — legal) or all nine
+// present. A partial config (e.g. INR plans set but USD plans missing) is
+// refused at boot rather than registering a Razorpay provider that would
+// fail confusingly on the first checkout in the unconfigured currency.
+func validateRazorpayConfig(r RazorpayConfig) []Issue {
+	fields := map[string]string{
+		"WPMGR_BILLING_RAZORPAY_KEY_ID":           r.KeyID,
+		"WPMGR_BILLING_RAZORPAY_KEY_SECRET":       r.KeySecret,
+		"WPMGR_BILLING_RAZORPAY_WEBHOOK_SECRET":   r.WebhookSecret,
+		"WPMGR_BILLING_RAZORPAY_PLAN_STARTER_USD": r.PlanStarterUSD,
+		"WPMGR_BILLING_RAZORPAY_PLAN_STARTER_INR": r.PlanStarterINR,
+		"WPMGR_BILLING_RAZORPAY_PLAN_AGENCY_USD":  r.PlanAgencyUSD,
+		"WPMGR_BILLING_RAZORPAY_PLAN_AGENCY_INR":  r.PlanAgencyINR,
+		"WPMGR_BILLING_RAZORPAY_PLAN_SCALE_USD":   r.PlanScaleUSD,
+		"WPMGR_BILLING_RAZORPAY_PLAN_SCALE_INR":   r.PlanScaleINR,
+	}
+	anySet := false
+	for _, v := range fields {
+		if v != "" {
+			anySet = true
+			break
+		}
+	}
+	if !anySet {
+		return nil
+	}
+
+	var issues []Issue
+	for name, v := range fields {
+		if v == "" {
+			issues = append(issues, Issue{
+				Name:   name,
+				Reason: "Razorpay billing is partially configured — every WPMGR_BILLING_RAZORPAY_* variable is required once any one of them is set",
 			})
 		}
 	}

--- a/apps/api/tests/billing_cancel_integration_test.go
+++ b/apps/api/tests/billing_cancel_integration_test.go
@@ -1,0 +1,180 @@
+package tests
+
+// billing_cancel_integration_test.go — Service.CancelSubscription and the
+// POST /billing/cancel route: the provider-agnostic "Cancel subscription"
+// backend added so a Razorpay tenant (no hosted portal — HasPortal()==false)
+// has SOME way to cancel.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/billing"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// TestCancelSubscription_CallsProviderCancel proves the happy path: the
+// tenant's OWN provider (not some other registered one) is called, with the
+// tenant's OWN stored provider_subscription_id — never a caller-suppliable
+// value.
+func TestCancelSubscription_CallsProviderCancel(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "billing-cancel-happy")
+	setTenantProvider(t, pool, tenant, "fake", "cus_cancel", "sub_cancel_1")
+
+	fp := newFakeProvider("fake")
+	svc := newTestBillingService(pool, fp)
+
+	if err := svc.CancelSubscription(ctx, tenant, billing.Actor{Type: "user", ID: "user-1"}); err != nil {
+		t.Fatalf("CancelSubscription: %v", err)
+	}
+	if fp.lastCancelSubscriptionID != "sub_cancel_1" {
+		t.Fatalf("provider.CancelSubscription called with %q, want sub_cancel_1", fp.lastCancelSubscriptionID)
+	}
+}
+
+// TestCancelSubscription_ProviderErrorPropagates proves a provider-side
+// cancel failure (e.g. the provider API rejects it) surfaces to the caller
+// rather than being swallowed.
+func TestCancelSubscription_ProviderErrorPropagates(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "billing-cancel-providererr")
+	setTenantProvider(t, pool, tenant, "fake", "cus_cancel_err", "sub_cancel_err")
+
+	fp := newFakeProvider("fake")
+	fp.cancelErr = domain.Internal("fake_cancel_failed", "the fake provider rejected the cancellation")
+	svc := newTestBillingService(pool, fp)
+
+	if err := svc.CancelSubscription(ctx, tenant, billing.Actor{}); err == nil {
+		t.Fatal("expected the provider's cancel error to propagate")
+	}
+}
+
+// TestCancelSubscription_NoActiveSubscriptionReturnsCleanError proves a
+// tenant that never checked out (no provider, no subscription id) gets a
+// clean domain error rather than attempting a nonsensical provider call.
+func TestCancelSubscription_NoActiveSubscriptionReturnsCleanError(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "billing-cancel-none")
+
+	fp := newFakeProvider("fake")
+	svc := newTestBillingService(pool, fp)
+
+	err := svc.CancelSubscription(ctx, tenant, billing.Actor{})
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindConflict {
+		t.Fatalf("want a KindConflict 'no active subscription' error, got %v", err)
+	}
+	if fp.lastCancelSubscriptionID != "" {
+		t.Fatalf("the provider should never have been called, got lastCancelSubscriptionID=%q", fp.lastCancelSubscriptionID)
+	}
+}
+
+// TestCancelSubscription_DoesNotMutateTenantPlanDirectly is the "pull is the
+// truth" regression guard: CancelSubscription tells the provider to cancel,
+// but tenants.plan/plan_status must remain EXACTLY as they were immediately
+// afterward — only a SEPARATE webhook delivery is allowed to change them.
+func TestCancelSubscription_DoesNotMutateTenantPlanDirectly(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "billing-cancel-nomutate")
+	setTenantPlan(t, pool, tenant, string(billing.TierAgency), "active")
+	setTenantProvider(t, pool, tenant, "fake", "cus_nomutate", "sub_nomutate")
+
+	fp := newFakeProvider("fake")
+	svc := newTestBillingService(pool, fp)
+
+	if err := svc.CancelSubscription(ctx, tenant, billing.Actor{}); err != nil {
+		t.Fatalf("CancelSubscription: %v", err)
+	}
+
+	plan, status := getTenantPlanStatus(t, pool, tenant)
+	if plan != string(billing.TierAgency) || status != "active" {
+		t.Fatalf("plan/status changed to %s/%s immediately after CancelSubscription — it must stay agency/active until a webhook arrives", plan, status)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Route-level: owner-gated, tenant-scoped.
+// ---------------------------------------------------------------------------
+
+// TestBillingCancelRoute_NonOwnerForbidden proves POST /billing/cancel
+// carries the SAME owner-only gate as every other /billing route.
+func TestBillingCancelRoute_NonOwnerForbidden(t *testing.T) {
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "billing-cancel-route-nonowner")
+	setTenantProvider(t, pool, tenant, "fake", "cus_1", "sub_1")
+
+	fp := newFakeProvider("fake")
+	svc := newTestBillingService(pool, fp)
+	h := billing.NewHandler(svc, nil, "https://cp.example.com")
+
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		p := domain.Principal{
+			Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenant,
+			Role: "admin", Scope: domain.ScopeOrg,
+		}
+		c.Request = c.Request.WithContext(domain.WithPrincipal(c.Request.Context(), p))
+		c.Next()
+	})
+	v1 := engine.Group("/api/v1")
+	h.Register(v1)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/billing/cancel", nil)
+	engine.ServeHTTP(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("POST /api/v1/billing/cancel (admin role) = %d, want 403", w.Code)
+	}
+	if fp.lastCancelSubscriptionID != "" {
+		t.Fatal("a forbidden request must never reach the provider")
+	}
+}
+
+// TestBillingCancelRoute_OwnerReachesHandlerAndCallsProvider proves the owner
+// path end to end: 200 + {"ok":true}, and the fake provider's
+// CancelSubscription was actually invoked with the tenant's own subscription
+// id.
+func TestBillingCancelRoute_OwnerReachesHandlerAndCallsProvider(t *testing.T) {
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "billing-cancel-route-owner")
+	setTenantProvider(t, pool, tenant, "fake", "cus_owner", "sub_owner_1")
+
+	fp := newFakeProvider("fake")
+	svc := newTestBillingService(pool, fp)
+	h := billing.NewHandler(svc, nil, "https://cp.example.com")
+
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		p := domain.Principal{
+			Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenant,
+			Role: "owner", Scope: domain.ScopeOrg,
+		}
+		c.Request = c.Request.WithContext(domain.WithPrincipal(c.Request.Context(), p))
+		c.Next()
+	})
+	v1 := engine.Group("/api/v1")
+	h.Register(v1)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/billing/cancel", nil)
+	engine.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST /api/v1/billing/cancel (owner) = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if want := `{"ok":true}`; w.Body.String() != want {
+		t.Fatalf("body = %q, want %q (PINNED contract)", w.Body.String(), want)
+	}
+	if fp.lastCancelSubscriptionID != "sub_owner_1" {
+		t.Fatalf("provider.CancelSubscription called with %q, want sub_owner_1", fp.lastCancelSubscriptionID)
+	}
+}

--- a/apps/api/tests/billing_checkout_integration_test.go
+++ b/apps/api/tests/billing_checkout_integration_test.go
@@ -2,9 +2,11 @@ package tests
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/billing"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
 // TestCreateCheckout_BindsToCallerTenantAndPersistsProvider proves the
@@ -24,7 +26,7 @@ func TestCreateCheckout_BindsToCallerTenantAndPersistsProvider(t *testing.T) {
 	fp := newFakeProvider("fake")
 	svc := newTestBillingService(pool, fp)
 
-	sess, err := svc.CreateCheckout(ctx, tenant, billing.TierAgency, "owner@example.com",
+	sess, err := svc.CreateCheckout(ctx, tenant, billing.TierAgency, "", "", "owner@example.com",
 		"https://cp.example.com/billing?checkout=success", "https://cp.example.com/billing?checkout=cancel",
 		billing.Actor{Type: "user", ID: "user-1"})
 	if err != nil {
@@ -65,7 +67,7 @@ func TestCreateCheckout_SecondCheckoutDoesNotRepointProvider(t *testing.T) {
 	fp := newFakeProvider("fake")
 	svc := newTestBillingService(pool, fp)
 
-	if _, err := svc.CreateCheckout(ctx, tenant, billing.TierStarter, "", "https://s", "https://c", billing.Actor{}); err != nil {
+	if _, err := svc.CreateCheckout(ctx, tenant, billing.TierStarter, "", "", "", "https://s", "https://c", billing.Actor{}); err != nil {
 		t.Fatalf("CreateCheckout: %v", err)
 	}
 
@@ -75,5 +77,118 @@ func TestCreateCheckout_SecondCheckoutDoesNotRepointProvider(t *testing.T) {
 	}
 	if billingProvider != "fake" {
 		t.Fatalf("billing_provider = %q, want it to remain %q (already set before this checkout)", billingProvider, "fake")
+	}
+}
+
+// TestCreateCheckout_RequestedProviderIsUsedOnFirstCheckout proves the
+// customer-chooses-provider-at-checkout contract: a tenant with NO pinned
+// provider yet gets the CALLER-REQUESTED provider (not silently the
+// instance's default), and only the requested provider's adapter is ever
+// invoked.
+func TestCreateCheckout_RequestedProviderIsUsedOnFirstCheckout(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "billing-checkout-requested-provider")
+
+	fpDefault := newFakeProvider("fake-default")
+	fpChosen := newFakeProvider("fake-chosen")
+	svc := billing.New(pool, nil, true, domain.SystemClock{}, slog.Default())
+	svc.SetProviders(billing.NewRegistry(fpDefault, fpChosen), fpDefault.Name())
+
+	sess, err := svc.CreateCheckout(ctx, tenant, billing.TierStarter, "fake-chosen", "", "", "https://s", "https://c", billing.Actor{})
+	if err != nil {
+		t.Fatalf("CreateCheckout: %v", err)
+	}
+	if sess.URL == "" {
+		t.Fatal("expected a non-empty checkout URL")
+	}
+	if fpChosen.lastCheckoutInput.TenantID != tenant {
+		t.Fatal("the REQUESTED provider should have received the checkout call")
+	}
+	if fpDefault.lastCheckoutInput.TenantID == tenant {
+		t.Fatal("the default provider should NOT have received the checkout call when a different provider was requested")
+	}
+
+	var billingProvider string
+	if err := pool.QueryRow(ctx, `SELECT billing_provider FROM tenants WHERE id = $1`, tenant).Scan(&billingProvider); err != nil {
+		t.Fatalf("read billing_provider: %v", err)
+	}
+	if billingProvider != "fake-chosen" {
+		t.Fatalf("billing_provider = %q, want fake-chosen", billingProvider)
+	}
+}
+
+// TestCreateCheckout_PinnedProviderWinsOverRequestedProvider proves "one
+// tenant = one provider at a time" holds even against an explicit
+// caller-requested provider: an already-pinned tenant can never be
+// re-pointed at a different provider via the request body.
+func TestCreateCheckout_PinnedProviderWinsOverRequestedProvider(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "billing-checkout-pinned-wins")
+	setTenantProvider(t, pool, tenant, "fake-default", "", "")
+
+	fpDefault := newFakeProvider("fake-default")
+	fpOther := newFakeProvider("fake-other")
+	svc := billing.New(pool, nil, true, domain.SystemClock{}, slog.Default())
+	svc.SetProviders(billing.NewRegistry(fpDefault, fpOther), fpDefault.Name())
+
+	if _, err := svc.CreateCheckout(ctx, tenant, billing.TierStarter, "fake-other", "", "", "https://s", "https://c", billing.Actor{}); err != nil {
+		t.Fatalf("CreateCheckout: %v", err)
+	}
+
+	if fpOther.lastCheckoutInput.TenantID == tenant {
+		t.Fatal("an already-pinned provider must win over a caller-requested one — 'fake-other' should never have been called")
+	}
+	var billingProvider string
+	if err := pool.QueryRow(ctx, `SELECT billing_provider FROM tenants WHERE id = $1`, tenant).Scan(&billingProvider); err != nil {
+		t.Fatalf("read billing_provider: %v", err)
+	}
+	if billingProvider != "fake-default" {
+		t.Fatalf("billing_provider = %q, want it to remain fake-default (pinned before this checkout)", billingProvider)
+	}
+}
+
+// TestGetBillingSummary_PortalAvailable_TrueForPortalHavingProvider proves
+// the default (Stripe-like) case: a provider that HasPortal()==true, with an
+// existing provider customer id, reports PortalAvailable=true.
+func TestGetBillingSummary_PortalAvailable_TrueForPortalHavingProvider(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "billing-summary-portal-true")
+	setTenantProvider(t, pool, tenant, "fake", "cus_1", "")
+
+	fp := newFakeProvider("fake")
+	svc := newTestBillingService(pool, fp)
+
+	summary, err := svc.GetBillingSummary(ctx, tenant)
+	if err != nil {
+		t.Fatalf("GetBillingSummary: %v", err)
+	}
+	if !summary.PortalAvailable {
+		t.Fatal("PortalAvailable should be true for a provider with HasPortal()==true and an existing customer id")
+	}
+}
+
+// TestGetBillingSummary_PortalAvailable_FalseForPortallessProvider is the
+// Razorpay regression guard: a provider that HasPortal()==false must NEVER
+// be advertised as having a portal, even with an existing provider customer
+// id on file.
+func TestGetBillingSummary_PortalAvailable_FalseForPortallessProvider(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "billing-summary-portal-false")
+	setTenantProvider(t, pool, tenant, "fake", "cus_1", "")
+
+	fp := newFakeProvider("fake")
+	fp.noPortal = true
+	svc := newTestBillingService(pool, fp)
+
+	summary, err := svc.GetBillingSummary(ctx, tenant)
+	if err != nil {
+		t.Fatalf("GetBillingSummary: %v", err)
+	}
+	if summary.PortalAvailable {
+		t.Fatal("PortalAvailable should be false for a provider whose HasPortal()==false (e.g. Razorpay)")
 	}
 }

--- a/apps/api/tests/billing_fake_provider_test.go
+++ b/apps/api/tests/billing_fake_provider_test.go
@@ -60,6 +60,17 @@ type fakeProvider struct {
 	checkoutErr       error
 	portalErr         error
 	verifyErr         error
+	cancelErr         error
+
+	// lastCancelSubscriptionID records what CancelSubscription was called
+	// with, so a test can assert the Service actually told THIS provider to
+	// cancel THIS subscription id.
+	lastCancelSubscriptionID string
+
+	// noPortal flips HasPortal() to false (a Razorpay-like provider). Zero
+	// value (false) keeps every existing test's Stripe-like (portal-having)
+	// assumption working unchanged.
+	noPortal bool
 }
 
 func newFakeProvider(name string) *fakeProvider {
@@ -67,6 +78,9 @@ func newFakeProvider(name string) *fakeProvider {
 }
 
 func (f *fakeProvider) Name() string { return f.name }
+
+// HasPortal implements billing.Provider.
+func (f *fakeProvider) HasPortal() bool { return !f.noPortal }
 
 func (f *fakeProvider) CreateCheckout(_ context.Context, in billing.CheckoutInput) (billing.CheckoutSession, error) {
 	f.lastCheckoutInput = in
@@ -114,4 +128,13 @@ func (f *fakeProvider) VerifyWebhook(rawBody []byte, _ http.Header) (billing.Eve
 
 func (f *fakeProvider) MapPriceToPlan(string) (billing.Tier, bool) {
 	return "", false // not exercised by these tests
+}
+
+// CancelSubscription implements billing.Provider. Records the id it was
+// called with (never mutates any state — mirrors real adapters, which only
+// tell the provider to cancel; the tenant's plan/status changes ONLY via a
+// subsequent webhook, driven separately in tests that need it).
+func (f *fakeProvider) CancelSubscription(_ context.Context, providerSubscriptionID string) error {
+	f.lastCancelSubscriptionID = providerSubscriptionID
+	return f.cancelErr
 }

--- a/apps/api/tests/billing_razorpay_webhook_integration_test.go
+++ b/apps/api/tests/billing_razorpay_webhook_integration_test.go
@@ -1,0 +1,134 @@
+package tests
+
+// billing_razorpay_webhook_integration_test.go — proves the Razorpay adapter
+// is a real, second Provider plugged into the SAME provider-agnostic webhook
+// flow as Stripe: a razorpay-shaped webhook (real HMAC signature, real
+// envelope shape, a real GetSubscription REST round trip against an
+// httptest.Server standing in for the Razorpay API) resolves via the
+// registry (no more 404) and drives tenants.plan/plan_status to active via
+// the EXACT SAME Service.ProcessWebhook/state-machine path Stripe uses.
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/billing"
+	billingrazorpay "github.com/mosamlife/wpmgr/apps/api/internal/billing/razorpay"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+func razorpaySignHex(body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// TestRazorpayWebhook_ResolvesProviderAndActivatesTenant is the "no more
+// 404" regression guard: before this adapter existed, POST
+// /webhooks/billing/razorpay 404'd for EVERY tenant (ProcessWebhook's
+// registry lookup failed for any provider name it didn't recognize). Here the
+// registry has a real *razorpay.Provider registered, a real webhook
+// signature is verified, and the subsequent GetSubscription re-fetch is a
+// real HTTP round trip (against an httptest.Server standing in for
+// api.razorpay.com) — proving the full pull-is-the-truth path, not just the
+// signature check.
+func TestRazorpayWebhook_ResolvesProviderAndActivatesTenant(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "billing-razorpay-webhook")
+	setTenantProvider(t, pool, tenant, "razorpay", "cust_rzp_1", "")
+
+	const webhookSecret = "whsec_test_razorpay"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/subscriptions/sub_rzp_1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"sub_rzp_1","plan_id":"plan_starter_usd","customer_id":"cust_rzp_1","status":"active","current_end":1900000000}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	rzp := billingrazorpay.New(billingrazorpay.Config{
+		KeyID:          "rzp_test_key",
+		KeySecret:      "rzp_test_secret",
+		WebhookSecret:  webhookSecret,
+		PlanStarterUSD: "plan_starter_usd",
+		PlanStarterINR: "plan_starter_inr",
+		PlanAgencyUSD:  "plan_agency_usd",
+		PlanAgencyINR:  "plan_agency_inr",
+		PlanScaleUSD:   "plan_scale_usd",
+		PlanScaleINR:   "plan_scale_inr",
+		BaseURL:        srv.URL,
+	})
+
+	svc := billing.New(pool, nil, true, domain.SystemClock{}, slog.Default())
+	svc.SetProviders(billing.NewRegistry(rzp), "razorpay")
+
+	payload := fmt.Sprintf(`{
+		"subscription": {"entity": {
+			"id": "sub_rzp_1", "plan_id": "plan_starter_usd", "customer_id": "cust_rzp_1",
+			"status": "active", "current_end": 1900000000,
+			"notes": {"wpmgr_tenant_id": %q}
+		}}
+	}`, tenant)
+	body := []byte(fmt.Sprintf(`{"entity":"event","event":"subscription.charged","contains":["subscription"],"payload":%s,"created_at":1700000000}`, payload))
+
+	headers := http.Header{}
+	headers.Set("X-Razorpay-Signature", razorpaySignHex(body, webhookSecret))
+	headers.Set("X-Razorpay-Event-Id", "evt_rzp_charged_1")
+
+	if err := svc.ProcessWebhook(ctx, "razorpay", body, headers); err != nil {
+		t.Fatalf("ProcessWebhook(razorpay): %v", err)
+	}
+
+	plan, status := getTenantPlanStatus(t, pool, tenant)
+	if plan != string(billing.TierStarter) || status != "active" {
+		t.Fatalf("plan/status = %s/%s, want starter/active", plan, status)
+	}
+	if got := countBillingEvents(t, pool, "razorpay", "evt_rzp_charged_1"); got != 1 {
+		t.Fatalf("billing_events rows for evt_rzp_charged_1 = %d, want 1", got)
+	}
+}
+
+// TestRazorpayWebhook_ForgedSignatureRejected proves the 401 path: a webhook
+// claiming to be from Razorpay, but signed with the wrong secret, is
+// rejected before touching the tenant or the billing_events ledger.
+func TestRazorpayWebhook_ForgedSignatureRejected(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "billing-razorpay-forged")
+	setTenantProvider(t, pool, tenant, "razorpay", "cust_rzp_2", "")
+
+	rzp := billingrazorpay.New(billingrazorpay.Config{
+		KeyID:          "rzp_test_key",
+		KeySecret:      "rzp_test_secret",
+		WebhookSecret:  "whsec_real_secret",
+		PlanStarterUSD: "plan_starter_usd",
+		PlanStarterINR: "plan_starter_inr",
+		PlanAgencyUSD:  "plan_agency_usd",
+		PlanAgencyINR:  "plan_agency_inr",
+		PlanScaleUSD:   "plan_scale_usd",
+		PlanScaleINR:   "plan_scale_inr",
+	})
+	svc := billing.New(pool, nil, true, domain.SystemClock{}, slog.Default())
+	svc.SetProviders(billing.NewRegistry(rzp), "razorpay")
+
+	body := []byte(`{"entity":"event","event":"subscription.charged","contains":[],"payload":{},"created_at":1700000000}`)
+	headers := http.Header{}
+	headers.Set("X-Razorpay-Signature", razorpaySignHex(body, "attacker_secret"))
+	headers.Set("X-Razorpay-Event-Id", "evt_rzp_forged")
+
+	err := svc.ProcessWebhook(ctx, "razorpay", body, headers)
+	if err == nil {
+		t.Fatal("expected an error for a forged Razorpay webhook signature")
+	}
+	if got := countBillingEvents(t, pool, "razorpay", "evt_rzp_forged"); got != 0 {
+		t.Fatalf("a rejected signature must never reach the billing_events ledger, found %d rows", got)
+	}
+}

--- a/apps/api/tests/billing_routes_contract_test.go
+++ b/apps/api/tests/billing_routes_contract_test.go
@@ -14,9 +14,9 @@ import (
 
 // TestBillingRoutes_404WhenUnhosted proves the routes-contract guarantee:
 // when billing.Handler is never mounted (mirrors cmd/wpmgr/main.go's
-// cfg.Hosted.Enabled==false wiring, which leaves deps.BillingH nil), all
-// three billing paths simply 404 — there is no special-cased "hosted
-// disabled" response, just an absent route.
+// cfg.Hosted.Enabled==false wiring, which leaves deps.BillingH nil), every
+// billing path simply 404s — there is no special-cased "hosted disabled"
+// response, just an absent route.
 func TestBillingRoutes_404WhenUnhosted(t *testing.T) {
 	engine := gin.New()
 	engine.Group("/api/v1") // no billing routes registered on it
@@ -24,7 +24,9 @@ func TestBillingRoutes_404WhenUnhosted(t *testing.T) {
 	for _, req := range []struct{ method, path string }{
 		{http.MethodGet, "/api/v1/billing"},
 		{http.MethodPost, "/api/v1/billing/checkout"},
+		{http.MethodPost, "/api/v1/billing/checkout/verify"},
 		{http.MethodPost, "/api/v1/billing/portal"},
+		{http.MethodPost, "/api/v1/billing/cancel"},
 	} {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(req.method, req.path, nil)

--- a/apps/web/src/components/ui/segmented-control.tsx
+++ b/apps/web/src/components/ui/segmented-control.tsx
@@ -1,0 +1,106 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+// SegmentedControl — a small, dependency-free "radio group rendered as
+// buttons" primitive (WAI-ARIA radiogroup pattern), for a short, mutually
+// exclusive choice with 2-4 text options (e.g. a payment provider, a
+// currency). Modeled on the icon-only density toggle in
+// features/sites/sites-toolbar.tsx, generalized to take a label per option
+// and real `role="radiogroup"`/`role="radio"` semantics (that toggle uses
+// `aria-pressed` buttons instead, which is the right call for icon buttons
+// but not for a labeled multi-option choice like this one).
+//
+//   <SegmentedControl
+//     aria-label="Payment provider"
+//     value={provider}
+//     onChange={setProvider}
+//     options={[
+//       { value: "stripe", label: "Stripe" },
+//       { value: "razorpay", label: "Razorpay" },
+//     ]}
+//   />
+
+export interface SegmentedControlOption<T extends string> {
+  value: T;
+  label: React.ReactNode;
+}
+
+export interface SegmentedControlProps<T extends string> {
+  value: T;
+  onChange: (value: T) => void;
+  options: readonly SegmentedControlOption<T>[];
+  "aria-label": string;
+  className?: string;
+}
+
+export function SegmentedControl<T extends string>({
+  value,
+  onChange,
+  options,
+  className,
+  ...aria
+}: SegmentedControlProps<T>) {
+  // Arrow-key roving over the options, Home/End to jump to the first/last —
+  // mirrors TabsList's keyboard handling (components/ui/tabs.tsx) so every
+  // "pick one of a short row of options" control in the app behaves the same
+  // way under the keyboard.
+  function onKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (!["ArrowRight", "ArrowLeft", "Home", "End"].includes(e.key)) return;
+    if (options.length === 0) return;
+    const current = options.findIndex((o) => o.value === value);
+    let next = current;
+    switch (e.key) {
+      case "ArrowRight":
+        next = current < 0 ? 0 : (current + 1) % options.length;
+        break;
+      case "ArrowLeft":
+        next = current <= 0 ? options.length - 1 : current - 1;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = options.length - 1;
+        break;
+    }
+    e.preventDefault();
+    const option = options[next];
+    if (option) onChange(option.value);
+  }
+
+  return (
+    <div
+      role="radiogroup"
+      onKeyDown={onKeyDown}
+      className={cn(
+        "inline-flex items-center rounded-md border border-[var(--color-border)] bg-[var(--color-background)] p-0.5",
+        className,
+      )}
+      {...aria}
+    >
+      {options.map((option) => {
+        const active = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            tabIndex={active ? 0 : -1}
+            onClick={() => onChange(option.value)}
+            className={cn(
+              "inline-flex items-center justify-center rounded-sm px-3 py-1 text-sm font-medium text-[var(--color-muted-foreground)] transition-colors",
+              "hover:text-[var(--color-foreground)]",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]",
+              active &&
+                "bg-[var(--color-accent)] text-[var(--color-accent-foreground)]",
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/features/billing/razorpay-checkout.test.ts
+++ b/apps/web/src/features/billing/razorpay-checkout.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import {
+  loadRazorpayCheckout,
+  __resetRazorpayCheckoutLoaderForTests,
+  type RazorpayConstructor,
+} from "./razorpay-checkout";
+
+// Pure loader-logic coverage (no React) — mirrors the pattern used for
+// use-billing.ts's `shouldPollCheckoutReturn` (see use-billing.test.ts): the
+// loader is dependency-free enough to drive directly against jsdom's real
+// `document`/`window`, so every branch (already loaded, load succeeds, load
+// fails, repeated calls reuse one script tag) is independently testable
+// without mounting any component.
+
+const FAKE_RAZORPAY = {} as unknown as RazorpayConstructor;
+
+function scriptTags(): HTMLScriptElement[] {
+  return Array.from(
+    document.querySelectorAll('script[src="https://checkout.razorpay.com/v1/checkout.js"]'),
+  );
+}
+
+beforeEach(() => {
+  __resetRazorpayCheckoutLoaderForTests();
+  delete (window as unknown as { Razorpay?: unknown }).Razorpay;
+  for (const s of scriptTags()) s.remove();
+});
+
+afterEach(() => {
+  delete (window as unknown as { Razorpay?: unknown }).Razorpay;
+  for (const s of scriptTags()) s.remove();
+});
+
+describe("loadRazorpayCheckout — already loaded", () => {
+  it("resolves immediately with window.Razorpay and never appends a script tag", async () => {
+    (window as unknown as { Razorpay?: unknown }).Razorpay = FAKE_RAZORPAY;
+
+    const result = await loadRazorpayCheckout();
+
+    expect(result).toBe(FAKE_RAZORPAY);
+    expect(scriptTags()).toHaveLength(0);
+  });
+});
+
+describe("loadRazorpayCheckout — first-time load", () => {
+  it("appends exactly ONE <script> tag pointed at Razorpay's Checkout.js, and resolves with window.Razorpay once it fires 'load'", async () => {
+    const pending = loadRazorpayCheckout();
+
+    // A second concurrent call before the first resolves must reuse the same
+    // in-flight promise rather than appending a second script tag (the
+    // "load once, on demand" contract this loader exists to guarantee).
+    const secondPending = loadRazorpayCheckout();
+    expect(scriptTags()).toHaveLength(1);
+
+    // Simulate the real script finishing: Razorpay's Checkout.js sets
+    // `window.Razorpay` as a side effect of executing, then the browser
+    // fires the script's 'load' event.
+    (window as unknown as { Razorpay?: unknown }).Razorpay = FAKE_RAZORPAY;
+    scriptTags()[0]!.dispatchEvent(new Event("load"));
+
+    const [first, second] = await Promise.all([pending, secondPending]);
+    expect(first).toBe(FAKE_RAZORPAY);
+    expect(second).toBe(FAKE_RAZORPAY);
+  });
+
+  it("rejects (never throws synchronously) when the script fails to load, e.g. blocked by CSP or an ad blocker", async () => {
+    const pending = loadRazorpayCheckout();
+    const script = scriptTags()[0];
+    expect(script).toBeDefined();
+
+    script!.dispatchEvent(new Event("error"));
+
+    await expect(pending).rejects.toThrow(
+      "Could not load the Razorpay checkout script.",
+    );
+  });
+
+  it("allows a fresh attempt (a new script tag) after a prior load failure", async () => {
+    const firstAttempt = loadRazorpayCheckout();
+    scriptTags()[0]!.dispatchEvent(new Event("error"));
+    await expect(firstAttempt).rejects.toThrow();
+
+    // Clean up the failed tag the way a real page would (this loader itself
+    // never removes it) before retrying, so the retry's own tag is the only
+    // one present.
+    for (const s of scriptTags()) s.remove();
+
+    const secondAttempt = loadRazorpayCheckout();
+    expect(scriptTags()).toHaveLength(1);
+    (window as unknown as { Razorpay?: unknown }).Razorpay = FAKE_RAZORPAY;
+    scriptTags()[0]!.dispatchEvent(new Event("load"));
+
+    await expect(secondAttempt).resolves.toBe(FAKE_RAZORPAY);
+  });
+});

--- a/apps/web/src/features/billing/razorpay-checkout.ts
+++ b/apps/web/src/features/billing/razorpay-checkout.ts
@@ -1,0 +1,118 @@
+// Razorpay Checkout.js loader for the in-app subscription checkout modal
+// (M16 Phase B). Checkout.js is a third-party script Razorpay hosts itself
+// (no first-party npm package ships this browser widget), so this loader
+// fetches it ONCE, on demand, the instant the operator actually picks the
+// Razorpay path — never a blocking <script> tag in index.html that would
+// load a payment-provider script for every visitor regardless of which
+// provider (or none) they end up choosing.
+//
+// CSP FLAG (frontend cannot fix this itself — see this feature's report):
+// the app's Content-Security-Policy must allow Razorpay's own domains before
+// this script can load or its modal can talk back to Razorpay's API.
+// `loadRazorpayCheckout()` will reject with a script-load error under the
+// current CSP until nginx.conf is updated.
+
+const CHECKOUT_JS_SRC = "https://checkout.razorpay.com/v1/checkout.js";
+
+/**
+ * The exact payload Razorpay's Checkout.js `handler` option hands the
+ * browser on a successful payment — field names verbatim, matching
+ * POST /api/v1/billing/checkout/verify's request body (see use-billing.ts's
+ * `RazorpayCheckoutSuccess`) so a caller can pass it straight through.
+ */
+export interface RazorpayHandlerResponse {
+  razorpay_payment_id: string;
+  razorpay_subscription_id: string;
+  razorpay_signature: string;
+}
+
+export interface RazorpayCheckoutOptions {
+  /** Razorpay's PUBLIC key id (Checkout.js's "key" option) — never the key secret. */
+  key: string;
+  subscription_id: string;
+  /** Smallest-unit amount (paise for INR, cents for USD) — Razorpay's own Plan remains authoritative for what is actually charged. */
+  amount?: number;
+  currency?: string;
+  name: string;
+  description?: string;
+  prefill?: { email?: string; name?: string };
+  theme?: { color?: string };
+  handler: (response: RazorpayHandlerResponse) => void;
+  modal?: {
+    /** Fires when the operator closes the modal without paying — a normal cancel, never an error. */
+    ondismiss?: () => void;
+  };
+}
+
+export interface RazorpayInstance {
+  open: () => void;
+  close?: () => void;
+}
+
+export interface RazorpayConstructor {
+  new (options: RazorpayCheckoutOptions): RazorpayInstance;
+}
+
+declare global {
+  interface Window {
+    Razorpay?: RazorpayConstructor;
+  }
+}
+
+let loadPromise: Promise<RazorpayConstructor> | null = null;
+
+/**
+ * Loads Razorpay's Checkout.js ONCE, on demand, and resolves with the
+ * `window.Razorpay` constructor. Safe to call repeatedly — returns the same
+ * in-flight/resolved promise rather than appending a second `<script>` tag.
+ * Rejects (never throws synchronously) on a network error, CSP block, or ad
+ * blocker, so a caller can show a fallback message instead of an uncaught
+ * exception deep inside a click handler.
+ */
+export function loadRazorpayCheckout(): Promise<RazorpayConstructor> {
+  if (typeof window !== "undefined" && window.Razorpay) {
+    return Promise.resolve(window.Razorpay);
+  }
+  if (loadPromise) return loadPromise;
+
+  loadPromise = new Promise<RazorpayConstructor>((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = CHECKOUT_JS_SRC;
+    script.async = true;
+    script.addEventListener(
+      "load",
+      () => {
+        if (window.Razorpay) {
+          resolve(window.Razorpay);
+        } else {
+          loadPromise = null;
+          reject(
+            new Error(
+              "Razorpay's checkout script loaded but window.Razorpay is unavailable.",
+            ),
+          );
+        }
+      },
+      { once: true },
+    );
+    script.addEventListener(
+      "error",
+      () => {
+        loadPromise = null;
+        reject(new Error("Could not load the Razorpay checkout script."));
+      },
+      { once: true },
+    );
+    document.head.appendChild(script);
+  });
+
+  return loadPromise;
+}
+
+/**
+ * Test-only escape hatch: clears the module-level load cache so a test can
+ * simulate "not yet loaded" again after a prior test populated it.
+ */
+export function __resetRazorpayCheckoutLoaderForTests(): void {
+  loadPromise = null;
+}

--- a/apps/web/src/features/billing/use-billing.ts
+++ b/apps/web/src/features/billing/use-billing.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import {
   useMutation,
   useQuery,
+  useQueryClient,
   type UseMutationResult,
   type UseQueryResult,
 } from "@tanstack/react-query";
@@ -21,8 +22,10 @@ import { toError } from "@/features/auth/use-auth";
 // landed contract.
 //
 //   GET  /api/v1/billing            (owner-only; 404 when not hosted)
-//   POST /api/v1/billing/checkout   { tier } -> { url }
-//   POST /api/v1/billing/portal     -> { url }
+//   POST /api/v1/billing/checkout        { tier, provider?, currency? } -> CheckoutResult
+//   POST /api/v1/billing/checkout/verify { razorpay_payment_id, razorpay_subscription_id, razorpay_signature } -> { verified }
+//   POST /api/v1/billing/portal          -> { url }
+//   POST /api/v1/billing/cancel          (owner-only) -> { ok }
 
 export type BillingPlanId = "free" | "starter" | "agency" | "scale";
 
@@ -32,6 +35,17 @@ export type CheckoutTierId = Exclude<BillingPlanId, "free">;
 export function isCheckoutTier(id: BillingPlanId): id is CheckoutTierId {
   return id !== "free";
 }
+
+/** Payment provider a checkout can target — mirrors the CP's provider registry (internal/billing/provider.go). */
+export type BillingProvider = "stripe" | "razorpay";
+
+/**
+ * Currency choice, meaningful ONLY for the Razorpay provider — Razorpay has
+ * no single multi-currency price the way Stripe's own Price object does, so
+ * the CP resolves a plan PER (tier, currency). Ignored by every other
+ * provider.
+ */
+export type BillingCurrency = "USD" | "INR";
 
 export type BillingPlanStatus =
   | "none"
@@ -101,25 +115,138 @@ export function useBilling(
   });
 }
 
-export interface CheckoutResult {
-  url: string;
+/**
+ * The data WPMgr's in-app Checkout.js modal needs to open a Razorpay
+ * subscription checkout — mirrors the CP's `RazorpayCheckoutData` wire shape
+ * exactly (apps/api/internal/billing/provider.go). `amount` is in the
+ * currency's smallest unit (paise for INR, cents for USD), read
+ * authoritatively off the Razorpay Plan — never computed client-side.
+ */
+export interface RazorpayCheckoutData {
+  subscription_id: string;
+  key_id: string;
+  currency: string;
+  amount: number;
 }
 
-/** POST /api/v1/billing/checkout { tier } -> { url }. Caller redirects the browser there. */
+/**
+ * POST /api/v1/billing/checkout's response. Exactly one of `url`/`razorpay`
+ * is populated depending on the chosen provider's checkout style:
+ *   - Stripe: `url` is a hosted Checkout Session redirect target.
+ *   - Razorpay: `razorpay` is handed straight to the in-app Checkout.js modal.
+ */
+export interface CheckoutResult {
+  url?: string;
+  razorpay?: RazorpayCheckoutData;
+}
+
+export interface CreateCheckoutVariables {
+  tier: CheckoutTierId;
+  /** Omitted defers to this tenant's already-pinned provider, then this instance's configured default ("stripe"). */
+  provider?: BillingProvider;
+  /** Razorpay-only; ignored (and omitted from the request body) for every other provider. */
+  currency?: BillingCurrency;
+}
+
+/**
+ * POST /api/v1/billing/checkout { tier, provider?, currency? } -> CheckoutResult.
+ * The caller branches on which field the result populates — see
+ * `routes/_authed/settings/billing.tsx`'s `startCheckout`.
+ */
 export function useCreateBillingCheckout(): UseMutationResult<
   CheckoutResult,
   Error,
-  { tier: CheckoutTierId }
+  CreateCheckoutVariables
 > {
   return useMutation({
-    mutationFn: async ({ tier }) => {
+    mutationFn: async ({ tier, provider, currency }) => {
+      const body: { tier: string; provider?: string; currency?: string } = {
+        tier,
+      };
+      if (provider) body.provider = provider;
+      if (provider === "razorpay" && currency) body.currency = currency;
       const result = await client.post<{ 200: CheckoutResult }>({
         url: "/api/v1/billing/checkout",
-        body: { tier },
+        body,
       });
       if (result.error) throw toError(result.error);
       if (!result.data) throw new Error("Empty response");
       return result.data;
+    },
+  });
+}
+
+/**
+ * The EXACT field names Razorpay's Checkout.js `handler` option hands the
+ * browser on a successful payment, passed straight through as this request's
+ * body so the frontend never renames them.
+ */
+export interface RazorpayCheckoutSuccess {
+  razorpay_payment_id: string;
+  razorpay_subscription_id: string;
+  razorpay_signature: string;
+}
+
+export interface VerifyCheckoutResult {
+  verified: boolean;
+}
+
+/**
+ * POST /api/v1/billing/checkout/verify. UX-CONFIRMATION ONLY — per the CP's
+ * own doc comment (`Service.VerifyCheckoutCallback`), this never mutates the
+ * tenant's plan itself; the provider webhook remains the sole source of
+ * truth. Callers must poll GET /api/v1/billing afterward (see
+ * `useBillingCheckoutReturn`) regardless of whether this call succeeds or
+ * fails — a bad/late signature here must never block the poll that will
+ * eventually observe the real plan flip.
+ */
+export function useVerifyRazorpayCheckout(): UseMutationResult<
+  VerifyCheckoutResult,
+  Error,
+  RazorpayCheckoutSuccess
+> {
+  return useMutation({
+    mutationFn: async (payload) => {
+      const result = await client.post<{ 200: VerifyCheckoutResult }>({
+        url: "/api/v1/billing/checkout/verify",
+        body: payload,
+      });
+      if (result.error) throw toError(result.error);
+      if (!result.data) throw new Error("Empty response");
+      return result.data;
+    },
+  });
+}
+
+export interface CancelSubscriptionResult {
+  ok: boolean;
+}
+
+/**
+ * POST /api/v1/billing/cancel (owner-only). Cancels the tenant's subscription
+ * AT THE END OF THE CURRENT BILLING PERIOD, never immediately — the
+ * provider's webhook then drives the non-destructive plan=free downgrade,
+ * exactly like a natural expiry. Only relevant when `portal_available` is
+ * false (e.g. Razorpay, which has no hosted billing-management portal to
+ * cancel through instead).
+ */
+export function useCancelBillingSubscription(): UseMutationResult<
+  CancelSubscriptionResult,
+  Error,
+  void
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      const result = await client.post<{ 200: CancelSubscriptionResult }>({
+        url: "/api/v1/billing/cancel",
+      });
+      if (result.error) throw toError(result.error);
+      if (!result.data) throw new Error("Empty response");
+      return result.data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: billingKeys.info() });
     },
   });
 }

--- a/apps/web/src/routes/_authed/settings/-billing.test.tsx
+++ b/apps/web/src/routes/_authed/settings/-billing.test.tsx
@@ -1,0 +1,521 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import type { UseMutationResult } from "@tanstack/react-query";
+import type { Me } from "@wpmgr/api";
+
+import { createTestQueryClient, renderWithProviders } from "@/test/render";
+import { mockMutationResult, mockQueryResult } from "@/test/query-mocks";
+import { authKeys } from "@/features/auth/use-auth";
+
+import { Route as BillingRoute } from "./billing";
+import {
+  useBilling,
+  useCreateBillingCheckout,
+  useCreateBillingPortal,
+  useCancelBillingSubscription,
+  useVerifyRazorpayCheckout,
+  type BillingInfo,
+  type CheckoutResult,
+  type CreateCheckoutVariables,
+  type CancelSubscriptionResult,
+  type VerifyCheckoutResult,
+  type RazorpayCheckoutSuccess,
+  type PortalResult,
+} from "@/features/billing/use-billing";
+import {
+  loadRazorpayCheckout,
+  type RazorpayCheckoutOptions,
+  type RazorpayInstance,
+} from "@/features/billing/razorpay-checkout";
+import { toast } from "@/components/toast";
+
+// M16 Phase B — Razorpay checkout UI outcome tests.
+//
+// Mounts the REAL route component/singleton (`Route.options.component`,
+// `Route.update(...)`), exactly like
+// routes/_authed/admin/accounts/-index.test.tsx and
+// routes/_authed/settings/-route.test.tsx: the page reads/writes the URL via
+// `Route.useSearch()` / `useNavigate({ from: Route.fullPath })`, both bound
+// to this file's own exported `Route` singleton, so the test router below
+// re-attaches that EXACT singleton to a throwaway root route rather than
+// rendering the component as an inert child of a generic wrapper (which
+// would leave `Route.useSearch()` unable to resolve anything).
+//
+// Only the billing data hooks, the Razorpay Checkout.js loader, and the
+// toast helpers are mocked. `useMe()` and `useBillingCheckoutReturn` run for
+// real: `useMe()` is pre-seeded into the query cache (mirrors the
+// admin-accounts test's own note on why — avoids an accidental real
+// `getMe()` network call), and `useBillingCheckoutReturn` is the exact
+// mechanism this feature reuses for the Razorpay post-payment "finalizing
+// your subscription" poll, so mocking it would test a stub instead of the
+// real reuse.
+
+vi.mock("@/features/billing/use-billing", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/billing/use-billing")>();
+  return {
+    ...actual,
+    useBilling: vi.fn(),
+    useCreateBillingCheckout: vi.fn(),
+    useCreateBillingPortal: vi.fn(),
+    useCancelBillingSubscription: vi.fn(),
+    useVerifyRazorpayCheckout: vi.fn(),
+  };
+});
+
+vi.mock("@/features/billing/razorpay-checkout", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/features/billing/razorpay-checkout")>();
+  return { ...actual, loadRazorpayCheckout: vi.fn() };
+});
+
+vi.mock("@/components/toast", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/toast")>();
+  return {
+    ...actual,
+    toast: { ...actual.toast, success: vi.fn(), error: vi.fn() },
+  };
+});
+
+const mockedUseBilling = vi.mocked(useBilling);
+const mockedUseCreateBillingCheckout = vi.mocked(useCreateBillingCheckout);
+const mockedUseCreateBillingPortal = vi.mocked(useCreateBillingPortal);
+const mockedUseCancelBillingSubscription = vi.mocked(useCancelBillingSubscription);
+const mockedUseVerifyRazorpayCheckout = vi.mocked(useVerifyRazorpayCheckout);
+const mockedLoadRazorpayCheckout = vi.mocked(loadRazorpayCheckout);
+const mockedToastSuccess = vi.mocked(toast.success);
+const mockedToastError = vi.mocked(toast.error);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TENANT_ID = "11111111-1111-1111-1111-111111111111";
+
+const ME_FIXTURE: Me = {
+  user: {
+    id: "00000000-0000-0000-0000-000000000001",
+    email: "owner@wpmgr.test",
+    name: "Owner",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  memberships: [
+    { user_id: "00000000-0000-0000-0000-000000000001", tenant_id: TENANT_ID, role: "owner" },
+  ],
+  active_tenant_id: TENANT_ID,
+  hosted: true,
+};
+
+function billingFixture(overrides: Partial<BillingInfo> = {}): BillingInfo {
+  return {
+    plan: "free",
+    plan_status: "none",
+    meters: { sites: { used: 1, limit: 3 } },
+    portal_available: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Attaches this file's exported `Route` singleton to a throwaway root route
+ * and returns a router mounted at `initialPath` — the same post-hoc wiring
+ * `routeTree.gen.ts` performs for every file route, scoped to a single
+ * collapsed path segment instead of the real `_authed`/`settings` parent
+ * chain (see routes/_authed/admin/accounts/-index.test.tsx's identical
+ * pattern and its module-doc explanation).
+ */
+function buildBillingRouter(initialPath: string) {
+  const rootRoute = createRootRoute({});
+  type UpdateOptions = Parameters<typeof BillingRoute.update>[0];
+  const billingRoute = BillingRoute.update({
+    id: "/settings/billing",
+    path: "/settings/billing",
+    getParentRoute: () => rootRoute,
+  } as unknown as UpdateOptions);
+  const routeTree = rootRoute.addChildren([billingRoute]);
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+  });
+}
+
+function renderBillingPage(initialPath = "/settings/billing") {
+  const queryClient = createTestQueryClient();
+  queryClient.setQueryData(authKeys.me, ME_FIXTURE);
+  const router = buildBillingRouter(initialPath);
+  renderWithProviders(<RouterProvider router={router} />, { queryClient });
+  return router;
+}
+
+/**
+ * Builds a `mutate` spy that synchronously invokes the caller's `onSuccess`
+ * with `result` — simulating a mutation that resolves immediately. Narrow
+ * cast at the mock boundary (same pattern as ban-list-panel.test.tsx /
+ * add-site-dialog.test.tsx): the mock only implements the 1-arg `onSuccess`
+ * callback shape the component actually calls, not TanStack Query's full
+ * 4-arg `MutateOptions` signature.
+ */
+function fireOnSuccess<TData, TVariables = unknown>(
+  result: TData,
+): UseMutationResult<TData, Error, TVariables>["mutate"] {
+  const mutate = vi.fn(
+    (_vars: TVariables, opts?: { onSuccess?: (result: TData) => void }) => {
+      opts?.onSuccess?.(result);
+    },
+  );
+  return mutate as UseMutationResult<TData, Error, TVariables>["mutate"];
+}
+
+/** Same idea as `fireOnSuccess`, but for a mutation whose caller only reads `onSettled`. */
+function fireOnSettled<TData, TVariables = unknown>(): UseMutationResult<
+  TData,
+  Error,
+  TVariables
+>["mutate"] {
+  const mutate = vi.fn(
+    (_vars: TVariables, opts?: { onSettled?: () => void }) => {
+      opts?.onSettled?.();
+    },
+  );
+  return mutate as UseMutationResult<TData, Error, TVariables>["mutate"];
+}
+
+// A fake Razorpay Checkout.js constructor: captures the options it was
+// constructed with and exposes a spy for `.open()`, so tests can both
+// inspect what the component handed Checkout.js and drive its callbacks
+// (`handler`, `modal.ondismiss`) as if the operator interacted with the real
+// modal.
+let capturedRazorpayOptions: RazorpayCheckoutOptions | null = null;
+const razorpayOpenMock = vi.fn();
+
+class FakeRazorpay implements RazorpayInstance {
+  constructor(options: RazorpayCheckoutOptions) {
+    capturedRazorpayOptions = options;
+  }
+  open = razorpayOpenMock;
+}
+
+const originalLocation = window.location;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedRazorpayOptions = null;
+
+  mockedUseCreateBillingPortal.mockReturnValue(
+    mockMutationResult<PortalResult, void>({}),
+  );
+  mockedUseCancelBillingSubscription.mockReturnValue(
+    mockMutationResult<CancelSubscriptionResult, void>({}),
+  );
+  mockedUseVerifyRazorpayCheckout.mockReturnValue(
+    mockMutationResult<VerifyCheckoutResult, RazorpayCheckoutSuccess>({}),
+  );
+  mockedLoadRazorpayCheckout.mockResolvedValue(FakeRazorpay);
+
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    writable: true,
+    value: { ...originalLocation, href: "" },
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    writable: true,
+    value: originalLocation,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider/currency picker — posts the right checkout body
+// ---------------------------------------------------------------------------
+
+describe("Payment method picker", () => {
+  it("defaults to Stripe: Upgrade posts { tier, provider: 'stripe' } with no currency (non-vacuous: proves the default matches the CP's own default)", async () => {
+    const mutateMock = vi.fn();
+    mockedUseBilling.mockReturnValue(
+      mockQueryResult<BillingInfo | null>({ data: billingFixture() }),
+    );
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+
+    renderBillingPage();
+
+    const stripeRadio = await screen.findByRole("radio", { name: "Stripe" });
+    expect(stripeRadio).toHaveAttribute("aria-checked", "true");
+    // The currency picker is Razorpay-only — must not render while Stripe is selected.
+    expect(screen.queryByRole("radiogroup", { name: "Currency" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade to Starter" }));
+
+    expect(mutateMock).toHaveBeenCalledTimes(1);
+    expect(mutateMock).toHaveBeenCalledWith(
+      { tier: "starter", provider: "stripe", currency: undefined },
+      expect.anything(),
+    );
+  });
+
+  it("switching to Razorpay reveals a currency choice; selecting INR posts { provider: 'razorpay', currency: 'INR' }", async () => {
+    const mutateMock = vi.fn();
+    mockedUseBilling.mockReturnValue(
+      mockQueryResult<BillingInfo | null>({ data: billingFixture() }),
+    );
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+
+    renderBillingPage();
+
+    fireEvent.click(await screen.findByRole("radio", { name: "Razorpay" }));
+    const currencyGroup = await screen.findByRole("radiogroup", { name: "Currency" });
+    expect(currencyGroup).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("radio", { name: "INR (₹)" }));
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade to Agency" }));
+
+    expect(mutateMock).toHaveBeenCalledWith(
+      { tier: "agency", provider: "razorpay", currency: "INR" },
+      expect.anything(),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stripe path — unregressed redirect behavior
+// ---------------------------------------------------------------------------
+
+describe("Stripe checkout", () => {
+  it("redirects the browser to the returned Stripe URL (existing behavior, unregressed)", async () => {
+    mockedUseBilling.mockReturnValue(
+      mockQueryResult<BillingInfo | null>({ data: billingFixture() }),
+    );
+    const mutateMock = fireOnSuccess<CheckoutResult, CreateCheckoutVariables>({
+      url: "https://checkout.stripe.com/session/abc",
+    });
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+
+    renderBillingPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Upgrade to Starter" }));
+
+    expect(window.location.href).toBe("https://checkout.stripe.com/session/abc");
+    // The Razorpay loader must never even be consulted on the Stripe path.
+    expect(mockedLoadRazorpayCheckout).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Razorpay path — Checkout.js modal + verify + poll
+// ---------------------------------------------------------------------------
+
+describe("Razorpay checkout", () => {
+  it("opens the Checkout.js modal with the subscription's key/id/amount/currency, and on handler success calls verify then starts the billing poll", async () => {
+    const refetchMock = vi.fn();
+    mockedUseBilling.mockReturnValue(
+      mockQueryResult<BillingInfo | null>({ data: billingFixture(), refetch: refetchMock }),
+    );
+    const mutateMock = fireOnSuccess<CheckoutResult, CreateCheckoutVariables>({
+      razorpay: {
+        subscription_id: "sub_123",
+        key_id: "rzp_test_456",
+        currency: "INR",
+        amount: 120000,
+      },
+    });
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+    const verifyMutateMock = fireOnSettled<VerifyCheckoutResult, RazorpayCheckoutSuccess>();
+    mockedUseVerifyRazorpayCheckout.mockReturnValue(
+      mockMutationResult<VerifyCheckoutResult, RazorpayCheckoutSuccess>({ mutate: verifyMutateMock }),
+    );
+
+    const router = renderBillingPage();
+
+    fireEvent.click(await screen.findByRole("radio", { name: "Razorpay" }));
+    fireEvent.click(screen.getByRole("radio", { name: "INR (₹)" }));
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade to Agency" }));
+
+    await waitFor(() => expect(mockedLoadRazorpayCheckout).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(razorpayOpenMock).toHaveBeenCalledTimes(1));
+
+    expect(capturedRazorpayOptions).not.toBeNull();
+    expect(capturedRazorpayOptions).toMatchObject({
+      key: "rzp_test_456",
+      subscription_id: "sub_123",
+      amount: 120000,
+      currency: "INR",
+      name: "WPMgr",
+    });
+
+    // Simulate Razorpay's Checkout.js calling back into our handler with the
+    // Checkout.js onSuccess payload (field names verbatim).
+    capturedRazorpayOptions!.handler({
+      razorpay_payment_id: "pay_1",
+      razorpay_subscription_id: "sub_123",
+      razorpay_signature: "sig_1",
+    });
+
+    expect(verifyMutateMock).toHaveBeenCalledWith(
+      {
+        razorpay_payment_id: "pay_1",
+        razorpay_subscription_id: "sub_123",
+        razorpay_signature: "sig_1",
+      },
+      expect.anything(),
+    );
+
+    // The verify call settling flips `?checkout=success` on THIS router (via
+    // useNavigate({ from: Route.fullPath })) — proving it reuses the real
+    // navigation the Stripe redirect success path uses, not a stand-in.
+    await waitFor(() => expect(router.state.location.search.checkout).toBe("success"));
+
+    // That in turn arms the real (unmocked) useBillingCheckoutReturn poll,
+    // which refetches billing immediately — the actual source of truth for
+    // the plan flip, never the client-side verify response.
+    await waitFor(() => expect(refetchMock).toHaveBeenCalled());
+    expect(await screen.findByText("Finalizing your subscription…")).toBeInTheDocument();
+  });
+
+  it("does nothing (no toast, no navigation) when the operator dismisses the modal without paying", async () => {
+    mockedUseBilling.mockReturnValue(
+      mockQueryResult<BillingInfo | null>({ data: billingFixture() }),
+    );
+    const mutateMock = fireOnSuccess<CheckoutResult, CreateCheckoutVariables>({
+      razorpay: {
+        subscription_id: "sub_123",
+        key_id: "rzp_test_456",
+        currency: "USD",
+        amount: 1500,
+      },
+    });
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+
+    const router = renderBillingPage();
+
+    fireEvent.click(await screen.findByRole("radio", { name: "Razorpay" }));
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade to Agency" }));
+    await waitFor(() => expect(razorpayOpenMock).toHaveBeenCalledTimes(1));
+
+    capturedRazorpayOptions!.modal!.ondismiss!();
+
+    expect(mockedToastError).not.toHaveBeenCalled();
+    expect(mockedToastSuccess).not.toHaveBeenCalled();
+    expect(router.state.location.search.checkout).toBeUndefined();
+  });
+
+  it("shows a fallback toast when Checkout.js fails to load, instead of throwing inside the click handler", async () => {
+    mockedUseBilling.mockReturnValue(
+      mockQueryResult<BillingInfo | null>({ data: billingFixture() }),
+    );
+    const mutateMock = fireOnSuccess<CheckoutResult, CreateCheckoutVariables>({
+      razorpay: {
+        subscription_id: "sub_123",
+        key_id: "rzp_test_456",
+        currency: "USD",
+        amount: 1500,
+      },
+    });
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+    mockedLoadRazorpayCheckout.mockRejectedValue(
+      new Error("Could not load the Razorpay checkout script."),
+    );
+
+    renderBillingPage();
+
+    fireEvent.click(await screen.findByRole("radio", { name: "Razorpay" }));
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade to Agency" }));
+
+    await waitFor(() => expect(mockedToastError).toHaveBeenCalledTimes(1));
+    expect(mockedToastError).toHaveBeenCalledWith(
+      "Could not open the Razorpay payment window",
+      expect.objectContaining({
+        description: "Could not load the Razorpay checkout script.",
+      }),
+    );
+    expect(razorpayOpenMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cancel action (no portal) vs Manage-billing portal link
+// ---------------------------------------------------------------------------
+
+describe("Cancel subscription vs Manage billing", () => {
+  it("shows Cancel subscription (never Manage billing) when portal_available is false, and posts an EMPTY-body POST /billing/cancel on confirm", async () => {
+    mockedUseBilling.mockReturnValue(
+      mockQueryResult<BillingInfo | null>({
+        data: billingFixture({ plan: "starter", plan_status: "active", portal_available: false }),
+      }),
+    );
+    const cancelMutateAsync = vi.fn(
+      (): Promise<CancelSubscriptionResult> => Promise.resolve({ ok: true }),
+    );
+    mockedUseCancelBillingSubscription.mockReturnValue(
+      mockMutationResult<CancelSubscriptionResult, void>({ mutateAsync: cancelMutateAsync }),
+    );
+
+    renderBillingPage();
+
+    expect(await screen.findByRole("button", { name: "Cancel subscription" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Manage billing" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel subscription" }));
+
+    const confirmInput = await screen.findByLabelText(/type/i);
+    fireEvent.change(confirmInput, { target: { value: "Starter" } });
+
+    // The trigger button is aria-hidden while the modal Radix dialog is open
+    // (see restore-dialog.test.tsx's identical note), so this uniquely
+    // resolves to the dialog's own confirm button.
+    fireEvent.click(screen.getByRole("button", { name: "Cancel subscription" }));
+
+    await waitFor(() => expect(cancelMutateAsync).toHaveBeenCalledTimes(1));
+    // Cancel's wire contract is a bare POST with an EMPTY body — the mutation
+    // hook takes no variables at all, unlike checkout/verify which carry a
+    // payload; this proves no stray body field was ever wired in.
+    expect(cancelMutateAsync).toHaveBeenCalledWith(undefined);
+
+    expect(mockedToastSuccess).toHaveBeenCalledWith(
+      "Your subscription will be cancelled at the end of the current billing period",
+    );
+  });
+
+  it("shows Manage billing (never Cancel subscription) when portal_available is true", async () => {
+    mockedUseBilling.mockReturnValue(
+      mockQueryResult<BillingInfo | null>({
+        data: billingFixture({ plan: "starter", plan_status: "active", portal_available: true }),
+      }),
+    );
+    const portalMutate = fireOnSuccess<PortalResult, void>({
+      url: "https://billing.stripe.com/p/session_abc",
+    });
+    mockedUseCreateBillingPortal.mockReturnValue(
+      mockMutationResult<PortalResult, void>({ mutate: portalMutate }),
+    );
+
+    renderBillingPage();
+
+    expect(await screen.findByRole("button", { name: "Manage billing" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Cancel subscription" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Manage billing" }));
+
+    expect(portalMutate).toHaveBeenCalledTimes(1);
+    expect(window.location.href).toBe("https://billing.stripe.com/p/session_abc");
+  });
+});

--- a/apps/web/src/routes/_authed/settings/billing.tsx
+++ b/apps/web/src/routes/_authed/settings/billing.tsx
@@ -1,4 +1,5 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { useState } from "react";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
 import { AlertTriangle, CircleCheck, Loader2 } from "lucide-react";
 
@@ -11,17 +12,30 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { SegmentedControl } from "@/components/ui/segmented-control";
 import { PageError } from "@/components/feedback";
 import { PageHeader } from "@/components/shared/page-header";
+import { DestructiveConfirm } from "@/components/dialogs/destructive-confirm";
+import { toast } from "@/components/toast";
 import { useMe, activeRole } from "@/features/auth/use-auth";
 import {
   useBilling,
   useCreateBillingCheckout,
   useCreateBillingPortal,
+  useCancelBillingSubscription,
+  useVerifyRazorpayCheckout,
   useBillingCheckoutReturn,
   isCheckoutTier,
   type BillingInfo,
+  type BillingProvider,
+  type BillingCurrency,
+  type RazorpayCheckoutData,
+  type CheckoutTierId,
 } from "@/features/billing/use-billing";
+import {
+  loadRazorpayCheckout,
+  type RazorpayHandlerResponse,
+} from "@/features/billing/razorpay-checkout";
 import {
   billingBannerFor,
   formatBillingDate,
@@ -31,6 +45,7 @@ import {
   PLAN_CATALOG,
   isDowngrade,
   exceedsPlanLimit,
+  planLabel,
 } from "@/features/billing/plan-catalog";
 import { UsageMeterList } from "@/features/billing/usage-meter-list";
 import { cn } from "@/lib/utils";
@@ -53,6 +68,7 @@ function BillingPage() {
   const hosted = me?.hosted === true;
   const isOwner = activeRole(me) === "owner";
   const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
 
   const billing = useBilling({ enabled: hosted && isOwner });
   const checkoutReturn = useBillingCheckoutReturn(
@@ -60,6 +76,18 @@ function BillingPage() {
     billing.data,
     () => void billing.refetch(),
   );
+
+  // Razorpay's Checkout.js modal completes IN-PAGE (no browser redirect), so
+  // there is no natural `?checkout=success` navigation the way Stripe's
+  // hosted-redirect success URL provides one. Setting the same search param
+  // here reuses `useBillingCheckoutReturn`'s existing poll/"finalizing your
+  // subscription" UX verbatim, instead of inventing a second mechanism.
+  function markCheckoutSuccess() {
+    void navigate({
+      search: (prev) => ({ ...prev, checkout: "success" }),
+      replace: true,
+    });
+  }
 
   if (!hosted) {
     return (
@@ -112,6 +140,7 @@ function BillingPage() {
       checkoutStatus={search.checkout}
       finalizing={checkoutReturn.finalizing}
       timedOut={checkoutReturn.timedOut}
+      onCheckoutSuccess={markCheckoutSuccess}
     />
   );
 }
@@ -136,14 +165,18 @@ function BillingContent({
   checkoutStatus,
   finalizing,
   timedOut,
+  onCheckoutSuccess,
 }: {
   billing: BillingInfo;
   checkoutStatus: "success" | "cancel" | undefined;
   finalizing: boolean;
   timedOut: boolean;
+  onCheckoutSuccess: () => void;
 }) {
   const banner = billingBannerFor(billing);
   const portal = useCreateBillingPortal();
+  const cancel = useCancelBillingSubscription();
+  const [cancelOpen, setCancelOpen] = useState(false);
 
   const openPortal = () => {
     portal.mutate(undefined, {
@@ -152,6 +185,24 @@ function BillingContent({
       },
     });
   };
+
+  async function performCancel() {
+    try {
+      await cancel.mutateAsync(undefined);
+      setCancelOpen(false);
+      toast.success(
+        "Your subscription will be cancelled at the end of the current billing period",
+      );
+    } catch {
+      // Error surfaces inside the confirm dialog via the mutation state.
+    }
+  }
+
+  // "Do NOT show both": a tenant either has a hosted portal (Stripe) or
+  // doesn't (Razorpay), never both. A free-plan tenant with no portal has no
+  // subscription to cancel either, so neither action renders for it.
+  const showManageBilling = billing.portal_available;
+  const showCancelSubscription = !billing.portal_available && billing.plan !== "free";
 
   return (
     <section className="max-w-3xl space-y-6">
@@ -202,7 +253,7 @@ function BillingContent({
               ) : null}
             </CardDescription>
           </div>
-          {billing.portal_available ? (
+          {showManageBilling ? (
             <Button
               type="button"
               variant="outline"
@@ -210,6 +261,14 @@ function BillingContent({
               onClick={openPortal}
             >
               {portal.isPending ? "Opening…" : "Manage billing"}
+            </Button>
+          ) : showCancelSubscription ? (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setCancelOpen(true)}
+            >
+              Cancel subscription
             </Button>
           ) : null}
         </CardHeader>
@@ -228,6 +287,27 @@ function BillingContent({
         portalAvailable={billing.portal_available}
         onManageBilling={openPortal}
         portalPending={portal.isPending}
+        onCheckoutSuccess={onCheckoutSuccess}
+      />
+
+      <DestructiveConfirm
+        open={cancelOpen}
+        onClose={() => setCancelOpen(false)}
+        onConfirm={performCancel}
+        title="Cancel subscription"
+        consequencesBody={
+          <>
+            Your {planLabel(billing.plan)} plan stays active through the end
+            of the current billing period. After that, this workspace moves
+            to the Free plan automatically. Nothing you have already backed
+            up or configured is deleted.
+          </>
+        }
+        resourceName={planLabel(billing.plan)}
+        confirmLabel="Cancel subscription"
+        cancelLabel="Keep subscription"
+        isPending={cancel.isPending}
+        errorMessage={cancel.isError ? cancel.error.message : null}
       />
     </section>
   );
@@ -296,6 +376,57 @@ function CheckoutReturnBanner({
 }
 
 // ---------------------------------------------------------------------------
+// Payment method picker — provider (Stripe/Razorpay) + Razorpay-only currency
+// ---------------------------------------------------------------------------
+
+function PaymentMethodPicker({
+  provider,
+  onProviderChange,
+  currency,
+  onCurrencyChange,
+}: {
+  provider: BillingProvider;
+  onProviderChange: (provider: BillingProvider) => void;
+  currency: BillingCurrency;
+  onCurrencyChange: (currency: BillingCurrency) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-4 rounded-lg border border-border bg-muted/20 px-4 py-3 text-sm">
+      <div className="flex items-center gap-2">
+        <span className="font-medium text-foreground">Pay via</span>
+        <SegmentedControl
+          aria-label="Payment provider"
+          value={provider}
+          onChange={onProviderChange}
+          options={[
+            { value: "stripe", label: "Stripe" },
+            { value: "razorpay", label: "Razorpay" },
+          ]}
+        />
+      </div>
+      {provider === "razorpay" ? (
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-foreground">Currency</span>
+          <SegmentedControl
+            aria-label="Currency"
+            value={currency}
+            onChange={onCurrencyChange}
+            options={[
+              { value: "USD", label: "USD ($)" },
+              { value: "INR", label: "INR (₹)" },
+            ]}
+          />
+          <span className="text-xs text-muted-foreground">
+            Prices below are shown in USD; the exact INR amount is confirmed
+            in the payment window before you pay.
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Plan tiers grid
 // ---------------------------------------------------------------------------
 
@@ -304,17 +435,85 @@ function PlanTiersGrid({
   portalAvailable,
   onManageBilling,
   portalPending,
+  onCheckoutSuccess,
 }: {
   billing: BillingInfo;
   portalAvailable: boolean;
   onManageBilling: () => void;
   portalPending: boolean;
+  onCheckoutSuccess: () => void;
 }) {
   const checkout = useCreateBillingCheckout();
+  const verify = useVerifyRazorpayCheckout();
+  const [provider, setProvider] = useState<BillingProvider>("stripe");
+  const [currency, setCurrency] = useState<BillingCurrency>("USD");
   const usedSites = billing.meters.sites?.used ?? 0;
+
+  function openRazorpayCheckout(data: RazorpayCheckoutData) {
+    loadRazorpayCheckout()
+      .then((Razorpay) => {
+        const instance = new Razorpay({
+          key: data.key_id,
+          subscription_id: data.subscription_id,
+          amount: data.amount,
+          currency: data.currency,
+          name: "WPMgr",
+          description: "WPMgr subscription",
+          handler: (response: RazorpayHandlerResponse) => {
+            // Verify is a UX confirmation only — the poll below (via
+            // onCheckoutSuccess -> the shared Stripe success-poll mechanism)
+            // is what actually observes the plan flip, so it must start
+            // regardless of whether verify itself succeeds or fails.
+            verify.mutate(response, {
+              onSettled: () => onCheckoutSuccess(),
+            });
+          },
+          modal: {
+            // The operator closed the modal without paying — a normal
+            // cancel, never an error. No toast, no navigation.
+            ondismiss: () => {},
+          },
+        });
+        instance.open();
+      })
+      .catch((err: unknown) => {
+        toast.error("Could not open the Razorpay payment window", {
+          description:
+            err instanceof Error
+              ? err.message
+              : "Please try again, or choose Stripe instead.",
+        });
+      });
+  }
+
+  function startCheckout(tier: CheckoutTierId) {
+    checkout.mutate(
+      {
+        tier,
+        provider,
+        currency: provider === "razorpay" ? currency : undefined,
+      },
+      {
+        onSuccess: (result) => {
+          if (result.razorpay) {
+            openRazorpayCheckout(result.razorpay);
+          } else if (result.url) {
+            window.location.href = result.url;
+          }
+        },
+      },
+    );
+  }
 
   return (
     <div className="space-y-3">
+      <PaymentMethodPicker
+        provider={provider}
+        onProviderChange={setProvider}
+        currency={currency}
+        onCurrencyChange={setCurrency}
+      />
+
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {PLAN_CATALOG.map((tier) => {
           const isCurrent = tier.id === billing.plan;
@@ -364,7 +563,8 @@ function PlanTiersGrid({
                     </Button>
                   ) : (
                     <p className="text-xs text-muted-foreground">
-                      Contact support to move to Free.
+                      Cancel your subscription above to move to Free at the
+                      end of the billing period.
                     </p>
                   )
                 ) : (
@@ -374,18 +574,13 @@ function PlanTiersGrid({
                     disabled={blocked || checkout.isPending}
                     onClick={() => {
                       if (!isCheckoutTier(tier.id)) return;
-                      checkout.mutate(
-                        { tier: tier.id },
-                        {
-                          onSuccess: (result) => {
-                            window.location.href = result.url;
-                          },
-                        },
-                      );
+                      startCheckout(tier.id);
                     }}
                   >
                     {checkout.isPending
-                      ? "Redirecting…"
+                      ? provider === "razorpay"
+                        ? "Opening…"
+                        : "Redirecting…"
                       : downgrade
                         ? `Switch to ${tier.name}`
                         : `Upgrade to ${tier.name}`}

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -54,7 +54,14 @@ server {
     #     is the standard scope for an authenticated dashboard showing
     #     user-content images, which cannot execute script.
     #   connect-src 'self'   — SSE + REST are same-origin via /api/v1.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'" always;
+    #   Razorpay Checkout.js in-app payment modal (loaded on demand only on
+    #     /settings/billing when the customer picks Razorpay) — enumerated hosts,
+    #     no wildcard: script-src checkout.razorpay.com; connect-src
+    #     api.razorpay.com + lumberjack.razorpay.com; frame-src api/checkout
+    #     .razorpay.com. style-src already allows 'unsafe-inline' (Radix/motion)
+    #     and img-src already allows https:, so those cover the modal's inline
+    #     styles + payment-method/bank/QR images with no further change.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://checkout.razorpay.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; connect-src 'self' https://api.razorpay.com https://lumberjack.razorpay.com; frame-src 'self' https://api.razorpay.com https://checkout.razorpay.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'" always;
 
     # Docker embedded DNS so the "api" upstream resolves at request time (nginx
     # starts even if api isn't up yet).


### PR DESCRIPTION
Builds Razorpay as a real provider on the existing provider-agnostic billing plumbing (Paddle rejected; Stripe+Razorpay only). Ships DARK behind WPMGR_HOSTED. Hand-rolled stdlib adapter (no SDK), dual-currency USD/INR plans resolved server-side, raw-body HMAC webhook (sole grant authority), server-stamped tenant attribution, provider+currency choice at checkout, Checkout.js in-app modal, provider-agnostic cancel, minimal nginx CSP. Security review: SHIP (no crit/high/med; 1 bounded LOW). ~90 backend + 12 web tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Razorpay as an optional hosted-billing payment method alongside Stripe.
  * Enabled dual-currency checkout for supported plans, with in-app Razorpay payment flow and billing cancellation.
  * Added payment method selection in billing settings, plus clearer portal vs. cancel subscription actions.

* **Bug Fixes**
  * Improved checkout success handling and billing state refresh after payment completion.
  * Hardened payment verification and subscription updates to reduce incorrect billing changes.

* **Style**
  * Updated site security settings to allow the Razorpay checkout experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->