### PR TITLE
fix(agent): plugin/theme updates no longer fail when a pre-update snapshot can't be captured (0.61.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.44] - 2026-07-08
+
+### Fixed
+
+- Plugin and theme updates failing with a snapshot error on some hosts (agent 0.61.17). A hardening change had made a pre-update safety snapshot mandatory and refused the update outright when the snapshot could not be captured, which broke every plugin and theme update on hosts where the snapshot path could not be resolved (for example open_basedir or symlinked wp-content setups); core updates were unaffected. The agent now resolves the snapshot source correctly on those hosts, and if a snapshot still cannot be taken it proceeds with the update anyway (relying on WordPress's own rollback plus the post-update health check) instead of blocking it. The full snapshot-and-auto-restore protection is unchanged on hosts that can take a snapshot.
+
 ## [0.61.43] - 2026-07-08
 
 ### Added

--- a/apps/agent/includes/commands/class-update-command.php
+++ b/apps/agent/includes/commands/class-update-command.php
@@ -45,10 +45,28 @@
  *     clears) any marker left stale by exactly that kill, both at the start
  *     of the next `update` command and via a recurring cron sweep — see its
  *     class doc for the full design and the staleness-margin reasoning.
- *   - Unprotected-apply refusal (S8, adversarial review): a plugin/theme item
- *     whose pre-update snapshot capture FAILED is never applied unguarded —
- *     execute() refuses the item outright (`failed`) rather than proceeding
- *     without a guard, an in-flight marker, or anything to roll back to.
+ *   - Unprotected-apply refusal, superseded by a graceful degraded-mode
+ *     proceed (S8, adversarial review; revised by the agent-only regression
+ *     fix below): S8 originally refused (`failed`) any plugin/theme item
+ *     whose pre-update snapshot capture failed, rather than ever applying it
+ *     unguarded. That over-fired on a healthy site whenever
+ *     SnapshotManager::liveDir()'s realpath()-based containment check
+ *     itself failed — open_basedir excluding a parent, or a
+ *     symlinked/relocated wp-content tree — making EVERY plugin/theme
+ *     update fail with a snapshot error while core (exempt from S8) kept
+ *     working. SnapshotManager::liveDir() now has a safe, anchored fallback
+ *     for that exact case (see its own class doc), which closes off the
+ *     most common trigger; capture() can still legitimately fail for other
+ *     reasons (a disk-constrained host, a genuinely missing source
+ *     directory), and for those S8 now PROCEEDS with a best-effort,
+ *     unprotected apply — matching capture()'s own "...proceeding without
+ *     snapshot" log intent — rather than refusing the item outright. No
+ *     guard is armed and no in-flight marker is written in this case (both
+ *     remain gated on a non-empty `$snapshotId`, unchanged); the apply
+ *     instead relies on WordPress core's own Plugin_Upgrader/Theme_Upgrader
+ *     temp-backup/rollback (WP 6.3+), the post-apply isComplete() verify
+ *     below, and the control plane's post-update health-probe +
+ *     auto-rollback.
  *   - Final-hardening round (issue #131 final-hardening review): the
  *     UpdateInFlight marker written before each guarded apply is now paired
  *     with an flock() liveness lock held for the apply's whole duration (B)
@@ -309,32 +327,41 @@ final class UpdateCommand implements CommandInterface
                     $log        .= $snap['log'];
                 }
 
-                // --- S8 (issue #131 adversarial review): refuse an
-                // unprotected apply --------------------------------------
+                // --- S8, revised (agent-only regression fix): degrade
+                // gracefully instead of refusing the apply -----------------
                 // plugin/theme ALWAYS expects a snapshot (shouldSnapshot is
-                // unconditionally true above); a capture failure here (e.g.
-                // a disk-constrained host) previously fell straight through
-                // to an UNGUARDED apply() — no UpdateGuard armed, no
-                // in-flight marker, nothing to roll back to if the copy dies
-                // mid-write. Refuse the item instead: a host that cannot
-                // hold one snapshot copy is not a host we should risk an
-                // unrecoverable half-write on. `core` is exempt — D3 already
-                // gives it no directory-level snapshot/restore protection by
-                // design (it relies on B1 + WordPress's own Core_Upgrader
-                // temp-backup mechanism instead), so a core snapshot
-                // capture failure (only reachable when `snapshot=true` was
-                // requested at all) must not block a core apply that never
-                // depended on it.
+                // unconditionally true above). S8 originally REFUSED
+                // (`failed`) the item outright when capture failed here,
+                // rather than ever falling through to an unguarded apply().
+                // That refusal itself became the bug: on a healthy site
+                // where SnapshotManager::liveDir()'s realpath()-based
+                // containment check failed (open_basedir excluding a
+                // parent, or a symlinked/relocated wp-content tree —
+                // liveDir() now has a safe anchored fallback for exactly
+                // this, see its class doc), EVERY plugin/theme update
+                // refused here while core (exempt from S8) kept applying
+                // fine. capture() can still legitimately fail for other
+                // reasons (a disk-constrained host, a genuinely missing
+                // source directory); for those, PROCEED with a best-effort,
+                // unprotected apply rather than block it — this matches
+                // capture()'s own "...proceeding without snapshot" log
+                // intent below, which this refusal previously contradicted.
+                // No guard is armed and no in-flight marker is written for
+                // this item (both remain gated on `$snapshotId !== ''`
+                // below) — there is nothing to roll back to — so this apply
+                // instead relies on WordPress core's own
+                // Plugin_Upgrader/Theme_Upgrader temp-backup/rollback (WP
+                // 6.3+), the post-apply isComplete() verify further down,
+                // and the control plane's post-update health-probe +
+                // auto-rollback. `core` was already exempt from this gate —
+                // D3 gives it no directory-level snapshot/restore
+                // protection by design (it relies on B1 + WordPress's own
+                // Core_Upgrader temp-backup mechanism instead), so a core
+                // snapshot capture failure (only reachable when
+                // `snapshot=true` was requested at all) never blocked a
+                // core apply that never depended on it, and still doesn't.
                 if ($type !== 'core' && $snapshotId === '') {
-                    return $this->result(
-                        $type,
-                        $slug,
-                        $fromVersion,
-                        $fromVersion,
-                        'failed',
-                        '',
-                        $log . "\nCould not capture a pre-update snapshot; refusing to apply unprotected."
-                    );
+                    $log .= "\nApplied without a pre-update snapshot (host could not capture one).";
                 }
 
                 // --- Arm the shutdown-time restore backstop (D2) -----------

--- a/apps/agent/includes/support/class-snapshot-manager.php
+++ b/apps/agent/includes/support/class-snapshot-manager.php
@@ -9,7 +9,12 @@
  * not copied); rollback is then a downgrade-by-version.
  *
  * All paths derived from request input are bounded to wp-content via realpath
- * containment checks, and slugs are sanitized upstream by UpdateCommand.
+ * containment checks, and slugs are sanitized upstream by UpdateCommand. When
+ * `realpath()` itself cannot confirm containment (open_basedir excluding a
+ * parent, or a symlinked/relocated wp-content tree), `liveDir()` falls back to
+ * a string/segment-anchored containment check against the trusted,
+ * WP-native root (WP_PLUGIN_DIR / get_theme_root()) — see its own doc for why
+ * that fallback can never itself become a path-escape.
  *
  * @package WPMgr\Agent\Support
  */
@@ -746,6 +751,21 @@ class SnapshotManager
     /**
      * Resolve the live directory for a plugin/theme, bounded to wp-content.
      *
+     * Agent-only regression fix (open_basedir / symlinked-relocated
+     * wp-content, follow-up to GitHub issue #131): the primary containment
+     * check below (`containedRealpath()`) rejects a path whenever either
+     * side's `realpath()` returns false OR the two resolved paths diverge.
+     * That is exactly what happens on a perfectly HEALTHY site when
+     * `open_basedir` excludes a parent of the real, resolved path, or when
+     * wp-content/the plugin or theme root is a symlink or bind mount whose
+     * `realpath()`'d target textually diverges from wp-content's own
+     * `realpath()`'d target even though both point at the same logical
+     * tree. Before this fix, that false negative propagated all the way up
+     * through `capture()` returning `''` and UpdateCommand's S8 gate then
+     * REFUSING the whole apply — the root cause of every plugin/theme
+     * update failing with a snapshot error while core (exempt from S8)
+     * kept working.
+     *
      * @param string $type plugin|theme.
      * @param string $slug Sanitized slug.
      * @return string Absolute path, or '' when it cannot be safely resolved.
@@ -772,13 +792,78 @@ class SnapshotManager
             return '';
         }
 
-        // Containment: the resolved path's parent must sit under wp-content.
-        $parent = dirname($path);
-        if ($this->containedRealpath($parent, $contentDir) === '') {
+        if ($root === '') {
             return '';
         }
 
-        return $path;
+        // Containment: the resolved path's parent must sit under wp-content.
+        $parent = dirname($path);
+        if ($this->containedRealpath($parent, $contentDir) !== '') {
+            return $path;
+        }
+
+        // Fallback: realpath()-based containment could not confirm this
+        // path, which on a healthy host is most often open_basedir or a
+        // symlinked/relocated wp-content tree defeating realpath() itself
+        // (see this method's class doc above) rather than a genuine escape
+        // attempt. Re-check containment with a STRING/SEGMENT-ANCHORED
+        // comparison against $root directly instead of realpath()'ing
+        // either side. This is safe here specifically because $root is
+        // NEVER attacker-controlled — it is WP_PLUGIN_DIR (a core-defined
+        // constant) or get_theme_root()'s return (a core API), never a
+        // value derived from request input — and $folder/$slug were already
+        // rejected upstream by UpdateCommand::sanitizeSlug() for `..`, null
+        // bytes, absolute paths, and drive letters before ever reaching
+        // here. anchoredContainment() additionally re-validates that no
+        // residual traversal segment survived, and `is_dir()` confirms a
+        // real, on-disk directory — a path that is merely wrong (not just
+        // realpath()-hostile) still resolves to '' here exactly as before.
+        if ($this->anchoredContainment($root, $path) && is_dir($path)) {
+            return $path;
+        }
+
+        return '';
+    }
+
+    /**
+     * String/segment-anchored containment check: is $path exactly $root, or
+     * a descendant of $root, with no residual traversal segment (`.`/`..`)
+     * in the remainder? Used by liveDir() as the open_basedir/symlink
+     * fallback when `realpath()`-based containment cannot resolve a
+     * genuinely valid path — see liveDir()'s class doc for why that fallback
+     * is safe (both inputs here are WP-native/already-sanitized, never raw
+     * request input).
+     *
+     * @param string $root Trusted root directory (never attacker-controlled).
+     * @param string $path Candidate path, expected to be "$root/<segment...>".
+     * @return bool
+     */
+    private function anchoredContainment(string $root, string $path): bool
+    {
+        $root = rtrim($root, '/\\');
+        if ($root === '' || $path === '') {
+            return false;
+        }
+
+        $normalizedRoot = str_replace('\\', '/', $root);
+        $normalizedPath = str_replace('\\', '/', $path);
+
+        if ($normalizedPath !== $normalizedRoot && !str_starts_with($normalizedPath, $normalizedRoot . '/')) {
+            return false;
+        }
+
+        $relative = ltrim(substr($normalizedPath, strlen($normalizedRoot)), '/');
+        if ($relative === '') {
+            return true;
+        }
+
+        foreach (explode('/', $relative) as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..') {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/apps/agent/patchwork.json
+++ b/apps/agent/patchwork.json
@@ -1,3 +1,11 @@
 {
-  "redefinable-internals": ["headers_list", "set_time_limit", "php_sapi_name", "http_response_code", "header", "headers_sent"]
+  "redefinable-internals": [
+    "headers_list",
+    "set_time_limit",
+    "php_sapi_name",
+    "http_response_code",
+    "header",
+    "headers_sent",
+    "realpath"
+  ]
 }

--- a/apps/agent/tests/SnapshotManagerTest.php
+++ b/apps/agent/tests/SnapshotManagerTest.php
@@ -399,6 +399,148 @@ final class SnapshotManagerTest extends TestCase
     }
 
     // =========================================================================
+    // Prong A (agent-only regression fix, follow-up to GitHub issue #131) —
+    // liveDir()'s open_basedir / symlinked-wp-content anchored-containment
+    // fallback. Drives the REAL (unoverridden) liveDir() via reflection —
+    // deliberately NOT the `manager()`/`managerWithNoLiveSource()` doubles
+    // above, which override liveDir() itself and so could never exercise
+    // this fix. WP_CONTENT_DIR/WP_PLUGIN_DIR are guard-defined per the same
+    // "may already be a frozen global PHP constant from another test file in
+    // this suite" idiom used elsewhere (e.g. RestoreRunnerLocalDestinationTest)
+    // — every path resolved under them here uses a fresh, unique per-test
+    // subdirectory, so whichever directory the constants already point at is
+    // fine.
+    // =========================================================================
+
+    /**
+     * Invoke the REAL, protected `liveDir()` via reflection — no test double
+     * involved — so `realpath()` mocked false below actually exercises
+     * liveDir()'s own fallback logic rather than an overridden stand-in.
+     */
+    private function realLiveDir(SnapshotManager $mgr, string $type, string $slug): string
+    {
+        // No setAccessible() call needed — ReflectionMethod::invoke() has
+        // been able to call non-public methods directly since PHP 8.1.
+        $method = new \ReflectionMethod(SnapshotManager::class, 'liveDir');
+
+        return (string) $method->invoke($mgr, $type, $slug);
+    }
+
+    /**
+     * Guard-define WP_CONTENT_DIR/WP_PLUGIN_DIR (may already be frozen by an
+     * earlier test file in this same PHPUnit process) and ensure both exist
+     * on disk, returning the resolved plugin root so the caller can create a
+     * live plugin folder under it.
+     */
+    private function ensurePluginRootConstants(): string
+    {
+        if (!defined('WP_CONTENT_DIR')) {
+            define('WP_CONTENT_DIR', sys_get_temp_dir() . '/wpmgr-shared-wp-content');
+        }
+        if (!is_dir(WP_CONTENT_DIR)) {
+            mkdir(WP_CONTENT_DIR, 0755, true);
+        }
+        if (!defined('WP_PLUGIN_DIR')) {
+            define('WP_PLUGIN_DIR', rtrim((string) WP_CONTENT_DIR, '/\\') . '/plugins');
+        }
+        if (!is_dir(WP_PLUGIN_DIR)) {
+            mkdir(WP_PLUGIN_DIR, 0755, true);
+        }
+
+        return rtrim((string) WP_PLUGIN_DIR, '/\\');
+    }
+
+    public function test_live_dir_resolves_a_valid_plugin_source_when_realpath_containment_fails(): void
+    {
+        $pluginRoot = $this->ensurePluginRootConstants();
+
+        $slug   = 'prong-a-plugin-' . bin2hex(random_bytes(6));
+        $folder = $pluginRoot . '/' . $slug;
+        mkdir($folder, 0755, true);
+        file_put_contents($folder . '/' . $slug . '.php', "<?php\n// live plugin file\n");
+
+        // Force EVERY realpath() call to fail, deterministically simulating
+        // the open_basedir / symlinked-wp-content case that made
+        // containedRealpath() reject a perfectly real, on-disk directory.
+        Functions\when('realpath')->justReturn(false);
+
+        $mgr    = new SnapshotManager();
+        $result = $this->realLiveDir($mgr, 'plugin', $slug . '/' . $slug . '.php');
+
+        $this->assertSame(
+            $folder,
+            $result,
+            'Prong A: a real, on-disk plugin directory must still resolve when realpath()-based containment fails'
+        );
+    }
+
+    public function test_live_dir_resolves_a_valid_theme_source_when_realpath_containment_fails(): void
+    {
+        $this->ensurePluginRootConstants();
+        $themeRoot = rtrim((string) WP_CONTENT_DIR, '/\\') . '/themes';
+        if (!is_dir($themeRoot)) {
+            mkdir($themeRoot, 0755, true);
+        }
+
+        $slug   = 'prong-a-theme-' . bin2hex(random_bytes(6));
+        $folder = $themeRoot . '/' . $slug;
+        mkdir($folder, 0755, true);
+        file_put_contents($folder . '/style.css', "/*\nTheme Name: Prong A Test Theme\n*/\n");
+
+        Functions\when('realpath')->justReturn(false);
+
+        $mgr    = new SnapshotManager();
+        $result = $this->realLiveDir($mgr, 'theme', $slug);
+
+        $this->assertSame(
+            $folder,
+            $result,
+            'Prong A: a real, on-disk theme directory must still resolve when realpath()-based containment fails'
+        );
+    }
+
+    public function test_live_dir_still_rejects_a_path_escape_even_when_realpath_containment_fails(): void
+    {
+        // Defense-in-depth: even with the anchored-containment fallback
+        // active, a traversal slug fed DIRECTLY to liveDir() (bypassing
+        // UpdateCommand::sanitizeSlug(), which would already reject it
+        // upstream in production) must never resolve outside wp-content.
+        $this->ensurePluginRootConstants();
+
+        Functions\when('realpath')->justReturn(false);
+
+        $mgr = new SnapshotManager();
+
+        $this->assertSame(
+            '',
+            $this->realLiveDir($mgr, 'theme', '../../etc/passwd'),
+            'Prong A: the anchored-containment fallback must still reject a traversal slug, never resolve it'
+        );
+        $this->assertSame(
+            '',
+            $this->realLiveDir($mgr, 'plugin', '../escape/escape.php'),
+            'Prong A: a plugin folder derived as ".." must still be rejected by the fallback, never resolved'
+        );
+    }
+
+    public function test_live_dir_returns_empty_for_a_source_that_genuinely_does_not_exist_even_with_the_fallback(): void
+    {
+        // The fallback must not turn a genuinely WRONG/missing path into a
+        // false positive — only a real, on-disk directory may resolve.
+        $this->ensurePluginRootConstants();
+
+        Functions\when('realpath')->justReturn(false);
+
+        $mgr = new SnapshotManager();
+
+        $this->assertSame(
+            '',
+            $this->realLiveDir($mgr, 'plugin', 'never-installed-' . bin2hex(random_bytes(6))),
+            'Prong A: a plugin folder that does not exist on disk must still resolve to \'\', fallback or not'
+        );
+    }
+
+    // =========================================================================
     // F4 — stranded `.wpmgr-old-<id>` aside sweep (gcExpired())
     // =========================================================================
 

--- a/apps/agent/tests/UpdateCommandTest.php
+++ b/apps/agent/tests/UpdateCommandTest.php
@@ -804,14 +804,22 @@ final class UpdateCommandTest extends TestCase
         );
     }
 
-    // ---- S8: unprotected-apply refusal on a failed snapshot capture (GitHub issue #131 adversarial review) ----
+    // ---- S8, revised: graceful degraded-mode proceed on a failed snapshot capture ----
+    // (originally a hard refusal — GitHub issue #131 adversarial review;
+    // downgraded to a best-effort proceed by an agent-only regression fix:
+    // that refusal was itself the root cause of GH report "all plugin/theme
+    // updates fail with a snapshot error" on any open_basedir/symlinked-
+    // wp-content host whose realpath()-based containment check failed.)
 
-    public function test_snapshot_capture_failure_refuses_the_apply_for_plugin_theme(): void
+    public function test_snapshot_capture_failure_still_applies_unprotected_for_plugin_theme(): void
     {
-        // S8 — a plugin/theme item whose pre-update snapshot capture FAILED
-        // must never fall through to an UNGUARDED apply(): no UpdateGuard
-        // armed, no in-flight marker, nothing to roll back to. execute()
-        // must refuse the item outright rather than attempt the apply.
+        // INVERTS the old S8 "refuses the apply" test, which encoded the
+        // now-fixed regression as intended behavior: a plugin/theme item
+        // whose pre-update snapshot capture FAILED must no longer be
+        // refused outright. It must PROCEED with a best-effort, unprotected
+        // apply — no UpdateGuard armed, no in-flight marker, nothing to roll
+        // back to, but the apply itself must run and a genuinely successful
+        // result must be reported succeeded, not failed.
         $runner = $this->spyRunner();
         $runner->versions['plugin:akismet/akismet.php']  = '5.0';
         $runner->available['plugin:akismet/akismet.php'] = '5.3';
@@ -839,17 +847,94 @@ final class UpdateCommandTest extends TestCase
         ]);
 
         $r = $out['results'][0];
-        $this->assertSame('failed', $r['status']);
-        $this->assertStringContainsString('refusing to apply unprotected', $r['log']);
         $this->assertSame(
-            [],
+            'succeeded',
+            $r['status'],
+            'a failed snapshot capture must no longer refuse the apply — the item must still succeed'
+        );
+        $this->assertStringContainsString('Applied without a pre-update snapshot', $r['log']);
+        $this->assertCount(
+            1,
             $runner->applied,
-            'S8: a snapshot capture failure must refuse the item outright — apply() must never be invoked unguarded'
+            'a snapshot capture failure must no longer block apply() from ever being invoked'
         );
         $this->assertSame(
             [],
             $snapshots->restored,
             'without a captured snapshot id there is nothing to restore from — the guard must never arm'
+        );
+    }
+
+    public function test_normal_update_still_applies_when_snapshot_cannot_be_captured(): void
+    {
+        // Faithful regression test for the reported symptom: "after updating
+        // to the latest agent, ALL plugin AND theme updates fail with a
+        // snapshot error, while core updates still work." Simulates a
+        // SnapshotManager whose capture() always fails (mirroring
+        // liveDir()'s realpath()-containment false-negative on an
+        // open_basedir/symlinked-wp-content host) across an ACTIVE plugin,
+        // an INACTIVE plugin, a theme, and core, all in one batch. Every
+        // plugin/theme item must now actually apply() and report succeeded
+        // (previously 'failed' with "refusing to apply unprotected"); core
+        // is unaffected either way (D3 exemption, unchanged).
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:active-plugin/active-plugin.php']    = '1.0';
+        $runner->available['plugin:active-plugin/active-plugin.php']   = '1.1';
+        $runner->versions['plugin:inactive-plugin/inactive-plugin.php'] = '2.0';
+        $runner->available['plugin:inactive-plugin/inactive-plugin.php'] = '2.1';
+        $runner->versions['theme:twentytwentyfour']  = '1.0';
+        $runner->available['theme:twentytwentyfour'] = '1.1';
+        $runner->versions['core:core']  = '6.4';
+        $runner->available['core:core'] = '6.5';
+
+        $neverCaptures = new class extends SnapshotManager {
+            /** @var array<int,array{string,string,string}> */
+            public array $restored = [];
+
+            public function capture(string $type, string $slug, string $fromVersion): array
+            {
+                return ['snapshot_id' => '', 'log' => 'Source directory not found; proceeding without snapshot.'];
+            }
+
+            public function restore(string $type, string $slug, string $snapshotId): array
+            {
+                $this->restored[] = [$type, $slug, $snapshotId];
+
+                return ['ok' => false, 'log' => 'unreachable'];
+            }
+        };
+        $cmd = new UpdateCommand($neverCaptures, $runner);
+
+        $out = $cmd->execute([], [
+            'snapshot' => true,
+            'items'    => [
+                ['type' => 'plugin', 'slug' => 'active-plugin/active-plugin.php', 'version' => 'latest'],
+                ['type' => 'plugin', 'slug' => 'inactive-plugin/inactive-plugin.php', 'version' => 'latest'],
+                ['type' => 'theme', 'slug' => 'twentytwentyfour', 'version' => 'latest'],
+                ['type' => 'core', 'slug' => '', 'version' => 'latest'],
+            ],
+        ]);
+
+        $this->assertTrue($out['ok'], 'a snapshot-capture-unavailable host must not fail an otherwise-good batch');
+        $this->assertCount(4, $out['results']);
+
+        foreach ($out['results'] as $r) {
+            $this->assertSame(
+                'succeeded',
+                $r['status'],
+                $r['type'] . ':' . $r['slug'] . ' must apply successfully even though its snapshot could not be captured'
+            );
+        }
+
+        $this->assertCount(
+            4,
+            $runner->applied,
+            'every item — active plugin, inactive plugin, theme, and core — must reach apply()'
+        );
+        $this->assertSame(
+            [],
+            $neverCaptures->restored,
+            'no restore may ever be attempted when no snapshot was captured to begin with'
         );
     }
 

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.16
+ * Version:           0.61.17
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.16');
+define('WPMGR_AGENT_VERSION', '0.61.17');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 


### PR DESCRIPTION
Regression from #131: a mandatory pre-update snapshot refused the update outright when it couldn't be captured, breaking ALL plugin/theme updates on open_basedir/symlinked hosts (core unaffected). Fix: (A) resolve the snapshot source correctly under open_basedir/symlinks with anchored containment (no path escape), (B) proceed with the update if a snapshot still can't be taken (WP native rollback + post-update health check as the net) instead of failing. Full guard intact where a snapshot can be taken. Security review SHIP. 2494 phpunit tests + wp plugin check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU