### PR TITLE
fix(agent): plugin/theme update no longer false-rollbacks on open_basedir hosts (stat-cache) (0.61.18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
           cache-dependency-path: apps/api/go.sum
 
       # Build the api module on its own (workspace disabled) so it does not
@@ -119,7 +119,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
           cache-dependency-path: apps/api/go.sum
 
       # govulncheck does call-graph reachability analysis, so it only fails on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.45] - 2026-07-08
+
+### Fixed
+
+- A good plugin or theme update could be reported as failed and automatically rolled back on some hosts, even though it had actually applied correctly (agent 0.61.18). After applying an update, the agent re-checks that the plugin or theme is still readable before declaring success; on some hosting environments that re-check could read a stale, cached view of the filesystem left over from just before the update and see the just-updated files as missing, treating a perfectly good update as incomplete and reverting it. The agent now clears that stale cache before the check, so this false failure can no longer happen; a genuinely incomplete update (a real half-written plugin or theme) is still caught and rolled back exactly as before. A failed check now also records the specific reason and what was actually found on disk, so any future case is easy to diagnose from the log alone.
+
 ## [0.61.44] - 2026-07-08
 
 ### Fixed

--- a/apps/agent/includes/commands/class-update-command.php
+++ b/apps/agent/includes/commands/class-update-command.php
@@ -76,6 +76,18 @@
  *     marker in the `finally` below) and opportunistically invokes
  *     SnapshotManager::gcExpired() (C) so orphaned snapshots/asides are
  *     reclaimed even on a `DISABLE_WP_CRON`/dormant site, not cron-only.
+ *   - False-rollback regression fix (agent-only, 0.61.18): on an
+ *     open_basedir/RunCloud-style host a perfectly GOOD apply was being
+ *     auto-reverted here — the completeness re-read (UpdateRunner::isComplete())
+ *     busts WordPress's OWN plugin/theme metadata cache but was reading
+ *     through a separate, still-stale PHP stat/realpath cache for the
+ *     just-swapped directory, producing a false "incomplete" verdict with no
+ *     genuine half-write behind it. UpdateRunner::isComplete() now busts that
+ *     cache too before its re-read (see its own class doc); this call site is
+ *     unchanged except that it now also passes `$available` (the version the
+ *     apply targeted) through as an optional third argument purely so a
+ *     `false` verdict's DebugLog line can report the expected-vs-on-disk
+ *     version — it never influences the verdict.
  *
  * Every input is treated as untrusted: type is whitelisted, slug is sanitized to
  * reject path traversal, and snapshot paths are bounded to wp-content.
@@ -417,7 +429,11 @@ final class UpdateCommand implements CommandInterface
                     // Short-circuits on $applied['ok'] === false, matching
                     // the original intent: a genuine upgrader failure never
                     // pays for the extra WP API round trip isComplete() costs.
-                    $complete = $applied['ok'] && $this->runner->isComplete($type, $slug);
+                    // $available (the version this apply targeted) is passed
+                    // through only to enrich isComplete()'s DebugLog
+                    // diagnostic on a `false` verdict (agent-only regression
+                    // fix, 0.61.18) — it never affects the verdict itself.
+                    $complete = $applied['ok'] && $this->runner->isComplete($type, $slug, $available);
                 } catch (\Throwable $verifyError) {
                     DebugLog::write(
                         'WPMgr Agent: post-apply verification threw for ' . $type . ':' . $slug

--- a/apps/agent/includes/support/class-update-runner.php
+++ b/apps/agent/includes/support/class-update-runner.php
@@ -241,15 +241,40 @@ class UpdateRunner
      * must never cause a false rollback of a genuinely good update; a real
      * problem still surfaces through the normal apply()/currentVersion() path.
      *
-     * @param string $type plugin|theme|core.
-     * @param string $slug Sanitized slug (ignored for core).
+     * Agent-only regression fix (0.61.18) — a GOOD apply was being
+     * auto-reverted on an open_basedir/RunCloud-style host: the update files
+     * DID apply (apply() returned ok:true, no mid-copy crash), but
+     * get_plugins()'s / validate_plugin()'s internal file_exists()/
+     * is_readable() calls — and wp_get_theme()'s style.css re-read — went
+     * through a PHP stat/realpath cache entry populated BEFORE this
+     * request's non-atomic directory copy, and reported the just-swapped
+     * main file/style.css as absent even though wp_clean_plugins_cache(true)/
+     * wp_clean_themes_cache() below had already busted WordPress's OWN
+     * metadata cache — that call never touches the separate OS-level stat
+     * cache. isPluginComplete()/isThemeComplete() now call
+     * clearstatcache(true) BEFORE that re-read (see each method's own doc).
+     * This can only ever turn a false "missing" into an accurate "present";
+     * a genuinely missing/truncated file still reads missing afterwards, so
+     * it cannot mask a real half-write, and the removed vendor/autoload.php
+     * sub-check above stays removed — no narrowing of half-write detection.
+     * Every `false` verdict is now also instrumented via DebugLog with the
+     * concrete failure reason plus a raw, cache-bypassing on-disk version
+     * read, so a future occurrence is diagnosable from one log line instead
+     * of guessed at again.
+     *
+     * @param string $type            plugin|theme|core.
+     * @param string $slug            Sanitized slug (ignored for core).
+     * @param string $expectedVersion Version the apply targeted, used only to
+     *                                enrich the DebugLog diagnostic on a
+     *                                `false` verdict ('' when unknown); never
+     *                                affects the return value.
      * @return bool
      */
-    public function isComplete(string $type, string $slug): bool
+    public function isComplete(string $type, string $slug, string $expectedVersion = ''): bool
     {
         return match ($type) {
-            'plugin' => $this->isPluginComplete($slug),
-            'theme'  => $this->isThemeComplete($slug),
+            'plugin' => $this->isPluginComplete($slug, $expectedVersion),
+            'theme'  => $this->isThemeComplete($slug, $expectedVersion),
             default  => true,
         };
     }
@@ -257,15 +282,35 @@ class UpdateRunner
     /**
      * Plugin half of isComplete(). See isComplete()'s doc for the rationale.
      *
-     * @param string $slug Sanitized plugin basename or folder.
+     * Agent-only regression fix (0.61.18) — clearstatcache(true) runs FIRST,
+     * before wp_clean_plugins_cache()/get_plugins()/validate_plugin() re-read
+     * the just-swapped directory. wp_clean_plugins_cache() only busts
+     * WordPress's OWN metadata cache; get_plugins()'s and validate_plugin()'s
+     * underlying file_exists()/is_readable() calls still go through PHP's
+     * separate OS-level stat/realpath cache, which install_package()'s
+     * non-atomic copy can leave stale for the exact file it just wrote — the
+     * false "incomplete" symptom reported on open_basedir/RunCloud-style
+     * hosts. No filename is passed to clearstatcache() here because the
+     * exact swapped path isn't known until get_plugins() resolves
+     * `$basename` a few lines down (a renamed main file resolves only by
+     * FOLDER — see S6 below); a full clear is a single cheap op run once per
+     * applied item, not a hot loop.
+     *
+     * @param string $slug            Sanitized plugin basename or folder.
+     * @param string $expectedVersion Version the apply targeted, for the
+     *                                DebugLog diagnostic only ('' when
+     *                                unknown); never affects the verdict.
      * @return bool
      */
-    private function isPluginComplete(string $slug): bool
+    private function isPluginComplete(string $slug, string $expectedVersion = ''): bool
     {
         $this->loadPluginApi();
         if (!function_exists('get_plugins') || !function_exists('validate_plugin')) {
             return true;
         }
+
+        // Agent-only regression fix (0.61.18) — see this method's class doc.
+        clearstatcache(true);
 
         if (function_exists('wp_clean_plugins_cache')) {
             // The main plugin file may have just been rewritten; force a
@@ -304,12 +349,39 @@ class UpdateRunner
 
         if ($basename === '') {
             // get_plugins() no longer resolves this slug to any header at
-            // all — the classic half-written-main-file symptom.
+            // all EVEN AFTER the clearstatcache()+wp_clean_plugins_cache()
+            // above — the genuine half-written-main-file symptom, not a
+            // stale-cache artifact.
+            DebugLog::write(
+                'WPMgr Agent: isComplete(plugin) => INCOMPLETE for "' . $slug . '"'
+                . ' | reason: basename-unresolved (no get_plugins() entry under'
+                . ' this slug or its folder, even after clearstatcache()+wp_clean_plugins_cache())'
+                . ' | ' . $this->pluginOnDiskDiagnostic($slug, $expectedVersion)
+            );
             return false;
+        }
+
+        if (function_exists('opcache_invalidate')) {
+            // Guarded: not every host runs OPcache. Harmless for the header
+            // re-read above (get_plugins()/validate_plugin() parse the file
+            // directly; they never `include`/`require` it) and correct for
+            // the reactivation include_once() a successful apply performs
+            // afterward — an in-place-overwritten main file could otherwise
+            // still execute stale cached bytecode there.
+            $mainFilePath = $this->pluginMainFilePath($basename);
+            if ($mainFilePath !== '') {
+                @opcache_invalidate($mainFilePath, true); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort opcode-cache bust; @-guarded so an open_basedir host can never warn/fatal here
+            }
         }
 
         $result = validate_plugin($basename);
         if (is_wp_error($result)) {
+            DebugLog::write(
+                'WPMgr Agent: isComplete(plugin) => INCOMPLETE for "' . $basename . '"'
+                . ' | reason: validate_plugin(): ' . $result->get_error_message()
+                . ' (after clearstatcache()+wp_clean_plugins_cache())'
+                . ' | ' . $this->pluginOnDiskDiagnostic($slug, $expectedVersion)
+            );
             return false;
         }
 
@@ -318,6 +390,67 @@ class UpdateRunner
         // REMOVED entirely; see this method's class doc (isComplete()) for
         // why. validate_plugin() succeeding is the whole signal.
         return true;
+    }
+
+    /**
+     * Absolute path to a resolved plugin basename's main file, for the
+     * opcode-cache bust in isPluginComplete(). Returns '' when WP_PLUGIN_DIR
+     * isn't defined (never the case in a real WordPress load).
+     *
+     * @param string $basename Resolved "folder/main-file.php" plugin basename.
+     * @return string
+     */
+    private function pluginMainFilePath(string $basename): string
+    {
+        $pluginDir = defined('WP_PLUGIN_DIR') ? (string) constant('WP_PLUGIN_DIR') : '';
+        return $pluginDir === '' ? '' : rtrim($pluginDir, '/\\') . '/' . $basename;
+    }
+
+    /**
+     * Diagnostic-only, best-effort RAW on-disk read of a plugin main file's
+     * Version header, entirely independent of get_plugins()/validate_plugin()
+     * — and therefore of whatever cache state THEY just saw — so a single
+     * DebugLog line recording an isComplete()=false verdict is enough to tell
+     * a stale-cache false negative (file present, at the expected version,
+     * on disk) apart from a genuine half-write (file missing or short)
+     * without guessing. Never throws and never affects the return value
+     * above; every filesystem touch is @-suppressed so an
+     * open_basedir-restricted probe can never warn/fatal here.
+     *
+     * @param string $slug            Sanitized plugin basename or folder.
+     * @param string $expectedVersion Version the apply targeted ('' when unknown).
+     * @return string Diagnostic fragment (never empty).
+     */
+    private function pluginOnDiskDiagnostic(string $slug, string $expectedVersion): string
+    {
+        $expected = $expectedVersion !== '' ? $expectedVersion : 'unknown';
+
+        $pluginDir = defined('WP_PLUGIN_DIR') ? (string) constant('WP_PLUGIN_DIR') : '';
+        if ($pluginDir === '' || !function_exists('get_plugin_data')) {
+            return 'on-disk read unavailable (expected version ' . $expected . ')';
+        }
+
+        // Best-effort candidate: the slug as given when it already looks
+        // like a "folder/file.php" basename, else guess the conventional
+        // "folder/folder.php" main-file name. Diagnostic-only — a wrong
+        // guess just yields "not found", itself a true (if less specific)
+        // signal; it never flips the actual isComplete() verdict above.
+        $candidate = str_contains($slug, '/') ? $slug : ($slug . '/' . $slug . '.php');
+        $path      = rtrim($pluginDir, '/\\') . '/' . $candidate;
+
+        clearstatcache(true, $path);
+
+        if (!@is_readable($path)) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort diagnostic probe on a guessed candidate path that may legitimately not exist; must never warn/fatal under open_basedir
+            return 'on-disk main file NOT found at "' . $candidate . '" (expected version ' . $expected . ')';
+        }
+
+        $data   = @get_plugin_data($path, false, false); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort raw header parse for a diagnostic log line only; must never warn/fatal under open_basedir
+        $onDisk = is_array($data) && isset($data['Version']) && $data['Version'] !== ''
+            ? (string) $data['Version']
+            : 'unreadable';
+
+        return 'on-disk main file present at "' . $candidate . '", raw Version header: ' . $onDisk
+            . ' (expected ' . $expected . ')';
     }
 
     /**
@@ -342,14 +475,25 @@ class UpdateRunner
     /**
      * Theme half of isComplete(). See isComplete()'s doc for the rationale.
      *
-     * @param string $slug Sanitized theme stylesheet.
+     * Agent-only regression fix (0.61.18) — same stale-stat-cache false
+     * negative as isPluginComplete(), same fix: clearstatcache(true) runs
+     * BEFORE wp_clean_themes_cache()/wp_get_theme() re-read the just-swapped
+     * style.css. See isPluginComplete()'s doc for the full rationale.
+     *
+     * @param string $slug            Sanitized theme stylesheet.
+     * @param string $expectedVersion Version the apply targeted, for the
+     *                                DebugLog diagnostic only ('' when
+     *                                unknown); never affects the verdict.
      * @return bool
      */
-    private function isThemeComplete(string $slug): bool
+    private function isThemeComplete(string $slug, string $expectedVersion = ''): bool
     {
         if (!function_exists('wp_get_theme')) {
             return true;
         }
+
+        // Agent-only regression fix (0.61.18) — see this method's class doc.
+        clearstatcache(true);
 
         if (function_exists('wp_clean_themes_cache')) {
             wp_clean_themes_cache();
@@ -360,12 +504,65 @@ class UpdateRunner
             return true;
         }
 
+        if (function_exists('opcache_invalidate') && function_exists('get_theme_root')) {
+            // Guarded/best-effort, mirroring isPluginComplete(); style.css is
+            // never `include`d so this is defensive rather than required.
+            $styleCss = rtrim((string) get_theme_root($slug), '/\\') . '/' . $slug . '/style.css';
+            @opcache_invalidate($styleCss, true); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort opcode-cache bust; @-guarded so an open_basedir host can never warn/fatal here
+        }
+
         // A half-written theme (style.css truncated or its header block
         // corrupted mid-copy) reads back with an empty Name — the same
         // signal WordPress itself treats as "this is not a valid theme".
         $name = (string) $theme->get('Name');
+        if ($name === '') {
+            DebugLog::write(
+                'WPMgr Agent: isComplete(theme) => INCOMPLETE for "' . $slug . '"'
+                . ' | reason: empty-style-name (after clearstatcache()+wp_clean_themes_cache())'
+                . ' | ' . $this->themeOnDiskDiagnostic($slug, $expectedVersion)
+            );
+            return false;
+        }
 
-        return $name !== '';
+        return true;
+    }
+
+    /**
+     * Diagnostic-only, best-effort RAW on-disk read of a theme's style.css
+     * headers, independent of wp_get_theme()'s cache. See
+     * pluginOnDiskDiagnostic()'s doc for the full rationale — same purpose,
+     * theme-side. Never throws and never affects the return value above;
+     * every filesystem touch is @-suppressed so an open_basedir-restricted
+     * probe can never warn/fatal here.
+     *
+     * @param string $slug            Sanitized theme stylesheet.
+     * @param string $expectedVersion Version the apply targeted ('' when unknown).
+     * @return string Diagnostic fragment (never empty).
+     */
+    private function themeOnDiskDiagnostic(string $slug, string $expectedVersion): string
+    {
+        $expected = $expectedVersion !== '' ? $expectedVersion : 'unknown';
+
+        if (!function_exists('get_theme_root') || !function_exists('get_file_data')) {
+            return 'on-disk read unavailable (expected version ' . $expected . ')';
+        }
+
+        $path = rtrim((string) get_theme_root($slug), '/\\') . '/' . $slug . '/style.css';
+        clearstatcache(true, $path);
+
+        if (!@is_readable($path)) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort diagnostic probe; must never warn/fatal under open_basedir
+            return 'on-disk style.css NOT found at "' . $slug . '/style.css" (expected version ' . $expected . ')';
+        }
+
+        $headers = @get_file_data($path, ['Version' => 'Version', 'Name' => 'Theme Name']); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort raw header parse for a diagnostic log line only; must never warn/fatal under open_basedir
+        $onDiskVersion   = is_array($headers) && isset($headers['Version']) && $headers['Version'] !== ''
+            ? (string) $headers['Version']
+            : 'unreadable';
+        $onDiskNameEmpty = !is_array($headers) || !isset($headers['Name']) || $headers['Name'] === '';
+
+        return 'on-disk style.css present, raw Version header: ' . $onDiskVersion
+            . ', raw Name header ' . ($onDiskNameEmpty ? 'EMPTY' : 'present')
+            . ' (expected version ' . $expected . ')';
     }
 
     /**

--- a/apps/agent/patchwork.json
+++ b/apps/agent/patchwork.json
@@ -6,6 +6,9 @@
     "http_response_code",
     "header",
     "headers_sent",
-    "realpath"
+    "realpath",
+    "clearstatcache",
+    "is_readable",
+    "opcache_invalidate"
   ]
 }

--- a/apps/agent/tests/UpdateCommandTest.php
+++ b/apps/agent/tests/UpdateCommandTest.php
@@ -122,7 +122,7 @@ final class UpdateCommandTest extends TestCase
                 return false;
             }
 
-            public function isComplete(string $type, string $slug): bool
+            public function isComplete(string $type, string $slug, string $expectedVersion = ''): bool
             {
                 $this->completeChecked[] = [$type, $slug];
 
@@ -1010,7 +1010,7 @@ final class UpdateCommandTest extends TestCase
                 return ['ok' => true, 'log' => 'applied'];
             }
 
-            public function isComplete(string $type, string $slug): bool
+            public function isComplete(string $type, string $slug, string $expectedVersion = ''): bool
             {
                 return true;
             }
@@ -1056,7 +1056,7 @@ final class UpdateCommandTest extends TestCase
                 return ['ok' => true, 'log' => 'applied'];
             }
 
-            public function isComplete(string $type, string $slug): bool
+            public function isComplete(string $type, string $slug, string $expectedVersion = ''): bool
             {
                 throw new \RuntimeException('simulated isComplete() blow-up');
             }
@@ -1396,7 +1396,7 @@ final class UpdateCommandTest extends TestCase
                 return ['ok' => true, 'log' => 'applied'];
             }
 
-            public function isComplete(string $type, string $slug): bool
+            public function isComplete(string $type, string $slug, string $expectedVersion = ''): bool
             {
                 return true;
             }

--- a/apps/agent/tests/UpdateInFlightTest.php
+++ b/apps/agent/tests/UpdateInFlightTest.php
@@ -134,7 +134,7 @@ final class UpdateInFlightTest extends TestCase
             {
             }
 
-            public function isComplete(string $type, string $slug): bool
+            public function isComplete(string $type, string $slug, string $expectedVersion = ''): bool
             {
                 return $this->complete;
             }

--- a/apps/agent/tests/UpdateRunnerCompletenessTest.php
+++ b/apps/agent/tests/UpdateRunnerCompletenessTest.php
@@ -217,4 +217,167 @@ final class UpdateRunnerCompletenessTest extends TestCase
 
         $this->assertTrue($runner->isComplete('plugin', 'akismet/akismet.php'));
     }
+
+    // =========================================================================
+    // Agent-only regression fix (0.61.18) — stale post-apply stat/realpath
+    // cache false-negative on open_basedir/RunCloud-style hosts. See
+    // UpdateRunner::isComplete()'s class doc for the full symptom/fix.
+    // =========================================================================
+
+    /**
+     * PROOF: a GOOD apply must no longer be reported incomplete just because
+     * the OS-level stat/realpath cache still holds the pre-apply directory
+     * listing. validate_plugin() is faked to return a WP_Error (the exact
+     * "stale cache reads the just-swapped main file as absent" symptom)
+     * UNTIL clearstatcache() has actually run, proving both the outcome
+     * (isComplete() === true) and the ORDER (clearstatcache() must run
+     * BEFORE the validate_plugin() re-read, not merely somewhere in the
+     * method) — a fix that busted the cache only AFTER this read would still
+     * observe the stale WP_Error here and fail this assertion.
+     */
+    public function test_stale_stat_cache_post_apply_still_reports_complete(): void
+    {
+        // Shared mutable flag. $cacheState is an object, so every closure
+        // below that captures it by VALUE still shares the same underlying
+        // instance (PHP object handles), no by-reference capture needed.
+        $cacheState = new class {
+            public bool $cleared = false;
+        };
+
+        Functions\when('clearstatcache')->alias(function () use ($cacheState) {
+            $cacheState->cleared = true;
+        });
+        Functions\when('get_plugins')->justReturn([
+            'demo/demo.php' => ['Name' => 'Demo', 'Version' => '2.0'],
+        ]);
+        Functions\when('wp_clean_plugins_cache')->justReturn(null);
+        Functions\when('validate_plugin')->alias(function () use ($cacheState) {
+            if (!$cacheState->cleared) {
+                return new \WP_Error('plugin_not_found', 'stale stat cache: main file not found.');
+            }
+
+            return 0;
+        });
+
+        $runner = new UpdateRunner();
+
+        $this->assertTrue(
+            $runner->isComplete('plugin', 'demo/demo.php'),
+            'clearstatcache() must run BEFORE validate_plugin() so a stale post-apply stat cache never produces a false incomplete verdict'
+        );
+        $this->assertTrue(
+            $cacheState->cleared,
+            'precondition: clearstatcache() must actually run as part of isComplete()'
+        );
+    }
+
+    /**
+     * ADVERSARIAL GUARD: the clearstatcache() fix must NOT weaken half-write
+     * detection into ignoring a real partial write. Unlike the stale-cache
+     * test above, validate_plugin() genuinely fails on EVERY call — cache-bust
+     * or not — the real symptom this check exists to catch.
+     */
+    public function test_genuinely_missing_main_file_still_reports_incomplete(): void
+    {
+        Functions\when('clearstatcache')->justReturn(null);
+        Functions\when('get_plugins')->justReturn([
+            'demo/demo.php' => ['Name' => 'Demo', 'Version' => '2.0'],
+        ]);
+        Functions\when('wp_clean_plugins_cache')->justReturn(null);
+        Functions\when('validate_plugin')->justReturn(
+            new \WP_Error('plugin_not_found', 'main file genuinely missing on disk.')
+        );
+
+        $runner = new UpdateRunner();
+
+        $this->assertFalse(
+            $runner->isComplete('plugin', 'demo/demo.php'),
+            'ADVERSARIAL: clearstatcache() must not mask a GENUINE half-write — validate_plugin() failing even after the cache-bust must still report incomplete'
+        );
+    }
+
+    // =========================================================================
+    // Theme parity — the same clearstatcache() fix, theme-side.
+    // =========================================================================
+
+    public function test_theme_truncated_style_css_still_reports_incomplete_after_cache_bust(): void
+    {
+        Functions\when('clearstatcache')->justReturn(null);
+        Functions\when('wp_clean_themes_cache')->justReturn(null);
+
+        // A genuinely truncated style.css (corrupted mid-copy) reads back
+        // with an empty Name even after the cache-bust — must still be
+        // reported incomplete, not masked.
+        $theme = new class {
+            public function get(string $key): string
+            {
+                return '';
+            }
+        };
+        Functions\when('wp_get_theme')->justReturn($theme);
+
+        $runner = new UpdateRunner();
+
+        $this->assertFalse(
+            $runner->isComplete('theme', 'broken-theme'),
+            'ADVERSARIAL: a genuinely truncated style.css must still report incomplete after the cache-bust'
+        );
+    }
+
+    public function test_theme_good_update_reports_complete_after_cache_bust(): void
+    {
+        Functions\when('clearstatcache')->justReturn(null);
+        Functions\when('wp_clean_themes_cache')->justReturn(null);
+
+        $theme = new class {
+            public function get(string $key): string
+            {
+                return $key === 'Name' ? 'Good Theme' : '2.0';
+            }
+        };
+        Functions\when('wp_get_theme')->justReturn($theme);
+
+        $runner = new UpdateRunner();
+
+        $this->assertTrue($runner->isComplete('theme', 'good-theme'));
+    }
+
+    /** Theme-side parity to test_stale_stat_cache_post_apply_still_reports_complete(). */
+    public function test_theme_stale_stat_cache_post_apply_still_reports_complete(): void
+    {
+        $cacheState = new class {
+            public bool $cleared = false;
+        };
+
+        Functions\when('clearstatcache')->alias(function () use ($cacheState) {
+            $cacheState->cleared = true;
+        });
+        Functions\when('wp_clean_themes_cache')->justReturn(null);
+
+        $theme = new class ($cacheState) {
+            public function __construct(private object $cacheState)
+            {
+            }
+
+            public function get(string $key): string
+            {
+                if (!$this->cacheState->cleared) {
+                    // The stale-cache symptom: an empty Name as if the
+                    // header hadn't landed yet.
+                    return '';
+                }
+
+                return $key === 'Name' ? 'Good Theme' : '2.0';
+            }
+        };
+        Functions\when('wp_get_theme')->justReturn($theme);
+
+        $runner = new UpdateRunner();
+
+        $this->assertTrue(
+            $runner->isComplete('theme', 'good-theme'),
+            'theme parity: clearstatcache() must run BEFORE wp_get_theme()\'s re-read too'
+        );
+        $this->assertTrue($cacheState->cleared);
+    }
 }

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.17
+ * Version:           0.61.18
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.17');
+define('WPMGR_AGENT_VERSION', '0.61.18');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 


### PR DESCRIPTION
Follow-up to 0.61.17. Updates now apply but were auto-restored on open_basedir hosts because isComplete() read a stale PHP stat cache (busted WP's plugin cache but not clearstatcache) and saw the just-updated file as missing. Fix: clearstatcache + guarded opcache_invalidate before the completeness re-read (can't mask a real half-write, proven adversarially) + instrument the previously-silent false path. Security review SHIP. 2499 tests + plugin check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU