### PR TITLE
fix(agent): #182 null-package TypeError in self-update hooks + surface update reason in CP (0.61.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.46] - 2026-07-08
+
+### Fixed
+
+- A WordPress dashboard bulk update could fatal error and strand the whole site in maintenance mode when it included a premium plugin that manages its own updates (agent 0.61.19, GitHub issue #182). The agent's self-update integration hooks into a shared WordPress filter that runs for every plugin and theme download, and some premium plugins legitimately leave that download's package location empty until their own license check succeeds; the agent's code was not written to expect that and crashed instead of skipping the download. It now recognizes and skips any download that is not its own, leaving WordPress to continue handling the other plugin normally. The agent's own signed, verified self-update path is unaffected.
+- When a plugin or theme update is applied but then detected as incomplete and automatically rolled back, the control plane's "View logs" now shows the specific reason (for example, the installed files did not validate, or the update package never actually landed) instead of only recording it in a debug log most users never see.
+
 ## [0.61.45] - 2026-07-08
 
 ### Fixed

--- a/apps/agent/includes/commands/class-update-command.php
+++ b/apps/agent/includes/commands/class-update-command.php
@@ -88,6 +88,19 @@
  *     apply targeted) through as an optional third argument purely so a
  *     `false` verdict's DebugLog line can report the expected-vs-on-disk
  *     version — it never influences the verdict.
+ *   - Failure-reason visibility fix (agent-only, 0.61.19, GitHub issue #182's
+ *     sibling fix): the concrete reason UpdateRunner::isComplete() decided
+ *     `false` (validate_plugin() error / basename-unresolved / empty-style-
+ *     name, plus the raw on-disk-version-vs-expected diagnostic) used to be
+ *     written ONLY to DebugLog, which is a silent no-op without WPMGR_DEBUG —
+ *     an operator watching the control plane's "View logs" for a rolled-back
+ *     item saw nothing more specific than "Update incomplete; auto-restored
+ *     the pre-update snapshot." UpdateRunner::lastIncompleteReason() now
+ *     exposes that same text; this method appends it (read ONLY immediately
+ *     after an isComplete() call that itself returned false — never
+ *     unconditionally, so a stale reason from an earlier item can never leak)
+ *     to the rollback log line below. Concise and non-secret (slug/version/WP
+ *     error message only); never changes the boolean gate semantics above.
  *
  * Every input is treated as untrusted: type is whitelisted, slug is sanitized to
  * reject path traversal, and snapshot paths are bounded to wp-content.
@@ -422,18 +435,31 @@ final class UpdateCommand implements CommandInterface
                 // The CP's own post-update health probe remains the backstop
                 // for a genuinely bad apply that happens to also break
                 // verification.
-                $toVersion = $fromVersion;
-                $complete  = false;
+                $toVersion        = $fromVersion;
+                $complete         = false;
+                // GitHub issue #182's sibling visibility fix (agent-only,
+                // 0.61.19): the concrete reason isComplete() decided `false`,
+                // read ONLY immediately after a call that itself returned
+                // false — see UpdateRunner::lastIncompleteReason()'s doc for
+                // why this must never be read unconditionally.
+                $incompleteReason = '';
                 try {
                     $toVersion = $this->runner->currentVersion($type, $slug);
-                    // Short-circuits on $applied['ok'] === false, matching
-                    // the original intent: a genuine upgrader failure never
-                    // pays for the extra WP API round trip isComplete() costs.
+                    // Preserves the original short-circuit intent (a genuine
+                    // upgrader failure never pays for the extra WP API round
+                    // trip isComplete() costs), but as an explicit `if` rather
+                    // than `&&` so lastIncompleteReason() is only ever read
+                    // right after an isComplete() call that actually ran.
                     // $available (the version this apply targeted) is passed
-                    // through only to enrich isComplete()'s DebugLog
-                    // diagnostic on a `false` verdict (agent-only regression
-                    // fix, 0.61.18) — it never affects the verdict itself.
-                    $complete = $applied['ok'] && $this->runner->isComplete($type, $slug, $available);
+                    // through only to enrich isComplete()'s diagnostic on a
+                    // `false` verdict (agent-only regression fix, 0.61.18) —
+                    // it never affects the verdict itself.
+                    if ($applied['ok']) {
+                        $complete = $this->runner->isComplete($type, $slug, $available);
+                        if (!$complete) {
+                            $incompleteReason = $this->runner->lastIncompleteReason();
+                        }
+                    }
                 } catch (\Throwable $verifyError) {
                     DebugLog::write(
                         'WPMgr Agent: post-apply verification threw for ' . $type . ':' . $slug
@@ -473,6 +499,17 @@ final class UpdateCommand implements CommandInterface
                     return $this->result($type, $slug, $fromVersion, $toVersion, $status, $snapshotId, $log);
                 }
 
+                // GitHub issue #182's sibling visibility fix (agent-only,
+                // 0.61.19): append the concrete isComplete() reason — the same
+                // facts UpdateRunner already writes to DebugLog — to the
+                // CP-visible item log below, so "View logs" explains WHY an
+                // apply that reported success was still rolled back, without
+                // requiring WPMGR_DEBUG. Empty when the incompleteness came
+                // from $applied['ok'] === false instead (that case already has
+                // its own descriptive $applied['log'] appended above) or when
+                // isComplete() itself threw (S7; never treated as incomplete).
+                $reasonSuffix = $incompleteReason !== '' ? ' Reason: ' . $incompleteReason . '.' : '';
+
                 // Incomplete or failed apply: roll back synchronously right
                 // now rather than waiting on the shutdown backstop, so the
                 // directory is restored before we even respond to the
@@ -483,15 +520,15 @@ final class UpdateCommand implements CommandInterface
                     $restore = $guard->fire();
                     if ($restore['fired']) {
                         $log .= "\n" . ($restore['ok']
-                            ? 'Update incomplete; auto-restored the pre-update snapshot.'
-                            : 'Update incomplete; auto-restore FAILED: ' . $restore['log']);
+                            ? 'Update incomplete; auto-restored the pre-update snapshot.' . $reasonSuffix
+                            : 'Update incomplete; auto-restore FAILED: ' . $restore['log'] . $reasonSuffix);
                         // Re-read the version now the directory should be
                         // back to its pre-update state, so the response
                         // reflects what is actually on disk.
                         $toVersion = $this->runner->currentVersion($type, $slug);
                     }
                 } else {
-                    $log .= "\nUpdate incomplete; no pre-update snapshot was available to auto-restore.";
+                    $log .= "\nUpdate incomplete; no pre-update snapshot was available to auto-restore." . $reasonSuffix;
                 }
 
                 return $this->result($type, $slug, $fromVersion, $toVersion, 'failed', $snapshotId, $log);

--- a/apps/agent/includes/support/class-update-checker.php
+++ b/apps/agent/includes/support/class-update-checker.php
@@ -719,16 +719,40 @@ final class UpdateChecker
      * Any failure returns a WP_Error (visible to the operator; aborts the install).
      * On sha256 mismatch the temp file is unlinked before returning.
      *
-     * @param mixed  $reply      Current reply (false = not handled yet).
-     * @param string $package    Package URL or sentinel from the transient.
-     * @param mixed  $upgrader   WP_Upgrader instance (filter arg 3; unused).
-     * @param mixed  $hook_extra Extra info from WP_Upgrader (array with 'plugin' key;
-     *                           absent on WP < 5.5, hence nullable + the sentinel
-     *                           fallback below).
+     * @param mixed       $reply      Current reply (false = not handled yet).
+     * @param string|null $package    Package URL or sentinel from the transient.
+     *                                WP core passes null (or occasionally false)
+     *                                whenever the current update-transient row for
+     *                                SOME OTHER plugin/theme has no ->package at
+     *                                all — see the is_string() guard below.
+     * @param mixed       $upgrader   WP_Upgrader instance (filter arg 3; unused).
+     * @param mixed       $hook_extra Extra info from WP_Upgrader (array with 'plugin' key;
+     *                                absent on WP < 5.5, hence nullable + the sentinel
+     *                                fallback below).
      * @return mixed Local temp path (string), WP_Error, or $reply untouched.
      */
-    public function verifyDownload($reply, string $package, $upgrader = null, $hook_extra = null)
+    public function verifyDownload($reply, $package, $upgrader = null, $hook_extra = null)
     {
+        // upgrader_pre_download is a GLOBAL filter — install()'s add_filter()
+        // registers this method for EVERY plugin/theme download, not only our
+        // own. WP core calls apply_filters('upgrader_pre_download', false,
+        // null, ...) whenever the CURRENT update-transient row has no
+        // ->package at all, which is legitimate for premium plugins that run
+        // their own updater (e.g. one that leaves ->package unset until a
+        // license check succeeds). $package therefore arrives here as null
+        // (or occasionally false/non-string) on every such download. Bail out
+        // immediately, before hash_equals() below would otherwise be handed a
+        // non-string and fatal with a TypeError — that fatal stranded the
+        // whole bulk-update request (and the site) in maintenance mode
+        // (GitHub issue #182). is_string() (not merely !== null) also covers
+        // false/int. Return $reply UNCHANGED — never $package itself, which
+        // would make WP treat this return as a resolved local file path and
+        // break the other plugin/theme's own download — so WordPress
+        // continues its normal handling for a package that was never ours.
+        if (!is_string($package)) {
+            return $reply;
+        }
+
         // Only act on our plugin key or our sentinel package. The sentinel is the
         // primary signal (it is what we inject as ->package, and it is present on
         // every WP version); hook_extra['plugin'] is a secondary signal available
@@ -863,14 +887,29 @@ final class UpdateChecker
      * Traversal-safe: uses wp_basename() to strip any path components in the
      * source name before comparing.
      *
-     * @param string $source        Path to the extracted source directory.
-     * @param string $remote_source Path to the remote source temp dir.
-     * @param mixed  $upgrader      WP_Upgrader instance.
-     * @param mixed  $hook_extra    Extra context from WP_Upgrader.
-     * @return string Corrected source path, or original on failure.
+     * @param string|null $source        Path to the extracted source directory.
+     *                                   Like verifyDownload()'s $package, WP core
+     *                                   can hand this filter a non-string (e.g. a
+     *                                   WP_Error passed through from an earlier,
+     *                                   already-failed step) for a download this
+     *                                   method was never meant to touch — see the
+     *                                   is_string() guard below.
+     * @param string      $remote_source Path to the remote source temp dir.
+     * @param mixed       $upgrader      WP_Upgrader instance.
+     * @param mixed       $hook_extra    Extra context from WP_Upgrader.
+     * @return mixed Corrected source path (string), or $source untouched.
      */
-    public function renameSource(string $source, string $remote_source, $upgrader, $hook_extra)
+    public function renameSource($source, string $remote_source, $upgrader, $hook_extra)
     {
+        // Same strict_types(1) hazard as verifyDownload(): this is also a
+        // GLOBAL upgrader filter, so a non-string $source (e.g. a WP_Error
+        // already carried through from an earlier failed step, for a plugin
+        // this method was never meant to touch) must never reach the
+        // wp_basename()/basename() calls below. Return it untouched.
+        if (!is_string($source)) {
+            return $source;
+        }
+
         // Only act on our plugin.
         if (!is_array($hook_extra) || !isset($hook_extra['plugin'])) {
             return $source;

--- a/apps/agent/includes/support/class-update-runner.php
+++ b/apps/agent/includes/support/class-update-runner.php
@@ -20,6 +20,19 @@ namespace WPMgr\Agent\Support;
 class UpdateRunner
 {
     /**
+     * The reason the most recent isComplete() call returned false, or '' when
+     * that call returned true (or isComplete() has not been called yet).
+     * Reset to '' at the START of every isComplete() call (see that method)
+     * so a caller can never read a stale reason left over from an earlier
+     * item in the same batch/request. Populated only from the same concise,
+     * non-secret (slug/version/WP-error-message) text already written to
+     * DebugLog by isPluginComplete()/isThemeComplete() — safe to surface
+     * directly in the CP-visible per-item result log (agent-only, 0.61.19,
+     * GitHub issue #182's sibling visibility fix).
+     */
+    private string $lastIncompleteReason = '';
+
+    /**
      * Validate an untrusted version string before it reaches WP-CLI argv or an
      * upgrader offer URL. Accepts only the literal "latest" or a token that
      * starts with a digit and contains only [0-9A-Za-z.-] (no spaces, no flag
@@ -272,11 +285,32 @@ class UpdateRunner
      */
     public function isComplete(string $type, string $slug, string $expectedVersion = ''): bool
     {
+        // Reset FIRST, unconditionally — so a caller that skips reading
+        // lastIncompleteReason() after a TRUE verdict (the common case) never
+        // leaves a prior item's reason lingering for the next isComplete()
+        // call in the same batch/request to accidentally inherit.
+        $this->lastIncompleteReason = '';
+
         return match ($type) {
             'plugin' => $this->isPluginComplete($slug, $expectedVersion),
             'theme'  => $this->isThemeComplete($slug, $expectedVersion),
             default  => true,
         };
+    }
+
+    /**
+     * The reason the most recent isComplete() call returned false. See the
+     * $lastIncompleteReason property doc for the reset/lifetime contract.
+     * UpdateCommand reads this ONLY immediately after an isComplete() call
+     * that itself returned false, so a caller must never treat a non-empty
+     * value here as meaningful on its own without having just observed that.
+     *
+     * @return string Concise, non-secret reason, or '' when the most recent
+     *                 isComplete() call returned true (or was never called).
+     */
+    public function lastIncompleteReason(): string
+    {
+        return $this->lastIncompleteReason;
     }
 
     /**
@@ -352,12 +386,17 @@ class UpdateRunner
             // all EVEN AFTER the clearstatcache()+wp_clean_plugins_cache()
             // above — the genuine half-written-main-file symptom, not a
             // stale-cache artifact.
+            $diagnostic = $this->pluginOnDiskDiagnostic($slug, $expectedVersion);
             DebugLog::write(
                 'WPMgr Agent: isComplete(plugin) => INCOMPLETE for "' . $slug . '"'
                 . ' | reason: basename-unresolved (no get_plugins() entry under'
                 . ' this slug or its folder, even after clearstatcache()+wp_clean_plugins_cache())'
-                . ' | ' . $this->pluginOnDiskDiagnostic($slug, $expectedVersion)
+                . ' | ' . $diagnostic
             );
+            // Surfaced to the CP-visible item log (agent-only, 0.61.19) — same
+            // facts as the DebugLog line above, condensed for a one-line
+            // display; never depends on WPMGR_DEBUG.
+            $this->lastIncompleteReason = 'basename-unresolved (no installed plugin found for this slug); ' . $diagnostic;
             return false;
         }
 
@@ -376,12 +415,17 @@ class UpdateRunner
 
         $result = validate_plugin($basename);
         if (is_wp_error($result)) {
+            $diagnostic = $this->pluginOnDiskDiagnostic($slug, $expectedVersion);
             DebugLog::write(
                 'WPMgr Agent: isComplete(plugin) => INCOMPLETE for "' . $basename . '"'
                 . ' | reason: validate_plugin(): ' . $result->get_error_message()
                 . ' (after clearstatcache()+wp_clean_plugins_cache())'
-                . ' | ' . $this->pluginOnDiskDiagnostic($slug, $expectedVersion)
+                . ' | ' . $diagnostic
             );
+            // Surfaced to the CP-visible item log (agent-only, 0.61.19) — same
+            // facts as the DebugLog line above, condensed for a one-line
+            // display; never depends on WPMGR_DEBUG.
+            $this->lastIncompleteReason = 'validate_plugin: ' . $result->get_error_message() . '; ' . $diagnostic;
             return false;
         }
 
@@ -516,11 +560,16 @@ class UpdateRunner
         // signal WordPress itself treats as "this is not a valid theme".
         $name = (string) $theme->get('Name');
         if ($name === '') {
+            $diagnostic = $this->themeOnDiskDiagnostic($slug, $expectedVersion);
             DebugLog::write(
                 'WPMgr Agent: isComplete(theme) => INCOMPLETE for "' . $slug . '"'
                 . ' | reason: empty-style-name (after clearstatcache()+wp_clean_themes_cache())'
-                . ' | ' . $this->themeOnDiskDiagnostic($slug, $expectedVersion)
+                . ' | ' . $diagnostic
             );
+            // Surfaced to the CP-visible item log (agent-only, 0.61.19) — same
+            // facts as the DebugLog line above, condensed for a one-line
+            // display; never depends on WPMGR_DEBUG.
+            $this->lastIncompleteReason = 'empty-style-name (style.css header did not re-read); ' . $diagnostic;
             return false;
         }
 

--- a/apps/agent/tests/UpdateCheckerTest.php
+++ b/apps/agent/tests/UpdateCheckerTest.php
@@ -711,6 +711,96 @@ final class UpdateCheckerTest extends TestCase
         $this->assertFalse($result, 'verifyDownload must return $reply unchanged for other plugins.');
     }
 
+    /**
+     * GitHub issue #182 (RED before Change 1, GREEN after): upgrader_pre_download
+     * is a GLOBAL filter — WP core calls
+     * apply_filters('upgrader_pre_download', false, null, ...) whenever the
+     * CURRENT update-transient row for some OTHER plugin/theme has no
+     * ->package at all (legitimate for premium plugins running their own
+     * updater, e.g. one that leaves ->package unset until a license check
+     * succeeds). Before the is_string() guard, PHP's strict_types(1) fatales
+     * a TypeError at this call boundary — before verifyDownload()'s own
+     * self-gate could even run — which fataled the whole bulk-update request
+     * and stranded the site in maintenance mode.
+     */
+    public function test_verifyDownload_null_package_passes_through(): void
+    {
+        $checker = $this->makeChecker();
+        $reply   = false;
+
+        $result = $checker->verifyDownload($reply, null, null, ['plugin' => 'other/other.php']);
+
+        $this->assertFalse($result, 'A null $package must pass $reply through unchanged, with no TypeError.');
+    }
+
+    /**
+     * is_string() (not merely !== null) must also cover a literal `false`
+     * package value — the other shape WP core can pass through this filter.
+     */
+    public function test_verifyDownload_false_package_passes_through(): void
+    {
+        $checker = $this->makeChecker();
+
+        $result = $checker->verifyDownload(false, false, null, null);
+
+        $this->assertFalse($result, 'A false $package must pass $reply through unchanged, with no TypeError.');
+    }
+
+    /**
+     * The #182 fix must never weaken (or bypass) the self-update integrity
+     * chain: a genuine agent package (sentinel + matching sha256) must still
+     * fetch a fresh manifest and verify byte-for-byte, returning the local
+     * temp file path WP_Upgrader installs from.
+     */
+    public function test_verifyDownload_still_verifies_agent_package(): void
+    {
+        $packageContent = str_repeat('Z', 64);
+        $claims         = $this->makeClaims([
+            'version'        => '0.11.0',
+            'package_size'   => 64,
+            'package_sha256' => hash('sha256', $packageContent),
+        ]);
+        $envelope     = $this->signClaims($claims);
+        $envelopeJson = (string) json_encode($envelope);
+
+        $callCount = 0;
+        Functions\when('wp_remote_get')->alias(function (string $url, array $args = []) use ($envelopeJson, &$callCount, $packageContent) {
+            $callCount++;
+            if ($callCount === 1) {
+                // First call: the manifest endpoint.
+                return [
+                    'response' => ['code' => 200, 'message' => 'OK'],
+                    'body'     => $envelopeJson,
+                    'filename' => '',
+                ];
+            }
+            // Second call: the package download.
+            $tmpFile = $args['filename'] ?? (sys_get_temp_dir() . '/wpmgr-test-' . bin2hex(random_bytes(4)) . '.zip');
+            file_put_contents($tmpFile, $packageContent);
+            return [
+                'response' => ['code' => 200, 'message' => 'OK'],
+                'body'     => '',
+                'filename' => $tmpFile,
+            ];
+        });
+        Functions\when('wp_remote_retrieve_response_code')->alias(function ($response) {
+            return $response['response']['code'] ?? 0;
+        });
+        Functions\when('wp_remote_retrieve_body')->alias(function ($response) {
+            return $response['body'] ?? '';
+        });
+        Functions\when('is_wp_error')->justReturn(false);
+
+        $checker = $this->makeChecker();
+        $result  = $checker->verifyDownload(false, UpdateChecker::PACKAGE_SENTINEL, null, ['plugin' => UpdateChecker::PLUGIN_KEY]);
+
+        $this->assertIsString($result, 'A verified, matching-sha256 self-update package must return the local temp file path.');
+        $this->assertTrue(is_file($result));
+        $this->assertSame($packageContent, file_get_contents($result));
+
+        @unlink($result); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- test-only temp-file cleanup
+    }
+
     public function test_verifyDownload_sha256_mismatch_returns_wp_error_and_unlinks(): void
     {
         $checker = $this->makeChecker();
@@ -798,6 +888,35 @@ final class UpdateCheckerTest extends TestCase
 
         $this->assertInstanceOf(\WP_Error::class, $result);
         $this->assertSame('wpmgr_update_manifest_failed', $result->get_error_code());
+    }
+
+    // =========================================================================
+    // renameSource tests
+    // =========================================================================
+
+    /**
+     * upgrader_source_selection is also a GLOBAL filter, and can likewise
+     * receive a non-string $source (e.g. a WP_Error already carried through
+     * from an earlier failed step) for a download this method was never
+     * meant to touch — the same strict_types(1) hazard as verifyDownload().
+     */
+    public function test_renameSource_non_string_source_passes_through(): void
+    {
+        $checker = $this->makeChecker();
+        $wpError = new \WP_Error('some_error', 'unrelated failure');
+
+        $result = $checker->renameSource($wpError, '/tmp/remote', null, ['plugin' => UpdateChecker::PLUGIN_KEY]);
+
+        $this->assertSame($wpError, $result, 'A non-string (WP_Error) $source must pass through untouched, with no TypeError.');
+    }
+
+    public function test_renameSource_null_source_passes_through(): void
+    {
+        $checker = $this->makeChecker();
+
+        $result = $checker->renameSource(null, '/tmp/remote', null, null);
+
+        $this->assertNull($result, 'A null $source must pass through untouched, with no TypeError.');
     }
 
     // =========================================================================

--- a/apps/agent/tests/UpdateCommandTest.php
+++ b/apps/agent/tests/UpdateCommandTest.php
@@ -75,6 +75,21 @@ final class UpdateCommandTest extends TestCase
             public array $completeOverride = [];
             /** @var array<int,array{string,string}> Args of each isComplete() call. */
             public array $completeChecked = [];
+            /**
+             * @var array<string,string> Explicit lastIncompleteReason()
+             *     overrides, keyed "type:slug" — agent-only, 0.61.19 (GitHub
+             *     issue #182's sibling visibility fix). Absent = '' (matches
+             *     the real UpdateRunner's default when isComplete() returned
+             *     true, or was never called).
+             */
+            public array $incompleteReasonOverride = [];
+            /**
+             * The "type:slug" key of the MOST RECENT isComplete() call, so
+             * lastIncompleteReason() mirrors the real UpdateRunner's
+             * single-mutable-property semantics (the reason belongs to
+             * whichever call happened last, not to every key ever checked).
+             */
+            private string $lastCompleteCheckedKey = '';
 
             public function currentVersion(string $type, string $slug): string
             {
@@ -124,9 +139,16 @@ final class UpdateCommandTest extends TestCase
 
             public function isComplete(string $type, string $slug, string $expectedVersion = ''): bool
             {
-                $this->completeChecked[] = [$type, $slug];
+                $this->completeChecked[]      = [$type, $slug];
+                $this->lastCompleteCheckedKey = $type . ':' . $slug;
 
                 return $this->completeOverride[$type . ':' . $slug] ?? true;
+            }
+
+            /** Agent-only, 0.61.19 (GitHub issue #182's sibling visibility fix). */
+            public function lastIncompleteReason(): string
+            {
+                return $this->incompleteReasonOverride[$this->lastCompleteCheckedKey] ?? '';
             }
         };
     }
@@ -750,6 +772,90 @@ final class UpdateCommandTest extends TestCase
         );
         $this->assertCount(1, $runner->completeChecked, 'the completeness check must run for an ok:true apply');
         $this->assertCount(1, $snapshots->restored, 'a half-written apply must be auto-restored');
+    }
+
+    // ---- failure-reason visibility (agent-only, 0.61.19, GitHub issue #182's sibling fix) ----
+
+    public function test_rollback_log_surfaces_the_validate_plugin_error_reason(): void
+    {
+        // The "digits 9.1.0.5 -> 9.1.0.5 Failed + rollback" class of report:
+        // the reason UpdateRunner::isComplete() decided `false` (here, a
+        // validate_plugin() WP_Error — the new package genuinely did not
+        // land) must now reach the CP-visible item log, not just DebugLog.
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:digits/digits.php']  = '9.1.0.4';
+        $runner->available['plugin:digits/digits.php'] = '9.1.0.5';
+        $runner->completeOverride['plugin:digits/digits.php']         = false;
+        $runner->incompleteReasonOverride['plugin:digits/digits.php'] =
+            'validate_plugin: plugin file does not exist; on-disk main file present, raw Version 9.1.0.4 (expected 9.1.0.5)';
+
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'digits/digits.php', 'version' => 'latest']],
+        ]);
+
+        $r = $out['results'][0];
+        $this->assertSame('failed', $r['status']);
+        $this->assertStringContainsString(
+            'Reason: validate_plugin: plugin file does not exist',
+            $r['log'],
+            'the concrete isComplete() reason must appear in the CP-visible item log, not only DebugLog'
+        );
+        $this->assertStringContainsString('9.1.0.4', $r['log'], 'the on-disk-vs-expected diagnostic must be included');
+        $this->assertStringContainsString('9.1.0.5', $r['log']);
+    }
+
+    public function test_rollback_log_surfaces_the_basename_unresolved_reason(): void
+    {
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:ghost-plugin/ghost-plugin.php']  = '1.0.0';
+        $runner->available['plugin:ghost-plugin/ghost-plugin.php'] = '1.1.0';
+        $runner->completeOverride['plugin:ghost-plugin/ghost-plugin.php']         = false;
+        $runner->incompleteReasonOverride['plugin:ghost-plugin/ghost-plugin.php'] =
+            'basename-unresolved (no installed plugin found for this slug); on-disk main file NOT found at "ghost-plugin/ghost-plugin.php" (expected version 1.1.0)';
+
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'ghost-plugin/ghost-plugin.php', 'version' => 'latest']],
+        ]);
+
+        $r = $out['results'][0];
+        $this->assertSame('failed', $r['status']);
+        $this->assertStringContainsString(
+            'Reason: basename-unresolved',
+            $r['log'],
+            'the basename-unresolved reason must appear in the CP-visible item log'
+        );
+    }
+
+    public function test_rollback_log_has_no_reason_suffix_when_apply_itself_reported_failure(): void
+    {
+        // isComplete() is never invoked when $applied['ok'] is already false
+        // (short-circuit, unchanged) — there is no reason to surface here;
+        // $applied['log'] (already appended above) is the real explanation.
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php']  = '5.0';
+        $runner->available['plugin:akismet/akismet.php'] = '5.3';
+        $runner->applySucceeds                           = false;
+
+        $cmd = new UpdateCommand($this->spySnapshots(), $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $r = $out['results'][0];
+        $this->assertSame('failed', $r['status']);
+        $this->assertSame([], $runner->completeChecked, 'isComplete() must never be invoked after an ok:false apply');
+        $this->assertStringNotContainsString(
+            'Reason:',
+            $r['log'],
+            'no isComplete() reason exists for a genuine upgrader-reported failure'
+        );
     }
 
     public function test_verified_good_apply_is_never_rolled_back(): void

--- a/apps/agent/tests/UpdateRunnerCompletenessTest.php
+++ b/apps/agent/tests/UpdateRunnerCompletenessTest.php
@@ -201,6 +201,15 @@ final class UpdateRunnerCompletenessTest extends TestCase
         $runner = new UpdateRunner();
 
         $this->assertFalse($runner->isComplete('plugin', 'gone-plugin/gone-plugin.php'));
+        // Agent-only, 0.61.19 (GitHub issue #182's sibling visibility fix):
+        // the same reason DebugLog already recorded must now also be readable
+        // via lastIncompleteReason(), so UpdateCommand can surface it in the
+        // CP-visible item log without requiring WPMGR_DEBUG.
+        $this->assertStringContainsString(
+            'basename-unresolved',
+            $runner->lastIncompleteReason(),
+            'lastIncompleteReason() must report the basename-unresolved reason'
+        );
     }
 
     public function test_isComplete_true_for_an_exact_unchanged_basename_match(): void
@@ -293,6 +302,67 @@ final class UpdateRunnerCompletenessTest extends TestCase
         $this->assertFalse(
             $runner->isComplete('plugin', 'demo/demo.php'),
             'ADVERSARIAL: clearstatcache() must not mask a GENUINE half-write — validate_plugin() failing even after the cache-bust must still report incomplete'
+        );
+        // Agent-only, 0.61.19: the validate_plugin() WP_Error message must be
+        // reflected in lastIncompleteReason() — the concrete "why" a #144-style
+        // "Failed + rollback" item needs, without WPMGR_DEBUG.
+        $this->assertStringContainsString(
+            'validate_plugin',
+            $runner->lastIncompleteReason(),
+            'lastIncompleteReason() must report the validate_plugin() error'
+        );
+        $this->assertStringContainsString(
+            'main file genuinely missing on disk.',
+            $runner->lastIncompleteReason(),
+            'lastIncompleteReason() must include the underlying WP_Error message'
+        );
+    }
+
+    // =========================================================================
+    // lastIncompleteReason() lifecycle — agent-only, 0.61.19
+    // =========================================================================
+
+    public function test_lastIncompleteReason_is_empty_after_a_true_verdict(): void
+    {
+        Functions\when('get_plugins')->justReturn([
+            'demo/demo.php' => ['Name' => 'Demo', 'Version' => '2.0'],
+        ]);
+        Functions\when('validate_plugin')->justReturn(0);
+        Functions\when('wp_clean_plugins_cache')->justReturn(null);
+
+        $runner = new UpdateRunner();
+
+        $this->assertTrue($runner->isComplete('plugin', 'demo/demo.php'));
+        $this->assertSame('', $runner->lastIncompleteReason(), 'a TRUE verdict must never leave a stale reason behind');
+    }
+
+    public function test_lastIncompleteReason_never_leaks_across_two_isComplete_calls_on_the_same_runner(): void
+    {
+        // A single UpdateCommand::execute() batch reuses ONE UpdateRunner
+        // across every item — if isComplete() didn't reset the reason at the
+        // START of every call, a SECOND item whose apply already failed
+        // (never reaching isComplete() at all) could read the FIRST item's
+        // stale reason. This proves the reset happens unconditionally.
+        Functions\when('get_plugins')->justReturn([
+            'unrelated/unrelated.php' => ['Name' => 'Unrelated', 'Version' => '1.0'],
+        ]);
+        Functions\when('wp_clean_plugins_cache')->justReturn(null);
+
+        $runner = new UpdateRunner();
+
+        $this->assertFalse($runner->isComplete('plugin', 'gone-plugin/gone-plugin.php'));
+        $this->assertNotSame('', $runner->lastIncompleteReason(), 'precondition: the first call must have set a reason');
+
+        Functions\when('get_plugins')->justReturn([
+            'demo/demo.php' => ['Name' => 'Demo', 'Version' => '2.0'],
+        ]);
+        Functions\when('validate_plugin')->justReturn(0);
+
+        $this->assertTrue($runner->isComplete('plugin', 'demo/demo.php'));
+        $this->assertSame(
+            '',
+            $runner->lastIncompleteReason(),
+            'a subsequent TRUE verdict must clear out the previous call\'s reason, never leak it'
         );
     }
 

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.18
+ * Version:           0.61.19
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.18');
+define('WPMGR_AGENT_VERSION', '0.61.19');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 


### PR DESCRIPTION
Closes #182. verifyDownload/renameSource (global WP upgrader filters, strict_types + string param) fataled when WP passes a null package (premium plugins with no ->package URL), stranding sites in maintenance mode. Fix: is_string() guard first, before hash_equals; self-update verification unweakened (sentinel is always a string). Also surfaces the isComplete rollback reason into the CP View logs (was DebugLog-only). Security review SHIP. 2509 tests + plugin check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bulk plugin/theme updates so they no longer fail or leave sites in maintenance mode when an update package is temporarily unavailable.
  * Improved rollback messaging so the “View logs” screen now shows the actual reason an update was marked incomplete, instead of only keeping it in debug logs.
  * Improved update handling for unusual update responses, reducing the chance of type-related failures during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->