### PR TITLE
fix(agent): updates no longer break on hosts where wp-content/upgrade isn't writable (0.61.20) + show agent log in CP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.47] - 2026-07-08
+
+### Fixed
+
+- Plugin and theme updates could fail and automatically roll back on some hosts, even though the same updates worked before a recent hardening change (agent 0.61.20). That change started pinning WordPress's temporary download/unpack directory to a folder inside the site's own wp-content directory, to keep updates working on hosts that restrict the system-wide temp location. On a host where that wp-content folder exists but is not actually writable in the context the update runs in (for example some open_basedir or managed-hosting setups), the pin itself broke the download and unpack step for every plugin and theme update, including free and premium plugins alike. The agent now only applies that pin when the folder is confirmed writable; otherwise it leaves WordPress to fall back to its own default temporary location, restoring the behavior that worked on this class of host before the change. Hosts where the folder is writable are unaffected.
+- The update run detail now shows the full agent log for a failed or rolled-back task. Previously the reason an update was reverted was clipped to a short preview and effectively hidden; each failed task now has a "View log" toggle that reveals the complete agent diagnostic (including the exact reason and the on-disk version it found), and a button to copy it.
+
 ## [0.61.46] - 2026-07-08
 
 ### Fixed

--- a/apps/agent/includes/support/class-update-runner.php
+++ b/apps/agent/includes/support/class-update-runner.php
@@ -790,22 +790,11 @@ class UpdateRunner
     {
         $this->loadUpgraderApi();
 
-        // B3 (GitHub issue #131) — harden the unpack directory. WordPress's
-        // own temp-directory resolution (get_temp_dir(), used by
-        // WP_Filesystem_*::unzip_file()/wp_tempnam() when WP_TEMP_DIR is
-        // undefined) falls through to sys_get_temp_dir() / upload_tmp_dir on
-        // a locked-down host, which can sit OUTSIDE open_basedir and fail
-        // silently there. wp-content/upgrade is always inside the site's own
-        // writable tree, so pin WP_TEMP_DIR to it explicitly rather than
-        // trusting that fallback.
-        $upgradeDir = defined('WP_CONTENT_DIR') ? rtrim((string) WP_CONTENT_DIR, '/\\') . '/upgrade' : '';
-        if ($upgradeDir !== '' && !is_dir($upgradeDir) && function_exists('wp_mkdir_p')) {
-            wp_mkdir_p($upgradeDir);
-        }
-        if ($upgradeDir !== '' && is_dir($upgradeDir) && !defined('WP_TEMP_DIR')) {
-            // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- WP_TEMP_DIR is a documented, overridable WordPress core constant (wp-admin/includes/file.php get_temp_dir()), not a constant of our own; it is simply missing from this sniff's hardcoded allowed_core_constants list
-            define('WP_TEMP_DIR', $upgradeDir);
-        }
+        // B3 (GitHub issue #131), revised (agent-only regression fix, 0.61.20
+        // — GitHub issue #131 follow-up): see pinTempDirForUnpack()'s doc for
+        // why this is now conditional on WRITABILITY, not merely existence.
+        $tempDirNote = $this->pinTempDirForUnpack();
+        DebugLog::write('WPMgr Agent: applyViaUpgrader() ' . $tempDirNote);
 
         if (function_exists('wp_update_plugins') && $type === 'plugin') {
             wp_update_plugins();
@@ -829,6 +818,12 @@ class UpdateRunner
         add_filter('upgrader_package_options', $forceCleanWorking);
 
         try {
+            // Set by whichever case below actually ran an upgrade; used after
+            // the switch to prefix the CP-visible log with $tempDirNote
+            // (agent-only, 0.61.20) and as the switch's fallthrough guard —
+            // stays null only when $type matched none of the cases.
+            $outcome = null;
+
             switch ($type) {
                 case 'plugin':
                     if (!class_exists('\Plugin_Upgrader') || !class_exists('\WP_Ajax_Upgrader_Skin')) {
@@ -873,7 +868,7 @@ class UpdateRunner
                         }
                     }
 
-                    return $outcome;
+                    break;
 
                 case 'theme':
                     if (!class_exists('\Theme_Upgrader') || !class_exists('\WP_Ajax_Upgrader_Skin')) {
@@ -886,16 +881,107 @@ class UpdateRunner
                         Maintenance::clear($upgrader);
                     }
 
-                    return $this->upgraderOutcome($result);
+                    $outcome = $this->upgraderOutcome($result);
+                    break;
 
                 case 'core':
-                    return $this->applyCoreUpgrade($version);
+                    $outcome = $this->applyCoreUpgrade($version);
+                    break;
             }
 
-            return ['ok' => false, 'log' => 'Unsupported type.'];
+            if ($outcome === null) {
+                return ['ok' => false, 'log' => 'Unsupported type.'];
+            }
+
+            // Agent-only, 0.61.20 — surface the temp-dir decision in the
+            // SAME log the CP shows for this item, not just DebugLog (which
+            // is silent unless WPMGR_DEBUG/WP_DEBUG_LOG is on). Prefixed so
+            // it reads first, ahead of whatever the upgrade itself logged.
+            if ($tempDirNote !== '') {
+                $outcome['log'] = '[wpmgr] ' . $tempDirNote
+                    . ($outcome['log'] !== '' ? "\n" . $outcome['log'] : '');
+            }
+
+            return $outcome;
         } finally {
             remove_filter('upgrader_package_options', $forceCleanWorking);
         }
+    }
+
+    /**
+     * Decide whether to pin WP_TEMP_DIR to wp-content/upgrade for THIS
+     * apply, and do so only when that directory is actually usable in this
+     * request's execution context.
+     *
+     * B3 (GitHub issue #131) pinned WP_TEMP_DIR to wp-content/upgrade
+     * unconditionally (guarded only by is_dir()) to keep WordPress's own
+     * temp-directory resolution (get_temp_dir(), used by
+     * WP_Filesystem_*::unzip_file()/wp_tempnam()) from falling through to
+     * sys_get_temp_dir()/upload_tmp_dir — a location that can sit OUTSIDE
+     * open_basedir on a locked-down host and fail silently there.
+     *
+     * That pin itself became a REGRESSION (agent-only, 0.61.20 — GitHub
+     * issue #131 follow-up): on a host where wp-content/upgrade EXISTS but
+     * is NOT writable in this request's execution context (open_basedir/
+     * RunCloud-style restrictions, a permissions layout that differs from
+     * what the request user can write to) while the PRE-#131 fallback
+     * (sys_get_temp_dir()/upload_tmp_dir) WAS writable, forcing the pin
+     * broke every plugin/theme update on that host — the download/unpack
+     * that used to succeed now fails, and the #131 isComplete() guard
+     * correctly (but unhelpfully) rolls the failed apply back.
+     *
+     * The fix: pin ONLY when wp-content/upgrade is both present (creating
+     * it on demand) AND writable. When it is not, leave WP_TEMP_DIR
+     * undefined entirely so WordPress's own get_temp_dir() resolves the
+     * next-best writable location itself — the exact pre-#131 behaviour
+     * that worked on this class of host. This never weakens the #131 intent
+     * on a host where wp-content/upgrade IS writable: the pin still applies
+     * there, unchanged.
+     *
+     * All filesystem probes are @-suppressed: on an open_basedir-restricted
+     * host a path outside the allowed set can make is_dir()/is_writable()
+     * emit a warning (never a fatal), and this method must never surface
+     * that noise — "can't tell" is treated the same as "not writable" by
+     * construction, so suppressing the warning changes nothing about the
+     * decision.
+     *
+     * @return string A short, log-safe (no secrets) description of the
+     *                decision, suitable for both DebugLog and the
+     *                CP-visible item log.
+     */
+    private function pinTempDirForUnpack(): string
+    {
+        if (defined('WP_TEMP_DIR')) {
+            // Respect whatever already defined it (an operator's
+            // wp-config.php override, or an earlier call in this same
+            // request) — never redefine a PHP constant (fatal) and never
+            // second-guess an explicit choice made elsewhere.
+            return 'temp dir: WP_TEMP_DIR already defined; leaving as-is.';
+        }
+
+        $upgradeDir = defined('WP_CONTENT_DIR') ? rtrim((string) WP_CONTENT_DIR, '/\\') . '/upgrade' : '';
+        if ($upgradeDir === '') {
+            return 'temp dir: WP_CONTENT_DIR unavailable; using WordPress\'s own default temp dir.';
+        }
+
+        if (!@is_dir($upgradeDir) && function_exists('wp_mkdir_p')) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort existence probe; must never warn/fatal under open_basedir, see method doc
+            @wp_mkdir_p($upgradeDir); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort directory creation; a failure here is caught by the writability check right below, not by this return value
+        }
+
+        // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- headless agent; WP_Filesystem never initialized (no interactive/FTP context); direct writability probe is the only option, must never warn/fatal under open_basedir
+        $writable = @is_dir($upgradeDir) && @is_writable($upgradeDir);
+        if (!$writable) {
+            // Do NOT force a broken pin — fall through with WP_TEMP_DIR left
+            // undefined so WordPress's own get_temp_dir() picks the
+            // next-best writable location itself. This is the fix.
+            return 'temp dir: ' . $upgradeDir . ' exists but is not writable here; '
+                . 'pin skipped, falling back to WordPress\'s own default temp dir.';
+        }
+
+        // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- WP_TEMP_DIR is a documented, overridable WordPress core constant (wp-admin/includes/file.php get_temp_dir()), not a constant of our own; it is simply missing from this sniff's hardcoded allowed_core_constants list
+        define('WP_TEMP_DIR', $upgradeDir);
+
+        return 'temp dir: pinned to ' . $upgradeDir;
     }
 
     /**

--- a/apps/agent/patchwork.json
+++ b/apps/agent/patchwork.json
@@ -9,6 +9,8 @@
     "realpath",
     "clearstatcache",
     "is_readable",
+    "is_dir",
+    "is_writable",
     "opcache_invalidate"
   ]
 }

--- a/apps/agent/tests/UpdateRunnerTempDirTest.php
+++ b/apps/agent/tests/UpdateRunnerTempDirTest.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * UpdateRunnerTempDirTest — agent-only regression fix (0.61.20, GitHub issue
+ * #131 follow-up).
+ *
+ * B3 (#131) pinned WP_TEMP_DIR to wp-content/upgrade guarded ONLY by
+ * is_dir() — no writability check. On a host where wp-content/upgrade
+ * EXISTS but is NOT writable in the request's execution context
+ * (open_basedir/RunCloud-style hosts), that unconditional pin broke EVERY
+ * plugin/theme update there: WordPress's download_url()/unzip_file() then
+ * tried to write INTO the pinned-but-unwritable directory instead of
+ * falling back to whatever location (sys_get_temp_dir()/upload_tmp_dir)
+ * actually worked before #131 — the apply failed, and the #131
+ * isComplete() guard correctly (but unhelpfully) rolled the failed apply
+ * back, exactly the "worked before #131, fails after" symptom reported.
+ *
+ * UpdateRunner::pinTempDirForUnpack() (extracted from applyViaUpgrader() as
+ * part of this fix) now checks is_writable() too and skips the define()
+ * entirely when the directory is not writable, leaving WP_TEMP_DIR
+ * undefined so WordPress's own get_temp_dir() resolves the fallback
+ * itself — the pre-#131 behaviour that worked on this class of host.
+ *
+ * Both tests below run in a SEPARATE PROCESS: WP_TEMP_DIR/WP_CONTENT_DIR
+ * are real PHP constants that, once defined, can never be undefined for
+ * the rest of a PHPUnit process. Running in-process after any other test
+ * in this file (or elsewhere in the suite) that already pinned WP_TEMP_DIR
+ * would make `defined('WP_TEMP_DIR')` trivially true regardless of what
+ * this fix actually does, defeating the regression lock — see
+ * Security/HideBackendModuleTest.php for the same idiom used for the same
+ * reason (a process-lifetime latch/constant).
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Support\UpdateRunner;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\UpdateRunner
+ */
+final class UpdateRunnerTempDirTest extends TestCase
+{
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        // Fresh per-process value — @runInSeparateProcess guarantees this is
+        // never already defined by an earlier test file, but guard it the
+        // same way the rest of this suite does for constants shared across
+        // files (see SnapshotManagerTest's guard-define idiom).
+        if (!defined('WP_CONTENT_DIR')) {
+            define('WP_CONTENT_DIR', sys_get_temp_dir() . '/wpmgr-tempdir-test-' . bin2hex(random_bytes(6)));
+        }
+    }
+
+    protected function tear_down(): void
+    {
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /** Invoke the private pinTempDirForUnpack() via reflection. */
+    private function pin(UpdateRunner $runner): string
+    {
+        // No setAccessible() call needed — ReflectionMethod::invoke() has
+        // been able to call non-public methods directly since PHP 8.1 (see
+        // SnapshotManagerTest::realLiveDir() for the same idiom).
+        $method = new \ReflectionMethod(UpdateRunner::class, 'pinTempDirForUnpack');
+
+        return (string) $method->invoke($runner);
+    }
+
+    /**
+     * CONTROL — the writable-host case is UNCHANGED from #131: when
+     * wp-content/upgrade exists AND is writable in this execution context,
+     * the pin is still applied exactly as before. Proves the fix only ADDS
+     * a fallback; it never weakens the #131 hardening on a host where it
+     * already worked.
+     *
+     * @runInSeparateProcess
+     */
+    public function test_temp_dir_pinned_when_upgrade_dir_writable(): void
+    {
+        Functions\when('is_dir')->justReturn(true);
+        Functions\when('is_writable')->justReturn(true);
+
+        $runner = new UpdateRunner();
+        $note   = $this->pin($runner);
+
+        $expected = rtrim((string) WP_CONTENT_DIR, '/\\') . '/upgrade';
+
+        $this->assertTrue(
+            defined('WP_TEMP_DIR'),
+            'a writable upgrade dir must still be pinned — unchanged #131 behaviour'
+        );
+        $this->assertSame($expected, WP_TEMP_DIR);
+        $this->assertStringContainsString('pinned to', $note);
+    }
+
+    /**
+     * THE REGRESSION LOCK — GitHub issue #131 follow-up (agent 0.61.20).
+     * Before this fix, wp-content/upgrade merely satisfying is_dir()=true
+     * was enough to pin WP_TEMP_DIR, REGARDLESS of writability — exactly
+     * the scenario that broke every plugin/theme update (WooCommerce free
+     * + a premium plugin both failing + rolling back) on an
+     * open_basedir/RunCloud host where wp-content/upgrade exists but isn't
+     * writable in this request's execution context.
+     *
+     * Proves the fix: is_writable()=false must leave WP_TEMP_DIR UNDEFINED
+     * so WordPress's own get_temp_dir() fallback
+     * (sys_get_temp_dir()/upload_tmp_dir) — the pre-#131 behaviour that
+     * worked on this class of host — is used instead of a broken pin. Run
+     * this test against the pre-fix (is_dir-only) code and it fails: that
+     * code pins WP_TEMP_DIR unconditionally once is_dir() is true, with no
+     * writability check at all.
+     *
+     * @runInSeparateProcess
+     */
+    public function test_temp_dir_pin_skipped_when_not_writable(): void
+    {
+        Functions\when('is_dir')->justReturn(true);
+        Functions\when('is_writable')->justReturn(false);
+
+        $runner = new UpdateRunner();
+        $note   = $this->pin($runner);
+
+        $this->assertFalse(
+            defined('WP_TEMP_DIR'),
+            'REGRESSION: wp-content/upgrade existing (is_dir=true) but NOT writable must NOT pin '
+            . 'WP_TEMP_DIR — the pre-fix is_dir()-only check pinned regardless of writability, '
+            . 'breaking every plugin/theme update on this class of host'
+        );
+        $this->assertStringContainsString('not writable', $note);
+        $this->assertStringContainsString('skipped', $note);
+    }
+
+    /**
+     * Respects an operator's own WP_TEMP_DIR override (or a prior call in
+     * the same request): never redefine a PHP constant — that is a fatal
+     * error, not merely a bug — and never second-guess an explicit choice
+     * made elsewhere.
+     *
+     * @runInSeparateProcess
+     */
+    public function test_temp_dir_pin_skipped_when_wp_temp_dir_already_defined(): void
+    {
+        define('WP_TEMP_DIR', '/already/defined/path');
+
+        // These must never even be consulted: an already-defined
+        // WP_TEMP_DIR short-circuits before any filesystem probe runs.
+        Functions\when('is_dir')->justReturn(true);
+        Functions\when('is_writable')->justReturn(true);
+
+        $runner = new UpdateRunner();
+        $note   = $this->pin($runner);
+
+        $this->assertSame('/already/defined/path', WP_TEMP_DIR);
+        $this->assertStringContainsString('already defined', $note);
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.19
+ * Version:           0.61.20
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.19');
+define('WPMGR_AGENT_VERSION', '0.61.20');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 

--- a/apps/web/src/features/updates/update-tasks-table.test.tsx
+++ b/apps/web/src/features/updates/update-tasks-table.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { fireEvent, screen, within } from "@testing-library/react";
+import type { UpdateTask } from "@wpmgr/api";
+
+import { renderWithProviders } from "@/test/render";
+
+import { UpdateTasksTable } from "./update-tasks-table";
+
+// Outcome test — visibility gap fix: a failed/rolled_back update task carries
+// the agent's full diagnostic log in `task.error`, but the run-detail Tasks
+// table used to render only the short `task.detail` string, truncated. This
+// pins the fix: the full `task.error` text must be reachable in one click via
+// a disclosure, alongside a copy affordance, and MUST NOT render for a task
+// whose `error` is empty (nothing to disclose).
+
+const RUN_ID = "11111111-1111-1111-1111-111111111111";
+const TENANT_ID = "22222222-2222-2222-2222-222222222222";
+const SITE_ID = "33333333-3333-3333-3333-333333333333";
+
+const FULL_LOG =
+  "Update incomplete; auto-restored the pre-update snapshot. Reason: " +
+  "activation check failed after replacing plugin files.\n" +
+  "on-disk version: 10.8.0\n" +
+  "expected version: 10.8.1\n" +
+  "snapshot restored from: pre-update-2026-07-08T00-00-00Z";
+
+function buildTask(overrides: Partial<UpdateTask>): UpdateTask {
+  return {
+    id: "task-1",
+    run_id: RUN_ID,
+    tenant_id: TENANT_ID,
+    site_id: SITE_ID,
+    target_type: "plugin",
+    target_slug: "woocommerce/woocommerce.php",
+    status: "failed",
+    created_at: "2026-07-08T00:00:00Z",
+    updated_at: "2026-07-08T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("UpdateTasksTable — failed task log disclosure", () => {
+  it("reveals the full agent log + copy affordance for a task with a non-empty error, and renders no disclosure for a task with an empty error", () => {
+    const failedTask = buildTask({
+      id: "task-failed",
+      status: "rolled_back",
+      detail: "agent reported update failure",
+      error: FULL_LOG,
+    });
+    const cleanFailure = buildTask({
+      id: "task-no-log",
+      target_slug: "another-plugin/another-plugin.php",
+      status: "failed",
+      detail: "agent reported update failure",
+      error: undefined,
+    });
+
+    renderWithProviders(
+      <UpdateTasksTable tasks={[failedTask, cleanFailure]} />,
+    );
+
+    const rows = screen.getAllByTestId("update-task-row");
+    expect(rows).toHaveLength(2);
+
+    // The task with no error has nothing to disclose: no toggle at all.
+    expect(
+      within(rows[1]!).queryByRole("button", { name: /view log/i }),
+    ).not.toBeInTheDocument();
+
+    // The full log text is never rendered until the disclosure is opened.
+    expect(screen.queryByText(/activation check failed/)).not.toBeInTheDocument();
+
+    // The failed task's row has exactly one toggle, and it opens the log.
+    const toggle = within(rows[0]!).getByRole("button", { name: /view log/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    // Full multi-line log is rendered verbatim (newlines preserved via <pre>),
+    // not just the short generic detail string.
+    const logPanel = screen.getByText(/activation check failed/).closest("pre");
+    expect(logPanel).not.toBeNull();
+    expect(logPanel?.textContent).toContain(FULL_LOG);
+    expect(logPanel?.textContent).toContain("on-disk version: 10.8.0");
+
+    // Copy affordance is present and scoped to the log panel.
+    expect(
+      screen.getByRole("button", { name: /copy agent log/i }),
+    ).toBeInTheDocument();
+
+    // Still exactly one disclosure toggle in the whole table (the clean
+    // failure never grew one).
+    expect(screen.getAllByRole("button", { name: /view log|hide log/i })).toHaveLength(1);
+  });
+
+  it("renders nothing (empty state) when there are no tasks", () => {
+    renderWithProviders(<UpdateTasksTable tasks={[]} />);
+    expect(screen.getByText(/no tasks yet/i)).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/updates/update-tasks-table.tsx
+++ b/apps/web/src/features/updates/update-tasks-table.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+import { Check, ChevronDown, ChevronRight, Copy } from "lucide-react";
 import type { UpdateTask } from "@wpmgr/api";
 
 import {
@@ -8,6 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
 import { VersionArrow } from "@/components/shared/version-arrow";
 import { TaskStatusBadge } from "@/features/updates/update-status";
 
@@ -15,6 +18,8 @@ import { TaskStatusBadge } from "@/features/updates/update-status";
 // import path change. Surface C agents may update their imports to ./summarize.
 // eslint-disable-next-line react-refresh/only-export-components -- intentional re-export bridge; callers that own this import will move to ./summarize in Surface C
 export { siteNameMap } from "./summarize";
+
+const TASK_COLUMN_COUNT = 5;
 
 // Live table of per-(site, target) update tasks. Rows reflect whatever is in
 // the run-detail query cache, which the SSE stream patches in place.
@@ -50,46 +55,149 @@ export function UpdateTasksTable({
           </TableHeader>
           <TableBody>
             {tasks.map((task) => (
-              <TableRow key={task.id} data-testid="update-task-row">
-                <TableCell className="font-medium">
-                  {siteNames?.get(task.site_id) ?? short(task.site_id)}
-                </TableCell>
-                <TableCell>
-                  <span className="font-mono text-xs text-muted-foreground capitalize">
-                    {task.target_type}
-                  </span>
-                  {task.target_type !== "core" && task.target_slug ? (
-                    <>
-                      {" "}
-                      <span className="font-mono text-xs font-medium">
-                        {task.target_slug}
-                      </span>
-                    </>
-                  ) : null}
-                </TableCell>
-                <TableCell>
-                  {task.from_version && task.to_version ? (
-                    <VersionArrow
-                      from={task.from_version}
-                      to={task.to_version}
-                    />
-                  ) : (
-                    <span className="text-muted-foreground text-xs">{"–"}</span>
-                  )}
-                </TableCell>
-                <TableCell>
-                  <TaskStatusBadge status={task.status} />
-                </TableCell>
-                <TableCell className="max-w-[200px] truncate font-mono text-xs text-muted-foreground">
-                  {task.error ?? task.detail ?? (
-                    <span aria-hidden="true">{"–"}</span>
-                  )}
-                </TableCell>
-              </TableRow>
+              <UpdateTaskRow
+                key={task.id}
+                task={task}
+                siteName={siteNames?.get(task.site_id)}
+              />
             ))}
           </TableBody>
         </Table>
       </div>
+    </div>
+  );
+}
+
+// One task row plus, when the agent reported a non-empty error/log, a
+// disclosure toggle that reveals a second full-width row with the full text.
+// `task.error` carries the agent's complete diagnostic (e.g. why a rollback
+// was triggered), while `task.detail` stays the short generic status string
+// — both are surfaced, but the full log is one click away instead of only
+// ever being available truncated in the Detail cell.
+function UpdateTaskRow({
+  task,
+  siteName,
+}: {
+  task: UpdateTask;
+  siteName?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const hasLog = Boolean(task.error && task.error.trim().length > 0);
+  const logId = `update-task-log-${task.id}`;
+
+  return (
+    <>
+      <TableRow data-testid="update-task-row">
+        <TableCell className="font-medium">
+          {siteName ?? short(task.site_id)}
+        </TableCell>
+        <TableCell>
+          <span className="font-mono text-xs text-muted-foreground capitalize">
+            {task.target_type}
+          </span>
+          {task.target_type !== "core" && task.target_slug ? (
+            <>
+              {" "}
+              <span className="font-mono text-xs font-medium">
+                {task.target_slug}
+              </span>
+            </>
+          ) : null}
+        </TableCell>
+        <TableCell>
+          {task.from_version && task.to_version ? (
+            <VersionArrow from={task.from_version} to={task.to_version} />
+          ) : (
+            <span className="text-muted-foreground text-xs">{"–"}</span>
+          )}
+        </TableCell>
+        <TableCell>
+          <TaskStatusBadge status={task.status} />
+        </TableCell>
+        <TableCell className="max-w-[220px] text-xs text-muted-foreground">
+          <div className="flex flex-col items-start gap-1">
+            <span
+              className="max-w-full min-w-0 truncate font-mono"
+              title={task.detail}
+            >
+              {task.detail ??
+                (hasLog ? "See log for details" : <span aria-hidden="true">{"–"}</span>)}
+            </span>
+            {hasLog ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setOpen((v) => !v)}
+                aria-expanded={open}
+                aria-controls={logId}
+                className="h-auto px-1.5 py-0.5 font-sans text-xs"
+              >
+                {open ? (
+                  <ChevronDown aria-hidden="true" className="size-3.5" />
+                ) : (
+                  <ChevronRight aria-hidden="true" className="size-3.5" />
+                )}
+                {open ? "Hide log" : "View log"}
+              </Button>
+            ) : null}
+          </div>
+        </TableCell>
+      </TableRow>
+      {hasLog && open ? (
+        <TableRow data-testid="update-task-log-row">
+          <TableCell colSpan={TASK_COLUMN_COUNT} className="bg-muted/20 p-0">
+            {/* task.error is a defined non-empty string here; hasLog narrows it. */}
+            <TaskLogPanel id={logId} error={task.error ?? ""} />
+          </TableCell>
+        </TableRow>
+      ) : null}
+    </>
+  );
+}
+
+// The full agent log for one task: monospace, newline-preserving, scrollable
+// past a reasonable height, and copyable in one click.
+function TaskLogPanel({ id, error }: { id: string; error: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = () => {
+    if (typeof navigator === "undefined" || !navigator.clipboard) return;
+    void navigator.clipboard.writeText(error).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <div id={id} className="space-y-2 border-t border-border p-3">
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Agent log
+        </h3>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onCopy}
+          aria-label="Copy agent log"
+        >
+          {copied ? (
+            <>
+              <Check aria-hidden="true" className="size-3.5" />
+              Copied
+            </>
+          ) : (
+            <>
+              <Copy aria-hidden="true" className="size-3.5" />
+              Copy
+            </>
+          )}
+        </Button>
+      </div>
+      <pre className="max-h-64 overflow-auto rounded-md border border-border bg-muted/50 p-3 font-mono text-xs whitespace-pre-wrap break-words text-foreground">
+        {error}
+      </pre>
     </div>
   );
 }


### PR DESCRIPTION
REGRESSION from #131: it pinned WP_TEMP_DIR to wp-content/upgrade with an is_dir()-only guard; on hosts where that dir isn't writable in-request the WP download/unzip breaks for ALL updates (free + premium), which the #131 guard then rolls back. Fix: only pin when writable, else fall back to WP default (pre-#131 behavior); writable hosts unchanged. Also: the run detail now shows the full (previously CSS-truncated) agent log per failed task. Both reviewed SHIP. 2512 phpunit + 937 web tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Update task rows can now expand to show the full log for failed or rolled-back tasks, with a copy-to-clipboard option.

* **Bug Fixes**
  * Improved update reliability on some hosts where the temporary update directory was previously unusable.
  * Update details now better reflect failures by showing clearer log information instead of only a brief summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->