### PR TITLE
fix(web): backup breadcrumbs (#188) + screenshot refresh never silent + self-host media-encoder default (#187)

### DIFF
--- a/.claude/agents/devops-engineer.md
+++ b/.claude/agents/devops-engineer.md
@@ -65,7 +65,7 @@ nginx.conf (`infra/nginx/nginx.conf`) — ONE hostname serves three surfaces and
 
 Compose layering:
 - Base `infra/docker-compose.yml` has `build:` stanzas + dev env (Postgres, Redis, SeaweedFS S3-gateway:8333, ClickHouse, api, web, dex, optional otel-lgtm). Two-DSN model: unprivileged `wpmgr_app` (NOBYPASSRLS) for the app, separate `WPMGR_DB_MIGRATION_DSN` owner role for migrations only.
-- `media-encoder` is behind the `media` profile (`profiles: ["media"]`) — self-hosters who don't want image optimization simply don't run it, keeping their core api a minimal static binary. It registers the `media_encode` River queue as the ONLY worker; the api registers that queue with zero workers (insert-only).
+- `media-encoder` is part of the BASE stack (GH #187, no `profiles:` gate — it used to be opt-in behind a `media` profile, which silently left screenshots/Media Optimizer dead on a plain `docker compose up -d`; now it starts by default). Self-hosters who want a leaner footprint disable it via `--scale media-encoder=0` rather than a profile flag. It registers the `media_encode` River queue as the ONLY worker; the api registers that queue with zero workers (insert-only).
 - `infra/docker-compose.prod.yml` is the pull-only overlay: `image: ghcr.io/mosamlife/wpmgr-{api,web,media-encoder}:${WPMGR_VERSION:-latest}` + `pull_policy: always`. Self-host users compose base + prod overlay.
 
 Release workflow (`.github/workflows/release.yml`):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,16 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
-## [0.61.48] - 2026-07-09
+## [0.61.49] - 2026-07-09
+
+### Fixed
+
+- Backup breadcrumbs (GH #188). When viewing a specific site backup, the navigation trail now reads Sites > [site] > Backups (mirroring the Updates section) with the "Backups" crumb linking back to that site's own backup list, instead of a dead-end trail that forced you to use the browser back button. The snapshot detail now lives under the site's own URL.
+- Refresh screenshot no longer silently does nothing (GH #187). If the screenshot could not be captured (most often because the media-encoder service is not running), the card no longer spins forever after a false "queued" message; it now stops and shows a warning, and the server returns clearer, specific errors ("service isn't running" / "not configured") instead of a generic failure.
+
+### Changed
+
+- Self-hosted installs now run the media-encoder by default (GH #187). It was previously opt-in behind a Compose profile, which silently disabled site screenshots and the Media Optimizer on a default `docker compose up`. It now starts with the base stack (it runs headless Chromium, so it adds some memory/CPU; you can opt out with `docker compose up -d --scale media-encoder=0`). The hosted service is unaffected.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 ### Media
 
 - **Dedicated cloud encoder** — Separate `media-encoder` container decodes from magic bytes (never trusted MIME) and re-encodes to AVIF (q50/speed8), WebP (q80), or re-optimized original. Animated GIFs → animated WebP.
-- **Optional, opt-in** — `docker compose --profile media up`; zero weight or native-library CVE surface on the core API for operators who don't use it.
+- **Runs by default, disable if unneeded** — Part of the base self-host stack (`docker compose up -d` starts it, no profile needed); disable on constrained hosts with `--scale media-encoder=0`. Zero weight or native-library CVE surface on the core API either way, since encoding never runs there.
 - **Per-image optimize and full reversible restore** — Originals archived on-site (`.wpmgr-original.*` rename); restore reverts every variant. A separate admin-gated delete-originals reclaims disk.
 - **No image bytes on the control plane** — Source and optimized bytes move agent-to-storage and encoder-to-storage via presigned URLs only. CP stores metadata rows only.
 - **`.htaccess` Accept-header fallback** — Serves the modern format only when the browser's `Accept` header advertises support; legacy twin is served otherwise. `Vary: Accept` for CDN correctness. nginx map equivalent emitted for non-Apache hosts.
@@ -248,7 +248,7 @@ See [docs/architecture.md](./docs/architecture.md) for a full system diagram.
 
 ## Quickstart (self-host)
 
-The bundled compose brings up the full stack — control plane, dashboard, Postgres, Redis, and object storage — building the API and dashboard from source:
+The bundled compose brings up the full stack — control plane, dashboard, Postgres, Redis, object storage, and the media encoder (screenshots + Media Optimizer) — building all three images from source:
 
 ```bash
 cp .env.example .env
@@ -259,20 +259,22 @@ curl localhost:8081/healthz   # {"status":"ok"}   (default WPMGR_API_PORT=8081)
 
 Open `http://localhost:8088` in your browser (the default `WPMGR_WEB_PORT`) — the first signup creates the owner account. After that, anyone can self-register and gains access only after verifying their email.
 
-Include the optional media encoder with the `media` profile:
+The media encoder runs headless Chromium for screenshots, so it adds some RAM/CPU over the api/web images. On a constrained host you can skip it without editing the compose file:
 
 ```bash
-docker compose -f infra/docker-compose.yml --profile media up -d
+docker compose -f infra/docker-compose.yml up -d --scale media-encoder=0
 ```
+
+Site screenshot cards then fall back to favicon/monogram and the Media Optimizer tab is unavailable; everything else works normally.
 
 ### Prebuilt container images
 
-The control plane, dashboard, and (optional) media encoder are published on GitHub Container Registry as multi-arch (`linux/amd64` + `linux/arm64`) images — wire them into your own compose, Kubernetes, or Swarm for production:
+The control plane, dashboard, and media encoder are published on GitHub Container Registry as multi-arch (`linux/amd64` + `linux/arm64`) images — wire them into your own compose, Kubernetes, or Swarm for production:
 
 ```bash
 docker pull ghcr.io/mosamlife/wpmgr-api:v0.43.3
 docker pull ghcr.io/mosamlife/wpmgr-web:v0.43.3
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.43.3   # optional
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.43.3
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:

--- a/apps/api/cmd/media-encoder/main.go
+++ b/apps/api/cmd/media-encoder/main.go
@@ -260,8 +260,8 @@ func run() error {
 	// startup probe fails the revision. The health server also hosts the
 	// /internal/drain wake endpoint: at min-instances=0 the CP holds a request
 	// open there to keep this cold-started instance alive until the media_encode
-	// queue drains. Self-hosters running this via docker-compose (the `media`
-	// profile) run it always-on and never call /internal/drain.
+	// queue drains. Self-hosters running this via the base docker-compose stack
+	// run it always-on and never call /internal/drain.
 	// Pass encoder-owned queues to the drain handler. The encoder must stay warm
 	// while any queue it processes has pending work.
 	healthSrv := startHealthServer(logger, pool, mediaSchema, model.MediaEncodeQueue, screenshot.ScreenshotQueue, mediafont.FontTranscodeQueue)

--- a/apps/api/internal/media/waker.go
+++ b/apps/api/internal/media/waker.go
@@ -41,7 +41,7 @@ const metadataIdentityURL = "http://metadata.google.internal/computeMetadata/v1/
 // covers any in-flight job interrupted by a mid-drain scale-down.
 //
 // Disabled (drainURL == "") on self-host, where the media-encoder runs as a
-// long-lived always-on container (docker-compose `media` profile) and needs no
+// long-lived always-on container in the base docker-compose stack and needs no
 // waking. Both Run and Kick become no-ops.
 type EncoderWaker struct {
 	pool     *db.Pool

--- a/apps/api/internal/screenshot/handler.go
+++ b/apps/api/internal/screenshot/handler.go
@@ -61,7 +61,7 @@ func (h *Handler) refresh(c *gin.Context) {
 	}
 
 	if h.svc.enqueuer == nil {
-		httpx.Error(c, domain.Internal("screenshot_disabled", "screenshot capture is not configured"))
+		httpx.Error(c, domain.Unavailable("screenshot_disabled", "screenshot capture is not configured on this server"))
 		return
 	}
 

--- a/apps/web/src/components/feedback/page-error.tsx
+++ b/apps/web/src/components/feedback/page-error.tsx
@@ -30,7 +30,7 @@ import { cn } from "@/lib/utils";
 //   • Surface: `--card` on `--background` (page-level), but the inner border
 //     uses `--destructive` at low alpha — paints "this is an error" without
 //     blasting the page red. Matches the Sprint 3 alert tone in
-//     `routes/_authed/backups/$snapshotId.tsx`.
+//     `routes/_authed/sites/$siteId.backups.$snapshotId.tsx`.
 //   • Headline: `--foreground` body weight 600.
 //   • Why: `--muted-foreground` body-sm.
 //   • Button: outline, sm — recovery is reversible and low-stakes by design.

--- a/apps/web/src/components/layout/top-bar-helpers.test.ts
+++ b/apps/web/src/components/layout/top-bar-helpers.test.ts
@@ -78,3 +78,37 @@ describe("ROUTELESS_SEGMENTS", () => {
     expect(ROUTELESS_SEGMENTS.has("sites")).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// GH #188 — snapshot-detail breadcrumb dead end
+//
+// The snapshot detail used to live at the top-level, siteId-less
+// `/backups/$snapshotId` route, so this pure pathname->label mapper could
+// only see `Backups › <snapshotId>`, with "Backups" linking to the FLEET
+// `/backups` list — a dead end that doesn't contain the snapshot. Moving the
+// route to `/sites/$siteId/backups/$snapshotId` (mirroring every other site
+// tab) makes the pathname itself carry siteId; NO change to this mapper was
+// needed ("backups" was already a linked TITLE, not a ROUTELESS_SEGMENT) —
+// these tests pin the resulting crumb shape as a regression lock.
+// ---------------------------------------------------------------------------
+
+describe("buildBreadcrumbCrumbs — snapshot detail nested under its site (GH #188)", () => {
+  it("renders Sites › <siteId> › Backups › <snapshotId>, with Backups linking to THIS site's backups tab", () => {
+    const crumbs = buildBreadcrumbCrumbs(
+      "/sites/site_01hzxy/backups/snap_01hzab",
+    );
+    expect(crumbs).toEqual([
+      { label: "Sites", to: "/sites" },
+      { label: "site_01hzxy", to: "/sites/site_01hzxy" },
+      { label: "Backups", to: "/sites/site_01hzxy/backups" },
+      { label: "snap_01hzab", to: null },
+    ]);
+  });
+
+  it("the 'Backups' crumb never points at the fleet-wide /backups list once nested under a site", () => {
+    const crumbs = buildBreadcrumbCrumbs("/sites/site_01hzxy/backups/snap_01hzab");
+    const backupsCrumb = crumbs.find((c) => c.label === "Backups");
+    expect(backupsCrumb?.to).not.toBe("/backups");
+    expect(backupsCrumb?.to).toBe("/sites/site_01hzxy/backups");
+  });
+});

--- a/apps/web/src/components/toast/use-toast-helpers.ts
+++ b/apps/web/src/components/toast/use-toast-helpers.ts
@@ -106,6 +106,24 @@ export const toast = {
   },
 
   /**
+   * Auto-dismisses in 6s. A soft heads-up that is NOT a hard failure (the
+   * request succeeded) but the operator should still notice — e.g. a
+   * background job that never confirmed completion (GH #187: a queued
+   * screenshot capture that never finished, most often because a self-hosted
+   * media-encoder isn't running). Sits between `info` (5s, fully neutral)
+   * and `error` (8s, red) in both duration and tone. Icon comes from the
+   * Toaster's per-type `icons.warning` (already wired) — no override needed,
+   * same as `success`/`error`/`info` above.
+   */
+  warning: (title: string, opts: CommonOpts = {}) => {
+    return sonner.warning(title, {
+      description: opts.description,
+      action: toAction(opts.action),
+      duration: 6000,
+    });
+  },
+
+  /**
    * Promise-bound toast. Shows `loading` immediately, swaps to `success` or
    * `error` based on resolution. Use for mutations where the operator
    * benefits from a single thread of feedback (e.g. an update run).

--- a/apps/web/src/features/backups/backups-section.test.tsx
+++ b/apps/web/src/features/backups/backups-section.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import type { Me } from "@wpmgr/api";
+
+import { renderWithProviders } from "@/test/render";
+import { mockQueryResult } from "@/test/query-mocks";
+
+import { BackupsSection } from "./backups-section";
+import { useBackups, useBackupSchedule } from "./use-backups";
+import { useRestoreRuns } from "./use-restores";
+import { useScheduleRuns } from "./use-schedule-runs";
+import { useMe } from "@/features/auth/use-auth";
+import type { BackupSnapshot } from "@wpmgr/api";
+
+// GH #188 caller test — the snapshot row's "View" link is the single most
+// common way an operator reaches the snapshot-detail route. Before the fix
+// it pointed at the top-level, siteId-less `/backups/$snapshotId` route
+// (see routes/_authed/sites/$siteId.backups.$snapshotId.tsx and
+// top-bar-helpers.test.ts for the breadcrumb half of this regression lock).
+// This test pins that the row now links to the SITE-NESTED route with BOTH
+// params wired.
+
+vi.mock("./use-backups", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./use-backups")>();
+  return { ...actual, useBackups: vi.fn(), useBackupSchedule: vi.fn() };
+});
+
+vi.mock("./use-restores", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./use-restores")>();
+  return { ...actual, useRestoreRuns: vi.fn() };
+});
+
+vi.mock("./use-schedule-runs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./use-schedule-runs")>();
+  return { ...actual, useScheduleRuns: vi.fn() };
+});
+
+vi.mock("@/features/auth/use-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/auth/use-auth")>();
+  return { ...actual, useMe: vi.fn() };
+});
+
+const mockedUseBackups = vi.mocked(useBackups);
+const mockedUseBackupSchedule = vi.mocked(useBackupSchedule);
+const mockedUseRestoreRuns = vi.mocked(useRestoreRuns);
+const mockedUseScheduleRuns = vi.mocked(useScheduleRuns);
+const mockedUseMe = vi.mocked(useMe);
+
+function buildSnapshot(overrides: Partial<BackupSnapshot> = {}): BackupSnapshot {
+  return {
+    id: "01hzxysnapshot0000000000",
+    tenant_id: "tenant-1",
+    site_id: "site-42",
+    kind: "full",
+    status: "completed",
+    created_at: "2026-07-01T00:00:00Z",
+    updated_at: "2026-07-01T00:05:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedUseMe.mockReturnValue(mockQueryResult<Me | null>({ data: null }));
+  mockedUseRestoreRuns.mockReturnValue(mockQueryResult({ data: [] }));
+  mockedUseScheduleRuns.mockReturnValue(
+    mockQueryResult({ data: { all: [], upcoming: [], past: [] } }),
+  );
+  mockedUseBackupSchedule.mockReturnValue(mockQueryResult({ data: null }));
+});
+
+describe("BackupsSection — snapshot row navigation (GH #188)", () => {
+  it("links a single snapshot's View button to the site-nested route with both siteId and snapshotId params", async () => {
+    const snapshot = buildSnapshot({ id: "snap-single", site_id: "site-42" });
+    mockedUseBackups.mockReturnValue(mockQueryResult({ data: [snapshot] }));
+
+    renderWithProviders(<BackupsSection siteId="site-42" canOperate={false} />, {
+      withRouter: true,
+      initialPath: "/sites/site-42/backups",
+    });
+
+    const link = await screen.findByRole("link", { name: "View" });
+    expect(link).toHaveAttribute("href", "/sites/site-42/backups/snap-single");
+  });
+
+  it("links each member of an incremental chain's View button to the site-nested route (not the old fleet-level /backups/$snapshotId)", async () => {
+    // Two members of the same chain (gen 0 base + gen 1 increment) so
+    // SnapshotList renders the ChainGroupRows/ChainMemberRow path instead of
+    // SingletonRow — a second, independent call site for the same link.
+    const base = buildSnapshot({
+      id: "snap-base",
+      site_id: "site-42",
+      chain_id: "chain-1",
+      is_incremental: false,
+      generation: 0,
+    });
+    const incr = buildSnapshot({
+      id: "snap-incr",
+      site_id: "site-42",
+      chain_id: "chain-1",
+      is_incremental: true,
+      generation: 1,
+      created_at: "2026-07-02T00:00:00Z",
+    });
+    mockedUseBackups.mockReturnValue(mockQueryResult({ data: [base, incr] }));
+
+    renderWithProviders(<BackupsSection siteId="site-42" canOperate={false} />, {
+      withRouter: true,
+      initialPath: "/sites/site-42/backups",
+    });
+
+    // The chain parent row shows the TIP (highest generation) collapsed;
+    // its View link must carry the tip's id and the site's id.
+    const tipLink = await screen.findByRole("link", { name: "View" });
+    expect(tipLink).toHaveAttribute("href", "/sites/site-42/backups/snap-incr");
+    expect(tipLink.getAttribute("href")).not.toMatch(/^\/backups\//);
+  });
+});

--- a/apps/web/src/features/backups/backups-section.tsx
+++ b/apps/web/src/features/backups/backups-section.tsx
@@ -919,8 +919,8 @@ function SingletonRow({
           ) : null}
           <Button asChild variant="outline" size="sm">
             <Link
-              to="/backups/$snapshotId"
-              params={{ snapshotId: snap.id }}
+              to="/sites/$siteId/backups/$snapshotId"
+              params={{ siteId, snapshotId: snap.id }}
             >
               View
             </Link>
@@ -1081,8 +1081,8 @@ function ChainGroupRows({
             ) : null}
             <Button asChild variant="outline" size="sm">
               <Link
-                to="/backups/$snapshotId"
-                params={{ snapshotId: tip.id }}
+                to="/sites/$siteId/backups/$snapshotId"
+                params={{ siteId, snapshotId: tip.id }}
               >
                 View
               </Link>
@@ -1251,8 +1251,8 @@ function ChainMemberRow({
           ) : null}
           <Button asChild variant="outline" size="sm">
             <Link
-              to="/backups/$snapshotId"
-              params={{ snapshotId: member.id }}
+              to="/sites/$siteId/backups/$snapshotId"
+              params={{ siteId, snapshotId: member.id }}
             >
               View
             </Link>
@@ -1847,8 +1847,8 @@ function ScheduleRunRow({
           {run.snapshot_id ? (
             <Button asChild variant="link" size="sm" className="h-auto p-0">
               <Link
-                to="/backups/$snapshotId"
-                params={{ snapshotId: run.snapshot_id }}
+                to="/sites/$siteId/backups/$snapshotId"
+                params={{ siteId: run.site_id, snapshotId: run.snapshot_id }}
               >
                 <code className="font-mono text-xs">
                   {run.snapshot_id.slice(0, 8)}

--- a/apps/web/src/features/sites/site-row-actions.test.tsx
+++ b/apps/web/src/features/sites/site-row-actions.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import type { Site } from "@wpmgr/api";
+import type { UseMutateFunction } from "@tanstack/react-query";
+
+import { renderWithProviders } from "@/test/render";
+import { mockMutationResult } from "@/test/query-mocks";
+
+import { SiteRowActions } from "./site-row-actions";
+import { useRefreshScreenshot } from "./use-sites";
+import { useRecheckConnection } from "./use-site-connection";
+import { toast } from "@/components/toast";
+
+// GH #187 (FE half) caller test — the row-action "Refresh screenshot" menu
+// item is the one and only place this mutation is fired from in the sites
+// list/grid. Pins: (a) the click fires the mutation with the site id and the
+// honest "queued" toast on the 202, and (c) whatever message the mutation
+// hook's error mapping produces (409/500/501/503, see use-sites.test.ts)
+// reaches the operator verbatim in the error toast's description.
+
+vi.mock("./use-sites", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./use-sites")>();
+  return { ...actual, useRefreshScreenshot: vi.fn() };
+});
+
+vi.mock("./use-site-connection", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./use-site-connection")>();
+  return { ...actual, useRecheckConnection: vi.fn() };
+});
+
+vi.mock("@/components/toast", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    destructive: vi.fn(),
+  },
+}));
+
+const mockedUseRefreshScreenshot = vi.mocked(useRefreshScreenshot);
+const mockedUseRecheckConnection = vi.mocked(useRecheckConnection);
+const mockedToastSuccess = vi.mocked(toast.success);
+const mockedToastError = vi.mocked(toast.error);
+
+function buildSite(overrides: Partial<Site> = {}): Site {
+  return {
+    id: "site-1",
+    tenant_id: "tenant-1",
+    url: "https://example.com",
+    name: "Example",
+    status: "active",
+    wp_version: "6.8",
+    php_version: "8.3",
+    health_status: "healthy",
+    multisite: false,
+    tags: [],
+    ...overrides,
+  } as unknown as Site;
+}
+
+type SimpleMutateOpts = {
+  onSuccess?: () => void;
+  onError?: (err: Error) => void;
+};
+type SimpleMutate = (siteId: string, opts?: SimpleMutateOpts) => void;
+
+/** `SiteRowActions` only ever calls `mutate(siteId, { onSuccess, onError })`
+ *  with zero/one-arg callbacks (see the real call site), so the test double
+ *  only needs to model that shape — cast through `unknown` to the real
+ *  `UseMutateFunction` signature rather than reproducing its full 4-arg
+ *  onSuccess/onError callback types (mirrors the `as unknown as Site`
+ *  pattern already used for test fixtures in sites-filter.test.ts). */
+function asMutateFn(fn: SimpleMutate): UseMutateFunction<void, Error, string> {
+  return fn as unknown as UseMutateFunction<void, Error, string>;
+}
+
+function openMenuAndFindRefreshItem() {
+  const trigger = screen.getByRole("button", { name: /more actions/i });
+  // Radix DropdownMenuTrigger opens on Enter/Space (keyboard) or pointerdown;
+  // Enter is the deterministic jsdom path (matches
+  // routes/_authed/settings/-route.test.tsx's precedent).
+  fireEvent.keyDown(trigger, { key: "Enter" });
+  return screen.findByRole("menuitem", { name: /refresh screenshot/i });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedUseRecheckConnection.mockReturnValue(
+    mockMutationResult({ mutate: vi.fn() }) as ReturnType<
+      typeof useRecheckConnection
+    >,
+  );
+});
+
+describe("SiteRowActions — Refresh screenshot wiring (GH #187)", () => {
+  it("fires the mutation with the site id and shows the honest 'queued' toast on the 202 ack", async () => {
+    const mutate = vi.fn<SimpleMutate>((_siteId, opts) => {
+      opts?.onSuccess?.();
+    });
+    mockedUseRefreshScreenshot.mockReturnValue(
+      mockMutationResult<void, string>({ mutate: asMutateFn(mutate) }),
+    );
+
+    renderWithProviders(
+      <SiteRowActions site={buildSite()} connectionState="connected" />,
+    );
+
+    const item = await openMenuAndFindRefreshItem();
+    fireEvent.click(item);
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate.mock.calls[0]?.[0]).toBe("site-1");
+    expect(mockedToastSuccess).toHaveBeenCalledTimes(1);
+    const [title, opts] = mockedToastSuccess.mock.calls[0] as [
+      string,
+      { description?: string }?,
+    ];
+    expect(title).toBe("Screenshot queued");
+    expect(opts?.description).toContain("shortly");
+  });
+
+  it.each([
+    ["The screenshot service isn't running.", 503],
+    ["Screenshots aren't configured on this server.", 500],
+    ["Screenshots aren't configured on this server.", 501],
+    ["Site is not enrolled; cannot capture screenshot.", 409],
+  ] as const)(
+    "surfaces the mutation's specific error message in the error toast (status %2$s)",
+    async (message, _status) => {
+      const mutate = vi.fn<SimpleMutate>((_siteId, opts) => {
+        opts?.onError?.(new Error(message));
+      });
+      mockedUseRefreshScreenshot.mockReturnValue(
+        mockMutationResult<void, string>({ mutate: asMutateFn(mutate) }),
+      );
+
+      renderWithProviders(
+        <SiteRowActions site={buildSite()} connectionState="connected" />,
+      );
+
+      const item = await openMenuAndFindRefreshItem();
+      fireEvent.click(item);
+
+      expect(mockedToastError).toHaveBeenCalledWith(
+        "Could not refresh screenshot",
+        expect.objectContaining({ description: message }),
+      );
+    },
+  );
+});

--- a/apps/web/src/features/sites/use-sites.test.ts
+++ b/apps/web/src/features/sites/use-sites.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import type { Site } from "@wpmgr/api";
+
+// GH #187 (FE half) — `useRefreshScreenshot` must never end in a silent
+// no-op. Before this fix, when the completion poll exhausted its 15 x 3s
+// window with the server still reporting "pending" (the common self-host
+// case: the media-encoder that performs the capture isn't running), the
+// mutation's onSuccess poll loop just `return`ed — the card stayed on the
+// "capturing" spinner forever and the operator got no further feedback at
+// all. These tests pin: (b) poll exhaustion clears the optimistic state and
+// fires a warning toast (the regression lock), and (c) the mutationFn maps
+// 409/500/501/503 to distinct, correct messages.
+
+const { refreshMock, toastWarning, toastSuccess, toastError, toastInfo } =
+  vi.hoisted(() => ({
+    refreshMock: vi.fn(),
+    toastWarning: vi.fn(),
+    toastSuccess: vi.fn(),
+    toastError: vi.fn(),
+    toastInfo: vi.fn(),
+  }));
+
+vi.mock("@wpmgr/api", () => ({
+  client: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+  listSites: vi.fn(),
+  getSite: vi.fn(),
+  deleteSite: vi.fn(),
+  createPairingCode: vi.fn(),
+  setSiteTags: vi.fn(),
+  refreshSiteScreenshot: refreshMock,
+}));
+
+vi.mock("@/components/toast", () => ({
+  toast: {
+    warning: toastWarning,
+    success: toastSuccess,
+    error: toastError,
+    info: toastInfo,
+  },
+}));
+
+import { useRefreshScreenshot, sitesKeys } from "./use-sites";
+
+function buildSite(overrides: Partial<Site> = {}): Site {
+  return {
+    id: "site-1",
+    tenant_id: "tenant-1",
+    url: "https://example.com",
+    name: "Example",
+    status: "active",
+    wp_version: "6.8",
+    php_version: "8.3",
+    health_status: "healthy",
+    multisite: false,
+    tags: [],
+    ...overrides,
+  } as unknown as Site;
+}
+
+function makeQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function wrapperFor(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: qc }, children);
+  };
+}
+
+beforeEach(() => {
+  refreshMock.mockReset();
+  toastWarning.mockReset();
+  toastSuccess.mockReset();
+  toastError.mockReset();
+  toastInfo.mockReset();
+});
+
+describe("useRefreshScreenshot — poll exhaustion never ends silently (GH #187)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("clears the optimistic 'capturing' state to 'failed' and fires a warning toast once the 45s poll window exhausts with status still pending", async () => {
+    vi.useFakeTimers();
+    const qc = makeQueryClient();
+    // Seed the list cache exactly as `useSites()` would have it before the
+    // refresh — a real, ready screenshot from a prior capture.
+    qc.setQueryData<Site[]>(sitesKeys.lists(), [
+      buildSite({ screenshot_status: "ready", screenshot_url: "https://cdn/old.webp" }),
+    ]);
+    refreshMock.mockResolvedValue({
+      data: undefined,
+      error: undefined,
+      response: { status: 202 },
+    });
+
+    const { result } = renderHook(() => useRefreshScreenshot(), {
+      wrapper: wrapperFor(qc),
+    });
+
+    await act(async () => {
+      result.current.mutate("site-1");
+      // Flush the mocked network promise + onMutate/onSuccess microtask
+      // chain before any timer exists to advance.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Optimistic patch landed: spinner state, stale url cleared.
+    const afterMutate = qc.getQueryData<Site[]>(sitesKeys.lists());
+    expect(afterMutate?.[0]?.screenshot_status).toBe("pending");
+    expect(afterMutate?.[0]?.screenshot_url).toBeUndefined();
+
+    // Drive the poll through all 15 ticks (3s apart = 45s) with the server
+    // NEVER reporting a terminal status — the exact "stuck job" scenario
+    // (self-host media-encoder not running) that #187 reports.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(45_000);
+    });
+
+    const afterExhaustion = qc.getQueryData<Site[]>(sitesKeys.lists());
+    // THE FIX: the card must leave the spinner state. Against the old code
+    // (a silent `return` on exhaustion with no cache patch) this assertion
+    // fails — screenshot_status would still read "pending" forever.
+    expect(afterExhaustion?.[0]?.screenshot_status).toBe("failed");
+
+    // THE FIX: an operator-visible signal must fire — never silence.
+    expect(toastWarning).toHaveBeenCalledTimes(1);
+    const [title, opts] = toastWarning.mock.calls[0] as [string, { description?: string }?];
+    expect(title).toMatch(/didn't finish/i);
+    expect(opts?.description).toMatch(/media-encoder/i);
+
+    // No other toast fired — the warning is the one and only terminal signal.
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("does NOT force 'failed' or warn when the server reports a terminal status before the poll window exhausts", async () => {
+    vi.useFakeTimers();
+    const qc = makeQueryClient();
+    qc.setQueryData<Site[]>(sitesKeys.lists(), [buildSite()]);
+    refreshMock.mockResolvedValue({
+      data: undefined,
+      error: undefined,
+      response: { status: 202 },
+    });
+
+    const { result } = renderHook(() => useRefreshScreenshot(), {
+      wrapper: wrapperFor(qc),
+    });
+
+    await act(async () => {
+      result.current.mutate("site-1");
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Simulate the SSE/refetch path landing a real "ready" screenshot after
+    // the first poll tick fires (before exhaustion).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+      qc.setQueryData<Site[]>(sitesKeys.lists(), [
+        buildSite({
+          screenshot_status: "ready",
+          screenshot_url: "https://cdn/new.webp",
+        }),
+      ]);
+      // Give the poll loop the rest of the window; it must see the terminal
+      // status on its next tick and stop rather than overwriting it.
+      await vi.advanceTimersByTimeAsync(45_000);
+    });
+
+    const final = qc.getQueryData<Site[]>(sitesKeys.lists());
+    expect(final?.[0]?.screenshot_status).toBe("ready");
+    expect(final?.[0]?.screenshot_url).toBe("https://cdn/new.webp");
+    expect(toastWarning).not.toHaveBeenCalled();
+  });
+});
+
+describe("useRefreshScreenshot — mutationFn error mapping (GH #187)", () => {
+  it("maps 409 to a not-enrolled message", async () => {
+    refreshMock.mockResolvedValue({ error: undefined, response: { status: 409 } });
+    const { result } = renderHook(() => useRefreshScreenshot(), {
+      wrapper: wrapperFor(makeQueryClient()),
+    });
+    await expect(result.current.mutateAsync("site-1")).rejects.toThrow(
+      /not enrolled/i,
+    );
+  });
+
+  it("maps 503 to 'the screenshot service isn't running' (worker not up)", async () => {
+    refreshMock.mockResolvedValue({ error: undefined, response: { status: 503 } });
+    const { result } = renderHook(() => useRefreshScreenshot(), {
+      wrapper: wrapperFor(makeQueryClient()),
+    });
+    await expect(result.current.mutateAsync("site-1")).rejects.toThrow(
+      "The screenshot service isn't running.",
+    );
+  });
+
+  it("maps 501 to the not-configured message", async () => {
+    refreshMock.mockResolvedValue({ error: undefined, response: { status: 501 } });
+    const { result } = renderHook(() => useRefreshScreenshot(), {
+      wrapper: wrapperFor(makeQueryClient()),
+    });
+    await expect(result.current.mutateAsync("site-1")).rejects.toThrow(
+      "Screenshots aren't configured on this server.",
+    );
+  });
+
+  it("maps 500 to the SAME not-configured message as 501 (previously fell through to a generic error)", async () => {
+    refreshMock.mockResolvedValue({ error: undefined, response: { status: 500 } });
+    const { result } = renderHook(() => useRefreshScreenshot(), {
+      wrapper: wrapperFor(makeQueryClient()),
+    });
+    await expect(result.current.mutateAsync("site-1")).rejects.toThrow(
+      "Screenshots aren't configured on this server.",
+    );
+  });
+});

--- a/apps/web/src/features/sites/use-sites.ts
+++ b/apps/web/src/features/sites/use-sites.ts
@@ -21,6 +21,8 @@ import {
   type ApiError,
 } from "@wpmgr/api";
 
+import { toast } from "@/components/toast";
+
 // Server-state hooks for the Sites domain. Built on the generated @wpmgr/api
 // SDK (Hey API). Each SDK call returns `{ data, error, response }`; we unwrap
 // `data` (throwing on transport/HTTP errors) so TanStack Query manages the
@@ -221,9 +223,22 @@ export function useSetSiteTags(): UseMutationResult<
  * invalidate both so the completed screenshot appears once the SSE event fires
  * or the next poll wins.
  *
+ * GH #187: on self-host, the media-encoder that actually performs the capture
+ * is frequently not running, so the job never completes. Without this fix the
+ * poll below exhausted SILENTLY, leaving the card stuck on the "capturing"
+ * spinner forever with no further feedback — a permanent false-pending state
+ * after an honest "Screenshot queued" toast. The poll's terminal branch below
+ * now ALWAYS resolves the optimistic state one way or another: either the
+ * server confirms ready/failed, or we time out and force the card back to
+ * "failed" (clearing the spinner) with a warning toast that names the likely
+ * cause. There is no code path where this mutation's UI effects end in
+ * silence.
+ *
  * Expected non-2xx:
  *   409 — site not enrolled (no agent to take the shot)
+ *   500 — screenshot capture failed / not configured on this instance
  *   501 — screenshot feature not configured on this instance
+ *   503 — the screenshot worker (media-encoder) is not running
  */
 export function useRefreshScreenshot(): UseMutationResult<void, Error, string> {
   const queryClient = useQueryClient();
@@ -234,8 +249,13 @@ export function useRefreshScreenshot(): UseMutationResult<void, Error, string> {
       });
       if (response?.status === 409)
         throw new Error("Site is not enrolled; cannot capture screenshot.");
-      if (response?.status === 501)
-        throw new Error("Screenshot capture is not configured on this instance.");
+      if (response?.status === 503)
+        throw new Error("The screenshot service isn't running.");
+      // 500 (capture failed / worker misconfigured) and 501 (feature not
+      // wired on this instance) are both "you can't use this here" from the
+      // operator's point of view — one clear message for both.
+      if (response?.status === 500 || response?.status === 501)
+        throw new Error("Screenshots aren't configured on this server.");
       if (error) throw toError(error);
     },
     onMutate: (siteId: string) => {
@@ -283,8 +303,40 @@ export function useRefreshScreenshot(): UseMutationResult<void, Error, string> {
             break;
           }
         }
-        if (status !== undefined && status !== "pending") return; // ready/failed
-        if (attempts >= maxAttempts) return;
+        if (status !== undefined && status !== "pending") {
+          // Terminal state confirmed by the server (ready or failed) — the
+          // list/detail cache already reflects it via the invalidation above.
+          return;
+        }
+        if (attempts >= maxAttempts) {
+          // Exhausted the poll window with the server still saying "pending"
+          // (or never surfacing this site at all). NEVER end silently here:
+          // force the optimistic state out of "capturing" so the spinner
+          // clears, and tell the operator why.
+          const clearStuckPending = (site: Site): Site =>
+            site.screenshot_status === "pending"
+              ? { ...site, screenshot_status: "failed" as const }
+              : site;
+          queryClient.setQueriesData<Site[]>(
+            { queryKey: sitesKeys.lists() },
+            (prevList) =>
+              prevList?.map((s) => (s.id === siteId ? clearStuckPending(s) : s)),
+          );
+          const prevDetail = queryClient.getQueryData<Site>(
+            sitesKeys.detail(siteId),
+          );
+          if (prevDetail) {
+            queryClient.setQueryData<Site>(
+              sitesKeys.detail(siteId),
+              clearStuckPending(prevDetail),
+            );
+          }
+          toast.warning("Screenshot didn't finish", {
+            description:
+              "If you self-host, make sure the media-encoder service is running.",
+          });
+          return;
+        }
         setTimeout(() => void poll(), 3000);
       };
       setTimeout(() => void poll(), 3000);

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -53,7 +53,6 @@ import { Route as AuthedSettingsAccountRouteImport } from './routes/_authed/sett
 import { Route as AuthedScheduleRunsRunIdRouteImport } from './routes/_authed/schedule-runs/$runId'
 import { Route as AuthedRestoresRestoreIdRouteImport } from './routes/_authed/restores/$restoreId'
 import { Route as AuthedClientsClientIdRouteImport } from './routes/_authed/clients/$clientId'
-import { Route as AuthedBackupsSnapshotIdRouteImport } from './routes/_authed/backups/$snapshotId'
 import { Route as AuthedAdminVulnFeedRouteImport } from './routes/_authed/admin/vuln-feed'
 import { Route as AuthedAdminRevenueRouteImport } from './routes/_authed/admin/revenue'
 import { Route as AuthedSitesSiteIdIndexRouteImport } from './routes/_authed/sites/$siteId.index'
@@ -76,6 +75,8 @@ import { Route as AuthedClientsClientIdSitesRouteImport } from './routes/_authed
 import { Route as AuthedClientsClientIdReportsRouteImport } from './routes/_authed/clients/$clientId.reports'
 import { Route as AuthedClientsClientIdMembersRouteImport } from './routes/_authed/clients/$clientId.members'
 import { Route as AuthedAdminAccountsTenantIdRouteImport } from './routes/_authed/admin/accounts/$tenantId'
+import { Route as AuthedSitesSiteIdBackupsIndexRouteImport } from './routes/_authed/sites/$siteId.backups.index'
+import { Route as AuthedSitesSiteIdBackupsSnapshotIdRouteImport } from './routes/_authed/sites/$siteId.backups.$snapshotId'
 
 const VerifyEmailRoute = VerifyEmailRouteImport.update({
   id: '/verify-email',
@@ -297,11 +298,6 @@ const AuthedClientsClientIdRoute = AuthedClientsClientIdRouteImport.update({
   path: '/clients/$clientId',
   getParentRoute: () => AuthedRoute,
 } as any)
-const AuthedBackupsSnapshotIdRoute = AuthedBackupsSnapshotIdRouteImport.update({
-  id: '/backups/$snapshotId',
-  path: '/backups/$snapshotId',
-  getParentRoute: () => AuthedRoute,
-} as any)
 const AuthedAdminVulnFeedRoute = AuthedAdminVulnFeedRouteImport.update({
   id: '/vuln-feed',
   path: '/vuln-feed',
@@ -424,6 +420,18 @@ const AuthedAdminAccountsTenantIdRoute =
     path: '/accounts/$tenantId',
     getParentRoute: () => AuthedAdminRouteRoute,
   } as any)
+const AuthedSitesSiteIdBackupsIndexRoute =
+  AuthedSitesSiteIdBackupsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthedSitesSiteIdBackupsRoute,
+  } as any)
+const AuthedSitesSiteIdBackupsSnapshotIdRoute =
+  AuthedSitesSiteIdBackupsSnapshotIdRouteImport.update({
+    id: '/$snapshotId',
+    path: '/$snapshotId',
+    getParentRoute: () => AuthedSitesSiteIdBackupsRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -451,7 +459,6 @@ export interface FileRoutesByFullPath {
   '/portal/': typeof PortalIndexRoute
   '/admin/revenue': typeof AuthedAdminRevenueRoute
   '/admin/vuln-feed': typeof AuthedAdminVulnFeedRoute
-  '/backups/$snapshotId': typeof AuthedBackupsSnapshotIdRoute
   '/clients/$clientId': typeof AuthedClientsClientIdRouteWithChildren
   '/restores/$restoreId': typeof AuthedRestoresRestoreIdRoute
   '/schedule-runs/$runId': typeof AuthedScheduleRunsRunIdRoute
@@ -477,7 +484,7 @@ export interface FileRoutesByFullPath {
   '/clients/$clientId/reports': typeof AuthedClientsClientIdReportsRoute
   '/clients/$clientId/sites': typeof AuthedClientsClientIdSitesRoute
   '/sites/$siteId/activity': typeof AuthedSitesSiteIdActivityRoute
-  '/sites/$siteId/backups': typeof AuthedSitesSiteIdBackupsRoute
+  '/sites/$siteId/backups': typeof AuthedSitesSiteIdBackupsRouteWithChildren
   '/sites/$siteId/cache': typeof AuthedSitesSiteIdCacheRoute
   '/sites/$siteId/email': typeof AuthedSitesSiteIdEmailRoute
   '/sites/$siteId/errors': typeof AuthedSitesSiteIdErrorsRoute
@@ -492,6 +499,8 @@ export interface FileRoutesByFullPath {
   '/admin/accounts/': typeof AuthedAdminAccountsIndexRoute
   '/clients/$clientId/': typeof AuthedClientsClientIdIndexRoute
   '/sites/$siteId/': typeof AuthedSitesSiteIdIndexRoute
+  '/sites/$siteId/backups/$snapshotId': typeof AuthedSitesSiteIdBackupsSnapshotIdRoute
+  '/sites/$siteId/backups/': typeof AuthedSitesSiteIdBackupsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -516,7 +525,6 @@ export interface FileRoutesByTo {
   '/portal': typeof PortalIndexRoute
   '/admin/revenue': typeof AuthedAdminRevenueRoute
   '/admin/vuln-feed': typeof AuthedAdminVulnFeedRoute
-  '/backups/$snapshotId': typeof AuthedBackupsSnapshotIdRoute
   '/restores/$restoreId': typeof AuthedRestoresRestoreIdRoute
   '/schedule-runs/$runId': typeof AuthedScheduleRunsRunIdRoute
   '/settings/account': typeof AuthedSettingsAccountRoute
@@ -540,7 +548,6 @@ export interface FileRoutesByTo {
   '/clients/$clientId/reports': typeof AuthedClientsClientIdReportsRoute
   '/clients/$clientId/sites': typeof AuthedClientsClientIdSitesRoute
   '/sites/$siteId/activity': typeof AuthedSitesSiteIdActivityRoute
-  '/sites/$siteId/backups': typeof AuthedSitesSiteIdBackupsRoute
   '/sites/$siteId/cache': typeof AuthedSitesSiteIdCacheRoute
   '/sites/$siteId/email': typeof AuthedSitesSiteIdEmailRoute
   '/sites/$siteId/errors': typeof AuthedSitesSiteIdErrorsRoute
@@ -555,6 +562,8 @@ export interface FileRoutesByTo {
   '/admin/accounts': typeof AuthedAdminAccountsIndexRoute
   '/clients/$clientId': typeof AuthedClientsClientIdIndexRoute
   '/sites/$siteId': typeof AuthedSitesSiteIdIndexRoute
+  '/sites/$siteId/backups/$snapshotId': typeof AuthedSitesSiteIdBackupsSnapshotIdRoute
+  '/sites/$siteId/backups': typeof AuthedSitesSiteIdBackupsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -584,7 +593,6 @@ export interface FileRoutesById {
   '/portal/': typeof PortalIndexRoute
   '/_authed/admin/revenue': typeof AuthedAdminRevenueRoute
   '/_authed/admin/vuln-feed': typeof AuthedAdminVulnFeedRoute
-  '/_authed/backups/$snapshotId': typeof AuthedBackupsSnapshotIdRoute
   '/_authed/clients/$clientId': typeof AuthedClientsClientIdRouteWithChildren
   '/_authed/restores/$restoreId': typeof AuthedRestoresRestoreIdRoute
   '/_authed/schedule-runs/$runId': typeof AuthedScheduleRunsRunIdRoute
@@ -610,7 +618,7 @@ export interface FileRoutesById {
   '/_authed/clients/$clientId/reports': typeof AuthedClientsClientIdReportsRoute
   '/_authed/clients/$clientId/sites': typeof AuthedClientsClientIdSitesRoute
   '/_authed/sites/$siteId/activity': typeof AuthedSitesSiteIdActivityRoute
-  '/_authed/sites/$siteId/backups': typeof AuthedSitesSiteIdBackupsRoute
+  '/_authed/sites/$siteId/backups': typeof AuthedSitesSiteIdBackupsRouteWithChildren
   '/_authed/sites/$siteId/cache': typeof AuthedSitesSiteIdCacheRoute
   '/_authed/sites/$siteId/email': typeof AuthedSitesSiteIdEmailRoute
   '/_authed/sites/$siteId/errors': typeof AuthedSitesSiteIdErrorsRoute
@@ -625,6 +633,8 @@ export interface FileRoutesById {
   '/_authed/admin/accounts/': typeof AuthedAdminAccountsIndexRoute
   '/_authed/clients/$clientId/': typeof AuthedClientsClientIdIndexRoute
   '/_authed/sites/$siteId/': typeof AuthedSitesSiteIdIndexRoute
+  '/_authed/sites/$siteId/backups/$snapshotId': typeof AuthedSitesSiteIdBackupsSnapshotIdRoute
+  '/_authed/sites/$siteId/backups/': typeof AuthedSitesSiteIdBackupsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -654,7 +664,6 @@ export interface FileRouteTypes {
     | '/portal/'
     | '/admin/revenue'
     | '/admin/vuln-feed'
-    | '/backups/$snapshotId'
     | '/clients/$clientId'
     | '/restores/$restoreId'
     | '/schedule-runs/$runId'
@@ -695,6 +704,8 @@ export interface FileRouteTypes {
     | '/admin/accounts/'
     | '/clients/$clientId/'
     | '/sites/$siteId/'
+    | '/sites/$siteId/backups/$snapshotId'
+    | '/sites/$siteId/backups/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -719,7 +730,6 @@ export interface FileRouteTypes {
     | '/portal'
     | '/admin/revenue'
     | '/admin/vuln-feed'
-    | '/backups/$snapshotId'
     | '/restores/$restoreId'
     | '/schedule-runs/$runId'
     | '/settings/account'
@@ -743,7 +753,6 @@ export interface FileRouteTypes {
     | '/clients/$clientId/reports'
     | '/clients/$clientId/sites'
     | '/sites/$siteId/activity'
-    | '/sites/$siteId/backups'
     | '/sites/$siteId/cache'
     | '/sites/$siteId/email'
     | '/sites/$siteId/errors'
@@ -758,6 +767,8 @@ export interface FileRouteTypes {
     | '/admin/accounts'
     | '/clients/$clientId'
     | '/sites/$siteId'
+    | '/sites/$siteId/backups/$snapshotId'
+    | '/sites/$siteId/backups'
   id:
     | '__root__'
     | '/'
@@ -786,7 +797,6 @@ export interface FileRouteTypes {
     | '/portal/'
     | '/_authed/admin/revenue'
     | '/_authed/admin/vuln-feed'
-    | '/_authed/backups/$snapshotId'
     | '/_authed/clients/$clientId'
     | '/_authed/restores/$restoreId'
     | '/_authed/schedule-runs/$runId'
@@ -827,6 +837,8 @@ export interface FileRouteTypes {
     | '/_authed/admin/accounts/'
     | '/_authed/clients/$clientId/'
     | '/_authed/sites/$siteId/'
+    | '/_authed/sites/$siteId/backups/$snapshotId'
+    | '/_authed/sites/$siteId/backups/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -1154,13 +1166,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedClientsClientIdRouteImport
       parentRoute: typeof AuthedRoute
     }
-    '/_authed/backups/$snapshotId': {
-      id: '/_authed/backups/$snapshotId'
-      path: '/backups/$snapshotId'
-      fullPath: '/backups/$snapshotId'
-      preLoaderRoute: typeof AuthedBackupsSnapshotIdRouteImport
-      parentRoute: typeof AuthedRoute
-    }
     '/_authed/admin/vuln-feed': {
       id: '/_authed/admin/vuln-feed'
       path: '/vuln-feed'
@@ -1315,6 +1320,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedAdminAccountsTenantIdRouteImport
       parentRoute: typeof AuthedAdminRouteRoute
     }
+    '/_authed/sites/$siteId/backups/': {
+      id: '/_authed/sites/$siteId/backups/'
+      path: '/'
+      fullPath: '/sites/$siteId/backups/'
+      preLoaderRoute: typeof AuthedSitesSiteIdBackupsIndexRouteImport
+      parentRoute: typeof AuthedSitesSiteIdBackupsRoute
+    }
+    '/_authed/sites/$siteId/backups/$snapshotId': {
+      id: '/_authed/sites/$siteId/backups/$snapshotId'
+      path: '/$snapshotId'
+      fullPath: '/sites/$siteId/backups/$snapshotId'
+      preLoaderRoute: typeof AuthedSitesSiteIdBackupsSnapshotIdRouteImport
+      parentRoute: typeof AuthedSitesSiteIdBackupsRoute
+    }
   }
 }
 
@@ -1397,9 +1416,26 @@ const AuthedClientsClientIdRouteWithChildren =
     AuthedClientsClientIdRouteChildren,
   )
 
+interface AuthedSitesSiteIdBackupsRouteChildren {
+  AuthedSitesSiteIdBackupsSnapshotIdRoute: typeof AuthedSitesSiteIdBackupsSnapshotIdRoute
+  AuthedSitesSiteIdBackupsIndexRoute: typeof AuthedSitesSiteIdBackupsIndexRoute
+}
+
+const AuthedSitesSiteIdBackupsRouteChildren: AuthedSitesSiteIdBackupsRouteChildren =
+  {
+    AuthedSitesSiteIdBackupsSnapshotIdRoute:
+      AuthedSitesSiteIdBackupsSnapshotIdRoute,
+    AuthedSitesSiteIdBackupsIndexRoute: AuthedSitesSiteIdBackupsIndexRoute,
+  }
+
+const AuthedSitesSiteIdBackupsRouteWithChildren =
+  AuthedSitesSiteIdBackupsRoute._addFileChildren(
+    AuthedSitesSiteIdBackupsRouteChildren,
+  )
+
 interface AuthedSitesSiteIdRouteChildren {
   AuthedSitesSiteIdActivityRoute: typeof AuthedSitesSiteIdActivityRoute
-  AuthedSitesSiteIdBackupsRoute: typeof AuthedSitesSiteIdBackupsRoute
+  AuthedSitesSiteIdBackupsRoute: typeof AuthedSitesSiteIdBackupsRouteWithChildren
   AuthedSitesSiteIdCacheRoute: typeof AuthedSitesSiteIdCacheRoute
   AuthedSitesSiteIdEmailRoute: typeof AuthedSitesSiteIdEmailRoute
   AuthedSitesSiteIdErrorsRoute: typeof AuthedSitesSiteIdErrorsRoute
@@ -1416,7 +1452,7 @@ interface AuthedSitesSiteIdRouteChildren {
 
 const AuthedSitesSiteIdRouteChildren: AuthedSitesSiteIdRouteChildren = {
   AuthedSitesSiteIdActivityRoute: AuthedSitesSiteIdActivityRoute,
-  AuthedSitesSiteIdBackupsRoute: AuthedSitesSiteIdBackupsRoute,
+  AuthedSitesSiteIdBackupsRoute: AuthedSitesSiteIdBackupsRouteWithChildren,
   AuthedSitesSiteIdCacheRoute: AuthedSitesSiteIdCacheRoute,
   AuthedSitesSiteIdEmailRoute: AuthedSitesSiteIdEmailRoute,
   AuthedSitesSiteIdErrorsRoute: AuthedSitesSiteIdErrorsRoute,
@@ -1445,7 +1481,6 @@ interface AuthedRouteChildren {
   AuthedSharedWithMeRoute: typeof AuthedSharedWithMeRoute
   AuthedUptimeRoute: typeof AuthedUptimeRoute
   AuthedVulnerabilitiesRoute: typeof AuthedVulnerabilitiesRoute
-  AuthedBackupsSnapshotIdRoute: typeof AuthedBackupsSnapshotIdRoute
   AuthedClientsClientIdRoute: typeof AuthedClientsClientIdRouteWithChildren
   AuthedRestoresRestoreIdRoute: typeof AuthedRestoresRestoreIdRoute
   AuthedScheduleRunsRunIdRoute: typeof AuthedScheduleRunsRunIdRoute
@@ -1469,7 +1504,6 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedSharedWithMeRoute: AuthedSharedWithMeRoute,
   AuthedUptimeRoute: AuthedUptimeRoute,
   AuthedVulnerabilitiesRoute: AuthedVulnerabilitiesRoute,
-  AuthedBackupsSnapshotIdRoute: AuthedBackupsSnapshotIdRoute,
   AuthedClientsClientIdRoute: AuthedClientsClientIdRouteWithChildren,
   AuthedRestoresRestoreIdRoute: AuthedRestoresRestoreIdRoute,
   AuthedScheduleRunsRunIdRoute: AuthedScheduleRunsRunIdRoute,

--- a/apps/web/src/routes/_authed/restores/$restoreId.tsx
+++ b/apps/web/src/routes/_authed/restores/$restoreId.tsx
@@ -241,8 +241,8 @@ function RestoreDetailView({ run }: { run: RestoreRun }) {
                 label: "Source snapshot",
                 value: (
                   <Link
-                    to="/backups/$snapshotId"
-                    params={{ snapshotId: run.snapshot_id }}
+                    to="/sites/$siteId/backups/$snapshotId"
+                    params={{ siteId: run.site_id, snapshotId: run.snapshot_id }}
                     className="font-mono text-xs underline-offset-2 hover:underline"
                   >
                     {run.snapshot_id.slice(0, 8)}

--- a/apps/web/src/routes/_authed/schedule-runs/$runId.tsx
+++ b/apps/web/src/routes/_authed/schedule-runs/$runId.tsx
@@ -239,8 +239,8 @@ function ScheduleRunDetailView({ run }: { run: ScheduleRun }) {
                 label: "Snapshot",
                 value: run.snapshot_id ? (
                   <Link
-                    to="/backups/$snapshotId"
-                    params={{ snapshotId: run.snapshot_id }}
+                    to="/sites/$siteId/backups/$snapshotId"
+                    params={{ siteId: run.site_id, snapshotId: run.snapshot_id }}
                     className="font-mono text-xs underline-offset-2 hover:underline"
                   >
                     {run.snapshot_id.slice(0, 8)}

--- a/apps/web/src/routes/_authed/sites/$siteId.backups.$snapshotId.tsx
+++ b/apps/web/src/routes/_authed/sites/$siteId.backups.$snapshotId.tsx
@@ -41,12 +41,23 @@ import { useSite } from "@/features/sites/use-sites";
 import { cn, formatBytes, relativeTime } from "@/lib/utils";
 import type { BackupSnapshot, BackupSnapshotDetail } from "@wpmgr/api";
 
-export const Route = createFileRoute("/_authed/backups/$snapshotId")({
+// `/sites/$siteId/backups/$snapshotId` — snapshot detail.
+//
+// GH #188: moved here from the top-level, siteId-less `/backups/$snapshotId`
+// route so the pathname carries siteId and the top-bar breadcrumb (a pure
+// pathname->label mapper) renders `Sites › <siteId> › Backups ›
+// <snapshotId>` with "Backups" correctly linking back to THIS site's
+// Backups tab instead of the fleet-wide `/backups` list. See the layout at
+// `$siteId.backups.tsx` for the route-nesting rationale.
+
+export const Route = createFileRoute(
+  "/_authed/sites/$siteId/backups/$snapshotId",
+)({
   component: SnapshotDetailPage,
 });
 
 function SnapshotDetailPage() {
-  const { snapshotId } = Route.useParams();
+  const { siteId, snapshotId } = Route.useParams();
   const { data, isPending, isError, error, refetch } = useBackup(snapshotId);
   const { data: me } = useMe();
   const operate = canOperate(me);
@@ -60,7 +71,9 @@ function SnapshotDetailPage() {
       return (
         <section aria-labelledby="snapshot-heading" className="space-y-4">
           <Button asChild variant="outline" size="sm">
-            <Link to="/sites">Back to sites</Link>
+            <Link to="/sites/$siteId/backups" params={{ siteId }}>
+              Back to backups
+            </Link>
           </Button>
           <div role="alert" className="space-y-2">
             <h1 id="snapshot-heading" className="text-2xl font-semibold">
@@ -78,7 +91,9 @@ function SnapshotDetailPage() {
     return (
       <section aria-labelledby="snapshot-heading" className="space-y-4">
         <Button asChild variant="outline" size="sm">
-          <Link to="/sites">Back to sites</Link>
+          <Link to="/sites/$siteId/backups" params={{ siteId }}>
+            Back to backups
+          </Link>
         </Button>
         <PageError
           what="Could not load this snapshot."
@@ -90,7 +105,7 @@ function SnapshotDetailPage() {
     );
   }
 
-  return <SnapshotDetailView detail={data} canRestore={operate} />;
+  return <SnapshotDetailView siteId={siteId} detail={data} canRestore={operate} />;
 }
 
 function DetailSkeleton() {
@@ -123,9 +138,11 @@ function isInFlight(snapshot: BackupSnapshot): boolean {
 }
 
 function SnapshotDetailView({
+  siteId,
   detail,
   canRestore,
 }: {
+  siteId: string;
   detail: BackupSnapshotDetail;
   canRestore: boolean;
 }) {
@@ -137,20 +154,21 @@ function SnapshotDetailView({
   );
   const navigate = useNavigate();
 
-  const deleteBackup = useDeleteBackup(snapshot.id, snapshot.site_id);
-  const cancelBackup = useCancelBackup(snapshot.id, snapshot.site_id);
+  const deleteBackup = useDeleteBackup(snapshot.id, siteId);
+  const cancelBackup = useCancelBackup(snapshot.id, siteId);
 
   function backToSiteBackups() {
     void navigate({
       to: "/sites/$siteId/backups",
-      params: { siteId: snapshot.site_id },
+      params: { siteId },
     });
   }
 
-  // Resolve the originating site so the back-link returns to the right
-  // Backups tab (not the global sites list) and so the destructive-confirm
-  // can use the real host.
-  const { data: site } = useSite(snapshot.site_id);
+  // Resolve the site so the destructive-confirm can use the real host, and
+  // so the header shows the site name (the back-link target is already
+  // known from the URL itself, unlike before GH #188 where it had to be
+  // derived from `snapshot.site_id`).
+  const { data: site } = useSite(siteId);
 
   // ALWAYS open the SSE stream on this page so the first restore event lands
   // and triggers the progress card to render. The returned state is consumed
@@ -274,7 +292,7 @@ function SnapshotDetailView({
         actions={headerActions}
         backTo={{
           to: "/sites/$siteId/backups",
-          params: { siteId: snapshot.site_id },
+          params: { siteId },
           label: site?.name
             ? `Back to ${site.name} backups`
             : "Back to site backups",

--- a/apps/web/src/routes/_authed/sites/$siteId.backups.index.tsx
+++ b/apps/web/src/routes/_authed/sites/$siteId.backups.index.tsx
@@ -1,0 +1,25 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { BackupsSection } from "@/features/backups/backups-section";
+import { useMe, canOperate } from "@/features/auth/use-auth";
+
+// `/sites/$siteId/backups` (index) — recent snapshots + schedule + run-now
+// (operator+). Moved here from `$siteId.backups.tsx` (GH #188), which is now
+// the layout that renders this index alongside the sibling
+// `$siteId.backups.$snapshotId.tsx` detail route.
+
+export const Route = createFileRoute("/_authed/sites/$siteId/backups/")({
+  component: BackupsTab,
+});
+
+function BackupsTab() {
+  const { siteId } = Route.useParams();
+  const { data: me } = useMe();
+  const operate = canOperate(me);
+
+  return (
+    <section aria-label="Backups" className="px-4 pb-8 pt-6 sm:px-6">
+      <BackupsSection siteId={siteId} canOperate={operate} />
+    </section>
+  );
+}

--- a/apps/web/src/routes/_authed/sites/$siteId.backups.tsx
+++ b/apps/web/src/routes/_authed/sites/$siteId.backups.tsx
@@ -1,22 +1,27 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Outlet } from "@tanstack/react-router";
 
-import { BackupsSection } from "@/features/backups/backups-section";
-import { useMe, canOperate } from "@/features/auth/use-auth";
-
-// `/sites/$siteId/backups` — recent snapshots + schedule + run-now (operator+).
+// `/sites/$siteId/backups` — LAYOUT for the site-scoped backups surface.
+//
+// GH #188: the snapshot detail used to live at the top-level, siteId-less
+// `/backups/$snapshotId` route, so the breadcrumb (a pure pathname->label
+// mapper, see components/layout/top-bar-helpers.ts) could only render
+// `Backups › <snapshotId>` with "Backups" linking to the FLEET `/backups`
+// list — a dead end that doesn't contain the snapshot. Nesting the snapshot
+// detail under `/sites/$siteId/backups/$snapshotId` (mirroring how every
+// other site tab works) makes the pathname itself carry siteId, so the
+// breadcrumb mapper produces `Sites › <siteId> › Backups › <snapshotId>`
+// with "Backups" correctly linking back to this site's Backups tab, with NO
+// change to the breadcrumb mechanism itself.
+//
+// This file is now a pure layout (no content of its own): the list body
+// lives in `$siteId.backups.index.tsx` and the snapshot detail lives in
+// `$siteId.backups.$snapshotId.tsx` — same layout+index pattern the site
+// shell already uses at `$siteId.tsx` / `$siteId.index.tsx`.
 
 export const Route = createFileRoute("/_authed/sites/$siteId/backups")({
-  component: BackupsTab,
+  component: BackupsLayout,
 });
 
-function BackupsTab() {
-  const { siteId } = Route.useParams();
-  const { data: me } = useMe();
-  const operate = canOperate(me);
-
-  return (
-    <section aria-label="Backups" className="px-4 pb-8 pt-6 sm:px-6">
-      <BackupsSection siteId={siteId} canOperate={operate} />
-    </section>
-  );
+function BackupsLayout() {
+  return <Outlet />;
 }

--- a/docs/adr/ADR-043-media-optimizer-architecture.md
+++ b/docs/adr/ADR-043-media-optimizer-architecture.md
@@ -4,6 +4,14 @@
 **Relates:** ADR-033 (backup transport — presigned S3), ADR-010 (object storage), ADR-031 (CP→agent signed commands).
 **Recon:** `analysis/media-optimizer-recon.md`.
 
+> **Update (2026-07-08, GH #187):** the self-host Compose deployment mechanism
+> described below (an opt-in `media` profile) is superseded — `media-encoder`
+> is now part of the base stack and starts by default, because gating it left
+> both the Media Optimizer and site screenshots silently dead on a plain
+> `docker compose up -d`. The rest of this ADR (separate image, presigned-URL
+> transport, no bytes on the CP) is unchanged. See
+> [install.md](../install.md#media-encoder).
+
 ## Context
 
 WPMgr is adding a Media Optimizer (JPEG/PNG → WebP/AVIF) with a product surface

--- a/docs/architecture/media-optimizer.md
+++ b/docs/architecture/media-optimizer.md
@@ -15,24 +15,28 @@ presigned S3); command channel: ADR-031 (CP→agent signed commands).
 > Encoding runs on WPMgr's own Go control plane using Discord's `lilliput` (MIT).
 > See [apps/agent/NOTICE.md](../../apps/agent/NOTICE.md).
 
-## Two binaries, one of them optional
+## Two binaries, one separate image
 
-| Service | Image | Encoding | Always on |
-|---------|-------|----------|-----------|
-| **Main API** (`cmd/wpmgr`) | `distroless/static`, `CGO_ENABLED=0` | none — serves DTOs, owns metadata + RLS | yes |
-| **`media-encoder`** (`cmd/media-encoder`) | `distroless/base-nonroot`, **CGO + glibc + lilliput** | runs the `media_encode` River worker | **opt-in** |
+| Service | Image | Encoding | Compose default |
+|---------|-------|----------|------------------|
+| **Main API** (`cmd/wpmgr`) | `distroless/static`, `CGO_ENABLED=0` | none — serves DTOs, owns metadata + RLS | on |
+| **`media-encoder`** (`cmd/media-encoder`) | `debian:trixie-slim`, **CGO + glibc + lilliput + headless Chromium** | runs the `media_encode`/screenshot/font-transcode River workers | on (base stack; see below) |
 
 `lilliput` is CGO + native codec libraries (libaom/dav1d for AVIF, libwebp,
 mozjpeg-class JPEG), so it cannot live in the lean static API image. It is
-isolated in a **separate, optional** service behind a compose profile:
+isolated in a **separate** service/image:
 
 ```bash
-docker compose --profile media up   # bring up the encoder
+docker compose -f infra/docker-compose.yml up -d   # brings up the encoder too, no profile needed
 ```
 
-A self-hoster who skips the profile keeps a minimal static API and simply has no
-optimize feature. On the hosted deployment the same container is a second Cloud
-Run service connecting to the same Postgres + object storage — nothing here is
+The encoder is part of the base Compose stack (GH #187 — it used to be behind
+an opt-in `media` profile, which silently left screenshots and image
+optimization dead on a default `up`). A self-hoster who wants a leaner
+footprint can disable it (`--scale media-encoder=0`, or comment out the
+service) and keep a minimal static API with no optimize/screenshot feature. On
+the hosted deployment the same container is a second Cloud Run service
+connecting to the same Postgres + object storage — nothing here is
 GCP-specific.
 
 ## Transport: presigned S3, no bytes on the CP

--- a/docs/features/media-optimizer.md
+++ b/docs/features/media-optimizer.md
@@ -9,13 +9,17 @@ Design: [ADR-043](../adr/ADR-043-media-optimizer-architecture.md).
 Architecture: [architecture/media-optimizer.md](../architecture/media-optimizer.md).
 API: [api/media.md](../api/media.md).
 
-> **Optional self-host component.** The encoder is opt-in. A self-hoster who
-> wants image optimization runs `docker compose --profile media up`; one who
-> doesn't simply omits the profile and their core API stays a minimal static
-> binary. See [install.md](../install.md).
+> **Self-host: on by default.** The `media-encoder` service is part of the base
+> Compose stack — a plain `docker compose up -d` starts it, no profile needed.
+> It's a separate service/image (CGO + native codec libs + headless Chromium)
+> so the core API stays a minimal `CGO_ENABLED=0` static binary regardless. On
+> a RAM-constrained host you can disable it (`--scale media-encoder=0` or
+> comment out the service); the Media Optimizer tab (and site screenshots) then
+> go unavailable while everything else keeps working. See
+> [install.md](../install.md#media-encoder).
 >
-> The bundled Compose profile isolates encoder-owned River jobs in the
-> `media_encoder` schema. If you deploy API and encoder separately, set the same
+> The Compose stack isolates encoder-owned River jobs in the `media_encoder`
+> schema. If you deploy API and encoder separately, set the same
 > `WPMGR_RIVER_MEDIA_SCHEMA` value on both processes.
 
 ## The Media tab

--- a/docs/features/sites.md
+++ b/docs/features/sites.md
@@ -72,15 +72,15 @@ is ready, with no manual reload.
 
 ### Self-host note
 
-Screenshots require the `media-encoder` service with headless Chromium. Start it
-with the `media` profile:
+Screenshots require the `media-encoder` service (headless Chromium). It is part
+of the base Compose stack and starts automatically with a plain
+`docker compose -f infra/docker-compose.yml up -d` — no profile or extra flag
+needed.
 
-```bash
-docker compose -f infra/docker-compose.yml --profile media up -d
-```
-
-Without the media-encoder, screenshot requests are accepted but captures never
-run; cards degrade to favicon / monogram permanently.
+If you disabled it (e.g. `--scale media-encoder=0` on a RAM-constrained host —
+see [install.md](../install.md#media-encoder)), screenshot requests are
+accepted but captures never run; cards degrade to favicon / monogram
+permanently.
 
 ---
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -176,7 +176,9 @@ docker compose -f infra/docker-compose.yml up -d
 ```
 
 This starts Postgres, Redis, SeaweedFS (S3 gateway on `:8333`), ClickHouse, the
-API, and the web dashboard (served by nginx). To avoid colliding with anything
+API, the web dashboard (served by nginx), and the media-encoder (screenshots +
+Media Optimizer — see [Media encoder](#media-encoder) below for its resource
+footprint and how to disable it). To avoid colliding with anything
 already bound on the host, the **published** host ports default to non-standard
 values — the dashboard on **`:8088`** and the API on **`:8081`** (the
 container-side ports are unchanged, so in-network wiring is unaffected). Override
@@ -198,7 +200,8 @@ docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -
 
 The overlay only swaps the three app services to `image:` + `pull_policy:
 always`; everything else (Postgres, Redis, SeaweedFS, ClickHouse, env, volumes)
-is inherited from the base file. Add `--profile media` for the encoder.
+is inherited from the base file, including `media-encoder` — it starts by
+default, no profile needed.
 
 > GHCR packages are public. `docker pull` needs no auth. arm64 multi-arch
 > images are a near-term follow-up.
@@ -226,31 +229,47 @@ Open the dashboard at `http://localhost:8088` (the default `WPMGR_WEB_PORT`; the
 `web` service serves the built SPA via nginx and proxies to the API). Set
 `WPMGR_WEB_PORT=80` in `.env` if you want it on the standard HTTP port.
 
-## Optional: Media Optimizer
+## Media encoder
 
-Image encoding (JPEG/PNG to WebP/AVIF) runs on a separate encoder service that
-is opt-in. Enable it with the `media` Compose profile:
+Image encoding (JPEG/PNG to WebP/AVIF, the Media Optimizer tab) and site
+screenshot capture (the Sites grid cards) both run on a separate `media-encoder`
+service. It is part of the **base** stack and starts automatically with the
+plain `docker compose -f infra/docker-compose.yml up -d` shown above — no
+Compose profile or extra flag needed. This means both features work out of the
+box on a default install.
+
+Resource footprint: the image bundles headless Chromium for screenshot capture,
+so it is noticeably heavier than the api/web images (expect on the order of a
+few hundred MB of additional RAM at idle, more while a capture or encode job is
+running). If you're on a constrained host and don't need screenshots or image
+optimization, disable it without editing the compose file:
 
 ```bash
-docker compose -f infra/docker-compose.yml --profile media up -d
+# scale it to zero — api/web still start normally
+docker compose -f infra/docker-compose.yml up -d --scale media-encoder=0
 ```
 
-The bundled Compose profile sets `WPMGR_RIVER_MEDIA_SCHEMA=media_encoder` on
-both the API and media-encoder services. Custom deployments should set the same
-value on both processes so media and screenshot jobs are inserted into the
-schema the encoder is polling. When this value names a dedicated schema, the
-encoder also needs the migration-owner DSN so it can create and migrate that
-schema safely.
+or comment out the `media-encoder:` service block in `infra/docker-compose.yml`
+if you never want it built/pulled at all. Either way, screenshot cards fall back
+to favicon/monogram permanently and the Media Optimizer tab is unavailable —
+everything else in the dashboard is unaffected.
 
-Upgrade note: on existing deployments, enabling the bundled `media_encoder`
-default does not migrate already queued `media_encode` or
-`site_screenshot_capture` rows from `public.river_job`. Drain media and
+The compose file sets `WPMGR_RIVER_MEDIA_SCHEMA=media_encoder` on both the API
+and media-encoder services. Custom deployments should set the same value on
+both processes so media and screenshot jobs are inserted into the schema the
+encoder is polling. When this value names a dedicated schema, the encoder also
+needs the migration-owner DSN so it can create and migrate that schema safely.
+
+Upgrade note: on deployments upgrading from before the `media_encoder` schema
+became the default, enabling it does not migrate already-queued `media_encode`
+or `site_screenshot_capture` rows from `public.river_job`. Drain media and
 screenshot jobs before upgrading, or set `WPMGR_RIVER_MEDIA_SCHEMA=` / `public`
 on both services to keep the current shared-schema behavior until you are ready
 to switch.
 
-Without the profile the core API starts fine; the Media Optimizer tab in the
-dashboard is unavailable. See [features/media-optimizer.md](./features/media-optimizer.md).
+See [features/media-optimizer.md](./features/media-optimizer.md) and
+[features/sites.md](./features/sites.md#website-screenshots) for the features
+themselves.
 
 ## Observability profile
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -48,12 +48,12 @@ WordPress sites. Threat surface and mitigations:
   `image/png` decode; anything else is rejected (`ErrUnsupportedSource`) and
   recorded `excluded`. The decoder is guarded by **50 MB** and **100 MP** limits
   (`ErrDimensionsTooBig`) and a **60s per-encode timeout** (`ErrEncoderTimeout`).
-- **Blast-radius isolation.** All decode/encode runs in the **optional
-  `media-encoder` container** (CGO + native codec libs), never in the static main
-  API. The `media_encode` River queue is bounded (small `MaxWorkers`) so a burst
-  of large images can't OOM the instance, and the encoder process is the only
-  place native codec CVE surface exists — a self-hoster who doesn't run the
-  `media` profile has none of it.
+- **Blast-radius isolation.** All decode/encode runs in the separate
+  **`media-encoder` container** (CGO + native codec libs), never in the static
+  main API. The `media_encode` River queue is bounded (small `MaxWorkers`) so a
+  burst of large images can't OOM the instance, and the encoder process is the
+  only place native codec CVE surface exists — a self-hoster who disables it
+  (it runs by default; `--scale media-encoder=0` opts out) has none of it.
 - **No media bytes on the control plane.** Bytes move agent ↔ object storage over
   **presigned URLs** (the backup transport, ADR-033); the CP never streams or
   persists source or optimized image bytes, and never calls a live `GetObject`

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -4,9 +4,10 @@
 #   export WPMGR_VERSION=v0.19.0     # omit to track :latest
 #   docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 #
-# Add the usual profiles as needed, e.g. the media encoder:
-#   docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml \
-#     --profile media up -d
+# media-encoder is part of the base stack's default service set (no profile
+# needed) — this overlay just swaps its image for the published GHCR one like
+# api/web. To disable it on a constrained host, add `--scale media-encoder=0`
+# to the `up` command above.
 #
 # `pull_policy: always` makes `up` pull the GHCR image rather than building the
 # base file's local `build:` stanza. All other service config (env, ports,

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,6 +1,8 @@
 # WPMgr — full self-host stack.
 #
-# Base profile: postgres, redis, seaweedfs (S3 gateway), clickhouse, api, web.
+# Base profile: postgres, redis, seaweedfs (S3 gateway), clickhouse, api, web,
+# media-encoder (screenshots + Media Optimizer — runs by default, see the
+# media-encoder service below for how to disable it on constrained hosts).
 # Optional "observability" profile adds a grafana/otel-lgtm backend.
 #
 # Image tags are pinned (no :latest). Bring up with:
@@ -191,6 +193,14 @@ services:
       WPMGR_S3_SECRET_KEY: ${WPMGR_S3_SECRET_KEY:-wpmgr-dev-secret}
       WPMGR_S3_FORCE_PATH_STYLE: "true"
       WPMGR_RIVER_MEDIA_SCHEMA: ${WPMGR_RIVER_MEDIA_SCHEMA:-media_encoder}
+      # WPMGR_MEDIA_ENCODER_URL is intentionally NOT set here. It only matters on
+      # a scale-to-zero deployment (Cloud Run), where the api holds a blocking
+      # POST to the encoder's /internal/drain to wake a cold instance — see
+      # internal/media/waker.go. In this compose stack media-encoder is a
+      # long-lived always-on container that polls Postgres directly, so there is
+      # nothing to wake; leaving this unset makes EncoderWaker a no-op, which is
+      # correct here (and it has no GCP metadata server to mint an ID token from
+      # anyway).
       WPMGR_CLICKHOUSE_ADDR: clickhouse:9000
       WPMGR_CLICKHOUSE_DB: ${WPMGR_CLICKHOUSE_DB:-wpmgr_metrics}
       WPMGR_OTEL_EXPORTER_OTLP_ENDPOINT: ${WPMGR_OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-lgtm:4318}
@@ -220,22 +230,34 @@ services:
     # (GET /healthz, GET /readyz), add an HTTP healthcheck (e.g. via a small
     # busybox sidecar or by embedding a `wpmgr healthcheck` subcommand). TODO.
 
-  # Media Optimizer encode worker (ADR-043, M23). OPTIONAL: behind the `media`
-  # profile so a self-hoster who doesn't want image optimization simply doesn't
-  # run it (and their core API stays a minimal CGO_ENABLED=0 static binary).
-  # Bring it up with:  docker compose --profile media up
+  # Media Optimizer / screenshot encode worker (ADR-043, M23). Part of the BASE
+  # stack (GH #187): screenshots (Sites grid cards) and the Media Optimizer tab
+  # both depend on this service, and a default `docker compose up -d` must make
+  # them work out of the box — an opt-in `media` Compose profile silently left
+  # both features dead on a plain `up`. It's the ONLY consumer of the CGO +
+  # lilliput + headless-Chromium image, so the core api stays a minimal
+  # CGO_ENABLED=0 static binary regardless.
   #
   # It connects to the SAME Postgres + object storage as the api (it runs under
   # the app.agent RLS GUC and moves bytes via presigned URLs — no extra grants).
   # It registers River workers for encoder-owned queues; the api only inserts
   # those jobs, so media work is only ever executed here.
+  #
+  # Resource footprint: this image bundles headless Chromium for screenshot
+  # capture, so it is noticeably heavier than the api/web images (expect it to
+  # add on the order of a few hundred MB RSS at idle, more while a capture or
+  # encode is in flight). On a RAM-constrained host you can disable it without
+  # editing this file — either scale it to zero:
+  #   docker compose -f infra/docker-compose.yml up -d --scale media-encoder=0
+  # or comment out this service block. Either way the api and dashboard still
+  # start fine; screenshots stop refreshing (cards fall back to favicon/
+  # monogram) and the Media tab's optimize action never completes.
   media-encoder:
     build:
       context: ..
       dockerfile: infra/Dockerfile.media-encoder
     image: wpmgr-media-encoder:dev
     restart: unless-stopped
-    profiles: ["media"]
     env_file:
       - path: ../.env
         required: false

--- a/scripts/quickstart-selfhost.sh
+++ b/scripts/quickstart-selfhost.sh
@@ -223,8 +223,10 @@ WPMgr is ready to start. Run:
   cd $(pwd)
   docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 
-To use the media optimizer (image encoding to WebP/AVIF), add --profile media:
-  docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml --profile media up -d
+This includes the media-encoder (screenshots + image optimizer to WebP/AVIF) by
+default — no extra flag needed. It runs headless Chromium, so it adds some RAM;
+to skip it on a constrained host, add --scale media-encoder=0 to the command
+above.
 
 Verify:
   curl localhost:${api_port}/healthz    # {"status":"ok"}


### PR DESCRIPTION
#188: nest the snapshot detail under the site so breadcrumbs read Sites > site > Backups. #187: media-encoder now runs by default on self-host (was opt-in, silently disabling screenshots); refresh no longer spins forever silently (warns + specific errors); disabled path returns 501 not 500. web+api+infra+docs, tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Site backups and snapshot details now use site-specific URLs, with breadcrumbs and “View” links pointing to the current site’s backups area.
  * Screenshot refresh now provides clearer status messages and warning feedback when captures can’t complete.

* **Bug Fixes**
  * Fixed backup navigation so users no longer land on dead-end or incorrect backup paths.
  * Fixed screenshot refresh from appearing to spin forever when the capture service isn’t available.
  * Self-hosted deployments now start the media encoder by default; it can be disabled if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->