### PR TITLE
fix: org switch immediate (#186) + fleet CWV all-3-metrics (#195) + CLS distribution matches p75 (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
-## [0.61.49] - 2026-07-09
+## [0.61.50] - 2026-07-09
+
+### Fixed
+
+- Switching organizations now takes effect immediately instead of only after a browser refresh (GH #186). The switch was clearing the cached data but not re-fetching it, so the view stayed on the previous organization until something else happened to trigger a reload; this was most visible when switching to an empty organization (which produced no live events to nudge a refresh). The same latent issue in the organization-delete path is fixed too.
+- Fleet-wide Core Web Vitals pass rate and the "worst offenders" table now consider all three Core Web Vitals, not just LCP (GH #195). A site with a good LCP but a failing CLS or INP was previously counted as passing in the fleet headline and never surfaced as a worst offender, even though its own per-site page correctly showed "Does not pass"; the fleet view now marks a site as passing only when LCP, INP, and CLS all pass, and surfaces sites failing on any of the three.
+- The CLS good / needs-improvement / poor distribution bar no longer contradicts the p75 rating shown next to it (GH #185). The distribution was classifying whole histogram buckets by their lower edge, but the CLS thresholds fall inside a bucket, so a value that the p75 correctly rated "needs work" could still show as 100% good. The distribution now splits a straddling bucket proportionally at the threshold, using the same assumption the p75 calculation already uses, so the two agree. LCP and INP distributions are unchanged.
 
 ### Fixed
 

--- a/apps/api/internal/perf/dto.go
+++ b/apps/api/internal/perf/dto.go
@@ -465,14 +465,17 @@ func nonNil(s []string) []string {
 // largest-remainder rounding). Distribution is nil (omitted) when the slice
 // is suppressed (SampleCount < min_sample_count).
 //
-// CLS distribution caveat: the CrUX histogram boundaries start at 200 ms-units
-// while the CLS "good" threshold is 100 milli-units and "NI" is 250 milli-units.
-// The entire first bucket [0, 200) straddles both boundaries, so it is assigned
-// wholesale to "good" per the straddle-to-lower-band rule. This means CLS
-// distribution is coarse for V1: the "good" band is slightly over-counted and
-// "needs_improvement" slightly under-counted relative to the true split within
-// [0, 200). The effect is minor in practice (most CLS values are near 0) and
-// will be refined in a future iteration using sub-200 histogram resolution.
+// CLS distribution note: the CrUX histogram boundaries start at 200 ms-units
+// while the CLS "good" threshold is 100 milli-units and "NI" is 250
+// milli-units, so the first two buckets ([0,200) and [200,300)) each straddle
+// a threshold. foldBucketsIntoDistribution splits a straddling bucket
+// proportionally at the threshold, assuming samples are uniformly distributed
+// within the bucket — the same assumption InterpolateP75FromCounts (p75.go)
+// uses when interpolating a p75 value inside a bucket. This keeps the
+// reported distribution consistent with the p75 rating by construction (GH
+// #185): e.g. 16 CLS samples all in [0,200) interpolate to p75=150 -> "needs
+// improvement", and the distribution now reports 8 good / 8 needs-improvement
+// rather than crediting the whole bucket to "good".
 type RumDistribution struct {
 	Good                int64 `json:"good"`
 	NeedsImprovement    int64 `json:"needs_improvement"`
@@ -486,59 +489,142 @@ type RumDistribution struct {
 // into three bands (good / needs-improvement / poor) using the official CWV
 // thresholds for the given metric.
 //
-// Fold rule: a bucket is assigned to the band whose upper bound first reaches
-// or exceeds the band boundary. Concretely, a bucket whose ENTIRE value range
-// is ≤ good-threshold goes to "good"; one entirely within (good, NI] goes to
-// "needs_improvement"; otherwise "poor". A bucket that straddles a threshold
-// (i.e. its lower bound is below the threshold but its upper bound is above) is
-// assigned to the LOWER band (conservative/PSI-compatible behaviour). For
-// LCP/FCP/TTFB/INP the thresholds coincide exactly with CrUX bucket boundaries,
-// so no bucket straddles and the fold is exact. For CLS (thresholds 100/250) the
-// first bucket [0,200) straddles both 100 and 250; it is assigned to "good".
-// See the RumDistribution comment for the full CLS coarseness caveat.
+// Fold rule: a bucket whose entire value range [lo, hi) falls on one side of
+// the good/NI thresholds is assigned wholesale to that band. A bucket that
+// straddles a threshold is split PROPORTIONALLY at the threshold, assuming
+// samples are uniformly distributed within the bucket — the same assumption
+// rum.InterpolateP75FromCounts (p75.go) makes when interpolating a p75 value
+// inside a bucket. This keeps the reported distribution consistent with the
+// p75 rating by construction (GH #185): a bucket can no longer be counted
+// 100% "good" while its p75 lands in "needs improvement".
+//
+// For LCP/FCP/TTFB/INP the thresholds coincide exactly with CrUX bucket
+// boundaries, so no bucket ever straddles and the split is a no-op (every
+// bucket falls wholly in one band, matching the pre-#185 behaviour exactly).
+// For CLS (thresholds 100/250 milli-units) the first two buckets ([0,200) and
+// [200,300)) straddle 100 and 250 respectively and are split accordingly. See
+// the RumDistribution comment for the worked example.
 //
 // Percentages are computed with Hamilton (largest-remainder) rounding so that
 // good_pct + needs_improvement_pct + poor_pct == 100 exactly, even in the
-// presence of rounding ties.
+// presence of rounding ties. The raw Good/NeedsImprovement/Poor counts are
+// similarly integerized (proportional split can produce fractional counts)
+// so they too sum exactly to the total sample count.
 func foldBucketsIntoDistribution(metric string, counts []int64) *RumDistribution {
 	goodUpper, niUpper := cwvThresholds(metric)
+	goodU, niU := float64(goodUpper), float64(niUpper)
 
-	var good, ni, poor int64
+	var good, ni, poor float64
+	var total int64
 	for i, c := range counts {
 		if c == 0 {
 			continue
 		}
-		// Lower bound (inclusive) of this bucket.
-		var bucketLower int32
+		total += c
+		// [lo, hi) bounds of this bucket. The final bucket is open-ended; its
+		// upper bound is only used to decide whether it straddles a threshold,
+		// and in practice CrUXBuckets' largest finite boundary (10000) already
+		// exceeds every metric's niUpper, so the open-ended bucket always lands
+		// wholly in "poor" without ever needing a real upper bound.
+		var lo, hi float64
 		if i > 0 {
-			bucketLower = rum.CrUXBuckets[i-1]
+			lo = float64(rum.CrUXBuckets[i-1])
 		}
-		// Assign by the bucket's lower bound. The straddle-to-lower-band rule is
-		// implicit: if the lower bound is below the threshold but the upper bound
-		// crosses it, the bucket's lower bound still places it in the lower band.
-		// For LCP/FCP/TTFB/INP the thresholds align with bucket boundaries exactly,
-		// so no bucket straddles in practice. For CLS (thresholds 100/250) the first
-		// bucket [0,200) has lower=0 which is < 100, so it correctly lands in "good".
-		switch {
-		case bucketLower < int32(goodUpper):
-			good += c
-		case bucketLower < int32(niUpper):
-			ni += c
-		default:
-			poor += c
+		if i < len(rum.CrUXBuckets) {
+			hi = float64(rum.CrUXBuckets[i])
+		} else {
+			hi = lo
 		}
+		fc := float64(c)
+		gf, nf, pf := splitBucketFraction(lo, hi, goodU, niU)
+		good += fc * gf
+		ni += fc * nf
+		poor += fc * pf
 	}
 
-	total := good + ni + poor
+	goodI, niI, poorI := integerizeHamilton(good, ni, poor, total)
 	d := &RumDistribution{
-		Good:             good,
-		NeedsImprovement: ni,
-		Poor:             poor,
+		Good:             goodI,
+		NeedsImprovement: niI,
+		Poor:             poorI,
 	}
 	if total > 0 {
-		d.GoodPct, d.NeedsImprovementPct, d.PoorPct = hamiltonRound3(good, ni, poor, total)
+		d.GoodPct, d.NeedsImprovementPct, d.PoorPct = hamiltonRound3(goodI, niI, poorI, total)
 	}
 	return d
+}
+
+// splitBucketFraction returns the fraction of a bucket [lo, hi) that falls
+// into the good / needs-improvement / poor bands, assuming samples are
+// distributed uniformly within the bucket. The three returned fractions
+// always sum to 1. A bucket entirely on one side of both thresholds returns
+// (1,0,0), (0,1,0), or (0,0,1); a bucket straddling one or both thresholds
+// splits proportionally by the overlap of [lo,hi) with each band.
+func splitBucketFraction(lo, hi, goodUpper, niUpper float64) (goodFrac, niFrac, poorFrac float64) {
+	width := hi - lo
+	switch {
+	case hi <= goodUpper:
+		return 1, 0, 0
+	case lo >= niUpper:
+		return 0, 0, 1
+	case lo >= goodUpper && hi <= niUpper:
+		return 0, 1, 0
+	case width <= 0:
+		// Degenerate (zero-width) bucket that isn't wholly on one side above —
+		// shouldn't happen for real CrUX boundaries, but avoid a NaN/divide-by-
+		// zero by falling back to the "needs improvement" band.
+		return 0, 1, 0
+	case hi <= niUpper:
+		// Spans only the good/NI boundary: lo < goodUpper < hi <= niUpper.
+		goodFrac = (goodUpper - lo) / width
+		return goodFrac, 1 - goodFrac, 0
+	case lo >= goodUpper:
+		// Spans only the NI/poor boundary: goodUpper <= lo < niUpper < hi.
+		niFrac = (niUpper - lo) / width
+		return 0, niFrac, 1 - niFrac
+	default:
+		// Spans both boundaries: lo < goodUpper and hi > niUpper.
+		goodFrac = (goodUpper - lo) / width
+		poorFrac = (hi - niUpper) / width
+		return goodFrac, 1 - goodFrac - poorFrac, poorFrac
+	}
+}
+
+// integerizeHamilton rounds three non-negative float64 values that (up to
+// floating-point error) sum to total into int64 counts that sum EXACTLY to
+// total, using the same Hamilton (largest-remainder) method as
+// hamiltonRound3: floor each value, then distribute the remaining units to
+// the values with the largest fractional remainder.
+func integerizeHamilton(a, b, c float64, total int64) (int64, int64, int64) {
+	if total == 0 {
+		return 0, 0, 0
+	}
+	ia, ib, ic := int64(a), int64(b), int64(c)
+	rem := int(total - ia - ib - ic)
+
+	type slot struct {
+		idx  int
+		frac float64
+	}
+	slots := [3]slot{{0, a - float64(ia)}, {1, b - float64(ib)}, {2, c - float64(ic)}}
+	for i := 1; i < 3; i++ {
+		for j := i; j > 0 && slots[j].frac > slots[j-1].frac; j-- {
+			slots[j], slots[j-1] = slots[j-1], slots[j]
+		}
+	}
+	vals := [3]int64{ia, ib, ic}
+	// Clamp for safety against floating-point drift; rem should always be in
+	// [0,2] for three non-negative values that sum to an integer total.
+	if rem < 0 {
+		rem = 0
+	}
+	if rem > 3 {
+		rem = 3
+	}
+	for k := 0; k < rem; k++ {
+		vals[slots[k].idx]++
+	}
+	return vals[0], vals[1], vals[2]
 }
 
 // cwvThresholds returns the (goodUpperInclusive, niUpperInclusive) for a metric

--- a/apps/api/internal/perf/rum_fleet_verdict_test.go
+++ b/apps/api/internal/perf/rum_fleet_verdict_test.go
@@ -1,0 +1,206 @@
+package perf
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/rum"
+)
+
+// ---------------------------------------------------------------------------
+// GH #195 — fleet CWV pass-rate + worst-offenders must consider all three
+// core metrics (LCP, INP, CLS), not just LCP.
+// ---------------------------------------------------------------------------
+
+// fleetSiteIDsStub is a minimal SiteLookup that returns a fixed site set,
+// ignoring the tenantID argument (fine for a single-tenant unit test).
+type fleetSiteIDsStub struct{ ids []uuid.UUID }
+
+func (s *fleetSiteIDsStub) GetSiteURL(context.Context, uuid.UUID, uuid.UUID) (string, error) {
+	return "", nil
+}
+func (s *fleetSiteIDsStub) ListSiteIDs(context.Context, uuid.UUID) ([]uuid.UUID, error) {
+	return s.ids, nil
+}
+
+// fleetInt32Counts builds a NumBuckets int32 slice with a single bucket index
+// holding the full sample count.
+func fleetInt32Counts(idx int, count int32) []int32 {
+	c := make([]int32, rum.NumBuckets)
+	c[idx] = count
+	return c
+}
+
+// newFleetRumHandler builds a Handler wired for rumFleet: ListAllSiteIDs
+// returns siteIDs (via fleetSiteIDsStub), and GetHourlyRollupsForSites always
+// returns the given rollups regardless of the requested tenant/site/window.
+func newFleetRumHandler(siteIDs []uuid.UUID, rollups []rum.HourlyRollup) *Handler {
+	svc := NewService(&fakeRepo{}, nil, nil, nil)
+	svc.SetAgentClient(nil, &fleetSiteIDsStub{ids: siteIDs})
+	reader := &RumResultsReader{
+		GetHourlyRollupsForSites: func(context.Context, uuid.UUID, []uuid.UUID, time.Time) ([]rum.HourlyRollup, error) {
+			return rollups, nil
+		},
+	}
+	return &Handler{svc: svc, rum: reader}
+}
+
+// callRumFleet issues GET /perf/rum/fleet against h and decodes the response.
+func callRumFleet(t *testing.T, h *Handler) FleetRumResponse {
+	t.Helper()
+	engine := gin.New()
+	engine.GET("/perf/rum/fleet", func(c *gin.Context) {
+		injectPrincipal(c)
+		h.rumFleet(c)
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/perf/rum/fleet", nil)
+	engine.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("rumFleet: expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp FleetRumResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode FleetRumResponse: %v (body: %s)", err, w.Body.String())
+	}
+	return resp
+}
+
+// findOffender returns the worst_offenders entry for siteID, or nil.
+func findOffender(resp FleetRumResponse, siteID uuid.UUID) *fleetRumWorstOffender {
+	for i := range resp.WorstOffenders {
+		if resp.WorstOffenders[i].SiteID == siteID {
+			return &resp.WorstOffenders[i]
+		}
+	}
+	return nil
+}
+
+// TestRumFleet_goodLCPPoorCLS_excludedFromPassAndFlaggedAsOffender is the core
+// GH #195 regression test: a site with a "good" LCP but a "poor" CLS must (a)
+// NOT count toward the fleet pass rate and (b) DOES appear in worst_offenders
+// with overall_rating reflecting the worst band (CLS "poor"), not LCP's "good".
+// Before the fix, the pass-rate loop and offender selection only looked at
+// LCP, so this exact site inflated the pass rate and never appeared as an
+// offender — contradicting its own per-site dashboard page.
+func TestRumFleet_goodLCPPoorCLS_excludedFromPassAndFlaggedAsOffender(t *testing.T) {
+	siteA := uuid.New() // good LCP, good INP, poor CLS
+	siteB := uuid.New() // good LCP only; INP/CLS never reported (missing data)
+
+	// All samples in bucket 0 ([0,200)) interpolate to p75≈150ms — "good" for
+	// both LCP (<=2500) and INP (<=200).
+	goodCounts := fleetInt32Counts(0, 50)
+	// All samples in bucket 2 ([300,400)) interpolate to p75≈376 milli-units —
+	// "poor" for CLS (>250).
+	poorCLSCounts := fleetInt32Counts(2, 50)
+
+	rollups := []rum.HourlyRollup{
+		{RollupKey: rum.RollupKey{SiteID: siteA, Metric: "lcp"}, SampleCount: 50, BucketCounts: goodCounts, MaxValue: 190},
+		{RollupKey: rum.RollupKey{SiteID: siteA, Metric: "inp"}, SampleCount: 50, BucketCounts: goodCounts, MaxValue: 190},
+		{RollupKey: rum.RollupKey{SiteID: siteA, Metric: "cls"}, SampleCount: 50, BucketCounts: poorCLSCounts, MaxValue: 390},
+		{RollupKey: rum.RollupKey{SiteID: siteB, Metric: "lcp"}, SampleCount: 50, BucketCounts: goodCounts, MaxValue: 190},
+	}
+
+	h := newFleetRumHandler([]uuid.UUID{siteA, siteB}, rollups)
+	resp := callRumFleet(t, h)
+
+	// --- pass rate: site A must NOT count as passing; site B (missing
+	// INP/CLS) must be excluded from the denominator entirely, so the only
+	// core-rated site is A, and it fails -> fleet_pass_pct must be 0.
+	if resp.FleetPassPct == nil {
+		t.Fatalf("expected fleet_pass_pct to be non-nil (site A is core-rated), got nil")
+	}
+	if *resp.FleetPassPct != 0 {
+		t.Errorf("fleet_pass_pct = %v, want 0 (site A fails on CLS, site B is not core-rated so must not count as passing)", *resp.FleetPassPct)
+	}
+
+	// --- worst offenders: site A must be present with overall_rating "poor"
+	// (the worst of good/good/poor), not omitted (the pre-fix bug) and not
+	// mislabeled "good" (LCP's own band).
+	off := findOffender(resp, siteA)
+	if off == nil {
+		t.Fatalf("expected site A (good LCP, poor CLS) in worst_offenders, got none; worst_offenders=%+v", resp.WorstOffenders)
+	}
+	if off.OverallRating != "poor" {
+		t.Errorf("site A overall_rating = %q, want %q (worst of lcp=good/inp=good/cls=poor)", off.OverallRating, "poor")
+	}
+	if off.LCPP75 == nil || off.INPP75 == nil || off.CLSP75 == nil {
+		t.Errorf("expected all three p75 fields populated for site A, got lcp=%v inp=%v cls=%v", off.LCPP75, off.INPP75, off.CLSP75)
+	}
+
+	// --- site B (missing INP/CLS, good LCP only) must NOT appear as an
+	// offender: its only rated metric (LCP) is "good", so nothing about it is
+	// poor/needs-improvement.
+	if bOff := findOffender(resp, siteB); bOff != nil {
+		t.Errorf("site B (LCP-only, good) should not appear in worst_offenders, got %+v", bOff)
+	}
+}
+
+// TestRumFleet_lcpOnlyPoor_offenderButExcludedFromPassDenominator verifies the
+// two selection criteria are independently correct: a site rated poor on ONLY
+// LCP (INP/CLS never reported) IS an offender (any rated core metric poor/NI
+// qualifies), but is excluded from the fleet-pass-rate denominator because it
+// is not core-rated (not all three metrics present).
+func TestRumFleet_lcpOnlyPoor_offenderButExcludedFromPassDenominator(t *testing.T) {
+	siteF := uuid.New()
+
+	// Bucket 17 lower bound is 4500ms, already > LCP's poor threshold (4000),
+	// so this is poor regardless of within-bucket interpolation.
+	poorLCPCounts := fleetInt32Counts(17, 50)
+
+	rollups := []rum.HourlyRollup{
+		{RollupKey: rum.RollupKey{SiteID: siteF, Metric: "lcp"}, SampleCount: 50, BucketCounts: poorLCPCounts, MaxValue: 4900},
+	}
+
+	h := newFleetRumHandler([]uuid.UUID{siteF}, rollups)
+	resp := callRumFleet(t, h)
+
+	// No core-rated sites at all (siteF is missing INP/CLS) -> pass pct nil.
+	if resp.FleetPassPct != nil {
+		t.Errorf("fleet_pass_pct = %v, want nil (no site is core-rated: siteF is missing INP/CLS)", *resp.FleetPassPct)
+	}
+
+	off := findOffender(resp, siteF)
+	if off == nil {
+		t.Fatalf("expected site F (poor LCP, no INP/CLS data) in worst_offenders, got none")
+	}
+	if off.OverallRating != "poor" {
+		t.Errorf("site F overall_rating = %q, want %q", off.OverallRating, "poor")
+	}
+	if off.INPP75 != nil || off.CLSP75 != nil {
+		t.Errorf("expected inp_p75/cls_p75 nil for site F (never reported), got inp=%v cls=%v", off.INPP75, off.CLSP75)
+	}
+}
+
+// TestRumFleet_normalizeRatingHyphenation verifies the fleet response never
+// emits the underscore form "needs_improvement" — the frontend contract uses
+// the hyphenated "needs-improvement".
+func TestRumFleet_normalizeRatingHyphenation(t *testing.T) {
+	siteG := uuid.New()
+	// LCP bucket 13 ([2500,3000)) is wholly "needs_improvement" per
+	// cwvThresholds (lo=2500 >= goodUpper, hi=3000 <= niUpper) regardless of
+	// within-bucket interpolation, so cwvRating returns the underscore form
+	// that normalizeRating/worstOfThree must convert to "needs-improvement".
+	niLCPCounts := fleetInt32Counts(13, 50)
+
+	rollups := []rum.HourlyRollup{
+		{RollupKey: rum.RollupKey{SiteID: siteG, Metric: "lcp"}, SampleCount: 50, BucketCounts: niLCPCounts, MaxValue: 2900},
+	}
+	h := newFleetRumHandler([]uuid.UUID{siteG}, rollups)
+	resp := callRumFleet(t, h)
+
+	off := findOffender(resp, siteG)
+	if off == nil {
+		t.Fatalf("expected site G in worst_offenders")
+	}
+	if off.OverallRating != "needs-improvement" {
+		t.Errorf("overall_rating = %q, want hyphenated %q", off.OverallRating, "needs-improvement")
+	}
+}

--- a/apps/api/internal/perf/rum_results_handler.go
+++ b/apps/api/internal/perf/rum_results_handler.go
@@ -521,6 +521,47 @@ type FleetRumResponse struct {
 	Trend          []fleetRumTrendPoint    `json:"trend"`
 }
 
+// normalizeRating converts cwvRating's "needs_improvement" (underscore) to the
+// hyphenated "needs-improvement" the frontend contract expects everywhere
+// else in the fleet response. "" (unrated), "good", and "poor" pass through
+// unchanged.
+func normalizeRating(rating string) string {
+	if rating == "needs_improvement" {
+		return "needs-improvement"
+	}
+	return rating
+}
+
+// ratingRank orders CWV ratings by severity for sorting: poor is worst,
+// unrated ("") sorts below "good" so it never outranks an actual failing
+// rating.
+func ratingRank(rating string) int {
+	switch rating {
+	case "poor":
+		return 2
+	case "needs-improvement":
+		return 1
+	case "good":
+		return 0
+	default:
+		return -1
+	}
+}
+
+// worstOfThree returns the most severe of the (already-normalized) lcp/inp/cls
+// ratings, ignoring any that are "" (unrated). Returns "" if none are rated.
+func worstOfThree(lcp, inp, cls string) string {
+	worst := ""
+	worstRank := -1
+	for _, r := range [3]string{lcp, inp, cls} {
+		if rank := ratingRank(r); rank > worstRank {
+			worstRank = rank
+			worst = r
+		}
+	}
+	return worst
+}
+
 // rumFleet handles GET /api/v1/perf/rum/fleet.
 // Returns a fleet-level CWV aggregate across all tenant sites that reported
 // RUM data in the window. Query params:
@@ -703,100 +744,101 @@ func (h *Handler) rumFleet(c *gin.Context) {
 		TTFB: buildMetric("ttfb", fleetAcc["ttfb"]),
 	}
 
-	// Fleet-pass-pct: fraction of reporting sites with "good" LCP p75.
-	var fleetPassPct *float64
-	var lcpGoodSites, lcpTotalSites int
+	// Per-site core-CWV verdict (GH #195). A site's fleet pass/fail status and
+	// its worst-offender rating must consider ALL THREE core metrics (LCP,
+	// INP, CLS) — mirroring the per-site FE logic in FleetRumPanel.tsx
+	// (coreRated = lcp && inp && cls all rated; allGood = all three "good").
+	// Each metric is independently gated on minSampleCount before it is
+	// rated; a metric below the floor leaves that field's rating "" (unrated)
+	// rather than being silently treated as passing.
+	type siteVerdict struct {
+		lcpP75, inpP75, clsP75             *float64
+		lcpRating, inpRating, clsRating    string // "" = unrated (suppressed/no data)
+		lcpSamples, inpSamples, clsSamples int64
+	}
+	siteVerdicts := make(map[uuid.UUID]*siteVerdict)
 	for smk, sa := range siteAcc {
-		if smk.metric != "lcp" {
+		if smk.metric != "lcp" && smk.metric != "inp" && smk.metric != "cls" {
 			continue
 		}
-		if sa.sampleCount < int64(minSampleCount) {
-			continue
+		sv, ok := siteVerdicts[smk.siteID]
+		if !ok {
+			sv = &siteVerdict{}
+			siteVerdicts[smk.siteID] = sv
 		}
-		lcpTotalSites++
-		siteP75 := rum.InterpolateP75FromCounts(sa.counts, sa.sampleCount, sa.maxVal)
-		if cwvRating("lcp", siteP75) == "good" {
-			lcpGoodSites++
+		var p75 *float64
+		var rating string
+		if sa.sampleCount >= int64(minSampleCount) {
+			v := rum.InterpolateP75FromCounts(sa.counts, sa.sampleCount, sa.maxVal)
+			p75 = &v
+			rating = normalizeRating(cwvRating(smk.metric, v))
+		}
+		switch smk.metric {
+		case "lcp":
+			sv.lcpP75, sv.lcpRating, sv.lcpSamples = p75, rating, sa.sampleCount
+		case "inp":
+			sv.inpP75, sv.inpRating, sv.inpSamples = p75, rating, sa.sampleCount
+		case "cls":
+			sv.clsP75, sv.clsRating, sv.clsSamples = p75, rating, sa.sampleCount
 		}
 	}
-	if lcpTotalSites > 0 {
-		v := float64(lcpGoodSites) / float64(lcpTotalSites) * 100
+
+	// Fleet-pass-pct: fraction of sites rated on ALL THREE core metrics
+	// (coreRated) whose lcp/inp/cls are all "good". A site missing INP/CLS
+	// data is excluded from BOTH the numerator and denominator — it is never
+	// counted as passing on LCP alone.
+	var fleetPassPct *float64
+	var coreRatedSites, passingSites int
+	for _, sv := range siteVerdicts {
+		if sv.lcpRating == "" || sv.inpRating == "" || sv.clsRating == "" {
+			continue
+		}
+		coreRatedSites++
+		if sv.lcpRating == "good" && sv.inpRating == "good" && sv.clsRating == "good" {
+			passingSites++
+		}
+	}
+	if coreRatedSites > 0 {
+		v := float64(passingSites) / float64(coreRatedSites) * 100
 		fleetPassPct = &v
 	}
 
-	// Worst offenders: collect unique sites with poor/needs-improvement LCP,
-	// joined with their inp/cls p75 values.
-	type offenderAcc struct {
-		lcpP75  float64
-		inpP75  *float64
-		clsP75  *float64
-		samples int64
-		rating  string
-	}
-	offenderMap := make(map[uuid.UUID]*offenderAcc)
-	for smk, sa := range siteAcc {
-		if smk.metric != "lcp" {
+	// Worst offenders: any site with at least one RATED core metric in the
+	// poor or needs-improvement band. Previously this only looked at LCP,
+	// which hid sites with good LCP but failing CLS/INP (GH #195).
+	// OverallRating is the worst band among whichever metrics are rated.
+	worstOffenders := make([]fleetRumWorstOffender, 0, len(siteVerdicts))
+	for siteID, sv := range siteVerdicts {
+		worst := worstOfThree(sv.lcpRating, sv.inpRating, sv.clsRating)
+		if worst != "poor" && worst != "needs-improvement" {
 			continue
 		}
-		if sa.sampleCount < int64(minSampleCount) {
-			continue
-		}
-		p75 := rum.InterpolateP75FromCounts(sa.counts, sa.sampleCount, sa.maxVal)
-		rating := cwvRating("lcp", p75)
-		// normalise: frontend expects "needs-improvement" (hyphen), not underscore
-		if rating == "needs_improvement" {
-			rating = "needs-improvement"
-		}
-		if rating == "poor" || rating == "needs-improvement" {
-			offenderMap[smk.siteID] = &offenderAcc{
-				lcpP75:  p75,
-				samples: sa.sampleCount,
-				rating:  rating,
-			}
-		}
-	}
-	// Enrich offenders with inp/cls p75 values.
-	for smk, sa := range siteAcc {
-		oa, isOffender := offenderMap[smk.siteID]
-		if !isOffender {
-			continue
-		}
-		if sa.sampleCount < int64(minSampleCount) {
-			continue
-		}
-		p75 := rum.InterpolateP75FromCounts(sa.counts, sa.sampleCount, sa.maxVal)
-		switch smk.metric {
-		case "inp":
-			oa.inpP75 = &p75
-		case "cls":
-			oa.clsP75 = &p75
-		}
-	}
-
-	worstOffenders := make([]fleetRumWorstOffender, 0, len(offenderMap))
-	for siteID, oa := range offenderMap {
-		lcpP75 := oa.lcpP75
 		worstOffenders = append(worstOffenders, fleetRumWorstOffender{
 			SiteID:        siteID,
 			Name:          "", // name/url not available without N+1 lookup; frontend tolerates empty
 			URL:           "",
-			LCPP75:        &lcpP75,
-			INPP75:        oa.inpP75,
-			CLSP75:        oa.clsP75,
-			OverallRating: oa.rating,
-			SampleCount:   oa.samples,
+			LCPP75:        sv.lcpP75,
+			INPP75:        sv.inpP75,
+			CLSP75:        sv.clsP75,
+			OverallRating: worst,
+			SampleCount:   sv.lcpSamples + sv.inpSamples + sv.clsSamples,
 		})
 	}
 	sort.Slice(worstOffenders, func(i, j int) bool {
-		// Sort by LCP p75 descending (worst first).
-		li, lj := float64(0), float64(0)
-		if worstOffenders[i].LCPP75 != nil {
-			li = *worstOffenders[i].LCPP75
+		a, b := worstOffenders[i], worstOffenders[j]
+		// Sort by rating severity first (poor before needs-improvement),
+		// then by LCP p75 descending (worst first; nil sorts last).
+		if ra, rb := ratingRank(a.OverallRating), ratingRank(b.OverallRating); ra != rb {
+			return ra > rb
 		}
-		if worstOffenders[j].LCPP75 != nil {
-			lj = *worstOffenders[j].LCPP75
+		la, lb := float64(0), float64(0)
+		if a.LCPP75 != nil {
+			la = *a.LCPP75
 		}
-		return li > lj
+		if b.LCPP75 != nil {
+			lb = *b.LCPP75
+		}
+		return la > lb
 	})
 	if len(worstOffenders) > 10 {
 		worstOffenders = worstOffenders[:10]

--- a/apps/api/internal/perf/rum_results_handler_test.go
+++ b/apps/api/internal/perf/rum_results_handler_test.go
@@ -251,9 +251,9 @@ func TestRumSummary_cwvRatings(t *testing.T) {
 		{"inp", 100, "good"},
 		{"inp", 300, "needs_improvement"},
 		{"inp", 600, "poor"},
-		{"cls", 50, "good"},    // 50 milli-units = 0.05 raw (good threshold is 0.1/100 milli)
+		{"cls", 50, "good"},               // 50 milli-units = 0.05 raw (good threshold is 0.1/100 milli)
 		{"cls", 200, "needs_improvement"}, // 0.2 raw
-		{"cls", 300, "poor"},   // 0.3 raw
+		{"cls", 300, "poor"},              // 0.3 raw
 		{"fcp", 1000, "good"},
 		{"fcp", 2500, "needs_improvement"},
 		{"fcp", 4000, "poor"},
@@ -353,29 +353,101 @@ func TestFoldBuckets_INP_exact(t *testing.T) {
 	}
 }
 
-// TestFoldBuckets_CLS_straddle verifies the CLS coarse-fold behaviour.
-// CLS thresholds: good≤100, NI≤250 (milli-units). The first CrUX boundary is 200,
-// so the entire first bucket [0,200) has lower=0 < 100 → assigned to "good"
-// (straddle-to-lower-band). Bucket 1 (lower=200 ≥ 100, < 250) → NI.
-// For this test, buckets 0..0 = good, bucket 1 = NI, bucket 2+ = poor.
-func TestFoldBuckets_CLS_straddle(t *testing.T) {
-	// bucket 0 lower=0 < 100 → good (even though [0,200) spans both 100 and 250)
-	// bucket 1 lower=200 ≥ 100 and < 250 → NI
-	// bucket 2 lower=300 ≥ 250 → poor
+// TestFoldBuckets_CLS_straddleProportionalSplit verifies the GH #185 fix: a
+// bucket that straddles a CLS threshold is split PROPORTIONALLY at the
+// threshold (uniform-within-bucket assumption), not assigned wholesale to the
+// lower band. CLS thresholds: good<=100, NI<=250 (milli-units); the first
+// CrUX boundary is 200, so bucket 0 ([0,200)) straddles 100 and bucket 1
+// ([200,300)) straddles 250.
+//
+//	bucket 0 [0,200), count=60: goodUpper=100 splits it exactly in half ->
+//	    30 good / 30 NI.
+//	bucket 1 [200,300), count=30: niUpper=250 splits it exactly in half ->
+//	    15 NI / 15 poor.
+//	bucket 2 [300,400), count=10: wholly >= niUpper(250) -> all poor.
+//
+// Totals: good=30, NI=30+15=45, poor=15+10=25 (sums to the original 100).
+func TestFoldBuckets_CLS_straddleProportionalSplit(t *testing.T) {
 	counts := makeCounts(0, 60, 1, 30, 2, 10)
 	d := foldBucketsIntoDistribution("cls", counts)
 
-	if d.Good != 60 {
-		t.Errorf("CLS good = %d, want 60 (straddle→lower band = good)", d.Good)
+	if d.Good != 30 {
+		t.Errorf("CLS good = %d, want 30 (bucket 0 split 50/50 at the 100 threshold)", d.Good)
 	}
-	if d.NeedsImprovement != 30 {
-		t.Errorf("CLS NI = %d, want 30", d.NeedsImprovement)
+	if d.NeedsImprovement != 45 {
+		t.Errorf("CLS NI = %d, want 45 (30 from bucket 0 + 15 from bucket 1)", d.NeedsImprovement)
 	}
-	if d.Poor != 10 {
-		t.Errorf("CLS poor = %d, want 10", d.Poor)
+	if d.Poor != 25 {
+		t.Errorf("CLS poor = %d, want 25 (15 from bucket 1 + 10 from bucket 2)", d.Poor)
 	}
 	if d.GoodPct+d.NeedsImprovementPct+d.PoorPct != 100 {
 		t.Errorf("CLS pct sum = %d, want 100", d.GoodPct+d.NeedsImprovementPct+d.PoorPct)
+	}
+}
+
+// TestFoldBuckets_CLS_matchesP75Rating is the exact GH #185 reported
+// scenario: 16 CLS samples, all in bucket 0 ([0,200)). InterpolateP75FromCounts
+// places p75 at 150 milli-units (75% of the way through [0,200)), which rates
+// "needs_improvement" (100 < 150 <= 250) — NOT "good". Before the fix,
+// foldBucketsIntoDistribution credited the whole bucket to "good" (100%),
+// directly contradicting that p75 rating. The fix must produce a split that is
+// consistent with the p75 rating: some samples good, some needs-improvement,
+// and NOT 100% good.
+func TestFoldBuckets_CLS_matchesP75Rating(t *testing.T) {
+	counts := makeCounts(0, 16)
+
+	p75 := rum.InterpolateP75FromCounts(counts, 16, 200)
+	wantRating := cwvRating("cls", p75)
+	if wantRating != "needs_improvement" {
+		t.Fatalf("test setup invalid: p75=%v rated %q, want needs_improvement", p75, wantRating)
+	}
+
+	d := foldBucketsIntoDistribution("cls", counts)
+	if d.Good == 16 {
+		t.Fatalf("CLS distribution reports 100%% good (good=%d/16) while p75=%v rates %q — distribution contradicts the rating (GH #185)", d.Good, p75, wantRating)
+	}
+	// The bucket's goodUpper(100) sits exactly at the midpoint of [0,200), so a
+	// uniform 16-sample bucket splits 8/8.
+	if d.Good != 8 || d.NeedsImprovement != 8 || d.Poor != 0 {
+		t.Errorf("CLS good/ni/poor = %d/%d/%d, want 8/8/0", d.Good, d.NeedsImprovement, d.Poor)
+	}
+	if d.Good+d.NeedsImprovement+d.Poor != 16 {
+		t.Errorf("CLS counts sum = %d, want 16", d.Good+d.NeedsImprovement+d.Poor)
+	}
+}
+
+// TestFoldBuckets_CLS_secondBucketPoorNoSplit verifies a bucket wholly beyond
+// niUpper is NOT split (regression guard alongside the straddle fix): bucket 2
+// ([300,400)) is entirely >= 250, so it must be 100% poor with none leaking
+// into "good" or "needs_improvement".
+func TestFoldBuckets_CLS_secondBucketPoorNoSplit(t *testing.T) {
+	counts := makeCounts(2, 40)
+	d := foldBucketsIntoDistribution("cls", counts)
+	if d.Good != 0 || d.NeedsImprovement != 0 || d.Poor != 40 {
+		t.Errorf("CLS good/ni/poor = %d/%d/%d, want 0/0/40 (bucket 2 is wholly poor)", d.Good, d.NeedsImprovement, d.Poor)
+	}
+}
+
+// TestFoldBuckets_LCP_INP_unaffectedByProportionalSplitFix is an explicit
+// GH #185 no-regression guard: LCP and INP's good/NI thresholds (2500/4000 and
+// 200/500 respectively) land exactly on CrUX bucket boundaries, so the
+// proportional-split fix must be a no-op for these metrics — every bucket
+// falls wholly within one band, identical to the pre-fix fold.
+func TestFoldBuckets_LCP_INP_unaffectedByProportionalSplitFix(t *testing.T) {
+	// LCP: bucket 11 ([1800,2000)) wholly good, bucket 14 ([3000,3500)) wholly
+	// NI, bucket 18 ([6000,7000)) wholly poor.
+	lcpCounts := makeCounts(11, 40, 14, 25, 18, 15)
+	lcp := foldBucketsIntoDistribution("lcp", lcpCounts)
+	if lcp.Good != 40 || lcp.NeedsImprovement != 25 || lcp.Poor != 15 {
+		t.Errorf("LCP good/ni/poor = %d/%d/%d, want 40/25/15 (no split expected)", lcp.Good, lcp.NeedsImprovement, lcp.Poor)
+	}
+
+	// INP: bucket 0 ([0,200)) wholly good, bucket 2 ([300,400)) wholly NI,
+	// bucket 4 ([600,800)) wholly poor.
+	inpCounts := makeCounts(0, 40, 2, 25, 4, 15)
+	inp := foldBucketsIntoDistribution("inp", inpCounts)
+	if inp.Good != 40 || inp.NeedsImprovement != 25 || inp.Poor != 15 {
+		t.Errorf("INP good/ni/poor = %d/%d/%d, want 40/25/15 (no split expected)", inp.Good, inp.NeedsImprovement, inp.Poor)
 	}
 }
 

--- a/apps/web/src/features/orgs/org-switcher.tsx
+++ b/apps/web/src/features/orgs/org-switcher.tsx
@@ -31,8 +31,8 @@ import { useSharedWithMe } from "@/features/sharing/use-shared-with-me";
 // collaborator can still see and switch to that org.
 //
 // Switching calls POST /api/v1/orgs/{id}/activate which sets the session's
-// active_tenant_id; useActivateOrg then clears ALL server state so every
-// query refetches in the new org context.
+// active_tenant_id; useActivateOrg then actively resets + refetches ALL
+// server state so every query reflects the new org context immediately.
 
 interface OrgEntry {
   id: string;

--- a/apps/web/src/features/orgs/use-orgs.test.ts
+++ b/apps/web/src/features/orgs/use-orgs.test.ts
@@ -1,30 +1,48 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { createElement, type ReactNode } from "react";
 
-// Mock the transport, toast, and SSE reset so useDeleteOrg's onSuccess can be
-// exercised without a network call or touching the real event stream.
-const { deleteMock, toastSuccess, toastError } = vi.hoisted(() => ({
-  deleteMock: vi.fn(),
-  toastSuccess: vi.fn(),
-  toastError: vi.fn(),
-}));
+// Mock the transport, toast, SSE reset, and router so useActivateOrg's and
+// useDeleteOrg's onSuccess can be exercised without a network call, the real
+// event stream, or a real TanStack Router instance (GH #186).
+const { deleteMock, postMock, toastSuccess, toastError, resetSiteStreamMock, routerInvalidateMock } =
+  vi.hoisted(() => ({
+    deleteMock: vi.fn(),
+    postMock: vi.fn(),
+    toastSuccess: vi.fn(),
+    toastError: vi.fn(),
+    resetSiteStreamMock: vi.fn(),
+    routerInvalidateMock: vi.fn(),
+  }));
 vi.mock("@wpmgr/api", () => ({
-  client: { delete: deleteMock, get: vi.fn(), post: vi.fn(), patch: vi.fn() },
+  client: { delete: deleteMock, get: vi.fn(), post: postMock, patch: vi.fn() },
 }));
 vi.mock("@/components/toast", () => ({
   toast: { success: toastSuccess, error: toastError },
 }));
-vi.mock("@/features/sites/use-site-events", () => ({ resetSiteStream: vi.fn() }));
+vi.mock("@/features/sites/use-site-events", () => ({ resetSiteStream: resetSiteStreamMock }));
+vi.mock("@/router", () => ({ router: { invalidate: routerInvalidateMock } }));
 
-import { mapDeleteOrgError, orgDeleteConfirmMatches, useDeleteOrg } from "./use-orgs";
+import {
+  mapDeleteOrgError,
+  orgDeleteConfirmMatches,
+  useActivateOrg,
+  useDeleteOrg,
+} from "./use-orgs";
 
 function hookWrapper({ children }: { children: ReactNode }) {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
   return createElement(QueryClientProvider, { client: qc }, children);
+}
+
+/** Like hookWrapper, but shares a single QueryClient instance across renderHook calls. */
+function wrapperFor(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: qc }, children);
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -121,6 +139,8 @@ describe("useDeleteOrg success toast", () => {
     deleteMock.mockReset();
     toastSuccess.mockReset();
     toastError.mockReset();
+    resetSiteStreamMock.mockReset();
+    routerInvalidateMock.mockReset();
   });
 
   it("hard delete shows a permanently-deleted toast with no grace-window description", async () => {
@@ -144,5 +164,140 @@ describe("useDeleteOrg success toast", () => {
       | undefined;
     expect(softCall?.[0]).toBe('"Acme" is scheduled for permanent deletion');
     expect(softCall?.[1]?.description).toContain("recoverable");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH #186: switching organizations must take effect in the UI immediately,
+// without a full browser refresh, even when the target org is EMPTY. The
+// bug: `queryClient.clear()` PASSIVELY empties the cache but never notifies
+// or refetches an already-mounted QueryObserver, so a mounted Sites route
+// kept rendering the PREVIOUS org's rows. For a populated target org this was
+// incidentally masked by the SSE reset (an incoming site event invalidates
+// and refetches) -- but an EMPTY target org has no sites, so no SSE event
+// ever fires, and the observer stayed frozen until a hard reload. These
+// tests never emit or depend on any SSE event, so they exercise exactly the
+// empty-org path that exposed the bug.
+// ---------------------------------------------------------------------------
+
+describe("useActivateOrg actively refetches mounted queries — GH #186", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    toastSuccess.mockReset();
+    toastError.mockReset();
+    resetSiteStreamMock.mockReset();
+    routerInvalidateMock.mockReset();
+  });
+
+  it("refetches a mounted org-scoped query on switch, with NO SSE event, proving the empty-target-org case", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = wrapperFor(qc);
+
+    // A mounted, org-scoped query holding the PREVIOUS org's data -- mirrors
+    // a live Sites route's useSites() staying mounted across the switch.
+    const sitesQueryFn = vi
+      .fn()
+      .mockResolvedValueOnce(["old-org-site"])
+      .mockResolvedValueOnce([]); // the target org is EMPTY (the reporter's exact repro)
+    const sites = renderHook(
+      () => useQuery({ queryKey: ["sites", "list"], queryFn: sitesQueryFn }),
+      { wrapper },
+    );
+    await waitFor(() => expect(sites.result.current.data).toEqual(["old-org-site"]));
+    expect(sitesQueryFn).toHaveBeenCalledTimes(1);
+
+    postMock.mockResolvedValue({ data: { active_tenant_id: "org-2" }, error: undefined });
+    const activate = renderHook(() => useActivateOrg(), { wrapper });
+    await activate.result.current.mutateAsync("org-2");
+
+    // Non-vacuous: against the old `queryClient.clear()` implementation this
+    // assertion fails outright -- `clear()` never notifies a mounted
+    // observer, so `sitesQueryFn` is never called a second time and `sites`
+    // keeps showing the previous org's stale rows forever (verified directly
+    // against real query-core semantics, not asserted on faith: a standalone
+    // check confirmed `clear()` leaves a mounted observer's fetch count
+    // unchanged while `resetQueries()` refetches it).
+    await waitFor(() => expect(sitesQueryFn).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(sites.result.current.data).toEqual([]));
+
+    // The SSE half (reset) and the route-loader half (router.invalidate)
+    // must both still fire alongside the active cache reset.
+    expect(resetSiteStreamMock).toHaveBeenCalledTimes(1);
+    expect(routerInvalidateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the mounted query's data to a fresh, non-stale value even before the empty org's refetch resolves", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = wrapperFor(qc);
+
+    let resolveSecondFetch: (value: string[]) => void = () => {};
+    const sitesQueryFn = vi
+      .fn()
+      .mockResolvedValueOnce(["old-org-site"])
+      .mockImplementationOnce(
+        () => new Promise<string[]>((resolve) => (resolveSecondFetch = resolve)),
+      );
+    const sites = renderHook(
+      () => useQuery({ queryKey: ["sites", "list"], queryFn: sitesQueryFn }),
+      { wrapper },
+    );
+    await waitFor(() => expect(sites.result.current.data).toEqual(["old-org-site"]));
+
+    postMock.mockResolvedValue({ data: { active_tenant_id: "org-2" }, error: undefined });
+    const activate = renderHook(() => useActivateOrg(), { wrapper });
+    const activatePromise = activate.result.current.mutateAsync("org-2");
+
+    // While the new org's fetch is still in flight, the observer must NOT be
+    // showing the old org's rows as if they were current -- resetQueries()
+    // clears the cached data back to undefined/pending instead of leaving
+    // last-known-good data displayed under the new tenant.
+    await waitFor(() => expect(sites.result.current.data).toBeUndefined());
+    await waitFor(() => expect(sites.result.current.isFetching).toBe(true));
+
+    resolveSecondFetch([]);
+    await activatePromise;
+    await waitFor(() => expect(sites.result.current.data).toEqual([]));
+  });
+});
+
+describe("useDeleteOrg actively refetches mounted queries — GH #186", () => {
+  beforeEach(() => {
+    deleteMock.mockReset();
+    toastSuccess.mockReset();
+    toastError.mockReset();
+    resetSiteStreamMock.mockReset();
+    routerInvalidateMock.mockReset();
+  });
+
+  it("refetches a mounted org-scoped query after deleting the org, with no SSE event relied on", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = wrapperFor(qc);
+
+    const membersQueryFn = vi
+      .fn()
+      .mockResolvedValueOnce(["old-org-member"])
+      .mockResolvedValueOnce([]); // the reassigned active org has no members loaded yet
+    const members = renderHook(
+      () => useQuery({ queryKey: ["members", "list"], queryFn: membersQueryFn }),
+      { wrapper },
+    );
+    await waitFor(() => expect(members.result.current.data).toEqual(["old-org-member"]));
+    expect(membersQueryFn).toHaveBeenCalledTimes(1);
+
+    deleteMock.mockResolvedValue({ data: { id: "o1", lane: "hard" }, error: undefined });
+    const del = renderHook(() => useDeleteOrg(), { wrapper });
+    await del.result.current.mutateAsync({ orgId: "o1", confirmName: "Acme" });
+
+    // Non-vacuous for the same reason as useActivateOrg: this fails against
+    // the old `queryClient.clear()` implementation.
+    await waitFor(() => expect(membersQueryFn).toHaveBeenCalledTimes(2));
+    expect(resetSiteStreamMock).toHaveBeenCalledTimes(1);
+    expect(routerInvalidateMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/features/orgs/use-orgs.ts
+++ b/apps/web/src/features/orgs/use-orgs.ts
@@ -10,6 +10,7 @@ import { client } from "@wpmgr/api";
 import { toError } from "@/features/auth/use-auth";
 import { resetSiteStream } from "@/features/sites/use-site-events";
 import { toast } from "@/components/toast";
+import { router } from "@/router";
 
 // Org (tenant) management hooks — hand-rolled endpoints, not in @wpmgr/api.
 // Pattern mirrors use-restores.ts / use-auth.ts.
@@ -88,8 +89,9 @@ export function useCreateOrg(): UseMutationResult<
 
 // ---------------------------------------------------------------------------
 // POST /api/v1/orgs/{orgId}/activate
-// Switch the session's active org. Clears ALL server state so every query
-// refetches under the new org context.
+// Switch the session's active org. Actively resets + refetches ALL server
+// state (GH #186 — a passive `clear()` never notifies mounted observers) so
+// every query reflects the new org context immediately, even when it's empty.
 // ---------------------------------------------------------------------------
 
 export function useActivateOrg(): UseMutationResult<
@@ -107,19 +109,31 @@ export function useActivateOrg(): UseMutationResult<
       if (result.error !== undefined) throw toError(result.error);
       return result.data as ActivateOrgResult;
     },
-    onSuccess: () => {
-      // Drop ALL server state — sites, members, me, etc. — so everything
-      // refetches in the context of the newly-active org.
-      queryClient.clear();
+    onSuccess: async () => {
+      // GH #186: `queryClient.clear()` only PASSIVELY empties the cache — it
+      // does not notify or refetch already-mounted QueryObservers, so a
+      // mounted Sites route kept rendering the PREVIOUS org's rows until a
+      // hard reload. `resetQueries()` resets every query back to its initial
+      // (data-less) state AND actively refetches every mounted observer
+      // (useMe, useSites, members, ...), so no stale cross-tenant data can
+      // ever be shown as "fresh" in the gap. This also fixes the case a
+      // populated-org switch was accidentally masking: an EMPTY target org
+      // has no sites, so the SSE reset below never fires a site event to
+      // nudge a frozen observer — resetQueries doesn't depend on that.
+      await queryClient.resetQueries();
       // The shared Sites SSE stream is a module-level singleton whose tenant
       // is resolved ONCE by the CP at connect time and held for the life of
-      // the connection (up to ~15 min). Clearing the cache only fixes the
+      // the connection (up to ~15 min). Resetting the cache only fixes the
       // pull (refetch) path — without this, an already-open stream keeps
       // delivering the OLD tenant's events (or none for the new one) until a
       // hard reload or the stream's natural expiry. Reset it so the live
       // (push) path re-establishes under the new tenant too, with a fresh
       // cursor (see resetSiteStream's doc for why the cursor must be dropped).
       resetSiteStream();
+      // Re-run the `_authed` route's beforeLoad/loaders (ensureMe, the
+      // superadmin bounce, per-route prefetches, ...) under the new tenant —
+      // the same thing a hard browser reload does.
+      await router.invalidate();
     },
     onError: (err) => {
       toast.error(`Could not switch organisation: ${err.message}`);
@@ -167,8 +181,8 @@ export function useRenameOrg(): UseMutationResult<
 //
 // Deletion is SOFT with a grace window: the org disappears from GET /orgs
 // the instant this commits (recoverable server-side until a background job
-// purges it), so onSuccess mirrors useActivateOrg's cache teardown -- every
-// org-scoped query (sites, members, keys, ...) is now stale.
+// purges it), so onSuccess mirrors useActivateOrg's active cache reset --
+// every org-scoped query (sites, members, keys, ...) is refetched fresh.
 // ---------------------------------------------------------------------------
 
 export interface DeleteOrgResult {
@@ -275,12 +289,17 @@ export function useDeleteOrg(): UseMutationResult<
       }
       return result.data as DeleteOrgResult;
     },
-    onSuccess: (result, variables) => {
-      // Drop ALL server state, mirroring useActivateOrg: the deleted org
-      // disappears from every list server-side immediately, so any cached
-      // org-scoped data (sites, members, keys, ...) is now stale.
-      queryClient.clear();
+    onSuccess: async (result, variables) => {
+      // GH #186: mirror useActivateOrg's fix. The active org is reassigned by
+      // the server on delete (the deleted org can never be the active one —
+      // see cannot_delete_active_org), so a passive `queryClient.clear()`
+      // carried the same latent freeze, just usually masked by the reassigned
+      // org's SSE traffic. `resetQueries()` actively refetches every mounted
+      // observer under the new active org, with no stale cross-tenant data
+      // shown in the gap even when that org is empty.
+      await queryClient.resetQueries();
       resetSiteStream();
+      await router.invalidate();
       // A "hard" delete (empty org) is gone immediately with no grace window,
       // so it must not claim to be recoverable (GH #161 CodeRabbit review).
       if (result.lane === "hard") {


### PR DESCRIPTION
#186: org switch now resetQueries()+router.invalidate() so it takes effect without a refresh (empty-org case). #195: fleet CWV pass-rate + worst-offenders now judge LCP+INP+CLS (mirroring the per-site rule), not LCP alone. #185: CLS distribution splits straddling buckets proportionally at thresholds so it agrees with the p75 (LCP/INP unchanged). Both reviewed SHIP; 940 web + perf/rum Go tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Switching to a different organization now updates the app immediately without needing a browser refresh.
  * Deleting an organization also refreshes the active context right away.

* **Bug Fixes**
  * Improved Core Web Vitals reporting so fleet pass rates and worst-offender lists reflect all key metrics together.
  * Fixed CLS distribution displays so the chart matches the rating shown beside it.
  * Corrected rating labels for “needs improvement” in performance views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->