### PR TITLE
fix: sites-to-review stat drillable (#197) + DB-size trend populates from daily diagnostics (#196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
-## [0.61.50] - 2026-07-09
+## [0.61.51] - 2026-07-09
+
+### Fixed
+
+- The fleet "Sites with items to review" database-health stat is no longer a dead end (GH #197). It was an inert number, and the data behind it only covered the ten largest databases, so sites flagged for review outside that window could not be reached at all. The stat now expands into the full list of every site with database items to review, each linking directly to that site's Orphaned-items view.
+- The database-size "90-day history" trend and the fleet "90-day growth" stat now populate automatically (GH #196). They read a size-history table that was only ever written on a manual "Scan database" click, so the trend stayed frozen. A size sample is now recorded from each site's daily diagnostics push (best-effort, so it can never affect the diagnostics itself), so the history builds over time for every site with no manual scanning. No agent update or database migration is required.
 
 ### Fixed
 

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -1829,6 +1829,13 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// on the next GET /diagnostics.
 	// diagnosticsRepo is already built above (before River start) so we reuse it.
 	diagnosticsSvc := diagnostics.NewService(diagnosticsRepo)
+	// GH #196 — tap the daily diagnostics push (wp-paths-sizes.database_size)
+	// so the 90-day DB-size trend + fleet growth read populate automatically
+	// instead of only on a manual "Scan database" click. perfRepo is already
+	// built above (before River start) so we reuse it; it satisfies
+	// diagnostics.DBSizeHistorySink structurally via
+	// RecordDBSizeHistoryFromDiagnostics.
+	diagnosticsSvc.SetDBSizeHistorySink(perfRepo)
 	// M28 — offline IP -> hosting-provider resolver. Self-disables (no-op) if the
 	// embedded DB-IP ASN database fails to open; never blocks boot.
 	if ipResolver, ipErr := ipprovider.New(); ipErr != nil {

--- a/apps/api/db/query/perf.sql
+++ b/apps/api/db/query/perf.sql
@@ -446,6 +446,18 @@ WHERE site_id   = @site_id
 ORDER BY scanned_at ASC
 LIMIT 366;
 
+-- name: GetLatestDBSizeHistoryTableCount :one
+-- Returns the table_count from the most recent site_db_size_history row for a
+-- site (from either a manual "Scan database" run or a prior diagnostics-
+-- sourced point; GH #196). The daily diagnostics push does not carry a table
+-- inventory, so the diagnostics ingest tap carries this value forward rather
+-- than writing a 0 over a real count. pgx.ErrNoRows when no prior point
+-- exists yet — callers default to 0 in that case.
+SELECT table_count FROM site_db_size_history
+WHERE site_id = @site_id AND tenant_id = @tenant_id
+ORDER BY scanned_at DESC
+LIMIT 1;
+
 -- name: PruneDBSizeHistory :execrows
 -- Deletes rows older than the cutoff across ALL tenants (InAgentTx / app.agent).
 -- LIMIT 2000 keeps each GC transaction short; the periodic job runs daily so

--- a/apps/api/internal/api/gen/oas_client_gen.go
+++ b/apps/api/internal/api/gen/oas_client_gen.go
@@ -977,7 +977,7 @@ type Invoker interface {
 	// by DB size. Org-scope only. Requires viewer+.
 	//
 	// GET /api/v1/perf/db/fleet-health
-	GetFleetDbHealth(ctx context.Context, params GetFleetDbHealthParams) error
+	GetFleetDbHealth(ctx context.Context, params GetFleetDbHealthParams) (*GetFleetDbHealthOK, error)
 	// GetFleetEmailDeliverability invokes getFleetEmailDeliverability operation.
 	//
 	// Returns per-site deliverability aggregates for a rolling window.
@@ -11955,9 +11955,9 @@ func (c *Client) sendGetFleetBackupHealth(ctx context.Context, params GetFleetBa
 // by DB size. Org-scope only. Requires viewer+.
 //
 // GET /api/v1/perf/db/fleet-health
-func (c *Client) GetFleetDbHealth(ctx context.Context, params GetFleetDbHealthParams) error {
-	_, err := c.sendGetFleetDbHealth(ctx, params)
-	return err
+func (c *Client) GetFleetDbHealth(ctx context.Context, params GetFleetDbHealthParams) (*GetFleetDbHealthOK, error) {
+	res, err := c.sendGetFleetDbHealth(ctx, params)
+	return res, err
 }
 
 func (c *Client) sendGetFleetDbHealth(ctx context.Context, params GetFleetDbHealthParams) (res *GetFleetDbHealthOK, err error) {

--- a/apps/api/internal/api/gen/oas_handlers_gen.go
+++ b/apps/api/internal/api/gen/oas_handlers_gen.go
@@ -15169,12 +15169,12 @@ func (s *Server) handleGetFleetDbHealthRequest(args [0]string, argsEscaped bool,
 			mreq,
 			unpackGetFleetDbHealthParams,
 			func(ctx context.Context, request Request, params Params) (response Response, err error) {
-				err = s.h.GetFleetDbHealth(ctx, params)
+				response, err = s.h.GetFleetDbHealth(ctx, params)
 				return response, err
 			},
 		)
 	} else {
-		err = s.h.GetFleetDbHealth(ctx, params)
+		response, err = s.h.GetFleetDbHealth(ctx, params)
 	}
 	if err != nil {
 		defer recordError("Internal", err)

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -38791,9 +38791,21 @@ func (s *GetFleetDbHealthOK) Encode(e *jx.Encoder) {
 
 // encodeFields encodes fields.
 func (s *GetFleetDbHealthOK) encodeFields(e *jx.Encoder) {
+	{
+		if s.SitesNeedingReview != nil {
+			e.FieldStart("sites_needing_review")
+			e.ArrStart()
+			for _, elem := range s.SitesNeedingReview {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
 }
 
-var jsonFieldsNameOfGetFleetDbHealthOK = [0]string{}
+var jsonFieldsNameOfGetFleetDbHealthOK = [1]string{
+	0: "sites_needing_review",
+}
 
 // Decode decodes GetFleetDbHealthOK from json.
 func (s *GetFleetDbHealthOK) Decode(d *jx.Decoder) error {
@@ -38803,9 +38815,27 @@ func (s *GetFleetDbHealthOK) Decode(d *jx.Decoder) error {
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
+		case "sites_needing_review":
+			if err := func() error {
+				s.SitesNeedingReview = make([]GetFleetDbHealthOKSitesNeedingReviewItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem GetFleetDbHealthOKSitesNeedingReviewItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.SitesNeedingReview = append(s.SitesNeedingReview, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"sites_needing_review\"")
+			}
 		default:
 			return d.Skip()
 		}
+		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode GetFleetDbHealthOK")
 	}
@@ -38822,6 +38852,120 @@ func (s *GetFleetDbHealthOK) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *GetFleetDbHealthOK) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *GetFleetDbHealthOKSitesNeedingReviewItem) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *GetFleetDbHealthOKSitesNeedingReviewItem) encodeFields(e *jx.Encoder) {
+	{
+		if s.SiteID.Set {
+			e.FieldStart("site_id")
+			s.SiteID.Encode(e)
+		}
+	}
+	{
+		if s.SiteName.Set {
+			e.FieldStart("site_name")
+			s.SiteName.Encode(e)
+		}
+	}
+	{
+		if s.OrphanedOptionsCount.Set {
+			e.FieldStart("orphaned_options_count")
+			s.OrphanedOptionsCount.Encode(e)
+		}
+	}
+	{
+		if s.OrphanedCronCount.Set {
+			e.FieldStart("orphaned_cron_count")
+			s.OrphanedCronCount.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfGetFleetDbHealthOKSitesNeedingReviewItem = [4]string{
+	0: "site_id",
+	1: "site_name",
+	2: "orphaned_options_count",
+	3: "orphaned_cron_count",
+}
+
+// Decode decodes GetFleetDbHealthOKSitesNeedingReviewItem from json.
+func (s *GetFleetDbHealthOKSitesNeedingReviewItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode GetFleetDbHealthOKSitesNeedingReviewItem to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "site_id":
+			if err := func() error {
+				s.SiteID.Reset()
+				if err := s.SiteID.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"site_id\"")
+			}
+		case "site_name":
+			if err := func() error {
+				s.SiteName.Reset()
+				if err := s.SiteName.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"site_name\"")
+			}
+		case "orphaned_options_count":
+			if err := func() error {
+				s.OrphanedOptionsCount.Reset()
+				if err := s.OrphanedOptionsCount.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"orphaned_options_count\"")
+			}
+		case "orphaned_cron_count":
+			if err := func() error {
+				s.OrphanedCronCount.Reset()
+				if err := s.OrphanedCronCount.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"orphaned_cron_count\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode GetFleetDbHealthOKSitesNeedingReviewItem")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *GetFleetDbHealthOKSitesNeedingReviewItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *GetFleetDbHealthOKSitesNeedingReviewItem) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -14427,7 +14427,72 @@ type GetEmailNotifySettingsUnauthorized Error
 func (*GetEmailNotifySettingsUnauthorized) getEmailNotifySettingsRes() {}
 
 // Fleet DB health aggregate (shape matches FleetDbHealth Go model).
-type GetFleetDbHealthOK struct{}
+type GetFleetDbHealthOK struct {
+	// Every scanned site with at least one orphan candidate
+	// (orphaned wp_options rows or WP-Cron events) — NOT
+	// capped, unlike top_sites (which is capped at 10 and
+	// ordered by DB size, so a small flagged site can be
+	// absent from it). Sorted by orphan count descending,
+	// then by site name.
+	SitesNeedingReview []GetFleetDbHealthOKSitesNeedingReviewItem `json:"sites_needing_review"`
+}
+
+// GetSitesNeedingReview returns the value of SitesNeedingReview.
+func (s *GetFleetDbHealthOK) GetSitesNeedingReview() []GetFleetDbHealthOKSitesNeedingReviewItem {
+	return s.SitesNeedingReview
+}
+
+// SetSitesNeedingReview sets the value of SitesNeedingReview.
+func (s *GetFleetDbHealthOK) SetSitesNeedingReview(val []GetFleetDbHealthOKSitesNeedingReviewItem) {
+	s.SitesNeedingReview = val
+}
+
+type GetFleetDbHealthOKSitesNeedingReviewItem struct {
+	SiteID               OptUUID   `json:"site_id"`
+	SiteName             OptString `json:"site_name"`
+	OrphanedOptionsCount OptInt    `json:"orphaned_options_count"`
+	OrphanedCronCount    OptInt    `json:"orphaned_cron_count"`
+}
+
+// GetSiteID returns the value of SiteID.
+func (s *GetFleetDbHealthOKSitesNeedingReviewItem) GetSiteID() OptUUID {
+	return s.SiteID
+}
+
+// GetSiteName returns the value of SiteName.
+func (s *GetFleetDbHealthOKSitesNeedingReviewItem) GetSiteName() OptString {
+	return s.SiteName
+}
+
+// GetOrphanedOptionsCount returns the value of OrphanedOptionsCount.
+func (s *GetFleetDbHealthOKSitesNeedingReviewItem) GetOrphanedOptionsCount() OptInt {
+	return s.OrphanedOptionsCount
+}
+
+// GetOrphanedCronCount returns the value of OrphanedCronCount.
+func (s *GetFleetDbHealthOKSitesNeedingReviewItem) GetOrphanedCronCount() OptInt {
+	return s.OrphanedCronCount
+}
+
+// SetSiteID sets the value of SiteID.
+func (s *GetFleetDbHealthOKSitesNeedingReviewItem) SetSiteID(val OptUUID) {
+	s.SiteID = val
+}
+
+// SetSiteName sets the value of SiteName.
+func (s *GetFleetDbHealthOKSitesNeedingReviewItem) SetSiteName(val OptString) {
+	s.SiteName = val
+}
+
+// SetOrphanedOptionsCount sets the value of OrphanedOptionsCount.
+func (s *GetFleetDbHealthOKSitesNeedingReviewItem) SetOrphanedOptionsCount(val OptInt) {
+	s.OrphanedOptionsCount = val
+}
+
+// SetOrphanedCronCount sets the value of OrphanedCronCount.
+func (s *GetFleetDbHealthOKSitesNeedingReviewItem) SetOrphanedCronCount(val OptInt) {
+	s.OrphanedCronCount = val
+}
 
 type GetFleetEmailDeliverabilityForbidden Error
 

--- a/apps/api/internal/api/gen/oas_server_gen.go
+++ b/apps/api/internal/api/gen/oas_server_gen.go
@@ -957,7 +957,7 @@ type Handler interface {
 	// by DB size. Org-scope only. Requires viewer+.
 	//
 	// GET /api/v1/perf/db/fleet-health
-	GetFleetDbHealth(ctx context.Context, params GetFleetDbHealthParams) error
+	GetFleetDbHealth(ctx context.Context, params GetFleetDbHealthParams) (*GetFleetDbHealthOK, error)
 	// GetFleetEmailDeliverability implements getFleetEmailDeliverability operation.
 	//
 	// Returns per-site deliverability aggregates for a rolling window.

--- a/apps/api/internal/api/gen/oas_unimplemented_gen.go
+++ b/apps/api/internal/api/gen/oas_unimplemented_gen.go
@@ -1250,8 +1250,8 @@ func (UnimplementedHandler) GetFleetBackupHealth(ctx context.Context, params Get
 // by DB size. Org-scope only. Requires viewer+.
 //
 // GET /api/v1/perf/db/fleet-health
-func (UnimplementedHandler) GetFleetDbHealth(ctx context.Context, params GetFleetDbHealthParams) error {
-	return ht.ErrNotImplemented
+func (UnimplementedHandler) GetFleetDbHealth(ctx context.Context, params GetFleetDbHealthParams) (r *GetFleetDbHealthOK, _ error) {
+	return r, ht.ErrNotImplemented
 }
 
 // GetFleetEmailDeliverability implements getFleetEmailDeliverability operation.

--- a/apps/api/internal/db/sqlc/perf.sql.go
+++ b/apps/api/internal/db/sqlc/perf.sql.go
@@ -371,6 +371,31 @@ func (q *Queries) GetFleetDbHealth(ctx context.Context, arg GetFleetDbHealthPara
 	return items, nil
 }
 
+const getLatestDBSizeHistoryTableCount = `-- name: GetLatestDBSizeHistoryTableCount :one
+SELECT table_count FROM site_db_size_history
+WHERE site_id = $1 AND tenant_id = $2
+ORDER BY scanned_at DESC
+LIMIT 1
+`
+
+type GetLatestDBSizeHistoryTableCountParams struct {
+	SiteID   uuid.UUID `json:"site_id"`
+	TenantID uuid.UUID `json:"tenant_id"`
+}
+
+// Returns the table_count from the most recent site_db_size_history row for a
+// site (from either a manual "Scan database" run or a prior diagnostics-
+// sourced point; GH #196). The daily diagnostics push does not carry a table
+// inventory, so the diagnostics ingest tap carries this value forward rather
+// than writing a 0 over a real count. pgx.ErrNoRows when no prior point
+// exists yet — callers default to 0 in that case.
+func (q *Queries) GetLatestDBSizeHistoryTableCount(ctx context.Context, arg GetLatestDBSizeHistoryTableCountParams) (int32, error) {
+	row := q.db.QueryRow(ctx, getLatestDBSizeHistoryTableCount, arg.SiteID, arg.TenantID)
+	var table_count int32
+	err := row.Scan(&table_count)
+	return table_count, err
+}
+
 const getPerfConfig = `-- name: GetPerfConfig :one
 
 

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -676,6 +676,13 @@ type Querier interface {
 	// Returns the current chain head (newest row) for a tenant — the anchor point
 	// captured by an integrity re-baseline. Not used by Verify itself.
 	GetLatestAuditEntry(ctx context.Context, tenantID uuid.UUID) (GetLatestAuditEntryRow, error)
+	// Returns the table_count from the most recent site_db_size_history row for a
+	// site (from either a manual "Scan database" run or a prior diagnostics-
+	// sourced point; GH #196). The daily diagnostics push does not carry a table
+	// inventory, so the diagnostics ingest tap carries this value forward rather
+	// than writing a 0 over a real count. pgx.ErrNoRows when no prior point
+	// exists yet — callers default to 0 in that case.
+	GetLatestDBSizeHistoryTableCount(ctx context.Context, arg GetLatestDBSizeHistoryTableCountParams) (int32, error)
 	GetMembership(ctx context.Context, arg GetMembershipParams) (Membership, error)
 	// ---------------------------------------------------------------------------
 	// email_notify_settings  (m62 — alerts + digest)

--- a/apps/api/internal/diagnostics/db_size_history.go
+++ b/apps/api/internal/diagnostics/db_size_history.go
@@ -1,0 +1,103 @@
+package diagnostics
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// DBSizeHistorySink appends a site_db_size_history data point sourced from a
+// diagnostics push (GH #196). *perf.Repo satisfies it via
+// RecordDBSizeHistoryFromDiagnostics; wired from main once the perf repo is
+// constructed.
+//
+// Declared here (rather than importing perf directly) to keep diagnostics
+// free of a cross-domain package import — the concrete wiring lives in
+// cmd/wpmgr. When never wired (nil), ingestDBSizeHistory is a no-op; the
+// pre-existing manual "Scan database" writer (perf.Repo.UpsertDBScanResult)
+// is unaffected either way.
+type DBSizeHistorySink interface {
+	RecordDBSizeHistoryFromDiagnostics(ctx context.Context, tenantID, siteID uuid.UUID, dbSizeBytes int64, scannedAt time.Time) error
+}
+
+// SetDBSizeHistorySink wires the DB-size trend writer (GH #196). Optional:
+// when never called, ingestDBSizeHistory silently no-ops.
+func (s *Service) SetDBSizeHistorySink(sink DBSizeHistorySink) {
+	s.dbSizeHistory = sink
+}
+
+// ingestDBSizeHistory taps the wp_native category's
+// wp-paths-sizes.fields.database_size.debug field — the byte count the
+// agent's SizeProbe already computes for the Directory Sizes card — and
+// appends a site_db_size_history data point on every successful diagnostics
+// push (GH #196).
+//
+// Before this tap, perf.Repo.UpsertDBScanResult (reached only via the
+// operator-triggered "Scan database" button) was the ONLY writer to
+// site_db_size_history, so the 90-day DB-size trend chart and the fleet
+// "90-day growth" read never populated for a site whose operator never
+// clicked that button. Every enrolled site already pushes diagnostics daily
+// and that push carries the current database size, so this tap is a second,
+// automatic writer for the same append-only, idempotent table.
+//
+// Best-effort and silently non-fatal, mirroring ingestSiteTimezone just
+// above: the 15-category upsert loop in IngestDiagnostics has already
+// succeeded by the time this runs, and neither a missing/zero/unparseable
+// size nor a downstream insert failure may fail the diagnostics push — the
+// agent's daily cron push must always see a 2xx.
+//
+// scanned_at is the diagnostics push's own collected_at, not time.Now():
+// site_db_size_history's uniqueness is (site_id, scanned_at), so reusing the
+// push's own timestamp naturally dedups to one point per push — a retried or
+// double-delivered push for the same collected_at is a no-op (ON CONFLICT DO
+// NOTHING), never a duplicate point.
+func (s *Service) ingestDBSizeHistory(ctx context.Context, tenantID, siteID uuid.UUID, payload json.RawMessage, collectedAt time.Time) {
+	if s.dbSizeHistory == nil {
+		return
+	}
+	dbSizeBytes, ok := dbSizeFromWPNative(payload)
+	if !ok {
+		return
+	}
+	_ = s.dbSizeHistory.RecordDBSizeHistoryFromDiagnostics(ctx, tenantID, siteID, dbSizeBytes, collectedAt)
+}
+
+// dbSizeFromWPNative extracts the database size in bytes from the wp_native
+// category payload's wp-paths-sizes.fields.database_size.debug field.
+//
+// Shape (see apps/agent SizeProbe + class-diagnostics-command.php):
+//
+//	{
+//	  "wp-paths-sizes": {
+//	    "fields": {
+//	      "database_size": { "value": "1.2 GB", "debug": 1288490188 }
+//	    }
+//	  }
+//	}
+//
+// `debug` carries the WP_Debug_Data placeholder string "Loading&hellip;"
+// (HTML-entity encoded) when the agent's SizeProbe has not yet resolved the
+// size (pending/timeout status) — decoding that as flexInt64 fails, so this
+// function correctly reports ok=false rather than recording a junk 0-byte
+// point. Returns ok=false when the field is absent, non-numeric, or <= 0.
+func dbSizeFromWPNative(payload json.RawMessage) (bytes int64, ok bool) {
+	var v struct {
+		WPPathsSizes struct {
+			Fields struct {
+				DatabaseSize struct {
+					Debug flexInt64 `json:"debug"`
+				} `json:"database_size"`
+			} `json:"fields"`
+		} `json:"wp-paths-sizes"`
+	}
+	if err := json.Unmarshal(payload, &v); err != nil {
+		return 0, false
+	}
+	b := int64(v.WPPathsSizes.Fields.DatabaseSize.Debug)
+	if b <= 0 {
+		return 0, false
+	}
+	return b, true
+}

--- a/apps/api/internal/diagnostics/service.go
+++ b/apps/api/internal/diagnostics/service.go
@@ -34,11 +34,12 @@ type AgentErrorConfigClient interface {
 // AgentErrorConfigClient (optional). Held stateless so handlers can compose
 // it freely.
 type Service struct {
-	repo         *Repo
-	enqueuer     RefreshEnqueuer
-	errorClient  AgentErrorConfigClient
-	siteLookup   SiteLookup
-	hostResolver HostResolver
+	repo          *Repo
+	enqueuer      RefreshEnqueuer
+	errorClient   AgentErrorConfigClient
+	siteLookup    SiteLookup
+	hostResolver  HostResolver
+	dbSizeHistory DBSizeHistorySink
 }
 
 // RefreshEnqueuer enqueues an on-demand diagnostics command to the agent.
@@ -234,6 +235,14 @@ func (s *Service) IngestDiagnostics(ctx context.Context, tenantID, siteID uuid.U
 		// payload must not abort the whole diagnostics ingest.
 		if cat == CategoryIdentity {
 			s.ingestSiteTimezone(ctx, tenantID, siteID, payload)
+		}
+
+		// At wp_native ingest, append a DB-size trend point from the
+		// wp-paths-sizes.fields.database_size the agent already computes for
+		// the Directory Sizes card (GH #196). Best-effort/non-fatal — see
+		// ingestDBSizeHistory (db_size_history.go).
+		if cat == CategoryWPNative {
+			s.ingestDBSizeHistory(ctx, tenantID, siteID, payload, collected)
 		}
 	}
 	return count, nil

--- a/apps/api/internal/perf/model.go
+++ b/apps/api/internal/perf/model.go
@@ -467,6 +467,18 @@ type FleetSiteDbSummary struct {
 	GrowthBytes int64 `json:"growth_bytes"`
 }
 
+// FleetSiteDbReview is the slim per-site entry in FleetDbHealth.SitesNeedingReview.
+// Unlike TopSites (capped at fleetTopN, ordered by DB size), this list carries
+// EVERY site flagged for review — i.e. every site with at least one orphan
+// candidate — regardless of DB size, so the FE can enumerate the full flagged
+// set (GH #197).
+type FleetSiteDbReview struct {
+	SiteID               uuid.UUID `json:"site_id"`
+	SiteName             string    `json:"site_name"`
+	OrphanedOptionsCount int       `json:"orphaned_options_count"`
+	OrphanedCronCount    int       `json:"orphaned_cron_count"`
+}
+
 // FleetDbHealth is the response payload for GET /api/v1/perf/db/fleet-health.
 // It aggregates database health across every site in the tenant that has at
 // least one completed scan.
@@ -488,6 +500,13 @@ type FleetDbHealth struct {
 	// TopSites is the top-N sites by DB size (descending). N is capped at 10.
 	// When TotalSitesScanned is zero, TopSites is an empty slice.
 	TopSites []FleetSiteDbSummary `json:"top_sites"`
+	// SitesNeedingReview is EVERY scanned site that has at least one orphan
+	// candidate (options or cron) — NOT capped, unlike TopSites. Sorted by
+	// (orphaned_options_count + orphaned_cron_count) descending, then by
+	// site_name. This is what lets the FE enumerate the full "sites with
+	// items to review" set (GH #197); TopSites alone can omit a small site
+	// that's flagged but not in the top-10-by-DB-size.
+	SitesNeedingReview []FleetSiteDbReview `json:"sites_needing_review"`
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/perf/repo.go
+++ b/apps/api/internal/perf/repo.go
@@ -651,6 +651,47 @@ func (r *Repo) UpsertDBScanResult(ctx context.Context, in DBScanResultInput) err
 	})
 }
 
+// RecordDBSizeHistoryFromDiagnostics appends a site_db_size_history data
+// point sourced from the agent's DAILY diagnostics push rather than a manual
+// "Scan database" run (GH #196). Before this tap, UpsertDBScanResult was the
+// ONLY writer, so the 90-day trend + fleet growth read never populated unless
+// an operator clicked "Scan database" — this taps the wp-paths-sizes size the
+// agent already ships on every diagnostics push instead.
+//
+// table_count is carried forward from the most recent site_db_size_history
+// row for the site (a prior manual scan or a prior diagnostics-sourced
+// point); diagnostics does not carry a table inventory, so 0 is used only
+// when no prior row exists at all. The chart plots db_size_bytes, so a
+// carried-forward (or zero) table_count does not affect what operators see.
+//
+// Operator-tenant write path via InTenantTx — mirrors UpsertDBScanResult.
+// Idempotent via the (site_id, scanned_at) unique constraint (ON CONFLICT DO
+// NOTHING): passing the diagnostics push's own collected_at as scanned_at
+// naturally dedups to one point per push.
+func (r *Repo) RecordDBSizeHistoryFromDiagnostics(ctx context.Context, tenantID, siteID uuid.UUID, dbSizeBytes int64, scannedAt time.Time) error {
+	return r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		q := sqlc.New(tx)
+		tableCount, qerr := q.GetLatestDBSizeHistoryTableCount(ctx, sqlc.GetLatestDBSizeHistoryTableCountParams{
+			SiteID:   siteID,
+			TenantID: tenantID,
+		})
+		if qerr != nil {
+			if !errors.Is(qerr, pgx.ErrNoRows) {
+				return qerr
+			}
+			tableCount = 0
+		}
+		_, qerr = q.InsertDBSizeHistory(ctx, sqlc.InsertDBSizeHistoryParams{
+			SiteID:      siteID,
+			TenantID:    tenantID,
+			DbSizeBytes: dbSizeBytes,
+			TableCount:  tableCount,
+			ScannedAt:   scannedAt,
+		})
+		return qerr
+	})
+}
+
 // GetDBSizeHistory returns size-trend data points for a site from `since`
 // onwards (up to 366 points), ordered oldest-first. Operator read path
 // (InTenantTx).

--- a/apps/api/internal/perf/service.go
+++ b/apps/api/internal/perf/service.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"math"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -1490,6 +1491,7 @@ func (s *Service) GetFleetDbHealth(ctx context.Context, tenantID uuid.UUID, days
 
 	var out FleetDbHealth
 	out.TopSites = make([]FleetSiteDbSummary, 0)
+	out.SitesNeedingReview = make([]FleetSiteDbReview, 0)
 
 	for _, row := range rows {
 		out.TotalSitesScanned++
@@ -1499,8 +1501,28 @@ func (s *Service) GetFleetDbHealth(ctx context.Context, tenantID uuid.UUID, days
 		out.TotalOrphanedCron += row.OrphanedCronCount
 		if row.OrphanedOptionsCount > 0 || row.OrphanedCronCount > 0 {
 			out.SitesWithOrphans++
+			out.SitesNeedingReview = append(out.SitesNeedingReview, FleetSiteDbReview{
+				SiteID:               row.SiteID,
+				SiteName:             row.SiteName,
+				OrphanedOptionsCount: row.OrphanedOptionsCount,
+				OrphanedCronCount:    row.OrphanedCronCount,
+			})
 		}
 	}
+
+	// SitesNeedingReview carries EVERY flagged site (not capped by fleetTopN)
+	// so the FE can enumerate the full "sites with items to review" set even
+	// when a flagged site isn't among the top-10-by-DB-size (GH #197). Sort
+	// by total orphan count descending, then by name for stable ordering.
+	sort.Slice(out.SitesNeedingReview, func(i, j int) bool {
+		a, b := out.SitesNeedingReview[i], out.SitesNeedingReview[j]
+		aTotal := a.OrphanedOptionsCount + a.OrphanedCronCount
+		bTotal := b.OrphanedOptionsCount + b.OrphanedCronCount
+		if aTotal != bTotal {
+			return aTotal > bTotal
+		}
+		return a.SiteName < b.SiteName
+	})
 
 	// Cap the top-N list. The SQL result is already ordered by db_size_bytes
 	// DESC so the first fleetTopN rows are the largest sites.

--- a/apps/api/internal/perf/service_test.go
+++ b/apps/api/internal/perf/service_test.go
@@ -33,6 +33,8 @@ type fakeRepo struct {
 	// GH #174 — ack-based beacon-key reconcile stubs.
 	beaconAckedCalls []bool // the `present` arg of each UpdateBeaconKeyAcked call
 	beaconAckedErr   error
+	// GH #197 — fleet DB health rows returned by GetFleetDbHealth.
+	fleetDbHealthRows []FleetSiteDbSummary
 }
 
 func (r *fakeRepo) GetConfig(_ context.Context, tenantID, siteID uuid.UUID) (Config, error) {
@@ -158,7 +160,9 @@ func (r *fakeRepo) PruneCacheHitRatioHistory(_ context.Context, _ time.Duration)
 
 // P3.7 — fleet DB health stub.
 func (r *fakeRepo) GetFleetDbHealth(_ context.Context, _ uuid.UUID, _ time.Time) ([]FleetSiteDbSummary, error) {
-	return nil, nil
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.fleetDbHealthRows, nil
 }
 
 // P3.8 — orphan-delete watchdog stubs.
@@ -2429,4 +2433,100 @@ func (a *mediaCleanSanitizeAgent) MediaClean(_ context.Context, _ uuid.UUID, _ s
 			},
 		},
 	}, nil
+}
+
+// TestGetFleetDbHealthSitesNeedingReviewNotCapped is GH #197: a site flagged
+// for review (orphan candidates present) must appear in SitesNeedingReview
+// even when it's far outside the top-10-by-DB-size TopSites list.
+func TestGetFleetDbHealthSitesNeedingReviewNotCapped(t *testing.T) {
+	const totalSites = 20
+	const flaggedSites = 14
+
+	rows := make([]FleetSiteDbSummary, 0, totalSites)
+	for i := 0; i < totalSites; i++ {
+		row := FleetSiteDbSummary{
+			SiteID: uuid.New(),
+			// Name encodes rank so we can identify entries later. Sorted
+			// descending by DBSizeBytes below, mirroring the SQL's ORDER BY.
+			SiteName:    fmt.Sprintf("site-%02d", i),
+			DBSizeBytes: int64(totalSites-i) * 1024 * 1024, // largest first
+			TableCount:  50,
+		}
+		// Flag the first 14 sites by rank (i=0..13) for review. Since rows
+		// are constructed largest-first (i=0 is the biggest DB), TopSites
+		// (capped at fleetTopN=10) only covers i=0..9 — flagged sites
+		// i=10..13 fall OUTSIDE TopSites, reproducing GH #197.
+		if i < flaggedSites {
+			row.OrphanedOptionsCount = i + 1
+			row.OrphanedCronCount = 1
+		}
+		rows = append(rows, row)
+	}
+
+	repo := &fakeRepo{fleetDbHealthRows: rows}
+	svc := NewService(repo, nil, nil, nil)
+
+	out, err := svc.GetFleetDbHealth(context.Background(), uuid.New(), 90)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(out.TopSites) != fleetTopN {
+		t.Fatalf("TopSites: got %d entries, want %d (capped)", len(out.TopSites), fleetTopN)
+	}
+
+	if out.SitesWithOrphans != flaggedSites {
+		t.Fatalf("SitesWithOrphans: got %d, want %d", out.SitesWithOrphans, flaggedSites)
+	}
+	if len(out.SitesNeedingReview) != flaggedSites {
+		t.Fatalf("SitesNeedingReview: got %d entries, want %d (uncapped)", len(out.SitesNeedingReview), flaggedSites)
+	}
+
+	// Confirm at least one flagged site OUTSIDE the top-10-by-size window is
+	// present in SitesNeedingReview but absent from TopSites — this is the
+	// exact bug being fixed.
+	inTopSites := make(map[uuid.UUID]bool, len(out.TopSites))
+	for _, s := range out.TopSites {
+		inTopSites[s.SiteID] = true
+	}
+	foundOutsideTop := false
+	for _, s := range out.SitesNeedingReview {
+		if !inTopSites[s.SiteID] {
+			foundOutsideTop = true
+			break
+		}
+	}
+	if !foundOutsideTop {
+		t.Fatal("expected at least one flagged site outside TopSites to be present in SitesNeedingReview")
+	}
+
+	// Sort order: descending total orphan count (options+cron), tie-break by
+	// site name ascending.
+	for i := 1; i < len(out.SitesNeedingReview); i++ {
+		prev, cur := out.SitesNeedingReview[i-1], out.SitesNeedingReview[i]
+		prevTotal := prev.OrphanedOptionsCount + prev.OrphanedCronCount
+		curTotal := cur.OrphanedOptionsCount + cur.OrphanedCronCount
+		if prevTotal < curTotal {
+			t.Fatalf("SitesNeedingReview not sorted by total orphan count desc at index %d: %d < %d", i, prevTotal, curTotal)
+		}
+		if prevTotal == curTotal && prev.SiteName > cur.SiteName {
+			t.Fatalf("SitesNeedingReview tie-break not sorted by name asc at index %d: %q > %q", i, prev.SiteName, cur.SiteName)
+		}
+	}
+
+	// Every review entry must carry the slim 4-field shape correctly mapped
+	// from the source row (spot-check by id).
+	bySiteID := make(map[uuid.UUID]FleetSiteDbSummary, len(rows))
+	for _, r := range rows {
+		bySiteID[r.SiteID] = r
+	}
+	for _, review := range out.SitesNeedingReview {
+		src, ok := bySiteID[review.SiteID]
+		if !ok {
+			t.Fatalf("SitesNeedingReview entry %s not found in source rows", review.SiteID)
+		}
+		if review.SiteName != src.SiteName || review.OrphanedOptionsCount != src.OrphanedOptionsCount || review.OrphanedCronCount != src.OrphanedCronCount {
+			t.Fatalf("SitesNeedingReview entry mismatch for %s: got %+v, want fields from %+v", review.SiteID, review, src)
+		}
+	}
 }

--- a/apps/api/tests/diagnostics_db_size_history_integration_test.go
+++ b/apps/api/tests/diagnostics_db_size_history_integration_test.go
@@ -1,0 +1,262 @@
+// Integration tests for GH #196: the daily diagnostics push now taps
+// wp-paths-sizes.fields.database_size to append a site_db_size_history point
+// automatically, alongside the pre-existing manual "Scan database" writer
+// (perf.Repo.UpsertDBScanResult). Exercises the real diagnostics.Service +
+// diagnostics.Repo + perf.Repo against a real Postgres (testcontainers) so
+// the RLS-scoped InTenantTx write path and the (site_id, scanned_at)
+// idempotent-insert constraint are genuinely proven, not mocked.
+//
+// Requires Docker; skips (via startPostgres) when unavailable.
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/diagnostics"
+	"github.com/mosamlife/wpmgr/apps/api/internal/perf"
+)
+
+// newDiagnosticsDBSizeHarness wires the real diagnostics.Service against the
+// real diagnostics.Repo + perf.Repo (the DBSizeHistorySink adapter), mirroring
+// the cmd/wpmgr wiring (diagnosticsSvc.SetDBSizeHistorySink(perfRepo)).
+func newDiagnosticsDBSizeHarness(pool *db.Pool) (*diagnostics.Service, *perf.Repo) {
+	diagRepo := diagnostics.NewRepo(pool)
+	perfRepo := perf.NewRepo(pool)
+	svc := diagnostics.NewService(diagRepo)
+	svc.SetDBSizeHistorySink(perfRepo)
+	return svc, perfRepo
+}
+
+// wpNativePayloadJSON builds a full diagnostics push body carrying only the
+// wp_native category, shaped like the agent's real
+// WP_Debug_Data::debug_data() + SizeProbe merge output
+// (wp-paths-sizes.fields.database_size.debug). collectedAt is the top-level
+// agent-side collection timestamp (unix seconds) IngestDiagnostics applies to
+// every category row — and the value the DB-size tap uses as scanned_at.
+func wpNativePayloadJSON(dbSizeBytes int64, collectedAt time.Time) []byte {
+	return []byte(fmt.Sprintf(
+		`{"wp_native":{"wp-paths-sizes":{"fields":{"database_size":{"value":"size","debug":%d}}}},"collected_at":%d}`,
+		dbSizeBytes, collectedAt.Unix(),
+	))
+}
+
+// TestDiagnosticsPushRecordsDBSizeHistoryPoint proves the happy path: a
+// diagnostics push carrying a positive wp-paths-sizes database_size appends
+// exactly one site_db_size_history point for the right site/tenant, with the
+// right byte count and scanned_at == the push's own collected_at.
+func TestDiagnosticsPushRecordsDBSizeHistoryPoint(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	tenantID := seedTenant(t, pool, "dbsize-happy-"+uuid.NewString()[:8])
+	siteID := seedSiteFor(t, admin, tenantID, "https://"+uuid.NewString()+".example.com")
+
+	svc, perfRepo := newDiagnosticsDBSizeHarness(pool)
+	collectedAt := time.Now().UTC().Truncate(time.Second)
+
+	const dbSizeBytes = int64(1288490188) // ~1.2 GB
+	body := wpNativePayloadJSON(dbSizeBytes, collectedAt)
+
+	count, err := svc.IngestDiagnostics(ctx, tenantID, siteID, body)
+	if err != nil {
+		t.Fatalf("IngestDiagnostics: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 category ingested (wp_native only), got %d", count)
+	}
+
+	points, err := perfRepo.GetDBSizeHistory(ctx, tenantID, siteID, collectedAt.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("GetDBSizeHistory: %v", err)
+	}
+	if len(points) != 1 {
+		t.Fatalf("expected exactly 1 db-size history point, got %d: %+v", len(points), points)
+	}
+	if points[0].DBSizeBytes != dbSizeBytes {
+		t.Errorf("db_size_bytes = %d, want %d", points[0].DBSizeBytes, dbSizeBytes)
+	}
+	if !points[0].ScannedAt.Equal(collectedAt) {
+		t.Errorf("scanned_at = %v, want %v (the push's own collected_at)", points[0].ScannedAt, collectedAt)
+	}
+	// No prior scan/history row exists for this brand-new site, so
+	// table_count must carry forward to the documented default of 0.
+	if points[0].TableCount != 0 {
+		t.Errorf("table_count = %d, want 0 (no prior history row to carry forward)", points[0].TableCount)
+	}
+}
+
+// TestDiagnosticsPushSkipsMissingOrZeroDBSize proves the guard: a push whose
+// wp_native category has no usable database_size (missing field, zero bytes,
+// or WP's un-resolved "Loading…" placeholder) must NOT write a history point.
+func TestDiagnosticsPushSkipsMissingOrZeroDBSize(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	tenantID := seedTenant(t, pool, "dbsize-skip-"+uuid.NewString()[:8])
+	siteID := seedSiteFor(t, admin, tenantID, "https://"+uuid.NewString()+".example.com")
+
+	svc, perfRepo := newDiagnosticsDBSizeHarness(pool)
+	collectedAt := time.Now().UTC().Truncate(time.Second)
+
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "database_size field entirely absent",
+			body: []byte(fmt.Sprintf(`{"wp_native":{"wp-paths-sizes":{"fields":{}}},"collected_at":%d}`, collectedAt.Unix())),
+		},
+		{
+			name: "database_size.debug is zero",
+			body: wpNativePayloadJSON(0, collectedAt),
+		},
+		{
+			name: "database_size.debug is the WP un-resolved placeholder string",
+			body: []byte(fmt.Sprintf(
+				`{"wp_native":{"wp-paths-sizes":{"fields":{"database_size":{"value":"Loading&hellip;","debug":"Loading&hellip;"}}}},"collected_at":%d}`,
+				collectedAt.Unix(),
+			)),
+		},
+		{
+			name: "wp-paths-sizes section entirely absent",
+			body: []byte(fmt.Sprintf(`{"wp_native":{"wp-core":{"fields":{}}},"collected_at":%d}`, collectedAt.Unix())),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			count, err := svc.IngestDiagnostics(ctx, tenantID, siteID, tc.body)
+			if err != nil {
+				t.Fatalf("IngestDiagnostics: %v", err)
+			}
+			if count != 1 {
+				t.Fatalf("expected 1 category ingested (wp_native), got %d", count)
+			}
+			points, err := perfRepo.GetDBSizeHistory(ctx, tenantID, siteID, collectedAt.Add(-time.Hour))
+			if err != nil {
+				t.Fatalf("GetDBSizeHistory: %v", err)
+			}
+			if len(points) != 0 {
+				t.Fatalf("expected no db-size history point, got %d: %+v", len(points), points)
+			}
+		})
+	}
+}
+
+// TestDiagnosticsPushDBSizeHistoryInsertFailureIsNonFatal proves the sink is
+// best-effort: when the history-sink write fails, IngestDiagnostics must
+// still succeed (the 15-category upsert has already landed) — a downstream
+// history-table outage must never turn the agent's daily diagnostics push
+// into a failed request.
+func TestDiagnosticsPushDBSizeHistoryInsertFailureIsNonFatal(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	tenantID := seedTenant(t, pool, "dbsize-failsafe-"+uuid.NewString()[:8])
+	siteID := seedSiteFor(t, admin, tenantID, "https://"+uuid.NewString()+".example.com")
+
+	diagRepo := diagnostics.NewRepo(pool)
+	svc := diagnostics.NewService(diagRepo)
+	sink := &failingDBSizeHistorySink{}
+	svc.SetDBSizeHistorySink(sink)
+
+	collectedAt := time.Now().UTC().Truncate(time.Second)
+	body := wpNativePayloadJSON(1288490188, collectedAt)
+
+	count, err := svc.IngestDiagnostics(ctx, tenantID, siteID, body)
+	if err != nil {
+		t.Fatalf("IngestDiagnostics must succeed even when the history sink fails, got: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 category ingested (wp_native), got %d", count)
+	}
+	if !sink.called {
+		t.Fatal("expected the (failing) DBSizeHistorySink to have been invoked")
+	}
+
+	// The core diagnostics row must still be persisted — the failure is
+	// scoped entirely to the best-effort history tap.
+	rows, err := diagRepo.ListDiagnosticsBySite(ctx, tenantID, siteID)
+	if err != nil {
+		t.Fatalf("ListDiagnosticsBySite: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Category != diagnostics.CategoryWPNative {
+		t.Fatalf("expected the wp_native diagnostics row to be stored despite the history-sink failure, got: %+v", rows)
+	}
+}
+
+// TestDiagnosticsPushCarriesForwardTableCount proves table_count is carried
+// forward from the most recent site_db_size_history row (a prior manual scan
+// or a prior diagnostics-sourced point) rather than always writing 0 — the
+// diagnostics push itself never carries a table inventory.
+func TestDiagnosticsPushCarriesForwardTableCount(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	tenantID := seedTenant(t, pool, "dbsize-carry-"+uuid.NewString()[:8])
+	siteID := seedSiteFor(t, admin, tenantID, "https://"+uuid.NewString()+".example.com")
+
+	// Seed a prior history point (standing in for an earlier manual "Scan
+	// database" run) with a known table_count, via the superuser admin pool
+	// (bypasses RLS for fixture setup, mirroring seedSiteFor above).
+	priorScannedAt := time.Now().UTC().Add(-24 * time.Hour).Truncate(time.Second)
+	const priorTableCount = 42
+	if _, err := admin.Exec(ctx,
+		`INSERT INTO site_db_size_history (site_id, tenant_id, db_size_bytes, table_count, scanned_at)
+		 VALUES ($1, $2, $3, $4, $5)`,
+		siteID, tenantID, int64(900000000), priorTableCount, priorScannedAt,
+	); err != nil {
+		t.Fatalf("seed prior db-size history point: %v", err)
+	}
+
+	svc, perfRepo := newDiagnosticsDBSizeHarness(pool)
+	collectedAt := time.Now().UTC().Truncate(time.Second)
+	body := wpNativePayloadJSON(1288490188, collectedAt)
+
+	if _, err := svc.IngestDiagnostics(ctx, tenantID, siteID, body); err != nil {
+		t.Fatalf("IngestDiagnostics: %v", err)
+	}
+
+	points, err := perfRepo.GetDBSizeHistory(ctx, tenantID, siteID, priorScannedAt.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("GetDBSizeHistory: %v", err)
+	}
+	if len(points) != 2 {
+		t.Fatalf("expected 2 db-size history points (prior + diagnostics-sourced), got %d: %+v", len(points), points)
+	}
+	// Points are ordered oldest-first; the newest (diagnostics-sourced) point
+	// must carry forward the prior point's table_count.
+	newest := points[len(points)-1]
+	if !newest.ScannedAt.Equal(collectedAt) {
+		t.Fatalf("newest point scanned_at = %v, want %v", newest.ScannedAt, collectedAt)
+	}
+	if newest.TableCount != priorTableCount {
+		t.Errorf("table_count = %d, want %d (carried forward from the prior history row)", newest.TableCount, priorTableCount)
+	}
+}
+
+// failingDBSizeHistorySink is a diagnostics.DBSizeHistorySink fake that always
+// errors, used to prove the tap is best-effort/non-fatal.
+type failingDBSizeHistorySink struct {
+	called bool
+}
+
+func (f *failingDBSizeHistorySink) RecordDBSizeHistoryFromDiagnostics(ctx context.Context, tenantID, siteID uuid.UUID, dbSizeBytes int64, scannedAt time.Time) error {
+	f.called = true
+	return errors.New("boom: history sink unavailable")
+}

--- a/apps/web/src/features/perf/optimize/FleetDbHealthPanel.test.tsx
+++ b/apps/web/src/features/perf/optimize/FleetDbHealthPanel.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+import { mockQueryResult } from "@/test/query-mocks";
+
+import { FleetDbHealthPanel } from "./FleetDbHealthPanel";
+import { useFleetDbHealth } from "../hooks/useFleetDbHealth";
+import type { FleetDbHealth } from "../types";
+
+// GH #197 — the amber "Sites with items to review" stat on the fleet DB
+// health panel used to be inert text: a count with no way to see WHICH
+// sites it referred to. This proves the stat is now a real disclosure that
+// drills through to every flagged site, each linking to that site's
+// existing Orphaned-items view (`/sites/$siteId/optimize`).
+
+vi.mock("../hooks/useFleetDbHealth", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../hooks/useFleetDbHealth")>();
+  return { ...actual, useFleetDbHealth: vi.fn() };
+});
+
+const mockedUseFleetDbHealth = vi.mocked(useFleetDbHealth);
+
+function buildHealth(overrides: Partial<FleetDbHealth> = {}): FleetDbHealth {
+  return {
+    total_sites_scanned: 4,
+    total_db_size_bytes: 400_000_000,
+    total_table_count: 120,
+    total_orphaned_options: 30,
+    total_orphaned_cron: 5,
+    sites_with_orphans: 2,
+    top_sites: [],
+    sites_needing_review: [
+      {
+        site_id: "site-aaa",
+        site_name: "aaa.example.com",
+        orphaned_options_count: 12,
+        orphaned_cron_count: 3,
+      },
+      {
+        site_id: "site-bbb",
+        site_name: "bbb.example.com",
+        orphaned_options_count: 8,
+        orphaned_cron_count: 0,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function renderPanel(health: FleetDbHealth) {
+  mockedUseFleetDbHealth.mockReturnValue(mockQueryResult<FleetDbHealth>({ data: health }));
+  return renderWithProviders(<FleetDbHealthPanel />, { withRouter: true });
+}
+
+describe("FleetDbHealthPanel — sites-needing-review drill-down (GH #197)", () => {
+  it("renders the amber stat as a collapsed, interactive disclosure by default", async () => {
+    renderPanel(buildHealth());
+
+    // RouterProvider's first paint is async (see src/test/render.tsx) —
+    // the FIRST assertion must be a findBy*, everything after is sync.
+    const stat = await screen.findByRole("button", {
+      name: /sites with items to review/i,
+    });
+    expect(stat).toHaveAttribute("aria-expanded", "false");
+
+    // Collapsed: no per-site links are in the DOM yet.
+    expect(
+      screen.queryByRole("link", { name: "aaa.example.com" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("expands to list every flagged site, each linking to its Orphaned-items view with the total orphan count, and toggles aria-expanded", async () => {
+    renderPanel(buildHealth());
+
+    const stat = await screen.findByRole("button", {
+      name: /sites with items to review/i,
+    });
+
+    fireEvent.click(stat);
+
+    expect(stat).toHaveAttribute("aria-expanded", "true");
+
+    // Non-vacuous: one Link per flagged site, pointing at the real route,
+    // showing the site name and the SUM of options + cron orphan counts.
+    const linkA = screen.getByRole("link", { name: "aaa.example.com" });
+    expect(linkA).toHaveAttribute("href", "/sites/site-aaa/optimize");
+    const linkB = screen.getByRole("link", { name: "bbb.example.com" });
+    expect(linkB).toHaveAttribute("href", "/sites/site-bbb/optimize");
+
+    expect(screen.getByText("15 items")).toBeInTheDocument(); // 12 + 3
+    expect(screen.getByText("8 items")).toBeInTheDocument(); // 8 + 0
+
+    // Collapses back on a second click.
+    fireEvent.click(stat);
+    expect(stat).toHaveAttribute("aria-expanded", "false");
+    expect(
+      screen.queryByRole("link", { name: "aaa.example.com" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render the amber stat at all when no sites have orphans", async () => {
+    renderPanel(
+      buildHealth({ sites_with_orphans: 0, sites_needing_review: [] }),
+    );
+
+    // Assert on something else that IS present first (async router paint),
+    // then confirm the amber stat never shows up.
+    await screen.findByText("Database health across your sites");
+    expect(
+      screen.queryByRole("button", { name: /sites with items to review/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("guards against an undefined sites_needing_review (older server response) without crashing", async () => {
+    const health = buildHealth();
+    delete (health as { sites_needing_review?: unknown }).sites_needing_review;
+
+    renderPanel(health);
+
+    const stat = await screen.findByRole("button", {
+      name: /sites with items to review/i,
+    });
+    fireEvent.click(stat);
+
+    expect(stat).toHaveAttribute("aria-expanded", "true");
+    // Nothing to show — no crash, no stray links.
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+  });
+});

--- a/apps/web/src/features/perf/optimize/FleetDbHealthPanel.tsx
+++ b/apps/web/src/features/perf/optimize/FleetDbHealthPanel.tsx
@@ -8,23 +8,29 @@
 // Placement: apps/web/src/routes/_authed/performance.tsx (Insights > Performance),
 // which is the natural portfolio/fleet home for cross-site rollups.
 
+import { useState } from "react";
 import {
   AlertTriangle,
+  ChevronDown,
   Database,
   TrendingDown,
   TrendingUp,
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 
+import { cn } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageError } from "@/components/feedback";
 
 import { useFleetDbHealth } from "../hooks/useFleetDbHealth";
 import { formatBytes, formatCount } from "../format";
-import type { FleetDbTopSite } from "../types";
+import type { FleetDbSiteNeedingReview, FleetDbTopSite } from "../types";
+
+const SITES_NEEDING_REVIEW_LIST_ID = "fleet-sites-needing-review-list";
 
 export function FleetDbHealthPanel() {
   const { data, isPending, isError, error, refetch } = useFleetDbHealth();
+  const [needingReviewExpanded, setNeedingReviewExpanded] = useState(false);
 
   return (
     <section
@@ -93,9 +99,20 @@ export function FleetDbHealthPanel() {
                 label="Sites with items to review"
                 value={formatCount(data.sites_with_orphans)}
                 highlight="amber"
+                expanded={needingReviewExpanded}
+                controls={SITES_NEEDING_REVIEW_LIST_ID}
+                onToggle={() => setNeedingReviewExpanded((v) => !v)}
               />
             )}
           </div>
+
+          {/* Sites needing review — drill-down disclosure */}
+          {needingReviewExpanded && (data.sites_needing_review?.length ?? 0) > 0 && (
+            <SitesNeedingReviewList
+              id={SITES_NEEDING_REVIEW_LIST_ID}
+              sites={data.sites_needing_review ?? []}
+            />
+          )}
 
           {/* Top sites table */}
           {data.top_sites.length > 0 && (
@@ -116,32 +133,121 @@ interface FleetStatProps {
   value: string;
   hint?: string;
   highlight?: "amber";
+  /** When set (together with `onToggle`), the stat renders as an expandable
+   *  disclosure button rather than inert text. */
+  expanded?: boolean;
+  /** id of the region this stat's disclosure controls, wired via
+   *  `aria-controls`. Required alongside `onToggle`. */
+  controls?: string;
+  onToggle?: () => void;
 }
 
-function FleetStat({ label, value, hint, highlight }: FleetStatProps) {
+function FleetStat({
+  label,
+  value,
+  hint,
+  highlight,
+  expanded,
+  controls,
+  onToggle,
+}: FleetStatProps) {
+  const valueEl = (
+    <span
+      className={`tabular-nums text-xl font-semibold leading-none ${
+        highlight === "amber"
+          ? "text-amber-700 dark:text-amber-400"
+          : "text-foreground"
+      }`}
+    >
+      {value}
+    </span>
+  );
+
+  const labelEl = (
+    <span className="text-xs text-muted-foreground" title={hint}>
+      {label}
+      {hint && (
+        <AlertTriangle
+          aria-label={hint}
+          className="ml-1 inline size-3 cursor-help text-muted-foreground/50"
+        />
+      )}
+    </span>
+  );
+
+  if (onToggle) {
+    return (
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded ?? false}
+        aria-controls={controls}
+        className="flex flex-col gap-0.5 rounded-sm text-left transition-colors hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      >
+        <span className="inline-flex items-center gap-1">
+          {valueEl}
+          <ChevronDown
+            aria-hidden="true"
+            className={cn(
+              "size-3.5 shrink-0 text-muted-foreground transition-transform",
+              expanded && "rotate-180",
+            )}
+          />
+        </span>
+        {labelEl}
+      </button>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-0.5">
-      <span
-        className={`tabular-nums text-xl font-semibold leading-none ${
-          highlight === "amber"
-            ? "text-amber-700 dark:text-amber-400"
-            : "text-foreground"
-        }`}
-      >
-        {value}
-      </span>
-      <span
-        className="text-xs text-muted-foreground"
-        title={hint}
-      >
-        {label}
-        {hint && (
-          <AlertTriangle
-            aria-label={hint}
-            className="ml-1 inline size-3 cursor-help text-muted-foreground/50"
-          />
-        )}
-      </span>
+      {valueEl}
+      {labelEl}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sites needing review — drill-down disclosure for the amber stat (GH #197)
+// ---------------------------------------------------------------------------
+
+function SitesNeedingReviewList({
+  id,
+  sites,
+}: {
+  id: string;
+  sites: FleetDbSiteNeedingReview[];
+}) {
+  return (
+    <div
+      id={id}
+      className="border-b border-border px-5 py-4"
+    >
+      <p className="mb-3 text-xs font-medium uppercase tracking-[0.02em] text-muted-foreground">
+        Sites with items to review
+      </p>
+      <ul className="space-y-2.5">
+        {sites.map((site) => {
+          const total = site.orphaned_options_count + site.orphaned_cron_count;
+          return (
+            <li
+              key={site.site_id}
+              className="flex items-center justify-between gap-3"
+            >
+              <Link
+                to="/sites/$siteId/optimize"
+                params={{ siteId: site.site_id }}
+                className="min-w-0 flex-1 truncate text-sm font-medium text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                {site.site_name}
+              </Link>
+              <span className="shrink-0 text-xs tabular-nums text-amber-700 dark:text-amber-400">
+                {formatCount(total)} item{total === 1 ? "" : "s"}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 }

--- a/apps/web/src/features/perf/types.ts
+++ b/apps/web/src/features/perf/types.ts
@@ -410,6 +410,26 @@ export interface FleetDbTopSite {
 }
 
 /**
+ * One entry in the FULL list of flagged sites returned by
+ * GET /api/v1/perf/db/fleet-health (`sites_needing_review`) — every site
+ * with at least one orphan candidate, unlike `top_sites` which is capped at
+ * the top-10-by-size.
+ *
+ * Field names match the Go FleetSiteNeedingReview JSON tags exactly
+ * (apps/api/internal/perf/model.go).
+ */
+export interface FleetDbSiteNeedingReview {
+  /** UUID of the site. */
+  site_id: string;
+  /** Human-readable site name. */
+  site_name: string;
+  /** Number of orphaned wp_options candidates from the latest scan. */
+  orphaned_options_count: number;
+  /** Number of orphaned cron-event candidates from the latest scan. */
+  orphaned_cron_count: number;
+}
+
+/**
  * Tenant-level aggregate returned by GET /api/v1/perf/db/fleet-health.
  *
  * Field names match the Go FleetDbHealth JSON tags exactly
@@ -430,6 +450,13 @@ export interface FleetDbHealth {
   sites_with_orphans: number;
   /** Top-N sites ordered by DB size descending (typically <= 10). */
   top_sites: FleetDbTopSite[];
+  /**
+   * The FULL list of every site flagged with at least one orphan candidate
+   * (options or cron), unlike `top_sites` which is capped at the
+   * top-10-by-size. May be absent on an older server response — callers
+   * must guard with `?? []`.
+   */
+  sites_needing_review?: FleetDbSiteNeedingReview[];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -10055,7 +10055,21 @@ export type GetFleetDbHealthResponses = {
    * Fleet DB health aggregate (shape matches FleetDbHealth Go model).
    */
   200: {
-    [key: string]: unknown;
+    /**
+     * Every scanned site with at least one orphan candidate
+     * (orphaned wp_options rows or WP-Cron events) — NOT
+     * capped, unlike top_sites (which is capped at 10 and
+     * ordered by DB size, so a small flagged site can be
+     * absent from it). Sorted by orphan count descending,
+     * then by site name.
+     *
+     */
+    sites_needing_review?: Array<{
+      site_id?: string;
+      site_name?: string;
+      orphaned_options_count?: number;
+      orphaned_cron_count?: number;
+    }>;
   };
 };
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -4210,6 +4210,28 @@ paths:
               schema:
                 type: object
                 description: Fleet DB health aggregate (shape matches FleetDbHealth Go model).
+                properties:
+                  sites_needing_review:
+                    type: array
+                    description: |
+                      Every scanned site with at least one orphan candidate
+                      (orphaned wp_options rows or WP-Cron events) — NOT
+                      capped, unlike top_sites (which is capped at 10 and
+                      ordered by DB size, so a small flagged site can be
+                      absent from it). Sorted by orphan count descending,
+                      then by site name.
+                    items:
+                      type: object
+                      properties:
+                        site_id:
+                          type: string
+                          format: uuid
+                        site_name:
+                          type: string
+                        orphaned_options_count:
+                          type: integer
+                        orphaned_cron_count:
+                          type: integer
   /api/v1/uptime/summary:
     get:
       operationId: getUptimeSummary


### PR DESCRIPTION
#197: the fleet review stat now expands to the full list of flagged sites (was inert + capped at top-10-by-size), each linking to its Orphaned-items view. #196: DB-size 90-day trend now records a sample from each daily diagnostics push (best-effort, RLS-safe, reuses the existing insert+GC) instead of only on a manual scan — no migration/agent/UI change. Tests green both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU