### PR TITLE
fix: fleet CWV offenders show site name (#202) + audit log associates backup/restore/update with their site (#201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
-## [0.61.51] - 2026-07-09
+## [0.61.52] - 2026-07-09
+
+### Fixed
+
+- The fleet Core Web Vitals "worst offenders" table now shows each site's name and URL (GH #202). The rows were built from the metrics data alone, which is keyed only by site id, so the Name/URL columns rendered blank. The final (top ten) rows are now enriched with a single site lookup, so you can see which sites they are.
+- Audit-log entries for backups, restores, and updates are now associated with their site (GH #201). Previously only events whose target was the site itself carried a site association, so backup/restore/update entries showed no site name and the "filter by site" control silently returned zero rows for them. The site filter now also matches the site id recorded in those entries' metadata (and the schedule target), and the log shows the site name for them. This is a read/display change only, the tamper-evident audit chain is untouched, and no migration is needed.
 
 ### Fixed
 

--- a/apps/api/cmd/wpmgr/siteadapter.go
+++ b/apps/api/cmd/wpmgr/siteadapter.go
@@ -336,6 +336,30 @@ func (a *perfSiteAdapter) ListSiteIDs(ctx context.Context, tenantID uuid.UUID) (
 	return a.svc.ListAllSiteIDs(ctx, tenantID)
 }
 
+// ListSitesMeta returns the name+url for every non-archived site in the
+// tenant (used by the fleet RUM worst-offenders enrichment, GH #202). Pages
+// through site.Service.List (which clamps Limit to 200 per call) so large
+// fleets are not silently truncated.
+func (a *perfSiteAdapter) ListSitesMeta(ctx context.Context, tenantID uuid.UUID) ([]perf.SiteMeta, error) {
+	const pageSize = 200
+	var metas []perf.SiteMeta
+	offset := int32(0)
+	for {
+		sites, err := a.svc.List(ctx, site.ListInput{TenantID: tenantID, Limit: pageSize, Offset: offset})
+		if err != nil {
+			return nil, err
+		}
+		for _, s := range sites {
+			metas = append(metas, perf.SiteMeta{ID: s.ID, Name: s.Name, URL: s.URL})
+		}
+		if len(sites) < pageSize {
+			break
+		}
+		offset += pageSize
+	}
+	return metas, nil
+}
+
 var _ perf.SiteLookup = (*perfSiteAdapter)(nil)
 
 // backupCheckerAdapter adapts the backup service to the perf.BackupChecker

--- a/apps/api/db/query/audit_log.sql
+++ b/apps/api/db/query/audit_log.sql
@@ -57,14 +57,30 @@ ORDER BY al.created_at DESC, al.id DESC
 LIMIT $2 OFFSET $3;
 
 -- name: ListAuditEntriesFiltered :many
--- Optional filters: action prefix (LIKE 'prefix%'), site_id (target_type='site'
--- AND target_id = site_id::text). Passing an empty string for action_prefix or
--- a zero UUID for site_id disables those filters respectively. RLS is still the
--- primary tenant-isolation gate; the explicit tenant_id is defense-in-depth.
+-- Optional filters: action prefix (LIKE 'prefix%'), site_id. Passing an empty
+-- string for action_prefix or a zero UUID for site_id disables those filters
+-- respectively. RLS is still the primary tenant-isolation gate; the explicit
+-- tenant_id is defense-in-depth.
 -- Newest-first (see ListAuditEntries); actor_user_name/actor_key_name/
 -- actor_email resolve the same way, including the CASE-guarded ::uuid cast
 -- (see ListAuditEntries for the full join contract and why a plain regex-AND
 -- guard is NOT safe here).
+--
+-- The site_id filter (GH #201) matches THREE shapes, because target_id only
+-- holds the site id for target_type='site' rows:
+--   1. target_type='site' AND target_id = site_id (site lifecycle events).
+--   2. metadata->>'site_id' = site_id (backup/restore/update lifecycle rows,
+--      whose target_id is a snapshot/run/task id, not the site — the
+--      recorders always stamp metadata.site_id for these).
+--   3. target_type='backup_schedule' AND target_id = site_id (the one
+--      recorder that carries the site id in target_id but never writes
+--      metadata.site_id — see backup.recordScheduleChange).
+-- metadata->>'site_id' is TEXT-to-TEXT on purpose: it must NEVER be cast to
+-- ::uuid. metadata is free-form JSONB and a malformed/absent value must
+-- degrade to NULL (never match) rather than throw 22P02 — the same class of
+-- bug the CASE-guarded actor join above exists to avoid. ->>'site_id' already
+-- returns NULL when the key is absent, so non-site rows are safely excluded
+-- without any extra guard.
 SELECT
     al.id, al.tenant_id, al.actor_type, al.actor_id, al.action, al.target_type,
     al.target_id, al.metadata, al.prev_hash, al.hash, al.created_at,
@@ -83,7 +99,12 @@ LEFT JOIN api_keys ak
                      THEN al.actor_id::uuid END
 WHERE al.tenant_id = @tenant_id
   AND (@action_prefix = '' OR al.action LIKE @action_prefix || '%')
-  AND (@site_id::text = '00000000-0000-0000-0000-000000000000' OR (al.target_type = 'site' AND al.target_id = @site_id::text))
+  AND (
+    @site_id::text = '00000000-0000-0000-0000-000000000000'
+    OR (al.target_type = 'site' AND al.target_id = @site_id::text)
+    OR (al.metadata->>'site_id' = @site_id::text)
+    OR (al.target_type = 'backup_schedule' AND al.target_id = @site_id::text)
+  )
 ORDER BY al.created_at DESC, al.id DESC
 LIMIT  @row_limit
 OFFSET @row_offset;

--- a/apps/api/internal/audit/audit.go
+++ b/apps/api/internal/audit/audit.go
@@ -519,11 +519,14 @@ type Filter struct {
 	// starts with this string (prefix match). An exact action string also works
 	// because it is a prefix of itself.
 	ActionPrefix string
-	// SiteID, when non-nil, restricts results to entries whose target_type is
-	// "site" and target_id equals this UUID (string form). All file-manager,
-	// perf, backup, and other per-site actions write their siteID as target_id
-	// with target_type="site", so this filter correctly captures the full
-	// per-site timeline without a schema change to audit_log.
+	// SiteID, when non-nil, restricts results to entries associated with this
+	// site (string UUID form). Most per-site actions (file-manager, perf, and
+	// site lifecycle events) write target_type="site" with target_id=site_id,
+	// but backup/restore/update lifecycle rows target a snapshot/run/task id
+	// instead, so those recorders stamp metadata.site_id — the query (GH #201)
+	// matches on whichever of the two shapes the row has (plus the
+	// backup_schedule special case: target_id=site_id, no metadata.site_id).
+	// See ListAuditEntriesFiltered in audit_log.sql for the full predicate.
 	SiteID *uuid.UUID
 }
 

--- a/apps/api/internal/db/sqlc/audit_log.sql.go
+++ b/apps/api/internal/db/sqlc/audit_log.sql.go
@@ -222,7 +222,12 @@ LEFT JOIN api_keys ak
                      THEN al.actor_id::uuid END
 WHERE al.tenant_id = $1
   AND ($2 = '' OR al.action LIKE $2 || '%')
-  AND ($3::text = '00000000-0000-0000-0000-000000000000' OR (al.target_type = 'site' AND al.target_id = $3::text))
+  AND (
+    $3::text = '00000000-0000-0000-0000-000000000000'
+    OR (al.target_type = 'site' AND al.target_id = $3::text)
+    OR (al.metadata->>'site_id' = $3::text)
+    OR (al.target_type = 'backup_schedule' AND al.target_id = $3::text)
+  )
 ORDER BY al.created_at DESC, al.id DESC
 LIMIT  $5
 OFFSET $4
@@ -253,14 +258,31 @@ type ListAuditEntriesFilteredRow struct {
 	ActorEmail    *string   `json:"actor_email"`
 }
 
-// Optional filters: action prefix (LIKE 'prefix%'), site_id (target_type='site'
-// AND target_id = site_id::text). Passing an empty string for action_prefix or
-// a zero UUID for site_id disables those filters respectively. RLS is still the
-// primary tenant-isolation gate; the explicit tenant_id is defense-in-depth.
+// Optional filters: action prefix (LIKE 'prefix%'), site_id. Passing an empty
+// string for action_prefix or a zero UUID for site_id disables those filters
+// respectively. RLS is still the primary tenant-isolation gate; the explicit
+// tenant_id is defense-in-depth.
 // Newest-first (see ListAuditEntries); actor_user_name/actor_key_name/
 // actor_email resolve the same way, including the CASE-guarded ::uuid cast
 // (see ListAuditEntries for the full join contract and why a plain regex-AND
 // guard is NOT safe here).
+//
+// The site_id filter (GH #201) matches THREE shapes, because target_id only
+// holds the site id for target_type='site' rows:
+//  1. target_type='site' AND target_id = site_id (site lifecycle events).
+//  2. metadata->>'site_id' = site_id (backup/restore/update lifecycle rows,
+//     whose target_id is a snapshot/run/task id, not the site — the
+//     recorders always stamp metadata.site_id for these).
+//  3. target_type='backup_schedule' AND target_id = site_id (the one
+//     recorder that carries the site id in target_id but never writes
+//     metadata.site_id — see backup.recordScheduleChange).
+//
+// metadata->>'site_id' is TEXT-to-TEXT on purpose: it must NEVER be cast to
+// ::uuid. metadata is free-form JSONB and a malformed/absent value must
+// degrade to NULL (never match) rather than throw 22P02 — the same class of
+// bug the CASE-guarded actor join above exists to avoid. ->>'site_id' already
+// returns NULL when the key is absent, so non-site rows are safely excluded
+// without any extra guard.
 func (q *Queries) ListAuditEntriesFiltered(ctx context.Context, arg ListAuditEntriesFilteredParams) ([]ListAuditEntriesFilteredRow, error) {
 	rows, err := q.db.Query(ctx, listAuditEntriesFiltered,
 		arg.TenantID,

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -1138,14 +1138,30 @@ type Querier interface {
 	// across a CASE/COALESCE spanning two different LEFT JOINs — see the LEFT
 	// JOIN LATERAL note in alerts.sql for the same class of limitation.
 	ListAuditEntries(ctx context.Context, arg ListAuditEntriesParams) ([]ListAuditEntriesRow, error)
-	// Optional filters: action prefix (LIKE 'prefix%'), site_id (target_type='site'
-	// AND target_id = site_id::text). Passing an empty string for action_prefix or
-	// a zero UUID for site_id disables those filters respectively. RLS is still the
-	// primary tenant-isolation gate; the explicit tenant_id is defense-in-depth.
+	// Optional filters: action prefix (LIKE 'prefix%'), site_id. Passing an empty
+	// string for action_prefix or a zero UUID for site_id disables those filters
+	// respectively. RLS is still the primary tenant-isolation gate; the explicit
+	// tenant_id is defense-in-depth.
 	// Newest-first (see ListAuditEntries); actor_user_name/actor_key_name/
 	// actor_email resolve the same way, including the CASE-guarded ::uuid cast
 	// (see ListAuditEntries for the full join contract and why a plain regex-AND
 	// guard is NOT safe here).
+	//
+	// The site_id filter (GH #201) matches THREE shapes, because target_id only
+	// holds the site id for target_type='site' rows:
+	//   1. target_type='site' AND target_id = site_id (site lifecycle events).
+	//   2. metadata->>'site_id' = site_id (backup/restore/update lifecycle rows,
+	//      whose target_id is a snapshot/run/task id, not the site — the
+	//      recorders always stamp metadata.site_id for these).
+	//   3. target_type='backup_schedule' AND target_id = site_id (the one
+	//      recorder that carries the site id in target_id but never writes
+	//      metadata.site_id — see backup.recordScheduleChange).
+	// metadata->>'site_id' is TEXT-to-TEXT on purpose: it must NEVER be cast to
+	// ::uuid. metadata is free-form JSONB and a malformed/absent value must
+	// degrade to NULL (never match) rather than throw 22P02 — the same class of
+	// bug the CASE-guarded actor join above exists to avoid. ->>'site_id' already
+	// returns NULL when the key is absent, so non-site rows are safely excluded
+	// without any extra guard.
 	ListAuditEntriesFiltered(ctx context.Context, arg ListAuditEntriesFilteredParams) ([]ListAuditEntriesFilteredRow, error)
 	ListAuditEntriesForVerify(ctx context.Context, tenantID uuid.UUID) ([]AuditLog, error)
 	// Same forward walk as ListAuditEntriesForVerify, but starting STRICTLY AFTER

--- a/apps/api/internal/perf/rum_fleet_verdict_test.go
+++ b/apps/api/internal/perf/rum_fleet_verdict_test.go
@@ -3,6 +3,7 @@ package perf
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,14 +21,27 @@ import (
 // ---------------------------------------------------------------------------
 
 // fleetSiteIDsStub is a minimal SiteLookup that returns a fixed site set,
-// ignoring the tenantID argument (fine for a single-tenant unit test).
-type fleetSiteIDsStub struct{ ids []uuid.UUID }
+// ignoring the tenantID argument (fine for a single-tenant unit test). meta,
+// when set, backs ListSitesMeta for the GH #202 offender-enrichment tests.
+// metaCalls, when non-nil, is incremented on every ListSitesMeta call so
+// tests can assert it is called exactly once per request (bulk, not N+1).
+type fleetSiteIDsStub struct {
+	ids       []uuid.UUID
+	meta      []SiteMeta
+	metaCalls *int
+}
 
 func (s *fleetSiteIDsStub) GetSiteURL(context.Context, uuid.UUID, uuid.UUID) (string, error) {
 	return "", nil
 }
 func (s *fleetSiteIDsStub) ListSiteIDs(context.Context, uuid.UUID) ([]uuid.UUID, error) {
 	return s.ids, nil
+}
+func (s *fleetSiteIDsStub) ListSitesMeta(context.Context, uuid.UUID) ([]SiteMeta, error) {
+	if s.metaCalls != nil {
+		*s.metaCalls++
+	}
+	return s.meta, nil
 }
 
 // fleetInt32Counts builds a NumBuckets int32 slice with a single bucket index
@@ -41,9 +55,10 @@ func fleetInt32Counts(idx int, count int32) []int32 {
 // newFleetRumHandler builds a Handler wired for rumFleet: ListAllSiteIDs
 // returns siteIDs (via fleetSiteIDsStub), and GetHourlyRollupsForSites always
 // returns the given rollups regardless of the requested tenant/site/window.
-func newFleetRumHandler(siteIDs []uuid.UUID, rollups []rum.HourlyRollup) *Handler {
+// meta, when given, backs ListSitesMeta for the GH #202 enrichment tests.
+func newFleetRumHandler(siteIDs []uuid.UUID, rollups []rum.HourlyRollup, meta ...SiteMeta) *Handler {
 	svc := NewService(&fakeRepo{}, nil, nil, nil)
-	svc.SetAgentClient(nil, &fleetSiteIDsStub{ids: siteIDs})
+	svc.SetAgentClient(nil, &fleetSiteIDsStub{ids: siteIDs, meta: meta})
 	reader := &RumResultsReader{
 		GetHourlyRollupsForSites: func(context.Context, uuid.UUID, []uuid.UUID, time.Time) ([]rum.HourlyRollup, error) {
 			return rollups, nil
@@ -202,5 +217,105 @@ func TestRumFleet_normalizeRatingHyphenation(t *testing.T) {
 	}
 	if off.OverallRating != "needs-improvement" {
 		t.Errorf("overall_rating = %q, want hyphenated %q", off.OverallRating, "needs-improvement")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GH #202 — worst_offenders rows must carry a display name+url, enriched
+// once (bulk) after sort+cap, never left blank by design nor fetched N+1.
+// ---------------------------------------------------------------------------
+
+// TestRumFleet_worstOffendersEnrichedWithNameURL verifies a resolvable site
+// gets its name/url populated on the offender row (previously hardcoded "").
+func TestRumFleet_worstOffendersEnrichedWithNameURL(t *testing.T) {
+	siteH := uuid.New()
+	// Bucket 17 lower bound (4500ms) is already > LCP's poor threshold (4000).
+	poorLCPCounts := fleetInt32Counts(17, 50)
+
+	rollups := []rum.HourlyRollup{
+		{RollupKey: rum.RollupKey{SiteID: siteH, Metric: "lcp"}, SampleCount: 50, BucketCounts: poorLCPCounts, MaxValue: 4900},
+	}
+	h := newFleetRumHandler([]uuid.UUID{siteH}, rollups, SiteMeta{ID: siteH, Name: "Acme Blog", URL: "https://acme.example"})
+	resp := callRumFleet(t, h)
+
+	off := findOffender(resp, siteH)
+	if off == nil {
+		t.Fatalf("expected site H in worst_offenders")
+	}
+	if off.Name != "Acme Blog" {
+		t.Errorf("Name = %q, want %q", off.Name, "Acme Blog")
+	}
+	if off.URL != "https://acme.example" {
+		t.Errorf("URL = %q, want %q", off.URL, "https://acme.example")
+	}
+}
+
+// TestRumFleet_worstOffendersUnresolvedMetaLeftBlank verifies a site absent
+// from the ListSitesMeta result (e.g. deleted between rollup write and the
+// fleet read) degrades to an empty name/url rather than erroring the request.
+func TestRumFleet_worstOffendersUnresolvedMetaLeftBlank(t *testing.T) {
+	siteI := uuid.New()
+	poorLCPCounts := fleetInt32Counts(17, 50)
+
+	rollups := []rum.HourlyRollup{
+		{RollupKey: rum.RollupKey{SiteID: siteI, Metric: "lcp"}, SampleCount: 50, BucketCounts: poorLCPCounts, MaxValue: 4900},
+	}
+	// No SiteMeta entries at all — ListSitesMeta returns an empty slice.
+	h := newFleetRumHandler([]uuid.UUID{siteI}, rollups)
+	resp := callRumFleet(t, h)
+
+	off := findOffender(resp, siteI)
+	if off == nil {
+		t.Fatalf("expected site I in worst_offenders")
+	}
+	if off.Name != "" || off.URL != "" {
+		t.Errorf("expected empty name/url for unresolved site, got name=%q url=%q", off.Name, off.URL)
+	}
+}
+
+// TestRumFleet_worstOffendersEnrichmentIsSingleBulkCall is GH #202's
+// no-N+1 requirement: even with more offending sites than fit in the
+// worst_offenders cap (10), ListSitesMeta must be called exactly ONCE per
+// request — enrichment happens after sort+cap, as one bulk lookup, never
+// once per offender and never once per reporting site.
+func TestRumFleet_worstOffendersEnrichmentIsSingleBulkCall(t *testing.T) {
+	const nSites = 15 // > the 10-row worst_offenders cap
+	siteIDs := make([]uuid.UUID, nSites)
+	var rollups []rum.HourlyRollup
+	meta := make([]SiteMeta, nSites)
+	poorLCPCounts := fleetInt32Counts(17, 50)
+	for i := 0; i < nSites; i++ {
+		id := uuid.New()
+		siteIDs[i] = id
+		rollups = append(rollups, rum.HourlyRollup{
+			RollupKey:    rum.RollupKey{SiteID: id, Metric: "lcp"},
+			SampleCount:  50,
+			BucketCounts: poorLCPCounts,
+			MaxValue:     4900,
+		})
+		meta[i] = SiteMeta{ID: id, Name: fmt.Sprintf("site-%d", i), URL: fmt.Sprintf("https://s%d.example", i)}
+	}
+
+	svc := NewService(&fakeRepo{}, nil, nil, nil)
+	calls := 0
+	svc.SetAgentClient(nil, &fleetSiteIDsStub{ids: siteIDs, meta: meta, metaCalls: &calls})
+	reader := &RumResultsReader{
+		GetHourlyRollupsForSites: func(context.Context, uuid.UUID, []uuid.UUID, time.Time) ([]rum.HourlyRollup, error) {
+			return rollups, nil
+		},
+	}
+	h := &Handler{svc: svc, rum: reader}
+	resp := callRumFleet(t, h)
+
+	if len(resp.WorstOffenders) != 10 {
+		t.Fatalf("expected worst_offenders capped to 10, got %d", len(resp.WorstOffenders))
+	}
+	for _, off := range resp.WorstOffenders {
+		if off.Name == "" || off.URL == "" {
+			t.Errorf("offender %s missing enrichment: name=%q url=%q", off.SiteID, off.Name, off.URL)
+		}
+	}
+	if calls != 1 {
+		t.Errorf("ListSitesMeta called %d times, want exactly 1 (bulk lookup, not N+1)", calls)
 	}
 }

--- a/apps/api/internal/perf/rum_results_handler.go
+++ b/apps/api/internal/perf/rum_results_handler.go
@@ -815,7 +815,7 @@ func (h *Handler) rumFleet(c *gin.Context) {
 		}
 		worstOffenders = append(worstOffenders, fleetRumWorstOffender{
 			SiteID:        siteID,
-			Name:          "", // name/url not available without N+1 lookup; frontend tolerates empty
+			Name:          "", // enriched below, after sort+cap (GH #202); left empty here by design
 			URL:           "",
 			LCPP75:        sv.lcpP75,
 			INPP75:        sv.inpP75,
@@ -842,6 +842,26 @@ func (h *Handler) rumFleet(c *gin.Context) {
 	})
 	if len(worstOffenders) > 10 {
 		worstOffenders = worstOffenders[:10]
+	}
+
+	// Enrich the (already-capped, <=10) offenders with a display name/url
+	// (GH #202). Deliberately done AFTER sort+cap so this never scales with
+	// the number of reporting sites — one bulk lookup, not an N+1 per site.
+	if len(worstOffenders) > 0 {
+		if metas, merr := h.svc.ListSitesMeta(c.Request.Context(), p.TenantID); merr == nil {
+			metaByID := make(map[uuid.UUID]SiteMeta, len(metas))
+			for _, m := range metas {
+				metaByID[m.ID] = m
+			}
+			for i := range worstOffenders {
+				if m, ok := metaByID[worstOffenders[i].SiteID]; ok {
+					worstOffenders[i].Name = m.Name
+					worstOffenders[i].URL = m.URL
+				}
+			}
+		}
+		// A lookup error is non-fatal: the offender rows still carry their
+		// site_id and CWV data; the frontend tolerates an empty name/url.
 	}
 
 	// Build trend: one point per day with lcp_p75/inp_p75/cls_p75.

--- a/apps/api/internal/perf/service.go
+++ b/apps/api/internal/perf/service.go
@@ -59,6 +59,19 @@ type SiteLookup interface {
 	// ListSiteIDs returns all site IDs for the tenant. Used by the fleet RUM
 	// aggregate endpoint to compute sites_total.
 	ListSiteIDs(ctx context.Context, tenantID uuid.UUID) ([]uuid.UUID, error)
+	// ListSitesMeta returns the name+url for every site in the tenant in a
+	// single bulk call (GH #202). Used to enrich the fleet RUM worst-offenders
+	// list, which only carries site IDs from the rollup aggregation, without
+	// an N+1 GetSiteURL round-trip per offender.
+	ListSitesMeta(ctx context.Context, tenantID uuid.UUID) ([]SiteMeta, error)
+}
+
+// SiteMeta is the minimal display info (name + url) for a site, returned in
+// bulk by SiteLookup.ListSitesMeta.
+type SiteMeta struct {
+	ID   uuid.UUID
+	Name string
+	URL  string
 }
 
 // EventPublisher publishes perf SSE envelopes on the shared tenant bus.
@@ -1480,6 +1493,14 @@ const fleetTopN = 10
 // handler to build the full candidate set and compute sites_total.
 func (s *Service) ListAllSiteIDs(ctx context.Context, tenantID uuid.UUID) ([]uuid.UUID, error) {
 	return s.sites.ListSiteIDs(ctx, tenantID)
+}
+
+// ListSitesMeta returns the name+url for every site in the tenant in one bulk
+// call (GH #202). Used by the fleet RUM handler to enrich the worst-offenders
+// list (capped to <=10 rows) with a display name/url after sort+cap, so the
+// lookup never scales with the tenant's total reporting site count.
+func (s *Service) ListSitesMeta(ctx context.Context, tenantID uuid.UUID) ([]SiteMeta, error) {
+	return s.sites.ListSitesMeta(ctx, tenantID)
 }
 
 func (s *Service) GetFleetDbHealth(ctx context.Context, tenantID uuid.UUID, days int) (FleetDbHealth, error) {

--- a/apps/api/internal/perf/service_test.go
+++ b/apps/api/internal/perf/service_test.go
@@ -348,6 +348,9 @@ func (s *fakeSites) GetSiteURL(context.Context, uuid.UUID, uuid.UUID) (string, e
 func (s *fakeSites) ListSiteIDs(_ context.Context, _ uuid.UUID) ([]uuid.UUID, error) {
 	return nil, nil
 }
+func (s *fakeSites) ListSitesMeta(_ context.Context, _ uuid.UUID) ([]SiteMeta, error) {
+	return nil, nil
+}
 
 // ---------------------------------------------------------------------------
 // config validation

--- a/apps/api/tests/audit_site_filter_test.go
+++ b/apps/api/tests/audit_site_filter_test.go
@@ -1,0 +1,263 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// TestAuditFilterBySiteID_MatchesMetadataSiteID is GH #201: backup/restore/
+// update lifecycle audit rows target a snapshot/run/task id (target_type !=
+// "site"), so the pre-fix site_id filter (which only matched
+// target_type='site' AND target_id=site_id) returned ZERO rows for them even
+// though the recorder always stamps metadata.site_id. Confirms the broadened
+// predicate now matches on metadata.site_id for a non-site target_type.
+func TestAuditFilterBySiteID_MatchesMetadataSiteID(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+
+	tenant := seedTenant(t, pool, "audit-site-filter-meta")
+	siteID := uuid.New()
+	snapshotID := uuid.New()
+
+	entry, err := rec.Record(ctx, audit.Event{
+		TenantID:   tenant,
+		ActorType:  audit.ActorSystem,
+		ActorID:    "",
+		Action:     "backup.snapshot.completed",
+		TargetType: "backup_snapshot",
+		TargetID:   snapshotID.String(),
+		Metadata:   map[string]any{"site_id": siteID.String(), "kind": "full"},
+	})
+	if err != nil {
+		t.Fatalf("record backup snapshot event: %v", err)
+	}
+
+	// A different site's event must NOT be returned.
+	other, err := rec.Record(ctx, audit.Event{
+		TenantID:   tenant,
+		ActorType:  audit.ActorSystem,
+		ActorID:    "",
+		Action:     "backup.snapshot.completed",
+		TargetType: "backup_snapshot",
+		TargetID:   uuid.New().String(),
+		Metadata:   map[string]any{"site_id": uuid.New().String(), "kind": "full"},
+	})
+	if err != nil {
+		t.Fatalf("record other-site backup snapshot event: %v", err)
+	}
+
+	got, err := rec.ListFiltered(ctx, tenant, audit.Filter{SiteID: &siteID}, 100, 0)
+	if err != nil {
+		t.Fatalf("ListFiltered by site_id errored: %v", err)
+	}
+
+	byID := make(map[uuid.UUID]audit.Entry, len(got))
+	for _, e := range got {
+		byID[e.ID] = e
+	}
+	if _, ok := byID[entry.ID]; !ok {
+		t.Errorf("expected backup_snapshot row (metadata.site_id match) in filtered results, got %d rows", len(got))
+	}
+	if _, ok := byID[other.ID]; ok {
+		t.Errorf("other site's backup_snapshot row must not be returned when filtering by a different site_id")
+	}
+}
+
+// TestAuditFilterBySiteID_MatchesBackupScheduleTargetID is GH #201's third
+// predicate shape: backup.schedule.changed rows carry the site id in
+// target_id (target_type="backup_schedule") but never write metadata.site_id
+// (see backup.Handler.recordScheduleChange) — they must still be matched.
+func TestAuditFilterBySiteID_MatchesBackupScheduleTargetID(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+
+	tenant := seedTenant(t, pool, "audit-site-filter-sched")
+	siteID := uuid.New()
+
+	entry, err := rec.Record(ctx, audit.Event{
+		TenantID:   tenant,
+		ActorType:  audit.ActorUser,
+		ActorID:    uuid.New().String(),
+		Action:     "backup.schedule.changed",
+		TargetType: "backup_schedule",
+		TargetID:   siteID.String(),
+		Metadata:   map[string]any{"cadence": "daily", "kind": "full", "enabled": true},
+	})
+	if err != nil {
+		t.Fatalf("record backup_schedule event: %v", err)
+	}
+
+	got, err := rec.ListFiltered(ctx, tenant, audit.Filter{SiteID: &siteID}, 100, 0)
+	if err != nil {
+		t.Fatalf("ListFiltered by site_id errored: %v", err)
+	}
+	found := false
+	for _, e := range got {
+		if e.ID == entry.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected backup_schedule row (target_id match, no metadata.site_id) in filtered results, got %d rows", len(got))
+	}
+}
+
+// TestAuditFilterBySiteID_MalformedOrAbsentMetadataSiteIDExcludedNoError
+// proves the metadata.site_id predicate is TEXT-to-TEXT and never throws: a
+// row whose metadata.site_id is malformed (not a valid UUID) or entirely
+// absent must be silently excluded from a site_id-filtered query, never a
+// 22P02 "invalid input syntax for type uuid" error — the same failure class
+// the CASE-guarded actor-id join exists to avoid (see audit_actor_join_test.go).
+func TestAuditFilterBySiteID_MalformedOrAbsentMetadataSiteIDExcludedNoError(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+
+	tenant := seedTenant(t, pool, "audit-site-filter-malformed")
+	siteID := uuid.New()
+
+	malformed, err := rec.Record(ctx, audit.Event{
+		TenantID:   tenant,
+		ActorType:  audit.ActorSystem,
+		ActorID:    "",
+		Action:     "update.task.failed",
+		TargetType: "update_task",
+		TargetID:   uuid.New().String(),
+		Metadata:   map[string]any{"site_id": "not-a-uuid"},
+	})
+	if err != nil {
+		t.Fatalf("record malformed-metadata event: %v", err)
+	}
+
+	absent, err := rec.Record(ctx, audit.Event{
+		TenantID:   tenant,
+		ActorType:  audit.ActorSystem,
+		ActorID:    "",
+		Action:     "update.run.created",
+		TargetType: "update_run",
+		TargetID:   uuid.New().String(),
+		Metadata:   map[string]any{"reason": "scheduled"}, // no site_id key at all
+	})
+	if err != nil {
+		t.Fatalf("record no-site-id-metadata event: %v", err)
+	}
+
+	got, err := rec.ListFiltered(ctx, tenant, audit.Filter{SiteID: &siteID}, 100, 0)
+	if err != nil {
+		t.Fatalf("ListFiltered must not error on malformed/absent metadata.site_id, got: %v", err)
+	}
+	for _, e := range got {
+		if e.ID == malformed.ID {
+			t.Errorf("malformed metadata.site_id row must not match an unrelated site_id filter")
+		}
+		if e.ID == absent.ID {
+			t.Errorf("row with no metadata.site_id key must not match a site_id filter")
+		}
+	}
+
+	// The unfiltered list must still surface both rows untouched — the fix
+	// only changes the filtered predicate, never the stored data.
+	all, err := rec.List(ctx, tenant, 100, 0)
+	if err != nil {
+		t.Fatalf("List errored: %v", err)
+	}
+	allByID := make(map[uuid.UUID]audit.Entry, len(all))
+	for _, e := range all {
+		allByID[e.ID] = e
+	}
+	if _, ok := allByID[malformed.ID]; !ok {
+		t.Errorf("malformed-metadata row missing from unfiltered List")
+	}
+	if _, ok := allByID[absent.ID]; !ok {
+		t.Errorf("absent-metadata row missing from unfiltered List")
+	}
+}
+
+// TestAuditFilterBySiteID_TenantIsolationHolds confirms the broadened site_id
+// predicate never weakens tenant isolation: two tenants each record a
+// backup-lifecycle row whose metadata.site_id happens to be the SAME value
+// (a plausible UUID collision is astronomically unlikely, but nothing in the
+// new OR-branches should ever let it cross tenants regardless — al.tenant_id
+// = @tenant_id gates the whole predicate, and RLS is the independent
+// second gate).
+func TestAuditFilterBySiteID_TenantIsolationHolds(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+
+	tenantA := seedTenant(t, pool, "audit-site-filter-tenant-a")
+	tenantB := seedTenant(t, pool, "audit-site-filter-tenant-b")
+	sharedSiteID := uuid.New() // simulated collision: same site_id value in both tenants' metadata
+
+	entryA, err := rec.Record(ctx, audit.Event{
+		TenantID:   tenantA,
+		ActorType:  audit.ActorSystem,
+		ActorID:    "",
+		Action:     "backup.snapshot.completed",
+		TargetType: "backup_snapshot",
+		TargetID:   uuid.New().String(),
+		Metadata:   map[string]any{"site_id": sharedSiteID.String()},
+	})
+	if err != nil {
+		t.Fatalf("record tenant A event: %v", err)
+	}
+	entryB, err := rec.Record(ctx, audit.Event{
+		TenantID:   tenantB,
+		ActorType:  audit.ActorSystem,
+		ActorID:    "",
+		Action:     "backup.snapshot.completed",
+		TargetType: "backup_snapshot",
+		TargetID:   uuid.New().String(),
+		Metadata:   map[string]any{"site_id": sharedSiteID.String()},
+	})
+	if err != nil {
+		t.Fatalf("record tenant B event: %v", err)
+	}
+
+	gotA, err := rec.ListFiltered(ctx, tenantA, audit.Filter{SiteID: &sharedSiteID}, 100, 0)
+	if err != nil {
+		t.Fatalf("ListFiltered (tenant A) errored: %v", err)
+	}
+	foundA, foundBInA := false, false
+	for _, e := range gotA {
+		if e.ID == entryA.ID {
+			foundA = true
+		}
+		if e.ID == entryB.ID {
+			foundBInA = true
+		}
+	}
+	if !foundA {
+		t.Errorf("tenant A's own matching row must be returned")
+	}
+	if foundBInA {
+		t.Fatalf("SECURITY: tenant B's row leaked into tenant A's site_id-filtered results")
+	}
+
+	gotB, err := rec.ListFiltered(ctx, tenantB, audit.Filter{SiteID: &sharedSiteID}, 100, 0)
+	if err != nil {
+		t.Fatalf("ListFiltered (tenant B) errored: %v", err)
+	}
+	foundB, foundAInB := false, false
+	for _, e := range gotB {
+		if e.ID == entryB.ID {
+			foundB = true
+		}
+		if e.ID == entryA.ID {
+			foundAInB = true
+		}
+	}
+	if !foundB {
+		t.Errorf("tenant B's own matching row must be returned")
+	}
+	if foundAInB {
+		t.Fatalf("SECURITY: tenant A's row leaked into tenant B's site_id-filtered results")
+	}
+}

--- a/apps/web/src/features/audit/audit-row.test.tsx
+++ b/apps/web/src/features/audit/audit-row.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import type { AuditEntry } from "@wpmgr/api";
+
+import { renderWithProviders } from "@/test/render";
+
+import { AuditEntryRow } from "./audit-row";
+import type { SiteMin } from "./types";
+
+// GH #201 — fleet Audit log: backup/restore/update entries are site-scoped
+// but carry a target_type other than "site" ("backup_snapshot",
+// "update_task", "backup_schedule", ...). The old TargetSlot only resolved +
+// rendered a site name when target_type === "site", so every one of these
+// rows showed the raw wire target_type string ("backup_snapshot",
+// "update_task") instead of which site the backup/restore/update actually
+// happened on. This pins the fix: for a non-"site" target_type, the row now
+// derives a candidate site id from `metadata.site_id` (or, for
+// "backup_schedule" specifically, `target_id` — the schedule row's id IS the
+// site id, see backup/handler.go's recordScheduleChange) and resolves it
+// against the known sites list, falling back to the original raw display
+// when nothing resolves.
+
+const SITE_ID = "11111111-1111-1111-1111-111111111111";
+const OTHER_SITE_ID = "22222222-2222-2222-2222-222222222222";
+const UNKNOWN_SITE_ID = "99999999-9999-9999-9999-999999999999";
+
+const SITES: SiteMin[] = [
+  { id: SITE_ID, name: "Acme Blog", url: "https://acme.example" },
+  { id: OTHER_SITE_ID, name: "Other Site", url: "https://other.example" },
+];
+
+let seq = 0;
+function entry(overrides: Partial<AuditEntry> = {}): AuditEntry {
+  seq += 1;
+  return {
+    id: overrides.id ?? `entry-${seq}`,
+    tenant_id: "tenant-1",
+    actor_type: "user",
+    actor_id: "user-1",
+    action: "backup.started",
+    target_type: "backup_snapshot",
+    target_id: `snap-${seq}`,
+    prev_hash: "prev",
+    hash: "hash",
+    created_at: "2026-07-08T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("AuditEntryRow target site resolution (GH #201)", () => {
+  it("resolves a backup_snapshot entry's site name from metadata.site_id, not the raw target_type", () => {
+    const e = entry({
+      target_type: "backup_snapshot",
+      target_id: "snap-1",
+      metadata: { site_id: SITE_ID, full: true },
+    });
+
+    renderWithProviders(<AuditEntryRow entry={e} sites={SITES} isToday={false} />);
+
+    // The resolved site name is shown...
+    expect(screen.getByText("Acme Blog")).toBeInTheDocument();
+    // ...and the raw target_type string is never rendered as the target
+    // label. This is the non-vacuous half of the assertion: the pre-fix
+    // TargetSlot renders exactly "backup_snapshot" here, so this line fails
+    // against the old target_type-only code and passes only with the fix.
+    expect(screen.queryByText("backup_snapshot")).not.toBeInTheDocument();
+  });
+
+  it("resolves a backup_schedule entry's site via target_id (the schedule id IS the site id; no metadata.site_id present)", () => {
+    const e = entry({
+      action: "backup.schedule.changed",
+      target_type: "backup_schedule",
+      target_id: OTHER_SITE_ID,
+      metadata: { cadence: "daily", kind: "full", enabled: true },
+    });
+
+    renderWithProviders(<AuditEntryRow entry={e} sites={SITES} isToday={false} />);
+
+    expect(screen.getByText("Other Site")).toBeInTheDocument();
+    expect(screen.queryByText("backup_schedule")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the raw target_type when metadata.site_id matches no known site, without crashing", () => {
+    const e = entry({
+      target_type: "backup_snapshot",
+      target_id: "snap-2",
+      metadata: { site_id: UNKNOWN_SITE_ID },
+    });
+
+    expect(() =>
+      renderWithProviders(<AuditEntryRow entry={e} sites={SITES} isToday={false} />),
+    ).not.toThrow();
+
+    expect(screen.getByText("backup_snapshot")).toBeInTheDocument();
+  });
+
+  it("falls back to the raw target_type when the entry carries no site id at all (e.g. update.run.created)", () => {
+    const e = entry({
+      action: "update.run.created",
+      target_type: "update_run",
+      target_id: "run-1",
+      metadata: { dry_run: false, task_count: 3 },
+    });
+
+    expect(() =>
+      renderWithProviders(<AuditEntryRow entry={e} sites={SITES} isToday={false} />),
+    ).not.toThrow();
+
+    expect(screen.getByText("update_run")).toBeInTheDocument();
+  });
+
+  it("still resolves a plain target_type: \"site\" entry unchanged", () => {
+    const e = entry({
+      action: "site.cache.purged",
+      target_type: "site",
+      target_id: SITE_ID,
+      metadata: {},
+    });
+
+    renderWithProviders(<AuditEntryRow entry={e} sites={SITES} isToday={false} />);
+
+    expect(screen.getByText("Acme Blog")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/audit/audit-row.tsx
+++ b/apps/web/src/features/audit/audit-row.tsx
@@ -9,7 +9,13 @@ import { AuditEntryDetail, RunDetail } from "./audit-detail";
 import type { AuditRun } from "./group-runs";
 import { runSummaryLabel } from "./group-runs";
 import { actionLabel, classifySeverity, type AuditSeverity } from "./labels";
-import { commonPathPrefix, formatClockTime, formatDateTime, metaString } from "./metadata";
+import {
+  commonPathPrefix,
+  formatClockTime,
+  formatDateTime,
+  humanizeTargetType,
+  metaString,
+} from "./metadata";
 import type { SiteMin } from "./types";
 
 // One row of the fleet audit log (redesign points 1, 3, 4, 5, 7, 10).
@@ -71,11 +77,33 @@ function EntryTime({ iso, isToday }: { iso: string; isToday: boolean }) {
   );
 }
 
+/**
+ * Best-effort site id for a non-"site" target_type, so a backup/restore/
+ * update row (target_type "backup_snapshot", "update_task", ...) can still
+ * resolve and show the site it happened on instead of just the raw target
+ * type (GH #201). The control plane attaches `metadata.site_id` to every
+ * site-scoped lifecycle event that isn't itself target_type "site"; the one
+ * exception is "backup_schedule", whose events don't carry metadata.site_id
+ * because the schedule row's own id IS the site id (backup/handler.go's
+ * recordScheduleChange sets TargetID to sched.SiteID). Entries with neither
+ * (e.g. update_run, which is scoped to a run, not a single site) return null
+ * and fall through to the existing raw target_type display.
+ */
+function targetSiteId(entry: AuditEntry): string | null {
+  if (entry.target_type === "site") return entry.target_id;
+  const metaSiteId = metaString(entry.metadata, "site_id");
+  if (metaSiteId) return metaSiteId;
+  if (entry.target_type === "backup_schedule") return entry.target_id;
+  return null;
+}
+
 function TargetSlot({ entry, sites }: { entry: AuditEntry; sites: SiteMin[] }) {
   const path = metaString(entry.metadata, "path");
+  const isSiteTarget = entry.target_type === "site";
+  const siteId = targetSiteId(entry);
+  const site = siteId ? sites.find((s) => s.id === siteId) : undefined;
 
-  if (entry.target_type === "site") {
-    const site = sites.find((s) => s.id === entry.target_id);
+  if (isSiteTarget) {
     return (
       <div className="flex min-w-0 flex-col gap-0.5">
         <span
@@ -94,6 +122,26 @@ function TargetSlot({ entry, sites }: { entry: AuditEntry; sites: SiteMin[] }) {
             {path}
           </span>
         ) : null}
+      </div>
+    );
+  }
+
+  // Site-scoped non-"site" target (backup/restore/update, ...): show the
+  // resolved site name as the primary label, and keep the target-type
+  // context (e.g. "Backup snapshot") as a secondary line rather than
+  // silently dropping the fact that this was a backup/update on that site.
+  if (site) {
+    return (
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="inline-flex w-fit max-w-full items-center truncate rounded bg-muted px-1.5 py-0.5 text-xs font-medium text-foreground">
+          {site.name || site.url}
+        </span>
+        <span
+          className="truncate text-[11px] text-muted-foreground"
+          title={`${humanizeTargetType(entry.target_type)} · ${entry.target_id}`}
+        >
+          {humanizeTargetType(entry.target_type)}
+        </span>
       </div>
     );
   }


### PR DESCRIPTION
#202: enrich the top-10 fleet CWV worst-offenders with a single site lookup so Name/URL populate (was blank; pre-existing). #201: broaden the audit site filter to match metadata.site_id + backup_schedule target (text-to-text, no ::uuid cast, tenant-gated) + client-side site-name resolution for backup/restore/update rows. Read/display only, chain untouched, no migration. Security review SHIP. Go + 949 web tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit log rows can now show the correct site name and URL for more event types, including backup/restore/update-related entries.
  * Fleet performance “worst offenders” entries now display site names and URLs when available.

* **Bug Fixes**
  * Fixed site filtering in audit logs so matching entries are found more reliably across different event formats.
  * Improved fallback behavior when site details can’t be resolved, avoiding broken or blank displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->