### PR TITLE
feat(billing): sign up into a paid plan from marketing + live pricing (hosted)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,16 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
-## [0.61.52] - 2026-07-09
+## [0.61.53] - 2026-07-10
+
+### Added
+
+- Sign up directly into a paid plan from the marketing site. Choosing Starter, Agency, or Scale on the pricing page now carries that choice through signup and email verification (persisted server-side, so it survives even if you open the verification email on a different device) and lands you on a "Complete your subscription" screen that opens checkout for the plan you picked, with a "Skip for now" option that keeps the free account. Previously every plan button led to the same generic signup and left you on the free plan to find billing yourself. Hosted only; self-host is unaffected.
+- Live pricing on the marketing pricing page. Prices are now fetched from the payment providers (Razorpay and Stripe) at build time rather than hardcoded, with a USD/INR currency toggle, so the amounts shown always match what is actually charged. A new public, cached pricing endpoint serves these amounts (no secrets, hosted only), and the page falls back to its built-in prices if the endpoint is unreachable so a fetch hiccup never breaks the site.
+
+### Fixed
+
+- The Stripe checkout return link pointed at `/billing` instead of `/settings/billing`, which showed a not-found page on return from Stripe; it now forwards correctly so the "finalizing your subscription" confirmation appears as expected.
 
 ### Fixed
 

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -67,6 +67,7 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/org"
 	"github.com/mosamlife/wpmgr/apps/api/internal/perf"
 	portalpkg "github.com/mosamlife/wpmgr/apps/api/internal/portal"
+	"github.com/mosamlife/wpmgr/apps/api/internal/pricing"
 	reportpkg "github.com/mosamlife/wpmgr/apps/api/internal/report"
 	reporthtml "github.com/mosamlife/wpmgr/apps/api/internal/report/render/html"
 	reportpdf "github.com/mosamlife/wpmgr/apps/api/internal/report/render/pdf"
@@ -502,8 +503,13 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	if len(billingProviders) == 0 && cfg.Hosted.Enabled {
 		logger.Warn("billing: hosted billing is enabled but no payment provider is configured — checkout/portal will return 503")
 	}
-	billingSvc.SetProviders(billing.NewRegistry(billingProviders...), "stripe")
+	billingRegistry := billing.NewRegistry(billingProviders...)
+	billingSvc.SetProviders(billingRegistry, "stripe")
 	billingSvc.SetAudit(auditRec)
+	// M16 Phase 0 — "sign up into a plan": billingSvc.ValidPaidTier no-ops to
+	// false when WPMGR_HOSTED is off, so this wiring is safe to leave on
+	// unconditionally, exactly like SetBillingGate above.
+	authSvc.SetPlanValidator(billingSvc)
 
 	// The billing HTTP handlers are always CONSTRUCTED (cheap, stateless) but
 	// only MOUNTED when hosted billing is enabled (see the server.Deps wiring
@@ -520,11 +526,22 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	billingWebhookH := billing.NewWebhookHandler(billingSvc, logger)
 	billingReconcileWorker := billing.NewReconcileWorker(billingSvc, logger)
 
+	// M16 live-pricing Phase 1 — public GET /api/v1/pricing (internal/pricing),
+	// the marketing site's price source. Reuses the SAME billingRegistry (so
+	// it sees exactly the providers billingSvc itself would use) and the
+	// SAME session Redis pool as the entitlements cache (a distinct
+	// "pricing:" key prefix keeps them from colliding). Always CONSTRUCTED
+	// (cheap, stateless) but only MOUNTED when hosted billing is enabled —
+	// same nil/non-nil split as billingH/billingWebhookH below.
+	pricingSvc := pricing.NewService(billingRegistry, redisPool, logger)
+	pricingH := pricing.NewHandler(pricingSvc)
+
 	// Both handlers are mounted ONLY when hosted billing is enabled — this
 	// nil/non-nil split is the routes-contract 404-when-unhosted guarantee
-	// (see server.Deps.BillingH/BillingWebhookH's doc comments).
+	// (see server.Deps.BillingH/BillingWebhookH/PricingH's doc comments).
 	var billingHForRoutes *billing.Handler
 	var billingWebhookHForRoutes *billing.WebhookHandler
+	var pricingHForRoutes *pricing.Handler
 	// M16 Phase C1 — the superadmin hard-lockout enforcement middleware
 	// (tenants.suspended_at, m92). Same nil/non-nil split: self-host
 	// (unhosted) never even constructs the closure, matching every other
@@ -535,6 +552,7 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 		billingHForRoutes = billingH
 		billingWebhookHForRoutes = billingWebhookH
 		billingSuspensionGateForRoutes = billingSvc.SuspensionGate()
+		pricingHForRoutes = pricingH
 	}
 
 	authn := middleware.NewAuthenticator(sessions, authSvc, apiKeySvc, pool)
@@ -2186,8 +2204,12 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 		BillingH:              billingHForRoutes,
 		BillingWebhookH:       billingWebhookHForRoutes,
 		BillingSuspensionGate: billingSuspensionGateForRoutes,
-		ServiceName:           cfg.OTel.ServiceName,
-		Version:               version,
+		// M16 live-pricing Phase 1 — public GET /api/v1/pricing. nil unless
+		// WPMGR_HOSTED is enabled (same 404-when-unhosted guarantee as the
+		// billing routes immediately above).
+		PricingH:    pricingHForRoutes,
+		ServiceName: cfg.OTel.ServiceName,
+		Version:     version,
 	})
 
 	return srv.Run(ctx)

--- a/apps/api/db/query/email_verification_tokens.sql
+++ b/apps/api/db/query/email_verification_tokens.sql
@@ -1,11 +1,13 @@
 -- name: InsertEmailVerificationToken :one
--- Run under Pool.InAgentTx (app.agent='on').
-INSERT INTO email_verification_tokens (user_id, token_hash, expires_at)
-VALUES (@user_id, @token_hash, @expires_at)
+-- Run under Pool.InAgentTx (app.agent='on'). desired_plan is a nullable M16
+-- "sign up into a plan" hint (Phase 0); pass nil for an ordinary signup.
+INSERT INTO email_verification_tokens (user_id, token_hash, expires_at, desired_plan)
+VALUES (@user_id, @token_hash, @expires_at, @desired_plan)
 RETURNING *;
 
 -- name: ConsumeEmailVerificationToken :one
--- Atomically consume an unused, unexpired verification token.
+-- Atomically consume an unused, unexpired verification token. The returned
+-- row's desired_plan (if any) is single-use: it is gone with the token.
 UPDATE email_verification_tokens
 SET used_at = now()
 WHERE token_hash = @token_hash
@@ -17,6 +19,16 @@ RETURNING *;
 UPDATE email_verification_tokens
 SET used_at = now()
 WHERE user_id = @user_id AND used_at IS NULL;
+
+-- name: GetLatestDesiredPlanForUser :one
+-- Looks up the most recent desired_plan captured across a user's
+-- verification tokens (active or already consumed/invalidated), so a resent
+-- verification link can carry the SAME plan intent forward onto its new
+-- token instead of losing it when the prior token is invalidated.
+SELECT desired_plan FROM email_verification_tokens
+WHERE user_id = @user_id
+ORDER BY created_at DESC
+LIMIT 1;
 
 -- name: SetUserPending :exec
 UPDATE users SET status = 'pending', updated_at = now() WHERE id = $1;

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -1852,12 +1852,20 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS email_verified_at timestamptz;
 -- Same hashed/TTL/single-use model as password_reset_tokens but purpose=verify.
 -- Consumed under app.agent='on' (pre-tenant, unauthenticated activation).
 CREATE TABLE email_verification_tokens (
-    id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id     uuid        NOT NULL REFERENCES users (id) ON DELETE CASCADE,
-    token_hash  bytea       NOT NULL,
-    expires_at  timestamptz NOT NULL,
-    used_at     timestamptz,
-    created_at  timestamptz NOT NULL DEFAULT now()
+    id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id       uuid        NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    token_hash    bytea       NOT NULL,
+    expires_at    timestamptz NOT NULL,
+    used_at       timestamptz,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    -- m98 — "sign up into a plan" Phase 0. A hosted-billing paid-tier hint
+    -- captured at self-serve registration time (validated against
+    -- internal/billing's plan ladder — never a free-form value; NULL means no
+    -- intent). Carried here (not on users) so it is naturally scoped to THIS
+    -- registration and disappears with the single-use token once consumed by
+    -- VerifyEmail. A resend (ResendVerification) copies the prior value
+    -- forward onto the new token instead of losing it.
+    desired_plan  text
 );
 
 CREATE UNIQUE INDEX email_verification_tokens_token_hash_key ON email_verification_tokens (token_hash);

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -43454,9 +43454,15 @@ func (s *Me) encodeFields(e *jx.Encoder) {
 			s.ManagedStorageAllowed.Encode(e)
 		}
 	}
+	{
+		if s.DesiredPlan.Set {
+			e.FieldStart("desired_plan")
+			s.DesiredPlan.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfMe = [8]string{
+var jsonFieldsNameOfMe = [9]string{
 	0: "user",
 	1: "memberships",
 	2: "active_tenant_id",
@@ -43465,6 +43471,7 @@ var jsonFieldsNameOfMe = [8]string{
 	5: "portal",
 	6: "hosted",
 	7: "managed_storage_allowed",
+	8: "desired_plan",
 }
 
 // Decode decodes Me from json.
@@ -43472,7 +43479,7 @@ func (s *Me) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode Me to nil")
 	}
-	var requiredBitSet [1]uint8
+	var requiredBitSet [2]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
@@ -43564,6 +43571,16 @@ func (s *Me) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"managed_storage_allowed\"")
 			}
+		case "desired_plan":
+			if err := func() error {
+				s.DesiredPlan.Reset()
+				if err := s.DesiredPlan.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"desired_plan\"")
+			}
 		default:
 			return d.Skip()
 		}
@@ -43573,8 +43590,9 @@ func (s *Me) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [1]uint8{
+	for i, mask := range [2]uint8{
 		0b00000011,
+		0b00000000,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -43616,6 +43634,48 @@ func (s *Me) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *Me) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes MeDesiredPlan as json.
+func (s MeDesiredPlan) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes MeDesiredPlan from json.
+func (s *MeDesiredPlan) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode MeDesiredPlan to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch MeDesiredPlan(v) {
+	case MeDesiredPlanStarter:
+		*s = MeDesiredPlanStarter
+	case MeDesiredPlanAgency:
+		*s = MeDesiredPlanAgency
+	case MeDesiredPlanScale:
+		*s = MeDesiredPlanScale
+	default:
+		*s = MeDesiredPlan(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s MeDesiredPlan) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *MeDesiredPlan) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -51643,6 +51703,39 @@ func (s *OptInt64) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes MeDesiredPlan as json.
+func (o OptMeDesiredPlan) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	e.Str(string(o.Value))
+}
+
+// Decode decodes MeDesiredPlan from json.
+func (o *OptMeDesiredPlan) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptMeDesiredPlan to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptMeDesiredPlan) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptMeDesiredPlan) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes MePortal as json.
 func (o OptMePortal) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -53654,6 +53747,39 @@ func (s OptPutEmailConnectionRequestConfig) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptPutEmailConnectionRequestConfig) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes RegisterRequestPlan as json.
+func (o OptRegisterRequestPlan) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	e.Str(string(o.Value))
+}
+
+// Decode decodes RegisterRequestPlan from json.
+func (o *OptRegisterRequestPlan) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptRegisterRequestPlan to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptRegisterRequestPlan) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptRegisterRequestPlan) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -65339,14 +65465,21 @@ func (s *RegisterRequest) encodeFields(e *jx.Encoder) {
 			s.TenantSlug.Encode(e)
 		}
 	}
+	{
+		if s.Plan.Set {
+			e.FieldStart("plan")
+			s.Plan.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfRegisterRequest = [5]string{
+var jsonFieldsNameOfRegisterRequest = [6]string{
 	0: "email",
 	1: "password",
 	2: "name",
 	3: "tenant_name",
 	4: "tenant_slug",
+	5: "plan",
 }
 
 // Decode decodes RegisterRequest from json.
@@ -65412,6 +65545,16 @@ func (s *RegisterRequest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"tenant_slug\"")
 			}
+		case "plan":
+			if err := func() error {
+				s.Plan.Reset()
+				if err := s.Plan.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"plan\"")
+			}
 		default:
 			return d.Skip()
 		}
@@ -65464,6 +65607,48 @@ func (s *RegisterRequest) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *RegisterRequest) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes RegisterRequestPlan as json.
+func (s RegisterRequestPlan) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes RegisterRequestPlan from json.
+func (s *RegisterRequestPlan) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode RegisterRequestPlan to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch RegisterRequestPlan(v) {
+	case RegisterRequestPlanStarter:
+		*s = RegisterRequestPlanStarter
+	case RegisterRequestPlanAgency:
+		*s = RegisterRequestPlanAgency
+	case RegisterRequestPlanScale:
+		*s = RegisterRequestPlanScale
+	default:
+		*s = RegisterRequestPlan(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s RegisterRequestPlan) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *RegisterRequestPlan) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -15594,6 +15594,13 @@ type Me struct {
 	// enforce the real check server-side and return 402 byo_destination_required when denied.
 	// Restoring/downloading an existing backup is never gated by this or any other check.
 	ManagedStorageAllowed OptBool `json:"managed_storage_allowed"`
+	// The M16 Phase 0 "sign up into a plan" hint captured at registration (RegisterRequest.plan),
+	// single-use: present ONLY in the direct response to POST /auth/verify-email (read off the
+	// just-consumed verification token) or the first-run bootstrap response of POST /auth/register —
+	// never on GET /auth/me or any other Me-returning response. The frontend uses this to auto-start
+	// checkout right after the account is verified. Absent means no intent was captured (free signup,
+	// self-hosted instance, or a resend/login/OIDC path that never carries one).
+	DesiredPlan OptMeDesiredPlan `json:"desired_plan"`
 }
 
 // GetUser returns the value of User.
@@ -15636,6 +15643,11 @@ func (s *Me) GetManagedStorageAllowed() OptBool {
 	return s.ManagedStorageAllowed
 }
 
+// GetDesiredPlan returns the value of DesiredPlan.
+func (s *Me) GetDesiredPlan() OptMeDesiredPlan {
+	return s.DesiredPlan
+}
+
 // SetUser sets the value of User.
 func (s *Me) SetUser(val User) {
 	s.User = val
@@ -15676,11 +15688,70 @@ func (s *Me) SetManagedStorageAllowed(val OptBool) {
 	s.ManagedStorageAllowed = val
 }
 
+// SetDesiredPlan sets the value of DesiredPlan.
+func (s *Me) SetDesiredPlan(val OptMeDesiredPlan) {
+	s.DesiredPlan = val
+}
+
 func (*Me) getMeRes()        {}
 func (*Me) loginRes()        {}
 func (*Me) oidcCallbackRes() {}
 func (*Me) registerRes()     {}
 func (*Me) verifyEmailRes()  {}
+
+// The M16 Phase 0 "sign up into a plan" hint captured at registration (RegisterRequest.plan),
+// single-use: present ONLY in the direct response to POST /auth/verify-email (read off the
+// just-consumed verification token) or the first-run bootstrap response of POST /auth/register —
+// never on GET /auth/me or any other Me-returning response. The frontend uses this to auto-start
+// checkout right after the account is verified. Absent means no intent was captured (free signup,
+// self-hosted instance, or a resend/login/OIDC path that never carries one).
+type MeDesiredPlan string
+
+const (
+	MeDesiredPlanStarter MeDesiredPlan = "starter"
+	MeDesiredPlanAgency  MeDesiredPlan = "agency"
+	MeDesiredPlanScale   MeDesiredPlan = "scale"
+)
+
+// AllValues returns all MeDesiredPlan values.
+func (MeDesiredPlan) AllValues() []MeDesiredPlan {
+	return []MeDesiredPlan{
+		MeDesiredPlanStarter,
+		MeDesiredPlanAgency,
+		MeDesiredPlanScale,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s MeDesiredPlan) MarshalText() ([]byte, error) {
+	switch s {
+	case MeDesiredPlanStarter:
+		return []byte(s), nil
+	case MeDesiredPlanAgency:
+		return []byte(s), nil
+	case MeDesiredPlanScale:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *MeDesiredPlan) UnmarshalText(data []byte) error {
+	switch MeDesiredPlan(data) {
+	case MeDesiredPlanStarter:
+		*s = MeDesiredPlanStarter
+		return nil
+	case MeDesiredPlanAgency:
+		*s = MeDesiredPlanAgency
+		return nil
+	case MeDesiredPlanScale:
+		*s = MeDesiredPlanScale
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
 
 // Portal branding context. Present only when role == "client".
 // Ref: #/components/schemas/MePortal
@@ -21554,6 +21625,52 @@ func (o OptListSitesState) Or(d ListSitesState) ListSitesState {
 	return d
 }
 
+// NewOptMeDesiredPlan returns new OptMeDesiredPlan with value set to v.
+func NewOptMeDesiredPlan(v MeDesiredPlan) OptMeDesiredPlan {
+	return OptMeDesiredPlan{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptMeDesiredPlan is optional MeDesiredPlan.
+type OptMeDesiredPlan struct {
+	Value MeDesiredPlan
+	Set   bool
+}
+
+// IsSet returns true if OptMeDesiredPlan was set.
+func (o OptMeDesiredPlan) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptMeDesiredPlan) Reset() {
+	var v MeDesiredPlan
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptMeDesiredPlan) SetTo(v MeDesiredPlan) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptMeDesiredPlan) Get() (v MeDesiredPlan, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptMeDesiredPlan) Or(d MeDesiredPlan) MeDesiredPlan {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
 // NewOptMePortal returns new OptMePortal with value set to v.
 func NewOptMePortal(v MePortal) OptMePortal {
 	return OptMePortal{
@@ -24159,6 +24276,52 @@ func (o OptPutEmailConnectionRequestConfig) Get() (v PutEmailConnectionRequestCo
 
 // Or returns value if set, or given parameter if does not.
 func (o OptPutEmailConnectionRequestConfig) Or(d PutEmailConnectionRequestConfig) PutEmailConnectionRequestConfig {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptRegisterRequestPlan returns new OptRegisterRequestPlan with value set to v.
+func NewOptRegisterRequestPlan(v RegisterRequestPlan) OptRegisterRequestPlan {
+	return OptRegisterRequestPlan{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptRegisterRequestPlan is optional RegisterRequestPlan.
+type OptRegisterRequestPlan struct {
+	Value RegisterRequestPlan
+	Set   bool
+}
+
+// IsSet returns true if OptRegisterRequestPlan was set.
+func (o OptRegisterRequestPlan) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptRegisterRequestPlan) Reset() {
+	var v RegisterRequestPlan
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptRegisterRequestPlan) SetTo(v RegisterRequestPlan) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptRegisterRequestPlan) Get() (v RegisterRequestPlan, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptRegisterRequestPlan) Or(d RegisterRequestPlan) RegisterRequestPlan {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -29059,6 +29222,13 @@ type RegisterRequest struct {
 	Name       OptString `json:"name"`
 	TenantName OptString `json:"tenant_name"`
 	TenantSlug OptString `json:"tenant_slug"`
+	// OPTIONAL "sign up into a plan" hint (M16 Phase 0, hosted billing only). Omit for an ordinary
+	// free-tier signup. Persisted against the email-verification token and surfaced back as Me.
+	// desired_plan once the account is verified (or immediately, on the first-run bootstrap path), so
+	// the frontend can auto-start checkout. A self-hosted instance, or any value that does not name a
+	// real paid tier, is silently treated as no intent — this field can never fail registration on its
+	// own.
+	Plan OptRegisterRequestPlan `json:"plan"`
 }
 
 // GetEmail returns the value of Email.
@@ -29086,6 +29256,11 @@ func (s *RegisterRequest) GetTenantSlug() OptString {
 	return s.TenantSlug
 }
 
+// GetPlan returns the value of Plan.
+func (s *RegisterRequest) GetPlan() OptRegisterRequestPlan {
+	return s.Plan
+}
+
 // SetEmail sets the value of Email.
 func (s *RegisterRequest) SetEmail(val string) {
 	s.Email = val
@@ -29109,6 +29284,65 @@ func (s *RegisterRequest) SetTenantName(val OptString) {
 // SetTenantSlug sets the value of TenantSlug.
 func (s *RegisterRequest) SetTenantSlug(val OptString) {
 	s.TenantSlug = val
+}
+
+// SetPlan sets the value of Plan.
+func (s *RegisterRequest) SetPlan(val OptRegisterRequestPlan) {
+	s.Plan = val
+}
+
+// OPTIONAL "sign up into a plan" hint (M16 Phase 0, hosted billing only). Omit for an ordinary
+// free-tier signup. Persisted against the email-verification token and surfaced back as Me.
+// desired_plan once the account is verified (or immediately, on the first-run bootstrap path), so
+// the frontend can auto-start checkout. A self-hosted instance, or any value that does not name a
+// real paid tier, is silently treated as no intent — this field can never fail registration on its
+// own.
+type RegisterRequestPlan string
+
+const (
+	RegisterRequestPlanStarter RegisterRequestPlan = "starter"
+	RegisterRequestPlanAgency  RegisterRequestPlan = "agency"
+	RegisterRequestPlanScale   RegisterRequestPlan = "scale"
+)
+
+// AllValues returns all RegisterRequestPlan values.
+func (RegisterRequestPlan) AllValues() []RegisterRequestPlan {
+	return []RegisterRequestPlan{
+		RegisterRequestPlanStarter,
+		RegisterRequestPlanAgency,
+		RegisterRequestPlanScale,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s RegisterRequestPlan) MarshalText() ([]byte, error) {
+	switch s {
+	case RegisterRequestPlanStarter:
+		return []byte(s), nil
+	case RegisterRequestPlanAgency:
+		return []byte(s), nil
+	case RegisterRequestPlanScale:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *RegisterRequestPlan) UnmarshalText(data []byte) error {
+	switch RegisterRequestPlan(data) {
+	case RegisterRequestPlanStarter:
+		*s = RegisterRequestPlanStarter
+		return nil
+	case RegisterRequestPlanAgency:
+		*s = RegisterRequestPlanAgency
+		return nil
+	case RegisterRequestPlanScale:
+		*s = RegisterRequestPlanScale
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
 }
 
 type RegisterUnprocessableEntity Error

--- a/apps/api/internal/api/gen/oas_validators_gen.go
+++ b/apps/api/internal/api/gen/oas_validators_gen.go
@@ -5883,10 +5883,41 @@ func (s *Me) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		if value, ok := s.DesiredPlan.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "desired_plan",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
 	return nil
+}
+
+func (s MeDesiredPlan) Validate() error {
+	switch s {
+	case "starter":
+		return nil
+	case "agency":
+		return nil
+	case "scale":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
 }
 
 func (s MeScope) Validate() error {
@@ -8315,10 +8346,41 @@ func (s *RegisterRequest) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		if value, ok := s.Plan.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "plan",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
 	return nil
+}
+
+func (s RegisterRequestPlan) Validate() error {
+	switch s {
+	case "starter":
+		return nil
+	case "agency":
+		return nil
+	case "scale":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
 }
 
 func (s *ResendVerificationReq) Validate() error {

--- a/apps/api/internal/auth/admin_ops.go
+++ b/apps/api/internal/auth/admin_ops.go
@@ -18,6 +18,6 @@ func (s *Service) ResendVerificationByID(ctx context.Context, userID uuid.UUID) 
 	if u.Status != "pending" {
 		return domain.Validation("not_pending", "user is not pending verification")
 	}
-	s.sendVerificationEmail(ctx, u.ID, u.Email, u.Name)
+	s.sendVerificationEmail(ctx, u.ID, u.Email, u.Name, s.priorDesiredPlan(ctx, u.ID))
 	return nil
 }

--- a/apps/api/internal/auth/handler.go
+++ b/apps/api/internal/auth/handler.go
@@ -175,7 +175,7 @@ func (h *Handler) login(c *gin.Context) {
 					httpx.Error(c, domain.Internal("session_failed", "failed to establish session").WithCause(err))
 					return
 				}
-				out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant))
+				out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant), res.DesiredPlan)
 				c.JSON(http.StatusOK, &out)
 				return
 			}
@@ -192,7 +192,7 @@ func (h *Handler) login(c *gin.Context) {
 	if !h.issueSessionOrChallenge(c, res, "") {
 		return
 	}
-	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant))
+	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant), res.DesiredPlan)
 	c.JSON(http.StatusOK, &out)
 }
 
@@ -202,6 +202,10 @@ type registerBody struct {
 	Name       string `json:"name"`
 	TenantName string `json:"tenant_name"`
 	TenantSlug string `json:"tenant_slug"`
+	// Plan is an OPTIONAL M16 Phase 0 "sign up into a plan" hint. See
+	// RegisterInput.Plan's doc comment: any non-paid-tier value (including
+	// "free", empty, or unrecognized) is silently treated as no intent.
+	Plan string `json:"plan"`
 }
 
 func (h *Handler) register(c *gin.Context) {
@@ -216,6 +220,7 @@ func (h *Handler) register(c *gin.Context) {
 		Name:       body.Name,
 		TenantName: body.TenantName,
 		TenantSlug: body.TenantSlug,
+		Plan:       body.Plan,
 	}
 
 	// First account on a fresh install bootstraps frictionlessly (no SMTP exists
@@ -235,7 +240,7 @@ func (h *Handler) register(c *gin.Context) {
 		if !h.issueSessionOrChallenge(c, res, "") {
 			return
 		}
-		out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant))
+		out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant), res.DesiredPlan)
 		c.JSON(http.StatusCreated, &out)
 		return
 	}
@@ -331,7 +336,7 @@ func (h *Handler) verifyEmail(c *gin.Context) {
 	if !h.issueSessionOrChallenge(c, res, "") {
 		return
 	}
-	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant))
+	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant), res.DesiredPlan)
 	c.JSON(http.StatusOK, &out)
 }
 
@@ -388,7 +393,7 @@ func (h *Handler) me(c *gin.Context) {
 		httpx.Error(c, err)
 		return
 	}
-	out := toMe(u, memberships, p.TenantID, h.hosted, h.managedStorageAllowed(c.Request.Context(), p.TenantID))
+	out := toMe(u, memberships, p.TenantID, h.hosted, h.managedStorageAllowed(c.Request.Context(), p.TenantID), "")
 	// m66 — portal principal: enrich Me with scope, role, and portal branding.
 	enrichMePortal(c.Request.Context(), &out, p, h.svc.repo)
 	c.JSON(http.StatusOK, &out)
@@ -417,7 +422,7 @@ func (h *Handler) updateProfile(c *gin.Context) {
 		httpx.Error(c, err)
 		return
 	}
-	out := toMe(u, memberships, p.TenantID, h.hosted, h.managedStorageAllowed(c.Request.Context(), p.TenantID))
+	out := toMe(u, memberships, p.TenantID, h.hosted, h.managedStorageAllowed(c.Request.Context(), p.TenantID), "")
 	c.JSON(http.StatusOK, &out)
 }
 
@@ -552,11 +557,15 @@ func (h *Handler) oidcCallback(c *gin.Context) {
 		return
 	}
 	// Non-2FA path: session was issued; redirect the browser to the SPA home.
-	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant))
+	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant), res.DesiredPlan)
 	c.JSON(http.StatusOK, &out)
 }
 
-func toMe(u User, memberships []Membership, active uuid.UUID, hosted, managedStorageAllowed bool) gen.Me {
+// toMe builds the wire Me response. desiredPlan is the M16 Phase 0 "sign up
+// into a plan" intent (LoginResult.DesiredPlan) — non-empty ONLY right after
+// Bootstrap or VerifyEmail; every other caller passes "" (no such field
+// exists on that path's result).
+func toMe(u User, memberships []Membership, active uuid.UUID, hosted, managedStorageAllowed bool, desiredPlan string) gen.Me {
 	me := gen.Me{
 		User:                  toAPIUser(u),
 		Memberships:           toAPIMemberships(memberships),
@@ -565,6 +574,9 @@ func toMe(u User, memberships []Membership, active uuid.UUID, hosted, managedSto
 	}
 	if active != uuid.Nil {
 		me.ActiveTenantID = gen.NewOptUUID(active)
+	}
+	if desiredPlan != "" {
+		me.DesiredPlan = gen.NewOptMeDesiredPlan(gen.MeDesiredPlan(desiredPlan))
 	}
 	return me
 }

--- a/apps/api/internal/auth/managed_storage_test.go
+++ b/apps/api/internal/auth/managed_storage_test.go
@@ -68,7 +68,7 @@ func TestManagedStorageAllowed_PropagatesResolverAnswer(t *testing.T) {
 // ---- toMe --------------------------------------------------------------
 
 func TestToMe_SetsManagedStorageAllowed(t *testing.T) {
-	me := toMe(User{}, nil, uuid.New(), true, false)
+	me := toMe(User{}, nil, uuid.New(), true, false, "")
 	if !me.Hosted.Value {
 		t.Fatal("expected Hosted to propagate through toMe")
 	}
@@ -76,7 +76,7 @@ func TestToMe_SetsManagedStorageAllowed(t *testing.T) {
 		t.Fatalf("expected ManagedStorageAllowed = false (set), got %+v", me.ManagedStorageAllowed)
 	}
 
-	me2 := toMe(User{}, nil, uuid.New(), true, true)
+	me2 := toMe(User{}, nil, uuid.New(), true, true, "")
 	if !me2.ManagedStorageAllowed.Set || !me2.ManagedStorageAllowed.Value {
 		t.Fatalf("expected ManagedStorageAllowed = true (set), got %+v", me2.ManagedStorageAllowed)
 	}

--- a/apps/api/internal/auth/register.go
+++ b/apps/api/internal/auth/register.go
@@ -78,13 +78,14 @@ func (s *Service) RegisterSelfServe(
 	if err := s.repo.SetUserPending(ctx, u.ID); err != nil {
 		return err
 	}
+	intent := s.validatePlanIntent(in.Plan)
 	_, _ = s.audit.Record(ctx, audit.Event{
 		TenantID: tenantID, ActorType: audit.ActorUser, ActorID: u.ID.String(),
 		Action: audit.ActionRegister, TargetType: "user", TargetID: u.ID.String(),
-		Metadata: map[string]any{"self_serve": true, "pending": true},
+		Metadata: map[string]any{"self_serve": true, "pending": true, "desired_plan": intent},
 	})
 
-	s.sendVerificationEmail(ctx, u.ID, u.Email, u.Name)
+	s.sendVerificationEmail(ctx, u.ID, u.Email, u.Name, intent)
 	return nil
 }
 
@@ -125,6 +126,7 @@ func (s *Service) VerifyEmail(ctx context.Context, token string) (LoginResult, e
 	}
 	hash := sha256Sum(token)
 	var userID uuid.UUID
+	var intent string
 	consumeErr := s.repo.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
 		row, err := sqlc.New(tx).ConsumeEmailVerificationToken(ctx, hash)
 		if err != nil {
@@ -134,6 +136,9 @@ func (s *Service) VerifyEmail(ctx context.Context, token string) (LoginResult, e
 			return err
 		}
 		userID = row.UserID
+		if row.DesiredPlan != nil {
+			intent = *row.DesiredPlan
+		}
 		return nil
 	})
 	if consumeErr != nil {
@@ -156,7 +161,7 @@ func (s *Service) VerifyEmail(ctx context.Context, token string) (LoginResult, e
 	}
 	memberships, _ := s.repo.ListMembershipsForUser(ctx, userID)
 	_ = s.repo.TouchLogin(ctx, userID)
-	res := LoginResult{User: u, Memberships: memberships}
+	res := LoginResult{User: u, Memberships: memberships, DesiredPlan: intent}
 	res.ActiveTenant = s.resolveActiveTenant(ctx, userID, memberships)
 	return res, nil
 }
@@ -177,8 +182,29 @@ func (s *Service) ResendVerification(ctx context.Context, email string) error {
 	if err != nil || u.Status != "pending" {
 		return nil
 	}
-	s.sendVerificationEmail(ctx, u.ID, u.Email, u.Name)
+	s.sendVerificationEmail(ctx, u.ID, u.Email, u.Name, s.priorDesiredPlan(ctx, u.ID))
 	return nil
+}
+
+// priorDesiredPlan looks up the most recent desired_plan captured across this
+// user's verification tokens (active or already consumed/invalidated), so a
+// resent verification link (ResendVerification, above) carries the SAME
+// intent forward onto its freshly minted token instead of losing it when the
+// prior token is invalidated. Best-effort: any lookup failure — including
+// "no token exists yet" — resolves to "", always a safe default.
+func (s *Service) priorDesiredPlan(ctx context.Context, userID uuid.UUID) string {
+	var intent string
+	_ = s.repo.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
+		got, err := sqlc.New(tx).GetLatestDesiredPlanForUser(ctx, userID)
+		if err != nil {
+			return nil // no rows yet: intent stays ""
+		}
+		if got != nil {
+			intent = *got
+		}
+		return nil
+	})
+	return intent
 }
 
 // sendAccountExists nudges an existing user who tried to re-register: sign in or
@@ -201,11 +227,18 @@ func (s *Service) sendAccountExists(ctx context.Context, email, name string) {
 }
 
 // sendVerificationEmail mints a verification token + enqueues the verify_email
-// template. Best-effort.
-func (s *Service) sendVerificationEmail(ctx context.Context, userID uuid.UUID, email, name string) {
+// template. desiredPlan is the M16 Phase 0 "sign up into a plan" hint to carry
+// on the new token ("" for none); the caller has already resolved it (either
+// freshly, via validatePlanIntent, or carried forward, via priorDesiredPlan).
+// Best-effort.
+func (s *Service) sendVerificationEmail(ctx context.Context, userID uuid.UUID, email, name, desiredPlan string) {
 	raw, hash, gerr := newResetToken()
 	if gerr != nil {
 		return
+	}
+	var desiredPlanArg *string
+	if desiredPlan != "" {
+		desiredPlanArg = &desiredPlan
 	}
 	txErr := s.repo.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
 		q := sqlc.New(tx)
@@ -213,9 +246,10 @@ func (s *Service) sendVerificationEmail(ctx context.Context, userID uuid.UUID, e
 			return err
 		}
 		_, err := q.InsertEmailVerificationToken(ctx, sqlc.InsertEmailVerificationTokenParams{
-			UserID:    userID,
-			TokenHash: hash,
-			ExpiresAt: time.Now().Add(verifyTokenTTL),
+			UserID:      userID,
+			TokenHash:   hash,
+			ExpiresAt:   time.Now().Add(verifyTokenTTL),
+			DesiredPlan: desiredPlanArg,
 		})
 		return err
 	})

--- a/apps/api/internal/auth/service.go
+++ b/apps/api/internal/auth/service.go
@@ -14,6 +14,23 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
+// PaidTierValidator answers whether a caller-supplied string names one of the
+// hosted PAID tiers (never the free tier) recognized by internal/billing's
+// plan ladder (M16 "sign up into a plan" Phase 0). This narrow interface
+// keeps internal/auth free of a direct internal/billing import — billing
+// already imports auth, so the reverse import would cycle — and keeps
+// internal/billing the SOLE owner of paid-tier vocabulary (see
+// billing/grep_guard_test.go): auth only ever asks the question, it never
+// spells out a tier name itself. Implemented by *internal/billing.Service
+// (wired in cmd/wpmgr via Service.SetPlanValidator), mirroring
+// ManagedStorageResolver above. A nil validator (never wired, e.g. in a test
+// that doesn't need this) or a validator that answers false for everything
+// (self-host / hosted disabled) both correctly resolve to "no intent" — there
+// is no checkout to route a plan to.
+type PaidTierValidator interface {
+	ValidPaidTier(plan string) bool
+}
+
 // Service holds authentication business logic: password login, first-run
 // bootstrap, invited registration, and OIDC user upsert. It records auth events
 // to the audit log.
@@ -28,6 +45,10 @@ type Service struct {
 	// twofa holds the Phase 2 two-factor service logic. Injected via
 	// SetTwoFactorDeps after startup. nil when 2FA is not configured.
 	twofa *TwoFactorService
+	// planValidator resolves a "sign up into a plan" hint (M16 Phase 0).
+	// Injected via SetPlanValidator after startup; nil treats every plan hint
+	// as no intent.
+	planValidator PaidTierValidator
 }
 
 // NewService builds an auth Service.
@@ -35,11 +56,37 @@ func NewService(repo *Repo, rec *audit.Recorder, v *domain.Validator) *Service {
 	return &Service{repo: repo, audit: rec, validator: v}
 }
 
+// SetPlanValidator wires the M16 Phase 0 paid-tier validator. Call this after
+// NewService, before serving. Pass the hosted *billing.Service at startup;
+// leaving it unset (self-host, or a test that does not exercise plan intent)
+// makes every registration's plan hint resolve to "no intent" — always safe.
+func (s *Service) SetPlanValidator(v PaidTierValidator) {
+	s.planValidator = v
+}
+
+// validatePlanIntent normalizes a caller-supplied "sign up into a plan" hint
+// and validates it against the wired PaidTierValidator. Returns "" — meaning
+// "no intent, nothing to persist" — for an empty string, an unrecognized or
+// free-tier value, or when no validator is wired. Case/whitespace-insensitive.
+func (s *Service) validatePlanIntent(raw string) string {
+	norm := strings.ToLower(strings.TrimSpace(raw))
+	if norm == "" || s.planValidator == nil || !s.planValidator.ValidPaidTier(norm) {
+		return ""
+	}
+	return norm
+}
+
 // LoginResult is the outcome of a successful login.
 type LoginResult struct {
 	User         User
 	Memberships  []Membership
 	ActiveTenant uuid.UUID
+	// DesiredPlan is the M16 Phase 0 "sign up into a plan" intent surfaced on
+	// the two paths that can carry one: Bootstrap (immediate session, echoes
+	// the just-validated request field) and VerifyEmail (read off the
+	// just-consumed verification token). Every other path (Login,
+	// UpsertOIDCUser, Me/UpdateProfile) leaves this at its zero value "".
+	DesiredPlan string
 }
 
 // loginInput validates the email/password login body.
@@ -147,6 +194,13 @@ type RegisterInput struct {
 	Name       string `validate:"max=200"`
 	TenantName string `validate:"max=200"`
 	TenantSlug string `validate:"omitempty,slug,max=64"`
+	// Plan is an OPTIONAL "sign up into a plan" hint (M16 Phase 0). Any value
+	// that is not a real hosted paid tier — including "free", empty, or
+	// unrecognized — is silently treated as no intent; this field never
+	// fails validation on its own. Resolved via Service.validatePlanIntent,
+	// which is the ONLY place in this package allowed to ask
+	// internal/billing whether a value is a real tier.
+	Plan string `validate:"omitempty,max=32"`
 }
 
 // Bootstrap creates the very first user together with their tenant and an owner
@@ -208,7 +262,12 @@ func (s *Service) Bootstrap(
 		Metadata:   map[string]any{"bootstrap": true},
 	})
 
-	return LoginResult{User: u, Memberships: []Membership{m}, ActiveTenant: tenantID}, nil
+	// Bootstrap issues an immediate session in this same request, so there is
+	// no verify-email gap to survive — the validated hint is simply echoed
+	// back for the caller to act on right away (no server-side persistence
+	// needed, unlike RegisterSelfServe).
+	intent := s.validatePlanIntent(in.Plan)
+	return LoginResult{User: u, Memberships: []Membership{m}, ActiveTenant: tenantID, DesiredPlan: intent}, nil
 }
 
 // InviteInput is an admin/owner request to add a user to a tenant.

--- a/apps/api/internal/auth/twofa_handler.go
+++ b/apps/api/internal/auth/twofa_handler.go
@@ -127,7 +127,7 @@ func (h *Handler) twoFATOTPComplete(c *gin.Context) {
 	}
 
 	remaining, _ := h.svc.CountRecoveryCodes(c.Request.Context(), res.User.ID)
-	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant))
+	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant), res.DesiredPlan)
 	c.JSON(http.StatusOK, gin.H{
 		"me":                        out,
 		"recovery_codes_remaining":  remaining,
@@ -175,7 +175,7 @@ func (h *Handler) twoFARecoveryComplete(c *gin.Context) {
 		h.issueDeviceCookieWithLabel(c, res, label)
 	}
 
-	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant))
+	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant), res.DesiredPlan)
 	c.JSON(http.StatusOK, gin.H{
 		"me":                       out,
 		"recovery_codes_remaining": remaining,
@@ -256,7 +256,7 @@ func (h *Handler) twoFAWebAuthnFinish(c *gin.Context) {
 		h.issueDeviceCookieWithLabel(c, res, label)
 	}
 
-	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant))
+	out := toMe(res.User, res.Memberships, res.ActiveTenant, h.hosted, h.managedStorageAllowed(c.Request.Context(), res.ActiveTenant), res.DesiredPlan)
 	c.JSON(http.StatusOK, &out)
 }
 

--- a/apps/api/internal/billing/entitlements.go
+++ b/apps/api/internal/billing/entitlements.go
@@ -207,6 +207,15 @@ func ValidTier(t Tier) bool {
 	return ok
 }
 
+// ValidPaidTier reports whether t is one of the three PAID tiers in the plan
+// ladder — TierFree is deliberately excluded, unlike ValidTier. Backs
+// Service.ValidPaidTier (M16 "sign up into a plan" Phase 0), which lets
+// internal/auth validate a self-serve registration's plan hint against the
+// real ladder without spelling out a tier name itself.
+func ValidPaidTier(t Tier) bool {
+	return t != TierFree && ValidTier(t)
+}
+
 // MonthlyPriceCentsForTier returns the ladder's list price (USD cents) for
 // t, ignoring plan_overrides (overrides never touch price). Returns 0 for an
 // unrecognized tier — indistinguishable from free's legitimate 0, which is

--- a/apps/api/internal/billing/provider.go
+++ b/apps/api/internal/billing/provider.go
@@ -238,6 +238,32 @@ type CheckoutCallbackVerifier interface {
 	VerifyCheckoutCallback(payload map[string]string) error
 }
 
+// StripePriceReader is an OPTIONAL capability a Provider may implement to
+// expose its live per-tier list price WITHOUT creating a subscription — the
+// read backing the public GET /api/v1/pricing endpoint (internal/pricing),
+// which the marketing site polls to show accurate prices. Declared as a
+// SEPARATE, optional interface (mirrors CheckoutCallbackVerifier immediately
+// above) rather than folded into Provider itself: a price-introspection
+// capability is not something every payment-provider adapter or test double
+// needs to carry.
+type StripePriceReader interface {
+	// GetPrice reads tier's price via a side-effect-free provider lookup (no
+	// subscription created) and returns the per-billing-cycle amount in the
+	// currency's smallest unit, its ISO 4217 currency code, and the billing
+	// interval (e.g. "month").
+	GetPrice(ctx context.Context, tier Tier) (amountMinor int64, currency string, interval string, err error)
+}
+
+// RazorpayPlanReader is the Razorpay-shaped equivalent of StripePriceReader:
+// Razorpay has no single multi-currency price object the way Stripe does —
+// it maintains one Plan PER CURRENCY PER TIER (see the razorpay package's own
+// doc comment) — so its price read is additionally keyed by currency.
+type RazorpayPlanReader interface {
+	// GetPlanAmount reads the (tier, currency) Plan's authoritative amount via
+	// a side-effect-free provider lookup (no subscription created).
+	GetPlanAmount(ctx context.Context, tier Tier, currency string) (amountMinor int64, resolvedCurrency string, interval string, err error)
+}
+
 // Registry is the set of payment providers wired at boot (from config). A
 // provider only appears here when its configuration is actually present
 // (e.g. Stripe's secret key + webhook secret + all three price IDs) — an

--- a/apps/api/internal/billing/razorpay/provider.go
+++ b/apps/api/internal/billing/razorpay/provider.go
@@ -212,6 +212,26 @@ func (p *Provider) CreateCheckout(ctx context.Context, in billing.CheckoutInput)
 	}, nil
 }
 
+// GetPlanAmount implements billing.RazorpayPlanReader: reads the (tier,
+// currency) Plan's authoritative amount via the SAME side-effect-free
+// GET /plans/{id} call CreateCheckout uses to read the Checkout.js "amount" —
+// no subscription is created. Backs the public GET /api/v1/pricing endpoint
+// (internal/pricing). Every Razorpay Plan this adapter creates bills
+// MONTHLY (see subscriptionTotalCycles's doc comment), so interval is always
+// "month".
+func (p *Provider) GetPlanAmount(ctx context.Context, tier billing.Tier, currency string) (amountMinor int64, resolvedCurrency string, interval string, err error) {
+	planID, ok := p.planID(tier, currency)
+	if !ok {
+		return 0, "", "", domain.NotFound("razorpay_plan_not_configured",
+			fmt.Sprintf("no Razorpay plan is configured for tier %q in currency %q", tier, currency))
+	}
+	plan, err := p.fetchPlan(ctx, planID)
+	if err != nil {
+		return 0, "", "", err
+	}
+	return plan.Item.Amount, plan.Item.Currency, "month", nil
+}
+
 // CreatePortalSession implements billing.Provider: Razorpay has no hosted
 // billing-management portal (unlike Stripe's Billing Portal). Returns a
 // clear domain KindUnavailable (HTTP 501) error rather than fabricating a

--- a/apps/api/internal/billing/razorpay/provider_test.go
+++ b/apps/api/internal/billing/razorpay/provider_test.go
@@ -597,3 +597,51 @@ func TestVerifyCheckoutCallback_MissingFields(t *testing.T) {
 		t.Fatalf("want KindValidation for missing callback fields, got %v", err)
 	}
 }
+
+// ---- GetPlanAmount (billing.RazorpayPlanReader — backs GET /api/v1/pricing) ----
+
+func TestGetPlanAmount_Success(t *testing.T) {
+	var sawSubscriptionCreate bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/plans/plan_agency_inr", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET (no subscription should ever be created)", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"plan_agency_inr","item":{"amount":489900,"currency":"INR"}}`)
+	})
+	mux.HandleFunc("/subscriptions", func(w http.ResponseWriter, r *http.Request) {
+		sawSubscriptionCreate = true
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BaseURL = srv.URL
+	p := New(cfg)
+
+	amount, currency, interval, err := p.GetPlanAmount(context.Background(), billing.TierAgency, CurrencyINR)
+	if err != nil {
+		t.Fatalf("GetPlanAmount: %v", err)
+	}
+	if amount != 489900 || currency != "INR" || interval != "month" {
+		t.Fatalf("GetPlanAmount = (%d, %q, %q), want (489900, INR, month)", amount, currency, interval)
+	}
+	if sawSubscriptionCreate {
+		t.Fatal("GetPlanAmount must be side-effect-free — it must never create a subscription")
+	}
+}
+
+func TestGetPlanAmount_UnconfiguredTierCurrencyCombo(t *testing.T) {
+	cfg := testConfig()
+	cfg.PlanScaleINR = "" // deliberately leave one (tier,currency) pair unconfigured
+	p := New(cfg)
+
+	_, _, _, err := p.GetPlanAmount(context.Background(), billing.TierScale, CurrencyINR)
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindNotFound {
+		t.Fatalf("want KindNotFound for an unconfigured (tier,currency) pair, got %v", err)
+	}
+}

--- a/apps/api/internal/billing/service.go
+++ b/apps/api/internal/billing/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"strings"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/google/uuid"
@@ -255,6 +256,26 @@ func (s *Service) ManagedStorageAllowed(ctx context.Context, tenantID uuid.UUID)
 		return false, err
 	}
 	return ent.ManagedBackupStorage, nil
+}
+
+// ValidPaidTier reports whether the given string names one of the hosted
+// PAID tiers (never the free tier) recognized by the plan ladder. Implements
+// auth.PaidTierValidator (internal/auth already imports internal/billing
+// indirectly via cmd/wpmgr's wiring, but billing itself imports auth for
+// TenantCreator-adjacent types, so the reverse import would cycle — this
+// narrow method lets internal/auth validate a "sign up into a plan" hint at
+// registration time without ever spelling out a tier name itself; see
+// grep_guard_test.go). Case/whitespace-insensitive so a caller need not
+// pre-normalize.
+//
+// Returns false, without touching the database, whenever hosted billing is
+// disabled: self-host and pre-Phase-B hosted deployments have no checkout to
+// route a plan intent to, so no intent should ever be captured.
+func (s *Service) ValidPaidTier(plan string) bool {
+	if !s.enabled {
+		return false
+	}
+	return ValidPaidTier(Tier(strings.ToLower(strings.TrimSpace(plan))))
 }
 
 // fetchTenantBilling loads the plan-resolution fields via any DBTX (the pool

--- a/apps/api/internal/billing/stripe/provider.go
+++ b/apps/api/internal/billing/stripe/provider.go
@@ -148,6 +148,25 @@ func (p *Provider) CreateCheckout(ctx context.Context, in billing.CheckoutInput)
 	return billing.CheckoutSession{URL: sess.URL}, nil
 }
 
+// GetPrice implements billing.StripePriceReader: reads tier's live price via
+// a side-effect-free GET /v1/prices/:id — no subscription is created. Backs
+// the public GET /api/v1/pricing endpoint (internal/pricing).
+func (p *Provider) GetPrice(ctx context.Context, tier billing.Tier) (amountMinor int64, currency string, interval string, err error) {
+	price, ok := p.planToPrice[tier]
+	if !ok || price == "" {
+		return 0, "", "", domain.Validation("billing_unknown_tier", "no Stripe price is configured for this tier")
+	}
+	pr, ferr := p.client.V1Prices.Retrieve(ctx, price, nil)
+	if ferr != nil {
+		return 0, "", "", wrapErr("stripe_price_fetch_failed", "failed to fetch the Stripe price", ferr)
+	}
+	interval = "month"
+	if pr.Recurring != nil && pr.Recurring.Interval != "" {
+		interval = string(pr.Recurring.Interval)
+	}
+	return pr.UnitAmount, string(pr.Currency), interval, nil
+}
+
 // CreatePortalSession implements billing.Provider.
 func (p *Provider) CreatePortalSession(ctx context.Context, providerCustomerID string) (billing.PortalSession, error) {
 	params := &stripesdk.BillingPortalSessionCreateParams{

--- a/apps/api/internal/billing/stripe/provider_test.go
+++ b/apps/api/internal/billing/stripe/provider_test.go
@@ -6,6 +6,7 @@ package stripe
 // mapping tests construct *stripesdk.Subscription values directly in Go.
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"github.com/stripe/stripe-go/v86/webhook"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/billing"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
 func testConfig() Config {
@@ -360,6 +362,25 @@ func TestMapStatus_FullMatrix(t *testing.T) {
 // ---------------------------------------------------------------------------
 // Config.Configured
 // ---------------------------------------------------------------------------
+
+// ---- GetPrice (billing.StripePriceReader — backs GET /api/v1/pricing) --------
+//
+// The live GET /v1/prices/:id round trip itself is exercised indirectly via
+// internal/pricing's fake-provider tests (which test the calling contract);
+// this file makes no live Stripe API calls (see the package doc comment
+// above), so only the pure, no-network guard clause is unit-tested here —
+// mirrors TestCreateCheckout's identical "no price configured" case.
+func TestGetPrice_UnconfiguredTier(t *testing.T) {
+	cfg := testConfig()
+	cfg.PriceScale = "" // deliberately leave one tier unconfigured
+	p := New(cfg)
+
+	_, _, _, err := p.GetPrice(context.Background(), billing.TierScale)
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindValidation {
+		t.Fatalf("want KindValidation for an unconfigured tier, got %v", err)
+	}
+}
 
 func TestConfigConfigured(t *testing.T) {
 	if (Config{}).Configured() {

--- a/apps/api/internal/db/sqlc/email_verification_tokens.sql.go
+++ b/apps/api/internal/db/sqlc/email_verification_tokens.sql.go
@@ -18,10 +18,11 @@ SET used_at = now()
 WHERE token_hash = $1
   AND used_at IS NULL
   AND expires_at > now()
-RETURNING id, user_id, token_hash, expires_at, used_at, created_at
+RETURNING id, user_id, token_hash, expires_at, used_at, created_at, desired_plan
 `
 
-// Atomically consume an unused, unexpired verification token.
+// Atomically consume an unused, unexpired verification token. The returned
+// row's desired_plan (if any) is single-use: it is gone with the token.
 func (q *Queries) ConsumeEmailVerificationToken(ctx context.Context, tokenHash []byte) (EmailVerificationToken, error) {
 	row := q.db.QueryRow(ctx, consumeEmailVerificationToken, tokenHash)
 	var i EmailVerificationToken
@@ -32,25 +33,51 @@ func (q *Queries) ConsumeEmailVerificationToken(ctx context.Context, tokenHash [
 		&i.ExpiresAt,
 		&i.UsedAt,
 		&i.CreatedAt,
+		&i.DesiredPlan,
 	)
 	return i, err
 }
 
+const getLatestDesiredPlanForUser = `-- name: GetLatestDesiredPlanForUser :one
+SELECT desired_plan FROM email_verification_tokens
+WHERE user_id = $1
+ORDER BY created_at DESC
+LIMIT 1
+`
+
+// Looks up the most recent desired_plan captured across a user's
+// verification tokens (active or already consumed/invalidated), so a resent
+// verification link can carry the SAME plan intent forward onto its new
+// token instead of losing it when the prior token is invalidated.
+func (q *Queries) GetLatestDesiredPlanForUser(ctx context.Context, userID uuid.UUID) (*string, error) {
+	row := q.db.QueryRow(ctx, getLatestDesiredPlanForUser, userID)
+	var desired_plan *string
+	err := row.Scan(&desired_plan)
+	return desired_plan, err
+}
+
 const insertEmailVerificationToken = `-- name: InsertEmailVerificationToken :one
-INSERT INTO email_verification_tokens (user_id, token_hash, expires_at)
-VALUES ($1, $2, $3)
-RETURNING id, user_id, token_hash, expires_at, used_at, created_at
+INSERT INTO email_verification_tokens (user_id, token_hash, expires_at, desired_plan)
+VALUES ($1, $2, $3, $4)
+RETURNING id, user_id, token_hash, expires_at, used_at, created_at, desired_plan
 `
 
 type InsertEmailVerificationTokenParams struct {
-	UserID    uuid.UUID `json:"user_id"`
-	TokenHash []byte    `json:"token_hash"`
-	ExpiresAt time.Time `json:"expires_at"`
+	UserID      uuid.UUID `json:"user_id"`
+	TokenHash   []byte    `json:"token_hash"`
+	ExpiresAt   time.Time `json:"expires_at"`
+	DesiredPlan *string   `json:"desired_plan"`
 }
 
-// Run under Pool.InAgentTx (app.agent='on').
+// Run under Pool.InAgentTx (app.agent='on'). desired_plan is a nullable M16
+// "sign up into a plan" hint (Phase 0); pass nil for an ordinary signup.
 func (q *Queries) InsertEmailVerificationToken(ctx context.Context, arg InsertEmailVerificationTokenParams) (EmailVerificationToken, error) {
-	row := q.db.QueryRow(ctx, insertEmailVerificationToken, arg.UserID, arg.TokenHash, arg.ExpiresAt)
+	row := q.db.QueryRow(ctx, insertEmailVerificationToken,
+		arg.UserID,
+		arg.TokenHash,
+		arg.ExpiresAt,
+		arg.DesiredPlan,
+	)
 	var i EmailVerificationToken
 	err := row.Scan(
 		&i.ID,
@@ -59,6 +86,7 @@ func (q *Queries) InsertEmailVerificationToken(ctx context.Context, arg InsertEm
 		&i.ExpiresAt,
 		&i.UsedAt,
 		&i.CreatedAt,
+		&i.DesiredPlan,
 	)
 	return i, err
 }

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -304,12 +304,13 @@ type EmailSuppression struct {
 }
 
 type EmailVerificationToken struct {
-	ID        uuid.UUID          `json:"id"`
-	UserID    uuid.UUID          `json:"user_id"`
-	TokenHash []byte             `json:"token_hash"`
-	ExpiresAt time.Time          `json:"expires_at"`
-	UsedAt    pgtype.Timestamptz `json:"used_at"`
-	CreatedAt time.Time          `json:"created_at"`
+	ID          uuid.UUID          `json:"id"`
+	UserID      uuid.UUID          `json:"user_id"`
+	TokenHash   []byte             `json:"token_hash"`
+	ExpiresAt   time.Time          `json:"expires_at"`
+	UsedAt      pgtype.Timestamptz `json:"used_at"`
+	CreatedAt   time.Time          `json:"created_at"`
+	DesiredPlan *string            `json:"desired_plan"`
 }
 
 type EmailWebhookEvent struct {

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -264,7 +264,8 @@ type Querier interface {
 	// site_id check binds the consume to the agent's verified identity (anti
 	// cross-tenant replay).
 	ConsumeAutologinToken(ctx context.Context, arg ConsumeAutologinTokenParams) (ConsumeAutologinTokenRow, error)
-	// Atomically consume an unused, unexpired verification token.
+	// Atomically consume an unused, unexpired verification token. The returned
+	// row's desired_plan (if any) is single-use: it is gone with the token.
 	ConsumeEmailVerificationToken(ctx context.Context, tokenHash []byte) (EmailVerificationToken, error)
 	// Enroll path (app.enroll GUC): mark consumed only if still unconsumed.
 	ConsumePairingCode(ctx context.Context, id uuid.UUID) (int64, error)
@@ -683,6 +684,11 @@ type Querier interface {
 	// than writing a 0 over a real count. pgx.ErrNoRows when no prior point
 	// exists yet — callers default to 0 in that case.
 	GetLatestDBSizeHistoryTableCount(ctx context.Context, arg GetLatestDBSizeHistoryTableCountParams) (int32, error)
+	// Looks up the most recent desired_plan captured across a user's
+	// verification tokens (active or already consumed/invalidated), so a resent
+	// verification link can carry the SAME plan intent forward onto its new
+	// token instead of losing it when the prior token is invalidated.
+	GetLatestDesiredPlanForUser(ctx context.Context, userID uuid.UUID) (*string, error)
 	GetMembership(ctx context.Context, arg GetMembershipParams) (Membership, error)
 	// ---------------------------------------------------------------------------
 	// email_notify_settings  (m62 — alerts + digest)
@@ -993,7 +999,8 @@ type Querier interface {
 	// Record a queued email before enqueuing the send_email job. Run under
 	// Pool.InAgentTx (app.agent='on'); tenant_id may be NULL for auth mail.
 	InsertEmailLog(ctx context.Context, arg InsertEmailLogParams) (EmailLog, error)
-	// Run under Pool.InAgentTx (app.agent='on').
+	// Run under Pool.InAgentTx (app.agent='on'). desired_plan is a nullable M16
+	// "sign up into a plan" hint (Phase 0); pass nil for an ordinary signup.
 	InsertEmailVerificationToken(ctx context.Context, arg InsertEmailVerificationTokenParams) (EmailVerificationToken, error)
 	// ---------------------------------------------------------------------------
 	// file_transfers

--- a/apps/api/internal/pricing/doubles_test.go
+++ b/apps/api/internal/pricing/doubles_test.go
@@ -1,0 +1,253 @@
+package pricing
+
+// doubles_test.go — shared test doubles for this package's tests: fake
+// payment-provider adapters (implementing billing.Provider plus the
+// optional StripePriceReader/RazorpayPlanReader capabilities) and a tiny
+// in-memory fake Redis server (implementing redigo's redis.Conn), so
+// Service.GetPricing's cache/resolve/fallback logic is testable without a
+// live payment provider or a real Redis instance.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/billing"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---- fake Stripe provider ---------------------------------------------------
+
+// fakeStripeProvider implements billing.Provider (stubbed, unused methods)
+// plus billing.StripePriceReader (the method this package's tests actually
+// exercise). priceFn is nil-safe: a nil priceFn makes GetPrice always error.
+//
+// hang and delay simulate a slow/hung upstream, exactly like a real HTTP
+// client bound to ctx would behave: hang blocks until ctx is done and
+// returns ctx.Err() (proves resolveTimeout actually bounds the call); delay
+// sleeps (or returns early on ctx.Done()) before calling priceFn — long
+// enough to make concurrent singleflight callers reliably overlap in a test.
+type fakeStripeProvider struct {
+	mu      sync.Mutex
+	calls   int
+	hang    bool
+	delay   time.Duration
+	priceFn func(tier billing.Tier) (int64, string, string, error)
+}
+
+func (f *fakeStripeProvider) Name() string { return "stripe" }
+
+func (f *fakeStripeProvider) CreateCheckout(context.Context, billing.CheckoutInput) (billing.CheckoutSession, error) {
+	return billing.CheckoutSession{}, domain.Unavailable("unused", "unused in this test double")
+}
+
+func (f *fakeStripeProvider) CreatePortalSession(context.Context, string) (billing.PortalSession, error) {
+	return billing.PortalSession{}, domain.Unavailable("unused", "unused in this test double")
+}
+
+func (f *fakeStripeProvider) CancelSubscription(context.Context, string) error { return nil }
+
+func (f *fakeStripeProvider) GetSubscription(context.Context, string) (billing.Subscription, error) {
+	return billing.Subscription{}, domain.Unavailable("unused", "unused in this test double")
+}
+
+func (f *fakeStripeProvider) VerifyWebhook([]byte, http.Header) (billing.Event, error) {
+	return billing.Event{}, domain.Unavailable("unused", "unused in this test double")
+}
+
+func (f *fakeStripeProvider) MapPriceToPlan(string) (billing.Tier, bool) { return "", false }
+
+func (f *fakeStripeProvider) HasPortal() bool { return true }
+
+// GetPrice implements billing.StripePriceReader.
+func (f *fakeStripeProvider) GetPrice(ctx context.Context, tier billing.Tier) (int64, string, string, error) {
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
+
+	if f.hang {
+		<-ctx.Done()
+		return 0, "", "", ctx.Err()
+	}
+	if f.delay > 0 {
+		select {
+		case <-ctx.Done():
+			return 0, "", "", ctx.Err()
+		case <-time.After(f.delay):
+		}
+	}
+	if f.priceFn == nil {
+		return 0, "", "", domain.Internal("fake_stripe_unconfigured", "fakeStripeProvider.priceFn is nil")
+	}
+	return f.priceFn(tier)
+}
+
+func (f *fakeStripeProvider) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// ---- fake Razorpay provider -------------------------------------------------
+
+// fakeRazorpayProvider implements billing.Provider (stubbed, unused methods)
+// plus billing.RazorpayPlanReader.
+type fakeRazorpayProvider struct {
+	mu     sync.Mutex
+	calls  int
+	planFn func(tier billing.Tier, currency string) (int64, string, string, error)
+}
+
+func (f *fakeRazorpayProvider) Name() string { return "razorpay" }
+
+func (f *fakeRazorpayProvider) CreateCheckout(context.Context, billing.CheckoutInput) (billing.CheckoutSession, error) {
+	return billing.CheckoutSession{}, domain.Unavailable("unused", "unused in this test double")
+}
+
+func (f *fakeRazorpayProvider) CreatePortalSession(context.Context, string) (billing.PortalSession, error) {
+	return billing.PortalSession{}, domain.Unavailable("razorpay_no_portal", "no hosted portal")
+}
+
+func (f *fakeRazorpayProvider) CancelSubscription(context.Context, string) error { return nil }
+
+func (f *fakeRazorpayProvider) GetSubscription(context.Context, string) (billing.Subscription, error) {
+	return billing.Subscription{}, domain.Unavailable("unused", "unused in this test double")
+}
+
+func (f *fakeRazorpayProvider) VerifyWebhook([]byte, http.Header) (billing.Event, error) {
+	return billing.Event{}, domain.Unavailable("unused", "unused in this test double")
+}
+
+func (f *fakeRazorpayProvider) MapPriceToPlan(string) (billing.Tier, bool) { return "", false }
+
+func (f *fakeRazorpayProvider) HasPortal() bool { return false }
+
+// GetPlanAmount implements billing.RazorpayPlanReader.
+func (f *fakeRazorpayProvider) GetPlanAmount(ctx context.Context, tier billing.Tier, currency string) (int64, string, string, error) {
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
+	if f.planFn == nil {
+		return 0, "", "", domain.Internal("fake_razorpay_unconfigured", "fakeRazorpayProvider.planFn is nil")
+	}
+	return f.planFn(tier, currency)
+}
+
+func (f *fakeRazorpayProvider) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// ---- fake Redis --------------------------------------------------------------
+
+// fakeRedisServer is a tiny in-memory Redis stand-in: just enough of GET/
+// SETEX/DEL for Service's cache methods, backed by a shared map so every
+// connection dialed from the SAME server sees the SAME data (mirroring how a
+// real redis.Pool's connections all talk to the same server). It does NOT
+// actually expire keys after their TTL (there is no real clock involved) —
+// it only RECORDS the TTL each SETEX was called with (see lastSetexTTL), so
+// tests can assert the negative-cache-vs-live-success TTL split without a
+// real 1h/60s wait.
+type fakeRedisServer struct {
+	mu   sync.Mutex
+	data map[string][]byte
+	ttls map[string]int
+}
+
+func newFakeRedisServer() *fakeRedisServer {
+	return &fakeRedisServer{data: map[string][]byte{}, ttls: map[string]int{}}
+}
+
+func (s *fakeRedisServer) dial() (redis.Conn, error) {
+	return &fakeRedisConn{srv: s}, nil
+}
+
+func (s *fakeRedisServer) pool() *redis.Pool {
+	return &redis.Pool{Dial: s.dial, MaxIdle: 1}
+}
+
+// seed pre-populates key with raw (as SETEX would have), for a cache-hit test.
+func (s *fakeRedisServer) seed(key string, raw []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[key] = raw
+}
+
+// lastSetexTTL returns the TTL (seconds) the most recent SETEX for key was
+// called with, or (0, false) if key has never been SETEX'd.
+func (s *fakeRedisServer) lastSetexTTL(key string) (int, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ttl, ok := s.ttls[key]
+	return ttl, ok
+}
+
+type fakeRedisConn struct {
+	srv *fakeRedisServer
+}
+
+func (c *fakeRedisConn) Close() error                      { return nil }
+func (c *fakeRedisConn) Err() error                        { return nil }
+func (c *fakeRedisConn) Send(string, ...interface{}) error { return nil }
+func (c *fakeRedisConn) Flush() error                      { return nil }
+func (c *fakeRedisConn) Receive() (interface{}, error)     { return nil, nil }
+
+func (c *fakeRedisConn) Do(cmd string, args ...interface{}) (interface{}, error) {
+	c.srv.mu.Lock()
+	defer c.srv.mu.Unlock()
+	switch cmd {
+	case "GET":
+		key, _ := args[0].(string)
+		v, ok := c.srv.data[key]
+		if !ok {
+			return nil, redis.ErrNil
+		}
+		return v, nil
+	case "SETEX":
+		if len(args) != 3 {
+			return nil, fmt.Errorf("fakeRedisConn: SETEX wants 3 args, got %d", len(args))
+		}
+		key, _ := args[0].(string)
+		c.srv.data[key] = toBytes(args[2])
+		c.srv.ttls[key] = toInt(args[1])
+		return "OK", nil
+	case "DEL":
+		key, _ := args[0].(string)
+		if _, ok := c.srv.data[key]; ok {
+			delete(c.srv.data, key)
+			return int64(1), nil
+		}
+		return int64(0), nil
+	default:
+		return nil, fmt.Errorf("fakeRedisConn: unsupported command %q", cmd)
+	}
+}
+
+func toBytes(v interface{}) []byte {
+	switch t := v.(type) {
+	case []byte:
+		return t
+	case string:
+		return []byte(t)
+	default:
+		return []byte(fmt.Sprint(t))
+	}
+}
+
+// toInt converts a SETEX TTL argument (an int, passed as `interface{}` via
+// redigo's variadic Do(...args)) to a plain int for lastSetexTTL.
+func toInt(v interface{}) int {
+	switch t := v.(type) {
+	case int:
+		return t
+	case int64:
+		return int(t)
+	default:
+		return 0
+	}
+}

--- a/apps/api/internal/pricing/handler.go
+++ b/apps/api/internal/pricing/handler.go
@@ -1,0 +1,44 @@
+package pricing
+
+// handler.go — the PUBLIC pricing endpoint:
+//
+//	GET /api/v1/pricing
+//
+// Unauthenticated, hosted-only. Mirrors how the billing webhook and RUM
+// ingest endpoints mount directly on the root engine (no session, no tenant
+// gate — see internal/server/server.go). Registered ONLY when WPMGR_HOSTED
+// is enabled (cmd/wpmgr/main.go wires internal/server.Deps.PricingH to nil
+// on self-host, exactly like Deps.BillingH/BillingWebhookH), so a self-host
+// install correctly 404s here.
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Handler serves GET /api/v1/pricing.
+type Handler struct {
+	svc *Service
+}
+
+// NewHandler builds the pricing Handler.
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+// RegisterPublic mounts GET /api/v1/pricing on the root engine — no session,
+// no tenant gate; the response is identical for every caller. Callers must
+// only invoke this when hosted billing is enabled (see the package doc
+// comment) — this method itself does not check that, mirroring
+// billing.WebhookHandler.RegisterPublic's nil/non-nil-gated-by-the-caller
+// convention.
+func (h *Handler) RegisterPublic(r *gin.Engine) {
+	r.GET("/api/v1/pricing", h.handle)
+}
+
+func (h *Handler) handle(c *gin.Context) {
+	raw := h.svc.GetPricing(c.Request.Context())
+	c.Header("Cache-Control", "public, max-age=3600")
+	c.Data(http.StatusOK, "application/json; charset=utf-8", raw)
+}

--- a/apps/api/internal/pricing/handler_test.go
+++ b/apps/api/internal/pricing/handler_test.go
@@ -1,0 +1,89 @@
+package pricing
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/billing"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// TestRegisterPublicServesPricing proves the happy path: once RegisterPublic
+// is called, GET /api/v1/pricing returns 200, a public Cache-Control header,
+// and a well-formed pricing body.
+func TestRegisterPublicServesPricing(t *testing.T) {
+	stripe := &fakeStripeProvider{priceFn: func(billing.Tier) (int64, string, string, error) {
+		return 1500, "USD", "month", nil
+	}}
+	svc := NewService(billing.NewRegistry(stripe), nil, slog.Default())
+	h := NewHandler(svc)
+
+	engine := gin.New()
+	h.RegisterPublic(engine)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pricing", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "public, max-age=3600" {
+		t.Fatalf("Cache-Control = %q, want %q", got, "public, max-age=3600")
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["currency_default"] != "USD" {
+		t.Fatalf("currency_default = %v, want USD", body["currency_default"])
+	}
+}
+
+// TestRouteNotMountedReturns404 proves the self-host (WPMGR_HOSTED=false)
+// contract: when the caller (cmd/wpmgr/main.go, gated on cfg.Hosted.Enabled)
+// never calls RegisterPublic at all, GET /api/v1/pricing 404s — the SAME
+// mechanism internal/server.Deps.PricingH's nil case relies on.
+func TestRouteNotMountedReturns404(t *testing.T) {
+	engine := gin.New() // RegisterPublic deliberately never called
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pricing", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (route must not be mounted on self-host)", rec.Code)
+	}
+}
+
+// TestHandlerNeverErrorsEvenOnTotalProviderFailure proves the HTTP layer
+// itself has no error path: Service.GetPricing never returns an error, so
+// the handler always writes 200 (backed by the static fallback when every
+// provider fails).
+func TestHandlerNeverErrorsEvenOnTotalProviderFailure(t *testing.T) {
+	failing := &fakeStripeProvider{priceFn: func(billing.Tier) (int64, string, string, error) {
+		return 0, "", "", context.DeadlineExceeded
+	}}
+	svc := NewService(billing.NewRegistry(failing), nil, slog.Default())
+	h := NewHandler(svc)
+
+	engine := gin.New()
+	h.RegisterPublic(engine)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pricing", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 even when every provider fails (static fallback)", rec.Code)
+	}
+}

--- a/apps/api/internal/pricing/service.go
+++ b/apps/api/internal/pricing/service.go
@@ -1,0 +1,397 @@
+// Package pricing serves the PUBLIC, unauthenticated GET /api/v1/pricing
+// endpoint the marketing site reads to show accurate hosted-plan prices. It
+// is HOSTED-ONLY (mounted only when WPMGR_HOSTED is enabled — see
+// internal/server/server.go's Deps.PricingH and cmd/wpmgr/main.go's wiring)
+// and never touches Postgres: it reads live prices from whichever payment
+// providers are configured (billing.Registry's optional StripePriceReader/
+// RazorpayPlanReader capabilities), behind a short Redis cache, with a
+// static in-Go fallback — so a marketing page load can NEVER 500 or hammer a
+// payment provider, even during a Stripe/Razorpay outage.
+//
+// Three things make this endpoint safe under public, unauthenticated fan-out
+// (see resolveAndCache):
+//
+//  1. NEGATIVE CACHING — the static fallback is cached too, just under a
+//     short TTL (fallbackCacheTTLSeconds), so a provider outage is rate
+//     limited to roughly one resolve attempt per window instead of one per
+//     public request.
+//  2. SINGLEFLIGHT — concurrent cold-cache callers collapse into ONE
+//     upstream resolve via golang.org/x/sync/singleflight, so a burst of N
+//     simultaneous requests never fans out to N*(3-6) provider calls.
+//  3. A BOUNDED resolve timeout (resolveTimeout), independent of each
+//     individual provider call's own HTTP client timeout, so one
+//     slow/hanging provider can never pin a gin handler (or every caller
+//     piggybacking on the same singleflight call) for tens of seconds.
+//
+// Together these protect the Stripe/Razorpay account's rate limit — and
+// therefore any OTHER caller of those same accounts, e.g. real checkout/
+// webhook traffic — from collateral damage caused by this public endpoint.
+//
+// The response carries ONLY amount/currency/interval/tier — never a
+// provider secret, key, or id (see PriceQuote) — and is identical for every
+// caller (no session, no tenant).
+package pricing
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/billing"
+)
+
+// cacheKey is the single Redis key the resolved pricing payload is cached
+// under (both a live success and the static fallback use this same key —
+// see cacheTTLSeconds / fallbackCacheTTLSeconds). It also doubles as the
+// singleflight.Group key: this package only ever resolves one thing.
+const cacheKey = "pricing:v1"
+
+// cacheTTLSeconds is the Redis TTL for a FULL LIVE resolve — mirrored by the
+// handler's HTTP `Cache-Control: max-age` (see Handler.handle).
+const cacheTTLSeconds = 3600 // 1 hour
+
+// fallbackCacheTTLSeconds is the Redis TTL used when GetPricing serves the
+// static fallback (no provider configured, a provider call errored, a
+// resolve timed out, or a marshal failure) — deliberately SHORT. Caching the
+// fallback at all (not just a live success) is what turns a Stripe/Razorpay
+// outage into "at most one resolve attempt every ~60s" instead of "one
+// resolve attempt per public request", which is what protects the payment
+// provider account's rate limit from a fan-out of concurrent public callers.
+const fallbackCacheTTLSeconds = 60
+
+// resolveTimeout bounds the ENTIRE fresh-provider resolve (every Stripe/
+// Razorpay call combined), independent of each individual provider call's
+// own ~15s HTTP client timeout. A public, unauthenticated gin handler must
+// never be pinned for tens of seconds by one hung upstream call — see
+// resolveAndCache. A `var`, not a `const`, SOLELY so the test suite can
+// temporarily shorten it (see TestGetPricingHungProviderRespectsBoundedTimeout)
+// rather than a unit test genuinely waiting out a real 4s timeout; production
+// code never mutates it.
+var resolveTimeout = 4 * time.Second
+
+// paidTiers are the three purchasable tiers this endpoint prices. Free is
+// handled separately (always a flat, zero-amount quote — never priced by a
+// payment provider). Uses billing's own Tier constants, never a bare string
+// literal, so this package carries no second copy of the plan-tier
+// vocabulary (see internal/billing's package doc + grep_guard_test.go).
+var paidTiers = []billing.Tier{billing.TierStarter, billing.TierAgency, billing.TierScale}
+
+// PriceQuote is one concrete, live price point: the per-billing-cycle charge
+// in the currency's smallest unit (cents/paise), its ISO 4217 currency code,
+// and the billing interval (e.g. "month"). Carries NO provider secret, key,
+// or id.
+type PriceQuote struct {
+	Amount   int64  `json:"amount"`
+	Currency string `json:"currency"`
+	Interval string `json:"interval"`
+}
+
+// TierPricing is one subscription tier's resolved public pricing.
+//
+//   - The free tier sets Free (a flat, always-zero-amount PriceQuote) and
+//     renders as flat {"id","amount","currency","interval"} fields.
+//   - A paid tier sets USD and/or INR — ONLY the sub-objects for whichever
+//     provider/currency pairs this instance actually resolved a price for
+//     (Stripe may not be configured; Razorpay may not be configured) — and
+//     renders as {"id","usd":{...},"inr":{...}}.
+//
+// See MarshalJSON for the flat-vs-nested wire shape.
+type TierPricing struct {
+	ID   string
+	Free *PriceQuote
+	USD  *PriceQuote
+	INR  *PriceQuote
+}
+
+// MarshalJSON renders the free tier as flat {"id","amount","currency",
+// "interval"} fields, and a paid tier as {"id","usd":{...},"inr":{...}}
+// (only the sub-objects this instance actually resolved a price for) — the
+// wire shape the marketing site's pricing page consumes.
+func (t TierPricing) MarshalJSON() ([]byte, error) {
+	if t.Free != nil {
+		return json.Marshal(struct {
+			ID       string `json:"id"`
+			Amount   int64  `json:"amount"`
+			Currency string `json:"currency"`
+			Interval string `json:"interval"`
+		}{ID: t.ID, Amount: t.Free.Amount, Currency: t.Free.Currency, Interval: t.Free.Interval})
+	}
+	return json.Marshal(struct {
+		ID  string      `json:"id"`
+		USD *PriceQuote `json:"usd,omitempty"`
+		INR *PriceQuote `json:"inr,omitempty"`
+	}{ID: t.ID, USD: t.USD, INR: t.INR})
+}
+
+// Pricing is the full GET /api/v1/pricing response body.
+type Pricing struct {
+	CurrencyDefault string        `json:"currency_default"`
+	Tiers           []TierPricing `json:"tiers"`
+}
+
+// Service resolves the public pricing payload: Redis cache -> live provider
+// reads (deduped + timeout-bounded) -> a static in-Go fallback. Every method
+// is safe to call even when redis is nil (cache always a miss, still
+// correct — just resolves fresh every time) or registry is nil/empty (falls
+// straight to the static fallback).
+type Service struct {
+	registry *billing.Registry
+	redis    *redis.Pool // optional; nil disables the pricing cache (still correct, just uncached)
+	logger   *slog.Logger
+
+	// group dedups concurrent cold-cache resolves (see resolveAndCache) —
+	// its zero value is ready to use, mirroring internal/rucss/service's
+	// identical singleflight.Group field.
+	group singleflight.Group
+}
+
+// NewService builds a pricing Service. redisPool is expected to be the SAME
+// pool billing.Service uses for its own entitlements cache (a distinct
+// "pricing:" key prefix keeps the two from colliding) — may be nil.
+func NewService(registry *billing.Registry, redisPool *redis.Pool, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{registry: registry, redis: redisPool, logger: logger}
+}
+
+// GetPricing returns the exact JSON bytes to serve for GET /api/v1/pricing.
+// It NEVER errors, NEVER blocks for more than resolveTimeout, and NEVER
+// calls a payment provider on a cache hit:
+//
+//  1. A warm Redis cache ("pricing:v1") is served as-is — no provider calls.
+//  2. On a cache miss (or a Redis outage), it resolves a fresh payload (or
+//     the static fallback) via resolveAndCache — concurrent callers that
+//     miss the cache at the same time collapse into ONE such resolve via
+//     singleflight, keyed by the single cache key this package resolves.
+func (s *Service) GetPricing(ctx context.Context) []byte {
+	if raw, ok := s.getCached(ctx); ok {
+		return raw
+	}
+
+	v, err, _ := s.group.Do(cacheKey, func() (interface{}, error) {
+		return s.resolveAndCache(ctx), nil
+	})
+	if err != nil {
+		// resolveAndCache never itself returns an error — this is a pure
+		// defensive backstop so a hypothetical singleflight-internal failure
+		// still can never turn into a 500.
+		s.logger.Warn("pricing: singleflight resolve failed, serving the static fallback", slog.Any("error", err))
+		return staticFallbackJSON()
+	}
+	raw, ok := v.([]byte)
+	if !ok {
+		return staticFallbackJSON()
+	}
+	return raw
+}
+
+// resolveAndCache resolves a fresh pricing payload — or, on any failure, the
+// static fallback — and writes whichever it produced to the Redis cache
+// before returning it (a live success under cacheTTLSeconds, everything
+// else under the much shorter fallbackCacheTTLSeconds — see that constant's
+// doc comment for why caching the fallback matters).
+//
+// The resolve itself runs against a context that is (a) DECOUPLED from
+// parentCtx's cancellation via context.WithoutCancel, so one singleflight
+// caller's client disconnecting can never cut off every OTHER caller
+// piggybacking on the same in-flight resolve, and (b) hard-capped at
+// resolveTimeout regardless — a slow/hanging provider can therefore never
+// pin this call, or any gin handler waiting on it, for tens of seconds.
+func (s *Service) resolveAndCache(parentCtx context.Context) []byte {
+	cacheCtx := context.WithoutCancel(parentCtx)
+
+	resolveCtx, cancel := context.WithTimeout(cacheCtx, resolveTimeout)
+	defer cancel()
+
+	if p, ok := s.resolveFresh(resolveCtx); ok {
+		raw, err := json.Marshal(p)
+		if err == nil {
+			s.setCached(cacheCtx, raw, cacheTTLSeconds)
+			return raw
+		}
+		s.logger.Warn("pricing: failed to marshal resolved pricing, serving the static fallback", slog.Any("error", err))
+	}
+
+	// Every fallback path — nothing configured, a provider error, a resolve
+	// timeout, or a marshal failure — is negative-cached under the SAME key
+	// with the short TTL: this is what rate-limits a provider incident to
+	// roughly one resolve attempt per fallbackCacheTTLSeconds instead of one
+	// attempt per public request.
+	raw := staticFallbackJSON()
+	s.setCached(cacheCtx, raw, fallbackCacheTTLSeconds)
+	return raw
+}
+
+// resolveFresh reads live prices from whichever payment providers are
+// configured. ok=false when there is nothing live to resolve (no provider
+// configured at all) or ANY configured provider call errors — a partial
+// result is never served; the caller falls back to the cache-miss/static
+// path instead, so a customer never sees a half-resolved price list.
+func (s *Service) resolveFresh(ctx context.Context) (Pricing, bool) {
+	stripeReader, hasStripe := stripePriceReader(s.registry)
+	razorpayReader, hasRazorpay := razorpayPlanReader(s.registry)
+	if !hasStripe && !hasRazorpay {
+		return Pricing{}, false
+	}
+
+	out := Pricing{
+		CurrencyDefault: "USD",
+		Tiers: []TierPricing{
+			{ID: string(billing.TierFree), Free: &PriceQuote{Amount: 0, Currency: "USD", Interval: "month"}},
+		},
+	}
+
+	for _, tier := range paidTiers {
+		entry := TierPricing{ID: string(tier)}
+
+		if hasStripe {
+			amount, currency, interval, err := stripeReader.GetPrice(ctx, tier)
+			if err != nil {
+				s.logger.Warn("pricing: stripe price lookup failed", slog.String("tier", string(tier)), slog.Any("error", err))
+				return Pricing{}, false
+			}
+			entry.USD = &PriceQuote{Amount: amount, Currency: strings.ToUpper(currency), Interval: interval}
+		}
+
+		if hasRazorpay {
+			// Stripe (when configured) is the USD source of truth — Razorpay
+			// only fills the "usd" slot when Stripe itself is not configured.
+			// INR has no Stripe equivalent, so Razorpay always supplies it.
+			if entry.USD == nil {
+				amount, currency, interval, err := razorpayReader.GetPlanAmount(ctx, tier, "USD")
+				if err != nil {
+					s.logger.Warn("pricing: razorpay USD plan lookup failed", slog.String("tier", string(tier)), slog.Any("error", err))
+					return Pricing{}, false
+				}
+				entry.USD = &PriceQuote{Amount: amount, Currency: strings.ToUpper(currency), Interval: interval}
+			}
+			amount, currency, interval, err := razorpayReader.GetPlanAmount(ctx, tier, "INR")
+			if err != nil {
+				s.logger.Warn("pricing: razorpay INR plan lookup failed", slog.String("tier", string(tier)), slog.Any("error", err))
+				return Pricing{}, false
+			}
+			entry.INR = &PriceQuote{Amount: amount, Currency: strings.ToUpper(currency), Interval: interval}
+		}
+
+		out.Tiers = append(out.Tiers, entry)
+	}
+
+	return out, true
+}
+
+// stripePriceReader resolves the registered "stripe" provider's optional
+// billing.StripePriceReader capability. ok=false when no Stripe provider is
+// registered (not configured on this instance) — handled gracefully, never
+// an error: the "usd" slot is simply filled by Razorpay instead, or omitted
+// entirely if neither is configured.
+func stripePriceReader(registry *billing.Registry) (billing.StripePriceReader, bool) {
+	if registry == nil {
+		return nil, false
+	}
+	p, ok := registry.Provider("stripe")
+	if !ok {
+		return nil, false
+	}
+	reader, ok := p.(billing.StripePriceReader)
+	return reader, ok
+}
+
+// razorpayPlanReader resolves the registered "razorpay" provider's optional
+// billing.RazorpayPlanReader capability. ok=false when no Razorpay provider
+// is registered — handled gracefully, never an error.
+func razorpayPlanReader(registry *billing.Registry) (billing.RazorpayPlanReader, bool) {
+	if registry == nil {
+		return nil, false
+	}
+	p, ok := registry.Provider("razorpay")
+	if !ok {
+		return nil, false
+	}
+	reader, ok := p.(billing.RazorpayPlanReader)
+	return reader, ok
+}
+
+// staticFallbackJSON returns the hardcoded, always-available list-price
+// payload used when neither the Redis cache nor a fresh provider resolve is
+// available (every payment provider is down, or none is configured yet).
+// Built from billing's own plan-ladder list prices
+// (MonthlyPriceCentsForTier) — the single source of truth for what each
+// tier costs — so this fallback can never drift from the real list price.
+// USD only: without a live Razorpay read there is no authoritative INR
+// amount to show, so the "inr" sub-object is simply omitted here.
+//
+// The caller (resolveAndCache) negative-caches this result under
+// fallbackCacheTTLSeconds — this function itself is pure/uncached.
+func staticFallbackJSON() []byte {
+	tiers := []TierPricing{
+		{ID: string(billing.TierFree), Free: &PriceQuote{Amount: 0, Currency: "USD", Interval: "month"}},
+	}
+	for _, tier := range paidTiers {
+		tiers = append(tiers, TierPricing{
+			ID:  string(tier),
+			USD: &PriceQuote{Amount: int64(billing.MonthlyPriceCentsForTier(tier)), Currency: "USD", Interval: "month"},
+		})
+	}
+	raw, err := json.Marshal(Pricing{CurrencyDefault: "USD", Tiers: tiers})
+	if err != nil {
+		// json.Marshal on this fixed, always-well-formed shape cannot
+		// realistically fail; this keeps the endpoint at a safe, non-500
+		// empty-list response rather than panicking if it somehow did.
+		return []byte(`{"currency_default":"USD","tiers":[]}`)
+	}
+	return raw
+}
+
+// getCached returns the cached pricing payload, or (nil, false) on a cache
+// miss OR any Redis failure. Every failure path logs a warning and falls
+// through to a fresh resolve — Redis must never be a hard dependency for a
+// public, unauthenticated endpoint.
+func (s *Service) getCached(ctx context.Context) ([]byte, bool) {
+	if s.redis == nil {
+		return nil, false
+	}
+	conn, err := s.redis.GetContext(ctx)
+	if err != nil {
+		s.logger.Warn("pricing: redis unavailable, resolving pricing fresh", slog.Any("error", err))
+		return nil, false
+	}
+	defer conn.Close()
+
+	raw, err := redis.Bytes(conn.Do("GET", cacheKey))
+	if err != nil {
+		if err != redis.ErrNil {
+			s.logger.Warn("pricing: redis GET failed, resolving pricing fresh", slog.Any("error", err))
+		}
+		return nil, false
+	}
+	if len(raw) == 0 {
+		return nil, false
+	}
+	return raw, true
+}
+
+// setCached best-effort writes raw to Redis under cacheKey with the given
+// TTL — cacheTTLSeconds for a full live resolve, fallbackCacheTTLSeconds for
+// the static fallback (see resolveAndCache). Any failure is logged and
+// swallowed: a cache write is never allowed to fail the request that just
+// resolved pricing correctly.
+func (s *Service) setCached(ctx context.Context, raw []byte, ttlSeconds int) {
+	if s.redis == nil {
+		return
+	}
+	conn, err := s.redis.GetContext(ctx)
+	if err != nil {
+		s.logger.Warn("pricing: redis unavailable, skipping pricing cache write", slog.Any("error", err))
+		return
+	}
+	defer conn.Close()
+	if _, err := conn.Do("SETEX", cacheKey, ttlSeconds, raw); err != nil {
+		s.logger.Warn("pricing: redis SETEX failed", slog.Any("error", err))
+	}
+}

--- a/apps/api/internal/pricing/service_test.go
+++ b/apps/api/internal/pricing/service_test.go
@@ -1,0 +1,585 @@
+package pricing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/billing"
+)
+
+// errAlwaysFailDial simulates "Redis is unreachable" (mirrors
+// internal/billing/entitlements_test.go's alwaysFailDial).
+var errAlwaysFailDial = errors.New("simulated redis outage")
+
+// Tier-id string constants, derived from billing's own Tier constants rather
+// than a bare paid-tier string literal — internal/billing's
+// TestNoPlanLiteralsOutsideBilling grep guard forbids those literals outside
+// the billing package itself (single-ownership of the plan-tier vocabulary),
+// and that guard scans every .go file, tests included.
+var (
+	tierStarterID = string(billing.TierStarter)
+	tierAgencyID  = string(billing.TierAgency)
+	tierScaleID   = string(billing.TierScale)
+)
+
+// ---- helpers ----------------------------------------------------------------
+
+// wireTier is a loosely-typed decode target mirroring the wire shape
+// TierPricing.MarshalJSON produces, used to assert on a resolved response
+// without depending on this package's internal struct shapes.
+type wireTier struct {
+	ID       string  `json:"id"`
+	Amount   *int64  `json:"amount"`
+	Currency *string `json:"currency"`
+	Interval *string `json:"interval"`
+	USD      *struct {
+		Amount   int64  `json:"amount"`
+		Currency string `json:"currency"`
+		Interval string `json:"interval"`
+	} `json:"usd"`
+	INR *struct {
+		Amount   int64  `json:"amount"`
+		Currency string `json:"currency"`
+		Interval string `json:"interval"`
+	} `json:"inr"`
+}
+
+type wirePricing struct {
+	CurrencyDefault string     `json:"currency_default"`
+	Tiers           []wireTier `json:"tiers"`
+}
+
+func decodePricing(t *testing.T, raw []byte) wirePricing {
+	t.Helper()
+	var p wirePricing
+	if err := json.Unmarshal(raw, &p); err != nil {
+		t.Fatalf("decode pricing response: %v\nraw: %s", err, raw)
+	}
+	return p
+}
+
+func tierByID(t *testing.T, p wirePricing, id string) wireTier {
+	t.Helper()
+	for _, tier := range p.Tiers {
+		if tier.ID == id {
+			return tier
+		}
+	}
+	t.Fatalf("no tier %q in response: %+v", id, p)
+	return wireTier{}
+}
+
+// ---- live provider resolution ------------------------------------------------
+
+func TestGetPricingResolvesLiveProviderPrices(t *testing.T) {
+	stripe := &fakeStripeProvider{priceFn: func(tier billing.Tier) (int64, string, string, error) {
+		switch tier {
+		case billing.TierStarter:
+			return 1500, "usd", "month", nil // lowercase, like real Stripe — proves normalization
+		case billing.TierAgency:
+			return 5900, "usd", "month", nil
+		case billing.TierScale:
+			return 16900, "usd", "month", nil
+		}
+		t.Fatalf("unexpected tier %q", tier)
+		return 0, "", "", nil
+	}}
+	razorpay := &fakeRazorpayProvider{planFn: func(tier billing.Tier, currency string) (int64, string, string, error) {
+		amounts := map[billing.Tier]int64{
+			billing.TierStarter: 124900,
+			billing.TierAgency:  489900,
+			billing.TierScale:   1399900,
+		}
+		return amounts[tier], currency, "month", nil // INR passed through uppercase from the caller
+	}}
+
+	registry := billing.NewRegistry(stripe, razorpay)
+	svc := NewService(registry, nil, slog.Default())
+
+	raw := svc.GetPricing(context.Background())
+	p := decodePricing(t, raw)
+
+	if p.CurrencyDefault != "USD" {
+		t.Fatalf("currency_default = %q, want USD", p.CurrencyDefault)
+	}
+
+	free := tierByID(t, p, "free")
+	if free.Amount == nil || *free.Amount != 0 {
+		t.Fatalf("free tier amount = %v, want 0", free.Amount)
+	}
+	if free.Currency == nil || *free.Currency != "USD" {
+		t.Fatalf("free tier currency = %v, want USD", free.Currency)
+	}
+	if free.USD != nil || free.INR != nil {
+		t.Fatalf("free tier must not carry usd/inr sub-objects, got %+v", free)
+	}
+
+	starter := tierByID(t, p, tierStarterID)
+	if starter.USD == nil || starter.USD.Amount != 1500 || starter.USD.Currency != "USD" {
+		t.Fatalf("starter.usd = %+v, want amount=1500 currency=USD (Stripe wins USD)", starter.USD)
+	}
+	if starter.INR == nil || starter.INR.Amount != 124900 || starter.INR.Currency != "INR" {
+		t.Fatalf("starter.inr = %+v, want amount=124900 currency=INR", starter.INR)
+	}
+	if starter.Amount != nil {
+		t.Fatalf("a paid tier must not carry a flat amount field, got %v", starter.Amount)
+	}
+
+	agency := tierByID(t, p, tierAgencyID)
+	if agency.USD == nil || agency.USD.Amount != 5900 {
+		t.Fatalf("agency.usd = %+v, want amount=5900", agency.USD)
+	}
+
+	scale := tierByID(t, p, tierScaleID)
+	if scale.USD == nil || scale.USD.Amount != 16900 {
+		t.Fatalf("scale.usd = %+v, want amount=16900", scale.USD)
+	}
+
+	if got := stripe.callCount(); got != 3 {
+		t.Fatalf("stripe GetPrice called %d times, want 3 (one per paid tier)", got)
+	}
+	// Only INR per paid tier: Stripe already supplied the "usd" slot, so
+	// resolveFresh never asks Razorpay for USD too (see its doc comment).
+	if got := razorpay.callCount(); got != 3 {
+		t.Fatalf("razorpay GetPlanAmount called %d times, want 3 (INR only per paid tier — Stripe already filled USD)", got)
+	}
+}
+
+// TestGetPricingRazorpayOnlyFillsUSDSlot proves that when Stripe is not
+// configured at all, Razorpay's own USD plan fills the "usd" slot instead of
+// it being omitted — "whichever are configured" from a single-provider
+// instance.
+func TestGetPricingRazorpayOnlyFillsUSDSlot(t *testing.T) {
+	razorpay := &fakeRazorpayProvider{planFn: func(tier billing.Tier, currency string) (int64, string, string, error) {
+		if currency == "USD" {
+			return 1500, "USD", "month", nil
+		}
+		return 124900, "INR", "month", nil
+	}}
+	registry := billing.NewRegistry(razorpay) // no Stripe provider registered
+	svc := NewService(registry, nil, slog.Default())
+
+	p := decodePricing(t, svc.GetPricing(context.Background()))
+	starter := tierByID(t, p, tierStarterID)
+	if starter.USD == nil || starter.USD.Amount != 1500 {
+		t.Fatalf("starter.usd = %+v, want Razorpay's USD amount=1500 when Stripe is unconfigured", starter.USD)
+	}
+	if starter.INR == nil || starter.INR.Amount != 124900 {
+		t.Fatalf("starter.inr = %+v, want amount=124900", starter.INR)
+	}
+}
+
+// TestGetPricingStripeOnlyOmitsINR proves that when Razorpay is not
+// configured, the "inr" sub-object is simply absent (never fabricated) —
+// "Include only the sub-objects for configured providers/currencies".
+func TestGetPricingStripeOnlyOmitsINR(t *testing.T) {
+	stripe := &fakeStripeProvider{priceFn: func(billing.Tier) (int64, string, string, error) {
+		return 1500, "USD", "month", nil
+	}}
+	registry := billing.NewRegistry(stripe) // no Razorpay provider registered
+	svc := NewService(registry, nil, slog.Default())
+
+	p := decodePricing(t, svc.GetPricing(context.Background()))
+	starter := tierByID(t, p, tierStarterID)
+	if starter.USD == nil || starter.USD.Amount != 1500 {
+		t.Fatalf("starter.usd = %+v, want amount=1500", starter.USD)
+	}
+	if starter.INR != nil {
+		t.Fatalf("starter.inr = %+v, want omitted (no Razorpay provider configured)", starter.INR)
+	}
+}
+
+// ---- fail-open: provider error / nothing configured -> static fallback ------
+
+func TestGetPricingFallsBackToStaticOnProviderError(t *testing.T) {
+	stripe := &fakeStripeProvider{priceFn: func(billing.Tier) (int64, string, string, error) {
+		return 0, "", "", context.DeadlineExceeded // simulate a Stripe outage
+	}}
+	registry := billing.NewRegistry(stripe)
+	svc := NewService(registry, nil, slog.Default())
+
+	raw := svc.GetPricing(context.Background()) // must never panic/500
+	p := decodePricing(t, raw)
+
+	starter := tierByID(t, p, tierStarterID)
+	wantAmount := int64(billing.MonthlyPriceCentsForTier(billing.TierStarter))
+	if starter.USD == nil || starter.USD.Amount != wantAmount {
+		t.Fatalf("starter.usd = %+v, want the static fallback list price %d", starter.USD, wantAmount)
+	}
+	free := tierByID(t, p, "free")
+	if free.Amount == nil || *free.Amount != 0 {
+		t.Fatalf("free tier amount = %v, want 0 even on the static fallback", free.Amount)
+	}
+}
+
+func TestGetPricingNoProvidersConfiguredFallsBackToStatic(t *testing.T) {
+	svc := NewService(billing.NewRegistry(), nil, slog.Default())
+
+	raw := svc.GetPricing(context.Background())
+	p := decodePricing(t, raw)
+
+	for _, tier := range []billing.Tier{billing.TierStarter, billing.TierAgency, billing.TierScale} {
+		entry := tierByID(t, p, string(tier))
+		want := int64(billing.MonthlyPriceCentsForTier(tier))
+		if entry.USD == nil || entry.USD.Amount != want {
+			t.Fatalf("%s.usd = %+v, want the static fallback list price %d", tier, entry.USD, want)
+		}
+	}
+}
+
+// TestGetPricingNilRegistryNeverPanics proves a nil registry (should not
+// happen given cmd/wpmgr's wiring, but this endpoint must be bulletproof) is
+// handled exactly like an empty one.
+func TestGetPricingNilRegistryNeverPanics(t *testing.T) {
+	svc := NewService(nil, nil, slog.Default())
+	raw := svc.GetPricing(context.Background())
+	_ = decodePricing(t, raw) // must decode cleanly, not panic
+}
+
+// ---- cache behavior -----------------------------------------------------------
+
+func TestGetPricingCacheHitSkipsProviderCalls(t *testing.T) {
+	srv := newFakeRedisServer()
+	seeded := []byte(`{"currency_default":"USD","tiers":[{"id":"free","amount":0,"currency":"USD","interval":"month"}]}`)
+	srv.seed(cacheKey, seeded)
+
+	stripe := &fakeStripeProvider{priceFn: func(billing.Tier) (int64, string, string, error) {
+		t.Fatal("stripe GetPrice must not be called on a warm cache")
+		return 0, "", "", nil
+	}}
+	razorpay := &fakeRazorpayProvider{planFn: func(billing.Tier, string) (int64, string, string, error) {
+		t.Fatal("razorpay GetPlanAmount must not be called on a warm cache")
+		return 0, "", "", nil
+	}}
+	registry := billing.NewRegistry(stripe, razorpay)
+	svc := NewService(registry, srv.pool(), slog.Default())
+
+	raw := svc.GetPricing(context.Background())
+	if string(raw) != string(seeded) {
+		t.Fatalf("cache-hit response = %s, want the exact seeded payload %s", raw, seeded)
+	}
+	if got := stripe.callCount(); got != 0 {
+		t.Fatalf("stripe.callCount() = %d, want 0 on a cache hit", got)
+	}
+	if got := razorpay.callCount(); got != 0 {
+		t.Fatalf("razorpay.callCount() = %d, want 0 on a cache hit", got)
+	}
+}
+
+func TestGetPricingCacheMissResolvesAndCaches(t *testing.T) {
+	srv := newFakeRedisServer()
+	stripe := &fakeStripeProvider{priceFn: func(billing.Tier) (int64, string, string, error) {
+		return 1500, "USD", "month", nil
+	}}
+	registry := billing.NewRegistry(stripe)
+	svc := NewService(registry, srv.pool(), slog.Default())
+
+	first := svc.GetPricing(context.Background())
+	if got := stripe.callCount(); got != 3 {
+		t.Fatalf("after a cold cache, stripe.callCount() = %d, want 3 (one per paid tier)", got)
+	}
+
+	// A second call must be served entirely from the now-warm cache — no
+	// further provider calls.
+	second := svc.GetPricing(context.Background())
+	if string(first) != string(second) {
+		t.Fatalf("second GetPricing = %s, want identical to the first %s", second, first)
+	}
+	if got := stripe.callCount(); got != 3 {
+		t.Fatalf("after a warm cache, stripe.callCount() = %d, want still 3 (no re-resolve)", got)
+	}
+}
+
+// TestGetPricingCacheMissWritesLongTTLOnLiveSuccess proves a full live
+// resolve is cached under cacheTTLSeconds (1h) — the complement of
+// TestGetPricingCachesFallbackWithShortTTLOnProviderError's short TTL.
+func TestGetPricingCacheMissWritesLongTTLOnLiveSuccess(t *testing.T) {
+	srv := newFakeRedisServer()
+	stripe := &fakeStripeProvider{priceFn: func(billing.Tier) (int64, string, string, error) {
+		return 1500, "USD", "month", nil
+	}}
+	svc := NewService(billing.NewRegistry(stripe), srv.pool(), slog.Default())
+
+	svc.GetPricing(context.Background())
+
+	gotTTL, ok := srv.lastSetexTTL(cacheKey)
+	if !ok {
+		t.Fatal("expected the live resolve to be written to the cache")
+	}
+	if gotTTL != cacheTTLSeconds {
+		t.Fatalf("live-success cache TTL = %d, want %d (cacheTTLSeconds)", gotTTL, cacheTTLSeconds)
+	}
+}
+
+// TestGetPricingCachesFallbackWithShortTTLOnProviderError is the MEDIUM
+// hardening this test locks in: when every configured provider errors, the
+// STATIC FALLBACK itself is negative-cached under fallbackCacheTTLSeconds
+// (60s, not the 1h live-success TTL) — so an immediate second request during
+// a provider outage is served from that negative cache instead of retrying
+// the (still-down) provider, rate-limiting the outage to roughly one resolve
+// attempt per window instead of one per public request.
+func TestGetPricingCachesFallbackWithShortTTLOnProviderError(t *testing.T) {
+	srv := newFakeRedisServer()
+	stripe := &fakeStripeProvider{priceFn: func(billing.Tier) (int64, string, string, error) {
+		return 0, "", "", context.DeadlineExceeded // simulated Stripe outage
+	}}
+	svc := NewService(billing.NewRegistry(stripe), srv.pool(), slog.Default())
+
+	first := svc.GetPricing(context.Background())
+	firstCalls := stripe.callCount()
+	if firstCalls == 0 {
+		t.Fatal("expected at least one provider call attempt to discover the outage")
+	}
+
+	gotTTL, ok := srv.lastSetexTTL(cacheKey)
+	if !ok {
+		t.Fatal("expected the static fallback to be written to the cache (negative caching)")
+	}
+	if gotTTL != fallbackCacheTTLSeconds {
+		t.Fatalf("fallback cache TTL = %d, want %d (fallbackCacheTTLSeconds — short, not the 1h live-success TTL)", gotTTL, fallbackCacheTTLSeconds)
+	}
+
+	// An immediate second request must be served from that negative cache —
+	// NOT by retrying the still-down provider.
+	second := svc.GetPricing(context.Background())
+	if string(second) != string(first) {
+		t.Fatalf("second GetPricing = %s, want the identical cached fallback %s", second, first)
+	}
+	if got := stripe.callCount(); got != firstCalls {
+		t.Fatalf("stripe.callCount() = %d after a second request, want unchanged %d (the negative cache must absorb it, not the provider)", got, firstCalls)
+	}
+}
+
+// TestGetPricingConcurrentColdCacheCallsCollapseViaSingleflight is the
+// second MEDIUM-hardening lock-in: N concurrent callers that all miss a
+// cold cache at once must trigger exactly ONE upstream resolve (one
+// GetPrice call per paid tier), not N — singleflight.Group.Do dedups them,
+// keyed by the single cache key this package ever resolves.
+func TestGetPricingConcurrentColdCacheCallsCollapseViaSingleflight(t *testing.T) {
+	stripe := &fakeStripeProvider{
+		// Long enough that all N goroutines below reliably issue their
+		// GetPricing call while the FIRST (singleflight leader) call is
+		// still in flight, so they genuinely collapse rather than racing to
+		// each be "first" in turn.
+		delay: 150 * time.Millisecond,
+		priceFn: func(billing.Tier) (int64, string, string, error) {
+			return 1500, "USD", "month", nil
+		},
+	}
+	svc := NewService(billing.NewRegistry(stripe), newFakeRedisServer().pool(), slog.Default())
+
+	const n = 20
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			results[i] = svc.GetPricing(context.Background())
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i := 1; i < n; i++ {
+		if string(results[i]) != string(results[0]) {
+			t.Fatalf("result %d = %s, want identical to result 0 %s — singleflight must serve every waiter the same payload", i, results[i], results[0])
+		}
+	}
+	// Exactly one resolve's worth of provider calls (one per paid tier),
+	// regardless of n concurrent callers.
+	if got := stripe.callCount(); got != 3 {
+		t.Fatalf("stripe.callCount() = %d, want exactly 3 — %d concurrent cold-cache callers must collapse into ONE upstream resolve, not fan out", got, n)
+	}
+}
+
+// TestGetPricingHungProviderRespectsBoundedTimeout is the third
+// MEDIUM-hardening lock-in: a provider call that never returns must not pin
+// GetPricing (or the gin handler calling it) for tens of seconds — the
+// resolve is hard-capped at resolveTimeout and falls back to the static
+// list, never a 500. resolveTimeout is temporarily shortened so this test
+// does not itself take 4+ real seconds to run.
+func TestGetPricingHungProviderRespectsBoundedTimeout(t *testing.T) {
+	original := resolveTimeout
+	resolveTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { resolveTimeout = original })
+
+	stripe := &fakeStripeProvider{hang: true}
+	svc := NewService(billing.NewRegistry(stripe), nil, slog.Default())
+
+	done := make(chan []byte, 1)
+	start := time.Now()
+	go func() { done <- svc.GetPricing(context.Background()) }()
+
+	select {
+	case raw := <-done:
+		if elapsed := time.Since(start); elapsed > 2*time.Second {
+			t.Fatalf("GetPricing took %v, want it bounded by resolveTimeout (%v)", elapsed, resolveTimeout)
+		}
+		p := decodePricing(t, raw)
+		starter := tierByID(t, p, tierStarterID)
+		want := int64(billing.MonthlyPriceCentsForTier(billing.TierStarter))
+		if starter.USD == nil || starter.USD.Amount != want {
+			t.Fatalf("starter.usd = %+v, want the static fallback list price %d (a hung provider must still resolve to the fallback, never hang or 500)", starter.USD, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("GetPricing did not return within 5s — a hung provider must not be able to pin this call past resolveTimeout")
+	}
+}
+
+// TestGetPricingRedisDownStillResolves proves a Redis outage (every Dial
+// fails) degrades to always resolving fresh — never a hard dependency, never
+// an error out of GetPricing.
+func TestGetPricingRedisDownStillResolves(t *testing.T) {
+	stripe := &fakeStripeProvider{priceFn: func(billing.Tier) (int64, string, string, error) {
+		return 1500, "USD", "month", nil
+	}}
+	registry := billing.NewRegistry(stripe)
+	alwaysFailPool := &redis.Pool{
+		Dial:    func() (redis.Conn, error) { return nil, errAlwaysFailDial },
+		MaxIdle: 1,
+	}
+	svc := NewService(registry, alwaysFailPool, slog.Default())
+
+	raw := svc.GetPricing(context.Background())
+	p := decodePricing(t, raw)
+	starter := tierByID(t, p, tierStarterID)
+	if starter.USD == nil || starter.USD.Amount != 1500 {
+		t.Fatalf("starter.usd = %+v, want amount=1500 resolved fresh despite Redis being down", starter.USD)
+	}
+}
+
+// ---- response shape / no-secrets -----------------------------------------------
+
+// allowedResponseKeys is the exhaustive set of JSON keys this endpoint may
+// EVER emit, at any nesting level. Any other key appearing anywhere in the
+// response is treated as a potential secret/id leak.
+var allowedResponseKeys = map[string]bool{
+	"currency_default": true,
+	"tiers":            true,
+	"id":               true,
+	"amount":           true,
+	"currency":         true,
+	"interval":         true,
+	"usd":              true,
+	"inr":              true,
+}
+
+func TestGetPricingResponseHasNoSecretFields(t *testing.T) {
+	stripe := &fakeStripeProvider{priceFn: func(billing.Tier) (int64, string, string, error) {
+		return 1500, "USD", "month", nil
+	}}
+	razorpay := &fakeRazorpayProvider{planFn: func(billing.Tier, string) (int64, string, string, error) {
+		return 124900, "INR", "month", nil
+	}}
+	registry := billing.NewRegistry(stripe, razorpay)
+	svc := NewService(registry, nil, slog.Default())
+
+	raw := svc.GetPricing(context.Background())
+	var generic interface{}
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	walkKeysAndValues(t, generic)
+
+	// Also assert the static fallback carries no secrets.
+	walkKeysAndValues(t, mustDecodeGeneric(t, staticFallbackJSON()))
+}
+
+func mustDecodeGeneric(t *testing.T, raw []byte) interface{} {
+	t.Helper()
+	var v interface{}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return v
+}
+
+// allowedTierIDs is the exhaustive set of values an "id" field may EVER
+// hold, derived from billing's own Tier constants (never a bare paid-tier
+// string literal — see the grep-guard note on tierStarterID et al. above).
+var allowedTierIDs = map[string]bool{
+	string(billing.TierFree): true,
+	tierStarterID:            true,
+	tierAgencyID:             true,
+	tierScaleID:              true,
+}
+
+// currencyPattern is what every "currency" field value must match: a bare
+// ISO 4217 alpha-3 code, uppercase, nothing else (no provider-internal
+// currency code variant, no stray whitespace/casing).
+var currencyPattern = regexp.MustCompile(`^[A-Z]{3}$`)
+
+// walkKeysAndValues recursively checks a decoded response: every object key
+// must be in allowedResponseKeys (catches an unexpected/leaked field), AND
+// every "id"/"currency" VALUE must match the expected, narrow shape (catches
+// a leaked value hiding behind an otherwise-expected key name — the
+// security review's own note that a keys-only check is not sufficient).
+func walkKeysAndValues(t *testing.T, v interface{}) {
+	t.Helper()
+	switch val := v.(type) {
+	case map[string]interface{}:
+		for k, vv := range val {
+			if !allowedResponseKeys[k] {
+				t.Fatalf("unexpected response key %q — possible secret/id leak", k)
+			}
+			switch k {
+			case "id":
+				s, ok := vv.(string)
+				if !ok || !allowedTierIDs[s] {
+					t.Fatalf("id value %v is not one of the known tiers %v — possible unexpected/leaked value", vv, allowedTierIDs)
+				}
+			case "currency":
+				s, ok := vv.(string)
+				if !ok || !currencyPattern.MatchString(s) {
+					t.Fatalf("currency value %v does not match %s — possible unexpected/leaked value", vv, currencyPattern)
+				}
+			}
+			walkKeysAndValues(t, vv)
+		}
+	case []interface{}:
+		for _, vv := range val {
+			walkKeysAndValues(t, vv)
+		}
+	}
+}
+
+// ---- TierPricing wire shape ----------------------------------------------------
+
+func TestTierPricingMarshalJSONFreeIsFlat(t *testing.T) {
+	tier := TierPricing{ID: "free", Free: &PriceQuote{Amount: 0, Currency: "USD", Interval: "month"}}
+	raw, err := json.Marshal(tier)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `{"id":"free","amount":0,"currency":"USD","interval":"month"}`
+	if string(raw) != want {
+		t.Fatalf("free tier JSON = %s, want %s", raw, want)
+	}
+}
+
+func TestTierPricingMarshalJSONPaidIsNested(t *testing.T) {
+	tier := TierPricing{
+		ID:  tierStarterID,
+		USD: &PriceQuote{Amount: 1500, Currency: "USD", Interval: "month"},
+	}
+	raw, err := json.Marshal(tier)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := fmt.Sprintf(`{"id":%q,"usd":{"amount":1500,"currency":"USD","interval":"month"}}`, tierStarterID)
+	if string(raw) != want {
+		t.Fatalf("paid tier JSON = %s, want %s (inr omitted when nil)", raw, want)
+	}
+}

--- a/apps/api/internal/server/server.go
+++ b/apps/api/internal/server/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/org"
 	"github.com/mosamlife/wpmgr/apps/api/internal/perf"
 	portalpkg "github.com/mosamlife/wpmgr/apps/api/internal/portal"
+	"github.com/mosamlife/wpmgr/apps/api/internal/pricing"
 	reportpkg "github.com/mosamlife/wpmgr/apps/api/internal/report"
 	"github.com/mosamlife/wpmgr/apps/api/internal/rum"
 	"github.com/mosamlife/wpmgr/apps/api/internal/scan"
@@ -212,6 +213,14 @@ type Deps struct {
 	// BillingWebhookH serves the M16 Phase B public payment-provider webhook
 	// endpoint at POST /webhooks/billing/:provider. nil ⇒ route not mounted.
 	BillingWebhookH *billing.WebhookHandler
+	// PricingH serves the PUBLIC, unauthenticated live-pricing endpoint at
+	// GET /api/v1/pricing (internal/pricing) — the marketing site's price
+	// source. nil ⇒ route not mounted; wired only when WPMGR_HOSTED is
+	// enabled (see cmd/wpmgr/main.go), mirroring BillingH/BillingWebhookH's
+	// nil-when-unhosted convention exactly. Mounted directly on the root
+	// engine (not under the tenant-gated /api/v1 group) despite sharing its
+	// path prefix — see RegisterPublic.
+	PricingH *pricing.Handler
 	// BillingSuspensionGate is the M16 Phase C1 superadmin hard-lockout
 	// middleware (billing.Service.SuspensionGate) mounted on the tenant-scoped
 	// v1 group. nil ⇒ WPMGR_HOSTED is off; self-host never sees this check
@@ -304,6 +313,13 @@ func New(deps Deps) *Server {
 	// sessionAuthGroup (H2 note above).
 	if deps.BillingWebhookH != nil {
 		deps.BillingWebhookH.RegisterPublic(engine)
+	}
+
+	// M16 live-pricing Phase 1 — public GET /api/v1/pricing. No session, no
+	// tenant gate; mounted directly on the root engine like the webhook
+	// immediately above. nil ⇒ WPMGR_HOSTED is off; self-host 404s here.
+	if deps.PricingH != nil {
+		deps.PricingH.RegisterPublic(engine)
 	}
 
 	// Agent-authenticated endpoints: the agent authenticator verifies an Ed25519

--- a/apps/api/migrations/20260731000000_m98_desired_plan_verification_token.sql
+++ b/apps/api/migrations/20260731000000_m98_desired_plan_verification_token.sql
@@ -1,0 +1,28 @@
+-- m98: "sign up into a plan" Phase 0 — carry a chosen plan through self-serve
+-- signup + email verification so the web app can auto-start checkout right
+-- after the account is verified.
+--
+-- desired_plan is a nullable hint captured on the email-verification token
+-- row at registration time (validated against internal/billing's plan
+-- ladder in Go — this column itself is intentionally vendor/vocabulary
+-- neutral, just text). It rides the same single-use/TTL lifecycle as the
+-- token: VerifyEmail reads it off the row it just consumed and surfaces it in
+-- the response, at which point it is gone with the token. Storing it here
+-- (not on users) keeps it naturally scoped to one registration attempt.
+--
+-- Mirrors m97's exact idempotent add-column style (information_schema.columns
+-- existence check inside a DO $$ block) so this migration is safe to re-run.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name   = 'email_verification_tokens'
+          AND column_name  = 'desired_plan'
+    ) THEN
+        ALTER TABLE "public"."email_verification_tokens"
+            ADD COLUMN "desired_plan" text;
+    END IF;
+END;
+$$;

--- a/apps/api/tests/auth_plan_intent_integration_test.go
+++ b/apps/api/tests/auth_plan_intent_integration_test.go
@@ -1,0 +1,376 @@
+// auth_plan_intent_integration_test.go — M16 "sign up into a plan" Phase 0.
+//
+// Covers: a validated paid-tier hint survives self-serve registration on the
+// email-verification token, is surfaced (and consumed) exactly once by
+// VerifyEmail, a resend carries the same intent forward onto its new token,
+// a non-paid-tier hint (free/unknown/empty, or no validator wired at all —
+// the self-host shape) is never persisted, and the first-run bootstrap path
+// echoes a validated hint straight back in its immediate-session response.
+package tests
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/auth"
+	"github.com/mosamlife/wpmgr/apps/api/internal/billing"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// newAuthStackWithBilling builds an auth.Service wired to a REAL hosted
+// billing.Service as its PaidTierValidator (mirrors newAuthStack in
+// auth_integration_test.go, plus the M16 Phase 0 wiring cmd/wpmgr performs).
+func newAuthStackWithBilling(pool *db.Pool) *auth.Service {
+	svc, _ := newAuthStack(pool)
+	svc.SetPlanValidator(newHostedBillingService(pool, true))
+	return svc
+}
+
+// capturingMailer is a minimal auth.EmailEnqueuer double that records the
+// data map of the most recent Enqueue call, so a test can pull the raw
+// verification token out of the rendered VerifyURL without needing River or
+// a real mailer.
+type capturingMailer struct {
+	lastData map[string]any
+}
+
+func (m *capturingMailer) Enqueue(_ context.Context, _ uuid.UUID, _ []string, _ string, data map[string]any) error {
+	m.lastData = data
+	return nil
+}
+
+// rawTokenFromVerifyURL extracts the ?token= query parameter a captured
+// verify_email VerifyURL carries.
+func rawTokenFromVerifyURL(t *testing.T, verifyURL string) string {
+	t.Helper()
+	u, err := url.Parse(verifyURL)
+	if err != nil {
+		t.Fatalf("parse VerifyURL %q: %v", verifyURL, err)
+	}
+	tok := u.Query().Get("token")
+	if tok == "" {
+		t.Fatalf("VerifyURL %q carried no token", verifyURL)
+	}
+	return tok
+}
+
+// desiredPlanForUser reads back the most recent desired_plan captured across
+// a user's verification tokens directly from Postgres — a white-box check
+// that registration persisted the intent SERVER-SIDE (on the token row),
+// independent of anything the Service surfaces back to a caller.
+func desiredPlanForUser(t *testing.T, pool *db.Pool, userID uuid.UUID) *string {
+	t.Helper()
+	var plan *string
+	err := pool.InAgentTx(context.Background(), func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT desired_plan FROM email_verification_tokens
+			 WHERE user_id = $1 ORDER BY created_at DESC LIMIT 1`,
+			userID,
+		).Scan(&plan)
+	})
+	if err != nil {
+		t.Fatalf("read back desired_plan for user %s: %v", userID, err)
+	}
+	return plan
+}
+
+func makeCreateTenant(t *testing.T, pool *db.Pool) func(ctx context.Context, name, slug string) (uuid.UUID, error) {
+	return func(ctx context.Context, name, slug string) (uuid.UUID, error) {
+		return seedTenant(t, pool, slug), nil
+	}
+}
+
+// TestRegisterSelfServe_PersistsDesiredPlanOnToken proves a validated paid-tier
+// hint lands on the verification-token row created by registration.
+func TestRegisterSelfServe_PersistsDesiredPlanOnToken(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	svc := newAuthStackWithBilling(pool)
+	repo := auth.NewRepo(pool)
+	createTenant := makeCreateTenant(t, pool)
+
+	const email = "plan-agency-signup@example.com"
+	if err := svc.RegisterSelfServe(ctx, auth.RegisterInput{
+		Email:    email,
+		Password: "a-very-strong-password",
+		Name:     "Agency Signup",
+		Plan:     string(billing.TierAgency),
+	}, createTenant); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	u, err := repo.GetUserByEmail(ctx, email)
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if u.Status != "pending" {
+		t.Fatalf("status = %q, want pending", u.Status)
+	}
+
+	got := desiredPlanForUser(t, pool, u.ID)
+	if got == nil {
+		t.Fatal("desired_plan on the verification token is NULL, want the agency tier")
+	}
+	if *got != string(billing.TierAgency) {
+		t.Fatalf("desired_plan = %q, want %q", *got, billing.TierAgency)
+	}
+}
+
+// TestRegisterSelfServe_NonPaidPlanHintsAreIgnored proves free, unknown, and
+// absent plan hints never persist a desired_plan — "no intent" is the only
+// correct outcome for each.
+func TestRegisterSelfServe_NonPaidPlanHintsAreIgnored(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	svc := newAuthStackWithBilling(pool)
+	repo := auth.NewRepo(pool)
+	createTenant := makeCreateTenant(t, pool)
+
+	cases := []struct {
+		name  string
+		email string
+		plan  string
+	}{
+		{"free tier is not an intent", "plan-free-signup@example.com", string(billing.TierFree)},
+		{"unrecognized value", "plan-bogus-signup@example.com", "not-a-real-tier"},
+		{"absent field", "plan-absent-signup@example.com", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := svc.RegisterSelfServe(ctx, auth.RegisterInput{
+				Email:    tc.email,
+				Password: "a-very-strong-password",
+				Name:     "Signup",
+				Plan:     tc.plan,
+			}, createTenant); err != nil {
+				t.Fatalf("register: %v", err)
+			}
+			u, err := repo.GetUserByEmail(ctx, tc.email)
+			if err != nil {
+				t.Fatalf("get user: %v", err)
+			}
+			if got := desiredPlanForUser(t, pool, u.ID); got != nil {
+				t.Fatalf("desired_plan = %q, want NULL (no intent)", *got)
+			}
+		})
+	}
+}
+
+// TestRegisterSelfServe_NoPlanValidatorMeansNoIntent proves the self-host
+// shape (no PaidTierValidator ever wired, i.e. Service.SetPlanValidator never
+// called) is exactly as safe as an explicit free/unknown hint: a plan value
+// is silently dropped rather than persisted.
+func TestRegisterSelfServe_NoPlanValidatorMeansNoIntent(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	svc, _ := newAuthStack(pool) // no SetPlanValidator call — mirrors self-host boot
+	repo := auth.NewRepo(pool)
+	createTenant := makeCreateTenant(t, pool)
+
+	const email = "plan-selfhost-signup@example.com"
+	if err := svc.RegisterSelfServe(ctx, auth.RegisterInput{
+		Email:    email,
+		Password: "a-very-strong-password",
+		Name:     "Self-host Signup",
+		Plan:     string(billing.TierAgency),
+	}, createTenant); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	u, err := repo.GetUserByEmail(ctx, email)
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if got := desiredPlanForUser(t, pool, u.ID); got != nil {
+		t.Fatalf("desired_plan = %q, want NULL (no validator wired => no intent)", *got)
+	}
+}
+
+// TestVerifyEmail_SurfacesAndConsumesDesiredPlan proves VerifyEmail reads the
+// desired_plan off the token it just consumed, returns it exactly once, and
+// that the token cannot be replayed to read it (or anything else) again.
+func TestVerifyEmail_SurfacesAndConsumesDesiredPlan(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	svc := newAuthStackWithBilling(pool)
+	createTenant := makeCreateTenant(t, pool)
+
+	mailer := &capturingMailer{}
+	svc.SetMailer(mailer, "https://manage.example.test", nil)
+
+	const email = "plan-starter-verify@example.com"
+	if err := svc.RegisterSelfServe(ctx, auth.RegisterInput{
+		Email:    email,
+		Password: "a-very-strong-password",
+		Name:     "Starter Signup",
+		Plan:     string(billing.TierStarter),
+	}, createTenant); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if mailer.lastData == nil {
+		t.Fatal("no verification email was enqueued")
+	}
+	verifyURL, _ := mailer.lastData["VerifyURL"].(string)
+	token := rawTokenFromVerifyURL(t, verifyURL)
+
+	res, err := svc.VerifyEmail(ctx, token)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if res.DesiredPlan != string(billing.TierStarter) {
+		t.Fatalf("VerifyEmail DesiredPlan = %q, want %q", res.DesiredPlan, billing.TierStarter)
+	}
+	if res.User.Email != email {
+		t.Fatalf("verified the wrong user: %q", res.User.Email)
+	}
+
+	// Single-use: the SAME token must never verify (or surface a plan) again.
+	if _, err := svc.VerifyEmail(ctx, token); err == nil {
+		t.Fatal("replaying a consumed verification token should fail")
+	} else if de, ok := domain.AsDomain(err); !ok || de.Kind != domain.KindGone {
+		t.Fatalf("want Gone on replay, got %v", err)
+	}
+
+	// The intent is gone with the token: nothing left to look up for this user.
+	if got := desiredPlanForUser(t, pool, res.User.ID); got == nil || *got != string(billing.TierStarter) {
+		t.Fatalf("desired_plan on the (now-consumed) token = %v, want it to still read back %q (row persists, only used_at flips)", got, billing.TierStarter)
+	}
+}
+
+// TestVerifyEmail_NoIntentReturnsEmpty proves an ordinary (no plan hint)
+// registration's verification response carries no desired_plan.
+func TestVerifyEmail_NoIntentReturnsEmpty(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	svc := newAuthStackWithBilling(pool)
+	createTenant := makeCreateTenant(t, pool)
+
+	mailer := &capturingMailer{}
+	svc.SetMailer(mailer, "https://manage.example.test", nil)
+
+	const email = "plan-none-verify@example.com"
+	if err := svc.RegisterSelfServe(ctx, auth.RegisterInput{
+		Email:    email,
+		Password: "a-very-strong-password",
+		Name:     "Ordinary Signup",
+	}, createTenant); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	token := rawTokenFromVerifyURL(t, mailer.lastData["VerifyURL"].(string))
+
+	res, err := svc.VerifyEmail(ctx, token)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if res.DesiredPlan != "" {
+		t.Fatalf("DesiredPlan = %q, want empty for an ordinary signup", res.DesiredPlan)
+	}
+}
+
+// TestResendVerification_CarriesForwardDesiredPlan proves a resend (which
+// invalidates the original token and mints a new one) does not silently
+// lose the original plan intent.
+func TestResendVerification_CarriesForwardDesiredPlan(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	svc := newAuthStackWithBilling(pool)
+	repo := auth.NewRepo(pool)
+	createTenant := makeCreateTenant(t, pool)
+
+	mailer := &capturingMailer{}
+	svc.SetMailer(mailer, "https://manage.example.test", nil)
+
+	const email = "plan-scale-resend@example.com"
+	if err := svc.RegisterSelfServe(ctx, auth.RegisterInput{
+		Email:    email,
+		Password: "a-very-strong-password",
+		Name:     "Scale Signup",
+		Plan:     string(billing.TierScale),
+	}, createTenant); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	firstToken := rawTokenFromVerifyURL(t, mailer.lastData["VerifyURL"].(string))
+
+	if err := svc.ResendVerification(ctx, email); err != nil {
+		t.Fatalf("resend: %v", err)
+	}
+	secondToken := rawTokenFromVerifyURL(t, mailer.lastData["VerifyURL"].(string))
+	if secondToken == firstToken {
+		t.Fatal("resend should mint a NEW token, not reuse the original")
+	}
+
+	// The original token was invalidated by the resend.
+	if _, err := svc.VerifyEmail(ctx, firstToken); err == nil {
+		t.Fatal("the pre-resend token should no longer verify")
+	}
+
+	res, err := svc.VerifyEmail(ctx, secondToken)
+	if err != nil {
+		t.Fatalf("verify with the resent token: %v", err)
+	}
+	if res.DesiredPlan != string(billing.TierScale) {
+		t.Fatalf("DesiredPlan after resend = %q, want %q (carried forward)", res.DesiredPlan, billing.TierScale)
+	}
+
+	u, err := repo.GetUserByEmail(ctx, email)
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if u.Status != "active" {
+		t.Fatalf("status = %q, want active after verification", u.Status)
+	}
+}
+
+// TestBootstrap_SurfacesDesiredPlanImmediately proves the first-run bootstrap
+// path — which never touches the verification-token table at all, since it
+// issues an immediate session in the same request — still echoes a validated
+// plan hint straight back on its LoginResult.
+func TestBootstrap_SurfacesDesiredPlanImmediately(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	svc := newAuthStackWithBilling(pool)
+	createTenant := makeCreateTenant(t, pool)
+
+	res, err := svc.Bootstrap(ctx, auth.RegisterInput{
+		Email:    "first-admin@example.com",
+		Password: "a-very-strong-password",
+		Name:     "First Admin",
+		Plan:     string(billing.TierScale),
+	}, createTenant)
+	if err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	if res.DesiredPlan != string(billing.TierScale) {
+		t.Fatalf("Bootstrap DesiredPlan = %q, want %q", res.DesiredPlan, billing.TierScale)
+	}
+	if res.ActiveTenant == uuid.Nil {
+		t.Fatal("bootstrap did not set an active tenant")
+	}
+}
+
+// TestBootstrap_NonPaidPlanHintSurfacesEmpty proves a non-paid bootstrap hint
+// (free tier) resolves to no intent, same as self-serve registration — on a
+// SEPARATE fresh instance, since Bootstrap only ever succeeds once (count==0).
+func TestBootstrap_NonPaidPlanHintSurfacesEmpty(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	svc := newAuthStackWithBilling(pool)
+	createTenant := makeCreateTenant(t, pool)
+
+	res, err := svc.Bootstrap(ctx, auth.RegisterInput{
+		Email:    "first-admin@example.com",
+		Password: "a-very-strong-password",
+		Name:     "First Admin",
+		Plan:     string(billing.TierFree),
+	}, createTenant)
+	if err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	if res.DesiredPlan != "" {
+		t.Fatalf("Bootstrap DesiredPlan for a free hint = %q, want empty", res.DesiredPlan)
+	}
+}

--- a/apps/marketing/app/(marketing)/pricing/page.tsx
+++ b/apps/marketing/app/(marketing)/pricing/page.tsx
@@ -1,11 +1,13 @@
 // PricingPage: real, priced hosted tiers plus the permanent free self-host
 // option. Tier data lives in lib/content/pricing.ts so it is edited in one
-// place. SoftwareApplication JSON-LD lists every tier as a separate Offer.
+// place. Prices are fetched live from the CP at build time (SSG) via
+// lib/pricing-live.ts, with a static fallback if that fetch fails for any
+// reason -- see resolveTierPrices. SoftwareApplication JSON-LD lists every
+// tier as a separate Offer per currency it is actually priced in.
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Icon } from "@/components/ui/icon";
-import { Button } from "@/components/ui/button";
-import { Container, Section, SectionHeading, Card } from "@/components/ui/primitives";
+import { Container, Section, SectionHeading } from "@/components/ui/primitives";
 import { Reveal } from "@/components/motion/reveal";
 import { Stagger, StaggerItem } from "@/components/motion/stagger";
 import { FAQ } from "@/components/sections/faq";
@@ -13,8 +15,9 @@ import { CTABand } from "@/components/sections/cta-band";
 import { buildMetadata, buildFAQPageLd, buildBreadcrumbLd, buildSoftwareApplicationLd } from "@/lib/seo";
 import { JsonLd } from "@/lib/json-ld";
 import { SITE_CONFIG } from "@/lib/site";
-import { PRICING_TIERS, PRICING_NOTE, PRICING_FAQ, PRICING_CTAS } from "@/lib/content/pricing";
-import { cn } from "@/lib/utils";
+import { PRICING_TIERS, PRICING_NOTE, PRICING_FAQ, PRICING_CTAS, resolveTierPrices } from "@/lib/content/pricing";
+import { fetchLivePricing } from "@/lib/pricing-live";
+import { PricingTierCards } from "./pricing-tiers";
 
 export const metadata: Metadata = buildMetadata({
   title: "Pricing | WPMgr",
@@ -23,7 +26,10 @@ export const metadata: Metadata = buildMetadata({
   canonical: "/pricing/",
 });
 
-export default function PricingPage() {
+export default async function PricingPage() {
+  const livePricing = await fetchLivePricing();
+  const prices = resolveTierPrices(livePricing);
+
   const breadcrumbLd = buildBreadcrumbLd([
     { name: "Home", href: "/" },
     { name: "Pricing", href: "/pricing/" },
@@ -31,14 +37,32 @@ export default function PricingPage() {
 
   const appLd = {
     ...buildSoftwareApplicationLd(),
-    offers: PRICING_TIERS.map((tier) => ({
-      "@type": "Offer",
-      name: `${tier.name} plan`,
-      price: String(tier.price),
-      priceCurrency: "USD",
-      description: tier.audience,
-      url: `${SITE_CONFIG.baseUrl}/pricing/`,
-    })),
+    // One Offer per (tier, currency) actually priced -- USD always, INR only
+    // when the tier has a live INR quote (see TierDisplayPrice.inr).
+    offers: PRICING_TIERS.flatMap((tier) => {
+      const tierPrice = prices[tier.id];
+      const offers = [
+        {
+          "@type": "Offer",
+          name: `${tier.name} plan`,
+          price: String(tierPrice.usd.amountMajor),
+          priceCurrency: "USD",
+          description: tier.audience,
+          url: `${SITE_CONFIG.baseUrl}/pricing/`,
+        },
+      ];
+      if (tierPrice.inr) {
+        offers.push({
+          "@type": "Offer",
+          name: `${tier.name} plan`,
+          price: String(tierPrice.inr.amountMajor),
+          priceCurrency: "INR",
+          description: tier.audience,
+          url: `${SITE_CONFIG.baseUrl}/pricing/`,
+        });
+      }
+      return offers;
+    }),
   };
 
   const faqLd = buildFAQPageLd(PRICING_FAQ);
@@ -102,63 +126,7 @@ export default function PricingPage() {
       {/* Tier cards */}
       <Section id="tiers">
         <Container>
-          <Stagger className="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
-            {PRICING_TIERS.map((tier) => {
-              const trailing = tier.cta.icon === "ArrowRight";
-              return (
-                <StaggerItem key={tier.id} className="h-full">
-                  <Card
-                    className={cn(
-                      "flex h-full flex-col gap-5",
-                      tier.mostPopular && "border-[var(--primary)]/50 ring-1 ring-[var(--primary)]/20",
-                    )}
-                  >
-                    {tier.mostPopular ? (
-                      <span className="inline-flex self-start rounded-full bg-[var(--primary-subtle)] px-2.5 py-0.5 text-xs font-semibold text-[var(--primary-pressed)]">
-                        Most popular
-                      </span>
-                    ) : (
-                      <span className="h-[22px]" aria-hidden />
-                    )}
-                    <div>
-                      <h2 className="text-lg font-semibold text-foreground">{tier.name}</h2>
-                      <p className="mt-0.5 text-xs font-medium text-[var(--primary-pressed)] uppercase tracking-wide">
-                        {tier.audience}
-                      </p>
-                    </div>
-                    <div className="flex items-baseline gap-1">
-                      <span
-                        className="text-3xl font-semibold text-foreground"
-                        style={{ fontVariantNumeric: "tabular-nums" }}
-                      >
-                        ${tier.price}
-                      </span>
-                      <span className="text-sm text-[var(--muted-foreground)]">/mo</span>
-                    </div>
-                    <ul className="flex-1 space-y-2.5">
-                      {tier.features.map((f) => (
-                        <li key={f} className="flex items-start gap-2 text-sm text-foreground">
-                          <Icon name="Check" size={16} className="mt-0.5 shrink-0 text-[var(--primary)]" />
-                          <span>{f}</span>
-                        </li>
-                      ))}
-                    </ul>
-                    <Button
-                      href={tier.cta.href}
-                      variant={tier.cta.variant}
-                      size="md"
-                      target="_blank"
-                      rel="noreferrer noopener"
-                      className="w-full"
-                    >
-                      {tier.cta.label}
-                      {trailing ? <Icon name="ArrowRight" size={16} /> : null}
-                    </Button>
-                  </Card>
-                </StaggerItem>
-              );
-            })}
-          </Stagger>
+          <PricingTierCards prices={prices} />
 
           <Reveal delay={0.1}>
             <p className="mx-auto mt-8 max-w-2xl text-center text-sm leading-relaxed text-[var(--muted-foreground)]">

--- a/apps/marketing/app/(marketing)/pricing/pricing-tiers.tsx
+++ b/apps/marketing/app/(marketing)/pricing/pricing-tiers.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+// Interactive tier cards + USD/INR currency toggle. Split out from
+// page.tsx (a Server Component doing the build-time pricing fetch) because
+// the toggle is client-only display state -- both currencies are already
+// resolved server-side (see resolveTierPrices); switching currency here
+// never triggers a network request.
+
+import { useState } from "react";
+import { Icon } from "@/components/ui/icon";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/primitives";
+import { Stagger, StaggerItem } from "@/components/motion/stagger";
+import { cn } from "@/lib/utils";
+import {
+  PRICING_TIERS,
+  ctaHrefWithCurrency,
+  type BillingCurrency,
+  type PricingTier,
+  type TierDisplayPrice,
+} from "@/lib/content/pricing";
+
+const CURRENCY_OPTIONS: BillingCurrency[] = ["USD", "INR"];
+
+export function PricingTierCards({
+  prices,
+}: {
+  prices: Record<PricingTier["id"], TierDisplayPrice>;
+}) {
+  const [currency, setCurrency] = useState<BillingCurrency>("USD");
+
+  return (
+    <>
+      <div className="mb-8 flex flex-col items-center gap-2">
+        <span className="text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
+          Show prices in
+        </span>
+        <div
+          role="radiogroup"
+          aria-label="Currency"
+          className="inline-flex rounded-[var(--radius)] border border-[var(--border)] bg-card p-1 shadow-sm"
+        >
+          {CURRENCY_OPTIONS.map((option) => (
+            <button
+              key={option}
+              type="button"
+              role="radio"
+              aria-checked={currency === option}
+              onClick={() => setCurrency(option)}
+              className={cn(
+                "min-w-[4.5rem] rounded-[calc(var(--radius)-2px)] px-4 py-1.5 text-sm font-medium",
+                "transition-colors duration-[var(--duration-fast)]",
+                "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]",
+                currency === option
+                  ? "bg-primary text-[var(--primary-foreground)] shadow-sm"
+                  : "text-[var(--muted-foreground)] hover:text-foreground",
+              )}
+            >
+              {option}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <Stagger className="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+        {PRICING_TIERS.map((tier) => {
+          const trailing = tier.cta.icon === "ArrowRight";
+          const tierPrice = prices[tier.id];
+          const showInr = currency === "INR" && tierPrice.inr !== null;
+          const priceLabel = showInr && tierPrice.inr ? tierPrice.inr.label : tierPrice.usd.label;
+          const usdOnlyNote = tier.id !== "free" && currency === "INR" && tierPrice.inr === null;
+
+          return (
+            <StaggerItem key={tier.id} className="h-full">
+              <Card
+                className={cn(
+                  "flex h-full flex-col gap-5",
+                  tier.mostPopular && "border-[var(--primary)]/50 ring-1 ring-[var(--primary)]/20",
+                )}
+              >
+                {tier.mostPopular ? (
+                  <span className="inline-flex self-start rounded-full bg-[var(--primary-subtle)] px-2.5 py-0.5 text-xs font-semibold text-[var(--primary-pressed)]">
+                    Most popular
+                  </span>
+                ) : (
+                  <span className="h-[22px]" aria-hidden />
+                )}
+                <div>
+                  <h2 className="text-lg font-semibold text-foreground">{tier.name}</h2>
+                  <p className="mt-0.5 text-xs font-medium text-[var(--primary-pressed)] uppercase tracking-wide">
+                    {tier.audience}
+                  </p>
+                </div>
+                <div>
+                  <div className="flex items-baseline gap-1">
+                    <span
+                      className="text-3xl font-semibold text-foreground"
+                      style={{ fontVariantNumeric: "tabular-nums" }}
+                    >
+                      {priceLabel}
+                    </span>
+                    <span className="text-sm text-[var(--muted-foreground)]">/mo</span>
+                  </div>
+                  {usdOnlyNote ? (
+                    <p className="mt-1 text-xs text-[var(--muted-foreground)]">Billed in USD</p>
+                  ) : null}
+                </div>
+                <ul className="flex-1 space-y-2.5">
+                  {tier.features.map((f) => (
+                    <li key={f} className="flex items-start gap-2 text-sm text-foreground">
+                      <Icon name="Check" size={16} className="mt-0.5 shrink-0 text-[var(--primary)]" />
+                      <span>{f}</span>
+                    </li>
+                  ))}
+                </ul>
+                <Button
+                  href={ctaHrefWithCurrency(tier.cta, currency)}
+                  variant={tier.cta.variant}
+                  size="md"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="w-full"
+                >
+                  {tier.cta.label}
+                  {trailing ? <Icon name="ArrowRight" size={16} /> : null}
+                </Button>
+              </Card>
+            </StaggerItem>
+          );
+        })}
+      </Stagger>
+    </>
+  );
+}

--- a/apps/marketing/lib/content/pricing.ts
+++ b/apps/marketing/lib/content/pricing.ts
@@ -1,16 +1,28 @@
 // Pricing page content module. Tier data, FAQ, and supporting copy for
 // /pricing. House rules enforced by scripts/check-copy.mjs: no em dashes,
 // no en dashes, no competitor plugin names.
+//
+// Live prices (from GET /api/v1/pricing, fetched at build time in
+// app/(marketing)/pricing/page.tsx via lib/pricing-live.ts) override each
+// paid tier's `price` fallback below, per currency -- see resolveTierPrices.
 import type { Cta, FaqItem } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
+import type { LivePricingResponse, LiveTier } from "@/lib/pricing-live";
 
 export type PricingTier = {
   id: "free" | "starter" | "agency" | "scale";
   name: string;
+  /** Fallback USD dollars/month, used whenever live pricing is unresolved. */
   price: number;
   audience: string;
   mostPopular?: boolean;
   features: string[];
+  /**
+   * The paid tiers' href already carries `?plan=<id>` so the signup app
+   * knows which plan to preselect at checkout; the free tier's href stays a
+   * bare signup link. Use ctaHrefWithCurrency to also thread the currency
+   * toggle's selection through.
+   */
   cta: Cta;
 };
 
@@ -46,7 +58,7 @@ export const PRICING_TIERS: PricingTier[] = [
     ],
     cta: {
       label: "Start with Starter",
-      href: SITE_CONFIG.signup,
+      href: `${SITE_CONFIG.signup}?plan=starter`,
       variant: "secondary",
       icon: "ArrowRight",
     },
@@ -65,7 +77,7 @@ export const PRICING_TIERS: PricingTier[] = [
     ],
     cta: {
       label: "Start with Agency",
-      href: SITE_CONFIG.signup,
+      href: `${SITE_CONFIG.signup}?plan=agency`,
       variant: "primary",
       icon: "ArrowRight",
     },
@@ -83,7 +95,7 @@ export const PRICING_TIERS: PricingTier[] = [
     ],
     cta: {
       label: "Start with Scale",
-      href: SITE_CONFIG.signup,
+      href: `${SITE_CONFIG.signup}?plan=scale`,
       variant: "secondary",
       icon: "ArrowRight",
     },
@@ -124,3 +136,86 @@ export const PRICING_CTAS: Cta[] = [
   { label: "Get started for free", href: SITE_CONFIG.signup, variant: "primary", icon: "ArrowRight" },
   { label: "Star on GitHub", href: SITE_CONFIG.github, variant: "secondary", icon: "Github" },
 ];
+
+// ---------------------------------------------------------------------------
+// Live pricing: build-time merge of GET /api/v1/pricing (lib/pricing-live.ts)
+// with the static fallback amounts above, plus the USD/INR display toggle.
+// ---------------------------------------------------------------------------
+
+export type BillingCurrency = "USD" | "INR";
+
+export type CurrencyPrice = {
+  /** Major-unit amount (dollars/rupees) -- used for the JSON-LD Offer.price. */
+  amountMajor: number;
+  /** Human display label with currency symbol, e.g. "$15" or "₹1,249". */
+  label: string;
+};
+
+export type TierDisplayPrice = {
+  usd: CurrencyPrice;
+  /**
+   * Null when this tier has no live INR price: the free tier (never priced
+   * by a payment provider), a Stripe-only paid tier, or the fully-offline
+   * static fallback (which is USD-only, mirroring the CP's own
+   * staticFallbackJSON in apps/api/internal/pricing/service.go).
+   */
+  inr: CurrencyPrice | null;
+};
+
+const CURRENCY_SYMBOLS: Record<BillingCurrency, string> = {
+  USD: "$",
+  INR: "₹",
+};
+
+function formatMajorAmount(amountMinor: number, currency: BillingCurrency): string {
+  const major = amountMinor / 100;
+  const hasFraction = !Number.isInteger(major);
+  const formatted = major.toLocaleString(currency === "INR" ? "en-IN" : "en-US", {
+    minimumFractionDigits: hasFraction ? 2 : 0,
+    maximumFractionDigits: hasFraction ? 2 : 0,
+  });
+  return `${CURRENCY_SYMBOLS[currency]}${formatted}`;
+}
+
+function buildCurrencyPrice(amountMinor: number, currency: BillingCurrency): CurrencyPrice {
+  return { amountMajor: amountMinor / 100, label: formatMajorAmount(amountMinor, currency) };
+}
+
+/**
+ * Resolves each tier's display price from the live CP payload, falling back
+ * to this module's static PRICING_TIERS `price` (USD dollars) per tier
+ * whenever the live fetch failed entirely, or a specific tier was missing
+ * from the live response. Safe to call with `live: null` (the build-time
+ * fetch failure path) -- every tier then resolves to its static USD
+ * fallback with no INR price, which is exactly the CP's own offline
+ * behavior.
+ */
+export function resolveTierPrices(
+  live: LivePricingResponse | null,
+): Record<PricingTier["id"], TierDisplayPrice> {
+  const byId = new Map<string, LiveTier>((live?.tiers ?? []).map((t) => [t.id, t]));
+  const out = {} as Record<PricingTier["id"], TierDisplayPrice>;
+
+  for (const tier of PRICING_TIERS) {
+    const raw = byId.get(tier.id);
+    const fallbackMinor = Math.round(tier.price * 100);
+    const usdMinor =
+      tier.id === "free" ? (raw?.amount ?? fallbackMinor) : (raw?.usd?.amount ?? fallbackMinor);
+    const inr = tier.id !== "free" && raw?.inr ? buildCurrencyPrice(raw.inr.amount, "INR") : null;
+
+    out[tier.id] = { usd: buildCurrencyPrice(usdMinor, "USD"), inr };
+  }
+
+  return out;
+}
+
+/**
+ * Appends `&currency=<currency>` to a paid tier's signup CTA href so the
+ * checkout defaults to whichever currency is selected on the page. The free
+ * tier's href never carries `?plan=`, so it is returned unchanged -- the
+ * free lane stays a bare signup link regardless of the currency toggle.
+ */
+export function ctaHrefWithCurrency(cta: Cta, currency: BillingCurrency): string {
+  if (!cta.href.includes("?")) return cta.href;
+  return `${cta.href}&currency=${currency}`;
+}

--- a/apps/marketing/lib/pricing-live.ts
+++ b/apps/marketing/lib/pricing-live.ts
@@ -1,0 +1,116 @@
+// Build-time (SSG) fetch of the control plane's public pricing endpoint
+// (GET /api/v1/pricing). This is SERVER-ONLY: it runs once, at `next build`,
+// when the /pricing page is statically rendered -- never in the browser, so
+// there is no runtime network dependency for a visitor and no CSP concern.
+//
+// Every failure mode (network error, non-2xx status, unexpected JSON shape,
+// or a slow/unreachable host) resolves to `null` so the caller
+// (lib/content/pricing.ts's resolveTierPrices) can always fall back to the
+// static PRICING_TIERS amounts -- the marketing build must never fail or
+// hang because the control plane is unreachable.
+
+const DEFAULT_API_URL = "https://manage.wpmgr.app";
+const FETCH_TIMEOUT_MS = 5000;
+
+/** One concrete, live price point in the currency's smallest unit (cents/paise). */
+export type LivePriceQuote = {
+  amount: number;
+  currency: string;
+  interval: string;
+};
+
+/**
+ * One tier entry as served by GET /api/v1/pricing. The free tier uses the
+ * flat `amount`/`currency`/`interval` fields; a paid tier uses the nested
+ * `usd`/`inr` sub-objects (only the currencies this instance actually
+ * resolved a live price for -- see apps/api/internal/pricing/service.go's
+ * TierPricing.MarshalJSON).
+ */
+export type LiveTier = {
+  id: string;
+  amount?: number;
+  currency?: string;
+  interval?: string;
+  usd?: LivePriceQuote;
+  inr?: LivePriceQuote;
+};
+
+export type LivePricingResponse = {
+  currency_default: string;
+  tiers: LiveTier[];
+};
+
+function isQuote(value: unknown): value is LivePriceQuote {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.amount === "number" &&
+    typeof v.currency === "string" &&
+    typeof v.interval === "string"
+  );
+}
+
+function isTier(value: unknown): value is LiveTier {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.id !== "string") return false;
+  if (v.amount !== undefined && typeof v.amount !== "number") return false;
+  if (v.currency !== undefined && typeof v.currency !== "string") return false;
+  if (v.interval !== undefined && typeof v.interval !== "string") return false;
+  if (v.usd !== undefined && !isQuote(v.usd)) return false;
+  if (v.inr !== undefined && !isQuote(v.inr)) return false;
+  return true;
+}
+
+function isPricingResponse(value: unknown): value is LivePricingResponse {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.currency_default === "string" &&
+    Array.isArray(v.tiers) &&
+    v.tiers.every(isTier)
+  );
+}
+
+/**
+ * Fetches GET /api/v1/pricing from WPMGR_API_URL (default
+ * https://manage.wpmgr.app) at build time. Returns `null` on any failure --
+ * network error, non-2xx status, unexpected JSON shape, or a host that does
+ * not answer within FETCH_TIMEOUT_MS -- so the caller can fall back to
+ * static pricing without ever failing or hanging the build.
+ */
+export async function fetchLivePricing(): Promise<LivePricingResponse | null> {
+  const apiUrl = process.env.WPMGR_API_URL || DEFAULT_API_URL;
+  try {
+    // No `cache: "no-store"` here on purpose: this fetch must stay
+    // cacheable so Next treats /pricing as a fully static route rendered
+    // once at build time (SSG), not a per-request dynamic route. A
+    // no-store/uncached fetch during static generation makes Next bail the
+    // whole route to server-rendered-on-demand, which would turn every
+    // production page view into a live call to the CP instead of a
+    // baked-at-build-time price.
+    const res = await fetch(`${apiUrl}/api/v1/pricing`, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      console.warn(
+        `pricing: GET ${apiUrl}/api/v1/pricing returned ${res.status}, using static fallback prices`,
+      );
+      return null;
+    }
+    const json: unknown = await res.json();
+    if (!isPricingResponse(json)) {
+      console.warn(
+        "pricing: unexpected /api/v1/pricing response shape, using static fallback prices",
+      );
+      return null;
+    }
+    return json;
+  } catch (err) {
+    console.warn(
+      "pricing: /api/v1/pricing fetch failed, using static fallback prices",
+      err,
+    );
+    return null;
+  }
+}

--- a/apps/web/src/features/billing/checkout-return-banner.tsx
+++ b/apps/web/src/features/billing/checkout-return-banner.tsx
@@ -1,0 +1,65 @@
+import { CircleCheck, Loader2 } from "lucide-react";
+
+// M16 Phase B/C — the checkout-return status banner shared by every surface
+// that drives `useBillingCheckoutReturn` (`/settings/billing` and
+// `/welcome/checkout`). Extracted verbatim out of billing.tsx's former
+// private `CheckoutReturnBanner` — a pure lift, not a behavior change (see
+// -billing.test.tsx, still green).
+
+export function CheckoutReturnBanner({
+  status,
+  finalizing,
+  timedOut,
+}: {
+  status: "success" | "cancel" | undefined;
+  finalizing: boolean;
+  timedOut: boolean;
+}) {
+  if (!status) return null;
+
+  if (status === "cancel") {
+    return (
+      <div
+        role="status"
+        className="rounded-lg border border-border bg-muted/40 px-4 py-3 text-sm text-muted-foreground"
+      >
+        Checkout was canceled. No changes were made to your plan.
+      </div>
+    );
+  }
+
+  if (finalizing) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex items-center gap-2 rounded-lg border border-border bg-muted/40 px-4 py-3 text-sm text-foreground"
+      >
+        <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+        Finalizing your subscription…
+      </div>
+    );
+  }
+
+  if (timedOut) {
+    return (
+      <div
+        role="status"
+        className="rounded-lg border border-border bg-muted/40 px-4 py-3 text-sm text-muted-foreground"
+      >
+        Payment received. It can take a few minutes for your plan to update
+        here.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="status"
+      className="flex items-center gap-2 rounded-lg bg-[var(--color-success-subtle)] px-4 py-3 text-sm text-[var(--color-success-subtle-fg)]"
+    >
+      <CircleCheck aria-hidden="true" className="size-4" />
+      Subscription updated.
+    </div>
+  );
+}

--- a/apps/web/src/features/billing/payment-method-picker.tsx
+++ b/apps/web/src/features/billing/payment-method-picker.tsx
@@ -1,0 +1,56 @@
+import { SegmentedControl } from "@/components/ui/segmented-control";
+
+import type { BillingCurrency, BillingProvider } from "./use-billing";
+
+// M16 Phase B/C — the provider (Stripe/Razorpay) + Razorpay-only currency
+// picker shared by every checkout surface (`/settings/billing`'s
+// `PlanTiersGrid` and `/welcome/checkout`'s post-verify screen). Extracted
+// verbatim out of billing.tsx's former private `PaymentMethodPicker` — a pure
+// lift, not a behavior change (see -billing.test.tsx, still green).
+
+export function PaymentMethodPicker({
+  provider,
+  onProviderChange,
+  currency,
+  onCurrencyChange,
+}: {
+  provider: BillingProvider;
+  onProviderChange: (provider: BillingProvider) => void;
+  currency: BillingCurrency;
+  onCurrencyChange: (currency: BillingCurrency) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-4 rounded-lg border border-border bg-muted/20 px-4 py-3 text-sm">
+      <div className="flex items-center gap-2">
+        <span className="font-medium text-foreground">Pay via</span>
+        <SegmentedControl
+          aria-label="Payment provider"
+          value={provider}
+          onChange={onProviderChange}
+          options={[
+            { value: "stripe", label: "Stripe" },
+            { value: "razorpay", label: "Razorpay" },
+          ]}
+        />
+      </div>
+      {provider === "razorpay" ? (
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-foreground">Currency</span>
+          <SegmentedControl
+            aria-label="Currency"
+            value={currency}
+            onChange={onCurrencyChange}
+            options={[
+              { value: "USD", label: "USD ($)" },
+              { value: "INR", label: "INR (₹)" },
+            ]}
+          />
+          <span className="text-xs text-muted-foreground">
+            Prices below are shown in USD; the exact INR amount is confirmed
+            in the payment window before you pay.
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/billing/pending-plan.test.ts
+++ b/apps/web/src/features/billing/pending-plan.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { stashPendingPlan, readPendingPlan, clearPendingPlan } from "./pending-plan";
+
+// M16 Phase C2 — the same-browser fast path for a plan chosen at
+// /register?plan=... . Pure storage-boundary coverage: no React, no router.
+
+function clearAllStorage() {
+  window.localStorage.clear();
+  document.cookie = "wpmgr_pending_plan=; max-age=0; path=/";
+}
+
+beforeEach(() => {
+  clearAllStorage();
+});
+
+describe("stashPendingPlan / readPendingPlan / clearPendingPlan", () => {
+  it("round-trips a stashed plan through localStorage", () => {
+    stashPendingPlan({ plan: "agency", currency: "INR" });
+
+    expect(readPendingPlan()).toEqual({ plan: "agency", currency: "INR" });
+  });
+
+  it("round-trips a stashed plan with no currency", () => {
+    stashPendingPlan({ plan: "starter" });
+
+    expect(readPendingPlan()).toEqual({ plan: "starter" });
+  });
+
+  it("also writes a cookie fallback (readable even if localStorage is cleared, matching a real private-mode fallback)", () => {
+    stashPendingPlan({ plan: "scale", currency: "USD" });
+    window.localStorage.clear();
+
+    expect(readPendingPlan()).toEqual({ plan: "scale", currency: "USD" });
+  });
+
+  it("returns null when nothing was ever stashed", () => {
+    expect(readPendingPlan()).toBeNull();
+  });
+
+  it("clearPendingPlan removes both the localStorage entry and the cookie", () => {
+    stashPendingPlan({ plan: "agency" });
+    expect(readPendingPlan()).not.toBeNull();
+
+    clearPendingPlan();
+
+    expect(readPendingPlan()).toBeNull();
+    expect(window.localStorage.getItem("wpmgr_pending_plan")).toBeNull();
+    expect(document.cookie).not.toContain("wpmgr_pending_plan=");
+  });
+
+  it("ignores a corrupt localStorage value rather than throwing", () => {
+    window.localStorage.setItem("wpmgr_pending_plan", "{not json");
+
+    expect(readPendingPlan()).toBeNull();
+  });
+
+  it("ignores a stashed value naming an unknown plan (defensive against a future/stale format)", () => {
+    window.localStorage.setItem(
+      "wpmgr_pending_plan",
+      JSON.stringify({ plan: "enterprise" }),
+    );
+
+    expect(readPendingPlan()).toBeNull();
+  });
+});

--- a/apps/web/src/features/billing/pending-plan.ts
+++ b/apps/web/src/features/billing/pending-plan.ts
@@ -1,0 +1,108 @@
+import { CHECKOUT_TIER_IDS, BILLING_CURRENCIES } from "./plan-catalog";
+import type { BillingCurrency, CheckoutTierId } from "./use-billing";
+
+// M16 Phase C2 — signup-to-premium (WPMgr, not to be confused with any
+// third-party "premium" naming): a same-browser fast path for the plan
+// chosen at `/register?plan=...`.
+//
+// The CANONICAL carrier of the chosen plan is always the backend:
+// `RegisterRequest.plan` is persisted against the email-verification token
+// and surfaced back as `Me.desired_plan` once verified (or immediately on
+// the first-run bootstrap path) — see use-auth.ts's `useRegister` /
+// `useVerifyEmail`. This stash is ONLY a convenience layered on top of that:
+//   - `/register`'s "check your email" branch stashes the plan so a same
+//     browser opening the verification link in a new tab can still recover a
+//     `?currency=` hint the backend response doesn't carry.
+//   - `/welcome/checkout` falls back to it when its own `?plan=` URL param is
+//     missing (e.g. a bookmarked/retried link).
+//
+// Never treated as authoritative for WHETHER to start a checkout — only
+// `Me.desired_plan` + `Me.hosted` decide that (see verify-email.tsx /
+// register.tsx). Both localStorage and a short-lived first-party cookie are
+// written so the read side has a fallback if either storage mechanism is
+// blocked (private browsing, cookie-only, etc).
+
+const STORAGE_KEY = "wpmgr_pending_plan";
+const COOKIE_NAME = "wpmgr_pending_plan";
+// Long enough to open a verification email and click through, short enough
+// that a stale, abandoned signup intent does not linger indefinitely.
+const COOKIE_MAX_AGE_SECONDS = 60 * 60;
+
+export interface PendingPlan {
+  plan: CheckoutTierId;
+  currency?: BillingCurrency;
+}
+
+function isPendingPlan(value: unknown): value is PendingPlan {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  const planOk =
+    typeof v.plan === "string" &&
+    (CHECKOUT_TIER_IDS as readonly string[]).includes(v.plan);
+  const currencyOk =
+    v.currency === undefined ||
+    (typeof v.currency === "string" &&
+      (BILLING_CURRENCIES as readonly string[]).includes(v.currency));
+  return planOk && currencyOk;
+}
+
+/** Stash the chosen plan for the same-browser fast path. Best-effort; never throws. */
+export function stashPendingPlan(pending: PendingPlan): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(pending));
+  } catch {
+    // localStorage blocked (e.g. private mode with storage denied) — the
+    // cookie below is the fallback read path.
+  }
+  try {
+    const value = encodeURIComponent(JSON.stringify(pending));
+    document.cookie = `${COOKIE_NAME}=${value}; max-age=${COOKIE_MAX_AGE_SECONDS}; path=/; SameSite=Lax`;
+  } catch {
+    // document.cookie can throw under some privacy settings — best effort only.
+  }
+}
+
+/** Read the stashed plan, if any. localStorage first, cookie fallback. */
+export function readPendingPlan(): PendingPlan | null {
+  return readFromLocalStorage() ?? readFromCookie();
+}
+
+/** Clear the stash — call once a checkout has started, or the user skips. */
+export function clearPendingPlan(): void {
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore — nothing to clean up if it was never written.
+  }
+  try {
+    document.cookie = `${COOKIE_NAME}=; max-age=0; path=/; SameSite=Lax`;
+  } catch {
+    // ignore
+  }
+}
+
+function readFromLocalStorage(): PendingPlan | null {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    return isPendingPlan(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function readFromCookie(): PendingPlan | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${COOKIE_NAME}=`));
+  if (!match) return null;
+  try {
+    const raw = decodeURIComponent(match.slice(COOKIE_NAME.length + 1));
+    const parsed: unknown = JSON.parse(raw);
+    return isPendingPlan(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/features/billing/plan-catalog.ts
+++ b/apps/web/src/features/billing/plan-catalog.ts
@@ -1,4 +1,4 @@
-import type { BillingPlanId } from "./use-billing";
+import type { BillingCurrency, BillingPlanId, CheckoutTierId } from "./use-billing";
 
 // The four hosted-SaaS tiers, in ascending order. Presentational catalog
 // data (marketing copy) for the pricing cards — independent of the backend's
@@ -56,6 +56,26 @@ export const PLAN_ORDER: readonly BillingPlanId[] = [
   "agency",
   "scale",
 ];
+
+/**
+ * The three paid tiers a checkout can ever target (same set as
+ * `CheckoutTierId`, spelled out as a plain array for call sites that need to
+ * check membership at runtime rather than the type alone — e.g. parsing a
+ * `?plan=` URL search param or a localStorage stash, see
+ * features/billing/pending-plan.ts and routes/register.tsx /
+ * routes/_authed/welcome.checkout.tsx). Zod's `z.enum()` needs a literal
+ * tuple rather than a `readonly T[]` (see the identical note in
+ * routes/_authed/admin/accounts/index.tsx), so the search-schema call sites
+ * still spell the literal tuple inline — keep both in sync with this array.
+ */
+export const CHECKOUT_TIER_IDS: readonly CheckoutTierId[] = [
+  "starter",
+  "agency",
+  "scale",
+];
+
+/** The two currencies a checkout can be started in (Razorpay-only; see `BillingCurrency`). */
+export const BILLING_CURRENCIES: readonly BillingCurrency[] = ["USD", "INR"];
 
 export function planRank(id: BillingPlanId): number {
   return PLAN_ORDER.indexOf(id);

--- a/apps/web/src/features/billing/use-checkout-flow.test.ts
+++ b/apps/web/src/features/billing/use-checkout-flow.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { UseMutationResult } from "@tanstack/react-query";
+
+import { mockMutationResult } from "@/test/query-mocks";
+import { toast } from "@/components/toast";
+
+import { useCheckoutFlow } from "./use-checkout-flow";
+import {
+  useCreateBillingCheckout,
+  useVerifyRazorpayCheckout,
+  type CheckoutResult,
+  type CreateCheckoutVariables,
+  type VerifyCheckoutResult,
+  type RazorpayCheckoutSuccess,
+} from "./use-billing";
+import {
+  loadRazorpayCheckout,
+  type RazorpayCheckoutOptions,
+  type RazorpayInstance,
+} from "./razorpay-checkout";
+
+// Phase C prep — a direct, hook-only regression lock for `useCheckoutFlow`,
+// the exact machinery `PlanTiersGrid` (routes/_authed/settings/billing.tsx)
+// calls today and the Phase C post-verify upgrade screen will call next.
+// Mirrors ../../routes/_authed/settings/-billing.test.tsx's Stripe/Razorpay
+// assertions but at the hook boundary, with no route/page chrome in the way,
+// so a future consumer of this hook can trust this file alone as the
+// contract without re-deriving it from the billing page's DOM.
+
+vi.mock("./use-billing", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./use-billing")>();
+  return {
+    ...actual,
+    useCreateBillingCheckout: vi.fn(),
+    useVerifyRazorpayCheckout: vi.fn(),
+  };
+});
+
+vi.mock("./razorpay-checkout", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./razorpay-checkout")>();
+  return { ...actual, loadRazorpayCheckout: vi.fn() };
+});
+
+vi.mock("@/components/toast", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/toast")>();
+  return {
+    ...actual,
+    toast: { ...actual.toast, success: vi.fn(), error: vi.fn() },
+  };
+});
+
+const mockedUseCreateBillingCheckout = vi.mocked(useCreateBillingCheckout);
+const mockedUseVerifyRazorpayCheckout = vi.mocked(useVerifyRazorpayCheckout);
+const mockedLoadRazorpayCheckout = vi.mocked(loadRazorpayCheckout);
+const mockedToastError = vi.mocked(toast.error);
+
+/** Same pattern as -billing.test.tsx's own helper: a `mutate` spy that
+ *  synchronously invokes the caller's `onSuccess` with `result`. Narrow cast
+ *  at the mock boundary — the mock only implements the 1-arg `onSuccess`
+ *  callback shape the hook actually calls, not TanStack Query's full 4-arg
+ *  `MutateOptions` signature. */
+function fireOnSuccess<TData, TVariables = unknown>(
+  result: TData,
+): UseMutationResult<TData, Error, TVariables>["mutate"] {
+  const mutate = vi.fn(
+    (_vars: TVariables, opts?: { onSuccess?: (result: TData) => void }) => {
+      opts?.onSuccess?.(result);
+    },
+  );
+  return mutate as UseMutationResult<TData, Error, TVariables>["mutate"];
+}
+
+/** Same idea, but for a mutation whose caller only reads `onSettled`. */
+function fireOnSettled<TData, TVariables = unknown>(): UseMutationResult<
+  TData,
+  Error,
+  TVariables
+>["mutate"] {
+  const mutate = vi.fn(
+    (_vars: TVariables, opts?: { onSettled?: () => void }) => {
+      opts?.onSettled?.();
+    },
+  );
+  return mutate as UseMutationResult<TData, Error, TVariables>["mutate"];
+}
+
+let capturedRazorpayOptions: RazorpayCheckoutOptions | null = null;
+const razorpayOpenMock = vi.fn();
+
+class FakeRazorpay implements RazorpayInstance {
+  constructor(options: RazorpayCheckoutOptions) {
+    capturedRazorpayOptions = options;
+  }
+  open = razorpayOpenMock;
+}
+
+const originalLocation = window.location;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedRazorpayOptions = null;
+  mockedLoadRazorpayCheckout.mockResolvedValue(FakeRazorpay);
+  mockedUseVerifyRazorpayCheckout.mockReturnValue(
+    mockMutationResult<VerifyCheckoutResult, RazorpayCheckoutSuccess>({}),
+  );
+
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    writable: true,
+    value: { ...originalLocation, href: "" },
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    writable: true,
+    value: originalLocation,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stripe path
+// ---------------------------------------------------------------------------
+
+describe("useCheckoutFlow — Stripe path", () => {
+  it("defaults to provider 'stripe', posts { tier, provider: 'stripe' } with no currency, and redirects the browser to the returned URL", () => {
+    const mutateMock = fireOnSuccess<CheckoutResult, CreateCheckoutVariables>({
+      url: "https://checkout.stripe.com/session/abc",
+    });
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+    const onCheckoutSuccess = vi.fn();
+
+    const { result } = renderHook(() => useCheckoutFlow({ onCheckoutSuccess }));
+
+    expect(result.current.provider).toBe("stripe");
+    expect(result.current.currency).toBe("USD");
+
+    act(() => {
+      result.current.startCheckout("starter");
+    });
+
+    expect(mutateMock).toHaveBeenCalledWith(
+      { tier: "starter", provider: "stripe", currency: undefined },
+      expect.anything(),
+    );
+    expect(window.location.href).toBe("https://checkout.stripe.com/session/abc");
+    // The Razorpay loader must never even be consulted on the Stripe path.
+    expect(mockedLoadRazorpayCheckout).not.toHaveBeenCalled();
+    expect(onCheckoutSuccess).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Razorpay path
+// ---------------------------------------------------------------------------
+
+describe("useCheckoutFlow — Razorpay path", () => {
+  it("posts the selected provider/currency, opens the Checkout.js modal with the subscription's key/id/amount/currency, and on handler success verifies then calls onCheckoutSuccess", async () => {
+    const mutateMock = fireOnSuccess<CheckoutResult, CreateCheckoutVariables>({
+      razorpay: {
+        subscription_id: "sub_123",
+        key_id: "rzp_test_456",
+        currency: "INR",
+        amount: 120000,
+      },
+    });
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+    const verifyMutateMock = fireOnSettled<VerifyCheckoutResult, RazorpayCheckoutSuccess>();
+    mockedUseVerifyRazorpayCheckout.mockReturnValue(
+      mockMutationResult<VerifyCheckoutResult, RazorpayCheckoutSuccess>({
+        mutate: verifyMutateMock,
+      }),
+    );
+    const onCheckoutSuccess = vi.fn();
+
+    const { result } = renderHook(() => useCheckoutFlow({ onCheckoutSuccess }));
+
+    act(() => result.current.setProvider("razorpay"));
+    act(() => result.current.setCurrency("INR"));
+    act(() => result.current.startCheckout("agency"));
+
+    expect(mutateMock).toHaveBeenCalledWith(
+      { tier: "agency", provider: "razorpay", currency: "INR" },
+      expect.anything(),
+    );
+
+    await waitFor(() => expect(mockedLoadRazorpayCheckout).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(razorpayOpenMock).toHaveBeenCalledTimes(1));
+
+    expect(capturedRazorpayOptions).not.toBeNull();
+    expect(capturedRazorpayOptions).toMatchObject({
+      key: "rzp_test_456",
+      subscription_id: "sub_123",
+      amount: 120000,
+      currency: "INR",
+      name: "WPMgr",
+    });
+
+    // Simulate Razorpay's Checkout.js calling back into our handler with the
+    // Checkout.js onSuccess payload (field names verbatim).
+    act(() => {
+      capturedRazorpayOptions!.handler({
+        razorpay_payment_id: "pay_1",
+        razorpay_subscription_id: "sub_123",
+        razorpay_signature: "sig_1",
+      });
+    });
+
+    expect(verifyMutateMock).toHaveBeenCalledWith(
+      {
+        razorpay_payment_id: "pay_1",
+        razorpay_subscription_id: "sub_123",
+        razorpay_signature: "sig_1",
+      },
+      expect.anything(),
+    );
+    // Verify's onSettled must fire the caller's success hook regardless of
+    // verify's own outcome — see the hook's own doc comment.
+    expect(onCheckoutSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing (no toast, no onCheckoutSuccess) when the operator dismisses the modal without paying", async () => {
+    const mutateMock = fireOnSuccess<CheckoutResult, CreateCheckoutVariables>({
+      razorpay: { subscription_id: "sub_1", key_id: "rzp_1", currency: "USD", amount: 1500 },
+    });
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+    const onCheckoutSuccess = vi.fn();
+
+    const { result } = renderHook(() => useCheckoutFlow({ onCheckoutSuccess }));
+    act(() => result.current.setProvider("razorpay"));
+    act(() => result.current.startCheckout("agency"));
+
+    await waitFor(() => expect(razorpayOpenMock).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      capturedRazorpayOptions!.modal!.ondismiss!();
+    });
+
+    expect(onCheckoutSuccess).not.toHaveBeenCalled();
+    expect(mockedToastError).not.toHaveBeenCalled();
+  });
+
+  it("shows a fallback toast (never throwing inside the click handler) when Checkout.js fails to load", async () => {
+    const mutateMock = fireOnSuccess<CheckoutResult, CreateCheckoutVariables>({
+      razorpay: { subscription_id: "sub_1", key_id: "rzp_1", currency: "USD", amount: 1500 },
+    });
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+    mockedLoadRazorpayCheckout.mockRejectedValue(
+      new Error("Could not load the Razorpay checkout script."),
+    );
+    const onCheckoutSuccess = vi.fn();
+
+    const { result } = renderHook(() => useCheckoutFlow({ onCheckoutSuccess }));
+    act(() => result.current.setProvider("razorpay"));
+    act(() => result.current.startCheckout("agency"));
+
+    await waitFor(() => expect(mockedToastError).toHaveBeenCalledTimes(1));
+    expect(mockedToastError).toHaveBeenCalledWith(
+      "Could not open the Razorpay payment window",
+      expect.objectContaining({
+        description: "Could not load the Razorpay checkout script.",
+      }),
+    );
+    expect(razorpayOpenMock).not.toHaveBeenCalled();
+    expect(onCheckoutSuccess).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isStarting / error surface
+// ---------------------------------------------------------------------------
+
+describe("useCheckoutFlow — loading/error surface", () => {
+  it("isStarting mirrors the checkout mutation's isPending", () => {
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ isPending: true }),
+    );
+
+    const { result } = renderHook(() => useCheckoutFlow({ onCheckoutSuccess: vi.fn() }));
+
+    expect(result.current.isStarting).toBe(true);
+  });
+
+  it("surfaces the checkout mutation's error once it has failed", () => {
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({
+        isError: true,
+        error: new Error("Checkout is temporarily unavailable"),
+      }),
+    );
+
+    const { result } = renderHook(() => useCheckoutFlow({ onCheckoutSuccess: vi.fn() }));
+
+    expect(result.current.error?.message).toBe("Checkout is temporarily unavailable");
+  });
+
+  it("error is null while the checkout mutation has not errored", () => {
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({}),
+    );
+
+    const { result } = renderHook(() => useCheckoutFlow({ onCheckoutSuccess: vi.fn() }));
+
+    expect(result.current.isStarting).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// initialCurrency — M16 Phase C2's `?currency=` hint (register.tsx / welcome.checkout.tsx)
+// ---------------------------------------------------------------------------
+
+describe("useCheckoutFlow — initialCurrency option", () => {
+  it("defaults to USD when initialCurrency is omitted (unregressed /settings/billing behavior)", () => {
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({}),
+    );
+
+    const { result } = renderHook(() => useCheckoutFlow({ onCheckoutSuccess: vi.fn() }));
+
+    expect(result.current.currency).toBe("USD");
+  });
+
+  it("seeds the currency state from initialCurrency when provided", () => {
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({}),
+    );
+
+    const { result } = renderHook(() =>
+      useCheckoutFlow({ onCheckoutSuccess: vi.fn(), initialCurrency: "INR" }),
+    );
+
+    expect(result.current.currency).toBe("INR");
+  });
+
+  it("posts the seeded currency once the operator switches to Razorpay, without an explicit setCurrency call", () => {
+    const mutateMock = fireOnSuccess<CheckoutResult, CreateCheckoutVariables>({
+      razorpay: { subscription_id: "sub_1", key_id: "rzp_1", currency: "INR", amount: 150000 },
+    });
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+
+    const { result } = renderHook(() =>
+      useCheckoutFlow({ onCheckoutSuccess: vi.fn(), initialCurrency: "INR" }),
+    );
+
+    act(() => result.current.setProvider("razorpay"));
+    act(() => result.current.startCheckout("agency"));
+
+    expect(mutateMock).toHaveBeenCalledWith(
+      { tier: "agency", provider: "razorpay", currency: "INR" },
+      expect.anything(),
+    );
+  });
+});

--- a/apps/web/src/features/billing/use-checkout-flow.ts
+++ b/apps/web/src/features/billing/use-checkout-flow.ts
@@ -1,0 +1,140 @@
+import { useState } from "react";
+
+import { toast } from "@/components/toast";
+
+import {
+  useCreateBillingCheckout,
+  useVerifyRazorpayCheckout,
+  type BillingCurrency,
+  type BillingProvider,
+  type CheckoutTierId,
+  type RazorpayCheckoutData,
+} from "./use-billing";
+import { loadRazorpayCheckout, type RazorpayHandlerResponse } from "./razorpay-checkout";
+
+// M16 Phase B/C — the checkout machinery shared by every surface that can
+// start a paid-tier checkout (today: /settings/billing's `PlanTiersGrid`;
+// Phase C's post-verify upgrade screen reuses this exact hook rather than a
+// second copy). Extracted verbatim out of billing.tsx's former
+// `PlanTiersGrid` internals — this is a pure lift, not a behavior change; see
+// use-checkout-flow.test.ts and the still-green -billing.test.tsx for the
+// parity proof.
+//
+// Encapsulates:
+//   - the provider (Stripe/Razorpay) + Razorpay-only currency selection state
+//     that feeds `PaymentMethodPicker`;
+//   - POST /billing/checkout via `useCreateBillingCheckout`;
+//   - the Stripe path: a hosted-redirect `{ url }` -> `window.location.href`;
+//   - the Razorpay path: opening the Checkout.js modal, then on a successful
+//     payment POSTing /billing/checkout/verify (UX-confirmation only) and
+//     calling the caller's `onCheckoutSuccess` regardless of verify's own
+//     outcome — the caller's own poll (`useBillingCheckoutReturn`) remains
+//     the sole source of truth for the actual plan flip;
+//   - the "Razorpay failed to load" fallback toast.
+
+export interface UseCheckoutFlowOptions {
+  /**
+   * Called once the Razorpay verify call SETTLES (success or failure) after
+   * a successful in-modal payment. Never called on the Stripe path — Stripe's
+   * own hosted-redirect return URL is what lands the browser back on
+   * `?checkout=success`, so there is no in-page event to hook there. The
+   * caller is expected to flip whatever "finalizing your subscription" state
+   * it drives off of (see billing.tsx's `markCheckoutSuccess`).
+   */
+  onCheckoutSuccess: () => void;
+  /**
+   * Initial currency selection — e.g. a `?currency=` URL hint carried from
+   * `/register` through to `/welcome/checkout` (M16 Phase C2). Only
+   * meaningful once the operator picks Razorpay; defaults to "USD", same as
+   * every caller that omits this (unregressed `/settings/billing` behavior).
+   */
+  initialCurrency?: BillingCurrency;
+}
+
+export interface UseCheckoutFlowResult {
+  provider: BillingProvider;
+  currency: BillingCurrency;
+  setProvider: (provider: BillingProvider) => void;
+  setCurrency: (currency: BillingCurrency) => void;
+  /** Starts a checkout for `tier` using the currently selected provider/currency. */
+  startCheckout: (tier: CheckoutTierId) => void;
+  /** True while the checkout POST (or the Razorpay modal it opens) is in flight. */
+  isStarting: boolean;
+  /** The checkout POST's error, if the most recent attempt failed. */
+  error: Error | null;
+}
+
+export function useCheckoutFlow(options: UseCheckoutFlowOptions): UseCheckoutFlowResult {
+  const checkout = useCreateBillingCheckout();
+  const verify = useVerifyRazorpayCheckout();
+  const [provider, setProvider] = useState<BillingProvider>("stripe");
+  const [currency, setCurrency] = useState<BillingCurrency>(
+    options.initialCurrency ?? "USD",
+  );
+
+  function openRazorpayCheckout(data: RazorpayCheckoutData) {
+    loadRazorpayCheckout()
+      .then((Razorpay) => {
+        const instance = new Razorpay({
+          key: data.key_id,
+          subscription_id: data.subscription_id,
+          amount: data.amount,
+          currency: data.currency,
+          name: "WPMgr",
+          description: "WPMgr subscription",
+          handler: (response: RazorpayHandlerResponse) => {
+            // Verify is a UX confirmation only — the poll the caller drives
+            // off of `onCheckoutSuccess` is what actually observes the plan
+            // flip, so it must start regardless of whether verify itself
+            // succeeds or fails.
+            verify.mutate(response, {
+              onSettled: () => options.onCheckoutSuccess(),
+            });
+          },
+          modal: {
+            // The operator closed the modal without paying — a normal
+            // cancel, never an error. No toast, no navigation.
+            ondismiss: () => {},
+          },
+        });
+        instance.open();
+      })
+      .catch((err: unknown) => {
+        toast.error("Could not open the Razorpay payment window", {
+          description:
+            err instanceof Error
+              ? err.message
+              : "Please try again, or choose Stripe instead.",
+        });
+      });
+  }
+
+  function startCheckout(tier: CheckoutTierId) {
+    checkout.mutate(
+      {
+        tier,
+        provider,
+        currency: provider === "razorpay" ? currency : undefined,
+      },
+      {
+        onSuccess: (result) => {
+          if (result.razorpay) {
+            openRazorpayCheckout(result.razorpay);
+          } else if (result.url) {
+            window.location.href = result.url;
+          }
+        },
+      },
+    );
+  }
+
+  return {
+    provider,
+    currency,
+    setProvider,
+    setCurrency,
+    startCheckout,
+    isStarting: checkout.isPending,
+    error: checkout.isError ? checkout.error : null,
+  };
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as AuthedSharedWithMeRouteImport } from './routes/_authed/shared-
 import { Route as AuthedPerformanceRouteImport } from './routes/_authed/performance'
 import { Route as AuthedMigrationsRouteImport } from './routes/_authed/migrations'
 import { Route as AuthedDestinationsRouteImport } from './routes/_authed/destinations'
+import { Route as AuthedBillingRouteImport } from './routes/_authed/billing'
 import { Route as AuthedAuditRouteImport } from './routes/_authed/audit'
 import { Route as AuthedAlertsRouteImport } from './routes/_authed/alerts'
 import { Route as AuthedSettingsRouteRouteImport } from './routes/_authed/settings/route'
@@ -41,6 +42,7 @@ import { Route as AuthedClientsIndexRouteImport } from './routes/_authed/clients
 import { Route as AuthedBackupsIndexRouteImport } from './routes/_authed/backups/index'
 import { Route as AuthedAdminIndexRouteImport } from './routes/_authed/admin/index'
 import { Route as PortalSitesSiteIdRouteImport } from './routes/portal/sites.$siteId'
+import { Route as AuthedWelcomeCheckoutRouteImport } from './routes/_authed/welcome.checkout'
 import { Route as AuthedUpdatesRunIdRouteImport } from './routes/_authed/updates/$runId'
 import { Route as AuthedSitesSiteIdRouteImport } from './routes/_authed/sites/$siteId'
 import { Route as AuthedSettingsSmtpRouteImport } from './routes/_authed/settings/smtp'
@@ -177,6 +179,11 @@ const AuthedDestinationsRoute = AuthedDestinationsRouteImport.update({
   path: '/destinations',
   getParentRoute: () => AuthedRoute,
 } as any)
+const AuthedBillingRoute = AuthedBillingRouteImport.update({
+  id: '/billing',
+  path: '/billing',
+  getParentRoute: () => AuthedRoute,
+} as any)
 const AuthedAuditRoute = AuthedAuditRouteImport.update({
   id: '/audit',
   path: '/audit',
@@ -236,6 +243,11 @@ const PortalSitesSiteIdRoute = PortalSitesSiteIdRouteImport.update({
   id: '/sites/$siteId',
   path: '/sites/$siteId',
   getParentRoute: () => PortalRouteRoute,
+} as any)
+const AuthedWelcomeCheckoutRoute = AuthedWelcomeCheckoutRouteImport.update({
+  id: '/welcome/checkout',
+  path: '/welcome/checkout',
+  getParentRoute: () => AuthedRoute,
 } as any)
 const AuthedUpdatesRunIdRoute = AuthedUpdatesRunIdRouteImport.update({
   id: '/updates/$runId',
@@ -449,6 +461,7 @@ export interface FileRoutesByFullPath {
   '/settings': typeof AuthedSettingsRouteRouteWithChildren
   '/alerts': typeof AuthedAlertsRoute
   '/audit': typeof AuthedAuditRoute
+  '/billing': typeof AuthedBillingRoute
   '/destinations': typeof AuthedDestinationsRoute
   '/migrations': typeof AuthedMigrationsRoute
   '/performance': typeof AuthedPerformanceRoute
@@ -471,6 +484,7 @@ export interface FileRoutesByFullPath {
   '/settings/smtp': typeof AuthedSettingsSmtpRoute
   '/sites/$siteId': typeof AuthedSitesSiteIdRouteWithChildren
   '/updates/$runId': typeof AuthedUpdatesRunIdRoute
+  '/welcome/checkout': typeof AuthedWelcomeCheckoutRoute
   '/portal/sites/$siteId': typeof PortalSitesSiteIdRoute
   '/admin/': typeof AuthedAdminIndexRoute
   '/backups/': typeof AuthedBackupsIndexRoute
@@ -515,6 +529,7 @@ export interface FileRoutesByTo {
   '/verify-email': typeof VerifyEmailRoute
   '/alerts': typeof AuthedAlertsRoute
   '/audit': typeof AuthedAuditRoute
+  '/billing': typeof AuthedBillingRoute
   '/destinations': typeof AuthedDestinationsRoute
   '/migrations': typeof AuthedMigrationsRoute
   '/performance': typeof AuthedPerformanceRoute
@@ -535,6 +550,7 @@ export interface FileRoutesByTo {
   '/settings/security': typeof AuthedSettingsSecurityRoute
   '/settings/smtp': typeof AuthedSettingsSmtpRoute
   '/updates/$runId': typeof AuthedUpdatesRunIdRoute
+  '/welcome/checkout': typeof AuthedWelcomeCheckoutRoute
   '/portal/sites/$siteId': typeof PortalSitesSiteIdRoute
   '/admin': typeof AuthedAdminIndexRoute
   '/backups': typeof AuthedBackupsIndexRoute
@@ -583,6 +599,7 @@ export interface FileRoutesById {
   '/_authed/settings': typeof AuthedSettingsRouteRouteWithChildren
   '/_authed/alerts': typeof AuthedAlertsRoute
   '/_authed/audit': typeof AuthedAuditRoute
+  '/_authed/billing': typeof AuthedBillingRoute
   '/_authed/destinations': typeof AuthedDestinationsRoute
   '/_authed/migrations': typeof AuthedMigrationsRoute
   '/_authed/performance': typeof AuthedPerformanceRoute
@@ -605,6 +622,7 @@ export interface FileRoutesById {
   '/_authed/settings/smtp': typeof AuthedSettingsSmtpRoute
   '/_authed/sites/$siteId': typeof AuthedSitesSiteIdRouteWithChildren
   '/_authed/updates/$runId': typeof AuthedUpdatesRunIdRoute
+  '/_authed/welcome/checkout': typeof AuthedWelcomeCheckoutRoute
   '/portal/sites/$siteId': typeof PortalSitesSiteIdRoute
   '/_authed/admin/': typeof AuthedAdminIndexRoute
   '/_authed/backups/': typeof AuthedBackupsIndexRoute
@@ -654,6 +672,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/alerts'
     | '/audit'
+    | '/billing'
     | '/destinations'
     | '/migrations'
     | '/performance'
@@ -676,6 +695,7 @@ export interface FileRouteTypes {
     | '/settings/smtp'
     | '/sites/$siteId'
     | '/updates/$runId'
+    | '/welcome/checkout'
     | '/portal/sites/$siteId'
     | '/admin/'
     | '/backups/'
@@ -720,6 +740,7 @@ export interface FileRouteTypes {
     | '/verify-email'
     | '/alerts'
     | '/audit'
+    | '/billing'
     | '/destinations'
     | '/migrations'
     | '/performance'
@@ -740,6 +761,7 @@ export interface FileRouteTypes {
     | '/settings/security'
     | '/settings/smtp'
     | '/updates/$runId'
+    | '/welcome/checkout'
     | '/portal/sites/$siteId'
     | '/admin'
     | '/backups'
@@ -787,6 +809,7 @@ export interface FileRouteTypes {
     | '/_authed/settings'
     | '/_authed/alerts'
     | '/_authed/audit'
+    | '/_authed/billing'
     | '/_authed/destinations'
     | '/_authed/migrations'
     | '/_authed/performance'
@@ -809,6 +832,7 @@ export interface FileRouteTypes {
     | '/_authed/settings/smtp'
     | '/_authed/sites/$siteId'
     | '/_authed/updates/$runId'
+    | '/_authed/welcome/checkout'
     | '/portal/sites/$siteId'
     | '/_authed/admin/'
     | '/_authed/backups/'
@@ -998,6 +1022,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedDestinationsRouteImport
       parentRoute: typeof AuthedRoute
     }
+    '/_authed/billing': {
+      id: '/_authed/billing'
+      path: '/billing'
+      fullPath: '/billing'
+      preLoaderRoute: typeof AuthedBillingRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/audit': {
       id: '/_authed/audit'
       path: '/audit'
@@ -1081,6 +1112,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/portal/sites/$siteId'
       preLoaderRoute: typeof PortalSitesSiteIdRouteImport
       parentRoute: typeof PortalRouteRoute
+    }
+    '/_authed/welcome/checkout': {
+      id: '/_authed/welcome/checkout'
+      path: '/welcome/checkout'
+      fullPath: '/welcome/checkout'
+      preLoaderRoute: typeof AuthedWelcomeCheckoutRouteImport
+      parentRoute: typeof AuthedRoute
     }
     '/_authed/updates/$runId': {
       id: '/_authed/updates/$runId'
@@ -1475,6 +1513,7 @@ interface AuthedRouteChildren {
   AuthedSettingsRouteRoute: typeof AuthedSettingsRouteRouteWithChildren
   AuthedAlertsRoute: typeof AuthedAlertsRoute
   AuthedAuditRoute: typeof AuthedAuditRoute
+  AuthedBillingRoute: typeof AuthedBillingRoute
   AuthedDestinationsRoute: typeof AuthedDestinationsRoute
   AuthedMigrationsRoute: typeof AuthedMigrationsRoute
   AuthedPerformanceRoute: typeof AuthedPerformanceRoute
@@ -1486,6 +1525,7 @@ interface AuthedRouteChildren {
   AuthedScheduleRunsRunIdRoute: typeof AuthedScheduleRunsRunIdRoute
   AuthedSitesSiteIdRoute: typeof AuthedSitesSiteIdRouteWithChildren
   AuthedUpdatesRunIdRoute: typeof AuthedUpdatesRunIdRoute
+  AuthedWelcomeCheckoutRoute: typeof AuthedWelcomeCheckoutRoute
   AuthedBackupsIndexRoute: typeof AuthedBackupsIndexRoute
   AuthedClientsIndexRoute: typeof AuthedClientsIndexRoute
   AuthedEmailIndexRoute: typeof AuthedEmailIndexRoute
@@ -1498,6 +1538,7 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedSettingsRouteRoute: AuthedSettingsRouteRouteWithChildren,
   AuthedAlertsRoute: AuthedAlertsRoute,
   AuthedAuditRoute: AuthedAuditRoute,
+  AuthedBillingRoute: AuthedBillingRoute,
   AuthedDestinationsRoute: AuthedDestinationsRoute,
   AuthedMigrationsRoute: AuthedMigrationsRoute,
   AuthedPerformanceRoute: AuthedPerformanceRoute,
@@ -1509,6 +1550,7 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedScheduleRunsRunIdRoute: AuthedScheduleRunsRunIdRoute,
   AuthedSitesSiteIdRoute: AuthedSitesSiteIdRouteWithChildren,
   AuthedUpdatesRunIdRoute: AuthedUpdatesRunIdRoute,
+  AuthedWelcomeCheckoutRoute: AuthedWelcomeCheckoutRoute,
   AuthedBackupsIndexRoute: AuthedBackupsIndexRoute,
   AuthedClientsIndexRoute: AuthedClientsIndexRoute,
   AuthedEmailIndexRoute: AuthedEmailIndexRoute,

--- a/apps/web/src/routes/-register.test.tsx
+++ b/apps/web/src/routes/-register.test.tsx
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRouteWithContext,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import type { UseMutationResult } from "@tanstack/react-query";
+import type { Me, RegisterRequest } from "@wpmgr/api";
+
+import { createTestQueryClient, renderWithProviders } from "@/test/render";
+import { mockMutationResult } from "@/test/query-mocks";
+import { authKeys } from "@/features/auth/use-auth";
+import type { RouterContext } from "@/router";
+
+import { Route as RegisterRoute } from "./register";
+import {
+  useRegister,
+  useResendVerification,
+  type RegisterResult,
+} from "@/features/auth/use-auth";
+import { readPendingPlan } from "@/features/billing/pending-plan";
+
+// M16 Phase C2 — signup-to-premium, the /register half: a `?plan=` carried
+// from the marketing pricing page threads through to the register call, the
+// same-browser stash, and (on the rare first-account bootstrap path) a
+// direct redirect into checkout. Mounts the REAL route component (`Route`'s
+// own `component`/`validateSearch`/`beforeLoad`) re-attached to a throwaway
+// root — same pattern as routes/_authed/settings/-billing.test.tsx and
+// routes/_authed/admin/accounts/-index.test.tsx (see those files' module
+// docs for why: `Route.useSearch()`/`useNavigate()` are bound to this file's
+// own exported `Route` singleton).
+
+vi.mock("@/features/auth/use-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/auth/use-auth")>();
+  return { ...actual, useRegister: vi.fn(), useResendVerification: vi.fn() };
+});
+
+const mockedUseRegister = vi.mocked(useRegister);
+const mockedUseResendVerification = vi.mocked(useResendVerification);
+
+const MINIMAL_ME: Me = {
+  user: {
+    id: "00000000-0000-0000-0000-000000000001",
+    email: "new@wpmgr.test",
+    name: "New Owner",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  memberships: [
+    {
+      user_id: "00000000-0000-0000-0000-000000000001",
+      tenant_id: "11111111-1111-1111-1111-111111111111",
+      role: "owner",
+    },
+  ],
+  active_tenant_id: "11111111-1111-1111-1111-111111111111",
+};
+
+/**
+ * Attaches register.tsx's own exported `Route` to a throwaway root, plus a
+ * `/sites` and `/welcome/checkout` stub so a real `navigate({ to: ... })`
+ * resolves and its search params are observable via `router.state.location`.
+ */
+function buildRegisterRouter(
+  initialPath: string,
+  queryClient: ReturnType<typeof createTestQueryClient>,
+) {
+  const rootRoute = createRootRouteWithContext<RouterContext>()({});
+  type UpdateOptions = Parameters<typeof RegisterRoute.update>[0];
+  const registerRoute = RegisterRoute.update({
+    id: "/register",
+    path: "/register",
+    getParentRoute: () => rootRoute,
+  } as unknown as UpdateOptions);
+  const sitesRoute = createRoute({
+    path: "/sites",
+    getParentRoute: () => rootRoute,
+    component: () => <div>Sites stub</div>,
+  });
+  const welcomeCheckoutRoute = createRoute({
+    path: "/welcome/checkout",
+    getParentRoute: () => rootRoute,
+    validateSearch: (search: Record<string, unknown>) => search,
+    component: () => <div>Welcome checkout stub</div>,
+  });
+  const routeTree = rootRoute.addChildren([registerRoute, sitesRoute, welcomeCheckoutRoute]);
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+    context: { queryClient },
+  });
+}
+
+function renderRegisterPage(initialPath = "/register") {
+  const queryClient = createTestQueryClient();
+  // Unauthenticated — register.tsx's own beforeLoad redirects to /sites when
+  // `ensureMe` resolves a real session, so seed `null` (the "no session"
+  // convention fetchMe uses on a 401) to keep the register form reachable.
+  queryClient.setQueryData(authKeys.me, null);
+  const router = buildRegisterRouter(initialPath, queryClient);
+  renderWithProviders(<RouterProvider router={router} />, { queryClient });
+  return router;
+}
+
+/** A `mutateAsync` spy that resolves with `result`, WITHOUT firing onSuccess. */
+function mutateAsyncResolving<TData>(
+  result: TData,
+): UseMutationResult<TData, Error, RegisterRequest>["mutateAsync"] {
+  return vi.fn().mockResolvedValue(result);
+}
+
+/** A `mutateAsync` spy that resolves with `result` AND fires the caller's `onSuccess`. */
+function mutateAsyncFiringOnSuccess<TData>(
+  result: TData,
+): UseMutationResult<TData, Error, RegisterRequest>["mutateAsync"] {
+  return vi.fn(
+    (_vars: RegisterRequest, opts?: { onSuccess?: (result: TData) => void }) => {
+      opts?.onSuccess?.(result);
+      return Promise.resolve(result);
+    },
+  ) as unknown as UseMutationResult<TData, Error, RegisterRequest>["mutateAsync"];
+}
+
+/**
+ * Fills and submits the registration form. Awaits the email field first —
+ * `RouterProvider`'s first paint resolves in a microtask (see
+ * src/test/render.tsx's module doc), so a bare `getByLabelText` right after
+ * `renderRegisterPage` races an empty DOM.
+ */
+async function fillAndSubmit(email = "new@wpmgr.test", password = "supersecretpassword") {
+  const emailInput = await screen.findByLabelText("Email");
+  fireEvent.change(emailInput, { target: { value: email } });
+  fireEvent.change(screen.getByLabelText("Password"), { target: { value: password } });
+  fireEvent.click(screen.getByRole("button", { name: "Create account" }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+  document.cookie = "wpmgr_pending_plan=; max-age=0; path=/";
+  mockedUseResendVerification.mockReturnValue(
+    mockMutationResult<void, { email: string }>({}),
+  );
+});
+
+describe("RegisterPage — plan summary chip", () => {
+  it("shows the Agency plan chip when the URL carries ?plan=agency", async () => {
+    mockedUseRegister.mockReturnValue(
+      mockMutationResult<RegisterResult, RegisterRequest>({
+        mutateAsync: mutateAsyncResolving<RegisterResult>({ pending: true }),
+      }),
+    );
+
+    renderRegisterPage("/register?plan=agency");
+
+    expect(
+      await screen.findByText(/You're signing up for the Agency plan/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows no chip and no plan field for a plain signup (no ?plan=)", async () => {
+    mockedUseRegister.mockReturnValue(
+      mockMutationResult<RegisterResult, RegisterRequest>({
+        mutateAsync: mutateAsyncResolving<RegisterResult>({ pending: true }),
+      }),
+    );
+
+    renderRegisterPage("/register");
+
+    expect(await screen.findByRole("heading", { name: "Create an account" })).toBeInTheDocument();
+    expect(screen.queryByText(/signing up for the/)).not.toBeInTheDocument();
+  });
+
+  it("ignores an unknown/free plan value rather than erroring the page (?plan=free)", async () => {
+    mockedUseRegister.mockReturnValue(
+      mockMutationResult<RegisterResult, RegisterRequest>({
+        mutateAsync: mutateAsyncResolving<RegisterResult>({ pending: true }),
+      }),
+    );
+
+    renderRegisterPage("/register?plan=free");
+
+    expect(await screen.findByRole("heading", { name: "Create an account" })).toBeInTheDocument();
+    expect(screen.queryByText(/signing up for the/)).not.toBeInTheDocument();
+  });
+});
+
+describe("RegisterPage — threads plan into the register call", () => {
+  it("sends plan: 'agency' in the register body when ?plan=agency", async () => {
+    const mutateAsyncMock = mutateAsyncResolving<RegisterResult>({ pending: true });
+    mockedUseRegister.mockReturnValue(
+      mockMutationResult<RegisterResult, RegisterRequest>({ mutateAsync: mutateAsyncMock }),
+    );
+
+    renderRegisterPage("/register?plan=agency");
+    await screen.findByText(/You're signing up for the Agency plan/);
+    await fillAndSubmit();
+
+    await waitFor(() => expect(mutateAsyncMock).toHaveBeenCalledTimes(1));
+    expect(mutateAsyncMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "new@wpmgr.test",
+        plan: "agency",
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("omits plan from the register body for a plain signup", async () => {
+    const mutateAsyncMock = mutateAsyncResolving<RegisterResult>({ pending: true });
+    mockedUseRegister.mockReturnValue(
+      mockMutationResult<RegisterResult, RegisterRequest>({ mutateAsync: mutateAsyncMock }),
+    );
+
+    renderRegisterPage("/register");
+    await fillAndSubmit();
+
+    await waitFor(() => expect(mutateAsyncMock).toHaveBeenCalledTimes(1));
+    expect(mutateAsyncMock).toHaveBeenCalledWith(
+      expect.objectContaining({ plan: undefined }),
+      expect.anything(),
+    );
+  });
+});
+
+describe("RegisterPage — pending branch stashes the plan (same-browser fast path)", () => {
+  it("stashes { plan, currency } once the register call reports pending", async () => {
+    const mutateAsyncMock = mutateAsyncFiringOnSuccess<RegisterResult>({ pending: true });
+    mockedUseRegister.mockReturnValue(
+      mockMutationResult<RegisterResult, RegisterRequest>({ mutateAsync: mutateAsyncMock }),
+    );
+
+    renderRegisterPage("/register?plan=agency&currency=INR");
+    await fillAndSubmit();
+
+    await screen.findByRole("heading", { name: "Check your email" });
+    expect(readPendingPlan()).toEqual({ plan: "agency", currency: "INR" });
+  });
+
+  it("stashes nothing for a plain signup (no plan chosen)", async () => {
+    const mutateAsyncMock = mutateAsyncFiringOnSuccess<RegisterResult>({ pending: true });
+    mockedUseRegister.mockReturnValue(
+      mockMutationResult<RegisterResult, RegisterRequest>({ mutateAsync: mutateAsyncMock }),
+    );
+
+    renderRegisterPage("/register");
+    await fillAndSubmit();
+
+    await screen.findByRole("heading", { name: "Check your email" });
+    expect(readPendingPlan()).toBeNull();
+  });
+});
+
+describe("RegisterPage — first-account bootstrap branch", () => {
+  it("navigates to /welcome/checkout?plan=agency when the bootstrap response carries desired_plan on a hosted instance", async () => {
+    const mutateAsyncMock = mutateAsyncFiringOnSuccess<RegisterResult>({
+      pending: false,
+      me: { ...MINIMAL_ME, hosted: true, desired_plan: "agency" },
+    });
+    mockedUseRegister.mockReturnValue(
+      mockMutationResult<RegisterResult, RegisterRequest>({ mutateAsync: mutateAsyncMock }),
+    );
+
+    const router = renderRegisterPage("/register?plan=agency");
+    await fillAndSubmit();
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/welcome/checkout"),
+    );
+    expect(router.state.location.search).toMatchObject({ plan: "agency" });
+  });
+
+  it("navigates to /sites (unregressed) when the bootstrap response carries no desired_plan", async () => {
+    const mutateAsyncMock = mutateAsyncFiringOnSuccess<RegisterResult>({
+      pending: false,
+      me: { ...MINIMAL_ME, hosted: true },
+    });
+    mockedUseRegister.mockReturnValue(
+      mockMutationResult<RegisterResult, RegisterRequest>({ mutateAsync: mutateAsyncMock }),
+    );
+
+    const router = renderRegisterPage("/register");
+    await fillAndSubmit();
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/sites"));
+  });
+
+  it("navigates to /sites when desired_plan is present but the instance is not hosted (self-host safety)", async () => {
+    const mutateAsyncMock = mutateAsyncFiringOnSuccess<RegisterResult>({
+      pending: false,
+      me: { ...MINIMAL_ME, hosted: false, desired_plan: "agency" },
+    });
+    mockedUseRegister.mockReturnValue(
+      mockMutationResult<RegisterResult, RegisterRequest>({ mutateAsync: mutateAsyncMock }),
+    );
+
+    const router = renderRegisterPage("/register?plan=agency");
+    await fillAndSubmit();
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/sites"));
+  });
+});

--- a/apps/web/src/routes/-verify-email.test.tsx
+++ b/apps/web/src/routes/-verify-email.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRouteWithContext,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import type { UseMutationResult } from "@tanstack/react-query";
+import type { Me } from "@wpmgr/api";
+
+import { createTestQueryClient, renderWithProviders } from "@/test/render";
+import { mockMutationResult } from "@/test/query-mocks";
+import type { RouterContext } from "@/router";
+
+import { Route as VerifyEmailRoute } from "./verify-email";
+import {
+  useVerifyEmail,
+  useResendVerification,
+  type VerifyEmailResult,
+} from "@/features/auth/use-auth";
+import { stashPendingPlan, clearPendingPlan } from "@/features/billing/pending-plan";
+
+// M16 Phase C2 — signup-to-premium, the /verify-email half: on a 200
+// response carrying `me.desired_plan` on a hosted instance, skip straight to
+// /welcome/checkout instead of an empty Sites page. Mounts the REAL route
+// component re-attached to a throwaway root (same pattern as
+// routes/-register.test.tsx / routes/_authed/settings/-billing.test.tsx).
+
+vi.mock("@/features/auth/use-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/auth/use-auth")>();
+  return { ...actual, useVerifyEmail: vi.fn(), useResendVerification: vi.fn() };
+});
+
+const mockedUseVerifyEmail = vi.mocked(useVerifyEmail);
+const mockedUseResendVerification = vi.mocked(useResendVerification);
+
+const MINIMAL_ME: Me = {
+  user: {
+    id: "00000000-0000-0000-0000-000000000001",
+    email: "new@wpmgr.test",
+    name: "New Owner",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  memberships: [
+    {
+      user_id: "00000000-0000-0000-0000-000000000001",
+      tenant_id: "11111111-1111-1111-1111-111111111111",
+      role: "owner",
+    },
+  ],
+  active_tenant_id: "11111111-1111-1111-1111-111111111111",
+};
+
+function buildVerifyEmailRouter(
+  initialPath: string,
+  queryClient: ReturnType<typeof createTestQueryClient>,
+) {
+  const rootRoute = createRootRouteWithContext<RouterContext>()({});
+  type UpdateOptions = Parameters<typeof VerifyEmailRoute.update>[0];
+  const verifyEmailRoute = VerifyEmailRoute.update({
+    id: "/verify-email",
+    path: "/verify-email",
+    getParentRoute: () => rootRoute,
+  } as unknown as UpdateOptions);
+  const sitesRoute = createRoute({
+    path: "/sites",
+    getParentRoute: () => rootRoute,
+    component: () => <div>Sites stub</div>,
+  });
+  const welcomeCheckoutRoute = createRoute({
+    path: "/welcome/checkout",
+    getParentRoute: () => rootRoute,
+    validateSearch: (search: Record<string, unknown>) => search,
+    component: () => <div>Welcome checkout stub</div>,
+  });
+  const routeTree = rootRoute.addChildren([
+    verifyEmailRoute,
+    sitesRoute,
+    welcomeCheckoutRoute,
+  ]);
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+    context: { queryClient },
+  });
+}
+
+function renderVerifyEmailPage(initialPath: string) {
+  const queryClient = createTestQueryClient();
+  const router = buildVerifyEmailRouter(initialPath, queryClient);
+  renderWithProviders(<RouterProvider router={router} />, { queryClient });
+  return router;
+}
+
+/** A `mutate` spy that synchronously fires the caller's `onSuccess` with `result`. */
+function mutateFiringOnSuccess(
+  result: VerifyEmailResult,
+): UseMutationResult<VerifyEmailResult, Error, { token: string }>["mutate"] {
+  return vi.fn(
+    (_vars: { token: string }, opts?: { onSuccess?: (result: VerifyEmailResult) => void }) => {
+      opts?.onSuccess?.(result);
+    },
+  ) as UseMutationResult<VerifyEmailResult, Error, { token: string }>["mutate"];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearPendingPlan();
+  mockedUseResendVerification.mockReturnValue(
+    mockMutationResult<void, { email: string }>({}),
+  );
+});
+
+describe("VerifyEmailPage — desired_plan routing on a 200 verify", () => {
+  it("navigates to /welcome/checkout?plan=agency when desired_plan is present and the instance is hosted", async () => {
+    mockedUseVerifyEmail.mockReturnValue(
+      mockMutationResult<VerifyEmailResult, { token: string }>({
+        mutate: mutateFiringOnSuccess({
+          status: 200,
+          me: { ...MINIMAL_ME, hosted: true, desired_plan: "agency" },
+        }),
+      }),
+    );
+
+    const router = renderVerifyEmailPage("/verify-email?token=abc123");
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/welcome/checkout"));
+    expect(router.state.location.search).toMatchObject({ plan: "agency" });
+  });
+
+  it("navigates to /sites (unregressed) when there is no desired_plan", async () => {
+    mockedUseVerifyEmail.mockReturnValue(
+      mockMutationResult<VerifyEmailResult, { token: string }>({
+        mutate: mutateFiringOnSuccess({
+          status: 200,
+          me: { ...MINIMAL_ME, hosted: true },
+        }),
+      }),
+    );
+
+    const router = renderVerifyEmailPage("/verify-email?token=abc123");
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/sites"));
+  });
+
+  it("navigates to /sites when desired_plan is present but the instance is not hosted (self-host safety)", async () => {
+    mockedUseVerifyEmail.mockReturnValue(
+      mockMutationResult<VerifyEmailResult, { token: string }>({
+        mutate: mutateFiringOnSuccess({
+          status: 200,
+          me: { ...MINIMAL_ME, hosted: false, desired_plan: "agency" },
+        }),
+      }),
+    );
+
+    const router = renderVerifyEmailPage("/verify-email?token=abc123");
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/sites"));
+  });
+
+  it("carries a stashed `?currency=` hint through to /welcome/checkout", async () => {
+    stashPendingPlan({ plan: "agency", currency: "INR" });
+    mockedUseVerifyEmail.mockReturnValue(
+      mockMutationResult<VerifyEmailResult, { token: string }>({
+        mutate: mutateFiringOnSuccess({
+          status: 200,
+          me: { ...MINIMAL_ME, hosted: true, desired_plan: "agency" },
+        }),
+      }),
+    );
+
+    const router = renderVerifyEmailPage("/verify-email?token=abc123");
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/welcome/checkout"));
+    expect(router.state.location.search).toMatchObject({ plan: "agency", currency: "INR" });
+  });
+
+  it("still shows the verifying state before the mutation settles (unregressed)", async () => {
+    mockedUseVerifyEmail.mockReturnValue(
+      mockMutationResult<VerifyEmailResult, { token: string }>({
+        mutate: vi.fn(),
+        isPending: true,
+        isSuccess: false,
+        isError: false,
+      }),
+    );
+
+    renderVerifyEmailPage("/verify-email?token=abc123");
+
+    expect(await screen.findByText("Verifying your email")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/_authed/-billing.test.tsx
+++ b/apps/web/src/routes/_authed/-billing.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { waitFor } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRouteWithContext,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+
+import { createTestQueryClient, renderWithProviders } from "@/test/render";
+import type { RouterContext } from "@/router";
+
+import { Route as BillingShimRoute } from "./billing";
+
+// Compatibility redirect regression lock: POST /billing/checkout's Stripe
+// success/cancel URLs are server-fixed to `{publicBaseURL}/billing?checkout=...`
+// (apps/api/internal/billing/handler.go), one path segment shorter than this
+// app's real route (`/settings/billing`) — this route exists purely to catch
+// that return trip and forward it on. See routes/_authed/billing.tsx's
+// module doc.
+
+function buildShimRouter(initialPath: string) {
+  const rootRoute = createRootRouteWithContext<RouterContext>()({});
+  type UpdateOptions = Parameters<typeof BillingShimRoute.update>[0];
+  const billingShimRoute = BillingShimRoute.update({
+    id: "/billing",
+    path: "/billing",
+    getParentRoute: () => rootRoute,
+  } as unknown as UpdateOptions);
+  const settingsBillingRoute = createRoute({
+    path: "/settings/billing",
+    getParentRoute: () => rootRoute,
+    component: () => <div>Settings billing stub</div>,
+  });
+  const routeTree = rootRoute.addChildren([billingShimRoute, settingsBillingRoute]);
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+    context: { queryClient: createTestQueryClient() },
+  });
+}
+
+function renderShim(initialPath: string) {
+  const router = buildShimRouter(initialPath);
+  renderWithProviders(<RouterProvider router={router} />);
+  return router;
+}
+
+describe("/_authed/billing compatibility redirect", () => {
+  it("forwards /billing?checkout=success to /settings/billing?checkout=success", async () => {
+    const router = renderShim("/billing?checkout=success");
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/settings/billing"));
+    expect(router.state.location.search).toMatchObject({ checkout: "success" });
+  });
+
+  it("forwards /billing?checkout=cancel to /settings/billing?checkout=cancel", async () => {
+    const router = renderShim("/billing?checkout=cancel");
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/settings/billing"));
+    expect(router.state.location.search).toMatchObject({ checkout: "cancel" });
+  });
+
+  it("forwards a bare /billing (no checkout param) to /settings/billing with no stray param", async () => {
+    const router = renderShim("/billing");
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/settings/billing"));
+    expect(router.state.location.search).not.toHaveProperty("checkout");
+  });
+});

--- a/apps/web/src/routes/_authed/-welcome.checkout.pure.test.ts
+++ b/apps/web/src/routes/_authed/-welcome.checkout.pure.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+
+import { resolveCheckoutTier, shouldDropIntoSitesAfterCheckout } from "./welcome.checkout";
+
+// Pure-logic coverage for welcome.checkout.tsx's two exported helpers — no
+// React/router needed (mirrors use-billing.test.ts's own
+// `shouldPollCheckoutReturn` pattern).
+
+describe("resolveCheckoutTier — URL then stash precedence", () => {
+  it("prefers the URL's own plan when both are present", () => {
+    expect(resolveCheckoutTier("starter", "scale")).toBe("starter");
+  });
+
+  it("falls back to the stash when the URL carries no plan", () => {
+    expect(resolveCheckoutTier(undefined, "scale")).toBe("scale");
+  });
+
+  it("returns undefined when neither is present", () => {
+    expect(resolveCheckoutTier(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe("shouldDropIntoSitesAfterCheckout — the Razorpay success-to-Sites edge", () => {
+  it("is false before any checkout has succeeded (status undefined)", () => {
+    expect(
+      shouldDropIntoSitesAfterCheckout({ status: undefined, wasFinalizing: false, isFinalizing: false }),
+    ).toBe(false);
+  });
+
+  it("is false on the very first render even if isFinalizing starts false (no prior finalizing edge yet)", () => {
+    expect(
+      shouldDropIntoSitesAfterCheckout({ status: "success", wasFinalizing: false, isFinalizing: false }),
+    ).toBe(false);
+  });
+
+  it("is false while still finalizing", () => {
+    expect(
+      shouldDropIntoSitesAfterCheckout({ status: "success", wasFinalizing: true, isFinalizing: true }),
+    ).toBe(false);
+  });
+
+  it("is true exactly on the finalizing-to-done edge once a checkout succeeded", () => {
+    expect(
+      shouldDropIntoSitesAfterCheckout({ status: "success", wasFinalizing: true, isFinalizing: false }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/routes/_authed/-welcome.checkout.test.tsx
+++ b/apps/web/src/routes/_authed/-welcome.checkout.test.tsx
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRouteWithContext,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import type { Me } from "@wpmgr/api";
+
+import { createTestQueryClient, renderWithProviders } from "@/test/render";
+import { mockMutationResult, mockQueryResult } from "@/test/query-mocks";
+import { authKeys } from "@/features/auth/use-auth";
+import type { RouterContext } from "@/router";
+
+import { Route as WelcomeCheckoutRoute } from "./welcome.checkout";
+import {
+  useBilling,
+  useCreateBillingCheckout,
+  useVerifyRazorpayCheckout,
+  type BillingInfo,
+  type CheckoutResult,
+  type CreateCheckoutVariables,
+  type VerifyCheckoutResult,
+  type RazorpayCheckoutSuccess,
+} from "@/features/billing/use-billing";
+import { loadRazorpayCheckout } from "@/features/billing/razorpay-checkout";
+import { readPendingPlan, stashPendingPlan, clearPendingPlan } from "@/features/billing/pending-plan";
+
+// M16 Phase C2 — the /welcome/checkout post-verify screen. Mounts the REAL
+// route (`beforeLoad` + `component`) re-attached to a throwaway root, exactly
+// like routes/_authed/settings/-billing.test.tsx (whose module doc explains
+// why: `Route.useSearch()` is bound to this file's own exported `Route`
+// singleton). Only the billing data hooks + Razorpay loader are mocked;
+// `useBillingCheckoutReturn` runs for real (same rationale as -billing.test.tsx).
+
+vi.mock("@/features/billing/use-billing", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/billing/use-billing")>();
+  return {
+    ...actual,
+    useBilling: vi.fn(),
+    useCreateBillingCheckout: vi.fn(),
+    useVerifyRazorpayCheckout: vi.fn(),
+  };
+});
+
+vi.mock("@/features/billing/razorpay-checkout", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/billing/razorpay-checkout")>();
+  return { ...actual, loadRazorpayCheckout: vi.fn() };
+});
+
+const mockedUseBilling = vi.mocked(useBilling);
+const mockedUseCreateBillingCheckout = vi.mocked(useCreateBillingCheckout);
+const mockedUseVerifyRazorpayCheckout = vi.mocked(useVerifyRazorpayCheckout);
+const mockedLoadRazorpayCheckout = vi.mocked(loadRazorpayCheckout);
+
+const TENANT_ID = "11111111-1111-1111-1111-111111111111";
+
+const HOSTED_OWNER_ME: Me = {
+  user: {
+    id: "00000000-0000-0000-0000-000000000001",
+    email: "owner@wpmgr.test",
+    name: "Owner",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  memberships: [{ user_id: "00000000-0000-0000-0000-000000000001", tenant_id: TENANT_ID, role: "owner" }],
+  active_tenant_id: TENANT_ID,
+  hosted: true,
+};
+
+function billingFixture(overrides: Partial<BillingInfo> = {}): BillingInfo {
+  return {
+    plan: "free",
+    plan_status: "none",
+    meters: { sites: { used: 1, limit: 3 } },
+    portal_available: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Attaches welcome.checkout.tsx's own `Route` (beforeLoad + component) to a
+ * throwaway root, plus a `/sites` stub so a real redirect/navigate resolves
+ * and is observable via `router.state.location`.
+ */
+function buildWelcomeCheckoutRouter(
+  initialPath: string,
+  queryClient: ReturnType<typeof createTestQueryClient>,
+) {
+  const rootRoute = createRootRouteWithContext<RouterContext>()({});
+  type UpdateOptions = Parameters<typeof WelcomeCheckoutRoute.update>[0];
+  const welcomeCheckoutRoute = WelcomeCheckoutRoute.update({
+    id: "/welcome/checkout",
+    path: "/welcome/checkout",
+    getParentRoute: () => rootRoute,
+  } as unknown as UpdateOptions);
+  const sitesRoute = createRoute({
+    path: "/sites",
+    getParentRoute: () => rootRoute,
+    component: () => <div>Sites stub</div>,
+  });
+  const routeTree = rootRoute.addChildren([welcomeCheckoutRoute, sitesRoute]);
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+    context: { queryClient },
+  });
+}
+
+function renderWelcomeCheckout(initialPath: string, me: Me | null = HOSTED_OWNER_ME) {
+  const queryClient = createTestQueryClient();
+  queryClient.setQueryData(authKeys.me, me);
+  const router = buildWelcomeCheckoutRouter(initialPath, queryClient);
+  renderWithProviders(<RouterProvider router={router} />, { queryClient });
+  return router;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearPendingPlan();
+  mockedUseBilling.mockReturnValue(mockQueryResult<BillingInfo | null>({ data: billingFixture() }));
+  mockedUseVerifyRazorpayCheckout.mockReturnValue(
+    mockMutationResult<VerifyCheckoutResult, RazorpayCheckoutSuccess>({}),
+  );
+  mockedLoadRazorpayCheckout.mockResolvedValue(
+    class {
+      open = vi.fn();
+      constructor() {}
+    },
+  );
+});
+
+describe("WelcomeCheckoutPage — self-host / resolution guards (beforeLoad)", () => {
+  it("redirects to /sites when the instance is not hosted", async () => {
+    const mutateMock = vi.fn();
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+
+    const router = renderWelcomeCheckout("/welcome/checkout?plan=agency", {
+      ...HOSTED_OWNER_ME,
+      hosted: false,
+    });
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/sites"));
+    // Self-host safety must block BEFORE any checkout is ever created.
+    expect(mutateMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /sites when no plan is resolvable (no ?plan= and no stash)", async () => {
+    const mutateMock = vi.fn();
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+
+    const router = renderWelcomeCheckout("/welcome/checkout");
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/sites"));
+    expect(mutateMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves the plan from the stash when the URL carries no ?plan=", async () => {
+    stashPendingPlan({ plan: "scale" });
+    const mutateMock = vi.fn();
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+
+    renderWelcomeCheckout("/welcome/checkout");
+
+    expect(
+      await screen.findByRole("heading", { name: "Complete your Scale subscription" }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mutateMock).toHaveBeenCalledWith(
+        { tier: "scale", provider: "stripe", currency: undefined },
+        expect.anything(),
+      ),
+    );
+  });
+
+  it("the URL's ?plan= wins over a conflicting stash", async () => {
+    stashPendingPlan({ plan: "scale" });
+    const mutateMock = vi.fn();
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+
+    renderWelcomeCheckout("/welcome/checkout?plan=starter");
+
+    expect(
+      await screen.findByRole("heading", { name: "Complete your Starter subscription" }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("WelcomeCheckoutPage — auto-starts checkout once on mount", () => {
+  it("auto-calls startCheckout(tier) with the default provider (Stripe) and renders the picker + plan summary", async () => {
+    const mutateMock = vi.fn();
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+
+    renderWelcomeCheckout("/welcome/checkout?plan=agency");
+
+    expect(
+      await screen.findByRole("heading", { name: "Complete your Agency subscription" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Agency")).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Stripe" })).toHaveAttribute("aria-checked", "true");
+
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+    expect(mutateMock).toHaveBeenCalledWith(
+      { tier: "agency", provider: "stripe", currency: undefined },
+      expect.anything(),
+    );
+  });
+
+  it("clears the pending-plan stash once checkout has started", async () => {
+    stashPendingPlan({ plan: "agency", currency: "INR" });
+    const mutateMock = vi.fn();
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+
+    renderWelcomeCheckout("/welcome/checkout?plan=agency");
+    await screen.findByRole("heading", { name: "Complete your Agency subscription" });
+
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(readPendingPlan()).toBeNull());
+  });
+
+  it("does not auto-start a second checkout on a re-render", async () => {
+    const mutateMock = vi.fn();
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+
+    renderWelcomeCheckout("/welcome/checkout?plan=agency");
+    await screen.findByRole("heading", { name: "Complete your Agency subscription" });
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+
+    // Switching provider triggers a re-render of the same mounted component;
+    // the auto-start effect must not fire again.
+    fireEvent.click(screen.getByRole("radio", { name: "Razorpay" }));
+    await waitFor(() =>
+      expect(screen.getByRole("radio", { name: "Razorpay" })).toHaveAttribute(
+        "aria-checked",
+        "true",
+      ),
+    );
+
+    expect(mutateMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("WelcomeCheckoutPage — Skip for now", () => {
+  it("clears the stash and navigates to /sites without ever starting a checkout call from the click", async () => {
+    const mutateMock = vi.fn();
+    mockedUseCreateBillingCheckout.mockReturnValue(
+      mockMutationResult<CheckoutResult, CreateCheckoutVariables>({ mutate: mutateMock }),
+    );
+
+    const router = renderWelcomeCheckout("/welcome/checkout?plan=agency");
+    await screen.findByRole("heading", { name: "Complete your Agency subscription" });
+    // Let the auto-start effect fire first (matches production timing) before skipping.
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/sites"));
+    expect(readPendingPlan()).toBeNull();
+    // Skip must never itself trigger an additional checkout-creation call.
+    expect(mutateMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/routes/_authed/billing.tsx
+++ b/apps/web/src/routes/_authed/billing.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { z } from "zod";
+
+// Compatibility redirect. POST /billing/checkout's Stripe success/cancel
+// return URLs are built server-side as `{publicBaseURL}/billing?checkout=...`
+// (apps/api/internal/billing/handler.go's `createCheckout`) — one path
+// segment shorter than this app's actual route (`/settings/billing`). Every
+// Stripe checkout return, whether started from /settings/billing or
+// /welcome/checkout, lands here first; forward it straight to
+// /settings/billing with the same `checkout` hint so the existing
+// finalizing/success banner (`useBillingCheckoutReturn`) still fires. Purely
+// a frontend routing fix — never touches the backend contract.
+const searchSchema = z.object({
+  checkout: z.enum(["success", "cancel"]).optional().catch(undefined),
+});
+
+export const Route = createFileRoute("/_authed/billing")({
+  validateSearch: searchSchema,
+  beforeLoad: ({ search }) => {
+    throw redirect({
+      to: "/settings/billing",
+      search: search.checkout ? { checkout: search.checkout } : {},
+      replace: true,
+    });
+  },
+});

--- a/apps/web/src/routes/_authed/settings/billing.tsx
+++ b/apps/web/src/routes/_authed/settings/billing.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
-import { AlertTriangle, CircleCheck, Loader2 } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -12,7 +12,6 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { SegmentedControl } from "@/components/ui/segmented-control";
 import { PageError } from "@/components/feedback";
 import { PageHeader } from "@/components/shared/page-header";
 import { DestructiveConfirm } from "@/components/dialogs/destructive-confirm";
@@ -20,22 +19,13 @@ import { toast } from "@/components/toast";
 import { useMe, activeRole } from "@/features/auth/use-auth";
 import {
   useBilling,
-  useCreateBillingCheckout,
   useCreateBillingPortal,
   useCancelBillingSubscription,
-  useVerifyRazorpayCheckout,
   useBillingCheckoutReturn,
   isCheckoutTier,
   type BillingInfo,
-  type BillingProvider,
-  type BillingCurrency,
-  type RazorpayCheckoutData,
-  type CheckoutTierId,
 } from "@/features/billing/use-billing";
-import {
-  loadRazorpayCheckout,
-  type RazorpayHandlerResponse,
-} from "@/features/billing/razorpay-checkout";
+import { useCheckoutFlow } from "@/features/billing/use-checkout-flow";
 import {
   billingBannerFor,
   formatBillingDate,
@@ -48,6 +38,8 @@ import {
   planLabel,
 } from "@/features/billing/plan-catalog";
 import { UsageMeterList } from "@/features/billing/usage-meter-list";
+import { PaymentMethodPicker } from "@/features/billing/payment-method-picker";
+import { CheckoutReturnBanner } from "@/features/billing/checkout-return-banner";
 import { cn } from "@/lib/utils";
 
 // M16 Phase B — the tenant Billing settings page. Owner-only, hosted-only
@@ -314,119 +306,6 @@ function BillingContent({
 }
 
 // ---------------------------------------------------------------------------
-// Checkout-return banner — success | cancel | finalizing | timed out
-// ---------------------------------------------------------------------------
-
-function CheckoutReturnBanner({
-  status,
-  finalizing,
-  timedOut,
-}: {
-  status: "success" | "cancel" | undefined;
-  finalizing: boolean;
-  timedOut: boolean;
-}) {
-  if (!status) return null;
-
-  if (status === "cancel") {
-    return (
-      <div
-        role="status"
-        className="rounded-lg border border-border bg-muted/40 px-4 py-3 text-sm text-muted-foreground"
-      >
-        Checkout was canceled. No changes were made to your plan.
-      </div>
-    );
-  }
-
-  if (finalizing) {
-    return (
-      <div
-        role="status"
-        aria-live="polite"
-        className="flex items-center gap-2 rounded-lg border border-border bg-muted/40 px-4 py-3 text-sm text-foreground"
-      >
-        <Loader2 aria-hidden="true" className="size-4 animate-spin" />
-        Finalizing your subscription…
-      </div>
-    );
-  }
-
-  if (timedOut) {
-    return (
-      <div
-        role="status"
-        className="rounded-lg border border-border bg-muted/40 px-4 py-3 text-sm text-muted-foreground"
-      >
-        Payment received. It can take a few minutes for your plan to update
-        here.
-      </div>
-    );
-  }
-
-  return (
-    <div
-      role="status"
-      className="flex items-center gap-2 rounded-lg bg-[var(--color-success-subtle)] px-4 py-3 text-sm text-[var(--color-success-subtle-fg)]"
-    >
-      <CircleCheck aria-hidden="true" className="size-4" />
-      Subscription updated.
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Payment method picker — provider (Stripe/Razorpay) + Razorpay-only currency
-// ---------------------------------------------------------------------------
-
-function PaymentMethodPicker({
-  provider,
-  onProviderChange,
-  currency,
-  onCurrencyChange,
-}: {
-  provider: BillingProvider;
-  onProviderChange: (provider: BillingProvider) => void;
-  currency: BillingCurrency;
-  onCurrencyChange: (currency: BillingCurrency) => void;
-}) {
-  return (
-    <div className="flex flex-wrap items-center gap-4 rounded-lg border border-border bg-muted/20 px-4 py-3 text-sm">
-      <div className="flex items-center gap-2">
-        <span className="font-medium text-foreground">Pay via</span>
-        <SegmentedControl
-          aria-label="Payment provider"
-          value={provider}
-          onChange={onProviderChange}
-          options={[
-            { value: "stripe", label: "Stripe" },
-            { value: "razorpay", label: "Razorpay" },
-          ]}
-        />
-      </div>
-      {provider === "razorpay" ? (
-        <div className="flex items-center gap-2">
-          <span className="font-medium text-foreground">Currency</span>
-          <SegmentedControl
-            aria-label="Currency"
-            value={currency}
-            onChange={onCurrencyChange}
-            options={[
-              { value: "USD", label: "USD ($)" },
-              { value: "INR", label: "INR (₹)" },
-            ]}
-          />
-          <span className="text-xs text-muted-foreground">
-            Prices below are shown in USD; the exact INR amount is confirmed
-            in the payment window before you pay.
-          </span>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Plan tiers grid
 // ---------------------------------------------------------------------------
 
@@ -443,67 +322,16 @@ function PlanTiersGrid({
   portalPending: boolean;
   onCheckoutSuccess: () => void;
 }) {
-  const checkout = useCreateBillingCheckout();
-  const verify = useVerifyRazorpayCheckout();
-  const [provider, setProvider] = useState<BillingProvider>("stripe");
-  const [currency, setCurrency] = useState<BillingCurrency>("USD");
+  const {
+    provider,
+    currency,
+    setProvider,
+    setCurrency,
+    startCheckout,
+    isStarting,
+    error: checkoutError,
+  } = useCheckoutFlow({ onCheckoutSuccess });
   const usedSites = billing.meters.sites?.used ?? 0;
-
-  function openRazorpayCheckout(data: RazorpayCheckoutData) {
-    loadRazorpayCheckout()
-      .then((Razorpay) => {
-        const instance = new Razorpay({
-          key: data.key_id,
-          subscription_id: data.subscription_id,
-          amount: data.amount,
-          currency: data.currency,
-          name: "WPMgr",
-          description: "WPMgr subscription",
-          handler: (response: RazorpayHandlerResponse) => {
-            // Verify is a UX confirmation only — the poll below (via
-            // onCheckoutSuccess -> the shared Stripe success-poll mechanism)
-            // is what actually observes the plan flip, so it must start
-            // regardless of whether verify itself succeeds or fails.
-            verify.mutate(response, {
-              onSettled: () => onCheckoutSuccess(),
-            });
-          },
-          modal: {
-            // The operator closed the modal without paying — a normal
-            // cancel, never an error. No toast, no navigation.
-            ondismiss: () => {},
-          },
-        });
-        instance.open();
-      })
-      .catch((err: unknown) => {
-        toast.error("Could not open the Razorpay payment window", {
-          description:
-            err instanceof Error
-              ? err.message
-              : "Please try again, or choose Stripe instead.",
-        });
-      });
-  }
-
-  function startCheckout(tier: CheckoutTierId) {
-    checkout.mutate(
-      {
-        tier,
-        provider,
-        currency: provider === "razorpay" ? currency : undefined,
-      },
-      {
-        onSuccess: (result) => {
-          if (result.razorpay) {
-            openRazorpayCheckout(result.razorpay);
-          } else if (result.url) {
-            window.location.href = result.url;
-          }
-        },
-      },
-    );
-  }
 
   return (
     <div className="space-y-3">
@@ -571,13 +399,13 @@ function PlanTiersGrid({
                   <Button
                     type="button"
                     className="w-full"
-                    disabled={blocked || checkout.isPending}
+                    disabled={blocked || isStarting}
                     onClick={() => {
                       if (!isCheckoutTier(tier.id)) return;
                       startCheckout(tier.id);
                     }}
                   >
-                    {checkout.isPending
+                    {isStarting
                       ? provider === "razorpay"
                         ? "Opening…"
                         : "Redirecting…"
@@ -591,9 +419,9 @@ function PlanTiersGrid({
           );
         })}
       </div>
-      {checkout.isError ? (
+      {checkoutError ? (
         <p role="alert" className="text-sm text-destructive">
-          {checkout.error.message}
+          {checkoutError.message}
         </p>
       ) : null}
     </div>

--- a/apps/web/src/routes/_authed/welcome.checkout.tsx
+++ b/apps/web/src/routes/_authed/welcome.checkout.tsx
@@ -1,0 +1,246 @@
+import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
+import { useEffect, useRef, useState } from "react";
+import { z } from "zod";
+import { Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { PageHeader } from "@/components/shared/page-header";
+import { ensureMe } from "@/features/auth/use-auth";
+import {
+  useBilling,
+  useBillingCheckoutReturn,
+  type CheckoutTierId,
+  type BillingCurrency,
+} from "@/features/billing/use-billing";
+import { useCheckoutFlow } from "@/features/billing/use-checkout-flow";
+import { PaymentMethodPicker } from "@/features/billing/payment-method-picker";
+import { CheckoutReturnBanner } from "@/features/billing/checkout-return-banner";
+import { planCatalogEntry } from "@/features/billing/plan-catalog";
+import { readPendingPlan, clearPendingPlan } from "@/features/billing/pending-plan";
+
+// M16 Phase C2 — the post-verify "finish signing up for a plan" screen.
+// Reached from either:
+//   - /register's first-account bootstrap branch (session established
+//     immediately, Me.desired_plan present) — see routes/register.tsx.
+//   - /verify-email's 200 branch (Me.desired_plan present) — see
+//     routes/verify-email.tsx.
+// Never a normal nav destination (no sidebar entry) — always arrived at via
+// one of those two redirects, always carrying `?plan=`.
+
+const checkoutSearchSchema = z.object({
+  plan: z.enum(["starter", "agency", "scale"]).optional().catch(undefined),
+  currency: z.enum(["USD", "INR"]).optional().catch(undefined),
+});
+
+/**
+ * Resolve the target tier: the URL's own `?plan=` wins, falling back to the
+ * same-browser localStorage/cookie stash (see pending-plan.ts). Exported as a
+ * pure function so the "URL then stash" precedence is directly unit-testable
+ * without a router/React harness.
+ */
+export function resolveCheckoutTier(
+  searchPlan: CheckoutTierId | undefined,
+  stashPlan: CheckoutTierId | undefined,
+): CheckoutTierId | undefined {
+  return searchPlan ?? stashPlan;
+}
+
+/**
+ * Whether the Razorpay in-page success path should drop the operator into
+ * Sites: only once a checkout actually completed AND the checkout-return
+ * poll has concluded (found the plan flip, or timed out — either way there
+ * is nothing more productive to show here). Exported for a direct,
+ * timer-free unit test of the edge condition (mirrors
+ * `shouldPollCheckoutReturn` in use-billing.ts).
+ */
+export function shouldDropIntoSitesAfterCheckout(params: {
+  status: "success" | undefined;
+  wasFinalizing: boolean;
+  isFinalizing: boolean;
+}): boolean {
+  return params.status === "success" && params.wasFinalizing && !params.isFinalizing;
+}
+
+export const Route = createFileRoute("/_authed/welcome/checkout")({
+  validateSearch: checkoutSearchSchema,
+  beforeLoad: async ({ context, search }) => {
+    const me = await ensureMe(context.queryClient);
+    // Self-host safety: paid checkout only ever exists on a hosted instance.
+    if (!me?.hosted) {
+      throw redirect({ to: "/sites" });
+    }
+    const tier = resolveCheckoutTier(search.plan, readPendingPlan()?.plan);
+    if (!tier) {
+      throw redirect({ to: "/sites" });
+    }
+  },
+  component: WelcomeCheckoutPage,
+});
+
+function WelcomeCheckoutPage() {
+  const search = Route.useSearch();
+  // Resolved ONCE at mount (lazy initializer) rather than re-derived every
+  // render: the mount effect below clears the pending-plan stash right after
+  // starting checkout, and re-reading the stash on a later render would
+  // otherwise make an already-in-flight checkout's tier disappear.
+  const [resolved] = useState(() => {
+    const stash = readPendingPlan();
+    return {
+      tier: resolveCheckoutTier(search.plan, stash?.plan),
+      currency: search.currency ?? stash?.currency,
+    };
+  });
+
+  // beforeLoad already guarantees a resolvable tier + a hosted session before
+  // this component ever mounts; this defensive check only covers a same-tick
+  // race and keeps the child component's tier prop non-optional.
+  if (!resolved.tier) return null;
+
+  return (
+    <WelcomeCheckoutContent tier={resolved.tier} currencyHint={resolved.currency} />
+  );
+}
+
+function WelcomeCheckoutContent({
+  tier,
+  currencyHint,
+}: {
+  tier: CheckoutTierId;
+  currencyHint: BillingCurrency | undefined;
+}) {
+  const navigate = useNavigate();
+  const entry = planCatalogEntry(tier);
+  // Guards the auto-start effect so React StrictMode's dev double-invoke
+  // never fires two checkout-creation calls (same pattern as
+  // verify-email.tsx's own `firedRef`).
+  const firedRef = useRef(false);
+  const [checkoutStatus, setCheckoutStatus] = useState<"success" | undefined>(
+    undefined,
+  );
+  const wasFinalizingRef = useRef(false);
+
+  const billing = useBilling({ enabled: true });
+  const checkoutReturn = useBillingCheckoutReturn(
+    checkoutStatus,
+    billing.data,
+    () => void billing.refetch(),
+  );
+
+  const {
+    provider,
+    currency,
+    setProvider,
+    setCurrency,
+    startCheckout,
+    isStarting,
+    error,
+  } = useCheckoutFlow({
+    initialCurrency: currencyHint,
+    // Only ever fires on the Razorpay in-page path — Stripe's own hosted
+    // redirect leaves this page entirely (see checkout-return-banner.tsx's
+    // module doc and the /billing compatibility redirect route).
+    onCheckoutSuccess: () => setCheckoutStatus("success"),
+  });
+
+  useEffect(() => {
+    if (firedRef.current) return;
+    firedRef.current = true;
+    startCheckout(tier);
+    // The same-browser stash has done its job (resolved above, if it was
+    // ever needed) — clear it now that a checkout has actually started.
+    clearPendingPlan();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tier]);
+
+  useEffect(() => {
+    const wasFinalizing = wasFinalizingRef.current;
+    wasFinalizingRef.current = checkoutReturn.finalizing;
+    if (
+      shouldDropIntoSitesAfterCheckout({
+        status: checkoutStatus,
+        wasFinalizing,
+        isFinalizing: checkoutReturn.finalizing,
+      })
+    ) {
+      void navigate({ to: "/sites" });
+    }
+  }, [checkoutStatus, checkoutReturn.finalizing, navigate]);
+
+  function handleSkip() {
+    clearPendingPlan();
+    void navigate({ to: "/sites" });
+  }
+
+  return (
+    <section className="mx-auto max-w-lg space-y-6 py-8">
+      <PageHeader
+        title={`Complete your ${entry?.name ?? "plan"} subscription`}
+        subline="One more step and your paid features are live."
+      />
+
+      <CheckoutReturnBanner
+        status={checkoutStatus}
+        finalizing={checkoutReturn.finalizing}
+        timedOut={checkoutReturn.timedOut}
+      />
+
+      <Card>
+        <CardHeader className="space-y-1">
+          <CardTitle className="flex items-center gap-2">
+            <Sparkles aria-hidden="true" className="size-4 text-[var(--color-primary)]" />
+            {entry?.name ?? "Plan"}
+          </CardTitle>
+          {entry ? <CardDescription>{entry.priceLabel}</CardDescription> : null}
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {entry ? (
+            <ul className="space-y-1 text-sm text-muted-foreground">
+              <li>{entry.sitesLimit} sites</li>
+              <li>{entry.storageLabel}</li>
+              <li>{entry.cadenceLabel}</li>
+            </ul>
+          ) : null}
+
+          <PaymentMethodPicker
+            provider={provider}
+            onProviderChange={setProvider}
+            currency={currency}
+            onCurrencyChange={setCurrency}
+          />
+
+          {error ? (
+            <p role="alert" className="text-sm text-destructive">
+              {error.message}
+            </p>
+          ) : null}
+
+          <Button
+            type="button"
+            className="w-full"
+            disabled={isStarting}
+            onClick={() => startCheckout(tier)}
+          >
+            {isStarting
+              ? provider === "razorpay"
+                ? "Opening…"
+                : "Redirecting…"
+              : "Continue to payment"}
+          </Button>
+        </CardContent>
+      </Card>
+
+      <div className="text-center">
+        <Button type="button" variant="ghost" onClick={handleSkip}>
+          Skip for now
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/routes/register.tsx
+++ b/apps/web/src/routes/register.tsx
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useState } from "react";
-import { AlertCircle, AlertTriangle, CheckCircle2, Globe } from "lucide-react";
+import { AlertCircle, AlertTriangle, CheckCircle2, Globe, Sparkles } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -16,8 +16,23 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { ensureMe, useRegister, useResendVerification } from "@/features/auth/use-auth";
+import { planCatalogEntry } from "@/features/billing/plan-catalog";
+import { stashPendingPlan } from "@/features/billing/pending-plan";
+import type { BillingCurrency, CheckoutTierId } from "@/features/billing/use-billing";
+
+// M16 Phase C2 — signup-to-premium: a plan chosen on the marketing pricing
+// page is carried through `/register?plan=...&currency=...` (see
+// registerSearchSchema below). Unknown/`free` values are silently ignored
+// (`.catch(undefined)`, same idiom as admin/accounts/index.tsx's own note on
+// why `z.enum()` needs a literal tuple) rather than erroring the whole route
+// out — a stray or stale query param must never break the signup page.
+const registerSearchSchema = z.object({
+  plan: z.enum(["starter", "agency", "scale"]).optional().catch(undefined),
+  currency: z.enum(["USD", "INR"]).optional().catch(undefined),
+});
 
 export const Route = createFileRoute("/register")({
+  validateSearch: registerSearchSchema,
   // Already signed in? Nothing to bootstrap — go to the app.
   beforeLoad: async ({ context }) => {
     const me = await ensureMe(context.queryClient);
@@ -45,6 +60,9 @@ type RegisterValues = z.infer<typeof registerSchema>;
 
 function RegisterPage() {
   const navigate = useNavigate();
+  const search = Route.useSearch();
+  const chosenPlan: CheckoutTierId | undefined = search.plan;
+  const chosenCurrency: BillingCurrency | undefined = search.currency;
   const registerMutation = useRegister();
   const resendMutation = useResendVerification();
   // When the self-serve path succeeds we flip to a confirmation view showing
@@ -69,14 +87,29 @@ function RegisterPage() {
         name: values.name || undefined,
         tenant_name: values.tenant_name || undefined,
         tenant_slug: values.tenant_slug || undefined,
+        plan: chosenPlan,
       },
       {
         onSuccess: (result) => {
           if (result.pending) {
             // Normal self-serve path: must verify email before logging in.
+            // Stash the chosen plan as a same-browser fast path — the
+            // canonical carrier is still the backend (persisted against the
+            // verification token, surfaced back as Me.desired_plan).
+            if (chosenPlan) {
+              stashPendingPlan({ plan: chosenPlan, currency: chosenCurrency });
+            }
             setPendingEmail(values.email);
+          } else if (result.me?.desired_plan && result.me.hosted) {
+            // First-account bootstrap path (session established immediately)
+            // with a captured paid-plan intent on a hosted instance: skip
+            // straight to checkout instead of landing on an empty Sites page.
+            void navigate({
+              to: "/welcome/checkout",
+              search: { plan: result.me.desired_plan, currency: chosenCurrency },
+            });
           } else {
-            // First-account path: session established, go into the app.
+            // First-account path, no paid intent (or self-hosted): go into the app.
             void navigate({ to: "/sites" });
           }
         },
@@ -182,6 +215,8 @@ function RegisterPage() {
           </CardDescription>
         </CardHeader>
         <CardContent>
+          {chosenPlan ? <PlanChip plan={chosenPlan} /> : null}
+
           <form
             onSubmit={(e) => void onSubmit(e)}
             noValidate
@@ -258,6 +293,26 @@ function RegisterPage() {
         </CardContent>
       </Card>
     </main>
+  );
+}
+
+/**
+ * Small summary chip shown above the form when the signup URL carries a
+ * `?plan=` hint (e.g. from the marketing pricing page). Purely informational
+ * — the actual plan is threaded through the register call and, on a hosted
+ * instance, resolved server-side; this never blocks a free signup.
+ */
+function PlanChip({ plan }: { plan: CheckoutTierId }) {
+  const entry = planCatalogEntry(plan);
+  if (!entry) return null;
+  return (
+    <div className="mb-4 flex items-center gap-2 rounded-full border border-[var(--color-primary)]/30 bg-[var(--color-primary)]/10 px-3 py-1.5 text-xs font-medium text-[var(--color-primary)]">
+      <Sparkles aria-hidden="true" className="size-3.5 shrink-0" />
+      You&apos;re signing up for the {entry.name} plan
+      <span className="text-[var(--color-primary)]/70">
+        &middot; {entry.priceLabel}
+      </span>
+    </div>
   );
 }
 

--- a/apps/web/src/routes/verify-email.tsx
+++ b/apps/web/src/routes/verify-email.tsx
@@ -26,6 +26,7 @@ import {
   useVerifyEmail,
   useResendVerification,
 } from "@/features/auth/use-auth";
+import { readPendingPlan } from "@/features/billing/pending-plan";
 
 // Unauthenticated — NOT under _authed, no beforeLoad guard.
 const searchSchema = z.object({
@@ -137,8 +138,22 @@ function VerifyWithToken({ token }: { token: string }) {
       {
         onSuccess: (result) => {
           if (result.status === 200) {
-            // Session is now live (me is in the query cache). Navigate into app.
-            void navigate({ to: "/sites" });
+            // Session is now live (me is in the query cache). A hosted
+            // instance where this account captured a paid-plan intent at
+            // signup (Me.desired_plan, single-use — see use-auth.ts) skips
+            // straight to checkout instead of an empty Sites page. The
+            // local same-browser stash only ever supplies a `?currency=`
+            // hint here; `desired_plan`+`hosted` alone decide whether to go.
+            const me = result.me;
+            if (me?.desired_plan && me.hosted) {
+              const stash = readPendingPlan();
+              void navigate({
+                to: "/welcome/checkout",
+                search: { plan: me.desired_plan, currency: stash?.currency },
+              });
+            } else {
+              void navigate({ to: "/sites" });
+            }
           }
           // 410/429 handled by rendering below.
         },

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -1151,6 +1151,12 @@ export const MeSchema = {
       description:
         "Whether the active tenant's plan currently permits routing a NEW backup to CP-managed storage (M16 Phase B). Always true on a self-hosted or hosted-billing-disabled instance, and true for every paid plan; false only for a free-plan tenant under WPMGR_HOSTED. This is a coarse, role-safe display signal for the operator-facing /destinations page (which any operator can view, unlike the owner-only /billing summary) — it is NOT the authoritative gate; the backup-run endpoints enforce the real check server-side and return 402 byo_destination_required when denied. Restoring/downloading an existing backup is never gated by this or any other check.\n",
     },
+    desired_plan: {
+      type: "string",
+      enum: ["starter", "agency", "scale"],
+      description:
+        'The M16 Phase 0 "sign up into a plan" hint captured at registration (RegisterRequest.plan), single-use: present ONLY in the direct response to POST /auth/verify-email (read off the just-consumed verification token) or the first-run bootstrap response of POST /auth/register — never on GET /auth/me or any other Me-returning response. The frontend uses this to auto-start checkout right after the account is verified. Absent means no intent was captured (free signup, self-hosted instance, or a resend/login/OIDC path that never carries one).',
+    },
   },
 } as const;
 
@@ -1228,6 +1234,12 @@ export const RegisterRequestSchema = {
       type: "string",
       maxLength: 64,
       pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+    },
+    plan: {
+      type: "string",
+      enum: ["starter", "agency", "scale"],
+      description:
+        'OPTIONAL "sign up into a plan" hint (M16 Phase 0, hosted billing only). Omit for an ordinary free-tier signup. Persisted against the email-verification token and surfaced back as Me.desired_plan once the account is verified (or immediately, on the first-run bootstrap path), so the frontend can auto-start checkout. A self-hosted instance, or any value that does not name a real paid tier, is silently treated as no intent — this field can never fail registration on its own.',
     },
   },
 } as const;

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -618,6 +618,10 @@ export type Me = {
    *
    */
   managed_storage_allowed?: boolean;
+  /**
+   * The M16 Phase 0 "sign up into a plan" hint captured at registration (RegisterRequest.plan), single-use: present ONLY in the direct response to POST /auth/verify-email (read off the just-consumed verification token) or the first-run bootstrap response of POST /auth/register — never on GET /auth/me or any other Me-returning response. The frontend uses this to auto-start checkout right after the account is verified. Absent means no intent was captured (free signup, self-hosted instance, or a resend/login/OIDC path that never carries one).
+   */
+  desired_plan?: "starter" | "agency" | "scale";
 };
 
 /**
@@ -664,6 +668,10 @@ export type RegisterRequest = {
   name?: string;
   tenant_name?: string;
   tenant_slug?: string;
+  /**
+   * OPTIONAL "sign up into a plan" hint (M16 Phase 0, hosted billing only). Omit for an ordinary free-tier signup. Persisted against the email-verification token and surfaced back as Me.desired_plan once the account is verified (or immediately, on the first-run bootstrap path), so the frontend can auto-start checkout. A self-hosted instance, or any value that does not name a real paid tier, is silently treated as no intent — this field can never fail registration on its own.
+   */
+  plan?: "starter" | "agency" | "scale";
 };
 
 export type InviteRequest = {

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -9631,6 +9631,19 @@ components:
             check server-side and return 402 byo_destination_required when
             denied. Restoring/downloading an existing backup is never gated
             by this or any other check.
+        desired_plan:
+          type: string
+          enum: [starter, agency, scale]
+          description: >-
+            The M16 Phase 0 "sign up into a plan" hint captured at
+            registration (RegisterRequest.plan), single-use: present ONLY in
+            the direct response to POST /auth/verify-email (read off the
+            just-consumed verification token) or the first-run bootstrap
+            response of POST /auth/register — never on GET /auth/me or any
+            other Me-returning response. The frontend uses this to
+            auto-start checkout right after the account is verified. Absent
+            means no intent was captured (free signup, self-hosted instance,
+            or a resend/login/OIDC path that never carries one).
 
     PrincipalRole:
       type: string
@@ -9690,6 +9703,18 @@ components:
           type: string
           maxLength: 64
           pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        plan:
+          type: string
+          enum: [starter, agency, scale]
+          description: >-
+            OPTIONAL "sign up into a plan" hint (M16 Phase 0, hosted billing
+            only). Omit for an ordinary free-tier signup. Persisted against
+            the email-verification token and surfaced back as
+            Me.desired_plan once the account is verified (or immediately, on
+            the first-run bootstrap path), so the frontend can auto-start
+            checkout. A self-hosted instance, or any value that does not name
+            a real paid tier, is silently treated as no intent — this field
+            can never fail registration on its own.
     InviteRequest:
       type: object
       required: [email, password, role]


### PR DESCRIPTION
Marketing pick-a-plan -> register carries + persists the plan (survives cross-device email verification) -> post-verify /welcome/checkout auto-opens checkout -> premium (account is born free, payment upgrades it). Plus a public cached /api/v1/pricing (live Razorpay+Stripe amounts, no secrets, hosted-only, fail-open + singleflight-hardened) consumed by the marketing page at build time with a USD/INR toggle + fallback. Reuses the existing checkout via an extracted useCheckoutFlow. Security review SHIP. apps/api + 999 web tests + marketing build green. Behind WPMGR_HOSTED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Start signup directly from a selected paid plan and continue to checkout after email verification.
  * Choose Stripe or Razorpay and supported currencies during checkout.
  * Marketing pricing now displays live provider pricing, with automatic fallback pricing when unavailable.
  * Added a “Skip for now” option before completing a subscription.

* **Bug Fixes**
  * Checkout returns now correctly open Billing Settings and display confirmation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->