### PR TITLE
fix(river): media-encoder refuses default/public schema, isolating fleet leader election (GH #205)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -227,19 +227,20 @@ WPMGR_SUPPORT_EMAIL=
 # ships). Format: true|false.
 WPMGR_AUTOLOGIN_REQUIRE_2FA_STEP_UP=false
 
-# ---- Media Optimizer (ADR-043, opt-in `media` profile) ----
+# ---- Media Optimizer (ADR-043, part of the base Compose stack) ----
 # URL of the media-encoder service for the scale-to-zero waker; empty disables the
 # wake POST. Format: URL. e.g. http://media-encoder:8080
 WPMGR_MEDIA_ENCODER_URL=
 # Bounded encode concurrency — read ONLY by the media-encoder binary, not the api.
 # Format: integer. e.g. 2
 WPMGR_MEDIA_ENCODE_WORKERS=2
-# River schema for encoder-owned media and screenshot jobs. The bundled compose
-# profile uses media_encoder for fresh installs; set the same value on both api
-# and media-encoder processes. Existing queued media/screenshot jobs in
-# public.river_job are not moved automatically. On upgrade, drain those jobs
-# first, or temporarily set this empty / public on both services to keep legacy
-# shared-schema mode.
+# River schema for encoder-owned media and screenshot jobs. REQUIRED to be a
+# dedicated schema (never the api's default/public schema) whenever a
+# media-encoder process runs: River leader election is per-schema, and a
+# media-encoder sharing the api's schema can silently win leadership and stop
+# ALL fleet periodic jobs (backups, uptime checks, sweeps) with no error (GH
+# #205). The media-encoder binary now refuses to start on the default/public
+# schema. Set the SAME value on both the api and media-encoder processes.
 # Format: simple Postgres identifier. e.g. media_encoder
 WPMGR_RIVER_MEDIA_SCHEMA=media_encoder
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.54] - 2026-07-10
+
+### Fixed
+
+- On self-hosted installs where the media-encoder ran using the API's default database schema (an unset or `public` `WPMGR_RIVER_MEDIA_SCHEMA`), it could silently take over background-job leader election and stop every scheduled fleet job, including backups, uptime checks, and cleanups, with no error anywhere (GH #205). The media-encoder now refuses to start in that misconfiguration instead of risking it. The safe, dedicated schema is now the built-in default, so no configuration change is needed on a fresh or existing install; the API also logs a clear warning if it ever sees itself configured to share its schema with a media-encoder. Any media or screenshot jobs left behind in the shared schema from before this fix are cleaned up automatically.
+
 ## [0.61.53] - 2026-07-10
 
 ### Added

--- a/apps/api/cmd/media-encoder/main.go
+++ b/apps/api/cmd/media-encoder/main.go
@@ -85,6 +85,21 @@ func run() error {
 	}
 	logger.Info("media River schema resolved", slog.String("media_river_schema", mediaSchemaLog))
 
+	// GH #205 (CRITICAL): this binary runs WORKERS, which makes it a River
+	// leadership candidate on whatever schema it connects to. River leader
+	// election and the periodic-job scheduler are per-schema, and only the
+	// elected leader's own client runs its PeriodicJobs. If this process
+	// shares the API's default/public schema, it can win leadership and
+	// silently stop the API's ENTIRE fleet cron (uptime_probe,
+	// backup_scheduler, site_connection_sweep, health-check, reapers, every
+	// GC/rollup) with no error anywhere. Refuse to boot rather than risk it —
+	// schema isolation is mandatory, not advisory.
+	if riverutil.IsDefaultSchema(mediaSchema) {
+		return errEnv("WPMGR_RIVER_MEDIA_SCHEMA must be set to a dedicated schema (e.g. \"media_encoder\"); " +
+			"running on the API's default/public River schema silently steals leader election and stops " +
+			"ALL fleet periodic jobs (GH #205)")
+	}
+
 	if !cfg.S3.Enabled() {
 		return errEnv("WPMGR_S3_BUCKET is required: the media-encoder transfers bytes via presigned object storage")
 	}
@@ -264,7 +279,18 @@ func run() error {
 	// run it always-on and never call /internal/drain.
 	// Pass encoder-owned queues to the drain handler. The encoder must stay warm
 	// while any queue it processes has pending work.
+	//
+	// Bind $PORT here, BEFORE the reconcile sweep below, so the startup probe
+	// passes immediately regardless of how large the public backlog is.
 	healthSrv := startHealthServer(logger, pool, mediaSchema, model.MediaEncodeQueue, screenshot.ScreenshotQueue, mediafont.FontTranscodeQueue)
+
+	// GH #205 follow-up: move any encoder-owned jobs stranded in the public
+	// schema (from before this schema was dedicated) onto this client. The
+	// hard-fail above guarantees mediaSchema is non-default here, so this
+	// always runs once the client is up; it is a no-op once public.river_job
+	// holds no matching rows. Best-effort, batched, and only after $PORT is
+	// bound — so it never delays startup.
+	reconcileStrandedPublicJobs(ctx, pool, client, logger)
 
 	<-ctx.Done()
 	logger.Info("shutdown signal received, draining encode queue")

--- a/apps/api/cmd/media-encoder/main_test.go
+++ b/apps/api/cmd/media-encoder/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+// main_test.go — GH #205 regression lock: the media-encoder MUST refuse to
+// boot on the API's default/public River schema, since this binary runs
+// workers and is therefore a leadership candidate on whatever schema it
+// connects to. Both assertions run before run() touches the DB or S3, so
+// they need no external services.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRun_DefaultSchemaRefused verifies run() returns a clear envError before
+// ever dialing the database or object storage when WPMGR_RIVER_MEDIA_SCHEMA
+// resolves to the default/public schema (unset, empty, or "public").
+func TestRun_DefaultSchemaRefused(t *testing.T) {
+	for _, schema := range []string{"", "public", "PUBLIC"} {
+		t.Run("schema="+schema, func(t *testing.T) {
+			t.Setenv("WPMGR_RIVER_MEDIA_SCHEMA", schema)
+			err := run()
+			if err == nil {
+				t.Fatal("run() = nil error, want a refusal for the default/public River schema")
+			}
+			if !strings.Contains(err.Error(), "WPMGR_RIVER_MEDIA_SCHEMA") || !strings.Contains(err.Error(), "GH #205") {
+				t.Fatalf("run() error = %q, want the GH #205 dedicated-schema refusal", err.Error())
+			}
+		})
+	}
+}
+
+// TestRun_DedicatedSchemaPassesGate verifies a real dedicated schema clears
+// the GH #205 gate: run() proceeds past the schema check into the next
+// startup guard (S3 configuration) instead of refusing on schema grounds.
+func TestRun_DedicatedSchemaPassesGate(t *testing.T) {
+	t.Setenv("WPMGR_RIVER_MEDIA_SCHEMA", "media_encoder")
+	t.Setenv("WPMGR_S3_BUCKET", "")
+	err := run()
+	if err == nil {
+		t.Fatal("run() = nil error, want the (unrelated) S3-required error in this unconfigured test env")
+	}
+	if strings.Contains(err.Error(), "GH #205") {
+		t.Fatalf("run() error = %q, want the schema gate to have passed (expected the S3 error instead)", err.Error())
+	}
+	if !strings.Contains(err.Error(), "WPMGR_S3_BUCKET") {
+		t.Fatalf("run() error = %q, want the S3-required error", err.Error())
+	}
+}

--- a/apps/api/cmd/media-encoder/reconcile.go
+++ b/apps/api/cmd/media-encoder/reconcile.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	mediafont "github.com/mosamlife/wpmgr/apps/api/internal/media/font"
+	"github.com/mosamlife/wpmgr/apps/api/internal/media/model"
+	"github.com/mosamlife/wpmgr/apps/api/internal/screenshot"
+	"github.com/mosamlife/wpmgr/apps/api/internal/screenshot/capture"
+)
+
+// encoderOwnedKinds lists every River job kind this binary's own workers
+// process. reconcileStrandedPublicJobs is STRICTLY scoped to these kinds so
+// it can never read or mutate a row belonging to the API's own public-schema
+// periodics (uptime_probe, backup_scheduler, site_connection_sweep, ...) —
+// see GH #205.
+//
+// INVARIANT: every kind here MUST be disposable / server-re-derivable. The
+// reconcile has at-least-once (not exactly-once) semantics and unconditionally
+// cancels the public row even when the re-insert into the dedicated schema
+// fails, so adding a kind whose loss or duplication would corrupt data (a
+// backup, a billing charge, anything with side effects that must run exactly
+// once) here would turn a best-effort sweep into silent data loss.
+var encoderOwnedKinds = []string{
+	model.EncodeArgs{}.Kind(),
+	mediafont.TranscodeArgs{}.Kind(),
+	screenshot.CaptureArgs{}.Kind(),
+	capture.WeeklyFanoutArgs{}.Kind(),
+}
+
+// reconcileBatchSize bounds how many stranded rows a single transaction claims.
+// The cutover boot carries the largest public backlog; batching keeps each
+// transaction's row lock short and makes incremental progress instead of
+// holding one long transaction that could delay the health-server port bind
+// (and thus the Cloud Run startup probe). The loop repeats until a batch comes
+// back short, so it still fully drains in one boot, just in bounded chunks.
+const reconcileBatchSize = 500
+
+// reconcileMaxBatches caps the sweep loop so a pathological state (e.g. rows
+// that keep failing to cancel) can never spin the boot path forever.
+const reconcileMaxBatches = 10000
+
+// strandedJob is one non-terminal row read from the public river_job table
+// that this process now owns on a dedicated media River schema.
+type strandedJob struct {
+	id   int64
+	kind string
+	args []byte
+}
+
+// reconcileStrandedPublicJobs re-enqueues encoder-owned jobs left behind in
+// the shared/public River schema from before WPMGR_RIVER_MEDIA_SCHEMA was set
+// to a dedicated schema (GH #205: while both processes shared the public
+// schema, River leader election could hand this process leadership and
+// silently stop the API's fleet periodics — the fix is schema isolation, but
+// any encoder jobs already sitting in public.river_job at the moment of the
+// fix would otherwise be stranded forever, since nothing polls that schema
+// for these kinds anymore).
+//
+// Scoped STRICTLY to encoderOwnedKinds — it never reads or writes any other
+// row, so the API's own public-schema jobs are untouched. Best-effort and
+// non-fatal: called only when mediaSchema is a real dedicated schema, and any
+// failure is logged and swallowed. It runs after the health server has already
+// bound $PORT (see main.go), so even a large cutover sweep cannot delay the
+// Cloud Run startup probe.
+//
+// Each stranded row is claimed with FOR UPDATE SKIP LOCKED (safe under
+// rolling-deploy races between multiple encoder replicas), re-inserted into
+// the dedicated-schema client when its args decode cleanly, and always marked
+// 'cancelled' in the public table afterward — whether or not the re-insert
+// succeeded. Semantics are AT LEAST ONCE into the dedicated schema, not exactly
+// once: the re-insert auto-commits on its own connection before the public row
+// is cancelled at tx.Commit, so a crash in that window re-selects the row on the
+// next boot and re-inserts it. That is safe because encoderOwnedKinds are all
+// disposable/idempotent (see the invariant above); the bias is deliberately
+// toward re-running disposable work over stranding it in a schema nothing polls.
+func reconcileStrandedPublicJobs(ctx context.Context, pool *db.Pool, client *river.Client[pgx.Tx], logger *slog.Logger) {
+	totalReenqueued := 0
+	totalDropped := 0
+	for batch := 0; batch < reconcileMaxBatches; batch++ {
+		claimed, reenqueued, dropped, err := reconcileOneBatch(ctx, pool, client, logger)
+		totalReenqueued += reenqueued
+		totalDropped += dropped
+		if err != nil {
+			break // already logged; stop rather than spin the boot path
+		}
+		if claimed < reconcileBatchSize {
+			break // drained (any remainder is locked by another replica, which owns it)
+		}
+	}
+	if totalReenqueued > 0 || totalDropped > 0 {
+		logger.Info("reconciled stranded public-schema River jobs (GH #205)",
+			slog.Int("reenqueued", totalReenqueued), slog.Int("dropped", totalDropped))
+	}
+}
+
+// reconcileOneBatch claims up to reconcileBatchSize stranded rows in a single
+// short transaction and returns the number claimed plus the re-enqueued/dropped
+// split. The table is qualified as public.river_job explicitly so the sweep is
+// independent of the connection's search_path and can never read or cancel the
+// dedicated media schema's own rows.
+func reconcileOneBatch(ctx context.Context, pool *db.Pool, client *river.Client[pgx.Tx], logger *slog.Logger) (claimed, reenqueued, dropped int, err error) {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		logger.Warn("reconcile stranded public River jobs: begin tx failed", slog.Any("error", err))
+		return 0, 0, 0, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	rows, err := tx.Query(ctx,
+		`SELECT id, kind, args FROM public.river_job
+		 WHERE kind = ANY($1) AND state IN ('available', 'scheduled', 'retryable')
+		 FOR UPDATE SKIP LOCKED
+		 LIMIT $2`,
+		encoderOwnedKinds, reconcileBatchSize)
+	if err != nil {
+		logger.Warn("reconcile stranded public River jobs: query failed", slog.Any("error", err))
+		return 0, 0, 0, err
+	}
+	var stranded []strandedJob
+	for rows.Next() {
+		var j strandedJob
+		if scanErr := rows.Scan(&j.id, &j.kind, &j.args); scanErr != nil {
+			rows.Close()
+			logger.Warn("reconcile stranded public River jobs: scan failed", slog.Any("error", scanErr))
+			return 0, 0, 0, scanErr
+		}
+		stranded = append(stranded, j)
+	}
+	if err = rows.Err(); err != nil {
+		logger.Warn("reconcile stranded public River jobs: row iteration failed", slog.Any("error", err))
+		return 0, 0, 0, err
+	}
+	if len(stranded) == 0 {
+		return 0, 0, 0, nil
+	}
+
+	ids := make([]int64, 0, len(stranded))
+	for _, j := range stranded {
+		ids = append(ids, j.id)
+		args, decErr := decodeEncoderArgs(j.kind, j.args)
+		if decErr != nil {
+			dropped++
+			logger.Warn("reconcile stranded public River job: args decode failed, cancelling",
+				slog.Int64("river_job_id", j.id), slog.String("kind", j.kind), slog.Any("error", decErr))
+			continue
+		}
+		if _, insErr := client.Insert(ctx, args, nil); insErr != nil {
+			dropped++
+			logger.Warn("reconcile stranded public River job: re-insert failed, cancelling",
+				slog.Int64("river_job_id", j.id), slog.String("kind", j.kind), slog.Any("error", insErr))
+			continue
+		}
+		reenqueued++
+	}
+
+	if _, err = tx.Exec(ctx,
+		`UPDATE public.river_job SET state = 'cancelled', finalized_at = now() WHERE id = ANY($1)`, ids); err != nil {
+		logger.Warn("reconcile stranded public River jobs: cancel failed", slog.Any("error", err))
+		return 0, 0, 0, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		logger.Warn("reconcile stranded public River jobs: commit failed", slog.Any("error", err))
+		return 0, 0, 0, err
+	}
+	return len(stranded), reenqueued, dropped, nil
+}
+
+// decodeEncoderArgs unmarshals a raw River args payload into the concrete
+// JobArgs type for kind. Returns an error for any kind outside
+// encoderOwnedKinds — reconcileStrandedPublicJobs's query already restricts
+// to that set, so this is defense in depth against a future kind rename.
+func decodeEncoderArgs(kind string, raw []byte) (river.JobArgs, error) {
+	switch kind {
+	case model.EncodeArgs{}.Kind():
+		var a model.EncodeArgs
+		if err := json.Unmarshal(raw, &a); err != nil {
+			return nil, err
+		}
+		return a, nil
+	case mediafont.TranscodeArgs{}.Kind():
+		var a mediafont.TranscodeArgs
+		if err := json.Unmarshal(raw, &a); err != nil {
+			return nil, err
+		}
+		return a, nil
+	case screenshot.CaptureArgs{}.Kind():
+		var a screenshot.CaptureArgs
+		if err := json.Unmarshal(raw, &a); err != nil {
+			return nil, err
+		}
+		return a, nil
+	case capture.WeeklyFanoutArgs{}.Kind():
+		var a capture.WeeklyFanoutArgs
+		if err := json.Unmarshal(raw, &a); err != nil {
+			return nil, err
+		}
+		return a, nil
+	default:
+		return nil, fmt.Errorf("unrecognized encoder-owned job kind %q", kind)
+	}
+}

--- a/apps/api/cmd/media-encoder/reconcile_test.go
+++ b/apps/api/cmd/media-encoder/reconcile_test.go
@@ -1,0 +1,232 @@
+package main
+
+// reconcile_test.go — GH #205 fast-follow: proves
+// reconcileStrandedPublicJobs re-enqueues encoder-owned rows stranded in the
+// public River schema onto a dedicated media schema, and — critically —
+// never touches a row belonging to one of the API's own job kinds. Mirrors
+// the testcontainers pattern used throughout apps/api/tests (see
+// tests/rls_integration_test.go's startPostgres) but lives in-package since
+// it exercises this package's unexported reconcile helpers.
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivermigrate"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/media/model"
+	"github.com/mosamlife/wpmgr/apps/api/internal/riverutil"
+	"github.com/mosamlife/wpmgr/apps/api/internal/screenshot"
+	"github.com/mosamlife/wpmgr/apps/api/internal/site"
+)
+
+// startReconcileTestPostgres spins up an ephemeral Postgres, migrates the
+// full WPMgr schema (creates the wpmgr_app role) plus River's own public
+// schema, and returns both the unprivileged app pool and the owner pool.
+// Trimmed copy of tests/rls_integration_test.go's startPostgres (unexported
+// in a different package and so cannot be imported here).
+func startReconcileTestPostgres(t *testing.T) (app *db.Pool, admin *db.Pool) {
+	t.Helper()
+	ctx := context.Background()
+
+	container, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("wpmgr"),
+		tcpostgres.WithUsername("wpmgr"),
+		tcpostgres.WithPassword("wpmgr"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+
+	adminPool, err := db.Connect(ctx, adminDSN)
+	if err != nil {
+		t.Fatalf("connect admin: %v", err)
+	}
+	if err := adminPool.Migrate(ctx); err != nil {
+		t.Fatalf("migrate wpmgr schema: %v", err)
+	}
+	migrator, err := rivermigrate.New(riverpgxv5.New(adminPool.Pool), nil)
+	if err != nil {
+		t.Fatalf("river migrator: %v", err)
+	}
+	if _, err := migrator.Migrate(ctx, rivermigrate.DirectionUp, nil); err != nil {
+		t.Fatalf("migrate river public schema: %v", err)
+	}
+	for _, stmt := range []string{
+		"ALTER ROLE wpmgr_app LOGIN PASSWORD 'app'",
+		"GRANT USAGE ON SCHEMA public TO wpmgr_app",
+		"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO wpmgr_app",
+		"REVOKE UPDATE, DELETE, TRUNCATE ON audit_log FROM wpmgr_app",
+	} {
+		if _, err := adminPool.Exec(ctx, stmt); err != nil {
+			t.Fatalf("provision app role (%q): %v", stmt, err)
+		}
+	}
+	t.Cleanup(adminPool.Close)
+
+	appDSN := strings.Replace(adminDSN, "wpmgr:wpmgr@", "wpmgr_app:app@", 1)
+	appPool, err := db.Connect(ctx, appDSN)
+	if err != nil {
+		t.Fatalf("connect app: %v", err)
+	}
+	t.Cleanup(appPool.Close)
+
+	return appPool, adminPool
+}
+
+// TestReconcileStrandedPublicJobs_MovesOnlyEncoderKinds is the GH #205
+// regression lock: encoder-owned jobs (media_encode, site_screenshot_capture)
+// left behind in public.river_job are re-enqueued onto the dedicated media
+// schema and cancelled in place, while a job of an API-owned kind
+// (site_health_check) sitting in the SAME table is left completely
+// untouched — proving the reconcile is scoped strictly to encoder kinds and
+// can never interfere with the API's own fleet periodics.
+func TestReconcileStrandedPublicJobs_MovesOnlyEncoderKinds(t *testing.T) {
+	appPool, adminPool := startReconcileTestPostgres(t)
+	ctx := context.Background()
+
+	const mediaSchema = "media_encoder"
+	if err := riverutil.EnsureSchema(ctx, adminPool.Pool, mediaSchema, "wpmgr_app"); err != nil {
+		t.Fatalf("ensure media schema: %v", err)
+	}
+
+	// Insert stranded rows into the PUBLIC schema exactly as they would have
+	// landed before the fix — one insert-only client per real job type, so
+	// every NOT NULL / default column is populated correctly by River itself.
+	publicClient, err := river.NewClient(riverpgxv5.New(appPool.Pool), &river.Config{SkipUnknownJobCheck: true})
+	if err != nil {
+		t.Fatalf("public client: %v", err)
+	}
+	encodeSiteID, screenshotSiteID := uuid.New(), uuid.New()
+	if _, err := publicClient.Insert(ctx, model.EncodeArgs{
+		TenantID: uuid.New(), SiteID: encodeSiteID, JobID: "stranded-encode",
+	}, nil); err != nil {
+		t.Fatalf("insert stranded encode job: %v", err)
+	}
+	if _, err := publicClient.Insert(ctx, screenshot.CaptureArgs{
+		TenantID: uuid.New(), SiteID: screenshotSiteID,
+		SiteURL: "https://stranded.example.com", Reason: screenshot.ReasonManual,
+	}, nil); err != nil {
+		t.Fatalf("insert stranded screenshot job: %v", err)
+	}
+	// A control row of an API-owned kind — reconcile must never touch this.
+	if _, err := publicClient.Insert(ctx, site.HealthCheckArgs{}, nil); err != nil {
+		t.Fatalf("insert control health-check job: %v", err)
+	}
+
+	mediaClient, err := river.NewClient(riverpgxv5.New(appPool.Pool), &river.Config{
+		Schema: mediaSchema, SkipUnknownJobCheck: true,
+	})
+	if err != nil {
+		t.Fatalf("media client: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	reconcileStrandedPublicJobs(ctx, appPool, mediaClient, logger)
+
+	// The encoder-owned rows in public must now be cancelled (never
+	// re-processed from the schema nothing polls anymore).
+	if n := countRows(t, appPool, `SELECT count(*) FROM river_job WHERE kind = 'media_encode' AND state = 'cancelled'`); n != 1 {
+		t.Fatalf("public cancelled media_encode rows = %d, want 1", n)
+	}
+	if n := countRows(t, appPool, `SELECT count(*) FROM river_job WHERE kind = 'site_screenshot_capture' AND state = 'cancelled'`); n != 1 {
+		t.Fatalf("public cancelled site_screenshot_capture rows = %d, want 1", n)
+	}
+	// ...and re-enqueued into the dedicated media schema, available to run.
+	if n := countRows(t, appPool, `SELECT count(*) FROM "media_encoder"."river_job" WHERE kind = 'media_encode' AND state = 'available'`); n != 1 {
+		t.Fatalf("media schema available media_encode rows = %d, want 1", n)
+	}
+	if n := countRows(t, appPool, `SELECT count(*) FROM "media_encoder"."river_job" WHERE kind = 'site_screenshot_capture' AND state = 'available'`); n != 1 {
+		t.Fatalf("media schema available site_screenshot_capture rows = %d, want 1", n)
+	}
+
+	// The API-owned control row must be completely untouched: still
+	// available in public, and never copied into the media schema.
+	if n := countRows(t, appPool, `SELECT count(*) FROM river_job WHERE kind = 'site_health_check' AND state = 'available'`); n != 1 {
+		t.Fatalf("public available site_health_check rows = %d, want 1 (untouched)", n)
+	}
+	if n := countRows(t, appPool, `SELECT count(*) FROM "media_encoder"."river_job" WHERE kind = 'site_health_check'`); n != 0 {
+		t.Fatalf("media schema site_health_check rows = %d, want 0 (never touched)", n)
+	}
+}
+
+// TestReconcileStrandedPublicJobs_NoStrandedRowsIsNoop verifies the reconcile
+// is a safe no-op (no error, no side effects) when public.river_job holds no
+// matching rows — the common case on every boot after the one-time
+// reconcile has already run.
+func TestReconcileStrandedPublicJobs_NoStrandedRowsIsNoop(t *testing.T) {
+	appPool, adminPool := startReconcileTestPostgres(t)
+	ctx := context.Background()
+
+	const mediaSchema = "media_encoder"
+	if err := riverutil.EnsureSchema(ctx, adminPool.Pool, mediaSchema, "wpmgr_app"); err != nil {
+		t.Fatalf("ensure media schema: %v", err)
+	}
+	mediaClient, err := river.NewClient(riverpgxv5.New(appPool.Pool), &river.Config{
+		Schema: mediaSchema, SkipUnknownJobCheck: true,
+	})
+	if err != nil {
+		t.Fatalf("media client: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	reconcileStrandedPublicJobs(ctx, appPool, mediaClient, logger) // must not panic or hang
+
+	if n := countRows(t, appPool, `SELECT count(*) FROM "media_encoder"."river_job"`); n != 0 {
+		t.Fatalf("media schema rows = %d, want 0", n)
+	}
+}
+
+// TestDecodeEncoderArgs verifies every encoder-owned kind round-trips through
+// JSON decode and that an unrecognized (e.g. API-owned) kind is rejected —
+// defense in depth behind the SQL-level kind filter.
+func TestDecodeEncoderArgs(t *testing.T) {
+	if _, err := decodeEncoderArgs("media_encode", []byte(`{"tenant_id":"`+uuid.Nil.String()+`","site_id":"`+uuid.Nil.String()+`","job_id":"j"}`)); err != nil {
+		t.Fatalf("decode media_encode: %v", err)
+	}
+	if _, err := decodeEncoderArgs("font_transcode", []byte(`{}`)); err != nil {
+		t.Fatalf("decode font_transcode: %v", err)
+	}
+	if _, err := decodeEncoderArgs("site_screenshot_capture", []byte(`{}`)); err != nil {
+		t.Fatalf("decode site_screenshot_capture: %v", err)
+	}
+	if _, err := decodeEncoderArgs("screenshot_weekly_fanout", []byte(`{}`)); err != nil {
+		t.Fatalf("decode screenshot_weekly_fanout: %v", err)
+	}
+	if _, err := decodeEncoderArgs("site_health_check", []byte(`{}`)); err == nil {
+		t.Fatal("decode site_health_check: want error, got nil (must never accept an API-owned kind)")
+	}
+}
+
+// countRows runs a focused count query for test assertions.
+func countRows(t *testing.T, pool *db.Pool, query string) int {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(), query).Scan(&n); err != nil {
+		t.Fatalf("count rows (%q): %v", query, err)
+	}
+	return n
+}

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -170,6 +170,23 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	}
 	logger.Info("media River schema resolved", slog.String("media_river_schema", mediaSchemaLog))
 
+	// GH #205 (CRITICAL, defense-in-depth): if a separate media-encoder
+	// process is deployed against this same default/public schema, River
+	// leadership is per-schema and only the elected leader's client runs its
+	// own PeriodicJobs — the encoder (which runs workers) can win leadership
+	// and silently stop ALL of this API's fleet periodic jobs (uptime_probe,
+	// backup_scheduler, site_connection_sweep, health-check, reapers, every
+	// GC/rollup). This is intentionally NOT a hard failure here: a
+	// single-process, encoder-less deploy on the default schema is legal.
+	// The media-encoder binary itself refuses to boot on a default schema.
+	if riverutil.IsDefaultSchema(mediaRiverSchema) {
+		logger.Warn("WPMGR_RIVER_MEDIA_SCHEMA is unset/public: if a media-encoder process is also "+
+			"deployed, it will silently steal River leader election on this schema and stop ALL fleet "+
+			"periodic jobs with no error (GH #205) — set WPMGR_RIVER_MEDIA_SCHEMA to a dedicated schema "+
+			"(e.g. \"media_encoder\") on BOTH the API and the media-encoder",
+			slog.String("media_river_schema", mediaSchemaLog))
+	}
+
 	// Migrations run with the owner/superuser DSN (creates the app role +
 	// privileged DDL); the application connects with the unprivileged app DSN.
 	// River's own schema is migrated here too, with the same owner DSN. In

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -190,8 +190,14 @@ func (s SMTPConfig) Enabled() bool { return s.Host != "" }
 // RiverConfig holds River queue/storage settings shared by API and worker
 // binaries.
 type RiverConfig struct {
-	// MediaSchema optionally moves media-encoder-owned jobs into a dedicated
-	// Postgres schema. Empty keeps the existing default-schema behavior.
+	// MediaSchema moves media-encoder-owned jobs into a dedicated Postgres
+	// schema, isolating River leader election from the API's own schema (GH
+	// #205: the media-encoder runs workers, making it a leadership candidate
+	// on whatever schema it shares — on the API's default/public schema it
+	// can silently win leadership and stop the API's entire fleet cron).
+	// Defaults to "media_encoder"; empty or "public" keeps the legacy
+	// single-schema behavior, which the media-encoder binary now refuses to
+	// boot on.
 	MediaSchema string `koanf:"media_schema"`
 }
 
@@ -528,7 +534,7 @@ func defaults() map[string]any {
 		"uptime.cron_kick_interval":         "5m",
 		"uptime.cron_kick_timeout":          "5s",
 		"uptime.cron_kick_concurrency":      10,
-		"river.media_schema":                "",
+		"river.media_schema":                "media_encoder",
 		"autologin.require_2fa_step_up":     false,
 		"conn.degrade_after":                "300s",
 		"conn.degrade_miss_threshold":       3,

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -71,15 +71,31 @@ func TestMigrateDSNFallback(t *testing.T) {
 }
 
 // TestLoadRiverMediaSchemaDefault verifies the media River schema defaults to
-// empty (public/default schema behavior) when the env var is unset.
+// a dedicated "media_encoder" schema when the env var is unset (GH #205: a
+// shared default schema lets the media-encoder silently steal River
+// leadership and stop the API's fleet periodics, so isolation is now the
+// binary default rather than opt-in).
 func TestLoadRiverMediaSchemaDefault(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.River.MediaSchema; got != "media_encoder" {
+		t.Fatalf("River.MediaSchema = %q, want media_encoder default", got)
+	}
+}
+
+// TestLoadRiverMediaSchemaExplicitEmpty verifies an operator can still
+// explicitly opt back into the legacy shared/public schema by setting the
+// env var to an empty string.
+func TestLoadRiverMediaSchemaExplicitEmpty(t *testing.T) {
 	t.Setenv("WPMGR_RIVER_MEDIA_SCHEMA", "")
 	cfg, err := Load("")
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
 	if got := cfg.River.MediaSchema; got != "" {
-		t.Fatalf("River.MediaSchema = %q, want empty default", got)
+		t.Fatalf("River.MediaSchema = %q, want empty when explicitly set", got)
 	}
 }
 

--- a/apps/api/tests/river_integration_test.go
+++ b/apps/api/tests/river_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivermigrate"
 
+	"github.com/mosamlife/wpmgr/apps/api/internal/config"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 	"github.com/mosamlife/wpmgr/apps/api/internal/media/model"
@@ -246,6 +247,65 @@ func TestRiverDualSchemaIsolation(t *testing.T) {
 	}
 	if got := countRiverJobs(t, admin, `SELECT count(*) FROM "media_encoder"."river_job" WHERE kind = 'site_health_check'`); got != 0 {
 		t.Fatalf("media schema site_health_check jobs = %d, want 0", got)
+	}
+}
+
+// TestRiverMediaSchemaSelfHealsOnBoot proves GH #205's load-bearing safety
+// property for the new binary default: a fresh/upgraded deploy that never
+// set WPMGR_RIVER_MEDIA_SCHEMA resolves to config's "media_encoder" default,
+// and EnsureSchema — called unconditionally at API boot (cmd/wpmgr/main.go)
+// and at media-encoder boot — creates that schema, migrates River's tables
+// into it, and grants the app role access, all from a completely fresh
+// database where the schema has never existed. Without this, changing the
+// binary default would break any deploy that relied on the old empty/public
+// default.
+func TestRiverMediaSchemaSelfHealsOnBoot(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+
+	cfg, err := config.Load("")
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	if cfg.River.MediaSchema != "media_encoder" {
+		t.Fatalf("config default River.MediaSchema = %q, want media_encoder", cfg.River.MediaSchema)
+	}
+
+	// Confirm the schema genuinely does not exist yet on this fresh database.
+	if got := countRiverJobs(t, admin,
+		"SELECT count(*) FROM information_schema.schemata WHERE schema_name = 'media_encoder'"); got != 0 {
+		t.Fatalf("media_encoder schema already exists before EnsureSchema, want 0")
+	}
+
+	// Mirror exactly what cmd/wpmgr/main.go's run() and cmd/media-encoder's
+	// run() both do unconditionally at boot.
+	if err := riverutil.EnsureSchema(ctx, admin.Pool, cfg.River.MediaSchema, "wpmgr_app"); err != nil {
+		t.Fatalf("ensure media schema from config default: %v", err)
+	}
+
+	if got := countRiverJobs(t, admin,
+		"SELECT count(*) FROM information_schema.schemata WHERE schema_name = 'media_encoder'"); got != 1 {
+		t.Fatalf("media_encoder schema after EnsureSchema = %d, want 1", got)
+	}
+	if got := countRiverJobs(t, admin,
+		`SELECT count(*) FROM information_schema.tables WHERE table_schema = 'media_encoder' AND table_name = 'river_job'`); got != 1 {
+		t.Fatalf("media_encoder.river_job table after EnsureSchema = %d, want 1", got)
+	}
+
+	// The unprivileged app role must be able to insert immediately — proving
+	// the grants (not just CREATE SCHEMA) are also self-healed.
+	client, err := river.NewClient(riverpgxv5.New(pool.Pool), &river.Config{
+		Schema: cfg.River.MediaSchema, SkipUnknownJobCheck: true,
+	})
+	if err != nil {
+		t.Fatalf("media client: %v", err)
+	}
+	if _, err := client.Insert(ctx, model.EncodeArgs{
+		TenantID: uuid.New(), SiteID: uuid.New(), JobID: "self-heal-check",
+	}, nil); err != nil {
+		t.Fatalf("insert into self-healed media schema as app role: %v", err)
 	}
 }
 

--- a/docs/architecture/media-optimizer.md
+++ b/docs/architecture/media-optimizer.md
@@ -65,11 +65,19 @@ callbacks** (agent → CP, the diagnostics/backup model). The `media_encode`
 River queue is bounded (small `MaxWorkers`) so a burst of large AVIF encodes
 can't OOM the encoder instance.
 
-Self-hosted deployments should run encoder-owned River jobs in a dedicated
-schema by setting the same `WPMGR_RIVER_MEDIA_SCHEMA` value on the API and
-media-encoder processes. The API keeps uptime, cron, backup, and other control
-plane jobs in the default schema; media and screenshot jobs are inserted into the
-encoder schema so the encoder cannot take leadership for API-owned periodics.
+Encoder-owned River jobs run in a dedicated schema (default `media_encoder`),
+set via the same `WPMGR_RIVER_MEDIA_SCHEMA` value on both the API and
+media-encoder processes. This isolation is required, not a tuning knob: River
+leader election is per-schema, so a media-encoder process (which runs
+workers) sharing the API's default/public schema could silently win
+leadership and stop the API's entire fleet cron (uptime_probe,
+backup_scheduler, site_connection_sweep, health-check, reapers, every
+GC/rollup) with no error anywhere (GH #205). The media-encoder binary refuses
+to start if it resolves to the API's default/public schema, so this
+misconfiguration cannot reach production. The API keeps uptime, cron, backup,
+and other control plane jobs in the default schema; media and screenshot jobs
+are inserted into the encoder's own schema instead. If the encoder is
+disabled entirely, this schema is unused and irrelevant.
 
 ```mermaid
 sequenceDiagram

--- a/docs/features/media-optimizer.md
+++ b/docs/features/media-optimizer.md
@@ -18,9 +18,15 @@ API: [api/media.md](../api/media.md).
 > go unavailable while everything else keeps working. See
 > [install.md](../install.md#media-encoder).
 >
-> The Compose stack isolates encoder-owned River jobs in the `media_encoder`
-> schema. If you deploy API and encoder separately, set the same
-> `WPMGR_RIVER_MEDIA_SCHEMA` value on both processes.
+> The encoder's River jobs must run in a dedicated schema (default
+> `media_encoder`), never the API's own default/public schema, so the
+> encoder can never take over leader election for the API's fleet periodic
+> jobs (backups, uptime checks, sweeps). This is enforced: the media-encoder
+> refuses to start if it resolves to the API's default/public schema. The
+> Compose stack already sets this correctly out of the box; if you deploy API
+> and encoder separately, set the same dedicated `WPMGR_RIVER_MEDIA_SCHEMA`
+> value on both processes. If you disable the encoder entirely, this setting
+> doesn't matter.
 
 ## The Media tab
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -254,18 +254,30 @@ if you never want it built/pulled at all. Either way, screenshot cards fall back
 to favicon/monogram permanently and the Media Optimizer tab is unavailable —
 everything else in the dashboard is unaffected.
 
-The compose file sets `WPMGR_RIVER_MEDIA_SCHEMA=media_encoder` on both the API
-and media-encoder services. Custom deployments should set the same value on
-both processes so media and screenshot jobs are inserted into the schema the
-encoder is polling. When this value names a dedicated schema, the encoder also
-needs the migration-owner DSN so it can create and migrate that schema safely.
+The media-encoder runs its jobs in a dedicated River schema (default
+`media_encoder`), separate from the API's own default/public schema. This is
+required, not optional: River leader election is per-schema, and if the
+media-encoder shared the API's schema it could silently win leadership and
+stop **all** of the API's fleet periodic jobs (backups, uptime checks,
+sweeps, GC) with no error anywhere (GH #205). The media-encoder binary
+refuses to start if it resolves to the API's default/public schema, so this
+can't happen by misconfiguration. The compose file sets
+`WPMGR_RIVER_MEDIA_SCHEMA=media_encoder` on both the API and media-encoder
+services; custom deployments must set the same dedicated value on both
+processes so media and screenshot jobs are inserted into the schema the
+encoder is polling. When this value names a dedicated schema, the encoder
+also needs the migration-owner DSN so it can create and migrate that schema
+safely. If you never run the media-encoder (disabled/scaled to zero), this
+setting has no effect on the API.
 
-Upgrade note: on deployments upgrading from before the `media_encoder` schema
-became the default, enabling it does not migrate already-queued `media_encode`
-or `site_screenshot_capture` rows from `public.river_job`. Drain media and
-screenshot jobs before upgrading, or set `WPMGR_RIVER_MEDIA_SCHEMA=` / `public`
-on both services to keep the current shared-schema behavior until you are ready
-to switch.
+Upgrade note: an existing self-host `.env` from before this variable existed
+needs no changes — both the compose default and the binary's built-in default
+already resolve to `media_encoder`. If your deployment previously ran the
+media-encoder against the API's shared/public schema (before the
+`media_encoder` default existed) and had media/screenshot jobs queued at the
+time, the encoder reconciles any jobs it still finds stranded in
+`public.river_job` automatically the first time it starts on the dedicated
+schema, so nothing further is required.
 
 See [features/media-optimizer.md](./features/media-optimizer.md) and
 [features/sites.md](./features/sites.md#website-screenshots) for the features


### PR DESCRIPTION
## GH #205 — silent fleet-wide cron death on self-host

River leader election is **per-schema**. When the media-encoder ran on the API's default/`public` River schema (an unset or `public` `WPMGR_RIVER_MEDIA_SCHEMA`), it could silently win leadership for the shared schema and stop the API from enqueuing **any** fleet periodic job (backups, uptime checks, cleanups) with no error anywhere. A latent footgun that #187 (encoder promoted to a base Compose service) made reachable on default self-host installs.

### Fix
- **media-encoder hard-fails** at boot on a default/`public` schema (before the River client is built). The encoder is always a separate process from the API, so refusing can never break a legitimate deploy.
- **Binary default** `river.media_schema` `""` → `media_encoder`, so an install with no env set now resolves to a dedicated schema and self-heals via the existing `EnsureSchema` (`CREATE SCHEMA IF NOT EXISTS` + rivermigrate + grants) on boot. No config change needed on fresh or existing installs.
- **API logs a loud warning** if it ever sees itself sharing its schema with a media-encoder.
- **Boot-time reconcile** moves encoder-owned jobs (`media_encode`, `font_transcode`, `site_screenshot_capture`, `screenshot_weekly_fanout`) stranded in `public.river_job` onto the dedicated schema, then cancels the public rows. Strictly scoped to encoder-owned kinds (SQL `kind` filter + decode allowlist) so the API's own periodics are provably untouched. Batched with `FOR UPDATE SKIP LOCKED`, runs after `$PORT` is bound so it never delays the Cloud Run startup probe, and qualified `public.river_job` so it is search_path-independent.

### Docs
Removed the old "set it empty/`public` for legacy shared-schema mode" guidance (the exact footgun) from `.env.example` and docs; state the dedicated schema is required and enforced.

### Tests (all green, incl. testcontainer integration)
Gate refusal (unset/`""`/`public`/`PUBLIC`) + dedicated-schema pass; config default; reconcile moves only encoder kinds (control `HealthCheck` row untouched); no-op on empty; self-heal on fresh DB; dual-schema isolation.

### Rollout
Hosted has `WPMGR_RIVER_MEDIA_SCHEMA` **unset** on both Cloud Run services, so the new binary default applies with **no env change**; the schema self-heals on boot and the reconcile sweeps any stranded jobs. Deploy API first (flips inserts to `media_encoder`), then the encoder.

Adversarially reviewed: reconcile provably cannot yank/lose/double a live job (running rows excluded, dual-layer kind scoping), and nothing correctness-critical is an encoder kind, so the rolling window can only delay disposable media work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Media Optimizer jobs now use a dedicated database schema by default.
  * Previously stranded media jobs are recovered automatically when the encoder starts.
  * Fresh installations automatically create and migrate the dedicated schema.

* **Bug Fixes**
  * Prevented the media encoder from disrupting scheduled API background jobs when configured with the default schema.
  * Added startup warnings for conflicting schema configurations.

* **Documentation**
  * Updated installation, configuration, and Media Optimizer guidance for dedicated schema setup and upgrades.
  * Added release notes for version 0.61.54.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->