### PR TITLE
fix: media-encoder crash-loop + screenshot capture (GH #207) and update-result accuracy (GH #208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.55] - 2026-07-11
+
+### Fixed
+
+- Self-hosted media-encoder no longer crash-loops on boot after upgrading to v0.61.54 (GH #207). The v0.61.54 River-schema safety change began preparing the dedicated `media_encoder` schema on every boot, which needs database-level CREATE privileges even when the schema already exists. On installs where the media-encoder connects with the unprivileged application role (no owner migration DSN configured for that service), this failed on every start. The media-encoder now detects an already-prepared schema and skips the privileged setup entirely, so a role with only the standard read and usage grants boots normally. Genuine first-time creation still needs an owner role and now reports a clear, actionable message instead of a raw database error.
+- Screenshot capture now works on the bundled media-encoder image (GH #207). The image did not create a home directory for the non-root user it runs as, so Chromium's crash handler could not start and every capture failed before the page loaded. The image now provides a real, writable home directory.
+- A failed screenshot capture is no longer recorded as a successful job (GH #207). An infrastructure failure, such as Chromium failing to launch, is now retried a bounded number of times so a transient or since-fixed environment recovers on its own, while a genuine site-level failure (an unreachable site, or one that blocks headless browsers) is still recorded without pointless retries. Every failure continues to update the dashboard's "didn't finish" state.
+- Core, plugin, and theme updates targeting "latest" no longer report "already up to date" when the site's cached update information is momentarily stale (GH #208). The agent now forces a fresh update check before deciding there is nothing to do, and an inability to determine availability is no longer treated as "up to date". The update is attempted, and its own fresh check settles it, rather than being silently skipped.
+- Update runs no longer spuriously report "failed" when a heavy update takes longer than 30 seconds on the agent (GH #208). A real update performs a pre-update snapshot, download, extraction, and, for core, a database migration synchronously, which can exceed the shared 30-second dispatch timeout even though the update itself completes. Update dispatch now uses a dedicated client with a longer timeout, matching the treatment already given to backup and media commands.
+
 ## [0.61.54] - 2026-07-10
 
 ### Fixed

--- a/apps/agent/includes/commands/class-update-command.php
+++ b/apps/agent/includes/commands/class-update-command.php
@@ -10,7 +10,10 @@
  *               status, snapshot_id, log } ] }
  *
  * Execution strategy:
- *   - dry_run: never touches the filesystem; reports would_update / up_to_date.
+ *   - dry_run: never touches the filesystem; reports would_update / up_to_date
+ *     / unknown (GitHub issue #208 — availability could not be determined
+ *     even after a forced fresh WordPress update check; see this class's
+ *     "Stale-availability visibility fix" note below).
  *   - Pre-update snapshot (GitHub issue #131): for plugin/theme items a
  *     snapshot is ALWAYS captured before applying, regardless of the
  *     request's `snapshot` flag — it is the precondition for the auto-restore
@@ -101,6 +104,35 @@
  *     unconditionally, so a stale reason from an earlier item can never leak)
  *     to the rollback log line below. Concise and non-secret (slug/version/WP
  *     error message only); never changes the boolean gate semantics above.
+ *   - Stale-availability visibility fix (agent-only, GitHub issue #208):
+ *     UpdateRunner::availableVersion() previously read WordPress's cached
+ *     update_core/update_plugins/update_themes transient AS-IS, with no
+ *     forced fresh check — a momentarily stale, expired, or never-yet-
+ *     populated transient was indistinguishable from "genuinely no update
+ *     available", so a real pending update could be silently reported here
+ *     as `up_to_date` while WordPress's own background auto-updater applied
+ *     it moments later. availableVersion() now forces exactly ONE fresh
+ *     check first (wp_version_check()/wp_update_plugins()/wp_update_themes(),
+ *     the same calls the apply path below already makes) and returns `null`
+ *     — distinct from `''` — when availability still cannot be determined
+ *     even after that check. `isUpdatable()` never treats `null` as
+ *     updatable; a `null` result must never be silently folded into
+ *     `up_to_date` either. Two call sites, two different fixes appropriate
+ *     to what each may do: dryRun() (which the CP contract forbids from ever
+ *     mutating) reports a distinct `unknown` status rather than guessing.
+ *     processItem() (the real, non-dry-run apply) instead falls through to
+ *     the normal snapshot+apply path unconditionally on `null` — apply()
+ *     performs its OWN forced fresh check right before mutating anything, so
+ *     a genuine pending update is still applied correctly, and a genuinely
+ *     already-current site still safely resolves to `up_to_date` once
+ *     to_version is re-read below and found unchanged. This also keeps the
+ *     real-apply response status within the control plane's existing
+ *     {succeeded,failed,skipped,up_to_date} vocabulary
+ *     (apps/api/internal/agentcmd/contract.go) — introducing a brand-new
+ *     status there would fall through the CP worker's runApply() switch to
+ *     its default "post-update probe healthy => succeeded" branch, which
+ *     would misreport an item that was never even attempted as a successful
+ *     update: worse than the bug being fixed here.
  *
  * Every input is treated as untrusted: type is whitelisted, slug is sanitized to
  * reject path traversal, and snapshot paths are bounded to wp-content.
@@ -318,8 +350,21 @@ final class UpdateCommand implements CommandInterface
             // up front as up_to_date without running a snapshot+apply — both
             // avoids needless work and keeps a target with no real update to
             // apply from ever being able to surface as a failure.
+            //
+            // GitHub issue #208 — $available === null means UpdateRunner
+            // could not determine availability AT ALL, even after forcing a
+            // fresh WordPress update check (see
+            // UpdateRunner::availableVersion()'s doc). This must never be
+            // treated as "up to date": isUpdatable() only ever returns true
+            // for a genuinely available, newer version, so the guard below
+            // is skipped entirely on null rather than short-circuiting —
+            // execution falls through to the normal snapshot+apply path,
+            // whose own apply() call performs its OWN forced fresh check
+            // before mutating anything (see this class's doc for the full
+            // rationale, including why the real-apply path deliberately does
+            // NOT introduce a new status here).
             $available = $this->runner->availableVersion($type, $slug, $version);
-            if (!self::isUpdatable($available, $fromVersion, $version)) {
+            if ($available !== null && !self::isUpdatable($available, $fromVersion, $version)) {
                 return $this->result(
                     $type,
                     $slug,
@@ -453,9 +498,13 @@ final class UpdateCommand implements CommandInterface
                     // $available (the version this apply targeted) is passed
                     // through only to enrich isComplete()'s diagnostic on a
                     // `false` verdict (agent-only regression fix, 0.61.18) —
-                    // it never affects the verdict itself.
+                    // it never affects the verdict itself. Coerced to '' when
+                    // null (GitHub issue #208's undetermined-availability
+                    // case) since isComplete()'s $expectedVersion parameter
+                    // is a plain string; its own diagnostic already renders
+                    // '' as "expected version unknown", which is accurate here.
                     if ($applied['ok']) {
-                        $complete = $this->runner->isComplete($type, $slug, $available);
+                        $complete = $this->runner->isComplete($type, $slug, $available ?? '');
                         if (!$complete) {
                             $incompleteReason = $this->runner->lastIncompleteReason();
                         }
@@ -583,6 +632,31 @@ final class UpdateCommand implements CommandInterface
     private function dryRun(string $type, string $slug, string $requested, string $fromVersion): array
     {
         $available = $this->runner->availableVersion($type, $slug, $requested);
+
+        // GitHub issue #208 — a dry run may never mutate the site (the
+        // control-plane contract's hard rule: "dry_run true => the agent
+        // MUST NOT mutate the site"), so unlike processItem()'s real-apply
+        // path there is no forced-fresh-check-on-apply() to fall back on
+        // here. Report a status distinct from BOTH `up_to_date` (would
+        // falsely claim we know nothing is pending) and `would_update`
+        // (would falsely claim we know something IS pending) so a dry-run
+        // report never silently misrepresents an undetermined result as
+        // either. Safe for the control plane's existing dry-run handling,
+        // which already treats any status other than `would_update` as
+        // "nothing to report" informationally, without mutating anything
+        // either way.
+        if ($available === null) {
+            return $this->result(
+                $type,
+                $slug,
+                $fromVersion,
+                $fromVersion,
+                'unknown',
+                '',
+                'Dry run: could not determine update availability.'
+            );
+        }
+
         $updatable = self::isUpdatable($available, $fromVersion, $requested);
 
         $status = $updatable ? 'would_update' : 'up_to_date';
@@ -599,14 +673,29 @@ final class UpdateCommand implements CommandInterface
      * version already matches what's installed, or (for a 'latest' request)
      * the available version isn't actually newer.
      *
-     * @param string $available   Version an update would move to ('' when none).
-     * @param string $fromVersion Currently installed version.
-     * @param string $requested   'latest' or an explicit x.y.z.
+     * GitHub issue #208 — deliberately accepts `$available === null` (the
+     * "availability could not be determined at all" signal from
+     * UpdateRunner::availableVersion(), distinct from '') and always returns
+     * `false` for it, exactly as it already does for `''`. This method only
+     * ever answers "should an apply be attempted right now"; it never
+     * conflates "unknown" with "definitely up to date" — that distinction is
+     * the CALLER's responsibility (see both call sites' surrounding comments
+     * for how processItem() and dryRun() report `null` differently).
+     *
+     * @param string|null $available   Version an update would move to ('' when
+     *                                  a fresh check confirms none is
+     *                                  available; null when undetermined).
+     * @param string      $fromVersion Currently installed version.
+     * @param string      $requested   'latest' or an explicit x.y.z.
      * @return bool
      */
-    private static function isUpdatable(string $available, string $fromVersion, string $requested): bool
+    private static function isUpdatable(?string $available, string $fromVersion, string $requested): bool
     {
-        return $available !== '' && $available !== $fromVersion
+        if ($available === null || $available === '') {
+            return false;
+        }
+
+        return $available !== $fromVersion
             && (version_compare($available, $fromVersion, '>') || $requested !== 'latest');
     }
 

--- a/apps/agent/includes/support/class-update-runner.php
+++ b/apps/agent/includes/support/class-update-runner.php
@@ -146,15 +146,33 @@ class UpdateRunner
     /**
      * Resolve the version that an update would move the item to.
      *
-     * Used only by dry-run. For an explicit version request we return it as-is.
-     * For 'latest' we consult the WordPress update transients / version check.
+     * Used by dry-run AND as the pre-apply "is anything even pending" check
+     * in UpdateCommand::processItem(). For an explicit version request we
+     * return it as-is (no WordPress check involved — the caller already
+     * knows the target). For 'latest' we consult the WordPress update
+     * transients, but ONLY after forcing exactly one fresh check first
+     * (GitHub issue #208): see pluginUpdateVersion()/themeUpdateVersion()/
+     * coreUpdateVersion() for why. Before that fix, a momentarily
+     * stale/expired/never-yet-populated transient was read as-is and
+     * indistinguishable from "genuinely no update available", so a real
+     * pending update could be silently reported as up_to_date here while
+     * WordPress's own background auto-updater applied it moments later.
      *
      * @param string $type      plugin|theme|core.
      * @param string $slug      Sanitized slug.
      * @param string $requested 'latest' or an explicit x.y.z.
-     * @return string Target version, or '' when none is available.
+     * @return string|null Target version, '' when a forced fresh check
+     *                confirms none is available (genuinely up to date), or
+     *                null when availability could not be determined AT ALL
+     *                even after that forced check (the update transient is
+     *                still missing/malformed, or the relevant WordPress
+     *                update-check function itself is unavailable in this
+     *                runtime). The caller (UpdateCommand) MUST treat null
+     *                distinctly from '' — never fold "couldn't tell" into
+     *                "nothing to do" (see UpdateCommand::isUpdatable()'s
+     *                doc and its two call sites).
      */
-    public function availableVersion(string $type, string $slug, string $requested): string
+    public function availableVersion(string $type, string $slug, string $requested): ?string
     {
         if ($requested !== 'latest') {
             return $requested;
@@ -1400,17 +1418,37 @@ class UpdateRunner
     /**
      * Pending update version for a plugin from the update transient.
      *
+     * Forces exactly ONE fresh check via wp_update_plugins() before reading
+     * the transient (GitHub issue #208) — the identical, unconditional call
+     * applyViaUpgrader() already makes before a real plugin apply (see
+     * below). This closes the gap where this READ-ONLY resolution path
+     * trusted whatever was already cached while the APPLY path would have
+     * refreshed it first: a stale/expired/never-yet-populated transient can
+     * no longer make a real pending update look like "up to date" here.
+     * Called at most once per availableVersion() resolution — never in a
+     * loop — matching the apply path's own single forced check per run.
+     *
      * @param string $slug Plugin basename.
-     * @return string
+     * @return string|null The pending version, '' when a forced fresh check
+     *                confirms none is available, or null when availability
+     *                could not be determined even after that check
+     *                (get_site_transient()/wp_update_plugins() unavailable
+     *                in this runtime, or the transient is not the
+     *                well-formed object WordPress itself always produces
+     *                once a check has actually completed).
      */
-    private function pluginUpdateVersion(string $slug): string
+    private function pluginUpdateVersion(string $slug): ?string
     {
+        if (function_exists('wp_update_plugins')) {
+            wp_update_plugins();
+        }
+
         if (!function_exists('get_site_transient')) {
-            return '';
+            return null;
         }
         $transient = get_site_transient('update_plugins');
         if (!is_object($transient) || !isset($transient->response) || !is_array($transient->response)) {
-            return '';
+            return null;
         }
         $entry = $transient->response[$slug] ?? null;
         if (is_object($entry) && isset($entry->new_version)) {
@@ -1423,17 +1461,31 @@ class UpdateRunner
     /**
      * Pending update version for a theme from the update transient.
      *
+     * Forces exactly ONE fresh check via wp_update_themes() before reading
+     * the transient (GitHub issue #208) — same rationale and shape as
+     * pluginUpdateVersion(); see its doc.
+     *
      * @param string $slug Theme stylesheet.
-     * @return string
+     * @return string|null The pending version, '' when a forced fresh check
+     *                confirms none is available, or null when availability
+     *                could not be determined even after that check
+     *                (get_site_transient()/wp_update_themes() unavailable
+     *                in this runtime, or the transient is not the
+     *                well-formed object WordPress itself always produces
+     *                once a check has actually completed).
      */
-    private function themeUpdateVersion(string $slug): string
+    private function themeUpdateVersion(string $slug): ?string
     {
+        if (function_exists('wp_update_themes')) {
+            wp_update_themes();
+        }
+
         if (!function_exists('get_site_transient')) {
-            return '';
+            return null;
         }
         $transient = get_site_transient('update_themes');
         if (!is_object($transient) || !isset($transient->response) || !is_array($transient->response)) {
-            return '';
+            return null;
         }
         $entry = $transient->response[$slug] ?? null;
         if (is_array($entry) && isset($entry['new_version'])) {
@@ -1446,16 +1498,33 @@ class UpdateRunner
     /**
      * Latest offered core version from the update transient.
      *
-     * @return string
+     * Forces exactly ONE fresh check via wp_version_check([], true) before
+     * reading the transient (GitHub issue #208) — the identical forced,
+     * cache-bypassing call applyCoreUpgrade() already makes before a real
+     * core apply (the `true` second argument is WordPress's own "ignore the
+     * 12-hour throttle" flag). Same rationale as pluginUpdateVersion(); see
+     * its doc.
+     *
+     * @return string|null The pending core version, '' when a forced fresh
+     *                check confirms none is available, or null when
+     *                availability could not be determined even after that
+     *                check (get_site_transient()/wp_version_check()
+     *                unavailable in this runtime, or the transient is not
+     *                the well-formed object WordPress itself always
+     *                produces once a check has actually completed).
      */
-    private function coreUpdateVersion(): string
+    private function coreUpdateVersion(): ?string
     {
+        if (function_exists('wp_version_check')) {
+            wp_version_check([], true);
+        }
+
         if (!function_exists('get_site_transient')) {
-            return '';
+            return null;
         }
         $transient = get_site_transient('update_core');
         if (!is_object($transient) || !isset($transient->updates) || !is_array($transient->updates)) {
-            return '';
+            return null;
         }
         foreach ($transient->updates as $update) {
             if (is_object($update) && isset($update->response) && $update->response === 'upgrade' && isset($update->version)) {

--- a/apps/agent/tests/UpdateCommandTest.php
+++ b/apps/agent/tests/UpdateCommandTest.php
@@ -62,6 +62,14 @@ final class UpdateCommandTest extends TestCase
             public array $versions = [];
             /** @var array<string,string> */
             public array $available = [];
+            /**
+             * @var array<string,bool> Keys ("type:slug") for which
+             *     availableVersion() must return null — i.e. availability
+             *     could not be determined even after a forced fresh check
+             *     (GitHub issue #208) — rather than '' (genuinely no
+             *     update) or a real version string.
+             */
+            public array $availableUnknown = [];
             /** @var array<string,bool> Explicit installed-state overrides, keyed "type:slug". */
             public array $installedOverride = [];
             /** Whether apply() should report success. */
@@ -113,9 +121,14 @@ final class UpdateCommandTest extends TestCase
                 return array_key_exists($key, $this->versions);
             }
 
-            public function availableVersion(string $type, string $slug, string $requested): string
+            public function availableVersion(string $type, string $slug, string $requested): ?string
             {
-                return $this->available[$type . ':' . $slug] ?? ($requested !== 'latest' ? $requested : '');
+                $key = $type . ':' . $slug;
+                if (isset($this->availableUnknown[$key])) {
+                    return null;
+                }
+
+                return $this->available[$key] ?? ($requested !== 'latest' ? $requested : '');
             }
 
             public function apply(string $type, string $slug, string $version): array
@@ -238,6 +251,112 @@ final class UpdateCommandTest extends TestCase
 
         $this->assertSame('up_to_date', $out['results'][0]['status']);
         $this->assertSame([], $runner->applied);
+    }
+
+    // ---- undetermined availability (GitHub issue #208) ---------------------
+
+    /**
+     * Dry run: a real pending update went silently unreported before this
+     * fix because a stale/expired/never-populated update transient was read
+     * as-is, indistinguishable from "genuinely no update available".
+     * UpdateRunner::availableVersion() now returns null (rather than '')
+     * when it cannot determine availability at all — even after forcing a
+     * fresh check — and the dry-run reporter must surface that as a status
+     * distinct from both `up_to_date` and `would_update`, never guessing.
+     */
+    public function test_dry_run_reports_unknown_status_when_availability_cannot_be_determined(): void
+    {
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:hello/hello.php'] = '1.7.2';
+        $runner->availableUnknown['plugin:hello/hello.php'] = true;
+
+        $cmd = new UpdateCommand($this->spySnapshots(), $runner);
+
+        $out = $cmd->execute([], [
+            'dry_run' => true,
+            'items'   => [['type' => 'plugin', 'slug' => 'hello/hello.php', 'version' => 'latest']],
+        ]);
+
+        $r = $out['results'][0];
+        $this->assertSame(
+            'unknown',
+            $r['status'],
+            'undetermined availability must never be silently folded into up_to_date (or falsely reported as would_update)'
+        );
+        $this->assertNotSame('up_to_date', $r['status']);
+        $this->assertNotSame('would_update', $r['status']);
+        $this->assertSame([], $runner->applied, 'a dry run must never mutate regardless of availability');
+    }
+
+    /**
+     * Real (non-dry-run) apply: when availability is undetermined, the
+     * caller must NOT silently report up_to_date and skip the item — it
+     * must fall through to the normal snapshot+apply path, whose own
+     * apply() call performs its own forced fresh check before mutating
+     * anything. A genuine pending update (simulated here by the spy's
+     * apply() successfully bumping the version) is still applied and
+     * reported succeeded, proving the item was never silently skipped.
+     */
+    public function test_undetermined_availability_is_not_reported_up_to_date_and_the_update_is_still_attempted(): void
+    {
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php'] = '5.0';
+        $runner->availableUnknown['plugin:akismet/akismet.php'] = true;
+
+        $cmd = new UpdateCommand($this->spySnapshots(), $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $r = $out['results'][0];
+        $this->assertNotSame(
+            'up_to_date',
+            $r['status'],
+            'undetermined availability must never be silently reported as up_to_date on a real apply'
+        );
+        $this->assertCount(
+            1,
+            $runner->applied,
+            'undetermined availability must fall through to the normal apply path, not skip the item'
+        );
+        $this->assertSame('succeeded', $r['status'], 'a genuine pending update behind an undetermined pre-check must still be applied');
+        $this->assertSame('9.9.9', $r['to_version']);
+    }
+
+    /**
+     * The complementary case: when availability is undetermined but the
+     * apply's own forced re-check (simulated by the spy's apply() being a
+     * true no-op — applySucceeds stays true but currentVersion never moves
+     * because 'latest' bumps to a fixed '9.9.9' in the spy, so this test
+     * instead pins an explicit version equal to from_version) turns out to
+     * genuinely have nothing to do, the result must still resolve
+     * accurately rather than reporting a false failure or false success.
+     */
+    public function test_undetermined_availability_that_turns_out_genuinely_current_reports_up_to_date_after_apply(): void
+    {
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php'] = '5.3';
+        $runner->availableUnknown['plugin:akismet/akismet.php'] = true;
+
+        $cmd = new UpdateCommand($this->spySnapshots(), $runner);
+
+        // Pin an explicit version equal to what's already installed — the
+        // spy's apply() only bumps the recorded version to '9.9.9' for a
+        // 'latest' request; for an explicit version it sets it to that exact
+        // string, so requesting the currently-installed version simulates
+        // an apply() that ends up changing nothing.
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => '5.3']],
+        ]);
+
+        $r = $out['results'][0];
+        $this->assertCount(1, $runner->applied, 'the apply must still be attempted for an undetermined pre-check');
+        $this->assertSame(
+            'up_to_date',
+            $r['status'],
+            'once the apply itself confirms nothing changed, the result must accurately settle on up_to_date, not a false failure'
+        );
     }
 
     public function test_response_shape_matches_contract_exactly(): void

--- a/apps/agent/tests/UpdateRunnerAvailabilityTest.php
+++ b/apps/agent/tests/UpdateRunnerAvailabilityTest.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * UpdateRunnerAvailabilityTest — GitHub issue #208: a real pending core (and
+ * plugin/theme) update was silently reported as "already up to date" because
+ * UpdateRunner::availableVersion() read WordPress's cached update_core /
+ * update_plugins / update_themes transient WITHOUT forcing a fresh check
+ * first, so a momentarily stale/expired/never-yet-populated transient was
+ * indistinguishable from "genuinely no update available".
+ *
+ * These tests exercise UpdateRunner::availableVersion() directly (the public
+ * entry point; coreUpdateVersion()/pluginUpdateVersion()/themeUpdateVersion()
+ * are private implementation details reached only through it for a 'latest'
+ * request) and prove:
+ *   1. A stale/empty transient that a forced check WOULD populate with a real
+ *      pending update is no longer silently read as "no update" — the forced
+ *      check runs first and the real version is returned.
+ *   2. A transient that is genuinely up to date even after the forced check
+ *      still correctly reports '' (unchanged behavior).
+ *   3. A transient that STILL cannot be resolved even after the forced check
+ *      (network failure, constrained runtime) reports `null` — a value
+ *      distinct from '' — so a caller can never fold "couldn't tell" into
+ *      "nothing to do".
+ *   4. The forced check runs at most ONCE per availableVersion() call, never
+ *      in a loop, and never at all for an explicit (non-'latest') version
+ *      request.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Support\UpdateRunner;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\UpdateRunner
+ */
+final class UpdateRunnerAvailabilityTest extends TestCase
+{
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+    }
+
+    protected function tear_down(): void
+    {
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // =========================================================================
+    // core
+    // =========================================================================
+
+    public function test_core_forced_check_discovers_a_real_update_behind_a_stale_empty_transient(): void
+    {
+        // Simulates the reported bug precisely: get_site_transient() would
+        // return false/empty (never yet populated, or expired) BEFORE any
+        // check runs. wp_version_check() is the forced fresh check that
+        // populates it with a genuine pending core update.
+        $transient = false;
+        Functions\expect('wp_version_check')
+            ->once()
+            ->andReturnUsing(function () use (&$transient): void {
+                $update           = new \stdClass();
+                $update->response = 'upgrade';
+                $update->version  = '6.5.2';
+
+                $populated          = new \stdClass();
+                $populated->updates = [$update];
+                $transient          = $populated;
+            });
+        Functions\when('get_site_transient')->alias(static function (string $key) use (&$transient) {
+            return $key === 'update_core' ? $transient : false;
+        });
+
+        $runner = new UpdateRunner();
+
+        $this->assertSame(
+            '6.5.2',
+            $runner->availableVersion('core', 'core', 'latest'),
+            'a real pending core update behind a stale/empty transient must be discovered by the forced check'
+        );
+    }
+
+    public function test_core_reports_up_to_date_when_the_forced_check_confirms_nothing_pending(): void
+    {
+        $update           = new \stdClass();
+        $update->response = 'latest';
+        $update->version  = '6.5.2';
+
+        $transient          = new \stdClass();
+        $transient->updates = [$update];
+
+        Functions\expect('wp_version_check')->once()->andReturnNull();
+        Functions\when('get_site_transient')->alias(static function (string $key) use ($transient) {
+            return $key === 'update_core' ? $transient : false;
+        });
+
+        $runner = new UpdateRunner();
+
+        $this->assertSame(
+            '',
+            $runner->availableVersion('core', 'core', 'latest'),
+            'a genuinely up-to-date result after the forced check must still report no update (unchanged behavior)'
+        );
+    }
+
+    public function test_core_reports_undetermined_when_still_unresolvable_after_forcing(): void
+    {
+        // The forced check runs but (network failure / constrained runtime)
+        // never populates a well-formed transient — it stays false.
+        Functions\expect('wp_version_check')->once()->andReturnNull();
+        Functions\when('get_site_transient')->justReturn(false);
+
+        $runner = new UpdateRunner();
+
+        $this->assertNull(
+            $runner->availableVersion('core', 'core', 'latest'),
+            'availability that cannot be determined even after a forced check must be null, not "" (up to date)'
+        );
+    }
+
+    public function test_core_forced_check_runs_exactly_once_not_in_a_loop(): void
+    {
+        Functions\expect('wp_version_check')->once()->andReturnNull();
+        Functions\when('get_site_transient')->justReturn(false);
+
+        $result = (new UpdateRunner())->availableVersion('core', 'core', 'latest');
+
+        // Functions\expect(...)->once() itself asserts the call count on
+        // Monkey\tearDown(); a second invocation here would fail that
+        // assertion, proving a single resolution never re-forces the check.
+        // The explicit assertion below is just to keep this a non-risky
+        // test — the real proof is the mock's own call-count expectation.
+        $this->assertNull($result);
+    }
+
+    public function test_core_explicit_version_request_never_forces_a_check(): void
+    {
+        Functions\expect('wp_version_check')->never();
+
+        $runner = new UpdateRunner();
+
+        $this->assertSame('6.4.1', $runner->availableVersion('core', 'core', '6.4.1'));
+    }
+
+    // =========================================================================
+    // plugin
+    // =========================================================================
+
+    public function test_plugin_forced_check_discovers_a_real_update_behind_a_stale_empty_transient(): void
+    {
+        $transient = false;
+        Functions\expect('wp_update_plugins')
+            ->once()
+            ->andReturnUsing(function () use (&$transient): void {
+                $entry              = new \stdClass();
+                $entry->new_version = '5.3.1';
+
+                $populated           = new \stdClass();
+                $populated->response = ['akismet/akismet.php' => $entry];
+                $transient           = $populated;
+            });
+        Functions\when('get_site_transient')->alias(static function (string $key) use (&$transient) {
+            return $key === 'update_plugins' ? $transient : false;
+        });
+
+        $runner = new UpdateRunner();
+
+        $this->assertSame(
+            '5.3.1',
+            $runner->availableVersion('plugin', 'akismet/akismet.php', 'latest'),
+            'a real pending plugin update behind a stale/empty transient must be discovered by the forced check'
+        );
+    }
+
+    public function test_plugin_reports_undetermined_when_still_unresolvable_after_forcing(): void
+    {
+        Functions\expect('wp_update_plugins')->once()->andReturnNull();
+        Functions\when('get_site_transient')->justReturn(false);
+
+        $runner = new UpdateRunner();
+
+        $this->assertNull(
+            $runner->availableVersion('plugin', 'akismet/akismet.php', 'latest'),
+            'plugin availability that cannot be determined even after a forced check must be null, not ""'
+        );
+    }
+
+    public function test_plugin_reports_up_to_date_when_the_forced_check_confirms_nothing_pending(): void
+    {
+        // A well-formed, forced-fresh response with no entry for this slug —
+        // WordPress's own "nothing pending for this plugin" shape.
+        $transient           = new \stdClass();
+        $transient->response = [];
+
+        Functions\expect('wp_update_plugins')->once()->andReturnNull();
+        Functions\when('get_site_transient')->alias(static function (string $key) use ($transient) {
+            return $key === 'update_plugins' ? $transient : false;
+        });
+
+        $runner = new UpdateRunner();
+
+        $this->assertSame('', $runner->availableVersion('plugin', 'akismet/akismet.php', 'latest'));
+    }
+
+    // =========================================================================
+    // theme
+    // =========================================================================
+
+    public function test_theme_forced_check_discovers_a_real_update_behind_a_stale_empty_transient(): void
+    {
+        $transient = false;
+        Functions\expect('wp_update_themes')
+            ->once()
+            ->andReturnUsing(function () use (&$transient): void {
+                $populated           = new \stdClass();
+                $populated->response = [
+                    'twentytwentyfour' => ['new_version' => '1.2'],
+                ];
+                $transient           = $populated;
+            });
+        Functions\when('get_site_transient')->alias(static function (string $key) use (&$transient) {
+            return $key === 'update_themes' ? $transient : false;
+        });
+
+        $runner = new UpdateRunner();
+
+        $this->assertSame(
+            '1.2',
+            $runner->availableVersion('theme', 'twentytwentyfour', 'latest'),
+            'a real pending theme update behind a stale/empty transient must be discovered by the forced check'
+        );
+    }
+
+    public function test_theme_reports_undetermined_when_still_unresolvable_after_forcing(): void
+    {
+        Functions\expect('wp_update_themes')->once()->andReturnNull();
+        Functions\when('get_site_transient')->justReturn(false);
+
+        $runner = new UpdateRunner();
+
+        $this->assertNull(
+            $runner->availableVersion('theme', 'twentytwentyfour', 'latest'),
+            'theme availability that cannot be determined even after a forced check must be null, not ""'
+        );
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.21
+ * Version:           0.61.55
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.21');
+define('WPMGR_AGENT_VERSION', '0.61.55');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -631,7 +631,21 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// grows expensive over time.
 	uptimeProbeGCWorker := metrics.NewUptimeProbeGCWorker(pool, logger)
 
-	updateWorker := update.NewWorker(updateRepo, sitesLookup, commander, prober, updateHub, auditRec, logger, cfg.Update.PerTenantParallelism)
+	// GH #208 Bug 2: a real update is synchronous and heavy on the agent (a
+	// mandatory pre-update snapshot + download + extract + core/plugin/theme
+	// DB migration, all inline in one request) and routinely exceeds the
+	// snappy 30s Update.HTTPTimeout the shared `commander`/`ssrfClient` uses —
+	// driving a spurious CP-recorded Failed even though the agent actually
+	// finished. Mirror the backup (:729-733) and media (:1219-1223) dedicated
+	// commander pattern via buildUpdateApplyCommander: build a SEPARATE
+	// SSRF-hardened client with a longer per-attempt cap
+	// (cfg.Update.ApplyHTTPTimeout, default 5m — see UpdateConfig's doc
+	// comment for how that default was picked) just for the update-apply
+	// commander, falling back to the shared `commander` when no signing key
+	// is configured (the cmdSigner == nil / disabled-commander case, guarded
+	// exactly like the media block does).
+	updateApplyCmd := buildUpdateApplyCommander(commander, cmdSigner, cfg.Update.ApplyHTTPTimeout)
+	updateWorker := update.NewWorker(updateRepo, sitesLookup, updateApplyCmd, prober, updateHub, auditRec, logger, cfg.Update.PerTenantParallelism)
 	// #131 follow-up — periodic reaper for update_tasks stuck in pending/running
 	// past staleTaskThreshold (a worker crash mid-task, or a failed enqueue that
 	// leaves a task pending). Without this, such a task permanently occupies its
@@ -3189,6 +3203,24 @@ func (disabledBackupCommander) IncrementalBackup(_ context.Context, _ uuid.UUID,
 
 func (disabledBackupCommander) Restore(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.RestoreRequest) (agentcmd.RestoreResponse, error) {
 	return agentcmd.RestoreResponse{}, fmt.Errorf("CP->agent commands are disabled: no signing key configured")
+}
+
+// buildUpdateApplyCommander builds the dedicated CP->agent commander used
+// only for update-apply dispatch (GH #208 Bug 2). It is extracted as a
+// standalone function — rather than inlined in run() — so this wiring is
+// unit-testable without a live agent or DB: falling back to the shared
+// commander when no signing key is configured, and otherwise building a
+// distinct client bound to applyTimeout (mirrors the backup/media dedicated
+// commander pattern; see the call site in run() for the full rationale).
+func buildUpdateApplyCommander(shared update.Commander, cmdSigner *agentcmd.Signer, applyTimeout time.Duration) update.Commander {
+	if cmdSigner == nil {
+		return shared
+	}
+	updateApplySSRFClient := httpclient.New(httpclient.Config{
+		Timeout:    applyTimeout,
+		MaxRetries: 0,
+	})
+	return agentcmd.NewClient(updateApplySSRFClient, cmdSigner)
 }
 
 // disabledCommander is the no-op Commander used when no CP signing key is

--- a/apps/api/cmd/wpmgr/update_commander_test.go
+++ b/apps/api/cmd/wpmgr/update_commander_test.go
@@ -1,0 +1,86 @@
+package main
+
+// update_commander_test.go — GH #208 Bug 2 regression lock: the update
+// worker must dispatch Update/Rollback commands through a DEDICATED
+// commander with a longer per-attempt HTTP timeout than the shared 30s
+// `commander`/`ssrfClient` (RefreshCommander, scan, etc. keep using the
+// shared one). A real update is heavy and synchronous on the agent
+// (mandatory pre-update snapshot + download + extract + core DB migration,
+// all inline in one request) and routinely exceeds 30s, which previously
+// drove a spurious CP-recorded "Failed" even though the agent had actually
+// finished the apply.
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
+	"github.com/mosamlife/wpmgr/apps/api/internal/update"
+)
+
+// fakeCommander is a distinguishable update.Commander stand-in for the
+// "shared commander" the fallback branch must return unmodified.
+type fakeCommander struct{}
+
+func (fakeCommander) Update(context.Context, uuid.UUID, string, agentcmd.UpdateRequest) (agentcmd.UpdateResponse, error) {
+	return agentcmd.UpdateResponse{}, nil
+}
+
+func (fakeCommander) Rollback(context.Context, uuid.UUID, string, agentcmd.RollbackRequest) (agentcmd.RollbackResponse, error) {
+	return agentcmd.RollbackResponse{}, nil
+}
+
+func newTestCmdSigner(t *testing.T) *agentcmd.Signer {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	signer, err := agentcmd.NewSigner(base64.StdEncoding.EncodeToString(priv))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	return signer
+}
+
+// TestBuildUpdateApplyCommander_FallsBackWhenSigningDisabled verifies that
+// with no CP signing key configured (cmdSigner == nil, mirroring the
+// disabled-commander boot path), buildUpdateApplyCommander returns the SAME
+// shared commander untouched rather than constructing a dedicated client —
+// consistent with every other CP->agent command path when signing is off.
+func TestBuildUpdateApplyCommander_FallsBackWhenSigningDisabled(t *testing.T) {
+	shared := fakeCommander{}
+
+	got := buildUpdateApplyCommander(shared, nil, 5*time.Minute)
+
+	if got != update.Commander(shared) {
+		t.Fatalf("buildUpdateApplyCommander(nil signer) = %v, want the shared commander returned unmodified", got)
+	}
+}
+
+// TestBuildUpdateApplyCommander_BuildsDedicatedClientWhenSigningEnabled
+// verifies that with a real CP signing key configured, the function returns
+// a DISTINCT commander (not the shared one, not sharing the shared 30s
+// client's timeout) — the concrete fix for GH #208 Bug 2.
+func TestBuildUpdateApplyCommander_BuildsDedicatedClientWhenSigningEnabled(t *testing.T) {
+	shared := fakeCommander{}
+	signer := newTestCmdSigner(t)
+
+	got := buildUpdateApplyCommander(shared, signer, 5*time.Minute)
+
+	if got == update.Commander(shared) {
+		t.Fatal("buildUpdateApplyCommander(real signer) returned the shared commander, want a dedicated client")
+	}
+	client, ok := got.(*agentcmd.Client)
+	if !ok {
+		t.Fatalf("buildUpdateApplyCommander(real signer) = %T, want *agentcmd.Client", got)
+	}
+	if client == nil {
+		t.Fatal("buildUpdateApplyCommander(real signer) returned a nil *agentcmd.Client")
+	}
+}

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -290,10 +290,25 @@ type BackupConfig struct {
 // shared worker pool (enforced via per-tenant River queue shards plus an
 // in-worker guard). HTTPTimeout/HTTPRetries tune the SSRF-hardened client used
 // for CP->agent commands and post-update health probes.
+//
+// ApplyHTTPTimeout (GH #208 Bug 2) is a SEPARATE, longer per-attempt cap used
+// only for the update-apply commander (the actual Update/Rollback dispatch),
+// not the lighter uses of the shared HTTPTimeout (refresh-inventory probes,
+// scan). A real update is heavy and synchronous on the agent — a mandatory
+// pre-update snapshot, download, extract, and core/plugin/theme DB migration
+// all happen inline in one request — and routinely exceeds the snappy 30s
+// HTTPTimeout, which previously drove a spurious CP-recorded "Failed" even
+// though the agent had actually finished. Defaults to 5m: longer than the
+// 30s shared update timeout, shorter than the 10m backup timeout (an update
+// apply + its mandatory snapshot is lighter than a full-site backup), and
+// leaves headroom under the agent's own apply script cap
+// (set_time_limit(900)) for network/transfer overhead on top of the agent's
+// own execution time.
 type UpdateConfig struct {
 	PerTenantParallelism int           `koanf:"per_tenant_parallelism"`
 	HTTPTimeout          time.Duration `koanf:"http_timeout"`
 	HTTPRetries          int           `koanf:"http_retries"`
+	ApplyHTTPTimeout     time.Duration `koanf:"apply_http_timeout"`
 }
 
 // AgentConfig holds the control-plane agent-protocol configuration.
@@ -503,6 +518,7 @@ func defaults() map[string]any {
 		"update.per_tenant_parallelism":     5,
 		"update.http_timeout":               "30s",
 		"update.http_retries":               2,
+		"update.apply_http_timeout":         "5m",
 		"s3.endpoint":                       "",
 		"s3.region":                         "us-east-1",
 		"s3.bucket":                         "",

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestValidateSessionSecret checks that empty, placeholder, and short session
@@ -67,6 +68,41 @@ func TestMigrateDSNFallback(t *testing.T) {
 	d.MigrationDSN = "postgres://owner@host/db"
 	if got := d.MigrateDSN(); got != "postgres://owner@host/db" {
 		t.Fatalf("MigrateDSN should use MigrationDSN when set: %q", got)
+	}
+}
+
+// TestLoadUpdateApplyHTTPTimeoutDefault is the GH #208 Bug 2 regression lock:
+// with no WPMGR_UPDATE_APPLY_HTTP_TIMEOUT env configured, Update.ApplyHTTPTimeout
+// must default to a value LONGER than the shared 30s Update.HTTPTimeout (the
+// whole point of the dedicated knob) but no longer than the 10m Backup.HTTPTimeout
+// (an update apply + its mandatory pre-update snapshot is lighter than a
+// full-site backup).
+func TestLoadUpdateApplyHTTPTimeoutDefault(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Update.ApplyHTTPTimeout; got <= cfg.Update.HTTPTimeout {
+		t.Fatalf("Update.ApplyHTTPTimeout = %v, want > Update.HTTPTimeout (%v) — otherwise the dedicated knob does nothing", got, cfg.Update.HTTPTimeout)
+	}
+	if got := cfg.Update.ApplyHTTPTimeout; got > cfg.Backup.HTTPTimeout {
+		t.Fatalf("Update.ApplyHTTPTimeout = %v, want <= Backup.HTTPTimeout (%v) — an update apply is lighter than a full-site backup", got, cfg.Backup.HTTPTimeout)
+	}
+	if got := cfg.Update.ApplyHTTPTimeout; got != 5*time.Minute {
+		t.Fatalf("Update.ApplyHTTPTimeout = %v, want 5m default", got)
+	}
+}
+
+// TestLoadUpdateApplyHTTPTimeoutEnv verifies WPMGR_UPDATE_APPLY_HTTP_TIMEOUT is
+// loaded from the environment when set.
+func TestLoadUpdateApplyHTTPTimeoutEnv(t *testing.T) {
+	t.Setenv("WPMGR_UPDATE_APPLY_HTTP_TIMEOUT", "3m")
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Update.ApplyHTTPTimeout; got != 3*time.Minute {
+		t.Fatalf("Update.ApplyHTTPTimeout = %v, want 3m", got)
 	}
 }
 

--- a/apps/api/internal/riverutil/schema.go
+++ b/apps/api/internal/riverutil/schema.go
@@ -2,15 +2,21 @@ package riverutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivermigrate"
 )
+
+// pgErrInsufficientPrivilege is the Postgres SQLSTATE for a permission-denied
+// error (e.g. CREATE SCHEMA without database-level CREATE).
+const pgErrInsufficientPrivilege = "42501"
 
 // safeIdentifierRE matches a simple Postgres identifier: letters, digits, and
 // underscores, not starting with a digit. Used to reject quoted/dotted values
@@ -69,6 +75,33 @@ func EnsureSchema(ctx context.Context, pool *pgxpool.Pool, schema, appRole strin
 
 	schemaIdent := pgx.Identifier{schema}.Sanitize()
 	roleIdent := pgx.Identifier{appRole}.Sanitize()
+
+	// GH #207 Bug 1: readiness fast-path. Once the schema exists and has been
+	// River-migrated, EVERY boot after the first needs only the read/USAGE
+	// privileges the app role already holds (granted by the FIRST creation's
+	// GRANTs below) — it must never re-run the privileged CREATE SCHEMA /
+	// GRANT / ALTER DEFAULT PRIVILEGES statements. Those statements require
+	// DATABASE-level CREATE even when the schema already exists (Postgres
+	// checks the privilege before the IF-NOT-EXISTS short-circuit runs), so a
+	// process connecting with the unprivileged app role (e.g. the
+	// media-encoder when no WPMGR_DB_MIGRATION_DSN owner DSN is configured on
+	// that service) crash-looped on every boot with SQLSTATE 42501 even
+	// though the schema was already fully set up.
+	//
+	// to_regclass resolves a schema-qualified name only when a matching
+	// relation exists AND is visible to the connected role — the app role's
+	// standing USAGE grant on the schema (from the original creation) is
+	// exactly what makes it visible, so a true result here is proof the
+	// schema is ready without ever touching a privileged DDL path.
+	qualifiedRiverJob := pgx.Identifier{schema, "river_job"}.Sanitize()
+	var ready bool
+	if err := pool.QueryRow(ctx, "SELECT to_regclass($1) IS NOT NULL", qualifiedRiverJob).Scan(&ready); err != nil {
+		return fmt.Errorf("probe River schema %q readiness: %w", schema, err)
+	}
+	if ready {
+		return nil
+	}
+
 	preMigration := []string{
 		fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", schemaIdent),
 		fmt.Sprintf("GRANT USAGE ON SCHEMA %s TO %s", schemaIdent, roleIdent),
@@ -77,7 +110,7 @@ func EnsureSchema(ctx context.Context, pool *pgxpool.Pool, schema, appRole strin
 	}
 	for _, stmt := range preMigration {
 		if _, err := pool.Exec(ctx, stmt); err != nil {
-			return fmt.Errorf("prepare River schema %q: %w", schema, err)
+			return wrapSchemaPermissionErr(schema, err)
 		}
 	}
 
@@ -95,8 +128,28 @@ func EnsureSchema(ctx context.Context, pool *pgxpool.Pool, schema, appRole strin
 	}
 	for _, stmt := range postMigration {
 		if _, err := pool.Exec(ctx, stmt); err != nil {
-			return fmt.Errorf("grant River schema %q: %w", schema, err)
+			return wrapSchemaPermissionErr(schema, err)
 		}
 	}
 	return nil
+}
+
+// wrapSchemaPermissionErr detects a Postgres insufficient_privilege error
+// (SQLSTATE 42501) on the privileged first-time River-schema setup path and
+// replaces the raw pg error with an actionable message. Unlike the readiness
+// fast-path above (which only ever needs the app role's own read/USAGE
+// grants), first-time creation of a dedicated River schema needs an
+// owner-level role — surface that distinction instead of a bare pg error. The
+// original error remains available via errors.Unwrap/errors.Is.
+func wrapSchemaPermissionErr(schema string, err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == pgErrInsufficientPrivilege {
+		return fmt.Errorf(
+			"prepare River schema %q: permission denied (SQLSTATE %s) — this schema has never been "+
+				"created, which requires an owner/superuser role; configure WPMGR_DB_MIGRATION_DSN with "+
+				"an owner role (or grant the app role CREATE on the database), then retry: %w",
+			schema, pgErrInsufficientPrivilege, err,
+		)
+	}
+	return fmt.Errorf("prepare River schema %q: %w", schema, err)
 }

--- a/apps/api/internal/riverutil/schema_ensure_test.go
+++ b/apps/api/internal/riverutil/schema_ensure_test.go
@@ -1,0 +1,193 @@
+package riverutil
+
+// schema_ensure_test.go — GH #207 Bug 1 regression lock: v0.61.54 flipped the
+// binary default of river.media_schema from "" to "media_encoder", which
+// activated the previously-skipped EnsureSchema block on the media-encoder
+// boot path. EnsureSchema's privileged CREATE SCHEMA/GRANT statements require
+// DATABASE-level CREATE even when the schema already exists (Postgres checks
+// the privilege before the IF-NOT-EXISTS short-circuit), so an encoder
+// connecting with the unprivileged app role (no WPMGR_DB_MIGRATION_DSN owner
+// DSN configured on that service) crash-looped on every boot with SQLSTATE
+// 42501 even though the schema was already fully set up. These tests prove
+// the fix: a readiness fast-path that needs no privileged DDL once the schema
+// exists, the happy-path first-time creation staying green, and a genuine
+// permission failure surfacing as a wrapped, actionable error.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// schemaTestEnv holds the two roles EnsureSchema's fast-path/first-creation
+// split needs to be exercised end-to-end: an owner (the testcontainers
+// superuser, full CREATE) and wpmgr_app, provisioned exactly like the real
+// deployment (migrations/20260527130000_auth_multitenancy.sql:
+// NOSUPERUSER NOBYPASSRLS, no database-level CREATE ever granted) with LOGIN
+// added only so the test can connect as it directly (production grants
+// LOGIN+password externally).
+type schemaTestEnv struct {
+	owner *pgxpool.Pool
+	app   *pgxpool.Pool
+}
+
+// startSchemaTestPostgres spins up an ephemeral Postgres and provisions the
+// owner + wpmgr_app roles. Trimmed, package-local copy of the pattern in
+// cmd/media-encoder/reconcile_test.go's startReconcileTestPostgres (that
+// helper is unexported in a different package and pulls in the full app
+// schema migration, which EnsureSchema does not need).
+func startSchemaTestPostgres(t *testing.T) *schemaTestEnv {
+	t.Helper()
+	ctx := context.Background()
+
+	container, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("wpmgr"),
+		tcpostgres.WithUsername("wpmgr"),
+		tcpostgres.WithPassword("wpmgr"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	ownerDSN, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	ownerPool, err := pgxpool.New(ctx, ownerDSN)
+	if err != nil {
+		t.Fatalf("connect owner: %v", err)
+	}
+	t.Cleanup(ownerPool.Close)
+
+	// wpmgr_app: same shape as the real app role, plus LOGIN so the test can
+	// connect directly. Explicitly revoke database-level CREATE from both
+	// PUBLIC and the role so the test does not depend on the base image's
+	// ambient defaults — the real wpmgr_app role never receives this grant.
+	for _, stmt := range []string{
+		"CREATE ROLE wpmgr_app LOGIN PASSWORD 'app' NOSUPERUSER NOBYPASSRLS",
+		"REVOKE CREATE ON DATABASE wpmgr FROM PUBLIC",
+		"REVOKE CREATE ON DATABASE wpmgr FROM wpmgr_app",
+	} {
+		if _, err := ownerPool.Exec(ctx, stmt); err != nil {
+			t.Fatalf("provision wpmgr_app (%q): %v", stmt, err)
+		}
+	}
+
+	appDSN := strings.Replace(ownerDSN, "wpmgr:wpmgr@", "wpmgr_app:app@", 1)
+	appPool, err := pgxpool.New(ctx, appDSN)
+	if err != nil {
+		t.Fatalf("connect wpmgr_app: %v", err)
+	}
+	t.Cleanup(appPool.Close)
+
+	var canCreate bool
+	if err := appPool.QueryRow(ctx, "SELECT has_database_privilege('wpmgr_app', current_database(), 'CREATE')").Scan(&canCreate); err != nil {
+		t.Fatalf("check wpmgr_app CREATE privilege: %v", err)
+	}
+	if canCreate {
+		t.Fatal("test setup invariant broken: wpmgr_app must NOT have database-level CREATE (it never does in production)")
+	}
+
+	return &schemaTestEnv{owner: ownerPool, app: appPool}
+}
+
+// TestEnsureSchema_ReadinessFastPath_NoCreatePrivilegeNeeded is the direct
+// GH #207 Bug 1 regression lock: once a schema is created and migrated (here,
+// by the owner — mirroring the API's own boot, which always runs
+// EnsureSchema with owner creds and owns migrations), every subsequent call
+// made with a connection that provably CANNOT run CREATE SCHEMA must still
+// succeed, proving the readiness fast-path — not the privileged path — is
+// what ran.
+func TestEnsureSchema_ReadinessFastPath_NoCreatePrivilegeNeeded(t *testing.T) {
+	env := startSchemaTestPostgres(t)
+	ctx := context.Background()
+	const schema = "media_encoder"
+
+	if err := EnsureSchema(ctx, env.owner, schema, "wpmgr_app"); err != nil {
+		t.Fatalf("owner EnsureSchema (first creation): %v", err)
+	}
+
+	// Steady-state boot, simulated by calling EnsureSchema again as the
+	// unprivileged wpmgr_app role — exactly what the media-encoder does when
+	// WPMGR_DB_MIGRATION_DSN is unset. Since the role provably has no
+	// database CREATE privilege, a nil error here can only mean the
+	// readiness fast-path ran (the privileged CREATE SCHEMA statement would
+	// have failed with 42501).
+	if err := EnsureSchema(ctx, env.app, schema, "wpmgr_app"); err != nil {
+		t.Fatalf("app-role EnsureSchema (steady-state boot) = %v, want nil (must use the readiness fast-path, not CREATE SCHEMA)", err)
+	}
+}
+
+// TestEnsureSchema_FreshSchema_OwnerCreatesMigratesAndGrants is the existing
+// happy path staying green: an owner connection on a never-created schema
+// still creates it, runs the River migration, and grants the app role
+// read/write access.
+func TestEnsureSchema_FreshSchema_OwnerCreatesMigratesAndGrants(t *testing.T) {
+	env := startSchemaTestPostgres(t)
+	ctx := context.Background()
+	const schema = "media_encoder"
+
+	if err := EnsureSchema(ctx, env.owner, schema, "wpmgr_app"); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	var ready bool
+	if err := env.owner.QueryRow(ctx, `SELECT to_regclass('"media_encoder"."river_job"') IS NOT NULL`).Scan(&ready); err != nil {
+		t.Fatalf("check river_job exists: %v", err)
+	}
+	if !ready {
+		t.Fatal("river_job table was not created/migrated in the dedicated schema")
+	}
+
+	// wpmgr_app must have been granted USAGE + table access by the
+	// privileged path — proven independently of the fast-path by having the
+	// app role actually read the freshly migrated table.
+	if _, err := env.app.Exec(ctx, `SELECT count(*) FROM "media_encoder"."river_job"`); err != nil {
+		t.Fatalf("wpmgr_app cannot read the migrated table after EnsureSchema: %v", err)
+	}
+}
+
+// TestEnsureSchema_PermissionDenied_WrapsActionableError verifies that a
+// genuine first-time-creation permission failure (the schema was never
+// created, and the connection lacks database CREATE) surfaces as a wrapped,
+// actionable error instead of a raw pg error, per the fix's requirement to
+// never swallow the underlying error.
+func TestEnsureSchema_PermissionDenied_WrapsActionableError(t *testing.T) {
+	env := startSchemaTestPostgres(t)
+	ctx := context.Background()
+	const schema = "media_encoder"
+
+	// No owner EnsureSchema call precedes this: the schema genuinely does
+	// not exist, so the readiness fast-path returns false and the call falls
+	// into the privileged CREATE SCHEMA path, which wpmgr_app cannot satisfy.
+	err := EnsureSchema(ctx, env.app, schema, "wpmgr_app")
+	if err == nil {
+		t.Fatal("EnsureSchema with an unprivileged connection on a never-created schema = nil, want an error")
+	}
+
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		t.Fatalf("error does not wrap the underlying *pgconn.PgError (raw pg error swallowed?): %v", err)
+	}
+	if pgErr.Code != pgErrInsufficientPrivilege {
+		t.Fatalf("underlying pg error code = %q, want %q (insufficient_privilege)", pgErr.Code, pgErrInsufficientPrivilege)
+	}
+	if !strings.Contains(err.Error(), "WPMGR_DB_MIGRATION_DSN") {
+		t.Fatalf("error message is not actionable, want mention of WPMGR_DB_MIGRATION_DSN: %v", err)
+	}
+}

--- a/apps/api/internal/screenshot/capture/worker.go
+++ b/apps/api/internal/screenshot/capture/worker.go
@@ -7,6 +7,7 @@ package capture
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -28,6 +29,19 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/site"
 	siteevents "github.com/mosamlife/wpmgr/apps/api/internal/site/events"
 )
+
+// errInfraCapture is a sentinel wrapped around browser/proxy INFRASTRUCTURE
+// failures (Chromium missing, SSRF proxy failing to start, Chromium failing
+// to launch) so Work can distinguish "the encoder's own environment can't
+// capture right now" (transient — worth a bounded River retry, since a fresh
+// attempt or a fresh encoder instance may well succeed) from "this particular
+// SITE couldn't be captured" (navigation/render/timeout failures AFTER a
+// browser connection was established — not transient; retrying won't make a
+// down or blocking site come up). GH #207 Bug 3: previously every capture
+// failure — including infra failures like a Chromium launch crash — was
+// recorded MarkFailed + Work returned nil, which told River the job
+// "completed" and it silently never retried even a self-healing infra hiccup.
+var errInfraCapture = errors.New("screenshot: infrastructure capture failure")
 
 // CaptureQueue is the dedicated River queue (alias for screenshot.ScreenshotQueue).
 const CaptureQueue = screenshot.ScreenshotQueue
@@ -92,6 +106,11 @@ type Worker struct {
 	logger *slog.Logger
 	// sem caps concurrent Chromium captures. Sized at construction.
 	sem chan struct{}
+	// captureFn is the browser-capture step, extracted as a field (defaulting
+	// to w.capture) so tests can substitute a fake implementation to exercise
+	// the infra-vs-site-level error classification in Work() without
+	// launching a real Chromium browser.
+	captureFn func(ctx context.Context, siteURL string) (img1x, img2x []byte, err error)
 }
 
 // NewWorker builds the capture worker.
@@ -108,13 +127,23 @@ func NewWorker(
 	if concurrency <= 0 {
 		concurrency = defaultConcurrency
 	}
-	return &Worker{
+	w := &Worker{
 		repo:   repo,
 		store:  store,
 		events: events,
 		logger: logger,
 		sem:    make(chan struct{}, concurrency),
 	}
+	w.captureFn = w.capture
+	return w
+}
+
+// SetCaptureFuncForTest overrides the browser-capture step. Exported so tests
+// in other packages (capture_test) can simulate infra vs. site-level capture
+// failures deterministically, without a real Chromium binary. Production code
+// must never call this — NewWorker already wires captureFn to w.capture.
+func (w *Worker) SetCaptureFuncForTest(fn func(ctx context.Context, siteURL string) (img1x, img2x []byte, err error)) {
+	w.captureFn = fn
 }
 
 // Timeout gives each capture job 30 s.
@@ -139,16 +168,30 @@ func (w *Worker) Work(ctx context.Context, job *river.Job[screenshot.CaptureArgs
 	capCtx, cancel := context.WithTimeout(ctx, captureTimeout)
 	defer cancel()
 
-	img1x, img2x, err := w.capture(capCtx, a.SiteURL)
+	img1x, img2x, err := w.captureFn(capCtx, a.SiteURL)
 	if err != nil {
 		reason := err.Error()
 		w.logger.WarnContext(ctx, "screenshot capture failed",
 			slog.String("site_id", a.SiteID.String()),
-			slog.String("reason", reason))
+			slog.String("reason", reason),
+			slog.Bool("infra", errors.Is(err, errInfraCapture)))
+		// MarkFailed unconditionally — the dashboard's "didn't finish" state
+		// must reflect every failure, infra or site-level, so the operator
+		// always sees the latest outcome regardless of whether River retries.
 		_, _ = w.repo.MarkFailed(ctx, a.TenantID, a.SiteID, reason)
-		// Return nil — a capture failure is NOT a transient error worth retrying
-		// automatically (if the site is down or blocks headless browsers, retries
-		// won't help). The operator can request a manual refresh.
+		if errors.Is(err, errInfraCapture) {
+			// Infrastructure failure (Chromium missing/launch crash, SSRF
+			// proxy start failure): return the error so River retries, bounded
+			// by CaptureArgs.InsertOpts().MaxAttempts. A transient encoder
+			// hiccup — or a self-healed environment on the next attempt —
+			// recovers automatically instead of being permanently stuck
+			// "completed" with no further attempt ever made.
+			return err
+		}
+		// Site-level failure (navigation/render/timeout after a browser
+		// connection was established): return nil — not a transient error
+		// worth retrying (if the site is down or blocks headless browsers,
+		// retries won't help). The operator can request a manual refresh.
 		return nil
 	}
 
@@ -212,14 +255,14 @@ func (w *Worker) capture(ctx context.Context, siteURL string) (img1x, img2x []by
 	// Fast-fail when Chromium is not installed (clear error message).
 	chromiumBin := chromiumBinPath()
 	if _, lookupErr := exec.LookPath(chromiumBin); lookupErr != nil {
-		return nil, nil, fmt.Errorf("chromium not found at %s: install chromium in the media-encoder image", chromiumBin)
+		return nil, nil, fmt.Errorf("chromium not found at %s: install chromium in the media-encoder image: %w", chromiumBin, errInfraCapture)
 	}
 
 	// 1. Start the SSRF proxy. Every TCP connection Chromium makes goes through
 	//    this proxy, whose dialer calls ssrf.Safe (same guard as httpclient).
 	proxy, proxyErr := ssrfproxy.New(w.logger)
 	if proxyErr != nil {
-		return nil, nil, fmt.Errorf("ssrf proxy start: %w", proxyErr)
+		return nil, nil, fmt.Errorf("ssrf proxy start: %w: %w", proxyErr, errInfraCapture)
 	}
 	defer proxy.Stop()
 
@@ -272,7 +315,7 @@ func (w *Worker) capture(ctx context.Context, siteURL string) (img1x, img2x []by
 
 	browserURL, launchErr := l.Launch()
 	if launchErr != nil {
-		return nil, nil, fmt.Errorf("chromium launch: %w", launchErr)
+		return nil, nil, fmt.Errorf("chromium launch: %w: %w", launchErr, errInfraCapture)
 	}
 	defer func() { l.Cleanup() }()
 

--- a/apps/api/internal/screenshot/capture/worker_test.go
+++ b/apps/api/internal/screenshot/capture/worker_test.go
@@ -2,6 +2,7 @@ package capture_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"sync"
@@ -150,9 +151,15 @@ func TestWorker_Timeout(t *testing.T) {
 	}
 }
 
-// TestWorker_MarksFailed_OnChromiumMissing verifies that when Chromium is not
-// found the worker marks the screenshot as failed (not a transient River error).
-func TestWorker_MarksFailed_OnChromiumMissing(t *testing.T) {
+// TestWorker_InfraFailure_OnChromiumMissing_RetriesAndMarksFailed is the
+// GH #207 Bug 3 regression lock for the INFRASTRUCTURE branch: Chromium
+// missing is an infra failure (not a site-level one), so Work() must both
+// MarkFailed (so the dashboard shows "didn't finish") AND return a non-nil
+// error so River retries (bounded by CaptureArgs.InsertOpts().MaxAttempts).
+// Before the fix, Work() returned nil here, which told River the job
+// "completed" and silently killed all future attempts — even once the
+// encoder environment (e.g. a fixed $HOME/crashpad issue) self-healed.
+func TestWorker_InfraFailure_OnChromiumMissing_RetriesAndMarksFailed(t *testing.T) {
 	// Force the chromium-missing path deterministically: point the worker at a
 	// path that cannot exist. Without this the test relied on the ambient
 	// environment NOT having Chromium, which is false on CI runners (they ship
@@ -174,10 +181,9 @@ func TestWorker_MarksFailed_OnChromiumMissing(t *testing.T) {
 		},
 	})
 
-	// Work() returns nil (not a transient error) — capture failures must not
-	// cause River to retry infinitely.
-	if err != nil {
-		t.Fatalf("Work() = %v, want nil (mark-failed, not retryable)", err)
+	// Work() must return a non-nil (retryable) error for an infra failure.
+	if err == nil {
+		t.Fatal("Work() = nil, want a non-nil error (Chromium-missing is an infra failure and must retry)")
 	}
 	repo.mu.Lock()
 	nFailed := len(repo.failed)
@@ -186,6 +192,49 @@ func TestWorker_MarksFailed_OnChromiumMissing(t *testing.T) {
 		t.Errorf("MarkFailed called %d times, want 1", nFailed)
 	}
 	if len(repo.failed[0]) == 0 {
+		t.Error("MarkFailed reason is empty")
+	}
+}
+
+// TestWorker_SiteLevelFailure_ReturnsNilAndMarksFailed verifies the
+// site-level branch (a failure AFTER the browser/proxy infrastructure came up
+// successfully — e.g. navigation, render, or a site timeout) still returns
+// nil (no River retry — retrying won't fix a down or blocking site) while
+// still marking the screenshot failed so the dashboard reflects it. Uses the
+// captureFn test seam (SetCaptureFuncForTest) to simulate a post-MustConnect
+// failure deterministically, without a real Chromium/network round trip.
+func TestWorker_SiteLevelFailure_ReturnsNilAndMarksFailed(t *testing.T) {
+	repo := &fakeRepo{}
+	store := &fakeStore{}
+	w := capture.NewWorker(repo, store, nil, 1, nil)
+	w.SetCaptureFuncForTest(func(ctx context.Context, siteURL string) ([]byte, []byte, error) {
+		return nil, nil, errors.New("navigate https://example.com: context deadline exceeded")
+	})
+
+	ctx := context.Background()
+	err := w.Work(ctx, &river.Job[screenshot.CaptureArgs]{
+		Args: screenshot.CaptureArgs{
+			SiteID:   uuid.New(),
+			TenantID: uuid.New(),
+			SiteURL:  "https://example.com",
+			Reason:   screenshot.ReasonManual,
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("Work() = %v, want nil (site-level failure must not retry)", err)
+	}
+	repo.mu.Lock()
+	nFailed := len(repo.failed)
+	failedReason := ""
+	if nFailed > 0 {
+		failedReason = repo.failed[0]
+	}
+	repo.mu.Unlock()
+	if nFailed != 1 {
+		t.Errorf("MarkFailed called %d times, want 1", nFailed)
+	}
+	if failedReason == "" {
 		t.Error("MarkFailed reason is empty")
 	}
 }

--- a/apps/api/internal/screenshot/enqueuer.go
+++ b/apps/api/internal/screenshot/enqueuer.go
@@ -13,11 +13,27 @@ import (
 // Kind() must be stable — changing it orphans in-flight jobs.
 func (CaptureArgs) Kind() string { return "site_screenshot_capture" }
 
+// captureMaxAttempts bounds River's retry storm for site_screenshot_capture
+// jobs. GH #207 Bug 3: capture.Worker.Work now returns a non-nil error (which
+// River retries) for INFRASTRUCTURE capture failures (Chromium missing/launch
+// crash, SSRF proxy start failure) so a transient encoder hiccup self-heals,
+// instead of the job being recorded "completed" with no further attempt ever
+// made. Without an explicit cap, River's package default (MaxAttemptsDefault
+// = 25, with exponential backoff) would let a PERSISTENTLY broken encoder
+// environment retry the same job 25 times. 3 is enough to ride out a
+// transient hiccup (or a redeploy of a broken encoder image) without turning
+// a real outage into a retry storm; site-level failures never retry at all
+// (Work returns nil for those), so this cap only ever bounds the infra case.
+const captureMaxAttempts = 3
+
 // InsertOpts pins every capture job to the screenshot queue with MaxWorkers=2.
 // The main API registers this queue with MaxWorkers=0 (insert-only); the
 // media-encoder process runs the workers.
 func (CaptureArgs) InsertOpts() river.InsertOpts {
-	return river.InsertOpts{Queue: ScreenshotQueue}
+	return river.InsertOpts{
+		Queue:       ScreenshotQueue,
+		MaxAttempts: captureMaxAttempts,
+	}
 }
 
 // captureUniqueWindow is the deduplication window for manual screenshot refresh

--- a/apps/api/internal/screenshot/enqueuer_test.go
+++ b/apps/api/internal/screenshot/enqueuer_test.go
@@ -19,6 +19,22 @@ func TestCaptureArgs_InsertOpts_Queue(t *testing.T) {
 	}
 }
 
+// TestCaptureArgs_InsertOpts_MaxAttemptsBounded is the GH #207 Bug 3
+// regression lock: now that capture.Worker.Work returns a non-nil error for
+// infra failures (so River retries), CaptureArgs must pin an explicit, small
+// MaxAttempts — otherwise River's package default (25, MaxAttemptsDefault)
+// would let a persistently broken encoder retry the same job 25 times.
+func TestCaptureArgs_InsertOpts_MaxAttemptsBounded(t *testing.T) {
+	var a screenshot.CaptureArgs
+	opts := a.InsertOpts()
+	if opts.MaxAttempts <= 0 {
+		t.Fatalf("InsertOpts().MaxAttempts = %d, want an explicit positive bound (River defaults to 25 when unset)", opts.MaxAttempts)
+	}
+	if opts.MaxAttempts > 5 {
+		t.Errorf("InsertOpts().MaxAttempts = %d, want a small bound (<=5) to avoid an infra-failure retry storm", opts.MaxAttempts)
+	}
+}
+
 // TestEnqueuer_UniqueOpts verifies that Enqueuer.Enqueue passes UniqueOpts
 // with ByArgs=true and a non-zero ByPeriod (M5: deduplication of manual-refresh
 // spam). We test this by constructing the same InsertOpts the Enqueuer builds

--- a/infra/Dockerfile.media-encoder
+++ b/infra/Dockerfile.media-encoder
@@ -107,11 +107,19 @@ RUN apt-get update \
     && ln -s /usr/bin/chromium /usr/bin/chromium-browser \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --gid 65532 nonroot \
-    && useradd --uid 65532 --gid 65532 --no-create-home --shell /usr/sbin/nologin nonroot
+    && useradd --uid 65532 --gid 65532 --no-create-home --shell /usr/sbin/nologin nonroot \
+    && mkdir -p /home/nonroot && chown 65532:65532 /home/nonroot
 
 WORKDIR /
 COPY --from=build /out/media-encoder /usr/local/bin/media-encoder
 
+# HOME must be a real, writable, owned directory: Chromium's crashpad handler
+# fails to launch ("--database is required") without a writable $HOME-relative
+# location for its crash-dump database. --no-create-home above means passwd's
+# HOME field for uid 65532 points at a directory that doesn't exist unless we
+# create it explicitly (see mkdir/chown in the RUN layer above). Set ENV HOME
+# too so it's explicit regardless of how the shell/exec resolves passwd.
+ENV HOME=/home/nonroot
 USER nonroot:nonroot
 
 ENTRYPOINT ["/usr/local/bin/media-encoder"]


### PR DESCRIPTION
Fixes two reported issues (five distinct bugs). Full root-cause + fix detail in the commit message and the GH issues.

## GH #207 — media-encoder screenshot capture (three stacked bugs)
1. **v0.61.54 regression, crash-loop:** `EnsureSchema` re-ran privileged DDL every boot; `CREATE SCHEMA IF NOT EXISTS` needs DB-level CREATE even when the schema exists, so an encoder on the unprivileged app role crash-looped (SQLSTATE 42501). Fix: readiness fast-path (`to_regclass` probe) skips all privileged DDL when the schema is already prepared; clear actionable error on genuine first-time creation without an owner DSN.
2. **`$HOME` missing:** `useradd --no-create-home` left `/home/nonroot` absent, so Chromium's crashpad handler failed at launch on every capture. Fix: create + chown the home dir + `ENV HOME` in the Dockerfile.
3. **Failed jobs recorded `completed`:** capture failures returned nil → River never retried. Fix: classify infra failures (retry, bounded `MaxAttempts=3`) vs site failures (no retry); every failure still marks the dashboard state.

## GH #208 — core update results did not match reality
1. **Stale update-check fails open:** the agent read a possibly-stale transient without forcing a fresh check, so a real pending update looked "up to date" and was skipped. Fix: force a fresh check for "latest"; resolvers return `?string` so undetermined is distinct from up-to-date; `isUpdatable` no longer folds unknown into up_to_date.
2. **30s dispatch timeout too short:** a real update (snapshot + download + extract + core DB migration, synchronous) can exceed the shared 30s client, so the CP recorded "failed" while the agent finished. Fix: dedicated update-apply commander (`ApplyHTTPTimeout` default 5m), matching the existing backup/media pattern.

## Verification
- apps/api build + vet clean; changed-package tests green
- `EnsureSchema` readiness/fresh/permission tests **live-verified via testcontainers** (the regression proof)
- screenshot infra-vs-site classification + retry-bound tests; update-apply commander + config tests
- agent phpunit 2532 green; `wp plugin check` 0 errors
- Adversarially reviewed: Fix A can't regress hosted (schema exists → fast-path skip); the agent `unknown` status is contract-safe (CP folds it to succeeded/no-change, no 422)

Multi-layer: api + media-encoder + agent (bumped to 0.61.55) + Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed self-hosted media-encoder crash loops after upgrades.
  * Restored screenshot capture reliability and ensured failed captures are retried only for temporary infrastructure issues.
  * Fixed “Latest” updates incorrectly reporting that no update is available when availability data is stale or unavailable.
  * Prevented long-running updates from being incorrectly marked as failed.
  * Improved error guidance when database setup requires elevated permissions.

* **Release**
  * Updated the agent to version 0.61.55.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->