### PR TITLE
fix(update): rollback survives site-wide fatal + phantom same-version + Refresh force (GH #210/#211/#212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.56] - 2026-07-11
+
+### Fixed
+
+- Automatic update rollback now recovers a site that an update left fataling on every request (GH #210). Previously, when a plugin or theme update applied cleanly but then caused a site-wide PHP fatal on every WordPress request, the automatic rollback could not run: it was dispatched to the same WordPress endpoint that was now fataling, so the site stayed fully down (front end and admin) until someone recovered it manually at the filesystem level. A new update watchdog loads before regular plugins and, when it detects a genuine post-update fatal, restores the pre-update snapshot directly at the filesystem level without needing WordPress to boot. It fires only for a real fatal attributable to the just-updated plugin or theme, within a short window after the update, and disarms itself as soon as the site boots healthily, so it cannot revert a working update. If the site is still reachable, rollback continues to work exactly as before. The dashboard also now shows this "site not responding, recovery attempted" condition distinctly instead of a generic rollback failure.
+- The "Available updates" panel no longer shows a phantom update whose target version equals the version already installed (GH #211), for example a theme listed as updatable from a version to the same version. WordPress's own update cache can occasionally hold such an entry; nothing in the pipeline compared the offered version to the installed one, so it surfaced as a real update and inflated the update count. The agent now suppresses same-version entries, the control plane drops them defensively (which also clears any already-stored phantoms on the next view, with no re-sync), and the update wizard no longer pre-selects them.
+- The "Refresh" button on a site's available updates now forces a real check against WordPress.org instead of sometimes returning the same cached list (GH #212). The refresh only bypassed WPMgr's own short lock, not WordPress core's separate, roughly twelve-hour check throttle, so it could take several clicks to match what the site's own Updates screen showed immediately. An explicit refresh now clears the relevant update caches and forces the underlying checks, so a single click returns current data. The scheduled background refresh stays gentle and is unchanged. A related gap in the update-apply path's own freshness check is fixed too, and a rollback now clears the update cache so the rolled-back-from version is not left showing as available.
+
 ## [0.61.55] - 2026-07-11
 
 ### Fixed

--- a/apps/agent/includes/class-enrollment.php
+++ b/apps/agent/includes/class-enrollment.php
@@ -476,6 +476,13 @@ final class Enrollment
      * update transients WordPress already maintains; does NOT force a refresh
      * (that is the 30-min metadata cron's job) so the 60s heartbeat stays light.
      *
+     * GH #211 sibling guard: each transient response entry is compared against
+     * the installed version before counting — WordPress's own transients can
+     * carry a stale/duplicate entry whose `new_version` is not actually newer,
+     * and blindly counting it would show a phantom "N updates available" badge
+     * that disagrees with the metadata push (which already applies this guard
+     * in MetadataCommand::normalizeAvailableUpdate()).
+     *
      * @return int
      */
     private function installedUpdatesCount(): int
@@ -485,23 +492,134 @@ final class Enrollment
         if (function_exists('get_site_transient')) {
             $plugins = get_site_transient('update_plugins');
             if (is_object($plugins) && isset($plugins->response) && is_array($plugins->response)) {
-                $count += count($plugins->response);
+                $installedPlugins = $this->pluginVersions();
+                foreach ($plugins->response as $file => $entry) {
+                    $installed  = is_string($file) ? ($installedPlugins[$file] ?? '') : '';
+                    $newVersion = $this->extractNewVersion($entry);
+                    if (!$this->isPhantomUpdate($newVersion, $installed)) {
+                        $count++;
+                    }
+                }
             }
             $themes = get_site_transient('update_themes');
             if (is_object($themes) && isset($themes->response) && is_array($themes->response)) {
-                $count += count($themes->response);
+                $installedThemes = $this->themeVersions();
+                foreach ($themes->response as $stylesheet => $entry) {
+                    $installed  = is_string($stylesheet) ? ($installedThemes[$stylesheet] ?? '') : '';
+                    $newVersion = $this->extractNewVersion($entry);
+                    if (!$this->isPhantomUpdate($newVersion, $installed)) {
+                        $count++;
+                    }
+                }
             }
             $core = get_site_transient('update_core');
             if (is_object($core) && isset($core->updates) && is_array($core->updates)) {
+                $installedCore = $this->wpVersion();
                 foreach ($core->updates as $update) {
-                    if (is_object($update) && isset($update->response) && $update->response === 'upgrade') {
-                        $count++;
+                    if (!is_object($update) || !isset($update->response) || $update->response !== 'upgrade') {
+                        continue;
                     }
+                    $newVersion = isset($update->version) && is_scalar($update->version)
+                        ? (string) $update->version
+                        : (isset($update->current) && is_scalar($update->current) ? (string) $update->current : '');
+                    if ($newVersion === '' || $this->isPhantomUpdate($newVersion, $installedCore)) {
+                        continue;
+                    }
+                    $count++;
                 }
             }
         }
 
         return $count;
+    }
+
+    /**
+     * A compact stylesheet=>version map of installed themes, mirroring
+     * {@see pluginVersions()}. Used only by installedUpdatesCount()'s GH #211
+     * phantom-update guard — not sent on the wire itself (the heartbeat only
+     * ships plugin_versions).
+     *
+     * @return array<string,string>
+     */
+    private function themeVersions(): array
+    {
+        if (!function_exists('wp_get_themes')) {
+            return [];
+        }
+        $themes = wp_get_themes();
+        if (!is_array($themes)) {
+            return [];
+        }
+        $map = [];
+        foreach ($themes as $stylesheet => $theme) {
+            if (!is_object($theme) || !method_exists($theme, 'get')) {
+                continue;
+            }
+            $version = $theme->get('Version');
+            $map[(string) $stylesheet] = is_scalar($version) ? (string) $version : '';
+        }
+        return $map;
+    }
+
+    /**
+     * Extract a usable `new_version` string from a transient response entry
+     * (object for plugins, array for themes). Returns '' when absent/unusable.
+     *
+     * @param mixed $entry Raw transient response entry.
+     * @return string
+     */
+    private function extractNewVersion(mixed $entry): string
+    {
+        if (is_object($entry)) {
+            $value = $entry->new_version ?? null;
+        } elseif (is_array($entry)) {
+            $value = $entry['new_version'] ?? null;
+        } else {
+            return '';
+        }
+        return (is_string($value) || is_numeric($value)) ? (string) $value : '';
+    }
+
+    /**
+     * GH #211 sibling guard: true when `$newVersion` is not strictly newer
+     * than `$installedVersion` (i.e. counting it would be a phantom "update").
+     * Fails OPEN (returns false, i.e. "keep counting it") when either side is
+     * empty/unreadable/the 'unknown' sentinel — over-counting is preferable to
+     * silently hiding a real update because a version string was unreadable.
+     * Mirrors MetadataCommand::normalizeAvailableUpdate()'s normalization:
+     * trim + strip a single leading `v`/`V`, leaving any prerelease/build
+     * suffix intact for version_compare() to arbitrate.
+     *
+     * @param string $newVersion       Offered version from the transient.
+     * @param string $installedVersion Currently-installed version.
+     * @return bool
+     */
+    private function isPhantomUpdate(string $newVersion, string $installedVersion): bool
+    {
+        if ($newVersion === '' || $installedVersion === '' || $installedVersion === 'unknown') {
+            return false;
+        }
+        $normNew       = $this->normalizeVersionForCompare($newVersion);
+        $normInstalled = $this->normalizeVersionForCompare($installedVersion);
+        return version_compare($normNew, $normInstalled, '<=');
+    }
+
+    /**
+     * Lightly normalize a version string for the phantom-update comparison:
+     * trims whitespace and strips a single leading `v`/`V`. See
+     * MetadataCommand::normalizeVersionForCompare() for the full rationale
+     * (deliberately does NOT strip prerelease/build suffixes).
+     *
+     * @param string $version Raw version string.
+     * @return string
+     */
+    private function normalizeVersionForCompare(string $version): string
+    {
+        $trimmed = trim($version);
+        if ($trimmed !== '' && ($trimmed[0] === 'v' || $trimmed[0] === 'V')) {
+            $trimmed = substr($trimmed, 1);
+        }
+        return $trimmed;
     }
 
     /**

--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -123,6 +123,7 @@ use WPMgr\Agent\Support\MuPluginInstaller;
 use WPMgr\Agent\Support\SnapshotManager;
 use WPMgr\Agent\Support\UpdateChecker;
 use WPMgr\Agent\Support\UpdateInFlight;
+use WPMgr\Agent\Support\UpdateWatchdogMarker;
 use WPMgr\Agent\AutoOptimizeUpload;
 use WPMgr\Agent\Webhooks\MediaModalInjector;
 
@@ -494,6 +495,18 @@ final class Plugin
         // any boot once the heartbeat event is found missing.
         add_action('plugins_loaded', [$this, 'maybeRescheduleCron']);
 
+        // GitHub issue #210, MEDIUM-1b (security review follow-up) — the
+        // "principled disarm" for the update-watchdog mu-plugin. Reaching
+        // plugins_loaded at all is proof the WHOLE plugin-loading loop
+        // (every active plugin, including any one an armed marker entry is
+        // watching) completed this request without the every-request
+        // bootstrap fatal GitHub issue #210 exists to catch — see
+        // UpdateWatchdogMarker::disarmHealthy()'s own doc for the full
+        // reasoning and its fail-closed guarantee. Gated internally on the
+        // marker file existing (one is_file() stat), so this costs nothing
+        // extra on the overwhelmingly common no-marker boot.
+        add_action('plugins_loaded', [$this, 'maybeDisarmUpdateWatchdog']);
+
         // M14: Guard against Performance Lab disabling our object-cache drop-in.
         // When the OC is configured (config file exists), register the filter so
         // Performance Lab cannot suppress it.
@@ -775,6 +788,21 @@ final class Plugin
             $this->muInstaller->installWaf();
         } elseif ($this->muInstaller->isWafInstalled()) {
             $this->muInstaller->uninstallWaf();
+        }
+
+        // GitHub issue #210 — install the update-watchdog mu-plugin whenever
+        // the site is enrolled (the only state in which UpdateCommand can
+        // ever run at all, and therefore the only state in which its marker
+        // could ever be armed). The mu-plugin itself is inert on every
+        // request until a marker actually exists (a single is_file() stat —
+        // see its own class doc), so no separate feature opt-in is needed
+        // beyond enrollment. Remove a previously-installed copy on
+        // un-enrollment so no executable mu-plugin lingers for a site the
+        // control plane no longer manages.
+        if ($this->settings->isEnrolled()) {
+            $this->muInstaller->installUpdateWatchdog();
+        } elseif ($this->muInstaller->isUpdateWatchdogInstalled()) {
+            $this->muInstaller->uninstallUpdateWatchdog();
         }
 
         // Login Whitelabel — bind login_head/login_headerurl/login_message hooks
@@ -1077,12 +1105,14 @@ final class Plugin
             wp_clear_scheduled_hook(PreloadQueue::WATCHDOG_HOOK);
         }
 
-        // Best-effort removal of both mu-plugins on deactivation so no executable
-        // PHP file installed by this plugin lingers in wp-content/mu-plugins/
-        // after the plugin is deactivated. Both calls are idempotent and
-        // best-effort; a failure must never block deactivation.
+        // Best-effort removal of all THREE mu-plugins on deactivation so no
+        // executable PHP file installed by this plugin lingers in
+        // wp-content/mu-plugins/ after the plugin is deactivated. All calls
+        // are idempotent and best-effort; a failure must never block
+        // deactivation.
         try {
             $this->muInstaller->uninstallWaf();
+            $this->muInstaller->uninstallUpdateWatchdog();
             $this->muInstaller->uninstall();
         } catch (\Throwable $e) {
             // Swallow — deactivation must always complete.
@@ -1255,6 +1285,19 @@ final class Plugin
     public function maybeRunSchemaMigrations(): void
     {
         Schema::ensureCurrent();
+    }
+
+    /**
+     * GitHub issue #210, MEDIUM-1b — clear the update-watchdog marker entry
+     * for any armed slug that just proved itself healthy on this exact
+     * request. See UpdateWatchdogMarker::disarmHealthy()'s own doc for the
+     * full reasoning; this method is only the plugins_loaded binding point.
+     *
+     * @return void
+     */
+    public function maybeDisarmUpdateWatchdog(): void
+    {
+        UpdateWatchdogMarker::disarmHealthy();
     }
 
     /**

--- a/apps/agent/includes/class-scheduler.php
+++ b/apps/agent/includes/class-scheduler.php
@@ -422,14 +422,37 @@ final class Scheduler
      * Public so a dispatcher (e.g. the RefreshInventoryCommand on-demand
      * refresh) can reuse the same throttle without re-implementing the lock.
      *
-     * @param bool $force Bypass the rate-limit lock (used by the on-demand
-     *                    refresh command, which is human-initiated).
+     * GH #212: `$force` bypassed only WPMgr's own 5-minute REFRESH_LOCK_KEY —
+     * it never bypassed WordPress core's own ~12h `update_plugins`/
+     * `update_themes`/`update_core` throttle, so wp_update_*() and
+     * wp_version_check() would silently no-op against a still-fresh core
+     * transient and a human "Refresh" often needed several clicks to land.
+     * When `$force` is true we now ALSO delete the three site transients
+     * before re-checking (clearing core's own throttle) and pass `true` as
+     * wp_version_check()'s second (bypass-cache) argument. This hard-force is
+     * gated strictly on `$force` — the 30-min cron and the
+     * upgrader_process_complete/switch_theme/activated_plugin/deactivated_plugin
+     * event hooks all call this via Scheduler::runMetadata() with the default
+     * `$force = false` and MUST stay on the soft/throttled path, or a bulk
+     * update (which fires several of those hooks back-to-back) would hammer
+     * wp.org on every plugin toggle.
+     *
+     * @param bool $force Bypass BOTH the WPMgr rate-limit lock AND WordPress
+     *                    core's own update-check throttle (used by the
+     *                    on-demand refresh command, which is human-initiated).
      * @return void
      */
     public function refreshUpdateTransients(bool $force = false): void
     {
         if (!$force && function_exists('get_transient') && get_transient(self::REFRESH_LOCK_KEY) !== false) {
             return;
+        }
+        if ($force) {
+            if (function_exists('delete_site_transient')) {
+                delete_site_transient('update_plugins');
+                delete_site_transient('update_themes');
+                delete_site_transient('update_core');
+            }
         }
         if (function_exists('wp_update_plugins')) {
             @wp_update_plugins();
@@ -438,7 +461,7 @@ final class Scheduler
             @wp_update_themes();
         }
         if (function_exists('wp_version_check')) {
-            @wp_version_check();
+            @wp_version_check([], $force);
         }
         if (function_exists('set_transient') && defined('MINUTE_IN_SECONDS')) {
             set_transient(self::REFRESH_LOCK_KEY, 1, 5 * MINUTE_IN_SECONDS);

--- a/apps/agent/includes/commands/class-diagnostics-command.php
+++ b/apps/agent/includes/commands/class-diagnostics-command.php
@@ -764,6 +764,13 @@ final class DiagnosticsCommand implements CommandInterface
      * Plugins category — installed/active counts, available updates count,
      * and the per-paid-plugin `licensing` probe (leapfrog feature).
      *
+     * GH #211 sibling guard: `available_updates` is only incremented for a
+     * transient response entry whose `new_version` is strictly newer than the
+     * installed version (per get_plugins()) — a stale/duplicate transient
+     * entry no longer inflates the site-health Plugins card with a phantom
+     * count. Mirrors MetadataCommand::normalizeAvailableUpdate() /
+     * Enrollment::installedUpdatesCount().
+     *
      * @return array<string,mixed>
      */
     private function collectPlugins(): array
@@ -779,7 +786,15 @@ final class DiagnosticsCommand implements CommandInterface
         $availableUpdates = 0;
         $updates = function_exists('get_site_transient') ? get_site_transient('update_plugins') : null;
         if (is_object($updates) && isset($updates->response) && is_array($updates->response)) {
-            $availableUpdates = count($updates->response);
+            foreach ($updates->response as $file => $entry) {
+                $installed = is_string($file) && isset($all[$file]['Version']) && is_scalar($all[$file]['Version'])
+                    ? (string) $all[$file]['Version']
+                    : '';
+                $newVersion = $this->extractNewVersion($entry);
+                if (!$this->isPhantomUpdate($newVersion, $installed)) {
+                    $availableUpdates++;
+                }
+            }
         }
 
         return [
@@ -790,6 +805,66 @@ final class DiagnosticsCommand implements CommandInterface
             // option keys (out of scope for this sprint to ship the allowlist).
             'licensing'              => $this->collectPluginLicensing($all),
         ];
+    }
+
+    /**
+     * Extract a usable `new_version` string from a transient response entry
+     * (object for plugins, array for themes). Returns '' when absent/unusable.
+     *
+     * @param mixed $entry Raw transient response entry.
+     * @return string
+     */
+    private function extractNewVersion(mixed $entry): string
+    {
+        if (is_object($entry)) {
+            $value = $entry->new_version ?? null;
+        } elseif (is_array($entry)) {
+            $value = $entry['new_version'] ?? null;
+        } else {
+            return '';
+        }
+        return (is_string($value) || is_numeric($value)) ? (string) $value : '';
+    }
+
+    /**
+     * GH #211 sibling guard: true when `$newVersion` is not strictly newer
+     * than `$installedVersion` (i.e. counting it would be a phantom "update").
+     * Fails OPEN (returns false, i.e. "keep counting it") when either side is
+     * empty/unreadable/the 'unknown' sentinel. Mirrors
+     * MetadataCommand::normalizeAvailableUpdate()'s normalization: trim +
+     * strip a single leading `v`/`V`, leaving any prerelease/build suffix
+     * intact for version_compare() to arbitrate.
+     *
+     * @param string $newVersion       Offered version from the transient.
+     * @param string $installedVersion Currently-installed version.
+     * @return bool
+     */
+    private function isPhantomUpdate(string $newVersion, string $installedVersion): bool
+    {
+        if ($newVersion === '' || $installedVersion === '' || $installedVersion === 'unknown') {
+            return false;
+        }
+        $normNew       = $this->normalizeVersionForCompare($newVersion);
+        $normInstalled = $this->normalizeVersionForCompare($installedVersion);
+        return version_compare($normNew, $normInstalled, '<=');
+    }
+
+    /**
+     * Lightly normalize a version string for the phantom-update comparison:
+     * trims whitespace and strips a single leading `v`/`V`. See
+     * MetadataCommand::normalizeVersionForCompare() for the full rationale
+     * (deliberately does NOT strip prerelease/build suffixes).
+     *
+     * @param string $version Raw version string.
+     * @return string
+     */
+    private function normalizeVersionForCompare(string $version): string
+    {
+        $trimmed = trim($version);
+        if ($trimmed !== '' && ($trimmed[0] === 'v' || $trimmed[0] === 'V')) {
+            $trimmed = substr($trimmed, 1);
+        }
+        return $trimmed;
     }
 
     /**

--- a/apps/agent/includes/commands/class-metadata-command.php
+++ b/apps/agent/includes/commands/class-metadata-command.php
@@ -317,12 +317,13 @@ final class MetadataCommand implements CommandInterface
             }
             $meta   = is_array($meta) ? $meta : [];
             $update = $updates[$file] ?? null;
+            $installedVersion = isset($meta['Version']) ? (string) $meta['Version'] : 'unknown';
             $out[] = [
                 'slug'             => $file,
                 'name'             => isset($meta['Name']) ? (string) $meta['Name'] : $file,
-                'version'          => isset($meta['Version']) ? (string) $meta['Version'] : 'unknown',
+                'version'          => $installedVersion,
                 'active'           => isset($activeSet[$file]),
-                'available_update' => $this->normalizeAvailableUpdate($update),
+                'available_update' => $this->normalizeAvailableUpdate($update, $installedVersion),
                 // ADR-037 Sprint 1, 1C — sparse-metadata expansion. Optional
                 // fields surfaced from get_plugins(); empty string when the
                 // plugin header omits them. CP tolerantly decodes.
@@ -366,12 +367,13 @@ final class MetadataCommand implements CommandInterface
             }
             $slug   = (string) $stylesheet;
             $update = $updates[$slug] ?? null;
+            $installedVersion = (string) $theme->get('Version');
             $out[]  = [
                 'slug'             => $slug,
                 'name'             => (string) $theme->get('Name'),
-                'version'          => (string) $theme->get('Version'),
+                'version'          => $installedVersion,
                 'active'           => $slug === $activeStylesheet,
-                'available_update' => $this->normalizeAvailableUpdate($update),
+                'available_update' => $this->normalizeAvailableUpdate($update, $installedVersion),
             ];
         }
 
@@ -436,12 +438,29 @@ final class MetadataCommand implements CommandInterface
 
     /**
      * Normalize a per-item update entry (object OR array) into the contract
-     * shape, or null when no entry is present / lacks a usable `new_version`.
+     * shape, or null when no entry is present / lacks a usable `new_version`,
+     * OR when the offered `new_version` is not strictly newer than what is
+     * already installed (GH #211 — WordPress's own update transients can
+     * carry a stale/duplicate response entry whose `new_version` equals or
+     * trails the installed version; surfacing that as an "available update"
+     * is a phantom the operator cannot act on).
      *
-     * @param object|array<string,mixed>|null $entry The transient entry, if any.
+     * Both sides are lightly normalized before comparison (trimmed, a single
+     * leading `v`/`V` stripped) so a header like `v1.5.1` compares equal to a
+     * transient `1.5.1`. No further normalization is applied — a prerelease
+     * or build suffix (`1.5.1-beta`) is left intact for version_compare() to
+     * arbitrate, so a genuinely newer prerelease still surfaces.
+     *
+     * An installed version that is empty or the `'unknown'` sentinel (see
+     * plugins()) cannot be compared, so the guard fails OPEN in that case and
+     * keeps the entry — over-reporting is preferable to hiding a real update
+     * because the installed version was unreadable.
+     *
+     * @param object|array<string,mixed>|null $entry            The transient entry, if any.
+     * @param string                          $installedVersion The currently-installed version, for the phantom-update guard.
      * @return array{new_version:string,package:?string,tested:?string,requires_php:?string}|null
      */
-    private function normalizeAvailableUpdate(object|array|null $entry): ?array
+    private function normalizeAvailableUpdate(object|array|null $entry, string $installedVersion): ?array
     {
         if ($entry === null) {
             return null;
@@ -462,6 +481,14 @@ final class MetadataCommand implements CommandInterface
             return null;
         }
 
+        if ($installedVersion !== '' && $installedVersion !== 'unknown') {
+            $normNew       = $this->normalizeVersionForCompare($newVersion);
+            $normInstalled = $this->normalizeVersionForCompare($installedVersion);
+            if (version_compare($normNew, $normInstalled, '<=')) {
+                return null;
+            }
+        }
+
         $package     = $get('package');
         $tested      = $get('tested');
         $requiresPhp = $get('requires_php');
@@ -472,6 +499,25 @@ final class MetadataCommand implements CommandInterface
             'tested'       => is_scalar($tested)      && (string) $tested      !== '' ? (string) $tested      : null,
             'requires_php' => is_scalar($requiresPhp) && (string) $requiresPhp !== '' ? (string) $requiresPhp : null,
         ];
+    }
+
+    /**
+     * Lightly normalize a version string for the phantom-update comparison:
+     * trims whitespace and strips a single leading `v`/`V` (e.g. `v1.5.1` ->
+     * `1.5.1`). Deliberately does NOT strip prerelease/build suffixes — those
+     * must remain visible to version_compare() so a real prerelease bump
+     * still surfaces as an update.
+     *
+     * @param string $version Raw version string.
+     * @return string Normalized version string.
+     */
+    private function normalizeVersionForCompare(string $version): string
+    {
+        $trimmed = trim($version);
+        if ($trimmed !== '' && ($trimmed[0] === 'v' || $trimmed[0] === 'V')) {
+            $trimmed = substr($trimmed, 1);
+        }
+        return $trimmed;
     }
 
     /**
@@ -527,6 +573,21 @@ final class MetadataCommand implements CommandInterface
             if ($newVersion === '') {
                 continue;
             }
+
+            // GH #211 sibling guard: only surface a core update when the
+            // offered version is strictly newer than what's installed —
+            // mirrors normalizeAvailableUpdate()'s phantom-suppression so a
+            // stale/duplicate 'upgrade' response entry does not report a
+            // same-version "update". Fails OPEN (keeps the entry) when
+            // $current is empty/unreadable.
+            if ($current !== '' && $current !== 'unknown') {
+                $normNew     = $this->normalizeVersionForCompare($newVersion);
+                $normCurrent = $this->normalizeVersionForCompare($current);
+                if (version_compare($normNew, $normCurrent, '<=')) {
+                    continue;
+                }
+            }
+
             return [
                 'new_version'     => $newVersion,
                 'current_version' => $current,

--- a/apps/agent/includes/commands/class-rollback-command.php
+++ b/apps/agent/includes/commands/class-rollback-command.php
@@ -116,6 +116,21 @@ final class RollbackCommand implements CommandInterface
                 ];
             }
 
+            // Completeness sweep (GH #211/#212 cluster) — a successful
+            // restore just put an OLDER version back on disk, but WordPress's
+            // own `update_plugins`/`update_themes` transient still remembers
+            // whatever it last saw as current, so the rolled-back-FROM
+            // version stays cached as "available" and re-offers itself
+            // (feeding the #211 phantom-update display, or a re-apply loop
+            // if the operator/CP acts on it). Invalidate NOW, synchronously,
+            // BEFORE this response reaches the CP and before any subsequent
+            // metadata pull re-reads the transient — the next check (cron or
+            // on-demand refresh) then re-polls wp.org against the version
+            // actually on disk.
+            if (function_exists('delete_site_transient')) {
+                delete_site_transient($type === 'plugin' ? 'update_plugins' : 'update_themes');
+            }
+
             // S4 (issue #131 adversarial review) — defensive cleanup: the CP
             // may call RollbackCommand directly against a snapshot whose
             // original `update` request was hard-killed severely enough that
@@ -178,6 +193,16 @@ final class RollbackCommand implements CommandInterface
                 'restored_version' => '',
                 'log'              => $result['log'],
             ];
+        }
+
+        // Completeness sweep (GH #211/#212 cluster) — same rationale as the
+        // plugin/theme path above: a successful core downgrade just put an
+        // older core on disk, but the `update_core` transient still
+        // remembers the pre-rollback "current" version, so it would keep
+        // offering the rolled-back-FROM version as an "update". Invalidate
+        // synchronously, before the CP's next metadata pull re-reads it.
+        if (function_exists('delete_site_transient')) {
+            delete_site_transient('update_core');
         }
 
         if ($snapshotId !== '') {

--- a/apps/agent/includes/commands/class-update-command.php
+++ b/apps/agent/includes/commands/class-update-command.php
@@ -150,6 +150,7 @@ use WPMgr\Agent\Support\SnapshotManager;
 use WPMgr\Agent\Support\UpdateGuard;
 use WPMgr\Agent\Support\UpdateInFlight;
 use WPMgr\Agent\Support\UpdateRunner;
+use WPMgr\Agent\Support\UpdateWatchdogMarker;
 
 /**
  * Performs core/plugin/theme updates with optional pre-update snapshots.
@@ -545,6 +546,18 @@ final class UpdateCommand implements CommandInterface
 
                     $status = $toVersion !== $fromVersion ? 'succeeded' : 'up_to_date';
 
+                    // GitHub issue #210 — arm the update-watchdog mu-plugin's
+                    // marker ONLY for a genuinely applied, verified-good
+                    // plugin/theme change: never `up_to_date` (nothing
+                    // changed, nothing to guard against), never `core` (no
+                    // directory-level snapshot exists for core — see this
+                    // class's own D3). Best-effort and isolated in its own
+                    // method so a resolution failure can never affect this
+                    // response — see UpdateWatchdogMarker::arm()'s own doc.
+                    if ($type !== 'core' && $status === 'succeeded' && $snapshotId !== '') {
+                        $this->armUpdateWatchdog($type, $slug, $snapshotId, $toVersion);
+                    }
+
                     return $this->result($type, $slug, $fromVersion, $toVersion, $status, $snapshotId, $log);
                 }
 
@@ -618,6 +631,45 @@ final class UpdateCommand implements CommandInterface
             // Never leak internals; keep the per-item failure contained.
             return $this->result($type, $slug, '', '', 'failed', $snapshotId, 'Update error.');
         }
+    }
+
+    /**
+     * GitHub issue #210 — resolve this apply's absolute live/payload paths
+     * via SnapshotManager (the single source of truth for that path
+     * resolution; see resolvedRestorePaths()'s own doc) and, only when both
+     * resolve, persist the update-watchdog marker. Isolated into its own
+     * method — rather than inlined at the call site — precisely so that any
+     * failure here can never bubble into, or otherwise affect, the
+     * already-decided `succeeded` response for the item that triggered it.
+     *
+     * @param string $type       'plugin'|'theme'.
+     * @param string $slug       Sanitized slug.
+     * @param string $snapshotId Snapshot identifier captured for this apply.
+     * @param string $toVersion  The version this apply moved the item to —
+     *                            recorded on the marker so MEDIUM-1b's
+     *                            healthy-boot disarm (see
+     *                            UpdateWatchdogMarker::disarmHealthy()) can
+     *                            confirm the on-disk version still matches
+     *                            before clearing the marker early.
+     * @return void
+     */
+    private function armUpdateWatchdog(string $type, string $slug, string $snapshotId, string $toVersion): void
+    {
+        try {
+            $paths = $this->snapshots->resolvedRestorePaths($type, $slug, $snapshotId);
+        } catch (\Throwable $e) {
+            DebugLog::write(
+                'WPMgr Agent: update-watchdog path resolution threw for ' . $type . ':' . $slug
+                . ': ' . $e->getMessage()
+            );
+            return;
+        }
+
+        if ($paths['live'] === '' || $paths['payload'] === '') {
+            return;
+        }
+
+        UpdateWatchdogMarker::arm($type, $slug, $snapshotId, $paths['live'], $paths['payload'], $toVersion);
     }
 
     /**

--- a/apps/agent/includes/support/class-mu-plugin-installer.php
+++ b/apps/agent/includes/support/class-mu-plugin-installer.php
@@ -51,11 +51,20 @@ final class MuPluginInstaller
     /** Source basename within the plugin's `mu-plugin-loader/` directory (WAF gate). */
     public const WAF_SOURCE_BASENAME = 'a-wpmgr-waf.php';
 
+    /** Destination basename within wp-content/mu-plugins/ for the update watchdog (GH #210). */
+    public const WATCHDOG_DEST_BASENAME = 'a-wpmgr-update-watchdog.php';
+
+    /** Source basename within the plugin's `mu-plugin-loader/` directory (update watchdog). */
+    public const WATCHDOG_SOURCE_BASENAME = 'a-wpmgr-update-watchdog.php';
+
     /** wp-options flag set when error-trap install has been verified at least once. */
     public const OPTION_INSTALLED = 'wpmgr_agent_mu_installed_at';
 
     /** wp-options flag set when WAF install has been verified at least once. */
     public const OPTION_WAF_INSTALLED = 'wpmgr_agent_mu_waf_installed_at';
+
+    /** wp-options flag set when update-watchdog install has been verified at least once. */
+    public const OPTION_WATCHDOG_INSTALLED = 'wpmgr_agent_mu_watchdog_installed_at';
 
     private string $pluginDir;
 
@@ -212,6 +221,99 @@ final class MuPluginInstaller
             return;
         }
         update_option(self::OPTION_WAF_INSTALLED, time(), false);
+    }
+
+    /**
+     * Ensure the update-watchdog mu-plugin file (GitHub issue #210) is
+     * present and up-to-date. Mirrors install()/installWaf() exactly.
+     *
+     * Idempotent: same source content + same destination content = no-op.
+     *
+     * @return bool True when the update-watchdog mu-plugin is in place;
+     *              false when install was attempted but failed (e.g.
+     *              mu-plugins/ not writable).
+     */
+    public function installUpdateWatchdog(): bool
+    {
+        $source = $this->pluginDir . '/mu-plugin-loader/' . self::WATCHDOG_SOURCE_BASENAME;
+        if (!file_exists($source) || !is_readable($source)) {
+            return false;
+        }
+
+        $muDir = defined('WPMU_PLUGIN_DIR') ? (string) constant('WPMU_PLUGIN_DIR') : (defined('WP_CONTENT_DIR') ? constant('WP_CONTENT_DIR') . '/mu-plugins' : '');
+        if ($muDir === '') {
+            return false;
+        }
+
+        if (!is_dir($muDir)) {
+            if (!wp_mkdir_p($muDir) && !is_dir($muDir)) {
+                return false;
+            }
+        }
+
+        $dest = rtrim($muDir, '/\\') . '/' . self::WATCHDOG_DEST_BASENAME;
+
+        // Content-fingerprint short-circuit: if the destination matches the
+        // source byte-for-byte, do nothing.
+        if (file_exists($dest) && @sha1_file($dest) === @sha1_file($source)) {
+            $this->markWatchdogInstalled();
+            return true;
+        }
+
+        $bytes = @file_get_contents($source);
+        if ($bytes === false) {
+            return false;
+        }
+        $written = @file_put_contents($dest, $bytes); // phpcs:ignore WordPress.Security.PluginDirectoryWrite.PluginDirectoryWrite,PluginCheck.CodeAnalysis.WriteFile.PluginDirectoryWrite -- writes to wp-content/mu-plugins, a persistent install target outside the plugin folder
+        if ($written === false) {
+            return false;
+        }
+        $this->markWatchdogInstalled();
+        return true;
+    }
+
+    /**
+     * Remove the update-watchdog mu-plugin file. Called on plugin
+     * deactivation, and on opt-out (never enrolled / no longer enrolled).
+     *
+     * @return bool
+     */
+    public function uninstallUpdateWatchdog(): bool
+    {
+        $muDir = defined('WPMU_PLUGIN_DIR') ? (string) constant('WPMU_PLUGIN_DIR') : '';
+        if ($muDir === '') {
+            return false;
+        }
+        $dest = rtrim($muDir, '/\\') . '/' . self::WATCHDOG_DEST_BASENAME;
+        if (!file_exists($dest)) {
+            return true;
+        }
+        if (function_exists('delete_option')) {
+            delete_option(self::OPTION_WATCHDOG_INSTALLED);
+        }
+        wp_delete_file($dest);
+        return !file_exists($dest);
+    }
+
+    /**
+     * Report whether the update-watchdog mu-plugin is currently present.
+     */
+    public function isUpdateWatchdogInstalled(): bool
+    {
+        $muDir = defined('WPMU_PLUGIN_DIR') ? (string) constant('WPMU_PLUGIN_DIR') : '';
+        if ($muDir === '') {
+            return false;
+        }
+        $dest = rtrim($muDir, '/\\') . '/' . self::WATCHDOG_DEST_BASENAME;
+        return file_exists($dest);
+    }
+
+    private function markWatchdogInstalled(): void
+    {
+        if (!function_exists('update_option')) {
+            return;
+        }
+        update_option(self::OPTION_WATCHDOG_INSTALLED, time(), false);
     }
 
     /**

--- a/apps/agent/includes/support/class-snapshot-manager.php
+++ b/apps/agent/includes/support/class-snapshot-manager.php
@@ -354,6 +354,61 @@ class SnapshotManager
     }
 
     /**
+     * GitHub issue #210 — resolve the ABSOLUTE, already-validated live
+     * directory and snapshot payload directory for a captured snapshot, for
+     * callers that need those two paths as plain strings without duplicating
+     * this class's containment logic.
+     *
+     * The sole caller today is UpdateCommand's update-watchdog ARM step: on a
+     * successful apply it persists these two absolute paths into a small
+     * marker file consumed by the autoloader-free mu-plugin
+     * `mu-plugin-loader/a-wpmgr-update-watchdog.php`, which restores this
+     * exact snapshot from a `register_shutdown_function()` callback if a
+     * LATER, unrelated request fatals during another plugin's bootstrap
+     * (before `rest_api_init` — and therefore RollbackCommand's REST route —
+     * would ever fire). This method is the single source of truth both that
+     * ARM step and any other same-process caller should use to resolve those
+     * paths; the mu-plugin itself cannot call it (no autoloader at the point
+     * it runs) and independently re-derives + re-validates the same paths in
+     * plain procedural PHP — see that file's own doc for why the paths are
+     * still re-validated there rather than simply trusted from the marker.
+     *
+     * @param string $type       plugin|theme.
+     * @param string $slug       Sanitized slug.
+     * @param string $snapshotId Snapshot identifier captured for this apply.
+     * @return array{live:string,payload:string} Both '' when either side
+     *     cannot be safely resolved right now — callers MUST treat that as
+     *     "do not arm the watchdog for this item", never as a fatal
+     *     condition; the update itself already succeeded.
+     */
+    public function resolvedRestorePaths(string $type, string $slug, string $snapshotId): array
+    {
+        $empty = ['live' => '', 'payload' => ''];
+
+        $base = $this->snapshotBaseDir();
+        if ($base === '') {
+            return $empty;
+        }
+
+        $snapshotDir = $this->resolveSnapshotDir($base, $snapshotId);
+        if ($snapshotDir === '') {
+            return $empty;
+        }
+
+        $payload = $snapshotDir . '/payload';
+        if (!is_dir($payload)) {
+            return $empty;
+        }
+
+        $live = $this->liveDir($type, $slug);
+        if ($live === '') {
+            return $empty;
+        }
+
+        return ['live' => $live, 'payload' => $payload];
+    }
+
+    /**
      * Remove a snapshot directory and its contents.
      *
      * @param string $snapshotId Snapshot identifier.
@@ -565,6 +620,17 @@ class SnapshotManager
      * on the SAME backstop TTL as the snapshot store itself, so both
      * classes of #131 orphan are reclaimed on one cadence.
      *
+     * MEDIUM-2 (GitHub issue #210 security review) — ALSO matches
+     * `<slug>.wpmgr-watchdog-old-<snap_id>`, the aside name
+     * `wpmgr_watchdog_swap_directories()` (the update-watchdog mu-plugin's
+     * own rename-based swap, mirroring this class's restore()) leaves
+     * behind on an interrupted watchdog restore. Before this fix, the
+     * regex here only matched the ORIGINAL `.wpmgr-old-` prefix, so a
+     * watchdog-interrupted aside was never reclaimed by this backstop —
+     * `strandedAsideRoots()` below already covers the right ROOTS (the same
+     * WP_PLUGIN_DIR / theme root the watchdog's own aside is a sibling
+     * under), only the pattern itself needed widening.
+     *
      * @return void
      */
     private function sweepStrandedAsides(): void
@@ -582,7 +648,7 @@ class SnapshotManager
                 if ($item === '.' || $item === '..') {
                     continue;
                 }
-                if (preg_match('#\.wpmgr-old-snap_[A-Za-z0-9_]+$#', $item) !== 1) {
+                if (preg_match('#\.wpmgr-(?:watchdog-)?old-snap_[A-Za-z0-9_]+$#', $item) !== 1) {
                     continue;
                 }
                 $path = $root . '/' . $item;

--- a/apps/agent/includes/support/class-update-runner.php
+++ b/apps/agent/includes/support/class-update-runner.php
@@ -1428,6 +1428,15 @@ class UpdateRunner
      * Called at most once per availableVersion() resolution — never in a
      * loop — matching the apply path's own single forced check per run.
      *
+     * GH #212 residual gap: wp_update_plugins() alone stays throttled by
+     * WordPress core's own ~12h `update_plugins` transient window — off-cron
+     * (i.e. any caller reaching this method outside the 30-min metadata cron,
+     * which already force-refreshed via Scheduler::refreshUpdateTransients())
+     * a "forced" check here could still read a stale cached response. Delete
+     * the transient FIRST so wp_update_plugins() always performs a real
+     * re-check, matching applyViaUpgrader()'s equivalent forced pre-apply
+     * check and coreUpdateVersion()'s `wp_version_check([], true)` below.
+     *
      * @param string $slug Plugin basename.
      * @return string|null The pending version, '' when a forced fresh check
      *                confirms none is available, or null when availability
@@ -1439,6 +1448,9 @@ class UpdateRunner
      */
     private function pluginUpdateVersion(string $slug): ?string
     {
+        if (function_exists('delete_site_transient')) {
+            delete_site_transient('update_plugins');
+        }
         if (function_exists('wp_update_plugins')) {
             wp_update_plugins();
         }
@@ -1465,6 +1477,10 @@ class UpdateRunner
      * the transient (GitHub issue #208) — same rationale and shape as
      * pluginUpdateVersion(); see its doc.
      *
+     * GH #212 residual gap: see pluginUpdateVersion()'s doc — the same
+     * off-cron core-throttle gap applies here, so the transient is deleted
+     * before wp_update_themes() forces a real re-check.
+     *
      * @param string $slug Theme stylesheet.
      * @return string|null The pending version, '' when a forced fresh check
      *                confirms none is available, or null when availability
@@ -1476,6 +1492,9 @@ class UpdateRunner
      */
     private function themeUpdateVersion(string $slug): ?string
     {
+        if (function_exists('delete_site_transient')) {
+            delete_site_transient('update_themes');
+        }
         if (function_exists('wp_update_themes')) {
             wp_update_themes();
         }

--- a/apps/agent/includes/support/class-update-watchdog-marker.php
+++ b/apps/agent/includes/support/class-update-watchdog-marker.php
@@ -1,0 +1,576 @@
+<?php
+/**
+ * UpdateWatchdogMarker: writes/refreshes the small "watch marker" file that
+ * the autoloader-free mu-plugin `mu-plugin-loader/a-wpmgr-update-watchdog.php`
+ * reads during a fatal-triggered `register_shutdown_function()` callback
+ * (GitHub issue #210). See the extended class doc below the direct-access
+ * guard for the full design rationale.
+ *
+ * @package WPMgr\Agent\Support
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Support;
+
+if (!defined('ABSPATH')) {
+    exit; // No direct access.
+}
+
+/*
+ * Background: when a plugin/theme update applies cleanly but then fatals on
+ * EVERY WordPress bootstrap (e.g. `Class ... not found` in the updated
+ * plugin's own loader), the site is down site-wide, and WPMgr's normal
+ * recovery path — a signed REST call to RollbackCommand — can never be
+ * reached, because `rest_api_init` fires AFTER all regular plugins have
+ * already finished loading; the fatal happens before that point is ever
+ * reached. `SnapshotManager::restore()` is a pure filesystem operation that
+ * needs no plugin bootstrap at all, so a `register_shutdown_function()`
+ * registered by an mu-plugin (which loads BEFORE any regular plugin) can
+ * still invoke an equivalent restore even when the agent plugin itself never
+ * finished loading on this request.
+ *
+ * This class is the ARM side of that mechanism, called from
+ * `UpdateCommand::processItem()` immediately after a plugin/theme apply is
+ * verified `succeeded` (never for `failed`/`skipped`/`up_to_date`, and never
+ * for `core` — there is no directory-level snapshot for core; see
+ * SnapshotManager's own class doc, D3). It persists a short-TTL, one-shot
+ * marker as a FILE (not a wp-option) in the agent's own state directory —
+ * see STORAGE LOCATION below for why — containing everything the mu-plugin
+ * needs, with ABSOLUTE paths resolved and validated up front via
+ * `SnapshotManager::resolvedRestorePaths()`: the mu-plugin never recomputes
+ * WordPress-dependent paths from scratch and never trusts the marker's path
+ * strings alone (see the mu-plugin's own doc for the independent
+ * re-validation it still performs before ever touching disk).
+ *
+ * STORAGE LOCATION — deliberately WP_CONTENT_DIR-based, NOT the uploads-first
+ * `StoragePaths::dataBase()` convention every other agent user-data store
+ * uses. The mu-plugin's per-request "does a marker exist at all" check MUST
+ * be a single, side-effect-free filesystem stat that runs on EVERY request
+ * (see that file's doc) — `wp_upload_dir()` is unsafe for that hot path: its
+ * default `$create_dir = true` argument can trigger an `apply_filters()` call
+ * and a `wp_mkdir_p()` write on every invocation, and it depends on options
+ * that may not yet be warm this early in bootstrap. `WP_CONTENT_DIR` is a
+ * plain PHP constant, defined before mu-plugins load, with zero I/O to read.
+ * Using it for BOTH the write (here) and the read (the mu-plugin) guarantees
+ * the two sides always agree on the marker's path, independent of any
+ * uploads relocation (`UPLOADS` constant / `upload_path` option) a site may
+ * have configured.
+ *
+ * MULTI-ITEM BATCHES — `UpdateCommand::execute()` can apply several
+ * plugin/theme items in one request. The marker file holds a small JSON
+ * ARRAY of per-slug entries (keyed by exact type+slug), not a single
+ * overwritten record, so a later item in the same batch succeeding never
+ * erases an earlier item's watch — each slug's entry is independently
+ * refreshed/replaced, and the mu-plugin's cheap per-request check still
+ * costs exactly one `is_file()` stat regardless of how many entries the file
+ * holds once it exists.
+ *
+ * EARLY DISARM (MEDIUM-1b, GitHub issue #210 security review) — TTL_SECONDS
+ * alone left a genuinely GOOD update revert-eligible for the full 5-minute
+ * window. `disarmHealthy()` clears an armed entry as soon as a normal,
+ * un-fataled agent boot proves the exact slug it is watching is installed,
+ * active, and on-disk at the armed `to_version` — see that method's own doc
+ * for the full reasoning and the fail-closed guarantee on every uncertain
+ * case.
+ */
+
+/**
+ * Persists the update-watchdog marker consumed by the mu-plugin shutdown hook.
+ */
+final class UpdateWatchdogMarker
+{
+    /**
+     * StoragePaths purpose slug — resolves (via legacyBase(), the
+     * WP_CONTENT_DIR-based resolver, NOT the uploads-first dataBase()) to
+     * `wp-content/wpmgr-update-watchdog/`. See class doc, STORAGE LOCATION.
+     */
+    private const PURPOSE = 'update-watchdog';
+
+    /**
+     * Deterministic marker filename. The mu-plugin's cheap per-request check
+     * stats EXACTLY this path (mirrored verbatim in
+     * `a-wpmgr-update-watchdog.php`'s own `wpmgr_watchdog_marker_path()`) —
+     * keep both in sync if this ever changes.
+     */
+    public const MARKER_BASENAME = 'watchdog-marker.json';
+
+    /**
+     * Prefix for the one-shot "claim" sentinel files the mu-plugin creates
+     * (via an atomic `fopen($file, 'x')`) the instant it commits to restoring
+     * one specific snapshot, so a second, concurrently-fataling request can
+     * never restore the same snapshot twice. Exposed here only so this
+     * class's opportunistic GC (pruneStaleClaims()) recognizes its own
+     * sentinels; the mu-plugin is the only writer.
+     */
+    private const CLAIM_PREFIX = 'watchdog-claim-';
+
+    /**
+     * A claim sentinel older than this is considered abandoned bookkeeping
+     * (its owning restore attempt — success or failure — finished long ago)
+     * and is swept opportunistically on the next arm() call. Generously
+     * longer than TTL_SECONDS so it can never race a genuinely in-progress
+     * watch window; purely a disk-hygiene backstop, not a safety control.
+     */
+    private const CLAIM_STALE_AFTER_SECONDS = 3600;
+
+    /**
+     * Watch-window TTL. MUST stay strictly less than
+     * `SnapshotManager::MIN_KEEP_AGE_SECONDS` (600s, see that constant's own
+     * class-level doc) so a marker can never legitimately outlive the
+     * retention floor protecting the exact snapshot payload it points at —
+     * if the marker ever DID outlive it, the mu-plugin's independent
+     * re-derivation of the payload path (which requires the payload
+     * directory to still exist on disk) would simply fail closed instead,
+     * but keeping the TTL strictly shorter means that never needs to be
+     * relied on. 300s (5 minutes) comfortably overlaps the control plane's
+     * ~1-minute post-update health-probe window (including its retry — see
+     * UpdateCommand's own class doc) while remaining far short of the 600s
+     * floor.
+     */
+    public const TTL_SECONDS = 300;
+
+    /**
+     * Arm (or refresh) the watch-marker entry for one successfully applied
+     * plugin/theme item. Best-effort and silent on any failure: this is
+     * defense-in-depth for a recovery path that does not exist today (GitHub
+     * issue #210); a failure to persist it must never affect the apply that
+     * already succeeded, nor the response returned to the control plane.
+     *
+     * Refuses to arm (silently, not an error) when:
+     *   - any argument is empty, or $type is not exactly 'plugin'/'theme';
+     *   - $liveDir resolves to the running agent's OWN plugin directory —
+     *     mirrors `FilesRestorer::PRESERVE_FROM_LIVE`'s protection of
+     *     `plugins/wpmgr-agent`: a directory-replacement recovery mechanism
+     *     must never be armed against the very code that could someday run
+     *     it.
+     *
+     * @param string $type       'plugin'|'theme'.
+     * @param string $slug       Sanitized slug (already validated by
+     *                            UpdateCommand::sanitizeSlug() upstream).
+     * @param string $snapshotId Snapshot identifier captured for this apply.
+     * @param string $liveDir    ABSOLUTE live target directory, already
+     *                            resolved + validated by
+     *                            SnapshotManager::resolvedRestorePaths().
+     * @param string $payloadDir ABSOLUTE snapshot payload directory (same).
+     * @param string $toVersion  The version this apply moved the item to.
+     *                            Recorded so MEDIUM-1b's disarmHealthy() can
+     *                            confirm the on-disk version still matches
+     *                            before clearing this entry early (see that
+     *                            method's own doc). An empty string is
+     *                            stored as-is when the caller could not
+     *                            determine it — disarmHealthy() then simply
+     *                            never disarms that entry early, falling
+     *                            back to the existing TTL.
+     * @return void
+     */
+    public static function arm(string $type, string $slug, string $snapshotId, string $liveDir, string $payloadDir, string $toVersion = ''): void
+    {
+        if ($type !== 'plugin' && $type !== 'theme') {
+            return;
+        }
+        if ($slug === '' || $snapshotId === '' || $liveDir === '' || $payloadDir === '') {
+            return;
+        }
+
+        $liveDir    = rtrim($liveDir, '/\\');
+        $payloadDir = rtrim($payloadDir, '/\\');
+
+        if (defined('WPMGR_AGENT_DIR')) {
+            $selfDir = rtrim((string) constant('WPMGR_AGENT_DIR'), '/\\');
+            if ($selfDir !== '' && $liveDir === $selfDir) {
+                return;
+            }
+        }
+
+        try {
+            $dir = StoragePaths::ensureHardenedPath(self::stateDir());
+            if ($dir === '') {
+                return;
+            }
+
+            $file = $dir . '/' . self::MARKER_BASENAME;
+            $now  = time();
+
+            $kept = [];
+            foreach (self::readMarkers($file) as $entry) {
+                if (!is_array($entry)) {
+                    continue;
+                }
+                $entryType = isset($entry['type']) && is_string($entry['type']) ? $entry['type'] : '';
+                $entrySlug = isset($entry['slug']) && is_string($entry['slug']) ? $entry['slug'] : '';
+                $expiresAt = isset($entry['expires_at']) && is_numeric($entry['expires_at']) ? (int) $entry['expires_at'] : 0;
+
+                if ($entryType === $type && $entrySlug === $slug) {
+                    // Superseded by the fresh entry below — "a new apply
+                    // overwrites/refreshes" (this exact slug's own watch).
+                    continue;
+                }
+                if ($expiresAt <= $now) {
+                    // Opportunistic prune of an already-expired sibling entry
+                    // so the file never grows across a long-lived site's
+                    // update history.
+                    continue;
+                }
+                $kept[] = $entry;
+            }
+
+            $kept[] = [
+                'type'        => $type,
+                'slug'        => $slug,
+                'snapshot_id' => $snapshotId,
+                'live_dir'    => $liveDir,
+                'payload_dir' => $payloadDir,
+                'to_version'  => $toVersion,
+                'applied_at'  => $now,
+                'expires_at'  => $now + self::TTL_SECONDS,
+            ];
+
+            self::writeMarkers($file, $kept);
+            self::pruneStaleClaims($dir, $now);
+        } catch (\Throwable $e) {
+            DebugLog::write(
+                'WPMgr Agent: update-watchdog arm() failed for ' . $type . ':' . $slug . ': ' . $e->getMessage()
+            );
+        }
+    }
+
+    /**
+     * MEDIUM-1b (GitHub issue #210 security review) — clear the marker entry
+     * for exactly one type/slug pair. Low-level primitive: mirrors
+     * `UpdateInFlight::clear()`'s per-slug removal shape. Used both by
+     * disarmHealthy() below and available standalone for any future caller
+     * that needs to remove a single slug's watch without touching sibling
+     * entries. Safe to call unconditionally, including when no marker file
+     * exists or no entry matches — both are silent no-ops.
+     *
+     * @param string $type 'plugin'|'theme'.
+     * @param string $slug Sanitized slug.
+     * @return void
+     */
+    public static function clearSlug(string $type, string $slug): void
+    {
+        if ($type === '' || $slug === '') {
+            return;
+        }
+
+        try {
+            $file = self::markerFile();
+            if ($file === '' || !is_file($file)) {
+                return;
+            }
+
+            $markers = self::readMarkers($file);
+            if ($markers === []) {
+                return;
+            }
+
+            $kept    = [];
+            $changed = false;
+            foreach ($markers as $entry) {
+                if (!is_array($entry)) {
+                    continue;
+                }
+                $entryType = isset($entry['type']) && is_string($entry['type']) ? $entry['type'] : '';
+                $entrySlug = isset($entry['slug']) && is_string($entry['slug']) ? $entry['slug'] : '';
+
+                if ($entryType === $type && $entrySlug === $slug) {
+                    $changed = true;
+                    continue;
+                }
+                $kept[] = $entry;
+            }
+
+            if (!$changed) {
+                return;
+            }
+
+            if ($kept === []) {
+                // Delete rather than write an empty {"markers":[]} file —
+                // keeps the mu-plugin's cheap per-request is_file() check
+                // returning false again immediately, rather than finding an
+                // empty-but-present file and registering a shutdown handler
+                // that would just no-op every time.
+                wp_delete_file($file);
+
+                return;
+            }
+
+            self::writeMarkers($file, $kept);
+        } catch (\Throwable $e) {
+            DebugLog::write(
+                'WPMgr Agent: update-watchdog clearSlug() failed for ' . $type . ':' . $slug . ': ' . $e->getMessage()
+            );
+        }
+    }
+
+    /**
+     * MEDIUM-1b (GitHub issue #210 security review) — the "principled
+     * disarm": clear the watchdog marker entry for any armed slug that has
+     * just been proven healthy on THIS exact request. Intended to be called
+     * from the agent's own `plugins_loaded` boot hook (see
+     * `WPMgr\Agent\Plugin`) — reaching that hook at all is itself proof the
+     * ENTIRE plugin-loading loop (every active plugin, including the one an
+     * armed entry is watching) completed this request without triggering
+     * the every-request bootstrap fatal GitHub issue #210 exists to catch.
+     * This shrinks the over-fire window from the full TTL_SECONDS down to
+     * exactly that scenario: a fataling boot never reaches this hook, so the
+     * marker correctly survives for the watchdog in that case.
+     *
+     * Gated on the marker file existing (a single is_file() stat, mirroring
+     * the mu-plugin's own cheap per-request check) so the common healthy
+     * hot path — no marker at all — costs nothing beyond that one stat.
+     *
+     * "Healthy" for one entry means ALL of:
+     *   - the recorded to_version is non-empty (a marker armed before this
+     *     fix, or one whose caller could not determine the target version,
+     *     is left alone — nothing to positively confirm against);
+     *   - the plugin/theme is currently installed AND its on-disk Version
+     *     header exactly equals the recorded to_version;
+     *   - the plugin/theme is currently ACTIVE (is_plugin_active()/
+     *     is_plugin_active_for_network() for a plugin; the current
+     *     stylesheet/template for a theme) — an installed-but-inactive item
+     *     proves nothing about whether ITS code loads cleanly, since
+     *     inactive plugin code is never included during the bootstrap loop
+     *     this feature guards.
+     * Every one of these fails CLOSED: any WP detection API being
+     * unavailable, or any single condition not positively confirmed, leaves
+     * the entry armed — the existing TTL_SECONDS window remains the
+     * backstop exactly as it was before this fix. This method never widens
+     * the window a marker survives in, only shrinks it.
+     *
+     * Deliberately does NOT reuse `UpdateRunner::isInstalled()` — that
+     * method fails OPEN (returns true when detection is unavailable) by
+     * design for its own (very different) purpose; a fail-open default here
+     * would be exactly backwards for a check whose only job is deciding
+     * whether it is safe to give up a safety net early.
+     *
+     * @return void
+     */
+    public static function disarmHealthy(): void
+    {
+        try {
+            $file = self::markerFile();
+            if ($file === '' || !is_file($file)) {
+                return;
+            }
+
+            $markers = self::readMarkers($file);
+            if ($markers === []) {
+                return;
+            }
+
+            foreach ($markers as $entry) {
+                if (!is_array($entry)) {
+                    continue;
+                }
+                $type = isset($entry['type']) && is_string($entry['type']) ? $entry['type'] : '';
+                $slug = isset($entry['slug']) && is_string($entry['slug']) ? $entry['slug'] : '';
+                if ($type === '' || $slug === '') {
+                    continue;
+                }
+                if (self::isEntryHealthy($entry)) {
+                    self::clearSlug($type, $slug);
+                }
+            }
+        } catch (\Throwable $e) {
+            DebugLog::write('WPMgr Agent: update-watchdog disarmHealthy() failed: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $entry Decoded marker entry.
+     * @return bool
+     */
+    private static function isEntryHealthy(array $entry): bool
+    {
+        $type      = isset($entry['type']) && is_string($entry['type']) ? $entry['type'] : '';
+        $slug      = isset($entry['slug']) && is_string($entry['slug']) ? $entry['slug'] : '';
+        $toVersion = isset($entry['to_version']) && is_string($entry['to_version']) ? $entry['to_version'] : '';
+
+        if ($slug === '' || $toVersion === '') {
+            return false;
+        }
+
+        if ($type === 'plugin') {
+            return self::isPluginHealthyAt($slug, $toVersion);
+        }
+        if ($type === 'theme') {
+            return self::isThemeHealthyAt($slug, $toVersion);
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $slug      Plugin slug ("folder/main-file.php").
+     * @param string $toVersion Recorded target version.
+     * @return bool
+     */
+    private static function isPluginHealthyAt(string $slug, string $toVersion): bool
+    {
+        // Mirrors UpdateRunner::loadPluginApi()'s own guard exactly.
+        if (!function_exists('get_plugins') && defined('ABSPATH') && file_exists(ABSPATH . 'wp-admin/includes/plugin.php')) {
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+        if (!function_exists('get_plugins') || !function_exists('is_plugin_active')) {
+            return false;
+        }
+
+        $all = get_plugins();
+        if (!is_array($all) || !isset($all[$slug]) || !is_array($all[$slug]) || !isset($all[$slug]['Version'])) {
+            return false;
+        }
+        if ((string) $all[$slug]['Version'] !== $toVersion) {
+            return false;
+        }
+
+        if (\is_plugin_active($slug)) {
+            return true;
+        }
+
+        return function_exists('is_plugin_active_for_network') && \is_plugin_active_for_network($slug);
+    }
+
+    /**
+     * @param string $slug      Theme stylesheet slug.
+     * @param string $toVersion Recorded target version.
+     * @return bool
+     */
+    private static function isThemeHealthyAt(string $slug, string $toVersion): bool
+    {
+        if (!function_exists('wp_get_themes')) {
+            return false;
+        }
+        $themes = wp_get_themes();
+        if (!is_array($themes) || !isset($themes[$slug])) {
+            return false;
+        }
+        $theme = $themes[$slug];
+        if (!is_object($theme) || !method_exists($theme, 'get')) {
+            return false;
+        }
+        if ((string) $theme->get('Version') !== $toVersion) {
+            return false;
+        }
+
+        if (function_exists('get_stylesheet') && get_stylesheet() === $slug) {
+            return true;
+        }
+
+        return function_exists('get_template') && get_template() === $slug;
+    }
+
+    /**
+     * The WP_CONTENT_DIR-based watchdog state directory, unhardened (no
+     * mkdir/guard-file side effects) — safe to call from the cheap
+     * disarmHealthy()/clearSlug() read paths. arm() is the only caller that
+     * needs the hardened (created + guarded) variant.
+     *
+     * @return string
+     */
+    private static function stateDir(): string
+    {
+        return StoragePaths::legacyBase(self::PURPOSE);
+    }
+
+    /**
+     * Absolute marker file path, or '' when the state dir cannot be
+     * resolved. Does not check existence.
+     *
+     * @return string
+     */
+    private static function markerFile(): string
+    {
+        $dir = self::stateDir();
+
+        return $dir === '' ? '' : rtrim($dir, '/\\') . '/' . self::MARKER_BASENAME;
+    }
+
+    /**
+     * Read the current marker file's entries. Returns an empty list when the
+     * file is absent, unreadable, or not shaped as expected — never throws.
+     *
+     * @param string $file Absolute marker file path.
+     * @return list<array<string,mixed>>
+     */
+    private static function readMarkers(string $file): array
+    {
+        if (!is_file($file)) {
+            return [];
+        }
+        $raw = @file_get_contents($file);
+        if (!is_string($raw) || $raw === '') {
+            return [];
+        }
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded) || !isset($decoded['markers']) || !is_array($decoded['markers'])) {
+            return [];
+        }
+
+        return array_values($decoded['markers']);
+    }
+
+    /**
+     * Atomically rewrite the marker file: write to a randomly-named temp file
+     * in the same directory, then `rename()` over the real path. rename() is
+     * atomic on the same filesystem, so a shutdown-handler reader (or a
+     * concurrent arm() call) never observes a half-written JSON file.
+     *
+     * @param string                     $file    Absolute marker file path.
+     * @param list<array<string,mixed>>  $markers Entries to persist.
+     * @return void
+     */
+    private static function writeMarkers(string $file, array $markers): void
+    {
+        $payload = wp_json_encode(['markers' => array_values($markers)]);
+        if (!is_string($payload)) {
+            return;
+        }
+
+        $tmp = $file . '.' . bin2hex(random_bytes(8)) . '.tmp';
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- headless agent; WP_Filesystem never initialized; direct write of a small, server-derived JSON marker to a temp path before an atomic rename
+        $written = @file_put_contents($tmp, $payload, LOCK_EX);
+        if ($written === false) {
+            return;
+        }
+        @chmod($tmp, 0600); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod -- explicit security perms (0600); WP_Filesystem would coerce to wider FS_CHMOD_FILE
+
+        if (!@rename($tmp, $file)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic same-filesystem swap so a concurrent reader never sees a half-written marker; WP_Filesystem::move() is copy+delete (non-atomic)
+            wp_delete_file($tmp);
+        }
+    }
+
+    /**
+     * Sweep claim sentinel files older than CLAIM_STALE_AFTER_SECONDS. Purely
+     * disk hygiene (each sentinel is a 0-byte file) — never affects
+     * correctness, since the mu-plugin's one-shot semantics only ever depend
+     * on a claim file's EXISTENCE at the moment it attempts `fopen($f,'x')`,
+     * never on its age.
+     *
+     * @param string $dir Watchdog state directory.
+     * @param int    $now Current time.
+     * @return void
+     */
+    private static function pruneStaleClaims(string $dir, int $now): void
+    {
+        $items = @scandir($dir);
+        if (!is_array($items)) {
+            return;
+        }
+        foreach ($items as $item) {
+            if (strpos($item, self::CLAIM_PREFIX) !== 0) {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (!is_file($path)) {
+                continue;
+            }
+            $mtime = @filemtime($path);
+            if ($mtime !== false && ($now - $mtime) < self::CLAIM_STALE_AFTER_SECONDS) {
+                continue;
+            }
+            wp_delete_file($path);
+        }
+    }
+}

--- a/apps/agent/mu-plugin-loader/a-wpmgr-update-watchdog.php
+++ b/apps/agent/mu-plugin-loader/a-wpmgr-update-watchdog.php
@@ -1,0 +1,949 @@
+<?php
+/**
+ * Plugin Name: WPMgr Update Watchdog (mu-plugin loader)
+ * Description: Registers a shutdown handler at the very top of the
+ *              WordPress plugin-loading pass that restores a plugin/theme
+ *              from its pre-update snapshot when the update itself applied
+ *              cleanly but the new code fatals on EVERY subsequent
+ *              bootstrap. GitHub issue #210.
+ * Version:     1.0.0
+ * Author:      WPMgr contributors
+ * License:     MIT
+ *
+ * ---------------------------------------------------------------------------
+ * THE PROBLEM (GitHub issue #210)
+ * ---------------------------------------------------------------------------
+ * WPMgr's normal update-recovery path is `RollbackCommand`, a regular signed
+ * REST route registered on `rest_api_init`. That hook fires only AFTER every
+ * regular plugin has finished loading. When an update applies cleanly (files
+ * copied correctly, the version header bumped) but the NEW code itself fatals
+ * on every bootstrap — e.g. `Class ... not found` in the updated plugin's own
+ * loader — the site is down on every single request, including the very
+ * request that would otherwise deliver a rollback command: the fatal happens
+ * before `rest_api_init` is ever reached. The one automated recovery path
+ * shares a single point of failure with the exact condition it exists to
+ * catch.
+ *
+ * ---------------------------------------------------------------------------
+ * THE FIX: a self-contained update-watchdog mu-plugin
+ * ---------------------------------------------------------------------------
+ * An mu-plugin loads BEFORE any regular plugin. A `register_shutdown_function`
+ * registered here still fires when a regular plugin fatals mid-bootstrap,
+ * exactly like `a-wpmgr-error-trap.php`'s shutdown handler already does for
+ * error CAPTURE. This file performs an actual RECOVERY instead:
+ * `WPMgr\Agent\Support\SnapshotManager::restore()` is a pure filesystem
+ * operation (move the live directory aside, copy the snapshot payload back)
+ * that needs no plugin bootstrap at all — the only reason it normally runs
+ * inside the fully-booted plugin is that `RollbackCommand` is the thing that
+ * calls it, not that it depends on anything the plugin bootstrap provides.
+ *
+ * The ARM side lives in `WPMgr\Agent\Commands\UpdateCommand` (fully-booted
+ * PHP, run inside a signed REST request): on a successful plugin/theme apply
+ * it calls `WPMgr\Agent\Support\UpdateWatchdogMarker::arm()`, which persists a
+ * short-TTL, one-shot marker FILE — see that class's doc for the exact
+ * schema, storage location rationale, and TTL reasoning — containing the
+ * ABSOLUTE live directory and ABSOLUTE snapshot payload directory, both
+ * already resolved and validated by `SnapshotManager::resolvedRestorePaths()`
+ * at arm time.
+ *
+ * Even the control plane's OWN post-update health-probe request — which also
+ * fatals, same as any other request — trips this same shutdown handler, so
+ * recovery happens without any CP round-trip, REST call, or cron tick.
+ *
+ * ---------------------------------------------------------------------------
+ * BOOTSTRAP-SAFE, FULLY SELF-CONTAINED (mirrors a-wpmgr-waf.php's posture)
+ * ---------------------------------------------------------------------------
+ * When a regular plugin fatals mid-bootstrap, the WPMgr autoloader is NOT
+ * guaranteed to be registered — the `wpmgr-agent` plugin folder loads
+ * alphabetically at 'w', which is AFTER many third-party plugin folders (e.g.
+ * 'suremembers-core' at 's'). This file therefore:
+ *   - Is pure procedural PHP with ZERO references to any `WPMgr\...` class.
+ *   - Re-derives and re-validates every path itself (see PATH SAFETY below)
+ *     rather than trusting the marker's recorded path strings — the marker
+ *     is used only as a fast identity check against an INDEPENDENTLY
+ *     re-derived expectation, exactly mirroring the containment discipline
+ *     in `SnapshotManager::liveDir()`/`resolveSnapshotDir()`.
+ *   - Wraps every function that can reach a filesystem or WordPress API call
+ *     in try/catch, so the watchdog can NEVER itself cause, or add to, a
+ *     fatal — the one thing worse than not recovering a broken site is
+ *     breaking a healthy one.
+ *
+ * ---------------------------------------------------------------------------
+ * THE HOT PATH: a single stat on every request
+ * ---------------------------------------------------------------------------
+ * This file's top-level code runs on EVERY request to EVERY page, whether or
+ * not an update was ever applied. The common case (no marker present) MUST
+ * cost essentially nothing: exactly one `is_file()` call against a path built
+ * from a plain PHP constant (`WP_CONTENT_DIR`) — no database query, no
+ * `wp_upload_dir()` call (which can itself trigger a directory-creation
+ * write; see `UpdateWatchdogMarker`'s own doc for why the marker deliberately
+ * does NOT live under the uploads-first convention every other agent
+ * user-data store uses), no filter application. Only when a marker actually
+ * exists (a narrow post-update window, see TTL_SECONDS) does any heavier work
+ * — registering the shutdown callback — happen at all; the RESTORE-CAPABLE
+ * work below only ever runs from inside that shutdown callback, and even then
+ * only when `error_get_last()` reports a genuine fatal.
+ *
+ * ---------------------------------------------------------------------------
+ * PATH SAFETY (GitHub issue #147 discipline, mirrored exactly)
+ * ---------------------------------------------------------------------------
+ * The repository has a real restore-anchoring data-loss history: GH #147, an
+ * UNANCHORED `strpos()` substring check silently dropped unrelated plugin
+ * files at restore time. Every path decision in this file uses exact-path /
+ * exact-segment / anchored-prefix / anchored-containment comparisons — never
+ * a bare substring match — and mirrors `SnapshotManager`'s own containment
+ * logic function-for-function (`liveDir()`'s realpath()-based check plus its
+ * documented open_basedir/symlink anchored fallback, `resolveSnapshotDir()`'s
+ * strict realpath containment, `copyDir()`/`deleteDir()`'s symlink-skip
+ * recursion). There is no globbing and no wildcard exclude anywhere below.
+ * The running agent's OWN plugin directory (`WPMGR_AGENT_DIR`) is refused as
+ * a restore target outright — mirrors `FilesRestorer::PRESERVE_FROM_LIVE`'s
+ * protection of `plugins/wpmgr-agent`: a directory-replacement recovery
+ * mechanism must never be pointed at the very code that could run it.
+ *
+ * ---------------------------------------------------------------------------
+ * CONCURRENCY: never race a live apply, never restore the same marker twice
+ * ---------------------------------------------------------------------------
+ *   - Before touching disk, this file attempts the SAME non-blocking
+ *     `flock()` liveness lock `WPMgr\Agent\Support\UpdateInFlight::mark()`
+ *     holds for the duration of a real, in-progress apply of the exact same
+ *     type/slug (same lock file path, independently recomputed from the
+ *     `sha256(type:slug)` key — no class dependency, pure hashing). If that
+ *     lock cannot be acquired, a genuine apply owns this slug right now:
+ *     stand down entirely rather than race it.
+ *   - One-shot: the first shutdown handler to reach a given marker entry
+ *     atomically "claims" it via `fopen($claimFile, 'x')` — exclusive
+ *     create, which only ever succeeds for exactly one concurrent caller.
+ *     Every other simultaneously-fataling request (multiple visitors hitting
+ *     the same down site at once, each in its own PHP-FPM worker) loses that
+ *     race and does nothing. A marker entry is therefore restored AT MOST
+ *     ONCE, no matter how many requests fatal while it is live.
+ *
+ * Installed by:
+ *   `WPMgr\Agent\Support\MuPluginInstaller::installUpdateWatchdog()` — called
+ *   from the agent plugin's boot pass whenever the site is enrolled
+ *   (idempotent: same content -> no-op). On a managed host where
+ *   `mu-plugins/` is not writable, this file is silently absent — the same
+ *   accepted degradation as the error-trap and WAF mu-plugins today; the
+ *   control plane already surfaces a "manual filesystem recovery" message
+ *   for that case.
+ *
+ * @package WPMgr\Agent
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit; // No direct access.
+}
+
+// =============================================================================
+// Cheap per-request short-circuit (see class doc, THE HOT PATH).
+// =============================================================================
+
+/**
+ * Absolute path to the watchdog state directory:
+ * `WP_CONTENT_DIR/wpmgr-update-watchdog`. Deliberately WP_CONTENT_DIR-based,
+ * not uploads-based — see this file's class doc, THE HOT PATH, and
+ * `WPMgr\Agent\Support\UpdateWatchdogMarker`'s own doc, STORAGE LOCATION.
+ *
+ * @return string Absolute path, or '' when WP_CONTENT_DIR is not defined.
+ */
+function wpmgr_watchdog_state_dir(): string
+{
+    if (!defined('WP_CONTENT_DIR')) {
+        return '';
+    }
+    $contentDir = rtrim((string) constant('WP_CONTENT_DIR'), '/\\');
+    if ($contentDir === '') {
+        return '';
+    }
+
+    return $contentDir . '/wpmgr-update-watchdog';
+}
+
+/**
+ * Absolute path to the marker file. Filename MUST match
+ * `WPMgr\Agent\Support\UpdateWatchdogMarker::MARKER_BASENAME` exactly.
+ *
+ * @return string Absolute path, or '' when the state dir cannot be resolved.
+ */
+function wpmgr_watchdog_marker_path(): string
+{
+    $dir = wpmgr_watchdog_state_dir();
+
+    return $dir === '' ? '' : $dir . '/watchdog-marker.json';
+}
+
+// =============================================================================
+// Shutdown handler — the actual recovery logic. Everything below this point
+// only ever runs when the cheap check at the bottom of this file found a
+// marker file AND a genuine fatal actually happened.
+// =============================================================================
+
+/**
+ * Whether $path, once normalized, is exactly $dir or a descendant of it.
+ * Anchored (segment/prefix) comparison, never a bare substring match — see
+ * this file's class doc, PATH SAFETY.
+ *
+ * @param string $path Absolute candidate path (already normalized/resolved).
+ * @param string $dir  Absolute directory to test containment against.
+ * @return bool
+ */
+function wpmgr_watchdog_path_is_within(string $path, string $dir): bool
+{
+    $path = str_replace('\\', '/', $path);
+    $dir  = rtrim(str_replace('\\', '/', $dir), '/');
+    if ($dir === '' || $path === '') {
+        return false;
+    }
+
+    return $path === $dir || strncmp($path, $dir . '/', strlen($dir) + 1) === 0;
+}
+
+/**
+ * String/segment-anchored containment check — mirrors
+ * `WPMgr\Agent\Support\SnapshotManager::anchoredContainment()` line for line.
+ * Used ONLY as the realpath()-unavailable fallback for the LIVE-directory
+ * side (mirroring `liveDir()`'s own documented open_basedir/symlinked-
+ * wp-content fallback); $root here is always WP-native (`WP_PLUGIN_DIR` or
+ * `get_theme_root()`'s return), never attacker-controlled.
+ *
+ * @param string $root Trusted root directory (never attacker-controlled).
+ * @param string $path Candidate path, expected to be "$root/<segment...>".
+ * @return bool
+ */
+function wpmgr_watchdog_anchored_containment(string $root, string $path): bool
+{
+    $root = rtrim($root, '/\\');
+    if ($root === '' || $path === '') {
+        return false;
+    }
+
+    $normalizedRoot = str_replace('\\', '/', $root);
+    $normalizedPath = str_replace('\\', '/', $path);
+
+    if ($normalizedPath !== $normalizedRoot && strncmp($normalizedPath, $normalizedRoot . '/', strlen($normalizedRoot) + 1) !== 0) {
+        return false;
+    }
+
+    $relative = ltrim(substr($normalizedPath, strlen($normalizedRoot)), '/');
+    if ($relative === '') {
+        return true;
+    }
+
+    foreach (explode('/', $relative) as $segment) {
+        if ($segment === '' || $segment === '.' || $segment === '..') {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Whether $slug passes the SAME allowlist
+ * `WPMgr\Agent\Commands\UpdateCommand::sanitizeSlug()` enforces upstream.
+ * Re-validated independently here — this file never trusts marker content as
+ * pre-sanitized (defense in depth; the marker is written by trusted, already
+ * -booted PHP, but this file has no way to prove that from inside a
+ * fatal-triggered shutdown handler with no autoloader).
+ *
+ * @param string $slug Candidate slug read from the marker.
+ * @return bool
+ */
+function wpmgr_watchdog_slug_is_safe(string $slug): bool
+{
+    $trimmed = trim($slug);
+    if ($trimmed === '' || $trimmed !== $slug) {
+        return false;
+    }
+    if (strpos($slug, '..') !== false || strpos($slug, "\0") !== false) {
+        return false;
+    }
+    if ($slug[0] === '/' || $slug[0] === '\\') {
+        return false;
+    }
+    if (preg_match('#^[A-Za-z]:#', $slug) === 1) {
+        return false;
+    }
+
+    return preg_match('#^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)?$#', $slug) === 1;
+}
+
+/**
+ * Theme root directory — mirrors `SnapshotManager::themeRoot()`.
+ *
+ * @param string $contentDir wp-content path.
+ * @return string
+ */
+function wpmgr_watchdog_theme_root(string $contentDir): string
+{
+    if (function_exists('get_theme_root')) {
+        $root = @get_theme_root();
+        if (is_string($root) && $root !== '') {
+            return rtrim($root, '/\\');
+        }
+    }
+
+    return $contentDir . '/themes';
+}
+
+/**
+ * Independently re-derive the EXPECTED absolute live directory for a
+ * type/slug pair, from WP-native roots only (`WP_PLUGIN_DIR` /
+ * `get_theme_root()`) — mirrors `SnapshotManager::liveDir()` exactly,
+ * including its realpath()-based primary containment check and its
+ * documented open_basedir/symlinked-wp-content anchored fallback.
+ *
+ * Additional hardening beyond `liveDir()`'s own logic: explicitly rejects a
+ * plugin-folder or theme-slug segment of exactly `.` or `..`, which
+ * `wpmgr_watchdog_slug_is_safe()`'s character-class regex alone does not
+ * exclude (a lone `.` is a legal character-class member) and which would
+ * otherwise let `dirname()`/`realpath()` collapse the resolved path to the
+ * plugin/theme ROOT itself rather than a single slug's subdirectory — see
+ * this file's class doc, PATH SAFETY. This mu-plugin enforces that extra
+ * check independently rather than relying on it being fixed upstream.
+ *
+ * @param string $type 'plugin'|'theme'.
+ * @param string $slug Already validated by wpmgr_watchdog_slug_is_safe().
+ * @return string Absolute path, or '' when it cannot be safely resolved.
+ */
+function wpmgr_watchdog_expected_live_dir(string $type, string $slug): string
+{
+    if (!defined('WP_CONTENT_DIR')) {
+        return '';
+    }
+    $contentDir = rtrim((string) constant('WP_CONTENT_DIR'), '/\\');
+    if ($contentDir === '') {
+        return '';
+    }
+
+    if ($type === 'plugin') {
+        if (!defined('WP_PLUGIN_DIR')) {
+            return '';
+        }
+        $root     = rtrim((string) constant('WP_PLUGIN_DIR'), '/\\');
+        $slashPos = strpos($slug, '/');
+        $folder   = $slashPos !== false ? substr($slug, 0, $slashPos) : $slug;
+        if ($folder === '' || $folder === '.' || $folder === '..') {
+            return '';
+        }
+        $path = $root . '/' . $folder;
+    } elseif ($type === 'theme') {
+        if ($slug === '.' || $slug === '..') {
+            return '';
+        }
+        $root = wpmgr_watchdog_theme_root($contentDir);
+        $path = $root . '/' . $slug;
+    } else {
+        return '';
+    }
+
+    if ($root === '') {
+        return '';
+    }
+
+    // Primary: realpath()-based containment (mirrors containedRealpath()).
+    $parent       = dirname($path);
+    $realParent   = @realpath($parent);
+    $realContent  = @realpath($contentDir);
+    if ($realParent !== false && $realContent !== false) {
+        $realContent = rtrim($realContent, '/\\');
+        if ($realParent === $realContent || strncmp($realParent, $realContent . DIRECTORY_SEPARATOR, strlen($realContent) + 1) === 0) {
+            return rtrim($path, '/\\');
+        }
+    }
+
+    // Fallback: anchored string/segment containment against the WP-native
+    // root (never attacker-controlled) — mirrors liveDir()'s own documented
+    // open_basedir/symlinked-wp-content fallback exactly.
+    if (wpmgr_watchdog_anchored_containment($root, $path) && is_dir($path)) {
+        return rtrim($path, '/\\');
+    }
+
+    return '';
+}
+
+/**
+ * Resolve the absolute uploads basedir. Safe to call `wp_upload_dir()` here
+ * — unlike the top-level per-request check, this function is only ever
+ * reached from inside the rare "marker + genuine fatal" shutdown branch, by
+ * which point core WordPress (the code that defines `wp_upload_dir()`) is
+ * always fully loaded regardless of which regular plugin fatally failed to
+ * load.
+ *
+ * @return string Absolute path, or '' when it cannot be resolved.
+ */
+function wpmgr_watchdog_uploads_base(): string
+{
+    if (function_exists('wp_upload_dir')) {
+        $u = @wp_upload_dir();
+        if (is_array($u) && isset($u['basedir']) && is_string($u['basedir']) && $u['basedir'] !== '') {
+            return rtrim($u['basedir'], '/\\');
+        }
+    }
+    if (defined('WP_CONTENT_DIR')) {
+        return rtrim((string) constant('WP_CONTENT_DIR'), '/\\') . '/uploads';
+    }
+
+    return '';
+}
+
+/**
+ * LOW-1 (GitHub issue #210 security review) — mirrors
+ * `WPMgr\Agent\Support\StoragePaths::dataBase($purpose)` EXACTLY, which is
+ * NOT the same fallback as wpmgr_watchdog_uploads_base() above.
+ * wpmgr_watchdog_uploads_base() mirrors `SnapshotManager::uploadsBaseDir()`'s
+ * DIFFERENT fallback — `<WP_CONTENT_DIR>/uploads` — which is correct for the
+ * snapshot-payload side (SnapshotManager itself falls back the same way).
+ * `StoragePaths::dataBase()` (used by `UpdateInFlight` for its lock-file
+ * store) instead falls back to `<WP_CONTENT_DIR>/wpmgr-<purpose>` — WITHOUT
+ * `/uploads`. Using the wrong helper for the in-flight lock path made this
+ * mu-plugin compute a DIFFERENT lock file than `UpdateInFlight::mark()`
+ * itself uses whenever `wp_upload_dir()` returns no usable basedir, silently
+ * defeating the in-flight stand-down check in exactly that fallback
+ * scenario. This function is used ONLY by wpmgr_watchdog_try_lock_inflight()
+ * below; wpmgr_watchdog_expected_payload_dir() correctly keeps using
+ * wpmgr_watchdog_uploads_base().
+ *
+ * @param string $purpose Lowercase slug, same convention as StoragePaths.
+ * @return string Absolute path, or '' when neither base is available.
+ */
+function wpmgr_watchdog_storage_data_base(string $purpose): string
+{
+    if (function_exists('wp_upload_dir')) {
+        $u = @wp_upload_dir();
+        if (is_array($u) && isset($u['basedir']) && is_string($u['basedir']) && $u['basedir'] !== '') {
+            return rtrim($u['basedir'], '/\\') . '/wpmgr-' . $purpose;
+        }
+    }
+    if (defined('WP_CONTENT_DIR')) {
+        return rtrim((string) constant('WP_CONTENT_DIR'), '/\\') . '/wpmgr-' . $purpose;
+    }
+
+    return '';
+}
+
+/**
+ * Independently re-derive the EXPECTED absolute snapshot payload directory
+ * for a snapshot id — mirrors `SnapshotManager::resolveSnapshotDir()`'s
+ * identifier-shape regex plus its strict realpath()-based containment
+ * exactly (no anchored fallback on this side; `resolveSnapshotDir()` itself
+ * has none), plus the `/payload` suffix and its own `is_dir()` check.
+ * Re-validates the identifier shape independently rather than relying
+ * solely on the caller having already done so (defense in depth).
+ *
+ * @param string $snapshotId Snapshot identifier, re-validated here.
+ * @return string Absolute payload path, or '' when it cannot be resolved.
+ */
+function wpmgr_watchdog_expected_payload_dir(string $snapshotId): string
+{
+    if (preg_match('#^snap_[A-Za-z0-9_]+$#', $snapshotId) !== 1) {
+        return '';
+    }
+
+    $uploadsBase = wpmgr_watchdog_uploads_base();
+    if ($uploadsBase === '') {
+        return '';
+    }
+    $base = $uploadsBase . '/wpmgr-snapshots';
+
+    $candidate = $base . '/' . $snapshotId;
+    if (!is_dir($candidate)) {
+        return '';
+    }
+
+    $realBase = @realpath($base);
+    $real     = @realpath($candidate);
+    if ($realBase === false || $real === false) {
+        return '';
+    }
+    $realBase = rtrim($realBase, '/\\');
+    if ($real !== $realBase && strncmp($real, $realBase . DIRECTORY_SEPARATOR, strlen($realBase) + 1) !== 0) {
+        return '';
+    }
+
+    $payload = rtrim($real, '/\\') . '/payload';
+
+    return is_dir($payload) ? $payload : '';
+}
+
+/**
+ * Attempt to acquire the SAME non-blocking `flock()` liveness lock
+ * `WPMgr\Agent\Support\UpdateInFlight::mark()` holds for the duration of a
+ * real, in-progress apply of this exact type/slug (see that class's own
+ * doc). The lock FILE path is recomputed independently — pure
+ * `sha256(type:slug)` hashing, no class dependency — via
+ * wpmgr_watchdog_storage_data_base('update-inflight'), which mirrors
+ * `StoragePaths::dataBase()` exactly (see that function's own doc for LOW-1
+ * — why this must NOT reuse wpmgr_watchdog_uploads_base()'s different
+ * fallback). Recomputing this path here is safe because this function only
+ * ever runs from the rare shutdown branch, not the hot path.
+ *
+ * @param string $type 'plugin'|'theme'.
+ * @param string $slug Sanitized slug.
+ * @return resource|null|false A held, locked resource on success (safe to
+ *     proceed — release via wpmgr_watchdog_unlock_inflight()); `false` when
+ *     the lock is currently held by a genuine in-progress apply (stand
+ *     down); `null` when the lock file itself could not even be opened
+ *     (treated identically to `false` by the caller — never proceed on an
+ *     inconclusive liveness check).
+ */
+function wpmgr_watchdog_try_lock_inflight(string $type, string $slug)
+{
+    $dir = wpmgr_watchdog_storage_data_base('update-inflight');
+    if ($dir === '') {
+        return null;
+    }
+    $key  = substr(hash('sha256', $type . ':' . $slug), 0, 32);
+    $lock = $dir . '/' . $key . '.lock';
+
+    // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- mu-plugin, no autoloader/WP_Filesystem available; recomputes the same coordination-file path WPMgr\Agent\Support\UpdateInFlight::acquireLock() uses
+    $handle = @fopen($lock, 'c');
+    if ($handle === false) {
+        return null;
+    }
+    if (!flock($handle, LOCK_EX | LOCK_NB)) {
+        fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- releasing our own failed-lock-attempt handle
+        return false;
+    }
+
+    return $handle;
+}
+
+/**
+ * Release a lock handle returned by wpmgr_watchdog_try_lock_inflight().
+ *
+ * @param resource|null|false $handle Handle to release.
+ * @return void
+ */
+function wpmgr_watchdog_unlock_inflight($handle): void
+{
+    if (is_resource($handle)) {
+        flock($handle, LOCK_UN);
+        fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- releasing our own advisory lock handle
+    }
+}
+
+/**
+ * Recursively copy a directory — mirrors `SnapshotManager::copyDir()` line
+ * for line (symlinks never followed, dirs recursed, first failure aborts).
+ *
+ * @param string $src Source directory.
+ * @param string $dst Destination directory.
+ * @return bool
+ */
+function wpmgr_watchdog_copy_dir(string $src, string $dst): bool
+{
+    if (!is_dir($src)) {
+        return false;
+    }
+    if (!is_dir($dst) && !@mkdir($dst, 0755, true) && !is_dir($dst)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- mu-plugin, no autoloader/WP_Filesystem available; wp_mkdir_p() itself is not safely callable this early on every path
+        return false;
+    }
+
+    $items = @scandir($src);
+    if ($items === false) {
+        return false;
+    }
+
+    foreach ($items as $item) {
+        if ($item === '.' || $item === '..') {
+            continue;
+        }
+        $from = $src . '/' . $item;
+        $to   = $dst . '/' . $item;
+
+        if (is_link($from)) {
+            continue;
+        }
+
+        if (is_dir($from)) {
+            if (!wpmgr_watchdog_copy_dir($from, $to)) {
+                return false;
+            }
+        } elseif (!@copy($from, $to)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Recursively delete a directory — mirrors `SnapshotManager::deleteDir()`.
+ *
+ * @param string $dir Directory to remove.
+ * @return bool
+ */
+function wpmgr_watchdog_delete_dir(string $dir): bool
+{
+    if (!is_dir($dir)) {
+        return false;
+    }
+    $items = @scandir($dir);
+    if ($items === false) {
+        return false;
+    }
+    foreach ($items as $item) {
+        if ($item === '.' || $item === '..') {
+            continue;
+        }
+        $path = $dir . '/' . $item;
+        if (is_dir($path) && !is_link($path)) {
+            wpmgr_watchdog_delete_dir($path);
+        } else {
+            @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- mu-plugin, no autoloader/wp_delete_file() available this early on every path
+        }
+    }
+
+    return @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- mu-plugin, no autoloader/WP_Filesystem available; removes an already-emptied scratch/aside dir
+}
+
+/**
+ * The actual directory swap: move $live aside, copy $payload into its place,
+ * drop the aside on success or roll back on failure. Mirrors
+ * `SnapshotManager::restore()`'s core swap (including its S5 fix: on a
+ * mid-copy failure, unconditionally clear whatever partial content copyDir()
+ * left at $live before restoring the aside) — with ONE deliberate,
+ * conservative omission: `restore()`'s F1 "heal a re-interrupted restore"
+ * branch (which recovers from an aside that already exists from a PRIOR
+ * interrupted attempt) is NOT reproduced here. If $asideName already exists,
+ * this function does nothing at all rather than guess at how to reconcile an
+ * unexpected on-disk state — this mu-plugin favors doing nothing over doing
+ * something clever whenever reality does not match a fresh restore's
+ * expectations. A genuinely stuck state left behind by this function's own
+ * prior (failed) attempt is recoverable via `RollbackCommand` once the site
+ * is next reachable, or by an operator.
+ *
+ * @param string $live       Absolute, already-validated live directory.
+ * @param string $payload    Absolute, already-validated snapshot payload directory.
+ * @param string $snapshotId Snapshot identifier (already regex-validated).
+ * @return void
+ */
+function wpmgr_watchdog_swap_directories(string $live, string $payload, string $snapshotId): void
+{
+    $asideName = $live . '.wpmgr-watchdog-old-' . $snapshotId;
+
+    if (file_exists($asideName)) {
+        return;
+    }
+
+    $liveExisted = is_dir($live);
+
+    if ($liveExisted) {
+        if (!@rename($live, $asideName)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic same-filesystem swap; mirrors SnapshotManager::restore()'s own rename-based staging
+            return;
+        }
+    }
+
+    if (!wpmgr_watchdog_copy_dir($payload, $live)) {
+        // Mirrors SnapshotManager::restore()'s S5 fix: copyDir() may have
+        // already created $live as an empty/partial directory even though
+        // the copy failed — clear it unconditionally before restoring the
+        // aside, rather than gate that restore on a check copyDir()'s own
+        // behavior would defeat.
+        if (is_dir($live)) {
+            wpmgr_watchdog_delete_dir($live);
+        }
+        if ($liveExisted && is_dir($asideName)) {
+            @rename($asideName, $live); // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- atomic same-filesystem rollback swap
+        }
+
+        return;
+    }
+
+    if ($liveExisted && is_dir($asideName)) {
+        wpmgr_watchdog_delete_dir($asideName);
+    }
+}
+
+/**
+ * Whether $path is exactly the running agent's own plugin directory
+ * (`WPMGR_AGENT_DIR`) — mirrors `FilesRestorer::PRESERVE_FROM_LIVE`'s
+ * protection of `plugins/wpmgr-agent`: a directory-replacement recovery
+ * mechanism must never be pointed at the very code that could run it.
+ * Extracted into its own function (rather than inlined) so it is directly
+ * unit-testable in isolation.
+ *
+ * @param string $path Absolute, already-resolved candidate path.
+ * @return bool
+ */
+function wpmgr_watchdog_is_self_path(string $path): bool
+{
+    if (!defined('WPMGR_AGENT_DIR') || $path === '') {
+        return false;
+    }
+    $selfDir = rtrim(str_replace('\\', '/', (string) constant('WPMGR_AGENT_DIR')), '/');
+
+    return $selfDir !== '' && str_replace('\\', '/', $path) === $selfDir;
+}
+
+/**
+ * Validate, independently re-derive, and (only when everything checks out)
+ * restore ONE marker entry. Every early `return` is a deliberate, silent
+ * stand-down — see this function's inline comments for exactly which
+ * safety condition each one enforces.
+ *
+ * @param array<string,mixed> $entry Decoded marker entry.
+ * @param int                 $now   Current time.
+ * @return void
+ */
+function wpmgr_watchdog_attempt_restore(array $entry, int $now): void
+{
+    $type            = isset($entry['type']) && is_string($entry['type']) ? $entry['type'] : '';
+    $slug            = isset($entry['slug']) && is_string($entry['slug']) ? $entry['slug'] : '';
+    $snapshotId      = isset($entry['snapshot_id']) && is_string($entry['snapshot_id']) ? $entry['snapshot_id'] : '';
+    $recordedLive    = isset($entry['live_dir']) && is_string($entry['live_dir']) ? rtrim($entry['live_dir'], '/\\') : '';
+    $recordedPayload = isset($entry['payload_dir']) && is_string($entry['payload_dir']) ? rtrim($entry['payload_dir'], '/\\') : '';
+    $expiresAt       = isset($entry['expires_at']) && is_numeric($entry['expires_at']) ? (int) $entry['expires_at'] : 0;
+
+    // Only plugin/theme carry a directory-level snapshot at all (see
+    // UpdateCommand's own class doc, D3 — core never arms this watchdog).
+    if ($type !== 'plugin' && $type !== 'theme') {
+        return;
+    }
+    if ($slug === '' || $snapshotId === '' || $recordedLive === '' || $recordedPayload === '') {
+        return;
+    }
+    // Fresh, one-shot window: an expired marker must never trigger a restore.
+    if ($expiresAt <= 0 || $now >= $expiresAt) {
+        return;
+    }
+    // Same identifier shape SnapshotManager itself generates/validates —
+    // never let an arbitrary string reach a filesystem path.
+    if (preg_match('#^snap_[A-Za-z0-9_]+$#', $snapshotId) !== 1) {
+        return;
+    }
+    if (!wpmgr_watchdog_slug_is_safe($slug)) {
+        return;
+    }
+
+    // The marker's recorded live_dir is used ONLY as an identity check
+    // against an INDEPENDENTLY re-derived expectation — never trusted as
+    // the sole source of truth. See this file's class doc, PATH SAFETY.
+    $expectedLive = wpmgr_watchdog_expected_live_dir($type, $slug);
+    if ($expectedLive === '' || $expectedLive !== $recordedLive) {
+        return;
+    }
+
+    // Never restore over the running agent's own plugin directory — mirrors
+    // FilesRestorer::PRESERVE_FROM_LIVE's protection of plugins/wpmgr-agent.
+    if (wpmgr_watchdog_is_self_path($expectedLive)) {
+        return;
+    }
+
+    $expectedPayload = wpmgr_watchdog_expected_payload_dir($snapshotId);
+    if ($expectedPayload === '' || $expectedPayload !== $recordedPayload) {
+        return;
+    }
+
+    // Stand down entirely if a genuine apply is in progress for this exact
+    // type/slug right now — never race a live UpdateCommand apply.
+    $inFlightLock = wpmgr_watchdog_try_lock_inflight($type, $slug);
+    if ($inFlightLock === null || $inFlightLock === false) {
+        return;
+    }
+
+    try {
+        $stateDir = wpmgr_watchdog_state_dir();
+        if ($stateDir === '') {
+            return;
+        }
+        $claimFile = $stateDir . '/watchdog-claim-' . $snapshotId . '.claim';
+
+        // One-shot atomic claim: only the FIRST concurrent shutdown handler
+        // to reach this exact snapshot id ever proceeds past this point.
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- mu-plugin, no autoloader/WP_Filesystem available; exclusive create is the one-shot mutual-exclusion primitive (see this file's class doc, CONCURRENCY)
+        $claimHandle = @fopen($claimFile, 'x');
+        if ($claimHandle === false) {
+            return;
+        }
+        fclose($claimHandle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing our own just-created claim sentinel; the file's mere existence is the signal, no content needed
+        @chmod($claimFile, 0600); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod -- explicit security perms (0600); WP_Filesystem would coerce to wider FS_CHMOD_FILE
+
+        wpmgr_watchdog_swap_directories($expectedLive, $expectedPayload, $snapshotId);
+    } finally {
+        wpmgr_watchdog_unlock_inflight($inFlightLock);
+    }
+}
+
+/**
+ * Decode the marker file's entries. Returns an empty list on any absence,
+ * unreadable content, or unexpected shape — never throws.
+ *
+ * @param string $file Absolute marker file path.
+ * @return list<array<string,mixed>>
+ */
+function wpmgr_watchdog_read_markers(string $file): array
+{
+    $raw = @file_get_contents($file);
+    if (!is_string($raw) || $raw === '') {
+        return [];
+    }
+    $decoded = json_decode($raw, true);
+    if (!is_array($decoded) || !isset($decoded['markers']) || !is_array($decoded['markers'])) {
+        return [];
+    }
+
+    return array_values($decoded['markers']);
+}
+
+/**
+ * MEDIUM-1a (GitHub issue #210 security review) — whether $message indicates
+ * a PHP resource-exhaustion fatal (out-of-memory / execution-timeout) rather
+ * than genuinely broken code. Matched case-insensitively against the exact
+ * substrings PHP's own core fatal-error messages use for these two classes:
+ * "Allowed memory size ... exhausted" and "Maximum execution time ...
+ * exceeded". An intermittent resource spike inside the updated plugin's own
+ * directory is NOT evidence that the update broke bootstrap — a large
+ * import, a slow report, or simply a momentarily busy host can trip either
+ * one on an otherwise perfectly good update. Reverting a good update because
+ * of a single transient resource spike is a real trust problem for an
+ * automated recovery feature, so these two classes are excluded from
+ * attribution entirely in wpmgr_watchdog_process_fatal() below — even when
+ * the fatal's file otherwise falls within an armed slug's live_dir.
+ *
+ * @param string $message Raw error message from error_get_last()/$err['message'].
+ * @return bool
+ */
+function wpmgr_watchdog_is_resource_exhaustion_message(string $message): bool
+{
+    if ($message === '') {
+        return false;
+    }
+
+    return stripos($message, 'Allowed memory size') !== false
+        || stripos($message, 'Maximum execution time') !== false;
+}
+
+/**
+ * Pure decision-plus-action core, separated from the real
+ * `error_get_last()` call so tests can drive it with a controlled error
+ * array — mirrors `a-wpmgr-waf.php`'s own `wpmgr_waf_should_deny()`
+ * extraction (a test loads THIS file directly and calls the real function,
+ * never a hand-copied replica). Acts ONLY when $err reports a genuine fatal
+ * (E_ERROR / E_PARSE / E_COMPILE_ERROR / E_CORE_ERROR — deliberately
+ * narrower than a-wpmgr-error-trap.php's own capture mask, which also
+ * includes E_USER_ERROR/E_RECOVERABLE_ERROR; this watchdog only ever acts on
+ * the class of fatal a broken bootstrap actually produces) that is NOT a
+ * resource-exhaustion fatal (MEDIUM-1a — see
+ * wpmgr_watchdog_is_resource_exhaustion_message()'s own doc), a marker file
+ * exists, and at least one entry's recorded live_dir CONTAINS the file the
+ * fatal was reported in — so a batch that updated several plugins/themes at
+ * once restores ONLY the one that actually caused THIS fatal, never the
+ * others. When no entry's live_dir contains the fatal's file (an ambiguous
+ * case — e.g. the fatal is reported inside a WP core file rather than the
+ * plugin/theme's own tree), this function deliberately does nothing rather
+ * than guess which entry to restore.
+ *
+ * @param array<string,mixed>|null $err The value `error_get_last()` returned.
+ * @return void
+ */
+function wpmgr_watchdog_process_fatal(?array $err): void
+{
+    if (!is_array($err)) {
+        return;
+    }
+    $code      = (int) ($err['type'] ?? 0);
+    $fatalMask = E_ERROR | E_PARSE | E_COMPILE_ERROR | E_CORE_ERROR;
+    if (($code & $fatalMask) === 0) {
+        return;
+    }
+
+    $message = isset($err['message']) && is_string($err['message']) ? $err['message'] : '';
+    if (wpmgr_watchdog_is_resource_exhaustion_message($message)) {
+        return;
+    }
+
+    $markerFile = wpmgr_watchdog_marker_path();
+    if ($markerFile === '' || !is_file($markerFile)) {
+        return;
+    }
+
+    $markers = wpmgr_watchdog_read_markers($markerFile);
+    if ($markers === []) {
+        return;
+    }
+
+    $errFile = isset($err['file']) && is_string($err['file']) ? $err['file'] : '';
+    if ($errFile === '') {
+        return;
+    }
+    $errFileReal = @realpath($errFile);
+    $errFileReal = is_string($errFileReal) && $errFileReal !== '' ? $errFileReal : $errFile;
+    $errFileReal = str_replace('\\', '/', $errFileReal);
+
+    $now = time();
+    foreach ($markers as $entry) {
+        if (!is_array($entry)) {
+            continue;
+        }
+        $liveDir = isset($entry['live_dir']) && is_string($entry['live_dir']) ? $entry['live_dir'] : '';
+        if ($liveDir === '') {
+            continue;
+        }
+        // realpath() the candidate live_dir the SAME way $errFileReal was
+        // just canonicalized above, falling back to the raw string when it
+        // cannot be resolved (e.g. the directory no longer exists). Without
+        // this, a host where wp-content (or one of its ancestors) is itself
+        // a symlink would realpath() the fatal's file to its resolved
+        // target while leaving live_dir un-resolved, producing a false
+        // "not contained" verdict for a genuinely matching entry — never
+        // restoring a site this watchdog exists to fix.
+        $liveDirReal = @realpath($liveDir);
+        $liveDirReal = is_string($liveDirReal) && $liveDirReal !== '' ? $liveDirReal : $liveDir;
+        $liveDirReal = str_replace('\\', '/', $liveDirReal);
+
+        if (!wpmgr_watchdog_path_is_within($errFileReal, $liveDirReal)) {
+            continue;
+        }
+
+        // Found the entry that owns the fatal's file — attempt exactly
+        // one restore for it, then stop (never touch any other entry on
+        // this same fatal).
+        wpmgr_watchdog_attempt_restore($entry, $now);
+
+        return;
+    }
+}
+
+/**
+ * The registered shutdown callback. Thin real-environment wrapper around
+ * wpmgr_watchdog_process_fatal() — see that function's doc for the actual
+ * decision logic. The entire body is wrapped in try/catch: this callback
+ * must NEVER itself throw or trigger a fatal, on top of every individual
+ * filesystem call already being `@`-guarded.
+ *
+ * @return void
+ */
+function wpmgr_watchdog_shutdown_check(): void
+{
+    try {
+        wpmgr_watchdog_process_fatal(error_get_last());
+    } catch (\Throwable $e) {
+        // The watchdog itself must never add a fatal.
+        return;
+    }
+}
+
+// =============================================================================
+// The cheap per-request check (see this file's class doc, THE HOT PATH).
+// WPMGR_WATCHDOG_TESTING: when defined, this file is being `require_once`'d
+// by the test suite to load function definitions only — skip the top-level
+// stat + register_shutdown_function() call (mirrors a-wpmgr-waf.php's own
+// WPMGR_WAF_TESTING convention).
+// =============================================================================
+
+if (!defined('WPMGR_WATCHDOG_TESTING')) {
+    try {
+        $wpmgr_watchdog_marker_file = wpmgr_watchdog_marker_path();
+        if ($wpmgr_watchdog_marker_file !== '' && is_file($wpmgr_watchdog_marker_file)) {
+            register_shutdown_function('wpmgr_watchdog_shutdown_check');
+        }
+    } catch (\Throwable $e) {
+        // Never let the top-level check itself become a fatal.
+    }
+    unset($wpmgr_watchdog_marker_file);
+}

--- a/apps/agent/tests/MetadataCommandTest.php
+++ b/apps/agent/tests/MetadataCommandTest.php
@@ -256,6 +256,133 @@ final class MetadataCommandTest extends TestCase
         $this->assertNull($data['plugins'][0]['available_update']);
     }
 
+    /**
+     * GH #211: WordPress's own `update_plugins` transient can carry a
+     * response entry whose `new_version` merely EQUALS the installed
+     * version (a stale/duplicate offer) — that must not surface as an
+     * "available update".
+     */
+    public function test_plugins_available_update_is_null_when_same_version(): void
+    {
+        Functions\when('get_bloginfo')->justReturn('6.5.2');
+        Functions\when('is_multisite')->justReturn(false);
+        Functions\when('get_option')->justReturn([]);
+        Functions\when('get_plugins')->justReturn([
+            'akismet/akismet.php' => ['Name' => 'Akismet', 'Version' => '5.3.1'],
+        ]);
+        Functions\when('wp_get_themes')->justReturn([]);
+        Functions\when('get_stylesheet')->justReturn('twentytwentyfour');
+        Functions\when('get_core_updates')->justReturn([]);
+
+        $pluginTransient = new \stdClass();
+        $pluginEntry = new \stdClass();
+        $pluginEntry->new_version = '5.3.1';
+        $pluginTransient->response = ['akismet/akismet.php' => $pluginEntry];
+        Functions\when('get_site_transient')->alias(static function ($key) use ($pluginTransient) {
+            return $key === 'update_plugins' ? $pluginTransient : false;
+        });
+
+        $data = (new MetadataCommand())->collect();
+
+        $this->assertCount(1, $data['plugins']);
+        $this->assertNull($data['plugins'][0]['available_update']);
+    }
+
+    /**
+     * GH #211 normalization: a leading `v`/`V` and incidental whitespace on
+     * either side of the comparison must not defeat the same-version guard
+     * (`v1.5.1` from the transient vs. ` 1.5.1 ` from the plugin header).
+     */
+    public function test_plugins_available_update_normalizes_leading_v_and_whitespace(): void
+    {
+        Functions\when('get_bloginfo')->justReturn('6.5.2');
+        Functions\when('is_multisite')->justReturn(false);
+        Functions\when('get_option')->justReturn([]);
+        Functions\when('get_plugins')->justReturn([
+            'foo/foo.php' => ['Name' => 'Foo', 'Version' => ' 1.5.1 '],
+        ]);
+        Functions\when('wp_get_themes')->justReturn([]);
+        Functions\when('get_stylesheet')->justReturn('twentytwentyfour');
+        Functions\when('get_core_updates')->justReturn([]);
+
+        $pluginTransient = new \stdClass();
+        $pluginEntry = new \stdClass();
+        $pluginEntry->new_version = 'v1.5.1';
+        $pluginTransient->response = ['foo/foo.php' => $pluginEntry];
+        Functions\when('get_site_transient')->alias(static function ($key) use ($pluginTransient) {
+            return $key === 'update_plugins' ? $pluginTransient : false;
+        });
+
+        $data = (new MetadataCommand())->collect();
+
+        $this->assertNull($data['plugins'][0]['available_update']);
+    }
+
+    /**
+     * Regression guard: the #211 same-version guard must NOT suppress a
+     * genuinely newer offer — a real update must still surface even when
+     * both versions carry a leading `v`.
+     */
+    public function test_plugins_available_update_still_surfaces_when_genuinely_newer(): void
+    {
+        Functions\when('get_bloginfo')->justReturn('6.5.2');
+        Functions\when('is_multisite')->justReturn(false);
+        Functions\when('get_option')->justReturn([]);
+        Functions\when('get_plugins')->justReturn([
+            'foo/foo.php' => ['Name' => 'Foo', 'Version' => 'v1.5.1'],
+        ]);
+        Functions\when('wp_get_themes')->justReturn([]);
+        Functions\when('get_stylesheet')->justReturn('twentytwentyfour');
+        Functions\when('get_core_updates')->justReturn([]);
+
+        $pluginTransient = new \stdClass();
+        $pluginEntry = new \stdClass();
+        $pluginEntry->new_version = '1.6.0';
+        $pluginTransient->response = ['foo/foo.php' => $pluginEntry];
+        Functions\when('get_site_transient')->alias(static function ($key) use ($pluginTransient) {
+            return $key === 'update_plugins' ? $pluginTransient : false;
+        });
+
+        $data = (new MetadataCommand())->collect();
+
+        $this->assertNotNull($data['plugins'][0]['available_update']);
+        $this->assertSame('1.6.0', $data['plugins'][0]['available_update']['new_version']);
+    }
+
+    /**
+     * Fail-open guard: when the installed version cannot be determined
+     * (get_plugins() omitted the Version header, so plugins() falls back to
+     * the 'unknown' sentinel), the same-version comparison must be skipped
+     * entirely and the offered update kept — hiding a real update because
+     * the installed version was unreadable would be worse than an occasional
+     * over-report.
+     */
+    public function test_plugins_available_update_present_when_installed_version_unknown(): void
+    {
+        Functions\when('get_bloginfo')->justReturn('6.5.2');
+        Functions\when('is_multisite')->justReturn(false);
+        Functions\when('get_option')->justReturn([]);
+        Functions\when('get_plugins')->justReturn([
+            'foo/foo.php' => ['Name' => 'Foo'],
+        ]);
+        Functions\when('wp_get_themes')->justReturn([]);
+        Functions\when('get_stylesheet')->justReturn('twentytwentyfour');
+        Functions\when('get_core_updates')->justReturn([]);
+
+        $pluginTransient = new \stdClass();
+        $pluginEntry = new \stdClass();
+        $pluginEntry->new_version = '1.0.0';
+        $pluginTransient->response = ['foo/foo.php' => $pluginEntry];
+        Functions\when('get_site_transient')->alias(static function ($key) use ($pluginTransient) {
+            return $key === 'update_plugins' ? $pluginTransient : false;
+        });
+
+        $data = (new MetadataCommand())->collect();
+
+        $this->assertSame('unknown', $data['plugins'][0]['version']);
+        $this->assertNotNull($data['plugins'][0]['available_update']);
+    }
+
     public function test_themes_include_available_update_when_transient_has_entry(): void
     {
         Functions\when('get_bloginfo')->justReturn('6.5.2');
@@ -304,6 +431,53 @@ final class MetadataCommandTest extends TestCase
         ], $data['themes'][0]['available_update']);
     }
 
+    /**
+     * GH #211 theme-side sibling of test_plugins_available_update_is_null_when_same_version():
+     * the `update_themes` transient's `new_version` merely EQUALS the
+     * installed stylesheet version — must not surface as an "available
+     * update".
+     */
+    public function test_themes_available_update_is_null_when_same_version(): void
+    {
+        Functions\when('get_bloginfo')->justReturn('6.5.2');
+        Functions\when('is_multisite')->justReturn(false);
+        Functions\when('get_option')->justReturn([]);
+        Functions\when('get_plugins')->justReturn([]);
+        $themeObj = new class {
+            /** @param string $k Field. @return string */
+            public function get($k): string
+            {
+                return match ($k) {
+                    'Name'    => 'Twenty Twenty-Four',
+                    'Version' => '1.5.1',
+                    default   => '',
+                };
+            }
+        };
+        Functions\when('wp_get_themes')->justReturn([
+            'twentytwentyfour' => $themeObj,
+        ]);
+        Functions\when('get_stylesheet')->justReturn('twentytwentyfour');
+        Functions\when('get_core_updates')->justReturn([]);
+
+        // Theme transient entries are ARRAYS, not objects (per WP core).
+        $themeTransient = new \stdClass();
+        $themeTransient->response = [
+            'twentytwentyfour' => [
+                'theme'       => 'twentytwentyfour',
+                'new_version' => '1.5.1',
+            ],
+        ];
+        Functions\when('get_site_transient')->alias(static function ($key) use ($themeTransient) {
+            return $key === 'update_themes' ? $themeTransient : false;
+        });
+
+        $data = (new MetadataCommand())->collect();
+
+        $this->assertCount(1, $data['themes']);
+        $this->assertNull($data['themes'][0]['available_update']);
+    }
+
     public function test_core_update_present_when_get_core_updates_returns_upgrade(): void
     {
         Functions\when('get_bloginfo')->alias(static fn ($k) => $k === 'version' ? '6.4.3' : '');
@@ -340,6 +514,32 @@ final class MetadataCommandTest extends TestCase
         // get_core_updates returns a `latest` response (not `upgrade`).
         $core = new \stdClass();
         $core->response = 'latest';
+        $core->version  = '6.5.2';
+        Functions\when('get_core_updates')->justReturn([$core]);
+
+        $data = (new MetadataCommand())->collect();
+
+        $this->assertNull($data['core_update']);
+    }
+
+    /**
+     * GH #211 core-side sibling: an `update_core` transient entry whose
+     * `response` is 'upgrade' but whose offered `version` merely EQUALS the
+     * currently-running core version (a stale/duplicate entry) must not
+     * surface as a core update.
+     */
+    public function test_core_update_null_when_new_version_not_newer(): void
+    {
+        Functions\when('get_bloginfo')->alias(static fn ($k) => $k === 'version' ? '6.5.2' : '');
+        Functions\when('is_multisite')->justReturn(false);
+        Functions\when('get_option')->justReturn([]);
+        Functions\when('get_plugins')->justReturn([]);
+        Functions\when('wp_get_themes')->justReturn([]);
+        Functions\when('get_stylesheet')->justReturn('twentytwentyfour');
+        Functions\when('get_site_transient')->justReturn(false);
+
+        $core = new \stdClass();
+        $core->response = 'upgrade';
         $core->version  = '6.5.2';
         Functions\when('get_core_updates')->justReturn([$core]);
 

--- a/apps/agent/tests/MuPluginGateTest.php
+++ b/apps/agent/tests/MuPluginGateTest.php
@@ -71,6 +71,7 @@ final class MuPluginGateTest extends TestCase
         }
         file_put_contents($loaderDir . '/' . MuPluginInstaller::SOURCE_BASENAME, '<?php // error-trap stub');
         file_put_contents($loaderDir . '/' . MuPluginInstaller::WAF_SOURCE_BASENAME, '<?php // waf stub');
+        file_put_contents($loaderDir . '/' . MuPluginInstaller::WATCHDOG_SOURCE_BASENAME, '<?php // watchdog stub');
 
         // Build the shared mu-plugins destination directory.
         self::$sharedMuDir = sys_get_temp_dir() . '/wpmgr_mu_gate_dest';
@@ -150,10 +151,16 @@ final class MuPluginGateTest extends TestCase
         return rtrim(self::$sharedMuDir, '/') . '/' . MuPluginInstaller::WAF_DEST_BASENAME;
     }
 
+    private function watchdogPath(): string
+    {
+        return rtrim(self::$sharedMuDir, '/') . '/' . MuPluginInstaller::WATCHDOG_DEST_BASENAME;
+    }
+
     private function cleanMuDir(): void
     {
         @unlink($this->errorTrapPath());
         @unlink($this->wafPath());
+        @unlink($this->watchdogPath());
     }
 
     private static function rmrfStatic(string $dir): void
@@ -286,24 +293,97 @@ final class MuPluginGateTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
-    // (e) deactivate() removes BOTH mu-plugin files
+    // (h) GitHub issue #210 — update-watchdog mu-plugin install/uninstall pair
     // -------------------------------------------------------------------------
 
-    public function test_deactivate_removes_both_mu_plugins(): void
+    public function test_update_watchdog_install_is_idempotent_and_writes_shipped_content(): void
     {
         Functions\when('update_option')->justReturn(true);
         $installer = $this->makeInstaller();
 
-        // Pre-install both.
+        $this->assertFalse(file_exists($this->watchdogPath()), 'file must not exist before install');
+
+        $result = $installer->installUpdateWatchdog();
+        $this->assertTrue($result, 'installUpdateWatchdog() must succeed with a writable temp dir');
+        $this->assertTrue(file_exists($this->watchdogPath()), 'update-watchdog mu-plugin must be written');
+        $this->assertTrue($installer->isUpdateWatchdogInstalled(), 'isUpdateWatchdogInstalled() must be true');
+
+        $firstWriteMtime = filemtime($this->watchdogPath());
+
+        // Re-installing with unchanged source content must be a content-
+        // fingerprint no-op (same idempotent short-circuit install()/
+        // installWaf() already use) — the destination file is not rewritten.
+        clearstatcache(true, $this->watchdogPath());
+        $second = $installer->installUpdateWatchdog();
+        $this->assertTrue($second, 'a repeat installUpdateWatchdog() call must still report success');
+        $this->assertSame(
+            $firstWriteMtime,
+            filemtime($this->watchdogPath()),
+            'installUpdateWatchdog() must be idempotent: unchanged source content must not rewrite the destination'
+        );
+    }
+
+    public function test_update_watchdog_installed_content_matches_the_real_shipped_mu_plugin_file(): void
+    {
+        Functions\when('update_option')->justReturn(true);
+
+        // Use the REAL plugin root (this repo's apps/agent/) rather than the
+        // stub fixture, so this test proves the installer copies the ACTUAL
+        // shipped a-wpmgr-update-watchdog.php byte-for-byte.
+        $realPluginDir = dirname(__DIR__);
+        $installer     = new MuPluginInstaller($realPluginDir);
+
+        $this->assertTrue($installer->installUpdateWatchdog(), 'installUpdateWatchdog() must succeed against the real shipped source file');
+
+        $shipped  = (string) file_get_contents($realPluginDir . '/mu-plugin-loader/' . MuPluginInstaller::WATCHDOG_SOURCE_BASENAME);
+        $installed = (string) file_get_contents($this->watchdogPath());
+
+        $this->assertSame($shipped, $installed, 'the installed mu-plugin file content must be EXACTLY what is shipped in mu-plugin-loader/');
+
+        // Clean up: this test intentionally installs from the real source,
+        // bypassing the shared stub fixture other tests in this class rely
+        // on for the SAME destination path.
+        $installer->uninstallUpdateWatchdog();
+    }
+
+    public function test_update_watchdog_opt_out_removes_the_file(): void
+    {
+        Functions\when('update_option')->justReturn(true);
+        $installer = $this->makeInstaller();
+
+        $this->assertTrue($installer->installUpdateWatchdog(), 'installUpdateWatchdog() must succeed with a writable temp dir');
+        $this->assertTrue(file_exists($this->watchdogPath()), 'watchdog file must be present after installUpdateWatchdog()');
+        $this->assertTrue($installer->isUpdateWatchdogInstalled());
+
+        // Simulate boot gate: un-enrolled + isUpdateWatchdogInstalled() -> uninstallUpdateWatchdog().
+        $installer->uninstallUpdateWatchdog();
+
+        $this->assertFalse(file_exists($this->watchdogPath()), 'update-watchdog mu-plugin must be removed on un-enrollment');
+        $this->assertFalse($installer->isUpdateWatchdogInstalled());
+    }
+
+    // -------------------------------------------------------------------------
+    // (e) deactivate() removes ALL THREE mu-plugin files
+    // -------------------------------------------------------------------------
+
+    public function test_deactivate_removes_all_three_mu_plugins(): void
+    {
+        Functions\when('update_option')->justReturn(true);
+        $installer = $this->makeInstaller();
+
+        // Pre-install all three.
         $this->assertTrue($installer->install(), 'install() must succeed');
         $this->assertTrue($installer->installWaf(), 'installWaf() must succeed');
+        $this->assertTrue($installer->installUpdateWatchdog(), 'installUpdateWatchdog() must succeed');
 
         $this->assertTrue(file_exists($this->errorTrapPath()), 'error-trap must be present before deactivate');
         $this->assertTrue(file_exists($this->wafPath()), 'WAF must be present before deactivate');
+        $this->assertTrue(file_exists($this->watchdogPath()), 'update-watchdog must be present before deactivate');
 
         // Simulate deactivate() cleanup block (must not throw).
         try {
             $installer->uninstallWaf();
+            $installer->uninstallUpdateWatchdog();
             $installer->uninstall();
         } catch (\Throwable $e) {
             $this->fail('uninstall must not throw: ' . $e->getMessage());
@@ -316,6 +396,10 @@ final class MuPluginGateTest extends TestCase
         $this->assertFalse(
             file_exists($this->wafPath()),
             'deactivate() must remove the WAF mu-plugin'
+        );
+        $this->assertFalse(
+            file_exists($this->watchdogPath()),
+            'deactivate() must remove the update-watchdog mu-plugin'
         );
     }
 

--- a/apps/agent/tests/RollbackCommandTest.php
+++ b/apps/agent/tests/RollbackCommandTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace WPMgr\Agent\Tests;
 
 use Brain\Monkey;
+use Brain\Monkey\Functions;
 use WPMgr\Agent\Commands\RollbackCommand;
 use WPMgr\Agent\Support\SnapshotManager;
 use WPMgr\Agent\Support\UpdateRunner;
@@ -23,6 +24,15 @@ final class RollbackCommandTest extends TestCase
 {
     /** Absolute path to the `.maintenance` marker under the test ABSPATH. */
     private string $maintenanceFile = '';
+
+    /**
+     * Spy for delete_site_transient() calls (completeness sweep — a
+     * successful rollback must invalidate the relevant update transient so
+     * the rolled-back-FROM version stops being offered as an "update").
+     *
+     * @var array<int,string>
+     */
+    private array $deletedTransients = [];
 
     protected function set_up(): void
     {
@@ -37,6 +47,18 @@ final class RollbackCommandTest extends TestCase
         if (file_exists($this->maintenanceFile)) {
             unlink($this->maintenanceFile); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
         }
+
+        // Stubbed unconditionally (rather than per-test) so every test in
+        // this file behaves predictably regardless of PHPUnit's run order —
+        // once ANY test in the process defines delete_site_transient as a
+        // Brain Monkey stub, function_exists('delete_site_transient') is
+        // true for every subsequent test, so an unstubbed call elsewhere
+        // would otherwise raise an "unmocked function" error.
+        $this->deletedTransients = [];
+        Functions\when('delete_site_transient')->alias(function (string $key): bool {
+            $this->deletedTransients[] = $key;
+            return true;
+        });
     }
 
     protected function tear_down(): void
@@ -202,6 +224,104 @@ final class RollbackCommandTest extends TestCase
 
         $this->assertTrue($out['ok']);
         $this->assertSame(['6.2.0'], $runner->forced);
+    }
+
+    // ---- transient invalidation completeness sweep (GH #211/#212 cluster) -
+
+    /**
+     * A successful plugin restore must invalidate `update_plugins` so the
+     * rolled-back-FROM version stops being cached as an "available update"
+     * (feeding the #211 phantom / a re-apply loop) before the CP's next
+     * metadata pull re-reads the transient.
+     */
+    public function test_successful_plugin_rollback_deletes_update_plugins_transient(): void
+    {
+        $cmd = new RollbackCommand($this->spySnapshots(true), $this->spyRunner());
+
+        $out = $cmd->execute([], [
+            'type'        => 'plugin',
+            'slug'        => 'akismet/akismet.php',
+            'snapshot_id' => 'snap_abc',
+        ]);
+
+        $this->assertTrue($out['ok']);
+        $this->assertSame(['update_plugins'], $this->deletedTransients);
+    }
+
+    /**
+     * Theme-side sibling of the plugin test above.
+     */
+    public function test_successful_theme_rollback_deletes_update_themes_transient(): void
+    {
+        $cmd = new RollbackCommand($this->spySnapshots(true), $this->spyRunner());
+
+        $out = $cmd->execute([], [
+            'type'        => 'theme',
+            'slug'        => 'twentytwentyfour',
+            'snapshot_id' => 'snap_abc',
+        ]);
+
+        $this->assertTrue($out['ok']);
+        $this->assertSame(['update_themes'], $this->deletedTransients);
+    }
+
+    /**
+     * Core-side sibling: a successful core downgrade must invalidate
+     * `update_core` so the pre-rollback "current" version WordPress cached
+     * stops being offered as an update.
+     */
+    public function test_successful_core_rollback_deletes_update_core_transient(): void
+    {
+        $runner = $this->spyRunner(true);
+        $runner->versions['core:core'] = '6.3.2';
+        $cmd = new RollbackCommand($this->spySnapshots(true), $runner);
+
+        $out = $cmd->execute([], [
+            'type'        => 'core',
+            'snapshot_id' => 'snap_core',
+            'to_version'  => '6.3.2',
+        ]);
+
+        $this->assertTrue($out['ok']);
+        $this->assertSame(['update_core'], $this->deletedTransients);
+    }
+
+    /**
+     * A FAILED restore must not invalidate the transient — there is nothing
+     * to invalidate against, and doing so would just cause an extra wp.org
+     * re-check for no reason.
+     */
+    public function test_failed_plugin_rollback_does_not_delete_any_transient(): void
+    {
+        $cmd = new RollbackCommand($this->spySnapshots(false), $this->spyRunner());
+
+        $out = $cmd->execute([], [
+            'type'        => 'plugin',
+            'slug'        => 'akismet/akismet.php',
+            'snapshot_id' => 'snap_abc',
+        ]);
+
+        $this->assertFalse($out['ok']);
+        $this->assertSame([], $this->deletedTransients);
+    }
+
+    /**
+     * A FAILED core rollback (forceCore returns ok=false) must likewise not
+     * invalidate `update_core`.
+     */
+    public function test_failed_core_rollback_does_not_delete_update_core_transient(): void
+    {
+        $runner = $this->spyRunner(false);
+        $cmd    = new RollbackCommand($this->spySnapshots(true), $runner);
+
+        $out = $cmd->execute([], [
+            'type'        => 'core',
+            'snapshot_id' => 'snap_core',
+            'to_version'  => '6.3.2',
+        ]);
+
+        $this->assertFalse($out['ok']);
+        $this->assertSame([], $this->deletedTransients);
     }
 
     public function test_invalid_type_is_rejected(): void

--- a/apps/agent/tests/SchedulerTest.php
+++ b/apps/agent/tests/SchedulerTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * SchedulerTest — GitHub issue #212: refreshUpdateTransients()'s `$force`
+ * flag only ever bypassed WPMgr's OWN 5-minute REFRESH_LOCK_KEY throttle; it
+ * never bypassed WordPress core's own ~12h `update_plugins`/`update_themes`/
+ * `update_core` transient throttle, so a human-initiated "Refresh" on the
+ * dashboard would often silently no-op against a still-fresh core transient
+ * and require several clicks to actually reach wp.org.
+ *
+ * These tests exercise Scheduler::refreshUpdateTransients() directly (via
+ * ReflectionClass::newInstanceWithoutConstructor() — the method under test
+ * never touches $settings/$enrollment/$lifecycle, only the WP transient/
+ * update-check functions, so constructing the real (final, heavy-dependency)
+ * collaborators would add nothing; see RouterTest.php for the identical
+ * precedent) and prove:
+ *   1. force=true deletes ALL THREE site transients (update_plugins,
+ *      update_themes, update_core) BEFORE re-checking, and passes `true` as
+ *      wp_version_check()'s second (bypass-cache) argument — even when
+ *      WPMgr's own REFRESH_LOCK_KEY lock is still held, i.e. the human
+ *      "Refresh" click is not throttled by a refresh that happened <5 min ago.
+ *   2. force=false (the 30-min cron / event-hook path) does NONE of the
+ *      transient deletes and passes `false` as wp_version_check()'s second
+ *      argument, so a bulk plugin/theme toggle (which fires several soft
+ *      refreshes back-to-back via upgrader_process_complete/switch_theme/
+ *      activated_plugin/deactivated_plugin) never hammers wp.org.
+ *
+ * Note: the existing RefreshInventoryCommandTest injects closures for its
+ * collaborators and therefore never exercises the real
+ * Scheduler::refreshUpdateTransients() body — it cannot catch this class of
+ * regression. This suite calls the real method.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Scheduler;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Scheduler
+ */
+final class SchedulerTest extends TestCase
+{
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+    }
+
+    protected function tear_down(): void
+    {
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * Builds a real Scheduler instance without calling __construct — the
+     * constructor requires Settings/Enrollment/Lifecycle (all final, with
+     * their own heavy dependency chains) that refreshUpdateTransients()
+     * never touches.
+     */
+    private function makeScheduler(): Scheduler
+    {
+        return (new \ReflectionClass(Scheduler::class))->newInstanceWithoutConstructor();
+    }
+
+    public function test_force_true_deletes_all_three_transients_and_hard_forces_core_check(): void
+    {
+        // The WPMgr REFRESH_LOCK_KEY is still held (as it would be if a human
+        // clicks Refresh twice within 5 minutes) — force=true must proceed
+        // anyway; get_transient() must not even gate the outcome.
+        Functions\when('get_transient')->justReturn(1);
+        Functions\when('set_transient')->justReturn(true);
+
+        $deletedKeys = [];
+        Functions\expect('delete_site_transient')
+            ->times(3)
+            ->andReturnUsing(function (string $key) use (&$deletedKeys): bool {
+                $deletedKeys[] = $key;
+                return true;
+            });
+
+        Functions\expect('wp_update_plugins')->once();
+        Functions\expect('wp_update_themes')->once();
+        Functions\expect('wp_version_check')->once()->with([], true);
+
+        $this->makeScheduler()->refreshUpdateTransients(true);
+
+        $this->assertSame(
+            ['update_plugins', 'update_themes', 'update_core'],
+            $deletedKeys,
+            'force=true must delete all three site transients before re-checking'
+        );
+    }
+
+    public function test_force_false_never_deletes_transients_and_soft_checks_core(): void
+    {
+        // Lock not held -> the soft path proceeds to the actual (throttled)
+        // WP.org re-checks.
+        Functions\when('get_transient')->justReturn(false);
+        Functions\when('set_transient')->justReturn(true);
+
+        Functions\expect('delete_site_transient')->never();
+        Functions\expect('wp_update_plugins')->once();
+        Functions\expect('wp_update_themes')->once();
+        Functions\expect('wp_version_check')->once()->with([], false);
+
+        $this->makeScheduler()->refreshUpdateTransients(false);
+
+        // The real proof is the mock call-count expectations above (verified
+        // on Monkey\tearDown()); this keeps the test itself non-risky.
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_force_defaults_to_false_when_omitted(): void
+    {
+        // The 30-min cron (runMetadata -> refreshUpdateTransients()) and the
+        // upgrader_process_complete/switch_theme/activated_plugin/
+        // deactivated_plugin event hooks all call with NO argument — the
+        // default must stay soft (false), never hard-forcing.
+        Functions\when('get_transient')->justReturn(false);
+        Functions\when('set_transient')->justReturn(true);
+        Functions\when('wp_update_plugins')->justReturn(null);
+        Functions\when('wp_update_themes')->justReturn(null);
+
+        Functions\expect('delete_site_transient')->never();
+        Functions\expect('wp_version_check')->once()->with([], false);
+
+        $this->makeScheduler()->refreshUpdateTransients();
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/apps/agent/tests/SnapshotManagerTest.php
+++ b/apps/agent/tests/SnapshotManagerTest.php
@@ -622,6 +622,42 @@ final class SnapshotManagerTest extends TestCase
         );
     }
 
+    /**
+     * MEDIUM-2 (GitHub issue #210 security review) — a stranded aside left
+     * behind by an INTERRUPTED update-watchdog restore
+     * (`wpmgr_watchdog_swap_directories()`'s `.wpmgr-watchdog-old-<snap_id>`
+     * naming, not SnapshotManager's own `.wpmgr-old-<snap_id>`) must be
+     * reclaimed by the SAME GC backstop, or it leaks as a permanent ghost
+     * plugin-directory duplicate.
+     */
+    public function test_gc_expired_sweeps_a_stranded_watchdog_aside_past_the_backstop_ttl(): void
+    {
+        $pluginsRoot = $this->root . '/plugins-root-watchdog';
+        mkdir($pluginsRoot . '/demo', 0755, true);
+
+        $strandedWatchdogAside = $pluginsRoot . '/demo.wpmgr-watchdog-old-snap_' . bin2hex(random_bytes(12));
+        mkdir($strandedWatchdogAside, 0755, true);
+        file_put_contents($strandedWatchdogAside . '/demo.php', "<?php\n// Plugin Name: Demo\n");
+        touch($strandedWatchdogAside, time() - (73 * 3600)); // > 72h backstop TTL
+
+        $recentWatchdogAside = $pluginsRoot . '/other.wpmgr-watchdog-old-snap_' . bin2hex(random_bytes(12));
+        mkdir($recentWatchdogAside, 0755, true);
+        touch($recentWatchdogAside, time() - 3600); // 1h — must survive
+
+        $class = $this->managerClassWithPluginRoot($pluginsRoot);
+        $class::gcExpired();
+
+        $this->assertFalse(
+            is_dir($strandedWatchdogAside),
+            'MEDIUM-2: a stranded .wpmgr-watchdog-old-<id> aside past the GC backstop TTL must be swept, same as the original .wpmgr-old-<id> naming'
+        );
+        $this->assertTrue(is_dir($recentWatchdogAside), 'a recent stranded watchdog aside must survive the sweep');
+        $this->assertTrue(
+            is_dir($pluginsRoot . '/demo'),
+            'the sweep must never touch the LIVE plugin directory itself, only the stranded aside sibling'
+        );
+    }
+
     // =========================================================================
     // F1 — recovery from a re-interrupted restore (deterministic aside name)
     // =========================================================================
@@ -930,5 +966,66 @@ final class SnapshotManagerTest extends TestCase
         $this->assertTrue($result['ok']);
         $this->assertSame('v1', file_get_contents($live . '/marker.txt'));
         $this->assertFalse(is_dir($live . '.wpmgr-old-' . $snap['snapshot_id']));
+    }
+
+    // =========================================================================
+    // GitHub issue #210 — resolvedRestorePaths() (update-watchdog ARM step)
+    // =========================================================================
+
+    public function test_resolved_restore_paths_returns_the_live_and_payload_dirs_for_a_real_snapshot(): void
+    {
+        $mgr  = $this->manager();
+        $live = $this->root . '/plugins-src/watchdog-demo';
+        mkdir($live, 0755, true);
+        file_put_contents($live . '/marker.txt', 'v1');
+        $mgr->liveOverride = $live;
+
+        $snap = $mgr->capture('plugin', 'watchdog-demo/watchdog-demo.php', '1.0');
+        $this->assertNotSame('', $snap['snapshot_id']);
+
+        $paths = $mgr->resolvedRestorePaths('plugin', 'watchdog-demo/watchdog-demo.php', $snap['snapshot_id']);
+
+        $this->assertSame($live, $paths['live'], 'resolvedRestorePaths() must return the exact liveDir() resolution');
+        // resolveSnapshotDir() returns a realpath()'d value (e.g. macOS
+        // resolves /var -> /private/var), so compare through realpath() on
+        // both sides rather than asserting exact string identity against a
+        // manually-concatenated (non-canonicalized) expectation.
+        $this->assertSame(
+            realpath($this->snapshotsBase . '/' . $snap['snapshot_id']) . '/payload',
+            $paths['payload'],
+            'resolvedRestorePaths() must return the exact snapshot payload directory'
+        );
+        $this->assertTrue(is_dir($paths['payload']), 'the returned payload dir must actually exist on disk');
+    }
+
+    public function test_resolved_restore_paths_returns_empty_for_an_unknown_snapshot_id(): void
+    {
+        $mgr  = $this->manager();
+        $mgr->liveOverride = $this->root . '/plugins-src/never-captured';
+
+        $paths = $mgr->resolvedRestorePaths('plugin', 'never-captured/never-captured.php', 'snap_' . bin2hex(random_bytes(12)));
+
+        $this->assertSame(['live' => '', 'payload' => ''], $paths);
+    }
+
+    public function test_resolved_restore_paths_returns_empty_when_the_live_dir_cannot_be_resolved(): void
+    {
+        $mgr  = $this->manager();
+        $live = $this->root . '/plugins-src/watchdog-demo2';
+        mkdir($live, 0755, true);
+        file_put_contents($live . '/marker.txt', 'v1');
+        $mgr->liveOverride = $live;
+
+        $snap = $mgr->capture('plugin', 'watchdog-demo2/watchdog-demo2.php', '1.0');
+        $this->assertNotSame('', $snap['snapshot_id']);
+
+        // Simulate liveDir() being unable to resolve (e.g. the live source
+        // has since been removed) — resolvedRestorePaths() must propagate
+        // '' rather than fabricate a path.
+        $mgr->liveOverride = '';
+
+        $paths = $mgr->resolvedRestorePaths('plugin', 'watchdog-demo2/watchdog-demo2.php', $snap['snapshot_id']);
+
+        $this->assertSame(['live' => '', 'payload' => ''], $paths);
     }
 }

--- a/apps/agent/tests/UpdateCommandTest.php
+++ b/apps/agent/tests/UpdateCommandTest.php
@@ -16,6 +16,7 @@ use WPMgr\Agent\Commands\UpdateCommand;
 use WPMgr\Agent\Support\SnapshotManager;
 use WPMgr\Agent\Support\UpdateInFlight;
 use WPMgr\Agent\Support\UpdateRunner;
+use WPMgr\Agent\Support\UpdateWatchdogMarker;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
@@ -1651,6 +1652,248 @@ final class UpdateCommandTest extends TestCase
         );
 
         $this->rrmdir($tmp);
+    }
+
+    // =========================================================================
+    // GitHub issue #210 — update-watchdog ARM step
+    // =========================================================================
+
+    /**
+     * Guard-define WP_CONTENT_DIR (same idiom used elsewhere in this suite —
+     * see SnapshotManagerTest::ensurePluginRootConstants()) and return the
+     * update-watchdog marker file's absolute path.
+     */
+    private function watchdogMarkerFile(): string
+    {
+        if (!defined('WP_CONTENT_DIR')) {
+            define('WP_CONTENT_DIR', sys_get_temp_dir() . '/wpmgr-shared-wp-content');
+        }
+        if (!is_dir(WP_CONTENT_DIR)) {
+            mkdir(WP_CONTENT_DIR, 0755, true);
+        }
+
+        return rtrim((string) WP_CONTENT_DIR, '/\\') . '/wpmgr-update-watchdog/watchdog-marker.json';
+    }
+
+    private function cleanWatchdogMarker(): void
+    {
+        $file = $this->watchdogMarkerFile();
+        if (file_exists($file)) {
+            unlink($file); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        }
+    }
+
+    /**
+     * A snapshot spy whose resolvedRestorePaths() returns fixed, controlled
+     * absolute paths (rather than the real WP_PLUGIN_DIR/uploads-dependent
+     * resolution), so the ARM step under test can be exercised deterministically.
+     */
+    private function spySnapshotsWithResolvedPaths(string $live, string $payload): SnapshotManager
+    {
+        return new class ($live, $payload) extends SnapshotManager {
+            /** @var array<int,array{string,string,string}> */
+            public array $captured = [];
+
+            public function __construct(private string $live, private string $payload)
+            {
+            }
+
+            public function capture(string $type, string $slug, string $fromVersion): array
+            {
+                $this->captured[] = [$type, $slug, $fromVersion];
+
+                return ['snapshot_id' => 'snap_test123', 'log' => 'captured'];
+            }
+
+            public function restore(string $type, string $slug, string $snapshotId): array
+            {
+                return ['ok' => true, 'log' => 'restored'];
+            }
+
+            public function snapshotExists(string $snapshotId): bool
+            {
+                return true;
+            }
+
+            public function resolvedRestorePaths(string $type, string $slug, string $snapshotId): array
+            {
+                return ['live' => $this->live, 'payload' => $this->payload];
+            }
+        };
+    }
+
+    public function test_successful_apply_arms_the_update_watchdog_marker_with_the_resolved_absolute_paths(): void
+    {
+        $this->cleanWatchdogMarker();
+
+        $live    = sys_get_temp_dir() . '/wpmgr-watchdog-arm-live-' . bin2hex(random_bytes(6));
+        $payload = sys_get_temp_dir() . '/wpmgr-watchdog-arm-payload-' . bin2hex(random_bytes(6));
+        mkdir($live, 0755, true);
+        mkdir($payload, 0755, true);
+
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php'] = '5.0';
+
+        $snapshots = $this->spySnapshotsWithResolvedPaths($live, $payload);
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $before = time();
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => '5.3']],
+        ]);
+        $after = time();
+
+        $this->assertSame('succeeded', $out['results'][0]['status']);
+        $this->assertFileExists($this->watchdogMarkerFile(), 'a succeeded plugin apply must arm the update-watchdog marker');
+
+        $decoded = json_decode((string) file_get_contents($this->watchdogMarkerFile()), true);
+        $this->assertCount(1, $decoded['markers']);
+        $entry = $decoded['markers'][0];
+        $this->assertSame('plugin', $entry['type']);
+        $this->assertSame('akismet/akismet.php', $entry['slug']);
+        $this->assertSame('snap_test123', $entry['snapshot_id']);
+        $this->assertSame($live, $entry['live_dir']);
+        $this->assertSame($payload, $entry['payload_dir']);
+        $this->assertSame('5.3', $entry['to_version'], 'MEDIUM-1b: the armed to_version must be threaded through from UpdateCommand');
+
+        $ttl = $entry['expires_at'] - $entry['applied_at'];
+        $this->assertSame(UpdateWatchdogMarker::TTL_SECONDS, $ttl);
+        $this->assertLessThan(600, $ttl, 'ARM test: TTL must be strictly less than SnapshotManager::MIN_KEEP_AGE_SECONDS (600)');
+        $this->assertGreaterThanOrEqual($before, $entry['applied_at']);
+        $this->assertLessThanOrEqual($after, $entry['applied_at']);
+
+        $this->rrmdir($live);
+        $this->rrmdir($payload);
+        $this->cleanWatchdogMarker();
+    }
+
+    public function test_failed_apply_does_not_arm_the_update_watchdog_marker(): void
+    {
+        $this->cleanWatchdogMarker();
+
+        $live    = sys_get_temp_dir() . '/wpmgr-watchdog-arm-live-' . bin2hex(random_bytes(6));
+        $payload = sys_get_temp_dir() . '/wpmgr-watchdog-arm-payload-' . bin2hex(random_bytes(6));
+        mkdir($live, 0755, true);
+        mkdir($payload, 0755, true);
+
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php'] = '5.0';
+        $runner->applySucceeds = false;
+
+        $snapshots = $this->spySnapshotsWithResolvedPaths($live, $payload);
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => '5.3']],
+        ]);
+
+        $this->assertSame('failed', $out['results'][0]['status']);
+        $this->assertFileDoesNotExist($this->watchdogMarkerFile(), 'a failed apply must never arm the update-watchdog marker');
+
+        $this->rrmdir($live);
+        $this->rrmdir($payload);
+    }
+
+    public function test_skipped_apply_does_not_arm_the_update_watchdog_marker(): void
+    {
+        $this->cleanWatchdogMarker();
+
+        $live    = sys_get_temp_dir() . '/wpmgr-watchdog-arm-live-' . bin2hex(random_bytes(6));
+        $payload = sys_get_temp_dir() . '/wpmgr-watchdog-arm-payload-' . bin2hex(random_bytes(6));
+        mkdir($live, 0755, true);
+        mkdir($payload, 0755, true);
+
+        $runner = $this->spyRunner();
+        // No version seeded -> isInstalled() reports false -> skipped.
+        $snapshots = $this->spySnapshotsWithResolvedPaths($live, $payload);
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'never-installed/never-installed.php', 'version' => 'latest']],
+        ]);
+
+        $this->assertSame('skipped', $out['results'][0]['status']);
+        $this->assertFileDoesNotExist($this->watchdogMarkerFile(), 'a skipped (not-installed) item must never arm the update-watchdog marker');
+
+        $this->rrmdir($live);
+        $this->rrmdir($payload);
+    }
+
+    public function test_up_to_date_apply_does_not_arm_the_update_watchdog_marker(): void
+    {
+        $this->cleanWatchdogMarker();
+
+        $live    = sys_get_temp_dir() . '/wpmgr-watchdog-arm-live-' . bin2hex(random_bytes(6));
+        $payload = sys_get_temp_dir() . '/wpmgr-watchdog-arm-payload-' . bin2hex(random_bytes(6));
+        mkdir($live, 0755, true);
+        mkdir($payload, 0755, true);
+
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php']  = '5.3';
+        $runner->available['plugin:akismet/akismet.php'] = '5.3';
+
+        $snapshots = $this->spySnapshotsWithResolvedPaths($live, $payload);
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => '5.3']],
+        ]);
+
+        $this->assertSame('up_to_date', $out['results'][0]['status']);
+        $this->assertFileDoesNotExist($this->watchdogMarkerFile(), 'an up_to_date item must never arm the update-watchdog marker — nothing changed to guard against');
+
+        $this->rrmdir($live);
+        $this->rrmdir($payload);
+    }
+
+    public function test_core_succeeded_apply_never_arms_the_update_watchdog_marker(): void
+    {
+        $this->cleanWatchdogMarker();
+
+        $live    = sys_get_temp_dir() . '/wpmgr-watchdog-arm-live-' . bin2hex(random_bytes(6));
+        $payload = sys_get_temp_dir() . '/wpmgr-watchdog-arm-payload-' . bin2hex(random_bytes(6));
+        mkdir($live, 0755, true);
+        mkdir($payload, 0755, true);
+
+        $runner = $this->spyRunner();
+        $runner->versions['core:core'] = '6.4.2';
+
+        $snapshots = $this->spySnapshotsWithResolvedPaths($live, $payload);
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'snapshot' => true,
+            'items'    => [['type' => 'core', 'slug' => 'core', 'version' => '6.4.3']],
+        ]);
+
+        $this->assertSame('succeeded', $out['results'][0]['status']);
+        $this->assertFileDoesNotExist(
+            $this->watchdogMarkerFile(),
+            'core has no directory-level snapshot (D3) and must never arm the update-watchdog marker, even when the apply itself succeeded'
+        );
+
+        $this->rrmdir($live);
+        $this->rrmdir($payload);
+    }
+
+    public function test_arm_is_skipped_when_resolved_restore_paths_cannot_be_determined(): void
+    {
+        $this->cleanWatchdogMarker();
+
+        // resolvedRestorePaths() returning empty strings (e.g. the live
+        // directory could not be resolved) must never write a marker.
+        $snapshots = $this->spySnapshotsWithResolvedPaths('', '');
+
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php'] = '5.0';
+        $cmd = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => '5.3']],
+        ]);
+
+        $this->assertSame('succeeded', $out['results'][0]['status'], 'the apply itself must still succeed');
+        $this->assertFileDoesNotExist($this->watchdogMarkerFile(), 'an unresolvable live/payload path must silently skip arming, never affect the response');
     }
 
     /** Recursive delete used only for test fixture cleanup. */

--- a/apps/agent/tests/UpdateRunnerAvailabilityTest.php
+++ b/apps/agent/tests/UpdateRunnerAvailabilityTest.php
@@ -45,6 +45,17 @@ final class UpdateRunnerAvailabilityTest extends TestCase
     {
         parent::set_up();
         Monkey\setUp();
+
+        // GH #212 residual-gap fix: pluginUpdateVersion()/themeUpdateVersion()
+        // now delete_site_transient() the relevant transient before forcing a
+        // fresh wp_update_plugins()/wp_update_themes() check (closing the
+        // off-cron 12h-throttle gap). Stub unconditionally, matching this
+        // suite's own convention (see class doc / sibling suites): once any
+        // test in the process defines delete_site_transient as a Brain Monkey
+        // stub, function_exists('delete_site_transient') is true for every
+        // subsequent test, so every test here must have a stub in place
+        // rather than risk an "unmocked function" error depending on run order.
+        Functions\when('delete_site_transient')->justReturn(true);
     }
 
     protected function tear_down(): void

--- a/apps/agent/tests/UpdateWatchdogMarkerTest.php
+++ b/apps/agent/tests/UpdateWatchdogMarkerTest.php
@@ -1,0 +1,477 @@
+<?php
+/**
+ * UpdateWatchdogMarkerTest — GitHub issue #210 (update-watchdog mu-plugin).
+ *
+ * Covers the ARM-side marker writer: schema, storage location, the TTL
+ * bound (< SnapshotManager::MIN_KEEP_AGE_SECONDS), per-slug refresh
+ * semantics across a multi-item batch, opportunistic pruning of expired
+ * sibling entries, self-protection against arming for the running agent's
+ * own plugin directory, and stale-claim-file GC.
+ *
+ * Also covers MEDIUM-1b (GitHub issue #210 security review): clearSlug()'s
+ * single-entry removal, and disarmHealthy()'s fail-closed healthy-boot
+ * disarm (active + on-disk at the armed to_version clears; not-yet-updated,
+ * absent, or inactive stays armed; sibling entries always untouched).
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Support\SnapshotManager;
+use WPMgr\Agent\Support\UpdateWatchdogMarker;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\UpdateWatchdogMarker
+ */
+final class UpdateWatchdogMarkerTest extends TestCase
+{
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+        $this->cleanState();
+    }
+
+    protected function tear_down(): void
+    {
+        $this->cleanState();
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * Guard-define WP_CONTENT_DIR (may already be a frozen global PHP
+     * constant from another test file in this same PHPUnit process — same
+     * idiom as SnapshotManagerTest::ensurePluginRootConstants()) and return
+     * the watchdog state directory the marker file lives under.
+     */
+    private function stateDir(): string
+    {
+        if (!defined('WP_CONTENT_DIR')) {
+            define('WP_CONTENT_DIR', sys_get_temp_dir() . '/wpmgr-shared-wp-content');
+        }
+        if (!is_dir(WP_CONTENT_DIR)) {
+            mkdir(WP_CONTENT_DIR, 0755, true);
+        }
+
+        return rtrim((string) WP_CONTENT_DIR, '/\\') . '/wpmgr-update-watchdog';
+    }
+
+    private function markerFile(): string
+    {
+        return $this->stateDir() . '/watchdog-marker.json';
+    }
+
+    private function cleanState(): void
+    {
+        $dir = $this->stateDir();
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir) ?: [];
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            unlink($dir . '/' . $item); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test fixture cleanup
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readMarkerFile(): array
+    {
+        $raw = file_get_contents($this->markerFile());
+        $decoded = json_decode((string) $raw, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    // =========================================================================
+    // Schema, storage location, TTL
+    // =========================================================================
+
+    public function test_arm_writes_the_marker_file_at_the_wp_content_based_state_dir_with_correct_schema(): void
+    {
+        // arm() persists these as opaque, already-validated strings — it
+        // does not require them to exist on disk (SnapshotManager::
+        // resolvedRestorePaths() is what enforces that BEFORE arm() is ever
+        // called; see UpdateCommandTest's ARM tests for that end-to-end path).
+        $live    = sys_get_temp_dir() . '/wpmgr-watchdog-marker-test-live-' . bin2hex(random_bytes(6));
+        $payload = sys_get_temp_dir() . '/wpmgr-watchdog-marker-test-payload-' . bin2hex(random_bytes(6));
+
+        $before = time();
+        UpdateWatchdogMarker::arm('plugin', 'demo/demo.php', 'snap_test123', $live, $payload, '5.3.0');
+        $after = time();
+
+        $this->assertFileExists($this->markerFile(), 'arm() must write the marker file at the WP_CONTENT_DIR-based state dir');
+
+        $decoded = $this->readMarkerFile();
+        $this->assertArrayHasKey('markers', $decoded);
+        $this->assertCount(1, $decoded['markers']);
+
+        $entry = $decoded['markers'][0];
+        $this->assertSame('plugin', $entry['type']);
+        $this->assertSame('demo/demo.php', $entry['slug']);
+        $this->assertSame('snap_test123', $entry['snapshot_id']);
+        $this->assertSame(rtrim($live, '/\\'), $entry['live_dir']);
+        $this->assertSame(rtrim($payload, '/\\'), $entry['payload_dir']);
+        $this->assertSame('5.3.0', $entry['to_version'], 'the armed target version (MEDIUM-1b disarm input) must be persisted');
+        $this->assertGreaterThanOrEqual($before, $entry['applied_at']);
+        $this->assertLessThanOrEqual($after, $entry['applied_at']);
+
+        $ttl = $entry['expires_at'] - $entry['applied_at'];
+        $this->assertSame(UpdateWatchdogMarker::TTL_SECONDS, $ttl, 'the persisted TTL must exactly match TTL_SECONDS');
+        $this->assertLessThan(
+            600,
+            $ttl,
+            'TTL MUST stay strictly less than SnapshotManager::MIN_KEEP_AGE_SECONDS (600) so the marker can never outlive the snapshot retention floor'
+        );
+        $this->assertGreaterThanOrEqual(180, $ttl, 'TTL must still comfortably overlap the ~1-minute CP post-update health-probe window');
+    }
+
+    public function test_arm_no_ops_silently_on_missing_arguments(): void
+    {
+        UpdateWatchdogMarker::arm('', 'slug', 'snap_x', '/live', '/payload');
+        UpdateWatchdogMarker::arm('plugin', '', 'snap_x', '/live', '/payload');
+        UpdateWatchdogMarker::arm('plugin', 'slug', '', '/live', '/payload');
+        UpdateWatchdogMarker::arm('plugin', 'slug', 'snap_x', '', '/payload');
+        UpdateWatchdogMarker::arm('plugin', 'slug', 'snap_x', '/live', '');
+        UpdateWatchdogMarker::arm('core', 'core', 'snap_x', '/live', '/payload');
+
+        $this->assertFileDoesNotExist($this->markerFile(), 'arm() must never write a file for an incomplete or non-plugin/theme call');
+    }
+
+    // =========================================================================
+    // Multi-item batch: per-slug refresh, sibling entries preserved
+    // =========================================================================
+
+    public function test_arming_a_second_slug_preserves_the_first_slugs_entry(): void
+    {
+        $tmp = sys_get_temp_dir();
+        $liveA = $tmp . '/wpmgr-watchdog-a';
+        $liveB = $tmp . '/wpmgr-watchdog-b';
+        $payloadA = $tmp . '/wpmgr-watchdog-snap-a-payload';
+        $payloadB = $tmp . '/wpmgr-watchdog-snap-b-payload';
+
+        UpdateWatchdogMarker::arm('plugin', 'a/a.php', 'snap_a', $liveA, $payloadA);
+        UpdateWatchdogMarker::arm('plugin', 'b/b.php', 'snap_b', $liveB, $payloadB);
+
+        $decoded = $this->readMarkerFile();
+        $this->assertCount(2, $decoded['markers'], 'both items from the same batch must have their own surviving entry');
+
+        $slugs = array_column($decoded['markers'], 'slug');
+        $this->assertContains('a/a.php', $slugs);
+        $this->assertContains('b/b.php', $slugs);
+    }
+
+    public function test_rearming_the_same_slug_refreshes_in_place_rather_than_duplicating(): void
+    {
+        $tmp = sys_get_temp_dir();
+        $live = $tmp . '/wpmgr-watchdog-demo';
+        $payload1 = $tmp . '/wpmgr-watchdog-snap-1-payload';
+        $payload2 = $tmp . '/wpmgr-watchdog-snap-2-payload';
+
+        UpdateWatchdogMarker::arm('plugin', 'demo/demo.php', 'snap_1', $live, $payload1);
+        UpdateWatchdogMarker::arm('plugin', 'demo/demo.php', 'snap_2', $live, $payload2);
+
+        $decoded = $this->readMarkerFile();
+        $this->assertCount(1, $decoded['markers'], 're-arming the exact same type/slug must refresh in place, not accumulate');
+        $this->assertSame('snap_2', $decoded['markers'][0]['snapshot_id'], 'the LATEST apply for a slug must win');
+    }
+
+    public function test_arm_opportunistically_prunes_an_already_expired_sibling_entry(): void
+    {
+        $tmp = sys_get_temp_dir();
+        $liveExpired  = $tmp . '/wpmgr-watchdog-expired';
+        $liveFresh    = $tmp . '/wpmgr-watchdog-fresh';
+        $payloadStale = $tmp . '/wpmgr-watchdog-snap-stale-payload';
+        $payloadFresh = $tmp . '/wpmgr-watchdog-snap-fresh-payload';
+
+        // Seed a marker file directly with an already-expired entry (as if
+        // arm() had written it long ago and its TTL has since elapsed).
+        $dir = $this->stateDir();
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+        file_put_contents($this->markerFile(), (string) json_encode([
+            'markers' => [[
+                'type'        => 'plugin',
+                'slug'        => 'expired/expired.php',
+                'snapshot_id' => 'snap_stale',
+                'live_dir'    => $liveExpired,
+                'payload_dir' => $payloadStale,
+                'applied_at'  => time() - 1000,
+                'expires_at'  => time() - 700,
+            ]],
+        ]));
+
+        UpdateWatchdogMarker::arm('plugin', 'fresh/fresh.php', 'snap_fresh', $liveFresh, $payloadFresh);
+
+        $decoded = $this->readMarkerFile();
+        $slugs = array_column($decoded['markers'], 'slug');
+        $this->assertNotContains('expired/expired.php', $slugs, 'an expired sibling entry must be pruned opportunistically');
+        $this->assertContains('fresh/fresh.php', $slugs);
+    }
+
+    // =========================================================================
+    // Self-protection: never arm against the running agent's own plugin dir
+    // =========================================================================
+
+    public function test_arm_refuses_to_arm_against_the_running_agents_own_plugin_directory(): void
+    {
+        $this->assertTrue(defined('WPMGR_AGENT_DIR'), 'precondition: WPMGR_AGENT_DIR must be defined by the test bootstrap');
+        $selfDir = rtrim((string) constant('WPMGR_AGENT_DIR'), '/\\');
+
+        $payload = sys_get_temp_dir() . '/wpmgr-watchdog-snap-self-payload';
+
+        UpdateWatchdogMarker::arm('plugin', 'wpmgr-agent/wpmgr-agent.php', 'snap_self', $selfDir, $payload);
+
+        $this->assertFileDoesNotExist(
+            $this->markerFile(),
+            'arm() must refuse to write ANY marker when live_dir resolves to the running agent\'s own plugin directory'
+        );
+    }
+
+    // =========================================================================
+    // Stale claim-file GC
+    // =========================================================================
+
+    public function test_arm_sweeps_stale_claim_sentinels_but_keeps_recent_ones(): void
+    {
+        $dir = $this->stateDir();
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $staleClaim  = $dir . '/watchdog-claim-snap_old.claim';
+        $recentClaim = $dir . '/watchdog-claim-snap_new.claim';
+        touch($staleClaim, time() - 7200); // 2h — past the 1h stale threshold
+        touch($recentClaim, time() - 60);  // 1m — must survive
+
+        $live    = sys_get_temp_dir() . '/wpmgr-watchdog-claim-sweep-demo';
+        $payload = sys_get_temp_dir() . '/wpmgr-watchdog-claim-sweep-demo-payload';
+
+        UpdateWatchdogMarker::arm('plugin', 'demo/demo.php', 'snap_demo', $live, $payload);
+
+        $this->assertFileDoesNotExist($staleClaim, 'a claim sentinel older than the stale threshold must be swept on the next arm()');
+        $this->assertFileExists($recentClaim, 'a recent claim sentinel must survive the sweep');
+    }
+
+    // =========================================================================
+    // SnapshotManager::resolvedRestorePaths() -> UpdateWatchdogMarker::arm()
+    // end-to-end wiring sanity (real SnapshotManager, real disk paths)
+    // =========================================================================
+
+    public function test_end_to_end_resolved_paths_from_a_real_snapshot_manager_arm_successfully(): void
+    {
+        $uploadsDir = sys_get_temp_dir() . '/wpmgr-watchdog-e2e-' . bin2hex(random_bytes(6));
+        mkdir($uploadsDir, 0755, true);
+        \Brain\Monkey\Functions\when('wp_upload_dir')->justReturn(['basedir' => $uploadsDir]);
+
+        $mgr  = new class extends SnapshotManager {
+            public string $liveOverride = '';
+
+            protected function liveDir(string $type, string $slug): string
+            {
+                return $this->liveOverride;
+            }
+        };
+        $live = sys_get_temp_dir() . '/wpmgr-watchdog-e2e-live-' . bin2hex(random_bytes(6));
+        mkdir($live, 0755, true);
+        file_put_contents($live . '/marker.txt', 'v1');
+        $mgr->liveOverride = $live;
+
+        $snap = $mgr->capture('plugin', 'e2e-demo/e2e-demo.php', '1.0');
+        $this->assertNotSame('', $snap['snapshot_id']);
+
+        $paths = $mgr->resolvedRestorePaths('plugin', 'e2e-demo/e2e-demo.php', $snap['snapshot_id']);
+        $this->assertNotSame('', $paths['live']);
+        $this->assertNotSame('', $paths['payload']);
+
+        UpdateWatchdogMarker::arm('plugin', 'e2e-demo/e2e-demo.php', $snap['snapshot_id'], $paths['live'], $paths['payload']);
+
+        $decoded = $this->readMarkerFile();
+        $this->assertCount(1, $decoded['markers']);
+        $this->assertSame($paths['live'], $decoded['markers'][0]['live_dir']);
+        $this->assertSame($paths['payload'], $decoded['markers'][0]['payload_dir']);
+
+        $this->rrmdir($uploadsDir);
+        $this->rrmdir($live);
+    }
+
+    // =========================================================================
+    // MEDIUM-1b (GitHub issue #210 security review) — clearSlug() / disarmHealthy()
+    // =========================================================================
+
+    public function test_clear_slug_removes_only_the_matching_entry_and_leaves_other_slugs_entries_untouched(): void
+    {
+        $tmp = sys_get_temp_dir();
+        UpdateWatchdogMarker::arm('plugin', 'a/a.php', 'snap_a', $tmp . '/wpmgr-watchdog-live-a', $tmp . '/wpmgr-watchdog-payload-a', '2.0');
+        UpdateWatchdogMarker::arm('plugin', 'b/b.php', 'snap_b', $tmp . '/wpmgr-watchdog-live-b', $tmp . '/wpmgr-watchdog-payload-b', '3.0');
+
+        UpdateWatchdogMarker::clearSlug('plugin', 'a/a.php');
+
+        $decoded = $this->readMarkerFile();
+        $this->assertCount(1, $decoded['markers'], 'clearSlug() must remove ONLY the matching entry');
+        $this->assertSame('b/b.php', $decoded['markers'][0]['slug'], "other slugs' entries must be left completely untouched");
+        $this->assertSame('3.0', $decoded['markers'][0]['to_version']);
+    }
+
+    public function test_clear_slug_deletes_the_marker_file_entirely_once_the_last_entry_is_removed(): void
+    {
+        $tmp = sys_get_temp_dir();
+        UpdateWatchdogMarker::arm('plugin', 'solo/solo.php', 'snap_solo', $tmp . '/wpmgr-watchdog-live-solo', $tmp . '/wpmgr-watchdog-payload-solo', '1.5');
+        $this->assertFileExists($this->markerFile());
+
+        UpdateWatchdogMarker::clearSlug('plugin', 'solo/solo.php');
+
+        $this->assertFileDoesNotExist(
+            $this->markerFile(),
+            'clearing the only entry must delete the marker file, not leave an empty {"markers":[]} behind'
+        );
+    }
+
+    public function test_clear_slug_is_a_silent_no_op_when_no_marker_file_exists(): void
+    {
+        UpdateWatchdogMarker::clearSlug('plugin', 'never-armed/never-armed.php');
+        $this->assertFileDoesNotExist($this->markerFile());
+    }
+
+    public function test_disarm_healthy_clears_a_slug_that_is_active_and_on_disk_at_the_armed_version(): void
+    {
+        $tmp = sys_get_temp_dir();
+        UpdateWatchdogMarker::arm('plugin', 'demo/demo.php', 'snap_demo', $tmp . '/wpmgr-watchdog-live-demo', $tmp . '/wpmgr-watchdog-payload-demo', '2.0');
+
+        Functions\when('get_plugins')->justReturn(['demo/demo.php' => ['Version' => '2.0']]);
+        Functions\when('is_plugin_active')->justReturn(true);
+
+        UpdateWatchdogMarker::disarmHealthy();
+
+        $this->assertFileDoesNotExist(
+            $this->markerFile(),
+            'a healthy boot with the slug active and at the armed version must clear that entry'
+        );
+    }
+
+    public function test_disarm_healthy_leaves_a_slug_armed_when_the_on_disk_version_has_not_reached_the_armed_target(): void
+    {
+        $tmp = sys_get_temp_dir();
+        UpdateWatchdogMarker::arm('plugin', 'demo/demo.php', 'snap_demo', $tmp . '/wpmgr-watchdog-live-demo2', $tmp . '/wpmgr-watchdog-payload-demo2', '2.0');
+
+        // On-disk version is STILL the pre-update one — not yet at the armed target.
+        Functions\when('get_plugins')->justReturn(['demo/demo.php' => ['Version' => '1.9']]);
+        Functions\when('is_plugin_active')->justReturn(true);
+
+        UpdateWatchdogMarker::disarmHealthy();
+
+        $decoded = $this->readMarkerFile();
+        $this->assertCount(1, $decoded['markers'], 'a slug NOT yet at the armed version must be left armed');
+        $this->assertSame('demo/demo.php', $decoded['markers'][0]['slug']);
+    }
+
+    public function test_disarm_healthy_leaves_a_slug_armed_when_it_is_absent_from_get_plugins(): void
+    {
+        $tmp = sys_get_temp_dir();
+        UpdateWatchdogMarker::arm('plugin', 'demo/demo.php', 'snap_demo', $tmp . '/wpmgr-watchdog-live-demo3', $tmp . '/wpmgr-watchdog-payload-demo3', '2.0');
+
+        // The slug is simply not present at all.
+        Functions\when('get_plugins')->justReturn([]);
+        Functions\when('is_plugin_active')->justReturn(true);
+
+        UpdateWatchdogMarker::disarmHealthy();
+
+        $decoded = $this->readMarkerFile();
+        $this->assertCount(1, $decoded['markers'], 'a slug absent from get_plugins() must be left armed, not disarmed');
+    }
+
+    public function test_disarm_healthy_leaves_a_slug_armed_when_installed_at_the_right_version_but_inactive(): void
+    {
+        $tmp = sys_get_temp_dir();
+        UpdateWatchdogMarker::arm('plugin', 'demo/demo.php', 'snap_demo', $tmp . '/wpmgr-watchdog-live-demo4', $tmp . '/wpmgr-watchdog-payload-demo4', '2.0');
+
+        Functions\when('get_plugins')->justReturn(['demo/demo.php' => ['Version' => '2.0']]);
+        Functions\when('is_plugin_active')->justReturn(false);
+        Functions\when('is_plugin_active_for_network')->justReturn(false);
+
+        UpdateWatchdogMarker::disarmHealthy();
+
+        $decoded = $this->readMarkerFile();
+        $this->assertCount(1, $decoded['markers'], 'an installed-but-INACTIVE plugin proves nothing about whether its code loads cleanly — must stay armed');
+    }
+
+    public function test_disarm_healthy_clears_only_the_healthy_slug_and_leaves_other_armed_slugs_entries_untouched(): void
+    {
+        $tmp = sys_get_temp_dir();
+        UpdateWatchdogMarker::arm('plugin', 'healthy/healthy.php', 'snap_healthy', $tmp . '/wpmgr-watchdog-live-healthy', $tmp . '/wpmgr-watchdog-payload-healthy', '2.0');
+        UpdateWatchdogMarker::arm('plugin', 'still-stale/still-stale.php', 'snap_stale', $tmp . '/wpmgr-watchdog-live-stale', $tmp . '/wpmgr-watchdog-payload-stale', '2.0');
+
+        Functions\when('get_plugins')->justReturn([
+            'healthy/healthy.php'         => ['Version' => '2.0'],
+            'still-stale/still-stale.php' => ['Version' => '1.0'], // not yet at its armed target
+        ]);
+        Functions\when('is_plugin_active')->alias(static fn ($slug) => $slug === 'healthy/healthy.php');
+
+        UpdateWatchdogMarker::disarmHealthy();
+
+        $decoded = $this->readMarkerFile();
+        $this->assertCount(1, $decoded['markers'], "other slugs' entries must be untouched — only the healthy one is cleared");
+        $this->assertSame('still-stale/still-stale.php', $decoded['markers'][0]['slug']);
+    }
+
+    public function test_disarm_healthy_clears_a_theme_slug_that_is_the_active_stylesheet_at_the_armed_version(): void
+    {
+        $tmp = sys_get_temp_dir();
+        UpdateWatchdogMarker::arm('theme', 'twentytwentyfour', 'snap_theme', $tmp . '/wpmgr-watchdog-live-theme', $tmp . '/wpmgr-watchdog-payload-theme', '1.2');
+
+        $theme = new class {
+            /** @param string $k Field. @return string */
+            public function get($k): string
+            {
+                return $k === 'Version' ? '1.2' : '';
+            }
+        };
+        Functions\when('wp_get_themes')->justReturn(['twentytwentyfour' => $theme]);
+        Functions\when('get_stylesheet')->justReturn('twentytwentyfour');
+        Functions\when('get_template')->justReturn('twentytwentyfour');
+
+        UpdateWatchdogMarker::disarmHealthy();
+
+        $this->assertFileDoesNotExist($this->markerFile(), 'the active theme at its armed version must be disarmed too');
+    }
+
+    public function test_disarm_healthy_is_a_cheap_no_op_when_no_marker_file_exists(): void
+    {
+        // No arm() call at all — the file must not exist, and disarmHealthy()
+        // must not create one or throw.
+        UpdateWatchdogMarker::disarmHealthy();
+        $this->assertFileDoesNotExist($this->markerFile());
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir) ?: [];
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->rrmdir($path);
+            } else {
+                unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test fixture cleanup
+            }
+        }
+        rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test fixture cleanup
+    }
+}

--- a/apps/agent/tests/UpdateWatchdogRestoreTest.php
+++ b/apps/agent/tests/UpdateWatchdogRestoreTest.php
@@ -1,0 +1,1026 @@
+<?php
+/**
+ * UpdateWatchdogRestoreTest — GitHub issue #210 (update-watchdog mu-plugin).
+ *
+ * Exercises the REAL functions defined in
+ * `mu-plugin-loader/a-wpmgr-update-watchdog.php` directly (never a
+ * hand-copied replica — mirrors WafGateHardeningTest.php's own convention).
+ *
+ * Two groups of coverage:
+ *   1. Restore behavior: given a fresh, unconsumed marker entry + a
+ *      simulated fatal, the live dir is replaced by the snapshot payload and
+ *      the entry is marked consumed (one-shot, via an atomic claim file).
+ *      No-op when: no marker; marker expired; marker already consumed;
+ *      error is null/non-fatal; a real apply is in flight for the same
+ *      slug; the fatal's file cannot be attributed to any entry.
+ *   2. Path-safety regression suite mirroring the GH #147 restore-anchoring
+ *      discipline: exact-path/segment containment, no globbing, an escape
+ *      attempt rejected, the running agent's own plugin dir refused as a
+ *      restore target.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+// Guard: define the testing constant BEFORE requiring the mu-plugin so the
+// top-level register_shutdown_function() call at the bottom of the file is
+// skipped (mirrors a-wpmgr-waf.php's own WPMGR_WAF_TESTING convention).
+if (!defined('WPMGR_WATCHDOG_TESTING')) {
+    define('WPMGR_WATCHDOG_TESTING', true);
+}
+
+// Load the real mu-plugin — defines every wpmgr_watchdog_*() function.
+// function_exists() guard makes this idempotent if another test already
+// loaded it.
+if (!function_exists('wpmgr_watchdog_path_is_within')) {
+    require_once dirname(__DIR__) . '/mu-plugin-loader/a-wpmgr-update-watchdog.php';
+}
+
+/**
+ * @covers wpmgr_watchdog_path_is_within
+ * @covers wpmgr_watchdog_anchored_containment
+ * @covers wpmgr_watchdog_slug_is_safe
+ * @covers wpmgr_watchdog_expected_live_dir
+ * @covers wpmgr_watchdog_expected_payload_dir
+ * @covers wpmgr_watchdog_try_lock_inflight
+ * @covers wpmgr_watchdog_storage_data_base
+ * @covers wpmgr_watchdog_copy_dir
+ * @covers wpmgr_watchdog_delete_dir
+ * @covers wpmgr_watchdog_swap_directories
+ * @covers wpmgr_watchdog_is_self_path
+ * @covers wpmgr_watchdog_attempt_restore
+ * @covers wpmgr_watchdog_process_fatal
+ * @covers wpmgr_watchdog_is_resource_exhaustion_message
+ */
+final class UpdateWatchdogRestoreTest extends TestCase
+{
+    /** Temp root for this test run (removed in tear_down). */
+    private string $root = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->root = sys_get_temp_dir() . '/wpmgr-watchdog-test-' . bin2hex(random_bytes(6));
+        mkdir($this->root, 0755, true);
+
+        // The watchdog state dir (where the marker file AND one-shot claim
+        // sentinels live) is normally created by UpdateWatchdogMarker::arm()
+        // via StoragePaths::ensureHardenedPath(). Tests here call
+        // wpmgr_watchdog_attempt_restore()/wpmgr_watchdog_process_fatal()
+        // directly, bypassing arm() entirely, so it must exist up front for
+        // fopen($claimFile, 'x') to succeed.
+        $this->ensurePluginRootConstants();
+        $stateDir = wpmgr_watchdog_state_dir();
+        if ($stateDir !== '' && !is_dir($stateDir)) {
+            mkdir($stateDir, 0755, true);
+        }
+    }
+
+    protected function tear_down(): void
+    {
+        $this->rrmdir($this->root);
+        $this->cleanSharedWatchdogStateDir();
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * Several tests write directly into the SHARED (WP_CONTENT_DIR-based)
+     * watchdog state directory — the marker file and/or one-shot claim
+     * sentinels. Sweep both after every test so no leftover file from one
+     * test can be mistaken for state by a later test in this same process
+     * (each test uses its own randomly-generated snapshot ids, so this is
+     * pure hygiene, not a correctness dependency).
+     */
+    private function cleanSharedWatchdogStateDir(): void
+    {
+        $dir = wpmgr_watchdog_state_dir();
+        if ($dir === '' || !is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir) ?: [];
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            @unlink($dir . '/' . $item); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test fixture cleanup
+        }
+    }
+
+    // =========================================================================
+    // Fixtures / helpers
+    // =========================================================================
+
+    /**
+     * Guard-define WP_CONTENT_DIR/WP_PLUGIN_DIR (may already be frozen by an
+     * earlier test file in this same PHPUnit process — same idiom as
+     * SnapshotManagerTest::ensurePluginRootConstants()).
+     */
+    private function ensurePluginRootConstants(): string
+    {
+        if (!defined('WP_CONTENT_DIR')) {
+            define('WP_CONTENT_DIR', sys_get_temp_dir() . '/wpmgr-shared-wp-content');
+        }
+        if (!is_dir(WP_CONTENT_DIR)) {
+            mkdir(WP_CONTENT_DIR, 0755, true);
+        }
+        if (!defined('WP_PLUGIN_DIR')) {
+            define('WP_PLUGIN_DIR', rtrim((string) WP_CONTENT_DIR, '/\\') . '/plugins');
+        }
+        if (!is_dir(WP_PLUGIN_DIR)) {
+            mkdir(WP_PLUGIN_DIR, 0755, true);
+        }
+
+        return rtrim((string) WP_PLUGIN_DIR, '/\\');
+    }
+
+    /**
+     * Build a real on-disk plugin directory with a main file, a "loader.php"
+     * (the file the simulated fatal is reported in), and a plain-text
+     * `marker.txt` carrying $content — read back by content assertions so
+     * they never have to account for PHP-file wrapper syntax.
+     *
+     * @return array{slug:string,live:string}
+     */
+    private function makeLivePlugin(string $content = 'BROKEN-UPDATE-CONTENT'): array
+    {
+        $pluginRoot = $this->ensurePluginRootConstants();
+        $folder     = 'watchdog-plugin-' . bin2hex(random_bytes(6));
+        $live       = $pluginRoot . '/' . $folder;
+        mkdir($live, 0755, true);
+        file_put_contents($live . '/' . $folder . '.php', "<?php\n// plugin main file\n");
+        file_put_contents($live . '/loader.php', "<?php\n// loader\n");
+        file_put_contents($live . '/marker.txt', $content);
+
+        return ['slug' => $folder . '/' . $folder . '.php', 'live' => $live];
+    }
+
+    /**
+     * Build a real on-disk snapshot payload directory (mirrors
+     * SnapshotManager's own `<uploads>/wpmgr-snapshots/<id>/payload/` layout)
+     * with one file, and point wp_upload_dir() at $uploadsDir for the
+     * duration of the test.
+     *
+     * @return array{snapshot_id:string,payload:string}
+     */
+    private function makeSnapshotPayload(string $uploadsDir, string $content = 'GOOD-PRE-UPDATE-CONTENT'): array
+    {
+        $snapshotId = 'snap_' . bin2hex(random_bytes(12));
+        $payload    = $uploadsDir . '/wpmgr-snapshots/' . $snapshotId . '/payload';
+        mkdir($payload, 0755, true);
+        file_put_contents($payload . '/marker.txt', $content);
+
+        // Canonicalize (e.g. macOS resolves /var -> /private/var): a real
+        // marker's payload_dir is always the realpath()'d value produced by
+        // SnapshotManager::resolveSnapshotDir() (via
+        // resolvedRestorePaths()) — tests that hand-construct a marker
+        // entry must match that exactly, since
+        // wpmgr_watchdog_expected_payload_dir() independently re-derives
+        // and realpath()'s it too.
+        return ['snapshot_id' => $snapshotId, 'payload' => realpath($payload)];
+    }
+
+    /**
+     * @param array<string,mixed> $overrides
+     * @return array<string,mixed>
+     */
+    private function markerEntry(string $type, string $live, string $snapshotId, string $payload, array $overrides = []): array
+    {
+        $now = time();
+
+        return array_merge([
+            'type'        => $type,
+            'slug'        => self::relativeSlugFor($live),
+            'snapshot_id' => $snapshotId,
+            'live_dir'    => $live,
+            'payload_dir' => $payload,
+            'applied_at'  => $now,
+            'expires_at'  => $now + 300,
+        ], $overrides);
+    }
+
+    /** Derive the plugin slug ("folder/folder.php") a live dir under WP_PLUGIN_DIR corresponds to. */
+    private static function relativeSlugFor(string $live): string
+    {
+        $folder = basename($live);
+
+        return $folder . '/' . $folder . '.php';
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test fixture cleanup
+    }
+
+    // =========================================================================
+    // wpmgr_watchdog_path_is_within() — anchored containment (GH #147 style)
+    // =========================================================================
+
+    public function test_path_is_within_matches_the_exact_directory_and_nested_files(): void
+    {
+        $this->assertTrue(wpmgr_watchdog_path_is_within('/a/b', '/a/b'));
+        $this->assertTrue(wpmgr_watchdog_path_is_within('/a/b/c.php', '/a/b'));
+        $this->assertTrue(wpmgr_watchdog_path_is_within('/a/b/c/d.php', '/a/b'));
+    }
+
+    public function test_path_is_within_rejects_a_sibling_with_a_shared_string_prefix(): void
+    {
+        // GH #147 discipline: /a/bc must NOT be considered "within" /a/b
+        // merely because it shares a string prefix — this is the exact class
+        // of bug an unanchored strpos() check introduced.
+        $this->assertFalse(wpmgr_watchdog_path_is_within('/a/bc/evil.php', '/a/b'));
+        $this->assertFalse(wpmgr_watchdog_path_is_within('/a/bcd.php', '/a/b'));
+    }
+
+    public function test_path_is_within_normalizes_backslashes(): void
+    {
+        $this->assertTrue(wpmgr_watchdog_path_is_within('C:\\a\\b\\c.php', 'C:\\a\\b'));
+    }
+
+    public function test_path_is_within_rejects_empty_inputs(): void
+    {
+        $this->assertFalse(wpmgr_watchdog_path_is_within('', '/a/b'));
+        $this->assertFalse(wpmgr_watchdog_path_is_within('/a/b/c.php', ''));
+    }
+
+    // =========================================================================
+    // wpmgr_watchdog_anchored_containment()
+    // =========================================================================
+
+    public function test_anchored_containment_accepts_root_and_descendants(): void
+    {
+        $this->assertTrue(wpmgr_watchdog_anchored_containment('/plugins', '/plugins'));
+        $this->assertTrue(wpmgr_watchdog_anchored_containment('/plugins', '/plugins/demo'));
+        $this->assertTrue(wpmgr_watchdog_anchored_containment('/plugins', '/plugins/demo/sub/file.php'));
+    }
+
+    public function test_anchored_containment_rejects_traversal_segments(): void
+    {
+        $this->assertFalse(wpmgr_watchdog_anchored_containment('/plugins', '/plugins/../evil'));
+        $this->assertFalse(wpmgr_watchdog_anchored_containment('/plugins', '/plugins/demo/../../evil'));
+    }
+
+    public function test_anchored_containment_rejects_a_sibling_with_a_shared_string_prefix(): void
+    {
+        $this->assertFalse(wpmgr_watchdog_anchored_containment('/plugins', '/plugins-evil/x'));
+    }
+
+    // =========================================================================
+    // wpmgr_watchdog_slug_is_safe()
+    // =========================================================================
+
+    public function test_slug_is_safe_accepts_valid_slugs(): void
+    {
+        $this->assertTrue(wpmgr_watchdog_slug_is_safe('akismet'));
+        $this->assertTrue(wpmgr_watchdog_slug_is_safe('akismet/akismet.php'));
+        $this->assertTrue(wpmgr_watchdog_slug_is_safe('woo-commerce'));
+    }
+
+    /**
+     * @dataProvider unsafeSlugs
+     */
+    public function test_slug_is_safe_rejects_traversal_and_malformed_slugs(string $slug): void
+    {
+        $this->assertFalse(wpmgr_watchdog_slug_is_safe($slug));
+    }
+
+    /**
+     * @return array<int,array{0:string}>
+     */
+    public static function unsafeSlugs(): array
+    {
+        return [
+            [''],
+            ['../evil'],
+            ['../../wp-config.php'],
+            ['/etc/passwd'],
+            ['foo/../../bar'],
+            ['C:\\Windows'],
+            ['..'],
+            ['foo/bar/baz'],
+            ["foo\0bar"],
+        ];
+    }
+
+    public function test_slug_is_safe_accepts_a_bare_dot_the_same_way_upstream_sanitize_slug_does(): void
+    {
+        // A bare "." satisfies UpdateCommand::sanitizeSlug()'s character-class
+        // regex too — this mu-plugin does NOT rely on slug_is_safe() alone to
+        // catch it; wpmgr_watchdog_expected_live_dir() has its OWN additional
+        // guard for exactly this case (see the next test group).
+        $this->assertTrue(wpmgr_watchdog_slug_is_safe('.'));
+    }
+
+    // =========================================================================
+    // wpmgr_watchdog_expected_live_dir() — mirrors SnapshotManager::liveDir()
+    // =========================================================================
+
+    public function test_expected_live_dir_resolves_a_real_plugin_directory(): void
+    {
+        $plugin = $this->makeLivePlugin();
+
+        $result = wpmgr_watchdog_expected_live_dir('plugin', $plugin['slug']);
+
+        $this->assertSame($plugin['live'], $result);
+    }
+
+    public function test_expected_live_dir_resolves_a_real_theme_directory(): void
+    {
+        $pluginRoot = $this->ensurePluginRootConstants();
+        $themeRoot  = rtrim((string) WP_CONTENT_DIR, '/\\') . '/themes';
+        if (!is_dir($themeRoot)) {
+            mkdir($themeRoot, 0755, true);
+        }
+        $slug   = 'watchdog-theme-' . bin2hex(random_bytes(6));
+        $folder = $themeRoot . '/' . $slug;
+        mkdir($folder, 0755, true);
+        file_put_contents($folder . '/style.css', "/*\nTheme Name: Watchdog Test\n*/\n");
+
+        $result = wpmgr_watchdog_expected_live_dir('theme', $slug);
+
+        $this->assertSame($folder, $result);
+    }
+
+    public function test_expected_live_dir_rejects_a_dot_folder_segment_even_though_the_slug_regex_allows_it(): void
+    {
+        $this->ensurePluginRootConstants();
+
+        // A lone "." would otherwise collapse to WP_PLUGIN_DIR itself via
+        // dirname()/realpath() — see this file's own doc for why this extra
+        // guard exists beyond what SnapshotManager::liveDir() checks.
+        $this->assertSame('', wpmgr_watchdog_expected_live_dir('plugin', '.'));
+        $this->assertSame('', wpmgr_watchdog_expected_live_dir('theme', '.'));
+    }
+
+    public function test_expected_live_dir_still_rejects_a_path_escape_even_when_realpath_containment_fails(): void
+    {
+        // Mirrors SnapshotManagerTest's own
+        // test_live_dir_still_rejects_a_path_escape_even_when_realpath_containment_fails.
+        $this->ensurePluginRootConstants();
+        Functions\when('realpath')->justReturn(false);
+
+        $this->assertSame('', wpmgr_watchdog_expected_live_dir('theme', '../../etc/passwd'));
+        $this->assertSame('', wpmgr_watchdog_expected_live_dir('plugin', '../escape/escape.php'));
+    }
+
+    public function test_expected_live_dir_returns_empty_for_an_unknown_type(): void
+    {
+        $this->assertSame('', wpmgr_watchdog_expected_live_dir('core', 'core'));
+        $this->assertSame('', wpmgr_watchdog_expected_live_dir('bogus', 'x'));
+    }
+
+    public function test_expected_live_dir_returns_empty_for_a_source_that_does_not_exist_even_with_the_fallback(): void
+    {
+        $this->ensurePluginRootConstants();
+        Functions\when('realpath')->justReturn(false);
+
+        $this->assertSame(
+            '',
+            wpmgr_watchdog_expected_live_dir('plugin', 'never-installed-' . bin2hex(random_bytes(6)))
+        );
+    }
+
+    // =========================================================================
+    // wpmgr_watchdog_expected_payload_dir()
+    // =========================================================================
+
+    public function test_expected_payload_dir_resolves_a_real_snapshot_payload(): void
+    {
+        $uploadsDir = $this->root . '/uploads';
+        mkdir($uploadsDir, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $uploadsDir]);
+
+        $snap = $this->makeSnapshotPayload($uploadsDir);
+
+        // wpmgr_watchdog_expected_payload_dir() returns a realpath()'d value
+        // (e.g. macOS resolves /var -> /private/var) — compare through
+        // realpath() on both sides rather than asserting exact string
+        // identity against a manually-concatenated expectation.
+        $this->assertSame(
+            realpath(dirname($snap['payload'])) . '/payload',
+            wpmgr_watchdog_expected_payload_dir($snap['snapshot_id'])
+        );
+    }
+
+    public function test_expected_payload_dir_rejects_a_malformed_snapshot_id(): void
+    {
+        $uploadsDir = $this->root . '/uploads';
+        mkdir($uploadsDir, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $uploadsDir]);
+
+        $this->assertSame('', wpmgr_watchdog_expected_payload_dir('../../etc/passwd'));
+        $this->assertSame('', wpmgr_watchdog_expected_payload_dir('snap_ok/../../escape'));
+        $this->assertSame('', wpmgr_watchdog_expected_payload_dir(''));
+    }
+
+    public function test_expected_payload_dir_returns_empty_when_the_payload_subdir_is_missing(): void
+    {
+        $uploadsDir = $this->root . '/uploads';
+        mkdir($uploadsDir, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $uploadsDir]);
+
+        $snapshotId = 'snap_' . bin2hex(random_bytes(12));
+        // Snapshot dir exists but has no payload/ subdir (e.g. a core-only
+        // meta snapshot).
+        mkdir($uploadsDir . '/wpmgr-snapshots/' . $snapshotId, 0755, true);
+
+        $this->assertSame('', wpmgr_watchdog_expected_payload_dir($snapshotId));
+    }
+
+    // =========================================================================
+    // wpmgr_watchdog_try_lock_inflight()
+    // =========================================================================
+
+    public function test_try_lock_inflight_succeeds_when_no_apply_is_in_progress(): void
+    {
+        $uploadsDir = $this->root . '/uploads';
+        mkdir($uploadsDir . '/wpmgr-update-inflight', 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $uploadsDir]);
+
+        $handle = wpmgr_watchdog_try_lock_inflight('plugin', 'demo/demo.php');
+
+        $this->assertIsResource($handle);
+        wpmgr_watchdog_unlock_inflight($handle);
+    }
+
+    public function test_try_lock_inflight_stands_down_when_a_real_apply_holds_the_lock(): void
+    {
+        $uploadsDir = $this->root . '/uploads';
+        $dir        = $uploadsDir . '/wpmgr-update-inflight';
+        mkdir($dir, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $uploadsDir]);
+
+        $key  = substr(hash('sha256', 'plugin:demo/demo.php'), 0, 32);
+        $lockFile = $dir . '/' . $key . '.lock';
+        $externalHandle = fopen($lockFile, 'c');
+        $this->assertIsResource($externalHandle);
+        $this->assertTrue(flock($externalHandle, LOCK_EX | LOCK_NB), 'precondition: the external handle must hold the lock');
+
+        $result = wpmgr_watchdog_try_lock_inflight('plugin', 'demo/demo.php');
+
+        $this->assertFalse($result, 'a genuinely in-progress apply must make the watchdog stand down');
+
+        flock($externalHandle, LOCK_UN);
+        fclose($externalHandle);
+    }
+
+    /**
+     * LOW-1 (GitHub issue #210 security review) — when wp_upload_dir()
+     * returns no usable basedir, the in-flight lock path MUST fall back to
+     * `WP_CONTENT_DIR/wpmgr-update-inflight/...` (mirroring
+     * StoragePaths::dataBase()'s own fallback, which UpdateInFlight itself
+     * uses) — NOT `WP_CONTENT_DIR/uploads/wpmgr-update-inflight/...` (the
+     * DIFFERENT fallback wpmgr_watchdog_uploads_base()/SnapshotManager use
+     * for the snapshot-payload side). Before this fix the two diverged in
+     * exactly this scenario, so a lock UpdateInFlight::mark() genuinely
+     * held at the correct (no-/uploads) path was invisible to the watchdog.
+     */
+    public function test_try_lock_inflight_uses_the_storagepaths_fallback_when_wp_upload_dir_returns_no_basedir(): void
+    {
+        $this->ensurePluginRootConstants(); // guard-defines WP_CONTENT_DIR if not already set.
+        Functions\when('wp_upload_dir')->justReturn([]); // No usable 'basedir' key at all.
+
+        $expectedDir = rtrim((string) WP_CONTENT_DIR, '/\\') . '/wpmgr-update-inflight';
+        if (!is_dir($expectedDir)) {
+            mkdir($expectedDir, 0755, true);
+        }
+
+        // A lock genuinely held at the CORRECT (StoragePaths::dataBase()-style,
+        // no "/uploads") fallback path — exactly where UpdateInFlight::mark()
+        // itself would create it in this same scenario.
+        $key      = substr(hash('sha256', 'plugin:fallback-demo/fallback-demo.php'), 0, 32);
+        $lockFile = $expectedDir . '/' . $key . '.lock';
+        $externalHandle = fopen($lockFile, 'c');
+        $this->assertIsResource($externalHandle);
+        $this->assertTrue(flock($externalHandle, LOCK_EX | LOCK_NB), 'precondition: the external handle must hold the lock at the StoragePaths-style fallback path');
+
+        $result = wpmgr_watchdog_try_lock_inflight('plugin', 'fallback-demo/fallback-demo.php');
+
+        $this->assertFalse(
+            $result,
+            'LOW-1: in the wp_upload_dir()-unavailable fallback, the watchdog must resolve the SAME lock path StoragePaths::dataBase()/UpdateInFlight use and correctly detect the held lock'
+        );
+
+        flock($externalHandle, LOCK_UN);
+        fclose($externalHandle);
+        unlink($lockFile); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test fixture cleanup
+    }
+
+    // =========================================================================
+    // wpmgr_watchdog_copy_dir() / wpmgr_watchdog_delete_dir()
+    // =========================================================================
+
+    public function test_copy_dir_recursively_copies_files_and_subdirectories(): void
+    {
+        $src = $this->root . '/copy-src';
+        $dst = $this->root . '/copy-dst';
+        mkdir($src . '/nested', 0755, true);
+        file_put_contents($src . '/top.txt', 'top');
+        file_put_contents($src . '/nested/deep.txt', 'deep');
+
+        $this->assertTrue(wpmgr_watchdog_copy_dir($src, $dst));
+        $this->assertSame('top', file_get_contents($dst . '/top.txt'));
+        $this->assertSame('deep', file_get_contents($dst . '/nested/deep.txt'));
+    }
+
+    public function test_copy_dir_skips_symlinks(): void
+    {
+        $src = $this->root . '/copy-src-sym';
+        $dst = $this->root . '/copy-dst-sym';
+        mkdir($src, 0755, true);
+        file_put_contents($this->root . '/outside.txt', 'outside');
+        file_put_contents($src . '/real.txt', 'real');
+        @symlink($this->root . '/outside.txt', $src . '/link.txt');
+
+        $this->assertTrue(wpmgr_watchdog_copy_dir($src, $dst));
+        $this->assertSame('real', file_get_contents($dst . '/real.txt'));
+        $this->assertFalse(file_exists($dst . '/link.txt'), 'a symlink entry must never be followed/copied');
+    }
+
+    public function test_delete_dir_recursively_removes_everything(): void
+    {
+        $dir = $this->root . '/delete-me';
+        mkdir($dir . '/nested', 0755, true);
+        file_put_contents($dir . '/top.txt', 'top');
+        file_put_contents($dir . '/nested/deep.txt', 'deep');
+
+        $this->assertTrue(wpmgr_watchdog_delete_dir($dir));
+        $this->assertFalse(is_dir($dir));
+    }
+
+    // =========================================================================
+    // wpmgr_watchdog_swap_directories() — the core swap, mirrors
+    // SnapshotManager::restore()'s rename-based staging + S5 rollback.
+    // =========================================================================
+
+    public function test_swap_directories_replaces_live_with_payload_on_the_happy_path(): void
+    {
+        $live = $this->root . '/live-demo';
+        mkdir($live, 0755, true);
+        file_put_contents($live . '/marker.txt', 'BROKEN');
+
+        $payload = $this->root . '/payload-demo';
+        mkdir($payload, 0755, true);
+        file_put_contents($payload . '/marker.txt', 'GOOD');
+
+        wpmgr_watchdog_swap_directories($live, $payload, 'snap_test');
+
+        $this->assertSame('GOOD', file_get_contents($live . '/marker.txt'));
+        $this->assertFalse(is_dir($live . '.wpmgr-watchdog-old-snap_test'), 'the aside must be dropped on success');
+    }
+
+    public function test_swap_directories_does_nothing_when_the_aside_already_exists(): void
+    {
+        $live = $this->root . '/live-demo2';
+        mkdir($live, 0755, true);
+        file_put_contents($live . '/marker.txt', 'CURRENT');
+
+        $payload = $this->root . '/payload-demo2';
+        mkdir($payload, 0755, true);
+        file_put_contents($payload . '/marker.txt', 'GOOD');
+
+        $aside = $live . '.wpmgr-watchdog-old-snap_test2';
+        mkdir($aside, 0755, true);
+
+        wpmgr_watchdog_swap_directories($live, $payload, 'snap_test2');
+
+        $this->assertSame('CURRENT', file_get_contents($live . '/marker.txt'), 'an unexpected pre-existing aside must leave live untouched');
+    }
+
+    public function test_swap_directories_rolls_back_when_the_copy_fails_mid_write(): void
+    {
+        $live = $this->root . '/live-demo3';
+        mkdir($live, 0755, true);
+        file_put_contents($live . '/marker.txt', 'PRE-RESTORE-ATTEMPT');
+
+        // Payload directory does not exist at all -> wpmgr_watchdog_copy_dir()
+        // fails immediately (is_dir($src) check).
+        $payload = $this->root . '/payload-missing';
+
+        wpmgr_watchdog_swap_directories($live, $payload, 'snap_test3');
+
+        $this->assertTrue(is_dir($live), 'the live directory must exist again — never left missing');
+        $this->assertSame(
+            'PRE-RESTORE-ATTEMPT',
+            file_get_contents($live . '/marker.txt'),
+            'a failed copy must roll back to the pre-restore-attempt state'
+        );
+        $this->assertFalse(is_dir($live . '.wpmgr-watchdog-old-snap_test3'));
+    }
+
+    // =========================================================================
+    // wpmgr_watchdog_attempt_restore() — full integration
+    // =========================================================================
+
+    public function test_attempt_restore_performs_the_swap_for_a_fresh_unconsumed_entry(): void
+    {
+        $uploadsDir = $this->root . '/uploads';
+        mkdir($uploadsDir, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $uploadsDir]);
+        mkdir($uploadsDir . '/wpmgr-update-inflight', 0755, true);
+
+        $plugin = $this->makeLivePlugin('BROKEN-UPDATE-CONTENT');
+        $snap   = $this->makeSnapshotPayload($uploadsDir);
+
+        $entry = $this->markerEntry('plugin', $plugin['live'], $snap['snapshot_id'], $snap['payload']);
+        $entry['slug'] = $plugin['slug'];
+
+        wpmgr_watchdog_attempt_restore($entry, time());
+
+        $this->assertSame(
+            'GOOD-PRE-UPDATE-CONTENT',
+            file_get_contents($plugin['live'] . '/marker.txt'),
+            'a fresh, unconsumed, valid entry must actually restore the snapshot payload over the live dir'
+        );
+    }
+
+    public function test_attempt_restore_is_one_shot_a_second_call_for_the_same_snapshot_does_nothing(): void
+    {
+        $uploadsDir = $this->root . '/uploads';
+        mkdir($uploadsDir, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $uploadsDir]);
+        mkdir($uploadsDir . '/wpmgr-update-inflight', 0755, true);
+
+        $plugin = $this->makeLivePlugin('BROKEN-UPDATE-CONTENT');
+        $snap   = $this->makeSnapshotPayload($uploadsDir);
+
+        $entry = $this->markerEntry('plugin', $plugin['live'], $snap['snapshot_id'], $snap['payload']);
+        $entry['slug'] = $plugin['slug'];
+
+        wpmgr_watchdog_attempt_restore($entry, time());
+        $this->assertSame('GOOD-PRE-UPDATE-CONTENT', file_get_contents($plugin['live'] . '/marker.txt'));
+
+        // Simulate a second, concurrently-fataling request re-processing the
+        // SAME marker entry — must be a complete no-op (the claim file from
+        // the first call already exists).
+        file_put_contents($plugin['live'] . '/marker.txt', 'MUTATED-AFTER-FIRST-RESTORE');
+        wpmgr_watchdog_attempt_restore($entry, time());
+
+        $this->assertSame(
+            'MUTATED-AFTER-FIRST-RESTORE',
+            file_get_contents($plugin['live'] . '/marker.txt'),
+            'a SECOND attempt for the exact same snapshot must never restore again — one-shot'
+        );
+    }
+
+    public function test_attempt_restore_does_nothing_for_an_expired_entry(): void
+    {
+        $uploadsDir = $this->root . '/uploads';
+        mkdir($uploadsDir, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $uploadsDir]);
+        mkdir($uploadsDir . '/wpmgr-update-inflight', 0755, true);
+
+        $plugin = $this->makeLivePlugin('BROKEN-UPDATE-CONTENT');
+        $snap   = $this->makeSnapshotPayload($uploadsDir);
+
+        $now   = time();
+        $entry = $this->markerEntry('plugin', $plugin['live'], $snap['snapshot_id'], $snap['payload'], [
+            'applied_at' => $now - 1000,
+            'expires_at' => $now - 700,
+        ]);
+        $entry['slug'] = $plugin['slug'];
+
+        wpmgr_watchdog_attempt_restore($entry, $now);
+
+        $this->assertSame('BROKEN-UPDATE-CONTENT', file_get_contents($plugin['live'] . '/marker.txt'));
+    }
+
+    public function test_attempt_restore_does_nothing_when_the_recorded_live_dir_does_not_match_the_independently_derived_expectation(): void
+    {
+        // Simulates a tampered/corrupt marker: the recorded live_dir is some
+        // OTHER absolute path entirely, not the one the slug independently
+        // resolves to. Must be rejected outright, never trusted.
+        $uploadsDir = $this->root . '/uploads';
+        mkdir($uploadsDir, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $uploadsDir]);
+        mkdir($uploadsDir . '/wpmgr-update-inflight', 0755, true);
+
+        $plugin  = $this->makeLivePlugin('BROKEN-UPDATE-CONTENT');
+        $snap    = $this->makeSnapshotPayload($uploadsDir);
+        $decoyLive = $this->root . '/totally-unrelated-dir';
+        mkdir($decoyLive, 0755, true);
+        file_put_contents($decoyLive . '/should-not-be-touched.txt', 'DECOY');
+
+        $entry = $this->markerEntry('plugin', $decoyLive, $snap['snapshot_id'], $snap['payload']);
+        $entry['slug'] = $plugin['slug']; // slug resolves to $plugin['live'], NOT $decoyLive.
+
+        wpmgr_watchdog_attempt_restore($entry, time());
+
+        $this->assertSame('DECOY', file_get_contents($decoyLive . '/should-not-be-touched.txt'), 'the decoy dir recorded in the marker must never be touched');
+        $this->assertSame(
+            'BROKEN-UPDATE-CONTENT',
+            file_get_contents($plugin['live'] . '/marker.txt'),
+            'the slug\'s REAL live dir must also be left untouched — the mismatch aborts the whole restore'
+        );
+    }
+
+    public function test_is_self_path_matches_only_the_running_agents_own_plugin_directory(): void
+    {
+        $this->assertTrue(defined('WPMGR_AGENT_DIR'), 'precondition: WPMGR_AGENT_DIR must be defined by the test bootstrap');
+        $selfDir = rtrim((string) constant('WPMGR_AGENT_DIR'), '/\\');
+
+        $this->assertTrue(wpmgr_watchdog_is_self_path($selfDir));
+        $this->assertFalse(wpmgr_watchdog_is_self_path($selfDir . '-lookalike'), 'a sibling with a shared string prefix must not match (anchored, not substring)');
+        $this->assertFalse(wpmgr_watchdog_is_self_path('/some/totally/unrelated/dir'));
+        $this->assertFalse(wpmgr_watchdog_is_self_path(''));
+    }
+
+    public function test_attempt_restore_stands_down_when_the_self_path_guard_fires(): void
+    {
+        // Integration-level proof that wpmgr_watchdog_attempt_restore()
+        // actually consults wpmgr_watchdog_is_self_path() for every
+        // candidate restore — forces the guard true via the same
+        // Brain-Monkey/Patchwork interception WafGateHardeningTest already
+        // relies on for calls made from this namespace-free mu-plugin file.
+        $uploadsDir = $this->root . '/uploads';
+        mkdir($uploadsDir, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $uploadsDir]);
+        mkdir($uploadsDir . '/wpmgr-update-inflight', 0755, true);
+
+        $plugin = $this->makeLivePlugin('BROKEN-UPDATE-CONTENT');
+        $snap   = $this->makeSnapshotPayload($uploadsDir);
+
+        $entry = $this->markerEntry('plugin', $plugin['live'], $snap['snapshot_id'], $snap['payload']);
+        $entry['slug'] = $plugin['slug'];
+
+        Functions\when('wpmgr_watchdog_is_self_path')->justReturn(true);
+
+        wpmgr_watchdog_attempt_restore($entry, time());
+
+        $this->assertSame(
+            'BROKEN-UPDATE-CONTENT',
+            file_get_contents($plugin['live'] . '/marker.txt'),
+            'when the self-path guard fires, the restore must be a complete no-op, even for an otherwise fully valid entry'
+        );
+    }
+
+    public function test_attempt_restore_stands_down_when_a_real_apply_is_in_flight_for_the_same_slug(): void
+    {
+        $uploadsDir = $this->root . '/uploads';
+        $inflightDir = $uploadsDir . '/wpmgr-update-inflight';
+        mkdir($inflightDir, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $uploadsDir]);
+
+        $plugin = $this->makeLivePlugin('BROKEN-UPDATE-CONTENT');
+        $snap   = $this->makeSnapshotPayload($uploadsDir);
+
+        $entry = $this->markerEntry('plugin', $plugin['live'], $snap['snapshot_id'], $snap['payload']);
+        $entry['slug'] = $plugin['slug'];
+
+        // Hold the SAME in-flight lock UpdateInFlight::mark() would hold for
+        // a real, currently-running apply of this exact slug.
+        $key  = substr(hash('sha256', 'plugin:' . $plugin['slug']), 0, 32);
+        $lockFile = $inflightDir . '/' . $key . '.lock';
+        $externalHandle = fopen($lockFile, 'c');
+        $this->assertTrue(flock($externalHandle, LOCK_EX | LOCK_NB));
+
+        wpmgr_watchdog_attempt_restore($entry, time());
+
+        $this->assertSame(
+            'BROKEN-UPDATE-CONTENT',
+            file_get_contents($plugin['live'] . '/marker.txt'),
+            'a genuinely in-progress apply for the same slug must never be raced by the watchdog'
+        );
+
+        flock($externalHandle, LOCK_UN);
+        fclose($externalHandle);
+    }
+
+    // =========================================================================
+    // wpmgr_watchdog_process_fatal() — the shutdown-callback core
+    // =========================================================================
+
+    public function test_process_fatal_does_nothing_for_a_null_error(): void
+    {
+        $plugin = $this->makeLivePlugin();
+        wpmgr_watchdog_process_fatal(null);
+        $this->assertSame('BROKEN-UPDATE-CONTENT', file_get_contents($plugin['live'] . '/marker.txt'));
+    }
+
+    /**
+     * @dataProvider nonFatalErrorCodes
+     */
+    public function test_process_fatal_does_nothing_for_a_non_fatal_error_code(int $code): void
+    {
+        $result = wpmgr_watchdog_process_fatal(['type' => $code, 'message' => 'x', 'file' => '/tmp/x.php', 'line' => 1]);
+        $this->assertNull($result);
+    }
+
+    /**
+     * @return array<int,array{0:int}>
+     */
+    public static function nonFatalErrorCodes(): array
+    {
+        return [
+            [E_WARNING],
+            [E_NOTICE],
+            [E_USER_WARNING],
+            [E_USER_NOTICE],
+            [E_DEPRECATED],
+            [E_USER_ERROR],        // Deliberately narrower mask than error-trap's.
+            [E_RECOVERABLE_ERROR],
+        ];
+    }
+
+    public function test_process_fatal_restores_the_entry_whose_live_dir_contains_the_fatals_file(): void
+    {
+        $uploadsDir = $this->root . '/uploads';
+        mkdir($uploadsDir, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $uploadsDir]);
+        mkdir($uploadsDir . '/wpmgr-update-inflight', 0755, true);
+
+        $broken = $this->makeLivePlugin('BROKEN-UPDATE-CONTENT');
+        $healthy = $this->makeLivePlugin('HEALTHY-CONTENT');
+        $snapBroken  = $this->makeSnapshotPayload($uploadsDir, 'GOOD-BROKEN-PLUGIN-CONTENT');
+        $snapHealthy = $this->makeSnapshotPayload($uploadsDir, 'GOOD-HEALTHY-PLUGIN-CONTENT');
+
+        $stateDir = wpmgr_watchdog_state_dir();
+        if (!is_dir($stateDir)) {
+            mkdir($stateDir, 0755, true);
+        }
+        file_put_contents($stateDir . '/watchdog-marker.json', (string) json_encode([
+            'markers' => [
+                $this->markerEntry('plugin', $broken['live'], $snapBroken['snapshot_id'], $snapBroken['payload'], ['slug' => $broken['slug']]),
+                $this->markerEntry('plugin', $healthy['live'], $snapHealthy['snapshot_id'], $snapHealthy['payload'], ['slug' => $healthy['slug']]),
+            ],
+        ]));
+
+        // The fatal happened inside the BROKEN plugin's own loader file.
+        $err = [
+            'type'    => E_ERROR,
+            'message' => "Uncaught Error: Class 'Foo' not found",
+            'file'    => $broken['live'] . '/loader.php',
+            'line'    => 3,
+        ];
+
+        wpmgr_watchdog_process_fatal($err);
+
+        $this->assertSame(
+            'GOOD-BROKEN-PLUGIN-CONTENT',
+            file_get_contents($broken['live'] . '/marker.txt'),
+            'the broken plugin (whose file the fatal was reported in) must be restored'
+        );
+        $this->assertSame(
+            'HEALTHY-CONTENT',
+            file_get_contents($healthy['live'] . '/marker.txt'),
+            'a healthy sibling from the SAME batch must never be touched — precise attribution, not blast-radius restore-everything'
+        );
+
+        $this->rrmdir($stateDir);
+    }
+
+    // =========================================================================
+    // MEDIUM-1a (GitHub issue #210 security review) — resource-exhaustion
+    // fatals (OOM / execution-timeout) are excluded from attribution.
+    // =========================================================================
+
+    /**
+     * @dataProvider resourceExhaustionMessages
+     */
+    public function test_is_resource_exhaustion_message_matches_oom_and_timeout(string $message): void
+    {
+        $this->assertTrue(wpmgr_watchdog_is_resource_exhaustion_message($message));
+    }
+
+    /**
+     * @return array<int,array{0:string}>
+     */
+    public static function resourceExhaustionMessages(): array
+    {
+        return [
+            ['Allowed memory size of 134217728 bytes exhausted (tried to allocate 20971520 bytes)'],
+            ['allowed memory size of 268435456 bytes exhausted'], // case-insensitive
+            ['Maximum execution time of 30 seconds exceeded'],
+            ['maximum execution time of 60 seconds exceeded'], // case-insensitive
+        ];
+    }
+
+    public function test_is_resource_exhaustion_message_rejects_a_genuine_code_fatal(): void
+    {
+        $this->assertFalse(wpmgr_watchdog_is_resource_exhaustion_message("Uncaught Error: Class 'Foo' not found"));
+        $this->assertFalse(wpmgr_watchdog_is_resource_exhaustion_message(''));
+    }
+
+    public function test_process_fatal_does_not_restore_on_an_allowed_memory_size_fatal_attributable_to_the_armed_slug(): void
+    {
+        $uploadsDir = $this->root . '/uploads';
+        mkdir($uploadsDir, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $uploadsDir]);
+        mkdir($uploadsDir . '/wpmgr-update-inflight', 0755, true);
+
+        $plugin = $this->makeLivePlugin('BROKEN-UPDATE-CONTENT');
+        $snap   = $this->makeSnapshotPayload($uploadsDir);
+
+        $stateDir = wpmgr_watchdog_state_dir();
+        if (!is_dir($stateDir)) {
+            mkdir($stateDir, 0755, true);
+        }
+        file_put_contents($stateDir . '/watchdog-marker.json', (string) json_encode([
+            'markers' => [$this->markerEntry('plugin', $plugin['live'], $snap['snapshot_id'], $snap['payload'], ['slug' => $plugin['slug']])],
+        ]));
+
+        // The fatal's file DOES fall within the armed slug's live_dir — the
+        // ONLY reason this must not restore is the OOM message itself.
+        $err = [
+            'type'    => E_ERROR,
+            'message' => 'Allowed memory size of 134217728 bytes exhausted (tried to allocate 20971520 bytes)',
+            'file'    => $plugin['live'] . '/loader.php',
+            'line'    => 42,
+        ];
+
+        wpmgr_watchdog_process_fatal($err);
+
+        $this->assertSame(
+            'BROKEN-UPDATE-CONTENT',
+            file_get_contents($plugin['live'] . '/marker.txt'),
+            'MEDIUM-1a: an OOM fatal must never trigger a restore, even when it is otherwise attributable to the armed slug'
+        );
+
+        $this->rrmdir($stateDir);
+    }
+
+    public function test_process_fatal_does_nothing_when_the_fatals_file_cannot_be_attributed_to_any_entry(): void
+    {
+        $uploadsDir = $this->root . '/uploads';
+        mkdir($uploadsDir, 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $uploadsDir]);
+
+        $plugin = $this->makeLivePlugin('BROKEN-UPDATE-CONTENT');
+        $snap   = $this->makeSnapshotPayload($uploadsDir);
+
+        $stateDir = wpmgr_watchdog_state_dir();
+        if (!is_dir($stateDir)) {
+            mkdir($stateDir, 0755, true);
+        }
+        file_put_contents($stateDir . '/watchdog-marker.json', (string) json_encode([
+            'markers' => [$this->markerEntry('plugin', $plugin['live'], $snap['snapshot_id'], $snap['payload'], ['slug' => $plugin['slug']])],
+        ]));
+
+        // The fatal is reported inside some UNRELATED file, not under any
+        // recorded live_dir — ambiguous, must not guess.
+        $err = [
+            'type'    => E_ERROR,
+            'message' => 'unrelated fatal',
+            'file'    => $this->root . '/somewhere-else/core-file.php',
+            'line'    => 1,
+        ];
+
+        wpmgr_watchdog_process_fatal($err);
+
+        $this->assertSame(
+            'BROKEN-UPDATE-CONTENT',
+            file_get_contents($plugin['live'] . '/marker.txt'),
+            'an unattributable fatal must never trigger a guessed restore'
+        );
+
+        $this->rrmdir($stateDir);
+    }
+
+    public function test_process_fatal_does_nothing_when_no_marker_file_exists(): void
+    {
+        $stateDir = wpmgr_watchdog_state_dir();
+        if (is_dir($stateDir)) {
+            $this->rrmdir($stateDir);
+        }
+
+        // Must not throw even though the state dir/marker do not exist.
+        wpmgr_watchdog_process_fatal(['type' => E_ERROR, 'message' => 'x', 'file' => '/tmp/x.php', 'line' => 1]);
+        $this->assertTrue(true, 'no exception was thrown');
+    }
+
+    public function test_shutdown_check_never_throws_even_with_no_environment_set_up(): void
+    {
+        // wpmgr_watchdog_shutdown_check() calls the REAL error_get_last();
+        // in a clean PHPUnit run that is typically null/empty. This test's
+        // only assertion is that calling it is always safe.
+        wpmgr_watchdog_shutdown_check();
+        $this->assertTrue(true, 'no exception was thrown');
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.55
+ * Version:           0.61.56
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.55');
+define('WPMGR_AGENT_VERSION', '0.61.56');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 

--- a/apps/api/cmd/wpmgr/siteadapter.go
+++ b/apps/api/cmd/wpmgr/siteadapter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/update"
 	"github.com/mosamlife/wpmgr/apps/api/internal/uptime"
 	"github.com/mosamlife/wpmgr/apps/api/internal/vuln"
+	"github.com/mosamlife/wpmgr/apps/api/internal/wpversion"
 )
 
 // uptimeSiteAdapter adapts the site service to the uptime package's SiteVerifier
@@ -513,7 +514,11 @@ func toSiteInfo(s site.Site) update.SiteInfo {
 		Enrolled:   s.EnrolledAt != nil,
 		Components: comps,
 	}
-	if core := s.ParsedCoreUpdate(); core != nil && core.NewVersion != "" {
+	// GH #211: drop a same-version phantom core-update advisory here too
+	// (defense-in-depth; the update package's planTasks authority,
+	// indexPending, re-checks this same condition independently).
+	if core := s.ParsedCoreUpdate(); core != nil && core.NewVersion != "" &&
+		!wpversion.SameVersion(core.CurrentVersion, core.NewVersion) {
 		info.CoreUpdateAvailable = true
 		info.CoreCurrentVersion = core.CurrentVersion
 		info.CoreNewVersion = core.NewVersion
@@ -523,7 +528,11 @@ func toSiteInfo(s site.Site) update.SiteInfo {
 
 func toUpdateComponent(typ string, c site.Component) update.Component {
 	out := update.Component{Type: typ, Slug: c.Slug, Version: c.Version}
-	if c.AvailableUpdate != nil && c.AvailableUpdate.NewVersion != "" {
+	// GH #211: a same-version advisory (new_version == the component's own
+	// installed Version) must never surface as UpdateAvailable, or planTasks
+	// would plan a doomed/no-op update task for it.
+	if c.AvailableUpdate != nil && c.AvailableUpdate.NewVersion != "" &&
+		!wpversion.SameVersion(c.Version, c.AvailableUpdate.NewVersion) {
 		out.UpdateAvailable = true
 		out.NewVersion = c.AvailableUpdate.NewVersion
 	}

--- a/apps/api/internal/agent/handler.go
+++ b/apps/api/internal/agent/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/api/gen"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 	"github.com/mosamlife/wpmgr/apps/api/internal/server/httpx"
+	"github.com/mosamlife/wpmgr/apps/api/internal/wpversion"
 )
 
 // maxMetadataBytes bounds the agent metadata body (untrusted input).
@@ -181,7 +182,12 @@ func (d metadataDTO) toMetadata() Metadata {
 				AuthorURI: string(c.AuthorURI),
 				Network:   bool(c.Network),
 			}
-			if c.AvailableUpdate != nil && string(c.AvailableUpdate.NewVersion) != "" {
+			// GH #211: the first CP checkpoint for agent-pushed metadata — drop
+			// a same-version phantom advisory (new_version == the component's
+			// own installed Version) here too, defense-in-depth ahead of the
+			// site package's write-path guard (sanitizeComponents).
+			if c.AvailableUpdate != nil && string(c.AvailableUpdate.NewVersion) != "" &&
+				!wpversion.SameVersion(string(c.Version), string(c.AvailableUpdate.NewVersion)) {
 				comp.AvailableUpdate = &AvailableUpdate{
 					NewVersion:  string(c.AvailableUpdate.NewVersion),
 					Package:     flexStringPtr(c.AvailableUpdate.Package),
@@ -204,7 +210,8 @@ func (d metadataDTO) toMetadata() Metadata {
 		Plugins:      conv(d.Plugins),
 		Themes:       conv(d.Themes),
 	}
-	if d.CoreUpdate != nil && string(d.CoreUpdate.NewVersion) != "" {
+	if d.CoreUpdate != nil && string(d.CoreUpdate.NewVersion) != "" &&
+		!wpversion.SameVersion(string(d.CoreUpdate.CurrentVersion), string(d.CoreUpdate.NewVersion)) {
 		m.CoreUpdate = &CoreUpdate{
 			NewVersion:     string(d.CoreUpdate.NewVersion),
 			CurrentVersion: string(d.CoreUpdate.CurrentVersion),

--- a/apps/api/internal/agent/metadata_dto_test.go
+++ b/apps/api/internal/agent/metadata_dto_test.go
@@ -144,3 +144,40 @@ func TestMetadataDTOTolerantOnFlexFields(t *testing.T) {
 		t.Fatalf("flexString tested not coerced from number: %+v", m.Plugins[0].AvailableUpdate)
 	}
 }
+
+// TestMetadataDTODropsSameVersionAvailableUpdate proves GH #211's first CP
+// checkpoint: toMetadata drops a component's available_update (and the
+// top-level core_update) when new_version normalizes equal to the reported
+// installed version — the WordPress update-transient quirk observed with
+// Kadence ("1.5.1 -> 1.5.1"). A legitimate newer advisory on a sibling
+// component in the same payload must still decode.
+func TestMetadataDTODropsSameVersionAvailableUpdate(t *testing.T) {
+	body := []byte(`{
+		"wp_version":"6.4.3",
+		"plugins":[
+			{"slug":"kadence","name":"Kadence","version":"1.5.1","active":true,
+			 "available_update":{"new_version":"1.5.1"}},
+			{"slug":"wp-rocket","name":"WP Rocket","version":"3.16.1","active":true,
+			 "available_update":{"new_version":"3.16.2"}}
+		],
+		"core_update":{"new_version":"6.4.3","current_version":"6.4.3"}
+	}`)
+	var dto metadataDTO
+	if err := json.Unmarshal(body, &dto); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	m := dto.toMetadata()
+	if len(m.Plugins) != 2 {
+		t.Fatalf("both components must survive (only the advisory is dropped): %+v", m.Plugins)
+	}
+	if m.Plugins[0].Slug != "kadence" || m.Plugins[0].AvailableUpdate != nil {
+		t.Fatalf("same-version phantom advisory must be dropped: %+v", m.Plugins[0])
+	}
+	if m.Plugins[1].Slug != "wp-rocket" || m.Plugins[1].AvailableUpdate == nil ||
+		m.Plugins[1].AvailableUpdate.NewVersion != "3.16.2" {
+		t.Fatalf("legitimate newer advisory must still decode: %+v", m.Plugins[1])
+	}
+	if m.CoreUpdate != nil {
+		t.Fatalf("same-version phantom core_update must be dropped: %+v", m.CoreUpdate)
+	}
+}

--- a/apps/api/internal/site/handler.go
+++ b/apps/api/internal/site/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 	"github.com/mosamlife/wpmgr/apps/api/internal/server/httpx"
+	"github.com/mosamlife/wpmgr/apps/api/internal/wpversion"
 )
 
 // RefreshEnqueuer schedules an immediate CP->agent inventory-refresh job for a
@@ -489,13 +490,17 @@ func buildAvailableUpdates(s Site) gen.SiteAvailableUpdates {
 	core := s.ParsedCoreUpdate()
 	items := make([]gen.SiteAvailableUpdatesItemsItem, 0, len(plugins)+len(themes))
 	for _, p := range plugins {
-		if p.AvailableUpdate == nil || p.AvailableUpdate.NewVersion == "" {
+		// GH #211: drop a same-version phantom advisory here too, so a site
+		// whose inventory was persisted before the write-path fix (see
+		// sanitizeComponents) self-heals on its next read — no re-sync
+		// required.
+		if p.AvailableUpdate == nil || p.AvailableUpdate.NewVersion == "" || wpversion.SameVersion(p.Version, p.AvailableUpdate.NewVersion) {
 			continue
 		}
 		items = append(items, toAvailableItem(gen.SiteAvailableUpdatesItemsItemTypePlugin, p))
 	}
 	for _, t := range themes {
-		if t.AvailableUpdate == nil || t.AvailableUpdate.NewVersion == "" {
+		if t.AvailableUpdate == nil || t.AvailableUpdate.NewVersion == "" || wpversion.SameVersion(t.Version, t.AvailableUpdate.NewVersion) {
 			continue
 		}
 		items = append(items, toAvailableItem(gen.SiteAvailableUpdatesItemsItemTypeTheme, t))
@@ -512,7 +517,7 @@ func buildAvailableUpdates(s Site) gen.SiteAvailableUpdates {
 		return items[i].Slug < items[j].Slug
 	})
 	out := gen.SiteAvailableUpdates{SiteID: s.ID, Items: items}
-	if core != nil {
+	if core != nil && !wpversion.SameVersion(core.CurrentVersion, core.NewVersion) {
 		out.CoreUpdate = gen.NewOptNilSiteAvailableUpdatesCoreUpdate(gen.SiteAvailableUpdatesCoreUpdate{
 			NewVersion:     core.NewVersion,
 			CurrentVersion: core.CurrentVersion,
@@ -686,18 +691,22 @@ func toAPI(s Site) gen.Site {
 		if json.Unmarshal(s.Components, &comp) == nil {
 			// M27 — updates_available: same predicate as buildAvailableUpdates
 			// (a non-empty AvailableUpdate.NewVersion), +1 for a core update.
+			// GH #211: a same-version advisory (new_version == the component's
+			// own installed Version) is excluded here too, so an
+			// already-persisted phantom self-heals on the next read.
 			updates := 0
 			for _, p := range comp.Plugins {
-				if p.AvailableUpdate != nil && p.AvailableUpdate.NewVersion != "" {
+				if p.AvailableUpdate != nil && p.AvailableUpdate.NewVersion != "" && !wpversion.SameVersion(p.Version, p.AvailableUpdate.NewVersion) {
 					updates++
 				}
 			}
 			for _, t := range comp.Themes {
-				if t.AvailableUpdate != nil && t.AvailableUpdate.NewVersion != "" {
+				if t.AvailableUpdate != nil && t.AvailableUpdate.NewVersion != "" && !wpversion.SameVersion(t.Version, t.AvailableUpdate.NewVersion) {
 					updates++
 				}
 			}
-			if comp.CoreUpdate != nil {
+			hasCoreUpdate := comp.CoreUpdate != nil && !wpversion.SameVersion(comp.CoreUpdate.CurrentVersion, comp.CoreUpdate.NewVersion)
+			if hasCoreUpdate {
 				updates++
 			}
 			out.UpdatesAvailable = gen.NewOptInt32(int32(updates))
@@ -707,7 +716,7 @@ func toAPI(s Site) gen.Site {
 					Plugins: toAPIComponents(comp.Plugins),
 					Themes:  toAPIComponents(comp.Themes),
 				}
-				if comp.CoreUpdate != nil {
+				if hasCoreUpdate {
 					sc.CoreUpdate = gen.NewOptNilSiteComponentsCoreUpdate(gen.SiteComponentsCoreUpdate{
 						NewVersion:     comp.CoreUpdate.NewVersion,
 						CurrentVersion: comp.CoreUpdate.CurrentVersion,
@@ -730,7 +739,10 @@ func toAPIComponents(cs []Component) []gen.SiteComponent {
 		if c.Version != "" {
 			gc.Version = gen.NewOptString(c.Version)
 		}
-		if c.AvailableUpdate != nil && c.AvailableUpdate.NewVersion != "" {
+		// GH #211: a same-version advisory is dropped here too (the full
+		// components inventory shares the phantom-update defect with the
+		// available-updates projection above).
+		if c.AvailableUpdate != nil && c.AvailableUpdate.NewVersion != "" && !wpversion.SameVersion(c.Version, c.AvailableUpdate.NewVersion) {
 			au := gen.SiteComponentAvailableUpdate{NewVersion: c.AvailableUpdate.NewVersion}
 			if c.AvailableUpdate.Package != "" {
 				au.Package = gen.NewOptNilString(c.AvailableUpdate.Package)

--- a/apps/api/internal/site/sanitize_test.go
+++ b/apps/api/internal/site/sanitize_test.go
@@ -166,3 +166,85 @@ func TestApplyMetadataHappyPath(t *testing.T) {
 		t.Fatalf("metadata not persisted as-is: %+v", repo.gotMeta)
 	}
 }
+
+// TestApplyMetadataDropsSameVersionAvailableUpdate proves GH #211: an
+// AvailableUpdate whose new_version normalizes equal to the component's own
+// installed Version (e.g. Kadence's observed "1.5.1 -> 1.5.1") is never
+// persisted — sanitizeComponents is the universal write chokepoint for
+// agent-pushed metadata, so this covers every write path (ApplyAgentMetadata,
+// the recheck handler, etc). The component itself still survives (only the
+// phantom advisory is dropped), and a legitimate newer advisory on a sibling
+// component in the same payload is unaffected. A same-version CoreUpdate
+// advisory is dropped the same way (sanitizeCoreUpdate).
+func TestApplyMetadataDropsSameVersionAvailableUpdate(t *testing.T) {
+	repo := &captureRepo{}
+	svc := newSvc(repo)
+
+	_, err := svc.ApplyMetadata(context.Background(), uuid.New(), uuid.New(), Metadata{
+		Plugins: []Component{
+			{Slug: "kadence", Name: "Kadence", Version: "1.5.1", Active: true,
+				AvailableUpdate: &AvailableUpdate{NewVersion: "1.5.1"}}, // GH #211 phantom
+			{Slug: "wp-rocket", Name: "WP Rocket", Version: "3.16.1", Active: true,
+				AvailableUpdate: &AvailableUpdate{NewVersion: "3.16.2"}}, // legitimate
+		},
+		CoreUpdate: &CoreUpdate{NewVersion: "6.4.3", CurrentVersion: "6.4.3"}, // phantom core advisory
+	})
+	if err != nil {
+		t.Fatalf("ApplyMetadata: %v", err)
+	}
+	if len(repo.gotMeta.Plugins) != 2 {
+		t.Fatalf("both components must survive (only the advisory is dropped): got %d", len(repo.gotMeta.Plugins))
+	}
+	if repo.gotMeta.Plugins[0].Slug != "kadence" || repo.gotMeta.Plugins[0].AvailableUpdate != nil {
+		t.Fatalf("same-version advisory must not be persisted: %+v", repo.gotMeta.Plugins[0])
+	}
+	if repo.gotMeta.Plugins[1].Slug != "wp-rocket" || repo.gotMeta.Plugins[1].AvailableUpdate == nil ||
+		repo.gotMeta.Plugins[1].AvailableUpdate.NewVersion != "3.16.2" {
+		t.Fatalf("legitimate newer advisory must still be persisted: %+v", repo.gotMeta.Plugins[1])
+	}
+	if repo.gotMeta.CoreUpdate != nil {
+		t.Fatalf("same-version core-update advisory must not be persisted: %+v", repo.gotMeta.CoreUpdate)
+	}
+
+	// The persisted JSONB itself must not carry the phantom advisory either.
+	var got struct {
+		Plugins []struct {
+			Slug            string           `json:"slug"`
+			AvailableUpdate *AvailableUpdate `json:"available_update"`
+		} `json:"plugins"`
+		CoreUpdate *CoreUpdate `json:"core_update"`
+	}
+	if err := json.Unmarshal(repo.gotComponents, &got); err != nil {
+		t.Fatalf("components JSON invalid: %v", err)
+	}
+	if got.Plugins[0].AvailableUpdate != nil {
+		t.Fatalf("persisted JSONB must not carry the phantom advisory: %+v", got.Plugins[0])
+	}
+	if got.CoreUpdate != nil {
+		t.Fatalf("persisted JSONB must not carry the phantom core advisory: %+v", got.CoreUpdate)
+	}
+}
+
+// TestApplyMetadataKeepsAvailableUpdateWhenInstalledVersionEmpty proves the
+// fail-open rule: a component reporting an empty installed Version keeps its
+// advisory (never suppressed) — wpversion.SameVersion returns false whenever
+// either side is empty, so an unknown/unreported installed version can never
+// hide a real update.
+func TestApplyMetadataKeepsAvailableUpdateWhenInstalledVersionEmpty(t *testing.T) {
+	repo := &captureRepo{}
+	svc := newSvc(repo)
+
+	_, err := svc.ApplyMetadata(context.Background(), uuid.New(), uuid.New(), Metadata{
+		Plugins: []Component{
+			{Slug: "mystery", Version: "", Active: true,
+				AvailableUpdate: &AvailableUpdate{NewVersion: "2.0"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyMetadata: %v", err)
+	}
+	if len(repo.gotMeta.Plugins) != 1 || repo.gotMeta.Plugins[0].AvailableUpdate == nil ||
+		repo.gotMeta.Plugins[0].AvailableUpdate.NewVersion != "2.0" {
+		t.Fatalf("fail-open: advisory on an empty-installed-version component must be kept: %+v", repo.gotMeta.Plugins)
+	}
+}

--- a/apps/api/internal/site/service.go
+++ b/apps/api/internal/site/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/api/gen"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 	"github.com/mosamlife/wpmgr/apps/api/internal/metrics"
+	"github.com/mosamlife/wpmgr/apps/api/internal/wpversion"
 )
 
 // Service holds site business logic. All operations require a tenant ID, which
@@ -483,7 +484,15 @@ func sanitizeComponents(cs []Component, maxLen int) []Component {
 		}
 		if c.AvailableUpdate != nil {
 			nv := strings.TrimSpace(c.AvailableUpdate.NewVersion)
-			if nv != "" {
+			// GH #211: a WordPress update transient can report new_version ==
+			// the already-installed Version (observed with Kadence, e.g.
+			// "1.5.1 -> 1.5.1"). This is the universal write chokepoint for
+			// agent-pushed metadata, so a same-version advisory is never
+			// persisted in the first place. wpversion.SameVersion is
+			// EQUALITY-only (never a version_compare-style ordering) and fails
+			// open (false) when either side is empty, so a component with an
+			// unknown installed Version always keeps its advisory.
+			if nv != "" && !wpversion.SameVersion(comp.Version, nv) {
 				comp.AvailableUpdate = &AvailableUpdate{
 					NewVersion:  truncateRunes(nv, maxVersionLen),
 					Package:     truncateRunes(c.AvailableUpdate.Package, maxPackageURL),
@@ -501,7 +510,9 @@ func sanitizeComponents(cs []Component, maxLen int) []Component {
 }
 
 // sanitizeCoreUpdate truncates the core-update advisory fields and drops the
-// whole advisory when new_version is empty (the contract requires it).
+// whole advisory when new_version is empty (the contract requires it), or
+// when new_version normalizes equal to current_version (GH #211-class
+// phantom advisory — see sanitizeComponents).
 func sanitizeCoreUpdate(cu *CoreUpdate) *CoreUpdate {
 	if cu == nil {
 		return nil
@@ -510,9 +521,13 @@ func sanitizeCoreUpdate(cu *CoreUpdate) *CoreUpdate {
 	if nv == "" {
 		return nil
 	}
+	cv := truncateRunes(cu.CurrentVersion, maxWPVersion)
+	if wpversion.SameVersion(cv, nv) {
+		return nil
+	}
 	return &CoreUpdate{
 		NewVersion:     nv,
-		CurrentVersion: truncateRunes(cu.CurrentVersion, maxWPVersion),
+		CurrentVersion: cv,
 	}
 }
 

--- a/apps/api/internal/site/updates_test.go
+++ b/apps/api/internal/site/updates_test.go
@@ -18,6 +18,10 @@ import (
 //     ties broken by slug
 //   - attaches the optional CoreUpdate from the JSONB inventory
 //   - stamps as_of from sites.updated_at
+//   - GH #211: drops a same-version phantom advisory (available_update.new_version
+//     == the component's own Version) from both Items and the item count, while
+//     a legitimate newer advisory still surfaces, and an advisory on a component
+//     with an EMPTY installed Version is kept (fail open — see wpversion.SameVersion)
 func TestBuildAvailableUpdatesFiltersAndSorts(t *testing.T) {
 	updatedAt := time.Date(2026, 5, 28, 10, 0, 0, 0, time.UTC)
 	siteID := uuid.New()
@@ -30,6 +34,18 @@ func TestBuildAvailableUpdatesFiltersAndSorts(t *testing.T) {
 				"available_update": map[string]any{"new_version": "5.3.2"}},
 			{"slug": "zoo", "name": "Zoo", "version": "1.0", "active": true,
 				"available_update": map[string]any{"new_version": "1.1"}},
+			// GH #211 phantom: new_version equals the installed Version
+			// (observed with Kadence, e.g. "1.5.1 -> 1.5.1") — must be dropped.
+			{"slug": "kadence", "name": "Kadence", "version": "1.5.1", "active": true,
+				"available_update": map[string]any{"new_version": "1.5.1"}},
+			// A "v"-prefixed phantom must also normalize-equal and drop.
+			{"slug": "v-prefixed", "name": "V Prefixed", "version": "2.0.0", "active": true,
+				"available_update": map[string]any{"new_version": "v2.0.0"}},
+			// Fail-open: an empty installed Version must never suppress a
+			// reported advisory (wpversion.SameVersion returns false when
+			// either side is empty).
+			{"slug": "zz-mystery", "name": "Mystery Plugin", "version": "", "active": true,
+				"available_update": map[string]any{"new_version": "2.0"}},
 		},
 		"themes": []map[string]any{
 			{"slug": "twentytwentyfour", "name": "Twenty Twenty-Four", "version": "1.0", "active": true,
@@ -58,22 +74,33 @@ func TestBuildAvailableUpdatesFiltersAndSorts(t *testing.T) {
 	if out.CoreUpdate.Value.NewVersion != "6.5.2" || out.CoreUpdate.Value.CurrentVersion != "6.4.3" {
 		t.Fatalf("core_update wrong: %+v", out.CoreUpdate.Value)
 	}
-	// 3 plugins (no-update dropped) + 2 themes = 5 items.
-	if got := len(out.Items); got != 5 {
-		t.Fatalf("filtered item count = %d, want 5: %+v", got, out.Items)
+	// 4 plugins (no-update, kadence phantom, v-prefixed phantom dropped) + 2
+	// themes = 6 items.
+	if got := len(out.Items); got != 6 {
+		t.Fatalf("filtered item count = %d, want 6: %+v", got, out.Items)
+	}
+	for _, it := range out.Items {
+		if it.Slug == "kadence" {
+			t.Fatalf("GH #211 phantom (same-version) advisory must be dropped: %+v", it)
+		}
+		if it.Slug == "v-prefixed" {
+			t.Fatalf("GH #211 phantom (v-prefixed same-version) advisory must be dropped: %+v", it)
+		}
 	}
 	// Expected sort: plugins (active before inactive, slug-sorted within each), then themes.
 	//   1. plugin/wp-rocket  (active)
 	//   2. plugin/zoo        (active)
-	//   3. plugin/akismet    (inactive)
-	//   4. theme/twentytwentyfour (active)
-	//   5. theme/old-theme   (inactive)
+	//   3. plugin/zz-mystery (active; fail-open empty-installed-version kept)
+	//   4. plugin/akismet    (inactive)
+	//   5. theme/twentytwentyfour (active)
+	//   6. theme/old-theme   (inactive)
 	want := []struct {
 		typ  gen.SiteAvailableUpdatesItemsItemType
 		slug string
 	}{
 		{gen.SiteAvailableUpdatesItemsItemTypePlugin, "wp-rocket"},
 		{gen.SiteAvailableUpdatesItemsItemTypePlugin, "zoo"},
+		{gen.SiteAvailableUpdatesItemsItemTypePlugin, "zz-mystery"},
 		{gen.SiteAvailableUpdatesItemsItemTypePlugin, "akismet"},
 		{gen.SiteAvailableUpdatesItemsItemTypeTheme, "twentytwentyfour"},
 		{gen.SiteAvailableUpdatesItemsItemTypeTheme, "old-theme"},
@@ -84,12 +111,18 @@ func TestBuildAvailableUpdatesFiltersAndSorts(t *testing.T) {
 			t.Fatalf("sort[%d] = (%s,%s), want (%s,%s)", i, got.Type, got.Slug, w.typ, w.slug)
 		}
 	}
-	// WP Rocket carries the package URL; check the OptNilString round-trip.
+	// WP Rocket carries the package URL; check the OptNilString round-trip. A
+	// legitimate newer advisory must still surface despite the new same-version
+	// guard.
 	if !out.Items[0].Package.Set || out.Items[0].Package.Value != "https://example.com/wp-rocket.zip" {
 		t.Fatalf("package URL not surfaced: %+v", out.Items[0].Package)
 	}
+	// zz-mystery: fail-open (empty installed Version) kept its advisory.
+	if out.Items[2].Slug != "zz-mystery" || out.Items[2].NewVersion != "2.0" {
+		t.Fatalf("fail-open (empty installed version) advisory not kept: %+v", out.Items[2])
+	}
 	// twentytwentyfour carries tested + requires_php.
-	tt := out.Items[3]
+	tt := out.Items[4]
 	if !tt.Tested.Set || tt.Tested.Value != "6.5" || !tt.RequiresPhp.Set || tt.RequiresPhp.Value != "7.4" {
 		t.Fatalf("optional advisory fields lost: %+v", tt)
 	}

--- a/apps/api/internal/update/service.go
+++ b/apps/api/internal/update/service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/wpversion"
 )
 
 // SiteInfo is the minimal site projection the update service needs to plan and
@@ -252,11 +253,17 @@ func (s *Service) planTasks(sites []SiteInfo, items []Item, inFlight map[InFligh
 func indexPending(site SiteInfo) map[string]string {
 	m := make(map[string]string, len(site.Components)+1)
 	for _, c := range site.Components {
-		if c.UpdateAvailable && c.NewVersion != "" {
+		// GH #211: this is the planTasks authority — a same-version phantom
+		// advisory (new_version == the component's own installed Version)
+		// must never be treated as pending here, defense-in-depth against a
+		// SiteLookup implementation that did not already filter it (see
+		// cmd/wpmgr's toUpdateComponent).
+		if c.UpdateAvailable && c.NewVersion != "" && !wpversion.SameVersion(c.Version, c.NewVersion) {
 			m[c.Type+"/"+c.Slug] = c.NewVersion
 		}
 	}
-	if site.CoreUpdateAvailable && site.CoreNewVersion != "" {
+	if site.CoreUpdateAvailable && site.CoreNewVersion != "" &&
+		!wpversion.SameVersion(site.CoreCurrentVersion, site.CoreNewVersion) {
 		m[TargetCore+"/core"] = site.CoreNewVersion
 	}
 	return m

--- a/apps/api/internal/update/service_test.go
+++ b/apps/api/internal/update/service_test.go
@@ -142,6 +142,80 @@ func (e *countingEnqueuer) EnqueueTask(context.Context, uuid.UUID, uuid.UUID, uu
 	return nil
 }
 
+// TestIndexPendingDropsSameVersionPhantom proves GH #210/#211's planTasks
+// authority checkpoint: indexPending (which planTasks intersects a run's
+// requested items against) excludes a component/core advisory whose
+// NewVersion normalizes equal to its own Version — a same-version phantom
+// (e.g. Kadence's observed "1.5.1 -> 1.5.1") must never be treated as
+// pending, or planTasks would plan a doomed/no-op update task for it. A
+// legitimate newer advisory (both component and core) is unaffected, and an
+// advisory on a component reporting an EMPTY installed Version is kept
+// (fail open — wpversion.SameVersion returns false when either side is
+// empty).
+func TestIndexPendingDropsSameVersionPhantom(t *testing.T) {
+	site := SiteInfo{
+		ID: uuid.New(), Enrolled: true,
+		Components: []Component{
+			// Phantom: NewVersion == Version — must not appear as pending.
+			{Type: TargetPlugin, Slug: "kadence", Version: "1.5.1", UpdateAvailable: true, NewVersion: "1.5.1"},
+			// Legitimate newer update — must appear as pending.
+			{Type: TargetPlugin, Slug: "wp-rocket", Version: "3.16.1", UpdateAvailable: true, NewVersion: "3.16.2"},
+			// Fail-open: empty installed Version must never suppress a real update.
+			{Type: TargetPlugin, Slug: "mystery", Version: "", UpdateAvailable: true, NewVersion: "2.0"},
+		},
+		CoreUpdateAvailable: true,
+		CoreCurrentVersion:  "6.4.3",
+		CoreNewVersion:      "6.4.3", // phantom core advisory
+	}
+
+	pending := indexPending(site)
+
+	if _, ok := pending[TargetPlugin+"/kadence"]; ok {
+		t.Fatalf("same-version phantom must not be indexed as pending: %+v", pending)
+	}
+	if _, ok := pending[TargetCore+"/core"]; ok {
+		t.Fatalf("same-version phantom core advisory must not be indexed as pending: %+v", pending)
+	}
+	if v, ok := pending[TargetPlugin+"/wp-rocket"]; !ok || v != "3.16.2" {
+		t.Fatalf("legitimate newer advisory must be indexed as pending: %+v", pending)
+	}
+	if v, ok := pending[TargetPlugin+"/mystery"]; !ok || v != "2.0" {
+		t.Fatalf("fail-open (empty installed version) advisory must be indexed as pending: %+v", pending)
+	}
+}
+
+// TestCreateRunNoTaskForSameVersionPhantomUpdate is the end-to-end companion
+// to TestIndexPendingDropsSameVersionPhantom: a site whose only "pending"
+// component is a same-version phantom produces NO task through the full
+// CreateRun -> planTasks -> indexPending path, exactly like a site with
+// nothing pending at all.
+func TestCreateRunNoTaskForSameVersionPhantomUpdate(t *testing.T) {
+	tenant := uuid.New()
+	siteA := uuid.New()
+	lookup := &fakeSiteLookup{sites: map[uuid.UUID]SiteInfo{
+		siteA: {
+			ID: siteA, Enrolled: true,
+			Components: []Component{
+				{Type: TargetPlugin, Slug: "kadence", Version: "1.5.1", UpdateAvailable: true, NewVersion: "1.5.1"},
+			},
+		},
+	}}
+	svc := NewService(&fakeCreateRepo{}, lookup, &countingEnqueuer{}, domain.NewValidator(), domain.SystemClock{})
+
+	_, _, err := svc.CreateRun(context.Background(), CreateRunInput{
+		TenantID: tenant,
+		SiteIDs:  []uuid.UUID{siteA},
+		Items:    []Item{{Type: "plugin", Slug: "kadence", Version: "latest"}},
+	})
+	if err == nil {
+		t.Fatal("want an error: a same-version phantom advisory must not plan a task")
+	}
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindValidation {
+		t.Fatalf("want a KindValidation domain error, got %v", err)
+	}
+}
+
 // TestCreateRunIntersectsPerSitePendingUpdates is the regression test for
 // #126 (Problem 1: the N×M task-explosion bug). Two sites are selected in one
 // run: site A has 3 of its own pending updates, site B has 20 (2 of which

--- a/apps/api/internal/update/worker.go
+++ b/apps/api/internal/update/worker.go
@@ -231,10 +231,10 @@ func (w *Worker) runApply(ctx context.Context, task Task, siteURL string, item a
 	probe, perr, attempts := w.probeHealthWithRetry(ctx, siteURL)
 	if perr != nil {
 		// Still unreachable after retrying — treat as unhealthy and roll back.
-		return w.rollback(ctx, task, siteURL, item, res, fmt.Sprintf("post-update probe error after %d attempt(s): %v", attempts, perr))
+		return w.rollback(ctx, task, siteURL, item, res, probe, fmt.Sprintf("post-update probe error after %d attempt(s): %v", attempts, perr))
 	}
 	if !probe.Healthy() {
-		return w.rollback(ctx, task, siteURL, item, res, fmt.Sprintf("post-update health failed after %d attempt(s): status=%d %s", attempts, probe.StatusCode, probe.Detail))
+		return w.rollback(ctx, task, siteURL, item, res, probe, fmt.Sprintf("post-update health failed after %d attempt(s): status=%d %s", attempts, probe.StatusCode, probe.Detail))
 	}
 
 	return w.finish(ctx, task, TaskSucceeded, fromOr(res.FromVersion, task.FromVersion), res.ToVersion, "updated and healthy", "")
@@ -276,8 +276,12 @@ func (w *Worker) probeHealthWithRetry(ctx context.Context, siteURL string) (prob
 	}
 }
 
-// rollback issues the signed rollback command and records the rolled_back state.
-func (w *Worker) rollback(ctx context.Context, task Task, siteURL string, item agentcmd.UpdateItem, res agentcmd.ItemResult, reason string) error {
+// rollback issues the signed rollback command and records the rolled_back
+// state. probe is the ProbeResult that triggered the rollback decision (the
+// zero value when rollback was reached via a probe TRANSPORT error rather
+// than a reachable-but-unhealthy response) — it is used only to classify a
+// rollback-transport failure below (GH #210).
+func (w *Worker) rollback(ctx context.Context, task Task, siteURL string, item agentcmd.UpdateItem, res agentcmd.ItemResult, probe agentcmd.ProbeResult, reason string) error {
 	from := fromOr(res.FromVersion, task.FromVersion)
 	_, rbErr := w.cmd.Rollback(ctx, task.SiteID, siteURL, agentcmd.RollbackRequest{
 		Type:       item.Type,
@@ -288,7 +292,21 @@ func (w *Worker) rollback(ctx context.Context, task Task, siteURL string, item a
 	if rbErr != nil {
 		// Rollback itself failed: this is the worst case. Record as failed with
 		// both the health reason and the rollback error so the operator is alerted.
-		return w.finish(ctx, task, TaskFailed, from, res.ToVersion, "rollback FAILED after unhealthy update: "+reason, rbErr.Error())
+		detail := "rollback FAILED after unhealthy update: " + reason
+		// GH #210: when the post-update probe ITSELF detected a site-wide PHP
+		// fatal (a fatal-error body signature, or a 5xx response) AND the
+		// rollback command's transport also errored, the site is very likely
+		// serving a site-wide PHP fatal that makes the agent's own REST
+		// endpoint undeliverable — a distinct, more actionable failure mode
+		// than a generic "rollback failed" (which could also mean e.g. a
+		// transient network blip unrelated to the update). Record a distinct
+		// detail so the operator knows the automatic filesystem-level
+		// recovery on the agent side is the remaining recovery path.
+		if probe.Fatal || probe.StatusCode >= 500 {
+			detail = "site not responding: site-wide PHP fatal after update; rollback command undeliverable. " +
+				"The agent update watchdog will attempt automatic filesystem recovery; if it cannot, manual filesystem recovery is required."
+		}
+		return w.finish(ctx, task, TaskFailed, from, res.ToVersion, detail, rbErr.Error())
 	}
 	return w.finish(ctx, task, TaskRolledBack, from, from, "rolled back: "+reason, "")
 }

--- a/apps/api/internal/update/worker_test.go
+++ b/apps/api/internal/update/worker_test.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -219,7 +220,7 @@ func TestRunApply_ProbeRetry_StillUnhealthyRollsBack(t *testing.T) {
 	}
 
 	reason := fmt.Sprintf("post-update health failed after %d attempt(s): status=%d %s", attempts, probe.StatusCode, probe.Detail)
-	if err := w.rollback(context.Background(), task, "https://example.test", item, res, reason); err != nil {
+	if err := w.rollback(context.Background(), task, "https://example.test", item, res, probe, reason); err != nil {
 		t.Fatalf("rollback: %v", err)
 	}
 	if !cmd.rollbackCalled {
@@ -281,5 +282,98 @@ func TestRunApply_ProbeRetry_RespectsContextCancellation(t *testing.T) {
 	}
 	if perr == nil {
 		t.Fatalf("expected a context error, got nil")
+	}
+}
+
+// TestRollback_FatalProbeAndRollbackTransportError_RecordsDistinctDetail
+// covers GH #210: when the post-update probe itself detected a site-wide PHP
+// fatal (a Fatal body signature, or a 5xx status) AND the rollback command's
+// own transport also errors — the site's REST endpoint is itself
+// undeliverable, most likely because of that same fatal — the recorded
+// detail must be the distinct, actionable message, not the generic
+// "rollback FAILED after unhealthy update", because the CP round trip cannot
+// recover this site; only the agent's own filesystem-level watchdog (or
+// manual intervention) can.
+func TestRollback_FatalProbeAndRollbackTransportError_RecordsDistinctDetail(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &fakeCommander{rollbackErr: fmt.Errorf("dial tcp: connection refused")}
+	w := newTestWorker(repo, cmd, &scriptedProber{script: []probeStep{unhealthyStep(503)}})
+
+	task := testTask()
+	item := updateItem()
+	res := agentcmd.ItemResult{Type: item.Type, Slug: item.Slug, FromVersion: "1.9.9", ToVersion: "2.0.0", Status: agentcmd.ItemSucceeded}
+	fatalProbe := agentcmd.ProbeResult{StatusCode: 200, Fatal: true, Detail: "fatal-error signature in response body"}
+
+	if err := w.rollback(context.Background(), task, "https://example.test", item, res, fatalProbe, "post-update health failed"); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if !cmd.rollbackCalled {
+		t.Fatalf("expected the rollback command to have been attempted")
+	}
+	if len(repo.finished) != 1 {
+		t.Fatalf("expected one finish call, got %d", len(repo.finished))
+	}
+	got := repo.finished[0]
+	if got.Status != TaskFailed {
+		t.Fatalf("expected TaskFailed, got %s", got.Status)
+	}
+	if !strings.Contains(got.Detail, "site not responding") || !strings.Contains(got.Detail, "rollback command undeliverable") {
+		t.Fatalf("expected the distinct site-wide-fatal detail, got %q", got.Detail)
+	}
+	if strings.Contains(got.Detail, "rollback FAILED after unhealthy update") {
+		t.Fatalf("must NOT use the generic rollback-failed detail on a fatal-probe branch: %q", got.Detail)
+	}
+}
+
+// TestRollback_FatalStatusOnlyAndRollbackTransportError_RecordsDistinctDetail
+// covers the 5xx-without-a-body-signature half of the GH #210 condition (the
+// agent.go/agentcmd Probe never sets Fatal for a bare 5xx — only StatusCode).
+func TestRollback_FatalStatusOnlyAndRollbackTransportError_RecordsDistinctDetail(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &fakeCommander{rollbackErr: fmt.Errorf("dial tcp: connection refused")}
+	w := newTestWorker(repo, cmd, &scriptedProber{script: []probeStep{unhealthyStep(503)}})
+
+	task := testTask()
+	item := updateItem()
+	res := agentcmd.ItemResult{Type: item.Type, Slug: item.Slug, FromVersion: "1.9.9", ToVersion: "2.0.0", Status: agentcmd.ItemSucceeded}
+	statusOnlyProbe := agentcmd.ProbeResult{StatusCode: 503, Detail: "server returned status 503"}
+
+	if err := w.rollback(context.Background(), task, "https://example.test", item, res, statusOnlyProbe, "post-update health failed"); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	got := repo.finished[0]
+	if !strings.Contains(got.Detail, "site not responding") {
+		t.Fatalf("expected the distinct site-wide-fatal detail for a 5xx-only probe, got %q", got.Detail)
+	}
+}
+
+// TestRollback_NonFatalTransportErrorKeepsGenericDetail proves the GH #210
+// distinct detail is scoped to a Fatal/5xx probe: a plain probe transport
+// error (the zero-value ProbeResult probeHealthWithRetry returns when the
+// probe itself never got a response) whose rollback ALSO fails to transport
+// keeps the existing generic "rollback FAILED" message — that combination is
+// just as likely to be an unrelated network blip as a site-wide PHP fatal.
+func TestRollback_NonFatalTransportErrorKeepsGenericDetail(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &fakeCommander{rollbackErr: fmt.Errorf("dial tcp: i/o timeout")}
+	w := newTestWorker(repo, cmd, &scriptedProber{})
+
+	task := testTask()
+	item := updateItem()
+	res := agentcmd.ItemResult{Type: item.Type, Slug: item.Slug, FromVersion: "1.9.9", ToVersion: "2.0.0", Status: agentcmd.ItemSucceeded}
+	transportErrProbe := agentcmd.ProbeResult{} // StatusCode 0, Fatal false
+
+	if err := w.rollback(context.Background(), task, "https://example.test", item, res, transportErrProbe, "post-update probe error"); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if len(repo.finished) != 1 {
+		t.Fatalf("expected one finish call, got %d", len(repo.finished))
+	}
+	got := repo.finished[0]
+	if !strings.HasPrefix(got.Detail, "rollback FAILED after unhealthy update:") {
+		t.Fatalf("expected the generic rollback-failed detail, got %q", got.Detail)
+	}
+	if strings.Contains(got.Detail, "site not responding") {
+		t.Fatalf("must NOT use the distinct fatal detail on a non-fatal transport error: %q", got.Detail)
 	}
 }

--- a/apps/api/internal/wpversion/compare.go
+++ b/apps/api/internal/wpversion/compare.go
@@ -336,3 +336,37 @@ func BestFixedVersion(installed string, patched []string) string {
 	}
 	return best
 }
+
+// SameVersion reports whether installed and available refer to the same
+// release after light, conservative normalization: both sides are
+// TrimSpace'd, then a single leading "v"/"V" prefix is stripped from each
+// (some update-transient sources report a "v"-prefixed version while the
+// installed Version string carries none, or vice versa).
+//
+// This is intentionally an EQUALITY-only comparison. Go has no
+// version_compare() equivalent safe enough to use for ORDERING an arbitrary
+// plugin/theme version string, and a hand-rolled ordering check risks
+// misclassifying a genuinely newer update as already-installed — far worse
+// than the phantom-update symptom this guards against (GH #211: a WordPress
+// update transient occasionally reports new_version == the already-installed
+// Version, e.g. a Kadence "1.5.1 -> 1.5.1" advisory). Compare() (PHP
+// version_compare semantics) is deliberately NOT used here.
+//
+// Either side empty returns false — fail OPEN, so a missing/unknown
+// installed version never suppresses a reported update.
+func SameVersion(installed, available string) bool {
+	installed = strings.TrimSpace(installed)
+	available = strings.TrimSpace(available)
+	if installed == "" || available == "" {
+		return false
+	}
+	return stripLeadingV(installed) == stripLeadingV(available)
+}
+
+// stripLeadingV removes a single leading "v"/"V" prefix, if present.
+func stripLeadingV(v string) string {
+	if len(v) > 0 && (v[0] == 'v' || v[0] == 'V') {
+		return v[1:]
+	}
+	return v
+}

--- a/apps/web/src/features/updates/available-updates-card.tsx
+++ b/apps/web/src/features/updates/available-updates-card.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 import { Link } from "@tanstack/react-router";
-import { Check, CheckCircle2, ExternalLink, RotateCcw, X } from "lucide-react";
+import {
+  AlertTriangle,
+  Check,
+  CheckCircle2,
+  ExternalLink,
+  RotateCcw,
+  X,
+} from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -31,6 +38,10 @@ import {
   type CoreUpdate,
   type SiteAvailableUpdates,
 } from "@/features/updates/types";
+import {
+  isSiteDownRecovery,
+  SITE_DOWN_RECOVERY_FALLBACK_DETAIL,
+} from "@/features/updates/summarize";
 import { toast } from "@/components/toast";
 import { wpOrgSlug } from "@/features/updates/wp-org-slug";
 
@@ -474,16 +485,33 @@ function RowStateLine({
         </span>
       );
     case "failed":
-      return (
-        <span
-          role="alert"
-          className="inline-flex items-center gap-1 text-[var(--color-destructive)]"
-        >
-          <X aria-hidden="true" className="size-3.5" />
-          {error ?? "Update failed"}
-        </span>
-      );
-    case "rolled_back":
+    case "rolled_back": {
+      // GH #210 — the worst-case rollback failure (site-wide fatal, the
+      // rollback command undeliverable, an agent watchdog attempting
+      // automatic filesystem recovery) reads as its own severe, actionable
+      // condition here too, not a generic "failed"/"rolled back" line.
+      if (isSiteDownRecovery(state, progress, error)) {
+        return (
+          <span
+            role="alert"
+            className="inline-flex items-start gap-1.5 text-destructive-subtle-fg"
+          >
+            <AlertTriangle aria-hidden="true" className="mt-0.5 size-3.5 shrink-0" />
+            {error ?? progress ?? SITE_DOWN_RECOVERY_FALLBACK_DETAIL}
+          </span>
+        );
+      }
+      if (state === "failed") {
+        return (
+          <span
+            role="alert"
+            className="inline-flex items-center gap-1 text-[var(--color-destructive)]"
+          >
+            <X aria-hidden="true" className="size-3.5" />
+            {error ?? "Update failed"}
+          </span>
+        );
+      }
       return (
         <span
           role="alert"
@@ -493,6 +521,7 @@ function RowStateLine({
           Rolled back{error ? `: ${error}` : ""}
         </span>
       );
+    }
     case "skipped":
       return (
         <span role="status" className="text-[var(--color-muted-foreground)]">

--- a/apps/web/src/features/updates/summarize.test.ts
+++ b/apps/web/src/features/updates/summarize.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+
+import { isSiteDownRecovery } from "./summarize";
+
+// GH #210 — pure-logic coverage for the site-down-recovery detector: the
+// worst-case rollback failure (site-wide PHP fatal, undeliverable rollback,
+// automatic filesystem recovery attempted by the agent watchdog). The
+// backend keeps the existing failed/rolled_back status and communicates the
+// condition purely through detail/error text, so this is the single source
+// of truth every rendering surface (TaskStatusBadge, UpdateTasksTable,
+// AvailableUpdatesCard's RowStateLine) keys off.
+
+describe("isSiteDownRecovery", () => {
+  it("is true for a rolled_back task whose detail describes the condition", () => {
+    expect(
+      isSiteDownRecovery(
+        "rolled_back",
+        "The site went down site-wide; automatic filesystem recovery was attempted.",
+        undefined,
+      ),
+    ).toBe(true);
+  });
+
+  it("is true for a failed task whose error (not detail) describes the condition", () => {
+    expect(
+      isSiteDownRecovery(
+        "failed",
+        undefined,
+        "Site is not responding; the rollback command was undeliverable and an agent watchdog attempted automatic recovery.",
+      ),
+    ).toBe(true);
+  });
+
+  it("is false for an ordinary rolled_back/failed task with unrelated detail/error text", () => {
+    expect(
+      isSiteDownRecovery("rolled_back", "agent reported update failure", "activation check failed"),
+    ).toBe(false);
+    expect(isSiteDownRecovery("failed", "connection timed out", undefined)).toBe(false);
+  });
+
+  it("is false for a non-terminal-failure status even if the text matches (e.g. a stray log line on a running task)", () => {
+    expect(
+      isSiteDownRecovery("running", "watchdog check in progress, site-wide scan", undefined),
+    ).toBe(false);
+    expect(isSiteDownRecovery("succeeded", "site-wide cache cleared", undefined)).toBe(false);
+    expect(isSiteDownRecovery("pending", undefined, undefined)).toBe(false);
+    expect(isSiteDownRecovery("skipped", undefined, undefined)).toBe(false);
+  });
+
+  it("is false when detail/error is empty on a terminal status", () => {
+    expect(isSiteDownRecovery("failed", undefined, undefined)).toBe(false);
+    expect(isSiteDownRecovery("rolled_back", "", "")).toBe(false);
+  });
+});

--- a/apps/web/src/features/updates/summarize.ts
+++ b/apps/web/src/features/updates/summarize.ts
@@ -33,3 +33,39 @@ export function siteNameMap(sites: Site[] | undefined): Map<string, string> {
   for (const site of sites ?? []) map.set(site.id, site.name);
   return map;
 }
+
+// GH #210 — the worst-case rollback failure: an update causes a site-wide
+// PHP fatal, so the rollback command is undeliverable (it rides the same
+// WordPress request that's fataling), and an agent-side watchdog attempts
+// automatic filesystem-level recovery. The backend keeps the existing task
+// status enum (failed/rolled_back) and communicates this condition purely
+// through the detail/error text, so callers key off content rather than a
+// new status value. Every surface that renders a task's outcome should use
+// this helper rather than re-deriving the pattern locally, so the condition
+// reads consistently (and never as a generic "rollback failed") everywhere.
+const SITE_DOWN_RECOVERY_STATUSES = new Set(["failed", "rolled_back"]);
+const SITE_DOWN_RECOVERY_PATTERN =
+  /site[- ]wide|site is down|not responding|undeliverable|filesystem recovery|automatic recovery|watchdog/i;
+
+/**
+ * True when a terminal (failed/rolled_back) task's detail/error text
+ * describes the site-wide-fatal + undeliverable-rollback + auto-filesystem-
+ * recovery condition, as opposed to an ordinary update failure or rollback.
+ */
+export function isSiteDownRecovery(
+  status: string,
+  detail?: string,
+  error?: string,
+): boolean {
+  if (!SITE_DOWN_RECOVERY_STATUSES.has(status)) return false;
+  return SITE_DOWN_RECOVERY_PATTERN.test(`${detail ?? ""} ${error ?? ""}`);
+}
+
+/** Distinct, actionable label for the site-down-recovery condition. Never
+ * collapse this into the generic "Rolled back"/"Failed" copy. */
+export const SITE_DOWN_RECOVERY_LABEL = "Site down, recovery attempted";
+
+/** Fallback body copy when the backend detail is empty but the condition is
+ * detected from `error` alone. */
+export const SITE_DOWN_RECOVERY_FALLBACK_DETAIL =
+  "The site went down site-wide during this update. Automatic filesystem recovery was attempted; manual filesystem recovery may be required.";

--- a/apps/web/src/features/updates/update-status.tsx
+++ b/apps/web/src/features/updates/update-status.tsx
@@ -2,6 +2,7 @@ import type { UpdateRun, UpdateTask } from "@wpmgr/api";
 
 import { StatusChip } from "@/components/status/status-chip";
 import type { StatusTone } from "@/components/status/status-dot";
+import { isSiteDownRecovery, SITE_DOWN_RECOVERY_LABEL } from "./summarize";
 
 type TaskStatus = UpdateTask["status"];
 type RunStatus = UpdateRun["status"];
@@ -15,8 +16,20 @@ const TASK_TONE: Record<TaskStatus, { tone: StatusTone; label: string; pulse?: b
   skipped: { tone: "muted", label: "Skipped" },
 };
 
-export function TaskStatusBadge({ status }: { status: TaskStatus }) {
-  const cfg = TASK_TONE[status];
+export function TaskStatusBadge({
+  task,
+}: {
+  task: Pick<UpdateTask, "status" | "detail" | "error">;
+}) {
+  // GH #210 — the site-wide-fatal + undeliverable-rollback + auto-filesystem-
+  // recovery condition is distinct and more severe than an ordinary failure
+  // or rollback. The backend reports it through detail/error text on the
+  // existing failed/rolled_back statuses, so surface it as its own chip
+  // instead of the generic "Failed"/"Rolled back" label.
+  if (isSiteDownRecovery(task.status, task.detail, task.error)) {
+    return <StatusChip tone="destructive" label={SITE_DOWN_RECOVERY_LABEL} />;
+  }
+  const cfg = TASK_TONE[task.status];
   return (
     <StatusChip
       tone={cfg.tone}

--- a/apps/web/src/features/updates/update-tasks-table.test.tsx
+++ b/apps/web/src/features/updates/update-tasks-table.test.tsx
@@ -101,3 +101,82 @@ describe("UpdateTasksTable — failed task log disclosure", () => {
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });
 });
+
+// GH #210 — the worst-case rollback failure: an update causes a site-wide
+// PHP fatal, so the rollback command is undeliverable (it rides the same
+// WordPress request that's fataling), and an agent-side watchdog attempts
+// automatic filesystem recovery. The backend keeps the existing
+// failed/rolled_back status and communicates this purely through the
+// detail/error text, so this MUST read as its own distinct, actionable
+// condition (never the generic "Rolled back"/"Failed" copy).
+describe("UpdateTasksTable — GH #210 site-down-recovery condition", () => {
+  it("renders the distinct site-down badge + non-truncated alert callout for a rolled_back task whose detail names the condition, instead of the generic 'Rolled back' copy", () => {
+    const task = buildTask({
+      id: "task-site-down",
+      status: "rolled_back",
+      detail:
+        "The site went down site-wide during this update. The rollback command was undeliverable; an automatic filesystem recovery was attempted.",
+      error: "Fatal error: watchdog restore log ...",
+    });
+
+    renderWithProviders(<UpdateTasksTable tasks={[task]} />);
+
+    const row = screen.getByTestId("update-task-row");
+
+    // Distinct badge label, not the generic "Rolled back" chip.
+    expect(within(row).getByText("Site down, recovery attempted")).toBeInTheDocument();
+    expect(within(row).queryByText("Rolled back")).not.toBeInTheDocument();
+
+    // The full detail text is surfaced directly (not truncated behind a
+    // title attribute) inside an alert-role callout.
+    const callout = within(row).getByRole("alert");
+    expect(callout).toHaveTextContent(/site went down site-wide/i);
+    expect(callout).toHaveTextContent(/automatic filesystem recovery/i);
+  });
+
+  it("renders the distinct treatment for a failed task whose error (not detail) names the condition, falling back to the canned explanation since detail is empty, while the raw error stays reachable via the log disclosure", () => {
+    const task = buildTask({
+      id: "task-failed-site-down",
+      status: "failed",
+      detail: undefined,
+      error:
+        "Site is not responding after the update; agent watchdog attempted automatic recovery of the filesystem.",
+    });
+
+    renderWithProviders(<UpdateTasksTable tasks={[task]} />);
+
+    const row = screen.getByTestId("update-task-row");
+    expect(within(row).getByText("Site down, recovery attempted")).toBeInTheDocument();
+    // No detail was provided, so the callout falls back to the canned
+    // explanation rather than rendering nothing.
+    expect(within(row).getByRole("alert")).toHaveTextContent(
+      /automatic filesystem recovery was attempted/i,
+    );
+    // The raw agent error is still reachable one click away, unchanged from
+    // the existing log-disclosure behavior.
+    fireEvent.click(within(row).getByRole("button", { name: /view log/i }));
+    expect(screen.getByText(/agent watchdog attempted automatic recovery/i)).toBeInTheDocument();
+  });
+
+  it("leaves an ordinary rolled_back / failed task on the generic status copy (no false positive)", () => {
+    const rolledBack = buildTask({
+      id: "task-ordinary-rollback",
+      status: "rolled_back",
+      detail: "agent reported update failure",
+      error: "activation check failed after replacing plugin files",
+    });
+    const failed = buildTask({
+      id: "task-ordinary-failed",
+      target_slug: "another-plugin/another-plugin.php",
+      status: "failed",
+      detail: "connection timed out",
+    });
+
+    renderWithProviders(<UpdateTasksTable tasks={[rolledBack, failed]} />);
+
+    const rows = screen.getAllByTestId("update-task-row");
+    expect(within(rows[0]!).getByText("Rolled back")).toBeInTheDocument();
+    expect(within(rows[1]!).getByText("Failed")).toBeInTheDocument();
+    expect(screen.queryByText("Site down, recovery attempted")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/updates/update-tasks-table.tsx
+++ b/apps/web/src/features/updates/update-tasks-table.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Check, ChevronDown, ChevronRight, Copy } from "lucide-react";
+import { AlertTriangle, Check, ChevronDown, ChevronRight, Copy } from "lucide-react";
 import type { UpdateTask } from "@wpmgr/api";
 
 import {
@@ -13,6 +13,10 @@ import {
 import { Button } from "@/components/ui/button";
 import { VersionArrow } from "@/components/shared/version-arrow";
 import { TaskStatusBadge } from "@/features/updates/update-status";
+import {
+  isSiteDownRecovery,
+  SITE_DOWN_RECOVERY_FALLBACK_DETAIL,
+} from "@/features/updates/summarize";
 
 // Re-export siteNameMap so existing callers (e.g. $runId.tsx) don't need an
 // import path change. Surface C agents may update their imports to ./summarize.
@@ -84,6 +88,7 @@ function UpdateTaskRow({
   const [open, setOpen] = useState(false);
   const hasLog = Boolean(task.error && task.error.trim().length > 0);
   const logId = `update-task-log-${task.id}`;
+  const siteDown = isSiteDownRecovery(task.status, task.detail, task.error);
 
   return (
     <>
@@ -112,17 +117,34 @@ function UpdateTaskRow({
           )}
         </TableCell>
         <TableCell>
-          <TaskStatusBadge status={task.status} />
+          <TaskStatusBadge task={task} />
         </TableCell>
         <TableCell className="max-w-[220px] text-xs text-muted-foreground">
           <div className="flex flex-col items-start gap-1">
-            <span
-              className="max-w-full min-w-0 truncate font-mono"
-              title={task.detail}
-            >
-              {task.detail ??
-                (hasLog ? "See log for details" : <span aria-hidden="true">{"–"}</span>)}
-            </span>
+            {siteDown ? (
+              // GH #210 — never truncate this: it's the worst-case rollback
+              // failure (site-wide fatal, undeliverable rollback, automatic
+              // filesystem recovery attempted) and needs to read as its own
+              // actionable condition, not a generic status string.
+              <span
+                role="alert"
+                className="flex items-start gap-1.5 whitespace-normal text-destructive-subtle-fg"
+              >
+                <AlertTriangle
+                  aria-hidden="true"
+                  className="mt-0.5 size-3.5 shrink-0"
+                />
+                <span>{task.detail ?? SITE_DOWN_RECOVERY_FALLBACK_DETAIL}</span>
+              </span>
+            ) : (
+              <span
+                className="max-w-full min-w-0 truncate font-mono"
+                title={task.detail}
+              >
+                {task.detail ??
+                  (hasLog ? "See log for details" : <span aria-hidden="true">{"–"}</span>)}
+              </span>
+            )}
             {hasLog ? (
               <Button
                 type="button"

--- a/apps/web/src/features/updates/update-wizard.test.tsx
+++ b/apps/web/src/features/updates/update-wizard.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { screen, fireEvent, within } from "@testing-library/react";
+import type { Site } from "@wpmgr/api";
+
+import { renderWithProviders } from "@/test/render";
+
+import { UpdateWizard, type WizardTarget } from "./update-wizard";
+
+// GH #211 — a WordPress update transient can occasionally report
+// `new_version` equal to the already-installed `version` (observed with
+// Kadence: "1.5.1 -> 1.5.1"). The bulk-update wizard used to treat any
+// non-null `available_update` as a real update, which pre-filtered the
+// phantom entry into the "has update" list and counted it in the tab badge.
+// This pins the fix: a same-version (post-normalization) entry is treated as
+// NOT having an update, everywhere `hasUpdate` drives visibility/labeling.
+
+function buildSite(overrides: Partial<Site> = {}): Site {
+  return {
+    id: "site-1",
+    tenant_id: "tenant-1",
+    url: "https://example.com",
+    name: "Example",
+    status: "active",
+    wp_version: "6.8",
+    php_version: "8.3",
+    health_status: "healthy",
+    multisite: false,
+    tags: [],
+    ...overrides,
+  } as unknown as Site;
+}
+
+const TARGET: WizardTarget = {
+  kind: "sites",
+  siteIds: ["site-1"],
+  updateKind: "plugins",
+};
+
+describe("UpdateWizard — GH #211 same-version phantom guard", () => {
+  it("excludes a same-version (and v-prefixed same-version) entry from the default 'has update' list and tab count, while a real update still appears", async () => {
+    const site = buildSite({
+      components: {
+        plugins: [
+          // Phantom: exact same-version advisory (the reported Kadence bug).
+          {
+            slug: "kadence",
+            name: "Kadence",
+            version: "1.5.1",
+            available_update: { new_version: "1.5.1" },
+          },
+          // Phantom: "v"-prefixed same-version advisory.
+          {
+            slug: "elementor",
+            name: "Elementor",
+            version: "2.0.0",
+            available_update: { new_version: "v2.0.0" },
+          },
+          // Real update: genuinely different version.
+          {
+            slug: "woocommerce",
+            name: "WooCommerce",
+            version: "8.0.0",
+            available_update: { new_version: "8.1.0" },
+          },
+        ],
+        themes: [],
+      },
+    });
+
+    renderWithProviders(
+      <UpdateWizard open target={TARGET} sites={[site]} onClose={() => {}} />,
+      { withRouter: true },
+    );
+
+    // Default filter is "with updates only" — only the real update shows.
+    // The test router's first paint is async (see test/render.tsx), so the
+    // first assertion must be a `findBy*`.
+    expect(await screen.findByText("WooCommerce")).toBeInTheDocument();
+    expect(screen.queryByText("Kadence")).not.toBeInTheDocument();
+    expect(screen.queryByText("Elementor")).not.toBeInTheDocument();
+
+    // The Plugins tab count badge reflects only the real update (1), not 3.
+    const tab = screen.getByRole("tab", { name: /plugins/i });
+    expect(within(tab).getByText("1")).toBeInTheDocument();
+
+    // Switching to "Show all" reveals the phantom rows, but they must be
+    // labeled "up to date", never the "update" pill.
+    fireEvent.click(screen.getByRole("button", { name: /show all/i }));
+
+    const kadenceRow = screen.getByText("Kadence").closest("li");
+    expect(kadenceRow).not.toBeNull();
+    expect(within(kadenceRow!).getByText("up to date")).toBeInTheDocument();
+    expect(within(kadenceRow!).queryByText("update")).not.toBeInTheDocument();
+
+    const elementorRow = screen.getByText("Elementor").closest("li");
+    expect(elementorRow).not.toBeNull();
+    expect(within(elementorRow!).getByText("up to date")).toBeInTheDocument();
+    expect(within(elementorRow!).queryByText("update")).not.toBeInTheDocument();
+
+    const wooRow = screen.getByText("WooCommerce").closest("li");
+    expect(wooRow).not.toBeNull();
+    expect(within(wooRow!).getByText("update")).toBeInTheDocument();
+  });
+
+  it("still treats a missing installed version as having an update (fails open)", async () => {
+    const site = buildSite({
+      components: {
+        plugins: [
+          {
+            slug: "mystery-plugin",
+            name: "Mystery Plugin",
+            available_update: { new_version: "2.0.0" },
+          },
+        ],
+        themes: [],
+      },
+    });
+
+    renderWithProviders(
+      <UpdateWizard open target={TARGET} sites={[site]} onClose={() => {}} />,
+      { withRouter: true },
+    );
+
+    expect(await screen.findByText("Mystery Plugin")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/updates/update-wizard.tsx
+++ b/apps/web/src/features/updates/update-wizard.tsx
@@ -48,6 +48,36 @@ interface ComponentOption {
   hasUpdate: boolean;
 }
 
+/**
+ * Normalize a version string for equality comparison: trim whitespace and
+ * strip a single leading "v"/"V" (mirrors the backend's normalized-equality
+ * check). Deliberately a simple string compare, not a semver parse; the
+ * backend is the authority on real version semantics.
+ */
+function normalizeVersion(version: string): string {
+  const trimmed = version.trim();
+  return /^[vV]/.test(trimmed) ? trimmed.slice(1) : trimmed;
+}
+
+/**
+ * True when `available_update` reports a version that actually differs from
+ * what's installed. Guards against a phantom same-version entry (e.g. a
+ * cached `1.5.1 -> 1.5.1` row) being treated as a real update (GH #211).
+ * The backend is also being fixed to stop sending/persisting these, but this
+ * keeps the wizard correct against already-cached data.
+ */
+function isRealUpdate(
+  installedVersion: string | undefined,
+  availableUpdate: { new_version: string } | undefined,
+): boolean {
+  if (!availableUpdate) return false;
+  if (installedVersion === undefined) return true;
+  return (
+    normalizeVersion(availableUpdate.new_version) !==
+    normalizeVersion(installedVersion)
+  );
+}
+
 /** Build a de-duplicated, sorted list of plugin/theme options from sites. */
 function componentOptions(sites: Site[]): ComponentOption[] {
   const seen = new Map<string, ComponentOption>();
@@ -59,12 +89,16 @@ function componentOptions(sites: Site[]): ComponentOption[] {
           type: "plugin",
           slug: plugin.slug,
           label: plugin.name ?? plugin.slug,
-          hasUpdate: Boolean(plugin.available_update),
+          hasUpdate: isRealUpdate(plugin.version, plugin.available_update),
         });
       } else {
-        // If any site reports an update available, mark the option as having one.
+        // If any site reports a real (different-version) update, mark the
+        // option as having one.
         const existing = seen.get(key)!;
-        if (plugin.available_update && !existing.hasUpdate) {
+        if (
+          isRealUpdate(plugin.version, plugin.available_update) &&
+          !existing.hasUpdate
+        ) {
           seen.set(key, { ...existing, hasUpdate: true });
         }
       }
@@ -76,11 +110,14 @@ function componentOptions(sites: Site[]): ComponentOption[] {
           type: "theme",
           slug: theme.slug,
           label: theme.name ?? theme.slug,
-          hasUpdate: Boolean(theme.available_update),
+          hasUpdate: isRealUpdate(theme.version, theme.available_update),
         });
       } else {
         const existing = seen.get(key)!;
-        if (theme.available_update && !existing.hasUpdate) {
+        if (
+          isRealUpdate(theme.version, theme.available_update) &&
+          !existing.hasUpdate
+        ) {
           seen.set(key, { ...existing, hasUpdate: true });
         }
       }


### PR DESCRIPTION
Three update-transient/recovery bugs reported on v0.61.55, fixed as a cluster after a parallel investigation with a whole-class completeness sweep.

## GH #210 (HIGH) — rollback fails when an update fatals every request
An update that applies cleanly but then causes a site-wide PHP fatal left rollback undeliverable (it rides the same WP REST route that's fataling), so the site stayed fully down. Fix: a self-contained **update-watchdog mu-plugin** (loads before regular plugins; its shutdown handler survives a regular-plugin bootstrap fatal) that does an autoloader-free filesystem restore of the pre-update snapshot. Anchoring mirrors `SnapshotManager` exactly and was **security-reviewed against the GH #147 data-loss history (verdict: SHIP)**. Hardened so it cannot revert a good update: OOM/timeout fatals excluded, and a healthy bootstrap disarms the marker. CP + web surface a distinct "site not responding, recovery attempted" state.

## GH #211 (Medium) — phantom same-version available update
No stage compared the offered version to the installed one (e.g. Kadence `1.5.1 -> 1.5.1`). Fixed at the agent normalizer, sibling counts, CP write chokepoint + read projection (self-heals stored phantoms), planTasks, and the wizard.

## GH #212 (Medium) — Refresh doesn't force a real check
`refreshUpdateTransients(force)` only bypassed WPMgr's own lock, not WP core's ~12h throttle. Explicit refresh now deletes the transients + forces the checks; scheduled refresh stays soft. Also fixes the residual gap in the apply-path freshness check and invalidates the transient after a rollback.

## Verification
- Investigation: 5-agent workflow (per-issue + completeness sweep) → reconciled design
- Security review of the #210 watchdog restore vs GH #147 anchoring: **SHIP** (data-loss class structurally absent); 4 flagged robustness findings fixed before this PR
- agent 2638 PHP tests (incl. 48 watchdog + #147-style path-safety), phpcs 0, `wp plugin check` 0 errors
- CP `go build`/`vet`/`test` green; web 1009 tests green
- Multi-layer: agent (0.61.56) + CP + web; no media-encoder, no schema/OpenAPI change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed phantom same-version updates from dashboards, site details, update counts, and the update wizard.
  * Refresh now performs a fresh update check instead of relying on stale cached results.
  * Improved rollback recovery for sites that become unavailable after an update.
  * Rollback failures caused by site-wide fatal errors now display clearer, dedicated status messaging.
  * Update and rollback results now refresh availability information more reliably.

* **Release**
  * Updated the application to version 0.61.56.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->