### PR TITLE
fix(agent): WordPress.org T13 review hardening + code quality (0.61.57)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ Thumbs.db
 # local wp-cli (Plugin Check harness)
 wp-cli.phar
 wp-cli.phar.asc
+docs/security/wporg-t13-*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.57] - 2026-07-14
+
+### Changed
+
+- Agent code-quality and WordPress.org-compliance hardening, with no behavior change for managed sites. The real-user-monitoring collector now loads through the standard `wp_enqueue_script` async mechanism instead of a hand-built script tag; the two-factor and forced-password-change login screens now escape their output through `wp_kses` with an explicit tag allowlist at the output boundary; the long-running backup, restore, dump, and media routines now use a bounded 900-second time limit instead of an unlimited one; the CloudPanel integration inline-sanitizes its server-variable reads; and a stale storage-path note and a broken readme link were corrected. These improvements land in both the self-hosted agent and the WordPress.org build (fleet-agent-site-manager), which keeps the operator features (auto-login, updates, backups) and strips only the self-updater.
+
 ## [0.61.56] - 2026-07-11
 
 ### Fixed

--- a/apps/agent/includes/backup/class-core-files-archiver.php
+++ b/apps/agent/includes/backup/class-core-files-archiver.php
@@ -37,6 +37,8 @@ declare(strict_types=1);
 
 namespace WPMgr\Agent\Backup;
 
+use WPMgr\Agent\Support\LongRunningJob;
+
 /**
  * Pure-PHP streaming WordPress core archiver.
  *
@@ -144,7 +146,7 @@ final class CoreFilesArchiver
      */
     public function archive(string $outDir, callable $progress): array
     {
-        @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup/restore loop must not hit max_execution_time; @-guarded
+        @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup/restore loop must not hit max_execution_time; @-guarded
         @ignore_user_abort(true);
 
         if (!is_dir($outDir) && !wp_mkdir_p($outDir) && !is_dir($outDir)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- converted to wp_mkdir_p

--- a/apps/agent/includes/backup/class-db-dumper.php
+++ b/apps/agent/includes/backup/class-db-dumper.php
@@ -56,6 +56,8 @@ declare(strict_types=1);
 
 namespace WPMgr\Agent\Backup;
 
+use WPMgr\Agent\Support\LongRunningJob;
+
 /**
  * Streaming DB dumper. Constructs its OWN mysqli connection from the
  * supplied credentials — does NOT reuse WordPress's global $wpdb so it
@@ -112,7 +114,7 @@ final class DbDumper
      */
     public function dump(string $outPath, array $resume, callable $progress): array
     {
-        @set_time_limit(0); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running DB dump must not hit max_execution_time; @-guarded
+        @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running DB dump must not hit max_execution_time; @-guarded
         @ignore_user_abort(true);
 
         if (!empty($resume['done'])) {

--- a/apps/agent/includes/backup/class-db-restorer.php
+++ b/apps/agent/includes/backup/class-db-restorer.php
@@ -44,6 +44,8 @@ declare(strict_types=1);
 
 namespace WPMgr\Agent\Backup;
 
+use WPMgr\Agent\Support\LongRunningJob;
+
 /**
  * SQL dump replayer + per-table atomic swap. Constructs its own mysqli
  * connection from the supplied credentials — same shape as DbDumper, and
@@ -103,7 +105,7 @@ final class DbRestorer
             throw new \RuntimeException('DbRestorer: sourcePrefix empty');
         }
 
-        @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running restore loop must not hit max_execution_time; @-guarded, no-op when disabled
+        @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running restore loop must not hit max_execution_time; @-guarded, no-op when disabled
         @ignore_user_abort(true);
 
         $mysqli = $this->connect();
@@ -253,7 +255,7 @@ final class DbRestorer
             throw new \RuntimeException('DbRestorer::swap: empty prefix');
         }
 
-        @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running restore swap loop must not hit max_execution_time; @-guarded, no-op when disabled
+        @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running restore swap loop must not hit max_execution_time; @-guarded, no-op when disabled
         @ignore_user_abort(true);
 
         $mysqli = $this->connect();
@@ -328,7 +330,7 @@ final class DbRestorer
      */
     public function rewriteAllTables(string $tmpPrefix, string $sourcePrefix, array $replacements, array $resume, callable $checkpoint, callable $progress): array
     {
-        @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running URL-rewrite loop must not hit max_execution_time; @-guarded, no-op when disabled
+        @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running URL-rewrite loop must not hit max_execution_time; @-guarded, no-op when disabled
         @ignore_user_abort(true);
 
         $mysqli = $this->connect();

--- a/apps/agent/includes/backup/class-encrypt-and-upload.php
+++ b/apps/agent/includes/backup/class-encrypt-and-upload.php
@@ -63,6 +63,7 @@ use WPMgr\Agent\Backup\Destinations\DestinationResolver;
 use WPMgr\Agent\Support\AgeCrypto;
 use WPMgr\Agent\Support\BackupTransport;
 use WPMgr\Agent\Support\Blake3;
+use WPMgr\Agent\Support\LongRunningJob;
 
 /**
  * Three-pass chunk pipeline: encrypt → upload (dedup-aware) → submit manifest.
@@ -194,7 +195,7 @@ final class EncryptAndUpload
     {
         // Lift caller-imposed time/abort guards. We may be running inside an
         // FPM request that has already called fastcgi_finish_request().
-        @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running encrypt pass must not hit max_execution_time; @-guarded, no-op when disabled
+        @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running encrypt pass must not hit max_execution_time; @-guarded, no-op when disabled
         @ignore_user_abort(true);
 
         // Idempotent no-op for an already-completed cursor.
@@ -399,7 +400,7 @@ final class EncryptAndUpload
      */
     public function uploadChunks(array $encryptCursor, array $resume, callable $progress): array
     {
-        @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running upload pass must not hit max_execution_time; @-guarded, no-op when disabled
+        @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running upload pass must not hit max_execution_time; @-guarded, no-op when disabled
         @ignore_user_abort(true);
 
         if (!empty($resume['done'])) {
@@ -607,7 +608,7 @@ final class EncryptAndUpload
      */
     public function submitManifest(array $entries, callable $progress): void
     {
-        @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running manifest submit must not hit max_execution_time; @-guarded, no-op when disabled
+        @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running manifest submit must not hit max_execution_time; @-guarded, no-op when disabled
         @ignore_user_abort(true);
 
         try {

--- a/apps/agent/includes/backup/class-files-archiver.php
+++ b/apps/agent/includes/backup/class-files-archiver.php
@@ -66,6 +66,8 @@ declare(strict_types=1);
 
 namespace WPMgr\Agent\Backup;
 
+use WPMgr\Agent\Support\LongRunningJob;
+
 /**
  * Pure-PHP streaming wp-content archiver with on-disk path cache and
  * checkpointed resume. See file docblock for the rationale.
@@ -474,7 +476,7 @@ final class FilesArchiver
         // Lift caller-imposed time/abort guards. Watchdog handles
         // stall recovery; we want this loop to run as long as the SAPI
         // will let it.
-        @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup/restore loop must not hit max_execution_time; @-guarded
+        @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup/restore loop must not hit max_execution_time; @-guarded
         @ignore_user_abort(true);
 
         if (!is_dir($outDir) && !wp_mkdir_p($outDir) && !is_dir($outDir)) {

--- a/apps/agent/includes/backup/class-restore-runner.php
+++ b/apps/agent/includes/backup/class-restore-runner.php
@@ -81,6 +81,7 @@ use WPMgr\Agent\Signer;
 use WPMgr\Agent\Support\AgeIdentity;
 use WPMgr\Agent\Support\BackupTransport;
 use WPMgr\Agent\Support\Blake3;
+use WPMgr\Agent\Support\LongRunningJob;
 
 /**
  * State-machine driver for a single restore task row. Declared `final` —
@@ -261,7 +262,7 @@ final class RestoreRunner
      */
     public function run(): string
     {
-        @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running restore loop must not hit max_execution_time; @-guarded, no-op when disabled
+        @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running restore loop must not hit max_execution_time; @-guarded, no-op when disabled
         @ignore_user_abort(true);
 
         $currentPhase = self::PHASE_PREFLIGHT;

--- a/apps/agent/includes/backup/class-restore-watchdog.php
+++ b/apps/agent/includes/backup/class-restore-watchdog.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace WPMgr\Agent\Backup;
 
 use WPMgr\Agent\Schema;
+use WPMgr\Agent\Support\LongRunningJob;
 
 final class RestoreWatchdog
 {
@@ -184,7 +185,7 @@ final class RestoreWatchdog
             \WPMgr\Agent\Support\DebugLog::write(sprintf('WPMgr Restore: dispatch cannot extract params for %s/%s', $snapshotId, $restoreId));
             return;
         }
-        @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup/restore loop must not hit max_execution_time; @-guarded
+        @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup/restore loop must not hit max_execution_time; @-guarded
         @ignore_user_abort(true);
         try {
             (new RestoreRunner($params))->run();

--- a/apps/agent/includes/backup/class-task-runner.php
+++ b/apps/agent/includes/backup/class-task-runner.php
@@ -78,6 +78,7 @@ use WPMgr\Agent\Signer;
 use WPMgr\Agent\Keystore;
 use WPMgr\Agent\Support\AgeCrypto;
 use WPMgr\Agent\Support\BackupTransport;
+use WPMgr\Agent\Support\LongRunningJob;
 
 /**
  * State-machine driver for a single backup task row.
@@ -178,7 +179,7 @@ final class TaskRunner
      */
     public function run(): string
     {
-        @set_time_limit(0); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection, Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup loop must not hit max_execution_time; @-guarded, no-op when disabled
+        @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection, Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup loop must not hit max_execution_time; @-guarded, no-op when disabled
         @ignore_user_abort(true);
 
         $currentPhase = self::PHASE_QUEUED;

--- a/apps/agent/includes/backup/class-watchdog.php
+++ b/apps/agent/includes/backup/class-watchdog.php
@@ -32,6 +32,7 @@ namespace WPMgr\Agent\Backup;
 
 use WPMgr\Agent\Schema;
 use WPMgr\Agent\Support\DebugLog;
+use WPMgr\Agent\Support\LongRunningJob;
 
 final class Watchdog
 {
@@ -279,7 +280,7 @@ final class Watchdog
             return;
         }
         // Lift PHP's per-request caps — this cron worker may run for minutes.
-        @set_time_limit(0); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup dispatch must not hit max_execution_time; @-guarded
+        @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup dispatch must not hit max_execution_time; @-guarded
         @ignore_user_abort(true);
         try {
             (new TaskRunner($params))->run();

--- a/apps/agent/includes/cache/class-woo-fragments-runtime.php
+++ b/apps/agent/includes/cache/class-woo-fragments-runtime.php
@@ -79,7 +79,7 @@ final class WooFragmentsRuntime
             return $html;
         }
 
-        // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript -- injected into the cache-write output buffer after wp_footer has run; WP's enqueue API is inapplicable in this OB callback (see class-rum-injector.php for the canonical note)
+        // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript -- this class only runs from Optimizer::run() (class-optimizer.php), called by CacheWriter's ob_start() callback (class-cache-writer.php) on the fully-rendered HTML string of a cacheable MISS, well after wp_footer has already printed; the shim is spliced into the already-buffered string, so it can only operate as a post-hoc string rewrite -- WP's enqueue API has no queue left to append to at this point
         $tag = '<script ' . self::MARKER_ATTR . '>' . $shim . '</script>';
 
         // Inject just before the closing </body> tag (whitespace-tolerant: accepts

--- a/apps/agent/includes/class-auto-optimize-upload.php
+++ b/apps/agent/includes/class-auto-optimize-upload.php
@@ -55,6 +55,7 @@ declare(strict_types=1);
 namespace WPMgr\Agent;
 
 use WPMgr\Agent\Media\MediaAttachmentRow;
+use WPMgr\Agent\Support\LongRunningJob;
 
 /**
  * Observes uploads, buffers attachment ids, and drains via a signed async POST.
@@ -294,8 +295,9 @@ final class AutoOptimizeUpload
      * drain reschedules itself with a short back-off so an offline CP cannot
      * silently drop pending uploads.
      *
-     * Runs under set_time_limit(0) + ignore_user_abort(true) because this is a
-     * cron worker in a separate FPM request — it must not be killed mid-POST.
+     * Runs under a bounded set_time_limit() + ignore_user_abort(true) because
+     * this is a cron worker in a separate FPM request — it must not be killed
+     * mid-POST.
      *
      * @return void
      */
@@ -307,7 +309,7 @@ final class AutoOptimizeUpload
 
         // Lift the PHP execution ceiling — we are in a dedicated cron worker.
         if (function_exists('set_time_limit')) {
-            @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup/restore loop must not hit max_execution_time; @-guarded
+            @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup/restore loop must not hit max_execution_time; @-guarded
         }
         if (function_exists('ignore_user_abort')) {
             ignore_user_abort(true);

--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -119,6 +119,7 @@ use WPMgr\Agent\Support\AgeIdentity;
 use WPMgr\Agent\Support\ErrorMonitor;
 use WPMgr\Agent\Support\LoginBrand;
 use WPMgr\Agent\Support\LoginProtection;
+use WPMgr\Agent\Support\LongRunningJob;
 use WPMgr\Agent\Support\MuPluginInstaller;
 use WPMgr\Agent\Support\SnapshotManager;
 use WPMgr\Agent\Support\UpdateChecker;
@@ -675,12 +676,14 @@ final class Plugin
         // that buffer, so a site with WPMgr page caching OFF (the norm when a
         // third-party page cache serves the site) or served from a third-party
         // cache HIT never received the collector and silently reported zero
-        // data. wp_head fires on every WordPress-rendered response regardless of
-        // any cache path, so binding there is the cache-independent fix. Bound
-        // on `init`; registerRumHooks() reads the perf config once and only adds
-        // the wp_head hook when rumEnabled is on, so an inert site pays just a
-        // single option read. A real method (not a closure) keeps the hook table
-        // serialization-safe.
+        // data. wp_enqueue_scripts fires on every WordPress-rendered response
+        // regardless of any cache path, so binding there is the cache-independent
+        // fix (and, per the 2026-07 wp.org review fix, lets the collector be
+        // enqueued via wp_enqueue_script() instead of echoed). Bound on `init`;
+        // registerRumHooks() reads the perf config once and only adds the
+        // wp_enqueue_scripts hook when rumEnabled is on, so an inert site pays
+        // just a single option read. A real method (not a closure) keeps the
+        // hook table serialization-safe.
         add_action('init', [$this, 'registerRumHooks'], 0);
 
         // DB-classify source-scan cache busting. When a plugin is activated or
@@ -707,9 +710,10 @@ final class Plugin
         add_action(Scheduler::HOOK_DIAGNOSTICS, [$this, 'runDiagnostics']);
 
         // Reliable-diagnostics — dedicated size-refresh cron handler. Runs the
-        // SizeProbe walk under set_time_limit(0) so recurse_dirsize/du has no
-        // ceiling imposed by the push request's max_execution_time. Plugin owns
-        // the binding; Scheduler owns the schedule (additive).
+        // SizeProbe walk under a bounded LongRunningJob::TIME_LIMIT_SECONDS cap
+        // so recurse_dirsize/du has a generous but non-infinite ceiling, well
+        // past the push request's normal max_execution_time. Plugin owns the
+        // binding; Scheduler owns the schedule (additive).
         add_action(Scheduler::HOOK_SIZES, [$this, 'runSizeProbe']);
 
         // Register the pre_recurse_dirsize filter (WP 5.6+) so WP core's own
@@ -1704,16 +1708,17 @@ final class Plugin
             fastcgi_finish_request();
         }
         if (function_exists('set_time_limit')) {
-            @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup/restore loop must not hit max_execution_time; @-guarded
+            @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup/restore loop must not hit max_execution_time; @-guarded
         }
         (new SizeProbe())->compute();
     }
 
     /**
      * Cron handler for the dedicated directory-size refresh event
-     * (Scheduler::HOOK_SIZES). Runs set_time_limit(0) so the du / recurse_dirsize
-     * walk has no time ceiling, then delegates to SizeProbe::compute() which
-     * persists the result to the non-autoloaded wp_option wpmgr_agent_dir_sizes.
+     * (Scheduler::HOOK_SIZES). Runs under a bounded LongRunningJob::TIME_LIMIT_SECONDS
+     * cap so the du / recurse_dirsize walk has a generous but non-infinite
+     * ceiling, then delegates to SizeProbe::compute() which persists the
+     * result to the non-autoloaded wp_option wpmgr_agent_dir_sizes.
      * A WP-Cron kill mid-walk leaves the previously-persisted last-good intact
      * (SizeProbe::compute() writes atomically via update_option at the end).
      *
@@ -1727,7 +1732,7 @@ final class Plugin
     public function runSizeProbe(): void
     {
         if (function_exists('set_time_limit')) {
-            @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup/restore loop must not hit max_execution_time; @-guarded
+            @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup/restore loop must not hit max_execution_time; @-guarded
         }
         (new SizeProbe())->compute();
     }
@@ -2133,18 +2138,25 @@ final class Plugin
     }
 
     /**
-     * RUM (Real User Monitoring) — bind the wp_head beacon-injection callback.
+     * RUM (Real User Monitoring) — bind the beacon-injection callback.
      *
      * Cache-independent by design (GH #154): the RUM collector used to be
      * injected only inside the page-cache/optimizer output buffer (Optimizer
      * stage 11), so a site with WPMgr page caching OFF — the norm when a
      * third-party page cache serves the site — or served from a third-party
      * cache HIT never got the collector, and rum_rollup stayed empty with no
-     * warning. wp_head is independent of any cache path: it fires on every
-     * WordPress-rendered response, so binding the injector there (at a late
-     * priority so it never blocks other <head> output) fixes the gap. Reads
-     * the perf config once and only registers the wp_head hook when rumEnabled
-     * is on, so an inert site pays just a single option read.
+     * warning. wp_enqueue_scripts is independent of any cache path: it fires
+     * on every WordPress-rendered response, so binding the injector there
+     * fixes the gap.
+     *
+     * 2026-07 wp.org review fix: this used to bind at `wp_head` priority 99
+     * and have RumInjector echo raw <script> tags directly. It is now bound
+     * to `wp_enqueue_scripts` (which WordPress core itself fires from inside
+     * `wp_head` at priority 1 -- i.e. BEFORE the previous priority-99 binding
+     * even ran), and RumInjector uses wp_enqueue_script()/wp_add_inline_script()
+     * instead of an echo. Reads the perf config once and only registers the
+     * hook when rumEnabled is on, so an inert site pays just a single option
+     * read.
      *
      * @return void
      */
@@ -2154,14 +2166,11 @@ final class Plugin
         if (!$config->rumEnabled || !function_exists('add_action')) {
             return;
         }
-        // Priority 99: prints near the end of <head>, faithfully replacing the
-        // former splice-before-</head> position without depending on any output
-        // buffer being open.
-        add_action('wp_head', [$this, 'renderRumHead'], 99);
+        add_action('wp_enqueue_scripts', [$this, 'renderRumHead']);
     }
 
     /**
-     * wp_head callback (priority 99, bound by {@see registerRumHooks()}).
+     * wp_enqueue_scripts callback bound by {@see registerRumHooks()}.
      * Builds a fresh RumInjector (it loads PerfConfig itself) and delegates to
      * its per-request guard chain (anonymous/GET/200/CSP/etc — see
      * RumInjector::renderHead()). A real method (not a closure) keeps the hook

--- a/apps/agent/includes/class-scheduler.php
+++ b/apps/agent/includes/class-scheduler.php
@@ -46,7 +46,7 @@ final class Scheduler
      * Reliable-diagnostics fix — dedicated directory-size computation cron hook
      * (daily, offset ~15 minutes before the diagnostics push). Decouples the
      * tree walk from the push request so recurse_dirsize or du runs in its own
-     * request with set_time_limit(0), not inline under the 10s HTTP timeout.
+     * request with a bounded set_time_limit(), not inline under the 10s HTTP timeout.
      * The callback is bound by Plugin::registerHooks; Scheduler only owns the
      * schedule, mirroring HOOK_DIAGNOSTICS.
      */

--- a/apps/agent/includes/commands/class-backup-command.php
+++ b/apps/agent/includes/commands/class-backup-command.php
@@ -43,6 +43,7 @@ use WPMgr\Agent\Backup\Watchdog;
 use WPMgr\Agent\Schema;
 use WPMgr\Agent\Support\AgeIdentity;
 use WPMgr\Agent\Support\DebugLog;
+use WPMgr\Agent\Support\LongRunningJob;
 
 /**
  * Accepts a `backup` command from the CP, seeds the task row, and drives
@@ -287,7 +288,7 @@ final class BackupCommand implements CommandInterface
         //   4. The FPM worker runs the backup while the FCGI connection is
         //      closed (fastcgi_finish_request). On hosts where
         //      fastcgi_finish_request does not fully close the upstream
-        //      connection, ignore_user_abort(true) + set_time_limit(0)
+        //      connection, ignore_user_abort(true) + a bounded set_time_limit()
         //      ensure the runner is not killed mid-backup.
         //
         // Note: spawn_cron() is still called even on gated sites as a belt-
@@ -313,7 +314,7 @@ final class BackupCommand implements CommandInterface
                 if (function_exists('fastcgi_finish_request')) {
                     fastcgi_finish_request(); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- intentional early-flush of the FCGI connection so the CP receives the ACK before TaskRunner runs
                 }
-                @set_time_limit(0); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup runner must not hit max_execution_time; @-guarded
+                @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup runner must not hit max_execution_time; @-guarded
                 @ignore_user_abort(true);
                 try {
                     (new TaskRunner($shutdownParams))->run();

--- a/apps/agent/includes/commands/class-db-clean-command.php
+++ b/apps/agent/includes/commands/class-db-clean-command.php
@@ -41,6 +41,7 @@ use WPMgr\Agent\Keystore;
 use WPMgr\Agent\Settings;
 use WPMgr\Agent\Signer;
 use WPMgr\Agent\Optimizer\DbCleanup;
+use WPMgr\Agent\Support\LongRunningJob;
 
 /**
  * Database cleanup command (M38 async + progress-push).
@@ -171,7 +172,7 @@ final class DbCleanCommand implements CommandInterface
 
                 // Expand execution budget — cleanup can be slow on large sites.
                 if (function_exists('set_time_limit')) {
-                    @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running cleanup loop must not hit max_execution_time; @-guarded, no-op when disabled
+                    @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running cleanup loop must not hit max_execution_time; @-guarded, no-op when disabled
                 }
 
                 self::runAsync(

--- a/apps/agent/includes/commands/class-db-orphan-delete-command.php
+++ b/apps/agent/includes/commands/class-db-orphan-delete-command.php
@@ -54,6 +54,7 @@ use WPMgr\Agent\Keystore;
 use WPMgr\Agent\Settings;
 use WPMgr\Agent\Signer;
 use WPMgr\Agent\Optimizer\DbCleanup;
+use WPMgr\Agent\Support\LongRunningJob;
 
 /**
  * Orphan-delete command (async, progress-push, full allowlist capture).
@@ -288,7 +289,7 @@ final class DbOrphanDeleteCommand implements CommandInterface
 
                 // Expand execution budget — delete loops can be slow on large sites.
                 if (function_exists('set_time_limit')) {
-                    @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running orphan-delete loop must not hit max_execution_time; @-guarded, no-op when disabled
+                    @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running orphan-delete loop must not hit max_execution_time; @-guarded, no-op when disabled
                 }
 
                 self::runAsync(

--- a/apps/agent/includes/commands/class-diagnostics-command.php
+++ b/apps/agent/includes/commands/class-diagnostics-command.php
@@ -39,7 +39,7 @@
  * Directory sizes (ADR-037 reliable-diagnostics JIT fix) — computed just-in-time
  * during the collection, exactly like the WP Site Health screen. mergeDirectorySizes()
  * calls SizeProbe::getOrCompute(): returns a FRESH last-good (< 6 h, O(1)) when
- * warm, otherwise computes NOW (set_time_limit(0) + du fast path + PHP/recurse_dirsize
+ * warm, otherwise computes NOW (a bounded set_time_limit() + du fast path + PHP/recurse_dirsize
  * fallback) and persists to the non-autoloaded wp_option wpmgr_agent_dir_sizes.
  * 'pending' is only emitted when both compute and any prior last-good are truly
  * unavailable — never just because a separate cron has not yet fired. Status is
@@ -262,7 +262,7 @@ final class DiagnosticsCommand implements CommandInterface
      * Resolution order (inside getOrCompute()):
      *   (a) FRESH last-good (< 6 h old) — returned instantly; no I/O beyond the
      *       option read (warm-cache fast path; same as Site Health's dirsize_cache).
-     *   (b) Stale or missing — compute NOW (set_time_limit(0) + du fast path +
+     *   (b) Stale or missing — compute NOW (a bounded set_time_limit() + du fast path +
      *       PHP/recurse_dirsize fallback); persist and use the result.
      *   (c) compute() fails/empty — fall back to stale prior (better than nothing).
      *   (d) Nothing at all — only then emit 'pending' (see below).

--- a/apps/agent/includes/commands/class-media-sync-command.php
+++ b/apps/agent/includes/commands/class-media-sync-command.php
@@ -30,6 +30,7 @@ namespace WPMgr\Agent\Commands;
 
 use WPMgr\Agent\Media\MediaAttachmentRow;
 use WPMgr\Agent\Media\MediaUploader;
+use WPMgr\Agent\Support\LongRunningJob;
 
 /**
  * Enumerates attachments and pushes them to the CP in <=200-row pages.
@@ -77,7 +78,7 @@ final class MediaSyncCommand implements CommandInterface
         // (the dispatch is bounded by the CP's 120s media commander) and survive
         // a dropped loopback connection. Mirrors the backup/diagnostics paths.
         if (function_exists('set_time_limit')) {
-            @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup/restore loop must not hit max_execution_time; @-guarded
+            @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup/restore loop must not hit max_execution_time; @-guarded
         }
         if (function_exists('ignore_user_abort')) {
             @ignore_user_abort(true);

--- a/apps/agent/includes/diagnostics/class-size-probe.php
+++ b/apps/agent/includes/diagnostics/class-size-probe.php
@@ -11,7 +11,7 @@
  *   1. `du -sb <dir>` — O(1) on most Linux/macOS hosts. Gated by
  *      execAvailable() (function_exists + disable_functions + safe_mode +
  *      open_basedir + live smoke test).
- *   2. WP core recurse_dirsize() under set_time_limit(0) with an exclude list
+ *   2. WP core recurse_dirsize() under a bounded set_time_limit() with an exclude list
  *      (own staging dirs, node_modules, vendor, cache layers). Method = "php".
  *   3. Per-dir miss: keep prior value from lastGood, mark result partial=true.
  *
@@ -45,6 +45,8 @@
 declare(strict_types=1);
 
 namespace WPMgr\Agent\Diagnostics;
+
+use WPMgr\Agent\Support\LongRunningJob;
 
 /**
  * Stateless collaborator; instances are cheap (no DB hit in __construct).
@@ -126,7 +128,7 @@ final class SizeProbe
         // killed by the push request's max_execution_time (same guard the
         // dedicated cron handler applies in Plugin::runSizeProbe).
         if (function_exists('set_time_limit')) {
-            @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running dirsize walk must not hit max_execution_time; @-guarded, no-op when disabled
+            @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running dirsize walk must not hit max_execution_time; @-guarded, no-op when disabled
         }
 
         try {
@@ -160,7 +162,7 @@ final class SizeProbe
     /**
      * Run the full size computation and persist the result.
      *
-     * Safe to call under a dedicated cron event (set_time_limit(0) is called
+     * Safe to call under a dedicated cron event (a bounded set_time_limit() is called
      * by the handler in Plugin::registerHooks before invoking this). Also safe
      * to call after fastcgi_finish_request — a PHP-FPM kill mid-walk leaves
      * the previously-persisted last-good intact.
@@ -437,7 +439,7 @@ final class SizeProbe
     }
 
     /**
-     * Measure a directory using WP core's recurse_dirsize() with set_time_limit(0)
+     * Measure a directory using WP core's recurse_dirsize() with a bounded set_time_limit()
      * and our exclude list. Called only from the dedicated cron context.
      *
      * @param string $dir Absolute directory path.
@@ -448,10 +450,11 @@ final class SizeProbe
         if ($dir === '' || !is_dir($dir) || !function_exists('recurse_dirsize')) {
             return null;
         }
-        // Ensure there is no time ceiling on this call (caller has already
-        // called set_time_limit(0) in the cron handler, but be explicit).
+        // Ensure there is a generous (not just the request default) time
+        // ceiling on this call (caller has already applied the same bound in the
+        // cron handler, but be explicit).
         if (function_exists('set_time_limit')) {
-            @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running recurse_dirsize walk must not hit max_execution_time; @-guarded, no-op when disabled
+            @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running recurse_dirsize walk must not hit max_execution_time; @-guarded, no-op when disabled
         }
 
         $exclude = $this->excludeList();

--- a/apps/agent/includes/integrations/class-cloudpanel.php
+++ b/apps/agent/includes/integrations/class-cloudpanel.php
@@ -321,8 +321,15 @@ final class CloudPanel extends Integration
         }
 
         if (isset($_SERVER['SERVER_NAME']) && is_string($_SERVER['SERVER_NAME']) && $_SERVER['SERVER_NAME'] !== '') {
-            // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- cleanHeaderValue() unslashes and sanitizes when WordPress helpers exist.
-            return $this->cleanHeaderValue($_SERVER['SERVER_NAME']);
+            // Unslash then sanitize at the read site (same order/behaviour
+            // cleanHeaderValue() applied, now visible at the point of read).
+            if (function_exists('sanitize_text_field') && function_exists('wp_unslash')) {
+                return trim((string) sanitize_text_field(wp_unslash($_SERVER['SERVER_NAME'])));
+            }
+            // No-WP-context fallback (e.g. a unit test or CLI script that has
+            // not booted WordPress): manually strip control characters since
+            // sanitize_text_field()/wp_unslash() are unavailable to call.
+            return trim((string) preg_replace('/[\r\n\t]+/', '', $_SERVER['SERVER_NAME'])); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- no-WP fallback path; preg_replace strips CR/LF/TAB directly since wp_unslash()/sanitize_text_field() are unavailable
         }
 
         return '';
@@ -460,8 +467,24 @@ final class CloudPanel extends Integration
     private function homeDirectories(): array
     {
         $homes = [];
-        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Local environment path normalized before use; not emitted.
-        foreach ([getenv('HOME'), $_SERVER['HOME'] ?? null] as $home) {
+
+        // Unslash then sanitize at the read site (this value is a local
+        // filesystem path, never emitted to a browser; normalized further by
+        // rtrim()/trim() below).
+        $serverHome = null;
+        if (isset($_SERVER['HOME']) && is_string($_SERVER['HOME'])) {
+            if (function_exists('sanitize_text_field') && function_exists('wp_unslash')) {
+                $serverHome = sanitize_text_field(wp_unslash($_SERVER['HOME']));
+            } else {
+                // No-WP-context fallback (e.g. a unit test or CLI script that
+                // has not booted WordPress): manually strip control
+                // characters since sanitize_text_field()/wp_unslash() are
+                // unavailable to call.
+                $serverHome = preg_replace('/[\r\n\t]+/', '', $_SERVER['HOME']); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- no-WP fallback path; preg_replace strips CR/LF/TAB directly since wp_unslash()/sanitize_text_field() are unavailable
+            }
+        }
+
+        foreach ([getenv('HOME'), $serverHome] as $home) {
             if (!is_string($home)) {
                 continue;
             }

--- a/apps/agent/includes/media/class-media-quarantine.php
+++ b/apps/agent/includes/media/class-media-quarantine.php
@@ -1,10 +1,19 @@
 <?php
 /**
- * MediaQuarantine: manages the wp-content/wpmgr-quarantine/ directory
- * where isolated (unused) attachment files are temporarily stored.
+ * MediaQuarantine: manages the uploads/wpmgr-quarantine/ directory (legacy:
+ * wp-content/wpmgr-quarantine/) where isolated (unused) attachment files are
+ * temporarily stored.
  *
- * Layout:
- *   wp-content/wpmgr-quarantine/
+ * Base path resolution is uploads-first (wp.org Guideline compliance, see
+ * {@see \WPMgr\Agent\Support\StoragePaths::dataBase()}): the resolved root is
+ * normally wp_upload_dir()['basedir'] . '/wpmgr-quarantine', falling back to
+ * WP_CONTENT_DIR . '/wpmgr-quarantine' only when the uploads directory is
+ * unavailable. Existing self-hosted installs that already have data under the
+ * legacy wp-content location keep working via {@see $legacyRoot} read-fallback
+ * and a one-time rename in {@see ensureQuarantineRoot()}.
+ *
+ * Layout (relative to the resolved root, described above):
+ *   wpmgr-quarantine/
  *     .htaccess              — deny all web access (Apache/LiteSpeed)
  *     index.php              — empty PHP guard
  *     manifests/             — manifest JSONs; NEVER web-reachable (outside media/)
@@ -45,9 +54,13 @@
  * Older manifests stored plain strings; restore/delete fall back gracefully.
  *
  * Security:
- *   - The quarantine root is inside wp-content but outside wp-content/uploads,
- *     so no attachment URLs point into it. Web access is blocked by .htaccess
- *     and an index.php guard.
+ *   - The resolved quarantine root (uploads/wpmgr-quarantine, or the legacy
+ *     wp-content/wpmgr-quarantine fallback) is a directory no attachment URL
+ *     ever points into. Because the uploads-first root sits inside the
+ *     web-served uploads/ tree, direct web access is blocked explicitly by
+ *     the .htaccess + index.php guard files ensureQuarantineRoot() writes on
+ *     first use (Deny all / Require all denied) rather than by directory
+ *     placement alone.
  *   - manifest_id values are 128-bit random hex strings. Callers treat them as
  *     opaque; the class never accepts a manifest_id from untrusted input —
  *     callers receive IDs from beginManifest() or from the manifest list, and
@@ -120,11 +133,15 @@ final class MediaQuarantine
         //   1. Explicit $contentDir passed by the caller (test override or known path).
         //   2. StoragePaths::dataBase('quarantine') — uploads-first; honors relocatable
         //      upload_path + multisite per-site subdirs (wp.org Guideline compliance).
-        //   3. WP_CONTENT_DIR / wpmgr-quarantine — legacy fallback for CLI/headless
-        //      contexts where wp_upload_dir() is unavailable.
-        //   4. ABSPATH + '/wp-content/wpmgr-quarantine' — last-resort fallback.
-        //   5. Unresolved — instance is marked unavailable; writes are blocked before
-        //      any mkdir call so nothing is ever created at the filesystem root.
+        //      Internally falls back to WP_CONTENT_DIR/wpmgr-quarantine when
+        //      wp_upload_dir() is unavailable (CLI/headless contexts) — see
+        //      StoragePaths::dataBase() for that fallback's own definition.
+        //   3. Unresolved — instance is marked unavailable; writes are blocked before
+        //      any mkdir call so nothing is ever created at the filesystem root. In
+        //      a real WordPress boot this is unreachable (WP core always defines
+        //      WP_CONTENT_DIR very early, well before any plugin loads), so there is
+        //      no separate ABSPATH-guessing fallback here — StoragePaths::dataBase()
+        //      already covers every path a normal WP request can take.
         if ($contentDir === '') {
             // Explicit empty string is the "unavailable" signal used by tests and by
             // callers that already know no base could be resolved. Treat as unresolved
@@ -150,9 +167,6 @@ final class MediaQuarantine
                 if ($legacy !== '' && $legacy !== $base) {
                     $this->legacyRoot = $legacy;
                 }
-            } elseif (defined('ABSPATH') && is_string(ABSPATH) && ABSPATH !== '') {
-                $base                   = rtrim(ABSPATH, '/\\') . '/wp-content/wpmgr-quarantine';
-                $this->basePathResolved = true;
             } else {
                 // No safe base available. Set the *Root properties to non-empty strings
                 // so that the readonly scandir callers (quarantinedAttachmentIds,

--- a/apps/agent/includes/media/class-media-run-store.php
+++ b/apps/agent/includes/media/class-media-run-store.php
@@ -49,6 +49,8 @@ declare(strict_types=1);
 
 namespace WPMgr\Agent\Media;
 
+use WPMgr\Agent\Support\LongRunningJob;
+
 /**
  * Persist + drain a bulk media batch in bounded background chunks.
  */
@@ -96,7 +98,7 @@ final class MediaRunStore
      *
      * 20s stays comfortably under any sane request_terminate_timeout while
      * letting a single run clear ~100+ local restores or ~10-20 S3-bound
-     * optimizes. set_time_limit(0) + ignore_user_abort(true) keep the worker
+     * optimizes. A bounded set_time_limit() + ignore_user_abort(true) keep the worker
      * alive for the full slice.
      */
     private const TIME_BUDGET_SECONDS = 20.0;
@@ -226,7 +228,7 @@ final class MediaRunStore
         // REST request, so it may run for the full time budget. ignore_user_abort
         // keeps it alive even if the loopback spawn_cron connection is dropped.
         if (function_exists('set_time_limit')) {
-            @set_time_limit(0); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running media background run must not hit max_execution_time; @-guarded, no-op when disabled
+            @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running media background run must not hit max_execution_time; @-guarded, no-op when disabled
         }
         if (function_exists('ignore_user_abort')) {
             @ignore_user_abort(true);

--- a/apps/agent/includes/optimizer/class-iframe.php
+++ b/apps/agent/includes/optimizer/class-iframe.php
@@ -125,7 +125,7 @@ final class IFrame
             . 'f.setAttribute("allowfullscreen","1");f.style.position="absolute";f.style.inset="0";'
             . 'f.style.width="100%";f.style.height="100%";e.innerHTML="";e.appendChild(f);}';
 
-        // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet,WordPress.WP.EnqueuedResources.NonEnqueuedScript -- injected into the cache-write output buffer after wp_head has run; WP's enqueue API is inapplicable in this OB callback (see class-rum-injector.php for the canonical note)
+        // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet,WordPress.WP.EnqueuedResources.NonEnqueuedScript -- this class only runs from Optimizer::run(), called by CacheWriter's ob_start() callback (class-cache-writer.php) on the fully-rendered HTML string of a cacheable MISS, well after wp_head has already printed; the transform rewrites body <iframe> markup already in the buffered string, so it can only operate as a post-hoc string rewrite -- WP's enqueue API has no queue left to append to at this point
         $assets = '<style data-wpmgr-yt-assets>' . $css . '</style><script data-wpmgr-yt-assets>' . $js . '</script>';
         if (stripos($html, '</head>') !== false) {
             return (string) preg_replace('/<\/head>/i', $assets . '</head>', $html, 1);

--- a/apps/agent/includes/optimizer/class-js-delay.php
+++ b/apps/agent/includes/optimizer/class-js-delay.php
@@ -172,7 +172,7 @@ final class JsDelay
         if ($runtime === '') {
             return $html;
         }
-        // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript -- injected into the cache-write output buffer after wp_footer has run; WP's enqueue API is inapplicable in this OB callback (see class-rum-injector.php for the canonical note)
+        // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript -- this class only runs from Optimizer::run(), called by CacheWriter's ob_start() callback (class-cache-writer.php) on the fully-rendered HTML string of a cacheable MISS, well after wp_footer has already printed; the delay runtime is spliced into the already-buffered string, so it can only operate as a post-hoc string rewrite -- WP's enqueue API has no queue left to append to at this point
         $tag = '<script data-wpmgr-delay-runtime>' . $runtime . '</script>';
         if (stripos($html, '</body>') !== false) {
             return (string) preg_replace('/<\/body>(?![\s\S]*<\/body>)/i', $tag . '</body>', $html, 1);

--- a/apps/agent/includes/optimizer/class-optimizer.php
+++ b/apps/agent/includes/optimizer/class-optimizer.php
@@ -24,10 +24,10 @@
  * was only ever injected inside THIS cache-writer output buffer — so a site
  * with WPMgr page caching off (the norm when a third-party page cache serves
  * the site), or a page served from a third-party cache HIT, never received the
- * collector at all and RUM silently collected zero data. RUM is now injected
- * by RumInjector::renderHead(), bound directly to the `wp_head` action
- * (Plugin::registerRumHooks()), independent of this optimizer/cache pipeline
- * entirely.
+ * collector at all and RUM silently collected zero data. RUM is now enqueued
+ * by RumInjector::renderHead(), bound directly to the `wp_enqueue_scripts`
+ * action (Plugin::registerRumHooks()), independent of this optimizer/cache
+ * pipeline entirely.
  *
  * Every transform is config-gated and a no-op when its flag is off. The whole
  * run() is wrapped so a transform failure can never corrupt or drop the page —

--- a/apps/agent/includes/optimizer/class-rucss-client.php
+++ b/apps/agent/includes/optimizer/class-rucss-client.php
@@ -517,7 +517,7 @@ final class RucssClient
      */
     private function applyUsedCss(string $html, string $usedCss): string
     {
-        // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet -- injected into the cache-write output buffer after wp_head has run; WP's enqueue API is inapplicable in this OB callback (see class-rum-injector.php for the canonical note)
+        // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet -- this class only runs from Optimizer::run(), called by CacheWriter's ob_start() callback (class-cache-writer.php) on the fully-rendered HTML string of a cacheable MISS, well after wp_head has already printed; the RUCSS transform rewrites a <style>/<link href> already in the buffered string, so it can only operate as a post-hoc string rewrite -- WP's enqueue API has no queue left to append to at this point
         $styleTag = '<style id="wpmgr-used-css">' . $usedCss . '</style>';
         if (stripos($html, '</head>') !== false) {
             $html = (string) preg_replace('/<\/head>/i', $styleTag . '</head>', $html, 1);

--- a/apps/agent/includes/optimizer/class-rum-injector.php
+++ b/apps/agent/includes/optimizer/class-rum-injector.php
@@ -1,25 +1,38 @@
 <?php
 /**
- * RumInjector — emit the RUM collector script into <head> via wp_head.
+ * RumInjector — enqueue the RUM collector script + config on wp_enqueue_scripts.
  *
  * GH #154 fix: the collector used to be spliced into the page HTML by an
  * Optimizer stage that only ran inside WPMgr's own page-cache output buffer.
  * That meant a site with WPMgr page caching OFF — the norm when a third-party
  * page cache serves the site — or a page served from a third-party cache HIT
  * never received the collector at all, and RUM silently collected zero data
- * with no warning. This class is now driven from a `wp_head` action (bound by
- * Plugin::registerRumHooks()/renderRumHead(), independent of CacheConfig or
- * any optimizer/cache buffer), so injection no longer depends on any cache
- * path. See {@see renderHead()}.
+ * with no warning. This class is driven from the `wp_enqueue_scripts` action
+ * (bound by Plugin::registerRumHooks()/renderRumHead()), independent of
+ * CacheConfig or any optimizer/cache buffer, so injection no longer depends
+ * on any cache path. See {@see renderHead()}.
  *
- * The emitted snippet is always the same two parts:
+ * 2026-07 wp.org review fix: this class used to build and `echo` the script
+ * tags directly from a `wp_head` priority-99 callback (after
+ * `print_head_scripts` had already run), with a docblock claiming "WP's
+ * enqueue API is inapplicable at this late priority". That claim was wrong —
+ * `wp_enqueue_scripts` fires as part of `wp_head` at priority 1 (WordPress
+ * core registers it via `add_action('wp_head', 'wp_enqueue_scripts', 1)`),
+ * i.e. BEFORE `print_head_scripts` runs, so a script enqueued there is still
+ * printed normally. The class is now bound directly to `wp_enqueue_scripts`
+ * and uses {@see wp_enqueue_script()} + {@see wp_add_inline_script()} instead
+ * of a raw echo.
  *
- *   1. A tiny inline <script> that sets window.__WPMGR_RUM__ = {key,url,rate}
- *      (the per-site constants; no per-request variance, no Vary header, no
- *      cookie).
+ * The registered assets are always the same two parts:
  *
- *   2. An external <script async src="…/assets/wpmgr-rum.min.js"> tag that
- *      loads the bundled web-vitals collector IIFE from the plugin assets dir.
+ *   1. A tiny inline script (wp_add_inline_script(..., 'before')) that sets
+ *      window.__WPMGR_RUM__ = {key,url,rate} (the per-site constants; no
+ *      per-request variance, no Vary header, no cookie), printed immediately
+ *      before the collector script tag.
+ *
+ *   2. The external collector script (wp_enqueue_script()), which loads the
+ *      bundled web-vitals collector IIFE from assets/wpmgr-rum.min.js with an
+ *      async loading strategy.
  *
  * Why <head> + async (not defer before </body>):
  *   web-vitals onCLS is gated on onFCP firing. If the collector is deferred to
@@ -31,9 +44,18 @@
  *   async (not defer) is used because web-vitals uses buffered PerformanceObserver
  *   entries and visibility-state history, so exact parse-time ordering relative
  *   to other scripts does not matter; async avoids blocking the render pipeline.
- *   Priority 99 on wp_head prints near the end of <head> — faithfully replacing
- *   the previous splice-before-</head> position — without depending on any
- *   output buffer being open.
+ *   `wp_enqueue_script()` is called with `in_footer` false so the tag prints in
+ *   <head>, faithfully replacing the previous splice-before-</head> position.
+ *
+ *   The plugin's minimum supported WordPress version (6.2) predates the
+ *   `strategy` argument to `wp_enqueue_script()` (added in WP 6.3, see
+ *   {@see https://make.wordpress.org/core/2023/07/14/registering-scripts-with-async-and-defer-attributes-in-wordpress-6-3/}).
+ *   On 6.3+ we pass `strategy => async` directly; on 6.2 (where the 5th
+ *   `wp_enqueue_script()` argument is still a plain `bool $in_footer`, so
+ *   passing an array there would be coerced to `true` and wrongly force the
+ *   script into the footer) we instead pass a plain `false` and fall back to
+ *   a `script_loader_tag` filter that adds the `async` attribute for this
+ *   handle only. See {@see enqueue()} and {@see filterAsyncScriptTag()}.
  *
  * The external src approach means the collector never violates a strict
  * no-unsafe-inline CSP on the main document. sendBeacon is governed by
@@ -44,21 +66,21 @@
  * 'unsafe-inline') AND the policy does not already allowlist the plugin's asset URL,
  * this stage skips injection rather than breaking the page.
  *
- * Deliberate coverage expansion: unlike the old cache-bound stage, wp_head has
- * no cache-cookie/URL-path exclusions, so the beacon now also fires for
- * anonymous visitors on cart/checkout pages and on pages carrying the
- * `_wpmgr_no_cache` / `_wpmgr_no_optimize` post meta. (WooCommerce's My
- * Account page is NOT a new coverage case here — it renders content only for
- * a logged-in visitor, and the anonymous-only guard in {@see renderHead()}
- * already excludes every logged-in request regardless of page type.) This is
- * intentional: the beacon payload is a metric name, value, device class,
- * connection type, and the current page URL — never cart contents or a
- * session identifier. The page URL IS transmitted (window.location.href in
- * the collector, apps/tracker/src/vitals.ts), but the collector strips the
- * query string and hash before sending (origin + pathname only), so a
- * per-visit token that a checkout/order-confirmation flow might carry in the
- * query string (e.g. a WooCommerce order-received key) never leaves the
- * browser.
+ * Deliberate coverage expansion: unlike the old cache-bound stage,
+ * wp_enqueue_scripts has no cache-cookie/URL-path exclusions, so the beacon
+ * now also fires for anonymous visitors on cart/checkout pages and on pages
+ * carrying the `_wpmgr_no_cache` / `_wpmgr_no_optimize` post meta.
+ * (WooCommerce's My Account page is NOT a new coverage case here — it renders
+ * content only for a logged-in visitor, and the anonymous-only guard in
+ * {@see renderHead()} already excludes every logged-in request regardless of
+ * page type.) This is intentional: the beacon payload is a metric name,
+ * value, device class, connection type, and the current page URL — never
+ * cart contents or a session identifier. The page URL IS transmitted
+ * (window.location.href in the collector, apps/tracker/src/vitals.ts), but
+ * the collector strips the query string and hash before sending (origin +
+ * pathname only), so a per-visit token that a checkout/order-confirmation
+ * flow might carry in the query string (e.g. a WooCommerce order-received
+ * key) never leaves the browser.
  *
  * @package WPMgr\Agent\Optimizer
  */
@@ -68,18 +90,21 @@ declare(strict_types=1);
 namespace WPMgr\Agent\Optimizer;
 
 /**
- * Emits the RUM beacon config + collector script on wp_head.
+ * Enqueues the RUM beacon config + collector script on wp_enqueue_scripts.
  */
 final class RumInjector
 {
+    /** wp_enqueue_script()/wp_add_inline_script() handle for the collector. */
+    public const SCRIPT_HANDLE = 'wpmgr-rum';
+
     private PerfConfig $config;
 
     /**
-     * Guards against emitting more than once per request — defends against a
-     * theme calling wp_head() twice, or the wp_head hook accidentally being
-     * registered more than once. A static property (not per-instance) so the
-     * guard holds even if a fresh RumInjector is constructed for each callback
-     * invocation.
+     * Guards against enqueuing more than once per request — defends against a
+     * theme calling wp_head() twice, or the wp_enqueue_scripts hook accidentally
+     * being registered more than once. A static property (not per-instance) so
+     * the guard holds even if a fresh RumInjector is constructed for each
+     * callback invocation.
      */
     private static bool $emitted = false;
 
@@ -92,14 +117,14 @@ final class RumInjector
     }
 
     /**
-     * wp_head callback: echo the RUM config + collector script directly.
+     * wp_enqueue_scripts callback: enqueue the RUM config + collector script.
      *
-     * wp_head already guarantees this only fires while WordPress is rendering
-     * a normal front-end template (not admin/REST/AJAX/cron/feeds), but it does
-     * NOT guarantee the response is an anonymous, GET, 200, non-password-
-     * protected page — those are checked explicitly below, mirroring the
-     * guards the old cache-bound stage got for free from the page-cache
-     * write path (see Cacheability::isRequestCacheable()).
+     * wp_enqueue_scripts already guarantees this only fires while WordPress is
+     * rendering a normal front-end template (not admin/REST/AJAX/cron/feeds),
+     * but it does NOT guarantee the response is an anonymous, GET, 200,
+     * non-password-protected page — those are checked explicitly below,
+     * mirroring the guards the old cache-bound stage got for free from the
+     * page-cache write path (see Cacheability::isRequestCacheable()).
      *
      * @return void
      */
@@ -129,8 +154,8 @@ final class RumInjector
             return;
         }
 
-        // GET only: wp_head can print during a page-rendering POST (e.g. a
-        // themed form handler that re-renders the page on submit).
+        // GET only: wp_enqueue_scripts can fire during a page-rendering POST
+        // (e.g. a themed form handler that re-renders the page on submit).
         $method = sanitize_text_field(
             wp_unslash(isset($_SERVER['REQUEST_METHOD']) ? (string) $_SERVER['REQUEST_METHOD'] : 'GET')
         );
@@ -159,39 +184,50 @@ final class RumInjector
             return;
         }
 
-        $snippet = $this->buildSnippet($key, $url, $this->config->rumSampleRate, $scriptUrl);
+        if (!function_exists('wp_enqueue_script') || !function_exists('wp_add_inline_script')) {
+            return;
+        }
 
-        // buildSnippet() escapes every dynamic value at construction time
-        // (wp_json_encode for the config object, esc_url for the script src);
-        // this is a plain echo of an already-escaped string, not a new sink.
-        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $snippet is built by buildSnippet(), which wp_json_encode()s the config object and esc_url()s the script src
-        echo $snippet;
+        $this->enqueue($key, $url, $this->config->rumSampleRate, $scriptUrl);
 
         self::$emitted = true;
     }
 
     /**
-     * Build the inline config + external collector snippet.
+     * Enqueue the collector script and its inline config.
      *
-     * The inline block sets window.__WPMGR_RUM__ (a plain object, no DOM
-     * interaction); the external script is async so it loads without blocking
-     * the render pipeline. async is preferred over defer here because web-vitals
-     * uses buffered PerformanceObserver entries and visibility-state history,
-     * so parse-time ordering relative to other scripts is irrelevant — what
-     * matters is that the observers are registered as early as possible.
-     *
-     * @param string $key        Plaintext beacon key.
-     * @param string $url        Ingest endpoint URL.
-     * @param float  $rate       Sample rate [0,1].
-     * @param string $scriptUrl  URL to wpmgr-rum.min.js.
-     * @return string HTML snippet.
+     * @param string $key       Plaintext beacon key.
+     * @param string $url       Ingest endpoint URL.
+     * @param float  $rate      Sample rate [0,1].
+     * @param string $scriptUrl URL to wpmgr-rum.min.js.
+     * @return void
      */
-    private function buildSnippet(string $key, string $url, float $rate, string $scriptUrl): string
+    private function enqueue(string $key, string $url, float $rate, string $scriptUrl): void
     {
+        $ver = defined('WPMGR_AGENT_VERSION') ? (string) constant('WPMGR_AGENT_VERSION') : false;
+
+        if ($this->coreSupportsScriptStrategy()) {
+            // WP 6.3+: the native way to load a script async without
+            // depending on script-loader-tag string surgery.
+            wp_enqueue_script(
+                self::SCRIPT_HANDLE,
+                $scriptUrl,
+                [],
+                $ver,
+                ['in_footer' => false, 'strategy' => 'async']
+            );
+        } else {
+            // WP 6.2 (this plugin's floor): the 5th wp_enqueue_script() arg is
+            // still a plain bool. Passing an array here would be coerced to
+            // `true` by PHP and wrongly force the script into the footer, so
+            // pass `false` (head) and add `async` via the tag filter below.
+            wp_enqueue_script(self::SCRIPT_HANDLE, $scriptUrl, [], $ver, false);
+            $this->ensureAsyncFallbackFilter();
+        }
+
         // Values are encoded with wp_json_encode then written into a JS object
-        // literal via a script tag — there is no unsafe-inline concern because
-        // this sets a config object, NOT an event handler or navigation.
-        // esc_url is applied to the script src attribute.
+        // literal — there is no unsafe-inline concern because this sets a
+        // config object, NOT an event handler or navigation.
         //
         // The JSON_HEX_* flags are the WP-correct hardening for JSON destined
         // for an inline <script> sink: they hex-escape <, >, &, ', and " so a
@@ -200,7 +236,7 @@ final class RumInjector
         // of the JS string context with a literal `</script>` or similar.
         $rate = round(max(0.0, min(1.0, $rate)), 4);
 
-        $config_json = (string) wp_json_encode(
+        $configJson = (string) wp_json_encode(
             [
                 'key'  => $key,
                 'url'  => $url,
@@ -209,20 +245,73 @@ final class RumInjector
             JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
         );
 
-        // Build the snippet without heredoc/nowdoc (Plugin Check bans heredocs).
-        // The inline config script sets a simple window variable; the external
-        // script loads the collector bundle. Both are echoed directly from the
-        // wp_head callback — WP's enqueue API is inapplicable at this late
-        // priority (print_head_scripts already ran at wp_head priority 1).
-        // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript -- echoed directly from a late (priority 99) wp_head callback, after print_head_scripts (priority 1) has already run; WP's enqueue API cannot inline a script this late
-        $inline_config = '<script data-wpmgr-rum-config>'
-            . 'window.__WPMGR_RUM__=' . $config_json . ';'
-            . '</script>';
+        // 'before' prints this inline script immediately before the collector
+        // tag, so window.__WPMGR_RUM__ is always set before the collector runs.
+        wp_add_inline_script(
+            self::SCRIPT_HANDLE,
+            'window.__WPMGR_RUM__=' . $configJson . ';',
+            'before'
+        );
+    }
 
-        // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript -- echoed directly from a late (priority 99) wp_head callback; WP's enqueue API cannot inline a script this late (same reasoning as the inline config block above)
-        $collector = '<script async src="' . esc_url($scriptUrl) . '"></script>';
+    /**
+     * Whether WP core's wp_enqueue_script() accepts the WP 6.3+ $args array
+     * form (in_footer/strategy) for the 5th parameter.
+     *
+     * @return bool
+     */
+    private function coreSupportsScriptStrategy(): bool
+    {
+        $version = isset($GLOBALS['wp_version']) && is_string($GLOBALS['wp_version'])
+            ? $GLOBALS['wp_version']
+            : '';
 
-        return $inline_config . $collector;
+        if ($version === '') {
+            // Unknown version: fall back to the universally-safe bool + filter
+            // path rather than risk mis-detecting a footer-forcing coercion.
+            return false;
+        }
+
+        return version_compare($version, '6.3', '>=');
+    }
+
+    /**
+     * Register the WP<6.3 `async` attribute fallback filter (idempotent --
+     * add_filter() with the same static callback is a safe no-op if already
+     * registered for this request).
+     *
+     * @return void
+     */
+    private function ensureAsyncFallbackFilter(): void
+    {
+        if (!function_exists('add_filter')) {
+            return;
+        }
+        add_filter('script_loader_tag', [self::class, 'filterAsyncScriptTag'], 10, 2);
+    }
+
+    /**
+     * script_loader_tag filter: add the `async` attribute to this plugin's
+     * collector script tag on WP < 6.3, where wp_enqueue_script() has no
+     * `strategy` argument.
+     *
+     * Idempotent: if the tag already carries `async` (e.g. because a future
+     * WP version starts adding it independently), the tag is returned
+     * unmodified rather than doubled up.
+     *
+     * @param string $tag    The <script> tag WP core built for $handle.
+     * @param string $handle The script's registered handle.
+     * @return string
+     */
+    public static function filterAsyncScriptTag(string $tag, string $handle): string
+    {
+        if ($handle !== self::SCRIPT_HANDLE) {
+            return $tag;
+        }
+        if (preg_match('/\basync\b/', $tag) === 1) {
+            return $tag;
+        }
+        return (string) preg_replace('/\ssrc=/', ' async src=', $tag, 1);
     }
 
     /**
@@ -231,6 +320,12 @@ final class RumInjector
      * Uses plugins_url() when available (the canonical WP function for
      * plugin assets), falling back to WP_PLUGIN_URL for headless contexts
      * where plugins_url() may not yet be registered.
+     *
+     * Deliberately does NOT append a `?ver=` query string itself (unlike the
+     * pre-enqueue implementation) -- wp_enqueue_script()'s own $ver argument
+     * (see {@see enqueue()}) is the correct place for cache-busting versioning
+     * once the script is enqueued rather than raw-echoed, and appending both
+     * would produce a duplicated/malformed query string.
      *
      * @return string URL, or '' when it cannot be resolved.
      */
@@ -256,22 +351,6 @@ final class RumInjector
             }
         }
 
-        if ($base === '') {
-            return '';
-        }
-
-        // Append the plugin version as a cache-busting query arg. The collector
-        // is served from a static, unversioned filename, so a CDN or browser
-        // cache keyed on the URL would keep serving the previous build after a
-        // plugin update -- a long-lived edge cache can mask a collector fix for
-        // the full length of its TTL. Versioning the URL changes it on every
-        // update, so the edge and the browser refetch the new bytes with no
-        // manual purge.
-        $ver = defined('WPMGR_AGENT_VERSION') ? (string) constant('WPMGR_AGENT_VERSION') : '';
-        if ($ver !== '') {
-            $base .= (strpos($base, '?') === false ? '?' : '&') . 'ver=' . rawurlencode($ver);
-        }
-
         return $base;
     }
 
@@ -286,7 +365,7 @@ final class RumInjector
      * browser CSP violation that would block the page's console with errors.
      *
      * This check uses headers_list(), which reflects whatever headers have
-     * already been queued via header() by the time wp_head runs.
+     * already been queued via header() by the time wp_enqueue_scripts runs.
      *
      * @return bool True when a conflicting CSP is detected.
      */

--- a/apps/agent/includes/optimizer/class-speculation-rules.php
+++ b/apps/agent/includes/optimizer/class-speculation-rules.php
@@ -78,7 +78,7 @@ final class SpeculationRules
         ];
 
         $json = (string) json_encode($rules, JSON_UNESCAPED_SLASHES);
-        // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript -- injected into the cache-write output buffer after wp_head has run; WP's enqueue API is inapplicable in this OB callback (see class-rum-injector.php for the canonical note)
+        // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript -- this class only runs from Optimizer::run(), called by CacheWriter's ob_start() callback (class-cache-writer.php) on the fully-rendered HTML string of a cacheable MISS, well after wp_head has already printed; the speculation-rules tag is spliced into the already-buffered string, so it can only operate as a post-hoc string rewrite -- WP's enqueue API has no queue left to append to at this point
         $tag  = '<script type="speculationrules">' . $json . '</script>';
 
         if (stripos($html, '</head>') !== false) {

--- a/apps/agent/includes/security/class-site-2fa-module.php
+++ b/apps/agent/includes/security/class-site-2fa-module.php
@@ -469,6 +469,102 @@ final class Site2faModule
     }
 
     /**
+     * Explicit wp_kses() tag/attribute allowlist for the 2FA verify/setup/
+     * forced-change interstitials and the WP profile-screen section.
+     *
+     * wp_kses_post() cannot be used for these screens: its default
+     * $allowedposttags omits <form>/<input>/<button>, which every one of
+     * these forms requires in order to render (and submit) at all. This
+     * allowlist is instead scoped to exactly the tags/attributes the module
+     * emits -- grep-verified against renderForcedChangeForm(),
+     * renderInterstitial(), renderSetupScreen() (and every
+     * buildSetup*Html() step it calls), renderProfileSection(), and every
+     * SiteTwoFactorProvider::renderForm() implementation (Totp/Email/
+     * BackupCodes) -- including the inline TOTP QR <svg>/<rect> emitted by
+     * QrEncoder::toSvg(). Each value placed into the markup is still
+     * esc_html()/esc_attr()/esc_url()'d at assembly time (belt-and-
+     * suspenders); wp_kses() here is the visible escape-at-output-boundary
+     * pass the 2026-07 wp.org review asked for.
+     *
+     * @return array<string,array<string,bool>>
+     */
+    private static function allowedFormKses(): array
+    {
+        return [
+            'form'   => ['name' => true, 'id' => true, 'action' => true, 'method' => true],
+            'p'      => ['class' => true, 'style' => true],
+            'label'  => ['for' => true],
+            'br'     => [],
+            'a'      => ['href' => true, 'class' => true, 'download' => true],
+            'h2'     => [],
+            'h3'     => [],
+            'em'     => [],
+            'span'   => ['style' => true],
+            'table'  => ['class' => true, 'style' => true],
+            'tr'     => ['style' => true],
+            'td'     => ['style' => true],
+            'th'     => ['scope' => true],
+            'strong' => [],
+            'small'  => [],
+            'code'   => ['id' => true, 'style' => true],
+            'ol'     => ['style' => true],
+            'ul'     => [],
+            'li'     => [],
+            'div'    => ['style' => true],
+            'button' => ['type' => true, 'name' => true, 'value' => true, 'class' => true],
+            'input'  => [
+                'type'         => true,
+                'name'         => true,
+                'id'           => true,
+                'value'        => true,
+                'class'        => true,
+                'autocomplete' => true,
+                'inputmode'    => true,
+                'pattern'      => true,
+                'maxlength'    => true,
+                'placeholder'  => true,
+                'required'     => true,
+                'autofocus'    => true,
+            ],
+            // The TOTP QR code (QrEncoder::toSvg()) is inline SVG, not user
+            // input: only the secret + issuer name feed it, and both go
+            // through rawurlencode() before QR encoding.
+            'svg'    => [
+                'xmlns'      => true,
+                'width'      => true,
+                'height'     => true,
+                'viewbox'    => true,
+                'role'       => true,
+                'aria-label' => true,
+            ],
+            'rect'   => [
+                'x'      => true,
+                'y'      => true,
+                'width'  => true,
+                'height' => true,
+                'fill'   => true,
+            ],
+        ];
+    }
+
+    /**
+     * URL protocols allowed inside {@see allowedFormKses()} markup, extending
+     * WP's default allowed protocols with `data:`.
+     *
+     * The backup-codes setup step's client-side "Download backup codes" link
+     * (see buildSetupBackupHtml()) is a `data:text/plain,...` URI so the codes
+     * never make a server round-trip; `data:` is not in
+     * wp_allowed_protocols() by default, so without this addition wp_kses()
+     * would strip the scheme from that href and leave a broken link.
+     *
+     * @return string[]
+     */
+    private static function allowedFormProtocols(): array
+    {
+        return array_merge(wp_allowed_protocols(), ['data']);
+    }
+
+    /**
      * Render the forced password-change form and die().
      *
      * @param \WP_User            $user
@@ -516,7 +612,10 @@ final class Site2faModule
         $formHtml .= esc_attr__('Change Password', 'wpmgr-agent') . '">';
         $formHtml .= '</p></form>';
 
-        echo $formHtml; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- fully escaped above; each component escaped with esc_html/esc_attr/esc_url individually
+        // Escape-at-output-boundary: every dynamic value above was already
+        // esc_html()/esc_attr()/esc_url()'d at assembly time; wp_kses() here
+        // is the visible boundary escape (see allowedFormKses()).
+        echo wp_kses($formHtml, self::allowedFormKses(), self::allowedFormProtocols());
 
         if (function_exists('login_footer')) {
             login_footer();
@@ -1584,7 +1683,11 @@ final class Site2faModule
         $formHtml .= '</p>';
         $formHtml .= '</form>';
 
-        echo $formHtml; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- fully escaped above; each component escaped with esc_html/esc_attr/esc_url individually
+        // Escape-at-output-boundary: every dynamic value above was already
+        // esc_html()/esc_attr()/esc_url()'d at assembly time (including the
+        // active provider's own renderForm()); wp_kses() here is the visible
+        // boundary escape (see allowedFormKses()).
+        echo wp_kses($formHtml, self::allowedFormKses(), self::allowedFormProtocols());
 
         if (function_exists('login_footer')) {
             login_footer();
@@ -1657,7 +1760,11 @@ final class Site2faModule
         $formHtml .= '</p>';
         $formHtml .= '</form>';
 
-        echo $formHtml; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- fully escaped above; each component escaped with esc_html/esc_attr/esc_url individually
+        // Escape-at-output-boundary: every dynamic value above (including
+        // every buildSetup*Html() step fragment) was already
+        // esc_html()/esc_attr()/esc_url()'d at assembly time; wp_kses() here
+        // is the visible boundary escape (see allowedFormKses()).
+        echo wp_kses($formHtml, self::allowedFormKses(), self::allowedFormProtocols());
 
         if (function_exists('login_footer')) {
             login_footer();
@@ -1835,7 +1942,13 @@ final class Site2faModule
         $html .= '<p>' . esc_html__('Scan the QR code below with your authenticator app (Google Authenticator, Authy, 1Password, etc.), or enter the secret key manually.', 'wpmgr-agent') . '</p>';
 
         if ($qrSvg !== '') {
-            $html .= '<div style="margin:16px 0;text-align:center">' . $qrSvg . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- QrEncoder::toSvg() generates inline SVG with esc_attr'd attributes; never contains user-supplied data (only the secret + issuer name go through rawurlencode before QR encoding)
+            // QrEncoder::toSvg() generates inline SVG with esc_attr()'d
+            // attributes; it never contains user-supplied data (only the
+            // secret + issuer name go through rawurlencode() before QR
+            // encoding). This fragment is returned up to renderSetupScreen(),
+            // whose echo runs the whole assembled form through wp_kses()
+            // (see allowedFormKses(), which allow-lists svg/rect).
+            $html .= '<div style="margin:16px 0;text-align:center">' . $qrSvg . '</div>';
         } else {
             $html .= '<p>' . esc_html__('QR code unavailable. Please use the manual entry key below.', 'wpmgr-agent') . '</p>';
         }
@@ -1954,7 +2067,11 @@ final class Site2faModule
             $html .= '<p>' . esc_html__('You have the following methods configured:', 'wpmgr-agent') . '</p>';
             $html .= '<ul>';
             foreach ($enabled as $label) {
-                $html .= '<li>' . $label . '</li>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- each $label already esc_html()'d above
+                // $label is already esc_html()'d above; this fragment is
+                // returned up to renderSetupScreen(), whose echo runs the
+                // whole assembled form through wp_kses() (see
+                // allowedFormKses()).
+                $html .= '<li>' . $label . '</li>';
             }
             $html .= '</ul>';
         }
@@ -2308,7 +2425,10 @@ final class Site2faModule
         $html .= '<input type="hidden" name="wpmgr_2fa_profile_nonce" value="' . esc_attr($nonce) . '">';
         $html .= '<input type="hidden" name="wpmgr_2fa_profile_user_id" value="' . esc_attr((string) ((int) $profileUser->ID)) . '">';
 
-        echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- fully escaped above; each component escaped with esc_html/esc_attr/esc_url individually
+        // Escape-at-output-boundary: every dynamic value above was already
+        // esc_html()/esc_attr()'d at assembly time; wp_kses() here is the
+        // visible boundary escape (see allowedFormKses()).
+        echo wp_kses($html, self::allowedFormKses(), self::allowedFormProtocols());
     }
 
     /**

--- a/apps/agent/includes/support/class-long-running-job.php
+++ b/apps/agent/includes/support/class-long-running-job.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * LongRunningJob — the shared bounded time limit for the agent's
+ * long-running background loops (backup/restore/dump/media/db-clean/
+ * diagnostics routines).
+ *
+ * S4 (issue #131 adversarial review, see UpdateCommand::APPLY_TIME_LIMIT_SECONDS)
+ * established why these loops must call `set_time_limit(N)` with a bounded,
+ * generous N rather than `set_time_limit(0)` (infinite): `0` throws away the
+ * ONE timer whose fatal runs register_shutdown_function() callbacks
+ * (max_execution_time), leaving only PHP-FPM's own request_terminate_timeout
+ * (when configured) to kill a truly-hung request -- and FPM's SIGTERM does
+ * NOT run shutdown functions at all, so a hang under `set_time_limit(0)` can
+ * silently skip every crash-recovery/cleanup hook the agent relies on.
+ *
+ * 900 seconds (15 minutes) is generous for even a very large backup/restore/
+ * dump/media pass, while still giving a truly-hung job a chance to hit PHP's
+ * own RECOVERABLE fatal before something else (a shorter FPM timeout, if
+ * configured) tears the process down with no recovery at all.
+ *
+ * Every call site keeps its existing `@`-guard and in-method placement
+ * (this constant only replaces the literal `0` argument) -- `set_time_limit()`
+ * is a no-op under most CLI SAPIs and when disabled via `disable_functions`,
+ * so the `@` suppression remains load-bearing.
+ *
+ * @package WPMgr\Agent\Support
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Support;
+
+/**
+ * Holds the single shared bounded time-limit constant for long-running jobs.
+ */
+final class LongRunningJob
+{
+    /**
+     * Bounded (not infinite) execution-time cap, in seconds, for a
+     * long-running backup/restore/dump/media/db-clean/diagnostics loop.
+     * Mirrors UpdateCommand::APPLY_TIME_LIMIT_SECONDS (also 900) -- kept as a
+     * separate constant rather than importing UpdateCommand into every one of
+     * these unrelated classes, since UpdateCommand is a REST command handler,
+     * not a shared utility.
+     */
+    public const TIME_LIMIT_SECONDS = 900;
+}

--- a/apps/agent/includes/webhooks/class-media-modal-injector.php
+++ b/apps/agent/includes/webhooks/class-media-modal-injector.php
@@ -128,8 +128,30 @@ final class MediaModalInjector
         if ($id <= 0) {
             return;
         }
-        // StatsRenderer escapes every dynamic value; the wrapper markup is static.
-        echo $this->renderer->renderForAttachment($id, $mime); // phpcs:ignore WordPress.Security.EscapeOutput
+        // StatsRenderer escapes every dynamic value with esc_html() at
+        // assembly time (belt-and-suspenders); wp_kses() here is the visible
+        // escape-at-output-boundary pass (2026-07 wp.org review fix), scoped
+        // to exactly the tags/attributes StatsRenderer emits.
+        echo wp_kses($this->renderer->renderForAttachment($id, $mime), self::allowedStatsKses());
+    }
+
+    /**
+     * Explicit wp_kses() tag/attribute allowlist for StatsRenderer's output,
+     * scoped to exactly the tags/attributes it emits (grep-verified): plain
+     * <div class="...">/<strong>/<span class="...">/<code> wrapper markup,
+     * no interactive elements at all -- unlike the 2FA module's forms, this
+     * is a read-only display panel.
+     *
+     * @return array<string,array<string,bool>>
+     */
+    private static function allowedStatsKses(): array
+    {
+        return [
+            'div'    => ['class' => true],
+            'span'   => ['class' => true],
+            'strong' => [],
+            'code'   => [],
+        ];
     }
 
     /**

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -4,7 +4,7 @@ Tags: backup, restore, performance, cache, security
 Requires at least: 6.2
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.36.0
+Stable tag: 0.61.56
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -111,7 +111,7 @@ Every management action (enrollment, diagnostics, heartbeat, backup progress, ca
 
 **Have I Been Pwned (https://haveibeenpwned.com) -- via the WPMgr control plane**
 
-When the optional password-policy breach check is enabled and a site user sets or changes a password, the plugin computes the SHA-1 hash of the candidate password and sends only the first 5 characters of that hash (a k-anonymity range query) to the WPMgr control plane. The full password and the full hash never leave the site. The WPMgr control plane relays the 5-character prefix to the Have I Been Pwned range API (https://haveibeenpwned.com/API/v3#searchingPwnedPasswordsByRange), receives back a list of matching hash suffixes and breach counts, and returns that list to the agent. The agent then checks the remaining 35-character suffix locally to determine whether the password is known-breached. No full password, no full hash, and no user identity is transmitted at any point in this flow. This check is off by default; it runs only when the breach-check policy is active and only at the moment of a password set or change. Data flow: site sends the 5-character prefix to the WPMgr control plane, which forwards the range query to Have I Been Pwned. Have I Been Pwned Terms https://haveibeenpwned.com/Terms -- Have I Been Pwned Privacy https://haveibeenpwned.com/Privacy. The WPMgr control-plane hop is also covered by the terms above: Terms https://manage.wpmgr.app/terms -- Privacy https://manage.wpmgr.app/privacy.
+When the optional password-policy breach check is enabled and a site user sets or changes a password, the plugin computes the SHA-1 hash of the candidate password and sends only the first 5 characters of that hash (a k-anonymity range query) to the WPMgr control plane. The full password and the full hash never leave the site. The WPMgr control plane relays the 5-character prefix to the Have I Been Pwned range API (https://haveibeenpwned.com/API/v3#searchingPwnedPasswordsByRange), receives back a list of matching hash suffixes and breach counts, and returns that list to the agent. The agent then checks the remaining 35-character suffix locally to determine whether the password is known-breached. No full password, no full hash, and no user identity is transmitted at any point in this flow. This check is off by default; it runs only when the breach-check policy is active and only at the moment of a password set or change. Data flow: site sends the 5-character prefix to the WPMgr control plane, which forwards the range query to Have I Been Pwned. Have I Been Pwned Terms https://haveibeenpwned.com/TermsOfUse -- Have I Been Pwned Privacy https://haveibeenpwned.com/Privacy. The WPMgr control-plane hop is also covered by the terms above: Terms https://manage.wpmgr.app/terms -- Privacy https://manage.wpmgr.app/privacy.
 
 **Object storage (configured by your control plane)**
 
@@ -141,9 +141,9 @@ When the "self-host third-party assets" optimization is enabled, the plugin down
 
 Postmark is a transactional email delivery service operated by Wildbit LLC. When Postmark is the configured email transport for this site, the plugin POSTs outgoing email to https://api.postmarkapp.com/email. Data sent: sender address, recipient addresses (To/Cc/Bcc), subject, message body (HTML and/or plain text), and any attachments. Trigger: only when Postmark is selected as the active email provider and an outgoing email is sent from this site. Terms https://postmarkapp.com/terms-of-service -- Privacy https://postmarkapp.com/privacy-policy
 
-**Amazon SES (https://email.{region}.amazonaws.com)**
+**Amazon SES (https://aws.amazon.com/ses/)**
 
-Amazon Simple Email Service (SES) is an email delivery service operated by Amazon Web Services, Inc. When Amazon SES is the configured email transport for this site, the plugin POSTs a raw MIME message to https://email.{region}.amazonaws.com/ (where {region} is the AWS region you configure, e.g. us-east-1). Data sent: sender address, recipient addresses (To/Cc/Bcc), subject, message body (HTML and/or plain text), and any attachments, encoded as a raw MIME message signed with AWS Signature Version 4. Trigger: only when Amazon SES is selected as the active email provider and an outgoing email is sent from this site. Terms https://aws.amazon.com/service-terms/ -- Privacy https://aws.amazon.com/privacy/
+Amazon Simple Email Service (SES) is an email delivery service operated by Amazon Web Services, Inc. When Amazon SES is the configured email transport for this site, the plugin POSTs a raw MIME message to the regional SES API endpoint (https://email.{region}.amazonaws.com/ -- {region} = your configured AWS region, e.g. us-east-1). Data sent: sender address, recipient addresses (To/Cc/Bcc), subject, message body (HTML and/or plain text), and any attachments, encoded as a raw MIME message signed with AWS Signature Version 4. Trigger: only when Amazon SES is selected as the active email provider and an outgoing email is sent from this site. Terms https://aws.amazon.com/service-terms/ -- Privacy https://aws.amazon.com/privacy/
 
 **Mailgun (https://api.mailgun.net, https://api.eu.mailgun.net)**
 

--- a/apps/agent/tests/IntegrationsPurgeTest.php
+++ b/apps/agent/tests/IntegrationsPurgeTest.php
@@ -121,6 +121,21 @@ final class IntegrationsPurgeTest extends TestCase
             }
             return 'https://shop.example' . ($path[0] === '/' ? $path : '/' . $path);
         });
+        // 2026-07 wp.org review fix: CloudPanel's $_SERVER['SERVER_NAME']/['HOME']
+        // reads are now sanitize_text_field(wp_unslash(...)) inline at the read
+        // site. Mock both realistically (not a passthrough) so the fallback
+        // branches are exercised deterministically regardless of what earlier
+        // test files may have already Patchwork-defined process-wide.
+        Functions\when('wp_unslash')->alias(static fn ($v) => is_string($v) ? stripslashes($v) : $v);
+        // Mirrors real WP core sanitize_text_field(): collapses \r\n\t\space
+        // RUNS into a single space (does NOT delete the surrounding text) --
+        // the real function's job is to make raw newline/CR bytes unable to
+        // start a new HTTP header line, not to redact arbitrary substrings.
+        Functions\when('sanitize_text_field')->alias(static function ($v) {
+            $v = (string) $v;
+            $v = preg_replace('/[\r\n\t ]+/', ' ', $v) ?? '';
+            return trim($v);
+        });
 
         unset($GLOBALS['kinsta_cache'], $GLOBALS['cloudflareHooks']);
         unset(
@@ -462,6 +477,89 @@ final class IntegrationsPurgeTest extends TestCase
         $this->assertSame('PURGE', $method1);
         $this->assertSame('http://127.0.0.1:6081/cart/?id=1', $url1);
         $this->assertSame('shop.example', $args1['headers']['Host']);
+    }
+
+    /**
+     * 2026-07 wp.org review fix regression: siteHost() falls back to
+     * $_SERVER['SERVER_NAME'] when home_url() cannot resolve a host, and must
+     * sanitize it inline (sanitize_text_field(wp_unslash(...))) rather than
+     * trusting the raw superglobal.
+     */
+    public function test_cloudpanel_site_host_falls_back_to_sanitized_server_name(): void
+    {
+        Functions\when('home_url')->justReturn('');
+        $_SERVER['SERVER_NAME'] = 'fallback.example';
+
+        $this->writeCloudPanelSettings([
+            'enabled'        => true,
+            'server'         => '127.0.0.1:6081',
+            'cacheTagPrefix' => 'testtag',
+        ]);
+
+        (new CloudPanel())->onPurgeEverything();
+
+        $this->assertNotEmpty($this->http);
+        [, , $args1] = $this->http[0];
+        $this->assertSame('fallback.example', $args1['headers']['Host']);
+
+        unset($_SERVER['SERVER_NAME']);
+    }
+
+    /**
+     * A hostile SERVER_NAME (e.g. a header-injection attempt riding a
+     * misconfigured proxy) must have raw CR/LF bytes neutralized by the
+     * inline sanitize_text_field(wp_unslash(...)) pass before it is ever used
+     * to build a Host header -- sanitize_text_field() collapses \r\n runs to
+     * a single space (the same behaviour real WP core applies), which is
+     * what makes header-splitting (injecting a SECOND header line) impossible;
+     * it is not a general substring redaction.
+     */
+    public function test_cloudpanel_site_host_strips_control_characters_from_server_name(): void
+    {
+        Functions\when('home_url')->justReturn('');
+        $_SERVER['SERVER_NAME'] = "evil.example\r\nX-Injected: 1";
+
+        $ref = new \ReflectionMethod(CloudPanel::class, 'siteHost');
+        $host = $ref->invoke(new CloudPanel());
+
+        $this->assertStringNotContainsString("\r", $host, 'no raw CR may survive sanitization');
+        $this->assertStringNotContainsString("\n", $host, 'no raw LF may survive sanitization -- this is what prevents HTTP header-splitting');
+        $this->assertSame('evil.example X-Injected: 1', $host, 'CRLF run collapses to a single space, exactly matching real sanitize_text_field()');
+
+        unset($_SERVER['SERVER_NAME']);
+    }
+
+    /**
+     * 2026-07 wp.org review fix regression: homeDirectories() reads
+     * $_SERVER['HOME'] through the same inline sanitize_text_field(wp_unslash(...))
+     * pass, neutralizing raw CR/LF/TAB bytes (collapsed to a single space,
+     * matching real sanitize_text_field()) before the value is used to build
+     * a filesystem path.
+     */
+    public function test_cloudpanel_home_directories_sanitizes_server_home(): void
+    {
+        $savedHome = $_SERVER['HOME'] ?? null;
+        $_SERVER['HOME'] = "/home/evil\r\n\t/sneaky";
+
+        $ref = new \ReflectionMethod(CloudPanel::class, 'homeDirectories');
+        $homes = $ref->invoke(new CloudPanel());
+
+        foreach ($homes as $home) {
+            $this->assertStringNotContainsString("\r", $home, 'no raw CR may survive sanitization');
+            $this->assertStringNotContainsString("\n", $home, 'no raw LF may survive sanitization');
+            $this->assertStringNotContainsString("\t", $home, 'no raw TAB may survive sanitization');
+        }
+        $this->assertContains(
+            '/home/evil /sneaky',
+            $homes,
+            'CRLF/TAB run collapses to a single space, exactly matching real sanitize_text_field()'
+        );
+
+        if ($savedHome === null) {
+            unset($_SERVER['HOME']);
+        } else {
+            $_SERVER['HOME'] = $savedHome;
+        }
     }
 
     public function test_cloudpanel_full_purge_wipes_pagespeed_host_cache(): void

--- a/apps/agent/tests/MediaModalInjectorTest.php
+++ b/apps/agent/tests/MediaModalInjectorTest.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * MediaModalInjector::renderMetaBox() escape-late regression tests (2026-07
+ * wp.org review fix).
+ *
+ * renderMetaBox() used to `echo` StatsRenderer's assembled HTML directly,
+ * with a bare `// phpcs:ignore WordPress.Security.EscapeOutput` (missing the
+ * exact `.OutputNotEscaped` sniff code) relying entirely on StatsRenderer
+ * having esc_html()'d each dynamic value at assembly time (escape-early). It
+ * now wraps that same echo in `wp_kses($html, self::allowedStatsKses())` --
+ * the visible escape-at-output-boundary pass -- while StatsRenderer's own
+ * esc_html() calls remain as belt-and-suspenders.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Media\StatsRenderer;
+use WPMgr\Agent\MediaKeystore;
+use WPMgr\Agent\Webhooks\MediaModalInjector;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Webhooks\MediaModalInjector
+ */
+final class MediaModalInjectorTest extends TestCase
+{
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+        Functions\when('esc_html')->alias(static fn ($s) => htmlspecialchars((string) $s, ENT_QUOTES, 'UTF-8'));
+        Functions\when('__')->alias(static fn ($s) => $s);
+        Functions\when('size_format')->alias(static fn ($b) => round($b / 1024, 1) . ' KB');
+        Functions\when('wp_get_attachment_metadata')->justReturn([]);
+        Functions\when('get_post_mime_type')->justReturn('image/jpeg');
+    }
+
+    protected function tear_down(): void
+    {
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    private function makeInjectorWithBlob(array $blob): MediaModalInjector
+    {
+        Functions\when('get_post_meta')->justReturn($blob);
+        $renderer = new StatsRenderer(new MediaKeystore());
+
+        return new MediaModalInjector($renderer);
+    }
+
+    private function makeAttachmentPost(int $id, string $mime = 'image/jpeg'): \stdClass
+    {
+        $post                  = new \stdClass();
+        $post->ID              = $id;
+        $post->post_mime_type  = $mime;
+        return $post;
+    }
+
+    /**
+     * @return array<string,array<string,bool>>
+     */
+    private function allowedStatsKses(): array
+    {
+        $ref = new \ReflectionMethod(MediaModalInjector::class, 'allowedStatsKses');
+        return $ref->invoke(null);
+    }
+
+    public function test_render_meta_box_passes_output_through_wp_kses_with_the_explicit_allowlist(): void
+    {
+        $blob = [
+            'status'          => 'optimized',
+            'sizes_optimized' => ['full'],
+            'original_data'   => ['file' => '2026/05/banner.jpg', 'filesize' => 200000, 'sizes' => []],
+        ];
+        $injector = $this->makeInjectorWithBlob($blob);
+
+        $captured = [];
+        Functions\when('wp_kses')->alias(function ($html, $allowed = []) use (&$captured) {
+            $captured[] = ['html' => $html, 'allowed' => $allowed];
+            return $html;
+        });
+
+        ob_start();
+        $injector->renderMetaBox($this->makeAttachmentPost(1));
+        $out = (string) ob_get_clean();
+
+        $this->assertCount(1, $captured, 'renderMetaBox() must call wp_kses() exactly once');
+        $this->assertSame(
+            $this->allowedStatsKses(),
+            $captured[0]['allowed'],
+            'renderMetaBox() must pass the module\'s own explicit allowlist'
+        );
+        $this->assertStringContainsString('wpmgr-media-stats', $out);
+    }
+
+    public function test_allowed_stats_kses_is_narrow_and_has_no_interactive_elements(): void
+    {
+        $allowed = $this->allowedStatsKses();
+
+        // This panel is read-only (no forms/inputs, unlike the 2FA module).
+        $this->assertArrayNotHasKey('form', $allowed);
+        $this->assertArrayNotHasKey('input', $allowed);
+        $this->assertArrayNotHasKey('script', $allowed);
+
+        $this->assertArrayHasKey('div', $allowed);
+        $this->assertArrayHasKey('span', $allowed);
+        $this->assertArrayHasKey('strong', $allowed);
+        $this->assertArrayHasKey('code', $allowed);
+        $this->assertArrayHasKey('class', $allowed['div']);
+        $this->assertArrayHasKey('class', $allowed['span']);
+    }
+
+    public function test_render_meta_box_output_is_fully_covered_by_allowlist(): void
+    {
+        // Exercise the "sizes not optimized" branch too, for full tag coverage.
+        $blob = [
+            'status'            => 'optimized',
+            'sizes_optimized'   => ['full'],
+            'sizes_unoptimized' => ['large' => 'too big'],
+            'original_data'     => [
+                'file'     => '2026/05/banner.jpg',
+                'filesize' => 200000,
+                'sizes'    => ['large' => ['width' => 1024, 'height' => 768, 'filesize' => 50000]],
+            ],
+        ];
+        $injector = $this->makeInjectorWithBlob($blob);
+
+        Functions\when('wp_kses')->returnArg();
+
+        ob_start();
+        $injector->renderMetaBox($this->makeAttachmentPost(1));
+        $html = (string) ob_get_clean();
+
+        $this->assertNotSame('', $html);
+
+        $doc = new \DOMDocument();
+        libxml_use_internal_errors(true);
+        $doc->loadHTML('<!DOCTYPE html><html><body>' . $html . '</body></html>', LIBXML_NOERROR | LIBXML_NOWARNING);
+        libxml_clear_errors();
+
+        $allowed = $this->allowedStatsKses();
+        $body    = $doc->getElementsByTagName('body')->item(0);
+        $this->assertNotNull($body);
+
+        $seenAnyTag = false;
+        $walker     = function (\DOMNode $node) use (&$walker, &$seenAnyTag, $allowed): void {
+            if ($node instanceof \DOMElement) {
+                $tag        = strtolower($node->tagName);
+                $seenAnyTag = true;
+                $this->assertArrayHasKey($tag, $allowed, "tag <$tag> is emitted but missing from allowedStatsKses()");
+                foreach ($node->attributes as $attr) {
+                    $attrLow = strtolower($attr->name);
+                    $this->assertArrayHasKey(
+                        $attrLow,
+                        $allowed[$tag],
+                        "attribute \"$attrLow\" on <$tag> is emitted but missing from allowedStatsKses()['$tag']"
+                    );
+                }
+            }
+            foreach ($node->childNodes as $child) {
+                $walker($child);
+            }
+        };
+        foreach ($body->childNodes as $child) {
+            $walker($child);
+        }
+
+        $this->assertTrue($seenAnyTag);
+    }
+
+    public function test_render_meta_box_returns_early_for_invalid_post(): void
+    {
+        $injector = $this->makeInjectorWithBlob([]);
+
+        $ranWpKses = false;
+        Functions\when('wp_kses')->alias(function ($html, $allowed = []) use (&$ranWpKses) {
+            $ranWpKses = true;
+            return $html;
+        });
+
+        ob_start();
+        $injector->renderMetaBox(new \stdClass());
+        $out = (string) ob_get_clean();
+
+        $this->assertSame('', $out);
+        $this->assertFalse($ranWpKses, 'must never call wp_kses() when there is no valid attachment id');
+    }
+}

--- a/apps/agent/tests/OptimizerRumTest.php
+++ b/apps/agent/tests/OptimizerRumTest.php
@@ -6,11 +6,22 @@
  * cache-write output buffer (Optimizer stage 11), which never ran when WPmgr
  * page caching was off (the norm when a third-party page cache serves the
  * site) or on a third-party cache HIT — so RUM silently collected zero data.
- * RUM is now injected by RumInjector::renderHead(), bound to `wp_head`
- * independent of the optimizer/cache pipeline. These tests cover both the
- * new injector behaviour and the two core regression proofs: (1) a RUM-only
- * config no longer activates the optimizer buffer, and (2) the beacon still
- * renders when the optimizer/page-cache is fully disabled.
+ * RUM is now injected by RumInjector::renderHead(), bound to
+ * `wp_enqueue_scripts` independent of the optimizer/cache pipeline. These
+ * tests cover both the injector behaviour and the two core regression
+ * proofs: (1) a RUM-only config no longer activates the optimizer buffer,
+ * and (2) the beacon still enqueues when the optimizer/page-cache is fully
+ * disabled.
+ *
+ * 2026-07 wp.org review fix: RumInjector used to `echo` raw <script> tags
+ * from a `wp_head` priority-99 callback (with two now-deleted
+ * `NonEnqueuedScript` phpcs:ignore suppressions and a docblock claiming
+ * WP's enqueue API was "inapplicable at this late priority" -- which was
+ * incorrect: `wp_enqueue_scripts` itself fires from inside `wp_head` at
+ * priority 1, before any priority-99 callback). It now calls
+ * wp_enqueue_script() + wp_add_inline_script() instead. These tests mock
+ * both functions (plus wp_version/add_filter for the WP<6.3 async fallback)
+ * and assert on the CALLS made rather than on echoed markup.
  *
  * Covered invariants:
  *   1. rumEnabled defaults to false.
@@ -22,12 +33,12 @@
  *      (RUM no longer rides the optimizer buffer — core regression proof).
  *   7. anyHtmlTransformEnabled() returns false when rumEnabled is off and all others off.
  *   8. PerfConfig round-trips RUM fields through toArray() -> constructor.
- *   9. RumInjector::renderHead(): flag OFF => nothing echoed.
- *  10. RumInjector::renderHead(): flag ON, empty key => nothing echoed.
- *  11. RumInjector::renderHead(): flag ON, empty url => nothing echoed.
- *  12. RumInjector::renderHead(): valid config, anon/GET/200 => echoes inline
- *      config + async external script.
- *  13. RumInjector::renderHead(): emits EXACTLY ONCE across two invocations
+ *   9. RumInjector::renderHead(): flag OFF => nothing enqueued.
+ *  10. RumInjector::renderHead(): flag ON, empty key => nothing enqueued.
+ *  11. RumInjector::renderHead(): flag ON, empty url => nothing enqueued.
+ *  12. RumInjector::renderHead(): valid config, anon/GET/200 => enqueues the
+ *      collector script + inline config, in that dependency order.
+ *  13. RumInjector::renderHead(): enqueues EXACTLY ONCE across two invocations
  *      (static once-per-request guard).
  *  14. RumInjector::renderHead(): sample_rate is clamped to [0,1] in the JSON config.
  *  15. RumInjector::renderHead(): CSP with nonce and without unsafe-inline => skip.
@@ -36,7 +47,7 @@
  *  18. RumInjector::renderHead(): REQUEST_METHOD POST => skip (GET-only guard).
  *  19. RumInjector::renderHead(): is_404() true => skip (200-only guard).
  *  20. RumInjector::renderHead(): post_password_required() true => skip.
- *  21. RumInjector::renderHead(): still emits when the optimizer/page-cache is
+ *  21. RumInjector::renderHead(): still enqueues when the optimizer/page-cache is
  *      fully disabled (core regression proof — RUM no longer requires
  *      CacheConfig->enabled or PerfConfig->anyHtmlTransformEnabled()).
  *  22. Optimizer::isActive() is false when ONLY rumEnabled is on.
@@ -44,8 +55,17 @@
  *      (proves the removed stage 11 is gone; RumInjector is not called from
  *      the pipeline at all).
  *  24. RumInjector::renderHead(): a hostile key/url containing `</script>` and
- *      `<!--<script>` is JSON_HEX_*-escaped so the emitted inline script can
- *      never be broken out of (script-sink hardening regression guard).
+ *      `<!--<script>` is JSON_HEX_*-escaped so the emitted inline script config
+ *      can never be broken out of (script-sink hardening regression guard).
+ *  25. On WP >= 6.3, wp_enqueue_script() is called with the array
+ *      in_footer/strategy=async form and no script_loader_tag filter is
+ *      registered.
+ *  26. On WP < 6.3 (or unknown), wp_enqueue_script() is called with a plain
+ *      bool(false) in_footer and the script_loader_tag async fallback filter
+ *      IS registered.
+ *  27. RumInjector::filterAsyncScriptTag() adds `async` to this plugin's own
+ *      handle's tag, leaves other handles' tags untouched, and does not
+ *      double up `async` if already present.
  *
  * @package WPMgr\Agent\Tests
  */
@@ -76,6 +96,15 @@ final class OptimizerRumTest extends TestCase
     /** @var array<string,mixed> Saved $_SERVER to restore in tear_down(). */
     private array $savedServer = [];
 
+    /** @var list<array{handle:string,src:string,deps:mixed,ver:mixed,args:mixed}> */
+    private array $enqueuedScripts = [];
+
+    /** @var list<array{handle:string,data:string,position:string}> */
+    private array $inlineScripts = [];
+
+    /** @var list<array{hook:string,callback:mixed,priority:int}> */
+    private array $registeredFilters = [];
+
     protected function set_up(): void
     {
         parent::set_up();
@@ -83,6 +112,10 @@ final class OptimizerRumTest extends TestCase
 
         $this->savedServer = $_SERVER;
         $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $this->enqueuedScripts   = [];
+        $this->inlineScripts     = [];
+        $this->registeredFilters = [];
 
         $this->options = [];
         Functions\when('get_option')->alias(fn ($k, $d = false) => $this->options[$k] ?? $d);
@@ -107,6 +140,23 @@ final class OptimizerRumTest extends TestCase
         Functions\when('home_url')->justReturn('https://example.com');
         Functions\when('get_site_option')->alias(fn ($k, $d = false) => $d);
 
+        Functions\when('wp_enqueue_script')->alias(function ($handle, $src = '', $deps = [], $ver = false, $args = false) {
+            $this->enqueuedScripts[] = ['handle' => $handle, 'src' => $src, 'deps' => $deps, 'ver' => $ver, 'args' => $args];
+            return true;
+        });
+        Functions\when('wp_add_inline_script')->alias(function ($handle, $data, $position = 'after') {
+            $this->inlineScripts[] = ['handle' => $handle, 'data' => $data, 'position' => $position];
+            return true;
+        });
+        Functions\when('add_filter')->alias(function ($hook, $callback, $priority = 10, $acceptedArgs = 1) {
+            $this->registeredFilters[] = ['hook' => $hook, 'callback' => $callback, 'priority' => $priority];
+            return true;
+        });
+
+        // Unset by default: coreSupportsScriptStrategy() must treat an
+        // unknown version as WP<6.3 (the safe default).
+        unset($GLOBALS['wp_version']);
+
         // The once-per-request static guard must not leak between tests.
         $this->resetRumEmitted();
 
@@ -118,6 +168,7 @@ final class OptimizerRumTest extends TestCase
     protected function tear_down(): void
     {
         $_SERVER = $this->savedServer;
+        unset($GLOBALS['wp_version']);
         $this->resetRumEmitted();
         Monkey\tearDown();
         parent::tear_down();
@@ -147,14 +198,35 @@ final class OptimizerRumTest extends TestCase
         ], $overrides));
     }
 
-    /**
-     * @return string Captured echo output of a renderHead() call.
-     */
-    private function render(PerfConfig $config): string
+    private function render(PerfConfig $config): void
     {
-        ob_start();
         (new RumInjector($config))->renderHead();
-        return (string) ob_get_clean();
+    }
+
+    /**
+     * @return array{handle:string,src:string,deps:mixed,ver:mixed,args:mixed}|null
+     */
+    private function enqueuedRumScript(): ?array
+    {
+        foreach ($this->enqueuedScripts as $call) {
+            if ($call['handle'] === RumInjector::SCRIPT_HANDLE) {
+                return $call;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return array{handle:string,data:string,position:string}|null
+     */
+    private function inlineRumScript(): ?array
+    {
+        foreach ($this->inlineScripts as $call) {
+            if ($call['handle'] === RumInjector::SCRIPT_HANDLE) {
+                return $call;
+            }
+        }
+        return null;
     }
 
     // ---- PerfConfig coercion tests ----
@@ -249,63 +321,70 @@ final class OptimizerRumTest extends TestCase
 
     public function test_render_noop_when_rum_disabled(): void
     {
-        $c   = new PerfConfig(['rum_enabled' => false]);
-        $out = $this->render($c);
-        $this->assertSame('', $out);
+        $c = new PerfConfig(['rum_enabled' => false]);
+        $this->render($c);
+        $this->assertSame([], $this->enqueuedScripts);
+        $this->assertSame([], $this->inlineScripts);
     }
 
     public function test_render_noop_when_key_empty(): void
     {
-        $c   = $this->makeConfig(['rum_beacon_key' => '']);
-        $out = $this->render($c);
-        $this->assertSame('', $out);
+        $c = $this->makeConfig(['rum_beacon_key' => '']);
+        $this->render($c);
+        $this->assertSame([], $this->enqueuedScripts);
     }
 
     public function test_render_noop_when_url_empty(): void
     {
-        $c   = $this->makeConfig(['rum_ingest_url' => '']);
-        $out = $this->render($c);
-        $this->assertSame('', $out);
+        $c = $this->makeConfig(['rum_ingest_url' => '']);
+        $this->render($c);
+        $this->assertSame([], $this->enqueuedScripts);
     }
 
-    public function test_render_emits_inline_config_and_external_script(): void
+    public function test_render_enqueues_collector_script_and_inline_config(): void
     {
-        $c   = $this->makeConfig();
-        $out = $this->render($c);
+        $c = $this->makeConfig();
+        $this->render($c);
 
-        $this->assertStringContainsString('data-wpmgr-rum-config', $out);
-        $this->assertStringContainsString('window.__WPMGR_RUM__', $out);
-        $this->assertStringContainsString('"TESTBEACONKEY"', $out);
-        $this->assertStringContainsString('cp.example.com', $out);
+        $script = $this->enqueuedRumScript();
+        $this->assertNotNull($script, 'the collector script must be enqueued');
+        $this->assertStringContainsString('wpmgr-rum.min.js', $script['src']);
 
-        $this->assertStringContainsString('wpmgr-rum.min.js', $out);
-        $this->assertStringContainsString('async', $out);
-        $this->assertStringNotContainsString('defer', $out);
+        $inline = $this->inlineRumScript();
+        $this->assertNotNull($inline, 'the config must be added as an inline script');
+        $this->assertSame('before', $inline['position'], 'config must print BEFORE the collector script');
+        $this->assertStringContainsString('window.__WPMGR_RUM__', $inline['data']);
+        $this->assertStringContainsString('"TESTBEACONKEY"', $inline['data']);
+        $this->assertStringContainsString('cp.example.com', $inline['data']);
     }
 
-    public function test_render_emits_exactly_once_across_two_invocations(): void
+    public function test_render_enqueues_exactly_once_across_two_invocations(): void
     {
         $c = $this->makeConfig();
 
-        $out1 = $this->render($c);
-        $out2 = $this->render($c);
+        $this->render($c);
+        $this->render($c);
 
-        $this->assertStringContainsString('data-wpmgr-rum-config', $out1, 'First wp_head invocation must emit the beacon');
-        $this->assertSame('', $out2, 'Second wp_head invocation in the same request must be a no-op');
+        $this->assertCount(1, $this->enqueuedScripts, 'a second wp_enqueue_scripts invocation in the same request must be a no-op');
+        $this->assertCount(1, $this->inlineScripts);
     }
 
     public function test_render_sample_rate_clamped_in_json(): void
     {
-        $c   = $this->makeConfig(['rum_sample_rate' => 2.0]);
-        $out = $this->render($c);
-        $this->assertStringContainsString('"rate":1', $out);
+        $c = $this->makeConfig(['rum_sample_rate' => 2.0]);
+        $this->render($c);
+
+        $inline = $this->inlineRumScript();
+        $this->assertNotNull($inline);
+        $this->assertStringContainsString('"rate":1', $inline['data']);
     }
 
     /**
      * Script-sink hardening regression guard. $key/$url are CP-controlled
-     * today (not reachable by end-user input), but buildSnippet() must apply
-     * JSON_HEX_TAG|JSON_HEX_AMP|JSON_HEX_APOS|JSON_HEX_QUOT to the config
-     * JSON regardless, as defense-in-depth for an inline <script> sink.
+     * today (not reachable by end-user input), but the config JSON must apply
+     * JSON_HEX_TAG|JSON_HEX_AMP|JSON_HEX_APOS|JSON_HEX_QUOT regardless, as
+     * defense-in-depth for an inline <script> sink (wp_add_inline_script()
+     * does not itself escape its $data argument).
      *
      * The hostile payload deliberately contains NO forward slash, so this
      * test exercises the JSON_HEX_* flags specifically rather than PHP's
@@ -317,17 +396,19 @@ final class OptimizerRumTest extends TestCase
         $hostileKey = 'K<!--<script>alert(1)';
         $hostileUrl = 'https://cp.example.com/rum<script>alert(2)';
 
-        $c   = $this->makeConfig([
+        $c = $this->makeConfig([
             'rum_beacon_key' => $hostileKey,
             'rum_ingest_url' => $hostileUrl,
         ]);
-        $out = $this->render($c);
+        $this->render($c);
 
-        $this->assertNotSame('', $out);
+        $inline = $this->inlineRumScript();
+        $this->assertNotNull($inline);
+        $out = $inline['data'];
 
         // No raw "<!--" or "<script" from the hostile payload may survive
-        // into the emitted HTML — both legitimate <script> tags we construct
-        // come from static PHP string literals, never from $key/$url.
+        // into the emitted inline script -- the hostile bytes come only
+        // from $key/$url, never from a static PHP string literal.
         $this->assertStringNotContainsString('<!--', $out, 'Hostile key/url must not inject a raw HTML comment open');
         $this->assertStringNotContainsString('<script>alert', $out, 'Hostile key/url must not inject a raw second <script> tag');
 
@@ -349,9 +430,9 @@ final class OptimizerRumTest extends TestCase
             "Content-Security-Policy: default-src 'self'; script-src 'nonce-abc123'",
         ]);
 
-        $c   = $this->makeConfig();
-        $out = $this->render($c);
-        $this->assertSame('', $out, 'Should skip injection on strict nonce CSP');
+        $c = $this->makeConfig();
+        $this->render($c);
+        $this->assertSame([], $this->enqueuedScripts, 'Should skip injection on strict nonce CSP');
     }
 
     public function test_render_allows_when_csp_has_unsafe_inline(): void
@@ -360,49 +441,49 @@ final class OptimizerRumTest extends TestCase
             "Content-Security-Policy: script-src 'nonce-abc123' 'unsafe-inline'",
         ]);
 
-        $c   = $this->makeConfig();
-        $out = $this->render($c);
-        $this->assertStringContainsString('data-wpmgr-rum-config', $out);
+        $c = $this->makeConfig();
+        $this->render($c);
+        $this->assertNotNull($this->enqueuedRumScript());
     }
 
     public function test_render_skips_when_user_logged_in(): void
     {
         Functions\when('is_user_logged_in')->justReturn(true);
 
-        $c   = $this->makeConfig();
-        $out = $this->render($c);
-        $this->assertSame('', $out, 'Anonymous-only guard: must not beacon a logged-in visitor');
+        $c = $this->makeConfig();
+        $this->render($c);
+        $this->assertSame([], $this->enqueuedScripts, 'Anonymous-only guard: must not beacon a logged-in visitor');
     }
 
     public function test_render_skips_on_post_request(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
 
-        $c   = $this->makeConfig();
-        $out = $this->render($c);
-        $this->assertSame('', $out, 'GET-only guard: wp_head firing during a POST must not beacon');
+        $c = $this->makeConfig();
+        $this->render($c);
+        $this->assertSame([], $this->enqueuedScripts, 'GET-only guard: firing during a POST must not beacon');
     }
 
     public function test_render_skips_on_404(): void
     {
         Functions\when('is_404')->justReturn(true);
 
-        $c   = $this->makeConfig();
-        $out = $this->render($c);
-        $this->assertSame('', $out, '200-only guard: must not beacon a 404 response');
+        $c = $this->makeConfig();
+        $this->render($c);
+        $this->assertSame([], $this->enqueuedScripts, '200-only guard: must not beacon a 404 response');
     }
 
     public function test_render_skips_on_password_protected(): void
     {
         Functions\when('post_password_required')->justReturn(true);
 
-        $c   = $this->makeConfig();
-        $out = $this->render($c);
-        $this->assertSame('', $out, 'Password-protected content must not beacon');
+        $c = $this->makeConfig();
+        $this->render($c);
+        $this->assertSame([], $this->enqueuedScripts, 'Password-protected content must not beacon');
     }
 
     /**
-     * Core regression proof: the beacon must render even when the optimizer
+     * Core regression proof: the beacon must enqueue even when the optimizer
      * (and therefore any WPMgr page-cache buffer) is completely disabled.
      * This is the GH #154 fix — RUM no longer requires
      * PerfConfig::anyHtmlTransformEnabled() / CacheConfig->enabled to be true.
@@ -417,10 +498,96 @@ final class OptimizerRumTest extends TestCase
         $opt = new Optimizer($c);
         $this->assertFalse($opt->isActive());
 
-        // Yet the wp_head-bound RUM injector still emits.
-        $out = $this->render($c);
-        $this->assertStringContainsString('data-wpmgr-rum-config', $out);
-        $this->assertStringContainsString('wpmgr-rum.min.js', $out);
+        // Yet the wp_enqueue_scripts-bound RUM injector still enqueues.
+        $this->render($c);
+        $this->assertNotNull($this->enqueuedRumScript());
+        $this->assertNotNull($this->inlineRumScript());
+    }
+
+    // ---- WP<6.3 async fallback tests (2026-07 wp.org review fix) ----
+
+    public function test_render_on_wp63_plus_uses_strategy_array_and_registers_no_fallback_filter(): void
+    {
+        $GLOBALS['wp_version'] = '6.4-alpha';
+
+        $c = $this->makeConfig();
+        $this->render($c);
+
+        $script = $this->enqueuedRumScript();
+        $this->assertNotNull($script);
+        $this->assertIsArray($script['args'], 'WP 6.3+ must use the array in_footer/strategy form');
+        $this->assertSame(false, $script['args']['in_footer'] ?? null);
+        $this->assertSame('async', $script['args']['strategy'] ?? null);
+
+        $this->assertSame(
+            [],
+            array_filter($this->registeredFilters, static fn ($f) => $f['hook'] === 'script_loader_tag'),
+            'WP 6.3+ must not need the script_loader_tag async fallback'
+        );
+    }
+
+    public function test_render_on_wp62_uses_bool_infooter_and_registers_fallback_filter(): void
+    {
+        $GLOBALS['wp_version'] = '6.2.2';
+
+        $c = $this->makeConfig();
+        $this->render($c);
+
+        $script = $this->enqueuedRumScript();
+        $this->assertNotNull($script);
+        $this->assertSame(
+            false,
+            $script['args'],
+            'WP<6.3 must pass a plain bool(false) in_footer, never an array (which PHP would coerce to true)'
+        );
+
+        $fallback = array_values(array_filter(
+            $this->registeredFilters,
+            static fn ($f) => $f['hook'] === 'script_loader_tag'
+        ));
+        $this->assertNotEmpty($fallback, 'WP<6.3 must register the script_loader_tag async fallback filter');
+        $this->assertSame([RumInjector::class, 'filterAsyncScriptTag'], $fallback[0]['callback']);
+    }
+
+    public function test_render_with_unknown_wp_version_defaults_to_wp62_safe_path(): void
+    {
+        // $GLOBALS['wp_version'] is unset in set_up(); coreSupportsScriptStrategy()
+        // must default to the safe (bool + filter) path rather than risk the
+        // footer-forcing array coercion on an unrecognized/older core.
+        $c = $this->makeConfig();
+        $this->render($c);
+
+        $script = $this->enqueuedRumScript();
+        $this->assertNotNull($script);
+        $this->assertSame(false, $script['args']);
+    }
+
+    public function test_filter_async_script_tag_adds_async_to_own_handle(): void
+    {
+        $tag = '<script src="https://example.com/wp-content/plugins/wpmgr-agent/assets/wpmgr-rum.min.js?ver=1.0.0" id="wpmgr-rum-js"></script>';
+
+        $out = RumInjector::filterAsyncScriptTag($tag, RumInjector::SCRIPT_HANDLE);
+
+        $this->assertStringContainsString('async src=', $out);
+    }
+
+    public function test_filter_async_script_tag_leaves_other_handles_untouched(): void
+    {
+        $tag = '<script src="https://example.com/some-other-plugin.js" id="some-other-plugin-js"></script>';
+
+        $out = RumInjector::filterAsyncScriptTag($tag, 'some-other-plugin');
+
+        $this->assertSame($tag, $out);
+    }
+
+    public function test_filter_async_script_tag_does_not_double_up_async(): void
+    {
+        $tag = '<script async src="https://example.com/wp-content/plugins/wpmgr-agent/assets/wpmgr-rum.min.js" id="wpmgr-rum-js"></script>';
+
+        $out = RumInjector::filterAsyncScriptTag($tag, RumInjector::SCRIPT_HANDLE);
+
+        $this->assertSame($tag, $out, 'must not double up async if already present (e.g. a future core also adding it)');
+        $this->assertSame(1, substr_count($out, 'async'));
     }
 
     // ---- Optimizer pipeline tests (stage 11 removal) ----
@@ -442,7 +609,7 @@ final class OptimizerRumTest extends TestCase
     {
         // Even if some OTHER transform is also on (so the pipeline actually
         // runs), the RUM marker must never appear in the optimizer's output —
-        // stage 11 is gone; RumInjector is reached only via wp_head now.
+        // stage 11 is gone; RumInjector is reached only via wp_enqueue_scripts now.
         $config = new PerfConfig([
             'cache_link_prefetch' => true,
             'rum_enabled'         => true,

--- a/apps/agent/tests/Security/EnrollmentFlowTest.php
+++ b/apps/agent/tests/Security/EnrollmentFlowTest.php
@@ -112,6 +112,11 @@ final class EnrollmentFlowTest extends TestCase
         Functions\when('wp_die')->alias(function ($msg, $title = '', $args = []) {
             throw new \RuntimeException('wp_die called: ' . (string) $msg);
         });
+        // Escape-late pass at every 2FA form/profile echo (2026-07 wp.org
+        // review fix). Passthrough here -- these tests exercise the module's
+        // routing/session logic, not wp_kses()'s own filtering.
+        Functions\when('wp_kses')->returnArg();
+        Functions\when('wp_allowed_protocols')->justReturn(['http', 'https', 'mailto']);
         Functions\when('wp_hash_password')->alias(fn ($p) => password_hash($p, PASSWORD_BCRYPT));
         Functions\when('wp_check_password')->alias(fn ($p, $h, $uid) => password_verify((string) $p, (string) $h));
         Functions\when('wp_create_nonce')->alias(fn ($action) => 'nonce_' . md5((string) $action));

--- a/apps/agent/tests/Security/Site2faKsesEscapingTest.php
+++ b/apps/agent/tests/Security/Site2faKsesEscapingTest.php
@@ -1,0 +1,595 @@
+<?php
+/**
+ * Regression tests for the 2026-07 wp.org review escape-late fix:
+ * Site2faModule's assembled-form echo sinks (renderForcedChangeForm,
+ * renderInterstitial, renderSetupScreen, renderProfileSection) now run
+ * through `wp_kses($html, self::allowedFormKses(), self::allowedFormProtocols())`
+ * instead of a raw `echo $formHtml; // phpcs:ignore ...OutputNotEscaped`.
+ *
+ * wp_kses_post() is deliberately NOT used: its default $allowedposttags
+ * omits <form>/<input>/<button>, which every one of these screens needs to
+ * render (and submit) at all. These tests prove:
+ *
+ *   1. Every one of the four echo sinks actually calls wp_kses() (not a bare
+ *      echo) with the module's own explicit allowlist + protocol list.
+ *   2. allowedFormKses() allows form/input/button/svg/rect (the exact set
+ *      wp_kses_post() would strip) plus every other tag/attribute the module
+ *      emits.
+ *   3. allowedFormProtocols() extends WP's default protocol list with
+ *      `data:` (needed for the backup-codes step's client-side download
+ *      link) without dropping the defaults.
+ *   4. Every tag/attribute actually present in each render path's raw
+ *      output is covered by allowedFormKses() -- a structural regression
+ *      guard so a future form change can't silently fall outside the
+ *      allowlist and get its markup stripped (or worse, someone "fixes" the
+ *      resulting breakage by reaching for wp_kses_post()).
+ *
+ * We invoke each private render*() method directly via reflection rather
+ * than through its public routing entrypoint (unlike most of this module's
+ * other tests) because renderForcedChangeForm()/renderInterstitial()/
+ * renderSetupScreen() all end with a literal `exit;` -- calling wp_kses()
+ * as a throwing spy (recording its args before throwing) lets us observe
+ * the call without ever reaching that exit() and killing the PHPUnit
+ * process.
+ *
+ * @package WPMgr\Agent\Tests\Security
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Security;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Security\BackupCodesProvider;
+use WPMgr\Agent\Security\EmailCodeProvider;
+use WPMgr\Agent\Security\SecurityPolicy;
+use WPMgr\Agent\Security\Site2faModule;
+use WPMgr\Agent\Security\TotpProvider;
+use WPMgr\Agent\Support\AgeIdentity;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Security\Site2faModule
+ */
+final class Site2faKsesEscapingTest extends TestCase
+{
+    /** @var array<int,array<string,mixed>> */
+    private array $userMeta = [];
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->userMeta = [];
+
+        Functions\when('get_user_meta')->alias(function ($uid, $key, $single) {
+            return $this->userMeta[$uid][$key] ?? '';
+        });
+        Functions\when('update_user_meta')->alias(function ($uid, $key, $value) {
+            $this->userMeta[$uid][$key] = $value;
+            return true;
+        });
+        Functions\when('delete_user_meta')->alias(function ($uid, $key) {
+            unset($this->userMeta[$uid][$key]);
+            return true;
+        });
+
+        Functions\when('get_option')->justReturn('');
+        Functions\when('update_option')->justReturn(true);
+        Functions\when('wp_json_encode')->alias(fn ($v) => json_encode($v));
+        Functions\when('esc_url_raw')->alias(fn ($u) => $u);
+        Functions\when('esc_url')->alias(fn ($u) => $u);
+        Functions\when('add_action')->justReturn(true);
+        Functions\when('add_filter')->justReturn(true);
+        Functions\when('is_ssl')->justReturn(false);
+        Functions\when('esc_html__')->alias(fn ($t, $d = '') => $t);
+        Functions\when('esc_html')->alias(fn ($t) => $t);
+        Functions\when('esc_attr')->alias(fn ($t) => $t);
+        Functions\when('esc_attr__')->alias(fn ($t, $d = '') => $t);
+        Functions\when('__')->alias(fn ($t, $d = '') => $t);
+        Functions\when('wp_login_url')->justReturn('/wp-login.php');
+        Functions\when('add_query_arg')->alias(fn ($args, $url = '') => $url . '?' . http_build_query($args));
+        Functions\when('login_header')->justReturn(null);
+        Functions\when('login_footer')->justReturn(null);
+        Functions\when('wp_salt')->justReturn('test-salt-value');
+        Functions\when('get_bloginfo')->justReturn('Test Site');
+        Functions\when('wp_hash')->alias(fn (string $data) => hash('sha256', $data));
+        Functions\when('wp_mail')->justReturn(true);
+        Functions\when('sanitize_text_field')->alias(fn ($t) => $t);
+        Functions\when('sanitize_file_name')->alias(fn ($t) => preg_replace('/[^A-Za-z0-9._-]/', '-', (string) $t));
+        Functions\when('wp_create_nonce')->justReturn('test-nonce');
+        // Real WP default: no 'data' scheme. allowedFormProtocols() must add it.
+        Functions\when('wp_allowed_protocols')->justReturn(['http', 'https', 'mailto']);
+    }
+
+    protected function tear_down(): void
+    {
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    private function makeUser(int $id, array $roles = ['administrator']): \WP_User
+    {
+        $u             = new \WP_User();
+        $u->ID         = $id;
+        $u->roles      = $roles;
+        $u->user_login = 'user' . $id;
+        $u->user_email = 'user' . $id . '@example.com';
+        return $u;
+    }
+
+    private function makeProviders(): array
+    {
+        $ageIdentity = new class extends AgeIdentity {
+            public function __construct()
+            {
+                // Skip parent -- no keystore needed in tests.
+            }
+
+            public function encryptChunk(string $plaintext): string
+            {
+                return $plaintext;
+            }
+
+            public function decryptChunk(string $ciphertext): string
+            {
+                return $ciphertext;
+            }
+        };
+
+        return [
+            new TotpProvider($ageIdentity),
+            new EmailCodeProvider(),
+            new BackupCodesProvider(),
+        ];
+    }
+
+    private function makeModule(SecurityPolicy $policy): Site2faModule
+    {
+        return new Site2faModule($policy, $this->makeProviders());
+    }
+
+    /**
+     * @return array<string,array<string,bool>>
+     */
+    private function allowedFormKses(): array
+    {
+        $ref = new \ReflectionMethod(Site2faModule::class, 'allowedFormKses');
+        return $ref->invoke(null);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function allowedFormProtocols(): array
+    {
+        $ref = new \ReflectionMethod(Site2faModule::class, 'allowedFormProtocols');
+        return $ref->invoke(null);
+    }
+
+    /**
+     * Install a throwing wp_kses() spy that records every call's args, then
+     * asserts exactly one call happened using the module's own allowlist +
+     * protocol helpers, and returns the captured HTML (pre-filtering, since
+     * the spy never reaches real wp_kses filtering -- that is intentional;
+     * see the class docblock).
+     *
+     * @param callable $invoke Callback that triggers the render path.
+     * @return string Captured $html argument from the single wp_kses() call.
+     */
+    private function captureWpKsesCall(callable $invoke): string
+    {
+        $captured = [];
+        Functions\when('wp_kses')->alias(function ($html, $allowed = [], $protocols = []) use (&$captured) {
+            $captured[] = ['html' => $html, 'allowed' => $allowed, 'protocols' => $protocols];
+            throw new \RuntimeException('marker:wp_kses_called');
+        });
+
+        $threw = false;
+        try {
+            $invoke();
+        } catch (\RuntimeException $e) {
+            if ($e->getMessage() === 'marker:wp_kses_called') {
+                $threw = true;
+            } else {
+                throw $e;
+            }
+        }
+
+        $this->assertTrue($threw, 'render path must reach an escape-at-output-boundary wp_kses() call');
+        $this->assertCount(1, $captured, 'render path must call wp_kses() exactly once');
+
+        $this->assertSame(
+            $this->allowedFormKses(),
+            $captured[0]['allowed'],
+            'render path must pass the module\'s own allowedFormKses() allowlist, not an ad-hoc or wp_kses_post() shape'
+        );
+        $this->assertSame(
+            $this->allowedFormProtocols(),
+            $captured[0]['protocols'],
+            'render path must pass the module\'s own allowedFormProtocols() (default protocols + data:)'
+        );
+
+        return (string) $captured[0]['html'];
+    }
+
+    // -------------------------------------------------------------------------
+    // 1) allowedFormKses() / allowedFormProtocols() structural assertions
+    // -------------------------------------------------------------------------
+
+    public function test_allowed_form_kses_permits_form_input_button_unlike_wp_kses_post(): void
+    {
+        $allowed = $this->allowedFormKses();
+
+        // The whole reason wp_kses_post() cannot be used for these screens.
+        $this->assertArrayHasKey('form', $allowed);
+        $this->assertArrayHasKey('input', $allowed);
+        $this->assertArrayHasKey('button', $allowed);
+
+        // The inline TOTP QR code (QrEncoder::toSvg()).
+        $this->assertArrayHasKey('svg', $allowed);
+        $this->assertArrayHasKey('rect', $allowed);
+
+        $this->assertArrayHasKey('action', $allowed['form']);
+        $this->assertArrayHasKey('method', $allowed['form']);
+        $this->assertArrayHasKey('type', $allowed['input']);
+        $this->assertArrayHasKey('required', $allowed['input']);
+        $this->assertArrayHasKey('viewbox', $allowed['svg']);
+    }
+
+    public function test_allowed_form_protocols_extends_defaults_with_data_scheme(): void
+    {
+        $protocols = $this->allowedFormProtocols();
+
+        $this->assertContains('data', $protocols, 'the backup-codes download link is a data: URI');
+        // Must extend, not replace, WP's own defaults.
+        $this->assertContains('http', $protocols);
+        $this->assertContains('https', $protocols);
+    }
+
+    // -------------------------------------------------------------------------
+    // 2) Every echo sink actually calls wp_kses() with the module's allowlist
+    // -------------------------------------------------------------------------
+
+    public function test_render_forced_change_form_escapes_via_wp_kses(): void
+    {
+        $policy = SecurityPolicy::fromArray(['policy' => ['two_factor_enabled' => true]]);
+        $module = $this->makeModule($policy);
+        $userId = 501;
+        $user   = $this->makeUser($userId);
+
+        $createRef = new \ReflectionMethod($module, 'createSession');
+        $session   = $createRef->invoke($module, $userId, '/wp-admin/', false, 'forced_change');
+
+        $renderRef = new \ReflectionMethod($module, 'renderForcedChangeForm');
+
+        $html = $this->captureWpKsesCall(
+            fn () => $renderRef->invoke($module, $user, $session, 'expiry', '')
+        );
+
+        $this->assertStringContainsString('<form', $html);
+        $this->assertStringContainsString('wpmgr_fc_pass1', $html);
+    }
+
+    public function test_render_interstitial_escapes_via_wp_kses(): void
+    {
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+        $module = $this->makeModule($policy);
+        $userId = 502;
+        $user   = $this->makeUser($userId);
+
+        $createRef = new \ReflectionMethod($module, 'createSession');
+        $session   = $createRef->invoke($module, $userId, '/wp-admin/', false, '2fa');
+
+        $renderRef = new \ReflectionMethod($module, 'renderInterstitial');
+
+        $html = $this->captureWpKsesCall(
+            fn () => $renderRef->invoke($module, $user, $session, '')
+        );
+
+        $this->assertStringContainsString('<form', $html);
+        $this->assertStringContainsString('wpmgr_2fa_token', $html);
+    }
+
+    public function test_render_setup_screen_totp_step_escapes_via_wp_kses_and_includes_svg(): void
+    {
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+        $module = $this->makeModule($policy);
+        $userId = 503;
+        $user   = $this->makeUser($userId);
+
+        $createRef = new \ReflectionMethod($module, 'createSession');
+        $session   = $createRef->invoke($module, $userId, '/wp-admin/', false, Site2faModule::SESSION_TYPE_2FA_SETUP);
+        $session['setup_step'] = Site2faModule::SETUP_STEP_TOTP;
+
+        $renderRef = new \ReflectionMethod($module, 'renderSetupScreen');
+
+        $html = $this->captureWpKsesCall(
+            fn () => $renderRef->invoke($module, $user, $session, '')
+        );
+
+        $this->assertStringContainsString('<form', $html);
+        // The QR code -- the reason svg/rect are in the allowlist at all.
+        $this->assertStringContainsString('<svg', $html);
+        $this->assertStringContainsString('<rect', $html);
+    }
+
+    public function test_render_setup_screen_backup_step_escapes_via_wp_kses_and_keeps_data_uri_download(): void
+    {
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+        $module = $this->makeModule($policy);
+        $userId = 504;
+        $user   = $this->makeUser($userId);
+
+        $createRef = new \ReflectionMethod($module, 'createSession');
+        $session   = $createRef->invoke($module, $userId, '/wp-admin/', false, Site2faModule::SESSION_TYPE_2FA_SETUP);
+        $session['setup_step']    = Site2faModule::SETUP_STEP_BACKUP;
+        $session['backup_codes']  = ['1111111111', '2222222222'];
+
+        $renderRef = new \ReflectionMethod($module, 'renderSetupScreen');
+
+        $html = $this->captureWpKsesCall(
+            fn () => $renderRef->invoke($module, $user, $session, '')
+        );
+
+        $this->assertStringContainsString('<ol', $html);
+        $this->assertStringContainsString('1111111111', $html);
+        // The client-side download link -- proves allowedFormProtocols()'s
+        // data: addition is actually needed by real emitted markup.
+        $this->assertStringContainsString('href="data:text/plain', $html);
+        $this->assertStringContainsString('download=', $html);
+    }
+
+    public function test_render_profile_section_escapes_via_wp_kses(): void
+    {
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+        $module = $this->makeModule($policy);
+        $user   = $this->makeUser(505);
+
+        $html = $this->captureWpKsesCall(
+            fn () => $module->renderProfileSection($user)
+        );
+
+        $this->assertStringContainsString('<table', $html);
+        $this->assertStringContainsString('wpmgr_2fa_profile_nonce', $html);
+    }
+
+    // -------------------------------------------------------------------------
+    // 3) Structural coverage: every tag/attribute actually emitted is allowed
+    // -------------------------------------------------------------------------
+
+    /**
+     * Parse a raw HTML fragment (the pre-kses string the module built) via
+     * DOMDocument (which correctly respects quoting -- unlike a naive regex,
+     * it will not mistake `charset=` inside a quoted `data:text/plain;
+     * charset=utf-8,...` attribute VALUE for a second attribute NAME) and
+     * assert every element/attribute pair is a key in allowedFormKses() --
+     * catching a future form edit that adds a tag/attribute without updating
+     * the allowlist (which would otherwise only surface as silently-stripped
+     * markup in production).
+     */
+    private function assertEveryTagAndAttributeIsAllowlisted(string $html): void
+    {
+        $allowed = $this->allowedFormKses();
+
+        $this->assertNotSame('', $html, 'sanity: captured HTML must not be empty');
+
+        $doc = new \DOMDocument();
+        libxml_use_internal_errors(true);
+        $doc->loadHTML(
+            '<!DOCTYPE html><html><body>' . $html . '</body></html>',
+            LIBXML_NOERROR | LIBXML_NOWARNING
+        );
+        libxml_clear_errors();
+
+        $body = $doc->getElementsByTagName('body')->item(0);
+        $this->assertNotNull($body, 'sanity: DOMDocument must parse the fragment');
+
+        $seenAnyTag = false;
+        $walker      = function (\DOMNode $node) use (&$walker, &$seenAnyTag, $allowed): void {
+            if ($node instanceof \DOMElement) {
+                $tag = strtolower($node->tagName);
+                $seenAnyTag = true;
+                $this->assertArrayHasKey(
+                    $tag,
+                    $allowed,
+                    "tag <$tag> is emitted by the module but missing from allowedFormKses()"
+                );
+                foreach ($node->attributes as $attr) {
+                    $attrLow = strtolower($attr->name);
+                    $this->assertArrayHasKey(
+                        $attrLow,
+                        $allowed[$tag],
+                        "attribute \"$attrLow\" on <$tag> is emitted by the module but missing from allowedFormKses()['$tag']"
+                    );
+                }
+            }
+            foreach ($node->childNodes as $child) {
+                $walker($child);
+            }
+        };
+        foreach ($body->childNodes as $child) {
+            $walker($child);
+        }
+
+        $this->assertTrue($seenAnyTag, 'sanity: at least one tag must be present');
+    }
+
+    public function test_forced_change_form_output_is_fully_covered_by_allowlist(): void
+    {
+        $policy = SecurityPolicy::fromArray(['policy' => ['two_factor_enabled' => true]]);
+        $module = $this->makeModule($policy);
+        $userId = 511;
+        $user   = $this->makeUser($userId);
+
+        $createRef = new \ReflectionMethod($module, 'createSession');
+        $session   = $createRef->invoke($module, $userId, '/wp-admin/', false, 'forced_change');
+
+        $renderRef = new \ReflectionMethod($module, 'renderForcedChangeForm');
+        $html      = $this->captureWpKsesCall(
+            fn () => $renderRef->invoke($module, $user, $session, 'expiry', 'Some error')
+        );
+
+        $this->assertEveryTagAndAttributeIsAllowlisted($html);
+    }
+
+    public function test_setup_totp_step_output_is_fully_covered_by_allowlist(): void
+    {
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+        $module = $this->makeModule($policy);
+        $userId = 512;
+        $user   = $this->makeUser($userId);
+
+        $createRef = new \ReflectionMethod($module, 'createSession');
+        $session   = $createRef->invoke($module, $userId, '/wp-admin/', false, Site2faModule::SESSION_TYPE_2FA_SETUP);
+        $session['setup_step'] = Site2faModule::SETUP_STEP_TOTP;
+
+        $renderRef = new \ReflectionMethod($module, 'renderSetupScreen');
+        $html      = $this->captureWpKsesCall(
+            fn () => $renderRef->invoke($module, $user, $session, '')
+        );
+
+        $this->assertEveryTagAndAttributeIsAllowlisted($html);
+    }
+
+    public function test_setup_choose_step_output_is_fully_covered_by_allowlist(): void
+    {
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+        $module = $this->makeModule($policy);
+        $userId = 513;
+        $user   = $this->makeUser($userId);
+
+        $createRef = new \ReflectionMethod($module, 'createSession');
+        $session   = $createRef->invoke($module, $userId, '/wp-admin/', false, Site2faModule::SESSION_TYPE_2FA_SETUP);
+        $session['setup_step'] = Site2faModule::SETUP_STEP_CHOOSE;
+
+        $renderRef = new \ReflectionMethod($module, 'renderSetupScreen');
+        $html      = $this->captureWpKsesCall(
+            fn () => $renderRef->invoke($module, $user, $session, '')
+        );
+
+        $this->assertEveryTagAndAttributeIsAllowlisted($html);
+    }
+
+    public function test_setup_backup_step_output_is_fully_covered_by_allowlist(): void
+    {
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+        $module = $this->makeModule($policy);
+        $userId = 514;
+        $user   = $this->makeUser($userId);
+
+        $createRef = new \ReflectionMethod($module, 'createSession');
+        $session   = $createRef->invoke($module, $userId, '/wp-admin/', false, Site2faModule::SESSION_TYPE_2FA_SETUP);
+        $session['setup_step']   = Site2faModule::SETUP_STEP_BACKUP;
+        $session['backup_codes'] = ['3333333333', '4444444444'];
+
+        $renderRef = new \ReflectionMethod($module, 'renderSetupScreen');
+        $html      = $this->captureWpKsesCall(
+            fn () => $renderRef->invoke($module, $user, $session, '')
+        );
+
+        $this->assertEveryTagAndAttributeIsAllowlisted($html);
+    }
+
+    public function test_setup_done_step_output_is_fully_covered_by_allowlist(): void
+    {
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+        $module = $this->makeModule($policy);
+        $userId = 515;
+        $user   = $this->makeUser($userId);
+
+        $createRef = new \ReflectionMethod($module, 'createSession');
+        $session   = $createRef->invoke($module, $userId, '/wp-admin/', false, Site2faModule::SESSION_TYPE_2FA_SETUP);
+        $session['setup_step'] = Site2faModule::SETUP_STEP_DONE;
+
+        $renderRef = new \ReflectionMethod($module, 'renderSetupScreen');
+        $html      = $this->captureWpKsesCall(
+            fn () => $renderRef->invoke($module, $user, $session, '')
+        );
+
+        $this->assertEveryTagAndAttributeIsAllowlisted($html);
+    }
+
+    public function test_interstitial_output_is_fully_covered_by_allowlist(): void
+    {
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+        $module = $this->makeModule($policy);
+        $userId = 516;
+        $user   = $this->makeUser($userId);
+
+        $createRef = new \ReflectionMethod($module, 'createSession');
+        $session   = $createRef->invoke($module, $userId, '/wp-admin/', false, '2fa');
+
+        $renderRef = new \ReflectionMethod($module, 'renderInterstitial');
+        $html      = $this->captureWpKsesCall(
+            fn () => $renderRef->invoke($module, $user, $session, 'Invalid code')
+        );
+
+        $this->assertEveryTagAndAttributeIsAllowlisted($html);
+    }
+
+    public function test_profile_section_output_is_fully_covered_by_allowlist(): void
+    {
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+        $module = $this->makeModule($policy);
+        $user   = $this->makeUser(517);
+
+        $html = $this->captureWpKsesCall(
+            fn () => $module->renderProfileSection($user)
+        );
+
+        $this->assertEveryTagAndAttributeIsAllowlisted($html);
+    }
+}

--- a/apps/agent/tests/Security/Site2faModuleTest.php
+++ b/apps/agent/tests/Security/Site2faModuleTest.php
@@ -108,6 +108,13 @@ final class Site2faModuleTest extends TestCase
         Functions\when('wp_die')->alias(function ($msg, $title = '', $args = []) {
             throw new \RuntimeException('wp_die called: ' . $msg);
         });
+        // Escape-late pass at every form/profile echo (2026-07 wp.org review
+        // fix). Passthrough here -- these tests exercise the module's routing
+        // logic, not wp_kses()'s own filtering (that is exercised by
+        // Site2faKsesEscapingTest, which asserts the exact allowlist/protocol
+        // args every call site passes).
+        Functions\when('wp_kses')->returnArg();
+        Functions\when('wp_allowed_protocols')->justReturn(['http', 'https', 'mailto']);
     }
 
     protected function tear_down(): void

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.56
+ * Version:           0.61.57
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.56');
+define('WPMGR_AGENT_VERSION', '0.61.57');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 


### PR DESCRIPTION
Agent-only hardening from the first thorough **human** wp.org review (T13). No behavior change for managed sites; improvements land in both the self-hosted agent and the wp.org build.

- **RUM collector → `wp_enqueue_script`** (core 6.3 async) + `wp_add_inline_script`, off the hand-built `wp_head@99` tag (WP<6.3 async fallback via `script_loader_tag`).
- **2FA / forced-password-change screens → `wp_kses` escape-late** with an explicit allowlist; whole-plugin sweep of the accumulate-then-echo-blob pattern.
- **Bounded `set_time_limit(900)`** (was `0`) across ~23 backup/restore/dump/media routines via a shared const.
- CloudPanel `$_SERVER` inline-sanitize; media-quarantine docblock + dead branch; comment repointing; readme SES URL + broken HIBP link + Stable tag.

Autologin is **defended in-build** per the maintainer decision (wp.org build strips only the self-updater). Full analysis + reply in `docs/security/wporg-t13-*`.

**Gates:** composer test 2665 (0 failures), phpcs 0, `wp plugin check` 0 errors, activates clean on WP 7.0.1; real-WP smoke tests on the RUM enqueue + `wp_kses`. Agent bumped to 0.61.57. No CP/web/media-encoder change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)