### PR TITLE
fix: latest issue batch #214-#219 (0.61.58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.58] - 2026-07-14
+
+### Fixed
+
+- Bulk update runs no longer trigger a separate WordPress.org update check for every item in the batch (GH #218). The earlier fix that forces a fresh check before deciding "nothing to update" was running once per item, so a batch of N items made N full-catalog checks back to back, each discarding the previous result, which could intermittently leave a genuinely-pending update reported as up to date. The fresh check now runs once per run per component type, so the whole batch shares one guaranteed-fresh result.
+- Plugin and theme updates no longer fail intermittently with "Could not copy file" on hosts whose system temporary directory is shared with PHP session storage and has grown to tens of thousands of stale files (GH #216). The agent now treats a writable-but-pathologically-overloaded default temp directory as unusable and falls back to its own dedicated, clean upload-directory temp location for the unpack step (only when the default is genuinely unhealthy).
+- The fleet backup health endpoint no longer returns a 500 for the whole fleet when a site has never completed a backup (GH #214). A site with no completed snapshot now reports as Unprotected with a zero size instead of failing the aggregation. Affects installs that rely on the instance-wide storage settings and have any new or monitoring-only site.
+- The bulk Update-sites wizard's Plugins/Themes tab badges now count only components that actually have a pending update, matching the list shown below them (GH #217). Previously a tab with components but no available updates showed a nonzero badge that contradicted the "Showing 0 with available updates" text.
+- The hide-login feature no longer blocks front-end AJAX (GH #219). It was 404ing logged-out requests to `admin-ajax.php` (and `admin-post.php`), which many themes and page builders use for front-end forms; those endpoints are now excluded from the block while the actual login and dashboard pages stay hidden.
+- Two-factor sign-in is clearer and slightly more forgiving (GH #215). The "incorrect code" message now explains that a code can only be used once (re-submitting the same code, for example from a password manager, is correctly rejected until your authenticator shows the next one); the accepted time window was widened to plus or minus 60 seconds for minor clock drift; and the code used to finish 2FA setup can no longer be reused for the first login. The single-use replay protection is unchanged.
+
 ## [0.61.57] - 2026-07-14
 
 ### Changed

--- a/apps/agent/includes/security/class-hide-backend-module.php
+++ b/apps/agent/includes/security/class-hide-backend-module.php
@@ -368,17 +368,45 @@ final class HideBackendModule
     }
 
     /**
+     * Legitimate front-end endpoints that live under /wp-admin/ but are
+     * explicitly designed to be reachable while logged out. WordPress serves
+     * these for un-authenticated visitors (admin-ajax.php dispatches
+     * wp_ajax_nopriv_* handlers; admin-post.php dispatches admin_post_nopriv_*
+     * handlers) and countless plugins/themes rely on them for public-facing
+     * AJAX and form submissions. They reveal neither the login page nor the
+     * admin dashboard, so hide-backend must NEVER gate them (GH #219).
+     *
+     * @var string[]
+     */
+    private const ALLOWED_FRONTEND_ADMIN_ENDPOINTS = [
+        'admin-ajax.php',
+        'admin-post.php',
+    ];
+
+    /**
      * Whether the path is a canonical wp-login or wp-admin location.
      * Also catches wp-login.php?action=* variants (lost password, register, etc.)
      * so the access-cookie check applies to the full login multi-request dance.
+     *
+     * admin-ajax.php and admin-post.php are explicitly EXCLUDED: they live under
+     * /wp-admin/ but are legitimate logged-out front-end endpoints (see
+     * ALLOWED_FRONTEND_ADMIN_ENDPOINTS). Gating them 404s public AJAX/POST used
+     * by plugins and page builders (GH #219).
      *
      * @param string $path The request path (no query string, no trailing slash).
      * @return bool
      */
     private function isLoginOrAdminPath(string $path): bool
     {
-        $loginFile = '/wp-login.php';
-        $adminDir  = '/wp-admin';
+        $adminDir = '/wp-admin';
+
+        // Never gate legitimate logged-out front-end endpoints that happen to
+        // live under /wp-admin/ (admin-ajax.php, admin-post.php). Match on the
+        // final path segment so it holds at any install depth
+        // (e.g. /subdir/wp-admin/admin-ajax.php).
+        if (in_array(basename($path), self::ALLOWED_FRONTEND_ADMIN_ENDPOINTS, true)) {
+            return false;
+        }
 
         // Match /wp-login.php at any install depth (e.g. /subdir/wp-login.php).
         // Also catch the original REQUEST_URI with a query string still present --

--- a/apps/agent/includes/security/class-site-2fa-module.php
+++ b/apps/agent/includes/security/class-site-2fa-module.php
@@ -914,7 +914,14 @@ final class Site2faModule
             $session['attempts'] = $attempts + 1;
             $this->storeSession($userId, $session);
             $this->incrementCrossRequestAttempts($userId);
-            $this->renderInterstitial($user, $session, esc_html__('Incorrect code. Please try again.', 'wpmgr-agent'));
+            $this->renderInterstitial(
+                $user,
+                $session,
+                esc_html__(
+                    'Incorrect code. Please try again. If you just used this code, wait for your authenticator to show a new one before trying again.',
+                    'wpmgr-agent'
+                )
+            );
             return;
         }
 

--- a/apps/agent/includes/security/class-totp-provider.php
+++ b/apps/agent/includes/security/class-totp-provider.php
@@ -4,9 +4,11 @@
  *
  * Algorithm:
  *   - SHA1 / 6 digits / 30-second period (matches major authenticator apps).
- *   - ±1 step skew window to tolerate clock drift.
+ *   - ±2 step (±60s) skew window to tolerate clock drift (GH #215).
  *   - Single-use step burn: the accepted counter step is stored in user-meta
- *     so the same code cannot be replayed within its validity window.
+ *     so the same code cannot be replayed within its validity window, even
+ *     across the wider skew window; the enrollment activation step is burned
+ *     too, so the setup-confirm code cannot be reused as the first login.
  *   - TOTP secret (160-bit, base32-encoded) stored encrypted in user-meta via
  *     the agent's AgeCrypto (AgeIdentity keypair). Decrypt failure = provider
  *     reports "configured but unusable" (never silent bypass).
@@ -54,8 +56,14 @@ final class TotpProvider implements SiteTwoFactorProvider
     /** Code length in digits. */
     private const DIGITS = 6;
 
-    /** Acceptable window (±N steps on either side of current). */
-    private const WINDOW = 1;
+    /**
+     * Acceptable window (±N steps on either side of current), i.e. ±(N*PERIOD)
+     * seconds of clock-drift tolerance. Widened from 1 to 2 (±60s) to absorb
+     * client clock drift (GH #215); the single-use step burn below still
+     * prevents replay across the wider window — a step is only ever accepted
+     * once regardless of how many steps the window spans.
+     */
+    private const WINDOW = 2;
 
     private AgeIdentity $ageIdentity;
 
@@ -204,6 +212,11 @@ final class TotpProvider implements SiteTwoFactorProvider
             if (hash_equals($this->generateCode($secret, $counter), $code)) {
                 // Code valid: promote pending → active.
                 $this->storeSecretToMeta($user, $secret, self::META_SECRET);
+                // Burn the activation step so the same confirm code cannot be
+                // replayed as the very first login validate() call (the
+                // activation step was previously never recorded in
+                // META_LAST_USED, leaving a one-time replay window).
+                update_user_meta((int) $user->ID, self::META_LAST_USED, $counter);
                 // Clear pending (it is now active).
                 if (function_exists('delete_user_meta')) {
                     delete_user_meta((int) $user->ID, self::META_PENDING_SECRET);

--- a/apps/agent/includes/support/class-update-runner.php
+++ b/apps/agent/includes/support/class-update-runner.php
@@ -20,6 +20,17 @@ namespace WPMgr\Agent\Support;
 class UpdateRunner
 {
     /**
+     * Above this many entries, WordPress's own default temp directory
+     * (get_temp_dir()) is treated as pathologically populated rather than
+     * healthy, even when it is genuinely writable — see
+     * pinTempDirForUnpack()'s doc (GitHub issue #216). Well above sane
+     * transient temp-file use, well below the 10,000+ stale `sess_*`
+     * entries observed on the reporting host's GC-disabled session-save-path
+     * default.
+     */
+    private const MAX_HEALTHY_DEFAULT_TEMP_ENTRIES = 2000;
+
+    /**
      * The reason the most recent isComplete() call returned false, or '' when
      * that call returned true (or isComplete() has not been called yet).
      * Reset to '' at the START of every isComplete() call (see that method)
@@ -31,6 +42,18 @@ class UpdateRunner
      * GitHub issue #182's sibling visibility fix).
      */
     private string $lastIncompleteReason = '';
+
+    /**
+     * Which component types (plugin|theme|core) have already had their
+     * forced fresh update-check run during THIS UpdateRunner instance's
+     * lifetime (== this run — one CP `update` command constructs exactly one
+     * UpdateRunner; see UpdateCommand's class doc). Keyed by type, value
+     * always true when present. See forceFreshCheckOncePerRun()'s doc
+     * (GitHub issue #218).
+     *
+     * @var array<string,bool>
+     */
+    private array $freshCheckedTypes = [];
 
     /**
      * Validate an untrusted version string before it reaches WP-CLI argv or an
@@ -150,13 +173,16 @@ class UpdateRunner
      * in UpdateCommand::processItem(). For an explicit version request we
      * return it as-is (no WordPress check involved — the caller already
      * knows the target). For 'latest' we consult the WordPress update
-     * transients, but ONLY after forcing exactly one fresh check first
-     * (GitHub issue #208): see pluginUpdateVersion()/themeUpdateVersion()/
+     * transients, but ONLY after forcing a fresh check first (GitHub issue
+     * #208): see pluginUpdateVersion()/themeUpdateVersion()/
      * coreUpdateVersion() for why. Before that fix, a momentarily
      * stale/expired/never-yet-populated transient was read as-is and
      * indistinguishable from "genuinely no update available", so a real
      * pending update could be silently reported as up_to_date here while
      * WordPress's own background auto-updater applied it moments later.
+     * That forced check is now memoized once per run per component-type
+     * (GitHub issue #218) via forceFreshCheckOncePerRun() rather than once
+     * per call — see its doc for the bulk-run regression that fixed.
      *
      * @param string $type      plugin|theme|core.
      * @param string $slug      Sanitized slug.
@@ -993,17 +1019,34 @@ class UpdateRunner
      * writable, open_basedir-safe temp location) while eliminating the
      * collision that caused this regression.
      *
+     * BROADENED (GitHub issue #216): "usable" no longer means merely
+     * writable. A directory can pass the writability probe above and STILL
+     * be a bad place to unpack an update — a reported host's get_temp_dir()
+     * resolved to its PHP session save path with garbage collection
+     * effectively disabled, which had accumulated 10,000+ stale `sess_*`
+     * files; heavy per-file I/O against a directory that populated failed
+     * intermittently with "Could not copy file." tempDirEntryCountExceeds()
+     * cheaply (streaming, bounded) tests whether the default holds more than
+     * self::MAX_HEALTHY_DEFAULT_TEMP_ENTRIES entries; when it does, the
+     * default is treated exactly like an unwritable one and this method
+     * falls through to the SAME conditional last-resort fallback+create+
+     * write-probe pin path below — this constant's doc, not a new pin
+     * location, is the change. The pin location itself is unchanged and
+     * remains a CONDITIONAL last-resort (never unconditional): this is
+     * exactly the posture defended to the wp.org reviewer for this
+     * `define(WP_TEMP_DIR)` call.
+     *
      * Never redefines an already-defined WP_TEMP_DIR (an operator's
      * wp-config.php override, or an earlier call in this same request) —
      * that would be a fatal error, and it is also never our place to
      * second-guess an explicit choice made elsewhere.
      *
      * All filesystem probes (resolveDefaultTempDir(), isDirWritableByProbe(),
-     * fallbackTempDirCandidate()) are @-suppressed: on an open_basedir-
-     * restricted host, touching a disallowed path can emit a PHP warning
-     * (never a fatal), and none of this decision logic may let that noise
-     * surface — "can't tell" is treated the same as "not writable" by
-     * construction.
+     * tempDirEntryCountExceeds(), fallbackTempDirCandidate()) are
+     * @-suppressed: on an open_basedir-restricted host, touching a
+     * disallowed path can emit a PHP warning (never a fatal), and none of
+     * this decision logic may let that noise surface — "can't tell" is
+     * treated the same as "not usable" by construction.
      *
      * @return string A short, log-safe (no secrets) description of the
      *                decision, suitable for both DebugLog and the
@@ -1020,7 +1063,23 @@ class UpdateRunner
         }
 
         $default = $this->resolveDefaultTempDir();
+
+        // "Usable" (GitHub issue #216) requires BOTH a real writability
+        // proof AND that the default isn't pathologically populated — see
+        // this method's class doc. $defaultUnusableReason records WHICH
+        // condition failed, for the log strings below, replacing the
+        // previously-hardcoded 'not writable' wording.
+        $defaultUsable         = false;
+        $defaultUnusableReason = 'not writable';
         if ($default !== '' && $this->isDirWritableByProbe($default)) {
+            if ($this->tempDirEntryCountExceeds($default, self::MAX_HEALTHY_DEFAULT_TEMP_ENTRIES)) {
+                $defaultUnusableReason = 'shared temp dir has ' . self::MAX_HEALTHY_DEFAULT_TEMP_ENTRIES . '+ entries';
+            } else {
+                $defaultUsable = true;
+            }
+        }
+
+        if ($defaultUsable) {
             // The fix: WordPress's own default already works here — never
             // define WP_TEMP_DIR, so it stays completely disjoint from
             // wp-content/upgrade and the collision described in this
@@ -1031,7 +1090,8 @@ class UpdateRunner
         [$fallbackDir, $fallbackLabel] = $this->fallbackTempDirCandidate();
         if ($fallbackDir === '') {
             return 'temp dir: WordPress\'s own default (' . ($default !== '' ? $default : 'unresolved')
-                . ') is not writable here and no fallback directory is available; leaving WP_TEMP_DIR unset.';
+                . ') is unusable here (' . $defaultUnusableReason
+                . ') and no fallback directory is available; leaving WP_TEMP_DIR unset.';
         }
 
         if (!@is_dir($fallbackDir) && function_exists('wp_mkdir_p')) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort existence probe; must never warn/fatal under open_basedir, see method doc
@@ -1040,15 +1100,68 @@ class UpdateRunner
 
         if (!$this->isDirWritableByProbe($fallbackDir)) {
             return 'temp dir: WordPress\'s own default (' . ($default !== '' ? $default : 'unresolved')
-                . ') is not writable here, and the fallback directory ' . $fallbackDir
+                . ') is unusable here (' . $defaultUnusableReason . '), and the fallback directory ' . $fallbackDir
                 . ' could not be created/written either; leaving WP_TEMP_DIR unset.';
         }
 
         // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- WP_TEMP_DIR is a documented, overridable WordPress core constant (wp-admin/includes/file.php get_temp_dir()), not a constant of our own; it is simply missing from this sniff's hardcoded allowed_core_constants list
         define('WP_TEMP_DIR', $fallbackDir);
 
-        return 'temp dir: WordPress\'s own default was not writable here; pinned to a dedicated fallback dir '
-            . $fallbackDir . ' (' . $fallbackLabel . ').';
+        return 'temp dir: WordPress\'s own default was unusable here (' . $defaultUnusableReason
+            . '); pinned to a dedicated fallback dir ' . $fallbackDir . ' (' . $fallbackLabel . ').';
+    }
+
+    /**
+     * Bounded, STREAMING check for whether $dir contains more than $limit
+     * entries (GitHub issue #216) — used to decide whether WordPress's own
+     * default temp dir is pathologically populated (see
+     * pinTempDirForUnpack()'s doc) rather than merely writable.
+     *
+     * Deliberately never builds a full listing (no scandir()/glob() over a
+     * directory that may hold tens of thousands of entries): opendir()/
+     * readdir() are used directly so this can return true as soon as the
+     * count exceeds $limit, costing at most $limit+1 readdir() calls even
+     * against a pathologically large directory.
+     *
+     * Fails CLOSED to "not exceeded" (returns false) whenever the directory
+     * cannot be opened at all — an open_basedir restriction, or a race where
+     * it was removed between the writability probe and this call — so this
+     * check can only ever ADD a fallback pin on top of a genuinely
+     * enumerable, pathologically populated directory; it can never itself
+     * cause a pin to be skipped by guessing. Every filesystem touch is
+     * @-suppressed, mirroring isDirWritableByProbe()'s posture: "can't tell"
+     * must never surface as a warning under open_basedir.
+     *
+     * @param string $dir   Absolute directory path to inspect.
+     * @param int    $limit Entry-count threshold; exceeded means strictly
+     *                      more than this many non-dot entries were found.
+     * @return bool True when $dir's entry count (excluding `.`/`..`) is
+     *              strictly greater than $limit. False when at or below
+     *              $limit, or when $dir could not be opened for reading.
+     */
+    private function tempDirEntryCountExceeds(string $dir, int $limit): bool
+    {
+        $handle = @opendir($dir); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort bounded probe; must never warn/fatal under open_basedir or a directory removed mid-race, see method doc
+        if ($handle === false) {
+            return false;
+        }
+
+        try {
+            $count = 0;
+            while (($entry = readdir($handle)) !== false) {
+                if ($entry === '.' || $entry === '..') {
+                    continue;
+                }
+                ++$count;
+                if ($count > $limit) {
+                    return true;
+                }
+            }
+        } finally {
+            @closedir($handle); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort cleanup; must never warn/fatal under open_basedir
+        }
+
+        return false;
     }
 
     /**
@@ -1416,17 +1529,96 @@ class UpdateRunner
     }
 
     /**
+     * Force exactly one fresh update-check per component-type for the
+     * lifetime of this UpdateRunner instance — i.e. once per RUN, not once
+     * per item (GitHub issue #218, a regression from #208/#212).
+     *
+     * #208/#212 made pluginUpdateVersion()/themeUpdateVersion()/
+     * coreUpdateVersion() each force a fresh check (delete the relevant
+     * site transient, then re-run wp_update_plugins()/wp_update_themes()/
+     * wp_version_check([], true)) before reading the transient, so a
+     * stale/expired transient could never masquerade as "genuinely up to
+     * date". But UpdateCommand::execute() calls availableVersion() — and
+     * therefore this force-fresh-check block — ONCE PER ITEM in its foreach
+     * over a bulk `update` task. With N `latest` items of the same type in
+     * one run, that meant N full wp.org catalog round-trips in a single
+     * request, each one discarding the fresh transient the PRIOR item's
+     * call had just populated; a mid-batch network failure could leave a
+     * later item reading a freshly-emptied/incomplete transient and
+     * misreport a genuinely pending update as up_to_date.
+     *
+     * The fix: memoize by type. The flag for $type is set FIRST, before the
+     * force block runs (re-entrancy safe — nothing inside wp_update_plugins()
+     * et al. can trigger a second round-trip or recursion for the same
+     * type), so every subsequent item of the SAME type in the same run reads
+     * the transient this first call already populated — one shared fresh
+     * transient covers every per-slug lookup, matching the apply path's own
+     * single forced check per run (see applyViaUpgrader()/
+     * applyCoreUpgrade()).
+     *
+     * VERIFIED SAFE: the apply path never calls this method or
+     * availableVersion() — applyViaUpgrader()/applyCoreUpgrade() call
+     * wp_update_plugins()/wp_update_themes()/wp_version_check() directly —
+     * so this memo cannot affect it. RollbackCommand builds its own
+     * UpdateRunner and never calls availableVersion() either.
+     *
+     * core intentionally has no delete_site_transient() call, matching
+     * coreUpdateVersion()'s pre-existing (unchanged) behaviour — core has no
+     * separate transient-deletion step; wp_version_check()'s own `true`
+     * second argument is WordPress's "ignore the 12-hour throttle" flag and
+     * was always sufficient on its own.
+     *
+     * @param string $type plugin|theme|core.
+     * @return void
+     */
+    private function forceFreshCheckOncePerRun(string $type): void
+    {
+        if (isset($this->freshCheckedTypes[$type])) {
+            return;
+        }
+        $this->freshCheckedTypes[$type] = true;
+
+        switch ($type) {
+            case 'plugin':
+                if (function_exists('delete_site_transient')) {
+                    delete_site_transient('update_plugins');
+                }
+                if (function_exists('wp_update_plugins')) {
+                    wp_update_plugins();
+                }
+                break;
+
+            case 'theme':
+                if (function_exists('delete_site_transient')) {
+                    delete_site_transient('update_themes');
+                }
+                if (function_exists('wp_update_themes')) {
+                    wp_update_themes();
+                }
+                break;
+
+            case 'core':
+                if (function_exists('wp_version_check')) {
+                    wp_version_check([], true);
+                }
+                break;
+        }
+    }
+
+    /**
      * Pending update version for a plugin from the update transient.
      *
-     * Forces exactly ONE fresh check via wp_update_plugins() before reading
-     * the transient (GitHub issue #208) — the identical, unconditional call
-     * applyViaUpgrader() already makes before a real plugin apply (see
-     * below). This closes the gap where this READ-ONLY resolution path
-     * trusted whatever was already cached while the APPLY path would have
-     * refreshed it first: a stale/expired/never-yet-populated transient can
-     * no longer make a real pending update look like "up to date" here.
-     * Called at most once per availableVersion() resolution — never in a
-     * loop — matching the apply path's own single forced check per run.
+     * Forces a fresh check via forceFreshCheckOncePerRun('plugin') before
+     * reading the transient (GitHub issue #208) — the identical,
+     * unconditional call applyViaUpgrader() already makes before a real
+     * plugin apply (see below). This closes the gap where this READ-ONLY
+     * resolution path trusted whatever was already cached while the APPLY
+     * path would have refreshed it first: a stale/expired/never-yet-populated
+     * transient can no longer make a real pending update look like "up to
+     * date" here. That forced check now runs at most ONCE PER RUN per
+     * component-type (GitHub issue #218), not once per item — see
+     * forceFreshCheckOncePerRun()'s doc for the bulk-run regression this
+     * fixes and why that is still safe.
      *
      * GH #212 residual gap: wp_update_plugins() alone stays throttled by
      * WordPress core's own ~12h `update_plugins` transient window — off-cron
@@ -1448,12 +1640,7 @@ class UpdateRunner
      */
     private function pluginUpdateVersion(string $slug): ?string
     {
-        if (function_exists('delete_site_transient')) {
-            delete_site_transient('update_plugins');
-        }
-        if (function_exists('wp_update_plugins')) {
-            wp_update_plugins();
-        }
+        $this->forceFreshCheckOncePerRun('plugin');
 
         if (!function_exists('get_site_transient')) {
             return null;
@@ -1473,9 +1660,11 @@ class UpdateRunner
     /**
      * Pending update version for a theme from the update transient.
      *
-     * Forces exactly ONE fresh check via wp_update_themes() before reading
-     * the transient (GitHub issue #208) — same rationale and shape as
-     * pluginUpdateVersion(); see its doc.
+     * Forces a fresh check via forceFreshCheckOncePerRun('theme') before
+     * reading the transient (GitHub issue #208) — same rationale and shape
+     * as pluginUpdateVersion(); see its doc. That forced check now runs at
+     * most ONCE PER RUN per component-type (GitHub issue #218), not once
+     * per item — see forceFreshCheckOncePerRun()'s doc.
      *
      * GH #212 residual gap: see pluginUpdateVersion()'s doc — the same
      * off-cron core-throttle gap applies here, so the transient is deleted
@@ -1492,12 +1681,7 @@ class UpdateRunner
      */
     private function themeUpdateVersion(string $slug): ?string
     {
-        if (function_exists('delete_site_transient')) {
-            delete_site_transient('update_themes');
-        }
-        if (function_exists('wp_update_themes')) {
-            wp_update_themes();
-        }
+        $this->forceFreshCheckOncePerRun('theme');
 
         if (!function_exists('get_site_transient')) {
             return null;
@@ -1517,12 +1701,14 @@ class UpdateRunner
     /**
      * Latest offered core version from the update transient.
      *
-     * Forces exactly ONE fresh check via wp_version_check([], true) before
+     * Forces a fresh check via forceFreshCheckOncePerRun('core') before
      * reading the transient (GitHub issue #208) — the identical forced,
      * cache-bypassing call applyCoreUpgrade() already makes before a real
      * core apply (the `true` second argument is WordPress's own "ignore the
      * 12-hour throttle" flag). Same rationale as pluginUpdateVersion(); see
-     * its doc.
+     * its doc. That forced check now runs at most ONCE PER RUN per
+     * component-type (GitHub issue #218), not once per item — see
+     * forceFreshCheckOncePerRun()'s doc.
      *
      * @return string|null The pending core version, '' when a forced fresh
      *                check confirms none is available, or null when
@@ -1534,9 +1720,7 @@ class UpdateRunner
      */
     private function coreUpdateVersion(): ?string
     {
-        if (function_exists('wp_version_check')) {
-            wp_version_check([], true);
-        }
+        $this->forceFreshCheckOncePerRun('core');
 
         if (!function_exists('get_site_transient')) {
             return null;

--- a/apps/agent/patchwork.json
+++ b/apps/agent/patchwork.json
@@ -12,6 +12,10 @@
     "is_dir",
     "is_writable",
     "opcache_invalidate",
-    "file_put_contents"
+    "file_put_contents",
+    "opendir",
+    "readdir",
+    "closedir",
+    "time"
   ]
 }

--- a/apps/agent/tests/Security/HideBackendModuleTest.php
+++ b/apps/agent/tests/Security/HideBackendModuleTest.php
@@ -213,6 +213,78 @@ final class HideBackendModuleTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // GH #219: admin-ajax.php / admin-post.php are legitimate logged-out
+    // front-end endpoints that live under /wp-admin/ and must NEVER be gated by
+    // hide-backend (a Bricks form posting to admin-ajax.php to send email via
+    // WPMgr SMTP was getting a 404, breaking submission).
+    // -------------------------------------------------------------------------
+
+    public function test_issue219_admin_ajax_and_admin_post_are_not_login_or_admin_paths(): void
+    {
+        $policy = $this->makePolicy(true, 'my-secret-login');
+        $mod    = $this->module($policy);
+
+        $ref = new \ReflectionMethod($mod, 'isLoginOrAdminPath');
+        $ref->setAccessible(true);
+
+        // Root install.
+        $this->assertFalse(
+            $ref->invoke($mod, '/wp-admin/admin-ajax.php'),
+            'GH #219: admin-ajax.php must NOT be gated by hide-backend'
+        );
+        $this->assertFalse(
+            $ref->invoke($mod, '/wp-admin/admin-post.php'),
+            'GH #219: admin-post.php must NOT be gated by hide-backend'
+        );
+
+        // Subdirectory install (match on final segment at any depth).
+        $this->assertFalse(
+            $ref->invoke($mod, '/subdir/wp-admin/admin-ajax.php'),
+            'GH #219: admin-ajax.php under a subdirectory install must NOT be gated'
+        );
+        $this->assertFalse(
+            $ref->invoke($mod, '/subdir/wp-admin/admin-post.php'),
+            'GH #219: admin-post.php under a subdirectory install must NOT be gated'
+        );
+
+        // Regression guard: every OTHER /wp-admin/ page must STILL be gated.
+        $this->assertTrue(
+            $ref->invoke($mod, '/wp-admin/edit.php'),
+            'GH #219 regression guard: real admin pages must still be gated'
+        );
+        $this->assertTrue(
+            $ref->invoke($mod, '/wp-admin'),
+            'GH #219 regression guard: /wp-admin dashboard must still be gated'
+        );
+    }
+
+    /**
+     * End-to-end: a logged-out, un-tokened visitor hitting admin-ajax.php must
+     * pass straight through interceptRequest() with NO 404 and NO redirect.
+     * This is the exact failure mode reported in GH #219.
+     */
+    public function test_issue219_intercept_does_not_block_admin_ajax_for_logged_out_visitor(): void
+    {
+        // Reach the block decision tree instead of bailing on the CLI check.
+        Functions\when('php_sapi_name')->justReturn('fpm-fcgi');
+
+        $policy = $this->makePolicy(true, 'my-secret-login', '');
+        $mod    = $this->module($policy);
+
+        // Logged out (set_up default), no access cookie, front-end AJAX POST.
+        $_SERVER['REQUEST_URI'] = '/wp-admin/admin-ajax.php?action=bricks_form_submit';
+
+        // The block branch must never fire for admin-ajax.php.
+        Functions\expect('http_response_code')->never();
+        Functions\expect('header')->never();
+
+        // Must return normally — no exception, no exit.
+        $mod->interceptRequest();
+
+        $this->addToAssertionCount(1);
+    }
+
+    // -------------------------------------------------------------------------
     // hasAccessCookie()
     // -------------------------------------------------------------------------
 

--- a/apps/agent/tests/Security/TotpProviderTest.php
+++ b/apps/agent/tests/Security/TotpProviderTest.php
@@ -11,6 +11,13 @@
  *   - validate() rejects code of wrong length
  *   - isConfiguredFor() checks user-meta
  *   - base32 encode/decode round-trip (via public test vector)
+ *   - GH #215: sequential logins at different steps (T, then T+10) both
+ *     succeed -- the anti-replay burn never blocks a normal repeated login
+ *   - GH #215: an immediate replay of the SAME accepted step is rejected --
+ *     locks the security property so a future refactor can't silently drop
+ *     the burn while "fixing" the reported bug
+ *   - GH #215: activatePendingSecret() burns the activation timestep so the
+ *     setup-confirm code cannot be reused as the very first login
  *
  * The AgeIdentity is not tested for encrypt/decrypt here; we mock those paths
  * by pre-seeding the user-meta with a base64-encoded "plaintext" that the
@@ -198,6 +205,125 @@ final class TotpProviderTest extends TestCase
 
         $result = $this->provider()->validate($user, ['wpmgr_totp_code' => '12345']);
         $this->assertFalse($result, '5-digit code must be rejected (needs 6)');
+    }
+
+    // -------------------------------------------------------------------------
+    // GH #215: "works once then invalid code" was reported as an anti-replay
+    // bug, but the burn (`$counter <= $last`) is CORRECT single-use TOTP —
+    // these tests drive the REAL provider through a realistic sequential-login
+    // scenario (accept at step T, then accept again at a LATER independent
+    // step) to lock in that normal repeated logins are never blocked, while
+    // still proving a genuine replay of the same accepted step IS rejected.
+    // The existing test_validate_rejects_replayed_step() above only ever
+    // pre-seeded LAST_USED and validated once — it never drove validate()
+    // twice in sequence, which is why the false anti-replay-bug hypothesis
+    // was initially plausible.
+    // -------------------------------------------------------------------------
+
+    public function test_issue215_sequential_logins_at_different_steps_both_succeed(): void
+    {
+        $secret = 'JBSWY3DPEHPK3PXP';
+        $user   = $this->makeUser(5);
+        $this->userMeta[5][TotpProvider::META_SECRET] = base64_encode($secret);
+
+        // Fixed, controllable clock so we can precisely advance by whole
+        // TOTP steps between the two validate() calls.
+        $clock = 1_700_000_000;
+        Functions\when('time')->alias(function () use (&$clock) {
+            return $clock;
+        });
+
+        $provider = $this->provider();
+
+        // First login at step T.
+        $counterT = (int) ($clock / 30);
+        $codeT    = $this->generateExpectedCode($secret, $counterT);
+
+        $this->assertTrue(
+            $provider->validate($user, ['wpmgr_totp_code' => $codeT]),
+            'GH #215: first login at step T must be accepted'
+        );
+        $this->assertSame(
+            $counterT,
+            (int) $this->userMeta[5][TotpProvider::META_LAST_USED],
+            'GH #215: step T must be burned (recorded as LAST_USED) after acceptance'
+        );
+
+        // Advance the clock by 10 steps (300s) -- a later, independent login
+        // (e.g. the next day), not a replay of the same code.
+        $clock += 10 * 30;
+        $counterT10 = (int) ($clock / 30);
+        $this->assertSame($counterT + 10, $counterT10, 'sanity: clock advanced exactly 10 steps');
+        $codeT10 = $this->generateExpectedCode($secret, $counterT10);
+
+        $this->assertTrue(
+            $provider->validate($user, ['wpmgr_totp_code' => $codeT10]),
+            'GH #215: a fresh code at a later step (T+10) must be ACCEPTED -- proves sequential logins are never blocked by the anti-replay burn'
+        );
+    }
+
+    public function test_issue215_replay_of_same_accepted_step_is_rejected(): void
+    {
+        $secret = 'JBSWY3DPEHPK3PXP';
+        $user   = $this->makeUser(6);
+        $this->userMeta[6][TotpProvider::META_SECRET] = base64_encode($secret);
+
+        $baseTime = 1_700_000_000;
+        Functions\when('time')->justReturn($baseTime);
+
+        $provider = $this->provider();
+        $counter  = (int) ($baseTime / 30);
+        $code     = $this->generateExpectedCode($secret, $counter);
+
+        $this->assertTrue(
+            $provider->validate($user, ['wpmgr_totp_code' => $code]),
+            'first submission of the code must be accepted'
+        );
+
+        // Immediately resubmit the IDENTICAL code within the same wall-clock
+        // window -- e.g. a password manager or browser re-submitting the
+        // already-consumed value. This MUST stay rejected: the burn is the
+        // security property that prevents TOTP replay and must never be
+        // silently weakened (do not loosen `<= $last` to `<`/`==`, and do
+        // not drop the update_user_meta() burn, to "fix" GH #215).
+        $this->assertFalse(
+            $provider->validate($user, ['wpmgr_totp_code' => $code]),
+            'GH #215: a replay of the already-accepted code within the same window must be REJECTED'
+        );
+    }
+
+    /**
+     * GH #215 hardening: activatePendingSecret() now burns the activation
+     * timestep, so the same confirm code used to finish 2FA setup cannot be
+     * replayed as the very first login validate() call.
+     */
+    public function test_issue215_activation_code_cannot_be_reused_as_first_login(): void
+    {
+        $secret = 'JBSWY3DPEHPK3PXP';
+        $user   = $this->makeUser(7);
+        $this->userMeta[7][TotpProvider::META_PENDING_SECRET] = base64_encode($secret);
+
+        $baseTime = 1_700_000_000;
+        Functions\when('time')->justReturn($baseTime);
+
+        $provider = $this->provider();
+        $counter  = (int) ($baseTime / 30);
+        $code     = $this->generateExpectedCode($secret, $counter);
+
+        $this->assertTrue(
+            $provider->activatePendingSecret($user, $code),
+            'activation must succeed with a valid code for the pending secret'
+        );
+        $this->assertSame(
+            $counter,
+            (int) ($this->userMeta[7][TotpProvider::META_LAST_USED] ?? -1),
+            'GH #215: activatePendingSecret() must burn the activation step (record LAST_USED)'
+        );
+
+        $this->assertFalse(
+            $provider->validate($user, ['wpmgr_totp_code' => $code]),
+            'GH #215: the activation/confirm code must not be replayable as the first login validate() call'
+        );
     }
 
     // -------------------------------------------------------------------------

--- a/apps/agent/tests/UpdateRunnerAvailabilityTest.php
+++ b/apps/agent/tests/UpdateRunnerAvailabilityTest.php
@@ -23,6 +23,14 @@
  *   4. The forced check runs at most ONCE per availableVersion() call, never
  *      in a loop, and never at all for an explicit (non-'latest') version
  *      request.
+ *   5. GitHub issue #218 (a regression from #208/#212): resolving MULTIPLE
+ *      items of the same type in one run (mirroring UpdateCommand::
+ *      execute()'s per-item foreach over a bulk `update` task) forces the
+ *      fresh check at most ONCE PER RUN, not once per item — a single-call
+ *      ->once() assertion on one resolution (item 4 above) would not catch
+ *      a regression here; see test_plugin_forced_check_runs_once_per_run_
+ *      not_once_per_item_across_multiple_slugs() below, which resolves two
+ *      different slugs on the SAME runner instance.
  *
  * @package WPMgr\Agent\Tests
  */
@@ -219,6 +227,54 @@ final class UpdateRunnerAvailabilityTest extends TestCase
         $runner = new UpdateRunner();
 
         $this->assertSame('', $runner->availableVersion('plugin', 'akismet/akismet.php', 'latest'));
+    }
+
+    public function test_plugin_forced_check_runs_once_per_run_not_once_per_item_across_multiple_slugs(): void
+    {
+        // GH #218 regression test — MULTI-ITEM proof. UpdateCommand::execute()
+        // calls availableVersion() once PER ITEM in its foreach over a bulk
+        // 'latest' update task; before this fix each call unconditionally
+        // deleted the transient and re-forced a full wp.org round-trip,
+        // discarding the transient the PRIOR item's call had just populated.
+        // A single-call ->once() assertion on ONE resolution (as used by the
+        // sibling tests above) would NOT catch that: it only proves the
+        // check runs at most once for a single availableVersion() call. Here
+        // we resolve TWO different slugs on the SAME runner instance and
+        // still expect wp_update_plugins() to fire only ONCE for the whole
+        // run, with BOTH slugs correctly resolved from that one shared fresh
+        // transient.
+        $transient = false;
+        Functions\expect('wp_update_plugins')
+            ->once()
+            ->andReturnUsing(function () use (&$transient): void {
+                $entryA              = new \stdClass();
+                $entryA->new_version = '5.3.1';
+                $entryB              = new \stdClass();
+                $entryB->new_version = '2.0.1';
+
+                $populated           = new \stdClass();
+                $populated->response = [
+                    'akismet/akismet.php'   => $entryA,
+                    'hello-dolly/hello.php' => $entryB,
+                ];
+                $transient           = $populated;
+            });
+        Functions\when('get_site_transient')->alias(static function (string $key) use (&$transient) {
+            return $key === 'update_plugins' ? $transient : false;
+        });
+
+        $runner = new UpdateRunner();
+
+        $this->assertSame(
+            '5.3.1',
+            $runner->availableVersion('plugin', 'akismet/akismet.php', 'latest'),
+            'the first item in a bulk run must resolve its own pending version'
+        );
+        $this->assertSame(
+            '2.0.1',
+            $runner->availableVersion('plugin', 'hello-dolly/hello.php', 'latest'),
+            'a second item of the SAME type in the SAME run must resolve from the shared fresh transient the first call already populated, without re-forcing a second wp.org round-trip'
+        );
     }
 
     // =========================================================================

--- a/apps/agent/tests/UpdateRunnerTempDirTest.php
+++ b/apps/agent/tests/UpdateRunnerTempDirTest.php
@@ -29,7 +29,16 @@
  * based subdirectory instead), so the pin itself can never again collide with
  * WP_Upgrader's own use of that folder.
  *
- * All three tests below run in a SEPARATE PROCESS: WP_TEMP_DIR/WP_CONTENT_DIR
+ * ADDED (GitHub issue #216): "usable" was broadened to require not just
+ * writability but also that the default isn't pathologically populated. A
+ * reported host's get_temp_dir() resolved to its session save path with GC
+ * effectively disabled, holding 10,000+ stale `sess_*` files; heavy per-file
+ * unzip I/O against that directory failed intermittently ("Could not copy
+ * file."), even though it was genuinely writable. See
+ * test_temp_dir_pinned_when_default_writable_but_pathologically_populated()
+ * below and UpdateRunner::pinTempDirForUnpack()'s class doc.
+ *
+ * All four tests below run in a SEPARATE PROCESS: WP_TEMP_DIR/WP_CONTENT_DIR
  * are real PHP constants that, once defined, can never be undefined for the
  * rest of a PHPUnit process. Running in-process after any other test in this
  * file (or elsewhere in the suite) that already pinned WP_TEMP_DIR would make
@@ -166,6 +175,60 @@ final class UpdateRunnerTempDirTest extends TestCase
             . 'own unpack_package() cleanup is exactly what this fix exists to stop colliding with'
         );
         $this->assertStringContainsString('pinned to a dedicated fallback dir', $note);
+    }
+
+    /**
+     * THE REGRESSION LOCK — GitHub issue #216. WordPress's own default temp
+     * dir is genuinely WRITABLE (unlike the #131/open_basedir case above) —
+     * proving this test isn't merely re-exercising that case — but it is
+     * pathologically POPULATED: opendir()/readdir() report it holds more
+     * than UpdateRunner::MAX_HEALTHY_DEFAULT_TEMP_ENTRIES entries, mirroring
+     * a shared host's GC-disabled session-save-path default with 10,000+
+     * stale `sess_*` files. Run this test against the pre-#216 code and it
+     * fails: that code treated a writable default as unconditionally usable
+     * and never defined WP_TEMP_DIR at all, leaving heavy per-file unzip I/O
+     * to fail intermittently against the polluted directory.
+     *
+     * @runInSeparateProcess
+     */
+    public function test_temp_dir_pinned_when_default_writable_but_pathologically_populated(): void
+    {
+        Functions\when('get_temp_dir')->justReturn('/wpmgr-fake-polluted-default/');
+        Functions\when('is_dir')->justReturn(true);
+        Functions\when('file_put_contents')->justReturn(1);
+        Functions\when('wp_delete_file')->justReturn(null);
+        Functions\when('wp_mkdir_p')->justReturn(true);
+        Functions\when('wp_upload_dir')->justReturn([
+            'basedir' => '/wpmgr-fake-uploads',
+            'error'   => false,
+        ]);
+
+        // The default IS genuinely writable — the writability probe above
+        // (is_dir()/file_put_contents()) passes exactly as it would on a
+        // healthy host. opendir()/readdir() are mocked to simulate a
+        // directory holding far more than MAX_HEALTHY_DEFAULT_TEMP_ENTRIES
+        // non-dot entries: readdir() never returns false, so
+        // tempDirEntryCountExceeds()'s bounded loop counts past the limit
+        // and returns true (early-exit, matching its own doc).
+        Functions\when('opendir')->justReturn('fake-dir-handle');
+        Functions\when('readdir')->justReturn('sess_deadbeef');
+        Functions\when('closedir')->justReturn(true);
+
+        $runner = new UpdateRunner();
+        $note   = $this->pin($runner);
+
+        $this->assertTrue(
+            defined('WP_TEMP_DIR'),
+            'REGRESSION: a writable-but-pathologically-populated default must be routed into the conditional '
+            . 'fallback pin, not left unset merely because it passed the writability probe'
+        );
+        $this->assertSame(
+            '/wpmgr-fake-uploads/.wpmgr-tmp',
+            WP_TEMP_DIR,
+            'the pin must still land at the existing dedicated fallback location, never wp-content/upgrade'
+        );
+        $this->assertStringContainsString('pinned', $note);
+        $this->assertStringContainsString('entries', $note);
     }
 
     /**

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.57
+ * Version:           0.61.58
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.57');
+define('WPMGR_AGENT_VERSION', '0.61.58');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 

--- a/apps/api/db/query/backups.sql
+++ b/apps/api/db/query/backups.sql
@@ -370,10 +370,13 @@ SELECT
     (SELECT MAX(finished_at) FROM backup_snapshots x
      WHERE x.tenant_id = s.tenant_id AND x.site_id = s.id AND x.status = 'failed')
                     AS last_failed_at,
-    -- latest completed size
-    (SELECT total_size FROM backup_snapshots x
-     WHERE x.tenant_id = s.tenant_id AND x.site_id = s.id AND x.status = 'completed'
-     ORDER BY finished_at DESC, x.id DESC LIMIT 1)
+    -- latest completed size (COALESCE: a site with zero completed snapshots
+    -- must not NULL-scan into the non-nullable int64 LatestSizeBytes column)
+    COALESCE(
+        (SELECT total_size FROM backup_snapshots x
+         WHERE x.tenant_id = s.tenant_id AND x.site_id = s.id AND x.status = 'completed'
+         ORDER BY finished_at DESC, x.id DESC LIMIT 1),
+        0)
                     AS latest_size_bytes,
     -- in-flight count (pending or running)
     (SELECT COUNT(*) FROM backup_snapshots x

--- a/apps/api/internal/db/sqlc/backups.sql.go
+++ b/apps/api/internal/db/sqlc/backups.sql.go
@@ -375,10 +375,13 @@ SELECT
     (SELECT MAX(finished_at) FROM backup_snapshots x
      WHERE x.tenant_id = s.tenant_id AND x.site_id = s.id AND x.status = 'failed')
                     AS last_failed_at,
-    -- latest completed size
-    (SELECT total_size FROM backup_snapshots x
-     WHERE x.tenant_id = s.tenant_id AND x.site_id = s.id AND x.status = 'completed'
-     ORDER BY finished_at DESC, x.id DESC LIMIT 1)
+    -- latest completed size (COALESCE: a site with zero completed snapshots
+    -- must not NULL-scan into the non-nullable int64 LatestSizeBytes column)
+    COALESCE(
+        (SELECT total_size FROM backup_snapshots x
+         WHERE x.tenant_id = s.tenant_id AND x.site_id = s.id AND x.status = 'completed'
+         ORDER BY finished_at DESC, x.id DESC LIMIT 1),
+        0)
                     AS latest_size_bytes,
     -- in-flight count (pending or running)
     (SELECT COUNT(*) FROM backup_snapshots x
@@ -407,7 +410,7 @@ type FleetBackupHealthRow struct {
 	SiteUrl         string             `json:"site_url"`
 	LastCompletedAt interface{}        `json:"last_completed_at"`
 	LastFailedAt    interface{}        `json:"last_failed_at"`
-	LatestSizeBytes int64              `json:"latest_size_bytes"`
+	LatestSizeBytes interface{}        `json:"latest_size_bytes"`
 	InFlightCount   int64              `json:"in_flight_count"`
 	ScheduleCadence *string            `json:"schedule_cadence"`
 	NextRunAt       pgtype.Timestamptz `json:"next_run_at"`

--- a/apps/api/tests/backup_fleet_health_integration_test.go
+++ b/apps/api/tests/backup_fleet_health_integration_test.go
@@ -1,0 +1,115 @@
+package tests
+
+// backup_fleet_health_integration_test.go — DB-real integration coverage for
+// GH #214: GET /api/v1/backups/health returned 500 (fleet_backup_health_failed)
+// whenever ANY in-scope site had never had a completed backup snapshot.
+//
+// Root cause: FleetBackupHealth's latest_size_bytes scalar subquery over
+// backup_snapshots.total_size (bigint NOT NULL -> sqlc int64) returns SQL NULL
+// when a site has zero completed snapshots. pgx then fails at rows.Scan with
+// "cannot scan NULL into *int64", which repo.go wraps as
+// domain.Internal("fleet_backup_health_failed") -> 500 for the WHOLE fleet
+// response, not just the unbacked site's row. The fix wraps that subquery in
+// COALESCE(..., 0), mirroring the existing precedent in perf.sql.
+//
+// This test seeds one site with a completed snapshot (real size) and one site
+// with NO snapshots at all (and zero site_destinations rows, ruling out the
+// reporter's site_destinations red herring), then calls the real
+// backup.Service.FleetBackupHealth -> pgRepo.FleetBackupHealth -> the actual
+// SQL against a live Postgres. Before the fix this fails with a NULL-scan
+// error; after the fix it returns 200-equivalent (no error), one item per
+// site, with the unbacked site classified Unprotected and
+// LatestSizeBytes == 0.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/backup"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// seedCompletedSnapshot inserts a completed backup_snapshots row with an
+// explicit total_size and finished_at (both required for FleetBackupHealth's
+// last_completed_at / latest_size_bytes correlated subqueries to resolve
+// non-NULL for this site).
+func seedCompletedSnapshot(t *testing.T, pool *db.Pool, tenant, siteID uuid.UUID, totalSize int64, finishedAt time.Time) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	err := pool.InTenantTx(context.Background(), tenant, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), `
+			INSERT INTO backup_snapshots
+				(tenant_id, site_id, kind, status, age_recipient, total_size, started_at, finished_at)
+			VALUES ($1, $2, 'files', 'completed', $3, $4, $5, $5)
+			RETURNING id`,
+			tenant, siteID, testRecipient, totalSize, finishedAt,
+		).Scan(&id)
+	})
+	if err != nil {
+		t.Fatalf("seed completed snapshot: %v", err)
+	}
+	return id
+}
+
+// TestFleetBackupHealth_UnbackedSiteDoesNotFailWholeFleet is the regression
+// test for GH #214.
+func TestFleetBackupHealth_UnbackedSiteDoesNotFailWholeFleet(t *testing.T) {
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "fleet-health-214")
+
+	backedSite := seedSite(t, pool, tenant, "https://fleet-health-214-backed.example.com")
+	unbackedSite := seedSite(t, pool, tenant, "https://fleet-health-214-unbacked.example.com")
+
+	// A completed snapshot with a real size for the "backed" site.
+	seedCompletedSnapshot(t, pool, tenant, backedSite, 12345, time.Now().Add(-time.Hour))
+
+	// The "unbacked" site has ZERO snapshots and ZERO site_destinations rows
+	// (the reporter's red herring: FleetBackupHealth never references
+	// site_destinations at all, so this is deliberately left empty).
+
+	repo := backup.NewRepo(pool)
+	p := domain.Principal{TenantID: tenant, Scope: ""} // org-scoped, matches the fleet dashboard's real caller shape
+
+	items, err := repo.FleetBackupHealth(context.Background(), p, tenant, []uuid.UUID{backedSite, unbackedSite})
+	if err != nil {
+		t.Fatalf("FleetBackupHealth: unexpected error (this is the GH #214 500): %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("FleetBackupHealth: expected 2 items, got %d", len(items))
+	}
+
+	var backed, unbacked *backup.FleetBackupHealthItem
+	for i := range items {
+		switch items[i].SiteID {
+		case backedSite:
+			backed = &items[i]
+		case unbackedSite:
+			unbacked = &items[i]
+		}
+	}
+	if backed == nil || unbacked == nil {
+		t.Fatalf("FleetBackupHealth: missing expected site(s) in %+v", items)
+	}
+
+	if unbacked.LatestSizeBytes != 0 {
+		t.Fatalf("unbacked site LatestSizeBytes = %d, want 0", unbacked.LatestSizeBytes)
+	}
+	if unbacked.Status != backup.HealthStatusUnprotected {
+		t.Fatalf("unbacked site Status = %q, want %q", unbacked.Status, backup.HealthStatusUnprotected)
+	}
+	if unbacked.LastCompletedAt != nil {
+		t.Fatalf("unbacked site LastCompletedAt = %v, want nil", unbacked.LastCompletedAt)
+	}
+
+	if backed.LatestSizeBytes != 12345 {
+		t.Fatalf("backed site LatestSizeBytes = %d, want 12345", backed.LatestSizeBytes)
+	}
+	if backed.LastCompletedAt == nil {
+		t.Fatal("backed site LastCompletedAt = nil, want a timestamp")
+	}
+}

--- a/apps/web/src/features/updates/update-wizard.test.tsx
+++ b/apps/web/src/features/updates/update-wizard.test.tsx
@@ -124,3 +124,54 @@ describe("UpdateWizard — GH #211 same-version phantom guard", () => {
     expect(await screen.findByText("Mystery Plugin")).toBeInTheDocument();
   });
 });
+
+// GH #217 — when a tab has components but NONE of them have a pending
+// update, the tab-strip badge used to fall back to the unfiltered distinct
+// component count (rendered in a muted style), contradicting the "Showing 0
+// with available updates" copy and the empty filtered list right below it.
+// The badge must now show nothing at all in that case.
+describe("UpdateWizard — GH #217 zero-updates tab badge", () => {
+  it("shows no numeric badge on the Plugins tab when no plugin has a pending update", async () => {
+    const site = buildSite({
+      components: {
+        plugins: [
+          { slug: "akismet", name: "Akismet", version: "5.3" },
+          { slug: "jetpack", name: "Jetpack", version: "13.0" },
+        ],
+        themes: [],
+      },
+    });
+
+    renderWithProviders(
+      <UpdateWizard open target={TARGET} sites={[site]} onClose={() => {}} />,
+      { withRouter: true },
+    );
+
+    // Wait for first async paint, then assert the empty-filtered state.
+    expect(
+      await screen.findByText(
+        "No plugins with available updates on the selected sites.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Showing 0 with available updates"),
+    ).toBeInTheDocument();
+
+    // The tab badge must render no number at all — not "2" (the distinct
+    // component count), muted or otherwise.
+    const tab = screen.getByRole("tab", { name: /plugins/i });
+    expect(within(tab).queryByText("2")).not.toBeInTheDocument();
+    expect(within(tab).queryByText("0")).not.toBeInTheDocument();
+
+    // Toggling "Show all" reveals both components, each labeled up to date.
+    fireEvent.click(screen.getByRole("button", { name: /show all/i }));
+
+    const akismetRow = screen.getByText("Akismet").closest("li");
+    expect(akismetRow).not.toBeNull();
+    expect(within(akismetRow!).getByText("up to date")).toBeInTheDocument();
+
+    const jetpackRow = screen.getByText("Jetpack").closest("li");
+    expect(jetpackRow).not.toBeNull();
+    expect(within(jetpackRow!).getByText("up to date")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/updates/update-wizard.tsx
+++ b/apps/web/src/features/updates/update-wizard.tsx
@@ -317,10 +317,6 @@ function WizardForm({
               {(["plugins", "themes"] as const).map((tab) => {
                 const count =
                   tab === "plugins" ? pluginsWithUpdate : themesWithUpdate;
-                const total =
-                  tab === "plugins"
-                    ? pluginOptions.length
-                    : themeOptions.length;
                 return (
                   <button
                     key={tab}
@@ -338,10 +334,6 @@ function WizardForm({
                     {count > 0 ? (
                       <span className="ml-1.5 rounded-sm bg-primary/10 px-1 text-[10px] font-semibold tabular-nums text-primary">
                         {count}
-                      </span>
-                    ) : total > 0 ? (
-                      <span className="ml-1.5 rounded-sm bg-muted-foreground/10 px-1 text-[10px] tabular-nums text-muted-foreground">
-                        {total}
                       </span>
                     ) : null}
                   </button>


### PR DESCRIPTION
Six reported issues, investigated in parallel then built routed by directory (no two agents editing the same dir at once). No media-encoder change.

- **#218** (agent, my #208/#212 regression): forced fresh update-check ran once per *item* in a bulk run → N redundant wp.org round-trips + intermittent stale "up to date". Fix: once-per-run per-component-type memo; apply path untouched.
- **#216** (agent): updates failed intermittently ("Could not copy file") on hosts whose temp dir is a GC-off session dir with 10k+ files. Temp-dir gate now treats writable-but-polluted (>2000 entries) as unusable → dedicated `uploads/.wpmgr-tmp` pin (conditional last-resort, wp.org-defensible).
- **#214** (CP): `backups/health` 500'd the whole fleet when any site had no completed snapshot (NULL scanned into non-null int64). Fix: `COALESCE(...,0)` + pinned sqlc regen; no-backup site reports Unprotected/0.
- **#217** (web): wizard tab badges counted all components, not just ones with updates → now match the filtered list.
- **#219** (agent): hide-login 404'd logged-out `admin-ajax.php`/`admin-post.php` (broke front-end forms); now excluded while login/admin pages stay hidden.
- **#215** (agent, **not a code bug**): the TOTP verifier is correct single-use; "works once then invalid" is a re-submitted already-consumed code or clock drift. The comparison + burn are **unchanged** (loosening = replay). Applied only safe hedges: clearer error copy, `WINDOW` 1→2 (±60s), burn the activation step, + regression tests.

**Gates:** agent composer test 2672 + phpcs 0 + `wp plugin check` 0; CP go build/vet/test incl. testcontainers green; web 1010 tests + lint. Agent → 0.61.58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk update checks to prevent inconsistent availability results.
  * Prevented update failures caused by overloaded temporary directories.
  * Fixed backup health reporting for sites without completed backups.
  * Corrected Plugins and Themes update counts in the update wizard.
  * Restored logged-out front-end AJAX functionality when backend pages are hidden.
  * Improved two-factor authentication messaging, timing tolerance, and code reuse protection.
* **Release**
  * Updated the WPMgr Agent to version 0.61.58.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->