### PR TITLE
fix(backup): delete-guard uses real parent chain of custody, not generation (GH #221)

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -32,3 +32,6 @@ infra/postgres/data
 # IDE / tooling
 **/*.log
 **/.DS_Store
+
+# PHPUnit result cache (transient; can vanish mid-archive)
+**/.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.59] - 2026-07-14
+
+### Fixed
+
+- A failed, empty backup snapshot can now be deleted on its own without being forced to also delete a healthy, unrelated later snapshot (GH #221). The chain-safety guard (and the dashboard "Delete + N dependents" warning) previously decided whether a snapshot had dependents by generation number alone, so a failed attempt was wrongly treated as a dependency of any later-generation snapshot in the same chain, even when that later snapshot's actual parent was a different, successful sibling at the same generation. Both the control plane and the dashboard now check the real parent-snapshot chain of custody, so only a snapshot that something genuinely descends from is protected from deletion. Control plane and dashboard only; the agent has no functional change in this release.
+
 ## [0.61.58] - 2026-07-14
 
 ### Fixed

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.58
+ * Version:           0.61.59
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.58');
+define('WPMGR_AGENT_VERSION', '0.61.59');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 

--- a/apps/api/internal/backup/bulk_delete_test.go
+++ b/apps/api/internal/backup/bulk_delete_test.go
@@ -39,8 +39,8 @@ func TestBulkDelete_ChainOrphanRefusal(t *testing.T) {
 	tenantID, siteID := uuid.New(), uuid.New()
 	chainID := uuid.New()
 	base := Snapshot{ID: chainID, TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, ChainID: &chainID, Generation: 0}
-	mid := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, ChainID: &chainID, Generation: 1, IsIncremental: true}
-	tip := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, ChainID: &chainID, Generation: 2, IsIncremental: true}
+	mid := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, ChainID: &chainID, Generation: 1, IsIncremental: true, ParentSnapshotID: &base.ID}
+	tip := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, ChainID: &chainID, Generation: 2, IsIncremental: true, ParentSnapshotID: &mid.ID}
 	repo.addChainSnap(chainID, base)
 	repo.addChainSnap(chainID, mid)
 	repo.addChainSnap(chainID, tip)
@@ -78,8 +78,8 @@ func TestBulkDelete_DeleteOrderNewestFirst(t *testing.T) {
 	tenantID, siteID := uuid.New(), uuid.New()
 	chainID := uuid.New()
 	base := Snapshot{ID: chainID, TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, ChainID: &chainID, Generation: 0, TotalSize: 100}
-	gen1 := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, ChainID: &chainID, Generation: 1, IsIncremental: true, TotalSize: 10}
-	gen2 := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, ChainID: &chainID, Generation: 2, IsIncremental: true, TotalSize: 20}
+	gen1 := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, ChainID: &chainID, Generation: 1, IsIncremental: true, TotalSize: 10, ParentSnapshotID: &base.ID}
+	gen2 := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, ChainID: &chainID, Generation: 2, IsIncremental: true, TotalSize: 20, ParentSnapshotID: &gen1.ID}
 	repo.addChainSnap(chainID, base)
 	repo.addChainSnap(chainID, gen1)
 	repo.addChainSnap(chainID, gen2)

--- a/apps/api/internal/backup/delete_cancel_test.go
+++ b/apps/api/internal/backup/delete_cancel_test.go
@@ -235,7 +235,7 @@ func TestDeleteSnapshotForUser_BaseWithDependentsRefused(t *testing.T) {
 	tenantID, siteID := uuid.New(), uuid.New()
 	chainID := uuid.New()
 	base := Snapshot{ID: chainID, TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, Generation: 0}
-	inc := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, Generation: 1, IsIncremental: true}
+	inc := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, Generation: 1, IsIncremental: true, ParentSnapshotID: &base.ID}
 	repo.addChainSnap(chainID, base)
 	repo.addChainSnap(chainID, inc)
 
@@ -255,7 +255,7 @@ func TestDeleteSnapshotForUser_LeafIncrementDeletes(t *testing.T) {
 	tenantID, siteID := uuid.New(), uuid.New()
 	chainID := uuid.New()
 	base := Snapshot{ID: chainID, TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, Generation: 0}
-	leaf := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, Generation: 1, IsIncremental: true}
+	leaf := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, Generation: 1, IsIncremental: true, ParentSnapshotID: &base.ID}
 	repo.addChainSnap(chainID, base)
 	repo.addChainSnap(chainID, leaf)
 
@@ -266,6 +266,88 @@ func TestDeleteSnapshotForUser_LeafIncrementDeletes(t *testing.T) {
 	if !repo.deleted[leaf.ID] {
 		t.Fatalf("leaf increment should have been deleted")
 	}
+}
+
+// TestDeleteSnapshotForUser_SameGenerationSiblingNotADependent reproduces GH
+// #221's exact topology: a chain with TWO snapshots at generation 1 (a failed
+// 0-byte attempt F and its successful retry S), both children of the same
+// gen-0 parent A, plus a real gen-2 increment C whose parent is the
+// SUCCESSFUL sibling S (never F). Before the fix, the guard refused deleting F
+// solely because S/C sat at a higher generation in the same chain, even
+// though nothing actually depends on F. After the fix:
+//   - F (a same-generation sibling with no real dependents) is deletable.
+//   - S is refused: C's parent_snapshot_id points at S.
+//   - A is refused: both S and F have parent_snapshot_id pointing at A.
+//   - deleting S and C TOGETHER in one bulk request allows S, because C is
+//     already accounted for via deletedThisReq.
+func TestDeleteSnapshotForUser_SameGenerationSiblingNotADependent(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	chainID := uuid.New()
+	a := Snapshot{ID: chainID, TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, Generation: 0}
+	s := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, Generation: 1, IsIncremental: true, ParentSnapshotID: &a.ID}
+	f := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: siteID, Status: StatusFailed, Generation: 1, IsIncremental: true, ParentSnapshotID: &a.ID, TotalSize: 0}
+	c := Snapshot{ID: uuid.New(), TenantID: tenantID, SiteID: siteID, Status: StatusCompleted, Generation: 2, IsIncremental: true, ParentSnapshotID: &s.ID}
+
+	buildRepo := func() *deleteCancelFakeRepo {
+		repo := newDeleteCancelFakeRepo()
+		repo.addChainSnap(chainID, a)
+		repo.addChainSnap(chainID, s)
+		repo.addChainSnap(chainID, f)
+		repo.addChainSnap(chainID, c)
+		return repo
+	}
+
+	t.Run("failed_same_gen_sibling_with_no_dependents_is_allowed", func(t *testing.T) {
+		repo := buildRepo()
+		svc := buildDeleteCancelSvc(repo)
+		if err := svc.DeleteSnapshotForUser(context.Background(), tenantID, f.ID); err != nil {
+			t.Fatalf("DeleteSnapshotForUser(F): unexpected error: %v (this is the GH #221 bug)", err)
+		}
+		if !repo.deleted[f.ID] {
+			t.Fatalf("F should have been deleted: nothing has parent_snapshot_id == F")
+		}
+	})
+
+	t.Run("successful_sibling_with_a_real_child_is_refused", func(t *testing.T) {
+		repo := buildRepo()
+		svc := buildDeleteCancelSvc(repo)
+		err := svc.DeleteSnapshotForUser(context.Background(), tenantID, s.ID)
+		de, ok := domain.AsDomain(err)
+		if !ok || de.Kind != domain.KindValidation || de.Code != "chain_has_dependents" {
+			t.Fatalf("err = %v, want Validation chain_has_dependents (C's parent is S)", err)
+		}
+		if repo.deleted[s.ID] {
+			t.Fatalf("S must NOT be deleted while its real child C exists")
+		}
+	})
+
+	t.Run("base_with_two_gen1_children_is_refused", func(t *testing.T) {
+		repo := buildRepo()
+		svc := buildDeleteCancelSvc(repo)
+		err := svc.DeleteSnapshotForUser(context.Background(), tenantID, a.ID)
+		de, ok := domain.AsDomain(err)
+		if !ok || de.Kind != domain.KindValidation || de.Code != "chain_has_dependents" {
+			t.Fatalf("err = %v, want Validation chain_has_dependents (S and F both have parent A)", err)
+		}
+		if repo.deleted[a.ID] {
+			t.Fatalf("A must NOT be deleted while S/F still have parent_snapshot_id == A")
+		}
+	})
+
+	t.Run("deleting_s_and_c_together_allows_s", func(t *testing.T) {
+		repo := buildRepo()
+		svc := buildDeleteCancelSvc(repo)
+		out, err := svc.BulkDeleteSnapshots(context.Background(), tenantID, siteID, []uuid.UUID{s.ID, c.ID}, false)
+		if err != nil {
+			t.Fatalf("BulkDeleteSnapshots: unexpected error: %v", err)
+		}
+		if out.Deleted != 2 || out.Skipped != 0 {
+			t.Fatalf("counts = deleted:%d skipped:%d, want 2/0 (deletedThisReq must cover C when checking S)", out.Deleted, out.Skipped)
+		}
+		if !repo.deleted[s.ID] || !repo.deleted[c.ID] {
+			t.Fatalf("both S and C should have been deleted; deleted=%v", repo.deleted)
+		}
+	})
 }
 
 func TestDeleteSnapshotForUser_RunningRefused(t *testing.T) {

--- a/apps/api/internal/backup/service.go
+++ b/apps/api/internal/backup/service.go
@@ -2137,9 +2137,12 @@ func (s *Service) DeleteSnapshotForUser(ctx context.Context, tenantID, snapshotI
 //  3. restore_in_progress — an active (queued|running) restore_runs row reads
 //     this snapshot's WHOLE chain (see restoreGroupKey), so deleting any member
 //     while a restore runs would pull the rug out from under the agent mid-read.
-//  4. chain_has_dependents — refuses to orphan a later-generation increment.
-//     Re-checked against LIVE chain membership (repo.ListChainSnapshots) rather
-//     than a snapshot list cached before this call. deletedThisReq lets a caller
+//  4. chain_has_dependents — refuses to orphan a direct dependent increment
+//     (a sibling whose parent_snapshot_id points at this snapshot), not merely
+//     a sibling at a higher generation — a chain can hold multiple snapshots at
+//     the SAME generation (e.g. a failed attempt alongside its successful
+//     retry). Re-checked against LIVE chain membership (repo.ListChainSnapshots)
+//     rather than a snapshot list cached before this call. deletedThisReq lets a caller
 //     that is deleting an entire chain in ONE bulk request treat siblings it has
 //     ALREADY deleted earlier in the SAME request as gone, so a newest-first
 //     walk down a whole chain doesn't trip this guard on its own already-doomed
@@ -2168,16 +2171,23 @@ func (s *Service) evaluateDeleteGuards(ctx context.Context, tenantID uuid.UUID, 
 		return SkipRestoreInProgress, nil
 	}
 
-	// Chain-safety: never orphan a dependent increment. If this snapshot anchors
-	// or sits mid-chain (i.e. a sibling exists at a HIGHER generation in the same
-	// chain), refuse — the dependents would become unrestorable.
+	// Chain-safety: never orphan a dependent increment. Refuse only when a
+	// sibling's PARENT is actually this snapshot (true chain-of-custody), not
+	// merely because a sibling exists at a higher generation — a chain can have
+	// several snapshots AT THE SAME generation (e.g. a failed attempt plus a
+	// successful retry, both children of the same parent), and a later
+	// increment's real parent is the successful one, not the failed sibling.
+	// Safety is preserved transitively: deleting a mid-chain snapshot A is
+	// refused while its direct child B still exists (parent==A); B itself can't
+	// be deleted while ITS child C still exists (parent==B), and so on, so
+	// nothing downstream is ever orphaned.
 	if snap.ChainID != nil {
 		siblings, lerr := s.repo.ListChainSnapshots(ctx, tenantID, *snap.ChainID, maxChainEnumGeneration)
 		if lerr != nil {
 			return "", lerr
 		}
 		for _, sib := range siblings {
-			if sib.Generation > snap.Generation && !deletedThisReq[sib.ID] {
+			if sib.ParentSnapshotID != nil && *sib.ParentSnapshotID == snap.ID && !deletedThisReq[sib.ID] {
 				return SkipChainHasDependents, nil
 			}
 		}

--- a/apps/web/src/features/backups/backups-chain-selection.test.ts
+++ b/apps/web/src/features/backups/backups-chain-selection.test.ts
@@ -22,20 +22,66 @@ function snap(overrides: Partial<BackupSnapshot> & { id: string }): BackupSnapsh
   };
 }
 
-// A 3-member chain: gen 0 (base), gen 1, gen 2 (tip).
+// A 3-member linear chain: gen 0 (base), gen 1 (child of base), gen 2 (tip,
+// child of gen1) — parent_snapshot_id mirrors generation order here so the
+// pre-existing tri-state tests below still hold under the parent-id fix.
 const base = snap({ id: "base", chain_id: "chain-1", generation: 0 });
-const gen1 = snap({ id: "gen1", chain_id: "chain-1", generation: 1 });
-const gen2 = snap({ id: "gen2", chain_id: "chain-1", generation: 2 });
+const gen1 = snap({
+  id: "gen1",
+  chain_id: "chain-1",
+  generation: 1,
+  parent_snapshot_id: "base",
+});
+const gen2 = snap({
+  id: "gen2",
+  chain_id: "chain-1",
+  generation: 2,
+  parent_snapshot_id: "gen1",
+});
 const chain = [base, gen1, gen2];
 
 describe("chainDependents", () => {
-  it("returns every member with a strictly higher generation", () => {
-    expect(chainDependents(chain, base).map((m) => m.id)).toEqual([
-      "gen1",
-      "gen2",
-    ]);
+  it("returns every member whose parent_snapshot_id is this member's id", () => {
+    expect(chainDependents(chain, base).map((m) => m.id)).toEqual(["gen1"]);
     expect(chainDependents(chain, gen1).map((m) => m.id)).toEqual(["gen2"]);
     expect(chainDependents(chain, gen2)).toEqual([]);
+  });
+
+  it("GH #221: a failed same-generation sibling with no real children shows zero dependents", () => {
+    // A chain where a failed attempt and a successful retry share a parent
+    // and generation: A(gen0) -> S(gen1, parent A) + F(gen1, parent A,
+    // failed 0-byte) -> C(gen2, parent S). Only S produced a child; F has
+    // none, even though it shares S's generation.
+    const chainA = snap({ id: "A", chain_id: "chain-2", generation: 0 });
+    const chainS = snap({
+      id: "S",
+      chain_id: "chain-2",
+      generation: 1,
+      parent_snapshot_id: "A",
+      status: "completed",
+    });
+    const chainF = snap({
+      id: "F",
+      chain_id: "chain-2",
+      generation: 1,
+      parent_snapshot_id: "A",
+      status: "failed",
+      total_size: 0,
+    });
+    const chainC = snap({
+      id: "C",
+      chain_id: "chain-2",
+      generation: 2,
+      parent_snapshot_id: "S",
+    });
+    const members = [chainA, chainS, chainF, chainC];
+
+    expect(chainDependents(members, chainF)).toEqual([]);
+    expect(chainDependents(members, chainS).map((m) => m.id)).toEqual(["C"]);
+    expect(chainDependents(members, chainA).map((m) => m.id)).toEqual([
+      "S",
+      "F",
+    ]);
   });
 });
 
@@ -64,15 +110,19 @@ describe("memberCheckState", () => {
   });
 
   it("is indeterminate when selected but a dependent is not", () => {
+    // gen1's direct dependent is gen2 (parent_snapshot_id: "gen1"), not
+    // selected here — base is unaffected since its only direct dependent
+    // (gen1) IS selected.
     const selected = new Set(["base", "gen1"]); // gen2 not selected
-    expect(memberCheckState(selected, chain, base)).toBe("indeterminate");
+    expect(memberCheckState(selected, chain, gen1)).toBe("indeterminate");
+    expect(memberCheckState(selected, chain, base)).toBe("checked");
   });
 
   it("is indeterminate when a dependent is non-terminal and can never be selected", () => {
     const running = { ...gen2, status: "running" as const };
     const members = [base, gen1, running];
     const selected = new Set(["base", "gen1"]);
-    expect(memberCheckState(selected, members, base)).toBe("indeterminate");
+    expect(memberCheckState(selected, members, gen1)).toBe("indeterminate");
   });
 });
 

--- a/apps/web/src/features/backups/backups-chain-selection.ts
+++ b/apps/web/src/features/backups/backups-chain-selection.ts
@@ -4,22 +4,26 @@ import { isTerminal } from "./use-backups";
 
 // Chain-aware selection helpers for the bulk-delete surface (issue #115).
 //
-// Dependents are locally derivable straight off the list DTO: any member of
-// the same chain_id with a strictly higher `generation` depends on this one
-// (the server refuses to delete a snapshot that still has a later increment —
-// "chain_has_dependents"). These are pure functions so the checkbox
-// tri-state logic and the auto-expand-on-check behaviour are unit-testable
-// without mounting <BackupsSection>.
+// Dependents are locally derivable straight off the list DTO: any member
+// whose `parent_snapshot_id` points at this one is a direct dependent (the
+// server refuses to delete a snapshot that still has a later increment —
+// "chain_has_dependents"). This MUST follow the actual `parent_snapshot_id`
+// chain of custody rather than `generation` — a chain can have multiple
+// members at the same generation (a failed attempt plus a successful retry,
+// both children of the same parent), and a later member's real parent is
+// whichever sibling actually produced it, not every same-or-lower-generation
+// member (GH #221). These are pure functions so the checkbox tri-state logic
+// and the auto-expand-on-check behaviour are unit-testable without mounting
+// <BackupsSection>.
 
 export type CheckState = "checked" | "indeterminate" | "unchecked";
 
-/** All members of `members` with a strictly higher generation than `member`. */
+/** All members of `members` whose `parent_snapshot_id` is `member.id`. */
 export function chainDependents(
   members: readonly BackupSnapshot[],
   member: BackupSnapshot,
 ): BackupSnapshot[] {
-  const gen = member.generation ?? 0;
-  return members.filter((m) => (m.generation ?? 0) > gen);
+  return members.filter((m) => m.parent_snapshot_id === member.id);
 }
 
 /** Terminal-only dependents — the subset eligible to be auto-selected. */

--- a/apps/web/src/features/backups/backups-section.test.tsx
+++ b/apps/web/src/features/backups/backups-section.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen } from "@testing-library/react";
+import { fireEvent, screen, within } from "@testing-library/react";
 import type { Me } from "@wpmgr/api";
 
 import { renderWithProviders } from "@/test/render";
@@ -114,5 +114,85 @@ describe("BackupsSection — snapshot row navigation (GH #188)", () => {
     const tipLink = await screen.findByRole("link", { name: "View" });
     expect(tipLink).toHaveAttribute("href", "/sites/site-42/backups/snap-incr");
     expect(tipLink.getAttribute("href")).not.toMatch(/^\/backups\//);
+  });
+});
+
+describe("BackupsSection — chain-of-custody dependents (GH #221)", () => {
+  it("shows a failed same-generation sibling with no real children as plain Delete, not '+1 dependents'", async () => {
+    // A(gen0) -> S(gen1, parent A, completed) + F(gen1, parent A, failed
+    // 0-byte) -> C(gen2, parent S). F shares S's generation but produced no
+    // children of its own, so it must show plain "Delete". S is the real
+    // parent of C and must show "Delete + 1 dependents".
+    const chainA = buildSnapshot({
+      id: "snap-a",
+      site_id: "site-42",
+      chain_id: "chain-221",
+      generation: 0,
+      is_incremental: false,
+    });
+    const chainS = buildSnapshot({
+      id: "snap-s",
+      site_id: "site-42",
+      chain_id: "chain-221",
+      generation: 1,
+      is_incremental: true,
+      parent_snapshot_id: "snap-a",
+      status: "completed",
+    });
+    const chainF = buildSnapshot({
+      id: "snap-f",
+      site_id: "site-42",
+      chain_id: "chain-221",
+      generation: 1,
+      is_incremental: true,
+      parent_snapshot_id: "snap-a",
+      status: "failed",
+      total_size: 0,
+    });
+    const chainC = buildSnapshot({
+      id: "snap-c",
+      site_id: "site-42",
+      chain_id: "chain-221",
+      generation: 2,
+      is_incremental: true,
+      parent_snapshot_id: "snap-s",
+    });
+    mockedUseBackups.mockReturnValue(
+      mockQueryResult({ data: [chainA, chainS, chainF, chainC] }),
+    );
+
+    renderWithProviders(<BackupsSection siteId="site-42" canOperate={true} />, {
+      withRouter: true,
+      initialPath: "/sites/site-42/backups",
+    });
+
+    const expandButton = await screen.findByRole("button", {
+      name: "Expand chain members",
+    });
+    fireEvent.click(expandButton);
+
+    const memberRows = screen.getAllByTestId("backup-chain-member");
+    function rowForSnapshot(id: string) {
+      const row = memberRows.find((r) =>
+        within(r)
+          .getByRole("link", { name: "View" })
+          .getAttribute("href")
+          ?.endsWith(`/${id}`),
+      );
+      if (!row) throw new Error(`no member row found for snapshot ${id}`);
+      return row;
+    }
+
+    // F (the failed, 0-byte snapshot) has zero real dependents.
+    expect(
+      within(rowForSnapshot("snap-f")).getByRole("button", { name: "Delete" }),
+    ).toBeInTheDocument();
+
+    // S is the real parent of C and correctly still shows its dependent.
+    expect(
+      within(rowForSnapshot("snap-s")).getByRole("button", {
+        name: "Delete + 1 dependents",
+      }),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
A failed, zero-byte snapshot couldn't be deleted on its own — the chain-safety guard refused it as \`chain_has_dependents\` purely because a higher-generation sibling existed, even when nothing descended from it. A chain can hold multiple snapshots at the same generation (a failed attempt + a successful retry, both children of the same parent); a later increment's real parent is the successful sibling, so the failed one has zero dependents but was wrongly protected.

Fix (both layers): check the real \`parent_snapshot_id\` chain of custody, not generation.
- **CP** (`service.go` `evaluateDeleteGuards`): refuse only when a sibling's `ParentSnapshotID == snap.ID` (and it's not being deleted in the same request). Confirmed `ListChainSnapshots` already SELECTs/maps `parent_snapshot_id` (no SQL/sqlc change). Transitive safety preserved (a mid-chain snapshot still refuses because its direct child remains; newest-first bulk-delete order + `deletedThisReq` unchanged).
- **Web** (`chainDependents`): a dependent is a member whose `parent_snapshot_id === member.id`, so the "Delete + N dependents" label matches reality.

api + web only; agent unchanged (version synced). Tests: CP adds the exact reported topology + updates the existing orphan-refusal tests to populate `ParentSnapshotID`; web mirrors it. `go test ./internal/backup ./tests` (incl. testcontainers) green; web 1012 + lint. Also carries a `.gcloudignore` build-race fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot deletion safeguards by checking actual parent-child relationships.
  * Failed snapshots without dependents can now be deleted independently, including same-generation siblings.
  * Updated backup selection and dependency indicators to accurately reflect snapshot relationships.
  * Bulk deletion now correctly handles snapshots deleted together in the same request.

* **Chores**
  * Updated the release version to 0.61.59.
  * Added PHPUnit cache files to ignore rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->