### PR TITLE
fix(crypto): stable secrets-at-rest key derived from session secret (SMTP-password-daily-reentry / likely #215)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,12 +64,16 @@ WPMGR_DB_MIGRATION_DSN=
 # Format: host:port. e.g. redis:6379
 WPMGR_REDIS_ADDR=localhost:6379
 
-# Secrets-at-rest key (age X25519). Encrypts stored SMTP passwords + per-site
-# destination secrets. EMPTY => a fresh EPHEMERAL identity each boot (dev only):
-# every restart orphans previously stored secrets. In production an empty value
-# HARD-FAILS boot. Format: age secret key, the literal "AGE-SECRET-KEY-1..."
-# (UPPERCASE; mixed case is rejected).
+# Secrets-at-rest key (age X25519). Encrypts stored SMTP passwords, per-site
+# email + destination secrets, object-cache creds, and 2FA secrets. OPTIONAL:
+# EMPTY => a STABLE key is derived from WPMGR_SESSION_SECRET, so a self-host just
+# works and secrets survive restarts (no ephemeral key). Set an explicit value
+# only if you want an isolated, independently rotatable secrets-at-rest key
+# (recommended for larger production deployments). Format: age secret key, the
+# literal "AGE-SECRET-KEY-1..." (UPPERCASE; mixed case is rejected).
 # run: docker compose run --rm api wpmgr-cli gen-secrets   (or: age-keygen)
+# NOTE: switching between derived and explicit (or changing either) re-keys the
+# store, so re-enter your SMTP password / secrets once after the change.
 WPMGR_SITE_DEST_AGE_SECRET=
 
 # Control-plane Ed25519 agent-signing keypair. Signs CP->agent commands; the public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.60] - 2026-07-14
+
+### Fixed
+
+- Stored secrets (SMTP password, per-site email and destination credentials, object-cache credentials, and two-factor secrets) now survive a restart on a self-hosted install that has not set an explicit secrets-at-rest key. Previously, if `WPMGR_SITE_DEST_AGE_SECRET` was empty, the control plane generated a fresh random encryption key on every boot, so every container restart or reboot orphaned everything encrypted at rest. The most visible symptom was having to re-enter the SMTP password almost daily (and notifications silently stopping until you did); it could also make two-factor sign-in fail after a restart. The key is now derived, stably, from the already-required `WPMGR_SESSION_SECRET` when no explicit key is set, so a self-host works without extra configuration and nothing is lost on restart. The encryption key is still never stored in the database.
+
+  Upgrade note: an install that was running without an explicit `WPMGR_SITE_DEST_AGE_SECRET` (so it was on the old per-boot key) will switch to the new stable derived key on this upgrade. Any secret that was encrypted under the old key needs to be re-entered once (re-save the SMTP password, and re-enroll two-factor from a recovery code if it was set up); after that it persists permanently. Installs that already set an explicit key are unaffected. Control plane only; no agent change.
+
 ## [0.61.59] - 2026-07-14
 
 ### Fixed

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.59
+ * Version:           0.61.60
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.59');
+define('WPMGR_AGENT_VERSION', '0.61.60');
 define('WPMGR_AGENT_FILE', __FILE__);
 define('WPMGR_AGENT_DIR', plugin_dir_path(__FILE__));
 

--- a/apps/api/cmd/wpmgr/age_identity_test.go
+++ b/apps/api/cmd/wpmgr/age_identity_test.go
@@ -1,0 +1,122 @@
+package main
+
+// age_identity_test.go — regression lock for the self-host secret-at-rest
+// stability fix: resolveAgeIdentity must never return an ephemeral key, must
+// let an explicit WPMGR_SITE_DEST_AGE_SECRET take precedence, and must fail
+// fast (not silently fall back) if that explicit key is unparseable.
+
+import (
+	"strings"
+	"testing"
+
+	"filippo.io/age"
+)
+
+// validSessionSecret mirrors the shape a real, config.ValidateSessionSecret-
+// approved WPMGR_SESSION_SECRET would have (>=32 bytes, not a placeholder).
+const validSessionSecret = "correct-horse-battery-staple-32-bytes-min"
+
+// TestResolveAgeIdentity_DerivesFromSessionSecretWhenEnvEmpty is the core
+// self-host regression lock: with no explicit WPMGR_SITE_DEST_AGE_SECRET,
+// the identity must be the DETERMINISTIC derivation, not
+// cryptbox.NewAgeIdentity("")'s fresh-random-key-every-call. Two resolutions
+// from the same session secret (simulating two restarts of the same
+// self-host install) must produce the identical identity.
+func TestResolveAgeIdentity_DerivesFromSessionSecretWhenEnvEmpty(t *testing.T) {
+	first, source, err := resolveAgeIdentity("", validSessionSecret)
+	if err != nil {
+		t.Fatalf("resolveAgeIdentity: %v", err)
+	}
+	if source != "derived from WPMGR_SESSION_SECRET" {
+		t.Fatalf("source = %q, want derivation path", source)
+	}
+
+	second, _, err := resolveAgeIdentity("", validSessionSecret)
+	if err != nil {
+		t.Fatalf("resolveAgeIdentity (second call): %v", err)
+	}
+
+	if first.RecipientString() != second.RecipientString() {
+		t.Fatalf("two resolutions from the same session secret produced different identities: %q vs %q", first.RecipientString(), second.RecipientString())
+	}
+
+	// And it must actually be usable across the simulated restart: the
+	// second resolution must decrypt what the first encrypted.
+	ciphertext, err := first.Encrypt([]byte("SMTP password"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	plaintext, err := second.Decrypt(ciphertext)
+	if err != nil {
+		t.Fatalf("post-restart identity failed to decrypt pre-restart ciphertext: %v", err)
+	}
+	if string(plaintext) != "SMTP password" {
+		t.Fatalf("decrypted = %q, want %q", plaintext, "SMTP password")
+	}
+}
+
+// TestResolveAgeIdentity_ExplicitEnvKeyTakesPrecedence asserts that when
+// WPMGR_SITE_DEST_AGE_SECRET is set, it is used verbatim rather than the
+// session-secret derivation, so existing installs that already rely on the
+// explicit key are unaffected by this change.
+func TestResolveAgeIdentity_ExplicitEnvKeyTakesPrecedence(t *testing.T) {
+	fixture, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate fixture age identity: %v", err)
+	}
+	explicitKeyString := fixture.String()
+	explicitRecipient := fixture.Recipient().String()
+
+	got, source, err := resolveAgeIdentity(explicitKeyString, validSessionSecret)
+	if err != nil {
+		t.Fatalf("resolveAgeIdentity: %v", err)
+	}
+	if source != "explicit WPMGR_SITE_DEST_AGE_SECRET" {
+		t.Fatalf("source = %q, want explicit path", source)
+	}
+	if got.RecipientString() != explicitRecipient {
+		t.Fatalf("recipient = %q, want %q (the explicit key's own recipient)", got.RecipientString(), explicitRecipient)
+	}
+
+	// It must differ from what the derivation path would have produced —
+	// proving the explicit key, not the session secret, was actually used.
+	derived, _, err := resolveAgeIdentity("", validSessionSecret)
+	if err != nil {
+		t.Fatalf("resolveAgeIdentity (derivation path): %v", err)
+	}
+	if got.RecipientString() == derived.RecipientString() {
+		t.Fatal("explicit-key path produced the same identity as the derivation path")
+	}
+}
+
+// TestResolveAgeIdentity_UnparseableExplicitKeyFailsFast asserts a malformed
+// explicit WPMGR_SITE_DEST_AGE_SECRET is a hard error — it must NOT silently
+// fall back to the session-secret derivation, which would surprise an
+// operator who set the env var expecting it to be honored.
+func TestResolveAgeIdentity_UnparseableExplicitKeyFailsFast(t *testing.T) {
+	_, _, err := resolveAgeIdentity("not-a-valid-age-secret-key", validSessionSecret)
+	if err == nil {
+		t.Fatal("expected an error for an unparseable explicit age secret key, got nil")
+	}
+	if !strings.Contains(err.Error(), "WPMGR_SITE_DEST_AGE_SECRET") {
+		t.Fatalf("error %q does not identify WPMGR_SITE_DEST_AGE_SECRET as the source of the problem", err.Error())
+	}
+}
+
+// TestResolveAgeIdentity_DifferentSessionSecretsDeriveDifferentIdentities
+// guards against a degenerate derivation that ignores its seed: two
+// different session secrets (e.g. two distinct self-host installs) must
+// resolve to two different, non-interoperable identities.
+func TestResolveAgeIdentity_DifferentSessionSecretsDeriveDifferentIdentities(t *testing.T) {
+	a, _, err := resolveAgeIdentity("", "install-A-session-secret-value-32b")
+	if err != nil {
+		t.Fatalf("resolveAgeIdentity (A): %v", err)
+	}
+	b, _, err := resolveAgeIdentity("", "install-B-session-secret-value-32b")
+	if err != nil {
+		t.Fatalf("resolveAgeIdentity (B): %v", err)
+	}
+	if a.RecipientString() == b.RecipientString() {
+		t.Fatal("two different session secrets derived the same identity")
+	}
+}

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/blobstore"
 	clientpkg "github.com/mosamlife/wpmgr/apps/api/internal/client"
 	"github.com/mosamlife/wpmgr/apps/api/internal/config"
+	"github.com/mosamlife/wpmgr/apps/api/internal/cryptbox"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
 	"github.com/mosamlife/wpmgr/apps/api/internal/dbclean"
@@ -126,6 +127,53 @@ func main() {
 		slog.Error("fatal", slog.Any("error", err))
 		os.Exit(1)
 	}
+}
+
+// ageIdentityDeriveInfo is the fixed HKDF info label used to derive the
+// shared secret-at-rest age identity from the session secret. It exists
+// purely for domain separation (see cryptbox.DeriveAgeIdentity) and must
+// never change once any install has booted with it — changing it would be
+// equivalent to rotating to a brand-new random key and orphan every stored
+// secret, exactly like the bug this derivation fixes.
+const ageIdentityDeriveInfo = "wpmgr-age-identity-v1"
+
+// resolveAgeIdentity picks the control plane's ONE shared secret-at-rest age
+// identity (used for SMTP passwords, per-site email creds, object-cache
+// creds, S3 backup-destination secrets, and TOTP 2FA secrets).
+//
+// Precedence:
+//  1. An explicit, non-empty envKey (WPMGR_SITE_DEST_AGE_SECRET) always wins.
+//     If it is set but fails to parse, this is a hard, fail-fast error in
+//     EVERY mode (dev, self-host, production) — a bad explicit key must
+//     never be silently swallowed in favor of a different, surprising key.
+//  2. Otherwise the identity is deterministically derived from sessionSecret
+//     (the control plane's already-validated, restart-stable
+//     WPMGR_SESSION_SECRET) via cryptbox.DeriveAgeIdentity. This is what
+//     makes a default self-host — which sets no explicit age secret and may
+//     not even set WPMGR_ENV=production — get a STABLE key across restarts
+//     instead of cryptbox.NewAgeIdentity("")'s fresh-random-key-every-boot,
+//     which previously orphaned every stored secret on every restart/reboot.
+//
+// sessionSecret must already be validated (config.ValidateSessionSecret) by
+// the caller so this function never has to re-derive that decision; it is
+// intentionally the exact same value the session store itself uses, so the
+// two can never diverge.
+//
+// It returns the identity plus a short, key-material-free description of
+// which path was taken, suitable for an INFO log line.
+func resolveAgeIdentity(envKey, sessionSecret string) (*cryptbox.AgeIdentity, string, error) {
+	if strings.TrimSpace(envKey) != "" {
+		id, err := cryptbox.NewAgeIdentity(envKey)
+		if err != nil {
+			return nil, "", fmt.Errorf("WPMGR_SITE_DEST_AGE_SECRET is set but invalid: %w", err)
+		}
+		return id, "explicit WPMGR_SITE_DEST_AGE_SECRET", nil
+	}
+	id, err := cryptbox.DeriveAgeIdentity([]byte(sessionSecret), ageIdentityDeriveInfo)
+	if err != nil {
+		return nil, "", fmt.Errorf("derive age identity from session secret: %w", err)
+	}
+	return id, "derived from WPMGR_SESSION_SECRET", nil
 }
 
 // run bootstraps the control plane: migrations, services, River worker pool,
@@ -822,17 +870,20 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// configuration ahead of enabling backups. The registry is bound to the
 	// backup service via SetRegistry below.
 	siteDestRepo := sitedestination.NewRepo(pool)
-	// ADR-045: refuse to boot in production without a stable age secret. An empty
-	// secret yields a fresh ephemeral key on every restart, which would orphan
-	// every stored SMTP password and site-destination secret (mirrors the
-	// session-secret guard).
-	if cfg.IsProduction() && strings.TrimSpace(os.Getenv("WPMGR_SITE_DEST_AGE_SECRET")) == "" {
-		return fmt.Errorf("WPMGR_SITE_DEST_AGE_SECRET is required in production: an empty secret uses an ephemeral key that orphans stored SMTP passwords and site-destination secrets on restart")
-	}
-	siteDestAgeID, err := sitedestination.NewAgeIdentity(os.Getenv("WPMGR_SITE_DEST_AGE_SECRET"))
+	// ADR-045 (and its self-host follow-up fix): resolve the shared
+	// secret-at-rest age identity used for SMTP passwords, per-site email
+	// creds, object-cache creds, S3 backup-destination secrets, and TOTP 2FA
+	// secrets. An explicit WPMGR_SITE_DEST_AGE_SECRET always wins; otherwise
+	// the identity is deterministically derived from the session secret
+	// (already validated non-empty and >=32 bytes above), which is stable
+	// across restarts in every mode — never an ephemeral random key, which
+	// would silently orphan every stored secret on the next restart/reboot.
+	// See resolveAgeIdentity for the full precedence and failure behavior.
+	siteDestAgeID, ageIdentitySource, err := resolveAgeIdentity(os.Getenv("WPMGR_SITE_DEST_AGE_SECRET"), cfg.Auth.SessionSecret)
 	if err != nil {
 		return fmt.Errorf("site destination age identity: %w", err)
 	}
+	logger.Info("secret-at-rest age identity resolved", slog.String("source", ageIdentitySource))
 	siteDestSvc := sitedestination.NewService(siteDestRepo, siteDestAgeID, logger)
 	siteDestH := sitedestination.NewHandler(siteDestSvc, auditRec)
 

--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/pquerna/otp v1.5.0
 	github.com/stripe/stripe-go/v86 v86.1.0
 	github.com/tdewolff/font v0.0.0-20260527091451-1663e68cb8a4
+	golang.org/x/crypto v0.52.0
 	golang.org/x/image v0.41.0
 )
 
@@ -216,7 +217,6 @@ require (
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.25.0 // indirect
-	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/apps/api/internal/cryptbox/bech32.go
+++ b/apps/api/internal/cryptbox/bech32.go
@@ -1,0 +1,142 @@
+package cryptbox
+
+import (
+	"fmt"
+	"strings"
+)
+
+// This file implements just enough of the Bech32 encoding (BIP-173) to build
+// age's on-disk X25519 secret-key string — "AGE-SECRET-KEY-1" followed by a
+// Bech32-encoded 32-byte scalar and a 6-character checksum, all upper-cased.
+// That is the exact format age.ParseX25519Identity accepts (and the format
+// age-keygen emits): filippo.io/age itself vendors this same reference
+// algorithm as an unexported internal package, so it cannot be imported from
+// here — this is an independent, from-spec reimplementation of the encode
+// half only. Its correctness is proven by round-tripping every value it
+// produces through age.ParseX25519Identity in cryptbox_test.go; a checksum
+// bug would fail every one of those tests, not just this package's own.
+
+const bech32Charset = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+
+var bech32Generator = [5]uint32{0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3}
+
+func bech32Polymod(values []byte) uint32 {
+	chk := uint32(1)
+	for _, v := range values {
+		top := chk >> 25
+		chk = (chk&0x1ffffff)<<5 ^ uint32(v)
+		for i := 0; i < 5; i++ {
+			if (top>>uint(i))&1 == 1 {
+				chk ^= bech32Generator[i]
+			}
+		}
+	}
+	return chk
+}
+
+func bech32HRPExpand(hrp string) []byte {
+	lower := strings.ToLower(hrp)
+	ret := make([]byte, 0, len(lower)*2+1)
+	for i := 0; i < len(lower); i++ {
+		ret = append(ret, lower[i]>>5)
+	}
+	ret = append(ret, 0)
+	for i := 0; i < len(lower); i++ {
+		ret = append(ret, lower[i]&31)
+	}
+	return ret
+}
+
+func bech32CreateChecksum(hrp string, data []byte) []byte {
+	values := append(bech32HRPExpand(hrp), data...)
+	values = append(values, 0, 0, 0, 0, 0, 0)
+	mod := bech32Polymod(values) ^ 1
+	ret := make([]byte, 6)
+	for p := 0; p < 6; p++ {
+		shift := uint(5 * (5 - p))
+		ret[p] = byte(mod>>shift) & 31
+	}
+	return ret
+}
+
+// bech32ConvertBits regroups a byte slice from an 8-bit-per-element base into
+// a 5-bit-per-element base (or the reverse), as required to map arbitrary
+// 8-bit secret-key bytes onto Bech32's 5-bit charset.
+func bech32ConvertBits(data []byte, fromBits, toBits uint, pad bool) ([]byte, error) {
+	var ret []byte
+	acc := uint32(0)
+	bits := uint(0)
+	maxv := uint32(1<<toBits - 1)
+	for idx, value := range data {
+		if uint32(value)>>fromBits != 0 {
+			return nil, fmt.Errorf("bech32: invalid data range: data[%d]=%d", idx, value)
+		}
+		acc = acc<<fromBits | uint32(value)
+		bits += fromBits
+		for bits >= toBits {
+			bits -= toBits
+			ret = append(ret, byte(acc>>bits)&byte(maxv))
+		}
+	}
+	if pad {
+		if bits > 0 {
+			ret = append(ret, byte(acc<<(toBits-bits))&byte(maxv))
+		}
+	} else if bits >= fromBits {
+		return nil, fmt.Errorf("bech32: illegal zero padding")
+	} else if byte(acc<<(toBits-bits))&byte(maxv) != 0 {
+		return nil, fmt.Errorf("bech32: non-zero padding")
+	}
+	return ret, nil
+}
+
+// bech32Encode encodes hrp+data as a Bech32 string. If hrp is not entirely
+// lowercase, the output is upper-cased in full (matching age's own encoder,
+// which is what makes the "AGE-SECRET-KEY-" human-readable part come out
+// upper-case to match age-keygen's convention).
+func bech32Encode(hrp string, data []byte) (string, error) {
+	if len(hrp) < 1 {
+		return "", fmt.Errorf("bech32: invalid hrp: %q", hrp)
+	}
+	for p, c := range hrp {
+		if c < 33 || c > 126 {
+			return "", fmt.Errorf("bech32: invalid hrp character: hrp[%d]=%d", p, c)
+		}
+	}
+	if strings.ToUpper(hrp) != hrp && strings.ToLower(hrp) != hrp {
+		return "", fmt.Errorf("bech32: mixed case hrp: %q", hrp)
+	}
+	values, err := bech32ConvertBits(data, 8, 5, true)
+	if err != nil {
+		return "", err
+	}
+	lower := strings.ToLower(hrp) == hrp
+	lowerHRP := strings.ToLower(hrp)
+	var sb strings.Builder
+	sb.WriteString(lowerHRP)
+	sb.WriteString("1")
+	for _, p := range values {
+		sb.WriteByte(bech32Charset[p])
+	}
+	for _, p := range bech32CreateChecksum(lowerHRP, values) {
+		sb.WriteByte(bech32Charset[p])
+	}
+	if lower {
+		return sb.String(), nil
+	}
+	return strings.ToUpper(sb.String()), nil
+}
+
+// ageSecretKeyHRP is age's human-readable part for an X25519 identity's
+// on-disk secret-key encoding.
+const ageSecretKeyHRP = "AGE-SECRET-KEY-"
+
+// encodeAgeSecretKey encodes a 32-byte X25519 scalar as age's on-disk secret
+// key string (bech32, HRP "AGE-SECRET-KEY-", upper-cased) — the exact format
+// age.ParseX25519Identity requires and age-keygen emits.
+func encodeAgeSecretKey(scalar []byte) (string, error) {
+	if len(scalar) != ageX25519ScalarSize {
+		return "", fmt.Errorf("encode age secret key: want %d bytes, got %d", ageX25519ScalarSize, len(scalar))
+	}
+	return bech32Encode(ageSecretKeyHRP, scalar)
+}

--- a/apps/api/internal/cryptbox/bech32_test.go
+++ b/apps/api/internal/cryptbox/bech32_test.go
@@ -1,0 +1,99 @@
+package cryptbox
+
+// bech32_test.go exercises the self-contained Bech32 encoder in bech32.go in
+// isolation, independent of DeriveAgeIdentity/age. TestBech32Encode_BIP173Vector
+// pins the encoder against a known-answer test vector straight from the
+// BIP-173 spec so a checksum regression is caught here directly, not only
+// indirectly via age.ParseX25519Identity failing elsewhere.
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"filippo.io/age"
+)
+
+// TestBech32Encode_BIP173Vector checks against BIP-173's published
+// zero-data-length test vector ("A12UEL5L" / "a12uel5l": hrp "a", empty
+// data), which pins the checksum/generator-polynomial constants without any
+// decoding ambiguity (there is no data payload to have gotten wrong).
+func TestBech32Encode_BIP173Vector(t *testing.T) {
+	upper, err := bech32Encode("A", nil)
+	if err != nil {
+		t.Fatalf("bech32Encode(A, nil): %v", err)
+	}
+	if upper != "A12UEL5L" {
+		t.Fatalf("bech32Encode(A, nil) = %q, want %q", upper, "A12UEL5L")
+	}
+
+	lower, err := bech32Encode("a", nil)
+	if err != nil {
+		t.Fatalf("bech32Encode(a, nil): %v", err)
+	}
+	if lower != "a12uel5l" {
+		t.Fatalf("bech32Encode(a, nil) = %q, want %q", lower, "a12uel5l")
+	}
+}
+
+// TestEncodeAgeSecretKey_RoundTripsThroughUpstreamAge feeds a battery of
+// scalar values (zero, all-0xFF, and several pseudo-random samples) through
+// encodeAgeSecretKey and confirms every one is accepted by the real
+// age.ParseX25519Identity parser and yields a working, self-consistent
+// identity. This directly targets the checksum arithmetic across many data
+// payloads, not just the empty-data BIP-173 vector above.
+func TestEncodeAgeSecretKey_RoundTripsThroughUpstreamAge(t *testing.T) {
+	scalars := [][]byte{
+		make([]byte, ageX25519ScalarSize),      // all zero
+		bytesRepeat(0xFF, ageX25519ScalarSize), // all 0xFF
+		bytesSeq(ageX25519ScalarSize),          // 0x00,0x01,0x02,...
+		sha256Sum32([]byte("scalar-fixture-seed-1")),
+		sha256Sum32([]byte("scalar-fixture-seed-2")),
+	}
+
+	for i, scalar := range scalars {
+		encoded, err := encodeAgeSecretKey(scalar)
+		if err != nil {
+			t.Fatalf("scalars[%d]: encodeAgeSecretKey: %v", i, err)
+		}
+		id, err := age.ParseX25519Identity(encoded)
+		if err != nil {
+			t.Fatalf("scalars[%d]: age.ParseX25519Identity(%q): %v", i, encoded, err)
+		}
+		box := &AgeIdentity{identity: id, recipient: id.Recipient()}
+		ciphertext, err := box.Encrypt([]byte("payload"))
+		if err != nil {
+			t.Fatalf("scalars[%d]: Encrypt: %v", i, err)
+		}
+		plaintext, err := box.Decrypt(ciphertext)
+		if err != nil {
+			t.Fatalf("scalars[%d]: Decrypt: %v", i, err)
+		}
+		if string(plaintext) != "payload" {
+			t.Fatalf("scalars[%d]: decrypted = %q, want %q", i, plaintext, "payload")
+		}
+	}
+}
+
+func bytesRepeat(b byte, n int) []byte {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}
+
+func bytesSeq(n int) []byte {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = byte(i)
+	}
+	return out
+}
+
+// sha256Sum32 returns a realistic (non-adversarially-chosen), non-repeating
+// 32-byte value derived from label, purely as test-fixture scalar material —
+// unrelated to and independent of the HKDF construction under test elsewhere.
+func sha256Sum32(label []byte) []byte {
+	sum := sha256.Sum256(label)
+	return sum[:]
+}

--- a/apps/api/internal/cryptbox/cryptbox.go
+++ b/apps/api/internal/cryptbox/cryptbox.go
@@ -1,22 +1,28 @@
 // Package cryptbox holds the control plane's shared secret-at-rest primitive:
 // an age (X25519) identity used to encrypt customer/operator secrets before they
 // touch Postgres. It was extracted from internal/sitedestination so multiple
-// domains (site destinations, SMTP settings, future alert-channel secrets) can
-// share one encryption boundary without importing each other.
+// domains (site destinations, SMTP settings, per-site email, object-cache
+// credentials, TOTP 2FA secrets, future alert-channel secrets) can share one
+// encryption boundary without importing each other.
 //
 // The identity's private key never leaves the control plane and is never shipped
-// to an agent. In production the operator MUST supply a stable key
-// (WPMGR_SITE_DEST_AGE_SECRET) — an empty key yields a fresh ephemeral identity
-// so dev boots, but every restart would then orphan previously stored secrets.
+// to an agent. Every environment needs a STABLE identity across restarts —
+// NewAgeIdentity("") deliberately does not provide one (see its doc comment);
+// production code must resolve a stable key via an explicit
+// WPMGR_SITE_DEST_AGE_SECRET or, absent that, DeriveAgeIdentity seeded from the
+// (already-validated, restart-stable) session secret — see cmd/wpmgr's
+// resolveAgeIdentity, the sole production wiring point for the shared identity.
 package cryptbox
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"strings"
 
 	"filippo.io/age"
+	"golang.org/x/crypto/hkdf"
 )
 
 // AgeIdentity wraps an age X25519 identity (for decryption) plus its recipient
@@ -27,9 +33,12 @@ type AgeIdentity struct {
 }
 
 // NewAgeIdentity parses an age secret key (the AGE-SECRET-KEY-1... format). An
-// empty key produces a fresh ephemeral identity so dev startup succeeds; callers
-// that must persist ciphertext across restarts should refuse to boot in
-// production on an empty key (see the startup guard in cmd/wpmgr).
+// empty key produces a fresh ephemeral identity — a NEW random key every call,
+// which cannot decrypt anything encrypted by a previous call. This only exists
+// for tests and other short-lived, non-persisting callers; production code
+// must never pass an empty key to this function (use DeriveAgeIdentity, or an
+// explicit key, so ciphertext survives a restart — see cmd/wpmgr's
+// resolveAgeIdentity).
 func NewAgeIdentity(secretKey string) (*AgeIdentity, error) {
 	if strings.TrimSpace(secretKey) == "" {
 		id, err := age.GenerateX25519Identity()
@@ -41,6 +50,55 @@ func NewAgeIdentity(secretKey string) (*AgeIdentity, error) {
 	id, err := age.ParseX25519Identity(strings.TrimSpace(secretKey))
 	if err != nil {
 		return nil, fmt.Errorf("parse age identity: %w", err)
+	}
+	return &AgeIdentity{identity: id, recipient: id.Recipient()}, nil
+}
+
+// ageX25519ScalarSize is the length in bytes of an X25519 secret scalar
+// (age's on-disk secret key encodes exactly this many bytes after the
+// "AGE-SECRET-KEY-" bech32 human-readable part).
+const ageX25519ScalarSize = 32
+
+// DeriveAgeIdentity deterministically derives a STABLE age X25519 identity
+// from seed material using HKDF-SHA256 (RFC 5869), with info as a fixed
+// domain-separation label. The same (seed, info) pair always yields the same
+// identity; a restart that re-derives from the same stable seed (e.g. the
+// control plane's session secret) recovers the SAME key and can decrypt
+// everything the previous process encrypted — unlike an ephemeral random
+// identity, which cannot.
+//
+// The derivation is one-way: HKDF-SHA256 is a cryptographic extract-and-expand
+// KDF, so the resulting 32-byte X25519 scalar does not allow recovering seed.
+// info provides domain separation — deriving with a different info label from
+// the same seed yields an unrelated, independent identity, so this function
+// can safely be reused for other stable-identity needs without key reuse
+// across purposes as long as each purpose has its own info label.
+//
+// seed should be secret, high-entropy material that is itself already
+// validated to be non-empty and long enough (the control plane's session
+// secret, validated by config.ValidateSessionSecret, qualifies). No salt is
+// used (HKDF's salt is optional and primarily useful when the input keying
+// material is not already high-entropy secret data); the info label is the
+// only ceremony required here.
+func DeriveAgeIdentity(seed []byte, info string) (*AgeIdentity, error) {
+	if len(seed) == 0 {
+		return nil, fmt.Errorf("derive age identity: seed is empty")
+	}
+	if strings.TrimSpace(info) == "" {
+		return nil, fmt.Errorf("derive age identity: info label is empty")
+	}
+	h := hkdf.New(sha256.New, seed, nil, []byte(info))
+	scalar := make([]byte, ageX25519ScalarSize)
+	if _, err := io.ReadFull(h, scalar); err != nil {
+		return nil, fmt.Errorf("derive age identity: hkdf expand: %w", err)
+	}
+	secretKey, err := encodeAgeSecretKey(scalar)
+	if err != nil {
+		return nil, fmt.Errorf("derive age identity: encode secret key: %w", err)
+	}
+	id, err := age.ParseX25519Identity(secretKey)
+	if err != nil {
+		return nil, fmt.Errorf("derive age identity: derived key failed to parse (this is a bug in the derivation, not caller input): %w", err)
 	}
 	return &AgeIdentity{identity: id, recipient: id.Recipient()}, nil
 }

--- a/apps/api/internal/cryptbox/cryptbox_test.go
+++ b/apps/api/internal/cryptbox/cryptbox_test.go
@@ -1,0 +1,171 @@
+package cryptbox
+
+// cryptbox_test.go proves DeriveAgeIdentity produces a STABLE, deterministic
+// age identity from seed material (the fix for the self-host bug where every
+// restart minted a fresh ephemeral key and orphaned every stored secret — see
+// docs/... in the accompanying PR/issue). The restart-stability test is the
+// core regression lock: it simulates a process restart by deriving a SECOND,
+// independent AgeIdentity from the same seed and proving it decrypts what the
+// first identity encrypted.
+
+import (
+	"strings"
+	"testing"
+
+	"filippo.io/age"
+)
+
+const testInfoLabel = "wpmgr-age-identity-v1"
+
+// TestDeriveAgeIdentity_RestartStability is the core regression lock: it
+// simulates a control-plane restart by deriving a SECOND AgeIdentity from the
+// same seed+info (as would happen on the next boot, re-reading the same
+// WPMGR_SESSION_SECRET) and asserts it can decrypt ciphertext produced by the
+// FIRST identity. Before this fix, a fresh restart minted an unrelated random
+// identity and every previously stored secret (SMTP password, per-site email
+// creds, object-cache Redis creds, S3 backup-destination secrets, TOTP 2FA
+// secrets) became permanently undecryptable.
+func TestDeriveAgeIdentity_RestartStability(t *testing.T) {
+	seed := []byte("a-32-byte-or-longer-session-secret!!")
+
+	before, err := DeriveAgeIdentity(seed, testInfoLabel)
+	if err != nil {
+		t.Fatalf("DeriveAgeIdentity (pre-restart): %v", err)
+	}
+	plaintext := []byte("s3cr3t-SMTP-p@ssw0rd")
+	ciphertext, err := before.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	// Simulate a restart: a brand-new process re-derives from the same seed.
+	after, err := DeriveAgeIdentity(seed, testInfoLabel)
+	if err != nil {
+		t.Fatalf("DeriveAgeIdentity (post-restart): %v", err)
+	}
+
+	decrypted, err := after.Decrypt(ciphertext)
+	if err != nil {
+		t.Fatalf("post-restart identity failed to decrypt pre-restart ciphertext: %v", err)
+	}
+	if string(decrypted) != string(plaintext) {
+		t.Fatalf("decrypted = %q, want %q", decrypted, plaintext)
+	}
+}
+
+// TestDeriveAgeIdentity_Deterministic asserts same seed+info always yields
+// the same identity (compared via its public RecipientString(), which is
+// safe to log/compare without exposing the private key), and that a
+// different seed yields a different, non-interoperable identity.
+func TestDeriveAgeIdentity_Deterministic(t *testing.T) {
+	seedA := []byte("session-secret-AAAAAAAAAAAAAAAAAAAA")
+	seedB := []byte("session-secret-BBBBBBBBBBBBBBBBBBBB")
+
+	a1, err := DeriveAgeIdentity(seedA, testInfoLabel)
+	if err != nil {
+		t.Fatalf("DeriveAgeIdentity(seedA) #1: %v", err)
+	}
+	a2, err := DeriveAgeIdentity(seedA, testInfoLabel)
+	if err != nil {
+		t.Fatalf("DeriveAgeIdentity(seedA) #2: %v", err)
+	}
+	if a1.RecipientString() == "" {
+		t.Fatal("expected non-empty recipient string")
+	}
+	if a1.RecipientString() != a2.RecipientString() {
+		t.Fatalf("same seed+info produced different recipients: %q vs %q", a1.RecipientString(), a2.RecipientString())
+	}
+
+	b, err := DeriveAgeIdentity(seedB, testInfoLabel)
+	if err != nil {
+		t.Fatalf("DeriveAgeIdentity(seedB): %v", err)
+	}
+	if b.RecipientString() == a1.RecipientString() {
+		t.Fatal("different seeds produced the same recipient")
+	}
+
+	// A different seed's identity must not be able to decrypt the first
+	// seed's ciphertext.
+	ciphertext, err := a1.Encrypt([]byte("payload"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if _, err := b.Decrypt(ciphertext); err == nil {
+		t.Fatal("expected decryption with an unrelated derived identity to fail, got success")
+	}
+}
+
+// TestDeriveAgeIdentity_InfoDomainSeparation asserts the info label provides
+// domain separation: the same seed with two different info labels must yield
+// two independent, non-interoperable identities. This is what lets
+// DeriveAgeIdentity be reused safely for other stable-identity needs derived
+// from the same underlying secret without key reuse across purposes.
+func TestDeriveAgeIdentity_InfoDomainSeparation(t *testing.T) {
+	seed := []byte("shared-seed-used-for-two-purposes!!")
+
+	a, err := DeriveAgeIdentity(seed, "purpose-a")
+	if err != nil {
+		t.Fatalf("DeriveAgeIdentity(purpose-a): %v", err)
+	}
+	b, err := DeriveAgeIdentity(seed, "purpose-b")
+	if err != nil {
+		t.Fatalf("DeriveAgeIdentity(purpose-b): %v", err)
+	}
+	if a.RecipientString() == b.RecipientString() {
+		t.Fatal("different info labels on the same seed produced the same identity")
+	}
+}
+
+// TestDeriveAgeIdentity_ValidAgeSecretKeyFormat asserts the derived identity's
+// secret-key string is a well-formed age X25519 secret key: it round-trips
+// through the upstream age.ParseX25519Identity parser (proving our
+// self-contained bech32 encoder in bech32.go produces exactly what age
+// expects) and the re-parsed identity's recipient matches the original.
+func TestDeriveAgeIdentity_ValidAgeSecretKeyFormat(t *testing.T) {
+	seed := []byte("another-restart-stable-seed-value!!")
+
+	id, err := DeriveAgeIdentity(seed, testInfoLabel)
+	if err != nil {
+		t.Fatalf("DeriveAgeIdentity: %v", err)
+	}
+
+	secretKeyString := id.identity.String()
+	if !strings.HasPrefix(secretKeyString, "AGE-SECRET-KEY-1") {
+		t.Fatalf("secret key string = %q, want AGE-SECRET-KEY-1 prefix", secretKeyString)
+	}
+
+	reparsed, err := age.ParseX25519Identity(secretKeyString)
+	if err != nil {
+		t.Fatalf("age.ParseX25519Identity round-trip: %v", err)
+	}
+	if reparsed.Recipient().String() != id.RecipientString() {
+		t.Fatalf("round-tripped identity recipient = %q, want %q", reparsed.Recipient().String(), id.RecipientString())
+	}
+
+	// And the round-tripped identity must actually decrypt what the
+	// originally derived identity encrypted.
+	ciphertext, err := id.Encrypt([]byte("round-trip-check"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	reparsedBox := &AgeIdentity{identity: reparsed, recipient: reparsed.Recipient()}
+	decrypted, err := reparsedBox.Decrypt(ciphertext)
+	if err != nil {
+		t.Fatalf("round-tripped identity Decrypt: %v", err)
+	}
+	if string(decrypted) != "round-trip-check" {
+		t.Fatalf("decrypted = %q, want %q", decrypted, "round-trip-check")
+	}
+}
+
+// TestDeriveAgeIdentity_RejectsEmptyInputs asserts the function fails closed
+// on missing seed or info rather than silently deriving from zero-value
+// input (which would be a stable but predictable, non-secret key).
+func TestDeriveAgeIdentity_RejectsEmptyInputs(t *testing.T) {
+	if _, err := DeriveAgeIdentity(nil, testInfoLabel); err == nil {
+		t.Fatal("expected error for empty seed, got nil")
+	}
+	if _, err := DeriveAgeIdentity([]byte("some-seed-material-of-decent-length"), ""); err == nil {
+		t.Fatal("expected error for empty info label, got nil")
+	}
+}

--- a/docs/install.md
+++ b/docs/install.md
@@ -30,7 +30,7 @@ at boot, so the app accepts them on the first try — are:
 | `WPMGR_SESSION_SECRET` | random ≥32-byte string | hard-fails boot if empty/too short |
 | `WPMGR_AGENT_SIGNING_PRIVATE_KEY` | base64-std of the **raw** 64-byte Ed25519 key | signs CP→agent commands; rejected in prod if it's the committed dev key |
 | `WPMGR_AGENT_SIGNING_PUBLIC_KEY` | base64-std of the **raw** 32-byte Ed25519 key | the public half agents verify with |
-| `WPMGR_SITE_DEST_AGE_SECRET` | age X25519 secret (`AGE-SECRET-KEY-1…`) | secrets-at-rest key; **hard-fails prod boot if empty** |
+| `WPMGR_SITE_DEST_AGE_SECRET` | age X25519 secret (`AGE-SECRET-KEY-1…`) | secrets-at-rest key. **Optional**: if empty, a stable key is derived from `WPMGR_SESSION_SECRET` (secrets survive restarts). Set explicitly for an isolated, independently rotatable key |
 
 > The values must be base64 of the **raw key bytes**, not of a PEM file — the old
 > `base64 < key.pem` recipe produced keys the runtime rejected. The generator


### PR DESCRIPTION
Self-host data-integrity bug (reported via community: the SMTP password must be re-entered almost daily; also the likely cause of #215 TOTP-2FA-breaks-after-restart).

**Root cause:** every at-rest secret (SMTP password, per-site email + destination creds, object-cache creds, TOTP 2FA secrets) is age-encrypted with one shared key. When `WPMGR_SITE_DEST_AGE_SECRET` was empty, cryptbox generated a **fresh random key every boot**; the empty-key boot guard only fired `if IsProduction()`, and the bundled compose sets neither `WPMGR_ENV` nor the age secret — so a default self-host ran non-prod with an ephemeral key, and every restart orphaned all stored secrets.

**Fix:** when the explicit key is empty, derive a **stable** age identity from the already-required `WPMGR_SESSION_SECRET` via `HKDF-SHA256` → age X25519 secret-key format. No new config; key stays out of the DB (DB-dump threat model preserved); stable across restarts; every mode. Explicit key still wins (and now fails fast if unparseable); ephemeral path unreachable.

**Crypto:** age's bech32 is an unexported internal pkg, so `cryptbox/bech32.go` is an independent from-spec reimplementation (encode only), verified against a BIP-173 vector + round-tripped through real `age.ParseX25519Identity`. **Security-reviewed: SHIP** — bech32 byte-accuracy confirmed byte-identical to an independent BIP-173 reference and age's own encoder (scalar preserved exactly); no-salt HKDF correct for the high-entropy domain-separated seed; graceful decrypt-fail handling (no panic/500). Tests: restart-stability, determinism, domain-separation, valid-format, wiring precedence/fail-fast, BIP-173 vector.

CP-only, no agent/web change (version synced). Upgrade note: installs on the old ephemeral key re-enter secrets once, then permanent. docs + `.env.example` updated (the key is now optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Secrets now persist across self-hosted restarts when no explicit encryption key is configured.
  * Existing encrypted secrets may require one-time re-entry after upgrading.

* **Documentation**
  * Clarified encryption-key configuration, fallback behavior, and re-keying requirements.
  * Updated installation guidance to reflect that the encryption key is optional.

* **Tests**
  * Added coverage for stable key generation, explicit-key precedence, validation, and restart-safe decryption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->