### PR TITLE
fix(agent): reliably reclaim pre-update rollback snapshots (GH #226, 0.61.62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
-## [0.61.61] - 2026-07-15
+## [0.61.62] - 2026-07-15
+
+### Fixed
+
+- Pre-update rollback snapshots (captured under `wp-content/uploads/wpmgr-snapshots/` before each plugin, theme, or core update so a failed update can be rolled back) are now reliably cleaned up instead of accumulating indefinitely (GH #226). Previously the only cleanup ran either on a WordPress cron event (which never fires on sites with `DISABLE_WP_CRON` or very little traffic) or at the start of the next update, so a site that ran a batch of updates once and then went quiet kept every snapshot forever, quietly consuming disk space and inodes. Cleanup now runs opportunistically on ordinary agent activity (no dependency on WordPress cron), a snapshot whose update succeeded is reclaimed within about an hour once it is safely past the rollback window, and any already-accumulated snapshots are swept on the first request after upgrading. Snapshots are never removed while a rollback could still be needed (a fixed minimum retention protects the control plane's post-update health-probe window and the update-safety watchdog), and a snapshot left behind by a failed rollback is still retained for a few days for manual recovery. Agent only; no change to update, backup, or rollback behavior.
 
 ### Changed
 

--- a/apps/agent/includes/class-lifecycle.php
+++ b/apps/agent/includes/class-lifecycle.php
@@ -465,6 +465,7 @@ final class Lifecycle
             ObjectCacheConfig::OPTION_CONFIG_HASH,
             ObjectCacheHeartbeat::OPTION_STATS,
             'wpmgr_oc_outage_marker', // WPMgr_Object_Cache::FAILBACK_MARKER_OPTION (H5).
+            'wpmgr_snapshot_gc_last', // SnapshotManager::OPTION_GC_LAST (GH #226 GC throttle stamp).
         ];
     }
 }

--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -508,6 +508,23 @@ final class Plugin
         // extra on the overwhelmingly common no-marker boot.
         add_action('plugins_loaded', [$this, 'maybeDisarmUpdateWatchdog']);
 
+        // GitHub issue #226 — WP-Cron-INDEPENDENT, throttled reclaim trigger
+        // for the wpmgr-snapshots/ store. Root cause: the only existing
+        // reclaim paths — pruneForSlug() (runs only at the SAME slug's next
+        // capture()) and gcExpired() (bound to the daily wpmgr_snapshot_gc
+        // cron event, or invoked opportunistically at the start of an
+        // `update` command) — both require something else to happen again
+        // later. A fleet that bulk-updates once and goes quiet (or has
+        // DISABLE_WP_CRON set) never sees either again, so a successful
+        // update's own snapshot never gets reclaimed. Binding this to
+        // plugins_loaded fires SnapshotManager::maybeGc() on every request
+        // the agent serves post-enrollment — including the control plane's
+        // own uptime probes and every signed command — so reclaim no longer
+        // depends on cron or another update ever running. maybeGc() itself
+        // throttles the actual sweep to once per hour via a stored option, so
+        // this costs one cheap get_option() read on every other request.
+        add_action('plugins_loaded', [$this, 'maybeGcSnapshots']);
+
         // M14: Guard against Performance Lab disabling our object-cache drop-in.
         // When the OC is configured (config file exists), register the filter so
         // Performance Lab cannot suppress it.
@@ -1304,6 +1321,30 @@ final class Plugin
     public function maybeDisarmUpdateWatchdog(): void
     {
         UpdateWatchdogMarker::disarmHealthy();
+    }
+
+    /**
+     * GitHub issue #226 — WP-Cron-independent GC trigger for the
+     * wpmgr-snapshots/ store. See registerHooks()'s binding comment for the
+     * root cause this closes; SnapshotManager::maybeGc() itself throttles the
+     * actual sweep to once per hour via a stored option and never lets a GC
+     * failure propagate, so this is cheap and safe to call on every request.
+     *
+     * Gated on isEnrolled(), mirroring maybeRescheduleCron() /
+     * maybeDisarmUpdateWatchdog(): a not-yet-enrolled site has never had an
+     * update (and therefore never a snapshot) to reclaim, and skipping keeps
+     * this from perturbing the one-shot auto-deactivate safety window that
+     * only matters while not enrolled.
+     *
+     * @return void
+     */
+    public function maybeGcSnapshots(): void
+    {
+        if (!$this->settings->isEnrolled()) {
+            return;
+        }
+
+        SnapshotManager::maybeGc();
     }
 
     /**

--- a/apps/agent/includes/commands/class-update-command.php
+++ b/apps/agent/includes/commands/class-update-command.php
@@ -556,6 +556,20 @@ final class UpdateCommand implements CommandInterface
                     // response — see UpdateWatchdogMarker::arm()'s own doc.
                     if ($type !== 'core' && $status === 'succeeded' && $snapshotId !== '') {
                         $this->armUpdateWatchdog($type, $slug, $snapshotId, $toVersion);
+
+                        // GitHub issue #226 — mark this snapshot's meta as
+                        // succeeded so SnapshotManager::gcExpired()'s two-tier
+                        // reclaim can drop it in ~1h instead of waiting out
+                        // the full 72h orphan backstop (the root cause of
+                        // #226: a successful update never had a reclaim path
+                        // of its own). Orthogonal to arming the watchdog
+                        // above — the snapshot must still exist for that —
+                        // and gated on the exact same "genuinely succeeded AND
+                        // a snapshot was captured" condition. Best-effort:
+                        // markSucceeded() itself never throws; a failure here
+                        // just leaves this snapshot on the unchanged 72h
+                        // backstop.
+                        $this->snapshots->markSucceeded($snapshotId);
                     }
 
                     return $this->result($type, $slug, $fromVersion, $toVersion, $status, $snapshotId, $log);

--- a/apps/agent/includes/support/class-snapshot-manager.php
+++ b/apps/agent/includes/support/class-snapshot-manager.php
@@ -108,6 +108,42 @@ class SnapshotManager
     private const GC_BACKSTOP_TTL_SECONDS = 259200; // 72h
 
     /**
+     * GitHub issue #226 — throttle for maybeGc()'s WP-Cron-independent GC
+     * trigger (see that method's doc for the root cause this closes: a
+     * successful update never had ANY reclaim path of its own, and the two
+     * that exist for other cases — pruneForSlug() at the slug's NEXT
+     * capture(), and gcExpired() from the daily cron event or the
+     * opportunistic call at the start of an `update` command — both require
+     * something else to happen first that a quiet, done-updating site may
+     * never see again). 1 hour bounds the full snapshot-store sweep this
+     * throttle guards to a single cheap get_option() read on every OTHER
+     * request in between, on every request the agent serves (not cron-only).
+     */
+    private const GC_THROTTLE_SECONDS = 3600; // 1h
+
+    /**
+     * GitHub issue #226 — reclaim TTL for a snapshot whose meta has been
+     * explicitly marked succeeded via markSucceeded(). 1 hour is 6x
+     * MIN_KEEP_AGE_SECONDS's 10-minute CP-rollback/watchdog-marker survival
+     * floor and comfortably past the 45-minute stale-task reaper window that
+     * terminalizes a stuck task WITHOUT ever issuing a rollback — by the time
+     * this TTL elapses nothing in the system can still need this snapshot.
+     * Reclaiming a genuinely-succeeded update's snapshot on this short a
+     * cadence, rather than only via the 72h GC_BACKSTOP_TTL_SECONDS meant for
+     * orphans that never resolve on their own, is what closes the root cause
+     * of a fleet that bulk-updates once and goes quiet never reclaiming disk.
+     */
+    private const SUCCESS_RECLAIM_TTL_SECONDS = 3600; // 1h
+
+    /**
+     * GitHub issue #226 — autoloaded option backing maybeGc()'s throttle
+     * timestamp. Autoloaded (not opt-out like the opcache-version option
+     * elsewhere in this codebase) since it is read on effectively every
+     * enrolled request via Plugin::maybeGcSnapshots().
+     */
+    private const OPTION_GC_LAST = 'wpmgr_snapshot_gc_last';
+
+    /**
      * Capture a pre-update snapshot for an item.
      *
      * For plugin/theme the live source directory is copied into the snapshot
@@ -428,6 +464,51 @@ class SnapshotManager
         return $this->deleteDir($dir);
     }
 
+    /**
+     * GitHub issue #226 — stamp a snapshot's meta.json with a terminal-success
+     * marker once UpdateCommand has verified the item it was captured for
+     * genuinely succeeded (see UpdateCommand's call site for the exact gate).
+     * This is the other half of gcExpired()'s two-tier reclaim decision (see
+     * its doc): a marked-succeeded snapshot is reclaimed after only
+     * SUCCESS_RECLAIM_TTL_SECONDS (1h) instead of waiting out the full
+     * GC_BACKSTOP_TTL_SECONDS (72h) meant for orphans that never resolve.
+     *
+     * Best-effort and deliberately never throws: marking succeeded is a
+     * disk-reclaim OPTIMIZATION, not a correctness requirement — a snapshot
+     * whose meta could not be read or rewritten here (a since-vanished
+     * directory, a permissions hiccup, a genuinely unreadable meta.json)
+     * simply falls back to the unchanged 72h backstop, which still reclaims
+     * it eventually. Never call this before the update it documents has been
+     * independently verified complete; it is purely a GC-timing hint.
+     *
+     * @param string $snapshotId Snapshot identifier captured for the apply
+     *                            that just succeeded.
+     * @return void
+     */
+    public function markSucceeded(string $snapshotId): void
+    {
+        try {
+            $base = $this->snapshotBaseDir();
+            if ($base === '') {
+                return;
+            }
+            $dir = $this->resolveSnapshotDir($base, $snapshotId);
+            if ($dir === '') {
+                return;
+            }
+            $meta = $this->readMeta($dir);
+            if ($meta === null) {
+                return;
+            }
+            $meta['succeeded_at'] = time();
+            @file_put_contents($dir . '/meta.json', (string) json_encode($meta));
+        } catch (\Throwable $e) {
+            // Never let a GC-timing optimization affect the caller — the
+            // snapshot simply falls back to the 72h backstop (safe
+            // degradation, see this method's doc).
+        }
+    }
+
     // ---------------------------------------------------------------------
     // M1 (issue #131) — bounded snapshot GC
     // ---------------------------------------------------------------------
@@ -551,20 +632,81 @@ class SnapshotManager
     }
 
     /**
+     * GitHub issue #226 — WP-Cron-INDEPENDENT, throttled trigger for
+     * gcExpired(). Root cause this closes: gcExpired() itself only ever ran
+     * from the `wpmgr_snapshot_gc` daily cron event (dead on
+     * `DISABLE_WP_CRON`/an idle site with no visitor traffic to fire the
+     * wp-cron.php pseudo-cron request) or opportunistically at the START of
+     * an `update` command (never arrives once a fleet stops sending updates)
+     * — so a site that bulk-updates once and goes quiet never reclaimed a
+     * single snapshot again. Plugin::maybeGcSnapshots() binds this to
+     * `plugins_loaded`, so it now runs on EVERY request the agent serves post
+     * enrollment — including the control plane's own uptime probes and every
+     * signed command — independent of cron entirely.
+     *
+     * Throttled to at most once per GC_THROTTLE_SECONDS (1h) via a stored
+     * option, so the actual sweep (a scandir() + per-entry meta read) still
+     * only runs hourly at most; every other request pays just one cheap
+     * get_option() read. The throttle timestamp is stamped BEFORE gcExpired()
+     * runs — not after a successful return — so a slow or failing sweep can
+     * never be retried on every single request within the same hour; the
+     * next throttled attempt an hour later gets a fresh try regardless of
+     * whether this one succeeded.
+     *
+     * gcExpired() itself is wrapped in try/catch: a GC sweep is disk-hygiene
+     * housekeeping, never a condition that may break the request (or hook)
+     * that happened to trigger it.
+     *
+     * `static::gcExpired()`, not `self::gcExpired()` — late static binding
+     * keeps this in the same test-double seam gcExpired() itself already
+     * documents (a subclass overriding gcExpired() is still reached via
+     * `SubclassName::maybeGc()`).
+     *
+     * @return void
+     */
+    public static function maybeGc(): void
+    {
+        if (!function_exists('get_option') || !function_exists('update_option')) {
+            return;
+        }
+
+        $now  = time();
+        $last = (int) get_option(self::OPTION_GC_LAST, 0);
+        if ($now - $last < self::GC_THROTTLE_SECONDS) {
+            return;
+        }
+
+        // Stamp BEFORE running — see this method's doc for why.
+        update_option(self::OPTION_GC_LAST, $now, true);
+
+        try {
+            static::gcExpired();
+        } catch (\Throwable $e) {
+            // A GC sweep failure must never break the caller (a request
+            // handler bound to plugins_loaded); the next throttled attempt
+            // an hour from now gets a fresh try.
+        }
+    }
+
+    /**
      * GC cron backstop — sweep the WHOLE snapshot store for any directory
-     * older than GC_BACKSTOP_TTL_SECONDS, independent of the per-slug prune
-     * in pruneForSlug() above. This is the safety net for what count-based
-     * pruning structurally cannot reach: a snapshot whose slug was later
-     * uninstalled or renamed (so it will never again be the target of a
-     * capture() call that would prune it), a core meta-only snapshot from a
-     * repeatedly-requested `snapshot=true` core update, or a crashed capture
-     * that left a directory behind with no readable meta.json at all.
+     * eligible under {@see shouldReclaim()}'s two-tier age decision,
+     * independent of the per-slug prune in pruneForSlug() above. This is the
+     * safety net for what count-based pruning structurally cannot reach: a
+     * snapshot whose slug was later uninstalled or renamed (so it will never
+     * again be the target of a capture() call that would prune it), a core
+     * meta-only snapshot from a repeatedly-requested `snapshot=true` core
+     * update, or a crashed capture that left a directory behind with no
+     * readable meta.json at all.
      * ALSO sweeps stranded `.wpmgr-old-<snap_id>` asides left behind in the
      * live plugins/themes tree (F4, issue #131 final-hardening review) — see
      * sweepStrandedAsides()'s doc. Bound to the `wpmgr_snapshot_gc` recurring
-     * cron event — see scheduleGc() — AND invoked opportunistically from the
-     * start of the `update` command (C, same review) since WP-Cron is
-     * unreliable on `DISABLE_WP_CRON`/dormant sites.
+     * cron event — see scheduleGc() — invoked opportunistically from the
+     * start of the `update` command (C, issue #131 final-hardening review),
+     * and (GitHub issue #226) driven WP-Cron-independently on every enrolled
+     * request via maybeGc() above, since WP-Cron is unreliable on
+     * `DISABLE_WP_CRON`/dormant sites and a quiet fleet may never send
+     * another `update` command either.
      *
      * `new static()`, not `new self()` — late static binding lets a test
      * double subclass override strandedAsideRoots() and still exercise this
@@ -594,7 +736,7 @@ class SnapshotManager
                         continue;
                     }
                     $age = $now - $mgr->snapshotAge($dir);
-                    if ($age < self::GC_BACKSTOP_TTL_SECONDS) {
+                    if (!$mgr->shouldReclaim($age, $mgr->isMarkedSucceeded($dir))) {
                         continue;
                     }
                     $mgr->deleteDir($dir);
@@ -603,6 +745,62 @@ class SnapshotManager
         }
 
         $mgr->sweepStrandedAsides();
+    }
+
+    /**
+     * GitHub issue #226 — the two-tier reclaim decision every snapshot
+     * directory in gcExpired()'s sweep is evaluated against:
+     *
+     *   - DEFENSIVE FLOOR: never reclaim anything younger than
+     *     MIN_KEEP_AGE_SECONDS (10 min), regardless of the success marker.
+     *     This is belt-and-suspenders — SUCCESS_RECLAIM_TTL_SECONDS (1h) is
+     *     already 6x this floor, so it can never actually fire under real
+     *     constant values today — but it is kept as an explicit, independent
+     *     check rather than relying on that ordering never changing.
+     *   - Marked succeeded (see markSucceeded()): reclaimed once older than
+     *     SUCCESS_RECLAIM_TTL_SECONDS (1h) — comfortably past both the CP's
+     *     post-update health-probe/rollback window and the 45-minute
+     *     stale-task reaper that terminalizes a stuck task without ever
+     *     issuing a rollback.
+     *   - Unmarked (an in-progress apply that never reached the success
+     *     marker, a failed-rollback broken-site snapshot kept for manual
+     *     recovery, an orphan/renamed slug, a core meta-only snapshot, or a
+     *     crashed capture with no readable meta at all): reclaimed only once
+     *     older than the original GC_BACKSTOP_TTL_SECONDS (72h), unchanged.
+     *
+     * Isolated into its own pure method (rather than inlined in gcExpired()'s
+     * loop) so this exact decision matrix is independently testable.
+     *
+     * @param int  $age       Snapshot age in seconds (see snapshotAge()).
+     * @param bool $succeeded Whether the snapshot's meta carries a
+     *                         markSucceeded() marker.
+     * @return bool True when this snapshot should be reclaimed now.
+     */
+    private function shouldReclaim(int $age, bool $succeeded): bool
+    {
+        if ($age < self::MIN_KEEP_AGE_SECONDS) {
+            return false;
+        }
+
+        $threshold = $succeeded ? self::SUCCESS_RECLAIM_TTL_SECONDS : self::GC_BACKSTOP_TTL_SECONDS;
+
+        return $age >= $threshold;
+    }
+
+    /**
+     * Whether a snapshot directory's meta.json carries a markSucceeded()
+     * marker. Returns false (never reclaim early) for a directory whose meta
+     * is missing or unreadable — exactly the crashed-capture / orphan cases
+     * gcExpired()'s unmarked branch (the unchanged 72h backstop) exists for.
+     *
+     * @param string $dir Absolute snapshot directory.
+     * @return bool
+     */
+    private function isMarkedSucceeded(string $dir): bool
+    {
+        $meta = $this->readMeta($dir);
+
+        return $meta !== null && isset($meta['succeeded_at']);
     }
 
     /**

--- a/apps/agent/tests/PluginMaybeGcSnapshotsTest.php
+++ b/apps/agent/tests/PluginMaybeGcSnapshotsTest.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * GitHub issue #226 — Plugin::maybeGcSnapshots() boot-wiring regression lock.
+ *
+ * Verifies the WP-Cron-independent GC trigger registerHooks() binds to
+ * `plugins_loaded` actually reaches SnapshotManager::maybeGc() -> gcExpired()
+ * when the site is enrolled, and is a cheap no-op (never touches the
+ * snapshot store) otherwise — mirroring the isEnrolled() gate already used by
+ * maybeRescheduleCron() / maybeDisarmUpdateWatchdog().
+ *
+ * Boots the REAL Plugin singleton with the same minimal stub set
+ * PluginActivationTest uses for boot() (no master-key setup needed here —
+ * this test never calls activate()).
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Plugin;
+use WPMgr\Agent\Settings;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Plugin
+ */
+final class PluginMaybeGcSnapshotsTest extends TestCase
+{
+    /** @var array<string,mixed> In-memory wp-option store. */
+    private array $options = [];
+
+    /** Temp uploads dir standing in for wp_upload_dir()'s basedir. */
+    private string $uploadsDir = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->uploadsDir = sys_get_temp_dir() . '/wpmgr-plugin-gc-' . bin2hex(random_bytes(6));
+        mkdir($this->uploadsDir, 0755, true);
+
+        $this->options = [];
+
+        // Same minimal boot-stub set as PluginActivationTest::set_up() — see
+        // its own doc for why each of these is needed for Plugin::boot() to
+        // complete without throwing.
+        foreach (['add_action', 'add_filter', 'register_activation_hook',
+                  'register_deactivation_hook', 'wp_schedule_single_event',
+                  'spawn_cron', 'wp_next_scheduled', 'wp_schedule_event',
+                  'wp_get_scheduled_event', 'wp_clear_scheduled_hook'] as $fn) {
+            Functions\when($fn)->justReturn(true);
+        }
+        Functions\when('is_admin')->justReturn(false);
+        Functions\when('is_multisite')->justReturn(false);
+        Functions\when('plugin_basename')->returnArg();
+
+        Functions\when('update_option')->alias(function ($name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('get_option')->alias(function ($name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('delete_option')->alias(function ($name) {
+            unset($this->options[$name]);
+            return true;
+        });
+        Functions\when('get_site_option')->alias(function ($name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('update_site_option')->alias(function ($name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
+
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $this->uploadsDir]);
+    }
+
+    protected function tear_down(): void
+    {
+        // Reset the Plugin singleton so this test's constructed instance does
+        // not leak into subsequent tests in the suite — same reasoning as
+        // PluginActivationTest::tear_down().
+        Plugin::resetForTesting();
+        $this->rrmdir($this->uploadsDir);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /** Recursive delete used only for test fixture cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+
+    /**
+     * Seed an orphaned snapshot directory well past the 72h GC backstop TTL —
+     * the exact class of orphan gcExpired() exists to reclaim.
+     *
+     * @return string Absolute path to the seeded snapshot directory.
+     */
+    private function seedOrphanSnapshot(): string
+    {
+        $snapshotsBase = $this->uploadsDir . '/wpmgr-snapshots';
+        if (!is_dir($snapshotsBase)) {
+            mkdir($snapshotsBase, 0755, true);
+        }
+        $dir = $snapshotsBase . '/snap_' . bin2hex(random_bytes(12));
+        mkdir($dir, 0755, true);
+        file_put_contents($dir . '/meta.json', (string) json_encode([
+            'type'         => 'plugin',
+            'slug'         => 'long-gone/long-gone.php',
+            'from_version' => '1.0',
+            'created_at'   => time() - (73 * 3600),
+        ]));
+
+        return $dir;
+    }
+
+    public function test_maybe_gc_snapshots_reclaims_an_orphan_via_snapshot_manager_maybe_gc_when_enrolled(): void
+    {
+        $this->options[Settings::OPTION_SITE_ID] = 'site-abc';
+        $this->options[Settings::OPTION_CP_URL]  = 'https://cp.example.test';
+
+        $orphan = $this->seedOrphanSnapshot();
+
+        $plugin = Plugin::boot();
+        $plugin->maybeGcSnapshots();
+
+        $this->assertFalse(
+            is_dir($orphan),
+            'an enrolled site must reclaim an orphaned snapshot via the plugins_loaded-bound maybeGcSnapshots() -> SnapshotManager::maybeGc() -> gcExpired() chain'
+        );
+    }
+
+    public function test_maybe_gc_snapshots_is_a_cheap_no_op_when_not_enrolled(): void
+    {
+        // Deliberately NOT enrolled: no site_id/cp_url set in the option store.
+        $orphan = $this->seedOrphanSnapshot();
+
+        $plugin = Plugin::boot();
+        $plugin->maybeGcSnapshots();
+
+        $this->assertTrue(
+            is_dir($orphan),
+            'a not-yet-enrolled site must never run the snapshot GC — maybeGcSnapshots() must be a cheap no-op'
+        );
+    }
+}

--- a/apps/agent/tests/SnapshotManagerTest.php
+++ b/apps/agent/tests/SnapshotManagerTest.php
@@ -53,6 +53,14 @@ final class SnapshotManagerTest extends TestCase
     /** wpmgr-snapshots store under $uploadsDir. */
     private string $snapshotsBase = '';
 
+    /**
+     * In-memory wp-option store backing get_option()/update_option() —
+     * needed for maybeGc()'s throttle timestamp (GitHub issue #226).
+     *
+     * @var array<string,mixed>
+     */
+    private array $options = [];
+
     protected function set_up(): void
     {
         parent::set_up();
@@ -64,6 +72,15 @@ final class SnapshotManagerTest extends TestCase
         mkdir($this->uploadsDir, 0755, true);
 
         Functions\when('wp_upload_dir')->justReturn(['basedir' => $this->uploadsDir]);
+
+        $this->options = [];
+        Functions\when('get_option')->alias(function ($name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('update_option')->alias(function ($name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
     }
 
     protected function tear_down(): void
@@ -144,18 +161,27 @@ final class SnapshotManagerTest extends TestCase
     /**
      * Seed a snapshot directory directly on disk (bypassing capture()) with a
      * controlled created_at, for prune/GC tests that need precise ages.
+     *
+     * @param bool $succeeded GitHub issue #226 — when true, stamps the same
+     *                         `succeeded_at` marker markSucceeded() writes, so
+     *                         GC tests can seed a two-tier scenario directly
+     *                         without a real capture()/markSucceeded() round trip.
      */
-    private function seedSnapshot(string $type, string $slug, int $createdAt): string
+    private function seedSnapshot(string $type, string $slug, int $createdAt, bool $succeeded = false): string
     {
         $id  = 'snap_' . bin2hex(random_bytes(12));
         $dir = $this->snapshotsBase . '/' . $id;
         mkdir($dir, 0755, true);
-        file_put_contents($dir . '/meta.json', (string) json_encode([
+        $meta = [
             'type'         => $type,
             'slug'         => $slug,
             'from_version' => '1.0',
             'created_at'   => $createdAt,
-        ]));
+        ];
+        if ($succeeded) {
+            $meta['succeeded_at'] = $createdAt;
+        }
+        file_put_contents($dir . '/meta.json', (string) json_encode($meta));
 
         return $id;
     }
@@ -396,6 +422,247 @@ final class SnapshotManagerTest extends TestCase
             is_dir($this->snapshotsBase . '/' . $r['snapshot_id']),
             'M1: a freshly captured snapshot must never be swept by the GC backstop — it is nowhere near the 72h TTL'
         );
+    }
+
+    // =========================================================================
+    // GitHub issue #226 — maybeGc() WP-Cron-independent throttled trigger
+    // =========================================================================
+
+    /**
+     * A SnapshotManager subclass whose gcExpired() is fully test-controlled
+     * (a static call counter, optionally throwing) — exercised via maybeGc()'s
+     * `static::gcExpired()` late-static-binding call, exactly the same seam
+     * gcExpired() itself already documents for strandedAsideRoots() overrides.
+     *
+     * @param bool $throws Whether gcExpired() should throw after recording the call.
+     * @return class-string<SnapshotManager>
+     */
+    private function managerClassCountingGcExpiredCalls(bool $throws = false): string
+    {
+        $class = new class extends SnapshotManager {
+            public static int $calls  = 0;
+            public static bool $throws = false;
+
+            public static function gcExpired(): void
+            {
+                self::$calls++;
+                if (self::$throws) {
+                    throw new \RuntimeException('simulated GC sweep failure');
+                }
+            }
+        };
+        $class::$calls  = 0;
+        $class::$throws = $throws;
+
+        return get_class($class);
+    }
+
+    public function test_maybe_gc_runs_on_first_call_skips_within_the_throttle_window_and_runs_again_after_it_elapses(): void
+    {
+        $now = 1_700_000_000;
+        Functions\when('time')->alias(static function () use (&$now) {
+            return $now;
+        });
+
+        $class = $this->managerClassCountingGcExpiredCalls();
+
+        // No stored throttle timestamp yet -> must run.
+        $class::maybeGc();
+        $this->assertSame(1, $class::$calls, 'the first ever call must run gcExpired()');
+
+        // Well within GC_THROTTLE_SECONDS (1h) -> must be skipped.
+        $now += 10;
+        $class::maybeGc();
+        $this->assertSame(1, $class::$calls, 'a call within the throttle window must skip gcExpired()');
+
+        // Past GC_THROTTLE_SECONDS since the stamped timestamp -> must run again.
+        $now += 3700;
+        $class::maybeGc();
+        $this->assertSame(2, $class::$calls, 'a call past the throttle window must run gcExpired() again');
+    }
+
+    public function test_maybe_gc_stamps_the_throttle_before_running_so_a_throwing_gc_expired_never_propagates_or_retries_every_request(): void
+    {
+        $class = $this->managerClassCountingGcExpiredCalls(throws: true);
+
+        // Must not throw even though the wrapped gcExpired() itself throws.
+        $class::maybeGc();
+        $this->assertSame(1, $class::$calls);
+
+        // Calling again immediately must NOT re-invoke gcExpired() — proving
+        // the throttle timestamp was stamped BEFORE gcExpired() ran (not only
+        // after a successful return), so a failing sweep cannot be retried on
+        // every single subsequent request within the same throttle window.
+        $class::maybeGc();
+        $this->assertSame(
+            1,
+            $class::$calls,
+            'the throttle timestamp must be stamped before gcExpired() runs, so a throw does not cause a retry on every request'
+        );
+    }
+
+    // =========================================================================
+    // GitHub issue #226 — two-tier reclaim decision (shouldReclaim()) + gcExpired()
+    // =========================================================================
+
+    public function test_should_reclaim_two_tier_decision_matrix(): void
+    {
+        $mgr    = new SnapshotManager();
+        $method = new \ReflectionMethod(SnapshotManager::class, 'shouldReclaim');
+
+        // Succeeded-marked, aged 90 minutes: past the 1h SUCCESS_RECLAIM_TTL_SECONDS -> reclaim.
+        $this->assertTrue(
+            (bool) $method->invoke($mgr, 90 * 60, true),
+            'a succeeded-marked snapshot past 1h must be reclaimed'
+        );
+
+        // Unmarked, aged 90 minutes: well under the 72h backstop -> kept.
+        $this->assertFalse(
+            (bool) $method->invoke($mgr, 90 * 60, false),
+            'an UNMARKED snapshot under 72h must be kept — only a success marker shortens the TTL'
+        );
+
+        // Unmarked, aged past 72h -> reclaim (the unchanged orphan backstop).
+        $this->assertTrue(
+            (bool) $method->invoke($mgr, 73 * 3600, false),
+            'an unmarked snapshot past the 72h backstop must still be reclaimed'
+        );
+
+        // Succeeded-marked but younger than MIN_KEEP_AGE_SECONDS (600s) — the
+        // defensive floor must override the marker regardless.
+        $this->assertFalse(
+            (bool) $method->invoke($mgr, 599, true),
+            'DEFENSIVE FLOOR: nothing younger than MIN_KEEP_AGE_SECONDS may ever be reclaimed, even when marked succeeded'
+        );
+
+        // Unmarked and younger than MIN_KEEP_AGE_SECONDS -> kept either way.
+        $this->assertFalse(
+            (bool) $method->invoke($mgr, 599, false),
+            'an unmarked snapshot younger than MIN_KEEP_AGE_SECONDS must also be kept'
+        );
+    }
+
+    public function test_gc_expired_reclaims_an_unmarked_snapshot_past_72h_and_a_succeeded_marked_snapshot_past_1h_with_no_wp_cron_involved(): void
+    {
+        $mgr = $this->managerWithNoLiveSource();
+        $mgr->capture('plugin', 'warmup/warmup.php', '1.0');
+
+        $unmarkedOrphan = $this->seedSnapshot('plugin', 'orphan/orphan.php', time() - (73 * 3600));
+        $succeededOld   = $this->seedSnapshot('plugin', 'done/done.php', time() - (61 * 60), true);
+
+        // Direct call, exactly as Plugin::maybeGcSnapshots() -> SnapshotManager::maybeGc()
+        // reaches it on plugins_loaded — no WP-Cron event involved at all.
+        SnapshotManager::gcExpired();
+
+        $this->assertFalse(
+            is_dir($this->snapshotsBase . '/' . $unmarkedOrphan),
+            'GitHub issue #226: an unmarked orphan past the 72h backstop must reclaim via a direct gcExpired() call, cron or not'
+        );
+        $this->assertFalse(
+            is_dir($this->snapshotsBase . '/' . $succeededOld),
+            'GitHub issue #226: a succeeded-marked snapshot past the 1h SUCCESS_RECLAIM_TTL must reclaim long before the 72h backstop'
+        );
+    }
+
+    public function test_gc_expired_keeps_a_succeeded_marked_snapshot_younger_than_the_min_keep_age_floor(): void
+    {
+        $mgr = $this->managerWithNoLiveSource();
+        $mgr->capture('plugin', 'warmup/warmup.php', '1.0');
+
+        // Marked succeeded but only 5 minutes old — well under
+        // MIN_KEEP_AGE_SECONDS (600s) — must survive regardless of the marker.
+        $freshSucceeded = $this->seedSnapshot('plugin', 'fresh/fresh.php', time() - 300, true);
+
+        SnapshotManager::gcExpired();
+
+        $this->assertTrue(
+            is_dir($this->snapshotsBase . '/' . $freshSucceeded),
+            'a snapshot younger than MIN_KEEP_AGE_SECONDS must never be reclaimed, even when marked succeeded'
+        );
+    }
+
+    public function test_gc_expired_keeps_an_unmarked_snapshot_between_1h_and_72h_but_reclaims_a_succeeded_marked_one_at_the_same_age(): void
+    {
+        $mgr = $this->managerWithNoLiveSource();
+        $mgr->capture('plugin', 'warmup/warmup.php', '1.0');
+
+        $ageSeconds       = 90 * 60; // 90 minutes: past the 1h SUCCESS TTL, well under the 72h backstop.
+        $unmarkedSameAge  = $this->seedSnapshot('plugin', 'still-unresolved/still-unresolved.php', time() - $ageSeconds);
+        $succeededSameAge = $this->seedSnapshot('plugin', 'succeeded/succeeded.php', time() - $ageSeconds, true);
+
+        SnapshotManager::gcExpired();
+
+        $this->assertTrue(
+            is_dir($this->snapshotsBase . '/' . $unmarkedSameAge),
+            'an UNMARKED snapshot aged 90 minutes (< 72h) must be KEPT'
+        );
+        $this->assertFalse(
+            is_dir($this->snapshotsBase . '/' . $succeededSameAge),
+            'a succeeded-MARKED snapshot at the SAME 90-minute age must be RECLAIMED — only the marker changes the outcome'
+        );
+    }
+
+    // =========================================================================
+    // GitHub issue #226 — markSucceeded()
+    // =========================================================================
+
+    public function test_mark_succeeded_stamps_the_meta_and_the_snapshot_then_reclaims_after_the_success_ttl(): void
+    {
+        $source = $this->root . '/plugins-src/demo-succeed';
+        mkdir($source, 0755, true);
+        file_put_contents($source . '/demo-succeed.php', "<?php\n// v1\n");
+
+        $mgr               = $this->manager();
+        $mgr->liveOverride = $source;
+
+        $snap = $mgr->capture('plugin', 'demo-succeed/demo-succeed.php', '1.0');
+        $this->assertNotSame('', $snap['snapshot_id']);
+
+        $dir = $this->snapshotsBase . '/' . $snap['snapshot_id'];
+
+        $mgr->markSucceeded($snap['snapshot_id']);
+
+        $meta = json_decode((string) file_get_contents($dir . '/meta.json'), true);
+        $this->assertArrayHasKey('succeeded_at', $meta, 'markSucceeded() must stamp the meta with a success marker');
+
+        // Age the snapshot past SUCCESS_RECLAIM_TTL_SECONDS (1h) but still
+        // well under GC_BACKSTOP_TTL_SECONDS (72h) — only the success
+        // marker's shorter TTL can explain an early reclaim here.
+        $meta['created_at'] = time() - (90 * 60);
+        file_put_contents($dir . '/meta.json', (string) json_encode($meta));
+
+        SnapshotManager::gcExpired();
+
+        $this->assertFalse(
+            is_dir($dir),
+            'a snapshot marked succeeded by markSucceeded() must reclaim ~1h after success, long before the 72h backstop'
+        );
+    }
+
+    public function test_mark_succeeded_is_a_safe_no_op_for_an_unknown_snapshot_id(): void
+    {
+        $mgr = $this->managerWithNoLiveSource();
+        $mgr->capture('plugin', 'warmup/warmup.php', '1.0'); // force the store to exist
+
+        // Must not throw even though this snapshot id was never captured.
+        $mgr->markSucceeded('snap_' . bin2hex(random_bytes(12)));
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_mark_succeeded_is_a_safe_no_op_when_the_snapshot_store_is_unavailable(): void
+    {
+        $mgr = new class extends SnapshotManager {
+            protected function snapshotBaseDir(): string
+            {
+                return '';
+            }
+        };
+
+        // Must not throw even though the store cannot be resolved at all.
+        $mgr->markSucceeded('snap_' . bin2hex(random_bytes(12)));
+
+        $this->addToAssertionCount(1);
     }
 
     // =========================================================================

--- a/apps/agent/tests/UpdateCommandTest.php
+++ b/apps/agent/tests/UpdateCommandTest.php
@@ -179,6 +179,11 @@ final class UpdateCommandTest extends TestCase
             public array $restored = [];
             /** Whether restore() should report success. */
             public bool $restoreSucceeds = true;
+            /**
+             * @var array<int,string> Snapshot ids passed to markSucceeded()
+             *     (GitHub issue #226).
+             */
+            public array $markedSucceeded = [];
 
             public function capture(string $type, string $slug, string $fromVersion): array
             {
@@ -203,6 +208,11 @@ final class UpdateCommandTest extends TestCase
                 // always report the snapshot present so that gate never blocks
                 // a restore this test otherwise expects.
                 return true;
+            }
+
+            public function markSucceeded(string $snapshotId): void
+            {
+                $this->markedSucceeded[] = $snapshotId;
             }
         };
     }
@@ -1693,6 +1703,11 @@ final class UpdateCommandTest extends TestCase
         return new class ($live, $payload) extends SnapshotManager {
             /** @var array<int,array{string,string,string}> */
             public array $captured = [];
+            /**
+             * @var array<int,string> Snapshot ids passed to markSucceeded()
+             *     (GitHub issue #226).
+             */
+            public array $markedSucceeded = [];
 
             public function __construct(private string $live, private string $payload)
             {
@@ -1718,6 +1733,11 @@ final class UpdateCommandTest extends TestCase
             public function resolvedRestorePaths(string $type, string $slug, string $snapshotId): array
             {
                 return ['live' => $this->live, 'payload' => $this->payload];
+            }
+
+            public function markSucceeded(string $snapshotId): void
+            {
+                $this->markedSucceeded[] = $snapshotId;
             }
         };
     }
@@ -1894,6 +1914,131 @@ final class UpdateCommandTest extends TestCase
 
         $this->assertSame('succeeded', $out['results'][0]['status'], 'the apply itself must still succeed');
         $this->assertFileDoesNotExist($this->watchdogMarkerFile(), 'an unresolvable live/payload path must silently skip arming, never affect the response');
+    }
+
+    // =========================================================================
+    // GitHub issue #226 — SnapshotManager::markSucceeded() call site
+    // =========================================================================
+
+    public function test_successful_apply_marks_the_snapshot_succeeded_without_disturbing_the_watchdog_arm(): void
+    {
+        $this->cleanWatchdogMarker();
+
+        $live    = sys_get_temp_dir() . '/wpmgr-mark-succeeded-live-' . bin2hex(random_bytes(6));
+        $payload = sys_get_temp_dir() . '/wpmgr-mark-succeeded-payload-' . bin2hex(random_bytes(6));
+        mkdir($live, 0755, true);
+        mkdir($payload, 0755, true);
+
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php'] = '5.0';
+
+        $snapshots = $this->spySnapshotsWithResolvedPaths($live, $payload);
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => '5.3']],
+        ]);
+
+        $this->assertSame('succeeded', $out['results'][0]['status']);
+        $this->assertSame(
+            ['snap_test123'],
+            $snapshots->markedSucceeded,
+            'GitHub issue #226: a genuinely successful apply must mark its captured snapshot succeeded'
+        );
+        $this->assertFileExists(
+            $this->watchdogMarkerFile(),
+            'marking the snapshot succeeded must not disturb the watchdog arm — the snapshot must still exist for it'
+        );
+
+        $this->rrmdir($live);
+        $this->rrmdir($payload);
+        $this->cleanWatchdogMarker();
+    }
+
+    public function test_failed_apply_does_not_mark_the_snapshot_succeeded(): void
+    {
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php']  = '5.0';
+        $runner->available['plugin:akismet/akismet.php'] = '5.3';
+        $runner->applySucceeds                           = false;
+
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $this->assertSame('failed', $out['results'][0]['status']);
+        $this->assertSame(
+            [],
+            $snapshots->markedSucceeded,
+            'GitHub issue #226: a failed apply must never mark its snapshot succeeded'
+        );
+    }
+
+    public function test_incomplete_apply_that_is_auto_restored_does_not_mark_the_snapshot_succeeded(): void
+    {
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:kadence-blocks/kadence-blocks.php']  = '3.2.0';
+        $runner->available['plugin:kadence-blocks/kadence-blocks.php'] = '3.2.1';
+        $runner->completeOverride['plugin:kadence-blocks/kadence-blocks.php'] = false;
+
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'kadence-blocks/kadence-blocks.php', 'version' => 'latest']],
+        ]);
+
+        $this->assertSame('failed', $out['results'][0]['status']);
+        $this->assertSame(
+            [],
+            $snapshots->markedSucceeded,
+            'GitHub issue #226: an incomplete apply that gets auto-restored must never mark its snapshot succeeded'
+        );
+    }
+
+    public function test_up_to_date_apply_does_not_mark_any_snapshot_succeeded(): void
+    {
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php']  = '5.3';
+        $runner->available['plugin:akismet/akismet.php'] = '5.3';
+
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'snapshot' => true,
+            'items'    => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => '5.3']],
+        ]);
+
+        $this->assertSame('up_to_date', $out['results'][0]['status']);
+        $this->assertSame(
+            [],
+            $snapshots->markedSucceeded,
+            'an up_to_date item (nothing changed) must never mark a snapshot succeeded'
+        );
+    }
+
+    public function test_core_succeeded_apply_never_marks_a_snapshot_succeeded(): void
+    {
+        // D3: core has no directory-level snapshot at all — snapshotId is
+        // always '' for core — so there is nothing for markSucceeded() to
+        // mark, even on a genuinely successful core apply.
+        $runner = $this->spyRunner();
+        $runner->versions['core:core']  = '6.4';
+        $runner->available['core:core'] = '6.5';
+
+        $snapshots = $this->spySnapshots();
+        $cmd       = new UpdateCommand($snapshots, $runner);
+
+        $out = $cmd->execute([], [
+            'items' => [['type' => 'core', 'slug' => '', 'version' => 'latest']],
+        ]);
+
+        $this->assertSame('succeeded', $out['results'][0]['status']);
+        $this->assertSame([], $snapshots->markedSucceeded);
     }
 
     /** Recursive delete used only for test fixture cleanup. */

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.61
+ * Version:           0.61.62
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.61');
+define('WPMGR_AGENT_VERSION', '0.61.62');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)


### PR DESCRIPTION
## Summary

Fixes #226 — pre-update rollback snapshots under `wp-content/uploads/wpmgr-snapshots/` accumulated indefinitely (thousands of files/inodes per fleet). Agent-only; no control-plane change; no change to update/backup/rollback behavior.

**Root cause:** the only cleanup ran via a WP-Cron event (dead on `DISABLE_WP_CRON` / idle sites) or opportunistically at the start of the *next* update, and a successful update never deleted its own snapshot — so a fleet that bulk-updated once and went quiet kept every snapshot forever.

**Fix:**
- **Reliable, WP-Cron-independent trigger:** a throttled `SnapshotManager::maybeGc()` (hourly, stamped-before-run, best-effort) invoked from the `plugins_loaded` boot path (`Plugin::maybeGcSnapshots`, enrolled-gated). GC now fires on ordinary agent activity, and sweeps already-accumulated snapshots on the first request after upgrade.
- **Prompt success reclaim:** `UpdateCommand` stamps the snapshot meta on a verified-successful apply; `gcExpired()` reclaims a *succeeded* snapshot past a 1h TTL, while unmarked ones (failed-rollback, orphan, crashed, core meta-only) keep the 72h backstop for manual recovery.
- **Safety floor unchanged:** never reclaims a snapshot younger than `MIN_KEEP_AGE_SECONDS` (600s) — covers the CP post-update health-probe rollback window (~1min) and the update-watchdog marker (300s). No #131 constant changed.
- Registers the new throttle option in `Lifecycle::ownedOptions()` for uninstall cleanup.

## Verification

- 14 new regression tests (throttle, cron-independent reclaim, two-tier TTL, survival floor, mark-on-success, boot wiring).
- Adversarial verify: **no reachable path deletes a still-needed snapshot**; fixes the reporter's exact idle-fleet scenario; 72h/stranded-aside paths proven byte-identical.
- Gates: `composer test` 2694 green, phpcs 0, `wp plugin check` 0 errors.

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of outdated update snapshots to prevent indefinite accumulation.
  * Successfully completed updates now allow their temporary snapshots to be reclaimed sooner.
  * Snapshot cleanup runs automatically for enrolled installations without relying solely on scheduled tasks.
  * Snapshots remain protected during the rollback-safe period.

* **Chores**
  * Updated the plugin version to 0.61.62.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->