### PR TITLE
chore(agent): ship readable wpmgr-rum.js source in-zip for wp.org (0.61.63)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ Thumbs.db
 wp-cli.phar
 wp-cli.phar.asc
 docs/security/wporg-t13-*.md
+docs/security/wporg-t14-*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.63] - 2026-07-16
+
+### Changed
+
+- The real-user-monitoring collector now also ships a readable, non-minified build (`assets/wpmgr-rum.js`) alongside the minified `assets/wpmgr-rum.min.js`, matching how the delay script already ships its readable source, so the distributed package includes human-readable source for every bundled script (the TypeScript source and build command remain documented in the readme and public repository). WordPress.org-directory transparency only; no runtime or behavior change.
+
 ## [0.61.62] - 2026-07-15
 
 ### Fixed

--- a/apps/agent/assets/wpmgr-rum.js
+++ b/apps/agent/assets/wpmgr-rum.js
@@ -1,0 +1,373 @@
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __getOwnPropSymbols = Object.getOwnPropertySymbols;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __propIsEnum = Object.prototype.propertyIsEnumerable;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __spreadValues = (a2, b2) => {
+    for (var prop in b2 || (b2 = {}))
+      if (__hasOwnProp.call(b2, prop))
+        __defNormalProp(a2, prop, b2[prop]);
+    if (__getOwnPropSymbols)
+      for (var prop of __getOwnPropSymbols(b2)) {
+        if (__propIsEnum.call(b2, prop))
+          __defNormalProp(a2, prop, b2[prop]);
+      }
+    return a2;
+  };
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // ../../node_modules/.pnpm/web-vitals@5.3.0/node_modules/web-vitals/dist/web-vitals.js
+  var e = -1;
+  var t = (t2) => {
+    addEventListener("pageshow", (n2) => {
+      n2.persisted && (e = n2.timeStamp, t2(n2));
+    }, true);
+  };
+  var n = (e2, t2, n2, i2) => {
+    let s2, o2;
+    return (r2) => {
+      t2.value >= 0 && (r2 || i2) && (o2 = t2.value - (s2 != null ? s2 : 0), (o2 || void 0 === s2) && (s2 = t2.value, t2.delta = o2, t2.rating = ((e3, t3) => e3 > t3[1] ? "poor" : e3 > t3[0] ? "needs-improvement" : "good")(t2.value, n2), e2(t2)));
+    };
+  };
+  var i = (e2) => {
+    requestAnimationFrame(() => requestAnimationFrame(e2));
+  };
+  var s = () => {
+    const e2 = performance.getEntriesByType("navigation")[0];
+    if (e2 && e2.responseStart > 0 && e2.responseStart < performance.now()) return e2;
+  };
+  var o = () => {
+    var _a, _b;
+    return (_b = (_a = s()) == null ? void 0 : _a.activationStart) != null ? _b : 0;
+  };
+  var r = (t2, n2 = -1) => {
+    const i2 = s();
+    let r2 = "navigate";
+    e >= 0 ? r2 = "back-forward-cache" : i2 && (document.prerendering || o() > 0 ? r2 = "prerender" : document.wasDiscarded ? r2 = "restore" : i2.type && (r2 = i2.type.replace(/_/g, "-")));
+    return { name: t2, value: n2, rating: "good", delta: 0, entries: [], id: "v5-".concat(Date.now(), "-").concat(Math.floor(8999999999999 * Math.random()) + 1e12), navigationType: r2 };
+  };
+  var c = /* @__PURE__ */ new WeakMap();
+  function a(e2, t2) {
+    let n2 = c.get(t2);
+    return n2 || (n2 = /* @__PURE__ */ new WeakMap(), c.set(t2, n2)), n2.get(e2) || n2.set(e2, new t2()), n2.get(e2);
+  }
+  var d = class {
+    constructor() {
+      __publicField(this, "t");
+      __publicField(this, "i", 0);
+      __publicField(this, "o", []);
+    }
+    h(e2) {
+      var _a;
+      if (e2.hadRecentInput) return;
+      const t2 = this.o[0], n2 = this.o.at(-1);
+      this.i && t2 && n2 && e2.startTime - n2.startTime < 1e3 && e2.startTime - t2.startTime < 5e3 ? (this.i += e2.value, this.o.push(e2)) : (this.i = e2.value, this.o = [e2]), (_a = this.t) == null ? void 0 : _a.call(this, e2);
+    }
+  };
+  var h = (e2, t2, n2 = {}) => {
+    try {
+      if (PerformanceObserver.supportedEntryTypes.includes(e2)) {
+        const i2 = new PerformanceObserver((e3) => {
+          queueMicrotask(() => {
+            t2(e3.getEntries());
+          });
+        });
+        return i2.observe(__spreadValues({ type: e2, buffered: true }, n2)), i2;
+      }
+    } catch (e3) {
+    }
+  };
+  var f = (e2) => {
+    let t2 = false;
+    return () => {
+      t2 || (e2(), t2 = true);
+    };
+  };
+  var l = -1;
+  var u = /* @__PURE__ */ new Set();
+  var m = () => "hidden" !== document.visibilityState || document.prerendering ? 1 / 0 : 0;
+  var p = (e2) => {
+    if ("hidden" === document.visibilityState) {
+      if ("visibilitychange" === e2.type) for (const e3 of u) e3();
+      isFinite(l) || (l = "visibilitychange" === e2.type ? e2.timeStamp : 0, removeEventListener("prerenderingchange", p, true));
+    }
+  };
+  var g = () => {
+    var _a;
+    if (l < 0) {
+      const e2 = o(), n2 = document.prerendering ? void 0 : (_a = globalThis.performance.getEntriesByType("visibility-state").find((t2) => "hidden" === t2.name && t2.startTime >= e2)) == null ? void 0 : _a.startTime;
+      l = n2 != null ? n2 : m(), addEventListener("visibilitychange", p, true), addEventListener("prerenderingchange", p, true), t(() => {
+        setTimeout(() => {
+          l = m();
+        });
+      });
+    }
+    return { get firstHiddenTime() {
+      return l;
+    }, onHidden(e2) {
+      u.add(e2);
+    } };
+  };
+  var v = (e2) => {
+    document.prerendering ? addEventListener("prerenderingchange", e2, true) : e2();
+  };
+  var y = [1800, 3e3];
+  var T = (e2, s2 = {}) => {
+    v(() => {
+      const c2 = g();
+      let a2, d2 = r("FCP");
+      const f2 = h("paint", (e3) => {
+        for (const t2 of e3) "first-contentful-paint" === t2.name && (f2.disconnect(), t2.startTime < c2.firstHiddenTime && (d2.value = Math.max(t2.startTime - o(), 0), d2.entries.push(t2), a2(true)));
+      });
+      f2 && (a2 = n(e2, d2, y, s2.reportAllChanges), t((t2) => {
+        d2 = r("FCP"), a2 = n(e2, d2, y, s2.reportAllChanges), i(() => {
+          d2.value = performance.now() - t2.timeStamp, a2(true);
+        });
+      }));
+    });
+  };
+  var E = [0.1, 0.25];
+  var b = (e2, s2 = {}) => {
+    const o2 = g();
+    T(f(() => {
+      let c2, f2 = r("CLS", 0);
+      const l2 = a(s2, d), u2 = (e3) => {
+        for (const t2 of e3) l2.h(t2);
+        l2.i > f2.value && (f2.value = l2.i, f2.entries = l2.o, c2());
+      }, m2 = h("layout-shift", u2);
+      m2 && (c2 = n(e2, f2, E, s2.reportAllChanges), o2.onHidden(() => {
+        u2(m2.takeRecords()), c2(true);
+      }), t(() => {
+        l2.i = 0, f2 = r("CLS", 0), c2 = n(e2, f2, E, s2.reportAllChanges), i(c2);
+      }), setTimeout(c2));
+    }));
+  };
+  var L = 0;
+  var P = 1 / 0;
+  var _ = 0;
+  var M = (e2) => {
+    for (const t2 of e2) t2.interactionId && (P = Math.min(P, t2.interactionId), _ = Math.max(_, t2.interactionId), L = _ ? (_ - P) / 7 + 1 : 0);
+  };
+  var w;
+  var C = () => {
+    var _a;
+    return w ? L : (_a = performance.interactionCount) != null ? _a : 0;
+  };
+  var I = () => {
+    "interactionCount" in performance || w || (w = h("event", M, { durationThreshold: 0 }));
+  };
+  var F = 0;
+  var k = class {
+    constructor() {
+      __publicField(this, "l", []);
+      __publicField(this, "u", /* @__PURE__ */ new Map());
+      __publicField(this, "m");
+      __publicField(this, "p");
+    }
+    v() {
+      F = C(), this.l.length = 0, this.u.clear();
+    }
+    T() {
+      const e2 = Math.min(this.l.length - 1, Math.floor((C() - F) / 50));
+      return this.l[e2];
+    }
+    h(e2) {
+      var _a, _b;
+      if ((_a = this.m) == null ? void 0 : _a.call(this, e2), !e2.interactionId && "first-input" !== e2.entryType) return;
+      const t2 = this.l.at(-1);
+      let n2 = this.u.get(e2.interactionId);
+      if (n2 || this.l.length < 10 || e2.duration > t2.L) {
+        if (n2 ? e2.duration > n2.L ? (n2.entries = [e2], n2.L = e2.duration) : e2.duration === n2.L && e2.startTime === n2.entries[0].startTime && n2.entries.push(e2) : (n2 = { id: e2.interactionId, entries: [e2], L: e2.duration }, this.u.set(n2.id, n2), this.l.push(n2)), this.l.sort((e3, t3) => t3.L - e3.L), this.l.length > 10) {
+          const e3 = this.l.splice(10);
+          for (const t3 of e3) this.u.delete(t3.id);
+        }
+        (_b = this.p) == null ? void 0 : _b.call(this, n2);
+      }
+    }
+  };
+  var A = (e2) => {
+    const t2 = globalThis.requestIdleCallback || setTimeout, n2 = globalThis.cancelIdleCallback || clearTimeout;
+    if ("hidden" === document.visibilityState) e2();
+    else {
+      const i2 = f(e2);
+      let s2 = -1;
+      const o2 = () => {
+        n2(s2), i2();
+      };
+      addEventListener("visibilitychange", o2, { once: true, capture: true }), s2 = t2(() => {
+        removeEventListener("visibilitychange", o2, { capture: true }), i2();
+      });
+    }
+  };
+  var B = [200, 500];
+  var S = (e2, i2 = {}) => {
+    if (!globalThis.PerformanceEventTiming || !("interactionId" in PerformanceEventTiming.prototype)) return;
+    const s2 = g();
+    v(() => {
+      var _a;
+      I();
+      let o2, c2 = r("INP");
+      const d2 = a(i2, k), f2 = (e3) => {
+        A(() => {
+          for (const t3 of e3) d2.h(t3);
+          const t2 = d2.T();
+          t2 && t2.L !== c2.value && (c2.value = t2.L, c2.entries = t2.entries, o2());
+        });
+      }, l2 = h("event", f2, { durationThreshold: (_a = i2.durationThreshold) != null ? _a : 40 });
+      o2 = n(e2, c2, B, i2.reportAllChanges), l2 && (l2.observe({ type: "first-input", buffered: true }), s2.onHidden(() => {
+        f2(l2.takeRecords()), o2(true);
+      }), t(() => {
+        d2.v(), c2 = r("INP"), o2 = n(e2, c2, B, i2.reportAllChanges);
+      }));
+    });
+  };
+  var q = class {
+    constructor() {
+      __publicField(this, "m");
+    }
+    h(e2) {
+      var _a;
+      (_a = this.m) == null ? void 0 : _a.call(this, e2);
+    }
+  };
+  var N = [2500, 4e3];
+  var x = (e2, s2 = {}) => {
+    v(() => {
+      const c2 = g();
+      let d2, l2 = r("LCP");
+      const u2 = a(s2, q), m2 = (e3) => {
+        s2.reportAllChanges || (e3 = e3.slice(-1));
+        for (const t2 of e3) u2.h(t2), t2.startTime < c2.firstHiddenTime && (l2.value = Math.max(t2.startTime - o(), 0), l2.entries = [t2], d2());
+      }, p2 = h("largest-contentful-paint", m2);
+      if (p2) {
+        d2 = n(e2, l2, N, s2.reportAllChanges);
+        const o2 = f(() => {
+          m2(p2.takeRecords()), p2.disconnect(), d2(true);
+        }), c3 = (e3) => {
+          e3.isTrusted && (A(o2), removeEventListener(e3.type, c3, { capture: true }));
+        };
+        for (const e3 of ["keydown", "click", "visibilitychange"]) addEventListener(e3, c3, { capture: true });
+        t((t2) => {
+          l2 = r("LCP"), d2 = n(e2, l2, N, s2.reportAllChanges), i(() => {
+            l2.value = performance.now() - t2.timeStamp, d2(true);
+          });
+        });
+      }
+    });
+  };
+  var H = [800, 1800];
+  var O = (e2) => {
+    document.prerendering ? v(() => O(e2)) : "complete" !== document.readyState ? addEventListener("load", () => O(e2), true) : setTimeout(e2);
+  };
+  var W = (e2, i2 = {}) => {
+    let c2 = r("TTFB"), a2 = n(e2, c2, H, i2.reportAllChanges);
+    O(() => {
+      const d2 = s();
+      d2 && (c2.value = Math.max(d2.responseStart - o(), 0), c2.entries = [d2], a2(true), t(() => {
+        c2 = r("TTFB", 0), a2 = n(e2, c2, H, i2.reportAllChanges), a2(true);
+      }));
+    });
+  };
+
+  // src/vitals.ts
+  function deviceType() {
+    var _a, _b;
+    try {
+      if ((_a = navigator.userAgentData) == null ? void 0 : _a.mobile) {
+        return window.innerWidth >= 768 ? "tablet" : "mobile";
+      }
+      const ua = (_b = navigator.userAgent) != null ? _b : "";
+      if (/tablet|ipad|playbook|silk/i.test(ua)) {
+        return "tablet";
+      }
+      if (/mobile|android|iphone|ipod|blackberry|iemobile|opera mini/i.test(ua)) {
+        return "mobile";
+      }
+      return "desktop";
+    } catch (e2) {
+      return "desktop";
+    }
+  }
+  function connType() {
+    var _a;
+    try {
+      if (!navigator.onLine) {
+        return "offline";
+      }
+      const et = (_a = navigator.connection) == null ? void 0 : _a.effectiveType;
+      if (et === "4g" || et === "3g" || et === "2g" || et === "slow-2g") {
+        return et;
+      }
+      return "unknown";
+    } catch (e2) {
+      return "unknown";
+    }
+  }
+  function stripQuery(href) {
+    try {
+      const u2 = new URL(href);
+      return u2.origin + u2.pathname;
+    } catch (e2) {
+      return href;
+    }
+  }
+  function metricValue(name, value) {
+    if (name === "CLS") {
+      return Math.round(value * 1e3);
+    }
+    return Math.round(value);
+  }
+  function makeSender(config, pageUrl, device, conn) {
+    return (m2) => {
+      try {
+        const body = JSON.stringify({
+          key: config.key,
+          url: pageUrl,
+          metric: m2.name.toLowerCase(),
+          value: metricValue(m2.name, m2.value),
+          device,
+          conn
+        });
+        const blob = new Blob([body], { type: "text/plain" });
+        navigator.sendBeacon(config.url, blob);
+      } catch (e2) {
+      }
+    };
+  }
+  function init() {
+    try {
+      if (!("sendBeacon" in navigator)) {
+        return;
+      }
+      if (typeof window.PerformanceObserver === "undefined") {
+        return;
+      }
+      const config = window.__WPMGR_RUM__;
+      if (!config || typeof config.key !== "string" || config.key === "") {
+        return;
+      }
+      if (typeof config.url !== "string" || config.url === "") {
+        return;
+      }
+      const rate = typeof config.rate === "number" ? config.rate : 1;
+      if (Math.random() >= rate) {
+        return;
+      }
+      const pageUrl = stripQuery(window.location.href);
+      const device = deviceType();
+      const conn = connType();
+      const send = makeSender(config, pageUrl, device, conn);
+      W(send);
+      T(send);
+      x(send);
+      b(send);
+      S(send);
+    } catch (e2) {
+    }
+  }
+
+  // src/index.ts
+  init();
+})();

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -171,7 +171,7 @@ No other third-party libraries are bundled in the plugin zip. Image encoding and
 
 This plugin ships two minified JavaScript files. Their human-readable source and build tooling are in the public repository at https://github.com/mosamlife/wpmgr.
 
-* **assets/wpmgr-rum.min.js** -- Real User Monitoring collector. TypeScript source: apps/tracker/src/index.ts and apps/tracker/src/vitals.ts. Build: cd apps/tracker && npm install && npm run build (esbuild IIFE bundle, also bundles Google web-vitals under its Apache-2.0 license).
+* **assets/wpmgr-rum.min.js** -- Real User Monitoring collector. The readable, non-minified build ships alongside the plugin at assets/wpmgr-rum.js. TypeScript source: apps/tracker/src/index.ts and apps/tracker/src/vitals.ts. Build: cd apps/tracker && npm install && npm run build (esbuild IIFE bundle, also bundles Google web-vitals under its Apache-2.0 license; the same build produces both the minified and readable outputs).
 * **assets/wpmgr-delay.min.js** -- deferred-script runtime. The readable source ships alongside the plugin at assets/wpmgr-delay.js in the same repository.
 
 == Screenshots ==

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.62
+ * Version:           0.61.63
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.62');
+define('WPMGR_AGENT_VERSION', '0.61.63');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/tracker/build.mjs
+++ b/apps/tracker/build.mjs
@@ -1,8 +1,13 @@
 /**
  * esbuild IIFE bundler for the @wpmgr/tracker RUM collector.
  *
- * Produces a single minified IIFE: dist/wpmgr-rum.min.js
- * Then copies it into the agent assets directory alongside wpmgr-delay.min.js.
+ * Produces a minified IIFE (dist/wpmgr-rum.min.js) and a readable,
+ * non-minified IIFE built from the identical entry/bundle/format/target
+ * (dist/wpmgr-rum.js), so the plugin zip ships a human-readable source
+ * alongside the minified asset it actually loads (mirrors wpmgr-delay.js /
+ * wpmgr-delay.min.js).
+ *
+ * Both are copied into the agent assets directory.
  *
  * Run with: node build.mjs
  */
@@ -16,18 +21,15 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const DIST = join(__dirname, 'dist');
 const OUT_FILE = join(DIST, 'wpmgr-rum.min.js');
+const OUT_FILE_READABLE = join(DIST, 'wpmgr-rum.js');
 const AGENT_ASSETS = join(__dirname, '../../apps/agent/assets');
 
-mkdirSync(DIST, { recursive: true });
-
-await build({
+const SHARED_OPTIONS = {
   entryPoints: [join(__dirname, 'src/index.ts')],
   bundle: true,
-  minify: true,
   format: 'iife',
   platform: 'browser',
   target: ['es2017', 'chrome70', 'firefox68', 'safari12'],
-  outfile: OUT_FILE,
   // web-vitals ships as a bundled dependency; include it entirely.
   // No external dependencies: the whole bundle must be self-contained.
   external: [],
@@ -36,11 +38,30 @@ await build({
     'process.env.NODE_ENV': '"production"',
   },
   legalComments: 'none',
+};
+
+mkdirSync(DIST, { recursive: true });
+
+await build({
+  ...SHARED_OPTIONS,
+  minify: true,
+  outfile: OUT_FILE,
 });
 
-// Copy the artifact into the agent's assets directory.
+// Readable, non-minified build of the exact same entry/bundle/format/target
+// as above, for the wp.org readable-source requirement.
+await build({
+  ...SHARED_OPTIONS,
+  minify: false,
+  outfile: OUT_FILE_READABLE,
+});
+
+// Copy the artifacts into the agent's assets directory.
 mkdirSync(AGENT_ASSETS, { recursive: true });
 copyFileSync(OUT_FILE, join(AGENT_ASSETS, 'wpmgr-rum.min.js'));
+copyFileSync(OUT_FILE_READABLE, join(AGENT_ASSETS, 'wpmgr-rum.js'));
 
 console.log('Built: dist/wpmgr-rum.min.js');
 console.log('Copied -> apps/agent/assets/wpmgr-rum.min.js');
+console.log('Built: dist/wpmgr-rum.js');
+console.log('Copied -> apps/agent/assets/wpmgr-rum.js');


### PR DESCRIPTION
## Summary

WordPress.org directory review (T14) repeatedly flagged `assets/wpmgr-rum.min.js` as lacking a readable source in the package, even though the readme documents the TypeScript source + public repo. The delay script already ships its readable `assets/wpmgr-delay.js` in-zip; the RUM script only linked out — that asymmetry is the likely cause of the repeat flag (the reviewer's only twice-flagged item).

- **`apps/tracker/build.mjs`**: emit a second, non-minified esbuild output (`assets/wpmgr-rum.js`) from the same entry/config as the minified bundle. `wpmgr-rum.min.js` is **byte-identical** (sha256 unchanged).
- **`apps/agent/readme.txt`** `== Source code ==`: note the readable build ships at `assets/wpmgr-rum.js`.
- **`.gitignore`**: gitignore the T14 reply/analysis docs (they name precedent plugins; must not reach the committed tree / docs-vocab gate).

Transparency-only; no runtime or behavior change.

## Context

A full adversarial analysis of the T14 review found **zero regressions** and **zero strict must-fixes** against 0.61.62 — this in-zip readable source is the single high-value action. The rest of T14 re-flags intentional patterns (streaming `mysqli`, operator autologin, pre-auth 2FA, page-cache inline output, backup-tool path resolution), re-defended in the reviewer reply.

## Verification
- `phpunit` 2694 green, `phpcs` 0
- tracker `typecheck` green
- wp.org zip (`agent-zip-wporg`) verified: both `wpmgr-rum.js` + `wpmgr-delay.js` ship readable next to their `.min.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real User Monitoring now includes a readable, non-minified script alongside the optimized build, improving transparency and inspection of distributed browser scripts.
* **Documentation**
  * Updated source-code documentation with build instructions, licensing information, and details about the available script outputs.
* **Chores**
  * Released version 0.61.63 with updated package metadata and changelog information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->