### PR TITLE
fix(agent,web): recover stalled scheduled backups (#232) + org-switch routing (#233) — 0.61.64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
-## [0.61.63] - 2026-07-16
+## [0.61.64] - 2026-07-16
+
+### Fixed
+
+- Scheduled backups no longer stall permanently at "queued" and are now reliably recovered (GH #232). A scheduled backup started only through WordPress cron (with a single in-process fallback that was active only on hosts where the loopback was gated), and its self-healing watchdog ran on that same cron; on a quiet, off-peak, or `DISABLE_WP_CRON` site the run could silently never start and the watchdog could silently never fire, leaving the task at "queued" forever with no error and the built-in resume never engaging (reported across a fleet as a rotating ~10-30% of sites failing nightly). The backup now always starts in-process (independent of WordPress cron), a request-driven sweeper re-dispatches any genuinely stalled task without needing a cron tick (so resume actually engages), and each stalled row now records how far it got for diagnosis. Concurrent execution of the same backup is prevented by a connection-independent file lock in addition to a database advisory lock, so a dropped database connection mid-dump can never let a second runner corrupt the in-progress backup. Agent only.
+- The dashboard no longer shows a "no website" error when you switch organizations while viewing a single site (GH #233). If the site you were viewing does not belong to the newly selected organization, you are now routed to that organization's Sites list instead of a dead page.
 
 ### Changed
 

--- a/apps/agent/includes/backup/class-backup-janitor.php
+++ b/apps/agent/includes/backup/class-backup-janitor.php
@@ -7,12 +7,17 @@
  * `completed` phase transition — the failure path deletes the
  * `wpmgr_backup_tasks` row without cleaning scratch, leaking the DB dump,
  * zip parts, and chunk files of every failed run forever. This class sweeps
- * those leaked directories on an age-gated cadence. Full design rationale
- * (the "a just-failed run has no task row" subtlety, the age-threshold
- * reasoning, and the task-row veto) is in the design notes at the bottom of
- * this file — kept there so the ABSPATH direct-access guard below stays
- * within the first ~50 lines of the file, which is what Plugin Check's
- * Direct_File_Access_Check regex fallback scans.
+ * those leaked directories on an age-gated cadence. GH #232 follow-up: the
+ * same sweep also reclaims the sibling `<snapshot_id>.lock` coordination
+ * FILE TaskRunner's flock() guard creates alongside each run directory —
+ * TaskRunner::run() reclaims its own on a normal terminal exit, but a run
+ * that crashes before reaching that cleanup (fatal/OOM/SIGKILL) leaks the
+ * lock file exactly like it always leaked the run directory. Full design
+ * rationale (the "a just-failed run has no task row" subtlety, the
+ * age-threshold reasoning, and the task-row veto) is in the design notes at
+ * the bottom of this file — kept there so the ABSPATH direct-access guard
+ * below stays within the first ~50 lines of the file, which is what Plugin
+ * Check's Direct_File_Access_Check regex fallback scans.
  *
  * @package WPMgr\Agent\Backup
  */
@@ -80,6 +85,43 @@ class BackupJanitor
         $now = time();
         foreach ($items as $item) {
             if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            // GH #232 follow-up: TaskRunner's flock() coordination file,
+            // `<snapshot_id>.lock` — created alongside (never inside) the
+            // per-snapshot run directory, so it is resolvable even before
+            // that directory exists (see TaskRunner::fileLockPath()'s doc).
+            // TaskRunner::run()'s own `finally` reclaims a run's OWN lock
+            // file once it reaches a genuinely terminal outcome, but a run
+            // that crashes before ever reaching that `finally` (fatal/OOM/
+            // SIGKILL) leaks it forever — the exact same class of leak GH
+            // #151 exists to fix for the run DIRECTORY, now for this
+            // sibling artifact. Same age gate + isActiveRun() veto as the
+            // directory sweep below; a file, not a directory, so it is
+            // reclaimed with a plain unlink rather than deleteDir().
+            if (preg_match('/^[0-9a-fA-F-]{36}\.lock$/', $item) === 1) {
+                $lockFile = $base . '/' . $item;
+                if (!is_file($lockFile) || is_link($lockFile)) {
+                    continue;
+                }
+
+                $lockMtime = @filemtime($lockFile);
+                if ($lockMtime === false) {
+                    // Fail-safe: cannot determine age — retain rather than
+                    // risk deleting a lock a still-running process holds.
+                    continue;
+                }
+                if (($now - $lockMtime) < self::RUNS_GC_AGE_SECONDS) {
+                    continue; // Too fresh — could still belong to an active run.
+                }
+
+                $snapshotId = substr($item, 0, -5); // Strip the '.lock' suffix.
+                if ($j->isActiveRun($snapshotId)) {
+                    continue; // Belt-and-suspenders: the task row says it's still live.
+                }
+
+                wp_delete_file($lockFile);
                 continue;
             }
 

--- a/apps/agent/includes/backup/class-task-runner.php
+++ b/apps/agent/includes/backup/class-task-runner.php
@@ -171,6 +171,60 @@ final class TaskRunner
      * resume from). NEVER throws — top-level catch translates any escape into
      * a `failed` phase + progress post.
      *
+     * GitHub issue #232: two independent, layered mutual-exclusion guards are
+     * taken before any phase work, because the now-guaranteed double-fire of
+     * the in-process shutdown-function runner (BackupCommand::execute()
+     * registers it unconditionally) racing the separate FPM worker
+     * `wp_schedule_single_event('wpmgr_backup_run')` + `spawn_cron()` dispatch
+     * (Watchdog::dispatch()) — and now also the WP-Cron-independent
+     * Watchdog::sweepStalled() reaper — means two or more processes CAN
+     * legitimately reach run() for the same snapshot_id at nearly the same
+     * instant:
+     *
+     *   1. GET_LOCK(name, 0) — a fast, cheap, cross-process reject. Grants a
+     *      MySQL named lock to AT MOST one session at a time; a non-blocking
+     *      second caller gets '0' immediately. Adversarial review finding
+     *      (post-ship): GET_LOCK is scoped to $wpdb's OWN mysqli CONNECTION
+     *      and is SILENTLY released the instant that connection drops — a
+     *      short `wait_timeout` on a managed host, a MySQL restart/failover,
+     *      or `$wpdb->check_connection()` auto-reconnecting after "server
+     *      has gone away" can all sever the connection mid-backup (e.g.
+     *      during a large-table dump in DbDumper, which streams over its own
+     *      separate mysqli handle and only calls back to $wpdb once per
+     *      table). The winner's session-scoped lock vanishes while the
+     *      winner keeps running — a SECOND caller (e.g. the reaper, once
+     *      last_progress_at goes stale) can then legitimately win GET_LOCK
+     *      while the first is still alive, so GET_LOCK ALONE is NOT
+     *      sufficient for correctness; it is now only the fast early-reject.
+     *   2. flock(LOCK_EX|LOCK_NB) on a deterministic per-snapshot lock file
+     *      (see fileLockPath()) — the AUTHORITATIVE guard. It is entirely
+     *      independent of $wpdb's connection state: the OS holds it for as
+     *      long as this PHP process is alive, and releases it automatically
+     *      the instant the process exits for ANY reason (including a
+     *      SIGKILL that skips every PHP-level `finally`) — so a second
+     *      caller's non-blocking acquire attempt correctly reports
+     *      "contended" for as long as the first is genuinely still running,
+     *      regardless of what happened to its DB connection in the
+     *      meantime. flock() is a single-node primitive — correct here
+     *      because a given site's backup always runs on the one WP node
+     *      whose local disk holds the scratch dir.
+     *
+     * Guard order: GET_LOCK first (cheap, no filesystem I/O) — a '0' is a
+     * fast reject with no need to even attempt the flock. Otherwise ('1' or
+     * null) the flock is attempted; losing IT is authoritative and rejects
+     * regardless of the GET_LOCK outcome (this is exactly what closes the
+     * dead-connection gap: GET_LOCK can hand out '1' to a second caller once
+     * the true owner's connection has silently dropped, but the true owner's
+     * OS-level flock is untouched by that and still rejects the second
+     * caller). A loser via EITHER guard writes the SAME lock_contended
+     * breadcrumb and returns WITHOUT mutating phase. If flock itself cannot
+     * even be attempted (path unresolvable, or the filesystem/permissions
+     * prevent opening the lock file — e.g. an exotic FS without flock()
+     * support), that degrades SAFELY to today's GET_LOCK-only behavior
+     * rather than blocking the run; the phase machine is already
+     * idempotent/re-entrant and the CP tolerates duplicate presigns via a
+     * 422, so that worst case is no worse than pre-#232 behavior.
+     *
      * @return string Terminal phase reached this invocation. One of
      *                PHASE_COMPLETED, PHASE_FAILED, or — if a future phase
      *                handler yields mid-run on a soft cap — the in-progress
@@ -183,6 +237,75 @@ final class TaskRunner
         @ignore_user_abort(true);
 
         $currentPhase = self::PHASE_QUEUED;
+
+        // ---- GH #232 guard 1: GET_LOCK — fast, cheap, cross-process reject.
+        //   '1'  => we won the lock — proceed to the (authoritative) flock
+        //           check below, and RELEASE_LOCK in the finally regardless
+        //           of how this invocation ends.
+        //   '0'  => another session already holds the lock and is provably
+        //           making progress (or about to) — write a lock_contended
+        //           breadcrumb and return WITHOUT mutating phase. Fast
+        //           reject: never even attempts the flock.
+        //   null => GET_LOCK() is unsupported (non-MySQL $wpdb, or the query
+        //           itself failed) — fall through to the flock check, which
+        //           is now the sole guard for this invocation.
+        $lockToken = $this->getLock();
+        if ($lockToken === '0') {
+            try {
+                $this->recordLockContended();
+            } catch (\Throwable $_) {
+                // Swallow — a breadcrumb write failure must never propagate
+                // from the loser path; run() never throws.
+            }
+            try {
+                $task = $this->loadTask();
+                return $task !== null ? (string) $task['phase'] : self::PHASE_QUEUED;
+            } catch (\Throwable $_) {
+                return self::PHASE_QUEUED;
+            }
+        }
+        $lockHeld = ($lockToken === '1');
+
+        // ---- GH #232 guard 2: flock — connection-independent, AUTHORITATIVE.
+        // Attempted regardless of the GET_LOCK outcome above ('1' or null):
+        // this is precisely what catches the dead-$wpdb-connection scenario
+        // where GET_LOCK handed out '1' to a second caller because the true
+        // owner's MySQL session silently dropped mid-backup while the owner
+        // (and its flock) is still alive.
+        $fileLock = $this->acquireFileLock();
+        if ($fileLock['contended']) {
+            // Authoritative loser. Release the GET_LOCK we may have just won
+            // (cleanup hygiene — this session is not doing any further work
+            // that needs it) before writing the SAME lock_contended
+            // breadcrumb the GET_LOCK-loser path above uses.
+            if ($lockHeld) {
+                $this->releaseLock();
+            }
+            try {
+                $this->recordLockContended();
+            } catch (\Throwable $_) {
+                // Swallow — see the GET_LOCK-loser path above.
+            }
+            try {
+                $task = $this->loadTask();
+                return $task !== null ? (string) $task['phase'] : self::PHASE_QUEUED;
+            } catch (\Throwable $_) {
+                return self::PHASE_QUEUED;
+            }
+        }
+        /** @var resource|null $fileLockHandle */
+        $fileLockHandle = $fileLock['handle'];
+
+        // GH #232 lock-file GC follow-up: set to true at every point this
+        // invocation reaches a TERMINAL outcome for the snapshot (already
+        // terminal on load, completed, or failed) — never on a loser return
+        // above (those return before this point) and never left false by an
+        // in-progress run, since every path through the try/catch below ends
+        // in exactly one of the three terminal returns. Read in the
+        // `finally` to decide whether OUR OWN lock file (the one this
+        // invocation created/held) should be unlinked now that the snapshot
+        // will never be re-entered again.
+        $terminal = false;
 
         try {
             // ---- Seed or load the task row. ------------------------------
@@ -201,7 +324,23 @@ final class TaskRunner
 
             // Terminal? Re-entry is a no-op.
             if ($currentPhase === self::PHASE_COMPLETED || $currentPhase === self::PHASE_FAILED) {
+                $terminal = true;
                 return $currentPhase;
+            }
+
+            // GH #232: stamp the runner_started breadcrumb now that we hold
+            // at least one real exclusivity guard (GET_LOCK and/or flock) and
+            // have a loaded/seeded row. Feeds the observability ladder
+            // alongside Watchdog::dispatch()'s dispatch_entered stamp:
+            //   no stage + last_progress_at==started_at => hook never fired
+            //   stage=dispatch_entered                  => hook fired, runner never advanced
+            //   stage=runner_started                     => a lock held, first phase failed to persist
+            //   phase past 'queued'                      => advanced
+            // Never stamped when BOTH guards were unavailable (a fully
+            // degraded environment — no lock semantics apply there at all).
+            if ($lockHeld || $fileLockHandle !== null) {
+                $subState['stage'] = 'runner_started';
+                $this->saveTaskState($currentPhase, $subState);
             }
 
             // ---- Phase dispatch loop. ------------------------------------
@@ -215,6 +354,12 @@ final class TaskRunner
                         // First entry: announce we're alive and pick the next phase.
                         $this->postProgress('queued', ['kind' => $this->kind(), 'started_at' => time()]);
                         $next = $this->nextAfterQueued();
+                        \WPMgr\Agent\Support\DebugLog::write(sprintf(
+                            'WPMgr TaskRunner: advancing phase %s -> %s for snapshot %s',
+                            $currentPhase,
+                            $next,
+                            $this->snapshotId()
+                        ));
                         $this->saveTaskState($next, $subState);
                         $currentPhase = $next;
                         break;
@@ -222,24 +367,48 @@ final class TaskRunner
                     case self::PHASE_DUMPING_DB:
                         $subState = $this->runDumpingDb($subState);
                         $next     = $this->nextAfterDumpingDb();
+                        \WPMgr\Agent\Support\DebugLog::write(sprintf(
+                            'WPMgr TaskRunner: advancing phase %s -> %s for snapshot %s',
+                            $currentPhase,
+                            $next,
+                            $this->snapshotId()
+                        ));
                         $this->saveTaskState($next, $subState);
                         $currentPhase = $next;
                         break;
 
                     case self::PHASE_ARCHIVING_FILES:
                         $subState = $this->runArchivingFiles($subState);
+                        \WPMgr\Agent\Support\DebugLog::write(sprintf(
+                            'WPMgr TaskRunner: advancing phase %s -> %s for snapshot %s',
+                            $currentPhase,
+                            self::PHASE_ENCRYPTING_UPLOADING,
+                            $this->snapshotId()
+                        ));
                         $this->saveTaskState(self::PHASE_ENCRYPTING_UPLOADING, $subState);
                         $currentPhase = self::PHASE_ENCRYPTING_UPLOADING;
                         break;
 
                     case self::PHASE_ENCRYPTING_UPLOADING:
                         $subState = $this->runEncryptingUploading($subState);
+                        \WPMgr\Agent\Support\DebugLog::write(sprintf(
+                            'WPMgr TaskRunner: advancing phase %s -> %s for snapshot %s',
+                            $currentPhase,
+                            self::PHASE_SUBMITTING_MANIFEST,
+                            $this->snapshotId()
+                        ));
                         $this->saveTaskState(self::PHASE_SUBMITTING_MANIFEST, $subState);
                         $currentPhase = self::PHASE_SUBMITTING_MANIFEST;
                         break;
 
                     case self::PHASE_SUBMITTING_MANIFEST:
                         $this->runSubmittingManifest($subState);
+                        \WPMgr\Agent\Support\DebugLog::write(sprintf(
+                            'WPMgr TaskRunner: advancing phase %s -> %s for snapshot %s',
+                            $currentPhase,
+                            self::PHASE_COMPLETED,
+                            $this->snapshotId()
+                        ));
                         $this->saveTaskState(self::PHASE_COMPLETED, $subState);
                         $currentPhase = self::PHASE_COMPLETED;
                         break;
@@ -253,6 +422,7 @@ final class TaskRunner
             $this->cleanupOnCompleted();
             $this->postProgress(self::PHASE_COMPLETED, ['snapshot_id' => $this->snapshotId()]);
 
+            $terminal = true;
             return self::PHASE_COMPLETED;
         } catch (\Throwable $e) {
             \WPMgr\Agent\Support\DebugLog::write('WPMgr TaskRunner: phase ' . $currentPhase . ' failed: ' . $e->getMessage());
@@ -292,7 +462,319 @@ final class TaskRunner
                 // Swallow.
             }
 
+            $terminal = true;
             return self::PHASE_FAILED;
+        } finally {
+            // GH #232: release BOTH guards regardless of how this invocation
+            // ends (completed, failed, or an escape the outer catch didn't
+            // anticipate) — never on the loser/no-lock-held paths above,
+            // which already returned and hold nothing to release here.
+            if ($lockHeld) {
+                $this->releaseLock();
+            }
+            if ($fileLockHandle !== null) {
+                // Release the flock FIRST (LOCK_UN + fclose) — only THEN,
+                // with the fd closed, unlink the lock file itself. Doing it
+                // in this order (never unlink-before-release) avoids any
+                // platform-specific flock-vs-unlink-on-an-open-fd subtlety.
+                $this->releaseFileLock($fileLockHandle);
+
+                // GH #232 lock-file GC follow-up: only the WINNER that
+                // brought this snapshot to a genuinely terminal state
+                // reclaims its own lock file — never on a contended-loser
+                // return (those exit above, before this finally is even
+                // reached) and never mid-run, so an in-flight winner's lock
+                // file is never removed out from under a legitimately
+                // waiting resumer. A crashed run that never reaches this
+                // `finally` at all (fatal/OOM/SIGKILL) leaks its lock file
+                // exactly like it always leaked its scratch dir before GH
+                // #151 — BackupJanitor::gcRuns() is the age-gated backstop
+                // for both.
+                if ($terminal) {
+                    $this->cleanupFileLock();
+                }
+            }
+        }
+    }
+
+    // ==================================================================
+    // Advisory run-lock (GitHub issue #232)
+    // ==================================================================
+
+    /**
+     * MySQL advisory-lock name for this snapshot's run. 9 + 36 = 45 chars,
+     * well under MySQL's 64-character GET_LOCK() name limit.
+     */
+    private function lockName(): string
+    {
+        return 'wpmgr_bk_' . $this->snapshotId();
+    }
+
+    /**
+     * Best-effort, non-blocking (timeout=0) MySQL advisory lock acquire.
+     *
+     * Adversarial-review correction: this is a FAST, CHEAP early-reject only
+     * — it is NOT, by itself, a reliable mutual-exclusion guarantee. GET_LOCK
+     * is scoped to $wpdb's own mysqli connection and is silently released the
+     * instant that connection drops (a short `wait_timeout` on a managed
+     * host, a MySQL restart/failover, or `$wpdb->check_connection()`
+     * reconnecting after "server has gone away" — all plausible mid-backup,
+     * e.g. during a large-table dump that only calls back to $wpdb once per
+     * table). A dropped connection can hand a genuinely-still-alive winner's
+     * '1' to a SECOND caller, so this alone can NOT promise "always exactly
+     * one winner, never two" — see run()'s doc for why flock() (guard 2) is
+     * the connection-independent, AUTHORITATIVE backstop that closes this
+     * exact gap, and why a caller who is a fast reject here ('0') never even
+     * needs to reach the more expensive flock check.
+     *
+     * @return string|null '1' when we won the lock, '0' when another session
+     *                      already holds it (fast reject — no flock attempt
+     *                      needed), null when GET_LOCK() is unsupported
+     *                      (non-MySQL $wpdb driver) or the probe itself
+     *                      failed — either way, run() still attempts the
+     *                      authoritative flock() guard next.
+     */
+    private function getLock(): ?string
+    {
+        global $wpdb;
+        if (!is_object($wpdb)) {
+            return null;
+        }
+        try {
+            /** @phpstan-ignore-next-line */
+            $result = $wpdb->get_var($wpdb->prepare('SELECT GET_LOCK(%s, 0)', $this->lockName())); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- advisory run-lock probe; anti-double-fire correctness read, not a cacheable value
+        } catch (\Throwable $e) {
+            return null;
+        }
+        return $result === null ? null : (string) $result;
+    }
+
+    /**
+     * Release the advisory lock acquired by getLock(). Best-effort — MySQL
+     * releases the lock automatically when this session's connection closes,
+     * so a failed RELEASE_LOCK() here is never fatal.
+     */
+    private function releaseLock(): void
+    {
+        global $wpdb;
+        if (!is_object($wpdb)) {
+            return;
+        }
+        try {
+            /** @phpstan-ignore-next-line */
+            $wpdb->get_var($wpdb->prepare('SELECT RELEASE_LOCK(%s)', $this->lockName())); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- advisory run-lock release; no core helper exists
+        } catch (\Throwable $e) {
+            // Swallow — MySQL releases the lock automatically on connection close.
+        }
+    }
+
+    /**
+     * Deterministic per-snapshot flock() lock-file path (GitHub issue #232
+     * adversarial-review follow-up — see run()'s doc for the full
+     * dead-connection rationale this guard closes).
+     *
+     * Derived from the PARENT of the per-snapshot scratch dir (the shared
+     * "runs" base, e.g. `wp-content/wpmgr-agent/runs/`) rather than the
+     * per-snapshot scratch dir itself, so the lock path is resolvable and
+     * stable even before that per-snapshot directory has been created — a
+     * watchdog resume or the reaper can race the very first
+     * ensureScratchDir() call. Falls back to deriving the same "runs" base
+     * from wp_content_path when scratch_dir itself is empty/malformed
+     * (defensive; both params are always set together in practice).
+     *
+     * @return string Absolute lock-file path, or '' when neither base can be
+     *                resolved at all (BackupCommand always sets scratch_dir
+     *                before a runner is ever constructed, so this is only
+     *                reachable via a malformed/hand-built params array).
+     */
+    private function fileLockPath(): string
+    {
+        $scratch = $this->scratchDir();
+        $base    = $scratch !== '' ? dirname($scratch) : '';
+
+        if ($base === '' || $base === '.' || $base === DIRECTORY_SEPARATOR) {
+            $contentPath = $this->wpContentPath();
+            $base        = $contentPath !== '' ? rtrim($contentPath, '/\\') . '/wpmgr-agent/runs' : '';
+        }
+
+        if ($base === '') {
+            return '';
+        }
+
+        return rtrim($base, '/\\') . DIRECTORY_SEPARATOR . $this->snapshotId() . '.lock';
+    }
+
+    /**
+     * Acquire the AUTHORITATIVE, connection-independent mutual-exclusion
+     * guard for this snapshot's run (GitHub issue #232 adversarial-review
+     * follow-up — see run()'s doc for the full rationale).
+     *
+     * Unlike getLock() (MySQL GET_LOCK, silently released if $wpdb's
+     * connection drops mid-run), this flock() is held by the OS for as long
+     * as this PHP process is alive and is released automatically the
+     * instant it exits for ANY reason — including a SIGKILL that skips every
+     * PHP-level `finally` — so a second caller's non-blocking attempt
+     * correctly reports contention for as long as the first caller is
+     * genuinely still running, independent of what happened to its database
+     * connection in the meantime.
+     *
+     * Three outcomes, distinguished so a caller can tell "no one else is
+     * running this" from "flock itself isn't usable right now":
+     *   - ['handle' => resource, 'contended' => false]  — WON the lock. The
+     *     caller must keep the handle open for the whole run and pass it to
+     *     releaseFileLock() when done.
+     *   - ['handle' => null,     'contended' => true]   — LOST: another live
+     *     process holds this exact snapshot's lock file right now (the
+     *     authoritative "someone else is really still running this" signal).
+     *   - ['handle' => null,     'contended' => false]  — the guard could not
+     *     even be attempted (no resolvable path, or the filesystem/
+     *     permissions prevent opening the lock file — e.g. an exotic FS
+     *     without flock() support). Degrades SAFELY: the caller proceeds
+     *     exactly as it would have before this guard existed.
+     *
+     * @return array{handle:resource|null,contended:bool}
+     */
+    private function acquireFileLock(): array
+    {
+        $path = $this->fileLockPath();
+        if ($path === '') {
+            return ['handle' => null, 'contended' => false];
+        }
+
+        $dir = dirname($path);
+        if (!is_dir($dir) && !wp_mkdir_p($dir) && !is_dir($dir)) {
+            return ['handle' => null, 'contended' => false];
+        }
+
+        // 'c': create the file if it does not exist yet, but never truncate
+        // an existing one — only flock()'s exclusivity matters here, the
+        // file's contents are never read or written by this guard.
+        $handle = @fopen($path, 'c'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- headless agent; WP_Filesystem has no flock()-equivalent API and is never initialized in this context; small, server-derived, empty coordination file
+        if ($handle === false) {
+            return ['handle' => null, 'contended' => false];
+        }
+        @chmod($path, 0600); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod -- explicit security perms on our own coordination file; WP_Filesystem would coerce to wider FS_CHMOD_FILE
+
+        if (!flock($handle, LOCK_EX | LOCK_NB)) {
+            // Genuinely contended: another live PHP process holds this exact
+            // snapshot's lock right now, regardless of its $wpdb connection
+            // state. This is the authoritative reject.
+            fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- releasing our own failed-lock-attempt handle, not a WP_Filesystem-managed resource
+            return ['handle' => null, 'contended' => true];
+        }
+
+        return ['handle' => $handle, 'contended' => false];
+    }
+
+    /**
+     * Release + close a flock handle returned by acquireFileLock(). Safe to
+     * call with a non-resource (a no-op). Best-effort: a failed
+     * flock(LOCK_UN) is never fatal — the OS releases the lock automatically
+     * the instant this process exits for any reason.
+     *
+     * @param resource|null $handle
+     */
+    private function releaseFileLock($handle): void
+    {
+        if ($handle === null || !is_resource($handle)) {
+            return;
+        }
+        flock($handle, LOCK_UN);
+        fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- releasing our own advisory lock handle; WP_Filesystem has no flock()-equivalent API and is never initialized in this headless agent context
+    }
+
+    /**
+     * Reclaim this run's own `<snapshot_id>.lock` coordination file — GH
+     * #232 follow-up: without this, one empty 0-byte file per snapshot
+     * accumulates in the runs base forever (thousands over time on an
+     * active fleet). Called from run()'s `finally`, AFTER
+     * releaseFileLock() has already run flock(LOCK_UN) + fclose() on this
+     * same handle — the fd is closed before the path is ever touched here,
+     * so there is no unlink-against-an-open-fd ordering subtlety. Only
+     * called when this invocation reached a genuinely TERMINAL outcome
+     * (see run()'s `$terminal` doc) — a run that crashes before reaching
+     * this `finally` at all (fatal/OOM/SIGKILL) still leaks its lock file,
+     * exactly like it always leaked its scratch dir before GH #151;
+     * BackupJanitor::gcRuns() is the age-gated backstop for both.
+     *
+     * Best-effort: a failed unlink here is cosmetic disk-hygiene, never a
+     * correctness concern — the file is empty and carries no state, and a
+     * lingering one is reclaimed by the janitor regardless.
+     */
+    private function cleanupFileLock(): void
+    {
+        $path = $this->fileLockPath();
+        if ($path === '' || !is_file($path)) {
+            return;
+        }
+        wp_delete_file($path);
+    }
+
+    /**
+     * Record a `lock_contended` breadcrumb on the task row WITHOUT touching
+     * `phase` — called when getLock() reports we lost the race to another
+     * session that is provably already running this task.
+     *
+     * Reads the RAW sub_state column value directly (NOT through loadTask(),
+     * which follows the sidecar-spill pointer and would rehydrate a
+     * potentially large de-sidecared cursor). Merging 'stage' into whatever
+     * tiny envelope already lives in the column — a genuine small sub_state
+     * OR a `{"_sidecar":true,...}` pointer object — keeps this write always
+     * small and never risks re-writing a large cursor inline (the exact
+     * @@max_allowed_packet overflow the sidecar exists to prevent).
+     *
+     * Best-effort: a failure here must never throw — the caller (run()'s
+     * loser path) already wraps this in its own try/catch, but every DB call
+     * inside is additionally guarded so nothing here can escalate on its own.
+     */
+    private function recordLockContended(): void
+    {
+        \WPMgr\Agent\Support\DebugLog::write(
+            'WPMgr TaskRunner: lock contended for snapshot ' . $this->snapshotId()
+            . ' — another session already holds the run-lock; skipping re-entry without mutating phase'
+        );
+
+        global $wpdb;
+        if (!is_object($wpdb)) {
+            return;
+        }
+        $table = $this->tableName();
+        if ($table === '') {
+            return;
+        }
+
+        try {
+            // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- interpolated identifier is prefix+constant (trusted); value bound via %s placeholder
+            $sql      = "SELECT sub_state FROM {$table} WHERE snapshot_id = %s LIMIT 1";
+            /** @phpstan-ignore-next-line */
+            $prepared = $wpdb->prepare($sql, $this->snapshotId()); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- already prepared on the preceding line
+            /** @phpstan-ignore-next-line */
+            $raw = $wpdb->get_var($prepared); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.UnescapedDBParameter, PluginCheck.Security.DirectDB.UnescapedDBParameter -- direct read on plugin-owned table; value is the output of $wpdb->prepare(); $table comes from tableName() (prefix+constant), opaque to static analysis but not user input
+
+            $envelope = [];
+            if (is_string($raw) && $raw !== '') {
+                $decoded = json_decode($raw, true);
+                if (is_array($decoded)) {
+                    $envelope = $decoded;
+                }
+            }
+            $envelope['stage'] = 'lock_contended';
+            $encoded = json_encode($envelope);
+            if ($encoded === false) {
+                return;
+            }
+
+            /** @phpstan-ignore-next-line */
+            $wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- direct update on plugin-owned table; breadcrumb-only write, phase column untouched
+                $table,
+                ['sub_state' => $encoded],
+                ['snapshot_id' => $this->snapshotId()],
+                ['%s'],
+                ['%s']
+            );
+        } catch (\Throwable $e) {
+            // Swallow — a breadcrumb write failure must never surface from
+            // the loser path.
         }
     }
 

--- a/apps/agent/includes/backup/class-watchdog.php
+++ b/apps/agent/includes/backup/class-watchdog.php
@@ -64,10 +64,46 @@ final class Watchdog
      * WP-Cron callbacks MUST NOT return a value (return-value handling is
      * undefined across WP-Cron implementations).
      *
+     * GitHub issue #232: run() is now a thin wrapper around
+     * resumeIfStalled() — the cron path is unchanged (no #131 regression),
+     * but the resume logic is now ALSO reachable from sweepStalled(), the
+     * WP-Cron-INDEPENDENT reaper bound to plugins_loaded via
+     * Plugin::maybeSweepStalledBackups().
+     *
      * @param string $snapshotId UUID of the snapshot to inspect.
      * @return void
      */
     public static function run(string $snapshotId): void
+    {
+        self::resumeIfStalled($snapshotId);
+    }
+
+    /**
+     * Resume a stalled backup task, or reschedule the watchdog if it's still
+     * healthy. Reusable entry point (GitHub issue #232): called by run() (the
+     * `wpmgr_backup_watchdog` WP-Cron callback) AND by sweepStalled() (the
+     * WP-Cron-INDEPENDENT reaper driven from ordinary request traffic).
+     *
+     *   - If terminal (`completed` / `failed`), do nothing (best-effort
+     *     defensive DELETE).
+     *   - If active but `last_progress_at < now() - STALL_THRESHOLD_SECONDS`,
+     *     the runner has stalled (PHP process killed, FPM worker recycled,
+     *     hosting restart…). Increment `resume_count` (cap at `max_resumes`)
+     *     and re-enter `TaskRunner::run()` from the persisted `sub_state`.
+     *   - If active but still posting progress, reschedule the watchdog
+     *     itself for another +120s. Belt-and-suspenders: even if the
+     *     runner never crashes, the watchdog stays alive long enough to
+     *     observe the eventual `completed`/`failed` transition.
+     *
+     * Every guard below is preserved VERBATIM from the pre-#232 run(): the
+     * 7200s hard-ceiling delete, the late-phase (encrypting_uploading /
+     * submitting_manifest) delete, the STALL_THRESHOLD_SECONDS staleness
+     * check, and the resume_count >= max_resumes -> mark-failed guard.
+     *
+     * @param string $snapshotId UUID of the snapshot to inspect.
+     * @return void
+     */
+    public static function resumeIfStalled(string $snapshotId): void
     {
         if ($snapshotId === '' || !preg_match('/^[a-f0-9-]{36}$/i', $snapshotId)) {
             return;
@@ -245,6 +281,17 @@ final class Watchdog
             DebugLog::write(sprintf('WPMgr Backup: dispatch cannot find task row for snapshot %s', $snapshotId));
             return;
         }
+
+        // GitHub issue #232: durable breadcrumb the very moment dispatch() is
+        // entered — the FIRST possible write after BackupCommand seeds
+        // phase=queued that is reachable even if TaskRunner::run() below
+        // never advances phase at all (e.g. it crashes before its own first
+        // saveTaskState). Distinguishes "the wpmgr_backup_run hook fired but
+        // the runner made zero progress" from "the hook never fired at all"
+        // — see the observability ladder in TaskRunner::run()'s GET_LOCK doc.
+        self::stampStage($snapshotId, 'dispatch_entered');
+        DebugLog::write(sprintf('WPMgr Backup: dispatch entered for snapshot %s', $snapshotId));
+
         $phase = (string) ($row['phase'] ?? '');
         if ($phase === TaskRunner::PHASE_COMPLETED || $phase === TaskRunner::PHASE_FAILED) {
             // Terminal. DELETE the row so this and any future stale
@@ -304,6 +351,142 @@ final class Watchdog
             return;
         }
         wp_schedule_single_event(time() + max(1, $delay), self::HOOK, [$snapshotId]);
+    }
+
+    /**
+     * GitHub issue #232 — WP-Cron-INDEPENDENT reaper. Finds every
+     * wpmgr_backup_tasks row that is non-terminal AND has gone stale (no
+     * progress for STALL_THRESHOLD_SECONDS) and resumes each one through
+     * resumeIfStalled(). Uses the existing `KEY phase` + `KEY
+     * last_progress_at` indexes already on the table (see
+     * Schema::BACKUP_TASKS_TABLE) — no migration required.
+     *
+     * Safe to call from an ordinary request — Plugin::maybeSweepStalledBackups()
+     * binds this to `plugins_loaded`, throttled to once per 60s. Each
+     * resumeIfStalled() re-enters TaskRunner::run(), which now takes the GH
+     * #232 advisory run-lock before doing any phase work — so a sweep that
+     * races an already-live runner in a separate PHP process/DB connection is
+     * a harmless no-op (the sweep's TaskRunner instance loses the lock and
+     * returns without mutating phase).
+     *
+     * @param int $limit Maximum number of stalled rows to resume per call —
+     *                    bounds the worst-case cost of a single request that
+     *                    happens to trigger the sweep.
+     * @return void
+     */
+    public static function sweepStalled(int $limit = 20): void
+    {
+        global $wpdb;
+        if (!is_object($wpdb)) {
+            return;
+        }
+
+        $table     = $wpdb->prefix . Schema::BACKUP_TASKS_TABLE;
+        $cutoff    = time() - self::STALL_THRESHOLD_SECONDS;
+        $safeLimit = max(1, $limit);
+
+        try {
+            // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- interpolated identifier is prefix+constant (trusted); values bound via placeholders
+            $sql = "SELECT snapshot_id FROM {$table}
+                    WHERE phase NOT IN (%s, %s) AND last_progress_at < %d
+                    ORDER BY started_at ASC
+                    LIMIT %d";
+            /** @phpstan-ignore-next-line — dynamic wpdb. */
+            $prepared = $wpdb->prepare(
+                // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is a hard-coded query template with placeholders only; values are bound by this very prepare() call
+                $sql,
+                TaskRunner::PHASE_COMPLETED,
+                TaskRunner::PHASE_FAILED,
+                $cutoff,
+                $safeLimit
+            );
+            /** @phpstan-ignore-next-line — dynamic wpdb. */
+            $rows = $wpdb->get_col($prepared); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- direct read on plugin-owned table; value is the output of $wpdb->prepare()
+        } catch (\Throwable $e) {
+            DebugLog::write('WPMgr Backup: sweepStalled query failed: ' . $e->getMessage());
+            return;
+        }
+
+        if (!is_array($rows)) {
+            return;
+        }
+
+        foreach ($rows as $snapshotId) {
+            if (!is_string($snapshotId) || $snapshotId === '') {
+                continue;
+            }
+            try {
+                self::resumeIfStalled($snapshotId);
+            } catch (\Throwable $e) {
+                DebugLog::write(sprintf('WPMgr Backup: sweepStalled resume failed for %s: %s', $snapshotId, $e->getMessage()));
+            }
+        }
+    }
+
+    /**
+     * Stamp a durable `sub_state.stage` breadcrumb on the task row, and touch
+     * `last_progress_at` to `now` (so a fired-then-killed hook is
+     * distinguishable from one that never fired, and becomes
+     * sweepStalled()-detectable). Feeds the observability ladder documented
+     * on TaskRunner::run() and dispatch() above:
+     *
+     *   no stage + last_progress_at==started_at => hook never fired
+     *   stage=dispatch_entered                   => hook fired, runner never advanced
+     *   stage=runner_started                     => lock held, first phase failed to persist
+     *   phase past 'queued'                      => advanced
+     *
+     * Reads the RAW sub_state column value directly (never through
+     * TaskRunner's sidecar-aware loadTask(), which would rehydrate a
+     * potentially large de-sidecared cursor). Merging 'stage' into whatever
+     * tiny envelope already lives in the column — a genuine small sub_state
+     * OR a `{"_sidecar":true,...}` pointer object — keeps this write always
+     * small. Best-effort: a breadcrumb write failure must never propagate.
+     *
+     * @param string $snapshotId Snapshot UUID.
+     * @param string $stage      Breadcrumb value to stamp.
+     * @return void
+     */
+    private static function stampStage(string $snapshotId, string $stage): void
+    {
+        global $wpdb;
+        if (!is_object($wpdb)) {
+            return;
+        }
+        $table = $wpdb->prefix . Schema::BACKUP_TASKS_TABLE;
+
+        try {
+            // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- interpolated identifier is prefix+constant (trusted); value bound via %s placeholder
+            $sql = "SELECT sub_state FROM {$table} WHERE snapshot_id = %s LIMIT 1";
+            /** @phpstan-ignore-next-line — dynamic wpdb. */
+            $prepared = $wpdb->prepare($sql, $snapshotId); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- already prepared on the preceding line
+            /** @phpstan-ignore-next-line — dynamic wpdb. */
+            $raw = $wpdb->get_var($prepared); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- direct read on plugin-owned table; value is the output of $wpdb->prepare()
+
+            $envelope = [];
+            if (is_string($raw) && $raw !== '') {
+                $decoded = json_decode($raw, true);
+                if (is_array($decoded)) {
+                    $envelope = $decoded;
+                }
+            }
+            $envelope['stage'] = $stage;
+            $encoded = json_encode($envelope);
+            if ($encoded === false) {
+                return;
+            }
+
+            /** @phpstan-ignore-next-line — dynamic wpdb. */
+            @$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- direct update on plugin-owned table; breadcrumb write, correctness requires a live write
+                $table,
+                ['sub_state' => $encoded, 'last_progress_at' => time()],
+                ['snapshot_id' => $snapshotId],
+                ['%s', '%d'],
+                ['%s']
+            );
+        } catch (\Throwable $e) {
+            // Swallow — a breadcrumb write failure must never break
+            // dispatch()/resumeIfStalled().
+        }
     }
 
     /**

--- a/apps/agent/includes/class-lifecycle.php
+++ b/apps/agent/includes/class-lifecycle.php
@@ -466,6 +466,7 @@ final class Lifecycle
             ObjectCacheHeartbeat::OPTION_STATS,
             'wpmgr_oc_outage_marker', // WPMgr_Object_Cache::FAILBACK_MARKER_OPTION (H5).
             'wpmgr_snapshot_gc_last', // SnapshotManager::OPTION_GC_LAST (GH #226 GC throttle stamp).
+            Plugin::OPTION_BACKUP_SWEEP_LAST, // GH #232 stalled-backup reaper throttle stamp.
         ];
     }
 }

--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -151,6 +151,24 @@ final class Plugin
      */
     public const OPTION_LAST_DIAGNOSTICS_AT = 'wpmgr_agent_last_diagnostics_at';
 
+    /**
+     * GitHub issue #232 — Unix timestamp of the last stalled-backup reaper
+     * sweep (Watchdog::sweepStalled()), stamped BEFORE the sweep runs. Read
+     * by maybeSweepStalledBackups() to throttle the sweep to once per
+     * BACKUP_SWEEP_THROTTLE_SECONDS. Mirrors
+     * SnapshotManager::OPTION_GC_LAST's throttle pattern exactly. Owned by
+     * the agent — removed on uninstall via Lifecycle::ownedOptions().
+     */
+    public const OPTION_BACKUP_SWEEP_LAST = 'wpmgr_backup_sweep_last';
+
+    /**
+     * Throttle window for maybeSweepStalledBackups(): the actual sweep (a
+     * bounded SELECT + at most 20 TaskRunner re-entries, each lock-guarded)
+     * runs at most once per this many seconds; every other request pays only
+     * one cheap get_option() read.
+     */
+    private const BACKUP_SWEEP_THROTTLE_SECONDS = 60;
+
     private static ?Plugin $instance = null;
 
     private Keystore $keystore;
@@ -524,6 +542,25 @@ final class Plugin
         // throttles the actual sweep to once per hour via a stored option, so
         // this costs one cheap get_option() read on every other request.
         add_action('plugins_loaded', [$this, 'maybeGcSnapshots']);
+
+        // GitHub issue #232 — WP-Cron-INDEPENDENT, throttled reaper trigger
+        // for `wpmgr_backup_tasks` rows stalled at phase=queued (or any other
+        // non-terminal phase). Root cause: BackupCommand's ONLY cron-
+        // independent starter used to be gated on isLoopbackGated(), and its
+        // recovery path (Watchdog's own `wpmgr_backup_watchdog` cron event)
+        // is itself just as WP-Cron-dependent — so on a non-gated,
+        // low-traffic/off-peak site (or DISABLE_WP_CRON) a freshly-seeded
+        // task row could get stuck at `queued` forever with nothing left to
+        // ever re-check it. Binding this to plugins_loaded — mirroring
+        // maybeGcSnapshots() immediately above — fires
+        // Watchdog::sweepStalled() on every request the agent serves
+        // post-enrollment, including the control plane's own ~60s
+        // heartbeat/uptime/diagnostic REST hits, so recovery no longer
+        // depends on WP-Cron ticking at all. maybeSweepStalledBackups()
+        // itself throttles the actual sweep to once per 60s via a stored
+        // option (stamped BEFORE the sweep runs), so this costs one cheap
+        // get_option() read on every other request.
+        add_action('plugins_loaded', [$this, 'maybeSweepStalledBackups']);
 
         // M14: Guard against Performance Lab disabling our object-cache drop-in.
         // When the OC is configured (config file exists), register the filter so
@@ -1345,6 +1382,53 @@ final class Plugin
         }
 
         SnapshotManager::maybeGc();
+    }
+
+    /**
+     * GitHub issue #232 — WP-Cron-independent reaper trigger for stalled
+     * `wpmgr_backup_tasks` rows. See registerHooks()'s binding comment (next
+     * to maybeGcSnapshots(), immediately above) for the root cause this
+     * closes.
+     *
+     * Mirrors maybeGcSnapshots() / SnapshotManager::maybeGc() exactly:
+     *   - Gated on isEnrolled(): a not-yet-enrolled site has never had a
+     *     backup scheduled (and therefore never a stalled row) to reap.
+     *   - Throttled to once per BACKUP_SWEEP_THROTTLE_SECONDS (60s) via a
+     *     stored option, stamped BEFORE the sweep runs — a slow or failing
+     *     sweep can never be retried on every single request within the
+     *     window; the next throttled attempt gets a fresh try regardless of
+     *     whether this one succeeded.
+     *   - Watchdog::sweepStalled() is wrapped in try/catch: a reaper sweep
+     *     is best-effort recovery housekeeping, never a condition that may
+     *     break the request (or hook) that happened to trigger it.
+     *
+     * @return void
+     */
+    public function maybeSweepStalledBackups(): void
+    {
+        if (!$this->settings->isEnrolled()) {
+            return;
+        }
+        if (!function_exists('get_option') || !function_exists('update_option')) {
+            return;
+        }
+
+        $now  = time();
+        $last = (int) get_option(self::OPTION_BACKUP_SWEEP_LAST, 0);
+        if ($now - $last < self::BACKUP_SWEEP_THROTTLE_SECONDS) {
+            return;
+        }
+
+        // Stamp BEFORE running — see this method's doc for why.
+        update_option(self::OPTION_BACKUP_SWEEP_LAST, $now, true);
+
+        try {
+            Watchdog::sweepStalled();
+        } catch (\Throwable $e) {
+            // A reaper sweep failure must never break the caller (a request
+            // handler bound to plugins_loaded); the next throttled attempt
+            // 60s from now gets a fresh try.
+        }
     }
 
     /**

--- a/apps/agent/includes/commands/class-backup-command.php
+++ b/apps/agent/includes/commands/class-backup-command.php
@@ -264,69 +264,83 @@ final class BackupCommand implements CommandInterface
 
         // --- 6. Trigger the backup runner ---------------------------------
         //
-        // Strategy: probe the wp-cron loopback URL (a lightweight HEAD/GET
-        // with no redirect-following) to detect whether the front-end is
-        // gated by a membership or privacy plugin. On gated sites every
-        // request to /wp-cron.php returns a 3xx redirect to a login page,
-        // which means spawn_cron() dispatches the backup event to a cron
-        // worker that immediately redirects away and never runs TaskRunner.
-        // The result is an empty run dir (no environment.json) and a
-        // "no progress for >2m0s" watchdog stall.
+        // GitHub issue #232: scheduled backups intermittently stalled
+        // PERMANENTLY at phase=queued because the ONLY cron-independent
+        // starter — the in-process shutdown-function runner below — used to
+        // register ONLY when isLoopbackGated() detected a membership/privacy
+        // redirect. On a non-gated site with no visitor traffic in the next
+        // few seconds (or DISABLE_WP_CRON, where spawn_cron() is a documented
+        // no-op), NOTHING invoked TaskRunner::run() for the first time, so
+        // the freshly-seeded row never left `queued` (started_at ==
+        // last_progress_at, resume_count=0 — no cron tick ever arrived to
+        // even attempt a resume). The fix: register the in-process runner
+        // UNCONDITIONALLY on every trigger — it is a durable, cron-
+        // INDEPENDENT starter that runs in the SAME FPM worker that already
+        // produced the ACK response to the CP, so it fires regardless of
+        // cron health.
         //
-        // Detected gates: HTTP 3xx status, WP_Error (DNS/connect failure).
-        // When the loopback IS accessible (2xx / 4xx / 5xx — anything that
-        // is NOT a redirect), spawn_cron() is used as before (the separate-
-        // FPM-worker approach that fixed the 1panel/openresty FCGI timeout).
-        //
-        // When the loopback is gated, we fall back to in-process execution:
-        //   1. Register a PHP shutdown handler (fires after execute() returns
-        //      and WP REST flushes the response body to FPM).
-        //   2. The handler calls fastcgi_finish_request() (defensive — WP has
-        //      already closed its output buffers at this point) then runs
-        //      TaskRunner::run() directly in the same PHP process.
-        //   3. execute() returns the ACK normally. The CP sees 200 < 1 s.
-        //   4. The FPM worker runs the backup while the FCGI connection is
+        //   1. A PHP shutdown handler (fires after execute() returns and WP
+        //      REST flushes the response body to FPM) calls
+        //      fastcgi_finish_request() (defensive — WP has usually already
+        //      closed its output buffers) then runs TaskRunner::run()
+        //      directly in the same PHP process.
+        //   2. execute() returns the ACK normally. The CP sees 200 < 1 s.
+        //   3. The FPM worker runs the backup while the FCGI connection is
         //      closed (fastcgi_finish_request). On hosts where
         //      fastcgi_finish_request does not fully close the upstream
         //      connection, ignore_user_abort(true) + a bounded set_time_limit()
         //      ensure the runner is not killed mid-backup.
         //
-        // Note: spawn_cron() is still called even on gated sites as a belt-
-        // and-suspenders measure — it costs nothing if the loopback is gated
-        // and acts as a secondary trigger in case the in-process path is also
-        // unreliable on an unusual SAPI configuration.
+        // wp_schedule_single_event('wpmgr_backup_run') + spawn_cron() below
+        // are KEPT as secondary triggers (they preserve the #131 watchdog +
+        // the separate-FPM-worker FCGI-timeout fix for hosts where the
+        // in-process path is unreliable on an unusual SAPI configuration).
+        // The now-guaranteed double-fire this creates — the in-process
+        // runner AND the separate wp-cron-dispatched worker both calling
+        // TaskRunner::run() for the same snapshot — is handled by
+        // TaskRunner::run()'s own GH #232 MySQL advisory run-lock: whichever
+        // process arrives second loses the lock and returns without
+        // mutating phase.
         if (function_exists('wp_schedule_single_event')) {
             wp_schedule_single_event(time(), 'wpmgr_backup_run', [$snapshotId]);
         }
 
-        $loopbackGated = $this->isLoopbackGated();
-        if ($loopbackGated) {
-            // Loopback is gated: run TaskRunner in-process after the ACK
-            // is sent. Capture the params in a local variable so the closure
-            // does not hold a reference to $this (which would keep the entire
-            // BackupCommand object alive through the shutdown chain).
-            $shutdownParams = $runnerParams;
-            register_shutdown_function(static function () use ($shutdownParams): void {
-                // fastcgi_finish_request() is only available under PHP-FPM.
-                // Call it defensively: WP has already closed its own output
-                // buffers before shutdown handlers run, so the response was
-                // most likely already sent. This is a belt-and-suspenders flush.
-                if (function_exists('fastcgi_finish_request')) {
-                    fastcgi_finish_request(); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- intentional early-flush of the FCGI connection so the CP receives the ACK before TaskRunner runs
-                }
-                @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup runner must not hit max_execution_time; @-guarded
-                @ignore_user_abort(true);
-                try {
-                    (new TaskRunner($shutdownParams))->run();
-                } catch (\Throwable $e) {
-                    \WPMgr\Agent\Support\DebugLog::write('WPMgr Backup: in-process runner fatal: ' . $e->getMessage());
-                }
-            });
+        // isLoopbackGated() is still probed — its own DebugLog side effect
+        // surfaces likely membership/privacy-gate hosts for diagnostics —
+        // but its result no longer decides whether the in-process runner
+        // below registers (see the trigger doc above).
+        if ($this->isLoopbackGated()) {
+            DebugLog::write(sprintf(
+                'WPMgr Backup: snapshot %s loopback probe reports gated; the always-on in-process shutdown runner is the primary starter for this run',
+                $snapshotId
+            ));
         }
 
-        // Always fire spawn_cron: on non-gated sites it is the primary
-        // trigger; on gated sites it is a no-op (the loopback redirects
-        // away) but the in-process shutdown above covers the gap.
+        // Capture the params in a local variable so the closure does not
+        // hold a reference to $this (which would keep the entire
+        // BackupCommand object alive through the shutdown chain).
+        $shutdownParams = $runnerParams;
+        register_shutdown_function(static function () use ($shutdownParams): void {
+            // fastcgi_finish_request() is only available under PHP-FPM.
+            // Call it defensively: WP has already closed its own output
+            // buffers before shutdown handlers run, so the response was
+            // most likely already sent. This is a belt-and-suspenders flush.
+            if (function_exists('fastcgi_finish_request')) {
+                fastcgi_finish_request(); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- intentional early-flush of the FCGI connection so the CP receives the ACK before TaskRunner runs
+            }
+            @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup runner must not hit max_execution_time; @-guarded
+            @ignore_user_abort(true);
+            try {
+                (new TaskRunner($shutdownParams))->run();
+            } catch (\Throwable $e) {
+                \WPMgr\Agent\Support\DebugLog::write('WPMgr Backup: in-process runner fatal: ' . $e->getMessage());
+            }
+        });
+
+        // Always fire spawn_cron: it is the primary trigger on non-gated
+        // sites and a harmless no-op on gated ones (the loopback redirects
+        // away) — the always-on in-process shutdown runner above covers the
+        // gap either way.
         if (function_exists('spawn_cron')) {
             @spawn_cron(); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- spawn_cron may emit a harmless notice when DISABLE_WP_CRON is set; @-suppressed intentionally
         }

--- a/apps/agent/tests/Backup/BackupAlwaysOnRunnerTest.php
+++ b/apps/agent/tests/Backup/BackupAlwaysOnRunnerTest.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * GitHub issue #232 regression: BackupCommand::execute() must register the
+ * in-process shutdown-function runner UNCONDITIONALLY on every accepted
+ * backup trigger, not only when isLoopbackGated() detects a membership/
+ * privacy redirect.
+ *
+ * Root cause this locks in: before the fix, a non-gated site relied ENTIRELY
+ * on WP-Cron (wp_schedule_single_event('wpmgr_backup_run') + spawn_cron()) to
+ * ever invoke TaskRunner::run() for the first time. On a low-traffic/off-peak
+ * schedule (or DISABLE_WP_CRON, where spawn_cron() is a documented no-op)
+ * nothing started the runner, so the freshly-seeded row never left
+ * phase=queued and stayed stuck there forever.
+ *
+ * register_shutdown_function() is intercepted via Brain Monkey's
+ * Functions\expect(), which records the call WITHOUT invoking the passed
+ * closure — so this test exercises the real acceptance path (preflight,
+ * dedup claim, scratch dir, task-row seed, watchdog schedule) without ever
+ * constructing a live TaskRunner/Keystore/Signer.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Commands\BackupCommand;
+use WPMgr\Agent\Schema;
+use WPMgr\Agent\Support\AgeIdentity;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Commands\BackupCommand
+ */
+final class BackupAlwaysOnRunnerTest extends TestCase
+{
+    private string $contentDir = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        if (!class_exists(\ZipArchive::class)) {
+            self::markTestSkipped('ext-zip not available');
+        }
+
+        if (!defined('WP_CONTENT_DIR')) {
+            $this->contentDir = sys_get_temp_dir() . '/wpmgr-alwayson-' . bin2hex(random_bytes(6));
+            mkdir($this->contentDir, 0755, true);
+            define('WP_CONTENT_DIR', $this->contentDir);
+        } else {
+            $this->contentDir = WP_CONTENT_DIR;
+            if (!is_dir($this->contentDir)) {
+                mkdir($this->contentDir, 0755, true);
+            }
+        }
+
+        Functions\when('wp_json_encode')->alias(static fn ($d) => json_encode($d));
+        Functions\when('get_option')->justReturn(Schema::CURRENT_VERSION);
+        Functions\when('wp_schedule_single_event')->justReturn(true);
+
+        $GLOBALS['wpdb'] = new AlwaysOnFakeWpdb();
+    }
+
+    protected function tear_down(): void
+    {
+        unset($GLOBALS['wpdb']);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /** A stub AgeIdentity that matches any recipient (mirrors BackupCommandTest). */
+    private function stubIdentity(): AgeIdentity
+    {
+        return new class extends AgeIdentity {
+            public function __construct()
+            {
+                // Deliberately does NOT call parent::__construct() — no
+                // Keystore is needed since recipient()/recipientMatches() are
+                // both overridden below (mirrors BackupCommandTest's
+                // stubIdentity()).
+            }
+
+            public function recipient(): string
+            {
+                return 'age1test0000000000000000000000000000000000000000000000000000';
+            }
+
+            public function recipientMatches(string $candidate): bool
+            {
+                return true;
+            }
+        };
+    }
+
+    /** @return array<string,mixed> */
+    private function acceptParams(): array
+    {
+        return [
+            'snapshot_id'       => '11111111-2222-3333-4444-555555555555',
+            'kind'              => 'files',
+            'age_recipient'     => 'age1test0000000000000000000000000000000000000000000000000000',
+            'chunk_bytes'       => 4 << 20,
+            'presign_endpoint'  => 'https://cp.example/agent/v1/backups/x/presign',
+            'manifest_endpoint' => 'https://cp.example/agent/v1/backups/x/manifest',
+            'progress_endpoint' => '',
+        ];
+    }
+
+    /** Stub the loopback probe as NOT gated (a normal 200 response). */
+    private function stubLoopbackNotGated(): void
+    {
+        Functions\when('site_url')->justReturn('https://open.example.com/wp-cron.php');
+        Functions\when('wp_remote_get')->justReturn([
+            'response' => ['code' => 200, 'message' => 'OK'],
+            'headers'  => [],
+            'body'     => '',
+        ]);
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(200);
+    }
+
+    /** Stub the loopback probe as GATED (a 302 redirect to a login page). */
+    private function stubLoopbackGated(): void
+    {
+        Functions\when('site_url')->justReturn('https://private.example.com/wp-cron.php');
+        Functions\when('wp_remote_get')->justReturn([
+            'response' => ['code' => 302, 'message' => 'Found'],
+            'headers'  => ['location' => 'https://private.example.com/login/'],
+            'body'     => '',
+        ]);
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(302);
+        Functions\when('wp_remote_retrieve_header')->justReturn('https://private.example.com/login/');
+    }
+
+    /**
+     * Non-gated site: register_shutdown_function must STILL be called
+     * exactly once — this is the exact bug (#232): before the fix it was
+     * called ZERO times on a non-gated site.
+     */
+    public function test_shutdown_runner_registers_on_non_gated_site(): void
+    {
+        $this->stubLoopbackNotGated();
+        Functions\expect('register_shutdown_function')->once();
+        Functions\expect('spawn_cron')->once()->andReturn(true);
+
+        $cmd = new BackupCommand($this->stubIdentity());
+        $res = $cmd->execute([], $this->acceptParams());
+
+        $this->assertTrue($res['ok'] ?? false, 'acceptance failed: ' . ($res['detail'] ?? ''));
+    }
+
+    /**
+     * Gated site: register_shutdown_function must ALSO be called exactly
+     * once (this path already worked pre-#232; it must not regress).
+     */
+    public function test_shutdown_runner_registers_on_gated_site(): void
+    {
+        $this->stubLoopbackGated();
+        Functions\expect('register_shutdown_function')->once();
+        Functions\expect('spawn_cron')->once()->andReturn(true);
+
+        $cmd = new BackupCommand($this->stubIdentity());
+        $res = $cmd->execute([], $this->acceptParams());
+
+        $this->assertTrue($res['ok'] ?? false, 'acceptance failed: ' . ($res['detail'] ?? ''));
+    }
+}
+
+/**
+ * Minimal in-memory $wpdb double supporting exactly the surface
+ * BackupCommand::execute()'s preflight + dedup-claim + task-row-seed steps
+ * touch. Follows the shared "prepare() returns a {sql,args} JSON envelope"
+ * convention used across this test suite (see tests/FakeWpdb.php,
+ * PacketLimitedWpdb in TaskRunnerSubStatePacketTest.php).
+ */
+final class AlwaysOnFakeWpdb
+{
+    public string $prefix = 'wp_';
+
+    public function prepare(string $query, ...$args): string
+    {
+        return json_encode(['sql' => $query, 'args' => $args]) ?: '';
+    }
+
+    /** @return string|null */
+    public function get_var(string $sql)
+    {
+        if ($sql === 'SELECT 1') {
+            return '1';
+        }
+        if (strpos($sql, 'max_allowed_packet') !== false) {
+            return '67108864'; // 64 MiB — clears both the hard-fail and warn thresholds.
+        }
+        return null;
+    }
+
+    /**
+     * @param mixed $mode
+     * @return array<int,array<string,mixed>>
+     */
+    public function get_results(string $sql, $mode = null): array
+    {
+        return []; // No tables — estimateBackupSize()'s DB contribution is 0.
+    }
+
+    /**
+     * Dedup-claim SELECT — always "no existing claim" so tryClaimDedup()
+     * falls through to the insert() branch.
+     *
+     * @param mixed $output
+     * @return null
+     */
+    public function get_row(string $prepared, $output = null)
+    {
+        return null;
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     * @param array<int,string>   $format
+     */
+    public function insert(string $table, array $data, array $format = []): int
+    {
+        return 1;
+    }
+
+    /** seedTaskRow()'s raw INSERT IGNORE. */
+    public function query(string $prepared): int
+    {
+        return 1;
+    }
+}

--- a/apps/agent/tests/Backup/BackupJanitorTest.php
+++ b/apps/agent/tests/Backup/BackupJanitorTest.php
@@ -154,6 +154,19 @@ final class BackupJanitorTest extends TestCase
         return $dir;
     }
 
+    /**
+     * Seed a bare `<snapshot_id>.lock` coordination file (TaskRunner's
+     * flock() guard — see class-task-runner.php's fileLockPath()) directly
+     * in the runs base, alongside (never inside) any run directory.
+     */
+    private function seedLockFile(string $id): string
+    {
+        $file = $this->runsBase . '/' . $id . '.lock';
+        touch($file);
+
+        return $file;
+    }
+
     /** A 36-character UUID-shaped snapshot id matching BackupJanitor's run-id regex. */
     private function newSnapshotId(): string
     {
@@ -281,6 +294,72 @@ final class BackupJanitorTest extends TestCase
         $this->assertTrue(
             is_dir($this->runsBase . '/restores'),
             'a sibling non-run directory (e.g. restores/) under the same base must never be touched'
+        );
+    }
+
+    // =========================================================================
+    // gcRuns() — GH #232 follow-up: sweeping <snapshot_id>.lock FILES.
+    // =========================================================================
+
+    public function test_aged_orphan_lock_file_is_swept(): void
+    {
+        $id   = $this->newSnapshotId();
+        $file = $this->seedLockFile($id);
+        touch($file, time() - (7 * 3600)); // past RUNS_GC_AGE_SECONDS (6h)
+        clearstatcache(true, $file);
+
+        // No wpmgr_backup_tasks row — the run this lock file belonged to
+        // crashed before reaching its own `finally` cleanup (fatal/OOM/
+        // SIGKILL), or completed/failed and its row is already gone.
+        $GLOBALS['wpdb'] = $this->fakeWpdb(null);
+
+        $class = $this->janitorClassWithBase($this->runsBase);
+        $class::gcRuns();
+
+        $this->assertFalse(
+            is_file($file),
+            'an aged orphan <snapshot_id>.lock file left by a crashed run must be swept — the same leak class as #151, for the sibling lock-file artifact'
+        );
+    }
+
+    public function test_active_runs_lock_file_is_not_swept_even_when_old(): void
+    {
+        $id   = $this->newSnapshotId();
+        $file = $this->seedLockFile($id);
+        touch($file, time() - (7 * 3600)); // past the age gate
+        clearstatcache(true, $file);
+
+        // A live task row: non-terminal phase, progress posted just now —
+        // the same belt-and-suspenders veto the directory sweep uses.
+        $GLOBALS['wpdb'] = $this->fakeWpdb([
+            'phase'            => TaskRunner::PHASE_ARCHIVING_FILES,
+            'last_progress_at' => time(),
+        ]);
+
+        $class = $this->janitorClassWithBase($this->runsBase);
+        $class::gcRuns();
+
+        $this->assertTrue(
+            is_file($file),
+            'a lock file whose task row reports an active, recently-progressing phase must be spared regardless of age'
+        );
+    }
+
+    public function test_fresh_lock_file_under_the_age_threshold_is_kept(): void
+    {
+        $id   = $this->newSnapshotId();
+        $file = $this->seedLockFile($id);
+        touch($file, time());
+        clearstatcache(true, $file);
+
+        $GLOBALS['wpdb'] = $this->fakeWpdb(null);
+
+        $class = $this->janitorClassWithBase($this->runsBase);
+        $class::gcRuns();
+
+        $this->assertTrue(
+            is_file($file),
+            'a lock file younger than RUNS_GC_AGE_SECONDS must never be swept, task row or not'
         );
     }
 

--- a/apps/agent/tests/Backup/FakeBackupTasksWpdb.php
+++ b/apps/agent/tests/Backup/FakeBackupTasksWpdb.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * Shared in-memory $wpdb double for the GitHub issue #232 backup-stall
+ * regression tests (TaskRunner's advisory run-lock + Watchdog's reaper).
+ *
+ * Emulates exactly the `wpmgr_backup_tasks` surface TaskRunner/Watchdog
+ * touch: prepare() returns a `{sql,args}` JSON envelope — the same
+ * convention already used across this suite (see tests/FakeWpdb.php and
+ * PacketLimitedWpdb in TaskRunnerSubStatePacketTest.php) — and get_var() /
+ * get_row() / get_col() / update() / insert() / query() / delete() all
+ * inspect that envelope to decide how to answer.
+ *
+ * GET_LOCK()/RELEASE_LOCK() emulation is scriptable per-instance via
+ * `$lockResponses` (an ordered list of '1'/'0'/null values, popped off in
+ * call order; the last entry repeats once the list is exhausted) so a test
+ * can express "first caller wins, second caller loses" or "GET_LOCK is
+ * unsupported".
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+/**
+ * In-memory wpmgr_backup_tasks double.
+ */
+final class FakeBackupTasksWpdb
+{
+    public string $prefix = 'wp_';
+
+    /** @var array<string,array<string,mixed>> snapshot_id => row */
+    public array $rows = [];
+
+    /**
+     * Scripted GET_LOCK() return values, consumed in call order. The final
+     * entry repeats for any call beyond the list's length. Defaults to
+     * "always wins" so tests that don't care about locking still complete.
+     *
+     * @var list<string|null>
+     */
+    public array $lockResponses = ['1'];
+
+    public int $lockCallCount = 0;
+
+    public int $releaseCallCount = 0;
+
+    /**
+     * Every update() call recorded, in order, for assertions.
+     *
+     * @var list<array{table:string,data:array<string,mixed>,where:array<string,mixed>}>
+     */
+    public array $updates = [];
+
+    /** Every prepare() call ever made, incremented regardless of query shape. */
+    public int $prepareCallCount = 0;
+
+    /**
+     * @param mixed ...$args
+     */
+    public function prepare(string $query, ...$args): string
+    {
+        $this->prepareCallCount++;
+        return json_encode(['sql' => $query, 'args' => $args]) ?: '';
+    }
+
+    /** @return string|null */
+    public function get_var(string $prepared)
+    {
+        [$sql, $args] = $this->decode($prepared);
+
+        if (strpos($sql, 'GET_LOCK') !== false) {
+            $idx = $this->lockCallCount;
+            $this->lockCallCount++;
+            if ($this->lockResponses === []) {
+                return null;
+            }
+            return $idx < count($this->lockResponses)
+                ? $this->lockResponses[$idx]
+                : $this->lockResponses[count($this->lockResponses) - 1];
+        }
+
+        if (strpos($sql, 'RELEASE_LOCK') !== false) {
+            $this->releaseCallCount++;
+            return '1';
+        }
+
+        if (strpos($sql, 'SELECT sub_state FROM') !== false) {
+            $id = (string) ($args[0] ?? '');
+            return isset($this->rows[$id]) ? (string) $this->rows[$id]['sub_state'] : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param mixed $output
+     * @return array<string,mixed>|null
+     */
+    public function get_row(string $prepared, $output = null)
+    {
+        [, $args] = $this->decode($prepared);
+        $id = $this->idFromArgs($args);
+        if ($id === '' || !isset($this->rows[$id])) {
+            return null;
+        }
+        return $this->rows[$id];
+    }
+
+    /** @return list<string> */
+    public function get_col(string $prepared): array
+    {
+        [, $args] = $this->decode($prepared);
+
+        // sweepStalled(): args = [PHASE_COMPLETED, PHASE_FAILED, $cutoff, $limit].
+        $excludedPhases = [(string) ($args[0] ?? ''), (string) ($args[1] ?? '')];
+        $cutoff         = (int) ($args[2] ?? 0);
+        $limit          = (int) ($args[3] ?? 20);
+
+        $candidates = $this->rows;
+        uasort($candidates, static fn (array $a, array $b): int => ((int) ($a['started_at'] ?? 0)) <=> ((int) ($b['started_at'] ?? 0)));
+
+        $matched = [];
+        foreach ($candidates as $id => $row) {
+            if (in_array((string) ($row['phase'] ?? ''), $excludedPhases, true)) {
+                continue;
+            }
+            if ((int) ($row['last_progress_at'] ?? 0) >= $cutoff) {
+                continue;
+            }
+            $matched[] = (string) $id;
+            if (count($matched) >= $limit) {
+                break;
+            }
+        }
+
+        return $matched;
+    }
+
+    /**
+     * @param array<string,mixed>       $data
+     * @param array<string,mixed>       $where
+     * @param list<string>|string|null  $format
+     * @param list<string>|string|null  $whereFormat
+     */
+    public function update(string $table, array $data, array $where, $format = null, $whereFormat = null): int
+    {
+        $id = (string) ($where['snapshot_id'] ?? '');
+        if ($id === '' || !isset($this->rows[$id])) {
+            return 0;
+        }
+        $this->updates[] = ['table' => $table, 'data' => $data, 'where' => $where];
+        foreach ($data as $k => $v) {
+            $this->rows[$id][$k] = $v;
+        }
+        return 1;
+    }
+
+    /**
+     * @param array<string,mixed>      $data
+     * @param list<string>|string|null $format
+     */
+    public function insert(string $table, array $data, $format = null): int
+    {
+        $id = (string) ($data['snapshot_id'] ?? '');
+        if ($id === '') {
+            return 0;
+        }
+        $this->rows[$id] = $data;
+        return 1;
+    }
+
+    /**
+     * @param array<string,mixed>      $where
+     * @param list<string>|string|null $whereFormat
+     */
+    public function delete(string $table, array $where, $whereFormat = null): int
+    {
+        $id = (string) ($where['snapshot_id'] ?? '');
+        if ($id !== '' && isset($this->rows[$id])) {
+            unset($this->rows[$id]);
+            return 1;
+        }
+        return 0;
+    }
+
+    /** Handles seedTask()'s / seedTaskRow()'s raw `INSERT IGNORE`. */
+    public function query(string $prepared): int
+    {
+        [$sql, $args] = $this->decode($prepared);
+
+        if (stripos($sql, 'INSERT IGNORE') !== false) {
+            $id = (string) ($args[0] ?? '');
+            if ($id === '' || isset($this->rows[$id])) {
+                return 0; // IGNORE — missing id, or already exists.
+            }
+            $this->rows[$id] = [
+                'snapshot_id'      => $id,
+                'kind'             => (string) ($args[1] ?? ''),
+                'phase'            => (string) ($args[2] ?? ''),
+                'sub_state'        => (string) ($args[3] ?? '{}'),
+                'started_at'       => (int) ($args[4] ?? time()),
+                'last_progress_at' => (int) ($args[5] ?? time()),
+                'resume_count'     => (int) ($args[6] ?? 0),
+                'max_resumes'      => (int) ($args[7] ?? 6),
+            ];
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Test helper: seed a row directly, mirroring
+     * BackupCommand::seedTaskRow()'s / TaskRunner::seedTask()'s shape.
+     *
+     * @param array<string,mixed> $overrides
+     */
+    public function seedRow(string $snapshotId, array $overrides = []): void
+    {
+        $now = time();
+        $this->rows[$snapshotId] = array_merge([
+            'snapshot_id'      => $snapshotId,
+            'kind'             => 'files',
+            'phase'            => 'queued',
+            'sub_state'        => '{}',
+            'started_at'       => $now,
+            'last_progress_at' => $now,
+            'resume_count'     => 0,
+            'max_resumes'      => 6,
+        ], $overrides);
+    }
+
+    /**
+     * @param string $prepared
+     * @return array{0:string,1:array<int,mixed>}
+     */
+    private function decode(string $prepared): array
+    {
+        $decoded = json_decode($prepared, true);
+        if (!is_array($decoded)) {
+            return ['', []];
+        }
+        $sql  = is_string($decoded['sql'] ?? null) ? $decoded['sql'] : '';
+        $args = is_array($decoded['args'] ?? null) ? $decoded['args'] : [];
+        return [$sql, $args];
+    }
+
+    /**
+     * @param array<int,mixed> $args
+     */
+    private function idFromArgs(array $args): string
+    {
+        foreach ($args as $a) {
+            if (is_string($a) && isset($this->rows[$a])) {
+                return $a;
+            }
+        }
+        return '';
+    }
+}

--- a/apps/agent/tests/Backup/PluginBackupSweepTest.php
+++ b/apps/agent/tests/Backup/PluginBackupSweepTest.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * GitHub issue #232 — Plugin::maybeSweepStalledBackups() regression lock.
+ *
+ * Exercises the REAL method under test via a Plugin instance built with
+ * `ReflectionClass::newInstanceWithoutConstructor()` + a directly-injected
+ * `Settings` instance (reflection-set onto the private `$settings`
+ * property). This deliberately avoids the heavy `Plugin::boot()` singleton
+ * path (schema migrations, cache manager, object cache, admin menus, error
+ * monitor, …) — maybeSweepStalledBackups() only ever touches
+ * `$this->settings->isEnrolled()`, `get_option()`/`update_option()`, and
+ * `Watchdog::sweepStalled()`, so this is a faithful, fully-isolated test of
+ * the production method. (`Plugin::boot()` was observed to leak global
+ * state — e.g. a real installed error handler / static config caches —
+ * that broke unrelated tests elsewhere in the suite when this test called
+ * it; reflection-injecting just the one property this method touches
+ * avoids that surface entirely.)
+ *
+ * Verifies:
+ *   - Gated on isEnrolled(): a not-yet-enrolled site never touches $wpdb.
+ *   - Throttled to once per 60s via a stored option, stamped BEFORE the
+ *     sweep runs (a slow/failing sweep can never re-run on every request
+ *     within the window).
+ *   - Past the throttle window, Watchdog::sweepStalled() actually runs
+ *     (observed via the shared FakeBackupTasksWpdb spy).
+ *   - A thrown sweep never bubbles out of the request.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use ReflectionClass;
+use WPMgr\Agent\Plugin;
+use WPMgr\Agent\Settings;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Plugin
+ */
+final class PluginBackupSweepTest extends TestCase
+{
+    /** @var array<string,mixed> In-memory wp-option store. */
+    private array $options = [];
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->options = [];
+        Functions\when('update_option')->alias(function ($name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('get_option')->alias(function ($name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+    }
+
+    protected function tear_down(): void
+    {
+        unset($GLOBALS['wpdb']);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * Build a Plugin instance WITHOUT running its (private, heavy)
+     * constructor or boot() — only `$settings` is wired, which is all
+     * maybeSweepStalledBackups() touches on `$this`.
+     */
+    private function makePlugin(): Plugin
+    {
+        $reflection = new ReflectionClass(Plugin::class);
+        /** @var Plugin $plugin */
+        $plugin = $reflection->newInstanceWithoutConstructor();
+
+        $settingsProp = $reflection->getProperty('settings');
+        $settingsProp->setValue($plugin, new Settings());
+
+        return $plugin;
+    }
+
+    private function markEnrolled(): void
+    {
+        $this->options[Settings::OPTION_SITE_ID] = 'site-abc';
+        $this->options[Settings::OPTION_CP_URL]  = 'https://cp.example.test';
+    }
+
+    public function test_not_enrolled_never_touches_wpdb(): void
+    {
+        // Deliberately NOT enrolled.
+        $wpdb = new FakeBackupTasksWpdb();
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $this->makePlugin()->maybeSweepStalledBackups();
+
+        $this->assertSame(0, $wpdb->prepareCallCount, 'a not-yet-enrolled site must never reach Watchdog::sweepStalled()');
+        $this->assertArrayNotHasKey(Plugin::OPTION_BACKUP_SWEEP_LAST, $this->options, 'a not-yet-enrolled site must never stamp the throttle option');
+    }
+
+    public function test_within_throttle_window_is_a_no_op(): void
+    {
+        $this->markEnrolled();
+        $this->options[Plugin::OPTION_BACKUP_SWEEP_LAST] = time() - 10; // 10s ago, well under the 60s window.
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $this->makePlugin()->maybeSweepStalledBackups();
+
+        $this->assertSame(
+            time() - 10,
+            $this->options[Plugin::OPTION_BACKUP_SWEEP_LAST],
+            'a throttled call within the window must never re-stamp the option'
+        );
+        $this->assertSame(0, $wpdb->prepareCallCount, 'a throttled call within the window must never touch $wpdb');
+    }
+
+    public function test_past_throttle_window_stamps_before_running_then_sweeps(): void
+    {
+        $this->markEnrolled();
+        $this->options[Plugin::OPTION_BACKUP_SWEEP_LAST] = time() - 3600; // long past the 60s window.
+
+        $wpdb = new FakeBackupTasksWpdb();
+        // A stale row so sweepStalled() has something to find and resume;
+        // proves the sweep actually ran end-to-end, not just that the
+        // throttle stamp updated.
+        $wpdb->seedRow('eeeeeeee-ffff-4000-8000-000000000000', [
+            'phase'            => 'queued',
+            'started_at'       => time() - 200,
+            'last_progress_at' => time() - 200,
+            'resume_count'     => 0,
+            'sub_state'        => '{}', // no params -> resumeIfStalled() bails cleanly after the resume_count bump.
+        ]);
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $before = time();
+        $this->makePlugin()->maybeSweepStalledBackups();
+
+        $this->assertGreaterThanOrEqual(
+            $before,
+            (int) $this->options[Plugin::OPTION_BACKUP_SWEEP_LAST],
+            'the throttle option must be stamped to "now" before the sweep runs'
+        );
+
+        // Proof the sweep actually reached the DB: the seeded stale row's
+        // resume_count was bumped from 0 to 1.
+        $row = $wpdb->rows['eeeeeeee-ffff-4000-8000-000000000000'] ?? null;
+        $this->assertNotNull($row);
+        $this->assertSame(1, $row['resume_count'], 'sweepStalled() must have resumed the stale row past the throttle gate');
+    }
+
+    public function test_a_thrown_sweep_never_bubbles_out_of_the_request(): void
+    {
+        $this->markEnrolled();
+
+        // A $wpdb double whose very first call (prepare()) throws — proves
+        // maybeSweepStalledBackups() completes normally (no uncaught
+        // exception) regardless of which layer contains the failure.
+        $wpdb = new class {
+            public string $prefix = 'wp_';
+
+            /**
+             * @param mixed ...$args
+             */
+            public function prepare(string $query, ...$args): string
+            {
+                throw new \RuntimeException('simulated DB failure');
+            }
+        };
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $plugin = $this->makePlugin();
+
+        $threw = false;
+        try {
+            $plugin->maybeSweepStalledBackups();
+        } catch (\Throwable $e) {
+            $threw = true;
+        }
+
+        $this->assertFalse($threw, 'a thrown sweep must never bubble out of the plugins_loaded-bound request handler');
+        $this->assertArrayHasKey(
+            Plugin::OPTION_BACKUP_SWEEP_LAST,
+            $this->options,
+            'the throttle stamp must still have been written (stamp-BEFORE-run) even though the sweep itself failed'
+        );
+    }
+}

--- a/apps/agent/tests/Backup/TaskRunnerLockTest.php
+++ b/apps/agent/tests/Backup/TaskRunnerLockTest.php
@@ -1,0 +1,547 @@
+<?php
+/**
+ * GitHub issue #232 regression: TaskRunner's two layered mutual-exclusion
+ * guards — GET_LOCK (fast cross-process reject) + flock (connection-
+ * independent, AUTHORITATIVE).
+ *
+ * Root cause recap: scheduled backups intermittently stalled PERMANENTLY at
+ * phase=queued because the agent had no cron-independent starter that ran
+ * unconditionally. The fix (BackupCommand + this class) makes the in-process
+ * shutdown-function runner ALWAYS register, which guarantees a double-fire
+ * against the separate wp-cron-dispatched worker (and now also the reaper)
+ * for the same snapshot_id.
+ *
+ * Adversarial-review follow-up (HIGH, pre-ship): GET_LOCK alone is NOT
+ * sufficient. It is scoped to $wpdb's own mysqli connection and is silently
+ * released the instant that connection drops — a short `wait_timeout` on a
+ * managed host, a MySQL restart/failover, or `$wpdb->check_connection()`
+ * reconnecting after "server has gone away" can all sever it mid-backup
+ * (DbDumper streams over its OWN separate mysqli handle and only calls back
+ * to $wpdb once per table, so a large-table dump can easily outlive
+ * $wpdb's connection). A second caller can then legitimately win GET_LOCK
+ * while the true owner is still alive and running — concurrently entering
+ * the SAME scratch dir. flock() on a deterministic per-snapshot lock file is
+ * the fix: it is held by the OS for as long as the owning PHP process is
+ * alive, independent of $wpdb entirely, and releases automatically on
+ * process exit for ANY reason (including a SIGKILL that skips every
+ * PHP-level `finally`).
+ *
+ * Covers:
+ *   1. Contended dispatch (GET_LOCK='0') never strands the row: the loser
+ *      returns without mutating phase and writes only a lock_contended
+ *      breadcrumb.
+ *   2. GET_LOCK NULL (unsupported host): run() proceeds and completes
+ *      exactly as it did before #232 — no lock semantics, no regression —
+ *      AND, separately, a flock held by a live process still blocks a
+ *      second caller even when GET_LOCK is entirely unsupported.
+ *   3. Concurrent-into-same-scratch is BLOCKED by flock even when GET_LOCK
+ *      reports "free" (simulating the dead-connection scenario above): the
+ *      second caller must return without ever entering the phase machine.
+ *   7. Happy path (GET_LOCK='1' + flock acquired): full queued -> ... ->
+ *      completed, the row is cleaned up, and BOTH guards are released via
+ *      the `finally` — including on the throw/failed path.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Backup\TaskRunner;
+use WPMgr\Agent\Keystore;
+use WPMgr\Agent\Support\AgeCrypto;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\TaskRunner
+ */
+final class TaskRunnerLockTest extends TestCase
+{
+    private const SNAPSHOT_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+    private string $root       = '';
+    private string $scratchDir = '';
+    private string $wpContent  = '';
+    private string $keyFile    = '';
+
+    /** @var array<string,mixed> in-memory wp-option store, shared by Keystore. */
+    private array $options = [];
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        if (!class_exists(\ZipArchive::class)) {
+            self::markTestSkipped('ext-zip not available');
+        }
+
+        $this->root       = sys_get_temp_dir() . '/wpmgr-lock-test-' . bin2hex(random_bytes(6));
+        $this->scratchDir = $this->root . '/scratch';
+        $this->wpContent  = $this->root . '/wp-content';
+        mkdir($this->scratchDir, 0755, true);
+        mkdir($this->wpContent, 0755, true);
+        file_put_contents($this->wpContent . '/marker.txt', 'a real file for FilesArchiver to pack');
+
+        $this->keyFile = sys_get_temp_dir() . '/wpmgr-lock-test-key-' . bin2hex(random_bytes(8)) . '.key';
+        if (!defined('WPMGR_AGENT_KEY_FILE')) {
+            define('WPMGR_AGENT_KEY_FILE', $this->keyFile);
+        }
+
+        $this->options = [];
+        Functions\when('update_option')->alias(function ($name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('get_option')->alias(function ($name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('wp_json_encode')->alias(static fn ($d) => json_encode($d));
+
+        // Pre-provision the site's Ed25519 keypair so TaskRunner's internal
+        // `new Keystore()` (constructed fresh inside runEncryptingUploading)
+        // finds it via the shared in-memory option store above — exactly the
+        // SignerTest pattern.
+        (new Keystore())->generateSiteKeypair();
+    }
+
+    protected function tear_down(): void
+    {
+        unset($GLOBALS['wpdb']);
+        if (is_file($this->keyFile)) {
+            @unlink($this->keyFile);
+        }
+        $this->rrmdir($this->root);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * Stub wp_remote_post/wp_remote_request/is_wp_error/wp_remote_retrieve_*
+     * so BackupTransport's presignChunks()/putChunk()/submitManifest() all
+     * succeed without any real network I/O. presignChunks() always reports
+     * "nothing needs upload" (empty uploads map) — a legitimate CP response
+     * (full content-addressed dedup) — so putChunk()/wp_remote_request is
+     * never exercised and doesn't need stubbing either.
+     */
+    private function stubNetworkSuccess(string $presignEndpoint, string $manifestEndpoint): void
+    {
+        Functions\when('wp_remote_post')->alias(function ($url, $args) use ($presignEndpoint, $manifestEndpoint) {
+            if ($url === $presignEndpoint) {
+                return ['response' => ['code' => 200], 'body' => (string) json_encode(['uploads' => []])];
+            }
+            if ($url === $manifestEndpoint) {
+                return ['response' => ['code' => 200], 'body' => (string) json_encode(['ok' => true, 'chunk_count' => 0, 'stored_count' => 0])];
+            }
+            return new \WP_Error('unexpected_url', 'unexpected URL: ' . $url);
+        });
+        Functions\when('is_wp_error')->alias(static fn ($v) => $v instanceof \WP_Error);
+        Functions\when('wp_remote_retrieve_response_code')->alias(static fn ($r) => is_array($r) ? ($r['response']['code'] ?? 0) : 0);
+        Functions\when('wp_remote_retrieve_body')->alias(static fn ($r) => is_array($r) ? ($r['body'] ?? '') : '');
+    }
+
+    /**
+     * @return array{0:array<string,mixed>,1:string} [params, real age recipient]
+     */
+    private function buildParams(): array
+    {
+        $identity = (new AgeCrypto())->generateIdentity();
+
+        $params = [
+            'snapshot_id'       => self::SNAPSHOT_ID,
+            'kind'              => 'files',
+            'age_recipient'     => $identity['recipient'],
+            'presign_endpoint'  => 'https://cp.invalid/agent/v1/backups/lock-test/presign',
+            'manifest_endpoint' => 'https://cp.invalid/agent/v1/backups/lock-test/manifest',
+            'progress_endpoint' => '',
+            'chunk_bytes'       => 4 * 1024 * 1024,
+            'scratch_dir'       => $this->scratchDir,
+            'wp_content_path'   => $this->wpContent,
+            'db'                => ['host' => 'localhost', 'user' => 'u', 'password' => 'p', 'name' => 'n', 'prefix' => 'wp_'],
+        ];
+
+        return [$params, $identity['recipient']];
+    }
+
+    // ------------------------------------------------------------------
+    // Test 1: contended dispatch (GET_LOCK='0') never strands the row.
+    // ------------------------------------------------------------------
+
+    public function test_contended_dispatch_does_not_strand(): void
+    {
+        [$params] = $this->buildParams();
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->lockResponses = ['0']; // loser on the very first (and only) probe.
+        $wpdb->seedRow(self::SNAPSHOT_ID, ['sub_state' => (string) json_encode(['params' => $params])]);
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $runner = new TaskRunner($params);
+        $runner->run();
+
+        $row = $wpdb->rows[self::SNAPSHOT_ID] ?? null;
+        $this->assertNotNull($row, 'the loser must never delete the row');
+        $this->assertSame('queued', $row['phase'], 'the loser must never mutate phase');
+
+        $subState = json_decode((string) $row['sub_state'], true);
+        $this->assertIsArray($subState);
+        $this->assertSame('lock_contended', $subState['stage'] ?? null, 'the loser must write a lock_contended breadcrumb');
+
+        $this->assertSame(0, $wpdb->releaseCallCount, 'the loser never held the lock — RELEASE_LOCK must never be called');
+    }
+
+    // ------------------------------------------------------------------
+    // Test 2: GET_LOCK NULL (unsupported host) — no regression.
+    // ------------------------------------------------------------------
+
+    public function test_get_lock_null_falls_through_and_completes_like_today(): void
+    {
+        [$params, $recipient] = $this->buildParams();
+        $this->stubNetworkSuccess($params['presign_endpoint'], $params['manifest_endpoint']);
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->lockResponses = [null]; // GET_LOCK unsupported.
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $runner = new TaskRunner($params);
+        $phase  = $runner->run();
+
+        $this->assertSame(TaskRunner::PHASE_COMPLETED, $phase, 'a null GET_LOCK() must not block completion');
+        $this->assertArrayNotHasKey(self::SNAPSHOT_ID, $wpdb->rows, 'a completed run deletes its row regardless of lock support');
+        $this->assertSame(0, $wpdb->releaseCallCount, 'no lock was held (null token) — RELEASE_LOCK must never be called');
+    }
+
+    /**
+     * Adversarial-review follow-up: even when MySQL locking is ENTIRELY
+     * unavailable (GET_LOCK returns null on every call — e.g. a non-MySQL
+     * $wpdb driver), a live process's flock alone must still prevent a
+     * second caller from ever entering the phase machine. This is the "no
+     * unlocked race" guarantee flock backstops independent of GET_LOCK.
+     */
+    public function test_get_lock_null_and_flock_held_still_blocks_a_second_runner(): void
+    {
+        [$params] = $this->buildParams();
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->lockResponses = [null]; // GET_LOCK unsupported for every caller.
+        $wpdb->seedRow(self::SNAPSHOT_ID, ['sub_state' => (string) json_encode(['params' => $params])]);
+        $GLOBALS['wpdb'] = $wpdb;
+
+        [$lockHandle] = $this->externallyHoldTheFlock($params);
+
+        try {
+            $runnerB = new TaskRunner($params);
+            $runnerB->run();
+
+            $row = $wpdb->rows[self::SNAPSHOT_ID] ?? null;
+            $this->assertNotNull($row, 'the flock-loser must never delete the row');
+            $this->assertSame(
+                'queued',
+                $row['phase'],
+                'without ANY MySQL lock support, a live process holding the flock must still prevent a concurrent run'
+            );
+
+            $subState = json_decode((string) $row['sub_state'], true);
+            $this->assertSame('lock_contended', $subState['stage'] ?? null);
+        } finally {
+            flock($lockHandle, LOCK_UN);
+            fclose($lockHandle);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Test 3: concurrent-into-same-scratch is BLOCKED by flock even when
+    // GET_LOCK reports "free" (the exact dead-connection scenario the
+    // adversarial review flagged: GET_LOCK is scoped to $wpdb's connection
+    // and is silently released if that connection drops mid-backup, but the
+    // true owner — and its flock — is still alive and running).
+    // ------------------------------------------------------------------
+
+    /**
+     * Simulates the HIGH-severity double-run finding directly: runner A
+     * holds the flock (a live process, regardless of its $wpdb connection
+     * state); runner B's GET_LOCK call reports '1' ("free" — as it would if
+     * A's mysqli connection had silently dropped). Runner B must still be
+     * rejected by the authoritative flock check, and — decisively — must
+     * NEVER create a single new file under the scratch dir (kind=files
+     * drives archiving_files, which needs no network/DB and so is fully
+     * self-contained: if B were let through, as the pre-fix GET_LOCK-only
+     * code would, it would produce real zip/files.list artifacts on disk
+     * here, no external dependency needed to observe the corruption). This
+     * guard sits at the very top of run(), before ANY phase dispatch, so it
+     * protects dumping_db/database.sql.gz — the concrete artifact the
+     * adversarial review's report centered on — identically; kind=files is
+     * used here only because it makes the "B touched nothing" proof
+     * observable without a live MySQL connection in the test sandbox.
+     *
+     * This test FAILS against a GET_LOCK-only implementation (no flock):
+     * with only GET_LOCK, B's '1' would let it straight into the phase loop
+     * and it would create real archive artifacts before ever touching
+     * anything DB/network-dependent.
+     */
+    public function test_concurrent_into_same_scratch_is_blocked_by_flock_even_when_get_lock_reports_free(): void
+    {
+        [$params] = $this->buildParams();
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->lockResponses = ['1']; // GET_LOCK reports "free" — simulates A's dead $wpdb connection.
+        $wpdb->seedRow(self::SNAPSHOT_ID, ['sub_state' => (string) json_encode(['params' => $params])]);
+        $GLOBALS['wpdb'] = $wpdb;
+
+        [$lockHandle, $lockPath] = $this->externallyHoldTheFlock($params);
+        $beforeScratchListing = $this->scratchDirListing();
+
+        try {
+            $runnerB = new TaskRunner($params);
+            $runnerB->run();
+
+            $row = $wpdb->rows[self::SNAPSHOT_ID] ?? null;
+            $this->assertNotNull($row, 'B must never delete the row it lost the race for');
+            $this->assertSame(
+                'queued',
+                $row['phase'],
+                'B must never advance phase — GET_LOCK reporting "free" must not be enough once the authoritative flock rejects it'
+            );
+
+            $subState = json_decode((string) $row['sub_state'], true);
+            $this->assertSame('lock_contended', $subState['stage'] ?? null);
+
+            $this->assertSame(
+                $beforeScratchListing,
+                $this->scratchDirListing(),
+                'B must create ZERO new files in the scratch dir — this is the exact concurrent-write corruption the adversarial review flagged'
+            );
+            $this->assertFileDoesNotExist(
+                $this->scratchDir . '/database.sql.gz',
+                'B must never reach dumping_db (the guard is phase-agnostic, checked before ANY phase work)'
+            );
+
+            $this->assertSame(
+                1,
+                $wpdb->releaseCallCount,
+                'B must release the GET_LOCK it provisionally won once the authoritative flock rejects it'
+            );
+
+            // GH #232 lock-file GC follow-up: a contended loser must NEVER
+            // delete the winner's (A's) lock file — A is still alive and
+            // running; only the invocation that actually reaches a terminal
+            // outcome for a snapshot may ever reclaim that snapshot's lock
+            // file, and B never reaches the `finally` code that does so at
+            // all (it returned above, before the try/finally even begins).
+            $this->assertFileExists(
+                $lockPath,
+                "the contended loser (B) must never delete the winner's (A's) still-held lock file"
+            );
+        } finally {
+            flock($lockHandle, LOCK_UN);
+            fclose($lockHandle);
+        }
+    }
+
+    /**
+     * Resolve the SAME per-snapshot flock path TaskRunner itself would
+     * compute for $params (via reflection on a throwaway instance sharing
+     * the same params — avoids re-implementing/duplicating the path
+     * derivation in the test, which would risk silently drifting out of
+     * sync with the production logic), then open + hold an exclusive,
+     * non-blocking flock on it — simulating a live process ("runner A")
+     * that already owns this snapshot's run.
+     *
+     * @param array<string,mixed> $params
+     * @return array{0:resource,1:string} [held lock handle, resolved path]
+     */
+    private function externallyHoldTheFlock(array $params): array
+    {
+        $probe    = new TaskRunner($params);
+        $method   = new \ReflectionMethod(TaskRunner::class, 'fileLockPath');
+        $lockPath = $method->invoke($probe);
+        $this->assertIsString($lockPath);
+        $this->assertNotSame('', $lockPath, 'sanity: a lock path must be resolvable from these params');
+
+        $dir = dirname($lockPath);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $handle = fopen($lockPath, 'c');
+        $this->assertNotFalse($handle, 'sanity: the lock file must be openable in the test');
+        $this->assertTrue(flock($handle, LOCK_EX | LOCK_NB), 'sanity: runner A must be able to acquire the flock first');
+
+        return [$handle, $lockPath];
+    }
+
+    /**
+     * Recursive listing of every file under the scratch dir, relative paths
+     * sorted — used to prove a blocked runner created ZERO new artifacts.
+     *
+     * @return list<string>
+     */
+    private function scratchDirListing(): array
+    {
+        if (!is_dir($this->scratchDir)) {
+            return [];
+        }
+        $out = [];
+        $it  = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->scratchDir, \FilesystemIterator::SKIP_DOTS)
+        );
+        foreach ($it as $file) {
+            /** @var \SplFileInfo $file */
+            $out[] = substr($file->getPathname(), strlen($this->scratchDir));
+        }
+        sort($out);
+        return $out;
+    }
+
+    // ------------------------------------------------------------------
+    // Test 7: happy path (GET_LOCK='1' + flock) completes; both guards
+    // released via the finally.
+    // ------------------------------------------------------------------
+
+    public function test_happy_path_completes_and_releases_lock(): void
+    {
+        [$params, $recipient] = $this->buildParams();
+        $this->stubNetworkSuccess($params['presign_endpoint'], $params['manifest_endpoint']);
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->lockResponses = ['1'];
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $runner = new TaskRunner($params);
+        $phase  = $runner->run();
+
+        $this->assertSame(TaskRunner::PHASE_COMPLETED, $phase);
+        $this->assertArrayNotHasKey(self::SNAPSHOT_ID, $wpdb->rows, 'a completed run must delete its row');
+        $this->assertSame(1, $wpdb->lockCallCount, 'exactly one GET_LOCK probe per run() invocation');
+        $this->assertSame(1, $wpdb->releaseCallCount, 'the winner must RELEASE_LOCK exactly once, via the finally');
+
+        // Confirm the runner_started breadcrumb was actually stamped BEFORE
+        // any phase advancement — i.e. the write that set stage=runner_started
+        // must itself still carry phase='queued' (the observability ladder's
+        // "lock held, first phase failed to persist" signal is exactly this
+        // transient state, captured here via the update() history since the
+        // row itself is deleted by the time run() returns).
+        $runnerStartedPhase = null;
+        foreach ($wpdb->updates as $u) {
+            $subState = isset($u['data']['sub_state']) ? json_decode((string) $u['data']['sub_state'], true) : null;
+            if (is_array($subState) && ($subState['stage'] ?? null) === 'runner_started') {
+                $runnerStartedPhase = $u['data']['phase'] ?? null;
+                break;
+            }
+        }
+        $this->assertSame(
+            TaskRunner::PHASE_QUEUED,
+            $runnerStartedPhase,
+            'the runner_started breadcrumb must be stamped while phase is still queued — the pre-advancement state a crash would leave behind'
+        );
+
+        $this->assertFlockIsFree($params, 'the winner must release its flock (in the finally) so a later legit resume can acquire it');
+
+        // GH #232 lock-file GC follow-up: a completed run must reclaim its
+        // OWN <snapshot_id>.lock coordination file — not merely release the
+        // flock on it (assertFlockIsFree() above proves that separately) —
+        // so it never accumulates as an orphaned 0-byte file forever.
+        $probe    = new TaskRunner($params);
+        $lockPath = (new \ReflectionMethod(TaskRunner::class, 'fileLockPath'))->invoke($probe);
+        $this->assertFileDoesNotExist(
+            $lockPath,
+            'a completed run must delete its own lock file, not just release the flock on it'
+        );
+    }
+
+    /**
+     * RELEASE_LOCK AND the flock must both fire via the `finally` even when
+     * a phase handler throws (the failed/catch path) — not only on the
+     * happy/completed path. A malformed age_recipient makes
+     * AgeCrypto::decodeRecipient() throw during the encrypting_uploading
+     * phase, well before any network call, so no network stubbing is
+     * required for this test.
+     */
+    public function test_release_lock_called_on_the_throw_path(): void
+    {
+        [$params] = $this->buildParams();
+        $params['age_recipient'] = 'not-a-valid-age-recipient';
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->lockResponses = ['1'];
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $runner = new TaskRunner($params);
+        $phase  = $runner->run();
+
+        $this->assertSame(TaskRunner::PHASE_FAILED, $phase, 'a malformed recipient must fail the run, not throw out of run()');
+        $this->assertArrayNotHasKey(self::SNAPSHOT_ID, $wpdb->rows, 'the failure path deletes its row too');
+        $this->assertSame(1, $wpdb->releaseCallCount, 'RELEASE_LOCK must fire via the finally even on the failed/throw path');
+
+        $this->assertFlockIsFree($params, 'the flock must be released via the finally even on the failed/throw path, so a later legit resume can acquire it');
+
+        // GH #232 lock-file GC follow-up: 'failed' is a terminal outcome too
+        // (the row is DELETEd on this path — see the DELETE assertion above
+        // — so the lock file has nothing left to protect against).
+        $probe    = new TaskRunner($params);
+        $lockPath = (new \ReflectionMethod(TaskRunner::class, 'fileLockPath'))->invoke($probe);
+        $this->assertFileDoesNotExist(
+            $lockPath,
+            'a failed run must also delete its own lock file (failed is a terminal outcome, same as completed)'
+        );
+    }
+
+    /**
+     * Assert the flock for $params is currently free by acquiring (and
+     * immediately releasing) it ourselves — proof that TaskRunner's own
+     * `finally` released it rather than leaving it held past the end of
+     * run().
+     *
+     * `fopen($lockPath, 'c')` CREATES the file if it is missing — which it
+     * will be, by design, after a terminal run's own cleanupFileLock() has
+     * already reclaimed it (see the GH #232 lock-file GC follow-up). This
+     * probe therefore always deletes the (possibly just-recreated) file
+     * again before returning, so a subsequent assertFileDoesNotExist() check
+     * in the same test reflects TaskRunner's OWN cleanup, never a side
+     * effect of this probe having resurrected the file.
+     *
+     * @param array<string,mixed> $params
+     */
+    private function assertFlockIsFree(array $params, string $message): void
+    {
+        $probe    = new TaskRunner($params);
+        $method   = new \ReflectionMethod(TaskRunner::class, 'fileLockPath');
+        $lockPath = $method->invoke($probe);
+        $this->assertIsString($lockPath);
+
+        $handle = fopen($lockPath, 'c');
+        $this->assertNotFalse($handle, 'sanity: the lock file must be openable in the test');
+        $this->assertTrue(flock($handle, LOCK_EX | LOCK_NB), $message);
+        flock($handle, LOCK_UN);
+        fclose($handle);
+
+        wp_delete_file($lockPath);
+    }
+
+    /** Recursive delete used only for test fixture cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if ($dir === '' || !is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+}

--- a/apps/agent/tests/Backup/WatchdogReaperTest.php
+++ b/apps/agent/tests/Backup/WatchdogReaperTest.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * GitHub issue #232 regression: Watchdog's WP-Cron-INDEPENDENT reaper
+ * (sweepStalled() / resumeIfStalled()) and the dispatch_entered breadcrumb.
+ *
+ * Root cause recap: the ONLY pre-existing recovery path for a stalled
+ * `wpmgr_backup_tasks` row was another single-shot WP-Cron event
+ * (`wpmgr_backup_watchdog`) — just as WP-Cron-dependent as the original
+ * dispatch, so a site with no qualifying traffic (or DISABLE_WP_CRON) could
+ * never recover a stuck row. sweepStalled() is a WP-Cron-INDEPENDENT
+ * reaper, driven from ordinary request traffic via
+ * Plugin::maybeSweepStalledBackups() (see PluginBackupSweepTest.php),
+ * that finds stale non-terminal rows via the existing `KEY phase` +
+ * `KEY last_progress_at` indexes and resumes each one through
+ * resumeIfStalled() — the exact same body run() (the WP-Cron callback) used
+ * before, now reusable.
+ *
+ * Covers:
+ *   3. Stale queued re-dispatch: sweepStalled() bumps resume_count and
+ *      enters TaskRunner (phase advances past queued); a fresh row is left
+ *      untouched.
+ *   5. Breadcrumb distinguishability: dispatch()'s dispatch_entered stamp.
+ *   8. resume_count cap preserved: a row already at max_resumes is marked
+ *      failed, not resumed again.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Backup\TaskRunner;
+use WPMgr\Agent\Backup\Watchdog;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\Watchdog
+ */
+final class WatchdogReaperTest extends TestCase
+{
+    private const STALE_ID = 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff';
+    private const FRESH_ID = 'cccccccc-dddd-4eee-8fff-000000000000';
+    private const CAPPED_ID = 'dddddddd-eeee-4fff-8000-111111111111';
+
+    private string $root       = '';
+    private string $scratchDir = '';
+    private string $wpContent  = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        if (!class_exists(\ZipArchive::class)) {
+            self::markTestSkipped('ext-zip not available');
+        }
+
+        $this->root       = sys_get_temp_dir() . '/wpmgr-reaper-test-' . bin2hex(random_bytes(6));
+        $this->scratchDir = $this->root . '/scratch';
+        $this->wpContent  = $this->root . '/wp-content';
+        mkdir($this->scratchDir, 0755, true);
+        mkdir($this->wpContent, 0755, true);
+        file_put_contents($this->wpContent . '/marker.txt', 'a real file for FilesArchiver to pack');
+
+        Functions\when('wp_json_encode')->alias(static fn ($d) => json_encode($d));
+        Functions\when('wp_schedule_single_event')->justReturn(true);
+    }
+
+    protected function tear_down(): void
+    {
+        unset($GLOBALS['wpdb']);
+        $this->rrmdir($this->root);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /** @return array<string,mixed> Minimal-but-valid TaskRunner params for kind=files. */
+    private function runnerParams(string $snapshotId): array
+    {
+        return [
+            'snapshot_id'       => $snapshotId,
+            'kind'              => 'files',
+            // Deliberately NOT a valid age recipient — this test only needs
+            // the phase machine to LEAVE `queued`, not to complete; the
+            // eventual failure (and its row DELETE) happens well after the
+            // phase-advancement assertions below are captured via update()
+            // history, so a real AgeCrypto identity + network stubs are
+            // unnecessary overhead here.
+            'age_recipient'     => 'age1' . str_repeat('q', 58),
+            'presign_endpoint'  => 'https://cp.invalid/agent/v1/backups/reaper-test/presign',
+            'manifest_endpoint' => 'https://cp.invalid/agent/v1/backups/reaper-test/manifest',
+            'progress_endpoint' => '',
+            'chunk_bytes'       => 4 * 1024 * 1024,
+            'scratch_dir'       => $this->scratchDir . '/' . $snapshotId,
+            'wp_content_path'   => $this->wpContent,
+            'db'                => ['host' => 'localhost', 'user' => 'u', 'password' => 'p', 'name' => 'n', 'prefix' => 'wp_'],
+        ];
+    }
+
+    /** Every update() call recorded for a given snapshot id, oldest first. */
+    private function updatesFor(FakeBackupTasksWpdb $wpdb, string $snapshotId): array
+    {
+        return array_values(array_filter(
+            $wpdb->updates,
+            static fn (array $u): bool => ($u['where']['snapshot_id'] ?? null) === $snapshotId
+        ));
+    }
+
+    // ------------------------------------------------------------------
+    // Test 3: stale queued re-dispatch (sweepStalled + resumeIfStalled).
+    // ------------------------------------------------------------------
+
+    public function test_sweep_stalled_resumes_stale_row_and_leaves_fresh_row_untouched(): void
+    {
+        $wpdb = new FakeBackupTasksWpdb();
+
+        // Stale: last_progress_at 200s ago (past STALL_THRESHOLD_SECONDS=180),
+        // resume_count=0, valid sub_state.params.
+        $wpdb->seedRow(self::STALE_ID, [
+            'phase'            => TaskRunner::PHASE_QUEUED,
+            'started_at'       => time() - 200,
+            'last_progress_at' => time() - 200,
+            'resume_count'     => 0,
+            'sub_state'        => (string) json_encode(['params' => $this->runnerParams(self::STALE_ID)]),
+        ]);
+
+        // Fresh: last_progress_at just now — must NOT be touched.
+        $wpdb->seedRow(self::FRESH_ID, [
+            'phase'            => TaskRunner::PHASE_QUEUED,
+            'started_at'       => time(),
+            'last_progress_at' => time(),
+            'resume_count'     => 0,
+            'sub_state'        => (string) json_encode(['params' => $this->runnerParams(self::FRESH_ID)]),
+        ]);
+
+        $GLOBALS['wpdb'] = $wpdb;
+
+        Watchdog::sweepStalled();
+
+        // The stale row's resume_count must have been bumped to 1 (recorded
+        // via update() history — the row itself may since have advanced past
+        // queued, or even been deleted on eventual failure deep in the
+        // pipeline, since the recipient is a shape-only fake).
+        $staleUpdates = $this->updatesFor($wpdb, self::STALE_ID);
+        $this->assertNotEmpty($staleUpdates, 'sweepStalled() must have resumed the stale row');
+        $resumeBump = null;
+        foreach ($staleUpdates as $u) {
+            if (array_key_exists('resume_count', $u['data'])) {
+                $resumeBump = $u['data']['resume_count'];
+                break;
+            }
+        }
+        $this->assertSame(1, $resumeBump, 'the first resume must bump resume_count from 0 to 1');
+
+        // Phase must have advanced past `queued` at some point (proof the
+        // resumed TaskRunner actually entered the phase machine, not just a
+        // resume_count bump with no re-entry).
+        $advancedPastQueued = false;
+        foreach ($staleUpdates as $u) {
+            if (($u['data']['phase'] ?? null) === TaskRunner::PHASE_ARCHIVING_FILES) {
+                $advancedPastQueued = true;
+                break;
+            }
+        }
+        $this->assertTrue($advancedPastQueued, 'the resumed runner must advance phase past queued');
+
+        // The fresh row must be completely untouched: no updates recorded.
+        $this->assertEmpty($this->updatesFor($wpdb, self::FRESH_ID), 'a fresh (non-stale) row must never be resumed');
+        $freshRow = $wpdb->rows[self::FRESH_ID] ?? null;
+        $this->assertNotNull($freshRow);
+        $this->assertSame(TaskRunner::PHASE_QUEUED, $freshRow['phase']);
+        $this->assertSame(0, $freshRow['resume_count']);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 5: breadcrumb distinguishability — dispatch_entered.
+    //
+    // (The "no stage marker on a freshly seeded row" rung of the ladder is a
+    // property of FakeBackupTasksWpdb::seedRow() itself, not of any
+    // production code path — asserting it here would be a fixture tautology,
+    // not a regression lock, so it is intentionally not a separate test. The
+    // real ladder step under test is the transition BELOW: a freshly seeded
+    // row that gets dispatch()-ed acquires the dispatch_entered stamp.)
+    // ------------------------------------------------------------------
+
+    public function test_dispatch_stamps_dispatch_entered_even_when_params_are_missing(): void
+    {
+        $wpdb = new FakeBackupTasksWpdb();
+        $seededAt = time() - 500;
+        $wpdb->seedRow(self::STALE_ID, [
+            'phase'            => TaskRunner::PHASE_QUEUED,
+            'started_at'       => $seededAt,
+            'last_progress_at' => $seededAt,
+            // No 'params' key — dispatch() must stamp the breadcrumb and
+            // THEN bail cleanly (never construct/attempt a TaskRunner).
+            'sub_state'        => '{}',
+        ]);
+        $GLOBALS['wpdb'] = $wpdb;
+
+        Watchdog::dispatch(self::STALE_ID);
+
+        $row = $wpdb->rows[self::STALE_ID] ?? null;
+        $this->assertNotNull($row, 'dispatch() must not delete a non-terminal row it cannot rehydrate');
+
+        $subState = json_decode((string) $row['sub_state'], true);
+        $this->assertIsArray($subState);
+        $this->assertSame('dispatch_entered', $subState['stage'] ?? null, 'dispatch() must stamp stage=dispatch_entered on entry');
+        $this->assertGreaterThan($seededAt, $row['last_progress_at'], 'dispatch() must touch last_progress_at even when it cannot proceed further');
+        $this->assertSame(TaskRunner::PHASE_QUEUED, $row['phase'], 'the phase itself must be untouched by the breadcrumb stamp alone');
+    }
+
+    // ------------------------------------------------------------------
+    // Test 8: resume_count cap preserved.
+    // ------------------------------------------------------------------
+
+    public function test_resume_count_at_cap_is_marked_failed_not_resumed(): void
+    {
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->seedRow(self::CAPPED_ID, [
+            'phase'            => TaskRunner::PHASE_QUEUED,
+            'started_at'       => time() - 200,
+            'last_progress_at' => time() - 200,
+            'resume_count'     => 6,
+            'max_resumes'      => 6,
+            'sub_state'        => (string) json_encode(['params' => $this->runnerParams(self::CAPPED_ID)]),
+        ]);
+        $GLOBALS['wpdb'] = $wpdb;
+
+        Watchdog::sweepStalled();
+
+        $row = $wpdb->rows[self::CAPPED_ID] ?? null;
+        $this->assertNotNull($row, 'a capped-out row is marked failed, not deleted, by this branch');
+        $this->assertSame(TaskRunner::PHASE_FAILED, $row['phase'], 'a row at resume_count>=max_resumes must be marked failed, never resumed again');
+        $this->assertSame(6, $row['resume_count'], 'resume_count must NOT be bumped past the cap');
+    }
+
+    /** Recursive delete used only for test fixture cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if ($dir === '' || !is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.63
+ * Version:           0.61.64
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.63');
+define('WPMGR_AGENT_VERSION', '0.61.64');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/web/src/features/orgs/use-orgs.test.ts
+++ b/apps/web/src/features/orgs/use-orgs.test.ts
@@ -6,15 +6,30 @@ import { createElement, type ReactNode } from "react";
 // Mock the transport, toast, SSE reset, and router so useActivateOrg's and
 // useDeleteOrg's onSuccess can be exercised without a network call, the real
 // event stream, or a real TanStack Router instance (GH #186).
-const { deleteMock, postMock, toastSuccess, toastError, resetSiteStreamMock, routerInvalidateMock } =
-  vi.hoisted(() => ({
-    deleteMock: vi.fn(),
-    postMock: vi.fn(),
-    toastSuccess: vi.fn(),
-    toastError: vi.fn(),
-    resetSiteStreamMock: vi.fn(),
-    routerInvalidateMock: vi.fn(),
-  }));
+//
+// `routerState` also backs GH #233's redirect check (`router.state.location`)
+// -- it's a plain mutable object (not reassigned) so individual tests can set
+// `routerState.location.pathname` before switching orgs, and `routerNavigateMock`
+// lets those tests assert whether `router.navigate({ to: "/sites" })` fired.
+const {
+  deleteMock,
+  postMock,
+  toastSuccess,
+  toastError,
+  resetSiteStreamMock,
+  routerInvalidateMock,
+  routerNavigateMock,
+  routerState,
+} = vi.hoisted(() => ({
+  deleteMock: vi.fn(),
+  postMock: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  resetSiteStreamMock: vi.fn(),
+  routerInvalidateMock: vi.fn(),
+  routerNavigateMock: vi.fn(),
+  routerState: { location: { pathname: "/dashboard" } },
+}));
 vi.mock("@wpmgr/api", () => ({
   client: { delete: deleteMock, get: vi.fn(), post: postMock, patch: vi.fn() },
 }));
@@ -22,7 +37,13 @@ vi.mock("@/components/toast", () => ({
   toast: { success: toastSuccess, error: toastError },
 }));
 vi.mock("@/features/sites/use-site-events", () => ({ resetSiteStream: resetSiteStreamMock }));
-vi.mock("@/router", () => ({ router: { invalidate: routerInvalidateMock } }));
+vi.mock("@/router", () => ({
+  router: {
+    invalidate: routerInvalidateMock,
+    navigate: routerNavigateMock,
+    state: routerState,
+  },
+}));
 
 import {
   mapDeleteOrgError,
@@ -30,6 +51,7 @@ import {
   useActivateOrg,
   useDeleteOrg,
 } from "./use-orgs";
+import { sitesKeys, NotFoundError as SiteNotFoundError } from "@/features/sites/use-sites";
 
 function hookWrapper({ children }: { children: ReactNode }) {
   const qc = new QueryClient({
@@ -141,6 +163,8 @@ describe("useDeleteOrg success toast", () => {
     toastError.mockReset();
     resetSiteStreamMock.mockReset();
     routerInvalidateMock.mockReset();
+    routerNavigateMock.mockReset();
+    routerState.location.pathname = "/dashboard";
   });
 
   it("hard delete shows a permanently-deleted toast with no grace-window description", async () => {
@@ -187,6 +211,8 @@ describe("useActivateOrg actively refetches mounted queries — GH #186", () => 
     toastError.mockReset();
     resetSiteStreamMock.mockReset();
     routerInvalidateMock.mockReset();
+    routerNavigateMock.mockReset();
+    routerState.location.pathname = "/dashboard";
   });
 
   it("refetches a mounted org-scoped query on switch, with NO SSE event, proving the empty-target-org case", async () => {
@@ -299,5 +325,116 @@ describe("useDeleteOrg actively refetches mounted queries — GH #186", () => {
     await waitFor(() => expect(membersQueryFn).toHaveBeenCalledTimes(2));
     expect(resetSiteStreamMock).toHaveBeenCalledTimes(1);
     expect(routerInvalidateMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH #233: switching org while parked on a site-detail route (`/sites/$id/*`)
+// for a site that belongs to the PREVIOUS org must not leave the operator
+// staring at a raw "site not found" error. `resetQueries()` above already
+// reset + refetched the mounted `useSite(siteId)` query under the new
+// session; when that refetch comes back NotFound, `useActivateOrg` redirects
+// to `/sites` (the new org's default list) instead of leaving the dead page
+// up. These tests drive that mounted query directly (keyed on
+// `sitesKeys.detail(siteId)`, exactly what `useSite` reads/writes) rather
+// than mocking `useSite` itself, so the assertion exercises the real
+// query-key contract between the two hooks.
+// ---------------------------------------------------------------------------
+
+describe("useActivateOrg redirects off a stale site-detail route — GH #233", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    toastSuccess.mockReset();
+    toastError.mockReset();
+    resetSiteStreamMock.mockReset();
+    routerInvalidateMock.mockReset();
+    routerNavigateMock.mockReset();
+    routerState.location.pathname = "/dashboard";
+  });
+
+  it("redirects to /sites when the site under the current route 404s in the new org", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = wrapperFor(qc);
+
+    // Mirrors useSite("site-1") mounted by the site-detail layout: resolves
+    // under the OLD org, then 404s once refetched under the NEW org.
+    const siteQueryFn = vi
+      .fn()
+      .mockResolvedValueOnce({ id: "site-1", name: "Old org's site" })
+      .mockRejectedValueOnce(new SiteNotFoundError("Site not found"));
+    const site = renderHook(
+      () => useQuery({ queryKey: sitesKeys.detail("site-1"), queryFn: siteQueryFn }),
+      { wrapper },
+    );
+    await waitFor(() => expect(site.result.current.data).toEqual({ id: "site-1", name: "Old org's site" }));
+
+    routerState.location.pathname = "/sites/site-1/health";
+
+    postMock.mockResolvedValue({ data: { active_tenant_id: "org-2" }, error: undefined });
+    const activate = renderHook(() => useActivateOrg(), { wrapper });
+    await activate.result.current.mutateAsync("org-2");
+
+    await waitFor(() => expect(site.result.current.error).toBeInstanceOf(SiteNotFoundError));
+    expect(routerNavigateMock).toHaveBeenCalledTimes(1);
+    expect(routerNavigateMock).toHaveBeenCalledWith({ to: "/sites" });
+  });
+
+  it("does NOT redirect when the site under the current route still exists in the new org", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = wrapperFor(qc);
+
+    const siteQueryFn = vi
+      .fn()
+      .mockResolvedValueOnce({ id: "site-1", name: "Shared site" })
+      .mockResolvedValueOnce({ id: "site-1", name: "Shared site" });
+    const site = renderHook(
+      () => useQuery({ queryKey: sitesKeys.detail("site-1"), queryFn: siteQueryFn }),
+      { wrapper },
+    );
+    await waitFor(() => expect(site.result.current.data).toEqual({ id: "site-1", name: "Shared site" }));
+
+    routerState.location.pathname = "/sites/site-1/health";
+
+    postMock.mockResolvedValue({ data: { active_tenant_id: "org-2" }, error: undefined });
+    const activate = renderHook(() => useActivateOrg(), { wrapper });
+    await activate.result.current.mutateAsync("org-2");
+
+    await waitFor(() => expect(siteQueryFn).toHaveBeenCalledTimes(2));
+    expect(routerNavigateMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT redirect when switching org from a non-site route (e.g. /dashboard)", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = wrapperFor(qc);
+
+    routerState.location.pathname = "/dashboard";
+
+    postMock.mockResolvedValue({ data: { active_tenant_id: "org-2" }, error: undefined });
+    const activate = renderHook(() => useActivateOrg(), { wrapper });
+    await activate.result.current.mutateAsync("org-2");
+
+    expect(routerNavigateMock).not.toHaveBeenCalled();
+    expect(routerInvalidateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT redirect when switching org while already on the /sites list", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = wrapperFor(qc);
+
+    routerState.location.pathname = "/sites";
+
+    postMock.mockResolvedValue({ data: { active_tenant_id: "org-2" }, error: undefined });
+    const activate = renderHook(() => useActivateOrg(), { wrapper });
+    await activate.result.current.mutateAsync("org-2");
+
+    expect(routerNavigateMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/orgs/use-orgs.ts
+++ b/apps/web/src/features/orgs/use-orgs.ts
@@ -2,6 +2,7 @@ import {
   useMutation,
   useQuery,
   useQueryClient,
+  type QueryClient,
   type UseMutationResult,
   type UseQueryResult,
 } from "@tanstack/react-query";
@@ -9,6 +10,7 @@ import { client } from "@wpmgr/api";
 
 import { toError } from "@/features/auth/use-auth";
 import { resetSiteStream } from "@/features/sites/use-site-events";
+import { sitesKeys, NotFoundError as SiteNotFoundError } from "@/features/sites/use-sites";
 import { toast } from "@/components/toast";
 import { router } from "@/router";
 
@@ -88,6 +90,56 @@ export function useCreateOrg(): UseMutationResult<
 }
 
 // ---------------------------------------------------------------------------
+// GH #233 — org switch off a site-detail route for a site the new org
+// doesn't have.
+//
+// Matches a site-detail path — "/sites/<id>", "/sites/<id>/health",
+// "/sites/<id>/backups/<snapshotId>", etc. Deliberately does NOT match the
+// bare "/sites" list route (no id segment after it), so the normal case
+// (switching org while already on the list, or on a non-site route like
+// /dashboard) never triggers a redirect.
+const SITE_DETAIL_PATH = /^\/sites\/([^/]+)/;
+
+function siteIdFromPathname(pathname: string): string | null {
+  const match = SITE_DETAIL_PATH.exec(pathname);
+  return match?.[1] ?? null;
+}
+
+/**
+ * An org switch can leave a mounted site-detail route (`/sites/$siteId/...`)
+ * pointing at a site that belongs to the PREVIOUS org — it does not exist
+ * under the newly-activated one, and the CP's `getSite` 404s. The caller's
+ * `resetQueries()` already reset + refetched that route's `useSite(siteId)`
+ * query (it's observed, since we're on that very route) under the new
+ * session; if that refetch came back NotFound, staying put would surface a
+ * raw "site not found" error for what is really just an org mismatch, not a
+ * deleted/missing site. Redirect to `/sites` (the new org's default list)
+ * instead — the same place a hard reload would land an operator whose deep
+ * link no longer resolves.
+ *
+ * This is a no-op for every other route (dashboard, /sites itself, settings,
+ * ...) and for a site that DOES exist in the new org (no NotFoundError → no
+ * redirect, the tab just shows the new org's version of that site).
+ *
+ * Proactive check (reading the just-reset query state) rather than a
+ * catch-in-the-route approach: it composes with the existing
+ * resetQueries/resetSiteStream/router.invalidate sequence already
+ * orchestrated here for a tenant-context change, so there is exactly one
+ * place that reacts to "the active org changed out from under the current
+ * page" instead of duplicating that reaction in the route's error boundary.
+ */
+async function redirectIfSiteRouteWentStale(
+  queryClient: QueryClient,
+): Promise<void> {
+  const siteId = siteIdFromPathname(router.state.location.pathname);
+  if (!siteId) return;
+  const state = queryClient.getQueryState(sitesKeys.detail(siteId));
+  if (state?.error instanceof SiteNotFoundError) {
+    await router.navigate({ to: "/sites" });
+  }
+}
+
+// ---------------------------------------------------------------------------
 // POST /api/v1/orgs/{orgId}/activate
 // Switch the session's active org. Actively resets + refetches ALL server
 // state (GH #186 — a passive `clear()` never notifies mounted observers) so
@@ -130,6 +182,10 @@ export function useActivateOrg(): UseMutationResult<
       // (push) path re-establishes under the new tenant too, with a fresh
       // cursor (see resetSiteStream's doc for why the cursor must be dropped).
       resetSiteStream();
+      // GH #233: if we just landed on a site-detail route for a site the
+      // newly-activated org doesn't have, get off that dead page BEFORE
+      // re-running loaders below — see redirectIfSiteRouteWentStale's doc.
+      await redirectIfSiteRouteWentStale(queryClient);
       // Re-run the `_authed` route's beforeLoad/loaders (ensureMe, the
       // superadmin bounce, per-route prefetches, ...) under the new tenant —
       // the same thing a hard browser reload does.


### PR DESCRIPTION
Two bug fixes, independent subsystems, batched into one release.

## #232 (agent) — scheduled backups stall permanently at `phase='queued'`
**Root cause:** the backup started only via WP-Cron (the one in-process fallback was registered *only* when the loopback was gated), and its self-healing watchdog ran on the same WP-Cron. On a quiet / off-peak / `DISABLE_WP_CRON` site the run could silently never start **and** the watchdog never fire → task stuck at `queued` forever, `resume_count` frozen at 0, no error (reported as a rotating ~10-30% of a 22-site fleet failing nightly). Not a lock-race — there was no lock at all.

**Fix** (the #226 lesson — recovery must not share the failure domain it recovers):
- Always register the in-process shutdown runner (cron-independent start); keep `wp_schedule_single_event` + `spawn_cron` as secondary.
- Request-driven `Watchdog::sweepStalled` reaper on `plugins_loaded` (enrolled-gated, 60s stamp-before-run throttle, try/catch) re-dispatches stalled tasks with no cron tick; `run()` refactored to a reusable `resumeIfStalled()` preserving every guard.
- **Concurrency:** the now-guaranteed double-fire is deduped by a MySQL `GET_LOCK` **and** an authoritative connection-independent `flock` — so a dropped `$wpdb` connection mid-dump can't silently release the lock and let a second runner corrupt the scratch dir (an adversarial-verify HIGH finding, fixed). `.lock` unlinked on terminal + swept by the janitor (no new leak).
- Durable `sub_state.stage` breadcrumbs + debug-gated phase logging.

## #233 (web) — "no website" error on org switch while viewing a site
`useActivateOrg` now redirects to `/sites` when the mounted site query 404s under the new org (reusing the GH #186 `resetQueries → resetSiteStream → invalidate` orchestration).

## Verification
Adversarially verified (3-lens + re-verify): concurrency **CLEAN** (flock closes the double-run hole, no leak, flock+unlink race negligible), recovery guaranteed, no #131/loopback regression, tests mutation-proven.
- Agent: `phpunit` 2712 green, `phpcs` 0, `wp plugin check` 0
- Web: 1016 tests green, `lint` 0

Closes #232
Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Scheduled backups now recover and resume reliably instead of remaining stuck in “queued.”
  - Improved protection against duplicate backup runs and cleanup of abandoned backup activity.
  - Switching organizations from a site details page now redirects to the Sites list when that site is unavailable.

- **Changed**
  - Real User Monitoring now includes a readable, non-minified collector build alongside the minified version, with no runtime behavior changes.

- **Tests**
  - Added regression coverage for backup recovery, concurrency, cleanup, and organization-switching navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->