### PR TITLE
fix(api,web,media-encoder): self-diagnose 2FA key-rotation (#215) + screenshot settle (#229) — 0.61.65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.65] - 2026-07-16
+
+### Changed
+
+- Two-factor and other stored secrets that can no longer be decrypted (because the secrets-at-rest encryption key changed) now fail loudly and clearly instead of looking like a wrong code (GH #215). If the encryption key is not pinned on a self-hosted install and the platform regenerates it across restarts, the previously-stored secret can no longer be read. The control plane now logs a fingerprint of the resolved key at startup (so a changed key across restarts is visible), warns at boot when stored secrets no longer decrypt (with the exact remediation: pin a stable `WPMGR_SITE_DEST_AGE_SECRET`), and shows a precise "the server's encryption key changed, sign in with a recovery code and re-enroll" message at the two-factor prompt instead of a generic failure. This is a diagnosability improvement; the underlying encryption behavior is unchanged (a pinned key was and remains stable across restarts).
+
+### Fixed
+
+- Website screenshots for slow-loading or uncached pages are no longer blank (GH #229). The capture worker previously snapshotted almost immediately; it now waits for the page load, network idle, and DOM to settle (with a short additional render delay), all bounded by a hard timeout so a slow page degrades to a best-effort partial capture rather than hanging or coming back blank.
+
 ## [0.61.64] - 2026-07-16
 
 ### Fixed

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.64
+ * Version:           0.61.65
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.64');
+define('WPMGR_AGENT_VERSION', '0.61.65');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/api/cmd/wpmgr/age_selfcheck.go
+++ b/apps/api/cmd/wpmgr/age_selfcheck.go
@@ -1,0 +1,309 @@
+package main
+
+// age_selfcheck.go — GH #215 diagnosability follow-up. The secrets-at-rest
+// age identity derivation itself is correct (see resolveAgeIdentity); the gap
+// this file closes is that a ROTATED key was previously silent at boot and
+// only surfaced later as a generic, unrelated-looking failure (e.g. "invalid
+// 2FA code" at login, or a mail-send failure). Two independent, non-secret
+// boot-time signals close that gap:
+//
+//  1. ageRecipientFingerprint — a short, non-secret fingerprint of the
+//     resolved identity's PUBLIC recipient, logged alongside the existing
+//     "source" line. Two boots that log a DIFFERENT fingerprint used a
+//     different key, full stop — a trivial, definitive comparison an
+//     operator can make across a restart/redeploy.
+//  2. ageIdentitySelfCheck — a best-effort boot probe that samples a bounded
+//     set of ALREADY-STORED at-rest ciphertexts and attempts to decrypt them
+//     with the resolved identity. If every sampled secret fails specifically
+//     with age's "wrong identity" signature, the key has rotated since those
+//     secrets were written, and we say so loudly with the exact remediation.
+//
+// Neither signal changes any crypto behavior, any resolution precedence, or
+// any request-path error mapping (twofa.go's totp_decrypt_failed domain error
+// is unchanged). Both are pure, additive diagnostics and both are designed to
+// never delay or block boot: bounded sample size, a short context timeout,
+// and a recover() so even a bug in this file degrades to a debug log line
+// rather than taking the process down.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"log/slog"
+	"time"
+
+	"filippo.io/age"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/cryptbox"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+)
+
+// ageFingerprintHexLen is the number of hex characters (4 bytes) of the
+// recipient's sha256 digest logged as the fingerprint — enough to make two
+// different keys distinguishable at a glance, short enough to stay a log
+// scalar rather than a wall of hex.
+const ageFingerprintHexLen = 8
+
+// ageRecipientFingerprint returns the first ageFingerprintHexLen hex
+// characters of sha256(recipient string) for the resolved identity's PUBLIC
+// age recipient ("age1..."). It is NEVER the secret key — RecipientString()
+// already only ever returns the public recipient — so this value is always
+// safe to log. Comparing it across two boots (e.g. before/after a redeploy
+// that may have regenerated WPMGR_SESSION_SECRET) is a definitive signal of
+// whether the resolved secrets-at-rest key changed.
+//
+// Returns "" for a nil identity or one with no recipient (defensive; never
+// happens for a successfully-resolved identity from resolveAgeIdentity).
+func ageRecipientFingerprint(id *cryptbox.AgeIdentity) string {
+	if id == nil {
+		return ""
+	}
+	recipient := id.RecipientString()
+	if recipient == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(recipient))
+	return hex.EncodeToString(sum[:])[:ageFingerprintHexLen]
+}
+
+// ageSelfCheckSampleLimit bounds how many existing at-rest ciphertexts the
+// boot self-check will ever fetch or attempt to decrypt, across all sources
+// combined. Kept small: this is a diagnostic sanity check, not a migration or
+// audit — it only needs enough samples to distinguish "one corrupted row"
+// from "every sampled secret fails the same way" (a rotated key).
+const ageSelfCheckSampleLimit = 5
+
+// ageSelfCheckTimeout bounds the total wall-clock time the self-check's DB
+// sampling is allowed to take. It is intentionally short: on a healthy
+// instance these are a handful of indexed/singleton-row reads, and a slow or
+// unreachable DB should degrade this diagnostic to a skipped debug line, not
+// add meaningful latency to boot.
+const ageSelfCheckTimeout = 3 * time.Second
+
+// ageSecretSample is one existing at-rest ciphertext blob sampled for the
+// boot-time decrypt self-check, tagged with a human-readable source label
+// (e.g. "users.totp_secret_encrypted") used only for logging.
+type ageSecretSample struct {
+	source     string
+	ciphertext []byte
+}
+
+// ageSecretSampler abstracts "fetch a small bounded sample of existing
+// at-rest ciphertexts" so the self-check's decision logic
+// (classifyAgeSelfCheck) can be table-driven tested without a live database.
+// dbAgeSecretSampler is the sole production implementation.
+type ageSecretSampler interface {
+	Sample(ctx context.Context) ([]ageSecretSample, error)
+}
+
+// dbAgeSecretSampler is the production ageSecretSampler. It samples up to
+// ageSelfCheckSampleLimit confirmed users.totp_secret_encrypted rows, and —
+// if there is still room in the budget — the smtp_settings singleton's
+// password_enc, if one has ever been set. Both are read-only.
+//
+// users carries no Row-Level Security (see db/schema.sql), so it is queried
+// directly. smtp_settings IS RLS-forced with only an app.agent='on' escape
+// policy (m30), so that read runs under pool.InAgentTx, exactly like every
+// other production reader of that table (e.g. the mailer's DB resolver).
+type dbAgeSecretSampler struct {
+	pool *db.Pool
+}
+
+func (s dbAgeSecretSampler) Sample(ctx context.Context) ([]ageSecretSample, error) {
+	if s.pool == nil {
+		return nil, errors.New("age self-check: nil db pool")
+	}
+
+	var samples []ageSecretSample
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT totp_secret_encrypted
+		   FROM users
+		  WHERE totp_secret_encrypted IS NOT NULL
+		    AND totp_confirmed_at IS NOT NULL
+		  ORDER BY id
+		  LIMIT $1`,
+		ageSelfCheckSampleLimit,
+	)
+	if err != nil {
+		return nil, errors.New("age self-check: sample users.totp_secret_encrypted: " + err.Error())
+	}
+	for rows.Next() {
+		var ct []byte
+		if scanErr := rows.Scan(&ct); scanErr != nil {
+			rows.Close()
+			return samples, errors.New("age self-check: scan users.totp_secret_encrypted: " + scanErr.Error())
+		}
+		samples = append(samples, ageSecretSample{source: "users.totp_secret_encrypted", ciphertext: ct})
+	}
+	rowsErr := rows.Err()
+	rows.Close()
+	if rowsErr != nil {
+		return samples, errors.New("age self-check: iterate users.totp_secret_encrypted: " + rowsErr.Error())
+	}
+
+	if len(samples) >= ageSelfCheckSampleLimit {
+		return samples, nil
+	}
+
+	// Best-effort second source: a failure here (e.g. smtp_settings has never
+	// been configured, or a transient DB hiccup) must not discard whatever
+	// users.totp_secret_encrypted samples were already gathered above.
+	_ = s.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
+		var ct []byte
+		qErr := tx.QueryRow(ctx, `SELECT password_enc FROM smtp_settings WHERE password_enc IS NOT NULL LIMIT 1`).Scan(&ct)
+		if qErr != nil {
+			return nil //nolint:nilerr // best-effort second source; see comment above
+		}
+		samples = append(samples, ageSecretSample{source: "smtp_settings.password_enc", ciphertext: ct})
+		return nil
+	})
+
+	return samples, nil
+}
+
+// ageSampleOutcome classifies a single sample's decrypt attempt.
+type ageSampleOutcome int
+
+const (
+	// ageOutcomeOK means the sample decrypted successfully with the resolved
+	// identity.
+	ageOutcomeOK ageSampleOutcome = iota
+	// ageOutcomeWrongIdentity means decryption failed specifically with age's
+	// "no identity matched any of the recipients" signature — the fingerprint
+	// of a genuinely different key than the one the ciphertext was encrypted
+	// under, i.e. a rotated shared identity.
+	ageOutcomeWrongIdentity
+	// ageOutcomeOther means decryption failed for any other reason (malformed
+	// ciphertext, truncated data, etc.) — evidence of a corrupted row, not
+	// necessarily a rotated key.
+	ageOutcomeOther
+)
+
+// isWrongAgeIdentity reports whether err is age's specific "none of the
+// supplied identities could unwrap this file" failure
+// (age.NoIdentityMatchError, which always wraps age.ErrIncorrectIdentity).
+// cryptbox.AgeIdentity.Decrypt wraps the underlying age error with %w, and
+// NoIdentityMatchError itself unwraps to its per-stanza ErrIncorrectIdentity
+// causes, so errors.Is sees straight through both wrapping layers.
+//
+// This is deliberately narrower than "any decrypt error": a malformed/
+// truncated ciphertext fails at header-parse time with an unrelated error
+// (not ErrIncorrectIdentity) and must NOT be classified as a key rotation —
+// only a structurally-valid age file whose recipient stanza does not match
+// the resolved identity's key is.
+func isWrongAgeIdentity(err error) bool {
+	return errors.Is(err, age.ErrIncorrectIdentity)
+}
+
+// classifyAgeSelfCheck turns a set of per-sample decrypt outcomes into a
+// boot-log decision.
+//
+//   - No samples at all (fresh install, or nothing sampled): (false, false) —
+//     the caller must treat this as "do nothing", never a false alarm.
+//   - Every sample decrypted OK: (false, true) — nothing to report beyond an
+//     optional quiet confirmation.
+//   - EVERY sample failed with the SAME wrong-identity signature: (true,
+//     false) — this is the rotated-key fingerprint; warn loudly.
+//   - Anything else (a mix of OK/failed, or failures that are not the
+//     wrong-identity signature): (false, false) — deliberately NOT a warning.
+//     A single failing sample could just be one corrupted row; requiring the
+//     failure across the WHOLE sample before crying wolf is the point — a
+//     genuinely rotated shared key fails every sample encrypted under the
+//     old one, not just one.
+func classifyAgeSelfCheck(outcomes []ageSampleOutcome) (warn bool, allOK bool) {
+	if len(outcomes) == 0 {
+		return false, false
+	}
+	wrongCount, okCount := 0, 0
+	for _, o := range outcomes {
+		switch o {
+		case ageOutcomeWrongIdentity:
+			wrongCount++
+		case ageOutcomeOK:
+			okCount++
+		}
+	}
+	if wrongCount == len(outcomes) {
+		return true, false
+	}
+	return false, okCount == len(outcomes)
+}
+
+// ageIdentitySelfCheck is the production entry point, called once at boot
+// right after the shared secrets-at-rest identity is resolved. It is
+// best-effort and MUST NEVER block or crash boot:
+//
+//   - a bounded ageSelfCheckTimeout caps how long sampling may run;
+//   - a recover() guards against any panic in this diagnostic path;
+//   - any sampling error (nil pool, query failure, context deadline) degrades
+//     to a single debug line, never a warning and never a returned error.
+//
+// It logs nothing at all when there is nothing to check (fresh install, or a
+// degraded/failed sample that yields zero rows) — that is the explicit
+// "never a false alarm on an empty instance" guarantee.
+func ageIdentitySelfCheck(ctx context.Context, pool *db.Pool, id *cryptbox.AgeIdentity, logger *slog.Logger) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Debug("secrets-at-rest age self-check: recovered from panic, skipping (best-effort)", slog.Any("panic", r))
+		}
+	}()
+	if pool == nil || id == nil || logger == nil {
+		return
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, ageSelfCheckTimeout)
+	defer cancel()
+
+	runAgeIdentitySelfCheck(cctx, dbAgeSecretSampler{pool: pool}, id, logger)
+}
+
+// runAgeIdentitySelfCheck is the testable core of the self-check: sample,
+// decrypt, classify, log. Split out from ageIdentitySelfCheck so tests can
+// inject a fake ageSecretSampler and a real (but throwaway) cryptbox identity
+// pair without a live database.
+func runAgeIdentitySelfCheck(ctx context.Context, sampler ageSecretSampler, id *cryptbox.AgeIdentity, logger *slog.Logger) {
+	samples, err := sampler.Sample(ctx)
+	if err != nil {
+		logger.Debug("secrets-at-rest age self-check: sampling failed, skipping (best-effort)", slog.Any("error", err))
+	}
+	if len(samples) == 0 {
+		return
+	}
+
+	outcomes := make([]ageSampleOutcome, len(samples))
+	for i, s := range samples {
+		_, decErr := id.Decrypt(s.ciphertext)
+		switch {
+		case decErr == nil:
+			outcomes[i] = ageOutcomeOK
+		case isWrongAgeIdentity(decErr):
+			outcomes[i] = ageOutcomeWrongIdentity
+		default:
+			outcomes[i] = ageOutcomeOther
+		}
+	}
+
+	warn, allOK := classifyAgeSelfCheck(outcomes)
+	switch {
+	case warn:
+		logger.Warn("secrets-at-rest age identity self-check FAILED: the secrets-at-rest key has changed "+
+			"since these secrets were stored — every sampled secret failed to decrypt with the currently "+
+			"resolved key. Every TOTP/SMTP/other secret encrypted under the previous key is now unreadable. "+
+			"On a PaaS that regenerates env per deploy, pin a stable WPMGR_SITE_DEST_AGE_SECRET (recommended) "+
+			"or a stable WPMGR_SESSION_SECRET, then sign in with a recovery code and re-enter secrets (2FA/SMTP)",
+			slog.Int("sampled", len(samples)),
+			slog.Int("failed", len(samples)),
+		)
+	case allOK:
+		logger.Debug("secrets-at-rest age self-check: all sampled secrets decrypted OK", slog.Int("sampled", len(samples)))
+	default:
+		// Ambiguous: a mix of outcomes, or failures that were not the
+		// wrong-identity signature (e.g. a corrupted single row). Not a clear
+		// rotation signal — deliberately not a warning — but worth a debug
+		// breadcrumb for anyone investigating a specific report.
+		logger.Debug("secrets-at-rest age self-check: mixed/inconclusive result, not a rotation signal", slog.Int("sampled", len(samples)))
+	}
+}

--- a/apps/api/cmd/wpmgr/age_selfcheck_test.go
+++ b/apps/api/cmd/wpmgr/age_selfcheck_test.go
@@ -1,0 +1,287 @@
+package main
+
+// age_selfcheck_test.go — GH #215 diagnosability follow-up regression lock.
+//
+// Covers:
+//   - ageRecipientFingerprint: stable for a fixed identity, differs across
+//     two distinct identities, never touches secret key material.
+//   - classifyAgeSelfCheck: the pure decision logic (no-rows → silent,
+//     all-ok → silent, sample-wrong-key → warn, everything else → silent)
+//     table-driven, with no DB and no cryptbox involved.
+//   - runAgeIdentitySelfCheck: the same three scenarios end-to-end through a
+//     fake ageSecretSampler + real (throwaway) age identities, asserting on
+//     the actual log output, still without any live database.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/cryptbox"
+)
+
+// newTestAgeIdentity returns a fresh ephemeral age identity for test use only
+// (cryptbox.NewAgeIdentity("") is documented as test-only: production code
+// must always use a stable derivation).
+func newTestAgeIdentity(t *testing.T) *cryptbox.AgeIdentity {
+	t.Helper()
+	id, err := cryptbox.NewAgeIdentity("")
+	if err != nil {
+		t.Fatalf("NewAgeIdentity: %v", err)
+	}
+	return id
+}
+
+// --- ageRecipientFingerprint -------------------------------------------------
+
+func TestAgeRecipientFingerprint_StableForSameIdentity(t *testing.T) {
+	id := newTestAgeIdentity(t)
+
+	first := ageRecipientFingerprint(id)
+	second := ageRecipientFingerprint(id)
+
+	if first == "" {
+		t.Fatal("fingerprint is empty for a valid identity")
+	}
+	if len(first) != ageFingerprintHexLen {
+		t.Fatalf("fingerprint length = %d, want %d", len(first), ageFingerprintHexLen)
+	}
+	if first != second {
+		t.Fatalf("fingerprint not stable for the same identity: %q vs %q", first, second)
+	}
+}
+
+func TestAgeRecipientFingerprint_DiffersForDifferentIdentity(t *testing.T) {
+	a := newTestAgeIdentity(t)
+	b := newTestAgeIdentity(t)
+
+	fa := ageRecipientFingerprint(a)
+	fb := ageRecipientFingerprint(b)
+
+	if fa == fb {
+		t.Fatalf("two different identities produced the same fingerprint: %q", fa)
+	}
+}
+
+func TestAgeRecipientFingerprint_NilIdentity(t *testing.T) {
+	if got := ageRecipientFingerprint(nil); got != "" {
+		t.Fatalf("fingerprint of nil identity = %q, want empty string", got)
+	}
+}
+
+// --- classifyAgeSelfCheck ----------------------------------------------------
+
+func TestClassifyAgeSelfCheck(t *testing.T) {
+	tests := []struct {
+		name      string
+		outcomes  []ageSampleOutcome
+		wantWarn  bool
+		wantAllOK bool
+	}{
+		{
+			name:      "no samples (fresh install) is silent",
+			outcomes:  nil,
+			wantWarn:  false,
+			wantAllOK: false,
+		},
+		{
+			name:      "all samples decrypt OK is silent",
+			outcomes:  []ageSampleOutcome{ageOutcomeOK, ageOutcomeOK, ageOutcomeOK},
+			wantWarn:  false,
+			wantAllOK: true,
+		},
+		{
+			name:      "every sample fails with wrong-identity signature warns",
+			outcomes:  []ageSampleOutcome{ageOutcomeWrongIdentity, ageOutcomeWrongIdentity, ageOutcomeWrongIdentity},
+			wantWarn:  true,
+			wantAllOK: false,
+		},
+		{
+			name:      "a single wrong-identity sample among successes does not warn",
+			outcomes:  []ageSampleOutcome{ageOutcomeOK, ageOutcomeWrongIdentity, ageOutcomeOK},
+			wantWarn:  false,
+			wantAllOK: false,
+		},
+		{
+			name:      "all-corrupted (non-identity) failures do not warn",
+			outcomes:  []ageSampleOutcome{ageOutcomeOther, ageOutcomeOther},
+			wantWarn:  false,
+			wantAllOK: false,
+		},
+		{
+			name:      "mixed wrong-identity and other failures do not warn",
+			outcomes:  []ageSampleOutcome{ageOutcomeWrongIdentity, ageOutcomeOther},
+			wantWarn:  false,
+			wantAllOK: false,
+		},
+		{
+			name:      "single sample, wrong identity, still warns (whole sample failed)",
+			outcomes:  []ageSampleOutcome{ageOutcomeWrongIdentity},
+			wantWarn:  true,
+			wantAllOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warn, allOK := classifyAgeSelfCheck(tt.outcomes)
+			if warn != tt.wantWarn {
+				t.Errorf("warn = %v, want %v", warn, tt.wantWarn)
+			}
+			if allOK != tt.wantAllOK {
+				t.Errorf("allOK = %v, want %v", allOK, tt.wantAllOK)
+			}
+		})
+	}
+}
+
+// --- fake sampler for end-to-end (no DB) tests ------------------------------
+
+type fakeAgeSecretSampler struct {
+	samples []ageSecretSample
+	err     error
+}
+
+func (f fakeAgeSecretSampler) Sample(context.Context) ([]ageSecretSample, error) {
+	return f.samples, f.err
+}
+
+func testLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func TestRunAgeIdentitySelfCheck_NoRowsIsSilent(t *testing.T) {
+	var buf bytes.Buffer
+	logger := testLogger(&buf)
+	id := newTestAgeIdentity(t)
+
+	runAgeIdentitySelfCheck(context.Background(), fakeAgeSecretSampler{}, id, logger)
+
+	if buf.Len() != 0 {
+		t.Fatalf("expected no log output for a fresh install (no sampled rows), got: %s", buf.String())
+	}
+}
+
+func TestRunAgeIdentitySelfCheck_SamplerErrorDegradesToDebugOnly(t *testing.T) {
+	var buf bytes.Buffer
+	logger := testLogger(&buf)
+	id := newTestAgeIdentity(t)
+
+	runAgeIdentitySelfCheck(context.Background(), fakeAgeSecretSampler{err: errors.New("boom: db unreachable")}, id, logger)
+
+	out := buf.String()
+	if strings.Contains(out, "level=WARN") {
+		t.Fatalf("a sampler error must never produce a WARN, got: %s", out)
+	}
+	if !strings.Contains(out, "level=DEBUG") {
+		t.Fatalf("expected a debug line for a degraded sample, got: %s", out)
+	}
+}
+
+func TestRunAgeIdentitySelfCheck_AllOKIsSilentOfWarnings(t *testing.T) {
+	var buf bytes.Buffer
+	logger := testLogger(&buf)
+	id := newTestAgeIdentity(t)
+
+	ciphertext, err := id.Encrypt([]byte("some TOTP secret"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	samples := []ageSecretSample{
+		{source: "users.totp_secret_encrypted", ciphertext: ciphertext},
+		{source: "users.totp_secret_encrypted", ciphertext: ciphertext},
+	}
+
+	runAgeIdentitySelfCheck(context.Background(), fakeAgeSecretSampler{samples: samples}, id, logger)
+
+	if strings.Contains(buf.String(), "level=WARN") {
+		t.Fatalf("all sampled secrets decrypted OK, must not warn, got: %s", buf.String())
+	}
+}
+
+// TestRunAgeIdentitySelfCheck_RotatedKeyWarns is the core GH #215 regression
+// lock: ciphertexts encrypted under the OLD identity, sampled and decrypted
+// with the NEW (currently-resolved) identity — simulating a self-host
+// restart where WPMGR_SESSION_SECRET (or an explicit
+// WPMGR_SITE_DEST_AGE_SECRET) changed underneath already-stored secrets —
+// must produce exactly one loud WARN naming the remediation.
+func TestRunAgeIdentitySelfCheck_RotatedKeyWarns(t *testing.T) {
+	var buf bytes.Buffer
+	logger := testLogger(&buf)
+
+	oldIdentity := newTestAgeIdentity(t)
+	newIdentity := newTestAgeIdentity(t)
+
+	ciphertext, err := oldIdentity.Encrypt([]byte("some TOTP secret"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	samples := []ageSecretSample{
+		{source: "users.totp_secret_encrypted", ciphertext: ciphertext},
+		{source: "users.totp_secret_encrypted", ciphertext: ciphertext},
+		{source: "smtp_settings.password_enc", ciphertext: ciphertext},
+	}
+
+	runAgeIdentitySelfCheck(context.Background(), fakeAgeSecretSampler{samples: samples}, newIdentity, logger)
+
+	out := buf.String()
+	if !strings.Contains(out, "level=WARN") {
+		t.Fatalf("expected a WARN for a fully-rotated key, got: %s", out)
+	}
+	if !strings.Contains(out, "WPMGR_SITE_DEST_AGE_SECRET") || !strings.Contains(out, "recovery code") {
+		t.Fatalf("WARN must name the remediation (pin a stable key, sign in with a recovery code), got: %s", out)
+	}
+}
+
+// TestRunAgeIdentitySelfCheck_PartialFailureDoesNotWarn guards the
+// "never cry wolf on a single possibly-corrupt row" requirement: one sample
+// decrypts fine, one does not (simulating a single corrupted/truncated row
+// rather than a rotated key) — must not warn.
+func TestRunAgeIdentitySelfCheck_PartialFailureDoesNotWarn(t *testing.T) {
+	var buf bytes.Buffer
+	logger := testLogger(&buf)
+
+	id := newTestAgeIdentity(t)
+	other := newTestAgeIdentity(t)
+
+	goodCiphertext, err := id.Encrypt([]byte("good secret"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	badCiphertext, err := other.Encrypt([]byte("secret encrypted under a different key"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	samples := []ageSecretSample{
+		{source: "users.totp_secret_encrypted", ciphertext: goodCiphertext},
+		{source: "users.totp_secret_encrypted", ciphertext: badCiphertext},
+	}
+
+	runAgeIdentitySelfCheck(context.Background(), fakeAgeSecretSampler{samples: samples}, id, logger)
+
+	if strings.Contains(buf.String(), "level=WARN") {
+		t.Fatalf("a single failing sample among successes must not warn, got: %s", buf.String())
+	}
+}
+
+// TestAgeIdentitySelfCheck_NeverPanics is a boot-safety smoke test: a nil
+// pool must never panic and must not log a warning.
+func TestAgeIdentitySelfCheck_NeverPanics(t *testing.T) {
+	var buf bytes.Buffer
+	logger := testLogger(&buf)
+	id := newTestAgeIdentity(t)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ageIdentitySelfCheck panicked with a nil pool: %v", r)
+		}
+	}()
+	ageIdentitySelfCheck(context.Background(), nil, id, logger)
+
+	if strings.Contains(buf.String(), "level=WARN") {
+		t.Fatalf("a nil pool must never produce a WARN, got: %s", buf.String())
+	}
+}

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -883,7 +883,24 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	if err != nil {
 		return fmt.Errorf("site destination age identity: %w", err)
 	}
-	logger.Info("secret-at-rest age identity resolved", slog.String("source", ageIdentitySource))
+	// recipient_fingerprint is a short, non-secret digest of the identity's
+	// PUBLIC recipient (see ageRecipientFingerprint) — never the secret key.
+	// Comparing this value across two boots is a definitive, at-a-glance
+	// signal of whether the resolved secrets-at-rest key rotated (GH #215:
+	// on a PaaS that regenerates WPMGR_SESSION_SECRET per deploy, the derived
+	// key silently rotated and only surfaced later as an unrelated "invalid
+	// 2FA code"/mail-send failure with no boot-time signal).
+	logger.Info("secret-at-rest age identity resolved",
+		slog.String("source", ageIdentitySource),
+		slog.String("recipient_fingerprint", ageRecipientFingerprint(siteDestAgeID)),
+	)
+	// Best-effort, non-fatal boot-time self-check (GH #215 follow-up): sample
+	// a bounded set of already-stored at-rest ciphertexts and confirm the
+	// resolved identity can still decrypt them, warning loudly (but never
+	// blocking/crashing boot) if the key has evidently rotated. See
+	// ageIdentitySelfCheck's doc comment in age_selfcheck.go for the full
+	// decision logic and boot-safety guarantees.
+	ageIdentitySelfCheck(ctx, pool, siteDestAgeID, logger)
 	siteDestSvc := sitedestination.NewService(siteDestRepo, siteDestAgeID, logger)
 	siteDestH := sitedestination.NewHandler(siteDestSvc, auditRec)
 

--- a/apps/api/internal/screenshot/capture/settle_internal_test.go
+++ b/apps/api/internal/screenshot/capture/settle_internal_test.go
@@ -1,0 +1,85 @@
+package capture
+
+// Internal (white-box) tests for the GH #229 ready-wait helpers. These pin the
+// bounded-settle / budget-clamp logic that guarantees a slow or broken page can
+// never make waitUntilReady hang the worker — verified here without launching a
+// real Chromium browser.
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSettleClamp(t *testing.T) {
+	tests := []struct {
+		name      string
+		remaining time.Duration
+		want      time.Duration
+	}{
+		{"no budget left is zero", 0, 0},
+		{"negative budget is zero", -5 * time.Second, 0},
+		{"ample budget yields full settle", 5 * time.Second, renderSettleWait},
+		{"exactly the settle yields full settle", renderSettleWait, renderSettleWait},
+		{"tight budget is shortened to what remains", 400 * time.Millisecond, 400 * time.Millisecond},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := settleClamp(tt.remaining)
+			if got != tt.want {
+				t.Errorf("settleClamp(%v) = %v, want %v", tt.remaining, got, tt.want)
+			}
+			// Invariant: the settle can never exceed the fixed cap and is never negative.
+			if got > renderSettleWait {
+				t.Errorf("settleClamp(%v) = %v exceeds renderSettleWait %v", tt.remaining, got, renderSettleWait)
+			}
+			if got < 0 {
+				t.Errorf("settleClamp(%v) = %v is negative", tt.remaining, got)
+			}
+		})
+	}
+}
+
+func TestReadyWaitBudget(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		t.Setenv("WPMGR_SCREENSHOT_READY_WAIT", "")
+		if got := readyWaitBudget(); got != defaultReadyWaitBudget {
+			t.Errorf("readyWaitBudget() = %v, want default %v", got, defaultReadyWaitBudget)
+		}
+	})
+
+	t.Run("valid override honored", func(t *testing.T) {
+		t.Setenv("WPMGR_SCREENSHOT_READY_WAIT", "5")
+		if got := readyWaitBudget(); got != 5*time.Second {
+			t.Errorf("readyWaitBudget() = %v, want 5s", got)
+		}
+	})
+
+	t.Run("override clamped to captureTimeout", func(t *testing.T) {
+		t.Setenv("WPMGR_SCREENSHOT_READY_WAIT", "999")
+		if got := readyWaitBudget(); got != captureTimeout {
+			t.Errorf("readyWaitBudget() = %v, want clamp to captureTimeout %v", got, captureTimeout)
+		}
+	})
+
+	// Any non-positive / non-numeric override falls back to the default so a
+	// misconfiguration can never zero out or invert the wait.
+	for _, bad := range []string{"0", "-3", "abc", "1.5"} {
+		t.Run("falls back for "+bad, func(t *testing.T) {
+			t.Setenv("WPMGR_SCREENSHOT_READY_WAIT", bad)
+			if got := readyWaitBudget(); got != defaultReadyWaitBudget {
+				t.Errorf("readyWaitBudget() with %q = %v, want default %v", bad, got, defaultReadyWaitBudget)
+			}
+		})
+	}
+
+	// The budget must always stay within the hard capture deadline so the wait
+	// can never outlast the job.
+	t.Run("budget never exceeds captureTimeout", func(t *testing.T) {
+		for _, v := range []string{"", "1", "8", "15", "60"} {
+			t.Setenv("WPMGR_SCREENSHOT_READY_WAIT", v)
+			if got := readyWaitBudget(); got > captureTimeout {
+				t.Errorf("readyWaitBudget() with %q = %v exceeds captureTimeout %v", v, got, captureTimeout)
+			}
+		}
+	})
+}

--- a/apps/api/internal/screenshot/capture/worker.go
+++ b/apps/api/internal/screenshot/capture/worker.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"sync"
 	"time"
 
@@ -54,6 +55,57 @@ const defaultConcurrency = 2
 // captureTimeout is the hard per-capture deadline (Chromium launch + navigate
 // + screenshot + upload). 15 s covers slow sites.
 const captureTimeout = 15 * time.Second
+
+// Ready-wait tuning (GH #229). Slow-hosting / uncached pages otherwise
+// screenshot blank because the capture fires before the page has painted.
+// waitUntilReady waits for the load event + network/DOM stability + a fixed
+// settle, all hard-bounded so a genuinely broken or slow page degrades to a
+// best-effort partial screenshot rather than hanging the worker.
+const (
+	// networkIdleWindow is the least quiet period WaitStable requires before it
+	// treats the network/DOM as idle. It is the stability WINDOW, not a timeout —
+	// the timeout is the ready-wait budget below.
+	networkIdleWindow = 500 * time.Millisecond
+
+	// renderSettleWait is the fixed post-stability settle that lets late,
+	// lazy-loaded / JS-rendered content paint after the network goes idle.
+	renderSettleWait = 1500 * time.Millisecond
+
+	// defaultReadyWaitBudget caps the TOTAL time waitUntilReady may spend (load +
+	// stability + settle). Chosen below captureTimeout so navigation, the wait,
+	// the screenshot, and the upload all fit inside the job deadline.
+	defaultReadyWaitBudget = 8 * time.Second
+)
+
+// readyWaitBudget resolves the ready-wait ceiling. Honors the optional
+// WPMGR_SCREENSHOT_READY_WAIT override (whole seconds — for self-hosters on
+// especially slow hosting), clamped to (0, captureTimeout] so a misconfiguration
+// can never let a single capture outlast its own capture/job deadline.
+func readyWaitBudget() time.Duration {
+	if v := os.Getenv("WPMGR_SCREENSHOT_READY_WAIT"); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+			d := time.Duration(secs) * time.Second
+			if d > captureTimeout {
+				d = captureTimeout
+			}
+			return d
+		}
+	}
+	return defaultReadyWaitBudget
+}
+
+// settleClamp returns the fixed render-settle delay, shortened to whatever time
+// is left in the ready-wait budget so the settle sleep can never push the total
+// wait past the budget. Returns 0 when no budget remains.
+func settleClamp(remaining time.Duration) time.Duration {
+	if remaining <= 0 {
+		return 0
+	}
+	if remaining < renderSettleWait {
+		return remaining
+	}
+	return renderSettleWait
+}
 
 // captureWidth / captureHeight are the 1x viewport dimensions.
 const (
@@ -352,12 +404,10 @@ func (w *Worker) capture(ctx context.Context, siteURL string) (img1x, img2x []by
 		return nil, nil, fmt.Errorf("navigate %s: %w", siteURL, navErr)
 	}
 
-	// Wait for the page to be visually stable. Use a short idle wait so a
-	// continuously-polling page doesn't stall us. WaitIdle returns on
-	// network-idle (no pending requests for idleTime).
-	idleCtx, idleCancel := context.WithTimeout(ctx, 5*time.Second)
-	defer idleCancel()
-	_ = page.Context(idleCtx).WaitIdle(2 * time.Second)
+	// 4a. Wait for the page to actually finish rendering before capturing so
+	//     slow-hosting / uncached sites don't screenshot blank (GH #229). This
+	//     is best-effort and hard-bounded — see waitUntilReady.
+	w.waitUntilReady(ctx, page)
 
 	// 5. Take the 1x screenshot (WebP, 85% quality).
 	shot1x, snapErr := page.Screenshot(false, &proto.PageCaptureScreenshot{
@@ -389,6 +439,45 @@ func (w *Worker) capture(ctx context.Context, siteURL string) (img1x, img2x []by
 	}
 
 	return shot1x, shot2x, nil
+}
+
+// waitUntilReady blocks until the page is visually ready to screenshot, or the
+// ready-wait budget elapses — whichever comes first (GH #229). Without it,
+// slow-hosting or uncached pages screenshot blank because the capture fires
+// before the page has painted. Every step is best-effort and hard-bounded:
+//
+//   - readyCtx caps the load + network/DOM stability wait at readyWaitBudget()
+//     (also transitively bounded by the caller's capture ctx, which carries the
+//     captureTimeout deadline).
+//   - WaitStable's argument is the least-idle WINDOW, not a timeout; the timeout
+//     is readyCtx, so a page that never stabilizes ends the wait at the budget
+//     instead of looping forever.
+//   - the trailing fixed settle (so late lazy-loaded / JS-rendered paints land)
+//     is clamped to the budget's remaining time.
+//
+// It deliberately NEVER returns an error and NEVER weakens the navigation ctx or
+// SSRF proxy: a page that never stabilizes is captured with whatever HAS
+// rendered, because a partial screenshot beats both a blank one and a hung
+// worker. It cannot hang — both the stability wait and the settle are bounded,
+// and the whole function is bounded by the caller's ctx.
+func (w *Worker) waitUntilReady(ctx context.Context, page *rod.Page) {
+	deadline := time.Now().Add(readyWaitBudget())
+	readyCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	// Load event + network-request idle + DOM stability, all bounded by readyCtx.
+	// The error (including deadline-exceeded) is intentionally ignored — we go on
+	// to capture whatever has rendered.
+	_ = page.Context(readyCtx).WaitStable(networkIdleWindow)
+
+	// Fixed settle for late lazy-loaded images / JS-rendered content, clamped so
+	// it can never extend the total wait past the budget.
+	if settle := settleClamp(time.Until(deadline)); settle > 0 {
+		select {
+		case <-time.After(settle):
+		case <-ctx.Done():
+		}
+	}
 }
 
 func (w *Worker) publish(ctx context.Context, a screenshot.CaptureArgs, data map[string]any) {

--- a/apps/web/src/features/auth/use-2fa.test.ts
+++ b/apps/web/src/features/auth/use-2fa.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+// GH #215: the TOTP login-challenge (`POST /auth/2fa/totp`, `useTotpChallenge`)
+// only branched on 410 (challenge_expired) and 401 (invalid_code /
+// too_many_attempts). When a self-host's secrets-at-rest key changes, the
+// server can no longer decrypt the operator's stored TOTP secret and returns
+// HTTP 500 with the distinct domain code `totp_decrypt_failed` (still present
+// in the JSON body per `httpx.Error` -- only the *message* is suppressed for
+// KindInternal errors, the code is always surfaced). Before this fix, that
+// 500 fell through to the generic `toError(result.error)` path and the route
+// rendered "Verification failed. Please try again.", which reads as "wrong
+// code" instead of a server configuration problem. These tests pin: the 500
+// branch now surfaces a distinct `code`, and the existing 401/410 branches
+// are unchanged (no regression).
+
+const { postMock } = vi.hoisted(() => ({ postMock: vi.fn() }));
+
+vi.mock("@wpmgr/api", () => ({
+  client: { get: vi.fn(), post: postMock, patch: vi.fn(), delete: vi.fn() },
+  getMe: vi.fn(),
+  login: vi.fn(),
+  logout: vi.fn(),
+  register: vi.fn(),
+}));
+
+vi.mock("@/components/toast", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}));
+
+import { useTotpChallenge } from "./use-2fa";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return createElement(QueryClientProvider, { client: qc }, children);
+}
+
+/** Reads the `.code` the mutation hook attaches via `Object.assign(new Error(...), { code })`. */
+function errorCode(err: unknown): string | undefined {
+  return (err as { code?: string } | null)?.code;
+}
+
+describe("useTotpChallenge error mapping — GH #215", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("surfaces a distinct `totp_decrypt_failed` code on a 500 with that domain code", async () => {
+    postMock.mockResolvedValue({
+      data: undefined,
+      error: { code: "totp_decrypt_failed", message: "internal server error" },
+      response: { status: 500 },
+    });
+
+    const { result } = renderHook(() => useTotpChallenge(), { wrapper });
+    result.current.mutate({ challenge: "c1", code: "123456", remember_device: false });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(errorCode(result.current.error)).toBe("totp_decrypt_failed");
+    // Non-vacuous: against the pre-fix code this fell through to the generic
+    // `toError()` path, which does NOT attach a `.code` at all.
+    expect(errorCode(result.current.error)).not.toBeUndefined();
+  });
+
+  it("still surfaces `invalid_code` on a plain 401 (no regression)", async () => {
+    postMock.mockResolvedValue({
+      data: undefined,
+      error: { code: "invalid_totp_code", message: "invalid TOTP code" },
+      response: { status: 401 },
+    });
+
+    const { result } = renderHook(() => useTotpChallenge(), { wrapper });
+    result.current.mutate({ challenge: "c1", code: "000000", remember_device: false });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(errorCode(result.current.error)).toBe("invalid_code");
+  });
+
+  it("still surfaces `too_many_attempts` on a 401 with that domain code (no regression)", async () => {
+    postMock.mockResolvedValue({
+      data: undefined,
+      error: { code: "too_many_attempts", message: "too many attempts" },
+      response: { status: 401 },
+    });
+
+    const { result } = renderHook(() => useTotpChallenge(), { wrapper });
+    result.current.mutate({ challenge: "c1", code: "000000", remember_device: false });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(errorCode(result.current.error)).toBe("too_many_attempts");
+  });
+
+  it("still surfaces `challenge_expired` on a 410 (no regression)", async () => {
+    postMock.mockResolvedValue({
+      data: undefined,
+      error: { code: "challenge_expired", message: "challenge expired" },
+      response: { status: 410 },
+    });
+
+    const { result } = renderHook(() => useTotpChallenge(), { wrapper });
+    result.current.mutate({ challenge: "c1", code: "000000", remember_device: false });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(errorCode(result.current.error)).toBe("challenge_expired");
+  });
+});

--- a/apps/web/src/features/auth/use-2fa.ts
+++ b/apps/web/src/features/auth/use-2fa.ts
@@ -358,6 +358,19 @@ export function useTotpChallenge() {
         }
         throw Object.assign(new Error("invalid_code"), { code: "invalid_code" });
       }
+      // A 500 with code `totp_decrypt_failed` means the server can no longer
+      // decrypt the operator's stored TOTP secret (the secrets-at-rest key
+      // changed on a self-host, e.g. GH #215) -- a server configuration
+      // problem, not a wrong code. The generic `toError` fallback below would
+      // otherwise surface this as an indistinguishable "Verification failed"
+      // banner, so it must be branched out here like the 401/410 cases above.
+      if (result.response?.status === 500) {
+        const raw = result.error as Record<string, unknown> | null | undefined;
+        const code = raw && typeof raw["code"] === "string" ? raw["code"] : "";
+        if (code === "totp_decrypt_failed") {
+          throw Object.assign(new Error("totp_decrypt_failed"), { code: "totp_decrypt_failed" });
+        }
+      }
       if (result.error !== undefined) throw toError(result.error);
       return result.data as ChallengeCompleteResult;
     },

--- a/apps/web/src/routes/-2fa-challenge.test.ts
+++ b/apps/web/src/routes/-2fa-challenge.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { getErrorMessage } from "./2fa-challenge";
+
+// GH #215: the 2FA challenge screen's error banner must distinguish a real
+// server configuration problem (the operator's TOTP secret can no longer be
+// decrypted because a self-host's secrets-at-rest key changed) from an
+// ordinary wrong code, so the operator doesn't waste time re-typing a code
+// that will never work. Pins the new `totp_decrypt_failed` copy and locks
+// the existing 401/410 copy against regression.
+describe("getErrorMessage — 2fa-challenge banner copy", () => {
+  it("surfaces a distinct, actionable message for `totp_decrypt_failed`, pointing at recovery codes", () => {
+    const message = getErrorMessage("totp_decrypt_failed");
+    expect(message).toContain("encryption key changed");
+    expect(message).toContain("not a wrong code");
+    expect(message).toContain("recovery code");
+    expect(message).toContain("WPMGR_SITE_DEST_AGE_SECRET");
+    // Must NOT fall through to the generic banner text.
+    expect(message).not.toBe("Verification failed. Please try again.");
+  });
+
+  it("still maps a plain invalid code to \"Incorrect code\" (no regression)", () => {
+    expect(getErrorMessage("invalid_code")).toBe(
+      "Incorrect code. Please check and try again.",
+    );
+  });
+
+  it("still maps challenge_expired to the session-expired copy (no regression)", () => {
+    expect(getErrorMessage("challenge_expired")).toBe(
+      "This login session has expired. Please sign in again.",
+    );
+  });
+
+  it("still maps too_many_attempts to the locked-session copy (no regression)", () => {
+    expect(getErrorMessage("too_many_attempts")).toBe(
+      "Too many failed attempts. This session is locked. Please sign in again.",
+    );
+  });
+
+  it("falls back to the generic message for an unrecognized code", () => {
+    expect(getErrorMessage("some_future_code")).toBe(
+      "Verification failed. Please try again.",
+    );
+  });
+});

--- a/apps/web/src/routes/2fa-challenge.tsx
+++ b/apps/web/src/routes/2fa-challenge.tsx
@@ -56,6 +56,34 @@ export const Route = createFileRoute("/2fa-challenge")({
 
 type Mode = "totp" | "recovery" | "webauthn";
 
+// Maps a challenge-mutation error `code` to house-style, actionable copy.
+// Exported (module-level, pure) so GH #215's fix can be pinned in a unit test
+// without mounting the whole route + form flow; mirrors `mapDeleteOrgError`
+// in `features/orgs/use-orgs.ts`.
+export function getErrorMessage(code: string): string {
+  switch (code) {
+    case "challenge_expired":
+      return "This login session has expired. Please sign in again.";
+    case "too_many_attempts":
+      return "Too many failed attempts. This session is locked. Please sign in again.";
+    case "invalid_code":
+      return "Incorrect code. Please check and try again.";
+    case "codes_exhausted":
+      return "All recovery codes have been used. Contact your administrator.";
+    case "recovery_code_already_used":
+      return "That recovery code has already been used.";
+    case "totp_decrypt_failed":
+      // The server can no longer decrypt the stored TOTP secret (its
+      // secrets-at-rest key changed on a self-host, GH #215) -- a server
+      // configuration problem, not a wrong code. Recovery codes are hashed
+      // (not encrypted), so they still work here; point the operator at the
+      // "Use a recovery code" switcher already rendered on this screen.
+      return "Your two-factor secret couldn't be decrypted because the server's encryption key changed. This is a server configuration issue, not a wrong code. Sign in with a recovery code below, then re-enroll two-factor after pinning a stable encryption key (WPMGR_SITE_DEST_AGE_SECRET).";
+    default:
+      return "Verification failed. Please try again.";
+  }
+}
+
 function TwoFaChallengePage() {
   const search = Route.useSearch();
   const navigate = useNavigate();
@@ -78,23 +106,6 @@ function TwoFaChallengePage() {
 
   // Shared error / success handling
   const [errorCode, setErrorCode] = useState<string | null>(null);
-
-  function getErrorMessage(code: string): string {
-    switch (code) {
-      case "challenge_expired":
-        return "This login session has expired. Please sign in again.";
-      case "too_many_attempts":
-        return "Too many failed attempts. This session is locked. Please sign in again.";
-      case "invalid_code":
-        return "Incorrect code. Please check and try again.";
-      case "codes_exhausted":
-        return "All recovery codes have been used. Contact your administrator.";
-      case "recovery_code_already_used":
-        return "That recovery code has already been used.";
-      default:
-        return "Verification failed. Please try again.";
-    }
-  }
 
   const isExpiredOrLocked =
     errorCode === "challenge_expired" || errorCode === "too_many_attempts";


### PR DESCRIPTION
## #215 — make a rotated secrets-at-rest key self-explaining (diagnosis: NOT a code bug)

A careful 3-lens investigation found **zero code defect**. Operator TOTP "works right after setup, then every later login fails" on self-host is a **decrypt-at-rest failure**: the age key derived from `WPMGR_SESSION_SECRET` rotates when a PaaS (e.g. Coolify) regenerates that seed per deploy, so the stored 2FA secret can no longer be decrypted, and the backend's distinct `totp_decrypt_failed` (HTTP 500) was masquerading as a generic "invalid code." **Hosted GCP is immune because it pins an explicit `WPMGR_SITE_DEST_AGE_SECRET`.** The reporter has the remediation (pin a stable key + re-enroll).

Diagnosability-only hardening (no crypto change):
- **api** — a non-secret **fingerprint** of the resolved age recipient at boot (a changed fingerprint across restarts = definitive rotation signal); a best-effort, **boot-safe decrypt self-check** that samples stored TOTP/SMTP ciphertexts and WARNs with exact remediation only when *every* sample fails with age's wrong-identity error (`recover` + 3s timeout + degrade-to-debug; never blocks boot, never cries wolf).
- **web** — the 2FA prompt now shows a precise "the server's encryption key changed — use a recovery code and re-enroll after pinning a stable key" message instead of the generic banner.

## #229 — blank screenshots on slow/uncached pages
The capture worker snapshotted almost immediately (`WaitIdle` only). It now waits for load + network idle + DOM stability (`page.WaitStable`) plus a short render-settle, hard-bounded by an 8s budget clamped under the 15s capture timeout (`WPMGR_SCREENSHOT_READY_WAIT`), and never errors — a page that won't settle is captured best-effort rather than blank/hung.

## Verification
- api `go build`/`vet`/`test` green (self-check: fingerprint + 7-case classify + boot-safety tests)
- web 1025 tests + lint green, 9 new tests (typecheck = known pre-existing zod-dup artifact, git-stash-verified identical before/after)
- encoder `go build`/`vet`/`test` green (settle/budget unit tests)

No functional agent change (version bumped for the unified release only; no `agent-release`).

Closes #229
Refs #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Website screenshots now wait for slow or uncached pages to finish loading, reducing blank results while avoiding indefinite waits.
  * Two-factor authentication now provides clearer guidance when encrypted secrets cannot be decrypted, including recovery-code and encryption-key remediation.
* **Improvements**
  * Startup diagnostics now identify potential encryption-key rotation issues and provide clearer warnings for affected stored secrets.
* **Release**
  * Updated the agent to version 0.61.65.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->