### PR TITLE
feat(web): last backup as relative time on the Sites list (GH #231) — 0.61.66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.66] - 2026-07-17
+
+### Changed
+
+- The Sites list now shows each site's last backup as a human-readable relative time (for example "2h ago"), with the exact date and time on hover, matching how the Backups page already displays it, instead of a raw timestamp (GH #231). Dashboard only.
+
 ## [0.61.65] - 2026-07-16
 
 ### Changed

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.65
+ * Version:           0.61.66
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.65');
+define('WPMGR_AGENT_VERSION', '0.61.66');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/web/src/components/status/backup-chip.tsx
+++ b/apps/web/src/components/status/backup-chip.tsx
@@ -13,6 +13,11 @@ export interface BackupChipProps {
   /** When provided on failed backups, renders an inline "Retry" link button. */
   onRetry?: () => void;
   className?: string;
+  /**
+   * Native `title` tooltip — pass the exact absolute timestamp so hovering
+   * the chip reveals full precision alongside the relative `time` text.
+   */
+  title?: string;
 }
 
 const statusBg: Record<BackupChipStatus, string> = {
@@ -35,9 +40,11 @@ export function BackupChip({
   progressPercent,
   onRetry,
   className,
+  title,
 }: BackupChipProps) {
   return (
     <span
+      title={title}
       className={cn(
         "inline-flex items-center gap-1.5 rounded px-2 py-0.5 text-xs font-medium",
         statusBg[status],

--- a/apps/web/src/features/sites/site-card.test.ts
+++ b/apps/web/src/features/sites/site-card.test.ts
@@ -4,6 +4,7 @@
  * connection-state-badge.test.ts / sites-filter.test.ts).
  */
 import { describe, it, expect } from "vitest";
+import { relativeTime } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
 // SslChip — threshold logic
@@ -295,6 +296,56 @@ describe("calm zero-states — backups", () => {
   it("last_backup_status 'failed' shows the BackupChip", () => {
     const backupStatus = "failed" as string | null;
     expect(backupStatus != null).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH #231 — Sites list "last backup" renders relative time (matches
+// /backups), with the exact absolute timestamp preserved on hover.
+// ---------------------------------------------------------------------------
+// Mirrors the derivation in site-card.tsx / sites-table.tsx: the BackupChip
+// `time` prop takes the shared `relativeTime()` label (never a raw ISO
+// string), and `title` carries the absolute timestamp for hover precision.
+
+function deriveBackupChipProps(lastBackupAt: string | null, now?: number) {
+  return {
+    time: relativeTime(lastBackupAt, now) ?? undefined,
+    title: lastBackupAt ? new Date(lastBackupAt).toLocaleString() : undefined,
+  };
+}
+
+describe("last-backup formatting — relative time + hover precision (GH #231)", () => {
+  const NOW = new Date("2026-06-16T12:00:00Z").getTime();
+
+  it("renders a short relative label, not the raw ISO timestamp", () => {
+    const twoHoursAgo = new Date(NOW - 2 * 60 * 60 * 1000).toISOString();
+    const { time } = deriveBackupChipProps(twoHoursAgo, NOW);
+    expect(time).toBe("2h ago");
+    expect(time).not.toContain("T"); // not an ISO string leaking through
+  });
+
+  it("renders 'just now' for a very recent backup", () => {
+    const secondsAgo = new Date(NOW - 5 * 1000).toISOString();
+    const { time } = deriveBackupChipProps(secondsAgo, NOW);
+    expect(time).toBe("just now");
+  });
+
+  it("renders day-granularity labels for older backups", () => {
+    const threeDaysAgo = new Date(NOW - 3 * 24 * 60 * 60 * 1000).toISOString();
+    const { time } = deriveBackupChipProps(threeDaysAgo, NOW);
+    expect(time).toBe("3d ago");
+  });
+
+  it("carries the exact absolute timestamp in `title` for hover precision", () => {
+    const iso = new Date(NOW - 2 * 60 * 60 * 1000).toISOString();
+    const { title } = deriveBackupChipProps(iso, NOW);
+    expect(title).toBe(new Date(iso).toLocaleString());
+  });
+
+  it("null last_backup_at yields no time/title (caller shows 'No backups yet')", () => {
+    const { time, title } = deriveBackupChipProps(null, NOW);
+    expect(time).toBeUndefined();
+    expect(title).toBeUndefined();
   });
 });
 

--- a/apps/web/src/features/sites/site-card.tsx
+++ b/apps/web/src/features/sites/site-card.tsx
@@ -158,6 +158,12 @@ export function SiteCard({
   const updatesCount = site.updates_available ?? 0;
   const backupStatus = (site.last_backup_status as BackupChipStatus | null) ?? null;
   const backupTime = site.last_backup_at ?? null;
+  // GH #231 — show a relative label ("2h ago") in the chip, with the exact
+  // absolute timestamp on hover, matching the /backups page convention.
+  const backupTimeRelative = relativeTime(backupTime) ?? undefined;
+  const backupTimeTitle = backupTime
+    ? new Date(backupTime).toLocaleString()
+    : undefined;
 
   const capabilityItems = buildCapabilityItems(site);
   const isCompact = cardSize === "compact";
@@ -322,7 +328,8 @@ export function SiteCard({
           {backupStatus ? (
             <BackupChip
               status={backupStatus}
-              time={backupTime ?? undefined}
+              time={backupTimeRelative}
+              title={backupTimeTitle}
             />
           ) : (
             <span className="text-xs text-muted-foreground">No backups yet</span>

--- a/apps/web/src/features/sites/sites-table.tsx
+++ b/apps/web/src/features/sites/sites-table.tsx
@@ -42,7 +42,7 @@ import {
   connectionStateOf,
   type ConnectionState,
 } from "@/features/sites/connection-state";
-import { cn } from "@/lib/utils";
+import { cn, relativeTime } from "@/lib/utils";
 import {
   rowHeightFor,
   useSitesDensity,
@@ -449,10 +449,14 @@ function buildColumns(
       cell: ({ row }) => {
         const status = row.original.backupStatus;
         if (!status) return <span aria-hidden="true" />;
+        // GH #231 — relative label in the chip, exact timestamp on hover
+        // (matches the /backups page's relativeTime + title convention).
+        const iso = row.original.backupTime;
         return (
           <BackupChip
             status={status}
-            time={row.original.backupTime ?? undefined}
+            time={relativeTime(iso) ?? undefined}
+            title={iso ? new Date(iso).toLocaleString() : undefined}
           />
         );
       },


### PR DESCRIPTION
## #231 — "last backup" hard to read on the Sites list

The sites grid + table passed the raw ISO `last_backup_at` straight into `BackupChip`'s `time` prop (which expects a *pre-formatted* relative string — the site-health tile already did this correctly). They now use the shared `relativeTime()` helper that the `/backups` page uses ("2h ago"), with the exact date/time preserved on hover via a new optional `BackupChip` `title` prop (mirroring the `/backups` absolute-on-hover pattern).

- Reuses the single shared `relativeTime()` (no second implementation).
- Null/never → existing "No backups yet" calm text (unchanged); very-recent → "just now" per the shared helper.
- `/backups` page + underlying data untouched — purely display formatting.

## Verification
- web `pnpm test` 1030 pass (+5 new for #231), `lint` 0 errors, `vite build` clean.
- typecheck = known pre-existing zod-duplicate artifact (git-stash-verified identical; zero new).

Web-only display change; agent version bumped for the unified release only (no `agent-release`).

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Site listings now show each site’s last backup using a human-readable relative time.
  * Hover over the backup time to view the exact date and time.
  * Sites without a recorded backup continue to display appropriately.

* **Chores**
  * Updated the WPMgr Agent version to 0.61.66.

* **Documentation**
  * Added release notes for version 0.61.66.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->