### PR TITLE
perf(api): interim keep-warm for the /sites uptime aggregate (0.61.67)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -211,6 +211,12 @@ WPMGR_UPTIME_PROBE_TIMEOUT=15s
 WPMGR_UPTIME_PROBE_CONCURRENCY=10
 WPMGR_UPTIME_ALERT_INTERVAL=60s
 WPMGR_UPTIME_DOWN_THRESHOLD=2
+# INTERIM stopgap for the recurring 7-8s post-idle GET /api/v1/sites latency:
+# periodically re-runs the fleet-uptime query so its 60s result cache and the
+# Postgres buffer cache backing it never go cold. Default true. Set false to
+# disable. REMOVE once the site_uptime_daily rollup lands (internal/site/
+# uptime_keepwarm.go).
+WPMGR_UPTIME_KEEPWARM=true
 
 # ---- Alert SMTP (M5 downtime alerts; M7 reports) ----
 # The ops ALERT engine. Empty host => email alerts no-op (webhooks still fire).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
-## [0.61.66] - 2026-07-17
+## [0.61.67] - 2026-07-17
+
+### Fixed
+
+- The Sites list no longer stalls for several seconds on the first load after a period of no traffic. The sites list enriches each row with uptime data via an aggregate over recent uptime probes; on a small database instance that aggregate was being re-read from disk (a cold cache) once the short-lived in-memory cache expired during idle, so the first request after ~15-30 minutes was slow while later requests were fast. A background refresher now keeps that query (and the database's cache for it) continuously warm, so the Sites list stays fast even after idle. Control plane only; a follow-up will roll the uptime data up so the query is inherently cheap regardless of cache state.
 
 ### Changed
 

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.66
+ * Version:           0.61.67
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.66');
+define('WPMGR_AGENT_VERSION', '0.61.67');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -1077,6 +1077,17 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// a direct read of site_uptime_probes (which is empty on ClickHouse installs).
 	siteSvc.SetUptimeStore(metricsStore)
 
+	// INTERIM stopgap (WPMGR_UPTIME_KEEPWARM, default true): periodically
+	// re-run the fleet-uptime query for every tenant with enrolled sites so
+	// the 60s result cache above never expires unpopulated AND the Postgres
+	// buffer cache backing site_uptime_probes stays resident — this is what
+	// fixes the recurring ~7-8s post-idle GET /api/v1/sites stall. Reuses
+	// siteSvc.UptimeStore() (the SAME cache-wrapped instance List() reads) and
+	// the SAME cross-tenant enrolled-site list the probe worker already
+	// sweeps every ~60s. REMOVE once the site_uptime_daily rollup lands — see
+	// internal/site/uptime_keepwarm.go's file doc comment.
+	site.StartUptimeKeepWarm(ctx, cfg.Uptime.KeepWarmEnabled, siteSvc.UptimeStore(), newUptimeKeepWarmLister(uptimeRepo), logger)
+
 	// P4b — cron kick: periodically fire a GET to wp-cron.php for all enrolled
 	// sites so fully page-cached sites boot PHP and drain WP-Cron even with zero
 	// PHP-booting organic traffic. Reuses the SSRF-hardened ssrfClient (ADR-009).

--- a/apps/api/cmd/wpmgr/siteadapter.go
+++ b/apps/api/cmd/wpmgr/siteadapter.go
@@ -69,6 +69,33 @@ var (
 	_ uptime.SiteLookup   = (*uptimeSiteAdapter)(nil)
 )
 
+// uptimeKeepWarmLister adapts uptime.Repo.ListEnrolledForProbe to the site
+// package's EnrolledSiteLister — the SAME cross-tenant enrolled-site list the
+// uptime probe worker already sweeps every ~60s (uptime.ProbeWorker), reused
+// here so the interim /sites keep-warm refresher (uptime_keepwarm.go) adds no
+// new query shape. INTERIM: remove alongside site.UptimeKeepWarmer.
+type uptimeKeepWarmLister struct {
+	repo uptime.Repo
+}
+
+func newUptimeKeepWarmLister(repo uptime.Repo) *uptimeKeepWarmLister {
+	return &uptimeKeepWarmLister{repo: repo}
+}
+
+func (a *uptimeKeepWarmLister) ListEnrolledSiteIDs(ctx context.Context) ([]site.TenantSiteID, error) {
+	enrolled, err := a.repo.ListEnrolledForProbe(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]site.TenantSiteID, 0, len(enrolled))
+	for _, e := range enrolled {
+		out = append(out, site.TenantSiteID{TenantID: e.TenantID, SiteID: e.ID})
+	}
+	return out, nil
+}
+
+var _ site.EnrolledSiteLister = (*uptimeKeepWarmLister)(nil)
+
 // siteLookup adapts the site service to the update package's SiteLookup
 // interface, translating site.Site (with its JSONB component inventory) into the
 // update.SiteInfo the orchestrator/worker need. It keeps the update package free

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -233,6 +233,15 @@ type UptimeConfig struct {
 	// CronKickConcurrency caps how many concurrent kicks fire per pass.
 	// Default 10. Env: WPMGR_CRON_KICK_CONCURRENCY.
 	CronKickConcurrency int `koanf:"cron_kick_concurrency"`
+
+	// KeepWarmEnabled gates the INTERIM /sites uptime keep-warm refresher
+	// (site.UptimeKeepWarmer) — a stopgap for the recurring 7-8s GET
+	// /api/v1/sites latency after ~15-30 min idle (cold Postgres buffer cache
+	// + expired 60s result cache backing QueryFleetUptime). Defaults to true;
+	// set WPMGR_UPTIME_KEEPWARM=false to disable. REMOVE this flag together
+	// with internal/site/uptime_keepwarm.go once the site_uptime_daily rollup
+	// lands and becomes the authoritative source for /sites uptime enrichment.
+	KeepWarmEnabled bool `koanf:"keepwarm"`
 }
 
 // S3Config holds the S3-compatible object-storage configuration (ADR-010).
@@ -550,6 +559,7 @@ func defaults() map[string]any {
 		"uptime.cron_kick_interval":         "5m",
 		"uptime.cron_kick_timeout":          "5s",
 		"uptime.cron_kick_concurrency":      10,
+		"uptime.keepwarm":                   true,
 		"river.media_schema":                "media_encoder",
 		"autologin.require_2fa_step_up":     false,
 		"conn.degrade_after":                "300s",

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -148,6 +148,34 @@ func TestLoadRiverMediaSchemaEnv(t *testing.T) {
 	}
 }
 
+// TestLoadUptimeKeepWarmDefault verifies the interim /sites uptime keep-warm
+// refresher (site.UptimeKeepWarmer) defaults to ENABLED with no
+// WPMGR_UPTIME_KEEPWARM env configured — it must be on by default so the
+// stopgap actually protects prod without an operator opting in.
+func TestLoadUptimeKeepWarmDefault(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.Uptime.KeepWarmEnabled {
+		t.Fatal("Uptime.KeepWarmEnabled = false, want true by default")
+	}
+}
+
+// TestLoadUptimeKeepWarmEnvDisable verifies WPMGR_UPTIME_KEEPWARM=false is
+// read from the environment, so the interim refresher can be turned off
+// cleanly (and later removed entirely) without a code change.
+func TestLoadUptimeKeepWarmEnvDisable(t *testing.T) {
+	t.Setenv("WPMGR_UPTIME_KEEPWARM", "false")
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Uptime.KeepWarmEnabled {
+		t.Fatal("Uptime.KeepWarmEnabled = true, want false when WPMGR_UPTIME_KEEPWARM=false")
+	}
+}
+
 // TestValidateRiverMediaSchema verifies that an invalid WPMGR_RIVER_MEDIA_SCHEMA
 // surfaces as a config Issue (so the server parks in readyz-degraded) while
 // empty, public, and valid identifiers are accepted.

--- a/apps/api/internal/site/service.go
+++ b/apps/api/internal/site/service.go
@@ -64,6 +64,13 @@ func (s *Service) SetUptimeStore(store metrics.Store) {
 	s.uptimeStore = newCachedMetricsStore(store)
 }
 
+// UptimeStore returns the (cache-wrapped) store wired via SetUptimeStore, or
+// nil if it was never called. Exposed so the interim uptime keep-warm
+// refresher (uptime_keepwarm.go, WPMGR_UPTIME_KEEPWARM) can refresh THIS
+// service's exact cache entries — refreshing any other store instance would
+// warm a cache List() never reads from.
+func (s *Service) UptimeStore() metrics.Store { return s.uptimeStore }
+
 // SetConnectionService wires the M21 lifecycle service into the enroll branch.
 // Call once at boot (the lifecycle service depends on this Service's repo, so
 // it is constructed after and injected here).

--- a/apps/api/internal/site/uptime_keepwarm.go
+++ b/apps/api/internal/site/uptime_keepwarm.go
@@ -1,0 +1,200 @@
+package site
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/metrics"
+)
+
+// ---------------------------------------------------------------------------
+// INTERIM uptime keep-warm refresher (stopgap — see WPMGR_UPTIME_KEEPWARM)
+// ---------------------------------------------------------------------------
+//
+// Confirmed root cause: GET /api/v1/sites enriches the sites list with uptime
+// data via metrics.Store.QueryFleetUptime — a per-site LATERAL aggregate over
+// the raw site_uptime_probes table for the last 30 days (~43k rows/site/
+// request). QueryFleetUptime's result is cached for fleetUptimeCacheTTL (60s,
+// see uptime_cache.go), but the recurring ~7-8s stall happens because BOTH
+// warm layers expire after 15-30 minutes of idle traffic: the 60s result
+// cache misses AND Postgres evicts the probes index from its buffer cache on
+// the small db-g1-small instance. A warm query is ~30ms; a cold one is ~8s.
+//
+// This refresher periodically re-runs QueryFleetUptime for every tenant with
+// enrolled sites, on a tick shorter than fleetUptimeCacheTTL, through the SAME
+// (cache-wrapped) metrics.Store the /sites handler reads — so a refresh here
+// populates the exact cache entry List() will hit, AND keeps the Postgres
+// buffer cache backing the query resident. This is a deliberate, bounded
+// "keep the DB busy on purpose" tradeoff: it turns an idle DB into one that
+// runs the uptime aggregate ~every 45s, which is fine short-term for a small
+// fleet.
+//
+// REMOVE this file (uptime_keepwarm.go), its wiring in cmd/wpmgr/main.go, and
+// the WPMGR_UPTIME_KEEPWARM config flag once the site_uptime_daily rollup
+// lands and becomes the authoritative source for /sites uptime enrichment —
+// the rollup turns QueryFleetUptime into a cheap read over a small
+// pre-aggregated table and this warming is no longer needed.
+
+const (
+	// uptimeKeepWarmInterval is intentionally under fleetUptimeCacheTTL (60s)
+	// so the result cache is always refreshed before it would otherwise expire
+	// unpopulated.
+	uptimeKeepWarmInterval = 45 * time.Second
+
+	// uptimeKeepWarmWindow MUST match the window List() queries (window30d in
+	// service.go) — a different window is a different cache key and warms an
+	// entry the real request path never reads.
+	uptimeKeepWarmWindow = 30 * 24 * time.Hour
+)
+
+// TenantSiteID is one (tenant, site) pair from the enrolled-site list.
+type TenantSiteID struct {
+	TenantID uuid.UUID
+	SiteID   uuid.UUID
+}
+
+// EnrolledSiteLister lists every currently-enrolled site across all tenants,
+// cross-tenant. Satisfied via a thin adapter over uptime.Repo.
+// ListEnrolledForProbe in cmd/wpmgr — the SAME cross-tenant list the uptime
+// probe worker already sweeps every ~60s, so the keep-warm refresher adds no
+// new query shape. Kept as a narrow interface (rather than importing the
+// uptime package directly) to avoid a cross-domain import — see repo.go's
+// ConnectionService/BillingGate/ScreenshotEnricher seams for the same
+// pattern.
+type EnrolledSiteLister interface {
+	ListEnrolledSiteIDs(ctx context.Context) ([]TenantSiteID, error)
+}
+
+// UptimeKeepWarmer periodically re-runs QueryFleetUptime for every tenant
+// with enrolled sites, keeping both the 60s in-process result cache and the
+// underlying Postgres buffer cache warm. See the file doc comment above —
+// this is an interim stopgap, env-gated for clean removal.
+type UptimeKeepWarmer struct {
+	store    metrics.Store
+	lister   EnrolledSiteLister
+	interval time.Duration
+	window   time.Duration
+	logger   *slog.Logger
+}
+
+// NewUptimeKeepWarmer builds a keep-warm refresher. store should be the SAME
+// cache-wrapped store instance wired via Service.SetUptimeStore (i.e. what
+// SetUptimeStore was called with), so a refresh here populates the exact
+// cache entry List() will read. lister enumerates enrolled sites cross-tenant.
+func NewUptimeKeepWarmer(store metrics.Store, lister EnrolledSiteLister, logger *slog.Logger) *UptimeKeepWarmer {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &UptimeKeepWarmer{
+		store:    store,
+		lister:   lister,
+		interval: uptimeKeepWarmInterval,
+		window:   uptimeKeepWarmWindow,
+		logger:   logger,
+	}
+}
+
+// StartUptimeKeepWarm starts the refresher in its own goroutine when enabled
+// is true, and returns nil without starting anything when enabled is false
+// (the WPMGR_UPTIME_KEEPWARM=false / default-off case). ctx controls the
+// refresher's lifetime — cancel it on shutdown for a clean stop. The returned
+// warmer is nil when disabled, mainly so callers/tests can observe whether the
+// gate started the loop.
+func StartUptimeKeepWarm(ctx context.Context, enabled bool, store metrics.Store, lister EnrolledSiteLister, logger *slog.Logger) *UptimeKeepWarmer {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if !enabled {
+		logger.Info("uptime keep-warm refresher disabled (WPMGR_UPTIME_KEEPWARM=false)")
+		return nil
+	}
+	if store == nil || lister == nil {
+		logger.Warn("uptime keep-warm refresher not started: store or lister not wired")
+		return nil
+	}
+	w := NewUptimeKeepWarmer(store, lister, logger)
+	go w.Run(ctx)
+	return w
+}
+
+// Run starts the periodic refresh loop and blocks until ctx is cancelled.
+// Call it in its own goroutine (StartUptimeKeepWarm does this). It refreshes
+// once immediately on start (so a fresh deploy doesn't wait a full interval
+// before the cache is warm), then on every tick thereafter. Each tick is
+// best-effort: a failure listing enrolled sites, or refreshing any one
+// tenant, is logged and never stops the loop or crashes the process.
+func (w *UptimeKeepWarmer) Run(ctx context.Context) {
+	w.logger.Info("uptime keep-warm refresher started",
+		slog.Duration("interval", w.interval))
+
+	w.tick(ctx)
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			w.logger.Info("uptime keep-warm refresher stopped")
+			return
+		case <-ticker.C:
+			w.tick(ctx)
+		}
+	}
+}
+
+// tick groups enrolled sites by tenant and refreshes each tenant's fleet-
+// uptime cache entry once.
+func (w *UptimeKeepWarmer) tick(ctx context.Context) {
+	t0 := time.Now()
+	sites, err := w.lister.ListEnrolledSiteIDs(ctx)
+	if err != nil {
+		w.logger.Warn("uptime keep-warm: list enrolled sites failed", slog.Any("error", err))
+		return
+	}
+	byTenant := groupByTenant(sites)
+	for tenantID, siteIDs := range byTenant {
+		w.refreshTenant(ctx, tenantID, siteIDs)
+	}
+	w.logger.Debug("uptime keep-warm tick",
+		slog.Int("tenants", len(byTenant)),
+		slog.Int("sites", len(sites)),
+		slog.Int64("elapsed_ms", time.Since(t0).Milliseconds()),
+	)
+}
+
+// refreshTenant re-runs QueryFleetUptime for one tenant, through the SAME
+// tenant-scoped path the /sites handler uses (QueryFleetUptime runs under
+// InAgentTx with an explicit tenant_id predicate — RLS is never bypassed).
+// Best-effort: a panic is recovered and an error is logged, never propagated
+// — a single tenant's failure must never stop the loop or affect others.
+func (w *UptimeKeepWarmer) refreshTenant(ctx context.Context, tenantID uuid.UUID, siteIDs []uuid.UUID) {
+	defer func() {
+		if r := recover(); r != nil {
+			w.logger.Warn("uptime keep-warm: tenant refresh panic",
+				slog.String("tenant_id", tenantID.String()),
+				slog.Any("panic", r))
+		}
+	}()
+	if _, err := w.store.QueryFleetUptime(ctx, tenantID, siteIDs, w.window); err != nil {
+		w.logger.Debug("uptime keep-warm: tenant refresh failed",
+			slog.String("tenant_id", tenantID.String()),
+			slog.Any("error", err))
+	}
+}
+
+// groupByTenant buckets (tenant, site) pairs into tenant -> siteIDs, skipping
+// any pair with a nil tenant or site ID (defensive; the lister should never
+// produce these).
+func groupByTenant(sites []TenantSiteID) map[uuid.UUID][]uuid.UUID {
+	out := make(map[uuid.UUID][]uuid.UUID)
+	for _, s := range sites {
+		if s.TenantID == uuid.Nil || s.SiteID == uuid.Nil {
+			continue
+		}
+		out[s.TenantID] = append(out[s.TenantID], s.SiteID)
+	}
+	return out
+}

--- a/apps/api/internal/site/uptime_keepwarm_test.go
+++ b/apps/api/internal/site/uptime_keepwarm_test.go
@@ -1,0 +1,294 @@
+package site
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/metrics"
+)
+
+// ---------------------------------------------------------------------------
+// Unit tests for the interim uptime keep-warm refresher (WPMGR_UPTIME_KEEPWARM)
+// ---------------------------------------------------------------------------
+
+// keepWarmFakeLister returns a fixed set of (tenant, site) pairs and counts
+// how many times it was called. Can be configured to error.
+type keepWarmFakeLister struct {
+	mu    sync.Mutex
+	sites []TenantSiteID
+	calls int
+	err   error
+}
+
+func (l *keepWarmFakeLister) ListEnrolledSiteIDs(_ context.Context) ([]TenantSiteID, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.calls++
+	if l.err != nil {
+		return nil, l.err
+	}
+	return l.sites, nil
+}
+
+func (l *keepWarmFakeLister) callCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.calls
+}
+
+var _ EnrolledSiteLister = (*keepWarmFakeLister)(nil)
+
+// keepWarmFakeStore records QueryFleetUptime calls per tenant and can be
+// configured to fail for exactly one tenant, so tests can prove a single
+// tenant's failure never stops the refresh loop.
+type keepWarmFakeStore struct {
+	mu         sync.Mutex
+	calls      map[uuid.UUID]int
+	failTenant uuid.UUID
+}
+
+func newKeepWarmFakeStore() *keepWarmFakeStore {
+	return &keepWarmFakeStore{calls: make(map[uuid.UUID]int)}
+}
+
+func (s *keepWarmFakeStore) Enabled() bool { return true }
+func (s *keepWarmFakeStore) Close() error  { return nil }
+func (s *keepWarmFakeStore) InsertChecks(_ context.Context, _ []metrics.Check) error {
+	return nil
+}
+func (s *keepWarmFakeStore) QueryAggregate(_ context.Context, _, _ uuid.UUID, _ time.Duration) (metrics.Aggregate, error) {
+	return metrics.Aggregate{}, nil
+}
+func (s *keepWarmFakeStore) QueryLatest(_ context.Context, _, _ uuid.UUID) (metrics.Latest, error) {
+	return metrics.Latest{}, nil
+}
+func (s *keepWarmFakeStore) QuerySeries(_ context.Context, _, _ uuid.UUID, _ time.Duration, _ int) ([]metrics.Point, error) {
+	return nil, nil
+}
+func (s *keepWarmFakeStore) QueryFleetUptime(_ context.Context, tenantID uuid.UUID, _ []uuid.UUID, _ time.Duration) (map[uuid.UUID]metrics.FleetUptimeRow, error) {
+	s.mu.Lock()
+	s.calls[tenantID]++
+	s.mu.Unlock()
+	if s.failTenant != uuid.Nil && tenantID == s.failTenant {
+		return nil, errors.New("simulated tenant refresh failure")
+	}
+	return map[uuid.UUID]metrics.FleetUptimeRow{}, nil
+}
+func (s *keepWarmFakeStore) QueryProbeWindow(_ context.Context, _, _ uuid.UUID, _, _ time.Time, _ int) ([]metrics.ProbeSample, error) {
+	return nil, nil
+}
+
+func (s *keepWarmFakeStore) callsFor(tenantID uuid.UUID) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls[tenantID]
+}
+
+func (s *keepWarmFakeStore) totalCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, c := range s.calls {
+		n += c
+	}
+	return n
+}
+
+var _ metrics.Store = (*keepWarmFakeStore)(nil)
+
+// ---------------------------------------------------------------------------
+// groupByTenant
+// ---------------------------------------------------------------------------
+
+func TestGroupByTenant(t *testing.T) {
+	tenantA := uuid.New()
+	tenantB := uuid.New()
+	siteA1 := uuid.New()
+	siteA2 := uuid.New()
+	siteB1 := uuid.New()
+
+	got := groupByTenant([]TenantSiteID{
+		{TenantID: tenantA, SiteID: siteA1},
+		{TenantID: tenantA, SiteID: siteA2},
+		{TenantID: tenantB, SiteID: siteB1},
+		{TenantID: uuid.Nil, SiteID: uuid.New()}, // nil tenant skipped
+		{TenantID: uuid.New(), SiteID: uuid.Nil}, // nil site skipped
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 tenants, got %d", len(got))
+	}
+	if len(got[tenantA]) != 2 {
+		t.Fatalf("expected 2 sites for tenantA, got %d", len(got[tenantA]))
+	}
+	if len(got[tenantB]) != 1 {
+		t.Fatalf("expected 1 site for tenantB, got %d", len(got[tenantB]))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UptimeKeepWarmer.tick — tenant-selection + per-tenant fault tolerance
+// ---------------------------------------------------------------------------
+
+func TestUptimeKeepWarmer_Tick_RefreshesEveryTenant_TolerantOfPerTenantError(t *testing.T) {
+	tenantOK1 := uuid.New()
+	tenantOK2 := uuid.New()
+	tenantFail := uuid.New()
+
+	lister := &keepWarmFakeLister{sites: []TenantSiteID{
+		{TenantID: tenantOK1, SiteID: uuid.New()},
+		{TenantID: tenantOK2, SiteID: uuid.New()},
+		{TenantID: tenantFail, SiteID: uuid.New()},
+	}}
+	store := newKeepWarmFakeStore()
+	store.failTenant = tenantFail
+
+	w := NewUptimeKeepWarmer(store, lister, nil)
+
+	// A single tenant's failure must not stop the others from being
+	// refreshed, and tick() itself must not panic or return early.
+	w.tick(context.Background())
+
+	if got := store.callsFor(tenantOK1); got != 1 {
+		t.Fatalf("expected tenantOK1 refreshed once, got %d", got)
+	}
+	if got := store.callsFor(tenantOK2); got != 1 {
+		t.Fatalf("expected tenantOK2 refreshed once, got %d", got)
+	}
+	if got := store.callsFor(tenantFail); got != 1 {
+		t.Fatalf("expected the failing tenant to still be attempted once, got %d", got)
+	}
+}
+
+func TestUptimeKeepWarmer_Tick_OnlyEnrolledTenantsAreTouched(t *testing.T) {
+	tenantWithSites := uuid.New()
+	lister := &keepWarmFakeLister{sites: []TenantSiteID{
+		{TenantID: tenantWithSites, SiteID: uuid.New()},
+	}}
+	store := newKeepWarmFakeStore()
+	w := NewUptimeKeepWarmer(store, lister, nil)
+
+	w.tick(context.Background())
+
+	if got := store.totalCalls(); got != 1 {
+		t.Fatalf("expected exactly 1 tenant refreshed (no zero-site tenants scanned), got %d", got)
+	}
+	if got := store.callsFor(tenantWithSites); got != 1 {
+		t.Fatalf("expected the enrolled tenant to be refreshed, got %d", got)
+	}
+	// A tenant that never appeared in the lister output must never be
+	// queried — there is nothing to assert an absence of a random UUID
+	// beyond totalCalls()==1 above, which already pins the exact call count.
+}
+
+func TestUptimeKeepWarmer_Tick_ListerErrorIsNonFatal(t *testing.T) {
+	lister := &keepWarmFakeLister{err: errors.New("boom")}
+	store := newKeepWarmFakeStore()
+	w := NewUptimeKeepWarmer(store, lister, nil)
+
+	// Must not panic; must simply skip this tick.
+	w.tick(context.Background())
+
+	if got := store.totalCalls(); got != 0 {
+		t.Fatalf("expected no store calls when the lister errors, got %d", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// StartUptimeKeepWarm — the env-gate
+// ---------------------------------------------------------------------------
+
+func TestStartUptimeKeepWarm_Disabled_DoesNotStart(t *testing.T) {
+	lister := &keepWarmFakeLister{sites: []TenantSiteID{{TenantID: uuid.New(), SiteID: uuid.New()}}}
+	store := newKeepWarmFakeStore()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := StartUptimeKeepWarm(ctx, false, store, lister, nil)
+	if w != nil {
+		t.Fatal("expected a nil warmer when disabled (goroutine must not start)")
+	}
+
+	// Give any (incorrectly) started goroutine a chance to run, then assert
+	// it never touched the lister/store.
+	deadline := time.Now().Add(150 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if lister.callCount() > 0 {
+			t.Fatal("disabled refresher must never call the lister")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := store.totalCalls(); got != 0 {
+		t.Fatalf("disabled refresher must never call the store, got %d calls", got)
+	}
+}
+
+func TestStartUptimeKeepWarm_Enabled_TicksImmediatelyOnStart(t *testing.T) {
+	tenantID := uuid.New()
+	lister := &keepWarmFakeLister{sites: []TenantSiteID{{TenantID: tenantID, SiteID: uuid.New()}}}
+	store := newKeepWarmFakeStore()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := StartUptimeKeepWarm(ctx, true, store, lister, nil)
+	if w == nil {
+		t.Fatal("expected a non-nil warmer when enabled")
+	}
+
+	// Run() refreshes once immediately on start (not just on the 45s ticker),
+	// so a fresh deploy doesn't sit cold for a full interval. Poll (bounded)
+	// rather than sleeping the full interval.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if store.callsFor(tenantID) > 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("expected the enabled refresher to have called QueryFleetUptime at least once within 2s")
+}
+
+func TestStartUptimeKeepWarm_StopsOnContextCancel(t *testing.T) {
+	tenantID := uuid.New()
+	lister := &keepWarmFakeLister{sites: []TenantSiteID{{TenantID: tenantID, SiteID: uuid.New()}}}
+	store := newKeepWarmFakeStore()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w := StartUptimeKeepWarm(ctx, true, store, lister, nil)
+	if w == nil {
+		t.Fatal("expected a non-nil warmer when enabled")
+	}
+
+	// Wait for the immediate startup tick, then cancel and confirm no
+	// subsequent tick occurs. (We can't observe goroutine exit directly
+	// without instrumenting Run further, so this only asserts cancellation
+	// doesn't itself panic/hang — the real "does it stop" guarantee is the
+	// select on ctx.Done() in Run, exercised here for crash-freedom.)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if store.callsFor(tenantID) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+}
+
+func TestStartUptimeKeepWarm_NilStoreOrLister_DoesNotStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if w := StartUptimeKeepWarm(ctx, true, nil, &keepWarmFakeLister{}, nil); w != nil {
+		t.Fatal("expected a nil warmer when store is nil")
+	}
+	if w := StartUptimeKeepWarm(ctx, true, newKeepWarmFakeStore(), nil, nil); w != nil {
+		t.Fatal("expected a nil warmer when lister is nil")
+	}
+}


### PR DESCRIPTION
## Recurring 7-8s on GET /api/v1/sites after ~15-30 min idle

A dynamic research workflow (prod logs + query + data-volume) pinned it definitively: the cost is **entirely** the uptime enrichment (`QueryFleetUptime`) — a per-site `LATERAL` aggregate over ~30d of raw `site_uptime_probes` (~43k rows/site) — running against a **cold** Postgres buffer cache on the small `db-g1-small`. The app's own "site list slow" WARN shows `repo_ms` (base query + pool acquire) = 30-79ms while `uptime_ms` ≈ all of `total_ms`. It recurs because both warm layers expire during idle (the 60s in-process cache **and** the PG buffers holding the probes index), and worsens as the un-pruned probe table grows.

## Interim stopgap (this PR)
A per-process `UptimeKeepWarmer` goroutine ticks every 45s (under the 60s cache TTL) and re-runs `QueryFleetUptime` for every enrolled tenant **through the same cache-wrapped store `List()` reads**, so the in-process cache never expires unpopulated and the PG buffers stay resident. Reuses `uptime.Repo.ListEnrolledForProbe`; RLS honored (`InAgentTx`); per-tenant failures recover-guarded; **env-gated `WPMGR_UPTIME_KEEPWARM` (default on)**, stopped on SIGTERM. Fully additive and cleanly removable.

## Durable follow-up (next PR)
A per-site uptime **rollup** (`site_uptime_daily` + a current-status stamp) so `QueryFleetUptime` reads ~30 rows/site instead of ~43k — O(sites), permanently cache-resident. This keep-warm is removed once the rollup lands.

CP-only; agent unchanged (version bumped for the unified release only). Gates: `go build`/`vet`/`test` green (+ keep-warm unit tests: tenant-selection, per-tenant fault tolerance, env-gate).

Refs the /sites latency report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JasKfWHYCN6MABVujvcMHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Sites list responsiveness after periods of inactivity.
  - Prevented delays caused by uptime information becoming stale or cold.

- **New Features**
  - Added an uptime keep-warm setting, enabled by default.
  - Administrators can disable this behavior with `WPMGR_UPTIME_KEEPWARM=false`.

- **Documentation**
  - Added release notes describing the Sites list performance improvement.

- **Chores**
  - Updated the application and agent release version to 0.61.67.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->