### PR TITLE
docs: close the docs-drift audit P1 gaps (changelog backfill, swagger version, secrets guidance)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,11 +66,17 @@ WPMGR_REDIS_ADDR=localhost:6379
 
 # Secrets-at-rest key (age X25519). Encrypts stored SMTP passwords, per-site
 # email + destination secrets, object-cache creds, and 2FA secrets. OPTIONAL:
-# EMPTY => a STABLE key is derived from WPMGR_SESSION_SECRET, so a self-host just
-# works and secrets survive restarts (no ephemeral key). Set an explicit value
-# only if you want an isolated, independently rotatable secrets-at-rest key
-# (recommended for larger production deployments). Format: age secret key, the
-# literal "AGE-SECRET-KEY-1..." (UPPERCASE; mixed case is rejected).
+# EMPTY => the key is derived from WPMGR_SESSION_SECRET, so it is exactly as
+# stable as that secret. On a plain Docker/VM install where .env never changes,
+# that means secrets survive restarts. BUT on any platform that regenerates env
+# values per deploy (many PaaS do), the derived key ROTATES with each deploy and
+# every stored secret becomes undecryptable: two-factor works once then fails on
+# every later login, and SMTP/destination credentials are lost until re-entered.
+# On such platforms you MUST set an explicit value here AND keep
+# WPMGR_SESSION_SECRET fixed. The api logs a key fingerprint at boot and WARNs
+# when stored secrets no longer decrypt; that WARN is the tell the key rotated.
+# Format: age secret key, the literal "AGE-SECRET-KEY-1..." (UPPERCASE; mixed
+# case is rejected).
 # run: docker compose run --rm api wpmgr-cli gen-secrets   (or: age-keygen)
 # NOTE: switching between derived and explicit (or changing either) re-keys the
 # store, so re-enter your SMTP password / secrets once after the change.
@@ -166,6 +172,16 @@ WPMGR_OIDC_CLIENT_SECRET=
 # (WPMGR_WEB_PORT=8088 by default); nginx proxies /auth/* to the api internally.
 # Do NOT use port 8081 (direct API host port) or :8080 (container-internal).
 WPMGR_OIDC_REDIRECT_URL=http://localhost:8088/auth/oidc/callback
+# WebAuthn / passkeys (dashboard 2FA). Defaults point at the hosted instance
+# (manage.wpmgr.app); self-hosters who want passkeys MUST set both to their own
+# dashboard domain. Left commented out so the built-in defaults apply.
+# Relying-party ID: the registrable domain the dashboard is served on.
+# Format: hostname. e.g. manage.example.com
+#WPMGR_AUTH_WEBAUTHN_RPID=manage.example.com
+# Allowed origins, comma-separated; must be https:// and match the dashboard
+# URL exactly (production boot rejects http:// and localhost origins).
+# Format: comma-separated URLs. e.g. https://manage.example.com
+#WPMGR_AUTH_WEBAUTHN_RP_ORIGINS=https://manage.example.com
 
 # ---- Agent protocol tuning ----
 # Anti-replay signature skew, heartbeat-staleness threshold, health-job cadence.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,52 @@ jobs:
             exit 1
           fi
 
+      # Docs-version drift guard. Two checks against the top CHANGELOG.md entry:
+      #  1. packages/openapi/openapi.yaml info.version must equal it exactly
+      #     (the marketing build self-heals the rendered doc, but the source of
+      #     truth should never drift).
+      #  2. The newest RELEASES entry in the marketing changelog page must be
+      #     within 5 patch versions of it (catches the changelog page silently
+      #     falling behind, without demanding an entry for every single tag).
+      # Both checks are forgiving: if any version fails to parse we warn and
+      # skip rather than false-positive-block a PR.
+      - name: Docs version drift guard (openapi + marketing changelog)
+        run: |
+          top=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | tr -d '#[] ' || true)
+          if [ -z "$top" ]; then
+            echo "WARN: could not parse the top CHANGELOG.md version; skipping the drift guard."
+            exit 0
+          fi
+          spec=$(grep -m1 -E '^[[:space:]]+version:' packages/openapi/openapi.yaml | awk '{print $2}' | tr -d '"' || true)
+          if [ -z "$spec" ]; then
+            echo "WARN: could not parse packages/openapi/openapi.yaml info.version; skipping that check."
+          elif [ "$spec" != "$top" ]; then
+            echo "ERROR: packages/openapi/openapi.yaml info.version is $spec but the top CHANGELOG.md entry is $top."
+            echo "Bump openapi.yaml info.version alongside the CHANGELOG."
+            exit 1
+          fi
+          page='apps/marketing/app/(marketing)/changelog/page.tsx'
+          # Newest RELEASES entry; may be a range like "0.61.64 - 0.61.65", take the first number.
+          mk=$(grep -m1 -oE 'version: "[0-9]+\.[0-9]+\.[0-9]+' "$page" 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
+          if [ -z "$mk" ]; then
+            echo "WARN: could not parse the newest marketing changelog version from $page; skipping that check."
+            exit 0
+          fi
+          if [ "${top%.*}" = "${mk%.*}" ]; then
+            top_patch=${top##*.}
+            mk_patch=${mk##*.}
+            behind=$((top_patch - mk_patch))
+            if [ "$behind" -gt 5 ]; then
+              echo "ERROR: the marketing changelog's newest entry ($mk) is $behind patch versions behind the top CHANGELOG.md entry ($top)."
+              echo "Backfill apps/marketing/app/(marketing)/changelog/page.tsx (grouped entries are fine)."
+              exit 1
+            fi
+            echo "Marketing changelog newest entry $mk is within tolerance of $top."
+          else
+            echo "WARN: major/minor differ between marketing changelog ($mk) and CHANGELOG.md ($top); skipping the drift compare."
+          fi
+          echo "openapi.yaml info.version matches the top CHANGELOG.md entry ($top)."
+
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26.5"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress sites from one dashboard — all running on infrastructure you control. The control plane is a Go binary with a React dashboard; a lightweight PHP plugin on each managed site handles the work. Everything between the agent and the control plane is Ed25519-signed.
 
-[![Latest release](https://img.shields.io/badge/release-v0.50.5-blue?style=flat)](https://github.com/mosamlife/wpmgr/releases)
+[![Latest release](https://img.shields.io/github/v/release/mosamlife/wpmgr?label=release&style=flat)](https://github.com/mosamlife/wpmgr/releases)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat)](./LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/mosamlife/wpmgr/ci.yml?branch=main&label=CI&style=flat)](https://github.com/mosamlife/wpmgr/actions/workflows/ci.yml)
 
@@ -16,7 +16,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
   <a href="https://wpmgr.app/docs/">API reference</a>
 </p>
 
-**v0.43.3** — open-source and production-usable for self-hosters.
+**v0.61.69** — open-source and production-usable for self-hosters.
 
 ---
 

--- a/apps/api/internal/config/validate.go
+++ b/apps/api/internal/config/validate.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/riverutil"
 )
 
-// validateWebAuthnOrigins checks that every WPMGR_AUTH_WEBAUTHN_RPORIGINS entry
+// validateWebAuthnOrigins checks that every WPMGR_AUTH_WEBAUTHN_RP_ORIGINS entry
 // uses HTTPS and is not a loopback/localhost origin. Called by Validate in
 // production only. Self-hosted operators who deploy HTTP or use localhost must
 // set WPMGR_ENV != "production".
@@ -25,7 +25,7 @@ func validateWebAuthnOrigins(origins string) *Issue {
 		lower := strings.ToLower(o)
 		if strings.HasPrefix(lower, "http://") {
 			return &Issue{
-				Name:   "WPMGR_AUTH_WEBAUTHN_RPORIGINS",
+				Name:   "WPMGR_AUTH_WEBAUTHN_RP_ORIGINS",
 				Reason: "contains an http:// origin (" + o + ") — WebAuthn requires HTTPS in production; use https://",
 			}
 		}
@@ -44,7 +44,7 @@ func validateWebAuthnOrigins(origins string) *Issue {
 		}
 		if host == "localhost" || host == "127.0.0.1" || host == "::1" || strings.HasSuffix(host, ".localhost") {
 			return &Issue{
-				Name:   "WPMGR_AUTH_WEBAUTHN_RPORIGINS",
+				Name:   "WPMGR_AUTH_WEBAUTHN_RP_ORIGINS",
 				Reason: "contains a loopback/localhost origin (" + o + ") — not permitted in production; use your public domain",
 			}
 		}

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -63,6 +63,155 @@ const RELEASES: ChangeEntry[] = [
         tag: "Fixed",
         text: "The Sites list stays fast even after long idle periods: uptime data shown on the list is now read from a compact per-site rollup instead of scanning the full probe history, with uptime percentages unchanged and exact.",
       },
+      {
+        tag: "Changed",
+        text: "The Sites list shows each site's last backup as a relative time (for example \"2h ago\"), with the exact date and time on hover (GH #231).",
+      },
+    ],
+  },
+  {
+    version: "0.61.64 - 0.61.65",
+    date: "2026-07-16",
+    summary: "Scheduled backups can no longer stall silently, and slow pages screenshot correctly.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Scheduled backups no longer stall permanently at \"queued\" (GH #232). A scheduled run previously depended on WordPress cron, which never fires on quiet or DISABLE_WP_CRON sites, and its watchdog ran on that same cron. Backups now always start in-process, a request-driven sweeper re-dispatches genuinely stalled tasks, and a connection-independent file lock prevents a second runner from ever corrupting an in-progress backup.",
+      },
+      {
+        tag: "Fixed",
+        text: "Website screenshots of slow-loading or uncached pages are no longer blank (GH #229). Capture now waits for page load, network idle, and the DOM to settle, bounded by a hard timeout so a slow page degrades to a best-effort partial capture.",
+      },
+      {
+        tag: "Fixed",
+        text: "Switching organizations while viewing a single site no longer lands on a dead \"no website\" page; you are routed to the new organization's Sites list (GH #233).",
+      },
+      {
+        tag: "Changed",
+        text: "Stored secrets that can no longer be decrypted because the server's encryption key changed now fail loudly and clearly instead of looking like a wrong two-factor code (GH #215): the control plane logs a key fingerprint at startup, warns at boot when stored secrets no longer decrypt (with the exact remediation, pin a stable WPMGR_SITE_DEST_AGE_SECRET), and the two-factor prompt shows a precise \"the server's encryption key changed\" message.",
+      },
+    ],
+  },
+  {
+    version: "0.61.62",
+    date: "2026-07-15",
+    summary: "Pre-update rollback snapshots are cleaned up reliably instead of accumulating forever.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Rollback snapshots captured before each plugin, theme, or core update are now reclaimed reliably (GH #226). Cleanup previously depended on WordPress cron, so a site that updated once and went quiet kept every snapshot forever, quietly consuming disk space. Cleanup now runs on ordinary agent activity, a snapshot whose update succeeded is reclaimed within about an hour once safely past the rollback window, and any backlog is swept on the first request after upgrading. Snapshots are never removed while a rollback could still be needed.",
+      },
+    ],
+  },
+  {
+    version: "0.61.58 - 0.61.60",
+    date: "2026-07-14",
+    summary: "Self-hosted secrets now survive restarts, plus a batch of fixes across updates, backups, hide-login, and two-factor.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Stored secrets (SMTP password, destination and object-cache credentials, two-factor secrets) now survive a restart on a self-hosted install that has not set an explicit secrets-at-rest key. The key is now derived stably from the already-required WPMGR_SESSION_SECRET, so nothing is lost on reboot. Upgrade note: installs that were on the old per-boot key need to re-enter affected secrets once.",
+      },
+      {
+        tag: "Fixed",
+        text: "A failed, empty backup snapshot can now be deleted on its own; the chain-safety guard now checks the real parent-snapshot chain of custody instead of generation numbers (GH #221).",
+      },
+      {
+        tag: "Fixed",
+        text: "Bulk update runs now make one guaranteed-fresh update check per run instead of one per item (GH #218), and updates no longer fail with \"Could not copy file\" on hosts whose shared temp directory has grown pathologically overloaded (GH #216).",
+      },
+      {
+        tag: "Fixed",
+        text: "The fleet backup health view no longer fails entirely when a site has never completed a backup; such a site now reports as Unprotected (GH #214).",
+      },
+      {
+        tag: "Fixed",
+        text: "Hide-login no longer blocks front-end AJAX: admin-ajax.php and admin-post.php are excluded while the login and dashboard pages stay hidden (GH #219).",
+      },
+      {
+        tag: "Fixed",
+        text: "Two-factor sign-in is clearer and slightly more forgiving: the single-use message explains why a re-submitted code is rejected, the accepted window widened to plus or minus 60 seconds, and the setup code can no longer be reused for the first login (GH #215). The bulk update wizard's tab badges now count only components with a real pending update (GH #217).",
+      },
+    ],
+  },
+  {
+    version: "0.61.55 - 0.61.56",
+    date: "2026-07-11",
+    summary: "Update rollback now recovers a site even when the update takes it fully down.",
+    items: [
+      {
+        tag: "Added",
+        text: "A new update watchdog loads before regular plugins and, when a plugin or theme update leaves the site fataling on every request, restores the pre-update snapshot directly at the filesystem level without needing WordPress to boot (GH #210). It fires only for a genuine post-update fatal within a short window, and disarms as soon as the site boots healthily, so it can never revert a working update.",
+      },
+      {
+        tag: "Fixed",
+        text: "Phantom updates whose target version equals the installed version are suppressed everywhere (GH #211), and the Refresh button on available updates now forces a real check against WordPress.org instead of returning a cached list (GH #212).",
+      },
+      {
+        tag: "Fixed",
+        text: "The self-hosted media-encoder no longer crash-loops on boot with an unprivileged database role, screenshots work on the bundled image, and an infrastructure capture failure is retried a bounded number of times instead of being recorded as success (GH #207).",
+      },
+      {
+        tag: "Fixed",
+        text: "Updates targeting \"latest\" no longer report \"already up to date\" from a momentarily stale cache, and heavy updates no longer spuriously report failed at the 30-second dispatch timeout (GH #208).",
+      },
+    ],
+  },
+  {
+    version: "0.61.54",
+    date: "2026-07-10",
+    summary: "Critical self-host fix: a misconfigured media-encoder could silently stop every scheduled job.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "On self-hosted installs where the media-encoder ran in the API's default database schema, it could silently take over background-job leader election and stop every scheduled fleet job, including backups, uptime checks, and cleanups, with no error anywhere (GH #205). The media-encoder now refuses to start in that misconfiguration, the safe dedicated schema is the built-in default with no configuration change needed, and any jobs left behind in the shared schema are cleaned up automatically.",
+      },
+    ],
+  },
+  {
+    version: "0.61.49 - 0.61.53",
+    date: "2026-07-10",
+    summary: "Sign up straight into a paid plan, honest fleet vitals, and the media-encoder on by default for self-host.",
+    items: [
+      {
+        tag: "Added",
+        text: "Choosing Starter, Agency, or Scale on the pricing page now carries that choice through signup and email verification into a checkout for the plan you picked, with a \"Skip for now\" option. Prices on the pricing page are fetched live from the payment providers at build time with a USD and INR currency toggle, backed by Stripe and Razorpay. Hosted only; self-host is unaffected.",
+      },
+      {
+        tag: "Changed",
+        text: "Self-hosted installs now run the media-encoder by default, so site screenshots and the Media Optimizer work on a default docker compose up; opt out with --scale media-encoder=0 (GH #187).",
+      },
+      {
+        tag: "Fixed",
+        text: "Fleet Core Web Vitals now count a site as passing only when LCP, INP, and CLS all pass (GH #195), the worst-offenders table shows each site's name and URL (GH #202), and the CLS distribution bar agrees with its p75 rating (GH #185).",
+      },
+      {
+        tag: "Fixed",
+        text: "Audit-log entries for backups, restores, and updates now show their site and match the site filter (GH #201), the \"sites with items to review\" database-health stat expands into the full linked list (GH #197), and the database-size 90-day history now populates automatically from each site's daily diagnostics (GH #196).",
+      },
+      {
+        tag: "Fixed",
+        text: "Switching organizations takes effect immediately (GH #186), backup detail pages have a real breadcrumb trail back to the site's backup list (GH #188), and a screenshot refresh that cannot run now stops with a clear warning instead of spinning forever (GH #187).",
+      },
+    ],
+  },
+  {
+    version: "0.61.41 - 0.61.48",
+    date: "2026-07-08",
+    summary: "A concentrated run of plugin and theme update reliability fixes, plus admin panel improvements.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "A series of update-reliability fixes across restricted and standard hosts: a pre-update snapshot failure no longer blocks the update on open_basedir or symlinked wp-content setups; a stale filesystem cache no longer causes a perfectly good update to be reported failed and rolled back; a bulk update including a premium plugin that manages its own updates no longer fatals and strands the site in maintenance mode (GH #182); and the temporary-directory pin that collided with WordPress's own unpack folder on standard hosts was removed, so updates work everywhere again while restricted hosts keep a dedicated safe fallback.",
+      },
+      {
+        tag: "Added",
+        text: "Failed or rolled-back update tasks now show the complete agent log, including WordPress's own explanation of what went wrong, with a \"View log\" toggle and a copy button.",
+      },
+      {
+        tag: "Fixed",
+        text: "Two-factor settings are now reachable for every account, including accounts without an organization and the instance superadmin; the instance-admin console is full width with cleaner navigation; and the Accounts list pagination advances correctly.",
+      },
     ],
   },
   {

--- a/apps/marketing/scripts/sync-openapi.mjs
+++ b/apps/marketing/scripts/sync-openapi.mjs
@@ -29,6 +29,26 @@ mkdirSync(assetsDir, { recursive: true });
 // 1. Parse the source YAML and emit minified JSON.
 //    Minified is smaller and faster for the browser to parse.
 const spec = parse(readFileSync(specYaml, "utf8"));
+
+// Self-healing version stamp: the rendered doc always shows the release
+// version from the top CHANGELOG.md entry, so info.version can never drift
+// on wpmgr.app/docs even if the yaml bump is forgotten. Falls back to the
+// yaml's own value when the CHANGELOG cannot be parsed.
+try {
+  const changelog = readFileSync(join(repoRoot, "CHANGELOG.md"), "utf8");
+  const m = changelog.match(/^## \[(\d+\.\d+\.\d+)\]/m);
+  if (m && spec.info) {
+    if (spec.info.version !== m[1]) {
+      console.warn(
+        `sync-openapi: overriding spec info.version ${spec.info.version} -> ${m[1]} (top CHANGELOG.md entry)`,
+      );
+    }
+    spec.info.version = m[1];
+  }
+} catch {
+  // CHANGELOG.md missing/unreadable: keep the yaml's version.
+}
+
 writeFileSync(join(publicDir, "openapi.json"), JSON.stringify(spec));
 
 // 2. Vendor the pinned Scalar standalone bundle.

--- a/docs/adr/ADR-056-dashboard-2fa.md
+++ b/docs/adr/ADR-056-dashboard-2fa.md
@@ -88,7 +88,7 @@ The WebAuthn RP ID and origin must be configurable for self-hosted instances. Tw
 
 ```
 WPMGR_AUTH_WEBAUTHN_RPID      (default: "manage.wpmgr.app")
-WPMGR_AUTH_WEBAUTHN_RPORIGINS (comma-separated; default: "https://manage.wpmgr.app")
+WPMGR_AUTH_WEBAUTHN_RP_ORIGINS (comma-separated; default: "https://manage.wpmgr.app")
 ```
 
 Self-hosted operators set these to match their `WPMGR_PUBLIC_BASE_URL`.
@@ -159,7 +159,7 @@ NIST SP 800-63B Section 5.1.5 (out-of-band authenticators) and Section 5.1.4 (si
 - The `users` table grows three columns (two nullable bytea/timestamptz). No existing query changes shape.
 - Five new tables are added; all are pre-tenant (auth-flow scope), using `app.agent='on'` RLS.
 - The `go-webauthn/webauthn` library is v0.x and pinned to v0.17.4. API changes require a coordinated update.
-- `WPMGR_AUTH_WEBAUTHN_RPID` and `WPMGR_AUTH_WEBAUTHN_RPORIGINS` must be set by self-hosted operators when they deploy Phase 6. Defaults cover the hosted instance.
+- `WPMGR_AUTH_WEBAUTHN_RPID` and `WPMGR_AUTH_WEBAUTHN_RP_ORIGINS` must be set by self-hosted operators when they deploy Phase 6. Defaults cover the hosted instance.
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -42,7 +42,9 @@ make dev           # full stack for local development
 make test          # all tests (Go + frontend)
 make build         # build api + web
 make lint          # go vet + pnpm lint
-make gen           # regenerate OpenAPI clients (Go + TS) from packages/openapi/openapi.yaml
+# Regenerate OpenAPI codegen (Go server types + TS client) from packages/openapi/openapi.yaml:
+cd apps/api && go generate ./internal/api/gen/...   # Go server types (ogen)
+pnpm -C packages/openapi-client generate            # TS client
 make agent-zip     # package the WordPress agent plugin
 ```
 
@@ -73,9 +75,10 @@ the backend domains. The Go binary entrypoint is `apps/api/cmd/wpmgr/main.go`.
 ## Contract-first API
 
 The OpenAPI spec at `packages/openapi/openapi.yaml` is the single source of
-truth. Change the spec, then run `make gen` to regenerate the Go server types
-(ogen, ADR-004) and the TS client. Don't hand-edit generated code. See
-[api.md](./api.md).
+truth. Change the spec, then regenerate the Go server types (ogen, ADR-004)
+with `go generate ./internal/api/gen/...` (run from `apps/api`) and the TS
+client with `pnpm -C packages/openapi-client generate`. Don't hand-edit
+generated code. See [api.md](./api.md).
 
 ## Commits & PRs
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -30,13 +30,26 @@ at boot, so the app accepts them on the first try — are:
 | `WPMGR_SESSION_SECRET` | random ≥32-byte string | hard-fails boot if empty/too short |
 | `WPMGR_AGENT_SIGNING_PRIVATE_KEY` | base64-std of the **raw** 64-byte Ed25519 key | signs CP→agent commands; rejected in prod if it's the committed dev key |
 | `WPMGR_AGENT_SIGNING_PUBLIC_KEY` | base64-std of the **raw** 32-byte Ed25519 key | the public half agents verify with |
-| `WPMGR_SITE_DEST_AGE_SECRET` | age X25519 secret (`AGE-SECRET-KEY-1…`) | secrets-at-rest key. **Optional**: if empty, a stable key is derived from `WPMGR_SESSION_SECRET` (secrets survive restarts). Set explicitly for an isolated, independently rotatable key |
+| `WPMGR_SITE_DEST_AGE_SECRET` | age X25519 secret (`AGE-SECRET-KEY-1…`) | secrets-at-rest key. **Optional**: if empty, the key is derived from `WPMGR_SESSION_SECRET` and is only as stable as that secret. Pin an explicit value on any platform that regenerates env values per deploy (see "Pin your secrets" below) |
 
 > The values must be base64 of the **raw key bytes**, not of a PEM file — the old
 > `base64 < key.pem` recipe produced keys the runtime rejected. The generator
 > (`wpmgr-cli gen-secrets`) self-verifies every value by decoding it back through
 > the server's own boot parsers before printing it, so a generated line is
 > guaranteed to load.
+
+### Pin your secrets
+
+Stored secrets (operator two-factor enrollments, SMTP passwords, backup-destination
+and object-cache credentials) are encrypted at rest, keyed by these values, so the
+key must be identical across restarts and redeploys. Pin an explicit
+`WPMGR_SITE_DEST_AGE_SECRET` (via `wpmgr-cli gen-secrets` or `age-keygen`) and keep
+`WPMGR_SESSION_SECRET` fixed; this is mandatory on any platform that regenerates
+env values per deploy (many PaaS do). The symptom of an unpinned key: two-factor
+works once, then every later login fails, and operators are logged out on each
+redeploy. The boot log prints a key fingerprint and a decrypt self-check WARN when
+the key has changed. To recover: pin both values, sign in with a recovery code,
+then re-enroll two-factor and re-enter the affected secrets.
 
 To print the four secret lines without touching `.env` (e.g. to paste into a
 secret manager), run the generator directly — it works with a Go toolchain or,

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.15.0
+  version: 0.61.69
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## From the full docs-drift audit against v0.61.69 reality

- **Marketing /changelog backfill** — the missing July 8 → 17 window added as 7 grouped entries (28 versions, ~24 user-facing; wp.org compliance-only releases folded), plus the GH #231 item on the 0.61.69 entry.
- **Swagger/OpenAPI version** — `info.version` 0.15.0 → 0.61.69, and it can never drift again: `sync-openapi.mjs` self-heals the version from the top CHANGELOG entry at marketing build time, and a new CI guard fails when `info.version` ≠ top CHANGELOG version or the marketing changelog falls >5 versions behind (parse failures degrade to warnings).
- **Secrets stability (GH #215 docs gap)** — `.env.example` + `docs/install.md` no longer claim the derived key is unconditionally stable; new "Pin your secrets" guidance.
- **WebAuthn env-var name bug (code fix)** — the boot validation *error message* named `WPMGR_AUTH_WEBAUTHN_RPORIGINS` but config only accepts `WPMGR_AUTH_WEBAUTHN_RP_ORIGINS`; a self-hoster following the error set a silently-ignored var. Fixed + ADR + `.env.example`.
- **README** dynamic release badge; **contributing.md** real regen commands.

Also filed from the audit: **#240** (fonts/transcode endpoint implemented but never mounted). Follow-ups scheduled: ~100-route OpenAPI backfill + feature-docs sprint + full-engine routes-vs-spec contract test.

**Gates:** go build/vet + config tests green; `check-copy.mjs` clean; `sync-openapi.mjs` stamps v0.61.69; ci.yml YAML-validated with guard dry-runs; marketing `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWiZ4iJ1fmYW8vtPghWmsn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified secret-key stability, deployment considerations, recovery steps, and two-factor authentication configuration.
  - Corrected the WebAuthn origins configuration name across validation and dashboard 2FA documentation.
  - Updated OpenAPI regeneration instructions and current release/version references.

- **Release Information**
  - Refreshed the marketing changelog with recent releases and backup timestamp details.
  - Updated the published OpenAPI version to match the current release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->