### PR TITLE
fix(api,web,agent): honest cache reporting + real capability dots + working Manage-in-WPMgr link (GH #243) — 0.61.71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
-## [0.61.70] - 2026-07-17
+## [0.61.71] - 2026-07-18
+
+### Fixed
+
+- The dashboard no longer under-reports a working page cache (GH #243). Three distinct gaps, all reporting or navigation defects; the cache itself was serving correctly:
+  - The cache hit-ratio chart showed a flat 0% on sites where the agent's managed web-server rules serve cached pages directly from disk, because those hits never execute PHP and cannot be counted there. The chart is now honest about what it measures: on such sites the Cache tab shows a "Served at the web-server level" state (that is the fastest path working as intended), the series is labeled as the PHP-layer ratio, and the copy explains how to verify caching via the `x-wpmgr-source` response header. No numbers are fabricated or altered.
+  - The site card's "Page Cache" and "Object Cache" configuration dots were gray for every site since they were introduced, because they looked for plugin entries that can never exist (both features are drop-ins, which WordPress does not list as plugins). The dots now read the real per-site cache configuration, exposed on the sites API.
+  - The agent's admin-bar "Manage in WPMgr" link pointed at a dashboard page that never existed and rendered "Not Found". The agent now links to the site's Cache tab, the dashboard redirects the old link target so already-installed agents work immediately after this control-plane update, and unknown dashboard paths now render a proper page with a way back instead of a bare "Not Found".
 
 ### Changed
 

--- a/apps/agent/includes/cache/class-admin-bar-purge.php
+++ b/apps/agent/includes/cache/class-admin-bar-purge.php
@@ -275,7 +275,7 @@ final class AdminBarPurge
         if ($cpUrl === '' || $siteId === '') {
             return '';
         }
-        return rtrim($cpUrl, '/') . '/sites/' . rawurlencode($siteId) . '/performance';
+        return rtrim($cpUrl, '/') . '/sites/' . rawurlencode($siteId) . '/cache';
     }
 
     /**

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -185,6 +185,24 @@ This plugin ships two minified JavaScript files. Their human-readable source and
 
 The entries below summarize the notable changes since 0.36.0. This project ships frequently; not every intermediate patch release is listed here individually -- see the full history at https://github.com/mosamlife/wpmgr/blob/main/CHANGELOG.md.
 
+= 0.61.71 =
+* Fix: the "Manage in WPMgr" admin bar link now opens the site's Cache page in the control-plane dashboard. It previously pointed at a page that has never existed.
+
+= 0.61.64 =
+* Fix: scheduled backups no longer stall indefinitely at "queued". A backup run now always starts immediately instead of depending solely on WordPress cron, and a request-driven check recovers any run that still gets stuck. A file-based lock alongside the existing database lock prevents two runs of the same backup from overlapping.
+
+= 0.61.63 =
+* Changed: the Real User Monitoring script now ships with a readable, non-minified source file alongside the minified one, for WordPress.org directory transparency. No behavior change.
+
+= 0.61.62 =
+* Fix: pre-update rollback snapshots (captured before each core, plugin, or theme update) are now reliably cleaned up instead of accumulating indefinitely on a quiet site. Cleanup no longer depends on WordPress cron.
+
+= 0.61.61 =
+* Hardening: a second WordPress.org-compliance pass. Login and forced-password-change screens now escape their output through an explicit allowed-tag list, the media-library helper script is enqueued instead of printed inline, the settings screen is fully translatable, and the WordPress.org build measures folder sizes without shelling out to the operating system.
+
+= 0.61.58 =
+* Fix: bulk update runs no longer repeat a full WordPress.org update check for every item in the batch. Updates no longer fail with "Could not copy file" on hosts with an overloaded shared temporary directory. The fleet backup-health check no longer errors for a site with no completed backup. Hide-login no longer blocks front-end AJAX requests. Two-factor sign-in messaging is clearer, with a wider accepted time window and single-use setup codes.
+
 = 0.61.57 =
 * Hardening: code-quality and WordPress.org-compliance pass with no behavior change for connected sites. Real User Monitoring now loads through the standard wp_enqueue_script mechanism instead of a hand-built script tag; the two-factor and forced-password-change login screens now escape their output through an explicit allowed-tag list at the point of output; the long-running backup, restore, database-dump, and media routines now use a bounded time limit instead of an unbounded one; and the CloudPanel cache-purge integration sanitizes its server-variable reads inline.
 

--- a/apps/agent/tests/Cache/AdminBarPurgeTest.php
+++ b/apps/agent/tests/Cache/AdminBarPurgeTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * AdminBarPurge: "Manage in WPMgr" deep-link URL generation.
+ *
+ * GH #243 (Gap C) — dashboardCacheUrl() built `{cp_base}/sites/{siteId}/performance`,
+ * a dashboard route that has never existed (the per-site tab is `/cache`; the
+ * `/performance` slug is a fleet-level page, not a per-site one). This test pins
+ * the exact generated URL for a known cp_url + siteId so a regression to the
+ * wrong slug (or a change to the CP web app's route shape) is caught here
+ * instead of shipping a dead admin-bar link again.
+ *
+ * @package WPMgr\Agent\Tests\Cache
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Cache;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Cache\AdminBarPurge;
+use WPMgr\Agent\Cache\CacheManager;
+use WPMgr\Agent\Settings;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Cache\AdminBarPurge
+ */
+final class AdminBarPurgeTest extends TestCase
+{
+    /** @var array<string,mixed> */
+    private array $options = [];
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->options = [];
+        Functions\when('update_option')->alias(function ($name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('get_option')->alias(function ($name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('get_site_option')->alias(function ($name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('is_multisite')->justReturn(false);
+    }
+
+    protected function tear_down(): void
+    {
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * Invoke the private dashboardCacheUrl() via reflection — it is the exact
+     * unit that shipped the wrong route in v0.18.0, and it is not observable
+     * through addBarNodes() without stubbing WP_Admin_Bar.
+     */
+    private function dashboardCacheUrl(AdminBarPurge $abp): string
+    {
+        $ref = new \ReflectionMethod(AdminBarPurge::class, 'dashboardCacheUrl');
+
+        return (string) $ref->invoke($abp);
+    }
+
+    public function test_dashboard_cache_url_points_at_the_per_site_cache_tab(): void
+    {
+        $settings = new Settings();
+        $settings->setControlPlaneUrl('https://manage.wpmgr.app');
+        $settings->setEnrollment('a1b2c3d4-1111-2222-3333-444455556666', 'tenant-x');
+
+        $abp = new AdminBarPurge(new CacheManager(), $settings);
+
+        $this->assertSame(
+            'https://manage.wpmgr.app/sites/a1b2c3d4-1111-2222-3333-444455556666/cache',
+            $this->dashboardCacheUrl($abp)
+        );
+    }
+
+    public function test_dashboard_cache_url_strips_a_trailing_slash_on_the_cp_base(): void
+    {
+        $settings = new Settings();
+        $settings->setControlPlaneUrl('https://manage.wpmgr.app/');
+        $settings->setEnrollment('a1b2c3d4-1111-2222-3333-444455556666', 'tenant-x');
+
+        $abp = new AdminBarPurge(new CacheManager(), $settings);
+
+        $this->assertSame(
+            'https://manage.wpmgr.app/sites/a1b2c3d4-1111-2222-3333-444455556666/cache',
+            $this->dashboardCacheUrl($abp)
+        );
+    }
+
+    public function test_dashboard_cache_url_rawurlencodes_the_site_id(): void
+    {
+        $settings = new Settings();
+        $settings->setControlPlaneUrl('https://manage.wpmgr.app');
+        // Not a real site_id shape, but proves the segment is encoded rather
+        // than interpolated raw.
+        $settings->setEnrollment('site/with spaces', 'tenant-x');
+
+        $abp = new AdminBarPurge(new CacheManager(), $settings);
+
+        $this->assertSame(
+            'https://manage.wpmgr.app/sites/site%2Fwith%20spaces/cache',
+            $this->dashboardCacheUrl($abp)
+        );
+    }
+
+    public function test_dashboard_cache_url_is_empty_when_not_enrolled(): void
+    {
+        $settings = new Settings();
+        $settings->setControlPlaneUrl('https://manage.wpmgr.app');
+        // No setEnrollment() call — site_id stays unset.
+
+        $abp = new AdminBarPurge(new CacheManager(), $settings);
+
+        $this->assertSame('', $this->dashboardCacheUrl($abp));
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.70
+ * Version:           0.61.71
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.70');
+define('WPMGR_AGENT_VERSION', '0.61.71');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/api/db/query/sites.sql
+++ b/apps/api/db/query/sites.sql
@@ -6,8 +6,23 @@ VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING *;
 
 -- name: GetSite :one
-SELECT * FROM sites
-WHERE id = $1 AND tenant_id = $2;
+-- GH #243: page_cache_enabled / object_cache_enabled surface the REAL
+-- drop-in config state (site_perf_config.cache_enabled / site_object_cache_
+-- config.enabled) via a PK-keyed LEFT JOIN (both tables are one-row-per-site,
+-- site_id PRIMARY KEY) instead of the old plugin-slug inference that could
+-- never match (both features ship as drop-ins, not plugins). Both joined
+-- tables carry their own tenant_isolation RLS, so this is RLS-safe; the
+-- explicit tenant_id match in the ON clause is defense-in-depth + keeps the
+-- planner on the PK index (project convention — see clients.sql).
+SELECT s.*,
+       COALESCE(pc.cache_enabled, false) AS page_cache_enabled,
+       COALESCE(oc.enabled, false) AS object_cache_enabled
+FROM sites s
+LEFT JOIN site_perf_config pc
+    ON pc.site_id = s.id AND pc.tenant_id = s.tenant_id
+LEFT JOIN site_object_cache_config oc
+    ON oc.site_id = s.id AND oc.tenant_id = s.tenant_id
+WHERE s.id = $1 AND s.tenant_id = $2;
 
 -- name: ListSites :many
 -- Defaults to hiding archived sites (ADR-041). When sqlc.narg('state') is set
@@ -18,16 +33,27 @@ WHERE id = $1 AND tenant_id = $2;
 -- replace the single-tag filter; both are served by the sites_tags_idx GIN
 -- index. The service maps exactly ONE of them per request (legacy ?tag=
 -- becomes any_tags=[tag]).
-SELECT * FROM sites
-WHERE tenant_id = $1
-  AND (sqlc.narg('any_tags')::text[] IS NULL OR tags && sqlc.narg('any_tags')::text[])
-  AND (sqlc.narg('all_tags')::text[] IS NULL OR tags @> sqlc.narg('all_tags')::text[])
+-- GH #243: page_cache_enabled / object_cache_enabled — see GetSite's comment
+-- above. Both LEFT JOINs are PK lookups (site_id), so this stays O(sites) per
+-- page (an index-only nested-loop per row) and does not regress the
+-- optimized /sites path.
+SELECT s.*,
+       COALESCE(pc.cache_enabled, false) AS page_cache_enabled,
+       COALESCE(oc.enabled, false) AS object_cache_enabled
+FROM sites s
+LEFT JOIN site_perf_config pc
+    ON pc.site_id = s.id AND pc.tenant_id = s.tenant_id
+LEFT JOIN site_object_cache_config oc
+    ON oc.site_id = s.id AND oc.tenant_id = s.tenant_id
+WHERE s.tenant_id = $1
+  AND (sqlc.narg('any_tags')::text[] IS NULL OR s.tags && sqlc.narg('any_tags')::text[])
+  AND (sqlc.narg('all_tags')::text[] IS NULL OR s.tags @> sqlc.narg('all_tags')::text[])
   AND (
-        (sqlc.narg('state')::text IS NULL AND connection_state <> 'archived')
-        OR sqlc.narg('state')::text = connection_state
+        (sqlc.narg('state')::text IS NULL AND s.connection_state <> 'archived')
+        OR sqlc.narg('state')::text = s.connection_state
       )
-  AND (sqlc.narg('client_id')::uuid IS NULL OR client_id = sqlc.narg('client_id')::uuid)
-ORDER BY created_at DESC
+  AND (sqlc.narg('client_id')::uuid IS NULL OR s.client_id = sqlc.narg('client_id')::uuid)
+ORDER BY s.created_at DESC
 LIMIT $2 OFFSET $3;
 
 -- name: ListClientNamesForSites :many

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -97653,6 +97653,14 @@ func (s *Site) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		e.FieldStart("page_cache_enabled")
+		e.Bool(s.PageCacheEnabled)
+	}
+	{
+		e.FieldStart("object_cache_enabled")
+		e.Bool(s.ObjectCacheEnabled)
+	}
+	{
 		e.FieldStart("created_at")
 		json.EncodeDateTime(e, s.CreatedAt)
 	}
@@ -97662,7 +97670,7 @@ func (s *Site) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfSite = [39]string{
+var jsonFieldsNameOfSite = [41]string{
 	0:  "id",
 	1:  "tenant_id",
 	2:  "url",
@@ -97700,8 +97708,10 @@ var jsonFieldsNameOfSite = [39]string{
 	34: "uptime_pct",
 	35: "avg_latency_ms",
 	36: "tls_expires_at",
-	37: "created_at",
-	38: "updated_at",
+	37: "page_cache_enabled",
+	38: "object_cache_enabled",
+	39: "created_at",
+	40: "updated_at",
 }
 
 // Decode decodes Site from json.
@@ -97709,7 +97719,7 @@ func (s *Site) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode Site to nil")
 	}
-	var requiredBitSet [5]uint8
+	var requiredBitSet [6]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
@@ -98107,8 +98117,32 @@ func (s *Site) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"tls_expires_at\"")
 			}
-		case "created_at":
+		case "page_cache_enabled":
 			requiredBitSet[4] |= 1 << 5
+			if err := func() error {
+				v, err := d.Bool()
+				s.PageCacheEnabled = bool(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"page_cache_enabled\"")
+			}
+		case "object_cache_enabled":
+			requiredBitSet[4] |= 1 << 6
+			if err := func() error {
+				v, err := d.Bool()
+				s.ObjectCacheEnabled = bool(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"object_cache_enabled\"")
+			}
+		case "created_at":
+			requiredBitSet[4] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeDateTime(d)
 				s.CreatedAt = v
@@ -98120,7 +98154,7 @@ func (s *Site) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"created_at\"")
 			}
 		case "updated_at":
-			requiredBitSet[4] |= 1 << 6
+			requiredBitSet[5] |= 1 << 0
 			if err := func() error {
 				v, err := json.DecodeDateTime(d)
 				s.UpdatedAt = v
@@ -98140,12 +98174,13 @@ func (s *Site) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [5]uint8{
+	for i, mask := range [6]uint8{
 		0b11111111,
 		0b01010000,
 		0b00000000,
 		0b00000000,
-		0b01100000,
+		0b11100000,
+		0b00000001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -39575,8 +39575,18 @@ type Site struct {
 	// RFC 3339 timestamp of the TLS certificate expiry captured on the most-recent uptime probe.
 	// Absent/null when the site is non-HTTPS or has never been probed.
 	TLSExpiresAt OptDateTime `json:"tls_expires_at"`
-	CreatedAt    time.Time   `json:"created_at"`
-	UpdatedAt    time.Time   `json:"updated_at"`
+	// GH #243 — the real Page Cache drop-in state (site_perf_config.cache_enabled),
+	// not an inference from an installed-plugin slug (the feature ships as a
+	// drop-in, not a plugin, so no such slug can ever exist). false both when
+	// caching is off AND when the site has no performance config yet.
+	PageCacheEnabled bool `json:"page_cache_enabled"`
+	// GH #243 — the real Object Cache drop-in state (site_object_cache_config.enabled),
+	// not an inference from an installed-plugin slug (the feature ships as a
+	// drop-in, not a plugin, so no such slug can ever exist). false both when
+	// object caching is off AND when the site has no object cache config yet.
+	ObjectCacheEnabled bool      `json:"object_cache_enabled"`
+	CreatedAt          time.Time `json:"created_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
 }
 
 // GetID returns the value of ID.
@@ -39762,6 +39772,16 @@ func (s *Site) GetAvgLatencyMs() OptInt32 {
 // GetTLSExpiresAt returns the value of TLSExpiresAt.
 func (s *Site) GetTLSExpiresAt() OptDateTime {
 	return s.TLSExpiresAt
+}
+
+// GetPageCacheEnabled returns the value of PageCacheEnabled.
+func (s *Site) GetPageCacheEnabled() bool {
+	return s.PageCacheEnabled
+}
+
+// GetObjectCacheEnabled returns the value of ObjectCacheEnabled.
+func (s *Site) GetObjectCacheEnabled() bool {
+	return s.ObjectCacheEnabled
 }
 
 // GetCreatedAt returns the value of CreatedAt.
@@ -39957,6 +39977,16 @@ func (s *Site) SetAvgLatencyMs(val OptInt32) {
 // SetTLSExpiresAt sets the value of TLSExpiresAt.
 func (s *Site) SetTLSExpiresAt(val OptDateTime) {
 	s.TLSExpiresAt = val
+}
+
+// SetPageCacheEnabled sets the value of PageCacheEnabled.
+func (s *Site) SetPageCacheEnabled(val bool) {
+	s.PageCacheEnabled = val
+}
+
+// SetObjectCacheEnabled sets the value of ObjectCacheEnabled.
+func (s *Site) SetObjectCacheEnabled(val bool) {
+	s.ObjectCacheEnabled = val
 }
 
 // SetCreatedAt sets the value of CreatedAt.

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -790,7 +790,15 @@ type Querier interface {
 	// The repo wraps each call in InTenantTx (operator) or InAgentTx (worker).
 	// updated_at is set here via now(); there is no trigger.
 	GetScreenshot(ctx context.Context, arg GetScreenshotParams) (SiteScreenshot, error)
-	GetSite(ctx context.Context, arg GetSiteParams) (Site, error)
+	// GH #243: page_cache_enabled / object_cache_enabled surface the REAL
+	// drop-in config state (site_perf_config.cache_enabled / site_object_cache_
+	// config.enabled) via a PK-keyed LEFT JOIN (both tables are one-row-per-site,
+	// site_id PRIMARY KEY) instead of the old plugin-slug inference that could
+	// never match (both features ship as drop-ins, not plugins). Both joined
+	// tables carry their own tenant_isolation RLS, so this is RLS-safe; the
+	// explicit tenant_id match in the ON clause is defense-in-depth + keeps the
+	// planner on the PK index (project convention — see clients.sql).
+	GetSite(ctx context.Context, arg GetSiteParams) (GetSiteRow, error)
 	// Cross-tenant read of one site's alert state (app.agent GUC) for the probe job.
 	GetSiteAlertState(ctx context.Context, siteID uuid.UUID) (SiteAlertState, error)
 	// Cross-tenant read-and-LOCK of one site's alert state (app.agent GUC), used by
@@ -1418,7 +1426,11 @@ type Querier interface {
 	// replace the single-tag filter; both are served by the sites_tags_idx GIN
 	// index. The service maps exactly ONE of them per request (legacy ?tag=
 	// becomes any_tags=[tag]).
-	ListSites(ctx context.Context, arg ListSitesParams) ([]Site, error)
+	// GH #243: page_cache_enabled / object_cache_enabled — see GetSite's comment
+	// above. Both LEFT JOINs are PK lookups (site_id), so this stays O(sites) per
+	// page (an index-only nested-loop per row) and does not regress the
+	// optimized /sites path.
+	ListSites(ctx context.Context, arg ListSitesParams) ([]ListSitesRow, error)
 	// connected sites whose last heartbeat is older than the degrade cutoff.
 	// url is included so the active-verify sweeper can dial the agent without a
 	// secondary tenant-scoped lookup.

--- a/apps/api/internal/db/sqlc/sites.sql.go
+++ b/apps/api/internal/db/sqlc/sites.sql.go
@@ -233,8 +233,15 @@ func (q *Queries) DeleteSite(ctx context.Context, arg DeleteSiteParams) (int64, 
 }
 
 const getSite = `-- name: GetSite :one
-SELECT id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at FROM sites
-WHERE id = $1 AND tenant_id = $2
+SELECT s.id, s.tenant_id, s.url, s.name, s.status, s.wp_version, s.php_version, s.agent_version, s.agent_public_key, s.enrolled_at, s.last_seen_at, s.health_status, s.server_info, s.multisite, s.active_theme, s.components, s.tags, s.age_recipient, s.wp_timezone, s.wp_gmt_offset, s.host_provider, s.host_provider_org, s.host_provider_ip, s.host_provider_checked_at, s.connection_state, s.connection_generation, s.disconnected_at, s.disconnected_reason, s.archived_at, s.missed_heartbeats, s.client_id, s.created_at, s.updated_at,
+       COALESCE(pc.cache_enabled, false) AS page_cache_enabled,
+       COALESCE(oc.enabled, false) AS object_cache_enabled
+FROM sites s
+LEFT JOIN site_perf_config pc
+    ON pc.site_id = s.id AND pc.tenant_id = s.tenant_id
+LEFT JOIN site_object_cache_config oc
+    ON oc.site_id = s.id AND oc.tenant_id = s.tenant_id
+WHERE s.id = $1 AND s.tenant_id = $2
 `
 
 type GetSiteParams struct {
@@ -242,9 +249,55 @@ type GetSiteParams struct {
 	TenantID uuid.UUID `json:"tenant_id"`
 }
 
-func (q *Queries) GetSite(ctx context.Context, arg GetSiteParams) (Site, error) {
+type GetSiteRow struct {
+	ID                    uuid.UUID          `json:"id"`
+	TenantID              uuid.UUID          `json:"tenant_id"`
+	Url                   string             `json:"url"`
+	Name                  string             `json:"name"`
+	Status                string             `json:"status"`
+	WpVersion             string             `json:"wp_version"`
+	PhpVersion            string             `json:"php_version"`
+	AgentVersion          string             `json:"agent_version"`
+	AgentPublicKey        string             `json:"agent_public_key"`
+	EnrolledAt            pgtype.Timestamptz `json:"enrolled_at"`
+	LastSeenAt            pgtype.Timestamptz `json:"last_seen_at"`
+	HealthStatus          string             `json:"health_status"`
+	ServerInfo            string             `json:"server_info"`
+	Multisite             bool               `json:"multisite"`
+	ActiveTheme           string             `json:"active_theme"`
+	Components            []byte             `json:"components"`
+	Tags                  []string           `json:"tags"`
+	AgeRecipient          string             `json:"age_recipient"`
+	WpTimezone            string             `json:"wp_timezone"`
+	WpGmtOffset           float32            `json:"wp_gmt_offset"`
+	HostProvider          string             `json:"host_provider"`
+	HostProviderOrg       string             `json:"host_provider_org"`
+	HostProviderIp        string             `json:"host_provider_ip"`
+	HostProviderCheckedAt pgtype.Timestamptz `json:"host_provider_checked_at"`
+	ConnectionState       string             `json:"connection_state"`
+	ConnectionGeneration  int32              `json:"connection_generation"`
+	DisconnectedAt        pgtype.Timestamptz `json:"disconnected_at"`
+	DisconnectedReason    *string            `json:"disconnected_reason"`
+	ArchivedAt            pgtype.Timestamptz `json:"archived_at"`
+	MissedHeartbeats      int32              `json:"missed_heartbeats"`
+	ClientID              pgtype.UUID        `json:"client_id"`
+	CreatedAt             time.Time          `json:"created_at"`
+	UpdatedAt             time.Time          `json:"updated_at"`
+	PageCacheEnabled      bool               `json:"page_cache_enabled"`
+	ObjectCacheEnabled    bool               `json:"object_cache_enabled"`
+}
+
+// GH #243: page_cache_enabled / object_cache_enabled surface the REAL
+// drop-in config state (site_perf_config.cache_enabled / site_object_cache_
+// config.enabled) via a PK-keyed LEFT JOIN (both tables are one-row-per-site,
+// site_id PRIMARY KEY) instead of the old plugin-slug inference that could
+// never match (both features ship as drop-ins, not plugins). Both joined
+// tables carry their own tenant_isolation RLS, so this is RLS-safe; the
+// explicit tenant_id match in the ON clause is defense-in-depth + keeps the
+// planner on the PK index (project convention — see clients.sql).
+func (q *Queries) GetSite(ctx context.Context, arg GetSiteParams) (GetSiteRow, error) {
 	row := q.db.QueryRow(ctx, getSite, arg.ID, arg.TenantID)
-	var i Site
+	var i GetSiteRow
 	err := row.Scan(
 		&i.ID,
 		&i.TenantID,
@@ -279,6 +332,8 @@ func (q *Queries) GetSite(ctx context.Context, arg GetSiteParams) (Site, error) 
 		&i.ClientID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.PageCacheEnabled,
+		&i.ObjectCacheEnabled,
 	)
 	return i, err
 }
@@ -630,16 +685,23 @@ func (q *Queries) ListLatestBackupsForSites(ctx context.Context, arg ListLatestB
 }
 
 const listSites = `-- name: ListSites :many
-SELECT id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at FROM sites
-WHERE tenant_id = $1
-  AND ($4::text[] IS NULL OR tags && $4::text[])
-  AND ($5::text[] IS NULL OR tags @> $5::text[])
+SELECT s.id, s.tenant_id, s.url, s.name, s.status, s.wp_version, s.php_version, s.agent_version, s.agent_public_key, s.enrolled_at, s.last_seen_at, s.health_status, s.server_info, s.multisite, s.active_theme, s.components, s.tags, s.age_recipient, s.wp_timezone, s.wp_gmt_offset, s.host_provider, s.host_provider_org, s.host_provider_ip, s.host_provider_checked_at, s.connection_state, s.connection_generation, s.disconnected_at, s.disconnected_reason, s.archived_at, s.missed_heartbeats, s.client_id, s.created_at, s.updated_at,
+       COALESCE(pc.cache_enabled, false) AS page_cache_enabled,
+       COALESCE(oc.enabled, false) AS object_cache_enabled
+FROM sites s
+LEFT JOIN site_perf_config pc
+    ON pc.site_id = s.id AND pc.tenant_id = s.tenant_id
+LEFT JOIN site_object_cache_config oc
+    ON oc.site_id = s.id AND oc.tenant_id = s.tenant_id
+WHERE s.tenant_id = $1
+  AND ($4::text[] IS NULL OR s.tags && $4::text[])
+  AND ($5::text[] IS NULL OR s.tags @> $5::text[])
   AND (
-        ($6::text IS NULL AND connection_state <> 'archived')
-        OR $6::text = connection_state
+        ($6::text IS NULL AND s.connection_state <> 'archived')
+        OR $6::text = s.connection_state
       )
-  AND ($7::uuid IS NULL OR client_id = $7::uuid)
-ORDER BY created_at DESC
+  AND ($7::uuid IS NULL OR s.client_id = $7::uuid)
+ORDER BY s.created_at DESC
 LIMIT $2 OFFSET $3
 `
 
@@ -653,6 +715,44 @@ type ListSitesParams struct {
 	ClientID pgtype.UUID `json:"client_id"`
 }
 
+type ListSitesRow struct {
+	ID                    uuid.UUID          `json:"id"`
+	TenantID              uuid.UUID          `json:"tenant_id"`
+	Url                   string             `json:"url"`
+	Name                  string             `json:"name"`
+	Status                string             `json:"status"`
+	WpVersion             string             `json:"wp_version"`
+	PhpVersion            string             `json:"php_version"`
+	AgentVersion          string             `json:"agent_version"`
+	AgentPublicKey        string             `json:"agent_public_key"`
+	EnrolledAt            pgtype.Timestamptz `json:"enrolled_at"`
+	LastSeenAt            pgtype.Timestamptz `json:"last_seen_at"`
+	HealthStatus          string             `json:"health_status"`
+	ServerInfo            string             `json:"server_info"`
+	Multisite             bool               `json:"multisite"`
+	ActiveTheme           string             `json:"active_theme"`
+	Components            []byte             `json:"components"`
+	Tags                  []string           `json:"tags"`
+	AgeRecipient          string             `json:"age_recipient"`
+	WpTimezone            string             `json:"wp_timezone"`
+	WpGmtOffset           float32            `json:"wp_gmt_offset"`
+	HostProvider          string             `json:"host_provider"`
+	HostProviderOrg       string             `json:"host_provider_org"`
+	HostProviderIp        string             `json:"host_provider_ip"`
+	HostProviderCheckedAt pgtype.Timestamptz `json:"host_provider_checked_at"`
+	ConnectionState       string             `json:"connection_state"`
+	ConnectionGeneration  int32              `json:"connection_generation"`
+	DisconnectedAt        pgtype.Timestamptz `json:"disconnected_at"`
+	DisconnectedReason    *string            `json:"disconnected_reason"`
+	ArchivedAt            pgtype.Timestamptz `json:"archived_at"`
+	MissedHeartbeats      int32              `json:"missed_heartbeats"`
+	ClientID              pgtype.UUID        `json:"client_id"`
+	CreatedAt             time.Time          `json:"created_at"`
+	UpdatedAt             time.Time          `json:"updated_at"`
+	PageCacheEnabled      bool               `json:"page_cache_enabled"`
+	ObjectCacheEnabled    bool               `json:"object_cache_enabled"`
+}
+
 // Defaults to hiding archived sites (ADR-041). When sqlc.narg('state') is set
 // the list is filtered to exactly that connection_state (e.g. 'archived' for
 // the archived chip); when it is NULL every non-archived site is returned.
@@ -661,7 +761,11 @@ type ListSitesParams struct {
 // replace the single-tag filter; both are served by the sites_tags_idx GIN
 // index. The service maps exactly ONE of them per request (legacy ?tag=
 // becomes any_tags=[tag]).
-func (q *Queries) ListSites(ctx context.Context, arg ListSitesParams) ([]Site, error) {
+// GH #243: page_cache_enabled / object_cache_enabled — see GetSite's comment
+// above. Both LEFT JOINs are PK lookups (site_id), so this stays O(sites) per
+// page (an index-only nested-loop per row) and does not regress the
+// optimized /sites path.
+func (q *Queries) ListSites(ctx context.Context, arg ListSitesParams) ([]ListSitesRow, error) {
 	rows, err := q.db.Query(ctx, listSites,
 		arg.TenantID,
 		arg.Limit,
@@ -675,9 +779,9 @@ func (q *Queries) ListSites(ctx context.Context, arg ListSitesParams) ([]Site, e
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Site
+	var items []ListSitesRow
 	for rows.Next() {
-		var i Site
+		var i ListSitesRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.TenantID,
@@ -712,6 +816,8 @@ func (q *Queries) ListSites(ctx context.Context, arg ListSitesParams) ([]Site, e
 			&i.ClientID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.PageCacheEnabled,
+			&i.ObjectCacheEnabled,
 		); err != nil {
 			return nil, err
 		}

--- a/apps/api/internal/site/cache_capability_fields_test.go
+++ b/apps/api/internal/site/cache_capability_fields_test.go
@@ -1,0 +1,97 @@
+// cache_capability_fields_test.go — GH #243: the site-card "Page Cache" /
+// "Object Cache" capability dots used to infer state from installed-plugin
+// slugs that can never exist (both features ship as drop-ins, not plugins),
+// leaving the dots permanently gray. This asserts toAPI() surfaces the real
+// Site.PageCacheEnabled / Site.ObjectCacheEnabled booleans (populated by
+// repo.Get/List's PK-keyed LEFT JOIN onto site_perf_config/
+// site_object_cache_config) verbatim, and that the OpenAPI-generated struct
+// carries the exact JSON field names the web client wires to (mirrors
+// TestSiteGenStructHasUptimeJSONTags's pattern).
+package site
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/api/gen"
+)
+
+func TestToAPICacheCapabilityFields(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name               string
+		pageCacheEnabled   bool
+		objectCacheEnabled bool
+	}{
+		// "No config row" is modeled the same as "config row with the feature
+		// off" at the Site-model level: repo.Get/List's COALESCE(...,false)
+		// collapses both cases to false before the model is ever built, so
+		// there is nothing further for toAPI to distinguish — both are
+		// asserted at the repo/integration layer (see
+		// tests/site_cache_capability_integration_test.go).
+		{"both off", false, false},
+		{"page cache on, object cache off", true, false},
+		{"page cache off, object cache on", false, true},
+		{"both on", true, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := Site{
+				ID:                 uuid.New(),
+				TenantID:           uuid.New(),
+				URL:                "https://example.com",
+				Name:               "Example",
+				Status:             "active",
+				HealthStatus:       "healthy",
+				ConnectionState:    StateConnected,
+				Tags:               []string{},
+				CreatedAt:          now,
+				UpdatedAt:          now,
+				PageCacheEnabled:   tc.pageCacheEnabled,
+				ObjectCacheEnabled: tc.objectCacheEnabled,
+			}
+
+			out := toAPI(s)
+
+			if out.PageCacheEnabled != tc.pageCacheEnabled {
+				t.Errorf("PageCacheEnabled = %v, want %v", out.PageCacheEnabled, tc.pageCacheEnabled)
+			}
+			if out.ObjectCacheEnabled != tc.objectCacheEnabled {
+				t.Errorf("ObjectCacheEnabled = %v, want %v", out.ObjectCacheEnabled, tc.objectCacheEnabled)
+			}
+		})
+	}
+}
+
+// TestSiteGenStructHasCacheCapabilityJSONTags verifies that the generated
+// gen.Site struct carries the exact JSON field names the web client wires to,
+// asserting the OpenAPI contract and both regenerated codegens are in sync.
+func TestSiteGenStructHasCacheCapabilityJSONTags(t *testing.T) {
+	wantTags := map[string]string{
+		"PageCacheEnabled":   "page_cache_enabled",
+		"ObjectCacheEnabled": "object_cache_enabled",
+	}
+	st := reflect.TypeOf(gen.Site{})
+	for fieldName, wantJSON := range wantTags {
+		f, ok := st.FieldByName(fieldName)
+		if !ok {
+			t.Errorf("gen.Site has no field %q — regen may be stale or field was renamed", fieldName)
+			continue
+		}
+		gotJSON := f.Tag.Get("json")
+		if gotJSON != wantJSON {
+			t.Errorf("gen.Site.%s json tag = %q, want %q", fieldName, gotJSON, wantJSON)
+		}
+		// Required (non-optional) field: the type must be the bare bool, not
+		// an OptBool — a bug here would silently make the dot omit from the
+		// JSON response instead of rendering as an explicit false.
+		if f.Type.Kind() != reflect.Bool {
+			t.Errorf("gen.Site.%s type = %s, want bool (required field, not optional)", fieldName, f.Type)
+		}
+	}
+}

--- a/apps/api/internal/site/handler.go
+++ b/apps/api/internal/site/handler.go
@@ -596,9 +596,15 @@ func toAPI(s Site) gen.Site {
 		HealthStatus: gen.SiteHealthStatus(s.HealthStatus),
 		Multisite:    s.Multisite,
 		Tags:         s.Tags,
-		Enrolled:     gen.NewOptBool(s.EnrolledAt != nil),
-		CreatedAt:    s.CreatedAt,
-		UpdatedAt:    s.UpdatedAt,
+		// GH #243 — the real drop-in config state (site_perf_config.cache_enabled
+		// / site_object_cache_config.enabled), replacing the old plugin-slug
+		// inference that could never match. Always present (COALESCE'd to false
+		// in the query when no config row exists yet).
+		PageCacheEnabled:   s.PageCacheEnabled,
+		ObjectCacheEnabled: s.ObjectCacheEnabled,
+		Enrolled:           gen.NewOptBool(s.EnrolledAt != nil),
+		CreatedAt:          s.CreatedAt,
+		UpdatedAt:          s.UpdatedAt,
 	}
 	if s.Tags == nil {
 		out.Tags = []string{}

--- a/apps/api/internal/site/model.go
+++ b/apps/api/internal/site/model.go
@@ -96,6 +96,15 @@ type Site struct {
 	UptimeUp       *bool      // current up/down from the most-recent probe; nil = never probed
 	AvgLatencyMs   *float64   // average total_ms over successful probes in the 30d window
 	TLSExpiresAt   *time.Time // cert expiry from the most-recent probe; nil = non-HTTPS or no probes
+	// GH #243 — the real drop-in config state, populated by repo.Get/List via a
+	// PK-keyed LEFT JOIN onto site_perf_config.cache_enabled and
+	// site_object_cache_config.enabled (both one-row-per-site, site_id PK).
+	// false both when a config row exists with the feature off AND when no
+	// config row exists yet (the site has never touched that feature). This
+	// replaces the old site-card capability dots, which inferred state from
+	// plugin slugs that can never exist — both features ship as drop-ins.
+	PageCacheEnabled   bool
+	ObjectCacheEnabled bool
 }
 
 // CreateInput is the validated input for creating a site under a tenant.

--- a/apps/api/internal/site/repo.go
+++ b/apps/api/internal/site/repo.go
@@ -300,7 +300,7 @@ func (r *pgRepo) Get(ctx context.Context, tenantID, id uuid.UUID) (Site, error) 
 			}
 			return domain.Internal("site_get_failed", "failed to load site").WithCause(err)
 		}
-		out = toModel(row)
+		out = toModelFromGetSiteRow(row)
 		return nil
 	})
 	return out, err
@@ -355,7 +355,7 @@ func (r *pgRepo) List(ctx context.Context, in ListInput) ([]Site, error) {
 		}
 		out = make([]Site, 0, len(rows))
 		for _, row := range rows {
-			out = append(out, toModel(row))
+			out = append(out, toModelFromListSitesRow(row))
 		}
 		// Batched per-site latest-backup lookup for the sites-table "Backup"
 		// column — ONE query for every listed site (index-only seek per site),
@@ -865,6 +865,96 @@ func toModel(s sqlc.Site) Site {
 		id := uuid.UUID(s.ClientID.Bytes)
 		m.ClientID = &id
 	}
+	return m
+}
+
+// toModelFromGetSiteRow converts the GH #243 GetSite row (the sites.* columns
+// plus the joined page_cache_enabled/object_cache_enabled) into a Site. It
+// re-uses toModel for the base sites.* fields by re-assembling an sqlc.Site
+// from the row (GetSiteRow's join adds two trailing columns sqlc.Site does
+// not have, so the two types cannot share Scan destinations directly).
+func toModelFromGetSiteRow(row sqlc.GetSiteRow) Site {
+	m := toModel(sqlc.Site{
+		ID:                    row.ID,
+		TenantID:              row.TenantID,
+		Url:                   row.Url,
+		Name:                  row.Name,
+		Status:                row.Status,
+		WpVersion:             row.WpVersion,
+		PhpVersion:            row.PhpVersion,
+		AgentVersion:          row.AgentVersion,
+		AgentPublicKey:        row.AgentPublicKey,
+		EnrolledAt:            row.EnrolledAt,
+		LastSeenAt:            row.LastSeenAt,
+		HealthStatus:          row.HealthStatus,
+		ServerInfo:            row.ServerInfo,
+		Multisite:             row.Multisite,
+		ActiveTheme:           row.ActiveTheme,
+		Components:            row.Components,
+		Tags:                  row.Tags,
+		AgeRecipient:          row.AgeRecipient,
+		WpTimezone:            row.WpTimezone,
+		WpGmtOffset:           row.WpGmtOffset,
+		HostProvider:          row.HostProvider,
+		HostProviderOrg:       row.HostProviderOrg,
+		HostProviderIp:        row.HostProviderIp,
+		HostProviderCheckedAt: row.HostProviderCheckedAt,
+		ConnectionState:       row.ConnectionState,
+		ConnectionGeneration:  row.ConnectionGeneration,
+		DisconnectedAt:        row.DisconnectedAt,
+		DisconnectedReason:    row.DisconnectedReason,
+		ArchivedAt:            row.ArchivedAt,
+		MissedHeartbeats:      row.MissedHeartbeats,
+		ClientID:              row.ClientID,
+		CreatedAt:             row.CreatedAt,
+		UpdatedAt:             row.UpdatedAt,
+	})
+	m.PageCacheEnabled = row.PageCacheEnabled
+	m.ObjectCacheEnabled = row.ObjectCacheEnabled
+	return m
+}
+
+// toModelFromListSitesRow is toModelFromGetSiteRow's ListSites counterpart
+// (identical join, separate sqlc row type since sqlc generates one Row struct
+// per query).
+func toModelFromListSitesRow(row sqlc.ListSitesRow) Site {
+	m := toModel(sqlc.Site{
+		ID:                    row.ID,
+		TenantID:              row.TenantID,
+		Url:                   row.Url,
+		Name:                  row.Name,
+		Status:                row.Status,
+		WpVersion:             row.WpVersion,
+		PhpVersion:            row.PhpVersion,
+		AgentVersion:          row.AgentVersion,
+		AgentPublicKey:        row.AgentPublicKey,
+		EnrolledAt:            row.EnrolledAt,
+		LastSeenAt:            row.LastSeenAt,
+		HealthStatus:          row.HealthStatus,
+		ServerInfo:            row.ServerInfo,
+		Multisite:             row.Multisite,
+		ActiveTheme:           row.ActiveTheme,
+		Components:            row.Components,
+		Tags:                  row.Tags,
+		AgeRecipient:          row.AgeRecipient,
+		WpTimezone:            row.WpTimezone,
+		WpGmtOffset:           row.WpGmtOffset,
+		HostProvider:          row.HostProvider,
+		HostProviderOrg:       row.HostProviderOrg,
+		HostProviderIp:        row.HostProviderIp,
+		HostProviderCheckedAt: row.HostProviderCheckedAt,
+		ConnectionState:       row.ConnectionState,
+		ConnectionGeneration:  row.ConnectionGeneration,
+		DisconnectedAt:        row.DisconnectedAt,
+		DisconnectedReason:    row.DisconnectedReason,
+		ArchivedAt:            row.ArchivedAt,
+		MissedHeartbeats:      row.MissedHeartbeats,
+		ClientID:              row.ClientID,
+		CreatedAt:             row.CreatedAt,
+		UpdatedAt:             row.UpdatedAt,
+	})
+	m.PageCacheEnabled = row.PageCacheEnabled
+	m.ObjectCacheEnabled = row.ObjectCacheEnabled
 	return m
 }
 

--- a/apps/api/tests/site_cache_capability_integration_test.go
+++ b/apps/api/tests/site_cache_capability_integration_test.go
@@ -1,0 +1,238 @@
+// site_cache_capability_integration_test.go — GH #243: the site-card
+// "Page Cache" / "Object Cache" capability dots used to infer state from
+// installed-plugin slugs that can never exist (both features ship as
+// drop-ins, not plugins), leaving the dots permanently gray. This proves,
+// against a real Postgres with the production non-superuser role, that
+// site.Repo's Get/List now surface the REAL config state via a PK-keyed
+// LEFT JOIN onto site_perf_config.cache_enabled / site_object_cache_config.
+// enabled — covering the three states each field can be in (no config row,
+// an enabled row, a disabled row) — and that the join cannot be tricked into
+// leaking a mismatched tenant's config row (RLS + the ON-clause tenant_id
+// match are both defense-in-depth here). Requires Docker; skips when
+// unavailable (via startPostgres).
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/site"
+)
+
+// seedPerfConfigRow inserts a minimal site_perf_config row (site_id PK; every
+// other column has a schema DEFAULT) directly under the tenant's own
+// InTenantTx, so the RLS WITH CHECK is exercised exactly as a real write
+// would be.
+func seedPerfConfigRow(t *testing.T, pool interface {
+	InTenantTx(ctx context.Context, tenantID uuid.UUID, fn func(pgx.Tx) error) error
+}, tenantID, siteID uuid.UUID, cacheEnabled bool) {
+	t.Helper()
+	ctx := context.Background()
+	err := pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		_, e := tx.Exec(ctx,
+			`INSERT INTO site_perf_config (site_id, tenant_id, cache_enabled) VALUES ($1, $2, $3)`,
+			siteID, tenantID, cacheEnabled)
+		return e
+	})
+	if err != nil {
+		t.Fatalf("seed site_perf_config row: %v", err)
+	}
+}
+
+// seedObjectCacheConfigRow is seedPerfConfigRow's site_object_cache_config
+// counterpart.
+func seedObjectCacheConfigRow(t *testing.T, pool interface {
+	InTenantTx(ctx context.Context, tenantID uuid.UUID, fn func(pgx.Tx) error) error
+}, tenantID, siteID uuid.UUID, enabled bool) {
+	t.Helper()
+	ctx := context.Background()
+	err := pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		_, e := tx.Exec(ctx,
+			`INSERT INTO site_object_cache_config (site_id, tenant_id, enabled) VALUES ($1, $2, $3)`,
+			siteID, tenantID, enabled)
+		return e
+	})
+	if err != nil {
+		t.Fatalf("seed site_object_cache_config row: %v", err)
+	}
+}
+
+// TestSiteCacheCapabilityFields_ListAndGet covers the three states each of
+// page_cache_enabled / object_cache_enabled can be in: no config row at all
+// (COALESCE default false), a config row with the feature explicitly
+// disabled (false), and a config row with the feature enabled (true). Both
+// site.Repo.List and site.Repo.Get are asserted since GH #243 required both
+// the sites list AND the site detail to surface the real state.
+func TestSiteCacheCapabilityFields_ListAndGet(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "cachecap-"+uuid.NewString()[:8])
+
+	siteSvc := site.NewService(site.NewRepo(pool), domain.NewValidator(), domain.SystemClock{})
+
+	mk := func(name string) site.Site {
+		s, err := siteSvc.Create(ctx, site.CreateInput{TenantID: tenant, URL: "https://" + name + ".example.com", Name: name})
+		if err != nil {
+			t.Fatalf("create site %s: %v", name, err)
+		}
+		return s
+	}
+
+	sNoConfig := mk("no-config")
+	sEnabled := mk("enabled")
+	sDisabled := mk("disabled")
+
+	// sNoConfig: no site_perf_config / site_object_cache_config row at all.
+	// sEnabled: both features explicitly ON.
+	seedPerfConfigRow(t, pool, tenant, sEnabled.ID, true)
+	seedObjectCacheConfigRow(t, pool, tenant, sEnabled.ID, true)
+	// sDisabled: config rows exist but both features explicitly OFF — this is
+	// the case a bare "row exists" check would get wrong; COALESCE + the raw
+	// boolean column must both resolve to false.
+	seedPerfConfigRow(t, pool, tenant, sDisabled.ID, false)
+	seedObjectCacheConfigRow(t, pool, tenant, sDisabled.ID, false)
+
+	want := map[uuid.UUID]struct {
+		page, object bool
+	}{
+		sNoConfig.ID: {false, false},
+		sEnabled.ID:  {true, true},
+		sDisabled.ID: {false, false},
+	}
+
+	t.Run("List", func(t *testing.T) {
+		list, err := siteSvc.List(ctx, site.ListInput{TenantID: tenant, Limit: 50})
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		byID := make(map[uuid.UUID]site.Site, len(list))
+		for _, s := range list {
+			byID[s.ID] = s
+		}
+		for id, w := range want {
+			s, ok := byID[id]
+			if !ok {
+				t.Fatalf("site %s missing from List result", id)
+			}
+			if s.PageCacheEnabled != w.page {
+				t.Errorf("site %s: List PageCacheEnabled = %v, want %v", s.Name, s.PageCacheEnabled, w.page)
+			}
+			if s.ObjectCacheEnabled != w.object {
+				t.Errorf("site %s: List ObjectCacheEnabled = %v, want %v", s.Name, s.ObjectCacheEnabled, w.object)
+			}
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		for id, w := range want {
+			s, err := siteSvc.Get(ctx, tenant, id)
+			if err != nil {
+				t.Fatalf("Get(%s): %v", id, err)
+			}
+			if s.PageCacheEnabled != w.page {
+				t.Errorf("site %s: Get PageCacheEnabled = %v, want %v", s.Name, s.PageCacheEnabled, w.page)
+			}
+			if s.ObjectCacheEnabled != w.object {
+				t.Errorf("site %s: Get ObjectCacheEnabled = %v, want %v", s.Name, s.ObjectCacheEnabled, w.object)
+			}
+		}
+	})
+}
+
+// TestSiteCacheCapabilityFields_TenantIsolation proves a second tenant's
+// config rows never leak into the join, including the adversarial case of a
+// site_perf_config/site_object_cache_config row whose tenant_id does not
+// match the owning site's tenant_id (simulating a data-integrity bug
+// elsewhere — site_perf_config.site_id is only a plain FK to sites(id), not a
+// composite FK enforcing tenant_id equality, so the DB schema alone does not
+// rule this out). Both the RLS tenant_isolation policy on the joined tables
+// AND the query's explicit `pc.tenant_id = s.tenant_id` / `oc.tenant_id =
+// s.tenant_id` ON-clause match are defense-in-depth against exactly this.
+func TestSiteCacheCapabilityFields_TenantIsolation(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	tenantA := seedTenant(t, pool, "cachecap-iso-a-"+uuid.NewString()[:8])
+	tenantB := seedTenant(t, pool, "cachecap-iso-b-"+uuid.NewString()[:8])
+
+	siteSvcA := site.NewService(site.NewRepo(pool), domain.NewValidator(), domain.SystemClock{})
+	sA, err := siteSvcA.Create(ctx, site.CreateInput{TenantID: tenantA, URL: "https://iso-a.example.com", Name: "iso-a"})
+	if err != nil {
+		t.Fatalf("create site for tenant A: %v", err)
+	}
+
+	// Tenant B has its own, unrelated site with caching genuinely enabled —
+	// proves normal cross-tenant separation (tenant A never sees tenant B's
+	// site at all; already covered by sites.tenant_id in every query, but
+	// asserted here as a baseline).
+	siteSvcB := site.NewService(site.NewRepo(pool), domain.NewValidator(), domain.SystemClock{})
+	sB, err := siteSvcB.Create(ctx, site.CreateInput{TenantID: tenantB, URL: "https://iso-b.example.com", Name: "iso-b"})
+	if err != nil {
+		t.Fatalf("create site for tenant B: %v", err)
+	}
+	seedPerfConfigRow(t, pool, tenantB, sB.ID, true)
+	seedObjectCacheConfigRow(t, pool, tenantB, sB.ID, true)
+
+	// Adversarial case: as the ADMIN (superuser, bypasses RLS), attach a
+	// site_perf_config / site_object_cache_config row to tenant A's site sA
+	// but stamp it with tenant B's tenant_id — a corrupted/mismatched row that
+	// should never be produced by the application, but the schema does not
+	// forbid it. The join must NOT surface tenant B's "enabled" state onto
+	// tenant A's site.
+	if _, err := admin.Exec(ctx,
+		`INSERT INTO site_perf_config (site_id, tenant_id, cache_enabled) VALUES ($1, $2, true)`,
+		sA.ID, tenantB); err != nil {
+		t.Fatalf("admin seed mismatched site_perf_config row: %v", err)
+	}
+	if _, err := admin.Exec(ctx,
+		`INSERT INTO site_object_cache_config (site_id, tenant_id, enabled) VALUES ($1, $2, true)`,
+		sA.ID, tenantB); err != nil {
+		t.Fatalf("admin seed mismatched site_object_cache_config row: %v", err)
+	}
+
+	// Querying sA under tenant A's own scope must NOT pick up tenant B's
+	// mismatched config row — page/object cache must read false, not leak
+	// tenant B's "true".
+	got, err := siteSvcA.Get(ctx, tenantA, sA.ID)
+	if err != nil {
+		t.Fatalf("Get sA under tenant A: %v", err)
+	}
+	if got.PageCacheEnabled {
+		t.Error("tenant A's site must NOT show page_cache_enabled=true from tenant B's mismatched config row (RLS/ON-clause leak)")
+	}
+	if got.ObjectCacheEnabled {
+		t.Error("tenant A's site must NOT show object_cache_enabled=true from tenant B's mismatched config row (RLS/ON-clause leak)")
+	}
+
+	listA, err := siteSvcA.List(ctx, site.ListInput{TenantID: tenantA, Limit: 50})
+	if err != nil {
+		t.Fatalf("List for tenant A: %v", err)
+	}
+	if len(listA) != 1 {
+		t.Fatalf("expected exactly 1 site for tenant A, got %d", len(listA))
+	}
+	if listA[0].PageCacheEnabled || listA[0].ObjectCacheEnabled {
+		t.Errorf("tenant A's ListSites row leaked tenant B's config: page=%v object=%v",
+			listA[0].PageCacheEnabled, listA[0].ObjectCacheEnabled)
+	}
+
+	// Sanity: tenant B's own, legitimately-owned site still reports its real
+	// (enabled) state — the isolation fix must not be a blanket false.
+	listB, err := siteSvcB.List(ctx, site.ListInput{TenantID: tenantB, Limit: 50})
+	if err != nil {
+		t.Fatalf("List for tenant B: %v", err)
+	}
+	if len(listB) != 1 {
+		t.Fatalf("expected exactly 1 site for tenant B, got %d", len(listB))
+	}
+	if !listB[0].PageCacheEnabled || !listB[0].ObjectCacheEnabled {
+		t.Errorf("tenant B's own site should report its real enabled state: page=%v object=%v",
+			listB[0].PageCacheEnabled, listB[0].ObjectCacheEnabled)
+	}
+}

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,29 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.70 - 0.61.71",
+    date: "2026-07-18",
+    summary: "Honest cache reporting, working configuration dots, and a complete API reference.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "The dashboard no longer under-reports a working page cache (GH #243). On sites where the managed web-server rules serve cached pages directly from disk, those hits never reach PHP and cannot be counted there; the Cache tab now shows a \"Served at the web-server level\" state, labels the chart as the PHP-layer ratio, and explains how to verify caching via the x-wpmgr-source response header. No numbers are fabricated.",
+      },
+      {
+        tag: "Fixed",
+        text: "The site card's Page Cache and Object Cache dots now reflect the real per-site configuration. They previously looked for plugin entries that can never exist (both features are drop-ins), so they showed gray for every site.",
+      },
+      {
+        tag: "Fixed",
+        text: "The agent's admin-bar \"Manage in WPMgr\" link now opens the site's Cache tab. It previously pointed at a page that never existed; the dashboard also redirects the old link target so already-installed agents work immediately, and unknown dashboard paths render a proper page instead of a bare \"Not Found\".",
+      },
+      {
+        tag: "Changed",
+        text: "The API reference at wpmgr.app/docs now documents the full control-plane surface (about 97 previously missing endpoints), kept in lockstep with the live routes by a new contract test. New user guides cover the file manager, security suite, monitoring, clients and portal, object cache, and audit log.",
+      },
+    ],
+  },
+  {
     version: "0.61.69",
     date: "2026-07-17",
     summary: "Site tags: organize, filter, and bulk-manage your fleet with colored tags.",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.69 / open source",
+  badge: "v0.61.71 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/apps/web/src/components/layout/not-found-page.tsx
+++ b/apps/web/src/components/layout/not-found-page.tsx
@@ -1,0 +1,41 @@
+import { Link } from "@tanstack/react-router";
+import { Compass } from "lucide-react";
+
+import { AppShell } from "@/components/layout/app-shell";
+import { Button } from "@/components/ui/button";
+
+// Branded router-level 404 (GH #243). Wired as the router's
+// `defaultNotFoundComponent` (see src/router.tsx) so an unmatched path (a
+// stale/mistyped deep link, a removed route like the old
+// `/sites/$siteId/performance` before its redirect existed) lands on this
+// instead of TanStack Router's bare, unstyled fallback. Renders inside the
+// same AppShell chrome as the rest of the app (sidebar + topbar) so the
+// operator never loses their navigation — minimal content, on-system tokens.
+
+export function NotFoundPage() {
+  return (
+    <AppShell>
+      <div
+        role="status"
+        className="flex min-h-[60vh] flex-col items-center justify-center gap-3 text-center"
+      >
+        <Compass
+          aria-hidden="true"
+          strokeWidth={1.5}
+          className="size-10 text-[var(--color-muted-foreground)]/50"
+        />
+        <div className="space-y-1">
+          <h1 className="text-lg font-semibold text-[var(--color-foreground)]">
+            This page doesn't exist.
+          </h1>
+          <p className="text-sm text-[var(--color-muted-foreground)]">
+            The link may be out of date, or the page may have moved.
+          </p>
+        </div>
+        <Button asChild size="sm" className="mt-2">
+          <Link to="/sites">Back to Sites</Link>
+        </Button>
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/src/features/perf/cache/CacheHitRatioTrendCard.test.tsx
+++ b/apps/web/src/features/perf/cache/CacheHitRatioTrendCard.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+import { mockQueryResult } from "@/test/query-mocks";
+
+import { CacheHitRatioTrendCard } from "./CacheHitRatioTrendCard";
+import { useCacheHealth } from "../hooks/useCacheHealth";
+import type { CacheHealthResponse } from "../types";
+
+// GH #243 — honest hit-ratio semantics. With the agent-managed .htaccess
+// active, Apache serves cache hits statically without ever running PHP, so
+// the PHP-side tally only ever sees misses. This card must say so plainly
+// (relabeled title + a success-toned callout) rather than let a near-0%
+// number read as "caching is broken" -- and must render exactly as before
+// when .htaccess is not managed (nginx, or not yet reconciled).
+
+vi.mock("../hooks/useCacheHealth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../hooks/useCacheHealth")>();
+  return { ...actual, useCacheHealth: vi.fn() };
+});
+
+const mockedUseCacheHealth = vi.mocked(useCacheHealth);
+
+function stubHealth(overrides: Partial<CacheHealthResponse> = {}) {
+  mockedUseCacheHealth.mockReturnValue(
+    mockQueryResult<CacheHealthResponse>({
+      data: {
+        points: [
+          { hit_count: 10, miss_count: 90, ratio_pct: 10, sampled_at: "2026-07-01T00:00:00Z" },
+          { hit_count: 12, miss_count: 88, ratio_pct: 12, sampled_at: "2026-07-02T00:00:00Z" },
+        ],
+        avg_ratio_pct: 11,
+        ...overrides,
+      },
+    }),
+  );
+}
+
+describe("CacheHitRatioTrendCard -- honest hit-ratio semantics (GH #243)", () => {
+  it("renders the plain 'Cache hit ratio' title with no callout when htaccess is not managed", () => {
+    stubHealth();
+
+    renderWithProviders(
+      <CacheHitRatioTrendCard siteId="site-1" htaccessManaged={false} />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Cache hit ratio" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Served at the web-server level/i),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/x-wpmgr-source/i)).not.toBeInTheDocument();
+  });
+
+  it("relabels to 'PHP-layer hit ratio' and shows the web-server-level callout when htaccess is managed", () => {
+    stubHealth();
+
+    renderWithProviders(
+      <CacheHitRatioTrendCard siteId="site-1" htaccessManaged={true} />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "PHP-layer hit ratio" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Served at the web-server level"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/x-wpmgr-source/i)).toBeInTheDocument();
+    // The sample-window subtitle is unchanged either way.
+    expect(
+      screen.getByText(/Hit percentage over the selected window/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not alter the underlying chart data -- same points render either way", () => {
+    stubHealth();
+
+    renderWithProviders(
+      <CacheHitRatioTrendCard siteId="site-1" htaccessManaged={true} />,
+    );
+
+    // The avg-ratio badge reflects the real (unmodified) average.
+    expect(screen.getByText("11.0% avg")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/perf/cache/CacheHitRatioTrendCard.tsx
+++ b/apps/web/src/features/perf/cache/CacheHitRatioTrendCard.tsx
@@ -4,6 +4,7 @@
 //
 // Layout:
 //   - Header: title + subtitle + average ratio badge + WindowToggle (7/30/90d)
+//     (+ a "served at the web server level" callout when htaccessManaged)
 //   - Body:   isFetching skeleton  |  error message  |  area chart or empty state
 //
 // The WindowToggle drives the days prop of useCacheHealth. isFetching (not
@@ -15,9 +16,18 @@
 //
 // Empty state is the normal first-paint: the endpoint returns no points until
 // the agent begins reporting hit/miss traffic.
+//
+// GH #243 (honest hit-ratio semantics) — with the agent-managed .htaccess
+// active, Apache serves cache hits statically without ever running PHP, so
+// the PHP-side tally only ever sees misses. The stored series is real data;
+// it is just measuring the PHP layer, not the whole site. When
+// `htaccessManaged` is true we say so plainly (title becomes "PHP-layer hit
+// ratio", plus a success-toned callout explaining where the fast-path hits
+// went) instead of letting a near-0% number read as "caching is broken".
+// When false (nginx, or .htaccess not managed) render exactly as before.
 
 import { useState } from "react";
-import { Loader2 } from "lucide-react";
+import { Loader2, Zap } from "lucide-react";
 
 import { Skeleton } from "@/components/ui/skeleton";
 import { CacheHitRatioChart } from "@/components/charts/cache-hit-ratio-chart";
@@ -34,43 +44,55 @@ const CACHE_WINDOWS: ReadonlyArray<{ value: CacheWindow; label: string }> = [
 
 export interface CacheHitRatioTrendCardProps {
   siteId: string;
+  /**
+   * GH #243 — true when the agent manages the site's .htaccess (Apache
+   * serves cached pages before PHP runs, so the PHP-layer tally undercounts
+   * hits). Drives the title relabel + the honest-semantics callout.
+   */
+  htaccessManaged: boolean;
   /** Chart height passed to CacheHitRatioChart (default 160). */
   chartHeight?: number;
 }
 
 export function CacheHitRatioTrendCard({
   siteId,
+  htaccessManaged,
   chartHeight = 160,
 }: CacheHitRatioTrendCardProps) {
   const [days, setDays] = useState<CacheWindow>(7);
   const { data, isLoading, isError, isFetching } = useCacheHealth(siteId, days);
 
   const hasPoints = (data?.points.length ?? 0) >= 1;
+  const title = htaccessManaged ? "PHP-layer hit ratio" : "Cache hit ratio";
 
   return (
     <section
-      aria-label="Cache hit ratio"
+      aria-label={title}
       className="rounded-xl border border-border bg-card text-card-foreground shadow-sm"
     >
       {/* Card header */}
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-5 py-3">
-        <div className="min-w-0">
-          <h3 className="text-sm font-semibold text-foreground">
-            Cache hit ratio
-          </h3>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            Hit percentage over the selected window — one point per sample
-          </p>
+      <div className="space-y-3 border-b border-border px-5 py-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h3 className="text-sm font-semibold text-foreground">
+              {title}
+            </h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Hit percentage over the selected window — one point per sample
+            </p>
+          </div>
+
+          <div className="flex items-center gap-3">
+            {/* Average ratio badge — only when we have data */}
+            {hasPoints && data ? (
+              <AvgRatioBadge avgRatioPct={data.avg_ratio_pct} busy={isFetching} />
+            ) : null}
+
+            <CacheWindowToggle value={days} onChange={setDays} busy={isFetching} />
+          </div>
         </div>
 
-        <div className="flex items-center gap-3">
-          {/* Average ratio badge — only when we have data */}
-          {hasPoints && data ? (
-            <AvgRatioBadge avgRatioPct={data.avg_ratio_pct} busy={isFetching} />
-          ) : null}
-
-          <CacheWindowToggle value={days} onChange={setDays} busy={isFetching} />
-        </div>
+        {htaccessManaged ? <ServedAtWebServerCallout /> : null}
       </div>
 
       {/* Chart body */}
@@ -92,6 +114,41 @@ export function CacheHitRatioTrendCard({
         )}
       </div>
     </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// "Served at the web server level" callout (GH #243)
+// ---------------------------------------------------------------------------
+// A calm SUCCESS-toned state, not a warning — the site is doing the fast
+// thing. Explains why the PHP-layer ratio below can read low even when the
+// page cache is working perfectly, and gives the operator a way to verify it
+// independently (the x-wpmgr-source response header).
+
+function ServedAtWebServerCallout() {
+  return (
+    <div
+      role="status"
+      className="flex items-start gap-2.5 rounded-lg border border-[var(--color-success)]/25 bg-[var(--color-success-subtle)] px-3.5 py-3 text-[var(--color-success-subtle-fg)]"
+    >
+      <Zap aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
+      <div className="min-w-0 space-y-1">
+        <p className="text-sm font-medium">Served at the web-server level</p>
+        <p className="text-xs">
+          Cached pages on this site are served directly by the web server
+          (the fastest path), before PHP runs. Those hits cannot be counted
+          at the PHP layer, so the ratio below reflects only requests that
+          reached PHP.
+        </p>
+        <p className="text-xs opacity-90">
+          To verify caching, check the{" "}
+          <span className="font-mono">x-wpmgr-source</span> response header
+          on an anonymous page view:{" "}
+          <span className="font-medium">Web Server</span> means the fast
+          path served it.
+        </p>
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/src/features/perf/cache/CacheTab.tsx
+++ b/apps/web/src/features/perf/cache/CacheTab.tsx
@@ -75,7 +75,7 @@ export function CacheTab({
 
       <PreloadProgress siteId={siteId} />
 
-      <CacheHitRatioTrendCard siteId={siteId} />
+      <CacheHitRatioTrendCard siteId={siteId} htaccessManaged={cfg.htaccess_managed} />
 
       {canOperate || canManage ? (
         <CacheControls

--- a/apps/web/src/features/sites/site-card.test.ts
+++ b/apps/web/src/features/sites/site-card.test.ts
@@ -89,9 +89,16 @@ describe("SslChip — label text", () => {
 });
 
 // ---------------------------------------------------------------------------
-// CapabilityStrip — lit / dim derivation
+// CapabilityStrip — lit / dim derivation (GH #243)
 // ---------------------------------------------------------------------------
 // The buildCapabilityItems logic from site-card.tsx extracted as a pure fn.
+//
+// Page Cache / Object Cache read the real contract booleans
+// (`site.page_cache_enabled` / `site.object_cache_enabled`) — both features
+// ship as drop-ins, so an active-plugin-slug inference could never be true
+// (that was the GH #243 bug: both dots were unconditionally gray since
+// v0.49.0). These tests assert on/off directly from the booleans, never from
+// a fabricated plugin-list fixture.
 
 import type { Site } from "@wpmgr/api";
 
@@ -104,14 +111,8 @@ interface CapabilityFlags {
 }
 
 function deriveCapabilityFlags(site: Partial<Site>): CapabilityFlags {
-  const hasPageCache =
-    site.components?.plugins?.some(
-      (p) => p.slug === "wpmgr-page-cache" && p.active === true,
-    ) ?? false;
-  const hasObjectCache =
-    site.components?.plugins?.some(
-      (p) => p.slug === "wpmgr-object-cache" && p.active === true,
-    ) ?? false;
+  const hasPageCache = site.page_cache_enabled ?? false;
+  const hasObjectCache = site.object_cache_enabled ?? false;
   const isHttps = (site.url ?? "").startsWith("https://");
   const hasBackups = site.last_backup_status != null;
   const isMultisite = site.multisite ?? false;
@@ -119,27 +120,25 @@ function deriveCapabilityFlags(site: Partial<Site>): CapabilityFlags {
 }
 
 describe("CapabilityStrip — lit glyphs (enabled=true)", () => {
-  it("page cache is lit when wpmgr-page-cache plugin is active", () => {
+  it("page cache is lit when site.page_cache_enabled is true", () => {
     const site: Partial<Site> = {
       url: "https://example.com",
       multisite: false,
       last_backup_status: undefined,
-      components: {
-        plugins: [{ slug: "wpmgr-page-cache", active: true }],
-      },
+      page_cache_enabled: true,
+      object_cache_enabled: false,
     };
     const flags = deriveCapabilityFlags(site);
     expect(flags.hasPageCache).toBe(true);
   });
 
-  it("object cache is lit when wpmgr-object-cache plugin is active", () => {
+  it("object cache is lit when site.object_cache_enabled is true", () => {
     const site: Partial<Site> = {
       url: "https://example.com",
       multisite: false,
       last_backup_status: undefined,
-      components: {
-        plugins: [{ slug: "wpmgr-object-cache", active: true }],
-      },
+      page_cache_enabled: false,
+      object_cache_enabled: true,
     };
     expect(deriveCapabilityFlags(site).hasObjectCache).toBe(true);
   });
@@ -165,20 +164,39 @@ describe("CapabilityStrip — lit glyphs (enabled=true)", () => {
 });
 
 describe("CapabilityStrip — dim glyphs (enabled=false)", () => {
-  it("page cache is dim when plugin is absent", () => {
-    const flags = deriveCapabilityFlags({ url: "https://example.com", multisite: false });
-    expect(flags.hasPageCache).toBe(false);
-  });
-
-  it("page cache is dim when plugin is present but inactive", () => {
+  it("page cache is dim when site.page_cache_enabled is false", () => {
     const site: Partial<Site> = {
       url: "https://example.com",
       multisite: false,
-      components: {
-        plugins: [{ slug: "wpmgr-page-cache", active: false }],
-      },
+      page_cache_enabled: false,
+      object_cache_enabled: false,
     };
     expect(deriveCapabilityFlags(site).hasPageCache).toBe(false);
+  });
+
+  it("object cache is dim when site.object_cache_enabled is false", () => {
+    const site: Partial<Site> = {
+      url: "https://example.com",
+      multisite: false,
+      page_cache_enabled: false,
+      object_cache_enabled: false,
+    };
+    expect(deriveCapabilityFlags(site).hasObjectCache).toBe(false);
+  });
+
+  it("both dots are dim when the site has no performance config yet (both false, not absent)", () => {
+    // Per the contract: page_cache_enabled/object_cache_enabled are required
+    // booleans that are false both when the feature is off AND when the site
+    // has no perf config row yet — never undefined.
+    const site: Partial<Site> = {
+      url: "https://example.com",
+      multisite: false,
+      page_cache_enabled: false,
+      object_cache_enabled: false,
+    };
+    const flags = deriveCapabilityFlags(site);
+    expect(flags.hasPageCache).toBe(false);
+    expect(flags.hasObjectCache).toBe(false);
   });
 
   it("HTTPS is dim for http:// sites", () => {

--- a/apps/web/src/features/sites/site-card.tsx
+++ b/apps/web/src/features/sites/site-card.tsx
@@ -82,15 +82,13 @@ function hostnameFromUrl(url: string): string {
  * `enabled` flag — never hue alone.
  */
 function buildCapabilityItems(site: Site): CapabilityItem[] {
-  const hasPageCache =
-    site.components?.plugins?.some(
-      (p) => p.slug === "wpmgr-page-cache" && p.active === true,
-    ) ?? false;
-
-  const hasObjectCache =
-    site.components?.plugins?.some(
-      (p) => p.slug === "wpmgr-object-cache" && p.active === true,
-    ) ?? false;
+  // GH #243 — read the real drop-in state directly off the site record.
+  // Page Cache / Object Cache both ship as drop-ins, never as a plugin, so
+  // an active-plugin-slug inference can never be true; it was a permanent
+  // false positive since v0.49.0. `site.page_cache_enabled` /
+  // `site.object_cache_enabled` are the authoritative booleans.
+  const hasPageCache = site.page_cache_enabled;
+  const hasObjectCache = site.object_cache_enabled;
 
   const isHttps = site.url.startsWith("https://");
   const hasBackups = site.last_backup_status != null;

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -65,6 +65,7 @@ import { Route as AuthedSitesSiteIdUpdatesRouteImport } from './routes/_authed/s
 import { Route as AuthedSitesSiteIdToolsRouteImport } from './routes/_authed/sites/$siteId.tools'
 import { Route as AuthedSitesSiteIdSettingsRouteImport } from './routes/_authed/sites/$siteId.settings'
 import { Route as AuthedSitesSiteIdSecurityRouteImport } from './routes/_authed/sites/$siteId.security'
+import { Route as AuthedSitesSiteIdPerformanceRouteImport } from './routes/_authed/sites/$siteId.performance'
 import { Route as AuthedSitesSiteIdOptimizeRouteImport } from './routes/_authed/sites/$siteId.optimize'
 import { Route as AuthedSitesSiteIdMediaRouteImport } from './routes/_authed/sites/$siteId.media'
 import { Route as AuthedSitesSiteIdHealthRouteImport } from './routes/_authed/sites/$siteId.health'
@@ -366,6 +367,12 @@ const AuthedSitesSiteIdSecurityRoute =
     path: '/security',
     getParentRoute: () => AuthedSitesSiteIdRoute,
   } as any)
+const AuthedSitesSiteIdPerformanceRoute =
+  AuthedSitesSiteIdPerformanceRouteImport.update({
+    id: '/performance',
+    path: '/performance',
+    getParentRoute: () => AuthedSitesSiteIdRoute,
+  } as any)
 const AuthedSitesSiteIdOptimizeRoute =
   AuthedSitesSiteIdOptimizeRouteImport.update({
     id: '/optimize',
@@ -513,6 +520,7 @@ export interface FileRoutesByFullPath {
   '/sites/$siteId/health': typeof AuthedSitesSiteIdHealthRoute
   '/sites/$siteId/media': typeof AuthedSitesSiteIdMediaRoute
   '/sites/$siteId/optimize': typeof AuthedSitesSiteIdOptimizeRoute
+  '/sites/$siteId/performance': typeof AuthedSitesSiteIdPerformanceRoute
   '/sites/$siteId/security': typeof AuthedSitesSiteIdSecurityRoute
   '/sites/$siteId/settings': typeof AuthedSitesSiteIdSettingsRoute
   '/sites/$siteId/tools': typeof AuthedSitesSiteIdToolsRoute
@@ -579,6 +587,7 @@ export interface FileRoutesByTo {
   '/sites/$siteId/health': typeof AuthedSitesSiteIdHealthRoute
   '/sites/$siteId/media': typeof AuthedSitesSiteIdMediaRoute
   '/sites/$siteId/optimize': typeof AuthedSitesSiteIdOptimizeRoute
+  '/sites/$siteId/performance': typeof AuthedSitesSiteIdPerformanceRoute
   '/sites/$siteId/security': typeof AuthedSitesSiteIdSecurityRoute
   '/sites/$siteId/settings': typeof AuthedSitesSiteIdSettingsRoute
   '/sites/$siteId/tools': typeof AuthedSitesSiteIdToolsRoute
@@ -653,6 +662,7 @@ export interface FileRoutesById {
   '/_authed/sites/$siteId/health': typeof AuthedSitesSiteIdHealthRoute
   '/_authed/sites/$siteId/media': typeof AuthedSitesSiteIdMediaRoute
   '/_authed/sites/$siteId/optimize': typeof AuthedSitesSiteIdOptimizeRoute
+  '/_authed/sites/$siteId/performance': typeof AuthedSitesSiteIdPerformanceRoute
   '/_authed/sites/$siteId/security': typeof AuthedSitesSiteIdSecurityRoute
   '/_authed/sites/$siteId/settings': typeof AuthedSitesSiteIdSettingsRoute
   '/_authed/sites/$siteId/tools': typeof AuthedSitesSiteIdToolsRoute
@@ -727,6 +737,7 @@ export interface FileRouteTypes {
     | '/sites/$siteId/health'
     | '/sites/$siteId/media'
     | '/sites/$siteId/optimize'
+    | '/sites/$siteId/performance'
     | '/sites/$siteId/security'
     | '/sites/$siteId/settings'
     | '/sites/$siteId/tools'
@@ -793,6 +804,7 @@ export interface FileRouteTypes {
     | '/sites/$siteId/health'
     | '/sites/$siteId/media'
     | '/sites/$siteId/optimize'
+    | '/sites/$siteId/performance'
     | '/sites/$siteId/security'
     | '/sites/$siteId/settings'
     | '/sites/$siteId/tools'
@@ -866,6 +878,7 @@ export interface FileRouteTypes {
     | '/_authed/sites/$siteId/health'
     | '/_authed/sites/$siteId/media'
     | '/_authed/sites/$siteId/optimize'
+    | '/_authed/sites/$siteId/performance'
     | '/_authed/sites/$siteId/security'
     | '/_authed/sites/$siteId/settings'
     | '/_authed/sites/$siteId/tools'
@@ -1286,6 +1299,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedSitesSiteIdSecurityRouteImport
       parentRoute: typeof AuthedSitesSiteIdRoute
     }
+    '/_authed/sites/$siteId/performance': {
+      id: '/_authed/sites/$siteId/performance'
+      path: '/performance'
+      fullPath: '/sites/$siteId/performance'
+      preLoaderRoute: typeof AuthedSitesSiteIdPerformanceRouteImport
+      parentRoute: typeof AuthedSitesSiteIdRoute
+    }
     '/_authed/sites/$siteId/optimize': {
       id: '/_authed/sites/$siteId/optimize'
       path: '/optimize'
@@ -1502,6 +1522,7 @@ interface AuthedSitesSiteIdRouteChildren {
   AuthedSitesSiteIdHealthRoute: typeof AuthedSitesSiteIdHealthRoute
   AuthedSitesSiteIdMediaRoute: typeof AuthedSitesSiteIdMediaRoute
   AuthedSitesSiteIdOptimizeRoute: typeof AuthedSitesSiteIdOptimizeRoute
+  AuthedSitesSiteIdPerformanceRoute: typeof AuthedSitesSiteIdPerformanceRoute
   AuthedSitesSiteIdSecurityRoute: typeof AuthedSitesSiteIdSecurityRoute
   AuthedSitesSiteIdSettingsRoute: typeof AuthedSitesSiteIdSettingsRoute
   AuthedSitesSiteIdToolsRoute: typeof AuthedSitesSiteIdToolsRoute
@@ -1519,6 +1540,7 @@ const AuthedSitesSiteIdRouteChildren: AuthedSitesSiteIdRouteChildren = {
   AuthedSitesSiteIdHealthRoute: AuthedSitesSiteIdHealthRoute,
   AuthedSitesSiteIdMediaRoute: AuthedSitesSiteIdMediaRoute,
   AuthedSitesSiteIdOptimizeRoute: AuthedSitesSiteIdOptimizeRoute,
+  AuthedSitesSiteIdPerformanceRoute: AuthedSitesSiteIdPerformanceRoute,
   AuthedSitesSiteIdSecurityRoute: AuthedSitesSiteIdSecurityRoute,
   AuthedSitesSiteIdSettingsRoute: AuthedSitesSiteIdSettingsRoute,
   AuthedSitesSiteIdToolsRoute: AuthedSitesSiteIdToolsRoute,

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -3,6 +3,7 @@ import type { QueryClient } from "@tanstack/react-query";
 
 import { routeTree } from "./routeTree.gen";
 import { queryClient } from "@/lib/query-client";
+import { NotFoundPage } from "@/components/layout/not-found-page";
 
 // Router context shape. The QueryClient is threaded through so route guards
 // (`beforeLoad`) and loaders can read/seed server state — notably the auth
@@ -16,6 +17,14 @@ export const router = createRouter({
   routeTree,
   defaultPreload: "intent",
   scrollRestoration: true,
+  // GH #243 — branded 404 for any unmatched path (stale/mistyped deep link,
+  // a removed route) instead of TanStack Router's bare default fallback.
+  // notFoundMode "root" is load-bearing: NotFoundPage mounts its own AppShell,
+  // and the default "fuzzy" mode would render it INSIDE the deepest matched
+  // layout (nested shell + duplicate command palette) on partially-matched
+  // dead paths like /sites/{id}/{removed-tab}.
+  defaultNotFoundComponent: NotFoundPage,
+  notFoundMode: "root",
   context: { queryClient } satisfies RouterContext,
 });
 

--- a/apps/web/src/routes/_authed/sites/$siteId.performance.tsx
+++ b/apps/web/src/routes/_authed/sites/$siteId.performance.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+// GH #243 — `/sites/$siteId/performance` → `/sites/$siteId/cache`.
+//
+// "Performance" was the old name for what is now the Cache tab (Performance
+// Suite / Phase 7). Sites bookmarked or linked (fleet dashboards, saved
+// operator notes, external docs) still point at the old path — redirect them
+// forward instead of 404ing. Mirrors the `beforeLoad` redirect idiom in
+// `$siteId.index.tsx` (bare `/sites/{id}` → `/sites/{id}/health`).
+
+export const Route = createFileRoute("/_authed/sites/$siteId/performance")({
+  beforeLoad: ({ params }) => {
+    throw redirect({
+      to: "/sites/$siteId/cache",
+      params: { siteId: params.siteId },
+      replace: true,
+    });
+  },
+});

--- a/apps/web/src/routes/_authed/sites/-$siteId.performance.test.tsx
+++ b/apps/web/src/routes/_authed/sites/-$siteId.performance.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { waitFor } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRouteWithContext,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+
+import { createTestQueryClient, renderWithProviders } from "@/test/render";
+import type { RouterContext } from "@/router";
+
+import { Route as PerformanceRedirectRoute } from "./$siteId.performance";
+
+// GH #243 — `/sites/$siteId/performance` (the old tab name) must forward to
+// the Cache tab instead of 404ing. Mounts the REAL route's `beforeLoad`
+// re-attached to a throwaway root (mirrors
+// routes/_authed/-welcome.checkout.test.tsx's rationale — `.update()` strips
+// the `_authed` pathless-layout prefix so the guard doesn't need mocking),
+// plus a `/sites/$siteId/cache` stub so the redirect target is directly
+// observable via `router.state.location`.
+
+const SITE_ID = "22222222-2222-2222-2222-222222222222";
+
+function buildRedirectRouter(
+  initialPath: string,
+  queryClient: ReturnType<typeof createTestQueryClient>,
+) {
+  const rootRoute = createRootRouteWithContext<RouterContext>()({});
+  type UpdateOptions = Parameters<typeof PerformanceRedirectRoute.update>[0];
+  const performanceRoute = PerformanceRedirectRoute.update({
+    id: "/sites/$siteId/performance",
+    path: "/sites/$siteId/performance",
+    getParentRoute: () => rootRoute,
+  } as unknown as UpdateOptions);
+  const cacheRoute = createRoute({
+    path: "/sites/$siteId/cache",
+    getParentRoute: () => rootRoute,
+    component: () => <div>Cache tab stub</div>,
+  });
+  const routeTree = rootRoute.addChildren([performanceRoute, cacheRoute]);
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+    context: { queryClient },
+  });
+}
+
+describe("/sites/$siteId/performance redirect (GH #243)", () => {
+  it("redirects to /sites/$siteId/cache for the same site, replacing history", async () => {
+    const queryClient = createTestQueryClient();
+    const router = buildRedirectRouter(`/sites/${SITE_ID}/performance`, queryClient);
+
+    renderWithProviders(<RouterProvider router={router} />, { queryClient });
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe(`/sites/${SITE_ID}/cache`),
+    );
+    // beforeLoad redirects with replace:true — the old URL must not remain
+    // reachable via back-navigation as a live history entry.
+    expect(router.history.location.pathname).toBe(`/sites/${SITE_ID}/cache`);
+  });
+
+  it("preserves the siteId param exactly (does not redirect to a different site)", async () => {
+    const otherSiteId = "33333333-3333-3333-3333-333333333333";
+    const queryClient = createTestQueryClient();
+    const router = buildRedirectRouter(`/sites/${otherSiteId}/performance`, queryClient);
+
+    renderWithProviders(<RouterProvider router={router} />, { queryClient });
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe(`/sites/${otherSiteId}/cache`),
+    );
+  });
+});

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -119,6 +119,8 @@ export const SiteSchema = {
     "health_status",
     "multisite",
     "tags",
+    "page_cache_enabled",
+    "object_cache_enabled",
     "created_at",
     "updated_at",
   ],
@@ -304,6 +306,16 @@ export const SiteSchema = {
       format: "date-time",
       description:
         "RFC 3339 timestamp of the TLS certificate expiry captured on the most-recent uptime probe.\nAbsent/null when the site is non-HTTPS or has never been probed.\n",
+    },
+    page_cache_enabled: {
+      type: "boolean",
+      description:
+        "GH #243 — the real Page Cache drop-in state (site_perf_config.cache_enabled),\nnot an inference from an installed-plugin slug (the feature ships as a\ndrop-in, not a plugin, so no such slug can ever exist). false both when\ncaching is off AND when the site has no performance config yet.\n",
+    },
+    object_cache_enabled: {
+      type: "boolean",
+      description:
+        "GH #243 — the real Object Cache drop-in state (site_object_cache_config.enabled),\nnot an inference from an installed-plugin slug (the feature ships as a\ndrop-in, not a plugin, so no such slug can ever exist). false both when\nobject caching is off AND when the site has no object cache config yet.\n",
     },
     created_at: {
       type: "string",

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -181,6 +181,22 @@ export type Site = {
    *
    */
   tls_expires_at?: string;
+  /**
+   * GH #243 — the real Page Cache drop-in state (site_perf_config.cache_enabled),
+   * not an inference from an installed-plugin slug (the feature ships as a
+   * drop-in, not a plugin, so no such slug can ever exist). false both when
+   * caching is off AND when the site has no performance config yet.
+   *
+   */
+  page_cache_enabled: boolean;
+  /**
+   * GH #243 — the real Object Cache drop-in state (site_object_cache_config.enabled),
+   * not an inference from an installed-plugin slug (the feature ships as a
+   * drop-in, not a plugin, so no such slug can ever exist). false both when
+   * object caching is off AND when the site has no object cache config yet.
+   *
+   */
+  object_cache_enabled: boolean;
   created_at: string;
   updated_at: string;
 };

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.70
+  version: 0.61.71
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,
@@ -12151,7 +12151,7 @@ components:
     Site:
       type: object
       required:
-        [id, tenant_id, url, name, status, wp_version, php_version, health_status, multisite, tags, created_at, updated_at]
+        [id, tenant_id, url, name, status, wp_version, php_version, health_status, multisite, tags, page_cache_enabled, object_cache_enabled, created_at, updated_at]
       properties:
         id:
           type: string
@@ -12295,6 +12295,20 @@ components:
           description: |
             RFC 3339 timestamp of the TLS certificate expiry captured on the most-recent uptime probe.
             Absent/null when the site is non-HTTPS or has never been probed.
+        page_cache_enabled:
+          type: boolean
+          description: |
+            GH #243 — the real Page Cache drop-in state (site_perf_config.cache_enabled),
+            not an inference from an installed-plugin slug (the feature ships as a
+            drop-in, not a plugin, so no such slug can ever exist). false both when
+            caching is off AND when the site has no performance config yet.
+        object_cache_enabled:
+          type: boolean
+          description: |
+            GH #243 — the real Object Cache drop-in state (site_object_cache_config.enabled),
+            not an inference from an installed-plugin slug (the feature ships as a
+            drop-in, not a plugin, so no such slug can ever exist). false both when
+            object caching is off AND when the site has no object cache config yet.
         created_at:
           type: string
           format: date-time


### PR DESCRIPTION
## GH #243 — "Cache from wpmgr is working?" Yes. The dashboard was lying, three different ways.

Research (4-lens workflow) confirmed the cache serves correctly on the reporter's site; every symptom was a reporting/navigation defect:

**Gap A — hit ratio flat 0% (structural blind spot).** The agent's own managed `.htaccess` serves cached pages straight from disk for anonymous requests — PHP never runs on exactly the requests that are hits, so the PHP-side tally honestly reports `hits=0, misses>0`. *The better the fast path works, the worse the chart looked.* Fix: **honest metrics** — when `htaccess_managed` is true the Cache tab shows a success-toned "Served at the web-server level" state, retitles the series "PHP-layer hit ratio", and documents the `x-wpmgr-source` verification header. No fabricated counts, no fast-path taxation, PHP-served configs unchanged.

**Gap B — capability dots gray for every site since v0.49.0.** They inferred state from plugin slugs that can never exist (both caches are drop-ins; WordPress never lists drop-ins as plugins). Fix: `ListSites`/`GetSite` LEFT JOIN the real config tables (PK joins, EXPLAIN-verified O(sites) preserved) exposing required `page_cache_enabled`/`object_cache_enabled`; the dots read the real booleans. Scoped-collaborator reads **empirically verified** against real Postgres.

**Gap C — "Manage in WPMgr" pointed at a route that never existed (since v0.18.0, no test).** Fixed to `/sites/{id}/cache` (+ the missing URL test); a web-side `/performance → /cache` redirect fixes the **entire deployed fleet the moment the CP deploys**; a branded 404 (with `notFoundMode: "root"` — the adversarial verify caught that fuzzy mode nests a second AppShell) replaces the bare "Not Found".

Also rides: agent `readme.txt` changelog refreshed through 0.61.71.

## Verification
Research → build (3 packages) → 2-lens adversarial verify → must-fix (notFoundMode) closed → re-verified. Gates: api go suite green (real-Postgres capability/isolation tests, route coverage); web 1097 tests/lint/build/impeccable clean; agent 2716 tests/phpcs/plugincheck clean. DoD lockstep: CHANGELOG + openapi 0.61.71 + marketing badge/changelog.

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWiZ4iJ1fmYW8vtPghWmsn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Site cards now show accurate Page Cache and Object Cache status.
  * Cache hit-ratio reporting now distinguishes PHP-layer activity from web-server-served cache hits.
  * Added a branded page for invalid dashboard links.
  * Updated site API data to include explicit cache configuration status.

* **Bug Fixes**
  * “Manage in WPMgr” links now open the correct cache page, including legacy links.

* **Documentation**
  * Updated release notes, guides, and API documentation for version 0.61.71.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->