### PR TITLE
fix(api,web): vuln severities no longer all show Low — feed rate-limit + honest Unknown bucket (GH #245) — 0.61.72

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ wp-cli.phar
 wp-cli.phar.asc
 docs/security/wporg-t13-*.md
 docs/security/wporg-t14-*.md
+docs/security/sftp-recovery-*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.72] - 2026-07-19
+
+### Fixed
+
+- Vulnerability findings no longer all show as "Low" (GH #245). Severity comes from the Wordfence Intelligence feed's CVSS data, but a request-spacing bug rate-limited the enrichment feed on every sync, so every finding was stored without a CVSS score and fell back to the lowest severity, meaning a critical core vulnerability could appear with a "Low" badge. The feed requests are now spaced correctly (the two feeds alternate across syncs, one request per sync) so real severities land and existing findings re-derive their severity on the next scan. A finding that genuinely has no severity data is now shown as "Unknown", ranked for attention above Low and Medium, never silently bucketed as Low. And when the enrichment feed is unreachable, the Vulnerabilities page and the admin feed status now say so explicitly instead of understating risk without a trace. Control plane and dashboard.
+
 ## [0.61.71] - 2026-07-18
 
 ### Fixed

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.71
+ * Version:           0.61.72
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.71');
+define('WPMGR_AGENT_VERSION', '0.61.72');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -3699,15 +3699,25 @@ CREATE INDEX IF NOT EXISTS idx_wf_vuln_software_lookup
 -- ---------------------------------------------------------------------------
 -- No RLS. Single row (id=1). Freshness timestamp, attribution notices, error.
 CREATE TABLE IF NOT EXISTS wordfence_vuln_feed_meta (
-    id              integer PRIMARY KEY DEFAULT 1
+    id                 integer PRIMARY KEY DEFAULT 1
         CONSTRAINT wordfence_vuln_feed_meta_singleton_chk CHECK (id = 1),
-    fetched_at      timestamptz,
-    ok              boolean NOT NULL DEFAULT false,
-    record_count    integer NOT NULL DEFAULT 0,
-    defiant_notice  text,
-    defiant_license text,
-    mitre_notice    text,
-    last_error      text
+    fetched_at         timestamptz,
+    ok                 boolean NOT NULL DEFAULT false,
+    record_count       integer NOT NULL DEFAULT 0,
+    defiant_notice     text,
+    defiant_license    text,
+    mitre_notice       text,
+    last_error         text,
+    -- m101 — Production-enrichment health, tracked independently of
+    -- ok/fetched_at/record_count (which track Scanner-driven detection
+    -- freshness and gate RescanSite). See internal/vuln/model.go FeedMeta doc.
+    enrichment_ok      boolean NOT NULL DEFAULT false,
+    last_enrichment_at timestamptz,
+    -- m101 — Scanner/Production alternation cursor (internal worker state
+    -- only; never exposed via the API). See internal/vuln/repo.go NextFeedKind.
+    next_feed_kind     text NOT NULL DEFAULT 'scanner'
+        CONSTRAINT wordfence_vuln_feed_meta_next_feed_chk
+        CHECK (next_feed_kind IN ('scanner', 'production'))
 );
 
 -- ---------------------------------------------------------------------------
@@ -3727,7 +3737,10 @@ CREATE TABLE IF NOT EXISTS site_vulnerabilities (
     fixed_version     text,
     severity          text NOT NULL
         CONSTRAINT site_vulnerabilities_severity_chk
-        CHECK (severity IN ('critical', 'high', 'medium', 'low')),
+        -- m101 — 'unknown': a finding with neither a cvss_rating nor a
+        -- cvss_score is genuinely "no data", not a confirmed low severity
+        -- (GH #245). See SeverityFromRating in internal/vuln/model.go.
+        CHECK (severity IN ('critical', 'high', 'medium', 'low', 'unknown')),
     cvss_score        numeric(3,1),
     cve               text,
     title             text NOT NULL,

--- a/apps/api/internal/admin/vuln_feed.go
+++ b/apps/api/internal/admin/vuln_feed.go
@@ -215,6 +215,12 @@ type VulnFeedStatus struct {
 	RecordCount int     `json:"record_count"`
 	LastSynced  *string `json:"last_synced,omitempty"` // RFC3339
 	LastError   string  `json:"last_error,omitempty"`
+
+	// EnrichmentAvailable/LastEnrichmentAt track the Production-feed CVSS
+	// enrichment pipeline independently of FeedOK (which tracks Scanner-driven
+	// detection freshness) — see vuln.FeedMeta doc.
+	EnrichmentAvailable bool    `json:"enrichment_available"`
+	LastEnrichmentAt    *string `json:"last_enrichment_at,omitempty"` // RFC3339
 }
 
 // feedMetaReader is a narrow slice of the vuln repo used by the status endpoint.

--- a/apps/api/internal/admin/vuln_feed_handler.go
+++ b/apps/api/internal/admin/vuln_feed_handler.go
@@ -27,8 +27,14 @@ import (
 type VulnFeedMetaReader interface {
 	// GetFeedMetaStatus returns the condensed feed meta needed by the status
 	// endpoint. Returns zero values (ok=false, recordCount=0, lastSynced=nil,
-	// lastError="") with nil error when the meta row has never been written.
-	GetFeedMetaStatus(ctx context.Context) (ok bool, recordCount int, lastSynced *time.Time, lastError string, err error)
+	// lastError="", enrichmentOK=false, lastEnrichmentAt=nil) with nil error
+	// when the meta row has never been written.
+	//
+	// ok/recordCount/lastSynced track Scanner-driven DETECTION freshness;
+	// enrichmentOK/lastEnrichmentAt separately track Production-driven CVSS
+	// enrichment health (kept independent so a Production hiccup never masks
+	// as a whole-feed outage — see vuln.FeedMeta doc).
+	GetFeedMetaStatus(ctx context.Context) (ok bool, recordCount int, lastSynced *time.Time, lastError string, enrichmentOK bool, lastEnrichmentAt *time.Time, err error)
 }
 
 // vulnFeedAdminHandler groups the vuln-feed admin sub-handler dependencies.
@@ -67,14 +73,19 @@ func (h *Handler) vulnFeedStatus(c *gin.Context) {
 
 	// Read feed meta (non-fatal: if the table row is never set, ok=false is fine).
 	if vf.meta != nil {
-		ok, cnt, synced, lastErr, err := vf.meta.GetFeedMetaStatus(ctx)
+		ok, cnt, synced, lastErr, enrichmentOK, lastEnrichAt, err := vf.meta.GetFeedMetaStatus(ctx)
 		if err == nil {
 			status.FeedOK = ok
 			status.RecordCount = cnt
 			status.LastError = lastErr
+			status.EnrichmentAvailable = enrichmentOK
 			if synced != nil {
 				s := synced.UTC().Format(time.RFC3339)
 				status.LastSynced = &s
+			}
+			if lastEnrichAt != nil {
+				s := lastEnrichAt.UTC().Format(time.RFC3339)
+				status.LastEnrichmentAt = &s
 			}
 		}
 		// If err != nil, leave zero values — the UI shows "not yet synced".

--- a/apps/api/internal/admin/vuln_feed_test.go
+++ b/apps/api/internal/admin/vuln_feed_test.go
@@ -71,14 +71,16 @@ func (e *captureFeedEnqueuer) EnqueueFeedRefresh(_ context.Context) error {
 
 // fakeFeedMetaReader returns canned status values for the status endpoint.
 type fakeFeedMetaReader struct {
-	ok          bool
-	recordCount int
-	lastSynced  *time.Time
-	lastError   string
+	ok               bool
+	recordCount      int
+	lastSynced       *time.Time
+	lastError        string
+	enrichmentOK     bool
+	lastEnrichmentAt *time.Time
 }
 
-func (f *fakeFeedMetaReader) GetFeedMetaStatus(_ context.Context) (bool, int, *time.Time, string, error) {
-	return f.ok, f.recordCount, f.lastSynced, f.lastError, nil
+func (f *fakeFeedMetaReader) GetFeedMetaStatus(_ context.Context) (bool, int, *time.Time, string, bool, *time.Time, error) {
+	return f.ok, f.recordCount, f.lastSynced, f.lastError, f.enrichmentOK, f.lastEnrichmentAt, nil
 }
 
 // newTestAgeIdentity returns a fresh ephemeral age identity for testing.
@@ -309,6 +311,67 @@ func TestVulnFeedStatus_NeverReturnsKey(t *testing.T) {
 		}
 	}
 }
+
+// TestVulnFeedStatus_ReflectsEnrichmentAvailable (WP3): the status endpoint's
+// enrichment_available/last_enrichment_at fields must reflect the
+// Production-enrichment state returned by GetFeedMetaStatus, independently of
+// feed_ok (which tracks Scanner-driven detection freshness).
+func TestVulnFeedStatus_ReflectsEnrichmentAvailable(t *testing.T) {
+	age := newTestAgeIdentity(t)
+	repo := newFakeInstSettingsRepo()
+	keySvc := NewVulnFeedKeyService(repo, age, "env-key-12345678", nil, nil)
+
+	cases := []struct {
+		name             string
+		ok               bool
+		enrichmentOK     bool
+		lastEnrichmentAt *time.Time
+	}{
+		{name: "detection_ok_enrichment_never_landed", ok: true, enrichmentOK: false, lastEnrichmentAt: nil},
+		{name: "detection_ok_enrichment_ok", ok: true, enrichmentOK: true, lastEnrichmentAt: timePtr(time.Now())},
+		{name: "detection_degraded_enrichment_still_sticky_ok", ok: false, enrichmentOK: true, lastEnrichmentAt: timePtr(time.Now())},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := &fakeFeedMetaReader{
+				ok:               tc.ok,
+				recordCount:      10,
+				enrichmentOK:     tc.enrichmentOK,
+				lastEnrichmentAt: tc.lastEnrichmentAt,
+			}
+			h := NewHandler(&Service{}, nil)
+			h.SetVulnFeed(meta, keySvc)
+			engine := buildTestEngine(h)
+
+			req := httptest.NewRequest(http.MethodGet, "/admin/vuln-feed/status", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status %d; want 200 (body: %s)", w.Code, w.Body.String())
+			}
+			var resp map[string]any
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if resp["feed_ok"] != tc.ok {
+				t.Errorf("feed_ok = %v; want %v", resp["feed_ok"], tc.ok)
+			}
+			if resp["enrichment_available"] != tc.enrichmentOK {
+				t.Errorf("enrichment_available = %v; want %v", resp["enrichment_available"], tc.enrichmentOK)
+			}
+			_, hasLastEnrichAt := resp["last_enrichment_at"]
+			if tc.lastEnrichmentAt == nil && hasLastEnrichAt {
+				t.Errorf("last_enrichment_at present = %v; want absent (omitempty, nil)", resp["last_enrichment_at"])
+			}
+			if tc.lastEnrichmentAt != nil && !hasLastEnrichAt {
+				t.Error("last_enrichment_at missing; want present")
+			}
+		})
+	}
+}
+
+func timePtr(t time.Time) *time.Time { return &t }
 
 // Test handler: PUT /admin/vuln-feed/key triggers an immediate sync.
 func TestVulnFeedSetKey_TriggersSyncViaHandler(t *testing.T) {

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -7980,15 +7980,27 @@ func (s *AdminVulnFeedStatus) encodeFields(e *jx.Encoder) {
 			s.LastError.Encode(e)
 		}
 	}
+	{
+		e.FieldStart("enrichment_available")
+		e.Bool(s.EnrichmentAvailable)
+	}
+	{
+		if s.LastEnrichmentAt.Set {
+			e.FieldStart("last_enrichment_at")
+			s.LastEnrichmentAt.Encode(e, json.EncodeDateTime)
+		}
+	}
 }
 
-var jsonFieldsNameOfAdminVulnFeedStatus = [6]string{
+var jsonFieldsNameOfAdminVulnFeedStatus = [8]string{
 	0: "configured",
 	1: "source",
 	2: "feed_ok",
 	3: "record_count",
 	4: "last_synced",
 	5: "last_error",
+	6: "enrichment_available",
+	7: "last_enrichment_at",
 }
 
 // Decode decodes AdminVulnFeedStatus from json.
@@ -8066,6 +8078,28 @@ func (s *AdminVulnFeedStatus) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"last_error\"")
 			}
+		case "enrichment_available":
+			requiredBitSet[0] |= 1 << 6
+			if err := func() error {
+				v, err := d.Bool()
+				s.EnrichmentAvailable = bool(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"enrichment_available\"")
+			}
+		case "last_enrichment_at":
+			if err := func() error {
+				s.LastEnrichmentAt.Reset()
+				if err := s.LastEnrichmentAt.Decode(d, json.DecodeDateTime); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"last_enrichment_at\"")
+			}
 		default:
 			return d.Skip()
 		}
@@ -8076,7 +8110,7 @@ func (s *AdminVulnFeedStatus) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00001111,
+		0b01001111,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -52856,6 +52890,10 @@ func (s *FleetVulnerabilitiesResponse) encodeFields(e *jx.Encoder) {
 		e.Int(s.Low)
 	}
 	{
+		e.FieldStart("unknown")
+		e.Int(s.Unknown)
+	}
+	{
 		e.FieldStart("items")
 		e.ArrStart()
 		for _, elem := range s.Items {
@@ -52877,18 +52915,31 @@ func (s *FleetVulnerabilitiesResponse) encodeFields(e *jx.Encoder) {
 			s.FeedSynced.Encode(e, json.EncodeDateTime)
 		}
 	}
+	{
+		e.FieldStart("enrichment_available")
+		e.Bool(s.EnrichmentAvailable)
+	}
+	{
+		if s.LastEnrichmentAt.Set {
+			e.FieldStart("last_enrichment_at")
+			s.LastEnrichmentAt.Encode(e, json.EncodeDateTime)
+		}
+	}
 }
 
-var jsonFieldsNameOfFleetVulnerabilitiesResponse = [9]string{
-	0: "total_open",
-	1: "critical",
-	2: "high",
-	3: "medium",
-	4: "low",
-	5: "items",
-	6: "attribution",
-	7: "feed_ok",
-	8: "feed_synced",
+var jsonFieldsNameOfFleetVulnerabilitiesResponse = [12]string{
+	0:  "total_open",
+	1:  "critical",
+	2:  "high",
+	3:  "medium",
+	4:  "low",
+	5:  "unknown",
+	6:  "items",
+	7:  "attribution",
+	8:  "feed_ok",
+	9:  "feed_synced",
+	10: "enrichment_available",
+	11: "last_enrichment_at",
 }
 
 // Decode decodes FleetVulnerabilitiesResponse from json.
@@ -52960,8 +53011,20 @@ func (s *FleetVulnerabilitiesResponse) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"low\"")
 			}
-		case "items":
+		case "unknown":
 			requiredBitSet[0] |= 1 << 5
+			if err := func() error {
+				v, err := d.Int()
+				s.Unknown = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"unknown\"")
+			}
+		case "items":
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				s.Items = make([]FleetVulnerabilitiesResponseItemsItem, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -52979,7 +53042,7 @@ func (s *FleetVulnerabilitiesResponse) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"items\"")
 			}
 		case "attribution":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				if err := s.Attribution.Decode(d); err != nil {
 					return err
@@ -52989,7 +53052,7 @@ func (s *FleetVulnerabilitiesResponse) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"attribution\"")
 			}
 		case "feed_ok":
-			requiredBitSet[0] |= 1 << 7
+			requiredBitSet[1] |= 1 << 0
 			if err := func() error {
 				v, err := d.Bool()
 				s.FeedOk = bool(v)
@@ -53010,6 +53073,28 @@ func (s *FleetVulnerabilitiesResponse) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"feed_synced\"")
 			}
+		case "enrichment_available":
+			requiredBitSet[1] |= 1 << 2
+			if err := func() error {
+				v, err := d.Bool()
+				s.EnrichmentAvailable = bool(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"enrichment_available\"")
+			}
+		case "last_enrichment_at":
+			if err := func() error {
+				s.LastEnrichmentAt.Reset()
+				if err := s.LastEnrichmentAt.Decode(d, json.DecodeDateTime); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"last_enrichment_at\"")
+			}
 		default:
 			return d.Skip()
 		}
@@ -53021,7 +53106,7 @@ func (s *FleetVulnerabilitiesResponse) Decode(d *jx.Decoder) error {
 	var failures []validate.FieldError
 	for i, mask := range [2]uint8{
 		0b11111111,
-		0b00000000,
+		0b00000101,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -108195,13 +108280,25 @@ func (s *SiteVulnerabilitiesResponse) encodeFields(e *jx.Encoder) {
 			s.FeedSynced.Encode(e, json.EncodeDateTime)
 		}
 	}
+	{
+		e.FieldStart("enrichment_available")
+		e.Bool(s.EnrichmentAvailable)
+	}
+	{
+		if s.LastEnrichmentAt.Set {
+			e.FieldStart("last_enrichment_at")
+			s.LastEnrichmentAt.Encode(e, json.EncodeDateTime)
+		}
+	}
 }
 
-var jsonFieldsNameOfSiteVulnerabilitiesResponse = [4]string{
+var jsonFieldsNameOfSiteVulnerabilitiesResponse = [6]string{
 	0: "items",
 	1: "attribution",
 	2: "feed_ok",
 	3: "feed_synced",
+	4: "enrichment_available",
+	5: "last_enrichment_at",
 }
 
 // Decode decodes SiteVulnerabilitiesResponse from json.
@@ -108263,6 +108360,28 @@ func (s *SiteVulnerabilitiesResponse) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"feed_synced\"")
 			}
+		case "enrichment_available":
+			requiredBitSet[0] |= 1 << 4
+			if err := func() error {
+				v, err := d.Bool()
+				s.EnrichmentAvailable = bool(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"enrichment_available\"")
+			}
+		case "last_enrichment_at":
+			if err := func() error {
+				s.LastEnrichmentAt.Reset()
+				if err := s.LastEnrichmentAt.Decode(d, json.DecodeDateTime); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"last_enrichment_at\"")
+			}
 		default:
 			return d.Skip()
 		}
@@ -108273,7 +108392,7 @@ func (s *SiteVulnerabilitiesResponse) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000111,
+		0b00010111,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -3087,6 +3087,10 @@ type AdminVulnFeedStatus struct {
 	RecordCount int                       `json:"record_count"`
 	LastSynced  OptDateTime               `json:"last_synced"`
 	LastError   OptString                 `json:"last_error"`
+	// True when the Production feed has successfully enriched findings with CVSS/CVE data, independent
+	// of feed_ok (which tracks Scanner-driven detection freshness).
+	EnrichmentAvailable bool        `json:"enrichment_available"`
+	LastEnrichmentAt    OptDateTime `json:"last_enrichment_at"`
 }
 
 // GetConfigured returns the value of Configured.
@@ -3119,6 +3123,16 @@ func (s *AdminVulnFeedStatus) GetLastError() OptString {
 	return s.LastError
 }
 
+// GetEnrichmentAvailable returns the value of EnrichmentAvailable.
+func (s *AdminVulnFeedStatus) GetEnrichmentAvailable() bool {
+	return s.EnrichmentAvailable
+}
+
+// GetLastEnrichmentAt returns the value of LastEnrichmentAt.
+func (s *AdminVulnFeedStatus) GetLastEnrichmentAt() OptDateTime {
+	return s.LastEnrichmentAt
+}
+
 // SetConfigured sets the value of Configured.
 func (s *AdminVulnFeedStatus) SetConfigured(val bool) {
 	s.Configured = val
@@ -3147,6 +3161,16 @@ func (s *AdminVulnFeedStatus) SetLastSynced(val OptDateTime) {
 // SetLastError sets the value of LastError.
 func (s *AdminVulnFeedStatus) SetLastError(val OptString) {
 	s.LastError = val
+}
+
+// SetEnrichmentAvailable sets the value of EnrichmentAvailable.
+func (s *AdminVulnFeedStatus) SetEnrichmentAvailable(val bool) {
+	s.EnrichmentAvailable = val
+}
+
+// SetLastEnrichmentAt sets the value of LastEnrichmentAt.
+func (s *AdminVulnFeedStatus) SetLastEnrichmentAt(val OptDateTime) {
+	s.LastEnrichmentAt = val
 }
 
 func (*AdminVulnFeedStatus) getAdminVulnFeedStatusRes() {}
@@ -18633,15 +18657,22 @@ func (s *FleetUptimeStatusItemStatus) UnmarshalText(data []byte) error {
 
 // Ref: #/components/schemas/FleetVulnerabilitiesResponse
 type FleetVulnerabilitiesResponse struct {
-	TotalOpen   int                                     `json:"total_open"`
-	Critical    int                                     `json:"critical"`
-	High        int                                     `json:"high"`
-	Medium      int                                     `json:"medium"`
-	Low         int                                     `json:"low"`
+	TotalOpen int `json:"total_open"`
+	Critical  int `json:"critical"`
+	High      int `json:"high"`
+	Medium    int `json:"medium"`
+	Low       int `json:"low"`
+	// Findings with neither a CVSS rating nor a numeric score yet — genuinely unknown severity, not a
+	// confirmed low.
+	Unknown     int                                     `json:"unknown"`
 	Items       []FleetVulnerabilitiesResponseItemsItem `json:"items"`
 	Attribution VulnAttribution                         `json:"attribution"`
 	FeedOk      bool                                    `json:"feed_ok"`
 	FeedSynced  OptDateTime                             `json:"feed_synced"`
+	// True when the Production feed has successfully enriched findings with CVSS/CVE data, independent
+	// of feed_ok (which tracks Scanner-driven detection freshness).
+	EnrichmentAvailable bool        `json:"enrichment_available"`
+	LastEnrichmentAt    OptDateTime `json:"last_enrichment_at"`
 }
 
 // GetTotalOpen returns the value of TotalOpen.
@@ -18669,6 +18700,11 @@ func (s *FleetVulnerabilitiesResponse) GetLow() int {
 	return s.Low
 }
 
+// GetUnknown returns the value of Unknown.
+func (s *FleetVulnerabilitiesResponse) GetUnknown() int {
+	return s.Unknown
+}
+
 // GetItems returns the value of Items.
 func (s *FleetVulnerabilitiesResponse) GetItems() []FleetVulnerabilitiesResponseItemsItem {
 	return s.Items
@@ -18687,6 +18723,16 @@ func (s *FleetVulnerabilitiesResponse) GetFeedOk() bool {
 // GetFeedSynced returns the value of FeedSynced.
 func (s *FleetVulnerabilitiesResponse) GetFeedSynced() OptDateTime {
 	return s.FeedSynced
+}
+
+// GetEnrichmentAvailable returns the value of EnrichmentAvailable.
+func (s *FleetVulnerabilitiesResponse) GetEnrichmentAvailable() bool {
+	return s.EnrichmentAvailable
+}
+
+// GetLastEnrichmentAt returns the value of LastEnrichmentAt.
+func (s *FleetVulnerabilitiesResponse) GetLastEnrichmentAt() OptDateTime {
+	return s.LastEnrichmentAt
 }
 
 // SetTotalOpen sets the value of TotalOpen.
@@ -18714,6 +18760,11 @@ func (s *FleetVulnerabilitiesResponse) SetLow(val int) {
 	s.Low = val
 }
 
+// SetUnknown sets the value of Unknown.
+func (s *FleetVulnerabilitiesResponse) SetUnknown(val int) {
+	s.Unknown = val
+}
+
 // SetItems sets the value of Items.
 func (s *FleetVulnerabilitiesResponse) SetItems(val []FleetVulnerabilitiesResponseItemsItem) {
 	s.Items = val
@@ -18732,6 +18783,16 @@ func (s *FleetVulnerabilitiesResponse) SetFeedOk(val bool) {
 // SetFeedSynced sets the value of FeedSynced.
 func (s *FleetVulnerabilitiesResponse) SetFeedSynced(val OptDateTime) {
 	s.FeedSynced = val
+}
+
+// SetEnrichmentAvailable sets the value of EnrichmentAvailable.
+func (s *FleetVulnerabilitiesResponse) SetEnrichmentAvailable(val bool) {
+	s.EnrichmentAvailable = val
+}
+
+// SetLastEnrichmentAt sets the value of LastEnrichmentAt.
+func (s *FleetVulnerabilitiesResponse) SetLastEnrichmentAt(val OptDateTime) {
+	s.LastEnrichmentAt = val
 }
 
 func (*FleetVulnerabilitiesResponse) getFleetVulnerabilitiesRes() {}
@@ -44668,6 +44729,10 @@ type SiteVulnerabilitiesResponse struct {
 	Attribution VulnAttribution `json:"attribution"`
 	FeedOk      bool            `json:"feed_ok"`
 	FeedSynced  OptDateTime     `json:"feed_synced"`
+	// True when the Production feed has successfully enriched findings with CVSS/CVE data, independent
+	// of feed_ok (which tracks Scanner-driven detection freshness).
+	EnrichmentAvailable bool        `json:"enrichment_available"`
+	LastEnrichmentAt    OptDateTime `json:"last_enrichment_at"`
 }
 
 // GetItems returns the value of Items.
@@ -44690,6 +44755,16 @@ func (s *SiteVulnerabilitiesResponse) GetFeedSynced() OptDateTime {
 	return s.FeedSynced
 }
 
+// GetEnrichmentAvailable returns the value of EnrichmentAvailable.
+func (s *SiteVulnerabilitiesResponse) GetEnrichmentAvailable() bool {
+	return s.EnrichmentAvailable
+}
+
+// GetLastEnrichmentAt returns the value of LastEnrichmentAt.
+func (s *SiteVulnerabilitiesResponse) GetLastEnrichmentAt() OptDateTime {
+	return s.LastEnrichmentAt
+}
+
 // SetItems sets the value of Items.
 func (s *SiteVulnerabilitiesResponse) SetItems(val []VulnFinding) {
 	s.Items = val
@@ -44708,6 +44783,16 @@ func (s *SiteVulnerabilitiesResponse) SetFeedOk(val bool) {
 // SetFeedSynced sets the value of FeedSynced.
 func (s *SiteVulnerabilitiesResponse) SetFeedSynced(val OptDateTime) {
 	s.FeedSynced = val
+}
+
+// SetEnrichmentAvailable sets the value of EnrichmentAvailable.
+func (s *SiteVulnerabilitiesResponse) SetEnrichmentAvailable(val bool) {
+	s.EnrichmentAvailable = val
+}
+
+// SetLastEnrichmentAt sets the value of LastEnrichmentAt.
+func (s *SiteVulnerabilitiesResponse) SetLastEnrichmentAt(val OptDateTime) {
+	s.LastEnrichmentAt = val
 }
 
 func (*SiteVulnerabilitiesResponse) listSiteVulnerabilitiesRes() {}

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -1247,14 +1247,17 @@ type WordfenceVulnFeed struct {
 }
 
 type WordfenceVulnFeedMetum struct {
-	ID             int32              `json:"id"`
-	FetchedAt      pgtype.Timestamptz `json:"fetched_at"`
-	Ok             bool               `json:"ok"`
-	RecordCount    int32              `json:"record_count"`
-	DefiantNotice  *string            `json:"defiant_notice"`
-	DefiantLicense *string            `json:"defiant_license"`
-	MitreNotice    *string            `json:"mitre_notice"`
-	LastError      *string            `json:"last_error"`
+	ID               int32              `json:"id"`
+	FetchedAt        pgtype.Timestamptz `json:"fetched_at"`
+	Ok               bool               `json:"ok"`
+	RecordCount      int32              `json:"record_count"`
+	DefiantNotice    *string            `json:"defiant_notice"`
+	DefiantLicense   *string            `json:"defiant_license"`
+	MitreNotice      *string            `json:"mitre_notice"`
+	LastError        *string            `json:"last_error"`
+	EnrichmentOk     bool               `json:"enrichment_ok"`
+	LastEnrichmentAt pgtype.Timestamptz `json:"last_enrichment_at"`
+	NextFeedKind     string             `json:"next_feed_kind"`
 }
 
 type WordfenceVulnSoftware struct {

--- a/apps/api/internal/vuln/handler.go
+++ b/apps/api/internal/vuln/handler.go
@@ -77,13 +77,17 @@ func (h *Handler) Register(r *gin.RouterGroup) {
 //	    "mitre_notice":    "..."
 //	  },
 //	  "feed_ok":     true,
-//	  "feed_synced": "2026-06-20T12:00:00Z"
+//	  "feed_synced": "2026-06-20T12:00:00Z",
+//	  "enrichment_available": true,
+//	  "last_enrichment_at":   "2026-06-20T12:00:00Z"
 //	}
 type siteVulnsResponseDTO struct {
-	Items       []findingDTO   `json:"items"`
-	Attribution attributionDTO `json:"attribution"`
-	FeedOK      bool           `json:"feed_ok"`
-	FeedSynced  *string        `json:"feed_synced,omitempty"`
+	Items               []findingDTO   `json:"items"`
+	Attribution         attributionDTO `json:"attribution"`
+	FeedOK              bool           `json:"feed_ok"`
+	FeedSynced          *string        `json:"feed_synced,omitempty"`
+	EnrichmentAvailable bool           `json:"enrichment_available"`
+	LastEnrichmentAt    *string        `json:"last_enrichment_at,omitempty"`
 }
 
 // attributionDTO carries the Wordfence Intelligence attribution notices.
@@ -123,21 +127,27 @@ type findingDTO struct {
 //	  "high":       8,
 //	  "medium":     20,
 //	  "low":        11,
+//	  "unknown":    0,
 //	  "items":      [ <fleetFindingDTO>, ... ],
 //	  "attribution": { ... },
 //	  "feed_ok":     true,
-//	  "feed_synced": "2026-06-20T12:00:00Z"
+//	  "feed_synced": "2026-06-20T12:00:00Z",
+//	  "enrichment_available": true,
+//	  "last_enrichment_at":   "2026-06-20T12:00:00Z"
 //	}
 type fleetVulnsResponseDTO struct {
-	TotalOpen   int              `json:"total_open"`
-	Critical    int              `json:"critical"`
-	High        int              `json:"high"`
-	Medium      int              `json:"medium"`
-	Low         int              `json:"low"`
-	Items       []fleetFindingDTO `json:"items"`
-	Attribution attributionDTO   `json:"attribution"`
-	FeedOK      bool             `json:"feed_ok"`
-	FeedSynced  *string          `json:"feed_synced,omitempty"`
+	TotalOpen           int               `json:"total_open"`
+	Critical            int               `json:"critical"`
+	High                int               `json:"high"`
+	Medium              int               `json:"medium"`
+	Low                 int               `json:"low"`
+	Unknown             int               `json:"unknown"`
+	Items               []fleetFindingDTO `json:"items"`
+	Attribution         attributionDTO    `json:"attribution"`
+	FeedOK              bool              `json:"feed_ok"`
+	FeedSynced          *string           `json:"feed_synced,omitempty"`
+	EnrichmentAvailable bool              `json:"enrichment_available"`
+	LastEnrichmentAt    *string           `json:"last_enrichment_at,omitempty"`
 }
 
 type fleetFindingDTO struct {
@@ -204,6 +214,16 @@ func feedSyncedStr(meta FeedMeta) *string {
 	return &s
 }
 
+// lastEnrichmentStr formats meta.LastEnrichmentAt for the wire, or nil when
+// Production has never successfully enriched the feed yet.
+func lastEnrichmentStr(meta FeedMeta) *string {
+	if meta.LastEnrichmentAt == nil {
+		return nil
+	}
+	s := meta.LastEnrichmentAt.UTC().Format(time.RFC3339)
+	return &s
+}
+
 // refsFromJSON parses the raw JSONB references column into a string slice of
 // URLs for the DTO.  Non-fatal: returns nil on parse error.
 func refsFromJSON(raw []byte) []string {
@@ -252,10 +272,12 @@ func (h *Handler) listFindings(c *gin.Context) {
 		items = append(items, toFindingDTO(f))
 	}
 	c.JSON(http.StatusOK, siteVulnsResponseDTO{
-		Items:       items,
-		Attribution: toAttributionDTO(meta),
-		FeedOK:      meta.OK,
-		FeedSynced:  feedSyncedStr(meta),
+		Items:               items,
+		Attribution:         toAttributionDTO(meta),
+		FeedOK:              meta.OK,
+		FeedSynced:          feedSyncedStr(meta),
+		EnrichmentAvailable: meta.EnrichmentOK,
+		LastEnrichmentAt:    lastEnrichmentStr(meta),
 	})
 }
 
@@ -381,15 +403,18 @@ func (h *Handler) fleetSummary(c *gin.Context) {
 		})
 	}
 	c.JSON(http.StatusOK, fleetVulnsResponseDTO{
-		TotalOpen:   summary.TotalOpen,
-		Critical:    summary.Critical,
-		High:        summary.High,
-		Medium:      summary.Medium,
-		Low:         summary.Low,
-		Items:       items,
-		Attribution: toAttributionDTO(meta),
-		FeedOK:      meta.OK,
-		FeedSynced:  feedSyncedStr(meta),
+		TotalOpen:           summary.TotalOpen,
+		Critical:            summary.Critical,
+		High:                summary.High,
+		Medium:              summary.Medium,
+		Low:                 summary.Low,
+		Unknown:             summary.Unknown,
+		Items:               items,
+		Attribution:         toAttributionDTO(meta),
+		FeedOK:              meta.OK,
+		FeedSynced:          feedSyncedStr(meta),
+		EnrichmentAvailable: meta.EnrichmentOK,
+		LastEnrichmentAt:    lastEnrichmentStr(meta),
 	})
 }
 

--- a/apps/api/internal/vuln/model.go
+++ b/apps/api/internal/vuln/model.go
@@ -24,12 +24,17 @@ import (
 )
 
 // Severity levels mirror the Wordfence cvss_rating buckets and the scan
-// domain's severity vocabulary.
+// domain's severity vocabulary. SeverityUnknown is a distinct bucket (GH
+// #245): a finding whose feed record carries neither a cvss_rating nor a
+// cvss_score is NOT the same thing as a confirmed-low-severity finding, and
+// must never be silently indistinguishable from one — the honest signal is
+// "unknown", not "low".
 const (
 	SeverityCritical = "critical"
 	SeverityHigh     = "high"
 	SeverityMedium   = "medium"
 	SeverityLow      = "low"
+	SeverityUnknown  = "unknown"
 )
 
 // Status values for a site_vulnerabilities row.
@@ -47,14 +52,22 @@ const (
 )
 
 // FeedMeta holds the current state of the feed ingestion sentinel row.
+//
+// OK/FetchedAt/RecordCount track Scanner-driven DETECTION freshness (Scanner
+// is the authoritative superset ID catalog; RescanSite gates on OK).
+// EnrichmentOK/LastEnrichmentAt separately track Production-driven CVSS/CVE
+// ENRICHMENT health — kept independent so a transient Production hiccup
+// (rate-limited, zero records) never blocks detection rescans.
 type FeedMeta struct {
-	FetchedAt      *time.Time
-	OK             bool
-	RecordCount    int
-	DefiantNotice  string
-	DefiantLicense string
-	MitreNotice    string
-	LastError      string
+	FetchedAt        *time.Time
+	OK               bool
+	RecordCount      int
+	DefiantNotice    string
+	DefiantLicense   string
+	MitreNotice      string
+	LastError        string
+	EnrichmentOK     bool
+	LastEnrichmentAt *time.Time
 }
 
 // VulnSoftware is one row from the wordfence_vuln_software index — a
@@ -113,6 +126,7 @@ type FleetSummary struct {
 	High      int
 	Medium    int
 	Low       int
+	Unknown   int
 	Findings  []FleetFinding
 }
 
@@ -143,8 +157,12 @@ type ComponentSnapshot struct {
 }
 
 // SeverityFromRating maps a Wordfence cvss_rating string to our severity bucket.
-// Falls back to numeric score when rating is absent. Falls back to "low" on
-// unknown inputs so we never silently drop a finding.
+// Falls back to numeric score when rating is absent. When NEITHER a
+// recognised rating NOR a numeric score is available, returns SeverityUnknown
+// — NOT SeverityLow (GH #245: bucketing "no data" as "low" silently hid a
+// CVSS 9.8 core RCE behind a confirmed-low-severity label). "None" is a
+// legitimate Wordfence rating (CVSS 0.0, informational) and stays mapped to
+// low; only the true no-data case changes.
 func SeverityFromRating(rating string, score *float64) string {
 	switch rating {
 	case "Critical":
@@ -169,5 +187,5 @@ func SeverityFromRating(rating string, score *float64) string {
 			return SeverityLow
 		}
 	}
-	return SeverityLow
+	return SeverityUnknown
 }

--- a/apps/api/internal/vuln/repo.go
+++ b/apps/api/internal/vuln/repo.go
@@ -35,6 +35,19 @@ func NewRepo(pool *db.Pool) *Repo {
 // UpsertFeedRecord inserts or replaces one vulnerability record and its
 // associated software rows inside the provided transaction.  Called once per
 // record during the feed import batch.
+//
+// cve/cve_link/cvss_score/cvss_rating/cwe/reference_urls are written STICKY
+// against the existing row: under the Scanner/Production alternation (GH
+// #245), a Scanner run's records typically carry none of these fields at all
+// (nilString turns "" into NULL, CVSSScore is already a nil-able *float64,
+// and parseFeedRecord defaults an absent references[] to a non-NULL '[]'
+// jsonb — never NULL), and a blind overwrite would erase enrichment a prior
+// Production run had already populated — flapping severity AND reference
+// link-outs between real values and empty every other hour. A Production
+// run's non-empty values always win: cve/cve_link/cvss_score/cvss_rating/cwe
+// via COALESCE (NULL loses to any non-NULL), reference_urls via
+// COALESCE(NULLIF(...,'[]'::jsonb), ...) since its "no data" sentinel is the
+// literal empty array, not SQL NULL.
 func (r *Repo) UpsertFeedRecord(ctx context.Context, tx pgx.Tx, rec FeedRecord) error {
 	_, err := tx.Exec(ctx, `
 		INSERT INTO wordfence_vuln_feed
@@ -43,13 +56,13 @@ func (r *Repo) UpsertFeedRecord(ctx context.Context, tx pgx.Tx, rec FeedRecord) 
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
 		ON CONFLICT (vuln_id) DO UPDATE SET
 			title          = EXCLUDED.title,
-			cve            = EXCLUDED.cve,
-			cve_link       = EXCLUDED.cve_link,
-			cvss_score     = EXCLUDED.cvss_score,
-			cvss_rating    = EXCLUDED.cvss_rating,
-			cwe            = EXCLUDED.cwe,
+			cve            = COALESCE(EXCLUDED.cve, wordfence_vuln_feed.cve),
+			cve_link       = COALESCE(EXCLUDED.cve_link, wordfence_vuln_feed.cve_link),
+			cvss_score     = COALESCE(EXCLUDED.cvss_score, wordfence_vuln_feed.cvss_score),
+			cvss_rating    = COALESCE(EXCLUDED.cvss_rating, wordfence_vuln_feed.cvss_rating),
+			cwe            = COALESCE(EXCLUDED.cwe, wordfence_vuln_feed.cwe),
 			informational  = EXCLUDED.informational,
-			reference_urls = EXCLUDED.reference_urls,
+			reference_urls = COALESCE(NULLIF(EXCLUDED.reference_urls, '[]'::jsonb), wordfence_vuln_feed.reference_urls),
 			published      = EXCLUDED.published,
 			updated        = EXCLUDED.updated,
 			raw            = EXCLUDED.raw`,
@@ -96,6 +109,13 @@ func (r *Repo) UpsertFeedRecord(ctx context.Context, tx pgx.Tx, rec FeedRecord) 
 // BulkUpsertFeedRecords upserts all feed records in a single pgx Batch, sending
 // every INSERT ... ON CONFLICT DO UPDATE in one round-trip instead of one per record.
 // This replaces the O(N) per-record path that timed out on 13k-record full-dump ingest.
+//
+// Sticky enrichment: see the identical rationale on UpsertFeedRecord — the
+// cve/cve_link/cvss_score/cvss_rating/cwe/reference_urls columns are all
+// preserved (COALESCE, or COALESCE+NULLIF for reference_urls whose "no data"
+// sentinel is the literal '[]' jsonb rather than NULL) so a Scanner run's
+// records (which normally carry none of these) can never blank out a prior
+// Production run's enrichment — including its reference link-outs.
 func (r *Repo) BulkUpsertFeedRecords(ctx context.Context, tx pgx.Tx, recs []FeedRecord) error {
 	if len(recs) == 0 {
 		return nil
@@ -108,13 +128,13 @@ func (r *Repo) BulkUpsertFeedRecords(ctx context.Context, tx pgx.Tx, recs []Feed
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
 		ON CONFLICT (vuln_id) DO UPDATE SET
 			title          = EXCLUDED.title,
-			cve            = EXCLUDED.cve,
-			cve_link       = EXCLUDED.cve_link,
-			cvss_score     = EXCLUDED.cvss_score,
-			cvss_rating    = EXCLUDED.cvss_rating,
-			cwe            = EXCLUDED.cwe,
+			cve            = COALESCE(EXCLUDED.cve, wordfence_vuln_feed.cve),
+			cve_link       = COALESCE(EXCLUDED.cve_link, wordfence_vuln_feed.cve_link),
+			cvss_score     = COALESCE(EXCLUDED.cvss_score, wordfence_vuln_feed.cvss_score),
+			cvss_rating    = COALESCE(EXCLUDED.cvss_rating, wordfence_vuln_feed.cvss_rating),
+			cwe            = COALESCE(EXCLUDED.cwe, wordfence_vuln_feed.cwe),
 			informational  = EXCLUDED.informational,
-			reference_urls = EXCLUDED.reference_urls,
+			reference_urls = COALESCE(NULLIF(EXCLUDED.reference_urls, '[]'::jsonb), wordfence_vuln_feed.reference_urls),
 			published      = EXCLUDED.published,
 			updated        = EXCLUDED.updated,
 			raw            = EXCLUDED.raw`
@@ -159,8 +179,8 @@ func (r *Repo) BulkUpsertFeedRecords(ctx context.Context, tx pgx.Tx, recs []Feed
 //   - A single feed record's software[] array listing the same (kind, slug) more
 //     than once (e.g. a plugin entry that appears with two different affected-version
 //     ranges).
-//   - Future expansion of mergeEnrichment to merge production software rows into
-//     scanner rows.
+//   - A future feed revision that lists the same (kind, slug) with a split
+//     affected-version range across two entries.
 //
 // Both are eliminated by dedupSoftwareRows, which merges rows sharing the same
 // normalised (vuln_id, kind, slug) key. A final map-based guard prevents any
@@ -385,27 +405,47 @@ func (r *Repo) PruneMissingVulns(ctx context.Context, tx pgx.Tx, knownIDs []stri
 	return nil
 }
 
-// StampFeedMeta writes the freshness + attribution sentinel row.
+// StampFeedMeta writes the freshness + attribution sentinel row after a
+// successful ingest of either feed.
+//
+// defiant_notice/defiant_license/mitre_notice are written via COALESCE so a
+// run whose records happened not to carry a copyrights block (odd shape,
+// truncated response, etc.) never blanks out previously-captured attribution
+// text — that text is a standing legal display obligation, not a per-run
+// value.
+//
+// enrichment_ok/last_enrichment_at are ALSO COALESCE-preserved: meta.EnrichmentOK
+// and meta.LastEnrichmentAt are nil-able pointers, and nil means "this run did
+// not touch enrichment" (the Scanner-run case) — leaving the last Production
+// run's enrichment status sticky rather than flapping it false every other
+// hour purely because Scanner doesn't carry CVSS.
 func (r *Repo) StampFeedMeta(ctx context.Context, tx pgx.Tx, meta FeedMetaUpdate) error {
 	_, err := tx.Exec(ctx, `
 		UPDATE wordfence_vuln_feed_meta SET
-			fetched_at      = $1,
-			ok              = $2,
-			record_count    = $3,
-			defiant_notice  = $4,
-			defiant_license = $5,
-			mitre_notice    = $6,
-			last_error      = $7
+			fetched_at         = $1,
+			ok                 = $2,
+			record_count       = $3,
+			defiant_notice     = COALESCE($4, defiant_notice),
+			defiant_license    = COALESCE($5, defiant_license),
+			mitre_notice       = COALESCE($6, mitre_notice),
+			last_error         = $7,
+			enrichment_ok      = COALESCE($8, enrichment_ok),
+			last_enrichment_at = COALESCE($9, last_enrichment_at)
 		WHERE id = 1`,
 		meta.FetchedAt, meta.OK, meta.RecordCount,
 		nilString(meta.DefiantNotice), nilString(meta.DefiantLicense),
 		nilString(meta.MitreNotice), nilString(meta.LastError),
+		meta.EnrichmentOK, meta.LastEnrichmentAt,
 	)
 	return err
 }
 
-// StampFeedError records an error without resetting the ok/fetched_at fields
-// from the last successful run.
+// StampFeedError records a DETECTION-feed error: it sets ok = false (the flag
+// RescanSite gates on) and last_error. It must only be called for a Scanner
+// fetch failure or a hard/non-rate-limit failure that affects the feed as a
+// whole — never for a routine Production-only hiccup (use
+// StampEnrichmentDegraded for that), or detection rescans would wrongly skip
+// every other hour once Scanner/Production alternation is in play.
 func (r *Repo) StampFeedError(ctx context.Context, lastError string) error {
 	_, err := r.pool.Exec(ctx,
 		`UPDATE wordfence_vuln_feed_meta SET ok = false, last_error = $1 WHERE id = 1`,
@@ -414,23 +454,43 @@ func (r *Repo) StampFeedError(ctx context.Context, lastError string) error {
 	return err
 }
 
+// StampEnrichmentDegraded records a Production-fetch failure or degradation
+// (rate-limited, zero records, transient error) WITHOUT touching the
+// detection-feed ok/fetched_at/record_count fields. Those track Scanner-driven
+// detection freshness and must stay exactly as the last successful Scanner run
+// left them — a Production hiccup is real (surfaced via enrichment_ok=false +
+// last_error) but must never make RescanSite skip a cycle.
+func (r *Repo) StampEnrichmentDegraded(ctx context.Context, lastError string) error {
+	_, err := r.pool.Exec(ctx,
+		`UPDATE wordfence_vuln_feed_meta SET enrichment_ok = false, last_error = $1 WHERE id = 1`,
+		lastError,
+	)
+	return err
+}
+
 // GetFeedMeta returns the current feed sentinel row.
 func (r *Repo) GetFeedMeta(ctx context.Context) (FeedMeta, error) {
 	var m FeedMeta
-	var fetchedAt pgtype.Timestamptz
+	var fetchedAt, lastEnrichmentAt pgtype.Timestamptz
 	var defiantNotice, defiantLicense, mitreNotice, lastError pgtype.Text
 	err := r.pool.QueryRow(ctx, `
 		SELECT fetched_at, ok, record_count,
-		       defiant_notice, defiant_license, mitre_notice, last_error
+		       defiant_notice, defiant_license, mitre_notice, last_error,
+		       enrichment_ok, last_enrichment_at
 		FROM wordfence_vuln_feed_meta WHERE id = 1`,
 	).Scan(&fetchedAt, &m.OK, &m.RecordCount,
-		&defiantNotice, &defiantLicense, &mitreNotice, &lastError)
+		&defiantNotice, &defiantLicense, &mitreNotice, &lastError,
+		&m.EnrichmentOK, &lastEnrichmentAt)
 	if err != nil {
 		return m, fmt.Errorf("get feed meta: %w", err)
 	}
 	if fetchedAt.Valid {
 		t := fetchedAt.Time
 		m.FetchedAt = &t
+	}
+	if lastEnrichmentAt.Valid {
+		t := lastEnrichmentAt.Time
+		m.LastEnrichmentAt = &t
 	}
 	m.DefiantNotice = defiantNotice.String
 	m.DefiantLicense = defiantLicense.String
@@ -443,12 +503,40 @@ func (r *Repo) GetFeedMeta(ctx context.Context) (FeedMeta, error) {
 // superadmin status endpoint. This satisfies admin.VulnFeedMetaReader.
 // Returns zero values with nil error when the meta row has never been written
 // (fetched_at IS NULL) — i.e. the feed has not yet run.
-func (r *Repo) GetFeedMetaStatus(ctx context.Context) (ok bool, recordCount int, lastSynced *time.Time, lastError string, err error) {
+func (r *Repo) GetFeedMetaStatus(ctx context.Context) (ok bool, recordCount int, lastSynced *time.Time, lastError string, enrichmentOK bool, lastEnrichmentAt *time.Time, err error) {
 	meta, ferr := r.GetFeedMeta(ctx)
 	if ferr != nil {
-		return false, 0, nil, "", ferr
+		return false, 0, nil, "", false, nil, ferr
 	}
-	return meta.OK, meta.RecordCount, meta.FetchedAt, meta.LastError, nil
+	return meta.OK, meta.RecordCount, meta.FetchedAt, meta.LastError, meta.EnrichmentOK, meta.LastEnrichmentAt, nil
+}
+
+// NextFeedKind atomically reads-and-advances the Scanner/Production
+// alternation cursor, returning the feed kind ("scanner"|"production") this
+// worker cycle should fetch. The cursor is flipped in the SAME statement via
+// a CTE + row lock, so alternation is a pure function of invocation count —
+// it does not depend on whether this cycle's fetch succeeds. That keeps the
+// invariant simple: each periodic run issues at most one Wordfence HTTP
+// request, and successive runs always target the other feed.
+func (r *Repo) NextFeedKind(ctx context.Context) (string, error) {
+	var kind string
+	err := r.pool.QueryRow(ctx, `
+		WITH cur AS (
+			SELECT next_feed_kind FROM wordfence_vuln_feed_meta WHERE id = 1 FOR UPDATE
+		)
+		UPDATE wordfence_vuln_feed_meta m
+		SET next_feed_kind = CASE cur.next_feed_kind
+			WHEN 'scanner' THEN 'production'
+			ELSE 'scanner'
+		END
+		FROM cur
+		WHERE m.id = 1
+		RETURNING cur.next_feed_kind`,
+	).Scan(&kind)
+	if err != nil {
+		return "", fmt.Errorf("advance feed cursor: %w", err)
+	}
+	return kind, nil
 }
 
 // LookupSoftware returns all vulnerability software rows for the given (kind, slug).
@@ -583,8 +671,10 @@ func (r *Repo) ListOpenFindings(ctx context.Context, tenantID, siteID uuid.UUID)
 				CASE v.severity
 					WHEN 'critical' THEN 1
 					WHEN 'high'     THEN 2
-					WHEN 'medium'   THEN 3
-					ELSE 4
+					WHEN 'unknown'  THEN 3
+					WHEN 'medium'   THEN 4
+					WHEN 'low'      THEN 5
+					ELSE 6
 				END,
 				v.cvss_score DESC NULLS LAST,
 				v.first_seen DESC`,
@@ -677,7 +767,7 @@ func (r *Repo) RestoreFinding(ctx context.Context, tenantID, siteID, findingID u
 
 // FleetOpenCounts returns the open finding counts per severity across all
 // sites for a tenant.
-func (r *Repo) FleetOpenCounts(ctx context.Context, tenantID uuid.UUID) (critical, high, medium, low int, err error) {
+func (r *Repo) FleetOpenCounts(ctx context.Context, tenantID uuid.UUID) (critical, high, medium, low, unknown int, err error) {
 	err = r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT severity, count(*)
@@ -703,6 +793,8 @@ func (r *Repo) FleetOpenCounts(ctx context.Context, tenantID uuid.UUID) (critica
 				medium = cnt
 			case SeverityLow:
 				low = cnt
+			case SeverityUnknown:
+				unknown = cnt
 			}
 		}
 		return rows.Err()
@@ -733,8 +825,10 @@ func (r *Repo) FleetOpenFindings(ctx context.Context, tenantID uuid.UUID, limit 
 				CASE v.severity
 					WHEN 'critical' THEN 1
 					WHEN 'high'     THEN 2
-					WHEN 'medium'   THEN 3
-					ELSE 4
+					WHEN 'unknown'  THEN 3
+					WHEN 'medium'   THEN 4
+					WHEN 'low'      THEN 5
+					ELSE 6
 				END,
 				v.cvss_score DESC NULLS LAST,
 				v.first_seen DESC
@@ -789,6 +883,11 @@ type SoftwareRow struct {
 }
 
 // FeedMetaUpdate is the data written to the sentinel row after ingestion.
+//
+// EnrichmentOK/LastEnrichmentAt are nil-able: nil means "this run did not
+// touch enrichment status" (a Scanner run), preserving whatever the last
+// Production run wrote (see StampFeedMeta doc). A non-nil pointer means this
+// run WAS a Production run and its outcome should replace the stored value.
 type FeedMetaUpdate struct {
 	FetchedAt      time.Time
 	OK             bool
@@ -797,6 +896,9 @@ type FeedMetaUpdate struct {
 	DefiantLicense string
 	MitreNotice    string
 	LastError      string
+
+	EnrichmentOK     *bool
+	LastEnrichmentAt *time.Time
 }
 
 // VulnSoftwareRow is the projection returned by LookupSoftware: all the

--- a/apps/api/internal/vuln/service.go
+++ b/apps/api/internal/vuln/service.go
@@ -315,7 +315,7 @@ func (s *Service) Remediate(ctx context.Context, tenantID, siteID, findingID, us
 
 // GetFleetSummary returns the cross-site vulnerability counts + prioritized list.
 func (s *Service) GetFleetSummary(ctx context.Context, tenantID uuid.UUID, limit int) (FleetSummary, FeedMeta, error) {
-	critical, high, medium, low, err := s.repo.FleetOpenCounts(ctx, tenantID)
+	critical, high, medium, low, unknown, err := s.repo.FleetOpenCounts(ctx, tenantID)
 	if err != nil {
 		return FleetSummary{}, FeedMeta{}, domain.Internal("fleet_counts_failed", "failed to aggregate fleet vulnerability counts").WithCause(err)
 	}
@@ -326,11 +326,15 @@ func (s *Service) GetFleetSummary(ctx context.Context, tenantID uuid.UUID, limit
 	meta, _ := s.repo.GetFeedMeta(ctx)
 
 	fleet := FleetSummary{
-		TotalOpen: critical + high + medium + low,
+		// Unknown MUST be included in TotalOpen — an unknown-severity finding
+		// (no CVSS data yet) is still an open finding; dropping it from the
+		// total would make it vanish from the fleet count entirely (GH #245).
+		TotalOpen: critical + high + medium + low + unknown,
 		Critical:  critical,
 		High:      high,
 		Medium:    medium,
 		Low:       low,
+		Unknown:   unknown,
 	}
 	for _, row := range rows {
 		fleet.Findings = append(fleet.Findings, FleetFinding{

--- a/apps/api/internal/vuln/service_test.go
+++ b/apps/api/internal/vuln/service_test.go
@@ -34,7 +34,7 @@ func TestSeverityFromRating(t *testing.T) {
 		{"High", nil, "high"},
 		{"Medium", nil, "medium"},
 		{"Low", nil, "low"},
-		{"None", nil, "low"},
+		{"None", nil, "low"}, // Wordfence "None" = CVSS 0.0, informational; a legitimate confirmed-low, not "no data"
 		{"", score(9.8), "critical"},
 		{"", score(9.0), "critical"},
 		{"", score(8.9), "high"},
@@ -43,8 +43,11 @@ func TestSeverityFromRating(t *testing.T) {
 		{"", score(4.0), "medium"},
 		{"", score(3.9), "low"},
 		{"", score(0.0), "low"},
-		{"", nil, "low"}, // no rating, no score → low
-		{"Unknown", nil, "low"},
+		// GH #245: no rating AND no score is genuinely "no data" — must be
+		// "unknown", never silently bucketed as a confirmed "low" (that
+		// fallback previously hid a CVSS 9.8 core RCE behind a "low" label).
+		{"", nil, "unknown"},
+		{"Unknown", nil, "unknown"}, // unrecognised rating string + no score → also honest-unknown
 	}
 	for _, tc := range cases {
 		got := vuln.SeverityFromRating(tc.rating, tc.score)

--- a/apps/api/internal/vuln/worker.go
+++ b/apps/api/internal/vuln/worker.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -47,25 +48,44 @@ type RescanSiteArgs struct {
 func (RescanSiteArgs) Kind() string { return "vuln_rescan_site" }
 
 // ---------------------------------------------------------------------------
-// Wordfence Intelligence V3 feed URL
+// Wordfence Intelligence V3 feed URLs — Scanner/Production alternation (GH #245)
 // ---------------------------------------------------------------------------
 
 // The Scanner feed carries the minimal detection-critical data (affected
-// versions, patched, severity). It is the primary fetch target.
+// versions, patched, severity) and is the authoritative, superset ID catalog
+// — it determines which vulnerabilities EXIST and which software they match.
 // The Production feed additionally carries CVSS scores, CVE identifiers,
-// remediation text, and the copyrights block. It is fetched on the same
-// schedule and used to ENRICH existing rows (a separate upsert into the same
-// wordfence_vuln_feed table).
+// remediation text, and a richer copyrights block; its ID set is a proper
+// SUBSET of Scanner's (it omits brand-new "being-researched" unrated
+// entries), so it is used only to ENRICH rows that Scanner already created —
+// never to determine existence.
+//
+// Wordfence Intelligence v3 enforces ~1 request / 30 minutes GLOBALLY per API
+// key. This job runs hourly; fetching BOTH feeds in the same run (even with a
+// short inter-fetch delay) deterministically 429'd the second fetch every
+// cycle, so Production — and therefore all CVSS/CVE enrichment — never landed
+// (GH #245: every finding fell back to a fabricated "low" severity, hiding a
+// real CVSS 9.8 core RCE). The fix: alternate feeds across successive runs via
+// a persisted cursor (Repo.NextFeedKind) so each run issues exactly ONE
+// request, comfortably inside the rate-limit window.
 const (
-	wfScannerURL    = "https://www.wordfence.com/api/intelligence/v3/vulnerabilities/scanner"
-	wfProductionURL = "https://www.wordfence.com/api/intelligence/v3/vulnerabilities/production"
+	ScannerFeedURL    = "https://www.wordfence.com/api/intelligence/v3/vulnerabilities/scanner"
+	ProductionFeedURL = "https://www.wordfence.com/api/intelligence/v3/vulnerabilities/production"
+)
+
+// Feed kind identifiers — mirror the wordfence_vuln_feed_meta.next_feed_kind
+// CHECK constraint values.
+const (
+	FeedKindScanner    = "scanner"
+	FeedKindProduction = "production"
 )
 
 // errRateLimited marks a 429 from the Wordfence feed. Wordfence documents no
 // Retry-After and no per-window number ("too many requests in a short period"),
-// so a 429 must NOT trigger River's aggressive retry — that just re-hits the
-// endpoint and keeps the rate-limit window warm. Instead we stamp the status and
-// succeed; the hourly periodic refresh is the natural, well-spaced retry.
+// so a 429 must NOT trigger an immediate in-process retry — that just re-hits
+// the endpoint and keeps the rate-limit window warm. Instead we stamp the
+// status and succeed; the next scheduled run (which targets the ALTERNATE
+// feed, per NextFeedKind) is the natural, well-spaced retry.
 var errRateLimited = errors.New("wordfence feed rate limited (429)")
 
 // FeedHTTPDoer is the subset of httpclient.Client the feed worker needs.
@@ -131,15 +151,19 @@ func NewFeedWorker(repo *Repo, pool *db.Pool, svc *Service, resolver APIKeyResol
 func (w *FeedWorker) SetService(svc *Service) { w.svc = svc }
 
 // Timeout gives the feed refresh job 10 minutes. A full-dump ingest of ~13k
-// records via CopyFrom completes in seconds, but the two HTTP fetches + the
-// 2s inter-fetch delay + any Postgres latency under load consume real wall
-// time. 10 minutes is generous headroom well above the expected 30–60s wall
-// time and avoids the context deadline that previously killed the per-record loop.
+// records via CopyFrom completes in seconds, but the single HTTP fetch (one
+// feed per run — see NextFeedKind) + any Postgres latency under load consume
+// real wall time. 10 minutes is generous headroom well above the expected
+// 15–30s wall time and avoids the context deadline that previously killed the
+// per-record loop.
 func (w *FeedWorker) Timeout(*river.Job[FeedRefreshArgs]) time.Duration {
 	return 10 * time.Minute
 }
 
-// Work performs the feed refresh.
+// Work performs the feed refresh: exactly ONE Wordfence Intelligence HTTP
+// request per invocation, alternating Scanner/Production across successive
+// runs (see the package-level doc comment above the feed URL constants and
+// Repo.NextFeedKind).
 func (w *FeedWorker) Work(ctx context.Context, job *river.Job[FeedRefreshArgs]) error {
 	// Resolve the key at run-time so a UI-set key takes effect on the next job
 	// without requiring a restart. Priority: UI key > env key > no-op.
@@ -151,53 +175,60 @@ func (w *FeedWorker) Work(ctx context.Context, job *river.Job[FeedRefreshArgs]) 
 	}
 	_ = source // used only for debug logging above
 
-	w.logger.Info("vuln: starting Wordfence Intelligence feed refresh")
-
-	// Fetch the Scanner feed (required).
-	records, defiantNotice, defiantLicense, mitreNotice, err := w.fetchFeed(ctx, wfScannerURL, apiKey)
-	if err != nil {
-		// A 429 must NOT be retried by River: Wordfence rate-limits "too many
-		// requests in a short period" with no Retry-After, so aggressive retries
-		// keep the window warm and never recover. Stamp the status and SUCCEED;
-		// the hourly periodic refresh is the natural, well-spaced retry.
-		if errors.Is(err, errRateLimited) {
-			_ = w.repo.StampFeedError(ctx, "rate limited by Wordfence; will retry on the next scheduled refresh")
-			w.logger.Warn("vuln: scanner feed rate limited; skipping this cycle (no River retry)")
-			return nil
-		}
-		errMsg := fmt.Sprintf("scanner feed fetch failed: %v", err)
-		_ = w.repo.StampFeedError(ctx, errMsg)
-		return fmt.Errorf("vuln feed refresh: %w", err) // River will retry real failures
+	// Advance the alternation cursor first: the flip is unconditional (does
+	// not depend on this cycle's outcome) so successive runs strictly
+	// alternate feeds regardless of transient failures. Fall back to Scanner
+	// on a cursor read error so a meta-row hiccup never wedges the worker.
+	feedKind, cerr := w.repo.NextFeedKind(ctx)
+	if cerr != nil {
+		w.logger.Warn("vuln: failed to read feed alternation cursor; defaulting to scanner",
+			slog.Any("error", cerr))
+		feedKind = FeedKindScanner
+	}
+	feedURL := ScannerFeedURL
+	if feedKind == FeedKindProduction {
+		feedURL = ProductionFeedURL
 	}
 
-	// Brief spacing between the two fetches reduces the chance of hitting the
-	// production endpoint's rate limit immediately after the scanner fetch.
-	time.Sleep(2 * time.Second)
+	w.logger.Info("vuln: starting Wordfence Intelligence feed refresh", slog.String("feed", feedKind))
 
-	// Optionally fetch the Production feed to enrich CVSS / CVE / copyrights.
-	// Errors here are non-fatal: we proceed with whatever the Scanner feed gave us.
-	prodRecords, prodDefiantNotice, prodDefiantLicense, prodMitreNotice, prodErr := w.fetchFeed(ctx, wfProductionURL, apiKey)
-	if prodErr != nil {
-		w.logger.Warn("vuln: production feed fetch failed; proceeding with scanner-only data",
-			slog.Any("error", prodErr))
-	} else {
-		// Merge production enrichment into scanner records: CVSS, CVE, CWE, refs,
-		// and copyrights (production feed has a richer copyrights block).
-		records = mergeEnrichment(records, prodRecords)
-		if prodDefiantNotice != "" {
-			defiantNotice = prodDefiantNotice
+	records, defiantNotice, defiantLicense, mitreNotice, err := w.fetchFeed(ctx, feedURL, apiKey)
+	if err != nil {
+		if errors.Is(err, errRateLimited) {
+			// Do NOT retry inside this cycle: a globally rate-limited window
+			// cannot be escaped by an immediate retry. Stamp degraded and let
+			// the next scheduled run — which targets the ALTERNATE feed and is
+			// naturally ~1 hour away — recover. A Production rate-limit must
+			// NOT flip the detection ok flag (RescanSite gates on it); a
+			// Scanner rate-limit legitimately does, matching prior behavior.
+			msg := fmt.Sprintf("%s feed rate limited by Wordfence; will retry on the next scheduled refresh", feedKind)
+			if feedKind == FeedKindProduction {
+				_ = w.repo.StampEnrichmentDegraded(ctx, msg)
+			} else {
+				_ = w.repo.StampFeedError(ctx, msg)
+			}
+			w.logger.Warn("vuln: feed rate limited; skipping this cycle (no in-window retry)",
+				slog.String("feed", feedKind))
+			return nil
 		}
-		if prodDefiantLicense != "" {
-			defiantLicense = prodDefiantLicense
-		}
-		if prodMitreNotice != "" {
-			mitreNotice = prodMitreNotice
-		}
+		errMsg := fmt.Sprintf("%s feed fetch failed: %v", feedKind, err)
+		_ = w.repo.StampFeedError(ctx, errMsg)
+		return fmt.Errorf("vuln feed refresh (%s): %w", feedKind, err) // River will retry real failures
 	}
 
 	if len(records) == 0 {
-		_ = w.repo.StampFeedError(ctx, "feed returned zero records; not applying update")
-		w.logger.Warn("vuln: feed returned zero records; skipping update")
+		// A zero-record response counts as "no enrichment" for a Production
+		// run (per WP2 spec) but must not touch the detection ok flag — the
+		// Scanner-driven catalog from the last successful Scanner run is still
+		// perfectly valid. A zero-record Scanner response is treated as before
+		// (ok=false): it means we have no usable detection catalog this cycle.
+		msg := fmt.Sprintf("%s feed returned zero records; not applying update", feedKind)
+		if feedKind == FeedKindProduction {
+			_ = w.repo.StampEnrichmentDegraded(ctx, msg)
+		} else {
+			_ = w.repo.StampFeedError(ctx, msg)
+		}
+		w.logger.Warn("vuln: " + msg)
 		return nil
 	}
 
@@ -209,23 +240,36 @@ func (w *FeedWorker) Work(ctx context.Context, job *river.Job[FeedRefreshArgs]) 
 		knownIDs = append(knownIDs, id)
 	}
 
-	pgErr := w.ingestRecords(ctx, records, knownIDs, FeedMetaUpdate{
-		FetchedAt:      time.Now().UTC(),
+	now := time.Now().UTC()
+	meta := FeedMetaUpdate{
+		FetchedAt:      now,
 		OK:             true,
 		RecordCount:    len(records),
 		DefiantNotice:  defiantNotice,
 		DefiantLicense: defiantLicense,
 		MitreNotice:    mitreNotice,
-	})
+	}
+	if feedKind == FeedKindProduction {
+		// len(records) > 0 is already established above, so this run
+		// successfully enriched at least one record.
+		enrichOK := true
+		meta.EnrichmentOK = &enrichOK
+		meta.LastEnrichmentAt = &now
+	}
+
+	pgErr := w.ingestRecords(ctx, records, knownIDs, meta, feedKind)
 	if pgErr != nil {
 		_ = w.repo.StampFeedError(ctx, pgErr.Error())
-		return fmt.Errorf("vuln: ingest records: %w", pgErr)
+		return fmt.Errorf("vuln: ingest records (%s): %w", feedKind, pgErr)
 	}
 
 	w.logger.Info("vuln: feed refresh complete",
-		slog.Int("records", len(records)))
+		slog.String("feed", feedKind), slog.Int("records", len(records)))
 
 	// Trigger a cross-tenant rescan (throttled: enqueues per-site River jobs).
+	// This runs after BOTH a Scanner ingest (new/changed detection data) and a
+	// Production ingest (newly-landed CVSS can upgrade findings out of the
+	// "unknown" severity bucket), so enrichment becomes visible promptly.
 	if err := w.svc.RescanAll(ctx, uuid.Nil); err != nil {
 		w.logger.Warn("vuln: post-feed rescan-all enqueue failed", slog.Any("error", err))
 	}
@@ -237,14 +281,27 @@ func (w *FeedWorker) Work(ctx context.Context, job *river.Job[FeedRefreshArgs]) 
 // bulk operations. The previous per-record loop (13k × DELETE+INSERT round-trips)
 // exceeded the River context deadline; the bulk path replaces that with:
 //
-//  1. A pgx Batch that sends all feed-row upserts in a single round-trip.
-//  2. A set-based DELETE of software rows for every vuln_id in the batch, then
-//     a single CopyFrom that streams all new software rows to Postgres.
-//  3. PruneMissingVulns (single set-based DELETE of retracted vulns).
+//  1. A pgx Batch that sends all feed-row upserts in a single round-trip. The
+//     upsert is STICKY for the enrichment columns (cvss_score, cvss_rating,
+//     cve, cve_link, cwe, reference_urls — see Repo.BulkUpsertFeedRecords): a
+//     Scanner run's records typically carry no CVSS data and no references at
+//     all, and a blind overwrite would erase whatever a prior Production run
+//     had already populated, flapping every finding's severity AND reference
+//     link-outs between real values and empty/"unknown" every other hour
+//     (GH #245 reintroduced).
+//  2. Scanner runs ONLY: a set-based DELETE of software rows for every
+//     vuln_id in the batch, then a single CopyFrom that streams all new
+//     software rows to Postgres.
+//  3. Scanner runs ONLY: PruneMissingVulns (single set-based DELETE of
+//     retracted vulns). Production's ID set is a proper SUBSET of Scanner's
+//     (it omits brand-new unrated entries), so running this off a Production
+//     batch would incorrectly delete legitimate Scanner-only rows every other
+//     cycle. Production ONLY enriches rows that already exist (or are
+//     inserted fresh via step 1) — it never determines existence.
 //  4. StampFeedMeta (single UPDATE).
 //
 // The entire operation is one transaction — atomic, with no partial state.
-func (w *FeedWorker) ingestRecords(ctx context.Context, records map[string]FeedRecord, knownIDs []string, meta FeedMetaUpdate) error {
+func (w *FeedWorker) ingestRecords(ctx context.Context, records map[string]FeedRecord, knownIDs []string, meta FeedMetaUpdate, feedKind string) error {
 	// Flatten the map into a slice for deterministic ordering (maps in Go are
 	// unordered; a slice makes the Batch and CopyFrom reproducible for debugging).
 	recs := make([]FeedRecord, 0, len(records))
@@ -266,11 +323,13 @@ func (w *FeedWorker) ingestRecords(ctx context.Context, records map[string]FeedR
 	if err := w.repo.BulkUpsertFeedRecords(ctx, tx, recs); err != nil {
 		return err
 	}
-	if err := w.repo.BulkReplaceAllSoftware(ctx, tx, recs); err != nil {
-		return err
-	}
-	if err := w.repo.PruneMissingVulns(ctx, tx, knownIDs); err != nil {
-		return err
+	if feedKind == FeedKindScanner {
+		if err := w.repo.BulkReplaceAllSoftware(ctx, tx, recs); err != nil {
+			return err
+		}
+		if err := w.repo.PruneMissingVulns(ctx, tx, knownIDs); err != nil {
+			return err
+		}
 	}
 	if err := w.repo.StampFeedMeta(ctx, tx, meta); err != nil {
 		return err
@@ -305,37 +364,16 @@ func (w *FeedWorker) fetchFeed(ctx context.Context, feedURL, apiKey string) (map
 		// and returned to the superadmin via the status endpoint).
 		return nil, "", "", "", fmt.Errorf("feed auth failed (HTTP %d): check the Wordfence Intelligence API key in the superadmin settings", resp.StatusCode)
 	case http.StatusTooManyRequests:
-		// Honor Retry-After if present; one retry then fall back.
-		retryAfter := resp.Header.Get("Retry-After")
-		delay := 10 * time.Second
-		if retryAfter != "" {
-			if d, parseErr := time.ParseDuration(retryAfter + "s"); parseErr == nil && d > 0 && d <= 30*time.Second {
-				delay = d
-			}
-		}
-		w.logger.Debug("vuln: rate limited; retrying after delay",
-			slog.String("url", feedURL), slog.Duration("delay", delay))
-		time.Sleep(delay)
-
-		// Single retry.
-		req2, rerr := http.NewRequestWithContext(ctx, http.MethodGet, feedURL, nil)
-		if rerr != nil {
-			return nil, "", "", "", fmt.Errorf("rate limited (429) fetching %s: %w", feedURL, errRateLimited)
-		}
-		req2.Header.Set("Authorization", "Bearer "+apiKey)
-		req2.Header.Set("Accept", "application/json")
-		req2.Header.Set("User-Agent", "WPMgr-VulnScanner/1.0")
-		resp2, rerr := w.client.Do(req2)
-		if rerr != nil || resp2.StatusCode != http.StatusOK {
-			if resp2 != nil {
-				_ = resp2.Body.Close()
-			}
-			return nil, "", "", "", fmt.Errorf("rate limited (429) fetching %s: %w", feedURL, errRateLimited)
-		}
-		// Swap to the retry response for decoding below.
-		_ = resp.Body.Close()
-		resp = resp2
-		defer func() { _ = resp.Body.Close() }()
+		// Do NOT retry inside this cycle: Wordfence's rate limit is a ~30-minute
+		// GLOBAL window per API key with no documented Retry-After and no fixed
+		// per-window count, so an immediate in-process retry cannot escape the
+		// window it is already inside — it only burns a second request and
+		// keeps the window warm (this was the direct mechanism behind GH #245:
+		// the Production fetch was always the second request in the same
+		// cycle, so it 429'd every time). The caller stamps degraded status and
+		// returns; the next scheduled run — which alternates to the OTHER feed
+		// via NextFeedKind — is the well-spaced retry.
+		return nil, "", "", "", fmt.Errorf("rate limited (429) fetching %s: %w", feedURL, errRateLimited)
 	default:
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		return nil, "", "", "", fmt.Errorf("unexpected status %d from %s: %s", resp.StatusCode, feedURL, body)
@@ -475,8 +513,42 @@ type wfRecord struct {
 
 // wfCVSS is the object shape inside the "cvss" key of the Production feed.
 type wfCVSS struct {
-	Score  *float64 `json:"score"`
-	Rating string   `json:"rating"`
+	Score  wfFlexFloat `json:"score"`
+	Rating string      `json:"rating"`
+}
+
+// wfFlexFloat tolerates a CVSS score encoded as either a JSON number
+// (9.8) or a stringified number ("9.8") — the feed has been observed sending
+// both shapes. UnmarshalJSON is intentionally lenient, mirroring wfTime: an
+// absent, null, empty, or unparseable value yields a nil score and never an
+// error, so one odd score field can never drop the whole record or discard a
+// sibling field (e.g. rating) that decoded fine.
+type wfFlexFloat struct{ v *float64 }
+
+func (f *wfFlexFloat) UnmarshalJSON(b []byte) error {
+	f.v = nil
+	s := strings.TrimSpace(string(b))
+	if s == "" || s == "null" {
+		return nil
+	}
+	// Try a JSON number first (the real v3 shape).
+	var num float64
+	if err := json.Unmarshal(b, &num); err == nil {
+		f.v = &num
+		return nil
+	}
+	// Tolerate a stringified number.
+	var str string
+	if err := json.Unmarshal(b, &str); err == nil {
+		str = strings.TrimSpace(str)
+		if str == "" {
+			return nil
+		}
+		if parsed, perr := strconv.ParseFloat(str, 64); perr == nil {
+			f.v = &parsed
+		}
+	}
+	return nil // unrecognised shape → nil score, record still ingests
 }
 
 // wfCopyrightEntry holds one party's attribution data.
@@ -536,16 +608,28 @@ func extractCVE(raw json.RawMessage) string {
 // The real v3 feed sends an object {vector, score, rating}; for forward
 // tolerance, a bare number is also accepted as a score-only value.
 // Returns (nil, "") on null/absent/unparseable input.
+//
+// Two hardening fixes (GH #245 follow-up): (1) a rating is honored even when
+// score is absent/null — an object like {"rating":"Critical"} with no score
+// field previously fell through this function entirely and lost the rating;
+// (2) score tolerates a stringified number ("9.8") via wfFlexFloat, which
+// previously made the WHOLE cvss object fail to unmarshal (json.Unmarshal
+// aborts a struct decode on any field type mismatch), silently discarding a
+// present rating too.
 func extractCVSS(raw json.RawMessage) (score *float64, rating string) {
 	if len(raw) == 0 || string(raw) == "null" {
 		return nil, ""
 	}
-	// Try object {score, rating} first (real v3 format).
+	// Object shape {score, rating} — the real v3 format. This unmarshal only
+	// succeeds when raw is structurally a JSON object (a bare number or array
+	// fails here and falls through to the tolerance branch below), so it is
+	// safe to return whatever fields are present without also requiring
+	// Score to be non-nil.
 	var obj wfCVSS
-	if json.Unmarshal(raw, &obj) == nil && obj.Score != nil {
-		return obj.Score, obj.Rating
+	if json.Unmarshal(raw, &obj) == nil {
+		return obj.Score.v, obj.Rating
 	}
-	// Forward-tolerance: bare number.
+	// Forward-tolerance: bare number (score-only, no object wrapper).
 	var f float64
 	if json.Unmarshal(raw, &f) == nil {
 		return &f, ""
@@ -782,41 +866,6 @@ func normalisePatchedVersions(raw []byte) []byte {
 		return b
 	}
 	return []byte("[]")
-}
-
-// mergeEnrichment copies CVSS, CVE, CWE, references, and copyrights from
-// the production records into the scanner records.  The scanner feed is the
-// canonical detection authority; production enriches display fields only.
-func mergeEnrichment(scanner, production map[string]FeedRecord) map[string]FeedRecord {
-	for id, prod := range production {
-		sc, ok := scanner[id]
-		if !ok {
-			// Production has records not in Scanner (older/retracted); skip.
-			continue
-		}
-		if sc.CVSSScore == nil && prod.CVSSScore != nil {
-			sc.CVSSScore = prod.CVSSScore
-		}
-		if sc.CVSSRating == "" && prod.CVSSRating != "" {
-			sc.CVSSRating = prod.CVSSRating
-		}
-		if sc.CVE == "" && prod.CVE != "" {
-			sc.CVE = prod.CVE
-		}
-		if sc.CVELink == "" && prod.CVELink != "" {
-			sc.CVELink = prod.CVELink
-		}
-		if len(sc.CWE) == 0 && len(prod.CWE) > 0 {
-			sc.CWE = prod.CWE
-		}
-		if string(sc.References) == "[]" && string(prod.References) != "[]" && len(prod.References) > 0 {
-			sc.References = prod.References
-		}
-		// Use the production raw for the stored snapshot (richer data).
-		sc.Raw = prod.Raw
-		scanner[id] = sc
-	}
-	return scanner
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/vuln/worker_test.go
+++ b/apps/api/internal/vuln/worker_test.go
@@ -418,6 +418,77 @@ func TestParseFeedRecord_CVSSObject(t *testing.T) {
 	}
 }
 
+// TestParseFeedRecord_CVSSRatingWithoutScore is the GH #245 follow-up
+// hardening guard: an object like {"rating":"Critical"} with no score field
+// must NOT be discarded. Before the fix, extractCVSS gated the whole object
+// branch on obj.Score != nil, so a rating-without-score record silently lost
+// its rating (and would have fallen back into SeverityFromRating's honest
+// "unknown" bucket even though a real rating string was present on the wire).
+func TestParseFeedRecord_CVSSRatingWithoutScore(t *testing.T) {
+	raw := json.RawMessage(`{
+		"title": "Rating without score",
+		"software": [{"type":"plugin","slug":"plug","affected_versions":{},"patched":false,"patched_versions":[]}],
+		"cvss": {"rating": "Critical"}
+	}`)
+	rec, _, _, _, err := vuln.ParseFeedRecord("rating-no-score", raw)
+	if err != nil {
+		t.Fatalf("parseFeedRecord error: %v", err)
+	}
+	if rec.CVSSScore != nil {
+		t.Errorf("CVSSScore = %v; want nil (absent from the object)", rec.CVSSScore)
+	}
+	if rec.CVSSRating != "Critical" {
+		t.Errorf("CVSSRating = %q; want %q (must survive a missing score)", rec.CVSSRating, "Critical")
+	}
+}
+
+// TestParseFeedRecord_CVSSStringifiedScore is the second GH #245 follow-up
+// hardening guard: a stringified score ("9.8" instead of 9.8) must not cause
+// the WHOLE cvss object unmarshal to fail — json.Unmarshal aborts a struct
+// decode on any field type mismatch, so a stringified score previously
+// discarded a co-present rating too.
+func TestParseFeedRecord_CVSSStringifiedScore(t *testing.T) {
+	raw := json.RawMessage(`{
+		"title": "Stringified score",
+		"software": [{"type":"plugin","slug":"plug","affected_versions":{},"patched":false,"patched_versions":[]}],
+		"cvss": {"score": "9.8", "rating": "Critical"}
+	}`)
+	rec, _, _, _, err := vuln.ParseFeedRecord("stringified-score", raw)
+	if err != nil {
+		t.Fatalf("parseFeedRecord error: %v", err)
+	}
+	if rec.CVSSScore == nil {
+		t.Fatal("CVSSScore is nil; want 9.8 (stringified score must be tolerated)")
+	}
+	if *rec.CVSSScore != 9.8 {
+		t.Errorf("CVSSScore = %v; want 9.8", *rec.CVSSScore)
+	}
+	if rec.CVSSRating != "Critical" {
+		t.Errorf("CVSSRating = %q; want %q (must survive a stringified score sibling field)", rec.CVSSRating, "Critical")
+	}
+}
+
+// TestParseFeedRecord_CVSSStringifiedScore_Unparseable verifies a garbage
+// stringified score degrades to a nil score (never an error / dropped record)
+// while still preserving a co-present rating.
+func TestParseFeedRecord_CVSSStringifiedScore_Unparseable(t *testing.T) {
+	raw := json.RawMessage(`{
+		"title": "Garbage stringified score",
+		"software": [{"type":"plugin","slug":"plug","affected_versions":{},"patched":false,"patched_versions":[]}],
+		"cvss": {"score": "not-a-number", "rating": "High"}
+	}`)
+	rec, _, _, _, err := vuln.ParseFeedRecord("garbage-score", raw)
+	if err != nil {
+		t.Fatalf("parseFeedRecord error: %v", err)
+	}
+	if rec.CVSSScore != nil {
+		t.Errorf("CVSSScore = %v; want nil (unparseable string)", rec.CVSSScore)
+	}
+	if rec.CVSSRating != "High" {
+		t.Errorf("CVSSRating = %q; want %q", rec.CVSSRating, "High")
+	}
+}
+
 func TestParseFeedRecord_CVSSNull(t *testing.T) {
 	raw := json.RawMessage(`{
 		"title": "No CVSS",

--- a/apps/api/migrations/20260803000000_m101_vuln_severity_unknown_feed_alternation.sql
+++ b/apps/api/migrations/20260803000000_m101_vuln_severity_unknown_feed_alternation.sql
@@ -1,0 +1,55 @@
+-- m101 — GH #245: honest-unknown severity fallback + Wordfence feed alternation.
+--
+-- Root cause: Wordfence Intelligence v3 enforces ~1 request / 30 min GLOBALLY
+-- per API key. The feed worker fetched the Scanner feed then slept only 2s
+-- before fetching the Production feed in the SAME run, so Production was
+-- deterministically 429'd every cycle. mergeEnrichment therefore never ran:
+-- every site_vulnerabilities row was stored with cvss_score = NULL and
+-- cvss_rating = '', and SeverityFromRating's unconditional "no data" fallback
+-- silently bucketed that as 'low' — including a real CVSS 9.8 core RCE.
+--
+-- Fix (application-side; this migration only widens storage for it):
+--   1. SeverityFromRating (internal/vuln/model.go) now returns 'unknown', not
+--      'low', when neither a rating nor a score is available — a "no data"
+--      finding must never be silently indistinguishable from a confirmed-low
+--      one. The severity CHECK constraint is widened to allow the new value.
+--   2. The feed worker (internal/vuln/worker.go) now alternates Scanner and
+--      Production across successive hourly runs — one HTTP request per run —
+--      via the persisted next_feed_kind cursor below, instead of fetching
+--      both feeds in the same run. This keeps every run comfortably clear of
+--      the ~30-min rate-limit window, so Production (which carries the
+--      CVSS/CVE/CWE enrichment) actually lands.
+--   3. enrichment_ok/last_enrichment_at track the Production-fetch pipeline's
+--      health independently of the pre-existing ok/fetched_at/record_count
+--      fields (which track Scanner-driven DETECTION freshness and gate
+--      RescanSite) — a Production hiccup must never block detection rescans.
+--
+-- next_feed_kind is internal worker state only; it is never exposed via the
+-- API (see admin.VulnFeedStatus / vuln.FeedMeta, which surface enrichment_ok/
+-- last_enrichment_at instead).
+--
+-- Idempotent throughout: ADD COLUMN IF NOT EXISTS (mirrors m92/m93) and
+-- DROP CONSTRAINT IF EXISTS + ADD CONSTRAINT (mirrors m87's cadence-widen).
+
+ALTER TABLE "public"."wordfence_vuln_feed_meta"
+    ADD COLUMN IF NOT EXISTS "enrichment_ok" boolean NOT NULL DEFAULT false;
+ALTER TABLE "public"."wordfence_vuln_feed_meta"
+    ADD COLUMN IF NOT EXISTS "last_enrichment_at" timestamptz;
+ALTER TABLE "public"."wordfence_vuln_feed_meta"
+    ADD COLUMN IF NOT EXISTS "next_feed_kind" text NOT NULL DEFAULT 'scanner';
+
+ALTER TABLE "public"."wordfence_vuln_feed_meta"
+    DROP CONSTRAINT IF EXISTS "wordfence_vuln_feed_meta_next_feed_chk";
+ALTER TABLE "public"."wordfence_vuln_feed_meta"
+    ADD CONSTRAINT "wordfence_vuln_feed_meta_next_feed_chk"
+    CHECK ("next_feed_kind" IN ('scanner', 'production'));
+
+-- Widen the severity CHECK to allow the new honest-unknown bucket. Must land
+-- before any code path writes 'unknown' — migrations apply on boot before the
+-- HTTP/worker layer starts serving, so a single deploy is always ordered
+-- correctly.
+ALTER TABLE "public"."site_vulnerabilities"
+    DROP CONSTRAINT IF EXISTS "site_vulnerabilities_severity_chk";
+ALTER TABLE "public"."site_vulnerabilities"
+    ADD CONSTRAINT "site_vulnerabilities_severity_chk"
+    CHECK ("severity" IN ('critical', 'high', 'medium', 'low', 'unknown'));

--- a/apps/api/tests/vuln_feed_alternation_integration_test.go
+++ b/apps/api/tests/vuln_feed_alternation_integration_test.go
@@ -1,0 +1,554 @@
+// Integration tests for GH #245 — the Wordfence Intelligence feed fetch fix.
+//
+// Root cause: Wordfence Intelligence v3 enforces ~1 request / 30 min GLOBALLY
+// per API key. The feed worker used to fetch Scanner then, after only a 2s
+// sleep, fetch Production in the SAME run — Production was deterministically
+// 429'd every cycle, so CVSS/CVE enrichment never landed and every finding
+// fell back to a fabricated "low" severity (SeverityFromRating's unconditional
+// no-data fallback), hiding a real CVSS 9.8 core RCE.
+//
+// These tests drive vuln.FeedWorker.Work end-to-end against a real Postgres
+// (migrations + RLS applied) with a fake HTTP client standing in for the
+// Wordfence API, proving:
+//   - each Work() invocation issues at most one HTTP request (alternation);
+//   - a Production fetch that lands CVSS data actually persists it in
+//     wordfence_vuln_feed (not just that an internal merge function ran);
+//   - a subsequent Scanner-only run does NOT null out that CVSS data
+//     (sticky enrichment — get this wrong and severities flap
+//     Unknown<->Critical every other hour, reintroducing #245 intermittently);
+//   - a 429 on the Production leg degrades enrichment_ok without an in-window
+//     retry and WITHOUT affecting the detection-feed ok flag (which gates
+//     RescanSite).
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/vuln"
+)
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+// fakeFeedHTTPClient implements vuln.FeedHTTPDoer, returning a canned response
+// per URL and recording every request it receives (in order) so tests can
+// assert the exact number and target of HTTP calls made per Work() cycle.
+type fakeFeedHTTPClient struct {
+	mu        sync.Mutex
+	calls     []string
+	responses map[string]func() (int, string) // URL -> (status, body) thunk
+}
+
+func newFakeFeedHTTPClient() *fakeFeedHTTPClient {
+	return &fakeFeedHTTPClient{responses: map[string]func() (int, string){}}
+}
+
+func (c *fakeFeedHTTPClient) setResponse(url string, status int, body string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.responses[url] = func() (int, string) { return status, body }
+}
+
+func (c *fakeFeedHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	c.mu.Lock()
+	url := req.URL.String()
+	c.calls = append(c.calls, url)
+	thunk, ok := c.responses[url]
+	c.mu.Unlock()
+
+	status, body := http.StatusOK, `{}`
+	if ok {
+		status, body = thunk()
+	}
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func (c *fakeFeedHTTPClient) callCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.calls)
+}
+
+func (c *fakeFeedHTTPClient) lastCall() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.calls) == 0 {
+		return ""
+	}
+	return c.calls[len(c.calls)-1]
+}
+
+// noopSiteLoader satisfies vuln.SiteLoader. It is never actually exercised by
+// these tests: RescanAll(ctx, uuid.Nil) enumerates tenants first and a fresh
+// migrated test DB has none, so the per-tenant ListAllSiteIDs fan-out never
+// runs. It exists only to satisfy vuln.NewService's constructor.
+type noopSiteLoader struct{}
+
+func (noopSiteLoader) GetSiteForVuln(_ context.Context, _, _ uuid.UUID) (vuln.SiteSnapshot, error) {
+	return vuln.SiteSnapshot{}, nil
+}
+
+func (noopSiteLoader) ListAllSiteIDs(_ context.Context, _ uuid.UUID) ([]uuid.UUID, error) {
+	return nil, nil
+}
+
+// noopRescanEnqueuer satisfies vuln.RescanEnqueuer for the same reason.
+type noopRescanEnqueuer struct{}
+
+func (noopRescanEnqueuer) EnqueueRescanSite(_ context.Context, _ vuln.RescanSiteArgs) error {
+	return nil
+}
+
+// buildFeedWorker wires a *vuln.FeedWorker against the real pool + a fake
+// HTTP client, mirroring the production wiring in cmd/wpmgr/main.go.
+func buildFeedWorker(pool *db.Pool, client *fakeFeedHTTPClient) *vuln.FeedWorker {
+	logger := slog.Default()
+	repo := vuln.NewRepo(pool)
+	svc := vuln.NewService(repo, pool, noopSiteLoader{}, nil, noopRescanEnqueuer{}, logger)
+	resolver := vuln.NewStaticKeyResolver("test-wordfence-key-1234")
+	return vuln.NewFeedWorker(repo, pool, svc, resolver, client, logger)
+}
+
+func runFeedWork(t *testing.T, w *vuln.FeedWorker) error {
+	t.Helper()
+	return w.Work(context.Background(), &river.Job[vuln.FeedRefreshArgs]{})
+}
+
+// ---------------------------------------------------------------------------
+// Fixture feed bodies
+// ---------------------------------------------------------------------------
+
+// scannerBodyNoCVSS is a Scanner-shaped response: a single vuln record with
+// software but NO cvss key at all (the real Scanner feed never carries CVSS).
+func scannerBodyNoCVSS(vulnID string) string {
+	return `{"` + vulnID + `": {
+		"title": "Test Plugin XSS",
+		"software": [
+			{"type":"plugin","slug":"test-plugin","affected_versions":{"* - 2.0.0":{"from_version":"*","from_inclusive":true,"to_version":"2.0.0","to_inclusive":false}},"patched":true,"patched_versions":["2.0.1"]}
+		]
+	}}`
+}
+
+// productionBodyReferenceURL is the reference URL carried by
+// productionBodyWithCVSS below, used by tests that assert on reference_urls.
+const productionBodyReferenceURL = "https://www.wordfence.com/threat-intel/vulnerabilities/test"
+
+// productionBodyWithCVSS is a Production-shaped response for the SAME
+// vuln_id, carrying a full cvss object + cve + a reference URL — the
+// enrichment data Scanner never sends (scannerBodyNoCVSS above carries
+// neither a "cvss" key nor a "references" key, matching the real feeds).
+func productionBodyWithCVSS(vulnID string) string {
+	return `{"` + vulnID + `": {
+		"title": "Test Plugin XSS",
+		"software": [
+			{"type":"plugin","slug":"test-plugin","affected_versions":{"* - 2.0.0":{"from_version":"*","from_inclusive":true,"to_version":"2.0.0","to_inclusive":false}},"patched":true,"patched_versions":["2.0.1"]}
+		],
+		"cvss": {"vector":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H","score":9.8,"rating":"Critical"},
+		"cve": "CVE-2026-24500",
+		"references": ["` + productionBodyReferenceURL + `"]
+	}}`
+}
+
+func feedRow(t *testing.T, pool *db.Pool, vulnID string) (cvssScore *float64, cvssRating, cve string) {
+	t.Helper()
+	var score *float64
+	var rating, cveVal *string
+	err := pool.QueryRow(context.Background(),
+		`SELECT cvss_score, cvss_rating, cve FROM wordfence_vuln_feed WHERE vuln_id = $1`,
+		vulnID,
+	).Scan(&score, &rating, &cveVal)
+	if err != nil {
+		t.Fatalf("select wordfence_vuln_feed row: %v", err)
+	}
+	r, c := "", ""
+	if rating != nil {
+		r = *rating
+	}
+	if cveVal != nil {
+		c = *cveVal
+	}
+	return score, r, c
+}
+
+// feedReferenceURLs reads and decodes wordfence_vuln_feed.reference_urls for vulnID.
+func feedReferenceURLs(t *testing.T, pool *db.Pool, vulnID string) []string {
+	t.Helper()
+	var raw []byte
+	if err := pool.QueryRow(context.Background(),
+		`SELECT reference_urls FROM wordfence_vuln_feed WHERE vuln_id = $1`, vulnID,
+	).Scan(&raw); err != nil {
+		t.Fatalf("select reference_urls: %v", err)
+	}
+	var urls []string
+	if err := json.Unmarshal(raw, &urls); err != nil {
+		t.Fatalf("unmarshal reference_urls (%s): %v", raw, err)
+	}
+	return urls
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: alternation — at most one HTTP request per Work() cycle, and
+// successive cycles target the OTHER feed.
+// ---------------------------------------------------------------------------
+
+func TestFeedWorker_AlternatesFeedsOneRequestPerRun(t *testing.T) {
+	pool := startPostgres(t)
+	client := newFakeFeedHTTPClient()
+	client.setResponse(vuln.ScannerFeedURL, http.StatusOK, scannerBodyNoCVSS("245-alt-vuln-1"))
+	client.setResponse(vuln.ProductionFeedURL, http.StatusOK, productionBodyWithCVSS("245-alt-vuln-1"))
+
+	w := buildFeedWorker(pool, client)
+
+	// The alternation cursor defaults to 'scanner' (schema default), so run 1
+	// must hit the Scanner URL and run 2 must hit Production, run 3 back to
+	// Scanner — and each run must issue EXACTLY one HTTP request.
+	wantSequence := []string{vuln.ScannerFeedURL, vuln.ProductionFeedURL, vuln.ScannerFeedURL}
+	for i, wantURL := range wantSequence {
+		before := client.callCount()
+		if err := runFeedWork(t, w); err != nil {
+			t.Fatalf("run %d: Work returned error: %v", i+1, err)
+		}
+		after := client.callCount()
+		if after-before != 1 {
+			t.Errorf("run %d: made %d HTTP request(s); want exactly 1 (Wordfence enforces ~1 request/30min globally)", i+1, after-before)
+		}
+		if got := client.lastCall(); got != wantURL {
+			t.Errorf("run %d: fetched %q; want %q", i+1, got, wantURL)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: a successful Production fetch actually lands CVSS end-to-end (not
+// just that some internal merge function ran).
+// ---------------------------------------------------------------------------
+
+func TestFeedWorker_ProductionFetch_CVSSLandsEndToEnd(t *testing.T) {
+	pool := startPostgres(t)
+	const vulnID = "245-e2e-vuln-1"
+	client := newFakeFeedHTTPClient()
+	client.setResponse(vuln.ScannerFeedURL, http.StatusOK, scannerBodyNoCVSS(vulnID))
+	client.setResponse(vuln.ProductionFeedURL, http.StatusOK, productionBodyWithCVSS(vulnID))
+
+	w := buildFeedWorker(pool, client)
+
+	// Run 1: Scanner creates the detection row with NO cvss data yet.
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 1 (scanner): %v", err)
+	}
+	score, rating, cve := feedRow(t, pool, vulnID)
+	if score != nil || rating != "" || cve != "" {
+		t.Fatalf("after scanner-only run: score=%v rating=%q cve=%q; want all empty (scanner never carries CVSS)", score, rating, cve)
+	}
+
+	// Run 2: Production enriches the SAME row.
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 2 (production): %v", err)
+	}
+	score, rating, cve = feedRow(t, pool, vulnID)
+	if score == nil {
+		t.Fatal("after production run: cvss_score is nil; want 9.8 (CVSS must land end-to-end, not just merge-called)")
+	}
+	if *score != 9.8 {
+		t.Errorf("cvss_score = %v; want 9.8", *score)
+	}
+	if rating != "Critical" {
+		t.Errorf("cvss_rating = %q; want %q", rating, "Critical")
+	}
+	if cve != "CVE-2026-24500" {
+		t.Errorf("cve = %q; want %q", cve, "CVE-2026-24500")
+	}
+
+	// Feed meta must reflect a successful enrichment.
+	meta, err := vuln.NewRepo(pool).GetFeedMeta(context.Background())
+	if err != nil {
+		t.Fatalf("GetFeedMeta: %v", err)
+	}
+	if !meta.EnrichmentOK {
+		t.Error("meta.EnrichmentOK = false; want true after a successful production ingest")
+	}
+	if meta.LastEnrichmentAt == nil {
+		t.Error("meta.LastEnrichmentAt is nil; want a timestamp after a successful production ingest")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: sticky enrichment — a Scanner run AFTER a Production run must NOT
+// null out the CVSS data Production already landed.
+// ---------------------------------------------------------------------------
+
+func TestFeedWorker_StickyEnrichment_ScannerRunPreservesCVSS(t *testing.T) {
+	pool := startPostgres(t)
+	const vulnID = "245-sticky-vuln-1"
+	client := newFakeFeedHTTPClient()
+	client.setResponse(vuln.ScannerFeedURL, http.StatusOK, scannerBodyNoCVSS(vulnID))
+	client.setResponse(vuln.ProductionFeedURL, http.StatusOK, productionBodyWithCVSS(vulnID))
+
+	w := buildFeedWorker(pool, client)
+
+	// Run 1: scanner (no cvss). Run 2: production (cvss lands).
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 1 (scanner): %v", err)
+	}
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 2 (production): %v", err)
+	}
+	score, rating, _ := feedRow(t, pool, vulnID)
+	if score == nil || rating != "Critical" {
+		t.Fatalf("precondition failed: score=%v rating=%q after production run; want 9.8/Critical", score, rating)
+	}
+
+	// Run 3: scanner AGAIN, re-sending the SAME record with no cvss key. This
+	// is exactly the flap scenario GH #245's follow-up warns about: a naive
+	// blind-overwrite upsert would null cvss_score/cvss_rating right back out.
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 3 (scanner again): %v", err)
+	}
+	score, rating, _ = feedRow(t, pool, vulnID)
+	if score == nil {
+		t.Fatal("after a subsequent scanner-only run: cvss_score is nil; want 9.8 preserved (sticky enrichment)")
+	}
+	if *score != 9.8 {
+		t.Errorf("cvss_score = %v; want 9.8 preserved across the scanner run", *score)
+	}
+	if rating != "Critical" {
+		t.Errorf("cvss_rating = %q; want %q preserved across the scanner run", rating, "Critical")
+	}
+
+	// enrichment_ok must ALSO remain sticky-true (a scanner run must not touch it).
+	meta, err := vuln.NewRepo(pool).GetFeedMeta(context.Background())
+	if err != nil {
+		t.Fatalf("GetFeedMeta: %v", err)
+	}
+	if !meta.EnrichmentOK {
+		t.Error("meta.EnrichmentOK = false after a scanner run; want it to stay sticky-true from the prior production run")
+	}
+}
+
+// TestFeedWorker_StickyEnrichment_ScannerRunPreservesReferences mirrors the
+// CVSS sticky test above for reference_urls — the ONE enrichment column that
+// was still a blind overwrite (adversarial-verify follow-up to GH #245):
+// parseFeedRecord defaults an absent references[] to the non-NULL '[]' jsonb
+// sentinel (never SQL NULL), and the Scanner feed never carries references,
+// so a plain COALESCE against the existing row does nothing — the empty-array
+// sentinel needs its own NULLIF guard. A subsequent Scanner run must NOT blank
+// out reference URLs a prior Production run already landed.
+func TestFeedWorker_StickyEnrichment_ScannerRunPreservesReferences(t *testing.T) {
+	pool := startPostgres(t)
+	const vulnID = "245-sticky-refs-vuln-1"
+	client := newFakeFeedHTTPClient()
+	client.setResponse(vuln.ScannerFeedURL, http.StatusOK, scannerBodyNoCVSS(vulnID))
+	client.setResponse(vuln.ProductionFeedURL, http.StatusOK, productionBodyWithCVSS(vulnID))
+
+	w := buildFeedWorker(pool, client)
+
+	// Run 1: scanner — scannerBodyNoCVSS carries no "references" key at all,
+	// so the stored reference_urls must be the empty-array default.
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 1 (scanner): %v", err)
+	}
+	if refs := feedReferenceURLs(t, pool, vulnID); len(refs) != 0 {
+		t.Fatalf("after scanner-only run: reference_urls = %v; want empty", refs)
+	}
+
+	// Run 2: production lands a real reference URL.
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 2 (production): %v", err)
+	}
+	refs := feedReferenceURLs(t, pool, vulnID)
+	if len(refs) != 1 || refs[0] != productionBodyReferenceURL {
+		t.Fatalf("after production run: reference_urls = %v; want [%s]", refs, productionBodyReferenceURL)
+	}
+
+	// Run 3: scanner AGAIN, re-sending the SAME record with no "references"
+	// key — parseFeedRecord defaults this to a non-NULL '[]' jsonb, which is
+	// exactly the value a naive COALESCE(EXCLUDED.x, existing.x) upsert cannot
+	// distinguish from "no update"; a blind overwrite would erase the URL
+	// Production just landed, making advisory link-outs oscillate every hour.
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 3 (scanner again): %v", err)
+	}
+	refs = feedReferenceURLs(t, pool, vulnID)
+	if len(refs) != 1 || refs[0] != productionBodyReferenceURL {
+		t.Errorf("after a subsequent scanner-only run: reference_urls = %v; want [%s] preserved (sticky enrichment)", refs, productionBodyReferenceURL)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: a 429 on the Production leg degrades enrichment status WITHOUT an
+// in-window retry and WITHOUT affecting the detection ok flag.
+// ---------------------------------------------------------------------------
+
+func TestFeedWorker_ProductionRateLimited_NoInWindowRetry_DetectionUnaffected(t *testing.T) {
+	pool := startPostgres(t)
+	const vulnID = "245-429-vuln-1"
+	client := newFakeFeedHTTPClient()
+	client.setResponse(vuln.ScannerFeedURL, http.StatusOK, scannerBodyNoCVSS(vulnID))
+	client.setResponse(vuln.ProductionFeedURL, http.StatusTooManyRequests, `{"error":"rate limited"}`)
+
+	w := buildFeedWorker(pool, client)
+
+	// Run 1: scanner succeeds, establishing a healthy detection feed.
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 1 (scanner): %v", err)
+	}
+	repo := vuln.NewRepo(pool)
+	meta, err := repo.GetFeedMeta(context.Background())
+	if err != nil {
+		t.Fatalf("GetFeedMeta after run 1: %v", err)
+	}
+	if !meta.OK {
+		t.Fatal("precondition failed: meta.OK = false after a successful scanner run")
+	}
+
+	// Run 2: production is rate-limited (429). Must return nil (no River
+	// retry) and must issue EXACTLY one HTTP request this cycle — no
+	// synchronous in-window retry loop.
+	before := client.callCount()
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 2 (production 429): Work returned an error; want nil (no River retry on a rate limit): %v", err)
+	}
+	after := client.callCount()
+	if after-before != 1 {
+		t.Errorf("run 2: made %d HTTP request(s) on a 429; want exactly 1 (no in-window retry)", after-before)
+	}
+
+	meta, err = repo.GetFeedMeta(context.Background())
+	if err != nil {
+		t.Fatalf("GetFeedMeta after run 2: %v", err)
+	}
+	// Detection freshness (ok) must be UNAFFECTED by a Production hiccup —
+	// otherwise RescanSite would wrongly skip every other hour once
+	// alternation is in play.
+	if !meta.OK {
+		t.Error("meta.OK = false after a Production 429; want true (Scanner-driven detection data is unaffected)")
+	}
+	// Enrichment status must reflect the degradation.
+	if meta.EnrichmentOK {
+		t.Error("meta.EnrichmentOK = true after a Production 429; want false")
+	}
+	if meta.LastError == "" || !strings.Contains(strings.ToLower(meta.LastError), "rate limit") {
+		t.Errorf("meta.LastError = %q; want it to mention the rate limit", meta.LastError)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Repo-level: severity 'unknown' bucket — CHECK constraint, counts, ordering.
+// ---------------------------------------------------------------------------
+
+// TestSeverityUnknown_StorageCountsAndOrdering exercises the full storage
+// path for the new 'unknown' severity bucket (GH #245 WP1):
+//   - the widened CHECK constraint accepts 'unknown' (a pre-migration schema
+//     would 500 on this insert — this is the direct regression guard for
+//     "the widening migration must land before any code writes it");
+//   - FleetOpenCounts tallies it separately;
+//   - the severity ORDER BY ranks it between 'high' and 'medium'.
+func TestSeverityUnknown_StorageCountsAndOrdering(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	repo := vuln.NewRepo(pool)
+
+	tenantID := uuid.New()
+	siteID := uuid.New()
+	insertTenantAndSite(t, pool, tenantID, siteID)
+
+	// One finding per severity bucket, including the new 'unknown' one.
+	severities := []string{
+		vuln.SeverityCritical, vuln.SeverityHigh, vuln.SeverityUnknown,
+		vuln.SeverityMedium, vuln.SeverityLow,
+	}
+	err := pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		for i, sev := range severities {
+			if err := repo.UpsertFinding(ctx, tx, vuln.FindingUpsert{
+				TenantID:         tenantID,
+				SiteID:           siteID,
+				VulnID:           uuid.NewString(),
+				Kind:             "plugin",
+				Slug:             "plug",
+				Name:             "Plug",
+				InstalledVersion: "1.0",
+				Severity:         sev,
+				Title:            "finding " + sev,
+			}); err != nil {
+				return err
+			}
+			_ = i
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed findings (severity CHECK constraint must accept 'unknown'): %v", err)
+	}
+
+	// FleetOpenCounts must tally 'unknown' separately.
+	critical, high, medium, low, unknown, err := repo.FleetOpenCounts(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("FleetOpenCounts: %v", err)
+	}
+	if critical != 1 || high != 1 || medium != 1 || low != 1 || unknown != 1 {
+		t.Errorf("counts = critical=%d high=%d medium=%d low=%d unknown=%d; want 1 each",
+			critical, high, medium, low, unknown)
+	}
+
+	// ORDER BY must rank: critical(1) < high(2) < unknown(3) < medium(4) < low(5).
+	findings, err := repo.ListOpenFindings(ctx, tenantID, siteID)
+	if err != nil {
+		t.Fatalf("ListOpenFindings: %v", err)
+	}
+	if len(findings) != 5 {
+		t.Fatalf("len(findings) = %d; want 5", len(findings))
+	}
+	gotOrder := make([]string, len(findings))
+	for i, f := range findings {
+		gotOrder[i] = f.Severity
+	}
+	wantOrder := []string{
+		vuln.SeverityCritical, vuln.SeverityHigh, vuln.SeverityUnknown,
+		vuln.SeverityMedium, vuln.SeverityLow,
+	}
+	for i := range wantOrder {
+		if gotOrder[i] != wantOrder[i] {
+			t.Errorf("severity order[%d] = %q; want %q (full order: %v)", i, gotOrder[i], wantOrder[i], gotOrder)
+			break
+		}
+	}
+}
+
+// insertTenantAndSite creates the minimal tenant + site rows needed for a
+// site_vulnerabilities FK-satisfying insert.
+func insertTenantAndSite(t *testing.T, pool *db.Pool, tenantID, siteID uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+	if err := pool.InAgentTx(ctx, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO tenants (id, name, slug) VALUES ($1, 'Test Tenant', $2)`,
+			tenantID, "test-tenant-"+tenantID.String(),
+		); err != nil {
+			return err
+		}
+		_, err := tx.Exec(ctx,
+			`INSERT INTO sites (id, tenant_id, name, url) VALUES ($1, $2, 'Test Site', 'https://example.com')`,
+			siteID, tenantID,
+		)
+		return err
+	}); err != nil {
+		t.Fatalf("seed tenant/site: %v", err)
+	}
+}

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,17 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.72",
+    date: "2026-07-19",
+    summary: "Vulnerability severities are now accurate, with an honest state when severity data is unavailable.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Vulnerability findings no longer all show as \"Low\" (GH #245). A request-spacing bug rate-limited the severity-enrichment feed on every sync, so every finding was stored without a CVSS score and fell back to the lowest severity, meaning a critical core vulnerability could appear with a \"Low\" badge. Severities now populate correctly. A finding with genuinely no severity data is shown as \"Unknown\", ranked for attention rather than hidden as Low, and when the enrichment feed is unreachable the Vulnerabilities page and admin feed status say so explicitly.",
+      },
+    ],
+  },
+  {
     version: "0.61.70 - 0.61.71",
     date: "2026-07-18",
     summary: "Honest cache reporting, working configuration dots, and a complete API reference.",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.71 / open source",
+  badge: "v0.61.72 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/apps/web/src/components/status/vuln-severity-chip.test.tsx
+++ b/apps/web/src/components/status/vuln-severity-chip.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { VulnSeverityChip } from "./vuln-severity-chip";
+
+// GH #245: the "unknown" severity bucket. A CVSS ingestion bug once caused
+// every genuinely-unrated finding to display as "Low" (a confirmed-safe
+// label). The fix adds a fifth, deliberately distinct bucket so an unrated
+// finding never again reads as "safe".
+
+describe("VulnSeverityChip", () => {
+  it("renders the Unknown label for severity='unknown'", () => {
+    render(<VulnSeverityChip severity="unknown" />);
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+  });
+
+  it("renders a leading count before the Unknown word", () => {
+    render(<VulnSeverityChip severity="unknown" count={7} />);
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+  });
+
+  it("Unknown uses its own dedicated severity-unknown token classes, distinct from Low", () => {
+    const { container: unknownContainer } = render(
+      <VulnSeverityChip severity="unknown" />,
+    );
+    const { container: lowContainer } = render(
+      <VulnSeverityChip severity="low" />,
+    );
+    const unknownChip = unknownContainer.querySelector("span");
+    const lowChip = lowContainer.querySelector("span");
+    expect(unknownChip?.className).toContain("bg-severity-unknown");
+    expect(unknownChip?.className).toContain("text-severity-unknown-foreground");
+    // Never falls back to the Low chip's background or its generic
+    // text-foreground treatment: the whole point is that Unknown must
+    // never visually read as Low.
+    expect(unknownChip?.className).not.toContain("bg-severity-low");
+    expect(lowChip?.className).not.toContain("bg-severity-unknown");
+  });
+
+  it("all five severities render their own word (critical/high/medium/low/unknown)", () => {
+    const severities = ["critical", "high", "medium", "low", "unknown"] as const;
+    for (const severity of severities) {
+      const { unmount } = render(<VulnSeverityChip severity={severity} />);
+      unmount();
+    }
+    // No assertion needed beyond "did not throw": each render() above would
+    // throw on a missing Record key at the type level already; this pins the
+    // full union is exhaustively handled at runtime too.
+    expect(severities).toHaveLength(5);
+  });
+});

--- a/apps/web/src/components/status/vuln-severity-chip.tsx
+++ b/apps/web/src/components/status/vuln-severity-chip.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils";
 
-export type VulnSeverity = "critical" | "high" | "medium" | "low";
+export type VulnSeverity = "critical" | "high" | "medium" | "low" | "unknown";
 
 export interface VulnSeverityChipProps {
   severity: VulnSeverity;
@@ -14,6 +14,7 @@ const severityWord: Record<VulnSeverity, string> = {
   high: "High",
   medium: "Medium",
   low: "Low",
+  unknown: "Unknown",
 };
 
 const severityClasses: Record<VulnSeverity, string> = {
@@ -23,10 +24,18 @@ const severityClasses: Record<VulnSeverity, string> = {
   // hits AA against both backgrounds.
   medium: "bg-severity-medium text-foreground",
   low: "bg-severity-low text-foreground",
+  // Unknown is a genuinely unrated finding (no CVSS score reached the CP),
+  // not a confirmed-low. GH #245: a CVSS ingestion bug once silently
+  // bucketed every unrated finding as "Low", hiding a critical RCE behind a
+  // muted label. Solid neutral slate with its own dedicated foreground
+  // token (mirroring Critical/High, not Medium/Low's pale-surface pattern)
+  // so it is deliberately, unmistakably distinct from the Low chip and
+  // reads as "needs triage", never as "safe".
+  unknown: "bg-severity-unknown text-severity-unknown-foreground",
 };
 
 /**
- * VulnSeverityChip — discrete 4-step vulnerability severity indicator.
+ * VulnSeverityChip — discrete 5-step vulnerability severity indicator.
  *
  * Per DESIGN: severity is a *discrete* scale, never a continuous gradient,
  * and the severity *word* must always appear (never a bare dot). Counts

--- a/apps/web/src/features/admin/use-admin-vuln-feed.test.ts
+++ b/apps/web/src/features/admin/use-admin-vuln-feed.test.ts
@@ -26,6 +26,8 @@ const STATUS_CONNECTED: VulnFeedStatus = {
   record_count: 12_431,
   last_synced: "2026-06-21T10:30:00Z",
   last_error: "",
+  enrichment_available: true,
+  last_enrichment_at: "2026-06-21T10:30:00Z",
 };
 
 /** Feed key comes from the environment variable, not the UI. */
@@ -36,6 +38,8 @@ const STATUS_ENV_SOURCE: VulnFeedStatus = {
   record_count: 7_200,
   last_synced: "2026-06-21T08:00:00Z",
   last_error: "",
+  enrichment_available: true,
+  last_enrichment_at: "2026-06-21T08:00:00Z",
 };
 
 /** Feed is configured but the last sync failed (bad key or network error). */
@@ -46,6 +50,7 @@ const STATUS_ERROR: VulnFeedStatus = {
   record_count: 0,
   last_synced: null,
   last_error: "feed auth failed: 401 Unauthorized",
+  enrichment_available: false,
 };
 
 /** No key has been configured from any source. */
@@ -56,6 +61,24 @@ const STATUS_NOT_CONFIGURED: VulnFeedStatus = {
   record_count: 0,
   last_synced: null,
   last_error: "",
+  enrichment_available: false,
+};
+
+/**
+ * Feed is connected and scanning fine (feed_ok=true), but the last sync was
+ * scanner-only: CVSS enrichment did not complete (GH #245 degraded state).
+ * Distinct from STATUS_ERROR (which fails the scanner-driven feed_ok gate
+ * entirely).
+ */
+const STATUS_CONNECTED_ENRICHMENT_DEGRADED: VulnFeedStatus = {
+  configured: true,
+  source: "ui",
+  feed_ok: true,
+  record_count: 12_431,
+  last_synced: "2026-07-19T10:30:00Z",
+  last_error: "",
+  enrichment_available: false,
+  last_enrichment_at: "2026-07-10T00:00:00Z",
 };
 
 /** Successful PUT /key response — sync kicked off immediately. */
@@ -121,6 +144,42 @@ describe("VulnFeedStatus DTO shape — connected state", () => {
 
   it("source='ui' when the key was saved via the admin console", () => {
     expect(STATUS_CONNECTED.source).toBe("ui");
+  });
+
+  it("has enrichment_available and optional last_enrichment_at", () => {
+    const s: VulnFeedStatus = STATUS_CONNECTED;
+    expect(typeof s.enrichment_available).toBe("boolean");
+    expect(s.enrichment_available).toBe(true);
+    expect(typeof s.last_enrichment_at).toBe("string");
+  });
+});
+
+describe("VulnFeedStatus DTO shape: connected but enrichment-degraded state (GH #245)", () => {
+  it("feed_ok=true + enrichment_available=false is distinct from the error state (scanner still healthy)", () => {
+    const s: VulnFeedStatus = STATUS_CONNECTED_ENRICHMENT_DEGRADED;
+    expect(s.configured).toBe(true);
+    expect(s.feed_ok).toBe(true);
+    expect(s.enrichment_available).toBe(false);
+  });
+
+  it("last_enrichment_at may lag behind last_synced when only the scanner ran", () => {
+    const s: VulnFeedStatus = STATUS_CONNECTED_ENRICHMENT_DEGRADED;
+    expect(s.last_synced).not.toBe(s.last_enrichment_at);
+  });
+
+  it("the 'Connected' header state derivation is unaffected by enrichment_available (feed_ok drives the header, not enrichment)", () => {
+    const state = !STATUS_CONNECTED_ENRICHMENT_DEGRADED.configured
+      ? "not-configured"
+      : STATUS_CONNECTED_ENRICHMENT_DEGRADED.feed_ok
+        ? "connected"
+        : "error";
+    expect(state).toBe("connected");
+    // The degraded sub-line is an ADDITIONAL signal layered on top of
+    // "Connected", never a replacement for it.
+    const showsDegradedSubline =
+      STATUS_CONNECTED_ENRICHMENT_DEGRADED.feed_ok &&
+      !STATUS_CONNECTED_ENRICHMENT_DEGRADED.enrichment_available;
+    expect(showsDegradedSubline).toBe(true);
   });
 });
 

--- a/apps/web/src/features/admin/use-admin-vuln-feed.ts
+++ b/apps/web/src/features/admin/use-admin-vuln-feed.ts
@@ -46,6 +46,16 @@ export interface VulnFeedStatus {
   last_synced: string | null;
   /** Human-readable description of the last sync error, or empty string. */
   last_error: string;
+  /**
+   * True when the feed's CVSS/CVE enrichment pass succeeded on the last
+   * sync, independent of `feed_ok` (which tracks scanner-driven detection
+   * freshness). False means the last sync was scanner-only: findings may be
+   * showing as `unknown` severity fleet-wide even though the feed itself is
+   * reachable.
+   */
+  enrichment_available: boolean;
+  /** ISO-8601 timestamp of the last successful enrichment pass, or absent when enrichment has never completed. */
+  last_enrichment_at?: string;
 }
 
 /**

--- a/apps/web/src/features/security/security-overview.tsx
+++ b/apps/web/src/features/security/security-overview.tsx
@@ -7,7 +7,7 @@ import type { HardeningConfig } from "./use-hardening";
 import type { SiteLoginProtectionConfig } from "@wpmgr/api";
 import type { ScanRun } from "./use-scan";
 import type { SiteSecurityPolicy } from "./use-policy";
-import type { SiteVulnsResponse } from "./use-vuln";
+import { isHighRisk, type SiteVulnsResponse } from "./use-vuln";
 
 // SecurityOverview — four status tiles at the top of the Security tab.
 //
@@ -237,8 +237,12 @@ export function SecurityOverview({
       const openCount = (vulnData.items ?? []).filter(
         (f) => f.status === "open",
       ).length;
-      const criticalCount = (vulnData.items ?? []).filter(
-        (f) => f.status === "open" && (f.severity === "critical" || f.severity === "high"),
+      // GH #245: unknown-severity findings count as high risk too (NOT
+      // mild). An unrated finding could be a CVSS 9.8 that enrichment
+      // simply hasn't scored yet, so it must never fall into the calm
+      // "amber" branch below alongside genuinely-confirmed medium/low.
+      const highRiskCount = (vulnData.items ?? []).filter(
+        (f) => f.status === "open" && isHighRisk(f.severity),
       ).length;
       if (openCount === 0) {
         vulnMetric = "Clean";
@@ -247,10 +251,10 @@ export function SecurityOverview({
       } else {
         vulnMetric = `${openCount}`;
         vulnStateLabel =
-          criticalCount > 0
-            ? `${criticalCount} critical/high`
+          highRiskCount > 0
+            ? `${highRiskCount} critical/high`
             : `${openCount} open`;
-        vulnColor = criticalCount > 0 ? "red" : "amber";
+        vulnColor = highRiskCount > 0 ? "red" : "amber";
       }
     }
   }

--- a/apps/web/src/features/security/use-vuln.test.ts
+++ b/apps/web/src/features/security/use-vuln.test.ts
@@ -126,6 +126,29 @@ const ATTRIBUTION: VulnAttribution = {
 // Fixture: per-site response with findings
 // ---------------------------------------------------------------------------
 
+/** Genuinely unrated finding: CVSS enrichment never landed a score. */
+const UNKNOWN_PLUGIN_FINDING: VulnFinding = {
+  id: "aaaaaaaa-0000-0000-0000-000000000006",
+  site_id: "bbbbbbbb-0000-0000-0000-000000000001",
+  vuln_id: "cccccccc-6666-6666-6666-666666666666",
+  kind: "plugin",
+  slug: "elementor",
+  name: "Elementor",
+  installed_version: "3.10.0",
+  fixed_version: "3.10.5",
+  severity: "unknown",
+  cvss_score: null,
+  cve: null,
+  cve_link: null,
+  title: "Elementor vulnerability (severity not yet rated)",
+  status: "open",
+  first_seen: "2024-06-10T00:00:00Z",
+  last_seen: "2024-06-15T10:00:00Z",
+  references: [
+    "https://www.wordfence.com/threat-intel/vulnerabilities/id/cccccccc-6666-6666-6666-666666666666",
+  ],
+};
+
 const SITE_VULNS_WITH_FINDINGS: SiteVulnsResponse = {
   items: [
     CRITICAL_PLUGIN_FINDING,
@@ -136,6 +159,7 @@ const SITE_VULNS_WITH_FINDINGS: SiteVulnsResponse = {
   attribution: ATTRIBUTION,
   feed_ok: true,
   feed_synced: "2024-06-15T09:00:00Z",
+  enrichment_available: true,
 };
 
 // ---------------------------------------------------------------------------
@@ -147,6 +171,7 @@ const SITE_VULNS_CLEAN: SiteVulnsResponse = {
   attribution: ATTRIBUTION,
   feed_ok: true,
   feed_synced: "2024-06-15T09:00:00Z",
+  enrichment_available: true,
 };
 
 // ---------------------------------------------------------------------------
@@ -162,6 +187,20 @@ const SITE_VULNS_FEED_NOT_CONFIGURED: SiteVulnsResponse = {
   },
   feed_ok: false,
   feed_synced: null,
+  enrichment_available: false,
+};
+
+// ---------------------------------------------------------------------------
+// Fixture: per-site response, feed configured + scanning, but the last sync
+// was scanner-only (CVSS enrichment unreachable): GH #245 degraded state.
+// ---------------------------------------------------------------------------
+
+const SITE_VULNS_ENRICHMENT_DEGRADED: SiteVulnsResponse = {
+  items: [MEDIUM_CORE_FINDING],
+  attribution: ATTRIBUTION,
+  feed_ok: true,
+  feed_synced: "2024-06-15T09:00:00Z",
+  enrichment_available: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -192,10 +231,12 @@ const FLEET_VULNS_RESPONSE: FleetVulnsResponse = {
   high: 1,
   medium: 0,
   low: 0,
+  unknown: 0,
   items: [FLEET_FINDING_1, FLEET_FINDING_2],
   attribution: ATTRIBUTION,
   feed_ok: true,
   feed_synced: "2024-06-15T09:00:00Z",
+  enrichment_available: true,
 };
 
 const FLEET_VULNS_FEED_NOT_CONFIGURED: FleetVulnsResponse = {
@@ -204,6 +245,7 @@ const FLEET_VULNS_FEED_NOT_CONFIGURED: FleetVulnsResponse = {
   high: 0,
   medium: 0,
   low: 0,
+  unknown: 0,
   items: [],
   attribution: {
     defiant_notice: "",
@@ -212,6 +254,38 @@ const FLEET_VULNS_FEED_NOT_CONFIGURED: FleetVulnsResponse = {
   },
   feed_ok: false,
   feed_synced: null,
+  enrichment_available: false,
+};
+
+// ---------------------------------------------------------------------------
+// Fixture: fleet response with unrated findings, feed configured but the
+// last sync was scanner-only (GH #245 degraded state).
+// ---------------------------------------------------------------------------
+
+const FLEET_VULNS_ENRICHMENT_DEGRADED: FleetVulnsResponse = {
+  total_open: 1,
+  critical: 0,
+  high: 0,
+  medium: 0,
+  low: 0,
+  unknown: 1,
+  items: [
+    {
+      site_id: "bbbbbbbb-0000-0000-0000-000000000001",
+      site_name: "acme.example.com",
+      site_url: "https://acme.example.com",
+      finding: {
+        ...CRITICAL_PLUGIN_FINDING,
+        id: "aaaaaaaa-0000-0000-0000-000000000007",
+        severity: "unknown",
+        cvss_score: null,
+      },
+    },
+  ],
+  attribution: ATTRIBUTION,
+  feed_ok: true,
+  feed_synced: "2024-06-15T09:00:00Z",
+  enrichment_available: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -233,7 +307,7 @@ describe("VulnFinding DTO shape — all required fields present", () => {
     expect(f.slug).toBeDefined();
     expect(f.name).toBeDefined();
     expect(f.installed_version).toBeDefined();
-    expect(["critical", "high", "medium", "low"]).toContain(f.severity);
+    expect(["critical", "high", "medium", "low", "unknown"]).toContain(f.severity);
     expect(f.title).toBeDefined();
     expect(["open", "dismissed", "remediated"]).toContain(f.status);
     expect(f.first_seen).toBeDefined();
@@ -259,11 +333,12 @@ describe("VulnFinding DTO shape — all required fields present", () => {
 });
 
 describe("SiteVulnsResponse DTO shape", () => {
-  it("has items, attribution, feed_ok, and optional feed_synced", () => {
+  it("has items, attribution, feed_ok, enrichment_available, and optional feed_synced", () => {
     const r: SiteVulnsResponse = SITE_VULNS_WITH_FINDINGS;
     expect(Array.isArray(r.items)).toBe(true);
     expect(typeof r.attribution).toBe("object");
     expect(typeof r.feed_ok).toBe("boolean");
+    expect(typeof r.enrichment_available).toBe("boolean");
   });
 
   it("feed_ok=true + empty items represents a clean site", () => {
@@ -277,21 +352,38 @@ describe("SiteVulnsResponse DTO shape", () => {
     expect(r.feed_ok).toBe(false);
     expect(r.items).toHaveLength(0);
   });
+
+  it("feed_ok=true + enrichment_available=false represents the GH #245 degraded state (scanner-only sync)", () => {
+    const r: SiteVulnsResponse = SITE_VULNS_ENRICHMENT_DEGRADED;
+    expect(r.feed_ok).toBe(true);
+    expect(r.enrichment_available).toBe(false);
+    // Distinct from feed-not-configured: the feed IS working, just without CVSS enrichment.
+    expect(r.feed_ok && !r.enrichment_available).toBe(true);
+  });
 });
 
 describe("FleetVulnsResponse DTO shape", () => {
-  it("has total_open, severity counts, items, attribution, feed_ok", () => {
+  it("has total_open, severity counts (incl. unknown), items, attribution, feed_ok, enrichment_available", () => {
     const r: FleetVulnsResponse = FLEET_VULNS_RESPONSE;
     expect(typeof r.total_open).toBe("number");
     expect(typeof r.critical).toBe("number");
     expect(typeof r.high).toBe("number");
     expect(typeof r.medium).toBe("number");
     expect(typeof r.low).toBe("number");
+    expect(typeof r.unknown).toBe("number");
     expect(Array.isArray(r.items)).toBe(true);
     expect(typeof r.attribution.defiant_notice).toBe("string");
     expect(typeof r.attribution.defiant_license).toBe("string");
     expect(typeof r.attribution.mitre_notice).toBe("string");
     expect(typeof r.feed_ok).toBe("boolean");
+    expect(typeof r.enrichment_available).toBe("boolean");
+  });
+
+  it("feed_ok=true + enrichment_available=false represents the GH #245 degraded fleet state", () => {
+    const r: FleetVulnsResponse = FLEET_VULNS_ENRICHMENT_DEGRADED;
+    expect(r.feed_ok).toBe(true);
+    expect(r.enrichment_available).toBe(false);
+    expect(r.unknown).toBeGreaterThan(0);
   });
 
   it("each fleet item has site_id, site_name, site_url, and a nested finding", () => {
@@ -373,6 +465,10 @@ describe("isHighRisk", () => {
   it("returns false for low severity", () => {
     expect(isHighRisk("low")).toBe(false);
   });
+
+  it("returns true for unknown severity (elevated, NOT mild; GH #245)", () => {
+    expect(isHighRisk("unknown")).toBe(true);
+  });
 });
 
 describe("countHighRisk", () => {
@@ -395,6 +491,16 @@ describe("countHighRisk", () => {
       status: "dismissed",
     };
     expect(countHighRisk([dismissed])).toBe(0);
+  });
+
+  it("counts open unknown-severity findings as high risk (GH #245: a fleet of unrated findings must not read as benign)", () => {
+    expect(countHighRisk([UNKNOWN_PLUGIN_FINDING])).toBe(1);
+  });
+
+  it("a mix of medium/low findings plus one open unknown finding is still high risk", () => {
+    const findings = [MEDIUM_CORE_FINDING, UNKNOWN_PLUGIN_FINDING];
+    // Only UNKNOWN_PLUGIN_FINDING should count (medium is not high risk).
+    expect(countHighRisk(findings)).toBe(1);
   });
 });
 
@@ -435,6 +541,21 @@ describe("worstSeverity", () => {
       CRITICAL_PLUGIN_FINDING,
     ];
     expect(worstSeverity(all)).toBe("critical");
+  });
+
+  it("returns unknown when only unknown findings are present", () => {
+    expect(worstSeverity([UNKNOWN_PLUGIN_FINDING])).toBe("unknown");
+  });
+
+  it("ranks unknown above medium and low but below critical and high (matches the CP's ORDER BY CASE)", () => {
+    const low: VulnFinding = { ...LOW_DISMISSED_FINDING, status: "open" };
+    expect(worstSeverity([low, MEDIUM_CORE_FINDING, UNKNOWN_PLUGIN_FINDING])).toBe(
+      "unknown",
+    );
+    expect(worstSeverity([UNKNOWN_PLUGIN_FINDING, HIGH_THEME_FINDING])).toBe("high");
+    expect(worstSeverity([UNKNOWN_PLUGIN_FINDING, CRITICAL_PLUGIN_FINDING])).toBe(
+      "critical",
+    );
   });
 });
 
@@ -646,6 +767,38 @@ describe("feed_ok state — correct UI branch selection", () => {
     expect(r.total_open).toBe(0);
     const isNotConfigured = !r.feed_ok;
     expect(isNotConfigured).toBe(true);
+  });
+
+  it("enrichment_available=false is distinct from feed_ok=false: the degraded banner gate must not fire when the feed isn't configured at all", () => {
+    // The feed-not-configured branch always wins first: it renders before the
+    // degraded banner is ever considered, so a caller must check `!feed_ok`
+    // BEFORE `!enrichment_available`.
+    const notConfigured = SITE_VULNS_FEED_NOT_CONFIGURED;
+    const degraded = SITE_VULNS_ENRICHMENT_DEGRADED;
+
+    expect(notConfigured.feed_ok).toBe(false);
+    expect(degraded.feed_ok).toBe(true);
+    expect(degraded.enrichment_available).toBe(false);
+
+    // Simulate the UI's branch order.
+    function showsFeedNotConfigured(r: SiteVulnsResponse): boolean {
+      return !r.feed_ok;
+    }
+    function showsDegradedBanner(r: SiteVulnsResponse): boolean {
+      return r.feed_ok && !r.enrichment_available;
+    }
+    expect(showsFeedNotConfigured(notConfigured)).toBe(true);
+    expect(showsDegradedBanner(notConfigured)).toBe(false);
+    expect(showsFeedNotConfigured(degraded)).toBe(false);
+    expect(showsDegradedBanner(degraded)).toBe(true);
+  });
+
+  it("fleet enrichment_available=false degraded state uses the same branch order as the per-site response", () => {
+    const r = FLEET_VULNS_ENRICHMENT_DEGRADED;
+    expect(r.feed_ok).toBe(true);
+    expect(r.enrichment_available).toBe(false);
+    const showsDegradedBanner = r.feed_ok && !r.enrichment_available;
+    expect(showsDegradedBanner).toBe(true);
   });
 });
 

--- a/apps/web/src/features/security/use-vuln.ts
+++ b/apps/web/src/features/security/use-vuln.ts
@@ -29,8 +29,17 @@ import { toError } from "@/features/auth/use-auth";
 // Domain types — MUST match Go DTOs exactly (handler.go lines 89-147)
 // ---------------------------------------------------------------------------
 
-/** Severity values: must match Go `site_vulnerabilities.severity` column. */
-export type VulnSeverity = "critical" | "high" | "medium" | "low";
+/**
+ * Severity values: must match Go `site_vulnerabilities.severity` column.
+ *
+ * `unknown` (GH #245) is a genuinely-unrated finding: the scanner detected a
+ * vulnerable component but CVSS enrichment never landed a real score for it.
+ * It is NOT the same thing as a confirmed-low finding, and must never be
+ * bucketed together with `low` in the UI: the bug this shipped to fix was
+ * exactly that conflation (every unrated finding silently displayed as
+ * "Low", once hiding a CVSS 9.8 core RCE behind a muted label).
+ */
+export type VulnSeverity = "critical" | "high" | "medium" | "low" | "unknown";
 
 /** Status values: must match Go `site_vulnerabilities.status` column. */
 export type VulnStatus = "open" | "dismissed" | "remediated";
@@ -97,6 +106,16 @@ export interface SiteVulnsResponse {
   feed_ok: boolean;
   /** RFC 3339 string or absent when the feed has never been synced. */
   feed_synced?: string | null;
+  /**
+   * True when the Wordfence Intelligence feed's CVSS/CVE enrichment pass
+   * succeeded on the last sync, independent of `feed_ok` (which tracks
+   * scanner-driven detection freshness, not enrichment). False means some
+   * findings may show as `unknown` severity even though a real rating
+   * exists upstream and simply could not be fetched.
+   */
+  enrichment_available: boolean;
+  /** RFC 3339 timestamp of the last successful enrichment pass, or absent when enrichment has never completed. */
+  last_enrichment_at?: string;
 }
 
 /**
@@ -120,10 +139,21 @@ export interface FleetVulnsResponse {
   high: number;
   medium: number;
   low: number;
+  /** Findings with neither a CVSS rating nor a numeric score yet: genuinely unknown severity, not a confirmed low. */
+  unknown: number;
   items: FleetVulnFinding[];
   attribution: VulnAttribution;
   feed_ok: boolean;
   feed_synced?: string | null;
+  /**
+   * True when the Wordfence Intelligence feed's CVSS/CVE enrichment pass
+   * succeeded on the last sync, independent of `feed_ok`. False means some
+   * findings across the fleet may show as `unknown` severity even though a
+   * real rating exists upstream and simply could not be fetched.
+   */
+  enrichment_available: boolean;
+  /** RFC 3339 timestamp of the last successful enrichment pass, or absent when enrichment has never completed. */
+  last_enrichment_at?: string;
 }
 
 /** POST /rescan response — maps to `rescanResponseDTO`. */
@@ -334,9 +364,15 @@ export function useRemediateVuln(
 // Helpers — exported for tests and components
 // ---------------------------------------------------------------------------
 
-/** True when the severity warrants a dangerous/urgent colour (auto-expand card). */
+/**
+ * True when the severity warrants a dangerous/urgent colour (auto-expand
+ * card). `unknown` counts as high risk, NOT mild: a genuinely-unrated
+ * finding might be a CVSS 9.8 that enrichment simply hasn't scored yet
+ * (GH #245), so treating it as benign would repeat the exact bug this
+ * severity bucket exists to fix.
+ */
 export function isHighRisk(severity: VulnSeverity): boolean {
-  return severity === "critical" || severity === "high";
+  return severity === "critical" || severity === "high" || severity === "unknown";
 }
 
 /** Returns the count of open findings with critical or high severity. */
@@ -346,8 +382,13 @@ export function countHighRisk(findings: VulnFinding[]): number {
   ).length;
 }
 
-/** Severity ranked worst-first, for picking the single worst severity to display. */
-const SEVERITY_RANK: VulnSeverity[] = ["critical", "high", "medium", "low"];
+/**
+ * Severity ranked worst-first, for picking the single worst severity to
+ * display. `unknown` ranks between `high` and `medium`, matching the CP's
+ * own ORDER BY CASE in repo.go (findings + fleetFindings queries), because
+ * an unrated finding could turn out to be critical once enrichment lands.
+ */
+const SEVERITY_RANK: VulnSeverity[] = ["critical", "high", "unknown", "medium", "low"];
 
 /**
  * Returns the worst (highest-priority) severity among the given findings, or

--- a/apps/web/src/features/security/vuln-enrichment-banner.tsx
+++ b/apps/web/src/features/security/vuln-enrichment-banner.tsx
@@ -1,0 +1,33 @@
+import { AlertTriangle } from "lucide-react";
+
+// VulnEnrichmentBanner: GH #245 degraded-signal banner.
+//
+// Shown when the vulnerability feed IS configured and scanning fine
+// (`feed_ok === true`) but the last sync's CVSS enrichment pass did not
+// complete (`enrichment_available === false`). This is a DIFFERENT state
+// from "feed not configured" (`feed_ok === false`, handled by each caller's
+// own FeedNotConfiguredState / early-return, which always takes priority).
+// Here the scanner ran and findings exist, but some of them may be showing
+// as `unknown` severity even though a real CVSS rating exists upstream.
+//
+// Tone: calm amber (`warning-subtle`), matching the app's other degraded /
+// recoverable-state banners (see components/feedback/offline-banner.tsx,
+// features/portal/portal-status-banner.tsx). Never destructive, since this
+// is a transient upstream condition, not an operator error.
+
+export function VulnEnrichmentBanner() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-start gap-3 rounded-lg bg-[var(--color-warning-subtle)] px-4 py-3 text-sm text-[var(--color-warning-subtle-fg)]"
+    >
+      <AlertTriangle aria-hidden="true" className="mt-px size-4 shrink-0" />
+      <p className="min-w-0 flex-1">
+        <span className="font-medium">Severity data unavailable.</span> The
+        CVSS enrichment feed was not reachable on the last sync, so some
+        findings may be understated.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/features/security/vuln-panel.test.tsx
+++ b/apps/web/src/features/security/vuln-panel.test.tsx
@@ -73,6 +73,7 @@ describe("VulnPanel — feed-not-configured state (security-misleading regressio
       attribution: ATTRIBUTION,
       feed_ok: false,
       feed_synced: null,
+      enrichment_available: false,
     };
     mockedUseSiteVulnerabilities.mockReturnValue(
       mockQueryResult<SiteVulnsResponse>({ data: response }),
@@ -91,6 +92,12 @@ describe("VulnPanel — feed-not-configured state (security-misleading regressio
     // case a future edit rewords it without changing the underlying bug.
     expect(screen.queryByText(/no known vulnerabilities/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/no vulnerabilities found/i)).not.toBeInTheDocument();
+
+    // The degraded-enrichment banner must NOT fire here either: feed-not-
+    // configured always takes priority, and this is a different state.
+    expect(
+      screen.queryByText(/Severity data unavailable/i),
+    ).not.toBeInTheDocument();
   });
 });
 
@@ -130,6 +137,7 @@ describe("VulnPanel — findings table + Gate 0 attribution", () => {
       attribution: ATTRIBUTION,
       feed_ok: true,
       feed_synced: "2026-07-06T00:00:00Z",
+      enrichment_available: true,
     };
     mockedUseSiteVulnerabilities.mockReturnValue(
       mockQueryResult<SiteVulnsResponse>({ data: response }),
@@ -159,5 +167,66 @@ describe("VulnPanel — findings table + Gate 0 attribution", () => {
     expect(screen.getByText(ATTRIBUTION.defiant_license)).toBeInTheDocument();
     expect(screen.getByText(ATTRIBUTION.mitre_notice)).toBeInTheDocument();
     expect(screen.getByText("Wordfence Intelligence")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH #245: degraded CVSS enrichment banner
+// ---------------------------------------------------------------------------
+
+describe("VulnPanel degraded-enrichment banner (GH #245)", () => {
+  it("renders the amber banner when feed_ok=true but enrichment_available=false", () => {
+    const response: SiteVulnsResponse = {
+      items: [
+        buildFinding({
+          id: "f-unknown",
+          slug: "unrated-plugin",
+          name: "Unrated Plugin",
+          severity: "unknown",
+          cvss_score: null,
+        }),
+      ],
+      attribution: ATTRIBUTION,
+      feed_ok: true,
+      feed_synced: "2026-07-06T00:00:00Z",
+      enrichment_available: false,
+    };
+    mockedUseSiteVulnerabilities.mockReturnValue(
+      mockQueryResult<SiteVulnsResponse>({ data: response }),
+    );
+
+    renderWithProviders(<VulnPanel siteId="site-1" />);
+
+    expect(
+      screen.getByText(/Severity data unavailable\./),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /The CVSS enrichment feed was not reachable on the last sync, so some findings may be understated\./,
+      ),
+    ).toBeInTheDocument();
+
+    // The finding renders with the distinct Unknown chip, not Low.
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+    expect(screen.queryByText("Low")).not.toBeInTheDocument();
+  });
+
+  it("does NOT render the banner when enrichment_available is true", () => {
+    const response: SiteVulnsResponse = {
+      items: [buildFinding({ severity: "low" })],
+      attribution: ATTRIBUTION,
+      feed_ok: true,
+      feed_synced: "2026-07-06T00:00:00Z",
+      enrichment_available: true,
+    };
+    mockedUseSiteVulnerabilities.mockReturnValue(
+      mockQueryResult<SiteVulnsResponse>({ data: response }),
+    );
+
+    renderWithProviders(<VulnPanel siteId="site-1" />);
+
+    expect(
+      screen.queryByText(/Severity data unavailable/i),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/security/vuln-panel.tsx
+++ b/apps/web/src/features/security/vuln-panel.tsx
@@ -13,6 +13,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageError } from "@/components/feedback";
 import { VulnSeverityChip } from "@/components/status/vuln-severity-chip";
+import { VulnEnrichmentBanner } from "./vuln-enrichment-banner";
 import { toast } from "@/components/toast";
 import { relativeTime } from "@/lib/utils";
 
@@ -43,6 +44,12 @@ import { useUpdateRun, useRunEventStream } from "@/features/updates/use-updates"
 // FEED-NOT-CONFIGURED STATE: when feed_ok is false, render an informational
 // state — never an empty "No vulnerabilities found" which would be misleading
 // when the feed hasn't been set up.
+//
+// DEGRADED-ENRICHMENT BANNER (GH #245): when feed_ok is true but
+// enrichment_available is false, the scanner is healthy but the last sync's
+// CVSS enrichment pass did not complete. Some findings may be showing as
+// Unknown severity when a real rating exists upstream. Distinct from the
+// feed-not-configured state; rendered via VulnEnrichmentBanner.
 //
 // GATE 0 ATTRIBUTION: Defiant copyright/license footer + MITRE notice on CVE
 // rows. These are legally required and must NOT be removed.
@@ -390,6 +397,11 @@ export function VulnPanel({ siteId, canWrite = false }: VulnPanelProps) {
           ) : null}
         </div>
       </div>
+
+      {/* GH #245 degraded-enrichment banner. Distinct from the FeedNotConfiguredState
+          early-return above: the feed IS configured and scanning (feed_ok=true),
+          but CVSS enrichment did not complete on the last sync. */}
+      {!data.enrichment_available ? <VulnEnrichmentBanner /> : null}
 
       {/* Zero-findings + feed OK state */}
       {allFindings.length === 0 ? (

--- a/apps/web/src/routes/_authed/-vulnerabilities.test.tsx
+++ b/apps/web/src/routes/_authed/-vulnerabilities.test.tsx
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+import { mockQueryResult } from "@/test/query-mocks";
+
+import { Route } from "./vulnerabilities";
+import { useFleetVulnerabilities } from "@/features/security/use-vuln";
+import type {
+  FleetVulnsResponse,
+  FleetVulnFinding,
+} from "@/features/security/use-vuln";
+
+// GH #245 web: the fleet Vulnerabilities page's 5th "Unknown" severity tile
+// and the degraded-CVSS-enrichment banner.
+//
+// Rendered via `Route.options.component` (see routes/_authed/settings/-route.test.tsx
+// for why: the vite router plugin auto-splits each route's component into its
+// own chunk, and a second named export would opt it back out of that split).
+// The page reads no route-bound search/params state, so it mounts fine under
+// the generic ad hoc test router from `renderWithProviders({ withRouter: true })`.
+//
+// GOTCHA (src/test/render.tsx): RouterProvider's first paint resolves in a
+// microtask, so every test below awaits its FIRST query with `findBy*`
+// before making any further synchronous `getBy*`/`queryBy*` assertions.
+
+vi.mock("@/features/security/use-vuln", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/security/use-vuln")>();
+  return {
+    ...actual,
+    useFleetVulnerabilities: vi.fn(),
+  };
+});
+
+const mockedUseFleetVulnerabilities = vi.mocked(useFleetVulnerabilities);
+
+const VulnerabilitiesPage = Route.options.component!;
+
+const ATTRIBUTION = {
+  defiant_notice:
+    "Vulnerability data is sourced from the Defiant vulnerability intelligence feed.",
+  defiant_license: "Used under the Defiant Vulnerability Database license.",
+  mitre_notice:
+    "CVE is a registered trademark of The MITRE Corporation, used with permission.",
+};
+
+function buildFleetFinding(
+  overrides: Partial<FleetVulnFinding["finding"]> & { siteId?: string },
+): FleetVulnFinding {
+  const { siteId = "11111111-0000-0000-0000-000000000001", ...findingOverrides } =
+    overrides;
+  return {
+    site_id: siteId,
+    site_name: "acme.example.com",
+    site_url: "https://acme.example.com",
+    finding: {
+      id: "00000000-0000-0000-0000-000000000001",
+      site_id: siteId,
+      vuln_id: "22222222-0000-0000-0000-000000000001",
+      kind: "plugin",
+      slug: "example-plugin",
+      name: "Example Plugin",
+      installed_version: "1.0.0",
+      fixed_version: "1.0.1",
+      severity: "low",
+      cvss_score: 3.1,
+      cve: null,
+      cve_link: null,
+      title: "Example finding",
+      status: "open",
+      first_seen: "2026-01-01T00:00:00Z",
+      last_seen: "2026-01-02T00:00:00Z",
+      references: [],
+      ...findingOverrides,
+    },
+  };
+}
+
+describe("Fleet Vulnerabilities page: Unknown severity tile (GH #245)", () => {
+  it("renders a 5th Unknown tile with the unknown count, ordered after High and before Medium", async () => {
+    const response: FleetVulnsResponse = {
+      total_open: 4,
+      critical: 1,
+      high: 1,
+      medium: 1,
+      low: 1,
+      unknown: 2,
+      items: [
+        buildFleetFinding({ id: "f1", severity: "critical" }),
+        buildFleetFinding({ id: "f2", severity: "high" }),
+        buildFleetFinding({ id: "f3", severity: "unknown", cvss_score: null }),
+        buildFleetFinding({ id: "f4", severity: "unknown", cvss_score: null }),
+        buildFleetFinding({ id: "f5", severity: "medium" }),
+        buildFleetFinding({ id: "f6", severity: "low" }),
+      ],
+      attribution: ATTRIBUTION,
+      feed_ok: true,
+      feed_synced: "2026-07-19T00:00:00Z",
+      enrichment_available: true,
+    };
+    mockedUseFleetVulnerabilities.mockReturnValue(
+      mockQueryResult<FleetVulnsResponse>({ data: response }),
+    );
+
+    renderWithProviders(<VulnerabilitiesPage />, { withRouter: true });
+
+    const unknownTile = await screen.findByRole("button", {
+      name: "Filter by Unknown: 2 findings",
+    });
+    expect(unknownTile).toBeInTheDocument();
+
+    const tiles = screen.getAllByRole("button", { name: /Filter by/ });
+    expect(tiles).toHaveLength(5);
+
+    // Order: Critical, High, Unknown, Medium, Low. Matches the CP's ORDER
+    // BY CASE sort rank (repo.go).
+    const order = tiles.map((t) =>
+      t.getAttribute("aria-label")?.replace(/^Filter by /, "").split(":")[0],
+    );
+    expect(order).toEqual(["Critical", "High", "Unknown", "Medium", "Low"]);
+  });
+
+  it("clicking the Unknown tile filters the table to unknown-severity findings only", async () => {
+    const response: FleetVulnsResponse = {
+      total_open: 2,
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 1,
+      unknown: 1,
+      items: [
+        buildFleetFinding({
+          id: "f-unknown",
+          name: "Unrated Plugin",
+          severity: "unknown",
+          cvss_score: null,
+        }),
+        buildFleetFinding({
+          id: "f-low",
+          name: "Low Plugin",
+          severity: "low",
+        }),
+      ],
+      attribution: ATTRIBUTION,
+      feed_ok: true,
+      feed_synced: "2026-07-19T00:00:00Z",
+      enrichment_available: true,
+    };
+    mockedUseFleetVulnerabilities.mockReturnValue(
+      mockQueryResult<FleetVulnsResponse>({ data: response }),
+    );
+
+    renderWithProviders(<VulnerabilitiesPage />, { withRouter: true });
+
+    const unknownTile = await screen.findByRole("button", {
+      name: "Filter by Unknown: 1 finding",
+    });
+    fireEvent.click(unknownTile);
+
+    expect(screen.getByText("Unrated Plugin")).toBeInTheDocument();
+    expect(screen.queryByText("Low Plugin")).not.toBeInTheDocument();
+  });
+});
+
+describe("Fleet Vulnerabilities page: degraded-enrichment banner (GH #245)", () => {
+  it("renders the amber banner when feed_ok=true and enrichment_available=false", async () => {
+    const response: FleetVulnsResponse = {
+      total_open: 1,
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      unknown: 1,
+      items: [
+        buildFleetFinding({ id: "f-unknown", severity: "unknown", cvss_score: null }),
+      ],
+      attribution: ATTRIBUTION,
+      feed_ok: true,
+      feed_synced: "2026-07-19T00:00:00Z",
+      enrichment_available: false,
+    };
+    mockedUseFleetVulnerabilities.mockReturnValue(
+      mockQueryResult<FleetVulnsResponse>({ data: response }),
+    );
+
+    renderWithProviders(<VulnerabilitiesPage />, { withRouter: true });
+
+    expect(
+      await screen.findByText(/Severity data unavailable\./),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /The CVSS enrichment feed was not reachable on the last sync, so some findings may be understated\./,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT render the banner when enrichment_available=true", async () => {
+    const response: FleetVulnsResponse = {
+      total_open: 1,
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 1,
+      unknown: 0,
+      items: [buildFleetFinding({ id: "f-low", severity: "low" })],
+      attribution: ATTRIBUTION,
+      feed_ok: true,
+      feed_synced: "2026-07-19T00:00:00Z",
+      enrichment_available: true,
+    };
+    mockedUseFleetVulnerabilities.mockReturnValue(
+      mockQueryResult<FleetVulnsResponse>({ data: response }),
+    );
+
+    renderWithProviders(<VulnerabilitiesPage />, { withRouter: true });
+
+    // Await a tile that IS expected to render, to clear the router's
+    // async first-paint, before asserting the banner's absence.
+    await screen.findByRole("button", { name: "Filter by Low: 1 finding" });
+
+    expect(
+      screen.queryByText(/Severity data unavailable/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does NOT render the banner when the feed is not configured (feed_ok=false takes priority)", async () => {
+    const response: FleetVulnsResponse = {
+      total_open: 0,
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      unknown: 0,
+      items: [],
+      attribution: { defiant_notice: "", defiant_license: "", mitre_notice: "" },
+      feed_ok: false,
+      feed_synced: null,
+      enrichment_available: false,
+    };
+    mockedUseFleetVulnerabilities.mockReturnValue(
+      mockQueryResult<FleetVulnsResponse>({ data: response }),
+    );
+
+    renderWithProviders(<VulnerabilitiesPage />, { withRouter: true });
+
+    expect(
+      await screen.findByText("Vulnerability feed not configured yet"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Severity data unavailable/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/_authed/admin/-vuln-feed.test.tsx
+++ b/apps/web/src/routes/_authed/admin/-vuln-feed.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+import { mockMutationResult } from "@/test/query-mocks";
+
+import { FeedStatusCard } from "./vuln-feed";
+import { useVulnFeedSync } from "@/features/admin/use-admin-vuln-feed";
+import type { VulnFeedStatus, VulnFeedSyncResult } from "@/features/admin/use-admin-vuln-feed";
+
+// GH #245 web: the admin Vulnerability feed status card's degraded-CVSS-
+// enrichment sub-line.
+//
+// `FeedStatusCard` is rendered directly (a plain named export alongside
+// `Route`, NOT via `Route.options.component`): the router vite plugin's
+// `autoCodeSplitting` extracts this ROUTE's `component:` reference
+// (`VulnFeedAdminPage`) into a separately-transformed chunk, and that
+// specific split module never resolves its dynamic import under this repo's
+// vitest + `@tanstack/router-plugin` combination (confirmed independent of
+// this feature's content: a real `vite build` produces a correct
+// `vuln-feed-*.js` chunk with no errors, and other never-before-tested
+// `admin/*` leaf routes mount fine via `Route.options.component`; the stall
+// is specific to this one route file's split boundary). `FeedStatusCard`
+// itself is an ordinary function component untouched by that split, so it
+// mounts synchronously like any other feature component test.
+
+vi.mock("@/features/admin/use-admin-vuln-feed", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/features/admin/use-admin-vuln-feed")>();
+  return {
+    ...actual,
+    useVulnFeedSync: vi.fn(),
+  };
+});
+
+const mockedUseVulnFeedSync = vi.mocked(useVulnFeedSync);
+
+function stubSync() {
+  mockedUseVulnFeedSync.mockReturnValue(
+    mockMutationResult<VulnFeedSyncResult, void>({}),
+  );
+}
+
+describe("FeedStatusCard: degraded-enrichment sub-line (GH #245)", () => {
+  it("shows the amber degraded sub-line when feed_ok=true and enrichment_available=false", () => {
+    stubSync();
+    const status: VulnFeedStatus = {
+      configured: true,
+      source: "ui",
+      feed_ok: true,
+      record_count: 12_431,
+      last_synced: "2026-07-19T10:00:00Z",
+      last_error: "",
+      enrichment_available: false,
+      last_enrichment_at: "2026-07-10T00:00:00Z",
+    };
+
+    renderWithProviders(<FeedStatusCard status={status} />);
+
+    // Header stays "Connected" (green): the scanner IS healthy.
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+
+    // The degraded sub-line is an ADDITIONAL amber signal, not a replacement.
+    expect(
+      screen.getByText(/Last sync was scanner-only\./),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /CVSS enrichment was unavailable, so severities may be understated\./,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the last_enrichment_at relative time when present", () => {
+    stubSync();
+    const status: VulnFeedStatus = {
+      configured: true,
+      source: "ui",
+      feed_ok: true,
+      record_count: 12_431,
+      last_synced: "2026-07-19T10:00:00Z",
+      last_error: "",
+      enrichment_available: false,
+      last_enrichment_at: "2026-07-19T09:00:00Z",
+    };
+
+    renderWithProviders(<FeedStatusCard status={status} />);
+
+    expect(screen.getByText(/Last enrichment/)).toBeInTheDocument();
+  });
+
+  it("does NOT show the degraded sub-line when enrichment_available=true", () => {
+    stubSync();
+    const status: VulnFeedStatus = {
+      configured: true,
+      source: "ui",
+      feed_ok: true,
+      record_count: 12_431,
+      last_synced: "2026-07-19T10:00:00Z",
+      last_error: "",
+      enrichment_available: true,
+      last_enrichment_at: "2026-07-19T10:00:00Z",
+    };
+
+    renderWithProviders(<FeedStatusCard status={status} />);
+
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Last sync was scanner-only/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does NOT show the degraded sub-line for the not-configured state (no false-positive on the amber signal)", () => {
+    stubSync();
+    const status: VulnFeedStatus = {
+      configured: false,
+      source: "none",
+      feed_ok: false,
+      record_count: 0,
+      last_synced: null,
+      last_error: "",
+      enrichment_available: false,
+    };
+
+    renderWithProviders(<FeedStatusCard status={status} />);
+
+    expect(screen.getByText("Not configured")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Last sync was scanner-only/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does NOT show the degraded sub-line for the error state (feed_ok=false takes priority over enrichment)", () => {
+    stubSync();
+    const status: VulnFeedStatus = {
+      configured: true,
+      source: "ui",
+      feed_ok: false,
+      record_count: 0,
+      last_synced: null,
+      last_error: "feed auth failed: 401 Unauthorized",
+      enrichment_available: false,
+    };
+
+    renderWithProviders(<FeedStatusCard status={status} />);
+
+    expect(screen.getByText("Error")).toBeInTheDocument();
+    expect(screen.getByText(status.last_error)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Last sync was scanner-only/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/_authed/admin/vuln-feed.tsx
+++ b/apps/web/src/routes/_authed/admin/vuln-feed.tsx
@@ -2,6 +2,7 @@ import { useId, useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import {
   AlertCircle,
+  AlertTriangle,
   CheckCircle2,
   ExternalLink,
   Info,
@@ -31,8 +32,7 @@ import {
   useVulnFeedSync,
   type VulnFeedStatus,
 } from "@/features/admin/use-admin-vuln-feed";
-import { relativeTime } from "@/lib/utils";
-import { cn } from "@/lib/utils";
+import { relativeTime, cn } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
 // Route — auth gate is enforced by the parent /admin layout route (route.tsx);
@@ -109,7 +109,12 @@ function VulnFeedAdminPage() {
 // FeedStatusCard
 // ---------------------------------------------------------------------------
 
-function FeedStatusCard({ status }: { status: VulnFeedStatus }) {
+// Exported (alongside `Route`) so tests can render this card directly rather
+// than through `Route.options.component`. Mirrors `SETTINGS_NAV_ITEMS` in
+// routes/_authed/settings/route.tsx, a plain named export living beside the
+// route registration without affecting the router vite plugin's
+// autoCodeSplitting of the `component:` reference.
+export function FeedStatusCard({ status }: { status: VulnFeedStatus }) {
   const sync = useVulnFeedSync();
 
   // Derive the connection state for display.
@@ -161,6 +166,21 @@ function FeedStatusCard({ status }: { status: VulnFeedStatus }) {
             ) : state === "error" && status.last_error ? (
               <p className="mt-0.5 text-xs text-destructive">
                 {status.last_error}
+              </p>
+            ) : null}
+            {/* GH #245 degraded-enrichment sub-line: the header stays green
+                "Connected" (the scanner IS healthy) but the last sync did not
+                complete CVSS enrichment, so severities may be understated. */}
+            {state === "connected" && !status.enrichment_available ? (
+              <p className="mt-1 flex items-start gap-1 text-xs text-warning-subtle-fg">
+                <AlertTriangle aria-hidden="true" className="mt-px size-3 shrink-0" />
+                <span>
+                  Last sync was scanner-only. CVSS enrichment was unavailable,
+                  so severities may be understated.
+                  {status.last_enrichment_at
+                    ? ` Last enrichment ${relativeTime(status.last_enrichment_at) ?? "recently"}.`
+                    : null}
+                </span>
               </p>
             ) : null}
           </div>

--- a/apps/web/src/routes/_authed/sites/$siteId.security.tsx
+++ b/apps/web/src/routes/_authed/sites/$siteId.security.tsx
@@ -145,6 +145,10 @@ function hideLoginStatus(
     : { variant: "muted", label: "Off" };
 }
 
+// GH #245: `countHighRisk` treats `unknown`-severity findings as elevated
+// (same as critical/high), so a site with only unrated findings correctly
+// falls into the `destructive` branch below rather than `success`/`warning`.
+// A fleet of unrated findings must never render as a benign card status.
 function vulnStatus(
   vulnData: ReturnType<typeof useSiteVulnerabilities>["data"],
 ): CardStatus {

--- a/apps/web/src/routes/_authed/vulnerabilities.tsx
+++ b/apps/web/src/routes/_authed/vulnerabilities.tsx
@@ -12,6 +12,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { PageError } from "@/components/feedback";
 import { VulnSeverityChip } from "@/components/status/vuln-severity-chip";
 import { VulnAttributionFooter } from "@/features/security/vuln-panel";
+import { VulnEnrichmentBanner } from "@/features/security/vuln-enrichment-banner";
 import {
   Table,
   TableBody,
@@ -33,11 +34,15 @@ import {
 //
 // Replaces the <PlannedFeature> stub (previously at this route) with a real
 // fleet rollup page:
-//   - 4-tile severity header (Critical / High / Medium / Low counts) +
+//   - 5-tile severity header (Critical / High / Unknown / Medium / Low counts) +
 //     total_open, click-to-filter by severity.
 //   - Prioritized table: site, component name, kind, installed -> fixed,
 //     severity badge, CVSS, CVE link + Wordfence reference link-back.
 //   - FEED-NOT-CONFIGURED STATE: feed_ok=false renders a clear info state.
+//   - DEGRADED-ENRICHMENT BANNER: feed_ok=true but enrichment_available=false
+//     (GH #245) renders an amber banner. The feed is scanning fine, but the
+//     last sync's CVSS enrichment pass did not complete, so findings may be
+//     showing as Unknown when a real rating exists upstream.
 //   - GATE 0 ATTRIBUTION: Defiant + MITRE notices rendered in footer/rows.
 //
 // Sidebar entry already exists (sidebar.tsx Security > Vulnerabilities).
@@ -74,6 +79,14 @@ const SEVERITY_COLORS: Record<
     icon: "text-[var(--color-muted-foreground)]",
     label: "text-[var(--color-muted-foreground)]",
   },
+  // Unknown (GH #245): a genuinely-unrated finding, not a confirmed low.
+  // Neutral slate, deliberately distinct from Low's plain card surface, so
+  // an unrated finding never reads as "checked and safe".
+  unknown: {
+    bg: "border-slate-300 bg-slate-100 dark:border-slate-700 dark:bg-slate-800",
+    icon: "text-slate-600 dark:text-slate-300",
+    label: "text-slate-700 dark:text-slate-200",
+  },
 };
 
 const SEVERITY_WORD: Record<VulnSeverity, string> = {
@@ -81,6 +94,7 @@ const SEVERITY_WORD: Record<VulnSeverity, string> = {
   high: "High",
   medium: "Medium",
   low: "Low",
+  unknown: "Unknown",
 };
 
 function SeverityTile({
@@ -320,8 +334,8 @@ function FleetVulnSkeleton() {
       className="space-y-6"
     >
       <span className="sr-only">Loading vulnerability data</span>
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        {Array.from({ length: 4 }).map((_, i) => (
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+        {Array.from({ length: 5 }).map((_, i) => (
           <Skeleton key={i} className="h-20 w-full rounded-xl" />
         ))}
       </div>
@@ -411,10 +425,14 @@ function VulnerabilitiesPage() {
     setActiveSeverity((prev) => (prev === sev ? null : sev));
   }
 
-  const severityOrder: VulnSeverity[] = ["critical", "high", "medium", "low"];
+  // Order matches the CP's own ORDER BY CASE in repo.go: unknown ranks above
+  // Medium/Low (an unrated finding could turn out to be a CVSS 9.8) but
+  // below Critical/High.
+  const severityOrder: VulnSeverity[] = ["critical", "high", "unknown", "medium", "low"];
   const countBySeverity: Record<VulnSeverity, number> = {
     critical: data.critical,
     high: data.high,
+    unknown: data.unknown,
     medium: data.medium,
     low: data.low,
   };
@@ -430,9 +448,14 @@ function VulnerabilitiesPage() {
         }
       />
 
+      {/* GH #245 degraded-enrichment banner. Distinct from the FeedNotConfiguredState
+          early-return above: the feed IS configured and scanning (feed_ok=true),
+          but CVSS enrichment did not complete on the last sync. */}
+      {!data.enrichment_available ? <VulnEnrichmentBanner /> : null}
+
       {/* Severity summary header */}
       <div
-        className="grid grid-cols-2 gap-3 sm:grid-cols-4"
+        className="grid grid-cols-2 gap-3 sm:grid-cols-5"
         role="group"
         aria-label="Filter vulnerabilities by severity"
       >

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -56,6 +56,13 @@
   --severity-high:      oklch(58% 0.20   25);
   --severity-medium:    oklch(70% 0.14   75);
   --severity-low:       oklch(58% 0.10  235);
+  /* Unknown (GH #245): a genuinely unrated finding, not a confirmed-low.
+     Near-zero chroma (true slate/gray) so it never reads as a tint of the
+     blue Low chip - solid + darker L than Low so it carries visual weight
+     ("needs triage"), matching Critical/High's dedicated-foreground pattern
+     rather than Medium/Low's pale-surface-plus-generic-text one. */
+  --severity-unknown:            oklch(40% 0.006 235);
+  --severity-unknown-foreground: oklch(99% 0.004 235);
 
   --chart-1: oklch(58% 0.12 195);
   --chart-2: oklch(60% 0.14 155);
@@ -113,6 +120,13 @@
   --severity-high:      oklch(68% 0.20   25);
   --severity-medium:    oklch(78% 0.16   75);
   --severity-low:       oklch(68% 0.12  235);
+  /* L raised 55% -> 60% (measured AA fix): the 55% bg against the 15% fg
+     text only reached ~4.059:1 for the chip's 12px font-medium label,
+     just under WCAG AA's 4.5:1 floor. 60% clears it at ~4.989:1 while
+     staying a desaturated slate (chroma unchanged), still clearly below
+     Low's L=68% chroma=0.12 so the two chips remain visually distinct. */
+  --severity-unknown:            oklch(60% 0.008 235);
+  --severity-unknown-foreground: oklch(15% 0.012 235);
 }
 
 @theme inline {
@@ -174,6 +188,8 @@
   --color-severity-high: var(--severity-high);
   --color-severity-medium: var(--severity-medium);
   --color-severity-low: var(--severity-low);
+  --color-severity-unknown: var(--severity-unknown);
+  --color-severity-unknown-foreground: var(--severity-unknown-foreground);
 
   --color-chart-1: var(--chart-1);
   --color-chart-2: var(--chart-2);

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -11722,7 +11722,7 @@ export const VulnFindingSchema = {
 
 export const SiteVulnerabilitiesResponseSchema = {
   type: "object",
-  required: ["items", "attribution", "feed_ok"],
+  required: ["items", "attribution", "feed_ok", "enrichment_available"],
   properties: {
     items: {
       type: "array",
@@ -11740,6 +11740,15 @@ export const SiteVulnerabilitiesResponseSchema = {
       type: "string",
       format: "date-time",
     },
+    enrichment_available: {
+      type: "boolean",
+      description:
+        "True when the Production feed has successfully enriched findings with CVSS/CVE data, independent of feed_ok (which tracks Scanner-driven detection freshness).",
+    },
+    last_enrichment_at: {
+      type: "string",
+      format: "date-time",
+    },
   },
 } as const;
 
@@ -11751,9 +11760,11 @@ export const FleetVulnerabilitiesResponseSchema = {
     "high",
     "medium",
     "low",
+    "unknown",
     "items",
     "attribution",
     "feed_ok",
+    "enrichment_available",
   ],
   properties: {
     total_open: {
@@ -11770,6 +11781,11 @@ export const FleetVulnerabilitiesResponseSchema = {
     },
     low: {
       type: "integer",
+    },
+    unknown: {
+      type: "integer",
+      description:
+        "Findings with neither a CVSS rating nor a numeric score yet — genuinely unknown severity, not a confirmed low.",
     },
     items: {
       type: "array",
@@ -11800,6 +11816,15 @@ export const FleetVulnerabilitiesResponseSchema = {
       type: "boolean",
     },
     feed_synced: {
+      type: "string",
+      format: "date-time",
+    },
+    enrichment_available: {
+      type: "boolean",
+      description:
+        "True when the Production feed has successfully enriched findings with CVSS/CVE data, independent of feed_ok (which tracks Scanner-driven detection freshness).",
+    },
+    last_enrichment_at: {
       type: "string",
       format: "date-time",
     },
@@ -12924,7 +12949,13 @@ export const AdminAccountsTenancySchema = {
 
 export const AdminVulnFeedStatusSchema = {
   type: "object",
-  required: ["configured", "source", "feed_ok", "record_count"],
+  required: [
+    "configured",
+    "source",
+    "feed_ok",
+    "record_count",
+    "enrichment_available",
+  ],
   properties: {
     configured: {
       type: "boolean",
@@ -12945,6 +12976,15 @@ export const AdminVulnFeedStatusSchema = {
     },
     last_error: {
       type: "string",
+    },
+    enrichment_available: {
+      type: "boolean",
+      description:
+        "True when the Production feed has successfully enriched findings with CVSS/CVE data, independent of feed_ok (which tracks Scanner-driven detection freshness).",
+    },
+    last_enrichment_at: {
+      type: "string",
+      format: "date-time",
     },
   },
 } as const;

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -6365,6 +6365,11 @@ export type SiteVulnerabilitiesResponse = {
   attribution: VulnAttribution;
   feed_ok: boolean;
   feed_synced?: string;
+  /**
+   * True when the Production feed has successfully enriched findings with CVSS/CVE data, independent of feed_ok (which tracks Scanner-driven detection freshness).
+   */
+  enrichment_available: boolean;
+  last_enrichment_at?: string;
 };
 
 export type FleetVulnerabilitiesResponse = {
@@ -6373,6 +6378,10 @@ export type FleetVulnerabilitiesResponse = {
   high: number;
   medium: number;
   low: number;
+  /**
+   * Findings with neither a CVSS rating nor a numeric score yet — genuinely unknown severity, not a confirmed low.
+   */
+  unknown: number;
   items: Array<{
     site_id: string;
     site_name: string;
@@ -6382,6 +6391,11 @@ export type FleetVulnerabilitiesResponse = {
   attribution: VulnAttribution;
   feed_ok: boolean;
   feed_synced?: string;
+  /**
+   * True when the Production feed has successfully enriched findings with CVSS/CVE data, independent of feed_ok (which tracks Scanner-driven detection freshness).
+   */
+  enrichment_available: boolean;
+  last_enrichment_at?: string;
 };
 
 export type SmtpSettings = {
@@ -6773,6 +6787,11 @@ export type AdminVulnFeedStatus = {
   record_count: number;
   last_synced?: string;
   last_error?: string;
+  /**
+   * True when the Production feed has successfully enriched findings with CVSS/CVE data, independent of feed_ok (which tracks Scanner-driven detection freshness).
+   */
+  enrichment_available: boolean;
+  last_enrichment_at?: string;
 };
 
 export type AgentActivityIngestRequest = {

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.71
+  version: 0.61.72
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,
@@ -20125,7 +20125,7 @@ components:
           items: { type: string }
     SiteVulnerabilitiesResponse:
       type: object
-      required: [items, attribution, feed_ok]
+      required: [items, attribution, feed_ok, enrichment_available]
       properties:
         items:
           type: array
@@ -20133,15 +20133,22 @@ components:
         attribution: { $ref: "#/components/schemas/VulnAttribution" }
         feed_ok: { type: boolean }
         feed_synced: { type: string, format: date-time }
+        enrichment_available:
+          type: boolean
+          description: True when the Production feed has successfully enriched findings with CVSS/CVE data, independent of feed_ok (which tracks Scanner-driven detection freshness).
+        last_enrichment_at: { type: string, format: date-time }
     FleetVulnerabilitiesResponse:
       type: object
-      required: [total_open, critical, high, medium, low, items, attribution, feed_ok]
+      required: [total_open, critical, high, medium, low, unknown, items, attribution, feed_ok, enrichment_available]
       properties:
         total_open: { type: integer }
         critical: { type: integer }
         high: { type: integer }
         medium: { type: integer }
         low: { type: integer }
+        unknown:
+          type: integer
+          description: Findings with neither a CVSS rating nor a numeric score yet — genuinely unknown severity, not a confirmed low.
         items:
           type: array
           items:
@@ -20155,6 +20162,10 @@ components:
         attribution: { $ref: "#/components/schemas/VulnAttribution" }
         feed_ok: { type: boolean }
         feed_synced: { type: string, format: date-time }
+        enrichment_available:
+          type: boolean
+          description: True when the Production feed has successfully enriched findings with CVSS/CVE data, independent of feed_ok (which tracks Scanner-driven detection freshness).
+        last_enrichment_at: { type: string, format: date-time }
 
     # ---------------------------------------------------------------------------
     # ADR-045 instance SMTP settings
@@ -20628,7 +20639,7 @@ components:
               member_count: { type: integer, format: int64 }
     AdminVulnFeedStatus:
       type: object
-      required: [configured, source, feed_ok, record_count]
+      required: [configured, source, feed_ok, record_count, enrichment_available]
       properties:
         configured: { type: boolean }
         source: { type: string, enum: [ui, env, none] }
@@ -20636,6 +20647,10 @@ components:
         record_count: { type: integer }
         last_synced: { type: string, format: date-time }
         last_error: { type: string }
+        enrichment_available:
+          type: boolean
+          description: True when the Production feed has successfully enriched findings with CVSS/CVE data, independent of feed_ok (which tracks Scanner-driven detection freshness).
+        last_enrichment_at: { type: string, format: date-time }
 
     # ---------------------------------------------------------------------------
     # Agent protocol — activity / diagnostics / errors / security ingest


### PR DESCRIPTION
## GH #245 — a CVSS 9.8 core RCE was displayed with a `Low` badge

Root cause (confirmed, **free-tier CVSS is obtainable — this is a bug, not a paywall**): Wordfence Intelligence v3 enforces ~1 request per 30 min *globally per key*. The worker fetched the Scanner feed, slept **2 seconds**, then fetched the Production feed (the CVSS source) in the same run, so Production was **429'd every cycle** and the 429 handler retried inside the same unescapable window. Enrichment never merged, every finding stored with no CVSS, and `SeverityFromRating`'s no-data fallback silently returned `Low`. The scanner-only run still stamped the feed green, so it was invisible.

### Fix (correct + honest defense-in-depth)
- **Fetch:** alternate Scanner/Production across the hourly runs (persisted, atomically-flipped `next_feed_kind`; first run = Scanner, the detection base) so exactly one request lands per 30-min window and real CVSS is ingested. Scanner is the detection authority; Production runs only enrich via a **sticky COALESCE upsert** that never nulls cvss/cve/cwe/`reference_urls` (the last needs `NULLIF('[]')` since absent refs default to a non-NULL empty array). Enrichment health is tracked separately from detection health.
- **Severity:** new `Unknown` bucket — the no-data fallback returns Unknown, never Low (and not err-high, which would flip everything to false Criticals). Own count, sums into the total, sorts above Medium/Low, treated as elevated; CHECK widened by m101 before any code writes it.
- **Honest degraded state:** `enrichment_available` drives an amber "severity data unavailable" banner on the Vulnerabilities page + admin feed card. Unknown chip is a distinct neutral slate (AA both themes).
- **Heal:** existing rows re-derive severity on the next scan once CVSS lands; a post-deploy rescan heals immediately.
- **Docs:** the "shows severity on a free key" claim becomes *true*, so it's kept, not corrected.

### Verification
Research → build → 2-lens adversarial verify → re-verify. The verify confirmed no severity flap, correct first-run cursor, CVSS lands end-to-end, rows heal, migration safe — and caught the one miss (`reference_urls` not sticky, now fixed) + an AA contrast nudge. Gates: api go suite green (6 vuln integration tests incl. sticky-cvss, sticky-refs, **CVSS-lands-in-DB**, one-request-per-run, no-in-window-retry; route coverage); web 1126 tests + lint 0 + vite build + impeccable 0 new. CP + web; agent unaffected. openapi/CHANGELOG/marketing in lockstep.

**Post-deploy check (standing):** trigger a rescan and confirm real Critical/High appear — a persistent all-Unknown fleet would mean the fetch fix didn't take.

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWiZ4iJ1fmYW8vtPghWmsn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Unknown** severity category for findings without available CVSS data.
  * Unknown-severity findings are highlighted as requiring attention and can be filtered separately.
  * Added clear indicators when vulnerability severity enrichment is unavailable, including last successful enrichment time.

* **Bug Fixes**
  * Prevented missing severity data from being incorrectly reported as Low.
  * Improved preservation of vulnerability details during feed updates.
  * Improved handling of rate-limited or unavailable enrichment feeds.

* **Chores**
  * Updated the release version to 0.61.72.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->