### PR TITLE
fix(api): enforce Wordfence feed request spacing by wall-clock (GH #245 follow-up) — 0.61.73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
-## [0.61.72] - 2026-07-19
+## [0.61.73] - 2026-07-19
+
+### Fixed
+
+- Follow-up to the vulnerability-severity fix (GH #245): the CVSS enrichment feed now refreshes reliably. The previous release alternated the two Wordfence feeds across syncs to respect the feed's rate limit, but that only worked if syncs were spaced far apart; when two syncs happened close together (for example a manual refresh shortly after a scheduled one, which are tracked in separate schedules and so are not de-duplicated against each other), the enrichment request was still rate-limited and skipped, leaving severities unrated for longer. The control plane now enforces the minimum spacing by wall-clock time: a sync that would arrive too soon after the previous request is skipped entirely (no request is made), and the feed it intended to fetch is retried on the next eligible run rather than passed over, so CVSS severities populate on the first available cycle regardless of how the syncs are timed. Control plane only.
 
 ### Fixed
 

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.72
+ * Version:           0.61.73
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.72');
+define('WPMGR_AGENT_VERSION', '0.61.73');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -3714,10 +3714,17 @@ CREATE TABLE IF NOT EXISTS wordfence_vuln_feed_meta (
     enrichment_ok      boolean NOT NULL DEFAULT false,
     last_enrichment_at timestamptz,
     -- m101 — Scanner/Production alternation cursor (internal worker state
-    -- only; never exposed via the API). See internal/vuln/repo.go NextFeedKind.
+    -- only; never exposed via the API). Advances only inside StampFeedMeta,
+    -- on a successful non-empty ingest — see internal/vuln/repo.go GetFeedGate.
     next_feed_kind     text NOT NULL DEFAULT 'scanner'
         CONSTRAINT wordfence_vuln_feed_meta_next_feed_chk
-        CHECK (next_feed_kind IN ('scanner', 'production'))
+        CHECK (next_feed_kind IN ('scanner', 'production')),
+    -- m102 — wall-clock time of the last ACTUAL Wordfence HTTP request (any
+    -- status code). Internal worker state only; never exposed via the API.
+    -- FeedWorker.Work() gates every run on this, not on assumed job cadence
+    -- (GH #245 post-deploy: a manually triggered sync landed 6 minutes after
+    -- the periodic tick, well inside Wordfence's ~30-min rate-limit window).
+    last_request_at    timestamptz
 );
 
 -- ---------------------------------------------------------------------------

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -1258,6 +1258,7 @@ type WordfenceVulnFeedMetum struct {
 	EnrichmentOk     bool               `json:"enrichment_ok"`
 	LastEnrichmentAt pgtype.Timestamptz `json:"last_enrichment_at"`
 	NextFeedKind     string             `json:"next_feed_kind"`
+	LastRequestAt    pgtype.Timestamptz `json:"last_request_at"`
 }
 
 type WordfenceVulnSoftware struct {

--- a/apps/api/internal/vuln/repo.go
+++ b/apps/api/internal/vuln/repo.go
@@ -406,7 +406,15 @@ func (r *Repo) PruneMissingVulns(ctx context.Context, tx pgx.Tx, knownIDs []stri
 }
 
 // StampFeedMeta writes the freshness + attribution sentinel row after a
-// successful ingest of either feed.
+// successful ingest of either feed, and ADVANCES the Scanner/Production
+// alternation cursor (next_feed_kind) to the other value.
+//
+// StampFeedMeta is called ONLY on a successful, non-empty ingest (see
+// FeedWorker.ingestRecords) — every other outcome (spacing-skip, 429,
+// zero-record response, hard fetch/ingest error) leaves the cursor untouched,
+// so a feed that hasn't yet been successfully fetched is never abandoned: the
+// next eligible (>=31min-spaced) run retries the SAME feed kind until it
+// finally lands (GH #245 wall-clock-spacing follow-up).
 //
 // defiant_notice/defiant_license/mitre_notice are written via COALESCE so a
 // run whose records happened not to carry a copyrights block (odd shape,
@@ -430,12 +438,31 @@ func (r *Repo) StampFeedMeta(ctx context.Context, tx pgx.Tx, meta FeedMetaUpdate
 			mitre_notice       = COALESCE($6, mitre_notice),
 			last_error         = $7,
 			enrichment_ok      = COALESCE($8, enrichment_ok),
-			last_enrichment_at = COALESCE($9, last_enrichment_at)
+			last_enrichment_at = COALESCE($9, last_enrichment_at),
+			next_feed_kind     = CASE next_feed_kind
+				WHEN 'scanner' THEN 'production'
+				ELSE 'scanner'
+			END
 		WHERE id = 1`,
 		meta.FetchedAt, meta.OK, meta.RecordCount,
 		nilString(meta.DefiantNotice), nilString(meta.DefiantLicense),
 		nilString(meta.MitreNotice), nilString(meta.LastError),
 		meta.EnrichmentOK, meta.LastEnrichmentAt,
+	)
+	return err
+}
+
+// StampRequestAt records the wall-clock time of an ACTUAL Wordfence HTTP
+// request — called whenever fetchFeed got a response from Wordfence's server,
+// regardless of status code (200 OR 429 both consume the shared ~30-min
+// rate-limit slot; a transport-level failure that never reached Wordfence
+// does not). This is deliberately separate from fetched_at, which is
+// success-only: last_request_at is the wall-clock input to Work()'s spacing
+// gate (GetFeedGate), so the gate is accurate even across a run that 429'd.
+func (r *Repo) StampRequestAt(ctx context.Context, at time.Time) error {
+	_, err := r.pool.Exec(ctx,
+		`UPDATE wordfence_vuln_feed_meta SET last_request_at = $1 WHERE id = 1`,
+		at,
 	)
 	return err
 }
@@ -511,32 +538,43 @@ func (r *Repo) GetFeedMetaStatus(ctx context.Context) (ok bool, recordCount int,
 	return meta.OK, meta.RecordCount, meta.FetchedAt, meta.LastError, meta.EnrichmentOK, meta.LastEnrichmentAt, nil
 }
 
-// NextFeedKind atomically reads-and-advances the Scanner/Production
-// alternation cursor, returning the feed kind ("scanner"|"production") this
-// worker cycle should fetch. The cursor is flipped in the SAME statement via
-// a CTE + row lock, so alternation is a pure function of invocation count —
-// it does not depend on whether this cycle's fetch succeeds. That keeps the
-// invariant simple: each periodic run issues at most one Wordfence HTTP
-// request, and successive runs always target the other feed.
-func (r *Repo) NextFeedKind(ctx context.Context) (string, error) {
-	var kind string
+// FeedGate is the worker's fetch-eligibility + alternation-cursor state, read
+// once at the top of Work(). Internal worker bookkeeping only — never
+// exposed via the API (mirrors next_feed_kind's existing internal-only status).
+type FeedGate struct {
+	// FeedKind is the feed ("scanner"|"production") this cycle should fetch
+	// IF eligible. It only changes when StampFeedMeta successfully advances it
+	// after a completed ingest — never on a read.
+	FeedKind string
+	// LastRequestAt is the wall-clock time of the last ACTUAL Wordfence HTTP
+	// request (any status code), or nil if none has ever been made. Work()
+	// uses this — NOT an assumption about job cadence — to enforce the
+	// ~30-min global rate-limit spacing (GH #245 follow-up: consecutive
+	// periodic + manually-triggered runs can land far closer together than
+	// the nominal hourly cadence).
+	LastRequestAt *time.Time
+}
+
+// GetFeedGate reads the current alternation cursor and last-request timestamp
+// WITHOUT mutating anything — a pure read. Advancing next_feed_kind (via
+// StampFeedMeta) and stamping last_request_at (via StampRequestAt) are
+// separate, explicit steps the caller invokes only after it has decided to
+// actually make a request and, for the cursor, only after that request's
+// ingest succeeds.
+func (r *Repo) GetFeedGate(ctx context.Context) (FeedGate, error) {
+	var g FeedGate
+	var lastRequestAt pgtype.Timestamptz
 	err := r.pool.QueryRow(ctx, `
-		WITH cur AS (
-			SELECT next_feed_kind FROM wordfence_vuln_feed_meta WHERE id = 1 FOR UPDATE
-		)
-		UPDATE wordfence_vuln_feed_meta m
-		SET next_feed_kind = CASE cur.next_feed_kind
-			WHEN 'scanner' THEN 'production'
-			ELSE 'scanner'
-		END
-		FROM cur
-		WHERE m.id = 1
-		RETURNING cur.next_feed_kind`,
-	).Scan(&kind)
+		SELECT next_feed_kind, last_request_at FROM wordfence_vuln_feed_meta WHERE id = 1`,
+	).Scan(&g.FeedKind, &lastRequestAt)
 	if err != nil {
-		return "", fmt.Errorf("advance feed cursor: %w", err)
+		return g, fmt.Errorf("get feed gate: %w", err)
 	}
-	return kind, nil
+	if lastRequestAt.Valid {
+		t := lastRequestAt.Time
+		g.LastRequestAt = &t
+	}
+	return g, nil
 }
 
 // LookupSoftware returns all vulnerability software rows for the given (kind, slug).

--- a/apps/api/internal/vuln/worker.go
+++ b/apps/api/internal/vuln/worker.go
@@ -66,8 +66,24 @@ func (RescanSiteArgs) Kind() string { return "vuln_rescan_site" }
 // cycle, so Production — and therefore all CVSS/CVE enrichment — never landed
 // (GH #245: every finding fell back to a fabricated "low" severity, hiding a
 // real CVSS 9.8 core RCE). The fix: alternate feeds across successive runs via
-// a persisted cursor (Repo.NextFeedKind) so each run issues exactly ONE
-// request, comfortably inside the rate-limit window.
+// a persisted cursor (Repo.GetFeedGate / StampFeedMeta) so each run issues
+// exactly ONE request, comfortably inside the rate-limit window.
+//
+// Follow-up (GH #245 post-deploy): the alternation above relied on the FALSE
+// assumption that consecutive runs are ~1h apart. In prod, a manually
+// triggered sync (admin.VulnFeedKeyService.TriggerSync, deduped on its own
+// 5-min ByPeriod window — distinct from the hourly periodic job's 1h ByPeriod
+// window, so River does NOT treat them as duplicates of each other) landed
+// only 6 minutes after the periodic tick, so the second (Production) request
+// still fell inside the 30-min window and 429'd — and because the cursor used
+// to advance unconditionally, Production was abandoned for a full cycle
+// instead of retried. Fix: Work() now enforces the spacing by WALL-CLOCK
+// (Repo.GetFeedGate.LastRequestAt, stamped on every actual request — 200 or
+// 429), skipping the entire run (zero requests) when too soon, and the
+// cursor advances ONLY inside StampFeedMeta after a successful, non-empty
+// ingest — never on a skip, a 429, or any other failure — so an abandoned
+// feed is always retried on the next eligible run instead of being skipped
+// over.
 const (
 	ScannerFeedURL    = "https://www.wordfence.com/api/intelligence/v3/vulnerabilities/scanner"
 	ProductionFeedURL = "https://www.wordfence.com/api/intelligence/v3/vulnerabilities/production"
@@ -80,12 +96,19 @@ const (
 	FeedKindProduction = "production"
 )
 
+// minRequestSpacing is the minimum wall-clock gap Work() enforces between two
+// ACTUAL Wordfence HTTP requests, regardless of job/trigger cadence. Wordfence
+// enforces ~30 minutes; the extra 1-minute margin absorbs clock/scheduling
+// jitter so a request is never dispatched right at the edge of the window.
+const minRequestSpacing = 31 * time.Minute
+
 // errRateLimited marks a 429 from the Wordfence feed. Wordfence documents no
 // Retry-After and no per-window number ("too many requests in a short period"),
 // so a 429 must NOT trigger an immediate in-process retry — that just re-hits
 // the endpoint and keeps the rate-limit window warm. Instead we stamp the
-// status and succeed; the next scheduled run (which targets the ALTERNATE
-// feed, per NextFeedKind) is the natural, well-spaced retry.
+// status and succeed; the next ELIGIBLE run (wall-clock spaced, see
+// minRequestSpacing) is the natural, well-spaced retry of the SAME feed (the
+// cursor does not advance on a 429).
 var errRateLimited = errors.New("wordfence feed rate limited (429)")
 
 // FeedHTTPDoer is the subset of httpclient.Client the feed worker needs.
@@ -152,7 +175,7 @@ func (w *FeedWorker) SetService(svc *Service) { w.svc = svc }
 
 // Timeout gives the feed refresh job 10 minutes. A full-dump ingest of ~13k
 // records via CopyFrom completes in seconds, but the single HTTP fetch (one
-// feed per run — see NextFeedKind) + any Postgres latency under load consume
+// feed per run — see GetFeedGate) + any Postgres latency under load consume
 // real wall time. 10 minutes is generous headroom well above the expected
 // 15–30s wall time and avoids the context deadline that previously killed the
 // per-record loop.
@@ -160,10 +183,13 @@ func (w *FeedWorker) Timeout(*river.Job[FeedRefreshArgs]) time.Duration {
 	return 10 * time.Minute
 }
 
-// Work performs the feed refresh: exactly ONE Wordfence Intelligence HTTP
+// Work performs the feed refresh: at most ONE Wordfence Intelligence HTTP
 // request per invocation, alternating Scanner/Production across successive
-// runs (see the package-level doc comment above the feed URL constants and
-// Repo.NextFeedKind).
+// ELIGIBLE runs (see the package-level doc comment above the feed URL
+// constants and Repo.GetFeedGate). Eligibility is gated by WALL-CLOCK spacing
+// since the last actual request, not by an assumption about job cadence —
+// consecutive runs (periodic + a manually triggered sync, or any other
+// clustering) can land far closer together than the nominal hourly interval.
 func (w *FeedWorker) Work(ctx context.Context, job *river.Job[FeedRefreshArgs]) error {
 	// Resolve the key at run-time so a UI-set key takes effect on the next job
 	// without requiring a restart. Priority: UI key > env key > no-op.
@@ -175,15 +201,26 @@ func (w *FeedWorker) Work(ctx context.Context, job *river.Job[FeedRefreshArgs]) 
 	}
 	_ = source // used only for debug logging above
 
-	// Advance the alternation cursor first: the flip is unconditional (does
-	// not depend on this cycle's outcome) so successive runs strictly
-	// alternate feeds regardless of transient failures. Fall back to Scanner
-	// on a cursor read error so a meta-row hiccup never wedges the worker.
-	feedKind, cerr := w.repo.NextFeedKind(ctx)
-	if cerr != nil {
-		w.logger.Warn("vuln: failed to read feed alternation cursor; defaulting to scanner",
-			slog.Any("error", cerr))
-		feedKind = FeedKindScanner
+	// Read (never mutate) the alternation cursor + last-request timestamp.
+	// Fall back to Scanner/no-prior-request on a read error so a meta-row
+	// hiccup never wedges the worker.
+	gate, gerr := w.repo.GetFeedGate(ctx)
+	feedKind := FeedKindScanner
+	if gerr != nil {
+		w.logger.Warn("vuln: failed to read feed gate; defaulting to scanner",
+			slog.Any("error", gerr))
+	} else {
+		feedKind = gate.FeedKind
+		if gate.LastRequestAt != nil {
+			if elapsed := time.Since(*gate.LastRequestAt); elapsed < minRequestSpacing {
+				// Make NO Wordfence request this cycle and leave the cursor
+				// exactly where it is: the next eligible run retries the SAME
+				// feed kind, so nothing is ever abandoned by a too-soon run.
+				w.logger.Info("vuln: skipping feed refresh, <31m since last Wordfence request (rate-limit spacing)",
+					slog.Float64("elapsed_minutes", elapsed.Minutes()))
+				return nil
+			}
+		}
 	}
 	feedURL := ScannerFeedURL
 	if feedKind == FeedKindProduction {
@@ -192,16 +229,29 @@ func (w *FeedWorker) Work(ctx context.Context, job *river.Job[FeedRefreshArgs]) 
 
 	w.logger.Info("vuln: starting Wordfence Intelligence feed refresh", slog.String("feed", feedKind))
 
-	records, defiantNotice, defiantLicense, mitreNotice, err := w.fetchFeed(ctx, feedURL, apiKey)
+	records, defiantNotice, defiantLicense, mitreNotice, requested, err := w.fetchFeed(ctx, feedURL, apiKey)
+	if requested {
+		// A response was received from Wordfence's server (200, 429, or any
+		// other status) — that attempt consumed the shared rate-limit slot,
+		// regardless of outcome, so the wall-clock gate above must see it on
+		// the next run. A pure transport failure (requested=false) never
+		// reached Wordfence and does not count.
+		if serr := w.repo.StampRequestAt(ctx, time.Now().UTC()); serr != nil {
+			w.logger.Warn("vuln: failed to stamp last_request_at", slog.Any("error", serr))
+		}
+	}
 	if err != nil {
 		if errors.Is(err, errRateLimited) {
 			// Do NOT retry inside this cycle: a globally rate-limited window
-			// cannot be escaped by an immediate retry. Stamp degraded and let
-			// the next scheduled run — which targets the ALTERNATE feed and is
-			// naturally ~1 hour away — recover. A Production rate-limit must
-			// NOT flip the detection ok flag (RescanSite gates on it); a
-			// Scanner rate-limit legitimately does, matching prior behavior.
-			msg := fmt.Sprintf("%s feed rate limited by Wordfence; will retry on the next scheduled refresh", feedKind)
+			// cannot be escaped by an immediate retry. Stamp degraded and
+			// leave the cursor untouched (belt-and-suspenders: the wall-clock
+			// gate above should normally prevent reaching this branch at all,
+			// but an external caller could still consume the shared slot) —
+			// the next ELIGIBLE run retries the SAME feed. A Production
+			// rate-limit must NOT flip the detection ok flag (RescanSite
+			// gates on it); a Scanner rate-limit legitimately does, matching
+			// prior behavior.
+			msg := fmt.Sprintf("%s feed rate limited by Wordfence; will retry on the next eligible refresh", feedKind)
 			if feedKind == FeedKindProduction {
 				_ = w.repo.StampEnrichmentDegraded(ctx, msg)
 			} else {
@@ -222,6 +272,8 @@ func (w *FeedWorker) Work(ctx context.Context, job *river.Job[FeedRefreshArgs]) 
 		// Scanner-driven catalog from the last successful Scanner run is still
 		// perfectly valid. A zero-record Scanner response is treated as before
 		// (ok=false): it means we have no usable detection catalog this cycle.
+		// Neither path advances the cursor — the SAME feed is retried next
+		// eligible run.
 		msg := fmt.Sprintf("%s feed returned zero records; not applying update", feedKind)
 		if feedKind == FeedKindProduction {
 			_ = w.repo.StampEnrichmentDegraded(ctx, msg)
@@ -257,6 +309,10 @@ func (w *FeedWorker) Work(ctx context.Context, job *river.Job[FeedRefreshArgs]) 
 		meta.LastEnrichmentAt = &now
 	}
 
+	// ingestRecords calls StampFeedMeta, which — ONLY on this successful,
+	// non-empty-ingest path — also advances next_feed_kind to the other feed.
+	// Every other outcome above (spacing-skip, 429, zero records, hard error)
+	// returns before reaching here, leaving the cursor exactly as it was.
 	pgErr := w.ingestRecords(ctx, records, knownIDs, meta, feedKind)
 	if pgErr != nil {
 		_ = w.repo.StampFeedError(ctx, pgErr.Error())
@@ -339,21 +395,36 @@ func (w *FeedWorker) ingestRecords(ctx context.Context, records map[string]FeedR
 
 // fetchFeed downloads and parses a Wordfence Intelligence V3 feed URL.
 // The V3 feed is a JSON object keyed by vuln UUID: { "<uuid>": { ... }, ... }.
-// Returned values: records map, defiant notice, defiant license, mitre notice, error.
-func (w *FeedWorker) fetchFeed(ctx context.Context, feedURL, apiKey string) (map[string]FeedRecord, string, string, string, error) {
+//
+// Returned values: records map, defiant notice, defiant license, mitre
+// notice, requested, error. requested reports whether a response was actually
+// received from Wordfence's server (true for EVERY status code — 200, 429,
+// 401/403, 5xx, or any other — since all of those represent a completed
+// network round-trip that counts against the shared ~30-min rate-limit slot).
+// requested is false only when the request never reached Wordfence at all
+// (building the *http.Request failed, or the transport-level Do() call itself
+// errored — DNS/connect/timeout before any response). The caller
+// (FeedWorker.Work) uses requested to decide whether to stamp last_request_at.
+func (w *FeedWorker) fetchFeed(ctx context.Context, feedURL, apiKey string) (records map[string]FeedRecord, defiantNotice, defiantLicense, mitreNotice string, requested bool, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, feedURL, nil)
 	if err != nil {
-		return nil, "", "", "", err
+		return nil, "", "", "", false, err
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", "WPMgr-VulnScanner/1.0")
 
-	resp, err := w.client.Do(req)
-	if err != nil {
-		return nil, "", "", "", fmt.Errorf("http get %s: %w", feedURL, err)
+	resp, doErr := w.client.Do(req)
+	if doErr != nil {
+		// Transport-level failure: no response ever came back from Wordfence,
+		// so this attempt did not consume the shared rate-limit slot.
+		return nil, "", "", "", false, fmt.Errorf("http get %s: %w", feedURL, doErr)
 	}
 	defer func() { _ = resp.Body.Close() }()
+
+	// A response was received — from here on every return path counts as a
+	// real request against the rate-limit window, regardless of status code.
+	requested = true
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -362,7 +433,7 @@ func (w *FeedWorker) fetchFeed(ctx context.Context, feedURL, apiKey string) (map
 		// Bad or missing API key — surface a clean error without including the key
 		// itself in the message (the message is stored in wordfence_vuln_feed_meta
 		// and returned to the superadmin via the status endpoint).
-		return nil, "", "", "", fmt.Errorf("feed auth failed (HTTP %d): check the Wordfence Intelligence API key in the superadmin settings", resp.StatusCode)
+		return nil, "", "", "", requested, fmt.Errorf("feed auth failed (HTTP %d): check the Wordfence Intelligence API key in the superadmin settings", resp.StatusCode)
 	case http.StatusTooManyRequests:
 		// Do NOT retry inside this cycle: Wordfence's rate limit is a ~30-minute
 		// GLOBAL window per API key with no documented Retry-After and no fixed
@@ -371,12 +442,12 @@ func (w *FeedWorker) fetchFeed(ctx context.Context, feedURL, apiKey string) (map
 		// keeps the window warm (this was the direct mechanism behind GH #245:
 		// the Production fetch was always the second request in the same
 		// cycle, so it 429'd every time). The caller stamps degraded status and
-		// returns; the next scheduled run — which alternates to the OTHER feed
-		// via NextFeedKind — is the well-spaced retry.
-		return nil, "", "", "", fmt.Errorf("rate limited (429) fetching %s: %w", feedURL, errRateLimited)
+		// returns; the next ELIGIBLE run (wall-clock spaced) retries the SAME
+		// feed since the cursor does not advance on a 429.
+		return nil, "", "", "", requested, fmt.Errorf("rate limited (429) fetching %s: %w", feedURL, errRateLimited)
 	default:
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return nil, "", "", "", fmt.Errorf("unexpected status %d from %s: %s", resp.StatusCode, feedURL, body)
+		return nil, "", "", "", requested, fmt.Errorf("unexpected status %d from %s: %s", resp.StatusCode, feedURL, body)
 	}
 
 	// Stream-decode the root JSON object so we don't load multi-MB into memory
@@ -384,18 +455,17 @@ func (w *FeedWorker) fetchFeed(ctx context.Context, feedURL, apiKey string) (map
 	dec := json.NewDecoder(resp.Body)
 
 	// Read opening "{".
-	if tok, err := dec.Token(); err != nil || tok.(json.Delim) != '{' {
-		return nil, "", "", "", fmt.Errorf("expected root object from %s", feedURL)
+	if tok, terr := dec.Token(); terr != nil || tok.(json.Delim) != '{' {
+		return nil, "", "", "", requested, fmt.Errorf("expected root object from %s", feedURL)
 	}
 
-	records := make(map[string]FeedRecord)
-	var defiantNotice, defiantLicense, mitreNotice string
+	recs := make(map[string]FeedRecord)
 
 	for dec.More() {
 		// Read the vuln UUID key.
-		keyTok, err := dec.Token()
-		if err != nil {
-			return nil, "", "", "", fmt.Errorf("read key: %w", err)
+		keyTok, kerr := dec.Token()
+		if kerr != nil {
+			return nil, "", "", "", requested, fmt.Errorf("read key: %w", kerr)
 		}
 		vulnID, ok := keyTok.(string)
 		if !ok {
@@ -404,13 +474,13 @@ func (w *FeedWorker) fetchFeed(ctx context.Context, feedURL, apiKey string) (map
 
 		// Decode the record object as raw JSON first (so we can preserve it in raw).
 		var rawMsg json.RawMessage
-		if err := dec.Decode(&rawMsg); err != nil {
-			return nil, "", "", "", fmt.Errorf("decode record %s: %w", vulnID, err)
+		if derr := dec.Decode(&rawMsg); derr != nil {
+			return nil, "", "", "", requested, fmt.Errorf("decode record %s: %w", vulnID, derr)
 		}
 
-		rec, notice, license, mitre, err := parseFeedRecord(vulnID, rawMsg)
-		if err != nil {
-			if errors.Is(err, errNoUsableSoftware) {
+		rec, notice, license, mitre, perr := parseFeedRecord(vulnID, rawMsg)
+		if perr != nil {
+			if errors.Is(perr, errNoUsableSoftware) {
 				// A record with no usable software cannot match any site inventory.
 				// Skip at Debug level — this is expected for certain informational entries.
 				w.logger.Debug("vuln: skipping record with no usable software",
@@ -419,12 +489,12 @@ func (w *FeedWorker) fetchFeed(ctx context.Context, feedURL, apiKey string) (map
 				// Defensive catch-all: parseFeedRecord is designed to never return other
 				// errors, but guard here anyway.
 				w.logger.Warn("vuln: skipping unparseable record",
-					slog.String("vuln_id", vulnID), slog.Any("error", err))
+					slog.String("vuln_id", vulnID), slog.Any("error", perr))
 			}
 			continue
 		}
 
-		records[vulnID] = rec
+		recs[vulnID] = rec
 
 		// Capture the first non-empty attribution texts seen.
 		if defiantNotice == "" && notice != "" {
@@ -438,7 +508,7 @@ func (w *FeedWorker) fetchFeed(ctx context.Context, feedURL, apiKey string) (map
 		}
 	}
 
-	return records, defiantNotice, defiantLicense, mitreNotice, nil
+	return recs, defiantNotice, defiantLicense, mitreNotice, requested, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/migrations/20260804000000_m102_vuln_feed_request_spacing.sql
+++ b/apps/api/migrations/20260804000000_m102_vuln_feed_request_spacing.sql
@@ -1,0 +1,31 @@
+-- m102 — GH #245 post-deploy follow-up: enforce Wordfence request spacing by
+-- wall-clock, not by assumed job cadence.
+--
+-- m101 alternated Scanner/Production across successive worker runs assuming
+-- consecutive runs are ~1h apart (the periodic job's nominal cadence). Prod
+-- logs showed that assumption is false: an admin-triggered sync (deduped on
+-- its own 5-min ByPeriod window, independent of the periodic job's 1h
+-- ByPeriod window — River does not treat two different dedup windows as
+-- duplicates of each other) landed only ~6 minutes after the periodic tick,
+-- so the Production request still fell inside Wordfence's ~30-min global
+-- rate-limit window and 429'd — and because the cursor advanced
+-- unconditionally, Production was abandoned for a full cycle instead of
+-- retried. CVSS never landed; severities stayed 'unknown'.
+--
+-- Fix: last_request_at records the wall-clock time of the last ACTUAL
+-- Wordfence HTTP request (any status code — 200 or 429 both consume the
+-- shared rate-limit slot). internal/vuln/worker.go's Work() checks this at
+-- the START of every run, before making any request, and skips the entire
+-- run (zero requests) when less than the spacing threshold has elapsed. The
+-- Scanner/Production cursor (next_feed_kind, m101) now advances ONLY inside
+-- a successful, non-empty ingest (StampFeedMeta) — never on a spacing-skip,
+-- a 429, or any other failure — so an abandoned feed is always retried on the
+-- next eligible run rather than skipped over.
+--
+-- last_request_at is internal worker state only, like next_feed_kind — never
+-- exposed via the API.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS (mirrors m101/m92/m93).
+
+ALTER TABLE "public"."wordfence_vuln_feed_meta"
+    ADD COLUMN IF NOT EXISTS "last_request_at" timestamptz;

--- a/apps/api/tests/vuln_feed_alternation_integration_test.go
+++ b/apps/api/tests/vuln_feed_alternation_integration_test.go
@@ -19,6 +19,24 @@
 //   - a 429 on the Production leg degrades enrichment_ok without an in-window
 //     retry and WITHOUT affecting the detection-feed ok flag (which gates
 //     RescanSite).
+//
+// Post-deploy follow-up (m102): the alternation above relied on the FALSE
+// assumption that consecutive runs are ~1h apart. Prod logs showed a
+// manually-triggered sync landing only ~6 minutes after the periodic tick, so
+// the Production request still fell inside Wordfence's ~30-min window and
+// 429'd — and because the cursor used to advance unconditionally, Production
+// was abandoned for a full cycle. These tests additionally prove:
+//   - a run inside the 31-min wall-clock spacing window makes NO request and
+//     leaves the alternation cursor untouched (nothing is ever abandoned);
+//   - a run that IS eligible (spacing satisfied) fetches the feed the cursor
+//     still points at and advances it only on success;
+//   - last_request_at advances on both a 200 and a 429 (either consumes the
+//     shared rate-limit slot), but the cursor never advances on a 429.
+//
+// Because the spacing gate is wall-clock (time.Since, not injectable), tests
+// that drive more than one Work() call use backdateLastRequest to rewind
+// wordfence_vuln_feed_meta.last_request_at directly rather than sleeping for
+// 31+ real minutes.
 package tests
 
 import (
@@ -30,6 +48,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -131,6 +150,20 @@ func runFeedWork(t *testing.T, w *vuln.FeedWorker) error {
 	return w.Work(context.Background(), &river.Job[vuln.FeedRefreshArgs]{})
 }
 
+// backdateLastRequest rewinds wordfence_vuln_feed_meta.last_request_at so the
+// NEXT Work() call is immediately eligible to make a request, without a test
+// waiting the real 31-minute wall-clock spacing the gate enforces.
+func backdateLastRequest(t *testing.T, pool *db.Pool, ago time.Duration) {
+	t.Helper()
+	target := time.Now().UTC().Add(-ago)
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE wordfence_vuln_feed_meta SET last_request_at = $1 WHERE id = 1`,
+		target,
+	); err != nil {
+		t.Fatalf("backdate last_request_at: %v", err)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Fixture feed bodies
 // ---------------------------------------------------------------------------
@@ -218,9 +251,14 @@ func TestFeedWorker_AlternatesFeedsOneRequestPerRun(t *testing.T) {
 
 	// The alternation cursor defaults to 'scanner' (schema default), so run 1
 	// must hit the Scanner URL and run 2 must hit Production, run 3 back to
-	// Scanner — and each run must issue EXACTLY one HTTP request.
+	// Scanner — and each run must issue EXACTLY one HTTP request. Runs after
+	// the first are backdated to be immediately eligible under the wall-clock
+	// spacing gate (m102) — this test is about alternation, not spacing.
 	wantSequence := []string{vuln.ScannerFeedURL, vuln.ProductionFeedURL, vuln.ScannerFeedURL}
 	for i, wantURL := range wantSequence {
+		if i > 0 {
+			backdateLastRequest(t, pool, 32*time.Minute)
+		}
 		before := client.callCount()
 		if err := runFeedWork(t, w); err != nil {
 			t.Fatalf("run %d: Work returned error: %v", i+1, err)
@@ -258,7 +296,9 @@ func TestFeedWorker_ProductionFetch_CVSSLandsEndToEnd(t *testing.T) {
 		t.Fatalf("after scanner-only run: score=%v rating=%q cve=%q; want all empty (scanner never carries CVSS)", score, rating, cve)
 	}
 
-	// Run 2: Production enriches the SAME row.
+	// Run 2: Production enriches the SAME row. Backdate to be immediately
+	// eligible under the wall-clock spacing gate (m102).
+	backdateLastRequest(t, pool, 32*time.Minute)
 	if err := runFeedWork(t, w); err != nil {
 		t.Fatalf("run 2 (production): %v", err)
 	}
@@ -303,10 +343,13 @@ func TestFeedWorker_StickyEnrichment_ScannerRunPreservesCVSS(t *testing.T) {
 
 	w := buildFeedWorker(pool, client)
 
-	// Run 1: scanner (no cvss). Run 2: production (cvss lands).
+	// Run 1: scanner (no cvss). Run 2: production (cvss lands). Runs after the
+	// first are backdated to be immediately eligible under the wall-clock
+	// spacing gate (m102).
 	if err := runFeedWork(t, w); err != nil {
 		t.Fatalf("run 1 (scanner): %v", err)
 	}
+	backdateLastRequest(t, pool, 32*time.Minute)
 	if err := runFeedWork(t, w); err != nil {
 		t.Fatalf("run 2 (production): %v", err)
 	}
@@ -318,6 +361,7 @@ func TestFeedWorker_StickyEnrichment_ScannerRunPreservesCVSS(t *testing.T) {
 	// Run 3: scanner AGAIN, re-sending the SAME record with no cvss key. This
 	// is exactly the flap scenario GH #245's follow-up warns about: a naive
 	// blind-overwrite upsert would null cvss_score/cvss_rating right back out.
+	backdateLastRequest(t, pool, 32*time.Minute)
 	if err := runFeedWork(t, w); err != nil {
 		t.Fatalf("run 3 (scanner again): %v", err)
 	}
@@ -368,7 +412,9 @@ func TestFeedWorker_StickyEnrichment_ScannerRunPreservesReferences(t *testing.T)
 		t.Fatalf("after scanner-only run: reference_urls = %v; want empty", refs)
 	}
 
-	// Run 2: production lands a real reference URL.
+	// Run 2: production lands a real reference URL. Backdate to be
+	// immediately eligible under the wall-clock spacing gate (m102).
+	backdateLastRequest(t, pool, 32*time.Minute)
 	if err := runFeedWork(t, w); err != nil {
 		t.Fatalf("run 2 (production): %v", err)
 	}
@@ -382,6 +428,7 @@ func TestFeedWorker_StickyEnrichment_ScannerRunPreservesReferences(t *testing.T)
 	// exactly the value a naive COALESCE(EXCLUDED.x, existing.x) upsert cannot
 	// distinguish from "no update"; a blind overwrite would erase the URL
 	// Production just landed, making advisory link-outs oscillate every hour.
+	backdateLastRequest(t, pool, 32*time.Minute)
 	if err := runFeedWork(t, w); err != nil {
 		t.Fatalf("run 3 (scanner again): %v", err)
 	}
@@ -420,7 +467,11 @@ func TestFeedWorker_ProductionRateLimited_NoInWindowRetry_DetectionUnaffected(t 
 
 	// Run 2: production is rate-limited (429). Must return nil (no River
 	// retry) and must issue EXACTLY one HTTP request this cycle — no
-	// synchronous in-window retry loop.
+	// synchronous in-window retry loop. Backdate to be immediately eligible
+	// under the wall-clock spacing gate (m102) so this run actually attempts
+	// the request (rather than being spacing-skipped, which would also make
+	// zero requests but for a different reason).
+	backdateLastRequest(t, pool, 32*time.Minute)
 	before := client.callCount()
 	if err := runFeedWork(t, w); err != nil {
 		t.Fatalf("run 2 (production 429): Work returned an error; want nil (no River retry on a rate limit): %v", err)
@@ -446,6 +497,164 @@ func TestFeedWorker_ProductionRateLimited_NoInWindowRetry_DetectionUnaffected(t 
 	}
 	if meta.LastError == "" || !strings.Contains(strings.ToLower(meta.LastError), "rate limit") {
 		t.Errorf("meta.LastError = %q; want it to mention the rate limit", meta.LastError)
+	}
+
+	// Belt-and-suspenders: a 429 must NOT advance the cursor — the same feed
+	// (production) is retried on the next eligible run rather than abandoned.
+	gate, err := repo.GetFeedGate(context.Background())
+	if err != nil {
+		t.Fatalf("GetFeedGate after run 2: %v", err)
+	}
+	if gate.FeedKind != vuln.FeedKindProduction {
+		t.Errorf("cursor after a 429 = %q; want still %q (429 must not advance the cursor)", gate.FeedKind, vuln.FeedKindProduction)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// m102 follow-up: wall-clock request spacing, independent of job cadence.
+// ---------------------------------------------------------------------------
+
+// TestFeedWorker_SpacingSkip_NoRequestNoCursorAdvance covers (a)+(d): a run
+// that lands inside the 31-min wall-clock spacing window — regardless of how
+// long it's actually been since the periodic job last fired — makes NO
+// Wordfence request and leaves the alternation cursor untouched, so the feed
+// it intended to fetch is retried, never abandoned, on the next eligible run.
+// This is the direct regression guard for the prod incident: a scanner run at
+// 04:47 followed by a second run only 6 minutes later must now skip entirely
+// instead of 429ing on production and losing that cycle.
+func TestFeedWorker_SpacingSkip_NoRequestNoCursorAdvance(t *testing.T) {
+	pool := startPostgres(t)
+	const vulnID = "245-spacing-skip-vuln-1"
+	client := newFakeFeedHTTPClient()
+	client.setResponse(vuln.ScannerFeedURL, http.StatusOK, scannerBodyNoCVSS(vulnID))
+	client.setResponse(vuln.ProductionFeedURL, http.StatusOK, productionBodyWithCVSS(vulnID))
+
+	w := buildFeedWorker(pool, client)
+	repo := vuln.NewRepo(pool)
+
+	// Run 1: scanner succeeds — establishes last_request_at ~now, cursor -> production.
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 1 (scanner): %v", err)
+	}
+	if got := client.callCount(); got != 1 {
+		t.Fatalf("after run 1: callCount = %d; want 1", got)
+	}
+	gate, err := repo.GetFeedGate(context.Background())
+	if err != nil {
+		t.Fatalf("GetFeedGate after run 1: %v", err)
+	}
+	if gate.FeedKind != vuln.FeedKindProduction {
+		t.Fatalf("cursor after run 1 = %q; want %q", gate.FeedKind, vuln.FeedKindProduction)
+	}
+
+	// Run 2: immediately after (real elapsed time in a test is milliseconds,
+	// nowhere near 31 minutes) — must skip entirely: no request, no error,
+	// cursor unchanged.
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 2 (spacing skip): Work returned an error; want nil: %v", err)
+	}
+	if got := client.callCount(); got != 1 {
+		t.Errorf("after run 2 (spacing-skip): callCount = %d; want still 1 (no new request)", got)
+	}
+	gate, err = repo.GetFeedGate(context.Background())
+	if err != nil {
+		t.Fatalf("GetFeedGate after run 2: %v", err)
+	}
+	if gate.FeedKind != vuln.FeedKindProduction {
+		t.Errorf("cursor after a spacing-skip = %q; want still %q (unchanged — never abandon a feed)", gate.FeedKind, vuln.FeedKindProduction)
+	}
+}
+
+// TestFeedWorker_EligibleAfterSpacing_FetchesIntendedFeedAndAdvances covers
+// (b): once >=31 minutes have elapsed since the last actual Wordfence request
+// (simulated here via backdateLastRequest rather than a real 31-minute
+// sleep), the next run fetches the feed the cursor still points at (the one
+// abandoned by the earlier spacing-skip scenario) and, on success, advances
+// the cursor — proving production is fetched on the first eligible run
+// instead of being skipped over indefinitely.
+func TestFeedWorker_EligibleAfterSpacing_FetchesIntendedFeedAndAdvances(t *testing.T) {
+	pool := startPostgres(t)
+	const vulnID = "245-eligible-vuln-1"
+	client := newFakeFeedHTTPClient()
+	client.setResponse(vuln.ScannerFeedURL, http.StatusOK, scannerBodyNoCVSS(vulnID))
+	client.setResponse(vuln.ProductionFeedURL, http.StatusOK, productionBodyWithCVSS(vulnID))
+
+	w := buildFeedWorker(pool, client)
+	repo := vuln.NewRepo(pool)
+
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 1 (scanner): %v", err)
+	}
+	backdateLastRequest(t, pool, 32*time.Minute)
+
+	before := client.callCount()
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 2 (eligible production): %v", err)
+	}
+	after := client.callCount()
+	if after-before != 1 {
+		t.Errorf("run 2: made %d HTTP request(s); want exactly 1 (now eligible)", after-before)
+	}
+	if got := client.lastCall(); got != vuln.ProductionFeedURL {
+		t.Errorf("run 2: fetched %q; want %q (cursor pointed at production)", got, vuln.ProductionFeedURL)
+	}
+
+	gate, err := repo.GetFeedGate(context.Background())
+	if err != nil {
+		t.Fatalf("GetFeedGate: %v", err)
+	}
+	if gate.FeedKind != vuln.FeedKindScanner {
+		t.Errorf("cursor after a successful eligible production ingest = %q; want %q (advanced)", gate.FeedKind, vuln.FeedKindScanner)
+	}
+}
+
+// TestFeedWorker_LastRequestAt_UpdatesOn200And429 covers (c): last_request_at
+// must advance on EVERY actual Wordfence request, whether it succeeds (200)
+// or is rate-limited (429) — both consume the shared rate-limit slot, so both
+// must feed the wall-clock spacing gate (otherwise a 429 would look like "no
+// request happened" and the very next run could immediately re-hit the same
+// still-limited window).
+func TestFeedWorker_LastRequestAt_UpdatesOn200And429(t *testing.T) {
+	pool := startPostgres(t)
+	const vulnID = "245-last-req-vuln-1"
+	client := newFakeFeedHTTPClient()
+	client.setResponse(vuln.ScannerFeedURL, http.StatusOK, scannerBodyNoCVSS(vulnID))
+	client.setResponse(vuln.ProductionFeedURL, http.StatusTooManyRequests, `{"error":"rate limited"}`)
+
+	w := buildFeedWorker(pool, client)
+	repo := vuln.NewRepo(pool)
+
+	// Run 1: scanner succeeds (200) — last_request_at must be set.
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 1 (scanner 200): %v", err)
+	}
+	gate, err := repo.GetFeedGate(context.Background())
+	if err != nil {
+		t.Fatalf("GetFeedGate after run 1: %v", err)
+	}
+	if gate.LastRequestAt == nil {
+		t.Fatal("LastRequestAt is nil after a successful (200) request; want non-nil")
+	}
+	firstStamp := *gate.LastRequestAt
+
+	// Make run 2 eligible, then hit the 429 on production.
+	backdateLastRequest(t, pool, 32*time.Minute)
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 2 (production 429): %v", err)
+	}
+	gate, err = repo.GetFeedGate(context.Background())
+	if err != nil {
+		t.Fatalf("GetFeedGate after run 2: %v", err)
+	}
+	if gate.LastRequestAt == nil {
+		t.Fatal("LastRequestAt is nil after a 429; want non-nil (a 429 still consumes the rate-limit slot)")
+	}
+	if !gate.LastRequestAt.After(firstStamp) {
+		t.Errorf("LastRequestAt after the 429 (%v) did not advance past the first stamp (%v)", gate.LastRequestAt, firstStamp)
+	}
+	// Cursor must NOT have advanced on the 429 (same feed retried next eligible run).
+	if gate.FeedKind != vuln.FeedKindProduction {
+		t.Errorf("cursor after a 429 = %q; want still %q (429 does not advance the cursor)", gate.FeedKind, vuln.FeedKindProduction)
 	}
 }
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.72
+  version: 0.61.73
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Post-deploy prod verification of 0.61.72 caught that CVSS still wasn't landing. The alternation fix assumed consecutive feed runs are ~1h apart, but prod logs showed a scanner run at 04:47 then a manually-triggered sync at **04:53 — 6 minutes later** (manual sync and the hourly periodic job live in separate River dedup buckets, so they aren't deduped against each other). Production still landed inside Wordfence's 30-min per-key window and 429'd, and because the cursor advanced unconditionally, Production was abandoned for a full cycle.

### Fix — enforce the ≥30-min spacing by wall-clock
- `m102` adds `last_request_at`, stamped on every actual Wordfence request (200 **or** 429 — a 429 still consumed the slot).
- `Work()` reads the gate first; if <31m since the last request it **skips the whole run** (zero HTTP requests, cursor untouched).
- The alternation cursor now flips **only** inside `StampFeedMeta` (successful non-empty ingest). A spacing-skip, a 429, zero-records, or a hard error leave the cursor on the still-unfetched feed, so it's **retried next eligible run, not abandoned**. The old unconditional flip is removed.
- `fetchFeed` returns `requested bool` so `last_request_at` is stamped only when a request actually reached Wordfence.

Traced: 04:47 scanner (cursor→production); 04:53 skipped (<31m, no request, cursor stays production); first run ≥05:18 fetches production → success → CVSS lands.

CP-only; agent unaffected; no web/marketing change. Gates: go build/vet/test green (9 vuln integration tests incl. 3 new). CHANGELOG + openapi in lockstep.

Refs #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWiZ4iJ1fmYW8vtPghWmsn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vulnerability severity enrichment so CVSS data is fetched reliably without triggering rate limits.
  * Deferred feed requests made too soon and retried the intended feed during the next eligible refresh.
  * Ensured feed rotation advances only after successful, non-empty ingestion.
  * Preserved retry behavior after rate-limited responses.

* **Release**
  * Updated the product version to 0.61.73.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->