### PR TITLE
fix(api): stream the Wordfence Production feed + 8m fetch budget (GH #245 follow-up) — 0.61.74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
-## [0.61.73] - 2026-07-19
+## [0.61.74] - 2026-07-19
+
+### Fixed
+
+- Follow-up to GH #245: the vulnerability CVSS enrichment feed now downloads reliably, so real severities populate. Once the earlier rate-limit fix let the enrichment feed request through cleanly for the first time, the download surfaced two latent problems that had always been hidden behind the rate limiting: the enrichment feed (much larger than the detection feed, since it carries CVSS, CVE, CWE, and reference data for every analyzed vulnerability) was loaded into memory all at once, which exhausted the control plane's memory and killed the process mid-download; and the fetch shared a short timeout intended for other traffic, which would have cut off the large download regardless. The enrichment feed is now streamed and written to the database in bounded batches so memory stays flat no matter how large the feed grows, and the fetch is given its own adequate time budget (with the network egress protections unchanged). The detection feed path is unchanged. Control plane only.
 
 ### Fixed
 

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.73
+ * Version:           0.61.74
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.73');
+define('WPMGR_AGENT_VERSION', '0.61.74');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -1572,7 +1572,23 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 		nil, // enqueuer wired below after River starts
 		logger,
 	)
-	vulnFeedWorker := vuln.NewFeedWorker(vulnRepo, pool, nil /*svc: wired below*/, vulnFeedKeySvc, ssrfClient, logger)
+	// Post-deploy follow-up: the Wordfence Intelligence Production feed can
+	// take several minutes to download+stream even after the streaming fix
+	// (its per-record payload is far richer than Scanner's) — well past the
+	// shared 30s ssrfClient's Timeout (cfg.Update.HTTPTimeout, tuned for
+	// unrelated agent/site traffic). Using the shared client here would make
+	// Production fail by client timeout instead of by OOM. Mirrors the
+	// update-apply/backup/media dedicated-client pattern
+	// (buildUpdateApplyCommander et al.): a SEPARATE SSRF-hardened client with
+	// a longer per-attempt cap (vuln.FeedFetchTimeout, 8m) just for the vuln
+	// feed worker. MaxRetries: 0 — a failed attempt is retried by the next
+	// wall-clock-eligible feed-worker run (Repo.GetFeedGate), not by an
+	// in-process retry loop.
+	vulnFeedHTTPClient := httpclient.New(httpclient.Config{
+		Timeout:    vuln.FeedFetchTimeout,
+		MaxRetries: 0,
+	})
+	vulnFeedWorker := vuln.NewFeedWorker(vulnRepo, pool, nil /*svc: wired below*/, vulnFeedKeySvc, vulnFeedHTTPClient, logger)
 	vulnRescanWorker := vuln.NewRescanSiteWorker(nil /*svc: wired below*/, logger)
 
 	riverClient, err := startRiver(ctx, pool.Pool, logger, riverDeps{

--- a/apps/api/internal/vuln/export_test.go
+++ b/apps/api/internal/vuln/export_test.go
@@ -31,3 +31,13 @@ func MergeAffectedVersions(a, b []byte) []byte { return mergeAffectedVersions(a,
 
 // MergePatchedVersions exposes mergePatchedVersions for unit tests.
 func MergePatchedVersions(a, b []byte) []byte { return mergePatchedVersions(a, b) }
+
+// StreamProductionRecords exposes (*FeedWorker).streamProductionRecords for
+// white-box unit testing the Production streaming/batching/memory-bound
+// behavior without any HTTP or DB dependency: dec must already be positioned
+// just past the feed's opening '{' (matching how fetchAndIngestProduction
+// calls it), and flush is invoked once per completed batch (plus once more
+// for any remainder) with a slice that is never longer than batchSize.
+func (w *FeedWorker) StreamProductionRecords(dec *json.Decoder, batchSize int, flush func(batch []FeedRecord) error) (n int, defiantNotice, defiantLicense, mitreNotice string, err error) {
+	return w.streamProductionRecords(dec, batchSize, flush)
+}

--- a/apps/api/internal/vuln/repo.go
+++ b/apps/api/internal/vuln/repo.go
@@ -159,6 +159,34 @@ func (r *Repo) BulkUpsertFeedRecords(ctx context.Context, tx pgx.Tx, recs []Feed
 	return br.Close()
 }
 
+// BulkUpsertFeedRecordsPool wraps BulkUpsertFeedRecords in its own short-lived
+// transaction — used by the streaming Production ingest path
+// (FeedWorker.fetchAndIngestProduction), which flushes bounded batches as the
+// feed is decoded rather than holding one long transaction open for the
+// entire (potentially very large) response. Production only ever upserts
+// existing/enrichment data (never BulkReplaceAllSoftware/PruneMissingVulns —
+// see ingestRecords), so each batch committing independently is safe: a
+// mid-stream failure on a later batch leaves earlier batches durably
+// enriched rather than losing all forward progress.
+func (r *Repo) BulkUpsertFeedRecordsPool(ctx context.Context, recs []FeedRecord) error {
+	if len(recs) == 0 {
+		return nil
+	}
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, "SELECT set_config('app.agent','on',true)"); err != nil {
+		return fmt.Errorf("set agent guc: %w", err)
+	}
+	if err := r.BulkUpsertFeedRecords(ctx, tx, recs); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
 // BulkReplaceAllSoftware replaces the software rows for every vuln_id in recs
 // using two set-based operations instead of per-record DELETE + INSERT loops:
 //
@@ -450,6 +478,27 @@ func (r *Repo) StampFeedMeta(ctx context.Context, tx pgx.Tx, meta FeedMetaUpdate
 		meta.EnrichmentOK, meta.LastEnrichmentAt,
 	)
 	return err
+}
+
+// StampFeedMetaFinal opens its own transaction to call StampFeedMeta directly
+// against the pool — used by the streaming Production ingest path
+// (FeedWorker.fetchAndIngestProduction / workProduction), whose record
+// batches are already committed incrementally (BulkUpsertFeedRecordsPool)
+// rather than atomically with the meta stamp. Calling this is what advances
+// next_feed_kind (via the CASE in StampFeedMeta's SQL), so it must only be
+// called once the ENTIRE stream has completed successfully — never on a
+// mid-stream failure, which returns an error before reaching this call.
+func (r *Repo) StampFeedMetaFinal(ctx context.Context, meta FeedMetaUpdate) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := r.StampFeedMeta(ctx, tx, meta); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }
 
 // StampRequestAt records the wall-clock time of an ACTUAL Wordfence HTTP

--- a/apps/api/internal/vuln/worker.go
+++ b/apps/api/internal/vuln/worker.go
@@ -102,6 +102,31 @@ const (
 // jitter so a request is never dispatched right at the edge of the window.
 const minRequestSpacing = 31 * time.Minute
 
+// FeedFetchTimeout bounds a single Wordfence Intelligence HTTP fetch (Scanner
+// or Production) via the REQUEST CONTEXT — not the shared httpclient's
+// per-request Timeout (cfg.Update.HTTPTimeout, 30s in cmd/wpmgr/main.go),
+// which is tuned for unrelated agent/site traffic and far too short here.
+//
+// Pre-streaming-fix, a large Production response OOM'd the pod ~10s in —
+// well before 30s could even matter. Post-streaming-fix it no longer OOMs,
+// so it downloads the FULL feed, which for Production (far richer per-record
+// than Scanner) can easily exceed 30s; without a dedicated budget the very
+// same 30s cap would now fail it a different way (mid-stream timeout instead
+// of OOM). FeedFetchTimeout gives the fetch up to 8 minutes, comfortably
+// under the River job's 10-minute Timeout (2 minutes of margin for the
+// DB flushes — see ingestRecords/BulkUpsertFeedRecordsPool, which typically
+// complete in low single-digit seconds even for thousands of records).
+//
+// cmd/wpmgr/main.go pairs this with a DEDICATED SSRF-hardened httpclient.Client
+// (httpclient.New(Config{Timeout: FeedFetchTimeout, ...})) built the SAME way
+// as the existing update-apply/backup/media dedicated-client precedent
+// (buildUpdateApplyCommander et al.) — never the shared 30s ssrfClient — so
+// the client's own Timeout cannot undercut this context deadline either.
+// Applying context.WithTimeout here too (in fetchFeed/fetchAndIngestProduction)
+// is defense-in-depth AND keeps the ~8m budget self-evident and unit-testable
+// from this package without depending on how main.go wires the client.
+const FeedFetchTimeout = 8 * time.Minute
+
 // errRateLimited marks a 429 from the Wordfence feed. Wordfence documents no
 // Retry-After and no per-window number ("too many requests in a short period"),
 // so a 429 must NOT trigger an immediate in-process retry — that just re-hits
@@ -173,12 +198,27 @@ func NewFeedWorker(repo *Repo, pool *db.Pool, svc *Service, resolver APIKeyResol
 // once at boot after startRiver returns (the service needs the River client).
 func (w *FeedWorker) SetService(svc *Service) { w.svc = svc }
 
-// Timeout gives the feed refresh job 10 minutes. A full-dump ingest of ~13k
-// records via CopyFrom completes in seconds, but the single HTTP fetch (one
-// feed per run — see GetFeedGate) + any Postgres latency under load consume
-// real wall time. 10 minutes is generous headroom well above the expected
-// 15–30s wall time and avoids the context deadline that previously killed the
-// per-record loop.
+// Timeout gives the feed refresh job 10 minutes — comfortably above
+// FeedFetchTimeout (8 minutes, the cap on the HTTP fetch itself) with a
+// 2-minute margin for the DB flushes that follow (BulkUpsertFeedRecordsPool/
+// ingestRecords typically complete in low single-digit seconds even for
+// thousands of records — see TestBulkIngest_Scale). A full-dump ingest of
+// ~13k records via CopyFrom completes in seconds; the previous per-record
+// loop is what originally needed this much headroom, and it still comfortably
+// covers the streaming Production path (incremental flushes interleaved with
+// the download, rather than one big end-of-run write).
+//
+// This Timeout bounds the WHOLE River job. It is deliberately independent of
+// (and larger than) FeedFetchTimeout, which bounds only the HTTP fetch via
+// the request context (see fetchFeed/fetchAndIngestProduction) — and is in
+// turn independent of the *http.Client's own per-request Timeout: the vuln
+// feed worker is wired in cmd/wpmgr/main.go with a DEDICATED SSRF-hardened
+// client (httpclient.New(Config{Timeout: FeedFetchTimeout, ...}), built the
+// same way as the update-apply/backup/media dedicated-client precedent — see
+// buildUpdateApplyCommander), never the shared 30s ssrfClient used for
+// unrelated agent/update traffic. Using that 30s-capped client here would
+// have made Production fail by timeout instead of by OOM once the streaming
+// fix stopped it from OOM'ing first.
 func (w *FeedWorker) Timeout(*river.Job[FeedRefreshArgs]) time.Duration {
 	return 10 * time.Minute
 }
@@ -190,6 +230,16 @@ func (w *FeedWorker) Timeout(*river.Job[FeedRefreshArgs]) time.Duration {
 // since the last actual request, not by an assumption about job cadence —
 // consecutive runs (periodic + a manually triggered sync, or any other
 // clustering) can land far closer together than the nominal hourly interval.
+//
+// The two feed kinds use DIFFERENT ingest strategies (workScanner /
+// workProduction below): Scanner is small enough (~37k MINIMAL records) to
+// buffer entirely in memory and ingest in one atomic transaction, and needs
+// the full record set anyway for BulkReplaceAllSoftware/PruneMissingVulns.
+// Production carries a much richer per-record payload (full CVSS/CVE/CWE/
+// copyrights/remediation/raw JSON) and is enrichment-only (no prune), so it
+// is STREAMED and flushed in bounded batches — buffering the whole Production
+// response in memory once let a request through for the first time (after
+// the wall-clock spacing fix) and OOM'd the pod (SIGKILL, prod incident).
 func (w *FeedWorker) Work(ctx context.Context, job *river.Job[FeedRefreshArgs]) error {
 	// Resolve the key at run-time so a UI-set key takes effect on the next job
 	// without requiring a restart. Priority: UI key > env key > no-op.
@@ -222,120 +272,176 @@ func (w *FeedWorker) Work(ctx context.Context, job *river.Job[FeedRefreshArgs]) 
 			}
 		}
 	}
-	feedURL := ScannerFeedURL
-	if feedKind == FeedKindProduction {
-		feedURL = ProductionFeedURL
-	}
 
 	w.logger.Info("vuln: starting Wordfence Intelligence feed refresh", slog.String("feed", feedKind))
 
-	records, defiantNotice, defiantLicense, mitreNotice, requested, err := w.fetchFeed(ctx, feedURL, apiKey)
-	if requested {
-		// A response was received from Wordfence's server (200, 429, or any
-		// other status) — that attempt consumed the shared rate-limit slot,
-		// regardless of outcome, so the wall-clock gate above must see it on
-		// the next run. A pure transport failure (requested=false) never
-		// reached Wordfence and does not count.
-		if serr := w.repo.StampRequestAt(ctx, time.Now().UTC()); serr != nil {
-			w.logger.Warn("vuln: failed to stamp last_request_at", slog.Any("error", serr))
-		}
+	if feedKind == FeedKindProduction {
+		return w.workProduction(ctx, apiKey)
 	}
-	if err != nil {
-		if errors.Is(err, errRateLimited) {
-			// Do NOT retry inside this cycle: a globally rate-limited window
-			// cannot be escaped by an immediate retry. Stamp degraded and
-			// leave the cursor untouched (belt-and-suspenders: the wall-clock
-			// gate above should normally prevent reaching this branch at all,
-			// but an external caller could still consume the shared slot) —
-			// the next ELIGIBLE run retries the SAME feed. A Production
-			// rate-limit must NOT flip the detection ok flag (RescanSite
-			// gates on it); a Scanner rate-limit legitimately does, matching
-			// prior behavior.
-			msg := fmt.Sprintf("%s feed rate limited by Wordfence; will retry on the next eligible refresh", feedKind)
-			if feedKind == FeedKindProduction {
-				_ = w.repo.StampEnrichmentDegraded(ctx, msg)
-			} else {
-				_ = w.repo.StampFeedError(ctx, msg)
-			}
-			w.logger.Warn("vuln: feed rate limited; skipping this cycle (no in-window retry)",
-				slog.String("feed", feedKind))
-			return nil
-		}
-		errMsg := fmt.Sprintf("%s feed fetch failed: %v", feedKind, err)
-		_ = w.repo.StampFeedError(ctx, errMsg)
-		return fmt.Errorf("vuln feed refresh (%s): %w", feedKind, err) // River will retry real failures
-	}
+	return w.workScanner(ctx, apiKey)
+}
 
-	if len(records) == 0 {
-		// A zero-record response counts as "no enrichment" for a Production
-		// run (per WP2 spec) but must not touch the detection ok flag — the
-		// Scanner-driven catalog from the last successful Scanner run is still
-		// perfectly valid. A zero-record Scanner response is treated as before
-		// (ok=false): it means we have no usable detection catalog this cycle.
-		// Neither path advances the cursor — the SAME feed is retried next
-		// eligible run.
-		msg := fmt.Sprintf("%s feed returned zero records; not applying update", feedKind)
+// stampRequestIfMade records last_request_at when requested is true — a
+// response (of any kind: 200, 429, or otherwise) was actually received from
+// Wordfence's server, which is what the wall-clock spacing gate in Work()
+// needs to see on the next run. A pure transport failure (requested=false)
+// never reached Wordfence and must not advance the gate.
+func (w *FeedWorker) stampRequestIfMade(ctx context.Context, requested bool) {
+	if !requested {
+		return
+	}
+	if serr := w.repo.StampRequestAt(ctx, time.Now().UTC()); serr != nil {
+		w.logger.Warn("vuln: failed to stamp last_request_at", slog.Any("error", serr))
+	}
+}
+
+// handleFetchError applies the shared rate-limit / hard-error handling common
+// to both feed paths (including a mid-stream Production failure, which
+// surfaces here as a plain non-errRateLimited error). Returns nil for a
+// rate-limit (no River retry; the cursor is never touched by either branch —
+// StampEnrichmentDegraded/StampFeedError do not reference next_feed_kind) or
+// the wrapped error for a hard failure (River retries; the cursor still
+// never advances because StampFeedMeta/StampFeedMetaFinal — the only calls
+// that flip it — are never reached on this path).
+func (w *FeedWorker) handleFetchError(ctx context.Context, feedKind string, err error) error {
+	if errors.Is(err, errRateLimited) {
+		msg := fmt.Sprintf("%s feed rate limited by Wordfence; will retry on the next eligible refresh", feedKind)
 		if feedKind == FeedKindProduction {
 			_ = w.repo.StampEnrichmentDegraded(ctx, msg)
 		} else {
 			_ = w.repo.StampFeedError(ctx, msg)
 		}
-		w.logger.Warn("vuln: " + msg)
+		w.logger.Warn("vuln: feed rate limited; skipping this cycle (no in-window retry)",
+			slog.String("feed", feedKind))
+		return nil
+	}
+	errMsg := fmt.Sprintf("%s feed fetch failed: %v", feedKind, err)
+	_ = w.repo.StampFeedError(ctx, errMsg)
+	return fmt.Errorf("vuln feed refresh (%s): %w", feedKind, err) // River will retry real failures
+}
+
+// handleZeroRecords applies the shared zero-record-response handling. A
+// zero-record Production response degrades enrichment_ok only (detection
+// freshness is untouched); a zero-record Scanner response means there is no
+// usable detection catalog this cycle (ok=false, matching prior behavior).
+// Neither advances the cursor.
+func (w *FeedWorker) handleZeroRecords(ctx context.Context, feedKind string) {
+	msg := fmt.Sprintf("%s feed returned zero records; not applying update", feedKind)
+	if feedKind == FeedKindProduction {
+		_ = w.repo.StampEnrichmentDegraded(ctx, msg)
+	} else {
+		_ = w.repo.StampFeedError(ctx, msg)
+	}
+	w.logger.Warn("vuln: " + msg)
+}
+
+// triggerRescanAll fans out per-site rescans after a successful ingest of
+// either feed: a Scanner ingest carries new/changed detection data, and a
+// Production ingest can land CVSS that upgrades findings out of the
+// "unknown" severity bucket — both should become visible promptly.
+func (w *FeedWorker) triggerRescanAll(ctx context.Context) {
+	if err := w.svc.RescanAll(ctx, uuid.Nil); err != nil {
+		w.logger.Warn("vuln: post-feed rescan-all enqueue failed", slog.Any("error", err))
+	}
+}
+
+// workScanner fetches and ingests the Scanner feed: buffer the whole
+// (minimal, ~37k-record) response in memory, then a single atomic transaction
+// (BulkUpsertFeedRecords + BulkReplaceAllSoftware + PruneMissingVulns +
+// StampFeedMeta — see ingestRecords). Scanner is small enough that buffering
+// is fine, and it NEEDS the full record set in one pass for prune to be
+// correct (see ingestRecords doc).
+func (w *FeedWorker) workScanner(ctx context.Context, apiKey string) error {
+	records, defiantNotice, defiantLicense, mitreNotice, requested, err := w.fetchFeed(ctx, ScannerFeedURL, apiKey)
+	w.stampRequestIfMade(ctx, requested)
+	if err != nil {
+		return w.handleFetchError(ctx, FeedKindScanner, err)
+	}
+	if len(records) == 0 {
+		w.handleZeroRecords(ctx, FeedKindScanner)
 		return nil
 	}
 
-	// Persist in a batch transaction using the pool directly (feed tables have
-	// no RLS, so no GUC setup is required; we set app.agent='on' anyway inside
-	// ingestRecords for forward-compatibility).
 	knownIDs := make([]string, 0, len(records))
 	for id := range records {
 		knownIDs = append(knownIDs, id)
 	}
 
-	now := time.Now().UTC()
 	meta := FeedMetaUpdate{
-		FetchedAt:      now,
+		FetchedAt:      time.Now().UTC(),
 		OK:             true,
 		RecordCount:    len(records),
 		DefiantNotice:  defiantNotice,
 		DefiantLicense: defiantLicense,
 		MitreNotice:    mitreNotice,
 	}
-	if feedKind == FeedKindProduction {
-		// len(records) > 0 is already established above, so this run
-		// successfully enriched at least one record.
-		enrichOK := true
-		meta.EnrichmentOK = &enrichOK
-		meta.LastEnrichmentAt = &now
-	}
 
 	// ingestRecords calls StampFeedMeta, which — ONLY on this successful,
-	// non-empty-ingest path — also advances next_feed_kind to the other feed.
-	// Every other outcome above (spacing-skip, 429, zero records, hard error)
-	// returns before reaching here, leaving the cursor exactly as it was.
-	pgErr := w.ingestRecords(ctx, records, knownIDs, meta, feedKind)
-	if pgErr != nil {
+	// non-empty-ingest path — also advances next_feed_kind to production.
+	if pgErr := w.ingestRecords(ctx, records, knownIDs, meta); pgErr != nil {
 		_ = w.repo.StampFeedError(ctx, pgErr.Error())
-		return fmt.Errorf("vuln: ingest records (%s): %w", feedKind, pgErr)
+		return fmt.Errorf("vuln: ingest records (%s): %w", FeedKindScanner, pgErr)
 	}
 
 	w.logger.Info("vuln: feed refresh complete",
-		slog.String("feed", feedKind), slog.Int("records", len(records)))
-
-	// Trigger a cross-tenant rescan (throttled: enqueues per-site River jobs).
-	// This runs after BOTH a Scanner ingest (new/changed detection data) and a
-	// Production ingest (newly-landed CVSS can upgrade findings out of the
-	// "unknown" severity bucket), so enrichment becomes visible promptly.
-	if err := w.svc.RescanAll(ctx, uuid.Nil); err != nil {
-		w.logger.Warn("vuln: post-feed rescan-all enqueue failed", slog.Any("error", err))
-	}
-
+		slog.String("feed", FeedKindScanner), slog.Int("records", len(records)))
+	w.triggerRescanAll(ctx)
 	return nil
 }
 
-// ingestRecords writes all records and the meta row in one transaction using
-// bulk operations. The previous per-record loop (13k × DELETE+INSERT round-trips)
-// exceeded the River context deadline; the bulk path replaces that with:
+// workProduction streams and ingests the Production feed in bounded batches
+// (fetchAndIngestProduction) rather than buffering the whole response — see
+// the package/Work doc comments for why. On success it stamps enrichment_ok +
+// last_enrichment_at and advances the cursor (StampFeedMetaFinal); on any
+// failure (rate limit, zero records, or a mid-stream error) it falls through
+// to the shared handlers, none of which touch the cursor.
+func (w *FeedWorker) workProduction(ctx context.Context, apiKey string) error {
+	n, defiantNotice, defiantLicense, mitreNotice, requested, err := w.fetchAndIngestProduction(ctx, apiKey)
+	w.stampRequestIfMade(ctx, requested)
+	if err != nil {
+		return w.handleFetchError(ctx, FeedKindProduction, err)
+	}
+	if n == 0 {
+		w.handleZeroRecords(ctx, FeedKindProduction)
+		return nil
+	}
+
+	now := time.Now().UTC()
+	enrichOK := true
+	meta := FeedMetaUpdate{
+		FetchedAt:        now,
+		OK:               true,
+		RecordCount:      n,
+		DefiantNotice:    defiantNotice,
+		DefiantLicense:   defiantLicense,
+		MitreNotice:      mitreNotice,
+		EnrichmentOK:     &enrichOK,
+		LastEnrichmentAt: &now,
+	}
+
+	// This is what advances next_feed_kind to scanner — only reached once
+	// every batch has already been durably flushed by
+	// fetchAndIngestProduction, so a mid-stream failure (returned as err
+	// above) can never reach here.
+	if serr := w.repo.StampFeedMetaFinal(ctx, meta); serr != nil {
+		_ = w.repo.StampFeedError(ctx, serr.Error())
+		return fmt.Errorf("vuln: stamp feed meta (%s): %w", FeedKindProduction, serr)
+	}
+
+	w.logger.Info("vuln: feed refresh complete",
+		slog.String("feed", FeedKindProduction), slog.Int("records", n))
+	w.triggerRescanAll(ctx)
+	return nil
+}
+
+// ingestRecords writes all Scanner records and the meta row in one
+// transaction using bulk operations. Scanner-ONLY: Production streams and
+// flushes incrementally instead (see fetchAndIngestProduction /
+// BulkUpsertFeedRecordsPool / StampFeedMetaFinal) since it is enrichment-only
+// and does not need BulkReplaceAllSoftware/PruneMissingVulns, which require
+// the FULL Scanner ID set in one pass to be correct. The previous per-record
+// loop (13k × DELETE+INSERT round-trips) exceeded the River context deadline;
+// the bulk path replaces that with:
 //
 //  1. A pgx Batch that sends all feed-row upserts in a single round-trip. The
 //     upsert is STICKY for the enrichment columns (cvss_score, cvss_rating,
@@ -345,19 +451,14 @@ func (w *FeedWorker) Work(ctx context.Context, job *river.Job[FeedRefreshArgs]) 
 //     had already populated, flapping every finding's severity AND reference
 //     link-outs between real values and empty/"unknown" every other hour
 //     (GH #245 reintroduced).
-//  2. Scanner runs ONLY: a set-based DELETE of software rows for every
-//     vuln_id in the batch, then a single CopyFrom that streams all new
-//     software rows to Postgres.
-//  3. Scanner runs ONLY: PruneMissingVulns (single set-based DELETE of
-//     retracted vulns). Production's ID set is a proper SUBSET of Scanner's
-//     (it omits brand-new unrated entries), so running this off a Production
-//     batch would incorrectly delete legitimate Scanner-only rows every other
-//     cycle. Production ONLY enriches rows that already exist (or are
-//     inserted fresh via step 1) — it never determines existence.
-//  4. StampFeedMeta (single UPDATE).
+//  2. A set-based DELETE of software rows for every vuln_id in the batch,
+//     then a single CopyFrom that streams all new software rows to Postgres.
+//  3. PruneMissingVulns (single set-based DELETE of retracted vulns) — safe
+//     here because Scanner's ID set is the authoritative superset.
+//  4. StampFeedMeta (single UPDATE) — advances next_feed_kind to production.
 //
 // The entire operation is one transaction — atomic, with no partial state.
-func (w *FeedWorker) ingestRecords(ctx context.Context, records map[string]FeedRecord, knownIDs []string, meta FeedMetaUpdate, feedKind string) error {
+func (w *FeedWorker) ingestRecords(ctx context.Context, records map[string]FeedRecord, knownIDs []string, meta FeedMetaUpdate) error {
 	// Flatten the map into a slice for deterministic ordering (maps in Go are
 	// unordered; a slice makes the Batch and CopyFrom reproducible for debugging).
 	recs := make([]FeedRecord, 0, len(records))
@@ -379,13 +480,11 @@ func (w *FeedWorker) ingestRecords(ctx context.Context, records map[string]FeedR
 	if err := w.repo.BulkUpsertFeedRecords(ctx, tx, recs); err != nil {
 		return err
 	}
-	if feedKind == FeedKindScanner {
-		if err := w.repo.BulkReplaceAllSoftware(ctx, tx, recs); err != nil {
-			return err
-		}
-		if err := w.repo.PruneMissingVulns(ctx, tx, knownIDs); err != nil {
-			return err
-		}
+	if err := w.repo.BulkReplaceAllSoftware(ctx, tx, recs); err != nil {
+		return err
+	}
+	if err := w.repo.PruneMissingVulns(ctx, tx, knownIDs); err != nil {
+		return err
 	}
 	if err := w.repo.StampFeedMeta(ctx, tx, meta); err != nil {
 		return err
@@ -406,7 +505,14 @@ func (w *FeedWorker) ingestRecords(ctx context.Context, records map[string]FeedR
 // errored — DNS/connect/timeout before any response). The caller
 // (FeedWorker.Work) uses requested to decide whether to stamp last_request_at.
 func (w *FeedWorker) fetchFeed(ctx context.Context, feedURL, apiKey string) (records map[string]FeedRecord, defiantNotice, defiantLicense, mitreNotice string, requested bool, err error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, feedURL, nil)
+	// Bound the fetch (request + full body read/decode, which happens
+	// synchronously below before this function returns) to FeedFetchTimeout —
+	// NOT the shared httpclient's much shorter per-request Timeout. Applied to
+	// Scanner too for consistency, even though Scanner already completes fast.
+	fetchCtx, cancel := context.WithTimeout(ctx, FeedFetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, feedURL, nil)
 	if err != nil {
 		return nil, "", "", "", false, err
 	}
@@ -509,6 +615,215 @@ func (w *FeedWorker) fetchFeed(ctx context.Context, feedURL, apiKey string) (rec
 	}
 
 	return recs, defiantNotice, defiantLicense, mitreNotice, requested, nil
+}
+
+// ProductionBatchSize is the number of Production feed records accumulated in
+// memory before each flush to the database. The Production feed carries a
+// much richer per-record payload than Scanner (full cvss/cve/cwe/copyrights/
+// remediation/raw JSON for every analyzed vulnerability), so — unlike
+// Scanner, which fetchFeed buffers entirely because its ~37k MINIMAL records
+// fit comfortably — Production MUST be streamed in bounded batches. Once the
+// wall-clock spacing fix (m102) let a Production request through cleanly for
+// the first time, buffering that response whole exceeded the pod's 1Gi
+// memory limit and SIGKILL'd it (prod incident, GH #245 third follow-up). 500
+// keeps memory bounded to roughly a handful of MB per batch regardless of
+// total feed size; 1000 would also be safe — this sits in the middle of the
+// requested 500–1000 range.
+const ProductionBatchSize = 500
+
+// fetchAndIngestProduction streams the Production feed and flushes it to
+// wordfence_vuln_feed in bounded batches of ProductionBatchSize records via
+// Repo.BulkUpsertFeedRecordsPool, so memory is O(batch) rather than O(whole
+// feed). This differs from fetchFeed (Scanner) in exactly one respect: it
+// never accumulates a full records map — the JSON is still decoded
+// token-by-token via the SAME json.Decoder approach (dec.Token() for each
+// key, dec.Decode(&rawMsg) for each value — see fetchFeed), but each decoded
+// record is appended to a small reusable batch slice that gets flushed and
+// reset (batch[:0], keeping the same backing array so memory never grows)
+// once it reaches ProductionBatchSize, instead of being retained in a
+// whole-feed map until the caller returns.
+//
+// Every batch flush goes through the SAME sticky COALESCE/NULLIF upsert as
+// Scanner (Repo.BulkUpsertFeedRecords, wrapped by BulkUpsertFeedRecordsPool
+// in its own short transaction): cve/cve_link/cvss_score/cvss_rating/cwe/
+// reference_urls are never nulled out. Production never touches software
+// rows or prunes (see ingestRecords doc) — each batch's upsert-only write is
+// independently safe to commit, so a mid-stream failure on batch K leaves
+// batches 1..K-1 durably enriched instead of losing all forward progress (an
+// improvement over the one-big-transaction approach, which would have rolled
+// back everything on any failure anyway).
+//
+// Returns: total records successfully ingested (recordCount — used for the
+// enrichment_ok=(recordCount>0) decision and the completion log), the
+// attribution strings, requested (whether the request reached Wordfence — see
+// fetchFeed doc), and error. On a mid-stream failure, recordCount reflects
+// however many records were flushed before the failure (already durable) and
+// err is non-nil; the caller (workProduction) routes err through
+// handleFetchError, which never advances the cursor — StampFeedMetaFinal
+// (the only call that does) is only reached on a nil error.
+func (w *FeedWorker) fetchAndIngestProduction(ctx context.Context, apiKey string) (recordCount int, defiantNotice, defiantLicense, mitreNotice string, requested bool, err error) {
+	// Bound the HTTP request + streamed body read to FeedFetchTimeout — NOT
+	// the shared httpclient's much shorter per-request Timeout (that 30s cap
+	// is what would make Production fail mid-stream now that the streaming
+	// fix means it no longer OOMs first). This deliberately does NOT wrap the
+	// DB flush calls below (they keep using the outer job ctx, whose deadline
+	// comes from the River job Timeout) — a slow-but-still-flushing batch
+	// write should not be cut off just because the HTTP-specific budget is
+	// tighter than the overall job budget.
+	fetchCtx, cancel := context.WithTimeout(ctx, FeedFetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, ProductionFeedURL, nil)
+	if err != nil {
+		return 0, "", "", "", false, err
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "WPMgr-VulnScanner/1.0")
+
+	resp, doErr := w.client.Do(req)
+	if doErr != nil {
+		// Transport-level failure: no response ever came back from Wordfence,
+		// so this attempt did not consume the shared rate-limit slot.
+		return 0, "", "", "", false, fmt.Errorf("http get %s: %w", ProductionFeedURL, doErr)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// A response was received — from here on every return path counts as a
+	// real request against the rate-limit window, regardless of status code.
+	requested = true
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// proceed
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return 0, "", "", "", requested, fmt.Errorf("feed auth failed (HTTP %d): check the Wordfence Intelligence API key in the superadmin settings", resp.StatusCode)
+	case http.StatusTooManyRequests:
+		return 0, "", "", "", requested, fmt.Errorf("rate limited (429) fetching %s: %w", ProductionFeedURL, errRateLimited)
+	default:
+		// Bounded 512-byte diagnostic read ONLY — never the full body. This is
+		// the sole non-streaming Read on the production path, and only ever
+		// hit on an already-failed non-OK status, before any streaming begins.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return 0, "", "", "", requested, fmt.Errorf("unexpected status %d from %s: %s", resp.StatusCode, ProductionFeedURL, body)
+	}
+
+	// Stream-decode the root JSON object token-by-token — identical approach
+	// to fetchFeed — but flush in bounded batches (streamProductionRecords)
+	// below instead of accumulating a whole-feed map.
+	dec := json.NewDecoder(resp.Body)
+	if tok, terr := dec.Token(); terr != nil || tok.(json.Delim) != '{' {
+		return 0, "", "", "", requested, fmt.Errorf("expected root object from %s", ProductionFeedURL)
+	}
+
+	n, defiantNotice, defiantLicense, mitreNotice, serr := w.streamProductionRecords(dec, ProductionBatchSize,
+		func(batch []FeedRecord) error { return w.repo.BulkUpsertFeedRecordsPool(ctx, batch) })
+	return n, defiantNotice, defiantLicense, mitreNotice, requested, serr
+}
+
+// streamProductionRecords decodes key/value pairs from dec — already
+// positioned just past the feed's opening '{' — and flushes them via flush in
+// batches of at most batchSize records, resetting the batch slice (keeping
+// its backing array) after each flush so memory never exceeds batchSize
+// records regardless of total feed size. This is the core loop extracted from
+// fetchAndIngestProduction so it can be unit-tested without any HTTP/DB
+// dependency (see export_test.go's StreamProductionRecords wrapper and
+// worker_test.go's TestFeedWorker_StreamProductionRecords_* tests, which
+// assert flush is called multiple times and never with more than batchSize
+// records).
+//
+// Returns the total records successfully queued-and-flushed, the attribution
+// strings, and an error. On error, the return values reflect whatever was
+// flushed via COMPLETED flush calls before the failure — the in-progress
+// (not-yet-flushed) batch at the moment of failure is discarded, which is why
+// FeedWorker.fetchAndIngestProduction's default ProductionBatchSize keeps
+// that discarded slice small regardless of total feed size.
+func (w *FeedWorker) streamProductionRecords(dec *json.Decoder, batchSize int, flush func(batch []FeedRecord) error) (n int, defiantNotice, defiantLicense, mitreNotice string, err error) {
+	logStreamFail := func(n int, stage string, streamErr error) {
+		w.logger.Error(fmt.Sprintf("vuln: production feed stream failed at record %d", n),
+			slog.String("stage", stage), slog.Any("error", streamErr))
+	}
+
+	batch := make([]FeedRecord, 0, batchSize)
+	flushBatch := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		if ferr := flush(batch); ferr != nil {
+			return ferr
+		}
+		batch = batch[:0] // reuse the backing array — memory never exceeds batchSize records
+		return nil
+	}
+
+	for dec.More() {
+		// Read the vuln UUID key.
+		keyTok, kerr := dec.Token()
+		if kerr != nil {
+			logStreamFail(n, "read_key", kerr)
+			return n, defiantNotice, defiantLicense, mitreNotice,
+				fmt.Errorf("production feed stream failed at record %d: read key: %w", n, kerr)
+		}
+		vulnID, ok := keyTok.(string)
+		if !ok {
+			continue
+		}
+
+		// Decode the record object as raw JSON first (so we can preserve it in raw).
+		var rawMsg json.RawMessage
+		if derr := dec.Decode(&rawMsg); derr != nil {
+			logStreamFail(n, "decode_record", derr)
+			return n, defiantNotice, defiantLicense, mitreNotice,
+				fmt.Errorf("production feed stream failed at record %d (%s): decode: %w", n, vulnID, derr)
+		}
+
+		rec, notice, license, mitre, perr := parseFeedRecord(vulnID, rawMsg)
+		if perr != nil {
+			if errors.Is(perr, errNoUsableSoftware) {
+				// A record with no usable software cannot match any site inventory.
+				// Skip at Debug level — this is expected for certain informational entries.
+				w.logger.Debug("vuln: skipping record with no usable software",
+					slog.String("vuln_id", vulnID))
+			} else {
+				// Defensive catch-all: parseFeedRecord is designed to never return other
+				// errors, but guard here anyway.
+				w.logger.Warn("vuln: skipping unparseable record",
+					slog.String("vuln_id", vulnID), slog.Any("error", perr))
+			}
+			continue
+		}
+
+		batch = append(batch, rec)
+		n++
+
+		// Capture the first non-empty attribution texts seen.
+		if defiantNotice == "" && notice != "" {
+			defiantNotice = notice
+		}
+		if defiantLicense == "" && license != "" {
+			defiantLicense = license
+		}
+		if mitreNotice == "" && mitre != "" {
+			mitreNotice = mitre
+		}
+
+		if len(batch) >= batchSize {
+			if ferr := flushBatch(); ferr != nil {
+				logStreamFail(n, "flush_batch", ferr)
+				return n, defiantNotice, defiantLicense, mitreNotice,
+					fmt.Errorf("production feed stream failed at record %d: flush batch: %w", n, ferr)
+			}
+		}
+	}
+
+	// Flush the remainder (fewer than batchSize records left over).
+	if ferr := flushBatch(); ferr != nil {
+		logStreamFail(n, "flush_final_batch", ferr)
+		return n, defiantNotice, defiantLicense, mitreNotice,
+			fmt.Errorf("production feed stream failed at record %d: flush final batch: %w", n, ferr)
+	}
+
+	return n, defiantNotice, defiantLicense, mitreNotice, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/vuln/worker_test.go
+++ b/apps/api/internal/vuln/worker_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -574,5 +575,183 @@ func TestParseFeedRecord_SlugNormalised(t *testing.T) {
 	}
 	if rec.Software[0].Slug != "woocommerce" {
 		t.Errorf("Slug = %q; want %q", rec.Software[0].Slug, "woocommerce")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Production streaming: batching + memory-bound proof (OOM follow-up).
+//
+// Once the wall-clock spacing fix let a Production request through cleanly
+// for the first time, buffering the whole (much richer per-record) response
+// in one in-memory map OOM'd the api pod (SIGKILL). These tests exercise the
+// extracted (*vuln.FeedWorker).StreamProductionRecords core loop directly —
+// no HTTP or DB dependency — to prove records are written in BOUNDED
+// batches, not accumulated whole-feed, regardless of total feed size.
+// ---------------------------------------------------------------------------
+
+// syntheticProductionStream builds a root JSON object with n valid,
+// Production-shaped records (each with a usable software[] entry and a cvss
+// object), optionally followed by a syntactically invalid trailing value —
+// used by the mid-stream-failure test below. Returns the object as a string,
+// still needing its opening '{' consumed before being handed to
+// StreamProductionRecords (mirroring how fetchAndIngestProduction calls it).
+func syntheticProductionStream(validCount int, appendBroken bool) string {
+	var sb strings.Builder
+	sb.WriteString("{")
+	for i := 0; i < validCount; i++ {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		fmt.Fprintf(&sb, `"stream-vuln-%05d": {"title":"t","software":[{"type":"plugin","slug":"p%05d","affected_versions":{},"patched":false,"patched_versions":[]}],"cvss":{"score":5.0,"rating":"Medium"}}`, i, i)
+	}
+	if appendBroken {
+		if validCount > 0 {
+			sb.WriteString(",")
+		}
+		// A syntactically invalid value (bare unquoted token) — dec.Decode
+		// into json.RawMessage fails on this, simulating a mid-stream error.
+		sb.WriteString(`"stream-vuln-BROKEN": not-valid-json`)
+	}
+	sb.WriteString("}")
+	return sb.String()
+}
+
+// newDecoderPastOpenBrace builds a json.Decoder over body and consumes the
+// opening '{' token, matching the state StreamProductionRecords expects.
+func newDecoderPastOpenBrace(t *testing.T, body string) *json.Decoder {
+	t.Helper()
+	dec := json.NewDecoder(strings.NewReader(body))
+	tok, err := dec.Token()
+	if err != nil {
+		t.Fatalf("read opening token: %v", err)
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		t.Fatalf("opening token = %v; want '{'", tok)
+	}
+	return dec
+}
+
+func newTestFeedWorker() *vuln.FeedWorker {
+	return vuln.NewFeedWorker(nil, nil, nil, nil, nil, slog.Default())
+}
+
+// TestFeedWorker_StreamProductionRecords_BatchesAndBoundsMemory is the direct
+// proof for the OOM fix: streaming a few-thousand-record synthetic Production
+// object flushes in multiple bounded batches — never one whole-feed batch —
+// and NO single flush ever receives more than batchSize records (the memory
+// bound the OOM fix depends on).
+func TestFeedWorker_StreamProductionRecords_BatchesAndBoundsMemory(t *testing.T) {
+	const totalRecords = 2500
+	batchSize := vuln.ProductionBatchSize // the real production constant (500)
+
+	dec := newDecoderPastOpenBrace(t, syntheticProductionStream(totalRecords, false))
+
+	var flushSizes []int
+	flushedTotal := 0
+	flush := func(batch []vuln.FeedRecord) error {
+		// Copy the length now — the caller reuses the backing array after
+		// this call returns, so retaining the slice itself would be unsafe,
+		// but capturing len(batch) here is exactly the "one batch at a time"
+		// assertion we need.
+		flushSizes = append(flushSizes, len(batch))
+		flushedTotal += len(batch)
+		if len(batch) > batchSize {
+			t.Fatalf("flush called with %d records; must never exceed batchSize=%d (memory-bound violation — this is exactly the OOM mechanism)", len(batch), batchSize)
+		}
+		return nil
+	}
+
+	w := newTestFeedWorker()
+	n, _, _, _, err := w.StreamProductionRecords(dec, batchSize, flush)
+	if err != nil {
+		t.Fatalf("StreamProductionRecords: %v", err)
+	}
+	if n != totalRecords {
+		t.Errorf("n = %d; want %d", n, totalRecords)
+	}
+	if flushedTotal != totalRecords {
+		t.Errorf("flushedTotal = %d; want %d (no records lost/duplicated across batches)", flushedTotal, totalRecords)
+	}
+	wantFlushes := (totalRecords + batchSize - 1) / batchSize // ceil division
+	if len(flushSizes) != wantFlushes {
+		t.Errorf("flush() called %d times; want %d (ceil(%d/%d)) — proves BATCHED writes, not one whole-feed write",
+			len(flushSizes), wantFlushes, totalRecords, batchSize)
+	}
+	if len(flushSizes) < 2 {
+		t.Fatalf("only %d flush(es) observed for %d records at batchSize=%d; want multiple — this is the batching claim itself",
+			len(flushSizes), totalRecords, batchSize)
+	}
+	// Every full batch must be exactly batchSize; only the final (remainder)
+	// batch may be smaller.
+	for i, sz := range flushSizes {
+		if i < len(flushSizes)-1 && sz != batchSize {
+			t.Errorf("flush[%d] size = %d; want %d (only the LAST flush may be a partial remainder)", i, sz, batchSize)
+		}
+	}
+}
+
+// TestFeedWorker_StreamProductionRecords_SmallFeedSingleFlush is the inverse
+// sanity check: a feed smaller than batchSize still flushes correctly (the
+// remainder-only flush path), proving the existing small-fixture tests
+// (productionBodyWithCVSS et al.) exercise the same code path as production.
+func TestFeedWorker_StreamProductionRecords_SmallFeedSingleFlush(t *testing.T) {
+	const totalRecords = 3
+	dec := newDecoderPastOpenBrace(t, syntheticProductionStream(totalRecords, false))
+
+	var flushSizes []int
+	flush := func(batch []vuln.FeedRecord) error {
+		flushSizes = append(flushSizes, len(batch))
+		return nil
+	}
+
+	w := newTestFeedWorker()
+	n, _, _, _, err := w.StreamProductionRecords(dec, 500, flush)
+	if err != nil {
+		t.Fatalf("StreamProductionRecords: %v", err)
+	}
+	if n != totalRecords {
+		t.Errorf("n = %d; want %d", n, totalRecords)
+	}
+	if len(flushSizes) != 1 || flushSizes[0] != totalRecords {
+		t.Errorf("flushSizes = %v; want a single flush of %d", flushSizes, totalRecords)
+	}
+}
+
+// TestFeedWorker_StreamProductionRecords_MidStreamError_PartialProgressKept
+// proves that a mid-stream decode failure (a) returns a non-nil error whose
+// message names the failing record index ("stream failed at record N"), and
+// (b) leaves every ALREADY-COMPLETED flush's data intact (the caller —
+// fetchAndIngestProduction — never re-flushes or rolls back a previously
+// successful batch): only the partially-filled, not-yet-flushed batch at the
+// moment of failure is discarded.
+func TestFeedWorker_StreamProductionRecords_MidStreamError_PartialProgressKept(t *testing.T) {
+	const batchSize = 500
+	const validBeforeBreak = 500 // exactly one full batch, flushed inline as soon as it fills
+
+	dec := newDecoderPastOpenBrace(t, syntheticProductionStream(validBeforeBreak, true))
+
+	var flushSizes []int
+	flush := func(batch []vuln.FeedRecord) error {
+		flushSizes = append(flushSizes, len(batch))
+		return nil
+	}
+
+	w := newTestFeedWorker()
+	n, _, _, _, err := w.StreamProductionRecords(dec, batchSize, flush)
+	if err == nil {
+		t.Fatal("StreamProductionRecords: got nil error; want a decode failure from the malformed trailing record")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("stream failed at record %d", validBeforeBreak)) {
+		t.Errorf("error = %q; want it to mention \"stream failed at record %d\"", err.Error(), validBeforeBreak)
+	}
+	// n reflects records successfully queued before the failure (the 500 that
+	// filled and flushed the first batch); the broken record never counted.
+	if n != validBeforeBreak {
+		t.Errorf("n = %d; want %d (records queued before the failure)", n, validBeforeBreak)
+	}
+	// Exactly one flush must have completed (the full batch of 500) — the
+	// broken record's batch never got a chance to flush.
+	if len(flushSizes) != 1 || flushSizes[0] != validBeforeBreak {
+		t.Errorf("flushSizes = %v; want exactly one flush of %d (partial progress preserved, nothing re-flushed or lost)", flushSizes, validBeforeBreak)
 	}
 }

--- a/apps/api/tests/vuln_feed_alternation_integration_test.go
+++ b/apps/api/tests/vuln_feed_alternation_integration_test.go
@@ -37,11 +37,32 @@
 // that drive more than one Work() call use backdateLastRequest to rewind
 // wordfence_vuln_feed_meta.last_request_at directly rather than sleeping for
 // 31+ real minutes.
+//
+// Second post-deploy follow-up (streaming): once the spacing fix let a
+// Production request through cleanly for the first time, buffering the whole
+// (much richer per-record) Production response in memory OOM'd the pod
+// (SIGKILL). FeedWorker now streams Production in bounded batches
+// (fetchAndIngestProduction / streamProductionRecords) instead of
+// accumulating a whole-feed map like Scanner's fetchFeed still does (Scanner
+// is small enough to buffer and needs the full ID set for
+// BulkReplaceAllSoftware/PruneMissingVulns anyway). These tests additionally
+// prove:
+//   - a mid-stream decode failure leaves already-flushed batches durably
+//     committed and does NOT advance the cursor;
+//   - the production path logs "vuln: feed refresh complete" with
+//     feed=production and the total record count (the ABSENCE of that log is
+//     exactly what made the OOM hard to spot in prod).
+//
+// The batching/memory-bound claim itself (records flushed in batches that
+// never exceed the flush size) is proven in a pure, DB-free unit test —
+// internal/vuln/worker_test.go's TestFeedWorker_StreamProductionRecords_*
+// tests, via the exported StreamProductionRecords test wrapper.
 package tests
 
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -64,10 +85,15 @@ import (
 
 // fakeFeedHTTPClient implements vuln.FeedHTTPDoer, returning a canned response
 // per URL and recording every request it receives (in order) so tests can
-// assert the exact number and target of HTTP calls made per Work() cycle.
+// assert the exact number and target of HTTP calls made per Work() cycle. It
+// also records each request's context deadline (deadlines []time.Time),
+// letting tests prove the fetch is bounded by vuln.FeedFetchTimeout (~8m) and
+// NOT by the shared 30s cfg.Update.HTTPTimeout — without a real client or a
+// slow/real-time-waiting server.
 type fakeFeedHTTPClient struct {
 	mu        sync.Mutex
 	calls     []string
+	deadlines []time.Time
 	responses map[string]func() (int, string) // URL -> (status, body) thunk
 }
 
@@ -85,6 +111,11 @@ func (c *fakeFeedHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	c.mu.Lock()
 	url := req.URL.String()
 	c.calls = append(c.calls, url)
+	if dl, ok := req.Context().Deadline(); ok {
+		c.deadlines = append(c.deadlines, dl)
+	} else {
+		c.deadlines = append(c.deadlines, time.Time{}) // no deadline — recorded as zero
+	}
 	thunk, ok := c.responses[url]
 	c.mu.Unlock()
 
@@ -97,6 +128,17 @@ func (c *fakeFeedHTTPClient) Do(req *http.Request) (*http.Response, error) {
 		Body:       io.NopCloser(strings.NewReader(body)),
 		Header:     make(http.Header),
 	}, nil
+}
+
+// lastDeadline returns the context deadline attached to the most recent
+// request (zero Time if that request's context had no deadline).
+func (c *fakeFeedHTTPClient) lastDeadline() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.deadlines) == 0 {
+		return time.Time{}
+	}
+	return c.deadlines[len(c.deadlines)-1]
 }
 
 func (c *fakeFeedHTTPClient) callCount() int {
@@ -138,7 +180,13 @@ func (noopRescanEnqueuer) EnqueueRescanSite(_ context.Context, _ vuln.RescanSite
 // buildFeedWorker wires a *vuln.FeedWorker against the real pool + a fake
 // HTTP client, mirroring the production wiring in cmd/wpmgr/main.go.
 func buildFeedWorker(pool *db.Pool, client *fakeFeedHTTPClient) *vuln.FeedWorker {
-	logger := slog.Default()
+	return buildFeedWorkerWithLogger(pool, client, slog.Default())
+}
+
+// buildFeedWorkerWithLogger is buildFeedWorker with an injectable logger —
+// used by tests that need to observe log output (e.g. the production path's
+// completion log, whose absence is exactly what hid the OOM incident in prod).
+func buildFeedWorkerWithLogger(pool *db.Pool, client *fakeFeedHTTPClient, logger *slog.Logger) *vuln.FeedWorker {
 	repo := vuln.NewRepo(pool)
 	svc := vuln.NewService(repo, pool, noopSiteLoader{}, nil, noopRescanEnqueuer{}, logger)
 	resolver := vuln.NewStaticKeyResolver("test-wordfence-key-1234")
@@ -184,9 +232,9 @@ func scannerBodyNoCVSS(vulnID string) string {
 const productionBodyReferenceURL = "https://www.wordfence.com/threat-intel/vulnerabilities/test"
 
 // productionBodyWithCVSS is a Production-shaped response for the SAME
-// vuln_id, carrying a full cvss object + cve + a reference URL — the
+// vuln_id, carrying a full cvss object + cve + cwe + a reference URL — the
 // enrichment data Scanner never sends (scannerBodyNoCVSS above carries
-// neither a "cvss" key nor a "references" key, matching the real feeds).
+// neither a "cvss" nor a "references" nor a "cwe" key, matching the real feeds).
 func productionBodyWithCVSS(vulnID string) string {
 	return `{"` + vulnID + `": {
 		"title": "Test Plugin XSS",
@@ -195,6 +243,7 @@ func productionBodyWithCVSS(vulnID string) string {
 		],
 		"cvss": {"vector":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H","score":9.8,"rating":"Critical"},
 		"cve": "CVE-2026-24500",
+		"cwe": {"id": 79, "name": "Cross-site Scripting"},
 		"references": ["` + productionBodyReferenceURL + `"]
 	}}`
 }
@@ -234,6 +283,77 @@ func feedReferenceURLs(t *testing.T, pool *db.Pool, vulnID string) []string {
 		t.Fatalf("unmarshal reference_urls (%s): %v", raw, err)
 	}
 	return urls
+}
+
+// feedCWERaw reads wordfence_vuln_feed.cwe for vulnID as raw JSON (nil when NULL).
+func feedCWERaw(t *testing.T, pool *db.Pool, vulnID string) []byte {
+	t.Helper()
+	var raw []byte
+	if err := pool.QueryRow(context.Background(),
+		`SELECT cwe FROM wordfence_vuln_feed WHERE vuln_id = $1`, vulnID,
+	).Scan(&raw); err != nil {
+		t.Fatalf("select cwe: %v", err)
+	}
+	return raw
+}
+
+// ---------------------------------------------------------------------------
+// Third post-deploy follow-up: the fetch must NOT be bounded by the shared
+// 30s cfg.Update.HTTPTimeout. Pre-streaming-fix, Production OOM'd ~10s in —
+// before 30s could even matter. Post-streaming-fix it no longer OOMs, so it
+// downloads the full feed, which can easily exceed 30s; without its own
+// budget the 30s cap would now fail it a different way (timeout instead of
+// OOM). worker.go wraps the request context with FeedFetchTimeout (~8m)
+// regardless of what Timeout the injected client itself carries.
+// ---------------------------------------------------------------------------
+
+// TestFeedWorker_FetchContextDeadline_UsesFeedFetchTimeout_NotSharedShortTimeout
+// asserts the ACTUAL mechanism the fix depends on: the *http.Request handed
+// to the client carries a context deadline close to vuln.FeedFetchTimeout
+// (~8 minutes out), never the shared 30s update timeout. This is fast and
+// deterministic (no real waiting / slow server needed) because it inspects
+// the request's context directly rather than timing an actual slow transfer.
+func TestFeedWorker_FetchContextDeadline_UsesFeedFetchTimeout_NotSharedShortTimeout(t *testing.T) {
+	pool := startPostgres(t)
+	client := newFakeFeedHTTPClient()
+	client.setResponse(vuln.ScannerFeedURL, http.StatusOK, scannerBodyNoCVSS("245-deadline-scanner-vuln"))
+	client.setResponse(vuln.ProductionFeedURL, http.StatusOK, productionBodyWithCVSS("245-deadline-production-vuln"))
+
+	w := buildFeedWorker(pool, client)
+
+	// Run 1 (Scanner): the fix applies to BOTH feeds.
+	callTime := time.Now()
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 1 (scanner): %v", err)
+	}
+	assertDeadlineIsFeedFetchTimeout(t, "scanner", callTime, client.lastDeadline())
+
+	// Run 2 (Production): the feed the streaming fix actually targets.
+	backdateLastRequest(t, pool, 32*time.Minute)
+	callTime = time.Now()
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 2 (production): %v", err)
+	}
+	assertDeadlineIsFeedFetchTimeout(t, "production", callTime, client.lastDeadline())
+}
+
+func assertDeadlineIsFeedFetchTimeout(t *testing.T, feed string, callTime, deadline time.Time) {
+	t.Helper()
+	if deadline.IsZero() {
+		t.Fatalf("%s: request had no context deadline at all; want ~%v (FeedFetchTimeout)", feed, vuln.FeedFetchTimeout)
+	}
+	elapsed := deadline.Sub(callTime)
+	// Must be comfortably longer than the shared 30s update timeout that
+	// would otherwise fail Production mid-download.
+	if elapsed <= 30*time.Second {
+		t.Fatalf("%s: request context deadline is only %v out; want >> 30s (the shared cfg.Update.HTTPTimeout must NOT bound this fetch)", feed, elapsed)
+	}
+	// Must be close to FeedFetchTimeout (allow slack for test wall-clock jitter).
+	const slack = 5 * time.Second
+	if elapsed < vuln.FeedFetchTimeout-slack || elapsed > vuln.FeedFetchTimeout+slack {
+		t.Errorf("%s: request context deadline ~%v from call time; want close to FeedFetchTimeout=%v (±%v)",
+			feed, elapsed, vuln.FeedFetchTimeout, slack)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -374,6 +494,11 @@ func TestFeedWorker_StickyEnrichment_ScannerRunPreservesCVSS(t *testing.T) {
 	}
 	if rating != "Critical" {
 		t.Errorf("cvss_rating = %q; want %q preserved across the scanner run", rating, "Critical")
+	}
+
+	// cwe must also be preserved (COALESCE-sticky, same as cvss/cve).
+	if cwe := feedCWERaw(t, pool, vulnID); len(cwe) == 0 || string(cwe) == "null" {
+		t.Errorf("cwe = %s; want the production-populated CWE object preserved across the scanner run", cwe)
 	}
 
 	// enrichment_ok must ALSO remain sticky-true (a scanner run must not touch it).
@@ -759,5 +884,212 @@ func insertTenantAndSite(t *testing.T, pool *db.Pool, tenantID, siteID uuid.UUID
 		return err
 	}); err != nil {
 		t.Fatalf("seed tenant/site: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Production streaming (OOM follow-up): mid-stream durability + completion log.
+//
+// The pure batching/memory-bound claim itself is proven without any HTTP/DB
+// dependency in internal/vuln/worker_test.go's
+// TestFeedWorker_StreamProductionRecords_* tests. These two tests instead
+// drive the FULL wired-up Work() -> workProduction ->
+// fetchAndIngestProduction path against the real DB + fake HTTP client, to
+// prove the end-to-end wiring: a mid-stream failure leaves earlier batches
+// durably committed and never advances the cursor, and a successful run
+// logs its completion (whose absence hid the OOM in prod).
+// ---------------------------------------------------------------------------
+
+// productionBodyManyRecordsThenBroken builds a Production-shaped root JSON
+// object with validCount valid records (vuln_id prefix "stream-err-vuln-")
+// followed by one syntactically invalid trailing value — the same shape as
+// internal/vuln/worker_test.go's syntheticProductionStream, duplicated here
+// (rather than exported across the API boundary) since this file drives the
+// fake HTTP layer, not the decoder directly.
+func productionBodyManyRecordsThenBroken(validCount int) string {
+	var sb strings.Builder
+	sb.WriteString("{")
+	for i := 0; i < validCount; i++ {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		fmt.Fprintf(&sb, `"stream-err-vuln-%05d": {"title":"t","software":[{"type":"plugin","slug":"sp%05d","affected_versions":{},"patched":false,"patched_versions":[]}],"cvss":{"score":5.0,"rating":"Medium"}}`, i, i)
+	}
+	if validCount > 0 {
+		sb.WriteString(",")
+	}
+	sb.WriteString(`"stream-err-vuln-BROKEN": not-valid-json}`)
+	return sb.String()
+}
+
+// TestFeedWorker_ProductionStream_MidStreamError_NoCursorAdvance_PartialProgressPersists
+// covers requirement (c): a mid-stream decode failure on the Production leg
+// must return an error (River retries) and must NOT advance the alternation
+// cursor — but, thanks to streaming, the batch(es) that DID complete before
+// the failure remain durably committed rather than being lost entirely (the
+// improvement streaming buys over the old buffer-then-write-once approach).
+func TestFeedWorker_ProductionStream_MidStreamError_NoCursorAdvance_PartialProgressPersists(t *testing.T) {
+	pool := startPostgres(t)
+	client := newFakeFeedHTTPClient()
+	client.setResponse(vuln.ScannerFeedURL, http.StatusOK, scannerBodyNoCVSS("245-stream-err-scanner-vuln"))
+	// Exactly one full batch (ProductionBatchSize records) flushes inline
+	// before the broken trailing record breaks the decode.
+	client.setResponse(vuln.ProductionFeedURL, http.StatusOK, productionBodyManyRecordsThenBroken(vuln.ProductionBatchSize))
+
+	w := buildFeedWorker(pool, client)
+	repo := vuln.NewRepo(pool)
+
+	// Run 1: scanner succeeds — cursor -> production.
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 1 (scanner): %v", err)
+	}
+	gateBefore, err := repo.GetFeedGate(context.Background())
+	if err != nil {
+		t.Fatalf("GetFeedGate after run 1: %v", err)
+	}
+	if gateBefore.FeedKind != vuln.FeedKindProduction {
+		t.Fatalf("cursor after run 1 = %q; want %q", gateBefore.FeedKind, vuln.FeedKindProduction)
+	}
+
+	// Run 2: production hits the mid-stream decode failure.
+	backdateLastRequest(t, pool, 32*time.Minute)
+	if err := runFeedWork(t, w); err == nil {
+		t.Fatal("run 2 (production, mid-stream failure): Work returned nil; want a non-nil error (River should retry)")
+	}
+
+	// The cursor must be UNCHANGED — still production, so the next eligible
+	// run retries production rather than moving on to scanner and abandoning
+	// the enrichment that never finished landing.
+	gateAfter, err := repo.GetFeedGate(context.Background())
+	if err != nil {
+		t.Fatalf("GetFeedGate after run 2: %v", err)
+	}
+	if gateAfter.FeedKind != vuln.FeedKindProduction {
+		t.Errorf("cursor after a mid-stream failure = %q; want still %q (unchanged)", gateAfter.FeedKind, vuln.FeedKindProduction)
+	}
+
+	// Partial progress: the one batch that completed before the failure
+	// (ProductionBatchSize records) must be durably present in the DB.
+	var landedCount int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM wordfence_vuln_feed WHERE vuln_id LIKE 'stream-err-vuln-%' AND vuln_id != 'stream-err-vuln-BROKEN'`,
+	).Scan(&landedCount); err != nil {
+		t.Fatalf("count landed records: %v", err)
+	}
+	if landedCount != vuln.ProductionBatchSize {
+		t.Errorf("landed records after mid-stream failure = %d; want %d (the one batch that completed before the failure, durably committed)",
+			landedCount, vuln.ProductionBatchSize)
+	}
+
+	// The broken record itself must never have landed.
+	var brokenCount int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM wordfence_vuln_feed WHERE vuln_id = 'stream-err-vuln-BROKEN'`,
+	).Scan(&brokenCount); err != nil {
+		t.Fatalf("count broken record: %v", err)
+	}
+	if brokenCount != 0 {
+		t.Error("the syntactically-broken trailing record must never land in wordfence_vuln_feed")
+	}
+}
+
+// capturingHandler is a minimal slog.Handler that records emitted log
+// records for test assertions — used to prove the production path logs its
+// completion (requirement (d)): the ABSENCE of that log is exactly what made
+// the OOM incident hard to spot in prod (the job just died mid-fetch with no
+// "feed refresh complete" ever printed).
+type capturingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *capturingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(_ string) slog.Handler      { return h }
+
+// findRecord returns the LAST captured log record with the given message —
+// both the Scanner and Production paths log the same "vuln: feed refresh
+// complete" message, so callers driving multiple Work() runs want the most
+// recent one.
+func (h *capturingHandler) findRecord(msg string) (slog.Record, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for i := len(h.records) - 1; i >= 0; i-- {
+		if h.records[i].Message == msg {
+			return h.records[i], true
+		}
+	}
+	return slog.Record{}, false
+}
+
+func recordAttrString(r slog.Record, key string) (string, bool) {
+	var val string
+	var found bool
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == key {
+			val, found = a.Value.String(), true
+			return false
+		}
+		return true
+	})
+	return val, found
+}
+
+func recordAttrInt64(r slog.Record, key string) (int64, bool) {
+	var val int64
+	var found bool
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == key {
+			val, found = a.Value.Int64(), true
+			return false
+		}
+		return true
+	})
+	return val, found
+}
+
+// TestFeedWorker_ProductionPath_LogsCompletionWithRecordCount covers
+// requirement (d): a successful Production ingest must log
+// "vuln: feed refresh complete" with feed=production and the total record
+// count — matching the Scanner path's existing completion log. Its absence
+// is exactly what made the prod OOM (the job died mid-fetch, so this log
+// line never printed) hard to diagnose from logs alone.
+func TestFeedWorker_ProductionPath_LogsCompletionWithRecordCount(t *testing.T) {
+	pool := startPostgres(t)
+	const vulnID = "245-completion-log-vuln-1"
+	client := newFakeFeedHTTPClient()
+	client.setResponse(vuln.ScannerFeedURL, http.StatusOK, scannerBodyNoCVSS(vulnID))
+	client.setResponse(vuln.ProductionFeedURL, http.StatusOK, productionBodyWithCVSS(vulnID))
+
+	handler := &capturingHandler{}
+	logger := slog.New(handler)
+	w := buildFeedWorkerWithLogger(pool, client, logger)
+
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 1 (scanner): %v", err)
+	}
+	backdateLastRequest(t, pool, 32*time.Minute)
+	if err := runFeedWork(t, w); err != nil {
+		t.Fatalf("run 2 (production): %v", err)
+	}
+
+	rec, ok := handler.findRecord("vuln: feed refresh complete")
+	if !ok {
+		t.Fatal(`no "vuln: feed refresh complete" log record found for the production run — its absence is exactly what hid the OOM incident in prod`)
+	}
+	if feed, _ := recordAttrString(rec, "feed"); feed != vuln.FeedKindProduction {
+		t.Errorf(`completion log "feed" attr = %q; want %q`, feed, vuln.FeedKindProduction)
+	}
+	records, found := recordAttrInt64(rec, "records")
+	if !found || records != 1 {
+		t.Errorf(`completion log "records" attr = %v (found=%v); want 1`, records, found)
 	}
 }

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.73
+  version: 0.61.74
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Post-deploy verification of 0.61.73 exposed the *real* reason CVSS still wasn't landing. With the wall-clock spacing fix, a Production request reached Wordfence cleanly **for the first time ever** (it always 429'd before), and the actual large-feed download surfaced two latent bugs the rate-limiting had masked:

1. **OOM.** Prod logged `Container terminated on signal 9` (SIGKILL) 10s into the fetch. The Production feed is the full enriched dataset (CVSS/CVE/CWE/references per vuln) vs Scanner's ~37k minimal records; every record was accumulated into one whole-feed map, blowing past the 1Gi instance.
2. **Timeout-in-waiting.** The fetch shared the 30s `http.Client.Timeout` meant for agent-update traffic. Pre-fix it OOM'd before 30s; once streaming stops the OOM, the full download exceeds 30s and would hit that timeout. Fixed before it could bite.

### Fix (CP-only, no schema change)
- **Stream the Production ingest** — token-stream the JSON and flush to the DB in bounded batches of 500 (each its own tx, so a mid-stream failure keeps prior batches). Batch slice reused (`batch[:0]`) → memory O(batch), never O(feed). Scanner left buffered/unchanged (it fits + owns prune).
- Cursor advances **only** on a fully-successful non-empty ingest (`StampFeedMetaFinal`); mid-stream error / 429 / zero-records never flip it → Production is retried, not abandoned.
- Production path now **logs its completion** (`records=N`) — its absence is what made the OOM hard to spot.
- **Dedicated SSRF-hardened feed client** (`httpclient.New`, 8m timeout, same guarded constructor as the existing dedicated clients) + a `context.WithTimeout(ctx, 8m)` on both fetches. DB flushes keep the 10m job ctx. The shared 30s knob is untouched, SSRF guard intact.

Verified via self-read of all four invariants. Gates: go build/vet/test green (15 vuln integration tests incl. 3 new streaming + 1 fetch-deadline; route coverage). CP-only; agent unaffected. CHANGELOG + openapi in lockstep.

Refs #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWiZ4iJ1fmYW8vtPghWmsn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Wordfence vulnerability feed downloads and CVSS/CWE enrichment.
  * Added separate timing limits to prevent feed refreshes from being cut short.
  * Production feed data is now processed in bounded batches to reduce memory usage.
  * Corrected feed progress tracking so incomplete refreshes can be retried safely.

* **Chores**
  * Updated the application and API version to 0.61.74.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->