### PR TITLE
feat(api,web): vulnerability alerts — new-finding email + digest + signed webhook (GH #247) — 0.61.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
-## [0.61.74] - 2026-07-19
+## [0.61.75] - 2026-07-19
+
+### Added
+
+- Vulnerability alerts (GH #247). WPMgr now notifies operators when a new vulnerability is found, instead of the finding only appearing on the dashboard:
+  - A single email per scan that summarizes the new findings across your sites (site, component, installed and fixed versions, severity, and CVE), batched so one feed update that matches many sites sends one email, not one per site or per finding.
+  - An operator-configurable minimum severity (High and above by default); findings that do not have a severity score yet are always included.
+  - A signed webhook fires the same event for Slack or custom integrations (best effort; email is the guaranteed channel).
+  - An open-findings section in the daily email digest.
+  - Configured on the Alerts page alongside downtime alerts, sharing the same recipients. Opt-in and off by default; existing findings are not retroactively alerted when you enable it.
+  - Also fixes a bug where saving alert settings could silently reset the security-events toggle and a couple of other fields.
 
 ### Fixed
 

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.74
+ * Version:           0.61.75
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.74');
+define('WPMGR_AGENT_VERSION', '0.61.75');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -1590,6 +1590,9 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	})
 	vulnFeedWorker := vuln.NewFeedWorker(vulnRepo, pool, nil /*svc: wired below*/, vulnFeedKeySvc, vulnFeedHTTPClient, logger)
 	vulnRescanWorker := vuln.NewRescanSiteWorker(nil /*svc: wired below*/, logger)
+	// m103 (GH #247) — batched vulnerability-alert dispatch worker; svc and
+	// the debounced enqueuer are wired below once riverClient is up.
+	vulnAlertDispatchWorker := vuln.NewAlertDispatchWorker(nil /*svc: wired below*/, logger)
 
 	riverClient, err := startRiver(ctx, pool.Pool, logger, riverDeps{
 		healthChecker:          healthChecker,
@@ -1654,6 +1657,8 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 		// when WPMGR_WORDFENCE_API_KEY is unset).
 		vulnFeedWorker:   vulnFeedWorker,
 		vulnRescanWorker: vulnRescanWorker,
+		// m103 (GH #247) — batched vulnerability-alert dispatch (always wired).
+		vulnAlertDispatchWorker: vulnAlertDispatchWorker,
 		// m82 — file-transfers GC (always non-nil; object deletion is a no-op
 		// when S3 is not configured).
 		fileTransfersGCWorker: fileTransfersGCWorker,
@@ -1733,6 +1738,26 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// PUT /admin/vuln-feed/key endpoint can trigger an immediate sync.
 	vulnFeedKeySvc.SetEnqueuer(vulnFeedRefreshEnq)
 	vulnH := vuln.NewHandler(vulnSvc, vulnRescanEnq, auditRec)
+
+	// m103 (GH #247) — vulnerability alerting: the debounced dispatch
+	// enqueuer (RescanSiteWorker.Work triggers it after every successful
+	// rescan), the dispatch worker's service pointer, and the vuln service's
+	// mailer/webhook/alert-config wiring. Reuses the SAME templated-mailer
+	// queue (mailer.NewEnqueuer) as every other transactional email, and the
+	// SAME signed-webhook channel as uptime/security alerts
+	// (uptimeDispatcher.PostSignedWebhook, via vulnWebhookAdapter) rather than
+	// standing up a parallel notification system.
+	vulnAlertDispatchEnq := vuln.NewRiverAlertDispatchEnqueuer(riverClient)
+	vulnAlertDispatchWorker.SetService(vulnSvc)
+	vulnRescanWorker.SetAlertDispatchEnqueuer(vulnAlertDispatchEnq)
+	vulnSvc.SetMailer(mailer.NewEnqueuer(mailerSvc, riverClient))
+	vulnSvc.SetWebhookPoster(vulnWebhookAdapter{d: uptimeDispatcher})
+	vulnSvc.SetAlertConfigReader(vulnAlertConfigAdapter{svc: uptimeSvc})
+	vulnSvc.SetPublicBase(emailPublicBase)
+	// The email digest's "new vulnerabilities" section composes the uptime
+	// alert-config gate (vuln_include_in_digest) with the vuln service's
+	// fleet summary — see vulnDigestSourceAdapter.
+	emailSvc.SetVulnDigestSource(vulnDigestSourceAdapter{uptime: uptimeSvc, vuln: vulnSvc})
 
 	// M23 Media Optimizer: wire the EncodeArgs enqueuer now that River has
 	// started. The enqueuer lives in the PURE media package (no encoder import),
@@ -2751,6 +2776,8 @@ type riverDeps struct {
 	// WPMGR_WORDFENCE_API_KEY is not set.
 	vulnFeedWorker   *vuln.FeedWorker
 	vulnRescanWorker *vuln.RescanSiteWorker
+	// m103 (GH #247) — batched vulnerability-alert dispatch worker. Always wired.
+	vulnAlertDispatchWorker *vuln.AlertDispatchWorker
 	// m82 — File-transfers GC: deletes stale file_transfers rows (and best-effort
 	// deletes their staged objects) once per day. Always wired; object deletion is
 	// a no-op when the object store is not configured.
@@ -3200,6 +3227,14 @@ func startRiver(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger, d 
 	if d.vulnRescanWorker != nil {
 		river.AddWorker(workers, d.vulnRescanWorker)
 		queues[vuln.RescanSiteQueue] = river.QueueConfig{MaxWorkers: 8}
+	}
+	// m103 (GH #247) — batched vulnerability-alert dispatch. Debounced
+	// enqueue happens in RescanSiteWorker.Work (5-minute delay + 10-minute
+	// dedupe window — see vuln.EnqueueAlertDispatch); no periodic schedule of
+	// its own is needed since every rescan wave re-triggers it.
+	if d.vulnAlertDispatchWorker != nil {
+		river.AddWorker(workers, d.vulnAlertDispatchWorker)
+		queues[vuln.AlertDispatchQueue] = river.QueueConfig{MaxWorkers: 1}
 	}
 
 	// m82 — file-transfers GC: prunes stale file_transfers rows (and their

--- a/apps/api/cmd/wpmgr/vuln_alert_adapter.go
+++ b/apps/api/cmd/wpmgr/vuln_alert_adapter.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/email"
+	"github.com/mosamlife/wpmgr/apps/api/internal/uptime"
+	"github.com/mosamlife/wpmgr/apps/api/internal/vuln"
+)
+
+// vuln_alert_adapter.go — m103 (GH #247) wiring adapters. Each domain
+// package (vuln, email) declares a NARROW local interface for what it needs
+// from a sibling domain (internal/uptime's AlertConfig/Dispatcher) rather
+// than importing that package directly (see internal/vuln/alertdispatch.go
+// and internal/email/notify.go's doc comments) — these adapters are where
+// the concrete cross-domain wiring actually happens, exactly like
+// uptimeMailerAdapter in uptime_mailer.go.
+
+// vulnAlertConfigAdapter satisfies vuln.AlertConfigReader by delegating to
+// *uptime.Service.GetAlertConfig and mapping the fields the vuln dispatcher
+// needs onto vuln.AlertChannelConfig.
+type vulnAlertConfigAdapter struct {
+	svc *uptime.Service
+}
+
+func (a vulnAlertConfigAdapter) GetVulnAlertChannel(ctx context.Context, tenantID uuid.UUID) (vuln.AlertChannelConfig, error) {
+	cfg, err := a.svc.GetAlertConfig(ctx, tenantID)
+	if err != nil {
+		return vuln.AlertChannelConfig{}, err
+	}
+	return vuln.AlertChannelConfig{
+		Enabled:             cfg.Enabled,
+		EmailRecipients:     cfg.EmailRecipients,
+		WebhookURL:          cfg.WebhookURL,
+		WebhookSecret:       cfg.WebhookSecret,
+		NotifyVulns:         cfg.NotifyVulns,
+		VulnMinSeverity:     cfg.VulnMinSeverity,
+		VulnIncludeInDigest: cfg.VulnIncludeInDigest,
+	}, nil
+}
+
+// vulnWebhookAdapter satisfies vuln.WebhookPoster by delegating to
+// *uptime.Dispatcher.PostSignedWebhook, reusing the SAME HMAC signing +
+// SSRF-hardened delivery as the uptime/security alert channels instead of
+// vuln standing up a parallel webhook client.
+type vulnWebhookAdapter struct {
+	d *uptime.Dispatcher
+}
+
+func (a vulnWebhookAdapter) PostSignedWebhook(ctx context.Context, url, secret string, payload any) error {
+	return a.d.PostSignedWebhook(ctx, url, secret, payload)
+}
+
+// vulnDigestSourceAdapter satisfies email.VulnDigestSource by composing
+// *uptime.Service (the vuln_include_in_digest gate, which lives on the
+// alert_configs table, NOT the email domain's own notify settings) with
+// *vuln.Service (the open-finding fleet summary) — a single call that gates
+// AND fetches, so internal/email needs only one interface method.
+type vulnDigestSourceAdapter struct {
+	uptime *uptime.Service
+	vuln   *vuln.Service
+}
+
+// maxDigestVulnFindings caps the "top findings" list in the email digest's
+// vulnerability section.
+const maxDigestVulnFindings = 5
+
+func (a vulnDigestSourceAdapter) GetVulnDigestSummary(ctx context.Context, tenantID uuid.UUID) (email.VulnDigestSummary, bool, error) {
+	cfg, err := a.uptime.GetAlertConfig(ctx, tenantID)
+	if err != nil {
+		return email.VulnDigestSummary{}, false, err
+	}
+	if !cfg.VulnIncludeInDigest {
+		return email.VulnDigestSummary{}, false, nil
+	}
+
+	fleet, _, err := a.vuln.GetFleetSummary(ctx, tenantID, maxDigestVulnFindings)
+	if err != nil {
+		return email.VulnDigestSummary{}, false, err
+	}
+
+	summary := email.VulnDigestSummary{
+		OpenCount:         fleet.TotalOpen,
+		CriticalHighCount: fleet.Critical + fleet.High,
+	}
+	for _, f := range fleet.Findings {
+		summary.Top = append(summary.Top, email.VulnDigestItem{
+			SiteName:  f.SiteName,
+			Component: vuln.ComponentLabel(f.Finding.Kind, f.Finding.Name),
+			Severity:  vuln.SeverityLabel(f.Finding.Severity),
+			CVE:       f.Finding.CVE,
+		})
+	}
+	return summary, true, nil
+}

--- a/apps/api/db/query/alerts.sql
+++ b/apps/api/db/query/alerts.sql
@@ -7,15 +7,27 @@ WHERE tenant_id = $1;
 
 -- name: UpsertAlertConfig :one
 -- Tenant-scoped create-or-update of the tenant's default alert channel.
-INSERT INTO alert_configs (tenant_id, email_recipients, webhook_url, webhook_secret, enabled, notify_security)
-VALUES ($1, $2, $3, $4, $5, $6)
+-- m103 (GH #247): notify_vulns/vuln_min_severity/vuln_include_in_digest are
+-- the vulnerability-alerting fields — the service layer (uptime.Service.
+-- SaveAlertConfig) is responsible for merging omitted-on-PUT fields from the
+-- existing row before calling this query (see the mergeAlertConfigUpdate /
+-- Or(existing.X) pattern in handler.go); this query always writes exactly
+-- what it is given.
+INSERT INTO alert_configs (
+    tenant_id, email_recipients, webhook_url, webhook_secret, enabled,
+    notify_security, notify_vulns, vuln_min_severity, vuln_include_in_digest
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 ON CONFLICT (tenant_id) DO UPDATE
-SET email_recipients = EXCLUDED.email_recipients,
-    webhook_url       = EXCLUDED.webhook_url,
-    webhook_secret    = EXCLUDED.webhook_secret,
-    enabled           = EXCLUDED.enabled,
-    notify_security   = EXCLUDED.notify_security,
-    updated_at        = now()
+SET email_recipients       = EXCLUDED.email_recipients,
+    webhook_url             = EXCLUDED.webhook_url,
+    webhook_secret          = EXCLUDED.webhook_secret,
+    enabled                 = EXCLUDED.enabled,
+    notify_security         = EXCLUDED.notify_security,
+    notify_vulns            = EXCLUDED.notify_vulns,
+    vuln_min_severity       = EXCLUDED.vuln_min_severity,
+    vuln_include_in_digest  = EXCLUDED.vuln_include_in_digest,
+    updated_at              = now()
 RETURNING *;
 
 -- name: ListAlertConfigsAllTenants :many

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -1292,6 +1292,19 @@ CREATE TABLE alert_configs (
     -- SAME alert channel (email + webhook) as downtime/recovery. Default off so
     -- existing tenants do not start receiving security alerts unexpectedly.
     notify_security  boolean   NOT NULL DEFAULT false,
+    -- m103 (GH #247) — vulnerability alerting is the THIRD signal on this same
+    -- per-tenant channel. notify_vulns is opt-in (default off), mirroring
+    -- notify_security. vuln_min_severity is the operator-configurable alert
+    -- threshold ('unknown' is deliberately NOT a selectable option here — an
+    -- unknown-severity finding always alerts regardless of threshold; see
+    -- internal/vuln/alertdispatch.go). vuln_include_in_digest gates a
+    -- "new vulnerabilities" section on the existing email digest and defaults
+    -- ON so an operator who has digests enabled sees vuln activity by default.
+    notify_vulns     boolean   NOT NULL DEFAULT false,
+    vuln_min_severity text     NOT NULL DEFAULT 'high'
+        CONSTRAINT alert_configs_vuln_min_severity_chk
+        CHECK (vuln_min_severity IN ('critical', 'high', 'medium', 'low')),
+    vuln_include_in_digest boolean NOT NULL DEFAULT true,
     created_at       timestamptz NOT NULL DEFAULT now(),
     updated_at       timestamptz NOT NULL DEFAULT now()
 );
@@ -3759,6 +3772,14 @@ CREATE TABLE IF NOT EXISTS site_vulnerabilities (
     resolved_at       timestamptz,
     dismissed_at      timestamptz,
     dismissed_by      uuid,
+    -- m103 (GH #247) — vulnerability alerting debounce/claim stamp. NULL means
+    -- "not yet alerted"; the dispatch job claims a batch by atomically setting
+    -- this to now() (see internal/vuln.Repo.ClaimUnnotifiedFindings). A
+    -- resolved->open re-open (UpsertFinding) resets this to NULL so a
+    -- reappearing vulnerability alerts again. A fresh migration backfills this
+    -- to now() for every pre-existing row so the first-ever dispatch does not
+    -- email every operator their entire historical backlog.
+    notified_at       timestamptz,
 
     CONSTRAINT site_vulnerabilities_tenant_fkey
         FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE CASCADE,
@@ -3776,6 +3797,12 @@ CREATE INDEX IF NOT EXISTS idx_site_vuln_tenant_sev
 
 CREATE INDEX IF NOT EXISTS site_vulnerabilities_tenant_idx
     ON site_vulnerabilities (tenant_id, site_id);
+
+-- m103: the dispatch job's claim query filters on exactly this predicate
+-- (status='open' AND notified_at IS NULL) grouped by tenant_id.
+CREATE INDEX IF NOT EXISTS idx_site_vuln_tenant_unnotified
+    ON site_vulnerabilities (tenant_id)
+    WHERE status = 'open' AND notified_at IS NULL;
 
 ALTER TABLE site_vulnerabilities ENABLE ROW LEVEL SECURITY;
 ALTER TABLE site_vulnerabilities FORCE ROW LEVEL SECURITY;

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -19492,13 +19492,33 @@ func (s *AlertConfig) encodeFields(e *jx.Encoder) {
 		e.FieldStart("enabled")
 		e.Bool(s.Enabled)
 	}
+	{
+		e.FieldStart("notify_security")
+		e.Bool(s.NotifySecurity)
+	}
+	{
+		e.FieldStart("notify_vulns")
+		e.Bool(s.NotifyVulns)
+	}
+	{
+		e.FieldStart("vuln_min_severity")
+		s.VulnMinSeverity.Encode(e)
+	}
+	{
+		e.FieldStart("vuln_include_in_digest")
+		e.Bool(s.VulnIncludeInDigest)
+	}
 }
 
-var jsonFieldsNameOfAlertConfig = [4]string{
+var jsonFieldsNameOfAlertConfig = [8]string{
 	0: "email_recipients",
 	1: "webhook_url",
 	2: "webhook_configured",
 	3: "enabled",
+	4: "notify_security",
+	5: "notify_vulns",
+	6: "vuln_min_severity",
+	7: "vuln_include_in_digest",
 }
 
 // Decode decodes AlertConfig from json.
@@ -19564,6 +19584,52 @@ func (s *AlertConfig) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"enabled\"")
 			}
+		case "notify_security":
+			requiredBitSet[0] |= 1 << 4
+			if err := func() error {
+				v, err := d.Bool()
+				s.NotifySecurity = bool(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"notify_security\"")
+			}
+		case "notify_vulns":
+			requiredBitSet[0] |= 1 << 5
+			if err := func() error {
+				v, err := d.Bool()
+				s.NotifyVulns = bool(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"notify_vulns\"")
+			}
+		case "vuln_min_severity":
+			requiredBitSet[0] |= 1 << 6
+			if err := func() error {
+				if err := s.VulnMinSeverity.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"vuln_min_severity\"")
+			}
+		case "vuln_include_in_digest":
+			requiredBitSet[0] |= 1 << 7
+			if err := func() error {
+				v, err := d.Bool()
+				s.VulnIncludeInDigest = bool(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"vuln_include_in_digest\"")
+			}
 		default:
 			return d.Skip()
 		}
@@ -19574,7 +19640,7 @@ func (s *AlertConfig) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00001101,
+		0b11111101,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -19657,13 +19723,41 @@ func (s *AlertConfigUpdate) encodeFields(e *jx.Encoder) {
 			s.Enabled.Encode(e)
 		}
 	}
+	{
+		if s.NotifySecurity.Set {
+			e.FieldStart("notify_security")
+			s.NotifySecurity.Encode(e)
+		}
+	}
+	{
+		if s.NotifyVulns.Set {
+			e.FieldStart("notify_vulns")
+			s.NotifyVulns.Encode(e)
+		}
+	}
+	{
+		if s.VulnMinSeverity.Set {
+			e.FieldStart("vuln_min_severity")
+			s.VulnMinSeverity.Encode(e)
+		}
+	}
+	{
+		if s.VulnIncludeInDigest.Set {
+			e.FieldStart("vuln_include_in_digest")
+			s.VulnIncludeInDigest.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfAlertConfigUpdate = [4]string{
+var jsonFieldsNameOfAlertConfigUpdate = [8]string{
 	0: "email_recipients",
 	1: "webhook_url",
 	2: "webhook_secret",
 	3: "enabled",
+	4: "notify_security",
+	5: "notify_vulns",
+	6: "vuln_min_severity",
+	7: "vuln_include_in_digest",
 }
 
 // Decode decodes AlertConfigUpdate from json.
@@ -19724,6 +19818,46 @@ func (s *AlertConfigUpdate) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"enabled\"")
 			}
+		case "notify_security":
+			if err := func() error {
+				s.NotifySecurity.Reset()
+				if err := s.NotifySecurity.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"notify_security\"")
+			}
+		case "notify_vulns":
+			if err := func() error {
+				s.NotifyVulns.Reset()
+				if err := s.NotifyVulns.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"notify_vulns\"")
+			}
+		case "vuln_min_severity":
+			if err := func() error {
+				s.VulnMinSeverity.Reset()
+				if err := s.VulnMinSeverity.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"vuln_min_severity\"")
+			}
+		case "vuln_include_in_digest":
+			if err := func() error {
+				s.VulnIncludeInDigest.Reset()
+				if err := s.VulnIncludeInDigest.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"vuln_include_in_digest\"")
+			}
 		default:
 			return d.Skip()
 		}
@@ -19744,6 +19878,94 @@ func (s *AlertConfigUpdate) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *AlertConfigUpdate) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes AlertConfigUpdateVulnMinSeverity as json.
+func (s AlertConfigUpdateVulnMinSeverity) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes AlertConfigUpdateVulnMinSeverity from json.
+func (s *AlertConfigUpdateVulnMinSeverity) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AlertConfigUpdateVulnMinSeverity to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch AlertConfigUpdateVulnMinSeverity(v) {
+	case AlertConfigUpdateVulnMinSeverityCritical:
+		*s = AlertConfigUpdateVulnMinSeverityCritical
+	case AlertConfigUpdateVulnMinSeverityHigh:
+		*s = AlertConfigUpdateVulnMinSeverityHigh
+	case AlertConfigUpdateVulnMinSeverityMedium:
+		*s = AlertConfigUpdateVulnMinSeverityMedium
+	case AlertConfigUpdateVulnMinSeverityLow:
+		*s = AlertConfigUpdateVulnMinSeverityLow
+	default:
+		*s = AlertConfigUpdateVulnMinSeverity(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s AlertConfigUpdateVulnMinSeverity) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AlertConfigUpdateVulnMinSeverity) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes AlertConfigVulnMinSeverity as json.
+func (s AlertConfigVulnMinSeverity) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes AlertConfigVulnMinSeverity from json.
+func (s *AlertConfigVulnMinSeverity) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AlertConfigVulnMinSeverity to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch AlertConfigVulnMinSeverity(v) {
+	case AlertConfigVulnMinSeverityCritical:
+		*s = AlertConfigVulnMinSeverityCritical
+	case AlertConfigVulnMinSeverityHigh:
+		*s = AlertConfigVulnMinSeverityHigh
+	case AlertConfigVulnMinSeverityMedium:
+		*s = AlertConfigVulnMinSeverityMedium
+	case AlertConfigVulnMinSeverityLow:
+		*s = AlertConfigVulnMinSeverityLow
+	default:
+		*s = AlertConfigVulnMinSeverity(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s AlertConfigVulnMinSeverity) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AlertConfigVulnMinSeverity) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -70930,6 +71152,39 @@ func (s OptAgentMediaPresignOKUploads) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptAgentMediaPresignOKUploads) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes AlertConfigUpdateVulnMinSeverity as json.
+func (o OptAlertConfigUpdateVulnMinSeverity) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	e.Str(string(o.Value))
+}
+
+// Decode decodes AlertConfigUpdateVulnMinSeverity from json.
+func (o *OptAlertConfigUpdateVulnMinSeverity) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptAlertConfigUpdateVulnMinSeverity to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptAlertConfigUpdateVulnMinSeverity) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptAlertConfigUpdateVulnMinSeverity) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -6806,14 +6806,29 @@ func (s *AgentSuppressionDeltaPageEntriesItem) SetCreatedAt(val time.Time) {
 	s.CreatedAt = val
 }
 
-// A tenant's uptime alert channel. The webhook secret is write-only and is
-// never returned; webhook_configured indicates whether a webhook URL is set.
+// A tenant's alert channel, shared by uptime downtime/recovery,
+// high-severity security events, and vulnerability alerting (GH #247).
+// The webhook secret is write-only and is never returned;
+// webhook_configured indicates whether a webhook URL is set.
 // Ref: #/components/schemas/AlertConfig
 type AlertConfig struct {
 	EmailRecipients   []string  `json:"email_recipients"`
 	WebhookURL        OptString `json:"webhook_url"`
 	WebhookConfigured bool      `json:"webhook_configured"`
 	Enabled           bool      `json:"enabled"`
+	// Routes high-severity activity-log security events into this same
+	// channel (email + webhook).
+	NotifySecurity bool `json:"notify_security"`
+	// Routes new vulnerability findings into this same channel (email +
+	// webhook). Opt-in; default false.
+	NotifyVulns bool `json:"notify_vulns"`
+	// The minimum severity that triggers a vulnerability alert. A
+	// finding with unknown severity (no CVSS data yet) always alerts
+	// regardless of this threshold.
+	VulnMinSeverity AlertConfigVulnMinSeverity `json:"vuln_min_severity"`
+	// Whether open vulnerabilities appear in the periodic email digest
+	// (see EmailNotifySettings). Default true.
+	VulnIncludeInDigest bool `json:"vuln_include_in_digest"`
 }
 
 // GetEmailRecipients returns the value of EmailRecipients.
@@ -6836,6 +6851,26 @@ func (s *AlertConfig) GetEnabled() bool {
 	return s.Enabled
 }
 
+// GetNotifySecurity returns the value of NotifySecurity.
+func (s *AlertConfig) GetNotifySecurity() bool {
+	return s.NotifySecurity
+}
+
+// GetNotifyVulns returns the value of NotifyVulns.
+func (s *AlertConfig) GetNotifyVulns() bool {
+	return s.NotifyVulns
+}
+
+// GetVulnMinSeverity returns the value of VulnMinSeverity.
+func (s *AlertConfig) GetVulnMinSeverity() AlertConfigVulnMinSeverity {
+	return s.VulnMinSeverity
+}
+
+// GetVulnIncludeInDigest returns the value of VulnIncludeInDigest.
+func (s *AlertConfig) GetVulnIncludeInDigest() bool {
+	return s.VulnIncludeInDigest
+}
+
 // SetEmailRecipients sets the value of EmailRecipients.
 func (s *AlertConfig) SetEmailRecipients(val []string) {
 	s.EmailRecipients = val
@@ -6856,9 +6891,29 @@ func (s *AlertConfig) SetEnabled(val bool) {
 	s.Enabled = val
 }
 
+// SetNotifySecurity sets the value of NotifySecurity.
+func (s *AlertConfig) SetNotifySecurity(val bool) {
+	s.NotifySecurity = val
+}
+
+// SetNotifyVulns sets the value of NotifyVulns.
+func (s *AlertConfig) SetNotifyVulns(val bool) {
+	s.NotifyVulns = val
+}
+
+// SetVulnMinSeverity sets the value of VulnMinSeverity.
+func (s *AlertConfig) SetVulnMinSeverity(val AlertConfigVulnMinSeverity) {
+	s.VulnMinSeverity = val
+}
+
+// SetVulnIncludeInDigest sets the value of VulnIncludeInDigest.
+func (s *AlertConfig) SetVulnIncludeInDigest(val bool) {
+	s.VulnIncludeInDigest = val
+}
+
 func (*AlertConfig) putAlertConfigRes() {}
 
-// Create or update the tenant's uptime alert channel.
+// Create or update the tenant's alert channel.
 // Ref: #/components/schemas/AlertConfigUpdate
 type AlertConfigUpdate struct {
 	EmailRecipients []string  `json:"email_recipients"`
@@ -6866,6 +6921,15 @@ type AlertConfigUpdate struct {
 	// Write-only HMAC signing secret for the webhook payload.
 	WebhookSecret OptString `json:"webhook_secret"`
 	Enabled       OptBool   `json:"enabled"`
+	// Omitted preserves the tenant's currently-stored value (all fields
+	// in this update body are optional and independently preservable).
+	NotifySecurity OptBool `json:"notify_security"`
+	// Omitted preserves the tenant's currently-stored value.
+	NotifyVulns OptBool `json:"notify_vulns"`
+	// Omitted preserves the tenant's currently-stored value.
+	VulnMinSeverity OptAlertConfigUpdateVulnMinSeverity `json:"vuln_min_severity"`
+	// Omitted preserves the tenant's currently-stored value.
+	VulnIncludeInDigest OptBool `json:"vuln_include_in_digest"`
 }
 
 // GetEmailRecipients returns the value of EmailRecipients.
@@ -6888,6 +6952,26 @@ func (s *AlertConfigUpdate) GetEnabled() OptBool {
 	return s.Enabled
 }
 
+// GetNotifySecurity returns the value of NotifySecurity.
+func (s *AlertConfigUpdate) GetNotifySecurity() OptBool {
+	return s.NotifySecurity
+}
+
+// GetNotifyVulns returns the value of NotifyVulns.
+func (s *AlertConfigUpdate) GetNotifyVulns() OptBool {
+	return s.NotifyVulns
+}
+
+// GetVulnMinSeverity returns the value of VulnMinSeverity.
+func (s *AlertConfigUpdate) GetVulnMinSeverity() OptAlertConfigUpdateVulnMinSeverity {
+	return s.VulnMinSeverity
+}
+
+// GetVulnIncludeInDigest returns the value of VulnIncludeInDigest.
+func (s *AlertConfigUpdate) GetVulnIncludeInDigest() OptBool {
+	return s.VulnIncludeInDigest
+}
+
 // SetEmailRecipients sets the value of EmailRecipients.
 func (s *AlertConfigUpdate) SetEmailRecipients(val []string) {
 	s.EmailRecipients = val
@@ -6906,6 +6990,140 @@ func (s *AlertConfigUpdate) SetWebhookSecret(val OptString) {
 // SetEnabled sets the value of Enabled.
 func (s *AlertConfigUpdate) SetEnabled(val OptBool) {
 	s.Enabled = val
+}
+
+// SetNotifySecurity sets the value of NotifySecurity.
+func (s *AlertConfigUpdate) SetNotifySecurity(val OptBool) {
+	s.NotifySecurity = val
+}
+
+// SetNotifyVulns sets the value of NotifyVulns.
+func (s *AlertConfigUpdate) SetNotifyVulns(val OptBool) {
+	s.NotifyVulns = val
+}
+
+// SetVulnMinSeverity sets the value of VulnMinSeverity.
+func (s *AlertConfigUpdate) SetVulnMinSeverity(val OptAlertConfigUpdateVulnMinSeverity) {
+	s.VulnMinSeverity = val
+}
+
+// SetVulnIncludeInDigest sets the value of VulnIncludeInDigest.
+func (s *AlertConfigUpdate) SetVulnIncludeInDigest(val OptBool) {
+	s.VulnIncludeInDigest = val
+}
+
+// Omitted preserves the tenant's currently-stored value.
+type AlertConfigUpdateVulnMinSeverity string
+
+const (
+	AlertConfigUpdateVulnMinSeverityCritical AlertConfigUpdateVulnMinSeverity = "critical"
+	AlertConfigUpdateVulnMinSeverityHigh     AlertConfigUpdateVulnMinSeverity = "high"
+	AlertConfigUpdateVulnMinSeverityMedium   AlertConfigUpdateVulnMinSeverity = "medium"
+	AlertConfigUpdateVulnMinSeverityLow      AlertConfigUpdateVulnMinSeverity = "low"
+)
+
+// AllValues returns all AlertConfigUpdateVulnMinSeverity values.
+func (AlertConfigUpdateVulnMinSeverity) AllValues() []AlertConfigUpdateVulnMinSeverity {
+	return []AlertConfigUpdateVulnMinSeverity{
+		AlertConfigUpdateVulnMinSeverityCritical,
+		AlertConfigUpdateVulnMinSeverityHigh,
+		AlertConfigUpdateVulnMinSeverityMedium,
+		AlertConfigUpdateVulnMinSeverityLow,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s AlertConfigUpdateVulnMinSeverity) MarshalText() ([]byte, error) {
+	switch s {
+	case AlertConfigUpdateVulnMinSeverityCritical:
+		return []byte(s), nil
+	case AlertConfigUpdateVulnMinSeverityHigh:
+		return []byte(s), nil
+	case AlertConfigUpdateVulnMinSeverityMedium:
+		return []byte(s), nil
+	case AlertConfigUpdateVulnMinSeverityLow:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *AlertConfigUpdateVulnMinSeverity) UnmarshalText(data []byte) error {
+	switch AlertConfigUpdateVulnMinSeverity(data) {
+	case AlertConfigUpdateVulnMinSeverityCritical:
+		*s = AlertConfigUpdateVulnMinSeverityCritical
+		return nil
+	case AlertConfigUpdateVulnMinSeverityHigh:
+		*s = AlertConfigUpdateVulnMinSeverityHigh
+		return nil
+	case AlertConfigUpdateVulnMinSeverityMedium:
+		*s = AlertConfigUpdateVulnMinSeverityMedium
+		return nil
+	case AlertConfigUpdateVulnMinSeverityLow:
+		*s = AlertConfigUpdateVulnMinSeverityLow
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// The minimum severity that triggers a vulnerability alert. A
+// finding with unknown severity (no CVSS data yet) always alerts
+// regardless of this threshold.
+type AlertConfigVulnMinSeverity string
+
+const (
+	AlertConfigVulnMinSeverityCritical AlertConfigVulnMinSeverity = "critical"
+	AlertConfigVulnMinSeverityHigh     AlertConfigVulnMinSeverity = "high"
+	AlertConfigVulnMinSeverityMedium   AlertConfigVulnMinSeverity = "medium"
+	AlertConfigVulnMinSeverityLow      AlertConfigVulnMinSeverity = "low"
+)
+
+// AllValues returns all AlertConfigVulnMinSeverity values.
+func (AlertConfigVulnMinSeverity) AllValues() []AlertConfigVulnMinSeverity {
+	return []AlertConfigVulnMinSeverity{
+		AlertConfigVulnMinSeverityCritical,
+		AlertConfigVulnMinSeverityHigh,
+		AlertConfigVulnMinSeverityMedium,
+		AlertConfigVulnMinSeverityLow,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s AlertConfigVulnMinSeverity) MarshalText() ([]byte, error) {
+	switch s {
+	case AlertConfigVulnMinSeverityCritical:
+		return []byte(s), nil
+	case AlertConfigVulnMinSeverityHigh:
+		return []byte(s), nil
+	case AlertConfigVulnMinSeverityMedium:
+		return []byte(s), nil
+	case AlertConfigVulnMinSeverityLow:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *AlertConfigVulnMinSeverity) UnmarshalText(data []byte) error {
+	switch AlertConfigVulnMinSeverity(data) {
+	case AlertConfigVulnMinSeverityCritical:
+		*s = AlertConfigVulnMinSeverityCritical
+		return nil
+	case AlertConfigVulnMinSeverityHigh:
+		*s = AlertConfigVulnMinSeverityHigh
+		return nil
+	case AlertConfigVulnMinSeverityMedium:
+		*s = AlertConfigVulnMinSeverityMedium
+		return nil
+	case AlertConfigVulnMinSeverityLow:
+		*s = AlertConfigVulnMinSeverityLow
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
 }
 
 // Ref: #/components/schemas/ApiKey
@@ -25647,6 +25865,52 @@ func (o OptAgentMediaPresignOKUploads) Get() (v AgentMediaPresignOKUploads, ok b
 
 // Or returns value if set, or given parameter if does not.
 func (o OptAgentMediaPresignOKUploads) Or(d AgentMediaPresignOKUploads) AgentMediaPresignOKUploads {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptAlertConfigUpdateVulnMinSeverity returns new OptAlertConfigUpdateVulnMinSeverity with value set to v.
+func NewOptAlertConfigUpdateVulnMinSeverity(v AlertConfigUpdateVulnMinSeverity) OptAlertConfigUpdateVulnMinSeverity {
+	return OptAlertConfigUpdateVulnMinSeverity{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptAlertConfigUpdateVulnMinSeverity is optional AlertConfigUpdateVulnMinSeverity.
+type OptAlertConfigUpdateVulnMinSeverity struct {
+	Value AlertConfigUpdateVulnMinSeverity
+	Set   bool
+}
+
+// IsSet returns true if OptAlertConfigUpdateVulnMinSeverity was set.
+func (o OptAlertConfigUpdateVulnMinSeverity) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptAlertConfigUpdateVulnMinSeverity) Reset() {
+	var v AlertConfigUpdateVulnMinSeverity
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptAlertConfigUpdateVulnMinSeverity) SetTo(v AlertConfigUpdateVulnMinSeverity) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptAlertConfigUpdateVulnMinSeverity) Get() (v AlertConfigUpdateVulnMinSeverity, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptAlertConfigUpdateVulnMinSeverity) Or(d AlertConfigUpdateVulnMinSeverity) AlertConfigUpdateVulnMinSeverity {
 	if v, ok := o.Get(); ok {
 		return v
 	}

--- a/apps/api/internal/api/gen/oas_validators_gen.go
+++ b/apps/api/internal/api/gen/oas_validators_gen.go
@@ -1820,6 +1820,17 @@ func (s *AlertConfig) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		if err := s.VulnMinSeverity.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "vuln_min_severity",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
@@ -1869,10 +1880,58 @@ func (s *AlertConfigUpdate) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		if value, ok := s.VulnMinSeverity.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "vuln_min_severity",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
 	return nil
+}
+
+func (s AlertConfigUpdateVulnMinSeverity) Validate() error {
+	switch s {
+	case "critical":
+		return nil
+	case "high":
+		return nil
+	case "medium":
+		return nil
+	case "low":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s AlertConfigVulnMinSeverity) Validate() error {
+	switch s {
+	case "critical":
+		return nil
+	case "high":
+		return nil
+	case "medium":
+		return nil
+	case "low":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
 }
 
 func (s *ApiKey) Validate() error {

--- a/apps/api/internal/db/sqlc/alerts.sql.go
+++ b/apps/api/internal/db/sqlc/alerts.sql.go
@@ -57,7 +57,7 @@ func (q *Queries) CountRecentIncidents(ctx context.Context, arg CountRecentIncid
 
 const getAlertConfig = `-- name: GetAlertConfig :one
 
-SELECT id, tenant_id, email_recipients, webhook_url, webhook_secret, enabled, notify_security, created_at, updated_at FROM alert_configs
+SELECT id, tenant_id, email_recipients, webhook_url, webhook_secret, enabled, notify_security, notify_vulns, vuln_min_severity, vuln_include_in_digest, created_at, updated_at FROM alert_configs
 WHERE tenant_id = $1
 `
 
@@ -74,6 +74,9 @@ func (q *Queries) GetAlertConfig(ctx context.Context, tenantID uuid.UUID) (Alert
 		&i.WebhookSecret,
 		&i.Enabled,
 		&i.NotifySecurity,
+		&i.NotifyVulns,
+		&i.VulnMinSeverity,
+		&i.VulnIncludeInDigest,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -186,7 +189,7 @@ func (q *Queries) GetSiteAlertStateForUpdate(ctx context.Context, siteID uuid.UU
 }
 
 const listAlertConfigsAllTenants = `-- name: ListAlertConfigsAllTenants :many
-SELECT id, tenant_id, email_recipients, webhook_url, webhook_secret, enabled, notify_security, created_at, updated_at FROM alert_configs
+SELECT id, tenant_id, email_recipients, webhook_url, webhook_secret, enabled, notify_security, notify_vulns, vuln_min_severity, vuln_include_in_digest, created_at, updated_at FROM alert_configs
 WHERE enabled = true
 `
 
@@ -209,6 +212,9 @@ func (q *Queries) ListAlertConfigsAllTenants(ctx context.Context) ([]AlertConfig
 			&i.WebhookSecret,
 			&i.Enabled,
 			&i.NotifySecurity,
+			&i.NotifyVulns,
+			&i.VulnMinSeverity,
+			&i.VulnIncludeInDigest,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -262,28 +268,43 @@ func (q *Queries) OpenIncident(ctx context.Context, arg OpenIncidentParams) erro
 }
 
 const upsertAlertConfig = `-- name: UpsertAlertConfig :one
-INSERT INTO alert_configs (tenant_id, email_recipients, webhook_url, webhook_secret, enabled, notify_security)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO alert_configs (
+    tenant_id, email_recipients, webhook_url, webhook_secret, enabled,
+    notify_security, notify_vulns, vuln_min_severity, vuln_include_in_digest
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 ON CONFLICT (tenant_id) DO UPDATE
-SET email_recipients = EXCLUDED.email_recipients,
-    webhook_url       = EXCLUDED.webhook_url,
-    webhook_secret    = EXCLUDED.webhook_secret,
-    enabled           = EXCLUDED.enabled,
-    notify_security   = EXCLUDED.notify_security,
-    updated_at        = now()
-RETURNING id, tenant_id, email_recipients, webhook_url, webhook_secret, enabled, notify_security, created_at, updated_at
+SET email_recipients       = EXCLUDED.email_recipients,
+    webhook_url             = EXCLUDED.webhook_url,
+    webhook_secret          = EXCLUDED.webhook_secret,
+    enabled                 = EXCLUDED.enabled,
+    notify_security         = EXCLUDED.notify_security,
+    notify_vulns            = EXCLUDED.notify_vulns,
+    vuln_min_severity       = EXCLUDED.vuln_min_severity,
+    vuln_include_in_digest  = EXCLUDED.vuln_include_in_digest,
+    updated_at              = now()
+RETURNING id, tenant_id, email_recipients, webhook_url, webhook_secret, enabled, notify_security, notify_vulns, vuln_min_severity, vuln_include_in_digest, created_at, updated_at
 `
 
 type UpsertAlertConfigParams struct {
-	TenantID        uuid.UUID `json:"tenant_id"`
-	EmailRecipients []string  `json:"email_recipients"`
-	WebhookUrl      string    `json:"webhook_url"`
-	WebhookSecret   string    `json:"webhook_secret"`
-	Enabled         bool      `json:"enabled"`
-	NotifySecurity  bool      `json:"notify_security"`
+	TenantID            uuid.UUID `json:"tenant_id"`
+	EmailRecipients     []string  `json:"email_recipients"`
+	WebhookUrl          string    `json:"webhook_url"`
+	WebhookSecret       string    `json:"webhook_secret"`
+	Enabled             bool      `json:"enabled"`
+	NotifySecurity      bool      `json:"notify_security"`
+	NotifyVulns         bool      `json:"notify_vulns"`
+	VulnMinSeverity     string    `json:"vuln_min_severity"`
+	VulnIncludeInDigest bool      `json:"vuln_include_in_digest"`
 }
 
 // Tenant-scoped create-or-update of the tenant's default alert channel.
+// m103 (GH #247): notify_vulns/vuln_min_severity/vuln_include_in_digest are
+// the vulnerability-alerting fields — the service layer (uptime.Service.
+// SaveAlertConfig) is responsible for merging omitted-on-PUT fields from the
+// existing row before calling this query (see the mergeAlertConfigUpdate /
+// Or(existing.X) pattern in handler.go); this query always writes exactly
+// what it is given.
 func (q *Queries) UpsertAlertConfig(ctx context.Context, arg UpsertAlertConfigParams) (AlertConfig, error) {
 	row := q.db.QueryRow(ctx, upsertAlertConfig,
 		arg.TenantID,
@@ -292,6 +313,9 @@ func (q *Queries) UpsertAlertConfig(ctx context.Context, arg UpsertAlertConfigPa
 		arg.WebhookSecret,
 		arg.Enabled,
 		arg.NotifySecurity,
+		arg.NotifyVulns,
+		arg.VulnMinSeverity,
+		arg.VulnIncludeInDigest,
 	)
 	var i AlertConfig
 	err := row.Scan(
@@ -302,6 +326,9 @@ func (q *Queries) UpsertAlertConfig(ctx context.Context, arg UpsertAlertConfigPa
 		&i.WebhookSecret,
 		&i.Enabled,
 		&i.NotifySecurity,
+		&i.NotifyVulns,
+		&i.VulnMinSeverity,
+		&i.VulnIncludeInDigest,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -20,15 +20,18 @@ type AgentNonce struct {
 }
 
 type AlertConfig struct {
-	ID              uuid.UUID `json:"id"`
-	TenantID        uuid.UUID `json:"tenant_id"`
-	EmailRecipients []string  `json:"email_recipients"`
-	WebhookUrl      string    `json:"webhook_url"`
-	WebhookSecret   string    `json:"webhook_secret"`
-	Enabled         bool      `json:"enabled"`
-	NotifySecurity  bool      `json:"notify_security"`
-	CreatedAt       time.Time `json:"created_at"`
-	UpdatedAt       time.Time `json:"updated_at"`
+	ID                  uuid.UUID `json:"id"`
+	TenantID            uuid.UUID `json:"tenant_id"`
+	EmailRecipients     []string  `json:"email_recipients"`
+	WebhookUrl          string    `json:"webhook_url"`
+	WebhookSecret       string    `json:"webhook_secret"`
+	Enabled             bool      `json:"enabled"`
+	NotifySecurity      bool      `json:"notify_security"`
+	NotifyVulns         bool      `json:"notify_vulns"`
+	VulnMinSeverity     string    `json:"vuln_min_severity"`
+	VulnIncludeInDigest bool      `json:"vuln_include_in_digest"`
+	CreatedAt           time.Time `json:"created_at"`
+	UpdatedAt           time.Time `json:"updated_at"`
 }
 
 type ApiKey struct {
@@ -1068,6 +1071,7 @@ type SiteVulnerability struct {
 	ResolvedAt       pgtype.Timestamptz `json:"resolved_at"`
 	DismissedAt      pgtype.Timestamptz `json:"dismissed_at"`
 	DismissedBy      pgtype.UUID        `json:"dismissed_by"`
+	NotifiedAt       pgtype.Timestamptz `json:"notified_at"`
 }
 
 type SmtpSetting struct {

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -1841,6 +1841,12 @@ type Querier interface {
 	// row (0 rows = operator has never saved a config for this site).
 	UpdateWooThemeFragmentsSupported(ctx context.Context, arg UpdateWooThemeFragmentsSupportedParams) (int64, error)
 	// Tenant-scoped create-or-update of the tenant's default alert channel.
+	// m103 (GH #247): notify_vulns/vuln_min_severity/vuln_include_in_digest are
+	// the vulnerability-alerting fields — the service layer (uptime.Service.
+	// SaveAlertConfig) is responsible for merging omitted-on-PUT fields from the
+	// existing row before calling this query (see the mergeAlertConfigUpdate /
+	// Or(existing.X) pattern in handler.go); this query always writes exactly
+	// what it is given.
 	UpsertAlertConfig(ctx context.Context, arg UpsertAlertConfigParams) (AlertConfig, error)
 	// Moves the tenant's integrity anchor to the given chain-head snapshot. At
 	// most one row per tenant (PRIMARY KEY tenant_id) — a second re-baseline

--- a/apps/api/internal/email/notify.go
+++ b/apps/api/internal/email/notify.go
@@ -34,6 +34,37 @@ type MailerStatus interface {
 	Enabled(ctx context.Context) bool
 }
 
+// VulnDigestSource supplies the "new vulnerabilities" section of the email
+// digest (m103, GH #247). Declared locally (mirrors MailerEnqueuer) so
+// internal/email never imports internal/uptime or internal/vuln directly;
+// the adapter wired in cmd/wpmgr/main.go composes *uptime.Service (the
+// vuln_include_in_digest gate, which lives on the alert_configs table, NOT
+// this package's own NotifySettings) with *vuln.Service (open-finding data)
+// to satisfy it.
+type VulnDigestSource interface {
+	// GetVulnDigestSummary returns the tenant's current open-vulnerability
+	// summary and whether the digest should include it at all. When
+	// included=false the caller must not render the section regardless of
+	// summary.OpenCount (e.g. the flag is off, or the read itself failed).
+	GetVulnDigestSummary(ctx context.Context, tenantID uuid.UUID) (summary VulnDigestSummary, included bool, err error)
+}
+
+// VulnDigestSummary is the vulnerability data for one tenant's digest section.
+type VulnDigestSummary struct {
+	OpenCount         int
+	CriticalHighCount int
+	// Top holds at most 5 findings, most-severe first.
+	Top []VulnDigestItem
+}
+
+// VulnDigestItem is one finding row in the digest's "top vulnerabilities" list.
+type VulnDigestItem struct {
+	SiteName  string
+	Component string
+	Severity  string
+	CVE       string
+}
+
 // maxAlertFailureSamples is the maximum number of recent failure samples
 // included in a per-failure alert email body.
 const maxAlertFailureSamples = 5
@@ -157,7 +188,28 @@ func (s *Service) buildDigestData(ctx context.Context, tenantID uuid.UUID, setti
 		bouncedCount += row.BouncedCount
 	}
 
-	if total == 0 {
+	// m103 (GH #247): fetch the vulnerability-digest section, gated on
+	// alert_configs.vuln_include_in_digest (a flag on a DIFFERENT table than
+	// this tenant's own email digest settings). Best-effort: a read failure
+	// here must never block the rest of the digest — the section is simply
+	// omitted, exactly like vulnIncluded=false.
+	var vulnSummary VulnDigestSummary
+	var vulnIncluded bool
+	if s.vulnDigest != nil {
+		vs, included, vErr := s.vulnDigest.GetVulnDigestSummary(ctx, tenantID)
+		if vErr != nil {
+			s.log.Warn("email digest: vuln summary fetch failed",
+				slog.String("tenant_id", tenantID.String()), slog.Any("error", vErr))
+		} else {
+			vulnSummary, vulnIncluded = vs, included
+		}
+	}
+
+	// Widened skip-send: previously this skipped whenever the EMAIL total was
+	// 0, which would silently suppress a digest that has NOTHING to report
+	// except open vulnerabilities. Skip only when there is truly nothing in
+	// either section.
+	if total == 0 && (!vulnIncluded || vulnSummary.OpenCount == 0) {
 		return nil, nil // skip-send per spec
 	}
 
@@ -217,7 +269,7 @@ func (s *Service) buildDigestData(ctx context.Context, tenantID uuid.UUID, setti
 
 	periodLabel := computePeriodLabel(settings.DigestCadence, from)
 
-	return map[string]any{
+	data := map[string]any{
 		"PeriodLabel":  periodLabel,
 		"From":         from.Format("2006-01-02"),
 		"To":           to.Format("2006-01-02"),
@@ -229,7 +281,25 @@ func (s *Service) buildDigestData(ctx context.Context, tenantID uuid.UUID, setti
 		"Sites":        siteList,
 		"TopFailures":  failureList,
 		"DashboardURL": s.publicBase + "/email",
-	}, nil
+	}
+
+	if vulnIncluded {
+		topVulns := make([]map[string]any, 0, len(vulnSummary.Top))
+		for _, v := range vulnSummary.Top {
+			topVulns = append(topVulns, map[string]any{
+				"SiteName":  v.SiteName,
+				"Component": v.Component,
+				"Severity":  v.Severity,
+				"CVE":       v.CVE,
+			})
+		}
+		data["OpenVulnCount"] = vulnSummary.OpenCount
+		data["CriticalHighCount"] = vulnSummary.CriticalHighCount
+		data["TopVulns"] = topVulns
+		data["VulnDashboardURL"] = s.publicBase + "/vulnerabilities"
+	}
+
+	return data, nil
 }
 
 // computePeriodLabel formats a human-readable period label (e.g. "July 2026").

--- a/apps/api/internal/email/notify_test.go
+++ b/apps/api/internal/email/notify_test.go
@@ -3,6 +3,7 @@ package email
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -135,5 +136,92 @@ func TestNextDigestAt_Daily(t *testing.T) {
 	}
 	if next.Hour() != 8 {
 		t.Errorf("expected hour 8, got %d", next.Hour())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// m103 (GH #247) — vulnerability digest section
+// ---------------------------------------------------------------------------
+
+// fakeVulnDigestSource is a test double for VulnDigestSource.
+type fakeVulnDigestSource struct {
+	summary  VulnDigestSummary
+	included bool
+	err      error
+}
+
+func (f *fakeVulnDigestSource) GetVulnDigestSummary(_ context.Context, _ uuid.UUID) (VulnDigestSummary, bool, error) {
+	return f.summary, f.included, f.err
+}
+
+// TestBuildDigestData_VulnOnly_StillSends is the widened-skip-send
+// regression: a tenant with ZERO email activity but open vulnerabilities
+// (and vuln_include_in_digest on) must still receive a digest instead of
+// being silently skipped — the pre-m103 rule skipped whenever the email
+// Total was 0, which would have suppressed a vuln-only digest entirely.
+func TestBuildDigestData_VulnOnly_StillSends(t *testing.T) {
+	tenantID := uuid.New()
+	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+	svc.repo = newFakeRepo()
+	svc.vulnDigest = &fakeVulnDigestSource{
+		included: true,
+		summary: VulnDigestSummary{
+			OpenCount:         3,
+			CriticalHighCount: 1,
+			Top: []VulnDigestItem{
+				{SiteName: "example.com", Component: "Plugin: Foo", Severity: "Critical", CVE: "CVE-2024-1"},
+			},
+		},
+	}
+	settings := defaultNotifySettings(tenantID)
+	from, to := time.Now().AddDate(0, 0, -7), time.Now()
+
+	data, err := svc.buildDigestData(context.Background(), tenantID, settings, from, to)
+	if err != nil {
+		t.Fatalf("buildDigestData: %v", err)
+	}
+	if data == nil {
+		t.Fatal("expected a non-nil digest data map for a vuln-only period (widened skip-send)")
+	}
+	if data["Total"] != int64(0) {
+		t.Errorf("Total should still reflect zero email activity, got %v", data["Total"])
+	}
+	if data["OpenVulnCount"] != 3 {
+		t.Errorf("OpenVulnCount = %v, want 3", data["OpenVulnCount"])
+	}
+	if data["CriticalHighCount"] != 1 {
+		t.Errorf("CriticalHighCount = %v, want 1", data["CriticalHighCount"])
+	}
+	topVulns, ok := data["TopVulns"].([]map[string]any)
+	if !ok || len(topVulns) != 1 {
+		t.Fatalf("expected 1 TopVulns entry, got %v", data["TopVulns"])
+	}
+	if data["VulnDashboardURL"] == "" {
+		t.Error("expected a non-empty VulnDashboardURL")
+	}
+}
+
+// TestBuildDigestData_FlagOff_OmitsSection_PreservesZeroSkip proves the
+// vuln_include_in_digest gate: when the flag is off (included=false, even
+// though the source has open findings), the vuln section is entirely absent
+// from the data, AND the original Total==0 skip-send rule still applies when
+// there is also no email activity.
+func TestBuildDigestData_FlagOff_OmitsSection_PreservesZeroSkip(t *testing.T) {
+	tenantID := uuid.New()
+	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+	svc.repo = newFakeRepo()
+	svc.vulnDigest = &fakeVulnDigestSource{
+		included: false, // flag off
+		summary:  VulnDigestSummary{OpenCount: 5},
+	}
+	settings := defaultNotifySettings(tenantID)
+	from, to := time.Now().AddDate(0, 0, -7), time.Now()
+
+	data, err := svc.buildDigestData(context.Background(), tenantID, settings, from, to)
+	if err != nil {
+		t.Fatalf("buildDigestData: %v", err)
+	}
+	if data != nil {
+		t.Fatalf("expected skip-send (nil) when the flag is off and there is no email activity, got %v", data)
 	}
 }

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -124,6 +124,9 @@ type Service struct {
 	mailerStatus MailerStatus
 	// m62: public base URL for constructing dashboard links in emails.
 	publicBase string
+	// m103 (GH #247): supplies the digest's "new vulnerabilities" section.
+	// Nil is safe — buildDigestData skips the section entirely.
+	vulnDigest VulnDigestSource
 }
 
 // NewService builds the email service. enc may be nil (all secret-write paths
@@ -167,6 +170,12 @@ func (s *Service) SetMailerStatus(ms MailerStatus) {
 // notification emails (e.g. "https://manage.wpmgr.app"). Called from main.go.
 func (s *Service) SetPublicBase(base string) {
 	s.publicBase = base
+}
+
+// SetVulnDigestSource wires the vulnerability-digest data source (m103, GH
+// #247). Called from main.go once both the uptime and vuln services exist.
+func (s *Service) SetVulnDigestSource(v VulnDigestSource) {
+	s.vulnDigest = v
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/mailer/email_job.go
+++ b/apps/api/internal/mailer/email_job.go
@@ -90,3 +90,33 @@ func (e *Enqueuer) Enqueue(ctx context.Context, tenantID uuid.UUID, recipients [
 	}
 	return nil
 }
+
+// EnqueueTx behaves like Enqueue but inserts BOTH the email_log row and the
+// send_email River job inside the CALLER's transaction (tx) instead of
+// opening new ones, so the enqueue commits or rolls back atomically with
+// whatever else the caller is doing in the same tx. This is a transactional
+// outbox: internal/vuln's alert dispatcher uses it to enqueue a batched
+// vuln_alert email in the SAME tx as claiming the underlying findings
+// (stamping notified_at) — if the email enqueue fails, the whole tx rolls
+// back and the claim is undone, so the findings are retried on the next
+// dispatch cycle instead of being silently claimed-but-unemailed.
+func (e *Enqueuer) EnqueueTx(ctx context.Context, tx pgx.Tx, tenantID uuid.UUID, recipients []string, template string, data map[string]any) error {
+	subject, ok := subjects[template]
+	if !ok {
+		return fmt.Errorf("unknown email template %q", template)
+	}
+	logID, err := e.svc.insertLogTx(ctx, tx, tenantID, recipients, subject, template)
+	if err != nil {
+		return fmt.Errorf("insert email log (tx): %w", err)
+	}
+	if _, err := e.client.InsertTx(ctx, tx, SendEmailArgs{
+		EmailLogID: logID,
+		TenantID:   tenantID,
+		Recipients: recipients,
+		Template:   template,
+		Data:       data,
+	}, nil); err != nil {
+		return fmt.Errorf("enqueue send_email (tx): %w", err)
+	}
+	return nil
+}

--- a/apps/api/internal/mailer/mailer.go
+++ b/apps/api/internal/mailer/mailer.go
@@ -258,6 +258,26 @@ func (s *Service) insertLog(ctx context.Context, tenantID uuid.UUID, recipients 
 	return id
 }
 
+// insertLogTx writes a pending email_log row using the CALLER'S transaction
+// instead of opening a new one via InAgentTx — used by Enqueuer.EnqueueTx so
+// the log row + the send_email River job insert commit atomically with
+// whatever else the caller is doing in the same tx (see EnqueueTx doc).
+// tx must already carry a GUC (app.tenant_id or app.agent) satisfying
+// email_log's RLS policies — the caller's InTenantTx/InAgentTx wrapper does
+// this; insertLogTx itself sets nothing.
+func (s *Service) insertLogTx(ctx context.Context, tx pgx.Tx, tenantID uuid.UUID, recipients []string, subject, template string) (uuid.UUID, error) {
+	row, err := sqlc.New(tx).InsertEmailLog(ctx, sqlc.InsertEmailLogParams{
+		TenantID:    pgUUID(tenantID),
+		ToAddresses: recipients,
+		Subject:     subject,
+		Template:    template,
+	})
+	if err != nil {
+		return uuid.Nil, err
+	}
+	return row.ID, nil
+}
+
 func (s *Service) markSent(ctx context.Context, id uuid.UUID) {
 	if id == uuid.Nil {
 		return

--- a/apps/api/internal/mailer/renderer.go
+++ b/apps/api/internal/mailer/renderer.go
@@ -32,6 +32,8 @@ var subjects = map[string]string{
 	// m62: per-site email alerts + digest.
 	"email_failure_alert": "Email delivery failures detected",
 	"email_digest":        "Your WPMgr email delivery digest",
+	// m103 (GH #247): vulnerability alerting.
+	"vuln_alert": "New vulnerabilities detected",
 	// m64: white-label client reports.
 	"report_ready": "Your website report is ready",
 	// m66: client portal.

--- a/apps/api/internal/mailer/renderer_test.go
+++ b/apps/api/internal/mailer/renderer_test.go
@@ -93,6 +93,42 @@ func sampleData(name string) map[string]any {
 			{"SiteName": "example.com", "Subject": "Order receipt", "Error": "550 mailbox unavailable"},
 		}
 		common["DashboardURL"] = "https://manage.wpmgr.app/email"
+		// m103 (GH #247): mirrors the shape buildDigestData adds when
+		// alert_configs.vuln_include_in_digest is on.
+		common["OpenVulnCount"] = 4
+		common["CriticalHighCount"] = 2
+		common["TopVulns"] = []map[string]any{
+			{"SiteName": "example.com", "Component": "Plugin: Rank Math SEO", "Severity": "Critical", "CVE": "CVE-2024-12345"},
+			{"SiteName": "shop.example.com", "Component": "Plugin: WooCommerce", "Severity": "High", "CVE": ""},
+		}
+		common["VulnDashboardURL"] = "https://manage.wpmgr.app/vulnerabilities"
+	case "vuln_alert":
+		// Mirrors the production shape built in vuln/alertdispatch.go
+		// buildVulnAlertEmailData: severity-rank-desc grouped per site, an
+		// empty FixedVersion is pre-formatted to "no fixed version yet", and
+		// OverflowCount is set to exercise the "+N more" summary line.
+		common["NewCount"] = 3
+		common["SiteCount"] = 2
+		common["Sites"] = []map[string]any{
+			{
+				"SiteName": "example.com",
+				"SiteURL":  "https://example.com",
+				"Findings": []map[string]any{
+					{"Component": "Plugin: Rank Math SEO", "InstalledVersion": "1.0.98", "FixedVersion": "1.0.114", "Severity": "Critical", "CVE": "CVE-2024-12345"},
+					{"Component": "Theme: Astra", "InstalledVersion": "4.6.0", "FixedVersion": "no fixed version yet", "Severity": "Unknown (no CVSS yet)", "CVE": ""},
+				},
+			},
+			{
+				"SiteName": "shop.example.com",
+				"SiteURL":  "https://shop.example.com",
+				"Findings": []map[string]any{
+					{"Component": "Plugin: WooCommerce", "InstalledVersion": "8.0.0", "FixedVersion": "8.0.3", "Severity": "High", "CVE": ""},
+				},
+			},
+		}
+		common["OverflowCount"] = 5
+		common["DashboardURL"] = "https://manage.wpmgr.app/vulnerabilities"
+		common["FooterNote"] = "You are receiving this because vulnerability alerts are enabled for this account. Manage this in Alerts settings."
 	}
 	return common
 }

--- a/apps/api/internal/mailer/templates/email_digest.html.tmpl
+++ b/apps/api/internal/mailer/templates/email_digest.html.tmpl
@@ -65,6 +65,23 @@
           </table>
           {{end}}
 
+          {{if .TopVulns}}
+          <p class="body" style="margin:0 0 8px 0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:14px;font-weight:600;color:#3A4A48;">New vulnerabilities ({{.OpenVulnCount}} open, {{.CriticalHighCount}} critical/high)</p>
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 8px 0;">
+            {{range .TopVulns}}
+            <tr>
+              <td style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#3A4A48;padding:4px 0;border-bottom:1px solid #E5E7EB;">
+                <strong>{{.SiteName}}</strong> — {{.Component}}<br>
+                <span style="color:#DC2626;font-size:12px;">{{.Severity}}{{if .CVE}} — {{.CVE}}{{end}}</span>
+              </td>
+            </tr>
+            {{end}}
+          </table>
+          <p class="body" style="margin:0 0 20px 0;">
+            <a href="{{.VulnDashboardURL}}" style="color:#0A6675;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;text-decoration:underline;">View all vulnerabilities</a>
+          </p>
+          {{end}}
+
           <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 20px 0;">
             <tr>
               <td style="border-radius:6px;background:#16302E;">

--- a/apps/api/internal/mailer/templates/email_digest.txt.tmpl
+++ b/apps/api/internal/mailer/templates/email_digest.txt.tmpl
@@ -23,6 +23,14 @@ TOP FAILURES
   Error: {{.Error}}
 {{end}}
 {{end}}
+{{if .TopVulns}}
+NEW VULNERABILITIES ({{.OpenVulnCount}} open, {{.CriticalHighCount}} critical/high)
+--------------------
+{{range .TopVulns}}{{.SiteName}} — {{.Component}}
+  {{.Severity}}{{if .CVE}} ({{.CVE}}){{end}}
+{{end}}
+View all vulnerabilities: {{.VulnDashboardURL}}
+{{end}}
 Open email dashboard: {{.DashboardURL}}
 
 ---

--- a/apps/api/internal/mailer/templates/vuln_alert.html.tmpl
+++ b/apps/api/internal/mailer/templates/vuln_alert.html.tmpl
@@ -1,0 +1,40 @@
+{{template "header" .}}
+          <h1 class="ink" style="margin:0 0 14px 0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:24px;line-height:1.3;font-weight:700;color:#16302E;">New vulnerabilities detected</h1>
+          <p class="body" style="margin:0 0 20px 0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;line-height:1.6;color:#3A4A48;">
+            The latest vulnerability scan found <strong>{{.NewCount}}</strong> new finding{{if ne .NewCount 1}}s{{end}} across <strong>{{.SiteCount}}</strong> of your sites.
+          </p>
+
+          {{range .Sites}}
+          <p class="body" style="margin:0 0 8px 0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:14px;font-weight:600;color:#3A4A48;"><a href="{{.SiteURL}}" style="color:#16302E;text-decoration:none;">{{.SiteName}}</a></p>
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 18px 0;border-collapse:collapse;">
+            <tr style="background:#F9FAFB;">
+              <th style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:12px;font-weight:600;color:#6B7280;text-align:left;padding:6px 8px;border-bottom:1px solid #E5E7EB;">Component</th>
+              <th style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:12px;font-weight:600;color:#6B7280;text-align:left;padding:6px 8px;border-bottom:1px solid #E5E7EB;">Installed</th>
+              <th style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:12px;font-weight:600;color:#6B7280;text-align:left;padding:6px 8px;border-bottom:1px solid #E5E7EB;">Fixed in</th>
+              <th style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:12px;font-weight:600;color:#6B7280;text-align:left;padding:6px 8px;border-bottom:1px solid #E5E7EB;">Severity</th>
+              <th style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:12px;font-weight:600;color:#6B7280;text-align:left;padding:6px 8px;border-bottom:1px solid #E5E7EB;">CVE</th>
+            </tr>
+            {{range .Findings}}
+            <tr>
+              <td style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#3A4A48;padding:5px 8px;border-bottom:1px solid #F3F4F6;">{{.Component}}</td>
+              <td style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#3A4A48;padding:5px 8px;border-bottom:1px solid #F3F4F6;">{{.InstalledVersion}}</td>
+              <td style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#3A4A48;padding:5px 8px;border-bottom:1px solid #F3F4F6;">{{.FixedVersion}}</td>
+              <td style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;font-weight:600;padding:5px 8px;border-bottom:1px solid #F3F4F6;{{if or (eq .Severity "Critical") (eq .Severity "High")}}color:#DC2626;{{else if eq .Severity "Medium"}}color:#D97706;{{else}}color:#6B7280;{{end}}">{{.Severity}}</td>
+              <td style="font-family:'SFMono-Regular',Consolas,Menlo,Monaco,'Courier New',monospace;font-size:12px;color:#3A4A48;padding:5px 8px;border-bottom:1px solid #F3F4F6;">{{if .CVE}}{{.CVE}}{{else}}&mdash;{{end}}</td>
+            </tr>
+            {{end}}
+          </table>
+          {{end}}
+
+          {{if .OverflowCount}}
+          <p class="muted" style="margin:0 0 20px 0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;line-height:1.6;color:#6B7280;">+{{.OverflowCount}} more finding{{if ne .OverflowCount 1}}s{{end}} not shown above.</p>
+          {{end}}
+
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 20px 0;">
+            <tr>
+              <td style="border-radius:6px;background:#16302E;">
+                <a href="{{.DashboardURL}}" style="display:inline-block;padding:12px 24px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">Review and update in WPMgr</a>
+              </td>
+            </tr>
+          </table>
+{{template "footer" .}}

--- a/apps/api/internal/mailer/templates/vuln_alert.txt.tmpl
+++ b/apps/api/internal/mailer/templates/vuln_alert.txt.tmpl
@@ -1,0 +1,17 @@
+New vulnerabilities detected — {{.ProductName}}
+
+The latest vulnerability scan found {{.NewCount}} new finding{{if ne .NewCount 1}}s{{end}} across {{.SiteCount}} of your sites.
+{{range .Sites}}
+{{.SiteName}}
+  {{.SiteURL}}
+{{range .Findings}}  - {{.Component}} — installed {{.InstalledVersion}}, fixed in {{.FixedVersion}} — {{.Severity}}{{if .CVE}} ({{.CVE}}){{end}}
+{{end}}{{end}}{{if .OverflowCount}}
++{{.OverflowCount}} more finding{{if ne .OverflowCount 1}}s{{end}} not shown above.
+{{end}}
+Review and update: {{.DashboardURL}}
+
+--
+{{.ProductName}} — fleet control for WordPress
+{{if .FooterNote}}{{.FooterNote}}
+{{end}}Need help? Contact {{.SupportEmail}}.
+(c) {{.Year}} {{.ProductName}}.

--- a/apps/api/internal/uptime/alerts.go
+++ b/apps/api/internal/uptime/alerts.go
@@ -163,8 +163,9 @@ func (d *Dispatcher) sendEmail(ctx context.Context, recipients []string, subject
 
 // sendWebhook POSTs the alert webhook (when configured) and returns the REAL
 // delivery outcome, with a coarse/scrubbed reason on failure that NEVER
-// includes the endpoint's response body.
-func (d *Dispatcher) sendWebhook(ctx context.Context, url, secret string, payload WebhookPayload) (SendResult, error) {
+// includes the endpoint's response body. payload is `any` so this helper
+// serves any alert-producing domain's payload shape (see WebhookPoster doc).
+func (d *Dispatcher) sendWebhook(ctx context.Context, url, secret string, payload any) (SendResult, error) {
 	if d.webhook == nil || url == "" {
 		return SendResult{Status: SendResultSkipped, Reason: "webhook_not_configured"}, nil
 	}
@@ -232,6 +233,25 @@ func (d *Dispatcher) FireSecurityEvent(ctx context.Context, cfg AlertConfig, ev 
 			Metadata:   meta,
 		})
 	}
+}
+
+// PostSignedWebhook posts an arbitrary JSON-serializable payload to url,
+// signed with the SAME HMAC-SHA256-over-body scheme (X-WPMgr-Signature
+// header) and delivered over the SAME SSRF-hardened client as
+// Fire/FireSecurityEvent. It is a thin passthrough to sendWebhook, exported
+// so other alert-producing domains can reuse this channel's signing +
+// delivery exactly instead of duplicating it — e.g. internal/vuln's batched
+// vulnerability-findings webhook (m103, GH #247), which has its own payload
+// shape (spanning multiple sites) that does not fit the uptime-specific
+// WebhookPayload struct. Returns an error only on an actual delivery failure
+// (never merely "no webhook configured" — an empty url is a silent no-op,
+// mirroring sendWebhook's SendResultSkipped case).
+func (d *Dispatcher) PostSignedWebhook(ctx context.Context, url, secret string, payload any) error {
+	if url == "" {
+		return nil
+	}
+	_, err := d.sendWebhook(ctx, url, secret, payload)
+	return err
 }
 
 // channelMetadata builds the shared email/webhook outcome fields persisted on

--- a/apps/api/internal/uptime/handler.go
+++ b/apps/api/internal/uptime/handler.go
@@ -176,28 +176,19 @@ func (h *Handler) putAlertConfig(c *gin.Context) {
 		return
 	}
 
-	// Read the existing config so an omitted webhook_secret preserves the stored
-	// one (the secret is write-only and never echoed back, so the client cannot
-	// resubmit it).
+	// Read the existing config so every OMITTED optional field preserves its
+	// stored value instead of resetting to a hardcoded default. Before m103
+	// this handler only did this for webhook_secret — every other optional
+	// field (including notify_security) was unconditionally overwritten with
+	// its Go zero value/hardcoded default on every PUT, so e.g. saving a
+	// webhook_secret rotation with notify_security omitted silently turned
+	// notify_security back off. See mergeAlertConfigUpdate.
 	existing, err := h.svc.GetAlertConfig(c.Request.Context(), tenantID)
 	if err != nil {
 		httpx.Error(c, err)
 		return
 	}
-	recipients := req.EmailRecipients
-	if recipients == nil {
-		recipients = []string{}
-	}
-	cfg := AlertConfig{
-		TenantID:        tenantID,
-		EmailRecipients: recipients,
-		WebhookURL:      req.WebhookURL.Or(""),
-		WebhookSecret:   existing.WebhookSecret,
-		Enabled:         req.Enabled.Or(true),
-	}
-	if req.WebhookSecret.Set {
-		cfg.WebhookSecret = req.WebhookSecret.Value
-	}
+	cfg := mergeAlertConfigUpdate(tenantID, existing, req)
 
 	saved, err := h.svc.SaveAlertConfig(c.Request.Context(), cfg)
 	if err != nil {
@@ -205,11 +196,44 @@ func (h *Handler) putAlertConfig(c *gin.Context) {
 		return
 	}
 	h.record(c, tenantID, map[string]any{
-		"email_recipients":   len(saved.EmailRecipients),
-		"webhook_configured": saved.WebhookURL != "",
-		"enabled":            saved.Enabled,
+		"email_recipients":       len(saved.EmailRecipients),
+		"webhook_configured":     saved.WebhookURL != "",
+		"enabled":                saved.Enabled,
+		"notify_security":        saved.NotifySecurity,
+		"notify_vulns":           saved.NotifyVulns,
+		"vuln_min_severity":      saved.VulnMinSeverity,
+		"vuln_include_in_digest": saved.VulnIncludeInDigest,
 	})
 	c.JSON(http.StatusOK, alertConfigToAPI(saved))
+}
+
+// mergeAlertConfigUpdate applies a partial AlertConfigUpdate onto the
+// tenant's existing config. Every optional field follows the same
+// nil-sentinel "Or(existing.X)" pattern: an omitted field in the request body
+// preserves whatever is already stored rather than resetting it to a zero
+// value/hardcoded default. Declared as a pure function (no I/O) so the m103
+// regression — notify_security being unconditionally dropped on every PUT —
+// is directly unit-testable without a database or HTTP round-trip.
+func mergeAlertConfigUpdate(tenantID uuid.UUID, existing AlertConfig, req gen.AlertConfigUpdate) AlertConfig {
+	recipients := req.EmailRecipients
+	if recipients == nil {
+		recipients = []string{}
+	}
+	cfg := AlertConfig{
+		TenantID:            tenantID,
+		EmailRecipients:     recipients,
+		WebhookURL:          req.WebhookURL.Or(existing.WebhookURL),
+		WebhookSecret:       existing.WebhookSecret,
+		Enabled:             req.Enabled.Or(existing.Enabled),
+		NotifySecurity:      req.NotifySecurity.Or(existing.NotifySecurity),
+		NotifyVulns:         req.NotifyVulns.Or(existing.NotifyVulns),
+		VulnMinSeverity:     string(req.VulnMinSeverity.Or(gen.AlertConfigUpdateVulnMinSeverity(existing.VulnMinSeverity))),
+		VulnIncludeInDigest: req.VulnIncludeInDigest.Or(existing.VulnIncludeInDigest),
+	}
+	if req.WebhookSecret.Set {
+		cfg.WebhookSecret = req.WebhookSecret.Value
+	}
+	return cfg
 }
 
 func (h *Handler) record(c *gin.Context, tenantID uuid.UUID, meta map[string]any) {
@@ -377,9 +401,13 @@ func alertConfigToAPI(cfg AlertConfig) *gen.AlertConfig {
 		recipients = []string{}
 	}
 	out := &gen.AlertConfig{
-		EmailRecipients:   recipients,
-		WebhookConfigured: cfg.WebhookURL != "",
-		Enabled:           cfg.Enabled,
+		EmailRecipients:     recipients,
+		WebhookConfigured:   cfg.WebhookURL != "",
+		Enabled:             cfg.Enabled,
+		NotifySecurity:      cfg.NotifySecurity,
+		NotifyVulns:         cfg.NotifyVulns,
+		VulnMinSeverity:     gen.AlertConfigVulnMinSeverity(cfg.VulnMinSeverity),
+		VulnIncludeInDigest: cfg.VulnIncludeInDigest,
 	}
 	if cfg.WebhookURL != "" {
 		out.WebhookURL = gen.NewOptString(cfg.WebhookURL)

--- a/apps/api/internal/uptime/handler_test.go
+++ b/apps/api/internal/uptime/handler_test.go
@@ -1,0 +1,127 @@
+package uptime
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/api/gen"
+)
+
+// TestMergeAlertConfigUpdate_PreservesOmittedFields is the m103 (GH #247)
+// regression test: before this fix, putAlertConfig unconditionally reset
+// notify_security (and, less obviously, webhook_url/enabled) to a zero
+// value/hardcoded default on every PUT because the handler never read them
+// from the existing config at all. A PUT that only intends to change one
+// field (e.g. rotating webhook_secret, or flipping notify_vulns) must leave
+// every other field exactly as it was stored.
+func TestMergeAlertConfigUpdate_PreservesOmittedFields(t *testing.T) {
+	tenantID := uuid.New()
+	existing := AlertConfig{
+		TenantID:            tenantID,
+		EmailRecipients:     []string{"ops@example.com"},
+		WebhookURL:          "https://hooks.example.com/wpmgr",
+		WebhookSecret:       "existing-secret",
+		Enabled:             false, // deliberately non-default, to catch a hardcoded `Or(true)`
+		NotifySecurity:      true,
+		NotifyVulns:         true,
+		VulnMinSeverity:     VulnSeverityCritical,
+		VulnIncludeInDigest: false,
+	}
+
+	// An update body that only sets email_recipients — every other field is
+	// omitted and must round-trip from `existing`.
+	req := gen.AlertConfigUpdate{
+		EmailRecipients: []string{"ops@example.com", "oncall@example.com"},
+	}
+
+	got := mergeAlertConfigUpdate(tenantID, existing, req)
+
+	if len(got.EmailRecipients) != 2 {
+		t.Fatalf("email_recipients should reflect the request body, got %v", got.EmailRecipients)
+	}
+	if got.WebhookURL != existing.WebhookURL {
+		t.Errorf("webhook_url must be preserved when omitted: got %q, want %q", got.WebhookURL, existing.WebhookURL)
+	}
+	if got.WebhookSecret != existing.WebhookSecret {
+		t.Errorf("webhook_secret must be preserved when omitted: got %q, want %q", got.WebhookSecret, existing.WebhookSecret)
+	}
+	if got.Enabled != existing.Enabled {
+		t.Errorf("enabled must be preserved when omitted (not hardcoded true): got %v, want %v", got.Enabled, existing.Enabled)
+	}
+	if got.NotifySecurity != existing.NotifySecurity {
+		t.Errorf("THE REGRESSION: notify_security must be preserved when omitted: got %v, want %v", got.NotifySecurity, existing.NotifySecurity)
+	}
+	if got.NotifyVulns != existing.NotifyVulns {
+		t.Errorf("notify_vulns must be preserved when omitted: got %v, want %v", got.NotifyVulns, existing.NotifyVulns)
+	}
+	if got.VulnMinSeverity != existing.VulnMinSeverity {
+		t.Errorf("vuln_min_severity must be preserved when omitted: got %q, want %q", got.VulnMinSeverity, existing.VulnMinSeverity)
+	}
+	if got.VulnIncludeInDigest != existing.VulnIncludeInDigest {
+		t.Errorf("vuln_include_in_digest must be preserved when omitted: got %v, want %v", got.VulnIncludeInDigest, existing.VulnIncludeInDigest)
+	}
+}
+
+// TestMergeAlertConfigUpdate_SetFieldsOverride proves the flip side: every
+// field, when EXPLICITLY set in the request, overrides the stored value
+// (mergeAlertConfigUpdate must not accidentally always-preserve).
+func TestMergeAlertConfigUpdate_SetFieldsOverride(t *testing.T) {
+	tenantID := uuid.New()
+	existing := AlertConfig{
+		TenantID:            tenantID,
+		WebhookURL:          "https://old.example.com/hook",
+		Enabled:             true,
+		NotifySecurity:      false,
+		NotifyVulns:         false,
+		VulnMinSeverity:     VulnSeverityHigh,
+		VulnIncludeInDigest: true,
+	}
+	req := gen.AlertConfigUpdate{
+		WebhookURL:          gen.NewOptString("https://new.example.com/hook"),
+		WebhookSecret:       gen.NewOptString("new-secret"),
+		Enabled:             gen.NewOptBool(false),
+		NotifySecurity:      gen.NewOptBool(true),
+		NotifyVulns:         gen.NewOptBool(true),
+		VulnMinSeverity:     gen.NewOptAlertConfigUpdateVulnMinSeverity(gen.AlertConfigUpdateVulnMinSeverityLow),
+		VulnIncludeInDigest: gen.NewOptBool(false),
+	}
+
+	got := mergeAlertConfigUpdate(tenantID, existing, req)
+
+	if got.WebhookURL != "https://new.example.com/hook" {
+		t.Errorf("webhook_url should be overridden, got %q", got.WebhookURL)
+	}
+	if got.WebhookSecret != "new-secret" {
+		t.Errorf("webhook_secret should be overridden, got %q", got.WebhookSecret)
+	}
+	if got.Enabled != false {
+		t.Errorf("enabled should be overridden to false, got %v", got.Enabled)
+	}
+	if !got.NotifySecurity {
+		t.Errorf("notify_security should be overridden to true")
+	}
+	if !got.NotifyVulns {
+		t.Errorf("notify_vulns should be overridden to true")
+	}
+	if got.VulnMinSeverity != VulnSeverityLow {
+		t.Errorf("vuln_min_severity should be overridden to low, got %q", got.VulnMinSeverity)
+	}
+	if got.VulnIncludeInDigest {
+		t.Errorf("vuln_include_in_digest should be overridden to false")
+	}
+}
+
+// TestSaveAlertConfig_InvalidVulnMinSeverity proves the severity enum is
+// validated server-side (defense-in-depth beyond the DB CHECK constraint and
+// the OpenAPI enum), and that a valid value is accepted.
+func TestSaveAlertConfig_InvalidVulnMinSeverity(t *testing.T) {
+	svc := &Service{repo: nil}
+	_, err := svc.SaveAlertConfig(nil, AlertConfig{ //nolint:staticcheck // nil ctx: validation short-circuits before any repo/ctx use
+		TenantID:        uuid.New(),
+		VulnMinSeverity: "unknown", // deliberately invalid: not a selectable threshold
+	})
+	if err == nil {
+		t.Fatal("expected a validation error for vuln_min_severity=unknown")
+	}
+}

--- a/apps/api/internal/uptime/model.go
+++ b/apps/api/internal/uptime/model.go
@@ -43,7 +43,18 @@ type AlertConfig struct {
 	// NotifySecurity routes high-severity ADR-037 activity-log events into this
 	// same channel (email + webhook). Default false.
 	NotifySecurity bool
-	UpdatedAt      time.Time
+	// m103 (GH #247) — vulnerability alerting is the THIRD signal on this same
+	// channel. NotifyVulns is opt-in (default false), mirroring NotifySecurity.
+	NotifyVulns bool
+	// VulnMinSeverity is the alert threshold: "critical"|"high"|"medium"|"low".
+	// A finding with SeverityUnknown ALWAYS alerts regardless of this value
+	// (see internal/vuln/alertdispatch.go) — "unknown" is deliberately not a
+	// selectable threshold value.
+	VulnMinSeverity string
+	// VulnIncludeInDigest gates a "new vulnerabilities" section on the existing
+	// email digest. Default true.
+	VulnIncludeInDigest bool
+	UpdatedAt           time.Time
 }
 
 // AlertState is a site's durable alert transition memory.
@@ -211,6 +222,30 @@ type IncidentDetail struct {
 	IncidentCount30d int             `json:"incident_count_30d"`
 	Probes           []IncidentProbe `json:"probes"`
 	ProbesTruncated  bool            `json:"probes_truncated"`
+}
+
+// Vulnerability alert-threshold values (m103, GH #247) for AlertConfig.
+// VulnMinSeverity. These deliberately mirror internal/vuln's severity
+// vocabulary as plain string literals (not an import of that package) so
+// internal/uptime does not take on a cross-domain dependency for four
+// constants — see CLAUDE.md's "don't cross-import sibling domains" rule.
+// "unknown" is intentionally absent: it is never a selectable threshold (an
+// unknown-severity finding always alerts regardless of threshold).
+const (
+	VulnSeverityCritical = "critical"
+	VulnSeverityHigh     = "high"
+	VulnSeverityMedium   = "medium"
+	VulnSeverityLow      = "low"
+)
+
+// ValidVulnMinSeverity reports whether s is one of the four selectable
+// alert-threshold values.
+func ValidVulnMinSeverity(s string) bool {
+	switch s {
+	case VulnSeverityCritical, VulnSeverityHigh, VulnSeverityMedium, VulnSeverityLow:
+		return true
+	}
+	return false
 }
 
 // AlertKind distinguishes a downtime alert from a recovery alert.

--- a/apps/api/internal/uptime/notify.go
+++ b/apps/api/internal/uptime/notify.go
@@ -108,9 +108,13 @@ func (m *SMTPMailer) Send(ctx context.Context, recipients []string, subject, bod
 }
 
 // WebhookPoster delivers a signed alert webhook. An interface so the evaluator
-// can be tested without real network I/O.
+// can be tested without real network I/O. payload is `any` (not the
+// uptime-specific WebhookPayload struct) so the SAME signing + SSRF-hardened
+// delivery can be reused for other alert-producing domains' payload shapes —
+// see Dispatcher.PostSignedWebhook, used by internal/vuln's batched
+// vulnerability-findings webhook (m103, GH #247).
 type WebhookPoster interface {
-	Post(ctx context.Context, url, secret string, payload WebhookPayload) error
+	Post(ctx context.Context, url, secret string, payload any) error
 }
 
 // WebhookPayload is the JSON body POSTed to an alert webhook.
@@ -138,8 +142,10 @@ func NewSSRFWebhookPoster(client *httpclient.Client) *SSRFWebhookPoster {
 }
 
 // Post marshals, signs (HMAC-SHA256 hex over the body), and POSTs the payload.
-// The Client.Do path already applies bounded retries with backoff.
-func (p *SSRFWebhookPoster) Post(ctx context.Context, url, secret string, payload WebhookPayload) error {
+// The Client.Do path already applies bounded retries with backoff. payload is
+// `any` and marshaled via encoding/json — any JSON-serializable struct works,
+// not just WebhookPayload (see the interface doc above).
+func (p *SSRFWebhookPoster) Post(ctx context.Context, url, secret string, payload any) error {
 	if url == "" {
 		return nil
 	}

--- a/apps/api/internal/uptime/repo.go
+++ b/apps/api/internal/uptime/repo.go
@@ -285,12 +285,15 @@ func (r *pgRepo) UpsertAlertConfig(ctx context.Context, cfg AlertConfig) (AlertC
 	var out AlertConfig
 	err := r.pool.InTenantTx(ctx, cfg.TenantID, func(tx pgx.Tx) error {
 		row, err := sqlc.New(tx).UpsertAlertConfig(ctx, sqlc.UpsertAlertConfigParams{
-			TenantID:        cfg.TenantID,
-			EmailRecipients: recipients,
-			WebhookUrl:      cfg.WebhookURL,
-			WebhookSecret:   cfg.WebhookSecret,
-			Enabled:         cfg.Enabled,
-			NotifySecurity:  cfg.NotifySecurity,
+			TenantID:            cfg.TenantID,
+			EmailRecipients:     recipients,
+			WebhookUrl:          cfg.WebhookURL,
+			WebhookSecret:       cfg.WebhookSecret,
+			Enabled:             cfg.Enabled,
+			NotifySecurity:      cfg.NotifySecurity,
+			NotifyVulns:         cfg.NotifyVulns,
+			VulnMinSeverity:     cfg.VulnMinSeverity,
+			VulnIncludeInDigest: cfg.VulnIncludeInDigest,
 		})
 		if err != nil {
 			return domain.Internal("uptime_upsert_config_failed", "failed to save alert config").WithCause(err)
@@ -519,13 +522,16 @@ func alertConfigFromRow(row sqlc.AlertConfig) AlertConfig {
 		recipients = []string{}
 	}
 	return AlertConfig{
-		TenantID:        row.TenantID,
-		EmailRecipients: recipients,
-		WebhookURL:      row.WebhookUrl,
-		WebhookSecret:   row.WebhookSecret,
-		Enabled:         row.Enabled,
-		NotifySecurity:  row.NotifySecurity,
-		UpdatedAt:       row.UpdatedAt,
+		TenantID:            row.TenantID,
+		EmailRecipients:     recipients,
+		WebhookURL:          row.WebhookUrl,
+		WebhookSecret:       row.WebhookSecret,
+		Enabled:             row.Enabled,
+		NotifySecurity:      row.NotifySecurity,
+		NotifyVulns:         row.NotifyVulns,
+		VulnMinSeverity:     row.VulnMinSeverity,
+		VulnIncludeInDigest: row.VulnIncludeInDigest,
+		UpdatedAt:           row.UpdatedAt,
 	}
 }
 

--- a/apps/api/internal/uptime/service.go
+++ b/apps/api/internal/uptime/service.go
@@ -144,7 +144,13 @@ func (s *Service) GetAlertConfig(ctx context.Context, tenantID uuid.UUID) (Alert
 		return AlertConfig{}, err
 	}
 	if !found {
-		return AlertConfig{TenantID: tenantID, EmailRecipients: []string{}, Enabled: true}, nil
+		return AlertConfig{
+			TenantID:            tenantID,
+			EmailRecipients:     []string{},
+			Enabled:             true,
+			VulnMinSeverity:     VulnSeverityHigh,
+			VulnIncludeInDigest: true,
+		}, nil
 	}
 	return cfg, nil
 }
@@ -338,6 +344,10 @@ func (s *Service) SaveAlertConfig(ctx context.Context, cfg AlertConfig) (AlertCo
 		if err != nil || u == nil || (u.Scheme != "http" && u.Scheme != "https") {
 			return AlertConfig{}, domain.Validation("webhook_url_scheme", "webhook_url must be an http or https URL")
 		}
+	}
+	if !ValidVulnMinSeverity(cfg.VulnMinSeverity) {
+		return AlertConfig{}, domain.Validation("invalid_vuln_min_severity",
+			"vuln_min_severity must be one of: critical, high, medium, low")
 	}
 	return s.repo.UpsertAlertConfig(ctx, cfg)
 }

--- a/apps/api/internal/vuln/alertdispatch.go
+++ b/apps/api/internal/vuln/alertdispatch.go
@@ -1,0 +1,465 @@
+// alertdispatch.go — m103 (GH #247) vulnerability alerting.
+//
+// Vulnerability alerts are the THIRD signal on the existing per-tenant alert
+// channel (alert_configs), alongside uptime downtime/recovery and
+// notify_security. A NEW finding is status='open' AND notified_at IS NULL
+// (see Repo.ClaimUnnotifiedFindings). RescanSiteWorker.Work enqueues a
+// debounced, batched AlertDispatchArgs job after every successful rescan (see
+// worker.go); DispatchVulnAlerts below does the actual claim + gate + send
+// fan-out, once per tenant that currently has unnotified findings.
+package vuln
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// ---------------------------------------------------------------------------
+// Local interfaces — declared here (not imported from internal/uptime or
+// internal/mailer) so this package does not cross-import sibling domains.
+// The concrete adapters satisfying these are wired in cmd/wpmgr/main.go.
+// ---------------------------------------------------------------------------
+
+// AlertChannelConfig is the subset of a tenant's alert_configs row the vuln
+// dispatcher needs. Declared locally (mirrors the MailerEnqueuer pattern in
+// internal/email/notify.go) instead of importing internal/uptime.AlertConfig,
+// so this package has no hard dependency on the uptime domain.
+type AlertChannelConfig struct {
+	Enabled             bool
+	EmailRecipients     []string
+	WebhookURL          string
+	WebhookSecret       string
+	NotifyVulns         bool
+	VulnMinSeverity     string
+	VulnIncludeInDigest bool
+}
+
+// AlertConfigReader resolves a tenant's alert channel + vulnerability
+// alerting gate/threshold. The adapter wired in cmd/wpmgr/main.go delegates
+// to *uptime.Service.GetAlertConfig.
+type AlertConfigReader interface {
+	GetVulnAlertChannel(ctx context.Context, tenantID uuid.UUID) (AlertChannelConfig, error)
+}
+
+// AlertMailer enqueues a durable templated email ("vuln_alert") within the
+// SAME pgx transaction as the caller's finding-claim tx, so the email is
+// enqueued only if that transaction actually commits (transactional outbox —
+// see dispatchTenant). *mailer.Enqueuer satisfies this via its EnqueueTx
+// method (wired in cmd/wpmgr/main.go); declared locally so this package does
+// not import internal/mailer's whole surface.
+type AlertMailer interface {
+	EnqueueTx(ctx context.Context, tx pgx.Tx, tenantID uuid.UUID, recipients []string, template string, data map[string]any) error
+}
+
+// WebhookPoster posts a signed vulnerability-alert webhook payload to a
+// tenant's configured endpoint. The adapter wired in cmd/wpmgr/main.go
+// delegates to *uptime.Dispatcher.PostSignedWebhook, reusing its HMAC
+// signing + SSRF-hardened delivery exactly rather than duplicating it here.
+type WebhookPoster interface {
+	PostSignedWebhook(ctx context.Context, url, secret string, payload any) error
+}
+
+// ---------------------------------------------------------------------------
+// Webhook payload shapes (security.vuln_new_findings)
+// ---------------------------------------------------------------------------
+
+// VulnAlertWebhookPayload is the JSON body POSTed for the batched
+// vulnerability-findings webhook event. Unlike the uptime Dispatcher's
+// per-site WebhookPayload, this can span multiple sites in one delivery — a
+// whole rescan wave collapses to ONE dispatch (see the debounce enqueue in
+// worker.go). Includes the FULL filtered finding set (no display cap — that
+// is an email-rendering constraint only).
+type VulnAlertWebhookPayload struct {
+	Event     string                 `json:"event"`
+	TenantID  string                 `json:"tenant_id"`
+	NewCount  int                    `json:"new_count"`
+	SiteCount int                    `json:"site_count"`
+	Sites     []VulnAlertWebhookSite `json:"sites"`
+	FiredAt   time.Time              `json:"fired_at"`
+}
+
+// VulnAlertWebhookSite is one site's group of findings in the payload.
+type VulnAlertWebhookSite struct {
+	SiteID   string                    `json:"site_id"`
+	SiteName string                    `json:"site_name"`
+	SiteURL  string                    `json:"site_url"`
+	Findings []VulnAlertWebhookFinding `json:"findings"`
+}
+
+// VulnAlertWebhookFinding is one finding entry in the payload.
+type VulnAlertWebhookFinding struct {
+	Component        string `json:"component"`
+	InstalledVersion string `json:"installed_version"`
+	FixedVersion     string `json:"fixed_version,omitempty"`
+	Severity         string `json:"severity"`
+	CVE              string `json:"cve,omitempty"`
+}
+
+// VulnAlertEvent is the webhook event-type constant for a batched
+// vulnerability-alert dispatch.
+const VulnAlertEvent = "security.vuln_new_findings"
+
+// ---------------------------------------------------------------------------
+// Severity threshold + display helpers
+// ---------------------------------------------------------------------------
+
+// severityThresholdRank orders the four SELECTABLE alert-threshold severities
+// low(1) < medium(2) < high(3) < critical(4). SeverityUnknown deliberately has
+// no entry — it is never a threshold value and always passes the filter (see
+// passesSeverityThreshold).
+var severityThresholdRank = map[string]int{
+	SeverityLow:      1,
+	SeverityMedium:   2,
+	SeverityHigh:     3,
+	SeverityCritical: 4,
+}
+
+// passesSeverityThreshold reports whether severity clears minSeverity.
+// SeverityUnknown ALWAYS passes regardless of minSeverity: it represents the
+// newest, un-enriched Scanner-only findings (no CVSS/rating yet) — GH #247's
+// motivating CVE sat as 'unknown' pre-#245, and an enrichment upgrade never
+// resets notified_at (see Repo.UpsertFinding), so a finding excluded from its
+// FIRST alert at 'unknown' would never get a second chance to alert once
+// enriched. An unrecognised severity value (defensive; should not happen
+// given the DB CHECK) fails closed (does not alert).
+func passesSeverityThreshold(severity, minSeverity string) bool {
+	if severity == SeverityUnknown {
+		return true
+	}
+	rank, ok := severityThresholdRank[severity]
+	if !ok {
+		return false
+	}
+	minRank, ok := severityThresholdRank[minSeverity]
+	if !ok {
+		minRank = severityThresholdRank[SeverityHigh] // safety net: default to the documented default threshold
+	}
+	return rank >= minRank
+}
+
+// severityDisplayRank orders severities for GROUPED DISPLAY (email/webhook
+// ordering), NOT for the threshold filter: critical, high, unknown, medium,
+// low — mirrors the ORDER BY CASE used by ListOpenFindings/FleetOpenFindings.
+var severityDisplayRank = map[string]int{
+	SeverityCritical: 1,
+	SeverityHigh:     2,
+	SeverityUnknown:  3,
+	SeverityMedium:   4,
+	SeverityLow:      5,
+}
+
+// SeverityLabel formats a severity value for human display in emails.
+func SeverityLabel(severity string) string {
+	switch severity {
+	case SeverityCritical:
+		return "Critical"
+	case SeverityHigh:
+		return "High"
+	case SeverityMedium:
+		return "Medium"
+	case SeverityLow:
+		return "Low"
+	case SeverityUnknown:
+		return "Unknown (no CVSS yet)"
+	default:
+		return severity
+	}
+}
+
+// ComponentLabel formats a finding's kind+name for human display, e.g.
+// "Plugin: Rank Math SEO".
+func ComponentLabel(kind, name string) string {
+	switch kind {
+	case KindPlugin:
+		return "Plugin: " + name
+	case KindTheme:
+		return "Theme: " + name
+	case KindCore:
+		return "WordPress Core"
+	default:
+		return name
+	}
+}
+
+// fixedVersionDisplay returns the fixed version, or a human note when none is
+// published yet.
+func fixedVersionDisplay(v string) string {
+	if v == "" {
+		return "no fixed version yet"
+	}
+	return v
+}
+
+// ---------------------------------------------------------------------------
+// Service wiring
+// ---------------------------------------------------------------------------
+
+// SetMailer wires the templated-email enqueuer for vuln alert emails.
+func (s *Service) SetMailer(m AlertMailer) { s.mailer = m }
+
+// SetWebhookPoster wires the signed-webhook poster for vuln alert webhooks.
+func (s *Service) SetWebhookPoster(w WebhookPoster) { s.webhook = w }
+
+// SetAlertConfigReader wires the tenant alert-channel reader.
+func (s *Service) SetAlertConfigReader(r AlertConfigReader) { s.alertCfg = r }
+
+// SetPublicBase sets the public base URL used to build dashboard links in
+// vulnerability alert emails/webhooks (e.g. "https://manage.wpmgr.app").
+func (s *Service) SetPublicBase(base string) { s.publicBase = base }
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+// maxVulnAlertEmailFindings caps the number of findings rendered in a single
+// alert email; the rest are summarised as "+N more". The webhook payload is
+// never capped.
+const maxVulnAlertEmailFindings = 20
+
+// DispatchVulnAlerts is the vuln_alert_dispatch River job's entry point. It
+// enumerates every tenant with at least one open, not-yet-notified finding
+// and dispatches each independently — one tenant's failure is logged and
+// never blocks the others. Safe to run concurrently (per-tenant claims are
+// row-locked; see Repo.ClaimUnnotifiedFindings).
+func (s *Service) DispatchVulnAlerts(ctx context.Context) error {
+	if s.alertCfg == nil {
+		// Not wired (e.g. a self-host boot path that never called
+		// SetAlertConfigReader) — nothing to gate on, so skip cleanly rather
+		// than claim findings nobody can ever be notified about.
+		return nil
+	}
+	tenantIDs, err := s.repo.ListTenantsWithUnnotifiedFindings(ctx)
+	if err != nil {
+		return fmt.Errorf("vuln: list tenants with unnotified findings: %w", err)
+	}
+	for _, tenantID := range tenantIDs {
+		if dErr := s.dispatchTenant(ctx, tenantID); dErr != nil {
+			s.logger.Warn("vuln: alert dispatch failed for tenant",
+				slog.String("tenant_id", tenantID.String()), slog.Any("error", dErr))
+		}
+	}
+	return nil
+}
+
+// dispatchTenant claims one tenant's unnotified findings and, if any pass the
+// tenant's notify_vulns + severity gate, sends a batched email (enqueued in
+// the SAME tx as the claim — transactional outbox) and fires a signed webhook
+// (best-effort, after the tx commits — never inside a DB transaction).
+func (s *Service) dispatchTenant(ctx context.Context, tenantID uuid.UUID) error {
+	cfg, err := s.alertCfg.GetVulnAlertChannel(ctx, tenantID)
+	if err != nil {
+		return fmt.Errorf("get alert channel: %w", err)
+	}
+
+	var toSend []ClaimedFinding
+	txErr := s.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		claimed, cErr := s.repo.ClaimUnnotifiedFindings(ctx, tx, tenantID)
+		if cErr != nil {
+			return cErr
+		}
+		if len(claimed) == 0 {
+			return nil
+		}
+		if !cfg.Enabled || !cfg.NotifyVulns {
+			// Rows stay stamped (claimed above); nothing to send. Enabling
+			// notify_vulns later never floods the tenant with this backlog.
+			return nil
+		}
+		filtered := filterBySeverity(claimed, cfg.VulnMinSeverity)
+		if len(filtered) == 0 {
+			return nil
+		}
+		toSend = filtered
+
+		if s.mailer != nil && len(cfg.EmailRecipients) > 0 {
+			data := buildVulnAlertEmailData(filtered, s.publicBase)
+			if mErr := s.mailer.EnqueueTx(ctx, tx, tenantID, cfg.EmailRecipients, "vuln_alert", data); mErr != nil {
+				// Roll back: the claim is undone, so these findings remain
+				// unnotified and are retried on the next dispatch cycle.
+				return fmt.Errorf("enqueue vuln alert email: %w", mErr)
+			}
+		}
+		return nil
+	})
+	if txErr != nil {
+		return txErr
+	}
+
+	if len(toSend) > 0 && cfg.WebhookURL != "" && s.webhook != nil {
+		payload := buildVulnAlertWebhookPayload(tenantID, toSend)
+		if wErr := s.webhook.PostSignedWebhook(ctx, cfg.WebhookURL, cfg.WebhookSecret, payload); wErr != nil {
+			s.logger.Warn("vuln: alert webhook failed",
+				slog.String("tenant_id", tenantID.String()), slog.Any("error", wErr))
+		}
+	}
+	return nil
+}
+
+// filterBySeverity returns the subset of claimed findings that clear the
+// tenant's alert threshold (see passesSeverityThreshold).
+func filterBySeverity(claimed []ClaimedFinding, minSeverity string) []ClaimedFinding {
+	out := make([]ClaimedFinding, 0, len(claimed))
+	for _, c := range claimed {
+		if passesSeverityThreshold(c.Finding.Severity, minSeverity) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// sortedForDisplay returns a copy of claimed sorted for grouped display: by
+// each SITE's most-severe finding first, then within a site by severity rank,
+// CVSS score (desc), and first-seen (desc) — mirroring the
+// ListOpenFindings/FleetOpenFindings ORDER BY convention.
+func sortedForDisplay(claimed []ClaimedFinding) []ClaimedFinding {
+	siteMinRank := make(map[uuid.UUID]int, len(claimed))
+	for _, c := range claimed {
+		r := severityDisplayRank[c.Finding.Severity]
+		if cur, ok := siteMinRank[c.Finding.SiteID]; !ok || r < cur {
+			siteMinRank[c.Finding.SiteID] = r
+		}
+	}
+	out := make([]ClaimedFinding, len(claimed))
+	copy(out, claimed)
+	sort.SliceStable(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		if siteMinRank[a.Finding.SiteID] != siteMinRank[b.Finding.SiteID] {
+			return siteMinRank[a.Finding.SiteID] < siteMinRank[b.Finding.SiteID]
+		}
+		if a.Finding.SiteID != b.Finding.SiteID {
+			return a.SiteName < b.SiteName
+		}
+		ra, rb := severityDisplayRank[a.Finding.Severity], severityDisplayRank[b.Finding.Severity]
+		if ra != rb {
+			return ra < rb
+		}
+		as, bs := a.Finding.CVSSScore, b.Finding.CVSSScore
+		if as != nil && bs != nil && *as != *bs {
+			return *as > *bs
+		}
+		if (as == nil) != (bs == nil) {
+			return bs == nil // non-nil score sorts before nil
+		}
+		return a.Finding.FirstSeen.After(b.Finding.FirstSeen)
+	})
+	return out
+}
+
+// buildVulnAlertEmailData builds the data map handed to the mailer's
+// "vuln_alert" template. Shape:
+//
+//	{NewCount, SiteCount, Sites:[{SiteName, SiteURL, Findings:[{Component,
+//	 InstalledVersion, FixedVersion, Severity, CVE}]}], OverflowCount,
+//	 DashboardURL, FooterNote}
+//
+// Findings are capped at maxVulnAlertEmailFindings across ALL sites combined
+// (OverflowCount = however many were cut); the webhook payload is never
+// capped (see buildVulnAlertWebhookPayload).
+func buildVulnAlertEmailData(claimed []ClaimedFinding, publicBase string) map[string]any {
+	sorted := sortedForDisplay(claimed)
+	total := len(sorted)
+
+	siteCount := map[uuid.UUID]bool{}
+	for _, c := range sorted {
+		siteCount[c.Finding.SiteID] = true
+	}
+
+	capped := sorted
+	overflow := 0
+	if total > maxVulnAlertEmailFindings {
+		capped = sorted[:maxVulnAlertEmailFindings]
+		overflow = total - maxVulnAlertEmailFindings
+	}
+
+	type siteOrderEntry struct {
+		siteID   uuid.UUID
+		siteName string
+		siteURL  string
+	}
+	var order []siteOrderEntry
+	bySite := map[uuid.UUID][]map[string]any{}
+	for _, c := range capped {
+		if _, ok := bySite[c.Finding.SiteID]; !ok {
+			order = append(order, siteOrderEntry{c.Finding.SiteID, c.SiteName, c.SiteURL})
+		}
+		bySite[c.Finding.SiteID] = append(bySite[c.Finding.SiteID], map[string]any{
+			"Component":        ComponentLabel(c.Finding.Kind, c.Finding.Name),
+			"InstalledVersion": c.Finding.InstalledVersion,
+			"FixedVersion":     fixedVersionDisplay(c.Finding.FixedVersion),
+			"Severity":         SeverityLabel(c.Finding.Severity),
+			"CVE":              c.Finding.CVE,
+		})
+	}
+
+	sites := make([]map[string]any, 0, len(order))
+	for _, o := range order {
+		sites = append(sites, map[string]any{
+			"SiteName": o.siteName,
+			"SiteURL":  o.siteURL,
+			"Findings": bySite[o.siteID],
+		})
+	}
+
+	return map[string]any{
+		"NewCount":      total,
+		"SiteCount":     len(siteCount),
+		"Sites":         sites,
+		"OverflowCount": overflow,
+		"DashboardURL":  publicBase + "/vulnerabilities",
+		"FooterNote":    "You are receiving this because vulnerability alerts are enabled for this account. Manage this in Alerts settings.",
+	}
+}
+
+// buildVulnAlertWebhookPayload builds the signed webhook body. Includes the
+// FULL filtered finding set — the 20-item cap in buildVulnAlertEmailData is
+// an email-rendering constraint only; webhook consumers are machines.
+func buildVulnAlertWebhookPayload(tenantID uuid.UUID, claimed []ClaimedFinding) VulnAlertWebhookPayload {
+	sorted := sortedForDisplay(claimed)
+
+	type siteOrderEntry struct {
+		siteID   uuid.UUID
+		siteName string
+		siteURL  string
+	}
+	var order []siteOrderEntry
+	bySite := map[uuid.UUID][]VulnAlertWebhookFinding{}
+	siteSet := map[uuid.UUID]bool{}
+	for _, c := range sorted {
+		siteSet[c.Finding.SiteID] = true
+		if _, ok := bySite[c.Finding.SiteID]; !ok {
+			order = append(order, siteOrderEntry{c.Finding.SiteID, c.SiteName, c.SiteURL})
+		}
+		bySite[c.Finding.SiteID] = append(bySite[c.Finding.SiteID], VulnAlertWebhookFinding{
+			Component:        ComponentLabel(c.Finding.Kind, c.Finding.Name),
+			InstalledVersion: c.Finding.InstalledVersion,
+			FixedVersion:     c.Finding.FixedVersion,
+			Severity:         c.Finding.Severity,
+			CVE:              c.Finding.CVE,
+		})
+	}
+
+	sites := make([]VulnAlertWebhookSite, 0, len(order))
+	for _, o := range order {
+		sites = append(sites, VulnAlertWebhookSite{
+			SiteID:   o.siteID.String(),
+			SiteName: o.siteName,
+			SiteURL:  o.siteURL,
+			Findings: bySite[o.siteID],
+		})
+	}
+
+	return VulnAlertWebhookPayload{
+		Event:     VulnAlertEvent,
+		TenantID:  tenantID.String(),
+		NewCount:  len(sorted),
+		SiteCount: len(siteSet),
+		Sites:     sites,
+		FiredAt:   time.Now().UTC(),
+	}
+}

--- a/apps/api/internal/vuln/alertdispatch_test.go
+++ b/apps/api/internal/vuln/alertdispatch_test.go
@@ -1,0 +1,227 @@
+package vuln_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/vuln"
+)
+
+func claimedFinding(siteID uuid.UUID, siteName, kind, name, severity string, firstSeen time.Time) vuln.ClaimedFinding {
+	return vuln.ClaimedFinding{
+		Finding: vuln.Finding{
+			ID:               uuid.New(),
+			SiteID:           siteID,
+			Kind:             kind,
+			Name:             name,
+			InstalledVersion: "1.0.0",
+			Severity:         severity,
+			FirstSeen:        firstSeen,
+		},
+		SiteName: siteName,
+		SiteURL:  "https://" + siteName,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Severity threshold filter
+// ---------------------------------------------------------------------------
+
+func TestPassesSeverityThreshold(t *testing.T) {
+	cases := []struct {
+		severity, minSeverity string
+		want                  bool
+	}{
+		// Unknown ALWAYS passes, regardless of how high the threshold is —
+		// the whole point (GH #247): an un-enriched Scanner-only finding must
+		// never be excluded from its first-ever alert opportunity.
+		{vuln.SeverityUnknown, vuln.SeverityCritical, true},
+		{vuln.SeverityUnknown, vuln.SeverityLow, true},
+
+		{vuln.SeverityCritical, vuln.SeverityHigh, true},
+		{vuln.SeverityHigh, vuln.SeverityHigh, true},
+		{vuln.SeverityMedium, vuln.SeverityHigh, false},
+		{vuln.SeverityLow, vuln.SeverityHigh, false},
+
+		{vuln.SeverityLow, vuln.SeverityLow, true},
+		{vuln.SeverityMedium, vuln.SeverityLow, true},
+	}
+	for _, tc := range cases {
+		got := vuln.PassesSeverityThreshold(tc.severity, tc.minSeverity)
+		if got != tc.want {
+			t.Errorf("PassesSeverityThreshold(%q, %q) = %v, want %v", tc.severity, tc.minSeverity, got, tc.want)
+		}
+	}
+}
+
+func TestFilterBySeverity_UnknownIncludedBelowThreshold(t *testing.T) {
+	site := uuid.New()
+	now := time.Now()
+	claimed := []vuln.ClaimedFinding{
+		claimedFinding(site, "a.example.com", vuln.KindPlugin, "P1", vuln.SeverityCritical, now),
+		claimedFinding(site, "a.example.com", vuln.KindPlugin, "P2", vuln.SeverityMedium, now),  // below "high" threshold
+		claimedFinding(site, "a.example.com", vuln.KindPlugin, "P3", vuln.SeverityUnknown, now), // always included
+		claimedFinding(site, "a.example.com", vuln.KindPlugin, "P4", vuln.SeverityLow, now),     // below threshold
+	}
+	got := vuln.FilterBySeverity(claimed, vuln.SeverityHigh)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 findings to pass (critical + unknown), got %d: %+v", len(got), got)
+	}
+	names := map[string]bool{}
+	for _, c := range got {
+		names[c.Finding.Name] = true
+	}
+	if !names["P1"] || !names["P3"] {
+		t.Errorf("expected P1 (critical) and P3 (unknown) to pass, got %v", names)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Email data builder
+// ---------------------------------------------------------------------------
+
+func TestBuildVulnAlertEmailData_ShapeAndFixedVersionDisplay(t *testing.T) {
+	siteA := uuid.New()
+	now := time.Now()
+	f := vuln.ClaimedFinding{
+		Finding: vuln.Finding{
+			ID:               uuid.New(),
+			SiteID:           siteA,
+			Kind:             vuln.KindPlugin,
+			Name:             "Rank Math SEO",
+			InstalledVersion: "1.0.98",
+			FixedVersion:     "", // must render as "no fixed version yet"
+			Severity:         vuln.SeverityCritical,
+			CVE:              "CVE-2024-12345",
+			FirstSeen:        now,
+		},
+		SiteName: "example.com",
+		SiteURL:  "https://example.com",
+	}
+
+	data := vuln.BuildVulnAlertEmailData([]vuln.ClaimedFinding{f}, "https://manage.wpmgr.app")
+
+	if data["NewCount"] != 1 {
+		t.Errorf("NewCount = %v, want 1", data["NewCount"])
+	}
+	if data["SiteCount"] != 1 {
+		t.Errorf("SiteCount = %v, want 1", data["SiteCount"])
+	}
+	if data["OverflowCount"] != 0 {
+		t.Errorf("OverflowCount = %v, want 0", data["OverflowCount"])
+	}
+	if data["DashboardURL"] != "https://manage.wpmgr.app/vulnerabilities" {
+		t.Errorf("DashboardURL = %v", data["DashboardURL"])
+	}
+
+	sites, ok := data["Sites"].([]map[string]any)
+	if !ok || len(sites) != 1 {
+		t.Fatalf("expected 1 site group, got %v", data["Sites"])
+	}
+	if sites[0]["SiteName"] != "example.com" {
+		t.Errorf("SiteName = %v", sites[0]["SiteName"])
+	}
+	findings, ok := sites[0]["Findings"].([]map[string]any)
+	if !ok || len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %v", sites[0]["Findings"])
+	}
+	if findings[0]["Component"] != "Plugin: Rank Math SEO" {
+		t.Errorf("Component = %v, want %q", findings[0]["Component"], "Plugin: Rank Math SEO")
+	}
+	if findings[0]["FixedVersion"] != "no fixed version yet" {
+		t.Errorf("FixedVersion = %v, want %q", findings[0]["FixedVersion"], "no fixed version yet")
+	}
+	if findings[0]["Severity"] != "Critical" {
+		t.Errorf("Severity = %v, want %q", findings[0]["Severity"], "Critical")
+	}
+}
+
+// TestBuildVulnAlertEmailData_CapAndOverflow proves the 20-item email display
+// cap and its "+N more" overflow count, and that NewCount/SiteCount reflect
+// the FULL (uncapped) set, not just what's shown.
+func TestBuildVulnAlertEmailData_CapAndOverflow(t *testing.T) {
+	site := uuid.New()
+	now := time.Now()
+	var claimed []vuln.ClaimedFinding
+	for i := 0; i < 25; i++ {
+		claimed = append(claimed, claimedFinding(site, "example.com", vuln.KindPlugin, "P", vuln.SeverityHigh, now))
+	}
+
+	data := vuln.BuildVulnAlertEmailData(claimed, "https://manage.wpmgr.app")
+
+	if data["NewCount"] != 25 {
+		t.Errorf("NewCount = %v, want 25 (uncapped)", data["NewCount"])
+	}
+	if data["OverflowCount"] != 5 {
+		t.Errorf("OverflowCount = %v, want 5", data["OverflowCount"])
+	}
+	sites := data["Sites"].([]map[string]any)
+	total := 0
+	for _, s := range sites {
+		total += len(s["Findings"].([]map[string]any))
+	}
+	if total != 20 {
+		t.Errorf("total rendered findings = %d, want 20 (the cap)", total)
+	}
+}
+
+// TestBuildVulnAlertEmailData_SeverityGrouping proves the display order:
+// each site's most-severe finding first, and within a site,
+// critical > high > unknown > medium > low.
+func TestBuildVulnAlertEmailData_SeverityGrouping(t *testing.T) {
+	site := uuid.New()
+	now := time.Now()
+	claimed := []vuln.ClaimedFinding{
+		claimedFinding(site, "example.com", vuln.KindPlugin, "Low1", vuln.SeverityLow, now),
+		claimedFinding(site, "example.com", vuln.KindPlugin, "Crit1", vuln.SeverityCritical, now),
+		claimedFinding(site, "example.com", vuln.KindPlugin, "Unk1", vuln.SeverityUnknown, now),
+		claimedFinding(site, "example.com", vuln.KindPlugin, "Med1", vuln.SeverityMedium, now),
+		claimedFinding(site, "example.com", vuln.KindPlugin, "High1", vuln.SeverityHigh, now),
+	}
+	data := vuln.BuildVulnAlertEmailData(claimed, "")
+	sites := data["Sites"].([]map[string]any)
+	findings := sites[0]["Findings"].([]map[string]any)
+	wantOrder := []string{"Critical", "High", "Unknown (no CVSS yet)", "Medium", "Low"}
+	if len(findings) != len(wantOrder) {
+		t.Fatalf("expected %d findings, got %d", len(wantOrder), len(findings))
+	}
+	for i, want := range wantOrder {
+		if findings[i]["Severity"] != want {
+			t.Errorf("position %d: severity = %v, want %q", i, findings[i]["Severity"], want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Webhook payload builder
+// ---------------------------------------------------------------------------
+
+func TestBuildVulnAlertWebhookPayload_Uncapped(t *testing.T) {
+	site := uuid.New()
+	now := time.Now()
+	var claimed []vuln.ClaimedFinding
+	for i := 0; i < 25; i++ {
+		claimed = append(claimed, claimedFinding(site, "example.com", vuln.KindPlugin, "P", vuln.SeverityHigh, now))
+	}
+	tenantID := uuid.New()
+
+	payload := vuln.BuildVulnAlertWebhookPayload(tenantID, claimed)
+
+	if payload.Event != vuln.VulnAlertEvent {
+		t.Errorf("Event = %q, want %q", payload.Event, vuln.VulnAlertEvent)
+	}
+	if payload.TenantID != tenantID.String() {
+		t.Errorf("TenantID = %q, want %q", payload.TenantID, tenantID.String())
+	}
+	if payload.NewCount != 25 {
+		t.Errorf("NewCount = %d, want 25 (webhook is never capped)", payload.NewCount)
+	}
+	if payload.SiteCount != 1 {
+		t.Errorf("SiteCount = %d, want 1", payload.SiteCount)
+	}
+	if len(payload.Sites) != 1 || len(payload.Sites[0].Findings) != 25 {
+		t.Fatalf("expected 1 site with 25 findings, got %+v", payload.Sites)
+	}
+}

--- a/apps/api/internal/vuln/enqueuer.go
+++ b/apps/api/internal/vuln/enqueuer.go
@@ -3,6 +3,7 @@ package vuln
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/riverqueue/river"
@@ -59,6 +60,54 @@ func (e *RiverFeedRefreshEnqueuer) EnqueueFeedRefresh(ctx context.Context) error
 	})
 	if err != nil {
 		return fmt.Errorf("enqueue vuln feed refresh: %w", err)
+	}
+	return nil
+}
+
+// AlertDispatchEnqueuer enqueues the debounced, batched vuln-alert dispatch
+// job (m103, GH #247). Implemented by RiverAlertDispatchEnqueuer.
+type AlertDispatchEnqueuer interface {
+	EnqueueAlertDispatch(ctx context.Context) error
+}
+
+// alertDispatchDelay is the debounce settle window: RescanSiteWorker.Work
+// enqueues a dispatch job scheduled this far in the future (not immediately)
+// so a whole rescan wave — many per-site RescanSiteWorker jobs completing
+// close together after a feed refresh — collapses into ONE dispatch instead
+// of one per site.
+const alertDispatchDelay = 5 * time.Minute
+
+// alertDispatchDedupeWindow bounds how often a NEW dispatch job can be queued
+// while one is already pending/scheduled/running for the SAME kind — a
+// second rescan wave that starts before the first dispatch has fired must not
+// pile up duplicate jobs.
+const alertDispatchDedupeWindow = 10 * time.Minute
+
+// RiverAlertDispatchEnqueuer satisfies AlertDispatchEnqueuer using a River client.
+type RiverAlertDispatchEnqueuer struct {
+	client *river.Client[pgx.Tx]
+}
+
+// NewRiverAlertDispatchEnqueuer builds a RiverAlertDispatchEnqueuer.
+func NewRiverAlertDispatchEnqueuer(client *river.Client[pgx.Tx]) *RiverAlertDispatchEnqueuer {
+	return &RiverAlertDispatchEnqueuer{client: client}
+}
+
+// EnqueueAlertDispatch inserts an AlertDispatchArgs job (empty args — the job
+// is cross-tenant, enumerating every tenant with unnotified findings itself),
+// scheduled alertDispatchDelay in the future and deduplicated within
+// alertDispatchDedupeWindow so a whole rescan wave collapses to ONE dispatch.
+func (e *RiverAlertDispatchEnqueuer) EnqueueAlertDispatch(ctx context.Context) error {
+	_, err := e.client.Insert(ctx, AlertDispatchArgs{}, &river.InsertOpts{
+		Queue:       AlertDispatchQueue,
+		ScheduledAt: time.Now().Add(alertDispatchDelay),
+		UniqueOpts: river.UniqueOpts{
+			ByArgs:   true,
+			ByPeriod: alertDispatchDedupeWindow,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("enqueue vuln alert dispatch: %w", err)
 	}
 	return nil
 }

--- a/apps/api/internal/vuln/export_test.go
+++ b/apps/api/internal/vuln/export_test.go
@@ -2,7 +2,11 @@
 // the vuln_test package. This file is compiled only during `go test`.
 package vuln
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/google/uuid"
+)
 
 // IsSafeURL is isSafeURL exposed for testing (F2).
 func IsSafeURL(u string) bool { return isSafeURL(u) }
@@ -31,6 +35,31 @@ func MergeAffectedVersions(a, b []byte) []byte { return mergeAffectedVersions(a,
 
 // MergePatchedVersions exposes mergePatchedVersions for unit tests.
 func MergePatchedVersions(a, b []byte) []byte { return mergePatchedVersions(a, b) }
+
+// PassesSeverityThreshold exposes passesSeverityThreshold for tests (m103, GH #247).
+func PassesSeverityThreshold(severity, minSeverity string) bool {
+	return passesSeverityThreshold(severity, minSeverity)
+}
+
+// FilterBySeverity exposes filterBySeverity for tests.
+func FilterBySeverity(claimed []ClaimedFinding, minSeverity string) []ClaimedFinding {
+	return filterBySeverity(claimed, minSeverity)
+}
+
+// SortedForDisplay exposes sortedForDisplay for tests.
+func SortedForDisplay(claimed []ClaimedFinding) []ClaimedFinding {
+	return sortedForDisplay(claimed)
+}
+
+// BuildVulnAlertEmailData exposes buildVulnAlertEmailData for tests.
+func BuildVulnAlertEmailData(claimed []ClaimedFinding, publicBase string) map[string]any {
+	return buildVulnAlertEmailData(claimed, publicBase)
+}
+
+// BuildVulnAlertWebhookPayload exposes buildVulnAlertWebhookPayload for tests.
+func BuildVulnAlertWebhookPayload(tenantID uuid.UUID, claimed []ClaimedFinding) VulnAlertWebhookPayload {
+	return buildVulnAlertWebhookPayload(tenantID, claimed)
+}
 
 // StreamProductionRecords exposes (*FeedWorker).streamProductionRecords for
 // white-box unit testing the Production streaming/batching/memory-bound

--- a/apps/api/internal/vuln/repo.go
+++ b/apps/api/internal/vuln/repo.go
@@ -703,6 +703,17 @@ func (r *Repo) UpsertFinding(ctx context.Context, tx pgx.Tx, f FindingUpsert) er
 			resolved_at = CASE
 				WHEN site_vulnerabilities.status = 'resolved' THEN NULL
 				ELSE site_vulnerabilities.resolved_at
+			END,
+			-- m103 (GH #247): a reappearing vulnerability alerts again. Every
+			-- OTHER branch of this upsert (a routine re-match of an already-open
+			-- finding, e.g. on every rescan) must NEVER touch notified_at — that
+			-- is the sole responsibility of the alert dispatcher's claim
+			-- (Repo.ClaimUnnotifiedFindings) and an enrichment-only DO UPDATE
+			-- (e.g. the Production feed later filling in a CVSS score for an
+			-- already-claimed 'unknown' finding) must not silently re-arm it.
+			notified_at = CASE
+				WHEN site_vulnerabilities.status = 'resolved' THEN NULL
+				ELSE site_vulnerabilities.notified_at
 			END`,
 		f.TenantID, f.SiteID, f.VulnID, f.Kind, f.Slug, f.Name,
 		f.InstalledVersion, nilString(f.FixedVersion), f.Severity,
@@ -936,6 +947,135 @@ func (r *Repo) FleetOpenFindings(ctx context.Context, tenantID uuid.UUID, limit 
 		return rows.Err()
 	})
 	return result, err
+}
+
+// ---------------------------------------------------------------------------
+// Vulnerability alerting (m103, GH #247)
+// ---------------------------------------------------------------------------
+
+// ClaimedFinding is one site_vulnerabilities row claimed by
+// ClaimUnnotifiedFindings, joined with its site's name/url so the alert
+// dispatcher can build the batched email/webhook payload without a second
+// round-trip.
+type ClaimedFinding struct {
+	Finding  Finding
+	SiteName string
+	SiteURL  string
+}
+
+// ListTenantsWithUnnotifiedFindings returns the distinct set of tenants that
+// currently have at least one open, not-yet-notified finding
+// (status='open' AND notified_at IS NULL). Runs under InAgentTx (cross-tenant
+// enumeration, mirrors the feed worker's cross-tenant tenant listing) — the
+// caller (Service.DispatchVulnAlerts) fans out to dispatchTenant per tenant,
+// each of which claims and gates independently under its own InTenantTx.
+func (r *Repo) ListTenantsWithUnnotifiedFindings(ctx context.Context) ([]uuid.UUID, error) {
+	var out []uuid.UUID
+	err := r.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT DISTINCT tenant_id FROM site_vulnerabilities
+			WHERE status = 'open' AND notified_at IS NULL`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id uuid.UUID
+			if err := rows.Scan(&id); err != nil {
+				return err
+			}
+			out = append(out, id)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+// ClaimUnnotifiedFindings atomically claims every open, not-yet-notified
+// finding for a tenant by stamping notified_at = now(), and returns the
+// claimed rows joined with their site's name/url. MUST run inside the
+// caller's transaction (tx) — the claim and any resulting email-enqueue
+// happen in the SAME tx so they commit or roll back together (transactional
+// outbox; see Service.dispatchTenant). The UPDATE's row locks make concurrent
+// dispatchers safe: a second dispatcher racing on the same tenant claims zero
+// rows once the first has committed (or blocks until it does, then also
+// claims zero).
+//
+// ALL matching rows are claimed regardless of severity, and regardless of
+// whether alerting is even enabled for the tenant — the caller applies the
+// notify_vulns/severity gate AFTER claiming. Stamping unconditionally means
+// enabling alerts later (or lowering the threshold) never floods the tenant
+// with a backlog of old findings that predate the change.
+func (r *Repo) ClaimUnnotifiedFindings(ctx context.Context, tx pgx.Tx, tenantID uuid.UUID) ([]ClaimedFinding, error) {
+	rows, err := tx.Query(ctx, `
+		WITH claimed AS (
+			UPDATE site_vulnerabilities
+			SET notified_at = now()
+			WHERE tenant_id = $1 AND status = 'open' AND notified_at IS NULL
+			RETURNING id, tenant_id, site_id, vuln_id, kind, slug, name,
+			          installed_version, fixed_version, severity, cvss_score,
+			          cve, title, status, first_seen, last_seen,
+			          resolved_at, dismissed_at, dismissed_by
+		)
+		SELECT c.id, c.tenant_id, c.site_id, c.vuln_id, c.kind, c.slug, c.name,
+		       c.installed_version, c.fixed_version, c.severity, c.cvss_score,
+		       c.cve, c.title, c.status, c.first_seen, c.last_seen,
+		       c.resolved_at, c.dismissed_at, c.dismissed_by,
+		       s.name AS site_name, s.url AS site_url
+		FROM claimed c
+		JOIN sites s ON s.id = c.site_id`,
+		tenantID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("claim unnotified findings for tenant %s: %w", tenantID, err)
+	}
+	defer rows.Close()
+
+	var out []ClaimedFinding
+	for rows.Next() {
+		var cf ClaimedFinding
+		var (
+			cvssScore   pgtype.Numeric
+			resolvedAt  pgtype.Timestamptz
+			dismissedAt pgtype.Timestamptz
+			dismissedBy pgtype.UUID
+			fixedVer    pgtype.Text
+			cve         pgtype.Text
+		)
+		f := &cf.Finding
+		if err := rows.Scan(
+			&f.ID, &f.TenantID, &f.SiteID, &f.VulnID, &f.Kind, &f.Slug, &f.Name,
+			&f.InstalledVersion, &fixedVer, &f.Severity, &cvssScore,
+			&cve, &f.Title, &f.Status, &f.FirstSeen, &f.LastSeen,
+			&resolvedAt, &dismissedAt, &dismissedBy,
+			&cf.SiteName, &cf.SiteURL,
+		); err != nil {
+			return nil, fmt.Errorf("scan claimed finding: %w", err)
+		}
+		f.FixedVersion = fixedVer.String
+		f.CVE = cve.String
+		if cvssScore.Valid {
+			fv, _ := cvssScore.Float64Value()
+			if fv.Valid {
+				v := fv.Float64
+				f.CVSSScore = &v
+			}
+		}
+		if resolvedAt.Valid {
+			t := resolvedAt.Time
+			f.ResolvedAt = &t
+		}
+		if dismissedAt.Valid {
+			t := dismissedAt.Time
+			f.DismissedAt = &t
+		}
+		if dismissedBy.Valid {
+			uid := uuid.UUID(dismissedBy.Bytes)
+			f.DismissedBy = &uid
+		}
+		out = append(out, cf)
+	}
+	return out, rows.Err()
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/vuln/service.go
+++ b/apps/api/internal/vuln/service.go
@@ -47,6 +47,14 @@ type Service struct {
 	updates UpdateCreator
 	enqueue RescanEnqueuer
 	logger  *slog.Logger
+
+	// m103 (GH #247) — vulnerability alerting. All four are wired post-boot
+	// via their Set* methods (mirrors email.Service's SetMailer/SetPublicBase
+	// pattern); a nil alertCfg makes DispatchVulnAlerts a clean no-op.
+	mailer     AlertMailer
+	webhook    WebhookPoster
+	alertCfg   AlertConfigReader
+	publicBase string
 }
 
 // NewService builds a Service.

--- a/apps/api/internal/vuln/worker.go
+++ b/apps/api/internal/vuln/worker.go
@@ -1263,6 +1263,10 @@ type RescanSiteWorker struct {
 	river.WorkerDefaults[RescanSiteArgs]
 	svc    *Service
 	logger *slog.Logger
+	// alertEnqueue is the m103 (GH #247) debounced vuln-alert-dispatch
+	// enqueuer, wired post-boot via SetAlertDispatchEnqueuer. Nil is safe
+	// (the dispatch hook below is skipped).
+	alertEnqueue AlertDispatchEnqueuer
 }
 
 // NewRescanSiteWorker builds a RescanSiteWorker.
@@ -1274,7 +1278,15 @@ func NewRescanSiteWorker(svc *Service, logger *slog.Logger) *RescanSiteWorker {
 // once at boot after startRiver returns (the service needs the River client).
 func (w *RescanSiteWorker) SetService(svc *Service) { w.svc = svc }
 
-// Work performs the per-site vulnerability rescan.
+// SetAlertDispatchEnqueuer wires the debounced batched-alert-dispatch
+// enqueuer. Called once at boot after River starts (mirrors SetService).
+func (w *RescanSiteWorker) SetAlertDispatchEnqueuer(e AlertDispatchEnqueuer) { w.alertEnqueue = e }
+
+// Work performs the per-site vulnerability rescan, then — on success —
+// enqueues a debounced, batched vuln-alert-dispatch job (m103, GH #247). This
+// is the ONE hook that covers every rescan trigger (the operator-facing
+// "rescan now" route, the post-feed-refresh RescanAll fan-out, and any future
+// caller): all of them enqueue a RescanSiteArgs job, which always lands here.
 func (w *RescanSiteWorker) Work(ctx context.Context, job *river.Job[RescanSiteArgs]) error {
 	args := job.Args
 	if err := w.svc.RescanSite(ctx, args.TenantID, args.SiteID); err != nil {
@@ -1282,6 +1294,59 @@ func (w *RescanSiteWorker) Work(ctx context.Context, job *river.Job[RescanSiteAr
 			slog.String("tenant_id", args.TenantID.String()),
 			slog.String("site_id", args.SiteID.String()),
 			slog.Any("error", err))
+		return err
+	}
+
+	// Best-effort: a failure here must never fail the rescan itself (findings
+	// are already durably saved) — it just means this tenant's alert waits
+	// for the next rescan to re-trigger the debounce.
+	if w.alertEnqueue != nil {
+		if err := w.alertEnqueue.EnqueueAlertDispatch(ctx); err != nil {
+			w.logger.Warn("vuln: enqueue alert dispatch failed",
+				slog.String("tenant_id", args.TenantID.String()),
+				slog.String("site_id", args.SiteID.String()),
+				slog.Any("error", err))
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Vulnerability alert dispatch worker (m103, GH #247)
+// ---------------------------------------------------------------------------
+
+// AlertDispatchQueue is the River queue for the batched vuln-alert dispatch job.
+const AlertDispatchQueue = "vuln_alert_dispatch"
+
+// AlertDispatchArgs is the (argument-less) River job payload for the
+// debounced, cross-tenant vulnerability-alert dispatch. Empty args + the
+// UniqueOpts on EnqueueAlertDispatch are what collapse a whole rescan wave
+// into a single dispatch job.
+type AlertDispatchArgs struct{}
+
+// Kind implements river.JobArgs.
+func (AlertDispatchArgs) Kind() string { return "vuln_alert_dispatch" }
+
+// AlertDispatchWorker runs Service.DispatchVulnAlerts.
+type AlertDispatchWorker struct {
+	river.WorkerDefaults[AlertDispatchArgs]
+	svc    *Service
+	logger *slog.Logger
+}
+
+// NewAlertDispatchWorker builds an AlertDispatchWorker.
+func NewAlertDispatchWorker(svc *Service, logger *slog.Logger) *AlertDispatchWorker {
+	return &AlertDispatchWorker{svc: svc, logger: logger}
+}
+
+// SetService wires the vuln service into the worker after construction.
+// Called once at boot after startRiver returns (mirrors RescanSiteWorker).
+func (w *AlertDispatchWorker) SetService(svc *Service) { w.svc = svc }
+
+// Work runs the batched dispatch across every tenant with unnotified findings.
+func (w *AlertDispatchWorker) Work(ctx context.Context, job *river.Job[AlertDispatchArgs]) error {
+	if err := w.svc.DispatchVulnAlerts(ctx); err != nil {
+		w.logger.Warn("vuln: alert dispatch job failed", slog.Any("error", err))
 		return err
 	}
 	return nil

--- a/apps/api/migrations/20260805000000_m103_vuln_alerting.sql
+++ b/apps/api/migrations/20260805000000_m103_vuln_alerting.sql
@@ -1,0 +1,63 @@
+-- m103 — GH #247: vulnerability alerting, the THIRD signal on the existing
+-- per-tenant alert channel (alert_configs), alongside downtime and
+-- notify_security.
+--
+-- alert_configs gains three columns:
+--   notify_vulns            — opt-in (default off), mirrors notify_security.
+--   vuln_min_severity       — the operator-configurable alert threshold.
+--                              'unknown' is deliberately NOT a selectable
+--                              value here: an unknown-severity finding always
+--                              alerts regardless of threshold (see
+--                              internal/vuln/alertdispatch.go) because it is
+--                              a newest, un-enriched Scanner-only entry that
+--                              may never resolve to a rated severity — #247's
+--                              motivating CVE sat as 'unknown' pre-#245.
+--   vuln_include_in_digest  — gates a "new vulnerabilities" section on the
+--                              existing email digest; defaults ON.
+-- Recipients + webhook delivery are NOT duplicated here — vuln alerts reuse
+-- the existing email_recipients/webhook_url/webhook_secret columns on this
+-- same row, exactly like notify_security.
+--
+-- site_vulnerabilities gains notified_at (nullable): NULL means "not yet
+-- alerted"; the dispatch job atomically claims a tenant's batch by setting it
+-- to now() (see internal/vuln.Repo.ClaimUnnotifiedFindings). CRITICAL:
+-- existing rows are backfilled to notified_at = now() below — without this,
+-- the very first dispatch run would treat every pre-existing open finding
+-- across every tenant as "new" and email the tenant's entire historical
+-- backlog in one batch. New-enrollment first scans are NOT suppressed (an
+-- open finding created AFTER this migration has notified_at = NULL from
+-- INSERT's column default, so it alerts normally on the next dispatch).
+--
+-- Idempotent throughout: ADD COLUMN IF NOT EXISTS (mirrors m101/m92/m93),
+-- DROP CONSTRAINT IF EXISTS + ADD CONSTRAINT (mirrors m101's severity widen),
+-- CREATE INDEX IF NOT EXISTS. The backfill UPDATE is naturally idempotent
+-- (subsequent runs match zero rows once notified_at is no longer NULL for
+-- pre-existing rows).
+
+ALTER TABLE "public"."alert_configs"
+    ADD COLUMN IF NOT EXISTS "notify_vulns" boolean NOT NULL DEFAULT false;
+ALTER TABLE "public"."alert_configs"
+    ADD COLUMN IF NOT EXISTS "vuln_min_severity" text NOT NULL DEFAULT 'high';
+ALTER TABLE "public"."alert_configs"
+    ADD COLUMN IF NOT EXISTS "vuln_include_in_digest" boolean NOT NULL DEFAULT true;
+
+ALTER TABLE "public"."alert_configs"
+    DROP CONSTRAINT IF EXISTS "alert_configs_vuln_min_severity_chk";
+ALTER TABLE "public"."alert_configs"
+    ADD CONSTRAINT "alert_configs_vuln_min_severity_chk"
+    CHECK ("vuln_min_severity" IN ('critical', 'high', 'medium', 'low'));
+
+ALTER TABLE "public"."site_vulnerabilities"
+    ADD COLUMN IF NOT EXISTS "notified_at" timestamptz;
+
+-- Backfill: every finding that existed before this migration is treated as
+-- already-notified so the first dispatch run never alerts on the backlog.
+-- Restricted to rows this migration itself just added the column for
+-- (notified_at IS NULL) so a re-run of this file is a no-op the second time.
+UPDATE "public"."site_vulnerabilities"
+SET "notified_at" = now()
+WHERE "notified_at" IS NULL;
+
+CREATE INDEX IF NOT EXISTS "idx_site_vuln_tenant_unnotified"
+    ON "public"."site_vulnerabilities" ("tenant_id")
+    WHERE "status" = 'open' AND "notified_at" IS NULL;

--- a/apps/api/tests/uptime_integration_test.go
+++ b/apps/api/tests/uptime_integration_test.go
@@ -95,6 +95,7 @@ func TestUptimeProbeAlertsTransitionDedupe(t *testing.T) {
 		WebhookURL:      hook.URL,
 		WebhookSecret:   "s3cr3t",
 		Enabled:         true,
+		VulnMinSeverity: uptime.VulnSeverityHigh, // m103 (GH #247): NOT NULL + CHECK enum
 	}); err != nil {
 		t.Fatalf("upsert alert config: %v", err)
 	}
@@ -723,6 +724,11 @@ func TestAlertConfigRLS(t *testing.T) {
 		TenantID:        tenantA,
 		EmailRecipients: []string{"a@example.com"},
 		Enabled:         true,
+		// m103 (GH #247): vuln_min_severity is NOT NULL with a CHECK enum;
+		// the service layer always defaults this before calling the repo
+		// (see mergeAlertConfigUpdate / defaultNotifySettings-style
+		// defaults), but this test calls the repo directly.
+		VulnMinSeverity: uptime.VulnSeverityHigh,
 	}); err != nil {
 		t.Fatalf("upsert config A: %v", err)
 	}

--- a/apps/api/tests/vuln_alerting_dispatch_integration_test.go
+++ b/apps/api/tests/vuln_alerting_dispatch_integration_test.go
@@ -1,0 +1,515 @@
+// vuln_alerting_dispatch_integration_test.go — m103 (GH #247) vulnerability
+// alerting: the claim/dispatch transactional-outbox correctness against a
+// real Postgres (RLS + row locks matter here, so fakes alone cannot prove
+// this). Requires Docker; skips when unavailable (via startPostgres).
+//
+// Fixture writes/reads that are NOT the behavior under test (seeding a
+// finding row, reading back notified_at/status for assertions) go through the
+// ADMIN (superuser) pool, exactly like seedSiteFor — site_vulnerabilities has
+// FORCE ROW LEVEL SECURITY, so an unscoped read/write from the non-superuser
+// app pool would itself fail RLS. The actual claim/dispatch logic under test
+// always goes through the real Repo/Service methods, which correctly open
+// their own InTenantTx/InAgentTx against the app pool.
+package tests
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/vuln"
+)
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+// fakeVulnAlertConfigReader returns a fixed per-tenant AlertChannelConfig.
+type fakeVulnAlertConfigReader struct {
+	mu  sync.Mutex
+	cfg map[uuid.UUID]vuln.AlertChannelConfig
+}
+
+func newFakeVulnAlertConfigReader() *fakeVulnAlertConfigReader {
+	return &fakeVulnAlertConfigReader{cfg: map[uuid.UUID]vuln.AlertChannelConfig{}}
+}
+
+func (f *fakeVulnAlertConfigReader) set(tenantID uuid.UUID, cfg vuln.AlertChannelConfig) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cfg[tenantID] = cfg
+}
+
+func (f *fakeVulnAlertConfigReader) GetVulnAlertChannel(_ context.Context, tenantID uuid.UUID) (vuln.AlertChannelConfig, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.cfg[tenantID], nil
+}
+
+// fakeVulnAlertMailer records EnqueueTx calls; failNext makes the NEXT call
+// return an error (to exercise the outbox rollback), then clears itself.
+type fakeVulnAlertMailer struct {
+	mu        sync.Mutex
+	calls     int
+	failNext  bool
+	lastRecip []string
+	lastData  map[string]any
+}
+
+func (f *fakeVulnAlertMailer) EnqueueTx(_ context.Context, _ pgx.Tx, _ uuid.UUID, recipients []string, _ string, data map[string]any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failNext {
+		f.failNext = false
+		return errors.New("fake mailer failure (outbox test)")
+	}
+	f.calls++
+	f.lastRecip = recipients
+	f.lastData = data
+	return nil
+}
+
+func (f *fakeVulnAlertMailer) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func (f *fakeVulnAlertMailer) lastNewCount() (int, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n, ok := f.lastData["NewCount"].(int)
+	return n, ok
+}
+
+// fakeVulnWebhookPoster records PostSignedWebhook calls.
+type fakeVulnWebhookPoster struct {
+	calls int32
+}
+
+func (f *fakeVulnWebhookPoster) PostSignedWebhook(_ context.Context, _, _ string, _ any) error {
+	atomic.AddInt32(&f.calls, 1)
+	return nil
+}
+
+func (f *fakeVulnWebhookPoster) callCount() int32 { return atomic.LoadInt32(&f.calls) }
+
+// ---------------------------------------------------------------------------
+// Fixture helpers (all via the admin/superuser pool — see file doc comment)
+// ---------------------------------------------------------------------------
+
+func seedFindingAdmin(t *testing.T, admin *db.Pool, tenant, site uuid.UUID, vulnID, severity, status string) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	err := admin.QueryRow(context.Background(), `
+		INSERT INTO site_vulnerabilities
+			(tenant_id, site_id, vuln_id, kind, slug, name, installed_version, severity, title, status)
+		VALUES ($1, $2, $3, 'plugin', $3, $3, '1.0.0', $4, 'seed finding', $5)
+		RETURNING id`,
+		tenant, site, vulnID, severity, status,
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("seed finding %s: %v", vulnID, err)
+	}
+	return id
+}
+
+func notifiedAtOfAdmin(t *testing.T, admin *db.Pool, id uuid.UUID) *time.Time {
+	t.Helper()
+	var v *time.Time
+	if err := admin.QueryRow(context.Background(), `SELECT notified_at FROM site_vulnerabilities WHERE id = $1`, id).Scan(&v); err != nil {
+		t.Fatalf("query notified_at: %v", err)
+	}
+	return v
+}
+
+func statusOfAdmin(t *testing.T, admin *db.Pool, id uuid.UUID) string {
+	t.Helper()
+	var s string
+	if err := admin.QueryRow(context.Background(), `SELECT status FROM site_vulnerabilities WHERE id = $1`, id).Scan(&s); err != nil {
+		t.Fatalf("query status: %v", err)
+	}
+	return s
+}
+
+// ---------------------------------------------------------------------------
+// Repo-level: claim idempotency + concurrency
+// ---------------------------------------------------------------------------
+
+// TestClaimUnnotifiedFindings_IdempotentRetry proves a second claim attempt
+// (e.g. a River job retry after some OTHER failure) claims zero rows once the
+// first claim has committed — findings are never double-claimed/double-sent.
+func TestClaimUnnotifiedFindings_IdempotentRetry(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "m103-claim-"+uuid.NewString()[:8])
+	site := seedSiteFor(t, admin, tenant, "https://m103-claim.example.com")
+	repo := vuln.NewRepo(pool)
+
+	seedFindingAdmin(t, admin, tenant, site, "v1", "critical", "open")
+	seedFindingAdmin(t, admin, tenant, site, "v2", "high", "open")
+
+	claim := func() int {
+		var n int
+		err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+			rows, cErr := repo.ClaimUnnotifiedFindings(ctx, tx, tenant)
+			n = len(rows)
+			return cErr
+		})
+		if err != nil {
+			t.Fatalf("claim: %v", err)
+		}
+		return n
+	}
+
+	if got := claim(); got != 2 {
+		t.Fatalf("first claim: expected 2 rows, got %d", got)
+	}
+	if got := claim(); got != 0 {
+		t.Fatalf("second (retry) claim: expected 0 rows (already claimed), got %d", got)
+	}
+}
+
+// TestClaimUnnotifiedFindings_ConcurrentClaim_OneWinner races two goroutines
+// claiming the SAME tenant's findings simultaneously and asserts the total
+// claimed across both is exactly the seeded count — never double-counted,
+// never lost.
+func TestClaimUnnotifiedFindings_ConcurrentClaim_OneWinner(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "m103-race-"+uuid.NewString()[:8])
+	site := seedSiteFor(t, admin, tenant, "https://m103-race.example.com")
+	repo := vuln.NewRepo(pool)
+
+	const n = 5
+	for i := 0; i < n; i++ {
+		seedFindingAdmin(t, admin, tenant, site, uuid.NewString(), "high", "open")
+	}
+
+	var wg sync.WaitGroup
+	var totalClaimed int32
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+				rows, err := repo.ClaimUnnotifiedFindings(ctx, tx, tenant)
+				if err != nil {
+					return err
+				}
+				atomic.AddInt32(&totalClaimed, int32(len(rows)))
+				return nil
+			})
+		}()
+	}
+	wg.Wait()
+
+	if totalClaimed != n {
+		t.Fatalf("total claimed across concurrent claimers = %d, want exactly %d (no double-claim, no lost claim)", totalClaimed, n)
+	}
+}
+
+// TestUpsertFinding_ReappearingVuln_ResetsNotifiedAt proves a resolved->open
+// transition resets notified_at (so it alerts again), while a routine
+// re-match of an already-open finding (the common rescan case) does NOT
+// touch notified_at once claimed.
+func TestUpsertFinding_ReappearingVuln_ResetsNotifiedAt(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "m103-reopen-"+uuid.NewString()[:8])
+	site := seedSiteFor(t, admin, tenant, "https://m103-reopen.example.com")
+	repo := vuln.NewRepo(pool)
+
+	id := seedFindingAdmin(t, admin, tenant, site, "v-reopen", "high", "open")
+
+	// Claim it (simulates a completed alert dispatch).
+	err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		_, cErr := repo.ClaimUnnotifiedFindings(ctx, tx, tenant)
+		return cErr
+	})
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if notifiedAtOfAdmin(t, admin, id) == nil {
+		t.Fatal("expected notified_at to be set after claim")
+	}
+
+	upsert := vuln.FindingUpsert{
+		TenantID: tenant, SiteID: site, VulnID: "v-reopen", Kind: "plugin", Slug: "v-reopen",
+		Name: "v-reopen", InstalledVersion: "1.0.0", Severity: "high", Title: "seed finding",
+	}
+
+	// A routine re-match while still 'open' (e.g. every subsequent rescan)
+	// must NOT reset notified_at.
+	err = pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		return repo.UpsertFinding(ctx, tx, upsert)
+	})
+	if err != nil {
+		t.Fatalf("routine re-upsert: %v", err)
+	}
+	if notifiedAtOfAdmin(t, admin, id) == nil {
+		t.Fatal("a routine re-match of an already-open finding must NOT reset notified_at")
+	}
+
+	// Resolve it (simulates ResolveStaleFindings after the vuln disappears).
+	if _, err := admin.Exec(ctx, `UPDATE site_vulnerabilities SET status='resolved', resolved_at=now() WHERE id=$1`, id); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	// Re-upsert (the vuln re-appears — resolved -> open transition).
+	err = pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		return repo.UpsertFinding(ctx, tx, upsert)
+	})
+	if err != nil {
+		t.Fatalf("reopen re-upsert: %v", err)
+	}
+	if statusOfAdmin(t, admin, id) != "open" {
+		t.Fatal("expected status back to 'open' after re-appearing")
+	}
+	if notifiedAtOfAdmin(t, admin, id) != nil {
+		t.Fatal("a REAPPEARING vulnerability (resolved -> open) must reset notified_at to NULL so it alerts again")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Service-level: DispatchVulnAlerts (gate, threshold, outbox, webhook)
+// ---------------------------------------------------------------------------
+
+func newDispatchService(pool *db.Pool, alertCfg *fakeVulnAlertConfigReader, mailer *fakeVulnAlertMailer, webhook *fakeVulnWebhookPoster) *vuln.Service {
+	svc := vuln.NewService(vuln.NewRepo(pool), pool, nil, nil, nil, slog.Default())
+	svc.SetAlertConfigReader(alertCfg)
+	svc.SetMailer(mailer)
+	svc.SetWebhookPoster(webhook)
+	svc.SetPublicBase("https://manage.wpmgr.app")
+	return svc
+}
+
+// TestDispatchVulnAlerts_DisabledTenant_RowsStillStamped proves findings are
+// claimed (notified_at stamped) even when notify_vulns is off — so enabling
+// it later never floods the tenant with this backlog — while the
+// mailer/webhook are never invoked.
+func TestDispatchVulnAlerts_DisabledTenant_RowsStillStamped(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "m103-disabled-"+uuid.NewString()[:8])
+	site := seedSiteFor(t, admin, tenant, "https://m103-disabled.example.com")
+
+	id := seedFindingAdmin(t, admin, tenant, site, "v-disabled", "critical", "open")
+
+	alertCfg := newFakeVulnAlertConfigReader()
+	alertCfg.set(tenant, vuln.AlertChannelConfig{
+		Enabled: true, NotifyVulns: false, // gate OFF
+		EmailRecipients: []string{"ops@example.com"}, VulnMinSeverity: "high",
+	})
+	mailer := &fakeVulnAlertMailer{}
+	webhook := &fakeVulnWebhookPoster{}
+	svc := newDispatchService(pool, alertCfg, mailer, webhook)
+
+	if err := svc.DispatchVulnAlerts(ctx); err != nil {
+		t.Fatalf("DispatchVulnAlerts: %v", err)
+	}
+
+	if notifiedAtOfAdmin(t, admin, id) == nil {
+		t.Fatal("finding must be stamped (claimed) even when notify_vulns is off")
+	}
+	if mailer.callCount() != 0 {
+		t.Errorf("mailer must not be called when notify_vulns is off, got %d calls", mailer.callCount())
+	}
+	if webhook.callCount() != 0 {
+		t.Errorf("webhook must not be called when notify_vulns is off, got %d calls", webhook.callCount())
+	}
+}
+
+// TestDispatchVulnAlerts_ThresholdFilter_DismissedNeverClaimed_WebhookFired
+// covers the threshold gate (unknown always included, low excluded below a
+// 'high' threshold but still claimed), a dismissed finding never being
+// claimed at all, and the webhook firing with the filtered set.
+func TestDispatchVulnAlerts_ThresholdFilter_DismissedNeverClaimed_WebhookFired(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "m103-threshold-"+uuid.NewString()[:8])
+	site := seedSiteFor(t, admin, tenant, "https://m103-threshold.example.com")
+
+	critID := seedFindingAdmin(t, admin, tenant, site, "v-crit", "critical", "open")
+	lowID := seedFindingAdmin(t, admin, tenant, site, "v-low", "low", "open")
+	unkID := seedFindingAdmin(t, admin, tenant, site, "v-unk", "unknown", "open")
+	dismissedID := seedFindingAdmin(t, admin, tenant, site, "v-dismissed", "critical", "dismissed")
+
+	alertCfg := newFakeVulnAlertConfigReader()
+	alertCfg.set(tenant, vuln.AlertChannelConfig{
+		Enabled: true, NotifyVulns: true,
+		EmailRecipients: []string{"ops@example.com"},
+		WebhookURL:      "https://hooks.example.com/wpmgr",
+		VulnMinSeverity: "high",
+	})
+	mailer := &fakeVulnAlertMailer{}
+	webhook := &fakeVulnWebhookPoster{}
+	svc := newDispatchService(pool, alertCfg, mailer, webhook)
+
+	if err := svc.DispatchVulnAlerts(ctx); err != nil {
+		t.Fatalf("DispatchVulnAlerts: %v", err)
+	}
+
+	// All THREE open findings get claimed (regardless of whether they pass
+	// the threshold) — only 'dismissed' is excluded by the claim's own WHERE
+	// status='open' clause.
+	for _, id := range []uuid.UUID{critID, lowID, unkID} {
+		if notifiedAtOfAdmin(t, admin, id) == nil {
+			t.Errorf("finding %s must be claimed (notified_at set)", id)
+		}
+	}
+	if notifiedAtOfAdmin(t, admin, dismissedID) != nil {
+		t.Error("a dismissed finding must NEVER be claimed (status filter), notified_at must stay NULL")
+	}
+
+	if mailer.callCount() != 1 {
+		t.Fatalf("expected exactly 1 batched email, got %d", mailer.callCount())
+	}
+	newCount, ok := mailer.lastNewCount()
+	if !ok || newCount != 2 {
+		t.Errorf("email NewCount = %v (ok=%v), want 2 (critical + unknown; low excluded by threshold)", newCount, ok)
+	}
+
+	if webhook.callCount() != 1 {
+		t.Fatalf("expected exactly 1 webhook POST, got %d", webhook.callCount())
+	}
+}
+
+// TestDispatchVulnAlerts_WebhookNotFiredWhenUnconfigured proves the webhook
+// leg is skipped (not called) when no webhook_url is configured, while the
+// email leg still proceeds normally.
+func TestDispatchVulnAlerts_WebhookNotFiredWhenUnconfigured(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "m103-nowebhook-"+uuid.NewString()[:8])
+	site := seedSiteFor(t, admin, tenant, "https://m103-nowebhook.example.com")
+	seedFindingAdmin(t, admin, tenant, site, "v1", "critical", "open")
+
+	alertCfg := newFakeVulnAlertConfigReader()
+	alertCfg.set(tenant, vuln.AlertChannelConfig{
+		Enabled: true, NotifyVulns: true,
+		EmailRecipients: []string{"ops@example.com"},
+		WebhookURL:      "", // not configured
+		VulnMinSeverity: "high",
+	})
+	mailer := &fakeVulnAlertMailer{}
+	webhook := &fakeVulnWebhookPoster{}
+	svc := newDispatchService(pool, alertCfg, mailer, webhook)
+
+	if err := svc.DispatchVulnAlerts(ctx); err != nil {
+		t.Fatalf("DispatchVulnAlerts: %v", err)
+	}
+	if mailer.callCount() != 1 {
+		t.Errorf("expected 1 email, got %d", mailer.callCount())
+	}
+	if webhook.callCount() != 0 {
+		t.Errorf("webhook must not be called when webhook_url is empty, got %d calls", webhook.callCount())
+	}
+}
+
+// TestDispatchVulnAlerts_Outbox_RollbackLeavesUnclaimed_RetrySucceeds is the
+// transactional-outbox correctness proof: when the email enqueue fails, the
+// claim (notified_at stamp) rolls back with it, so the finding is retried on
+// the NEXT dispatch cycle instead of being silently claimed-but-unemailed.
+func TestDispatchVulnAlerts_Outbox_RollbackLeavesUnclaimed_RetrySucceeds(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "m103-outbox-"+uuid.NewString()[:8])
+	site := seedSiteFor(t, admin, tenant, "https://m103-outbox.example.com")
+	id := seedFindingAdmin(t, admin, tenant, site, "v-outbox", "critical", "open")
+
+	alertCfg := newFakeVulnAlertConfigReader()
+	alertCfg.set(tenant, vuln.AlertChannelConfig{
+		Enabled: true, NotifyVulns: true,
+		EmailRecipients: []string{"ops@example.com"},
+		VulnMinSeverity: "high",
+	})
+	mailer := &fakeVulnAlertMailer{failNext: true} // fail the first EnqueueTx call
+	webhook := &fakeVulnWebhookPoster{}
+	svc := newDispatchService(pool, alertCfg, mailer, webhook)
+
+	// First run: the mailer fails -> the whole tx (claim + enqueue) rolls back.
+	if err := svc.DispatchVulnAlerts(ctx); err != nil {
+		t.Fatalf("DispatchVulnAlerts (first run): %v", err)
+	}
+	if notifiedAtOfAdmin(t, admin, id) != nil {
+		t.Fatal("outbox rollback: notified_at must stay NULL when the email enqueue fails (claim undone)")
+	}
+	if mailer.callCount() != 0 {
+		t.Errorf("expected 0 successful mailer calls after the rollback, got %d", mailer.callCount())
+	}
+	if webhook.callCount() != 0 {
+		t.Errorf("webhook must not fire when the tx rolled back (nothing to send), got %d calls", webhook.callCount())
+	}
+
+	// Second run (retry — the debounced dispatch job re-runs, or a fresh
+	// dispatch cycle picks it up): the mailer now succeeds.
+	if err := svc.DispatchVulnAlerts(ctx); err != nil {
+		t.Fatalf("DispatchVulnAlerts (retry): %v", err)
+	}
+	if notifiedAtOfAdmin(t, admin, id) == nil {
+		t.Fatal("retry: expected the finding to be claimed once the email enqueue succeeds")
+	}
+	if mailer.callCount() != 1 {
+		t.Errorf("expected exactly 1 successful mailer call after retry, got %d", mailer.callCount())
+	}
+}
+
+// TestDispatchVulnAlerts_RepeatRun_NoNewSendsWithoutNewFindings proves
+// idempotency at the service level: running DispatchVulnAlerts again
+// immediately after a successful dispatch (no new findings in between) sends
+// nothing further.
+func TestDispatchVulnAlerts_RepeatRun_NoNewSendsWithoutNewFindings(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "m103-repeat-"+uuid.NewString()[:8])
+	site := seedSiteFor(t, admin, tenant, "https://m103-repeat.example.com")
+	seedFindingAdmin(t, admin, tenant, site, "v1", "critical", "open")
+
+	alertCfg := newFakeVulnAlertConfigReader()
+	alertCfg.set(tenant, vuln.AlertChannelConfig{
+		Enabled: true, NotifyVulns: true,
+		EmailRecipients: []string{"ops@example.com"},
+		VulnMinSeverity: "high",
+	})
+	mailer := &fakeVulnAlertMailer{}
+	webhook := &fakeVulnWebhookPoster{}
+	svc := newDispatchService(pool, alertCfg, mailer, webhook)
+
+	if err := svc.DispatchVulnAlerts(ctx); err != nil {
+		t.Fatalf("first dispatch: %v", err)
+	}
+	if mailer.callCount() != 1 {
+		t.Fatalf("expected 1 email after the first dispatch, got %d", mailer.callCount())
+	}
+	if err := svc.DispatchVulnAlerts(ctx); err != nil {
+		t.Fatalf("second dispatch: %v", err)
+	}
+	if mailer.callCount() != 1 {
+		t.Errorf("a repeat dispatch with no new findings must send nothing further, got %d total calls", mailer.callCount())
+	}
+}

--- a/apps/api/tests/vuln_alerting_m103_test.go
+++ b/apps/api/tests/vuln_alerting_m103_test.go
@@ -1,0 +1,271 @@
+// vuln_alerting_m103_test.go — m103 (GH #247) migration backfill regression
+// test. Mirrors sitetag_migration_test.go's pattern exactly: boot a
+// container, apply every embedded migration UP TO (not including) m103, seed
+// alert_configs and site_vulnerabilities rows the way a live pre-m103
+// deployment would already have them (across open/dismissed/resolved
+// statuses), finish the boot (applying m103, including its backfill UPDATE),
+// and assert EVERY pre-existing site_vulnerabilities row is stamped
+// notified_at (so the first-ever dispatch never emails the tenant's entire
+// historical backlog) and the new alert_configs columns land with their
+// documented defaults. Also proves the backfill is idempotent by re-executing
+// the migration's own SQL text a second time.
+package tests
+
+import (
+	"context"
+	"io/fs"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/migrations"
+)
+
+// m103MigrationVersion is the embedded migration filename (sans .sql) that
+// adds vulnerability-alerting columns and backfills notified_at.
+const m103MigrationVersion = "20260805000000_m103_vuln_alerting"
+
+// startPostgresBeforeM103 mirrors startPostgresBeforeM100's container
+// bootstrap but stops short of m103.
+func startPostgresBeforeM103(t *testing.T) *db.Pool {
+	t.Helper()
+	ctx := context.Background()
+
+	container, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("wpmgr"),
+		tcpostgres.WithUsername("wpmgr"),
+		tcpostgres.WithPassword("wpmgr"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	pool, err := db.Connect(ctx, adminDSN)
+	if err != nil {
+		t.Fatalf("connect admin: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	applyMigrationsBeforeM103(t, pool, m103MigrationVersion)
+	return pool
+}
+
+// applyMigrationsBeforeM103 is a package-local copy of
+// applyMigrationsBeforeM100's embedded-FS walk (kept local per that file's
+// own stated convention so this file has no compile-order dependency on it).
+func applyMigrationsBeforeM103(t *testing.T, pool *db.Pool, stopAt string) {
+	t.Helper()
+	ctx := context.Background()
+
+	if _, err := pool.Exec(ctx, `CREATE TABLE IF NOT EXISTS schema_migrations (
+		version    text        PRIMARY KEY,
+		applied_at timestamptz NOT NULL DEFAULT now()
+	)`); err != nil {
+		t.Fatalf("ensure schema_migrations: %v", err)
+	}
+
+	entries, err := fs.ReadDir(migrations.FS, ".")
+	if err != nil {
+		t.Fatalf("read embedded migrations: %v", err)
+	}
+	var versions []string
+	files := map[string]string{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".sql") {
+			continue
+		}
+		version := strings.TrimSuffix(name, ".sql")
+		versions = append(versions, version)
+		files[version] = name
+	}
+	sort.Strings(versions)
+
+	found := false
+	for _, version := range versions {
+		if version == stopAt {
+			found = true
+			break
+		}
+		body, err := fs.ReadFile(migrations.FS, files[version])
+		if err != nil {
+			t.Fatalf("read migration %s: %v", version, err)
+		}
+		err = pgx.BeginFunc(ctx, pool.Pool, func(tx pgx.Tx) error {
+			if _, err := tx.Exec(ctx, string(body)); err != nil {
+				return err
+			}
+			_, err := tx.Exec(ctx, "INSERT INTO schema_migrations (version) VALUES ($1)", version)
+			return err
+		})
+		if err != nil {
+			t.Fatalf("apply migration %s: %v", version, err)
+		}
+	}
+	if !found {
+		t.Fatalf("stopAt version %q not found among embedded migrations (renamed/removed?)", stopAt)
+	}
+}
+
+// TestM103Migration_BackfillNotifiedAt_AndDefaults is the ship-level
+// regression test: every pre-existing site_vulnerabilities row (regardless of
+// status) gets notified_at stamped, and alert_configs gains the three new
+// columns with their documented defaults.
+func TestM103Migration_BackfillNotifiedAt_AndDefaults(t *testing.T) {
+	pool := startPostgresBeforeM103(t)
+	ctx := context.Background()
+
+	var tenant uuid.UUID
+	if err := pool.QueryRow(ctx, `INSERT INTO tenants (name, slug) VALUES ($1, $1) RETURNING id`,
+		"m103-"+uuid.NewString()[:8]).Scan(&tenant); err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+
+	var siteID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO sites (tenant_id, url, name) VALUES ($1, $2, 'seed') RETURNING id`,
+		tenant, "https://m103-site.example.com").Scan(&siteID); err != nil {
+		t.Fatalf("seed site: %v", err)
+	}
+
+	// A pre-existing alert_configs row (pre-m103 shape: no vuln columns yet).
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO alert_configs (tenant_id, enabled, notify_security) VALUES ($1, true, true)`,
+		tenant); err != nil {
+		t.Fatalf("seed alert_configs: %v", err)
+	}
+
+	// Three pre-existing findings across the three statuses — the backfill
+	// must stamp ALL of them, not just open ones (dismissed/resolved rows
+	// never alert anyway per the dispatch claim's WHERE status='open', but
+	// the migration's backfill is a blanket UPDATE by design).
+	seedFinding := func(vulnID, status string) uuid.UUID {
+		var id uuid.UUID
+		err := pool.QueryRow(ctx, `
+			INSERT INTO site_vulnerabilities
+				(tenant_id, site_id, vuln_id, kind, slug, name, installed_version,
+				 severity, title, status)
+			VALUES ($1, $2, $3, 'plugin', $3, 'seed', '1.0.0', 'high', 'seed finding', $4)
+			RETURNING id`,
+			tenant, siteID, vulnID, status,
+		).Scan(&id)
+		if err != nil {
+			t.Fatalf("seed finding (%s): %v", status, err)
+		}
+		return id
+	}
+	openID := seedFinding("vuln-open", "open")
+	dismissedID := seedFinding("vuln-dismissed", "dismissed")
+	resolvedID := seedFinding("vuln-resolved", "resolved")
+
+	// Finish the boot: applies m103 (columns + CHECK + backfill + index).
+	if err := pool.Migrate(ctx); err != nil {
+		t.Fatalf("m103 migration failed: %v", err)
+	}
+
+	assertBackfilled := func(t *testing.T) map[uuid.UUID]time.Time {
+		t.Helper()
+		stamps := map[uuid.UUID]time.Time{}
+		for _, id := range []uuid.UUID{openID, dismissedID, resolvedID} {
+			var notifiedAt *time.Time
+			if err := pool.QueryRow(ctx, `SELECT notified_at FROM site_vulnerabilities WHERE id = $1`, id).Scan(&notifiedAt); err != nil {
+				t.Fatalf("query notified_at for %s: %v", id, err)
+			}
+			if notifiedAt == nil {
+				t.Fatalf("finding %s: notified_at must be backfilled (non-NULL), got NULL", id)
+			}
+			stamps[id] = *notifiedAt
+		}
+		return stamps
+	}
+	firstStamps := assertBackfilled(t)
+
+	var notifyVulns, vulnIncludeInDigest bool
+	var vulnMinSeverity string
+	if err := pool.QueryRow(ctx,
+		`SELECT notify_vulns, vuln_min_severity, vuln_include_in_digest FROM alert_configs WHERE tenant_id = $1`,
+		tenant).Scan(&notifyVulns, &vulnMinSeverity, &vulnIncludeInDigest); err != nil {
+		t.Fatalf("query alert_configs new columns: %v", err)
+	}
+	if notifyVulns {
+		t.Error("notify_vulns must default to false")
+	}
+	if vulnMinSeverity != "high" {
+		t.Errorf("vuln_min_severity must default to 'high', got %q", vulnMinSeverity)
+	}
+	if !vulnIncludeInDigest {
+		t.Error("vuln_include_in_digest must default to true")
+	}
+
+	// Idempotency: re-execute m103's own SQL text a second time directly
+	// (bypassing schema_migrations tracking) and assert the notified_at
+	// stamps are UNCHANGED (not re-stamped to a later time).
+	body, err := fs.ReadFile(migrations.FS, m103MigrationVersion+".sql")
+	if err != nil {
+		t.Fatalf("read m103 migration body: %v", err)
+	}
+	if _, err := pool.Exec(ctx, string(body)); err != nil {
+		t.Fatalf("re-apply m103 migration SQL: %v", err)
+	}
+	secondStamps := assertBackfilled(t)
+	for id, first := range firstStamps {
+		if !secondStamps[id].Equal(first) {
+			t.Fatalf("finding %s: notified_at changed on re-apply (%v -> %v); backfill must be idempotent", id, first, secondStamps[id])
+		}
+	}
+}
+
+// TestM103_NewFindingAfterMigration_NotBackfilled proves new-enrollment first
+// scans are NOT suppressed: a finding INSERTed after m103 has applied gets
+// notified_at = NULL from the column default (no explicit value), so it
+// alerts normally on the next dispatch — the migration's backfill only
+// touches rows that existed AT MIGRATION TIME.
+func TestM103_NewFindingAfterMigration_NotBackfilled(t *testing.T) {
+	pool := startPostgres(t) // full boot (all migrations applied), non-superuser role
+	ctx := context.Background()
+
+	tenant := seedTenant(t, pool, "m103-new-"+uuid.NewString()[:8])
+	siteID := seedSite(t, pool, tenant, "")
+
+	err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO site_vulnerabilities
+				(tenant_id, site_id, vuln_id, kind, slug, name, installed_version, severity, title, status)
+			VALUES ($1, $2, 'vuln-new', 'plugin', 'vuln-new', 'seed', '1.0.0', 'high', 'seed', 'open')`,
+			tenant, siteID)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("insert post-migration finding: %v", err)
+	}
+
+	var notifiedAt *time.Time
+	err = pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT notified_at FROM site_vulnerabilities WHERE tenant_id = $1 AND vuln_id = 'vuln-new'`, tenant).Scan(&notifiedAt)
+	})
+	if err != nil {
+		t.Fatalf("query notified_at: %v", err)
+	}
+	if notifiedAt != nil {
+		t.Fatalf("a NEW finding must have notified_at = NULL (alerts normally), got %v", *notifiedAt)
+	}
+}

--- a/apps/api/tests/vuln_alerting_rls_integration_test.go
+++ b/apps/api/tests/vuln_alerting_rls_integration_test.go
@@ -1,0 +1,161 @@
+// vuln_alerting_rls_integration_test.go — m103 (GH #247) RLS regression:
+// proves the new alert_configs vulnerability-alerting columns and the new
+// site_vulnerabilities.notified_at column are covered by the SAME
+// tenant_isolation + agent (cross-tenant) policies as every pre-existing
+// column on those tables — a foreign tenant cannot read another tenant's
+// findings/config, and the app.agent sweep used by the dispatch job's
+// ListTenantsWithUnnotifiedFindings/ClaimUnnotifiedFindings can enumerate
+// across tenants. Mirrors tests/sitetag_rls_integration_test.go's pattern.
+// Requires Docker; skips when unavailable (via startPostgres).
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/uptime"
+	"github.com/mosamlife/wpmgr/apps/api/internal/vuln"
+)
+
+// TestVulnAlertConfigColumns_RLS proves alert_configs' new notify_vulns/
+// vuln_min_severity/vuln_include_in_digest columns round-trip through the
+// SAME whole-row RLS policies as every pre-existing column: tenant isolation
+// on a tenant-scoped read, and cross-tenant visibility under the app.agent
+// evaluator policy (the dispatch job's AlertConfigReader path).
+func TestVulnAlertConfigColumns_RLS(t *testing.T) {
+	app := startPostgres(t)
+	ctx := context.Background()
+	tenantA := seedTenant(t, app, "vuln-cfg-rls-a-"+uuid.NewString()[:8])
+	tenantB := seedTenant(t, app, "vuln-cfg-rls-b-"+uuid.NewString()[:8])
+
+	repo := uptime.NewRepo(app)
+	if _, err := repo.UpsertAlertConfig(ctx, uptime.AlertConfig{
+		TenantID:            tenantA,
+		EmailRecipients:     []string{"a@example.com"},
+		Enabled:             true,
+		NotifyVulns:         true,
+		VulnMinSeverity:     uptime.VulnSeverityCritical,
+		VulnIncludeInDigest: false,
+	}); err != nil {
+		t.Fatalf("upsert config A: %v", err)
+	}
+
+	// Tenant A reads its own config with the new fields intact.
+	cfgA, foundA, err := repo.GetAlertConfig(ctx, tenantA)
+	if err != nil || !foundA {
+		t.Fatalf("tenant A get config: found=%v err=%v", foundA, err)
+	}
+	if !cfgA.NotifyVulns || cfgA.VulnMinSeverity != uptime.VulnSeverityCritical || cfgA.VulnIncludeInDigest {
+		t.Fatalf("tenant A config vuln fields wrong: %+v", cfgA)
+	}
+
+	// Tenant B sees no config (tenant_isolation covers the new columns too —
+	// there is no separate policy per column, but this proves the row itself
+	// including the new columns is invisible).
+	_, foundB, err := repo.GetAlertConfig(ctx, tenantB)
+	if err != nil {
+		t.Fatalf("tenant B get config: %v", err)
+	}
+	if foundB {
+		t.Fatal("tenant B must NOT see tenant A's alert config (RLS leak)")
+	}
+
+	// The cross-tenant evaluator (app.agent) sees it, with the new columns.
+	all, err := repo.ListAlertConfigsAllTenants(ctx)
+	if err != nil {
+		t.Fatalf("list all configs (agent scope): %v", err)
+	}
+	var sawA bool
+	for _, c := range all {
+		if c.TenantID == tenantA {
+			sawA = true
+			if !c.NotifyVulns || c.VulnMinSeverity != uptime.VulnSeverityCritical {
+				t.Errorf("agent-scope read of tenant A's config missing vuln fields: %+v", c)
+			}
+		}
+	}
+	if !sawA {
+		t.Fatal("agent scope must see tenant A's config (evaluator policy)")
+	}
+}
+
+// TestVulnFindingsNotifiedAt_RLS proves site_vulnerabilities.notified_at (and
+// the row it lives on) is tenant-isolated, and that the agent scope used by
+// ListTenantsWithUnnotifiedFindings/ClaimUnnotifiedFindings can enumerate
+// across tenants.
+func TestVulnFindingsNotifiedAt_RLS(t *testing.T) {
+	app := startPostgres(t)
+	admin := connectAdmin(t, app)
+	defer admin.Close()
+	ctx := context.Background()
+	tenantA := seedTenant(t, app, "vuln-find-rls-a-"+uuid.NewString()[:8])
+	tenantB := seedTenant(t, app, "vuln-find-rls-b-"+uuid.NewString()[:8])
+	siteA := seedSiteFor(t, admin, tenantA, "https://vuln-find-rls-a.example.com")
+
+	seedFindingAdmin(t, admin, tenantA, siteA, "v-rls", "critical", "open")
+
+	countUnder := func(run func(fn func(pgx.Tx) error) error) int {
+		var n int
+		if err := run(func(tx pgx.Tx) error {
+			return tx.QueryRow(ctx, `SELECT count(*) FROM site_vulnerabilities WHERE tenant_id = $1`, tenantA).Scan(&n)
+		}); err != nil {
+			t.Fatalf("count query: %v", err)
+		}
+		return n
+	}
+
+	// 1. Tenant A sees its own finding.
+	if got := countUnder(func(fn func(pgx.Tx) error) error { return app.InTenantTx(ctx, tenantA, fn) }); got != 1 {
+		t.Fatalf("tenant A must see its own finding, got %d", got)
+	}
+	// 2. Tenant B does NOT see tenant A's finding — even though the WHERE
+	// clause explicitly targets tenantA's id, proving RLS (not just the
+	// app-level WHERE) enforces isolation.
+	if got := countUnder(func(fn func(pgx.Tx) error) error { return app.InTenantTx(ctx, tenantB, fn) }); got != 0 {
+		t.Fatalf("tenant B must NOT see tenant A's finding (tenant_isolation), got %d", got)
+	}
+	// 3. The agent scope (the dispatch job's ListTenantsWithUnnotifiedFindings
+	// / ClaimUnnotifiedFindings path) sees it cross-tenant.
+	if got := countUnder(func(fn func(pgx.Tx) error) error { return app.InAgentTx(ctx, fn) }); got != 1 {
+		t.Fatalf("agent scope must see the finding (agent policy), got %d", got)
+	}
+
+	// 4. Repo-level: ListTenantsWithUnnotifiedFindings enumerates tenantA
+	// (unnotified) and never tenantB (no rows at all).
+	repo := vuln.NewRepo(app)
+	tenants, err := repo.ListTenantsWithUnnotifiedFindings(ctx)
+	if err != nil {
+		t.Fatalf("ListTenantsWithUnnotifiedFindings: %v", err)
+	}
+	var sawA, sawB bool
+	for _, id := range tenants {
+		if id == tenantA {
+			sawA = true
+		}
+		if id == tenantB {
+			sawB = true
+		}
+	}
+	if !sawA {
+		t.Fatal("expected tenant A to be listed as having unnotified findings")
+	}
+	if sawB {
+		t.Fatal("tenant B has no findings at all and must not be listed")
+	}
+
+	// 5. WITH CHECK: tenant B cannot INSERT a finding row carrying tenant A's id.
+	errWrite := app.InTenantTx(ctx, tenantB, func(tx pgx.Tx) error {
+		_, e := tx.Exec(ctx, `
+			INSERT INTO site_vulnerabilities
+				(tenant_id, site_id, vuln_id, kind, slug, name, installed_version, severity, title, status)
+			VALUES ($1, $2, 'cross-tenant', 'plugin', 'cross-tenant', 'x', '1.0.0', 'high', 'x', 'open')`,
+			tenantA, siteA)
+		return e
+	})
+	if errWrite == nil {
+		t.Fatal("tenant B must NOT be able to write a site_vulnerabilities row for tenant A (WITH CHECK)")
+	}
+}

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,17 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.75",
+    date: "2026-07-19",
+    summary: "Get notified when a new vulnerability is found, instead of having to check the dashboard.",
+    items: [
+      {
+        tag: "Added",
+        text: "Vulnerability alerts (GH #247). WPMgr now emails you when a new vulnerability is found on your sites: one summary email per scan (site, component, installed and fixed versions, severity, and CVE), batched so a feed update matching many sites sends one email, not one per site. Set a minimum severity (High and above by default; unscored findings are always included), fire a signed webhook for Slack or custom integrations, and add an open-findings section to the daily digest. Configured on the Alerts page alongside downtime alerts, opt-in and off by default.",
+      },
+    ],
+  },
+  {
     version: "0.61.72",
     date: "2026-07-19",
     summary: "Vulnerability severities are now accurate, with an honest state when severity data is unavailable.",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.72 / open source",
+  badge: "v0.61.75 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/apps/web/src/features/monitoring/alert-config-form.test.tsx
+++ b/apps/web/src/features/monitoring/alert-config-form.test.tsx
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ReactElement } from "react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+
+import { renderWithProviders, type RenderWithProvidersOptions } from "@/test/render";
+import { mockMutationResult, mockQueryResult } from "@/test/query-mocks";
+import { ShellContext } from "@/components/layout/app-shell-context";
+
+import { AlertConfigForm } from "./alert-config-form";
+import { useAlertConfig, usePutAlertConfig } from "./use-uptime";
+import { useEmailNotifySettings } from "@/features/email/use-email";
+import type { EmailNotifySettings } from "@/features/email/use-email";
+import type { AlertConfig, AlertConfigUpdate } from "@wpmgr/api";
+
+// `StickySaveBar` (mounted unconditionally by `AlertConfigForm`) reads
+// `useShellState`, which throws outside a real `<AppShell>`. `renderWithProviders`
+// deliberately doesn't wire the shell (see its module doc), so this file
+// supplies a minimal stub provider directly around the component under test.
+function renderForm(
+  ui: ReactElement,
+  options?: RenderWithProvidersOptions,
+) {
+  return renderWithProviders(
+    <ShellContext.Provider
+      value={{
+        collapsed: false,
+        toggleCollapsed: vi.fn(),
+        mobileOpen: false,
+        setMobileOpen: vi.fn(),
+      }}
+    >
+      {ui}
+    </ShellContext.Provider>,
+    options,
+  );
+}
+
+// GH #247 (vulnerability alerting) — the alert channel form now edits four
+// signals off one shared resource (recipients/webhook, downtime, security
+// events, vulnerability alerts). These tests cover the three regressions
+// this surface is most likely to reintroduce:
+//   1. `notify_security` silently dropped on save (the exact CP bug #247
+//      fixed on the backend — the FE must not reintroduce it by omitting
+//      the field from a partial-looking edit).
+//   2. The severity <select> not actually wired to `vuln_min_severity`, or
+//      its "visible but disabled while off" gating drifting.
+//   3. The instance-mailer warning banner (mirrored from
+//      EmailNotifySettingsCard) not showing/hiding correctly.
+//
+// Only `useAlertConfig` / `usePutAlertConfig` and `useEmailNotifySettings`
+// are mocked — the latter backs the warning banner only and would otherwise
+// issue a real query.
+
+vi.mock("./use-uptime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./use-uptime")>();
+  return {
+    ...actual,
+    useAlertConfig: vi.fn(),
+    usePutAlertConfig: vi.fn(),
+  };
+});
+
+vi.mock("@/features/email/use-email", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/email/use-email")>();
+  return {
+    ...actual,
+    useEmailNotifySettings: vi.fn(),
+  };
+});
+
+const mockedUseAlertConfig = vi.mocked(useAlertConfig);
+const mockedUsePutAlertConfig = vi.mocked(usePutAlertConfig);
+const mockedUseEmailNotifySettings = vi.mocked(useEmailNotifySettings);
+
+// Matches `usePutAlertConfig`'s optimistic-update context in use-uptime.ts.
+type AlertConfigMutationContext = { previous: AlertConfig | null | undefined };
+
+function mockPutAlertConfig(
+  overrides: Partial<
+    ReturnType<typeof usePutAlertConfig>
+  > = {},
+) {
+  mockedUsePutAlertConfig.mockReturnValue(
+    mockMutationResult<
+      AlertConfig,
+      AlertConfigUpdate,
+      Error,
+      AlertConfigMutationContext
+    >(overrides),
+  );
+}
+
+function buildAlertConfig(overrides: Partial<AlertConfig> = {}): AlertConfig {
+  return {
+    email_recipients: ["ops@example.com"],
+    webhook_url: "",
+    webhook_configured: false,
+    enabled: true,
+    notify_security: false,
+    notify_vulns: false,
+    vuln_min_severity: "high",
+    vuln_include_in_digest: true,
+    ...overrides,
+  };
+}
+
+function buildEmailSettings(
+  overrides: Partial<EmailNotifySettings> = {},
+): EmailNotifySettings {
+  return {
+    enabled: true,
+    recipients: [],
+    alert_on_failure: false,
+    alert_throttle_minutes: 60,
+    digest_enabled: false,
+    digest_cadence: "daily",
+    digest_day: 0,
+    digest_hour: 8,
+    timezone: "UTC",
+    instance_mailer_configured: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedUseEmailNotifySettings.mockReturnValue(
+    mockQueryResult<EmailNotifySettings>({ data: buildEmailSettings() }),
+  );
+});
+
+describe("AlertConfigForm — save always sends every signal field", () => {
+  it("includes notify_security, notify_vulns, vuln_min_severity, and vuln_include_in_digest on save, even when only the recipients textarea was edited", async () => {
+    const config = buildAlertConfig({
+      email_recipients: ["ops@example.com"],
+      notify_security: true,
+      notify_vulns: true,
+      vuln_min_severity: "medium",
+      vuln_include_in_digest: false,
+    });
+    mockedUseAlertConfig.mockReturnValue(
+      mockQueryResult<AlertConfig | null>({ data: config }),
+    );
+    const mutateMock = vi.fn();
+    mockPutAlertConfig({ mutate: mutateMock });
+
+    renderForm(<AlertConfigForm />);
+
+    const recipients = await screen.findByLabelText("Email recipients");
+    fireEvent.change(recipients, {
+      target: { value: "ops@example.com\nnew@example.com" },
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+    // The bug this guards against: a save that only "touches" recipients
+    // must still resend the booleans/enum at their CURRENT form values —
+    // never omit them and rely on the server to "preserve" what it already
+    // had, which is exactly the silent-drop class of bug #247 fixed.
+    expect(mutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email_recipients: ["ops@example.com", "new@example.com"],
+        notify_security: true,
+        notify_vulns: true,
+        vuln_min_severity: "medium",
+        vuln_include_in_digest: false,
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("sends the flipped notify_security value when only the Security events switch is toggled", async () => {
+    const config = buildAlertConfig({ notify_security: false });
+    mockedUseAlertConfig.mockReturnValue(
+      mockQueryResult<AlertConfig | null>({ data: config }),
+    );
+    const mutateMock = vi.fn();
+    mockPutAlertConfig({ mutate: mutateMock });
+
+    renderForm(<AlertConfigForm />);
+
+    const securitySwitch = await screen.findByLabelText(
+      "Email on high-severity security events",
+    );
+    expect(securitySwitch).toHaveAttribute("aria-checked", "false");
+    fireEvent.click(securitySwitch);
+    expect(securitySwitch).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+    expect(mutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ notify_security: true }),
+      expect.anything(),
+    );
+  });
+});
+
+describe("AlertConfigForm — vulnerability alerts severity select", () => {
+  it("renders the configured minimum severity and submits a changed selection", async () => {
+    const config = buildAlertConfig({
+      notify_vulns: true,
+      vuln_min_severity: "high",
+    });
+    mockedUseAlertConfig.mockReturnValue(
+      mockQueryResult<AlertConfig | null>({ data: config }),
+    );
+    const mutateMock = vi.fn();
+    mockPutAlertConfig({ mutate: mutateMock });
+
+    renderForm(<AlertConfigForm />);
+
+    const select = await screen.findByLabelText("Minimum severity");
+    expect(select).toHaveValue("high");
+    expect(select).toBeEnabled();
+
+    fireEvent.change(select, { target: { value: "critical" } });
+    expect(select).toHaveValue("critical");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+    expect(mutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ vuln_min_severity: "critical" }),
+      expect.anything(),
+    );
+  });
+
+  it("keeps the minimum-severity select and digest toggle visible but disabled while vulnerability alerts are off, without disabling the enable switch itself", async () => {
+    const config = buildAlertConfig({
+      notify_vulns: false,
+      vuln_min_severity: "high",
+      vuln_include_in_digest: true,
+    });
+    mockedUseAlertConfig.mockReturnValue(
+      mockQueryResult<AlertConfig | null>({ data: config }),
+    );
+    mockPutAlertConfig();
+
+    renderForm(<AlertConfigForm />);
+
+    const enableSwitch = await screen.findByLabelText(
+      "Enable vulnerability alerts",
+    );
+    const select = screen.getByLabelText("Minimum severity");
+    const digestSwitch = screen.getByLabelText(
+      "Include open findings in the email digest",
+    );
+
+    // Visible (not conditionally unmounted) ...
+    expect(select).toBeInTheDocument();
+    expect(digestSwitch).toBeInTheDocument();
+    // ... but disabled, while the master switch stays interactive.
+    expect(select).toBeDisabled();
+    expect(digestSwitch).toBeDisabled();
+    expect(enableSwitch).toBeEnabled();
+  });
+});
+
+describe("AlertConfigForm — instance mailer warning banner", () => {
+  it("shows the 'instance mailer not configured' banner with a link to /settings/smtp when instance email is not configured", async () => {
+    mockedUseAlertConfig.mockReturnValue(
+      mockQueryResult<AlertConfig | null>({ data: buildAlertConfig() }),
+    );
+    mockPutAlertConfig();
+    mockedUseEmailNotifySettings.mockReturnValue(
+      mockQueryResult<EmailNotifySettings>({
+        data: buildEmailSettings({ instance_mailer_configured: false }),
+      }),
+    );
+
+    renderForm(<AlertConfigForm />, { withRouter: true });
+
+    expect(
+      await screen.findByText("Instance mailer not configured."),
+    ).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: "Configure SMTP" });
+    expect(link).toHaveAttribute("href", "/settings/smtp");
+  });
+
+  it("hides the banner when instance email is configured", async () => {
+    mockedUseAlertConfig.mockReturnValue(
+      mockQueryResult<AlertConfig | null>({ data: buildAlertConfig() }),
+    );
+    mockPutAlertConfig();
+    mockedUseEmailNotifySettings.mockReturnValue(
+      mockQueryResult<EmailNotifySettings>({
+        data: buildEmailSettings({ instance_mailer_configured: true }),
+      }),
+    );
+
+    renderForm(<AlertConfigForm />);
+
+    await screen.findByLabelText("Email recipients");
+    expect(
+      screen.queryByText("Instance mailer not configured."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/monitoring/alert-config-form.tsx
+++ b/apps/web/src/features/monitoring/alert-config-form.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
+import { AlertTriangle } from "lucide-react";
+import { Link } from "@tanstack/react-router";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -13,6 +15,8 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { FieldError } from "@/components/forms/field-error";
 import { FormSection } from "@/components/forms/form-section";
 import { StickySaveBar } from "@/components/forms/sticky-save-bar";
@@ -20,17 +24,35 @@ import {
   useAlertConfig,
   usePutAlertConfig,
 } from "@/features/monitoring/use-uptime";
+import { useEmailNotifySettings } from "@/features/email/use-email";
 import type { AlertConfigUpdate } from "@wpmgr/api";
 
-// Downtime alert configuration editor (operator+). The tenant gets a comma- or
-// newline-separated list of email recipients notified on downtime plus an
-// optional webhook URL. GETs the current config (or null when none) and PUTs
-// changes via react-hook-form + Zod, with an optimistic cache update in the
-// mutation hook.
+// Tenant alert-channel editor (operator+). One shared channel — email
+// recipients plus an optional webhook — feeds three signals: uptime
+// downtime/recovery, high-severity activity-log security events, and
+// vulnerability alerting (GH #247). GETs the current config (or null when
+// none) and PUTs changes via react-hook-form + Zod, with an optimistic cache
+// update in the mutation hook.
 //
 // Sprint 4 (forms): per-section "Save" button removed in favor of a global
 // `StickySaveBar`. Validation runs on blur and surfaces through `FieldError`
 // in the what/why/how shape from DESIGN.md.
+//
+// Recipients & webhook is the FIRST section (unchanged from the pre-#247
+// layout) precisely so the Downtime / Security events / Vulnerability alerts
+// sections below it can each say "the recipients above" and mean it.
+
+const VULN_SEVERITY_VALUES = ["critical", "high", "medium", "low"] as const;
+
+const VULN_SEVERITY_OPTIONS: ReadonlyArray<{
+  value: (typeof VULN_SEVERITY_VALUES)[number];
+  label: string;
+}> = [
+  { value: "critical", label: "Critical only" },
+  { value: "high", label: "High and above" },
+  { value: "medium", label: "Medium and above" },
+  { value: "low", label: "Low and above" },
+];
 
 const formSchema = z.object({
   // A textarea of recipients; validation happens after splitting (below).
@@ -50,6 +72,10 @@ const formSchema = z.object({
   webhook_url: z
     .union([z.literal(""), z.string().url("Invalid URL")])
     .optional(),
+  notify_security: z.boolean(),
+  notify_vulns: z.boolean(),
+  vuln_min_severity: z.enum(VULN_SEVERITY_VALUES),
+  vuln_include_in_digest: z.boolean(),
 });
 
 type FormValues = z.infer<typeof formSchema>;
@@ -66,16 +92,35 @@ export function AlertConfigForm() {
   const { data: config, isPending, isError, error, refetch } = useAlertConfig();
   const save = usePutAlertConfig();
 
+  // Secondary, informational fetch: drives the "instance mailer not
+  // configured" warning banner only. Shares its cache with the Email page
+  // (`emailKeys.notifySettings()`), so this never issues an extra request
+  // once that page has been visited. Defaults `instanceMailerConfigured` to
+  // `true` while loading so the banner never flashes a false negative.
+  const emailSettingsQuery = useEmailNotifySettings();
+  const instanceMailerConfigured =
+    emailSettingsQuery.data?.instance_mailer_configured ?? true;
+
   const {
     register,
     handleSubmit,
     reset,
+    control,
     formState: { errors, isDirty },
   } = useForm<FormValues>({
     resolver: zodResolver(formSchema),
-    defaultValues: { recipients: "", webhook_url: "" },
+    defaultValues: {
+      recipients: "",
+      webhook_url: "",
+      notify_security: false,
+      notify_vulns: false,
+      vuln_min_severity: "high",
+      vuln_include_in_digest: true,
+    },
     mode: "onBlur",
   });
+
+  const notifyVulns = useWatch({ control, name: "notify_vulns" });
 
   // Seed the form once the config loads (or stays empty when none configured).
   useEffect(() => {
@@ -83,6 +128,10 @@ export function AlertConfigForm() {
     reset({
       recipients: config ? config.email_recipients.join("\n") : "",
       webhook_url: config?.webhook_url ?? "",
+      notify_security: config?.notify_security ?? false,
+      notify_vulns: config?.notify_vulns ?? false,
+      vuln_min_severity: config?.vuln_min_severity ?? "high",
+      vuln_include_in_digest: config?.vuln_include_in_digest ?? true,
     });
   }, [config, isPending, reset]);
 
@@ -90,6 +139,12 @@ export function AlertConfigForm() {
     const body: AlertConfigUpdate = {
       email_recipients: splitRecipients(values.recipients),
       webhook_url: values.webhook_url?.trim() ? values.webhook_url.trim() : "",
+      // Always sent explicitly (never omitted) so a save never silently
+      // drops a signal the operator didn't touch this time around.
+      notify_security: values.notify_security,
+      notify_vulns: values.notify_vulns,
+      vuln_min_severity: values.vuln_min_severity,
+      vuln_include_in_digest: values.vuln_include_in_digest,
     };
     save.mutate(body, {
       onSuccess: () => {
@@ -103,10 +158,10 @@ export function AlertConfigForm() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Downtime alerts</CardTitle>
+        <CardTitle>Alert channel</CardTitle>
         <CardDescription>
-          Who to notify when a monitored site goes down. Applies to all sites in
-          this tenant.
+          One shared channel for downtime, security events, and vulnerability
+          alerts across every site in this tenant.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -122,80 +177,224 @@ export function AlertConfigForm() {
             </Button>
           </div>
         ) : (
-          <form
-            onSubmit={(e) => void handleSubmit(onSubmit)(e)}
-            noValidate
-            // Bottom padding clears the sticky save bar so the last input
-            // stays visible above the floating chrome.
-            className="space-y-0 pb-24"
-          >
-            <FormSection
-              title="Email recipients"
-              description="Operators who should receive downtime emails. Applies tenant-wide."
-            >
-              <div className="space-y-1">
-                <Label htmlFor="recipients">Email recipients</Label>
-                <textarea
-                  id="recipients"
-                  rows={3}
-                  {...register("recipients")}
-                  aria-invalid={errors.recipients ? "true" : undefined}
-                  aria-describedby="recipients-help"
-                  placeholder="ops@example.com, oncall@example.com"
-                  className="w-full rounded-md border border-[var(--color-input)] bg-transparent px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+          <>
+            {!instanceMailerConfigured ? (
+              <div className="mb-6 flex gap-2 rounded-md border border-[var(--color-warning)]/50 bg-[var(--color-warning)]/10 px-3 py-2.5">
+                <AlertTriangle
+                  aria-hidden="true"
+                  className="mt-0.5 size-4 shrink-0 text-[var(--color-warning)]"
                 />
-                <p
-                  id="recipients-help"
-                  className="text-sm text-muted-foreground"
-                >
-                  One per line, or separated by commas.
-                </p>
-                <FieldError
-                  what={errors.recipients?.message}
-                  why="At least one valid email address is required."
-                  how="Edit the list above."
-                />
+                <div className="text-sm">
+                  <span className="font-medium">
+                    Instance mailer not configured.
+                  </span>{" "}
+                  Alerts cannot be delivered by email until instance-level SMTP
+                  is set up. Webhook delivery is unaffected.{" "}
+                  <Link
+                    to="/settings/smtp"
+                    className="font-medium text-[var(--color-primary)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+                  >
+                    Configure SMTP
+                  </Link>
+                </div>
               </div>
-            </FormSection>
+            ) : null}
 
-            <FormSection
-              title="Webhook"
-              description="Optional. Receives a JSON payload on every downtime event."
+            <form
+              onSubmit={(e) => void handleSubmit(onSubmit)(e)}
+              noValidate
+              // Bottom padding clears the sticky save bar so the last input
+              // stays visible above the floating chrome.
+              className="space-y-0 pb-24"
             >
-              <div className="space-y-1">
-                <Label htmlFor="webhook_url">Webhook URL (optional)</Label>
-                <Input
-                  id="webhook_url"
-                  type="url"
-                  {...register("webhook_url")}
-                  aria-invalid={errors.webhook_url ? "true" : undefined}
-                  aria-describedby="webhook-help"
-                  placeholder="https://hooks.example.com/wpmgr"
-                />
-                <p
-                  id="webhook-help"
-                  className="text-sm text-muted-foreground"
-                >
-                  Must use https. Leave blank to disable webhooks.
-                </p>
-                <FieldError
-                  what={errors.webhook_url?.message}
-                  why="It must start with https:// or be blank."
-                  how="Edit the URL above."
-                />
-              </div>
-            </FormSection>
+              <FormSection
+                title="Recipients & webhook"
+                description="Where every alert in this channel is delivered. Downtime, security events, and vulnerability alerts below all use these recipients and this webhook."
+              >
+                <div className="space-y-1">
+                  <Label htmlFor="recipients">Email recipients</Label>
+                  <textarea
+                    id="recipients"
+                    rows={3}
+                    {...register("recipients")}
+                    aria-invalid={errors.recipients ? "true" : undefined}
+                    aria-describedby="recipients-help"
+                    placeholder="ops@example.com, oncall@example.com"
+                    className="w-full rounded-md border border-[var(--color-input)] bg-transparent px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+                  />
+                  <p
+                    id="recipients-help"
+                    className="text-sm text-muted-foreground"
+                  >
+                    One per line, or separated by commas.
+                  </p>
+                  <FieldError
+                    what={errors.recipients?.message}
+                    why="At least one valid email address is required."
+                    how="Edit the list above."
+                  />
+                </div>
 
-            <StickySaveBar
-              isDirty={isDirty}
-              isPending={save.isPending}
-              errorMessage={save.isError ? save.error.message : null}
-              onSave={() => handleSubmit(onSubmit)()}
-              onDiscard={() => reset()}
-              saveLabel="Save changes"
-              discardLabel="Discard changes"
-            />
-          </form>
+                <div className="space-y-1">
+                  <Label htmlFor="webhook_url">Webhook URL (optional)</Label>
+                  <Input
+                    id="webhook_url"
+                    type="url"
+                    {...register("webhook_url")}
+                    aria-invalid={errors.webhook_url ? "true" : undefined}
+                    aria-describedby="webhook-help webhook-guarantee-help"
+                    placeholder="https://hooks.example.com/wpmgr"
+                  />
+                  <p
+                    id="webhook-help"
+                    className="text-sm text-muted-foreground"
+                  >
+                    Must use https. Leave blank to disable webhooks.
+                  </p>
+                  <p
+                    id="webhook-guarantee-help"
+                    className="text-sm text-muted-foreground"
+                  >
+                    Webhook delivery is best effort. Email is the guaranteed
+                    channel for alerts.
+                  </p>
+                  <FieldError
+                    what={errors.webhook_url?.message}
+                    why="It must start with https:// or be blank."
+                    how="Edit the URL above."
+                  />
+                </div>
+              </FormSection>
+
+              <FormSection
+                title="Downtime"
+                description="Email and webhook whenever a monitored site goes down or comes back online. Applies to every site in this tenant."
+              >
+                <p className="text-sm text-muted-foreground">
+                  Uses the recipients and webhook above. There is no separate
+                  switch for downtime alerts.
+                </p>
+              </FormSection>
+
+              <FormSection
+                title="Security events"
+                description="Route high-severity activity-log events, such as permission changes and suspicious logins, into this same channel."
+              >
+                <div className="flex items-center gap-3">
+                  <Controller
+                    control={control}
+                    name="notify_security"
+                    render={({ field }) => (
+                      <Switch
+                        id="notify-security"
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    )}
+                  />
+                  <Label htmlFor="notify-security" className="cursor-pointer">
+                    Email on high-severity security events
+                  </Label>
+                </div>
+              </FormSection>
+
+              <FormSection
+                title="Vulnerability alerts"
+                description="Get notified when a new vulnerability affecting a plugin, theme, or WordPress core is found on a site in this tenant."
+              >
+                <div className="space-y-4">
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-3">
+                      <Controller
+                        control={control}
+                        name="notify_vulns"
+                        render={({ field }) => (
+                          <Switch
+                            id="notify-vulns"
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
+                        )}
+                      />
+                      <Label htmlFor="notify-vulns" className="cursor-pointer">
+                        Enable vulnerability alerts
+                      </Label>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      Email a summary when new vulnerabilities are found on
+                      your sites.
+                    </p>
+                  </div>
+
+                  <div className="space-y-1">
+                    <Label htmlFor="vuln-min-severity">Minimum severity</Label>
+                    <Controller
+                      control={control}
+                      name="vuln_min_severity"
+                      render={({ field }) => (
+                        <Select
+                          id="vuln-min-severity"
+                          value={field.value}
+                          onChange={(e) => field.onChange(e.target.value)}
+                          disabled={!notifyVulns}
+                        >
+                          {VULN_SEVERITY_OPTIONS.map((o) => (
+                            <option key={o.value} value={o.value}>
+                              {o.label}
+                            </option>
+                          ))}
+                        </Select>
+                      )}
+                    />
+                    <p className="text-sm text-muted-foreground">
+                      Findings without a severity score yet are always
+                      included.
+                    </p>
+                  </div>
+
+                  <p className="text-sm text-muted-foreground">
+                    Sent to the alert recipients above.
+                  </p>
+
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-3">
+                      <Controller
+                        control={control}
+                        name="vuln_include_in_digest"
+                        render={({ field }) => (
+                          <Switch
+                            id="vuln-include-in-digest"
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                            disabled={!notifyVulns}
+                          />
+                        )}
+                      />
+                      <Label
+                        htmlFor="vuln-include-in-digest"
+                        className="cursor-pointer"
+                      >
+                        Include open findings in the email digest
+                      </Label>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      The digest itself is configured on the Email page.
+                    </p>
+                  </div>
+                </div>
+              </FormSection>
+
+              <StickySaveBar
+                isDirty={isDirty}
+                isPending={save.isPending}
+                errorMessage={save.isError ? save.error.message : null}
+                onSave={() => handleSubmit(onSubmit)()}
+                onDiscard={() => reset()}
+                saveLabel="Save changes"
+                discardLabel="Discard changes"
+              />
+            </form>
+          </>
         )}
       </CardContent>
     </Card>

--- a/apps/web/src/features/monitoring/use-uptime.ts
+++ b/apps/web/src/features/monitoring/use-uptime.ts
@@ -148,6 +148,12 @@ export function usePutAlertConfig(): UseMutationResult<
           email_recipients:
             body.email_recipients ?? previous.email_recipients,
           webhook_url: body.webhook_url ?? previous.webhook_url,
+          notify_security: body.notify_security ?? previous.notify_security,
+          notify_vulns: body.notify_vulns ?? previous.notify_vulns,
+          vuln_min_severity:
+            body.vuln_min_severity ?? previous.vuln_min_severity,
+          vuln_include_in_digest:
+            body.vuln_include_in_digest ?? previous.vuln_include_in_digest,
         });
       }
       return { previous };

--- a/apps/web/src/routes/_authed/alerts.tsx
+++ b/apps/web/src/routes/_authed/alerts.tsx
@@ -4,10 +4,6 @@ import { PageHeader } from "@/components/shared/page-header";
 import { useMe, canOperate } from "@/features/auth/use-auth";
 import { AlertConfigForm } from "@/features/monitoring/alert-config-form";
 
-// Future field: notify_security (boolean) -- suppress/surface security scanner
-// alerts per-tenant. Needs an ogen regen once the backend route is wired.
-// Do not add it here until the OpenAPI spec is updated.
-
 export const Route = createFileRoute("/_authed/alerts")({
   component: AlertSettingsPage,
 });
@@ -20,7 +16,7 @@ function AlertSettingsPage() {
     <section aria-labelledby="alerts-heading" className="max-w-2xl space-y-6">
       <PageHeader
         title="Alert settings"
-        subline="Configure how this tenant is notified when monitored sites go down."
+        subline="Configure how this tenant is notified about downtime, security events, and new vulnerabilities."
       />
 
       {operate ? (

--- a/apps/web/src/test/query-mocks.ts
+++ b/apps/web/src/test/query-mocks.ts
@@ -59,10 +59,20 @@ export function mockQueryResult<TData, TError = Error>(
  * Builds a `UseMutationResult` for mocking a mutation hook. Defaults to
  * idle (never called). Pass `{ mutate: vi.fn() }` / `{ mutateAsync:
  * vi.fn() }` to capture and assert on calls the component under test makes.
+ *
+ * `TContext` (the optimistic-update context type from a hook's `onMutate`,
+ * e.g. `usePutAlertConfig`'s `{ previous: AlertConfig | null | undefined }`)
+ * defaults to `unknown` so the common case — a mutation hook with no
+ * explicit context type — needs no 4th type argument at the call site.
  */
-export function mockMutationResult<TData, TVariables, TError = Error>(
-  overrides: Partial<UseMutationResult<TData, TError, TVariables>>,
-): UseMutationResult<TData, TError, TVariables> {
+export function mockMutationResult<
+  TData,
+  TVariables,
+  TError = Error,
+  TContext = unknown,
+>(
+  overrides: Partial<UseMutationResult<TData, TError, TVariables, TContext>>,
+): UseMutationResult<TData, TError, TVariables, TContext> {
   const base = {
     mutate: vi.fn(),
     mutateAsync: vi.fn(),
@@ -82,5 +92,5 @@ export function mockMutationResult<TData, TVariables, TError = Error>(
     reset: vi.fn(),
     ...overrides,
   };
-  return base as unknown as UseMutationResult<TData, TError, TVariables>;
+  return base as unknown as UseMutationResult<TData, TError, TVariables, TContext>;
 }

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -4597,8 +4597,16 @@ export const UptimeSummaryItemSchema = {
 export const AlertConfigSchema = {
   type: "object",
   description:
-    "A tenant's uptime alert channel. The webhook secret is write-only and is\nnever returned; webhook_configured indicates whether a webhook URL is set.\n",
-  required: ["email_recipients", "enabled", "webhook_configured"],
+    "A tenant's alert channel, shared by uptime downtime/recovery,\nhigh-severity security events, and vulnerability alerting (GH #247).\nThe webhook secret is write-only and is never returned;\nwebhook_configured indicates whether a webhook URL is set.\n",
+  required: [
+    "email_recipients",
+    "enabled",
+    "webhook_configured",
+    "notify_security",
+    "notify_vulns",
+    "vuln_min_severity",
+    "vuln_include_in_digest",
+  ],
   properties: {
     email_recipients: {
       type: "array",
@@ -4616,12 +4624,33 @@ export const AlertConfigSchema = {
     enabled: {
       type: "boolean",
     },
+    notify_security: {
+      type: "boolean",
+      description:
+        "Routes high-severity activity-log security events into this same\nchannel (email + webhook).\n",
+    },
+    notify_vulns: {
+      type: "boolean",
+      description:
+        "Routes new vulnerability findings into this same channel (email +\nwebhook). Opt-in; default false.\n",
+    },
+    vuln_min_severity: {
+      type: "string",
+      enum: ["critical", "high", "medium", "low"],
+      description:
+        "The minimum severity that triggers a vulnerability alert. A\nfinding with unknown severity (no CVSS data yet) always alerts\nregardless of this threshold.\n",
+    },
+    vuln_include_in_digest: {
+      type: "boolean",
+      description:
+        "Whether open vulnerabilities appear in the periodic email digest\n(see EmailNotifySettings). Default true.\n",
+    },
   },
 } as const;
 
 export const AlertConfigUpdateSchema = {
   type: "object",
-  description: "Create or update the tenant's uptime alert channel.",
+  description: "Create or update the tenant's alert channel.",
   properties: {
     email_recipients: {
       type: "array",
@@ -4640,6 +4669,24 @@ export const AlertConfigUpdateSchema = {
     enabled: {
       type: "boolean",
       default: true,
+    },
+    notify_security: {
+      type: "boolean",
+      description:
+        "Omitted preserves the tenant's currently-stored value (all fields\nin this update body are optional and independently preservable).\n",
+    },
+    notify_vulns: {
+      type: "boolean",
+      description: "Omitted preserves the tenant's currently-stored value.",
+    },
+    vuln_min_severity: {
+      type: "string",
+      enum: ["critical", "high", "medium", "low"],
+      description: "Omitted preserves the tenant's currently-stored value.",
+    },
+    vuln_include_in_digest: {
+      type: "boolean",
+      description: "Omitted preserves the tenant's currently-stored value.",
     },
   },
 } as const;

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -2299,8 +2299,10 @@ export type UptimeSummaryItem = {
 };
 
 /**
- * A tenant's uptime alert channel. The webhook secret is write-only and is
- * never returned; webhook_configured indicates whether a webhook URL is set.
+ * A tenant's alert channel, shared by uptime downtime/recovery,
+ * high-severity security events, and vulnerability alerting (GH #247).
+ * The webhook secret is write-only and is never returned;
+ * webhook_configured indicates whether a webhook URL is set.
  *
  */
 export type AlertConfig = {
@@ -2308,10 +2310,35 @@ export type AlertConfig = {
   webhook_url?: string;
   webhook_configured: boolean;
   enabled: boolean;
+  /**
+   * Routes high-severity activity-log security events into this same
+   * channel (email + webhook).
+   *
+   */
+  notify_security: boolean;
+  /**
+   * Routes new vulnerability findings into this same channel (email +
+   * webhook). Opt-in; default false.
+   *
+   */
+  notify_vulns: boolean;
+  /**
+   * The minimum severity that triggers a vulnerability alert. A
+   * finding with unknown severity (no CVSS data yet) always alerts
+   * regardless of this threshold.
+   *
+   */
+  vuln_min_severity: "critical" | "high" | "medium" | "low";
+  /**
+   * Whether open vulnerabilities appear in the periodic email digest
+   * (see EmailNotifySettings). Default true.
+   *
+   */
+  vuln_include_in_digest: boolean;
 };
 
 /**
- * Create or update the tenant's uptime alert channel.
+ * Create or update the tenant's alert channel.
  */
 export type AlertConfigUpdate = {
   email_recipients?: Array<string>;
@@ -2321,6 +2348,24 @@ export type AlertConfigUpdate = {
    */
   webhook_secret?: string;
   enabled?: boolean;
+  /**
+   * Omitted preserves the tenant's currently-stored value (all fields
+   * in this update body are optional and independently preservable).
+   *
+   */
+  notify_security?: boolean;
+  /**
+   * Omitted preserves the tenant's currently-stored value.
+   */
+  notify_vulns?: boolean;
+  /**
+   * Omitted preserves the tenant's currently-stored value.
+   */
+  vuln_min_severity?: "critical" | "high" | "medium" | "low";
+  /**
+   * Omitted preserves the tenant's currently-stored value.
+   */
+  vuln_include_in_digest?: boolean;
 };
 
 /**

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.74
+  version: 0.61.75
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,
@@ -15196,9 +15196,20 @@ components:
     AlertConfig:
       type: object
       description: |
-        A tenant's uptime alert channel. The webhook secret is write-only and is
-        never returned; webhook_configured indicates whether a webhook URL is set.
-      required: [email_recipients, enabled, webhook_configured]
+        A tenant's alert channel, shared by uptime downtime/recovery,
+        high-severity security events, and vulnerability alerting (GH #247).
+        The webhook secret is write-only and is never returned;
+        webhook_configured indicates whether a webhook URL is set.
+      required:
+        [
+          email_recipients,
+          enabled,
+          webhook_configured,
+          notify_security,
+          notify_vulns,
+          vuln_min_severity,
+          vuln_include_in_digest,
+        ]
       properties:
         email_recipients:
           type: array
@@ -15211,9 +15222,31 @@ components:
           type: boolean
         enabled:
           type: boolean
+        notify_security:
+          type: boolean
+          description: |
+            Routes high-severity activity-log security events into this same
+            channel (email + webhook).
+        notify_vulns:
+          type: boolean
+          description: |
+            Routes new vulnerability findings into this same channel (email +
+            webhook). Opt-in; default false.
+        vuln_min_severity:
+          type: string
+          enum: [critical, high, medium, low]
+          description: |
+            The minimum severity that triggers a vulnerability alert. A
+            finding with unknown severity (no CVSS data yet) always alerts
+            regardless of this threshold.
+        vuln_include_in_digest:
+          type: boolean
+          description: |
+            Whether open vulnerabilities appear in the periodic email digest
+            (see EmailNotifySettings). Default true.
     AlertConfigUpdate:
       type: object
-      description: Create or update the tenant's uptime alert channel.
+      description: Create or update the tenant's alert channel.
       properties:
         email_recipients:
           type: array
@@ -15228,6 +15261,21 @@ components:
         enabled:
           type: boolean
           default: true
+        notify_security:
+          type: boolean
+          description: |
+            Omitted preserves the tenant's currently-stored value (all fields
+            in this update body are optional and independently preservable).
+        notify_vulns:
+          type: boolean
+          description: Omitted preserves the tenant's currently-stored value.
+        vuln_min_severity:
+          type: string
+          enum: [critical, high, medium, low]
+          description: Omitted preserves the tenant's currently-stored value.
+        vuln_include_in_digest:
+          type: boolean
+          description: Omitted preserves the tenant's currently-stored value.
     AutologinCreate:
       type: object
       description: |


### PR DESCRIPTION
Vulnerabilities were the one major signal with no alerting path: an operator got an email when a site was down for minutes, but not when a CVSS 9.8 RCE landed on it. This wires vuln alerts into the **existing** per-tenant alert channel + durable mailer + signed webhook Dispatcher — no new dispatch plumbing.

### What
- **m103**: `alert_configs` gains `notify_vulns` / `vuln_min_severity` (default `high`) / `vuln_include_in_digest`; `site_vulnerabilities` gains `notified_at`. Migration **backfills** all existing rows so the first dispatch never floods operators with the backlog.
- **New-finding detection** is the `notified_at` flag (retry-safe, not a time window). `resolved→open` resets it (a reappearing vuln re-alerts); dismissed never alerts.
- **Debounced cross-tenant dispatch** after each rescan wave: atomic `UPDATE...RETURNING` claim (row locks → one winner), stamps all rows even when disabled (enabling later never floods), filters to min severity with **Unknown always included** (a 9.8 can sit unscored), and sends **one batched email per tenant via a transactional outbox** (no dup, no silent miss). Signed SSRF-hardened **webhook** fires alongside (best-effort).
- **Digest** gains an open-findings section.
- **Web**: a Vulnerability-alerts section on the existing Alerts card + exposes the security-events toggle. Also **fixes `putAlertConfig` silently resetting `notify_security`/`enabled`/`webhook_url`** on every PUT (a real latent lost-update bug).

Decisions: default High-and-above (+unknown always); v1 = email + digest + webhook; new-enrollment first scan alerts.

### Verification
Security-reviewer **SHIP** (no critical/high; cross-tenant / outbox / SSRF / email-XSS all clean; concurrent-claim + outbox-rollback proven against Postgres). ogen regen deterministic; route coverage green. Gates: api go build/vet/test green (m103 + 8 dispatch + RLS + template + digest tests); web 1132 tests + lint 0 + vite build + impeccable 0 new. CP + web; agent unaffected. CHANGELOG + openapi + marketing lockstep.

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWiZ4iJ1fmYW8vtPghWmsn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in vulnerability alerts with batched email notifications and signed webhook support.
  * Added configurable minimum severity thresholds, including findings without severity scores.
  * Added vulnerability summaries to daily email digests, including open-finding counts and top findings.
  * Expanded Alerts settings with vulnerability controls and mail-configuration guidance.
* **Bug Fixes**
  * Alert settings now preserve security and vulnerability options when unrelated fields are updated.
  * Existing findings are not retroactively alerted after the feature is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->