### PR TITLE
fix(web): email log shows site name (#251) + remove duplicate Add-site button (#252) — 0.61.76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.76] - 2026-07-20
+
+### Fixed
+
+- The fleet Email log now shows each site's name instead of its internal ID (GH #251). Dashboard only.
+- Removed a duplicate "Add site" button on the Sites page; the button also no longer appeared twice on the empty state (GH #252). Dashboard only.
+
 ## [0.61.75] - 2026-07-19
 
 ### Added

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.75
+ * Version:           0.61.76
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.75');
+define('WPMGR_AGENT_VERSION', '0.61.76');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/web/src/features/email/fleet-email-log-table.test.tsx
+++ b/apps/web/src/features/email/fleet-email-log-table.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import type { Site, SiteEmailLogEntry } from "@wpmgr/api";
+
+import { renderWithProviders } from "@/test/render";
+import { mockQueryResult } from "@/test/query-mocks";
+
+// GH #251: the fleet Email log's "Site" column resolved `site_id` to a
+// truncated raw UUID instead of the site's name. Fixed on the frontend by
+// resolving `site_id` -> name through the shared `useSites` hook (the same
+// cache the Sites list + capability dots already read).
+
+const { useSitesMock, useFleetEmailLogMock } = vi.hoisted(() => ({
+  useSitesMock: vi.fn(),
+  useFleetEmailLogMock: vi.fn(),
+}));
+
+vi.mock("@/features/sites/use-sites", () => ({ useSites: useSitesMock }));
+vi.mock("./use-email", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./use-email")>();
+  return { ...actual, useFleetEmailLog: useFleetEmailLogMock };
+});
+
+import { FleetEmailLogTable } from "./fleet-email-log-table";
+
+function buildSite(overrides: Partial<Site> = {}): Site {
+  return {
+    id: "11111111-0000-0000-0000-000000000001",
+    tenant_id: "tenant-1",
+    url: "https://acme.example.com",
+    name: "Acme Blog",
+    status: "active",
+    wp_version: "6.8",
+    php_version: "8.3",
+    health_status: "healthy",
+    multisite: false,
+    tags: [],
+    ...overrides,
+  } as unknown as Site;
+}
+
+function buildLogEntry(
+  overrides: Partial<SiteEmailLogEntry> = {},
+): SiteEmailLogEntry {
+  return {
+    id: "log-1",
+    tenant_id: "tenant-1",
+    site_id: "11111111-0000-0000-0000-000000000001",
+    to_addresses: ["ops@example.com"],
+    from_address: "wp@example.com",
+    subject: "Test subject",
+    provider: "smtp",
+    status: "sent",
+    response: {},
+    error: "",
+    retries: 0,
+    resent_count: 0,
+    body_stored: false,
+    created_at: "2026-07-19T00:00:00Z",
+    updated_at: "2026-07-19T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function mockFleetEmailLog(entries: SiteEmailLogEntry[]) {
+  useFleetEmailLogMock.mockReturnValue({
+    entries,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    isPending: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+}
+
+describe("FleetEmailLogTable site name resolution (GH #251)", () => {
+  it("renders the resolved site name instead of the raw id when the site is in the sites list", async () => {
+    useSitesMock.mockReturnValue(
+      mockQueryResult<Site[]>({ data: [buildSite()] }),
+    );
+    mockFleetEmailLog([
+      buildLogEntry({ site_id: "11111111-0000-0000-0000-000000000001" }),
+    ]);
+
+    renderWithProviders(<FleetEmailLogTable />, { withRouter: true });
+
+    const link = await screen.findByRole("link", { name: "Acme Blog" });
+    expect(link).toHaveAttribute(
+      "href",
+      "/sites/11111111-0000-0000-0000-000000000001/email",
+    );
+    expect(screen.queryByText(/11111111…/)).not.toBeInTheDocument();
+  });
+
+  it("falls back to the truncated id when the site is not in the sites list (archived/removed)", async () => {
+    // The sites list has loaded but does not contain this entry's site_id.
+    useSitesMock.mockReturnValue(mockQueryResult<Site[]>({ data: [] }));
+    mockFleetEmailLog([
+      buildLogEntry({ site_id: "22222222-aaaa-0000-0000-000000000002" }),
+    ]);
+
+    renderWithProviders(<FleetEmailLogTable />, { withRouter: true });
+
+    const link = await screen.findByRole("link", { name: "22222222…" });
+    expect(link).toHaveAttribute(
+      "href",
+      "/sites/22222222-aaaa-0000-0000-000000000002/email",
+    );
+  });
+
+  it("falls back to the truncated id while the sites list is still loading", async () => {
+    useSitesMock.mockReturnValue(
+      mockQueryResult<Site[]>({ data: undefined, isPending: true }),
+    );
+    mockFleetEmailLog([
+      buildLogEntry({ site_id: "33333333-bbbb-0000-0000-000000000003" }),
+    ]);
+
+    renderWithProviders(<FleetEmailLogTable />, { withRouter: true });
+
+    const link = await screen.findByRole("link", { name: "33333333…" });
+    expect(link).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/email/fleet-email-log-table.tsx
+++ b/apps/web/src/features/email/fleet-email-log-table.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Download, Loader2, Search, Paperclip } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 
@@ -17,6 +17,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageError } from "@/components/feedback";
 import { relativeTime } from "@/lib/utils";
+import { useSites } from "@/features/sites/use-sites";
 import type { SiteEmailLogEntry } from "@wpmgr/api";
 import {
   useFleetEmailLog,
@@ -49,6 +50,20 @@ export function FleetEmailLogTable() {
     error,
     refetch,
   } = useFleetEmailLog(filters);
+
+  // Bug #251: the log entries only carry `site_id`; resolve it to a name via
+  // the shared sites list (same cache the Sites list and capability dots
+  // read, so this is no extra network cost). Loading and archived/removed
+  // sites simply miss the map, so FleetEmailRow falls back to the truncated
+  // id.
+  const { data: sites } = useSites();
+  const siteNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const s of sites ?? []) {
+      map.set(s.id, s.name || s.url);
+    }
+    return map;
+  }, [sites]);
 
   function setFilter<K extends keyof FleetEmailLogFilters>(
     key: K,
@@ -149,7 +164,11 @@ export function FleetEmailLogTable() {
             </TableHeader>
             <TableBody>
               {entries.map((entry) => (
-                <FleetEmailRow key={entry.id} entry={entry} />
+                <FleetEmailRow
+                  key={entry.id}
+                  entry={entry}
+                  siteName={siteNameById.get(entry.site_id)}
+                />
               ))}
             </TableBody>
           </Table>
@@ -181,7 +200,16 @@ export function FleetEmailLogTable() {
 // Row with site drill-in link
 // ---------------------------------------------------------------------------
 
-function FleetEmailRow({ entry }: { entry: SiteEmailLogEntry }) {
+function FleetEmailRow({
+  entry,
+  siteName,
+}: {
+  entry: SiteEmailLogEntry;
+  /** Resolved from the tenant's sites list; undefined while loading or when
+   *  the site is archived/removed and no longer in the list. Either way we
+   *  fall back to the truncated id so the row never breaks. */
+  siteName?: string;
+}) {
   const toLabel = entry.to_addresses.slice(0, 2).join(", ");
   const hasMore = entry.to_addresses.length > 2;
 
@@ -195,9 +223,9 @@ function FleetEmailRow({ entry }: { entry: SiteEmailLogEntry }) {
         <Link
           to="/sites/$siteId/email"
           params={{ siteId: entry.site_id }}
-          className="text-sm text-[var(--color-primary)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+          className="block max-w-[160px] truncate text-sm text-[var(--color-primary)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
         >
-          {entry.site_id.slice(0, 8)}…
+          {siteName || `${entry.site_id.slice(0, 8)}…`}
         </Link>
       </TableCell>
       <TableCell className="max-w-[140px] truncate text-sm">

--- a/apps/web/src/routes/_authed/sites/-index.test.tsx
+++ b/apps/web/src/routes/_authed/sites/-index.test.tsx
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { screen } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import type { QueryClient } from "@tanstack/react-query";
+import type { Me, Site } from "@wpmgr/api";
+
+import { createTestQueryClient, renderWithProviders } from "@/test/render";
+import { mockQueryResult } from "@/test/query-mocks";
+import { authKeys } from "@/features/auth/use-auth";
+
+import { Route as SitesIndexRoute } from "./index";
+import { useSites } from "@/features/sites/use-sites";
+import { useClients } from "@/features/clients/use-clients";
+import { useTags } from "@/features/tags/use-tags";
+import { useSitesLiveSync } from "@/features/sites/use-sites-live";
+import type { UseSitesOptions } from "@/features/sites/use-sites";
+
+// GH #252: the Sites list page rendered TWO visible "Add site" triggers for
+// operators (the PageHeader action AND the toolbar's addSiteSlot). Fixed by
+// making the PageHeader the page's single primary-action location (matching
+// every other list page's `actions=` primary-action convention, e.g.
+// `routes/_authed/settings/tags.tsx`'s "New tag" button) and suppressing the
+// toolbar's own trigger. The truly-empty (post-onboarding, zero-sites)
+// state had the SAME defect one layer down: NoSitesEmpty defaults its own
+// `cta` to another <AddSiteDialog />, so that state is covered here too.
+//
+// Mounts the REAL route component with the file's own exported `Route`
+// singleton re-attached to a throwaway root (mirrors
+// routes/_authed/admin/accounts/-index.test.tsx) because the page reads the
+// URL via `Route.useSearch()` / `useNavigate({ from: Route.fullPath })`,
+// both bound to that exact singleton.
+
+vi.mock("@/features/sites/use-sites", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/sites/use-sites")>();
+  return { ...actual, useSites: vi.fn() };
+});
+vi.mock("@/features/clients/use-clients", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/clients/use-clients")>();
+  return { ...actual, useClients: vi.fn() };
+});
+vi.mock("@/features/tags/use-tags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/tags/use-tags")>();
+  return { ...actual, useTags: vi.fn() };
+});
+vi.mock("@/features/sites/use-sites-live", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/sites/use-sites-live")>();
+  return { ...actual, useSitesLiveSync: vi.fn() };
+});
+
+const mockedUseSites = vi.mocked(useSites);
+const mockedUseClients = vi.mocked(useClients);
+const mockedUseTags = vi.mocked(useTags);
+const mockedUseSitesLiveSync = vi.mocked(useSitesLiveSync);
+
+const OWNER_ME: Me = {
+  user: {
+    id: "00000000-0000-0000-0000-0000000000u1",
+    email: "owner@example.com",
+    name: "Owner",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  memberships: [{ user_id: "00000000-0000-0000-0000-0000000000u1", tenant_id: "t1", role: "owner" }],
+  active_tenant_id: "t1",
+  hosted: false,
+};
+
+function buildSite(overrides: Partial<Site> = {}): Site {
+  return {
+    id: "11111111-0000-0000-0000-000000000001",
+    tenant_id: "t1",
+    url: "https://acme.example.com",
+    name: "Acme",
+    status: "active",
+    wp_version: "6.8",
+    php_version: "8.3",
+    health_status: "healthy",
+    multisite: false,
+    tags: [],
+    ...overrides,
+  } as unknown as Site;
+}
+
+/** Re-attaches the route file's real `Route` singleton to a throwaway root,
+ *  same technique as routes/_authed/admin/accounts/-index.test.tsx. The
+ *  route's `loader` reads `context.queryClient` (to prefetch the default
+ *  sites list) exactly like the real app router (src/router.tsx), so the
+ *  test router needs the same `context: { queryClient }` wiring or the
+ *  loader throws on `undefined.prefetchQuery`. */
+function buildSitesRouter(initialPath: string, queryClient: QueryClient) {
+  const rootRoute = createRootRoute({});
+  type UpdateOptions = Parameters<typeof SitesIndexRoute.update>[0];
+  const sitesRoute = SitesIndexRoute.update({
+    id: "/sites",
+    path: "/sites",
+    getParentRoute: () => rootRoute,
+  } as unknown as UpdateOptions);
+  const routeTree = rootRoute.addChildren([sitesRoute]);
+  return createRouter({
+    routeTree,
+    context: { queryClient },
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+  });
+}
+
+function renderSitesPage(initialPath = "/sites") {
+  const queryClient = createTestQueryClient();
+  queryClient.setQueryData(authKeys.me, OWNER_ME);
+  const router = buildSitesRouter(initialPath, queryClient);
+  renderWithProviders(<RouterProvider router={router} />, { queryClient });
+  return router;
+}
+
+beforeEach(() => {
+  mockedUseClients.mockReturnValue(mockQueryResult({ data: [] }));
+  mockedUseTags.mockReturnValue(mockQueryResult({ data: [] }));
+  mockedUseSitesLiveSync.mockReturnValue(undefined);
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("Sites page: exactly one 'Add site' trigger for an operator (GH #252)", () => {
+  it("list view with sites loaded renders exactly one Add site button (the PageHeader's)", async () => {
+    mockedUseSites.mockImplementation((options?: UseSitesOptions) =>
+      mockQueryResult<Site[]>({ data: options?.view === "archived" ? [] : [buildSite()] }),
+    );
+
+    renderSitesPage();
+
+    // The page renders asynchronously behind RouterProvider's first paint
+    // (see src/test/render.tsx's module doc); the row list itself is
+    // virtualized (react-virtuoso), which does not measure/paint rows in
+    // jsdom's zero-size layout, so assert on the toolbar landing (proof the
+    // "sites loaded" branch, not the empty/error one, is showing) rather
+    // than on a specific row's text.
+    await screen.findByRole("toolbar", { name: "Filter sites" });
+    expect(screen.getByText("1 site enrolled")).toBeInTheDocument();
+
+    const addSiteButtons = screen.getAllByRole("button", { name: /^add site$/i });
+    expect(addSiteButtons).toHaveLength(1);
+  });
+
+  it("the truly-empty, post-onboarding state renders exactly one Add site trigger (not a second one from NoSitesEmpty's default CTA)", async () => {
+    // Mark onboarding already dismissed on this "browser" so SitesPageEmpty
+    // renders NoSitesEmpty (not OnboardingWizard, whose CTA is "Continue",
+    // not "Add site"; see onboarding-wizard.tsx).
+    window.localStorage.setItem("wpmgr.onboarding.completed", "true");
+
+    mockedUseSites.mockImplementation(() => mockQueryResult<Site[]>({ data: [] }));
+
+    renderSitesPage();
+
+    await screen.findByRole("heading", {
+      name: "Connect your first WordPress site.",
+    });
+
+    const addSiteButtons = screen.getAllByRole("button", { name: /^add site$/i });
+    expect(addSiteButtons).toHaveLength(1);
+  });
+});

--- a/apps/web/src/routes/_authed/sites/index.tsx
+++ b/apps/web/src/routes/_authed/sites/index.tsx
@@ -697,7 +697,13 @@ function SitesPage() {
             />
           ) : null}
           <SitesPageEmpty
-            cta={operate ? undefined : <AddSitePlaceholder />}
+            // GH #252: NoSitesEmpty (rendered here once onboarding has been
+            // dismissed on this browser) defaults its own `cta` to another
+            // <AddSiteDialog />. The PageHeader's action above already owns
+            // the page's one Add-site trigger, so suppress this one for
+            // BOTH roles (not just non-operators) rather than let a second
+            // "Add site" button appear alongside the header's.
+            cta={<AddSitePlaceholder />}
             onOnboardingHandoff={operate ? ({ url }) => setOnboardingUrl(url) : undefined}
           />
         </>
@@ -779,7 +785,12 @@ function SitesPage() {
             onBulkSetClient={handleBulkSetClient}
             onBulkPauseMonitoring={handleBulkPauseMonitoring}
             onBulkDelete={handleBulkDelete}
-            addSiteSlot={operate ? <AddSiteDialog /> : <AddSitePlaceholder />}
+            // GH #252: the primary "Add site" action lives in the PageHeader
+            // only (top-right, matching every other list page's primary
+            // action), so don't duplicate the trigger here. Non-operators
+            // keep the placeholder slot wired so the affordance point stays
+            // in exactly one place.
+            addSiteSlot={operate ? undefined : <AddSitePlaceholder />}
           />
 
           {/* Phase 5 — archived filter chip */}

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.75
+  version: 0.61.76
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Two small dashboard display bugs from the same reporter (self-host, v0.61.71).

**#251 — fleet Email log showed the site ID instead of the name.** `/email` rendered `entry.site_id.slice(0, 8)…` (a truncated UUID) because `SiteEmailLogEntry` carries only `site_id`. Now resolved to the site name on the frontend via the existing `useSites()` cache (`Map<site_id, name>`, falling back to url then the truncated id for archived/removed/loading sites), keeping the per-site drill-in link. No API change.

**#252 — duplicate "Add site" button on /sites.** Operators saw two triggers (the `PageHeader` primary action + the toolbar `addSiteSlot`). Kept the header button (matches every other list page — tags/members put New/Add in the header) and dropped the toolbar duplicate, preserving the non-operator `AddSitePlaceholder`. Tracing every render path also surfaced a **third** duplicate: the zero-sites empty state's own default CTA stacked with the header button for a returning operator with no sites — suppressed so the header owns the single trigger.

Web-only; agent unaffected. Gates: web 1137 tests (+5 new) + lint 0 + vite build + impeccable 0 new. CHANGELOG + openapi lockstep.

Closes #251
Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWiZ4iJ1fmYW8vtPghWmsn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fleet email logs now show the site name instead of its internal ID.
  * Removed the duplicate “Add site” button from the Sites page and empty state.
* **Release**
  * Updated the application and agent version to 0.61.76.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->