### PR TITLE
test(web): de-flake the #252 one-Add-site route test — 0.61.77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.77] - 2026-07-20
+
+### Fixed
+
+- Internal: made a Sites-page UI test deterministic so it no longer fails intermittently in CI. No user-facing change; carries the 0.61.76 dashboard fixes.
+
 ## [0.61.76] - 2026-07-20
 
 ### Fixed

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.76
+ * Version:           0.61.77
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.76');
+define('WPMGR_AGENT_VERSION', '0.61.77');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/web/src/routes/_authed/sites/-index.test.tsx
+++ b/apps/web/src/routes/_authed/sites/-index.test.tsx
@@ -126,6 +126,37 @@ afterEach(() => {
   window.localStorage.clear();
 });
 
+// Both tests below wait on the actual "Add site" button(s) as the PRIMARY
+// (and only) async anchor, with a generous explicit timeout rather than
+// testing-library's 1000ms default. This closes a real flake: RouterProvider's
+// first paint is an async microtask (see src/test/render.tsx's module doc),
+// and on a busy/contended CI runner that paint can land after the default
+// findBy* timeout, well before any application-level slowness. `findByRole`
+// on `role="toolbar"` (or, in the empty-state test, the onboarding heading)
+// raced that SAME async paint with the SAME default timeout and intermittently
+// lost. Reproduced locally by running this file under CPU contention (many
+// parallel vitest + CPU-bound processes), which deterministically reproduced
+// "Unable to find role=\"toolbar\" and name \"Filter sites\"" (and the
+// analogous heading miss in the second test) even though the component logic
+// itself is 100% synchronous once mounted (the mocked `useSites` never
+// transitions through a pending state, so there is nothing async to wait on
+// BELOW the first paint).
+//
+// `findAllByRole` for the button is deliberately the wait target instead of
+// `findByRole`: unlike the singular query, it doesn't throw on >1 match, so a
+// REGRESSION of the GH #252 bug (both triggers rendering again) still fails
+// the length assertion below with a clear message, rather than failing early
+// inside the wait with a less informative "found multiple elements" error.
+//
+// Once the button wait resolves, the toolbar/heading check that follows is a
+// SYNCHRONOUS assertion (no waiting): by the time the button is in the DOM,
+// SitesPage has already committed its single render pass, so the toolbar (or
+// the onboarding heading) is guaranteed to already be present too. This keeps
+// the test's real invariant intact: it still genuinely proves the "sites
+// loaded" (or "truly empty") branch rendered, not just that any element
+// showed up trivially fast.
+const FIND_TIMEOUT = 5000;
+
 describe("Sites page: exactly one 'Add site' trigger for an operator (GH #252)", () => {
   it("list view with sites loaded renders exactly one Add site button (the PageHeader's)", async () => {
     mockedUseSites.mockImplementation((options?: UseSitesOptions) =>
@@ -134,16 +165,19 @@ describe("Sites page: exactly one 'Add site' trigger for an operator (GH #252)",
 
     renderSitesPage();
 
-    // The page renders asynchronously behind RouterProvider's first paint
-    // (see src/test/render.tsx's module doc); the row list itself is
-    // virtualized (react-virtuoso), which does not measure/paint rows in
-    // jsdom's zero-size layout, so assert on the toolbar landing (proof the
-    // "sites loaded" branch, not the empty/error one, is showing) rather
-    // than on a specific row's text.
-    await screen.findByRole("toolbar", { name: "Filter sites" });
+    const addSiteButtons = await screen.findAllByRole(
+      "button",
+      { name: /^add site$/i },
+      { timeout: FIND_TIMEOUT },
+    );
+
+    // Confirms this is genuinely the "sites loaded" branch (toolbar + row
+    // list), not the empty/error branch. The toolbar is where the GH #252
+    // duplicate used to live, so its presence here is load-bearing, not
+    // incidental.
+    expect(screen.getByRole("toolbar", { name: "Filter sites" })).toBeInTheDocument();
     expect(screen.getByText("1 site enrolled")).toBeInTheDocument();
 
-    const addSiteButtons = screen.getAllByRole("button", { name: /^add site$/i });
     expect(addSiteButtons).toHaveLength(1);
   });
 
@@ -157,11 +191,18 @@ describe("Sites page: exactly one 'Add site' trigger for an operator (GH #252)",
 
     renderSitesPage();
 
-    await screen.findByRole("heading", {
-      name: "Connect your first WordPress site.",
-    });
+    const addSiteButtons = await screen.findAllByRole(
+      "button",
+      { name: /^add site$/i },
+      { timeout: FIND_TIMEOUT },
+    );
 
-    const addSiteButtons = screen.getAllByRole("button", { name: /^add site$/i });
+    // Confirms this is genuinely the truly-empty NoSitesEmpty branch (where
+    // the second GH #252 duplicate used to live), not some other branch.
+    expect(
+      screen.getByRole("heading", { name: "Connect your first WordPress site." }),
+    ).toBeInTheDocument();
+
     expect(addSiteButtons).toHaveLength(1);
   });
 });

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.76
+  version: 0.61.77
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
The #252 test passed on the PR run but failed on the busier `main` run (leaving `main` red). It awaited the sites toolbar (`findByRole "toolbar"/"Filter sites"`) as its "loaded branch rendered" anchor, and that await raced the RouterProvider async first paint against the default 1000ms `findBy` timeout.

**Fix:** await the actual element under test (the "Add site" button, `findAllByRole` with a generous explicit timeout) as the sole async anchor, then assert the toolbar/heading **synchronously** (`getByRole`) — the render has committed by then, so no race, and the test still genuinely verifies exactly one Add-site trigger.

Verified deterministic: **10/10 parallel runs under CPU contention** + 6/6 local + full suite 1137 green. Test-only; the production fixes (#251/#252) are unchanged. This release carries those dashboard fixes live.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of the Sites page’s “Add site” interface during loading and empty-state scenarios.
* **Chores**
  * Released version 0.61.77 with updated version metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->