### PR TITLE
fix(agent): wp.org T15 upgrader-filter gate + Wordfence false-positive fix (#266) — 0.61.80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.80] - 2026-07-21
+
+### Changed
+
+- The managed-update runner no longer adjusts WordPress's upgrader working-directory handling in the WordPress.org distribution build; self-hosted installs are unchanged.
+
+### Fixed
+
+- Reworded a documentation comment in the file-manager write guard that quoted an example attack payload verbatim, which made some security scanners (for example Wordfence) report a false-positive match on the plugin's own file (GH #266). The comment described a payload the guard blocks; no code path or behavior changed.
+
 ## [0.61.79] - 2026-07-21
 
 ### Fixed

--- a/apps/agent/includes/cache/class-cache-writer.php
+++ b/apps/agent/includes/cache/class-cache-writer.php
@@ -342,7 +342,7 @@ final class CacheWriter
             'method'            => $method,
             'user_agent'        => $ua,
             'cookies'           => wp_unslash( $_COOKIE ), // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.NonceVerification.Recommended -- cache-key context only; each value is slugified to [a-z0-9-_] by CacheKey::sanitizeSegment, kept byte-identical to the pre-WordPress serve path in assets/wpmgr-advanced-cache.php; no output, no SQL, no state change.
-            'query'             => $_GET, // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- cache-key context assembly; read-only query data passed to cache-key builder; no state change, no form processing
+            'query'             => wp_unslash( $_GET ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- cache-key context assembly; read-only query data passed to cache-key builder; no state change, no form processing
             'is_admin'          => $isAdmin,
             'is_ajax'           => $isAjax,
             'status'            => $status,

--- a/apps/agent/includes/commands/class-file-guards.php
+++ b/apps/agent/includes/commands/class-file-guards.php
@@ -95,7 +95,8 @@ final class FileGuards {
 	 *
 	 *   (c) Content sniff: decoded content contains '<?php', '<?=', or any bare '<?'
 	 *       not immediately followed by 'xml' (case-insensitive).
-	 *       "notes.txt" with body "<? system($_GET['c']);" → blocked.
+	 *       e.g. a plain ".txt" file whose decoded body opens with a bare
+	 *       short-open PHP tag is blocked.
 	 *       $content is the DECODED bytes (callers must pass decoded, not base64).
 	 *       An empty $content (e.g. rename with no content) does NOT trigger (c).
 	 *

--- a/apps/agent/includes/support/class-update-runner.php
+++ b/apps/agent/includes/support/class-update-runner.php
@@ -861,7 +861,13 @@ class UpdateRunner
             $options['clear_working'] = true;
             return $options;
         };
-        add_filter('upgrader_package_options', $forceCleanWorking);
+        // Self-host only. The wp.org distribution build (WPMGR_WPORG_BUILD) must not
+        // alter core's upgrader behaviour, so it never registers this filter and
+        // degrades to WordPress's default working-directory handling. Kept for
+        // self-hosted installs to make interrupted-update recovery robust.
+        if (!defined('WPMGR_WPORG_BUILD') || !WPMGR_WPORG_BUILD) {
+            add_filter('upgrader_package_options', $forceCleanWorking);
+        }
 
         try {
             // Set by whichever case below actually ran an upgrade; used after

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -185,6 +185,10 @@ This plugin ships two minified JavaScript files. Their human-readable source and
 
 The entries below summarize the notable changes since 0.36.0. This project ships frequently; not every intermediate patch release is listed here individually -- see the full history at https://github.com/mosamlife/wpmgr/blob/main/CHANGELOG.md.
 
+= 0.61.80 =
+* Changed: the WordPress.org distribution build no longer adjusts WordPress's own upgrader working-directory handling during a plugin, theme, or core update. Self-hosted installs are unaffected.
+* Fixed: reworded a documentation comment in the file-manager write guard that quoted an example attack payload verbatim, so security scanners no longer report a false-positive match on the plugin's own file (GH #266). No behavior changed.
+
 = 0.61.79 =
 * Fix: on a site installed from a plain git clone or a GitHub source download (no `composer install` run), activating the plugin could fail immediately with a fatal error (GH #262). The plugin's own class loader could not find a handful of its own files on its own; it now resolves every one of them without depending on any other tool being present.
 

--- a/apps/agent/tests/UpdateRunnerWporgFilterTest.php
+++ b/apps/agent/tests/UpdateRunnerWporgFilterTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * UpdateRunnerWporgFilterTest — wp.org pre-resubmission review response
+ * (T15): the `upgrader_package_options` filter UpdateRunner::applyViaUpgrader()
+ * registers to force a clean working directory for the current upgrade must
+ * never be registered in the wp.org distribution build, so that build never
+ * alters WordPress core's own upgrader behaviour and instead degrades to
+ * core's default working-directory handling.
+ *
+ * `make agent-zip-wporg` injects `define('WPMGR_WPORG_BUILD', true);` into
+ * the staged main file — exactly what
+ * test_filter_not_registered_in_wporg_build() below reproduces. The closure
+ * definition and the `finally`-block `remove_filter()` call are unchanged by
+ * this fix and are intentionally NOT under test here: `remove_filter()` of a
+ * callback that was never registered is a harmless no-op, so self-hosted
+ * behaviour (the default build, WPMGR_WPORG_BUILD undefined) stays
+ * bit-for-bit identical — see test_filter_registered_in_default_build().
+ *
+ * Both tests invoke the protected applyViaUpgrader() via reflection with a
+ * deliberately unsupported $type ('wpmgr-test-unsupported-type'), which
+ * short-circuits the switch in the method's `try` block with none of its
+ * plugin/theme/core cases matching. That reaches — and passes through — the
+ * add_filter()/remove_filter() pair under test without needing the real
+ * Plugin_Upgrader/Theme_Upgrader machinery (not stubbed anywhere in this
+ * suite) to actually run an upgrade.
+ *
+ * Both tests run in a SEPARATE PROCESS: WPMGR_WPORG_BUILD and WP_TEMP_DIR are
+ * real PHP constants that, once defined, can never be undefined for the rest
+ * of a PHPUnit process — see SizeProbeWporgGuardTest and UpdateRunnerTempDirTest
+ * for the same idiom used for the same reason. WP_TEMP_DIR is pre-defined in
+ * set_up() so pinTempDirForUnpack() short-circuits at its very first check,
+ * keeping this test isolated from the filesystem-writability probing that
+ * method otherwise performs (irrelevant to what's under test here).
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Filters;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use WPMgr\Agent\Support\UpdateRunner;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\UpdateRunner
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+final class UpdateRunnerWporgFilterTest extends TestCase
+{
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        if (!defined('WP_TEMP_DIR')) {
+            define('WP_TEMP_DIR', sys_get_temp_dir());
+        }
+    }
+
+    protected function tear_down(): void
+    {
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * Invoke the protected applyViaUpgrader() with an unsupported $type via
+     * reflection. No setAccessible() call needed — ReflectionMethod::invoke()
+     * has been able to call non-public methods directly since PHP 8.1 (see
+     * UpdateRunnerTempDirTest::pin() for the same idiom).
+     *
+     * @return array{ok:bool,log:string}
+     */
+    private function applyWithUnsupportedType(UpdateRunner $runner): array
+    {
+        $method = new \ReflectionMethod(UpdateRunner::class, 'applyViaUpgrader');
+
+        /** @var array{ok:bool,log:string} $result */
+        $result = $method->invoke($runner, 'wpmgr-test-unsupported-type', 'irrelevant-slug', 'latest');
+
+        return $result;
+    }
+
+    /**
+     * THE REGRESSION LOCK. With WPMGR_WPORG_BUILD defined true (exactly as
+     * `make agent-zip-wporg` stamps the staged main file), applyViaUpgrader()
+     * must never register the upgrader_package_options filter. Run this test
+     * against the pre-fix code and it fails: the old add_filter() call ran
+     * unconditionally regardless of build identity.
+     */
+    public function test_filter_not_registered_in_wporg_build(): void
+    {
+        define('WPMGR_WPORG_BUILD', true);
+
+        Filters\expectAdded('upgrader_package_options')->never();
+
+        $runner = new UpdateRunner();
+        $result = $this->applyWithUnsupportedType($runner);
+
+        $this->assertFalse($result['ok'], 'Unsupported type must still resolve to a failed outcome, not a fatal.');
+    }
+
+    /**
+     * Self-hosted installs (WPMGR_WPORG_BUILD undefined) are UNCHANGED — the
+     * filter is still registered for THIS upgrade to force a clean working
+     * directory, exactly as before this fix.
+     */
+    public function test_filter_registered_in_default_build(): void
+    {
+        // WPMGR_WPORG_BUILD intentionally left undefined in this process —
+        // mirrors a self-hosted install.
+        Filters\expectAdded('upgrader_package_options')->once();
+
+        $runner = new UpdateRunner();
+        $result = $this->applyWithUnsupportedType($runner);
+
+        $this->assertFalse($result['ok'], 'Unsupported type must still resolve to a failed outcome, not a fatal.');
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.79
+ * Version:           0.61.80
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.79');
+define('WPMGR_AGENT_VERSION', '0.61.80');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.79
+  version: 0.61.80
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Agent-only changes for the WordPress.org review round (T15) plus a reported security-scanner false positive.

### wp.org T15
- Gate the managed-update runner's `upgrader_package_options` (force clean-working-dir) filter behind `WPMGR_WPORG_BUILD`, so the directory build doesn't alter core's upgrader behaviour. **Self-host keeps the filter** (interrupted-update recovery); registration is bit-for-bit identical there. Covered by a separate-process test.
- `wp_unslash()` on the `$_GET` cache-key read for parity with its `$_COOKIE` sibling (segments are slugified regardless; zero behaviour change).

### GH #266 — Wordfence `Backdoor:PHP/malapp.10873` false positive
Wordfence matched a **documentation comment** in `class-file-guards.php` (the anti-RCE file-write guard) that quoted the example payload `<? system($_GET['c']);` to describe what the guard blocks. The string was in a docblock only, never on a code path, and the sole occurrence in the shipped plugin. Reworded so no signature scanner matches it. No behaviour changed. `class-file-guards.php` ships in both builds, so this also cleans the wp.org zip.

### Verification
- Agent phpunit **2772 / 0 failures**, phpcs **0 errors**, `make agent-plugincheck` **0 errors**.
- wp.org zip rebuilt and verified free of the flagged string.

Version-lockstep bumps to 0.61.80 (agent header + `WPMGR_AGENT_VERSION`, readme, CHANGELOG, openapi `info.version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWiZ4iJ1fmYW8vtPghWmsn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the WPMgr Agent release to version 0.61.80.

* **Changed**
  * WordPress.org distribution builds now retain WordPress’s default upgrader working-directory handling. Self-hosted installations are unchanged.
  * Cache-key query inputs are consistently unslashed before processing.

* **Bug Fixes**
  * Improved cache-key consistency for request parameters.

* **Documentation**
  * Clarified file-manager security documentation without changing runtime behavior.
  * Updated release documentation and API version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->