### PR TITLE
fix(agent): don't write wp-config defines that collide with Roots/Bedrock (#268) — 0.61.82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.82] - 2026-07-22
+
+### Fixed
+
+- The "disable file editor" hardening toggle could fatal every request on a Roots/Bedrock site (GH #268). The agent wrote a raw `define('DISALLOW_FILE_EDIT', true)` at the top of wp-config.php, but Roots/Bedrock manages that same constant through its own config layer, which throws when the same constant is defined a second time. The agent now checks whether the constant is already defined (or the config file is otherwise framework-managed) before writing anything; when it is, nothing is written to wp-config.php and the toggle still reports success, since the constant is already enforced. Standard WordPress installs are unaffected: the constant is written exactly as before when nothing else has already defined it. The same protection now also covers the full-page cache's `WP_CACHE` constant, which is written through the same code path.
+
 ## [0.61.81] - 2026-07-22
 
 ### Fixed

--- a/apps/agent/includes/cache/class-wp-config-editor.php
+++ b/apps/agent/includes/cache/class-wp-config-editor.php
@@ -37,12 +37,36 @@ final class WpConfigEditor
     private ?string $explicitPath;
 
     /**
+     * Informational note captured by the most recent {@see setConstant()} call
+     * when it completed as a no-op WITHOUT writing wp-config.php because the
+     * constant is already enforced or the file is managed by another layer
+     * (e.g. a Roots/Bedrock install, which defines constants via
+     * `Roots\WPConfig\Config` before this editor's caller ever runs). Reset to
+     * null at the start of every {@see setConstant()} / {@see removeConstant()}
+     * call. This is NOT an error signal — the caller's intent (the constant
+     * ends up enforced) is satisfied either way; callers may surface it as an
+     * informational detail but must never treat it as a failure.
+     */
+    private ?string $lastNotice = null;
+
+    /**
      * @param string|null $explicitPath Absolute path to a wp-config.php (used by
      *   tests / unusual layouts). When null the path is auto-resolved.
      */
     public function __construct(?string $explicitPath = null)
     {
         $this->explicitPath = $explicitPath;
+    }
+
+    /**
+     * Informational note from the most recent setConstant()/removeConstant()
+     * call, or null when there is none. See {@see $lastNotice}.
+     *
+     * @return string|null
+     */
+    public function lastNotice(): ?string
+    {
+        return $this->lastNotice;
     }
 
     /**
@@ -103,12 +127,45 @@ final class WpConfigEditor
      * untouched (returns true). Otherwise any prior define line is stripped and a
      * fresh one is inserted immediately after the opening `<?php` tag.
      *
+     * GH #268: some platforms resolve/define config constants themselves ahead
+     * of any agent command — e.g. a Roots/Bedrock install's web/wp-config.php
+     * requires config/application.php, which manages constants via
+     * `Roots\WPConfig\Config::define()` and THROWS a
+     * `ConstantAlreadyDefinedException` if the same constant is defined again
+     * via a raw `define()`. By the time this command executes, wp-config.php
+     * (and any framework config layer it required) has already fully loaded
+     * for this request, so PHP's own `defined()`/`constant()` reflect the
+     * platform's real, current state. Before writing anything, this method:
+     *
+     *   1. Returns true (no-op) when the constant is already defined at
+     *      runtime with exactly the desired value — enforced elsewhere,
+     *      nothing to write.
+     *   2. Returns true (no-op) when the constant is defined at runtime with a
+     *      different value — owned by another layer (a platform config, another
+     *      plugin, or a raw define this editor did not write, e.g. a host or
+     *      user that set DISALLOW_FILE_EDIT=false). This branch IS reachable on
+     *      ordinary sites; the constant is never overwritten, to avoid a
+     *      conflicting redefinition, and a notice is surfaced. For
+     *      DISALLOW_FILE_EDIT the runtime user_has_cap filter still enforces the
+     *      toggle regardless of the file constant.
+     *   3. Returns true (no-op) when the constant is not yet defined but the
+     *      wp-config.php content itself looks framework-managed (see
+     *      {@see isManagedWpConfig()}) — refuses to insert a raw define that
+     *      could race or conflict with the framework's own constant
+     *      management.
+     *
+     * None of these paths are failures: the operator's intent (the constant
+     * ends up enforced) is satisfied either way. See {@see lastNotice()} for
+     * an informational (never error) explanation callers may surface.
+     *
      * @param string          $name  Constant name (validated [A-Z0-9_]).
      * @param string|bool|int $value Value to set.
      * @return bool True when the file ends in the desired state.
      */
     public function setConstant(string $name, $value): bool
     {
+        $this->lastNotice = null;
+
         if (!$this->validName($name)) {
             return false;
         }
@@ -126,8 +183,40 @@ final class WpConfigEditor
         $literal = $this->literal($value);
         $defineLine = sprintf("define('%s', %s); %s", $name, $literal, self::MARKER);
 
-        // Already present and identical? No-op.
+        // Already present (our own marked define) and identical? No-op.
         if ($this->hasExactDefine($content, $name, $literal)) {
+            return true;
+        }
+
+        // Runtime already reflects a defined constant (Roots/Bedrock or any
+        // other layer that resolved before this command ran) — never write
+        // over it. See the method docblock for the two sub-cases.
+        if (defined($name)) {
+            $current = constant($name);
+            if ($current === $value) {
+                $this->lastNotice = sprintf(
+                    "%s is already enforced (defined elsewhere with the requested value, e.g. by a platform such as Roots/Bedrock) — wp-config.php was left untouched.",
+                    $name
+                );
+            } else {
+                $this->lastNotice = sprintf(
+                    '%s is already defined with a different value by another layer (e.g. a platform config, another plugin, or a raw define this editor did not write) — wp-config.php was left untouched to avoid a conflicting redefinition.',
+                    $name
+                );
+            }
+            return true;
+        }
+
+        // Not yet defined at runtime, but the file itself indicates a
+        // framework-managed wp-config.php (e.g. Roots/Bedrock, whose actual
+        // constant definitions live in a required config file rather than
+        // wp-config.php itself) — refuse to insert a raw define even in this
+        // edge case, so we never race the framework's own definition.
+        if ($this->isManagedWpConfig($content)) {
+            $this->lastNotice = sprintf(
+                "%s was not written: wp-config.php appears to be managed by a framework such as Roots/Bedrock (references Roots\\WPConfig\\Config / requires config/application.php) — inserting a raw define here could conflict with the framework's own constant management.",
+                $name
+            );
             return true;
         }
 
@@ -148,11 +237,20 @@ final class WpConfigEditor
     /**
      * Remove any `define('NAME', ...)` line. Idempotent (absent ⇒ no-op true).
      *
+     * Safe on a framework-managed wp-config.php (e.g. Roots/Bedrock): a
+     * framework such as Roots/Bedrock manages constants via
+     * `Roots\WPConfig\Config::define()` in a separate, required config file,
+     * never a raw `define()` line inside wp-config.php itself, so
+     * {@see stripDefine()} simply finds nothing to remove there and returns
+     * this file untouched.
+     *
      * @param string $name Constant name.
      * @return bool
      */
     public function removeConstant(string $name): bool
     {
+        $this->lastNotice = null;
+
         if (!$this->validName($name)) {
             return false;
         }
@@ -237,6 +335,31 @@ final class WpConfigEditor
     // -------------------------------------------------------------------------
     // Private helpers
     // -------------------------------------------------------------------------
+
+    /**
+     * Whether wp-config.php content indicates a framework-managed config
+     * layer that owns constant definitions itself (GH #268). Roots/Bedrock is
+     * the primary real-world case: its web/wp-config.php requires a separate
+     * config/application.php file, which defines every WP constant via
+     * `Roots\WPConfig\Config::define()` and throws on redefinition.
+     *
+     * Signals checked (any one is sufficient):
+     *   - references the `Roots\WPConfig\Config` class (the config manager).
+     *   - references the `roots/wp-config` package.
+     *   - a `require`/`require_once` of a `config/application.php` file
+     *     (Bedrock's own bootstrap step), regardless of quoting/concatenation.
+     *
+     * @param string $content wp-config.php content.
+     * @return bool
+     */
+    private function isManagedWpConfig(string $content): bool
+    {
+        if (str_contains($content, 'Roots\WPConfig\Config') || str_contains($content, 'roots/wp-config')) {
+            return true;
+        }
+
+        return preg_match('/\brequire(_once)?\b[^;]*config\/application\.php/', $content) === 1;
+    }
 
     /**
      * Atomic write: temp file in the same directory + rename over the target.

--- a/apps/agent/includes/commands/class-sync-security-hardening-command.php
+++ b/apps/agent/includes/commands/class-sync-security-hardening-command.php
@@ -125,6 +125,15 @@ final class SyncSecurityHardeningCommand implements CommandInterface
         $detail = 'applied';
         if ($config->disableFileEditor && !$wpConfigOk) {
             $detail = 'applied; wp-config.php not writable — disable_file_editor via runtime filter only';
+        } elseif ($config->disableFileEditor) {
+            // Informational only (GH #268): e.g. on Roots/Bedrock the constant
+            // is already enforced elsewhere and wp-config.php was left
+            // untouched. Never surfaced as a failure — $wpConfigOk is already
+            // true here.
+            $notice = $this->module->lastWpConfigNotice();
+            if ($notice !== null) {
+                $detail = 'applied; ' . $notice;
+            }
         }
 
         return ['ok' => true, 'detail' => $detail];

--- a/apps/agent/includes/security/class-hardening-module.php
+++ b/apps/agent/includes/security/class-hardening-module.php
@@ -38,6 +38,15 @@ final class HardeningModule
     private const AGENT_AUTOLOGIN_PATH = '/autologin';
 
     /**
+     * Informational note from the most recent {@see syncWpConfigFileEdit()}
+     * call, captured from {@see WpConfigEditor::lastNotice()}. Null when the
+     * wp-config write succeeded/was a plain idempotent re-apply, the toggle
+     * was off, or no notice applies. This is NEVER a failure signal — see
+     * {@see lastWpConfigNotice()}.
+     */
+    private ?string $lastWpConfigNotice = null;
+
+    /**
      * Persist a new config and install/refresh the server-config block.
      *
      * Called by SyncSecurityHardeningCommand::execute(). Returns true when
@@ -140,11 +149,20 @@ final class HardeningModule
      * handler after persistence so the define lands in wp-config immediately.
      * Also removes the define when the toggle is turned off.
      *
+     * GH #268: on platforms such as Roots/Bedrock, DISALLOW_FILE_EDIT is
+     * already managed elsewhere by the time this runs (see
+     * {@see WpConfigEditor::setConstant()}); the write is safely skipped and
+     * this still returns true (intent satisfied) rather than fatal. Any
+     * informational (non-error) explanation of that skip is available via
+     * {@see lastWpConfigNotice()} afterwards.
+     *
      * @param HardeningConfig $config
      * @return bool
      */
     public function syncWpConfigFileEdit(HardeningConfig $config): bool
     {
+        $this->lastWpConfigNotice = null;
+
         $editor = new WpConfigEditor();
         if (!$editor->isWritable()) {
             // Non-writable wp-config: runtime filter (registered by install()) is
@@ -153,10 +171,25 @@ final class HardeningModule
         }
 
         if ($config->disableFileEditor) {
-            return $editor->setConstant('DISALLOW_FILE_EDIT', true);
+            $result = $editor->setConstant('DISALLOW_FILE_EDIT', true);
+            $this->lastWpConfigNotice = $editor->lastNotice();
+            return $result;
         } else {
             return $editor->removeConstant('DISALLOW_FILE_EDIT');
         }
+    }
+
+    /**
+     * Informational note from the most recent {@see syncWpConfigFileEdit()}
+     * call (e.g. "DISALLOW_FILE_EDIT is already enforced ... left untouched"
+     * on a Roots/Bedrock site), or null when there is none. Callers may
+     * surface this as an informational detail — it is never an error.
+     *
+     * @return string|null
+     */
+    public function lastWpConfigNotice(): ?string
+    {
+        return $this->lastWpConfigNotice;
     }
 
     /**

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -185,6 +185,9 @@ This plugin ships two minified JavaScript files. Their human-readable source and
 
 The entries below summarize the notable changes since 0.36.0. This project ships frequently; not every intermediate patch release is listed here individually -- see the full history at https://github.com/mosamlife/wpmgr/blob/main/CHANGELOG.md.
 
+= 0.61.82 =
+* Fixed: the "disable file editor" hardening toggle could fatal every request on a Roots/Bedrock site (GH #268). Roots/Bedrock manages that constant through its own config layer and throws when it is defined a second time; the agent now checks whether it is already defined (or the config file is otherwise framework-managed) before writing anything, so nothing is written in that case and the toggle still reports success. Standard WordPress installs are unaffected. The full-page cache's WP_CACHE constant is protected the same way.
+
 = 0.61.81 =
 * Fixed: agent command updates (and other control-plane commands) could fail on sites running some third-party plugins that globally decode the Authorization header on every request, for example as part of their own JWT-based auth (GH #269). The agent now moves its own signed Authorization value out of the request before any other plugin's code runs, so this class of conflict can no longer occur.
 

--- a/apps/agent/tests/CacheWpConfigEditorManagedRuntimeTest.php
+++ b/apps/agent/tests/CacheWpConfigEditorManagedRuntimeTest.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * GH #268 regression: WpConfigEditor::setConstant() must be a pure no-op —
+ * NEVER writing to wp-config.php — once a constant is already defined at PHP
+ * runtime with the desired value, e.g. by a Roots/Bedrock install (which
+ * manages constants via `Roots\WPConfig\Config::define()` and throws a
+ * `ConstantAlreadyDefinedException` on any raw redefinition). Before this
+ * fix, WpConfigEditor unconditionally inserted a raw `define()` at the top of
+ * wp-config.php, which fataled every request on such a site.
+ *
+ * PHP constants cannot be undefined once defined in a process, so every test
+ * here that `define()`s DISALLOW_FILE_EDIT for real must run in its own
+ * separate process — the same discipline used by KeystoreMasterKeyTest.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use WPMgr\Agent\Cache\WpConfigEditor;
+use WPMgr\Agent\Security\HardeningConfig;
+use WPMgr\Agent\Security\HardeningModule;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Cache\WpConfigEditor
+ * @covers \WPMgr\Agent\Security\HardeningModule
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+final class CacheWpConfigEditorManagedRuntimeTest extends TestCase
+{
+    private string $dir = '';
+
+    private string $configPath = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        $this->dir = sys_get_temp_dir() . '/wpmgr-cfg-rt-' . uniqid('', true);
+        mkdir($this->dir, 0o777, true);
+        $this->configPath = $this->dir . '/wp-config.php';
+        file_put_contents(
+            $this->configPath,
+            "<?php\n/* wp-config */\ndefine('DB_NAME', 'wp');\n\nrequire_once ABSPATH . 'wp-settings.php';\n"
+        );
+    }
+
+    protected function tear_down(): void
+    {
+        foreach (glob($this->dir . '/*') ?: [] as $f) {
+            @unlink($f);
+        }
+        @rmdir($this->dir);
+        parent::tear_down();
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 1 (the #268 regression test): already-defined-true (Bedrock) is a
+    // pure no-op — nothing is written.
+    // -------------------------------------------------------------------------
+
+    public function test_set_constant_is_a_pure_noop_when_constant_already_defined_true(): void
+    {
+        // Simulate a Bedrock site: DISALLOW_FILE_EDIT is already defined true
+        // by the time our command runs (Roots\WPConfig\Config, or any other
+        // layer, resolved before this command executes).
+        define('DISALLOW_FILE_EDIT', true);
+
+        $editor = new WpConfigEditor($this->configPath);
+        $before = (string) file_get_contents($this->configPath);
+
+        $this->assertTrue($editor->setConstant('DISALLOW_FILE_EDIT', true));
+
+        $after = (string) file_get_contents($this->configPath);
+        $this->assertSame(
+            $before,
+            $after,
+            'wp-config.php must be byte-for-byte unchanged when the constant is already correctly defined'
+        );
+        $this->assertStringNotContainsString(
+            'DISALLOW_FILE_EDIT',
+            $after,
+            'no define line for this constant may be added'
+        );
+        $this->assertNotNull($editor->lastNotice(), 'an informational (non-error) notice must be available');
+    }
+
+    public function test_set_constant_is_a_noop_when_defined_with_a_different_value(): void
+    {
+        // Item 2 of the fix design: defined, but not with the value we asked
+        // for. This is reachable on ordinary sites (a host or user can set
+        // DISALLOW_FILE_EDIT=false to keep the editor on); the guard must refuse
+        // to overwrite a constant owned by another layer rather than silently
+        // reassigning it. (The runtime user_has_cap filter still enforces the
+        // disable-editor toggle regardless of this file constant.)
+        define('DISALLOW_FILE_EDIT', false);
+
+        $editor = new WpConfigEditor($this->configPath);
+        $before = (string) file_get_contents($this->configPath);
+
+        $this->assertTrue($editor->setConstant('DISALLOW_FILE_EDIT', true));
+
+        $after = (string) file_get_contents($this->configPath);
+        $this->assertSame($before, $after, 'a conflicting runtime value must still never trigger a write');
+        $this->assertNotNull($editor->lastNotice());
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 5: HardeningModule::syncWpConfigFileEdit() — the actual #268 call
+    // path — returns success (no fatal, no error) when the constant is
+    // already defined.
+    // -------------------------------------------------------------------------
+
+    public function test_hardening_module_sync_wp_config_file_edit_succeeds_when_already_defined(): void
+    {
+        define('DISALLOW_FILE_EDIT', true);
+
+        // syncWpConfigFileEdit() constructs the DEFAULT (ABSPATH-resolved)
+        // WpConfigEditor, so a real wp-config.php must exist at ABSPATH for
+        // isWritable() to be true and the (skipped) write path to be
+        // reachable at all. bootstrap.php only creates dirname(ABSPATH), so
+        // create ABSPATH itself here (same convention as FileManagerCommandsTest).
+        $abspath = rtrim((string) constant('ABSPATH'), '/\\');
+        if (!is_dir($abspath)) {
+            mkdir($abspath, 0755, true);
+        }
+        $realConfigPath = $abspath . '/wp-config.php';
+        file_put_contents($realConfigPath, "<?php\n/* wp-config */\ndefine('DB_NAME', 'wp');\n");
+
+        try {
+            $config = HardeningConfig::fromArray(['config' => ['disable_file_editor' => true]]);
+            $module = new HardeningModule();
+
+            $result = $module->syncWpConfigFileEdit($config);
+
+            $this->assertTrue($result, 'must report success — never a fatal/error — when the constant is already enforced');
+            $this->assertNotNull(
+                $module->lastWpConfigNotice(),
+                'an informational (non-error) notice must be surfaced for the dashboard'
+            );
+
+            $after = (string) file_get_contents($realConfigPath);
+            $this->assertStringNotContainsString(
+                'DISALLOW_FILE_EDIT',
+                $after,
+                'no raw define may be inserted when the constant is already enforced elsewhere'
+            );
+        } finally {
+            @unlink($realConfigPath);
+        }
+    }
+}

--- a/apps/agent/tests/CacheWpConfigEditorTest.php
+++ b/apps/agent/tests/CacheWpConfigEditorTest.php
@@ -144,4 +144,75 @@ final class CacheWpConfigEditorTest extends TestCase
         $this->assertFalse($editor->setConstant('BAD NAME', true));
         $this->assertFalse($editor->setConstant('1BAD', true));
     }
+
+    public function test_set_constant_disallow_file_editor_writes_on_standard_wp(): void
+    {
+        // GH #268 baseline: standard WP (no framework markers, constant not
+        // defined) must be entirely unaffected by the managed-config guard —
+        // the define is inserted exactly as before.
+        $editor = $this->editor();
+        $this->assertTrue($editor->setConstant('DISALLOW_FILE_EDIT', true));
+
+        $content = (string) file_get_contents($this->configPath);
+        $this->assertStringContainsString("define('DISALLOW_FILE_EDIT', true); // Added by WPMgr Cache", $content);
+        $this->assertNull($editor->lastNotice(), 'a real write must not carry an informational notice');
+    }
+
+    // -------------------------------------------------------------------------
+    // GH #268 — Roots/Bedrock managed wp-config.php: never insert a raw define
+    // -------------------------------------------------------------------------
+
+    public function test_is_managed_wp_config_via_application_php_require_skips_write(): void
+    {
+        // Bedrock's own web/wp-config.php shape: no raw defines for WP
+        // constants at all — they live in the required config/application.php,
+        // which this test never actually requires (only the STRING signal
+        // matters to isManagedWpConfig()).
+        file_put_contents(
+            $this->configPath,
+            "<?php\nrequire_once __DIR__ . '/../config/application.php';\n"
+        );
+
+        $editor = $this->editor();
+        $before = (string) file_get_contents($this->configPath);
+
+        $this->assertTrue($editor->setConstant('DISALLOW_FILE_EDIT', true));
+
+        $after = (string) file_get_contents($this->configPath);
+        $this->assertSame($before, $after, 'a Bedrock-managed wp-config.php must be left byte-for-byte unchanged');
+        $this->assertStringNotContainsString('DISALLOW_FILE_EDIT', $after);
+        $this->assertNotNull($editor->lastNotice(), 'a managed-config skip must surface an informational notice');
+    }
+
+    public function test_is_managed_wp_config_via_roots_wpconfig_class_skips_write(): void
+    {
+        file_put_contents(
+            $this->configPath,
+            "<?php\nuse Roots\\WPConfig\\Config;\nConfig::define('WP_ENV', 'production');\n"
+        );
+
+        $editor = $this->editor();
+        $before = (string) file_get_contents($this->configPath);
+
+        $this->assertTrue($editor->setConstant('DISALLOW_FILE_EDIT', true));
+
+        $after = (string) file_get_contents($this->configPath);
+        $this->assertSame($before, $after, 'a Roots\\WPConfig\\Config-managed wp-config.php must be left unchanged');
+        $this->assertStringNotContainsString('DISALLOW_FILE_EDIT', $after);
+    }
+
+    public function test_remove_constant_on_managed_config_without_our_marker_is_a_safe_noop(): void
+    {
+        $managedContent = "<?php\nrequire_once __DIR__ . '/../config/application.php';\n";
+        file_put_contents($this->configPath, $managedContent);
+
+        $editor = $this->editor();
+
+        // Never had our marker (or any raw define for this name) — must be a
+        // clean no-op: no throw, file untouched.
+        $this->assertTrue($editor->removeConstant('DISALLOW_FILE_EDIT'));
+
+        $after = (string) file_get_contents($this->configPath);
+        $this->assertSame($managedContent, $after, 'removeConstant must not touch a managed wp-config.php that never had our define');
+    }
 }

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.81
+ * Version:           0.61.82
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.81');
+define('WPMGR_AGENT_VERSION', '0.61.82');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.81
+  version: 0.61.82
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Fixes **GH #268**: the "disable file editor" hardening toggle wrote a raw `define('DISALLOW_FILE_EDIT', true)` into `wp-config.php`. On Roots/Bedrock, `config/application.php` manages that constant via `Roots\WPConfig\Config::define()`, which throws `ConstantAlreadyDefinedException` on redefine → fatal every request.

### Fix
`WpConfigEditor::setConstant()` now guards before writing:
- No-op when the constant is already `defined()` at runtime (any Roots-managed constant is, by the time the CP command runs).
- Detects a framework-managed `wp-config.php` (`Roots\WPConfig\Config` / `roots/wp-config` / a require of `config/application.php`) and refuses to insert a raw define.
- Standard WordPress unchanged. Same guard protects the cache module's `WP_CACHE` write. An informational notice is surfaced through the hardening command's `detail`.

On Bedrock the toggle becomes a safe no-op, and disable-file-editor stays enforced via the runtime `user_has_cap` filter regardless of the constant. Already-broken sites recover by removing the marked line from `wp-config.php` (the agent can't self-heal a fatal that aborts before WP boots — covered in the issue reply).

### Verification
- Agent phpunit **2790 / 0** (7 new tests incl. a separate-process #268 regression: flipping the toggle when the constant is already defined writes nothing and doesn't fatal).
- phpcs **0**, `make agent-plugincheck` **0 errors**.
- **security-reviewer: SHIP** — no bypass, write-path safety intact, the different-value no-op is not a false-success (runtime cap filter enforces + notice surfaced).

Version-lockstep to 0.61.82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWiZ4iJ1fmYW8vtPghWmsn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the file editor hardening toggle on Roots/Bedrock and other framework-managed configurations.
  * Prevented fatal errors when security constants are already defined.
  * The toggle now safely reports success without modifying managed configuration files.
  * Applied the same protection to the full-page cache setting.

* **Release**
  * Updated the product version to 0.61.82.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->