### PR TITLE
fix(web): tri-state uptime badge so unknown never reads as "Up" (#272) — 0.61.83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.83] - 2026-07-23
+
+### Fixed
+
+- The Sites dashboard uptime badge could show a green "Up" for a site that had never been probed, or whose probe result had not synced yet (GH #272). The badge only special-cased the literal `false` value, so `null`/absent uptime data fell through to "Up" instead of a neutral state, which is the wrong failure mode during an incident (a fully-down, never-probed site could display green). The badge is now a proper three-state indicator: "Up" (green) only after an explicit successful probe, "Down" (red) after an explicit failed probe, and a neutral "Unknown" whenever the probe result is not yet known, on both the grid and table views of the Sites list.
+
 ## [0.61.82] - 2026-07-22
 
 ### Fixed

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.82
+ * Version:           0.61.83
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.82');
+define('WPMGR_AGENT_VERSION', '0.61.83');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/web/src/features/sites/site-card.test.ts
+++ b/apps/web/src/features/sites/site-card.test.ts
@@ -5,6 +5,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { relativeTime } from "@/lib/utils";
+import { siteUptimeBadge } from "@/features/sites/uptime-badge";
 
 // ---------------------------------------------------------------------------
 // SslChip — threshold logic
@@ -382,17 +383,39 @@ describe("uptime row — conditional rendering", () => {
     expect(site.uptime_pct != null).toBe(false);
   });
 
-  it("StatusDot uses destructive tone when up is false", () => {
-    function uptimeTone(up: boolean | undefined): "destructive" | "success" {
-      return up === false ? "destructive" : "success";
-    }
-    expect(uptimeTone(false)).toBe("destructive");
+  it("StatusDot uses success tone + 'Up' label when up is true", () => {
+    const badge = siteUptimeBadge(true);
+    expect(badge.tone).toBe("success");
+    expect(badge.label).toBe("Up");
+    expect(badge.status).toBe("up");
   });
 
-  it("StatusDot uses success tone when up is true", () => {
-    function uptimeTone(up: boolean | undefined): "destructive" | "success" {
-      return up === false ? "destructive" : "success";
-    }
-    expect(uptimeTone(true)).toBe("success");
+  it("StatusDot uses destructive tone + 'Down' label when up is false", () => {
+    const badge = siteUptimeBadge(false);
+    expect(badge.tone).toBe("destructive");
+    expect(badge.label).toBe("Down");
+    expect(badge.status).toBe("down");
+  });
+
+  // GH #272 regression: a never-probed (null/undefined) site must render as
+  // a neutral "Unknown", never as green "Up" — a fully-down site with no
+  // probe result yet must not display a false "Up" during an incident.
+  it("GH #272 — StatusDot uses a neutral (non-success) tone + 'Unknown' label when up is undefined", () => {
+    const badge = siteUptimeBadge(undefined);
+    expect(badge.tone).not.toBe("success");
+    expect(badge.tone).toBe("muted");
+    expect(badge.label).toBe("Unknown");
+    expect(badge.status).toBe("unknown");
+  });
+
+  it("GH #272 — StatusDot uses a neutral (non-success) tone + 'Unknown' label when up is null", () => {
+    // API-level `Site.up` is nullable at runtime (Go `*bool`) even though the
+    // generated TS type currently narrows to `boolean | undefined`; guard the
+    // explicit-null case defensively.
+    const badge = siteUptimeBadge(null);
+    expect(badge.tone).not.toBe("success");
+    expect(badge.tone).toBe("muted");
+    expect(badge.label).toBe("Unknown");
+    expect(badge.status).toBe("unknown");
   });
 });

--- a/apps/web/src/features/sites/site-card.tsx
+++ b/apps/web/src/features/sites/site-card.tsx
@@ -58,6 +58,7 @@ import {
 } from "@/features/sites/connection-state";
 import { SiteRowActions } from "@/features/sites/site-row-actions";
 import { SiteCardThumbnail } from "@/features/sites/site-card-thumbnail";
+import { siteUptimeBadge } from "@/features/sites/uptime-badge";
 import {
   CapabilityGroup,
   type CapabilityItem,
@@ -167,6 +168,8 @@ export function SiteCard({
   const backupTimeTitle = backupTime
     ? new Date(backupTime).toLocaleString()
     : undefined;
+  // GH #272 — tri-state (never green unless up === true); see uptime-badge.ts.
+  const uptimeBadge = siteUptimeBadge(site.up);
 
   const capabilityItems = buildCapabilityItems(site);
   const isCompact = cardSize === "compact";
@@ -400,12 +403,9 @@ export function SiteCard({
         <div className="flex min-h-5 items-center">
           {site.uptime_pct != null ? (
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <StatusDot
-                tone={site.up === false ? "destructive" : "success"}
-                label={site.up === false ? "Down" : "Up"}
-              />
+              <StatusDot tone={uptimeBadge.tone} label={uptimeBadge.label} />
               <span className="tabular-nums">
-                {site.up === false ? "Down" : "Up"}
+                {uptimeBadge.label}
                 {" · Uptime "}
                 <span className="font-medium text-foreground tabular-nums">
                   {site.uptime_pct.toFixed(2)}%

--- a/apps/web/src/features/sites/sites-table.tsx
+++ b/apps/web/src/features/sites/sites-table.tsx
@@ -56,6 +56,7 @@ import {
   type SitesSelection,
 } from "@/features/sites/use-sites-selection";
 import { SiteRowActions } from "@/features/sites/site-row-actions";
+import { siteUptimeBadge, siteUptimeTextClass } from "@/features/sites/uptime-badge";
 
 // Surface 4.5 — the Sites table.
 //
@@ -517,37 +518,30 @@ function buildColumns(
       cell: ({ row }) => {
         const { up, uptime_pct } = row.original.site;
         // Neither field present: site has never been probed.
-        if (up === undefined && uptime_pct === undefined) {
+        if (up == null && uptime_pct === undefined) {
           return <span aria-hidden="true" />;
         }
+        // GH #272 — tri-state (never green/foreground-as-ok unless
+        // up === true); see uptime-badge.ts.
+        const badge = siteUptimeBadge(up);
+        const toneClass = siteUptimeTextClass(badge.status);
         // Show the 30-day percentage when available, otherwise the live
-        // up/down indicator.
+        // up/down/unknown indicator.
         if (uptime_pct !== undefined) {
           const pct = uptime_pct.toFixed(1);
-          const isDown = up === false;
           return (
             <span
-              className={cn(
-                "tabular-nums text-xs font-medium",
-                isDown
-                  ? "text-[var(--color-destructive)]"
-                  : "text-[var(--color-foreground)]",
-              )}
+              className={cn("tabular-nums text-xs font-medium", toneClass)}
               title={`${pct}% uptime (30 days)`}
             >
               {pct}%
             </span>
           );
         }
-        // Only live up/down is available (no 30-day window yet).
+        // Only live up/down/unknown is available (no 30-day window yet).
         return (
-          <span
-            className={cn(
-              "text-xs font-medium",
-              up ? "text-[var(--color-foreground)]" : "text-[var(--color-destructive)]",
-            )}
-          >
-            {up ? "Up" : "Down"}
+          <span className={cn("text-xs font-medium", toneClass)}>
+            {badge.label}
           </span>
         );
       },

--- a/apps/web/src/features/sites/uptime-badge.test.ts
+++ b/apps/web/src/features/sites/uptime-badge.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for the Sites uptime badge helper (GH #272).
+ *
+ * Regression coverage: a never-probed site (`up` is `null` or `undefined`)
+ * must render as a neutral "Unknown", never as a green "Up" — a fully-down
+ * site with no probe result yet must not display a false "Up" during an
+ * incident.
+ */
+import { describe, it, expect } from "vitest";
+
+import { siteUptimeBadge, siteUptimeTextClass } from "@/features/sites/uptime-badge";
+
+describe("siteUptimeBadge — tri-state mapping (GH #272)", () => {
+  it("up === true -> 'Up' / success", () => {
+    expect(siteUptimeBadge(true)).toEqual({
+      status: "up",
+      label: "Up",
+      tone: "success",
+    });
+  });
+
+  it("up === false -> 'Down' / destructive", () => {
+    expect(siteUptimeBadge(false)).toEqual({
+      status: "down",
+      label: "Down",
+      tone: "destructive",
+    });
+  });
+
+  it("up === undefined -> 'Unknown' / muted (never success)", () => {
+    const badge = siteUptimeBadge(undefined);
+    expect(badge.status).toBe("unknown");
+    expect(badge.label).toBe("Unknown");
+    expect(badge.tone).toBe("muted");
+    expect(badge.tone).not.toBe("success");
+  });
+
+  it("up === null -> 'Unknown' / muted (never success)", () => {
+    const badge = siteUptimeBadge(null);
+    expect(badge.status).toBe("unknown");
+    expect(badge.label).toBe("Unknown");
+    expect(badge.tone).toBe("muted");
+    expect(badge.tone).not.toBe("success");
+  });
+});
+
+describe("siteUptimeTextClass — sites-table color mapping", () => {
+  it("uses the foreground token for up", () => {
+    expect(siteUptimeTextClass("up")).toBe("text-[var(--color-foreground)]");
+  });
+
+  it("uses the destructive token for down", () => {
+    expect(siteUptimeTextClass("down")).toBe(
+      "text-[var(--color-destructive)]",
+    );
+  });
+
+  it("uses the muted-foreground token for unknown (not destructive, not foreground)", () => {
+    const cls = siteUptimeTextClass("unknown");
+    expect(cls).toBe("text-[var(--color-muted-foreground)]");
+    expect(cls).not.toBe("text-[var(--color-destructive)]");
+    expect(cls).not.toBe("text-[var(--color-foreground)]");
+  });
+});

--- a/apps/web/src/features/sites/uptime-badge.ts
+++ b/apps/web/src/features/sites/uptime-badge.ts
@@ -1,0 +1,59 @@
+// GH #272 — tri-state uptime badge for the Sites list/grid.
+//
+// `Site.up` (`@wpmgr/api`) maps from the API's `UptimeUp *bool`: `true` after
+// an explicit successful probe, `false` after an explicit failed probe, and
+// `null`/`undefined` when the site has never been probed (or a probe result
+// has not synced yet). A prior version of the Sites badge only special-cased
+// the literal `false`, so `null`/`undefined` fell through to a green "Up" —
+// a fully-down, never-probed site could read as healthy during an incident.
+//
+// This helper is the single source of truth for that mapping so the grid
+// (site-card.tsx) and the table (sites-table.tsx) can't drift apart again.
+// It intentionally mirrors the fleet dashboard's unknown handling
+// (features/fleet/uptime-status.ts STATUS_COLOR_CLASS.unknown = muted) for
+// visual consistency across the app, but stays a dedicated helper rather
+// than reusing features/monitoring/uptime-badges-helpers.ts — that helper's
+// `statusFromItem`/`statusFromStatus` key off a different field
+// (`last_check`) for a different data shape (UptimeSummaryItem/UptimeStatus)
+// and changing its `up` fallback would affect unrelated monitoring callers.
+
+import type { StatusTone } from "@/components/status/status-dot";
+
+export type SiteUpDown = "up" | "down" | "unknown";
+
+export interface SiteUptimeBadge {
+  status: SiteUpDown;
+  /** Human-readable label ("Up" / "Down" / "Unknown"). */
+  label: string;
+  /** Semantic tone for StatusDot/StatusChip-style consumers. */
+  tone: StatusTone;
+}
+
+/**
+ * Derive the tri-state uptime badge from `Site.up`.
+ *
+ * The core invariant: the badge is green ("up") ONLY when there is an
+ * explicit "up" probe result. `null` and `undefined` both mean "we don't
+ * know" and must render as a neutral "Unknown", never as "Up".
+ */
+export function siteUptimeBadge(up: boolean | null | undefined): SiteUptimeBadge {
+  if (up === true) return { status: "up", label: "Up", tone: "success" };
+  if (up === false) return { status: "down", label: "Down", tone: "destructive" };
+  return { status: "unknown", label: "Unknown", tone: "muted" };
+}
+
+/**
+ * Text-color class for callers (sites-table.tsx) that color plain text
+ * instead of rendering a `StatusDot`. Keyed off `status` (not re-deriving
+ * from `up`) so it always agrees with `siteUptimeBadge`.
+ */
+export function siteUptimeTextClass(status: SiteUpDown): string {
+  switch (status) {
+    case "up":
+      return "text-[var(--color-foreground)]";
+    case "down":
+      return "text-[var(--color-destructive)]";
+    case "unknown":
+      return "text-[var(--color-muted-foreground)]";
+  }
+}

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.82
+  version: 0.61.83
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Fixes **GH #272**: the Sites uptime badge rendered `site.up === false ? "Down" : "Up"`, so `null`/`undefined` (never probed) **failed open to a green "Up"** — a fully-down, unprobed site could look healthy during an incident.

### Fix
New shared helper `siteUptimeBadge(up)` (single source of truth):
- `up === true` → "Up" / success
- `up === false` → "Down" / destructive
- `up == null` → **"Unknown" / muted** (neutral, non-green, mirroring the fleet view's unknown tone)

Both the card and the table route through it (the drift happened because the same fail-open ternary was copied). The table's never-probed guard now also catches explicit `null`. **Green appears only on an explicit up probe result.** Not conflating agent-reachability into this badge (separate signal).

### Verification
- Web vitest **1146 tests green**, including new `uptime-badge.test.ts` + two named GH #272 regression tests asserting `null`/`undefined` render "Unknown" with a non-`success` tone.
- `vite build` clean; single-file eslint clean; impeccable-detect clean on the sites feature.

Version-lockstep to 0.61.83 (CHANGELOG, openapi `info.version`, unified version stamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWiZ4iJ1fmYW8vtPghWmsn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Sites uptime badges incorrectly showing “Up” when uptime data is unavailable.
  * Badges now clearly display “Up,” “Down,” or “Unknown” based on the available probe result.
  * Updated uptime table styling and display behavior for unknown or incomplete data.

* **Chores**
  * Updated the application release version to 0.61.83.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->