### PR TITLE
fix: backups time out on OpenLiteSpeed + already-running misreported as failure (#274) — 0.61.84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.84] - 2026-07-23
+
+### Fixed
+
+- Backups no longer time out on OpenLiteSpeed and LiteSpeed servers (GH #274). The agent acknowledges a backup request to the control plane and then continues the work in the background; it previously released that acknowledgment using a PHP-FPM-only mechanism, which OpenLiteSpeed's PHP does not provide, so the connection stayed open for the entire backup and a reverse proxy in front of the control plane eventually timed it out. The agent now releases the acknowledgment using whichever mechanism the site's server actually supports, covering PHP-FPM, OpenLiteSpeed and LiteSpeed, and any other server as a last resort. A backup or restore that was already running when a duplicate request arrived is also no longer misreported as failed to the operator or left orphaned in the dashboard; the control plane now recognizes this specific case and keeps tracking the original run instead.
+
 ## [0.61.83] - 2026-07-23
 
 ### Fixed

--- a/apps/agent/assets/wpmgr-advanced-cache.php
+++ b/apps/agent/assets/wpmgr-advanced-cache.php
@@ -461,8 +461,15 @@ if ($wpmgr_method === 'HEAD') {
 readfile($wpmgr_file); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_readfile -- advanced-cache drop-in streams the cached body before WordPress is loaded; readfile is the canonical low-memory emit
 
 // Flush to the client before the loopback kick so the visitor never waits.
+// This file runs BEFORE the plugin autoloader (it's a WordPress drop-in), so
+// it cannot use the WPMgr\Agent\Support\ConnectionFinisher class — the same
+// fastcgi/litespeed/fallback ladder is kept inline here instead. The
+// litespeed_finish_request() rung covers OpenLiteSpeed hosts (GH #274), which
+// have no fastcgi_finish_request().
 if (function_exists('fastcgi_finish_request')) {
     @fastcgi_finish_request(); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort FPM flush; failure falls back to ob_end_flush below
+} elseif (function_exists('litespeed_finish_request')) {
+    @litespeed_finish_request(); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- OpenLiteSpeed/LiteSpeed equivalent of fastcgi_finish_request (GH #274); best-effort, falls back to ob_end_flush below
 } else {
     @ob_end_flush(); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort flush; not all SAPI/OB setups support this
     flush();

--- a/apps/agent/includes/backup/class-encrypt-and-upload.php
+++ b/apps/agent/includes/backup/class-encrypt-and-upload.php
@@ -193,8 +193,9 @@ final class EncryptAndUpload
      */
     public function encryptChunks(string $scratchDir, array $artifacts, array $resume, callable $progress): array
     {
-        // Lift caller-imposed time/abort guards. We may be running inside an
-        // FPM request that has already called fastcgi_finish_request().
+        // Lift caller-imposed time/abort guards. We may be running inside a
+        // request that has already released the client connection via the
+        // SAPI-aware finish (fastcgi/litespeed/fallback — see ConnectionFinisher).
         @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running encrypt pass must not hit max_execution_time; @-guarded, no-op when disabled
         @ignore_user_abort(true);
 

--- a/apps/agent/includes/backup/class-task-runner.php
+++ b/apps/agent/includes/backup/class-task-runner.php
@@ -4,8 +4,9 @@
  * `wpmgr_backup_tasks` into a completed backup snapshot.
  *
  * This is the only "active" component in the state-machine pipeline: the
- * REST handler (Phase D) writes the task row, calls fastcgi_finish_request(),
- * then invokes TaskRunner::run() in the same PHP process. The watchdog hook
+ * REST handler (Phase D) writes the task row, calls the SAPI-aware finish
+ * (fastcgi/litespeed/fallback — see ConnectionFinisher), then invokes
+ * TaskRunner::run() in the same PHP process. The watchdog hook
  * (also Phase D) calls TaskRunner::run() on re-entry. Both entry points are
  * idempotent — the state machine reads `phase` + `sub_state` and resumes from
  * wherever the last invocation left off.

--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -116,6 +116,7 @@ use WPMgr\Agent\Media\MediaUploader;
 use WPMgr\Agent\Media\Rename;
 use WPMgr\Agent\Support\ActivityLog;
 use WPMgr\Agent\Support\AgeIdentity;
+use WPMgr\Agent\Support\ConnectionFinisher;
 use WPMgr\Agent\Support\ErrorMonitor;
 use WPMgr\Agent\Support\LoginBrand;
 use WPMgr\Agent\Support\LoginProtection;
@@ -1881,15 +1882,16 @@ final class Plugin
         // block above.
         $this->shipLoginEvents();
 
-        // Reliable-diagnostics opportunistic warm: if the PHP-FPM fast-finish
-        // hook is available, release the HTTP response to the CP first, then
-        // run a size probe to warm the cache for the next push. On a kill mid-
-        // walk (request_terminate_timeout) the previously-persisted last-good
-        // remains intact. On non-FPM SAPIs the probe still runs in-process but
-        // is in a non-blocking position (response already shipped via cron).
-        if (function_exists('fastcgi_finish_request')) {
-            fastcgi_finish_request();
-        }
+        // Reliable-diagnostics opportunistic warm: release the HTTP response
+        // to the CP first via the SAPI-aware ConnectionFinisher (fastcgi on
+        // PHP-FPM, litespeed_finish_request on OpenLiteSpeed — GH #274 — or a
+        // portable fallback), then run a size probe to warm the cache for the
+        // next push. On a kill mid-walk (request_terminate_timeout) the
+        // previously-persisted last-good remains intact. This is a cron
+        // loopback, not a CP-facing request, so there is no CP-side 504 risk
+        // here either way — adopted for symmetry with the other early-ACK
+        // sites.
+        (new ConnectionFinisher())->finish();
         if (function_exists('set_time_limit')) {
             @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup/restore loop must not hit max_execution_time; @-guarded
         }

--- a/apps/agent/includes/commands/class-backup-command.php
+++ b/apps/agent/includes/commands/class-backup-command.php
@@ -14,8 +14,10 @@
  *   3. Persist the TaskRunner params into `wpmgr_backup_tasks.sub_state.params`
  *      so the watchdog can rehydrate the runner on a stall recovery.
  *   4. Schedule the watchdog cron event for +120s.
- *   5. `fastcgi_finish_request()` to release the HTTP response to the CP in
- *      well under a second.
+ *   5. The SAPI-aware finish (fastcgi/litespeed/fallback — see
+ *      ConnectionFinisher) to release the HTTP response to the CP in well
+ *      under a second, regardless of whether the host runs PHP-FPM or
+ *      OpenLiteSpeed (GH #274).
  *   6. Continue running under `ignore_user_abort(true)`: invoke
  *      `TaskRunner::run()` which drives the dumping_db → archiving_files →
  *      encrypting_uploading → submitting_manifest pipeline, persisting
@@ -42,13 +44,15 @@ use WPMgr\Agent\Backup\TaskRunner;
 use WPMgr\Agent\Backup\Watchdog;
 use WPMgr\Agent\Schema;
 use WPMgr\Agent\Support\AgeIdentity;
+use WPMgr\Agent\Support\ConnectionFinisher;
 use WPMgr\Agent\Support\DebugLog;
 use WPMgr\Agent\Support\LongRunningJob;
 
 /**
  * Accepts a `backup` command from the CP, seeds the task row, and drives
- * the backup state machine. The HTTP response is released early via
- * `fastcgi_finish_request()` so the CP sees the ACK in well under a second
+ * the backup state machine. The HTTP response is released early via the
+ * SAPI-aware ConnectionFinisher (fastcgi/litespeed/fallback) so the CP sees
+ * the ACK in well under a second, on PHP-FPM or OpenLiteSpeed (GH #274),
  * while the real work continues under `ignore_user_abort(true)`.
  */
 final class BackupCommand implements CommandInterface
@@ -69,9 +73,16 @@ final class BackupCommand implements CommandInterface
 
     private AgeIdentity $identity;
 
-    public function __construct(AgeIdentity $identity)
+    private ConnectionFinisher $finisher;
+
+    /**
+     * @param AgeIdentity             $identity Backup-encryption identity/recipient checks.
+     * @param ConnectionFinisher|null $finisher Injected for tests; defaults to a real ladder.
+     */
+    public function __construct(AgeIdentity $identity, ?ConnectionFinisher $finisher = null)
     {
         $this->identity = $identity;
+        $this->finisher = $finisher ?? new ConnectionFinisher();
     }
 
     public function name(): string
@@ -84,7 +95,7 @@ final class BackupCommand implements CommandInterface
      *
      * @param array<string,mixed> $claims Validated JWT claims (unused — Connector verified them).
      * @param array<string,mixed> $params BackupRequest fields.
-     * @return array{ok:bool,detail:string}
+     * @return array{ok:bool,detail:string,code?:string}
      */
     public function execute(array $claims, array $params): array
     {
@@ -188,7 +199,7 @@ final class BackupCommand implements CommandInterface
         // command uses to self-heal a stale install.
         Schema::ensureCurrent();
         if (!$this->tryClaimDedup($snapshotId)) {
-            return $this->refuse('runner already in flight for this snapshot');
+            return $this->refuse('runner already in flight for this snapshot', 'runner_in_flight');
         }
 
         // --- 3. Prepare scratch + assemble runner params ------------------
@@ -280,16 +291,19 @@ final class BackupCommand implements CommandInterface
         // cron health.
         //
         //   1. A PHP shutdown handler (fires after execute() returns and WP
-        //      REST flushes the response body to FPM) calls
-        //      fastcgi_finish_request() (defensive — WP has usually already
-        //      closed its output buffers) then runs TaskRunner::run()
-        //      directly in the same PHP process.
+        //      REST flushes the response body) calls the SAPI-aware
+        //      ConnectionFinisher (defensive — WP has usually already closed
+        //      its output buffers) then runs TaskRunner::run() directly in
+        //      the same PHP process. ConnectionFinisher tries
+        //      fastcgi_finish_request() (PHP-FPM), then
+        //      litespeed_finish_request() (OpenLiteSpeed — GH #274), then a
+        //      portable best-effort flush.
         //   2. execute() returns the ACK normally. The CP sees 200 < 1 s.
-        //   3. The FPM worker runs the backup while the FCGI connection is
-        //      closed (fastcgi_finish_request). On hosts where
-        //      fastcgi_finish_request does not fully close the upstream
-        //      connection, ignore_user_abort(true) + a bounded set_time_limit()
-        //      ensure the runner is not killed mid-backup.
+        //   3. The worker runs the backup while the connection has been
+        //      released by ConnectionFinisher. On hosts where none of the
+        //      finish-request functions fully close the upstream connection,
+        //      ignore_user_abort(true) + a bounded set_time_limit() ensure
+        //      the runner is not killed mid-backup.
         //
         // wp_schedule_single_event('wpmgr_backup_run') + spawn_cron() below
         // are KEPT as secondary triggers (they preserve the #131 watchdog +
@@ -318,16 +332,18 @@ final class BackupCommand implements CommandInterface
 
         // Capture the params in a local variable so the closure does not
         // hold a reference to $this (which would keep the entire
-        // BackupCommand object alive through the shutdown chain).
+        // BackupCommand object alive through the shutdown chain). $finisher
+        // is captured too — it is a small, stateless collaborator (no $this
+        // reference of its own), so this doesn't reintroduce the leak.
         $shutdownParams = $runnerParams;
-        register_shutdown_function(static function () use ($shutdownParams): void {
-            // fastcgi_finish_request() is only available under PHP-FPM.
-            // Call it defensively: WP has already closed its own output
-            // buffers before shutdown handlers run, so the response was
-            // most likely already sent. This is a belt-and-suspenders flush.
-            if (function_exists('fastcgi_finish_request')) {
-                fastcgi_finish_request(); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- intentional early-flush of the FCGI connection so the CP receives the ACK before TaskRunner runs
-            }
+        $finisher       = $this->finisher;
+        register_shutdown_function(static function () use ($shutdownParams, $finisher): void {
+            // The SAPI-aware finish. Called defensively: WP has already
+            // closed its own output buffers before shutdown handlers run, so
+            // the response was most likely already sent. This is a
+            // belt-and-suspenders flush that also covers OpenLiteSpeed
+            // (GH #274), which has no fastcgi_finish_request().
+            $finisher->finish();
             @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running backup runner must not hit max_execution_time; @-guarded
             @ignore_user_abort(true);
             try {
@@ -539,10 +555,22 @@ final class BackupCommand implements CommandInterface
         return false;
     }
 
-    /** Refusal response — the agent didn't accept the job. */
-    private function refuse(string $detail): array
+    /**
+     * Refusal response — the agent didn't accept the job.
+     *
+     * @param string $detail Human-readable reason (unchanged wire field).
+     * @param string $code   Optional stable machine code for the CP to branch
+     *                       on (e.g. 'runner_in_flight'). Empty string omits
+     *                       the field entirely — most refusals carry no code.
+     * @return array{ok:bool,detail:string,code?:string}
+     */
+    private function refuse(string $detail, string $code = ''): array
     {
-        return ['ok' => false, 'detail' => $detail];
+        $response = ['ok' => false, 'detail' => $detail];
+        if ($code !== '') {
+            $response['code'] = $code;
+        }
+        return $response;
     }
 
     /** @param array<string,mixed> $params */

--- a/apps/agent/includes/commands/class-db-clean-command.php
+++ b/apps/agent/includes/commands/class-db-clean-command.php
@@ -18,10 +18,12 @@
  * Async model:
  *   execute() returns the ACK immediately via the REST HTTP response, then
  *   register_shutdown_function runs the actual cleanup AFTER the response is
- *   flushed.  On PHP-FPM, fastcgi_finish_request() closes the client connection
- *   while the worker process keeps running; on mod_php the connection stays open
- *   until the shutdown callback completes (acceptable — the CP client's timeout
- *   covers only the ACK round-trip).
+ *   flushed, via the SAPI-aware ConnectionFinisher (fastcgi/litespeed/
+ *   fallback — see ConnectionFinisher). On PHP-FPM or OpenLiteSpeed the
+ *   client connection is closed while the worker process keeps running; on
+ *   any other SAPI the connection stays open until the shutdown callback
+ *   completes (acceptable — the CP client's timeout covers only the ACK
+ *   round-trip).
  *
  *   After each category the agent POSTs one progress push to progress_endpoint
  *   (signed with its Ed25519 key, mirroring PerfReporter).  The final push has
@@ -41,6 +43,7 @@ use WPMgr\Agent\Keystore;
 use WPMgr\Agent\Settings;
 use WPMgr\Agent\Signer;
 use WPMgr\Agent\Optimizer\DbCleanup;
+use WPMgr\Agent\Support\ConnectionFinisher;
 use WPMgr\Agent\Support\LongRunningJob;
 
 /**
@@ -83,19 +86,24 @@ final class DbCleanCommand implements CommandInterface
 
     private ?Settings $settings;
 
+    private ConnectionFinisher $finisher;
+
     /**
-     * @param DbCleanup|null $cleanup  Injected for tests; defaults to a live engine.
-     * @param Keystore|null  $keystore Injected for tests; defaults to a fresh keystore.
-     * @param Settings|null  $settings Injected for tests; defaults to a fresh settings.
+     * @param DbCleanup|null          $cleanup  Injected for tests; defaults to a live engine.
+     * @param Keystore|null           $keystore Injected for tests; defaults to a fresh keystore.
+     * @param Settings|null           $settings Injected for tests; defaults to a fresh settings.
+     * @param ConnectionFinisher|null $finisher Injected for tests; defaults to a real ladder.
      */
     public function __construct(
         ?DbCleanup $cleanup = null,
         ?Keystore $keystore = null,
-        ?Settings $settings = null
+        ?Settings $settings = null,
+        ?ConnectionFinisher $finisher = null
     ) {
         $this->cleanup  = $cleanup;
         $this->keystore = $keystore;
         $this->settings = $settings;
+        $this->finisher = $finisher ?? new ConnectionFinisher();
     }
 
     /**
@@ -153,6 +161,7 @@ final class DbCleanCommand implements CommandInterface
         $capturedEngine   = $engine;
         $capturedKeystore = $this->keystore;
         $capturedSettings = $this->settings;
+        $capturedFinisher = $this->finisher;
 
         register_shutdown_function(
             static function () use (
@@ -161,14 +170,14 @@ final class DbCleanCommand implements CommandInterface
                 $capturedEndpoint,
                 $capturedEngine,
                 $capturedKeystore,
-                $capturedSettings
+                $capturedSettings,
+                $capturedFinisher
             ): void {
-                // On PHP-FPM: close the client connection while this worker
-                // process keeps running so the CP's ACK read completes before
-                // the (potentially long) cleanup loop starts.
-                if (function_exists('fastcgi_finish_request')) {
-                    fastcgi_finish_request();
-                }
+                // Release the client connection (SAPI-aware: PHP-FPM,
+                // OpenLiteSpeed — GH #274 — or a portable fallback) while
+                // this worker process keeps running, so the CP's ACK read
+                // completes before the (potentially long) cleanup loop starts.
+                $capturedFinisher->finish();
 
                 // Expand execution budget — cleanup can be slow on large sites.
                 if (function_exists('set_time_limit')) {

--- a/apps/agent/includes/commands/class-db-orphan-delete-command.php
+++ b/apps/agent/includes/commands/class-db-orphan-delete-command.php
@@ -19,9 +19,10 @@
  * Async model:
  *   execute() returns the ACK immediately via the REST HTTP response, then
  *   register_shutdown_function runs the actual deletions AFTER the response is
- *   flushed. The full items[] array (kind + name + owner_slug) is captured into
- *   the closure by value — NOT just item names — so live re-verify has all fields
- *   available at delete time.
+ *   flushed, via the SAPI-aware ConnectionFinisher (fastcgi/litespeed/
+ *   fallback — see ConnectionFinisher). The full items[] array (kind + name +
+ *   owner_slug) is captured into the closure by value — NOT just item names —
+ *   so live re-verify has all fields available at delete time.
  *
  *   After each batch of up to BATCH_SIZE items the agent POSTs one progress push
  *   to progress_endpoint (signed with its Ed25519 key, same pattern as
@@ -54,6 +55,7 @@ use WPMgr\Agent\Keystore;
 use WPMgr\Agent\Settings;
 use WPMgr\Agent\Signer;
 use WPMgr\Agent\Optimizer\DbCleanup;
+use WPMgr\Agent\Support\ConnectionFinisher;
 use WPMgr\Agent\Support\LongRunningJob;
 
 /**
@@ -171,22 +173,27 @@ final class DbOrphanDeleteCommand implements CommandInterface
     /** @var object|null Injected $wpdb (tests); defaults to global. */
     private ?object $wpdb;
 
+    private ConnectionFinisher $finisher;
+
     /**
-     * @param DbCleanup|null $cleanup  Injected for tests; defaults to a live engine.
-     * @param Keystore|null  $keystore Injected for tests; defaults to a fresh keystore.
-     * @param Settings|null  $settings Injected for tests; defaults to a fresh settings.
-     * @param object|null    $wpdb     Injected for tests; defaults to global $wpdb.
+     * @param DbCleanup|null          $cleanup  Injected for tests; defaults to a live engine.
+     * @param Keystore|null           $keystore Injected for tests; defaults to a fresh keystore.
+     * @param Settings|null           $settings Injected for tests; defaults to a fresh settings.
+     * @param object|null             $wpdb     Injected for tests; defaults to global $wpdb.
+     * @param ConnectionFinisher|null $finisher Injected for tests; defaults to a real ladder.
      */
     public function __construct(
         ?DbCleanup $cleanup = null,
         ?Keystore $keystore = null,
         ?Settings $settings = null,
-        ?object $wpdb = null
+        ?object $wpdb = null,
+        ?ConnectionFinisher $finisher = null
     ) {
         $this->cleanup  = $cleanup;
         $this->keystore = $keystore;
         $this->settings = $settings;
         $this->wpdb     = $wpdb ?? (isset($GLOBALS['wpdb']) && is_object($GLOBALS['wpdb']) ? $GLOBALS['wpdb'] : null);
+        $this->finisher = $finisher ?? new ConnectionFinisher();
     }
 
     /**
@@ -270,6 +277,7 @@ final class DbOrphanDeleteCommand implements CommandInterface
         $capturedCleanup  = $this->cleanup;
         $capturedKeystore = $this->keystore;
         $capturedWpdb     = $this->wpdb;
+        $capturedFinisher = $this->finisher;
 
         register_shutdown_function(
             static function () use (
@@ -278,14 +286,14 @@ final class DbOrphanDeleteCommand implements CommandInterface
                 $capturedEndpoint,
                 $capturedCleanup,
                 $capturedKeystore,
-                $capturedWpdb
+                $capturedWpdb,
+                $capturedFinisher
             ): void {
-                // On PHP-FPM: close the client connection while this worker
-                // process keeps running so the CP's ACK read completes before
-                // the delete loop starts.
-                if (function_exists('fastcgi_finish_request')) {
-                    fastcgi_finish_request();
-                }
+                // Release the client connection (SAPI-aware: PHP-FPM,
+                // OpenLiteSpeed — GH #274 — or a portable fallback) while
+                // this worker process keeps running so the CP's ACK read
+                // completes before the delete loop starts.
+                $capturedFinisher->finish();
 
                 // Expand execution budget — delete loops can be slow on large sites.
                 if (function_exists('set_time_limit')) {

--- a/apps/agent/includes/commands/class-restore-command.php
+++ b/apps/agent/includes/commands/class-restore-command.php
@@ -94,7 +94,7 @@ final class RestoreCommand implements CommandInterface
      *
      * @param array<string,mixed> $claims Validated JWT claims (unused).
      * @param array<string,mixed> $params RestoreRequest fields.
-     * @return array{ok:bool,detail:string}
+     * @return array{ok:bool,detail:string,code?:string}
      */
     public function execute(array $claims, array $params): array
     {
@@ -154,7 +154,7 @@ final class RestoreCommand implements CommandInterface
         // --- 2. Dedup claim ------------------------------------------------
         Schema::ensureCurrent();
         if (!$this->tryClaimDedup($snapshotId, $restoreId)) {
-            return $this->refuse('runner already in flight for this restore');
+            return $this->refuse('runner already in flight for this restore', 'runner_in_flight');
         }
 
         // --- 3. Prepare scratch dir + assemble runner params --------------
@@ -475,11 +475,19 @@ final class RestoreCommand implements CommandInterface
     /**
      * Refusal response.
      *
-     * @return array{ok:bool,detail:string}
+     * @param string $detail Human-readable reason (unchanged wire field).
+     * @param string $code   Optional stable machine code for the CP to branch
+     *                       on (e.g. 'runner_in_flight'). Empty string omits
+     *                       the field entirely — most refusals carry no code.
+     * @return array{ok:bool,detail:string,code?:string}
      */
-    private function refuse(string $detail): array
+    private function refuse(string $detail, string $code = ''): array
     {
-        return ['ok' => false, 'detail' => $detail];
+        $response = ['ok' => false, 'detail' => $detail];
+        if ($code !== '') {
+            $response['code'] = $code;
+        }
+        return $response;
     }
 
     /** @param array<string,mixed> $params */

--- a/apps/agent/includes/diagnostics/class-size-probe.php
+++ b/apps/agent/includes/diagnostics/class-size-probe.php
@@ -5,7 +5,8 @@
  * Owns ALL size logic so DiagnosticsCommand::execute() never blocks the daily
  * push on a tree walk. The push reads last-good from wp_options; the walk runs
  * in a dedicated WP-Cron event (wpmgr_agent_sizes_daily) and optionally after
- * fastcgi_finish_request has released the push response.
+ * the SAPI-aware finish (fastcgi/litespeed/fallback — see ConnectionFinisher)
+ * has released the push response.
  *
  * Computation order (first success wins per directory):
  *   1. `du -sb <dir>` — O(1) on most Linux/macOS hosts. Gated by
@@ -167,8 +168,8 @@ final class SizeProbe
      *
      * Safe to call under a dedicated cron event (a bounded set_time_limit() is called
      * by the handler in Plugin::registerHooks before invoking this). Also safe
-     * to call after fastcgi_finish_request — a PHP-FPM kill mid-walk leaves
-     * the previously-persisted last-good intact.
+     * to call after the SAPI-aware finish (fastcgi/litespeed/fallback) — a
+     * mid-walk kill leaves the previously-persisted last-good intact.
      *
      * @return array<string,mixed> The persisted blob (same shape as lastGood()).
      */

--- a/apps/agent/includes/support/class-connection-finisher.php
+++ b/apps/agent/includes/support/class-connection-finisher.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * ConnectionFinisher: the SAPI-aware "flush the response, keep the worker
+ * running" seam shared by every in-process early-ACK command.
+ *
+ * WordPress agent commands (backup, db_clean, db_orphan_delete, the daily
+ * diagnostics push) ACK a control-plane request in well under a second and
+ * then continue heavy work in the SAME PHP worker via
+ * register_shutdown_function(). Releasing the HTTP response to the client
+ * BEFORE that heavy work starts is what keeps the control plane — and any
+ * reverse proxy in front of it — from holding the connection open (and
+ * eventually timing out) for the full duration of the job.
+ *
+ * GitHub issue #274: this used to be ONLY fastcgi_finish_request(), gated by
+ * function_exists(). That function is PHP-FPM-specific. OpenLiteSpeed's PHP
+ * SAPI is `litespeed`, which does NOT expose fastcgi_finish_request() (the
+ * LSAPI alias was disabled in php-src) — but DOES expose the equivalent
+ * litespeed_finish_request() (LSAPI >= 7.3, present on every current
+ * OpenLiteSpeed build). Without that second rung, a LiteSpeed host had no
+ * early flush at all: the worker held the HTTP response open for the entire
+ * backup, and a reverse proxy in front of the control plane (e.g. Nginx
+ * Proxy Manager) 504'd waiting on the header read.
+ *
+ * Ladder (first available rung wins):
+ *   1. fastcgi_finish_request() — PHP-FPM.
+ *   2. litespeed_finish_request() — OpenLiteSpeed / LiteSpeed (GH #274).
+ *   3. A portable best-effort flush — every other SAPI (mod_php, the CLI
+ *      dev server, etc). This does NOT truly detach the connection — there
+ *      is no portable equivalent — which is exactly why it is only ever
+ *      reached as the last rung.
+ *
+ * The three collaborators (availability probe, invocation, fallback) are
+ * constructor-injected so every rung is unit testable without a real SAPI —
+ * LiteSpeed cannot be reproduced in CI.
+ *
+ * @package WPMgr\Agent\Support
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Support;
+
+if (!defined('ABSPATH')) {
+    exit; // No direct access.
+}
+
+/**
+ * SAPI-aware early-flush ladder: fastcgi_finish_request -> litespeed_finish_request -> fallback.
+ */
+final class ConnectionFinisher
+{
+    /** @var callable(string):bool */
+    private $available;
+
+    /** @var callable(string):void */
+    private $invoke;
+
+    /** @var callable():void */
+    private $fallback;
+
+    /**
+     * @param callable(string):bool|null $available Returns whether the named
+     *        global function exists. Defaults to function_exists().
+     * @param callable(string):void|null $invoke     Invokes the named global
+     *        function with no arguments. Reached ONLY after $available has
+     *        already returned true for that same name, so it can never be
+     *        asked to dispatch a function that isn't there. Defaults to
+     *        calling it directly.
+     * @param callable():void|null       $fallback   The last-rung flush, used
+     *        when neither finish-request function is available. Defaults to
+     *        defaultFallbackFlush().
+     */
+    public function __construct(?callable $available = null, ?callable $invoke = null, ?callable $fallback = null)
+    {
+        $this->available = $available ?? static fn (string $fn): bool => function_exists($fn);
+        $this->invoke    = $invoke ?? static function (string $fn): void {
+            $fn();
+        };
+        $this->fallback  = $fallback ?? static function (): void {
+            self::defaultFallbackFlush();
+        };
+    }
+
+    /**
+     * Release the HTTP response to the client using the best mechanism this
+     * SAPI offers.
+     *
+     * @return string One of 'fpm' | 'litespeed' | 'fallback' — which rung fired.
+     */
+    public function finish(): string
+    {
+        if (($this->available)('fastcgi_finish_request')) {
+            ($this->invoke)('fastcgi_finish_request'); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- intentional early-flush of the FCGI connection so the caller receives the ACK before the heavy work runs
+            return 'fpm';
+        }
+
+        if (($this->available)('litespeed_finish_request')) {
+            ($this->invoke)('litespeed_finish_request'); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- OpenLiteSpeed/LiteSpeed equivalent of fastcgi_finish_request (GH #274); LSAPI >= 7.3
+            return 'litespeed';
+        }
+
+        ($this->fallback)();
+        return 'fallback';
+    }
+
+    /**
+     * Best-effort flush for SAPIs offering neither finish-request function
+     * (mod_php, the CLI dev server, etc). This does NOT truly detach the
+     * connection — there is no portable equivalent for that — which is why
+     * it is only ever reached as the last rung of finish().
+     *
+     * The ACK body was already echoed by WP REST before this runs (finish()
+     * is invoked from a register_shutdown_function callback, which fires
+     * AFTER the response body has been sent), so this must NOT — and does
+     * NOT — echo a second body. It only flushes what is already buffered and
+     * signals the peer that the response is complete.
+     *
+     * @return void
+     */
+    private static function defaultFallbackFlush(): void
+    {
+        ignore_user_abort(true);
+
+        if (!headers_sent()) {
+            header('Connection: close');
+            header('Content-Encoding: none'); // defeat gzip so the peer sees a complete response
+        }
+
+        while (ob_get_level() > 0) {
+            @ob_end_flush(); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort flush; not all SAPI/OB setups support this
+        }
+        @flush(); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort flush; not all SAPI/OB setups support this
+    }
+}

--- a/apps/agent/patchwork.json
+++ b/apps/agent/patchwork.json
@@ -23,6 +23,9 @@
     "disk_total_space",
     "disk_free_space",
     "set_error_handler",
-    "register_shutdown_function"
+    "register_shutdown_function",
+    "ob_get_level",
+    "ob_end_flush",
+    "flush"
   ]
 }

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -185,6 +185,9 @@ This plugin ships two minified JavaScript files. Their human-readable source and
 
 The entries below summarize the notable changes since 0.36.0. This project ships frequently; not every intermediate patch release is listed here individually -- see the full history at https://github.com/mosamlife/wpmgr/blob/main/CHANGELOG.md.
 
+= 0.61.84 =
+* Fixed: backups no longer time out on OpenLiteSpeed and LiteSpeed servers (GH #274). The agent acknowledges a backup request and continues the work in the background; it previously released that acknowledgment using a PHP-FPM-only mechanism, which OpenLiteSpeed's PHP does not provide, so the connection stayed open for the entire backup. The agent now releases the acknowledgment using whichever mechanism the site's server actually supports.
+
 = 0.61.82 =
 * Fixed: the "disable file editor" hardening toggle could fatal every request on a Roots/Bedrock site (GH #268). Roots/Bedrock manages that constant through its own config layer and throws when it is defined a second time; the agent now checks whether it is already defined (or the config file is otherwise framework-managed) before writing anything, so nothing is written in that case and the toggle still reports success. Standard WordPress installs are unaffected. The full-page cache's WP_CACHE constant is protected the same way.
 

--- a/apps/agent/tests/Backup/BackupConnectionFinisherTest.php
+++ b/apps/agent/tests/Backup/BackupConnectionFinisherTest.php
@@ -1,0 +1,322 @@
+<?php
+/**
+ * BackupConnectionFinisherTest — GitHub issue #274 regression: BackupCommand
+ * releases the CP's HTTP connection via the SAPI-aware ConnectionFinisher
+ * (fastcgi/litespeed/fallback) from inside the in-process shutdown-function
+ * runner, for every SAPI the ladder supports — not only PHP-FPM.
+ *
+ * Coverage:
+ *   - fpm/litespeed/fallback configs: the shutdown closure calls the
+ *     injected ConnectionFinisher exactly once, dispatching the correct
+ *     rung for the given SAPI config, AFTER the dedup lock is claimed and
+ *     the shutdown runner is registered, and BEFORE the heavy TaskRunner
+ *     work begins. A probe exception thrown by the injected
+ *     available/invoke/fallback closures aborts the closure the instant
+ *     finish() completes, so TaskRunner — which needs a live
+ *     Keystore/Signer/DB connection — never gets constructed. That keeps
+ *     this test fast and independent of TaskRunner's own machinery, which
+ *     is covered elsewhere (TaskRunnerTest, TaskRunnerLockTest, ...).
+ *   - A validation-refused run (bad recipient) never registers the shutdown
+ *     runner, so finish() can never fire.
+ *   - A dedup-refused run (an in-flight claim already exists) never
+ *     registers the shutdown runner either, and its refuse() body carries
+ *     code=runner_in_flight for the CP to branch on.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Commands\BackupCommand;
+use WPMgr\Agent\Schema;
+use WPMgr\Agent\Support\AgeIdentity;
+use WPMgr\Agent\Support\ConnectionFinisher;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Commands\BackupCommand
+ * @covers \WPMgr\Agent\Support\ConnectionFinisher
+ */
+final class BackupConnectionFinisherTest extends TestCase
+{
+    private string $contentDir = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        if (!class_exists(\ZipArchive::class)) {
+            self::markTestSkipped('ext-zip not available');
+        }
+
+        if (!defined('WP_CONTENT_DIR')) {
+            $this->contentDir = sys_get_temp_dir() . '/wpmgr-cf-' . bin2hex(random_bytes(6));
+            mkdir($this->contentDir, 0755, true);
+            define('WP_CONTENT_DIR', $this->contentDir);
+        } else {
+            $this->contentDir = WP_CONTENT_DIR;
+            if (!is_dir($this->contentDir)) {
+                mkdir($this->contentDir, 0755, true);
+            }
+        }
+
+        Functions\when('wp_json_encode')->alias(static fn ($d) => json_encode($d));
+        Functions\when('get_option')->justReturn(Schema::CURRENT_VERSION);
+        Functions\when('wp_schedule_single_event')->justReturn(true);
+        Functions\when('spawn_cron')->justReturn(true);
+        Functions\when('site_url')->justReturn('https://open.example.com/wp-cron.php');
+        Functions\when('wp_remote_get')->justReturn([
+            'response' => ['code' => 200, 'message' => 'OK'],
+            'headers'  => [],
+            'body'     => '',
+        ]);
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(200);
+
+        $GLOBALS['wpdb'] = new ConnectionFinisherFakeWpdb();
+    }
+
+    protected function tear_down(): void
+    {
+        unset($GLOBALS['wpdb']);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /** A stub AgeIdentity that matches any recipient (mirrors BackupCommandTest). */
+    private function stubIdentity(): AgeIdentity
+    {
+        return new class extends AgeIdentity {
+            public function __construct()
+            {
+                // Deliberately does NOT call parent::__construct() — no
+                // Keystore needed since recipient()/recipientMatches() are
+                // both overridden below.
+            }
+
+            public function recipient(): string
+            {
+                return 'age1test0000000000000000000000000000000000000000000000000000';
+            }
+
+            public function recipientMatches(string $candidate): bool
+            {
+                return true;
+            }
+        };
+    }
+
+    /** @return array<string,mixed> */
+    private function acceptParams(): array
+    {
+        return [
+            'snapshot_id'       => '11111111-2222-3333-4444-555555555555',
+            'kind'              => 'files',
+            'age_recipient'     => 'age1test0000000000000000000000000000000000000000000000000000',
+            'chunk_bytes'       => 4 << 20,
+            'presign_endpoint'  => 'https://cp.example/agent/v1/backups/x/presign',
+            'manifest_endpoint' => 'https://cp.example/agent/v1/backups/x/manifest',
+            'progress_endpoint' => '',
+        ];
+    }
+
+    /**
+     * A ConnectionFinisher whose $invoke/$fallback closures record the rung
+     * that fired and then throw a sentinel exception. Because the exception
+     * propagates out of the shutdown closure's `$finisher->finish()` call —
+     * BEFORE that closure's own try/catch (which wraps only the TaskRunner
+     * construction/run()) is reached — this proves both WHICH rung fired
+     * and that it fired strictly before the heavy work could have started.
+     *
+     * @param string       $availableName The one function name available()
+     *                                    answers 'yes' to; '' means none (the
+     *                                    fallback rung).
+     * @param list<string> $log           Recording sink, by reference.
+     */
+    private function probeFinisher(string $availableName, array &$log): ConnectionFinisher
+    {
+        return new ConnectionFinisher(
+            static fn (string $fn): bool => $availableName !== '' && $fn === $availableName,
+            static function (string $fn) use (&$log): void {
+                $log[] = 'invoke:' . $fn;
+                throw new ConnectionFinisherProbeException($fn);
+            },
+            static function () use (&$log): void {
+                $log[] = 'fallback';
+                throw new ConnectionFinisherProbeException('fallback');
+            }
+        );
+    }
+
+    /**
+     * Drive execute() to acceptance, capture the registered shutdown closure
+     * (WITHOUT letting it run as a real PHP shutdown handler), then invoke
+     * it once ourselves and assert the probe fired exactly once with the
+     * expected rung.
+     */
+    private function driveAndAssertRung(string $sapi, string $availableName, string $expectedLogEntry): void
+    {
+        $log      = [];
+        $finisher = $this->probeFinisher($availableName, $log);
+
+        /** @var callable|null $captured */
+        $captured = null;
+        Functions\expect('register_shutdown_function')
+            ->once()
+            ->andReturnUsing(function ($cb) use (&$captured): bool {
+                $captured = $cb;
+                return true;
+            });
+
+        $cmd = new BackupCommand($this->stubIdentity(), $finisher);
+        $res = $cmd->execute([], $this->acceptParams());
+
+        self::assertTrue($res['ok'] ?? false, "{$sapi}: acceptance failed: " . ($res['detail'] ?? ''));
+        self::assertNotNull($captured, "{$sapi}: shutdown runner was not registered");
+        self::assertSame([], $log, "{$sapi}: finish() must not fire before the shutdown closure runs");
+
+        try {
+            ($captured)();
+            self::fail("{$sapi}: expected the ConnectionFinisher probe exception to propagate out of the shutdown closure");
+        } catch (ConnectionFinisherProbeException $e) {
+            // Expected — proves finish() fired, and fired BEFORE TaskRunner
+            // ever constructed (TaskRunner's own try/catch only wraps ITS
+            // construction/run(), so it could not have swallowed this).
+        }
+
+        self::assertSame([$expectedLogEntry], $log, "{$sapi}: finish() must fire exactly once, via the {$sapi} rung");
+    }
+
+    public function test_fpm_config_finish_fires_once_via_fastcgi(): void
+    {
+        $this->driveAndAssertRung('fpm', 'fastcgi_finish_request', 'invoke:fastcgi_finish_request');
+    }
+
+    public function test_litespeed_config_finish_fires_once_via_litespeed(): void
+    {
+        $this->driveAndAssertRung('litespeed', 'litespeed_finish_request', 'invoke:litespeed_finish_request');
+    }
+
+    public function test_fallback_config_finish_fires_once_via_fallback(): void
+    {
+        $this->driveAndAssertRung('fallback', '', 'fallback');
+    }
+
+    public function test_validation_refused_run_never_registers_shutdown_runner(): void
+    {
+        Functions\expect('register_shutdown_function')->never();
+
+        $log      = [];
+        $finisher = $this->probeFinisher('fastcgi_finish_request', $log);
+        $cmd      = new BackupCommand($this->stubIdentity(), $finisher);
+
+        $params                   = $this->acceptParams();
+        $params['age_recipient']  = ''; // fails the "missing age recipient" guard, before the dedup claim.
+
+        $res = $cmd->execute([], $params);
+
+        self::assertFalse($res['ok'] ?? true);
+        self::assertSame([], $log, 'finish() must never fire on a validation refusal');
+    }
+
+    public function test_dedup_refused_run_never_registers_shutdown_runner_and_carries_code(): void
+    {
+        Functions\expect('register_shutdown_function')->never();
+
+        $wpdb = $GLOBALS['wpdb'];
+        self::assertInstanceOf(ConnectionFinisherFakeWpdb::class, $wpdb);
+        $wpdb->existingClaim = true; // Simulate an in-flight claim within the dedup window.
+
+        $log      = [];
+        $finisher = $this->probeFinisher('fastcgi_finish_request', $log);
+        $cmd      = new BackupCommand($this->stubIdentity(), $finisher);
+
+        $res = $cmd->execute([], $this->acceptParams());
+
+        self::assertFalse($res['ok'] ?? true);
+        self::assertSame('runner_in_flight', $res['code'] ?? null, 'the in-flight refuse body must carry code=runner_in_flight');
+        self::assertSame([], $log, 'finish() must never fire on a dedup refusal');
+    }
+}
+
+/**
+ * Sentinel exception the probe finisher throws to prove finish() fired,
+ * and fired before any heavier work, without needing a live TaskRunner.
+ */
+final class ConnectionFinisherProbeException extends \RuntimeException
+{
+}
+
+/**
+ * Minimal in-memory $wpdb double for the acceptance path BackupCommand::
+ * execute() touches (preflight + dedup-claim + task-row-seed). Mirrors
+ * AlwaysOnFakeWpdb (BackupAlwaysOnRunnerTest.php) with one addition:
+ * $existingClaim toggles tryClaimDedup() into the "already in flight" branch.
+ */
+final class ConnectionFinisherFakeWpdb
+{
+    public string $prefix = 'wp_';
+
+    /** When true, get_row() reports an existing, still-fresh dedup claim. */
+    public bool $existingClaim = false;
+
+    public function prepare(string $query, ...$args): string
+    {
+        return json_encode(['sql' => $query, 'args' => $args]) ?: '';
+    }
+
+    /** @return string|null */
+    public function get_var(string $sql)
+    {
+        if ($sql === 'SELECT 1') {
+            return '1';
+        }
+        if (strpos($sql, 'max_allowed_packet') !== false) {
+            return '67108864'; // 64 MiB — clears both the hard-fail and warn thresholds.
+        }
+        return null;
+    }
+
+    /**
+     * @param mixed $mode
+     * @return array<int,array<string,mixed>>
+     */
+    public function get_results(string $sql, $mode = null): array
+    {
+        return []; // No tables — estimateBackupSize()'s DB contribution is 0.
+    }
+
+    /**
+     * Dedup-claim SELECT.
+     *
+     * @param mixed $output
+     * @return object|null
+     */
+    public function get_row(string $prepared, $output = null)
+    {
+        if (!$this->existingClaim) {
+            return null;
+        }
+        return (object) ['pid' => 12345, 'started_at' => time()];
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     * @param array<int,string>   $format
+     */
+    public function insert(string $table, array $data, array $format = []): int
+    {
+        return 1;
+    }
+
+    /** seedTaskRow()'s raw INSERT IGNORE. */
+    public function query(string $prepared): int
+    {
+        return 1;
+    }
+}

--- a/apps/agent/tests/ConnectionFinisherAdoptionGuardTest.php
+++ b/apps/agent/tests/ConnectionFinisherAdoptionGuardTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * ConnectionFinisherAdoptionGuardTest — a static guard for GitHub issue #274:
+ * every in-process early-ACK site must go through ConnectionFinisher's
+ * SAPI-aware ladder (fastcgi_finish_request -> litespeed_finish_request ->
+ * fallback), never a raw `function_exists('fastcgi_finish_request')` guard
+ * on its own, which is exactly the pre-#274 bug — it silently drops the
+ * LiteSpeed rung. This scans for that specific call-pattern (a
+ * function_exists() check naming either finish-request function as a
+ * string literal), NOT every narrative mention of the function names in
+ * docblocks — those are expected and accurate now that the docs describe
+ * the SAPI-aware ladder.
+ *
+ * The only place allowed to contain that pattern is
+ * assets/wpmgr-advanced-cache.php — a WordPress drop-in that runs BEFORE the
+ * plugin autoloader (so it cannot use the ConnectionFinisher class) and
+ * keeps its OWN inline fastcgi/litespeed/fallback ladder instead.
+ * includes/support/class-connection-finisher.php itself uses the injected
+ * $available seam, not a literal function_exists() call, so it is not an
+ * exception to this guard — it simply doesn't match the pattern.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\ConnectionFinisher
+ */
+final class ConnectionFinisherAdoptionGuardTest extends TestCase
+{
+    /** Files allowed to contain a raw function_exists('...finish_request') guard. */
+    private const ALLOWED_FILES = [
+        'assets/wpmgr-advanced-cache.php',
+    ];
+
+    /** The anti-pattern this guard scans for: a raw function_exists() check on either finish-request function. */
+    private const ANTI_PATTERN = '/function_exists\s*\(\s*[\'"](?:fastcgi|litespeed)_finish_request[\'"]\s*\)/';
+
+    public function test_no_php_file_reimplements_the_fastcgi_ladder_outside_the_allowed_files(): void
+    {
+        $root      = dirname(__DIR__);
+        $offenders = [];
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::LEAVES_ONLY
+        );
+
+        foreach ($iterator as $file) {
+            if (!$file instanceof \SplFileInfo || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $relative = ltrim(str_replace($root, '', $file->getPathname()), '/\\');
+            $relative = str_replace('\\', '/', $relative);
+
+            // Skip vendor/, tests/, node_modules/, tools/ — only shipped
+            // plugin source is in scope for this guard.
+            if (
+                str_starts_with($relative, 'vendor/')
+                || str_starts_with($relative, 'tests/')
+                || str_starts_with($relative, 'node_modules/')
+                || str_starts_with($relative, 'tools/')
+                || str_starts_with($relative, 'release/')
+            ) {
+                continue;
+            }
+
+            if (in_array($relative, self::ALLOWED_FILES, true)) {
+                continue;
+            }
+
+            $contents = file_get_contents($file->getPathname());
+            if ($contents === false) {
+                continue;
+            }
+
+            if (preg_match(self::ANTI_PATTERN, $contents) === 1) {
+                $offenders[] = $relative;
+            }
+        }
+
+        self::assertSame(
+            [],
+            $offenders,
+            'These files re-implement the raw function_exists(\'fastcgi_finish_request\'/'
+            . '\'litespeed_finish_request\') guard directly instead of routing through '
+            . 'WPMgr\\Agent\\Support\\ConnectionFinisher: '
+            . implode(', ', $offenders)
+        );
+    }
+}

--- a/apps/agent/tests/ConnectionFinisherTest.php
+++ b/apps/agent/tests/ConnectionFinisherTest.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * ConnectionFinisherTest — GitHub issue #274 regression coverage.
+ *
+ * ConnectionFinisher is the SAPI-aware "flush the response, keep the worker
+ * running" ladder shared by every in-process early-ACK command
+ * (BackupCommand, DbCleanCommand, DbOrphanDeleteCommand, Plugin::runDiagnostics):
+ *
+ *   1. fastcgi_finish_request() — PHP-FPM.
+ *   2. litespeed_finish_request() — OpenLiteSpeed / LiteSpeed (GH #274; the
+ *      root cause this class fixes — LiteSpeed exposes NO
+ *      fastcgi_finish_request(), so before this class existed a LiteSpeed
+ *      host had no early flush at all, and a reverse proxy in front of the
+ *      control plane 504'd waiting on the header read for the full backup).
+ *   3. A portable best-effort flush — everything else.
+ *
+ * Tests (a)-(e) exercise the ladder purely through the constructor-injected
+ * seams — no Brain Monkey/Patchwork/separate-process needed, since LiteSpeed
+ * cannot be reproduced in CI and the seam is the whole point. Test (f) is the
+ * one exception: it exercises the REAL default fallback (header()/
+ * ob_get_level()/ob_end_flush()/flush()), which does touch PHP internals, so
+ * the class runs under process isolation to keep those redefinitions from
+ * leaking into the rest of the suite.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use WPMgr\Agent\Support\ConnectionFinisher;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\ConnectionFinisher
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+final class ConnectionFinisherTest extends TestCase
+{
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+    }
+
+    protected function tear_down(): void
+    {
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // -------------------------------------------------------------------------
+    // (a) FPM: fastcgi_finish_request available -> invoked once, 'fpm' returned,
+    //     litespeed never invoked, fallback never called.
+    // -------------------------------------------------------------------------
+
+    public function test_fpm_rung_invokes_fastcgi_and_returns_fpm(): void
+    {
+        $available = ['fastcgi_finish_request'];
+        $invoked   = [];
+        $fallbackCalled = false;
+
+        $finisher = new ConnectionFinisher(
+            static fn (string $fn): bool => in_array($fn, $available, true),
+            static function (string $fn) use (&$invoked): void {
+                $invoked[] = $fn;
+            },
+            static function () use (&$fallbackCalled): void {
+                $fallbackCalled = true;
+            }
+        );
+
+        $result = $finisher->finish();
+
+        self::assertSame('fpm', $result);
+        self::assertSame(['fastcgi_finish_request'], $invoked);
+        self::assertFalse($fallbackCalled);
+    }
+
+    // -------------------------------------------------------------------------
+    // (b) LiteSpeed: fastcgi unavailable, litespeed_finish_request available ->
+    //     invoked once, 'litespeed' returned. THE #274 fix.
+    // -------------------------------------------------------------------------
+
+    public function test_litespeed_rung_invokes_litespeed_and_returns_litespeed(): void
+    {
+        $available = ['litespeed_finish_request'];
+        $invoked   = [];
+        $fallbackCalled = false;
+
+        $finisher = new ConnectionFinisher(
+            static fn (string $fn): bool => in_array($fn, $available, true),
+            static function (string $fn) use (&$invoked): void {
+                $invoked[] = $fn;
+            },
+            static function () use (&$fallbackCalled): void {
+                $fallbackCalled = true;
+            }
+        );
+
+        $result = $finisher->finish();
+
+        self::assertSame('litespeed', $result);
+        self::assertSame(['litespeed_finish_request'], $invoked);
+        self::assertFalse($fallbackCalled);
+    }
+
+    // -------------------------------------------------------------------------
+    // (c) Neither available -> fallback called once, 'fallback' returned.
+    // -------------------------------------------------------------------------
+
+    public function test_neither_available_calls_fallback_and_returns_fallback(): void
+    {
+        $invoked        = [];
+        $fallbackCalls  = 0;
+
+        $finisher = new ConnectionFinisher(
+            static fn (string $fn): bool => false,
+            static function (string $fn) use (&$invoked): void {
+                $invoked[] = $fn;
+            },
+            static function () use (&$fallbackCalls): void {
+                $fallbackCalls++;
+            }
+        );
+
+        $result = $finisher->finish();
+
+        self::assertSame('fallback', $result);
+        self::assertSame(1, $fallbackCalls);
+        self::assertSame([], $invoked);
+    }
+
+    // -------------------------------------------------------------------------
+    // (d) Precedence: both available -> fpm wins, litespeed NOT invoked.
+    // -------------------------------------------------------------------------
+
+    public function test_when_both_available_fpm_wins_over_litespeed(): void
+    {
+        $invoked = [];
+
+        $finisher = new ConnectionFinisher(
+            static fn (string $fn): bool => true, // both fastcgi_finish_request AND litespeed_finish_request "exist"
+            static function (string $fn) use (&$invoked): void {
+                $invoked[] = $fn;
+            },
+            static function (): void {
+                self::fail('fallback must not run when fastcgi_finish_request is available');
+            }
+        );
+
+        $result = $finisher->finish();
+
+        self::assertSame('fpm', $result);
+        self::assertSame(['fastcgi_finish_request'], $invoked);
+    }
+
+    // -------------------------------------------------------------------------
+    // (e) Guard-order invariant: $invoke is NEVER called for a name whose
+    //     $available returned false for.
+    // -------------------------------------------------------------------------
+
+    public function test_invoke_is_never_called_for_a_name_available_said_no_to(): void
+    {
+        // $available only allows litespeed_finish_request -> the ladder must
+        // ask about fastcgi_finish_request (and get 'no'), then ask about
+        // litespeed_finish_request (and get 'yes'), then invoke ONLY the
+        // latter. If $invoke were ever called with 'fastcgi_finish_request'
+        // that would mean the ladder dispatched a function $available said
+        // was missing.
+        $askedButUnavailable = [];
+
+        $finisher = new ConnectionFinisher(
+            static function (string $fn) use (&$askedButUnavailable): bool {
+                if ($fn === 'litespeed_finish_request') {
+                    return true;
+                }
+                $askedButUnavailable[] = $fn;
+                return false;
+            },
+            static function (string $fn) use (&$askedButUnavailable): void {
+                if (in_array($fn, $askedButUnavailable, true)) {
+                    self::fail("invoke() called for '{$fn}', which available() reported as missing");
+                }
+            },
+            static function (): void {
+                self::fail('fallback must not run when litespeed_finish_request is available');
+            }
+        );
+
+        $result = $finisher->finish();
+
+        self::assertSame('litespeed', $result);
+        self::assertSame(['fastcgi_finish_request'], $askedButUnavailable);
+    }
+
+    // -------------------------------------------------------------------------
+    // (f) defaultFallbackFlush() — the ONLY case touching real PHP internals.
+    //     In the PHPUnit CLI SAPI, function_exists('fastcgi_finish_request')
+    //     and function_exists('litespeed_finish_request') are both naturally
+    //     false, so a plain `new ConnectionFinisher()` (all-default seams)
+    //     already reaches the real fallback without needing to fake
+    //     unavailability.
+    // -------------------------------------------------------------------------
+
+    public function test_default_fallback_flush_flushes_without_fatal_and_sends_connection_close(): void
+    {
+        $capturedHeaders = [];
+        Functions\when('headers_sent')->justReturn(false);
+        Functions\when('header')->alias(static function (string $header) use (&$capturedHeaders): void {
+            $capturedHeaders[] = $header;
+        });
+
+        // Two buffer levels deep -> the while(ob_get_level() > 0) loop must
+        // drain both via ob_end_flush(), never echoing a body of its own.
+        $level = 2;
+        Functions\when('ob_get_level')->alias(static function () use (&$level): int {
+            return $level;
+        });
+        Functions\expect('ob_end_flush')
+            ->twice()
+            ->andReturnUsing(static function () use (&$level): bool {
+                $level--;
+                return true;
+            });
+        Functions\expect('flush')->once();
+
+        $finisher = new ConnectionFinisher();
+        $result   = $finisher->finish();
+
+        self::assertSame('fallback', $result);
+        self::assertContains('Connection: close', $capturedHeaders);
+        self::assertContains('Content-Encoding: none', $capturedHeaders);
+    }
+}

--- a/apps/agent/tests/DbOrphanDeleteCommandTest.php
+++ b/apps/agent/tests/DbOrphanDeleteCommandTest.php
@@ -24,6 +24,7 @@ use Brain\Monkey\Functions;
 use WPMgr\Agent\Commands\DbOrphanDeleteCommand;
 use WPMgr\Agent\Optimizer\DbCleanup;
 use WPMgr\Agent\Optimizer\PerfConfig;
+use WPMgr\Agent\Support\ConnectionFinisher;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
@@ -259,6 +260,66 @@ final class DbOrphanDeleteCommandTest extends TestCase
 
         $maxRef = new \ReflectionClassConstant(DbOrphanDeleteCommand::class, 'MAX_ITEMS');
         $this->assertSame(500, $maxRef->getValue(), 'MAX_ITEMS must be 500 per the contract');
+    }
+
+    // =========================================================================
+    // GitHub issue #274 — ConnectionFinisher call-site parity: the SAPI-aware
+    // finish fires exactly once from inside the shutdown closure, and adding
+    // it does not short-circuit the background delete (runAsync still runs
+    // to completion afterward). register_shutdown_function is intercepted
+    // via Functions\expect()->andReturnUsing() so the closure is captured and
+    // invoked directly here rather than actually registered as a real PHP
+    // shutdown handler (which would fire outside the Brain Monkey context —
+    // see the note above test_valid_request_ack_structure_via_name_and_constants).
+    // =========================================================================
+
+    public function test_connection_finisher_fires_once_and_delete_still_backgrounds(): void
+    {
+        Functions\expect('wp_clear_scheduled_hook')
+            ->once()
+            ->with('acme_cleanup');
+
+        $finishCalls = [];
+        $finisher    = new ConnectionFinisher(
+            static fn (string $fn): bool => $fn === 'fastcgi_finish_request',
+            static function (string $fn) use (&$finishCalls): void {
+                $finishCalls[] = $fn;
+            },
+            static function () use (&$finishCalls): void {
+                $finishCalls[] = 'fallback';
+            }
+        );
+
+        /** @var callable|null $captured */
+        $captured = null;
+        Functions\expect('register_shutdown_function')
+            ->once()
+            ->andReturnUsing(function ($cb) use (&$captured): bool {
+                $captured = $cb;
+                return true;
+            });
+
+        $wpdb = new OrphanWpdb();
+        $cmd  = new DbOrphanDeleteCommand(null, null, null, $wpdb, $finisher);
+
+        $res = $cmd->execute([], [
+            'job_id' => 'uuid-cf-parity',
+            'items'  => [['kind' => 'cron', 'name' => 'acme_cleanup', 'owner_slug' => 'acme-plugin']],
+            // progress_endpoint deliberately omitted — keeps runAsync's
+            // postProgress a no-op, so this test needs no network stubs.
+        ]);
+
+        $this->assertTrue($res['ok'] ?? false);
+        $this->assertNotNull($captured, 'shutdown runner was not registered');
+        $this->assertSame([], $finishCalls, 'finish() must not fire before the shutdown closure runs');
+
+        // Invoke the captured closure directly (never as a real PHP shutdown
+        // handler). This proves both that finish() fires exactly once AND
+        // that runAsync() still runs to completion afterward — call-site
+        // parity: adding the finisher did not short-circuit the delete.
+        ($captured)();
+
+        $this->assertSame(['fastcgi_finish_request'], $finishCalls, 'finish() must fire exactly once');
     }
 
     // =========================================================================

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.83
+ * Version:           0.61.84
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.83');
+define('WPMGR_AGENT_VERSION', '0.61.84');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/api/internal/agentcmd/backup_contract.go
+++ b/apps/api/internal/agentcmd/backup_contract.go
@@ -219,9 +219,16 @@ type BackupRequest struct {
 //
 //	ok       the agent accepted the backup job.
 //	detail   short human-readable note (e.g. "queued" or an early refusal reason).
+//	code     GH #274: a STABLE machine-readable refusal code, set only when
+//	         ok=false. Empty on older agents and on refusals without a known
+//	         code — callers MUST treat an empty/unrecognized code as a normal
+//	         terminal refusal and only special-case the codes they know about
+//	         (e.g. "runner_in_flight"). Never parse `detail` text to recover
+//	         this — it is a free-form human string and may change wording.
 type BackupResponse struct {
 	OK     bool   `json:"ok"`
 	Detail string `json:"detail,omitempty"`
+	Code   string `json:"code,omitempty"`
 }
 
 // ChunkRef is one ordered ciphertext chunk of a manifest entry.
@@ -436,11 +443,15 @@ type RestoreRequest struct {
 //	restored_entries number of entries reassembled/imported.
 //	verified         true if every downloaded ciphertext chunk matched its blake3.
 //	log              short human-readable detail.
+//	code             GH #274: a STABLE machine-readable refusal code, set only
+//	                 when ok=false. Same contract as BackupResponse.Code — see
+//	                 its doc comment.
 type RestoreResponse struct {
 	OK              bool   `json:"ok"`
 	RestoredEntries int    `json:"restored_entries"`
 	Verified        bool   `json:"verified"`
 	Log             string `json:"log,omitempty"`
+	Code            string `json:"code,omitempty"`
 }
 
 // ============================================================================

--- a/apps/api/internal/backup/worker.go
+++ b/apps/api/internal/backup/worker.go
@@ -32,6 +32,26 @@ var chainBrokenErrorCodes = map[string]bool{
 	"parent_files_list_chunk_missing": true,
 }
 
+// codeRunnerInFlight (GH #274) is the STABLE machine-readable refusal code the
+// agent sets on BackupResponse.Code / RestoreResponse.Code when its own
+// single-flight dedup guard refuses a dispatch because a runner for this
+// exact snapshot is ALREADY in flight (class-backup-command.php /
+// class-restore-command.php: "runner already in flight for this
+// snapshot/restore"). This can legitimately happen on a slow host (e.g.
+// OpenLiteSpeed without fastcgi_finish_request): the agent's synchronous ack
+// takes long enough that the CP's HTTP round-trip times out and returns a
+// transport error, River retries the job with a fresh dispatch, and THAT
+// retry hits the still-running original run's guard.
+//
+// BackupWorker.Work and RestoreWorker.Work key ONLY on this exact Code value
+// — never on the free-form Detail/Log text, which is not a stable contract —
+// and treat it as benign/non-terminal: the snapshot is left running (or the
+// restore run left as-is) because the still-in-flight original run will
+// complete it via its own manifest submission / progress events. Any OTHER
+// ok=false refusal (empty Code, or a different Code) is UNCHANGED and still
+// takes the existing terminal-failure path.
+const codeRunnerInFlight = "runner_in_flight"
+
 // Audit action names for the backup/restore lifecycle.
 const (
 	ActionBackupStarted    = "backup.started"
@@ -262,6 +282,22 @@ func (w *BackupWorker) Work(ctx context.Context, job *river.Job[BackupArgs]) err
 		return fmt.Errorf("backup command to agent failed: %w", err)
 	}
 	if !resp.OK {
+		if resp.Code == codeRunnerInFlight {
+			// GH #274: benign — a backup for this snapshot is ALREADY running
+			// (this dispatch was a River retry of a slow/timed-out original
+			// attempt). Do NOT fail the snapshot: it stays `running`, the
+			// still-in-flight original run completes it via its own
+			// SubmitManifest call, and the existing 120s progress watchdog
+			// still catches a genuinely-dead run accurately. Terminal-failing
+			// here would flip a healthy running snapshot to failed, trip the
+			// SubmitManifest status==failed guard and orphan the real run's
+			// chunks, and fire a false backup_failed email.
+			w.logger.Warn("backup already running for snapshot; not failing this attempt",
+				slog.String("snapshot_id", snap.ID.String()),
+				slog.String("tenant_id", snap.TenantID.String()),
+				slog.String("detail", resp.Detail))
+			return nil
+		}
 		return w.fail(ctx, snap, "agent refused the backup: "+resp.Detail)
 	}
 	// The agent accepted the job; completion happens when it submits the manifest
@@ -526,6 +562,23 @@ func (w *RestoreWorker) Work(ctx context.Context, job *river.Job[RestoreArgs]) e
 		return fmt.Errorf("restore command to agent failed: %w", err)
 	}
 	if !resp.OK {
+		if resp.Code == codeRunnerInFlight {
+			// GH #274: benign — a restore for this snapshot is ALREADY running
+			// (this dispatch was a River retry of a slow/timed-out original
+			// attempt). Do NOT record a terminal failure: recordAudit(...Failed)
+			// and RecordProgress("failed", ...) both flip the run/snapshot to a
+			// terminal state (RecordProgress's "failed" phase internally calls
+			// FailSnapshot), which would wrongly kill the still-in-flight
+			// original run and fire a false restore-failure signal. The
+			// original run continues to drive completion via its own
+			// /progress events.
+			w.logger.Warn("restore already running for snapshot; not failing this attempt",
+				slog.String("snapshot_id", snap.ID.String()),
+				slog.String("tenant_id", snap.TenantID.String()),
+				slog.String("restore_id", restoreID),
+				slog.String("detail", resp.Log))
+			return nil
+		}
 		// Agent refused the dispatch (e.g. another restore in flight). Terminal.
 		w.recordAudit(ctx, snap, ActionRestoreFailed, map[string]any{
 			"restore_id": restoreID,

--- a/apps/api/internal/backup/worker_test.go
+++ b/apps/api/internal/backup/worker_test.go
@@ -1,0 +1,346 @@
+package backup
+
+// worker_test.go — GH #274 unit tests.
+//
+// On a slow host (most commonly OpenLiteSpeed missing
+// fastcgi_finish_request), the agent's synchronous ack of a backup/restore
+// dispatch can take long enough that the CP's HTTP round-trip times out
+// before the ack arrives. River then retries the job with a fresh dispatch,
+// and THAT retry hits the still-running original run's own single-flight
+// dedup guard, which the agent refuses with a STABLE machine-readable code:
+//
+//	{"ok": false, "detail": "runner already in flight for this snapshot", "code": "runner_in_flight"}
+//
+// Before this fix, BackupWorker.Work / RestoreWorker.Work treated ANY
+// ok=false as a terminal failure. For the in-flight case that is wrong and
+// destructive: it flips a healthy running snapshot to failed (backup) or
+// finalizes the genuinely-active restore_run row as failed (restore), even
+// though the ORIGINAL run is still executing and will complete normally.
+//
+// These tests prove:
+//  1. A "runner_in_flight" refusal is treated as benign — Work() returns nil,
+//     but does NOT call FailSnapshot / terminally finalize the restore run.
+//  2. The benign branch is NARROW: it keys on the STABLE Code field only. Any
+//     other ok=false refusal (no code, or a different code) still takes the
+//     existing terminal-failure path, unchanged — a regression guard so a
+//     mistaken widening of the branch (e.g. matching on Detail/Log text)
+//     would be caught here.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// refusalCommander — a Commander double whose Backup/IncrementalBackup/Restore
+// responses are configured per-test. fakeCommander (worker_incremental_test.go)
+// only models a boolean ok/not-ok; these tests need to control Detail/Log/Code
+// on the refusal wire shape, so they use this sibling double instead.
+// ---------------------------------------------------------------------------
+
+type refusalCommander struct {
+	backupResp  agentcmd.BackupResponse
+	restoreResp agentcmd.RestoreResponse
+}
+
+func (c *refusalCommander) Backup(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.BackupRequest) (agentcmd.BackupResponse, error) {
+	return c.backupResp, nil
+}
+
+func (c *refusalCommander) IncrementalBackup(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.IncrementalBackupRequest) (agentcmd.BackupResponse, error) {
+	return c.backupResp, nil
+}
+
+func (c *refusalCommander) Restore(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.RestoreRequest) (agentcmd.RestoreResponse, error) {
+	return c.restoreResp, nil
+}
+
+// ---------------------------------------------------------------------------
+// failTrackingWorkerRepo wraps fakeWorkerRepo (worker_incremental_test.go) and
+// additionally:
+//   - tracks whether FailSnapshot was ever called, so tests can assert on the
+//     terminal-failure side effect directly rather than inferring it from
+//     status alone.
+//   - implements UpdateSnapshotProgress, which RestoreWorker.Work calls
+//     UNCONDITIONALLY (the "preflight" progress tick fires before the agent
+//     dispatch, regardless of how the agent ultimately responds) and which
+//     the base fakeRepo leaves panicking as "not implemented".
+// ---------------------------------------------------------------------------
+
+type failTrackingWorkerRepo struct {
+	*fakeWorkerRepo
+	failCalled bool
+}
+
+func newFailTrackingWorkerRepo() *failTrackingWorkerRepo {
+	return &failTrackingWorkerRepo{
+		fakeWorkerRepo: &fakeWorkerRepo{fakeRepo: newFakeRepo(), workerManifests: map[uuid.UUID][]ManifestEntry{}},
+	}
+}
+
+func (r *failTrackingWorkerRepo) FailSnapshot(ctx context.Context, tenantID, snapshotID uuid.UUID, msg string) (Snapshot, error) {
+	r.failCalled = true
+	return r.fakeWorkerRepo.FailSnapshot(ctx, tenantID, snapshotID, msg)
+}
+
+func (r *failTrackingWorkerRepo) UpdateSnapshotProgress(_ context.Context, _, snapshotID uuid.UUID, _ []byte) (Snapshot, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.snapshots[snapshotID], nil
+}
+
+// ---------------------------------------------------------------------------
+// fakeRestoreRunStore — a minimal RestoreRunStore double that records every
+// MarkRestoreRunStatus call. `active`, when set, is returned by
+// ActiveRestoreRunForSnapshot so persistRestoreRunEvent finds a run to
+// (possibly) finalize — mirroring the real ORIGINAL, still-running restore
+// this scenario is about.
+// ---------------------------------------------------------------------------
+
+type fakeRestoreRunStore struct {
+	active      RestoreRun
+	hasActive   bool
+	statusCalls []MarkRestoreRunStatusInput
+}
+
+func (f *fakeRestoreRunStore) CreateRestoreRun(_ context.Context, _ CreateRestoreRunInput) (RestoreRun, error) {
+	return RestoreRun{}, nil
+}
+func (f *fakeRestoreRunStore) GetRestoreRun(_ context.Context, _, _ uuid.UUID) (RestoreRun, error) {
+	return RestoreRun{}, nil
+}
+func (f *fakeRestoreRunStore) ListRestoreRunsBySite(_ context.Context, _, _ uuid.UUID, _ int) ([]RestoreRun, error) {
+	return nil, nil
+}
+func (f *fakeRestoreRunStore) ActiveRestoreRunForSnapshot(_ context.Context, _, _ uuid.UUID) (RestoreRun, error) {
+	if !f.hasActive {
+		return RestoreRun{}, domain.NotFound("restore_run_not_found", "no active restore run")
+	}
+	return f.active, nil
+}
+func (f *fakeRestoreRunStore) AppendRestoreEvent(_ context.Context, _ AppendRestoreEventInput) (RestoreRunEvent, error) {
+	return RestoreRunEvent{}, nil
+}
+func (f *fakeRestoreRunStore) UpdateRestoreRunPhase(_ context.Context, _, _ uuid.UUID, _ string) error {
+	return nil
+}
+func (f *fakeRestoreRunStore) MarkRestoreRunStatus(_ context.Context, in MarkRestoreRunStatusInput) error {
+	f.statusCalls = append(f.statusCalls, in)
+	return nil
+}
+func (f *fakeRestoreRunStore) ListRestoreEvents(_ context.Context, _, _ uuid.UUID, _ int64, _ int) ([]RestoreRunEvent, error) {
+	return nil, nil
+}
+
+// ---------------------------------------------------------------------------
+// BackupWorker.Work — runner_in_flight (GH #274)
+// ---------------------------------------------------------------------------
+
+func newBackupWorkerFixture() (*failTrackingWorkerRepo, uuid.UUID, uuid.UUID, *Service) {
+	repo := newFailTrackingWorkerRepo()
+	tenantID := uuid.New()
+	snapshotID := uuid.New()
+	snap := Snapshot{
+		ID:           snapshotID,
+		TenantID:     tenantID,
+		SiteID:       uuid.New(),
+		Kind:         KindFull,
+		Status:       StatusPending,
+		AgeRecipient: "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p",
+	}
+	repo.setSnapshot(snap)
+	svc := &Service{repo: repo, sites: fakeWorkerSiteLookup{}, clock: fakeClock{t: time.Now()}}
+	return repo, tenantID, snapshotID, svc
+}
+
+// TestBackupWorker_RunnerInFlight_DoesNotFailSnapshot: an agent refusal
+// carrying Code="runner_in_flight" must be treated as benign — Work() returns
+// nil (so River does not retry a job that would only be refused again), but
+// must NOT call FailSnapshot, and the snapshot must stay `running` so the
+// still-in-flight original run's own SubmitManifest completes it normally.
+func TestBackupWorker_RunnerInFlight_DoesNotFailSnapshot(t *testing.T) {
+	repo, tenantID, snapshotID, svc := newBackupWorkerFixture()
+	cmd := &refusalCommander{backupResp: agentcmd.BackupResponse{
+		OK:     false,
+		Detail: "runner already in flight for this snapshot",
+		Code:   "runner_in_flight",
+	}}
+	worker := NewBackupWorker(svc, cmd, nil, nil, "https://cp.example.com", 0)
+
+	job := &river.Job[BackupArgs]{Args: BackupArgs{TenantID: tenantID, SnapshotID: snapshotID}}
+	if err := worker.Work(context.Background(), job); err != nil {
+		t.Fatalf("Work() error: %v (a runner_in_flight refusal must be swallowed, not returned as a retryable error)", err)
+	}
+	if repo.failCalled {
+		t.Error("FailSnapshot must NOT be called for a runner_in_flight refusal")
+	}
+	got := repo.snapshots[snapshotID]
+	if got.Status != StatusRunning {
+		t.Errorf("snapshot status = %q, want %q (must stay running so the in-flight run's own manifest submission completes it)", got.Status, StatusRunning)
+	}
+}
+
+// TestBackupWorker_RefuseWithoutCode_StillFailsTerminal is the narrow-branch
+// regression guard: an ordinary ok=false refusal with no Code, or a Code that
+// is not "runner_in_flight", must still terminal-fail exactly as before.
+func TestBackupWorker_RefuseWithoutCode_StillFailsTerminal(t *testing.T) {
+	tests := []struct {
+		name string
+		resp agentcmd.BackupResponse
+	}{
+		{"no code at all", agentcmd.BackupResponse{OK: false, Detail: "preflight_failed: disk full"}},
+		{"a different, unrelated code", agentcmd.BackupResponse{OK: false, Detail: "disk full", Code: "preflight_failed"}},
+		{"detail text happens to mention in flight, but no code", agentcmd.BackupResponse{OK: false, Detail: "runner already in flight for this snapshot"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, tenantID, snapshotID, svc := newBackupWorkerFixture()
+			cmd := &refusalCommander{backupResp: tt.resp}
+			worker := NewBackupWorker(svc, cmd, nil, nil, "https://cp.example.com", 0)
+
+			job := &river.Job[BackupArgs]{Args: BackupArgs{TenantID: tenantID, SnapshotID: snapshotID}}
+			if err := worker.Work(context.Background(), job); err != nil {
+				t.Fatalf("Work() error: %v (a terminal refusal is recorded via w.fail and returns nil so River does not retry)", err)
+			}
+			if !repo.failCalled {
+				t.Error("FailSnapshot must be called for a code-less/unrelated-code refusal (this is the narrow-branch regression guard)")
+			}
+			got := repo.snapshots[snapshotID]
+			if got.Status != StatusFailed {
+				t.Errorf("snapshot status = %q, want %q", got.Status, StatusFailed)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RestoreWorker.Work — runner_in_flight (GH #274), symmetric to the backup
+// case above but the destructive side effect is different: instead of
+// flipping backup_snapshots.status, the pre-fix code finalized the ACTIVE
+// restore_runs row (found via ActiveRestoreRunForSnapshot — i.e. the
+// genuinely in-flight ORIGINAL restore) as failed via persistRestoreRunEvent.
+// ---------------------------------------------------------------------------
+
+func newRestoreWorkerFixture(t *testing.T) (*failTrackingWorkerRepo, *fakeRestoreRunStore, uuid.UUID, uuid.UUID, *Service) {
+	t.Helper()
+	repo := newFailTrackingWorkerRepo()
+	tenantID := uuid.New()
+	siteID := uuid.New()
+	snapshotID := uuid.New()
+
+	// The restored-FROM snapshot is a completed backup (the only kind that is
+	// ever restorable) — this matters: RecordProgress's own guard only calls
+	// FailSnapshot for a phase="failed" event when the snapshot is NOT already
+	// completed, so a completed backup's status is never at risk here. The
+	// real GH #274 blast radius for restore is the ACTIVE restore_runs row.
+	snap := Snapshot{
+		ID:           snapshotID,
+		TenantID:     tenantID,
+		SiteID:       siteID,
+		Kind:         KindFull,
+		Status:       StatusCompleted,
+		AgeRecipient: "age1test",
+	}
+	repo.setSnapshot(snap)
+	repo.workerManifests[snapshotID] = []ManifestEntry{
+		{Path: "wp-content/plugins/foo/foo.php", EntryKind: EntryKindFile, ChunkHashes: []string{"aaa"}, Size: 100},
+	}
+
+	runStore := &fakeRestoreRunStore{
+		hasActive: true,
+		active: RestoreRun{
+			ID:         uuid.New(),
+			TenantID:   tenantID,
+			SiteID:     siteID,
+			SnapshotID: snapshotID,
+			Status:     RestoreStatusRunning,
+		},
+	}
+
+	fp := &fakePresigner{}
+	svc := &Service{
+		repo:        repo,
+		sites:       &fakeSiteLookup{},
+		store:       &tenantPresigner{tenantID: tenantID, inner: fp},
+		clock:       fakeClock{t: time.Now()},
+		presignTTL:  time.Hour,
+		restoreRuns: runStore,
+	}
+	return repo, runStore, tenantID, snapshotID, svc
+}
+
+// TestRestoreWorker_RunnerInFlight_DoesNotFailRestoreRun: an agent refusal
+// carrying Code="runner_in_flight" must be treated as benign — Work() returns
+// nil, but must NOT record ActionRestoreFailed / emit a "failed" progress
+// event, and therefore must NOT finalize the genuinely-active restore_run row
+// (asserted here via the fake store's MarkRestoreRunStatus call log, which
+// must stay empty) nor flip the snapshot to failed.
+func TestRestoreWorker_RunnerInFlight_DoesNotFailRestoreRun(t *testing.T) {
+	repo, runStore, tenantID, snapshotID, svc := newRestoreWorkerFixture(t)
+	cmd := &refusalCommander{restoreResp: agentcmd.RestoreResponse{
+		OK:   false,
+		Log:  "runner already in flight for this restore",
+		Code: "runner_in_flight",
+	}}
+	worker := NewRestoreWorker(svc, cmd, nil, nil, "https://cp.example.com", 0)
+
+	job := &river.Job[RestoreArgs]{Args: RestoreArgs{TenantID: tenantID, SnapshotID: snapshotID, Full: true}}
+	if err := worker.Work(context.Background(), job); err != nil {
+		t.Fatalf("Work() error: %v (a runner_in_flight refusal must be swallowed, not returned as a retryable error)", err)
+	}
+	if repo.failCalled {
+		t.Error("FailSnapshot must NOT be called for a runner_in_flight refusal")
+	}
+	if len(runStore.statusCalls) != 0 {
+		t.Errorf("MarkRestoreRunStatus must NOT be called for a runner_in_flight refusal (the active restore_run is genuinely still running), got %+v", runStore.statusCalls)
+	}
+	got := repo.snapshots[snapshotID]
+	if got.Status != StatusCompleted {
+		t.Errorf("snapshot status = %q, want unchanged %q", got.Status, StatusCompleted)
+	}
+}
+
+// TestRestoreWorker_RefuseWithoutCode_StillFailsTerminal is the narrow-branch
+// regression guard for restore: an ordinary ok=false refusal with no Code, or
+// an unrelated Code, must still terminal-fail exactly as before — recording
+// ActionRestoreFailed and finalizing the active restore_run row as failed.
+func TestRestoreWorker_RefuseWithoutCode_StillFailsTerminal(t *testing.T) {
+	tests := []struct {
+		name string
+		resp agentcmd.RestoreResponse
+	}{
+		{"no code at all", agentcmd.RestoreResponse{OK: false, Log: "some other refusal"}},
+		{"a different, unrelated code", agentcmd.RestoreResponse{OK: false, Log: "preflight failed", Code: "preflight_failed"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, runStore, tenantID, snapshotID, svc := newRestoreWorkerFixture(t)
+			cmd := &refusalCommander{restoreResp: tt.resp}
+			worker := NewRestoreWorker(svc, cmd, nil, nil, "https://cp.example.com", 0)
+
+			job := &river.Job[RestoreArgs]{Args: RestoreArgs{TenantID: tenantID, SnapshotID: snapshotID, Full: true}}
+			if err := worker.Work(context.Background(), job); err != nil {
+				t.Fatalf("Work() error: %v", err)
+			}
+			if len(runStore.statusCalls) != 1 {
+				t.Fatalf("expected exactly 1 MarkRestoreRunStatus call (the terminal finalize), got %d: %+v", len(runStore.statusCalls), runStore.statusCalls)
+			}
+			if runStore.statusCalls[0].Status != RestoreStatusFailed {
+				t.Errorf("MarkRestoreRunStatus status = %q, want %q", runStore.statusCalls[0].Status, RestoreStatusFailed)
+			}
+			// The restored-FROM snapshot is already `completed` (see fixture doc
+			// comment) — RecordProgress's own guard means FailSnapshot is never
+			// reached for a restore refusal either way; confirm that holds.
+			if repo.failCalled {
+				t.Error("FailSnapshot must not be called on the backup snapshot for a restore refusal")
+			}
+		})
+	}
+}

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.83
+  version: 0.61.84
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Fixes **GH #274** — two coordinated bugs.

**Agent (the reported 504):** OpenLiteSpeed's PHP SAPI is `litespeed`, which doesn't expose `fastcgi_finish_request()` (it exposes `litespeed_finish_request()`). The agent's early-ack path (backup, db-clean, db-orphan-delete) only tried the FPM function, so on LiteSpeed there was no early flush — the worker held the response open for the whole backup, Nginx Proxy Manager 504'd on the ~60s header read, and the CP retried into the "runner already in flight" guard. New `WPMgr\Agent\Support\ConnectionFinisher` acks via a SAPI-aware ladder (`fastcgi` → `litespeed` → portable fallback), constructor-injected seam so all three paths are unit-testable without a real SAPI. In-flight refusals now carry a stable `code: "runner_in_flight"`.

**Control plane (the destructive part):** that in-flight refuse was mapped to a **terminal failure** — flipping the snapshot `running → failed`, orphaning the still-running real backup, and sending a false failure email. `BackupWorker`/`RestoreWorker` now branch on the stable `Code` (not detail text): "already running" leaves the snapshot `running` so the real run completes via its own manifest; the 120s watchdog still catches dead runs. An `ok=false` with no code still fails terminally. Protects any slow host, not just LiteSpeed.

### Verification
- Agent phpunit **2803 / 0** (13 new incl. litespeed + neither-SAPI regression), phpcs 0, `make agent-plugincheck` 0 errors.
- CP `go test ./...` green (incl. the integration suite); benign-branch narrowness proven by a regression test.
- **Cross-boundary contract verified**: field `code`, value `runner_in_flight`, matched on both sides for backup and restore.
- Built by two specialists in parallel over disjoint files (agent PHP / CP Go); no cross-contamination.

Ships as **0.61.84** (agent-release for the fleet + prod API deploy for the CP change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWiZ4iJ1fmYW8vtPghWmsn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backup acknowledgments now complete reliably on PHP-FPM, OpenLiteSpeed, LiteSpeed, and fallback server configurations, preventing unnecessary timeouts.
  * Duplicate backup and restore requests are handled safely without marking the original active operation as failed or orphaning it.
  * Backup and restore responses now include a consistent machine-readable refusal code when an operation is already in progress.
* **Release**
  * Updated version to 0.61.84.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->