### PR TITLE
docs: self-host requirements page + one-click README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
   <a href="https://wpmgr.app/docs/">API reference</a>
 </p>
 
-**v0.61.69** — open-source and production-usable for self-hosters.
+**v0.61.84** — open-source and production-usable for self-hosters.
 
 ---
 
@@ -249,16 +249,44 @@ See [docs/architecture.md](./docs/architecture.md) for a full system diagram.
 
 ## Quickstart (self-host)
 
-The bundled compose brings up the full stack — control plane, dashboard, Postgres, Redis, object storage, and the media encoder (screenshots + Media Optimizer) — building all three images from source:
+### One-click install (recommended)
+
+No repo clone needed. This single command downloads every file the stack needs, generates all secrets (session, agent signing, age), and prints the exact command to start WPMgr:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mosamlife/wpmgr/main/scripts/quickstart-selfhost.sh | bash
+```
+
+Options: `--hostname=https://wpmgr.example.com` (sets `WPMGR_PUBLIC_BASE_URL` non-interactively), `--version=vX.Y.Z` (pin a release tag, default `:latest`), `--dir=PATH` (default `./wpmgr`), `--force` (re-download files).
+
+Host requirements: Docker 24+ with the Compose plugin, `curl` or `wget`, and `openssl`.
+
+The script prints the exact command to run next, using the pull-only overlay (prebuilt images, no local build):
+
+```bash
+cd wpmgr
+docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
+curl localhost:8081/healthz   # {"status":"ok"}
+```
+
+Open `http://localhost:8088` in your browser; the first signup creates the owner account.
+
+`WPMGR_S3_ENDPOINT` in the generated `.env` must be reachable by your WordPress hosts, not just the control plane. The default (`http://seaweedfs:8333`) only resolves inside Docker; for remote WordPress sites, point it at a tunnel or public URL.
+
+See [docs/requirements.md](./docs/requirements.md) for CPU, RAM, and disk sizing by fleet size before you provision the host.
+
+### Build from source (clone path)
+
+If you have cloned the repo, the bundled compose brings up the full stack (control plane, dashboard, Postgres, Redis, object storage, and the media encoder for screenshots and the Media Optimizer), building all three images from source:
 
 ```bash
 cp .env.example .env
-# Edit .env — at minimum set WPMGR_SESSION_SECRET, WPMGR_DB_PASSWORD, WPMGR_S3_SECRET_KEY
+# Edit .env: at minimum set WPMGR_SESSION_SECRET, WPMGR_DB_PASSWORD, WPMGR_S3_SECRET_KEY
 docker compose -f infra/docker-compose.yml up -d
 curl localhost:8081/healthz   # {"status":"ok"}   (default WPMGR_API_PORT=8081)
 ```
 
-Open `http://localhost:8088` in your browser (the default `WPMGR_WEB_PORT`) — the first signup creates the owner account. After that, anyone can self-register and gains access only after verifying their email.
+Open `http://localhost:8088` in your browser (the default `WPMGR_WEB_PORT`); the first signup creates the owner account. After that, anyone can self-register and gains access only after verifying their email.
 
 The media encoder runs headless Chromium for screenshots, so it adds some RAM/CPU over the api/web images. On a constrained host you can skip it without editing the compose file:
 
@@ -270,18 +298,18 @@ Site screenshot cards then fall back to favicon/monogram and the Media Optimizer
 
 ### Prebuilt container images
 
-The control plane, dashboard, and media encoder are published on GitHub Container Registry as multi-arch (`linux/amd64` + `linux/arm64`) images — wire them into your own compose, Kubernetes, or Swarm for production:
+The control plane, dashboard, and media encoder are published on GitHub Container Registry as multi-arch (`linux/amd64` + `linux/arm64`) images, for wiring into your own compose, Kubernetes, or Swarm setup:
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.43.3
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.43.3
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.43.3
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.84
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.84
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.84
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.43.3   # omit to track :latest
+export WPMGR_VERSION=v0.61.84   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 
@@ -333,7 +361,7 @@ infra/
   Dockerfile.api · Dockerfile.web · Dockerfile.media-encoder
   postgres/ · seaweedfs/ · nginx/ · dex/ · grafana/
 docs/
-  install.md · agent.md · architecture.md · contributing.md · security.md · api.md · adr/
+  install.md · requirements.md · agent.md · architecture.md · contributing.md · security.md · api.md · adr/
 ```
 
 ---
@@ -371,6 +399,7 @@ See [docs/contributing.md](./docs/contributing.md) for the full dev setup, PR ch
 ## Links
 
 - [Install (self-host)](./docs/install.md)
+- [System requirements](./docs/requirements.md)
 - [WordPress agent](./docs/agent.md)
 - [Architecture](./docs/architecture.md)
 - [API reference](./docs/api.md)

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,10 +3,16 @@
 Self-host WPMgr with Docker Compose. The stack runs the control plane (Go),
 dashboard (React), and data plane (Postgres, Redis, SeaweedFS, ClickHouse).
 
+> Fastest way in: the one-click installer, no clone needed. See
+> [Quickstart: prebuilt images, no clone](#quickstart-prebuilt-images-no-clone-recommended-for-first-time-installs)
+> below.
+
 ## Prerequisites
 
 - **Docker** 24+ with the Compose plugin (`docker compose`, not `docker-compose`)
-- ~2 GB free RAM for the full stack
+- Minimum ~2 GB RAM (lean, no Media Optimizer); ~8 GB recommended for the full
+  default stack. See [docs/requirements.md](./requirements.md) for the full
+  sizing breakdown by fleet size.
 
 ## 1. Configure env
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,149 @@
+# Requirements (self-host)
+
+These are the system requirements for running the WPMgr control plane
+(control plane, dashboard, and data plane) on your own infrastructure. They
+are architecture-derived estimates, not load-tested benchmarks; see
+[Caveats](#caveats) before you provision hardware. They do not cover the
+managed WordPress hosts themselves: the agent plugin only needs PHP 8.1+ and
+WordPress 6.0+, see [agent.md](./agent.md).
+
+## Host prerequisites
+
+- 64-bit Linux host, x86-64 or ARM64
+- Docker Engine 24+ with the Compose v2 plugin (`docker compose`, not `docker-compose`)
+- Outbound network access (image pulls, WordPress.org checksum lookups, TLS certificate checks)
+- A `WPMGR_S3_ENDPOINT` reachable by both the control plane and the managed
+  WordPress hosts, see [install.md#s3-networking](./install.md#s3-networking)
+
+## Minimum vs recommended
+
+### Minimum: lean control plane, no Media Optimizer, fleet under 25 sites
+
+| Resource | Spec |
+|---|---|
+| CPU | 2 vCPU |
+| RAM | 2 GB |
+| Disk | 20 GB SSD to start, growing with backups |
+
+What's running: postgres, redis, api, web, plus an object-storage target
+(external S3/R2, or the bundled SeaweedFS container). What's off:
+media-encoder scaled to 0, ClickHouse off (`WPMGR_CLICKHOUSE_ADDR` unset falls
+back to the Postgres metrics store), Dex off (email and password auth).
+
+RAM breakdown: core services idle at roughly 250-500 MB combined; SeaweedFS
+adds another 40-100 MB idle. Disk breakdown: OS plus roughly 2-3 GB of images,
+Postgres at 1-2 GB, and a few small backups to start.
+
+This boots the full control plane: enrollment, uptime monitoring, updates,
+backups and restore, alerts, and the dashboard. You only give up site
+screenshots, the Media Optimizer, WOFF2 font tooling, and large-fleet
+time-series performance.
+
+### Recommended: full default stack, small-to-mid fleet
+
+| Resource | Spec |
+|---|---|
+| CPU | 4 vCPU |
+| RAM | 8 GB |
+| Disk | 100 GB+ SSD, dominated by backup chunk storage |
+
+What's running: postgres, redis, api, web, object storage, and media-encoder.
+Set `WPMGR_MEDIA_ENCODE_WORKERS=2` on self-host (the image default is 3).
+
+RAM jumps from 2 GB to 8 GB because of media-encoder: each in-flight headless
+Chromium capture is roughly 150-300 MiB at the default capture concurrency of
+2, plus encode workers on top, needing about 1-2 GB of live headroom over the
+core services.
+
+A plain `docker compose up` also starts ClickHouse
+(`WPMGR_CLICKHOUSE_ADDR` defaults to `clickhouse:9000`) and Dex. ClickHouse is
+the heaviest idle datastore (roughly 250-500 MB, and it wants several GB at
+scale) and buys nothing under about 100 sites, so below that size leave it off
+and 4-6 GB RAM is comfortable.
+
+## By fleet size
+
+| Fleet size | CPU | RAM | Disk | Notes |
+|---|---|---|---|---|
+| Under 25 sites | 2 vCPU | 2 GB without Media Optimizer, 4 GB with it | 20-50 GB SSD (Postgres 1-2 GB; backups dominate) | Defaults are fine: ClickHouse off, probe concurrency 10, probe interval 60s. Set `WPMGR_MEDIA_ENCODE_WORKERS=2` if running the encoder. |
+| 25 to 100 sites | 2-4 vCPU | 4 GB without Media Optimizer, 8 GB with it | 100-300 GB SSD (backup chunks dominant; Postgres roughly 5-10 GB) | The Postgres metrics store is still fine to about 100 sites. Raise `WPMGR_UPTIME_PROBE_CONCURRENCY` toward 25-50 as you approach 100 so each 60s sweep does not overlap. |
+| 100 to 500+ sites | 4-8 vCPU | 8-16 GB (add 2-4 GB if enabling ClickHouse; add 2-4 GB for the Media Optimizer) | Hundreds of GB to multiple TB | Strongly prefer external S3/R2 over a local SeaweedFS volume at this tier. Turn on ClickHouse (`WPMGR_CLICKHOUSE_ADDR`) to offload the uptime time series and give it its own 2-4 GB or more. Raise probe concurrency to 50-100, and/or lengthen the probe interval, and/or trim retention. Give Postgres 4-8 GB and tune `shared_buffers`; only raise `max_connections` if you also scale the api service horizontally (the pgx pool is a hardcoded 5 connections per api instance). |
+
+## Required vs optional services
+
+The base compose stack has 9 services. Here is what each one does, whether
+you can drop it, and what dropping it costs.
+
+| Service | Required? | What it does | Dropping it |
+|---|---|---|---|
+| `postgres` | Required | System of record, plus the embedded River job queue, plus the Postgres metrics fallback. `postgres:16.4-alpine`. | Not possible; the control plane cannot boot without it. |
+| `redis` | Required | Operator dashboard session store. `redis:7.4-alpine`. | Not possible in production: if Redis is unreachable, every authenticated request returns 500 (there is no cookie or in-memory fallback in the production boot path). |
+| `api` | Required | The Go control plane. Runs all fleet cron: uptime probe, backup scheduler, garbage collection, sweeps. Pure-Go static binary, light at idle on a single instance (roughly 30-80 MB). | Not possible; this is the control plane itself. |
+| `web` | Required | nginx serving the React dashboard bundle and proxying `/api` and `/auth`. Trivial footprint (roughly 10-30 MB). | Not possible without replacing it with your own reverse proxy in front of the api. |
+| object storage (`seaweedfs` or external S3) | Conditional | SeaweedFS (bundled, Apache-2.0 S3 gateway) or any external S3-compatible endpoint (AWS S3, Cloudflare R2, external MinIO) via `WPMGR_S3_ENDPOINT`. | The api boots without it, but any storage-backed feature needs it: backups and restore, the Media Optimizer, screenshots, WOFF2 fonts, client report PDFs. Presigned URLs must be reachable by the managed WordPress hosts, so an in-network-only SeaweedFS default (`http://seaweedfs:8333`) is not usable for real remote sites; give it a routable address or use external S3. |
+| `media-encoder` | Optional | The single heaviest RAM component. A pull worker for screenshots (headless Chromium), image optimize to AVIF/WebP, and WOFF2 font transcode. | Disable without editing files: `docker compose -f infra/docker-compose.yml up -d --scale media-encoder=0`. Screenshots stop (cards fall back to favicon/monogram), the Media Optimizer's optimize step never completes, WOFF2 transcode is dead; everything else keeps working. When it does run, it must use a dedicated River schema (`WPMGR_RIVER_MEDIA_SCHEMA=media_encoder`, set identically on `api` and `media-encoder`) or it wins River leader election and silently stops all fleet cron. |
+| `clickhouse` | Optional | Metrics time-series store. The base compose wires it on by default (`WPMGR_CLICKHOUSE_ADDR=clickhouse:9000`). | To drop it, unset that env and do not start the container; an empty address falls back cleanly to the Postgres metrics store. It is the heaviest idle datastore (roughly 250-500 MB) and only pays off at large fleet size or high probe volume. |
+| `dex` | Optional | Self-host OIDC identity provider for SSO. | The api falls back to email and password auth when `WPMGR_OIDC_ISSUER` is unset. A plain `compose up` waits on Dex via `depends_on`, so fully dropping it means removing that dependency and leaving the issuer unset. |
+| `otel-lgtm` (observability bundle) | Optional | Traces, metrics, and Grafana. | Behind the `observability` compose profile; never starts on a default `up`. |
+
+## Storage guidance
+
+Two stores dominate. Disk is driven far more by backups than by site count.
+
+**Postgres.** The data dir is dominated by the `site_uptime_probes` table:
+exactly one row per site per probe interval (default 60s, 1,440 rows per site
+per day), retained 90 days and rolled up daily. Budget roughly 50-100 MB
+Postgres per site: about 1-2 GB at 25 sites, about 5-10 GB at 100 sites, about
+15-30 GB at 500 sites. Shrink it by lengthening
+`WPMGR_UPTIME_PROBE_INTERVAL`, lowering retention, or offloading to
+ClickHouse.
+
+**Backup chunk storage (S3 or SeaweedFS).** This is the dominant consumer and
+dwarfs everything else. Chunks are content-addressed (blake3), age-encrypted
+on the agent, and deduplicated within a tenant, with incremental
+archive-delta backups: each increment packs only changed or new files.
+Budget roughly 1.5 to 3 times one full backup per site (a typical WordPress
+full backup is 0.5-5 GB), sized by sites times site size times
+`WPMGR_BACKUP_RETENTION_DAYS` (default 30), plus 12 monthly archives. Worked
+example: 100 sites at roughly 2 GB effective works out to about 200-300 GB.
+Plan disk around this line item, and at scale prefer external S3/R2.
+Screenshots, Media Optimizer output, and WOFF2 fonts share the same bucket
+but are a rounding error next to backups.
+
+## Tuning knobs
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `WPMGR_UPTIME_PROBE_INTERVAL` | How often each site is probed | `60s` |
+| `WPMGR_UPTIME_PROBE_CONCURRENCY` | Probes run concurrently per sweep | `10` |
+| `WPMGR_CLICKHOUSE_ADDR` | ClickHouse address; empty falls back to the Postgres metrics store | `clickhouse:9000` in the base compose |
+| `WPMGR_S3_ENDPOINT` / `_BUCKET` / `_ACCESS_KEY` / `_SECRET_KEY` | Object storage target: bundled SeaweedFS or external S3 | see `.env.example` |
+| `WPMGR_S3_FORCE_PATH_STYLE` | Required `true` for SeaweedFS/MinIO-style endpoints; can be `false` for AWS S3 | `true` |
+| `WPMGR_MEDIA_ENCODE_WORKERS` | media-encoder concurrency | `3` |
+| `WPMGR_RIVER_MEDIA_SCHEMA` | Dedicated River schema for media-encoder jobs (must match on `api` and `media-encoder`) | `media_encoder` |
+| `WPMGR_BACKUP_RETENTION_DAYS` | How long backup snapshots are retained before garbage collection | `30` |
+
+## Caveats
+
+- These are architecture-derived estimates, not load-tested benchmarks. Real
+  usage varies with site size, backup frequency, probe interval, and which
+  features are enabled.
+- media-encoder is the RAM swing factor: it scales with concurrent screenshot
+  captures, not fleet size.
+- Backup chunk storage is the dominant, least predictable disk cost. It
+  tracks total managed site size times retention, not site count.
+- Postgres connections are not a bottleneck on a single-node self-host
+  (roughly 13 live connections against the image default `max_connections=100`).
+- A plain `docker compose up` starts the heavy default: ClickHouse,
+  media-encoder, Dex, and SeaweedFS all together. Reaching the lean minimum
+  requires actively trimming (scale media-encoder to 0, unset
+  `WPMGR_CLICKHOUSE_ADDR` and skip the container, remove the Dex dependency).
+- Hosted-production Cloud Run caps (api 1 vCPU/1 GiB, web 1 vCPU/512 MiB,
+  media-encoder 4 vCPU/16 GiB) are a fleet-wide upper bound serving every
+  tenant at once, not a self-host floor.
+
+## See also
+
+- [install.md](./install.md) for the step-by-step setup, including the
+  one-click installer and the S3-networking gotcha for remote WordPress
+  hosts.


### PR DESCRIPTION
## What

Two documentation deliverables, grounded in an architecture-research pass over the actual compose stack, pgx pool config, and GC/retention constants:

### 1. New `docs/requirements.md` (canonical self-host requirements)
There was no minimum-requirements page in the repo. This pins down:
- **Minimum**: 2 vCPU / 2 GB RAM / 20 GB SSD (lean control plane, no Media Optimizer, < 25 sites)
- **Recommended**: 4 vCPU / 8 GB RAM / 100 GB+ SSD (full default stack)
- Tiers by fleet size (< 25 / 25-100 / 100-500+)
- Required vs optional breakdown of all 9 compose services (what each does, whether you can drop it, what dropping it costs)
- Storage guidance (backup chunk storage is the dominant, least-predictable line item; Postgres growth is driven by uptime probes)
- Tuning-knob reference + honest caveats (media-encoder is the RAM swing factor; prod Cloud Run caps are a fleet-wide upper bound, not a self-host floor)

### 2. README one-click quickstart
The repo already ships `scripts/quickstart-selfhost.sh` but the README never surfaced it. Now it's the headline "One-click install (recommended)" path (`curl | bash`), with the build-from-source flow kept below as an alternative.

## Also fixed (stale)
- README prebuilt-image tags `v0.43.3` -> `v0.61.84` (pull lines + `WPMGR_VERSION` export)
- README version string `v0.61.69` -> `v0.61.84`
- `docs/install.md` prerequisites: `~2 GB free RAM` -> `~2 GB lean / ~8 GB full stack`, linking the new requirements page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWiZ4iJ1fmYW8vtPghWmsn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a one-click self-host installation guide with follow-up commands and configuration options.
  * Updated prebuilt container instructions for version v0.61.84.
  * Added detailed system requirements, resource sizing guidance, storage considerations, and service recommendations.
  * Clarified RAM requirements for lean and full-stack installations.
  * Documented required network access, including S3 endpoint reachability.
  * Updated repository layout and added a System requirements link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->