### PR TITLE
docs(readme): surface one-command quickstart at the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 
 ---
 
+## Quick start
+
+Get the whole stack running on your own server with one command, no repo clone needed:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mosamlife/wpmgr/main/scripts/quickstart-selfhost.sh | bash
+```
+
+The script downloads every file the stack needs, generates all secrets, and prints the exact command to bring WPMgr up. You need a 64-bit Linux host with Docker 24+ (2 GB RAM is enough to start). See [system requirements](./docs/requirements.md) for sizing by fleet size, or the [full quickstart](#quickstart-self-host) below for options, prebuilt images, and the build-from-source path.
+
+---
+
 ## Features
 
 ### Fleet connection


### PR DESCRIPTION
## What

Adds a highlighted **Quick start** section directly under the README header, before the (long) Features list, so a first-time visitor immediately sees the one-command self-host install:

```bash
curl -fsSL https://raw.githubusercontent.com/mosamlife/wpmgr/main/scripts/quickstart-selfhost.sh | bash
```

## Why

The install instructions previously lived ~250 lines down, after the full feature catalog. This puts the fastest path to a running stack front and center, with links down to the detailed quickstart (`#quickstart-self-host`) and the [system requirements](./docs/requirements.md) page.

Docs-only, 12-line addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWiZ4iJ1fmYW8vtPghWmsn