### PR TITLE
fix(backup): stop scheduled backups for archived and revoked sites (GH #282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.86] - 2026-07-24
+
+### Fixed
+
+- Archiving a site now stops its scheduled backups (GH #282). Previously the backup scheduler looked only at the schedule row, so a site that had been disconnected and archived kept firing its nightly backup, which then failed because the site is no longer managed and sent a misleading "backup failed" email. The scheduler now skips schedules for archived or revoked sites (and for organizations that have been deleted), while still attempting and alerting for sites that are only temporarily unreachable, since that failure is actionable. A failed backup for an archived or revoked site no longer sends an email, and a manual backup on such a site is refused with a clear message. Restoring a site resumes its schedule automatically on the next scheduler tick.
+
 ## [0.61.85] - 2026-07-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
   <a href="https://wpmgr.app/docs/">API reference</a>
 </p>
 
-**v0.61.85** — open-source and production-usable for self-hosters.
+**v0.61.86** — open-source and production-usable for self-hosters.
 
 ---
 
@@ -313,15 +313,15 @@ Site screenshot cards then fall back to favicon/monogram and the Media Optimizer
 The control plane, dashboard, and media encoder are published on GitHub Container Registry as multi-arch (`linux/amd64` + `linux/arm64`) images, for wiring into your own compose, Kubernetes, or Swarm setup:
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.85
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.85
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.85
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.86
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.86
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.86
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.85   # omit to track :latest
+export WPMGR_VERSION=v0.61.86   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/api/cmd/wpmgr/siteadapter.go
+++ b/apps/api/cmd/wpmgr/siteadapter.go
@@ -139,12 +139,13 @@ func (l *backupSiteLookup) GetBackupSiteInfo(ctx context.Context, tenantID, site
 		return backup.SiteInfo{}, err
 	}
 	return backup.SiteInfo{
-		ID:           s.ID,
-		URL:          s.URL,
-		Enrolled:     s.EnrolledAt != nil,
-		AgeRecipient: s.AgeRecipient,
-		WpTimezone:   s.WpTimezone,
-		WpGmtOffset:  s.WpGmtOffset,
+		ID:              s.ID,
+		URL:             s.URL,
+		Enrolled:        s.EnrolledAt != nil,
+		AgeRecipient:    s.AgeRecipient,
+		WpTimezone:      s.WpTimezone,
+		WpGmtOffset:     s.WpGmtOffset,
+		ConnectionState: string(s.ConnectionState),
 	}, nil
 }
 

--- a/apps/api/internal/backup/gh282_site_state_guard_test.go
+++ b/apps/api/internal/backup/gh282_site_state_guard_test.go
@@ -1,0 +1,234 @@
+package backup
+
+// gh282_site_state_guard_test.go: GH #282 regression, archiving a site did
+// not stop its backup schedule (scheduled backups kept firing/failing/
+// emailing for an unmanaged site). The scheduler-query guard itself lives in
+// SQL (repo.go: ListDueSchedules / ClaimAndAdvanceDueSchedules /
+// HealOverdueSchedules all now JOIN sites + tenants and skip archived/revoked
+// sites and soft-deleted tenants) and is covered by the real-Postgres
+// integration tests in apps/api/tests/backup_gh282_scheduler_guard_test.go.
+//
+// This file covers the two in-memory-fake-testable defense-in-depth guards
+// that sit above the SQL layer:
+//  1. CreateBackup (manual "run now") refuses an archived or revoked site.
+//  2. sendBackupEmail is suppressed for an archived or revoked site, even
+//     when notify_on_completion is configured (covers a manual backup or an
+//     in-flight scheduled backup that fails AFTER the site was archived).
+//
+// All tests use in-memory fakes and a deterministic fakeClock; no database.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// CreateBackup refuses a manual backup on an archived/revoked site.
+// ---------------------------------------------------------------------------
+
+func TestCreateBackup_ArchivedSite_Refused(t *testing.T) {
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	tenantID, siteID := uuid.New(), uuid.New()
+
+	repo := newSchedulerTestRepo()
+	svc := &Service{
+		repo: repo,
+		sites: fakeSites{info: SiteInfo{
+			Enrolled: true, AgeRecipient: "age1test",
+			ConnectionState: ConnStateArchived,
+		}},
+		clock:    fakeClock{t: now},
+		enqueuer: &recordingEnqueuer{},
+	}
+
+	_, err := svc.CreateBackup(context.Background(), tenantID, siteID, uuid.New(), KindFull)
+	if err == nil {
+		t.Fatal("CreateBackup on an archived site: expected error, got nil")
+	}
+	var de *domain.Error
+	if !asError(err, &de) {
+		t.Fatalf("expected a domain.Error, got: %v", err)
+	}
+	if de.Kind != domain.KindValidation {
+		t.Errorf("expected KindValidation, got %v", de.Kind)
+	}
+	if de.Code != "site_not_manageable" {
+		t.Errorf("expected code site_not_manageable, got %q", de.Code)
+	}
+}
+
+func TestCreateBackup_RevokedSite_Refused(t *testing.T) {
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	tenantID, siteID := uuid.New(), uuid.New()
+
+	repo := newSchedulerTestRepo()
+	svc := &Service{
+		repo: repo,
+		sites: fakeSites{info: SiteInfo{
+			Enrolled: true, AgeRecipient: "age1test",
+			ConnectionState: ConnStateRevoked,
+		}},
+		clock:    fakeClock{t: now},
+		enqueuer: &recordingEnqueuer{},
+	}
+
+	_, err := svc.CreateBackup(context.Background(), tenantID, siteID, uuid.New(), KindFull)
+	if err == nil {
+		t.Fatal("CreateBackup on a revoked site: expected error, got nil")
+	}
+	var de *domain.Error
+	if !asError(err, &de) {
+		t.Fatalf("expected a domain.Error, got: %v", err)
+	}
+	if de.Kind != domain.KindValidation {
+		t.Errorf("expected KindValidation, got %v", de.Kind)
+	}
+	if de.Code != "site_not_manageable" {
+		t.Errorf("expected code site_not_manageable, got %q", de.Code)
+	}
+}
+
+// TestCreateBackup_ConnectedSite_NotRefused proves the new guard is narrowly
+// scoped: a connected site (the common case) is unaffected.
+func TestCreateBackup_ConnectedSite_NotRefused(t *testing.T) {
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	tenantID, siteID := uuid.New(), uuid.New()
+
+	repo := newSchedulerTestRepo()
+	svc := &Service{
+		repo: repo,
+		sites: fakeSites{info: SiteInfo{
+			Enrolled: true, AgeRecipient: "age1test",
+			ConnectionState: "connected",
+		}},
+		clock:    fakeClock{t: now},
+		enqueuer: &recordingEnqueuer{},
+	}
+
+	if _, err := svc.CreateBackup(context.Background(), tenantID, siteID, uuid.New(), KindFull); err != nil {
+		t.Fatalf("CreateBackup on a connected site: unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// sendBackupEmail suppresses the notification for an archived/revoked site.
+// ---------------------------------------------------------------------------
+
+// gh282FakeSiteLookup is a SiteLookup whose ConnectionState is settable per
+// test, unlike the package's zero-field fakeSettingsSiteLookup.
+type gh282FakeSiteLookup struct {
+	state string
+}
+
+func (f gh282FakeSiteLookup) GetBackupSiteInfo(_ context.Context, _, _ uuid.UUID) (SiteInfo, error) {
+	return SiteInfo{URL: "https://example.com", Enrolled: true, ConnectionState: f.state}, nil
+}
+func (f gh282FakeSiteLookup) ListSiteIDs(_ context.Context, _ uuid.UUID) ([]uuid.UUID, error) {
+	return nil, nil
+}
+
+func TestSendBackupEmail_ArchivedSite_Suppressed(t *testing.T) {
+	repo := newSettingsFakeRepo()
+	siteID := uuid.New()
+	repo.rows[siteID] = SiteBackupSettings{
+		SiteID:             siteID,
+		NotifyOnCompletion: "always",
+		NotifyRecipients:   []string{"admin@example.com"},
+		CreatedAt:          time.Now(),
+		UpdatedAt:          time.Now(),
+	}
+	mailer := &fakeBackupMailer{}
+	svc := &Service{
+		repo: repo, mailer: mailer,
+		sites: gh282FakeSiteLookup{state: ConnStateArchived},
+		clock: fakeClock{t: time.Now()},
+	}
+
+	snap := Snapshot{ID: uuid.New(), TenantID: uuid.New(), SiteID: siteID}
+	svc.sendBackupEmail(context.Background(), snap, "backup_completed")
+	if mailer.calls != 0 {
+		t.Errorf("archived site: notification must be suppressed; got %d calls", mailer.calls)
+	}
+}
+
+func TestSendBackupEmail_RevokedSite_Suppressed(t *testing.T) {
+	repo := newSettingsFakeRepo()
+	siteID := uuid.New()
+	repo.rows[siteID] = SiteBackupSettings{
+		SiteID:             siteID,
+		NotifyOnCompletion: "on_failure",
+		NotifyRecipients:   []string{"admin@example.com"},
+		CreatedAt:          time.Now(),
+		UpdatedAt:          time.Now(),
+	}
+	mailer := &fakeBackupMailer{}
+	svc := &Service{
+		repo: repo, mailer: mailer,
+		sites: gh282FakeSiteLookup{state: ConnStateRevoked},
+		clock: fakeClock{t: time.Now()},
+	}
+
+	// A failed run against a revoked site (e.g. an in-flight run that lost
+	// the race with the operator revoking mid-flight) must still be
+	// suppressed even though on_failure + backup_failed would otherwise send.
+	snap := Snapshot{ID: uuid.New(), TenantID: uuid.New(), SiteID: siteID}
+	svc.sendBackupEmail(context.Background(), snap, "backup_failed")
+	if mailer.calls != 0 {
+		t.Errorf("revoked site: notification must be suppressed; got %d calls", mailer.calls)
+	}
+}
+
+// TestSendBackupEmail_ConnectedSite_StillSent proves the new guard is
+// narrowly scoped: a connected site's "always" notification still sends.
+func TestSendBackupEmail_ConnectedSite_StillSent(t *testing.T) {
+	repo := newSettingsFakeRepo()
+	siteID := uuid.New()
+	repo.rows[siteID] = SiteBackupSettings{
+		SiteID:             siteID,
+		NotifyOnCompletion: "always",
+		NotifyRecipients:   []string{"admin@example.com"},
+		CreatedAt:          time.Now(),
+		UpdatedAt:          time.Now(),
+	}
+	mailer := &fakeBackupMailer{}
+	svc := &Service{
+		repo: repo, mailer: mailer,
+		sites: gh282FakeSiteLookup{state: "connected"},
+		clock: fakeClock{t: time.Now()},
+	}
+
+	snap := Snapshot{ID: uuid.New(), TenantID: uuid.New(), SiteID: siteID}
+	svc.sendBackupEmail(context.Background(), snap, "backup_completed")
+	if mailer.calls != 1 {
+		t.Errorf("connected site + always policy: expected 1 email, got %d", mailer.calls)
+	}
+}
+
+// TestSendBackupEmail_SiteLookupError_StillSent proves a site-lookup failure
+// falls through to the pre-existing best-effort behaviour (still send) rather
+// than blocking the notification. We cannot confirm archived/revoked, but we
+// must not regress every existing "no site info" delivery either.
+func TestSendBackupEmail_SiteLookupError_StillSent(t *testing.T) {
+	repo := newSettingsFakeRepo()
+	siteID := uuid.New()
+	repo.rows[siteID] = SiteBackupSettings{
+		SiteID:             siteID,
+		NotifyOnCompletion: "always",
+		NotifyRecipients:   []string{"admin@example.com"},
+		CreatedAt:          time.Now(),
+		UpdatedAt:          time.Now(),
+	}
+	mailer := &fakeBackupMailer{}
+	svc := &Service{repo: repo, mailer: mailer, sites: fakeSitesError{err: domain.NotFound("site_not_found", "gone")}, clock: fakeClock{t: time.Now()}}
+
+	snap := Snapshot{ID: uuid.New(), TenantID: uuid.New(), SiteID: siteID}
+	svc.sendBackupEmail(context.Background(), snap, "backup_completed")
+	if mailer.calls != 1 {
+		t.Errorf("site lookup error: expected the pre-existing best-effort send (1 call), got %d", mailer.calls)
+	}
+}

--- a/apps/api/internal/backup/repo.go
+++ b/apps/api/internal/backup/repo.go
@@ -1052,9 +1052,11 @@ func (r *pgRepo) ListDueSchedules(ctx context.Context, now time.Time, limit int3
 	var out []Schedule
 	err := r.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
 		pgRows, err := tx.Query(ctx,
-			scheduleSelectColumns+` FROM backup_schedules
-			  WHERE enabled = true AND next_run_at <= $1
-			  ORDER BY next_run_at ASC
+			scheduleSelectColumnsQualified+` FROM backup_schedules
+			  `+scheduleSiteJoin+`
+			  WHERE backup_schedules.enabled = true AND backup_schedules.next_run_at <= $1
+			  `+scheduleSiteStateGuard+`
+			  ORDER BY backup_schedules.next_run_at ASC
 			  LIMIT $2`,
 			now, limit,
 		)
@@ -1927,6 +1929,43 @@ const scheduleColumnList = `id, tenant_id, site_id, cadence, kind, enabled, rete
 
 const scheduleSelectColumns = `SELECT ` + scheduleColumnList
 
+// scheduleColumnListQualified is scheduleColumnList with every column
+// qualified by the backup_schedules table name. GH #282: the scheduler
+// queries below JOIN sites (and check tenants) to guard against an archived/
+// revoked site or a soft-deleted tenant, and several columns in this list
+// ("id", "tenant_id") also exist on sites/tenants, so an unqualified SELECT
+// against the joined query would raise a Postgres "column reference is
+// ambiguous" error. This constant keeps scanScheduleRow's column order intact
+// while resolving the ambiguity.
+const scheduleColumnListQualified = `backup_schedules.id, backup_schedules.tenant_id, backup_schedules.site_id,
+    backup_schedules.cadence, backup_schedules.kind, backup_schedules.enabled, backup_schedules.retention_days,
+    backup_schedules.monthly_archive_keep, backup_schedules.run_hour, backup_schedules.run_minute,
+    backup_schedules.day_of_week, backup_schedules.day_of_month,
+    backup_schedules.frequency_hours, backup_schedules.keep_last, backup_schedules.incremental_enabled,
+    backup_schedules.base_window_days,
+    backup_schedules.next_run_at, backup_schedules.last_run_at, backup_schedules.created_at, backup_schedules.updated_at`
+
+const scheduleSelectColumnsQualified = `SELECT ` + scheduleColumnListQualified
+
+// scheduleSiteStateGuard is the GH #282 non-destructive site-state guard
+// shared by the three scheduler queries (ListDueSchedules,
+// ClaimAndAdvanceDueSchedules, HealOverdueSchedules): a schedule is only DUE
+// when its site is not deliberately unmanaged (archived or revoked) and its
+// tenant has not been soft-deleted (m93). A transiently disconnected/degraded/
+// pending-enrollment site keeps firing its schedule, because a failed backup
+// on those states is still actionable operator signal; only a deliberate
+// archive or revoke should stop the schedule. Requires the caller's FROM
+// clause to include "JOIN sites s ON s.id = backup_schedules.site_id AND
+// s.tenant_id = backup_schedules.tenant_id".
+const scheduleSiteStateGuard = `
+    AND s.connection_state NOT IN ('archived', 'revoked')
+    AND NOT EXISTS (
+        SELECT 1 FROM tenants t
+         WHERE t.id = backup_schedules.tenant_id AND t.deleted_at IS NOT NULL
+    )`
+
+const scheduleSiteJoin = `JOIN sites s ON s.id = backup_schedules.site_id AND s.tenant_id = backup_schedules.tenant_id`
+
 // scanScheduleRow scans a row produced by scheduleSelectColumns into a
 // Schedule. After m50, Track-A and Track-B fields have moved to
 // site_backup_settings and are no longer present on backup_schedules.
@@ -2575,11 +2614,20 @@ func (r *pgRepo) ClaimAndAdvanceDueSchedules(ctx context.Context, now time.Time,
 	var out []Schedule
 	err := r.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
 		// 1. Lock all due, enabled rows — skip any already locked by a peer.
+		// GH #282: FOR UPDATE OF backup_schedules restricts the row lock to the
+		// backup_schedules rows only. Postgres rejects a bare FOR UPDATE against
+		// a query with an outer/joined table without naming the target relation
+		// once more than one relation is in the FROM list, and even where it
+		// would be accepted, an unqualified FOR UPDATE would also lock the
+		// joined sites row, which is undesired and unnecessary since sites is
+		// read-only here.
 		pgRows, err := tx.Query(ctx,
-			scheduleSelectColumns+` FROM backup_schedules
-			  WHERE enabled = true AND next_run_at <= $1
-			  ORDER BY next_run_at ASC
-			  FOR UPDATE SKIP LOCKED`,
+			scheduleSelectColumnsQualified+` FROM backup_schedules
+			  `+scheduleSiteJoin+`
+			  WHERE backup_schedules.enabled = true AND backup_schedules.next_run_at <= $1
+			  `+scheduleSiteStateGuard+`
+			  ORDER BY backup_schedules.next_run_at ASC
+			  FOR UPDATE OF backup_schedules SKIP LOCKED`,
 			now,
 		)
 		if err != nil {
@@ -2654,8 +2702,10 @@ func (r *pgRepo) HealOverdueSchedules(ctx context.Context, now time.Time, comput
 	var overdueRows []Schedule
 	if err := r.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
 		pgRows, err := tx.Query(ctx,
-			scheduleSelectColumns+` FROM backup_schedules
-			  WHERE enabled = true AND next_run_at <= $1`,
+			scheduleSelectColumnsQualified+` FROM backup_schedules
+			  `+scheduleSiteJoin+`
+			  WHERE backup_schedules.enabled = true AND backup_schedules.next_run_at <= $1
+			  `+scheduleSiteStateGuard,
 			now,
 		)
 		if err != nil {

--- a/apps/api/internal/backup/service.go
+++ b/apps/api/internal/backup/service.go
@@ -21,14 +21,37 @@ import (
 // SiteInfo is the minimal site projection the backup service needs: identity,
 // the agent target URL, enrollment status, and the age PUBLIC recipient backups
 // for the site are encrypted to. WpTimezone/WpGmtOffset are the M17 timezone
-// fields for schedule computation.
+// fields for schedule computation. ConnectionState is the M21 lifecycle state
+// (GH #282): a plain string (not the site package's ConnectionState type) so
+// this package stays free of a site import; compare it against the
+// ConnState* constants below.
 type SiteInfo struct {
-	ID           uuid.UUID
-	URL          string
-	Enrolled     bool
-	AgeRecipient string
-	WpTimezone   string
-	WpGmtOffset  float64
+	ID              uuid.UUID
+	URL             string
+	Enrolled        bool
+	AgeRecipient    string
+	WpTimezone      string
+	WpGmtOffset     float64
+	ConnectionState string
+}
+
+// ConnState* mirror the connection_state values the site package's M21
+// lifecycle uses (site.StateArchived / site.StateRevoked), duplicated here as
+// plain strings so this package needs no site import. GH #282: a site in
+// either of these states is deliberately unmanaged, so its backup schedule
+// must not fire and its manual "run now" must be refused.
+const (
+	ConnStateArchived = "archived"
+	ConnStateRevoked  = "revoked"
+)
+
+// siteIsUnmanageable reports whether si's connection state means the site was
+// deliberately taken out of management (archived or revoked), as opposed to a
+// transient connectivity issue (degraded/disconnected) or a not-yet-enrolled
+// site (pending_enrollment); those keep their schedules live because a
+// failed backup there is still actionable operator signal.
+func siteIsUnmanageable(si SiteInfo) bool {
+	return si.ConnectionState == ConnStateArchived || si.ConnectionState == ConnStateRevoked
 }
 
 // SiteLookup resolves the target site (implemented by the site service, wired
@@ -496,6 +519,16 @@ func (s *Service) CreateBackup(ctx context.Context, tenantID, siteID, createdBy 
 	si, err := s.sites.GetBackupSiteInfo(ctx, tenantID, siteID)
 	if err != nil {
 		return Snapshot{}, err
+	}
+	// GH #282: a manual "run now" against an archived or revoked site is
+	// refused the same way the scheduler skips it. The site was deliberately
+	// taken out of management, so no new backup should start until it is
+	// brought back (restore for archived, re-enroll for revoked).
+	switch si.ConnectionState {
+	case ConnStateArchived:
+		return Snapshot{}, domain.Validation("site_not_manageable", "site is archived; restore it to run backups")
+	case ConnStateRevoked:
+		return Snapshot{}, domain.Validation("site_not_manageable", "site is revoked; re-enroll it to run backups")
 	}
 	if !si.Enrolled {
 		return Snapshot{}, domain.Validation("site_not_enrolled", "the site is not enrolled; only enrolled sites can be backed up")
@@ -3563,6 +3596,17 @@ func (s *Service) sendBackupEmail(ctx context.Context, snap Snapshot, template s
 		return
 	}
 
+	// GH #282: suppress the notification for an archived/revoked site. This
+	// covers a manual "run now" fired just before archiving and a scheduled
+	// run that was already claimed and started before the site was archived
+	// mid-flight (the scheduler guard alone cannot catch either case). A site
+	// lookup failure falls through to the pre-existing best-effort behaviour
+	// (still send; SiteURL just stays empty) rather than blocking on it.
+	si, sierr := s.sites.GetBackupSiteInfo(ctx, snap.TenantID, snap.SiteID)
+	if sierr == nil && siteIsUnmanageable(si) {
+		return
+	}
+
 	data := map[string]any{
 		"SiteURL":    "",
 		"Kind":       snap.Kind,
@@ -3571,7 +3615,7 @@ func (s *Service) sendBackupEmail(ctx context.Context, snap Snapshot, template s
 		"FinishedAt": snap.FinishedAt,
 		"Error":      snap.Error,
 	}
-	if si, sierr := s.sites.GetBackupSiteInfo(ctx, snap.TenantID, snap.SiteID); sierr == nil {
+	if sierr == nil {
 		data["SiteURL"] = si.URL
 	}
 

--- a/apps/api/tests/backup_gh282_scheduler_guard_test.go
+++ b/apps/api/tests/backup_gh282_scheduler_guard_test.go
@@ -1,0 +1,343 @@
+// backup_gh282_scheduler_guard_test.go: GH #282 regression, archiving a site
+// did not stop its backup schedule (scheduled backups kept firing/failing/
+// emailing for an unmanaged site).
+//
+// These run against a REAL Postgres (testcontainers) so the actual guarded
+// SQL in internal/backup/repo.go (ListDueSchedules, ClaimAndAdvanceDueSchedules,
+// HealOverdueSchedules, all three now JOIN sites, and skip a site whose
+// connection_state is archived/revoked or whose tenant is soft-deleted) is
+// exercised end to end, under the real RLS policies, connected as the
+// non-superuser application role. The narrower in-memory-fake coverage for
+// CreateBackup's manual-run guard and sendBackupEmail's suppression lives in
+// internal/backup/gh282_site_state_guard_test.go.
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/backup"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+)
+
+// seedGuardSite inserts a site row with the given connection_state and
+// returns its id. connection_state defaults to 'pending_enrollment' when
+// state == "" (the column's own schema default).
+func seedGuardSite(t *testing.T, admin *db.Pool, tenant uuid.UUID, state string) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	var err error
+	if state == "" {
+		err = admin.QueryRow(context.Background(),
+			`INSERT INTO sites (tenant_id, url, name) VALUES ($1, $2, 'seed') RETURNING id`,
+			tenant, "https://"+uuid.NewString()+".example.com").Scan(&id)
+	} else {
+		err = admin.QueryRow(context.Background(),
+			`INSERT INTO sites (tenant_id, url, name, connection_state) VALUES ($1, $2, 'seed', $3) RETURNING id`,
+			tenant, "https://"+uuid.NewString()+".example.com", state).Scan(&id)
+	}
+	if err != nil {
+		t.Fatalf("seed site (state=%q): %v", state, err)
+	}
+	return id
+}
+
+// seedGuardSchedule inserts a backup_schedules row due at nextRunAt and
+// returns its id. Every other column takes its schema default (enabled=true,
+// daily cadence, etc.); the guard predicate only cares about enabled,
+// next_run_at, and the joined site/tenant state.
+func seedGuardSchedule(t *testing.T, admin *db.Pool, tenant, site uuid.UUID, nextRunAt time.Time) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	err := admin.QueryRow(context.Background(),
+		`INSERT INTO backup_schedules (tenant_id, site_id, next_run_at) VALUES ($1, $2, $3) RETURNING id`,
+		tenant, site, nextRunAt).Scan(&id)
+	if err != nil {
+		t.Fatalf("seed schedule: %v", err)
+	}
+	return id
+}
+
+// readScheduleNextRunAt reads the current next_run_at for a schedule id,
+// truncated to microsecond precision (Postgres timestamptz truncation; see
+// the sibling uptime-rollup precision fix) so it compares safely against a
+// Go time.Time built at nanosecond precision.
+func readScheduleNextRunAt(t *testing.T, admin *db.Pool, id uuid.UUID) time.Time {
+	t.Helper()
+	var next time.Time
+	if err := admin.QueryRow(context.Background(),
+		`SELECT next_run_at FROM backup_schedules WHERE id = $1`, id).Scan(&next); err != nil {
+		t.Fatalf("read schedule next_run_at: %v", err)
+	}
+	return next.Truncate(time.Microsecond)
+}
+
+func setGuardSiteConnectionState(t *testing.T, admin *db.Pool, site uuid.UUID, state string) {
+	t.Helper()
+	if _, err := admin.Exec(context.Background(),
+		`UPDATE sites SET connection_state = $2 WHERE id = $1`, site, state); err != nil {
+		t.Fatalf("update site connection_state: %v", err)
+	}
+}
+
+func softDeleteGuardTenant(t *testing.T, admin *db.Pool, tenant uuid.UUID) {
+	t.Helper()
+	if _, err := admin.Exec(context.Background(),
+		`UPDATE tenants SET deleted_at = now() WHERE id = $1`, tenant); err != nil {
+		t.Fatalf("soft-delete tenant: %v", err)
+	}
+}
+
+func idSet(schedules []backup.Schedule) map[uuid.UUID]bool {
+	out := make(map[uuid.UUID]bool, len(schedules))
+	for _, s := range schedules {
+		out[s.ID] = true
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// ClaimAndAdvanceDueSchedules: the live atomic claim path.
+// ---------------------------------------------------------------------------
+
+// TestBackupSchedulerGuard_ClaimAndAdvance_SkipsArchivedAndRevoked_KeepsOtherStates
+// seeds one due schedule per connection_state and proves: archived and
+// revoked are neither claimed (returned) nor advanced (next_run_at
+// unchanged); connected, degraded, disconnected, and pending_enrollment are
+// both claimed and advanced. This is the primary GH #282 fix surface, the
+// scheduler's actual firing path.
+func TestBackupSchedulerGuard_ClaimAndAdvance_SkipsArchivedAndRevoked_KeepsOtherStates(t *testing.T) {
+	app := startPostgres(t)
+	admin := connectAdmin(t, app)
+	ctx := context.Background()
+
+	tenant := seedTenant(t, admin, "gh282-claim-"+uuid.NewString())
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	due := now.Add(-1 * time.Hour)
+
+	states := map[string]string{
+		"connected":          "connected",
+		"degraded":           "degraded",
+		"disconnected":       "disconnected",
+		"pending_enrollment": "", // "" seeds the schema default, pending_enrollment
+		"archived":           "archived",
+		"revoked":            "revoked",
+	}
+	scheduleIDs := make(map[string]uuid.UUID, len(states))
+	for label, state := range states {
+		site := seedGuardSite(t, admin, tenant, state)
+		scheduleIDs[label] = seedGuardSchedule(t, admin, tenant, site, due)
+	}
+
+	repo := backup.NewRepo(app)
+
+	nextAt := make(map[uuid.UUID]time.Time, len(scheduleIDs))
+	advanceTo := now.Add(24 * time.Hour)
+	for _, id := range scheduleIDs {
+		nextAt[id] = advanceTo
+	}
+
+	claimed, err := repo.ClaimAndAdvanceDueSchedules(ctx, now, nextAt)
+	if err != nil {
+		t.Fatalf("ClaimAndAdvanceDueSchedules: %v", err)
+	}
+	claimedIDs := idSet(claimed)
+
+	keepFiring := []string{"connected", "degraded", "disconnected", "pending_enrollment"}
+	skip := []string{"archived", "revoked"}
+
+	for _, label := range keepFiring {
+		id := scheduleIDs[label]
+		if !claimedIDs[id] {
+			t.Errorf("%s site: schedule was NOT claimed; expected it to keep firing", label)
+		}
+		if got := readScheduleNextRunAt(t, admin, id); !got.Equal(advanceTo) {
+			t.Errorf("%s site: next_run_at = %v, want advanced to %v", label, got, advanceTo)
+		}
+	}
+	for _, label := range skip {
+		id := scheduleIDs[label]
+		if claimedIDs[id] {
+			t.Errorf("%s site: schedule WAS claimed; expected the scheduler to skip a deliberately unmanaged site", label)
+		}
+		if got := readScheduleNextRunAt(t, admin, id); !got.Equal(due) {
+			t.Errorf("%s site: next_run_at = %v, want UNCHANGED at %v (no advance, no enqueue)", label, got, due)
+		}
+	}
+}
+
+// TestBackupSchedulerGuard_ClaimAndAdvance_SkipsSoftDeletedTenant proves a
+// schedule belonging to a soft-deleted tenant (m93) is skipped even though
+// its site is connected: the latent sibling gap on the same query surface.
+func TestBackupSchedulerGuard_ClaimAndAdvance_SkipsSoftDeletedTenant(t *testing.T) {
+	app := startPostgres(t)
+	admin := connectAdmin(t, app)
+	ctx := context.Background()
+
+	tenant := seedTenant(t, admin, "gh282-softdel-"+uuid.NewString())
+	site := seedGuardSite(t, admin, tenant, "connected")
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	due := now.Add(-1 * time.Hour)
+	schedID := seedGuardSchedule(t, admin, tenant, site, due)
+
+	softDeleteGuardTenant(t, admin, tenant)
+
+	repo := backup.NewRepo(app)
+	advanceTo := now.Add(24 * time.Hour)
+	claimed, err := repo.ClaimAndAdvanceDueSchedules(ctx, now, map[uuid.UUID]time.Time{schedID: advanceTo})
+	if err != nil {
+		t.Fatalf("ClaimAndAdvanceDueSchedules: %v", err)
+	}
+	if idSet(claimed)[schedID] {
+		t.Error("soft-deleted tenant: schedule WAS claimed; expected it to be skipped")
+	}
+	if got := readScheduleNextRunAt(t, admin, schedID); !got.Equal(due) {
+		t.Errorf("soft-deleted tenant: next_run_at = %v, want UNCHANGED at %v", got, due)
+	}
+}
+
+// TestBackupSchedulerGuard_RestoredSite_BecomesEligibleAgain proves the
+// guard is non-destructive: once an archived site is restored (connection_state
+// leaves 'archived'), its still-due schedule becomes claimable again on the
+// very next scheduler tick, with no manual re-enable step.
+func TestBackupSchedulerGuard_RestoredSite_BecomesEligibleAgain(t *testing.T) {
+	app := startPostgres(t)
+	admin := connectAdmin(t, app)
+	ctx := context.Background()
+
+	tenant := seedTenant(t, admin, "gh282-restore-"+uuid.NewString())
+	site := seedGuardSite(t, admin, tenant, "archived")
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	due := now.Add(-1 * time.Hour)
+	schedID := seedGuardSchedule(t, admin, tenant, site, due)
+
+	repo := backup.NewRepo(app)
+	advanceTo := now.Add(24 * time.Hour)
+
+	// First tick: still archived, must be skipped.
+	claimed, err := repo.ClaimAndAdvanceDueSchedules(ctx, now, map[uuid.UUID]time.Time{schedID: advanceTo})
+	if err != nil {
+		t.Fatalf("ClaimAndAdvanceDueSchedules (archived): %v", err)
+	}
+	if idSet(claimed)[schedID] {
+		t.Fatal("archived site: schedule was claimed on the first tick; expected it to be skipped")
+	}
+	if got := readScheduleNextRunAt(t, admin, schedID); !got.Equal(due) {
+		t.Fatalf("archived site: next_run_at advanced unexpectedly to %v", got)
+	}
+
+	// Restore: connection_state leaves 'archived' (e.g. site.Restore() moves it
+	// to 'disconnected' pending a fresh heartbeat).
+	setGuardSiteConnectionState(t, admin, site, "disconnected")
+
+	// Second tick: the schedule is still due (never advanced) and the site is
+	// no longer archived, so it must now be claimed and advanced. This is one
+	// immediate catch-up run, which is the accepted/intended behaviour.
+	claimed, err = repo.ClaimAndAdvanceDueSchedules(ctx, now, map[uuid.UUID]time.Time{schedID: advanceTo})
+	if err != nil {
+		t.Fatalf("ClaimAndAdvanceDueSchedules (restored): %v", err)
+	}
+	if !idSet(claimed)[schedID] {
+		t.Fatal("restored site: schedule was NOT claimed; expected it to become eligible again")
+	}
+	if got := readScheduleNextRunAt(t, admin, schedID); !got.Equal(advanceTo) {
+		t.Errorf("restored site: next_run_at = %v, want advanced to %v", got, advanceTo)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListDueSchedules: the candidate-enumeration path (ClaimDueSchedules'
+// pre-computation pass reads this before the atomic claim).
+// ---------------------------------------------------------------------------
+
+func TestBackupSchedulerGuard_ListDueSchedules_ExcludesArchivedAndRevoked(t *testing.T) {
+	app := startPostgres(t)
+	admin := connectAdmin(t, app)
+	ctx := context.Background()
+
+	tenant := seedTenant(t, admin, "gh282-list-"+uuid.NewString())
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	due := now.Add(-1 * time.Hour)
+
+	connectedSite := seedGuardSite(t, admin, tenant, "connected")
+	archivedSite := seedGuardSite(t, admin, tenant, "archived")
+	revokedSite := seedGuardSite(t, admin, tenant, "revoked")
+
+	connectedSchedID := seedGuardSchedule(t, admin, tenant, connectedSite, due)
+	archivedSchedID := seedGuardSchedule(t, admin, tenant, archivedSite, due)
+	revokedSchedID := seedGuardSchedule(t, admin, tenant, revokedSite, due)
+
+	repo := backup.NewRepo(app)
+	due2, err := repo.ListDueSchedules(ctx, now, 200)
+	if err != nil {
+		t.Fatalf("ListDueSchedules: %v", err)
+	}
+	ids := idSet(due2)
+	if !ids[connectedSchedID] {
+		t.Error("connected site's schedule missing from ListDueSchedules")
+	}
+	if ids[archivedSchedID] {
+		t.Error("archived site's schedule present in ListDueSchedules; expected it excluded")
+	}
+	if ids[revokedSchedID] {
+		t.Error("revoked site's schedule present in ListDueSchedules; expected it excluded")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HealOverdueSchedules: the boot-time heal pass.
+// ---------------------------------------------------------------------------
+
+func TestBackupSchedulerGuard_HealOverdueSchedules_SkipsArchivedRevokedAndSoftDeletedTenant(t *testing.T) {
+	app := startPostgres(t)
+	admin := connectAdmin(t, app)
+	ctx := context.Background()
+
+	activeTenant := seedTenant(t, admin, "gh282-heal-active-"+uuid.NewString())
+	deletedTenant := seedTenant(t, admin, "gh282-heal-deleted-"+uuid.NewString())
+	softDeleteGuardTenant(t, admin, deletedTenant)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	due := now.Add(-1 * time.Hour)
+
+	connectedSite := seedGuardSite(t, admin, activeTenant, "connected")
+	archivedSite := seedGuardSite(t, admin, activeTenant, "archived")
+	revokedSite := seedGuardSite(t, admin, activeTenant, "revoked")
+	deletedTenantSite := seedGuardSite(t, admin, deletedTenant, "connected")
+
+	connectedSchedID := seedGuardSchedule(t, admin, activeTenant, connectedSite, due)
+	archivedSchedID := seedGuardSchedule(t, admin, activeTenant, archivedSite, due)
+	revokedSchedID := seedGuardSchedule(t, admin, activeTenant, revokedSite, due)
+	deletedTenantSchedID := seedGuardSchedule(t, admin, deletedTenant, deletedTenantSite, due)
+
+	repo := backup.NewRepo(app)
+	healedTo := now.Add(48 * time.Hour)
+	compute := func(_ backup.Schedule, _ time.Time) time.Time { return healedTo }
+
+	healed, err := repo.HealOverdueSchedules(ctx, now, compute)
+	if err != nil {
+		t.Fatalf("HealOverdueSchedules: %v", err)
+	}
+	if healed != 1 {
+		t.Errorf("healed = %d, want 1 (only the connected site's schedule)", healed)
+	}
+
+	if got := readScheduleNextRunAt(t, admin, connectedSchedID); !got.Equal(healedTo) {
+		t.Errorf("connected site: next_run_at = %v, want healed to %v", got, healedTo)
+	}
+	for label, id := range map[string]uuid.UUID{
+		"archived":            archivedSchedID,
+		"revoked":             revokedSchedID,
+		"soft-deleted tenant": deletedTenantSchedID,
+	} {
+		if got := readScheduleNextRunAt(t, admin, id); !got.Equal(due) {
+			t.Errorf("%s: next_run_at = %v, want UNCHANGED at %v (not healed)", label, got, due)
+		}
+	}
+}

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.85
+  version: 0.61.86
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Fixes #282.

## Root cause
Archiving a site only flips its `connection_state`; the backup scheduler's due-query (`WHERE enabled=true AND next_run_at<=$1`) never joined `sites`, so an archived (or revoked) site kept firing its nightly backup, which then failed because the site is no longer managed and sent a misleading "backup failed" email. The only lifecycle gate was `si.Enrolled`, and `ArchiveSite` never clears `enrolled_at`, so archived sites sailed through.

## Fix (non-destructive site-state guard, CP-only, no migration)
- **All three scheduler queries** (`ListDueSchedules`, `ClaimAndAdvanceDueSchedules`, `HealOverdueSchedules`) now JOIN `sites` and skip `connection_state IN ('archived','revoked')`, plus schedules whose tenant is soft-deleted (a latent sibling gap). The atomic claim uses `FOR UPDATE OF backup_schedules SKIP LOCKED` so only schedule rows are locked.
- **`connected`/`degraded`/`disconnected`/`pending_enrollment` keep firing** so a transiently unreachable site still attempts and alerts (the reporter's nuance: a down agent is actionable, an archived site isn't).
- **Restore is self-healing**: once a site leaves `archived`, its schedule is claimable again on the next tick. No `enabled` flip, so no re-enable dance and no ambiguity between archive-disabled and user-disabled.

## Defense in depth
- `sendBackupEmail` is suppressed for archived/revoked sites (covers a backup already in flight when the site is archived).
- `CreateBackup` refuses a manual backup on an archived/revoked site with a clear message.

## Notes
- `connection_state` is threaded onto `backup.SiteInfo` from the existing `GetSite` read, so **no new query and no sqlc regen** (the three scheduler queries are hand-written raw SQL). The build also caught that the `GetBackupSiteInfo` SQL query is dead code and fixed the real path instead.
- Tests: 7 in-memory + **5 real-Postgres testcontainer** integration tests exercising the guarded SQL under real RLS (one schedule per `connection_state`, asserting both claim and `next_run_at` advancement).
- Adversarially reviewed (security + correctness): both **SHIP**, no must-fix findings; the `FOR UPDATE OF` scoping and multi-tenant JOIN isolation were specifically verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWiZ4iJ1fmYW8vtPghWmsn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Archived or revoked sites no longer receive scheduled backup attempts or misleading backup notifications.
  - Manual backups for archived or revoked sites are blocked with a clear error message.
  - Backup scheduling resumes automatically when a site is restored.
  - Backups are skipped for deleted organizations while remaining eligible sites continue normally.

- **Documentation**
  - Updated version references and release information to 0.61.86.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->