### PR TITLE
fix(agent): make backup upload crash-safe so an interrupted run resumes (GH #283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.87] - 2026-07-24
+
+### Fixed
+
+- Interrupted backups now resume cleanly instead of failing with a missing local chunk (GH #283). During the upload stage the agent deletes each chunk from local disk right after uploading it, but it only recorded which chunks it had uploaded once the whole upload finished. If the server stopped the worker partway through, the resumed backup asked the control plane for upload URLs again, was correctly told to send chunks it had already uploaded and deleted, and then failed looking for the missing local files. The agent now records its upload progress durably as it goes, never deletes a local chunk until that progress is safely persisted, and on resume skips any chunk it has already uploaded. This was surfaced by the v0.61.85 backup watchdog change, which lets a slow backup resume rather than aborting.
+
 ## [0.61.86] - 2026-07-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
   <a href="https://wpmgr.app/docs/">API reference</a>
 </p>
 
-**v0.61.86** — open-source and production-usable for self-hosters.
+**v0.61.87** — open-source and production-usable for self-hosters.
 
 ---
 
@@ -313,15 +313,15 @@ Site screenshot cards then fall back to favicon/monogram and the Media Optimizer
 The control plane, dashboard, and media encoder are published on GitHub Container Registry as multi-arch (`linux/amd64` + `linux/arm64`) images, for wiring into your own compose, Kubernetes, or Swarm setup:
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.86
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.86
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.86
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.87
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.87
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.87
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.86   # omit to track :latest
+export WPMGR_VERSION=v0.61.87   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/agent/includes/backup/class-encrypt-and-upload.php
+++ b/apps/agent/includes/backup/class-encrypt-and-upload.php
@@ -25,9 +25,17 @@
  *      the CP returns presigned PUT URLs ONLY for hashes it doesn't already
  *      have (incremental dedup — repeat backups of the same site re-upload
  *      only the diff). For each (hash, url) the pass reads the local
- *      ciphertext, PUTs it, and on success @unlinks the local file to free
- *      disk progressively. Also @unlinks files for hashes the CP already had
- *      (no PUT needed; the local file is dead weight).
+ *      ciphertext and PUTs it. Also handles hashes the CP already had (no
+ *      PUT needed; the local file is dead weight). GH #283 delete-after-
+ *      persist invariant: a local chunk file is unlinked ONLY after its
+ *      hash has been durably persisted through the caller's checkpoint
+ *      callback (every PERSIST_EVERY_UPLOAD chunks and at the end of every
+ *      sweep): never inline right after the PUT/dedup decision. This keeps
+ *      a worker kill mid-loop safe: any file still on disk after a crash
+ *      belongs to a hash the resumed pass hasn't recorded yet, so it just
+ *      re-PUTs it (content-addressed key, identical bytes); any hash that
+ *      WAS durably recorded is skipped on resume before its (possibly
+ *      already-deleted) local file is ever touched again.
  *
  *   3. submitManifest()
  *      One signed POST to the CP's manifest endpoint with the ordered entries
@@ -101,6 +109,19 @@ final class EncryptAndUpload
 
     /** Emit a progress event every N PUT calls (uploadChunks pass). */
     private const PROGRESS_EVERY_UPLOAD = 4;
+
+    /**
+     * GH #283: durably persist the upload cursor (via the caller-supplied
+     * checkpoint callback) every N successful PUTs/dedup-skips, in addition
+     * to always flushing at the end of each sweep. A worker kill between two
+     * checkpoints can therefore delete at most N local chunk files whose
+     * hashes are not yet durably recorded, and even those are safe to lose,
+     * because the delete-after-persist ordering (see checkpointAndFlush())
+     * guarantees a file is only ever removed AFTER its hash was already
+     * confirmed persisted. A MySQL row UPDATE is on the order of a
+     * millisecond next to a multi-second PUT, so this cadence is cheap.
+     */
+    private const PERSIST_EVERY_UPLOAD = 16;
 
     /**
      * GH #279: default wall-clock heartbeat interval, in seconds. Mirrors
@@ -432,17 +453,41 @@ final class EncryptAndUpload
      * Calls BackupTransport::presignChunks() once with the full hash set; the
      * response is a `{hash => presigned PUT URL}` map of ONLY the hashes the
      * CP hasn't already stored (incremental dedup). For each entry we read
-     * the local ciphertext from scratch, PUT it, and on success @unlink the
-     * local file (free disk as we go). Hashes the CP already had are
-     * @unlink'd outright — no PUT needed.
+     * the local ciphertext from scratch, PUT it, and on success queue the
+     * local file for deletion. Hashes the CP already had are queued for
+     * deletion outright, no PUT needed.
+     *
+     * GH #283 (delete-after-persist invariant): a queued file is deleted
+     * ONLY after its hash has been durably persisted via the `$checkpoint`
+     * callback (see checkpointAndFlush()), every PERSIST_EVERY_UPLOAD
+     * chunks and always once more at the end of each sweep. This makes a
+     * worker kill mid-loop safe: any local file still on disk after a crash
+     * is, by construction, for a hash that was never confirmed persisted, so
+     * the resumed pass simply re-PUTs it (content-addressed key, identical
+     * bytes -> idempotent). Any hash that WAS persisted before the crash is
+     * skipped on resume (the `isset($uploadedHashes[$hash])` guards below,
+     * fed from `$resume['uploaded_hashes']`) before its local file is ever
+     * touched again, so a deleted-but-already-uploaded chunk never trips the
+     * "missing local chunk" throw.
      *
      * @param array<string,mixed> $encryptCursor The cursor returned by encryptChunks() with done=true.
      * @param array<string,mixed> $resume        Upload-pass resume cursor.
      * @param callable            $progress      function(string $phase, array $detail): void
+     * @param callable|null       $checkpoint    GH #283 optional durable-persist hook:
+     *   function(array $partialUploadCursor): void. Called periodically
+     *   during the loop (and once more after each sweep) with the SAME
+     *   shape as this method's return value, but with `done` false. The
+     *   caller is expected to write $partialUploadCursor into its own
+     *   resumable state (e.g. TaskRunner::saveTaskState) BEFORE returning,
+     *   so a thrown exception here safely aborts the pass without deleting
+     *   any file whose hash wasn't actually persisted. When null, local
+     *   files are still queued and flushed in the same batches, just
+     *   without any interim durability guarantee (matches pre-GH-#283
+     *   behavior for callers that don't opt in).
      * @return array<string,mixed> On completion: `done:true`, telemetry.
      * @throws \RuntimeException On transport-level PUT failure.
      */
-    public function uploadChunks(array $encryptCursor, array $resume, callable $progress): array
+    public function uploadChunks(array $encryptCursor, array $resume, callable $progress, ?callable $checkpoint = null): array
     {
         @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- long-running upload pass must not hit max_execution_time; @-guarded, no-op when disabled
         @ignore_user_abort(true);
@@ -502,7 +547,14 @@ final class EncryptAndUpload
             // destination's putChunk no-ops when the file already exists).
             $this->destination->prepare($this->snapshotId);
             $uploads = [];
+            $sinceCheckpoint = 0;
+            /** @var array<string,string> $pendingDeletes hash => local chunk path, flushed only after checkpointAndFlush() has durably persisted it. */
+            $pendingDeletes = [];
             foreach ($allHashes as $hash) {
+                // GH #283: skip a hash the persisted cursor already confirms
+                // uploaded BEFORE ever touching its local file. On a resumed
+                // pass this is what prevents re-reading a file this same
+                // hash's earlier (persisted) checkpoint already deleted.
                 if (isset($uploadedHashes[$hash])) {
                     continue;
                 }
@@ -519,12 +571,24 @@ final class EncryptAndUpload
                 }
                 $bytesUploaded += strlen($cipher);
                 $cipher = '';
-                wp_delete_file($chunkPath);
 
+                // GH #283: record success and queue the local file for
+                // deletion. Do NOT delete yet. checkpointAndFlush() below
+                // persists the cursor first and only then flushes the queue,
+                // so a crash before that point leaves the file on disk for
+                // an idempotent resume (same content-addressed path).
                 $uploadedHashes[$hash] = 1;
+                $pendingDeletes[$hash] = $chunkPath;
                 $putCount++;
                 $chunksDone++;
                 $sinceTick++;
+                $sinceCheckpoint++;
+
+                if ($sinceCheckpoint >= self::PERSIST_EVERY_UPLOAD) {
+                    $this->checkpointAndFlush($checkpoint, $uploadedHashes, $chunksTotal, $putCount, $dedupHits, $bytesUploaded, $pendingDeletes);
+                    $sinceCheckpoint = 0;
+                }
+
                 if ($sinceTick >= self::PROGRESS_EVERY_UPLOAD) {
                     $this->safeProgress($progress, 'encrypting_uploading', [
                         'stage'          => 'upload',
@@ -544,6 +608,11 @@ final class EncryptAndUpload
                     'bytes_uploaded' => $bytesUploaded,
                 ]);
             }
+            // Flush any tail chunks that didn't reach a full PERSIST_EVERY_UPLOAD
+            // batch. GH #283 requires this pass to persist at least once at
+            // the end, not only every N chunks. A no-op when the loop above
+            // already flushed everything on its last iteration.
+            $this->checkpointAndFlush($checkpoint, $uploadedHashes, $chunksTotal, $putCount, $dedupHits, $bytesUploaded, $pendingDeletes);
         } else {
             // CP / s3_compat: legacy bulk-presign + PUT. Both kinds talk to
             // the CP callback identically — only audit/telemetry differ.
@@ -558,21 +627,33 @@ final class EncryptAndUpload
             }
 
             // First sweep: PUT the missing hashes.
+            $sinceCheckpoint = 0;
+            /** @var array<string,string> $pendingDeletes hash => local chunk path, flushed only after checkpointAndFlush() has durably persisted it. */
+            $pendingDeletes = [];
             foreach ($uploads as $hash => $url) {
                 if (!is_string($hash) || $hash === '' || !is_string($url) || $url === '') {
                     continue;
                 }
+                // GH #283: skip a hash the persisted cursor already confirms
+                // uploaded BEFORE the is_file()/throw check below. The CP's
+                // dedup is manifest-scoped and blind to in-flight presigned
+                // PUTs, so a resumed pass can legitimately be re-asked to
+                // "upload" a hash it already finished (and whose local file
+                // it already deleted) in a prior, interrupted run. Without
+                // this guard firing first, that hash would fall through to
+                // the missing-file throw below.
                 if (isset($uploadedHashes[$hash])) {
                     continue;
                 }
                 $chunkPath = $this->chunkPath($scratchDir, $hash);
                 if (!is_file($chunkPath)) {
-                    // The encrypt pass writes chunks-<hash>.age for every chunk we
-                    // emit; if it's gone, either a previous upload pass unlinked
-                    // it (dedup hit on a re-entry) or someone tampered with the
-                    // scratch dir. Treat as already-uploaded only if the CP no
-                    // longer asks for it — but here the CP IS asking for it, so
-                    // this is fatal.
+                    // GH #283: reachable only when a hash is neither in the
+                    // durably persisted uploaded_hashes cursor (the skip
+                    // above) NOR on disk. The delete-after-persist ordering
+                    // enforced by checkpointAndFlush() means every deletion
+                    // is preceded by a successful persist of that same hash,
+                    // so this should never fire in practice; kept as
+                    // defense-in-depth against a tampered scratch dir.
                     throw new \RuntimeException('EncryptAndUpload: missing local chunk for upload: ' . esc_html($hash));
                 }
                 $cipher = @file_get_contents($chunkPath);
@@ -592,13 +673,19 @@ final class EncryptAndUpload
                 $bytesUploaded += strlen($cipher);
                 $cipher         = '';
 
-                // Drop the local copy now we know it's durably uploaded.
-                wp_delete_file($chunkPath);
-
+                // GH #283: record success and queue the local file for
+                // deletion. Do NOT delete yet. See checkpointAndFlush().
                 $uploadedHashes[$hash] = 1;
+                $pendingDeletes[$hash] = $chunkPath;
                 $putCount++;
                 $chunksDone++;
                 $sinceTick++;
+                $sinceCheckpoint++;
+
+                if ($sinceCheckpoint >= self::PERSIST_EVERY_UPLOAD) {
+                    $this->checkpointAndFlush($checkpoint, $uploadedHashes, $chunksTotal, $putCount, $dedupHits, $bytesUploaded, $pendingDeletes);
+                    $sinceCheckpoint = 0;
+                }
 
                 if ($sinceTick >= self::PROGRESS_EVERY_UPLOAD) {
                     $this->safeProgress($progress, 'encrypting_uploading', [
@@ -621,11 +708,18 @@ final class EncryptAndUpload
                     'bytes_uploaded' => $bytesUploaded,
                 ]);
             }
+            // Flush the tail of the first sweep. GH #283 always persists at
+            // the end of a sweep, not only every PERSIST_EVERY_UPLOAD chunks,
+            // so the second sweep's dedup bookkeeping below builds on an
+            // already-durable base.
+            $this->checkpointAndFlush($checkpoint, $uploadedHashes, $chunksTotal, $putCount, $dedupHits, $bytesUploaded, $pendingDeletes);
 
             // Second sweep: drop local files for hashes the CP already had — they
             // weren't in $uploads, so they're not pending upload. (We do this
             // after the PUT loop so disk pressure during uploads is bounded only
             // by chunks we ARE uploading.)
+            $sinceCheckpoint = 0;
+            $pendingDeletes  = [];
             foreach ($allHashes as $hash) {
                 if (isset($uploadedHashes[$hash])) {
                     continue;
@@ -634,14 +728,23 @@ final class EncryptAndUpload
                     // Should have been put above; if not, the loop above threw.
                     continue;
                 }
+                $uploadedHashes[$hash] = 1;
                 $chunkPath = $this->chunkPath($scratchDir, $hash);
                 if (is_file($chunkPath)) {
-                    wp_delete_file($chunkPath);
+                    // GH #283: same delete-after-persist ordering as the PUT
+                    // sweep above: queue, don't delete inline.
+                    $pendingDeletes[$hash] = $chunkPath;
                 }
-                $uploadedHashes[$hash] = 1;
                 $dedupHits++;
                 $chunksDone++;
+                $sinceCheckpoint++;
+                if ($sinceCheckpoint >= self::PERSIST_EVERY_UPLOAD) {
+                    $this->checkpointAndFlush($checkpoint, $uploadedHashes, $chunksTotal, $putCount, $dedupHits, $bytesUploaded, $pendingDeletes);
+                    $sinceCheckpoint = 0;
+                }
             }
+            // Flush the tail of the second sweep.
+            $this->checkpointAndFlush($checkpoint, $uploadedHashes, $chunksTotal, $putCount, $dedupHits, $bytesUploaded, $pendingDeletes);
         }
 
         $this->safeProgress($progress, 'encrypting_uploading', [
@@ -1106,6 +1209,80 @@ final class EncryptAndUpload
             // ignore.
         }
         return $count;
+    }
+
+    /**
+     * GH #283: the delete-after-persist checkpoint. Called from inside
+     * uploadChunks()'s PUT/dedup loops every PERSIST_EVERY_UPLOAD chunks and
+     * once more at the end of every sweep.
+     *
+     * Order is the whole point: persist FIRST, delete SECOND.
+     *   1. If a `$checkpoint` callback was supplied, invoke it with the
+     *      current partial upload cursor (same shape as uploadChunks()'s
+     *      return value, `done` forced false). The caller is expected to
+     *      write this into its own durable resumable state (e.g.
+     *      TaskRunner writes it into `sub_state.upload` via saveTaskState())
+     *      BEFORE this call returns. If the callback throws (the
+     *      persist genuinely failed), the exception propagates out of this
+     *      method and `$pendingDeletes` is never flushed: every file it
+     *      references is left on disk, and the resumed pass will re-PUT (or
+     *      re-skip, for a dedup hit) each one under the same
+     *      content-addressed hash.
+     *   2. Only once step 1 has returned successfully do we unlink every
+     *      file in `$pendingDeletes` and clear the queue.
+     *
+     * Crash-window analysis this ordering guarantees:
+     *   - Crash during the PUT/dedup work itself (before this method is
+     *     even called): the chunk's local file still exists (never queued),
+     *     the cursor was never touched. Resume re-processes it from scratch.
+     *   - Crash inside step 1 (the persist itself failed or the process died
+     *     mid-write): `$pendingDeletes` is never flushed, so every one of
+     *     those files is still on disk. Resume re-PUTs/re-skips them
+     *     idempotently.
+     *   - Crash strictly after step 1 returns (persist succeeded) but during
+     *     or after step 2's deletes: the hash is already durably recorded in
+     *     `uploaded_hashes`, so the resumed pass's `isset($uploadedHashes[...])`
+     *     guard skips it before ever touching the (possibly already-deleted)
+     *     local file.
+     * In every case, a resumed pass either finds the file (re-upload is
+     * idempotent) or finds the hash already persisted (skip before touching
+     * the file), never both "file gone" AND "hash not persisted" together,
+     * which is exactly the state that produced the original "missing local
+     * chunk" throw.
+     *
+     * @param callable|null         $checkpoint     Caller's persist hook, or null to opt out (files still batch-delete, just without an interim durability guarantee).
+     * @param array<string,int>     $uploadedHashes Hash set (hash => 1) accumulated so far this pass.
+     * @param int                   $chunksTotal    Total hash count for this pass (for telemetry parity with the final return shape).
+     * @param int                   $putCount       PUTs performed so far.
+     * @param int                   $dedupHits      Dedup-skip count so far.
+     * @param int                   $bytesUploaded  Bytes PUT so far.
+     * @param array<string,string>  $pendingDeletes hash => absolute local chunk path queued since the previous checkpoint; cleared on return.
+     */
+    private function checkpointAndFlush(
+        ?callable $checkpoint,
+        array $uploadedHashes,
+        int $chunksTotal,
+        int $putCount,
+        int $dedupHits,
+        int $bytesUploaded,
+        array &$pendingDeletes
+    ): void {
+        if ($checkpoint !== null) {
+            $checkpoint([
+                'done'            => false,
+                'chunks_total'    => $chunksTotal,
+                'chunks_put'      => $putCount,
+                'chunks_dedup'    => $dedupHits,
+                'bytes_uploaded'  => $bytesUploaded,
+                'uploaded_hashes' => array_keys($uploadedHashes),
+            ]);
+        }
+        foreach ($pendingDeletes as $path) {
+            if (is_string($path) && $path !== '' && is_file($path)) {
+                wp_delete_file($path);
+            }
+        }
+        $pendingDeletes = [];
     }
 
     /**

--- a/apps/agent/includes/backup/class-task-runner.php
+++ b/apps/agent/includes/backup/class-task-runner.php
@@ -1268,6 +1268,35 @@ final class TaskRunner
             $uploadResume,
             function (string $phase, array $detail): void {
                 $this->onPhaseProgress($phase, $detail);
+            },
+            // GH #283: durable mid-loop checkpoint. Unlike the progress
+            // callback above (observability, best-effort, failures
+            // swallowed), this writes the partial uploaded_hashes cursor
+            // into sub_state.upload via the SAME saveTaskState() path the
+            // outer phase-dispatch loop uses, so a worker kill between two
+            // checkpoints resumes from a cursor that matches exactly which
+            // local chunk files EncryptAndUpload has already deleted. A
+            // thrown saveTaskState() failure here propagates out of
+            // uploadChunks() (per its checkpoint contract) so no local file
+            // is ever deleted on top of an unpersisted cursor.
+            //
+            // GH #283 follow-up: saveTaskState() also has three SILENT
+            // no-op paths (no $wpdb, no resolvable table name, or a
+            // json_encode failure) that persist nothing and return
+            // normally, with no exception to propagate. Left unchecked,
+            // checkpointAndFlush() would see the checkpoint callback return
+            // without throwing and go on to delete this batch's local
+            // chunk files even though uploaded_hashes was never actually
+            // advanced, reproducing the exact "missing local chunk for
+            // upload" failure on the next resume. Treat a false return the
+            // same as a thrown exception: throw here so checkpointAndFlush()
+            // keeps every queued file on disk for the next resume.
+            function (array $partialUploadCursor) use (&$subState): void {
+                $subState['upload'] = $partialUploadCursor;
+                $persisted = $this->saveTaskState(self::PHASE_ENCRYPTING_UPLOADING, $subState);
+                if (!$persisted) {
+                    throw new \RuntimeException('GH283: upload cursor persist failed; keeping local chunks for resume');
+                }
             }
         );
         $subState['upload'] = $upCursor;
@@ -1676,8 +1705,25 @@ final class TaskRunner
      * is done AFTER the sidecar write to avoid a false-positive on the
      * pointer row (the pointer is tiny and should never fail).
      *
+     * GH #283 follow-up: the three early-return paths below (no $wpdb, no
+     * table name, json_encode failure) used to persist nothing and return
+     * NORMALLY, indistinguishable from a genuine durable write to any caller
+     * that only checks "did this throw". A caller relying on "no exception
+     * means durably persisted" (e.g. EncryptAndUpload's checkpoint contract)
+     * could then treat those chunks as safely deletable when nothing was
+     * ever written. The return value makes that distinction explicit: `true`
+     * only when the write genuinely reached durable storage (the DB row or
+     * the sidecar file), `false` on each of the three no-op paths. Existing
+     * callers that ignore the return value are unaffected (PHP permits
+     * discarding a return value); this is purely additive.
+     *
      * @param string              $phase    New phase.
      * @param array<string,mixed> $subState New sub_state to persist.
+     * @return bool True when the state was durably persisted (DB row or
+     *              sidecar file). False on a silent no-op path (no $wpdb, no
+     *              resolvable table name, or json_encode failure): the
+     *              caller should treat this exactly like a thrown exception
+     *              for any invariant that depends on durability.
      * @throws \RuntimeException When the DB write fails AND we cannot fall
      *                           back to the sidecar.
      *
@@ -1685,15 +1731,15 @@ final class TaskRunner
      * overrides this to a no-op so runArchivingFiles can be driven without a
      * live $wpdb.
      */
-    protected function saveTaskState(string $phase, array $subState): void
+    protected function saveTaskState(string $phase, array $subState): bool
     {
         global $wpdb;
         if (!is_object($wpdb)) {
-            return;
+            return false;
         }
         $table = $this->tableName();
         if ($table === '') {
-            return;
+            return false;
         }
 
         $now     = time();
@@ -1704,7 +1750,7 @@ final class TaskRunner
             // part-cursor state we persist; if it does, logging is better
             // than wiping the prior cursor with '{}'.
             \WPMgr\Agent\Support\DebugLog::write('WPMgr TaskRunner: sub_state json_encode failed for phase ' . $phase . ' — skipping state write to preserve the prior cursor');
-            return;
+            return false;
         }
 
         $this->lastDbUpdate = $now;
@@ -1755,6 +1801,8 @@ final class TaskRunner
                 'TaskRunner: DB update failed for phase ' . esc_html($phase) . ' (possible @@max_allowed_packet overflow or connection loss)'
             );
         }
+
+        return true;
     }
 
     /**

--- a/apps/agent/tests/Backup/EncryptAndUploadCheckpointTest.php
+++ b/apps/agent/tests/Backup/EncryptAndUploadCheckpointTest.php
@@ -1,0 +1,584 @@
+<?php
+/**
+ * GH #283: the upload-cursor checkpoint + delete-after-persist invariant.
+ *
+ * Root cause this guards against: uploadChunks() used to delete each local
+ * chunk file immediately after a successful PUT, while the durable
+ * uploaded_hashes cursor was only ever persisted once uploadChunks() fully
+ * RETURNED. A worker killed mid-loop could therefore delete N local chunk
+ * files while persisting zero of them. On resume, the encrypt pass is
+ * skipped (its cursor was already marked done), so those chunk files were
+ * never regenerated, and because the CP's dedup is manifest-scoped, it
+ * re-presigned the very hashes the agent had already uploaded, sending the
+ * resumed pass straight into a "missing local chunk for upload" throw.
+ *
+ * The fix threads an optional checkpoint callback through uploadChunks()
+ * that durably persists the partial cursor every PERSIST_EVERY_UPLOAD
+ * chunks (and once more at the end of every sweep) BEFORE any of that
+ * batch's local files are deleted. These tests exercise that contract
+ * directly against EncryptAndUpload, the same seam TaskRunner wires its
+ * saveTaskState()-backed checkpoint into.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use ReflectionClassConstant;
+use WPMgr\Agent\Backup\EncryptAndUpload;
+use WPMgr\Agent\Support\AgeCrypto;
+use WPMgr\Agent\Support\BackupTransport;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\EncryptAndUpload
+ */
+final class EncryptAndUploadCheckpointTest extends TestCase
+{
+    private string $scratchDir = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+        Functions\when('wp_json_encode')->alias(static fn ($d) => json_encode($d));
+
+        $this->scratchDir = sys_get_temp_dir() . '/wpmgr-encrypt-upload-ckpt-' . bin2hex(random_bytes(6));
+        if (!is_dir($this->scratchDir) && !mkdir($this->scratchDir, 0700, true) && !is_dir($this->scratchDir)) {
+            self::fail('could not create scratch dir for test');
+        }
+    }
+
+    protected function tear_down(): void
+    {
+        $this->rrmdir($this->scratchDir);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * A transport stub that records PUTs without doing real network I/O.
+     * `$onlyHashes` (when non-null) restricts presignChunks() to return a
+     * URL for ONLY those hashes, every other hash is treated by the CP as
+     * already-stored (a dedup hit), matching how a real presign response
+     * omits hashes the CP already has.
+     */
+    private function transport(?array $onlyHashes = null): BackupTransport
+    {
+        return new class($onlyHashes) extends BackupTransport {
+            /** @var array<string,string> hash => uploaded bytes PUT */
+            public array $puts = [];
+            /** @var list<string>|null */
+            public ?array $onlyHashes;
+
+            public function __construct(?array $onlyHashes)
+            {
+                $this->onlyHashes = $onlyHashes;
+            }
+
+            public function presignChunks(string $endpoint, string $snapshotId, array $hashes): array
+            {
+                $uploads = [];
+                foreach ($hashes as $h) {
+                    if ($this->onlyHashes !== null && !in_array($h, $this->onlyHashes, true)) {
+                        continue;
+                    }
+                    $uploads[$h] = 'https://s3.example/put/' . $h;
+                }
+                return $uploads;
+            }
+
+            public function putChunk(string $presignedUrl, string $ciphertext): bool
+            {
+                $hash = substr($presignedUrl, strlen('https://s3.example/put/'));
+                $this->puts[$hash] = $ciphertext;
+                return true;
+            }
+        };
+    }
+
+    private function makePipeline(int $chunkBytes, BackupTransport $transport): EncryptAndUpload
+    {
+        return new EncryptAndUpload(
+            new AgeCrypto(),
+            $transport,
+            'snap-ckpt-1',
+            'age1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+            'https://cp.example/agent/v1/backups/snap-ckpt-1/presign',
+            'https://cp.example/agent/v1/backups/snap-ckpt-1/manifest',
+            $chunkBytes
+        );
+    }
+
+    private function noopProgress(): callable
+    {
+        return static function (string $phase, array $detail): void {
+        };
+    }
+
+    /**
+     * Write an artifact made of $chunkCount distinct, exactly-$chunkBytes-
+     * sized blocks so encryptChunks() produces $chunkCount DISTINCT chunk
+     * hashes (content-addressing means identical blocks would collapse to
+     * the same hash, which would defeat these tests' per-chunk bookkeeping).
+     */
+    private function writeDistinctArtifact(string $name, int $chunkBytes, int $chunkCount): string
+    {
+        $bytes = '';
+        for ($i = 0; $i < $chunkCount; $i++) {
+            $bytes .= str_pad((string) $i, $chunkBytes, '0', STR_PAD_LEFT);
+        }
+        $path = $this->scratchDir . DIRECTORY_SEPARATOR . $name;
+        file_put_contents($path, $bytes);
+        return $path;
+    }
+
+    /**
+     * Ordered blake3 hash list for a manifest entry, by logical path. Robust
+     * to the synthetic environment.json artifact encryptChunks() always
+     * appends, callers ask for exactly the entry they care about instead
+     * of assuming a fixed total chunk count.
+     *
+     * @param array<string,mixed> $encCursor
+     * @return list<string>
+     */
+    private function hashesFor(array $encCursor, string $logical): array
+    {
+        foreach (($encCursor['entries'] ?? []) as $entry) {
+            if (($entry['path'] ?? null) === $logical) {
+                return array_column($entry['chunks'] ?? [], 'blake3');
+            }
+        }
+        self::fail("no manifest entry for path: {$logical}");
+    }
+
+    /**
+     * Mirrors EncryptAndUpload::chunkPath() for ENCRYPT_CHUNKS=false (the
+     * V0/self-hosted default): `chunks-<hash>.bin` under the scratch dir.
+     */
+    private function chunkPathFor(string $hash): string
+    {
+        return $this->scratchDir . DIRECTORY_SEPARATOR . 'chunks-' . $hash . '.bin';
+    }
+
+    /**
+     * (a) Mid-upload-interrupt resume: seed the resume cursor with hashes
+     * whose local files are already gone (as GH #283's fix would leave
+     * behind after a durably-checkpointed batch), present a presign
+     * response that RE-INCLUDES those hashes plus new ones (the CP's
+     * manifest-scoped dedup is blind to in-flight PUTs), and confirm the
+     * resumed uploadChunks() skips the already-uploaded hashes instead of
+     * throwing "missing local chunk for upload", uploads the remaining
+     * hashes, and completes.
+     */
+    public function test_resume_skips_already_uploaded_hashes_whose_local_file_is_gone(): void
+    {
+        $artifactPath = $this->writeDistinctArtifact('blob.bin', 16, 4);
+        $transport    = $this->transport();
+        $pipeline     = $this->makePipeline(16, $transport);
+        $noop         = $this->noopProgress();
+
+        $encCursor = $pipeline->encryptChunks(
+            $this->scratchDir,
+            [['path' => $artifactPath, 'logical' => 'blob.bin']],
+            [],
+            $noop
+        );
+        self::assertTrue($encCursor['done'] ?? false);
+
+        $blobHashes = $this->hashesFor($encCursor, 'blob.bin');
+        self::assertCount(4, $blobHashes, 'expected 4 distinct 16-byte blocks to produce 4 distinct chunks');
+
+        // Simulate the state a GH #283-fixed prior pass leaves behind after
+        // a worker kill immediately following a durable checkpoint: the
+        // first two hashes are recorded in the persisted cursor AND their
+        // local files are already gone.
+        $alreadyUploaded = array_slice($blobHashes, 0, 2);
+        foreach ($alreadyUploaded as $hash) {
+            self::assertTrue(unlink($this->chunkPathFor($hash)));
+        }
+
+        $resume = [
+            'scratch_dir'     => $this->scratchDir,
+            'uploaded_hashes' => $alreadyUploaded,
+        ];
+
+        // The CP re-presigns ALL hashes (including the two already
+        // uploaded), exactly the root-cause scenario: manifest-scoped
+        // dedup is blind to in-flight presigned PUTs from the interrupted
+        // run.
+        $upCursor = $pipeline->uploadChunks($encCursor, $resume, $noop);
+
+        self::assertTrue($upCursor['done'] ?? false, 'resumed uploadChunks must complete, not throw');
+        foreach ($blobHashes as $hash) {
+            self::assertContains($hash, $upCursor['uploaded_hashes']);
+        }
+
+        // The already-uploaded hashes must be SKIPPED, not re-PUT.
+        self::assertArrayNotHasKey($blobHashes[0], $transport->puts, 'an already-uploaded hash must be skipped, not re-PUT');
+        self::assertArrayNotHasKey($blobHashes[1], $transport->puts, 'an already-uploaded hash must be skipped, not re-PUT');
+        // The genuinely new hashes must have been uploaded.
+        self::assertArrayHasKey($blobHashes[2], $transport->puts);
+        self::assertArrayHasKey($blobHashes[3], $transport->puts);
+    }
+
+    /**
+     * (b) Delete-after-persist invariant: for every hash newly reported in a
+     * checkpoint call, its local chunk file must still exist AT THE MOMENT
+     * the checkpoint fires (deletion happens strictly after the checkpoint
+     * callback returns). Uses > PERSIST_EVERY_UPLOAD chunks so the ordering
+     * is exercised across a real mid-loop checkpoint, not just the final
+     * end-of-sweep flush.
+     */
+    public function test_delete_after_persist_ordering(): void
+    {
+        $chunkBytes = 32;
+        $chunkCount = 20; // > PERSIST_EVERY_UPLOAD (16): forces a mid-loop checkpoint + a tail flush.
+
+        $artifactPath = $this->writeDistinctArtifact('blob.bin', $chunkBytes, $chunkCount);
+        $transport    = $this->transport();
+        $pipeline     = $this->makePipeline($chunkBytes, $transport);
+        $noop         = $this->noopProgress();
+
+        $encCursor = $pipeline->encryptChunks(
+            $this->scratchDir,
+            [['path' => $artifactPath, 'logical' => 'blob.bin']],
+            [],
+            $noop
+        );
+        self::assertTrue($encCursor['done'] ?? false);
+
+        $previouslyPersisted = [];
+        $violations          = [];
+        $checkpoint          = function (array $partial) use (&$previouslyPersisted, &$violations): void {
+            $now       = $partial['uploaded_hashes'] ?? [];
+            $newHashes = array_diff($now, $previouslyPersisted);
+            foreach ($newHashes as $hash) {
+                // checkpointAndFlush() must call the checkpoint BEFORE it
+                // deletes any file, so at this exact moment, every
+                // newly-persisted hash's local file must still be present.
+                if (!is_file($this->chunkPathFor($hash))) {
+                    $violations[] = $hash;
+                }
+            }
+            $previouslyPersisted = $now;
+        };
+
+        $upCursor = $pipeline->uploadChunks(
+            $encCursor,
+            ['scratch_dir' => $this->scratchDir],
+            $noop,
+            $checkpoint
+        );
+
+        self::assertTrue($upCursor['done'] ?? false);
+        self::assertSame(
+            [],
+            $violations,
+            'a chunk file must never be deleted before its hash is confirmed persisted via the checkpoint callback'
+        );
+
+        // Once uploadChunks() has fully returned, every uploaded hash's
+        // local file has, in fact, been cleaned up (deletion does happen,
+        // just strictly after persistence).
+        foreach ($upCursor['uploaded_hashes'] as $hash) {
+            self::assertFileDoesNotExist(
+                $this->chunkPathFor($hash),
+                'local chunk file must be deleted once its hash is durably persisted'
+            );
+        }
+    }
+
+    /**
+     * (c) The cursor is persisted mid-loop, not only at the end: for a run
+     * spanning multiple PERSIST_EVERY_UPLOAD batches, the checkpoint
+     * callback must fire more than once, and at least the first call must
+     * report a genuinely partial cursor (done=false, fewer uploaded_hashes
+     * than the total).
+     */
+    public function test_checkpoint_persists_mid_loop_not_only_at_the_end(): void
+    {
+        $chunkBytes = 32;
+        $chunkCount = 20;
+
+        $artifactPath = $this->writeDistinctArtifact('blob.bin', $chunkBytes, $chunkCount);
+        $transport    = $this->transport();
+        $pipeline     = $this->makePipeline($chunkBytes, $transport);
+        $noop         = $this->noopProgress();
+
+        $encCursor = $pipeline->encryptChunks(
+            $this->scratchDir,
+            [['path' => $artifactPath, 'logical' => 'blob.bin']],
+            [],
+            $noop
+        );
+        self::assertTrue($encCursor['done'] ?? false);
+        $totalHashes = count($encCursor['all_hashes']);
+
+        $persistEvery = (int) (new ReflectionClassConstant(EncryptAndUpload::class, 'PERSIST_EVERY_UPLOAD'))->getValue();
+        self::assertGreaterThan($persistEvery, $totalHashes, 'test must exercise at least one mid-loop checkpoint');
+
+        $calls      = [];
+        $checkpoint = function (array $partial) use (&$calls): void {
+            $calls[] = $partial;
+        };
+
+        $upCursor = $pipeline->uploadChunks(
+            $encCursor,
+            ['scratch_dir' => $this->scratchDir],
+            $noop,
+            $checkpoint
+        );
+
+        self::assertTrue($upCursor['done'] ?? false);
+        self::assertGreaterThanOrEqual(
+            2,
+            count($calls),
+            'checkpoint must fire more than once across multiple PERSIST_EVERY_UPLOAD batches'
+        );
+
+        $firstCall = $calls[0];
+        self::assertFalse($firstCall['done'] ?? true, 'a mid-loop checkpoint must report done=false');
+        self::assertLessThan(
+            $totalHashes,
+            count($firstCall['uploaded_hashes'] ?? []),
+            'the first checkpoint must fire while the cursor is still genuinely partial'
+        );
+    }
+
+    /**
+     * (d) Dedup second-sweep hashes (the CP already had them, so they never
+     * appear in the presign response) are still handled correctly: counted
+     * as dedup hits, their local files cleaned up, and never mistaken for a
+     * missing chunk.
+     */
+    public function test_dedup_second_sweep_hashes_are_not_treated_as_missing(): void
+    {
+        $chunkBytes   = 16;
+        $artifactPath = $this->writeDistinctArtifact('blob.bin', $chunkBytes, 4);
+        $transport    = $this->transport();
+        $pipeline     = $this->makePipeline($chunkBytes, $transport);
+        $noop         = $this->noopProgress();
+
+        $encCursor = $pipeline->encryptChunks(
+            $this->scratchDir,
+            [['path' => $artifactPath, 'logical' => 'blob.bin']],
+            [],
+            $noop
+        );
+        self::assertTrue($encCursor['done'] ?? false);
+
+        $blobHashes = $this->hashesFor($encCursor, 'blob.bin');
+        self::assertCount(4, $blobHashes);
+        $envHashes = $this->hashesFor($encCursor, 'environment.json');
+
+        // The CP reports it already has the first two blob chunks (a dedup
+        // hit); they're deliberately OMITTED from the presign response.
+        $dedupHashes   = array_slice($blobHashes, 0, 2);
+        $missingHashes = array_merge(array_slice($blobHashes, 2), $envHashes);
+        $transport->onlyHashes = $missingHashes;
+
+        $calls      = [];
+        $checkpoint = function (array $partial) use (&$calls): void {
+            $calls[] = $partial;
+        };
+
+        $upCursor = $pipeline->uploadChunks(
+            $encCursor,
+            ['scratch_dir' => $this->scratchDir],
+            $noop,
+            $checkpoint
+        );
+
+        self::assertTrue($upCursor['done'] ?? false, 'a dedup hit must never surface as a missing-chunk failure');
+        self::assertSame(2, $upCursor['chunks_dedup'], 'the two CP-already-has hashes must be counted as dedup hits');
+        self::assertSame(count($missingHashes), $upCursor['chunks_put']);
+
+        foreach ($dedupHashes as $hash) {
+            self::assertArrayNotHasKey($hash, $transport->puts, 'a dedup hash must never be PUT');
+            self::assertContains($hash, $upCursor['uploaded_hashes']);
+            self::assertFileDoesNotExist($this->chunkPathFor($hash), 'a dedup-hit local chunk file must still be cleaned up');
+        }
+        foreach ($missingHashes as $hash) {
+            self::assertArrayHasKey($hash, $transport->puts);
+        }
+
+        self::assertNotEmpty($calls, 'the dedup second sweep must also checkpoint, not just the PUT sweep');
+    }
+
+    /**
+     * (e) GH #283 follow-up: saveTaskState() has silent no-op paths (no
+     * $wpdb, no resolvable table name, a json_encode failure) that persist
+     * nothing and return normally. The checkpoint closure in
+     * TaskRunner::runEncryptingUploading() reacts to saveTaskState()
+     * returning false by throwing a RuntimeException, so a failed persist
+     * reaches checkpointAndFlush() as a thrown exception, exactly like this
+     * stub simulates. Proves the invariant end to end: when persistence did
+     * not durably happen, checkpointAndFlush() must NOT delete the queued
+     * local chunk files. Fails against a naive implementation that deletes
+     * the pending queue regardless of what the checkpoint callback does.
+     */
+    public function test_checkpoint_failure_leaves_pending_chunks_on_disk(): void
+    {
+        $chunkBytes   = 16;
+        $artifactPath = $this->writeDistinctArtifact('blob.bin', $chunkBytes, 4);
+        $transport    = $this->transport();
+        $pipeline     = $this->makePipeline($chunkBytes, $transport);
+        $noop         = $this->noopProgress();
+
+        $encCursor = $pipeline->encryptChunks(
+            $this->scratchDir,
+            [['path' => $artifactPath, 'logical' => 'blob.bin']],
+            [],
+            $noop
+        );
+        self::assertTrue($encCursor['done'] ?? false);
+
+        $blobHashes = $this->hashesFor($encCursor, 'blob.bin');
+        self::assertCount(4, $blobHashes);
+        $envHashes = $this->hashesFor($encCursor, 'environment.json');
+
+        // Simulates saveTaskState() signaling a failed persist: the
+        // caller's checkpoint closure throws instead of returning normally.
+        $failingCheckpoint = function (array $partial): void {
+            throw new \RuntimeException('GH283: upload cursor persist failed, keeping local chunks for resume');
+        };
+
+        $threw = false;
+        try {
+            $pipeline->uploadChunks(
+                $encCursor,
+                ['scratch_dir' => $this->scratchDir],
+                $noop,
+                $failingCheckpoint
+            );
+        } catch (\RuntimeException $e) {
+            $threw = true;
+        }
+        self::assertTrue($threw, 'uploadChunks() must propagate a checkpoint persist failure, not swallow it');
+
+        // The whole point of the fix: none of this pass's local chunk files
+        // were deleted, because checkpointAndFlush() never reaches the
+        // delete step once the checkpoint callback throws.
+        foreach (array_merge($blobHashes, $envHashes) as $hash) {
+            self::assertFileExists(
+                $this->chunkPathFor($hash),
+                'a local chunk file must stay on disk when its checkpoint persist failed'
+            );
+        }
+    }
+
+    /**
+     * (f) End-to-end interrupt + resume, seeded from what a mid-loop
+     * checkpoint actually persisted. This is the scenario GH #283 fixes:
+     * pre-fix code deleted each local chunk file immediately after a
+     * successful PUT and only persisted the uploaded_hashes cursor once
+     * uploadChunks() fully RETURNED, so an interrupt this early would have
+     * captured an EMPTY cursor and a resume seeded from it would have hit
+     * the "missing local chunk for upload" throw once it reached the
+     * already-deleted, not-yet-recorded hashes.
+     *
+     * Drives a real checkpoint that records the FIRST partial cursor it
+     * sees, then throws to simulate a worker kill right after that first
+     * durable persist. Asserts the captured cursor is genuinely partial
+     * (proves persistence already happened mid-loop, not only at the end),
+     * then feeds that exact cursor into a fresh uploadChunks() call and
+     * asserts it completes cleanly.
+     */
+    public function test_interrupted_resume_seeded_from_mid_loop_checkpoint_completes(): void
+    {
+        $chunkBytes = 32;
+        $chunkCount = 20; // > PERSIST_EVERY_UPLOAD (16): forces a real mid-loop checkpoint.
+
+        $artifactPath = $this->writeDistinctArtifact('blob.bin', $chunkBytes, $chunkCount);
+        $transport    = $this->transport();
+        $pipeline     = $this->makePipeline($chunkBytes, $transport);
+        $noop         = $this->noopProgress();
+
+        $encCursor = $pipeline->encryptChunks(
+            $this->scratchDir,
+            [['path' => $artifactPath, 'logical' => 'blob.bin']],
+            [],
+            $noop
+        );
+        self::assertTrue($encCursor['done'] ?? false);
+        $totalHashes = count($encCursor['all_hashes']);
+
+        $persistEvery = (int) (new ReflectionClassConstant(EncryptAndUpload::class, 'PERSIST_EVERY_UPLOAD'))->getValue();
+        self::assertGreaterThan($persistEvery, $totalHashes, 'test must exercise at least one mid-loop checkpoint');
+
+        $capturedCursor = null;
+        $interruptingCheckpoint = function (array $partial) use (&$capturedCursor): void {
+            $capturedCursor = $partial;
+            throw new \RuntimeException('simulated worker kill right after the first durable checkpoint');
+        };
+
+        $interrupted = false;
+        try {
+            $pipeline->uploadChunks(
+                $encCursor,
+                ['scratch_dir' => $this->scratchDir],
+                $noop,
+                $interruptingCheckpoint
+            );
+        } catch (\RuntimeException $e) {
+            $interrupted = true;
+        }
+        self::assertTrue($interrupted, 'the simulated interrupt must abort uploadChunks()');
+        self::assertNotNull($capturedCursor, 'the checkpoint must have fired at least once before the interrupt');
+
+        $firstBatchHashes = $capturedCursor['uploaded_hashes'] ?? [];
+        self::assertSame(
+            $persistEvery,
+            count($firstBatchHashes),
+            'the first checkpoint must fire after exactly PERSIST_EVERY_UPLOAD chunks, proving persistence already happened mid-loop (pre-fix code persisted nothing until the pass fully returned, so this would have been empty)'
+        );
+
+        // Resume: a fresh uploadChunks() call seeded from exactly what the
+        // interrupted run's first checkpoint persisted.
+        $resumeCursor = $pipeline->uploadChunks(
+            $encCursor,
+            [
+                'scratch_dir'     => $this->scratchDir,
+                'uploaded_hashes' => $firstBatchHashes,
+            ],
+            $noop
+        );
+
+        self::assertTrue(
+            $resumeCursor['done'] ?? false,
+            'a resume seeded from the mid-loop-persisted cursor must complete, not throw missing local chunk for upload'
+        );
+        foreach ($encCursor['all_hashes'] as $hash) {
+            self::assertContains($hash, $resumeCursor['uploaded_hashes']);
+        }
+    }
+
+    /**
+     * Recursively delete a directory tree (used by tear_down).
+     */
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            if (is_file($dir) || is_link($dir)) {
+                @unlink($dir);
+            }
+            return;
+        }
+        $entries = scandir($dir);
+        if ($entries === false) {
+            return;
+        }
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $this->rrmdir($dir . DIRECTORY_SEPARATOR . $entry);
+        }
+        @rmdir($dir);
+    }
+}

--- a/apps/agent/tests/Backup/TaskRunnerTest.php
+++ b/apps/agent/tests/Backup/TaskRunnerTest.php
@@ -258,6 +258,94 @@ final class TaskRunnerTest extends TestCase
     }
 
     /**
+     * GH #283 follow-up: saveTaskState() must return true only when the
+     * write genuinely reached durable storage. A successful $wpdb->update()
+     * is the durable case.
+     */
+    public function test_save_task_state_returns_true_on_durable_persist(): void
+    {
+        $wpdb = new CapturingWpdb();
+        $GLOBALS['wpdb'] = $wpdb;
+
+        try {
+            $runner     = $this->buildRunner(TaskRunner::KIND_FULL);
+            $reflection = new ReflectionClass(TaskRunner::class);
+            $save       = $reflection->getMethod('saveTaskState');
+            $result     = $save->invoke($runner, TaskRunner::PHASE_ENCRYPTING_UPLOADING, ['upload' => ['uploaded_hashes' => ['abc']]]);
+
+            $this->assertTrue($result, 'a successful DB write must report true, not just "did not throw"');
+        } finally {
+            unset($GLOBALS['wpdb']);
+        }
+    }
+
+    /**
+     * GH #283 follow-up: saveTaskState() has three silent no-op paths that
+     * persist nothing and return normally, with nothing to throw. Each one
+     * must now report false so a caller relying on "did this throw" alone
+     * (the old bug) can instead check the return value.
+     */
+    public function test_save_task_state_returns_false_when_wpdb_missing(): void
+    {
+        unset($GLOBALS['wpdb']);
+
+        $runner     = $this->buildRunner(TaskRunner::KIND_FULL);
+        $reflection = new ReflectionClass(TaskRunner::class);
+        $save       = $reflection->getMethod('saveTaskState');
+        $result     = $save->invoke($runner, TaskRunner::PHASE_ENCRYPTING_UPLOADING, ['upload' => ['uploaded_hashes' => ['abc']]]);
+
+        $this->assertFalse($result, 'no $wpdb at all is a silent no-op and must report false, not just "did not throw"');
+    }
+
+    /**
+     * See test_save_task_state_returns_false_when_wpdb_missing for context.
+     * This covers the second silent path: $wpdb is present but the table
+     * name cannot be resolved (an empty prefix).
+     */
+    public function test_save_task_state_returns_false_when_table_name_unresolvable(): void
+    {
+        $wpdb = new CapturingWpdb();
+        $wpdb->prefix = '';
+        $GLOBALS['wpdb'] = $wpdb;
+
+        try {
+            $runner     = $this->buildRunner(TaskRunner::KIND_FULL);
+            $reflection = new ReflectionClass(TaskRunner::class);
+            $save       = $reflection->getMethod('saveTaskState');
+            $result     = $save->invoke($runner, TaskRunner::PHASE_ENCRYPTING_UPLOADING, ['upload' => ['uploaded_hashes' => ['abc']]]);
+
+            $this->assertFalse($result, 'an unresolvable table name is a silent no-op and must report false, not just "did not throw"');
+        } finally {
+            unset($GLOBALS['wpdb']);
+        }
+    }
+
+    /**
+     * See test_save_task_state_returns_false_when_wpdb_missing for context.
+     * This covers the third silent path: json_encode() itself fails
+     * (malformed UTF8 bytes in sub_state, which json_encode rejects by
+     * default with no flags to coerce or escape it).
+     */
+    public function test_save_task_state_returns_false_when_json_encode_fails(): void
+    {
+        $wpdb = new CapturingWpdb();
+        $GLOBALS['wpdb'] = $wpdb;
+
+        try {
+            $runner     = $this->buildRunner(TaskRunner::KIND_FULL);
+            $reflection = new ReflectionClass(TaskRunner::class);
+            $save       = $reflection->getMethod('saveTaskState');
+            // "\xB1\x31" is not valid UTF8, so json_encode() returns false.
+            $result = $save->invoke($runner, TaskRunner::PHASE_ENCRYPTING_UPLOADING, ['bad' => "\xB1\x31"]);
+
+            $this->assertFalse($result, 'a json_encode failure is a silent no-op and must report false, not just "did not throw"');
+            $this->assertNull($wpdb->lastSubState, 'nothing should have reached the DB update call');
+        } finally {
+            unset($GLOBALS['wpdb']);
+        }
+    }
+
+    /**
      * Build a TaskRunner with a minimal, syntactically-valid params payload.
      * We never actually touch the network/disk in these tests — the
      * reflection-driven asserts target pure transition helpers.

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.85
+ * Version:           0.61.87
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.85');
+define('WPMGR_AGENT_VERSION', '0.61.87');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,29 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.87",
+    date: "2026-07-24",
+    summary: "Backup reliability improvements for large sites and slow servers.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Full backups on slow servers no longer fail at the upload stage (GH #279). A large backup that went quiet for a while during archiving could be wrongly marked failed while it was still running. The control plane now flags a quiet backup as taking longer than expected but keeps it running, and only fails it after a much longer, configurable timeout.",
+      },
+      {
+        tag: "Fixed",
+        text: "An interrupted backup now resumes cleanly instead of failing (GH #283). If the server stopped a backup partway through its upload, the resumed run could fail looking for a chunk it had already uploaded and cleaned up. The agent now records its upload progress durably as it goes and skips work it has already completed on resume.",
+      },
+      {
+        tag: "Fixed",
+        text: "Archiving a site now stops its scheduled backups (GH #282). An archived or removed site kept running its nightly backup, which then failed and sent a misleading failure email. Archived and removed sites are now skipped, while a temporarily unreachable site still attempts its backup and alerts you.",
+      },
+      {
+        tag: "Fixed",
+        text: "Backups no longer time out on OpenLiteSpeed and LiteSpeed servers (GH #274). The agent now acknowledges a backup request and continues the work in the background using whichever mechanism the server supports.",
+      },
+    ],
+  },
+  {
     version: "0.61.81",
     date: "2026-07-22",
     summary: "Fixes command updates failing on sites where another plugin globally intercepts the Authorization header.",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.81 / open source",
+  badge: "v0.61.87 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.86
+  version: 0.61.87
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Fixes #283.

## Root cause
During `encrypting_uploading` the agent deletes each local chunk right after its PUT (to shrink disk), but it only persisted the `uploaded_hashes` cursor when the whole upload returned, **never mid-loop**. A PHP worker kill mid-upload deleted N chunk files with **zero** of them checkpointed. On resume the encrypt pass is skipped (so files aren't regenerated), the CP re-presigns the already-uploaded chunks (its dedup `ExistingChunkHashes` is **manifest-scoped**, blind to in-flight presigned PUTs), and the agent hard-failed reading the deleted local file:

```
EncryptAndUpload: missing local chunk for upload: <hash>
```

The #279 soft-stall **exposed** this (didn't cause it): the resumed presign now returns 200 instead of the pre-#279 422 that used to abort cleanly.

## Fix (agent-only, path-agnostic, no CP change)
- **`checkpointAndFlush()`** batches deletions: PUT/dedup → queue the file path → every `PERSIST_EVERY_UPLOAD` chunks (and at the end of each sweep) persist the cursor via `saveTaskState`, and **only after a durable persist** delete the batch's local files.
- **Invariant:** never delete a chunk whose uploaded-hash is not yet durably recorded, so a crash in any window re-PUTs it idempotently (content-addressed key).
- **`saveTaskState` now returns `bool`**; the checkpoint closure throws if a persist did not durably land (the three silent no-op paths: no `$wpdb`, empty table, `json_encode` failure), so `checkpointAndFlush` keeps the files for the next resume.
- **On resume**, the upload sweep skips any presigned hash already in the persisted cursor (it's already in the bucket), removing the missing-chunk throw.
- **No re-encrypt** (the `ENCRYPT_CHUNKS=true` path is non-deterministic); skip-by-cursor is correct for both the raw and encrypted paths.

## Verification
- Agent: `phpcs` 0 errors, full `phpunit` suite **2829 green**, `make agent-plugincheck` **0 errors**.
- 6 tests in `EncryptAndUploadCheckpointTest` (resume-skip end-to-end, delete-after-persist ordering, mid-loop cadence, persist-failure-keeps-files, dedup sweep) + 4 `saveTaskState` bool-contract tests. The resume tests **fail against pre-fix code**.
- Adversarially reviewed (security + correctness): both **SHIP**; the one invariant hole (silent no-op persist could still delete) and the test-strength finding were folded in.

Agent-only fix. Marketing changelog backfilled to 0.61.87 (it was about to exceed the drift-guard tolerance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWiZ4iJ1fmYW8vtPghWmsn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Interrupted backups now resume reliably without failing when previously uploaded chunk files are no longer available.
  - Backup progress is saved before local chunks are removed, improving crash recovery and preventing data loss during retries.
  - Duplicate chunks are handled correctly during resumed backups.

- **Documentation**
  - Added release notes for version 0.61.87.

- **Chores**
  - Updated displayed application, container, API, and marketing version numbers to 0.61.87.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->