### PR TITLE
chore(security): pin postcss 8.5.18 + backfill marketing changelog 0.61.88

### DIFF
--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,17 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.88",
+    date: "2026-07-24",
+    summary: "Choose which account one-click wp-admin login uses, per site.",
+    items: [
+      {
+        tag: "Added",
+        text: "A per-site default account for one-click sign in (GH #286). On a site with several administrators, one-click login used to land on whichever admin had the lowest user ID, which was opaque and hard to audit. You can now pick the default account in Site settings under Access, or set it while logging in as a specific user, and the wp-admin button shows which account it will use. Leaving it blank keeps the previous behavior of signing in as the first administrator. The audit trail now records the actual account used, and existing site agents honor the setting with no update.",
+      },
+    ],
+  },
+  {
     version: "0.61.87",
     date: "2026-07-24",
     summary: "Backup reliability improvements for large sites and slow servers.",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.87 / open source",
+  badge: "v0.61.88 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   js-yaml@3: 3.15.0
   js-yaml@4: 4.3.0
   sharp: 0.35.3
-  postcss: 8.5.12
+  postcss: 8.5.18
 
 importers:
 
@@ -4588,8 +4588,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  postcss@8.5.12:
-    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   powershell-utils@0.1.0:
@@ -7627,7 +7627,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
-      postcss: 8.5.12
+      postcss: 8.5.18
       tailwindcss: 4.3.1
 
   '@tailwindcss/vite@4.3.0(vite@6.4.2(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
@@ -8138,7 +8138,7 @@ snapshots:
       '@vue/shared': 3.5.38
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.12
+      postcss: 8.5.18
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.38':
@@ -9985,7 +9985,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.32
       caniuse-lite: 1.0.30001793
-      postcss: 8.5.12
+      postcss: 8.5.18
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(react@19.2.6)
@@ -10138,7 +10138,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss@8.5.12:
+  postcss@8.5.18:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -10992,7 +10992,7 @@ snapshots:
   vite@5.4.21(@types/node@24.13.2)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.5.12
+      postcss: 8.5.18
       rollup: 4.60.4
     optionalDependencies:
       '@types/node': 24.13.2
@@ -11004,7 +11004,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.12
+      postcss: 8.5.18
       rollup: 4.60.4
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,10 +15,11 @@ overrides:
   # 0.35.0+; Next pulls it as an optional dep for image optimization and its
   # transform API is unchanged across this bump. Verified the marketing build.
   sharp: 0.35.3
-  # postcss <=8.5.11 allows arbitrary file read via a crafted source map
-  # (GHSA-6g55-p6wh-862q). Patched in 8.5.12; Next pulls it transitively and the
-  # patch is a same-major bug fix, so no API change. Verified the marketing build.
-  postcss: 8.5.12
+  # postcss path/source-map advisories (GHSA-6g55-p6wh-862q file read, then
+  # GHSA-r28c-9q8g-f849 path traversal in a previous source map, fixed in
+  # 8.5.18). Next pulls postcss transitively; these are same-major bug fixes, so
+  # no API change. Verified the marketing build.
+  postcss: 8.5.18
 allowBuilds:
   esbuild: true
   # Puppeteer's postinstall downloads ~100 MB of Chromium. Disabled because


### PR DESCRIPTION
## Security audit fix
`pnpm audit --prod --audit-level high` went **red on main** after a newly-published advisory: **GHSA-r28c-9q8g-f849** (postcss path traversal in a previous source map, `<=8.5.17`, patched `>=8.5.18`), pulled transitively through `next` in `apps/marketing`. The prior override pinned `8.5.12`, now below the fix, so it re-tripped. Bumped the workspace override to `postcss 8.5.18` (same-major bug fix, marketing build verified). Audit now reports `2 low / 1 moderate`, no high.

## Marketing changelog
Added the **0.61.88 (GH #286, per-site default Login As User)** entry to the marketing changelog and bumped the home badge, so the public `/changelog` reflects the current release instead of lagging (it was at 0.61.87).

Docs/deps only; no version bump (supports the current 0.61.88 release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWiZ4iJ1fmYW8vtPghWmsn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a per-site default account setting for one-click wp-admin login.
  * Existing site agents and audit trails now honor this setting.
  * Leaving the setting blank preserves the current login behavior.

* **Documentation**
  * Updated the changelog and homepage version badge to 0.61.88.

* **Security**
  * Updated the PostCSS version to include the latest advisory fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->