### PR TITLE
fix(uptime): stop showing a broken site as Up when its cache is masking it (GH #291, phases 0+1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.90] - 2026-07-27
+
+### Fixed
+
+- A site whose WordPress had stopped working could still show as fully "Up" on the fleet view (GH #291). The uptime check requests the site's homepage, and on a site with page caching that page can be served straight from the cache without WordPress running at all, so a completely broken site kept returning a healthy response. WPMgr already knew better: when the site agent stops answering, the control plane verifies it over a signed request that cannot be cached, and marks the site disconnected. That signal was being ignored when deciding what to show. A site that is serving cached pages while its agent is unreachable is now shown as degraded, with a plain explanation of what that means and what is likely broken, instead of a reassuring green tick. Sites where the agent was deliberately deactivated or uninstalled are unaffected and still show as normal.
+- Uptime figures themselves are unchanged by this release. A cached page that loads is still counted as up, because visitors really are being served; what changed is only what the dashboard tells you about the state behind it.
+
+### Changed
+
+- For self-hosted installs using the optional ClickHouse metrics backend, the uptime table now adds any missing columns on startup instead of silently keeping an outdated shape. A failure to do so is logged and no longer prevents the control plane from starting, since metrics should never block site management.
+
 ## [0.61.89] - 2026-07-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
   <a href="https://wpmgr.app/docs/">API reference</a>
 </p>
 
-**v0.61.89** — open-source and production-usable for self-hosters.
+**v0.61.90** — open-source and production-usable for self-hosters.
 
 ---
 
@@ -313,15 +313,15 @@ Site screenshot cards then fall back to favicon/monogram and the Media Optimizer
 The control plane, dashboard, and media encoder are published on GitHub Container Registry as multi-arch (`linux/amd64` + `linux/arm64`) images, for wiring into your own compose, Kubernetes, or Swarm setup:
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.89
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.89
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.89
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.90
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.90
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.90
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.89   # omit to track :latest
+export WPMGR_VERSION=v0.61.90   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/api/internal/agentcmd/client.go
+++ b/apps/api/internal/agentcmd/client.go
@@ -3,11 +3,17 @@ package agentcmd
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -298,6 +304,47 @@ func (c *Client) Ping(ctx context.Context, siteID uuid.UUID, siteURL string) (Pi
 	return out, nil
 }
 
+// ReachabilityReason classifies WHY VerifyReachableWithReason concluded alive
+// or not-alive (GH #291 Task 3). Under the old bool-only contract an agent
+// that is merely UNINSTALLED (nothing answers the wpmgr routes at all) looked
+// identical to one whose SITE IS BROKEN (the plugin is there but PHP is
+// fatal-ing), both collapsed to alive=false with no way to tell them apart.
+// That ambiguity would produce false alarms in a later alerting phase, so the
+// reason is classified here, up front, even though this phase does not yet
+// act on it.
+type ReachabilityReason string
+
+const (
+	// ReasonAlive: a check succeeded (ping 2xx ok=true, or the metadata
+	// fallback returned a recognizably agent-shaped 2xx).
+	ReasonAlive ReachabilityReason = "alive"
+	// ReasonAgentAbsent404: ping AND the metadata fallback both 404'd,
+	// meaning nothing that looks like the plugin is installed at this URL at
+	// all, as opposed to an installed-but-broken agent.
+	ReasonAgentAbsent404 ReachabilityReason = "agent_absent_404"
+	// ReasonHTTP4xx: the agent (or something at the URL) answered with a
+	// non-404 client error (400/401/403/etc). The server responded, so
+	// something booted, but the request was rejected.
+	ReasonHTTP4xx ReachabilityReason = "http_4xx"
+	// ReasonHTTP5xx: the agent responded but with a server error, the
+	// strongest "installed but broken" signal short of a hard transport
+	// failure, and the case GH #291 needs to be able to name.
+	ReasonHTTP5xx ReachabilityReason = "http_5xx"
+	// ReasonTimeout: the dial or read exceeded the caller's deadline.
+	ReasonTimeout ReachabilityReason = "timeout"
+	// ReasonTLSError: the TLS handshake failed (expired/mismatched/untrusted
+	// certificate, or a non-TLS response on an https port).
+	ReasonTLSError ReachabilityReason = "tls_error"
+	// ReasonNotAgentShaped: something answered 2xx but the body was not
+	// agent-shaped JSON (captive portal, generic maintenance splash), so the
+	// URL is reachable, but not by our agent.
+	ReasonNotAgentShaped ReachabilityReason = "not_agent_shaped"
+	// ReasonUnreachable is the catch-all transport failure (connection
+	// refused, DNS failure, SSRF-blocked, JWT-mint failure, etc) that does
+	// not match any of the more specific classifications above.
+	ReasonUnreachable ReachabilityReason = "unreachable"
+)
+
 // VerifyReachable implements the 0.44.0 liveness-fallback contract:
 //
 //  1. Try the `ping` command (new agents).  A 2xx response means alive.
@@ -310,14 +357,30 @@ func (c *Client) Ping(ctx context.Context, siteID uuid.UUID, siteURL string) (Pi
 // (e.g. JWT-mint failure). Response bodies are discarded beyond the minimal
 // decode needed to detect the error; nothing is logged by this function —
 // callers should emit structured log lines with the returned outcome.
+//
+// This is a thin wrapper around VerifyReachableWithReason that discards the
+// classified reason, so the two implementations can never drift and every
+// existing caller (the connection Sweeper's AgentVerifier interface, and its
+// tests) is unaffected by the addition of the reason.
 func (c *Client) VerifyReachable(ctx context.Context, siteID uuid.UUID, siteURL string) (alive bool, fallbackUsed bool, err error) {
+	alive, fallbackUsed, _, err = c.VerifyReachableWithReason(ctx, siteID, siteURL)
+	return alive, fallbackUsed, err
+}
+
+// VerifyReachableWithReason is VerifyReachable's typed-reason superset (GH
+// #291 Task 3): identical alive/fallbackUsed/err outcomes for every case
+// VerifyReachable already handles, plus a ReachabilityReason classification
+// of WHY. Persisting or alerting on the reason is intentionally out of scope
+// for this phase; it is classified here so a later phase does not have to
+// re-derive it from scratch.
+func (c *Client) VerifyReachableWithReason(ctx context.Context, siteID uuid.UUID, siteURL string) (alive bool, fallbackUsed bool, reason ReachabilityReason, err error) {
 	out, pingErr := c.Ping(ctx, siteID, siteURL)
 	if pingErr == nil && out.OK {
-		return true, false, nil
+		return true, false, ReasonAlive, nil
 	}
 
 	// Fall back to the metadata command when ping looks like an old agent
-	// (404/400 unknown command) — or when something answered 2xx without the
+	// (404/400 unknown command) or when something answered 2xx without the
 	// agent-shaped ok field (captive portal, generic maintenance page): the
 	// metadata shape check below settles whether a real agent is behind it.
 	fallback := pingErr == nil && !out.OK
@@ -329,16 +392,110 @@ func (c *Client) VerifyReachable(ctx context.Context, siteID uuid.UUID, siteURL 
 	if fallback {
 		raw, metaErr := c.MetadataRaw(ctx, siteID, siteURL)
 		if metaErr == nil && looksLikeAgentMetadata(raw) {
-			return true, true, nil
+			return true, true, ReasonAlive, nil
 		}
-		// Both ping and shape-checked metadata failed — not alive.
-		return false, true, nil
+		// Both ping and shape-checked metadata failed, so not alive. Classify
+		// using whichever error is available: a hard 404 on ping means
+		// "nothing here at all", while a 2xx-but-wrong-shape ping means
+		// something answered, just not our agent.
+		if pingErr != nil {
+			if status, ok := extractHTTPStatus(pingErr); ok && status == http.StatusNotFound {
+				return false, true, ReasonAgentAbsent404, nil
+			}
+			return false, true, classifyTransportErr(pingErr), nil
+		}
+		return false, true, ReasonNotAgentShaped, nil
 	}
 
-	// Hard transport / 5xx failure on ping — not alive.  The JWT-mint path
+	// Hard transport / 5xx failure on ping, so not alive. The JWT-mint path
 	// returns a format error (no status code), so it falls here too: treat it
 	// as not alive rather than an infra error, to avoid blocking the sweeper.
-	return false, false, nil
+	return false, false, classifyTransportErr(pingErr), nil
+}
+
+// httpStatusPattern extracts the numeric status code from the canonical
+// "…rejected by agent: status NNN body=…" error format built by postRaw, and
+// from the "…transport: %w" wrapping used for lower-level failures (which
+// never contains a "status NNN" substring, so the pattern simply does not
+// match there).
+var httpStatusPattern = regexp.MustCompile(`status (\d{3})\b`)
+
+// extractHTTPStatus pulls the HTTP status code out of an agentcmd error, when
+// present. ok=false means the error is a transport-level failure with no HTTP
+// status at all (connection refused, DNS failure, timeout, TLS error, etc).
+func extractHTTPStatus(err error) (status int, ok bool) {
+	if err == nil {
+		return 0, false
+	}
+	m := httpStatusPattern.FindStringSubmatch(err.Error())
+	if m == nil {
+		return 0, false
+	}
+	n, cerr := strconv.Atoi(m[1])
+	if cerr != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// classifyTransportErr classifies a non-nil VerifyReachable failure (from
+// either the ping attempt directly, or after a failed metadata fallback) into
+// a ReachabilityReason. It never returns ReasonAlive.
+func classifyTransportErr(err error) ReachabilityReason {
+	if err == nil {
+		return ReasonUnreachable
+	}
+	if status, ok := extractHTTPStatus(err); ok {
+		switch {
+		case status == http.StatusNotFound:
+			return ReasonAgentAbsent404
+		case status >= 500:
+			return ReasonHTTP5xx
+		case status >= 400:
+			return ReasonHTTP4xx
+		}
+	}
+	if isTimeoutErr(err) {
+		return ReasonTimeout
+	}
+	if isTLSErr(err) {
+		return ReasonTLSError
+	}
+	return ReasonUnreachable
+}
+
+// isTimeoutErr reports whether err is (or wraps) a deadline/timeout failure,
+// either the net.Error Timeout() signal from the transport, or the context
+// package's own deadline-exceeded error.
+func isTimeoutErr(err error) bool {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return errors.Is(err, context.DeadlineExceeded)
+}
+
+// isTLSErr reports whether err is (or wraps) a TLS handshake failure: an
+// invalid, hostname-mismatched, or untrusted certificate, or a malformed TLS
+// record (e.g. a plaintext response on an https port).
+func isTLSErr(err error) bool {
+	var certErr x509.CertificateInvalidError
+	if errors.As(err, &certErr) {
+		return true
+	}
+	var hostErr x509.HostnameError
+	if errors.As(err, &hostErr) {
+		return true
+	}
+	var authErr x509.UnknownAuthorityError
+	if errors.As(err, &authErr) {
+		return true
+	}
+	var recErr tls.RecordHeaderError
+	if errors.As(err, &recErr) {
+		return true
+	}
+	return false
 }
 
 // looksLikeAgentMetadata is the liveness shape check for the metadata

--- a/apps/api/internal/agentcmd/verify_reachable_reason_test.go
+++ b/apps/api/internal/agentcmd/verify_reachable_reason_test.go
@@ -1,0 +1,250 @@
+package agentcmd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TestVerifyReachableWithReason_PingAlive proves the alive-via-ping path
+// classifies as ReasonAlive, matching the plain VerifyReachable outcome.
+func TestVerifyReachableWithReason_PingAlive(t *testing.T) {
+	siteID := uuid.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/wp-json/wpmgr/v1/command/ping" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true,"agent_version":"0.44.0"}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := buildTestAgentClient(t, srv)
+	alive, fallback, reason, err := client.VerifyReachableWithReason(context.Background(), siteID, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !alive || fallback {
+		t.Fatalf("alive=%v fallback=%v, want true/false", alive, fallback)
+	}
+	if reason != ReasonAlive {
+		t.Fatalf("reason = %q, want %q", reason, ReasonAlive)
+	}
+}
+
+// TestVerifyReachableWithReason_MetadataFallbackAlive proves the old-agent
+// fallback path (ping 404, metadata 200) also classifies as ReasonAlive.
+func TestVerifyReachableWithReason_MetadataFallbackAlive(t *testing.T) {
+	siteID := uuid.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/wp-json/wpmgr/v1/command/ping":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"code":"rest_no_route"}`))
+		case "/wp-json/wpmgr/v1/command/metadata":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true,"wp_version":"6.5.0"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := buildTestAgentClient(t, srv)
+	alive, fallback, reason, err := client.VerifyReachableWithReason(context.Background(), siteID, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !alive || !fallback {
+		t.Fatalf("alive=%v fallback=%v, want true/true", alive, fallback)
+	}
+	if reason != ReasonAlive {
+		t.Fatalf("reason = %q, want %q", reason, ReasonAlive)
+	}
+}
+
+// TestVerifyReachableWithReason_AgentAbsent404 proves that when BOTH ping and
+// the metadata fallback 404, the reason distinguishes "nothing here at all"
+// (an uninstalled agent) from a broken one, per GH #291 Task 3's stated goal.
+func TestVerifyReachableWithReason_AgentAbsent404(t *testing.T) {
+	siteID := uuid.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"code":"rest_no_route"}`))
+	}))
+	defer srv.Close()
+
+	client := buildTestAgentClient(t, srv)
+	alive, fallback, reason, err := client.VerifyReachableWithReason(context.Background(), siteID, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if alive || !fallback {
+		t.Fatalf("alive=%v fallback=%v, want false/true", alive, fallback)
+	}
+	if reason != ReasonAgentAbsent404 {
+		t.Fatalf("reason = %q, want %q", reason, ReasonAgentAbsent404)
+	}
+}
+
+// TestVerifyReachableWithReason_NotAgentShaped proves the captive-portal case
+// (a 2xx that is not agent-shaped JSON on both ping and metadata) is
+// classified as ReasonNotAgentShaped: the URL answers, just not with our
+// agent, which is a materially different situation from a 404 or a 5xx.
+func TestVerifyReachableWithReason_NotAgentShaped(t *testing.T) {
+	siteID := uuid.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"welcome","login":"/portal"}`))
+	}))
+	defer srv.Close()
+
+	client := buildTestAgentClient(t, srv)
+	alive, fallback, reason, err := client.VerifyReachableWithReason(context.Background(), siteID, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if alive || !fallback {
+		t.Fatalf("alive=%v fallback=%v, want false/true", alive, fallback)
+	}
+	if reason != ReasonNotAgentShaped {
+		t.Fatalf("reason = %q, want %q", reason, ReasonNotAgentShaped)
+	}
+}
+
+// TestVerifyReachableWithReason_HTTP5xx proves a hard 5xx on ping (no
+// 404/400 fallback trigger) classifies as ReasonHTTP5xx: an installed agent
+// that is answering, but broken. This is the case GH #291 needs a name for.
+func TestVerifyReachableWithReason_HTTP5xx(t *testing.T) {
+	siteID := uuid.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"code":"service_unavailable"}`))
+	}))
+	defer srv.Close()
+
+	client := buildTestAgentClient(t, srv)
+	alive, fallback, reason, err := client.VerifyReachableWithReason(context.Background(), siteID, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if alive || fallback {
+		t.Fatalf("alive=%v fallback=%v, want false/false", alive, fallback)
+	}
+	if reason != ReasonHTTP5xx {
+		t.Fatalf("reason = %q, want %q", reason, ReasonHTTP5xx)
+	}
+}
+
+// TestVerifyReachableWithReason_HTTP4xx proves a non-404 client error on ping
+// (e.g. a security plugin's 403) classifies as ReasonHTTP4xx, not as
+// ReasonAgentAbsent404 or a generic unreachable.
+func TestVerifyReachableWithReason_HTTP4xx(t *testing.T) {
+	siteID := uuid.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"code":"rest_forbidden"}`))
+	}))
+	defer srv.Close()
+
+	client := buildTestAgentClient(t, srv)
+	alive, fallback, reason, err := client.VerifyReachableWithReason(context.Background(), siteID, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if alive || fallback {
+		t.Fatalf("alive=%v fallback=%v, want false/false", alive, fallback)
+	}
+	if reason != ReasonHTTP4xx {
+		t.Fatalf("reason = %q, want %q", reason, ReasonHTTP4xx)
+	}
+}
+
+// TestVerifyReachableWithReason_Timeout proves a request that exceeds the
+// caller's context deadline classifies as ReasonTimeout, not the generic
+// ReasonUnreachable catch-all.
+func TestVerifyReachableWithReason_Timeout(t *testing.T) {
+	siteID := uuid.New()
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer func() {
+		close(release)
+		srv.Close()
+	}()
+
+	client := buildTestAgentClient(t, srv)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	alive, fallback, reason, err := client.VerifyReachableWithReason(ctx, siteID, srv.URL)
+	if err != nil {
+		t.Fatalf("VerifyReachableWithReason must return (false,false,ReasonTimeout,nil) on a deadline, got err=%v", err)
+	}
+	if alive || fallback {
+		t.Fatalf("alive=%v fallback=%v, want false/false", alive, fallback)
+	}
+	if reason != ReasonTimeout {
+		t.Fatalf("reason = %q, want %q", reason, ReasonTimeout)
+	}
+}
+
+// TestVerifyReachableWithReason_TLSError proves a certificate the client does
+// not trust (an httptest TLS server's self-signed leaf, verified without the
+// test-only InsecureSkipTLSVerify escape hatch) classifies as ReasonTLSError.
+func TestVerifyReachableWithReason_TLSError(t *testing.T) {
+	siteID := uuid.New()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	// buildTestAgentClient deliberately does NOT set InsecureSkipTLSVerify, so
+	// the self-signed httptest certificate fails normal chain verification.
+	client := buildTestAgentClient(t, srv)
+	alive, fallback, reason, err := client.VerifyReachableWithReason(context.Background(), siteID, srv.URL)
+	if err != nil {
+		t.Fatalf("VerifyReachableWithReason must return (false,false,ReasonTLSError,nil) on a cert failure, got err=%v", err)
+	}
+	if alive || fallback {
+		t.Fatalf("alive=%v fallback=%v, want false/false", alive, fallback)
+	}
+	if reason != ReasonTLSError {
+		t.Fatalf("reason = %q, want %q", reason, ReasonTLSError)
+	}
+}
+
+// TestVerifyReachableWithReason_MatchesVerifyReachable proves VerifyReachable
+// and VerifyReachableWithReason never disagree on alive/fallbackUsed/err. The
+// former must remain a pure delegate of the latter (GH #291 Task 3's "do not
+// change the existing boolean contract" requirement).
+func TestVerifyReachableWithReason_MatchesVerifyReachable(t *testing.T) {
+	siteID := uuid.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	client := buildTestAgentClient(t, srv)
+	wantAlive, wantFallback, wantErr := client.VerifyReachable(context.Background(), siteID, srv.URL)
+	gotAlive, gotFallback, reason, gotErr := client.VerifyReachableWithReason(context.Background(), siteID, srv.URL)
+
+	if wantAlive != gotAlive || wantFallback != gotFallback {
+		t.Fatalf("VerifyReachable=(%v,%v) VerifyReachableWithReason=(%v,%v), must match",
+			wantAlive, wantFallback, gotAlive, gotFallback)
+	}
+	if (wantErr == nil) != (gotErr == nil) {
+		t.Fatalf("VerifyReachable err=%v VerifyReachableWithReason err=%v, must match presence", wantErr, gotErr)
+	}
+	if reason != ReasonHTTP5xx {
+		t.Fatalf("reason = %q, want %q", reason, ReasonHTTP5xx)
+	}
+}

--- a/apps/api/internal/api/gen/oas_client_gen.go
+++ b/apps/api/internal/api/gen/oas_client_gen.go
@@ -1399,8 +1399,13 @@ type Invoker interface {
 	// Returns summary counts {up, degraded, down, unknown} and a per-site list
 	// with the latest probe result, 7-day uptime %, and in-incident flag.
 	// Status derivation: down=latest probe up=false; degraded=up but latency
-	// >2000ms or connection_state=degraded; up=probe up+fast; unknown=no probe.
-	// Requires viewer+.
+	// >2000ms, or connection_state=degraded (status_reason=agent_degraded),
+	// or connection_state=disconnected (status_reason=agent_unreachable, GH
+	// #291: a cached response can stay up=true while the agent side already
+	// proved the site unreachable); up=probe up+fast; unknown=no probe.
+	// connection_state=revoked/archived does not affect status derivation
+	// (the operator deliberately stopped managing the site). Requires
+	// viewer+.
 	//
 	// GET /api/v1/fleet/status
 	GetFleetUptimeStatus(ctx context.Context) (*FleetUptimeStatus, error)
@@ -18185,8 +18190,13 @@ func (c *Client) sendGetFleetRumAggregate(ctx context.Context, params GetFleetRu
 // Returns summary counts {up, degraded, down, unknown} and a per-site list
 // with the latest probe result, 7-day uptime %, and in-incident flag.
 // Status derivation: down=latest probe up=false; degraded=up but latency
-// >2000ms or connection_state=degraded; up=probe up+fast; unknown=no probe.
-// Requires viewer+.
+// >2000ms, or connection_state=degraded (status_reason=agent_degraded),
+// or connection_state=disconnected (status_reason=agent_unreachable, GH
+// #291: a cached response can stay up=true while the agent side already
+// proved the site unreachable); up=probe up+fast; unknown=no probe.
+// connection_state=revoked/archived does not affect status derivation
+// (the operator deliberately stopped managing the site). Requires
+// viewer+.
 //
 // GET /api/v1/fleet/status
 func (c *Client) GetFleetUptimeStatus(ctx context.Context) (*FleetUptimeStatus, error) {

--- a/apps/api/internal/api/gen/oas_handlers_gen.go
+++ b/apps/api/internal/api/gen/oas_handlers_gen.go
@@ -23595,8 +23595,13 @@ func (s *Server) handleGetFleetRumAggregateRequest(args [0]string, argsEscaped b
 // Returns summary counts {up, degraded, down, unknown} and a per-site list
 // with the latest probe result, 7-day uptime %, and in-incident flag.
 // Status derivation: down=latest probe up=false; degraded=up but latency
-// >2000ms or connection_state=degraded; up=probe up+fast; unknown=no probe.
-// Requires viewer+.
+// >2000ms, or connection_state=degraded (status_reason=agent_degraded),
+// or connection_state=disconnected (status_reason=agent_unreachable, GH
+// #291: a cached response can stay up=true while the agent side already
+// proved the site unreachable); up=probe up+fast; unknown=no probe.
+// connection_state=revoked/archived does not affect status derivation
+// (the operator deliberately stopped managing the site). Requires
+// viewer+.
 //
 // GET /api/v1/fleet/status
 func (s *Server) handleGetFleetUptimeStatusRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -52817,6 +52817,12 @@ func (s *FleetUptimeStatusItem) encodeFields(e *jx.Encoder) {
 		s.Status.Encode(e)
 	}
 	{
+		if s.StatusReason.Set {
+			e.FieldStart("status_reason")
+			s.StatusReason.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("uptime_pct_7d")
 		e.Float64(s.UptimePct7d)
 	}
@@ -52856,19 +52862,20 @@ func (s *FleetUptimeStatusItem) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfFleetUptimeStatusItem = [12]string{
+var jsonFieldsNameOfFleetUptimeStatusItem = [13]string{
 	0:  "site_id",
 	1:  "site_name",
 	2:  "site_url",
 	3:  "status",
-	4:  "uptime_pct_7d",
-	5:  "avg_latency_ms_7d",
-	6:  "latest_total_ms",
-	7:  "last_probe_at",
-	8:  "tls_expiry",
-	9:  "in_incident",
-	10: "connection_state",
-	11: "health_status",
+	4:  "status_reason",
+	5:  "uptime_pct_7d",
+	6:  "avg_latency_ms_7d",
+	7:  "latest_total_ms",
+	8:  "last_probe_at",
+	9:  "tls_expiry",
+	10: "in_incident",
+	11: "connection_state",
+	12: "health_status",
 }
 
 // Decode decodes FleetUptimeStatusItem from json.
@@ -52926,8 +52933,18 @@ func (s *FleetUptimeStatusItem) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
+		case "status_reason":
+			if err := func() error {
+				s.StatusReason.Reset()
+				if err := s.StatusReason.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"status_reason\"")
+			}
 		case "uptime_pct_7d":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Float64()
 				s.UptimePct7d = float64(v)
@@ -52939,7 +52956,7 @@ func (s *FleetUptimeStatusItem) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"uptime_pct_7d\"")
 			}
 		case "avg_latency_ms_7d":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := d.Float64()
 				s.AvgLatencyMs7d = float64(v)
@@ -52981,7 +52998,7 @@ func (s *FleetUptimeStatusItem) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"tls_expiry\"")
 			}
 		case "in_incident":
-			requiredBitSet[1] |= 1 << 1
+			requiredBitSet[1] |= 1 << 2
 			if err := func() error {
 				v, err := d.Bool()
 				s.InIncident = bool(v)
@@ -52993,7 +53010,7 @@ func (s *FleetUptimeStatusItem) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"in_incident\"")
 			}
 		case "connection_state":
-			requiredBitSet[1] |= 1 << 2
+			requiredBitSet[1] |= 1 << 3
 			if err := func() error {
 				v, err := d.Str()
 				s.ConnectionState = string(v)
@@ -53005,7 +53022,7 @@ func (s *FleetUptimeStatusItem) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"connection_state\"")
 			}
 		case "health_status":
-			requiredBitSet[1] |= 1 << 3
+			requiredBitSet[1] |= 1 << 4
 			if err := func() error {
 				v, err := d.Str()
 				s.HealthStatus = string(v)
@@ -53026,8 +53043,8 @@ func (s *FleetUptimeStatusItem) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [2]uint8{
-		0b00111111,
-		0b00001110,
+		0b01101111,
+		0b00011100,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -18714,18 +18714,23 @@ func (s *FleetUptimeStatus) SetItems(val []FleetUptimeStatusItem) {
 
 // Ref: #/components/schemas/FleetUptimeStatusItem
 type FleetUptimeStatusItem struct {
-	SiteID          uuid.UUID                   `json:"site_id"`
-	SiteName        string                      `json:"site_name"`
-	SiteURL         string                      `json:"site_url"`
-	Status          FleetUptimeStatusItemStatus `json:"status"`
-	UptimePct7d     float64                     `json:"uptime_pct_7d"`
-	AvgLatencyMs7d  float64                     `json:"avg_latency_ms_7d"`
-	LatestTotalMs   OptFloat64                  `json:"latest_total_ms"`
-	LastProbeAt     OptDateTime                 `json:"last_probe_at"`
-	TLSExpiry       OptDateTime                 `json:"tls_expiry"`
-	InIncident      bool                        `json:"in_incident"`
-	ConnectionState string                      `json:"connection_state"`
-	HealthStatus    string                      `json:"health_status"`
+	SiteID   uuid.UUID                   `json:"site_id"`
+	SiteName string                      `json:"site_name"`
+	SiteURL  string                      `json:"site_url"`
+	Status   FleetUptimeStatusItemStatus `json:"status"`
+	// Short machine-readable explanation for status, populated when
+	// status=degraded (agent_unreachable, agent_degraded, or
+	// slow_response). Empty/absent when the status needs no further
+	// explanation.
+	StatusReason    OptString   `json:"status_reason"`
+	UptimePct7d     float64     `json:"uptime_pct_7d"`
+	AvgLatencyMs7d  float64     `json:"avg_latency_ms_7d"`
+	LatestTotalMs   OptFloat64  `json:"latest_total_ms"`
+	LastProbeAt     OptDateTime `json:"last_probe_at"`
+	TLSExpiry       OptDateTime `json:"tls_expiry"`
+	InIncident      bool        `json:"in_incident"`
+	ConnectionState string      `json:"connection_state"`
+	HealthStatus    string      `json:"health_status"`
 }
 
 // GetSiteID returns the value of SiteID.
@@ -18746,6 +18751,11 @@ func (s *FleetUptimeStatusItem) GetSiteURL() string {
 // GetStatus returns the value of Status.
 func (s *FleetUptimeStatusItem) GetStatus() FleetUptimeStatusItemStatus {
 	return s.Status
+}
+
+// GetStatusReason returns the value of StatusReason.
+func (s *FleetUptimeStatusItem) GetStatusReason() OptString {
+	return s.StatusReason
 }
 
 // GetUptimePct7d returns the value of UptimePct7d.
@@ -18806,6 +18816,11 @@ func (s *FleetUptimeStatusItem) SetSiteURL(val string) {
 // SetStatus sets the value of Status.
 func (s *FleetUptimeStatusItem) SetStatus(val FleetUptimeStatusItemStatus) {
 	s.Status = val
+}
+
+// SetStatusReason sets the value of StatusReason.
+func (s *FleetUptimeStatusItem) SetStatusReason(val OptString) {
+	s.StatusReason = val
 }
 
 // SetUptimePct7d sets the value of UptimePct7d.

--- a/apps/api/internal/api/gen/oas_server_gen.go
+++ b/apps/api/internal/api/gen/oas_server_gen.go
@@ -1379,8 +1379,13 @@ type Handler interface {
 	// Returns summary counts {up, degraded, down, unknown} and a per-site list
 	// with the latest probe result, 7-day uptime %, and in-incident flag.
 	// Status derivation: down=latest probe up=false; degraded=up but latency
-	// >2000ms or connection_state=degraded; up=probe up+fast; unknown=no probe.
-	// Requires viewer+.
+	// >2000ms, or connection_state=degraded (status_reason=agent_degraded),
+	// or connection_state=disconnected (status_reason=agent_unreachable, GH
+	// #291: a cached response can stay up=true while the agent side already
+	// proved the site unreachable); up=probe up+fast; unknown=no probe.
+	// connection_state=revoked/archived does not affect status derivation
+	// (the operator deliberately stopped managing the site). Requires
+	// viewer+.
 	//
 	// GET /api/v1/fleet/status
 	GetFleetUptimeStatus(ctx context.Context) (*FleetUptimeStatus, error)

--- a/apps/api/internal/api/gen/oas_unimplemented_gen.go
+++ b/apps/api/internal/api/gen/oas_unimplemented_gen.go
@@ -1836,8 +1836,13 @@ func (UnimplementedHandler) GetFleetRumAggregate(ctx context.Context, params Get
 // Returns summary counts {up, degraded, down, unknown} and a per-site list
 // with the latest probe result, 7-day uptime %, and in-incident flag.
 // Status derivation: down=latest probe up=false; degraded=up but latency
-// >2000ms or connection_state=degraded; up=probe up+fast; unknown=no probe.
-// Requires viewer+.
+// >2000ms, or connection_state=degraded (status_reason=agent_degraded),
+// or connection_state=disconnected (status_reason=agent_unreachable, GH
+// #291: a cached response can stay up=true while the agent side already
+// proved the site unreachable); up=probe up+fast; unknown=no probe.
+// connection_state=revoked/archived does not affect status derivation
+// (the operator deliberately stopped managing the site). Requires
+// viewer+.
 //
 // GET /api/v1/fleet/status
 func (UnimplementedHandler) GetFleetUptimeStatus(ctx context.Context) (r *FleetUptimeStatus, _ error) {

--- a/apps/api/internal/metrics/metrics.go
+++ b/apps/api/internal/metrics/metrics.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -177,6 +178,36 @@ type chStore struct {
 // retentionDays is the uptime_checks TTL window (~90d).
 const retentionDays = 90
 
+// uptimeChecksColumn is one column of the uptime_checks table: its name and
+// its ClickHouse type.
+type uptimeChecksColumn struct {
+	name string
+	typ  string
+}
+
+// uptimeChecksColumns is the single declared source of truth for the
+// uptime_checks table shape. Both ensureSchema (CREATE TABLE and the
+// per-column ADD COLUMN IF NOT EXISTS convergence) and InsertChecks (the
+// column-explicit INSERT column list and the matching Append order) are
+// driven from this one list, so the DDL, the migration path and the insert
+// path cannot drift apart. Adding a column here is the only step required to
+// both create it on a fresh table and backfill it onto an existing one; see
+// ensureSchema.
+var uptimeChecksColumns = []uptimeChecksColumn{
+	{"checked_at", "DateTime"},
+	{"tenant_id", "UUID"},
+	{"site_id", "UUID"},
+	{"up", "UInt8"},
+	{"http_status", "UInt16"},
+	{"dns_ms", "Float64"},
+	{"connect_ms", "Float64"},
+	{"tls_ms", "Float64"},
+	{"ttfb_ms", "Float64"},
+	{"total_ms", "Float64"},
+	{"tls_expiry", "DateTime"},
+	{"error", "String"},
+}
+
 // New connects to ClickHouse and ensures the schema exists. When cfg.Addr is
 // empty it returns a disabled Store (Enabled()==false) that no-ops, so the
 // stack runs without ClickHouse. A configured-but-unreachable ClickHouse is a
@@ -239,34 +270,116 @@ func (s *chStore) Close() error {
 	return s.conn.Close()
 }
 
-// ensureSchema creates the database and the uptime_checks table if absent. The
-// table is a MergeTree ordered by (tenant_id, site_id, checked_at) — the exact
-// prefix every tenant-scoped per-site query filters on — with a 90-day TTL on
-// checked_at so old rows are reclaimed automatically.
+// ensureSchema creates the database and the uptime_checks table if absent,
+// then converges an already-existing table's COLUMN SET to the currently
+// declared uptimeChecksColumns. The table is created as a MergeTree ordered
+// by (tenant_id, site_id, checked_at), the exact prefix every tenant-scoped
+// per-site query filters on, with a 90-day TTL on checked_at so old rows are
+// reclaimed automatically, but that only applies to a fresh CREATE TABLE.
+// ONLY the column set converges on every boot. The engine, the ORDER BY, the
+// TTL clause, and the declared TYPE of an already-existing column do NOT
+// converge. An operator who hand-alters uptime_checks (a different ORDER BY,
+// a wider or narrower column type, TTL removed) will find that drift persists
+// across restarts; this function never re-issues CREATE TABLE and never runs
+// an ALTER ... MODIFY on an existing table, it only ADDs a COLUMN for a name
+// it cannot find.
+//
+// CREATE TABLE IF NOT EXISTS is a no-op against a table that already exists,
+// so a column appended to uptimeChecksColumns after a deployment's table was
+// first created would never land there on its own: InsertChecks would then
+// try to write more values than the physical table has columns and fail
+// outright. To make new columns safe to add in a later phase, every boot
+// reads the table's actual column names from system.columns ONCE and issues
+// an idempotent ALTER TABLE ... ADD COLUMN IF NOT EXISTS only for declared
+// columns that read is missing, so a table that has already converged costs
+// one cheap read and zero DDL, instead of 12 unconditional round trips every
+// boot. Both the CREATE TABLE column list and the convergence loop are driven
+// from the same uptimeChecksColumns list, so the create path and the
+// migration path cannot drift apart.
+//
+// Every ALTER in the convergence loop is NON-FATAL. An older ClickHouse that
+// rejects this ALTER syntax, or a role without ALTER privilege on this table,
+// must not prevent the control plane from starting over an uptime-metrics
+// nicety. This follows the same precedent as the vulnerability feed, which
+// degrades to a clean no-op instead of blocking boot when it cannot run (see
+// internal/admin/vuln_feed.go). Failures are logged at error level with the
+// column name so the gap is loud rather than silent, and if any declared
+// column is still missing once the loop finishes, one summary error names all
+// of them: InsertChecks will fail on this table until that is resolved, and
+// that must be visible in the logs even though it did not stop boot. If the
+// system.columns read itself fails (e.g. no SELECT grant on system tables),
+// convergence falls back to attempting every declared column unconditionally,
+// same as before this fix, still non-fatal, just without the zero-DDL fast
+// path for a table that was already converged.
 func (s *chStore) ensureSchema(ctx context.Context) error {
 	if err := s.conn.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", s.db)); err != nil {
 		return fmt.Errorf("clickhouse create database: %w", err)
 	}
+
+	columnDefs := make([]string, len(uptimeChecksColumns))
+	for i, c := range uptimeChecksColumns {
+		columnDefs[i] = fmt.Sprintf("    %s %s", c.name, c.typ)
+	}
 	ddl := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.uptime_checks (
-    checked_at  DateTime,
-    tenant_id   UUID,
-    site_id     UUID,
-    up          UInt8,
-    http_status UInt16,
-    dns_ms      Float64,
-    connect_ms  Float64,
-    tls_ms      Float64,
-    ttfb_ms     Float64,
-    total_ms    Float64,
-    tls_expiry  DateTime,
-    error       String
+%s
 ) ENGINE = MergeTree()
 ORDER BY (tenant_id, site_id, checked_at)
-TTL checked_at + INTERVAL %d DAY`, s.db, retentionDays)
+TTL checked_at + INTERVAL %d DAY`, s.db, strings.Join(columnDefs, ",\n"), retentionDays)
 	if err := s.conn.Exec(ctx, ddl); err != nil {
 		return fmt.Errorf("clickhouse create uptime_checks: %w", err)
 	}
+
+	existing, err := s.existingUptimeChecksColumns(ctx)
+	if err != nil {
+		s.logger.Error("clickhouse read existing uptime_checks columns failed; falling back to attempting every declared column",
+			slog.String("clickhouse_db", s.db), slog.Any("error", err))
+		existing = map[string]bool{}
+	}
+
+	var stillMissing []string
+	for _, c := range uptimeChecksColumns {
+		if existing[c.name] {
+			continue
+		}
+		alter := fmt.Sprintf("ALTER TABLE %s.uptime_checks ADD COLUMN IF NOT EXISTS %s %s", s.db, c.name, c.typ)
+		if err := s.conn.Exec(ctx, alter); err != nil {
+			s.logger.Error("clickhouse add column failed; boot continues, but this column will not be available until resolved",
+				slog.String("clickhouse_db", s.db), slog.String("column", c.name), slog.Any("error", err))
+			stillMissing = append(stillMissing, c.name)
+		}
+	}
+	if len(stillMissing) > 0 {
+		s.logger.Error("uptime_checks is missing columns InsertChecks requires; probe inserts will fail until this is resolved",
+			slog.String("clickhouse_db", s.db), slog.Any("missing_columns", stillMissing))
+	}
 	return nil
+}
+
+// existingUptimeChecksColumns reads the actual column names of
+// <db>.uptime_checks from system.columns, so ensureSchema's convergence loop
+// can skip ADD COLUMN for names that already exist instead of issuing all 12
+// unconditionally on every boot.
+func (s *chStore) existingUptimeChecksColumns(ctx context.Context) (map[string]bool, error) {
+	rows, err := s.conn.Query(ctx,
+		"SELECT name FROM system.columns WHERE database = ? AND table = ?",
+		s.db, "uptime_checks")
+	if err != nil {
+		return nil, fmt.Errorf("clickhouse read system.columns: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]bool)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("clickhouse scan system.columns row: %w", err)
+		}
+		out[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("clickhouse iterate system.columns: %w", err)
+	}
+	return out, nil
 }
 
 // chTime keeps a DateTime value within ClickHouse's representable range and at
@@ -280,11 +393,23 @@ func chTime(t time.Time) time.Time {
 
 // InsertChecks batch-inserts probe results via PrepareBatch. No-ops (returns
 // nil) when the store is disabled or the batch is empty.
+//
+// The INSERT statement names every column explicitly (from
+// uptimeChecksColumns) instead of relying on the table's physical column
+// order. The ClickHouse driver resorts the batch to the named column order,
+// so batch.Append below must supply values in that exact order too; a
+// positional-only insert is what turns a schema drift (an ALTER that adds or
+// reorders a column) into a silent value-shift or a column-count mismatch.
 func (s *chStore) InsertChecks(ctx context.Context, checks []Check) error {
 	if !s.Enabled() || len(checks) == 0 {
 		return nil
 	}
-	batch, err := s.conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s.uptime_checks", s.db))
+	columnNames := make([]string, len(uptimeChecksColumns))
+	for i, c := range uptimeChecksColumns {
+		columnNames[i] = c.name
+	}
+	insertSQL := fmt.Sprintf("INSERT INTO %s.uptime_checks (%s)", s.db, strings.Join(columnNames, ", "))
+	batch, err := s.conn.PrepareBatch(ctx, insertSQL)
 	if err != nil {
 		return fmt.Errorf("clickhouse prepare batch: %w", err)
 	}
@@ -293,6 +418,9 @@ func (s *chStore) InsertChecks(ctx context.Context, checks []Check) error {
 		if c.Up {
 			up = 1
 		}
+		// Append order must match uptimeChecksColumns / columnNames above
+		// exactly: checked_at, tenant_id, site_id, up, http_status, dns_ms,
+		// connect_ms, tls_ms, ttfb_ms, total_ms, tls_expiry, error.
 		if err := batch.Append(
 			chTime(c.CheckedAt),
 			c.TenantID,

--- a/apps/api/internal/uptime/derive_fleet_status_test.go
+++ b/apps/api/internal/uptime/derive_fleet_status_test.go
@@ -1,0 +1,142 @@
+package uptime
+
+import "testing"
+
+// TestDeriveFleetStatus_ConnectionStateMatrix is the GH #291 Task 1 unit test:
+// it pins deriveFleetStatus's behavior for every connection_state value
+// against an up=true (cached 200) probe result, proving:
+//
+//   - "disconnected" now derives Degraded when disconnected_reason names the
+//     sweeper's own active-verify failure (the core fix: previously fell
+//     through to a clean Up even though the connection sweeper's signed,
+//     uncacheable active-verify had already failed against the agent).
+//   - "degraded" continues to derive Degraded (pre-existing behavior).
+//   - "connected"/"pending_enrollment" continue to derive Up.
+//   - "revoked"/"archived" ALSO derive Up: the operator deliberately stopped
+//     managing the site, so no alarming Degraded is raised (see GH #282 for
+//     the identical precedent in backup scheduling).
+//   - Task 2's status_reason is populated exactly when the status is
+//     Degraded, and matches the specific cause.
+func TestDeriveFleetStatus_ConnectionStateMatrix(t *testing.T) {
+	up := true
+	fast := 100.0
+
+	cases := []struct {
+		name               string
+		connectionState    string
+		disconnectedReason string
+		wantStatus         FleetSiteStatus
+		wantReason         string
+	}{
+		{"connected stays up", "connected", "", FleetStatusUp, ""},
+		{"pending_enrollment stays up", "pending_enrollment", "", FleetStatusUp, ""},
+		{"degraded derives degraded", "degraded", "", FleetStatusDegraded, FleetReasonAgentDegraded},
+		{"disconnected+agent_unreachable derives degraded (GH #291 core fix)", "disconnected", "agent_unreachable", FleetStatusDegraded, FleetReasonAgentUnreachable},
+		{"disconnected+heartbeat_timeout derives degraded (GH #291 core fix)", "disconnected", "heartbeat_timeout", FleetStatusDegraded, FleetReasonAgentUnreachable},
+		{"revoked stays up (operator deliberately unmanaged, GH #282 precedent)", "revoked", "", FleetStatusUp, ""},
+		{"archived stays up (operator deliberately unmanaged, GH #282 precedent)", "archived", "", FleetStatusUp, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStatus, gotReason := deriveFleetStatus(&up, &fast, tc.connectionState, tc.disconnectedReason)
+			if gotStatus != tc.wantStatus {
+				t.Errorf("status = %q, want %q", gotStatus, tc.wantStatus)
+			}
+			if gotReason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", gotReason, tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestDeriveFleetStatus_DisconnectedReasonDisambiguation is the GH #291
+// follow-up regression test: a "disconnected" site is reached by two
+// completely different, equally legitimate paths (internal/site/sweeper.go
+// Sweep vs connService.RecordLastWillTenant), and only the sweeper's own
+// paths may raise the alarming Degraded chip. A clean operator-initiated
+// last-will disconnect (deactivate/uninstall, or the handler's
+// "user_initiated" default) must render exactly like a healthy "connected"
+// site — no false alarm on a site that was cleanly taken offline on purpose.
+func TestDeriveFleetStatus_DisconnectedReasonDisambiguation(t *testing.T) {
+	up := true
+	fast := 100.0
+
+	cases := []struct {
+		name               string
+		disconnectedReason string
+		wantStatus         FleetSiteStatus
+		wantReason         string
+	}{
+		// Sweeper-authored reasons (internal/site/sweeper.go Sweep): real,
+		// CP-observed unreachability. Must alarm.
+		{"sweeper active-verify failure", "agent_unreachable", FleetStatusDegraded, FleetReasonAgentUnreachable},
+		{"sweeper passive heartbeat timeout", "heartbeat_timeout", FleetStatusDegraded, FleetReasonAgentUnreachable},
+		// Signed agent last-will (ADR-040): the operator chose to stop the
+		// agent. The site is healthy and must NOT alarm.
+		{"last-will deactivated", "deactivated", FleetStatusUp, ""},
+		{"last-will uninstalled", "uninstalled", FleetStatusUp, ""},
+		{"last-will default reason", "user_initiated", FleetStatusUp, ""},
+		// Conservative fallback: any value that is not positively attributable
+		// to the sweeper (unrecognized text, or a legacy/empty row that
+		// predates the disconnected_reason column) must NOT alarm either — the
+		// data cannot prove the site is unhealthy, so it must not claim it is.
+		{"unrecognized reason string", "something_unexpected", FleetStatusUp, ""},
+		{"empty/legacy reason", "", FleetStatusUp, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStatus, gotReason := deriveFleetStatus(&up, &fast, "disconnected", tc.disconnectedReason)
+			if gotStatus != tc.wantStatus {
+				t.Errorf("disconnected_reason=%q: status = %q, want %q", tc.disconnectedReason, gotStatus, tc.wantStatus)
+			}
+			if gotReason != tc.wantReason {
+				t.Errorf("disconnected_reason=%q: reason = %q, want %q", tc.disconnectedReason, gotReason, tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestDeriveFleetStatus_DownAndUnknownIgnoreConnectionState proves that
+// up=false and up=nil are decided purely by the probe result, regardless of
+// connection_state or disconnected_reason, and never carry a status_reason
+// (down/unknown are self-explanatory).
+func TestDeriveFleetStatus_DownAndUnknownIgnoreConnectionState(t *testing.T) {
+	down := false
+	fast := 100.0
+
+	for _, cs := range []string{"connected", "degraded", "disconnected", "revoked", "archived", ""} {
+		status, reason := deriveFleetStatus(&down, &fast, cs, "agent_unreachable")
+		if status != FleetStatusDown {
+			t.Errorf("connection_state=%q: status = %q, want down", cs, status)
+		}
+		if reason != "" {
+			t.Errorf("connection_state=%q: reason = %q, want empty", cs, reason)
+		}
+	}
+
+	for _, cs := range []string{"connected", "degraded", "disconnected", "revoked", "archived", ""} {
+		status, reason := deriveFleetStatus(nil, nil, cs, "agent_unreachable")
+		if status != FleetStatusUnknown {
+			t.Errorf("connection_state=%q: status = %q, want unknown", cs, status)
+		}
+		if reason != "" {
+			t.Errorf("connection_state=%q: reason = %q, want empty", cs, reason)
+		}
+	}
+}
+
+// TestDeriveFleetStatus_SlowResponseReason proves the pre-existing latency
+// threshold path still derives Degraded, now with a distinct status_reason
+// from the connection-state-driven cases, when connection_state is healthy.
+func TestDeriveFleetStatus_SlowResponseReason(t *testing.T) {
+	up := true
+	slow := slowThresholdMs + 1
+
+	status, reason := deriveFleetStatus(&up, &slow, "connected", "")
+	if status != FleetStatusDegraded {
+		t.Fatalf("status = %q, want degraded", status)
+	}
+	if reason != FleetReasonSlowResponse {
+		t.Fatalf("reason = %q, want %q", reason, FleetReasonSlowResponse)
+	}
+}

--- a/apps/api/internal/uptime/fleet_store_test.go
+++ b/apps/api/internal/uptime/fleet_store_test.go
@@ -304,3 +304,137 @@ func TestGetFleetStatus_PostgresModeParity(t *testing.T) {
 		t.Errorf("Status = %q, want %q", it.Status, FleetStatusUp)
 	}
 }
+
+// TestGetFleetStatus_DisconnectedCachedUpStaysUpDisplayOnlyChanges is the GH
+// #291 golden no-regression test (Task 4). It pins the phase's core promise:
+// a site whose latest probe is up=true (what a page cache keeps serving even
+// while the backend is fatal-ing) MUST still report up=true, with an
+// unchanged 7-day uptime percentage, unchanged latency, and unchanged
+// Postgres-resident health_status. The ONLY thing allowed to move is the
+// DERIVED display status, from Up to Degraded, once sites.connection_state
+// has been marked "disconnected" by the connection sweeper's independent,
+// signed, uncacheable active-verify.
+//
+// Two sites are compared side by side with IDENTICAL probe/store data and
+// IDENTICAL Postgres health_status; the only difference is connection_state.
+// If this test ever fails because up/uptime_pct_7d/avg_latency_ms/
+// health_status differ between the two sites, this phase has stopped being
+// display-only and started rewriting what "up" means, which is the one thing
+// explicitly forbidden by the design.
+func TestGetFleetStatus_DisconnectedCachedUpStaysUpDisplayOnlyChanges(t *testing.T) {
+	tenantID := uuid.New()
+	healthySite := uuid.New() // connection_state=connected
+	brokenSite := uuid.New()  // connection_state=disconnected, same probe data
+
+	probedAt := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	up := true
+	const pct = 100.0    // a fully page-cached site answers every probe
+	const latency = 45.0 // cached responses are fast
+
+	repo := &stubRepo{
+		infos: []FleetSiteInfo{
+			{
+				SiteID:          healthySite,
+				Name:            "healthy-site",
+				URL:             "https://healthy.example.com",
+				ConnectionState: "connected",
+				HealthStatus:    "healthy",
+				InIncident:      false,
+			},
+			{
+				SiteID:          brokenSite,
+				Name:            "broken-site",
+				URL:             "https://broken.example.com",
+				ConnectionState: "disconnected",
+				// health_status is written ONLY by the M5 reachability probe
+				// worker (SetSiteHealthStatus), which this phase does not
+				// touch. It stays "healthy" here on purpose, exactly like
+				// the reported incident, to prove this function does not
+				// derive or overwrite it.
+				HealthStatus: "healthy",
+				InIncident:   false,
+				// disconnected_reason names the sweeper's own active-verify
+				// failure (internal/site/sweeper.go Sweep), matching the
+				// reported incident: the sweeper's signed POST to the agent
+				// failed, not an operator-initiated last-will disconnect. See
+				// TestDeriveFleetStatus_DisconnectedReasonDisambiguation for
+				// the last-will side of this distinction.
+				DisconnectedReason: "agent_unreachable",
+			},
+		},
+	}
+	// Identical store-sourced probe data for both sites: same up, same
+	// uptime %, same latency, same last-probe timestamp. Only Postgres
+	// connection_state differs between the two repo infos above.
+	store := &stubStore{
+		uptimeMap: map[uuid.UUID]metrics.FleetUptimeRow{
+			healthySite: {Up: &up, LastProbeAt: &probedAt, UptimePct7d: ptrF64(pct), AvgLatencyMs: ptrF64(latency)},
+			brokenSite:  {Up: &up, LastProbeAt: &probedAt, UptimePct7d: ptrF64(pct), AvgLatencyMs: ptrF64(latency)},
+		},
+	}
+
+	svc := NewService(repo, store, nil)
+	resp, err := svc.GetFleetStatus(context.Background(), tenantID, []uuid.UUID{healthySite, brokenSite})
+	if err != nil {
+		t.Fatalf("GetFleetStatus: %v", err)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(resp.Items))
+	}
+
+	var healthy, broken FleetStatusItem
+	for _, it := range resp.Items {
+		switch it.SiteID {
+		case healthySite:
+			healthy = it
+		case brokenSite:
+			broken = it
+		}
+	}
+
+	// FROZEN: up, uptime_pct_7d, avg_latency_ms, health_status must be
+	// bit-identical between the two sites. connection_state must not leak
+	// into any of them.
+	if broken.Up == nil || !*broken.Up {
+		t.Fatalf("broken site Up = %v, want true (a cached 200 is still up=true)", broken.Up)
+	}
+	if healthy.Up == nil || *healthy.Up != *broken.Up {
+		t.Fatalf("Up mismatch: healthy=%v broken=%v, want identical", healthy.Up, broken.Up)
+	}
+	if broken.UptimePct7d != pct || healthy.UptimePct7d != broken.UptimePct7d {
+		t.Fatalf("UptimePct7d mismatch: healthy=%v broken=%v, want both %v", healthy.UptimePct7d, broken.UptimePct7d, pct)
+	}
+	if broken.AvgLatencyMs == nil || *broken.AvgLatencyMs != latency {
+		t.Fatalf("broken site AvgLatencyMs = %v, want %v", broken.AvgLatencyMs, latency)
+	}
+	if healthy.AvgLatencyMs == nil || *healthy.AvgLatencyMs != *broken.AvgLatencyMs {
+		t.Fatalf("AvgLatencyMs mismatch: healthy=%v broken=%v, want identical", healthy.AvgLatencyMs, broken.AvgLatencyMs)
+	}
+	if broken.HealthStatus != "healthy" || healthy.HealthStatus != broken.HealthStatus {
+		t.Fatalf("HealthStatus mismatch: healthy=%q broken=%q, want both %q", healthy.HealthStatus, broken.HealthStatus, "healthy")
+	}
+
+	// The ONLY thing allowed to move: the derived display status.
+	if healthy.Status != FleetStatusUp {
+		t.Errorf("healthy site Status = %q, want %q (unaffected by this fix)", healthy.Status, FleetStatusUp)
+	}
+	if healthy.StatusReason != "" {
+		t.Errorf("healthy site StatusReason = %q, want empty", healthy.StatusReason)
+	}
+	if broken.Status != FleetStatusDegraded {
+		t.Errorf("broken site Status = %q, want %q (GH #291: was Up before this fix)", broken.Status, FleetStatusDegraded)
+	}
+	if broken.StatusReason != FleetReasonAgentUnreachable {
+		t.Errorf("broken site StatusReason = %q, want %q", broken.StatusReason, FleetReasonAgentUnreachable)
+	}
+
+	// Summary counts must reflect exactly one Up and one Degraded, not two Up.
+	if resp.Summary.Up != 1 {
+		t.Errorf("Summary.Up = %d, want 1", resp.Summary.Up)
+	}
+	if resp.Summary.Degraded != 1 {
+		t.Errorf("Summary.Degraded = %d, want 1", resp.Summary.Degraded)
+	}
+}
+
+func ptrF64(f float64) *float64 { return &f }

--- a/apps/api/internal/uptime/model.go
+++ b/apps/api/internal/uptime/model.go
@@ -86,6 +86,51 @@ const (
 	FleetStatusUnknown  FleetSiteStatus = "unknown"
 )
 
+// Fleet status reason strings (GH #291 Task 2): a short, machine-readable
+// explanation for WHY deriveFleetStatus picked FleetStatusDegraded, so the API
+// and UI can say which degraded it is instead of rendering a bare chip. Empty
+// string means the status needs no further explanation (up/down/unknown).
+const (
+	// FleetReasonAgentUnreachable: sites.connection_state = "disconnected" AND
+	// sites.disconnected_reason names one of the sweeper's own transitions
+	// (see sweeperDisconnectReasons below). The connection sweeper's signed,
+	// uncacheable active-verify already failed against the agent, or the agent
+	// stopped heartbeating outright (GH #291).
+	FleetReasonAgentUnreachable = "agent_unreachable"
+	// FleetReasonAgentDegraded: sites.connection_state = "degraded", meaning
+	// the agent heartbeat is stale but not yet past the disconnect threshold.
+	// This state has no last-will path (see sweeperDisconnectReasons), so it
+	// needs no reason disambiguation.
+	FleetReasonAgentDegraded = "agent_degraded"
+	// FleetReasonSlowResponse: the probe succeeded but total_ms exceeded
+	// slowThresholdMs.
+	FleetReasonSlowResponse = "slow_response"
+)
+
+// sweeperDisconnectReasons are the exact sites.disconnected_reason values the
+// connection sweeper itself writes when it drives connected/degraded ->
+// disconnected (internal/site/sweeper.go Sweep): "agent_unreachable" from the
+// active-verify path, "heartbeat_timeout" from the passive fallback path used
+// when active verify is disabled. Both mean the CP independently observed the
+// agent going silent or refusing a signed probe, i.e. a real outage.
+//
+// Every OTHER disconnected site reached that state via a SIGNED agent
+// last-will (ADR-040, connService.RecordLastWillTenant): the operator
+// deactivated or uninstalled the plugin, or some other agent-supplied reason.
+// The agent controls that reason string (bounded to 64 bytes, defaults to
+// "user_initiated", see internal/agent/handler.go disconnect()), so it is
+// deliberately NOT trusted as a positive signal; only the two CP-authored
+// strings below are ever treated as evidence of an unhealthy site. Anything
+// else (a known last-will reason, an unrecognized string, or an empty/legacy
+// row predating this column) is treated as healthy: deriveFleetStatus must
+// never raise an alarming Degraded chip on a site the operator cleanly took
+// offline, and a value it cannot positively attribute to the sweeper is not
+// proof of an outage.
+var sweeperDisconnectReasons = map[string]bool{
+	"agent_unreachable": true,
+	"heartbeat_timeout": true,
+}
+
 // FleetStatusCounts is the summary count header in the fleet status response.
 type FleetStatusCounts struct {
 	Up       int `json:"up"`
@@ -99,18 +144,22 @@ type FleetStatusCounts struct {
 // apps/web/src/features/fleet/fleet-types.ts — do not rename without
 // updating both sides.
 type FleetStatusItem struct {
-	SiteID           uuid.UUID       `json:"site_id"`
-	Name             string          `json:"name"`
-	URL              string          `json:"url"`
-	ConnectionState  string          `json:"connection_state"`
-	HealthStatus     string          `json:"health_status"`
-	Status           FleetSiteStatus `json:"status"`
-	Up               *bool           `json:"up"`
-	LastProbeAt      *time.Time      `json:"last_probe_at"`
-	UptimePct7d      float64         `json:"uptime_pct_7d"`
-	AvgLatencyMs     *float64        `json:"avg_latency_ms"`
-	TLSExpiry        *time.Time      `json:"tls_expiry"`
-	LatencySparkline []float64       `json:"latency_sparkline"`
+	SiteID          uuid.UUID       `json:"site_id"`
+	Name            string          `json:"name"`
+	URL             string          `json:"url"`
+	ConnectionState string          `json:"connection_state"`
+	HealthStatus    string          `json:"health_status"`
+	Status          FleetSiteStatus `json:"status"`
+	// StatusReason explains WHY Status is what it is when that is not
+	// self-evident (currently only populated for FleetStatusDegraded, one of
+	// the FleetReason* constants). Empty for up/down/unknown.
+	StatusReason     string     `json:"status_reason,omitempty"`
+	Up               *bool      `json:"up"`
+	LastProbeAt      *time.Time `json:"last_probe_at"`
+	UptimePct7d      float64    `json:"uptime_pct_7d"`
+	AvgLatencyMs     *float64   `json:"avg_latency_ms"`
+	TLSExpiry        *time.Time `json:"tls_expiry"`
+	LatencySparkline []float64  `json:"latency_sparkline"`
 	// InIncident is kept for internal use (summary counting) but not needed
 	// by the frontend contract — retained for the service-layer logic.
 	InIncident bool `json:"in_incident"`
@@ -132,6 +181,12 @@ type FleetSiteInfo struct {
 	ConnectionState string
 	HealthStatus    string
 	InIncident      bool
+	// DisconnectedReason is sites.disconnected_reason (empty when NULL or when
+	// ConnectionState is not "disconnected"). deriveFleetStatus reads this to
+	// tell a sweeper-detected outage apart from an operator-initiated last-will
+	// disconnect (GH #291 follow-up). See the FleetReasonAgentUnreachable doc
+	// comment for the full set of values this can hold.
+	DisconnectedReason string
 }
 
 // FleetIncidentItem is one open or recently-started incident for the fleet

--- a/apps/api/internal/uptime/repo.go
+++ b/apps/api/internal/uptime/repo.go
@@ -56,9 +56,10 @@ type Repo interface {
 	// because sqlc generates non-nullable types for nullable columns.
 
 	// GetFleetSiteInfo returns the Postgres-resident fields for the requested
-	// sites: name, url, connection_state, health_status, in_incident. Probe /
-	// uptime metrics are NOT included — the service layer merges those from the
-	// metrics.Store so both ClickHouse and Postgres deployments work correctly.
+	// sites: name, url, connection_state, health_status, in_incident,
+	// disconnected_reason. Probe / uptime metrics are NOT included: the
+	// service layer merges those from the metrics.Store so both ClickHouse and
+	// Postgres deployments work correctly.
 	GetFleetSiteInfo(ctx context.Context, tenantID uuid.UUID, siteIDs []uuid.UUID) ([]FleetSiteInfo, error)
 
 	// GetFleetIncidents returns open incidents and incidents that started at or
@@ -309,11 +310,11 @@ func (r *pgRepo) UpsertAlertConfig(ctx context.Context, cfg AlertConfig) (AlertC
 // ---------------------------------------------------------------------------
 
 // GetFleetSiteInfo returns the Postgres-resident fields for each requested
-// site: name, url, connection_state, health_status, in_incident. Probe /
-// uptime metrics are intentionally excluded — the service merges those from
-// the metrics.Store so the endpoint works on both ClickHouse and Postgres
-// deployments (previously these were read directly from site_uptime_probes,
-// which is empty on ClickHouse installs).
+// site: name, url, connection_state, health_status, in_incident,
+// disconnected_reason. Probe / uptime metrics are intentionally excluded:
+// the service merges those from the metrics.Store so the endpoint works on
+// both ClickHouse and Postgres deployments (previously these were read
+// directly from site_uptime_probes, which is empty on ClickHouse installs).
 func (r *pgRepo) GetFleetSiteInfo(ctx context.Context, tenantID uuid.UUID, siteIDs []uuid.UUID) ([]FleetSiteInfo, error) {
 	const q = `
 SELECT
@@ -322,7 +323,8 @@ SELECT
     s.url,
     s.connection_state,
     s.health_status,
-    COALESCE(ast.in_incident, false) AS in_incident
+    COALESCE(ast.in_incident, false) AS in_incident,
+    s.disconnected_reason
 FROM sites s
 LEFT JOIN site_alert_state ast ON ast.site_id = s.id
 WHERE s.tenant_id = $1
@@ -338,11 +340,16 @@ ORDER BY s.name ASC
 		defer rows.Close()
 		for rows.Next() {
 			var info FleetSiteInfo
+			var disconnectedReason *string
 			if err := rows.Scan(
 				&info.SiteID, &info.Name, &info.URL,
 				&info.ConnectionState, &info.HealthStatus, &info.InIncident,
+				&disconnectedReason,
 			); err != nil {
 				return domain.Internal("fleet_site_info_scan_failed", "failed to scan fleet site info row").WithCause(err)
+			}
+			if disconnectedReason != nil {
+				info.DisconnectedReason = *disconnectedReason
 			}
 			out = append(out, info)
 		}
@@ -357,22 +364,91 @@ ORDER BY s.name ASC
 	return out, nil
 }
 
-// deriveFleetStatus computes the FleetSiteStatus from the latest probe result.
-func deriveFleetStatus(up *bool, totalMs *float64, connectionState string) FleetSiteStatus {
+// deriveFleetStatus computes the FleetSiteStatus from the latest probe result,
+// plus a short machine-readable reason (FleetReason*, empty when the status is
+// self-explanatory) so the API/UI can say WHICH degraded it is instead of
+// rendering a bare chip.
+//
+// GH #291: a page cache in front of a fatal-on-every-request site keeps
+// answering probe A (the reachability probe, frozen, see the design doc) with
+// a cached 200, so `up` alone cannot see past the cache. It does not need to:
+// the control plane already has a stronger, independent signal from the agent
+// side. ADR-039's connection sweeper sends a SIGNED, UNCACHEABLE POST straight
+// to the agent and tracks the outcome in sites.connection_state, completely
+// out of band from the cached probe. Two of its states now flip the derived
+// fleet status to Degraded even though the cached probe reported up=true:
+//
+//   - "degraded": the heartbeat is stale (missed >= 300s) but not yet stale
+//     enough to disconnect. This is the weaker of the two signals.
+//   - "disconnected": the sweeper's active-verify already tried the signed
+//     POST and got a failure (5xx/timeout/conn-error), OR the passive
+//     heartbeat-timeout fallback fired. This is the strongest signal short of
+//     `up` itself going false, and it is the literal GH #291 case: previously
+//     this state fell through to a clean FleetStatusUp.
+//
+// GH #291 follow-up (false Degraded on a clean deactivation): "disconnected"
+// is NOT reached only by the sweeper. A SIGNED agent last-will
+// (ADR-040, connService.RecordLastWillTenant) drives the exact same
+// connected/degraded -> disconnected transition when an operator deactivates
+// or uninstalls the plugin, and that site is a perfectly healthy site that
+// chose to stop heartbeating, not an outage. Both paths land on
+// connection_state "disconnected" with no other distinguishing column on the
+// read side except sites.disconnected_reason (threaded through as
+// disconnectedReason here). The two are DISTINGUISHABLE: the sweeper always
+// writes one of exactly two CP-authored strings (see
+// sweeperDisconnectReasons), while a last-will disconnect is either the
+// agent's own fixed reasons ("deactivated", "uninstalled") or the handler's
+// "user_initiated" default, never one of the sweeper's strings. Because the
+// agent controls its last-will reason text (bounded, not enum-validated),
+// this function does NOT try to enumerate every last-will value; it does the
+// reverse and requires a positive match against the small, CP-authored
+// sweeper set before it will raise the alarming Degraded chip. Any value it
+// cannot positively attribute to the sweeper (a known last-will reason, an
+// unrecognized string, or an empty/legacy row that predates this column) is
+// treated as healthy, per the conservative rule: never show an alarming
+// Degraded when the data cannot prove the site is unhealthy.
+//
+// "revoked" and "archived" are deliberately EXCLUDED from this check. Both
+// mean the OPERATOR chose to stop managing the site (see GH #282, which
+// excludes the same two states from backup scheduling for the identical
+// reason), not a connectivity problem. Flagging them Degraded would raise a
+// false alarm on a site nobody is watching. FleetStatusUnknown is not a
+// substitute: it already means "no probe recorded yet", and reusing it here
+// would make an operator unable to tell "never probed" apart from
+// "deliberately archived". None of the four existing FleetSiteStatus values
+// expresses "deliberately unmanaged" without being misleading in one
+// direction or the other, and adding a fifth would break the API enum and
+// every FE consumer (out of scope for this phase, per the design doc's "no
+// new enum value" rule). So revoked/archived sites keep exactly today's
+// behavior: their derived status depends only on `up` and latency, same as
+// before this fix. A distinct non-alarming "unmanaged" indicator is a
+// candidate for a future phase, not squeezed in here.
+//
+// `up` itself, sites.health_status, uptime percentages and everything else
+// probe A feeds are UNCHANGED by this function. Only the derived display
+// status moves.
+func deriveFleetStatus(up *bool, totalMs *float64, connectionState, disconnectedReason string) (FleetSiteStatus, string) {
 	if up == nil {
-		return FleetStatusUnknown
+		return FleetStatusUnknown, ""
 	}
 	if !*up {
-		return FleetStatusDown
+		return FleetStatusDown, ""
 	}
-	// Site is up — check for degraded: slow response OR degraded connection state.
-	if connectionState == "degraded" {
-		return FleetStatusDegraded
+	switch connectionState {
+	case "disconnected":
+		if sweeperDisconnectReasons[disconnectedReason] {
+			return FleetStatusDegraded, FleetReasonAgentUnreachable
+		}
+		// A clean last-will disconnect (or a reason we cannot positively
+		// attribute to the sweeper): fall through to the same derivation a
+		// healthy "connected" site gets, below.
+	case "degraded":
+		return FleetStatusDegraded, FleetReasonAgentDegraded
 	}
 	if totalMs != nil && *totalMs > slowThresholdMs {
-		return FleetStatusDegraded
+		return FleetStatusDegraded, FleetReasonSlowResponse
 	}
-	return FleetStatusUp
+	return FleetStatusUp, ""
 }
 
 // GetFleetIncidents returns open incidents (ended_at IS NULL) and incidents

--- a/apps/api/internal/uptime/service.go
+++ b/apps/api/internal/uptime/service.go
@@ -216,7 +216,7 @@ func (s *Service) GetFleetStatus(ctx context.Context, tenantID uuid.UUID, siteID
 			if um.AvgLatencyMs != nil {
 				totalMsPtr = um.AvgLatencyMs
 			}
-			item.Status = deriveFleetStatus(um.Up, totalMsPtr, info.ConnectionState)
+			item.Status, item.StatusReason = deriveFleetStatus(um.Up, totalMsPtr, info.ConnectionState, info.DisconnectedReason)
 		} else {
 			item.Status = FleetStatusUnknown
 		}

--- a/apps/api/tests/metrics_schema_convergence_integration_test.go
+++ b/apps/api/tests/metrics_schema_convergence_integration_test.go
@@ -1,0 +1,179 @@
+package tests
+
+// GH #291 Phase 0 regression test: proves ensureSchema converges an existing
+// ClickHouse uptime_checks table (created with only a subset of the declared
+// columns, simulating an older deployment that predates a later added
+// column) to the current column set via ADD COLUMN IF NOT EXISTS, that a
+// converged table accepts a full-shape InsertChecks without a column-count
+// mismatch, and that a second ensureSchema run is a clean no-op. Requires
+// Docker and skips when it is unavailable (same pattern as
+// metrics_integration_test.go).
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+	"github.com/testcontainers/testcontainers-go"
+	tcclickhouse "github.com/testcontainers/testcontainers-go/modules/clickhouse"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/metrics"
+)
+
+func TestMetricsClickHouseSchemaConvergence(t *testing.T) {
+	ctx := context.Background()
+
+	container, err := tcclickhouse.Run(ctx,
+		"clickhouse/clickhouse-server:24.3-alpine",
+		tcclickhouse.WithUsername("wpmgr"),
+		tcclickhouse.WithPassword("wpmgr"),
+		tcclickhouse.WithDatabase("default"),
+		testcontainers.WithWaitStrategy(
+			wait.ForListeningPort("9000/tcp").WithStartupTimeout(120*time.Second),
+		),
+	)
+	if err != nil {
+		t.Skipf("skipping: cannot start clickhouse container (docker unavailable?): %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	host, err := container.ConnectionHost(ctx)
+	if err != nil {
+		t.Fatalf("clickhouse connection host: %v", err)
+	}
+
+	rawConn, err := clickhouse.Open(&clickhouse.Options{
+		Addr: []string{host},
+		Auth: clickhouse.Auth{Database: "default", Username: "wpmgr", Password: "wpmgr"},
+	})
+	if err != nil {
+		t.Fatalf("raw connect: %v", err)
+	}
+	defer rawConn.Close()
+
+	// The entrypoint restarts the server after first-run init; poll until the
+	// driver succeeds, same race the real integration test absorbs.
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		if perr := rawConn.Ping(ctx); perr == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("raw driver never became ready")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	if err := rawConn.Exec(ctx, "CREATE DATABASE IF NOT EXISTS wpmgr_metrics"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	// Legacy shape: missing tls_ms, ttfb_ms, tls_expiry, error (simulates a
+	// table created before those columns existed).
+	legacyDDL := `CREATE TABLE wpmgr_metrics.uptime_checks (
+    checked_at  DateTime,
+    tenant_id   UUID,
+    site_id     UUID,
+    up          UInt8,
+    http_status UInt16,
+    dns_ms      Float64,
+    connect_ms  Float64,
+    total_ms    Float64
+) ENGINE = MergeTree()
+ORDER BY (tenant_id, site_id, checked_at)`
+	if err := rawConn.Exec(ctx, legacyDDL); err != nil {
+		t.Fatalf("create legacy table: %v", err)
+	}
+
+	// Sanity: the legacy table is missing columns our full Check struct needs.
+	before, err := columnSet(ctx, rawConn)
+	if err != nil {
+		t.Fatalf("describe legacy: %v", err)
+	}
+	if before["tls_expiry"] || before["error"] {
+		t.Fatalf("legacy table unexpectedly already has full shape: %+v", before)
+	}
+	t.Logf("legacy columns before convergence: %v", before)
+
+	// Now point metrics.New at this SAME container/db. ensureSchema must run
+	// CREATE TABLE IF NOT EXISTS (no-op, table exists) then ADD COLUMN IF NOT
+	// EXISTS for every declared column, converging the legacy table.
+	store, err := metrics.New(ctx, metrics.Config{
+		Addr:     host,
+		Database: "wpmgr_metrics",
+		Username: "wpmgr",
+		Password: "wpmgr",
+	}, nil)
+	if err != nil {
+		t.Fatalf("metrics.New against legacy table: %v", err)
+	}
+	defer store.Close()
+
+	after, err := columnSet(ctx, rawConn)
+	if err != nil {
+		t.Fatalf("describe after convergence: %v", err)
+	}
+	for _, want := range []string{"checked_at", "tenant_id", "site_id", "up", "http_status", "dns_ms", "connect_ms", "tls_ms", "ttfb_ms", "total_ms", "tls_expiry", "error"} {
+		if !after[want] {
+			t.Fatalf("expected column %q after convergence, got columns: %v", want, after)
+		}
+	}
+	t.Logf("columns after convergence: %v", after)
+
+	// A converged table must accept a full-shape insert without a
+	// column-count mismatch.
+	tenantID, siteID := uuid.New(), uuid.New()
+	err = store.InsertChecks(ctx, []metrics.Check{{
+		CheckedAt:  time.Now(),
+		TenantID:   tenantID,
+		SiteID:     siteID,
+		Up:         true,
+		HTTPStatus: 200,
+		TotalMs:    42,
+		Error:      "",
+	}})
+	if err != nil {
+		t.Fatalf("insert after convergence: %v", err)
+	}
+
+	agg, err := store.QueryAggregate(ctx, tenantID, siteID, time.Hour)
+	if err != nil {
+		t.Fatalf("query aggregate after convergence: %v", err)
+	}
+	if agg.Checks != 1 || agg.UpChecks != 1 {
+		t.Fatalf("expected 1/1 after convergence insert, got %+v", agg)
+	}
+
+	// Re-running ensureSchema again (simulating a second boot) must be a
+	// pure no-op: no error, same columns.
+	store2, err := metrics.New(ctx, metrics.Config{
+		Addr:     host,
+		Database: "wpmgr_metrics",
+		Username: "wpmgr",
+		Password: "wpmgr",
+	}, nil)
+	if err != nil {
+		t.Fatalf("metrics.New second boot (idempotency): %v", err)
+	}
+	defer store2.Close()
+}
+
+func columnSet(ctx context.Context, conn driver.Conn) (map[string]bool, error) {
+	rows, err := conn.Query(ctx, "SELECT name FROM system.columns WHERE database = 'wpmgr_metrics' AND table = 'uptime_checks'")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]bool{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		out[name] = true
+	}
+	return out, rows.Err()
+}

--- a/apps/web/src/features/fleet/StatusChip.test.tsx
+++ b/apps/web/src/features/fleet/StatusChip.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+
+import { StatusChip } from "./StatusChip";
+
+// GH #291 — a page-cached site whose PHP backend is completely dead used to
+// render a bare green "Up" chip. The control plane now derives "degraded"
+// AND sends a `status_reason` code; the fix is that the chip explains
+// itself instead of leaving the operator to guess. These assertions are
+// non-vacuous: a regression that drops the reason lookup (or renders the
+// note for every status, or renders it for an unrecognised code) fails one
+// of these.
+
+describe("StatusChip", () => {
+  it("renders the plain-language explanation for a degraded item with a known reason", () => {
+    renderWithProviders(
+      <StatusChip status="degraded" reason="agent_unreachable" />,
+    );
+
+    expect(screen.getByText("Degraded")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Serving visitors, but the site agent is not responding. Cached pages may be masking a broken backend.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the agent_degraded explanation for a degraded item", () => {
+    renderWithProviders(<StatusChip status="degraded" reason="agent_degraded" />);
+
+    expect(
+      screen.getByText(
+        "Serving visitors, but the site agent is late checking in.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the slow_response explanation for a degraded item", () => {
+    renderWithProviders(<StatusChip status="degraded" reason="slow_response" />);
+
+    expect(screen.getByText("Responding slowly.")).toBeInTheDocument();
+  });
+
+  it("renders no explanation for a degraded item with no reason", () => {
+    renderWithProviders(<StatusChip status="degraded" />);
+
+    expect(screen.getByText("Degraded")).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Serving visitors, but the site agent is not responding. Cached pages may be masking a broken backend.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Serving visitors|Responding slowly/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders no explanation for an unrecognised reason code (future-proofing)", () => {
+    renderWithProviders(
+      <StatusChip status="degraded" reason="some_future_reason_code" />,
+    );
+
+    expect(screen.getByText("Degraded")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Serving visitors|Responding slowly/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("never renders an explanation for a non-degraded status, even if a reason is present", () => {
+    renderWithProviders(<StatusChip status="up" reason="agent_unreachable" />);
+
+    expect(screen.getByText("Up")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Serving visitors|Responding slowly/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/fleet/StatusChip.tsx
+++ b/apps/web/src/features/fleet/StatusChip.tsx
@@ -1,0 +1,46 @@
+// StatusChip — icon + label for an uptime status kind, shared by the fleet
+// Uptime table's Status column (the "site row" an operator scans) and any
+// other place a per-site `FleetStatusItem.status` needs the same triple
+// encoded (colour + label + icon) treatment.
+//
+// GH #291: also renders a short, plain-language explanation under a
+// `degraded` chip when the control plane sends a recognised
+// `status_reason` code. The explanation is real text in the DOM (not a
+// hover-only tooltip, not colour alone) so it is announced to a screen
+// reader and stays visible without a pointer. An absent or unrecognised
+// reason renders NOTHING extra — the chip looks exactly like it always has.
+
+import { cn } from "@/lib/utils";
+import { STATUS_ICON, STATUS_LABEL, STATUS_COLOR_CLASS, statusReasonCopy } from "./uptime-status";
+import type { UptimeStatusKind } from "./fleet-types";
+
+export interface StatusChipProps {
+  status: UptimeStatusKind;
+  /** `FleetStatusItem.status_reason` — only surfaced for a `degraded` status. */
+  reason?: string | null;
+  className?: string;
+}
+
+export function StatusChip({ status, reason, className }: StatusChipProps) {
+  const Icon = STATUS_ICON[status];
+  const note = status === "degraded" ? statusReasonCopy(reason) : null;
+
+  return (
+    <span className={cn("inline-flex flex-col items-start gap-0.5", className)}>
+      <span
+        className={cn(
+          "inline-flex items-center gap-1 text-xs",
+          STATUS_COLOR_CLASS[status],
+        )}
+      >
+        <Icon aria-hidden="true" className="size-3.5 shrink-0" />
+        {STATUS_LABEL[status]}
+      </span>
+      {note && (
+        <span className="text-[11px] leading-snug text-[var(--color-muted-foreground)]">
+          {note}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/web/src/features/fleet/StatusMatrix.tsx
+++ b/apps/web/src/features/fleet/StatusMatrix.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/skeleton";
+import { statusReasonCopy } from "./uptime-status";
 import type { UptimeStatusKind } from "./fleet-types";
 
 // ---------------------------------------------------------------------------
@@ -44,6 +45,12 @@ export interface MatrixCell {
   status: UptimeStatusKind;
   /** Optional secondary metric shown in the tooltip (e.g. "24 ms"). */
   metricLabel?: string;
+  /**
+   * `FleetStatusItem.status_reason` (GH #291) — only surfaced when `status`
+   * is `degraded` and the code is one this UI recognises; otherwise the
+   * cell renders exactly as it always has.
+   */
+  statusReason?: string | null;
 }
 
 export interface StatusMatrixProps {
@@ -98,6 +105,10 @@ export function StatusMatrix({
       >
         {cells.map((cell) => {
           const isSelected = cell.siteId === selectedSiteId;
+          const note =
+            cell.status === "degraded"
+              ? statusReasonCopy(cell.statusReason)
+              : null;
           const tooltipContent = (
             <span className="space-y-0.5">
               <span className="block font-medium">{cell.name}</span>
@@ -106,6 +117,11 @@ export function StatusMatrix({
                 {STATUS_LABEL[cell.status]}
                 {cell.metricLabel ? ` · ${cell.metricLabel}` : ""}
               </span>
+              {note && (
+                <span className="block max-w-[220px] text-[10px] opacity-80">
+                  {note}
+                </span>
+              )}
             </span>
           );
           return (
@@ -114,7 +130,7 @@ export function StatusMatrix({
                 <button
                   type="button"
                   role="gridcell"
-                  aria-label={`${cell.name}: ${STATUS_LABEL[cell.status]}${cell.metricLabel ? ", " + cell.metricLabel : ""}`}
+                  aria-label={`${cell.name}: ${STATUS_LABEL[cell.status]}${cell.metricLabel ? ", " + cell.metricLabel : ""}${note ? ". " + note : ""}`}
                   aria-pressed={isSelected}
                   onClick={() => onSelect?.(cell.siteId)}
                   style={{ width: cellSize, height: cellSize }}

--- a/apps/web/src/features/fleet/fleet-types.ts
+++ b/apps/web/src/features/fleet/fleet-types.ts
@@ -21,6 +21,18 @@ export interface FleetStatusItem {
   avg_latency_ms: number | null;
   tls_expiry: string | null;
   latency_sparkline: number[];
+  /**
+   * Plain-language reason code for why the control plane derived a
+   * `degraded` status (GH #291), e.g. a page-cached site whose PHP backend
+   * is unreachable. Optional so an older control-plane response (which
+   * never sent this field) cannot break the UI. Known values today:
+   * "agent_unreachable" | "agent_degraded" | "slow_response" — but this is
+   * intentionally typed as `string`, not a union, so a future reason code
+   * the control plane adds is never a type error here; unrecognised codes
+   * are handled by the copy map (see `uptime-status.ts`), not by widening
+   * this type.
+   */
+  status_reason?: string;
 }
 
 export interface FleetStatusSummary {

--- a/apps/web/src/features/fleet/uptime-status.ts
+++ b/apps/web/src/features/fleet/uptime-status.ts
@@ -36,3 +36,35 @@ export const STATUS_COLOR_CLASS: Record<UptimeStatusKind, string> = {
   down: "text-[var(--color-destructive-subtle-fg)]",
   unknown: "text-[var(--color-muted-foreground)]",
 };
+
+// ---------------------------------------------------------------------------
+// status_reason (GH #291) — a page-cached site whose PHP backend is
+// completely dead used to render a clean green "Up"; the control plane now
+// correctly derives "degraded" for it AND sends a reason code explaining
+// why. A bare "Degraded" chip is not actionable on its own, so every reason
+// code we know about maps to a short, calm, plain-language explanation.
+//
+// Deliberately a plain Record (not keyed by a union of the reason codes):
+// the control plane can add a new code at any time, and a code missing from
+// this map must fall back to "no explanation" rather than a type error or a
+// broken render — see `statusReasonCopy` below.
+// ---------------------------------------------------------------------------
+
+export const STATUS_REASON_COPY: Record<string, string> = {
+  agent_unreachable:
+    "Serving visitors, but the site agent is not responding. Cached pages may be masking a broken backend.",
+  agent_degraded: "Serving visitors, but the site agent is late checking in.",
+  slow_response: "Responding slowly.",
+};
+
+/**
+ * Resolve a `FleetStatusItem.status_reason` code to its plain-language copy.
+ * Returns `null` for an absent OR unrecognised reason so callers render the
+ * status chip exactly as they always have, with no extra text — a future
+ * control-plane reason code this map does not yet know about can never
+ * break the UI.
+ */
+export function statusReasonCopy(reason: string | null | undefined): string | null {
+  if (!reason) return null;
+  return STATUS_REASON_COPY[reason] ?? null;
+}

--- a/apps/web/src/routes/_authed/uptime.tsx
+++ b/apps/web/src/routes/_authed/uptime.tsx
@@ -31,6 +31,7 @@ import {
   type TileDefinition,
 } from "@/features/fleet/ExceptionSummaryTiles";
 import { StatusMatrix, type MatrixCell } from "@/features/fleet/StatusMatrix";
+import { StatusChip } from "@/features/fleet/StatusChip";
 import { FleetTable } from "@/features/fleet/FleetTable";
 import {
   DayBarStrip,
@@ -46,11 +47,6 @@ import {
   isIncidentOngoing,
   formatIncidentDuration,
 } from "@/features/fleet/incident-format";
-import {
-  STATUS_ICON,
-  STATUS_LABEL,
-  STATUS_COLOR_CLASS,
-} from "@/features/fleet/uptime-status";
 import { IncidentDetailDialog } from "@/features/fleet/incident-detail-dialog";
 import type {
   FleetStatusItem,
@@ -202,22 +198,13 @@ function buildColumns(): ColumnDef<FleetStatusItem>[] {
       id: "status",
       header: "Status",
       accessorFn: (row) => row.status,
-      meta: { width: "10%" },
-      cell: ({ row }) => {
-        const s = row.original.status;
-        const Icon = STATUS_ICON[s];
-        return (
-          <span
-            className={cn(
-              "inline-flex items-center gap-1 text-xs",
-              STATUS_COLOR_CLASS[s],
-            )}
-          >
-            <Icon aria-hidden="true" className="size-3.5 shrink-0" />
-            {STATUS_LABEL[s]}
-          </span>
-        );
-      },
+      meta: { width: "14%" },
+      cell: ({ row }) => (
+        <StatusChip
+          status={row.original.status}
+          reason={row.original.status_reason}
+        />
+      ),
     },
     {
       id: "uptime_pct_7d",
@@ -540,6 +527,7 @@ function UptimePage() {
           item.avg_latency_ms !== null
             ? `${Math.round(item.avg_latency_ms)} ms`
             : undefined,
+        statusReason: item.status_reason,
       })),
     [allItems],
   );

--- a/docs/security/uptime-app-health-design-2026-07-27.md
+++ b/docs/security/uptime-app-health-design-2026-07-27.md
@@ -1,0 +1,122 @@
+# GH #291: uptime probe cannot see past a page cache
+
+**Date:** 2026-07-27
+**Status:** Design locked, ready to build. Phased, each phase independently shippable.
+**Method:** 3-agent workflow (codebase audit + field research with citations + design synthesis).
+
+---
+
+## 0. The headline: we already had the answer and threw it away
+
+During the reporter's outage the control plane **knew the site was broken** and rendered it as a clean green "Up".
+
+A fatal-on-every-request outage means the agent's WP-Cron heartbeat cannot run, so `sites.last_seen_at` goes stale. `Sweeper.Sweep` hits the 900s `disconnectAfter`, sends a **signed, uncacheable** POST to `/wp-json/wpmgr/v1/command/ping`, gets a 5xx, and marks the site `connection_state='disconnected'`. The site was almost certainly disconnected for most of those hours.
+
+Then `deriveFleetStatus` (`apps/api/internal/uptime/repo.go:361-376`) special-cases **only** the literal string `"degraded"`. `disconnected` falls through to `return FleetStatusUp`.
+
+That is a roughly 3-line bug in existing code. Fixing it would have caught this exact incident **with zero new HTTP requests**.
+
+A second existing asset was also already in place: `CronKicker` (`internal/uptime/cron_kick.go:127-137`) already makes a PHP-booting request to `/wp-cron.php` every 5 minutes for every site, and its own doc comment states the premise of this bug ("a fully page-cached site never boots PHP for organic traffic"). It records nothing.
+
+---
+
+## 1. What "up" means: decided
+
+**`up` keeps its exact current meaning forever.** A cached 200 is `up`, and that is the honest answer: visitors are being served. We add a **second orthogonal signal**. No existing number moves.
+
+| Signal | Question | Owns |
+|---|---|---|
+| `up` (reachability) | Did a visitor's request succeed? | `site_uptime_probes.up`, `sites.health_status`, `site_incidents`, uptime %, SLA, client portal, white-label PDFs. **FROZEN.** |
+| `app_up` (application health) | Did PHP and WordPress actually execute? | The new operator state and the new alert kind. Three-valued: true / false / **unknown**. |
+
+**No new enum value.** The scenario maps onto the existing `degraded` value of `UptimeStatusKind`. API enum, counters and every FE consumer keep their shape; only the label and reason are new.
+
+The operator-facing copy is the product:
+
+> "Visitors are being served (HTTP 200), but WordPress is not responding. The agent has been unreachable since 14:07 and /wp-json/ returned HTTP 500. Cached pages will keep working until the cache expires; wp-admin, logins, forms and checkout are likely already broken."
+
+Honest in both directions: it does not say the site is down, and it does not say it is fine. Where app health is **unknown** (`cache_bypass_defeated`, `edge_blocked`, `rest_disabled`) the chip stays green and a neutral marker appears. **Unknown is never dressed up as either healthy or broken.**
+
+---
+
+## 2. Verdict on the reporter's four suggestions
+
+**1. Cache-busting query param: ADAPT, demote from mechanism to belt-and-braces, never on the primary probe.**
+
+It works on nginx FastCGI cache, on the common mod_rewrite-based page caches, and on Cloudflare APO, all of which skip the cache when a query string is present. It is defeated by **one click** on Cloudflare "Ignore Query String", by Varnish configured to ignore query strings, and by any nginx keyed on `$uri` rather than `$request_uri`. A live test against one managed host showed it **stores** the busted response, so each probe mints a new cache object there.
+
+Two hard costs rule it out on the 60s primary probe:
+- 1,440 uncached full theme renders per site per day, exactly the traffic the cache exists to eliminate, on hosts often metered by PHP worker or CPU-second.
+- It would silently redefine `dns_ms/connect_ms/tls_ms/ttfb_ms/total_ms` from "what a visitor experiences" to "worst-case cold render", corrupting the fleet perf dashboard, the `slowThresholdMs` degraded classification, and white-label client PDFs, with no migration and no explanation.
+
+Param name `wpmgr_hc`, deliberately not `utm`-adjacent: WP Engine strips those server-side before PHP sees them, so a buster named `utm_probe` would be silently neutralised.
+
+**Adopt the corollary, which is worth more than the buster:** you can *detect* that your bypass was ignored, via `cf-cache-status`, `x-litespeed-cache`, `x-kinsta-cache`, `x-proxy-cache`, `x-cache`, or `Age > 0`. That is what turns a silent false-healthy into an honest `unknown`.
+
+**2. Probe `/wp-json/`: ADOPT as the app probe, with fallbacks.** Not as a replacement for `/`.
+
+**3. Per-site health path: ADOPT as an override**, surfaced when the probe reports `unknown`.
+
+**4. Agent cross-check: ADOPT, and promote it to first-class.** It is the cheapest and most reliable signal we have, and it is the one thing a pure uptime monitor cannot do.
+
+---
+
+## 3. Probe strategy
+
+**Probe A (reachability) is FROZEN**, bit for bit unchanged. The one change is adding test assertions that the requested path is exactly `/` with an empty query, because **none of the 26 existing probe tests assert the requested path**. That gap must close in the same PR that introduces a second probe, or the two will drift.
+
+**Probe B (application health), new**, default 300s (not 60s), timeout 10s:
+
+- **B0, agent ground truth:** if `sites.last_seen_at` is fresher than the interval, a heartbeat already proves PHP booted. Record `app_up=true, kind='agent'` and make **zero network requests**. On a healthy fleet this is the common case, so steady-state added traffic is near zero. The HTTP probe only fires when the heartbeat is already suspect, which is exactly when you want it.
+- **B1:** `GET <site>/wp-json/?wpmgr_hc=<random>`, bounded 16 KB read.
+- **B2 fallback** (404 or non-JSON 200): `GET <site>/?rest_route=/&wpmgr_hc=<random>`, WP core's permalinks-off REST entrypoint. Skipping it would misclassify every plain-permalink install.
+- **B3 override:** per-site `app_probe_path`.
+
+**4xx is not app-down.** A 401 `rest_not_logged_in` is extremely common (security plugins, including WPMgr's own suite) and 404 is normal on REST-disabled installs. Treating those as down would produce a fleet-wide false-alarm storm.
+
+---
+
+## 4. The sibling bug is more dangerous than the reported one
+
+`update.runApply` (`apps/api/internal/update/worker.go:212-243`) probes the site root after an update and, on a cached site, reads the **pre-update** HTML. A plugin update that fatals PHP therefore **passes its health check, is not rolled back**, and the operator is told "updated and healthy". `probeHealthWithRetry`'s ~21s retry schedule makes it strictly worse: it waits longer, giving the cache more time to serve a warm copy.
+
+**Fix, in priority order:**
+1. **Agent-ping-first.** The CP has *just* spoken to the agent over a signed POST. A signed `VerifyReachable` is a guaranteed-uncacheable, PHP-booting check that **already exists** and is already used by the connection sweeper. Call it first, before the public GET. A cache cannot fake a signed POST response, because the route does not exist unless PHP booted and the plugin loaded.
+2. Fix `ProbeResult.Healthy()` (`client.go:802`), where 401/403/404/410 currently count as healthy, but **do not** make 4xx mean rollback.
+3. Cache-buster on the post-update GET.
+4. Share the extracted `scanFatal` and cache-detection helpers.
+
+---
+
+## 5. Rollout: measure first, alert later
+
+The new probe **will** immediately find real, previously-invisible breakage across the whole fleet. If that arrives as pages, operators disable the feature within an hour and we have shipped nothing.
+
+- `app_probe_enabled` = **true** (collect and display from day one).
+- `app_alerts_enabled` = **false** on any deployment that already has sites. Nobody's phone rings on upgrade.
+- **Fresh installs get alerting on**, decided deterministically *in the migration*, not by a runtime guess:
+  `INSERT INTO instance_settings ... SELECT 'uptime.app_alerts_default', (count(*) = 0)::text FROM sites`
+- Threshold 5 (~25 min), requires `ever_app_up = true` so a never-healthy site can never fire, plus a fleet circuit-breaker collapsing >25% simultaneous app-down into one aggregate alert.
+- **Existing sites' behaviour on upgrade is bit-identical**, enforced by a golden test written before the feature: a site serving cached 200s with a dead backend must still report `up=true`, unchanged `uptime_pct_30d`, unchanged `health_status`.
+
+---
+
+## 6. Phases
+
+| Phase | Ships | Why |
+|---|---|---|
+| **0** | ClickHouse hardening: idempotent `ADD COLUMN IF NOT EXISTS` in `ensureSchema`, column-explicit `InsertChecks`. | **Fixes a live P0.** `ensureSchema` has no ALTER path and `CREATE TABLE IF NOT EXISTS` is a no-op on an existing table, so appending new values later breaks inserts outright. CORRECTION (verified during the Phase 0 build): the earlier claim that `tls_issuer`/`tls_subject` are "already drifted" in ClickHouse is wrong. Those two columns exist and are written only in the **Postgres** implementation; they were never declared in the ClickHouse DDL, so there is nothing to wire through. Phase 0 stands on the missing ALTER path alone, which is sufficient. |
+| **1** | Fix `deriveFleetStatus` to stop rendering `disconnected` as green Up; typed reasons from `VerifyReachable`. | **Zero new HTTP requests, no metrics schema change, and it would have caught this incident.** Highest value per line in the whole plan. **AS BUILT:** `revoked`/`archived` were deliberately left at today's behaviour rather than given a distinct state, because the only way to express one is a 5th enum value, which this design forbids. Follow-up, not a gap. The disconnected check is gated on a **whitelist** of the two CP-authored sweeper reasons (`agent_unreachable`, `heartbeat_timeout`), so a signed agent last-will (deactivate or uninstall, where the reason string is agent-supplied and not enum-validated) can never raise a false Degraded. |
+| **2** | m107 additive nullable columns, the app prober (B0-B3), two-signal recording. Alerting still off. | The actual new capability. |
+| **3** | App-health alerting, per-site override, fleet circuit-breaker. | Opt-in, conservative. |
+| **4** | The post-update rollback probe fix (agent-ping-first). | Independently shippable; the more dangerous bug. |
+
+---
+
+## 7. Risks the build must respect
+
+- **ClickHouse arity trap is a live P0** that Phase 2 would trigger. Phase 0 exists to defuse it first.
+- **Never record app health as a second row** per sweep: `site_uptime_daily` has no kind dimension (PK `site_id, day`), so `total_checks` would double and `up_checks` would blend two meanings, silently corrupting every uptime percentage in the product.
+- The 300s app probe against the 60s reachability probe means **4 of every 5 rollup upserts carry `app_up = NULL`**. A naive `latest_app_up = EXCLUDED.latest_app_up` clobbers a known value with NULL 80% of the time. The upsert must be COALESCE-guarded.
+- Cache-busting is defeated one click away, and Cloudflare Always Online defeats everything. A design that silently reports healthy in those cases is worse than the current bug, which is why cache-HIT detection maps to `unknown`, not to healthy.
+- `VerifyReachable` today collapses a 404 into a bare `alive=false` and discards the reason, so an *uninstalled* agent looks like a *broken* one. Typed reasons are a prerequisite for the cross-check.

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -4376,6 +4376,11 @@ export const FleetUptimeStatusItemSchema = {
       type: "string",
       enum: ["up", "degraded", "down", "unknown"],
     },
+    status_reason: {
+      type: "string",
+      description:
+        "Short machine-readable explanation for status, populated when\nstatus=degraded (agent_unreachable, agent_degraded, or\nslow_response). Empty/absent when the status needs no further\nexplanation.\n",
+    },
     uptime_pct_7d: {
       type: "number",
       format: "double",

--- a/packages/openapi-client/src/generated/sdk.gen.ts
+++ b/packages/openapi-client/src/generated/sdk.gen.ts
@@ -4941,8 +4941,13 @@ export const getFleetBackupHealth = <ThrowOnError extends boolean = false>(
  * Returns summary counts {up, degraded, down, unknown} and a per-site list
  * with the latest probe result, 7-day uptime %, and in-incident flag.
  * Status derivation: down=latest probe up=false; degraded=up but latency
- * >2000ms or connection_state=degraded; up=probe up+fast; unknown=no probe.
- * Requires viewer+.
+ * >2000ms, or connection_state=degraded (status_reason=agent_degraded),
+ * or connection_state=disconnected (status_reason=agent_unreachable, GH
+ * #291: a cached response can stay up=true while the agent side already
+ * proved the site unreachable); up=probe up+fast; unknown=no probe.
+ * connection_state=revoked/archived does not affect status derivation
+ * (the operator deliberately stopped managing the site). Requires
+ * viewer+.
  *
  */
 export const getFleetUptimeStatus = <ThrowOnError extends boolean = false>(

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -2229,6 +2229,14 @@ export type FleetUptimeStatusItem = {
   site_name: string;
   site_url: string;
   status: "up" | "degraded" | "down" | "unknown";
+  /**
+   * Short machine-readable explanation for status, populated when
+   * status=degraded (agent_unreachable, agent_degraded, or
+   * slow_response). Empty/absent when the status needs no further
+   * explanation.
+   *
+   */
+  status_reason?: string;
   uptime_pct_7d: number;
   avg_latency_ms_7d: number;
   latest_total_ms?: number;

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.89
+  version: 0.61.90
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,
@@ -6614,8 +6614,13 @@ paths:
         Returns summary counts {up, degraded, down, unknown} and a per-site list
         with the latest probe result, 7-day uptime %, and in-incident flag.
         Status derivation: down=latest probe up=false; degraded=up but latency
-        >2000ms or connection_state=degraded; up=probe up+fast; unknown=no probe.
-        Requires viewer+.
+        >2000ms, or connection_state=degraded (status_reason=agent_degraded),
+        or connection_state=disconnected (status_reason=agent_unreachable, GH
+        #291: a cached response can stay up=true while the agent side already
+        proved the site unreachable); up=probe up+fast; unknown=no probe.
+        connection_state=revoked/archived does not affect status derivation
+        (the operator deliberately stopped managing the site). Requires
+        viewer+.
       tags: [uptime]
       responses:
         "200":
@@ -15163,6 +15168,13 @@ components:
         status:
           type: string
           enum: [up, degraded, down, unknown]
+        status_reason:
+          type: string
+          description: |
+            Short machine-readable explanation for status, populated when
+            status=degraded (agent_unreachable, agent_degraded, or
+            slow_response). Empty/absent when the status needs no further
+            explanation.
         uptime_pct_7d:
           type: number
           format: double


### PR DESCRIPTION
Addresses #291 (phases 0 and 1 of 4; phases 2-4 follow).

## The bug

A site whose PHP was fatal on **every request for hours** kept reporting an unbroken `up=1, 200` stream. The probe requests the homepage, and a page cache serves it without WordPress running at all, so the one thing being checked is exactly the thing a cache keeps serving regardless of backend health. The existing WSOD body-signature detection can't help either: the cache replays the **last good render**, so the body looks perfectly healthy.

## The key finding: we already knew

When the agent stops answering, the connection sweeper active-verifies over a **signed, uncacheable POST**, gets a 5xx, and marks the site `disconnected`. But `deriveFleetStatus` special-cased **only** the literal string `"degraded"`, so `disconnected` fell through to `FleetStatusUp`.

The dashboard rendered green while the control plane held proof of the opposite. Fixing that catches this incident with **zero new HTTP requests**.

## Phase 1 (the fix)

- `deriveFleetStatus` now derives **Degraded** for a disconnected site, gated on a **whitelist** of the two CP-authored sweeper reasons (`agent_unreachable`, `heartbeat_timeout`). A whitelist, not a last-will blacklist, because the **agent** supplies the last-will reason string and it is not enum-validated. A site whose agent was cleanly deactivated or uninstalled is healthy and is unaffected.
- A new `status_reason` travels with the status so the UI can say *which* degraded it is, rendered as **real accessible text** (not colour, not hover-only): *"Serving visitors, but the site agent is not responding. Cached pages may be masking a broken backend."*
- `agentcmd` gains **typed reachability reasons**, so an agent that is merely *uninstalled* is no longer indistinguishable from one whose site is *broken*. That distinction is a prerequisite for the alerting in phase 3.

## Phase 0 (groundwork, self-host only)

The ClickHouse metrics path had **no ALTER route**: `ensureSchema` only issued `CREATE TABLE IF NOT EXISTS`, which is a no-op on an existing table, so any column added later would never land and inserts would then break outright. It now reads `system.columns` once and ALTERs only genuinely missing columns (converged table = zero DDL). Failures are logged and **non-fatal**, because metrics must never block control-plane boot. `InsertChecks` is now column-explicit.

Not used by hosted prod, which runs the Postgres metrics store. It matters for default self-host installs, which enable ClickHouse, including the reporter's.

## "up" is deliberately unchanged

Verified **bit-identical**: a cached 200 is still `up`, because visitors really are being served. Uptime percentages, `sites.health_status`, `site_incidents`, the client portal and white-label PDFs all keep their exact values. Only the derived **display** status moves, pinned by a golden regression test.

## Verification

- Go build/vet/tests green; web lint clean, 134 fleet+routes tests pass, vite build clean.
- Phase 0 proven against a **real ClickHouse container**: a legacy 8-column table converged to all 12, a full insert round-tripped, and a second boot was a clean no-op.
- Adversarially reviewed **twice**. Round one caught a false Degraded on cleanly-deactivated sites, an `ensureSchema` that could hard-fail boot, and a `status_reason` that never reached the operator. All fixed and re-verified.

Design and remaining phases: `docs/security/uptime-app-health-design-2026-07-27.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LijsBvT79KkVsM8DY4tD1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fleet uptime statuses now include clear explanations for degraded states, such as unreachable agents, degraded agents, or slow responses.
  * Status explanations are visible in uptime tables, status indicators, tooltips, and accessibility labels.
* **Bug Fixes**
  * Corrected fleet status reporting when cached pages appear healthy despite an unreachable site.
  * Improved compatibility with existing self-hosted metrics databases during startup.
* **Documentation**
  * Updated release information and API documentation for version 0.61.90.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->