### PR TITLE
fix(update): a broken update could pass its health check and never roll back (GH #291 phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.91] - 2026-07-27
+
+### Fixed
+
+- An update that broke a site could be reported as successful and never rolled back (GH #291). After applying an update WPMgr checks the site's homepage to decide whether to undo it, but on a site with page caching that check could be answered from the cache with the pre-update page, so an update that broke WordPress outright still looked healthy. WPMgr now asks the site agent directly first, over a signed request that cannot be served from a cache and only works if WordPress actually loaded, and it still checks the public homepage afterwards so that a theme or front-end problem the agent cannot see is caught too. A response that is identified as coming from a cache is now treated as inconclusive rather than as proof of success.
+- Updates are no longer at risk of being cut off partway through. The job running an update was bound by a one minute limit, while a single slow install was allowed up to five minutes, so a slow but successful update could be terminated mid-flight and left stuck. The limit is now derived from the time the work is actually allowed to take.
+- An update is only undone now when a failure is confirmed repeatedly, never on a single reading. A site that returns an error briefly while it finishes activating, restarts, or is momentarily behind a failing proxy is given time to recover first, so a good update is not reverted because of a passing blip.
+
 ## [0.61.90] - 2026-07-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
   <a href="https://wpmgr.app/docs/">API reference</a>
 </p>
 
-**v0.61.90** — open-source and production-usable for self-hosters.
+**v0.61.91** — open-source and production-usable for self-hosters.
 
 ---
 
@@ -313,15 +313,15 @@ Site screenshot cards then fall back to favicon/monogram and the Media Optimizer
 The control plane, dashboard, and media encoder are published on GitHub Container Registry as multi-arch (`linux/amd64` + `linux/arm64`) images, for wiring into your own compose, Kubernetes, or Swarm setup:
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.90
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.90
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.90
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.91
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.91
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.91
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.90   # omit to track :latest
+export WPMGR_VERSION=v0.61.91   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -694,7 +694,16 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// is configured (the cmdSigner == nil / disabled-commander case, guarded
 	// exactly like the media block does).
 	updateApplyCmd := buildUpdateApplyCommander(commander, cmdSigner, cfg.Update.ApplyHTTPTimeout)
-	updateWorker := update.NewWorker(updateRepo, sitesLookup, updateApplyCmd, prober, updateHub, auditRec, logger, cfg.Update.PerTenantParallelism)
+	// The update-task River job otherwise inherits River's own 60s default
+	// (river.Config.JobTimeout is unset below), which is shorter than
+	// cfg.Update.ApplyHTTPTimeout (5m) alone, let alone the apply call PLUS the
+	// GH #291 Phase 4 post-update health check that runs after it in the same
+	// job. Mirror the backup worker's jobTimeout pattern (backupJobTimeout,
+	// below): derive a job-level budget that genuinely covers the worst case
+	// instead of relying on the 60s default. See DeriveApplyJobTimeout's doc
+	// comment for the full arithmetic.
+	updateJobTimeout := update.DeriveApplyJobTimeout(cfg.Update.ApplyHTTPTimeout, cfg.Update.HTTPTimeout)
+	updateWorker := update.NewWorker(updateRepo, sitesLookup, updateApplyCmd, prober, updateHub, auditRec, logger, cfg.Update.PerTenantParallelism, updateJobTimeout)
 	// #131 follow-up — periodic reaper for update_tasks stuck in pending/running
 	// past staleTaskThreshold (a worker crash mid-task, or a failed enqueue that
 	// leaves a task pending). Without this, such a task permanently occupies its

--- a/apps/api/internal/agentcmd/client.go
+++ b/apps/api/internal/agentcmd/client.go
@@ -950,12 +950,30 @@ type ProbeResult struct {
 	// Fatal is true when the response looks like a PHP fatal / WSOD even with a
 	// 200 status (WordPress sometimes returns 200 with a fatal-error body).
 	Fatal bool
+	// CacheHit is true when the response carries a header (or Age value) that
+	// identifies it as served from a page/edge cache rather than freshly
+	// rendered, even though Get() appended a cache-busting query parameter
+	// (see addCacheBuster). A cache that is keyed on path only, ignoring the
+	// query string entirely (Cloudflare's "Ignore Query String" page rule,
+	// Varnish configured that way, nginx keyed on $uri), defeats the buster
+	// with one click, so this is the honest backstop: a caller MUST NOT treat
+	// a CacheHit response as proof of anything about the current backend
+	// state (GH #291 Phase 4 Change 3).
+	CacheHit bool
 	// Detail is a short reason string for logging/audit.
 	Detail string
 }
 
 // Healthy reports whether the probe indicates a healthy site: a non-5xx status
-// and no fatal-error signature.
+// and no fatal-error signature. This is the ORIGINAL, unchanged reachability
+// check: 401/403/404/410 all count as healthy here, which is deliberately
+// lenient for a generic "did something answer" question. It is intentionally
+// NOT used for the post-update rollback decision (see
+// internal/update.classifyPostUpdateProbe), which needs a narrower rule (a
+// 404/410 on the site root after an update IS a broken-update signal, a
+// 401/403 is NOT). Adding that narrower rule as a separate, explicit
+// classification next to its one caller, rather than changing what Healthy()
+// means, keeps every other/future caller of this shared helper unaffected.
 func (r ProbeResult) Healthy() bool {
 	return r.StatusCode > 0 && r.StatusCode < 500 && !r.Fatal
 }
@@ -971,11 +989,84 @@ var fatalSignatures = []string{
 	"cannot redeclare",
 }
 
+// cacheBusterParam is the query parameter Get appends to every probed URL
+// (GH #291 Phase 4 Change 3). Deliberately NOT utm-adjacent: some managed
+// hosts (WP Engine among them) strip utm_* params server-side before PHP ever
+// sees them, which would silently neutralize a buster named that way.
+//
+// This IS a deliberate departure from the frozen 60s uptime reachability
+// probe (internal/uptime), which never busts its cache for good reasons (see
+// docs/security/uptime-app-health-design-2026-07-27.md section 2): a
+// recurring 60s probe with a buster would mint ~1,440 uncached full renders
+// per site per day and would corrupt the perf-timing numbers it also
+// collects. NEITHER objection applies here: this Probe fires at most a
+// handful of times, once, right after an update is applied, not on a
+// recurring schedule, and it collects no timing metrics. Do not remove this
+// on the assumption it is the same mistake the uptime probe design rejected.
+const cacheBusterParam = "wpmgr_hc"
+
+// addCacheBuster appends a fresh, unpredictable-enough query parameter to
+// targetURL so a query-string-keyed cache treats this request as a new
+// object. It is not a security token; it only needs to vary per call.
+func addCacheBuster(targetURL string) (string, error) {
+	u, err := url.Parse(targetURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid probe url: %w", err)
+	}
+	q := u.Query()
+	q.Set(cacheBusterParam, strconv.FormatInt(time.Now().UnixNano(), 36))
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// cacheHitHeaders are the response headers various page/edge caches use to
+// report that a response was served from cache rather than freshly rendered.
+// Checked case-insensitively via http.Header.Get's own canonicalization.
+var cacheHitHeaders = []string{
+	"Cf-Cache-Status",   // Cloudflare
+	"X-Litespeed-Cache", // LiteSpeed / OpenLiteSpeed built-in page cache
+	"X-Kinsta-Cache",    // Kinsta
+	"X-Proxy-Cache",     // common nginx/Varnish proxy_cache naming
+	"X-Cache",           // Varnish, Fastly, many generic reverse proxies
+	"X-Cache-Status",    // the standard nginx add_header X-Cache-Status $upstream_cache_status form
+}
+
+// detectCacheHit reports whether h carries a cache-status header (or an Age
+// value greater than zero) indicating the response was served from cache. A
+// cache that ignores query strings when computing its cache key defeats
+// addCacheBuster with one click of configuration (see cacheBusterParam), so
+// this is the honest backstop that turns a silently-stale 200 into a
+// detectable, reportable CacheHit instead of trusted proof of health.
+func detectCacheHit(h http.Header) (hit bool, detail string) {
+	for _, name := range cacheHitHeaders {
+		v := h.Get(name)
+		if v == "" {
+			continue
+		}
+		if strings.Contains(strings.ToUpper(v), "HIT") {
+			return true, fmt.Sprintf("cache hit (%s: %s)", name, v)
+		}
+	}
+	if age := strings.TrimSpace(h.Get("Age")); age != "" {
+		if n, err := strconv.Atoi(age); err == nil && n > 0 {
+			return true, fmt.Sprintf("cache hit (Age: %s)", age)
+		}
+	}
+	return false, ""
+}
+
 // Get probes targetURL and classifies the result. A transport error (including
 // an SSRF block) is returned as err; a reachable-but-broken site is a non-error
-// ProbeResult with Healthy()==false.
+// ProbeResult with Healthy()==false. The URL is cache-busted (see
+// cacheBusterParam) and the response headers are checked for a cache-status
+// signal (see detectCacheHit / ProbeResult.CacheHit) before the caller decides
+// what the result proves.
 func (p *Probe) Get(ctx context.Context, targetURL string) (ProbeResult, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
+	bustedURL, err := addCacheBuster(targetURL)
+	if err != nil {
+		return ProbeResult{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, bustedURL, nil)
 	if err != nil {
 		return ProbeResult{}, fmt.Errorf("build probe request: %w", err)
 	}
@@ -987,11 +1078,13 @@ func (p *Probe) Get(ctx context.Context, targetURL string) (ProbeResult, error) 
 	}
 	defer func() { _, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxRespBody)); _ = resp.Body.Close() }()
 
+	cacheHit, cacheDetail := detectCacheHit(resp.Header)
+
 	// Read a bounded prefix to scan for fatal-error signatures.
 	const scanLimit = 64 << 10
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, scanLimit))
 	lower := strings.ToLower(string(body))
-	res := ProbeResult{StatusCode: resp.StatusCode}
+	res := ProbeResult{StatusCode: resp.StatusCode, CacheHit: cacheHit}
 	for _, sig := range fatalSignatures {
 		if strings.Contains(lower, sig) {
 			res.Fatal = true
@@ -1001,6 +1094,10 @@ func (p *Probe) Get(ctx context.Context, targetURL string) (ProbeResult, error) 
 	}
 	if resp.StatusCode >= 500 {
 		res.Detail = fmt.Sprintf("server returned status %d", resp.StatusCode)
+		return res, nil
+	}
+	if cacheHit {
+		res.Detail = cacheDetail
 	}
 	return res, nil
 }

--- a/apps/api/internal/agentcmd/probe_test.go
+++ b/apps/api/internal/agentcmd/probe_test.go
@@ -1,0 +1,164 @@
+package agentcmd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/httpclient"
+)
+
+// buildTestProbe builds a *Probe backed by an SSRF-disabled httpclient that
+// can reach loopback httptest servers (test-only).
+func buildTestProbe(t *testing.T) *Probe {
+	t.Helper()
+	hc := httpclient.New(httpclient.Config{AllowPrivateNetworks: true})
+	return NewProbe(hc)
+}
+
+// TestProbeGet_AppendsCacheBusterQueryParam proves GH #291 Phase 4 Change 3:
+// every probe request carries the wpmgr_hc cache-busting query parameter, and
+// a fresh value on every call so a query-string-keyed cache treats it as a
+// new object each time.
+func TestProbeGet_AppendsCacheBusterQueryParam(t *testing.T) {
+	var seenQueries []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenQueries = append(seenQueries, r.URL.RawQuery)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := buildTestProbe(t)
+	for i := 0; i < 2; i++ {
+		if _, err := p.Get(context.Background(), srv.URL); err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+	}
+
+	if len(seenQueries) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(seenQueries))
+	}
+	for i, q := range seenQueries {
+		if q == "" {
+			t.Fatalf("request %d: expected a %s query parameter, got no query string at all", i, cacheBusterParam)
+		}
+		values, err := url.ParseQuery(q)
+		if err != nil {
+			t.Fatalf("request %d: parse query %q: %v", i, q, err)
+		}
+		if values.Get(cacheBusterParam) == "" {
+			t.Fatalf("request %d: expected %s in query %q", i, cacheBusterParam, q)
+		}
+	}
+	if seenQueries[0] == seenQueries[1] {
+		t.Fatalf("expected a fresh cache-buster value per request, got the same query twice: %q", seenQueries[0])
+	}
+}
+
+// TestProbeGet_DetectsCacheHitViaCfCacheStatus proves a Cloudflare
+// cf-cache-status: HIT response is flagged CacheHit even though it is a plain
+// 200, so the caller does not mistake it for proof of a fresh render.
+func TestProbeGet_DetectsCacheHitViaCfCacheStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cf-Cache-Status", "HIT")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html>ok</html>"))
+	}))
+	defer srv.Close()
+
+	p := buildTestProbe(t)
+	res, err := p.Get(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !res.CacheHit {
+		t.Fatalf("expected CacheHit=true for cf-cache-status: HIT, got %+v", res)
+	}
+	if !res.Healthy() {
+		t.Fatalf("Healthy() must remain unchanged (still true for a cache-hit 200): %+v", res)
+	}
+}
+
+// TestProbeGet_DetectsCacheHitViaXCacheStatusHeader proves the standard
+// nginx `add_header X-Cache-Status $upstream_cache_status` form is
+// recognized (fix 4's header widening), not just the vendor-specific headers
+// already covered above.
+func TestProbeGet_DetectsCacheHitViaXCacheStatusHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Cache-Status", "HIT")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := buildTestProbe(t)
+	res, err := p.Get(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !res.CacheHit {
+		t.Fatalf("expected CacheHit=true for X-Cache-Status: HIT, got %+v", res)
+	}
+}
+
+// TestProbeGet_DetectsCacheHitViaAgeHeader proves the Age > 0 backstop: a
+// cache that does not set any of the named vendor headers but does report its
+// own Age is still flagged CacheHit.
+func TestProbeGet_DetectsCacheHitViaAgeHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Age", "42")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := buildTestProbe(t)
+	res, err := p.Get(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !res.CacheHit {
+		t.Fatalf("expected CacheHit=true for Age: 42, got %+v", res)
+	}
+}
+
+// TestProbeGet_NoCacheHeaders_NotFlagged proves a plain, uncached response is
+// NOT flagged CacheHit (no false positives on a normal fresh render).
+func TestProbeGet_NoCacheHeaders_NotFlagged(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html>ok</html>"))
+	}))
+	defer srv.Close()
+
+	p := buildTestProbe(t)
+	res, err := p.Get(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if res.CacheHit {
+		t.Fatalf("expected CacheHit=false for a response with no cache headers, got %+v", res)
+	}
+}
+
+// TestProbeGet_FatalSignatureStillDetectedAlongsideBuster proves the existing
+// fatal-error body scan is unaffected by the cache-buster/cache-hit additions.
+func TestProbeGet_FatalSignatureStillDetectedAlongsideBuster(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html>Fatal error: something broke</html>"))
+	}))
+	defer srv.Close()
+
+	p := buildTestProbe(t)
+	res, err := p.Get(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !res.Fatal {
+		t.Fatalf("expected Fatal=true for a fatal-error body signature, got %+v", res)
+	}
+	if res.Healthy() {
+		t.Fatalf("Healthy() must be false for a fatal response: %+v", res)
+	}
+}

--- a/apps/api/internal/update/worker.go
+++ b/apps/api/internal/update/worker.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"time"
 
 	"github.com/google/uuid"
@@ -101,6 +102,14 @@ type Worker struct {
 	// schedule (probeRetryDelays). Nil uses the default. Tests set this to a
 	// tiny schedule so the retry loop does not actually sleep ~21s.
 	probeDelays []time.Duration
+	// jobTimeout overrides River's default 60s per-job context deadline (see
+	// DeriveApplyJobTimeout, and NewBackupWorker's identical jobTimeout field for
+	// the same pattern applied to backups). runApply makes one apply/rollback
+	// command round trip plus the full GH #291 Phase 4 post-update health check
+	// (the agent-first reachability ladder and the public probe ladder, both of
+	// which can retry with backoff), all inside the same River job, comfortably
+	// longer than the 60s default. Zero falls back to river.Config.JobTimeout.
+	jobTimeout time.Duration
 }
 
 // probeRetryDelays is the backoff schedule between post-update health-probe
@@ -127,15 +136,86 @@ func (w *Worker) SetProbeRetryDelays(delays []time.Duration) {
 	w.probeDelays = delays
 }
 
-// NewWorker builds the update task worker.
-func NewWorker(repo Repo, sites SiteLookup, cmd Commander, prober HealthProber, hub *Hub, rec *audit.Recorder, logger *slog.Logger, perTenantLimit int) *Worker {
+// NewWorker builds the update task worker. jobTimeout overrides River's
+// default 60s per-job deadline; pass update.DeriveApplyJobTimeout(cfg.Update.
+// ApplyHTTPTimeout, cfg.Update.HTTPTimeout) (see that function's doc comment
+// for the arithmetic). Zero keeps River's default.
+func NewWorker(repo Repo, sites SiteLookup, cmd Commander, prober HealthProber, hub *Hub, rec *audit.Recorder, logger *slog.Logger, perTenantLimit int, jobTimeout time.Duration) *Worker {
 	if perTenantLimit <= 0 {
 		perTenantLimit = 5
 	}
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Worker{repo: repo, sites: sites, cmd: cmd, prober: prober, hub: hub, audit: rec, logger: logger, perTenantLimit: perTenantLimit}
+	return &Worker{repo: repo, sites: sites, cmd: cmd, prober: prober, hub: hub, audit: rec, logger: logger, perTenantLimit: perTenantLimit, jobTimeout: jobTimeout}
+}
+
+// Timeout overrides River's default per-job context deadline (60s) for the
+// update-task worker, the same way BackupWorker.Timeout does. Returning a
+// positive duration makes River use it instead of river.Config.JobTimeout;
+// returning 0 keeps the default (see cmp.Or in river's job executor, which
+// falls through to river.Config.JobTimeout, itself defaulting to River's own
+// 60s river.JobTimeoutDefault when that is also unset, exactly as it is in
+// this codebase's river.Config today). River documents that returning -1
+// disables the deadline entirely; we intentionally do NOT do that: a wedged
+// update task must eventually error out so River can retry/reap it.
+func (w *Worker) Timeout(*river.Job[TaskArgs]) time.Duration { return w.jobTimeout }
+
+// DeriveApplyJobTimeout computes the River job-level Timeout() budget for the
+// update-apply worker (see Worker.Timeout and NewWorker). It reads the actual
+// ladder schedules (probeRetryDelays, agentVerifyTimeout) rather than assuming
+// them, so this stays correct if either is ever tuned.
+//
+// runApply's worst-case wall-clock budget, in the order the work happens:
+//
+//  1. applyHTTPTimeout: the ONE apply/rollback command round trip
+//     (cfg.Update.ApplyHTTPTimeout; see UpdateConfig's doc comment in
+//     internal/config for how its 5m default was picked).
+//  2. the agent-first reachability ladder (verifyAgentHealthWithRetry, GH #291
+//     Phase 4): up to len(probeRetryDelays)+1 attempts, each hard-capped at
+//     agentVerifyTimeout via context.WithTimeout, plus the sleep between
+//     attempts:
+//     (len(probeRetryDelays)+1)*agentVerifyTimeout + sum(probeRetryDelays)
+//  3. the public homepage probe ladder (probeHealthWithRetry), which reuses
+//     the SAME probeRetryDelays schedule; each attempt is one prober.Get call
+//     capped at probeHTTPTimeout (cfg.Update.HTTPTimeout, the timeout the
+//     shared SSRF client that backs the prober is built with):
+//     (len(probeRetryDelays)+1)*probeHTTPTimeout + sum(probeRetryDelays)
+//  4. headroom, mirroring the backup worker's `+2*time.Minute` (see
+//     NewBackupWorker/backupJobTimeout in cmd/wpmgr/main.go) for scheduling
+//     jitter and the small per-attempt backoff the shared HTTP client's own
+//     retry-on-5xx layer can add on top of a single probeHTTPTimeout window
+//     (internal/httpclient.Client.Do; not separately itemized above to keep
+//     this arithmetic reviewable).
+//
+// With the production defaults (applyHTTPTimeout=5m, probeHTTPTimeout=30s,
+// agentVerifyTimeout=8s, probeRetryDelays summing to ~21s across 4 delays)
+// this computes to 5m + 61s + 171s + 2m = 10m52s, comfortably under
+// staleTaskThreshold (45m), so the periodic reaper still cannot terminalize a
+// task that is legitimately still running.
+//
+// Returns 0 (defer to river.Config.JobTimeout) when applyHTTPTimeout is not
+// positive, so a zero/misconfigured input never produces a misleadingly small
+// nonzero timeout that omits the apply round trip it is meant to cover.
+func DeriveApplyJobTimeout(applyHTTPTimeout, probeHTTPTimeout time.Duration) time.Duration {
+	if applyHTTPTimeout <= 0 {
+		return 0
+	}
+	if probeHTTPTimeout <= 0 {
+		probeHTTPTimeout = agentVerifyTimeout
+	}
+
+	attempts := time.Duration(len(probeRetryDelays) + 1)
+	var delaySum time.Duration
+	for _, d := range probeRetryDelays {
+		delaySum += d
+	}
+
+	agentLadder := attempts*agentVerifyTimeout + delaySum
+	probeLadder := attempts*probeHTTPTimeout + delaySum
+	const headroom = 2 * time.Minute
+
+	return applyHTTPTimeout + agentLadder + probeLadder + headroom
 }
 
 // SetRefreshEnqueuer wires the post-update inventory-refresh enqueuer + its
@@ -224,28 +304,261 @@ func (w *Worker) runApply(ctx context.Context, task Task, siteURL string, item a
 		return w.finish(ctx, task, TaskSkipped, fromOr(res.FromVersion, task.FromVersion), res.ToVersion, "already up to date", "")
 	}
 
-	// Post-update health probe of the site homepage, retried with backoff
-	// before declaring the update unhealthy (see probeHealthWithRetry): a
-	// normal DB-migration 503 immediately after activation must not trigger an
-	// unnecessary rollback of a site that in fact updated successfully.
+	// GH #291 Phase 4 (post-review fix): ask the agent FIRST, over a signed and
+	// therefore uncacheable round trip. The control plane has JUST spoken to
+	// this exact agent to apply the update; a fresh signed check is
+	// authoritative proof PHP booted and the plugin loaded (the signed command
+	// route does not exist otherwise), and no page cache can fake it. See
+	// verifyAgentHealth for the per-attempt decision table and
+	// verifyAgentHealthWithRetry for why a single unhealthy sample is never
+	// enough on its own (the same transient-migration window that can make the
+	// public homepage 503 for a few seconds can just as easily hit the agent's
+	// own PHP route, since it is served by the same stack). An inconclusive
+	// verdict (no signing key configured, the agent is absent/uninstalled, or
+	// the check timed out or hit a TLS/transport error) does NOT roll back on
+	// its own, because plenty of legitimate sites have no agent reachable this
+	// way; it falls through to the public probe below exactly like a healthy
+	// verdict does.
+	verdict, verifyDetail, agentAttempts := w.verifyAgentHealthWithRetry(ctx, task.SiteID, siteURL)
+	if verdict == agentHealthUnhealthy {
+		return w.rollback(ctx, task, siteURL, item, res, agentcmd.ProbeResult{}, true,
+			fmt.Sprintf("post-update agent reachability check failed after %d attempt(s): %s", agentAttempts, verifyDetail))
+	}
+
+	// The public homepage probe still runs even when the agent-first check
+	// came back healthy. The signed agent route only proves PHP booted and the
+	// WPMgr plugin loaded; it proves nothing about whether the site RENDERS. A
+	// theme update, or a plugin that only fatals on a front-end hook (e.g.
+	// wp_head or the_content), can leave the agent route perfectly healthy
+	// while the homepage is fatal, so an agent-healthy verdict must not by
+	// itself end the check for any target type, plugin included.
+	//
+	// Reusing probeHealthWithRetry here, rather than a bespoke single-shot
+	// check, keeps the added latency close to zero on the common path:
+	// probeHealthWithRetry only invokes its backoff schedule when the FIRST
+	// attempt is not already postUpdateHealthy, so an agent-confirmed-healthy
+	// update whose front end also renders fine (the overwhelming common case)
+	// costs exactly one extra request. Only a front end that is ALSO failing
+	// pays the bounded (about 21s worst case) retry cost, which is the same
+	// budget a broken update already paid before this phase existed, and which
+	// exists for the same reason as verifyAgentHealthWithRetry: a single failed
+	// sample right after activation must not be mistaken for a broken update.
 	probe, perr, attempts := w.probeHealthWithRetry(ctx, siteURL)
 	if perr != nil {
-		// Still unreachable after retrying — treat as unhealthy and roll back.
-		return w.rollback(ctx, task, siteURL, item, res, probe, fmt.Sprintf("post-update probe error after %d attempt(s): %v", attempts, perr))
+		// Still unreachable after retrying: treat as unhealthy and roll back.
+		return w.rollback(ctx, task, siteURL, item, res, probe, false, fmt.Sprintf("post-update probe error after %d attempt(s): %v", attempts, perr))
 	}
-	if !probe.Healthy() {
-		return w.rollback(ctx, task, siteURL, item, res, probe, fmt.Sprintf("post-update health failed after %d attempt(s): status=%d %s", attempts, probe.StatusCode, probe.Detail))
+	switch classifyPostUpdateProbe(probe) {
+	case postUpdateHealthy:
+		detail := "updated and healthy"
+		if verdict == agentHealthHealthy {
+			detail = "updated and healthy (signed agent check and public probe both confirmed)"
+		}
+		return w.finish(ctx, task, TaskSucceeded, fromOr(res.FromVersion, task.FromVersion), res.ToVersion, detail, "")
+	case postUpdateInconclusive:
+		// A cached response (or, per the design doc's baseline note below, a
+		// 404/410 on the site root with no pre-update baseline to compare
+		// against) is NOT proof of health. Do not roll back on it alone, but
+		// record the uncertainty plainly rather than claiming "healthy".
+		detail := fmt.Sprintf("updated; post-update probe inconclusive after %d attempt(s): %s, so this could not confirm the update did not break the site", attempts, probe.Detail)
+		if verdict == agentHealthHealthy {
+			detail = fmt.Sprintf("updated; signed agent check confirmed the backend healthy, but the public probe was inconclusive after %d attempt(s): %s, so the front end could not be separately confirmed", attempts, probe.Detail)
+		}
+		return w.finish(ctx, task, TaskSucceeded, fromOr(res.FromVersion, task.FromVersion), res.ToVersion, detail, "")
+	default: // postUpdateUnhealthy
+		reason := fmt.Sprintf("post-update health failed after %d attempt(s): status=%d %s", attempts, probe.StatusCode, probe.Detail)
+		if verdict == agentHealthHealthy {
+			reason = fmt.Sprintf("signed agent check reported healthy, but the public homepage failed after %d attempt(s): status=%d %s (a front-end-only failure the agent route cannot see)", attempts, probe.StatusCode, probe.Detail)
+		}
+		return w.rollback(ctx, task, siteURL, item, res, probe, false, reason)
 	}
-
-	return w.finish(ctx, task, TaskSucceeded, fromOr(res.FromVersion, task.FromVersion), res.ToVersion, "updated and healthy", "")
 }
 
-// probeHealthWithRetry probes siteURL and, if the site is unhealthy or
-// unreachable, retries with backoff (probeDelays, defaulting to
-// probeRetryDelays) before giving up. It returns as soon as any attempt
-// reports Healthy(); otherwise it returns the LAST probe result/error after
-// exhausting the schedule, plus the number of attempts made (folded into the
-// rollback reason so an operator can see the update was given a fair chance).
+// agentVerifyTimeout bounds ONE attempt of the agent-first post-update
+// reachability check (GH #291 Phase 4). Short and independent of the update
+// command's own (possibly multi-minute) timeout: this is a lightweight signed
+// ping/metadata round trip, not the heavy update operation itself. Applied
+// per attempt inside verifyAgentHealthWithRetry, not to the retry loop as a
+// whole.
+const agentVerifyTimeout = 8 * time.Second
+
+// agentHealthVerdict is the outcome of the agent-first post-update
+// reachability check (see Worker.verifyAgentHealth and
+// Worker.verifyAgentHealthWithRetry). The zero value is agentHealthInconclusive
+// so a mistakenly-unset verdict never triggers either a false "healthy" or a
+// false rollback.
+type agentHealthVerdict int
+
+const (
+	// agentHealthInconclusive covers both "the check could not be run at all"
+	// (no signing key configured, or a Commander test double that does not
+	// implement agentVerifier) and "the check ran but the result does not
+	// prove anything either way" (agent absent/uninstalled, a non-404/5xx
+	// HTTP status, a timeout, or a TLS/transport error). It deliberately does
+	// NOT roll back on its own: a great many legitimate sites will have no
+	// agent reachable from this specific check, and rolling back a good
+	// update on that basis alone would be its own outage. The caller falls
+	// through to the public probe, exactly like agentHealthHealthy does.
+	agentHealthInconclusive agentHealthVerdict = iota
+	// agentHealthHealthy means the signed command route answered: PHP booted
+	// and the plugin loaded. This is authoritative and cannot be a cache
+	// artifact (the route only exists once PHP has booted). It proves nothing
+	// about the front end, though, so the caller still runs the public probe
+	// (see runApply); it only proves the backend is alive, which lets that
+	// probe skip its own retry ladder on the common happy path.
+	agentHealthHealthy
+	// agentHealthUnhealthy means the signed command route itself returned a
+	// server error on EVERY attempt across verifyAgentHealthWithRetry's retry
+	// window, not merely once: PHP is persistently fatal-ing on every request,
+	// including the agent's own route. This is the strongest signal available
+	// short of total unreachability, and because it came back over a signed
+	// round trip rather than a cacheable public GET, it cannot be a stale
+	// cached read. A single unhealthy sample is deliberately NOT enough to
+	// reach this verdict (see verifyAgentHealthWithRetry): the agent's ping
+	// route is served by the same PHP and WordPress stack as the homepage, so
+	// it is exposed to the same transient migration-on-activation window,
+	// php-fpm restart, opcache reset, or WAF/CDN origin error that
+	// probeRetryDelays already exists to ride out for the public probe.
+	agentHealthUnhealthy
+)
+
+// agentVerifier is the subset of *agentcmd.Client used for the agent-first
+// post-update reachability check. Defined locally, matching the method
+// agentcmd.Client already exposes, so this package does not need to import
+// internal/site's identically-shaped AgentVerifier, and so any Commander test
+// double that does not implement it (most of worker_test.go's fakes) simply
+// fails the type assertion in verifyAgentHealth rather than needing a stub
+// method, which itself resolves to the correct agentHealthInconclusive
+// behaviour.
+type agentVerifier interface {
+	VerifyReachableWithReason(ctx context.Context, siteID uuid.UUID, siteURL string) (alive bool, fallbackUsed bool, reason agentcmd.ReachabilityReason, err error)
+}
+
+// verifyAgentHealth implements GH #291 Phase 4's per-attempt agent-first
+// decision table (see verifyAgentHealthWithRetry for the retry wrapper that
+// callers actually use). It never returns an error: any failure to even run
+// the check collapses to agentHealthInconclusive, exactly like an ambiguous
+// check result, so a caller can never mistake "we couldn't ask" for "we
+// asked and it's fine" or "we asked and it's broken".
+func (w *Worker) verifyAgentHealth(ctx context.Context, siteID uuid.UUID, siteURL string) (agentHealthVerdict, string) {
+	verifier, ok := w.cmd.(agentVerifier)
+	if !ok {
+		return agentHealthInconclusive, "agent reachability check unavailable (no signing key configured)"
+	}
+	verifyCtx, cancel := context.WithTimeout(ctx, agentVerifyTimeout)
+	defer cancel()
+	alive, _, reason, err := verifier.VerifyReachableWithReason(verifyCtx, siteID, siteURL)
+	if err != nil {
+		// An infrastructure failure minting/sending the check (e.g. a JWT-mint
+		// error) proves nothing about the site itself: ambiguous, not a signal.
+		return agentHealthInconclusive, fmt.Sprintf("agent reachability check error: %v", err)
+	}
+	if alive {
+		return agentHealthHealthy, "signed agent route reachable"
+	}
+	if reason == agentcmd.ReasonHTTP5xx {
+		return agentHealthUnhealthy, "signed agent route returned a server error (PHP fatal)"
+	}
+	return agentHealthInconclusive, fmt.Sprintf("agent reachability ambiguous (%s)", reason)
+}
+
+// verifyAgentHealthWithRetry retries the agent-first reachability check (see
+// verifyAgentHealth) using the SAME backoff schedule as the public probe
+// (probeRetryDelays, or w.probeDelays in tests), rather than a second bespoke
+// schedule. A single unhealthy sample must never conclude agentHealthUnhealthy
+// on its own: the agent's ping route is served by the same PHP and WordPress
+// stack as the homepage, so a transient DB-migration-on-activation window (or
+// a php-fpm restart, opcache reset, or WAF/CDN origin error) can make it 5xx
+// for a few seconds exactly like the public homepage. Only a verdict that
+// STAYS agentHealthUnhealthy across the whole retry window reaches that
+// conclusion here; a verdict that resolves to healthy or inconclusive at any
+// attempt returns immediately, mirroring probeHealthWithRetry's early return
+// on postUpdateHealthy.
+func (w *Worker) verifyAgentHealthWithRetry(ctx context.Context, siteID uuid.UUID, siteURL string) (verdict agentHealthVerdict, detail string, attempts int) {
+	delays := probeRetryDelays
+	if w.probeDelays != nil {
+		delays = w.probeDelays
+	}
+	for i := 0; ; i++ {
+		attempts = i + 1
+		verdict, detail = w.verifyAgentHealth(ctx, siteID, siteURL)
+		if verdict != agentHealthUnhealthy {
+			return verdict, detail, attempts
+		}
+		if i >= len(delays) {
+			return verdict, detail, attempts
+		}
+		select {
+		case <-ctx.Done():
+			return verdict, detail, attempts
+		case <-time.After(delays[i]):
+		}
+	}
+}
+
+// postUpdateVerdict classifies a public homepage ProbeResult specifically for
+// the post-update rollback decision. This is intentionally NOT the same rule
+// as ProbeResult.Healthy(): see classifyPostUpdateProbe's doc comment for why
+// a separate, explicit classification exists instead of changing Healthy()
+// itself.
+type postUpdateVerdict int
+
+const (
+	postUpdateUnhealthy postUpdateVerdict = iota
+	postUpdateHealthy
+	postUpdateInconclusive
+)
+
+// classifyPostUpdateProbe applies the post-update-specific health rule.
+//
+// A response flagged CacheHit is checked FIRST, before any status-code based
+// classification: a cached response proves nothing about the CURRENT backend
+// state, so evaluating Fatal/5xx/404 first would let a stale cached error (or
+// a stale cached 404) drive a rollback, or a stale cached 200 claim health,
+// for a site the update may never have touched. A CacheHit result is always
+// classified inconclusive, regardless of its status code.
+//
+// A 5xx status or a fatal-error body signature is unhealthy (unchanged from
+// Healthy()). A 401 or 403 is healthy, because those are common and
+// legitimate on the homepage (staging HTTP auth, a members-only site, a
+// security plugin) and rolling back a good update because of one would be its
+// own outage.
+//
+// A 404 or 410 on the site root is classified inconclusive, NOT unhealthy and
+// NOT healthy (see docs/security/uptime-app-health-design-2026-07-27.md
+// section 4 item 2, which explicitly forbids treating 4xx as a rollback
+// trigger). There is no pre-update baseline recorded for this task, so a site
+// that legitimately already returned 404 on its root BEFORE the update (a
+// headless install, a site whose root is intentionally empty, a redirect-only
+// domain) cannot be told apart from one broken BY the update; rolling back the
+// former would be its own outage. Classifying it inconclusive rather than
+// healthy still stops the caller from claiming the update was confirmed fine.
+// Follow-up: record a pre-update probe of the site root so a 404 that appears
+// ONLY after the update can be promoted to a real unhealthy signal.
+func classifyPostUpdateProbe(probe agentcmd.ProbeResult) postUpdateVerdict {
+	if probe.CacheHit {
+		return postUpdateInconclusive
+	}
+	if probe.StatusCode <= 0 || probe.Fatal || probe.StatusCode >= 500 {
+		return postUpdateUnhealthy
+	}
+	if probe.StatusCode == http.StatusNotFound || probe.StatusCode == http.StatusGone {
+		return postUpdateInconclusive
+	}
+	return postUpdateHealthy
+}
+
+// probeHealthWithRetry probes siteURL and, if the site is unhealthy,
+// inconclusive, or unreachable, retries with backoff (probeDelays, defaulting
+// to probeRetryDelays) before giving up. It returns as soon as any attempt
+// classifies postUpdateHealthy (see classifyPostUpdateProbe; NOT the same
+// rule as ProbeResult.Healthy(), see classifyPostUpdateProbe's doc comment for
+// why); otherwise it returns the LAST probe result/error after exhausting the
+// schedule, plus the number of attempts made (folded into the rollback reason
+// so an operator can see the update was given a fair chance). Retrying on an
+// inconclusive (cache-hit) result too, rather than exiting early on it, gives a
+// cache-busted retry a real chance to land on a genuine cache MISS within the
+// window.
 //
 // A transient transport error (perr != nil) is retried the same as an
 // unhealthy-but-reachable response: during a post-update migration window a
@@ -262,7 +575,7 @@ func (w *Worker) probeHealthWithRetry(ctx context.Context, siteURL string) (prob
 	for i := 0; ; i++ {
 		attempts = i + 1
 		probe, perr = w.prober.Get(ctx, siteURL)
-		if perr == nil && probe.Healthy() {
+		if perr == nil && classifyPostUpdateProbe(probe) == postUpdateHealthy {
 			return probe, nil, attempts
 		}
 		if i >= len(delays) {
@@ -278,10 +591,16 @@ func (w *Worker) probeHealthWithRetry(ctx context.Context, siteURL string) (prob
 
 // rollback issues the signed rollback command and records the rolled_back
 // state. probe is the ProbeResult that triggered the rollback decision (the
-// zero value when rollback was reached via a probe TRANSPORT error rather
-// than a reachable-but-unhealthy response) — it is used only to classify a
-// rollback-transport failure below (GH #210).
-func (w *Worker) rollback(ctx context.Context, task Task, siteURL string, item agentcmd.UpdateItem, res agentcmd.ItemResult, probe agentcmd.ProbeResult, reason string) error {
+// zero value when rollback was reached via a probe TRANSPORT error, or via
+// the GH #291 Phase 4 agent-first check, rather than a reachable-but-unhealthy
+// public-probe response), and is used, together with agentConfirmedFatal,
+// only to classify a rollback-transport failure below (GH #210).
+// agentConfirmedFatal is true when the rollback decision came from the
+// signed agent-first reachability check itself returning a server error
+// (agentHealthUnhealthy), which is exactly as strong a "site-wide PHP fatal"
+// signal as probe.Fatal or probe.StatusCode >= 500, but arrives with no
+// ProbeResult to carry it.
+func (w *Worker) rollback(ctx context.Context, task Task, siteURL string, item agentcmd.UpdateItem, res agentcmd.ItemResult, probe agentcmd.ProbeResult, agentConfirmedFatal bool, reason string) error {
 	from := fromOr(res.FromVersion, task.FromVersion)
 	_, rbErr := w.cmd.Rollback(ctx, task.SiteID, siteURL, agentcmd.RollbackRequest{
 		Type:       item.Type,
@@ -293,16 +612,18 @@ func (w *Worker) rollback(ctx context.Context, task Task, siteURL string, item a
 		// Rollback itself failed: this is the worst case. Record as failed with
 		// both the health reason and the rollback error so the operator is alerted.
 		detail := "rollback FAILED after unhealthy update: " + reason
-		// GH #210: when the post-update probe ITSELF detected a site-wide PHP
-		// fatal (a fatal-error body signature, or a 5xx response) AND the
-		// rollback command's transport also errored, the site is very likely
-		// serving a site-wide PHP fatal that makes the agent's own REST
-		// endpoint undeliverable — a distinct, more actionable failure mode
-		// than a generic "rollback failed" (which could also mean e.g. a
+		// GH #210: when the post-update health check ITSELF detected a
+		// site-wide PHP fatal (a fatal-error body signature, a 5xx probe
+		// response, or the GH #291 Phase 4 signed agent-first check itself
+		// getting a 5xx, agentConfirmedFatal) AND the rollback command's
+		// transport also errored, the site is very likely serving a
+		// site-wide PHP fatal that makes the agent's own REST endpoint
+		// undeliverable, a distinct, more actionable failure mode than a
+		// generic "rollback failed" (which could also mean e.g. a
 		// transient network blip unrelated to the update). Record a distinct
 		// detail so the operator knows the automatic filesystem-level
 		// recovery on the agent side is the remaining recovery path.
-		if probe.Fatal || probe.StatusCode >= 500 {
+		if probe.Fatal || probe.StatusCode >= 500 || agentConfirmedFatal {
 			detail = "site not responding: site-wide PHP fatal after update; rollback command undeliverable. " +
 				"The agent update watchdog will attempt automatic filesystem recovery; if it cannot, manual filesystem recovery is required."
 		}
@@ -473,13 +794,18 @@ func (ReapStaleTasksArgs) Kind() string { return "update_task_reaper" }
 
 // staleTaskThreshold is how long a task may sit in pending/running before the
 // reaper terminalizes it. Comfortably longer than any real update, including
-// the post-update health-probe retry window (worst case ~21s, see
-// probeRetryDelays) and the per-tenant parallelism snooze backoff: a worker
-// crash between MarkTaskRunning and finish(), or an EnqueueTask failure that
-// leaves a task pending (Service.CreateRun's best-effort enqueue after
-// CreateRunWithTasks), would otherwise permanently occupy the
+// the full apply + post-update health-check budget the River job itself is
+// now given (see Worker.Timeout / DeriveApplyJobTimeout, with production
+// defaults that budget is ~10m52s, itself already inclusive of both
+// post-update retry ladders) and the per-tenant parallelism snooze backoff: a
+// worker crash between MarkTaskRunning and finish(), or an EnqueueTask
+// failure that leaves a task pending (Service.CreateRun's best-effort enqueue
+// after CreateRunWithTasks), would otherwise permanently occupy the
 // update_tasks_inflight_target_idx slot for that (tenant, site, target) —
 // every future update attempt for it 409s targets_in_flight forever (m88).
+// If DeriveApplyJobTimeout's budget is ever tuned up near or past this value,
+// this threshold must grow with it: the reaper terminalizing a task that is
+// still legitimately within its own job deadline would itself be a bug.
 const staleTaskThreshold = 45 * time.Minute
 
 // staleTaskReapLimit bounds how many stale tasks one sweep reaps, so an

--- a/apps/api/internal/update/worker_test.go
+++ b/apps/api/internal/update/worker_test.go
@@ -97,6 +97,114 @@ func (c *fakeCommander) Rollback(context.Context, uuid.UUID, string, agentcmd.Ro
 	return agentcmd.RollbackResponse{OK: true, RestoredVersion: "1.9.9"}, nil
 }
 
+// applyOnlyCommander is a Commander test double that implements ONLY
+// Update/Rollback, deliberately WITHOUT VerifyReachableWithReason (GH #291
+// Phase 4). It exercises runApply end-to-end (unlike fakeCommander's Update,
+// which panics) while proving the agent-first type assertion in
+// Worker.verifyAgentHealth fails gracefully for a Commander that cannot run
+// the signed check at all (mirrors the real "no signing key configured"
+// case, where the wired commander is main.go's disabledCommander).
+type applyOnlyCommander struct {
+	rollbackCalled bool
+	rollbackErr    error
+}
+
+func (c *applyOnlyCommander) Update(_ context.Context, _ uuid.UUID, _ string, req agentcmd.UpdateRequest) (agentcmd.UpdateResponse, error) {
+	item := req.Items[0]
+	return agentcmd.UpdateResponse{OK: true, Results: []agentcmd.ItemResult{{
+		Type: item.Type, Slug: item.Slug, FromVersion: "1.9.9", ToVersion: item.Version,
+		Status: agentcmd.ItemSucceeded, SnapshotID: "snap-1",
+	}}}, nil
+}
+
+func (c *applyOnlyCommander) Rollback(context.Context, uuid.UUID, string, agentcmd.RollbackRequest) (agentcmd.RollbackResponse, error) {
+	c.rollbackCalled = true
+	if c.rollbackErr != nil {
+		return agentcmd.RollbackResponse{}, c.rollbackErr
+	}
+	return agentcmd.RollbackResponse{OK: true, RestoredVersion: "1.9.9"}, nil
+}
+
+// verifyingCommander embeds applyOnlyCommander's Update/Rollback behaviour and
+// additionally implements VerifyReachableWithReason with a single fixed
+// scripted outcome returned on every call, so runApply's GH #291 Phase 4
+// agent-first check can be driven precisely without a real agentcmd.Client or
+// live HTTP. verifyCalls counts every invocation so a test can assert the
+// retry discipline in verifyAgentHealthWithRetry actually ran (or did not).
+type verifyingCommander struct {
+	applyOnlyCommander
+	alive        bool
+	fallbackUsed bool
+	reason       agentcmd.ReachabilityReason
+	verifyErr    error
+	verifyCalled bool
+	verifyCalls  int
+}
+
+func (c *verifyingCommander) VerifyReachableWithReason(_ context.Context, _ uuid.UUID, _ string) (bool, bool, agentcmd.ReachabilityReason, error) {
+	c.verifyCalled = true
+	c.verifyCalls++
+	return c.alive, c.fallbackUsed, c.reason, c.verifyErr
+}
+
+// verifyStep is one scripted VerifyReachableWithReason outcome.
+type verifyStep struct {
+	alive        bool
+	fallbackUsed bool
+	reason       agentcmd.ReachabilityReason
+	err          error
+}
+
+// scriptedVerifyCommander embeds applyOnlyCommander's Update/Rollback
+// behaviour and returns a queued SEQUENCE of VerifyReachableWithReason
+// outcomes, one per call; the last entry repeats once the queue is exhausted.
+// Used to pin GH #291 Phase 4 fix 1: a TRANSIENT agent 5xx that clears within
+// verifyAgentHealthWithRetry's retry window must not roll back, while a
+// PERSISTENT one (a script that never clears) must.
+type scriptedVerifyCommander struct {
+	applyOnlyCommander
+	script []verifyStep
+	calls  int
+}
+
+func (c *scriptedVerifyCommander) VerifyReachableWithReason(_ context.Context, _ uuid.UUID, _ string) (bool, bool, agentcmd.ReachabilityReason, error) {
+	i := c.calls
+	if i >= len(c.script) {
+		i = len(c.script) - 1
+	}
+	c.calls++
+	s := c.script[i]
+	return s.alive, s.fallbackUsed, s.reason, s.err
+}
+
+func healthyVerifyStep() verifyStep {
+	return verifyStep{alive: true, reason: agentcmd.ReasonAlive}
+}
+
+func unhealthyVerifyStep() verifyStep {
+	return verifyStep{alive: false, reason: agentcmd.ReasonHTTP5xx}
+}
+
+// panicProber fails the test immediately if Get is ever called. Used to prove
+// the agent-first check (GH #291 Phase 4 Change 1), when conclusive, skips
+// the public homepage probe entirely rather than merely racing through it.
+type panicProber struct{ t *testing.T }
+
+func (p *panicProber) Get(context.Context, string) (agentcmd.ProbeResult, error) {
+	p.t.Fatalf("public probe must not be called: the agent-first check already reached a conclusive verdict")
+	return agentcmd.ProbeResult{}, nil
+}
+
+// newApplyTestWorker builds a Worker around any Commander implementation with
+// a tiny, non-sleeping probe-retry schedule (mirrors newTestWorker, but
+// generalized to Commander so the GH #291 Phase 4 test doubles above, which
+// are not *fakeCommander, can be used).
+func newApplyTestWorker(repo *probeFakeRepo, cmd Commander, prober HealthProber) *Worker {
+	w := NewWorker(repo, nil /* sites: unused by runApply */, cmd, prober, nil /* hub */, nil /* audit */, nil, 5, 0)
+	w.SetProbeRetryDelays([]time.Duration{time.Millisecond, time.Millisecond, time.Millisecond, time.Millisecond})
+	return w
+}
+
 // scriptedProber returns a queued sequence of (ProbeResult, error) pairs, one
 // per call to Get; the last entry repeats once the queue is exhausted.
 type scriptedProber struct {
@@ -131,7 +239,7 @@ func unhealthyStep(status int) probeStep {
 // probe-retry schedule so the tests run fast regardless of the production
 // ~21s backoff window.
 func newTestWorker(repo *probeFakeRepo, cmd *fakeCommander, prober HealthProber) *Worker {
-	w := NewWorker(repo, nil /* sites: unused by runApply */, cmd, prober, nil /* hub */, nil /* audit */, nil, 5)
+	w := NewWorker(repo, nil /* sites: unused by runApply */, cmd, prober, nil /* hub */, nil /* audit */, nil, 5, 0)
 	w.SetProbeRetryDelays([]time.Duration{time.Millisecond, time.Millisecond, time.Millisecond, time.Millisecond})
 	return w
 }
@@ -220,7 +328,7 @@ func TestRunApply_ProbeRetry_StillUnhealthyRollsBack(t *testing.T) {
 	}
 
 	reason := fmt.Sprintf("post-update health failed after %d attempt(s): status=%d %s", attempts, probe.StatusCode, probe.Detail)
-	if err := w.rollback(context.Background(), task, "https://example.test", item, res, probe, reason); err != nil {
+	if err := w.rollback(context.Background(), task, "https://example.test", item, res, probe, false, reason); err != nil {
 		t.Fatalf("rollback: %v", err)
 	}
 	if !cmd.rollbackCalled {
@@ -304,7 +412,7 @@ func TestRollback_FatalProbeAndRollbackTransportError_RecordsDistinctDetail(t *t
 	res := agentcmd.ItemResult{Type: item.Type, Slug: item.Slug, FromVersion: "1.9.9", ToVersion: "2.0.0", Status: agentcmd.ItemSucceeded}
 	fatalProbe := agentcmd.ProbeResult{StatusCode: 200, Fatal: true, Detail: "fatal-error signature in response body"}
 
-	if err := w.rollback(context.Background(), task, "https://example.test", item, res, fatalProbe, "post-update health failed"); err != nil {
+	if err := w.rollback(context.Background(), task, "https://example.test", item, res, fatalProbe, false, "post-update health failed"); err != nil {
 		t.Fatalf("rollback: %v", err)
 	}
 	if !cmd.rollbackCalled {
@@ -338,7 +446,7 @@ func TestRollback_FatalStatusOnlyAndRollbackTransportError_RecordsDistinctDetail
 	res := agentcmd.ItemResult{Type: item.Type, Slug: item.Slug, FromVersion: "1.9.9", ToVersion: "2.0.0", Status: agentcmd.ItemSucceeded}
 	statusOnlyProbe := agentcmd.ProbeResult{StatusCode: 503, Detail: "server returned status 503"}
 
-	if err := w.rollback(context.Background(), task, "https://example.test", item, res, statusOnlyProbe, "post-update health failed"); err != nil {
+	if err := w.rollback(context.Background(), task, "https://example.test", item, res, statusOnlyProbe, false, "post-update health failed"); err != nil {
 		t.Fatalf("rollback: %v", err)
 	}
 	got := repo.finished[0]
@@ -363,7 +471,7 @@ func TestRollback_NonFatalTransportErrorKeepsGenericDetail(t *testing.T) {
 	res := agentcmd.ItemResult{Type: item.Type, Slug: item.Slug, FromVersion: "1.9.9", ToVersion: "2.0.0", Status: agentcmd.ItemSucceeded}
 	transportErrProbe := agentcmd.ProbeResult{} // StatusCode 0, Fatal false
 
-	if err := w.rollback(context.Background(), task, "https://example.test", item, res, transportErrProbe, "post-update probe error"); err != nil {
+	if err := w.rollback(context.Background(), task, "https://example.test", item, res, transportErrProbe, false, "post-update probe error"); err != nil {
 		t.Fatalf("rollback: %v", err)
 	}
 	if len(repo.finished) != 1 {
@@ -376,4 +484,438 @@ func TestRollback_NonFatalTransportErrorKeepsGenericDetail(t *testing.T) {
 	if strings.Contains(got.Detail, "site not responding") {
 		t.Fatalf("must NOT use the distinct fatal detail on a non-fatal transport error: %q", got.Detail)
 	}
+}
+
+// ----------------------------------------------------------------------------
+// GH #291 Phase 4: agent-first post-update health check + fixed public-probe
+// classification. See docs/security/uptime-app-health-design-2026-07-27.md
+// section 4. Every test below fails against the pre-fix code where noted.
+// ----------------------------------------------------------------------------
+
+// TestRunApply_AgentHealthy_PublicProbeAlsoConfirms_Succeeds proves the
+// agent-first check does NOT end the health decision by itself: when the
+// signed check reports alive, the public probe is still consulted (fix 2),
+// and when it too reports healthy the task succeeds. Fails against the
+// pre-fix code only in spirit (the pre-fix code also succeeds here), but
+// pins the requirement that the probe is actually called by using a prober
+// that fails the test if it is NOT.
+func TestRunApply_AgentHealthy_PublicProbeAlsoConfirms_Succeeds(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &verifyingCommander{alive: true, reason: agentcmd.ReasonAlive}
+	prober := &scriptedProber{script: []probeStep{healthyStep()}}
+	w := newApplyTestWorker(repo, cmd, prober)
+
+	task := testTask()
+	item := updateItem()
+	if err := w.runApply(context.Background(), task, "https://example.test", item); err != nil {
+		t.Fatalf("runApply: %v", err)
+	}
+	if !cmd.verifyCalled {
+		t.Fatalf("expected the agent-first reachability check to have been called")
+	}
+	if prober.calls == 0 {
+		t.Fatalf("expected the public probe to have been consulted even though the agent-first check reported healthy")
+	}
+	if cmd.rollbackCalled {
+		t.Fatalf("rollback must not be called when both the agent-first check and the public probe report healthy")
+	}
+	if len(repo.finished) != 1 || repo.finished[0].Status != TaskSucceeded {
+		t.Fatalf("expected one TaskSucceeded finish, got %+v", repo.finished)
+	}
+}
+
+// TestRunApply_AgentHealthy_FrontEndFatal_StillRollsBack pins fix 2: an
+// agent-healthy PLUGIN update whose homepage is fatal must still be caught
+// and rolled back. The signed agent route only proves PHP booted and the
+// plugin loaded; it does not prove the site renders. Fails against the
+// pre-fix code, which returns "healthy, public probe skipped" as soon as the
+// agent-first check is alive and would never see the fatal homepage at all.
+func TestRunApply_AgentHealthy_FrontEndFatal_StillRollsBack(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &verifyingCommander{alive: true, reason: agentcmd.ReasonAlive}
+	fatalStep := probeStep{result: agentcmd.ProbeResult{StatusCode: 200, Fatal: true, Detail: "fatal-error signature in response body"}}
+	prober := &scriptedProber{script: []probeStep{fatalStep}} // repeats: the front end never recovers
+	w := newApplyTestWorker(repo, cmd, prober)
+
+	task := testTask() // TargetType: TargetPlugin
+	item := updateItem()
+	if err := w.runApply(context.Background(), task, "https://example.test", item); err != nil {
+		t.Fatalf("runApply: %v", err)
+	}
+	if !cmd.rollbackCalled {
+		t.Fatalf("expected rollback: the agent reported healthy but the homepage is fatal, a front-end-only failure the agent route cannot see")
+	}
+	if len(repo.finished) != 1 || repo.finished[0].Status != TaskRolledBack {
+		t.Fatalf("expected one TaskRolledBack finish, got %+v", repo.finished)
+	}
+	if !strings.Contains(repo.finished[0].Detail, "front-end") {
+		t.Fatalf("expected the rollback detail to note the front-end-only nature of the failure, got %q", repo.finished[0].Detail)
+	}
+}
+
+// TestRunApply_AgentHealthy_NoExtraLatency is the golden test: a NORMAL
+// healthy update, using the REAL (non-overridden) probeRetryDelays schedule,
+// still completes quickly and without a rollback. It proves that consulting
+// the public probe after an agent-healthy verdict (fix 2) costs no meaningful
+// extra latency on the common happy path: probeHealthWithRetry only invokes
+// its backoff schedule when the FIRST attempt is not already healthy, so one
+// fast, healthy probe call is all this costs here.
+func TestRunApply_AgentHealthy_NoExtraLatency(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &verifyingCommander{alive: true, reason: agentcmd.ReasonAlive}
+	prober := &scriptedProber{script: []probeStep{healthyStep()}}
+	// Deliberately built WITHOUT newApplyTestWorker/SetProbeRetryDelays: this
+	// worker uses the production probeRetryDelays schedule (~21s worst case)
+	// so the assertion below actually proves that schedule is never invoked
+	// on the happy path, not just that it is shortened.
+	w := NewWorker(repo, nil, cmd, prober, nil, nil, nil, 5, 0)
+
+	task := testTask()
+	item := updateItem()
+	start := time.Now()
+	if err := w.runApply(context.Background(), task, "https://example.test", item); err != nil {
+		t.Fatalf("runApply: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("runApply took %s using the PRODUCTION probe-retry schedule; "+
+			"a healthy agent-first check plus a healthy public probe must not burn the ~21s retry window", elapsed)
+	}
+	if prober.calls != 1 {
+		t.Fatalf("expected exactly one public-probe call on the happy path, got %d", prober.calls)
+	}
+	if cmd.rollbackCalled {
+		t.Fatalf("rollback must not be called on the happy path")
+	}
+	if len(repo.finished) != 1 || repo.finished[0].Status != TaskSucceeded {
+		t.Fatalf("expected one TaskSucceeded finish, got %+v", repo.finished)
+	}
+}
+
+// TestRunApply_AgentHTTP5xxPersistent_RollsBackWithoutPublicProbe pins fix 1's
+// "persistent" half: a signed agent route that returns a server error on
+// EVERY attempt across the retry window is treated as authoritative proof of
+// a broken update (PHP fatal-ing even on its own agent route) and rolls back
+// WITHOUT ever consulting the public probe, which could only read a stale
+// cached copy anyway. This is exactly THE BUG scenario: a page-cached site
+// whose public GET / would return a stale healthy-looking 200.
+func TestRunApply_AgentHTTP5xxPersistent_RollsBackWithoutPublicProbe(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &verifyingCommander{alive: false, reason: agentcmd.ReasonHTTP5xx}
+	w := newApplyTestWorker(repo, cmd, &panicProber{t: t})
+
+	task := testTask()
+	item := updateItem()
+	if err := w.runApply(context.Background(), task, "https://example.test", item); err != nil {
+		t.Fatalf("runApply: %v", err)
+	}
+	if cmd.verifyCalls < 2 {
+		t.Fatalf("expected the agent-first check to have been retried before concluding persistent, got %d call(s)", cmd.verifyCalls)
+	}
+	if !cmd.rollbackCalled {
+		t.Fatalf("expected rollback to be called: the signed agent route returned a 5xx on every attempt")
+	}
+	if len(repo.finished) != 1 || repo.finished[0].Status != TaskRolledBack {
+		t.Fatalf("expected one TaskRolledBack finish, got %+v", repo.finished)
+	}
+}
+
+// TestRunApply_AgentHTTP5xxTransient_ClearsWithinRetryWindow_DoesNotRollBack
+// pins fix 1's "transient" half and is the direct regression test for GH #127
+// Defect 2 reintroduced at the agent layer: a signed agent route that returns
+// a server error on its FIRST couple of attempts, then recovers within the
+// retry window (e.g. a major-version upgrade running a synchronous DB
+// migration on activation), must NOT roll back. Fails against the pre-fix
+// code, which rolls back on the single first observation with zero retries.
+func TestRunApply_AgentHTTP5xxTransient_ClearsWithinRetryWindow_DoesNotRollBack(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &scriptedVerifyCommander{script: []verifyStep{
+		unhealthyVerifyStep(), unhealthyVerifyStep(), healthyVerifyStep(),
+	}}
+	prober := &scriptedProber{script: []probeStep{healthyStep()}}
+	w := newApplyTestWorker(repo, cmd, prober)
+
+	task := testTask()
+	item := updateItem()
+	if err := w.runApply(context.Background(), task, "https://example.test", item); err != nil {
+		t.Fatalf("runApply: %v", err)
+	}
+	if cmd.calls < 3 {
+		t.Fatalf("expected at least 3 agent-first attempts (2 transient failures + 1 recovery), got %d", cmd.calls)
+	}
+	if cmd.rollbackCalled {
+		t.Fatalf("rollback must NOT be called: the agent-first check recovered within the retry window, exactly like a transient migration 503")
+	}
+	if len(repo.finished) != 1 || repo.finished[0].Status != TaskSucceeded {
+		t.Fatalf("expected one TaskSucceeded finish, got %+v", repo.finished)
+	}
+}
+
+// TestRunApply_AgentAbsent_FallsThroughAndDoesNotItselfRollBack proves Change
+// 1's third decision-table row: a Commander with no agent-first capability at
+// all (mirrors "no signing key configured" / an old agent) must NOT roll back
+// on that absence alone. The outcome is decided entirely by the public probe
+// below it, which here reports healthy.
+func TestRunApply_AgentAbsent_FallsThroughAndDoesNotItselfRollBack(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &applyOnlyCommander{} // no VerifyReachableWithReason method at all
+	prober := &scriptedProber{script: []probeStep{healthyStep()}}
+	w := newApplyTestWorker(repo, cmd, prober)
+
+	task := testTask()
+	item := updateItem()
+	if err := w.runApply(context.Background(), task, "https://example.test", item); err != nil {
+		t.Fatalf("runApply: %v", err)
+	}
+	if prober.calls == 0 {
+		t.Fatalf("expected the public probe to have been consulted (agent-first check was unavailable)")
+	}
+	if cmd.rollbackCalled {
+		t.Fatalf("an absent agent-first check must NOT by itself trigger a rollback")
+	}
+	if len(repo.finished) != 1 || repo.finished[0].Status != TaskSucceeded {
+		t.Fatalf("expected one TaskSucceeded finish, got %+v", repo.finished)
+	}
+}
+
+// TestRunApply_CachedPublicProbe_IsInconclusiveNotHealthy proves a public
+// probe response flagged CacheHit (a stale cached 200) must NOT be read as
+// proof of health, and must NOT itself trigger a rollback either (a cache
+// hit is common and expected). Fails against the pre-fix code because
+// ProbeResult.Healthy() has no CacheHit concept at all and would
+// unconditionally record "updated and healthy".
+func TestRunApply_CachedPublicProbe_IsInconclusiveNotHealthy(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &applyOnlyCommander{}
+	cached := probeStep{result: agentcmd.ProbeResult{StatusCode: 200, CacheHit: true, Detail: "cache hit (cf-cache-status: HIT)"}}
+	prober := &scriptedProber{script: []probeStep{cached}} // repeats: cache never busts
+	w := newApplyTestWorker(repo, cmd, prober)
+
+	task := testTask()
+	item := updateItem()
+	if err := w.runApply(context.Background(), task, "https://example.test", item); err != nil {
+		t.Fatalf("runApply: %v", err)
+	}
+	if cmd.rollbackCalled {
+		t.Fatalf("a cache-hit response must NOT trigger a rollback (it is inconclusive, not unhealthy)")
+	}
+	if len(repo.finished) != 1 {
+		t.Fatalf("expected one finish call, got %d", len(repo.finished))
+	}
+	got := repo.finished[0]
+	if got.Status != TaskSucceeded {
+		t.Fatalf("expected TaskSucceeded (cannot roll back on an inconclusive result), got %s", got.Status)
+	}
+	if got.Detail == "updated and healthy" {
+		t.Fatalf("a cache-hit result must NOT be recorded as plain \"updated and healthy\": %q", got.Detail)
+	}
+	if !strings.Contains(got.Detail, "inconclusive") {
+		t.Fatalf("expected the detail to record the check was inconclusive, got %q", got.Detail)
+	}
+}
+
+// TestRunApply_PublicProbe404Root_DoesNotRollBack pins fix 3: a 404 on the
+// site root after an update must NOT roll back. There is no pre-update
+// baseline recorded, so a site that already returned 404 on its root BEFORE
+// the update (a headless install, a site whose root is intentionally empty,
+// a redirect-only domain) would otherwise be rolled back for a condition the
+// update did not cause. The task still records the check as inconclusive,
+// not healthy, so an operator is not falsely told the update was confirmed
+// fine. Fails against the pre-fix code, which treats 404 as unhealthy and
+// rolls back.
+func TestRunApply_PublicProbe404Root_DoesNotRollBack(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &applyOnlyCommander{}
+	prober := &scriptedProber{script: []probeStep{{result: agentcmd.ProbeResult{StatusCode: 404}}}}
+	w := newApplyTestWorker(repo, cmd, prober)
+
+	task := testTask()
+	item := updateItem()
+	if err := w.runApply(context.Background(), task, "https://example.test", item); err != nil {
+		t.Fatalf("runApply: %v", err)
+	}
+	if cmd.rollbackCalled {
+		t.Fatalf("a 404 on the site root must NOT trigger a rollback: there is no pre-update baseline to know the update caused it")
+	}
+	if len(repo.finished) != 1 || repo.finished[0].Status != TaskSucceeded {
+		t.Fatalf("expected one TaskSucceeded finish, got %+v", repo.finished)
+	}
+	if !strings.Contains(repo.finished[0].Detail, "inconclusive") {
+		t.Fatalf("expected the detail to record the check was inconclusive (not a confirmed-healthy claim), got %q", repo.finished[0].Detail)
+	}
+}
+
+// TestRunApply_PublicProbe401Or403_DoesNotTriggerRollback proves the other
+// half: 401/403 on the site root is common and legitimate (staging HTTP
+// auth, a members-only site, a security plugin) and must NOT be treated as a
+// broken-update signal, unlike 404/410.
+func TestRunApply_PublicProbe401Or403_DoesNotTriggerRollback(t *testing.T) {
+	for _, status := range []int{401, 403} {
+		t.Run(fmt.Sprintf("status_%d", status), func(t *testing.T) {
+			repo := &probeFakeRepo{}
+			cmd := &applyOnlyCommander{}
+			prober := &scriptedProber{script: []probeStep{{result: agentcmd.ProbeResult{StatusCode: status}}}}
+			w := newApplyTestWorker(repo, cmd, prober)
+
+			task := testTask()
+			item := updateItem()
+			if err := w.runApply(context.Background(), task, "https://example.test", item); err != nil {
+				t.Fatalf("runApply: %v", err)
+			}
+			if cmd.rollbackCalled {
+				t.Fatalf("a %d on the site root must NOT trigger a rollback", status)
+			}
+			if len(repo.finished) != 1 || repo.finished[0].Status != TaskSucceeded {
+				t.Fatalf("expected one TaskSucceeded finish, got %+v", repo.finished)
+			}
+		})
+	}
+}
+
+// TestClassifyPostUpdateProbe_CacheHitCheckedBeforeStatus pins fix 4: a
+// response flagged CacheHit must classify inconclusive REGARDLESS of a
+// status code that would otherwise look conclusive on its own (a 5xx that
+// would otherwise be unhealthy, or a 404 that would otherwise be
+// inconclusive-for-a-different-reason). A cached response proves nothing
+// about the CURRENT backend state, so the cache check must run before, not
+// after, any status-code based classification. Fails against the pre-fix
+// code, which checked Fatal/5xx/404 before CacheHit and would classify a
+// cached 500 as unhealthy.
+func TestClassifyPostUpdateProbe_CacheHitCheckedBeforeStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		in   agentcmd.ProbeResult
+		want postUpdateVerdict
+	}{
+		{"cache_hit_500_is_inconclusive_not_unhealthy", agentcmd.ProbeResult{StatusCode: 500, CacheHit: true}, postUpdateInconclusive},
+		{"cache_hit_404_is_inconclusive", agentcmd.ProbeResult{StatusCode: 404, CacheHit: true}, postUpdateInconclusive},
+		{"cache_hit_200_is_inconclusive", agentcmd.ProbeResult{StatusCode: 200, CacheHit: true}, postUpdateInconclusive},
+		{"cache_hit_fatal_is_inconclusive_not_unhealthy", agentcmd.ProbeResult{StatusCode: 200, Fatal: true, CacheHit: true}, postUpdateInconclusive},
+		{"no_cache_500_is_unhealthy", agentcmd.ProbeResult{StatusCode: 500}, postUpdateUnhealthy},
+		{"no_cache_404_is_inconclusive", agentcmd.ProbeResult{StatusCode: 404}, postUpdateInconclusive},
+		{"no_cache_200_is_healthy", agentcmd.ProbeResult{StatusCode: 200}, postUpdateHealthy},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyPostUpdateProbe(tc.in)
+			if got != tc.want {
+				t.Fatalf("classifyPostUpdateProbe(%+v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRunApply_CachedFiveHundred_IsInconclusiveNotUnhealthy is the full-stack
+// (runApply) pin for fix 4, proving the reordering matters end to end, not
+// just at the classify-function level: a probe response that is BOTH
+// CacheHit AND a 500 status must not roll back, because the cache check runs
+// first. Fails against the pre-fix code, which would classify this
+// unhealthy and roll back.
+func TestRunApply_CachedFiveHundred_IsInconclusiveNotUnhealthy(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &applyOnlyCommander{}
+	cachedFatal := probeStep{result: agentcmd.ProbeResult{StatusCode: 500, CacheHit: true, Detail: "cache hit (x-cache-status: HIT); server returned status 500"}}
+	prober := &scriptedProber{script: []probeStep{cachedFatal}} // repeats: cache never busts
+	w := newApplyTestWorker(repo, cmd, prober)
+
+	task := testTask()
+	item := updateItem()
+	if err := w.runApply(context.Background(), task, "https://example.test", item); err != nil {
+		t.Fatalf("runApply: %v", err)
+	}
+	if cmd.rollbackCalled {
+		t.Fatalf("a cache-hit response must NOT trigger a rollback even when its status code is 500: the cache check must be evaluated first")
+	}
+	if len(repo.finished) != 1 || repo.finished[0].Status != TaskSucceeded {
+		t.Fatalf("expected one TaskSucceeded finish, got %+v", repo.finished)
+	}
+	if !strings.Contains(repo.finished[0].Detail, "inconclusive") {
+		t.Fatalf("expected the detail to record the check was inconclusive, got %q", repo.finished[0].Detail)
+	}
+}
+
+// TestWorker_Timeout is the job-timeout-mismatch regression lock: the
+// update-task worker's River job used to inherit River's own 60s default
+// (Worker embedded river.WorkerDefaults[TaskArgs] with no Timeout override),
+// even though a real runApply can spend cfg.Update.ApplyHTTPTimeout (5m by
+// default) on the apply call ALONE, before the GH #291 Phase 4 post-update
+// health check even starts. This asserts NewWorker threads its jobTimeout
+// argument straight through to Timeout(), and that a zero jobTimeout (the
+// zero value, and what every other test in this file passes since they don't
+// care about the job deadline) reports back as 0, the documented signal
+// (see Worker.Timeout's doc comment) for "fall back to river.Config.
+// JobTimeout" rather than an accidental instant timeout.
+func TestWorker_Timeout(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &applyOnlyCommander{}
+	prober := &scriptedProber{}
+
+	t.Run("threads a positive jobTimeout through to Timeout()", func(t *testing.T) {
+		w := NewWorker(repo, nil, cmd, prober, nil, nil, nil, 5, 42*time.Minute)
+		if got := w.Timeout(nil); got != 42*time.Minute {
+			t.Fatalf("Timeout() = %v, want 42m (the jobTimeout passed to NewWorker)", got)
+		}
+	})
+
+	t.Run("zero jobTimeout falls back to River's default, not an instant timeout", func(t *testing.T) {
+		w := NewWorker(repo, nil, cmd, prober, nil, nil, nil, 5, 0)
+		if got := w.Timeout(nil); got != 0 {
+			t.Fatalf("Timeout() = %v, want 0 (river's job executor falls back to river.Config.JobTimeout on exactly 0, per cmp.Or)", got)
+		}
+	})
+}
+
+// TestDeriveApplyJobTimeout pins the arithmetic DeriveApplyJobTimeout uses to
+// size the update-task job's River Timeout(): applyHTTPTimeout (the apply
+// call) plus BOTH post-update health-check retry ladders (read from the
+// actual probeRetryDelays/agentVerifyTimeout constants, not a hardcoded
+// number) plus a fixed headroom, and a zero applyHTTPTimeout falling back to
+// 0 (river.Config.JobTimeout) rather than a partial, misleadingly-small
+// budget that omits the apply round trip.
+func TestDeriveApplyJobTimeout(t *testing.T) {
+	var delaySum time.Duration
+	for _, d := range probeRetryDelays {
+		delaySum += d
+	}
+	attempts := time.Duration(len(probeRetryDelays) + 1)
+
+	t.Run("production defaults: apply(5m) + agent ladder + probe ladder + 2m headroom", func(t *testing.T) {
+		applyHTTPTimeout := 5 * time.Minute
+		probeHTTPTimeout := 30 * time.Second
+
+		want := applyHTTPTimeout +
+			(attempts*agentVerifyTimeout + delaySum) +
+			(attempts*probeHTTPTimeout + delaySum) +
+			2*time.Minute
+
+		got := DeriveApplyJobTimeout(applyHTTPTimeout, probeHTTPTimeout)
+		if got != want {
+			t.Fatalf("DeriveApplyJobTimeout(%v, %v) = %v, want %v", applyHTTPTimeout, probeHTTPTimeout, got, want)
+		}
+		// Pin the concrete number too, so a future change to probeRetryDelays or
+		// agentVerifyTimeout is caught even if it happens to keep the formula above
+		// (copy-pasted from the function) in sync with itself.
+		if got != 10*time.Minute+52*time.Second {
+			t.Fatalf("DeriveApplyJobTimeout(5m, 30s) = %v, want 10m52s with current ladder constants", got)
+		}
+	})
+
+	t.Run("result comfortably fits under staleTaskThreshold", func(t *testing.T) {
+		got := DeriveApplyJobTimeout(5*time.Minute, 30*time.Second)
+		if got >= staleTaskThreshold {
+			t.Fatalf("DeriveApplyJobTimeout() = %v, want < staleTaskThreshold (%v): the reaper must never terminalize a task still legitimately within its own job deadline", got, staleTaskThreshold)
+		}
+	})
+
+	t.Run("zero applyHTTPTimeout falls back to 0, not a partial budget", func(t *testing.T) {
+		if got := DeriveApplyJobTimeout(0, 30*time.Second); got != 0 {
+			t.Fatalf("DeriveApplyJobTimeout(0, 30s) = %v, want 0", got)
+		}
+	})
+
+	t.Run("zero probeHTTPTimeout does not zero out the whole result", func(t *testing.T) {
+		got := DeriveApplyJobTimeout(5*time.Minute, 0)
+		if got <= 5*time.Minute {
+			t.Fatalf("DeriveApplyJobTimeout(5m, 0) = %v, want > 5m (probeHTTPTimeout=0 should fall back internally, not collapse the probe ladder to 0)", got)
+		}
+	})
 }

--- a/apps/api/tests/update_integration_test.go
+++ b/apps/api/tests/update_integration_test.go
@@ -37,6 +37,7 @@ type fakeAgent struct {
 	mu            sync.Mutex
 	updateCalls   int32
 	rollbackCalls int32
+	homepageCalls int32
 	dryRunSeen    bool
 	snapshotSeen  bool
 	// expectAud is the enrollment site_id the agent verifies the JWT aud against
@@ -51,6 +52,28 @@ type fakeAgent struct {
 	// homepageStatus is returned for GET / (the health probe). 0 ⇒ 200.
 	homepageStatus int
 	homepageBody   string
+	// pingStatus/pingBody override the signed ping-command response (GH #291
+	// Phase 4 agent-first check) INDEPENDENTLY of homepageStatus/homepageBody.
+	// pingConfigured=false (the default) mirrors homepageStatus/homepageBody
+	// exactly, matching this fake agent's behaviour before the ping route
+	// existed here (an unmatched path fell through to the "/" handler), so
+	// every test that never calls setPing is unaffected. A test calls setPing
+	// to decouple the two, e.g. to simulate a page-cached homepage (stale 200)
+	// sitting in front of a genuinely fatal backend (ping 500), which is the
+	// exact scenario this phase fixes.
+	pingConfigured bool
+	pingStatus     int
+	pingBody       string
+	// pingFailRemaining, when > 0, overrides pingStatus/pingBody for exactly
+	// that many remaining ping calls (each call decrements it by one), then
+	// the agent answers a plain healthy 200. Used to simulate a TRANSIENT
+	// agent-side failure (e.g. the synchronous DB-migration-on-activation
+	// window GH #127 documents) that clears within a few requests, as opposed
+	// to setPing's persistent override.
+	pingFailRemaining int32
+	pingFailStatus    int
+	pingFailBody      string
+	pingCalls         int32
 	// updateResp/rollbackResp override the command responses.
 	updateResp   agentcmd.UpdateResponse
 	rollbackResp agentcmd.RollbackResponse
@@ -101,7 +124,40 @@ func newFakeAgent(t *testing.T) *fakeAgent {
 		}
 		writeJSON(w, resp)
 	})
+	mux.HandleFunc("/wp-json/wpmgr/v1/command/ping", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&fa.pingCalls, 1)
+		fa.mu.Lock()
+		status, body := fa.pingStatus, fa.pingBody
+		if !fa.pingConfigured {
+			status, body = fa.homepageStatus, fa.homepageBody
+		}
+		if fa.pingFailRemaining > 0 {
+			// A transient failure overrides everything else above for exactly
+			// this many remaining calls, then clears (see setPingTransientFailure).
+			fa.pingFailRemaining--
+			status, body = fa.pingFailStatus, fa.pingFailBody
+		}
+		expect := fa.expectAud
+		fa.mu.Unlock()
+		aud, cmd := bearerAudCmd(r)
+		if r.Header.Get("Authorization") == "" || (expect != "" && aud != expect) || cmd != "ping" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.WriteHeader(status)
+		if body != "" {
+			_, _ = w.Write([]byte(body))
+		} else if status >= 200 && status < 300 {
+			// A plain 200 with no body override IS a valid, agent-shaped OK
+			// ping response, matching the real agent's ping command handler.
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}
+	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&fa.homepageCalls, 1)
 		fa.mu.Lock()
 		status := fa.homepageStatus
 		body := fa.homepageBody
@@ -125,6 +181,31 @@ func (fa *fakeAgent) setHomepage(status int, body string) {
 	fa.mu.Lock()
 	fa.homepageStatus = status
 	fa.homepageBody = body
+	fa.mu.Unlock()
+}
+
+// setPing decouples the signed ping-command response from the public
+// homepage response (GH #291 Phase 4). Until called, ping mirrors
+// homepageStatus/homepageBody exactly.
+func (fa *fakeAgent) setPing(status int, body string) {
+	fa.mu.Lock()
+	fa.pingConfigured = true
+	fa.pingStatus = status
+	fa.pingBody = body
+	fa.mu.Unlock()
+}
+
+// setPingTransientFailure makes the next n ping calls answer with status/body,
+// then reverts to a plain healthy 200 for every call after that. Used to
+// simulate a transient agent-side failure (e.g. a synchronous DB migration
+// on activation, GH #127) that clears within the retry window, as opposed to
+// setPing's persistent override.
+func (fa *fakeAgent) setPingTransientFailure(n int, status int, body string) {
+	fa.mu.Lock()
+	fa.pingConfigured = true
+	fa.pingFailRemaining = int32(n)
+	fa.pingFailStatus = status
+	fa.pingFailBody = body
 	fa.mu.Unlock()
 }
 
@@ -363,7 +444,7 @@ func buildHarness(t *testing.T, pool *db.Pool, commander update.Commander, probe
 	siteSvc := site.NewService(site.NewRepo(pool), domain.NewValidator(), domain.SystemClock{})
 	rec := audit.NewRecorder(pool, domain.SystemClock{})
 	lookup := &svcSiteLookup{svc: siteSvc}
-	worker := update.NewWorker(repo, lookup, commander, prober, hub, rec, nil, 5)
+	worker := update.NewWorker(repo, lookup, commander, prober, hub, rec, nil, 5, 0)
 	client := startUpdateRiver(t, pool, worker)
 	svc := update.NewService(repo, lookup, update.NewRiverEnqueuer(client), domain.NewValidator(), domain.SystemClock{})
 	return &updateTestHarness{pool: pool, repo: repo, hub: hub, svc: svc, worker: worker, client: client, siteSvc: siteSvc}
@@ -483,6 +564,117 @@ func TestUpdateAutoRollback(t *testing.T) {
 	}
 	if rbCmd != "rollback" {
 		t.Fatalf("rollback JWT cmd = %q, want rollback", rbCmd)
+	}
+}
+
+// TestUpdateAutoRollback_CachedHomepageMaskedFatal_StillRollsBack reproduces
+// THE BUG this phase fixes end-to-end, over a real agentcmd.Client and a real
+// River-driven worker: a page cache serves a stale pre-update 200 for the
+// public homepage (what the old code alone would have read as "healthy"),
+// while the SAME broken plugin update has made PHP fatal on EVERY request,
+// including the agent's own signed ping route, which a cache can never serve
+// stale because it is a fresh, uncacheable, signed round trip. The task must
+// still roll back, and it must do so WITHOUT ever consulting the (misleading)
+// public homepage probe at all.
+//
+// The fake agent's ping response here is persistently 500 (it never clears),
+// so this also doubles as the end-to-end pin for fix 1's "persistent" half: a
+// rollback is reached only after the agent-first check has been retried
+// across its full window, not on the first observation. A tiny probe-retry
+// schedule is installed on the worker so the test does not actually wait out
+// the production ~21s window.
+func TestUpdateAutoRollback_CachedHomepageMaskedFatal_StillRollsBack(t *testing.T) {
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "upd-cache-mask")
+	fa := newFakeAgent(t)
+	// The public homepage: a page cache serving the stale pre-update 200.
+	fa.setHomepage(http.StatusOK, "<html>looks fine (stale cache)</html>")
+	// The signed ping route: PHP is actually fatal-ing on every request, and
+	// stays that way for the whole test (a persistent, not transient, fatal).
+	fa.setPing(http.StatusInternalServerError, "")
+
+	h := buildHarness(t, pool, newTestCommander(t), newTestProber(t))
+	// Fix 1 gives the agent-first check the same retry discipline as the
+	// public probe, reusing probeRetryDelays. Override it here with a tiny
+	// schedule so this test proves the retry-then-persist behavior without
+	// spending the real ~21s window.
+	h.worker.SetProbeRetryDelays([]time.Duration{10 * time.Millisecond, 10 * time.Millisecond, 10 * time.Millisecond, 10 * time.Millisecond})
+	s := enrollFakeSite(t, pool, tenant, fa.url())
+	fa.setExpectAud(s.ID.String())
+	seedPendingPlugin(t, h, tenant, s, "broken-plugin", "1.0.0", "1.1.0")
+
+	run, _, err := h.svc.CreateRun(context.Background(), update.CreateRunInput{
+		TenantID: tenant,
+		SiteIDs:  []uuid.UUID{s.ID},
+		Items:    []update.Item{{Type: "plugin", Slug: "broken-plugin", Version: "latest"}},
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	start := time.Now()
+	_, finalTasks := waitRunCompleted(t, h, tenant, run.ID)
+	elapsed := time.Since(start)
+
+	tk := finalTasks[0]
+	if tk.Status != update.TaskRolledBack {
+		t.Fatalf("task status = %s, want rolled_back (detail=%s); a cached-200 homepage must not mask a fatal backend", tk.Status, tk.Detail)
+	}
+	if atomic.LoadInt32(&fa.rollbackCalls) != 1 {
+		t.Fatalf("rollback called %d times, want 1", fa.rollbackCalls)
+	}
+	if atomic.LoadInt32(&fa.homepageCalls) != 0 {
+		t.Fatalf("the public homepage probe was called %d time(s); a PERSISTENT agent-confirmed fatal is conclusive and should have skipped it entirely", fa.homepageCalls)
+	}
+	// With the tiny test schedule installed above, the whole retry-then-persist
+	// sequence should finish in well under a second; a much larger bound is
+	// used here only to absorb CI scheduling jitter, not to allow the real
+	// production window to run.
+	if elapsed > 5*time.Second {
+		t.Fatalf("run took %s to complete using the tiny test retry schedule; the persistent-agent-fatal path should not take anywhere near that long", elapsed)
+	}
+}
+
+// TestUpdateNoRollback_TransientAgentPingRecovers is the end-to-end pin for
+// fix 1's "transient" half, over a real agentcmd.Client and a real
+// River-driven worker: the signed ping route returns a server error for the
+// FIRST couple of calls, then recovers, exactly like the synchronous
+// DB-migration-on-activation window GH #127 documents. The task must
+// succeed, not roll back, and the agent-first check must have been retried
+// (not just observed once) before it did.
+func TestUpdateNoRollback_TransientAgentPingRecovers(t *testing.T) {
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "upd-agent-transient")
+	fa := newFakeAgent(t)
+	fa.setHomepage(http.StatusOK, "<html>ok</html>")
+	// The signed ping route fails twice, then clears.
+	fa.setPingTransientFailure(2, http.StatusInternalServerError, "")
+
+	h := buildHarness(t, pool, newTestCommander(t), newTestProber(t))
+	h.worker.SetProbeRetryDelays([]time.Duration{10 * time.Millisecond, 10 * time.Millisecond, 10 * time.Millisecond, 10 * time.Millisecond})
+	s := enrollFakeSite(t, pool, tenant, fa.url())
+	fa.setExpectAud(s.ID.String())
+	seedPendingPlugin(t, h, tenant, s, "migrating-plugin", "1.9.9", "2.0.0")
+
+	run, _, err := h.svc.CreateRun(context.Background(), update.CreateRunInput{
+		TenantID: tenant,
+		SiteIDs:  []uuid.UUID{s.ID},
+		Items:    []update.Item{{Type: "plugin", Slug: "migrating-plugin", Version: "latest"}},
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	_, finalTasks := waitRunCompleted(t, h, tenant, run.ID)
+	tk := finalTasks[0]
+	if tk.Status != update.TaskSucceeded {
+		t.Fatalf("task status = %s, want succeeded (detail=%s); a transient agent-side failure that clears within the retry window must not roll back", tk.Status, tk.Detail)
+	}
+	if atomic.LoadInt32(&fa.rollbackCalls) != 0 {
+		t.Fatalf("rollback called %d times, want 0: the agent-first check recovered before the retry window was exhausted", fa.rollbackCalls)
+	}
+	if atomic.LoadInt32(&fa.pingCalls) < 3 {
+		t.Fatalf("expected at least 3 ping calls (2 transient failures + 1 recovery), got %d", fa.pingCalls)
 	}
 }
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.90
+  version: 0.61.91
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Addresses #291 phase 4 of 4. Phases 0 and 1 shipped in v0.61.90; phases 2 and 3 follow.

## The bug (more dangerous than the reported one)

After applying an update, `runApply` health-probes the site root to decide whether to roll back. On a page-cached site that GET is served **from cache**, so it reads the **pre-update HTML**. An update that fatals PHP therefore **passed its check, was not rolled back, and the operator was told "updated and healthy"** while the site was down.

The `{3s,4s,6s,8s}` retry schedule made it strictly worse: it waited longer, giving the cache more time to serve a warm copy, and could only ever observe the same cached bytes.

## The fix: ask the agent first

The control plane has *just* spoken to the agent over a signed POST. That route is **uncacheable by construction** because it does not exist unless PHP booted and the plugin loaded, so a cache cannot fake it. The machinery already existed (`VerifyReachableWithReason`, used by the connection sweeper).

## Rollback now requires a confirmed failure, never a single reading

| Signal | Rolls back? |
|---|---|
| Agent 5xx, **persistent** across the retry window | Yes |
| Agent 5xx that **clears** within the window | **No** |
| Public probe unhealthy after the retry window | Yes |
| Agent healthy but **homepage fatal** | Yes (front-end detection preserved) |
| Response flagged as a **cache HIT** | No, inconclusive |
| **404/410** on the root | No, inconclusive |
| **401/403** on the root | No, healthy |
| Agent **absent** or unreachable | No, falls through to the public probe |

Three of these exist because the first review round caught me introducing them:

- **A single-observation agent rollback would have reintroduced GH #127's transient-503 false rollback.** `probeRetryDelays`' own comment documents the scenario: an on-activation DB migration can legitimately 503 for seconds, and the agent route is served by the *same PHP stack* as the homepage, so it catches every transient the ladder exists to absorb.
- **An agent-healthy verdict must not end the check.** The agent proves PHP booted, not that the site *renders*. A theme update, or a plugin fataling on a front-end hook, leaves the REST route healthy while the homepage is dead.
- **404 must not roll back.** Without a pre-update baseline, a site that legitimately 404s on its root would be rolled back for a condition the update did not cause. (The design doc said so explicitly; the build had contradicted it.)

`ProbeResult.Healthy()` is deliberately **unchanged** (it has exactly one production caller, verified); the narrower rule was added as `classifyPostUpdateProbe` next to that caller rather than mutating a shared helper.

## Also fixes a pre-existing job-budget mismatch this exposed

Update jobs ran on River's **1-minute default** (`river.Config` sets no `JobTimeout`, `update.Worker` had no `Timeout()` override) while the apply client alone allows **5 minutes**. A single HTTP call was permitted five times longer than the job containing it, so a slow-but-successful update could be killed mid-flight and left stuck. This plausibly contributed to the stuck tasks that #131 needed a reaper for.

The budget is now **derived from the real constants** (apply timeout + both retry ladders + headroom = 10m52s at defaults) rather than hardcoded, mirroring the backup worker precedent. The 45m reaper threshold still clears it 2.5x over.

## Verification

- `go build`/`vet` clean; `internal/update` and `internal/agentcmd` suites green; all 9 update integration tests pass against real Postgres.
- New tests: transient-vs-persistent agent 5xx, agent-healthy-with-fatal-front-end, 404-does-not-roll-back, cache-HIT-before-status, plus an **end-to-end integration test** over a real agent client and River worker reproducing the original bug.
- Adversarially reviewed twice. The re-verification was done **by mutation**: the reviewer reintroduced each bug and confirmed the tests kill it.

## Follow-up noted, not fixed here

`uptime.ProbeWorker` has the same missing `Timeout()` override, where a fleet sweep can exceed 60s once the fleet is more than a few dozen sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LijsBvT79KkVsM8DY4tD1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update verification to avoid false success reports caused by cached homepage responses.
  * Strengthened rollback decisions by confirming persistent failures and allowing transient issues time to recover.
  * Improved handling and reporting of site-wide failures during rollback.
  * Extended update execution time limits to support longer-running updates and health checks.

* **Documentation**
  * Updated release information and container image instructions for version 0.61.91.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->