### PR TITLE
feat(uptime): detect a dead WordPress behind a warm page cache (GH #291 phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.92] - 2026-07-27
+
+### Added
+
+- WPMgr now checks whether WordPress itself is actually running, not just whether the site returns a page (GH #291). A site with page caching can keep serving visitors a saved copy of its homepage even when WordPress is completely broken, which is why such an outage could previously go unnoticed. Alongside the existing check, WPMgr now asks the site for something a cache does not answer, so a site that is serving cached pages while WordPress is down is shown as degraded with an explanation of what that means for logins, forms and the admin area.
+- Uptime figures are deliberately unchanged. A cached page that loads still counts as up, because visitors really are being served. Application health is reported as a separate signal, so historical uptime and SLA figures keep their meaning.
+- The check costs almost nothing on a healthy site: if the site agent has reported in recently, that already proves WordPress is running and no extra request is made at all. The direct check only runs for sites that have gone quiet, which is exactly when it is needed.
+- WPMgr reports this as unknown rather than guessing whenever it cannot be certain, including when a response turns out to have come from a cache, when the site is merely slow, when it is in maintenance mode during an update, or when a security plugin blocks the check. Only a genuine WordPress error counts as broken. No alerts are sent for this signal yet; that follows in a later release with an explicit opt in.
+
 ## [0.61.91] - 2026-07-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
   <a href="https://wpmgr.app/docs/">API reference</a>
 </p>
 
-**v0.61.91** — open-source and production-usable for self-hosters.
+**v0.61.92** — open-source and production-usable for self-hosters.
 
 ---
 
@@ -313,15 +313,15 @@ Site screenshot cards then fall back to favicon/monogram and the Media Optimizer
 The control plane, dashboard, and media encoder are published on GitHub Container Registry as multi-arch (`linux/amd64` + `linux/arm64`) images, for wiring into your own compose, Kubernetes, or Swarm setup:
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.91
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.91
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.91
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.92
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.92
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.92
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.91   # omit to track :latest
+export WPMGR_VERSION=v0.61.92   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -1088,6 +1088,21 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	webhookPoster := uptime.NewSSRFWebhookPoster(ssrfClient)
 	uptimeDispatcher := uptime.NewDispatcher(uptimeMailer, webhookPoster, auditRec, logger)
 	uptimeWorker := uptime.NewProbeWorker(uptimeRepo, uptimeProber, metricsStore, uptimeDispatcher, uptimeSiteAdapter, logger, cfg.Uptime.ProbeConcurrency, cfg.Uptime.DownThreshold)
+	// GH #291 Phase 2 - application-health probe. Piggybacks onto the
+	// existing reachability sweep (uptimeWorker) rather than its own
+	// periodic job; see uptime.ProbeWorker.SetAppProber / appProbeDue.
+	// WPMGR_UPTIME_APP_PROBE_ENABLED=false leaves uptimeWorker exactly as it
+	// was before this feature existed (SetAppProber never called).
+	if cfg.Uptime.AppProbeEnabled {
+		appProber := uptime.NewAppProber(ssrfClient, cfg.Uptime.AppProbeTimeout)
+		uptimeWorker.SetAppProber(appProber, cfg.Uptime.ProbeInterval, cfg.Uptime.AppProbeInterval)
+		logger.Info("uptime app-health probe enabled (GH #291 Phase 2)",
+			slog.Duration("app_probe_interval", cfg.Uptime.AppProbeInterval),
+			slog.Duration("app_probe_timeout", cfg.Uptime.AppProbeTimeout),
+		)
+	} else {
+		logger.Info("uptime app-health probe disabled (WPMGR_UPTIME_APP_PROBE_ENABLED=false)")
+	}
 	uptimeSvc := uptime.NewService(uptimeRepo, metricsStore, uptimeSiteAdapter)
 	uptimeH := uptime.NewHandler(uptimeSvc, auditRec)
 	// Wire the metrics store into the site service so site-list uptime fields

--- a/apps/api/db/query/sites.sql
+++ b/apps/api/db/query/sites.sql
@@ -176,7 +176,11 @@ WHERE id = $1 AND health_status <> 'unreachable';
 -- Cross-tenant enumeration of enrolled sites WITH their URL for the M5 uptime
 -- probe job. Runs under the app.agent GUC (sites_agent policy) since it spans
 -- tenants. Only enrolled sites have an agent URL worth probing.
-SELECT id, tenant_id, url, health_status FROM sites
+-- last_seen_at and app_probe_path (m107, GH #291 Phase 2) are carried for the
+-- application-health prober: B0 (agent ground truth) reads last_seen_at, B3
+-- (per-site override) reads app_probe_path. The reachability probe and the
+-- cron-kicker ignore both.
+SELECT id, tenant_id, url, health_status, last_seen_at, app_probe_path FROM sites
 WHERE enrolled_at IS NOT NULL;
 
 -- name: SetSiteHealthStatus :execrows

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -277,6 +277,13 @@ CREATE TABLE sites (
     -- The composite FK to clients (id, tenant_id) is added after the clients
     -- table definition below (ON DELETE SET NULL — unassign, never cascade).
     client_id   uuid,
+    -- m107 (GH #291 Phase 2): B3 override for the application-health probe.
+    -- When set, the app prober requests this path instead of auto-detecting
+    -- /wp-json/ (with the ?rest_route=/ fallback). NULL/empty means
+    -- auto-detect. Not yet operator-settable via the API (planned for Phase
+    -- 3's per-site override UI); the column and probe support exist now so
+    -- Phase 3 needs no further schema change.
+    app_probe_path text,
     created_at  timestamptz NOT NULL DEFAULT now(),
     updated_at  timestamptz NOT NULL DEFAULT now()
 );
@@ -1392,6 +1399,20 @@ CREATE TABLE site_uptime_probes (
     tls_issuer   text             NOT NULL DEFAULT '',
     tls_subject  text             NOT NULL DEFAULT '',
     error_text   text             NOT NULL DEFAULT '',
+    -- m107 (GH #291 Phase 2): the application-health probe rides the SAME row
+    -- as the reachability probe it was piggybacked onto (see
+    -- uptime.ProbeWorker.Sweep / appProbeDue) instead of a second row, so no
+    -- aggregate that counts/sums site_uptime_probes rows is ever affected by
+    -- app-health data. app_up is NULL on every row where no app probe was
+    -- attempted (the common case: the app probe runs on a slower cadence
+    -- than this reachability probe) and tri-state (true/false/NULL=unknown)
+    -- on a row where one was. app_probe_reason is NULL exactly when app_up
+    -- is NULL-because-not-attempted, and non-NULL (one of the
+    -- AppProbeReason* constants) whenever an app probe actually ran on this
+    -- row, including a conclusive "unknown" verdict - see
+    -- metrics.Check.AppProbeReason.
+    app_up            boolean,
+    app_probe_reason  text,
     PRIMARY KEY (id)
 );
 
@@ -1462,6 +1483,18 @@ CREATE TABLE site_uptime_daily (
     total_checks    integer          NOT NULL DEFAULT 0,
     sum_latency_ms  double precision NOT NULL DEFAULT 0,
     latency_samples integer          NOT NULL DEFAULT 0,
+    -- m107 (GH #291 Phase 2): additive app-health counters riding the SAME
+    -- (site_id, day) row - NOT a second row, which would double total_checks
+    -- and blend two different meanings into every uptime percentage in the
+    -- product (this table has no "kind" dimension to disambiguate rows).
+    -- Nullable with no default (mirrors this migration's other new columns);
+    -- the upsert COALESCEs against NULL so a pre-migration/never-touched row
+    -- adds correctly. app_total_checks counts every app probe ATTEMPT
+    -- (including an inconclusive "unknown" verdict); app_up_checks counts
+    -- only a conclusive true verdict - mirrors up_checks/total_checks
+    -- exactly, just for the app-health signal.
+    app_up_checks    integer,
+    app_total_checks integer,
     updated_at      timestamptz      NOT NULL DEFAULT now(),
     PRIMARY KEY (site_id, day)
 );
@@ -1521,6 +1554,19 @@ CREATE TABLE site_uptime_status (
     latest_up      boolean     NOT NULL,
     last_probed_at timestamptz NOT NULL,
     tls_expiry     timestamptz,
+    -- m107 (GH #291 Phase 2): the application-health snapshot, upserted
+    -- alongside the reachability fields above but COALESCE/CASE-guarded
+    -- against NULL independently of them (see metrics.pgStore.UpsertRollup).
+    -- The app probe runs on a slower cadence than the reachability probe
+    -- (default 300s vs 60s), so most sweeps that reach this upsert carry NO
+    -- app-health opinion at all - a plain "latest_app_up = EXCLUDED.
+    -- latest_app_up" would clobber a known value with NULL on ~4 of every 5
+    -- sweeps. last_app_probed_at is separate from last_probed_at (the
+    -- reachability timestamp this row's freshness guard is keyed on)
+    -- because the two probes do not always coincide.
+    latest_app_up      boolean,
+    app_probe_reason   text,
+    last_app_probed_at timestamptz,
     updated_at     timestamptz NOT NULL DEFAULT now()
 );
 

--- a/apps/api/internal/agentcmd/client.go
+++ b/apps/api/internal/agentcmd/client.go
@@ -1021,7 +1021,9 @@ func addCacheBuster(targetURL string) (string, error) {
 
 // cacheHitHeaders are the response headers various page/edge caches use to
 // report that a response was served from cache rather than freshly rendered.
-// Checked case-insensitively via http.Header.Get's own canonicalization.
+// Checked case-insensitively via http.Header.Get's own canonicalization. This
+// list can never be exhaustive - see cacheHitShapeRe below for the fallback
+// that catches a vendor not named here.
 var cacheHitHeaders = []string{
 	"Cf-Cache-Status",   // Cloudflare
 	"X-Litespeed-Cache", // LiteSpeed / OpenLiteSpeed built-in page cache
@@ -1031,13 +1033,42 @@ var cacheHitHeaders = []string{
 	"X-Cache-Status",    // the standard nginx add_header X-Cache-Status $upstream_cache_status form
 }
 
+// cacheHitShapeRe is the FALLBACK for a cache-status header not named in
+// cacheHitHeaders. Appending vendor names to that list forever is a losing
+// game - a real-world fleet was found running a stack whose cache-status
+// header matched neither list, so DetectCacheHit would have silently missed
+// a cache HIT on exactly the setup that motivates this check (GH #291 Phase
+// 2). Rather than chase every vendor, this also matches the common SHAPE of a
+// cache-status header name: "x-<something>-cache" (X-Swarm-Cache,
+// X-Rocket-Cache, ...) or "x-cache-<something>" (X-Cache-Hits, ...),
+// case-insensitively. Anchored on the full header name (not a substring
+// search) so an unrelated header merely containing "cache" somewhere in a
+// longer name never false-positives.
+var cacheHitShapeRe = regexp.MustCompile(`(?i)^x-[a-z0-9]+-cache$|^x-cache-[a-z0-9]+$`)
+
+// cacheHitValueRe matches a header value that reads as an affirmative
+// cache-status verdict: a bare HIT, plus the handful of near-hit states real
+// caches emit that still mean "this response did not come from a fresh
+// backend render" (STALE served while revalidating, UPDATING served the old
+// object while refreshing, REVALIDATED served after a conditional check).
+// MISS/BYPASS/EXPIRED/DYNAMIC are deliberately NOT matched - those mean the
+// cache was NOT the source of this response, which is exactly the "prove the
+// bypass worked" case this whole mechanism exists for.
+var cacheHitValueRe = regexp.MustCompile(`(?i)\b(HIT|STALE|UPDATING|REVALIDATED)\b`)
+
 // detectCacheHit reports whether h carries a cache-status header (or an Age
 // value greater than zero) indicating the response was served from cache. A
 // cache that ignores query strings when computing its cache key defeats
 // addCacheBuster with one click of configuration (see cacheBusterParam), so
 // this is the honest backstop that turns a silently-stale 200 into a
 // detectable, reportable CacheHit instead of trusted proof of health.
-func detectCacheHit(h http.Header) (hit bool, detail string) {
+//
+// Two layers, checked in order: the explicit cacheHitHeaders list (known
+// vendors, cheapest and most precise), then cacheHitShapeRe (a header this
+// deployment's cache emits under a name not in that list, but whose shape and
+// value still say HIT/STALE/UPDATING/REVALIDATED). The Age > 0 backstop
+// applies regardless of either header check.
+func DetectCacheHit(h http.Header) (hit bool, detail string) {
 	for _, name := range cacheHitHeaders {
 		v := h.Get(name)
 		if v == "" {
@@ -1045,6 +1076,16 @@ func detectCacheHit(h http.Header) (hit bool, detail string) {
 		}
 		if strings.Contains(strings.ToUpper(v), "HIT") {
 			return true, fmt.Sprintf("cache hit (%s: %s)", name, v)
+		}
+	}
+	for name, values := range h {
+		if !cacheHitShapeRe.MatchString(name) {
+			continue
+		}
+		for _, v := range values {
+			if v != "" && cacheHitValueRe.MatchString(v) {
+				return true, fmt.Sprintf("cache hit (%s: %s)", name, v)
+			}
 		}
 	}
 	if age := strings.TrimSpace(h.Get("Age")); age != "" {
@@ -1059,7 +1100,7 @@ func detectCacheHit(h http.Header) (hit bool, detail string) {
 // an SSRF block) is returned as err; a reachable-but-broken site is a non-error
 // ProbeResult with Healthy()==false. The URL is cache-busted (see
 // cacheBusterParam) and the response headers are checked for a cache-status
-// signal (see detectCacheHit / ProbeResult.CacheHit) before the caller decides
+// signal (see DetectCacheHit / ProbeResult.CacheHit) before the caller decides
 // what the result proves.
 func (p *Probe) Get(ctx context.Context, targetURL string) (ProbeResult, error) {
 	bustedURL, err := addCacheBuster(targetURL)
@@ -1078,7 +1119,7 @@ func (p *Probe) Get(ctx context.Context, targetURL string) (ProbeResult, error) 
 	}
 	defer func() { _, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxRespBody)); _ = resp.Body.Close() }()
 
-	cacheHit, cacheDetail := detectCacheHit(resp.Header)
+	cacheHit, cacheDetail := DetectCacheHit(resp.Header)
 
 	// Read a bounded prefix to scan for fatal-error signatures.
 	const scanLimit = 64 << 10

--- a/apps/api/internal/agentcmd/probe_test.go
+++ b/apps/api/internal/agentcmd/probe_test.go
@@ -141,6 +141,71 @@ func TestProbeGet_NoCacheHeaders_NotFlagged(t *testing.T) {
 	}
 }
 
+// TestDetectCacheHit_KnownVendorHeader proves the explicit cacheHitHeaders
+// list still works after generalizing DetectCacheHit (GH #291 Phase 2 change
+// 3): a named vendor header (LiteSpeed) with a HIT value is still detected.
+func TestDetectCacheHit_KnownVendorHeader(t *testing.T) {
+	h := http.Header{}
+	h.Set("X-Litespeed-Cache", "hit")
+	hit, detail := DetectCacheHit(h)
+	if !hit {
+		t.Fatalf("expected CacheHit=true for a known vendor header, got hit=%v detail=%q", hit, detail)
+	}
+}
+
+// TestDetectCacheHit_UnknownVendorShapeHeader proves the GH #291 Phase 2
+// fix: a cache-status header NOT in cacheHitHeaders, but matching the common
+// x-<something>-cache shape with a HIT-like value, is still detected. This is
+// the exact gap the reporter's fleet fell into - a real stack's cache-status
+// header name matched neither vendor list, so the OLD detectCacheHit would
+// have silently missed the HIT on exactly the setup that produced the bug.
+func TestDetectCacheHit_UnknownVendorShapeHeader(t *testing.T) {
+	cases := []struct {
+		name, header, value string
+	}{
+		{"x-<something>-cache shape", "X-Swarm-Cache", "HIT"},
+		{"x-cache-<something> shape", "X-Cache-Hits", "STALE"},
+		{"updating value", "X-Rocket-Cache", "UPDATING"},
+		{"revalidated value", "X-Edge-Cache", "REVALIDATED"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := http.Header{}
+			h.Set(tc.header, tc.value)
+			hit, detail := DetectCacheHit(h)
+			if !hit {
+				t.Fatalf("expected CacheHit=true for %s: %s, got hit=%v detail=%q", tc.header, tc.value, hit, detail)
+			}
+		})
+	}
+}
+
+// TestDetectCacheHit_ShapeRegexDoesNotFalsePositive proves the shape fallback
+// is not trigger-happy: an unrelated header (even one that merely contains
+// "cache" somewhere) and a shape-matching header with a MISS/BYPASS value
+// (the cache was NOT the source of the response - proof the bypass worked)
+// are both left undetected.
+func TestDetectCacheHit_ShapeRegexDoesNotFalsePositive(t *testing.T) {
+	cases := []struct {
+		name, header, value string
+	}{
+		{"unrelated header merely containing cache", "X-My-Cacheable-Widget", "HIT"},
+		{"shape match but MISS value", "X-Swarm-Cache", "MISS"},
+		{"shape match but BYPASS value", "X-Cache-Status", "BYPASS"},
+		{"shape match but DYNAMIC value", "X-Edge-Cache", "DYNAMIC"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := http.Header{}
+			h.Set(tc.header, tc.value)
+			hit, detail := DetectCacheHit(h)
+			if hit {
+				t.Fatalf("expected CacheHit=false for %s: %s, got hit=%v detail=%q", tc.header, tc.value, hit, detail)
+			}
+		})
+	}
+}
+
 // TestProbeGet_FatalSignatureStillDetectedAlongsideBuster proves the existing
 // fatal-error body scan is unaffected by the cache-buster/cache-hit additions.
 func TestProbeGet_FatalSignatureStillDetectedAlongsideBuster(t *testing.T) {

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -52860,9 +52860,21 @@ func (s *FleetUptimeStatusItem) encodeFields(e *jx.Encoder) {
 		e.FieldStart("health_status")
 		e.Str(s.HealthStatus)
 	}
+	{
+		if s.AppUp.Set {
+			e.FieldStart("app_up")
+			s.AppUp.Encode(e)
+		}
+	}
+	{
+		if s.AppProbeReason.Set {
+			e.FieldStart("app_probe_reason")
+			s.AppProbeReason.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfFleetUptimeStatusItem = [13]string{
+var jsonFieldsNameOfFleetUptimeStatusItem = [15]string{
 	0:  "site_id",
 	1:  "site_name",
 	2:  "site_url",
@@ -52876,6 +52888,8 @@ var jsonFieldsNameOfFleetUptimeStatusItem = [13]string{
 	10: "in_incident",
 	11: "connection_state",
 	12: "health_status",
+	13: "app_up",
+	14: "app_probe_reason",
 }
 
 // Decode decodes FleetUptimeStatusItem from json.
@@ -53032,6 +53046,26 @@ func (s *FleetUptimeStatusItem) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"health_status\"")
+			}
+		case "app_up":
+			if err := func() error {
+				s.AppUp.Reset()
+				if err := s.AppUp.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"app_up\"")
+			}
+		case "app_probe_reason":
+			if err := func() error {
+				s.AppProbeReason.Reset()
+				if err := s.AppProbeReason.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"app_probe_reason\"")
 			}
 		default:
 			return d.Skip()

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -18719,7 +18719,7 @@ type FleetUptimeStatusItem struct {
 	SiteURL  string                      `json:"site_url"`
 	Status   FleetUptimeStatusItemStatus `json:"status"`
 	// Short machine-readable explanation for status, populated when
-	// status=degraded (agent_unreachable, agent_degraded, or
+	// status=degraded (agent_unreachable, agent_degraded, app_down, or
 	// slow_response). Empty/absent when the status needs no further
 	// explanation.
 	StatusReason    OptString   `json:"status_reason"`
@@ -18731,6 +18731,20 @@ type FleetUptimeStatusItem struct {
 	InIncident      bool        `json:"in_incident"`
 	ConnectionState string      `json:"connection_state"`
 	HealthStatus    string      `json:"health_status"`
+	// GH #291 Phase 2 application-health verdict from the most recent
+	// app probe: true (WordPress responded), false (conclusively
+	// down), or absent/null (never probed, or the most recent probe
+	// was inconclusive; see app_probe_reason). Independent of `up`
+	// (the reachability signal, unchanged forever): a cached 200
+	// (up=true) can coexist with app_up=false when a page cache is
+	// masking a dead PHP backend.
+	AppUp OptNilBool `json:"app_up"`
+	// Machine-readable reason for the most recent app-health verdict
+	// (agent_fresh, rest_ok, rest_5xx, wp_fatal_error, cache_hit,
+	// rest_forbidden, rest_absent, rest_4xx, rest_non_json,
+	// unreachable, rest_unexpected). Empty when no app probe has run
+	// yet.
+	AppProbeReason OptString `json:"app_probe_reason"`
 }
 
 // GetSiteID returns the value of SiteID.
@@ -18798,6 +18812,16 @@ func (s *FleetUptimeStatusItem) GetHealthStatus() string {
 	return s.HealthStatus
 }
 
+// GetAppUp returns the value of AppUp.
+func (s *FleetUptimeStatusItem) GetAppUp() OptNilBool {
+	return s.AppUp
+}
+
+// GetAppProbeReason returns the value of AppProbeReason.
+func (s *FleetUptimeStatusItem) GetAppProbeReason() OptString {
+	return s.AppProbeReason
+}
+
 // SetSiteID sets the value of SiteID.
 func (s *FleetUptimeStatusItem) SetSiteID(val uuid.UUID) {
 	s.SiteID = val
@@ -18861,6 +18885,16 @@ func (s *FleetUptimeStatusItem) SetConnectionState(val string) {
 // SetHealthStatus sets the value of HealthStatus.
 func (s *FleetUptimeStatusItem) SetHealthStatus(val string) {
 	s.HealthStatus = val
+}
+
+// SetAppUp sets the value of AppUp.
+func (s *FleetUptimeStatusItem) SetAppUp(val OptNilBool) {
+	s.AppUp = val
+}
+
+// SetAppProbeReason sets the value of AppProbeReason.
+func (s *FleetUptimeStatusItem) SetAppProbeReason(val OptString) {
+	s.AppProbeReason = val
 }
 
 type FleetUptimeStatusItemStatus string

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -233,6 +233,24 @@ type UptimeConfig struct {
 	// CronKickConcurrency caps how many concurrent kicks fire per pass.
 	// Default 10. Env: WPMGR_CRON_KICK_CONCURRENCY.
 	CronKickConcurrency int `koanf:"cron_kick_concurrency"`
+
+	// AppProbeEnabled enables the GH #291 Phase 2 application-health probe
+	// (B0-B3, see internal/uptime/app_probe.go). Default true - the design
+	// is "measure and display from day one", with alerting (a later phase)
+	// staying opt-in separately. Set WPMGR_UPTIME_APP_PROBE_ENABLED=false to
+	// disable entirely (the reachability probe and everything it feeds are
+	// completely unaffected either way).
+	AppProbeEnabled bool `koanf:"app_probe_enabled"`
+	// AppProbeInterval is the desired app-probe cadence, piggybacked onto the
+	// existing reachability sweep via the stateless appProbeDue cadence
+	// check rather than its own periodic job. Default 300s (slower than the
+	// 60s reachability probe on purpose - see the design doc's "measure
+	// first" rollout notes). Env: WPMGR_UPTIME_APP_PROBE_INTERVAL.
+	AppProbeInterval time.Duration `koanf:"app_probe_interval"`
+	// AppProbeTimeout bounds a single app-probe HTTP attempt (B1, B2, or the
+	// B3 override - each gets its own timeout, not a combined one). Default
+	// 10s. Env: WPMGR_UPTIME_APP_PROBE_TIMEOUT.
+	AppProbeTimeout time.Duration `koanf:"app_probe_timeout"`
 }
 
 // S3Config holds the S3-compatible object-storage configuration (ADR-010).
@@ -564,6 +582,9 @@ func defaults() map[string]any {
 		"uptime.cron_kick_interval":         "5m",
 		"uptime.cron_kick_timeout":          "5s",
 		"uptime.cron_kick_concurrency":      10,
+		"uptime.app_probe_enabled":          true,
+		"uptime.app_probe_interval":         "300s",
+		"uptime.app_probe_timeout":          "10s",
 		"river.media_schema":                "media_encoder",
 		"autologin.require_2fa_step_up":     false,
 		"conn.degrade_after":                "300s",

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -596,6 +596,7 @@ type Site struct {
 	ArchivedAt            pgtype.Timestamptz `json:"archived_at"`
 	MissedHeartbeats      int32              `json:"missed_heartbeats"`
 	ClientID              pgtype.UUID        `json:"client_id"`
+	AppProbePath          *string            `json:"app_probe_path"`
 	CreatedAt             time.Time          `json:"created_at"`
 	UpdatedAt             time.Time          `json:"updated_at"`
 }
@@ -1023,34 +1024,41 @@ type SiteUptimeDaily struct {
 	TotalChecks    int32       `json:"total_checks"`
 	SumLatencyMs   float64     `json:"sum_latency_ms"`
 	LatencySamples int32       `json:"latency_samples"`
+	AppUpChecks    *int32      `json:"app_up_checks"`
+	AppTotalChecks *int32      `json:"app_total_checks"`
 	UpdatedAt      time.Time   `json:"updated_at"`
 }
 
 type SiteUptimeProbe struct {
-	ID         uuid.UUID          `json:"id"`
-	TenantID   uuid.UUID          `json:"tenant_id"`
-	SiteID     uuid.UUID          `json:"site_id"`
-	ProbedAt   time.Time          `json:"probed_at"`
-	Up         bool               `json:"up"`
-	HttpStatus int32              `json:"http_status"`
-	DnsMs      float64            `json:"dns_ms"`
-	ConnectMs  float64            `json:"connect_ms"`
-	TlsMs      float64            `json:"tls_ms"`
-	TtfbMs     float64            `json:"ttfb_ms"`
-	TotalMs    float64            `json:"total_ms"`
-	TlsExpiry  pgtype.Timestamptz `json:"tls_expiry"`
-	TlsIssuer  string             `json:"tls_issuer"`
-	TlsSubject string             `json:"tls_subject"`
-	ErrorText  string             `json:"error_text"`
+	ID             uuid.UUID          `json:"id"`
+	TenantID       uuid.UUID          `json:"tenant_id"`
+	SiteID         uuid.UUID          `json:"site_id"`
+	ProbedAt       time.Time          `json:"probed_at"`
+	Up             bool               `json:"up"`
+	HttpStatus     int32              `json:"http_status"`
+	DnsMs          float64            `json:"dns_ms"`
+	ConnectMs      float64            `json:"connect_ms"`
+	TlsMs          float64            `json:"tls_ms"`
+	TtfbMs         float64            `json:"ttfb_ms"`
+	TotalMs        float64            `json:"total_ms"`
+	TlsExpiry      pgtype.Timestamptz `json:"tls_expiry"`
+	TlsIssuer      string             `json:"tls_issuer"`
+	TlsSubject     string             `json:"tls_subject"`
+	ErrorText      string             `json:"error_text"`
+	AppUp          *bool              `json:"app_up"`
+	AppProbeReason *string            `json:"app_probe_reason"`
 }
 
 type SiteUptimeStatus struct {
-	SiteID       uuid.UUID          `json:"site_id"`
-	TenantID     uuid.UUID          `json:"tenant_id"`
-	LatestUp     bool               `json:"latest_up"`
-	LastProbedAt time.Time          `json:"last_probed_at"`
-	TlsExpiry    pgtype.Timestamptz `json:"tls_expiry"`
-	UpdatedAt    time.Time          `json:"updated_at"`
+	SiteID          uuid.UUID          `json:"site_id"`
+	TenantID        uuid.UUID          `json:"tenant_id"`
+	LatestUp        bool               `json:"latest_up"`
+	LastProbedAt    time.Time          `json:"last_probed_at"`
+	TlsExpiry       pgtype.Timestamptz `json:"tls_expiry"`
+	LatestAppUp     *bool              `json:"latest_app_up"`
+	AppProbeReason  *string            `json:"app_probe_reason"`
+	LastAppProbedAt pgtype.Timestamptz `json:"last_app_probed_at"`
+	UpdatedAt       time.Time          `json:"updated_at"`
 }
 
 type SiteVulnerability struct {
@@ -1274,4 +1282,22 @@ type WordfenceVulnSoftware struct {
 	AffectedVersions []byte `json:"affected_versions"`
 	Patched          bool   `json:"patched"`
 	PatchedVersions  []byte `json:"patched_versions"`
+}
+
+type WporgPluginChecksum struct {
+	Kind      string    `json:"kind"`
+	Slug      string    `json:"slug"`
+	Version   string    `json:"version"`
+	Path      string    `json:"path"`
+	Md5       string    `json:"md5"`
+	Sha256    *string   `json:"sha256"`
+	FetchedAt time.Time `json:"fetched_at"`
+}
+
+type WporgPluginChecksumsMetum struct {
+	Kind      string    `json:"kind"`
+	Slug      string    `json:"slug"`
+	Version   string    `json:"version"`
+	FetchedAt time.Time `json:"fetched_at"`
+	Ok        bool      `json:"ok"`
 }

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -1314,6 +1314,10 @@ type Querier interface {
 	// Cross-tenant enumeration of enrolled sites WITH their URL for the M5 uptime
 	// probe job. Runs under the app.agent GUC (sites_agent policy) since it spans
 	// tenants. Only enrolled sites have an agent URL worth probing.
+	// last_seen_at and app_probe_path (m107, GH #291 Phase 2) are carried for the
+	// application-health prober: B0 (agent ground truth) reads last_seen_at, B3
+	// (per-site override) reads app_probe_path. The reachability probe and the
+	// cron-kicker ignore both.
 	ListEnrolledSitesForProbe(ctx context.Context) ([]ListEnrolledSitesForProbeRow, error)
 	// Completed snapshots older than the cutoff that are NOT archive-retained, in a
 	// single tenant scope. The GC job decrements chunk refcounts for each then

--- a/apps/api/internal/db/sqlc/site_connection.sql.go
+++ b/apps/api/internal/db/sqlc/site_connection.sql.go
@@ -20,7 +20,7 @@ SET connection_state = 'archived',
     archived_at      = now(),
     updated_at       = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at
 `
 
 type ArchiveSiteParams struct {
@@ -65,6 +65,7 @@ func (q *Queries) ArchiveSite(ctx context.Context, arg ArchiveSiteParams) (Site,
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -85,7 +86,7 @@ SET agent_public_key = $3,
     php_version      = $5,
     updated_at       = now()
 WHERE id = $1 AND tenant_id = $2 AND connection_state = 'pending_enrollment'
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at
 `
 
 type AttachAgentAndConnectParams struct {
@@ -147,6 +148,7 @@ func (q *Queries) AttachAgentAndConnect(ctx context.Context, arg AttachAgentAndC
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -161,7 +163,7 @@ SET connection_state = 'pending_enrollment',
     connection_generation = connection_generation + 1,
     updated_at       = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at
 `
 
 type BeginSiteReEnrollmentParams struct {
@@ -207,6 +209,7 @@ func (q *Queries) BeginSiteReEnrollment(ctx context.Context, arg BeginSiteReEnro
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -216,7 +219,7 @@ func (q *Queries) BeginSiteReEnrollment(ctx context.Context, arg BeginSiteReEnro
 const createPendingSite = `-- name: CreatePendingSite :one
 INSERT INTO sites (tenant_id, url, name, status, connection_state, tags)
 VALUES ($1, $2, $3, 'pending', 'pending_enrollment', $4)
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at
 `
 
 type CreatePendingSiteParams struct {
@@ -269,6 +272,7 @@ func (q *Queries) CreatePendingSite(ctx context.Context, arg CreatePendingSitePa
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -359,7 +363,7 @@ func (q *Queries) GetSiteEvent(ctx context.Context, arg GetSiteEventParams) (Sit
 const getSiteForTransition = `-- name: GetSiteForTransition :one
 
 
-SELECT id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at FROM sites
+SELECT id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at FROM sites
 WHERE id = $1 AND tenant_id = $2
 FOR UPDATE
 `
@@ -415,6 +419,7 @@ func (q *Queries) GetSiteForTransition(ctx context.Context, arg GetSiteForTransi
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -684,7 +689,7 @@ SET connection_state   = 'connected',
     disconnected_reason = NULL,
     updated_at         = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at
 `
 
 type MarkSiteConnectedParams struct {
@@ -735,6 +740,7 @@ func (q *Queries) MarkSiteConnected(ctx context.Context, arg MarkSiteConnectedPa
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -747,7 +753,7 @@ SET connection_state = 'degraded',
     health_status    = 'unreachable',
     updated_at       = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at
 `
 
 type MarkSiteDegradedParams struct {
@@ -791,6 +797,7 @@ func (q *Queries) MarkSiteDegraded(ctx context.Context, arg MarkSiteDegradedPara
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -806,7 +813,7 @@ SET connection_state    = 'disconnected',
     disconnected_reason = $3,
     updated_at          = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at
 `
 
 type MarkSiteDisconnectedParams struct {
@@ -852,6 +859,7 @@ func (q *Queries) MarkSiteDisconnected(ctx context.Context, arg MarkSiteDisconne
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -867,7 +875,7 @@ SET connection_state    = 'revoked',
     disconnected_reason = $3,
     updated_at          = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at
 `
 
 type MarkSiteRevokedParams struct {
@@ -917,6 +925,7 @@ func (q *Queries) MarkSiteRevoked(ctx context.Context, arg MarkSiteRevokedParams
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -1009,7 +1018,7 @@ SET connection_state = 'disconnected',
     archived_at      = NULL,
     updated_at       = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at
 `
 
 type RestoreSiteParams struct {
@@ -1053,6 +1062,7 @@ func (q *Queries) RestoreSite(ctx context.Context, arg RestoreSiteParams) (Site,
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -1066,7 +1076,7 @@ SET last_seen_at      = now(),
     missed_heartbeats = 0,
     updated_at        = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at
 `
 
 type TouchSiteHeartbeatParams struct {
@@ -1118,6 +1128,7 @@ func (q *Queries) TouchSiteHeartbeat(ctx context.Context, arg TouchSiteHeartbeat
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/apps/api/internal/db/sqlc/sites.sql.go
+++ b/apps/api/internal/db/sqlc/sites.sql.go
@@ -24,7 +24,7 @@ SET agent_public_key = $3,
     php_version = $5,
     updated_at = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at
 `
 
 type AttachAgentToSiteParams struct {
@@ -77,6 +77,7 @@ func (q *Queries) AttachAgentToSite(ctx context.Context, arg AttachAgentToSitePa
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -86,7 +87,7 @@ func (q *Queries) AttachAgentToSite(ctx context.Context, arg AttachAgentToSitePa
 const createSite = `-- name: CreateSite :one
 INSERT INTO sites (tenant_id, url, name, status, wp_version, php_version)
 VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at
 `
 
 type CreateSiteParams struct {
@@ -142,6 +143,7 @@ func (q *Queries) CreateSite(ctx context.Context, arg CreateSiteParams) (Site, e
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -152,7 +154,7 @@ const createSiteForEnroll = `-- name: CreateSiteForEnroll :one
 INSERT INTO sites (tenant_id, url, name, status, wp_version, php_version,
                    agent_public_key, enrolled_at, last_seen_at, health_status, tags)
 VALUES ($1, $2, $3, 'active', $4, $5, $6, now(), now(), 'healthy', $7)
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at
 `
 
 type CreateSiteForEnrollParams struct {
@@ -208,6 +210,7 @@ func (q *Queries) CreateSiteForEnroll(ctx context.Context, arg CreateSiteForEnro
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -233,7 +236,7 @@ func (q *Queries) DeleteSite(ctx context.Context, arg DeleteSiteParams) (int64, 
 }
 
 const getSite = `-- name: GetSite :one
-SELECT s.id, s.tenant_id, s.url, s.name, s.status, s.wp_version, s.php_version, s.agent_version, s.agent_public_key, s.enrolled_at, s.last_seen_at, s.health_status, s.server_info, s.multisite, s.active_theme, s.components, s.tags, s.age_recipient, s.wp_timezone, s.wp_gmt_offset, s.host_provider, s.host_provider_org, s.host_provider_ip, s.host_provider_checked_at, s.connection_state, s.connection_generation, s.disconnected_at, s.disconnected_reason, s.archived_at, s.missed_heartbeats, s.client_id, s.created_at, s.updated_at,
+SELECT s.id, s.tenant_id, s.url, s.name, s.status, s.wp_version, s.php_version, s.agent_version, s.agent_public_key, s.enrolled_at, s.last_seen_at, s.health_status, s.server_info, s.multisite, s.active_theme, s.components, s.tags, s.age_recipient, s.wp_timezone, s.wp_gmt_offset, s.host_provider, s.host_provider_org, s.host_provider_ip, s.host_provider_checked_at, s.connection_state, s.connection_generation, s.disconnected_at, s.disconnected_reason, s.archived_at, s.missed_heartbeats, s.client_id, s.app_probe_path, s.created_at, s.updated_at,
        COALESCE(pc.cache_enabled, false) AS page_cache_enabled,
        COALESCE(oc.enabled, false) AS object_cache_enabled
 FROM sites s
@@ -281,6 +284,7 @@ type GetSiteRow struct {
 	ArchivedAt            pgtype.Timestamptz `json:"archived_at"`
 	MissedHeartbeats      int32              `json:"missed_heartbeats"`
 	ClientID              pgtype.UUID        `json:"client_id"`
+	AppProbePath          *string            `json:"app_probe_path"`
 	CreatedAt             time.Time          `json:"created_at"`
 	UpdatedAt             time.Time          `json:"updated_at"`
 	PageCacheEnabled      bool               `json:"page_cache_enabled"`
@@ -330,6 +334,7 @@ func (q *Queries) GetSite(ctx context.Context, arg GetSiteParams) (GetSiteRow, e
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.PageCacheEnabled,
@@ -340,7 +345,7 @@ func (q *Queries) GetSite(ctx context.Context, arg GetSiteParams) (GetSiteRow, e
 
 const getSiteByAgentKey = `-- name: GetSiteByAgentKey :one
 
-SELECT id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at FROM sites
+SELECT id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at FROM sites
 WHERE agent_public_key = $1 AND agent_public_key <> ''
 `
 
@@ -382,6 +387,7 @@ func (q *Queries) GetSiteByAgentKey(ctx context.Context, agentPublicKey string) 
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -390,7 +396,7 @@ func (q *Queries) GetSiteByAgentKey(ctx context.Context, agentPublicKey string) 
 
 const getSiteByURLForEnroll = `-- name: GetSiteByURLForEnroll :one
 
-SELECT id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at FROM sites
+SELECT id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at FROM sites
 WHERE tenant_id = $1 AND url = $2
 `
 
@@ -437,6 +443,7 @@ func (q *Queries) GetSiteByURLForEnroll(ctx context.Context, arg GetSiteByURLFor
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -596,20 +603,26 @@ func (q *Queries) ListEnrolledSitesAllTenants(ctx context.Context) ([]ListEnroll
 }
 
 const listEnrolledSitesForProbe = `-- name: ListEnrolledSitesForProbe :many
-SELECT id, tenant_id, url, health_status FROM sites
+SELECT id, tenant_id, url, health_status, last_seen_at, app_probe_path FROM sites
 WHERE enrolled_at IS NOT NULL
 `
 
 type ListEnrolledSitesForProbeRow struct {
-	ID           uuid.UUID `json:"id"`
-	TenantID     uuid.UUID `json:"tenant_id"`
-	Url          string    `json:"url"`
-	HealthStatus string    `json:"health_status"`
+	ID           uuid.UUID          `json:"id"`
+	TenantID     uuid.UUID          `json:"tenant_id"`
+	Url          string             `json:"url"`
+	HealthStatus string             `json:"health_status"`
+	LastSeenAt   pgtype.Timestamptz `json:"last_seen_at"`
+	AppProbePath *string            `json:"app_probe_path"`
 }
 
 // Cross-tenant enumeration of enrolled sites WITH their URL for the M5 uptime
 // probe job. Runs under the app.agent GUC (sites_agent policy) since it spans
 // tenants. Only enrolled sites have an agent URL worth probing.
+// last_seen_at and app_probe_path (m107, GH #291 Phase 2) are carried for the
+// application-health prober: B0 (agent ground truth) reads last_seen_at, B3
+// (per-site override) reads app_probe_path. The reachability probe and the
+// cron-kicker ignore both.
 func (q *Queries) ListEnrolledSitesForProbe(ctx context.Context) ([]ListEnrolledSitesForProbeRow, error) {
 	rows, err := q.db.Query(ctx, listEnrolledSitesForProbe)
 	if err != nil {
@@ -624,6 +637,8 @@ func (q *Queries) ListEnrolledSitesForProbe(ctx context.Context) ([]ListEnrolled
 			&i.TenantID,
 			&i.Url,
 			&i.HealthStatus,
+			&i.LastSeenAt,
+			&i.AppProbePath,
 		); err != nil {
 			return nil, err
 		}
@@ -685,7 +700,7 @@ func (q *Queries) ListLatestBackupsForSites(ctx context.Context, arg ListLatestB
 }
 
 const listSites = `-- name: ListSites :many
-SELECT s.id, s.tenant_id, s.url, s.name, s.status, s.wp_version, s.php_version, s.agent_version, s.agent_public_key, s.enrolled_at, s.last_seen_at, s.health_status, s.server_info, s.multisite, s.active_theme, s.components, s.tags, s.age_recipient, s.wp_timezone, s.wp_gmt_offset, s.host_provider, s.host_provider_org, s.host_provider_ip, s.host_provider_checked_at, s.connection_state, s.connection_generation, s.disconnected_at, s.disconnected_reason, s.archived_at, s.missed_heartbeats, s.client_id, s.created_at, s.updated_at,
+SELECT s.id, s.tenant_id, s.url, s.name, s.status, s.wp_version, s.php_version, s.agent_version, s.agent_public_key, s.enrolled_at, s.last_seen_at, s.health_status, s.server_info, s.multisite, s.active_theme, s.components, s.tags, s.age_recipient, s.wp_timezone, s.wp_gmt_offset, s.host_provider, s.host_provider_org, s.host_provider_ip, s.host_provider_checked_at, s.connection_state, s.connection_generation, s.disconnected_at, s.disconnected_reason, s.archived_at, s.missed_heartbeats, s.client_id, s.app_probe_path, s.created_at, s.updated_at,
        COALESCE(pc.cache_enabled, false) AS page_cache_enabled,
        COALESCE(oc.enabled, false) AS object_cache_enabled
 FROM sites s
@@ -747,6 +762,7 @@ type ListSitesRow struct {
 	ArchivedAt            pgtype.Timestamptz `json:"archived_at"`
 	MissedHeartbeats      int32              `json:"missed_heartbeats"`
 	ClientID              pgtype.UUID        `json:"client_id"`
+	AppProbePath          *string            `json:"app_probe_path"`
 	CreatedAt             time.Time          `json:"created_at"`
 	UpdatedAt             time.Time          `json:"updated_at"`
 	PageCacheEnabled      bool               `json:"page_cache_enabled"`
@@ -814,6 +830,7 @@ func (q *Queries) ListSites(ctx context.Context, arg ListSitesParams) ([]ListSit
 			&i.ArchivedAt,
 			&i.MissedHeartbeats,
 			&i.ClientID,
+			&i.AppProbePath,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.PageCacheEnabled,
@@ -848,7 +865,7 @@ const setSiteAgeRecipient = `-- name: SetSiteAgeRecipient :one
 UPDATE sites
 SET age_recipient = $3, updated_at = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at
 `
 
 type SetSiteAgeRecipientParams struct {
@@ -894,6 +911,7 @@ func (q *Queries) SetSiteAgeRecipient(ctx context.Context, arg SetSiteAgeRecipie
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -925,7 +943,7 @@ const setSiteTags = `-- name: SetSiteTags :one
 UPDATE sites
 SET tags = $3, updated_at = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at
 `
 
 type SetSiteTagsParams struct {
@@ -969,6 +987,7 @@ func (q *Queries) SetSiteTags(ctx context.Context, arg SetSiteTagsParams) (Site,
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -981,7 +1000,7 @@ SET last_seen_at = now(),
     health_status = 'healthy',
     updated_at = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at
 `
 
 type TouchSiteSeenParams struct {
@@ -1024,6 +1043,7 @@ func (q *Queries) TouchSiteSeen(ctx context.Context, arg TouchSiteSeenParams) (S
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -1043,7 +1063,7 @@ SET wp_version   = $3,
     health_status = 'healthy',
     updated_at   = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, created_at, updated_at
 `
 
 type UpdateSiteMetadataParams struct {
@@ -1105,6 +1125,7 @@ func (q *Queries) UpdateSiteMetadata(ctx context.Context, arg UpdateSiteMetadata
 		&i.ArchivedAt,
 		&i.MissedHeartbeats,
 		&i.ClientID,
+		&i.AppProbePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/apps/api/internal/metrics/metrics.go
+++ b/apps/api/internal/metrics/metrics.go
@@ -55,6 +55,25 @@ type Check struct {
 	// TLSSubject is the leaf certificate subject CommonName. Empty when not HTTPS.
 	TLSSubject string
 	Error      string
+	// AppUp is the GH #291 Phase 2 application-health verdict (three-valued:
+	// true / false / nil=unknown), piggybacked onto whichever reachability
+	// Check this sweep tick also attempted an app probe for - see
+	// uptime.ProbeWorker.Sweep / appProbeDue. nil means "no app probe was
+	// attempted on THIS check" (the common case: the app probe runs on a
+	// slower cadence than the reachability probe), which is a DIFFERENT
+	// meaning than "attempted, verdict unknown" - see AppProbeReason, which
+	// disambiguates the two. Orthogonal to Up: never derived from it, never
+	// feeds site_uptime_probes.up / site_uptime_daily's up_checks /
+	// total_checks / site_uptime_status.latest_up.
+	AppUp *bool
+	// AppProbeReason is the machine-readable reason for AppUp's verdict (one
+	// of the AppProbeReason* constants in package uptime - this package does
+	// not import that one, to avoid a cross-domain dependency for a handful
+	// of string constants). Empty means "no app probe was attempted on this
+	// check" - the sentinel every write path (InsertChecks, UpsertRollup)
+	// uses to tell that apart from "attempted, verdict unknown" (a non-empty
+	// reason with a nil AppUp).
+	AppProbeReason string
 }
 
 // Aggregate is the windowed uptime summary for a single site.
@@ -114,6 +133,16 @@ type FleetUptimeRow struct {
 	AvgLatencyMs *float64
 	// TLSExpiry is the cert NotAfter from the most-recent probe (nil = non-HTTPS or no probes).
 	TLSExpiry *time.Time
+	// AppUp is the GH #291 Phase 2 application-health verdict from the most
+	// recent app probe: true, false, or nil (never probed, or the most
+	// recent probe was inconclusive - see AppProbeReason). Independent of Up:
+	// a cached 200 (Up=true) can coexist with AppUp=false when a page cache
+	// is masking a dead PHP backend - the literal GH #291 incident.
+	AppUp *bool
+	// AppProbeReason is the machine-readable reason for AppUp's most recent
+	// verdict (one of package uptime's AppProbeReason* constants). Empty
+	// when no app probe has run yet.
+	AppProbeReason string
 }
 
 // Store is the uptime metrics store contract. Backends implement it for
@@ -206,6 +235,30 @@ var uptimeChecksColumns = []uptimeChecksColumn{
 	{"total_ms", "Float64"},
 	{"tls_expiry", "DateTime"},
 	{"error", "String"},
+	// m107 (GH #291 Phase 2). This table has no Nullable column anywhere else
+	// (tls_expiry uses the chTime epoch-0 sentinel instead), so app_up
+	// follows that same convention rather than introducing the first
+	// Nullable(...) column: Int8 with -1 = unknown/not-probed-this-row,
+	// 1 = true, 0 = false. See chAppUp / the Check.AppUp doc comment for why
+	// "not probed this row" and "probed, verdict unknown" are both -1 here -
+	// unlike the Postgres side, ClickHouse's uptime_checks has no separate
+	// rollup-status table where that distinction matters for a COALESCE
+	// guard, so collapsing them is safe.
+	{"app_up", "Int8"},
+	{"app_probe_reason", "String"},
+}
+
+// chAppUp maps a Check.AppUp tri-state onto the Int8 sentinel scheme
+// uptime_checks.app_up uses (see uptimeChecksColumns): -1 unknown/not
+// probed, 1 true, 0 false.
+func chAppUp(v *bool) int8 {
+	if v == nil {
+		return -1
+	}
+	if *v {
+		return 1
+	}
+	return 0
 }
 
 // New connects to ClickHouse and ensures the schema exists. When cfg.Addr is
@@ -420,7 +473,8 @@ func (s *chStore) InsertChecks(ctx context.Context, checks []Check) error {
 		}
 		// Append order must match uptimeChecksColumns / columnNames above
 		// exactly: checked_at, tenant_id, site_id, up, http_status, dns_ms,
-		// connect_ms, tls_ms, ttfb_ms, total_ms, tls_expiry, error.
+		// connect_ms, tls_ms, ttfb_ms, total_ms, tls_expiry, error, app_up,
+		// app_probe_reason.
 		if err := batch.Append(
 			chTime(c.CheckedAt),
 			c.TenantID,
@@ -434,6 +488,8 @@ func (s *chStore) InsertChecks(ctx context.Context, checks []Check) error {
 			c.TotalMs,
 			chTime(c.TLSExpiry),
 			c.Error,
+			chAppUp(c.AppUp),
+			c.AppProbeReason,
 		); err != nil {
 			_ = batch.Abort()
 			return fmt.Errorf("clickhouse append row: %w", err)
@@ -524,21 +580,52 @@ func (s *chStore) QueryFleetUptime(ctx context.Context, tenantID uuid.UUID, site
 		return map[uuid.UUID]FleetUptimeRow{}, nil
 	}
 	since := time.Now().Add(-window)
+	// GH #291 Phase 2: the "latest app verdict" is joined from a SEPARATE
+	// subquery, pre-filtered to app_probe_reason != '' (a real app-probe
+	// attempt), rather than argMax'd in the same GROUP BY as the
+	// reachability aggregate above. The app probe runs on a slower cadence
+	// than the reachability probe this table's grain follows, so most rows
+	// in the window never attempted one - an unfiltered
+	// argMax(app_up, checked_at) would almost always resolve to the
+	// "not probed this row" sentinel from the globally-latest row even when
+	// a real verdict exists a few rows earlier. Both app_up and
+	// app_probe_reason are explicitly cast toNullable(...) so an unmatched
+	// site (never app-probed) reads back as a real SQL NULL from the LEFT
+	// JOIN regardless of the server's join_use_nulls setting, which a plain
+	// (non-Nullable) column's join-fill behavior does not guarantee.
 	rows, err := s.conn.Query(ctx, fmt.Sprintf(`
 SELECT
-    site_id,
-    argMax(up,        checked_at) AS latest_up,
-    max(checked_at)               AS latest_at,
-    argMax(tls_expiry, checked_at) AS latest_tls,
-    count()                        AS checks,
-    sum(up)                        AS up_checks,
-    avgOrNullIf(total_ms, up = 1)  AS avg_latency
-FROM %s.uptime_checks
-WHERE tenant_id = ?
-  AND site_id IN ?
-  AND checked_at >= ?
-GROUP BY site_id`, s.db),
-		tenantID, siteIDs, chTime(since))
+    r.site_id,
+    r.latest_up, r.latest_at, r.latest_tls, r.checks, r.up_checks, r.avg_latency,
+    a.latest_app_up, a.latest_app_reason
+FROM (
+    SELECT
+        site_id,
+        argMax(up,        checked_at) AS latest_up,
+        max(checked_at)               AS latest_at,
+        argMax(tls_expiry, checked_at) AS latest_tls,
+        count()                        AS checks,
+        sum(up)                        AS up_checks,
+        avgOrNullIf(total_ms, up = 1)  AS avg_latency
+    FROM %[1]s.uptime_checks
+    WHERE tenant_id = ?
+      AND site_id IN ?
+      AND checked_at >= ?
+    GROUP BY site_id
+) r
+LEFT JOIN (
+    SELECT
+        site_id,
+        toNullable(argMax(app_up,           checked_at)) AS latest_app_up,
+        toNullable(argMax(app_probe_reason, checked_at)) AS latest_app_reason
+    FROM %[1]s.uptime_checks
+    WHERE tenant_id = ?
+      AND site_id IN ?
+      AND checked_at >= ?
+      AND app_probe_reason != ''
+    GROUP BY site_id
+) a ON a.site_id = r.site_id`, s.db),
+		tenantID, siteIDs, chTime(since), tenantID, siteIDs, chTime(since))
 	if err != nil {
 		return nil, fmt.Errorf("clickhouse fleet uptime query: %w", err)
 	}
@@ -547,15 +634,17 @@ GROUP BY site_id`, s.db),
 	out := make(map[uuid.UUID]FleetUptimeRow, len(siteIDs))
 	for rows.Next() {
 		var (
-			siteID     uuid.UUID
-			latestUpU  uint8
-			latestAt   time.Time
-			latestTLS  time.Time
-			checks     uint64
-			upChecks   uint64
-			avgLatency *float64
+			siteID          uuid.UUID
+			latestUpU       uint8
+			latestAt        time.Time
+			latestTLS       time.Time
+			checks          uint64
+			upChecks        uint64
+			avgLatency      *float64
+			latestAppUp     *int8
+			latestAppReason *string
 		)
-		if err := rows.Scan(&siteID, &latestUpU, &latestAt, &latestTLS, &checks, &upChecks, &avgLatency); err != nil {
+		if err := rows.Scan(&siteID, &latestUpU, &latestAt, &latestTLS, &checks, &upChecks, &avgLatency, &latestAppUp, &latestAppReason); err != nil {
 			return nil, fmt.Errorf("clickhouse fleet uptime scan: %w", err)
 		}
 		row := FleetUptimeRow{}
@@ -575,6 +664,13 @@ GROUP BY site_id`, s.db),
 		}
 		if avgLatency != nil {
 			row.AvgLatencyMs = avgLatency
+		}
+		if latestAppReason != nil && *latestAppReason != "" {
+			row.AppProbeReason = *latestAppReason
+			if latestAppUp != nil && *latestAppUp != -1 {
+				b := *latestAppUp == 1
+				row.AppUp = &b
+			}
 		}
 		out[siteID] = row
 	}

--- a/apps/api/internal/metrics/postgres.go
+++ b/apps/api/internal/metrics/postgres.go
@@ -57,8 +57,8 @@ func (s *pgStore) InsertChecks(ctx context.Context, checks []Check) error {
 		for _, c := range checks {
 			batch.Queue(`INSERT INTO site_uptime_probes
 (tenant_id, site_id, probed_at, up, http_status, dns_ms, connect_ms, tls_ms, ttfb_ms, total_ms,
- tls_expiry, tls_issuer, tls_subject, error_text)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+ tls_expiry, tls_issuer, tls_subject, error_text, app_up, app_probe_reason)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
 				c.TenantID,
 				c.SiteID,
 				ifZeroNow(c.CheckedAt),
@@ -73,6 +73,11 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
 				c.TLSIssuer,
 				c.TLSSubject,
 				c.Error,
+				// GH #291 Phase 2: nil/empty on every check the app probe did
+				// not attempt this row - see the Check.AppUp/AppProbeReason
+				// doc comments.
+				c.AppUp,
+				nullableString(c.AppProbeReason),
 			)
 		}
 		br := tx.SendBatch(ctx, batch)
@@ -117,6 +122,30 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
 // doc comment describes for alert state, applied here to the status stamp.
 // site_uptime_daily's counters need no such guard: addition is commutative,
 // so two overlapping sweeps' increments land correctly regardless of order.
+//
+// GH #291 Phase 2 (app health) rides the SAME two upserts as separate
+// columns - never a second row/statement - guarded independently of the
+// reachability fields above:
+//
+//   - site_uptime_daily.app_up_checks / app_total_checks are additive, same
+//     as up_checks/total_checks, but COALESCE(existing, 0) on the LEFT side
+//     of the addition: these columns are nullable with no default (m107), so
+//     a pre-migration or never-app-probed row reads NULL, and NULL + n is
+//     NULL in SQL, not n.
+//   - site_uptime_status.latest_app_up / app_probe_reason / last_app_probed_at
+//     are POINT-IN-TIME snapshots, not additive, so they need a different
+//     guard: the app probe runs on a slower cadence than the reachability
+//     probe (default 300s vs 60s), so ~4 of every 5 calls into this function
+//     carry a Check with AppProbeReason == "" (no app probe attempted this
+//     row). A plain "latest_app_up = EXCLUDED.latest_app_up" would clobber a
+//     known value with NULL on those calls. The guard is keyed on
+//     app_probe_reason being NON-NULL (i.e. THIS check actually attempted an
+//     app probe, including a conclusive "unknown" verdict), not on
+//     latest_app_up being non-NULL - latest_app_up is NULL both when "not
+//     attempted this check" AND when "attempted, verdict unknown", and only
+//     the reason-is-non-null test can tell those apart. This is why
+//     AppProbeReason's "" sentinel exists and why nullableString is used
+//     instead of always writing a string.
 func (s *pgStore) UpsertRollup(ctx context.Context, checks []Check) error {
 	if len(checks) == 0 {
 		return nil
@@ -138,29 +167,47 @@ func (s *pgStore) UpsertRollup(ctx context.Context, checks []Check) error {
 				latencySample = 1
 			}
 
+			// appTotalInc counts every app-probe ATTEMPT this check made
+			// (including an inconclusive "unknown" verdict); appUpInc counts
+			// only a conclusive true verdict. Both are 0 when AppProbeReason
+			// is empty (no attempt this check).
+			var appTotalInc, appUpInc int32
+			if c.AppProbeReason != "" {
+				appTotalInc = 1
+				if c.AppUp != nil && *c.AppUp {
+					appUpInc = 1
+				}
+			}
+
 			batch.Queue(`INSERT INTO site_uptime_daily
-(tenant_id, site_id, day, up_checks, total_checks, sum_latency_ms, latency_samples)
-VALUES ($1, $2, $3, $4, 1, $5, $6)
+(tenant_id, site_id, day, up_checks, total_checks, sum_latency_ms, latency_samples, app_up_checks, app_total_checks)
+VALUES ($1, $2, $3, $4, 1, $5, $6, $7, $8)
 ON CONFLICT (site_id, day) DO UPDATE SET
-    up_checks       = site_uptime_daily.up_checks + EXCLUDED.up_checks,
-    total_checks    = site_uptime_daily.total_checks + EXCLUDED.total_checks,
-    sum_latency_ms  = site_uptime_daily.sum_latency_ms + EXCLUDED.sum_latency_ms,
-    latency_samples = site_uptime_daily.latency_samples + EXCLUDED.latency_samples,
-    updated_at      = now()`,
-				c.TenantID, c.SiteID, day, upInc, latencyMs, latencySample,
+    up_checks        = site_uptime_daily.up_checks + EXCLUDED.up_checks,
+    total_checks     = site_uptime_daily.total_checks + EXCLUDED.total_checks,
+    sum_latency_ms   = site_uptime_daily.sum_latency_ms + EXCLUDED.sum_latency_ms,
+    latency_samples  = site_uptime_daily.latency_samples + EXCLUDED.latency_samples,
+    app_up_checks    = COALESCE(site_uptime_daily.app_up_checks, 0) + EXCLUDED.app_up_checks,
+    app_total_checks = COALESCE(site_uptime_daily.app_total_checks, 0) + EXCLUDED.app_total_checks,
+    updated_at       = now()`,
+				c.TenantID, c.SiteID, day, upInc, latencyMs, latencySample, appUpInc, appTotalInc,
 			)
 
 			batch.Queue(`INSERT INTO site_uptime_status
-(site_id, tenant_id, latest_up, last_probed_at, tls_expiry, updated_at)
-VALUES ($1, $2, $3, $4, $5, now())
+(site_id, tenant_id, latest_up, last_probed_at, tls_expiry, latest_app_up, app_probe_reason, last_app_probed_at, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
 ON CONFLICT (site_id) DO UPDATE SET
-    tenant_id      = EXCLUDED.tenant_id,
-    latest_up      = EXCLUDED.latest_up,
-    last_probed_at = EXCLUDED.last_probed_at,
-    tls_expiry     = EXCLUDED.tls_expiry,
-    updated_at     = now()
+    tenant_id          = EXCLUDED.tenant_id,
+    latest_up          = EXCLUDED.latest_up,
+    last_probed_at     = EXCLUDED.last_probed_at,
+    tls_expiry         = EXCLUDED.tls_expiry,
+    latest_app_up      = CASE WHEN EXCLUDED.app_probe_reason IS NOT NULL THEN EXCLUDED.latest_app_up ELSE site_uptime_status.latest_app_up END,
+    app_probe_reason   = CASE WHEN EXCLUDED.app_probe_reason IS NOT NULL THEN EXCLUDED.app_probe_reason ELSE site_uptime_status.app_probe_reason END,
+    last_app_probed_at = CASE WHEN EXCLUDED.app_probe_reason IS NOT NULL THEN EXCLUDED.last_app_probed_at ELSE site_uptime_status.last_app_probed_at END,
+    updated_at         = now()
 WHERE EXCLUDED.last_probed_at >= site_uptime_status.last_probed_at`,
 				c.SiteID, c.TenantID, c.Up, checkedAt, nullableTime(c.TLSExpiry),
+				c.AppUp, nullableString(c.AppProbeReason), appProbedAt(checkedAt, c.AppProbeReason),
 			)
 		}
 		br := tx.SendBatch(ctx, batch)
@@ -176,6 +223,18 @@ WHERE EXCLUDED.last_probed_at >= site_uptime_status.last_probed_at`,
 		}
 		return nil
 	})
+}
+
+// appProbedAt returns checkedAt when reason is non-empty (this check
+// attempted an app probe, so last_app_probed_at should advance to this
+// check's timestamp) or nil otherwise (no attempt this check - the
+// site_uptime_status upsert's CASE guard then leaves the stored
+// last_app_probed_at untouched rather than writing a meaningless value).
+func appProbedAt(checkedAt time.Time, reason string) any {
+	if reason == "" {
+		return nil
+	}
+	return checkedAt
 }
 
 var _ RollupWriter = (*pgStore)(nil)
@@ -316,6 +375,19 @@ LIMIT 1`, tenantID, siteID)
 // aged past uptime probe retention (probeRetention, shared with
 // UptimeProbeGCWorker) reads as "no data" — exactly like the old query,
 // where a GC'd site's last raw probe row would already be gone.
+//
+// GH #291 Phase 2 (review follow-up): st.latest_app_up and st.app_probe_reason
+// are selected alongside the reachability columns above - NO extra JOIN is
+// needed, unlike the ClickHouse read path (metrics.chStore.QueryFleetUptime),
+// which has to LEFT JOIN a separate app-probe-only subquery because
+// uptime_checks is a flat per-probe table with no rollup-status row. Here the
+// m99 rollup already carries both signals on the SAME site_uptime_status row
+// (see pgStore.UpsertRollup's doc comment), so reading them costs nothing
+// extra. This was the CRITICAL gap this comment's own review closed: these
+// two columns were written by every sweep but never selected here, so the
+// entire application-health feature was invisible on Postgres - the default
+// metrics backend and the one hosted production actually runs - even though
+// it worked correctly on ClickHouse.
 const fleetUptimeQuery = `
 SELECT
     s.id AS site_id,
@@ -325,7 +397,9 @@ SELECT
     agg.up_checks,
     agg.total_checks,
     agg.sum_latency_ms,
-    agg.latency_samples
+    agg.latency_samples,
+    st.latest_app_up,
+    st.app_probe_reason
 FROM unnest($2::uuid[]) AS s(id)
 LEFT JOIN site_uptime_status st
     ON st.site_id = s.id
@@ -448,8 +522,10 @@ func (s *pgStore) QueryFleetUptime(ctx context.Context, tenantID uuid.UUID, site
 				totalChecks    int64
 				sumLatencyMs   float64
 				latencySamples int64
+				latestAppUp    *bool
+				appProbeReason *string
 			)
-			if err := rows.Scan(&siteID, &latestUp, &latestAt, &latestTLS, &upChecks, &totalChecks, &sumLatencyMs, &latencySamples); err != nil {
+			if err := rows.Scan(&siteID, &latestUp, &latestAt, &latestTLS, &upChecks, &totalChecks, &sumLatencyMs, &latencySamples, &latestAppUp, &appProbeReason); err != nil {
 				return fmt.Errorf("postgres fleet uptime scan: %w", err)
 			}
 			// Site has no status row at all (never probed, or its only
@@ -470,6 +546,16 @@ func (s *pgStore) QueryFleetUptime(ctx context.Context, tenantID uuid.UUID, site
 			if latencySamples > 0 {
 				avg := sumLatencyMs / float64(latencySamples)
 				row.AvgLatencyMs = &avg
+			}
+			// GH #291 Phase 2: app_probe_reason is the sentinel (NULL means
+			// "no app probe has ever completed for this site", mirroring the
+			// ClickHouse read path's identical guard) - latest_app_up alone
+			// cannot distinguish "never attempted" from "attempted, verdict
+			// unknown", since both store NULL there (see
+			// pgStore.UpsertRollup's doc comment).
+			if appProbeReason != nil && *appProbeReason != "" {
+				row.AppProbeReason = *appProbeReason
+				row.AppUp = latestAppUp
 			}
 			out[siteID] = row
 		}
@@ -589,4 +675,17 @@ func nullableTime(t time.Time) any {
 		return nil
 	}
 	return t
+}
+
+// nullableString maps an empty string to a Postgres NULL. Used for
+// Check.AppProbeReason (GH #291 Phase 2): "" is the sentinel for "no app
+// probe was attempted on this check" and must round-trip as SQL NULL, not
+// the literal empty string, so a not-empty-string SQL predicate on that
+// column (see the ClickHouse fleet-uptime join for the equivalent idea)
+// behaves the same way on both backends.
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
 }

--- a/apps/api/internal/metrics/postgres_explain_test.go
+++ b/apps/api/internal/metrics/postgres_explain_test.go
@@ -294,6 +294,109 @@ func absDiff(a, b float64) float64 {
 	return b - a
 }
 
+// TestQueryFleetUptime_SurfacesAppHealthColumns is the GH #291 Phase 2 review
+// fix: it proves the Postgres READ path (QueryFleetUptime), not just the
+// WRITE path (UpsertRollup, already proven by
+// tests/uptime_app_health_integration_test.go's TestAppHealthRollup_
+// CoalesceGuard), surfaces latest_app_up/app_probe_reason on the returned
+// FleetUptimeRow. Before this fix, fleetUptimeQuery never selected either
+// column, so every sweep wrote a correct application-health verdict to
+// site_uptime_status and QueryFleetUptime silently never returned it -
+// Postgres is the DEFAULT metrics backend and the one hosted production
+// actually runs (WPMGR_CLICKHOUSE_ADDR unset), so the entire Phase 2 feature
+// was invisible there. Exercises all three FleetUptimeRow.AppUp/
+// AppProbeReason states in one pass, mirroring the semantics
+// metrics.chStore.QueryFleetUptime already implements for ClickHouse:
+//
+//   - never app-probed: AppProbeReason == "" and AppUp == nil.
+//   - app-probed, conclusive: AppProbeReason == the reason and AppUp non-nil.
+//   - app-probed, inconclusive (unknown): AppProbeReason == the reason but
+//     AppUp == nil - this is the state a naive `latest_app_up != nil` guard
+//     cannot distinguish from "never probed"; only app_probe_reason can.
+func TestQueryFleetUptime_SurfacesAppHealthColumns(t *testing.T) {
+	app, admin := startMetricsTestPostgres(t)
+	ctx := context.Background()
+	store := NewPostgres(app, nil)
+	rw := store.(RollupWriter)
+
+	tenant := metricsSeedTenant(t, admin, "m291-app-health-"+uuid.NewString()[:8])
+	conclusiveTrueSite := metricsSeedSite(t, admin, tenant, "https://"+uuid.NewString()+".example.com")
+	conclusiveFalseSite := metricsSeedSite(t, admin, tenant, "https://"+uuid.NewString()+".example.com")
+	unknownSite := metricsSeedSite(t, admin, tenant, "https://"+uuid.NewString()+".example.com")
+	neverProbedSite := metricsSeedSite(t, admin, tenant, "https://"+uuid.NewString()+".example.com")
+
+	now := time.Now()
+	appTrue, appFalse := true, false
+	checks := []Check{
+		{TenantID: tenant, SiteID: conclusiveTrueSite, CheckedAt: now, Up: true, TotalMs: 50,
+			AppUp: &appTrue, AppProbeReason: "rest_ok"},
+		{TenantID: tenant, SiteID: conclusiveFalseSite, CheckedAt: now, Up: true, TotalMs: 50,
+			AppUp: &appFalse, AppProbeReason: "rest_5xx"},
+		{TenantID: tenant, SiteID: unknownSite, CheckedAt: now, Up: true, TotalMs: 50,
+			AppUp: nil, AppProbeReason: "rest_forbidden"},
+		// neverProbedSite: a reachability-only check, exactly like every
+		// sweep tick that does not land on the app-probe cadence
+		// (AppUp/AppProbeReason left zero-value).
+		{TenantID: tenant, SiteID: neverProbedSite, CheckedAt: now, Up: true, TotalMs: 50},
+	}
+	if err := store.InsertChecks(ctx, checks); err != nil {
+		t.Fatalf("insert checks: %v", err)
+	}
+	if err := rw.UpsertRollup(ctx, checks); err != nil {
+		t.Fatalf("upsert rollup: %v", err)
+	}
+
+	got, err := store.QueryFleetUptime(ctx, tenant,
+		[]uuid.UUID{conclusiveTrueSite, conclusiveFalseSite, unknownSite, neverProbedSite}, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("QueryFleetUptime: %v", err)
+	}
+
+	trueRow, ok := got[conclusiveTrueSite]
+	if !ok {
+		t.Fatal("conclusiveTrueSite missing from result")
+	}
+	if trueRow.AppProbeReason != "rest_ok" {
+		t.Fatalf("conclusiveTrueSite AppProbeReason = %q, want %q", trueRow.AppProbeReason, "rest_ok")
+	}
+	if trueRow.AppUp == nil || !*trueRow.AppUp {
+		t.Fatalf("conclusiveTrueSite AppUp = %v, want true", trueRow.AppUp)
+	}
+
+	falseRow, ok := got[conclusiveFalseSite]
+	if !ok {
+		t.Fatal("conclusiveFalseSite missing from result")
+	}
+	if falseRow.AppProbeReason != "rest_5xx" {
+		t.Fatalf("conclusiveFalseSite AppProbeReason = %q, want %q", falseRow.AppProbeReason, "rest_5xx")
+	}
+	if falseRow.AppUp == nil || *falseRow.AppUp {
+		t.Fatalf("conclusiveFalseSite AppUp = %v, want false", falseRow.AppUp)
+	}
+
+	unknownRow, ok := got[unknownSite]
+	if !ok {
+		t.Fatal("unknownSite missing from result")
+	}
+	if unknownRow.AppProbeReason != "rest_forbidden" {
+		t.Fatalf("unknownSite AppProbeReason = %q, want %q", unknownRow.AppProbeReason, "rest_forbidden")
+	}
+	if unknownRow.AppUp != nil {
+		t.Fatalf("unknownSite AppUp = %v, want nil (attempted, but inconclusive)", unknownRow.AppUp)
+	}
+
+	neverRow, ok := got[neverProbedSite]
+	if !ok {
+		t.Fatal("neverProbedSite missing from result")
+	}
+	if neverRow.AppProbeReason != "" {
+		t.Fatalf("neverProbedSite AppProbeReason = %q, want \"\" (no app probe ever attempted)", neverRow.AppProbeReason)
+	}
+	if neverRow.AppUp != nil {
+		t.Fatalf("neverProbedSite AppUp = %v, want nil", neverRow.AppUp)
+	}
+}
+
 // TestQueryFleetUptime_RawReadsAreIndexBounded proves, via EXPLAIN ANALYZE
 // against a realistically large site_uptime_probes table (well beyond the
 // ~2 edge days), that the two raw sub-selects inside fleetUptimeQuery are

--- a/apps/api/internal/metrics/postgres_test.go
+++ b/apps/api/internal/metrics/postgres_test.go
@@ -61,6 +61,27 @@ func TestFleetUptimeQuery_ReferencesRollupAndBoundedRawEdges(t *testing.T) {
 	}
 }
 
+// TestFleetUptimeQuery_SelectsAppHealthColumns is the static regression guard
+// for the GH #291 Phase 2 review finding: the Postgres fleet-uptime read
+// never selected st.latest_app_up / st.app_probe_reason, so every sweep wrote
+// the application-health verdict and QueryFleetUptime silently never
+// surfaced it on Postgres - the default metrics backend and the one hosted
+// production runs. This inspects the fleetUptimeQuery constant directly (no
+// DB needed), the same style as
+// TestFleetUptimeQuery_ReferencesRollupAndBoundedRawEdges above, so a future
+// edit that drops these two columns from the SELECT list fails a fast,
+// DB-less test rather than only a real-Postgres one. See
+// TestQueryFleetUptime_SurfacesAppHealthColumns in postgres_explain_test.go
+// for the real-Postgres, read-path-specific proof.
+func TestFleetUptimeQuery_SelectsAppHealthColumns(t *testing.T) {
+	if !strings.Contains(fleetUptimeQuery, "st.latest_app_up") {
+		t.Fatal("fleetUptimeQuery no longer selects st.latest_app_up - the application-health verdict would be invisible on Postgres again")
+	}
+	if !strings.Contains(fleetUptimeQuery, "st.app_probe_reason") {
+		t.Fatal("fleetUptimeQuery no longer selects st.app_probe_reason - QueryFleetUptime cannot distinguish \"never app-probed\" from \"probed, verdict unknown\" without it")
+	}
+}
+
 // TestFleetUptimeParams_DecomposesWithNoGapNoOverlap is a pure (no DB) unit
 // test of the window decomposition math: for a range of windows and "now"
 // instants (including degenerate sub-day windows and windows that land

--- a/apps/api/internal/uptime/app_probe.go
+++ b/apps/api/internal/uptime/app_probe.go
@@ -1,0 +1,556 @@
+// GH #291 Phase 2: the application-health probe.
+//
+// The FROZEN reachability probe (probe.go) requests the cacheable homepage,
+// so a site whose PHP is completely dead but still served a cached 200
+// reports "up" forever - the literal incident this phase exists to close.
+// Phase 1 already fixed the case where the AGENT can tell us (a disconnected
+// agent now derives Degraded, see deriveFleetStatus). This file adds a
+// direct measurement so the control plane does not depend on the agent being
+// enrolled and disconnected to notice.
+//
+// Two-signal model (locked, see docs/security/uptime-app-health-design-
+// 2026-07-27.md section 1): "up" keeps its exact current meaning forever -
+// nothing in this file ever touches site_uptime_probes.up, sites.
+// health_status, site_incidents, uptime percentages, or anything probe.go
+// computes. "app_up" is a new, orthogonal, three-valued signal (true / false
+// / unknown) that this file alone produces.
+package uptime
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
+	"github.com/mosamlife/wpmgr/apps/api/internal/httpclient"
+)
+
+// appProbeMaxBody bounds how much of the app-probe response body is read.
+// The WP REST index (/wp-json/) can run to hundreds of KB; only a small
+// prefix is needed to tell JSON from an HTML fatal-error page.
+const appProbeMaxBody = 16 << 10
+
+// appProbeBusterParam is the query parameter added to every app-probe
+// request so a query-string-keyed cache treats it as a new object. Same name
+// the design specifies and the Phase 4 post-update probe already uses
+// (internal/agentcmd/client.go cacheBusterParam) - NOT a security token, and
+// deliberately not utm-adjacent (some managed hosts strip utm_* server-side
+// before PHP ever sees them).
+const appProbeBusterParam = "wpmgr_hc"
+
+// appProbeUserAgent identifies the app-health probe in a site's access logs,
+// distinct from the reachability probe and the cron-kicker.
+const appProbeUserAgent = "WPMgr-AppHealthProbe/1.0"
+
+// Machine-readable reasons for an AppProbeResult, so the UI (and a later
+// alerting phase) can explain a verdict instead of rendering a bare chip.
+const (
+	// AppProbeReasonAgentFresh is B0: sites.last_seen_at is fresher than the
+	// app-probe interval, so a heartbeat already proves PHP booted. Zero
+	// network requests made.
+	AppProbeReasonAgentFresh = "agent_fresh"
+	// AppProbeReasonRestOK is a 2xx response whose body is a JSON object -
+	// the WP REST index (or the operator's B3 override, held to the same
+	// bar). app_up=true.
+	AppProbeReasonRestOK = "rest_ok"
+	// AppProbeReasonRest5xx is HTTP 500 specifically - PHP itself returned an
+	// error, which IS the positive evidence of the application running and
+	// failing that this signal exists to capture. app_up=false. See the 5xx
+	// switch case in fetchAndClassify for the full reasoning on why every
+	// OTHER 5xx status (502, 503, 504, and the unenumerated remainder)
+	// defaults to UNKNOWN instead.
+	AppProbeReasonRest5xx = "rest_5xx"
+	// AppProbeReasonRestMaintenance is HTTP 503. UNKNOWN, never false - 503
+	// is exactly what WordPress core's own maintenance mode emits (the
+	// .maintenance file dropped during ANY core/plugin/theme update, update
+	// windows this product itself schedules) and is also the conventional
+	// response from a rate limiter or an under-attack challenge page. A
+	// fleet-wide managed core-update window would otherwise paint every site
+	// application-down purely because this product is doing its job.
+	AppProbeReasonRestMaintenance = "rest_maintenance"
+	// AppProbeReasonRestBadGateway is HTTP 502. UNKNOWN, never false - a 502
+	// means the reverse proxy in front of the site could not reach its
+	// upstream at all. That is the SAME condition AppProbeReasonUnreachable
+	// already covers when this file's own HTTP client observes a connection
+	// refused directly; learning about it secondhand, via the site's own
+	// proxy, is not stronger evidence that the application ran and failed -
+	// if anything the application never got the chance to run.
+	AppProbeReasonRestBadGateway = "rest_bad_gateway"
+	// AppProbeReasonRestGatewayTimeout is HTTP 504. UNKNOWN, never false - a
+	// 504 is literally a timeout, just reported by the proxy instead of
+	// observed directly by this probe's own client. See AppProbeReasonTimeout
+	// for why a timeout is never conclusive (a merely slow site is common and
+	// healthy); a timeout reported secondhand by the proxy is no more
+	// conclusive than one this probe times out on itself.
+	AppProbeReasonRestGatewayTimeout = "rest_gateway_timeout"
+	// AppProbeReasonRest5xxOther is any 5xx status other than 500 (conclusive
+	// false), 502, 503, or 504 (each UNKNOWN with its own reason above).
+	// UNKNOWN, never false - see the 5xx switch case in fetchAndClassify for
+	// why the default for the rest of the 5xx space, including codes this
+	// comment does not enumerate by number (505, 507-509, and Cloudflare's
+	// 520-527 origin-error range among them), is UNKNOWN rather than
+	// conclusive.
+	AppProbeReasonRest5xxOther = "rest_5xx_other"
+	// AppProbeReasonWPFatalError is a 2xx response whose body carries the
+	// same WordPress fatal-error page signature probe.go's scanFatal
+	// detects for the reachability probe (a wp_die()/db-error screen served
+	// with HTTP 200). app_up=false.
+	AppProbeReasonWPFatalError = "wp_fatal_error"
+	// AppProbeReasonCacheHit is a detected cache HIT on the probe response -
+	// the bypass was defeated. UNKNOWN, never healthy: silently reporting
+	// healthy when the bypass failed would be worse than the bug this phase
+	// fixes.
+	AppProbeReasonCacheHit = "cache_hit"
+	// AppProbeReasonRestForbidden is a 401/403. Extremely common (security
+	// plugins, including WPMgr's own suite, commonly gate the REST API).
+	// UNKNOWN, never false - a fleet-wide false-alarm storm is worse than an
+	// unclassified site.
+	AppProbeReasonRestForbidden = "rest_forbidden"
+	// AppProbeReasonRestAbsent is a 404 on the default /wp-json/ target -
+	// normal on a permalinks-off / REST-disabled install. Triggers the B2
+	// fallback; only the FINAL request's 404 (after B2 also 404s, or B2 does
+	// not apply - an overridden B3 target) settles as this reason. UNKNOWN,
+	// never false.
+	AppProbeReasonRestAbsent = "rest_absent"
+	// AppProbeReasonRest4xx is any other 4xx status. UNKNOWN, never false -
+	// mirrors the 401/404 rule for the long tail of other client-error codes
+	// a WAF/security plugin might return.
+	AppProbeReasonRest4xx = "rest_4xx"
+	// AppProbeReasonRestNonJSON is a 2xx response whose body is not a JSON
+	// object. Triggers the B2 fallback; only the FINAL request's non-JSON
+	// 200 settles as this reason. UNKNOWN, never false.
+	AppProbeReasonRestNonJSON = "rest_non_json"
+	// AppProbeReasonTimeout is a request that did not complete within the
+	// probe's own budget (the context deadline NewAppProber's timeout sets,
+	// or a lower-level dial/TLS timeout that self-reports as one). UNKNOWN,
+	// never false: a timeout proves the response did not arrive in time, not
+	// that the application ran and failed - a merely SLOW site (a heavy
+	// plugin, a cold PHP-FPM worker, a slow upstream) is common and healthy,
+	// and reporting it as application-down would be a false positive.
+	AppProbeReasonTimeout = "timeout"
+	// AppProbeReasonUnreachable is any OTHER transport-level failure
+	// (connection refused, DNS failure, TLS handshake failure, an SSRF
+	// block, or a request that could not even be built) - see
+	// AppProbeReasonTimeout for the timeout case, classified separately.
+	// UNKNOWN, never false. This is a deliberate departure from the
+	// reachability probe's own posture: a connection refused is arguably
+	// conclusive for the SITE as a whole, but that judgment already belongs
+	// to probe.go, which independently records the site DOWN. This signal
+	// answers a narrower question - did the APPLICATION itself execute and
+	// fail? - and a transport failure never proves the application ran at
+	// all, so it cannot supply evidence for that question either way. The
+	// same false-alarm-storm reasoning that governs 401/403/404 above
+	// applies here: prefer UNKNOWN whenever conclusive evidence of the
+	// application actually running and failing is unavailable.
+	AppProbeReasonUnreachable = "unreachable"
+	// AppProbeReasonRestUnexpected covers a response classified by none of
+	// the rules above (e.g. an unfollowed 3xx). UNKNOWN, never false.
+	AppProbeReasonRestUnexpected = "rest_unexpected"
+	// AppProbeReasonInvalidSiteURL is buildURL failing to construct a probe
+	// target from the site's stored URL (not http(s), no host, or otherwise
+	// unparseable). UNKNOWN, never false - a malformed stored site URL is a
+	// configuration problem, not evidence the application ran and failed;
+	// naming it distinctly from AppProbeReasonUnreachable also lets an
+	// operator see at a glance that this is a config issue to fix on the
+	// site record, not an outage to investigate.
+	AppProbeReasonInvalidSiteURL = "invalid_site_url"
+)
+
+// AppProbeResult is the tri-state verdict from one application-health probe.
+// Up is nil for UNKNOWN - never coerced to true or false. Reason is always
+// populated (one of the AppProbeReason* constants) whenever a probe actually
+// ran, including an unknown verdict; it is the sentinel package metrics'
+// UpsertRollup/InsertChecks use to tell "attempted, unknown" apart from "not
+// attempted this check" (see metrics.Check.AppProbeReason).
+type AppProbeResult struct {
+	Up     *bool
+	Reason string
+}
+
+// AppProber performs the GH #291 Phase 2 application-health probe: B0 (agent
+// ground truth, zero network requests) falling through to B1 (/wp-json/),
+// B2 (the ?rest_route=/ fallback, only on 404 or non-JSON 200), or B3 (a
+// per-site override path that replaces B1/B2 entirely). It reuses the same
+// SSRF-hardened *httpclient.Client the reachability prober uses (ADR-009).
+type AppProber struct {
+	client  *httpclient.Client
+	timeout time.Duration
+}
+
+// NewAppProber builds an AppProber. timeout bounds a single probe attempt
+// (B1 or B2 or the B3 override - never both B1 and B2 combined into one
+// deadline; each gets its own context), defaulting to 10s when non-positive.
+func NewAppProber(client *httpclient.Client, timeout time.Duration) *AppProber {
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return &AppProber{client: client, timeout: timeout}
+}
+
+// Probe runs B0-B3 for one site, stopping at the first conclusive result.
+//
+//   - lastSeenAt / appProbeInterval implement B0: when lastSeenAt is fresher
+//     than appProbeInterval, a heartbeat already proves PHP booted and
+//     WordPress loaded - zero network requests are made. lastSeenAt nil (the
+//     site has never heartbeated) always falls through to B1/B2/B3.
+//   - overridePath implements B3: when non-empty, it REPLACES the default
+//     target entirely (no B2 fallback) - an operator who configured a custom
+//     health-check path presumably did so because the default targets are
+//     blocked/unreliable for this site, so falling back to them would defeat
+//     the point of the override.
+func (p *AppProber) Probe(ctx context.Context, siteURL string, lastSeenAt *time.Time, appProbeInterval time.Duration, overridePath string) AppProbeResult {
+	// B0: agent ground truth.
+	if lastSeenAt != nil && !lastSeenAt.IsZero() && appProbeInterval > 0 && time.Since(*lastSeenAt) < appProbeInterval {
+		t := true
+		return AppProbeResult{Up: &t, Reason: AppProbeReasonAgentFresh}
+	}
+
+	if overridePath != "" {
+		target, err := p.buildURL(siteURL, normalizeOverridePath(overridePath), nil)
+		if err != nil {
+			// A malformed/unparseable stored site URL is a configuration
+			// problem, not evidence the application ran and failed - see
+			// AppProbeReasonInvalidSiteURL. UNKNOWN, never a conclusive false.
+			return AppProbeResult{Up: nil, Reason: AppProbeReasonInvalidSiteURL}
+		}
+		up, reason, _ := p.fetchAndClassifyWithTimeout(ctx, target)
+		return AppProbeResult{Up: up, Reason: reason}
+	}
+
+	// B1.
+	b1URL, err := p.buildURL(siteURL, "/wp-json/", nil)
+	if err != nil {
+		// Same reasoning as the B3 override branch above: a bad site URL is
+		// a config problem, never conclusive evidence of app failure.
+		return AppProbeResult{Up: nil, Reason: AppProbeReasonInvalidSiteURL}
+	}
+	up, reason, tryFallback := p.fetchAndClassifyWithTimeout(ctx, b1URL)
+	if !tryFallback {
+		return AppProbeResult{Up: up, Reason: reason}
+	}
+
+	// B2 fallback: only on 404 or a non-JSON 200 from B1 (see
+	// fetchAndClassify's tryFallback return). Gets its OWN fresh timeout
+	// budget below (fetchAndClassifyWithTimeout), independent of however
+	// long B1 already took.
+	b2URL, err := p.buildURL(siteURL, "/", map[string]string{"rest_route": "/"})
+	if err != nil {
+		// Could not build the fallback URL: report B1's own (inconclusive)
+		// verdict rather than discarding it.
+		return AppProbeResult{Up: up, Reason: reason}
+	}
+	up2, reason2, _ := p.fetchAndClassifyWithTimeout(ctx, b2URL)
+	return AppProbeResult{Up: up2, Reason: reason2}
+}
+
+// fetchAndClassifyWithTimeout wraps fetchAndClassify with a FRESH
+// context.WithTimeout derived from ctx (the caller's own context, NEVER
+// chained off a previous attempt's already-partially-consumed deadline), so
+// B1, B2, and the B3 override each get the FULL p.timeout budget for their
+// own single attempt - exactly the contract NewAppProber's doc comment
+// states. Before this, Probe built ONE shared context up front and reused it
+// for every attempt, so a slow B1 could leave B2 with almost no time
+// remaining and produce a misleading verdict from a starved request rather
+// than a genuine one. The tradeoff: Probe's worst-case wall-clock duration is
+// now bounded by (attempts made) * p.timeout, not by p.timeout alone - at
+// most 2*p.timeout today, since a sweep tick that reaches B2 makes exactly
+// two attempts, and the B3 override path makes exactly one.
+func (p *AppProber) fetchAndClassifyWithTimeout(ctx context.Context, targetURL string) (up *bool, reason string, tryFallback bool) {
+	attemptCtx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
+	return p.fetchAndClassify(attemptCtx, targetURL)
+}
+
+// normalizeOverridePath ensures a per-site override path (sites.
+// app_probe_path) is treated as a path, not a bare filename - a leading
+// slash is required by buildURL's join.
+func normalizeOverridePath(p string) string {
+	if !strings.HasPrefix(p, "/") {
+		return "/" + p
+	}
+	return p
+}
+
+// buildURL joins extraPath (which must start with "/") onto siteURL's
+// origin, merges query (if any), and appends a fresh appProbeBusterParam
+// value. siteURL must be http(s) with a host - the same validation
+// joinCommandURL applies to agent command URLs.
+//
+// Deliberately NOT path.Join: that function calls path.Clean, which strips a
+// trailing slash - turning "/wp-json/" into "/wp-json". WP's REST index only
+// answers reliably at the trailing-slash form the design specifies
+// (GET <site>/wp-json/?wpmgr_hc=...); a bare "/wp-json" is a different route
+// on some configurations. Plain concatenation onto a trailing-slash-trimmed
+// base path preserves extraPath's own trailing slash exactly as given.
+func (p *AppProber) buildURL(siteURL, extraPath string, query map[string]string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(siteURL))
+	if err != nil {
+		return "", fmt.Errorf("invalid site url: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("invalid site url scheme %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("site url has no host")
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + extraPath
+	q := u.Query()
+	for k, v := range query {
+		q.Set(k, v)
+	}
+	q.Set(appProbeBusterParam, randomBusterToken())
+	u.RawQuery = q.Encode()
+	u.Fragment = ""
+	return u.String(), nil
+}
+
+// randomBusterToken returns a fresh, unpredictable-enough token for the
+// cache-buster query parameter - it is not a security token, it only needs
+// to vary per call so a query-string-keyed cache treats each probe as a new
+// object. Falls back to a fixed value only if crypto/rand is somehow
+// unavailable (never observed in practice; keeps buildURL infallible).
+func randomBusterToken() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "wpmgrhc"
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// fetchAndClassify issues one GET to targetURL and classifies the result.
+// tryFallback is true only when the caller should retry via B2 - a 404, or a
+// 2xx whose body is not JSON (see the AppProbeReason* doc comments for the
+// full classification table).
+func (p *AppProber) fetchAndClassify(ctx context.Context, targetURL string) (up *bool, reason string, tryFallback bool) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
+	if err != nil {
+		// A request that cannot even be constructed is a local/config
+		// problem (targetURL already passed buildURL's own validation, so
+		// this is effectively unreachable in practice) - never evidence the
+		// application ran and failed. UNKNOWN, same reasoning as the
+		// client.Do() branch below.
+		return nil, AppProbeReasonUnreachable, false
+	}
+	req.Header.Set("User-Agent", appProbeUserAgent)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("Pragma", "no-cache")
+
+	resp, err := p.client.HTTPClient().Do(req)
+	if err != nil {
+		if isTimeoutError(err) {
+			// A timeout proves only that the response did not arrive within
+			// the probe's budget - see AppProbeReasonTimeout. A merely SLOW
+			// site is common and healthy; reporting it as application-down
+			// would be a false positive the moment Phase 3 turns verdicts
+			// into pages.
+			return nil, AppProbeReasonTimeout, false
+		}
+		// Every other transport-level failure (DNS failure, TLS handshake
+		// failure, connection refused, an SSRF block) lands here - see
+		// AppProbeReasonUnreachable's doc comment for why a connection
+		// refused is deliberately UNKNOWN rather than conclusive false: it
+		// is the reachability prober's job (probe.go) to declare the site
+		// unreachable, and a transport failure never proves the application
+		// itself ran and failed.
+		return nil, AppProbeReasonUnreachable, false
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// A detected cache HIT means UNKNOWN, never healthy - the bypass was
+	// defeated, and silently reporting healthy in that case is worse than
+	// the bug this phase exists to fix. Checked before status/body
+	// classification: an HTTP 200 that is actually a stale cached object
+	// proves nothing about the current backend.
+	if hit, _ := agentcmd.DetectCacheHit(resp.Header); hit {
+		return nil, AppProbeReasonCacheHit, false
+	}
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, io.LimitReader(resp.Body, appProbeMaxBody))
+	body := buf.Bytes()
+
+	switch {
+	case resp.StatusCode == http.StatusServiceUnavailable:
+		// 503 is exactly what WordPress core's own maintenance mode emits
+		// (the .maintenance file, dropped during ANY core/plugin/theme
+		// update - including an update window this product itself
+		// schedules), and is also the conventional response from a rate
+		// limiter or an under-attack challenge page. Must be checked BEFORE
+		// the generic >=500 case below, or a fleet-wide managed update
+		// window would paint every site application-down purely because
+		// this product is doing its job. A Retry-After header (RFC 9110) or
+		// a challenge-page marker in the body would be even stronger
+		// evidence of a deliberate temporary state, but the safe default -
+		// UNKNOWN on every 503, regardless of headers/body - is sufficient
+		// on its own and keeps this branch simple.
+		return nil, AppProbeReasonRestMaintenance, false
+	case resp.StatusCode == http.StatusBadGateway:
+		// 502: the reverse proxy in front of the site could not reach its
+		// upstream at all - see AppProbeReasonRestBadGateway. That is the
+		// SAME condition this file's own HTTP client classifies as
+		// AppProbeReasonUnreachable when it observes a connection refused
+		// directly (below); observing it secondhand via the site's own proxy
+		// is not stronger evidence. UNKNOWN.
+		return nil, AppProbeReasonRestBadGateway, false
+	case resp.StatusCode == http.StatusGatewayTimeout:
+		// 504 is literally a timeout, reported by the proxy - see
+		// AppProbeReasonRestGatewayTimeout / AppProbeReasonTimeout. A
+		// merely SLOW site is common and healthy; this client's own timeout
+		// on the same request is UNKNOWN, so a proxy reporting the identical
+		// condition cannot be treated as stronger evidence. UNKNOWN.
+		return nil, AppProbeReasonRestGatewayTimeout, false
+	case resp.StatusCode == http.StatusInternalServerError:
+		// 500: PHP itself returned an error. This IS the positive evidence
+		// that the application ran and failed that this whole signal exists
+		// to capture, so it is the one 5xx status that stays conclusive.
+		f := false
+		return &f, AppProbeReasonRest5xx, false
+	case resp.StatusCode >= 500:
+		// Every 5xx status NOT already handled above (501, 505, 507-509, and
+		// Cloudflare's 520-527 origin-error range among them - this default
+		// deliberately does not hand-enumerate every vendor-specific 5xx a
+		// proxy/CDN/WAF in front of a site might emit, since that list would
+		// inevitably miss one) defaults to UNKNOWN rather than conclusive.
+		// Cloudflare's 520-527 range in particular documents itself as an
+		// ORIGIN-unreachable/misbehaving condition at the network layer, the
+		// same category as 502/504 above, not a PHP error like 500. The cost
+		// asymmetry favours under-alarming here: an unrecognised 5xx staying
+		// UNKNOWN costs at most a missed page for a rare code, while reading
+		// a network-layer proxy error as "the application ran and failed"
+		// when it may never have gotten the chance to run risks the false
+		// positive this whole file exists to eliminate.
+		return nil, AppProbeReasonRest5xxOther, false
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		// 4xx is NOT app-down: a 401 rest_not_logged_in is extremely common
+		// (security plugins, including WPMgr's own suite, gate the REST
+		// API) and treating it as down would cause a fleet-wide
+		// false-alarm storm.
+		return nil, AppProbeReasonRestForbidden, false
+	case resp.StatusCode == http.StatusNotFound:
+		// Normal on a REST-disabled/permalinks-off install; try B2 before
+		// settling.
+		return nil, AppProbeReasonRestAbsent, true
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		if looksLikeJSONObject(body) {
+			t := true
+			return &t, AppProbeReasonRestOK, false
+		}
+		// A WordPress fatal-error/db-error screen only reaches the client as
+		// HTTP 200 once headers have already been sent - reuse the SAME
+		// structural scan the (frozen) reachability probe uses, rather than
+		// a second, looser detector that could disagree with it (probe.go
+		// is same-package; this does not modify it).
+		if down, _ := scanFatal(body, resp.Header.Get("Content-Type")); down {
+			f := false
+			return &f, AppProbeReasonWPFatalError, false
+		}
+		return nil, AppProbeReasonRestNonJSON, true
+	case resp.StatusCode >= 400 && resp.StatusCode < 500:
+		return nil, AppProbeReasonRest4xx, false
+	default:
+		return nil, AppProbeReasonRestUnexpected, false
+	}
+}
+
+// isTimeoutError reports whether err represents a request that did not
+// complete within its deadline - the probe's own context.WithTimeout
+// expiring (surfaces as context.DeadlineExceeded, possibly wrapped in a
+// *url.Error by net/http) or a lower-level net.Error that self-reports
+// Timeout()==true (e.g. a dial timeout on a slow/black-holed host) - as
+// opposed to a definite connection-level failure (refused, DNS, TLS, an SSRF
+// block), which is NOT a timeout even though it is equally a client.Do()
+// error.
+func isTimeoutError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+	return false
+}
+
+// looksLikeJSONObject reports whether body's PREFIX (it may be truncated at
+// appProbeMaxBody - the WP REST index can run to hundreds of KB) begins a
+// well-formed JSON object. json.Decoder.Token only needs to see the opening
+// "{" to succeed; it does not require the rest of the document to be
+// present, so this is safe to call on a deliberately truncated read.
+func looksLikeJSONObject(body []byte) bool {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	tok, err := dec.Token()
+	if err != nil {
+		return false
+	}
+	d, ok := tok.(json.Delim)
+	return ok && d == '{'
+}
+
+// appProbeDue is the stateless, restart-safe cadence check that lets the app
+// probe piggyback on the reachability sweep's existing 60s tick without
+// keeping any cadence state in memory or in the database. Given the sweep's
+// own timestamp (now - the same value uptime.ProbeWorker.Sweep already
+// receives and uses for every site in the sweep) and the two configured
+// intervals, it deterministically decides which sites are "due" THIS tick:
+//
+//   - ratio = round(appProbeInterval / probeInterval) - at the documented
+//     defaults (300s / 60s) this is 5, matching the design's "roughly 4 of
+//     every 5 rollup upserts carry app_up = NULL" arithmetic exactly: 1 of
+//     every `ratio` sweeps performs an app probe for a given site, the other
+//     `ratio`-1 do not.
+//   - seq is the sweep's own tick number (now truncated to whole
+//     probeInterval units) - every process computes the SAME seq from the
+//     SAME now, with no shared state and no coordination required.
+//   - offset is derived from the site's own UUID, spreading sites evenly
+//     across the `ratio` buckets instead of every site coming due on the
+//     exact same tick (which would turn the app probe into a periodic
+//     thundering herd instead of a steady trickle).
+//
+// A process restart loses no state: the next tick's seq is still correctly
+// derived from wall-clock time, so at worst a site's app probe is delayed by
+// up to one ratio-worth of ticks - an acceptable, self-healing imprecision
+// for a "roughly" cadence (see the design doc), not a correctness bug.
+func appProbeDue(siteID uuid.UUID, now time.Time, probeInterval, appProbeInterval time.Duration) bool {
+	if probeInterval <= 0 {
+		probeInterval = time.Minute
+	}
+	if appProbeInterval <= 0 {
+		appProbeInterval = 5 * time.Minute
+	}
+	ratio := int64(appProbeInterval / probeInterval)
+	if ratio < 1 {
+		ratio = 1
+	}
+	// probeInterval.Seconds() truncates to whole seconds via the int64
+	// conversion below, so any sub-second probeInterval (already floored to
+	// time.Minute above only when it was <= 0, not when it is merely small)
+	// would otherwise make this divisor 0 and panic. Floor it at 1 second -
+	// the same self-healing "roughly" cadence tolerance appProbeDue's own doc
+	// comment already accepts for a process restart.
+	divisor := int64(probeInterval.Seconds())
+	if divisor < 1 {
+		divisor = 1
+	}
+	seq := now.Unix() / divisor
+
+	var h uint64
+	for i := 0; i < len(siteID) && i < 8; i++ {
+		h = h<<8 | uint64(siteID[i])
+	}
+	offset := int64(h % uint64(ratio))
+
+	return (seq+offset)%ratio == 0
+}

--- a/apps/api/internal/uptime/app_probe_test.go
+++ b/apps/api/internal/uptime/app_probe_test.go
@@ -1,0 +1,626 @@
+package uptime
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/httpclient"
+)
+
+// buildTestAppProber builds an *AppProber backed by an SSRF-disabled
+// httpclient that can reach loopback httptest servers (test-only), mirroring
+// internal/agentcmd's buildTestProbe.
+func buildTestAppProber(t *testing.T) *AppProber {
+	t.Helper()
+	hc := httpclient.New(httpclient.Config{Timeout: 5 * time.Second, AllowPrivateNetworks: true})
+	return NewAppProber(hc, 5*time.Second)
+}
+
+// hitTracker records every request path this test server received, so a test
+// can assert exactly which endpoints were (or were not) hit.
+type hitTracker struct {
+	mu    sync.Mutex
+	paths []string
+}
+
+func (h *hitTracker) record(path string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.paths = append(h.paths, path)
+}
+
+func (h *hitTracker) count(path string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	n := 0
+	for _, p := range h.paths {
+		if p == path {
+			n++
+		}
+	}
+	return n
+}
+
+func (h *hitTracker) total() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.paths)
+}
+
+// TestAppProber_FreshHeartbeat_ZeroHTTPRequests proves B0 (agent ground
+// truth): a heartbeat fresher than the app-probe interval already proves PHP
+// booted, so the probe makes ZERO network requests - the server fails the
+// test outright if it receives any request at all.
+func TestAppProber_FreshHeartbeat_ZeroHTTPRequests(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected HTTP request to %s - B0 must make zero network requests on a fresh heartbeat", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	p := buildTestAppProber(t)
+	lastSeen := time.Now().Add(-30 * time.Second)
+	res := p.Probe(context.Background(), srv.URL, &lastSeen, 5*time.Minute, "")
+
+	if res.Up == nil || !*res.Up {
+		t.Fatalf("expected Up=true for a fresh heartbeat, got %+v", res)
+	}
+	if res.Reason != AppProbeReasonAgentFresh {
+		t.Fatalf("expected reason %q, got %q", AppProbeReasonAgentFresh, res.Reason)
+	}
+}
+
+// TestAppProber_StaleHeartbeat_FallsThroughToNetworkProbe proves B0 does NOT
+// short-circuit when the heartbeat is older than the app-probe interval -
+// exactly when the direct measurement is needed.
+func TestAppProber_StaleHeartbeat_FallsThroughToNetworkProbe(t *testing.T) {
+	tr := &hitTracker{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tr.record(r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name":"Test Site"}`))
+	}))
+	defer srv.Close()
+
+	p := buildTestAppProber(t)
+	stale := time.Now().Add(-10 * time.Minute)
+	res := p.Probe(context.Background(), srv.URL, &stale, 5*time.Minute, "")
+
+	if tr.total() == 0 {
+		t.Fatal("expected at least one network request for a stale heartbeat")
+	}
+	if res.Up == nil || !*res.Up {
+		t.Fatalf("expected Up=true, got %+v", res)
+	}
+}
+
+// TestAppProber_RestOK_JSONIndex_AppUpTrue proves B1 against a valid WP REST
+// index (200, JSON object body) resolves app_up=true, and that the request
+// went to /wp-json/ carrying the cache-buster query parameter.
+func TestAppProber_RestOK_JSONIndex_AppUpTrue(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name":"Test Site","description":"just another WordPress site"}`))
+	}))
+	defer srv.Close()
+
+	p := buildTestAppProber(t)
+	res := p.Probe(context.Background(), srv.URL, nil, 5*time.Minute, "")
+
+	if res.Up == nil || !*res.Up {
+		t.Fatalf("expected Up=true for a valid JSON REST index, got %+v", res)
+	}
+	if res.Reason != AppProbeReasonRestOK {
+		t.Fatalf("expected reason %q, got %q", AppProbeReasonRestOK, res.Reason)
+	}
+	if gotPath != "/wp-json/" {
+		t.Fatalf("expected request to /wp-json/, got %q", gotPath)
+	}
+	if gotQuery == "" {
+		t.Fatal("expected a cache-buster query parameter, got none")
+	}
+}
+
+// TestAppProber_5xx_AppUpFalse proves a 5xx response is conclusively down.
+func TestAppProber_5xx_AppUpFalse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	p := buildTestAppProber(t)
+	res := p.Probe(context.Background(), srv.URL, nil, 5*time.Minute, "")
+
+	if res.Up == nil || *res.Up {
+		t.Fatalf("expected Up=false for a 5xx response, got %+v", res)
+	}
+	if res.Reason != AppProbeReasonRest5xx {
+		t.Fatalf("expected reason %q, got %q", AppProbeReasonRest5xx, res.Reason)
+	}
+}
+
+// TestAppProber_502And504_Unknown proves 502 and 504 classify UNKNOWN with
+// their own distinct reasons, never conclusive false - a 502 is the same
+// "upstream unreachable" condition this file already classifies UNKNOWN when
+// its own client sees a connection refused directly, and a 504 is literally a
+// timeout reported by the proxy instead of this probe's own client, which is
+// already UNKNOWN when observed directly (AppProbeReasonTimeout). Observing
+// either secondhand via the site's reverse proxy is not stronger evidence.
+func TestAppProber_502And504_Unknown(t *testing.T) {
+	t.Run("502 bad gateway", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+		}))
+		defer srv.Close()
+
+		p := buildTestAppProber(t)
+		res := p.Probe(context.Background(), srv.URL, nil, 5*time.Minute, "")
+		if res.Up != nil {
+			t.Fatalf("expected Up=nil (unknown) for a 502, got %+v", res)
+		}
+		if res.Reason != AppProbeReasonRestBadGateway {
+			t.Fatalf("expected reason %q, got %q", AppProbeReasonRestBadGateway, res.Reason)
+		}
+	})
+
+	t.Run("504 gateway timeout", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusGatewayTimeout)
+		}))
+		defer srv.Close()
+
+		p := buildTestAppProber(t)
+		res := p.Probe(context.Background(), srv.URL, nil, 5*time.Minute, "")
+		if res.Up != nil {
+			t.Fatalf("expected Up=nil (unknown) for a 504, got %+v", res)
+		}
+		if res.Reason != AppProbeReasonRestGatewayTimeout {
+			t.Fatalf("expected reason %q, got %q", AppProbeReasonRestGatewayTimeout, res.Reason)
+		}
+	})
+}
+
+// TestAppProber_500_StillConclusiveFalse proves the 502/504 UNKNOWN carve-outs
+// did not weaken the 500 case: PHP itself returning an error remains the
+// positive evidence of the application running and failing that this signal
+// exists to capture, so it must stay a conclusive false with the original
+// AppProbeReasonRest5xx reason.
+func TestAppProber_500_StillConclusiveFalse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	p := buildTestAppProber(t)
+	res := p.Probe(context.Background(), srv.URL, nil, 5*time.Minute, "")
+
+	if res.Up == nil || *res.Up {
+		t.Fatalf("expected Up=false for a 500, got %+v", res)
+	}
+	if res.Reason != AppProbeReasonRest5xx {
+		t.Fatalf("expected reason %q, got %q", AppProbeReasonRest5xx, res.Reason)
+	}
+}
+
+// TestAppProber_MalformedSiteURL_Unknown proves a site URL that buildURL
+// cannot turn into a request (no host here) classifies UNKNOWN with a reason
+// that names the real cause, never a conclusive false - a malformed stored
+// site URL is a configuration problem, not evidence the application ran and
+// failed. Covers both the B1 default-target call site and the B3 override
+// call site, since Probe returns early from each independently.
+func TestAppProber_MalformedSiteURL_Unknown(t *testing.T) {
+	t.Run("B1 default target", func(t *testing.T) {
+		p := buildTestAppProber(t)
+		res := p.Probe(context.Background(), "not-a-valid-url", nil, 5*time.Minute, "")
+		if res.Up != nil {
+			t.Fatalf("expected Up=nil (unknown) for a malformed site URL, got %+v", res)
+		}
+		if res.Reason != AppProbeReasonInvalidSiteURL {
+			t.Fatalf("expected reason %q, got %q", AppProbeReasonInvalidSiteURL, res.Reason)
+		}
+	})
+
+	t.Run("B3 override target", func(t *testing.T) {
+		p := buildTestAppProber(t)
+		res := p.Probe(context.Background(), "not-a-valid-url", nil, 5*time.Minute, "/healthz")
+		if res.Up != nil {
+			t.Fatalf("expected Up=nil (unknown) for a malformed site URL, got %+v", res)
+		}
+		if res.Reason != AppProbeReasonInvalidSiteURL {
+			t.Fatalf("expected reason %q, got %q", AppProbeReasonInvalidSiteURL, res.Reason)
+		}
+	})
+}
+
+// TestAppProber_WPFatalPage200_ConclusiveFalse proves the path GH #291 review
+// flagged as untested: an HTTP 200 whose body carries the WordPress
+// fatal-error page signature (headers already sent before wp_die() ran) is a
+// conclusive app_up=false, not merely UNKNOWN - this is the exact case Phase 3
+// turns into a page, so it must be exercised directly rather than only
+// documented.
+func TestAppProber_WPFatalPage200_ConclusiveFalse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(wpDieCriticalErrorHTML))
+	}))
+	defer srv.Close()
+
+	p := buildTestAppProber(t)
+	res := p.Probe(context.Background(), srv.URL, nil, 5*time.Minute, "")
+
+	if res.Up == nil || *res.Up {
+		t.Fatalf("expected Up=false for a 200 WP fatal-error page, got %+v", res)
+	}
+	if res.Reason != AppProbeReasonWPFatalError {
+		t.Fatalf("expected reason %q, got %q", AppProbeReasonWPFatalError, res.Reason)
+	}
+}
+
+// TestAppProber_ConnectionFailure_Unknown proves a transport-level failure
+// (nothing listening) classifies UNKNOWN, never a conclusive false - GH #291
+// review finding 2: a connection refused is arguably conclusive for the SITE
+// as a whole, but that judgment belongs to the reachability prober
+// (probe.go), which already records the site DOWN independently of this
+// probe. This narrower application-health signal never proves the
+// application itself ran and failed from a bare transport error, so it must
+// not manufacture a false positive.
+func TestAppProber_ConnectionFailure_Unknown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	deadURL := srv.URL
+	srv.Close() // nothing is listening anymore.
+
+	p := buildTestAppProber(t)
+	res := p.Probe(context.Background(), deadURL, nil, 5*time.Minute, "")
+
+	if res.Up != nil {
+		t.Fatalf("expected Up=nil (unknown) for a connection failure, got %+v", res)
+	}
+	if res.Reason != AppProbeReasonUnreachable {
+		t.Fatalf("expected reason %q, got %q", AppProbeReasonUnreachable, res.Reason)
+	}
+}
+
+// TestAppProber_Timeout_Unknown proves a request that blows the probe's own
+// context deadline classifies UNKNOWN with its own distinct reason, never a
+// conclusive false - GH #291 review finding 2: a merely SLOW site (a heavy
+// plugin, a cold PHP-FPM worker) is common and healthy, and treating a
+// timeout as application-down would be a false positive the moment a later
+// phase turns verdicts into pages.
+func TestAppProber_Timeout_Unknown(t *testing.T) {
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-block // never respond within the probe's timeout.
+	}))
+	// srv.Close() blocks until every in-flight handler returns, so the block
+	// channel MUST be closed (unblocking the handler goroutine still waiting
+	// on the timed-out request) BEFORE Close() is called, not via a separate
+	// t.Cleanup - t.Cleanup hooks run AFTER this function's own defers, which
+	// would call Close() first and deadlock forever.
+	defer func() {
+		close(block)
+		srv.Close()
+	}()
+
+	hc := httpclient.New(httpclient.Config{Timeout: 5 * time.Second, AllowPrivateNetworks: true})
+	p := NewAppProber(hc, 100*time.Millisecond)
+	res := p.Probe(context.Background(), srv.URL, nil, 5*time.Minute, "")
+
+	if res.Up != nil {
+		t.Fatalf("expected Up=nil (unknown) for a timeout, got %+v", res)
+	}
+	if res.Reason != AppProbeReasonTimeout {
+		t.Fatalf("expected reason %q, got %q", AppProbeReasonTimeout, res.Reason)
+	}
+}
+
+// TestAppProber_503_MaintenanceUnknown proves HTTP 503 classifies UNKNOWN
+// with its own reason, never a conclusive false - GH #291 review finding 3:
+// 503 is exactly what WordPress core's own maintenance mode emits via the
+// .maintenance file, so any site this product is actively updating would
+// otherwise be painted application-down purely because the update is
+// running as designed.
+func TestAppProber_503_MaintenanceUnknown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	p := buildTestAppProber(t)
+	res := p.Probe(context.Background(), srv.URL, nil, 5*time.Minute, "")
+
+	if res.Up != nil {
+		t.Fatalf("expected Up=nil (unknown) for a 503, got %+v", res)
+	}
+	if res.Reason != AppProbeReasonRestMaintenance {
+		t.Fatalf("expected reason %q, got %q", AppProbeReasonRestMaintenance, res.Reason)
+	}
+}
+
+// TestAppProber_B2GetsOwnTimeoutBudget_NotStarvedByB1 proves GH #291 review
+// finding 4: B1 and B2 each get their OWN full timeout budget rather than
+// sharing one deadline. A B1 target that consumes almost the entire budget
+// (but still answers, inconclusively, in time to trigger the B2 fallback)
+// must not leave B2 starved - B2 must still have enough of ITS OWN budget
+// left to complete a fast response and produce its own genuine verdict,
+// which is only possible if B2's context is a fresh one, not B1's leftover.
+func TestAppProber_B2GetsOwnTimeoutBudget_NotStarvedByB1(t *testing.T) {
+	const timeout = 300 * time.Millisecond
+	tr := &hitTracker{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tr.record(r.URL.Path)
+		if r.URL.Path == "/wp-json/" {
+			// Consume most of a single attempt's budget before answering
+			// inconclusively (404), triggering the B2 fallback.
+			time.Sleep(timeout - 50*time.Millisecond)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		// B2 fallback target: answers fast, well within a FRESH budget, but
+		// would be starved if it only inherited whatever remained of B1's
+		// already-mostly-consumed deadline.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name":"Test Site (fallback)"}`))
+	}))
+	defer srv.Close()
+
+	hc := httpclient.New(httpclient.Config{Timeout: 5 * time.Second, AllowPrivateNetworks: true})
+	p := NewAppProber(hc, timeout)
+	res := p.Probe(context.Background(), srv.URL, nil, 5*time.Minute, "")
+
+	if tr.count("/") == 0 {
+		t.Fatalf("expected the B2 fallback to be attempted, got requests: %v", tr.paths)
+	}
+	if res.Up == nil || !*res.Up || res.Reason != AppProbeReasonRestOK {
+		t.Fatalf("expected B2's own successful verdict (not starved by B1's near-timeout budget), got %+v", res)
+	}
+}
+
+// TestAppProber_CacheHit_Unknown proves the GH #291 Phase 2 rule that matters
+// most: a detected cache HIT is UNKNOWN, never healthy - even when the
+// cached body happens to be valid JSON. Silently reporting healthy when the
+// bypass was defeated would be worse than the bug this phase fixes.
+func TestAppProber_CacheHit_Unknown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Cache-Status", "HIT")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name":"Test Site"}`))
+	}))
+	defer srv.Close()
+
+	p := buildTestAppProber(t)
+	res := p.Probe(context.Background(), srv.URL, nil, 5*time.Minute, "")
+
+	if res.Up != nil {
+		t.Fatalf("expected Up=nil (unknown) for a cache HIT, got %+v", res)
+	}
+	if res.Reason != AppProbeReasonCacheHit {
+		t.Fatalf("expected reason %q, got %q", AppProbeReasonCacheHit, res.Reason)
+	}
+}
+
+// TestAppProber_401And404_Unknown proves 401 and 404 are UNKNOWN, never
+// app-down - a 401 rest_not_logged_in is extremely common (security plugins,
+// including WPMgr's own suite) and a 404 is normal on a REST-disabled
+// install. Treating either as down would cause a fleet-wide false-alarm
+// storm.
+func TestAppProber_401And404_Unknown(t *testing.T) {
+	t.Run("401 forbidden", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+
+		p := buildTestAppProber(t)
+		res := p.Probe(context.Background(), srv.URL, nil, 5*time.Minute, "")
+		if res.Up != nil {
+			t.Fatalf("expected Up=nil (unknown) for a 401, got %+v", res)
+		}
+		if res.Reason != AppProbeReasonRestForbidden {
+			t.Fatalf("expected reason %q, got %q", AppProbeReasonRestForbidden, res.Reason)
+		}
+	})
+
+	t.Run("404 on both wp-json and the rest_route fallback", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		p := buildTestAppProber(t)
+		res := p.Probe(context.Background(), srv.URL, nil, 5*time.Minute, "")
+		if res.Up != nil {
+			t.Fatalf("expected Up=nil (unknown) for a 404, got %+v", res)
+		}
+		if res.Reason != AppProbeReasonRestAbsent {
+			t.Fatalf("expected reason %q, got %q", AppProbeReasonRestAbsent, res.Reason)
+		}
+	})
+}
+
+// TestAppProber_B2Fallback_OnlyOn404OrNonJSON proves the fallback rule
+// precisely: B2 (?rest_route=/) fires when B1 (/wp-json/) returns 404 or a
+// non-JSON 200, and NEVER fires for any other B1 outcome (401, 5xx, or a
+// conclusive JSON 200) - retrying an unreachable/forbidden/broken backend a
+// second way would not change the verdict and would double the load.
+func TestAppProber_B2Fallback_OnlyOn404OrNonJSON(t *testing.T) {
+	cases := []struct {
+		name            string
+		b1Status        int
+		b1ContentType   string
+		b1Body          string
+		wantFallbackHit bool
+	}{
+		{"404 triggers fallback", http.StatusNotFound, "", "", true},
+		{"non-JSON 200 triggers fallback", http.StatusOK, "text/html", "<html>not json</html>", true},
+		{"401 does not trigger fallback", http.StatusUnauthorized, "", "", false},
+		{"403 does not trigger fallback", http.StatusForbidden, "", "", false},
+		{"5xx does not trigger fallback", http.StatusInternalServerError, "", "", false},
+		{"other 4xx does not trigger fallback", http.StatusTooManyRequests, "", "", false},
+		{"valid JSON 200 does not trigger fallback", http.StatusOK, "application/json", `{"name":"Test"}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := &hitTracker{}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				tr.record(r.URL.Path)
+				if r.URL.Path == "/wp-json/" {
+					if tc.b1ContentType != "" {
+						w.Header().Set("Content-Type", tc.b1ContentType)
+					}
+					w.WriteHeader(tc.b1Status)
+					_, _ = w.Write([]byte(tc.b1Body))
+					return
+				}
+				// The B2 fallback target (rest_route=/ on the site root):
+				// always answer with a valid JSON index so a fired fallback
+				// is unambiguously observable via its OWN distinct verdict.
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"name":"Test Site (fallback)"}`))
+			}))
+			defer srv.Close()
+
+			p := buildTestAppProber(t)
+			res := p.Probe(context.Background(), srv.URL, nil, 5*time.Minute, "")
+
+			fallbackHit := tr.count("/") > 0
+			if fallbackHit != tc.wantFallbackHit {
+				t.Fatalf("fallback hit = %v, want %v (result: %+v, requests: %v)", fallbackHit, tc.wantFallbackHit, res, tr.paths)
+			}
+			if tc.wantFallbackHit && (res.Up == nil || !*res.Up || res.Reason != AppProbeReasonRestOK) {
+				t.Fatalf("expected the fallback's own successful verdict to win, got %+v", res)
+			}
+		})
+	}
+}
+
+// TestAppProber_Override_ReplacesDefaultTarget proves B3: a per-site
+// override path is requested INSTEAD of /wp-json/, with no B2 fallback even
+// on a 404 - an operator who configured a custom health-check path
+// presumably did so because the default targets are unreliable for this
+// site.
+func TestAppProber_Override_ReplacesDefaultTarget(t *testing.T) {
+	tr := &hitTracker{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tr.record(r.URL.Path)
+		if r.URL.Path == "/healthz" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	p := buildTestAppProber(t)
+	res := p.Probe(context.Background(), srv.URL, nil, 5*time.Minute, "/healthz")
+
+	if res.Up == nil || !*res.Up {
+		t.Fatalf("expected Up=true via the override path, got %+v", res)
+	}
+	if tr.count("/wp-json/") != 0 {
+		t.Fatalf("expected the default /wp-json/ target to never be requested when an override is set, got requests: %v", tr.paths)
+	}
+	if tr.count("/") != 0 {
+		t.Fatalf("expected no B2 fallback when an override is set, got requests: %v", tr.paths)
+	}
+	if tr.count("/healthz") != 1 {
+		t.Fatalf("expected exactly one request to the override path, got requests: %v", tr.paths)
+	}
+}
+
+// TestAppProbeDue_DefaultRatio_RoughlyOneInFive proves the stateless cadence
+// check's arithmetic at the documented default ratio (300s / 60s = 5): over
+// 5 consecutive sweep ticks, a given site is due on EXACTLY one of them -
+// the "roughly 4 of every 5 rollup upserts carry app_up = NULL" the design
+// doc describes.
+func TestAppProbeDue_DefaultRatio_RoughlyOneInFive(t *testing.T) {
+	siteID := uuid.New()
+	probeInterval := time.Minute
+	appProbeInterval := 5 * time.Minute
+	base := time.Now().Truncate(time.Minute)
+
+	dueCount := 0
+	for i := 0; i < 5; i++ {
+		tick := base.Add(time.Duration(i) * probeInterval)
+		if appProbeDue(siteID, tick, probeInterval, appProbeInterval) {
+			dueCount++
+		}
+	}
+	if dueCount != 1 {
+		t.Fatalf("expected exactly 1 due tick out of 5 consecutive ticks, got %d", dueCount)
+	}
+}
+
+// TestAppProbeDue_Deterministic proves the same (siteID, now, intervals)
+// input always produces the same output - required for the cadence check to
+// be safely stateless/restart-safe (no shared memory, no DB round trip).
+func TestAppProbeDue_Deterministic(t *testing.T) {
+	siteID := uuid.New()
+	now := time.Now()
+	a := appProbeDue(siteID, now, time.Minute, 5*time.Minute)
+	b := appProbeDue(siteID, now, time.Minute, 5*time.Minute)
+	if a != b {
+		t.Fatalf("expected deterministic result, got %v then %v", a, b)
+	}
+}
+
+// TestAppProbeDue_DistributesAcrossSites proves different sites are not all
+// due on the same tick (which would turn the app probe into a periodic
+// thundering herd instead of a steady trickle) - at least two distinct
+// due/not-due outcomes across a handful of sites on the SAME tick.
+func TestAppProbeDue_DistributesAcrossSites(t *testing.T) {
+	now := time.Now()
+	dueTrue, dueFalse := false, false
+	for i := 0; i < 50; i++ {
+		if appProbeDue(uuid.New(), now, time.Minute, 5*time.Minute) {
+			dueTrue = true
+		} else {
+			dueFalse = true
+		}
+		if dueTrue && dueFalse {
+			return
+		}
+	}
+	t.Fatal("expected both due and not-due sites among 50 random UUIDs on the same tick - cadence may not be spreading load")
+}
+
+// TestAppProbeDue_ZeroOrNegativeIntervals_DefaultsSafely proves
+// non-positive intervals fall back to sane defaults rather than panicking
+// (e.g. a division by zero) or making every site due on every tick forever.
+func TestAppProbeDue_ZeroOrNegativeIntervals_DefaultsSafely(t *testing.T) {
+	siteID := uuid.New()
+	now := time.Now()
+	// Must not panic.
+	_ = appProbeDue(siteID, now, 0, 0)
+	_ = appProbeDue(siteID, now, -time.Minute, -time.Minute)
+}
+
+// TestAppProbeDue_SubSecondProbeInterval_DoesNotPanic proves a probeInterval
+// that is POSITIVE but under one second does not panic: appProbeDue's own
+// divisor is int64(probeInterval.Seconds()), which truncates a value like
+// 500ms to 0 - the `probeInterval <= 0` guard alone does not catch this,
+// since 500ms is not <= 0, so the divisor still needs its own floor.
+func TestAppProbeDue_SubSecondProbeInterval_DoesNotPanic(t *testing.T) {
+	siteID := uuid.New()
+	now := time.Now()
+	// Must not panic with an integer divide-by-zero.
+	_ = appProbeDue(siteID, now, 500*time.Millisecond, 5*time.Minute)
+	_ = appProbeDue(siteID, now, 1*time.Nanosecond, 5*time.Minute)
+}

--- a/apps/api/internal/uptime/derive_fleet_status_test.go
+++ b/apps/api/internal/uptime/derive_fleet_status_test.go
@@ -38,7 +38,10 @@ func TestDeriveFleetStatus_ConnectionStateMatrix(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotStatus, gotReason := deriveFleetStatus(&up, &fast, tc.connectionState, tc.disconnectedReason)
+			// appUp=nil throughout: this test pins the PRE-Phase-2 behavior,
+			// and "no app-health signal available" must never change it
+			// (see TestDeriveFleetStatus_AppDown for the new branch).
+			gotStatus, gotReason := deriveFleetStatus(&up, &fast, tc.connectionState, tc.disconnectedReason, nil)
 			if gotStatus != tc.wantStatus {
 				t.Errorf("status = %q, want %q", gotStatus, tc.wantStatus)
 			}
@@ -85,7 +88,7 @@ func TestDeriveFleetStatus_DisconnectedReasonDisambiguation(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotStatus, gotReason := deriveFleetStatus(&up, &fast, "disconnected", tc.disconnectedReason)
+			gotStatus, gotReason := deriveFleetStatus(&up, &fast, "disconnected", tc.disconnectedReason, nil)
 			if gotStatus != tc.wantStatus {
 				t.Errorf("disconnected_reason=%q: status = %q, want %q", tc.disconnectedReason, gotStatus, tc.wantStatus)
 			}
@@ -104,8 +107,12 @@ func TestDeriveFleetStatus_DownAndUnknownIgnoreConnectionState(t *testing.T) {
 	down := false
 	fast := 100.0
 
+	appDown := false
+
 	for _, cs := range []string{"connected", "degraded", "disconnected", "revoked", "archived", ""} {
-		status, reason := deriveFleetStatus(&down, &fast, cs, "agent_unreachable")
+		// Even a conclusive appUp=false must not override a down reachability
+		// probe - up=false already means "down", the strongest signal.
+		status, reason := deriveFleetStatus(&down, &fast, cs, "agent_unreachable", &appDown)
 		if status != FleetStatusDown {
 			t.Errorf("connection_state=%q: status = %q, want down", cs, status)
 		}
@@ -115,7 +122,7 @@ func TestDeriveFleetStatus_DownAndUnknownIgnoreConnectionState(t *testing.T) {
 	}
 
 	for _, cs := range []string{"connected", "degraded", "disconnected", "revoked", "archived", ""} {
-		status, reason := deriveFleetStatus(nil, nil, cs, "agent_unreachable")
+		status, reason := deriveFleetStatus(nil, nil, cs, "agent_unreachable", &appDown)
 		if status != FleetStatusUnknown {
 			t.Errorf("connection_state=%q: status = %q, want unknown", cs, status)
 		}
@@ -132,11 +139,83 @@ func TestDeriveFleetStatus_SlowResponseReason(t *testing.T) {
 	up := true
 	slow := slowThresholdMs + 1
 
-	status, reason := deriveFleetStatus(&up, &slow, "connected", "")
+	status, reason := deriveFleetStatus(&up, &slow, "connected", "", nil)
 	if status != FleetStatusDegraded {
 		t.Fatalf("status = %q, want degraded", status)
 	}
 	if reason != FleetReasonSlowResponse {
 		t.Fatalf("reason = %q, want %q", reason, FleetReasonSlowResponse)
+	}
+}
+
+// TestDeriveFleetStatus_AppDown is the GH #291 Phase 2 headline test: a
+// cached 200 (up=true, connection healthy, fast response) whose application
+// probe conclusively found app_up=false must derive Degraded with
+// FleetReasonAppDown - the exact scenario the design doc's incident
+// describes (a page cache masking a completely dead PHP backend).
+func TestDeriveFleetStatus_AppDown(t *testing.T) {
+	up := true
+	fast := 100.0
+	appDown := false
+	appUnknown := (*bool)(nil)
+	appUp := true
+
+	cases := []struct {
+		name       string
+		appUp      *bool
+		wantStatus FleetSiteStatus
+		wantReason string
+	}{
+		{"conclusive app_up=false derives degraded (headline case)", &appDown, FleetStatusDegraded, FleetReasonAppDown},
+		{"app_up=nil (unknown) never dressed up as broken - falls through to up", appUnknown, FleetStatusUp, ""},
+		{"conclusive app_up=true stays up", &appUp, FleetStatusUp, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, reason := deriveFleetStatus(&up, &fast, "connected", "", tc.appUp)
+			if status != tc.wantStatus {
+				t.Errorf("status = %q, want %q", status, tc.wantStatus)
+			}
+			if reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestDeriveFleetStatus_AppDownTakesPriorityOverSlowResponse proves app_down
+// is checked (and reported) before the pre-existing slow-response threshold,
+// so a site that is BOTH app-down AND slow reports the more specific,
+// more actionable reason.
+func TestDeriveFleetStatus_AppDownTakesPriorityOverSlowResponse(t *testing.T) {
+	up := true
+	slow := slowThresholdMs + 1
+	appDown := false
+
+	status, reason := deriveFleetStatus(&up, &slow, "connected", "", &appDown)
+	if status != FleetStatusDegraded {
+		t.Fatalf("status = %q, want degraded", status)
+	}
+	if reason != FleetReasonAppDown {
+		t.Fatalf("reason = %q, want %q (app_down must take priority over slow_response)", reason, FleetReasonAppDown)
+	}
+}
+
+// TestDeriveFleetStatus_AgentSignalsTakePriorityOverAppDown proves the
+// existing agent-side signals (Phase 1) are checked BEFORE app_down: a
+// disconnected/degraded agent is a stronger, more specific signal than an
+// app probe that may itself be unable to reach the site for the same
+// underlying reason.
+func TestDeriveFleetStatus_AgentSignalsTakePriorityOverAppDown(t *testing.T) {
+	up := true
+	fast := 100.0
+	appDown := false
+
+	status, reason := deriveFleetStatus(&up, &fast, "degraded", "", &appDown)
+	if status != FleetStatusDegraded {
+		t.Fatalf("status = %q, want degraded", status)
+	}
+	if reason != FleetReasonAgentDegraded {
+		t.Fatalf("reason = %q, want %q (agent signal must take priority over app_down)", reason, FleetReasonAgentDegraded)
 	}
 }

--- a/apps/api/internal/uptime/model.go
+++ b/apps/api/internal/uptime/model.go
@@ -30,6 +30,17 @@ type EnrolledSite struct {
 	TenantID     uuid.UUID
 	URL          string
 	HealthStatus string
+	// LastSeenAt is sites.last_seen_at (nil when the site has never
+	// heartbeated). GH #291 Phase 2's app prober reads this for B0 (agent
+	// ground truth): a fresh heartbeat already proves PHP booted and
+	// WordPress loaded, so the prober makes zero network requests. Ignored
+	// by the reachability prober and the cron-kicker.
+	LastSeenAt *time.Time
+	// AppProbePath is sites.app_probe_path (empty when unset). GH #291 Phase
+	// 2's app prober reads this for B3 (per-site override): when set, it
+	// replaces the default /wp-json/ (with ?rest_route=/ fallback) target
+	// entirely. Ignored by the reachability prober and the cron-kicker.
+	AppProbePath string
 }
 
 // AlertConfig is a tenant's default alert channel.
@@ -102,6 +113,15 @@ const (
 	// This state has no last-will path (see sweeperDisconnectReasons), so it
 	// needs no reason disambiguation.
 	FleetReasonAgentDegraded = "agent_degraded"
+	// FleetReasonAppDown (GH #291 Phase 2): the reachability probe reports
+	// up=true (visitors are being served, possibly a cached response) but
+	// the application-health probe conclusively found app_up=false - the
+	// literal incident this phase exists to catch: a page cache masking a
+	// completely dead PHP backend. The granular reason (rest_5xx,
+	// wp_fatal_error, unreachable, ...) is carried separately on
+	// FleetStatusItem.AppProbeReason; this constant is only the coarse
+	// status_reason, matching the shape of every other FleetReason*.
+	FleetReasonAppDown = "app_down"
 	// FleetReasonSlowResponse: the probe succeeded but total_ms exceeded
 	// slowThresholdMs.
 	FleetReasonSlowResponse = "slow_response"
@@ -163,6 +183,16 @@ type FleetStatusItem struct {
 	// InIncident is kept for internal use (summary counting) but not needed
 	// by the frontend contract — retained for the service-layer logic.
 	InIncident bool `json:"in_incident"`
+	// AppUp is the GH #291 Phase 2 application-health verdict from the most
+	// recent app probe: true, false, or nil (never probed, or the most
+	// recent probe was inconclusive - see AppProbeReason). Independent of
+	// Up: a cached 200 (Up=true) can coexist with AppUp=false when a page
+	// cache is masking a dead PHP backend. An additive, backend-only key - 	// see TestFleetStatusItemJSONContract.
+	AppUp *bool `json:"app_up"`
+	// AppProbeReason is the machine-readable reason for AppUp's most recent
+	// verdict (one of the AppProbeReason* constants - e.g. "agent_fresh",
+	// "rest_ok", "cache_hit"). Empty when no app probe has run yet.
+	AppProbeReason string `json:"app_probe_reason,omitempty"`
 }
 
 // FleetStatusResponse is the response body for GET /api/v1/fleet/status.

--- a/apps/api/internal/uptime/probe_test.go
+++ b/apps/api/internal/uptime/probe_test.go
@@ -48,6 +48,35 @@ func TestProbeUp200(t *testing.T) {
 	}
 }
 
+// TestProbeRequestsRootPathWithEmptyQuery locks in the FROZEN reachability
+// probe's request shape: it requests exactly "/" (the cacheable homepage)
+// with an EMPTY query string - no path suffix, no cache-buster or any other
+// query parameter. GH #291 Phase 2 added a second prober (AppProber) that
+// deliberately targets /wp-json/ (or an operator override) WITH a
+// cache-busting query parameter, and nothing previously asserted the two
+// could not silently drift into requesting the same shape - see the design
+// doc's two-signal model: probe.go's request shape must never change.
+func TestProbeRequestsRootPathWithEmptyQuery(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	res := NewProber(testClient(), 5*time.Second).Probe(context.Background(), srv.URL)
+	if !res.Up {
+		t.Fatalf("expected up, got %+v", res)
+	}
+	if gotPath != "/" {
+		t.Fatalf("expected the frozen reachability probe to request exactly \"/\", got %q", gotPath)
+	}
+	if gotQuery != "" {
+		t.Fatalf("expected the frozen reachability probe to send an EMPTY query string, got %q", gotQuery)
+	}
+}
+
 func TestProbeDown500(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/apps/api/internal/uptime/repo.go
+++ b/apps/api/internal/uptime/repo.go
@@ -96,7 +96,15 @@ func (r *pgRepo) ListEnrolledForProbe(ctx context.Context) ([]EnrolledSite, erro
 		}
 		out = make([]EnrolledSite, 0, len(rows))
 		for _, row := range rows {
-			out = append(out, EnrolledSite{ID: row.ID, TenantID: row.TenantID, URL: row.Url, HealthStatus: row.HealthStatus})
+			s := EnrolledSite{ID: row.ID, TenantID: row.TenantID, URL: row.Url, HealthStatus: row.HealthStatus}
+			if row.LastSeenAt.Valid {
+				t := row.LastSeenAt.Time
+				s.LastSeenAt = &t
+			}
+			if row.AppProbePath != nil {
+				s.AppProbePath = *row.AppProbePath
+			}
+			out = append(out, s)
 		}
 		return nil
 	})
@@ -427,7 +435,19 @@ ORDER BY s.name ASC
 // `up` itself, sites.health_status, uptime percentages and everything else
 // probe A feeds are UNCHANGED by this function. Only the derived display
 // status moves.
-func deriveFleetStatus(up *bool, totalMs *float64, connectionState, disconnectedReason string) (FleetSiteStatus, string) {
+//
+// appUp is the GH #291 Phase 2 signal (metrics.FleetUptimeRow.AppUp): the
+// application-health probe's most recent verdict, tri-state (true/false/nil
+// =unknown). A conclusive false - the app probe positively determined
+// WordPress is not responding, independent of and possibly disagreeing with
+// `up` - derives Degraded with FleetReasonAppDown. This is the phase's
+// headline case: a page cache can keep `up` reporting true (visitors ARE
+// being served a cached page) while the app probe proves the backend is
+// dead. appUp==nil (never probed, or the most recent probe was
+// inconclusive - cache-hit-defeated, 4xx, etc.) makes NO difference here;
+// unknown is never dressed up as broken, so it simply falls through to
+// whatever this site would have derived before Phase 2 existed.
+func deriveFleetStatus(up *bool, totalMs *float64, connectionState, disconnectedReason string, appUp *bool) (FleetSiteStatus, string) {
 	if up == nil {
 		return FleetStatusUnknown, ""
 	}
@@ -444,6 +464,9 @@ func deriveFleetStatus(up *bool, totalMs *float64, connectionState, disconnected
 		// healthy "connected" site gets, below.
 	case "degraded":
 		return FleetStatusDegraded, FleetReasonAgentDegraded
+	}
+	if appUp != nil && !*appUp {
+		return FleetStatusDegraded, FleetReasonAppDown
 	}
 	if totalMs != nil && *totalMs > slowThresholdMs {
 		return FleetStatusDegraded, FleetReasonSlowResponse

--- a/apps/api/internal/uptime/service.go
+++ b/apps/api/internal/uptime/service.go
@@ -211,12 +211,16 @@ func (s *Service) GetFleetStatus(ctx context.Context, tenantID uuid.UUID, siteID
 				item.UptimePct7d = *um.UptimePct7d
 			}
 			item.AvgLatencyMs = um.AvgLatencyMs
+			// GH #291 Phase 2: surface the app-health verdict alongside the
+			// (unchanged) reachability fields above.
+			item.AppUp = um.AppUp
+			item.AppProbeReason = um.AppProbeReason
 			// Derive total_ms pointer for deriveFleetStatus threshold check.
 			var totalMsPtr *float64
 			if um.AvgLatencyMs != nil {
 				totalMsPtr = um.AvgLatencyMs
 			}
-			item.Status, item.StatusReason = deriveFleetStatus(um.Up, totalMsPtr, info.ConnectionState, info.DisconnectedReason)
+			item.Status, item.StatusReason = deriveFleetStatus(um.Up, totalMsPtr, info.ConnectionState, info.DisconnectedReason, um.AppUp)
 		} else {
 			item.Status = FleetStatusUnknown
 		}

--- a/apps/api/internal/uptime/worker.go
+++ b/apps/api/internal/uptime/worker.go
@@ -41,6 +41,15 @@ type ProbeWorker struct {
 	logger      *slog.Logger
 	concurrency int
 	threshold   int
+
+	// GH #291 Phase 2 (application health). All three are zero-value/nil
+	// until SetAppProber is called: appProber stays nil, so Sweep's app-probe
+	// branch below never runs and every check this worker writes carries
+	// AppUp=nil / AppProbeReason="" - bit-identical to this worker's
+	// behavior before this feature existed. See SetAppProber.
+	appProber        *AppProber
+	probeInterval    time.Duration
+	appProbeInterval time.Duration
 }
 
 // NewProbeWorker builds the probe worker. concurrency caps simultaneous probes;
@@ -56,6 +65,25 @@ func NewProbeWorker(repo Repo, prober *Prober, store metrics.Store, dispatcher *
 		threshold = 2
 	}
 	return &ProbeWorker{repo: repo, prober: prober, store: store, dispatcher: dispatcher, sites: sites, logger: logger, concurrency: concurrency, threshold: threshold}
+}
+
+// SetAppProber wires the GH #291 Phase 2 application-health prober into the
+// existing reachability sweep. Optional: a ProbeWorker this is never called
+// on (every existing caller/test, and any deployment with
+// WPMGR_UPTIME_APP_PROBE_ENABLED=false) makes zero app-probe network
+// requests and writes exactly what it wrote before this feature existed -
+// this is the mechanism behind the design's bit-identical-on-upgrade
+// requirement, not a separate code path.
+//
+// probeInterval is this worker's OWN reachability cadence (the same value
+// main.go registers its periodic job under); appProbeInterval is the desired
+// app-probe cadence. Both feed appProbeDue, the stateless cadence check that
+// decides, per sweep tick and per site, whether THIS tick also attempts an
+// app probe.
+func (w *ProbeWorker) SetAppProber(ap *AppProber, probeInterval, appProbeInterval time.Duration) {
+	w.appProber = ap
+	w.probeInterval = probeInterval
+	w.appProbeInterval = appProbeInterval
 }
 
 // Work runs one sweep.
@@ -82,7 +110,11 @@ func (w *ProbeWorker) Sweep(ctx context.Context, now time.Time) (int, error) {
 		checks  []metrics.Check
 		results = make(map[uuid.UUID]ProbeResult, len(sites))
 		sem     = make(chan struct{}, w.concurrency)
-		wg      sync.WaitGroup
+		// appSem is a SEPARATE, equally-sized semaphore for the GH #291
+		// Phase 2 app probe - see the release-order comment below for why
+		// this exists instead of reusing sem.
+		appSem = make(chan struct{}, w.concurrency)
+		wg     sync.WaitGroup
 	)
 
 	for _, s := range sites {
@@ -91,26 +123,59 @@ func (w *ProbeWorker) Sweep(ctx context.Context, now time.Time) (int, error) {
 		sem <- struct{}{}
 		go func() {
 			defer wg.Done()
-			defer func() { <-sem }()
 			res := w.prober.Probe(ctx, s.URL)
+			// Release the reachability slot as soon as the reachability
+			// probe itself finishes, BEFORE the (optional) app probe below
+			// - not via a single defer covering the whole goroutine. sem
+			// exists to bound how many probes hit the network at once for
+			// the reachability sweep specifically ("bounds concurrency ...
+			// so one sweep cannot stampede the network", ProbeWorker's own
+			// doc comment); if the app probe held this same slot for
+			// however long it additionally takes (review finding: up to
+			// 2*appProber.timeout after the FIX 4 change), a fleet-wide app
+			// probe would proportionally slow the reachability sweep for
+			// sites that have nothing to do with it. appSem below bounds
+			// the app probe's own concurrency instead, so it still cannot
+			// stampede the network, but on its OWN budget.
+			<-sem
 			checkedAt := time.Now()
+
+			// GH #291 Phase 2: piggyback an application-health probe onto
+			// THIS reachability check when the worker has one configured
+			// (SetAppProber) AND this site is due this tick (appProbeDue).
+			// Attaching it to the SAME Check below - never a separate write
+			// - is what keeps site_uptime_probes/site_uptime_daily free of
+			// the "second row corrupts every aggregate" trap (see the
+			// design doc and metrics.pgStore.UpsertRollup's doc comment).
+			var appUp *bool
+			var appReason string
+			if w.appProber != nil && appProbeDue(s.ID, now, w.probeInterval, w.appProbeInterval) {
+				appSem <- struct{}{}
+				ar := w.appProber.Probe(ctx, s.URL, s.LastSeenAt, w.appProbeInterval, s.AppProbePath)
+				<-appSem
+				appUp = ar.Up
+				appReason = ar.Reason
+			}
+
 			mu.Lock()
 			results[s.ID] = res
 			checks = append(checks, metrics.Check{
-				CheckedAt:  checkedAt,
-				TenantID:   s.TenantID,
-				SiteID:     s.ID,
-				Up:         res.Up,
-				HTTPStatus: uint16(res.HTTPStatus),
-				DNSMs:      res.DNSMs,
-				ConnectMs:  res.ConnectMs,
-				TLSMs:      res.TLSMs,
-				TTFBMs:     res.TTFBMs,
-				TotalMs:    res.TotalMs,
-				TLSExpiry:  res.TLSExpiry,
-				TLSIssuer:  res.TLSIssuer,
-				TLSSubject: res.TLSSubject,
-				Error:      res.Error,
+				CheckedAt:      checkedAt,
+				TenantID:       s.TenantID,
+				SiteID:         s.ID,
+				Up:             res.Up,
+				HTTPStatus:     uint16(res.HTTPStatus),
+				DNSMs:          res.DNSMs,
+				ConnectMs:      res.ConnectMs,
+				TLSMs:          res.TLSMs,
+				TTFBMs:         res.TTFBMs,
+				TotalMs:        res.TotalMs,
+				TLSExpiry:      res.TLSExpiry,
+				TLSIssuer:      res.TLSIssuer,
+				TLSSubject:     res.TLSSubject,
+				Error:          res.Error,
+				AppUp:          appUp,
+				AppProbeReason: appReason,
 			})
 			mu.Unlock()
 		}()

--- a/apps/api/migrations/20260809000000_m107_uptime_app_health.sql
+++ b/apps/api/migrations/20260809000000_m107_uptime_app_health.sql
@@ -1,0 +1,63 @@
+-- m107 - GH #291 Phase 2: application-health probe (the actual new
+-- capability; Phase 0 hardened ClickHouse, Phase 1 fixed deriveFleetStatus
+-- to stop rendering a sweeper-detected outage as green Up).
+--
+-- Problem: the FROZEN reachability probe requests the cacheable homepage, so
+-- a site whose PHP is completely dead but is still served a cached 200
+-- reports "up" forever. Phase 1 already fixed the case where the AGENT can
+-- tell us (a disconnected agent now derives Degraded). This migration adds
+-- the columns for a DIRECT measurement so the control plane does not depend
+-- on the agent being enrolled-and-disconnected to notice.
+--
+-- Two-signal model (locked, see docs/security/uptime-app-health-design-
+-- 2026-07-27.md section 1): "up" (reachability) keeps its exact current
+-- meaning forever - every column it already feeds (site_uptime_probes.up,
+-- sites.health_status, site_incidents, uptime percentages, SLA, the client
+-- portal, white-label PDFs) is UNTOUCHED by this migration. "app_up"
+-- (application health) is a new, orthogonal, three-valued signal (true /
+-- false / unknown=NULL) living entirely in new, additive, nullable columns.
+-- No new sites.connection_state / FleetSiteStatus enum value.
+--
+-- Columns, all additive and nullable (no backfill, no default, no table
+-- rewrite):
+--
+--   sites.app_probe_path            B3 per-site override path (text).
+--   site_uptime_probes.app_up            per-probe verdict (boolean).
+--   site_uptime_probes.app_probe_reason  per-probe machine-readable reason.
+--   site_uptime_daily.app_up_checks      additive day counter (integer).
+--   site_uptime_daily.app_total_checks   additive day counter (integer).
+--   site_uptime_status.latest_app_up        latest verdict (boolean).
+--   site_uptime_status.app_probe_reason     latest reason (text).
+--   site_uptime_status.last_app_probed_at   latest app-probe timestamp.
+--
+-- TRAP #1 (this migration does NOT fall into it): site_uptime_daily is keyed
+-- (site_id, day) with no "kind" dimension, so recording app health as a
+-- SECOND ROW per sweep would double total_checks and blend two different
+-- meanings, silently corrupting every uptime percentage in the product. App
+-- health rides the SAME row as new nullable columns instead.
+--
+-- TRAP #2 (handled in application code, not SQL, but the reason these
+-- columns are nullable-with-no-default rather than NOT NULL DEFAULT 0/false):
+-- the app probe runs at a slower cadence than the reachability probe
+-- (default 300s vs 60s), so most rollup upserts carry no app-health opinion
+-- at all. metrics.pgStore.UpsertRollup COALESCE/CASE-guards every write to
+-- these columns so an absent opinion never overwrites a known value - see
+-- that function's doc comment.
+--
+-- Idempotent (ADD COLUMN IF NOT EXISTS mirrors m104/m103/m101/m92/m93).
+
+ALTER TABLE "public"."sites"
+    ADD COLUMN IF NOT EXISTS "app_probe_path" text NULL;
+
+ALTER TABLE "public"."site_uptime_probes"
+    ADD COLUMN IF NOT EXISTS "app_up" boolean NULL,
+    ADD COLUMN IF NOT EXISTS "app_probe_reason" text NULL;
+
+ALTER TABLE "public"."site_uptime_daily"
+    ADD COLUMN IF NOT EXISTS "app_up_checks" integer NULL,
+    ADD COLUMN IF NOT EXISTS "app_total_checks" integer NULL;
+
+ALTER TABLE "public"."site_uptime_status"
+    ADD COLUMN IF NOT EXISTS "latest_app_up" boolean NULL,
+    ADD COLUMN IF NOT EXISTS "app_probe_reason" text NULL,
+    ADD COLUMN IF NOT EXISTS "last_app_probed_at" timestamptz NULL;

--- a/apps/api/tests/uptime_app_health_integration_test.go
+++ b/apps/api/tests/uptime_app_health_integration_test.go
@@ -1,0 +1,311 @@
+// uptime_app_health_integration_test.go - GH #291 Phase 2: the
+// application-health probe. Two load-bearing properties this whole change
+// depends on:
+//
+//   - The COALESCE-guarded rollup: the app probe runs on a slower cadence
+//     than the reachability probe, so most sweeps carry no app-health
+//     opinion at all. A naive upsert would clobber a known app_up value with
+//     NULL on those sweeps - TestAppHealthRollup_CoalesceGuard proves it
+//     never does.
+//   - The GOLDEN, bit-identical-on-upgrade property the design doc requires:
+//     uptime percentages, sites.health_status, and site_incidents must be
+//     EXACTLY the same whether or not the app probe ran, even when the app
+//     probe conclusively finds the backend dead. "up" (reachability) is
+//     frozen forever; only the new, orthogonal app_up signal may move.
+package tests
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/metrics"
+	"github.com/mosamlife/wpmgr/apps/api/internal/uptime"
+)
+
+// queryAppStatusRow reads the site_uptime_status app-health columns via the
+// admin (RLS-bypassing) connection.
+func queryAppStatusRow(t *testing.T, admin *db.Pool, siteID uuid.UUID) (latestAppUp *bool, reason string, lastAppProbedAt *time.Time, found bool) {
+	t.Helper()
+	ctx := context.Background()
+	var (
+		up      *bool
+		reason2 *string
+		at      *time.Time
+	)
+	err := admin.QueryRow(ctx,
+		`SELECT latest_app_up, app_probe_reason, last_app_probed_at FROM site_uptime_status WHERE site_id = $1`,
+		siteID).Scan(&up, &reason2, &at)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, "", nil, false
+		}
+		t.Fatalf("query app status row: %v", err)
+	}
+	r := ""
+	if reason2 != nil {
+		r = *reason2
+	}
+	return up, r, at, true
+}
+
+// queryDailyAppBucket reads the site_uptime_daily app-health counters via the
+// admin connection. NULL (never touched) reads back as 0/false-found.
+func queryDailyAppBucket(t *testing.T, admin *db.Pool, siteID uuid.UUID, day time.Time) (appUpChecks, appTotalChecks int32, found bool) {
+	t.Helper()
+	ctx := context.Background()
+	var (
+		up    *int32
+		total *int32
+	)
+	err := admin.QueryRow(ctx,
+		`SELECT app_up_checks, app_total_checks FROM site_uptime_daily WHERE site_id = $1 AND day = $2`,
+		siteID, day.UTC().Truncate(24*time.Hour)).Scan(&up, &total)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return 0, 0, false
+		}
+		t.Fatalf("query daily app bucket: %v", err)
+	}
+	if up != nil {
+		appUpChecks = *up
+	}
+	if total != nil {
+		appTotalChecks = *total
+	}
+	return appUpChecks, appTotalChecks, true
+}
+
+// TestAppHealthRollup_CoalesceGuard proves metrics.pgStore.UpsertRollup never
+// lets a NULL (no app-probe attempt this check - the common case, since the
+// app probe runs on a slower cadence than the reachability probe) overwrite
+// a previously-recorded known app_up value, and that it DOES advance once a
+// genuinely fresher app-probe attempt arrives.
+func TestAppHealthRollup_CoalesceGuard(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	store := metrics.NewPostgres(pool, nil)
+	rw, ok := store.(metrics.RollupWriter)
+	if !ok {
+		t.Fatal("metrics.NewPostgres must return a RollupWriter")
+	}
+
+	tenantID := seedTenant(t, pool, "app-health-coalesce-"+uuid.NewString()[:8])
+	siteID := seedSiteFor(t, admin, tenantID, "https://"+uuid.NewString()+".example.com")
+
+	now := time.Now().UTC()
+	appTrue := true
+	appFalse := false
+
+	// Check 1: a reachability probe that ALSO attempted (and succeeded) an
+	// app probe.
+	check1 := metrics.Check{
+		TenantID: tenantID, SiteID: siteID, CheckedAt: now, Up: true, TotalMs: 50,
+		AppUp: &appTrue, AppProbeReason: uptime.AppProbeReasonRestOK,
+	}
+	if err := rw.UpsertRollup(ctx, []metrics.Check{check1}); err != nil {
+		t.Fatalf("upsert rollup (check1): %v", err)
+	}
+
+	upAfter1, reasonAfter1, atAfter1, found := queryAppStatusRow(t, admin, siteID)
+	if !found || upAfter1 == nil || !*upAfter1 || reasonAfter1 != uptime.AppProbeReasonRestOK {
+		t.Fatalf("after check1: latest_app_up=%v reason=%q found=%v, want true/rest_ok", upAfter1, reasonAfter1, found)
+	}
+	if atAfter1 == nil {
+		t.Fatal("after check1: expected last_app_probed_at to be set")
+	}
+
+	// Checks 2-5: FOUR consecutive reachability-only sweeps (no app-probe
+	// attempt this tick - mirrors the ~4-of-5 cadence ratio at the documented
+	// defaults). Each one must NOT clobber the known app_up=true.
+	for i := 2; i <= 5; i++ {
+		check := metrics.Check{
+			TenantID: tenantID, SiteID: siteID, CheckedAt: now.Add(time.Duration(i) * time.Minute), Up: true, TotalMs: 50,
+			// AppUp/AppProbeReason left zero-value: no app-probe attempt.
+		}
+		if err := rw.UpsertRollup(ctx, []metrics.Check{check}); err != nil {
+			t.Fatalf("upsert rollup (check%d): %v", i, err)
+		}
+		up, reason, at, found := queryAppStatusRow(t, admin, siteID)
+		if !found || up == nil || !*up || reason != uptime.AppProbeReasonRestOK {
+			t.Fatalf("after check%d (no app-probe attempt): latest_app_up=%v reason=%q found=%v - a NULL/absent app opinion must NEVER clobber the known value", i, up, reason, found)
+		}
+		if at == nil || !at.Equal(*atAfter1) {
+			t.Fatalf("after check%d: last_app_probed_at moved (%v) even though no app probe was attempted - want unchanged (%v)", i, at, atAfter1)
+		}
+	}
+
+	// Check 6: a genuinely fresher app-probe attempt (conclusively false)
+	// must advance the stored verdict, reason, and timestamp.
+	check6At := now.Add(6 * time.Minute)
+	check6 := metrics.Check{
+		TenantID: tenantID, SiteID: siteID, CheckedAt: check6At, Up: true, TotalMs: 50,
+		AppUp: &appFalse, AppProbeReason: uptime.AppProbeReasonRest5xx,
+	}
+	if err := rw.UpsertRollup(ctx, []metrics.Check{check6}); err != nil {
+		t.Fatalf("upsert rollup (check6): %v", err)
+	}
+	upAfter6, reasonAfter6, atAfter6, found := queryAppStatusRow(t, admin, siteID)
+	if !found || upAfter6 == nil || *upAfter6 || reasonAfter6 != uptime.AppProbeReasonRest5xx {
+		t.Fatalf("after check6: latest_app_up=%v reason=%q found=%v, want false/rest_5xx", upAfter6, reasonAfter6, found)
+	}
+	if atAfter6 == nil || !atAfter6.Truncate(time.Microsecond).Equal(check6At.Truncate(time.Microsecond)) {
+		t.Fatalf("after check6: last_app_probed_at = %v, want %v", atAfter6, check6At)
+	}
+
+	// site_uptime_daily: app_total_checks counts every ATTEMPT (check1 and
+	// check6 - 2 attempts), app_up_checks counts only the conclusive true
+	// (check1 - 1). The 4 no-attempt checks (2-5) contribute 0/0.
+	appUpChecks, appTotalChecks, found := queryDailyAppBucket(t, admin, siteID, now)
+	if !found {
+		t.Fatal("expected a site_uptime_daily row")
+	}
+	if appTotalChecks != 2 {
+		t.Fatalf("app_total_checks = %d, want 2 (only check1 and check6 attempted)", appTotalChecks)
+	}
+	if appUpChecks != 1 {
+		t.Fatalf("app_up_checks = %d, want 1 (only check1 was conclusively true)", appUpChecks)
+	}
+
+	// The reachability counters must be untouched by any of this: all 6
+	// checks were Up=true.
+	upChecks, totalChecks, _, _, found := queryDailyBucket(t, admin, siteID, now)
+	if !found || upChecks != 6 || totalChecks != 6 {
+		t.Fatalf("reachability up_checks=%d total_checks=%d found=%v, want 6/6 (app-health writes must never affect these)", upChecks, totalChecks, found)
+	}
+}
+
+// appHealthGoldenScenario seeds a tenant+site whose reachability probe target
+// (site root) always answers a cached 200 and whose app-probe target
+// (/wp-json/) always answers 500 - the literal GH #291 incident shape: a
+// page cache masking a completely dead PHP backend. withAppProbe controls
+// whether the app prober is wired at all.
+func appHealthGoldenScenario(t *testing.T, withAppProbe bool) (healthStatus string, uptimePct float64, incidentCount int64, latestAppUp *bool) {
+	t.Helper()
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/wp-json/" {
+			// The app probe's target: a dead PHP backend.
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		// The reachability probe's target (site root): a cached 200 - a
+		// visitor IS being served, which is the honest, unchanged meaning
+		// of "up".
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html>cached page, dead backend</html>"))
+	}))
+	defer srv.Close()
+
+	tenant := seedTenant(t, pool, "app-health-golden-"+uuid.NewString()[:8])
+	s := enrollFakeSite(t, pool, tenant, srv.URL)
+	// Enrollment itself stamps last_seen_at = now(), which would otherwise
+	// make B0 (agent ground truth) short-circuit every sweep in this test
+	// and never actually reach the /wp-json/ target below. Backdate it to
+	// simulate a site whose heartbeat is stale enough that B0 correctly
+	// falls through to the direct measurement - the exact situation Phase 2
+	// exists for.
+	if _, err := admin.Exec(ctx, "UPDATE sites SET last_seen_at = now() - interval '1 hour' WHERE id = $1", s.ID); err != nil {
+		t.Fatalf("backdate last_seen_at: %v", err)
+	}
+
+	store := metrics.NewPostgres(pool, nil)
+	repo := uptime.NewRepo(pool)
+	prober := uptime.NewProber(loopbackClient(), 5*time.Second)
+	w := uptime.NewProbeWorker(repo, prober, store, nil, nil, nil, 5, 2)
+	if withAppProbe {
+		appProber := uptime.NewAppProber(loopbackClient(), 5*time.Second)
+		// probeInterval == appProbeInterval (ratio 1): every sweep also
+		// attempts an app probe, so the golden comparison does not depend on
+		// timing/hashing luck.
+		w.SetAppProber(appProber, time.Minute, time.Minute)
+	}
+
+	now := time.Now()
+	for i := 0; i < 3; i++ {
+		if _, err := w.Sweep(ctx, now); err != nil {
+			t.Fatalf("sweep %d: %v", i, err)
+		}
+	}
+
+	var health string
+	if err := admin.QueryRow(ctx, "SELECT health_status FROM sites WHERE id = $1", s.ID).Scan(&health); err != nil {
+		t.Fatalf("read health_status: %v", err)
+	}
+
+	agg, err := store.QueryAggregate(ctx, tenant, s.ID, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("query aggregate: %v", err)
+	}
+
+	var incidents int64
+	if err := admin.QueryRow(ctx, "SELECT count(*) FROM site_incidents WHERE site_id = $1", s.ID).Scan(&incidents); err != nil {
+		t.Fatalf("count incidents: %v", err)
+	}
+
+	var appUp *bool
+	if withAppProbe {
+		appUp, _, _, _ = queryAppStatusRow(t, admin, s.ID)
+	}
+
+	return health, agg.UptimePct, incidents, appUp
+}
+
+// TestAppHealthGolden_FrozenSignalsBitIdentical is the design doc's required
+// golden test: a site serving cached 200s over a dead backend must report
+// EXACTLY the same sites.health_status, uptime percentage, and
+// site_incidents count whether or not the app probe ran - even though the
+// app probe conclusively (and correctly) determines the backend is dead.
+// Only the new, orthogonal app_up signal may move.
+func TestAppHealthGolden_FrozenSignalsBitIdentical(t *testing.T) {
+	baselineHealth, baselinePct, baselineIncidents, baselineAppUp := appHealthGoldenScenario(t, false)
+	withAppHealth, withAppPct, withAppIncidents, withAppAppUp := appHealthGoldenScenario(t, true)
+
+	if baselineAppUp != nil {
+		t.Fatalf("baseline (app probe disabled) scenario unexpectedly recorded an app_up value: %v", baselineAppUp)
+	}
+
+	// The frozen triad: bit-identical regardless of the app probe.
+	if baselineHealth != withAppHealth {
+		t.Fatalf("sites.health_status diverged: baseline=%q with-app-probe=%q - the app probe must NEVER affect this frozen signal", baselineHealth, withAppHealth)
+	}
+	if baselineHealth != "healthy" {
+		t.Fatalf("sanity: expected health_status=healthy for a cached-200 reachability target, got %q", baselineHealth)
+	}
+	if baselinePct != withAppPct {
+		t.Fatalf("uptime percentage diverged: baseline=%.4f with-app-probe=%.4f - the app probe must NEVER affect this frozen signal", baselinePct, withAppPct)
+	}
+	if baselinePct != 100 {
+		t.Fatalf("sanity: expected 100%% uptime (every reachability probe was a cached 200), got %.4f", baselinePct)
+	}
+	if baselineIncidents != withAppIncidents {
+		t.Fatalf("site_incidents count diverged: baseline=%d with-app-probe=%d - the app probe must NEVER affect this frozen signal", baselineIncidents, withAppIncidents)
+	}
+	if baselineIncidents != 0 {
+		t.Fatalf("sanity: expected 0 incidents (reachability never went down), got %d", baselineIncidents)
+	}
+
+	// Proof the test scenario actually exercised something real: the app
+	// probe DID record a conclusive false verdict - the whole point of
+	// Phase 2, orthogonal to (and not reflected in) any of the frozen
+	// signals asserted above.
+	if withAppAppUp == nil {
+		t.Fatal("expected the app-probe scenario to record a conclusive app_up value, got none")
+	}
+	if *withAppAppUp {
+		t.Fatal("expected the app-probe scenario to record app_up=false (dead backend behind the cache), got true")
+	}
+}

--- a/apps/web/src/features/fleet/StatusChip.test.tsx
+++ b/apps/web/src/features/fleet/StatusChip.test.tsx
@@ -43,6 +43,21 @@ describe("StatusChip", () => {
     expect(screen.getByText("Responding slowly.")).toBeInTheDocument();
   });
 
+  // GH #291 — app_down is the reason the explanation feature exists: a
+  // page-cached site whose WordPress backend is completely dead. The copy
+  // must not imply an outage (visitors ARE being served) and must not
+  // imply everything is fine (WordPress is not responding).
+  it("renders the app_down explanation for a degraded item", () => {
+    renderWithProviders(<StatusChip status="degraded" reason="app_down" />);
+
+    expect(screen.getByText("Degraded")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Serving visitors from cache, but WordPress is not responding. Logins, forms and the admin area are likely already broken.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("renders no explanation for a degraded item with no reason", () => {
     renderWithProviders(<StatusChip status="degraded" />);
 

--- a/apps/web/src/features/fleet/fleet-types.ts
+++ b/apps/web/src/features/fleet/fleet-types.ts
@@ -26,13 +26,30 @@ export interface FleetStatusItem {
    * `degraded` status (GH #291), e.g. a page-cached site whose PHP backend
    * is unreachable. Optional so an older control-plane response (which
    * never sent this field) cannot break the UI. Known values today:
-   * "agent_unreachable" | "agent_degraded" | "slow_response" — but this is
-   * intentionally typed as `string`, not a union, so a future reason code
-   * the control plane adds is never a type error here; unrecognised codes
-   * are handled by the copy map (see `uptime-status.ts`), not by widening
-   * this type.
+   * "agent_unreachable" | "agent_degraded" | "app_down" | "slow_response" —
+   * but this is intentionally typed as `string`, not a union, so a future
+   * reason code the control plane adds is never a type error here;
+   * unrecognised codes are handled by the copy map (see `uptime-status.ts`),
+   * not by widening this type.
    */
   status_reason?: string;
+  /**
+   * GH #291 Phase 2 application-health verdict from the most recent app
+   * probe: `true` (WordPress responded), `false` (conclusively down), or
+   * absent/null (never probed, or the most recent probe was inconclusive
+   * — see `app_probe_reason`). Independent of `up` (the reachability
+   * signal): a cached 200 (`up=true`) can coexist with `app_up=false` when
+   * a page cache is masking a dead PHP backend. Not currently rendered
+   * directly; `status_reason: "app_down"` already carries the
+   * user-facing explanation for this case (see `uptime-status.ts`).
+   */
+  app_up?: boolean | null;
+  /**
+   * Machine-readable reason for the most recent app-health verdict (e.g.
+   * "rest_5xx", "wp_fatal_error", "rest_forbidden"). Diagnostic only — not
+   * mapped to user-facing copy, so it is intentionally not rendered.
+   */
+  app_probe_reason?: string;
 }
 
 export interface FleetStatusSummary {

--- a/apps/web/src/features/fleet/uptime-status.ts
+++ b/apps/web/src/features/fleet/uptime-status.ts
@@ -54,6 +54,14 @@ export const STATUS_REASON_COPY: Record<string, string> = {
   agent_unreachable:
     "Serving visitors, but the site agent is not responding. Cached pages may be masking a broken backend.",
   agent_degraded: "Serving visitors, but the site agent is late checking in.",
+  // GH #291 — the reason the explanation feature exists: a page cache can
+  // keep serving a healthy-looking 200 while WordPress itself is dead
+  // behind it. Honest in both directions: visitors are NOT seeing an
+  // outage (so this must not read as "down"), but WordPress is not
+  // responding (so it must not read as "fine" either), and it points an
+  // operator at what is actually broken.
+  app_down:
+    "Serving visitors from cache, but WordPress is not responding. Logins, forms and the admin area are likely already broken.",
   slow_response: "Responding slowly.",
 };
 

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -4379,7 +4379,7 @@ export const FleetUptimeStatusItemSchema = {
     status_reason: {
       type: "string",
       description:
-        "Short machine-readable explanation for status, populated when\nstatus=degraded (agent_unreachable, agent_degraded, or\nslow_response). Empty/absent when the status needs no further\nexplanation.\n",
+        "Short machine-readable explanation for status, populated when\nstatus=degraded (agent_unreachable, agent_degraded, app_down, or\nslow_response). Empty/absent when the status needs no further\nexplanation.\n",
     },
     uptime_pct_7d: {
       type: "number",
@@ -4409,6 +4409,17 @@ export const FleetUptimeStatusItemSchema = {
     },
     health_status: {
       type: "string",
+    },
+    app_up: {
+      type: "boolean",
+      nullable: true,
+      description:
+        "GH #291 Phase 2 application-health verdict from the most recent\napp probe: true (WordPress responded), false (conclusively\ndown), or absent/null (never probed, or the most recent probe\nwas inconclusive; see app_probe_reason). Independent of `up`\n(the reachability signal, unchanged forever): a cached 200\n(up=true) can coexist with app_up=false when a page cache is\nmasking a dead PHP backend.\n",
+    },
+    app_probe_reason: {
+      type: "string",
+      description:
+        "Machine-readable reason for the most recent app-health verdict\n(agent_fresh, rest_ok, rest_5xx, wp_fatal_error, cache_hit,\nrest_forbidden, rest_absent, rest_4xx, rest_non_json,\nunreachable, rest_unexpected). Empty when no app probe has run\nyet.\n",
     },
   },
 } as const;

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -2231,7 +2231,7 @@ export type FleetUptimeStatusItem = {
   status: "up" | "degraded" | "down" | "unknown";
   /**
    * Short machine-readable explanation for status, populated when
-   * status=degraded (agent_unreachable, agent_degraded, or
+   * status=degraded (agent_unreachable, agent_degraded, app_down, or
    * slow_response). Empty/absent when the status needs no further
    * explanation.
    *
@@ -2245,6 +2245,26 @@ export type FleetUptimeStatusItem = {
   in_incident: boolean;
   connection_state: string;
   health_status: string;
+  /**
+   * GH #291 Phase 2 application-health verdict from the most recent
+   * app probe: true (WordPress responded), false (conclusively
+   * down), or absent/null (never probed, or the most recent probe
+   * was inconclusive; see app_probe_reason). Independent of `up`
+   * (the reachability signal, unchanged forever): a cached 200
+   * (up=true) can coexist with app_up=false when a page cache is
+   * masking a dead PHP backend.
+   *
+   */
+  app_up?: boolean;
+  /**
+   * Machine-readable reason for the most recent app-health verdict
+   * (agent_fresh, rest_ok, rest_5xx, wp_fatal_error, cache_hit,
+   * rest_forbidden, rest_absent, rest_4xx, rest_non_json,
+   * unreachable, rest_unexpected). Empty when no app probe has run
+   * yet.
+   *
+   */
+  app_probe_reason?: string;
 };
 
 export type FleetUptimeStatus = {

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.91
+  version: 0.61.92
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,
@@ -15172,7 +15172,7 @@ components:
           type: string
           description: |
             Short machine-readable explanation for status, populated when
-            status=degraded (agent_unreachable, agent_degraded, or
+            status=degraded (agent_unreachable, agent_degraded, app_down, or
             slow_response). Empty/absent when the status needs no further
             explanation.
         uptime_pct_7d:
@@ -15196,6 +15196,25 @@ components:
           type: string
         health_status:
           type: string
+        app_up:
+          type: boolean
+          nullable: true
+          description: |
+            GH #291 Phase 2 application-health verdict from the most recent
+            app probe: true (WordPress responded), false (conclusively
+            down), or absent/null (never probed, or the most recent probe
+            was inconclusive; see app_probe_reason). Independent of `up`
+            (the reachability signal, unchanged forever): a cached 200
+            (up=true) can coexist with app_up=false when a page cache is
+            masking a dead PHP backend.
+        app_probe_reason:
+          type: string
+          description: |
+            Machine-readable reason for the most recent app-health verdict
+            (agent_fresh, rest_ok, rest_5xx, wp_fatal_error, cache_hit,
+            rest_forbidden, rest_absent, rest_4xx, rest_non_json,
+            unreachable, rest_unexpected). Empty when no app probe has run
+            yet.
     FleetUptimeStatus:
       type: object
       required: [summary, items]


### PR DESCRIPTION
Addresses #291 phase 2 of 4. Phases 0, 1 and 4 are shipped (v0.61.90, v0.61.91). Phase 3 (alerting) follows.

## What this adds

Phase 1 caught the reported incident **indirectly**, by noticing the agent had gone unreachable. Phase 2 **measures it directly**, so a page-cached site with a dead backend is detected even when the agent state does not give it away.

The reporter confirmed the probe target empirically, on the exact stack that produced the outage:

```
GET /wp-json/  ->  cache MISS, cache-control: no-cache, must-revalidate
GET /          ->  cache HIT
```

He also confirmed the two-signal model is what he wants, because it keeps historical SLA figures stable.

## Two signals, not one

**`up` keeps its exact meaning forever.** A cached 200 is `up`, because visitors genuinely are being served. `app_up` is a new, orthogonal, **three-valued** signal (true / false / **unknown**) recorded on the *same* probe row.

Verified **bit-identical**: uptime percentages, `sites.health_status`, `site_incidents`, the client portal and white-label PDFs do not move. Both traps the design called out were avoided and re-verified:
- **Never a second row per sweep.** `site_uptime_daily` is keyed `(site_id, day)` with no kind dimension, so a second row would double `total_checks` and silently corrupt every uptime percentage in the product.
- **COALESCE/CASE guarded rollup.** The 300s app cadence against the 60s reachability cadence means ~4 in 5 upserts carry `app_up = NULL`; an unguarded upsert would clobber a known value 80% of the time.

## Cheap by design

If the agent heartbeat is fresh, that **already proves** PHP booted and WordPress loaded, so it records healthy and makes **zero network requests**. The HTTP probe only fires for sites already gone quiet, which is exactly when it is wanted. It piggybacks on the existing sweep with a stateless, hash-distributed cadence rather than adding a scheduler.

## Conservative by construction

Phase 3 turns these into pages, so the bar for "broken" is deliberately high. Exactly **two** conditions yield a conclusive app-down: **HTTP 500**, and a **200 carrying the WordPress fatal-page signature**.

Everything else is **unknown**, never false:

| Condition | Why not conclusive |
|---|---|
| Cache HIT | Reporting healthy when the bypass was defeated is worse than the original bug |
| **503** | What WordPress core maintenance mode emits, so a fleet update run by **this product** would paint every site app-down |
| **502 / 504** | The same evidence as a refusal or timeout seen secondhand via the site's proxy, both already unknown when seen directly |
| Other 5xx incl. CF 520-527 | Network-layer origin conditions, not PHP errors |
| 401 / 403 | Security plugins are common |
| 404 | Normal on REST-disabled installs |
| Timeout / transport / bad URL | No evidence the application ran and failed |

## Also

Cache detection was **generalised from a fixed vendor list to match the header shape**, after the reporter's own output showed a cache header we did not recognise, which would have produced a false healthy on the very stack that reported the bug.

## Review

Adversarially reviewed twice. Round one caught that the **Postgres read path was never extended** so the verdict was written but never surfaced, making the whole feature **invisible on the default backend and on hosted production**. It also caught the timeout, 503, shared-deadline and missing-UI-copy issues. All fixed and re-verified against a real Postgres.

**Alerting is deliberately not included**; that is phase 3 and ships opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LijsBvT79KkVsM8DY4tD1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WordPress application-health monitoring alongside existing site availability checks.
  * Sites serving cached pages while WordPress is unavailable now appear as degraded.
  * Added diagnostic health details, including unknown status when results are inconclusive.
  * Added support for configurable application probe paths and intervals.

* **Bug Fixes**
  * Improved detection of cache responses from previously unsupported cache providers.

* **Documentation**
  * Updated release documentation, API specifications, and version references for 0.61.92.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->