### PR TITLE
fix(uptime): give the sweep a real job budget so it is not cut off mid-flight

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -242,6 +242,13 @@ WPMGR_UPTIME_PROBE_TIMEOUT=15s
 WPMGR_UPTIME_PROBE_CONCURRENCY=10
 WPMGR_UPTIME_ALERT_INTERVAL=60s
 WPMGR_UPTIME_DOWN_THRESHOLD=2
+# Fleet size the probe sweep's River job Timeout() budget is sized against
+# (see uptime.DeriveProbeJobTimeout), deliberately NOT a live enrolled-site
+# count, which would go stale as the fleet grows. Raise only if a single
+# deployment's enrolled site count genuinely approaches this ceiling; a
+# larger fleet is not silently broken by leaving it as-is (the sweep degrades
+# to a partial-but-recorded result instead). Format: integer. Default 2000.
+#WPMGR_UPTIME_MAX_FLEET_SIZE=2000
 # WSOD detection kill-switch: an HTTP-200 response whose body is really a WP
 # fatal-error page is classified DOWN. On by default; ONLY "0" or "false"
 # (case-insensitive) disables it. Format: true|false.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.94] - 2026-07-27
+
+### Fixed
+
+- Uptime checks could be cut off partway through on a larger fleet, leaving gaps in uptime history with nothing to explain them. The job running a sweep was bound by a one minute limit, but a sweep of more than about forty sites can legitimately take longer when sites are slow to answer, which is exactly what happens during the fleet-wide problems the checks exist to catch. Some sites were then checked and recorded while the rest were quietly skipped, with no error. The limit is now derived from how long a sweep can actually take, and a sweep that still runs short of time now stops cleanly and records how many sites it managed rather than being cut off mid-flight.
+
 ## [0.61.93] - 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
   <a href="https://wpmgr.app/docs/">API reference</a>
 </p>
 
-**v0.61.93** — open-source and production-usable for self-hosters.
+**v0.61.94** — open-source and production-usable for self-hosters.
 
 ---
 
@@ -313,15 +313,15 @@ Site screenshot cards then fall back to favicon/monogram and the Media Optimizer
 The control plane, dashboard, and media encoder are published on GitHub Container Registry as multi-arch (`linux/amd64` + `linux/arm64`) images, for wiring into your own compose, Kubernetes, or Swarm setup:
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.93
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.93
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.93
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.94
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.94
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.94
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.93   # omit to track :latest
+export WPMGR_VERSION=v0.61.94   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -1103,6 +1103,42 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	} else {
 		logger.Info("uptime app-health probe disabled (WPMGR_UPTIME_APP_PROBE_ENABLED=false)")
 	}
+	// The uptime_probe River job otherwise inherits River's own 60s default
+	// (river.Config.JobTimeout is unset below), which only covers the
+	// reachability pass up to ~40 sites at the production defaults
+	// (ProbeConcurrency=10, ProbeTimeout=15s); past that, and further
+	// reduced once the GH #291 Phase 2 app-health pass adds its own work
+	// inside the same job, River silently cancels the sweep mid-flight: some
+	// sites get probed and recorded, the rest simply are not, with no error
+	// explaining the gap. Mirror the update/backup worker jobTimeout pattern
+	// (updateJobTimeout / backupJobTimeout, above): derive a job-level budget
+	// that genuinely covers the worst case for cfg.Uptime.MaxFleetSize sites
+	// instead of relying on the 60s default. See DeriveProbeJobTimeout's doc
+	// comment for the full arithmetic. appProbeTimeoutForBudget is 0 (the app
+	// pass contributes nothing to the budget) unless the app probe was
+	// actually wired above; the budget must match what Sweep can actually do
+	// this deployment, not what it could theoretically do if the feature were
+	// enabled.
+	appProbeTimeoutForBudget := time.Duration(0)
+	if cfg.Uptime.AppProbeEnabled {
+		appProbeTimeoutForBudget = cfg.Uptime.AppProbeTimeout
+	}
+	uptimeJobTimeout := uptime.DeriveProbeJobTimeout(
+		cfg.Uptime.ProbeConcurrency,
+		cfg.Uptime.ProbeTimeout,
+		cfg.Uptime.ProbeInterval,
+		cfg.Uptime.AppProbeInterval,
+		appProbeTimeoutForBudget,
+		cfg.Uptime.MaxFleetSize,
+	)
+	uptimeWorker.SetJobTimeout(uptimeJobTimeout)
+	resolvedMaxFleetSize := cfg.Uptime.MaxFleetSize
+	if resolvedMaxFleetSize <= 0 {
+		resolvedMaxFleetSize = uptime.DefaultMaxFleetSizeForProbeTimeout
+	}
+	logger.Info("uptime probe sweep job timeout configured",
+		slog.Duration("job_timeout", uptimeJobTimeout),
+		slog.Int("max_fleet_size", resolvedMaxFleetSize))
 	// GH #291 Phase 3 - app-health ALERTING numeric knobs. Safe to wire
 	// unconditionally: whenever the app probe is disabled (or a site never
 	// gets a conclusive verdict), ProbeWorker's app-alert transition step is

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -263,6 +263,21 @@ type UptimeConfig struct {
 	// into one aggregate notification. Default 0.25 (25%).
 	// Env: WPMGR_UPTIME_APP_ALERT_BREAKER_RATIO.
 	AppAlertBreakerRatio float64 `koanf:"app_alert_breaker_ratio"`
+
+	// MaxFleetSize is the fleet size the probe sweep's River job-level
+	// Timeout() budget is sized against (see uptime.DeriveProbeJobTimeout).
+	// It is deliberately NOT "however many sites are enrolled right now", a
+	// live count would go stale as the fleet grows and could silently
+	// reintroduce the exact job-timeout mismatch this budget exists to fix.
+	// Default 2000 (uptime.DefaultMaxFleetSizeForProbeTimeout), which
+	// comfortably exceeds any fleet this deployment has been operated
+	// against to date; raise it only if a single deployment's enrolled site
+	// count genuinely approaches that ceiling. A fleet that outgrows this
+	// value is still not silently broken: the sweep's own admission-control
+	// backstop degrades it to a partial-but-recorded result instead of an
+	// abrupt cancellation (see uptime.ProbeWorker.Sweep). <= 0 falls back to
+	// the default. Env: WPMGR_UPTIME_MAX_FLEET_SIZE.
+	MaxFleetSize int `koanf:"max_fleet_size"`
 }
 
 // S3Config holds the S3-compatible object-storage configuration (ADR-010).
@@ -599,6 +614,7 @@ func defaults() map[string]any {
 		"uptime.app_probe_timeout":          "10s",
 		"uptime.app_alert_threshold":        5,
 		"uptime.app_alert_breaker_ratio":    0.25,
+		"uptime.max_fleet_size":             2000,
 		"river.media_schema":                "media_encoder",
 		"autologin.require_2fa_step_up":     false,
 		"conn.degrade_after":                "300s",

--- a/apps/api/internal/uptime/worker.go
+++ b/apps/api/internal/uptime/worker.go
@@ -60,6 +60,18 @@ type ProbeWorker struct {
 	// DISPATCH is gated, per-tenant, on AlertConfig.AppAlertsEnabled.
 	appAlertThreshold    int
 	appAlertBreakerRatio float64
+
+	// jobTimeout overrides River's default 60s per-job context deadline (see
+	// Timeout, DeriveProbeJobTimeout, and the identical jobTimeout field on
+	// update.Worker / backup.BackupWorker for the same pattern applied to
+	// their own jobs). Sweep's worst-case wall-clock cost scales with the
+	// size of the fleet being probed (see DeriveProbeJobTimeout's doc
+	// comment), so the 60s default is only correct for a small fleet. Past
+	// that, River silently cancels the job mid-sweep: some sites get probed
+	// and recorded, the rest simply are not, with no error explaining the
+	// gap. Zero falls back to river.Config.JobTimeout, see Timeout's doc
+	// comment.
+	jobTimeout time.Duration
 }
 
 // defaultAppAlertThreshold is ~25 minutes at the documented 300s app-probe
@@ -122,6 +134,202 @@ func (w *ProbeWorker) SetAppAlertConfig(threshold int, breakerRatio float64) {
 	w.appAlertBreakerRatio = breakerRatio
 }
 
+// SetJobTimeout overrides River's default per-job context deadline for the
+// probe sweep (see Timeout). Call once at boot with
+// uptime.DeriveProbeJobTimeout(...), see that function's doc comment for the
+// arithmetic. Optional: a ProbeWorker this is never called on keeps
+// jobTimeout at its zero value, which Timeout reports back as 0 (defer to
+// river.Config.JobTimeout), so every existing caller/test is unaffected.
+func (w *ProbeWorker) SetJobTimeout(d time.Duration) {
+	w.jobTimeout = d
+}
+
+// Timeout overrides River's default per-job context deadline (60s) for the
+// uptime probe sweep, the same way update.Worker.Timeout and
+// backup.BackupWorker.Timeout do for their own jobs. Returning a positive
+// duration makes River use it instead of river.Config.JobTimeout; returning 0
+// keeps the default. River documents that returning -1 disables the deadline
+// entirely; we intentionally do NOT do that: a genuinely wedged sweep must
+// eventually error out so River can retry it. Sweep's own admission-control
+// backstop (see sweepBudgetExhausted) is meant to degrade a large-fleet sweep
+// gracefully well before this deadline is ever reached; Timeout is the last
+// resort behind it, not the primary mechanism.
+func (w *ProbeWorker) Timeout(*river.Job[ProbeArgs]) time.Duration { return w.jobTimeout }
+
+// DefaultMaxFleetSizeForProbeTimeout is the fleet size DeriveProbeJobTimeout
+// assumes when sizing the probe sweep's job-level Timeout() budget and no
+// more specific value is configured (see UptimeConfig.MaxFleetSize in
+// internal/config).
+//
+// The sweep's real worst case is not a fixed number: it scales with however
+// many sites ListEnrolledForProbe returns, which grows with the fleet and is
+// never a compile-time constant. Two ways to size a job Timeout() budget
+// against that moving target were considered:
+//
+//   - Derive it from the CURRENTLY enrolled site count (a live COUNT query at
+//     boot, or refreshed periodically). Rejected: the budget would then go
+//     stale as the fleet grows between boots/refreshes, silently
+//     reintroducing exactly the bug this function exists to fix, and a
+//     fleet-wide incident (the scenario that actually needs the larger
+//     budget) is also the scenario least likely to coincide with a recent
+//     redeploy.
+//   - A generous, deliberately FIXED ceiling, decoupled from the actual
+//     current fleet size and therefore immune to that staleness failure
+//     mode, configurable (WPMGR_UPTIME_MAX_FLEET_SIZE /
+//     UptimeConfig.MaxFleetSize) for an operator who legitimately runs a
+//     larger fleet than the default covers. This is what
+//     DefaultMaxFleetSizeForProbeTimeout does.
+//
+// 2000 is chosen to comfortably exceed any fleet size this deployment has
+// been operated against to date while still keeping the resulting Timeout()
+// (see DeriveProbeJobTimeout's worked example) under an hour, so a genuinely
+// wedged sweep is still caught in a reasonable window rather than only after
+// a multi-hour deadline. A fleet that outgrows this ceiling, configured or
+// default, is not silently broken by that: Sweep's own admission-control
+// backstop (sweepBudgetExhausted) stops admitting new sites once the job's
+// remaining budget can no longer safely cover another one, so the sweep still
+// finishes with a partial-but-recorded result and a logged skip count instead
+// of an abrupt River cancellation. Raising this value only widens the window
+// before that backstop would ever need to engage.
+const DefaultMaxFleetSizeForProbeTimeout = 2000
+
+// DeriveProbeJobTimeout computes the River job-level Timeout() budget for the
+// uptime probe sweep (see ProbeWorker.Timeout / SetJobTimeout). It reads the
+// actual sweep knobs (concurrency, both probe timeouts, and the app-probe
+// cadence ratio) rather than assuming them, so this stays correct if any of
+// them is ever tuned.
+//
+// Sweep's worst-case wall-clock budget, in the order the work happens (see
+// Sweep):
+//
+//  1. reachability pass: every one of maxFleetSize sites is probed under the
+//     `sem` semaphore (bounded to `concurrency` in flight at once), each
+//     probe hard-capped at probeTimeout:
+//     ceil(maxFleetSize / concurrency) * probeTimeout
+//     (this term alone reproduces the mismatch this function exists to fix:
+//     at the production defaults, concurrency=10 and probeTimeout=15s, a
+//     500-site fleet already costs ceil(500/10)*15s = 750s, twelve and a
+//     half times River's 60s default.)
+//  2. app-health pass (only when appProbeTimeout > 0, i.e. SetAppProber was
+//     called, see NewProbeWorker/SetAppProber's zero-value-safe doc
+//     comments): appProbeDue buckets sites into `ratio` = max(1,
+//     appProbeInterval / probeInterval) roughly-even groups keyed on site
+//     ID (mirroring appProbeDue's own defaults and integer arithmetic
+//     exactly, so this budget always matches what Sweep actually does at
+//     runtime), so AT MOST ceil(maxFleetSize / ratio) sites attempt an app
+//     probe on any single tick, each bounded by appProbeTimeout under the
+//     separate `appSem` semaphore (also sized `concurrency`):
+//     ceil(ceil(maxFleetSize / ratio) / concurrency) * appProbeTimeout
+//  3. headroom, mirroring update.DeriveApplyJobTimeout's `+2*time.Minute`:
+//     scheduling jitter, the sequential per-site TransitionAlertState /
+//     SetSiteHealth writes that run after wg.Wait() (cheap per site, but not
+//     exactly zero at fleet scale), and appProbeDue's bucketing being only
+//     APPROXIMATELY even (a real hash is not a perfectly balanced
+//     partition): a protective margin, not a separately itemized worst
+//     case.
+//
+// maxFleetSize is deliberately NOT "however many sites are enrolled right
+// now", see DefaultMaxFleetSizeForProbeTimeout's doc comment for why a live
+// count would be the wrong input here. A value <= 0 falls back to
+// DefaultMaxFleetSizeForProbeTimeout.
+//
+// With the production defaults (concurrency=10, probeTimeout=15s,
+// appProbeTimeout=10s, probeInterval=60s, appProbeInterval=300s so ratio=5,
+// maxFleetSize=DefaultMaxFleetSizeForProbeTimeout=2000) this computes to
+// 50m0s (reachability) + 6m40s (app) + 2m (headroom) = 58m40s.
+//
+// Returns 0 (defer to river.Config.JobTimeout) when concurrency or
+// probeTimeout is not positive, so a zero/misconfigured input never produces
+// a misleadingly small nonzero timeout that omits the reachability pass it is
+// meant to cover.
+func DeriveProbeJobTimeout(concurrency int, probeTimeout, probeInterval, appProbeInterval, appProbeTimeout time.Duration, maxFleetSize int) time.Duration {
+	if concurrency <= 0 || probeTimeout <= 0 {
+		return 0
+	}
+	if maxFleetSize <= 0 {
+		maxFleetSize = DefaultMaxFleetSizeForProbeTimeout
+	}
+
+	reachabilityPass := time.Duration(ceilDivInt(maxFleetSize, concurrency)) * probeTimeout
+
+	var appPass time.Duration
+	if appProbeTimeout > 0 {
+		// Mirror appProbeDue's own interval defaults and ratio arithmetic
+		// exactly (see its doc comment) so this budget always matches what
+		// Sweep will actually do at runtime.
+		pi := probeInterval
+		if pi <= 0 {
+			pi = time.Minute
+		}
+		api := appProbeInterval
+		if api <= 0 {
+			api = 5 * time.Minute
+		}
+		ratio := int(api / pi)
+		if ratio < 1 {
+			ratio = 1
+		}
+		appSites := ceilDivInt(maxFleetSize, ratio)
+		appPass = time.Duration(ceilDivInt(appSites, concurrency)) * appProbeTimeout
+	}
+
+	const headroom = 2 * time.Minute
+	return reachabilityPass + appPass + headroom
+}
+
+// ceilDivInt returns ceil(n/d) for n >= 0 and d >= 1, without floating point.
+// d <= 0 is treated as 1 (never divides by zero); n <= 0 returns 0.
+func ceilDivInt(n, d int) int {
+	if d <= 0 {
+		d = 1
+	}
+	if n <= 0 {
+		return 0
+	}
+	return (n + d - 1) / d
+}
+
+// probeAdmissionBudget is the worst-case wall-clock ONE already-admitted
+// site's goroutine can still take to finish (see Sweep): the reachability
+// probe (w.prober's own configured timeout) plus, when the app-health probe
+// is wired (SetAppProber), its own timeout too. These are additive rather
+// than overlapping for a single site because the app probe only starts AFTER
+// the reachability probe finishes and releases `sem` (see the release-order
+// comment in Sweep).
+func (w *ProbeWorker) probeAdmissionBudget() time.Duration {
+	if w.prober == nil {
+		return 0
+	}
+	budget := w.prober.timeout
+	if w.appProber != nil {
+		budget += w.appProber.timeout
+	}
+	return budget
+}
+
+// sweepBudgetExhausted reports whether the sweep's job context is close
+// enough to its own deadline that admitting one more site risks that site's
+// probe being abruptly cancelled mid-flight instead of completing and being
+// recorded. This is Sweep's graceful-degradation backstop for the case
+// DeriveProbeJobTimeout budgets for (see its doc comment): a fleet that has
+// grown past the configured/default ceiling. A context with no deadline
+// (context.Background(), every existing unit/integration test in this
+// package) never trips this: it is not a change to normal-sized-fleet
+// behavior, only a backstop for when the job's own deadline is genuinely
+// close. admissionBudget <= 0 (an unconfigured prober, never happens via
+// NewProbeWorker, but guarded defensively) also never trips this, since there
+// is then no meaningful worst case to compare against.
+func sweepBudgetExhausted(ctx context.Context, admissionBudget time.Duration) bool {
+	if admissionBudget <= 0 {
+		return false
+	}
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return false
+	}
+	return time.Until(deadline) < admissionBudget
+}
+
 // Work runs one sweep.
 func (w *ProbeWorker) Work(ctx context.Context, _ *river.Job[ProbeArgs]) error {
 	_, err := w.Sweep(ctx, time.Now())
@@ -154,7 +362,26 @@ func (w *ProbeWorker) Sweep(ctx context.Context, now time.Time) (int, error) {
 		wg     sync.WaitGroup
 	)
 
-	for _, s := range sites {
+	// GH follow-up (job-timeout mismatch): stop ADMITTING new sites once the
+	// job's own remaining context budget can no longer safely cover one more
+	// site's worst case (see sweepBudgetExhausted / probeAdmissionBudget /
+	// DeriveProbeJobTimeout). Sites admitted before the cutoff are completely
+	// unaffected by this: they run to completion and are recorded exactly as
+	// before. `sites` is reassigned to the admitted prefix below so every
+	// later use in this function (InsertChecks/UpsertRollup already only ever
+	// see admitted results via `checks`; the alert-processing loop and the
+	// returned count both range over `sites` directly) automatically covers
+	// only what was actually probed. A skipped site is left completely
+	// untouched (no health_status write, no alert-state transition) rather
+	// than misread as "down", which reading its zero-value ProbeResult would
+	// otherwise produce.
+	admissionBudget := w.probeAdmissionBudget()
+	admitted := len(sites)
+	for i, s := range sites {
+		if sweepBudgetExhausted(ctx, admissionBudget) {
+			admitted = i
+			break
+		}
 		s := s
 		wg.Add(1)
 		sem <- struct{}{}
@@ -225,6 +452,22 @@ func (w *ProbeWorker) Sweep(ctx context.Context, now time.Time) (int, error) {
 		}()
 	}
 	wg.Wait()
+
+	if admitted < len(sites) {
+		// The gap this closes: previously River would simply cancel the
+		// whole job at the Timeout() deadline, leaving no error and no
+		// record explaining which sites were skipped. This log line, plus
+		// the fact that `sites` below only covers what was actually
+		// admitted, is what turns that into a documented partial result
+		// instead of a silent hole in uptime history. The next periodic
+		// tick (ProbeInterval, ~60s) picks up every site regardless, so this
+		// sweep does not need to remember which ones it skipped.
+		w.logger.Warn("uptime sweep: job budget nearly exhausted; stopped admitting new sites mid-sweep",
+			slog.Int("sites_total", len(sites)),
+			slog.Int("sites_admitted", admitted),
+			slog.Int("sites_skipped", len(sites)-admitted))
+		sites = sites[:admitted]
+	}
 
 	// Batch-write the time-series (no-op when ClickHouse is disabled).
 	if err := w.store.InsertChecks(ctx, checks); err != nil {

--- a/apps/api/internal/uptime/worker_test.go
+++ b/apps/api/internal/uptime/worker_test.go
@@ -1,7 +1,9 @@
 package uptime
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -92,4 +94,183 @@ func TestAppFireDownOnlyFiltersRecoveries(t *testing.T) {
 	if out := appFireDownOnly([]pendingAppFire{recovery1, recovery2}); len(out) != 0 {
 		t.Fatalf("appFireDownOnly(all recoveries) = %+v, want empty", out)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// ProbeWorker.Timeout / SetJobTimeout - the job-timeout mismatch fix. The
+// uptime_probe River job otherwise inherits River's own 60s default
+// (river.Config.JobTimeout is unset in cmd/wpmgr/main.go), which only covers
+// the reachability pass up to ~40 sites at the production defaults
+// (ProbeConcurrency=10, ProbeTimeout=15s); past that, River silently cancels
+// the sweep mid-flight with no error explaining which sites were skipped.
+// ---------------------------------------------------------------------------
+
+// TestProbeWorker_Timeout mirrors update.TestWorker_Timeout /
+// backup.BackupWorker.Timeout's own test coverage: SetJobTimeout threads a
+// positive duration straight through to Timeout(), and the zero value (every
+// existing NewProbeWorker call site, since none of them call SetJobTimeout)
+// reports back as exactly 0 - the documented signal for "fall back to
+// river.Config.JobTimeout" (see river's job executor, which uses cmp.Or) -
+// rather than an accidental instant timeout.
+func TestProbeWorker_Timeout(t *testing.T) {
+	t.Run("SetJobTimeout threads a positive duration through to Timeout()", func(t *testing.T) {
+		w := &ProbeWorker{}
+		w.SetJobTimeout(42 * time.Minute)
+		if got := w.Timeout(nil); got != 42*time.Minute {
+			t.Fatalf("Timeout() = %v, want 42m (the duration passed to SetJobTimeout)", got)
+		}
+	})
+
+	t.Run("never calling SetJobTimeout falls back to River's default, not an instant timeout", func(t *testing.T) {
+		w := &ProbeWorker{}
+		if got := w.Timeout(nil); got != 0 {
+			t.Fatalf("Timeout() = %v, want 0 (river falls back to river.Config.JobTimeout on exactly 0)", got)
+		}
+	})
+
+	t.Run("SetJobTimeout(0) is indistinguishable from never calling it", func(t *testing.T) {
+		w := &ProbeWorker{}
+		w.SetJobTimeout(42 * time.Minute)
+		w.SetJobTimeout(0)
+		if got := w.Timeout(nil); got != 0 {
+			t.Fatalf("Timeout() = %v, want 0 after SetJobTimeout(0)", got)
+		}
+	})
+}
+
+// TestDeriveProbeJobTimeout pins the arithmetic DeriveProbeJobTimeout uses to
+// size the probe sweep's River Timeout(): ceil(maxFleetSize/concurrency) *
+// probeTimeout (reachability) + ceil(ceil(maxFleetSize/ratio)/concurrency) *
+// appProbeTimeout (app-health, only when wired) + a fixed 2-minute headroom,
+// and the documented fallback behavior for each unset/invalid input.
+func TestDeriveProbeJobTimeout(t *testing.T) {
+	const (
+		concurrency      = 10
+		probeTimeout     = 15 * time.Second
+		probeInterval    = 60 * time.Second
+		appProbeInterval = 300 * time.Second
+		appProbeTimeout  = 10 * time.Second
+	)
+
+	t.Run("production defaults at the default fleet-size ceiling: 50m reachability + 6m40s app + 2m headroom = 58m40s", func(t *testing.T) {
+		got := DeriveProbeJobTimeout(concurrency, probeTimeout, probeInterval, appProbeInterval, appProbeTimeout, DefaultMaxFleetSizeForProbeTimeout)
+		want := 58*time.Minute + 40*time.Second
+		if got != want {
+			t.Fatalf("DeriveProbeJobTimeout(...) = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("maxFleetSize <= 0 falls back to DefaultMaxFleetSizeForProbeTimeout", func(t *testing.T) {
+		want := DeriveProbeJobTimeout(concurrency, probeTimeout, probeInterval, appProbeInterval, appProbeTimeout, DefaultMaxFleetSizeForProbeTimeout)
+		if got := DeriveProbeJobTimeout(concurrency, probeTimeout, probeInterval, appProbeInterval, appProbeTimeout, 0); got != want {
+			t.Fatalf("DeriveProbeJobTimeout(maxFleetSize=0) = %v, want %v (same as the explicit default)", got, want)
+		}
+		if got := DeriveProbeJobTimeout(concurrency, probeTimeout, probeInterval, appProbeInterval, appProbeTimeout, -1); got != want {
+			t.Fatalf("DeriveProbeJobTimeout(maxFleetSize=-1) = %v, want %v (same as the explicit default)", got, want)
+		}
+	})
+
+	t.Run("reachability-only term matches the documented ceil(N/concurrency)*probeTimeout formula at N=500", func(t *testing.T) {
+		// The motivating worked example: at the production defaults a 500-site
+		// fleet's reachability pass alone already costs ceil(500/10)*15s =
+		// 750s, twelve and a half times River's 60s default.
+		got := DeriveProbeJobTimeout(concurrency, probeTimeout, probeInterval, appProbeInterval, 0, 500)
+		want := 750*time.Second + 2*time.Minute // + the fixed headroom
+		if got != want {
+			t.Fatalf("DeriveProbeJobTimeout(maxFleetSize=500, app disabled) = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("appProbeTimeout <= 0 (app probe never wired via SetAppProber) omits the app pass entirely", func(t *testing.T) {
+		withApp := DeriveProbeJobTimeout(concurrency, probeTimeout, probeInterval, appProbeInterval, appProbeTimeout, DefaultMaxFleetSizeForProbeTimeout)
+		withoutApp := DeriveProbeJobTimeout(concurrency, probeTimeout, probeInterval, appProbeInterval, 0, DefaultMaxFleetSizeForProbeTimeout)
+		if withoutApp >= withApp {
+			t.Fatalf("DeriveProbeJobTimeout(appProbeTimeout=0) = %v, want < %v (the app pass with it wired)", withoutApp, withApp)
+		}
+		wantWithoutApp := 50*time.Minute + 2*time.Minute
+		if withoutApp != wantWithoutApp {
+			t.Fatalf("DeriveProbeJobTimeout(appProbeTimeout=0) = %v, want %v (reachability + headroom only)", withoutApp, wantWithoutApp)
+		}
+	})
+
+	t.Run("zero concurrency falls back to 0, not a misleadingly small nonzero budget", func(t *testing.T) {
+		if got := DeriveProbeJobTimeout(0, probeTimeout, probeInterval, appProbeInterval, appProbeTimeout, DefaultMaxFleetSizeForProbeTimeout); got != 0 {
+			t.Fatalf("DeriveProbeJobTimeout(concurrency=0) = %v, want 0", got)
+		}
+	})
+
+	t.Run("zero probeTimeout falls back to 0, not a misleadingly small nonzero budget", func(t *testing.T) {
+		if got := DeriveProbeJobTimeout(concurrency, 0, probeInterval, appProbeInterval, appProbeTimeout, DefaultMaxFleetSizeForProbeTimeout); got != 0 {
+			t.Fatalf("DeriveProbeJobTimeout(probeTimeout=0) = %v, want 0", got)
+		}
+	})
+
+	t.Run("zero probeInterval/appProbeInterval mirror appProbeDue's own defaults (60s/300s) rather than dividing by zero", func(t *testing.T) {
+		got := DeriveProbeJobTimeout(concurrency, probeTimeout, 0, 0, appProbeTimeout, DefaultMaxFleetSizeForProbeTimeout)
+		want := DeriveProbeJobTimeout(concurrency, probeTimeout, probeInterval, appProbeInterval, appProbeTimeout, DefaultMaxFleetSizeForProbeTimeout)
+		if got != want {
+			t.Fatalf("DeriveProbeJobTimeout(probeInterval=0, appProbeInterval=0) = %v, want %v (same as explicit 60s/300s)", got, want)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Sweep's admission-control backstop - a fleet larger than the configured/
+// default ceiling degrades to a partial-but-recorded sweep instead of an
+// abrupt River cancellation. See ProbeWorker.Sweep and DeriveProbeJobTimeout.
+// ---------------------------------------------------------------------------
+
+func TestSweepBudgetExhausted(t *testing.T) {
+	t.Run("no context deadline never trips it (every existing test/call site)", func(t *testing.T) {
+		if sweepBudgetExhausted(context.Background(), time.Hour) {
+			t.Fatal("sweepBudgetExhausted(no deadline) = true, want false")
+		}
+	})
+
+	t.Run("admissionBudget <= 0 never trips it even with an imminent deadline", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Millisecond))
+		defer cancel()
+		if sweepBudgetExhausted(ctx, 0) {
+			t.Fatal("sweepBudgetExhausted(admissionBudget=0) = true, want false")
+		}
+	})
+
+	t.Run("deadline comfortably beyond the admission budget is false", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Hour))
+		defer cancel()
+		if sweepBudgetExhausted(ctx, 25*time.Second) {
+			t.Fatal("sweepBudgetExhausted(deadline 1h away, budget 25s) = true, want false")
+		}
+	})
+
+	t.Run("deadline within the admission budget is true", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
+		defer cancel()
+		if !sweepBudgetExhausted(ctx, 25*time.Second) {
+			t.Fatal("sweepBudgetExhausted(deadline 5s away, budget 25s) = false, want true")
+		}
+	})
+}
+
+func TestProbeWorker_ProbeAdmissionBudget(t *testing.T) {
+	t.Run("reachability timeout only when no app prober is wired", func(t *testing.T) {
+		w := &ProbeWorker{prober: NewProber(nil, 15*time.Second)}
+		if got := w.probeAdmissionBudget(); got != 15*time.Second {
+			t.Fatalf("probeAdmissionBudget() = %v, want 15s", got)
+		}
+	})
+
+	t.Run("reachability + app timeout when the app prober is wired (SetAppProber)", func(t *testing.T) {
+		w := &ProbeWorker{prober: NewProber(nil, 15*time.Second), appProber: NewAppProber(nil, 10*time.Second)}
+		if got := w.probeAdmissionBudget(); got != 25*time.Second {
+			t.Fatalf("probeAdmissionBudget() = %v, want 25s (15s reachability + 10s app)", got)
+		}
+	})
+
+	t.Run("nil prober is guarded defensively", func(t *testing.T) {
+		w := &ProbeWorker{}
+		if got := w.probeAdmissionBudget(); got != 0 {
+			t.Fatalf("probeAdmissionBudget() = %v, want 0", got)
+		}
+	})
 }

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.93
+  version: 0.61.94
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Follow-up to #291, found while fixing phase 4. Filed separately to stay reviewable.

## The bug

`uptime.ProbeWorker` embedded `river.WorkerDefaults` with **no `Timeout()` override**, and `river.Config` sets no `JobTimeout`, so every sweep ran on River's **1 minute** default.

The sweep's own worst case passes that well before a fleet gets large. With the defaults (concurrency 10, probe timeout 15s), the reachability pass alone is `ceil(sites/10) * 15s`:

| Sites | Worst case | vs 1 min |
|---|---|---|
| 20 | 30s | ok |
| **40** | **60s** | exactly at the limit |
| 80 | 120s | exceeds |
| 200 | 300s | exceeds |
| 500 | 750s | exceeds |

And #291 phase 2 then added the application-health pass into the same job.

## Why it is worse than an ordinary timeout bug

**It only bites during incidents.** The worst case assumes probes run to their full timeout, which happens when sites are slow or unreachable. Day to day probes return in well under a second, so this is invisible in normal operation and fires precisely during the fleet-wide problem the monitoring exists to catch.

**Failure was silent and partial.** River cancelled the job mid-sweep, so some sites were probed and recorded and the rest simply were not: no results, no alert evaluation for the unprocessed tail, and no error explaining the gap. An operator sees holes in uptime history with nothing to correlate them to.

Same class as the `update.Worker` budget fixed in #294, but bounding a **batch** rather than a single call.

## The fix

`DeriveProbeJobTimeout` computes the budget from the real constants (reachability pass + app-health pass when wired + 2 minutes headroom), mirroring `DeriveApplyJobTimeout`. At production defaults with the 2000-site ceiling: `50m + 6m40s + 2m = 58m40s`.

**On the fleet-size input:** deliberately a generous fixed ceiling (2000, configurable via `WPMGR_UPTIME_MAX_FLEET_SIZE`) rather than a live enrolled-site count. A count read at boot goes stale as the fleet grows, which would silently reintroduce this exact bug during the exact scenario it guards against.

**Self-bounding backstop** (the difference between a silent gap and a known partial result): `Sweep` now stops admitting sites once the remaining deadline cannot cover one more site's worst case, logs `sites_total` / `sites_admitted` / `sites_skipped`, and truncates the slice so the rest of `Sweep` never misreads an unprobed site as **down**. A context with no deadline never triggers it, so existing behaviour is unchanged.

## Follow-ups found, deliberately not fixed here

- **`uptime.CronKicker`** has the identical shape and crosses 60s past roughly 130 sites. Low severity (a kick failure is already silently swallowed and self-heals next tick), same root cause.
- **`backup.GCWorker`** has no `Timeout()` override despite `BackupWorker`, `RestoreWorker` and `SqlInspectLegacyWorker` in the same file already using the `jobTimeout` pattern. Notably `gc.go`'s own comment claims the periodic GCWorker "is the authoritative backstop regardless" — which is not true today, because no bound exists there either. A doc asserting a safety property that does not exist.
- Lighter-weight candidates not deeply audited: `backup.ScheduleWorker`, `backup.ProgressWatchdogWorker`, `site.HealthCheckWorker`.

## Verification

`go build`/`vet` clean; `internal/uptime` and `internal/config` suites green; all 27 uptime-related integration tests pass against real Postgres. New tests cover the derived arithmetic at production defaults, the 500-site spot-check reproducing the 750s figure above, the zero-value fallbacks, and the admission backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LijsBvT79KkVsM8DY4tD1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved uptime sweeps for larger fleets by dynamically sizing execution time.
  * Prevented mid-sweep cancellations; when limits are reached, processing stops cleanly and reports skipped sites.
  * Included optional application health checks in timeout calculations.

* **Configuration**
  * Added a configurable maximum fleet size for timeout planning, defaulting to 2,000 sites.

* **Documentation**
  * Updated release, API, container image, and configuration documentation to version 0.61.94.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->