### PR TITLE
fix(agent): reclaim backup working files when a backup gives up (GH #256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.95] - 2026-07-27
+
+### Fixed
+
+- A failed backup left its working files on the site instead of cleaning up after itself (GH #256). When a backup gave up, the control plane deleted its record, but the site kept the half-finished working directory: upload parts, copied plugins and themes, and the database dump. One reported site was left with roughly 1.4 GB spread across seven part files of about 198 MB each. There were four separate paths in the agent's backup watchdog that could give up on a backup (a hard time ceiling, a late-phase stall, running out of resume attempts, and a stale-task guard), and none of them cleaned up the working directory. All four now reclaim it, but only after taking the same run-lock a live backup holds before deleting anything: a backup that is merely slow and still running keeps its working directory untouched, and cleanup is left for a later sweep.
+- The routine cleanup that reclaims old backup working directories, and the separate one that clears leftover files after a restore, both depended entirely on WP-Cron, so on a site where WP-Cron is disabled, unreliable, or simply has no visitors to trigger it, neither ever ran and nothing was ever reclaimed. Both now also run on an ordinary page load, throttled to once an hour for backup working directories and once every fifteen minutes for restore leftovers, so a busy site pays effectively nothing for them. The restore cleanup also had a way to wedge itself permanently: it scheduled itself as a one-shot event, and once its scheduled time passed without firing, WordPress still counted it as "already scheduled", so every later restore skipped scheduling a new one and cleanup never ran again. An overdue event is now detected and replaced with a fresh one.
+- The backup delete dialog said deleting a backup "reclaims its storage", but the site's own temporary files stayed on the host regardless. The wording now says what actually happens, and notes that the site cleans up its own temporary files separately.
+- The Sites grid could show a green "Backups" indicator next to a red "Failed" badge for the same site. The indicator lit up whenever a site had any backup status at all, including a failed one, so a failed backup still looked healthy at a glance. It has been removed; the backup chip beside it already shows the real status.
+- Two other backup failures visible in the original report were already fixed in earlier releases: the "runner already in flight" refusal (0.61.84) and the missing local chunk on upload after an interrupted backup (0.61.87).
+
 ## [0.61.94] - 2026-07-27
 
 ### Fixed

--- a/apps/agent/includes/backup/class-backup-janitor.php
+++ b/apps/agent/includes/backup/class-backup-janitor.php
@@ -152,7 +152,40 @@ class BackupJanitor
                 continue; // Belt-and-suspenders: the task row says it's still live.
             }
 
-            $j->deleteDir($dir);
+            // GH #256 finding 3 (post-ship re-review): isActiveRun() above
+            // is itself derived purely from DB-column signals (phase +
+            // last_progress_at staleness) that cannot distinguish a
+            // genuinely abandoned run from one that is simply quiet on
+            // last_progress_at while still alive and writing. Every
+            // give-up branch in Watchdog::resumeIfStalled()/dispatch()
+            // deliberately DELETEs the task row without gating on liveness,
+            // so "no row" (isActiveRun()'s other "not active" case) is
+            // exactly the state EVERY one of those give-up branches leaves
+            // behind, live run or not. Worse, this directory's own mtime
+            // does not advance when a file's CONTENTS are written (only
+            // when an entry is added/removed within it), so a long
+            // single-file database dump can leave a live run's directory
+            // looking untouched for well past RUNS_GC_AGE_SECONDS. Before
+            // deleting, take the exact same run-lock TaskRunner::run()
+            // itself relies on for correctness (TaskRunner::withRunLock(),
+            // GH #256 finding 1) and run the delete from inside it, so a
+            // live runner's flock (held for as long as its process is
+            // alive, independent of any DB row or directory mtime) is the
+            // final word. Deliberately attempted only here, AFTER both the
+            // age gate and the isActiveRun() veto already passed, so a tidy
+            // site, nothing old enough to even consider, never pays the
+            // cost of constructing a TaskRunner or touching a lock file.
+            try {
+                $runner = new TaskRunner(['snapshot_id' => $item, 'scratch_dir' => $dir]);
+                $runner->withRunLock(function () use ($j, $dir): void {
+                    $j->deleteDir($dir);
+                });
+            } catch (\Throwable $e) {
+                // A lock-gate failure for one directory must never abort the
+                // sweep for the rest of this pass; the next scheduled tick
+                // gets a fresh try at this same directory.
+                continue;
+            }
         }
     }
 
@@ -312,7 +345,23 @@ class BackupJanitor
  * in-flight window: 3x Watchdog::STALL_THRESHOLD_SECONDS's sibling hard
  * re-entry ceiling (class-watchdog.php's 7200s/2h "refuse to re-enter an
  * implausibly long-running task" guard) and roughly 12x the ~30-minute
- * longest legitimate backup observed on a real WP host. No sweepable
- * directory can therefore ever host a run that is still legitimately
- * running.
+ * longest legitimate backup observed on a real WP host.
+ *
+ * GH #256 finding 3 (post-ship re-review) corrected an overstatement that
+ * used to sit here: the age gate alone does NOT prove a sweepable directory
+ * can never host a still-running run. A directory's mtime only advances when
+ * an entry is added, removed, or renamed within it, never when an existing
+ * file's CONTENTS are written, so a single large database dump streaming
+ * into `database.sql.gz` for hours can leave the run directory's own mtime
+ * unchanged the entire time, and every Watchdog give-up branch deliberately
+ * DELETEs the task row regardless of whether the run is actually still
+ * alive, which is exactly the state isActiveRun()'s "no row" case cannot
+ * distinguish from a genuinely dead run. gcRuns() therefore takes one more
+ * step before deleting a run directory that has passed both the age gate and
+ * the isActiveRun() veto: it acquires the run-lock TaskRunner::run() itself
+ * relies on for correctness (TaskRunner::withRunLock(); see that method's
+ * doc, and GH #256 finding 1) and performs the delete only from inside it.
+ * That lock, held by the OS for as long as the owning process is alive and
+ * independent of any DB row or directory mtime, is what actually closes the
+ * gap the age gate and the task-row veto alone cannot.
  */

--- a/apps/agent/includes/backup/class-restore-runner.php
+++ b/apps/agent/includes/backup/class-restore-runner.php
@@ -2287,8 +2287,31 @@ final class RestoreRunner
         }
 
         if (function_exists('wp_next_scheduled') && function_exists('wp_schedule_single_event')) {
-            if (!wp_next_scheduled('wpmgr_restore_oldfiles_gc')) {
-                wp_schedule_single_event($expiresAt + 60, 'wpmgr_restore_oldfiles_gc');
+            $gcHook           = 'wpmgr_restore_oldfiles_gc';
+            $existingSchedule = wp_next_scheduled($gcHook);
+            // GH #256: a one-shot event that is scheduled but OVERDUE (i.e.
+            // WP-Cron never ticked past its timestamp, on a quiet site or one
+            // with DISABLE_WP_CRON set) stays in the cron array forever, so
+            // wp_next_scheduled() keeps returning it as truthy and every
+            // LATER restore's runCleanup() would otherwise decline to
+            // schedule a replacement here: one missed tick permanently
+            // poisons this trigger for every restore that follows. Treat an
+            // overdue timestamp as "nothing usefully scheduled": clear it
+            // and fall through to scheduling a fresh one, rather than
+            // leaving a self-poisoning no-op event in place. (The
+            // Plugin::maybeGcRestoreArtifacts() plugins_loaded trigger now
+            // drives both GC sweeps independently of this cron event too,
+            // so this hook is a backstop rather than the only trigger, but
+            // a trigger that can permanently disable itself should not be
+            // left in place regardless.)
+            if ($existingSchedule !== false && $existingSchedule < time()) {
+                if (function_exists('wp_unschedule_event')) {
+                    wp_unschedule_event($existingSchedule, $gcHook);
+                }
+                $existingSchedule = false;
+            }
+            if ($existingSchedule === false) {
+                wp_schedule_single_event($expiresAt + 60, $gcHook);
             }
         }
 

--- a/apps/agent/includes/backup/class-task-runner.php
+++ b/apps/agent/includes/backup/class-task-runner.php
@@ -515,6 +515,113 @@ final class TaskRunner
     // ==================================================================
 
     /**
+     * GH #256 (post-ship review, finding 1, TOCTOU): acquire run()'s own two
+     * mutual-exclusion guards (GET_LOCK then flock, the exact same order and
+     * the exact same per-snapshot names run() itself uses), invoke
+     * $callback while BOTH are held, and release both in a `finally`,
+     * regardless of whether $callback returns normally or throws.
+     *
+     * This exists so a caller entirely OUTSIDE run() (Watchdog's terminal
+     * give-up paths and BackupJanitor::gcRuns(), both of which construct a
+     * throwaway TaskRunner purely to reclaim a snapshot's scratch directory
+     * once its task row/age is judged dead) can perform that reclaim using
+     * the same locks run() relies on for correctness, instead of a second,
+     * independently maintained liveness heuristic that could disagree with
+     * the real one. Making the lock itself the liveness signal, held for
+     * the FULL duration of the reclaim rather than merely probed beforehand,
+     * is what closes the race where a live runner is still writing chunks
+     * into the scratch directory while a give-up path deletes it out from
+     * under the process.
+     *
+     * The earlier shape of this guard (a bool-returning `isRunLockFree()`
+     * probe, checked by the caller, which then did its own file deletion
+     * AFTER this method had already released both locks) left exactly the
+     * TOCTOU window this method exists to close: on a multi-hour backup with
+     * thousands of chunk files, the caller's own glob-and-unlink sweep could
+     * easily still be running tens of milliseconds after the probe reported
+     * "free", by which time a resumed/re-entered runner could have started
+     * writing into the same directory again. Folding the actual reclaim work
+     * INTO the locked critical section, never a separate probe-then-act pair
+     * of calls, removes that window entirely.
+     *
+     * GH #256 finding 2 (fail-open): unlike run()'s own inline guard (left
+     * intentionally unchanged, see its doc), this method treats a flock
+     * guard that could not even be ATTEMPTED (acquireFileLock() returning
+     * `['handle' => null, 'contended' => false]`, meaning an unresolvable
+     * lock path, a wp_mkdir_p() failure, or a fopen() failure from
+     * permissions / open_basedir / a read-only filesystem) as NOT provably
+     * free, and never invokes $callback. That degraded outcome is a
+     * legitimate reason for run() to forge ahead without a flock guard
+     * (worst case: a wasted duplicate run, the phase machine is idempotent),
+     * but here the consequence of proceeding is a DELETE: absence of proof
+     * that no one else is running is not proof of absence, so this path
+     * refuses rather than gambles.
+     *
+     * @param callable(): void $callback Invoked only when BOTH guards were
+     *                                    acquired free of contention AND the
+     *                                    flock guard was genuinely attempted
+     *                                    (not degraded). Runs with both
+     *                                    guards held for its entire
+     *                                    duration.
+     * @return bool True when $callback ran. False when GET_LOCK reported
+     *              contention, the flock reported contention, or the flock
+     *              guard degraded to "could not be attempted"; in every
+     *              false case $callback was never invoked and the caller
+     *              must leave the snapshot's files untouched this pass.
+     */
+    public function withRunLock(callable $callback): bool
+    {
+        $lockToken = $this->getLock();
+        if ($lockToken === '0') {
+            return false;
+        }
+        $lockHeld = ($lockToken === '1');
+
+        $fileLock = $this->acquireFileLock();
+
+        // GH #256 finding 2: a degraded (unattemptable) flock guard is NOT
+        // "free" on this reclaim-only path; see this method's doc.
+        if ($fileLock['handle'] === null && $fileLock['contended'] === false) {
+            if ($lockHeld) {
+                $this->releaseLock();
+            }
+            return false;
+        }
+
+        if ($fileLock['contended']) {
+            if ($lockHeld) {
+                $this->releaseLock();
+            }
+            return false;
+        }
+
+        /** @var resource $fileLockHandle */
+        $fileLockHandle = $fileLock['handle'];
+
+        try {
+            $callback();
+        } finally {
+            if ($lockHeld) {
+                $this->releaseLock();
+            }
+            // Release the flock FIRST (LOCK_UN + fclose); only THEN, with
+            // the fd closed, unlink the lock file itself (same ordering
+            // run()'s own `finally` uses; see cleanupFileLock()'s doc).
+            // $callback ran, which means this snapshot's scratch state is
+            // being reclaimed regardless of $callback's own outcome, and
+            // there is no future resume left to protect. The coordination
+            // file this call opened (or found already orphaned) is always
+            // reclaimed here rather than left behind as a fresh zero-byte
+            // file for BackupJanitor::gcRuns()'s own age-gated sweep to find
+            // later.
+            $this->releaseFileLock($fileLockHandle);
+            $this->cleanupFileLock();
+        }
+
+        return true;
+    }
+
+    /**
      * MySQL advisory-lock name for this snapshot's run. 9 + 36 = 45 chars,
      * well under MySQL's 64-character GET_LOCK() name limit.
      */
@@ -1559,6 +1666,55 @@ final class TaskRunner
     // ==================================================================
 
     /**
+     * Decode a raw `sub_state` DB column value, following the sidecar-spill
+     * pointer to disk when present (see SUBSTATE_SIDECAR_THRESHOLD /
+     * saveTaskState()). This is the SAME rehydration loadTask() applies to
+     * its own read, factored out as a shared static helper so any other
+     * caller that only has the raw column value from an already-SELECTed
+     * row (Watchdog's give-up paths, none of which go through loadTask()
+     * because they must read sub_state.params BEFORE deciding whether to
+     * re-enter run() at all) gets the exact same sidecar-aware behavior
+     * instead of a second, independently duplicated (and, until GH #256
+     * finding 5, silently sidecar-blind) decode.
+     *
+     * @param mixed $raw Raw `sub_state` column value.
+     * @return array<string,mixed> Decoded sub_state, or [] on any failure
+     *                             (missing column, invalid JSON, unreadable
+     *                             sidecar file).
+     */
+    public static function decodeSubStateColumn($raw): array
+    {
+        if (!is_string($raw) || $raw === '') {
+            return [];
+        }
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        // Sidecar rehydration: when the DB column holds a pointer (written
+        // by saveTaskState() when sub_state exceeded
+        // SUBSTATE_SIDECAR_THRESHOLD), read the full cursor from disk. This
+        // is exactly the case that matters most for a scratch reclaim: the
+        // biggest runs (the most scratch to reclaim) are the ones most
+        // likely to have spilled.
+        if (!empty($decoded[self::SUBSTATE_SIDECAR_KEY]) && isset($decoded['file']) && is_string($decoded['file'])) {
+            $sidecarPath = (string) $decoded['file'];
+            if (is_file($sidecarPath)) {
+                $sidecarRaw = @file_get_contents($sidecarPath);
+                if ($sidecarRaw !== false && $sidecarRaw !== '') {
+                    $full = json_decode($sidecarRaw, true);
+                    if (is_array($full)) {
+                        $decoded = $full;
+                    }
+                }
+            }
+        }
+
+        return $decoded;
+    }
+
+    /**
      * Load the task row by snapshot_id. Returns null if the row doesn't exist.
      *
      * @return array{phase:string,kind:string,sub_state:array<string,mixed>,resume_count:int,max_resumes:int}|null
@@ -1585,28 +1741,7 @@ final class TaskRunner
             return null;
         }
 
-        $sub = [];
-        if (isset($row['sub_state']) && is_string($row['sub_state']) && $row['sub_state'] !== '') {
-            $decoded = json_decode($row['sub_state'], true);
-            if (is_array($decoded)) {
-                // Sidecar rehydration: when the DB column holds a pointer
-                // (written by saveTaskState when sub_state exceeded the
-                // SUBSTATE_SIDECAR_THRESHOLD), read the full cursor from disk.
-                if (!empty($decoded[self::SUBSTATE_SIDECAR_KEY]) && isset($decoded['file']) && is_string($decoded['file'])) {
-                    $sidecarPath = (string) $decoded['file'];
-                    if (is_file($sidecarPath)) {
-                        $raw = @file_get_contents($sidecarPath);
-                        if ($raw !== false && $raw !== '') {
-                            $full = json_decode($raw, true);
-                            if (is_array($full)) {
-                                $decoded = $full;
-                            }
-                        }
-                    }
-                }
-                $sub = $decoded;
-            }
-        }
+        $sub = self::decodeSubStateColumn($row['sub_state'] ?? null);
 
         return [
             'phase'        => (string) ($row['phase'] ?? self::PHASE_QUEUED),
@@ -1992,7 +2127,9 @@ final class TaskRunner
      *
      * Called from inside the top-level catch in run(); failures here are
      * swallowed by the caller so a second exception never masks the
-     * original failure.
+     * original failure. ALSO called via the public reclaimScratch()
+     * wrapper below (GH #256) by callers outside run() entirely; see that
+     * method's doc.
      */
     private function cleanupOnFailed(): void
     {
@@ -2058,6 +2195,45 @@ final class TaskRunner
         // fine; BackupJanitor::gcRuns() is still the age-gated backstop for
         // any artifact this best-effort sweep missed).
         @rmdir($scratch); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- removes an empty server-derived scratch dir; WP_Filesystem not initialized
+    }
+
+    /**
+     * GH #256: public wrapper around cleanupOnFailed() so a caller OUTSIDE
+     * this instance's own run() (specifically, Watchdog's terminal give-up
+     * paths: the 7200s hard-ceiling guard, the late-phase stale guard, the
+     * max-resumes exhaustion, and dispatch()'s stale-task guard, every path
+     * that discards a task row without ever entering run()'s own try/catch)
+     * can reclaim this run's scratch directory through the EXACT same,
+     * already-tested file-level sweep run() itself uses on a caught failure,
+     * instead of a second, independently-duplicated implementation.
+     *
+     * Constructing a TaskRunner purely to call this has no I/O side effect
+     * of its own. The constructor builds an OPTIONAL ProgressClient when
+     * `progress_endpoint` is a non-empty string in $params; the caller here
+     * (Watchdog::reclaimRunScratch()) reconstructs `$params` from
+     * sub_state.params, the same array BackupCommand originally seeded, so
+     * `progress_endpoint` is normally PRESENT and a ProgressClient IS built.
+     * That construction is still side-effect free: ProgressClient's own
+     * constructor only assigns properties, and this method never calls
+     * postProgress()/the client's post() method, touches $wpdb, or touches
+     * the task row; it is a pure filesystem sweep keyed off
+     * $params['scratch_dir']. The caller (Watchdog::reclaimRunScratch(), and
+     * BackupJanitor::gcRuns() for its own run-directory sweep) invokes this
+     * method from INSIDE the callback it hands to withRunLock() on the SAME
+     * constructed instance, never a separate probe-then-call, so this
+     * runs only while both run-lock guards are held for the caller, closing
+     * the TOCTOU window a standalone probe would otherwise leave open.
+     *
+     * Never touches the wpmgr_backup_tasks / wpmgr_backup_runs rows (same
+     * contract as cleanupOnFailed()). The caller owns discarding the row
+     * and must read whatever it needs from it BEFORE calling this, since
+     * this reads only $this->params, never the row.
+     *
+     * @return void
+     */
+    public function reclaimScratch(): void
+    {
+        $this->cleanupOnFailed();
     }
 
     // ==================================================================

--- a/apps/agent/includes/backup/class-watchdog.php
+++ b/apps/agent/includes/backup/class-watchdog.php
@@ -144,6 +144,18 @@ final class Watchdog
         $startedAt = (int) ($row['started_at'] ?? 0);
         $age       = time() - $startedAt;
         if ($startedAt > 0 && $age > 7200) {
+            // GH #256: reclaim this run's scratch directory BEFORE the row
+            // (the only record of where that scratch lives) is deleted
+            // below. A row "running" for over 2h with no completion is a
+            // strong signal by itself, but not a certain one: an unusually
+            // large site can legitimately take that long, so
+            // reclaimRunScratch() does not treat this age alone as proof
+            // the run is dead. It reclaims the file only from INSIDE
+            // TaskRunner's own run-lock (TaskRunner::withRunLock()), and
+            // skips the file reclaim entirely (deferring to
+            // BackupJanitor::gcRuns()) if a live runner still holds it. See
+            // reclaimRunScratch()'s own doc for the full rationale.
+            self::reclaimRunScratch($row);
             // DELETE the row (not just mark failed) so the next watchdog
             // tick finds nothing and immediately returns. We DON'T touch
             // the CP — the snapshot's CP-side status is whatever the
@@ -161,12 +173,32 @@ final class Watchdog
 
         // SAFETY 2 (Bug 2 fix): refuse to re-enter a task whose phase has
         // been stuck at `encrypting_uploading` or `submitting_manifest` for
-        // more than 5 minutes. These are the LATE phases of the pipeline —
+        // more than 5 minutes. These are the LATE phases of the pipeline;
         // if we got that far the artifacts are already uploaded and the
         // manifest is either submitted or about to be. Re-entering would
         // re-issue presignChunks calls the CP would 422-reject (the
-        // observed bug). Strong signal: dead/stale row regardless of
-        // started_at age.
+        // observed bug).
+        //
+        // GH #256 finding 4 (post-ship review): this 300s figure is NOT a
+        // reliable dead-run signal on its own. The GH #279 heartbeat is
+        // emitted BETWEEN chunks, so a single large chunk upload on a slow
+        // link can legitimately exceed 300s of database silence while the
+        // runner is completely alive. Kept at 300s deliberately, for two
+        // separate reasons rather than one:
+        //   - As the trigger for the ROW discard below, 300s is fine: the
+        //     row is only bookkeeping, and every other give-up branch in
+        //     this method already accepts that a live runner can lose its
+        //     row (see the class doc's re-entry contract) without harming
+        //     the in-flight run itself.
+        //   - As the trigger for the FILE reclaim, the number itself no
+        //     longer needs to be conservative, because reclaimRunScratch()
+        //     no longer trusts this threshold as proof of death: it
+        //     reclaims files only from inside TaskRunner's own run-lock
+        //     (TaskRunner::withRunLock()) and skips deleting any file
+        //     when a live runner still holds it, deferring to
+        //     BackupJanitor::gcRuns() instead. A slow-but-alive upload that
+        //     trips this 300s gate simply has its reclaim attempt safely
+        //     no-op.
         $lastProgress = (int) ($row['last_progress_at'] ?? 0);
         $stalledFor   = time() - $lastProgress;
         if (
@@ -174,6 +206,14 @@ final class Watchdog
                 || $phase === TaskRunner::PHASE_SUBMITTING_MANIFEST)
             && $stalledFor > 300
         ) {
+            // GH #256: reclaim scratch BEFORE discarding the row. This is
+            // the LARGEST leak this fix closes: at this late phase every
+            // zip part and every encrypted chunk file is already on disk
+            // (see the class doc's "reporter's screenshot shape" note).
+            // See reclaimRunScratch()'s own doc and the SAFETY 2 note above
+            // for why this is now gated on the run-lock rather than on
+            // $stalledFor alone.
+            self::reclaimRunScratch($row);
             // @phpstan-ignore-next-line — dynamic wpdb.
             @$wpdb->delete($table, ['snapshot_id' => $snapshotId], ['%s']); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct delete on plugin-owned table; late-phase stale-row cleanup
             DebugLog::write(sprintf(
@@ -194,27 +234,49 @@ final class Watchdog
         $resumeCount = (int) ($row['resume_count'] ?? 0);
         $maxResumes  = (int) ($row['max_resumes'] ?? 6);
         if ($resumeCount >= $maxResumes) {
-            // Give up — too many resume attempts. Mark failed so the CP
-            // and UI see a terminal state. The TaskRunner's own
-            // bookkeeping does this normally; doing it here too is
-            // defensive (the runner might be wedged in a way we can't
-            // re-enter).
+            // Give up: too many resume attempts. The runner might be
+            // wedged in a way we can't re-enter.
             //
             // If the task never left the `queued` phase (phase=queued AND
             // resume_count already at max), the runner was never dispatched
-            // at all — strong signal that both the spawn_cron loopback and
+            // at all: strong signal that both the spawn_cron loopback and
             // the in-process fallback failed to start the runner. Detect the
             // loopback-gate scenario and surface a clear, actionable reason.
             $failureReason = self::detectQueuedStallReason($phase, $snapshotId);
+
+            // GH #256: reclaim scratch BEFORE discarding the row. This
+            // branch is only reached after $resumeCount >= $maxResumes
+            // (default 6) SEPARATE stall detections, each already requiring
+            // STALL_THRESHOLD_SECONDS (180s) of silence, a stronger dead-run
+            // signal than either single-stall guard above, but still not a
+            // certain one on its own for the reason explained in
+            // reclaimRunScratch()'s own doc: the file reclaim inside that
+            // call only ever runs from inside TaskRunner's own run-lock
+            // (TaskRunner::withRunLock()) and skips deleting any file
+            // when a live runner still holds it.
+            //
+            // DELETE the row rather than marking it failed (the pre-#256
+            // behavior): a row left at phase=failed here was never revisited
+            // by anything else in the agent (sweepStalled()'s own query
+            // excludes terminal phases, so the row leaked forever), and
+            // WORSE, a later re-entry into TaskRunner::run() for this exact
+            // snapshot_id (e.g. a CP retry reusing the same id) would find
+            // phase=failed and short-circuit at the "terminal? no-op" check
+            // BEFORE ever reaching the catch block that calls
+            // cleanupOnFailed(), so the scratch could never be reclaimed for
+            // that snapshot again. Deleting the row here, mirroring every
+            // other give-up branch in this method, closes both gaps at
+            // once and matches BackupJanitor::isActiveRun()'s own existing
+            // assumption that no row for a snapshot means "not active,
+            // defer to the age gate" (never a live run). Nothing else in the
+            // agent reads wpmgr_backup_tasks once a snapshot is terminal;
+            // the failure reason is still captured below via DebugLog for
+            // local troubleshooting, and the CP's own progress-watchdog
+            // independently times the snapshot out on its side regardless.
+            self::reclaimRunScratch($row);
             // @phpstan-ignore-next-line
-            @$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct update on plugin-owned table; correctness requires a live write
-                $table,
-                ['phase' => TaskRunner::PHASE_FAILED, 'last_progress_at' => time(), 'sub_state' => (string) wp_json_encode(['reason_code' => 'stalled', 'phase_detail' => ['message' => $failureReason]])],
-                ['snapshot_id' => $snapshotId],
-                ['%s', '%d', '%s'],
-                ['%s']
-            );
-            DebugLog::write(sprintf('WPMgr Backup: snapshot %s exhausted %d resume attempts; marked failed. %s', $snapshotId, $maxResumes, $failureReason));
+            @$wpdb->delete($table, ['snapshot_id' => $snapshotId], ['%s']); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct delete on plugin-owned table; terminal give-up, no further recovery is ever attempted for this row
+            DebugLog::write(sprintf('WPMgr Backup: snapshot %s exhausted %d resume attempts; reclaimed scratch and deleted row. %s', $snapshotId, $maxResumes, $failureReason));
             return;
         }
 
@@ -244,6 +306,97 @@ final class Watchdog
         // runner reads phase + sub_state and dispatches.
         $runner = new TaskRunner($params);
         $runner->run();
+    }
+
+    /**
+     * GH #256: reclaim a give-up path's scratch directory BEFORE the task
+     * row that names it is discarded (deleted, in every branch that calls
+     * this). Reuses TaskRunner::reclaimScratch() (itself a thin wrapper
+     * around the existing, already-tested cleanupOnFailed() file-level
+     * sweep) rather than a second, independently-duplicated implementation.
+     *
+     * Every give-up path that calls this already holds the freshly-SELECTed
+     * $row in memory: this decodes sub_state.params from THAT row (never
+     * issues a second query) and reads everything it needs before the
+     * caller's own row DELETE runs.
+     *
+     * SAFETY (post-ship review, ship blocker, findings 1/2/3): a task row
+     * reaching one of this method's four call sites (resumeIfStalled()'s
+     * 7200s hard-ceiling guard, its late-phase 300s stale guard, its
+     * max-resumes exhaustion, and dispatch()'s 7200s stale-task guard) is
+     * judged "dead" purely from DB-column signals: started_at age,
+     * last_progress_at age, resume_count. None of those signals can
+     * distinguish a genuinely abandoned run from one that is still alive
+     * and simply has not posted progress recently (for example, a single
+     * large chunk upload on a slow link legitimately blocking for minutes
+     * with no callback in between). A large site's backup can legitimately
+     * run for hours. Deleting a LIVE runner's scratch directory out from
+     * under it while it is actively writing chunks is far worse than the
+     * disk leak this method exists to close.
+     *
+     * GH #256 finding 1 (TOCTOU, post-ship re-review): this used to acquire
+     * the EXACT SAME run-lock guards TaskRunner::run() itself takes for this
+     * snapshot via a standalone probe (TaskRunner::isRunLockFree()),
+     * release them immediately, and only THEN call reclaimScratch() as a
+     * separate step. That left a window between "the probe reported free"
+     * and "the glob-and-unlink sweep actually finished" spanning the whole
+     * cleanup (globs plus N unlinks, tens of milliseconds on a run with
+     * thousands of chunk files) during which a resumed/re-entered runner
+     * could start writing into the same directory again. This now calls
+     * TaskRunner::withRunLock(), which acquires the exact same guards
+     * (GET_LOCK then flock) and invokes the reclaim callback WHILE holding
+     * both, releasing them only once the callback returns, so there is no
+     * gap between "checked" and "used":
+     *   - Lock acquired: no live runner is working this snapshot right now
+     *     (run() itself would also be free to proceed), so the reclaim
+     *     callback runs and the scratch directory is removed before the
+     *     lock is ever released.
+     *   - Lock held by someone else (or the flock guard could not even be
+     *     attempted, GH #256 finding 2, see TaskRunner::withRunLock()'s
+     *     doc): the scratch directory is left untouched.
+     *     BackupJanitor::gcRuns() (its own 6h age gate, isActiveRun() veto,
+     *     and, GH #256 finding 3, the same run-lock gate) remains the
+     *     safe backstop that reclaims it once the run genuinely finishes or
+     *     is abandoned.
+     * The lock is the liveness signal here, not a second, independently
+     * maintained heuristic that could disagree with the one run() itself
+     * relies on for correctness. This does not change the caller's row
+     * DELETE, which proceeds regardless: only the file reclaim is gated.
+     *
+     * Best-effort and defensive: sub_state.params (or its scratch_dir) may
+     * be absent (a row seeded by something other than BackupCommand, or a
+     * corrupt sub_state), in which case there is no scratch_dir to resolve
+     * and this is a silent no-op, exactly like every other best-effort
+     * cleanup in this class. A thrown reclaim failure is swallowed so it can
+     * never mask (or block) the give-up path's own row discard.
+     *
+     * @param array<string,mixed> $row Task row already loaded by the caller.
+     * @return void
+     */
+    private static function reclaimRunScratch(array $row): void
+    {
+        $subState = self::decodeSubState($row['sub_state'] ?? '');
+        $params   = is_array($subState['params'] ?? null) ? $subState['params'] : null;
+        if (!is_array($params) || !isset($params['scratch_dir']) || !is_string($params['scratch_dir']) || $params['scratch_dir'] === '') {
+            return;
+        }
+
+        $snapshotId = isset($row['snapshot_id']) && is_string($row['snapshot_id']) ? $row['snapshot_id'] : '';
+
+        try {
+            $runner   = new TaskRunner($params);
+            $reclaimed = $runner->withRunLock(static function () use ($runner): void {
+                $runner->reclaimScratch();
+            });
+            if (!$reclaimed) {
+                DebugLog::write(sprintf(
+                    'WPMgr Backup: watchdog declined to reclaim scratch for snapshot %s: the run-lock is held by a live runner (or could not be proven free); leaving the scratch directory for BackupJanitor::gcRuns()',
+                    $snapshotId
+                ));
+            }
+        } catch (\Throwable $e) {
+            DebugLog::write('WPMgr Backup: watchdog scratch reclaim failed: ' . $e->getMessage());
+        }
     }
 
     /**
@@ -311,6 +464,17 @@ final class Watchdog
         // (observed in M5.6 ADR-034 live QA, mid-restore).
         $startedAt = (int) ($row['started_at'] ?? 0);
         if ($startedAt > 0 && (time() - $startedAt) > 7200 && $phase !== TaskRunner::PHASE_QUEUED) {
+            // GH #256: reclaim scratch BEFORE the row (the only record of
+            // where it lives) is deleted below. Same 7200s dead-run premise
+            // as resumeIfStalled()'s own hard-ceiling guard above, and the
+            // same caveat: an unusually large site can legitimately still
+            // be running at this age, so the file reclaim inside
+            // reclaimRunScratch() does not rely on this age check alone. It
+            // only ever reclaims files from inside TaskRunner's own
+            // run-lock (TaskRunner::withRunLock()) and skips deleting any
+            // file when a live runner still holds it, deferring to
+            // BackupJanitor::gcRuns(). See reclaimRunScratch()'s own doc.
+            self::reclaimRunScratch($row);
             // @phpstan-ignore-next-line — dynamic wpdb.
             @$wpdb->delete($table, ['snapshot_id' => $snapshotId], ['%s']); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct delete on plugin-owned table; stale dispatch cleanup
             DebugLog::write(sprintf(
@@ -566,13 +730,26 @@ final class Watchdog
         return $generic;
     }
 
-    /** Best-effort JSON decode. Returns [] on any failure. */
+    /**
+     * Best-effort JSON decode of a raw `sub_state` column value. Delegates
+     * to TaskRunner::decodeSubStateColumn() (rather than a second,
+     * independently maintained decode) so this class follows the exact
+     * same sidecar-spill rehydration TaskRunner::loadTask() applies.
+     *
+     * GH #256 finding 5: a bare json_decode() here (the pre-fix behavior)
+     * returned only the small `{"_sidecar":true,...}` pointer object for
+     * any task whose cursor had spilled to the sidecar file, which
+     * silently dropped `sub_state.params` for every caller of this method,
+     * including reclaimRunScratch()'s own read of `scratch_dir`, on
+     * exactly the largest runs (the ones with the most scratch to
+     * reclaim, and the ones most likely to trip TaskRunner's
+     * SUBSTATE_SIDECAR_THRESHOLD in the first place).
+     *
+     * Returns [] on any failure (missing column, invalid JSON, unreadable
+     * sidecar file).
+     */
     private static function decodeSubState($raw): array
     {
-        if (!is_string($raw) || $raw === '') {
-            return [];
-        }
-        $decoded = json_decode($raw, true);
-        return is_array($decoded) ? $decoded : [];
+        return TaskRunner::decodeSubStateColumn($raw);
     }
 }

--- a/apps/agent/includes/class-lifecycle.php
+++ b/apps/agent/includes/class-lifecycle.php
@@ -471,6 +471,8 @@ final class Lifecycle
             'wpmgr_oc_outage_marker', // WPMgr_Object_Cache::FAILBACK_MARKER_OPTION (H5).
             'wpmgr_snapshot_gc_last', // SnapshotManager::OPTION_GC_LAST (GH #226 GC throttle stamp).
             Plugin::OPTION_BACKUP_SWEEP_LAST, // GH #232 stalled-backup reaper throttle stamp.
+            Plugin::OPTION_BACKUP_JANITOR_LAST, // GH #256 backup-scratch GC (BackupJanitor::gcRuns()) throttle stamp.
+            Plugin::OPTION_RESTORE_GC_LAST, // GH #256 restore-rollback-material GC throttle stamp.
         ];
     }
 }

--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -170,6 +170,57 @@ final class Plugin
      */
     private const BACKUP_SWEEP_THROTTLE_SECONDS = 60;
 
+    /**
+     * GitHub issue #256: Unix timestamp of the last WP-Cron-independent
+     * backup-scratch GC sweep (BackupJanitor::gcRuns()), stamped BEFORE the
+     * sweep runs. Read by maybeGcBackupRuns() to throttle the sweep to once
+     * per BACKUP_JANITOR_THROTTLE_SECONDS. Mirrors
+     * SnapshotManager::OPTION_GC_LAST / OPTION_BACKUP_SWEEP_LAST's throttle
+     * pattern exactly. Owned by the agent, removed on uninstall via
+     * Lifecycle::ownedOptions().
+     */
+    public const OPTION_BACKUP_JANITOR_LAST = 'wpmgr_backup_janitor_gc_last';
+
+    /**
+     * Throttle window for maybeGcBackupRuns(): gcRuns() itself is cheap per
+     * invocation (GH #256: a constant read plus one is_dir() on a site with
+     * no backups, one scandir() on a tidy one; BackupJanitor::RUNS_GC_AGE_SECONDS
+     * (6h) already bounds each top-level entry to single digits), so this
+     * does not need the 60s cadence maybeSweepStalledBackups() uses to
+     * recover an ACTIVELY stalled, still-time-sensitive run. It also does not
+     * need to run every request: gcRuns() only ever reclaims directories that
+     * are already at least RUNS_GC_AGE_SECONDS (6h) stale, so an hourly
+     * cadence adds at most ~1h of extra opportunistic-reclaim delay on top of
+     * that 6h floor, negligible relative to the leak this closes (which was
+     * previously "never", not "up to 7h"). Matches
+     * SnapshotManager::maybeGc()'s hourly throttle exactly, since both are
+     * opportunistic backstops for the same class of job (a daily cron GC that
+     * a quiet/DISABLE_WP_CRON site may never fire).
+     */
+    private const BACKUP_JANITOR_THROTTLE_SECONDS = 3600;
+
+    /**
+     * GitHub issue #256: Unix timestamp of the last WP-Cron-independent
+     * restore-rollback-material GC sweep (FilesRestorer::gcOldFiles() +
+     * RestoreRunner::gcPreRestoreDumps()), stamped BEFORE the sweep runs.
+     * Read by maybeGcRestoreArtifacts() to throttle the sweep to once per
+     * RESTORE_GC_THROTTLE_SECONDS. Owned by the agent, removed on uninstall
+     * via Lifecycle::ownedOptions().
+     */
+    public const OPTION_RESTORE_GC_LAST = 'wpmgr_restore_gc_last';
+
+    /**
+     * Throttle window for maybeGcRestoreArtifacts(). FilesRestorer's default
+     * retention window (OLDFILES_GC_AGE_SECONDS, 1h) is 6x shorter than
+     * BackupJanitor::RUNS_GC_AGE_SECONDS (6h), so this uses a shorter
+     * throttle than BACKUP_JANITOR_THROTTLE_SECONDS to keep the worst-case
+     * extra opportunistic-reclaim delay proportionate to that shorter
+     * window, while remaining cheap even at that cadence (both sweeps are a
+     * handful of glob() calls against directories that typically match
+     * nothing).
+     */
+    private const RESTORE_GC_THROTTLE_SECONDS = 900;
+
     private static ?Plugin $instance = null;
 
     private Keystore $keystore;
@@ -562,6 +613,38 @@ final class Plugin
         // option (stamped BEFORE the sweep runs), so this costs one cheap
         // get_option() read on every other request.
         add_action('plugins_loaded', [$this, 'maybeSweepStalledBackups']);
+
+        // GitHub issue #256: WP-Cron-INDEPENDENT, throttled reclaim trigger
+        // for BackupJanitor::gcRuns() (the backup pipeline's
+        // wpmgr-agent/runs/ scratch-dir GC backstop). Root cause: gcRuns()
+        // was bound ONLY to its daily wpmgr_backup_runs_gc cron event, the
+        // exact same WP-Cron-dependency gap that maybeGcSnapshots() and
+        // maybeSweepStalledBackups() (both immediately above) already close
+        // for their own stores. A quiet/low-traffic site, or one with
+        // DISABLE_WP_CRON set, could delete a failed backup from the
+        // dashboard and never again see a request that fires this event, so
+        // the on-host scratch (DB dump, zip parts, chunk files) leaked
+        // forever regardless of the age gate. Mirrors maybeGcSnapshots() /
+        // maybeSweepStalledBackups() exactly; see maybeGcBackupRuns()'s own
+        // doc for the full gating/throttle/safety contract.
+        add_action('plugins_loaded', [$this, 'maybeGcBackupRuns']);
+
+        // GitHub issue #256: WP-Cron-INDEPENDENT, throttled reclaim trigger
+        // for the restore pipeline's deferred rollback material:
+        // FilesRestorer::gcOldFiles() (`.wpmgr-old-*` / `.wpmgr-staging-*`
+        // trees) and RestoreRunner::gcPreRestoreDumps() (the pre-restore DB
+        // dump), both previously reachable ONLY via a wp_schedule_single_event
+        // ONE-SHOT scheduled at the end of a successful RestoreRunner::runCleanup(),
+        // worse than a recurring cron gap: a crashed/aborted restore never
+        // schedules the event at all, and even a scheduled-but-unfired event
+        // (WP-Cron never ticked) stays in the cron array and silently
+        // suppresses every later restore's attempt to schedule a replacement
+        // (see the one-shot fix in RestoreRunner::runCleanup() for that half).
+        // Both GC targets are gated by their own on-disk `.expires` markers
+        // (written well after the live swap completes), so calling them from
+        // every request is safe by construction; see maybeGcRestoreArtifacts()'s
+        // own doc.
+        add_action('plugins_loaded', [$this, 'maybeGcRestoreArtifacts']);
 
         // M14: Guard against Performance Lab disabling our object-cache drop-in.
         // When the OC is configured (config file exists), register the filter so
@@ -1485,6 +1568,149 @@ final class Plugin
             // A reaper sweep failure must never break the caller (a request
             // handler bound to plugins_loaded); the next throttled attempt
             // 60s from now gets a fresh try.
+        }
+    }
+
+    /**
+     * GitHub issue #256: WP-Cron-independent GC trigger for
+     * BackupJanitor::gcRuns() (the backup pipeline's wpmgr-agent/runs/
+     * scratch-dir GC backstop). See registerHooks()'s binding comment for
+     * the root cause this closes.
+     *
+     * Mirrors maybeGcSnapshots() / maybeSweepStalledBackups() exactly:
+     *   - Gated on isEnrolled(): a not-yet-enrolled site has never had a
+     *     backup run (and therefore never a leaked run directory) to reap.
+     *   - Throttled to once per BACKUP_JANITOR_THROTTLE_SECONDS (1h) via a
+     *     stored option, stamped BEFORE the sweep runs: a slow or failing
+     *     sweep can never be retried on every single request within the
+     *     window; the next throttled attempt gets a fresh try regardless of
+     *     whether this one succeeded.
+     *   - BackupJanitor::gcRuns() is wrapped in try/catch: a GC sweep is
+     *     best-effort disk-hygiene housekeeping, never a condition that may
+     *     break the request (or hook) that happened to trigger it.
+     *
+     * SAFETY: gcRuns() itself already enforces the two guards that make this
+     * safe to call opportunistically (the RUNS_GC_AGE_SECONDS (6h) mtime
+     * gate and the isActiveRun() task-row veto, see BackupJanitor's own
+     * design notes); this method adds NEITHER new deletion logic NOR a
+     * weaker gate. It only adds a cron-independent trigger for the exact
+     * same, already-guarded sweep the daily cron already ran.
+     *
+     * @return void
+     */
+    public function maybeGcBackupRuns(): void
+    {
+        if (!$this->settings->isEnrolled()) {
+            return;
+        }
+        if (!function_exists('get_option') || !function_exists('update_option')) {
+            return;
+        }
+
+        $now  = time();
+        $last = (int) get_option(self::OPTION_BACKUP_JANITOR_LAST, 0);
+        if ($now - $last < self::BACKUP_JANITOR_THROTTLE_SECONDS) {
+            return;
+        }
+
+        // Stamp BEFORE running, see this method's doc for why.
+        update_option(self::OPTION_BACKUP_JANITOR_LAST, $now, true);
+
+        try {
+            BackupJanitor::gcRuns();
+        } catch (\Throwable $e) {
+            // A GC sweep failure must never break the caller (a request
+            // handler bound to plugins_loaded); the next throttled attempt
+            // gets a fresh try.
+        }
+    }
+
+    /**
+     * GitHub issue #256: WP-Cron-independent GC trigger for the restore
+     * pipeline's deferred rollback material: FilesRestorer::gcOldFiles()
+     * (`.wpmgr-old-*` / `.wpmgr-staging-*` trees) and
+     * RestoreRunner::gcPreRestoreDumps() (the pre-restore DB dump). See
+     * registerHooks()'s binding comment for the root cause this closes.
+     *
+     * Mirrors maybeGcBackupRuns() / maybeGcSnapshots() / maybeSweepStalledBackups():
+     *   - Gated on isEnrolled(): a not-yet-enrolled site has never run a
+     *     restore (and therefore never has rollback material to reap).
+     *   - Throttled to once per RESTORE_GC_THROTTLE_SECONDS (15 min) via a
+     *     stored option, stamped BEFORE the sweep runs.
+     *   - Each GC call is independently wrapped in try/catch so a failure in
+     *     one (e.g. gcOldFiles()) can never suppress the other
+     *     (gcPreRestoreDumps()), and neither can ever break the caller.
+     *
+     * SAFETY (corrected, GH #256 post-ship review: the prior wording here
+     * overstated this): RestoreRunner::gcPreRestoreDumps() IS gated
+     * entirely by its own on-disk `<path>.expires` sidecar markers; it
+     * skips any per-restore directory that has none at all. RestoreRunner
+     * writes each marker with a future unix timestamp only once the live
+     * swap has already completed and the restore has moved past the point
+     * that material is needed for an in-flight rollback, and the method
+     * itself refuses to touch anything whose marker has not yet expired.
+     *
+     * FilesRestorer::gcOldFiles() is marker-gated for the same `.expires`
+     * paths, but it ALSO carries a separate legacy/crash-only fallback
+     * (gcByMtimeLongThreshold(), FilesRestorer::OLDFILES_GC_AGE_SECONDS_LONG,
+     * 24h) for `.wpmgr-old-*` directories written before the marker scheme
+     * existed and for `.wpmgr-staging-*` directories left behind by a
+     * restore that crashed before ever reaching runCleanup() (and therefore
+     * never wrote a marker at all). That fallback is NOT marker-gated; its
+     * only gate is the directory's own mtime (via `filemtime($dir)` on the
+     * directory itself) being more than 24h stale, and the prior wording
+     * here should not have described both GC targets as "gated entirely by
+     * their own on-disk markers."
+     *
+     * SAFETY (corrected AGAIN, GH #256 post-ship re-review: the wording that
+     * replaced the sentence above was itself still wrong): this fallback can
+     * race a restore that is still actively writing into its own staging
+     * directory. A directory's mtime advances only when an entry is added,
+     * removed, or renamed within it, never when an existing file's
+     * CONTENTS are written, and never when a change happens only in a
+     * nested subdirectory several levels down. A restore stage that is deep
+     * into copying large files (overwriting existing paths in place) or
+     * working several directories below the staged root can leave the
+     * staged root's own mtime unchanged well past the 24h threshold while
+     * still genuinely in progress. This fallback is a real,
+     * marker-independent deletion path with a gap the mtime check alone
+     * does not close; it is documented here rather than silently trusted.
+     * Calling both sweeps opportunistically from every request still adds
+     * no new deletion condition beyond what the daily cron already runs; it
+     * only adds a cron-independent trigger for the same conditions.
+     *
+     * @return void
+     */
+    public function maybeGcRestoreArtifacts(): void
+    {
+        if (!$this->settings->isEnrolled()) {
+            return;
+        }
+        if (!function_exists('get_option') || !function_exists('update_option')) {
+            return;
+        }
+
+        $now  = time();
+        $last = (int) get_option(self::OPTION_RESTORE_GC_LAST, 0);
+        if ($now - $last < self::RESTORE_GC_THROTTLE_SECONDS) {
+            return;
+        }
+
+        // Stamp BEFORE running, see this method's doc for why.
+        update_option(self::OPTION_RESTORE_GC_LAST, $now, true);
+
+        try {
+            FilesRestorer::gcOldFiles();
+        } catch (\Throwable $e) {
+            // A GC sweep failure must never break the caller; the next
+            // throttled attempt gets a fresh try. Independent of the
+            // gcPreRestoreDumps() call below so one failing target can never
+            // suppress the other.
+        }
+        try {
+            RestoreRunner::gcPreRestoreDumps();
+        } catch (\Throwable $e) {
+            // See above.
         }
     }
 

--- a/apps/agent/tests/Backup/BackupJanitorTest.php
+++ b/apps/agent/tests/Backup/BackupJanitorTest.php
@@ -23,6 +23,10 @@
  *     phase is NOT swept, even though it is past the age threshold — the
  *     task-row veto is a belt-and-suspenders guard layered on top of, never
  *     a substitute for, the age gate.
+ *   - GH #256 finding 3: a stale run dir with no task row (so the
+ *     isActiveRun() veto does not fire) whose TaskRunner run-lock is still
+ *     held by a live runner is NOT swept, since the age gate and the
+ *     task-row veto alone are not proof of death; see TaskRunner::withRunLock().
  *   - A fresh run dir (under the age threshold) is kept regardless of the
  *     task row.
  *   - A non-run entry (neither a UUID-shaped file nor directory) is never
@@ -230,6 +234,55 @@ final class BackupJanitorTest extends TestCase
             is_dir($dir),
             'a run dir past RUNS_GC_AGE_SECONDS with no task row must be swept — this is the #151 failed-backup scratch leak'
         );
+    }
+
+    /**
+     * GH #256 finding 3 (post-ship re-review): isActiveRun()'s "no row"
+     * case cannot distinguish a genuinely dead run from one every Watchdog
+     * give-up branch already discarded the row for while the run itself is
+     * still alive. A run directory's own mtime also does not advance while
+     * an existing file's CONTENTS are being written (e.g. a long single-file
+     * database dump), so a live run can look exactly like the just-failed
+     * case this class exists to sweep. Simulated here by holding the exact
+     * same lock file TaskRunner::run() itself would hold for this snapshot
+     * (see TaskRunner::fileLockPath()), sitting alongside, never inside,
+     * the run directory, before invoking the sweep.
+     *
+     * FAILS against the pre-fix code: before this fix, gcRuns() deleted a
+     * run directory once it passed the age gate and the isActiveRun() veto,
+     * with no further check, so it would delete this directory even while a
+     * live runner (simulated below) still owns it.
+     */
+    public function test_stale_run_with_a_live_run_lock_held_survives_the_sweep(): void
+    {
+        $id  = $this->newSnapshotId();
+        $dir = $this->seedRunDir($id);
+        touch($dir, time() - (7 * 3600)); // past RUNS_GC_AGE_SECONDS (6h)
+        clearstatcache(true, $dir);
+
+        // No wpmgr_backup_tasks row: this passes the isActiveRun() veto
+        // exactly like the just-failed-backup case above, but a live
+        // runner is still genuinely writing this run's files.
+        $GLOBALS['wpdb'] = $this->fakeWpdb(null);
+
+        $lockPath = $this->runsBase . '/' . $id . '.lock';
+        $handle   = fopen($lockPath, 'c'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- test-only fixture simulating a live runner's own flock handle
+        $this->assertNotFalse($handle, 'test fixture must be able to open the lock file');
+        $this->assertTrue(flock($handle, LOCK_EX | LOCK_NB), 'test fixture must be able to acquire the lock before the sweep attempts it');
+
+        try {
+            $class = $this->janitorClassWithBase($this->runsBase);
+            $class::gcRuns();
+
+            $this->assertTrue(
+                is_dir($dir),
+                'a directory past RUNS_GC_AGE_SECONDS whose run-lock is still held by a live runner must survive gcRuns(): age plus isActiveRun() alone are not proof of death'
+            );
+            $this->assertFileExists($dir . '/database.sql.gz', 'the live runner\'s in-flight artifact must survive the sweep');
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- test-only fixture cleanup
+        }
     }
 
     public function test_active_run_is_not_swept_even_when_old(): void

--- a/apps/agent/tests/Backup/PluginBackupJanitorSweepTest.php
+++ b/apps/agent/tests/Backup/PluginBackupJanitorSweepTest.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * GitHub issue #256: Plugin::maybeGcBackupRuns() regression lock.
+ *
+ * BackupJanitor::gcRuns() was previously reachable ONLY via its daily
+ * wpmgr_backup_runs_gc cron event, so a quiet/DISABLE_WP_CRON site (or one
+ * where an operator deleted a failed backup from the dashboard, which is
+ * entirely control-plane-local and dispatches no agent command at all) could
+ * leak the on-host `wpmgr-agent/runs/<snapshot_id>/` scratch directory
+ * forever. This mirrors PluginBackupSweepTest.php's shape (GH #232) exactly,
+ * one directory up the same cron-independence ladder as maybeGcSnapshots()
+ * and maybeSweepStalledBackups().
+ *
+ * Exercises the REAL method under test via a Plugin instance built with
+ * `ReflectionClass::newInstanceWithoutConstructor()` + a directly-injected
+ * `Settings` instance, the same isolation PluginBackupSweepTest uses, for
+ * the same reason (avoid the heavy Plugin::boot() singleton path).
+ *
+ * Verifies:
+ *   - Gated on isEnrolled(): a not-yet-enrolled site never touches the
+ *     filesystem.
+ *   - Throttled via a stored option, stamped BEFORE the sweep runs.
+ *   - Past the throttle window, BackupJanitor::gcRuns() actually runs
+ *     (observed via a real stale run directory being swept on disk).
+ *   - A thrown sweep never bubbles out of the request.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use ReflectionClass;
+use WPMgr\Agent\Plugin;
+use WPMgr\Agent\Settings;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Plugin
+ * @covers \WPMgr\Agent\Backup\BackupJanitor
+ */
+final class PluginBackupJanitorSweepTest extends TestCase
+{
+    /** @var array<string,mixed> In-memory wp-option store. */
+    private array $options = [];
+
+    private string $contentDir = '';
+
+    private string $runsBase = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        if (!defined('WP_CONTENT_DIR')) {
+            $this->contentDir = sys_get_temp_dir() . '/wpmgr-janitor-plugin-' . bin2hex(random_bytes(6));
+            mkdir($this->contentDir, 0755, true);
+            define('WP_CONTENT_DIR', $this->contentDir);
+        } else {
+            $this->contentDir = WP_CONTENT_DIR;
+        }
+        $this->runsBase = rtrim($this->contentDir, '/\\') . '/wpmgr-agent/runs';
+        if (!is_dir($this->runsBase)) {
+            mkdir($this->runsBase, 0755, true);
+        }
+
+        $this->options = [];
+        Functions\when('update_option')->alias(function ($name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('get_option')->alias(function ($name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('wp_delete_file')->alias(static function ($f) {
+            return @unlink($f); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        });
+    }
+
+    protected function tear_down(): void
+    {
+        unset($GLOBALS['wpdb']);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * Build a Plugin instance WITHOUT running its (private, heavy)
+     * constructor or boot(); only `$settings` is wired, which is all
+     * maybeGcBackupRuns() touches on `$this`.
+     */
+    private function makePlugin(): Plugin
+    {
+        $reflection = new ReflectionClass(Plugin::class);
+        /** @var Plugin $plugin */
+        $plugin = $reflection->newInstanceWithoutConstructor();
+
+        $settingsProp = $reflection->getProperty('settings');
+        $settingsProp->setValue($plugin, new Settings());
+
+        return $plugin;
+    }
+
+    private function markEnrolled(): void
+    {
+        $this->options[Settings::OPTION_SITE_ID] = 'site-abc';
+        $this->options[Settings::OPTION_CP_URL]  = 'https://cp.example.test';
+    }
+
+    /** A 36-character UUID-shaped snapshot id matching BackupJanitor's run-id regex. */
+    private function newSnapshotId(): string
+    {
+        return sprintf(
+            '%08x-%04x-%04x-%04x-%012x',
+            random_int(0, 0xffffffff),
+            random_int(0, 0xffff),
+            random_int(0, 0xffff),
+            random_int(0, 0xffff),
+            random_int(0, 0xffffffffffff)
+        );
+    }
+
+    /** Seed a stale (past the 6h age gate), inactive run dir with no task row. */
+    private function seedStaleRunDir(string $id): string
+    {
+        $dir = $this->runsBase . '/' . $id;
+        mkdir($dir, 0700, true);
+        file_put_contents($dir . '/database.sql.gz', 'fixture-content');
+        touch($dir, time() - (7 * 3600));
+        clearstatcache(true, $dir);
+
+        return $dir;
+    }
+
+    /** Minimal $wpdb double: no row for any snapshot id (isActiveRun() -> not active). */
+    private function noRowWpdb(): object
+    {
+        return new class {
+            public string $prefix = 'wp_';
+
+            /**
+             * @param mixed ...$args
+             */
+            public function prepare(string $query, ...$args): string
+            {
+                return (string) json_encode(['sql' => $query, 'args' => $args]);
+            }
+
+            /**
+             * @param mixed $mode
+             * @return array<string,mixed>|null
+             */
+            public function get_row(string $prepared, $mode = null): ?array
+            {
+                return null;
+            }
+        };
+    }
+
+    public function test_not_enrolled_never_touches_filesystem(): void
+    {
+        $id  = $this->newSnapshotId();
+        $dir = $this->seedStaleRunDir($id);
+        $GLOBALS['wpdb'] = $this->noRowWpdb();
+
+        // Deliberately NOT enrolled.
+        $this->makePlugin()->maybeGcBackupRuns();
+
+        $this->assertTrue(is_dir($dir), 'a not-yet-enrolled site must never sweep the filesystem');
+        $this->assertArrayNotHasKey(Plugin::OPTION_BACKUP_JANITOR_LAST, $this->options, 'a not-yet-enrolled site must never stamp the throttle option');
+    }
+
+    public function test_within_throttle_window_is_a_no_op(): void
+    {
+        $this->markEnrolled();
+        $this->options[Plugin::OPTION_BACKUP_JANITOR_LAST] = time() - 10; // well under the 3600s window.
+
+        $id  = $this->newSnapshotId();
+        $dir = $this->seedStaleRunDir($id);
+        $GLOBALS['wpdb'] = $this->noRowWpdb();
+
+        $this->makePlugin()->maybeGcBackupRuns();
+
+        $this->assertTrue(is_dir($dir), 'a throttled call within the window must never sweep the filesystem');
+        $this->assertSame(time() - 10, $this->options[Plugin::OPTION_BACKUP_JANITOR_LAST], 'a throttled call within the window must never re-stamp the option');
+    }
+
+    public function test_past_throttle_window_stamps_before_running_then_sweeps(): void
+    {
+        $this->markEnrolled();
+        $this->options[Plugin::OPTION_BACKUP_JANITOR_LAST] = time() - 7200; // past the 3600s window.
+
+        $id  = $this->newSnapshotId();
+        $dir = $this->seedStaleRunDir($id);
+        $GLOBALS['wpdb'] = $this->noRowWpdb();
+
+        $before = time();
+        $this->makePlugin()->maybeGcBackupRuns();
+
+        $this->assertGreaterThanOrEqual(
+            $before,
+            (int) $this->options[Plugin::OPTION_BACKUP_JANITOR_LAST],
+            'the throttle option must be stamped to "now" before the sweep runs'
+        );
+        $this->assertFalse(is_dir($dir), 'past the throttle window, BackupJanitor::gcRuns() must actually sweep the stale, inactive run dir');
+    }
+
+    public function test_a_thrown_sweep_never_bubbles_out_of_the_request(): void
+    {
+        $this->markEnrolled();
+
+        $id = $this->newSnapshotId();
+        $this->seedStaleRunDir($id);
+
+        // A $wpdb double whose prepare() throws, proving maybeGcBackupRuns()
+        // completes normally regardless of which layer inside gcRuns() ->
+        // isActiveRun() contains the failure.
+        $wpdb = new class {
+            public string $prefix = 'wp_';
+
+            /**
+             * @param mixed ...$args
+             */
+            public function prepare(string $query, ...$args): string
+            {
+                throw new \RuntimeException('simulated DB failure');
+            }
+        };
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $plugin = $this->makePlugin();
+
+        $threw = false;
+        try {
+            $plugin->maybeGcBackupRuns();
+        } catch (\Throwable $e) {
+            $threw = true;
+        }
+
+        $this->assertFalse($threw, 'a thrown sweep must never bubble out of the plugins_loaded-bound request handler');
+        $this->assertArrayHasKey(
+            Plugin::OPTION_BACKUP_JANITOR_LAST,
+            $this->options,
+            'the throttle stamp must still have been written (stamp-BEFORE-run) even though the sweep itself failed'
+        );
+    }
+}

--- a/apps/agent/tests/Backup/PluginRestoreGcSweepTest.php
+++ b/apps/agent/tests/Backup/PluginRestoreGcSweepTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * GitHub issue #256: Plugin::maybeGcRestoreArtifacts() regression lock.
+ *
+ * FilesRestorer::gcOldFiles() + RestoreRunner::gcPreRestoreDumps() were
+ * previously reachable ONLY via a wp_schedule_single_event ONE-SHOT
+ * scheduled at the end of a successful RestoreRunner::runCleanup(). A
+ * crashed/aborted restore never scheduled it at all, and even a
+ * scheduled-but-unfired event (WP-Cron never ticked) permanently suppressed
+ * every later restore's attempt to schedule a replacement (see
+ * RestoreOldFilesGcRescheduleTest for that half of the fix). This mirrors
+ * PluginBackupJanitorSweepTest.php's shape (GH #256, backup side) for the
+ * restore side.
+ *
+ * Verifies:
+ *   - Gated on isEnrolled(): a not-yet-enrolled site never touches the
+ *     filesystem.
+ *   - Throttled via a stored option, stamped BEFORE the sweep runs.
+ *   - Past the throttle window, BOTH gcOldFiles() and gcPreRestoreDumps()
+ *     actually run (observed via real expired `.expires`-marked fixtures
+ *     being reclaimed on disk).
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use ReflectionClass;
+use WPMgr\Agent\Plugin;
+use WPMgr\Agent\Settings;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Plugin
+ * @covers \WPMgr\Agent\Backup\FilesRestorer
+ * @covers \WPMgr\Agent\Backup\RestoreRunner
+ */
+final class PluginRestoreGcSweepTest extends TestCase
+{
+    /** @var array<string,mixed> In-memory wp-option store. */
+    private array $options = [];
+
+    private string $contentDir = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        if (!defined('WP_CONTENT_DIR')) {
+            $this->contentDir = sys_get_temp_dir() . '/wpmgr-restore-gc-plugin-' . bin2hex(random_bytes(6));
+            mkdir($this->contentDir, 0755, true);
+            define('WP_CONTENT_DIR', $this->contentDir);
+        } else {
+            $this->contentDir = WP_CONTENT_DIR;
+        }
+
+        $this->options = [];
+        Functions\when('update_option')->alias(function ($name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('get_option')->alias(function ($name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('wp_delete_file')->alias(static function ($f) {
+            return @unlink($f); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        });
+    }
+
+    protected function tear_down(): void
+    {
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    private function makePlugin(): Plugin
+    {
+        $reflection = new ReflectionClass(Plugin::class);
+        /** @var Plugin $plugin */
+        $plugin = $reflection->newInstanceWithoutConstructor();
+
+        $settingsProp = $reflection->getProperty('settings');
+        $settingsProp->setValue($plugin, new Settings());
+
+        return $plugin;
+    }
+
+    private function markEnrolled(): void
+    {
+        $this->options[Settings::OPTION_SITE_ID] = 'site-abc';
+        $this->options[Settings::OPTION_CP_URL]  = 'https://cp.example.test';
+    }
+
+    /**
+     * Seed an already-expired `.wpmgr-old-files-<id>` rollback tree directly
+     * under WP_CONTENT_DIR (one of gcOldFiles()'s three candidate dirs).
+     *
+     * @return array{dir:string,marker:string}
+     */
+    private function seedExpiredOldFilesFixture(): array
+    {
+        $id     = bin2hex(random_bytes(6));
+        $dir    = rtrim($this->contentDir, '/\\') . '/.wpmgr-old-files-' . $id;
+        $marker = $dir . '.expires';
+        mkdir($dir, 0755, true);
+        file_put_contents($dir . '/good.txt', 'pre-restore-tree');
+        file_put_contents($marker, (string) (time() - 10));
+
+        return ['dir' => $dir, 'marker' => $marker];
+    }
+
+    /**
+     * Seed an already-expired pre-restore DB dump directly under
+     * `<WP_CONTENT_DIR>/wpmgr-agent/restores/<restore-id>/`.
+     *
+     * @return array{dump:string,marker:string,dir:string}
+     */
+    private function seedExpiredDumpFixture(): array
+    {
+        $restoreId = bin2hex(random_bytes(6));
+        $dir       = rtrim($this->contentDir, '/\\') . '/wpmgr-agent/restores/' . $restoreId;
+        $dump      = $dir . '/pre-restore-db.sql.gz';
+        $marker    = $dump . '.expires';
+        mkdir($dir, 0755, true);
+        file_put_contents($dump, 'fixture-dump-bytes');
+        file_put_contents($marker, (string) (time() - 10));
+
+        return ['dump' => $dump, 'marker' => $marker, 'dir' => $dir];
+    }
+
+    public function test_not_enrolled_never_touches_filesystem(): void
+    {
+        $oldFiles = $this->seedExpiredOldFilesFixture();
+        $dump     = $this->seedExpiredDumpFixture();
+
+        // Deliberately NOT enrolled.
+        $this->makePlugin()->maybeGcRestoreArtifacts();
+
+        $this->assertTrue(is_dir($oldFiles['dir']), 'a not-yet-enrolled site must never sweep gcOldFiles() targets');
+        $this->assertTrue(is_file($dump['dump']), 'a not-yet-enrolled site must never sweep gcPreRestoreDumps() targets');
+        $this->assertArrayNotHasKey(Plugin::OPTION_RESTORE_GC_LAST, $this->options, 'a not-yet-enrolled site must never stamp the throttle option');
+    }
+
+    public function test_within_throttle_window_is_a_no_op(): void
+    {
+        $this->markEnrolled();
+        $this->options[Plugin::OPTION_RESTORE_GC_LAST] = time() - 10; // well under the 900s window.
+
+        $oldFiles = $this->seedExpiredOldFilesFixture();
+        $dump     = $this->seedExpiredDumpFixture();
+
+        $this->makePlugin()->maybeGcRestoreArtifacts();
+
+        $this->assertTrue(is_dir($oldFiles['dir']), 'a throttled call within the window must never sweep the filesystem');
+        $this->assertTrue(is_file($dump['dump']), 'a throttled call within the window must never sweep the filesystem');
+        $this->assertSame(time() - 10, $this->options[Plugin::OPTION_RESTORE_GC_LAST], 'a throttled call within the window must never re-stamp the option');
+    }
+
+    public function test_past_throttle_window_stamps_before_running_then_sweeps_both_targets(): void
+    {
+        $this->markEnrolled();
+        $this->options[Plugin::OPTION_RESTORE_GC_LAST] = time() - 1000; // past the 900s window.
+
+        $oldFiles = $this->seedExpiredOldFilesFixture();
+        $dump     = $this->seedExpiredDumpFixture();
+
+        $before = time();
+        $this->makePlugin()->maybeGcRestoreArtifacts();
+
+        $this->assertGreaterThanOrEqual(
+            $before,
+            (int) $this->options[Plugin::OPTION_RESTORE_GC_LAST],
+            'the throttle option must be stamped to "now" before the sweep runs'
+        );
+        $this->assertFalse(is_dir($oldFiles['dir']), 'past the throttle window, gcOldFiles() must reclaim the expired rollback tree');
+        $this->assertFalse(is_file($oldFiles['marker']), 'the expired .expires marker must also be removed');
+        $this->assertFalse(is_file($dump['dump']), 'past the throttle window, gcPreRestoreDumps() must reclaim the expired pre-restore dump');
+        $this->assertFalse(is_file($dump['marker']), 'the expired dump .expires marker must also be removed');
+    }
+}

--- a/apps/agent/tests/Backup/RestoreOldFilesGcRescheduleTest.php
+++ b/apps/agent/tests/Backup/RestoreOldFilesGcRescheduleTest.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * GitHub issue #256: RestoreRunner::runCleanup()'s self-poisoning one-shot
+ * `wpmgr_restore_oldfiles_gc` scheduling bug.
+ *
+ * Root cause: an event scheduled but OVERDUE (WP-Cron never ticked past its
+ * timestamp, on a quiet site or one with DISABLE_WP_CRON set) stays in the
+ * cron array forever, so `wp_next_scheduled()` keeps returning it as truthy
+ * and the pre-#256 `if (!wp_next_scheduled(...))` guard permanently declined
+ * to schedule a replacement for EVERY later restore: one missed tick
+ * poisons the trigger for good. The fix treats an overdue timestamp as
+ * "nothing usefully scheduled": it clears the stale entry via
+ * `wp_unschedule_event()` and schedules a fresh one.
+ *
+ * Reaches the private runCleanup() directly via reflection, mirroring
+ * TaskRunnerCleanupOnFailedTest's convention: it only touches the
+ * filesystem + the WP-Cron scheduling functions (no $wpdb), so this stays
+ * hermetic per the "self-contained fakes" test convention.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use ReflectionClass;
+use WPMgr\Agent\Backup\RestoreRunner;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\RestoreRunner
+ */
+final class RestoreOldFilesGcRescheduleTest extends TestCase
+{
+    private const GC_HOOK = 'wpmgr_restore_oldfiles_gc';
+
+    private string $root        = '';
+    private string $scratchDir  = '';
+    private string $oldFilesDir = '';
+
+    /** @var list<array{ts:int,hook:string}> */
+    private array $scheduled = [];
+
+    /** @var list<array{ts:int,hook:string}> */
+    private array $unscheduled = [];
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->root        = sys_get_temp_dir() . '/wpmgr-oldfiles-resched-' . bin2hex(random_bytes(6));
+        $this->scratchDir  = $this->root . '/scratch';
+        $this->oldFilesDir = $this->root . '/.wpmgr-old-files-aaaaaaaaaaaa';
+        mkdir($this->scratchDir, 0755, true);
+        mkdir($this->oldFilesDir, 0755, true);
+        file_put_contents($this->oldFilesDir . '/good.txt', 'pre-restore-tree');
+
+        $this->scheduled   = [];
+        $this->unscheduled = [];
+        Functions\when('wp_delete_file')->alias(static function ($f) {
+            return @unlink($f); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        });
+        Functions\when('wp_schedule_single_event')->alias(function (int $ts, string $hook, array $args = []): bool {
+            $this->scheduled[] = ['ts' => $ts, 'hook' => $hook];
+            return true;
+        });
+        Functions\when('wp_unschedule_event')->alias(function (int $ts, string $hook, array $args = []): bool {
+            $this->unscheduled[] = ['ts' => $ts, 'hook' => $hook];
+            return true;
+        });
+    }
+
+    protected function tear_down(): void
+    {
+        $this->rrmdir($this->root);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    private function buildRunner(): RestoreRunner
+    {
+        return new RestoreRunner([
+            'snapshot_id'       => '55555555-5555-4555-8555-555555555555',
+            'restore_id'        => '66666666-6666-4666-8666-666666666666',
+            'kind'              => 'full',
+            'progress_endpoint' => '',
+            'scratch_dir'       => $this->scratchDir,
+            'wp_content_path'   => $this->root . '/wp-content',
+            'wp_root'           => $this->root . '/wproot',
+            'db'                => ['host' => '', 'user' => '', 'password' => '', 'name' => '', 'prefix' => 'wp_'],
+        ]);
+    }
+
+    /**
+     * @param array<string,mixed> $subState
+     * @return array<string,mixed>
+     */
+    private function runCleanup(RestoreRunner $runner, array $subState): array
+    {
+        $reflection = new ReflectionClass(RestoreRunner::class);
+        $method     = $reflection->getMethod('runCleanup');
+
+        return $method->invoke($runner, $subState);
+    }
+
+    /** @return array<string,mixed> */
+    private function swapFilesSubState(): array
+    {
+        return [
+            'swap_files' => [
+                'done'          => true,
+                'old_files_dir' => $this->oldFilesDir,
+                'mode'          => 'legacy_whole',
+            ],
+        ];
+    }
+
+    public function test_no_existing_schedule_schedules_a_fresh_event(): void
+    {
+        Functions\when('wp_next_scheduled')->justReturn(false);
+
+        $this->runCleanup($this->buildRunner(), $this->swapFilesSubState());
+
+        $this->assertNotEmpty($this->scheduled, 'a fresh event must be scheduled when nothing is currently scheduled');
+        $this->assertSame(self::GC_HOOK, $this->scheduled[0]['hook']);
+        $this->assertEmpty($this->unscheduled, 'nothing to unschedule when no event exists');
+    }
+
+    public function test_future_scheduled_event_is_left_alone_and_no_duplicate_is_scheduled(): void
+    {
+        $future = time() + 1800;
+        Functions\when('wp_next_scheduled')->justReturn($future);
+
+        $this->runCleanup($this->buildRunner(), $this->swapFilesSubState());
+
+        $this->assertEmpty($this->scheduled, 'an event already scheduled in the future must not be duplicated');
+        $this->assertEmpty($this->unscheduled, 'a future (not overdue) event must never be unscheduled');
+    }
+
+    public function test_overdue_scheduled_event_is_cleared_and_a_fresh_one_is_scheduled(): void
+    {
+        // GH #256: an event scheduled for the past (WP-Cron never ticked
+        // it) previously stayed in the cron array forever, so
+        // wp_next_scheduled() kept returning it as truthy and permanently
+        // suppressed every later restore's attempt to schedule a
+        // replacement.
+        $overdue = time() - 3600;
+        Functions\when('wp_next_scheduled')->justReturn($overdue);
+
+        $this->runCleanup($this->buildRunner(), $this->swapFilesSubState());
+
+        $this->assertNotEmpty($this->unscheduled, 'the overdue, never-fired event must be cleared');
+        $this->assertSame($overdue, $this->unscheduled[0]['ts']);
+        $this->assertSame(self::GC_HOOK, $this->unscheduled[0]['hook']);
+
+        $this->assertNotEmpty($this->scheduled, 'a fresh replacement event must be scheduled once the overdue one is cleared');
+        $this->assertSame(self::GC_HOOK, $this->scheduled[0]['hook']);
+        $this->assertGreaterThan(time(), $this->scheduled[0]['ts'], 'the replacement must be scheduled for the future, not re-using the overdue timestamp');
+    }
+
+    /** Recursive delete used only for test fixture cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if ($dir === '' || !is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+}

--- a/apps/agent/tests/Backup/TaskRunnerCleanupOnFailedTest.php
+++ b/apps/agent/tests/Backup/TaskRunnerCleanupOnFailedTest.php
@@ -128,6 +128,25 @@ final class TaskRunnerCleanupOnFailedTest extends TestCase
     }
 
     /**
+     * GH #256: reclaimScratch() is the public wrapper Watchdog's terminal
+     * give-up paths use to reach cleanupOnFailed() from OUTSIDE run()'s own
+     * try/catch. Proves it delegates to the exact same sweep (no second,
+     * independently-duplicated implementation) without going through
+     * reflection.
+     */
+    public function test_reclaim_scratch_delegates_to_the_same_sweep_as_cleanup_on_failed(): void
+    {
+        $dir = $this->scratchDir;
+        file_put_contents($dir . '/database.sql.gz', 'gz-bytes');
+        file_put_contents($dir . '/chunks-aaaa1111.age', 'ciphertext');
+
+        $runner = $this->buildRunner(['scratch_dir' => $dir]);
+        $runner->reclaimScratch();
+
+        self::assertDirectoryDoesNotExist($dir, 'reclaimScratch() must remove the now-empty scratch dir via the same sweep cleanupOnFailed() runs');
+    }
+
+    /**
      * Build a TaskRunner with a minimal, syntactically-valid params payload.
      * Mirrors TaskRunnerTest::buildRunner().
      *

--- a/apps/agent/tests/Backup/TaskRunnerLockTest.php
+++ b/apps/agent/tests/Backup/TaskRunnerLockTest.php
@@ -521,6 +521,195 @@ final class TaskRunnerLockTest extends TestCase
         wp_delete_file($lockPath);
     }
 
+    // ------------------------------------------------------------------
+    // GH #256 finding 1/2/3 (post-ship re-review): withRunLock(), the
+    // callback-taking replacement for the earlier bool-returning
+    // isRunLockFree() probe. Watchdog's give-up paths and
+    // BackupJanitor::gcRuns() both reclaim a snapshot's scratch directory
+    // from INSIDE the callback rather than probing-then-acting as two
+    // separate calls, closing the TOCTOU window a probe-then-release
+    // pattern leaves open. Mirrors run()'s own GET_LOCK-then-flock guard
+    // order exactly.
+    // ------------------------------------------------------------------
+
+    public function test_with_run_lock_invokes_callback_and_releases_both_guards_when_nothing_else_holds_them(): void
+    {
+        [$params] = $this->buildParams();
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->lockResponses = ['1'];
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $runner       = new TaskRunner($params);
+        $invoked      = false;
+        $ran          = $runner->withRunLock(static function () use (&$invoked): void {
+            $invoked = true;
+        });
+
+        $this->assertTrue($ran, 'nothing else holds either guard, so withRunLock() must run the callback and report true');
+        $this->assertTrue($invoked, 'the callback must actually be invoked while both guards are held');
+        $this->assertSame(1, $wpdb->releaseCallCount, 'the GET_LOCK provisionally won must be released once the callback returns');
+
+        // Check the lock file is gone BEFORE assertFlockIsFree() below, which
+        // would itself recreate-then-delete the file as a side effect and so
+        // must not run first, or this assertion would be checking its own
+        // cleanup rather than withRunLock()'s.
+        $probe    = new TaskRunner($params);
+        $lockPath = (new \ReflectionMethod(TaskRunner::class, 'fileLockPath'))->invoke($probe);
+        $this->assertFileDoesNotExist($lockPath, 'a successful reclaim must delete its own lock coordination file, not leave a fresh zero-byte one behind for the janitor');
+
+        $this->assertFlockIsFree($params, 'the flock acquired for the callback must be released once it returns, so a real run() can still proceed afterward');
+    }
+
+    public function test_with_run_lock_does_not_invoke_callback_on_get_lock_contention_without_attempting_flock(): void
+    {
+        [$params] = $this->buildParams();
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->lockResponses = ['0']; // another session already holds GET_LOCK.
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $runner  = new TaskRunner($params);
+        $invoked = false;
+        $ran     = $runner->withRunLock(static function () use (&$invoked): void {
+            $invoked = true;
+        });
+
+        $this->assertFalse($ran, 'a GET_LOCK contention must report the run-lock as held');
+        $this->assertFalse($invoked, 'the callback must never run when GET_LOCK is contended');
+        $this->assertSame(0, $wpdb->releaseCallCount, 'the probe never won GET_LOCK, so it must never call RELEASE_LOCK');
+    }
+
+    /**
+     * The exact scenario GH #256 finding 3 exists to close: GET_LOCK
+     * reports "free" (as it would if the live runner's own $wpdb
+     * connection had silently dropped mid-backup, see run()'s own doc),
+     * but the live runner's flock is still held. withRunLock() must defer
+     * to the authoritative flock, never invoke the callback, and report
+     * contention.
+     */
+    public function test_with_run_lock_does_not_invoke_callback_when_flock_is_held_even_if_get_lock_reports_free(): void
+    {
+        [$params] = $this->buildParams();
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->lockResponses = ['1']; // GET_LOCK reports "free".
+        $GLOBALS['wpdb'] = $wpdb;
+
+        [$lockHandle, $lockPath] = $this->externallyHoldTheFlock($params);
+
+        try {
+            $runner  = new TaskRunner($params);
+            $invoked = false;
+            $ran     = $runner->withRunLock(static function () use (&$invoked): void {
+                $invoked = true;
+            });
+
+            $this->assertFalse($ran, 'a live runner still holds the flock; withRunLock() must report the run-lock as held');
+            $this->assertFalse($invoked, 'the callback must never run while a live runner holds the flock');
+            $this->assertSame(1, $wpdb->releaseCallCount, 'the GET_LOCK provisionally won must be released once the flock rejects it');
+            $this->assertFileExists($lockPath, "a contended caller must never delete the winner's still-held lock file");
+        } finally {
+            flock($lockHandle, LOCK_UN);
+            fclose($lockHandle);
+        }
+    }
+
+    /**
+     * GH #256 finding 1 (TOCTOU): the core property this fix exists to
+     * establish: the callback runs WHILE both guards are still held, not
+     * after they have already been released and re-acquired by someone
+     * else. Proven directly by attempting a second, independent, exclusive,
+     * non-blocking flock() on the exact same lock-file path from a SEPARATE
+     * file handle from INSIDE the callback: it must fail (the outer guard
+     * is still held), and succeed again once withRunLock() has returned
+     * (the outer guard has been released). A probe-then-release-then-act
+     * implementation (the pre-fix shape: isRunLockFree() released both
+     * guards before the caller ever touched a file) would let this second
+     * acquisition SUCCEED while "inside" the outer call, because by that
+     * point there would be nothing left holding it.
+     */
+    public function test_with_run_lock_holds_both_guards_for_the_full_duration_of_the_callback(): void
+    {
+        [$params] = $this->buildParams();
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->lockResponses = ['1'];
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $probe    = new TaskRunner($params);
+        $lockPath = (new \ReflectionMethod(TaskRunner::class, 'fileLockPath'))->invoke($probe);
+
+        $runner              = new TaskRunner($params);
+        $lockWasHeldInside   = null;
+        $ran                 = $runner->withRunLock(function () use (&$lockWasHeldInside, $lockPath): void {
+            $second = fopen($lockPath, 'c'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- test-only: a second independent handle proving the outer flock is still held
+            $this->assertNotFalse($second, 'sanity: the lock file must be openable from a second handle');
+            $lockWasHeldInside = !flock($second, LOCK_EX | LOCK_NB);
+            fclose($second); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- test-only fixture cleanup
+        });
+
+        $this->assertTrue($ran, 'sanity: nothing else holds either guard, so the callback must run');
+        $this->assertTrue(
+            $lockWasHeldInside,
+            'a second, independent flock attempt on the exact same lock file must FAIL while inside the callback: this proves withRunLock() holds the lock across the callback rather than probing-then-releasing beforehand'
+        );
+
+        // After withRunLock() returns, the guard must be free again.
+        $after = fopen($lockPath, 'c'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- test-only fixture
+        $this->assertNotFalse($after, 'sanity: the lock file must be openable after withRunLock() returns');
+        $this->assertTrue(flock($after, LOCK_EX | LOCK_NB), 'the guard must be released once withRunLock() returns');
+        flock($after, LOCK_UN);
+        fclose($after); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- test-only fixture cleanup
+        wp_delete_file($lockPath);
+    }
+
+    /**
+     * GH #256 finding 2 (fail-open): a flock guard that could not even be
+     * ATTEMPTED (acquireFileLock() returning `['handle' => null, 'contended'
+     * => false]`, here forced via a lock-file directory with no write
+     * permission, the same class of failure as open_basedir or a
+     * read-only filesystem) must be treated as NOT provably free on this
+     * reclaim-only path, unlike run()'s own inline guard (unchanged, and
+     * correct for its own purpose: proceeding without a flock guard there
+     * costs at most a wasted duplicate run). The callback must never run.
+     */
+    public function test_with_run_lock_treats_a_degraded_flock_guard_as_not_free(): void
+    {
+        if (function_exists('posix_getuid') && posix_getuid() === 0) {
+            self::markTestSkipped('running as root bypasses filesystem permission checks');
+        }
+
+        $restrictedBase = sys_get_temp_dir() . '/wpmgr-lock-degraded-test-' . bin2hex(random_bytes(6));
+        mkdir($restrictedBase, 0755, true);
+        $runsDir = $restrictedBase . '/runs';
+        mkdir($runsDir, 0755, true);
+        chmod($runsDir, 0500); // read + execute only: fopen('c') for a NEW file inside must fail.
+
+        try {
+            [$params] = $this->buildParams();
+            $params['scratch_dir'] = $runsDir . '/' . self::SNAPSHOT_ID;
+
+            $wpdb = new FakeBackupTasksWpdb();
+            $wpdb->lockResponses = ['1'];
+            $GLOBALS['wpdb'] = $wpdb;
+
+            $runner  = new TaskRunner($params);
+            $invoked = false;
+            $ran     = $runner->withRunLock(static function () use (&$invoked): void {
+                $invoked = true;
+            });
+
+            $this->assertFalse($ran, 'a flock guard that could not even be attempted must be treated as NOT free on the reclaim path');
+            $this->assertFalse($invoked, 'the callback must never run when the flock guard is degraded');
+            $this->assertSame(1, $wpdb->releaseCallCount, 'the GET_LOCK provisionally won must still be released once the degraded flock guard refuses');
+        } finally {
+            chmod($runsDir, 0755);
+            @rmdir($runsDir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+            @rmdir($restrictedBase); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+        }
+    }
+
     /** Recursive delete used only for test fixture cleanup. */
     private function rrmdir(string $dir): void
     {

--- a/apps/agent/tests/Backup/TaskRunnerSubStatePacketTest.php
+++ b/apps/agent/tests/Backup/TaskRunnerSubStatePacketTest.php
@@ -226,6 +226,59 @@ final class TaskRunnerSubStatePacketTest extends TestCase
         $this->assertCount(3000, $sub['files']['tombstones'], 'all 3000 tombstone entries must reload intact from sidecar');
     }
 
+    /**
+     * GH #256 finding 5: TaskRunner::decodeSubStateColumn() is the shared,
+     * public helper loadTask() itself uses, and the ONLY correct way to
+     * decode a raw sub_state column value once it may have spilled to the
+     * sidecar. A bare json_decode() of the column (the pre-fix behavior in
+     * Watchdog::decodeSubState()) returns only the small
+     * `{"_sidecar":true,"file":"..."}` pointer for a spilled row, never the
+     * real payload underneath, including `params`. Asserted directly here,
+     * independent of loadTask()/Watchdog, so a future caller of this shared
+     * helper gets the same guarantee.
+     */
+    public function test_decode_sub_state_column_follows_the_sidecar_pointer(): void
+    {
+        $wpdb = new PacketLimitedWpdb(1024 * 1024);
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $snapshotId = '99999999-aaaa-4bbb-8ccc-dddddddddddd';
+        $params     = $this->params($snapshotId);
+        $wpdb->seedRow($snapshotId, 'full', $params);
+
+        $runner = new TaskRunner($params);
+        $ref    = new ReflectionClass($runner);
+        $save   = $ref->getMethod('saveTaskState');
+
+        $bigTombstones = [];
+        for ($i = 0; $i < 3000; $i++) {
+            $bigTombstones[] = 'plugins/some-plugin/file-' . $i . '.php';
+        }
+        $subState = [
+            'params' => $params,
+            'files'  => [
+                'done'       => true,
+                'tombstones' => $bigTombstones,
+            ],
+        ];
+        $save->invoke($runner, TaskRunner::PHASE_ENCRYPTING_UPLOADING, $subState);
+
+        $rawColumn = (string) ($wpdb->rows[$snapshotId]['sub_state'] ?? '');
+        $this->assertStringContainsString('_sidecar', $rawColumn, 'sanity: the fixture must actually have spilled to the sidecar');
+
+        // A bare json_decode() (the pre-fix behavior) would stop here.
+        $bareDecode = json_decode($rawColumn, true);
+        $this->assertIsArray($bareDecode);
+        $this->assertArrayNotHasKey('params', $bareDecode, 'sanity: the raw column alone never carries params once spilled');
+
+        // The shared helper must follow the pointer and recover the full payload.
+        $decoded = TaskRunner::decodeSubStateColumn($rawColumn);
+        $this->assertArrayHasKey('params', $decoded, 'decodeSubStateColumn() must rehydrate params from the sidecar');
+        $this->assertSame($snapshotId, $decoded['params']['snapshot_id'] ?? null);
+        $this->assertArrayHasKey('files', $decoded);
+        $this->assertCount(3000, $decoded['files']['tombstones'] ?? []);
+    }
+
     /** @return array<string,mixed> */
     private function params(string $snapshotId): array
     {

--- a/apps/agent/tests/Backup/WatchdogReaperTest.php
+++ b/apps/agent/tests/Backup/WatchdogReaperTest.php
@@ -216,25 +216,43 @@ final class WatchdogReaperTest extends TestCase
     // Test 8: resume_count cap preserved.
     // ------------------------------------------------------------------
 
-    public function test_resume_count_at_cap_is_marked_failed_not_resumed(): void
+    /**
+     * GH #256: the resume-cap give-up branch used to mark the row
+     * phase=failed and leave it (and its scratch directory) in place
+     * forever, since sweepStalled()'s own query excludes terminal phases, so
+     * that row was never revisited again, and its scratch dir survived
+     * until the age-gated BackupJanitor::gcRuns() backstop eventually swept
+     * it. It now reclaims the scratch directory THEN deletes the row
+     * outright, mirroring every other give-up branch in this class.
+     */
+    public function test_resume_count_at_cap_reclaims_scratch_and_deletes_row(): void
     {
-        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb   = new FakeBackupTasksWpdb();
+        $params = $this->runnerParams(self::CAPPED_ID);
+        mkdir($params['scratch_dir'], 0700, true);
+        file_put_contents($params['scratch_dir'] . '/database.sql.gz', 'fixture-bytes');
+
         $wpdb->seedRow(self::CAPPED_ID, [
             'phase'            => TaskRunner::PHASE_QUEUED,
             'started_at'       => time() - 200,
             'last_progress_at' => time() - 200,
             'resume_count'     => 6,
             'max_resumes'      => 6,
-            'sub_state'        => (string) json_encode(['params' => $this->runnerParams(self::CAPPED_ID)]),
+            'sub_state'        => (string) json_encode(['params' => $params]),
         ]);
         $GLOBALS['wpdb'] = $wpdb;
 
         Watchdog::sweepStalled();
 
-        $row = $wpdb->rows[self::CAPPED_ID] ?? null;
-        $this->assertNotNull($row, 'a capped-out row is marked failed, not deleted, by this branch');
-        $this->assertSame(TaskRunner::PHASE_FAILED, $row['phase'], 'a row at resume_count>=max_resumes must be marked failed, never resumed again');
-        $this->assertSame(6, $row['resume_count'], 'resume_count must NOT be bumped past the cap');
+        $this->assertArrayNotHasKey(
+            self::CAPPED_ID,
+            $wpdb->rows,
+            'a row at resume_count>=max_resumes must be DELETEd, never left at phase=failed forever (sweepStalled() excludes terminal phases and would never revisit it again)'
+        );
+        $this->assertDirectoryDoesNotExist(
+            $params['scratch_dir'],
+            'GH #256: the scratch directory must be reclaimed before the row that names it is discarded'
+        );
     }
 
     /** Recursive delete used only for test fixture cleanup. */

--- a/apps/agent/tests/Backup/WatchdogReclaimRunLockTest.php
+++ b/apps/agent/tests/Backup/WatchdogReclaimRunLockTest.php
@@ -1,0 +1,330 @@
+<?php
+/**
+ * GitHub issue #256 post-ship review, findings 1/2/3: a Watchdog give-up
+ * path (the 7200s hard-ceiling guard, the late-phase 300s stale guard, the
+ * max-resumes exhaustion, and dispatch()'s stale-task guard) reclaims a
+ * snapshot's scratch directory purely from DB-column signals (row age,
+ * last_progress_at age, resume_count). None of those signals can prove the
+ * runner that owns the snapshot has actually stopped: a real backup of a
+ * large site can legitimately run for hours, and a single large chunk
+ * upload on a slow link can legitimately go quiet for minutes at a time
+ * (see WatchdogReclaimSubstateSidecarTest for the sidecar-spill half of
+ * this review).
+ *
+ * Before this fix, none of the four give-up paths took any lock at all
+ * before deleting scratch files, so a genuinely live runner racing a
+ * give-up path (holding TaskRunner::run()'s own advisory lock while this
+ * class independently decided the row was dead) could have its in-flight
+ * chunk/artifact files deleted out from under it.
+ *
+ * This suite proves the fix by simulating a live runner: it opens and
+ * flock()s the exact lock-file path TaskRunner::run() itself would use for
+ * a given snapshot (see TaskRunner::fileLockPath()) BEFORE invoking a
+ * Watchdog give-up path, then asserts the scratch directory survives.
+ * PHP's flock() contends across two separate file handles to the same path
+ * even within a single process/test, which is exactly what makes this a
+ * faithful, deterministic simulation without spinning a second process.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Backup\TaskRunner;
+use WPMgr\Agent\Backup\Watchdog;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\Watchdog
+ * @covers \WPMgr\Agent\Backup\TaskRunner
+ */
+final class WatchdogReclaimRunLockTest extends TestCase
+{
+    private const HARD_CEILING_ID   = '55555555-6666-4777-8888-999999999999';
+    private const LATE_PHASE_ID     = '66666666-7777-4888-8999-aaaaaaaaaaaa';
+    private const MAX_RESUMES_ID    = '77777777-8888-4999-8aaa-bbbbbbbbbbbb';
+    private const DISPATCH_STALE_ID = '88888888-9999-4aaa-8bbb-cccccccccccc';
+
+    private string $root       = '';
+    private string $scratchDir = '';
+
+    /** @var resource|null */
+    private $liveRunnerLockHandle = null;
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->root       = sys_get_temp_dir() . '/wpmgr-reclaim-lock-test-' . bin2hex(random_bytes(6));
+        $this->scratchDir = $this->root . '/scratch';
+        mkdir($this->scratchDir, 0755, true);
+
+        Functions\when('wp_json_encode')->alias(static fn ($d) => json_encode($d));
+        Functions\when('wp_schedule_single_event')->justReturn(true);
+        Functions\when('wp_delete_file')->alias(static function ($f) {
+            return @unlink($f); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        });
+    }
+
+    protected function tear_down(): void
+    {
+        if (is_resource($this->liveRunnerLockHandle)) {
+            flock($this->liveRunnerLockHandle, LOCK_UN);
+            fclose($this->liveRunnerLockHandle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- test-only fixture cleanup
+            $this->liveRunnerLockHandle = null;
+        }
+        unset($GLOBALS['wpdb']);
+        $this->rrmdir($this->root);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /** @return array<string,mixed> Minimal-but-valid TaskRunner params. */
+    private function runnerParams(string $snapshotId): array
+    {
+        return [
+            'snapshot_id'       => $snapshotId,
+            'kind'              => 'files',
+            'age_recipient'     => 'age1' . str_repeat('q', 58),
+            'presign_endpoint'  => 'https://cp.invalid/agent/v1/backups/reclaim-lock-test/presign',
+            'manifest_endpoint' => 'https://cp.invalid/agent/v1/backups/reclaim-lock-test/manifest',
+            'progress_endpoint' => '',
+            'chunk_bytes'       => 4 * 1024 * 1024,
+            'scratch_dir'       => $this->scratchDir . '/' . $snapshotId,
+            'wp_content_path'   => $this->root . '/wp-content',
+            'db'                => ['host' => 'localhost', 'user' => 'u', 'password' => 'p', 'name' => 'n', 'prefix' => 'wp_'],
+        ];
+    }
+
+    /** Seed a run's scratch dir with a representative artifact file. */
+    private function seedScratch(string $snapshotId): string
+    {
+        $dir = $this->scratchDir . '/' . $snapshotId;
+        mkdir($dir, 0700, true);
+        file_put_contents($dir . '/database.sql.gz', 'fixture-bytes');
+        file_put_contents($dir . '/wp-content.g000.part001.zip', 'fixture-zip-bytes');
+
+        return $dir;
+    }
+
+    /**
+     * Hold the exact lock file TaskRunner::run() would hold for this
+     * snapshot, simulating a live runner still in flight. The lock path is
+     * derived from the PARENT of the scratch dir (see
+     * TaskRunner::fileLockPath()), which in this fixture is $this->scratchDir
+     * itself, shared by every snapshot under test.
+     */
+    private function simulateLiveRunnerHoldingLock(string $snapshotId): void
+    {
+        $lockPath = $this->scratchDir . DIRECTORY_SEPARATOR . $snapshotId . '.lock';
+        $handle   = fopen($lockPath, 'c'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- test-only fixture simulating a live runner's own flock handle
+        $this->assertNotFalse($handle, 'test fixture must be able to open the lock file');
+        $this->assertTrue(flock($handle, LOCK_EX | LOCK_NB), 'test fixture must be able to acquire the lock before the code under test attempts it');
+        $this->liveRunnerLockHandle = $handle;
+    }
+
+    // ------------------------------------------------------------------
+    // resumeIfStalled(): 7200s hard-ceiling guard.
+    // ------------------------------------------------------------------
+
+    /**
+     * FAILS against the pre-fix code: before GH #256 finding 3, none of the
+     * four give-up paths took any lock at all, so reclaimRunScratch() would
+     * delete the scratch directory even while a live runner (simulated here
+     * by holding the exact same lock file TaskRunner::run() would hold)
+     * still owns it.
+     */
+    public function test_hard_ceiling_guard_does_not_delete_scratch_while_a_live_runner_holds_the_lock(): void
+    {
+        $dir = $this->seedScratch(self::HARD_CEILING_ID);
+        $this->simulateLiveRunnerHoldingLock(self::HARD_CEILING_ID);
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->seedRow(self::HARD_CEILING_ID, [
+            'phase'            => TaskRunner::PHASE_ARCHIVING_FILES,
+            'started_at'       => time() - 7300, // past the 7200s hard ceiling.
+            'last_progress_at' => time() - 7300,
+            'sub_state'        => (string) json_encode(['params' => $this->runnerParams(self::HARD_CEILING_ID)]),
+        ]);
+        $GLOBALS['wpdb'] = $wpdb;
+
+        Watchdog::resumeIfStalled(self::HARD_CEILING_ID);
+
+        $this->assertDirectoryExists($dir, 'a live runner still holds the run-lock; its scratch directory must NOT be deleted out from under it');
+        $this->assertFileExists($dir . '/database.sql.gz', 'the live runner\'s in-flight artifact file must survive the give-up path');
+        $this->assertArrayNotHasKey(self::HARD_CEILING_ID, $wpdb->rows, 'the task row discard is unaffected by the lock gate: only the file reclaim is gated');
+    }
+
+    // ------------------------------------------------------------------
+    // resumeIfStalled(): late-phase (encrypting_uploading /
+    // submitting_manifest) stale guard.
+    // ------------------------------------------------------------------
+
+    /**
+     * GH #256 finding 4: the 300s late-phase threshold can legitimately fire
+     * while a single large chunk upload is still in flight on a slow link.
+     * This is the scenario that guard's threshold alone cannot distinguish
+     * from a genuinely dead runner; the run-lock probe is what makes the
+     * file reclaim safe regardless of the threshold value.
+     */
+    public function test_late_phase_guard_does_not_delete_scratch_while_a_live_runner_holds_the_lock(): void
+    {
+        $dir = $this->seedScratch(self::LATE_PHASE_ID);
+        $this->simulateLiveRunnerHoldingLock(self::LATE_PHASE_ID);
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->seedRow(self::LATE_PHASE_ID, [
+            'phase'            => TaskRunner::PHASE_ENCRYPTING_UPLOADING,
+            'started_at'       => time() - 600,
+            'last_progress_at' => time() - 400, // past the 300s late-phase threshold.
+            'sub_state'        => (string) json_encode(['params' => $this->runnerParams(self::LATE_PHASE_ID)]),
+        ]);
+        $GLOBALS['wpdb'] = $wpdb;
+
+        Watchdog::resumeIfStalled(self::LATE_PHASE_ID);
+
+        $this->assertDirectoryExists($dir, 'a live runner still holds the run-lock (e.g. mid-upload of one large chunk); its scratch directory must NOT be deleted');
+        $this->assertFileExists($dir . '/wp-content.g000.part001.zip', 'the live runner\'s in-flight archive part must survive the give-up path');
+        $this->assertArrayNotHasKey(self::LATE_PHASE_ID, $wpdb->rows, 'the task row discard is unaffected by the lock gate: only the file reclaim is gated');
+    }
+
+    // ------------------------------------------------------------------
+    // resumeIfStalled(): max-resumes exhaustion guard.
+    // ------------------------------------------------------------------
+
+    /**
+     * FAILS against the pre-fix code for the same reason as the two guards
+     * above: none of the four give-up paths took any lock before this fix,
+     * including this one (reached only after $resumeCount >= $maxResumes
+     * separate stall detections).
+     */
+    public function test_max_resumes_exhaustion_guard_does_not_delete_scratch_while_a_live_runner_holds_the_lock(): void
+    {
+        $dir = $this->seedScratch(self::MAX_RESUMES_ID);
+        $this->simulateLiveRunnerHoldingLock(self::MAX_RESUMES_ID);
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->seedRow(self::MAX_RESUMES_ID, [
+            'phase'            => TaskRunner::PHASE_ARCHIVING_FILES,
+            'started_at'       => time() - 600,  // well under the 7200s hard ceiling.
+            'last_progress_at' => time() - 200,  // past STALL_THRESHOLD_SECONDS (180s).
+            'resume_count'     => 6,
+            'max_resumes'      => 6,
+            'sub_state'        => (string) json_encode(['params' => $this->runnerParams(self::MAX_RESUMES_ID)]),
+        ]);
+        $GLOBALS['wpdb'] = $wpdb;
+
+        Watchdog::resumeIfStalled(self::MAX_RESUMES_ID);
+
+        $this->assertDirectoryExists($dir, 'a live runner still holds the run-lock; its scratch directory must NOT be deleted even after resume attempts are exhausted');
+        $this->assertFileExists($dir . '/database.sql.gz', 'the live runner\'s in-flight artifact file must survive the give-up path');
+        $this->assertArrayNotHasKey(self::MAX_RESUMES_ID, $wpdb->rows, 'the task row discard is unaffected by the lock gate: only the file reclaim is gated');
+    }
+
+    // ------------------------------------------------------------------
+    // dispatch(): 7200s stale-task guard.
+    // ------------------------------------------------------------------
+
+    /**
+     * FAILS against the pre-fix code for the same reason as the other three
+     * give-up paths: dispatch()'s own stale-task guard took no lock before
+     * this fix either.
+     */
+    public function test_dispatch_stale_task_guard_does_not_delete_scratch_while_a_live_runner_holds_the_lock(): void
+    {
+        $dir = $this->seedScratch(self::DISPATCH_STALE_ID);
+        $this->simulateLiveRunnerHoldingLock(self::DISPATCH_STALE_ID);
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->seedRow(self::DISPATCH_STALE_ID, [
+            'phase'            => TaskRunner::PHASE_ARCHIVING_FILES,
+            'started_at'       => time() - 7300, // past dispatch()'s own 7200s guard.
+            'last_progress_at' => time() - 7300,
+            'sub_state'        => (string) json_encode(['params' => $this->runnerParams(self::DISPATCH_STALE_ID)]),
+        ]);
+        $GLOBALS['wpdb'] = $wpdb;
+
+        Watchdog::dispatch(self::DISPATCH_STALE_ID);
+
+        $this->assertDirectoryExists($dir, 'a live runner still holds the run-lock; its scratch directory must NOT be deleted by dispatch()\'s stale-task guard');
+        $this->assertFileExists($dir . '/wp-content.g000.part001.zip', 'the live runner\'s in-flight archive part must survive the give-up path');
+        $this->assertArrayNotHasKey(self::DISPATCH_STALE_ID, $wpdb->rows, 'the task row discard is unaffected by the lock gate: only the file reclaim is gated');
+    }
+
+    // ------------------------------------------------------------------
+    // Once the lock is released, the SAME give-up decision reclaims safely
+    // (this is the pre-existing, already-covered behavior in
+    // WatchdogScratchReclaimTest.php; asserted once more here, in the same
+    // fixture shape, purely to show the gate is a probe-and-release, not a
+    // permanent block).
+    // ------------------------------------------------------------------
+
+    public function test_reclaim_proceeds_once_the_run_lock_is_released(): void
+    {
+        $dir = $this->seedScratch(self::HARD_CEILING_ID);
+        $this->simulateLiveRunnerHoldingLock(self::HARD_CEILING_ID);
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->seedRow(self::HARD_CEILING_ID, [
+            'phase'            => TaskRunner::PHASE_ARCHIVING_FILES,
+            'started_at'       => time() - 7300,
+            'last_progress_at' => time() - 7300,
+            'sub_state'        => (string) json_encode(['params' => $this->runnerParams(self::HARD_CEILING_ID)]),
+        ]);
+        $GLOBALS['wpdb'] = $wpdb;
+
+        // First attempt: lock held, files must survive; row is still deleted.
+        Watchdog::resumeIfStalled(self::HARD_CEILING_ID);
+        $this->assertDirectoryExists($dir);
+        $this->assertArrayNotHasKey(self::HARD_CEILING_ID, $wpdb->rows);
+
+        // The live runner finishes (or crashes) and releases its lock.
+        flock($this->liveRunnerLockHandle, LOCK_UN);
+        fclose($this->liveRunnerLockHandle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- test-only fixture cleanup
+        $this->liveRunnerLockHandle = null;
+
+        // A later reaper tick discovers the same still-orphaned row (a fresh
+        // seed here stands in for whatever re-discovers it, e.g. a stale
+        // BackupJanitor sweep candidate) with the lock now free.
+        $wpdb->seedRow(self::HARD_CEILING_ID, [
+            'phase'            => TaskRunner::PHASE_ARCHIVING_FILES,
+            'started_at'       => time() - 7300,
+            'last_progress_at' => time() - 7300,
+            'sub_state'        => (string) json_encode(['params' => $this->runnerParams(self::HARD_CEILING_ID)]),
+        ]);
+
+        Watchdog::resumeIfStalled(self::HARD_CEILING_ID);
+
+        $this->assertDirectoryDoesNotExist($dir, 'with the lock free, the give-up path must reclaim the scratch directory exactly as before this fix');
+        $this->assertArrayNotHasKey(self::HARD_CEILING_ID, $wpdb->rows);
+    }
+
+    /** Recursive delete used only for test fixture cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if ($dir === '' || !is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+}

--- a/apps/agent/tests/Backup/WatchdogReclaimSubstateSidecarTest.php
+++ b/apps/agent/tests/Backup/WatchdogReclaimSubstateSidecarTest.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * GitHub issue #256 post-ship review, finding 5: reclaimRunScratch() must
+ * follow the sidecar-spill pointer the same way TaskRunner::loadTask()
+ * does, or it silently no-ops on exactly the biggest runs: the ones whose
+ * encoded sub_state exceeded TaskRunner's SUBSTATE_SIDECAR_THRESHOLD
+ * (48 KiB) and got spilled to a `<scratch>/task_substate.json` sidecar
+ * file, leaving only a small `{"_sidecar":true,"file":"..."}` pointer
+ * inline in the DB column (see TaskRunner::saveTaskState()).
+ *
+ * A bare json_decode() of that column (the pre-fix Watchdog::decodeSubState()
+ * behavior) never sees `sub_state.params` for a spilled row, so
+ * reclaimRunScratch() could not resolve scratch_dir and returned without
+ * deleting anything, on precisely the runs with the most scratch to
+ * reclaim (the ones large enough to have spilled in the first place).
+ *
+ * This fixture builds a spilled sub_state the same shape TaskRunner's own
+ * saveTaskState() produces (see TaskRunnerSubStatePacketTest for the
+ * production-code round trip), then drives it through a Watchdog give-up
+ * path and asserts the scratch directory IS reclaimed.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Backup\TaskRunner;
+use WPMgr\Agent\Backup\Watchdog;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\Watchdog
+ * @covers \WPMgr\Agent\Backup\TaskRunner
+ */
+final class WatchdogReclaimSubstateSidecarTest extends TestCase
+{
+    private const SNAPSHOT_ID = '77777777-8888-4999-8aaa-bbbbbbbbbbbb';
+
+    /** Mirrors TaskRunner::SUBSTATE_SIDECAR_NAME, a private class constant. */
+    private const SIDECAR_FILENAME = 'task_substate.json';
+
+    private string $root       = '';
+    private string $scratchDir = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->root       = sys_get_temp_dir() . '/wpmgr-reclaim-sidecar-test-' . bin2hex(random_bytes(6));
+        $this->scratchDir = $this->root . '/scratch/' . self::SNAPSHOT_ID;
+        mkdir($this->scratchDir, 0700, true);
+
+        Functions\when('wp_json_encode')->alias(static fn ($d) => json_encode($d));
+        Functions\when('wp_schedule_single_event')->justReturn(true);
+        Functions\when('wp_delete_file')->alias(static function ($f) {
+            return @unlink($f); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        });
+    }
+
+    protected function tear_down(): void
+    {
+        unset($GLOBALS['wpdb']);
+        $this->rrmdir($this->root);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /** @return array<string,mixed> Minimal-but-valid TaskRunner params. */
+    private function runnerParams(): array
+    {
+        return [
+            'snapshot_id'       => self::SNAPSHOT_ID,
+            'kind'              => 'files',
+            'age_recipient'     => 'age1' . str_repeat('q', 58),
+            'presign_endpoint'  => 'https://cp.invalid/agent/v1/backups/sidecar-test/presign',
+            'manifest_endpoint' => 'https://cp.invalid/agent/v1/backups/sidecar-test/manifest',
+            'progress_endpoint' => '',
+            'chunk_bytes'       => 4 * 1024 * 1024,
+            'scratch_dir'       => $this->scratchDir,
+            'wp_content_path'   => $this->root . '/wp-content',
+            'db'                => ['host' => 'localhost', 'user' => 'u', 'password' => 'p', 'name' => 'n', 'prefix' => 'wp_'],
+        ];
+    }
+
+    /**
+     * Build a spilled sub_state fixture the same shape saveTaskState()
+     * produces once the encoded cursor exceeds SUBSTATE_SIDECAR_THRESHOLD
+     * (48 KiB): the full cursor, including sub_state.params (the very thing
+     * reclaimRunScratch() needs to find scratch_dir), written to
+     * `<scratch>/task_substate.json`, with only a small pointer left
+     * inline for the DB column.
+     *
+     * @return string The pointer JSON that belongs in the row's sub_state column.
+     */
+    private function seedSpilledSubState(): string
+    {
+        // A large inline tombstones array is exactly what pushed a real
+        // sub_state over the sidecar threshold before ADR-051 moved
+        // tombstones to an on-disk flat file (see
+        // TaskRunnerSubStatePacketTest); reused here purely to build a
+        // realistically oversized fixture.
+        $bigTombstones = [];
+        for ($i = 0; $i < 3000; $i++) {
+            $bigTombstones[] = 'plugins/some-plugin/file-' . $i . '.php';
+        }
+
+        $fullSubState = [
+            'params' => $this->runnerParams(),
+            'files'  => [
+                'done'       => true,
+                'parts'      => ['wp-content.g000.part001.zip'],
+                'tombstones' => $bigTombstones,
+            ],
+        ];
+        $encoded = (string) json_encode($fullSubState);
+        $this->assertGreaterThan(48 * 1024, strlen($encoded), 'fixture must actually exceed the sidecar threshold to be a faithful test');
+
+        $sidecarPath = $this->scratchDir . DIRECTORY_SEPARATOR . self::SIDECAR_FILENAME;
+        file_put_contents($sidecarPath, $encoded);
+
+        return (string) json_encode(['_sidecar' => true, 'file' => $sidecarPath]);
+    }
+
+    /**
+     * FAILS against the pre-fix code: Watchdog::decodeSubState() used a
+     * bare json_decode() of the raw column, which for a spilled row
+     * returns only the `{"_sidecar":true,...}` pointer object and never
+     * sees sub_state.params, so reclaimRunScratch() could not resolve
+     * scratch_dir and silently did nothing, leaking exactly the largest
+     * runs' scratch directories (short of the age-gated
+     * BackupJanitor::gcRuns() backstop).
+     */
+    public function test_hard_ceiling_guard_reclaims_scratch_when_substate_has_spilled_to_the_sidecar(): void
+    {
+        file_put_contents($this->scratchDir . '/database.sql.gz', 'fixture-bytes');
+        file_put_contents($this->scratchDir . '/wp-content.g000.part001.zip', 'fixture-zip-bytes');
+
+        $pointerJson = $this->seedSpilledSubState();
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->seedRow(self::SNAPSHOT_ID, [
+            'phase'            => TaskRunner::PHASE_ARCHIVING_FILES,
+            'started_at'       => time() - 7300, // past the 7200s hard ceiling.
+            'last_progress_at' => time() - 7300,
+            'sub_state'        => $pointerJson,
+        ]);
+        $GLOBALS['wpdb'] = $wpdb;
+
+        Watchdog::resumeIfStalled(self::SNAPSHOT_ID);
+
+        $this->assertDirectoryDoesNotExist(
+            $this->scratchDir,
+            'a spilled sub_state must still resolve scratch_dir (by following the sidecar pointer) and reclaim the scratch directory'
+        );
+        $this->assertArrayNotHasKey(self::SNAPSHOT_ID, $wpdb->rows);
+    }
+
+    /** Recursive delete used only for test fixture cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if ($dir === '' || !is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+}

--- a/apps/agent/tests/Backup/WatchdogScratchReclaimTest.php
+++ b/apps/agent/tests/Backup/WatchdogScratchReclaimTest.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * GitHub issue #256 regression: every Watchdog path that gives up on a
+ * `wpmgr_backup_tasks` row (discarding it via DELETE, or, pre-#256, an
+ * UPDATE to phase=failed) must reclaim that snapshot's scratch directory
+ * FIRST, since the row is the only record of where that scratch lives.
+ * Before this fix, none of these paths touched the filesystem at all, so a
+ * failed/abandoned backup's entire `wpmgr-agent/runs/<snapshot_id>/`
+ * directory (DB dump, zip parts, encrypted chunk files) leaked until the
+ * age-gated BackupJanitor::gcRuns() backstop eventually swept it hours
+ * later.
+ *
+ * Covers the four give-up paths named in GH #256:
+ *   - resumeIfStalled()'s 7200s hard-ceiling guard.
+ *   - resumeIfStalled()'s late-phase (encrypting_uploading /
+ *     submitting_manifest) stale guard: the LARGEST leak, since every zip
+ *     part and encrypted chunk is already on disk by that phase.
+ *   - dispatch()'s stale-task guard.
+ *   - The max-resumes exhaustion branch is covered separately in
+ *     WatchdogReaperTest (it changed from "mark failed" to "reclaim +
+ *     delete", which is a behavior change worth keeping alongside that
+ *     branch's existing coverage).
+ *
+ * Also covers the defensive no-op: a row whose sub_state.params (or
+ * scratch_dir) is missing/corrupt must never error; reclaiming scratch is
+ * best-effort, exactly like every other cleanup path in this class.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Backup\TaskRunner;
+use WPMgr\Agent\Backup\Watchdog;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\Watchdog
+ * @covers \WPMgr\Agent\Backup\TaskRunner
+ */
+final class WatchdogScratchReclaimTest extends TestCase
+{
+    private const HARD_CEILING_ID    = '11111111-2222-4333-8444-555555555555';
+    private const LATE_PHASE_ID      = '22222222-3333-4444-8555-666666666666';
+    private const DISPATCH_STALE_ID  = '33333333-4444-4555-8666-777777777777';
+    private const NO_PARAMS_ID       = '44444444-5555-4666-8777-888888888888';
+
+    private string $root       = '';
+    private string $scratchDir = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->root       = sys_get_temp_dir() . '/wpmgr-reclaim-test-' . bin2hex(random_bytes(6));
+        $this->scratchDir = $this->root . '/scratch';
+        mkdir($this->scratchDir, 0755, true);
+
+        Functions\when('wp_json_encode')->alias(static fn ($d) => json_encode($d));
+        Functions\when('wp_schedule_single_event')->justReturn(true);
+        Functions\when('wp_delete_file')->alias(static function ($f) {
+            return @unlink($f); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        });
+    }
+
+    protected function tear_down(): void
+    {
+        unset($GLOBALS['wpdb']);
+        $this->rrmdir($this->root);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /** @return array<string,mixed> Minimal-but-valid TaskRunner params. */
+    private function runnerParams(string $snapshotId): array
+    {
+        return [
+            'snapshot_id'       => $snapshotId,
+            'kind'              => 'files',
+            'age_recipient'     => 'age1' . str_repeat('q', 58),
+            'presign_endpoint'  => 'https://cp.invalid/agent/v1/backups/reclaim-test/presign',
+            'manifest_endpoint' => 'https://cp.invalid/agent/v1/backups/reclaim-test/manifest',
+            'progress_endpoint' => '',
+            'chunk_bytes'       => 4 * 1024 * 1024,
+            'scratch_dir'       => $this->scratchDir . '/' . $snapshotId,
+            'wp_content_path'   => $this->root . '/wp-content',
+            'db'                => ['host' => 'localhost', 'user' => 'u', 'password' => 'p', 'name' => 'n', 'prefix' => 'wp_'],
+        ];
+    }
+
+    /** Seed a run's scratch dir with a representative artifact file. */
+    private function seedScratch(string $snapshotId): string
+    {
+        $dir = $this->scratchDir . '/' . $snapshotId;
+        mkdir($dir, 0700, true);
+        file_put_contents($dir . '/database.sql.gz', 'fixture-bytes');
+        file_put_contents($dir . '/wp-content.g000.part001.zip', 'fixture-zip-bytes');
+
+        return $dir;
+    }
+
+    // ------------------------------------------------------------------
+    // resumeIfStalled(): 7200s hard-ceiling guard.
+    // ------------------------------------------------------------------
+
+    public function test_hard_ceiling_guard_reclaims_scratch_before_deleting_row(): void
+    {
+        $dir = $this->seedScratch(self::HARD_CEILING_ID);
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->seedRow(self::HARD_CEILING_ID, [
+            'phase'            => TaskRunner::PHASE_ARCHIVING_FILES,
+            'started_at'       => time() - 7300, // past the 7200s hard ceiling.
+            'last_progress_at' => time() - 7300,
+            'sub_state'        => (string) json_encode(['params' => $this->runnerParams(self::HARD_CEILING_ID)]),
+        ]);
+        $GLOBALS['wpdb'] = $wpdb;
+
+        Watchdog::resumeIfStalled(self::HARD_CEILING_ID);
+
+        $this->assertDirectoryDoesNotExist($dir, 'the 7200s hard-ceiling guard must reclaim scratch before deleting the row');
+        $this->assertArrayNotHasKey(self::HARD_CEILING_ID, $wpdb->rows, 'the row must still be deleted, exactly as before this fix');
+    }
+
+    // ------------------------------------------------------------------
+    // resumeIfStalled(): late-phase (encrypting_uploading /
+    // submitting_manifest) stale guard: the LARGEST leak.
+    // ------------------------------------------------------------------
+
+    public function test_late_phase_stale_guard_reclaims_scratch_before_deleting_row(): void
+    {
+        $dir = $this->seedScratch(self::LATE_PHASE_ID);
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->seedRow(self::LATE_PHASE_ID, [
+            'phase'            => TaskRunner::PHASE_ENCRYPTING_UPLOADING,
+            'started_at'       => time() - 600,
+            'last_progress_at' => time() - 400, // past the 300s late-phase threshold.
+            'sub_state'        => (string) json_encode(['params' => $this->runnerParams(self::LATE_PHASE_ID)]),
+        ]);
+        $GLOBALS['wpdb'] = $wpdb;
+
+        Watchdog::resumeIfStalled(self::LATE_PHASE_ID);
+
+        $this->assertDirectoryDoesNotExist($dir, 'the late-phase stale guard must reclaim scratch: this is the reporter\'s exact screenshot shape and the largest leak (zip parts + chunks already on disk)');
+        $this->assertArrayNotHasKey(self::LATE_PHASE_ID, $wpdb->rows, 'the row must still be deleted, exactly as before this fix');
+    }
+
+    // ------------------------------------------------------------------
+    // dispatch(): stale-task guard.
+    // ------------------------------------------------------------------
+
+    public function test_dispatch_stale_task_guard_reclaims_scratch_before_deleting_row(): void
+    {
+        $dir = $this->seedScratch(self::DISPATCH_STALE_ID);
+
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->seedRow(self::DISPATCH_STALE_ID, [
+            'phase'            => TaskRunner::PHASE_ARCHIVING_FILES, // past `queued`.
+            'started_at'       => time() - 7300, // past the 7200s ceiling.
+            'last_progress_at' => time() - 7300,
+            'sub_state'        => (string) json_encode(['params' => $this->runnerParams(self::DISPATCH_STALE_ID)]),
+        ]);
+        $GLOBALS['wpdb'] = $wpdb;
+
+        Watchdog::dispatch(self::DISPATCH_STALE_ID);
+
+        $this->assertDirectoryDoesNotExist($dir, 'dispatch()\'s stale-task guard must reclaim scratch before deleting the row');
+        $this->assertArrayNotHasKey(self::DISPATCH_STALE_ID, $wpdb->rows, 'the row must still be deleted, exactly as before this fix');
+    }
+
+    // ------------------------------------------------------------------
+    // Defensive: missing/corrupt sub_state.params must never error.
+    // ------------------------------------------------------------------
+
+    public function test_reclaim_is_a_silent_no_op_when_params_are_missing(): void
+    {
+        $wpdb = new FakeBackupTasksWpdb();
+        $wpdb->seedRow(self::NO_PARAMS_ID, [
+            'phase'            => TaskRunner::PHASE_ARCHIVING_FILES,
+            'started_at'       => time() - 7300,
+            'last_progress_at' => time() - 7300,
+            'sub_state'        => '{}', // no 'params' key at all.
+        ]);
+        $GLOBALS['wpdb'] = $wpdb;
+
+        // Must not throw.
+        Watchdog::resumeIfStalled(self::NO_PARAMS_ID);
+
+        $this->assertArrayNotHasKey(self::NO_PARAMS_ID, $wpdb->rows, 'the row must still be deleted by the hard-ceiling guard even when scratch cannot be resolved');
+    }
+
+    /** Recursive delete used only for test fixture cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if ($dir === '' || !is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.87
+ * Version:           0.61.95
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.87');
+define('WPMGR_AGENT_VERSION', '0.61.95');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,30 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.95",
+    date: "2026-07-27",
+    summary: "A failed backup no longer leaves its working files behind on the site.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "A failed backup left its working directory (upload parts, copied plugins and themes, the database dump) on the site instead of cleaning up after itself (GH #256). One reported site was left with about 1.4 GB behind. Four separate give-up paths in the agent's backup watchdog now all reclaim it, but only once the same run-lock a live backup holds confirms the backup is truly stopped, so a slow but still-running backup is never touched.",
+      },
+      {
+        tag: "Fixed",
+        text: "The routine cleanup for old backup working directories, and the separate one for restore leftovers, depended entirely on WP-Cron and so never ran at all on a site where WP-Cron is disabled, unreliable, or gets no visitors. Both now also run on an ordinary page load, throttled so a busy site pays almost nothing for them. A bug that could permanently wedge the restore cleanup after one missed run is also fixed.",
+      },
+      {
+        tag: "Fixed",
+        text: "The Sites grid could show a green \"Backups\" indicator next to a red \"Failed\" badge for the same site; the misleading indicator has been removed, and the backup chip beside it already shows the real status.",
+      },
+      {
+        tag: "Fixed",
+        text: "The backup delete dialog said deleting a backup reclaims the site's storage, which was not true since the site's own temporary files stayed on the host; the wording now says what actually happens.",
+      },
+    ],
+    featureLinks: [{ label: "Backups", href: "/features/backups/" }],
+  },
+  {
     version: "0.61.93",
     date: "2026-07-27",
     summary: "Spot a site whose WordPress has failed even when its cache keeps serving visitors.",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.93 / open source",
+  badge: "v0.61.95 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/apps/web/src/features/backups/backups-section.tsx
+++ b/apps/web/src/features/backups/backups-section.tsx
@@ -1443,9 +1443,10 @@ function BackupRowActions({
         consequencesBody={
           <>
             <p>
-              This permanently deletes the snapshot and reclaims its storage.
-              Unique chunks are removed; chunks still used by other snapshots are
-              kept. This cannot be undone.
+              This permanently deletes the snapshot and its stored data.
+              Unique chunks are removed; chunks still used by other snapshots
+              are kept. Any temporary files the site left on the host are
+              cleaned up separately by the site itself. This cannot be undone.
             </p>
             {dependentsCount > 0 ? (
               <p className="text-warning-subtle-fg">

--- a/apps/web/src/features/sites/site-card.test.ts
+++ b/apps/web/src/features/sites/site-card.test.ts
@@ -107,7 +107,6 @@ interface CapabilityFlags {
   hasPageCache: boolean;
   hasObjectCache: boolean;
   isHttps: boolean;
-  hasBackups: boolean;
   isMultisite: boolean;
 }
 
@@ -115,9 +114,8 @@ function deriveCapabilityFlags(site: Partial<Site>): CapabilityFlags {
   const hasPageCache = site.page_cache_enabled ?? false;
   const hasObjectCache = site.object_cache_enabled ?? false;
   const isHttps = (site.url ?? "").startsWith("https://");
-  const hasBackups = site.last_backup_status != null;
   const isMultisite = site.multisite ?? false;
-  return { hasPageCache, hasObjectCache, isHttps, hasBackups, isMultisite };
+  return { hasPageCache, hasObjectCache, isHttps, isMultisite };
 }
 
 describe("CapabilityStrip — lit glyphs (enabled=true)", () => {
@@ -125,7 +123,6 @@ describe("CapabilityStrip — lit glyphs (enabled=true)", () => {
     const site: Partial<Site> = {
       url: "https://example.com",
       multisite: false,
-      last_backup_status: undefined,
       page_cache_enabled: true,
       object_cache_enabled: false,
     };
@@ -137,7 +134,6 @@ describe("CapabilityStrip — lit glyphs (enabled=true)", () => {
     const site: Partial<Site> = {
       url: "https://example.com",
       multisite: false,
-      last_backup_status: undefined,
       page_cache_enabled: false,
       object_cache_enabled: true,
     };
@@ -147,15 +143,6 @@ describe("CapabilityStrip — lit glyphs (enabled=true)", () => {
   it("HTTPS is lit when url starts with https://", () => {
     const flags = deriveCapabilityFlags({ url: "https://example.com", multisite: false });
     expect(flags.isHttps).toBe(true);
-  });
-
-  it("backups are lit when last_backup_status is non-null", () => {
-    const flags = deriveCapabilityFlags({
-      url: "https://example.com",
-      multisite: false,
-      last_backup_status: "success",
-    });
-    expect(flags.hasBackups).toBe(true);
   });
 
   it("multisite is lit when multisite flag is true", () => {
@@ -203,15 +190,6 @@ describe("CapabilityStrip — dim glyphs (enabled=false)", () => {
   it("HTTPS is dim for http:// sites", () => {
     const flags = deriveCapabilityFlags({ url: "http://example.com", multisite: false });
     expect(flags.isHttps).toBe(false);
-  });
-
-  it("backups are dim when last_backup_status is null/undefined", () => {
-    const flags = deriveCapabilityFlags({
-      url: "https://example.com",
-      multisite: false,
-      last_backup_status: undefined,
-    });
-    expect(flags.hasBackups).toBe(false);
   });
 
   it("multisite is dim when flag is false", () => {

--- a/apps/web/src/features/sites/site-card.tsx
+++ b/apps/web/src/features/sites/site-card.tsx
@@ -10,7 +10,7 @@
  *   2. Header row         — site name link + SiteRowActions menu
  *   3. Status rail        — ConnectionStateBadge + hostname (mono, reserved slot)
  *   4. Capability group   — labeled 2-col grid: Page Cache / Object Cache /
- *                           HTTPS / Backups / Multisite — always visible
+ *                           HTTPS / Multisite — always visible
  *   5. Chip flow          — UpdateChip / calm "Up to date" | BackupChip / calm
  *                           "No backups yet" | SslChip (when tls_expires_at)
  *   6. Uptime row         — pct + latency + StatusDot, reserved slot
@@ -34,7 +34,6 @@ import {
   HardDrive,
   Lock,
   Plus,
-  RefreshCcw,
 } from "lucide-react";
 import type { ReactNode } from "react";
 import type { Site } from "@wpmgr/api";
@@ -92,7 +91,6 @@ function buildCapabilityItems(site: Site): CapabilityItem[] {
   const hasObjectCache = site.object_cache_enabled;
 
   const isHttps = site.url.startsWith("https://");
-  const hasBackups = site.last_backup_status != null;
   const isMultisite = site.multisite;
 
   return [
@@ -110,11 +108,6 @@ function buildCapabilityItems(site: Site): CapabilityItem[] {
       icon: Lock,
       label: "HTTPS",
       enabled: isHttps,
-    },
-    {
-      icon: RefreshCcw,
-      label: "Backups",
-      enabled: hasBackups,
     },
     {
       icon: Globe,

--- a/apps/web/src/routes/_authed/sites/$siteId.backups.$snapshotId.tsx
+++ b/apps/web/src/routes/_authed/sites/$siteId.backups.$snapshotId.tsx
@@ -420,11 +420,13 @@ function SnapshotDetailView({
             title="Delete backup"
             consequencesBody={
               <p>
-                This permanently deletes this snapshot and reclaims its storage.
+                This permanently deletes this snapshot and its stored data.
                 Unique chunks are removed; chunks still used by other snapshots
-                are kept. If this backup anchors an incremental chain with newer
-                increments, deletion is refused until those are removed first.
-                This cannot be undone.
+                are kept. Any temporary files the site left on the host are
+                cleaned up separately by the site itself. If this backup
+                anchors an incremental chain with newer increments, deletion
+                is refused until those are removed first. This cannot be
+                undone.
               </p>
             }
             resourceName={snapshot.id.slice(0, 8)}

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.94
+  version: 0.61.95
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Fixes #256. Reported by @iacopoincerpi, corroborated in detail by @infoproxa-oss.

## What was wrong

A failed backup deleted its control-plane record but left its **working directory on the site**: upload parts, copied plugins and themes, and the database dump. One reported site carried roughly **1.4 GB** across seven part files of about 198 MB each.

Two independent layers caused it, and research found a third:

1. **Four give-up paths, none of which cleaned up.** `Watchdog::resumeIfStalled()` (hard time ceiling, late-phase stall, resume attempts exhausted) and `Watchdog::dispatch()` (stale-task guard) all deleted the task row without touching the scratch directory.
2. **The cleanup that did exist was WP-Cron only.** On sites where WP-Cron is disabled, unreliable, or simply has no visitors, neither the backup-scratch janitor nor the restore-leftover cleanup ever ran.
3. **The restore cleanup could wedge permanently.** It scheduled itself as a one-shot; once its scheduled time passed without firing, `wp_next_scheduled()` still reported it as scheduled, so every later restore declined to reschedule and cleanup never ran again.

## The part that needed care

The obvious fix, delete the scratch directory on give-up, **would have deleted the working directory of a running backup**. Multi-hour backups on large sites are normal, and none of the give-up conditions actually prove the runner is dead. That is a far worse bug than the disk leak.

Every delete now runs inside `TaskRunner::withRunLock()`: the same `GET_LOCK` plus `flock` a live backup holds, acquired for the *duration of the delete* and released in a `finally`. `run()` holds that flock across its entire body (`class-task-runner.php:276` to `:493`), so it is a real liveness proof independent of any DB row or mtime. If the lock is held, the sweep skips the directory and leaves it for a later pass.

A lock that **cannot even be attempted** (unresolvable path, `open_basedir`, read-only filesystem) counts as *not provably free* on this path. `run()` treats that same degradation as safe because a duplicate run is merely wasteful; for a delete, absence of proof is not proof of absence.

### `gcRuns()` needed the same gate, and this change is why

When the reclaim correctly skips a live run, `BackupJanitor::gcRuns()` becomes the sole reclaimer. Its own guards are **not sufficient alone**:

- `isActiveRun()` reports "not active" when there is **no task row**, which is exactly the state every give-up branch leaves behind.
- A directory's mtime **does not advance when a file's contents are written**, so a long single-file database dump can leave a live run's directory looking untouched well past the 6 hour age gate.

Both were pre-existing and dormant *because `gcRuns()` never actually ran on cron-quiet sites*. Adding the hourly trigger makes it run on precisely those sites, so this change would have activated the weakness. `gcRuns()` now takes the same gate, attempted only **after** the age gate and `isActiveRun()` veto both pass, so a tidy site pays nothing.

## Interface honesty

Both of these were reported in the thread:

- The delete dialog promised it *"reclaims its storage"* while host temporary files remained. Reworded to say what actually happens.
- The Sites grid lit a green **Backups** indicator whenever `last_backup_status != null`, **including `"failed"`** so a failed backup showed a green indicator beside its own red **Failed** badge. Removed; the backup chip already carries the real status. This is a small product change riding with the fix rather than a separate PR because it is the reporter's own screenshot.

## Already fixed, noted for anyone reading the issue

Two failures visible in the report are not new work: the `runner already in flight` refusal was fixed in 0.61.84 (#274), and `EncryptAndUpload: missing local chunk` in 0.61.87 (#283).

## Verification

Each safety fix has a test **confirmed to fail against the pre-fix code** (temporary revert, run, restore):

| Fix | Test | Pre-fix failure |
|---|---|---|
| Lock held across delete | `test_with_run_lock_holds_both_guards_for_the_full_duration_of_the_callback` | second flock inside the callback succeeded, proving early release |
| Degraded flock not "free" | `test_with_run_lock_treats_a_degraded_flock_guard_as_not_free` | callback ran with no liveness proof |
| Janitor gate | `test_stale_run_with_a_live_run_lock_held_survives_the_sweep` | directory deleted while a live flock was held |

- `phpunit`: 2857 tests, 16145 assertions, 0 failures
- `phpcs`: 0 errors, 0 warnings
- `wp plugin check`: 0 errors
- web: 99 files, 1214 tests green

Agent-side fix, so this needs `make agent-release` after merge alongside the usual deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LijsBvT79KkVsM8DY4tD1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup and restore cleanup after failures, including recovery of leftover temporary files.
  * Cleanup now runs reliably without depending solely on scheduled tasks.
  * Prevented cleanup from removing files still used by active backup processes.
  * Fixed overdue restore cleanup schedules so they are renewed correctly.
  * Corrected site backup status indicators to avoid conflicting success and failure states.

* **Documentation**
  * Updated backup deletion messaging to clarify permanent removal, shared data retention, and temporary file cleanup.
  * Published release notes for version 0.61.95.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->