### PR TITLE
fix(deps): bump grpc to 1.82.1 for GO-2026-6061

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.96] - 2026-07-28
+
+### Security
+
+- Updated the gRPC library the control plane depends on, from 1.81.1 to 1.82.1, to pick up fixes for GO-2026-6061 (GHSA-hrxh-6v49-42gf), which covers issues in that library's authorization engine and its HTTP/2 server transport. The library reaches WPMgr indirectly, through the OpenTelemetry trace exporter, and the affected code was reachable from database connection pool shutdown, so the update is worth taking even though WPMgr does not use the authorization engine itself. Official container images already build against a patched Go release; this update closes the remaining path.
+
 ## [0.61.95] - 2026-07-27
 
 ### Fixed

--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -225,7 +225,7 @@ require (
 	golang.org/x/tools v0.47.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/apps/api/go.sum
+++ b/apps/api/go.sum
@@ -639,8 +639,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.95 / open source",
+  badge: "v0.61.96 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.95
+  version: 0.61.96
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Restores green `main`. Ships as 0.61.96.

## What happened

`Security audit` went red on `main` immediately after #298 merged. It is **not** caused by that change, which touched PHP and TSX only and contained zero Go. The advisory was published between #298's PR run and its merge run, which is why the identical gate passed minutes earlier.

## The advisory

**GO-2026-6061** / GHSA-hrxh-6v49-42gf, in `google.golang.org/grpc`: the xDS RBAC authorization engine and the HTTP/2 server transport.

We do not use the authorization engine, but govulncheck reports it as reachable:

```
cmd/wpmgr/main.go:250:16: wpmgr.run calls pgxpool.Pool.Close,
  which eventually calls transport.NewHTTP2Client
```

grpc reaches us **indirectly**, via the OpenTelemetry OTLP trace exporter, and the pool flushes traces over it on shutdown. Fixed in **1.82.1**; no source changes needed.

## Two things checked and deliberately left alone

Worth stating so the next person does not re-derive them:

1. **Local govulncheck also reports three Go standard library advisories** (including one in the `crypto/x509` path used by WebAuthn login), all fixed in go1.26.4. These are an artifact of my local toolchain being **go1.26.3**. CI builds on **1.26.5** and reported only the grpc issue, so they are not a CI or production concern.
2. **`go.mod` still declares `go 1.26.3`**, which is itself a vulnerable stdlib. That only affects someone building locally with exactly that toolchain. `infra/Dockerfile.api` builds on the floating `golang:1.26` tag, so official container images already resolve to a patched stdlib. Raising the `go` directive would lift the floor for every contributor for no gain in the artifacts we actually ship, so it is left as is.

## Verification

- `govulncheck`: grpc no longer reported (remaining local hits are the stdlib ones above, absent on CI's 1.26.5)
- `go build`: clean
- `go vet`: clean
- `go test ./...`: **exit 0**, 64 packages, zero failures

Version lockstep: CHANGELOG 0.61.96 + openapi `info.version` 0.61.96 + marketing badge. No marketing changelog entry, since a transitive dependency bump is not user-facing and 0.61.95 is within the 5-patch tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LijsBvT79KkVsM8DY4tD1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated the control-plane gRPC dependency to address a reported security vulnerability.
  * Documented the security update in the changelog.

* **Release Updates**
  * Updated the application, marketing badge, and API specification to version 0.61.96.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->