### PR TITLE
feat: fleet-wide agent self-update, wave-gated, ships disabled (GH #255 phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.98] - 2026-07-28
+
+### Added
+
+- Fleet-wide agent updates (GH #255, phase 2 of two). An owner or administrator can now start an agent update across selected sites from the Sites list, instead of visiting each site's wp-admin one at a time to click the update the agent already offers there. Starting a rollout is restricted to those two roles.
+- This ships turned off. The capability sits behind a control-plane switch that defaults to off, so upgrading to this release changes nothing on its own. It will be turned on once it has been exercised against real sites.
+- A rollout proceeds in waves rather than hitting every selected site at once. The first wave is a single site, the second is a small percentage of the selection, and only once those have gone well does the rest of the fleet follow. A wave only opens after every site in the wave before it has confirmed, and confirmation means the updated agent itself reported back its new version, not that the update was merely scheduled or acknowledged. If the first wave fails, or too many sites in a later wave fail to confirm, the whole run stops and every remaining site is cancelled. A stop control halts every agent update in progress across the fleet.
+- Updating the agent works differently from updating any other plugin, because the agent is how WPMgr reaches a site at all. The update itself runs in a separate background request rather than the request that reports the result, and success is only ever recorded once the new agent version reports back in. A site that cannot complete that background step is left untouched and reported as unconfirmed, not failed.
+- Sites that cannot take an agent update from this channel are reported with a reason instead of being counted as a failed rollout: the WordPress.org build ships without the self-updater, and a site running an agent older than this release does not yet have the update channel this relies on. Both are skipped, not failed.
+
+### Fixed
+
+- A rollout whose target version stopped being published partway through used to carry on as though it had succeeded; it now stops the run instead, since a site that did not change is not a successful update.
+
 ## [0.61.97] - 2026-07-28
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,19 @@ agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip (fl
 		exit 1; \
 	fi
 	@echo "agent-zip-wporg: self-target guard constant OK (SELF_PLUGIN_FOLDER = 'fleet-agent-site-manager')"
+	# ASSERT no staged file resolves the (now absent) self-updater class outside a
+	# guard. includes/class-plugin.php SURVIVES the rsync above and holds two hard
+	# class fetches, `new UpdateChecker(...)` and `UpdateChecker::HOOK_APPLY`, each
+	# safe only because it sits inside a guard. Both sit among a dozen visually
+	# identical unconditional calls, so dedenting one out is a plausible refactor,
+	# and it would raise
+	#   Fatal error: Uncaught Error: Class "WPMgr\Agent\Support\UpdateChecker" not found
+	# on every request of every wp.org install. `wp plugin check` is static analysis
+	# and never executes the plugin, so it cannot catch that. This assert runs
+	# against the artifact that actually ships. Mirrors the SELF_PLUGIN_FOLDER
+	# assertion above. tools/ is excluded from the staged tree, so the checker is
+	# invoked from the source tree.
+	php apps/agent/tools/assert-wporg-updatechecker-guard.php release/fleet-agent-site-manager
 	cd release && zip -r fleet-agent-site-manager.zip fleet-agent-site-manager
 	rm -rf release/fleet-agent-site-manager
 	@echo "agent wporg zip: $$(du -sh release/fleet-agent-site-manager.zip | cut -f1)"

--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -17,6 +17,7 @@ use WPMgr\Agent\Backup\FilesRestorer;
 use WPMgr\Agent\Backup\RestoreRunner;
 use WPMgr\Agent\Backup\RestoreWatchdog;
 use WPMgr\Agent\Backup\Watchdog;
+use WPMgr\Agent\Commands\AgentSelfUpdateCommand;
 use WPMgr\Agent\Commands\AutologinCommand;
 use WPMgr\Agent\Commands\BackupCommand;
 use WPMgr\Agent\Commands\CommandInterface;
@@ -117,6 +118,7 @@ use WPMgr\Agent\Media\Rename;
 use WPMgr\Agent\Support\ActivityLog;
 use WPMgr\Agent\Support\AgeIdentity;
 use WPMgr\Agent\Support\ConnectionFinisher;
+use WPMgr\Agent\Support\DebugLog;
 use WPMgr\Agent\Support\ErrorMonitor;
 use WPMgr\Agent\Support\LoginBrand;
 use WPMgr\Agent\Support\LoginProtection;
@@ -139,6 +141,15 @@ final class Plugin
      * so admin pages can surface a fix-it notice and a lazy retry can run.
      */
     public const OPTION_KEYSTORE_ERROR = 'wpmgr_agent_keystore_error';
+
+    /**
+     * Highest agent version this site has already confirmed to the control
+     * plane by pushing metadata from it. Drives beat 3 of the CP-commanded
+     * self-update (see maybePushVersionChangedMetadata): a boot whose
+     * WPMGR_AGENT_VERSION differs from this value pushes once, then stamps.
+     * Non-autoloaded.
+     */
+    public const OPTION_REPORTED_VERSION = 'wpmgr_agent_reported_version';
 
     /**
      * v0.9.13 — Unix timestamp of the most recent SUCCESSFUL diagnostics push
@@ -938,8 +949,7 @@ final class Plugin
         // the site is enrolled (the only state in which UpdateCommand can
         // ever run at all, and therefore the only state in which its marker
         // could ever be armed). The mu-plugin itself is inert on every
-        // request until a marker actually exists (a single is_file() stat —
-        // see its own class doc), so no separate feature opt-in is needed
+        // request until a marker actually exists (a single is_file() stat, // see its own class doc), so no separate feature opt-in is needed
         // beyond enrollment. Remove a previously-installed copy on
         // un-enrollment so no executable mu-plugin lingers for a site the
         // control plane no longer manages.
@@ -973,8 +983,29 @@ final class Plugin
         // ADR-042 Phase 2 — bind the CP self-update hooks. Self-gates on
         // isEnrolled() inside UpdateChecker::install(); idempotent (static guard).
         // Skipped for the wp.org distribution build (WPMGR_WPORG_BUILD constant).
+        //
+        // The two bindings below belong to the CP-commanded three-beat
+        // self-update and are deliberately INSIDE this null guard: on the
+        // wp.org build $this->updateChecker is null and class-update-checker.php
+        // is not shipped at all, so no scheduled event and no boot hook may ever
+        // reference the missing class. (The agent_self_update COMMAND itself is
+        // registered unconditionally in commands(); it is null-tolerant by
+        // construction and answers "not_eligible" there, which is a better CP
+        // experience than an unknown-command 404.)
         if ($this->updateChecker !== null) {
             $this->updateChecker->install();
+
+            // BEAT 2 (APPLY): a separate WordPress bootstrap runs the upgrade,
+            // so no CP response rides on the request that copies the files.
+            // Single-shot: the staged record is claimed and deleted before any
+            // upgrade work starts, and nothing here schedules a follow-up.
+            add_action(UpdateChecker::HOOK_APPLY, [$this->updateChecker, 'applyStagedSelfUpdate'], 10, 1);
+
+            // BEAT 3 (CONFIRM): the only trustworthy success signal is the NEW
+            // code phoning home, so the freshly-installed build pushes metadata
+            // once on its first boot rather than waiting up to 30 minutes for
+            // the metadata cron.
+            add_action('plugins_loaded', [$this, 'maybePushVersionChangedMetadata']);
         }
 
         // Email (Phase 2) — register the pre_wp_mail interception hook.
@@ -1756,6 +1787,82 @@ final class Plugin
     }
 
     /**
+     * BEAT 3 (CONFIRM) of the CP-commanded self-update: push metadata once, on
+     * the first boot that runs a version this site has not yet reported.
+     *
+     * A "scheduled" acknowledgement from beat 1 is never success, and beat 2
+     * runs in a request that cannot be trusted to report its own outcome (it is
+     * replacing the code that would do the reporting). The only trustworthy
+     * signal is the NEW code phoning home, which is exactly what this is: the
+     * metadata payload already carries agent_version, so a push from the new
+     * build IS the confirmation. Without it the CP would wait up to 30 minutes
+     * for the metadata cron.
+     *
+     * Bound on plugins_loaded behind registerHooks()'s updateChecker-not-null
+     * guard, so the wp.org distribution build never registers it.
+     *
+     * Cheap on the hot path: one get_option() plus one constant read, and on
+     * every request after the first at the new version it returns at the
+     * version comparison. The push itself is deferred to 'shutdown' so the one
+     * request that happens to be the first boot never pays CP latency.
+     *
+     * The stamp is written BEFORE the push, not after (same reasoning as
+     * maybeRunRestoreGc): this is a network call, and a CP that is unreachable
+     * must not make every subsequent request re-attempt it. The 30-minute
+     * metadata cron is the backstop for a single missed confirmation.
+     *
+     * @return bool True when this call armed the confirmation push (at most
+     *              once per version), false when there was nothing to confirm.
+     *              Returned for testability; WordPress ignores an action
+     *              callback's return value.
+     */
+    public function maybePushVersionChangedMetadata(): bool
+    {
+        if (!function_exists('get_option') || !function_exists('update_option') || !function_exists('add_action')) {
+            return false;
+        }
+
+        // Nothing to confirm to a control plane this site is not talking to.
+        if (!$this->settings->isEnrolled()) {
+            return false;
+        }
+
+        $currentVersion = defined('WPMGR_AGENT_VERSION') ? (string) constant('WPMGR_AGENT_VERSION') : '';
+        if ($currentVersion === '') {
+            return false;
+        }
+
+        $reportedVersion = (string) get_option(self::OPTION_REPORTED_VERSION, '');
+        if ($reportedVersion === $currentVersion) {
+            return false;
+        }
+
+        update_option(self::OPTION_REPORTED_VERSION, $currentVersion, false);
+
+        add_action('shutdown', [$this, 'pushVersionChangedMetadata'], 9998);
+
+        return true;
+    }
+
+    /**
+     * Shutdown callback for the beat-3 confirmation push.
+     *
+     * Public so WordPress can call it as a named hook callback. Swallows every
+     * failure: a confirmation that cannot be delivered right now is picked up
+     * by the next metadata cron, and must never disturb the request it rides on.
+     *
+     * @return void
+     */
+    public function pushVersionChangedMetadata(): void
+    {
+        try {
+            $this->enrollment->pushMetadata();
+        } catch (\Throwable $e) {
+            DebugLog::write('WPMgr Agent: version-changed metadata confirmation failed: ' . $e->getMessage());
+        }
+    }
+
+    /**
      * Cron self-heal: re-arm the recurring reporting crons when they have gone
      * missing (the canonical case being an in-place plugin update — see the
      * plugins_loaded binding in registerHooks for the full failure mode).
@@ -1809,8 +1916,7 @@ final class Plugin
         // Phase 4b — suppression-cache pull — re-arm when missing.
         SuppressionCache::schedule_pull($now);
 
-        // M1 (issue #131 adversarial review) — snapshot-store GC backstop —
-        // re-arm when missing.
+        // M1 (issue #131 adversarial review), snapshot-store GC backstop, // re-arm when missing.
         SnapshotManager::scheduleGc($now);
 
         // S4 (issue #131 adversarial review) — update-in-flight reconcile
@@ -1862,6 +1968,17 @@ final class Plugin
             // FilesRestorer, DbRestorer) inside the cron worker.
             new RestoreCommand(),
             new UpdateCommand(),
+            // BEAT 1 (ARM) of the CP-commanded agent self-update. UpdateCommand
+            // above REFUSES any task that targets the agent's own directory
+            // (Phase 1) and keeps doing so; this is the separate, dedicated
+            // channel that replaces it. Verify-only: nothing on disk moves in
+            // the request that answers the CP.
+            //
+            // Registered UNCONDITIONALLY, including on the wp.org build where
+            // $this->updateChecker is null: the command is null-tolerant and
+            // answers "not_eligible" rather than fataling or 404ing. It names
+            // no self-updater symbol at file scope for exactly that reason.
+            new AgentSelfUpdateCommand($this->updateChecker),
             new RollbackCommand(),
             new ScanCommand(),
             // S3 — on-demand single-file fetch for scan findings inspection.
@@ -2326,8 +2443,7 @@ final class Plugin
      *
      * WordPress deletes only the files it tracks in _wp_attachment_metadata (the
      * in-place optimized file in REPLACE mode, the .avif/.webp in COEXIST mode).
-     * WPMgr additionally created UNTRACKED originals that WP knows nothing about —
-     * the *.wpmgr-original.<ext> archive (REPLACE) and the original-ext twin
+     * WPMgr additionally created UNTRACKED originals that WP knows nothing about, * the *.wpmgr-original.<ext> archive (REPLACE) and the original-ext twin
      * (COEXIST). This handler removes ONLY those untracked, blob-derived paths,
      * confined to the uploads basedir, then best-effort notifies the CP so the
      * site_media_assets row is reconciled.
@@ -2553,8 +2669,7 @@ final class Plugin
      *
      * Current implementation: bound to `wp_enqueue_scripts` (which WordPress
      * core itself fires from inside `wp_head` at priority 1), and RumInjector
-     * enqueues the collector via wp_enqueue_script()/wp_add_inline_script() —
-     * see {@see RumInjector::enqueue()}. Reads the perf config once and only
+     * enqueues the collector via wp_enqueue_script()/wp_add_inline_script(), * see {@see RumInjector::enqueue()}. Reads the perf config once and only
      * registers the hook when rumEnabled is on, so an inert site pays just a
      * single option read.
      *

--- a/apps/agent/includes/commands/class-agent-self-update-command.php
+++ b/apps/agent/includes/commands/class-agent-self-update-command.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Agent self-update command: BEAT 1 (ARM) of the three-beat self-update.
+ *
+ * Wire contract (CP -> agent):
+ *   POST /wp-json/wpmgr/v1/command/agent_self_update
+ *   body: {}
+ *   response (always HTTP 200):
+ *     {
+ *       "ok":           bool,
+ *       "status":       "not_eligible"|"up_to_date"|"scheduled"|"already_scheduled"|"error",
+ *       "from_version": string,
+ *       "to_version":   string,   // "" unless status is scheduled/already_scheduled
+ *       "detail":       string,
+ *       "cron_mode":    "loopback"|"external",
+ *       "expires_at":   int       // Unix ts; 0 unless a record was staged
+ *     }
+ *
+ * "scheduled" is an ACKNOWLEDGEMENT, never a success. Nothing on disk has moved
+ * when it is returned, and on a site whose loopback cron is broken nothing ever
+ * will, which is the SAFE outcome, and must surface at the CP as unconfirmed.
+ * The only trustworthy success signal is the NEW code phoning home: the
+ * version-changed boot metadata push (beat 3).
+ *
+ * WHY THIS FILE IS A THIN SHELL
+ * -----------------------------
+ * `make agent-zip-wporg` physically excludes includes/support/class-update-checker.php
+ * from the wp.org distribution build (Guideline 8), but this file SURVIVES that
+ * rsync. So it carries two hard rules:
+ *
+ *   (a) its own WPMGR_WPORG_BUILD guard, and
+ *   (b) NO UpdateChecker symbol at file scope. There is no `use` import, no
+ *       typed property and no typed parameter naming that class anywhere in
+ *       this file. A static reference would send the plugin's autoloader
+ *       after a file that does not exist in that build. The collaborator
+ *       arrives as a plain `?object` and the symbol is resolved lazily, by
+ *       string, behind a class_exists() check inside execute().
+ *
+ * "not_eligible" is the correct, non-fatal answer whenever the self-updater is
+ * absent (wp.org build) or the site is not enrolled.
+ *
+ * @package WPMgr\Agent\Commands
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Commands;
+
+/**
+ * Arms a CP-commanded agent self-update. Verify-only: this command never
+ * touches a file.
+ */
+final class AgentSelfUpdateCommand implements CommandInterface
+{
+    /**
+     * wp-option holding the outcome of the last APPLY beat, so the next
+     * metadata push carries it to the control plane. Declared HERE rather than
+     * on the self-updater because MetadataCommand reads it and must keep
+     * working in the wp.org build, where the self-updater does not exist.
+     *
+     * Shape: ['status'=>string,'from_version'=>string,'to_version'=>string,
+     *         'detail'=>string,'at'=>int]
+     */
+    public const OPTION_RESULT = 'wpmgr_agent_self_update_result';
+
+    /**
+     * Fully-qualified self-updater class name, held as a STRING on purpose.
+     * See the file header: a real symbol here would be resolved by the
+     * autoloader in a build that does not ship the class.
+     */
+    private const CHECKER_CLASS = 'WPMgr\\Agent\\Support\\UpdateChecker';
+
+    /**
+     * The self-updater, or null. Typed `?object` (not the concrete class) so
+     * this file names no symbol that the wp.org build omits.
+     *
+     * @var object|null
+     */
+    private ?object $updateChecker;
+
+    /**
+     * @param object|null $updateChecker Plugin passes its UpdateChecker
+     *                                    instance, which is already null on the
+     *                                    wp.org distribution build.
+     */
+    public function __construct(?object $updateChecker = null)
+    {
+        $this->updateChecker = $updateChecker;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function name(): string
+    {
+        return 'agent_self_update';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * The Router's permission_callback has already enforced the signed-JWT
+     * contract (Ed25519 signature, aud=siteId, cmd="agent_self_update", jti
+     * anti-replay) via Connector::verifyCommand, so by the time execute() runs
+     * the caller is authenticated.
+     *
+     * @param array<string,mixed> $claims Validated JWT claims (unused; the
+     *                                    Router already enforced the aud + cmd
+     *                                    binding).
+     * @param array<string,mixed> $params Request parameters; MUST be empty.
+     * @return array<string,mixed> See the wire contract in the file header.
+     */
+    public function execute(array $claims, array $params): array
+    {
+        // Body shape: refuse anything beyond an empty object, matching
+        // RefreshInventoryCommand. Future options go behind explicit named
+        // params, not "accept whatever arrives".
+        if ($params !== []) {
+            return $this->answer('error', 'This command takes no parameters.');
+        }
+
+        // Rule (a): the wp.org distribution build never self-updates.
+        if (defined('WPMGR_WPORG_BUILD') && constant('WPMGR_WPORG_BUILD')) {
+            return $this->answer('not_eligible', 'Self-update is not part of this distribution build.');
+        }
+
+        // Rule (b): resolve the self-updater lazily, by string. class_exists()
+        // is what makes a build that ships this file WITHOUT the self-updater
+        // answer instead of fatal.
+        $checker = $this->updateChecker;
+        if ($checker === null || !class_exists(self::CHECKER_CLASS)) {
+            return $this->answer('not_eligible', 'The self-updater is not available in this build.');
+        }
+        if (!method_exists($checker, 'stageSelfUpdate')) {
+            return $this->answer('not_eligible', 'The self-updater does not support staged updates.');
+        }
+
+        try {
+            $staged = $checker->stageSelfUpdate();
+        } catch (\Throwable $e) {
+            // ARM moves nothing on disk, so a throw here leaves the site
+            // exactly as it was. Report it rather than letting the Router turn
+            // it into an opaque 500.
+            return $this->answer('error', 'Staging failed: ' . $e->getMessage());
+        }
+
+        if (!is_array($staged) || !isset($staged['status']) || !is_string($staged['status'])) {
+            return $this->answer('error', 'The self-updater returned an unrecognised result.');
+        }
+
+        return $staged;
+    }
+
+    /**
+     * Build a locally-generated answer in the same shape the self-updater
+     * returns, so the CP parses exactly one response schema.
+     *
+     * @param string $status One of not_eligible|error.
+     * @param string $detail Human-readable, non-secret detail.
+     * @return array{status:string,ok:bool,from_version:string,to_version:string,detail:string,cron_mode:string,expires_at:int}
+     */
+    private function answer(string $status, string $detail): array
+    {
+        return [
+            'status'       => $status,
+            'ok'           => $status !== 'error',
+            'from_version' => defined('WPMGR_AGENT_VERSION') ? (string) constant('WPMGR_AGENT_VERSION') : '',
+            'to_version'   => '',
+            'detail'       => $detail,
+            'cron_mode'    => (defined('DISABLE_WP_CRON') && constant('DISABLE_WP_CRON')) ? 'external' : 'loopback',
+            'expires_at'   => 0,
+        ];
+    }
+}

--- a/apps/agent/includes/commands/class-metadata-command.php
+++ b/apps/agent/includes/commands/class-metadata-command.php
@@ -109,7 +109,52 @@ final class MetadataCommand implements CommandInterface
                 // Swallow — telemetry must not fail the sync.
             }
         }
+
+        // Outcome of the last self-update APPLY beat, when there is one. The
+        // apply runs in a cron request that has no CP response to ride on, so
+        // the next metadata push is how a FAILED apply reaches the control
+        // plane at all. Only ever present on a site that actually staged one.
+        $selfUpdate = $this->selfUpdateResult();
+        if ($selfUpdate !== null) {
+            $payload['agent_self_update'] = $selfUpdate;
+        }
+
         return $payload;
+    }
+
+    /**
+     * Read the last self-update apply outcome, if any.
+     *
+     * Reads the plain wp-option by name rather than going through the
+     * self-updater: that class is not shipped in the wp.org distribution build,
+     * and this collector runs in both builds. The option key constant lives on
+     * AgentSelfUpdateCommand, which is present in both.
+     *
+     * @return array{status:string,from_version:string,to_version:string,detail:string,at:int}|null
+     */
+    private function selfUpdateResult(): ?array
+    {
+        if (!function_exists('get_option')) {
+            return null;
+        }
+
+        $stored = get_option(AgentSelfUpdateCommand::OPTION_RESULT, null);
+        if (!is_array($stored)) {
+            return null;
+        }
+
+        $status = isset($stored['status']) && is_string($stored['status']) ? $stored['status'] : '';
+        if ($status === '') {
+            return null;
+        }
+
+        return [
+            'status'       => $status,
+            'from_version' => isset($stored['from_version']) && is_string($stored['from_version']) ? $stored['from_version'] : '',
+            'to_version'   => isset($stored['to_version'])   && is_string($stored['to_version'])   ? $stored['to_version']   : '',
+            'detail'       => isset($stored['detail'])       && is_string($stored['detail'])       ? $stored['detail']       : '',
+            'at'           => isset($stored['at']) && is_numeric($stored['at']) ? (int) $stored['at'] : 0,
+        ];
     }
 
     /**
@@ -575,8 +620,7 @@ final class MetadataCommand implements CommandInterface
             }
 
             // GH #211 sibling guard: only surface a core update when the
-            // offered version is strictly newer than what's installed —
-            // mirrors normalizeAvailableUpdate()'s phantom-suppression so a
+            // offered version is strictly newer than what's installed, // mirrors normalizeAvailableUpdate()'s phantom-suppression so a
             // stale/duplicate 'upgrade' response entry does not report a
             // same-version "update". Fails OPEN (keeps the entry) when
             // $current is empty/unreadable.

--- a/apps/agent/includes/support/class-update-checker.php
+++ b/apps/agent/includes/support/class-update-checker.php
@@ -38,6 +38,12 @@
  *   - WP_Error is returned on any download/sha failure (aborts the update
  *     visibly; temp file is unlinked before returning).
  *
+ * This file also carries the CP-commanded three-beat self-update (ARM in the
+ * signed command request, APPLY in a separate cron bootstrap, CONFIRM by the
+ * new code phoning home). It lives HERE, and not in a new file, because
+ * `make agent-zip-wporg` physically excludes this one path from the wp.org
+ * distribution build; see the block comment above stageSelfUpdate().
+ *
  * @package WPMgr\Agent\Support
  */
 
@@ -45,6 +51,7 @@ declare(strict_types=1);
 
 namespace WPMgr\Agent\Support;
 
+use WPMgr\Agent\Commands\AgentSelfUpdateCommand;
 use WPMgr\Agent\Keystore;
 use WPMgr\Agent\ReplayCache;
 use WPMgr\Agent\Settings;
@@ -105,6 +112,50 @@ final class UpdateChecker
     public const MAX_PACKAGE_BYTES = 64 * 1024 * 1024;
 
     /**
+     * Cron hook that runs beat 2 (APPLY) of the three-beat self-update
+     * protocol, in its own WordPress bootstrap. Bound in Plugin::registerHooks()
+     * behind the same updateChecker-not-null guard that skips this whole class
+     * on the wp.org distribution build, so the event can never fire into a
+     * missing class there.
+     */
+    public const HOOK_APPLY = 'wpmgr_agent_self_update_apply';
+
+    /**
+     * wp-option holding the single staged self-update record written by beat 1
+     * (ARM). Non-autoloaded: read only by the apply cron. Shape:
+     *   ['from_version'=>string,'to_version'=>string,'staged_at'=>int,
+     *    'expires_at'=>int,'token'=>string]
+     */
+    public const OPTION_STAGED = 'wpmgr_agent_self_update_staged';
+
+    /**
+     * Seconds a staged record stays claimable. Beat 2 discards (never retries)
+     * an expired record: a site whose loopback cron is broken simply never
+     * reaches beat 2, which is safe because ARM moved nothing on disk.
+     *
+     * COUPLED TO THE CONTROL PLANE'S CONFIRM DEADLINE. Read this before
+     * changing either number.
+     *
+     * The CP waits for beat 3 (the new build phoning home) for a bounded
+     * window that depends on the cron_mode this agent reported in beat 1:
+     *
+     *   cron_mode "loopback" : 20 minutes  (agentConfirmDeadline)
+     *   cron_mode "external" : 90 minutes  (agentConfirmDeadlineExternalCron)
+     *
+     * Both live in apps/api/internal/update/agent_worker.go. The stage MUST
+     * outlive the CP's LONGEST patience, otherwise a site whose system cron
+     * runs hourly expires its own staged record before the cron tick that
+     * would have applied it, and the CP records a confirm timeout for a build
+     * that was never given a chance to install. On a fleet that is not an edge
+     * case, it is a coin flip, and it halts canary rollouts for no reason.
+     *
+     * 7200s (2 hours) sits 30 minutes clear of the 90-minute external-cron
+     * deadline. If the CP window is ever raised, raise this FIRST and keep the
+     * headroom. This value must never fall below agentConfirmDeadlineExternalCron.
+     */
+    public const STAGED_TTL_SECONDS = 7200;
+
+    /**
      * Clock-skew grace for the exp field (seconds). The agent rejects a manifest
      * whose exp is in the past, but allows up to this many seconds of clock drift
      * between the CP and the agent host. We apply NO grace on the exp upper bound
@@ -130,6 +181,24 @@ final class UpdateChecker
     private Keystore $keystore;
 
     private ReplayCache $replayCache;
+
+    /**
+     * Why the most recent fetchManifest()/verifyManifest() pair returned null.
+     *
+     * fetchManifest() collapses "the CP published nothing" and "the manifest
+     * failed verification" into the same null return, which is exactly the
+     * right shape for the transient-injection path but not for beat 1 of the
+     * self-update protocol: the control plane has to be able to tell
+     * "up_to_date" (benign, nothing to do) apart from "error" (worth surfacing).
+     * Every terminal path of the two methods tags itself here so
+     * stageSelfUpdate() can classify a null without re-running any check.
+     *
+     * Values: '' (never run), 'ok', 'no_update' (HTTP 204), 'up_to_date'
+     * (signed manifest verified but not newer than on-disk), 'unavailable'
+     * (transport/config), 'invalid' (unparseable body), 'rejected' (any other
+     * verification-chain failure).
+     */
+    private string $lastManifestOutcome = '';
 
     // -------------------------------------------------------------------------
     // Constructor
@@ -205,6 +274,10 @@ final class UpdateChecker
      */
     public function fetchManifest(): ?array
     {
+        // Default tag for every transport/config bail-out below; the parse and
+        // verification steps overwrite it with a more specific value.
+        $this->lastManifestOutcome = 'unavailable';
+
         $base = $this->settings->controlPlaneUrl();
         if ($base === '') {
             return null;
@@ -248,6 +321,7 @@ final class UpdateChecker
 
         if ($status === 204) {
             // No update published — this is normal, not an error.
+            $this->lastManifestOutcome = 'no_update';
             return null;
         }
 
@@ -266,12 +340,14 @@ final class UpdateChecker
 
         if ($rawBody === '') {
             error_log('wpmgr-agent: UpdateChecker manifest response body is empty.');
+            $this->lastManifestOutcome = 'invalid';
             return null;
         }
 
         $envelope = json_decode($rawBody, true);
         if (!is_array($envelope)) {
             error_log('wpmgr-agent: UpdateChecker manifest response is not valid JSON.');
+            $this->lastManifestOutcome = 'invalid';
             return null;
         }
 
@@ -298,6 +374,11 @@ final class UpdateChecker
      */
     public function verifyManifest(array $envelope): ?array
     {
+        // Default tag for every rejection below; step 8 narrows the benign
+        // "verified but not newer" case to 'up_to_date' and the success path
+        // tags 'ok'. See $lastManifestOutcome for why this distinction exists.
+        $this->lastManifestOutcome = 'rejected';
+
         // ---- Step 1: base64url-decode manifest + signature ------------------
         $manifestB64 = isset($envelope['manifest']) && is_string($envelope['manifest'])
             ? $envelope['manifest']
@@ -481,6 +562,10 @@ final class UpdateChecker
                 $claimedVersion,
                 $onDisk
             ));
+            // A correctly signed manifest that simply is not newer is the
+            // steady state, not a failure. Tag it so beat 1 can answer
+            // "up_to_date" instead of "error".
+            $this->lastManifestOutcome = 'up_to_date';
             return null;
         }
         // min_version is mandatory (the CP always sets at least 0.0.0). An empty
@@ -551,6 +636,8 @@ final class UpdateChecker
         // All checks passed. Return the full verified claims.
         // Note: package_url IS included here so verifyDownload can use it.
         // injectUpdate() strips it before caching.
+        $this->lastManifestOutcome = 'ok';
+
         /** @var array<string,mixed> $claims */
         return $claims;
     }
@@ -609,8 +696,16 @@ final class UpdateChecker
 
         $onDisk = $this->onDiskVersion();
 
+        // Normalize BOTH sides, exactly as the verifyManifest() downgrade guard
+        // does. This comparison used to be made on the raw strings, which meant
+        // the two gates could disagree: PHP version_compare() reads
+        // '0.10.5-cron-selfheal' as a PRE-RELEASE of (lower than) '0.10.5', so a
+        // manifest 'version: 0.10.5' was refused by verifyManifest() but still
+        // offered here whenever a cached claims array reached injectUpdate(),
+        // surfacing a dashboard update entry for a build that the security chain
+        // would then refuse to install. One normalization rule, both gates.
         if (is_array($claims) && isset($claims['version']) && is_string($claims['version'])
-            && version_compare($claims['version'], $onDisk, '>')
+            && version_compare($this->normalizeVersion($claims['version']), $this->normalizeVersion($onDisk), '>')
         ) {
             // Inject the update entry. Package is the SENTINEL (not a presigned
             // URL): the real URL is fetched fresh inside verifyDownload().
@@ -991,6 +1086,438 @@ final class UpdateChecker
         if (function_exists('delete_site_transient')) {
             delete_site_transient(self::TRANSIENT_MANIFEST);
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // Three-beat CP-commanded self-update
+    //
+    // A normal update command cannot be used on the agent's own directory: the
+    // plugin would overwrite its own files while its code is the code doing the
+    // overwriting, inside the request that has to report the outcome. If that
+    // request dies partway there is no working code left to report it, and the
+    // snapshot + automatic rollback that protects every other plugin update
+    // deliberately does NOT arm for the agent's own directory (whatever performs
+    // the rollback is what is being replaced). Recovery would need per-site
+    // filesystem access; across a fleet that is unrecoverable.
+    //
+    // So the CP-commanded path is split into three beats, each in its own
+    // request:
+    //   1. ARM    (stageSelfUpdate, inside the signed command request):
+    //             verify only. Nothing on disk moves.
+    //   2. APPLY  (applyStagedSelfUpdate, the cron request): a SEPARATE
+    //             WordPress bootstrap runs Plugin_Upgrader::upgrade(). No CP
+    //             response rides on this request, so a mid-copy death is not a
+    //             lost answer.
+    //   3. CONFIRM: the only trustworthy success signal is the NEW code
+    //             phoning home: the version-changed boot metadata push in
+    //             Plugin. A "scheduled" acknowledgement is NEVER success.
+    // -------------------------------------------------------------------------
+
+    /**
+     * BEAT 1 (ARM). Verify that a newer agent build is on offer and, if so,
+     * stage it for the apply cron. NOTHING on disk is moved, unpacked or
+     * overwritten here; the only writes are the staged wp-option record and
+     * the manifest site-transient.
+     *
+     * Runs the FULL existing verification chain by way of fetchManifest():
+     * Ed25519 signature, cmd/slug/aud binding, iat/exp window, jti replay,
+     * monotonic-iat anti-rollback, downgrade guard, https + exact-host
+     * allowlist and package size cap. Nothing new is trusted here that the
+     * one-click path does not already trust.
+     *
+     * @return array{status:string,ok:bool,from_version:string,to_version:string,detail:string,cron_mode:string,expires_at:int}
+     */
+    public function stageSelfUpdate(): array
+    {
+        $onDisk = $this->onDiskVersion();
+
+        // The wp.org distribution build ships without this file at all, so in
+        // practice the command shell answers not_eligible long before we get
+        // here. Kept as a belt-and-braces guard for a hand-assembled tree that
+        // defines the constant but still carries the source file.
+        if (defined('WPMGR_WPORG_BUILD') && constant('WPMGR_WPORG_BUILD')) {
+            return $this->stageAnswer('not_eligible', $onDisk, '', 'Self-update is not part of this distribution build.');
+        }
+
+        if (!$this->settings->isEnrolled()) {
+            return $this->stageAnswer('not_eligible', $onDisk, '', 'Site is not enrolled.');
+        }
+
+        if (!function_exists('update_option') || !function_exists('wp_schedule_single_event')) {
+            return $this->stageAnswer('not_eligible', $onDisk, '', 'WordPress option or cron API unavailable.');
+        }
+
+        // An unexpired record is already staged: never stage twice, and never
+        // re-schedule. The existing event owns this window.
+        $existing = $this->readStagedRecord();
+        if ($existing !== null && time() <= (int) $existing['expires_at']) {
+            $answer = $this->stageAnswer(
+                'already_scheduled',
+                (string) $existing['from_version'],
+                (string) $existing['to_version'],
+                'A self-update is already staged for this site.'
+            );
+            $answer['expires_at'] = (int) $existing['expires_at'];
+
+            return $answer;
+        }
+
+        $claims = $this->fetchManifest();
+        if (!is_array($claims)) {
+            if ($this->lastManifestOutcome === 'no_update' || $this->lastManifestOutcome === 'up_to_date') {
+                return $this->stageAnswer('up_to_date', $onDisk, '', 'No newer agent build is published for this site.');
+            }
+
+            // Deliberately reports only the coarse outcome tag. The manifest
+            // body carries a short-lived presigned package_url; nothing derived
+            // from it may reach a CP-visible string.
+            return $this->stageAnswer(
+                'error',
+                $onDisk,
+                '',
+                'Update manifest could not be fetched or verified (' . $this->lastManifestOutcome . ').'
+            );
+        }
+
+        $toVersion = isset($claims['version']) && is_string($claims['version']) ? $claims['version'] : '';
+        if ($toVersion === '') {
+            return $this->stageAnswer('error', $onDisk, '', 'Verified manifest carries no version.');
+        }
+
+        // Cache the verified claims (package_url stripped, since it is a bearer
+        // credential) so beat 2's injectUpdate() offers this exact build to
+        // Plugin_Upgrader without another CP round trip. Identical shape to the
+        // caching injectUpdate() already performs.
+        $toCache = $claims;
+        unset($toCache['package_url']);
+        if (function_exists('set_site_transient') && defined('HOUR_IN_SECONDS')) {
+            set_site_transient(self::TRANSIENT_MANIFEST, $toCache, 12 * HOUR_IN_SECONDS);
+        }
+
+        $now    = time();
+        $token  = bin2hex(random_bytes(16));
+        $record = [
+            'from_version' => $onDisk,
+            'to_version'   => $toVersion,
+            'staged_at'    => $now,
+            'expires_at'   => $now + self::STAGED_TTL_SECONDS,
+            'token'        => $token,
+        ];
+        update_option(self::OPTION_STAGED, $record, false);
+
+        // Drop any previous outcome so a stale 'failed' from an earlier run can
+        // never be read back as the result of THIS one.
+        if (function_exists('delete_option')) {
+            delete_option(AgentSelfUpdateCommand::OPTION_RESULT);
+        }
+
+        // The token rides in the event args for two reasons: it makes each
+        // stage a distinct event (WP silently drops a duplicate single event
+        // scheduled within 10 minutes of an identical one), and it lets beat 2
+        // ignore a stale event left over from an earlier stage.
+        wp_schedule_single_event($now, self::HOOK_APPLY, [$token]);
+
+        if (function_exists('spawn_cron')) {
+            @spawn_cron(); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- spawn_cron may emit a harmless notice when DISABLE_WP_CRON is set; @-suppressed intentionally
+        }
+
+        $answer = $this->stageAnswer('scheduled', $onDisk, $toVersion, 'Self-update staged; apply runs in a separate request.');
+        $answer['expires_at'] = $record['expires_at'];
+
+        return $answer;
+    }
+
+    /**
+     * BEAT 2 (APPLY). Runs in the wp-cron request, a SEPARATE WordPress
+     * bootstrap from the one that answered the CP. No CP response rides on this
+     * request, so a death mid-copy is not a lost answer.
+     *
+     * Single-shot by construction: the staged record is CLAIMED (deleted)
+     * before any upgrade work begins, so a request that dies partway can never
+     * be retried by a later cron tick. An expired record is discarded, not
+     * retried. Nothing here schedules a follow-up event.
+     *
+     * Reuses the existing upgrader_pre_download / upgrader_source_selection
+     * chain unchanged; there is zero new download, verification or unzip code
+     * on this path.
+     *
+     * @param string $token Stage token carried in the cron event args.
+     * @return void
+     */
+    public function applyStagedSelfUpdate(string $token = ''): void
+    {
+        if (defined('WPMGR_WPORG_BUILD') && constant('WPMGR_WPORG_BUILD')) {
+            return;
+        }
+        if (!function_exists('get_option') || !function_exists('delete_option')) {
+            return;
+        }
+
+        $record = $this->readStagedRecord();
+        if ($record === null) {
+            // Nothing staged (or already claimed by an earlier tick). Silent
+            // no-op; this is the normal state on every site.
+            return;
+        }
+
+        $recordToken = (string) $record['token'];
+        if ($token !== '' && $recordToken !== '' && !hash_equals($recordToken, $token)) {
+            // A stale duplicate event from an earlier stage. Leave the current
+            // record alone so its own event can still claim it.
+            return;
+        }
+
+        // CLAIM. Everything below runs at most once per staged record.
+        delete_option(self::OPTION_STAGED);
+
+        $from      = (string) $record['from_version'];
+        $to        = (string) $record['to_version'];
+        $expiresAt = (int) $record['expires_at'];
+
+        if ($expiresAt > 0 && time() > $expiresAt) {
+            $this->recordSelfUpdateResult('expired', $from, $to, 'Staged self-update expired before the apply request ran.');
+            return;
+        }
+
+        $onDisk = $this->onDiskVersion();
+        if (!version_compare($this->normalizeVersion($to), $this->normalizeVersion($onDisk), '>')) {
+            // Already at (or past) the target: a second event for a build that
+            // landed some other way. Discard rather than reinstall.
+            $this->recordSelfUpdateResult('already_applied', $from, $to, 'On-disk version already at or past the staged target.');
+            return;
+        }
+
+        $this->runUpgrade($from, $to);
+    }
+
+    /**
+     * The Plugin_Upgrader half of beat 2, split out so applyStagedSelfUpdate()
+     * reads as the claim/discard state machine it is.
+     *
+     * Mirrors UpdateRunner's plugin branch: it captures active state BEFORE the
+     * upgrade (Plugin_Upgrader::upgrade() silently deactivates and never
+     * re-activates) and clears maintenance mode on EVERY terminal path, so a
+     * failed apply leaves a working, active site rather than a deactivated
+     * agent behind a maintenance page.
+     *
+     * @param string $from On-disk version at stage time.
+     * @param string $to   Verified target version.
+     * @return void
+     */
+    private function runUpgrade(string $from, string $to): void
+    {
+        if (!defined('ABSPATH')) {
+            $this->recordSelfUpdateResult('failed', $from, $to, 'ABSPATH is not defined; upgrader unavailable.');
+            return;
+        }
+
+        $adminDir = (string) constant('ABSPATH') . 'wp-admin/includes/';
+        foreach (['file.php', 'misc.php', 'plugin.php', 'class-wp-upgrader.php'] as $adminInclude) {
+            if (is_file($adminDir . $adminInclude)) {
+                require_once $adminDir . $adminInclude;
+            }
+        }
+
+        if (!class_exists('\Plugin_Upgrader') || !class_exists('\Automatic_Upgrader_Skin')) {
+            $this->recordSelfUpdateResult('failed', $from, $to, 'Upgrader API unavailable.');
+            return;
+        }
+
+        $wasActive        = function_exists('is_plugin_active')             ? \is_plugin_active(self::PLUGIN_KEY) : false;
+        $wasNetworkActive = function_exists('is_plugin_active_for_network') ? \is_plugin_active_for_network(self::PLUGIN_KEY) : false;
+
+        // Force WordPress to rebuild the plugin-update transient so the
+        // site_transient_update_plugins filter (injectUpdate) offers the build
+        // stage() just verified. Plugin_Upgrader::upgrade() reads that transient
+        // to find the package.
+        if (function_exists('delete_site_transient')) {
+            delete_site_transient('update_plugins');
+        }
+
+        $upgrader = new \Plugin_Upgrader(new \Automatic_Upgrader_Skin());
+        $result   = null;
+        $thrown   = '';
+
+        try {
+            $result = $upgrader->upgrade(self::PLUGIN_KEY);
+        } catch (\Throwable $e) {
+            $thrown = $e->getMessage();
+        } finally {
+            // GUARANTEE: maintenance mode is cleared on every terminal path of
+            // this upgrade, whether it succeeded, returned a WP_Error, or threw.
+            Maintenance::clear($upgrader);
+        }
+
+        if ($thrown !== '') {
+            $this->recordSelfUpdateResult('failed', $from, $to, 'Upgrader threw: ' . $thrown);
+            $this->restoreActiveState($wasActive, $wasNetworkActive);
+            return;
+        }
+
+        if (is_object($result) && method_exists($result, 'get_error_message')) {
+            $code    = method_exists($result, 'get_error_code') ? (string) $result->get_error_code() : '';
+            $message = (string) $result->get_error_message();
+            $this->recordSelfUpdateResult(
+                'failed',
+                $from,
+                $to,
+                'WP_Error' . ($code !== '' ? ' (' . $code . ')' : '') . ': ' . $message
+            );
+            $this->restoreActiveState($wasActive, $wasNetworkActive);
+            return;
+        }
+
+        if ($result === false || $result === null) {
+            $this->recordSelfUpdateResult('failed', $from, $to, 'Upgrader reported no result.');
+            $this->restoreActiveState($wasActive, $wasNetworkActive);
+            return;
+        }
+
+        // The new files are on disk, but THIS request is still running the old
+        // code, so it is in no position to declare success to anyone. It records
+        // a local outcome and stops. Beat 3, the version-changed boot metadata
+        // push from the NEW code, is the only success signal the CP trusts.
+        $this->restoreActiveState($wasActive, $wasNetworkActive);
+        $this->flushCache();
+        if (function_exists('delete_site_transient')) {
+            delete_site_transient('update_plugins');
+        }
+        $this->recordSelfUpdateResult('applied', $from, $to, '');
+    }
+
+    /**
+     * Re-activate the agent when Plugin_Upgrader::upgrade() left it deactivated.
+     *
+     * WordPress's upgrader registers an upgrader_pre_install hook that calls
+     * deactivate_plugins($plugin, silent=true) and does NOT re-activate
+     * afterwards. For any other plugin that is merely untidy; for the agent it
+     * would sever the control-plane connection, so restoring the pre-upgrade
+     * state is part of "leave the site working".
+     *
+     * @param bool $wasActive        Site-level active state before the upgrade.
+     * @param bool $wasNetworkActive Network active state before the upgrade.
+     * @return void
+     */
+    private function restoreActiveState(bool $wasActive, bool $wasNetworkActive): void
+    {
+        if (!$wasActive && !$wasNetworkActive) {
+            return;
+        }
+        if (!function_exists('activate_plugin')) {
+            return;
+        }
+
+        // Refresh the plugin cache first: the upgrade may have rewritten the
+        // main plugin file, so the cached header data is stale.
+        if (function_exists('wp_clean_plugins_cache')) {
+            \wp_clean_plugins_cache(true);
+        }
+
+        try {
+            $activated = \activate_plugin(self::PLUGIN_KEY, '', $wasNetworkActive, true);
+            if (function_exists('is_wp_error') && \is_wp_error($activated)) {
+                error_log('wpmgr-agent: UpdateChecker post-apply reactivation failed.');
+            }
+        } catch (\Throwable $e) {
+            error_log('wpmgr-agent: UpdateChecker post-apply reactivation threw: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Read and shape-validate the staged record. Returns null when absent or
+     * malformed (a malformed record is treated as "nothing staged").
+     *
+     * Does NOT apply the expiry; callers decide what an expired record means
+     * (beat 1 re-stages over it, beat 2 discards it and records the reason).
+     *
+     * @return array{from_version:string,to_version:string,staged_at:int,expires_at:int,token:string}|null
+     */
+    private function readStagedRecord(): ?array
+    {
+        if (!function_exists('get_option')) {
+            return null;
+        }
+
+        $stored = get_option(self::OPTION_STAGED, null);
+        if (!is_array($stored)) {
+            return null;
+        }
+
+        $to = isset($stored['to_version']) && is_string($stored['to_version']) ? $stored['to_version'] : '';
+        if ($to === '') {
+            return null;
+        }
+
+        return [
+            'from_version' => isset($stored['from_version']) && is_string($stored['from_version']) ? $stored['from_version'] : '',
+            'to_version'   => $to,
+            'staged_at'    => isset($stored['staged_at']) && is_numeric($stored['staged_at']) ? (int) $stored['staged_at'] : 0,
+            'expires_at'   => isset($stored['expires_at']) && is_numeric($stored['expires_at']) ? (int) $stored['expires_at'] : 0,
+            'token'        => isset($stored['token']) && is_string($stored['token']) ? $stored['token'] : '',
+        ];
+    }
+
+    /**
+     * Persist the apply outcome so the next metadata push carries it to the CP.
+     *
+     * The stored detail is scrubbed of anything URL-shaped: upgrader and skin
+     * messages can echo a package string back, and the manifest's package_url
+     * is a short-lived bearer credential that must never reach a CP-visible
+     * field or a log line.
+     *
+     * @param string $status One of applied|failed|expired|already_applied.
+     * @param string $from   On-disk version at stage time.
+     * @param string $to     Staged target version.
+     * @param string $detail Human-readable, non-secret detail (may be empty).
+     * @return void
+     */
+    private function recordSelfUpdateResult(string $status, string $from, string $to, string $detail): void
+    {
+        if (!function_exists('update_option')) {
+            return;
+        }
+
+        $scrubbed = (string) preg_replace('#https?://\S+#i', '[url]', $detail);
+        if (strlen($scrubbed) > 500) {
+            $scrubbed = substr($scrubbed, 0, 500);
+        }
+
+        update_option(
+            AgentSelfUpdateCommand::OPTION_RESULT,
+            [
+                'status'       => $status,
+                'from_version' => $from,
+                'to_version'   => $to,
+                'detail'       => $scrubbed,
+                'at'           => time(),
+            ],
+            false
+        );
+    }
+
+    /**
+     * Build a beat-1 answer in the single shape the control plane parses.
+     *
+     * @param string $status One of not_eligible|up_to_date|scheduled|already_scheduled|error.
+     * @param string $from   On-disk version.
+     * @param string $to     Target version ('' when there is none).
+     * @param string $detail Human-readable, non-secret detail.
+     * @return array{status:string,ok:bool,from_version:string,to_version:string,detail:string,cron_mode:string,expires_at:int}
+     */
+    private function stageAnswer(string $status, string $from, string $to, string $detail): array
+    {
+        return [
+            'status'       => $status,
+            // 'scheduled' is an ACKNOWLEDGEMENT, never a success: the update has
+            // not been applied and may never be. The CP treats it as unconfirmed
+            // until the new code phones home (beat 3).
+            'ok'           => $status !== 'error',
+            'from_version' => $from,
+            'to_version'   => $to,
+            'detail'       => $detail,
+            'cron_mode'    => (defined('DISABLE_WP_CRON') && constant('DISABLE_WP_CRON')) ? 'external' : 'loopback',
+            'expires_at'   => 0,
+        ];
     }
 
     // -------------------------------------------------------------------------

--- a/apps/agent/tests/AgentSelfUpdateTest.php
+++ b/apps/agent/tests/AgentSelfUpdateTest.php
@@ -1,0 +1,695 @@
+<?php
+/**
+ * Tests for the CP-commanded three-beat agent self-update.
+ *
+ * BEAT 1 (ARM) is UpdateChecker::stageSelfUpdate(), reached through the thin
+ * AgentSelfUpdateCommand shell. BEAT 2 (APPLY) is
+ * UpdateChecker::applyStagedSelfUpdate(), which runs in a separate WordPress
+ * bootstrap. BEAT 3 (CONFIRM) lives in Plugin and is covered by
+ * PluginVersionChangedPushTest.
+ *
+ * The fixture mirrors UpdateCheckerTest: a real per-test Ed25519 keypair so the
+ * signature chain is exercised authentically, Brain Monkey for the WordPress
+ * function surface, and a configurable ReplayCache double.
+ *
+ * The load-bearing assertion of the "scheduled" case is that ARM touches
+ * NOTHING on disk. It is asserted structurally (a hashed snapshot of a fixture
+ * tree taken before and after the call) rather than by trusting the return
+ * value.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Commands\AgentSelfUpdateCommand;
+use WPMgr\Agent\Keystore;
+use WPMgr\Agent\ReplayCache;
+use WPMgr\Agent\Settings;
+use WPMgr\Agent\Signer;
+use WPMgr\Agent\Support\UpdateChecker;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\UpdateChecker
+ * @covers \WPMgr\Agent\Commands\AgentSelfUpdateCommand
+ */
+final class AgentSelfUpdateTest extends TestCase
+{
+    /** Raw 64-byte CP Ed25519 secret key (for signing manifests). */
+    private string $cpSecret;
+
+    /** Raw 32-byte CP Ed25519 public key (stored in Keystore). */
+    private string $cpPublic;
+
+    /** The enrolled site_id for this test run. */
+    private string $siteId = 'test-site-uuid-selfupdate';
+
+    /** On-disk plugin version (simulates the current installed version). */
+    private string $onDiskVersion = '0.10.5';
+
+    /**
+     * The version the CP offers: always one numeric segment above the on-disk
+     * core, so the fixture stays valid whatever WPMGR_AGENT_VERSION another
+     * test file in this process pinned first. Derived from the NORMALIZED core
+     * because a dev suffix never participates in the comparison.
+     */
+    private string $targetVersion = '';
+
+    private Keystore $keystore;
+    private Settings $settings;
+    private Signer $signer;
+
+    /** @var array<string,mixed> wp-option store. */
+    private array $options = [];
+
+    /** @var array<string,mixed> site_transient store. */
+    private array $siteTransients = [];
+
+    /** @var list<array{hook:string,args:array<int,mixed>,timestamp:int}> */
+    private array $scheduledEvents = [];
+
+    /** @var list<string> Every URL handed to wp_remote_get during a test. */
+    private array $httpCalls = [];
+
+    /** Temporary key file for the Keystore master key. */
+    private string $keyFile = '';
+
+    /** Fixture tree standing in for the on-disk plugin directory. */
+    private string $diskFixture = '';
+
+    /** Fake ReplayCache instance. */
+    private object $replayCache;
+
+    /** Set true to make the site look un-enrolled. */
+    public bool $forceUnenrolled = false;
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->keyFile = sys_get_temp_dir() . '/wpmgr-asu-test-' . bin2hex(random_bytes(8)) . '.key';
+        if (!defined('WPMGR_AGENT_KEY_FILE')) {
+            define('WPMGR_AGENT_KEY_FILE', $this->keyFile);
+        }
+        file_put_contents($this->keyFile, random_bytes(32));
+
+        $cpKeypair      = sodium_crypto_sign_keypair();
+        $this->cpSecret = sodium_crypto_sign_secretkey($cpKeypair);
+        $this->cpPublic = sodium_crypto_sign_publickey($cpKeypair);
+
+        $this->options         = [];
+        $this->siteTransients  = [];
+        $this->scheduledEvents = [];
+        $this->httpCalls       = [];
+        $this->forceUnenrolled = false;
+
+        Functions\when('get_option')->alias(function (string $name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('update_option')->alias(function (string $name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('delete_option')->alias(function (string $name) {
+            unset($this->options[$name]);
+            return true;
+        });
+        // NOTE: get_site_transient is deliberately NOT stubbed. Brain Monkey
+        // defines a stubbed function process-wide for the remainder of the
+        // PHPUnit run, and this file sorts FIRST in the suite, so stubbing a
+        // function nothing on these code paths calls would flip
+        // function_exists() to true inside unrelated, later tests that
+        // legitimately rely on it being absent. Only stub what beat 1 and
+        // beat 2 actually reach.
+        Functions\when('set_site_transient')->alias(function (string $key, $value, int $ttl = 0) {
+            $this->siteTransients[$key] = $value;
+            return true;
+        });
+        Functions\when('delete_site_transient')->alias(function (string $key) {
+            unset($this->siteTransients[$key]);
+            return true;
+        });
+        Functions\when('wp_parse_url')->alias(fn (string $url) => parse_url($url));
+        Functions\when('get_plugin_data')->alias(fn () => ['Version' => $this->onDiskVersion]);
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('spawn_cron')->justReturn(true);
+
+        Functions\when('wp_schedule_single_event')->alias(
+            function (int $timestamp, string $hook, array $args = []) {
+                $this->scheduledEvents[] = ['hook' => $hook, 'args' => $args, 'timestamp' => $timestamp];
+                return true;
+            }
+        );
+
+        // PHP constants are process-global and cannot be undefined, so another
+        // file in this (non-isolated) suite may already have pinned the agent
+        // version. Adopt whatever won rather than asserting against a literal,
+        // and keep the get_plugin_data() stub in agreement with it so
+        // onDiskVersion() answers the same value down either of its two paths.
+        //
+        // WPMGR_AGENT_FILE is deliberately NOT defined here: this file sorts
+        // FIRST in the suite, and pinning that constant would change what later
+        // tests (which guard-define it to their own __FILE__) observe.
+        if (!defined('WPMGR_AGENT_VERSION')) {
+            define('WPMGR_AGENT_VERSION', $this->onDiskVersion);
+        }
+        $this->onDiskVersion = (string) constant('WPMGR_AGENT_VERSION');
+        $this->targetVersion = (string) preg_replace('/[-+].*$/', '', $this->onDiskVersion) . '.1';
+        if (!defined('HOUR_IN_SECONDS')) {
+            define('HOUR_IN_SECONDS', 3600);
+        }
+
+        $this->keystore = new Keystore();
+        $this->keystore->storeControlPlanePublicKey($this->cpPublic);
+
+        Functions\when('get_site_option')->alias(function (string $key, $default = null) {
+            if ($this->forceUnenrolled) {
+                return $default === null ? false : $default;
+            }
+            if ($key === Settings::OPTION_SITE_ID) {
+                return $this->siteId;
+            }
+            if ($key === Settings::OPTION_CP_URL) {
+                return 'https://cp.example.com';
+            }
+            return $default === null ? false : $default;
+        });
+
+        $this->settings = new Settings();
+        $this->keystore->generateSiteKeypair();
+        $this->signer = new Signer($this->keystore);
+
+        $self = $this;
+        $this->replayCache = new class($self) extends ReplayCache {
+            private AgentSelfUpdateTest $test;
+            public function __construct(AgentSelfUpdateTest $test)
+            {
+                $this->test = $test;
+            }
+            public function seen(string $jti, ?int $now = null): bool
+            {
+                return false;
+            }
+            public function mark(string $jti, int $ttlSeconds, ?int $now = null): bool
+            {
+                return true;
+            }
+        };
+
+        // A small tree standing in for the on-disk plugin directory, so the
+        // "ARM touches nothing on disk" assertion is structural.
+        $this->diskFixture = sys_get_temp_dir() . '/wpmgr-asu-disk-' . bin2hex(random_bytes(6));
+        mkdir($this->diskFixture . '/includes', 0755, true);
+        file_put_contents($this->diskFixture . '/wpmgr-agent.php', "<?php // v{$this->onDiskVersion}\n");
+        file_put_contents($this->diskFixture . '/includes/class-plugin.php', "<?php // plugin\n");
+    }
+
+    protected function tear_down(): void
+    {
+        if ($this->keyFile !== '' && is_file($this->keyFile)) {
+            @unlink($this->keyFile); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        }
+        $this->rrmdir($this->diskFixture);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Recursive delete used only for test fixture cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if ($dir === '' || !is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+
+    /**
+     * Content-addressed snapshot of the fixture tree: relative path -> sha256.
+     *
+     * @return array<string,string>
+     */
+    private function snapshotDisk(): array
+    {
+        $out      = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->diskFixture, \FilesystemIterator::SKIP_DOTS)
+        );
+        /** @var \SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+            $rel       = substr($file->getPathname(), strlen($this->diskFixture) + 1);
+            $out[$rel] = (string) hash_file('sha256', $file->getPathname());
+        }
+        ksort($out);
+
+        return $out;
+    }
+
+    /**
+     * Build a valid manifest claims array with safe defaults.
+     *
+     * @param array<string,mixed> $overrides Fields to override.
+     * @return array<string,mixed>
+     */
+    private function makeClaims(array $overrides = []): array
+    {
+        $now = time();
+
+        return array_merge([
+            'aud'            => $this->siteId,
+            'cmd'            => 'update_manifest',
+            'slug'           => 'wpmgr-agent',
+            'version'        => $this->targetVersion,
+            'min_version'    => '0.0.0',
+            'package_url'    => 'https://storage.googleapis.com/wpmgr-chunks-prod/agent-releases/0.11.0/wpmgr-agent.zip?sig=xxx',
+            'package_sha256' => str_repeat('ab', 32),
+            'package_size'   => 359578,
+            'requires'       => '6.0',
+            'requires_php'   => '8.1',
+            'tested'         => '6.8',
+            'iat'            => $now,
+            'exp'            => $now + 300,
+            'jti'            => bin2hex(random_bytes(16)),
+        ], $overrides);
+    }
+
+    /**
+     * Sign a claims array and return the wire envelope.
+     *
+     * @param array<string,mixed> $claims Claims to sign.
+     * @return array{manifest:string, signature:string}
+     */
+    private function signClaims(array $claims): array
+    {
+        $payloadRaw = (string) json_encode($claims);
+        $sigRaw     = sodium_crypto_sign_detached($payloadRaw, $this->cpSecret);
+
+        return [
+            'manifest'  => $this->b64url($payloadRaw),
+            'signature' => $this->b64url($sigRaw),
+        ];
+    }
+
+    /** URL-safe base64 no-padding encode. */
+    private function b64url(string $bytes): string
+    {
+        return rtrim(strtr(base64_encode($bytes), '+/', '-_'), '=');
+    }
+
+    /**
+     * Stub the CP manifest endpoint with the given HTTP status and body.
+     *
+     * @param int    $status HTTP status the manifest endpoint returns.
+     * @param string $body   Response body.
+     * @return void
+     */
+    private function stubManifestEndpoint(int $status, string $body): void
+    {
+        Functions\when('wp_remote_get')->alias(function (string $url, array $args = []) use ($status, $body) {
+            $this->httpCalls[] = $url;
+            return ['response' => ['code' => $status], 'body' => $body, 'filename' => ''];
+        });
+        Functions\when('wp_remote_retrieve_response_code')->alias(
+            fn ($response) => $response['response']['code'] ?? 0
+        );
+        Functions\when('wp_remote_retrieve_body')->alias(fn ($response) => $response['body'] ?? '');
+    }
+
+    private function makeChecker(): UpdateChecker
+    {
+        return new UpdateChecker($this->signer, $this->settings, $this->keystore, $this->replayCache);
+    }
+
+    // =========================================================================
+    // BEAT 1 (ARM)
+    // =========================================================================
+
+    /**
+     * A signed manifest offering a newer build stages a record, schedules the
+     * apply cron, and moves NOTHING on disk. The disk snapshot is the load-
+     * bearing assertion here: "scheduled" must mean "nothing has happened yet".
+     */
+    public function test_stage_schedules_the_apply_cron_and_touches_nothing_on_disk(): void
+    {
+        $claims = $this->makeClaims(['version' => $this->targetVersion]);
+        $this->stubManifestEndpoint(200, (string) json_encode($this->signClaims($claims)));
+
+        $before = $this->snapshotDisk();
+        $answer = $this->makeChecker()->stageSelfUpdate();
+        $after  = $this->snapshotDisk();
+
+        $this->assertSame('scheduled', $answer['status']);
+        $this->assertTrue($answer['ok']);
+        $this->assertSame($this->onDiskVersion, $answer['from_version']);
+        $this->assertSame($this->targetVersion, $answer['to_version']);
+        $this->assertSame('loopback', $answer['cron_mode']);
+        $this->assertGreaterThan(time(), $answer['expires_at']);
+
+        $this->assertSame($before, $after, 'ARM must not create, delete or modify a single byte on disk');
+
+        $staged = $this->options[UpdateChecker::OPTION_STAGED] ?? null;
+        $this->assertIsArray($staged, 'ARM must persist exactly one staged record');
+        $this->assertSame($this->targetVersion, $staged['to_version']);
+        $this->assertSame($this->onDiskVersion, $staged['from_version']);
+        $this->assertNotSame('', (string) $staged['token']);
+
+        $this->assertCount(1, $this->scheduledEvents, 'ARM must schedule exactly one apply event');
+        $this->assertSame(UpdateChecker::HOOK_APPLY, $this->scheduledEvents[0]['hook']);
+        $this->assertSame([$staged['token']], $this->scheduledEvents[0]['args'], 'the event must carry the stage token');
+
+        $this->assertCount(1, $this->httpCalls, 'ARM must make exactly one CP call (the manifest fetch) and no package download');
+    }
+
+    /**
+     * The CP publishing nothing (HTTP 204) is the steady state, not an error.
+     */
+    public function test_stage_returns_up_to_date_when_the_cp_publishes_nothing(): void
+    {
+        $this->stubManifestEndpoint(204, '');
+
+        $answer = $this->makeChecker()->stageSelfUpdate();
+
+        $this->assertSame('up_to_date', $answer['status']);
+        $this->assertTrue($answer['ok']);
+        $this->assertSame('', $answer['to_version']);
+        $this->assertArrayNotHasKey(UpdateChecker::OPTION_STAGED, $this->options);
+        $this->assertSame([], $this->scheduledEvents);
+    }
+
+    /**
+     * A correctly signed manifest that is not NEWER than the on-disk build is
+     * also up_to_date, not an error: the existing downgrade guard rejects it
+     * and beat 1 must classify that rejection as benign.
+     */
+    public function test_stage_returns_up_to_date_when_the_published_build_is_not_newer(): void
+    {
+        $claims = $this->makeClaims(['version' => $this->onDiskVersion]);
+        $this->stubManifestEndpoint(200, (string) json_encode($this->signClaims($claims)));
+
+        $answer = $this->makeChecker()->stageSelfUpdate();
+
+        $this->assertSame('up_to_date', $answer['status']);
+        $this->assertArrayNotHasKey(UpdateChecker::OPTION_STAGED, $this->options);
+        $this->assertSame([], $this->scheduledEvents);
+    }
+
+    /**
+     * A manifest that fails the signature chain is an ERROR, and stages
+     * nothing. Distinguishing this from up_to_date is the whole reason the
+     * outcome tag exists.
+     */
+    public function test_stage_returns_error_when_the_manifest_fails_verification(): void
+    {
+        $claims                = $this->makeClaims();
+        $envelope              = $this->signClaims($claims);
+        $envelope['signature'] = $this->b64url(random_bytes(SODIUM_CRYPTO_SIGN_BYTES));
+        $this->stubManifestEndpoint(200, (string) json_encode($envelope));
+
+        $answer = $this->makeChecker()->stageSelfUpdate();
+
+        $this->assertSame('error', $answer['status']);
+        $this->assertFalse($answer['ok']);
+        $this->assertArrayNotHasKey(UpdateChecker::OPTION_STAGED, $this->options);
+        $this->assertSame([], $this->scheduledEvents);
+    }
+
+    /**
+     * A second ARM inside the staging window is a no-op: one staged record, one
+     * scheduled event, no second CP round trip.
+     */
+    public function test_stage_refuses_to_stage_twice_inside_the_window(): void
+    {
+        $claims = $this->makeClaims(['version' => $this->targetVersion]);
+        $this->stubManifestEndpoint(200, (string) json_encode($this->signClaims($claims)));
+
+        $checker = $this->makeChecker();
+        $first   = $checker->stageSelfUpdate();
+        $second  = $checker->stageSelfUpdate();
+
+        $this->assertSame('scheduled', $first['status']);
+        $this->assertSame('already_scheduled', $second['status']);
+        $this->assertSame($this->targetVersion, $second['to_version']);
+        $this->assertCount(1, $this->scheduledEvents, 'a second ARM must not schedule a second apply event');
+        $this->assertCount(1, $this->httpCalls, 'a second ARM must not re-hit the CP manifest endpoint');
+    }
+
+    /**
+     * An un-enrolled site has no control plane to obey.
+     */
+    public function test_stage_is_not_eligible_when_the_site_is_not_enrolled(): void
+    {
+        $this->forceUnenrolled = true;
+        $this->settings        = new Settings();
+
+        $answer = $this->makeChecker()->stageSelfUpdate();
+
+        $this->assertSame('not_eligible', $answer['status']);
+        $this->assertArrayNotHasKey(UpdateChecker::OPTION_STAGED, $this->options);
+        $this->assertSame([], $this->scheduledEvents);
+    }
+
+    // =========================================================================
+    // The command shell
+    // =========================================================================
+
+    public function test_command_name_is_agent_self_update(): void
+    {
+        $this->assertSame('agent_self_update', (new AgentSelfUpdateCommand())->name());
+    }
+
+    public function test_command_forwards_the_stage_answer_verbatim(): void
+    {
+        $claims = $this->makeClaims(['version' => $this->targetVersion]);
+        $this->stubManifestEndpoint(200, (string) json_encode($this->signClaims($claims)));
+
+        $result = (new AgentSelfUpdateCommand($this->makeChecker()))->execute([], []);
+
+        $this->assertSame('scheduled', $result['status']);
+        $this->assertSame($this->targetVersion, $result['to_version']);
+    }
+
+    /**
+     * A null self-updater (exactly what Plugin passes on the wp.org build) is
+     * answered, never fataled. The in-process counterpart to
+     * AgentSelfUpdateWporgBuildTest, which proves the same thing in a process
+     * where the class genuinely does not exist.
+     */
+    public function test_command_answers_not_eligible_when_no_self_updater_is_injected(): void
+    {
+        $result = (new AgentSelfUpdateCommand(null))->execute([], []);
+
+        $this->assertSame('not_eligible', $result['status']);
+        $this->assertTrue($result['ok']);
+        $this->assertSame('', $result['to_version']);
+    }
+
+    public function test_command_rejects_unexpected_parameters(): void
+    {
+        $result = (new AgentSelfUpdateCommand($this->makeChecker()))->execute([], ['version' => '9.9.9']);
+
+        $this->assertSame('error', $result['status']);
+        $this->assertFalse($result['ok']);
+        $this->assertSame([], $this->scheduledEvents);
+    }
+
+    // =========================================================================
+    // BEAT 2 (APPLY)
+    // =========================================================================
+
+    /**
+     * No staged record is the normal state on every site: the apply beat is a
+     * silent no-op and records no outcome.
+     */
+    public function test_apply_is_a_silent_no_op_without_a_staged_record(): void
+    {
+        $this->makeChecker()->applyStagedSelfUpdate('some-token');
+
+        $this->assertArrayNotHasKey(AgentSelfUpdateCommand::OPTION_RESULT, $this->options);
+    }
+
+    /**
+     * A site whose loopback cron is broken never reaches beat 2 in time. The
+     * record must then be DISCARDED, not retried: no disk was touched at ARM,
+     * so an expired stage is safely a non-event that surfaces as unconfirmed.
+     */
+    public function test_apply_discards_an_expired_staged_record_without_retrying(): void
+    {
+        $this->options[UpdateChecker::OPTION_STAGED] = [
+            'from_version' => '0.10.5',
+            'to_version'   => $this->targetVersion,
+            'staged_at'    => time() - (UpdateChecker::STAGED_TTL_SECONDS + 120),
+            'expires_at'   => time() - 120,
+            'token'        => 'stale-token',
+        ];
+
+        $this->makeChecker()->applyStagedSelfUpdate('stale-token');
+
+        $this->assertArrayNotHasKey(
+            UpdateChecker::OPTION_STAGED,
+            $this->options,
+            'an expired record must be discarded, never left behind for a later tick to retry'
+        );
+        $this->assertSame([], $this->scheduledEvents, 'the apply beat must never schedule a retry');
+
+        $result = $this->options[AgentSelfUpdateCommand::OPTION_RESULT] ?? null;
+        $this->assertIsArray($result);
+        $this->assertSame('expired', $result['status']);
+        $this->assertSame($this->targetVersion, $result['to_version']);
+    }
+
+    /**
+     * The staged record is CLAIMED (deleted) before any upgrade work starts, so
+     * an apply that dies partway can never be retried by a later cron tick. The
+     * upgrader is deliberately unavailable in this process, which exercises the
+     * failure path: the record is gone, a failure is recorded for the next
+     * metadata push, and nothing is rescheduled.
+     */
+    public function test_apply_claims_the_record_before_upgrading_and_never_retries_a_failure(): void
+    {
+        $this->options[UpdateChecker::OPTION_STAGED] = [
+            'from_version' => '0.10.5',
+            'to_version'   => $this->targetVersion,
+            'staged_at'    => time(),
+            'expires_at'   => time() + UpdateChecker::STAGED_TTL_SECONDS,
+            'token'        => 'live-token',
+        ];
+
+        $before = $this->snapshotDisk();
+        $this->makeChecker()->applyStagedSelfUpdate('live-token');
+        $after = $this->snapshotDisk();
+
+        $this->assertSame($before, $after);
+        $this->assertArrayNotHasKey(
+            UpdateChecker::OPTION_STAGED,
+            $this->options,
+            'the record must be claimed and deleted before the upgrade, so a mid-copy death cannot loop'
+        );
+        $this->assertSame([], $this->scheduledEvents, 'a failed apply must not schedule a retry');
+
+        $result = $this->options[AgentSelfUpdateCommand::OPTION_RESULT] ?? null;
+        $this->assertIsArray($result);
+        $this->assertSame('failed', $result['status']);
+        $this->assertSame($this->targetVersion, $result['to_version']);
+    }
+
+    /**
+     * A stale duplicate event from an earlier stage must not consume the record
+     * belonging to the CURRENT stage.
+     */
+    public function test_apply_ignores_an_event_whose_token_does_not_match_the_record(): void
+    {
+        $record = [
+            'from_version' => '0.10.5',
+            'to_version'   => $this->targetVersion,
+            'staged_at'    => time(),
+            'expires_at'   => time() + UpdateChecker::STAGED_TTL_SECONDS,
+            'token'        => 'current-token',
+        ];
+        $this->options[UpdateChecker::OPTION_STAGED] = $record;
+
+        $this->makeChecker()->applyStagedSelfUpdate('token-from-an-earlier-stage');
+
+        $this->assertSame($record, $this->options[UpdateChecker::OPTION_STAGED]);
+        $this->assertArrayNotHasKey(AgentSelfUpdateCommand::OPTION_RESULT, $this->options);
+    }
+
+    /**
+     * A target the site is already running is discarded rather than reinstalled.
+     */
+    public function test_apply_discards_a_record_whose_target_is_already_on_disk(): void
+    {
+        $this->options[UpdateChecker::OPTION_STAGED] = [
+            'from_version' => '0.10.4',
+            'to_version'   => $this->onDiskVersion,
+            'staged_at'    => time(),
+            'expires_at'   => time() + UpdateChecker::STAGED_TTL_SECONDS,
+            'token'        => 'live-token',
+        ];
+
+        $this->makeChecker()->applyStagedSelfUpdate('live-token');
+
+        $this->assertArrayNotHasKey(UpdateChecker::OPTION_STAGED, $this->options);
+        $result = $this->options[AgentSelfUpdateCommand::OPTION_RESULT] ?? null;
+        $this->assertIsArray($result);
+        $this->assertSame('already_applied', $result['status']);
+    }
+
+    /**
+     * The apply outcome reaches the control plane through the next metadata
+     * push, which is the ONLY channel a cron-side failure has.
+     */
+    public function test_metadata_payload_carries_the_last_apply_outcome(): void
+    {
+        Functions\when('is_multisite')->justReturn(false);
+
+        $collector = new \WPMgr\Agent\Commands\MetadataCommand();
+        $this->assertArrayNotHasKey(
+            'agent_self_update',
+            $collector->collect(),
+            'a site that never staged a self-update must not carry the key at all'
+        );
+
+        $this->options[AgentSelfUpdateCommand::OPTION_RESULT] = [
+            'status'       => 'failed',
+            'from_version' => '0.10.5',
+            'to_version'   => $this->targetVersion,
+            'detail'       => 'Upgrader API unavailable.',
+            'at'           => time(),
+        ];
+
+        $payload = $collector->collect();
+        $this->assertArrayHasKey('agent_self_update', $payload);
+        $this->assertSame('failed', $payload['agent_self_update']['status']);
+        $this->assertSame($this->targetVersion, $payload['agent_self_update']['to_version']);
+    }
+
+    /**
+     * The recorded detail must never carry a URL: upgrader and skin messages
+     * can echo a package string back, and the manifest's package_url is a
+     * short-lived bearer credential.
+     */
+    public function test_recorded_failure_detail_is_scrubbed_of_urls(): void
+    {
+        $checker = $this->makeChecker();
+        $method  = new \ReflectionMethod($checker, 'recordSelfUpdateResult');
+        $method->invoke(
+            $checker,
+            'failed',
+            '0.10.5',
+            $this->targetVersion,
+            'download failed: https://storage.googleapis.com/bucket/a.zip?X-Goog-Signature=deadbeef'
+        );
+
+        $detail = (string) $this->options[AgentSelfUpdateCommand::OPTION_RESULT]['detail'];
+        $this->assertStringNotContainsString('X-Goog-Signature', $detail);
+        $this->assertStringNotContainsString('https://', $detail);
+        $this->assertStringContainsString('[url]', $detail);
+    }
+}

--- a/apps/agent/tests/AgentSelfUpdateWireContractTest.php
+++ b/apps/agent/tests/AgentSelfUpdateWireContractTest.php
@@ -1,0 +1,399 @@
+<?php
+/**
+ * SHARED GOLDEN VECTOR for the agent self-update beat 1 (ARM) wire contract.
+ *
+ * This is the PHP half. The Go half lives in apps/api/internal/agentcmd and
+ * pins the SAME literals. Both halves are deliberately redundant: the defects
+ * this file was written for were three status/cron_mode strings that one side
+ * believed in and the other never emitted, and they were invisible to both
+ * suites because each suite only ever tested its own half's fiction. A golden
+ * vector that each side pins independently is the only thing that turns a
+ * one-sided edit into a failing suite on the side that made it.
+ *
+ * THE CONTRACT, authoritative.
+ *
+ * status, exactly five strings:
+ *   "scheduled"          verified and staged, cron event spawned. Carries
+ *                        to_version and expires_at.
+ *   "up_to_date"         the verified manifest offers nothing newer than what
+ *                        is installed.
+ *   "not_eligible"       this build cannot self-update (wp.org build) or the
+ *                        site is not enrolled.
+ *   "already_scheduled"  a staged record from a previous arm is still live.
+ *                        Carries to_version and expires_at. NOT a failure.
+ *   "error"              the arm failed. Carries a human-readable detail.
+ *
+ * cron_mode, exactly two strings:
+ *   "loopback"   WordPress loopback cron is available.
+ *   "external"   loopback cron is unavailable (DISABLE_WP_CRON or equivalent);
+ *                the site relies on system cron.
+ *
+ * "failed", "disabled" and "alternate" are NOT part of this contract. The agent
+ * has never emitted any of them from beat 1. ("failed" remains a legitimate
+ * value of the separate BEAT 3 apply-result record stored in
+ * AgentSelfUpdateCommand::OPTION_RESULT, which is a different field on a
+ * different wire; the assertions below scope themselves to beat 1.)
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use WPMgr\Agent\Commands\AgentSelfUpdateCommand;
+use WPMgr\Agent\Support\UpdateChecker;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Commands\AgentSelfUpdateCommand
+ * @covers \WPMgr\Agent\Support\UpdateChecker
+ */
+final class AgentSelfUpdateWireContractTest extends TestCase
+{
+    /**
+     * THE golden status vector. Sorted, so set comparisons below read as
+     * equality rather than as a subset test.
+     *
+     * @var list<string>
+     */
+    private const GOLDEN_STATUSES = [
+        'already_scheduled',
+        'error',
+        'not_eligible',
+        'scheduled',
+        'up_to_date',
+    ];
+
+    /**
+     * THE golden cron_mode vector.
+     *
+     * @var list<string>
+     */
+    private const GOLDEN_CRON_MODES = [
+        'external',
+        'loopback',
+    ];
+
+    /**
+     * Strings a previous version of the control-plane contract believed in and
+     * the agent never emitted. Pinned here so re-introducing one on this side
+     * fails loudly instead of quietly resurrecting the mismatch.
+     *
+     * @var list<string>
+     */
+    private const NEVER_EMITTED = ['failed', 'disabled', 'alternate'];
+
+    /**
+     * The exact response shape. Beat 1 answers exactly these keys, always,
+     * whichever status it carries.
+     *
+     * @var list<string>
+     */
+    private const RESPONSE_KEYS = [
+        'status',
+        'ok',
+        'from_version',
+        'to_version',
+        'detail',
+        'cron_mode',
+        'expires_at',
+    ];
+
+    // -------------------------------------------------------------------------
+    // The vector itself
+    // -------------------------------------------------------------------------
+
+    /**
+     * Pins the literals. If a future edit widens or narrows the contract, this
+     * is the assertion that has to be changed deliberately, in the same commit
+     * as its Go counterpart.
+     */
+    public function test_golden_vector_is_exactly_five_statuses_and_two_cron_modes(): void
+    {
+        $this->assertCount(5, self::GOLDEN_STATUSES);
+        $this->assertSame(
+            ['already_scheduled', 'error', 'not_eligible', 'scheduled', 'up_to_date'],
+            self::GOLDEN_STATUSES
+        );
+
+        $this->assertCount(2, self::GOLDEN_CRON_MODES);
+        $this->assertSame(['external', 'loopback'], self::GOLDEN_CRON_MODES);
+
+        foreach (self::NEVER_EMITTED as $ghost) {
+            $this->assertNotContains(
+                $ghost,
+                self::GOLDEN_STATUSES,
+                "'{$ghost}' is not a beat 1 status; it was removed from the contract because the agent never emitted it"
+            );
+            $this->assertNotContains($ghost, self::GOLDEN_CRON_MODES);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // What the sources actually emit
+    // -------------------------------------------------------------------------
+
+    /**
+     * Every status literal the two beat 1 answer builders can produce, taken
+     * from the source rather than from a doc block, must be exactly the golden
+     * set. Not a subset: adding a sixth status fails here, and so does dropping
+     * one, which is what keeps the two halves honest.
+     */
+    public function test_the_arm_sources_emit_exactly_the_golden_statuses(): void
+    {
+        $emitted = array_merge(
+            self::firstStringArguments(self::checkerSource(), ['stageAnswer']),
+            self::firstStringArguments(self::commandSource(), ['answer'])
+        );
+
+        $emitted = array_values(array_unique($emitted));
+        sort($emitted);
+
+        $this->assertSame(
+            self::GOLDEN_STATUSES,
+            $emitted,
+            'the beat 1 status set drifted from the wire contract. Statuses found in the agent source: '
+            . implode(', ', $emitted)
+        );
+    }
+
+    /**
+     * The same for cron_mode, read out of the `'cron_mode' =>` expression in
+     * each answer builder. Both builders must offer the same two values, so a
+     * site never reports one vocabulary from the command shell and another from
+     * the self-updater.
+     */
+    public function test_both_answer_builders_emit_exactly_the_golden_cron_modes(): void
+    {
+        foreach (['class-update-checker.php' => self::checkerSource(), 'class-agent-self-update-command.php' => self::commandSource()] as $label => $source) {
+            $modes = self::cronModeLiterals($source);
+
+            $this->assertSame(
+                self::GOLDEN_CRON_MODES,
+                $modes,
+                "{$label} emits a cron_mode set that is not the wire contract's two values. Found: "
+                . (implode(', ', $modes) ?: '(none, so the expression was refactored and this vector needs re-pinning)')
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Timing, the other half of the contract
+    // -------------------------------------------------------------------------
+
+    /**
+     * The staged record MUST outlive the control plane's patience.
+     *
+     * The CP waits for beat 3 for a window chosen by the cron_mode this agent
+     * reported in beat 1: 20 minutes for "loopback", 90 minutes for "external"
+     * (agentConfirmDeadline and agentConfirmDeadlineExternalCron in
+     * apps/api/internal/update/agent_worker.go). A staged TTL shorter than the
+     * longer of the two is a defect, not a tuning choice: a site whose system
+     * cron runs hourly expires its own staged record before the tick that
+     * would have applied it, so the canary false-fails and the rollout halts
+     * with nothing wrong with the build.
+     */
+    public function test_staged_ttl_outlives_the_control_planes_longest_confirm_deadline(): void
+    {
+        $cpLoopbackDeadline = 20 * 60;
+        $cpExternalDeadline = 90 * 60;
+
+        // The control plane declares this floor itself, as
+        // SelfUpdateStagedTTLFloor in
+        // apps/api/internal/agentcmd/agent_self_update_contract.go. Assert the
+        // SAME number rather than a locally derived "deadline plus headroom":
+        // a weaker local sum let this constant be lowered to a value that kept
+        // both suites green while violating the floor the other half publishes,
+        // which is the exact class of two-halves-disagree defect this whole
+        // contract test exists to catch.
+        $cpDeclaredFloor = 2 * 60 * 60;
+
+        $this->assertGreaterThan(
+            $cpLoopbackDeadline,
+            UpdateChecker::STAGED_TTL_SECONDS,
+            'a stage that expires before the loopback confirm window cannot be applied in time'
+        );
+
+        $this->assertGreaterThanOrEqual(
+            $cpDeclaredFloor,
+            UpdateChecker::STAGED_TTL_SECONDS,
+            'STAGED_TTL_SECONDS must be at least the control plane\'s declared floor ('
+            . $cpDeclaredFloor . 's, SelfUpdateStagedTTLFloor), which already carries headroom over its longest'
+            . ' confirm deadline (' . $cpExternalDeadline . 's, external cron). Raise the TTL first, then the CP window.'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Runtime: the shape and the locally reachable statuses
+    // -------------------------------------------------------------------------
+
+    /**
+     * The command shell's two locally generated answers, exercised for real.
+     * These are the paths that do not need the self-updater, so they run
+     * without a WordPress fixture: a body that carries parameters is an
+     * "error", and a null self-updater is "not_eligible".
+     */
+    public function test_command_local_paths_answer_only_golden_values(): void
+    {
+        $command = new AgentSelfUpdateCommand(null);
+
+        $rejected = $command->execute([], ['unexpected' => 1]);
+        $this->assertSame('error', $rejected['status']);
+        $this->assertFalse($rejected['ok'], 'only "error" answers ok=false');
+
+        $ineligible = $command->execute([], []);
+        $this->assertSame('not_eligible', $ineligible['status']);
+        $this->assertTrue($ineligible['ok'], '"not_eligible" is informational, never a failure');
+
+        foreach ([$rejected, $ineligible] as $answer) {
+            $this->assertSame(self::RESPONSE_KEYS, array_keys($answer));
+            $this->assertContains($answer['status'], self::GOLDEN_STATUSES);
+            $this->assertContains($answer['cron_mode'], self::GOLDEN_CRON_MODES);
+            $this->assertIsString($answer['from_version']);
+            $this->assertSame('', $answer['to_version'], 'only scheduled/already_scheduled carry a target version');
+            $this->assertIsString($answer['detail']);
+            $this->assertSame(0, $answer['expires_at'], 'expires_at is 0 unless a record was staged');
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Source helpers
+    // -------------------------------------------------------------------------
+
+    /** @return string Source of the self-updater. */
+    private static function checkerSource(): string
+    {
+        return (string) file_get_contents(dirname(__DIR__) . '/includes/support/class-update-checker.php');
+    }
+
+    /** @return string Source of the command shell. */
+    private static function commandSource(): string
+    {
+        return (string) file_get_contents(dirname(__DIR__) . '/includes/commands/class-agent-self-update-command.php');
+    }
+
+    /**
+     * Collect the first argument of every call to one of $methods, when that
+     * argument is a plain quoted string. Method DECLARATIONS are skipped for
+     * free: their first token after `(` is a type, not a string literal.
+     *
+     * @param string       $source  PHP source.
+     * @param list<string> $methods Method names to collect from.
+     * @return list<string> Unquoted literals, in source order.
+     */
+    private static function firstStringArguments(string $source, array $methods): array
+    {
+        $tokens = token_get_all($source);
+        $count  = count($tokens);
+        $found  = [];
+
+        for ($i = 0; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if (!is_array($token) || $token[0] !== T_STRING || !in_array($token[1], $methods, true)) {
+                continue;
+            }
+
+            $open = self::nextSignificant($tokens, $i);
+            if ($open === -1 || $tokens[$open] !== '(') {
+                continue;
+            }
+
+            $arg = self::nextSignificant($tokens, $open);
+            if ($arg === -1 || !is_array($tokens[$arg]) || $tokens[$arg][0] !== T_CONSTANT_ENCAPSED_STRING) {
+                continue;
+            }
+
+            $found[] = self::unquote($tokens[$arg][1]);
+        }
+
+        return $found;
+    }
+
+    /**
+     * Collect the string literals of the `'cron_mode' => ...` array entry, at
+     * the entry's own nesting level only. Literals nested inside a call (the
+     * DISABLE_WP_CRON constant name) are not part of the emitted vocabulary and
+     * are skipped.
+     *
+     * @param string $source PHP source.
+     * @return list<string> Sorted, de-duplicated literals.
+     */
+    private static function cronModeLiterals(string $source): array
+    {
+        $tokens = token_get_all($source);
+        $count  = count($tokens);
+        $found  = [];
+
+        for ($i = 0; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if (!is_array($token) || $token[0] !== T_CONSTANT_ENCAPSED_STRING) {
+                continue;
+            }
+            if (self::unquote($token[1]) !== 'cron_mode') {
+                continue;
+            }
+
+            $arrow = self::nextSignificant($tokens, $i);
+            if ($arrow === -1 || !is_array($tokens[$arrow]) || $tokens[$arrow][0] !== T_DOUBLE_ARROW) {
+                continue;
+            }
+
+            $depth = 0;
+            for ($j = $arrow + 1; $j < $count; $j++) {
+                $inner = $tokens[$j];
+                if ($inner === '(' || $inner === '[') {
+                    $depth++;
+                    continue;
+                }
+                if ($inner === ')' || $inner === ']') {
+                    if ($depth === 0) {
+                        break;
+                    }
+                    $depth--;
+                    continue;
+                }
+                if ($inner === ',' && $depth === 0) {
+                    break;
+                }
+                if ($depth === 0 && is_array($inner) && $inner[0] === T_CONSTANT_ENCAPSED_STRING) {
+                    $found[] = self::unquote($inner[1]);
+                }
+            }
+        }
+
+        $found = array_values(array_unique($found));
+        sort($found);
+
+        return $found;
+    }
+
+    /**
+     * @param string $literal Quoted PHP string literal.
+     * @return string Its value, for the simple single-quoted case this file needs.
+     */
+    private static function unquote(string $literal): string
+    {
+        return trim($literal, "'\"");
+    }
+
+    /**
+     * @param list<array{0:int,1:string,2:int}|string> $tokens Full token list.
+     * @param int                                      $from   Index to search after.
+     * @return int Index of the next significant token, or -1.
+     */
+    private static function nextSignificant(array $tokens, int $from): int
+    {
+        $count = count($tokens);
+        for ($i = $from + 1; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            return $i;
+        }
+
+        return -1;
+    }
+}

--- a/apps/agent/tests/AgentSelfUpdateWporgBuildTest.php
+++ b/apps/agent/tests/AgentSelfUpdateWporgBuildTest.php
@@ -1,0 +1,341 @@
+<?php
+/**
+ * THE wp.org-build lock for the agent self-update command.
+ *
+ * `make agent-zip-wporg` physically excludes
+ * includes/support/class-update-checker.php from the distribution build
+ * (Guideline 8), but includes/commands/class-agent-self-update-command.php
+ * SURVIVES that rsync. So in the wp.org build the command file exists in a tree
+ * where the UpdateChecker class does not. If that file named the class at file
+ * scope (a `use` import, a typed property, a typed parameter), the plugin's
+ * autoloader would go looking for a file that is not there, and the command
+ * would fatal instead of answering.
+ *
+ * The correct answer in that build is a clean "not_eligible".
+ *
+ * This cannot be proven in-process: the PHPUnit process loads the whole plugin
+ * through Composer's classmap, so UpdateChecker always exists there. Both tests
+ * below therefore spawn a disposable child process that loads ONLY the command
+ * file and its interface: no Composer autoloader, no plugin bootstrap, and
+ * critically no UpdateChecker anywhere on disk from that process's point of
+ * view. The child asserts the class really is absent, then calls the command
+ * and reports what it got as JSON. Same disposable-subprocess idiom as
+ * MetadataCommandTest's open_basedir probe.
+ *
+ * The static companions go further than the command file. includes/class-plugin.php
+ * also survives the rsync and is the ONLY surviving file that names the
+ * self-updater in executable code (`new UpdateChecker(...)` and
+ * `UpdateChecker::HOOK_APPLY`), each safe only because it sits inside a guard.
+ * Those namings are checked here with the same analyser the agent-zip-wporg
+ * build-time assertion runs against the staged artifact.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use WPMgr\Agent\Tools\WporgUpdateCheckerGuard;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Commands\AgentSelfUpdateCommand
+ * @covers \WPMgr\Agent\Plugin
+ */
+final class AgentSelfUpdateWporgBuildTest extends TestCase
+{
+    /**
+     * The wp.org build: WPMGR_WPORG_BUILD is defined true (exactly as
+     * agent-zip-wporg stamps the staged main file) AND the self-updater source
+     * file is absent. The command must load and answer "not_eligible".
+     */
+    public function test_command_answers_not_eligible_in_a_tree_without_the_self_updater(): void
+    {
+        $result = $this->runProbe(true);
+
+        $this->assertSame('agent_self_update', $result['name']);
+        $this->assertSame('not_eligible', $result['result']['status']);
+        $this->assertTrue($result['result']['ok']);
+        $this->assertSame('', $result['result']['to_version']);
+    }
+
+    /**
+     * The same tree WITHOUT the constant: a hand-assembled or partially-copied
+     * install that carries the command but not the self-updater must still
+     * answer rather than fatal. This is the case the lazy, string-keyed
+     * class_exists() resolution inside execute() exists for. The constant
+     * guard alone would not cover it.
+     */
+    public function test_command_answers_not_eligible_when_only_the_self_updater_is_missing(): void
+    {
+        $result = $this->runProbe(false);
+
+        $this->assertSame('not_eligible', $result['result']['status']);
+        $this->assertTrue($result['result']['ok']);
+    }
+
+    /**
+     * Static companion to the runtime probes: the command source must name no
+     * UpdateChecker symbol at file scope. A future edit that adds a `use`
+     * import or a concrete type hint would still pass the probes today (the
+     * probe process registers no autoloader at all, so an unresolved symbol
+     * never gets looked up) but would fatal in the real wp.org build, where the
+     * plugin's own autoloader IS registered.
+     */
+    public function test_command_source_names_no_self_updater_symbol_at_file_scope(): void
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__) . '/includes/commands/class-agent-self-update-command.php'
+        );
+
+        // Strip comments and doc blocks: the file legitimately EXPLAINS the rule
+        // in prose, and prose is never resolved by an autoloader.
+        $code = '';
+        foreach (token_get_all($source) as $token) {
+            if (is_array($token) && ($token[0] === T_COMMENT || $token[0] === T_DOC_COMMENT)) {
+                continue;
+            }
+            $code .= is_array($token) ? $token[1] : $token;
+        }
+
+        // The only permitted occurrence is inside the single-quoted, escaped
+        // class-name STRING constant, which no autoloader ever sees.
+        $code = str_replace("'WPMgr\\\\Agent\\\\Support\\\\UpdateChecker'", "''", $code);
+
+        $this->assertStringNotContainsString(
+            'UpdateChecker',
+            $code,
+            'class-agent-self-update-command.php ships in the wp.org build, where the self-updater does not exist;'
+            . ' it must resolve that symbol lazily by string, never name it in executable code'
+        );
+    }
+
+    /**
+     * THE regression this file exists to prevent, checked on the file that
+     * actually carries the risk.
+     *
+     * The test above inspects class-agent-self-update-command.php, which by
+     * design names the self-updater nowhere, so it can never fail on the real
+     * hazard. includes/class-plugin.php is the file that does name it, twice,
+     * in executable code:
+     *
+     *   new UpdateChecker(...)          inside a WPMGR_WPORG_BUILD guard
+     *   UpdateChecker::HOOK_APPLY       inside an updateChecker-not-null guard
+     *
+     * class-plugin.php SURVIVES the wp.org rsync while
+     * includes/support/class-update-checker.php does not, so either line, if
+     * dedented out of its guard, is a hard class fetch that raises
+     * "Class WPMgr\Agent\Support\UpdateChecker not found" on every request of
+     * every wp.org install. Both sit among roughly a dozen visually identical
+     * unconditional add_action() calls, which makes that dedent a plausible
+     * refactor rather than an exotic one.
+     *
+     * Shares its analyser with the build-time assertion the agent-zip-wporg
+     * target runs against the staged artifact, so the source tree and the
+     * shipped tree are judged by one implementation.
+     */
+    public function test_plugin_source_resolves_no_self_updater_symbol_outside_a_wporg_guard(): void
+    {
+        require_once dirname(__DIR__) . '/tools/assert-wporg-updatechecker-guard.php';
+
+        $pluginFile = dirname(__DIR__) . '/includes/class-plugin.php';
+        $report     = WporgUpdateCheckerGuard::analyse((string) file_get_contents($pluginFile));
+
+        $rendered = '';
+        foreach ($report['violations'] as $violation) {
+            $rendered .= "\n  class-plugin.php:{$violation['line']}  {$violation['context']}";
+        }
+
+        $this->assertSame(
+            [],
+            $report['violations'],
+            'class-plugin.php ships in the wp.org build, where the self-updater does not exist. Every executable'
+            . ' naming of that class must stay inside a WPMGR_WPORG_BUILD or updateChecker-not-null guard, or the'
+            . ' plugin fatals on every request of every wp.org install. Unguarded:' . $rendered
+        );
+
+        // Guard against the assertion going vacuous: if class-plugin.php stops
+        // naming the class in executable code at all, the check above passes
+        // for the wrong reason.
+        $this->assertGreaterThanOrEqual(
+            1,
+            $report['resolving'],
+            'class-plugin.php no longer resolves the self-updater anywhere, so this test proves nothing;'
+            . ' if the self-update wiring moved, move this assertion with it'
+        );
+    }
+
+    /**
+     * Same rule, applied to every source file that survives the wp.org rsync.
+     * The hazard is not specific to class-plugin.php: any file the build keeps
+     * can introduce it. Only includes/support/class-update-checker.php is
+     * exempt, because the build removes that file outright.
+     */
+    public function test_no_surviving_source_file_resolves_the_self_updater_outside_a_guard(): void
+    {
+        require_once dirname(__DIR__) . '/tools/assert-wporg-updatechecker-guard.php';
+
+        $root     = dirname(__DIR__) . '/includes';
+        $excluded = dirname(__DIR__) . '/' . WporgUpdateCheckerGuard::EXCLUDED_FILE;
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        $offenders = [];
+        /** @var \SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+            if ($file->getPathname() === $excluded) {
+                continue;
+            }
+
+            $source = (string) file_get_contents($file->getPathname());
+            if (!str_contains($source, WporgUpdateCheckerGuard::CLASS_NAME)) {
+                continue;
+            }
+
+            foreach (WporgUpdateCheckerGuard::analyse($source)['violations'] as $violation) {
+                $offenders[] = $file->getBasename() . ':' . $violation['line'] . '  ' . $violation['context'];
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $offenders,
+            'these files ship in the wp.org build and resolve the absent self-updater class outside a guard: '
+            . implode(' | ', $offenders)
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Probe harness
+    // -------------------------------------------------------------------------
+
+    /**
+     * Stage a tree containing ONLY the command file and its interface (i.e. the
+     * wp.org build's view of the world), then run the probe against it.
+     *
+     * @param bool $defineWporgConstant Whether the child defines WPMGR_WPORG_BUILD.
+     * @return array{name:string,result:array<string,mixed>}
+     */
+    private function runProbe(bool $defineWporgConstant): array
+    {
+        if (!function_exists('exec')) {
+            $this->markTestSkipped('exec() is unavailable in this PHP configuration.');
+        }
+
+        $agentDir = dirname(__DIR__);
+        $stageDir = sys_get_temp_dir() . '/wpmgr-wporg-probe-' . bin2hex(random_bytes(6));
+        mkdir($stageDir . '/includes/commands', 0755, true);
+        mkdir($stageDir . '/includes/support', 0755, true);
+
+        copy(
+            $agentDir . '/includes/commands/interface-command-interface.php',
+            $stageDir . '/includes/commands/interface-command-interface.php'
+        );
+        copy(
+            $agentDir . '/includes/commands/class-agent-self-update-command.php',
+            $stageDir . '/includes/commands/class-agent-self-update-command.php'
+        );
+
+        // Assert the premise rather than assume it: includes/support/ is staged
+        // but deliberately EMPTY of the self-updater, exactly as agent-zip-wporg
+        // leaves it.
+        $this->assertFileDoesNotExist($stageDir . '/includes/support/class-update-checker.php');
+
+        $probeScript = $stageDir . '/probe.php';
+        file_put_contents($probeScript, self::probeSource());
+
+        $outputLines = [];
+        $exitCode    = 1;
+        try {
+            $cmd = escapeshellarg(PHP_BINARY)
+                . ' -f ' . escapeshellarg($probeScript)
+                . ' -- ' . escapeshellarg($stageDir)
+                . ' ' . escapeshellarg($defineWporgConstant ? '1' : '0');
+
+            exec($cmd . ' 2>&1', $outputLines, $exitCode); // phpcs:ignore WordPress.PHP.DiscouragedFunctions.exec -- test-only: spawns a disposable subprocess to load the command file in a tree that genuinely lacks the self-updater; all inputs are internally generated absolute paths, none are request-derived
+        } finally {
+            $this->rrmdir($stageDir);
+        }
+
+        $rawOutput = implode("\n", $outputLines);
+        $this->assertSame(
+            0,
+            $exitCode,
+            'the command file must LOAD AND ANSWER in a tree without the self-updater, never fatal: ' . $rawOutput
+        );
+
+        $decoded = json_decode($rawOutput, true);
+        $this->assertIsArray($decoded, 'probe subprocess must emit parseable JSON: ' . $rawOutput);
+
+        /** @var array{name:string,result:array<string,mixed>} $decoded */
+        return $decoded;
+    }
+
+    /**
+     * Source of the child process. Loads the two staged files by hand (no
+     * Composer autoloader is registered, so an unresolvable symbol would be a
+     * hard fatal, which is precisely the failure this test is looking for),
+     * proves the self-updater class is absent, then invokes the command.
+     *
+     * @return string
+     */
+    private static function probeSource(): string
+    {
+        return <<<'PHP'
+<?php
+declare(strict_types=1);
+
+$stageDir = $argv[1] ?? '';
+$wporg    = ($argv[2] ?? '0') === '1';
+
+if ($wporg) {
+    define('WPMGR_WPORG_BUILD', true);
+}
+
+require_once $stageDir . '/includes/commands/interface-command-interface.php';
+require_once $stageDir . '/includes/commands/class-agent-self-update-command.php';
+
+if (class_exists('WPMgr\Agent\Support\UpdateChecker', false)) {
+    fwrite(STDERR, "premise violated: UpdateChecker is present in the probe process\n");
+    exit(2);
+}
+
+$command = new WPMgr\Agent\Commands\AgentSelfUpdateCommand(null);
+
+echo json_encode([
+    'name'   => $command->name(),
+    'result' => $command->execute([], []),
+]);
+PHP;
+    }
+
+    /** Recursive delete used only for test fixture cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if ($dir === '' || !is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+}

--- a/apps/agent/tests/PluginVersionChangedPushTest.php
+++ b/apps/agent/tests/PluginVersionChangedPushTest.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * BEAT 3 (CONFIRM) of the CP-commanded agent self-update.
+ *
+ * A "scheduled" acknowledgement from beat 1 is never success, and beat 2 runs
+ * in a request that is busy replacing the very code that would report its own
+ * outcome. The only trustworthy success signal is the NEW code phoning home, so
+ * the freshly-installed build pushes metadata once on its first boot rather
+ * than leaving the control plane to wait out the 30-minute metadata cron.
+ *
+ * "Once and only once per version" is the load-bearing property: this fires on
+ * plugins_loaded, i.e. on EVERY request, so a boot that failed to stamp would
+ * turn one confirmation into a CP call per page view.
+ *
+ * Boots the REAL Plugin singleton with the same minimal stub set
+ * PluginMaybeGcSnapshotsTest uses.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Plugin;
+use WPMgr\Agent\Settings;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Plugin
+ */
+final class PluginVersionChangedPushTest extends TestCase
+{
+    /** @var array<string,mixed> In-memory wp-option store. */
+    private array $options = [];
+
+    /** Temp uploads dir standing in for wp_upload_dir()'s basedir. */
+    private string $uploadsDir = '';
+
+    /** @var list<array{hook:string,priority:int}> Every add_action() seen after boot. */
+    private array $actions = [];
+
+    /** Set true once boot() has finished, so only post-boot hooks are recorded. */
+    private bool $recordActions = false;
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->uploadsDir    = sys_get_temp_dir() . '/wpmgr-plugin-b3-' . bin2hex(random_bytes(6));
+        mkdir($this->uploadsDir, 0755, true);
+        $this->options       = [];
+        $this->actions       = [];
+        $this->recordActions = false;
+
+        // Same minimal boot-stub set as PluginMaybeGcSnapshotsTest::set_up().
+        foreach (['add_filter', 'register_activation_hook',
+                  'register_deactivation_hook', 'wp_schedule_single_event',
+                  'spawn_cron', 'wp_next_scheduled', 'wp_schedule_event',
+                  'wp_get_scheduled_event', 'wp_clear_scheduled_hook'] as $fn) {
+            Functions\when($fn)->justReturn(true);
+        }
+        Functions\when('add_action')->alias(function (string $hook, $callback, int $priority = 10) {
+            if ($this->recordActions) {
+                $this->actions[] = ['hook' => $hook, 'priority' => $priority];
+            }
+            return true;
+        });
+        Functions\when('is_admin')->justReturn(false);
+        Functions\when('is_multisite')->justReturn(false);
+        Functions\when('plugin_basename')->returnArg();
+
+        Functions\when('update_option')->alias(function ($name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('get_option')->alias(function ($name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('delete_option')->alias(function ($name) {
+            unset($this->options[$name]);
+            return true;
+        });
+        Functions\when('get_site_option')->alias(function ($name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('update_site_option')->alias(function ($name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $this->uploadsDir]);
+
+        // The version under test. Guard-defined because PHP constants are
+        // process-global and another test file in this (non-isolated) suite may
+        // already have defined it, so the assertions read the live value back
+        // rather than assuming this literal won.
+        if (!defined('WPMGR_AGENT_VERSION')) {
+            define('WPMGR_AGENT_VERSION', '0.10.5');
+        }
+    }
+
+    protected function tear_down(): void
+    {
+        Plugin::resetForTesting();
+        $this->rrmdir($this->uploadsDir);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /** Recursive delete used only for test fixture cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if ($dir === '' || !is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+
+    /** Boot the real singleton and start recording hook registrations. */
+    private function bootPlugin(): Plugin
+    {
+        $plugin              = Plugin::boot();
+        $this->recordActions = true;
+
+        return $plugin;
+    }
+
+    /** Count the 'shutdown' registrations captured since boot finished. */
+    private function shutdownHookCount(): int
+    {
+        $count = 0;
+        foreach ($this->actions as $action) {
+            if ($action['hook'] === 'shutdown') {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * The whole point: the confirmation push arms EXACTLY ONCE for a given
+     * version, no matter how many requests boot on it. This runs on
+     * plugins_loaded, so a missing stamp would mean a CP round trip per page
+     * view.
+     */
+    public function test_confirmation_push_arms_once_and_only_once_per_version(): void
+    {
+        $this->options[Settings::OPTION_SITE_ID] = 'site-abc';
+        $this->options[Settings::OPTION_CP_URL]  = 'https://cp.example.test';
+
+        $plugin = $this->bootPlugin();
+
+        $this->assertTrue(
+            $plugin->maybePushVersionChangedMetadata(),
+            'the first boot on an unreported version must arm the confirmation push'
+        );
+        $this->assertSame(1, $this->shutdownHookCount());
+        $this->assertSame(
+            (string) constant('WPMGR_AGENT_VERSION'),
+            $this->options[Plugin::OPTION_REPORTED_VERSION] ?? null,
+            'the reported-version stamp must be written by the arming call'
+        );
+
+        $this->assertFalse($plugin->maybePushVersionChangedMetadata());
+        $this->assertFalse($plugin->maybePushVersionChangedMetadata());
+        $this->assertSame(
+            1,
+            $this->shutdownHookCount(),
+            'later boots on the same version must not arm a second push'
+        );
+    }
+
+    /**
+     * The stamp is written BEFORE the network push, not after: a control plane
+     * that is unreachable must not make every subsequent request re-attempt the
+     * confirmation. The 30-minute metadata cron is the backstop.
+     */
+    public function test_a_later_version_change_arms_the_push_again(): void
+    {
+        $this->options[Settings::OPTION_SITE_ID]         = 'site-abc';
+        $this->options[Settings::OPTION_CP_URL]          = 'https://cp.example.test';
+        $this->options[Plugin::OPTION_REPORTED_VERSION]  = '0.0.1-some-older-build';
+
+        $plugin = $this->bootPlugin();
+
+        $this->assertTrue($plugin->maybePushVersionChangedMetadata());
+        $this->assertSame(1, $this->shutdownHookCount());
+        $this->assertFalse($plugin->maybePushVersionChangedMetadata());
+        $this->assertSame(1, $this->shutdownHookCount());
+    }
+
+    /**
+     * A site that is not enrolled has no control plane to confirm anything to,
+     * and must not even stamp (so its first push after enrollment still fires).
+     */
+    public function test_an_unenrolled_site_never_arms_the_push(): void
+    {
+        // Deliberately NOT enrolled: no site_id/cp_url in the option store.
+        $plugin = $this->bootPlugin();
+
+        $this->assertFalse($plugin->maybePushVersionChangedMetadata());
+        $this->assertSame(0, $this->shutdownHookCount());
+        $this->assertArrayNotHasKey(Plugin::OPTION_REPORTED_VERSION, $this->options);
+    }
+}

--- a/apps/agent/tests/UpdateCheckerTest.php
+++ b/apps/agent/tests/UpdateCheckerTest.php
@@ -642,6 +642,71 @@ final class UpdateCheckerTest extends TestCase
         $this->assertArrayHasKey(UpdateChecker::PLUGIN_KEY, $result->no_update);
     }
 
+    /**
+     * REGRESSION LOCK: injectUpdate() and verifyManifest() must apply the SAME
+     * version-comparison rule.
+     *
+     * verifyManifest()'s downgrade guard (step 8) normalizes both sides before
+     * comparing; injectUpdate() used to compare the RAW strings. PHP
+     * version_compare() reads '0.10.5-cron-selfheal' as a PRE-RELEASE of (i.e.
+     * LOWER than) '0.10.5', so a cached manifest claiming version '0.10.5'
+     * satisfied the raw comparison and was offered in the dashboard as an
+     * available update, while the install path's verifyManifest() would then
+     * refuse the very same build as a sidegrade. One rule, both gates.
+     *
+     * Confirmed RED against the pre-change code: with the bare
+     * version_compare($claims['version'], $onDisk, '>') this test found the
+     * entry in $result->response and failed on the first assertion.
+     */
+    public function test_injectUpdate_does_not_offer_a_bare_numeric_sidegrade_of_a_dev_suffixed_build(): void
+    {
+        $this->onDiskVersion = '0.10.5-cron-selfheal';
+
+        $toCache = $this->makeClaims(['version' => '0.10.5']);
+        unset($toCache['package_url']);
+        $this->siteTransients[UpdateChecker::TRANSIENT_MANIFEST] = $toCache;
+
+        $transient = new \stdClass();
+        $transient->response  = [];
+        $transient->no_update = [];
+
+        $result = $this->makeChecker()->injectUpdate($transient);
+
+        $this->assertArrayNotHasKey(
+            UpdateChecker::PLUGIN_KEY,
+            $result->response,
+            'a bare-numeric sidegrade of a dev-suffixed on-disk build must never be offered as an update'
+        );
+        $this->assertArrayHasKey(
+            UpdateChecker::PLUGIN_KEY,
+            $result->no_update,
+            'the sidegrade case belongs in no_update[], exactly like any other up-to-date site'
+        );
+    }
+
+    /**
+     * The companion to the lock above: normalizing must not suppress a REAL
+     * update. A numeric-core bump is still offered even when both sides carry
+     * descriptive suffixes.
+     */
+    public function test_injectUpdate_still_offers_a_numeric_core_bump_over_a_dev_suffixed_build(): void
+    {
+        $this->onDiskVersion = '0.10.5-cron-selfheal';
+
+        $toCache = $this->makeClaims(['version' => '0.10.6-self-update']);
+        unset($toCache['package_url']);
+        $this->siteTransients[UpdateChecker::TRANSIENT_MANIFEST] = $toCache;
+
+        $transient = new \stdClass();
+        $transient->response  = [];
+        $transient->no_update = [];
+
+        $result = $this->makeChecker()->injectUpdate($transient);
+
+        $this->assertArrayHasKey(UpdateChecker::PLUGIN_KEY, $result->response);
+        $this->assertSame('0.10.6-self-update', $result->response[UpdateChecker::PLUGIN_KEY]->new_version);
+    }
+
     public function test_injectUpdate_uses_cached_manifest_without_second_fetch(): void
     {
         // Pre-populate the 12h cache.

--- a/apps/agent/tools/assert-wporg-updatechecker-guard.php
+++ b/apps/agent/tools/assert-wporg-updatechecker-guard.php
@@ -1,0 +1,477 @@
+<?php
+/**
+ * BUILD-TIME ASSERTION: no staged wp.org file may resolve the self-updater
+ * class outside a guard.
+ *
+ * `make agent-zip-wporg` physically removes
+ * includes/support/class-update-checker.php from the distribution build
+ * (Guideline 8). Several files that DO survive that rsync still name
+ * WPMgr\Agent\Support\UpdateChecker, and that is fine as long as the naming
+ * never causes the plugin's autoloader to go looking for the missing file:
+ *
+ *   ALLOWED anywhere
+ *     `use WPMgr\Agent\Support\UpdateChecker;`   an import, never resolved
+ *     `?UpdateChecker $x` / `: ?UpdateChecker`   a nullable type declaration,
+ *                                               never resolved while the value
+ *                                               is null, which it always is in
+ *                                               the wp.org build
+ *
+ *   ALLOWED only inside a guard
+ *     `new UpdateChecker(...)`  `UpdateChecker::CONST`  `UpdateChecker::method()`
+ *     `instanceof UpdateChecker` and every other executable naming. Each of
+ *     these is a hard class fetch that triggers the autoloader on EVERY request
+ *     of EVERY wp.org install, producing:
+ *       Fatal error: Uncaught Error: Class "WPMgr\Agent\Support\UpdateChecker" not found
+ *
+ * A guard is an `if` whose condition tests WPMGR_WPORG_BUILD, or tests the
+ * updateChecker collaborator against null.
+ *
+ * WHY A BUILD-TIME ASSERT AND NOT ONLY A TEST
+ * -------------------------------------------
+ * The risky line sits among roughly a dozen visually identical unconditional
+ * add_action() calls, so dedenting it out of the guard is a plausible refactor.
+ * `wp plugin check` is static analysis and never executes the plugin, so it
+ * cannot catch it. This assert runs against the ARTIFACT THAT ACTUALLY SHIPS,
+ * which is the strongest place to check. It mirrors the SELF_PLUGIN_FOLDER
+ * assertion the same Makefile target already performs.
+ *
+ * Usage:
+ *   php tools/assert-wporg-updatechecker-guard.php <staged-tree-dir>
+ *
+ * Exit codes:
+ *   0  The staged tree is safe.
+ *   1  A violation was found, or the tree does not look like a staged wp.org build.
+ *
+ * The analyser is also required directly by the PHPUnit companion
+ * (tests/AgentSelfUpdateWporgBuildTest.php) so the source tree and the staged
+ * artifact are judged by exactly one implementation.
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tools;
+
+/**
+ * Tokenizes PHP source and reports every executable naming of the self-updater
+ * class that is not wrapped in a guard.
+ */
+final class WporgUpdateCheckerGuard
+{
+    /** Short class name of the self-updater. */
+    public const CLASS_NAME = 'UpdateChecker';
+
+    /** Path, relative to a plugin root, of the file the wp.org build removes. */
+    public const EXCLUDED_FILE = 'includes/support/class-update-checker.php';
+
+    /**
+     * Analyse one PHP source string.
+     *
+     * @param string $source PHP source code.
+     * @return array{violations:list<array{line:int,context:string}>,resolving:int,allowed:int}
+     *         `resolving` counts executable namings that ARE correctly guarded;
+     *         `allowed` counts imports and nullable type declarations.
+     */
+    public static function analyse(string $source): array
+    {
+        $tokens = token_get_all($source);
+        $count  = count($tokens);
+
+        $depth      = 0;
+        $braceStack = [];   // one entry per open brace: true when it is a guard block.
+        $guardAt    = -1;   // token index of the `{` that opens a guard block.
+        $guardValue = false;
+
+        $violations = [];
+        $resolving  = 0;
+        $allowed    = 0;
+
+        for ($i = 0; $i < $count; $i++) {
+            $token = $tokens[$i];
+
+            // ---- brace bookkeeping -------------------------------------------
+            if ($token === '{') {
+                $depth++;
+                $braceStack[] = ($guardAt === $i) ? $guardValue : false;
+                if ($guardAt === $i) {
+                    $guardAt    = -1;
+                    $guardValue = false;
+                }
+                continue;
+            }
+            if (is_array($token) && ($token[0] === T_CURLY_OPEN || $token[0] === T_DOLLAR_OPEN_CURLY_BRACES)) {
+                // String interpolation opens a brace that a plain '}' closes;
+                // count it so the stack stays balanced.
+                $depth++;
+                $braceStack[] = false;
+                continue;
+            }
+            if ($token === '}') {
+                array_pop($braceStack);
+                $depth--;
+                continue;
+            }
+
+            if (!is_array($token)) {
+                continue;
+            }
+
+            // ---- remember the condition of an `if` that opens a block --------
+            if ($token[0] === T_IF || $token[0] === T_ELSEIF) {
+                $open = self::nextSignificant($tokens, $i);
+                if ($open === -1 || $tokens[$open] !== '(') {
+                    continue;
+                }
+                $close = self::matchParen($tokens, $open);
+                if ($close === -1) {
+                    continue;
+                }
+                $brace = self::nextSignificant($tokens, $close);
+                if ($brace === -1 || $tokens[$brace] !== '{') {
+                    // A braceless `if` cannot contain anything, so nothing to arm.
+                    continue;
+                }
+                $guardAt    = $brace;
+                $guardValue = self::isGuardCondition(self::text($tokens, $open, $close));
+                continue;
+            }
+
+            // ---- the naming itself -------------------------------------------
+            if (!self::namesTheClass($token)) {
+                continue;
+            }
+
+            $kind = self::classifyNaming($tokens, $i);
+            if ($kind !== 'resolving') {
+                $allowed++;
+                continue;
+            }
+
+            if (in_array(true, $braceStack, true)) {
+                $resolving++;
+                continue;
+            }
+
+            $violations[] = [
+                'line'    => (int) $token[2],
+                'context' => self::lineOf($source, (int) $token[2]),
+            ];
+        }
+
+        return [
+            'violations' => $violations,
+            'resolving'  => $resolving,
+            'allowed'    => $allowed,
+        ];
+    }
+
+    /**
+     * Does this token name the self-updater class?
+     *
+     * Comments, doc blocks and quoted strings are different token types, so
+     * prose that merely mentions the class and the deliberately string-keyed
+     * class name inside the command shell are both invisible here, which is
+     * exactly right: an autoloader never sees either.
+     *
+     * @param array{0:int,1:string,2:int} $token Tokenizer token.
+     * @return bool
+     */
+    private static function namesTheClass(array $token): bool
+    {
+        $types = [T_STRING];
+        if (defined('T_NAME_QUALIFIED')) {
+            $types[] = T_NAME_QUALIFIED;
+        }
+        if (defined('T_NAME_FULLY_QUALIFIED')) {
+            $types[] = T_NAME_FULLY_QUALIFIED;
+        }
+        if (!in_array($token[0], $types, true)) {
+            return false;
+        }
+
+        $text = $token[1];
+
+        return $text === self::CLASS_NAME || str_ends_with($text, '\\' . self::CLASS_NAME);
+    }
+
+    /**
+     * Classify one naming as 'import', 'nullable-type' or 'resolving'.
+     *
+     * Anything that is not provably one of the first two is treated as
+     * resolving. The assertion is deliberately pessimistic: a new syntax it
+     * does not recognise fails the build rather than shipping the fatal.
+     *
+     * @param list<array{0:int,1:string,2:int}|string> $tokens Full token list.
+     * @param int                                      $index  Index of the naming.
+     * @return string
+     */
+    private static function classifyNaming(array $tokens, int $index): string
+    {
+        $prev = self::prevSignificant($tokens, $index);
+        if ($prev === -1) {
+            return 'resolving';
+        }
+
+        // `?UpdateChecker` in a property, parameter or return type. The class is
+        // not fetched while the value is null.
+        if ($tokens[$prev] === '?') {
+            return 'nullable-type';
+        }
+
+        // `use WPMgr\Agent\Support\UpdateChecker;` (also the multi-name form).
+        if (self::statementStartsWithUse($tokens, $index)) {
+            return 'import';
+        }
+
+        return 'resolving';
+    }
+
+    /**
+     * Walk back to the start of the statement containing $index and report
+     * whether its first significant token is `use`.
+     *
+     * @param list<array{0:int,1:string,2:int}|string> $tokens Full token list.
+     * @param int                                      $index  Index inside the statement.
+     * @return bool
+     */
+    private static function statementStartsWithUse(array $tokens, int $index): bool
+    {
+        for ($i = $index - 1; $i >= 0; $i--) {
+            $token = $tokens[$i];
+            if ($token === ';' || $token === '{' || $token === '}') {
+                break;
+            }
+            if (is_array($token) && $token[0] === T_OPEN_TAG) {
+                break;
+            }
+            if (self::isSignificant($token)) {
+                $first = $token;
+            }
+        }
+
+        return isset($first) && is_array($first) && $first[0] === T_USE;
+    }
+
+    /**
+     * Is this condition text a wp.org build guard?
+     *
+     * @param string $condition Raw source of the `if` condition, parens included.
+     * @return bool
+     */
+    private static function isGuardCondition(string $condition): bool
+    {
+        if (str_contains($condition, 'WPMGR_WPORG_BUILD')) {
+            return true;
+        }
+
+        return str_contains($condition, 'updateChecker') && str_contains($condition, 'null');
+    }
+
+    // -------------------------------------------------------------------------
+    // Token helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * @param array{0:int,1:string,2:int}|string $token Tokenizer token.
+     * @return bool
+     */
+    private static function isSignificant($token): bool
+    {
+        if (!is_array($token)) {
+            return true;
+        }
+
+        return !in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true);
+    }
+
+    /**
+     * @param list<array{0:int,1:string,2:int}|string> $tokens Full token list.
+     * @param int                                      $from   Index to search after.
+     * @return int Index of the next significant token, or -1.
+     */
+    private static function nextSignificant(array $tokens, int $from): int
+    {
+        $count = count($tokens);
+        for ($i = $from + 1; $i < $count; $i++) {
+            if (self::isSignificant($tokens[$i])) {
+                return $i;
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * @param list<array{0:int,1:string,2:int}|string> $tokens Full token list.
+     * @param int                                      $from   Index to search before.
+     * @return int Index of the previous significant token, or -1.
+     */
+    private static function prevSignificant(array $tokens, int $from): int
+    {
+        for ($i = $from - 1; $i >= 0; $i--) {
+            if (self::isSignificant($tokens[$i])) {
+                return $i;
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * @param list<array{0:int,1:string,2:int}|string> $tokens Full token list.
+     * @param int                                      $open   Index of the `(`.
+     * @return int Index of the matching `)`, or -1.
+     */
+    private static function matchParen(array $tokens, int $open): int
+    {
+        $count = count($tokens);
+        $level = 0;
+        for ($i = $open; $i < $count; $i++) {
+            if ($tokens[$i] === '(') {
+                $level++;
+            } elseif ($tokens[$i] === ')') {
+                $level--;
+                if ($level === 0) {
+                    return $i;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * @param list<array{0:int,1:string,2:int}|string> $tokens Full token list.
+     * @param int                                      $from   First index (inclusive).
+     * @param int                                      $to     Last index (inclusive).
+     * @return string Raw source text of the range.
+     */
+    private static function text(array $tokens, int $from, int $to): string
+    {
+        $out = '';
+        for ($i = $from; $i <= $to; $i++) {
+            $out .= is_array($tokens[$i]) ? $tokens[$i][1] : $tokens[$i];
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param string $source PHP source code.
+     * @param int    $line   1-based line number.
+     * @return string Trimmed source line, for the failure message.
+     */
+    private static function lineOf(string $source, int $line): string
+    {
+        $lines = explode("\n", $source);
+
+        return trim($lines[$line - 1] ?? '');
+    }
+}
+
+// -----------------------------------------------------------------------------
+// CLI entry point. Skipped when the file is merely required by the test suite.
+// -----------------------------------------------------------------------------
+
+if (PHP_SAPI !== 'cli' || !isset($argv[0]) || realpath($argv[0]) !== realpath(__FILE__)) {
+    return;
+}
+
+$stagedRoot = $argv[1] ?? '';
+if ($stagedRoot === '' || !is_dir($stagedRoot)) {
+    fwrite(STDERR, "assert-wporg-updatechecker-guard: usage: php tools/assert-wporg-updatechecker-guard.php <staged-tree-dir>\n");
+    exit(1);
+}
+$stagedRoot = rtrim($stagedRoot, '/');
+
+// Premise 1: the staged tree really is a wp.org build, i.e. the self-updater
+// source is gone. Without this the guard assertion below would be meaningless.
+if (file_exists($stagedRoot . '/' . WporgUpdateCheckerGuard::EXCLUDED_FILE)) {
+    fwrite(
+        STDERR,
+        "assert-wporg-updatechecker-guard: FAILED. " . WporgUpdateCheckerGuard::EXCLUDED_FILE
+        . " is still present in the staged tree, so this is not a wp.org build. Check the rsync excludes in the agent-zip-wporg target.\n"
+    );
+    exit(1);
+}
+
+$pluginFile = $stagedRoot . '/includes/class-plugin.php';
+if (!is_file($pluginFile)) {
+    fwrite(STDERR, "assert-wporg-updatechecker-guard: FAILED. includes/class-plugin.php is missing from the staged tree.\n");
+    exit(1);
+}
+
+// Sweep every staged PHP file outside vendor/: any file that survives the rsync
+// can introduce the fatal, not just class-plugin.php.
+$iterator = new \RecursiveIteratorIterator(
+    new \RecursiveDirectoryIterator($stagedRoot, \FilesystemIterator::SKIP_DOTS)
+);
+
+$failed         = false;
+$scanned        = 0;
+$guardedTotal   = 0;
+$pluginResolved = 0;
+
+/** @var \SplFileInfo $file */
+foreach ($iterator as $file) {
+    if (!$file->isFile() || $file->getExtension() !== 'php') {
+        continue;
+    }
+
+    $path = $file->getPathname();
+    if (str_contains($path, '/vendor/') || str_contains($path, '/node_modules/')) {
+        continue;
+    }
+
+    $source = file_get_contents($path);
+    if ($source === false) {
+        fwrite(STDERR, "assert-wporg-updatechecker-guard: FAILED. Could not read {$path}.\n");
+        exit(1);
+    }
+
+    if (!str_contains($source, WporgUpdateCheckerGuard::CLASS_NAME)) {
+        $scanned++;
+        continue;
+    }
+
+    $report = WporgUpdateCheckerGuard::analyse($source);
+    $scanned++;
+    $guardedTotal += $report['resolving'];
+
+    $relative = ltrim(substr($path, strlen($stagedRoot)), '/');
+    if ($relative === 'includes/class-plugin.php') {
+        $pluginResolved = $report['resolving'];
+    }
+
+    foreach ($report['violations'] as $violation) {
+        $failed = true;
+        fwrite(
+            STDERR,
+            "assert-wporg-updatechecker-guard: FAILED. {$relative}:{$violation['line']} resolves the self-updater class"
+            . " outside a WPMGR_WPORG_BUILD / updateChecker-not-null guard:\n"
+            . "    {$violation['context']}\n"
+            . "  The wp.org build ships no " . WporgUpdateCheckerGuard::EXCLUDED_FILE . ", so this line would raise\n"
+            . "  Fatal error: Uncaught Error: Class \"WPMgr\\Agent\\Support\\UpdateChecker\" not found\n"
+            . "  on every request of every wp.org install. Move it back inside the guard.\n"
+        );
+    }
+}
+
+if ($failed) {
+    exit(1);
+}
+
+// Premise 2: class-plugin.php must still carry at least one guarded resolving
+// reference. If it carries none the assertion above has quietly become
+// vacuous, which is itself a regression in the check.
+if ($pluginResolved < 1) {
+    fwrite(
+        STDERR,
+        "assert-wporg-updatechecker-guard: FAILED. includes/class-plugin.php names the self-updater nowhere in"
+        . " executable code, so this assertion no longer proves anything. If the self-update wiring genuinely moved,"
+        . " update this tool along with it.\n"
+    );
+    exit(1);
+}
+
+echo "assert-wporg-updatechecker-guard: OK ({$scanned} staged PHP files scanned, {$guardedTotal} guarded self-updater references, 0 unguarded)\n";
+exit(0);

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.97
+ * Version:           0.61.98
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.97');
+define('WPMGR_AGENT_VERSION', '0.61.98');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -358,8 +358,7 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// where org is a tenant slug or name. Recreates a deleted user (active +
 	// verified), attaches it to the EXISTING org as owner, and logs a one-time
 	// set-password link. Use this to recover an account whose org + sites are
-	// intact but whose user row was deleted. Idempotent. REMOVE the env after use —
-	// it re-mints a link on every boot otherwise.
+	// intact but whose user row was deleted. Idempotent. REMOVE the env after use, // it re-mints a link on every boot otherwise.
 	if raw := os.Getenv("WPMGR_RECOVER_ACCOUNTS"); raw != "" {
 		rcBaseURL := strings.TrimRight(os.Getenv("WPMGR_PUBLIC_BASE_URL"), "/")
 		for _, entry := range strings.Split(raw, ",") {
@@ -598,8 +597,7 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// it sees exactly the providers billingSvc itself would use) and the
 	// SAME session Redis pool as the entitlements cache (a distinct
 	// "pricing:" key prefix keeps them from colliding). Always CONSTRUCTED
-	// (cheap, stateless) but only MOUNTED when hosted billing is enabled —
-	// same nil/non-nil split as billingH/billingWebhookH below.
+	// (cheap, stateless) but only MOUNTED when hosted billing is enabled, // same nil/non-nil split as billingH/billingWebhookH below.
 	pricingSvc := pricing.NewService(billingRegistry, redisPool, logger)
 	pricingH := pricing.NewHandler(pricingSvc)
 
@@ -684,8 +682,7 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// GH #208 Bug 2: a real update is synchronous and heavy on the agent (a
 	// mandatory pre-update snapshot + download + extract + core/plugin/theme
 	// DB migration, all inline in one request) and routinely exceeds the
-	// snappy 30s Update.HTTPTimeout the shared `commander`/`ssrfClient` uses —
-	// driving a spurious CP-recorded Failed even though the agent actually
+	// snappy 30s Update.HTTPTimeout the shared `commander`/`ssrfClient` uses, // driving a spurious CP-recorded Failed even though the agent actually
 	// finished. Mirror the backup (:729-733) and media (:1219-1223) dedicated
 	// commander pattern via buildUpdateApplyCommander: build a SEPARATE
 	// SSRF-hardened client with a longer per-attempt cap
@@ -715,6 +712,12 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// signing key (it only reads/writes update_tasks), and reaping is itself the
 	// backstop for MF-1 (the m88 migration's pre-dedup) going forward.
 	updateReaperWorker := update.NewReaperWorker(updateWorker)
+	// Beat 3 of the agent self-update protocol: the poll that waits for the
+	// upgraded agent to report its new version. Always registered (it shares
+	// updateWorker's repo/hub/audit/logger and needs nothing of its own), but
+	// no job of this kind is ever inserted while the channel is disabled,
+	// because nothing dispatches beat 1.
+	updateAgentConfirmWorker := update.NewAgentConfirmWorker(updateWorker)
 	// Updates feature (Track B): the refresh-inventory worker dispatches signed
 	// CP->agent commands to re-pull a site's inventory. It satisfies River's
 	// JobArgs interface so the per-tenant queue shard bounds its concurrency
@@ -1665,25 +1668,26 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	vulnAlertDispatchWorker := vuln.NewAlertDispatchWorker(nil /*svc: wired below*/, logger)
 
 	riverClient, err := startRiver(ctx, pool.Pool, logger, riverDeps{
-		healthChecker:          healthChecker,
-		healthInterval:         cfg.Agent.HealthInterval,
-		siteSweepWorker:        siteSweepWorker,
-		siteEventPruneWorker:   siteEventPruneWorker,
-		updateWorker:           updateWorker,
-		updateReaperWorker:     updateReaperWorker,
-		refreshWorker:          refreshWorker,
-		perTenantParallelism:   cfg.Update.PerTenantParallelism,
-		backupWorker:           backupWorker,
-		restoreWorker:          restoreWorker,
-		gcWorker:               gcWorker,
-		scheduleWorker:         scheduleWorker,
-		progressWatchdog:       progressWatchdog,
-		sqlInspectLegacyWorker: sqlInspectLegacyWorker,
-		scheduleInterval:       cfg.Backup.ScheduleInterval,
-		gcInterval:             cfg.Backup.GCInterval,
-		uptimeWorker:           uptimeWorker,
-		probeInterval:          cfg.Uptime.ProbeInterval,
-		phpErrorsGCWorker:      phpErrorsGCWorker,
+		healthChecker:            healthChecker,
+		healthInterval:           cfg.Agent.HealthInterval,
+		siteSweepWorker:          siteSweepWorker,
+		siteEventPruneWorker:     siteEventPruneWorker,
+		updateWorker:             updateWorker,
+		updateReaperWorker:       updateReaperWorker,
+		updateAgentConfirmWorker: updateAgentConfirmWorker,
+		refreshWorker:            refreshWorker,
+		perTenantParallelism:     cfg.Update.PerTenantParallelism,
+		backupWorker:             backupWorker,
+		restoreWorker:            restoreWorker,
+		gcWorker:                 gcWorker,
+		scheduleWorker:           scheduleWorker,
+		progressWatchdog:         progressWatchdog,
+		sqlInspectLegacyWorker:   sqlInspectLegacyWorker,
+		scheduleInterval:         cfg.Backup.ScheduleInterval,
+		gcInterval:               cfg.Backup.GCInterval,
+		uptimeWorker:             uptimeWorker,
+		probeInterval:            cfg.Uptime.ProbeInterval,
+		phpErrorsGCWorker:        phpErrorsGCWorker,
 		// S3 scan workers (nil when signing key is not configured).
 		scanRunWorker:    scanWorker,
 		scanHashGCWorker: scanHashGCWorker,
@@ -2341,6 +2345,45 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	}
 	agentReleaseH := agentrelease.NewHandler(agentrelease.NewService(agentrelease.NewRepo(pool), agentReleaseReader))
 
+	// The agent's OWN upgrade channel (three-beat arm/apply/confirm, staged in
+	// gated waves). SHIPS DARK: cfg.Update.AgentSelfUpdateEnabled defaults to
+	// false, so wiring it here changes nothing until an operator sets
+	// WPMGR_UPDATE_AGENT_SELF_UPDATE_ENABLED. The flag is passed to BOTH the
+	// service (so an operator gets an immediate refusal instead of a run that
+	// halts on its first task) and the worker (which is the authoritative
+	// pre-dispatch check, and the only one that can stop a run already in
+	// flight). A missing signing key leaves selfUpdateCmd nil, which disables
+	// the channel exactly as the flag does, an unsigned self-update command
+	// must never be sent.
+	var selfUpdateCmd update.AgentSelfUpdateCommander
+	if suc, ok := commander.(update.AgentSelfUpdateCommander); ok {
+		selfUpdateCmd = suc
+	}
+	updateSvc.SetAgentSelfUpdate(cfg.Update.AgentSelfUpdateEnabled, agentReleaseReader)
+	updateWorker.SetAgentSelfUpdate(update.AgentSelfUpdateDeps{
+		Enabled:  cfg.Update.AgentSelfUpdateEnabled,
+		Cmd:      selfUpdateCmd,
+		Versions: sitesLookup,
+		Waves:    update.NewAgentWaveRepo(pool),
+		Tasks:    updateEnqueuer,
+		Confirms: updateEnqueuer,
+		// The SAME published-version reader the service plans against, so an
+		// agent answering "up_to_date" is checked against what this control
+		// plane actually publishes instead of being believed. A reverted or
+		// missing latest.json makes every site answer that way, and believing
+		// it would complete a fleet-wide rollout 100% green with not one agent
+		// moved (see update.Worker.upToDate).
+		Releases: agentReleaseReader,
+		// The agent's own account of its last apply beat, replayed on its
+		// signed metadata push. Used only to explain a confirmation TIMEOUT,
+		// where it is the single thing that separates "the cron run never
+		// happened" from "the cron run happened and the upgrade failed".
+		Results: sitesLookup,
+	})
+	if cfg.Update.AgentSelfUpdateEnabled {
+		logger.Warn("agent self-update channel is ENABLED: agent upgrades will be dispatched in gated waves")
+	}
+
 	// ADR-056 Phase 3 — wire two-factor authentication into the auth handler.
 	// TOTPFactor and WebAuthnFactor are stateless and shared across goroutines.
 	// The same siteDestAgeID (age X25519) used for SMTP credential encryption
@@ -2813,19 +2856,22 @@ type riverDeps struct {
 	updateWorker         *update.Worker
 	// #131 follow-up — periodic reaper for update_tasks stuck in
 	// pending/running past the stale-task threshold (always wired).
-	updateReaperWorker     *update.ReaperWorker
-	refreshWorker          *update.RefreshInventoryWorker
-	perTenantParallelism   int
-	backupWorker           *backup.BackupWorker
-	restoreWorker          *backup.RestoreWorker
-	gcWorker               *backup.GCWorker
-	scheduleWorker         *backup.ScheduleWorker
-	progressWatchdog       *backup.ProgressWatchdogWorker
-	sqlInspectLegacyWorker *backup.SqlInspectLegacyWorker
-	scheduleInterval       time.Duration
-	gcInterval             time.Duration
-	uptimeWorker           *uptime.ProbeWorker
-	probeInterval          time.Duration
+	updateReaperWorker *update.ReaperWorker
+	// Beat 3 of the agent self-update protocol (always registered; no job of
+	// this kind is inserted while the channel's kill switch is off).
+	updateAgentConfirmWorker *update.AgentConfirmWorker
+	refreshWorker            *update.RefreshInventoryWorker
+	perTenantParallelism     int
+	backupWorker             *backup.BackupWorker
+	restoreWorker            *backup.RestoreWorker
+	gcWorker                 *backup.GCWorker
+	scheduleWorker           *backup.ScheduleWorker
+	progressWatchdog         *backup.ProgressWatchdogWorker
+	sqlInspectLegacyWorker   *backup.SqlInspectLegacyWorker
+	scheduleInterval         time.Duration
+	gcInterval               time.Duration
+	uptimeWorker             *uptime.ProbeWorker
+	probeInterval            time.Duration
 	// S1.1 (D) — PHP-error retention GC. Always non-nil (wired unconditionally).
 	phpErrorsGCWorker *diagnostics.ErrorsGCWorker
 	// S3 — Malware / File-Integrity Scan workers (nil when signing key empty).
@@ -2913,6 +2959,9 @@ func startRiver(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger, d 
 	river.AddWorker(workers, d.updateWorker)
 	if d.updateReaperWorker != nil {
 		river.AddWorker(workers, d.updateReaperWorker)
+	}
+	if d.updateAgentConfirmWorker != nil {
+		river.AddWorker(workers, d.updateAgentConfirmWorker)
 	}
 	if d.refreshWorker != nil {
 		river.AddWorker(workers, d.refreshWorker)
@@ -3386,8 +3435,7 @@ func startRiver(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger, d 
 		))
 	}
 
-	// GH #152 part 2 — daily org grace-window purge sweep. RunOnStart: false —
-	// unlike the billing reconcile above, missing one day here has no user-
+	// GH #152 part 2, daily org grace-window purge sweep. RunOnStart: false, // unlike the billing reconcile above, missing one day here has no user-
 	// visible cost (the org is already fully hidden from every read path the
 	// instant it was soft-deleted; only the destructive purge is delayed by
 	// up to ~24h past the configured grace window), so there is no reason to

--- a/apps/api/cmd/wpmgr/siteadapter.go
+++ b/apps/api/cmd/wpmgr/siteadapter.go
@@ -88,6 +88,54 @@ func (l *siteLookup) GetSiteInfo(ctx context.Context, tenantID, siteID uuid.UUID
 	return toSiteInfo(s), nil
 }
 
+// AgentVersion returns the agent version the site last reported over its
+// signed metadata push. It is the ONLY signal the agent self-update channel
+// accepts as proof an upgrade landed (update.AgentConfirmWorker): the new code
+// speaking for itself, over a channel the old code cannot fake once it has
+// been replaced. A not-found site propagates as a domain.NotFound error so the
+// confirmation worker can tell "this site is gone" from "this site has not
+// reported yet".
+func (l *siteLookup) AgentVersion(ctx context.Context, tenantID, siteID uuid.UUID) (string, error) {
+	s, err := l.svc.Get(ctx, tenantID, siteID)
+	if err != nil {
+		return "", err
+	}
+	return s.AgentVersion, nil
+}
+
+// AgentSelfUpdateResult returns the agent's own account of its last self-update
+// apply beat, as replayed on the site's signed metadata push and stored in the
+// site's inventory blob. It satisfies update.AgentApplyResultLookup.
+//
+// The apply runs in a WordPress cron request that has no control-plane response
+// to ride on, so this record is the only way a FAILED or EXPIRED apply is ever
+// heard about. The confirmation worker uses it to explain a timeout: without it
+// "the cron run never happened" and "the cron run happened and the upgrade
+// failed" are the same silence.
+//
+// Best-effort throughout: a site that never staged an upgrade, and an agent old
+// enough not to send the record, both return false with no error.
+func (l *siteLookup) AgentSelfUpdateResult(ctx context.Context, tenantID, siteID uuid.UUID) (update.AgentApplyResult, bool, error) {
+	s, err := l.svc.Get(ctx, tenantID, siteID)
+	if err != nil {
+		return update.AgentApplyResult{}, false, err
+	}
+	r := s.ParsedAgentSelfUpdate()
+	if r == nil {
+		return update.AgentApplyResult{}, false, nil
+	}
+	out := update.AgentApplyResult{
+		Status:      r.Status,
+		FromVersion: r.FromVersion,
+		ToVersion:   r.ToVersion,
+		Detail:      r.Detail,
+	}
+	if r.At > 0 {
+		out.At = time.Unix(r.At, 0).UTC()
+	}
+	return out, true, nil
+}
+
 func (l *siteLookup) ListSiteInfoByTag(ctx context.Context, tenantID uuid.UUID, tag string) ([]update.SiteInfo, error) {
 	sites, err := l.svc.List(ctx, site.ListInput{TenantID: tenantID, AnyTags: []string{tag}, Limit: 200, Offset: 0})
 	if err != nil {
@@ -510,11 +558,16 @@ func toSiteInfo(s site.Site) update.SiteInfo {
 		comps = append(comps, toUpdateComponent(update.TargetTheme, t))
 	}
 	info := update.SiteInfo{
-		ID:         s.ID,
-		URL:        s.URL,
-		Name:       s.Name,
-		Enrolled:   s.EnrolledAt != nil,
-		Components: comps,
+		ID:       s.ID,
+		URL:      s.URL,
+		Name:     s.Name,
+		Enrolled: s.EnrolledAt != nil,
+		// Carried straight from the site row, NOT from the component
+		// inventory: the agent self-update planner compares this against the
+		// published release version and must not depend on the site's own
+		// (deliberately suppressed) self-update advisory.
+		AgentVersion: s.AgentVersion,
+		Components:   comps,
 	}
 	// GH #211: drop a same-version phantom core-update advisory here too
 	// (defense-in-depth; the update package's planTasks authority,

--- a/apps/api/db/query/updates.sql
+++ b/apps/api/db/query/updates.sql
@@ -80,8 +80,17 @@ WHERE id = $1 AND tenant_id = $2
 RETURNING *;
 
 -- name: FinishUpdateTask :one
--- Records a terminal task state (succeeded|failed|rolled_back|skipped) with the
--- resolved versions and any detail/error. Tenant-scoped by id+tenant_id.
+-- Records a terminal task state (succeeded|failed|rolled_back|skipped|cancelled)
+-- with the resolved versions and any detail/error. Tenant-scoped by
+-- id+tenant_id.
+--
+-- The status precondition is what makes a terminal state FINAL. Without it, a
+-- worker that was already in flight when its run was halted comes back later
+-- and overwrites 'cancelled' with 'succeeded', so the kill switch appears to
+-- have stopped a rollout that in fact reported itself as a success. Only a task
+-- still open (pending|running) may be finished; a caller that matches no row
+-- must read the row back and leave the recorded outcome alone (see
+-- pgRepo.FinishTask / ErrTaskNotOpen).
 UPDATE update_tasks
 SET status = $3,
     from_version = $4,
@@ -91,6 +100,29 @@ SET status = $3,
     finished_at = now(),
     updated_at = now()
 WHERE id = $1 AND tenant_id = $2
+  AND status IN ('pending', 'running')
+RETURNING *;
+
+-- name: CancelPendingUpdateTask :one
+-- Cancels ONE not-yet-dispatched task as part of halting its run.
+--
+-- The 'pending' precondition is the whole point, and it is enforced here rather
+-- than in Go so it is atomic against a worker claiming the same row. A halt may
+-- only cancel tasks nothing was ever sent for: update_tasks.status='cancelled'
+-- means exactly "nothing was ever sent to this site". A RUNNING task has
+-- already had its command delivered and (for an agent self-update) a cron event
+-- spawned on the site, so cancelling it would both record a falsehood and make
+-- the control plane stop listening for the outcome, at the exact moment an
+-- operator hit the kill switch and most needs to know. Running tasks are left
+-- to be resolved by their own confirmation job; the run is halted, so no
+-- further wave can open behind them.
+UPDATE update_tasks
+SET status = 'cancelled',
+    detail = $3,
+    finished_at = now(),
+    updated_at = now()
+WHERE id = $1 AND tenant_id = $2
+  AND status = 'pending'
 RETURNING *;
 
 -- name: SetUpdateRunStatus :one

--- a/apps/api/internal/agent/handler.go
+++ b/apps/api/internal/agent/handler.go
@@ -108,6 +108,32 @@ type metadataDTO struct {
 	Disk       *diskDTO      `json:"disk,omitempty"`
 	UserCount  *int          `json:"user_count,omitempty"`
 	AdminCount *int          `json:"admin_count,omitempty"`
+
+	// AgentSelfUpdate is the agent's own account of its last self-update APPLY
+	// beat. Optional; only ever present on a site that actually staged one, and
+	// never sent by an agent old enough to predate the channel.
+	//
+	// It is the only way a FAILED apply reaches the control plane at all: the
+	// apply runs inside a cron request that has no CP response to ride on, so
+	// if it fails, expires, or finds itself already applied, the next metadata
+	// push is the sole carrier of that fact. Without it a confirmation timeout
+	// is indistinguishable between "the cron run never happened" and "the cron
+	// run happened and the upgrade failed", which are different incidents with
+	// different fixes.
+	AgentSelfUpdate *agentSelfUpdateResultDTO `json:"agent_self_update,omitempty"`
+}
+
+// agentSelfUpdateResultDTO is the apply-beat outcome the agent records on disk
+// and replays on its next metadata push. Every field is flex-decoded and
+// optional except the status, which is what makes the record meaningful at all.
+type agentSelfUpdateResultDTO struct {
+	Status      flexString `json:"status"`
+	FromVersion flexString `json:"from_version"`
+	ToVersion   flexString `json:"to_version"`
+	Detail      flexString `json:"detail"`
+	// At is the unix timestamp the agent stamped the record with. Decoded into
+	// a pointer so a missing field stays distinguishable from a zero one.
+	At *int64 `json:"at,omitempty"`
 }
 
 // hostFlagsDTO mirrors the defined()-based hosting fingerprint the agent
@@ -244,6 +270,17 @@ func (d metadataDTO) toMetadata() Metadata {
 	if d.AdminCount != nil {
 		m.AdminCount = *d.AdminCount
 	}
+	// The agent's account of its last apply beat. A record with no status says
+	// nothing, so it is dropped here rather than persisted as an empty shell.
+	if d.AgentSelfUpdate != nil && strings.TrimSpace(string(d.AgentSelfUpdate.Status)) != "" {
+		m.AgentSelfUpdate = &AgentSelfUpdateResult{
+			Status:      string(d.AgentSelfUpdate.Status),
+			FromVersion: string(d.AgentSelfUpdate.FromVersion),
+			ToVersion:   string(d.AgentSelfUpdate.ToVersion),
+			Detail:      string(d.AgentSelfUpdate.Detail),
+			At:          int64PtrOrZero(d.AgentSelfUpdate.At),
+		}
+	}
 	return m
 }
 
@@ -300,6 +337,25 @@ type Metadata struct {
 	Disk       *Disk
 	UserCount  int
 	AdminCount int
+	// AgentSelfUpdate is the agent's own account of its last self-update apply
+	// beat. nil when the site never staged one, or when the agent predates the
+	// channel entirely.
+	AgentSelfUpdate *AgentSelfUpdateResult
+}
+
+// AgentSelfUpdateResult is the apply-beat outcome an agent replays on its next
+// metadata push. Status is one of applied|failed|expired|already_applied; it is
+// carried as a plain string rather than an enum so a status a newer agent
+// introduces reaches an operator verbatim instead of being silently dropped by
+// an older control plane.
+type AgentSelfUpdateResult struct {
+	Status      string
+	FromVersion string
+	ToVersion   string
+	Detail      string
+	// At is the unix timestamp the agent stamped the record with; 0 when it did
+	// not say.
+	At int64
 }
 
 // Component is one installed plugin/theme. AvailableUpdate is set when the
@@ -467,8 +523,7 @@ func (h *Handler) metadata(c *gin.Context) {
 // connected, and returns {ok, instructions?} (e.g. ["revoke"] for a revoked
 // site). Without the lifecycle sink it falls back to the legacy liveness-only
 // Heartbeat (204). The light metadata body is accepted and decoded best-effort;
-// it is currently not persisted (the M21 migration added no column for it) —
-// see the note in the brief; the heartbeat never fails over the payload.
+// it is currently not persisted (the M21 migration added no column for it), // see the note in the brief; the heartbeat never fails over the payload.
 func (h *Handler) heartbeat(c *gin.Context) {
 	id, ok := IdentityFromContext(c.Request.Context())
 	if !ok {

--- a/apps/api/internal/agent/metadata_dto_test.go
+++ b/apps/api/internal/agent/metadata_dto_test.go
@@ -181,3 +181,73 @@ func TestMetadataDTODropsSameVersionAvailableUpdate(t *testing.T) {
 		t.Fatalf("same-version phantom core_update must be dropped: %+v", m.CoreUpdate)
 	}
 }
+
+// TestMetadataDTODecodesTheAgentSelfUpdateAdvisory pins the wire shape of the
+// agent's own account of its last self-update apply beat, exactly as
+// class-metadata-command.php builds it.
+//
+// The apply runs in a cron request that has no control-plane response to ride
+// on, so this advisory is the ONLY way a failed or expired apply is ever heard
+// about. It rides the ordinary metadata push, which means it has to decode as
+// tolerantly as everything else here and stay absent for every agent that
+// predates it.
+func TestMetadataDTODecodesTheAgentSelfUpdateAdvisory(t *testing.T) {
+	body := []byte(`{
+		"wp_version":"6.4.3",
+		"agent_version":"0.61.80",
+		"plugins":[],
+		"themes":[],
+		"agent_self_update":{
+			"status":"failed",
+			"from_version":"0.61.80",
+			"to_version":"0.62.0",
+			"detail":"Upgrader threw: could not create directory",
+			"at":1785000000
+		}
+	}`)
+	var dto metadataDTO
+	if err := json.Unmarshal(body, &dto); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	m := dto.toMetadata()
+	if m.AgentSelfUpdate == nil {
+		t.Fatal("the agent's account of its apply beat was dropped")
+	}
+	got := *m.AgentSelfUpdate
+	if got.Status != "failed" || got.FromVersion != "0.61.80" || got.ToVersion != "0.62.0" {
+		t.Fatalf("advisory not decoded: %+v", got)
+	}
+	if got.Detail != "Upgrader threw: could not create directory" {
+		t.Fatalf("the agent's own reason is the whole value of the record, got %q", got.Detail)
+	}
+	if got.At != 1785000000 {
+		t.Fatalf("at = %d, want the agent's stamp", got.At)
+	}
+}
+
+// TestMetadataDTOToleratesAnAbsentOrEmptyAgentSelfUpdateAdvisory: the record is
+// additive. An agent that never staged a self-update, and every agent that
+// predates the channel, send nothing, and a record with no status says nothing
+// and must not be persisted as an empty shell.
+func TestMetadataDTOToleratesAnAbsentOrEmptyAgentSelfUpdateAdvisory(t *testing.T) {
+	for name, body := range map[string]string{
+		"absent":       `{"wp_version":"6.4.3","plugins":[],"themes":[]}`,
+		"null":         `{"wp_version":"6.4.3","agent_self_update":null}`,
+		"empty object": `{"wp_version":"6.4.3","agent_self_update":{}}`,
+		"blank status": `{"wp_version":"6.4.3","agent_self_update":{"status":"  ","to_version":"0.62.0"}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var dto metadataDTO
+			if err := json.Unmarshal([]byte(body), &dto); err != nil {
+				t.Fatalf("decode failed: %v", err)
+			}
+			m := dto.toMetadata()
+			if m.AgentSelfUpdate != nil {
+				t.Fatalf("want no advisory, got %+v", *m.AgentSelfUpdate)
+			}
+			if m.WPVersion != "6.4.3" {
+				t.Fatalf("the rest of the push must still decode: %+v", m)
+			}
+		})
+	}
+}

--- a/apps/api/internal/agentcmd/agent_self_update_contract.go
+++ b/apps/api/internal/agentcmd/agent_self_update_contract.go
@@ -1,0 +1,159 @@
+package agentcmd
+
+import "time"
+
+// This file is the AUTHORITATIVE CP->agent command contract for the agent's
+// own self-update channel (Phase 2). The wp-agent-engineer mirrors these
+// shapes in the agent's command handler. Field names are JSON wire names; do
+// not rename without updating both sides.
+//
+// Transport, agent_self_update:
+//   POST {site_url}/wp-json/wpmgr/v1/command/agent_self_update
+//   Header: Authorization: Bearer <minted EdDSA JWT>
+//           cmd="agent_self_update", aud=<siteId>
+//   Body:   application/json, AgentSelfUpdateRequest below.
+//   Response: 200 with AgentSelfUpdateResponse; a non-200 is a transport-level
+//             failure the CP records as a failed task.
+//
+// WHY THIS IS NOT AN `update` COMMAND WITH type="plugin"
+// -----------------------------------------------------
+// Applying a normal plugin update to the agent means the plugin overwrites its
+// own files while its code is the code performing the update, inside the very
+// request that has to report the outcome. If it dies partway there is no
+// working code left to report it, and the snapshot + automatic rollback that
+// protects every other plugin update deliberately does NOT arm for the agent's
+// own directory (whatever performs the rollback is what is being replaced).
+// Recovery would need per-site filesystem access, which across a fleet is not
+// recovery at all. The control plane therefore refuses the agent as an update
+// target outright (see internal/agentplugin) and ships agent upgrades over
+// this separate three-beat protocol instead.
+//
+// THE THREE-BEAT PROTOCOL
+// -----------------------
+// BEAT 1 ARM, this command. NOTHING on disk moves. The agent refuses when it
+//   has no self-updater at all (the wordpress.org build, which ships without
+//   it) or the site is not enrolled, with status "not_eligible"; otherwise it
+//   fetches and FULLY verifies a release manifest through its existing
+//   verification chain (signature, cmd/slug/aud, iat/exp/jti replay,
+//   monotonic-iat, downgrade guard, https + host allowlist + size cap) before
+//   anything is staged. Nothing newer than what is installed yields
+//   "up_to_date". A staged record from an earlier arm that is still live yields
+//   "already_scheduled". Otherwise the agent writes a small staged record with
+//   an expiry, schedules a single cron event, spawns cron, and answers
+//   "scheduled". An arm that could not complete answers "error".
+// BEAT 2 APPLY, a SEPARATE WordPress bootstrap (the cron request) runs the
+//   upgrade. No CP response rides on that request, so a mid-copy death takes
+//   nothing down with it. There is no new download/verify/unzip code: the
+//   agent's existing upgrader hooks engage unchanged.
+// BEAT 3 CONFIRM, the ONLY trustworthy success signal is the NEW code phoning
+//   home: a signed metadata push carrying the new agent_version, which the CP
+//   observes on sites.agent_version. A "scheduled" acknowledgement is NEVER
+//   success (see update.AgentConfirmWorker). A site whose loopback cron is
+//   broken simply never reaches beat 2, which is SAFE, nothing was touched, //   and must surface as unconfirmed, never as a silent success.
+
+// AgentSelfUpdateRequest is the POST body for the `agent_self_update` command
+// (beat 1, ARM). It carries no parameters on purpose: the agent resolves and
+// verifies the target build from its own release manifest, and the control
+// plane never names a version. A CP-supplied version would be a second,
+// unverified source of truth for the one upgrade whose integrity chain must
+// not have one, and the agent's downgrade guard would refuse an older build
+// anyway. The struct is reserved for future flags.
+type AgentSelfUpdateRequest struct{}
+
+// Agent self-update ARM outcomes (agent -> CP). These five strings are the
+// WHOLE set: the agent emits nothing else, and the control plane declares
+// nothing else. A status the CP declares but the agent never sends is worse
+// than useless, it is a branch that looks handled and is dead, while the
+// status the agent DOES send falls through to a default that discards its
+// detail. Both halves pin these literals in a golden-vector test
+// (TestAgentSelfUpdateWireContractGoldenVector here,
+// AgentSelfUpdateWireContractTest on the agent side) so an edit to either half
+// fails its own suite.
+const (
+	// SelfUpdateScheduled: the manifest verified, a newer build is staged, the
+	// cron event is scheduled and cron was spawned. This is an ACKNOWLEDGEMENT,
+	// not a success: nothing has been applied yet and beat 2 may never run.
+	// Carries ToVersion and ExpiresAt.
+	SelfUpdateScheduled = "scheduled"
+	// SelfUpdateAlreadyScheduled: a staged record from a PREVIOUS arm is still
+	// live, so this arm did not need to stage anything. It carries the same
+	// ToVersion and ExpiresAt as the arm that staged it, and means the earlier
+	// arm succeeded and its upgrade is still pending. It is NOT a failure and
+	// must never halt a wave: treated exactly like SelfUpdateScheduled.
+	SelfUpdateAlreadyScheduled = "already_scheduled"
+	// SelfUpdateUpToDate: the agent's verified manifest offers nothing newer
+	// than what is installed. Nothing was staged. See the control plane's
+	// handling (update.Worker.upToDate): this is NEVER an unqualified success,
+	// because the CP only creates a task for a site it already classified as
+	// outdated, so this answer means the two disagree.
+	SelfUpdateUpToDate = "up_to_date"
+	// SelfUpdateNotEligible: this build cannot self-update (the wordpress.org
+	// build ships without a self-updater and is upgraded by the directory) or
+	// the site is not enrolled. The channel does not apply to this site at all.
+	SelfUpdateNotEligible = "not_eligible"
+	// SelfUpdateError: the arm failed, manifest fetch/verification failed, the
+	// staged record could not be written, or cron could not be scheduled.
+	// Nothing was applied. Carries a human-readable Detail, which the control
+	// plane must preserve on the task rather than recording the bare status.
+	SelfUpdateError = "error"
+)
+
+// WP-Cron modes the agent reports alongside an ARM acknowledgement. Exactly
+// two strings ride the wire. The value tells the control plane how long to wait
+// for beat 3: a site without loopback cron depends on an external scheduler
+// whose period the CP cannot see, so it is given a much wider confirmation
+// deadline rather than being declared unconfirmed while its upgrade is still
+// legitimately queued.
+const (
+	// CronModeLoopback: WordPress loopback cron is available, and the agent
+	// spawned it in beat 1. The cron request normally lands within seconds.
+	CronModeLoopback = "loopback"
+	// CronModeExternal: loopback cron is unavailable (DISABLE_WP_CRON or
+	// equivalent), so nothing the agent does can make the cron request happen;
+	// the site relies on a system scheduler running wp-cron.php on its own
+	// period, commonly every 15 minutes but sometimes hourly.
+	CronModeExternal = "external"
+	// CronModeUnknown is NOT a wire value: it is the zero value the CP sees
+	// when an agent omits the field. Treated exactly like CronModeLoopback for
+	// the deadline, the narrow window is the honest default when the CP has no
+	// evidence the site needs a wider one.
+	CronModeUnknown = ""
+)
+
+// SelfUpdateStagedTTLFloor is the timing contract between the two halves, and
+// it is load-bearing: the agent's staged record MUST outlive the control
+// plane's patience. If the record expires first, a slow site expires its own
+// stage, beat 2 finds nothing to apply, and the canary false-fails, halting a
+// rollout that was fine. So the agent's staged TTL has to comfortably exceed
+// the CP's LONGEST confirmation deadline (the external-cron window), and the CP
+// may never widen a deadline past this floor. A staged TTL shorter than the CP
+// deadline is a defect on the agent side; a CP deadline longer than this floor
+// is a defect on this side. TestStagedTTLFloorExceedsEveryConfirmDeadline and
+// update.TestConfirmDeadlinesFitTheStagedTTLFloor pin the two halves of that
+// inequality.
+const SelfUpdateStagedTTLFloor = 2 * time.Hour
+
+// AgentSelfUpdateResponse is the agent's response to the `agent_self_update`
+// command (beat 1, ARM).
+//
+//	status        one of the SelfUpdate* constants above.
+//	from_version  the agent version installed right now.
+//	to_version    the version the verified manifest points at. Set when status
+//	              is "scheduled" or "already_scheduled" (what beat 2 will
+//	              install); empty otherwise.
+//	cron_mode     one of the CronMode* constants; how beat 2 will be reached.
+//	detail        short human-readable note, surfaced verbatim to the operator
+//	              on the update task. Carries the refusal reason for
+//	              "not_eligible" and the failure reason for "error".
+//	expires_at    Unix seconds at which the staged record lapses. Set when
+//	              status is "scheduled" or "already_scheduled"; 0 otherwise.
+//	              See SelfUpdateStagedTTLFloor: it must sit beyond the
+//	              confirmation deadline the CP is about to set.
+type AgentSelfUpdateResponse struct {
+	Status      string `json:"status"`
+	FromVersion string `json:"from_version,omitempty"`
+	ToVersion   string `json:"to_version,omitempty"`
+	CronMode    string `json:"cron_mode,omitempty"`
+	Detail      string `json:"detail,omitempty"`
+	ExpiresAt   int64  `json:"expires_at,omitempty"`
+}

--- a/apps/api/internal/agentcmd/agent_self_update_contract_test.go
+++ b/apps/api/internal/agentcmd/agent_self_update_contract_test.go
@@ -1,0 +1,186 @@
+package agentcmd
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// SHARED GOLDEN VECTOR for the agent self-update beat 1 (ARM) wire contract.
+//
+// This is the Go half. The PHP half is
+// apps/agent/tests/AgentSelfUpdateWireContractTest.php and pins the SAME
+// literals. The redundancy is the point: the three defects this vector was
+// written for were status and cron_mode strings that one side believed in and
+// the other never emitted, and every one of them was invisible to both suites,
+// because each suite only ever exercised its own half's fiction. A vector each
+// side pins INDEPENDENTLY is what turns a one-sided edit into a failing suite
+// on the side that made it.
+//
+// THE CONTRACT, authoritative.
+//
+// status, exactly five strings:
+//
+//	"scheduled"          verified and staged, cron event spawned. Carries
+//	                     to_version and expires_at.
+//	"up_to_date"         the verified manifest offers nothing newer than what
+//	                     is installed.
+//	"not_eligible"       this build cannot self-update (wordpress.org build) or
+//	                     the site is not enrolled.
+//	"already_scheduled"  a staged record from a previous arm is still live.
+//	                     Carries to_version and expires_at. NOT a failure.
+//	"error"              the arm failed. Carries a human-readable detail.
+//
+// cron_mode, exactly two strings:
+//
+//	"loopback"   WordPress loopback cron is available.
+//	"external"   loopback cron is unavailable (DISABLE_WP_CRON or equivalent);
+//	             the site relies on system cron.
+//
+// "failed", "disabled" and "alternate" are NOT part of this contract. The agent
+// has never emitted any of them from beat 1.
+
+// goldenSelfUpdateStatuses is THE status vector, sorted so the comparison below
+// reads as equality rather than as a subset test.
+var goldenSelfUpdateStatuses = []string{
+	"already_scheduled",
+	"error",
+	"not_eligible",
+	"scheduled",
+	"up_to_date",
+}
+
+// goldenSelfUpdateCronModes is THE cron_mode vector. CronModeUnknown is
+// deliberately absent: it is the zero value the control plane sees when the
+// field is omitted, never a value the agent sends.
+var goldenSelfUpdateCronModes = []string{
+	"external",
+	"loopback",
+}
+
+// neverEmitted are strings a previous version of this contract declared and the
+// agent never sent. Pinned so re-introducing one fails loudly instead of
+// quietly resurrecting the mismatch.
+var neverEmitted = []string{"failed", "disabled", "alternate"}
+
+// TestAgentSelfUpdateWireContractGoldenVector pins the literals. If the
+// contract is ever widened or narrowed, this is the assertion that has to be
+// changed deliberately, in the same commit as its PHP counterpart.
+func TestAgentSelfUpdateWireContractGoldenVector(t *testing.T) {
+	declaredStatuses := []string{
+		SelfUpdateAlreadyScheduled,
+		SelfUpdateError,
+		SelfUpdateNotEligible,
+		SelfUpdateScheduled,
+		SelfUpdateUpToDate,
+	}
+	if len(declaredStatuses) != len(goldenSelfUpdateStatuses) {
+		t.Fatalf("the contract declares %d statuses, the golden vector has %d",
+			len(declaredStatuses), len(goldenSelfUpdateStatuses))
+	}
+	for i, want := range goldenSelfUpdateStatuses {
+		if declaredStatuses[i] != want {
+			t.Fatalf("status %d = %q, want %q", i, declaredStatuses[i], want)
+		}
+	}
+
+	declaredCronModes := []string{CronModeExternal, CronModeLoopback}
+	if len(declaredCronModes) != len(goldenSelfUpdateCronModes) {
+		t.Fatalf("the contract declares %d cron modes, the golden vector has %d",
+			len(declaredCronModes), len(goldenSelfUpdateCronModes))
+	}
+	for i, want := range goldenSelfUpdateCronModes {
+		if declaredCronModes[i] != want {
+			t.Fatalf("cron mode %d = %q, want %q", i, declaredCronModes[i], want)
+		}
+	}
+
+	if CronModeUnknown != "" {
+		t.Fatalf("CronModeUnknown = %q, want the empty zero value: it is the absent field, not a wire value", CronModeUnknown)
+	}
+
+	for _, ghost := range neverEmitted {
+		for _, s := range declaredStatuses {
+			if s == ghost {
+				t.Fatalf("%q is not a beat 1 status: it was removed from the contract because the agent never emitted it", ghost)
+			}
+		}
+		for _, m := range declaredCronModes {
+			if m == ghost {
+				t.Fatalf("%q is not a beat 1 cron mode: it was removed from the contract because the agent never emitted it", ghost)
+			}
+		}
+	}
+}
+
+// TestAgentSelfUpdateResponseDecodesTheWireShape pins the JSON field names
+// against a payload written by hand from the agent's own documented shape (see
+// the header of apps/agent/includes/commands/class-agent-self-update-command.php).
+// A renamed tag here would leave the control plane silently reading zero
+// values out of a perfectly good response.
+func TestAgentSelfUpdateResponseDecodesTheWireShape(t *testing.T) {
+	const payload = `{
+		"ok": true,
+		"status": "already_scheduled",
+		"from_version": "0.61.88",
+		"to_version": "0.62.0",
+		"detail": "an upgrade to 0.62.0 is already staged",
+		"cron_mode": "external",
+		"expires_at": 1780000000
+	}`
+
+	var got AgentSelfUpdateResponse
+	if err := json.Unmarshal([]byte(payload), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Status != SelfUpdateAlreadyScheduled {
+		t.Fatalf("status = %q", got.Status)
+	}
+	if got.FromVersion != "0.61.88" {
+		t.Fatalf("from_version = %q", got.FromVersion)
+	}
+	if got.ToVersion != "0.62.0" {
+		t.Fatalf("to_version = %q", got.ToVersion)
+	}
+	if got.CronMode != CronModeExternal {
+		t.Fatalf("cron_mode = %q", got.CronMode)
+	}
+	if got.Detail == "" {
+		t.Fatal("detail was dropped: it is the whole diagnostic value of an error, and the operator-facing note of every other status")
+	}
+	if got.ExpiresAt != 1780000000 {
+		t.Fatalf("expires_at = %d: a staged record whose expiry the control plane cannot read cannot be checked against its own deadline", got.ExpiresAt)
+	}
+
+	// An agent that omits cron_mode must decode to the zero value, which the
+	// control plane treats as the narrow (honest) window.
+	var minimal AgentSelfUpdateResponse
+	if err := json.Unmarshal([]byte(`{"status":"up_to_date","from_version":"0.62.0"}`), &minimal); err != nil {
+		t.Fatalf("unmarshal minimal: %v", err)
+	}
+	if minimal.CronMode != CronModeUnknown {
+		t.Fatalf("an omitted cron_mode must decode to CronModeUnknown, got %q", minimal.CronMode)
+	}
+	if minimal.ExpiresAt != 0 {
+		t.Fatalf("an omitted expires_at must decode to 0, got %d", minimal.ExpiresAt)
+	}
+}
+
+// TestStagedTTLFloorExceedsEveryConfirmDeadline is the timing half of the
+// contract, stated where the constant lives. The staged record must outlive the
+// control plane's patience: a stage that lapses first means beat 2 finds
+// nothing to apply, and the site false-fails a build it was never given a
+// chance to install. The agent holds a stage for 7200s
+// (UpdateChecker::STAGED_TTL_SECONDS); the CP's longest window is 90 minutes
+// (update.agentConfirmDeadlineExternalCron), and that side pins the same
+// inequality from its own constants.
+func TestStagedTTLFloorExceedsEveryConfirmDeadline(t *testing.T) {
+	const cpLongestConfirmDeadline = 90 * time.Minute
+	if SelfUpdateStagedTTLFloor <= cpLongestConfirmDeadline {
+		t.Fatalf("SelfUpdateStagedTTLFloor = %s, must exceed the control plane's longest confirm deadline (%s)",
+			SelfUpdateStagedTTLFloor, cpLongestConfirmDeadline)
+	}
+	if headroom := SelfUpdateStagedTTLFloor - cpLongestConfirmDeadline; headroom < 15*time.Minute {
+		t.Fatalf("headroom = %s: raise the agent's staged TTL first, then the control plane window, and keep the margin", headroom)
+	}
+}

--- a/apps/api/internal/agentcmd/client.go
+++ b/apps/api/internal/agentcmd/client.go
@@ -131,6 +131,25 @@ func (c *Client) RefreshInventory(ctx context.Context, siteID uuid.UUID, siteURL
 	return out, nil
 }
 
+// AgentSelfUpdate sends the signed `agent_self_update` command to the site's
+// agent, beat 1 (ARM) of the three-beat self-update protocol (see
+// agent_self_update_contract.go). siteID is the target site's stable
+// enrollment UUID, bound into the JWT's aud claim.
+//
+// This call NEVER applies anything: a 200 with status "scheduled" only means
+// the agent verified a newer build and queued the cron event that will apply
+// it in a separate WordPress bootstrap. Success is established later and
+// elsewhere, by the NEW code reporting its version (see
+// update.AgentConfirmWorker); callers must never record a "scheduled" ack as a
+// successful upgrade.
+func (c *Client) AgentSelfUpdate(ctx context.Context, siteID uuid.UUID, siteURL string, req AgentSelfUpdateRequest) (AgentSelfUpdateResponse, error) {
+	var out AgentSelfUpdateResponse
+	if err := c.post(ctx, siteID, siteURL, "agent_self_update", req, &out); err != nil {
+		return AgentSelfUpdateResponse{}, err
+	}
+	return out, nil
+}
+
 // SyncErrorConfig sends the signed `sync_error_config` command to the site's
 // agent, pushing the per-site PHP error-level mask and ignore-list. siteID is
 // the target site's stable enrollment UUID, bound into the JWT's aud claim.
@@ -355,8 +374,7 @@ const (
 // The function returns (true, nil) when the site is reachable, (false, nil)
 // when it is not, and (false, err) only on unexpected infrastructure failures
 // (e.g. JWT-mint failure). Response bodies are discarded beyond the minimal
-// decode needed to detect the error; nothing is logged by this function —
-// callers should emit structured log lines with the returned outcome.
+// decode needed to detect the error; nothing is logged by this function, // callers should emit structured log lines with the returned outcome.
 //
 // This is a thin wrapper around VerifyReachableWithReason that discards the
 // classified reason, so the two implementations can never drift and every

--- a/apps/api/internal/agentrelease/classify.go
+++ b/apps/api/internal/agentrelease/classify.go
@@ -50,6 +50,15 @@ func isWellFormedVersion(v string) bool {
 	return versionPattern.MatchString(strings.TrimSpace(v))
 }
 
+// WellFormed reports whether v is a version string this package is willing to
+// order. Exported for callers that must distinguish "this particular version is
+// missing or garbage" from "these two versions compare thus": Classify collapses
+// both unreadable sides into a single StatusUnknown, which cannot say WHICH one
+// was unreadable. The agent self-update channel needs that distinction, because
+// "the run recorded no target" and "the site reported no version" are different
+// facts an operator has to act on differently.
+func WellFormed(v string) bool { return isWellFormedVersion(v) }
+
 // Classify compares a site's reported agent_version against the currently
 // published latestVersion and returns the fleet-rollup status. Either side
 // being empty or not well-formed (isWellFormedVersion) always yields

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -114742,6 +114742,8 @@ func (s *UpdateItemType) Decode(d *jx.Decoder) error {
 		*s = UpdateItemTypeTheme
 	case UpdateItemTypeCore:
 		*s = UpdateItemTypeCore
+	case UpdateItemTypeAgent:
+		*s = UpdateItemTypeAgent
 	default:
 		*s = UpdateItemType(v)
 	}
@@ -115674,6 +115676,8 @@ func (s *UpdateRunStatus) Decode(d *jx.Decoder) error {
 		*s = UpdateRunStatusRunning
 	case UpdateRunStatusCompleted:
 		*s = UpdateRunStatusCompleted
+	case UpdateRunStatusHalted:
+		*s = UpdateRunStatusHalted
 	default:
 		*s = UpdateRunStatus(v)
 	}
@@ -116526,6 +116530,8 @@ func (s *UpdateTaskStatus) Decode(d *jx.Decoder) error {
 		*s = UpdateTaskStatusRolledBack
 	case UpdateTaskStatusSkipped:
 		*s = UpdateTaskStatusSkipped
+	case UpdateTaskStatusCancelled:
+		*s = UpdateTaskStatusCancelled
 	default:
 		*s = UpdateTaskStatus(v)
 	}
@@ -116568,6 +116574,8 @@ func (s *UpdateTaskTargetType) Decode(d *jx.Decoder) error {
 		*s = UpdateTaskTargetTypeTheme
 	case UpdateTaskTargetTypeCore:
 		*s = UpdateTaskTargetTypeCore
+	case UpdateTaskTargetTypeAgent:
+		*s = UpdateTaskTargetTypeAgent
 	default:
 		*s = UpdateTaskTargetType(v)
 	}

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -5064,8 +5064,7 @@ type AgentHeartbeatResult struct {
 	Instructions []string `json:"instructions"`
 	// Present with a `["revoke"]` instruction: a short-lived signed Ed25519
 	// JWT (aud=site_id, cmd="revoke") the agent MUST verify with the CP
-	// public key before any self-teardown (ADR-040 addendum). Fail-closed —
-	// an absent/invalid token must be a no-op.
+	// public key before any self-teardown (ADR-040 addendum). Fail-closed, // an absent/invalid token must be a no-op.
 	RevokeToken OptString `json:"revoke_token"`
 }
 
@@ -21923,8 +21922,7 @@ type Me struct {
 	ManagedStorageAllowed OptBool `json:"managed_storage_allowed"`
 	// The M16 Phase 0 "sign up into a plan" hint captured at registration (RegisterRequest.plan),
 	// single-use: present ONLY in the direct response to POST /auth/verify-email (read off the
-	// just-consumed verification token) or the first-run bootstrap response of POST /auth/register —
-	// never on GET /auth/me or any other Me-returning response. The frontend uses this to auto-start
+	// just-consumed verification token) or the first-run bootstrap response of POST /auth/register, // never on GET /auth/me or any other Me-returning response. The frontend uses this to auto-start
 	// checkout right after the account is verified. Absent means no intent was captured (free signup,
 	// self-hosted instance, or a resend/login/OIDC path that never carries one).
 	DesiredPlan OptMeDesiredPlan `json:"desired_plan"`
@@ -22030,8 +22028,7 @@ func (*Me) verifyEmailRes()             {}
 
 // The M16 Phase 0 "sign up into a plan" hint captured at registration (RegisterRequest.plan),
 // single-use: present ONLY in the direct response to POST /auth/verify-email (read off the
-// just-consumed verification token) or the first-run bootstrap response of POST /auth/register —
-// never on GET /auth/me or any other Me-returning response. The frontend uses this to auto-start
+// just-consumed verification token) or the first-run bootstrap response of POST /auth/register, // never on GET /auth/me or any other Me-returning response. The frontend uses this to auto-start
 // checkout right after the account is verified. Absent means no intent was captured (free signup,
 // self-hosted instance, or a resend/login/OIDC path that never carries one).
 type MeDesiredPlan string
@@ -35791,8 +35788,7 @@ type PutEmailConnectionNotFound Error
 
 func (*PutEmailConnectionNotFound) putEmailConnectionRes() {}
 
-// Request body for PUT /sites/{siteId}/email/connections/{connKey}. All fields are optional —
-// omitted fields are unchanged (PATCH semantics within a PUT envelope). Omitting `secret` preserves
+// Request body for PUT /sites/{siteId}/email/connections/{connKey}. All fields are optional, // omitted fields are unchanged (PATCH semantics within a PUT envelope). Omitting `secret` preserves
 // the existing stored credential (nil-sentinel pattern).
 // Ref: #/components/schemas/PutEmailConnectionRequest
 type PutEmailConnectionRequest struct {
@@ -45243,8 +45239,7 @@ func (s *SiteShareList) SetItems(val []SiteShare) {
 func (*SiteShareList) listSharedWithMeRes() {}
 func (*SiteShareList) listSiteSharesRes()   {}
 
-// Role a site collaborator holds. Subset of the full org Role enum —
-// site shares cannot be owner.
+// Role a site collaborator holds. Subset of the full org Role enum, // site shares cannot be owner.
 // Ref: #/components/schemas/SiteShareRole
 type SiteShareRole string
 
@@ -46899,10 +46894,21 @@ func (s *UpdateFileManagerSettingsRequest) SetWriteEnabled(val OptBool) {
 // One thing to update on a site.
 // Ref: #/components/schemas/UpdateItem
 type UpdateItem struct {
+	// What to update. `agent` upgrades the WPMgr agent itself over its own
+	// dedicated signed channel and behaves differently from the others: it
+	// must be the ONLY item in its run (its staged-wave rollout is defined
+	// over the whole run), it takes no slug and no version pin, and it has
+	// no dry run. Success is established only when the upgraded agent
+	// reports its new version back; a scheduled acknowledgement is not
+	// success. The channel is off unless the control plane enables it.
 	Type UpdateItemType `json:"type"`
-	// Plugin/theme slug. Ignored (forced to "core") when type is core.
+	// Plugin/theme slug. Ignored (forced to "core") when type is core; must be omitted when type is
+	// agent.
 	Slug OptString `json:"slug"`
 	// Desired version, "latest" or an explicit pin. Defaults to latest.
+	// A pin is REJECTED when type is agent: the agent's release manifest
+	// only ever points at the published build and the agent refuses to
+	// install an older one, so a pin could not be honoured.
 	Version OptString `json:"version"`
 }
 
@@ -46936,12 +46942,20 @@ func (s *UpdateItem) SetVersion(val OptString) {
 	s.Version = val
 }
 
+// What to update. `agent` upgrades the WPMgr agent itself over its own
+// dedicated signed channel and behaves differently from the others: it
+// must be the ONLY item in its run (its staged-wave rollout is defined
+// over the whole run), it takes no slug and no version pin, and it has
+// no dry run. Success is established only when the upgraded agent
+// reports its new version back; a scheduled acknowledgement is not
+// success. The channel is off unless the control plane enables it.
 type UpdateItemType string
 
 const (
 	UpdateItemTypePlugin UpdateItemType = "plugin"
 	UpdateItemTypeTheme  UpdateItemType = "theme"
 	UpdateItemTypeCore   UpdateItemType = "core"
+	UpdateItemTypeAgent  UpdateItemType = "agent"
 )
 
 // AllValues returns all UpdateItemType values.
@@ -46950,6 +46964,7 @@ func (UpdateItemType) AllValues() []UpdateItemType {
 		UpdateItemTypePlugin,
 		UpdateItemTypeTheme,
 		UpdateItemTypeCore,
+		UpdateItemTypeAgent,
 	}
 }
 
@@ -46961,6 +46976,8 @@ func (s UpdateItemType) MarshalText() ([]byte, error) {
 	case UpdateItemTypeTheme:
 		return []byte(s), nil
 	case UpdateItemTypeCore:
+		return []byte(s), nil
+	case UpdateItemTypeAgent:
 		return []byte(s), nil
 	default:
 		return nil, errors.Errorf("invalid value: %q", s)
@@ -46978,6 +46995,9 @@ func (s *UpdateItemType) UnmarshalText(data []byte) error {
 		return nil
 	case UpdateItemTypeCore:
 		*s = UpdateItemTypeCore
+		return nil
+	case UpdateItemTypeAgent:
+		*s = UpdateItemTypeAgent
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)
@@ -47020,9 +47040,13 @@ func (*UpdateMediaSettingsUnprocessableEntity) updateMediaSettingsRes() {}
 
 // Ref: #/components/schemas/UpdateRun
 type UpdateRun struct {
-	ID          uuid.UUID       `json:"id"`
-	TenantID    uuid.UUID       `json:"tenant_id"`
-	CreatedBy   OptUUID         `json:"created_by"`
+	ID        uuid.UUID `json:"id"`
+	TenantID  uuid.UUID `json:"tenant_id"`
+	CreatedBy OptUUID   `json:"created_by"`
+	// `halted` is terminal and specific to an agent self-update run: a
+	// staged-rollout wave failed to prove itself, so every task the run
+	// had not already dispatched was cancelled. It is distinct from
+	// `completed`, which would hide the fact that the run was stopped.
 	Status      UpdateRunStatus `json:"status"`
 	DryRun      bool            `json:"dry_run"`
 	ScheduledAt OptDateTime     `json:"scheduled_at"`
@@ -47253,12 +47277,17 @@ func (s *UpdateRunList) SetItems(val []UpdateRun) {
 	s.Items = val
 }
 
+// `halted` is terminal and specific to an agent self-update run: a
+// staged-rollout wave failed to prove itself, so every task the run
+// had not already dispatched was cancelled. It is distinct from
+// `completed`, which would hide the fact that the run was stopped.
 type UpdateRunStatus string
 
 const (
 	UpdateRunStatusPending   UpdateRunStatus = "pending"
 	UpdateRunStatusRunning   UpdateRunStatus = "running"
 	UpdateRunStatusCompleted UpdateRunStatus = "completed"
+	UpdateRunStatusHalted    UpdateRunStatus = "halted"
 )
 
 // AllValues returns all UpdateRunStatus values.
@@ -47267,6 +47296,7 @@ func (UpdateRunStatus) AllValues() []UpdateRunStatus {
 		UpdateRunStatusPending,
 		UpdateRunStatusRunning,
 		UpdateRunStatusCompleted,
+		UpdateRunStatusHalted,
 	}
 }
 
@@ -47278,6 +47308,8 @@ func (s UpdateRunStatus) MarshalText() ([]byte, error) {
 	case UpdateRunStatusRunning:
 		return []byte(s), nil
 	case UpdateRunStatusCompleted:
+		return []byte(s), nil
+	case UpdateRunStatusHalted:
 		return []byte(s), nil
 	default:
 		return nil, errors.Errorf("invalid value: %q", s)
@@ -47295,6 +47327,9 @@ func (s *UpdateRunStatus) UnmarshalText(data []byte) error {
 		return nil
 	case UpdateRunStatusCompleted:
 		*s = UpdateRunStatusCompleted
+		return nil
+	case UpdateRunStatusHalted:
+		*s = UpdateRunStatusHalted
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)
@@ -47360,13 +47395,16 @@ type UpdateTask struct {
 	DesiredVersion OptString            `json:"desired_version"`
 	FromVersion    OptString            `json:"from_version"`
 	ToVersion      OptString            `json:"to_version"`
-	Status         UpdateTaskStatus     `json:"status"`
-	Detail         OptString            `json:"detail"`
-	Error          OptString            `json:"error"`
-	StartedAt      OptDateTime          `json:"started_at"`
-	FinishedAt     OptDateTime          `json:"finished_at"`
-	CreatedAt      time.Time            `json:"created_at"`
-	UpdatedAt      time.Time            `json:"updated_at"`
+	// `cancelled` means the task was never dispatched because its run was
+	// halted first; nothing was sent to the site. Only agent self-update
+	// runs can halt.
+	Status     UpdateTaskStatus `json:"status"`
+	Detail     OptString        `json:"detail"`
+	Error      OptString        `json:"error"`
+	StartedAt  OptDateTime      `json:"started_at"`
+	FinishedAt OptDateTime      `json:"finished_at"`
+	CreatedAt  time.Time        `json:"created_at"`
+	UpdatedAt  time.Time        `json:"updated_at"`
 }
 
 // GetID returns the value of ID.
@@ -47529,6 +47567,9 @@ func (s *UpdateTask) SetUpdatedAt(val time.Time) {
 	s.UpdatedAt = val
 }
 
+// `cancelled` means the task was never dispatched because its run was
+// halted first; nothing was sent to the site. Only agent self-update
+// runs can halt.
 type UpdateTaskStatus string
 
 const (
@@ -47538,6 +47579,7 @@ const (
 	UpdateTaskStatusFailed     UpdateTaskStatus = "failed"
 	UpdateTaskStatusRolledBack UpdateTaskStatus = "rolled_back"
 	UpdateTaskStatusSkipped    UpdateTaskStatus = "skipped"
+	UpdateTaskStatusCancelled  UpdateTaskStatus = "cancelled"
 )
 
 // AllValues returns all UpdateTaskStatus values.
@@ -47549,6 +47591,7 @@ func (UpdateTaskStatus) AllValues() []UpdateTaskStatus {
 		UpdateTaskStatusFailed,
 		UpdateTaskStatusRolledBack,
 		UpdateTaskStatusSkipped,
+		UpdateTaskStatusCancelled,
 	}
 }
 
@@ -47566,6 +47609,8 @@ func (s UpdateTaskStatus) MarshalText() ([]byte, error) {
 	case UpdateTaskStatusRolledBack:
 		return []byte(s), nil
 	case UpdateTaskStatusSkipped:
+		return []byte(s), nil
+	case UpdateTaskStatusCancelled:
 		return []byte(s), nil
 	default:
 		return nil, errors.Errorf("invalid value: %q", s)
@@ -47593,6 +47638,9 @@ func (s *UpdateTaskStatus) UnmarshalText(data []byte) error {
 	case UpdateTaskStatusSkipped:
 		*s = UpdateTaskStatusSkipped
 		return nil
+	case UpdateTaskStatusCancelled:
+		*s = UpdateTaskStatusCancelled
+		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)
 	}
@@ -47604,6 +47652,7 @@ const (
 	UpdateTaskTargetTypePlugin UpdateTaskTargetType = "plugin"
 	UpdateTaskTargetTypeTheme  UpdateTaskTargetType = "theme"
 	UpdateTaskTargetTypeCore   UpdateTaskTargetType = "core"
+	UpdateTaskTargetTypeAgent  UpdateTaskTargetType = "agent"
 )
 
 // AllValues returns all UpdateTaskTargetType values.
@@ -47612,6 +47661,7 @@ func (UpdateTaskTargetType) AllValues() []UpdateTaskTargetType {
 		UpdateTaskTargetTypePlugin,
 		UpdateTaskTargetTypeTheme,
 		UpdateTaskTargetTypeCore,
+		UpdateTaskTargetTypeAgent,
 	}
 }
 
@@ -47623,6 +47673,8 @@ func (s UpdateTaskTargetType) MarshalText() ([]byte, error) {
 	case UpdateTaskTargetTypeTheme:
 		return []byte(s), nil
 	case UpdateTaskTargetTypeCore:
+		return []byte(s), nil
+	case UpdateTaskTargetTypeAgent:
 		return []byte(s), nil
 	default:
 		return nil, errors.Errorf("invalid value: %q", s)
@@ -47640,6 +47692,9 @@ func (s *UpdateTaskTargetType) UnmarshalText(data []byte) error {
 		return nil
 	case UpdateTaskTargetTypeCore:
 		*s = UpdateTaskTargetTypeCore
+		return nil
+	case UpdateTaskTargetTypeAgent:
+		*s = UpdateTaskTargetTypeAgent
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)

--- a/apps/api/internal/api/gen/oas_validators_gen.go
+++ b/apps/api/internal/api/gen/oas_validators_gen.go
@@ -13932,6 +13932,8 @@ func (s UpdateItemType) Validate() error {
 		return nil
 	case "core":
 		return nil
+	case "agent":
+		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}
@@ -14111,6 +14113,8 @@ func (s UpdateRunStatus) Validate() error {
 		return nil
 	case "completed":
 		return nil
+	case "halted":
+		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}
@@ -14164,6 +14168,8 @@ func (s UpdateTaskStatus) Validate() error {
 		return nil
 	case "skipped":
 		return nil
+	case "cancelled":
+		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}
@@ -14176,6 +14182,8 @@ func (s UpdateTaskTargetType) Validate() error {
 	case "theme":
 		return nil
 	case "core":
+		return nil
+	case "agent":
 		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -61,8 +61,7 @@ type StripeConfig struct {
 	// verify POST /webhooks/billing/stripe. Env: WPMGR_BILLING_STRIPE_WEBHOOK_SECRET.
 	WebhookSecret string `koanf:"webhook_secret"`
 	// PriceStarter/PriceAgency/PriceScale are the Stripe recurring Price ids
-	// for the three paid tiers (created once in the Stripe Dashboard/API —
-	// this control plane never creates prices itself). Env:
+	// for the three paid tiers (created once in the Stripe Dashboard/API, // this control plane never creates prices itself). Env:
 	// WPMGR_BILLING_STRIPE_PRICE_STARTER / _PRICE_AGENCY / _PRICE_SCALE.
 	PriceStarter string `koanf:"price_starter"`
 	PriceAgency  string `koanf:"price_agency"`
@@ -103,8 +102,7 @@ type RazorpayConfig struct {
 
 // HostedConfig gates the M16 Phase A hosted-billing entitlement substrate
 // (internal/billing). Enabled defaults to FALSE: self-host and current prod
-// see zero behavior change — every entitlement check no-ops (Unlimited()) —
-// until an operator explicitly sets WPMGR_HOSTED=true. There is no payment-
+// see zero behavior change, every entitlement check no-ops (Unlimited()), // until an operator explicitly sets WPMGR_HOSTED=true. There is no payment-
 // provider integration yet (Phase B); this phase is the plan/site-cap
 // substrate only.
 type HostedConfig struct {
@@ -148,8 +146,7 @@ type ConnConfig struct {
 // Require2FAStepUp is a GLOBAL kill-switch that masks the per-site policy's
 // require_2fa_step_up column: when FALSE (the V0 default), the service ignores
 // the per-site flag entirely because the 2FA enrollment system is not built
-// yet. Flipping it to TRUE after 2FA ships does NOT require a schema change —
-// the per-site column is already in place. Today the 409 "2fa_required" path
+// yet. Flipping it to TRUE after 2FA ships does NOT require a schema change, // the per-site column is already in place. Today the 409 "2fa_required" path
 // is unreachable; that is intentional and tested.
 type AutologinConfig struct {
 	Require2FAStepUp bool `koanf:"require_2fa_step_up"`
@@ -361,11 +358,24 @@ type BackupConfig struct {
 // leaves headroom under the agent's own apply script cap
 // (set_time_limit(900)) for network/transfer overhead on top of the agent's
 // own execution time.
+//
+// AgentSelfUpdateEnabled (WPMGR_UPDATE_AGENT_SELF_UPDATE_ENABLED) is the
+// fleet-wide kill switch for the agent's OWN upgrade channel, and it DEFAULTS
+// TO FALSE. While false, no agent self-update command is sent to any site,
+// whatever runs already exist and whatever jobs are already enqueued: the
+// worker checks it immediately before dispatch, not merely at run creation.
+//
+// It has to stop DISPATCH rather than work through the release channel,
+// because repointing the published manifest at an older build does not
+// un-brick anyone, the agent's downgrade guard refuses to install anything
+// older than what it is already running. Turning this off is therefore the
+// only thing that actually stops an agent rollout in progress.
 type UpdateConfig struct {
-	PerTenantParallelism int           `koanf:"per_tenant_parallelism"`
-	HTTPTimeout          time.Duration `koanf:"http_timeout"`
-	HTTPRetries          int           `koanf:"http_retries"`
-	ApplyHTTPTimeout     time.Duration `koanf:"apply_http_timeout"`
+	PerTenantParallelism   int           `koanf:"per_tenant_parallelism"`
+	HTTPTimeout            time.Duration `koanf:"http_timeout"`
+	HTTPRetries            int           `koanf:"http_retries"`
+	ApplyHTTPTimeout       time.Duration `koanf:"apply_http_timeout"`
+	AgentSelfUpdateEnabled bool          `koanf:"agent_self_update_enabled"`
 }
 
 // AgentConfig holds the control-plane agent-protocol configuration.
@@ -557,25 +567,29 @@ func defaults() map[string]any {
 		"auth.absolute_expiry":     "720h", // 30 days hard cap
 		// ADR-056: WebAuthn relying party defaults (hosted instance).
 		// Self-hosted operators override via WPMGR_AUTH_WEBAUTHN_RPID etc.
-		"auth.webauthn_rpid":                "manage.wpmgr.app",
-		"auth.webauthn_rp_origins":          "https://manage.wpmgr.app",
-		"auth.webauthn_rp_display_name":     "WPMgr",
-		"oidc.issuer":                       "",
-		"oidc.client_id":                    "",
-		"oidc.client_secret":                "",
-		"oidc.redirect_url":                 "",
-		"otel.exporter_otlp_endpoint":       "",
-		"otel.service_name":                 "wpmgr-api",
-		"shutdown.timeout":                  "15s",
-		"agent.signing_private_key":         "",
-		"agent.signing_public_key":          "",
-		"agent.signature_skew":              "5m",
-		"agent.stale_after":                 "10m", // ~2 missed 5-min heartbeats
-		"agent.health_interval":             "5m",
-		"update.per_tenant_parallelism":     5,
-		"update.http_timeout":               "30s",
-		"update.http_retries":               2,
-		"update.apply_http_timeout":         "5m",
+		"auth.webauthn_rpid":            "manage.wpmgr.app",
+		"auth.webauthn_rp_origins":      "https://manage.wpmgr.app",
+		"auth.webauthn_rp_display_name": "WPMgr",
+		"oidc.issuer":                   "",
+		"oidc.client_id":                "",
+		"oidc.client_secret":            "",
+		"oidc.redirect_url":             "",
+		"otel.exporter_otlp_endpoint":   "",
+		"otel.service_name":             "wpmgr-api",
+		"shutdown.timeout":              "15s",
+		"agent.signing_private_key":     "",
+		"agent.signing_public_key":      "",
+		"agent.signature_skew":          "5m",
+		"agent.stale_after":             "10m", // ~2 missed 5-min heartbeats
+		"agent.health_interval":         "5m",
+		"update.per_tenant_parallelism": 5,
+		"update.http_timeout":           "30s",
+		"update.http_retries":           2,
+		"update.apply_http_timeout":     "5m",
+		// Fleet-wide kill switch for the agent's own upgrade channel. Ships
+		// DISABLED: merging the channel changes nothing until an operator
+		// explicitly turns it on. See UpdateConfig.AgentSelfUpdateEnabled.
+		"update.agent_self_update_enabled":  false,
 		"s3.endpoint":                       "",
 		"s3.region":                         "us-east-1",
 		"s3.bucket":                         "",

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -226,6 +226,19 @@ type Querier interface {
 	// generation counter and clears archived_at so the row leaves the archived list.
 	// The next consume increments nothing further — generation already advanced.
 	BeginSiteReEnrollment(ctx context.Context, arg BeginSiteReEnrollmentParams) (Site, error)
+	// Cancels ONE not-yet-dispatched task as part of halting its run.
+	//
+	// The 'pending' precondition is the whole point, and it is enforced here rather
+	// than in Go so it is atomic against a worker claiming the same row. A halt may
+	// only cancel tasks nothing was ever sent for: update_tasks.status='cancelled'
+	// means exactly "nothing was ever sent to this site". A RUNNING task has
+	// already had its command delivered and (for an agent self-update) a cron event
+	// spawned on the site, so cancelling it would both record a falsehood and make
+	// the control plane stop listening for the outcome, at the exact moment an
+	// operator hit the kill switch and most needs to know. Running tasks are left
+	// to be resolved by their own confirmation job; the run is halted, so no
+	// further wave can open behind them.
+	CancelPendingUpdateTask(ctx context.Context, arg CancelPendingUpdateTaskParams) (UpdateTask, error)
 	// Advance next_digest_at to the next period as a conditional claim.
 	// Returns the updated row if the claim succeeds (next_digest_at still <= now(),
 	// guard against double-claim by concurrent workers). Runs under InAgentTx.
@@ -473,8 +486,17 @@ type Querier interface {
 	// expanded). Returns pgx.ErrNoRows when no tenant matches — the caller then
 	// treats the event as "unknown customer" (record + warn, change nothing).
 	FindTenantByProviderCustomer(ctx context.Context, arg FindTenantByProviderCustomerParams) (uuid.UUID, error)
-	// Records a terminal task state (succeeded|failed|rolled_back|skipped) with the
-	// resolved versions and any detail/error. Tenant-scoped by id+tenant_id.
+	// Records a terminal task state (succeeded|failed|rolled_back|skipped|cancelled)
+	// with the resolved versions and any detail/error. Tenant-scoped by
+	// id+tenant_id.
+	//
+	// The status precondition is what makes a terminal state FINAL. Without it, a
+	// worker that was already in flight when its run was halted comes back later
+	// and overwrites 'cancelled' with 'succeeded', so the kill switch appears to
+	// have stopped a rollout that in fact reported itself as a success. Only a task
+	// still open (pending|running) may be finished; a caller that matches no row
+	// must read the row back and leave the recorded outcome alone (see
+	// pgRepo.FinishTask / ErrTaskNotOpen).
 	FinishUpdateTask(ctx context.Context, arg FinishUpdateTaskParams) (UpdateTask, error)
 	// Runs under InUserTx. Returns the tenant of the user's earliest ACTIVE
 	// client membership, used at login to resolve an active tenant for

--- a/apps/api/internal/db/sqlc/updates.sql.go
+++ b/apps/api/internal/db/sqlc/updates.sql.go
@@ -13,6 +13,59 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const cancelPendingUpdateTask = `-- name: CancelPendingUpdateTask :one
+UPDATE update_tasks
+SET status = 'cancelled',
+    detail = $3,
+    finished_at = now(),
+    updated_at = now()
+WHERE id = $1 AND tenant_id = $2
+  AND status = 'pending'
+RETURNING id, run_id, tenant_id, site_id, target_type, target_slug, desired_version, from_version, to_version, status, detail, error, started_at, finished_at, created_at, updated_at
+`
+
+type CancelPendingUpdateTaskParams struct {
+	ID       uuid.UUID `json:"id"`
+	TenantID uuid.UUID `json:"tenant_id"`
+	Detail   string    `json:"detail"`
+}
+
+// Cancels ONE not-yet-dispatched task as part of halting its run.
+//
+// The 'pending' precondition is the whole point, and it is enforced here rather
+// than in Go so it is atomic against a worker claiming the same row. A halt may
+// only cancel tasks nothing was ever sent for: update_tasks.status='cancelled'
+// means exactly "nothing was ever sent to this site". A RUNNING task has
+// already had its command delivered and (for an agent self-update) a cron event
+// spawned on the site, so cancelling it would both record a falsehood and make
+// the control plane stop listening for the outcome, at the exact moment an
+// operator hit the kill switch and most needs to know. Running tasks are left
+// to be resolved by their own confirmation job; the run is halted, so no
+// further wave can open behind them.
+func (q *Queries) CancelPendingUpdateTask(ctx context.Context, arg CancelPendingUpdateTaskParams) (UpdateTask, error) {
+	row := q.db.QueryRow(ctx, cancelPendingUpdateTask, arg.ID, arg.TenantID, arg.Detail)
+	var i UpdateTask
+	err := row.Scan(
+		&i.ID,
+		&i.RunID,
+		&i.TenantID,
+		&i.SiteID,
+		&i.TargetType,
+		&i.TargetSlug,
+		&i.DesiredVersion,
+		&i.FromVersion,
+		&i.ToVersion,
+		&i.Status,
+		&i.Detail,
+		&i.Error,
+		&i.StartedAt,
+		&i.FinishedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const countRunningTasksForTenant = `-- name: CountRunningTasksForTenant :one
 SELECT count(*) FROM update_tasks
 WHERE tenant_id = $1 AND status = 'running'
@@ -158,6 +211,7 @@ SET status = $3,
     finished_at = now(),
     updated_at = now()
 WHERE id = $1 AND tenant_id = $2
+  AND status IN ('pending', 'running')
 RETURNING id, run_id, tenant_id, site_id, target_type, target_slug, desired_version, from_version, to_version, status, detail, error, started_at, finished_at, created_at, updated_at
 `
 
@@ -171,8 +225,17 @@ type FinishUpdateTaskParams struct {
 	Error       string    `json:"error"`
 }
 
-// Records a terminal task state (succeeded|failed|rolled_back|skipped) with the
-// resolved versions and any detail/error. Tenant-scoped by id+tenant_id.
+// Records a terminal task state (succeeded|failed|rolled_back|skipped|cancelled)
+// with the resolved versions and any detail/error. Tenant-scoped by
+// id+tenant_id.
+//
+// The status precondition is what makes a terminal state FINAL. Without it, a
+// worker that was already in flight when its run was halted comes back later
+// and overwrites 'cancelled' with 'succeeded', so the kill switch appears to
+// have stopped a rollout that in fact reported itself as a success. Only a task
+// still open (pending|running) may be finished; a caller that matches no row
+// must read the row back and leave the recorded outcome alone (see
+// pgRepo.FinishTask / ErrTaskNotOpen).
 func (q *Queries) FinishUpdateTask(ctx context.Context, arg FinishUpdateTaskParams) (UpdateTask, error) {
 	row := q.db.QueryRow(ctx, finishUpdateTask,
 		arg.ID,

--- a/apps/api/internal/site/agent_self_update_test.go
+++ b/apps/api/internal/site/agent_self_update_test.go
@@ -2,6 +2,7 @@ package site
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -156,4 +157,115 @@ func TestAgentSelfUpdateExcludedFromReadProjections(t *testing.T) {
 	if !akismet {
 		t.Fatal("the ordinary plugin disappeared from the components inventory")
 	}
+}
+
+// TestAgentSelfUpdateApplyRecordIsPersistedAndReadBack covers the OTHER
+// agent_self_update payload: not the plugin-inventory advisory stripped above,
+// but the agent's own account of what happened on the apply beat of its own
+// upgrade.
+//
+// The two are easy to confuse and are opposites. The inventory advisory is a
+// WordPress-supplied claim that an update is AVAILABLE, and it is dropped
+// because acting on it would have the agent overwrite its running code. This
+// record is the agent's report of an upgrade it ALREADY attempted, and it is
+// kept because it is the only evidence of a failed apply that ever reaches the
+// control plane: the apply runs in a cron request with no CP response to ride
+// on.
+func TestAgentSelfUpdateApplyRecordIsPersistedAndReadBack(t *testing.T) {
+	m := sanitizeMetadata(Metadata{
+		AgentVersion: "0.61.80",
+		AgentSelfUpdate: &AgentSelfUpdateResult{
+			Status:      "failed",
+			FromVersion: "0.61.80",
+			ToVersion:   "0.62.0",
+			Detail:      "Upgrader threw: could not create directory",
+			At:          1785000000,
+		},
+	})
+	if m.AgentSelfUpdate == nil {
+		t.Fatal("the agent's account of its apply beat was dropped at the write chokepoint")
+	}
+
+	// Round-trip through the JSONB inventory exactly as ApplyMetadata stores it.
+	raw, err := json.Marshal(map[string]any{
+		"plugins":           []Component{},
+		"themes":            []Component{},
+		"agent_self_update": m.AgentSelfUpdate,
+	})
+	if err != nil {
+		t.Fatalf("marshal inventory: %v", err)
+	}
+	got := Site{ID: uuid.New(), Components: raw}.ParsedAgentSelfUpdate()
+	if got == nil {
+		t.Fatal("the stored record did not read back")
+	}
+	if got.Status != "failed" || got.ToVersion != "0.62.0" {
+		t.Fatalf("record did not round-trip: %+v", got)
+	}
+	if got.Detail != "Upgrader threw: could not create directory" {
+		t.Fatalf("the agent's own reason is the whole value of the record, got %q", got.Detail)
+	}
+	if got.At != 1785000000 {
+		t.Fatalf("at = %d, want the agent's stamp", got.At)
+	}
+}
+
+// TestAgentSelfUpdateApplyRecordIsBoundedAndOptional: the record is agent-
+// supplied telemetry like everything else here, so it is bounded on arrival
+// rather than trusted, and its absence is never an error.
+func TestAgentSelfUpdateApplyRecordIsBoundedAndOptional(t *testing.T) {
+	t.Run("absent stays absent", func(t *testing.T) {
+		if got := sanitizeMetadata(Metadata{AgentVersion: "0.61.80"}).AgentSelfUpdate; got != nil {
+			t.Fatalf("want no record for an agent that sent none, got %+v", got)
+		}
+	})
+
+	t.Run("a record with no status says nothing and is dropped", func(t *testing.T) {
+		got := sanitizeMetadata(Metadata{
+			AgentSelfUpdate: &AgentSelfUpdateResult{Status: "   ", ToVersion: "0.62.0"},
+		}).AgentSelfUpdate
+		if got != nil {
+			t.Fatalf("want the empty shell dropped, got %+v", got)
+		}
+	})
+
+	t.Run("oversized fields are truncated, not rejected", func(t *testing.T) {
+		got := sanitizeMetadata(Metadata{
+			AgentSelfUpdate: &AgentSelfUpdateResult{
+				Status:      strings.Repeat("s", 200),
+				FromVersion: strings.Repeat("1", 200),
+				ToVersion:   strings.Repeat("2", 200),
+				Detail:      strings.Repeat("d", 4000),
+				At:          -1,
+			},
+		}).AgentSelfUpdate
+		if got == nil {
+			t.Fatal("an oversized record must be bounded, never dropped: it may be the only account of a failure")
+		}
+		if len(got.Status) != maxSelfUpdateStatus {
+			t.Fatalf("status len = %d, want %d", len(got.Status), maxSelfUpdateStatus)
+		}
+		if len(got.Detail) != maxSelfUpdateDetail {
+			t.Fatalf("detail len = %d, want %d", len(got.Detail), maxSelfUpdateDetail)
+		}
+		if len(got.FromVersion) != maxVersionLen || len(got.ToVersion) != maxVersionLen {
+			t.Fatalf("versions not bounded: %+v", got)
+		}
+		if got.At != 0 {
+			t.Fatalf("a negative timestamp must normalize to unset, got %d", got.At)
+		}
+	})
+
+	t.Run("a site with no inventory reads back nothing", func(t *testing.T) {
+		for name, s := range map[string]Site{
+			"empty":       {},
+			"malformed":   {Components: []byte("{")},
+			"no such key": {Components: []byte(`{"plugins":[],"themes":[]}`)},
+			"no status":   {Components: []byte(`{"agent_self_update":{"to_version":"0.62.0"}}`)},
+		} {
+			if got := s.ParsedAgentSelfUpdate(); got != nil {
+				t.Fatalf("%s: want nil, got %+v", name, got)
+			}
+		}
+	})
 }

--- a/apps/api/internal/site/model.go
+++ b/apps/api/internal/site/model.go
@@ -235,6 +235,26 @@ func (s Site) ParsedCoreUpdate() *CoreUpdate {
 	return comp.CoreUpdate
 }
 
+// ParsedAgentSelfUpdate decodes the site's JSONB inventory and returns the
+// optional record of the agent's last self-update apply beat (nil when the site
+// never reported one, or the inventory is empty/malformed). A record with no
+// status is treated as absent: it says nothing.
+func (s Site) ParsedAgentSelfUpdate() *AgentSelfUpdateResult {
+	if len(s.Components) == 0 {
+		return nil
+	}
+	var comp struct {
+		AgentSelfUpdate *AgentSelfUpdateResult `json:"agent_self_update,omitempty"`
+	}
+	if json.Unmarshal(s.Components, &comp) != nil {
+		return nil
+	}
+	if comp.AgentSelfUpdate == nil || comp.AgentSelfUpdate.Status == "" {
+		return nil
+	}
+	return comp.AgentSelfUpdate
+}
+
 // Metadata is the site inventory an authenticated agent pushes.
 type Metadata struct {
 	WPVersion   string `json:"wp_version" validate:"max=32"`
@@ -256,6 +276,40 @@ type Metadata struct {
 	// agent reported none of the expansion fields — the sink does not
 	// overwrite previously-stored values in that case.
 	Extras *MetadataExtras `json:"-"`
+	// AgentSelfUpdate is the agent's own account of its last self-update apply
+	// beat. Optional and additive: nil for a site that never staged one and for
+	// every agent old enough to predate the channel.
+	AgentSelfUpdate *AgentSelfUpdateResult `json:"-"`
+}
+
+// AgentSelfUpdateResult is the agent's account of what happened on the apply
+// beat of its own upgrade, round-tripped through the JSONB inventory column
+// under the `agent_self_update` key (no migration: the column is JSONB).
+//
+// The apply runs inside a WordPress cron request that has no control-plane
+// response to ride on, so this record is the ONLY channel by which a failed,
+// expired or already-applied outcome ever reaches the control plane. Dropping it
+// leaves a confirmation timeout unable to distinguish "the cron run never
+// happened" (the site was never touched) from "the cron run happened and the
+// upgrade failed" (the site may need looking at), which are the two things an
+// operator most needs told apart.
+type AgentSelfUpdateResult struct {
+	// Status is one of applied|failed|expired|already_applied. Stored as a plain
+	// string, not an enum: a status a newer agent introduces must reach an
+	// operator verbatim rather than being dropped by an older control plane.
+	Status string `json:"status"`
+	// FromVersion is the on-disk version at stage time; ToVersion the staged
+	// target. Both best-effort.
+	FromVersion string `json:"from_version,omitempty"`
+	ToVersion   string `json:"to_version,omitempty"`
+	// Detail is the agent's own human-readable, non-secret sentence. The agent
+	// scrubs anything URL-shaped out of it before storing (the manifest's
+	// package URL is a short-lived bearer credential), and this side bounds its
+	// length like every other agent-supplied string.
+	Detail string `json:"detail,omitempty"`
+	// At is the unix timestamp the agent stamped the record with; 0 when it did
+	// not say.
+	At int64 `json:"at,omitempty"`
 }
 
 // MetadataExtras carries the ADR-037 Sprint 1 sparse-metadata expansion. The

--- a/apps/api/internal/site/service.go
+++ b/apps/api/internal/site/service.go
@@ -358,6 +358,9 @@ func (s *Service) ApplyAgentMetadata(ctx context.Context, tenantID, siteID uuid.
 		// components.disk / components.user_count / components.admin_count
 		// path. Old agents send none of these and the fields stay absent.
 		Extras: fromAgentMetadataExtras(m),
+		// The agent's own account of its last self-update apply beat. Additive
+		// and tolerant of absence: old agents send nothing here.
+		AgentSelfUpdate: fromAgentSelfUpdateResult(m.AgentSelfUpdate),
 	})
 	if err != nil {
 		return gen.Site{}, err
@@ -435,6 +438,22 @@ func fromAgentMetadataExtras(m agentpkg.Metadata) *MetadataExtras {
 	return x
 }
 
+// fromAgentSelfUpdateResult lifts the agent's apply-beat record from the agent
+// package DTO onto the site domain type. nil in, nil out: an agent that never
+// staged a self-update, and every agent predating the channel, sends nothing.
+func fromAgentSelfUpdateResult(r *agentpkg.AgentSelfUpdateResult) *AgentSelfUpdateResult {
+	if r == nil || r.Status == "" {
+		return nil
+	}
+	return &AgentSelfUpdateResult{
+		Status:      r.Status,
+		FromVersion: r.FromVersion,
+		ToVersion:   r.ToVersion,
+		Detail:      r.Detail,
+		At:          r.At,
+	}
+}
+
 func fromAgentCoreUpdate(cu *agentpkg.CoreUpdate) *CoreUpdate {
 	if cu == nil || cu.NewVersion == "" {
 		return nil
@@ -443,8 +462,7 @@ func fromAgentCoreUpdate(cu *agentpkg.CoreUpdate) *CoreUpdate {
 }
 
 // Metadata sanitization bounds. Metadata is best-effort telemetry from
-// arbitrary real-world sites, so we never reject a sync over field lengths —
-// we truncate (on rune boundaries) and cap slice sizes instead.
+// arbitrary real-world sites, so we never reject a sync over field lengths, // we truncate (on rune boundaries) and cap slice sizes instead.
 const (
 	maxWPVersion    = 32
 	maxPHPVersion   = 32
@@ -459,6 +477,13 @@ const (
 	maxPackageURL  = 2048
 	maxTestedLen   = 32
 	maxRequiresPHP = 32
+	// Agent self-update apply-record bounds. The agent already caps its own
+	// detail at 500 characters, but that is the agent's promise, not a bound
+	// this side may rely on: the record is agent-supplied telemetry like every
+	// other field here and is truncated on arrival. maxSelfUpdateStatus is
+	// generous enough for a status a newer agent introduces.
+	maxSelfUpdateStatus = 32
+	maxSelfUpdateDetail = 500
 )
 
 // truncateRunes returns s truncated to at most n runes, never splitting a
@@ -554,6 +579,30 @@ func sanitizeCoreUpdate(cu *CoreUpdate) *CoreUpdate {
 	}
 }
 
+// sanitizeAgentSelfUpdate bounds the agent's apply-beat record and drops it
+// entirely when it carries no status, which is the one field that makes it mean
+// anything. Everything else is best-effort and may be empty.
+func sanitizeAgentSelfUpdate(r *AgentSelfUpdateResult) *AgentSelfUpdateResult {
+	if r == nil {
+		return nil
+	}
+	status := truncateRunes(strings.TrimSpace(r.Status), maxSelfUpdateStatus)
+	if status == "" {
+		return nil
+	}
+	at := r.At
+	if at < 0 {
+		at = 0
+	}
+	return &AgentSelfUpdateResult{
+		Status:      status,
+		FromVersion: truncateRunes(strings.TrimSpace(r.FromVersion), maxVersionLen),
+		ToVersion:   truncateRunes(strings.TrimSpace(r.ToVersion), maxVersionLen),
+		Detail:      truncateRunes(r.Detail, maxSelfUpdateDetail),
+		At:          at,
+	}
+}
+
 // sanitizeMetadata coerces arbitrary agent-reported metadata into the stored
 // bounds without ever erroring: scalar fields are truncated on rune
 // boundaries, components with empty slugs are dropped, and the plugin/theme
@@ -572,7 +621,8 @@ func sanitizeMetadata(m Metadata) Metadata {
 		// ADR-037 Sprint 1, 1C — Extras pass through unchanged. The agent
 		// already bounds disk-usage walks to 2s; user/admin counts are tiny
 		// non-negative ints; host_flags is a fixed boolean enum.
-		Extras: m.Extras,
+		Extras:          m.Extras,
+		AgentSelfUpdate: sanitizeAgentSelfUpdate(m.AgentSelfUpdate),
 	}
 }
 
@@ -610,6 +660,13 @@ func (s *Service) ApplyMetadata(ctx context.Context, tenantID, siteID uuid.UUID,
 		if m.Extras.AdminCount > 0 {
 			payload["admin_count"] = m.Extras.AdminCount
 		}
+	}
+	// The agent's account of its last self-update apply beat, stored as a
+	// sibling key to plugins/themes. Absent when the agent sent nothing, exactly
+	// like core_update: the whole inventory blob is rewritten by every push, so
+	// a site that has never staged a self-update simply never carries the key.
+	if m.AgentSelfUpdate != nil {
+		payload["agent_self_update"] = m.AgentSelfUpdate
 	}
 	components, err := json.Marshal(payload)
 	if err != nil {

--- a/apps/api/internal/update/agent_repo.go
+++ b/apps/api/internal/update/agent_repo.go
@@ -1,0 +1,333 @@
+package update
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// agentWaveLockKey is the advisory-lock key namespace serializing every write
+// the agent self-update wave machine makes to ONE run. Both ClaimAgentWaveTask
+// (which turns a pending task into a dispatched one) and EvaluateAgentRun
+// (which halts the run and cancels what is left) take
+// pg_advisory_xact_lock(hashtext('update_agent_wave'), hashtext(run_id)) as
+// their first statement, so they mutually exclude each other per run and
+// release on commit/rollback. This is the same discipline org lifecycle uses
+// (see internal/org/delete_handler.go's orgLifecycleLockKey); no new locking
+// mechanism is introduced here.
+//
+// The lock is what makes the derived wave state (agent_wave.go) safe to act
+// on. Two workers finishing concurrently both compute the same verdict, but
+// only one of them gets to perform the transition: the loser re-reads the rows
+// the winner just wrote, inside its own lock, and sees that there is nothing
+// left to do. That is why neither "both advance the wave" nor "advance a wave
+// a halt just cancelled" is representable.
+const agentWaveLockKey = "update_agent_wave"
+
+// AgentWaveClaim is the outcome of asking to dispatch one agent self-update
+// task.
+type AgentWaveClaim int
+
+const (
+	// ClaimWait: an earlier wave has not finished proving itself. Nothing was
+	// written; the caller must snooze and ask again.
+	ClaimWait AgentWaveClaim = iota
+	// ClaimProceed: THIS caller moved the task pending -> running and is the
+	// only caller that will. It, and only it, may contact the site.
+	ClaimProceed
+	// ClaimHalted: the run is halted (already, or as of this call). The caller
+	// must not contact the site. A task that was still pending has been
+	// cancelled by the halt; one that was already running is left alone for its
+	// own confirmation job to resolve (see haltLocked), and this claim is
+	// simply a duplicate job arriving late.
+	ClaimHalted
+	// ClaimAlreadyClaimed: another job already took this task past pending, or
+	// it is already terminal. Nothing was written and the caller must not
+	// dispatch, this is the duplicate-enqueue no-op.
+	ClaimAlreadyClaimed
+)
+
+// AgentRunEvaluation is the result of re-judging a run's wave gate after one
+// of its tasks reached a terminal state.
+type AgentRunEvaluation struct {
+	// Halted is true when the run is halted, whether this call halted it or
+	// found it already halted.
+	Halted bool
+	// Reason explains the halt in operator-readable terms; empty when !Halted.
+	Reason string
+	// Cancelled counts the tasks THIS call cancelled.
+	Cancelled int
+	// Changed is true only for the call that performed the halt transition, so
+	// exactly one caller records the audit event and logs the incident.
+	Changed bool
+	// Dispatchable is the tasks of a wave that JUST opened: the set the caller
+	// should enqueue now, and nothing it has already enqueued. Empty when
+	// Halted, and empty on the transitions that open no new wave, which is
+	// what keeps a fleet-wide rollout's enqueue work linear rather than
+	// quadratic (see AgentWaveState.DispatchableTasks). Safe to enqueue
+	// unconditionally: the claim path only ever hands one caller the
+	// pending -> running transition.
+	Dispatchable []Task
+}
+
+// AgentWaveRepo is the extra persistence the agent self-update wave machine
+// needs, kept separate from Repo so the ordinary update path (and every fake
+// that implements Repo) is untouched by it.
+type AgentWaveRepo interface {
+	// ClaimAgentWaveTask atomically decides whether one agent task may be
+	// dispatched and, if so, claims it. Everything happens inside one
+	// transaction under the per-run advisory lock.
+	ClaimAgentWaveTask(ctx context.Context, tenantID, runID, taskID uuid.UUID) (AgentWaveClaim, Task, error)
+	// EvaluateAgentRun re-judges the wave gate after a terminal transition,
+	// halting the run (and cancelling every task that was never dispatched)
+	// when a completed wave failed its gate. Idempotent: only the first caller
+	// to halt a given run reports Changed.
+	EvaluateAgentRun(ctx context.Context, tenantID, runID uuid.UUID) (AgentRunEvaluation, error)
+	// HaltAgentRun halts a run for a reason the wave gate itself cannot see
+	// (today: the fleet-wide kill switch), cancelling every task that was never
+	// dispatched and leaving running tasks to their own confirmation job (see
+	// haltLocked). Idempotent in the same way as EvaluateAgentRun.
+	HaltAgentRun(ctx context.Context, tenantID, runID uuid.UUID, reason string) (AgentRunEvaluation, error)
+}
+
+// NewAgentWaveRepo builds the agent self-update wave repo, backed by the same
+// pgx pool and the same tenant-scoped RLS transactions as NewRepo.
+func NewAgentWaveRepo(pool *db.Pool) AgentWaveRepo { return &pgRepo{pool: pool} }
+
+// lockAgentRun takes the transaction-scoped advisory lock for one run. It must
+// be the first statement of any wave-machine transaction.
+func lockAgentRun(ctx context.Context, tx pgx.Tx, runID uuid.UUID) error {
+	if _, err := tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))`,
+		agentWaveLockKey, runID.String(),
+	); err != nil {
+		return domain.Internal("update_agent_wave_lock_failed", "failed to lock the update run's wave gate").WithCause(err)
+	}
+	return nil
+}
+
+// loadAgentRunLocked reads a run and its tasks inside an already-locked
+// transaction.
+func loadAgentRunLocked(ctx context.Context, q *sqlc.Queries, tenantID, runID uuid.UUID) (Run, []Task, error) {
+	runRow, err := q.GetUpdateRun(ctx, sqlc.GetUpdateRunParams{ID: runID, TenantID: tenantID})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Run{}, nil, domain.NotFound("update_run_not_found", "update run not found")
+		}
+		return Run{}, nil, domain.Internal("update_run_get_failed", "failed to load update run").WithCause(err)
+	}
+	taskRows, err := q.ListUpdateTasksForRun(ctx, sqlc.ListUpdateTasksForRunParams{RunID: runID, TenantID: tenantID})
+	if err != nil {
+		return Run{}, nil, domain.Internal("update_task_list_failed", "failed to list update tasks").WithCause(err)
+	}
+	tasks := make([]Task, 0, len(taskRows))
+	for _, row := range taskRows {
+		tasks = append(tasks, toTask(row))
+	}
+	return toRun(runRow), tasks, nil
+}
+
+func (r *pgRepo) ClaimAgentWaveTask(ctx context.Context, tenantID, runID, taskID uuid.UUID) (AgentWaveClaim, Task, error) {
+	claim := ClaimWait
+	var out Task
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		if err := lockAgentRun(ctx, tx, runID); err != nil {
+			return err
+		}
+		q := sqlc.New(tx)
+		run, tasks, err := loadAgentRunLocked(ctx, q, tenantID, runID)
+		if err != nil {
+			return err
+		}
+
+		me, found := findTask(tasks, taskID)
+		if !found {
+			return domain.NotFound("update_task_not_found", "update task not found")
+		}
+		out = me
+
+		// Already terminal (a duplicate job, or a halt that cancelled us
+		// between enqueue and now): never dispatch.
+		if terminal(me.Status) {
+			claim = ClaimAlreadyClaimed
+			return nil
+		}
+
+		state := DeriveAgentWaveState(tasks)
+
+		// The gate is re-judged here, not just after terminal transitions, so
+		// a halt is self-healing: even if the post-finish evaluation was lost
+		// to a crash, the next task that asks to dispatch halts the run
+		// instead of proceeding on a failed wave.
+		if run.Status == RunHalted || state.Halt {
+			reason := state.HaltReason
+			if run.Status == RunHalted && reason == "" {
+				reason = "the run was halted"
+			}
+			if _, herr := haltLocked(ctx, q, tenantID, run, tasks, reason); herr != nil {
+				return herr
+			}
+			// Re-read our own row: haltLocked cancelled it if it was still
+			// pending, and left it running if it had already been dispatched.
+			cancelled, cerr := q.GetUpdateTask(ctx, sqlc.GetUpdateTaskParams{ID: taskID, TenantID: tenantID})
+			if cerr != nil {
+				return domain.Internal("update_task_get_failed", "failed to load update task").WithCause(cerr)
+			}
+			out = toTask(cancelled)
+			claim = ClaimHalted
+			return nil
+		}
+
+		// Someone else already took this task out of pending.
+		if me.Status != TaskPending {
+			claim = ClaimAlreadyClaimed
+			return nil
+		}
+
+		if !state.GateOpenFor(taskID) {
+			claim = ClaimWait
+			return nil
+		}
+
+		row, err := q.MarkUpdateTaskRunning(ctx, sqlc.MarkUpdateTaskRunningParams{ID: taskID, TenantID: tenantID})
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return domain.NotFound("update_task_not_found", "update task not found")
+			}
+			return domain.Internal("update_task_run_failed", "failed to mark task running").WithCause(err)
+		}
+		out = toTask(row)
+		claim = ClaimProceed
+		return nil
+	})
+	if err != nil {
+		return ClaimWait, Task{}, err
+	}
+	return claim, out, nil
+}
+
+func (r *pgRepo) EvaluateAgentRun(ctx context.Context, tenantID, runID uuid.UUID) (AgentRunEvaluation, error) {
+	var out AgentRunEvaluation
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		if err := lockAgentRun(ctx, tx, runID); err != nil {
+			return err
+		}
+		q := sqlc.New(tx)
+		run, tasks, err := loadAgentRunLocked(ctx, q, tenantID, runID)
+		if err != nil {
+			return err
+		}
+
+		state := DeriveAgentWaveState(tasks)
+		if !state.Halt && run.Status != RunHalted {
+			out.Dispatchable = state.DispatchableTasks()
+			return nil
+		}
+		reason := state.HaltReason
+		if reason == "" {
+			reason = "the run was halted"
+		}
+		ev, herr := haltLocked(ctx, q, tenantID, run, tasks, reason)
+		if herr != nil {
+			return herr
+		}
+		out = ev
+		return nil
+	})
+	return out, err
+}
+
+func (r *pgRepo) HaltAgentRun(ctx context.Context, tenantID, runID uuid.UUID, reason string) (AgentRunEvaluation, error) {
+	var out AgentRunEvaluation
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		if err := lockAgentRun(ctx, tx, runID); err != nil {
+			return err
+		}
+		q := sqlc.New(tx)
+		run, tasks, err := loadAgentRunLocked(ctx, q, tenantID, runID)
+		if err != nil {
+			return err
+		}
+		ev, herr := haltLocked(ctx, q, tenantID, run, tasks, reason)
+		if herr != nil {
+			return herr
+		}
+		out = ev
+		return nil
+	})
+	return out, err
+}
+
+// haltLocked performs the halt inside an already-locked transaction: every
+// task that was never dispatched is cancelled with the reason, and the run is
+// marked halted.
+//
+// ONLY PENDING TASKS ARE CANCELLED. A running task has already had its command
+// delivered and, for an agent self-update, a cron event spawned on the site.
+// Cancelling it would record a falsehood, model.go defines TaskCancelled as
+// "nothing was ever sent to this site", and, worse, blind the control plane:
+// AgentConfirmWorker.Work short-circuits on a terminal status, so the confirm
+// poll would return, see 'cancelled', and stop. The CP would never learn
+// whether those sites upgraded or bricked, at the exact moment an operator hit
+// the kill switch and most needs to know. So a running task is left to be
+// resolved by its own confirmation job; the run is halted either way, so no
+// further wave can open behind it.
+//
+// The cancel is atomic against a concurrent claim: CancelPendingUpdateTask
+// carries the status='pending' precondition in SQL rather than trusting the
+// snapshot read at the top of this transaction.
+//
+// The run status is (re-)written even when it already reads halted. That is
+// deliberate: a task that was already dispatched when the halt landed will
+// finish later, and Worker.finish's ordinary run-completion check can flip a
+// halted run to completed. Since every agent task's terminal transition is
+// followed by EvaluateAgentRun, which lands here, that drift is always
+// corrected and the run's final recorded state is the honest one.
+//
+// Changed is true only when this call was the one that moved the run into the
+// halted state, so exactly one caller records the audit event.
+func haltLocked(ctx context.Context, q *sqlc.Queries, tenantID uuid.UUID, run Run, tasks []Task, reason string) (AgentRunEvaluation, error) {
+	ev := AgentRunEvaluation{Halted: true, Reason: reason, Changed: run.Status != RunHalted}
+
+	detail := "cancelled: " + reason
+	for _, t := range tasks {
+		if t.Status != TaskPending {
+			continue
+		}
+		if _, err := q.CancelPendingUpdateTask(ctx, sqlc.CancelPendingUpdateTaskParams{
+			ID:       t.ID,
+			TenantID: tenantID,
+			Detail:   detail,
+		}); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				// Claimed or finished between the snapshot and this statement.
+				// Whatever it became, it is not ours to overwrite.
+				continue
+			}
+			return AgentRunEvaluation{}, domain.Internal("update_task_finish_failed", "failed to cancel update task").WithCause(err)
+		}
+		ev.Cancelled++
+	}
+
+	if _, err := q.SetUpdateRunStatus(ctx, sqlc.SetUpdateRunStatusParams{ID: run.ID, TenantID: tenantID, Status: RunHalted}); err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return AgentRunEvaluation{}, domain.Internal("update_run_status_failed", "failed to halt update run").WithCause(err)
+		}
+	}
+	return ev, nil
+}
+
+func findTask(tasks []Task, id uuid.UUID) (Task, bool) {
+	for _, t := range tasks {
+		if t.ID == id {
+			return t, true
+		}
+	}
+	return Task{}, false
+}

--- a/apps/api/internal/update/agent_self_update_channel_test.go
+++ b/apps/api/internal/update/agent_self_update_channel_test.go
@@ -1,0 +1,1992 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// Doubles
+// ---------------------------------------------------------------------------
+
+// recordingSelfUpdater is the beat-1 commander. It records every site it was
+// asked to arm, which is the fact most of these tests assert on: whether a
+// site was contacted at all.
+type recordingSelfUpdater struct {
+	resp  agentcmd.AgentSelfUpdateResponse
+	err   error
+	calls []uuid.UUID
+}
+
+func (c *recordingSelfUpdater) AgentSelfUpdate(_ context.Context, siteID uuid.UUID, _ string, _ agentcmd.AgentSelfUpdateRequest) (agentcmd.AgentSelfUpdateResponse, error) {
+	c.calls = append(c.calls, siteID)
+	if c.err != nil {
+		return agentcmd.AgentSelfUpdateResponse{}, c.err
+	}
+	return c.resp, nil
+}
+
+// scriptedSelfUpdater answers differently per CALL, which is what a mixed fleet
+// looks like: one wave containing sites that upgrade normally alongside sites
+// whose agent predates the channel entirely. Answers are consumed in call order;
+// running past the end is a test bug and says so.
+type scriptedSelfUpdater struct {
+	answers []selfUpdateAnswer
+	calls   []uuid.UUID
+	t       *testing.T
+}
+
+type selfUpdateAnswer struct {
+	resp agentcmd.AgentSelfUpdateResponse
+	err  error
+}
+
+func (c *scriptedSelfUpdater) AgentSelfUpdate(_ context.Context, siteID uuid.UUID, _ string, _ agentcmd.AgentSelfUpdateRequest) (agentcmd.AgentSelfUpdateResponse, error) {
+	i := len(c.calls)
+	c.calls = append(c.calls, siteID)
+	if i >= len(c.answers) {
+		c.t.Fatalf("the worker contacted %d sites; only %d answers were scripted", i+1, len(c.answers))
+		return agentcmd.AgentSelfUpdateResponse{}, nil
+	}
+	a := c.answers[i]
+	return a.resp, a.err
+}
+
+// oldAgentRouteMissing is the error an agent that predates this channel really
+// produces: its REST API has no such route, so the request 404s and
+// agentcmd.Client.post wraps it in the canonical form the CP sniffs. Written out
+// literally rather than built from a helper, so a change to that wire format
+// fails this test instead of silently un-branching the code under it.
+func oldAgentRouteMissing() error {
+	return errors.New(`agent_self_update command rejected by agent: status 404 body={"code":"rest_no_route","message":"No route was found matching the URL and request method."}`)
+}
+
+// fakeApplyResults stands in for the site inventory's record of the agent's own
+// apply beat.
+type fakeApplyResults struct {
+	results map[uuid.UUID]AgentApplyResult
+	err     error
+}
+
+func (f *fakeApplyResults) AgentSelfUpdateResult(_ context.Context, _, siteID uuid.UUID) (AgentApplyResult, bool, error) {
+	if f.err != nil {
+		return AgentApplyResult{}, false, f.err
+	}
+	r, ok := f.results[siteID]
+	return r, ok, nil
+}
+
+// explodingSelfUpdater fails the test if it is ever reached. Used wherever the
+// point of the test is that NOTHING was sent to a site.
+type explodingSelfUpdater struct{ t *testing.T }
+
+func (c *explodingSelfUpdater) AgentSelfUpdate(context.Context, uuid.UUID, string, agentcmd.AgentSelfUpdateRequest) (agentcmd.AgentSelfUpdateResponse, error) {
+	c.t.Fatal("no agent self-update command may be sent to a site here")
+	return agentcmd.AgentSelfUpdateResponse{}, nil
+}
+
+type fakeVersions struct {
+	versions map[uuid.UUID]string
+	err      error
+}
+
+func (f *fakeVersions) AgentVersion(_ context.Context, _, siteID uuid.UUID) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.versions[siteID], nil
+}
+
+type recordingEnqueuer struct {
+	tasks    []uuid.UUID
+	confirms []AgentConfirmArgs
+	err      error
+}
+
+func (e *recordingEnqueuer) EnqueueTask(_ context.Context, _, _, taskID uuid.UUID, _ bool) error {
+	e.tasks = append(e.tasks, taskID)
+	return nil
+}
+
+func (e *recordingEnqueuer) EnqueueAgentConfirm(_ context.Context, args AgentConfirmArgs) error {
+	if e.err != nil {
+		return e.err
+	}
+	e.confirms = append(e.confirms, args)
+	return nil
+}
+
+type fixedReleases struct{ version string }
+
+func (f fixedReleases) LatestVersion(context.Context) string { return f.version }
+
+// agentHarness wires a Worker over an agentStore for the dispatch tests.
+type agentHarness struct {
+	store *agentStore
+	repo  *fakeAgentRepo
+	waves *fakeWaveRepo
+	enq   *recordingEnqueuer
+	w     *Worker
+}
+
+// newAgentHarness builds a Worker whose ORDINARY Commander is nil on purpose.
+// Worker.rollback and Worker.runApply both go through w.cmd, so a nil there
+// means any attempt to reach the plugin-update machinery (snapshot, health
+// probe, rollback) from the agent branch panics instead of quietly working.
+// The agent branch uses a different interface entirely (w.agent.Cmd), which
+// has no rollback method on it at all.
+func newAgentHarness(t *testing.T, siteCount int, cmd AgentSelfUpdateCommander, versions AgentVersionLookup, enabled bool) *agentHarness {
+	t.Helper()
+	tenant := uuid.New()
+	store := newAgentStore(tenant, siteCount)
+	repo := &fakeAgentRepo{s: store}
+	waves := &fakeWaveRepo{s: store}
+	enq := &recordingEnqueuer{}
+
+	sites := map[uuid.UUID]SiteInfo{}
+	for _, task := range store.tasks {
+		sites[task.SiteID] = SiteInfo{ID: task.SiteID, URL: "https://site.example", Enrolled: true, AgentVersion: "0.61.80"}
+	}
+
+	w := NewWorker(repo, &fakeSiteLookup{sites: sites}, nil, nil, nil, nil, nil, 5, 0)
+	w.SetAgentSelfUpdate(AgentSelfUpdateDeps{
+		Enabled:  enabled,
+		Cmd:      cmd,
+		Versions: versions,
+		Waves:    waves,
+		Tasks:    enq,
+		Confirms: enq,
+		// Wired exactly as main.go wires it: the published version is what an
+		// "up_to_date" answer is checked against. The store's tasks are planned
+		// from 0.61.80, so 0.62.0 is the build this run is rolling out.
+		Releases: fixedReleases{version: "0.62.0"},
+	})
+	return &agentHarness{store: store, repo: repo, waves: waves, enq: enq, w: w}
+}
+
+// withPublished overrides what this control plane believes it publishes, for
+// the tests that turn the two halves against each other.
+func (h *agentHarness) withPublished(version string) *agentHarness {
+	deps := h.w.agent
+	deps.Releases = fixedReleases{version: version}
+	h.w.SetAgentSelfUpdate(deps)
+	return h
+}
+
+// withoutReleases removes the published-version reader entirely, standing in
+// for a control plane that cannot read its own release channel.
+func (h *agentHarness) withoutReleases() *agentHarness {
+	deps := h.w.agent
+	deps.Releases = nil
+	h.w.SetAgentSelfUpdate(deps)
+	return h
+}
+
+// withPlan rewrites the plan-time record on every seeded task: the version this
+// run set out to install, and the version each site reported when it was
+// planned. This is the run's premise, and the thing an "up_to_date" answer is
+// checked against, so a test about a moving release manifest has to be able to
+// state it explicitly rather than inherit it.
+//
+// An empty planned target stands in for a row created before the target was
+// persisted (desired_version "latest"), which is what an in-flight run looks
+// like across the deploy that introduced this.
+func (h *agentHarness) withPlan(planned, plannedFrom string) *agentHarness {
+	h.store.mu.Lock()
+	defer h.store.mu.Unlock()
+	for _, t := range h.store.tasks {
+		if planned == "" {
+			t.DesiredVersion = "latest"
+		} else {
+			t.DesiredVersion = planned
+		}
+		t.FromVersion = plannedFrom
+	}
+	return h
+}
+
+// withApplyResults wires the optional lookup for the agent's own account of its
+// apply beat, keyed by site.
+func (h *agentHarness) withApplyResults(r AgentApplyResultLookup) *agentHarness {
+	deps := h.w.agent
+	deps.Results = r
+	h.w.SetAgentSelfUpdate(deps)
+	return h
+}
+
+func (h *agentHarness) work(ctx context.Context, i int) error {
+	task := h.store.Task(i)
+	return h.w.Work(ctx, &river.Job[TaskArgs]{Args: TaskArgs{
+		TenantID: task.TenantID, RunID: task.RunID, TaskID: task.ID,
+	}})
+}
+
+func isSnooze(err error) bool {
+	var snooze *rivertype.JobSnoozeError
+	return errors.As(err, &snooze)
+}
+
+// ---------------------------------------------------------------------------
+// Kill switch
+// ---------------------------------------------------------------------------
+
+// TestKillSwitchBlocksDispatch is the dark-ship guarantee: with the switch off
+// (its default), a task that is already created and already enqueued still
+// never reaches a site. The commander fails the test if it is called at all.
+//
+// The switch has to stop DISPATCH rather than work through the release
+// channel, because repointing the published manifest backwards does not
+// un-brick anyone: the agent's downgrade guard refuses to install anything
+// older than what it is already running.
+func TestKillSwitchBlocksDispatch(t *testing.T) {
+	h := newAgentHarness(t, 10, &explodingSelfUpdater{t: t}, &fakeVersions{}, false)
+
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+
+	if got := h.store.Task(0).Status; got != TaskSkipped {
+		t.Fatalf("a task refused by the kill switch is skipped, got %q", got)
+	}
+	if !strings.Contains(h.store.Task(0).Detail, "disabled") {
+		t.Fatalf("the refusal must say why: %q", h.store.Task(0).Detail)
+	}
+	// And it stops the WHOLE run, not just this task: the remaining sites are
+	// cancelled rather than left to be attempted one by one.
+	if h.store.RunStatus() != RunHalted {
+		t.Fatalf("run status = %q, want %q", h.store.RunStatus(), RunHalted)
+	}
+	for i := 1; i < 10; i++ {
+		if got := h.store.Task(i).Status; got != TaskCancelled {
+			t.Fatalf("task %d status = %q, want %q", i, got, TaskCancelled)
+		}
+	}
+	if len(h.enq.confirms) != 0 {
+		t.Fatalf("no confirmation poll may be scheduled when nothing was armed: %+v", h.enq.confirms)
+	}
+}
+
+// TestMissingSignerBlocksDispatch: no signing key means no signed command can
+// be minted, and an unsigned self-update command must never be sent. That is
+// the same refusal as the kill switch, reached a different way.
+func TestMissingSignerBlocksDispatch(t *testing.T) {
+	h := newAgentHarness(t, 3, nil, &fakeVersions{}, true)
+
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if got := h.store.Task(0).Status; got != TaskSkipped {
+		t.Fatalf("status = %q, want %q", got, TaskSkipped)
+	}
+	if h.store.RunStatus() != RunHalted {
+		t.Fatalf("run status = %q, want %q", h.store.RunStatus(), RunHalted)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Beat 1: arming is not success
+// ---------------------------------------------------------------------------
+
+// TestScheduledAckIsNeverSuccess is the single most important behaviour in
+// this channel. The agent answering "scheduled" means only that a cron event
+// was queued: nothing has been applied, and on a site with broken loopback
+// cron nothing ever will be. Recording that as success would report a fleet as
+// upgraded while an unknown share of it still runs the old build.
+func TestScheduledAckIsNeverSuccess(t *testing.T) {
+	cmd := &recordingSelfUpdater{resp: agentcmd.AgentSelfUpdateResponse{
+		Status:      agentcmd.SelfUpdateScheduled,
+		FromVersion: "0.61.80",
+		ToVersion:   "0.62.0",
+		CronMode:    agentcmd.CronModeLoopback,
+	}}
+	h := newAgentHarness(t, 10, cmd, &fakeVersions{}, true)
+
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+
+	task := h.store.Task(0)
+	if terminal(task.Status) {
+		t.Fatalf("a scheduled ack must leave the task un-finished, got status %q", task.Status)
+	}
+	if task.Status != TaskRunning {
+		t.Fatalf("status = %q, want %q", task.Status, TaskRunning)
+	}
+	for _, fin := range h.repo.finished {
+		if fin.Status == TaskSucceeded {
+			t.Fatalf("a scheduled ack must never be recorded as succeeded: %+v", fin)
+		}
+	}
+	// The run must not advance either: wave 1 is still shut behind an
+	// unconfirmed canary.
+	if len(h.enq.tasks) != 0 {
+		t.Fatalf("no further wave may be enqueued on a scheduled ack: %+v", h.enq.tasks)
+	}
+	// What it MUST do is arrange for the truth to be established later.
+	if len(h.enq.confirms) != 1 {
+		t.Fatalf("a scheduled ack must schedule exactly one confirmation poll, got %d", len(h.enq.confirms))
+	}
+	if got := h.enq.confirms[0].ExpectVersion; got != "0.62.0" {
+		t.Fatalf("the confirmation poll must carry the expected version, got %q", got)
+	}
+}
+
+// TestConfirmDeadlineWidensForExternalCron: a site whose loopback cron cannot
+// run depends on an external scheduler the control plane cannot see, so it
+// gets a much wider window. Declaring such a site unconfirmed on the narrow
+// window would fail a healthy upgrade and, worse, feed a false failure into
+// the wave gate.
+//
+// The wire carries exactly two cron modes. This test previously drove
+// "disabled" and "alternate", two strings the agent has never emitted, so it
+// was green while covering a path production could not reach, and the one
+// value production DOES send, "external", fell through to the narrow window.
+func TestConfirmDeadlineWidensForExternalCron(t *testing.T) {
+	cases := []struct {
+		name     string
+		cronMode string
+		want     time.Duration
+	}{
+		{"loopback", agentcmd.CronModeLoopback, agentConfirmDeadline},
+		{"field omitted", agentcmd.CronModeUnknown, agentConfirmDeadline},
+		{"a value this control plane does not know", "something-we-do-not-know", agentConfirmDeadline},
+		// The strings deleted from the contract must NOT buy the wide window:
+		// they are now as unrecognized as any other typo.
+		{"the deleted disabled literal", "disabled", agentConfirmDeadline},
+		{"the deleted alternate literal", "alternate", agentConfirmDeadline},
+		{"external", agentcmd.CronModeExternal, agentConfirmDeadlineExternalCron},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := confirmWindowFor(tc.cronMode); got != tc.want {
+				t.Fatalf("confirmWindowFor(%q) = %s, want %s", tc.cronMode, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestConfirmDeadlinesFitTheStagedTTLFloor is the control plane's half of the
+// timing contract. The agent's staged record must outlive the CP's patience,
+// or a slow site expires its own stage, beat 2 finds nothing to apply, and the
+// canary false-fails a build that was never given a chance. The agent holds a
+// stage for agentcmd.SelfUpdateStagedTTLFloor; this side may never widen a
+// deadline past it. Raise the agent's TTL first, then this window.
+func TestConfirmDeadlinesFitTheStagedTTLFloor(t *testing.T) {
+	if agentConfirmDeadline >= agentcmd.SelfUpdateStagedTTLFloor {
+		t.Fatalf("the loopback confirm deadline (%s) must sit inside the agent's staged TTL (%s)",
+			agentConfirmDeadline, agentcmd.SelfUpdateStagedTTLFloor)
+	}
+	if agentConfirmDeadlineExternalCron >= agentcmd.SelfUpdateStagedTTLFloor {
+		t.Fatalf("the external-cron confirm deadline (%s) must sit inside the agent's staged TTL (%s): "+
+			"a control plane that waits longer than the site holds its stage fails sites that did nothing wrong",
+			agentConfirmDeadlineExternalCron, agentcmd.SelfUpdateStagedTTLFloor)
+	}
+	if agentConfirmDeadlineExternalCron <= agentConfirmDeadline {
+		t.Fatalf("the external-cron window (%s) must be the wider of the two (%s)",
+			agentConfirmDeadlineExternalCron, agentConfirmDeadline)
+	}
+}
+
+// TestArmOutcomesMapToTaskStates pins the rest of the beat-1 decision table,
+// against the statuses the agent ACTUALLY emits.
+//
+// Its predecessor asserted on a "failed" status that has never been on the
+// wire: a green test for a branch production never reaches. The status the
+// agent really sends for a failed arm, "error", fell into the default branch,
+// which recorded the bare status string and discarded the agent's detail, the
+// one piece of information that outcome exists to carry.
+func TestArmOutcomesMapToTaskStates(t *testing.T) {
+	cases := []struct {
+		name         string
+		resp         agentcmd.AgentSelfUpdateResponse
+		err          error
+		wantStatus   string
+		wantConfirms int
+		// wantInDetail and wantInError must appear in the recorded task.
+		wantInDetail string
+		wantInError  string
+	}{
+		{
+			name: "an agent-reported error fails the task and keeps its words",
+			resp: agentcmd.AgentSelfUpdateResponse{
+				Status: agentcmd.SelfUpdateError, FromVersion: "0.61.80", Detail: "manifest signature invalid"},
+			wantStatus:   TaskFailed,
+			wantInDetail: "manifest signature invalid",
+			wantInError:  "manifest signature invalid",
+		},
+		{
+			name: "a build that cannot self-update is skipped, not failed",
+			resp: agentcmd.AgentSelfUpdateResponse{
+				Status: agentcmd.SelfUpdateNotEligible, FromVersion: "0.61.80", Detail: "this build has no self-updater"},
+			wantStatus:   TaskSkipped,
+			wantInDetail: "this build has no self-updater",
+		},
+		{
+			name:         "an unrecognized status fails rather than being assumed fine",
+			resp:         agentcmd.AgentSelfUpdateResponse{Status: "wat", Detail: "who knows"},
+			wantStatus:   TaskFailed,
+			wantInDetail: "wat",
+			wantInError:  "who knows",
+		},
+		{
+			// The status the CP used to declare and the agent never sent. It is
+			// now exactly as unrecognized as any other stray string, and must
+			// not be silently accepted as a known outcome.
+			name:         "the deleted failed literal is not a known status",
+			resp:         agentcmd.AgentSelfUpdateResponse{Status: "failed", Detail: "whatever"},
+			wantStatus:   TaskFailed,
+			wantInDetail: "unrecognized",
+		},
+		{
+			name:        "a transport error fails the task",
+			err:         errors.New("connection refused"),
+			wantStatus:  TaskFailed,
+			wantInError: "connection refused",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &recordingSelfUpdater{resp: tc.resp, err: tc.err}
+			h := newAgentHarness(t, 10, cmd, &fakeVersions{}, true)
+
+			if err := h.work(context.Background(), 0); err != nil {
+				t.Fatalf("Work: %v", err)
+			}
+			task := h.store.Task(0)
+			if task.Status != tc.wantStatus {
+				t.Fatalf("status = %q, want %q", task.Status, tc.wantStatus)
+			}
+			if tc.wantInDetail != "" && !strings.Contains(task.Detail, tc.wantInDetail) {
+				t.Fatalf("detail = %q, want it to carry %q", task.Detail, tc.wantInDetail)
+			}
+			if tc.wantInError != "" && !strings.Contains(task.Error, tc.wantInError) {
+				t.Fatalf("error = %q, want it to carry %q", task.Error, tc.wantInError)
+			}
+			if len(h.enq.confirms) != tc.wantConfirms {
+				t.Fatalf("confirmation polls = %d, want %d: only an arm ack schedules one",
+					len(h.enq.confirms), tc.wantConfirms)
+			}
+		})
+	}
+}
+
+// TestArmErrorNeverLosesTheAgentsDetail is the narrow, load-bearing assertion
+// behind the case above, stated on its own because it is the whole point of
+// the "error" outcome: the agent's sentence is the entire diagnostic value of a
+// failed arm, and an operator staring at a task that says only "error" has
+// nothing to act on. It must survive into BOTH the detail and the error, so no
+// single code path can drop it.
+func TestArmErrorNeverLosesTheAgentsDetail(t *testing.T) {
+	const reason = "cron could not be scheduled: wp_schedule_single_event returned false"
+	cmd := &recordingSelfUpdater{resp: agentcmd.AgentSelfUpdateResponse{
+		Status: agentcmd.SelfUpdateError, FromVersion: "0.61.80", Detail: reason}}
+	h := newAgentHarness(t, 10, cmd, &fakeVersions{}, true)
+
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	task := h.store.Task(0)
+	if task.Status != TaskFailed {
+		t.Fatalf("status = %q, want %q", task.Status, TaskFailed)
+	}
+	if !strings.Contains(task.Detail, reason) {
+		t.Fatalf("the operator-facing detail lost the agent's reason: %q", task.Detail)
+	}
+	if !strings.Contains(task.Error, reason) {
+		t.Fatalf("the task error lost the agent's reason: %q", task.Error)
+	}
+	if task.Error == agentcmd.SelfUpdateError {
+		t.Fatal("the task error must be the agent's reason, not the bare status string")
+	}
+}
+
+// TestAlreadyScheduledArmsRatherThanHalts covers the retry case the CP used to
+// treat as garbage. "already_scheduled" means an EARLIER arm succeeded and its
+// upgrade is still pending: it carries the same to_version and expiry as
+// "scheduled" and is not a failure. Falling into the default branch made a
+// duplicate job, a River retry, or a manual re-run FAIL the task, and in wave
+// 0 that halts the whole rollout on a site that is doing exactly what it was
+// told.
+func TestAlreadyScheduledArmsRatherThanHalts(t *testing.T) {
+	cmd := &recordingSelfUpdater{resp: agentcmd.AgentSelfUpdateResponse{
+		Status:      agentcmd.SelfUpdateAlreadyScheduled,
+		FromVersion: "0.61.80",
+		ToVersion:   "0.62.0",
+		CronMode:    agentcmd.CronModeExternal,
+		ExpiresAt:   time.Now().Add(2 * time.Hour).Unix(),
+		Detail:      "an upgrade to 0.62.0 is already staged",
+	}}
+	h := newAgentHarness(t, 10, cmd, &fakeVersions{}, true)
+
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+
+	task := h.store.Task(0)
+	if terminal(task.Status) {
+		t.Fatalf("an already-staged upgrade must leave the task un-finished, got %q (%s)", task.Status, task.Detail)
+	}
+	if task.Status != TaskRunning {
+		t.Fatalf("status = %q, want %q", task.Status, TaskRunning)
+	}
+	if h.store.RunStatus() == RunHalted {
+		t.Fatal("a site reporting an upgrade already staged must never halt the run")
+	}
+	if len(h.enq.confirms) != 1 {
+		t.Fatalf("an already-staged upgrade still needs its confirmation poll, got %d", len(h.enq.confirms))
+	}
+	got := h.enq.confirms[0]
+	if got.ExpectVersion != "0.62.0" {
+		t.Fatalf("the confirmation poll must carry the staged target version, got %q", got.ExpectVersion)
+	}
+	// And it is the SAME path as "scheduled" in every respect that matters,
+	// including the wider window an external-cron site earns.
+	if want := time.Now().Add(agentConfirmDeadlineExternalCron); got.DeadlineAt.Before(want.Add(-time.Minute)) {
+		t.Fatalf("deadline = %s, want the external-cron window", got.DeadlineAt)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Beat 1: an agent that predates the channel
+// ---------------------------------------------------------------------------
+
+// TestOldAgentWithoutTheSelfUpdateRouteIsNotAFailure covers the site every
+// FIRST rollout of this channel is made of.
+//
+// An agent that predates this release has no self-update route, so the request
+// 404s with rest_no_route. Recorded as TaskFailed, that is a canary "failure"
+// an operator cannot tell apart from a genuinely broken build: the rollout stops
+// with an error pointing at the release when the release is fine and the site
+// simply has nothing to receive the command.
+//
+// It is not a failure. Nothing was sent that the site could act on and nothing
+// was applied. It is not a confirmation either, so it is recorded non-confirming
+// and the gate stays shut on the strength of it.
+func TestOldAgentWithoutTheSelfUpdateRouteIsNotAFailure(t *testing.T) {
+	cmd := &recordingSelfUpdater{err: oldAgentRouteMissing()}
+	h := newAgentHarness(t, 100, cmd, &fakeVersions{}, true)
+
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+
+	canary := h.store.Task(0)
+	if canary.Status == TaskFailed {
+		t.Fatalf("an agent with no self-update route is not a site failure: %+v", canary)
+	}
+	if canary.Status != TaskSkipped {
+		t.Fatalf("status = %q, want %q (neither confirmed nor failed)", canary.Status, TaskSkipped)
+	}
+	if !strings.Contains(canary.Detail, "predates the self-update channel") {
+		t.Fatalf("the detail must say what actually happened: %q", canary.Detail)
+	}
+	if canary.Error != "" {
+		t.Fatalf("a site that was never able to receive the command has no error to report, got %q", canary.Error)
+	}
+
+	// The tally is what the gate reads, and it must score this as evidence of
+	// nothing rather than as a broken site.
+	tally := tallyWave(waveOrder(h.store.snapshotLocked()), WaveRange{Start: 0, End: 1})
+	if tally.Failed != 0 {
+		t.Fatalf("an agent that predates the channel counted as %d failure(s)", tally.Failed)
+	}
+	if tally.Other != 1 {
+		t.Fatalf("want it scored as neither, got Other=%d", tally.Other)
+	}
+
+	// A wave of ONLY such sites still stops the run, which is correct: it
+	// proved nothing, and this channel cannot upgrade an agent that has no
+	// self-update route. What changed is the reason, which now points at the
+	// sites rather than at the build.
+	if h.store.RunStatus() != RunHalted {
+		t.Fatalf("run status = %q, want %q", h.store.RunStatus(), RunHalted)
+	}
+	if reason := h.waves.lastHaltReason(); strings.Contains(reason, "failed on") {
+		t.Fatalf("the halt must not read as a canary failure: %q", reason)
+	} else if !strings.Contains(reason, "not attempted") {
+		t.Fatalf("the halt must say the wave attempted nothing: %q", reason)
+	}
+}
+
+// TestAMixedWaveIsNotFailedByAgentsThatPredateTheChannel is where the
+// classification pays for itself. A real fleet is mixed, so a pilot wave holds
+// both kinds of site at once.
+//
+// Scored as failures, ONE old agent among three pilot sites is a 33% failure
+// rate against a 10% threshold, and the rollout halts on sites that were never
+// eligible to be upgraded through this channel in the first place. Scored as
+// "proved nothing", the two sites that did confirm carry the wave.
+func TestAMixedWaveIsNotFailedByAgentsThatPredateTheChannel(t *testing.T) {
+	armed := agentcmd.AgentSelfUpdateResponse{
+		Status: agentcmd.SelfUpdateScheduled, FromVersion: agentPlanFrom, ToVersion: agentPlanTarget,
+		CronMode: agentcmd.CronModeLoopback,
+	}
+	cmd := &scriptedSelfUpdater{t: t, answers: []selfUpdateAnswer{
+		// wave 0: the canary upgrades normally.
+		{resp: armed},
+		// wave 1, first site: an agent from before this channel existed.
+		{err: oldAgentRouteMissing()},
+		// wave 1, the other two sites.
+		{resp: armed},
+		{resp: armed},
+	}}
+	versions := &fakeVersions{versions: map[uuid.UUID]string{}}
+	h := newAgentHarness(t, 10, cmd, versions, true)
+	confirm := NewAgentConfirmWorker(h.w)
+
+	// Confirming a task the way beat 3 does: the new code reports its version.
+	confirmTask := func(i int) {
+		t.Helper()
+		task := h.store.Task(i)
+		args, found := AgentConfirmArgs{}, false
+		for _, c := range h.enq.confirms {
+			if c.TaskID == task.ID {
+				args, found = c, true
+			}
+		}
+		if !found {
+			t.Fatalf("task %d never scheduled a confirmation poll", i)
+		}
+		versions.versions[args.SiteID] = agentPlanTarget
+		if err := confirm.Work(context.Background(), &river.Job[AgentConfirmArgs]{Args: args}); err != nil {
+			t.Fatalf("confirm task %d: %v", i, err)
+		}
+		if got := h.store.Task(i).Status; got != TaskSucceeded {
+			t.Fatalf("task %d status = %q, want %q", i, got, TaskSucceeded)
+		}
+	}
+
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("canary Work: %v", err)
+	}
+	confirmTask(0)
+
+	for i := 1; i <= 3; i++ {
+		if err := h.work(context.Background(), i); err != nil {
+			t.Fatalf("wave 1 site %d Work: %v", i, err)
+		}
+	}
+	if got := h.store.Task(1).Status; got != TaskSkipped {
+		t.Fatalf("the old agent's task is %q, want %q", got, TaskSkipped)
+	}
+	confirmTask(2)
+	confirmTask(3)
+
+	tally := tallyWave(waveOrder(h.store.snapshotLocked()), WaveRange{Start: 1, End: 4})
+	if tally.Failed != 0 {
+		t.Fatalf("the pilot recorded %d failure(s); an agent that predates the channel is not one", tally.Failed)
+	}
+	if tally.Confirmed != 2 || tally.Other != 1 {
+		t.Fatalf("pilot tally = %+v, want 2 confirmed and 1 neither", tally)
+	}
+	if h.store.RunStatus() == RunHalted {
+		t.Fatalf("a pilot that confirmed two of three sites must not halt the run: %q", h.waves.lastHaltReason())
+	}
+	// And the rollout continues: wave 2's six sites are enqueued.
+	state := DeriveAgentWaveState(h.store.snapshotLocked())
+	if state.OpenThrough != 3 {
+		t.Fatalf("OpenThrough = %d, want 3 (wave 2 open)", state.OpenThrough)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Beat 1: "up_to_date" is a disagreement, not a confirmation
+// ---------------------------------------------------------------------------
+
+// TestUpToDateIsCheckedAgainstThePublishedVersion pins the rule that makes an
+// "up_to_date" answer meaningful: a confirmation must prove THE SITE reached the
+// version this run set out to install, never that the published version moved
+// down to meet the site.
+//
+// Every case therefore states the run's whole premise (the plan-time target and
+// the version the site itself reported at plan time) alongside what the agent
+// claims now and what the control plane publishes now. The old version of this
+// test named only the last two, which is exactly the pair that cannot tell a
+// site that upgraded from a manifest that was reverted.
+func TestUpToDateIsCheckedAgainstThePublishedVersion(t *testing.T) {
+	cases := []struct {
+		name string
+		// planned is the version the run was created to install, recorded on
+		// every task. Empty stands in for a pre-existing row that predates the
+		// planned-target record.
+		planned string
+		// plannedFrom is what the site reported when the run was planned.
+		plannedFrom string
+		// published is what this control plane says the current build is NOW.
+		published string
+		// reported is the version the agent says it is already running NOW.
+		reported   string
+		noReleases bool
+		wantStatus string
+		wantHalted bool
+		// wantDetail are substrings the operator-facing detail must carry.
+		wantDetail []string
+	}{
+		{
+			// The site MOVED: it ran 0.61.80 when the run was planned and now
+			// reports the 0.62.0 this run set out to install. That, and only
+			// that, is what makes this a confirmation.
+			name:    "the site reached the version this run set out to install",
+			planned: "0.62.0", plannedFrom: "0.61.80",
+			published: "0.62.0", reported: "0.62.0",
+			wantStatus: TaskSucceeded,
+		},
+		{
+			// Past the target (a site that took a later build in the meantime)
+			// still reached it.
+			name:    "the site is past the version this run set out to install",
+			planned: "0.62.0", plannedFrom: "0.61.80",
+			published: "0.62.0", reported: "0.62.1",
+			wantStatus: TaskSucceeded,
+		},
+		{
+			// THE FAILURE THIS RULE EXISTS FOR. The operator reverted the
+			// manifest to the fleet's own build, so published == reported ==
+			// the version this site was already running when the run was
+			// planned. Nothing moved except the manifest. Under the old rule
+			// (score the answer against a live read of the manifest) this
+			// recorded SUCCEEDED.
+			name:    "the manifest was reverted to the version the site already ran",
+			planned: "0.62.0", plannedFrom: "0.61.80",
+			published: "0.61.80", reported: "0.61.80",
+			wantStatus: TaskSkipped,
+			// The premise is void as well: the target is no longer published.
+			wantHalted: true,
+			wantDetail: []string{"0.62.0", "0.61.80"},
+		},
+		{
+			// The same revert, seen on a site that DID upgrade before the
+			// revert landed. The site's own outcome is honest (it reached the
+			// target), but the run is over: no remaining site can reach a
+			// version that is no longer published.
+			name:    "a site that did reach the target before the manifest was reverted",
+			planned: "0.62.0", plannedFrom: "0.61.80",
+			published: "0.61.80", reported: "0.62.0",
+			wantStatus: TaskSucceeded,
+			wantHalted: true,
+		},
+		{
+			// The ordinary disagreement: the target is still published and this
+			// site simply has not got there.
+			name:    "the site is still behind the version this run set out to install",
+			planned: "0.62.0", plannedFrom: "0.61.80",
+			published: "0.62.0", reported: "0.61.80",
+			wantStatus: TaskSkipped,
+			wantDetail: []string{"0.62.0", "0.61.80"},
+		},
+		{
+			// latest.json absent entirely: the manifest handler 204s and the
+			// agent has nothing to offer. Proving nothing must not read as
+			// proving something. It is NOT a void premise either: "cannot read
+			// the manifest" is not "the manifest was reverted", and a transient
+			// read failure must not halt a fleet on its own.
+			name:    "the published version cannot be read",
+			planned: "0.62.0", plannedFrom: "0.61.80",
+			published: "", reported: "0.61.80",
+			wantStatus: TaskSkipped,
+			wantDetail: []string{"missing", "0.62.0"},
+		},
+		{
+			name:    "there is no release reader at all",
+			planned: "0.62.0", plannedFrom: "0.61.80",
+			noReleases: true, reported: "0.62.0",
+			// The site did reach the run's target, and that fact does not
+			// depend on being able to read the manifest at all: the target was
+			// recorded when the run was planned.
+			wantStatus: TaskSucceeded,
+		},
+		{
+			// A row created before the planned target was persisted. There is
+			// nothing to check the claim against, so it confirms nothing.
+			// Fail-closed is the only safe direction for an in-flight run
+			// spanning the deploy that introduced the record.
+			name:    "the run recorded no target at all",
+			planned: "", plannedFrom: "0.61.80",
+			published: "0.61.80", reported: "0.61.80",
+			wantStatus: TaskSkipped,
+			wantDetail: []string{"did not record"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &recordingSelfUpdater{resp: agentcmd.AgentSelfUpdateResponse{
+				Status: agentcmd.SelfUpdateUpToDate, FromVersion: tc.reported}}
+			h := newAgentHarness(t, 10, cmd, &fakeVersions{}, true).withPlan(tc.planned, tc.plannedFrom)
+			if tc.noReleases {
+				h.withoutReleases()
+			} else {
+				h.withPublished(tc.published)
+			}
+
+			if err := h.work(context.Background(), 0); err != nil {
+				t.Fatalf("Work: %v", err)
+			}
+			task := h.store.Task(0)
+			if task.Status != tc.wantStatus {
+				t.Fatalf("status = %q, want %q (detail: %s)", task.Status, tc.wantStatus, task.Detail)
+			}
+			for _, want := range tc.wantDetail {
+				if !strings.Contains(task.Detail, want) {
+					t.Fatalf("detail = %q, want it to name %q", task.Detail, want)
+				}
+			}
+			if tc.wantStatus == TaskSkipped && !strings.Contains(task.Detail, tc.reported) {
+				t.Fatalf("a non-confirming answer must name the site's own version; detail = %q", task.Detail)
+			}
+			if halted := h.store.RunStatus() == RunHalted; halted != tc.wantHalted && tc.wantStatus == TaskSucceeded {
+				// A non-confirming canary halts through the ordinary wave gate
+				// (it proved nothing), so only the CONFIRMING cases isolate the
+				// void-premise halt from that.
+				t.Fatalf("run halted = %v, want %v (status %q)", halted, tc.wantHalted, task.Status)
+			}
+		})
+	}
+}
+
+// TestRevertedReleaseManifestHaltsInsteadOfReportingSuccess is the failure this
+// whole check exists for, driven end to end over a real fleet.
+//
+// The setup is the emergency path exactly as an operator walks it: the run is
+// planned while 0.62.0 is published, the canary bricks a site, and the operator
+// reverts latest.json to 0.61.80, the last known good build, which is what the
+// fleet is already running. That revert is the natural reflex during an
+// incident, and the release reader caches for five minutes, so it propagates
+// well inside any rollout window.
+//
+// Every subsequent arm then answers "up_to_date", because the agent's downgrade
+// guard refuses the older manifest. Scored against a LIVE read of that manifest,
+// all 100 sites matched the published version, all 100 recorded succeeded, the
+// Failed tally stayed at zero, every wave gate passed, and the run reported
+// "completed, succeeded=100" with NOT ONE AGENT MOVED. The same fleet must now
+// stop at the canary.
+//
+// Note what makes this test the thing its name says, and what the previous
+// version of it was missing: the manifest is genuinely REVERTED here (published
+// drops to the fleet's own 0.61.80). Publishing something the fleet has not
+// reached yet only tests "the site is still behind", which was never the risky
+// case, because a still-newer published version cannot be matched by a site that
+// stood still.
+func TestRevertedReleaseManifestHaltsInsteadOfReportingSuccess(t *testing.T) {
+	cmd := &recordingSelfUpdater{resp: agentcmd.AgentSelfUpdateResponse{
+		Status: agentcmd.SelfUpdateUpToDate, FromVersion: agentPlanFrom,
+		Detail: "no update available"}}
+	// Planned against 0.62.0 (the store's plan-time record), then reverted to
+	// the version the whole fleet already runs.
+	h := newAgentHarness(t, 100, cmd, &fakeVersions{}, true).withPublished(agentPlanFrom)
+
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+
+	canary := h.store.Task(0)
+	if canary.Status == TaskSucceeded {
+		t.Fatalf("a site that stood still while the manifest moved down to meet it must never confirm itself: %+v", canary)
+	}
+	if canary.Status != TaskSkipped {
+		t.Fatalf("canary status = %q, want %q (neither confirmed nor failed)", canary.Status, TaskSkipped)
+	}
+	// The detail has to name all three numbers, because they are what separates
+	// "reverted manifest" from "site has not upgraded yet".
+	for _, want := range []string{agentPlanTarget, agentPlanFrom} {
+		if !strings.Contains(canary.Detail, want) {
+			t.Fatalf("detail must name the planned target, the site's version and the published version: %q", canary.Detail)
+		}
+	}
+
+	// The rollout must stop, and it must stop here.
+	if h.store.RunStatus() != RunHalted {
+		t.Fatalf("run status = %q, want %q: a wave that confirmed nothing may not open the next one",
+			h.store.RunStatus(), RunHalted)
+	}
+	for i := 1; i < 100; i++ {
+		if got := h.store.Task(i).Status; got != TaskCancelled {
+			t.Fatalf("task %d status = %q, want %q", i, got, TaskCancelled)
+		}
+	}
+	if len(cmd.calls) != 1 {
+		t.Fatalf("exactly one site may be contacted before the halt, got %d", len(cmd.calls))
+	}
+
+	// And the tally itself: neither confirmed nor failed.
+	tally := tallyWave(waveOrder(h.store.snapshotLocked()), WaveRange{Start: 0, End: 1})
+	if tally.Confirmed != 0 {
+		t.Fatalf("a disagreement counted as %d confirmation(s)", tally.Confirmed)
+	}
+	if tally.Failed != 0 {
+		t.Fatalf("a disagreement counted as %d failure(s); it is evidence of nothing, not of a broken site", tally.Failed)
+	}
+	if tally.Other != 1 {
+		t.Fatalf("want the disagreement scored as neither, got Other=%d", tally.Other)
+	}
+}
+
+// TestACanaryThatAppliedNothingCannotOpenWaveOne is the consequence that makes
+// the rule above load-bearing rather than cosmetic, and it is the shape a mixed
+// fleet actually produces.
+//
+// The canary is an arbitrary site (waveOrder is a uuid ordering, not a choice),
+// so on a fleet where some sites already run the reverted build the canary can
+// BE one of them. It answers up_to_date, matches the reverted manifest exactly,
+// and applies nothing. If that counts as a confirmation, wave 0 "proves" the
+// upgrade works and waves 1 and 2 open against sites that genuinely are behind:
+// a rollout authorised by a site that did nothing.
+//
+// The wave gate is the entire safety mechanism of this feature, so the property
+// under test is stated directly: no task outside wave 0 may become dispatchable,
+// be enqueued, or be contacted.
+func TestACanaryThatAppliedNothingCannotOpenWaveOne(t *testing.T) {
+	cmd := &recordingSelfUpdater{resp: agentcmd.AgentSelfUpdateResponse{
+		Status: agentcmd.SelfUpdateUpToDate, FromVersion: agentPlanFrom}}
+	h := newAgentHarness(t, 100, cmd, &fakeVersions{}, true).withPublished(agentPlanFrom)
+
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+
+	state := DeriveAgentWaveState(h.store.snapshotLocked())
+	if !state.Halt {
+		t.Fatal("a canary that applied nothing must halt the run")
+	}
+	if state.OpenThrough != 0 {
+		t.Fatalf("OpenThrough = %d, want 0: no wave may be open behind a canary that proved nothing", state.OpenThrough)
+	}
+	if len(state.DispatchableTasks()) != 0 {
+		t.Fatalf("a canary that applied nothing made %d task(s) dispatchable", len(state.DispatchableTasks()))
+	}
+	// Named directly: the first site of wave 1.
+	wave1 := h.store.Task(1)
+	if state.GateOpenFor(wave1.ID) {
+		t.Fatal("wave 1 opened on the strength of a canary that applied nothing")
+	}
+	if len(h.enq.tasks) != 0 {
+		t.Fatalf("no further wave may be enqueued: %+v", h.enq.tasks)
+	}
+	if len(cmd.calls) != 1 {
+		t.Fatalf("%d sites were contacted; only the canary may be", len(cmd.calls))
+	}
+
+	// Drive the wave-1 job anyway, as a duplicate enqueue or a manual retry
+	// would: the gate, not the absence of a job, is what protects the fleet.
+	if err := h.work(context.Background(), 1); err != nil {
+		t.Fatalf("wave 1 Work: %v", err)
+	}
+	if len(cmd.calls) != 1 {
+		t.Fatalf("a wave-1 job reached its site after a canary that applied nothing: %d calls", len(cmd.calls))
+	}
+	if got := h.store.Task(1).Status; got != TaskCancelled {
+		t.Fatalf("wave-1 task status = %q, want %q", got, TaskCancelled)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rollback is never attempted
+// ---------------------------------------------------------------------------
+
+// TestAgentTargetNeverRollsBack proves the agent branch cannot reach the
+// rollback machinery. The Worker is built with a NIL ordinary Commander, which
+// is what Worker.rollback and Worker.runApply both call through, so any
+// attempt to snapshot, health-probe or roll back would panic. The task is
+// driven to every failure outcome the branch has, because a rollback attempt
+// would be most tempting exactly there.
+//
+// A rollback for this target is undeliverable by construction: the code that
+// would receive and execute the rollback command is the code that was being
+// replaced. Attempting it would only add a misleading "rollback FAILED" to a
+// task whose real problem is something else.
+func TestAgentTargetNeverRollsBack(t *testing.T) {
+	cases := []struct {
+		name string
+		resp agentcmd.AgentSelfUpdateResponse
+		err  error
+	}{
+		{"agent reported error", agentcmd.AgentSelfUpdateResponse{Status: agentcmd.SelfUpdateError}, nil},
+		{"transport error", agentcmd.AgentSelfUpdateResponse{}, errors.New("connection refused")},
+		{"scheduled but never confirmed", agentcmd.AgentSelfUpdateResponse{
+			Status: agentcmd.SelfUpdateScheduled, FromVersion: "0.61.80", ToVersion: "0.62.0"}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &recordingSelfUpdater{resp: tc.resp, err: tc.err}
+			versions := &fakeVersions{versions: map[uuid.UUID]string{}}
+			h := newAgentHarness(t, 3, cmd, versions, true)
+
+			// A nil Commander means w.cmd.Rollback would panic; recovering here
+			// turns that into a readable failure rather than a crashed test run.
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("the agent target reached the plugin update/rollback path: %v", r)
+				}
+			}()
+
+			if err := h.work(context.Background(), 0); err != nil {
+				t.Fatalf("Work: %v", err)
+			}
+			// Drive the scheduled case all the way through its deadline too,
+			// since that is the outcome that most resembles a broken update.
+			if len(h.enq.confirms) == 1 {
+				args := h.enq.confirms[0]
+				args.DeadlineAt = time.Now().Add(-time.Minute)
+				cw := NewAgentConfirmWorker(h.w)
+				if err := cw.Work(context.Background(), &river.Job[AgentConfirmArgs]{Args: args}); err != nil {
+					t.Fatalf("confirm Work: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Beat 3: confirmation
+// ---------------------------------------------------------------------------
+
+// TestConfirmationIsTheOnlySuccess walks the confirmation poll through its
+// three outcomes: still waiting, confirmed, and past the deadline.
+func TestConfirmationIsTheOnlySuccess(t *testing.T) {
+	arm := agentcmd.AgentSelfUpdateResponse{
+		Status: agentcmd.SelfUpdateScheduled, FromVersion: "0.61.80", ToVersion: "0.62.0",
+		CronMode: agentcmd.CronModeLoopback,
+	}
+
+	t.Run("still on the old version keeps waiting", func(t *testing.T) {
+		versions := &fakeVersions{versions: map[uuid.UUID]string{}}
+		h := newAgentHarness(t, 10, &recordingSelfUpdater{resp: arm}, versions, true)
+		if err := h.work(context.Background(), 0); err != nil {
+			t.Fatalf("Work: %v", err)
+		}
+		args := h.enq.confirms[0]
+		versions.versions[args.SiteID] = "0.61.80" // unchanged
+
+		cw := NewAgentConfirmWorker(h.w)
+		err := cw.Work(context.Background(), &river.Job[AgentConfirmArgs]{Args: args})
+		if !isSnooze(err) {
+			t.Fatalf("an unconfirmed upgrade inside its window must snooze, got %v", err)
+		}
+		if terminal(h.store.Task(0).Status) {
+			t.Fatalf("the task must stay running while waiting, got %q", h.store.Task(0).Status)
+		}
+	})
+
+	t.Run("the new version reporting in confirms", func(t *testing.T) {
+		versions := &fakeVersions{versions: map[uuid.UUID]string{}}
+		h := newAgentHarness(t, 10, &recordingSelfUpdater{resp: arm}, versions, true)
+		if err := h.work(context.Background(), 0); err != nil {
+			t.Fatalf("Work: %v", err)
+		}
+		args := h.enq.confirms[0]
+		versions.versions[args.SiteID] = "0.62.0" // the new code phoned home
+
+		cw := NewAgentConfirmWorker(h.w)
+		if err := cw.Work(context.Background(), &river.Job[AgentConfirmArgs]{Args: args}); err != nil {
+			t.Fatalf("confirm Work: %v", err)
+		}
+		task := h.store.Task(0)
+		if task.Status != TaskSucceeded {
+			t.Fatalf("status = %q, want %q", task.Status, TaskSucceeded)
+		}
+		if task.ToVersion != "0.62.0" {
+			t.Fatalf("to_version = %q, want the version the site actually reported", task.ToVersion)
+		}
+		// Confirming the canary is what opens wave 1, and only wave 1.
+		if len(h.enq.tasks) != 3 {
+			t.Fatalf("confirming the canary must enqueue wave 1's three sites, got %d", len(h.enq.tasks))
+		}
+	})
+
+	t.Run("deadline expiry fails as unconfirmed", func(t *testing.T) {
+		versions := &fakeVersions{versions: map[uuid.UUID]string{}}
+		h := newAgentHarness(t, 10, &recordingSelfUpdater{resp: arm}, versions, true)
+		if err := h.work(context.Background(), 0); err != nil {
+			t.Fatalf("Work: %v", err)
+		}
+		args := h.enq.confirms[0]
+		versions.versions[args.SiteID] = "0.61.80"
+		args.DeadlineAt = time.Now().Add(-time.Second) // window already closed
+
+		cw := NewAgentConfirmWorker(h.w)
+		if err := cw.Work(context.Background(), &river.Job[AgentConfirmArgs]{Args: args}); err != nil {
+			t.Fatalf("confirm Work: %v", err)
+		}
+		task := h.store.Task(0)
+		if task.Status != TaskFailed {
+			t.Fatalf("status = %q, want %q", task.Status, TaskFailed)
+		}
+		if task.Error != "agent_self_update_unconfirmed" {
+			t.Fatalf("an unconfirmed timeout needs its own distinct reason, got %q", task.Error)
+		}
+		if !strings.Contains(task.Detail, "unconfirmed") {
+			t.Fatalf("detail must say unconfirmed: %q", task.Detail)
+		}
+		// It must also say the site was not necessarily touched, because that
+		// is the difference between "go look at this site" and "this site is
+		// fine, its cron is not".
+		if !strings.Contains(task.Detail, "not necessarily") {
+			t.Fatalf("detail must explain that nothing was necessarily applied: %q", task.Detail)
+		}
+		// And an unconfirmed canary halts the fleet.
+		if h.store.RunStatus() != RunHalted {
+			t.Fatalf("run status = %q, want %q", h.store.RunStatus(), RunHalted)
+		}
+	})
+}
+
+// TestConfirmTimeoutCarriesTheAgentsOwnAccountOfTheApply covers the one thing
+// this control plane cannot work out for itself.
+//
+// Beat 2 runs inside a WordPress cron request that has no CP response to ride
+// on, so from here "the cron run never happened" and "the cron run happened and
+// the upgrade failed" are the SAME silence: the site keeps reporting the old
+// version until the deadline expires either way. They are different incidents.
+// One means the site was never touched and its cron needs looking at; the other
+// means the upgrade ran and broke, on a site that was touched.
+//
+// The agent records which of the two it was and replays it on its next metadata
+// push. Discarding that record throws away the only account of what happened.
+func TestConfirmTimeoutCarriesTheAgentsOwnAccountOfTheApply(t *testing.T) {
+	arm := agentcmd.AgentSelfUpdateResponse{
+		Status: agentcmd.SelfUpdateScheduled, FromVersion: agentPlanFrom, ToVersion: agentPlanTarget,
+		CronMode: agentcmd.CronModeLoopback,
+	}
+	stamped := time.Date(2026, 7, 28, 9, 30, 0, 0, time.UTC)
+
+	cases := []struct {
+		name string
+		// result is what the agent reported; nil means it reported nothing,
+		// which is what every agent predating the record does.
+		result *AgentApplyResult
+		// lookupErr stands in for the site read failing outright.
+		lookupErr error
+		// noLookup stands in for a control plane that never wired the lookup.
+		noLookup bool
+		want     []string
+		notWant  []string
+	}{
+		{
+			name:   "the apply ran and failed",
+			result: &AgentApplyResult{Status: "failed", FromVersion: agentPlanFrom, ToVersion: agentPlanTarget, Detail: "Upgrader threw: could not create directory", At: stamped},
+			want:   []string{"FAILED", "could not create directory", agentPlanTarget, "2026-07-28T09:30:00Z"},
+		},
+		{
+			name:   "the staged upgrade expired before any apply ran",
+			result: &AgentApplyResult{Status: "expired", FromVersion: agentPlanFrom, ToVersion: agentPlanTarget, Detail: "Staged self-update expired before the apply request ran.", At: stamped},
+			want:   []string{"EXPIRED", "never happened in time"},
+		},
+		{
+			name:   "the agent says it did apply, so the version report is what is missing",
+			result: &AgentApplyResult{Status: "applied", FromVersion: agentPlanFrom, ToVersion: agentPlanTarget, At: stamped},
+			want:   []string{"DID apply", "metadata push"},
+		},
+		{
+			name:   "the on-disk version was already at the target",
+			result: &AgentApplyResult{Status: "already_applied", FromVersion: agentPlanTarget, ToVersion: agentPlanTarget, At: stamped},
+			want:   []string{"ALREADY at or past"},
+		},
+		{
+			// Forward compatibility: a status a newer agent introduces must
+			// reach the operator verbatim rather than being swallowed by an
+			// older control plane that does not recognise it.
+			name:   "a status this control plane does not recognise",
+			result: &AgentApplyResult{Status: "quarantined", ToVersion: agentPlanTarget, Detail: "held by the host", At: stamped},
+			want:   []string{`"quarantined"`, "held by the host"},
+		},
+		{
+			// Old agents send nothing. The timeout must read exactly as it did
+			// before this record existed.
+			name:    "the agent reported nothing",
+			result:  nil,
+			notWant: []string{"The agent's own record"},
+		},
+		{
+			name:      "the site read fails",
+			lookupErr: errors.New("database unavailable"),
+			notWant:   []string{"The agent's own record", "database unavailable"},
+		},
+		{
+			name:     "the lookup was never wired",
+			noLookup: true,
+			notWant:  []string{"The agent's own record"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			versions := &fakeVersions{versions: map[uuid.UUID]string{}}
+			h := newAgentHarness(t, 10, &recordingSelfUpdater{resp: arm}, versions, true)
+			if err := h.work(context.Background(), 0); err != nil {
+				t.Fatalf("Work: %v", err)
+			}
+			args := h.enq.confirms[0]
+			versions.versions[args.SiteID] = agentPlanFrom // never moved
+
+			if !tc.noLookup {
+				results := &fakeApplyResults{results: map[uuid.UUID]AgentApplyResult{}, err: tc.lookupErr}
+				if tc.result != nil {
+					results.results[args.SiteID] = *tc.result
+				}
+				h.withApplyResults(results)
+			}
+
+			args.DeadlineAt = time.Now().Add(-time.Second)
+			cw := NewAgentConfirmWorker(h.w)
+			if err := cw.Work(context.Background(), &river.Job[AgentConfirmArgs]{Args: args}); err != nil {
+				t.Fatalf("confirm Work: %v", err)
+			}
+
+			task := h.store.Task(0)
+			// Whatever the agent said, the outcome itself is unchanged: an
+			// unconfirmed upgrade is a failed task. The record explains it, it
+			// does not excuse it.
+			if task.Status != TaskFailed {
+				t.Fatalf("status = %q, want %q", task.Status, TaskFailed)
+			}
+			if task.Error != "agent_self_update_unconfirmed" {
+				t.Fatalf("error = %q, want the distinct unconfirmed reason", task.Error)
+			}
+			if !strings.Contains(task.Detail, "unconfirmed") {
+				t.Fatalf("the base explanation must survive: %q", task.Detail)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(task.Detail, want) {
+					t.Fatalf("detail = %q, want it to carry %q", task.Detail, want)
+				}
+			}
+			for _, notWant := range tc.notWant {
+				if strings.Contains(task.Detail, notWant) {
+					t.Fatalf("detail = %q, must not carry %q", task.Detail, notWant)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Wave gating through the worker
+// ---------------------------------------------------------------------------
+
+// TestWaveZeroFailureHaltsRunThroughWorker is the end-to-end version of the
+// canary gate: one failing site, and the other 99 are cancelled without ever
+// being contacted.
+func TestWaveZeroFailureHaltsRunThroughWorker(t *testing.T) {
+	cmd := &recordingSelfUpdater{resp: agentcmd.AgentSelfUpdateResponse{
+		Status: agentcmd.SelfUpdateError, FromVersion: "0.61.80", Detail: "manifest fetch failed"}}
+	h := newAgentHarness(t, 100, cmd, &fakeVersions{}, true)
+
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+
+	if got := h.store.Task(0).Status; got != TaskFailed {
+		t.Fatalf("the canary status = %q, want %q", got, TaskFailed)
+	}
+	if h.store.RunStatus() != RunHalted {
+		t.Fatalf("run status = %q, want %q", h.store.RunStatus(), RunHalted)
+	}
+	for i := 1; i < 100; i++ {
+		if got := h.store.Task(i).Status; got != TaskCancelled {
+			t.Fatalf("task %d status = %q, want %q", i, got, TaskCancelled)
+		}
+	}
+	if len(cmd.calls) != 1 {
+		t.Fatalf("exactly one site may be contacted before the halt, got %d", len(cmd.calls))
+	}
+	if len(h.enq.tasks) != 0 {
+		t.Fatalf("a halted run enqueues nothing further: %+v", h.enq.tasks)
+	}
+}
+
+// TestWaveGateSnoozesUntilPriorWaveConfirms is the end-to-end ordering proof:
+// a wave-1 job that runs before the canary confirmed snoozes WITHOUT
+// contacting its site, then proceeds once the canary is confirmed.
+func TestWaveGateSnoozesUntilPriorWaveConfirms(t *testing.T) {
+	cmd := &recordingSelfUpdater{resp: agentcmd.AgentSelfUpdateResponse{
+		Status: agentcmd.SelfUpdateScheduled, FromVersion: "0.61.80", ToVersion: "0.62.0"}}
+	h := newAgentHarness(t, 10, cmd, &fakeVersions{}, true)
+
+	// The canary arms and is awaiting confirmation.
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	armed := len(cmd.calls)
+
+	// A wave-1 job arrives early (a duplicate enqueue, a manual retry, a
+	// leftover job). It must not touch its site.
+	err := h.work(context.Background(), 1)
+	if !isSnooze(err) {
+		t.Fatalf("a task whose wave has not opened must snooze, got %v", err)
+	}
+	if len(cmd.calls) != armed {
+		t.Fatalf("a gated task contacted its site: %d calls, want %d", len(cmd.calls), armed)
+	}
+	if got := h.store.Task(1).Status; got != TaskPending {
+		t.Fatalf("a gated task stays pending, got %q", got)
+	}
+
+	// The canary confirms; now the same job proceeds.
+	h.store.setStatus(0, TaskSucceeded)
+	if err := h.work(context.Background(), 1); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if len(cmd.calls) != armed+1 {
+		t.Fatalf("the wave-1 task must dispatch once its wave opened: %d calls", len(cmd.calls))
+	}
+
+	// Wave 2 is still shut behind the unconfirmed pilot.
+	if err := h.work(context.Background(), 4); !isSnooze(err) {
+		t.Fatalf("wave 2 must stay gated behind an unconfirmed pilot, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Halting an in-flight rollout
+// ---------------------------------------------------------------------------
+
+// TestHaltCancelsOnlyTasksNothingWasSentFor is the kill switch's honesty
+// property. A halt cancels what was never dispatched and LEAVES RUNNING TASKS
+// ALONE.
+//
+// Cancelling a running task is wrong twice over. It records a falsehood:
+// model.go defines TaskCancelled as "nothing was ever sent to this site", and a
+// running agent self-update task has already had its command delivered and a
+// cron event spawned on the site. And it blinds the control plane:
+// AgentConfirmWorker.Work short-circuits on a terminal status, so cancelling
+// the row stops the poll that would have established whether that site upgraded
+// or bricked, at the exact moment an operator hit the kill switch and most
+// needs to know.
+func TestHaltCancelsOnlyTasksNothingWasSentFor(t *testing.T) {
+	tenant := uuid.New()
+	s := newAgentStore(tenant, 10)
+	repo := &fakeWaveRepo{s: s}
+
+	// A realistic in-flight moment: the canary confirmed, one wave-1 site is
+	// armed and awaiting beat 3, one already failed, and the rest are pending.
+	s.setStatus(0, TaskSucceeded)
+	s.setStatus(1, TaskRunning)
+	s.setStatus(2, TaskFailed)
+
+	ev, err := repo.HaltAgentRun(context.Background(), tenant, s.run.ID, "stopped by the operator")
+	if err != nil {
+		t.Fatalf("halt: %v", err)
+	}
+
+	if got := s.Task(1).Status; got != TaskRunning {
+		t.Fatalf("the armed, in-flight task was moved to %q: a halt must not claim nothing was sent to a site that was contacted", got)
+	}
+	if got := s.Task(0).Status; got != TaskSucceeded {
+		t.Fatalf("task 0 status = %q, want the recorded outcome untouched", got)
+	}
+	if got := s.Task(2).Status; got != TaskFailed {
+		t.Fatalf("task 2 status = %q, want the recorded outcome untouched", got)
+	}
+	for i := 3; i < 10; i++ {
+		if got := s.Task(i).Status; got != TaskCancelled {
+			t.Fatalf("task %d status = %q, want %q: nothing was ever sent for it", i, got, TaskCancelled)
+		}
+	}
+	if ev.Cancelled != 7 {
+		t.Fatalf("cancelled %d tasks, want the 7 that were still pending", ev.Cancelled)
+	}
+	if s.RunStatus() != RunHalted {
+		t.Fatalf("run status = %q, want %q", s.RunStatus(), RunHalted)
+	}
+}
+
+// TestHaltLeavesTheConfirmPollAbleToResolveARunningTask is the consequence that
+// makes the rule above matter, driven through the real confirmation worker: a
+// site that was mid-upgrade when the run halted still gets its outcome
+// established. Cancelling the row would have made Work return immediately on a
+// terminal status, and the control plane would never have learned that this
+// site did in fact come back on the new build.
+func TestHaltLeavesTheConfirmPollAbleToResolveARunningTask(t *testing.T) {
+	arm := agentcmd.AgentSelfUpdateResponse{
+		Status: agentcmd.SelfUpdateScheduled, FromVersion: "0.61.80", ToVersion: "0.62.0",
+		CronMode: agentcmd.CronModeLoopback,
+	}
+	versions := &fakeVersions{versions: map[uuid.UUID]string{}}
+	h := newAgentHarness(t, 10, &recordingSelfUpdater{resp: arm}, versions, true)
+
+	// The canary arms and is awaiting confirmation.
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	args := h.enq.confirms[0]
+
+	// The operator hits the kill switch mid-flight.
+	if _, err := h.waves.HaltAgentRun(context.Background(), args.TenantID, args.RunID, "stopped by the operator"); err != nil {
+		t.Fatalf("halt: %v", err)
+	}
+	if got := h.store.Task(0).Status; got != TaskRunning {
+		t.Fatalf("the in-flight canary is %q; the halt must leave it for its confirm job", got)
+	}
+
+	// The site comes back on the new build. The CP must still record it.
+	versions.versions[args.SiteID] = "0.62.0"
+	cw := NewAgentConfirmWorker(h.w)
+	if err := cw.Work(context.Background(), &river.Job[AgentConfirmArgs]{Args: args}); err != nil {
+		t.Fatalf("confirm Work: %v", err)
+	}
+	task := h.store.Task(0)
+	if task.Status != TaskSucceeded {
+		t.Fatalf("status = %q, want %q: the halt must not stop the CP learning what happened to a site it had already touched",
+			task.Status, TaskSucceeded)
+	}
+	if task.ToVersion != "0.62.0" {
+		t.Fatalf("to_version = %q, want the version the site actually reported", task.ToVersion)
+	}
+}
+
+// TestAPostHaltWorkerCannotOverwriteACancelledTask covers the other side of the
+// same race, one layer down. A worker that was already in flight when the halt
+// landed comes back and reports its outcome. The task row was cancelled while
+// it was away, and the first recorded outcome must win: overwriting 'cancelled'
+// with 'succeeded' would make the kill switch look like it stopped a rollout
+// that then reported itself a success.
+//
+// The precondition is enforced in SQL (db/query/updates.sql: FinishUpdateTask
+// matches only status IN ('pending','running')), so it is atomic against the
+// halt rather than a check-then-write in Go. fakeAgentRepo.FinishTask mirrors
+// it, including returning ErrTaskNotOpen with the row unchanged.
+func TestAPostHaltWorkerCannotOverwriteACancelledTask(t *testing.T) {
+	arm := agentcmd.AgentSelfUpdateResponse{
+		Status: agentcmd.SelfUpdateScheduled, FromVersion: "0.61.80", ToVersion: "0.62.0",
+		CronMode: agentcmd.CronModeLoopback,
+	}
+	versions := &fakeVersions{versions: map[uuid.UUID]string{}}
+	h := newAgentHarness(t, 10, &recordingSelfUpdater{resp: arm}, versions, true)
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	args := h.enq.confirms[0]
+
+	// The task is cancelled out from under the in-flight worker (the halt path
+	// only cancels PENDING rows, so this stands in for a task that was still
+	// pending when the halt landed and whose duplicate job arrived afterwards).
+	h.store.setStatus(0, TaskCancelled)
+
+	// The worker returns with a success it can no longer record.
+	versions.versions[args.SiteID] = "0.62.0"
+	cw := NewAgentConfirmWorker(h.w)
+	if err := cw.Work(context.Background(), &river.Job[AgentConfirmArgs]{Args: args}); err != nil {
+		t.Fatalf("confirm Work: %v", err)
+	}
+	if got := h.store.Task(0).Status; got != TaskCancelled {
+		t.Fatalf("status = %q, want %q: a cancelled task must not be overwritten by a worker that finished after the halt", got, TaskCancelled)
+	}
+
+	// The same must hold for the beat-1 path, which reaches Worker.finish by a
+	// different route.
+	if err := h.w.finish(context.Background(), h.store.Task(0), TaskSucceeded, "0.61.80", "0.62.0", "late success", ""); err != nil {
+		t.Fatalf("finish must treat an already-terminal task as a no-op, got %v", err)
+	}
+	if got := h.store.Task(0).Status; got != TaskCancelled {
+		t.Fatalf("status = %q, want %q", got, TaskCancelled)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch cost
+// ---------------------------------------------------------------------------
+
+// TestWaveDispatchIsLinearInFleetSize is a performance property with a
+// correctness consequence, so it is asserted like one.
+//
+// Every agent-task terminal transition re-judges the wave gate, and the gate
+// used to answer with EVERY still-pending task of the open wave. On a fleet of
+// n sites that means each of the final wave's completions re-enqueued its
+// ~n still-pending siblings: O(n^2) River inserts, on the one feature whose
+// entire purpose is fleet-wide rollout. At 1000 sites that is roughly half a
+// million jobs for 1000 units of work.
+//
+// The driver below is the real state machine (DeriveAgentWaveState through the
+// claim/evaluate repo) walked to completion, counting enqueues. Each task must
+// be enqueued exactly once, as its wave opens.
+func TestWaveDispatchIsLinearInFleetSize(t *testing.T) {
+	const n = 200
+	ctx := context.Background()
+	tenant := uuid.New()
+	s := newAgentStore(tenant, n)
+	repo := &fakeWaveRepo{s: s}
+
+	enqueues := map[uuid.UUID]int{}
+	total := 0
+	enqueue := func(id uuid.UUID) {
+		enqueues[id]++
+		total++
+	}
+
+	// Service.CreateRun enqueues only the canary; every later job exists
+	// because a wave opened.
+	queue := []uuid.UUID{s.tasks[0].ID}
+	enqueue(queue[0])
+
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+
+		claim, _, err := repo.ClaimAgentWaveTask(ctx, tenant, s.run.ID, id)
+		if err != nil {
+			t.Fatalf("claim: %v", err)
+		}
+		if claim != ClaimProceed {
+			continue
+		}
+		// The site upgrades and confirms.
+		s.setStatusByID(id, TaskSucceeded)
+
+		ev, err := repo.EvaluateAgentRun(ctx, tenant, s.run.ID)
+		if err != nil {
+			t.Fatalf("evaluate: %v", err)
+		}
+		if ev.Halted {
+			t.Fatalf("a fleet that confirmed every site must not halt: %s", ev.Reason)
+		}
+		for _, task := range ev.Dispatchable {
+			enqueue(task.ID)
+			queue = append(queue, task.ID)
+		}
+	}
+
+	// Every site ran...
+	for i := 0; i < n; i++ {
+		if got := s.Task(i).Status; got != TaskSucceeded {
+			t.Fatalf("task %d status = %q: the rollout did not reach every site", i, got)
+		}
+	}
+	// ...and each was enqueued exactly once.
+	for i := 0; i < n; i++ {
+		if got := enqueues[s.tasks[i].ID]; got != 1 {
+			t.Fatalf("task %d was enqueued %d times, want exactly 1", i, got)
+		}
+	}
+	if total != n {
+		t.Fatalf("%d enqueues for %d sites: dispatch work must be linear in fleet size, not quadratic", total, n)
+	}
+}
+
+// TestWaveGatingIsUnchangedByTheDispatchFix guards the boundary of that
+// performance fix: the ORDER and the GATE are untouched. A wave still opens
+// only when the wave before it has confirmed, still dispatches exactly its own
+// sites, and a duplicate evaluation still produces no extra dispatch.
+func TestWaveGatingIsUnchangedByTheDispatchFix(t *testing.T) {
+	ctx := context.Background()
+	tenant := uuid.New()
+	s := newAgentStore(tenant, 10) // waves: [0,1) [1,4) [4,10)
+	repo := &fakeWaveRepo{s: s}
+
+	// Nothing opens behind an unfinished canary.
+	ev, err := repo.EvaluateAgentRun(ctx, tenant, s.run.ID)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(ev.Dispatchable) != 1 || ev.Dispatchable[0].ID != s.tasks[0].ID {
+		t.Fatalf("wave 0 is open on sight and is the only dispatchable wave, got %d task(s)", len(ev.Dispatchable))
+	}
+
+	// The canary confirms: exactly wave 1's three sites, and nothing else.
+	s.setStatus(0, TaskSucceeded)
+	ev, err = repo.EvaluateAgentRun(ctx, tenant, s.run.ID)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(ev.Dispatchable) != 3 {
+		t.Fatalf("want wave 1's three sites, got %d", len(ev.Dispatchable))
+	}
+	for _, task := range ev.Dispatchable {
+		if task.ID == s.tasks[0].ID || task.ID == s.tasks[4].ID {
+			t.Fatalf("the dispatch set leaked outside wave 1: %s", task.ID)
+		}
+	}
+
+	// Wave 1 starts moving. Its jobs already exist, so nothing more is
+	// dispatched, this is the quadratic re-enqueue that used to happen here.
+	s.setStatus(1, TaskRunning)
+	ev, err = repo.EvaluateAgentRun(ctx, tenant, s.run.ID)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(ev.Dispatchable) != 0 {
+		t.Fatalf("a wave already being worked must not be re-dispatched, got %d task(s)", len(ev.Dispatchable))
+	}
+
+	// And wave 2 stays shut until wave 1 has confirmed, gate unchanged.
+	st := DeriveAgentWaveState(s.snapshotLocked())
+	if st.GateOpenFor(s.tasks[4].ID) {
+		t.Fatal("wave 2 must stay shut behind an unconfirmed pilot")
+	}
+	s.setStatus(1, TaskSucceeded)
+	s.setStatus(2, TaskSucceeded)
+	s.setStatus(3, TaskSucceeded)
+	ev, err = repo.EvaluateAgentRun(ctx, tenant, s.run.ID)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(ev.Dispatchable) != 6 {
+		t.Fatalf("want wave 2's six sites once the pilot confirmed, got %d", len(ev.Dispatchable))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Planning / API boundary
+// ---------------------------------------------------------------------------
+
+func agentServiceFixture(t *testing.T, enabled bool, latest string, sites map[uuid.UUID]SiteInfo) (*Service, *countingEnqueuer, *fakeCreateRepo) {
+	t.Helper()
+	repo := &fakeCreateRepo{}
+	enq := &countingEnqueuer{}
+	svc := NewService(repo, &fakeSiteLookup{sites: sites}, enq, domain.NewValidator(), domain.SystemClock{})
+	svc.SetAgentSelfUpdate(enabled, fixedReleases{version: latest})
+	return svc, enq, repo
+}
+
+// TestAgentTargetRejectsVersionPin is the API-boundary refusal the design
+// insists on: a pin cannot be honoured (the agent's manifest only ever points
+// at the published build, and its downgrade guard refuses older ones), so
+// accepting one and installing something else would lie to the operator.
+func TestAgentTargetRejectsVersionPin(t *testing.T) {
+	siteID := uuid.New()
+	sites := map[uuid.UUID]SiteInfo{
+		siteID: {ID: siteID, Enrolled: true, AgentVersion: "0.61.80"},
+	}
+
+	cases := []struct {
+		name     string
+		version  string
+		wantCode string
+	}{
+		{"explicit pin", "0.62.0", "agent_version_pin_unsupported"},
+		{"older pin", "0.61.70", "agent_version_pin_unsupported"},
+		{"a pin that would otherwise pass the charset check", "1.2.3", "agent_version_pin_unsupported"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, enq, _ := agentServiceFixture(t, true, "0.62.0", sites)
+			_, tasks, err := svc.CreateRun(context.Background(), CreateRunInput{
+				TenantID: uuid.New(),
+				SiteIDs:  []uuid.UUID{siteID},
+				Items:    []Item{{Type: TargetAgent, Version: tc.version}},
+			})
+			de, ok := domain.AsDomain(err)
+			if !ok || de.Kind != domain.KindValidation {
+				t.Fatalf("want a validation domain error, got %v", err)
+			}
+			if de.Code != tc.wantCode {
+				t.Fatalf("code = %q, want %q", de.Code, tc.wantCode)
+			}
+			if len(tasks) != 0 || enq.n != 0 {
+				t.Fatalf("a rejected pin must create nothing: %d tasks, %d jobs", len(tasks), enq.n)
+			}
+		})
+	}
+
+	// "latest" and the unset default describe what the channel actually does,
+	// so both are accepted.
+	for _, version := range []string{"", "latest"} {
+		t.Run("accepted version "+version, func(t *testing.T) {
+			svc, _, _ := agentServiceFixture(t, true, "0.62.0", sites)
+			_, tasks, err := svc.CreateRun(context.Background(), CreateRunInput{
+				TenantID: uuid.New(),
+				SiteIDs:  []uuid.UUID{siteID},
+				Items:    []Item{{Type: TargetAgent, Version: version}},
+			})
+			if err != nil {
+				t.Fatalf("version %q must be accepted: %v", version, err)
+			}
+			if len(tasks) != 1 {
+				t.Fatalf("want one task, got %d", len(tasks))
+			}
+			// Accepting "latest" from the operator and RECORDING "latest" on the
+			// task are different things. What the run must persist is the
+			// version "latest" resolved to at plan time: that is the run's
+			// premise, and it is the only fixed thing an "up_to_date" answer can
+			// later be checked against. Storing the word "latest" leaves nothing
+			// to check but a live read of a mutable manifest.
+			if tasks[0].DesiredVersion != "0.62.0" {
+				t.Fatalf("desired_version = %q, want the resolved published version 0.62.0: the run's target must survive a manifest change",
+					tasks[0].DesiredVersion)
+			}
+			if tasks[0].FromVersion != "0.61.80" {
+				t.Fatalf("from_version = %q, want the version the site reported at plan time", tasks[0].FromVersion)
+			}
+			if tasks[0].TargetSlug != AgentTargetSlug {
+				t.Fatalf("target_slug = %q, want %q", tasks[0].TargetSlug, AgentTargetSlug)
+			}
+		})
+	}
+}
+
+// TestAgentRunRecordsItsPlannedTarget states the persistence rule on its own,
+// because everything the confirmation check does rests on it: a run has a
+// premise, "install version X", and X has to survive the manifest changing
+// under it.
+//
+// The published version is deliberately read ONCE per run here (planAgentTasks
+// resolves it, then every task carries it), so two sites planned in the same run
+// can never end up scored against two different targets.
+func TestAgentRunRecordsItsPlannedTarget(t *testing.T) {
+	siteA, siteB := uuid.New(), uuid.New()
+	sites := map[uuid.UUID]SiteInfo{
+		siteA: {ID: siteA, Enrolled: true, AgentVersion: "0.61.80"},
+		siteB: {ID: siteB, Enrolled: true, AgentVersion: "0.60.1"},
+	}
+	svc, _, _ := agentServiceFixture(t, true, "0.62.0", sites)
+
+	_, tasks, err := svc.CreateRun(context.Background(), CreateRunInput{
+		TenantID: uuid.New(),
+		SiteIDs:  []uuid.UUID{siteA, siteB},
+		Items:    []Item{{Type: TargetAgent}},
+	})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("want two tasks, got %d", len(tasks))
+	}
+	for _, task := range tasks {
+		if task.DesiredVersion != "0.62.0" {
+			t.Fatalf("site %s: desired_version = %q, want the one resolved target 0.62.0", task.SiteID, task.DesiredVersion)
+		}
+		// And the plan-time from_version stays per-site: it is what makes "this
+		// site moved" checkable, so it must be this site's own version.
+		if want := sites[task.SiteID].AgentVersion; task.FromVersion != want {
+			t.Fatalf("site %s: from_version = %q, want its own reported %q", task.SiteID, task.FromVersion, want)
+		}
+	}
+}
+
+// TestAgentTargetBoundaryRefusals covers the remaining refusals at the API
+// boundary, each of which exists because the alternative would be a silent
+// half-truth.
+func TestAgentTargetBoundaryRefusals(t *testing.T) {
+	siteID := uuid.New()
+	sites := map[uuid.UUID]SiteInfo{
+		siteID: {ID: siteID, Enrolled: true, AgentVersion: "0.61.80"},
+	}
+
+	cases := []struct {
+		name     string
+		enabled  bool
+		latest   string
+		in       CreateRunInput
+		wantCode string
+	}{
+		{
+			name: "the kill switch refuses the run outright", enabled: false, latest: "0.62.0",
+			in:       CreateRunInput{SiteIDs: []uuid.UUID{siteID}, Items: []Item{{Type: TargetAgent}}},
+			wantCode: "agent_self_update_disabled",
+		},
+		{
+			name: "an unknown published version cannot call anyone behind", enabled: true, latest: "",
+			in:       CreateRunInput{SiteIDs: []uuid.UUID{siteID}, Items: []Item{{Type: TargetAgent}}},
+			wantCode: "agent_release_unknown",
+		},
+		{
+			name: "the agent target cannot share a run", enabled: true, latest: "0.62.0",
+			in: CreateRunInput{SiteIDs: []uuid.UUID{siteID}, Items: []Item{
+				{Type: TargetAgent},
+				{Type: TargetPlugin, Slug: "akismet/akismet.php"},
+			}},
+			wantCode: "agent_target_exclusive",
+		},
+		{
+			name: "there is no dry run", enabled: true, latest: "0.62.0",
+			in:       CreateRunInput{SiteIDs: []uuid.UUID{siteID}, Items: []Item{{Type: TargetAgent}}, DryRun: true},
+			wantCode: "agent_dry_run_unsupported",
+		},
+		{
+			name: "a slug is not accepted for this target", enabled: true, latest: "0.62.0",
+			in:       CreateRunInput{SiteIDs: []uuid.UUID{siteID}, Items: []Item{{Type: TargetAgent, Slug: "some-other-plugin"}}},
+			wantCode: "agent_slug_unsupported",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, enq, _ := agentServiceFixture(t, tc.enabled, tc.latest, sites)
+			in := tc.in
+			in.TenantID = uuid.New()
+			_, tasks, err := svc.CreateRun(context.Background(), in)
+			de, ok := domain.AsDomain(err)
+			if !ok {
+				t.Fatalf("want a domain error, got %v", err)
+			}
+			if de.Code != tc.wantCode {
+				t.Fatalf("code = %q, want %q (%s)", de.Code, tc.wantCode, de.Message)
+			}
+			if len(tasks) != 0 || enq.n != 0 {
+				t.Fatalf("a refused run must create nothing: %d tasks, %d jobs", len(tasks), enq.n)
+			}
+		})
+	}
+}
+
+// TestAgentPlanUsesReportedVersionNotInventory pins the planning authority.
+// Only a site whose REPORTED agent version is behind the PUBLISHED one gets a
+// task; a site already current, one running the build that has no self-updater
+// at all, and one whose version cannot be read are all left alone. In
+// particular the site's plugin inventory (which carries an agent self-update
+// advisory the control plane suppresses everywhere else) is never the input.
+func TestAgentPlanUsesReportedVersionNotInventory(t *testing.T) {
+	outdated := uuid.New()
+	current := uuid.New()
+	directory := uuid.New()
+	unknown := uuid.New()
+	staleInventory := uuid.New()
+
+	sites := map[uuid.UUID]SiteInfo{
+		outdated: {ID: outdated, Enrolled: true, AgentVersion: "0.61.80"},
+		current:  {ID: current, Enrolled: true, AgentVersion: "0.62.0"},
+		// The plugin-directory build ships without a self-updater and is
+		// upgraded by the directory, so it can never consume this channel.
+		directory: {ID: directory, Enrolled: true, AgentVersion: "0.61.80", Components: []Component{
+			{Type: TargetPlugin, Slug: "fleet-agent-site-manager/fleet-agent-site-manager.php", Name: "Fleet Agent Site Manager"},
+		}},
+		// Never reported a version: never guess.
+		unknown: {ID: unknown, Enrolled: true, AgentVersion: ""},
+		// Reported version is CURRENT, but its inventory still carries a stale
+		// self-update advisory. The reported version must win.
+		staleInventory: {ID: staleInventory, Enrolled: true, AgentVersion: "0.62.0", Components: []Component{
+			{Type: TargetPlugin, Slug: "wpmgr-agent/wpmgr-agent.php", Name: "WPMgr Agent",
+				Version: "0.61.80", UpdateAvailable: true, NewVersion: "0.62.0"},
+		}},
+	}
+
+	svc, enq, _ := agentServiceFixture(t, true, "0.62.0", sites)
+	_, tasks, err := svc.CreateRun(context.Background(), CreateRunInput{
+		TenantID: uuid.New(),
+		SiteIDs:  []uuid.UUID{outdated, current, directory, unknown, staleInventory},
+		Items:    []Item{{Type: TargetAgent}},
+	})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("only the genuinely outdated site may be planned, got %d tasks", len(tasks))
+	}
+	if tasks[0].SiteID != outdated {
+		t.Fatalf("planned the wrong site: %s", tasks[0].SiteID)
+	}
+	if tasks[0].FromVersion != "0.61.80" {
+		t.Fatalf("from_version = %q, want the site's own reported version", tasks[0].FromVersion)
+	}
+	if tasks[0].TargetType != TargetAgent {
+		t.Fatalf("target_type = %q, want %q", tasks[0].TargetType, TargetAgent)
+	}
+	if enq.n != 1 {
+		t.Fatalf("one planned task, one enqueued job; got %d", enq.n)
+	}
+}
+
+// TestAgentRunEnqueuesOnlyTheFirstWave: a rollout that must not continue never
+// has a job sitting ready to run. Only the canary is enqueued at creation; the
+// rest of the fleet is enqueued wave by wave as each one confirms.
+func TestAgentRunEnqueuesOnlyTheFirstWave(t *testing.T) {
+	sites := map[uuid.UUID]SiteInfo{}
+	ids := make([]uuid.UUID, 0, 40)
+	for i := 0; i < 40; i++ {
+		id := uuid.New()
+		ids = append(ids, id)
+		sites[id] = SiteInfo{ID: id, Enrolled: true, AgentVersion: "0.61.80"}
+	}
+
+	svc, enq, _ := agentServiceFixture(t, true, "0.62.0", sites)
+	_, tasks, err := svc.CreateRun(context.Background(), CreateRunInput{
+		TenantID: uuid.New(),
+		SiteIDs:  ids,
+		Items:    []Item{{Type: TargetAgent}},
+	})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if len(tasks) != 40 {
+		t.Fatalf("want 40 planned tasks, got %d", len(tasks))
+	}
+	if enq.n != 1 {
+		t.Fatalf("only the canary may be enqueued at creation, got %d job(s)", enq.n)
+	}
+
+	// The control: an ORDINARY run still enqueues everything at once, so this
+	// staging is specific to the agent channel and did not change bulk updates.
+	pluginSites := map[uuid.UUID]SiteInfo{}
+	pluginIDs := make([]uuid.UUID, 0, 5)
+	for i := 0; i < 5; i++ {
+		id := uuid.New()
+		pluginIDs = append(pluginIDs, id)
+		pluginSites[id] = SiteInfo{ID: id, Enrolled: true, Components: []Component{
+			{Type: TargetPlugin, Slug: "akismet/akismet.php", Name: "Akismet Anti-spam",
+				Version: "5.3.1", UpdateAvailable: true, NewVersion: "5.3.2"},
+		}}
+	}
+	svc2, enq2, _ := agentServiceFixture(t, true, "0.62.0", pluginSites)
+	if _, _, err := svc2.CreateRun(context.Background(), CreateRunInput{
+		TenantID: uuid.New(),
+		SiteIDs:  pluginIDs,
+		Items:    []Item{{Type: TargetPlugin, Slug: "akismet/akismet.php"}},
+	}); err != nil {
+		t.Fatalf("CreateRun (plugin control): %v", err)
+	}
+	if enq2.n != 5 {
+		t.Fatalf("an ordinary run must still enqueue every task, got %d", enq2.n)
+	}
+}
+
+// TestReaperSparesAnAgentTaskWithinItsOwnThreshold: an agent task is
+// legitimately slow, a later wave waits for every earlier wave, and a site on
+// external cron waits up to 90 minutes for beat 3 alone. The 45-minute
+// stale-task threshold would reap those as failures and, worse, feed a false
+// failure into the wave gate and halt a healthy rollout.
+func TestReaperSparesAnAgentTaskWithinItsOwnThreshold(t *testing.T) {
+	tenant := uuid.New()
+	store := newAgentStore(tenant, 3)
+	repo := &reaperFakeRepo{fakeAgentRepo: fakeAgentRepo{s: store}}
+
+	// Both rows are well past the ordinary threshold, so the SQL sweep returns
+	// them; only the agent one is spared here.
+	agentTask := store.Task(0)
+	agentTask.UpdatedAt = time.Now().Add(-2 * time.Hour)
+	pluginTask := store.Task(1)
+	pluginTask.TargetType = TargetPlugin
+	pluginTask.TargetSlug = "akismet/akismet.php"
+	pluginTask.UpdatedAt = time.Now().Add(-2 * time.Hour)
+	repo.stale = []Task{agentTask, pluginTask}
+
+	w := NewWorker(repo, nil, nil, nil, nil, nil, nil, 5, 0)
+	if err := NewReaperWorker(w).Work(context.Background(), &river.Job[ReapStaleTasksArgs]{}); err != nil {
+		t.Fatalf("reaper Work: %v", err)
+	}
+
+	if len(repo.finished) != 1 {
+		t.Fatalf("only the ordinary task may be reaped, got %d terminal transitions", len(repo.finished))
+	}
+	if repo.finished[0].TaskID != pluginTask.ID {
+		t.Fatalf("the reaper terminalized the agent task, which is legitimately slow")
+	}
+
+	// Past its OWN threshold, an agent task is still reaped: it must not hold
+	// its in-flight slot forever.
+	repo.finished = nil
+	agentTask.UpdatedAt = time.Now().Add(-agentStaleTaskThreshold - time.Minute)
+	repo.stale = []Task{agentTask}
+	if err := NewReaperWorker(w).Work(context.Background(), &river.Job[ReapStaleTasksArgs]{}); err != nil {
+		t.Fatalf("reaper Work: %v", err)
+	}
+	if len(repo.finished) != 1 {
+		t.Fatalf("a genuinely stuck agent task must still be reaped, got %d", len(repo.finished))
+	}
+}
+
+// reaperFakeRepo serves a fixed stale-task list to the reaper.
+type reaperFakeRepo struct {
+	fakeAgentRepo
+	stale []Task
+}
+
+func (f *reaperFakeRepo) ListStaleUpdateTasks(context.Context, time.Duration, int32) ([]Task, error) {
+	return f.stale, nil
+}

--- a/apps/api/internal/update/agent_wave.go
+++ b/apps/api/internal/update/agent_wave.go
@@ -1,0 +1,362 @@
+package update
+
+import (
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentplugin"
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentrelease"
+)
+
+// This file is the wave gate: the primary safety property of the agent
+// self-update channel, and the one thing the ordinary per-task update worker
+// has no equivalent of (worker.go is strictly per-task-per-site, with no
+// notion of a run-wide rollout order).
+//
+// A fleet-wide agent upgrade is the one update whose failure mode is not
+// recoverable per site: the code being replaced is the code that would report
+// and repair the failure. So the rollout is staged, and each stage must PROVE
+// itself, by the new code phoning home, before the next one is allowed to
+// touch a site.
+//
+// Everything here is a pure function of the run's current task rows. There is
+// no separate wave ledger to drift out of sync, no "current wave" column to
+// double-advance, and no schema change: the wave a task belongs to is derived
+// from its position in the run's deterministic task order, and a wave's state
+// is derived from its tasks' statuses. Two workers that evaluate concurrently
+// compute the SAME verdict from the same rows; the transaction-scoped advisory
+// lock in the repo (see pgRepo.ClaimAgentWaveTask / EvaluateAgentRun) is what
+// makes the resulting ACTION happen exactly once.
+
+// Wave sizing. wave 0 is a single canary site; wave 1 is a small pilot; wave 2
+// is everything else.
+const (
+	// waveCanarySize is wave 0: exactly one site. One site is the smallest
+	// blast radius that can still prove the whole three-beat protocol works
+	// against a real site in this fleet.
+	waveCanarySize = 1
+
+	// wavePilotFraction sizes wave 1 as a fraction of the whole run.
+	wavePilotFraction = 0.05
+
+	// wavePilotMinimum floors wave 1 at three sites. A pilot of one or two
+	// cannot distinguish "the upgrade works" from "one site happened to be
+	// fine": the failure-rate gate below needs a denominator.
+	wavePilotMinimum = 3
+
+	// waveFailureThreshold is the confirmation-failure rate above which a
+	// completed wave halts the run. Deliberately small: this channel replaces
+	// the code that would otherwise report and repair a failure, so a rate that
+	// would be unremarkable for a plugin rollout is already a fleet incident
+	// here. Compared with `>`, so a pilot of 3 halts on its first failure
+	// (33% > 10%) while a large final wave tolerates a thin tail of sites whose
+	// cron never fires.
+	waveFailureThreshold = 0.10
+)
+
+// WaveRange is one wave's half-open span [Start, End) over a run's ordered
+// task list.
+type WaveRange struct {
+	Start int
+	End   int
+}
+
+// Len returns how many tasks the wave covers.
+func (w WaveRange) Len() int { return w.End - w.Start }
+
+// PlanWaves splits n ordered tasks into the canary/pilot/remainder waves.
+// Empty trailing waves are dropped, so a 1-site run has exactly one wave and a
+// 3-site run has two. n <= 0 yields no waves.
+func PlanWaves(n int) []WaveRange {
+	if n <= 0 {
+		return nil
+	}
+	waves := make([]WaveRange, 0, 3)
+	cursor := 0
+
+	canary := waveCanarySize
+	if canary > n {
+		canary = n
+	}
+	waves = append(waves, WaveRange{Start: cursor, End: cursor + canary})
+	cursor += canary
+	if cursor >= n {
+		return waves
+	}
+
+	pilot := int(math.Ceil(float64(n) * wavePilotFraction))
+	if pilot < wavePilotMinimum {
+		pilot = wavePilotMinimum
+	}
+	if pilot > n-cursor {
+		pilot = n - cursor
+	}
+	waves = append(waves, WaveRange{Start: cursor, End: cursor + pilot})
+	cursor += pilot
+	if cursor >= n {
+		return waves
+	}
+
+	waves = append(waves, WaveRange{Start: cursor, End: n})
+	return waves
+}
+
+// waveOrder returns a run's agent self-update tasks in the ONE deterministic
+// order the wave plan is defined over, filtering out anything that is not an
+// agent task (a run cannot mix targets, see validateAgentItem, but the
+// filter keeps this function total rather than trusting that invariant).
+//
+// The order is (created_at, id). Note that created_at is NOT a tiebreaker in
+// practice: every task in a run is inserted by one transaction, and Postgres
+// gives every now() in a transaction the same transaction timestamp, so all
+// rows in a run share created_at exactly. The id is therefore what actually
+// orders them. That is fine, the property the gate needs is a STABLE total
+// order that every worker computes identically, which (created_at, id) is, // but it does mean wave 0's canary is an arbitrary site rather than a chosen
+// one. Ordering by created_at alone would be worse than arbitrary: it would be
+// non-deterministic, and different workers could disagree about which wave a
+// task belongs to.
+func waveOrder(tasks []Task) []Task {
+	out := make([]Task, 0, len(tasks))
+	for _, t := range tasks {
+		if t.TargetType == TargetAgent {
+			out = append(out, t)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].CreatedAt.Before(out[j].CreatedAt)
+		}
+		return out[i].ID.String() < out[j].ID.String()
+	})
+	return out
+}
+
+// waveTally counts one wave's task outcomes.
+type waveTally struct {
+	Total int
+	// InFlight is pending or running: the wave has not finished.
+	InFlight int
+	// Confirmed is the ONLY success: the new agent code reported its version
+	// (see AgentConfirmWorker), or the site already ran the published build.
+	Confirmed int
+	// Failed covers every way a site did not come back: the arm command
+	// failed, the agent reported a failure, or the upgrade was never confirmed
+	// before its deadline.
+	Failed int
+	// Other is terminal-but-neither: skipped (the CP declined this site) or
+	// cancelled (an earlier halt). Counted separately because it must not be
+	// read as proof of anything.
+	Other int
+}
+
+func tallyWave(order []Task, w WaveRange) waveTally {
+	var t waveTally
+	for i := w.Start; i < w.End && i < len(order); i++ {
+		t.Total++
+		switch order[i].Status {
+		case TaskSucceeded:
+			t.Confirmed++
+		case TaskFailed, TaskRolledBack:
+			t.Failed++
+		case TaskSkipped, TaskCancelled:
+			t.Other++
+		default: // pending, running
+			t.InFlight++
+		}
+	}
+	return t
+}
+
+// haltReasonFor returns why a COMPLETED wave forbids the rollout continuing,
+// or "" when it does not.
+//
+// Zero confirmations is always a halt, whatever the mix of failures and skips
+// behind it. "Confirmed" is the only evidence this channel produces, so a wave
+// that produced none proved nothing, and opening the next wave on the strength
+// of it would be opening it on no evidence at all.
+func haltReasonFor(index int, t waveTally) string {
+	if t.Total == 0 {
+		return ""
+	}
+	if t.Confirmed == 0 {
+		return fmt.Sprintf("wave %d confirmed no site (%d failed, %d not attempted of %d): the upgrade proved nothing, so no further site may be touched",
+			index, t.Failed, t.Other, t.Total)
+	}
+	if index == 0 && t.Failed > 0 {
+		return fmt.Sprintf("wave 0 (the canary) failed on %d of %d site(s)", t.Failed, t.Total)
+	}
+	if rate := float64(t.Failed) / float64(t.Total); rate > waveFailureThreshold {
+		return fmt.Sprintf("wave %d confirmation-failure rate %.0f%% (%d of %d) exceeds the %.0f%% threshold",
+			index, rate*100, t.Failed, t.Total, waveFailureThreshold*100)
+	}
+	return ""
+}
+
+// AgentWaveState is a run's whole wave machine, derived from its task rows.
+type AgentWaveState struct {
+	// Order is the run's agent tasks in wave order.
+	Order []Task
+	// Waves is the wave plan over Order.
+	Waves []WaveRange
+	// Halt is true when a completed wave forbids the rollout continuing.
+	Halt bool
+	// HaltReason explains Halt in operator-readable terms; empty when !Halt.
+	HaltReason string
+	// OpenThrough is the number of waves cleared to dispatch: a task in wave
+	// index i may be sent to its site iff i < OpenThrough. Wave 0 is always
+	// open (nothing precedes it); each later wave opens only once every
+	// preceding wave is fully terminal and passed its gate. Always 0 when Halt.
+	OpenThrough int
+}
+
+// DeriveAgentWaveState computes the wave machine from the run's current task
+// rows. It is deliberately a pure function with no clock, no I/O and no
+// hidden state, so two workers finishing concurrently derive the identical
+// verdict and the repo's advisory lock only has to make the resulting write
+// happen once.
+func DeriveAgentWaveState(tasks []Task) AgentWaveState {
+	order := waveOrder(tasks)
+	st := AgentWaveState{Order: order, Waves: PlanWaves(len(order))}
+	if len(st.Waves) == 0 {
+		return st
+	}
+
+	// Wave 0 has nothing before it to prove anything, so it is open on sight.
+	st.OpenThrough = 1
+	for i, w := range st.Waves {
+		t := tallyWave(order, w)
+		if t.InFlight > 0 {
+			// This wave is still running: nothing after it may open, and its
+			// gate cannot be judged yet.
+			return st
+		}
+		if reason := haltReasonFor(i, t); reason != "" {
+			st.Halt = true
+			st.HaltReason = reason
+			st.OpenThrough = 0
+			return st
+		}
+		st.OpenThrough = i + 2
+	}
+	if st.OpenThrough > len(st.Waves) {
+		st.OpenThrough = len(st.Waves)
+	}
+	return st
+}
+
+// WaveIndexOf returns the wave a task belongs to, and whether it was found in
+// the run's wave order at all.
+func (s AgentWaveState) WaveIndexOf(taskID uuid.UUID) (int, bool) {
+	pos := -1
+	for i, t := range s.Order {
+		if t.ID == taskID {
+			pos = i
+			break
+		}
+	}
+	if pos < 0 {
+		return 0, false
+	}
+	for i, w := range s.Waves {
+		if pos >= w.Start && pos < w.End {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// GateOpenFor reports whether a task is cleared to dispatch right now.
+func (s AgentWaveState) GateOpenFor(taskID uuid.UUID) bool {
+	if s.Halt {
+		return false
+	}
+	idx, ok := s.WaveIndexOf(taskID)
+	if !ok {
+		return false
+	}
+	return idx < s.OpenThrough
+}
+
+// DispatchableTasks returns the tasks that must be enqueued NOW: the pending
+// tasks of a wave that has JUST opened, and nothing else.
+//
+// "Just opened" is a property of the rows, not of a remembered transition: the
+// newest open wave (index OpenThrough-1) is newly open exactly when every one
+// of its tasks is still pending. A task can only leave pending by being claimed
+// (pgRepo.ClaimAgentWaveTask moves it pending -> running, and every terminal
+// state for an agent task is reached through a claim), so an all-pending open
+// wave is one that has never had a job dispatched from it. Every wave BEFORE it
+// is fully terminal by construction, that is the gate's opening condition, so
+// there is never a pending task in an earlier open wave to pick up here.
+//
+// Returning the whole open-wave pending set on EVERY terminal transition, which
+// is what this used to do, is quadratic: each of a 950-site final wave's
+// completions re-returned the ~950 still-pending siblings, so a fleet-wide
+// rollout enqueued on the order of n^2/2 River jobs and melted the control
+// plane at exactly the scale this feature exists for. Enqueueing each task once
+// as its wave opens is the same dispatch set spread over the same waves, in
+// linear work.
+//
+// The gating semantics are untouched: which tasks may run, and when, is still
+// decided by GateOpenFor at claim time. Duplicate enqueues remain harmless
+// (two finishers of the previous wave may both observe the same newly-opened
+// wave, and the claim path only ever hands one caller the pending -> running
+// transition), and a job whose wave has since shut simply snoozes.
+//
+// A task whose enqueue is LOST is therefore no longer re-dispatched by the next
+// sibling's completion. That is deliberate: it stays pending, its wave never
+// completes, and the stale-task reaper (agentStaleTaskThreshold) terminalizes
+// it, which the wave gate reads as a wave that confirmed less than it should
+// have and halts the run. For this channel, stopping is the safe direction.
+func (s AgentWaveState) DispatchableTasks() []Task {
+	if s.Halt || s.OpenThrough <= 0 || s.OpenThrough > len(s.Waves) {
+		return nil
+	}
+	w := s.Waves[s.OpenThrough-1]
+
+	out := make([]Task, 0, w.Len())
+	for j := w.Start; j < w.End && j < len(s.Order); j++ {
+		if s.Order[j].Status != TaskPending {
+			// Something in this wave has already been dispatched, so this wave
+			// is not newly open and its jobs already exist.
+			return nil
+		}
+		out = append(out, s.Order[j])
+	}
+	return out
+}
+
+// agentSelfUpdateConfirmed decides beat 3: has the NEW code phoned home?
+//
+// reported is the version the site last pushed over its signed metadata
+// channel (sites.agent_version). expect is the version the agent said beat 2
+// would install; from is what it was running when the run was armed.
+//
+// The comparison is delegated to agentrelease.Classify, the same classifier
+// the fleet agent-freshness dashboard uses, so "is this site on the published
+// build" has exactly one definition in this codebase. Classify returns
+// StatusCurrent only when BOTH versions are well-formed and reported >= the
+// target, so a site reporting an empty or garbage version is never mistaken
+// for a confirmed upgrade.
+//
+// When the agent did not tell us what it would install, the fallback is
+// strictly stronger than "not equal": the reported version must be well-formed
+// AND newer than what the site was running. A site that merely re-reported its
+// OLD version is not a confirmation.
+func agentSelfUpdateConfirmed(reported, from, expect string) bool {
+	if expect != "" {
+		return agentrelease.Classify(reported, expect, agentplugin.DistributionNone) == agentrelease.StatusCurrent
+	}
+	if from == "" {
+		return false
+	}
+	// reported must be strictly newer than from: Classify(reported, from)
+	// being Current means reported >= from, so exclude the equal case.
+	if agentrelease.Classify(reported, from, agentplugin.DistributionNone) != agentrelease.StatusCurrent {
+		return false
+	}
+	return agentrelease.Classify(from, reported, agentplugin.DistributionNone) == agentrelease.StatusOutdated
+}

--- a/apps/api/internal/update/agent_wave_test.go
+++ b/apps/api/internal/update/agent_wave_test.go
@@ -1,0 +1,723 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// Shared in-memory doubles for the agent self-update channel
+// ---------------------------------------------------------------------------
+
+// agentTaskID builds a UUID whose STRING form sorts by i. waveOrder breaks
+// ties on the id string, and every task in a run shares one created_at (they
+// are inserted by a single transaction, and Postgres gives every now() in a
+// transaction the same value), so the id is what actually orders a run. Making
+// that order match the array index is what lets these tests talk about "task
+// 0" and mean the canary.
+func agentTaskID(i int) uuid.UUID {
+	return uuid.MustParse(fmt.Sprintf("00000000-0000-4000-8000-%012d", i))
+}
+
+// agentStore is a faithful in-memory stand-in for the two tables the wave
+// machine writes: update_runs and update_tasks.
+//
+// It mirrors pgRepo's logic step for step and drives the SAME pure derivation
+// (DeriveAgentWaveState), with a mutex where the repo takes
+// pg_advisory_xact_lock(hashtext('update_agent_wave'), hashtext(run_id)) and a
+// map where the repo has rows. So what these tests exercise is the state
+// machine and the exactly-once discipline built on top of it. What they cannot
+// exercise is Postgres itself holding that lock across two connections; that
+// is the repo's own contract and is pinned by reading agent_repo.go, where
+// every wave-machine transaction takes the lock as its first statement.
+type agentStore struct {
+	mu    sync.Mutex
+	run   Run
+	tasks []*Task
+
+	// proceeds counts how many callers were ever handed ClaimProceed. Exactly
+	// one per task is the whole point.
+	proceeds map[uuid.UUID]int
+	// haltTransitions counts calls that actually moved the run into halted,
+	// as opposed to finding it already halted.
+	haltTransitions int
+	// firstHaltReason is the reason recorded by the call that performed the
+	// halt transition.
+	firstHaltReason string
+}
+
+// The plan-time record every seeded agent task carries, matching what
+// planAgentTasks writes for a fleet on agentPlanFrom while agentPlanTarget is
+// the published build:
+//
+//   - desired_version is the RESOLVED target, never the literal "latest". It is
+//     the run's premise, and it is what an "up_to_date" answer is scored
+//     against, so a fake that stored "latest" here could not exercise the rule
+//     at all.
+//   - from_version is what the site itself reported at plan time, which is what
+//     makes "the site moved" a checkable statement later.
+const (
+	agentPlanFrom   = "0.61.80"
+	agentPlanTarget = "0.62.0"
+)
+
+func newAgentStore(tenantID uuid.UUID, n int) *agentStore {
+	runID := uuid.New()
+	s := &agentStore{
+		run:      Run{ID: runID, TenantID: tenantID, Status: RunPending},
+		proceeds: map[uuid.UUID]int{},
+	}
+	created := time.Date(2026, 7, 28, 9, 0, 0, 0, time.UTC)
+	for i := 0; i < n; i++ {
+		s.tasks = append(s.tasks, &Task{
+			ID:             agentTaskID(i),
+			RunID:          runID,
+			TenantID:       tenantID,
+			SiteID:         uuid.New(),
+			TargetType:     TargetAgent,
+			TargetSlug:     AgentTargetSlug,
+			DesiredVersion: agentPlanTarget,
+			FromVersion:    agentPlanFrom,
+			Status:         TaskPending,
+			// Every task shares one created_at, exactly as a single insert
+			// transaction produces.
+			CreatedAt: created,
+			UpdatedAt: created,
+		})
+	}
+	return s
+}
+
+// snapshotLocked copies the task rows, the way a SELECT inside the locked
+// transaction would.
+func (s *agentStore) snapshotLocked() []Task {
+	out := make([]Task, 0, len(s.tasks))
+	for _, t := range s.tasks {
+		out = append(out, *t)
+	}
+	return out
+}
+
+func (s *agentStore) find(id uuid.UUID) *Task {
+	for _, t := range s.tasks {
+		if t.ID == id {
+			return t
+		}
+	}
+	return nil
+}
+
+// Task returns a copy of one task row (test assertions).
+func (s *agentStore) Task(i int) Task {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return *s.tasks[i]
+}
+
+// RunStatus returns the run's current status (test assertions).
+func (s *agentStore) RunStatus() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.run.Status
+}
+
+// setStatus is a test helper that writes a task's status directly, standing in
+// for an outcome some other part of the system already recorded.
+func (s *agentStore) setStatus(i int, status string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tasks[i].Status = status
+}
+
+// setStatusByID is setStatus for a driver that only holds task ids.
+func (s *agentStore) setStatusByID(id uuid.UUID, status string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if t := s.find(id); t != nil {
+		t.Status = status
+	}
+}
+
+// haltLocked mirrors the repo's haltLocked (agent_repo.go), including the rule
+// that matters most: ONLY PENDING tasks are cancelled. A running task has
+// already had its command delivered and a cron event spawned on the site, so
+// cancelling it would record "nothing was ever sent to this site" about a site
+// that was in fact touched, and would stop the confirm poll from ever
+// establishing what happened there.
+func (s *agentStore) haltLocked(reason string) AgentRunEvaluation {
+	ev := AgentRunEvaluation{Halted: true, Reason: reason, Changed: s.run.Status != RunHalted}
+	for _, t := range s.tasks {
+		if t.Status != TaskPending {
+			continue
+		}
+		t.Status = TaskCancelled
+		t.Detail = "cancelled: " + reason
+		ev.Cancelled++
+	}
+	s.run.Status = RunHalted
+	if ev.Changed {
+		s.haltTransitions++
+		s.firstHaltReason = reason
+	}
+	return ev
+}
+
+// lastHaltReason returns the reason recorded by the call that actually halted
+// the run (later calls only re-assert an existing halt). Tests assert on it
+// because WHY a rollout stopped is what an operator acts on: "the canary failed"
+// sends them to look at the build, "the wave attempted nothing" sends them to
+// look at the sites.
+func (f *fakeWaveRepo) lastHaltReason() string {
+	f.s.mu.Lock()
+	defer f.s.mu.Unlock()
+	return f.s.firstHaltReason
+}
+
+// --- AgentWaveRepo ---------------------------------------------------------
+
+type fakeWaveRepo struct{ s *agentStore }
+
+func (f *fakeWaveRepo) ClaimAgentWaveTask(_ context.Context, _, _, taskID uuid.UUID) (AgentWaveClaim, Task, error) {
+	f.s.mu.Lock()
+	defer f.s.mu.Unlock()
+
+	me := f.s.find(taskID)
+	if me == nil {
+		return ClaimWait, Task{}, fmt.Errorf("task not found")
+	}
+	if terminal(me.Status) {
+		return ClaimAlreadyClaimed, *me, nil
+	}
+
+	state := DeriveAgentWaveState(f.s.snapshotLocked())
+	if f.s.run.Status == RunHalted || state.Halt {
+		reason := state.HaltReason
+		if reason == "" {
+			reason = "the run was halted"
+		}
+		f.s.haltLocked(reason)
+		return ClaimHalted, *me, nil
+	}
+	if me.Status != TaskPending {
+		return ClaimAlreadyClaimed, *me, nil
+	}
+	if !state.GateOpenFor(taskID) {
+		return ClaimWait, *me, nil
+	}
+	me.Status = TaskRunning
+	f.s.proceeds[taskID]++
+	return ClaimProceed, *me, nil
+}
+
+func (f *fakeWaveRepo) EvaluateAgentRun(_ context.Context, _, _ uuid.UUID) (AgentRunEvaluation, error) {
+	f.s.mu.Lock()
+	defer f.s.mu.Unlock()
+
+	state := DeriveAgentWaveState(f.s.snapshotLocked())
+	if !state.Halt && f.s.run.Status != RunHalted {
+		return AgentRunEvaluation{Dispatchable: state.DispatchableTasks()}, nil
+	}
+	reason := state.HaltReason
+	if reason == "" {
+		reason = "the run was halted"
+	}
+	return f.s.haltLocked(reason), nil
+}
+
+func (f *fakeWaveRepo) HaltAgentRun(_ context.Context, _, _ uuid.UUID, reason string) (AgentRunEvaluation, error) {
+	f.s.mu.Lock()
+	defer f.s.mu.Unlock()
+	return f.s.haltLocked(reason), nil
+}
+
+// --- Repo (only the methods the agent branch reaches) ----------------------
+
+type fakeAgentRepo struct {
+	probeFakeRepo
+	s *agentStore
+}
+
+func (f *fakeAgentRepo) GetTask(_ context.Context, _, taskID uuid.UUID) (Task, error) {
+	f.s.mu.Lock()
+	defer f.s.mu.Unlock()
+	t := f.s.find(taskID)
+	if t == nil {
+		return Task{}, fmt.Errorf("task not found")
+	}
+	return *t, nil
+}
+
+// FinishTask mirrors pgRepo.FinishTask, including the status precondition the
+// SQL carries (db/query/updates.sql: FinishUpdateTask matches only
+// status IN ('pending','running')). A task that already reached a terminal
+// state is returned unchanged with ErrTaskNotOpen, so a worker coming back
+// after its run was halted cannot overwrite 'cancelled' with 'succeeded'.
+func (f *fakeAgentRepo) FinishTask(_ context.Context, in FinishTaskInput) (Task, error) {
+	f.s.mu.Lock()
+	defer f.s.mu.Unlock()
+	t := f.s.find(in.TaskID)
+	if t == nil {
+		return Task{}, fmt.Errorf("task not found")
+	}
+	if terminal(t.Status) {
+		return *t, ErrTaskNotOpen
+	}
+	f.finished = append(f.finished, in)
+	t.Status = in.Status
+	t.FromVersion = in.FromVersion
+	t.ToVersion = in.ToVersion
+	t.Detail = in.Detail
+	t.Error = in.Error
+	return *t, nil
+}
+
+func (f *fakeAgentRepo) CountUnfinishedTasks(context.Context, uuid.UUID, uuid.UUID) (int64, error) {
+	f.s.mu.Lock()
+	defer f.s.mu.Unlock()
+	var n int64
+	for _, t := range f.s.tasks {
+		if !terminal(t.Status) {
+			n++
+		}
+	}
+	return n, nil
+}
+
+func (f *fakeAgentRepo) SetRunStatus(_ context.Context, _, _ uuid.UUID, status string) (Run, error) {
+	f.s.mu.Lock()
+	defer f.s.mu.Unlock()
+	f.s.run.Status = status
+	return f.s.run, nil
+}
+
+func (f *fakeAgentRepo) GetRun(context.Context, uuid.UUID, uuid.UUID) (Run, error) {
+	f.s.mu.Lock()
+	defer f.s.mu.Unlock()
+	return f.s.run, nil
+}
+
+// ---------------------------------------------------------------------------
+// Wave plan
+// ---------------------------------------------------------------------------
+
+// TestPlanWavesShape pins the rollout shape the whole safety property rests
+// on: one canary, then a small pilot (5% of the run, never fewer than 3), then
+// the remainder. If this ever silently changed, a fleet-wide agent rollout
+// would go out in one step and nothing else in this file could catch it.
+func TestPlanWavesShape(t *testing.T) {
+	cases := []struct {
+		n    int
+		want []WaveRange
+	}{
+		{0, nil},
+		{1, []WaveRange{{0, 1}}},
+		{2, []WaveRange{{0, 1}, {1, 2}}},
+		{4, []WaveRange{{0, 1}, {1, 4}}},
+		// 5% of 10 is 0.5, floored by the 3-site pilot minimum.
+		{10, []WaveRange{{0, 1}, {1, 4}, {4, 10}}},
+		// 5% of 200 is 10, comfortably above the minimum.
+		{200, []WaveRange{{0, 1}, {1, 11}, {11, 200}}},
+		// 5% of 61 is 3.05, which must round UP to 4 rather than down to 3.
+		{61, []WaveRange{{0, 1}, {1, 5}, {5, 61}}},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("n=%d", tc.n), func(t *testing.T) {
+			got := PlanWaves(tc.n)
+			if len(got) != len(tc.want) {
+				t.Fatalf("PlanWaves(%d) = %+v, want %+v", tc.n, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("PlanWaves(%d) = %+v, want %+v", tc.n, got, tc.want)
+				}
+			}
+			// Every wave must be non-empty and the plan must cover exactly
+			// [0, n) with no gap and no overlap: a task that fell in no wave
+			// would never be gated, and one in two waves would be double-sent.
+			covered := 0
+			for i, w := range got {
+				if w.Len() <= 0 {
+					t.Fatalf("wave %d is empty: %+v", i, got)
+				}
+				if i > 0 && w.Start != got[i-1].End {
+					t.Fatalf("wave plan has a gap or overlap: %+v", got)
+				}
+				covered += w.Len()
+			}
+			if covered != tc.n {
+				t.Fatalf("wave plan covers %d of %d tasks: %+v", covered, tc.n, got)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Gate + halt derivation
+// ---------------------------------------------------------------------------
+
+// TestWaveDoesNotOpenUntilThePriorWaveConfirmed is the ordering property: a
+// wave is not merely "later", it is BLOCKED until every site in the wave
+// before it has confirmed. It walks a 10-site run through wave 0 in the three
+// states that must all keep wave 1 shut (pending, running, and running with
+// the canary armed but unconfirmed), then opens it only on confirmation.
+func TestWaveDoesNotOpenUntilThePriorWaveConfirmed(t *testing.T) {
+	s := newAgentStore(uuid.New(), 10)
+	wave1Task := s.tasks[1].ID
+
+	for _, tc := range []struct {
+		canaryStatus string
+		// wantDispatchable is the canary itself while it is still pending
+		// (wave 0 is open on sight), and nothing at all once it is running.
+		// Either way NO wave-1 site is ever in the set.
+		wantDispatchable int
+	}{
+		{TaskPending, 1},
+		{TaskRunning, 0},
+	} {
+		s.setStatus(0, tc.canaryStatus)
+		st := DeriveAgentWaveState(s.snapshotLocked())
+		if st.GateOpenFor(wave1Task) {
+			t.Fatalf("wave 1 must stay shut while the canary is %q", tc.canaryStatus)
+		}
+		if st.OpenThrough != 1 {
+			t.Fatalf("only wave 0 may be open while the canary is %q, got OpenThrough=%d", tc.canaryStatus, st.OpenThrough)
+		}
+		dispatchable := st.DispatchableTasks()
+		if len(dispatchable) != tc.wantDispatchable {
+			t.Fatalf("canary %q: %d dispatchable task(s), want %d", tc.canaryStatus, len(dispatchable), tc.wantDispatchable)
+		}
+		for _, task := range dispatchable {
+			if task.ID != s.tasks[0].ID {
+				t.Fatalf("canary %q: a site outside wave 0 became dispatchable: %s", tc.canaryStatus, task.ID)
+			}
+		}
+	}
+
+	// Only a CONFIRMED canary opens wave 1.
+	s.setStatus(0, TaskSucceeded)
+	st := DeriveAgentWaveState(s.snapshotLocked())
+	if !st.GateOpenFor(wave1Task) {
+		t.Fatal("wave 1 must open once the canary confirmed")
+	}
+	if st.OpenThrough != 2 {
+		t.Fatalf("OpenThrough = %d, want 2 (waves 0 and 1)", st.OpenThrough)
+	}
+	// ...and only wave 1. Wave 2 must still be shut.
+	if st.GateOpenFor(s.tasks[4].ID) {
+		t.Fatal("wave 2 must stay shut until wave 1 confirms")
+	}
+	dispatchable := st.DispatchableTasks()
+	if len(dispatchable) != 3 {
+		t.Fatalf("exactly wave 1's three sites become dispatchable, got %d", len(dispatchable))
+	}
+	for _, task := range dispatchable {
+		if task.ID == s.tasks[0].ID || task.ID == s.tasks[4].ID {
+			t.Fatalf("dispatchable set leaked outside wave 1: %s", task.ID)
+		}
+	}
+}
+
+// TestWaveZeroFailureHalts proves the canary is a real gate: a single failure
+// in wave 0 stops the run, whatever the size of the fleet behind it.
+func TestWaveZeroFailureHalts(t *testing.T) {
+	for _, status := range []string{TaskFailed, TaskSkipped} {
+		t.Run(status, func(t *testing.T) {
+			s := newAgentStore(uuid.New(), 100)
+			s.setStatus(0, status)
+
+			st := DeriveAgentWaveState(s.snapshotLocked())
+			if !st.Halt {
+				t.Fatalf("a wave-0 %q must halt the run", status)
+			}
+			if st.HaltReason == "" {
+				t.Fatal("a halt must carry an operator-readable reason")
+			}
+			if st.OpenThrough != 0 {
+				t.Fatalf("a halted run opens no wave, got OpenThrough=%d", st.OpenThrough)
+			}
+			if got := len(st.DispatchableTasks()); got != 0 {
+				t.Fatalf("a halted run dispatches nothing, got %d task(s)", got)
+			}
+			if st.GateOpenFor(s.tasks[1].ID) {
+				t.Fatal("no task may pass the gate once the run has halted")
+			}
+		})
+	}
+}
+
+// TestLaterWaveHaltsOnFailureRate covers the threshold gate: a later wave is
+// allowed a thin tail of stragglers but not a real failure rate. With a pilot
+// of three, one failure is already 33% and stops the run; a large final wave
+// tolerates a couple of unconfirmed sites out of a hundred.
+func TestLaterWaveHaltsOnFailureRate(t *testing.T) {
+	t.Run("one failure in a three-site pilot halts", func(t *testing.T) {
+		s := newAgentStore(uuid.New(), 10)
+		s.setStatus(0, TaskSucceeded)
+		s.setStatus(1, TaskSucceeded)
+		s.setStatus(2, TaskSucceeded)
+		s.setStatus(3, TaskFailed)
+
+		st := DeriveAgentWaveState(s.snapshotLocked())
+		if !st.Halt {
+			t.Fatal("a 33% pilot failure rate must halt the run")
+		}
+		if st.GateOpenFor(s.tasks[4].ID) {
+			t.Fatal("wave 2 must never open behind a failed pilot")
+		}
+	})
+
+	t.Run("a thin tail in a large wave does not halt", func(t *testing.T) {
+		// 100 sites: wave 0 = 1, wave 1 = 5, wave 2 = 94. Five failures in
+		// wave 2 is 5.3%, under the threshold.
+		s := newAgentStore(uuid.New(), 100)
+		for i := 0; i < 100; i++ {
+			s.setStatus(i, TaskSucceeded)
+		}
+		for i := 95; i < 100; i++ {
+			s.setStatus(i, TaskFailed)
+		}
+		st := DeriveAgentWaveState(s.snapshotLocked())
+		if st.Halt {
+			t.Fatalf("5%% failures in the final wave must not halt: %s", st.HaltReason)
+		}
+	})
+
+	t.Run("a wave that confirmed nothing halts even with no failures", func(t *testing.T) {
+		// Every pilot site was skipped: no failures, but no evidence either.
+		// Opening the next wave on that would be opening it on nothing.
+		s := newAgentStore(uuid.New(), 10)
+		s.setStatus(0, TaskSucceeded)
+		for i := 1; i < 4; i++ {
+			s.setStatus(i, TaskSkipped)
+		}
+		st := DeriveAgentWaveState(s.snapshotLocked())
+		if !st.Halt {
+			t.Fatal("a wave that confirmed no site proves nothing and must halt")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency
+// ---------------------------------------------------------------------------
+
+// TestConcurrentClaimsDispatchOnce proves the exactly-once claim: however many
+// duplicate jobs race for the same task, only one is ever told to contact the
+// site. This is what makes re-enqueueing an open wave safe, and therefore what
+// lets the wave machine be stateless.
+func TestConcurrentClaimsDispatchOnce(t *testing.T) {
+	tenant := uuid.New()
+	s := newAgentStore(tenant, 10)
+	repo := &fakeWaveRepo{s: s}
+	taskID := s.tasks[0].ID
+
+	const racers = 16
+	var wg sync.WaitGroup
+	claims := make([]AgentWaveClaim, racers)
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			c, _, err := repo.ClaimAgentWaveTask(context.Background(), tenant, s.run.ID, taskID)
+			if err != nil {
+				t.Errorf("claim: %v", err)
+			}
+			claims[i] = c
+		}(i)
+	}
+	wg.Wait()
+
+	proceeds := 0
+	for _, c := range claims {
+		if c == ClaimProceed {
+			proceeds++
+		} else if c != ClaimAlreadyClaimed {
+			t.Fatalf("a loser must see ClaimAlreadyClaimed, got %v", c)
+		}
+	}
+	if proceeds != 1 {
+		t.Fatalf("exactly one racer may dispatch, got %d", proceeds)
+	}
+	if s.proceeds[taskID] != 1 {
+		t.Fatalf("the store recorded %d claims, want 1", s.proceeds[taskID])
+	}
+}
+
+// TestConcurrentCompletionsAdvanceOnce proves two workers finishing at the
+// same moment cannot both advance the wave: the dispatchable set they compute
+// is identical, and re-dispatching it is a no-op because each task can still
+// only be claimed once. The assertion is on the OUTCOME that matters (how many
+// sites get contacted), not on how many times the evaluation ran.
+func TestConcurrentCompletionsAdvanceOnce(t *testing.T) {
+	tenant := uuid.New()
+	s := newAgentStore(tenant, 10)
+	repo := &fakeWaveRepo{s: s}
+	s.setStatus(0, TaskSucceeded) // canary confirmed: wave 1 is now open.
+
+	// Two finishers evaluate concurrently, each enqueueing whatever it is
+	// told is dispatchable, and every enqueued task is then claimed.
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var enqueued []Task
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ev, err := repo.EvaluateAgentRun(context.Background(), tenant, s.run.ID)
+			if err != nil {
+				t.Errorf("evaluate: %v", err)
+				return
+			}
+			mu.Lock()
+			enqueued = append(enqueued, ev.Dispatchable...)
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	// Both evaluations may well have returned the same three tasks, that is
+	// expected and harmless. What must hold is that claiming them all still
+	// dispatches each site exactly once.
+	for _, task := range enqueued {
+		if _, _, err := repo.ClaimAgentWaveTask(context.Background(), tenant, s.run.ID, task.ID); err != nil {
+			t.Fatalf("claim: %v", err)
+		}
+	}
+	for i := 1; i < 4; i++ {
+		if got := s.proceeds[s.tasks[i].ID]; got != 1 {
+			t.Fatalf("wave 1 task %d was dispatched %d times, want exactly 1", i, got)
+		}
+	}
+	for i := 4; i < 10; i++ {
+		if got := s.proceeds[s.tasks[i].ID]; got != 0 {
+			t.Fatalf("wave 2 task %d was dispatched %d times before its wave opened", i, got)
+		}
+	}
+}
+
+// TestClaimNeverDispatchesIntoAHalt is the second half of the race the design
+// calls out: a wave must not advance into a halt that just cancelled it. A
+// claim that arrives after the halt commits must be refused and the task
+// cancelled, never dispatched.
+func TestClaimNeverDispatchesIntoAHalt(t *testing.T) {
+	tenant := uuid.New()
+	s := newAgentStore(tenant, 10)
+	repo := &fakeWaveRepo{s: s}
+	s.setStatus(0, TaskSucceeded) // wave 1 open
+
+	// The halt lands (for a reason outside the gate, e.g. the kill switch).
+	if _, err := repo.HaltAgentRun(context.Background(), tenant, s.run.ID, "stopped by the operator"); err != nil {
+		t.Fatalf("halt: %v", err)
+	}
+
+	// Every still-enqueued job for this run now arrives.
+	for i := 1; i < 10; i++ {
+		claim, task, err := repo.ClaimAgentWaveTask(context.Background(), tenant, s.run.ID, s.tasks[i].ID)
+		if err != nil {
+			t.Fatalf("claim: %v", err)
+		}
+		if claim == ClaimProceed {
+			t.Fatalf("task %d was dispatched after the run halted", i)
+		}
+		if task.Status != TaskCancelled {
+			t.Fatalf("task %d after a halt has status %q, want %q", i, task.Status, TaskCancelled)
+		}
+	}
+	if s.RunStatus() != RunHalted {
+		t.Fatalf("run status = %q, want %q", s.RunStatus(), RunHalted)
+	}
+	for id, n := range s.proceeds {
+		t.Fatalf("no site may be contacted after a halt, but %s was claimed %d time(s)", id, n)
+	}
+}
+
+// TestConcurrentHaltsRecordOneIncident proves the halt itself is
+// exactly-once: several workers can decide to halt the same run at the same
+// moment, but only one reports Changed, so the operator sees one incident
+// rather than a storm of duplicates.
+func TestConcurrentHaltsRecordOneIncident(t *testing.T) {
+	tenant := uuid.New()
+	s := newAgentStore(tenant, 10)
+	repo := &fakeWaveRepo{s: s}
+	s.setStatus(0, TaskFailed) // the canary failed: every finisher will halt.
+
+	const racers = 8
+	var wg sync.WaitGroup
+	changed := make([]bool, racers)
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ev, err := repo.EvaluateAgentRun(context.Background(), tenant, s.run.ID)
+			if err != nil {
+				t.Errorf("evaluate: %v", err)
+				return
+			}
+			if !ev.Halted {
+				t.Errorf("every evaluation must see the halt")
+			}
+			changed[i] = ev.Changed
+		}(i)
+	}
+	wg.Wait()
+
+	n := 0
+	for _, c := range changed {
+		if c {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("exactly one caller may perform the halt transition, got %d", n)
+	}
+	if s.haltTransitions != 1 {
+		t.Fatalf("the store recorded %d halt transitions, want 1", s.haltTransitions)
+	}
+	// And the halt actually cancelled the rest of the fleet.
+	for i := 1; i < 10; i++ {
+		if got := s.Task(i).Status; got != TaskCancelled {
+			t.Fatalf("task %d status = %q, want %q", i, got, TaskCancelled)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Confirmation predicate
+// ---------------------------------------------------------------------------
+
+// TestAgentSelfUpdateConfirmed pins what counts as proof the upgrade landed.
+// The channel's whole safety argument is that only the NEW code phoning home
+// is success, so every way of NOT knowing must read as "not confirmed".
+func TestAgentSelfUpdateConfirmed(t *testing.T) {
+	cases := []struct {
+		name                   string
+		reported, from, expect string
+		want                   bool
+	}{
+		{"reported matches the expected build", "0.62.0", "0.61.80", "0.62.0", true},
+		{"reported is newer than expected", "0.62.1", "0.61.80", "0.62.0", true},
+		{"still reporting the old version", "0.61.80", "0.61.80", "0.62.0", false},
+		{"never reported anything", "", "0.61.80", "0.62.0", false},
+		{"reported garbage", "not-a-version", "0.61.80", "0.62.0", false},
+		{"reported older than expected", "0.61.90", "0.61.80", "0.62.0", false},
+		// With no expected version, only a strictly newer well-formed version
+		// confirms: re-reporting the same build is not evidence of anything.
+		{"no expectation, newer version", "0.62.0", "0.61.80", "", true},
+		{"no expectation, same version", "0.61.80", "0.61.80", "", false},
+		{"no expectation, older version", "0.61.70", "0.61.80", "", false},
+		{"no expectation and nothing known", "0.62.0", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := agentSelfUpdateConfirmed(tc.reported, tc.from, tc.expect); got != tc.want {
+				t.Fatalf("agentSelfUpdateConfirmed(%q, %q, %q) = %v, want %v",
+					tc.reported, tc.from, tc.expect, got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/api/internal/update/agent_worker.go
+++ b/apps/api/internal/update/agent_worker.go
@@ -1,0 +1,866 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentplugin"
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentrelease"
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// Audit actions for the agent self-update channel.
+const (
+	// ActionRunHalted records the wave gate stopping a run. Emitted exactly
+	// once per run (see AgentRunEvaluation.Changed).
+	ActionRunHalted = "update.run.halted"
+	// ActionAgentSelfUpdateArmed records a successful beat 1: the agent
+	// verified a newer build and scheduled the cron event that will apply it.
+	// It is NOT a success record, the task is still running at this point.
+	ActionAgentSelfUpdateArmed = "update.agent.armed"
+)
+
+// Confirmation timing. These bound beat 3: how long the control plane waits
+// for the NEW agent code to phone home before declaring the upgrade
+// unconfirmed.
+const (
+	// agentConfirmPoll is how often the confirm job re-reads the site's
+	// reported agent version. The signal it waits for is a push from the site
+	// (a version-changed boot pushes metadata immediately), so this only
+	// bounds how quickly the CP notices, not how quickly the site upgrades.
+	agentConfirmPoll = 30 * time.Second
+
+	// agentConfirmDeadline is the confirmation window when the agent reported
+	// ordinary loopback cron: beat 2 is spawned during beat 1 and normally
+	// lands within seconds, so anything past this window means the cron
+	// request never happened or the upgrade did not complete.
+	agentConfirmDeadline = 20 * time.Minute
+
+	// agentConfirmDeadlineExternalCron is the confirmation window when the
+	// agent reported that loopback cron cannot run (agentcmd.CronModeExternal).
+	// Beat 2 then depends on an external scheduler whose period the control
+	// plane cannot see, commonly every 15 minutes but sometimes hourly. Using
+	// the narrow window here would declare a healthy, still-queued upgrade
+	// "unconfirmed" and halt a rollout that was fine.
+	//
+	// This is the LONGEST deadline the channel has, so it is the one the
+	// agent's staged record must outlive: it may never be widened past
+	// agentcmd.SelfUpdateStagedTTLFloor.
+	agentConfirmDeadlineExternalCron = 90 * time.Minute
+
+	// agentWaveGatePoll is how often a task whose wave has not opened yet
+	// re-checks the gate.
+	agentWaveGatePoll = 30 * time.Second
+)
+
+// AgentSelfUpdateCommander sends beat 1 (ARM) of the agent self-update
+// protocol. Deliberately a DIFFERENT interface from Commander: nothing that
+// can send an `update` or `rollback` command is reachable from the agent
+// target's code path, and nothing on this interface can be used to update an
+// ordinary plugin.
+type AgentSelfUpdateCommander interface {
+	AgentSelfUpdate(ctx context.Context, siteID uuid.UUID, siteURL string, req agentcmd.AgentSelfUpdateRequest) (agentcmd.AgentSelfUpdateResponse, error)
+}
+
+// AgentVersionLookup reads a site's last self-reported agent version
+// (sites.agent_version), written by the agent's signed metadata push. This is
+// the ONLY channel beat 3 trusts: it is the new code speaking for itself.
+type AgentVersionLookup interface {
+	AgentVersion(ctx context.Context, tenantID, siteID uuid.UUID) (string, error)
+}
+
+// AgentApplyResult is the agent's OWN account of beat 2, the apply. The agent
+// records it on disk when the cron request runs and replays it on its next
+// signed metadata push.
+//
+// It is the only way a failed apply reaches the control plane at all: the apply
+// runs inside a cron request with no CP response to ride on, so nothing else
+// carries the outcome back. Status is one of applied|failed|expired|
+// already_applied, kept as a plain string so a status a newer agent introduces
+// reaches an operator verbatim.
+type AgentApplyResult struct {
+	Status      string
+	FromVersion string
+	ToVersion   string
+	Detail      string
+	// At is when the agent stamped the record; the zero time when it did not say.
+	At time.Time
+}
+
+// AgentApplyResultLookup reads the last apply-beat record a site reported.
+// Optional throughout: an unwired lookup, a site that never staged an upgrade,
+// and an agent too old to send the record all produce (zero, false, nil), and
+// the channel behaves exactly as it did before the record existed.
+type AgentApplyResultLookup interface {
+	AgentSelfUpdateResult(ctx context.Context, tenantID, siteID uuid.UUID) (AgentApplyResult, bool, error)
+}
+
+// AgentReleaseReader reports the currently published agent version, or "" when
+// it cannot be determined. Satisfied by *agentrelease.Reader.
+type AgentReleaseReader interface {
+	LatestVersion(ctx context.Context) string
+}
+
+// AgentConfirmEnqueuer schedules the beat-3 confirmation poll job.
+type AgentConfirmEnqueuer interface {
+	EnqueueAgentConfirm(ctx context.Context, args AgentConfirmArgs) error
+}
+
+// AgentSelfUpdateDeps bundles everything the agent self-update channel needs.
+// Wired once at boot via Worker.SetAgentSelfUpdate; the zero value leaves the
+// channel disabled, which is the shipped default.
+type AgentSelfUpdateDeps struct {
+	// Enabled is the fleet-wide kill switch. FALSE BY DEFAULT. While false no
+	// agent self-update command is sent to any site, whatever is already
+	// enqueued and whatever the release manifest says.
+	Enabled bool
+	// Cmd sends beat 1. A nil Cmd disables the channel exactly like Enabled
+	// being false (no signing key configured means no signed command can be
+	// minted, and an unsigned one must never be sent).
+	Cmd AgentSelfUpdateCommander
+	// Versions reads sites.agent_version for beat 3.
+	Versions AgentVersionLookup
+	// Waves is the run-scoped wave gate persistence.
+	Waves AgentWaveRepo
+	// Tasks enqueues a wave's tasks once the gate opens for it.
+	Tasks Enqueuer
+	// Confirms enqueues the beat-3 poll job after a successful arm.
+	Confirms AgentConfirmEnqueuer
+	// Releases reports the currently published agent version. It is what makes
+	// an "up_to_date" answer checkable: the control plane only ever creates a
+	// task for a site it classified as OUTDATED, so a site claiming to be up to
+	// date means the CP and the agent's manifest disagree, and the disagreement
+	// has to be resolved against the published version rather than believed.
+	// A nil Releases (or an unknown published version) is fail-closed: the
+	// answer confirms nothing. See Worker.upToDate.
+	Releases AgentReleaseReader
+	// Results reads the agent's own account of its last apply beat, used to
+	// explain a confirmation TIMEOUT. Entirely optional: nil leaves the timeout
+	// detail exactly as it was, and ready() deliberately does not require it, so
+	// a control plane that never wires it still runs the channel.
+	Results AgentApplyResultLookup
+}
+
+// ready reports whether the channel can actually dispatch.
+func (d AgentSelfUpdateDeps) ready() bool {
+	return d.Enabled && d.Cmd != nil && d.Versions != nil && d.Waves != nil && d.Confirms != nil
+}
+
+// SetAgentSelfUpdate wires the agent self-update channel. Call once at boot.
+// Not calling it at all leaves the channel off, so a deployment that never
+// opts in behaves exactly as it did before this channel existed.
+func (w *Worker) SetAgentSelfUpdate(d AgentSelfUpdateDeps) { w.agent = d }
+
+// runAgentSelfUpdate executes ONE agent self-update task: beats 1 and the
+// handoff to beat 3. It is a wholly distinct branch from runApply/runDry, and
+// deliberately does NOT reuse them.
+//
+// Two things runApply does are absent here, on purpose:
+//
+//   - NO post-update health probe. runApply's agent-first reachability check
+//     asks the agent whether it is alive; that is precisely the signal a bad
+//     self-update destroys, so a failure would be indistinguishable from the
+//     upgrade being mid-flight, and a success right after ARM would only prove
+//     the OLD code is still running (nothing has been applied yet at that
+//     point). The signal this channel trusts instead is the new code
+//     volunteering its own version, see AgentConfirmWorker.
+//   - NO rollback, ever. Worker.rollback sends a signed `rollback` command to
+//     the agent. If an agent self-update went wrong, the code that would
+//     receive and execute that command is exactly the code that was being
+//     replaced, so the command is undeliverable by construction. Attempting it
+//     would add a misleading "rollback FAILED" to a task whose real problem is
+//     something else entirely. The agent's own snapshot watchdog deliberately
+//     does not arm for its own directory for the same reason. This branch never
+//     calls w.cmd (which is what holds Rollback) at all: it uses w.agent.Cmd,
+//     an interface with no rollback method on it.
+func (w *Worker) runAgentSelfUpdate(ctx context.Context, args TaskArgs, task Task) error {
+	// ---------------------------------------------------------------------
+	// KILL SWITCH. Checked here, before the task is even claimed and long
+	// before anything is sent to a site, so flipping it off stops every agent
+	// self-update fleet-wide including runs already created and jobs already
+	// enqueued. It has to stop DISPATCH rather than rely on the release
+	// channel: repointing the published manifest at an older build does not
+	// un-brick anybody, because the agent's downgrade guard refuses to install
+	// anything older than what it is running.
+	// ---------------------------------------------------------------------
+	if !w.agent.ready() {
+		return w.haltAgentRun(ctx, task,
+			"the agent self-update channel is disabled on this control plane",
+			"agent self-update is disabled on this control plane")
+	}
+
+	claim, claimed, err := w.agent.Waves.ClaimAgentWaveTask(ctx, args.TenantID, args.RunID, args.TaskID)
+	if err != nil {
+		return err
+	}
+	switch claim {
+	case ClaimWait:
+		// An earlier wave has not confirmed yet. Nothing was written and
+		// nothing was sent; ask again shortly.
+		return river.JobSnooze(agentWaveGatePoll)
+	case ClaimAlreadyClaimed:
+		// A duplicate job for a task another worker already took, or one a
+		// halt already cancelled. Both are no-ops.
+		return nil
+	case ClaimHalted:
+		w.publish(claimed, RunHalted)
+		w.recordAudit(ctx, claimed)
+		return nil
+	}
+
+	w.publish(claimed, RunRunning)
+	w.ensureRunRunning(ctx, args.TenantID, args.RunID)
+
+	site, err := w.sites.GetSiteInfo(ctx, args.TenantID, claimed.SiteID)
+	if err != nil {
+		return w.finishAgentTask(ctx, claimed, TaskFailed, claimed.FromVersion, "", "site unresolved", err.Error())
+	}
+
+	// ---- BEAT 1: ARM. Nothing on the site's disk moves in this call. ----
+	resp, err := w.agent.Cmd.AgentSelfUpdate(ctx, claimed.SiteID, site.URL, agentcmd.AgentSelfUpdateRequest{})
+	if err != nil {
+		// An agent that predates this channel has no self-update route at all,
+		// so its REST API answers 404 rest_no_route. That is not a broken site
+		// and not a broken build: nothing was sent that the site could act on,
+		// and nothing was applied.
+		//
+		// It matters most on the FIRST fleet-wide rollout of this channel, which
+		// by construction targets exactly those agents. Recording it as
+		// TaskFailed made the canary fail with an error an operator cannot tell
+		// apart from a genuinely bad build, and made a MIXED wave (a few old
+		// agents among sites that upgraded fine) trip the failure-rate gate on
+		// sites that were never even eligible.
+		//
+		// So it is recorded non-confirming instead: skipped, which the wave
+		// tally scores as neither confirmed nor failed (waveTally.Other). Note
+		// this still does not let a wave that confirmed NOTHING open the next
+		// one, which is the gate's whole point; it stops the run honestly
+		// ("proved nothing") rather than dishonestly ("the canary failed").
+		//
+		// isOldAgentRouteMissing is the same predicate RefreshInventoryWorker
+		// applies to the same situation (refresh.go), against the same canonical
+		// agentcmd error format.
+		if isOldAgentRouteMissing(err) {
+			w.logger.Info("agent self-update: site's agent has no self-update route (old agent); not attempted",
+				slog.String("task_id", claimed.ID.String()),
+				slog.String("site_id", claimed.SiteID.String()),
+				slog.String("error", err.Error()))
+			return w.finishAgentTask(ctx, claimed, TaskSkipped, claimed.FromVersion, "",
+				"not attempted: this site's agent predates the self-update channel and has no self-update route, "+
+					"so it cannot upgrade itself and must be upgraded another way. Nothing was sent to the site and nothing was applied.", "")
+		}
+		return w.finishAgentTask(ctx, claimed, TaskFailed, claimed.FromVersion, "",
+			"agent self-update arm command failed", err.Error())
+	}
+
+	from := fromOr(resp.FromVersion, claimed.FromVersion)
+	switch resp.Status {
+	case agentcmd.SelfUpdateScheduled, agentcmd.SelfUpdateAlreadyScheduled:
+		// "already_scheduled" travels the SAME path as "scheduled" on purpose:
+		// it carries the same to_version and expiry, and it means an EARLIER
+		// arm succeeded and its upgrade is still pending. Treating it as
+		// anything other than armed would fail a task whose site is doing
+		// exactly what it was told, and (in wave 0) halt the whole rollout on
+		// a retry, the one thing a retry must never do.
+		return w.armed(ctx, args, claimed, from, resp)
+
+	case agentcmd.SelfUpdateUpToDate:
+		return w.upToDate(ctx, claimed, from, resp)
+
+	case agentcmd.SelfUpdateNotEligible:
+		// This build cannot self-update (the wordpress.org build is upgraded by
+		// the directory), or the site is not enrolled. Not a site failure, so
+		// it is skipped rather than failed, but it is not a confirmation
+		// either, and the wave gate counts it as proving nothing.
+		return w.finishAgentTask(ctx, claimed, TaskSkipped, from, "",
+			detailOr(resp.Detail, "this agent build cannot self-update and is upgraded outside this channel"), "")
+
+	case agentcmd.SelfUpdateError:
+		// The agent's own words are the whole diagnostic value of this
+		// outcome ("manifest signature invalid", "cron could not be
+		// scheduled"). They go into BOTH the operator-facing detail and the
+		// task's error, so no code path can drop them and leave an operator
+		// staring at the word "error".
+		return w.finishAgentTask(ctx, claimed, TaskFailed, from, resp.ToVersion,
+			"the agent could not arm its self-update: "+detailOr(resp.Detail, "the agent gave no reason"),
+			detailOr(resp.Detail, "agent_self_update_arm_error"))
+
+	default:
+		return w.finishAgentTask(ctx, claimed, TaskFailed, from, resp.ToVersion,
+			"the agent returned an unrecognized self-update status: "+resp.Status,
+			detailOr(resp.Detail, resp.Status))
+	}
+}
+
+// upToDate resolves an "up_to_date" answer, which is NEVER an unqualified
+// success.
+//
+// planAgentTasks only creates a task for a site whose REPORTED agent version is
+// behind the version this control plane published AT PLAN TIME, so by the time
+// this command was sent the control plane had already classified this site as
+// outdated. The agent answering "my manifest offers nothing newer" therefore
+// means the two disagree, which is precisely the case that must not be trusted.
+//
+// THE RULE: a run has a premise, "install version X", fixed when the run was
+// planned and persisted on every one of its tasks (update_tasks.desired_version,
+// see planAgentTasks). A confirmation must mean THE SITE REACHED X. It may never
+// mean that X moved down to meet the site.
+//
+// That distinction is the whole fix. Scoring the answer against a LIVE read of
+// the release manifest scores it against a moving target, and the manifest moves
+// for a reason the design explicitly expects: an operator publishes a bad build,
+// a site bricks, and the operator reverts latest.json to the last known good
+// build, which is typically the very version the fleet is already running. Every
+// subsequent arm then answers "up_to_date" (the agent's downgrade guard refuses
+// the older manifest), every one of those answers matches the freshly-reverted
+// published version, every task records succeeded, no wave fails its gate, and
+// the run completes 100% green with not one agent moved. Worse, on a mixed fleet
+// the wave-0 canary can itself be a site already at the reverted version: it
+// "confirms" having applied nothing, and that confirmation is what authorises
+// waves 1 and 2 to touch sites that genuinely are behind. A canary that applied
+// nothing must never open a wave.
+//
+// So the answer is checked against the run's OWN target:
+//
+//   - The site reached the run's planned target, and its version actually moved
+//     from what was recorded for it at plan time -> a genuine confirmation, and
+//     the only case that may count toward a wave's evidence.
+//   - Anything else, including "the site is exactly where it was at plan time
+//     and now merely claims parity with a manifest that moved" -> non-confirming.
+//     Recorded as TaskSkipped, which the wave tally scores as neither confirmed
+//     nor failed (waveTally.Other), so a wave of these confirms nothing and the
+//     gate stays shut instead of opening on a rollout that did not happen.
+//
+// Independently of this task's own outcome, a published version that has moved
+// BELOW the run's target voids the run's premise: the version this run exists to
+// install is no longer on offer, so no remaining site can possibly reach it and
+// dispatching further waves would only produce more "up_to_date" answers. The
+// run is halted rather than continued.
+func (w *Worker) upToDate(ctx context.Context, task Task, from string, resp agentcmd.AgentSelfUpdateResponse) error {
+	latest := ""
+	if w.agent.Releases != nil {
+		latest = w.agent.Releases.LatestVersion(ctx)
+	}
+	planned := task.DesiredVersion
+
+	status, detail := TaskSkipped, upToDateNotConfirmedDetail(planned, from, latest)
+	toVersion := ""
+	if agentSelfUpdateReachedTarget(from, planned, task.FromVersion) {
+		status, toVersion = TaskSucceeded, from
+		detail = fmt.Sprintf("confirmed: the site reports %s, at or beyond %s, the version this run was planned to install (it reported %s when the run was planned)",
+			from, planned, task.FromVersion)
+		if resp.Detail != "" {
+			detail += " (" + resp.Detail + ")"
+		}
+	} else {
+		w.logger.Warn("agent self-update: the site did not reach the version this run was planned to install",
+			slog.String("task_id", task.ID.String()),
+			slog.String("site_id", task.SiteID.String()),
+			slog.String("planned_version", planned),
+			slog.String("planned_from_version", task.FromVersion),
+			slog.String("site_version", from),
+			slog.String("published_version", latest))
+	}
+
+	if agentRunPremiseVoid(planned, latest) {
+		w.logger.Warn("agent self-update: the published version moved below this run's target; halting",
+			slog.String("run_id", task.RunID.String()),
+			slog.String("planned_version", planned),
+			slog.String("published_version", latest))
+		return w.haltAgentRunWith(ctx, task, status, from, toVersion, detail, "",
+			fmt.Sprintf("this run was planned to install %s but this control plane now publishes %s, which is older: "+
+				"the version this run exists to install is no longer offered, so no remaining site can reach it", planned, latest))
+	}
+	return w.finishAgentTask(ctx, task, status, from, toVersion, detail, "")
+}
+
+// agentSelfUpdateReachedTarget decides whether an "up_to_date" answer proves the
+// SITE moved to the version this run set out to install.
+//
+// reported is the version the agent says it is running now; planned is the
+// version resolved from the release manifest when the run was created and
+// persisted on the task; plannedFrom is the version the site itself reported at
+// that same moment.
+//
+// Both halves are required:
+//
+//   - reported >= planned: the site actually reached the run's target.
+//   - reported > plannedFrom: the site's own version MOVED. For any task the
+//     planner created this is implied by the first half (it only creates a task
+//     for a site strictly behind the target), but it is stated independently so
+//     the rule holds on its own rather than resting on that invariant, and so a
+//     legacy or hand-written row cannot confirm itself by standing still.
+//
+// A planned target this package cannot read (an empty or literal "latest"
+// desired_version, written by runs created before the target was persisted) is
+// refused: an answer that cannot be checked against the run's premise proves
+// nothing. Same for an unreadable version on either other side.
+func agentSelfUpdateReachedTarget(reported, planned, plannedFrom string) bool {
+	if !agentrelease.WellFormed(planned) || !agentrelease.WellFormed(reported) || !agentrelease.WellFormed(plannedFrom) {
+		return false
+	}
+	if agentrelease.Classify(reported, planned, agentplugin.DistributionNone) != agentrelease.StatusCurrent {
+		return false
+	}
+	return agentrelease.Classify(plannedFrom, reported, agentplugin.DistributionNone) == agentrelease.StatusOutdated
+}
+
+// agentRunPremiseVoid reports whether the currently published version has moved
+// BELOW the version this run was planned to install, which makes the run's
+// premise unsatisfiable for every site it has left.
+//
+// A published version that cannot be read at all is deliberately NOT treated as
+// void: "the manifest is missing" is a different fact from "the manifest was
+// reverted", it may be a transient read failure, and it already produces
+// non-confirming outcomes that the wave gate stops on by itself. Halting the
+// whole run on a blip would be the wrong direction for the one case where the
+// control plane cannot see.
+func agentRunPremiseVoid(planned, published string) bool {
+	if !agentrelease.WellFormed(planned) || !agentrelease.WellFormed(published) {
+		return false
+	}
+	return agentrelease.Classify(published, planned, agentplugin.DistributionNone) == agentrelease.StatusOutdated
+}
+
+// upToDateNotConfirmedDetail explains a non-confirming "up_to_date" answer in
+// the three terms an operator needs to tell the two failure shapes apart: what
+// this run set out to install, where the site actually is, and what this control
+// plane publishes right now. A reverted manifest and a site that simply has not
+// upgraded yet both produce this outcome, and only those three numbers
+// distinguish them.
+func upToDateNotConfirmedDetail(planned, from, published string) string {
+	target := planned
+	if !agentrelease.WellFormed(target) {
+		target = "a version it did not record (this run predates the planned-target record)"
+	}
+	pub := published
+	if pub == "" {
+		pub = "a version it cannot read (the published release manifest is missing)"
+	}
+	return fmt.Sprintf("not confirmed: the agent reports it is already up to date on %s, but this run was planned to install %s "+
+		"and this control plane now publishes %s. The site did not reach this run's target, so nothing was proved and nothing was "+
+		"applied. A reverted or missing release manifest looks exactly like this: the published version moving is not the site moving.",
+		fromOr(from, "an unreported version"), target, pub)
+}
+
+// armed handles a "scheduled" or "already_scheduled" acknowledgement. The task
+// stays RUNNING: an arm ack is never success, because nothing has been applied
+// yet and the cron request that will apply it may never happen (a site with
+// broken loopback cron simply never reaches beat 2, which is safe, nothing was
+// touched, but must surface as unconfirmed, not as a silent success).
+func (w *Worker) armed(ctx context.Context, args TaskArgs, task Task, from string, resp agentcmd.AgentSelfUpdateResponse) error {
+	deadline := time.Now().Add(confirmWindowFor(resp.CronMode))
+
+	// The staged record has to outlive this control plane's patience, or a slow
+	// site expires its own stage and then false-fails its wave (see
+	// agentcmd.SelfUpdateStagedTTLFloor). Nothing here can repair that, // shortening the deadline would only fail the same site sooner, but the
+	// control plane must not be silent about it.
+	if resp.ExpiresAt > 0 {
+		if expiry := time.Unix(resp.ExpiresAt, 0); expiry.Before(deadline) {
+			w.logger.Warn("agent self-update: the site's staged record expires before this control plane stops waiting",
+				slog.String("task_id", task.ID.String()),
+				slog.String("site_id", task.SiteID.String()),
+				slog.Time("staged_expires_at", expiry.UTC()),
+				slog.Time("confirm_deadline", deadline))
+		}
+	}
+
+	if err := w.agent.Confirms.EnqueueAgentConfirm(ctx, AgentConfirmArgs{
+		TenantID:      task.TenantID,
+		RunID:         task.RunID,
+		TaskID:        task.ID,
+		SiteID:        task.SiteID,
+		FromVersion:   from,
+		ExpectVersion: resp.ToVersion,
+		CronMode:      resp.CronMode,
+		DeadlineAt:    deadline,
+	}); err != nil {
+		// Without the confirmation job nothing would ever establish whether
+		// this upgrade landed, and the task would sit running until the
+		// reaper swept it. Fail it now, honestly: the agent may well apply the
+		// upgrade, but this control plane can no longer prove it.
+		return w.finishAgentTask(ctx, task, TaskFailed, from, resp.ToVersion,
+			"the agent scheduled its upgrade but the confirmation poll could not be enqueued", err.Error())
+	}
+
+	w.logger.Info("agent self-update armed",
+		slog.String("task_id", task.ID.String()),
+		slog.String("site_id", task.SiteID.String()),
+		slog.String("arm_status", resp.Status),
+		slog.String("from_version", from),
+		slog.String("to_version", resp.ToVersion),
+		slog.String("cron_mode", resp.CronMode),
+		slog.Time("confirm_deadline", deadline))
+
+	if w.audit != nil {
+		_, _ = w.audit.Record(ctx, audit.Event{
+			TenantID:   task.TenantID,
+			ActorType:  audit.ActorSystem,
+			Action:     ActionAgentSelfUpdateArmed,
+			TargetType: "update_task",
+			TargetID:   task.ID.String(),
+			Metadata: map[string]any{
+				"run_id":       args.RunID.String(),
+				"site_id":      task.SiteID.String(),
+				"arm_status":   resp.Status,
+				"from_version": from,
+				"to_version":   resp.ToVersion,
+				"cron_mode":    resp.CronMode,
+				"deadline_at":  deadline.UTC().Format(time.RFC3339),
+			},
+		})
+	}
+	return nil
+}
+
+// confirmWindowFor picks the beat-3 deadline from the cron mode the agent
+// reported. The wire carries exactly two modes; anything else (an omitted
+// field, or a value this control plane does not know) gets the NARROW window,
+// because widening on an unrecognized value would let a typo silently buy an
+// hour and a half of false patience.
+func confirmWindowFor(cronMode string) time.Duration {
+	switch cronMode {
+	case agentcmd.CronModeExternal:
+		return agentConfirmDeadlineExternalCron
+	default:
+		return agentConfirmDeadline
+	}
+}
+
+// haltAgentRun stops the whole run for a reason outside the wave gate (today:
+// the kill switch), then records this task's own outcome. The task is SKIPPED,
+// not failed: the control plane declined to act, which is not a site error.
+func (w *Worker) haltAgentRun(ctx context.Context, task Task, reason, taskDetail string) error {
+	w.logger.Warn("agent self-update refused before dispatch",
+		slog.String("task_id", task.ID.String()),
+		slog.String("site_id", task.SiteID.String()),
+		slog.String("reason", reason))
+
+	return w.haltAgentRunWith(ctx, task, TaskSkipped, task.FromVersion, "", taskDetail, "", reason)
+}
+
+// haltAgentRunWith records THIS task's outcome and then halts the whole run for
+// a reason the wave gate itself cannot derive from the task rows (the kill
+// switch, or a release manifest that no longer offers the version the run exists
+// to install).
+//
+// The task is finished FIRST, and deliberately not through finishAgentTask:
+//
+//   - Halting first would leave every sibling cancelled by the time this task
+//     finished, so the ordinary run-completion check would flip the run to
+//     "completed" and the gate re-evaluation would then have to correct it back
+//     to "halted", recording a second incident for one incident.
+//   - finishAgentTask re-judges the wave gate, which on a CONFIRMING outcome
+//     would open and enqueue the next wave a moment before the halt shuts it.
+//     Those jobs are harmless (they claim, see the halt and stop) but they are
+//     jobs dispatched for a rollout that is over.
+//
+// The halt still cancels every task nothing was sent for and leaves running ones
+// to their own confirmation job (see haltLocked).
+func (w *Worker) haltAgentRunWith(ctx context.Context, task Task, status, fromVersion, toVersion, detail, errMsg, reason string) error {
+	if err := w.finish(ctx, task, status, fromVersion, toVersion, detail, errMsg); err != nil {
+		return err
+	}
+	if w.agent.Waves == nil {
+		// Nothing to halt against; this task's own outcome is still recorded.
+		return nil
+	}
+	ev, err := w.agent.Waves.HaltAgentRun(ctx, task.TenantID, task.RunID, reason)
+	if err != nil {
+		w.logger.Warn("agent self-update: halt failed", slog.Any("error", err))
+		return nil
+	}
+	w.recordRunHalted(ctx, task.TenantID, task.RunID, ev)
+	return nil
+}
+
+// finishAgentTask records an agent task's terminal state and then re-judges
+// the run's wave gate. Every agent-task terminal transition goes through here,
+// which is what makes the gate self-correcting: the halt verdict is recomputed
+// from the authoritative rows after every change, and the run's status is
+// re-asserted afterwards (see haltLocked) so an ordinary run-completion check
+// can never quietly overwrite a halt with "completed".
+func (w *Worker) finishAgentTask(ctx context.Context, task Task, status, fromVersion, toVersion, detail, errMsg string) error {
+	if err := w.finish(ctx, task, status, fromVersion, toVersion, detail, errMsg); err != nil {
+		return err
+	}
+	w.evaluateAgentRun(ctx, task.TenantID, task.RunID)
+	return nil
+}
+
+// evaluateAgentRun re-judges the wave gate and either records the halt or
+// enqueues whatever the newly-opened wave made dispatchable. Best-effort: an
+// error here never fails the River job (the task already reached a terminal
+// state), and the gate is re-judged from scratch by the next terminal
+// transition and by every claim attempt, so a lost evaluation self-heals.
+func (w *Worker) evaluateAgentRun(ctx context.Context, tenantID, runID uuid.UUID) {
+	if w.agent.Waves == nil {
+		return
+	}
+	ev, err := w.agent.Waves.EvaluateAgentRun(ctx, tenantID, runID)
+	if err != nil {
+		w.logger.Warn("agent self-update: wave evaluation failed",
+			slog.String("run_id", runID.String()), slog.Any("error", err))
+		return
+	}
+	if ev.Halted {
+		w.recordRunHalted(ctx, tenantID, runID, ev)
+		return
+	}
+	if w.agent.Tasks == nil {
+		return
+	}
+	for _, t := range ev.Dispatchable {
+		if err := w.agent.Tasks.EnqueueTask(ctx, tenantID, runID, t.ID, false); err != nil {
+			w.logger.Warn("agent self-update: enqueue of the next wave failed",
+				slog.String("run_id", runID.String()),
+				slog.String("task_id", t.ID.String()), slog.Any("error", err))
+		}
+	}
+}
+
+// recordRunHalted logs and audits a halt exactly once (AgentRunEvaluation.
+// Changed is true only for the caller that performed the transition, so
+// concurrent finishers do not produce duplicate incident records).
+func (w *Worker) recordRunHalted(ctx context.Context, tenantID, runID uuid.UUID, ev AgentRunEvaluation) {
+	if !ev.Changed {
+		return
+	}
+	w.logger.Warn("agent self-update run halted",
+		slog.String("run_id", runID.String()),
+		slog.String("reason", ev.Reason),
+		slog.Int("cancelled_tasks", ev.Cancelled))
+	if w.audit == nil {
+		return
+	}
+	_, _ = w.audit.Record(ctx, audit.Event{
+		TenantID:   tenantID,
+		ActorType:  audit.ActorSystem,
+		Action:     ActionRunHalted,
+		TargetType: "update_run",
+		TargetID:   runID.String(),
+		Metadata: map[string]any{
+			"reason":          ev.Reason,
+			"cancelled_tasks": ev.Cancelled,
+		},
+	})
+}
+
+func detailOr(primary, fallback string) string {
+	if primary != "" {
+		return primary
+	}
+	return fallback
+}
+
+// ---------------------------------------------------------------------------
+// BEAT 3, confirmation
+// ---------------------------------------------------------------------------
+
+// AgentConfirmArgs is the River job payload for the beat-3 confirmation poll.
+// The deadline is an ABSOLUTE time carried in the args, so it survives the
+// job snoozing itself repeatedly and cannot be reset by a retry.
+type AgentConfirmArgs struct {
+	TenantID uuid.UUID `json:"tenant_id"`
+	RunID    uuid.UUID `json:"run_id"`
+	TaskID   uuid.UUID `json:"task_id"`
+	SiteID   uuid.UUID `json:"site_id"`
+	// FromVersion is what the site ran when it armed.
+	FromVersion string `json:"from_version,omitempty"`
+	// ExpectVersion is the version the agent said beat 2 would install. Empty
+	// when the agent did not say, in which case any strictly newer well-formed
+	// version confirms.
+	ExpectVersion string `json:"expect_version,omitempty"`
+	// CronMode is carried for the operator-facing detail on a timeout, so a
+	// site whose cron is disabled explains itself in the failure text.
+	CronMode string `json:"cron_mode,omitempty"`
+	// DeadlineAt is when an unconfirmed upgrade becomes a failure.
+	DeadlineAt time.Time `json:"deadline_at"`
+}
+
+// Kind implements river.JobArgs.
+func (AgentConfirmArgs) Kind() string { return "update_agent_confirm" }
+
+// InsertOpts reuses the per-tenant queue shard so confirmation polls are
+// bounded by the same per-tenant parallelism limit as the tasks they belong to.
+func (a AgentConfirmArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{Queue: QueueForTenant(a.TenantID)}
+}
+
+// AgentConfirmWorker is beat 3: it waits for the NEW agent code to phone home.
+//
+// This is the only place an agent self-update is allowed to become
+// TaskSucceeded. The ARM acknowledgement from beat 1 says only that a cron
+// event was scheduled; nothing had been applied when it was sent, and on a
+// site whose loopback cron is broken nothing ever will be. Recording that ack
+// as success would report a fleet as upgraded while an unknown share of it
+// still runs the old build.
+type AgentConfirmWorker struct {
+	river.WorkerDefaults[AgentConfirmArgs]
+	w    *Worker
+	poll time.Duration
+	now  func() time.Time
+}
+
+// NewAgentConfirmWorker builds the confirmation worker on top of the same
+// Worker (and therefore the same repo/hub/audit/logger and the same wave
+// gate) that dispatches the tasks.
+func NewAgentConfirmWorker(w *Worker) *AgentConfirmWorker {
+	return &AgentConfirmWorker{w: w, poll: agentConfirmPoll, now: time.Now}
+}
+
+// SetPollInterval overrides the re-check interval. Exposed for tests so the
+// poll loop does not actually wait the production 30s; production code should
+// rely on the default.
+func (c *AgentConfirmWorker) SetPollInterval(d time.Duration) {
+	if d > 0 {
+		c.poll = d
+	}
+}
+
+// SetClock overrides the time source (tests).
+func (c *AgentConfirmWorker) SetClock(now func() time.Time) {
+	if now != nil {
+		c.now = now
+	}
+}
+
+// Work runs one confirmation poll.
+func (c *AgentConfirmWorker) Work(ctx context.Context, job *river.Job[AgentConfirmArgs]) error {
+	a := job.Args
+	w := c.w
+
+	task, err := w.repo.GetTask(ctx, a.TenantID, a.TaskID)
+	if err != nil {
+		return err
+	}
+	if terminal(task.Status) {
+		// Already resolved: the run halted and cancelled it, or a duplicate
+		// poll got there first.
+		return nil
+	}
+	if w.agent.Versions == nil {
+		return w.finishAgentTask(ctx, task, TaskFailed, a.FromVersion, a.ExpectVersion,
+			"the agent self-update channel is disabled on this control plane", "")
+	}
+
+	reported, err := w.agent.Versions.AgentVersion(ctx, a.TenantID, a.SiteID)
+	if err != nil {
+		if de, ok := domain.AsDomain(err); ok && de.Kind == domain.KindNotFound {
+			return w.finishAgentTask(ctx, task, TaskFailed, a.FromVersion, a.ExpectVersion,
+				"site unresolved while confirming the agent self-update", err.Error())
+		}
+		// A transient read failure proves nothing either way. Keep waiting;
+		// the deadline below is what eventually resolves this task.
+		w.logger.Warn("agent self-update: version read failed",
+			slog.String("site_id", a.SiteID.String()), slog.Any("error", err))
+	} else if agentSelfUpdateConfirmed(reported, a.FromVersion, a.ExpectVersion) {
+		// BEAT 3. The new code reported its own version over the signed
+		// metadata channel. This is the only success this channel recognizes.
+		return w.finishAgentTask(ctx, task, TaskSucceeded, a.FromVersion, reported,
+			fmt.Sprintf("upgraded and confirmed: the agent reported %s over its signed metadata channel", reported), "")
+	}
+
+	if !c.now().Before(a.DeadlineAt) {
+		return w.finishAgentTask(ctx, task, TaskFailed, a.FromVersion, a.ExpectVersion,
+			unconfirmedDetail(a, reported, w.agentApplyResult(ctx, a.TenantID, a.SiteID)), "agent_self_update_unconfirmed")
+	}
+	return river.JobSnooze(c.poll)
+}
+
+// agentApplyResult reads the agent's own account of its last apply beat, or nil
+// when there is nothing to read. Best-effort by design: this only ever enriches
+// an explanation, so an unwired lookup, a read failure, or a site that never
+// reported one all resolve to "the agent said nothing" rather than changing any
+// outcome.
+func (w *Worker) agentApplyResult(ctx context.Context, tenantID, siteID uuid.UUID) *AgentApplyResult {
+	if w.agent.Results == nil {
+		return nil
+	}
+	res, ok, err := w.agent.Results.AgentSelfUpdateResult(ctx, tenantID, siteID)
+	if err != nil {
+		w.logger.Debug("agent self-update: apply-result read failed",
+			slog.String("site_id", siteID.String()), slog.Any("error", err))
+		return nil
+	}
+	if !ok || res.Status == "" {
+		return nil
+	}
+	return &res
+}
+
+// unconfirmedDetail explains a deadline expiry in terms an operator can act
+// on, including the crucial fact that nothing was necessarily applied: a site
+// that never reached beat 2 was never touched.
+//
+// When the agent left an account of its own apply beat, that account is what
+// turns this from a shrug into a diagnosis: "the cron run never happened" and
+// "the cron run happened and the upgrade failed" produce the identical timeout
+// here, and only the agent can tell them apart.
+func unconfirmedDetail(a AgentConfirmArgs, reported string, res *AgentApplyResult) string {
+	still := reported
+	if still == "" {
+		still = "an unknown version"
+	}
+	base := fmt.Sprintf("unconfirmed: the agent scheduled its upgrade to %s but never reported it (still reporting %s). "+
+		"The site was not necessarily modified: an upgrade that never reached its cron run leaves the agent exactly as it was.",
+		fromOr(a.ExpectVersion, "the published build"), still)
+	if a.CronMode == agentcmd.CronModeExternal {
+		base += " This site reports that WordPress loopback cron is unavailable, so the upgrade depends on an external scheduler this control plane cannot see."
+	}
+	if s := applyResultSentence(res); s != "" {
+		base += " " + s
+	}
+	return base
+}
+
+// applyResultSentence renders the agent's apply-beat record as one operator-
+// facing sentence, or "" when there is no record. The four statuses the agent
+// reports each mean something different about where to look next, so each gets
+// its own wording rather than a generic dump; an unrecognized status (a newer
+// agent) is still surfaced verbatim rather than swallowed.
+func applyResultSentence(res *AgentApplyResult) string {
+	if res == nil || res.Status == "" {
+		return ""
+	}
+	when := ""
+	if !res.At.IsZero() {
+		when = " at " + res.At.UTC().Format(time.RFC3339)
+	}
+	detail := ""
+	if res.Detail != "" {
+		detail = ": " + res.Detail
+	}
+	move := fmt.Sprintf("%s to %s", fromOr(res.FromVersion, "an unreported version"), fromOr(res.ToVersion, "the staged build"))
+
+	switch res.Status {
+	case agentApplyApplied:
+		return fmt.Sprintf("The agent's own record says it DID apply the upgrade (%s)%s, so the apply ran and it is the version report that has not arrived; "+
+			"look at the site's metadata push rather than at the upgrade%s.", move, when, detail)
+	case agentApplyFailed:
+		return fmt.Sprintf("The agent's own record says the apply FAILED (%s)%s, so the cron run did happen and the upgrade is what did not%s.", move, when, detail)
+	case agentApplyExpired:
+		return fmt.Sprintf("The agent's own record says the staged upgrade EXPIRED before any apply request ran%s, so the cron run never happened in time "+
+			"and nothing was applied%s.", when, detail)
+	case agentApplyAlreadyApplied:
+		return fmt.Sprintf("The agent's own record says the on-disk version was ALREADY at or past the staged target (%s)%s%s.", move, when, detail)
+	default:
+		return fmt.Sprintf("The agent's own record of its last apply reads %q (%s)%s%s.", res.Status, move, when, detail)
+	}
+}
+
+// The apply-beat statuses the agent reports. Mirrored here as constants so the
+// wire vocabulary this control plane branches on is stated in one place.
+const (
+	agentApplyApplied        = "applied"
+	agentApplyFailed         = "failed"
+	agentApplyExpired        = "expired"
+	agentApplyAlreadyApplied = "already_applied"
+)

--- a/apps/api/internal/update/enqueuer.go
+++ b/apps/api/internal/update/enqueuer.go
@@ -38,3 +38,13 @@ func (e *RiverEnqueuer) EnqueueRefresh(ctx context.Context, args RefreshInventor
 	}
 	return nil
 }
+
+// EnqueueAgentConfirm inserts one agent self-update confirmation-poll job
+// (beat 3). The job's InsertOpts pin it to the tenant's queue shard. Satisfies
+// AgentConfirmEnqueuer.
+func (e *RiverEnqueuer) EnqueueAgentConfirm(ctx context.Context, args AgentConfirmArgs) error {
+	if _, err := e.client.Insert(ctx, args, nil); err != nil {
+		return fmt.Errorf("enqueue agent self-update confirmation: %w", err)
+	}
+	return nil
+}

--- a/apps/api/internal/update/model.go
+++ b/apps/api/internal/update/model.go
@@ -24,6 +24,11 @@ const (
 	RunPending   = "pending"
 	RunRunning   = "running"
 	RunCompleted = "completed"
+	// RunHalted is terminal and specific to an agent self-update run: a wave
+	// gate refused to advance, so every task the run had not already dispatched
+	// was cancelled. It is deliberately distinct from RunCompleted, which would
+	// erase the fact that the run was stopped rather than finished.
+	RunHalted = "halted"
 )
 
 // Task statuses.
@@ -34,14 +39,38 @@ const (
 	TaskFailed     = "failed"
 	TaskRolledBack = "rolled_back"
 	TaskSkipped    = "skipped"
+	// TaskCancelled is terminal: the task was never dispatched because its run
+	// halted first. Distinct from TaskSkipped (the control plane declined this
+	// particular target) and from TaskFailed (the site was contacted and did
+	// not come back): nothing was ever sent to this site.
+	TaskCancelled = "cancelled"
 )
 
-// Target types (mirror agentcmd.TargetPlugin/Theme/Core).
+// Target types. plugin/theme/core mirror agentcmd.TargetPlugin/Theme/Core.
 const (
 	TargetPlugin = "plugin"
 	TargetTheme  = "theme"
 	TargetCore   = "core"
+	// TargetAgent is the agent's OWN upgrade, shipped over the dedicated
+	// three-beat signed channel (agentcmd.AgentSelfUpdateRequest), never over
+	// the plugin update path. It is a separate target type rather than a
+	// plugin slug precisely so no code that handles a plugin update can ever
+	// reach it: the snapshot/rollback that guards every plugin update cannot be
+	// delivered by the process being replaced.
+	//
+	// update_tasks.target_type is plain text NOT NULL (m3), so this value needs
+	// no migration.
+	TargetAgent = "agent"
 )
+
+// AgentTargetSlug is the fixed target_slug every agent self-update task
+// carries. The agent target names exactly one thing, this control plane's own
+// plugin, so the operator never supplies a slug and the planner never derives
+// one from a site's inventory (which is what a renamed plugin directory or a
+// stale advisory could poison). It is pinned to the self-hosted distribution
+// slug because that is the build the release channel publishes for; the
+// plugin-directory build has no self-updater and is excluded at planning time.
+const AgentTargetSlug = agentplugin.SlugSelfHosted
 
 // Run is an update run: a tenant-scoped unit grouping per-(site,item) tasks.
 type Run struct {
@@ -87,7 +116,7 @@ type Task struct {
 
 // Item is one requested update target within a CreateRunInput.
 type Item struct {
-	Type    string `json:"type" validate:"required,oneof=plugin theme core"`
+	Type    string `json:"type" validate:"required,oneof=plugin theme core agent"`
 	Slug    string `json:"slug" validate:"max=200"`
 	Version string `json:"version" validate:"max=64"`
 }
@@ -123,6 +152,12 @@ var slugPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)?$`)
 // matches the plugin-header name, and again by the worker before dispatch.
 func validateItems(items []Item) error {
 	for _, it := range items {
+		if it.Type == TargetAgent {
+			if err := validateAgentItem(it, len(items)); err != nil {
+				return err
+			}
+			continue
+		}
 		if len(it.Slug) > 200 || !slugPattern.MatchString(it.Slug) {
 			return domain.Validation("invalid_slug", "update item slug contains an unsafe value: "+it.Slug)
 		}
@@ -133,6 +168,44 @@ func validateItems(items []Item) error {
 		if it.Version != "" && !versionPattern.MatchString(it.Version) {
 			return domain.Validation("invalid_version", "update item version contains an unsafe value: "+it.Version)
 		}
+	}
+	return nil
+}
+
+// validateAgentItem is the API boundary for the agent self-update target.
+//
+// A version pin is REJECTED rather than ignored. The release manifest the
+// agent verifies only ever points at the currently published build, and the
+// agent's own downgrade guard refuses anything older than what it is running,
+// so a pin cannot be honoured by construction. Accepting one and quietly
+// installing something else would tell the operator they pinned a version when
+// they did not; refusing is the only honest answer. "latest" (and the unset
+// default, which means the same thing) is accepted because it is what the
+// channel actually does.
+//
+// The slug is not operator-supplied either: this target names exactly one
+// thing. An empty slug is accepted and normalized to AgentTargetSlug; anything
+// else is refused rather than silently replaced, for the same reason.
+//
+// The agent target must also be the ONLY item in its run. The wave gate that
+// makes this channel safe is defined over "the run", wave 0 is one site, wave
+// 1 is 5% of the run, and a run also carrying plugin/theme/core tasks has no
+// well-defined denominator, no meaningful canary, and would let an unrelated
+// plugin failure halt an agent rollout (or an agent failure cancel unrelated
+// plugin work). Splitting them is one extra request and keeps both machines
+// honest.
+func validateAgentItem(it Item, itemCount int) error {
+	if itemCount != 1 {
+		return domain.Validation("agent_target_exclusive",
+			"the agent self-update target must be the only item in its run: its wave gate is defined over the whole run")
+	}
+	if it.Version != "" && it.Version != "latest" {
+		return domain.Validation("agent_version_pin_unsupported",
+			"the agent self-update channel cannot install a pinned version: the release manifest only ever points at the published build and the agent refuses to downgrade")
+	}
+	if it.Slug != "" && it.Slug != AgentTargetSlug {
+		return domain.Validation("agent_slug_unsupported",
+			"the agent self-update target takes no slug: it names this control plane's own agent plugin")
 	}
 	return nil
 }
@@ -152,7 +225,7 @@ type CreateRunInput struct {
 // terminal reports whether a task status is a final state.
 func terminal(status string) bool {
 	switch status {
-	case TaskSucceeded, TaskFailed, TaskRolledBack, TaskSkipped:
+	case TaskSucceeded, TaskFailed, TaskRolledBack, TaskSkipped, TaskCancelled:
 		return true
 	default:
 		return false

--- a/apps/api/internal/update/repo.go
+++ b/apps/api/internal/update/repo.go
@@ -14,6 +14,16 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
+// ErrTaskNotOpen reports that a task could not be finished because it was no
+// longer open (pending|running): something else already recorded its terminal
+// state. The overwhelmingly common case is a run that was halted while this
+// worker was in flight, the halt cancelled the task, and the worker returning
+// afterwards must not overwrite 'cancelled' with 'succeeded', which would make
+// the kill switch look like it stopped a rollout that then reported itself a
+// success. It is not an error condition for the caller: the recorded outcome
+// stands and the job is done. See Worker.finish.
+var ErrTaskNotOpen = errors.New("update task is not open")
+
 // Repo is the tenant-scoped persistence interface for update runs/tasks. Every
 // method runs inside a tenant-scoped transaction so RLS enforces isolation even
 // if a query omitted its tenant filter.
@@ -30,6 +40,9 @@ type Repo interface {
 	GetTask(ctx context.Context, tenantID, taskID uuid.UUID) (Task, error)
 
 	MarkTaskRunning(ctx context.Context, tenantID, taskID uuid.UUID) (Task, error)
+	// FinishTask records a terminal state for a task that is still OPEN
+	// (pending|running). A task that already reached a terminal state is
+	// returned unchanged alongside ErrTaskNotOpen: its recorded outcome wins.
 	FinishTask(ctx context.Context, in FinishTaskInput) (Task, error)
 	SetRunStatus(ctx context.Context, tenantID, runID uuid.UUID, status string) (Run, error)
 	CountUnfinishedTasks(ctx context.Context, tenantID, runID uuid.UUID) (int64, error)
@@ -40,8 +53,7 @@ type Repo interface {
 	// a duplicate task for a target that already has an update in flight from
 	// another run (#131 hardening): without this, a scheduled auto-update, an
 	// operator bulk update, and a portal trigger can all create tasks for the
-	// SAME (site, plugin) within the same window, and several run concurrently —
-	// racing the agent's own rollback-snapshot pruning and running concurrent
+	// SAME (site, plugin) within the same window, and several run concurrently, // racing the agent's own rollback-snapshot pruning and running concurrent
 	// WordPress Plugin_Upgrader instances against the same plugin directory. The
 	// authoritative guard is the update_tasks_inflight_target_idx partial unique
 	// index (see CreateUpdateTask's ON CONFLICT); this pre-check just avoids
@@ -292,7 +304,8 @@ func (r *pgRepo) MarkTaskRunning(ctx context.Context, tenantID, taskID uuid.UUID
 func (r *pgRepo) FinishTask(ctx context.Context, in FinishTaskInput) (Task, error) {
 	var out Task
 	err := r.pool.InTenantTx(ctx, in.TenantID, func(tx pgx.Tx) error {
-		row, err := sqlc.New(tx).FinishUpdateTask(ctx, sqlc.FinishUpdateTaskParams{
+		q := sqlc.New(tx)
+		row, err := q.FinishUpdateTask(ctx, sqlc.FinishUpdateTaskParams{
 			ID:          in.TaskID,
 			TenantID:    in.TenantID,
 			Status:      in.Status,
@@ -302,10 +315,24 @@ func (r *pgRepo) FinishTask(ctx context.Context, in FinishTaskInput) (Task, erro
 			Error:       in.Error,
 		})
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return domain.NotFound("update_task_not_found", "update task not found")
+			if !errors.Is(err, pgx.ErrNoRows) {
+				return domain.Internal("update_task_finish_failed", "failed to finish task").WithCause(err)
 			}
-			return domain.Internal("update_task_finish_failed", "failed to finish task").WithCause(err)
+			// FinishUpdateTask only matches an OPEN task (pending|running), so
+			// no row means either the task does not exist or it already
+			// reached a terminal state, most importantly 'cancelled', written
+			// by a halt while this worker was still in flight. Read the row
+			// back to tell the two apart, and return the recorded outcome
+			// rather than overwriting it.
+			existing, gerr := q.GetUpdateTask(ctx, sqlc.GetUpdateTaskParams{ID: in.TaskID, TenantID: in.TenantID})
+			if gerr != nil {
+				if errors.Is(gerr, pgx.ErrNoRows) {
+					return domain.NotFound("update_task_not_found", "update task not found")
+				}
+				return domain.Internal("update_task_get_failed", "failed to load update task").WithCause(gerr)
+			}
+			out = toTask(existing)
+			return ErrTaskNotOpen
 		}
 		out = toTask(row)
 		return nil

--- a/apps/api/internal/update/service.go
+++ b/apps/api/internal/update/service.go
@@ -2,11 +2,13 @@ package update
 
 import (
 	"context"
+	"sort"
 	"strings"
 
 	"github.com/google/uuid"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/agentplugin"
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentrelease"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 	"github.com/mosamlife/wpmgr/apps/api/internal/wpversion"
 )
@@ -30,6 +32,16 @@ type SiteInfo struct {
 	CoreUpdateAvailable bool
 	CoreCurrentVersion  string
 	CoreNewVersion      string
+
+	// AgentVersion is the agent version the site last reported over its signed
+	// metadata push (sites.agent_version). It is the ONLY input the agent
+	// self-update planner uses to decide whether a site is behind, precisely
+	// because it does not come from the site's plugin inventory: that inventory
+	// is built from the site's own WordPress update-check cache, which for the
+	// agent is a stale advisory the control plane deliberately suppresses
+	// everywhere else (see indexPending). Empty when the site has never
+	// reported one.
+	AgentVersion string
 }
 
 // Component is one installed plugin/theme with its current version and its
@@ -74,11 +86,28 @@ type Service struct {
 	enqueuer  Enqueuer
 	validator *domain.Validator
 	clock     domain.Clock
+
+	// agentSelfUpdate is the fleet-wide kill switch, mirrored from the worker's
+	// copy so an operator gets an immediate refusal instead of a run that
+	// halts on its first task. FALSE BY DEFAULT: a Service that never has
+	// SetAgentSelfUpdate called on it refuses the agent target outright.
+	agentSelfUpdate bool
+	// releases reports the currently published agent version, the yardstick
+	// the agent planner compares each site against.
+	releases AgentReleaseReader
 }
 
 // NewService builds an update Service.
 func NewService(repo Repo, sites SiteLookup, enqueuer Enqueuer, v *domain.Validator, clock domain.Clock) *Service {
 	return &Service{repo: repo, sites: sites, enqueuer: enqueuer, validator: v, clock: clock}
+}
+
+// SetAgentSelfUpdate wires the agent self-update channel's kill switch and the
+// published-version reader. Call once at boot; not calling it leaves the
+// channel off.
+func (s *Service) SetAgentSelfUpdate(enabled bool, releases AgentReleaseReader) {
+	s.agentSelfUpdate = enabled
+	s.releases = releases
 }
 
 // CreateRun validates the input, resolves the target sites, creates the run and
@@ -131,10 +160,27 @@ func (s *Service) CreateRun(ctx context.Context, in CreateRunInput) (Run, []Task
 		return Run{}, nil, err
 	}
 
-	tasks, skippedInFlight := s.planTasks(sites, in.Items, inFlight)
+	agentRun := isAgentRun(in.Items)
+
+	var (
+		tasks           []NewTask
+		skippedInFlight int
+	)
+	if agentRun {
+		tasks, skippedInFlight, err = s.planAgentTasks(ctx, sites, in, inFlight)
+		if err != nil {
+			return Run{}, nil, err
+		}
+	} else {
+		tasks, skippedInFlight = s.planTasks(sites, in.Items, inFlight)
+	}
 	if len(tasks) == 0 {
 		if skippedInFlight > 0 {
 			return Run{}, nil, domain.Conflict("targets_in_flight", "the selected updates already have an update in progress in another run")
+		}
+		if agentRun {
+			return Run{}, nil, domain.Validation("no_tasks",
+				"no selected site needs an agent upgrade: each one already runs the published version, or runs a build this channel cannot upgrade")
 		}
 		return Run{}, nil, domain.Validation("no_tasks", "the selection produced no update tasks")
 	}
@@ -147,12 +193,135 @@ func (s *Service) CreateRun(ctx context.Context, in CreateRunInput) (Run, []Task
 	// Enqueue one background job per task. A best-effort enqueue: a failure here
 	// leaves the task pending (the caller still gets the run); we surface the
 	// first enqueue error so the operator can retry.
-	for _, t := range createdTasks {
+	//
+	// An agent run enqueues ONLY its first wave. Later waves are enqueued by
+	// the worker after the preceding wave has confirmed (see
+	// Worker.evaluateAgentRun), so a rollout that must not continue never has
+	// a job sitting ready to run. The worker-side gate
+	// (pgRepo.ClaimAgentWaveTask) is the authoritative guard regardless, so an
+	// early or duplicated enqueue still cannot dispatch out of turn.
+	for _, t := range enqueueSet(createdTasks, agentRun) {
 		if eerr := s.enqueuer.EnqueueTask(ctx, run.TenantID, run.ID, t.ID, run.DryRun); eerr != nil {
 			return run, createdTasks, eerr
 		}
 	}
 	return run, createdTasks, nil
+}
+
+// isAgentRun reports whether the run targets the agent's own upgrade.
+// validateAgentItem already guarantees such a run carries exactly one item.
+func isAgentRun(items []Item) bool {
+	return len(items) == 1 && items[0].Type == TargetAgent
+}
+
+// enqueueSet returns the tasks to enqueue immediately: all of them for an
+// ordinary run, and only the first wave for an agent run.
+func enqueueSet(tasks []Task, agentRun bool) []Task {
+	if !agentRun {
+		return tasks
+	}
+	return DeriveAgentWaveState(tasks).DispatchableTasks()
+}
+
+// planAgentTasks builds the agent self-update run's ORDERED task set.
+//
+// It deliberately does NOT consult the site's plugin inventory, which is what
+// every other target is planned from. That inventory is the site's own
+// WordPress update-check cache, and for the agent it carries an advisory the
+// control plane suppresses everywhere else precisely because it is stale,
+// self-referential, and (under a renamed plugin directory) not reliably
+// attributable. The authority here is instead the pair of facts the control
+// plane can vouch for on its own: the version the site's agent reported over
+// its signed metadata push (SiteInfo.AgentVersion) and the version this
+// control plane actually publishes (AgentReleaseReader).
+//
+// Comparison is delegated to agentrelease.Classify, the same classifier
+// behind the fleet agent-freshness dashboard, so "this site is behind" has
+// exactly one definition. Only StatusOutdated produces a task:
+//
+//   - StatusCurrent    the site already runs the published build.
+//   - StatusIneligible the site runs the plugin-directory build, which ships
+//     without a self-updater and is upgraded by the directory.
+//   - StatusUnknown    one of the two versions is missing or not well-formed.
+//     Never guess: an unreadable version must not become an upgrade.
+func (s *Service) planAgentTasks(ctx context.Context, sites []SiteInfo, in CreateRunInput, inFlight map[InFlightKey]struct{}) ([]NewTask, int, error) {
+	if !s.agentSelfUpdate {
+		return nil, 0, domain.Conflict("agent_self_update_disabled",
+			"the agent self-update channel is disabled on this control plane")
+	}
+	if in.DryRun {
+		return nil, 0, domain.Validation("agent_dry_run_unsupported",
+			"the agent self-update channel has no dry run: arming already changes nothing on the site, and applying happens in a later request the control plane does not drive")
+	}
+	latest := ""
+	if s.releases != nil {
+		latest = s.releases.LatestVersion(ctx)
+	}
+	if latest == "" {
+		return nil, 0, domain.Conflict("agent_release_unknown",
+			"the currently published agent version could not be determined, so no site can be told it is behind")
+	}
+
+	ordered := make([]SiteInfo, len(sites))
+	copy(ordered, sites)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].ID.String() < ordered[j].ID.String() })
+
+	tasks := make([]NewTask, 0, len(ordered))
+	skippedInFlight := 0
+	for _, site := range ordered {
+		if agentrelease.Classify(site.AgentVersion, latest, agentDistributionOf(site.Components)) != agentrelease.StatusOutdated {
+			continue
+		}
+		if _, blocked := inFlight[InFlightKey{SiteID: site.ID, TargetType: TargetAgent, TargetSlug: AgentTargetSlug}]; blocked {
+			skippedInFlight++
+			continue
+		}
+		tasks = append(tasks, NewTask{
+			SiteID:     site.ID,
+			TargetType: TargetAgent,
+			TargetSlug: AgentTargetSlug,
+			// The RESOLVED published version, not the literal "latest". This is
+			// the run's PREMISE recorded at the moment it was planned: "this run
+			// sets out to install THIS version".
+			//
+			// It changes nothing on the wire. A pin is refused at the API
+			// boundary (see validateAgentItem) and the arm command carries no
+			// version at all: the agent installs whatever its own signed manifest
+			// offers, and its downgrade guard refuses anything older than what it
+			// runs. What this column buys is the ability to CHECK an answer
+			// later.
+			//
+			// The release manifest is mutable, and reverting it is exactly what
+			// an operator is expected to do during an incident. Without the
+			// planned target persisted, the only thing a later "up_to_date"
+			// answer could be scored against is a LIVE read of that same
+			// manifest, which scores the site against a target that may have
+			// moved down to meet it: every site then answers "already current",
+			// every task records succeeded, and a fleet-wide run completes green
+			// with not one agent moved. See Worker.upToDate.
+			DesiredVersion: latest,
+			FromVersion:    site.AgentVersion,
+		})
+	}
+	return tasks, skippedInFlight, nil
+}
+
+// agentDistributionOf identifies which build of the agent a site runs, from
+// the site's own plugin inventory. Used ONLY to exclude the plugin-directory
+// build, which has no self-updater at all; the version comparison itself never
+// touches the inventory. DistributionNone (no recognizable agent entry) falls
+// through to the version comparison unchanged, exactly as the fleet dashboard
+// treats it.
+func agentDistributionOf(components []Component) agentplugin.Distribution {
+	for _, c := range components {
+		if c.Type != TargetPlugin {
+			continue
+		}
+		if d := agentplugin.DistributionOf(c.Slug, c.Name); d != agentplugin.DistributionNone {
+			return d
+		}
+	}
+	return agentplugin.DistributionNone
 }
 
 // resolveSites returns the target SiteInfos for the run input.
@@ -338,6 +507,13 @@ func normalizeItems(items []Item) []Item {
 		it.Version = strings.TrimSpace(it.Version)
 		if it.Type == TargetCore {
 			it.Slug = "core"
+		}
+		// The agent target names exactly one thing, so an omitted slug is the
+		// normal case and is filled in here rather than dropped. A slug the
+		// caller DID supply is left alone for validateAgentItem to accept or
+		// refuse; silently replacing it would hide a mistaken request.
+		if it.Type == TargetAgent && it.Slug == "" {
+			it.Slug = AgentTargetSlug
 		}
 		if it.Type != TargetCore && it.Slug == "" {
 			continue

--- a/apps/api/internal/update/worker.go
+++ b/apps/api/internal/update/worker.go
@@ -103,6 +103,11 @@ type Worker struct {
 	// schedule (probeRetryDelays). Nil uses the default. Tests set this to a
 	// tiny schedule so the retry loop does not actually sleep ~21s.
 	probeDelays []time.Duration
+	// agent holds the agent self-update channel's dependencies and its
+	// fleet-wide kill switch. The ZERO VALUE IS DISABLED: a deployment that
+	// never calls SetAgentSelfUpdate never sends an agent self-update command
+	// to any site.
+	agent AgentSelfUpdateDeps
 	// jobTimeout overrides River's default 60s per-job context deadline (see
 	// DeriveApplyJobTimeout, and NewBackupWorker's identical jobTimeout field for
 	// the same pattern applied to backups). runApply makes one apply/rollback
@@ -240,6 +245,16 @@ func (w *Worker) Work(ctx context.Context, job *river.Job[TaskArgs]) error {
 	}
 	if terminal(task.Status) {
 		return nil // already finished (retry/dup); nothing to do.
+	}
+
+	// The agent's OWN upgrade travels a wholly separate branch: a wave-gated
+	// three-beat protocol with no health probe and no rollback (see
+	// runAgentSelfUpdate for why each of those is absent). It shares nothing
+	// with the plugin/theme/core path below except this dispatch point, so no
+	// code that snapshots, probes or rolls back a site can ever be reached
+	// with the agent as its target.
+	if task.TargetType == TargetAgent {
+		return w.runAgentSelfUpdate(ctx, a, task)
 	}
 
 	// Last line of defense before anything is sent to a site: a task targeting
@@ -694,7 +709,19 @@ func (w *Worker) finish(ctx context.Context, task Task, status, fromVersion, toV
 		Error:       errMsg,
 	})
 	if err != nil {
-		return err
+		if !errors.Is(err, ErrTaskNotOpen) {
+			return err
+		}
+		// The task already has a terminal state, typically 'cancelled',
+		// written by a halt while this worker was in flight. First outcome
+		// recorded wins: reporting this one would overwrite the halt with a
+		// success and hide the fact that the run was stopped. The job itself
+		// succeeded; there is simply nothing left to record.
+		w.logger.Info("update task already finished; leaving the recorded outcome alone",
+			slog.String("task_id", task.ID.String()),
+			slog.String("recorded_status", finished.Status),
+			slog.String("discarded_status", status))
+		return nil
 	}
 
 	runStatus := RunRunning
@@ -849,8 +876,7 @@ func (ReapStaleTasksArgs) Kind() string { return "update_task_reaper" }
 // worker crash between MarkTaskRunning and finish(), or an EnqueueTask
 // failure that leaves a task pending (Service.CreateRun's best-effort enqueue
 // after CreateRunWithTasks), would otherwise permanently occupy the
-// update_tasks_inflight_target_idx slot for that (tenant, site, target) —
-// every future update attempt for it 409s targets_in_flight forever (m88).
+// update_tasks_inflight_target_idx slot for that (tenant, site, target), // every future update attempt for it 409s targets_in_flight forever (m88).
 // If DeriveApplyJobTimeout's budget is ever tuned up near or past this value,
 // this threshold must grow with it: the reaper terminalizing a task that is
 // still legitimately within its own job deadline would itself be a bug.
@@ -861,6 +887,22 @@ const staleTaskThreshold = 45 * time.Minute
 // remainder is caught by the next sweep (see the periodic job interval, wired
 // in cmd/wpmgr/main.go).
 const staleTaskReapLimit = 500
+
+// agentStaleTaskThreshold is the reaper's threshold for an AGENT self-update
+// task. It is far longer than staleTaskThreshold because such a task is
+// legitimately slow in two ways the ordinary threshold never anticipates: a
+// task in a later wave sits pending until every earlier wave has confirmed
+// (which for a large fleet is several confirmation windows back to back), and
+// a task on a site with external cron waits up to
+// agentConfirmDeadlineExternalCron for beat 3 on its own. Reaping either as
+// "stale" would fail a task that is behaving exactly as designed, and, worse
+//, feed a false failure into the wave gate, halting a healthy rollout.
+//
+// It is still finite: a genuinely stuck agent task must eventually release its
+// (tenant, site, target_type, target_slug) slot in the
+// update_tasks_inflight_target_idx partial unique index (m88), or every future
+// agent upgrade for that site would 409 forever.
+const agentStaleTaskThreshold = 6 * time.Hour
 
 // ReaperWorker is the periodic River job that sweeps update_tasks for rows
 // stuck in pending/running past staleTaskThreshold and terminalizes them as
@@ -893,6 +935,13 @@ func (rw *ReaperWorker) Work(ctx context.Context, _ *river.Job[ReapStaleTasksArg
 		return nil
 	}
 	for _, task := range stale {
+		// An agent self-update task is legitimately slow (wave gating +
+		// external-cron confirmation windows); it gets its own, much longer
+		// threshold. The SQL sweep cannot express two thresholds, so the
+		// narrower one is applied here.
+		if task.TargetType == TargetAgent && time.Since(task.UpdatedAt) < agentStaleTaskThreshold {
+			continue
+		}
 		if ferr := rw.w.finish(ctx, task, TaskFailed, task.FromVersion, task.ToVersion,
 			"stale: task exceeded max runtime", "reaped by the periodic stale-task sweep after no progress within the threshold"); ferr != nil {
 			rw.w.logger.Warn("update task reaper: failed to terminalize stale task",

--- a/apps/api/tests/update_agent_halt_guard_test.go
+++ b/apps/api/tests/update_agent_halt_guard_test.go
@@ -1,0 +1,375 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/update"
+)
+
+// GH #255 Phase 2, the two SQL preconditions that keep a halted agent
+// self-update run honest, exercised against a real Postgres through the real
+// generated queries. The in-package unit tests drive the same rules through
+// in-memory doubles; these prove the rules live where they have to be atomic,
+// in db/query/updates.sql.
+//
+//   - CancelPendingUpdateTask carries `AND status = 'pending'`, so a halt can
+//     only cancel a task nothing was ever sent for. update_tasks.status
+//     'cancelled' means exactly "nothing was ever sent to this site"; applying
+//     it to a running task would record a falsehood AND stop the confirmation
+//     poll (AgentConfirmWorker.Work short-circuits on a terminal status) from
+//     ever establishing what happened to a site the control plane had already
+//     touched, at the moment an operator hit the kill switch and most needs to
+//     know.
+//   - FinishUpdateTask carries `AND status IN ('pending','running')`, so a
+//     worker that was in flight when the halt landed cannot come back and
+//     overwrite 'cancelled' with 'succeeded'. Without it the kill switch looks
+//     like it stopped a rollout that then reported itself a success.
+
+// seedAgentRun creates one agent self-update run with n tasks over n freshly
+// enrolled sites, through the real repo, so RLS, the in-flight unique index and
+// every column default are the production ones.
+func seedAgentRun(t *testing.T, pool *db.Pool, tenant uuid.UUID, repo update.Repo, n int) (update.Run, []update.Task) {
+	t.Helper()
+
+	newTasks := make([]update.NewTask, 0, n)
+	for i := 0; i < n; i++ {
+		s := enrollFakeSite(t, pool, tenant, "https://"+uuid.NewString()+".example.com")
+		newTasks = append(newTasks, update.NewTask{
+			SiteID:     s.ID,
+			TargetType: update.TargetAgent,
+			TargetSlug: update.AgentTargetSlug,
+			// The RESOLVED target the planner records, not the literal
+			// "latest": it is the run's premise and the only fixed thing a
+			// later "up_to_date" answer can be checked against.
+			DesiredVersion: "0.62.0",
+			FromVersion:    "0.61.80",
+		})
+	}
+
+	run, tasks, err := repo.CreateRunWithTasks(context.Background(),
+		update.CreateRunInput{TenantID: tenant}, newTasks)
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if len(tasks) != n {
+		t.Fatalf("created %d tasks, want %d", len(tasks), n)
+	}
+	return run, tasks
+}
+
+// TestAgentHaltCancelsOnlyPendingTasks: a halt cancels what was never
+// dispatched and leaves a RUNNING task alone for its own confirmation job.
+func TestAgentHaltCancelsOnlyPendingTasks(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "agent-halt-pending")
+
+	repo := update.NewRepo(pool)
+	waves := update.NewAgentWaveRepo(pool)
+	run, tasks := seedAgentRun(t, pool, tenant, repo, 4)
+
+	// Task 0 has been dispatched: its command is delivered and (in production)
+	// a cron event is spawned on the site. Tasks 1..3 were never sent anything.
+	if _, err := repo.MarkTaskRunning(ctx, tenant, tasks[0].ID); err != nil {
+		t.Fatalf("mark running: %v", err)
+	}
+
+	ev, err := waves.HaltAgentRun(ctx, tenant, run.ID, "stopped by the operator")
+	if err != nil {
+		t.Fatalf("halt: %v", err)
+	}
+	if !ev.Halted || !ev.Changed {
+		t.Fatalf("the first halt must report the transition: %+v", ev)
+	}
+	if ev.Cancelled != 3 {
+		t.Fatalf("cancelled %d tasks, want the 3 that were still pending", ev.Cancelled)
+	}
+
+	got, err := repo.ListTasks(ctx, tenant, run.ID)
+	if err != nil {
+		t.Fatalf("list tasks: %v", err)
+	}
+	byID := map[uuid.UUID]update.Task{}
+	for _, task := range got {
+		byID[task.ID] = task
+	}
+	if s := byID[tasks[0].ID].Status; s != update.TaskRunning {
+		t.Fatalf("the dispatched task is %q, want %q: a halt must not claim nothing was sent to a site that was contacted",
+			s, update.TaskRunning)
+	}
+	for i := 1; i < 4; i++ {
+		if s := byID[tasks[i].ID].Status; s != update.TaskCancelled {
+			t.Fatalf("task %d is %q, want %q", i, s, update.TaskCancelled)
+		}
+	}
+
+	// Halting again is idempotent and still leaves the running task alone.
+	second, err := waves.HaltAgentRun(ctx, tenant, run.ID, "stopped by the operator")
+	if err != nil {
+		t.Fatalf("second halt: %v", err)
+	}
+	if second.Changed || second.Cancelled != 0 {
+		t.Fatalf("a repeated halt must be a no-op: %+v", second)
+	}
+	after, err := repo.GetTask(ctx, tenant, tasks[0].ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if after.Status != update.TaskRunning {
+		t.Fatalf("the dispatched task is %q after a second halt, want %q", after.Status, update.TaskRunning)
+	}
+}
+
+// TestCancelPendingUpdateTaskRefusesEveryNonPendingRow exercises the SQL
+// precondition on its own, which the test above cannot.
+//
+// TestAgentHaltCancelsOnlyPendingTasks drives the cancel through
+// HaltAgentRun, and haltLocked ALREADY filters to pending rows in Go before it
+// issues the statement. Both writers also hold the same per-run advisory lock,
+// so the Go filter is never even racing anything there. Delete `AND status =
+// 'pending'` from db/query/updates.sql and that test still passes: the guard
+// this file exists to protect can be removed without a single failure.
+//
+// So this one calls the generated query DIRECTLY, with no Go filter in front of
+// it, once for every status a task can already hold. That is also the shape of
+// the race the precondition is really for: a worker claims a task (pending ->
+// running) between the halt's snapshot read and its UPDATE, and only the
+// database can settle who wins.
+//
+// The property: the statement must touch NO row that is not pending, and it must
+// leave the recorded outcome exactly as it found it.
+func TestCancelPendingUpdateTaskRefusesEveryNonPendingRow(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "agent-cancel-precondition")
+
+	repo := update.NewRepo(pool)
+
+	// Every non-pending status a row can hold when a halt reaches it, plus the
+	// pending control that proves the statement is a precondition and not a
+	// blanket refusal.
+	cases := []struct {
+		name string
+		// setup moves the seeded task into the status under test and returns
+		// the detail the row must still carry afterwards.
+		setup      func(t *testing.T, task update.Task) string
+		wantCancel bool
+	}{
+		{
+			// The one the design is actually about: a dispatched task, whose
+			// command is delivered and whose cron event is spawned on the site.
+			name: "running",
+			setup: func(t *testing.T, task update.Task) string {
+				t.Helper()
+				if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+					t.Fatalf("mark running: %v", err)
+				}
+				return ""
+			},
+		},
+		{
+			name: "succeeded",
+			setup: func(t *testing.T, task update.Task) string {
+				t.Helper()
+				finishTaskAs(t, repo, tenant, task.ID, update.TaskSucceeded, "upgraded and confirmed")
+				return "upgraded and confirmed"
+			},
+		},
+		{
+			name: "failed",
+			setup: func(t *testing.T, task update.Task) string {
+				t.Helper()
+				finishTaskAs(t, repo, tenant, task.ID, update.TaskFailed, "the agent could not arm its self-update")
+				return "the agent could not arm its self-update"
+			},
+		},
+		{
+			name: "skipped",
+			setup: func(t *testing.T, task update.Task) string {
+				t.Helper()
+				finishTaskAs(t, repo, tenant, task.ID, update.TaskSkipped, "not confirmed: the site did not reach this run's target")
+				return "not confirmed: the site did not reach this run's target"
+			},
+		},
+		{
+			// An earlier halt already cancelled this row. The detail is
+			// deliberately a DIFFERENT reason from the one this cancel would
+			// write, so "nothing was written" is distinguishable from "the same
+			// thing was written twice".
+			name: "cancelled already",
+			setup: func(t *testing.T, task update.Task) string {
+				t.Helper()
+				finishTaskAs(t, repo, tenant, task.ID, update.TaskCancelled, "cancelled: an earlier halt, for its own reason")
+				return "cancelled: an earlier halt, for its own reason"
+			},
+		},
+		{
+			name:       "pending (the control)",
+			setup:      func(*testing.T, update.Task) string { return "" },
+			wantCancel: true,
+		},
+	}
+
+	const haltDetail = "cancelled: stopped by the operator"
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, tasks := seedAgentRun(t, pool, tenant, repo, 1)
+			task := tasks[0]
+			wantDetail := tc.setup(t, task)
+
+			before, err := repo.GetTask(ctx, tenant, task.ID)
+			if err != nil {
+				t.Fatalf("get task: %v", err)
+			}
+
+			var cancelled bool
+			err = pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+				_, qerr := sqlc.New(tx).CancelPendingUpdateTask(ctx, sqlc.CancelPendingUpdateTaskParams{
+					ID:       task.ID,
+					TenantID: tenant,
+					Detail:   haltDetail,
+				})
+				if errors.Is(qerr, pgx.ErrNoRows) {
+					return nil // refused: no row matched the precondition.
+				}
+				if qerr != nil {
+					return qerr
+				}
+				cancelled = true
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("cancel: %v", err)
+			}
+
+			after, err := repo.GetTask(ctx, tenant, task.ID)
+			if err != nil {
+				t.Fatalf("get task after: %v", err)
+			}
+
+			if cancelled != tc.wantCancel {
+				t.Fatalf("the statement %s a %s task; want %v. Status is now %q.\n"+
+					"This is the `AND status = 'pending'` precondition in db/query/updates.sql: without it a halt "+
+					"can record \"nothing was ever sent to this site\" about a site that was contacted, and stop the "+
+					"confirmation poll from ever establishing what happened there.",
+					map[bool]string{true: "cancelled", false: "refused"}[cancelled], tc.name, tc.wantCancel, after.Status)
+			}
+			if tc.wantCancel {
+				if after.Status != update.TaskCancelled || after.Detail != haltDetail {
+					t.Fatalf("a pending task must still be cancellable: status %q detail %q", after.Status, after.Detail)
+				}
+				return
+			}
+			if after.Status != before.Status {
+				t.Fatalf("status moved from %q to %q", before.Status, after.Status)
+			}
+			if after.Detail != wantDetail {
+				t.Fatalf("detail = %q, want the outcome already recorded (%q): a refused cancel must write nothing at all",
+					after.Detail, wantDetail)
+			}
+			if after.Detail == haltDetail {
+				t.Fatalf("a %s task acquired the halt's cancellation detail", tc.name)
+			}
+		})
+	}
+}
+
+// finishTaskAs drives one task to a terminal status through the real repo.
+func finishTaskAs(t *testing.T, repo update.Repo, tenant, taskID uuid.UUID, status, detail string) {
+	t.Helper()
+	if _, err := repo.FinishTask(context.Background(), update.FinishTaskInput{
+		TenantID: tenant,
+		TaskID:   taskID,
+		Status:   status,
+		Detail:   detail,
+	}); err != nil {
+		t.Fatalf("finish as %s: %v", status, err)
+	}
+}
+
+// TestFinishUpdateTaskCannotOverwriteATerminalTask: the in-flight worker comes
+// back after the halt. Its outcome must not land on a task that already has
+// one, and the caller must be told so rather than being handed a lie.
+func TestFinishUpdateTaskCannotOverwriteATerminalTask(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "agent-halt-overwrite")
+
+	repo := update.NewRepo(pool)
+	waves := update.NewAgentWaveRepo(pool)
+	halted, haltedTasks := seedAgentRun(t, pool, tenant, repo, 2)
+
+	// A second, untouched run: the control that proves the guard below is a
+	// precondition and not a blanket refusal.
+	_, openTasks := seedAgentRun(t, pool, tenant, repo, 1)
+	if _, err := repo.MarkTaskRunning(ctx, tenant, openTasks[0].ID); err != nil {
+		t.Fatalf("mark running: %v", err)
+	}
+
+	if _, err := waves.HaltAgentRun(ctx, tenant, halted.ID, "stopped by the operator"); err != nil {
+		t.Fatalf("halt: %v", err)
+	}
+
+	// The worker that was already in flight reports its success afterwards.
+	out, err := repo.FinishTask(ctx, update.FinishTaskInput{
+		TenantID:    tenant,
+		TaskID:      haltedTasks[0].ID,
+		Status:      update.TaskSucceeded,
+		FromVersion: "0.61.80",
+		ToVersion:   "0.62.0",
+		Detail:      "upgraded and confirmed",
+	})
+	if !errors.Is(err, update.ErrTaskNotOpen) {
+		t.Fatalf("finishing an already-terminal task must report ErrTaskNotOpen, got %v", err)
+	}
+	if out.Status != update.TaskCancelled {
+		t.Fatalf("the returned row is %q, want the recorded outcome %q", out.Status, update.TaskCancelled)
+	}
+
+	stored, err := repo.GetTask(ctx, tenant, haltedTasks[0].ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if stored.Status != update.TaskCancelled {
+		t.Fatalf("status = %q, want %q: the first recorded outcome wins", stored.Status, update.TaskCancelled)
+	}
+	if stored.ToVersion == "0.62.0" {
+		t.Fatal("a cancelled task must not acquire the version a late worker reported")
+	}
+	if stored.Detail == "upgraded and confirmed" {
+		t.Fatal("a cancelled task must keep the halt's reason, not a late worker's detail")
+	}
+
+	// The control: a task that is still open finishes exactly as before.
+	finished, err := repo.FinishTask(ctx, update.FinishTaskInput{
+		TenantID:    tenant,
+		TaskID:      openTasks[0].ID,
+		Status:      update.TaskSucceeded,
+		FromVersion: "0.61.80",
+		ToVersion:   "0.62.0",
+		Detail:      "upgraded and confirmed",
+	})
+	if err != nil {
+		t.Fatalf("an open task must still finish: %v", err)
+	}
+	if finished.Status != update.TaskSucceeded {
+		t.Fatalf("status = %q, want %q", finished.Status, update.TaskSucceeded)
+	}
+
+	// And a task that does not exist at all is still a clean not-found, not
+	// mistaken for a task that merely closed.
+	if _, err := repo.FinishTask(ctx, update.FinishTaskInput{
+		TenantID: tenant,
+		TaskID:   uuid.New(),
+		Status:   update.TaskSucceeded,
+	}); err == nil || errors.Is(err, update.ErrTaskNotOpen) {
+		t.Fatalf("finishing an unknown task must be a not-found, got %v", err)
+	}
+}

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,30 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.98",
+    date: "2026-07-28",
+    summary: "Update the WPMgr agent across the fleet from the dashboard, rolled out in waves and shipped turned off.",
+    items: [
+      {
+        tag: "Added",
+        text: "Fleet-wide agent updates (GH #255, phase 2 of two). An owner or administrator can start an agent update across selected sites from the Sites list instead of visiting each site's wp-admin. This ships turned off behind a control-plane switch and will be turned on once it has been proven on real sites.",
+      },
+      {
+        tag: "Added",
+        text: "A rollout goes out in waves: one site, then a small percentage, then the rest of the fleet, and a wave only opens once every site in the one before it has confirmed by reporting its new agent version back. A failed wave stops the run and cancels what's left, and a stop control halts every agent update across the fleet at once.",
+      },
+      {
+        tag: "Added",
+        text: "The update itself runs in a background request rather than the one reporting the result, since the agent is what lets WPMgr reach the site in the first place; a site that can't complete that step is reported as unconfirmed, not failed. Sites on the WordPress.org build, and sites running an agent too old for this channel, are skipped with a reason instead of counted as failures.",
+      },
+      {
+        tag: "Fixed",
+        text: "A rollout whose target version stopped being published partway through now stops instead of reporting success.",
+      },
+    ],
+    featureLinks: [{ label: "Updates", href: "/features/updates/" }],
+  },
+  {
     version: "0.61.97",
     date: "2026-07-28",
     summary: "The agent can no longer update itself into a corner, and the dashboard now shows which sites are running an outdated agent.",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.97 / open source",
+  badge: "v0.61.98 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/apps/web/src/features/sites/bulk-action-drawer.tsx
+++ b/apps/web/src/features/sites/bulk-action-drawer.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils";
 import { drawerUp, fade } from "@/lib/motion-presets";
 import { useSites } from "@/features/sites/use-sites";
 import { useUpdateRun, useRunEventStream } from "@/features/updates/use-updates";
+import { isTerminalRunStatus } from "@/features/updates/summarize";
 import type { UpdateTask, BulkResult, Site, SiteTag } from "@wpmgr/api";
 
 import { TagPicker, type TagPickerState } from "@/features/sites/tag-picker";
@@ -47,8 +48,7 @@ import {
 //
 // Phase 5: the panel + scrim are driven by the shared `drawerUp` and `fade`
 // presets via motion/react so timing matches the dialog/save-bar/toolbar.
-// We keep AnimatePresence around so exit transforms run before unmount —
-// the previous hand-rolled "mounted" state machine is no longer needed.
+// We keep AnimatePresence around so exit transforms run before unmount, // the previous hand-rolled "mounted" state machine is no longer needed.
 
 // ---------------------------------------------------------------------------
 // Provider
@@ -342,7 +342,10 @@ export function BulkActionDrawer({
   const settledRef = useRef<string | null>(null);
   useEffect(() => {
     if (!run || !runId) return;
-    if (run.status !== "completed") return;
+    // `halted` (GH #255 Phase 2) is terminal exactly like `completed`: an
+    // agent self-update run that a wave gate stopped early still needs to
+    // settle, or its bell badge count would never clear.
+    if (!isTerminalRunStatus(run.status)) return;
     if (settledRef.current === runId) return;
     settledRef.current = runId;
     onSettled?.(runId);
@@ -571,8 +574,11 @@ function priority(status: UpdateTask["status"]): number {
       return 4;
     case "skipped":
       return 5;
-    default:
+    // GH #255 Phase 2: never dispatched because its run halted first.
+    case "cancelled":
       return 6;
+    default:
+      return 7;
   }
 }
 
@@ -583,6 +589,10 @@ function rollupStatus(tasks: UpdateTask[]): UpdateTask["status"] {
   if (tasks.some((t) => t.status === "failed")) return "failed";
   if (tasks.some((t) => t.status === "rolled_back")) return "rolled_back";
   if (tasks.every((t) => t.status === "skipped")) return "skipped";
+  // A halted run cancels every task it had not already dispatched, so this
+  // must never fall through to the "succeeded" default below, which would
+  // show an untouched site as done.
+  if (tasks.every((t) => t.status === "cancelled")) return "cancelled";
   return "succeeded";
 }
 
@@ -597,6 +607,7 @@ function toneFor(status: UpdateTask["status"]): StatusTone {
     case "rolled_back":
       return "destructive";
     case "skipped":
+    case "cancelled":
       return "muted";
     default:
       return "muted";
@@ -617,6 +628,8 @@ function statusLabel(status: UpdateTask["status"]): string {
       return "Rolled back";
     case "skipped":
       return "Skipped";
+    case "cancelled":
+      return "Cancelled";
     default:
       return "Unknown";
   }
@@ -637,6 +650,13 @@ function detailFor(task: UpdateTask | undefined): string {
   if (!task) return "";
   if (task.error) return task.error;
   if (task.detail) return task.detail;
+  // GH #255 Phase 2: an armed agent task has no detail text until beat 3
+  // resolves it; the generic target/version synthesis below would read
+  // "Updating {slug}", which is misleading for a task that is only waiting
+  // on the site's own cron.
+  if (task.target_type === "agent" && task.status === "running") {
+    return "Waiting for the upgraded agent to report back";
+  }
   // Synthesize a reasonable progress string from target + versions when
   // the agent has not yet pushed a detail field.
   const target =

--- a/apps/web/src/features/sites/sites-toolbar.tsx
+++ b/apps/web/src/features/sites/sites-toolbar.tsx
@@ -159,6 +159,15 @@ export interface SitesToolbarProps {
   onBulkSetClient: () => void;
   onBulkPauseMonitoring: () => void;
   onBulkDelete: () => void;
+  /**
+   * GH #255 Phase 2: arms the agent self-update confirmation dialog for the
+   * current selection. Owner/admin only (gated by the caller via `canManage`,
+   * a stricter check than `canOperate` below: this is infrastructure, not
+   * content) AND only while the control-plane kill switch is on. Undefined
+   * hides the menu item entirely: nothing appears usable while the channel
+   * ships dark.
+   */
+  onUpdateAgent?: () => void;
 
   // ---- Idle-mode primary action ------------------------------------------
   addSiteSlot?: ReactNode;
@@ -966,6 +975,7 @@ function ActionMode({
   onBulkSetClient,
   onBulkPauseMonitoring,
   onBulkDelete,
+  onUpdateAgent,
 }: SitesToolbarProps) {
   const count = selection.count;
   const sitesNoun = useMemo(() => (count === 1 ? "site" : "sites"), [count]);
@@ -1048,6 +1058,7 @@ function ActionMode({
             onBulkSetClient={onBulkSetClient}
             onBulkPauseMonitoring={onBulkPauseMonitoring}
             onBulkDelete={onBulkDelete}
+            onUpdateAgent={onUpdateAgent}
             count={count}
             sitesNoun={sitesNoun}
           />
@@ -1109,6 +1120,7 @@ function MoreActions({
   onBulkSetClient,
   onBulkPauseMonitoring,
   onBulkDelete,
+  onUpdateAgent,
   count,
   sitesNoun,
 }: {
@@ -1116,6 +1128,7 @@ function MoreActions({
   onBulkSetClient: () => void;
   onBulkPauseMonitoring: () => void;
   onBulkDelete: () => void;
+  onUpdateAgent?: () => void;
   count: number;
   sitesNoun: string;
 }) {
@@ -1144,6 +1157,14 @@ function MoreActions({
         <DropdownMenuItem onSelect={onBulkPauseMonitoring}>
           Pause monitoring on {count} {sitesNoun}
         </DropdownMenuItem>
+        {onUpdateAgent ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={onUpdateAgent}>
+              Update WPMgr agent on {count} {sitesNoun}...
+            </DropdownMenuItem>
+          </>
+        ) : null}
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onSelect={onBulkDelete}

--- a/apps/web/src/features/updates/agent-self-update-dialog.tsx
+++ b/apps/web/src/features/updates/agent-self-update-dialog.tsx
@@ -1,0 +1,196 @@
+import { useMemo } from "react";
+import { useNavigate } from "@tanstack/react-router";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { AGENT_STATUS_LABEL, type AgentStatus } from "@/components/status";
+import { useCreateUpdateRun } from "@/features/updates/use-updates";
+import type { Site } from "@wpmgr/api";
+
+// GH #255 Phase 2: the confirmation dialog for the "Update WPMgr agent" bulk
+// action (sites toolbar > More). Reuses the fleet agent-version rollup
+// (Phase 1's useFleetAgentVersions, already loaded on the Sites page for the
+// status chip/filter) to tell the operator the truth up front: which of the
+// selected sites will actually be targeted, and which are excluded and why.
+//
+// Deliberately its own dialog rather than <UpdateWizard>: the agent target
+// takes no slug/version, has no dry run, and is a fundamentally different
+// operation (a staged, wave-gated rollout of the manager itself, not a
+// plugin/theme/core bump), so mixing it into the wizard's component picker
+// would misrepresent both.
+
+export function AgentSelfUpdateDialog({
+  open,
+  onClose,
+  sites,
+  agentStatusById,
+}: {
+  open: boolean;
+  onClose: () => void;
+  /** The full current selection (may include sites outside the loaded view). */
+  sites: Site[];
+  /** Per-site agent-freshness classification from the fleet rollup. */
+  agentStatusById: Map<string, AgentStatus> | undefined;
+}) {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      {/* Remount on open so a previous attempt's error/pending state never
+          leaks into the next time the dialog is opened for a new selection. */}
+      {open ? (
+        <AgentSelfUpdateDialogBody
+          key={sites.map((s) => s.id).join(",")}
+          sites={sites}
+          agentStatusById={agentStatusById}
+          onClose={onClose}
+        />
+      ) : null}
+    </Dialog>
+  );
+}
+
+function AgentSelfUpdateDialogBody({
+  sites,
+  agentStatusById,
+  onClose,
+}: {
+  sites: Site[];
+  agentStatusById: Map<string, AgentStatus> | undefined;
+  onClose: () => void;
+}) {
+  const navigate = useNavigate();
+  const create = useCreateUpdateRun();
+
+  // Known once the fleet rollup has loaded. Only "outdated" sites are ever
+  // targeted (planAgentTasks on the control plane silently excludes every
+  // other status), so the dialog must say that up front rather than let the
+  // operator believe every selected site will be touched.
+  const knownEligibility = agentStatusById !== undefined;
+  const eligible = useMemo(
+    () =>
+      sites.filter((s) => agentStatusById?.get(s.id) === "outdated"),
+    [sites, agentStatusById],
+  );
+  const excludedCounts = useMemo(() => {
+    const counts: Partial<Record<AgentStatus, number>> = {};
+    if (!knownEligibility) return counts;
+    for (const site of sites) {
+      const status = agentStatusById?.get(site.id) ?? "unknown";
+      if (status === "outdated") continue;
+      counts[status] = (counts[status] ?? 0) + 1;
+    }
+    return counts;
+  }, [sites, agentStatusById, knownEligibility]);
+
+  const targetCount = knownEligibility ? eligible.length : sites.length;
+  const sitesNoun = sites.length === 1 ? "site" : "sites";
+  const targetNoun = targetCount === 1 ? "site" : "sites";
+
+  async function handleConfirm() {
+    if (targetCount === 0) return;
+    const targetIds = knownEligibility
+      ? eligible.map((s) => s.id)
+      : sites.map((s) => s.id);
+    try {
+      const run = await create.mutateAsync({
+        site_ids: targetIds,
+        items: [{ type: "agent" }],
+        dry_run: false,
+      });
+      onClose();
+      void navigate({ to: "/updates/$runId", params: { runId: run.id } });
+    } catch {
+      // create.isError renders below; nothing further to do here.
+    }
+  }
+
+  return (
+    <DialogContent
+      ariaLabelledBy="agent-self-update-title"
+      ariaDescribedBy="agent-self-update-description"
+      className="max-w-[520px]"
+    >
+      <DialogHeader>
+        <DialogTitle id="agent-self-update-title">
+          Update WPMgr agent
+        </DialogTitle>
+        <DialogDescription id="agent-self-update-description">
+          {knownEligibility
+            ? `${targetCount} of ${sites.length} selected ${sitesNoun} will be targeted.`
+            : `Targeting ${sites.length} selected ${sitesNoun}.`}
+        </DialogDescription>
+      </DialogHeader>
+
+      <DialogBody className="space-y-3 text-sm text-foreground">
+        <p>
+          The agent update is applied in staged waves, starting with a single
+          site. Each wave has to prove itself before the next one is allowed
+          to start, so a bad build is caught early rather than reaching the
+          whole fleet.
+        </p>
+        <p>
+          A site only counts as updated once its agent reports the new
+          version back on its own. Scheduling the update is not success by
+          itself.
+        </p>
+        <p>
+          A site WPMgr cannot reach, or that never confirms, is left
+          untouched rather than marked failed. This can take a while: the
+          upgrade runs on each site's own cron, which is not instant.
+        </p>
+
+        {knownEligibility && Object.keys(excludedCounts).length > 0 ? (
+          <p className="text-muted-foreground">
+            Not targeted:{" "}
+            {(Object.entries(excludedCounts) as [AgentStatus, number][])
+              .map(
+                ([status, n]) =>
+                  `${n} ${AGENT_STATUS_LABEL[status].toLowerCase()}`,
+              )
+              .join(", ")}
+            .
+          </p>
+        ) : null}
+
+        {knownEligibility && targetCount === 0 ? (
+          <p role="status" className="text-muted-foreground">
+            None of the selected sites need an agent update right now.
+          </p>
+        ) : null}
+
+        {create.isError ? (
+          <p role="alert" className="text-destructive">
+            {create.error.message}
+          </p>
+        ) : null}
+      </DialogBody>
+
+      <DialogFooter className="pt-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onClose}
+          disabled={create.isPending}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          onClick={() => void handleConfirm()}
+          disabled={create.isPending || targetCount === 0}
+        >
+          {create.isPending
+            ? "Starting..."
+            : `Update ${targetCount} ${targetNoun}`}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  );
+}

--- a/apps/web/src/features/updates/summarize.test.ts
+++ b/apps/web/src/features/updates/summarize.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "vitest";
+import type { UpdateTask } from "@wpmgr/api";
 
-import { isSiteDownRecovery } from "./summarize";
+import {
+  isSiteDownRecovery,
+  isTerminalRunStatus,
+  isAgentNotEligible,
+  haltReason,
+} from "./summarize";
 
 // GH #210 — pure-logic coverage for the site-down-recovery detector: the
 // worst-case rollback failure (site-wide PHP fatal, undeliverable rollback,
@@ -50,5 +56,123 @@ describe("isSiteDownRecovery", () => {
   it("is false when detail/error is empty on a terminal status", () => {
     expect(isSiteDownRecovery("failed", undefined, undefined)).toBe(false);
     expect(isSiteDownRecovery("rolled_back", "", "")).toBe(false);
+  });
+});
+
+// GH #255 Phase 2: the agent self-update channel's own terminal-state and
+// vocabulary helpers.
+
+describe("isTerminalRunStatus", () => {
+  it("treats completed and halted as terminal", () => {
+    expect(isTerminalRunStatus("completed")).toBe(true);
+    expect(isTerminalRunStatus("halted")).toBe(true);
+  });
+
+  it("treats pending, running and undefined as not terminal", () => {
+    expect(isTerminalRunStatus("pending")).toBe(false);
+    expect(isTerminalRunStatus("running")).toBe(false);
+    expect(isTerminalRunStatus(undefined)).toBe(false);
+  });
+});
+
+describe("isAgentNotEligible", () => {
+  it("is true for a skipped agent task whose detail names the not-eligible condition", () => {
+    expect(
+      isAgentNotEligible(
+        "agent",
+        "skipped",
+        "this agent build has no self-updater and is upgraded outside this channel",
+      ),
+    ).toBe(true);
+  });
+
+  it("is false for a non-agent target, even with matching detail text", () => {
+    expect(
+      isAgentNotEligible(
+        "plugin",
+        "skipped",
+        "this agent build has no self-updater",
+      ),
+    ).toBe(false);
+  });
+
+  it("is false for an agent task that is not skipped", () => {
+    expect(isAgentNotEligible("agent", "running", "no self-updater")).toBe(
+      false,
+    );
+  });
+
+  it("is false for a skipped agent task with unrelated detail text", () => {
+    expect(
+      isAgentNotEligible("agent", "skipped", "cancelled: the run was halted"),
+    ).toBe(false);
+  });
+});
+
+describe("haltReason", () => {
+  function task(overrides: Partial<UpdateTask>): UpdateTask {
+    return {
+      id: "task-1",
+      run_id: "run-1",
+      tenant_id: "tenant-1",
+      site_id: "site-1",
+      target_type: "agent",
+      target_slug: "wpmgr",
+      status: "cancelled",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      ...overrides,
+    };
+  }
+
+  it("returns null for a run that has not halted", () => {
+    expect(haltReason({ status: "running", tasks: [] })).toBeNull();
+    expect(haltReason(undefined)).toBeNull();
+  });
+
+  it("strips the 'cancelled: ' prefix from a cancelled task's detail", () => {
+    expect(
+      haltReason({
+        status: "halted",
+        tasks: [
+          task({
+            detail:
+              "cancelled: wave 0 (the canary) failed on 1 of 1 site(s)",
+          }),
+        ],
+      }),
+    ).toBe("wave 0 (the canary) failed on 1 of 1 site(s)");
+  });
+
+  it("returns the detail verbatim when it has no 'cancelled: ' prefix", () => {
+    expect(
+      haltReason({
+        status: "halted",
+        tasks: [task({ detail: "the run was halted" })],
+      }),
+    ).toBe("the run was halted");
+  });
+
+  it("falls back to a counts-derived summary when no task was cancelled", () => {
+    // A single-site canary run: the one task is already terminal (failed) by
+    // the time the gate re-judges it, so haltLocked has nothing left to
+    // cancel.
+    expect(
+      haltReason({
+        status: "halted",
+        tasks: [task({ status: "failed" })],
+      }),
+    ).toBe(
+      "The rollout was halted after 1 of 1 contacted site failed to confirm the upgrade.",
+    );
+  });
+
+  it("falls back to the 'never contacted' summary when nothing was even attempted", () => {
+    expect(
+      haltReason({
+        status: "halted",
+        tasks: [task({ status: "cancelled", detail: undefined })],
+      }),
+    ).toBe("The rollout was halted before any site could be contacted.");
   });
 });

--- a/apps/web/src/features/updates/summarize.ts
+++ b/apps/web/src/features/updates/summarize.ts
@@ -3,9 +3,10 @@
 // non-component values trip the react-refresh/only-export-components rule.
 // Surface agents import from here; the originals will remove their copies.
 
-import type { Site, UpdateTask } from "@wpmgr/api";
+import type { Site, UpdateRun, UpdateTask } from "@wpmgr/api";
 
 type TaskStatus = UpdateTask["status"];
+type RunStatus = UpdateRun["status"];
 
 /** Count task statuses and derive a 0..total "settled" progress figure. */
 export function summarizeTasks(tasks: UpdateTask[]): {
@@ -20,11 +21,87 @@ export function summarizeTasks(tasks: UpdateTask[]): {
     failed: 0,
     rolled_back: 0,
     skipped: 0,
+    // GH #255 Phase 2: a task the wave gate never dispatched because its run
+    // halted first. Distinct from `skipped` (the control plane declined this
+    // one target) and `failed` (the site was contacted and did not come
+    // back): nothing was ever sent here.
+    cancelled: 0,
   };
   for (const task of tasks) counts[task.status] += 1;
   const done =
-    counts.succeeded + counts.failed + counts.rolled_back + counts.skipped;
+    counts.succeeded +
+    counts.failed +
+    counts.rolled_back +
+    counts.skipped +
+    counts.cancelled;
   return { total: tasks.length, done, counts };
+}
+
+/**
+ * Terminal run states. `halted` (GH #255 Phase 2) is specific to the agent
+ * self-update channel: a staged-rollout wave failed to prove itself, so the
+ * run stopped early and every task not already dispatched was cancelled.
+ * Every surface that gates "is this run still going" (SSE close, poll
+ * interval, the bulk-action-drawer's settled flag, the run detail page's
+ * live indicator) must treat it as terminal exactly like `completed`, or a
+ * halted run reads as perpetually in progress.
+ */
+export function isTerminalRunStatus(status: RunStatus | undefined): boolean {
+  return status === "completed" || status === "halted";
+}
+
+// GH #255 Phase 2: the agent self-update channel's own outcome vocabulary.
+//
+// `planAgentTasks` (apps/api/internal/update/service.go) already excludes a
+// site the control plane's own inventory heuristic classifies as the
+// plugin-directory build before a task is ever created for it, but the AGENT
+// is the final authority on its own distribution: a task can still come back
+// `skipped` this way when the two disagree (e.g. a renamed plugin folder the
+// inventory heuristic could not identify). This is informational, never an
+// error: the site updates through its own channel, nothing went wrong, so
+// it must read distinctly from an ordinary skip.
+const AGENT_NOT_ELIGIBLE_PATTERN = /no self-updater|outside this channel/i;
+
+/** True for an agent-target task the agent itself declined as not able to
+ * self-update, as opposed to any other reason a task might be skipped. */
+export function isAgentNotEligible(
+  targetType: string,
+  status: string,
+  detail?: string,
+): boolean {
+  if (targetType !== "agent" || status !== "skipped") return false;
+  return AGENT_NOT_ELIGIBLE_PATTERN.test(detail ?? "");
+}
+
+/**
+ * Human-readable explanation for a halted agent self-update run, taken from
+ * the backend's own wording rather than re-derived client-side. Every task
+ * the wave gate cancels carries `detail = "cancelled: " + reason` (see
+ * apps/api/internal/update/agent_repo.go haltLocked), so any cancelled task
+ * in the run carries the same reason. A run can halt with zero cancelled
+ * tasks (e.g. a single-site canary already terminal when the gate re-judged
+ * it); in that case fall back to a summary built from the run's own counts,
+ * which is still grounded in real data even though it is not the backend's
+ * literal sentence. Returns null for a run that has not halted.
+ */
+export function haltReason(
+  run: Pick<UpdateRun, "status" | "tasks"> | undefined,
+): string | null {
+  if (!run || run.status !== "halted") return null;
+  const cancelledDetail = run.tasks?.find(
+    (t) => t.status === "cancelled" && t.detail,
+  )?.detail;
+  if (cancelledDetail) {
+    return cancelledDetail.startsWith("cancelled: ")
+      ? cancelledDetail.slice("cancelled: ".length)
+      : cancelledDetail;
+  }
+  const { counts } = summarizeTasks(run.tasks ?? []);
+  const contacted = counts.succeeded + counts.failed + counts.rolled_back;
+  if (contacted === 0) {
+    return "The rollout was halted before any site could be contacted.";
+  }
+  return `The rollout was halted after ${counts.failed} of ${contacted} contacted site${contacted === 1 ? "" : "s"} failed to confirm the upgrade.`;
 }
 
 /** Build a site id -> name lookup from the sites list cache. */

--- a/apps/web/src/features/updates/update-status.tsx
+++ b/apps/web/src/features/updates/update-status.tsx
@@ -2,7 +2,11 @@ import type { UpdateRun, UpdateTask } from "@wpmgr/api";
 
 import { StatusChip } from "@/components/status/status-chip";
 import type { StatusTone } from "@/components/status/status-dot";
-import { isSiteDownRecovery, SITE_DOWN_RECOVERY_LABEL } from "./summarize";
+import {
+  isAgentNotEligible,
+  isSiteDownRecovery,
+  SITE_DOWN_RECOVERY_LABEL,
+} from "./summarize";
 
 type TaskStatus = UpdateTask["status"];
 type RunStatus = UpdateRun["status"];
@@ -14,12 +18,14 @@ const TASK_TONE: Record<TaskStatus, { tone: StatusTone; label: string; pulse?: b
   running: { tone: "info", label: "Running", pulse: true },
   pending: { tone: "muted", label: "Pending" },
   skipped: { tone: "muted", label: "Skipped" },
+  // GH #255 Phase 2: never dispatched because its run halted first.
+  cancelled: { tone: "muted", label: "Cancelled" },
 };
 
 export function TaskStatusBadge({
   task,
 }: {
-  task: Pick<UpdateTask, "status" | "detail" | "error">;
+  task: Pick<UpdateTask, "status" | "detail" | "error" | "target_type">;
 }) {
   // GH #210 — the site-wide-fatal + undeliverable-rollback + auto-filesystem-
   // recovery condition is distinct and more severe than an ordinary failure
@@ -28,6 +34,21 @@ export function TaskStatusBadge({
   // instead of the generic "Failed"/"Rolled back" label.
   if (isSiteDownRecovery(task.status, task.detail, task.error)) {
     return <StatusChip tone="destructive" label={SITE_DOWN_RECOVERY_LABEL} />;
+  }
+  // GH #255 Phase 2: the agent self-update channel's own vocabulary. A
+  // `running` agent task has already been armed (beat 1 acknowledged) and is
+  // waiting on the site's own cron to apply it and phone home (beat 3); the
+  // generic "Running" label would suggest the control plane is doing
+  // something right now, when really nothing further happens here until the
+  // site reports back. "Not eligible" reads as informational, never as an
+  // error: the site updates through its own channel.
+  if (task.target_type === "agent") {
+    if (task.status === "running") {
+      return <StatusChip tone="info" label="Awaiting confirmation" pulse />;
+    }
+    if (isAgentNotEligible(task.target_type, task.status, task.detail)) {
+      return <StatusChip tone="muted" label="Not eligible" />;
+    }
   }
   const cfg = TASK_TONE[task.status];
   return (
@@ -43,6 +64,10 @@ const RUN_TONE: Record<RunStatus, { tone: StatusTone; label: string; pulse?: boo
   pending: { tone: "muted", label: "Pending" },
   running: { tone: "info", label: "Running", pulse: true },
   completed: { tone: "success", label: "Completed" },
+  // GH #255 Phase 2: a wave failed to prove itself; the run stopped early.
+  // Destructive tone on purpose: this is the signal that a bad agent build
+  // was caught and needs the operator's attention.
+  halted: { tone: "destructive", label: "Halted" },
 };
 
 export function RunStatusBadge({ status }: { status: RunStatus }) {

--- a/apps/web/src/features/updates/update-tasks-table.tsx
+++ b/apps/web/src/features/updates/update-tasks-table.tsx
@@ -89,6 +89,12 @@ function UpdateTaskRow({
   const hasLog = Boolean(task.error && task.error.trim().length > 0);
   const logId = `update-task-log-${task.id}`;
   const siteDown = isSiteDownRecovery(task.status, task.detail, task.error);
+  // GH #255 Phase 2: an armed agent task has no detail text until beat 3
+  // resolves it (nothing has happened on the site yet beyond scheduling the
+  // cron event that will apply the upgrade), so the generic empty-cell
+  // fallback would read as a stall rather than the expected wait.
+  const awaitingConfirmation =
+    task.target_type === "agent" && task.status === "running";
 
   return (
     <>
@@ -142,7 +148,11 @@ function UpdateTaskRow({
                 title={task.detail}
               >
                 {task.detail ??
-                  (hasLog ? "See log for details" : <span aria-hidden="true">{"–"}</span>)}
+                  (awaitingConfirmation
+                    ? "Waiting for the upgraded agent to report back"
+                    : hasLog
+                      ? "See log for details"
+                      : <span aria-hidden="true">{","}</span>)}
               </span>
             )}
             {hasLog ? (

--- a/apps/web/src/features/updates/use-updates.ts
+++ b/apps/web/src/features/updates/use-updates.ts
@@ -18,6 +18,8 @@ import {
   type ApiError,
 } from "@wpmgr/api";
 
+import { isTerminalRunStatus } from "./summarize";
+
 // Server-state hooks for the Updates (bulk update runs) domain. Built on the
 // generated @wpmgr/api SDK; each call returns `{ data, error, response }` which
 // we unwrap so TanStack Query manages loading/error/success.
@@ -80,9 +82,11 @@ export function useUpdateRun(
       return data;
     },
     enabled: enabled && runId !== "",
-    // Poll every 2s while enabled AND the run is not yet completed.
+    // Poll every 2s while enabled AND the run has not reached a terminal
+    // state. `halted` (GH #255 Phase 2) is terminal exactly like `completed`;
+    // see isTerminalRunStatus.
     refetchInterval: (query) =>
-      poll && query.state.data?.status !== "completed" ? 2000 : false,
+      poll && !isTerminalRunStatus(query.state.data?.status) ? 2000 : false,
   });
 }
 
@@ -227,7 +231,11 @@ export function useRunEventStream(
         return; // ignore heartbeats / malformed frames
       }
       patchEvent(queryClient, runId, event);
-      if (event.run_status === "completed") {
+      // `halted` (GH #255 Phase 2) is terminal exactly like `completed`: no
+      // further deltas will arrive for this run once the wave gate has
+      // cancelled everything left, so keeping the stream open would just
+      // wait for events that are never coming.
+      if (isTerminalRunStatus(event.run_status)) {
         closed = true;
         source.close();
         onStateRef.current?.("closed");

--- a/apps/web/src/routes/_authed/sites/index.tsx
+++ b/apps/web/src/routes/_authed/sites/index.tsx
@@ -41,7 +41,8 @@ import {
   UpdateWizard,
   type WizardTarget,
 } from "@/features/updates/update-wizard";
-import { useMe, canOperate } from "@/features/auth/use-auth";
+import { AgentSelfUpdateDialog } from "@/features/updates/agent-self-update-dialog";
+import { useMe, canOperate, canManage } from "@/features/auth/use-auth";
 import { useBulkBackup } from "@/features/backups/use-bulk-backup";
 import { useBulkAction } from "@/features/sites/use-bulk-action";
 import { toast } from "@/components/toast";
@@ -132,6 +133,9 @@ function SitesPage() {
   const { data: me } = useMe();
   const operate = canOperate(me);
   const autoLogin = canAutoLogin(me);
+  // GH #255 Phase 2: agent self-update is infrastructure, not content, so gate
+  // it to owner/admin (canManage), not the looser operator-capable canOperate.
+  const manageAgents = canManage(me);
 
   // ── URL search params (P1: all filter axes) ──────────────────────────────
   // Use navigate instead of useState so filters survive reload and are shareable.
@@ -211,10 +215,14 @@ function SitesPage() {
       fleetAgents.sites.map((s) => [s.site_id, s.status]),
     );
   }, [fleetAgents]);
+  // GH #255 Phase 2: the fleet-wide kill switch, read from the same
+  // already-loaded rollup rather than a separate request. Absent (older
+  // control plane, or the field not yet wired) reads as off, matching the
+  // channel's "ships dark by default" contract.
+  const agentSelfUpdateEnabled = fleetAgents?.self_update_enabled === true;
 
   // Active on any filter axis, including the (now server-side) tags filter.
-  // A tag filter that matches nothing legitimately returns `sites: []` —
-  // that must render as a filtered-empty state, never the onboarding empty
+  // A tag filter that matches nothing legitimately returns `sites: []`, // that must render as a filtered-empty state, never the onboarding empty
   // state (which means "this tenant has no sites at all").
   const hasActiveFilters =
     Boolean(search.q?.trim()) ||
@@ -247,6 +255,7 @@ function SitesPage() {
 
   const [wizardTarget, setWizardTarget] = useState<WizardTarget | null>(null);
   const [openAdminSites, setOpenAdminSites] = useState<Site[] | null>(null);
+  const [agentUpdateOpen, setAgentUpdateOpen] = useState(false);
 
   // ── Derived filter options ─────────────────────────────────────────────────
 
@@ -607,6 +616,15 @@ function SitesPage() {
     [selection],
   );
 
+  // GH #255 Phase 2: opens the agent self-update confirmation dialog for the
+  // current selection. The toolbar item itself is hidden unless manageAgents
+  // && agentSelfUpdateEnabled (see onUpdateAgent below), so reaching this
+  // handler already implies both.
+  const handleUpdateAgent = useCallback(() => {
+    if (selection.count === 0) return;
+    setAgentUpdateOpen(true);
+  }, [selection.count]);
+
   const handleBulkBackup = useCallback(async () => {
     const ids = Array.from(selection.selected);
     if (ids.length === 0) return;
@@ -874,6 +892,14 @@ function SitesPage() {
             onBulkSetClient={handleBulkSetClient}
             onBulkPauseMonitoring={handleBulkPauseMonitoring}
             onBulkDelete={handleBulkDelete}
+            // GH #255 Phase 2: undefined hides the menu item entirely; the
+            // action must not appear usable while the control-plane kill
+            // switch is off, and it is infrastructure (owner/admin only).
+            onUpdateAgent={
+              manageAgents && agentSelfUpdateEnabled
+                ? handleUpdateAgent
+                : undefined
+            }
             // GH #252: the primary "Add site" action lives in the PageHeader
             // only (top-right, matching every other list page's primary
             // action), so don't duplicate the trigger here. Non-operators
@@ -959,6 +985,15 @@ function SitesPage() {
               ? selectedSites
               : (sites ?? [])
           }
+        />
+      ) : null}
+
+      {manageAgents ? (
+        <AgentSelfUpdateDialog
+          open={agentUpdateOpen}
+          onClose={() => setAgentUpdateOpen(false)}
+          sites={selectedSites}
+          agentStatusById={agentStatusById}
         />
       ) : null}
 

--- a/apps/web/src/routes/_authed/updates/$runId.tsx
+++ b/apps/web/src/routes/_authed/updates/$runId.tsx
@@ -23,7 +23,12 @@ import {
   type RunStreamState,
 } from "@/features/updates/use-updates";
 import { UpdateTasksTable } from "@/features/updates/update-tasks-table";
-import { summarizeTasks, siteNameMap } from "@/features/updates/summarize";
+import {
+  summarizeTasks,
+  siteNameMap,
+  haltReason,
+  isTerminalRunStatus,
+} from "@/features/updates/summarize";
 import { useSites } from "@/features/sites/use-sites";
 import { relativeTime } from "@/lib/utils";
 import type { UpdateRun } from "@wpmgr/api";
@@ -54,9 +59,11 @@ function RunDetailPage() {
   );
 
   // Subscribe to the SSE stream; it patches the run-detail cache directly.
-  // Disabled once the run is completed (no more deltas to receive).
+  // Disabled once the run reaches a terminal state (no more deltas to
+  // receive). `halted` (GH #255 Phase 2) is terminal exactly like
+  // `completed`; see isTerminalRunStatus.
   useRunEventStream(runId, {
-    enabled: run?.status !== "completed",
+    enabled: !isTerminalRunStatus(run?.status),
     onState: setStreamState,
   });
 
@@ -108,12 +115,16 @@ const RUN_STATUS_TONE: Record<RunStatus, StatusTone> = {
   pending: "muted",
   running: "info",
   completed: "success",
+  // GH #255 Phase 2: a wave failed to prove itself; destructive tone flags
+  // it for immediate attention, matching the prominent banner below.
+  halted: "destructive",
 };
 
 const RUN_STATUS_LABEL: Record<RunStatus, string> = {
   pending: "Pending",
   running: "Running",
   completed: "Completed",
+  halted: "Halted",
 };
 
 function RunDetail({
@@ -127,7 +138,10 @@ function RunDetail({
   const tasks = run.tasks ?? [];
   const summary = summarizeTasks(tasks);
   const created = relativeTime(run.created_at);
-  const live = run.status !== "completed";
+  // `halted` (GH #255 Phase 2) is terminal exactly like `completed`; see
+  // isTerminalRunStatus.
+  const live = !isTerminalRunStatus(run.status);
+  const halted = run.status === "halted";
 
   const liveState = toLiveState(streamState);
   const liveLabel = streamState === "polling" ? "Polling" : undefined;
@@ -166,6 +180,18 @@ function RunDetail({
         }
       />
 
+      {halted ? (
+        // GH #255 Phase 2: a halt means a bad agent build was caught before
+        // it could reach the rest of the fleet, which the operator needs to
+        // see immediately, with the reason. Reuses PageError (no retry: the
+        // run is terminal, not a failed fetch) so it reads with the same
+        // weight as every other "this needs your attention" surface.
+        <PageError
+          what="This rollout was halted"
+          why={haltReason(run) ?? undefined}
+        />
+      ) : null}
+
       <Card>
         <CardHeader>
           <CardTitle>Progress</CardTitle>
@@ -191,6 +217,7 @@ function RunDetail({
               { label: "Running", value: summary.counts.running, tabular: true },
               { label: "Pending", value: summary.counts.pending, tabular: true },
               { label: "Skipped", value: summary.counts.skipped, tabular: true },
+              { label: "Cancelled", value: summary.counts.cancelled, tabular: true },
             ]}
           />
         </CardContent>

--- a/apps/web/src/routes/_authed/updates/index.tsx
+++ b/apps/web/src/routes/_authed/updates/index.tsx
@@ -28,12 +28,16 @@ const RUN_STATUS_TONE: Record<RunStatus, StatusTone> = {
   pending: "muted",
   running: "info",
   completed: "success",
+  // GH #255 Phase 2: a wave failed to prove itself; destructive tone flags
+  // it for immediate attention among an otherwise calm list of runs.
+  halted: "destructive",
 };
 
 const RUN_STATUS_LABEL: Record<RunStatus, string> = {
   pending: "Pending",
   running: "Running",
   completed: "Completed",
+  halted: "Halted",
 };
 
 function UpdatesPage() {

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -817,7 +817,7 @@ export const AgentHeartbeatResultSchema = {
     revoke_token: {
       type: "string",
       description:
-        'Present with a `["revoke"]` instruction: a short-lived signed Ed25519\nJWT (aud=site_id, cmd="revoke") the agent MUST verify with the CP\npublic key before any self-teardown (ADR-040 addendum). Fail-closed —\nan absent/invalid token must be a no-op.\n',
+        'Present with a `["revoke"]` instruction: a short-lived signed Ed25519\nJWT (aud=site_id, cmd="revoke") the agent MUST verify with the CP\npublic key before any self-teardown (ADR-040 addendum). Fail-closed, an absent/invalid token must be a no-op.\n',
     },
   },
 } as const;
@@ -1828,7 +1828,7 @@ export const BillingSummarySchema = {
       type: "string",
       enum: ["free", "starter", "agency", "scale"],
       description:
-        'The tenant\'s SUBSCRIBED tier (tenants.plan). A canceled subscription resolves this to "free" (non-destructive downgrade — see plan_status).',
+        'The tenant\'s SUBSCRIBED tier (tenants.plan). A canceled subscription resolves this to "free" (non-destructive downgrade, see plan_status).',
     },
     plan_status: {
       type: "string",
@@ -2000,7 +2000,7 @@ export const AdminAccountListItemSchema = {
       type: "integer",
       format: "int64",
       description:
-        "A v1 APPROXIMATION (SUM of backup_chunks.size for the tenant) — does not yet distinguish CP-managed from BYO-storage destinations.",
+        "A v1 APPROXIMATION (SUM of backup_chunks.size for the tenant), does not yet distinguish CP-managed from BYO-storage destinations.",
     },
     storage_cap_bytes: {
       type: "integer",
@@ -2661,19 +2661,21 @@ export const UpdateItemSchema = {
   properties: {
     type: {
       type: "string",
-      enum: ["plugin", "theme", "core"],
+      enum: ["plugin", "theme", "core", "agent"],
+      description:
+        "What to update. `agent` upgrades the WPMgr agent itself over its own\ndedicated signed channel and behaves differently from the others: it\nmust be the ONLY item in its run (its staged-wave rollout is defined\nover the whole run), it takes no slug and no version pin, and it has\nno dry run. Success is established only when the upgraded agent\nreports its new version back; a scheduled acknowledgement is not\nsuccess. The channel is off unless the control plane enables it.\n",
     },
     slug: {
       type: "string",
       maxLength: 200,
       description:
-        'Plugin/theme slug. Ignored (forced to "core") when type is core.',
+        'Plugin/theme slug. Ignored (forced to "core") when type is core; must be omitted when type is agent.',
     },
     version: {
       type: "string",
       maxLength: 64,
       description:
-        'Desired version, "latest" or an explicit pin. Defaults to latest.',
+        'Desired version, "latest" or an explicit pin. Defaults to latest.\nA pin is REJECTED when type is agent: the agent\'s release manifest\nonly ever points at the published build and the agent refuses to\ninstall an older one, so a pin could not be honoured.\n',
     },
   },
 } as const;
@@ -2750,7 +2752,7 @@ export const UpdateTaskSchema = {
     },
     target_type: {
       type: "string",
-      enum: ["plugin", "theme", "core"],
+      enum: ["plugin", "theme", "core", "agent"],
     },
     target_slug: {
       type: "string",
@@ -2773,7 +2775,10 @@ export const UpdateTaskSchema = {
         "failed",
         "rolled_back",
         "skipped",
+        "cancelled",
       ],
+      description:
+        "`cancelled` means the task was never dispatched because its run was\nhalted first; nothing was sent to the site. Only agent self-update\nruns can halt.\n",
     },
     detail: {
       type: "string",
@@ -2825,7 +2830,9 @@ export const UpdateRunSchema = {
     },
     status: {
       type: "string",
-      enum: ["pending", "running", "completed"],
+      enum: ["pending", "running", "completed", "halted"],
+      description:
+        "`halted` is terminal and specific to an agent self-update run: a\nstaged-rollout wave failed to prove itself, so every task the run\nhad not already dispatched was cancelled. It is distinct from\n`completed`, which would hide the fact that the run was stopped.\n",
     },
     dry_run: {
       type: "boolean",
@@ -2913,7 +2920,7 @@ export const UpdateEventSchema = {
     },
     target_type: {
       type: "string",
-      enum: ["plugin", "theme", "core"],
+      enum: ["plugin", "theme", "core", "agent"],
     },
     target_slug: {
       type: "string",
@@ -2927,6 +2934,7 @@ export const UpdateEventSchema = {
         "failed",
         "rolled_back",
         "skipped",
+        "cancelled",
       ],
     },
     from_version: {
@@ -2940,7 +2948,7 @@ export const UpdateEventSchema = {
     },
     run_status: {
       type: "string",
-      enum: ["pending", "running", "completed"],
+      enum: ["pending", "running", "completed", "halted"],
     },
   },
 } as const;
@@ -5680,7 +5688,7 @@ export const SiteShareRoleSchema = {
   type: "string",
   enum: ["viewer", "operator", "admin"],
   description:
-    "Role a site collaborator holds. Subset of the full org Role enum —\nsite shares cannot be owner.\n",
+    "Role a site collaborator holds. Subset of the full org Role enum, site shares cannot be owner.\n",
 } as const;
 
 export const SiteShareSchema = {
@@ -12077,6 +12085,11 @@ export const FleetAgentVersionsSchema = {
         $ref: "#/components/schemas/FleetAgentSite",
       },
     },
+    self_update_enabled: {
+      type: "boolean",
+      description:
+        "Whether the control plane's agent self-update channel (the fleet-wide WPMGR_UPDATE_AGENT_SELF_UPDATE_ENABLED kill switch) is currently turned on for this instance. Absent or false while the channel ships dark. The frontend uses this, together with the operator's role, to decide whether the \"Update WPMgr agent\" bulk action is shown at all, rather than let an operator arm a run the control plane will only refuse.\n",
+    },
   },
 } as const;
 
@@ -13288,7 +13301,7 @@ export const AgentActivityIngestRequestSchema = {
           meta: {
             type: "object",
             description:
-              "Verbatim wire bytes as emitted by the agent's wp_json_encode — hashed exactly as sent, never re-serialized.",
+              "Verbatim wire bytes as emitted by the agent's wp_json_encode, hashed exactly as sent, never re-serialized.",
           },
           prev_hash: {
             type: "string",

--- a/packages/openapi-client/src/generated/sdk.gen.ts
+++ b/packages/openapi-client/src/generated/sdk.gen.ts
@@ -1736,8 +1736,7 @@ export const activateOrg = <ThrowOnError extends boolean = false>(
  * grace-window purge worker runs. `confirm_name` must exactly match the
  * organisation's current name. When this is the caller's active org,
  * their session is reassigned to another live membership, or cleared
- * entirely (dropping to onboarding) if it was their last org —
- * `active_tenant_id` in the response reflects the post-delete state.
+ * entirely (dropping to onboarding) if it was their last org, `active_tenant_id` in the response reflects the post-delete state.
  * On a hosted instance an active paid subscription must be
  * cancelled/downgraded first (`billing_active` 409).
  *
@@ -2698,8 +2697,7 @@ export const forceAdminAccountState = <ThrowOnError extends boolean = false>(
 /**
  * Instance-wide revenue dashboard (superadmin)
  *
- * Local-state-only revenue view derived from tenants + billing_events —
- * zero payment-provider API calls. Requires is_superadmin=true.
+ * Local-state-only revenue view derived from tenants + billing_events, zero payment-provider API calls. Requires is_superadmin=true.
  *
  */
 export const getAdminRevenue = <ThrowOnError extends boolean = false>(
@@ -4490,8 +4488,7 @@ export const bulkDeleteBackups = <ThrowOnError extends boolean = false>(
  * CHAIN-SAFE: deleting a base or mid-chain increment that still has
  * dependent later-generation increments is refused with 422
  * (chain_has_dependents); delete the newer increments first. A
- * running/pending snapshot is refused with 422 (snapshot_in_progress) —
- * cancel it first. Requires operator+.
+ * running/pending snapshot is refused with 422 (snapshot_in_progress), cancel it first. Requires operator+.
  *
  */
 export const deleteBackup = <ThrowOnError extends boolean = false>(
@@ -8096,8 +8093,7 @@ export const readSiteFileContent = <ThrowOnError extends boolean = false>(
  * severity. The agent independently enforces its executable deny-list
  * regardless.
  *
- * **Sensitive-file gate (T6):** Same as above for `confirm_sensitive=true`
- * — requires owner (`site.files.write_code`) and is audited at elevated
+ * **Sensitive-file gate (T6):** Same as above for `confirm_sensitive=true`, requires owner (`site.files.write_code`) and is audited at elevated
  * severity on both success and denial.
  *
  * Requires `site.files.write` permission (admin+).
@@ -8337,8 +8333,7 @@ export const applySiteFileUpload = <ThrowOnError extends boolean = false>(
  *
  * A `file_transfers` row is persisted for audit and GC tracking.
  *
- * **Sensitive-path gate (T6):** same rules as `readSiteFileContent` —
- * owner-level permission required; the attempt is always audited.
+ * **Sensitive-path gate (T6):** same rules as `readSiteFileContent`, owner-level permission required; the attempt is always audited.
  *
  * Returns `503 storage_not_configured` when object storage is not
  * configured (self-hosted deployments without S3).

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -429,8 +429,7 @@ export type AgentHeartbeatResult = {
   /**
    * Present with a `["revoke"]` instruction: a short-lived signed Ed25519
    * JWT (aud=site_id, cmd="revoke") the agent MUST verify with the CP
-   * public key before any self-teardown (ADR-040 addendum). Fail-closed —
-   * an absent/invalid token must be a no-op.
+   * public key before any self-teardown (ADR-040 addendum). Fail-closed, an absent/invalid token must be a no-op.
    *
    */
   revoke_token?: string;
@@ -945,7 +944,7 @@ export type BillingMeters = {
 
 export type BillingSummary = {
   /**
-   * The tenant's SUBSCRIBED tier (tenants.plan). A canceled subscription resolves this to "free" (non-destructive downgrade — see plan_status).
+   * The tenant's SUBSCRIBED tier (tenants.plan). A canceled subscription resolves this to "free" (non-destructive downgrade, see plan_status).
    */
   plan: "free" | "starter" | "agency" | "scale";
   plan_status:
@@ -1026,7 +1025,7 @@ export type AdminAccountListItem = {
   sites_used: number;
   sites_cap: number;
   /**
-   * A v1 APPROXIMATION (SUM of backup_chunks.size for the tenant) — does not yet distinguish CP-managed from BYO-storage destinations.
+   * A v1 APPROXIMATION (SUM of backup_chunks.size for the tenant), does not yet distinguish CP-managed from BYO-storage destinations.
    */
   storage_used_bytes_approx: number;
   /**
@@ -1290,13 +1289,27 @@ export type AdminForceStateRequest = {
  * One thing to update on a site.
  */
 export type UpdateItem = {
-  type: "plugin" | "theme" | "core";
   /**
-   * Plugin/theme slug. Ignored (forced to "core") when type is core.
+   * What to update. `agent` upgrades the WPMgr agent itself over its own
+   * dedicated signed channel and behaves differently from the others: it
+   * must be the ONLY item in its run (its staged-wave rollout is defined
+   * over the whole run), it takes no slug and no version pin, and it has
+   * no dry run. Success is established only when the upgraded agent
+   * reports its new version back; a scheduled acknowledgement is not
+   * success. The channel is off unless the control plane enables it.
+   *
+   */
+  type: "plugin" | "theme" | "core" | "agent";
+  /**
+   * Plugin/theme slug. Ignored (forced to "core") when type is core; must be omitted when type is agent.
    */
   slug?: string;
   /**
    * Desired version, "latest" or an explicit pin. Defaults to latest.
+   * A pin is REJECTED when type is agent: the agent's release manifest
+   * only ever points at the published build and the agent refuses to
+   * install an older one, so a pin could not be honoured.
+   *
    */
   version?: string;
 };
@@ -1331,18 +1344,25 @@ export type UpdateTask = {
   run_id: string;
   tenant_id: string;
   site_id: string;
-  target_type: "plugin" | "theme" | "core";
+  target_type: "plugin" | "theme" | "core" | "agent";
   target_slug: string;
   desired_version?: string;
   from_version?: string;
   to_version?: string;
+  /**
+   * `cancelled` means the task was never dispatched because its run was
+   * halted first; nothing was sent to the site. Only agent self-update
+   * runs can halt.
+   *
+   */
   status:
     | "pending"
     | "running"
     | "succeeded"
     | "failed"
     | "rolled_back"
-    | "skipped";
+    | "skipped"
+    | "cancelled";
   detail?: string;
   error?: string;
   started_at?: string;
@@ -1355,7 +1375,14 @@ export type UpdateRun = {
   id: string;
   tenant_id: string;
   created_by?: string;
-  status: "pending" | "running" | "completed";
+  /**
+   * `halted` is terminal and specific to an agent self-update run: a
+   * staged-rollout wave failed to prove itself, so every task the run
+   * had not already dispatched was cancelled. It is distinct from
+   * `completed`, which would hide the fact that the run was stopped.
+   *
+   */
+  status: "pending" | "running" | "completed" | "halted";
   dry_run: boolean;
   scheduled_at?: string;
   created_at: string;
@@ -1390,7 +1417,7 @@ export type UpdateEvent = {
   run_id: string;
   task_id: string;
   site_id: string;
-  target_type: "plugin" | "theme" | "core";
+  target_type: "plugin" | "theme" | "core" | "agent";
   target_slug: string;
   status:
     | "pending"
@@ -1398,11 +1425,12 @@ export type UpdateEvent = {
     | "succeeded"
     | "failed"
     | "rolled_back"
-    | "skipped";
+    | "skipped"
+    | "cancelled";
   from_version?: string;
   to_version?: string;
   detail?: string;
-  run_status: "pending" | "running" | "completed";
+  run_status: "pending" | "running" | "completed" | "halted";
 };
 
 /**
@@ -3076,8 +3104,7 @@ export type ActivateOrgResponse = {
 };
 
 /**
- * Role a site collaborator holds. Subset of the full org Role enum —
- * site shares cannot be owner.
+ * Role a site collaborator holds. Subset of the full org Role enum, site shares cannot be owner.
  *
  */
 export const SiteShareRole = {
@@ -3087,8 +3114,7 @@ export const SiteShareRole = {
 } as const;
 
 /**
- * Role a site collaborator holds. Subset of the full org Role enum —
- * site shares cannot be owner.
+ * Role a site collaborator holds. Subset of the full org Role enum, site shares cannot be owner.
  *
  */
 export type SiteShareRole = (typeof SiteShareRole)[keyof typeof SiteShareRole];
@@ -6612,6 +6638,11 @@ export type FleetAgentVersions = {
   latest_version: string;
   counts: FleetAgentCounts;
   sites: Array<FleetAgentSite>;
+  /**
+   * Whether the control plane's agent self-update channel (the fleet-wide WPMGR_UPDATE_AGENT_SELF_UPDATE_ENABLED kill switch) is currently turned on for this instance. Absent or false while the channel ships dark. The frontend uses this, together with the operator's role, to decide whether the "Update WPMgr agent" bulk action is shown at all, rather than let an operator arm a run the control plane will only refuse.
+   *
+   */
+  self_update_enabled?: boolean;
 };
 
 export type SmtpSettings = {
@@ -7022,7 +7053,7 @@ export type AgentActivityIngestRequest = {
     actor_ip?: string;
     summary?: string;
     /**
-     * Verbatim wire bytes as emitted by the agent's wp_json_encode — hashed exactly as sent, never re-serialized.
+     * Verbatim wire bytes as emitted by the agent's wp_json_encode, hashed exactly as sent, never re-serialized.
      */
     meta?: {
       [key: string]: unknown;
@@ -8573,7 +8604,7 @@ export type DeleteOrgErrors = {
    */
   404: Error;
   /**
-   * org_already_deleted | billing_active | restore_in_progress — see the error `code` for which precondition failed
+   * org_already_deleted | billing_active | restore_in_progress, see the error `code` for which precondition failed
    */
   409: Error;
   /**
@@ -19157,7 +19188,7 @@ export type ExtractSiteFileArchiveErrors = {
    */
   404: Error;
   /**
-   * Archive is structurally valid but contains unsafe entries (`zip_slip` — path traversal outside destination, or `zip_bomb` — exceeds uncompressed-size / entry-count guard).
+   * Archive is structurally valid but contains unsafe entries (`zip_slip`, path traversal outside destination, or `zip_bomb`, exceeds uncompressed-size / entry-count guard).
    *
    */
   422: Error;

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.97
+  version: 0.61.98
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,
@@ -1236,8 +1236,7 @@ paths:
         grace-window purge worker runs. `confirm_name` must exactly match the
         organisation's current name. When this is the caller's active org,
         their session is reassigned to another live membership, or cleared
-        entirely (dropping to onboarding) if it was their last org —
-        `active_tenant_id` in the response reflects the post-delete state.
+        entirely (dropping to onboarding) if it was their last org, `active_tenant_id` in the response reflects the post-delete state.
         On a hosted instance an active paid subscription must be
         cancelled/downgraded first (`billing_active` 409).
       tags: [orgs]
@@ -1272,8 +1271,7 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           description: >-
-            org_already_deleted | billing_active | restore_in_progress —
-            see the error `code` for which precondition failed
+            org_already_deleted | billing_active | restore_in_progress, see the error `code` for which precondition failed
           content:
             application/json:
               schema:
@@ -3186,8 +3184,7 @@ paths:
       operationId: getAdminRevenue
       summary: Instance-wide revenue dashboard (superadmin)
       description: |
-        Local-state-only revenue view derived from tenants + billing_events —
-        zero payment-provider API calls. Requires is_superadmin=true.
+        Local-state-only revenue view derived from tenants + billing_events, zero payment-provider API calls. Requires is_superadmin=true.
       tags: [admin-billing]
       responses:
         "200":
@@ -5867,8 +5864,7 @@ paths:
         CHAIN-SAFE: deleting a base or mid-chain increment that still has
         dependent later-generation increments is refused with 422
         (chain_has_dependents); delete the newer increments first. A
-        running/pending snapshot is refused with 422 (snapshot_in_progress) —
-        cancel it first. Requires operator+.
+        running/pending snapshot is refused with 422 (snapshot_in_progress), cancel it first. Requires operator+.
       tags: [backups]
       parameters:
         - $ref: "#/components/parameters/SnapshotId"
@@ -11524,8 +11520,7 @@ paths:
         severity. The agent independently enforces its executable deny-list
         regardless.
 
-        **Sensitive-file gate (T6):** Same as above for `confirm_sensitive=true`
-        — requires owner (`site.files.write_code`) and is audited at elevated
+        **Sensitive-file gate (T6):** Same as above for `confirm_sensitive=true`, requires owner (`site.files.write_code`) and is audited at elevated
         severity on both success and denial.
 
         Requires `site.files.write` permission (admin+).
@@ -11842,8 +11837,7 @@ paths:
 
         A `file_transfers` row is persisted for audit and GC tracking.
 
-        **Sensitive-path gate (T6):** same rules as `readSiteFileContent` —
-        owner-level permission required; the attempt is always audited.
+        **Sensitive-path gate (T6):** same rules as `readSiteFileContent`, owner-level permission required; the attempt is always audited.
 
         Returns `503 storage_not_configured` when object storage is not
         configured (self-hosted deployments without S3).
@@ -12004,8 +11998,7 @@ paths:
         "422":
           description: >
             Archive is structurally valid but contains unsafe entries
-            (`zip_slip` — path traversal outside destination, or `zip_bomb` —
-            exceeds uncompressed-size / entry-count guard).
+            (`zip_slip`, path traversal outside destination, or `zip_bomb`, exceeds uncompressed-size / entry-count guard).
           content:
             application/json:
               schema:
@@ -12899,8 +12892,7 @@ components:
           description: |
             Present with a `["revoke"]` instruction: a short-lived signed Ed25519
             JWT (aud=site_id, cmd="revoke") the agent MUST verify with the CP
-            public key before any self-teardown (ADR-040 addendum). Fail-closed —
-            an absent/invalid token must be a no-op.
+            public key before any self-teardown (ADR-040 addendum). Fail-closed, an absent/invalid token must be a no-op.
     AgentDisconnect:
       type: object
       description: M21 — the signed last-will body.
@@ -13622,8 +13614,7 @@ components:
           enum: [free, starter, agency, scale]
           description: >-
             The tenant's SUBSCRIBED tier (tenants.plan). A canceled
-            subscription resolves this to "free" (non-destructive downgrade —
-            see plan_status).
+            subscription resolves this to "free" (non-destructive downgrade, see plan_status).
         plan_status:
           type: string
           enum: [none, trialing, active, past_due, canceled, paused, comped]
@@ -13727,8 +13718,7 @@ components:
           type: integer
           format: int64
           description: >-
-            A v1 APPROXIMATION (SUM of backup_chunks.size for the tenant) —
-            does not yet distinguish CP-managed from BYO-storage
+            A v1 APPROXIMATION (SUM of backup_chunks.size for the tenant), does not yet distinguish CP-managed from BYO-storage
             destinations.
         storage_cap_bytes:
           type: integer
@@ -14047,15 +14037,27 @@ components:
       properties:
         type:
           type: string
-          enum: [plugin, theme, core]
+          enum: [plugin, theme, core, agent]
+          description: |
+            What to update. `agent` upgrades the WPMgr agent itself over its own
+            dedicated signed channel and behaves differently from the others: it
+            must be the ONLY item in its run (its staged-wave rollout is defined
+            over the whole run), it takes no slug and no version pin, and it has
+            no dry run. Success is established only when the upgraded agent
+            reports its new version back; a scheduled acknowledgement is not
+            success. The channel is off unless the control plane enables it.
         slug:
           type: string
           maxLength: 200
-          description: Plugin/theme slug. Ignored (forced to "core") when type is core.
+          description: Plugin/theme slug. Ignored (forced to "core") when type is core; must be omitted when type is agent.
         version:
           type: string
           maxLength: 64
-          description: Desired version, "latest" or an explicit pin. Defaults to latest.
+          description: |
+            Desired version, "latest" or an explicit pin. Defaults to latest.
+            A pin is REJECTED when type is agent: the agent's release manifest
+            only ever points at the published build and the agent refuses to
+            install an older one, so a pin could not be honoured.
     UpdateRunCreate:
       type: object
       required: [items]
@@ -14105,7 +14107,7 @@ components:
           format: uuid
         target_type:
           type: string
-          enum: [plugin, theme, core]
+          enum: [plugin, theme, core, agent]
         target_slug:
           type: string
         desired_version:
@@ -14116,7 +14118,11 @@ components:
           type: string
         status:
           type: string
-          enum: [pending, running, succeeded, failed, rolled_back, skipped]
+          enum: [pending, running, succeeded, failed, rolled_back, skipped, cancelled]
+          description: |
+            `cancelled` means the task was never dispatched because its run was
+            halted first; nothing was sent to the site. Only agent self-update
+            runs can halt.
         detail:
           type: string
         error:
@@ -14148,7 +14154,12 @@ components:
           format: uuid
         status:
           type: string
-          enum: [pending, running, completed]
+          enum: [pending, running, completed, halted]
+          description: |
+            `halted` is terminal and specific to an agent self-update run: a
+            staged-rollout wave failed to prove itself, so every task the run
+            had not already dispatched was cancelled. It is distinct from
+            `completed`, which would hide the fact that the run was stopped.
         dry_run:
           type: boolean
         scheduled_at:
@@ -14204,12 +14215,12 @@ components:
           format: uuid
         target_type:
           type: string
-          enum: [plugin, theme, core]
+          enum: [plugin, theme, core, agent]
         target_slug:
           type: string
         status:
           type: string
-          enum: [pending, running, succeeded, failed, rolled_back, skipped]
+          enum: [pending, running, succeeded, failed, rolled_back, skipped, cancelled]
         from_version:
           type: string
         to_version:
@@ -14218,7 +14229,7 @@ components:
           type: string
         run_status:
           type: string
-          enum: [pending, running, completed]
+          enum: [pending, running, completed, halted]
     BackupEvent:
       type: object
       description: |
@@ -16368,8 +16379,7 @@ components:
       type: string
       enum: [viewer, operator, admin]
       description: |
-        Role a site collaborator holds. Subset of the full org Role enum —
-        site shares cannot be owner.
+        Role a site collaborator holds. Subset of the full org Role enum, site shares cannot be owner.
     SiteShare:
       type: object
       required: [id, site_id, user_id, role, created_at]
@@ -20641,6 +20651,16 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/FleetAgentSite"
+        self_update_enabled:
+          type: boolean
+          description: >
+            Whether the control plane's agent self-update channel (the
+            fleet-wide WPMGR_UPDATE_AGENT_SELF_UPDATE_ENABLED kill switch) is
+            currently turned on for this instance. Absent or false while the
+            channel ships dark. The frontend uses this, together with the
+            operator's role, to decide whether the "Update WPMgr agent" bulk
+            action is shown at all, rather than let an operator arm a run the
+            control plane will only refuse.
 
     # ---------------------------------------------------------------------------
     # ADR-045 instance SMTP settings
@@ -21152,8 +21172,7 @@ components:
               meta:
                 type: object
                 description: >-
-                  Verbatim wire bytes as emitted by the agent's wp_json_encode
-                  — hashed exactly as sent, never re-serialized.
+                  Verbatim wire bytes as emitted by the agent's wp_json_encode, hashed exactly as sent, never re-serialized.
               prev_hash: { type: string }
               this_hash: { type: string }
               occurred_at: { type: string, format: date-time }


### PR DESCRIPTION
Phase 2 of two for #255. Ships as 0.61.98, **turned off**.

Phase 1 (#300) made agent versions visible and stopped the agent being targeted by an ordinary plugin update. This adds the capability itself. The control-plane switch defaults to `false`, so merging changes nothing in production until someone deliberately enables it.

## Why this is not a button

The agent is how the control plane reaches a site, so replacing it is unlike replacing any other plugin:

- Do the swap inside the signed command request and **the response is serialized by code that was just deleted**, so the CP cannot tell "worked" from "failed".
- The snapshot and automatic rollback that protects every other plugin update **deliberately does not arm** for the agent's own directory (`class-update-watchdog-marker.php:179-184`), because whatever performs the rollback is what is being replaced.
- Repointing the release manifest backwards does not help either: the agent's downgrade guard refuses older builds. The only lever is stopping dispatch.

So the swap runs in a **separate WordPress cron bootstrap**, with no control-plane response riding on it, and zero new download/verify/unzip code (the existing `upgrader_pre_download` chain engages unchanged).

## Confirmation is the only success

A `scheduled` ack is never recorded as success. `agentSelfUpdateReachedTarget` requires **both**:

1. the reported version is at or beyond the run's **planned** target, and
2. the site's own version **moved** from what was recorded at plan time

Asking only "is the site current?" is not enough, and this is the defect that survived two review rounds. Reverting the published manifest to last-known-good, which is the natural reflex mid-incident, makes every site answer `up_to_date`. A reviewer drove the real worker over 100 sites and got `run="completed" succeeded=100/100` with **not one agent moved**. Worse, on a mixed fleet the canary itself could be a site already at the reverted version, so a canary that applied nothing would authorise the real rollout.

If the published version drops below the run's target, the premise is void and the run halts instead of opening more waves.

## Waves

Wave 0 is one site, wave 1 is 5%, wave 2 the rest, each opening only after the previous confirmed. Any wave 0 failure, or too many unconfirmed later, halts and cancels the remainder.

A halt cancels **only pending** tasks. Already-armed tasks are left for their confirm job, so the CP does not blind itself to sites that are mid-update at the exact moment the operator pulls the switch.

## Honest skips

The wordpress.org build ships without the self-updater, and agents older than this release do not have the route. Both are skipped with a reason rather than counted as failures. Without this the **first rollout would always halt on its own canary**, since it necessarily targets agents that predate the channel.

## Review

Three adversarial rounds, each found something:

| Round | Found |
|---|---|
| 1 | three wire mismatches (`error`/`already_scheduled`/`external` unrecognised), `up_to_date` false-green, halt cancelling armed tasks, O(n²) enqueue |
| 2 | contract closed and mutation-verified, but the false-green only partly fixed |
| 3 | both lenses independently reproduced the remaining false-green against the real worker |

The wire contract is now pinned by a **golden-vector test on both halves**, verified by mutating a literal on each side and watching that side's suite go red. The two halves had been built in parallel and disagreed three ways, with each suite green against its own fiction. The agent's staged TTL is asserted against the CP's declared floor for the same reason (it was 15 minutes against a 90 minute CP window, which would have expired every hourly-system-cron site and false-failed the canary).

A build-time assertion (`Makefile:281`) now fails the wordpress.org artifact if `class-plugin.php` loses the null guard around its `UpdateChecker` reference, which would otherwise fatal every request on every install of that build. Proven by dedenting it and watching the build abort.

## Verification

- Go: build/vet clean, `go test ./...` **exit 0**
- Agent: phpunit **2904**, phpcs 0, plugincheck 0
- Web: **1252** tests, lint 0 errors
- Kill switch: `update.agent_self_update_enabled` defaults `false`, checked inside `runAgentSelfUpdate` (per dispatch, not just at run creation)

## Rollout plan

Merge dark. Exercise on staging, then wave 0 against one real site, then dogfood on our own managed fleet before enabling for tenants.

Agent-side change, so this needs `make agent-release` after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fleet-wide WPMgr agent updates with role-based access, staged waves, confirmation tracking, stop controls, and configurable rollout enablement.
  * Added agent self-update actions and confirmation status reporting.
  * Added clearer update statuses, including “Awaiting confirmation,” “Not eligible,” “Cancelled,” and “Halted.”
  * Added rollout details showing skipped sites and halt reasons.

* **Bug Fixes**
  * Prevented agents from updating their own plugin directory.
  * Improved version comparisons and protected completed or cancelled update results from being overwritten.
  * Added safeguards for stalled, expired, or interrupted rollout tasks.

* **Documentation**
  * Updated release notes and public API documentation for version 0.61.98.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->