### PR TITLE
fix: fleet agent-version worked only on hosted installs (GH #255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.99] - 2026-07-28
+
+### Fixed
+
+- The Agent version card could read "0 of 24 sites on unknown, 24 unknown", with the agent-status filter on the Sites list appearing to do nothing (GH #255, reported on a self-hosted install running 24 sites immediately after 0.61.97). The fleet agent-version feature compares each site against the currently published agent version, which it reads from a pointer file the release process writes into the hosted service's object storage; a self-hosted install has its own object storage and never receives that file, so WPMgr had no version to compare against, and with no reference version every site necessarily fell back to unknown. The sites were reporting their versions correctly the whole time, and the filter was not broken either: it only offers values that actually appear, so with every site unknown there was a single option that matched everything, which looked like nothing happening.
+- When there is no published reference version, self-hosted installs now compare each site against the newest agent version present in that install's own fleet instead, so a site lagging behind the others shows up as behind. The interface says plainly when the comparison is against the fleet rather than a published release, so "current" is never mistaken for "up to date with the newest release that exists." When there is genuinely nothing to compare against, WPMgr now says so in plain language instead of printing "unknown" as though it were a version number.
+- On the hosted service, the published agent version is cached, and a brief object-storage failure used to be cached too, which could make the dashboard fall back to comparing against the fleet and briefly report every site as current when they were in fact behind. The last successfully read version is now kept and used across a brief failure, a failure is retried quickly rather than held, and a version that has gone stale beyond a bound is no longer presented as though it came from the published release. An install whose release channel exists but is temporarily unreachable now says it cannot determine a reference version, which is a different situation from an install that has no release channel at all.
+- The control-plane switch that enables the fleet-wide agent update introduced in 0.61.98 was not reported to the dashboard, so the action stayed hidden even when an operator turned the switch on. It is now reported, and the action appears exactly when the control plane would honor it. The feature still ships turned off.
+- Comments in generated API client code that had been reflowed incorrectly in 0.61.98 are restored by regenerating the client, with no behavior change.
+
 ## [0.61.98] - 2026-07-28
 
 ### Added

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -2343,7 +2343,14 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	} else {
 		agentReleaseReader = agentrelease.NewReader(nil, 0)
 	}
-	agentReleaseH := agentrelease.NewHandler(agentrelease.NewService(agentrelease.NewRepo(pool), agentReleaseReader))
+	// The fleet rollup reports the self-update kill switch from the SAME config
+	// value the update service and worker gate dispatch on (see
+	// SetAgentSelfUpdate below), so the UI can only offer the action when this
+	// control plane would actually honour it.
+	agentReleaseH := agentrelease.NewHandler(
+		agentrelease.NewService(agentrelease.NewRepo(pool), agentReleaseReader),
+		cfg.Update.AgentSelfUpdateEnabled,
+	)
 
 	// The agent's OWN upgrade channel (three-beat arm/apply/confirm, staged in
 	// gated waves). SHIPS DARK: cfg.Update.AgentSelfUpdateEnabled defaults to

--- a/apps/api/internal/agentrelease/handler.go
+++ b/apps/api/internal/agentrelease/handler.go
@@ -21,13 +21,24 @@ const unknownVersion = "unknown"
 //	GET /fleet/agents: tenant-scoped per-site agent-version rollup
 type Handler struct {
 	svc *Service
+	// selfUpdateEnabled mirrors cfg.Update.AgentSelfUpdateEnabled
+	// (WPMGR_UPDATE_AGENT_SELF_UPDATE_ENABLED), the SAME fleet-wide kill
+	// switch the update service and worker check before dispatching an agent
+	// self-update. It is reported on the fleet rollup so the UI reveals the
+	// "Update WPMgr agent" action exactly when the control plane would honour
+	// it, instead of offering an operator a run that is refused pre-dispatch.
+	// A boot-time snapshot is the whole truth here: the flag is process
+	// configuration (env/koanf), never a per-request or database value.
+	selfUpdateEnabled bool
 }
 
 // NewHandler builds the Handler. svc may be nil (see the routes' nil guards
 // below); Register still mounts the routes so a misconfiguration is a clean
 // 503, not a 404 (mirrors internal/vuln.Handler's enq-nil pattern).
-func NewHandler(svc *Service) *Handler {
-	return &Handler{svc: svc}
+// selfUpdateEnabled must be the same config value the update worker gates
+// dispatch on.
+func NewHandler(svc *Service, selfUpdateEnabled bool) *Handler {
+	return &Handler{svc: svc, selfUpdateEnabled: selfUpdateEnabled}
 }
 
 // Register mounts the routes on the authenticated /api/v1 group.
@@ -62,12 +73,22 @@ type agentLatestResponseDTO struct {
 //
 //	{
 //	  "latest_version": "0.61.95",
+//	  "reference_source": "published",
 //	  "counts": {"current": 10, "outdated": 3, "unknown": 1, "ineligible": 0},
 //	  "sites": [
 //	    {"site_id": "...", "site_name": "...", "agent_version": "0.61.90", "status": "outdated"},
 //	    ...
-//	  ]
+//	  ],
+//	  "self_update_enabled": false
 //	}
+//
+// latest_version is the version the counts were computed against, and
+// reference_source says where it came from: "published" (the release channel
+// manifest), "fleet" (the newest agent version in this tenant's own fleet,
+// used when the manifest cannot be read), or "none" (neither was available,
+// so every site is "unknown"). A caller must read the two together: under
+// "fleet", latest_version is the newest agent SEEN HERE, not the newest that
+// exists, and presenting it as the latter would overclaim.
 //
 // agent_version is the site's raw last-reported value verbatim (empty when
 // the agent has never reported one), distinct from status="unknown", which
@@ -86,10 +107,15 @@ type fleetAgentSiteDTO struct {
 	Status       string `json:"status"`
 }
 
+// self_update_enabled is always emitted, never omitted: a caller must be able
+// to read it as a settled false rather than have to treat "absent" and "off"
+// as the same undefined thing.
 type fleetAgentsResponseDTO struct {
-	LatestVersion string               `json:"latest_version"`
-	Counts        fleetAgentsCountsDTO `json:"counts"`
-	Sites         []fleetAgentSiteDTO  `json:"sites"`
+	LatestVersion     string               `json:"latest_version"`
+	ReferenceSource   string               `json:"reference_source"`
+	Counts            fleetAgentsCountsDTO `json:"counts"`
+	Sites             []fleetAgentSiteDTO  `json:"sites"`
+	SelfUpdateEnabled bool                 `json:"self_update_enabled"`
 }
 
 // ---------------------------------------------------------------------------
@@ -118,9 +144,15 @@ func (h *Handler) fleetAgents(c *gin.Context) {
 		return
 	}
 
-	latest := summary.LatestVersion
+	latest := summary.ReferenceVersion
 	if latest == "" {
 		latest = unknownVersion
+	}
+	// A zero ReferenceSource can only mean "nothing was available"; never emit
+	// an empty discriminator the caller would have to interpret.
+	source := summary.ReferenceSource
+	if source == "" {
+		source = ReferenceSourceNone
 	}
 
 	sites := make([]fleetAgentSiteDTO, 0, len(summary.Sites))
@@ -134,13 +166,15 @@ func (h *Handler) fleetAgents(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, fleetAgentsResponseDTO{
-		LatestVersion: latest,
+		LatestVersion:   latest,
+		ReferenceSource: string(source),
 		Counts: fleetAgentsCountsDTO{
 			Current:    summary.Counts.Current,
 			Outdated:   summary.Counts.Outdated,
 			Unknown:    summary.Counts.Unknown,
 			Ineligible: summary.Counts.Ineligible,
 		},
-		Sites: sites,
+		Sites:             sites,
+		SelfUpdateEnabled: h.selfUpdateEnabled,
 	})
 }

--- a/apps/api/internal/agentrelease/handler_test.go
+++ b/apps/api/internal/agentrelease/handler_test.go
@@ -53,7 +53,7 @@ func doRequest(engine *gin.Engine, method, path string, p domain.Principal) *htt
 // with 403 before reaching the handler; an org-scoped member reaches it.
 func TestFleetAgents_RequiresOrgScope(t *testing.T) {
 	tenantID := uuid.New()
-	h := agentrelease.NewHandler(nil)
+	h := agentrelease.NewHandler(nil, false)
 	engine := newTestEngine(h)
 
 	sitePrincipal := domain.Principal{
@@ -98,7 +98,7 @@ func TestCrossTenantIsolation_FleetAgents(t *testing.T) {
 		tenantB: {{SiteID: siteB, SiteName: "tenant-b-site", AgentVersion: "0.61.95"}},
 	}}
 	svc := agentrelease.NewService(repo, &fakeVersionReader{version: "0.61.95"})
-	h := agentrelease.NewHandler(svc)
+	h := agentrelease.NewHandler(svc, false)
 	engine := newTestEngine(h)
 
 	principalFor := func(tenantID uuid.UUID) domain.Principal {
@@ -153,11 +153,50 @@ func TestCrossTenantIsolation_FleetAgents(t *testing.T) {
 	}
 }
 
+// TestFleetAgents_EmitsSelfUpdateEnabled pins the Phase 2 feature flag on the
+// wire. The field is specified and the UI gates the "Update WPMgr agent" bulk
+// action on it, so until the control plane actually emits it the action stays
+// hidden even on an instance where WPMGR_UPDATE_AGENT_SELF_UPDATE_ENABLED is
+// on, i.e. the channel could not be turned on at all. It must be present in
+// BOTH states and track the same config the update worker gates dispatch on.
+func TestFleetAgents_EmitsSelfUpdateEnabled(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		t.Run(map[bool]string{false: "disabled", true: "enabled"}[enabled], func(t *testing.T) {
+			tenantID := uuid.New()
+			repo := &fakeSiteLister{byTenant: map[uuid.UUID][]agentrelease.SiteAgentVersion{
+				tenantID: {{SiteID: uuid.New(), SiteName: "s", AgentVersion: "0.61.90"}},
+			}}
+			svc := agentrelease.NewService(repo, &fakeVersionReader{version: "0.61.95"})
+			engine := newTestEngine(agentrelease.NewHandler(svc, enabled))
+			p := domain.Principal{TenantID: tenantID, Type: domain.PrincipalUser, UserID: uuid.New(), Role: string(authz.RoleViewer)}
+
+			w := doRequest(engine, http.MethodGet, "/api/v1/fleet/agents", p)
+			if w.Code != http.StatusOK {
+				t.Fatalf("GET /fleet/agents = %d; want 200, body=%s", w.Code, w.Body.String())
+			}
+			// Decoded into a pointer so "absent" is distinguishable from
+			// "false": absent is exactly the bug this test exists to catch.
+			var resp struct {
+				SelfUpdateEnabled *bool `json:"self_update_enabled"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if resp.SelfUpdateEnabled == nil {
+				t.Fatalf("self_update_enabled absent from the response; the UI cannot reveal the action without it. body=%s", w.Body.String())
+			}
+			if *resp.SelfUpdateEnabled != enabled {
+				t.Errorf("self_update_enabled = %v; want %v (must track the config the worker checks)", *resp.SelfUpdateEnabled, enabled)
+			}
+		})
+	}
+}
+
 // TestAgentLatest_DegradesToUnknown proves GET /agent/latest never errors:
 // a nil service (object storage unconfigured / never wired) still returns
 // 200 with version="unknown".
 func TestAgentLatest_DegradesToUnknown(t *testing.T) {
-	h := agentrelease.NewHandler(nil)
+	h := agentrelease.NewHandler(nil, false)
 	engine := newTestEngine(h)
 	p := domain.Principal{TenantID: uuid.New(), Type: domain.PrincipalUser, UserID: uuid.New(), Role: string(authz.RoleViewer)}
 

--- a/apps/api/internal/agentrelease/reader.go
+++ b/apps/api/internal/agentrelease/reader.go
@@ -35,6 +35,31 @@ const maxManifestBytes = 64 << 10
 // defaultTTL is used when NewReader is given a non-positive ttl.
 const defaultTTL = 5 * time.Minute
 
+// defaultNegativeTTL bounds how long a FAILED read is allowed to stand before
+// the next call retries. A failure is cheap to retry and expensive to believe
+// (see Reader's doc comment), so it must never inherit the full success TTL:
+// one transient presign or storage blip would otherwise pin "unknown" for five
+// minutes across every replica that saw it.
+const defaultNegativeTTL = 30 * time.Second
+
+// maxLastKnownGoodAge bounds how OLD the last known good version may get before
+// this Reader stops offering it in place of a live read.
+//
+// Serving the last good value across a blip is correct and must stay (see
+// Reader): a rollup silently reclassified against something else is a plausible
+// wrong answer, which is worse than a visibly stale one. Serving it forever is
+// not correct. With storage broken permanently after a single success, an
+// unbounded last known good reports that version as the "published" reference
+// indefinitely, so a release landing during a sustained outage is never seen
+// and the dashboard shows a confident all-clear attributed to a channel it can
+// no longer read. Past this age the honest answer is that no reference can be
+// determined right now.
+//
+// One hour is twelve times the 5-minute success TTL: far longer than any
+// realistic presign blip, storage failover or rolling redeploy, and short
+// enough that a stale reference cannot outlive a release.
+const maxLastKnownGoodAge = time.Hour
+
 // Store is the narrow object-storage surface this package needs: a read via
 // presigned GET. Satisfied by *blobstore.Store.
 type Store interface {
@@ -48,48 +73,171 @@ type manifest struct {
 
 // Reader is a cached, best-effort reader of the currently published agent
 // release version. A read failure (no store wired, object missing, storage
-// unreachable, malformed JSON) ALWAYS degrades to "" (unknown); this feeds a
-// read-only dashboard, and it must never turn into an error response or
-// block boot.
+// unreachable, malformed JSON) degrades to the LAST KNOWN GOOD version, or to
+// "" (unknown) when this process has never read one; this feeds a read-only
+// dashboard, and it must never turn into an error response or block boot.
+//
+// Three properties of the cache are load-bearing, all learned the hard way:
+//
+//   - A failure NEVER overwrites a good value. The published version is the
+//     reference the whole fleet rollup is classified against, and a rollup
+//     silently reclassified against something else is a plausible wrong answer,
+//     which is worse than a visibly stale one. Stale but true beats derived.
+//   - A failure is cached for a much shorter negative TTL than a success, so a
+//     single blip cannot hold the degraded answer for the full success TTL.
+//     Each API replica holds its own Reader, so a long-held failure also makes
+//     the dashboard disagree with itself between replicas on refresh.
+//   - That good value is nonetheless AGE BOUNDED (maxLastKnownGoodAge). Stale
+//     but true stops being true at some point: a value read an hour ago is no
+//     longer evidence about what is published now, and standing behind it
+//     indefinitely turns a sustained outage into a confident all-clear
+//     attributed to a channel this process can no longer read. Past the bound
+//     LatestVersion returns "" and the caller reports that no reference can be
+//     determined.
 type Reader struct {
-	store Store
-	ttl   time.Duration
+	store       Store
+	ttl         time.Duration
+	negativeTTL time.Duration
+	// maxAge bounds how old cached may get before it stops being served at all
+	// (see maxLastKnownGoodAge).
+	maxAge time.Duration
 
-	mu          sync.Mutex
-	cached      string
-	haveFetched bool
-	fetchedAt   time.Time
+	mu sync.Mutex
+	// cached is the last SUCCESSFULLY read version, retained across failures.
+	cached string
+	// cachedAt is when cached was read, i.e. the age the maxAge bound applies
+	// to. It advances only on a successful read, never on a failure.
+	cachedAt time.Time
+	// everPublished records whether a well-formed version has ever been read
+	// by this process. It is the honest discriminator between "this install
+	// has a release channel that is momentarily unreadable" and "this install
+	// has no release channel at all", which is the self-hosted steady state
+	// the fleet-derived fallback exists for (see Service.referenceVersion).
+	everPublished bool
+	haveFetched   bool
+	lastFetchOK   bool
+	fetchedAt     time.Time
 }
 
 // NewReader builds a cached Reader. store may be nil (object storage not
 // configured); LatestVersion then always returns "". ttl<=0 uses a 5-minute
-// default.
+// default, and failures are cached for defaultNegativeTTL (capped at ttl, so a
+// deliberately short ttl stays short).
 func NewReader(store Store, ttl time.Duration) *Reader {
+	return NewReaderWithLimits(store, ttl, defaultNegativeTTL, maxLastKnownGoodAge)
+}
+
+// NewReaderWithNegativeTTL builds a cached Reader with an explicit negative
+// TTL: how long a failed read is cached before the next call retries. Both
+// non-positive values take their defaults, and negativeTTL is capped at ttl (a
+// failure is never cached longer than a success). The last known good version
+// is bounded at the default maxLastKnownGoodAge.
+func NewReaderWithNegativeTTL(store Store, ttl, negativeTTL time.Duration) *Reader {
+	return NewReaderWithLimits(store, ttl, negativeTTL, maxLastKnownGoodAge)
+}
+
+// NewReaderWithLimits builds a cached Reader with all three bounds stated
+// explicitly:
+//
+//   - ttl: how long a SUCCESSFUL read is served before it is read again.
+//   - negativeTTL: how long a FAILED read is held before the next call retries.
+//   - maxLastKnownGood: how old the last successfully read version may get
+//     before the Reader stops serving it and reports unknown instead.
+//
+// Non-positive values take their defaults. negativeTTL is capped at ttl (a
+// failure is never cached longer than a success), and ttl is capped at
+// maxLastKnownGood, so no value is ever served past the age bound whatever the
+// TTL says.
+func NewReaderWithLimits(store Store, ttl, negativeTTL, maxLastKnownGood time.Duration) *Reader {
+	if maxLastKnownGood <= 0 {
+		maxLastKnownGood = maxLastKnownGoodAge
+	}
 	if ttl <= 0 {
 		ttl = defaultTTL
 	}
-	return &Reader{store: store, ttl: ttl}
+	if ttl > maxLastKnownGood {
+		ttl = maxLastKnownGood
+	}
+	if negativeTTL <= 0 {
+		negativeTTL = defaultNegativeTTL
+	}
+	if negativeTTL > ttl {
+		negativeTTL = ttl
+	}
+	return &Reader{store: store, ttl: ttl, negativeTTL: negativeTTL, maxAge: maxLastKnownGood}
 }
 
 // LatestVersion returns the currently published agent version, or "" when it
-// cannot be determined right now. Never returns an error.
+// cannot be determined right now. A read that fails after an earlier success
+// returns that earlier version rather than "", up to maxLastKnownGoodAge; past
+// that bound it returns "" so a sustained outage is reported as unknown instead
+// of as a stale published claim. Never returns an error.
 func (r *Reader) LatestVersion(ctx context.Context) string {
 	r.mu.Lock()
-	if r.haveFetched && time.Since(r.fetchedAt) < r.ttl {
-		v := r.cached
+	if r.haveFetched && time.Since(r.fetchedAt) < r.currentTTLLocked() {
+		v := r.lastKnownGoodLocked()
 		r.mu.Unlock()
 		return v
 	}
 	r.mu.Unlock()
 
 	v := r.fetch(ctx)
+	// A fetch counts as successful only when it yields a version this package
+	// is willing to order. A manifest that reads but carries garbage is no
+	// more usable than an absent one, and must not be promoted to last known
+	// good nor recorded as proof that a release channel exists here.
+	ok := isWellFormedVersion(v)
 
 	r.mu.Lock()
-	r.cached = v
+	defer r.mu.Unlock()
 	r.haveFetched = true
+	r.lastFetchOK = ok
 	r.fetchedAt = time.Now()
-	r.mu.Unlock()
-	return v
+	if ok {
+		r.cached = strings.TrimSpace(v)
+		r.cachedAt = r.fetchedAt
+		r.everPublished = true
+	}
+	// On failure r.cached is deliberately left untouched: the last known good
+	// version survives the blip, and stays "" when there has never been one.
+	// It is served only while still inside the age bound.
+	return r.lastKnownGoodLocked()
+}
+
+// lastKnownGoodLocked returns the last successfully read version while it is
+// still young enough to stand in for a live read, and "" once it is not (or
+// when there has never been one). Caller must hold r.mu.
+//
+// Deliberately does NOT clear r.cached or r.everPublished. A bounded-out value
+// is withheld, not forgotten: the next successful read refreshes it in place,
+// and the proof that this install HAS a release channel is what keeps the fleet
+// rollup on "none" instead of falling through to a fleet-derived reference
+// (see Service.referenceVersion).
+func (r *Reader) lastKnownGoodLocked() string {
+	if r.cached == "" || time.Since(r.cachedAt) >= r.maxAge {
+		return ""
+	}
+	return r.cached
+}
+
+// EverPublished reports whether this Reader has ever successfully read a
+// well-formed published version. False is the self-hosted steady state (no
+// release pipeline ever writes agent-releases/latest.json into that install's
+// own bucket); it is deliberately NOT the same fact as "the last read failed".
+func (r *Reader) EverPublished() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.everPublished
+}
+
+// currentTTLLocked returns the TTL that applies to the entry currently held:
+// the full ttl after a successful read, the much shorter negativeTTL after a
+// failed one. Caller must hold r.mu.
+func (r *Reader) currentTTLLocked() time.Duration {
+	if r.lastFetchOK {
+		return r.ttl
+	}
+	return r.negativeTTL
 }
 
 // fetch performs the actual read. Any failure (store unwired, object missing:

--- a/apps/api/internal/agentrelease/reader_test.go
+++ b/apps/api/internal/agentrelease/reader_test.go
@@ -96,3 +96,169 @@ func TestReader_LatestVersion_RefetchesAfterTTL(t *testing.T) {
 		t.Errorf("store.calls = %d; want 2 (re-fetched after TTL expiry)", store.calls)
 	}
 }
+
+// scriptedStore serves a different outcome per call, so a test can stage a
+// transient blip: fail on the listed 1-based call numbers, serve body on every
+// other call.
+// failFrom, when positive, additionally fails every call from that 1-based
+// number onward: storage that breaks and stays broken, as opposed to a blip.
+type scriptedStore struct {
+	body      string
+	failCalls map[int]bool
+	failFrom  int
+	calls     int
+}
+
+func (s *scriptedStore) GetViaPresign(_ context.Context, key string) (io.ReadCloser, error) {
+	s.calls++
+	if key != ManifestKey {
+		return nil, errors.New("unexpected key: " + key)
+	}
+	if s.failCalls[s.calls] || (s.failFrom > 0 && s.calls >= s.failFrom) {
+		return nil, errors.New("simulated: transient presign failure")
+	}
+	return io.NopCloser(strings.NewReader(s.body)), nil
+}
+
+// TestReader_LatestVersion_FailureServesLastKnownGood is the core of the
+// regression: a blip after a good read must return the good read, not "".
+// Serving "" hands the fleet rollup an unusable reference, which it then
+// replaces with a fleet-derived one, turning a visible degradation into a
+// plausible wrong answer.
+func TestReader_LatestVersion_FailureServesLastKnownGood(t *testing.T) {
+	store := &scriptedStore{body: `{"version":"0.62.0"}`, failCalls: map[int]bool{2: true, 3: true}}
+	r := NewReaderWithNegativeTTL(store, 5*time.Millisecond, time.Millisecond)
+	ctx := context.Background()
+
+	if got := r.LatestVersion(ctx); got != "0.62.0" {
+		t.Fatalf("first LatestVersion() = %q; want %q", got, "0.62.0")
+	}
+	time.Sleep(20 * time.Millisecond)
+	if got := r.LatestVersion(ctx); got != "0.62.0" {
+		t.Errorf("LatestVersion() during a blip = %q; want the last known good %q", got, "0.62.0")
+	}
+	time.Sleep(20 * time.Millisecond)
+	if got := r.LatestVersion(ctx); got != "0.62.0" {
+		t.Errorf("LatestVersion() during a second blip = %q; want the last known good %q", got, "0.62.0")
+	}
+	if store.calls < 3 {
+		t.Errorf("store.calls = %d; want at least 3 (each expiry retried)", store.calls)
+	}
+}
+
+// TestReader_LatestVersion_FailureUsesShortNegativeTTL proves a failed read is
+// held for the negative TTL, not the full success TTL: with an hour-long
+// success TTL, the very next call after the negative window must retry rather
+// than serve the failure for the hour.
+func TestReader_LatestVersion_FailureUsesShortNegativeTTL(t *testing.T) {
+	store := &scriptedStore{body: `{"version":"0.62.0"}`, failCalls: map[int]bool{1: true}}
+	r := NewReaderWithNegativeTTL(store, time.Hour, 5*time.Millisecond)
+	ctx := context.Background()
+
+	if got := r.LatestVersion(ctx); got != "" {
+		t.Fatalf("first LatestVersion() = %q; want empty (nothing has ever been read)", got)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if got := r.LatestVersion(ctx); got != "0.62.0" {
+		t.Errorf("LatestVersion() after the negative TTL = %q; want %q (a blip must not be cached for the success TTL)", got, "0.62.0")
+	}
+	if store.calls != 2 {
+		t.Errorf("store.calls = %d; want 2 (retried once the negative TTL expired)", store.calls)
+	}
+}
+
+// TestReader_NegativeTTLNeverExceedsTTL pins the invariant that a failure is
+// never cached longer than a success, however the Reader is constructed.
+func TestReader_NegativeTTLNeverExceedsTTL(t *testing.T) {
+	if r := NewReader(nil, time.Second); r.negativeTTL > r.ttl {
+		t.Errorf("NewReader negativeTTL = %v; must not exceed ttl = %v", r.negativeTTL, r.ttl)
+	}
+	if r := NewReaderWithNegativeTTL(nil, time.Second, time.Hour); r.negativeTTL != time.Second {
+		t.Errorf("negativeTTL = %v; want it capped at ttl (1s)", r.negativeTTL)
+	}
+	if r := NewReader(nil, 0); r.negativeTTL != defaultNegativeTTL {
+		t.Errorf("default negativeTTL = %v; want %v", r.negativeTTL, defaultNegativeTTL)
+	}
+}
+
+// TestReader_TTLNeverExceedsMaxAge: a success TTL longer than the age bound
+// would park the Reader on a value it is no longer willing to serve, returning
+// unknown without re-reading until the TTL finally expired. Capping ttl keeps
+// every expiry a retry.
+func TestReader_TTLNeverExceedsMaxAge(t *testing.T) {
+	if r := NewReaderWithLimits(nil, 2*time.Hour, time.Second, time.Hour); r.ttl != time.Hour {
+		t.Errorf("ttl = %v; want it capped at maxLastKnownGood (1h)", r.ttl)
+	}
+	if r := NewReader(nil, 0); r.maxAge != maxLastKnownGoodAge {
+		t.Errorf("default maxAge = %v; want %v", r.maxAge, maxLastKnownGoodAge)
+	}
+}
+
+// TestReader_LastKnownGoodExpiresAtMaxAge is the bound on staleness. Storage
+// serves the manifest once and is then broken permanently.
+//
+// Standing in for a live read is right while the good value is young: that is
+// what stops one blip from handing the fleet rollup an unusable reference it
+// would then replace with a fleet-derived one. It is wrong forever. Unbounded,
+// this Reader reports 0.62.0 as the published version for the entire life of
+// the process, so a release landing during the outage is never seen and the
+// dashboard states a confident all-clear sourced from a channel it can no
+// longer read. Past the bound the honest answer is unknown.
+func TestReader_LastKnownGoodExpiresAtMaxAge(t *testing.T) {
+	store := &scriptedStore{body: `{"version":"0.62.0"}`, failFrom: 2}
+	r := NewReaderWithLimits(store, 5*time.Millisecond, time.Millisecond, 50*time.Millisecond)
+	ctx := context.Background()
+
+	if got := r.LatestVersion(ctx); got != "0.62.0" {
+		t.Fatalf("first LatestVersion() = %q; want %q", got, "0.62.0")
+	}
+	time.Sleep(10 * time.Millisecond) // past the success TTL, well inside the bound
+	if got := r.LatestVersion(ctx); got != "0.62.0" {
+		t.Errorf("LatestVersion() inside the bound = %q; want the last known good %q", got, "0.62.0")
+	}
+	time.Sleep(60 * time.Millisecond) // past the bound
+	if got := r.LatestVersion(ctx); got != "" {
+		t.Errorf("LatestVersion() past the age bound = %q; want empty (a stale value must not stand in forever)", got)
+	}
+	// The channel demonstrably exists here, and that fact does not decay with
+	// the value: it is what keeps the rollup on "none" rather than falling
+	// through to a fleet-derived reference (see Service.referenceVersion).
+	if !r.EverPublished() {
+		t.Error("EverPublished() = false; a proven publish must stay proven")
+	}
+}
+
+// TestReader_EverPublished distinguishes "this install has no release channel"
+// (the self-hosted steady state) from "the channel this install does have was
+// briefly unreadable". Only the first may unlock the fleet-derived fallback.
+func TestReader_EverPublished(t *testing.T) {
+	ctx := context.Background()
+
+	never := NewReaderWithNegativeTTL(&scriptedStore{body: `{"version":"0.62.0"}`, failCalls: map[int]bool{1: true}}, time.Hour, time.Millisecond)
+	if never.EverPublished() {
+		t.Error("EverPublished() before any read = true; want false")
+	}
+	_ = never.LatestVersion(ctx)
+	if never.EverPublished() {
+		t.Error("EverPublished() after a failed read = true; want false")
+	}
+
+	garbage := NewReader(&fakeStore{body: `{"version":"not-a-version"}`}, time.Hour)
+	_ = garbage.LatestVersion(ctx)
+	if garbage.EverPublished() {
+		t.Error("EverPublished() after reading a garbage version = true; want false (unusable is not published)")
+	}
+
+	published := NewReaderWithNegativeTTL(&scriptedStore{body: `{"version":"0.62.0"}`, failCalls: map[int]bool{2: true}}, 5*time.Millisecond, time.Millisecond)
+	if got := published.LatestVersion(ctx); got != "0.62.0" {
+		t.Fatalf("LatestVersion() = %q; want %q", got, "0.62.0")
+	}
+	if !published.EverPublished() {
+		t.Fatal("EverPublished() after a successful read = false; want true")
+	}
+	time.Sleep(20 * time.Millisecond)
+	_ = published.LatestVersion(ctx)
+	if !published.EverPublished() {
+		t.Error("EverPublished() after a later blip = false; want true (it stays true once proven)")
+	}
+}

--- a/apps/api/internal/agentrelease/release_blip_test.go
+++ b/apps/api/internal/agentrelease/release_blip_test.go
@@ -1,0 +1,166 @@
+package agentrelease_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentrelease"
+)
+
+// blipStore is an agentrelease.Store that fails on the listed 1-based call
+// numbers and serves the manifest on every other call: one transient presign
+// or storage failure, exactly as reported in production.
+// failFrom, when positive, additionally fails every call from that 1-based
+// number onward: storage that breaks and stays broken, i.e. a sustained outage
+// rather than a blip.
+type blipStore struct {
+	version   string
+	failCalls map[int]bool
+	failFrom  int
+	calls     int
+}
+
+func (b *blipStore) GetViaPresign(_ context.Context, key string) (io.ReadCloser, error) {
+	b.calls++
+	if key != agentrelease.ManifestKey {
+		return nil, errors.New("unexpected key: " + key)
+	}
+	if b.failCalls[b.calls] || (b.failFrom > 0 && b.calls >= b.failFrom) {
+		return nil, errors.New("simulated: transient object storage failure")
+	}
+	return io.NopCloser(strings.NewReader(`{"version":"` + b.version + `"}`)), nil
+}
+
+// fleetOn builds n sites all reporting the same agent version.
+func fleetOn(n int, version string) []agentrelease.SiteAgentVersion {
+	rows := make([]agentrelease.SiteAgentVersion, 0, n)
+	for i := 0; i < n; i++ {
+		rows = append(rows, site(version))
+	}
+	return rows
+}
+
+func rollupWithReader(t *testing.T, reader agentrelease.VersionReader, rows []agentrelease.SiteAgentVersion) agentrelease.FleetSummary {
+	t.Helper()
+	tenantID := uuid.New()
+	repo := &fakeSiteLister{byTenant: map[uuid.UUID][]agentrelease.SiteAgentVersion{tenantID: rows}}
+	summary, err := agentrelease.NewService(repo, reader).FleetRollup(context.Background(), tenantID)
+	if err != nil {
+		t.Fatalf("FleetRollup: %v", err)
+	}
+	return summary
+}
+
+// TestFleetRollup_StorageBlipDoesNotFlipTheFleetToCurrent is the production
+// regression, reproduced from the reported scenario: 24 sites on 0.61.97, the
+// manifest publishing 0.62.0, and object storage failing exactly once.
+//
+// Before the fix the failed read was cached as "" for the FULL success TTL
+// (five minutes), so the rollup silently re-derived its reference from the
+// fleet itself and answered "24 of 24 current" on release day, hiding the
+// outdated call to action for five minutes on every replica that saw the blip.
+// Truth is 24 outdated.
+//
+// The fix bounds that window to the much shorter negative TTL: the blip is
+// retried, the published version returns, and the fleet reads outdated again.
+func TestFleetRollup_StorageBlipDoesNotFlipTheFleetToCurrent(t *testing.T) {
+	store := &blipStore{version: "0.62.0", failCalls: map[int]bool{1: true}}
+	// A production-shaped success TTL with a test-shaped negative TTL: the
+	// point of the test is precisely that the two differ.
+	reader := agentrelease.NewReaderWithNegativeTTL(store, 5*time.Minute, 5*time.Millisecond)
+	rows := fleetOn(24, "0.61.97")
+
+	// During the blip nothing has ever been published in this process, so the
+	// self-hosted fallback still applies and the fleet-derived answer is the
+	// best available. It must not be allowed to STICK.
+	during := rollupWithReader(t, reader, rows)
+	if during.ReferenceSource == agentrelease.ReferenceSourcePublished {
+		t.Fatalf("during the blip ReferenceSource = %q; the manifest was unreadable", during.ReferenceSource)
+	}
+
+	time.Sleep(20 * time.Millisecond) // outlive the negative TTL, not the 5m one
+
+	after := rollupWithReader(t, reader, rows)
+	assertSummary(t, after, "0.62.0", agentrelease.ReferenceSourcePublished,
+		agentrelease.Counts{Outdated: 24})
+	if store.calls != 2 {
+		t.Errorf("store.calls = %d; want 2 (the blip was retried, not cached for the success TTL)", store.calls)
+	}
+}
+
+// TestFleetRollup_BlipAfterPublishServesLastKnownGood is the same failure one
+// beat later, and the harmful one: the manifest HAS been read, then a blip
+// hits. Before the fix the good version was overwritten with "", the reference
+// fell back to the fleet's own newest agent, and the dashboard flipped from
+// "24 outdated" to "24 current" (losing the "View outdated sites" link, which
+// is gated on outdated > 0). Stale but true beats fleet-derived.
+func TestFleetRollup_BlipAfterPublishServesLastKnownGood(t *testing.T) {
+	store := &blipStore{version: "0.62.0", failCalls: map[int]bool{2: true, 3: true}}
+	reader := agentrelease.NewReaderWithNegativeTTL(store, 5*time.Millisecond, time.Millisecond)
+	rows := fleetOn(24, "0.61.97")
+
+	before := rollupWithReader(t, reader, rows)
+	assertSummary(t, before, "0.62.0", agentrelease.ReferenceSourcePublished,
+		agentrelease.Counts{Outdated: 24})
+
+	time.Sleep(20 * time.Millisecond) // expire the good entry so the blip is hit
+
+	during := rollupWithReader(t, reader, rows)
+	assertSummary(t, during, "0.62.0", agentrelease.ReferenceSourcePublished,
+		agentrelease.Counts{Outdated: 24})
+
+	time.Sleep(20 * time.Millisecond)
+
+	stillDuring := rollupWithReader(t, reader, rows)
+	assertSummary(t, stillDuring, "0.62.0", agentrelease.ReferenceSourcePublished,
+		agentrelease.Counts{Outdated: 24})
+}
+
+// TestFleetRollup_UnreadableAfterPublishIsNoneNotFleet pins the gate itself,
+// and does so through a REAL *agentrelease.Reader rather than a hand-written
+// double that simply asserts the state. Only a real reader proves the branch is
+// one production can reach: a double can be made to answer "published before,
+// unreadable now" whether or not any real code path produces it.
+//
+// The sequence is a sustained outage: storage serves the manifest once and is
+// then broken permanently. While the last known good version is young it stands
+// in for the live read and the fleet stays correctly measured against the
+// published 0.62.0, which is the blip fix and must not regress. Once it ages
+// past the bound the Reader stops offering it and the rollup answers source
+// "none", because the two states are genuinely different questions:
+//
+//   - This install has NO release channel (self-hosted; EverPublished false).
+//     The fleet-derived reference is the right answer.
+//   - This install HAS a release channel and it is currently unreachable
+//     (EverPublished true). Saying so is the right answer. Falling through to
+//     the fleet reference would report "24 of 24 current" against the fleet's
+//     own newest agent and hide any release that landed during the outage.
+func TestFleetRollup_UnreadableAfterPublishIsNoneNotFleet(t *testing.T) {
+	store := &blipStore{version: "0.62.0", failFrom: 2}
+	reader := agentrelease.NewReaderWithLimits(store, 20*time.Millisecond, 5*time.Millisecond, 200*time.Millisecond)
+	rows := fleetOn(24, "0.61.97")
+
+	assertSummary(t, rollupWithReader(t, reader, rows), "0.62.0",
+		agentrelease.ReferenceSourcePublished, agentrelease.Counts{Outdated: 24})
+
+	time.Sleep(40 * time.Millisecond) // past the success TTL, inside the age bound
+	assertSummary(t, rollupWithReader(t, reader, rows), "0.62.0",
+		agentrelease.ReferenceSourcePublished, agentrelease.Counts{Outdated: 24})
+
+	time.Sleep(220 * time.Millisecond) // past the age bound
+	assertSummary(t, rollupWithReader(t, reader, rows), "",
+		agentrelease.ReferenceSourceNone, agentrelease.Counts{Unknown: 24})
+
+	// Never "fleet": the channel is proven to exist, so the honest report is
+	// that WPMgr cannot determine a reference right now, not a reference
+	// derived from the fleet's own peers.
+	if !reader.EverPublished() {
+		t.Error("EverPublished() = false after a proven publish; the gate would wrongly unlock the fleet fallback")
+	}
+}

--- a/apps/api/internal/agentrelease/service.go
+++ b/apps/api/internal/agentrelease/service.go
@@ -2,8 +2,11 @@ package agentrelease
 
 import (
 	"context"
+	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/wpversion"
 )
 
 // SiteRollup is one site's classified row for the fleet agent-version
@@ -23,12 +26,44 @@ type Counts struct {
 	Ineligible int
 }
 
+// ReferenceSource names where the version the fleet was classified against
+// came from. It is part of the response because the two sources answer
+// genuinely different questions, and the caller must never have to guess
+// which one it got from an empty string.
+type ReferenceSource string
+
+const (
+	// ReferenceSourcePublished: the published release channel, i.e. the
+	// agent-releases/latest.json pointer manifest this control plane can
+	// read. "current" against this reference means the site runs the newest
+	// agent that exists.
+	ReferenceSourcePublished ReferenceSource = "published"
+	// ReferenceSourceFleet: the newest well-formed agent version present in
+	// this tenant's OWN fleet, used only when the published manifest cannot
+	// be read. A self-hosted install has its own object storage and nothing
+	// ever writes the release pipeline's pointer manifest into it, so the
+	// published version is permanently unreadable there and every site would
+	// otherwise classify "unknown" forever. "current" against this reference
+	// means only that no newer agent has been seen in this fleet, NOT that
+	// the site runs the newest agent that exists; callers presenting this
+	// must say so.
+	ReferenceSourceFleet ReferenceSource = "fleet"
+	// ReferenceSourceNone: no manifest and no well-formed agent version
+	// anywhere in the fleet, so there is nothing safe to compare against and
+	// every site is "unknown". The honest answer, never a guess.
+	ReferenceSourceNone ReferenceSource = "none"
+)
+
 // FleetSummary is the GET /api/v1/fleet/agents payload, at the service layer
 // (DTO-agnostic: the handler maps this to the wire shape).
 type FleetSummary struct {
-	LatestVersion string
-	Counts        Counts
-	Sites         []SiteRollup
+	// ReferenceVersion is the single version every row in Sites was
+	// classified against, "" when there was none (ReferenceSourceNone).
+	// ReferenceSource says where it came from.
+	ReferenceVersion string
+	ReferenceSource  ReferenceSource
+	Counts           Counts
+	Sites            []SiteRollup
 }
 
 // SiteLister is the narrow repo surface Service needs. Satisfied by *Repo.
@@ -40,6 +75,14 @@ type SiteLister interface {
 // *Reader.
 type VersionReader interface {
 	LatestVersion(ctx context.Context) string
+}
+
+// PublishHistoryReader is an OPTIONAL capability of a VersionReader: whether a
+// published version has ever been read successfully. *Reader implements it.
+// A VersionReader that does not is treated as never having published, which
+// keeps the fleet-derived fallback available to it (see referenceVersion).
+type PublishHistoryReader interface {
+	EverPublished() bool
 }
 
 // Service composes the tenant-scoped site rollup with the cached published
@@ -65,22 +108,170 @@ func (s *Service) LatestVersion(ctx context.Context) string {
 	return s.reader.LatestVersion(ctx)
 }
 
+// everPublished reports whether the reader has ever successfully read a
+// published version. A nil reader, or one that does not carry the optional
+// PublishHistoryReader capability, answers false: that is the conservative
+// answer here, because false is what keeps the self-hosted fleet fallback
+// working (see referenceVersion).
+func (s *Service) everPublished() bool {
+	if s.reader == nil {
+		return false
+	}
+	if hr, ok := s.reader.(PublishHistoryReader); ok {
+		return hr.EverPublished()
+	}
+	return false
+}
+
+// referenceVersion picks the single version the fleet is classified against,
+// and reports where it came from.
+//
+// The published manifest always wins when it is readable, so a hosted install
+// behaves exactly as it did before this fallback existed. On an install that
+// has never had a readable manifest, the reference is derived from the rows
+// the rollup ALREADY loaded (fleetReference): a self-hosted install never
+// receives the release pipeline's pointer manifest (nothing writes
+// agent-releases/latest.json into its own bucket), and reporting "unknown"
+// for every site there answers none of the operator's question, which is
+// "which of my sites are lagging?". This is a single pass over data already
+// in hand: no second query, no extra round trip.
+//
+// The control plane's own build version is deliberately NOT a candidate: the
+// agent version only moves when the agent changes, so a control plane ahead
+// of the agent would mark a correctly updated fleet outdated.
+//
+// Every site contributes, including the plugin-directory build. Its version
+// is a real agent version, and the site itself is still classified
+// StatusIneligible whatever the reference turns out to be.
+//
+// rows carries exactly one tenant's sites (ListSiteAgentVersions is
+// tenant-scoped, under both RLS and an explicit tenant_id filter), so the
+// derived reference is tenant-local by construction and can never be pulled
+// up by a busier neighbour's fleet.
+//
+// PRECEDENCE, in order:
+//
+//  1. The published manifest, whenever it is well-formed. Reader serves the
+//     last known good version across a read failure, so a blip does not reach
+//     here at all; that value is age bounded (maxLastKnownGoodAge), so a
+//     SUSTAINED outage eventually does.
+//  2. Nothing (ReferenceSourceNone) when no version is readable right now but
+//     this install HAS a release channel (everPublished). A gap in a channel
+//     that does exist is not a licence to reclassify the whole fleet against
+//     itself: the fleet-derived reference would report every site "current"
+//     against its own newest agent on the exact day a release lands, which
+//     reads as a confident all-clear and hides the "outdated" call to action.
+//     Saying plainly that no reference can be determined is the lesser harm,
+//     and it is the honest one: the distinction that matters to an operator is
+//     "this install has no channel" (self-hosted, case 3) versus "this install
+//     has a channel and it is currently unreachable" (here).
+//  3. The fleet-derived reference (fleetReference), only when no published
+//     version has ever been read. That is precisely the self-hosted steady
+//     state this fallback was built for: nothing ever writes the release
+//     pipeline's pointer manifest into a self-hosted install's own bucket, so
+//     the published version is permanently unreadable there and every site
+//     would otherwise classify "unknown" forever.
+func referenceVersion(published string, everPublished bool, rows []SiteAgentVersion) (string, ReferenceSource) {
+	if isWellFormedVersion(published) {
+		return published, ReferenceSourcePublished
+	}
+	if everPublished {
+		return "", ReferenceSourceNone
+	}
+	derived := fleetReference(rows)
+	if derived == "" {
+		return "", ReferenceSourceNone
+	}
+	return derived, ReferenceSourceFleet
+}
+
+// fleetReference derives the reference version from the tenant's own reported
+// agent versions: the HIGHEST well-formed, non-pre-release version any site in
+// this fleet reports, or "" when nothing usable is present. A single site is
+// enough to move it.
+//
+// DO NOT REINSTATE CORROBORATION. An earlier revision required a version to be
+// reported by two or more distinct sites before it could become the reference,
+// on the theory that one machine should not speak for the whole tenant. It was
+// removed because it trades a rare problem for a common one:
+//
+//   - It suppresses real rollouts, and one site updated first is the NORMAL
+//     shape of a rollout in progress. A fleet of 24 sites on 0.61.97 with one
+//     site legitimately updated to 0.62.0 answered "25 current, 0 outdated":
+//     a confident all-clear while 24 sites were genuinely behind an agent that
+//     demonstrably exists in that very fleet. That is the same "everything
+//     looks current while things are behind" failure the published path was
+//     already fixed for, reintroduced on the fallback path.
+//   - It could not deliver its guarantee anyway. When no version reached two
+//     reporters the rule was abandoned and the bare highest won, so a three
+//     site fleet on 0.61.90 / 0.61.95 / 9.9.9 still answered 9.9.9. It failed
+//     on precisely the small self-hosted fleets this fallback exists to serve.
+//   - The threat it targeted clears a threshold of two trivially: a sideloaded
+//     or locally built agent is rarely on only one machine.
+//
+// The unguarded newest is correct here because of what the reference actually
+// claims. Under ReferenceSourceFleet the product says "newest seen in this
+// fleet", not "newest that exists". If one site reports 9.9.9 then 9.9.9 IS
+// the newest seen in that fleet, the statement stays true, and that site is
+// visible in the very list the operator is looking at. A heuristic that hides
+// a real update in order to avoid an unusual one is the worse trade.
+//
+// Pre-release and build-tagged versions (any -suffix or +suffix, e.g.
+// 0.62.0-rc.1) remain excluded from BECOMING the reference: a pre-release is
+// not something you would tell an operator to move to. Unlike corroboration,
+// this exclusion cannot suppress a legitimate stable rollout, because a stable
+// release carries no such suffix. Sites running a pre-release are still
+// classified normally and come out current, being ahead of the reference.
+func fleetReference(rows []SiteAgentVersion) string {
+	highest := ""
+	for _, row := range rows {
+		v := strings.TrimSpace(row.AgentVersion)
+		if !isWellFormedVersion(v) || isPreRelease(v) {
+			continue
+		}
+		if highest == "" || wpversion.Compare(v, highest) > 0 {
+			highest = v
+		}
+	}
+	return highest
+}
+
+// isPreRelease reports whether a well-formed version carries a pre-release or
+// build suffix ("0.62.0-rc.1", "0.61.97+build.3"), the part versionPattern
+// admits after the dotted-numeric core.
+func isPreRelease(v string) bool {
+	return strings.ContainsAny(strings.TrimSpace(v), "-+")
+}
+
 // FleetRollup returns the tenant-scoped per-site agent-version rollup plus
-// counts, classified against the currently published version.
+// counts, classified against the published agent version when it can be read
+// and against the newest agent version present in the tenant's own fleet when
+// this install has no readable release channel at all (see referenceVersion).
+// The returned FleetSummary always states which of the two, or neither, it
+// used.
+//
+// This fallback is confined to this read-only dashboard on purpose. The
+// write path that actually arms an agent self-update (internal/update.
+// Service.planAgentTasks) still requires the published version and refuses
+// the run without it: a fleet-derived reference describes what is already
+// installed somewhere, and there is no artifact to install from it.
 func (s *Service) FleetRollup(ctx context.Context, tenantID uuid.UUID) (FleetSummary, error) {
-	latest := s.LatestVersion(ctx)
+	published := s.LatestVersion(ctx)
 
 	rows, err := s.repo.ListSiteAgentVersions(ctx, tenantID)
 	if err != nil {
 		return FleetSummary{}, err
 	}
 
+	reference, source := referenceVersion(published, s.everPublished(), rows)
+
 	summary := FleetSummary{
-		LatestVersion: latest,
-		Sites:         make([]SiteRollup, 0, len(rows)),
+		ReferenceVersion: reference,
+		ReferenceSource:  source,
+		Sites:            make([]SiteRollup, 0, len(rows)),
 	}
 	for _, row := range rows {
-		status := Classify(row.AgentVersion, latest, row.Distribution)
+		status := Classify(row.AgentVersion, reference, row.Distribution)
 		switch status {
 		case StatusCurrent:
 			summary.Counts.Current++

--- a/apps/api/internal/agentrelease/service_test.go
+++ b/apps/api/internal/agentrelease/service_test.go
@@ -1,0 +1,362 @@
+package agentrelease_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentplugin"
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentrelease"
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// site builds one fleet row with an unidentified distribution, i.e. an
+// ordinary site that CAN consume the release channel.
+func site(version string) agentrelease.SiteAgentVersion {
+	return agentrelease.SiteAgentVersion{
+		SiteID:       uuid.New(),
+		SiteName:     "site-" + version,
+		AgentVersion: version,
+	}
+}
+
+// rollupFor runs FleetRollup for a one-tenant fleet against the given
+// published version ("" = manifest unreadable, the self-hosted steady state).
+func rollupFor(t *testing.T, published string, rows []agentrelease.SiteAgentVersion) agentrelease.FleetSummary {
+	t.Helper()
+	tenantID := uuid.New()
+	repo := &fakeSiteLister{byTenant: map[uuid.UUID][]agentrelease.SiteAgentVersion{tenantID: rows}}
+	svc := agentrelease.NewService(repo, &fakeVersionReader{version: published})
+	summary, err := svc.FleetRollup(context.Background(), tenantID)
+	if err != nil {
+		t.Fatalf("FleetRollup: %v", err)
+	}
+	return summary
+}
+
+func assertSummary(t *testing.T, got agentrelease.FleetSummary, wantVersion string, wantSource agentrelease.ReferenceSource, wantCounts agentrelease.Counts) {
+	t.Helper()
+	if got.ReferenceVersion != wantVersion {
+		t.Errorf("ReferenceVersion = %q; want %q", got.ReferenceVersion, wantVersion)
+	}
+	if got.ReferenceSource != wantSource {
+		t.Errorf("ReferenceSource = %q; want %q", got.ReferenceSource, wantSource)
+	}
+	if got.Counts != wantCounts {
+		t.Errorf("Counts = %+v; want %+v", got.Counts, wantCounts)
+	}
+}
+
+// TestFleetRollup_PublishedManifestUnchanged is the no-regression pin: when
+// the manifest reads, the published version is the reference and the counts
+// are exactly what they were before the fleet-derived fallback existed. In
+// particular the newest version PRESENT in the fleet (0.62.0 here) must not
+// displace the published one.
+func TestFleetRollup_PublishedManifestUnchanged(t *testing.T) {
+	summary := rollupFor(t, "0.61.95", []agentrelease.SiteAgentVersion{
+		site("0.61.90"),
+		site("0.61.95"),
+		site("0.62.0"),
+		site(""),
+	})
+	assertSummary(t, summary, "0.61.95", agentrelease.ReferenceSourcePublished,
+		agentrelease.Counts{Current: 2, Outdated: 1, Unknown: 1})
+}
+
+// TestFleetRollup_NoManifestDerivesNewestInFleet is the reported bug (GH
+// #255): a self-hosted install has no published manifest, and before the
+// fallback every site classified "unknown" no matter what it reported. The
+// newest well-formed version in the tenant's own fleet is now the reference,
+// so the laggards read "outdated" and the operator's actual question is
+// answered.
+func TestFleetRollup_NoManifestDerivesNewestInFleet(t *testing.T) {
+	summary := rollupFor(t, "", []agentrelease.SiteAgentVersion{
+		site("0.61.90"),
+		site("0.61.97"),
+		site("0.61.95"),
+	})
+	assertSummary(t, summary, "0.61.97", agentrelease.ReferenceSourceFleet,
+		agentrelease.Counts{Current: 1, Outdated: 2})
+
+	byVersion := map[string]agentrelease.Status{}
+	for _, row := range summary.Sites {
+		byVersion[row.AgentVersion] = row.Status
+	}
+	for version, want := range map[string]agentrelease.Status{
+		"0.61.90": agentrelease.StatusOutdated,
+		"0.61.95": agentrelease.StatusOutdated,
+		"0.61.97": agentrelease.StatusCurrent,
+	} {
+		if got := byVersion[version]; got != want {
+			t.Errorf("site on %s = %q; want %q", version, got, want)
+		}
+	}
+}
+
+// TestFleetRollup_NoManifestAllEqualInventsNoUpdate: with every site on the
+// same version, the newest present IS that version, so the honest answer is
+// "all current". The fallback must never manufacture an update that does not
+// exist.
+func TestFleetRollup_NoManifestAllEqualInventsNoUpdate(t *testing.T) {
+	summary := rollupFor(t, "", []agentrelease.SiteAgentVersion{
+		site("0.61.97"),
+		site("0.61.97"),
+		site("0.61.97"),
+	})
+	assertSummary(t, summary, "0.61.97", agentrelease.ReferenceSourceFleet,
+		agentrelease.Counts{Current: 3})
+}
+
+// TestFleetRollup_NoManifestNoUsableVersions: no manifest AND nothing
+// well-formed anywhere leaves nothing safe to compare against. Source "none"
+// plus every site "unknown" is the truthful answer, not a fabricated
+// reference.
+func TestFleetRollup_NoManifestNoUsableVersions(t *testing.T) {
+	summary := rollupFor(t, "", []agentrelease.SiteAgentVersion{
+		site(""),
+		site("not-a-version"),
+		site("5"),
+	})
+	assertSummary(t, summary, "", agentrelease.ReferenceSourceNone,
+		agentrelease.Counts{Unknown: 3})
+}
+
+// TestFleetRollup_MalformedManifestFallsBackToFleet: a manifest that reads
+// but carries garbage is no more usable than an absent one, and must take the
+// same honest fallback rather than poisoning every comparison.
+func TestFleetRollup_MalformedManifestFallsBackToFleet(t *testing.T) {
+	summary := rollupFor(t, "unknown", []agentrelease.SiteAgentVersion{
+		site("0.61.90"),
+		site("0.61.97"),
+	})
+	assertSummary(t, summary, "0.61.97", agentrelease.ReferenceSourceFleet,
+		agentrelease.Counts{Current: 1, Outdated: 1})
+}
+
+// TestFleetRollup_EmptyFleetIsSourceNone: a tenant with no sites at all has
+// no reference to derive and reports none, not an empty-string reference the
+// caller would have to interpret.
+func TestFleetRollup_EmptyFleetIsSourceNone(t *testing.T) {
+	summary := rollupFor(t, "", nil)
+	assertSummary(t, summary, "", agentrelease.ReferenceSourceNone, agentrelease.Counts{})
+	if len(summary.Sites) != 0 {
+		t.Errorf("Sites = %d; want 0", len(summary.Sites))
+	}
+}
+
+// TestFleetRollup_FleetReferenceKeepsDirectoryBuildIneligible: the
+// plugin-directory build has no self-updater, so it stays ineligible under a
+// fleet-derived reference exactly as it does under a published one. Its
+// version still counts toward the reference, because it is a real agent
+// version somebody in this fleet is running.
+func TestFleetRollup_FleetReferenceKeepsDirectoryBuildIneligible(t *testing.T) {
+	directory := site("0.61.97")
+	directory.Distribution = agentplugin.DistributionDirectory
+	summary := rollupFor(t, "", []agentrelease.SiteAgentVersion{
+		site("0.61.90"),
+		directory,
+	})
+	assertSummary(t, summary, "0.61.97", agentrelease.ReferenceSourceFleet,
+		agentrelease.Counts{Outdated: 1, Ineligible: 1})
+}
+
+// TestFleetRollup_FleetReferenceNeverCrossesTenants is the tenancy pin. Two
+// tenants share one repo; tenant B runs a newer agent than anything tenant A
+// has. With no published manifest, tenant A's reference must be derived from
+// tenant A's OWN fleet only: its sites are current against their own newest,
+// and B's 0.61.99 must never leak in to mark them outdated (nor appear as A's
+// reference version).
+func TestFleetRollup_FleetReferenceNeverCrossesTenants(t *testing.T) {
+	tenantA := uuid.New()
+	tenantB := uuid.New()
+
+	repo := &fakeSiteLister{byTenant: map[uuid.UUID][]agentrelease.SiteAgentVersion{
+		tenantA: {site("0.61.90"), site("0.61.90")},
+		tenantB: {site("0.61.99")},
+	}}
+	svc := agentrelease.NewService(repo, &fakeVersionReader{version: ""})
+
+	summaryA, err := svc.FleetRollup(context.Background(), tenantA)
+	if err != nil {
+		t.Fatalf("FleetRollup(tenant A): %v", err)
+	}
+	assertSummary(t, summaryA, "0.61.90", agentrelease.ReferenceSourceFleet,
+		agentrelease.Counts{Current: 2})
+	if summaryA.ReferenceVersion == "0.61.99" {
+		t.Fatalf("tenant A's reference leaked tenant B's version 0.61.99")
+	}
+
+	summaryB, err := svc.FleetRollup(context.Background(), tenantB)
+	if err != nil {
+		t.Fatalf("FleetRollup(tenant B): %v", err)
+	}
+	assertSummary(t, summaryB, "0.61.99", agentrelease.ReferenceSourceFleet,
+		agentrelease.Counts{Current: 1})
+}
+
+// TestFleetRollup_OneSiteUpdatedFirstOutdatesTheRest is the case that must
+// never regress. One site updated first is the NORMAL shape of a rollout in
+// progress, not an edge case.
+//
+// A previous revision required two distinct sites to report a version before it
+// could become the reference. Under that rule this exact fleet answered
+// reference 0.61.97 with "25 current, 0 outdated": a confident all-clear while
+// 24 sites were genuinely behind an agent that demonstrably exists in this very
+// fleet. Suppressing a real update is a far worse failure than surfacing an
+// unusual one, and it is the same "everything looks current while things are
+// behind" defect that was already fixed on the published path.
+func TestFleetRollup_OneSiteUpdatedFirstOutdatesTheRest(t *testing.T) {
+	rows := make([]agentrelease.SiteAgentVersion, 0, 25)
+	for i := 0; i < 24; i++ {
+		rows = append(rows, site("0.61.97"))
+	}
+	rows = append(rows, site("0.62.0"))
+
+	summary := rollupFor(t, "", rows)
+	assertSummary(t, summary, "0.62.0", agentrelease.ReferenceSourceFleet,
+		agentrelease.Counts{Current: 1, Outdated: 24})
+}
+
+// TestFleetRollup_LoneNewestVersionIsTheReference pins the deliberate other
+// side of that trade. A single site reporting a version nobody else has (a
+// locally built agent, a sideloaded dev build) DOES become the reference, and
+// the rest of the fleet reads outdated behind it.
+//
+// That is accepted on purpose. The claim this reference carries on the wire is
+// literally "the newest agent version seen in this fleet": if one site reports
+// 9.9.9 then 9.9.9 genuinely is the newest seen here, the statement stays true,
+// and the outlier site is right there in the list the operator is reading. A
+// version this rule cannot become is checked separately, see
+// TestFleetRollup_PreReleaseNeverBecomesTheReference.
+func TestFleetRollup_LoneNewestVersionIsTheReference(t *testing.T) {
+	rows := make([]agentrelease.SiteAgentVersion, 0, 25)
+	for i := 0; i < 24; i++ {
+		rows = append(rows, site("0.61.97"))
+	}
+	rows = append(rows, site("9.9.9"))
+
+	summary := rollupFor(t, "", rows)
+	assertSummary(t, summary, "9.9.9", agentrelease.ReferenceSourceFleet,
+		agentrelease.Counts{Current: 1, Outdated: 24})
+}
+
+// TestFleetRollup_PreReleaseNeverBecomesTheReference: a pre-release or
+// build-tagged version is by definition not the release the fleet is expected
+// to be on, so it is never eligible to BE the reference (the site running it
+// is still classified, and comes out current because it is ahead). Unlike a
+// corroboration count, this exclusion cannot suppress a legitimate stable
+// rollout, because a stable release carries no such suffix.
+func TestFleetRollup_PreReleaseNeverBecomesTheReference(t *testing.T) {
+	for _, outlier := range []string{"0.62.0-rc.1", "0.62.0+build.7"} {
+		t.Run(outlier, func(t *testing.T) {
+			// Exactly one site on the stable version, so this also proves the
+			// exclusion is not doing its job by accident via a headcount: the
+			// lone stable 0.61.97 wins over the pre-release above it.
+			rows := []agentrelease.SiteAgentVersion{site("0.61.97"), site(outlier)}
+			summary := rollupFor(t, "", rows)
+			assertSummary(t, summary, "0.61.97", agentrelease.ReferenceSourceFleet,
+				agentrelease.Counts{Current: 2})
+		})
+	}
+}
+
+// TestFleetRollup_OnlyPreReleasesIsSourceNone: with nothing but pre-releases in
+// the fleet there is no version anyone should be told to move to, so the honest
+// answer is no reference at all rather than promoting a release candidate.
+func TestFleetRollup_OnlyPreReleasesIsSourceNone(t *testing.T) {
+	summary := rollupFor(t, "", []agentrelease.SiteAgentVersion{
+		site("0.62.0-rc.1"), site("0.62.0-rc.2"),
+	})
+	assertSummary(t, summary, "", agentrelease.ReferenceSourceNone,
+		agentrelease.Counts{Unknown: 2})
+}
+
+// TestFleetAgents_WireShapeCarriesReferenceSource proves the discriminator
+// reaches the wire on both paths, so the UI never has to infer the source
+// from an empty or sentinel version string. This is the exact payload GH
+// #255's reporter would now receive: latest_version "unknown" became a real
+// version, with reference_source saying where it came from.
+func TestFleetAgents_WireShapeCarriesReferenceSource(t *testing.T) {
+	type fleetResponse struct {
+		LatestVersion   string `json:"latest_version"`
+		ReferenceSource string `json:"reference_source"`
+		Counts          struct {
+			Current    int `json:"current"`
+			Outdated   int `json:"outdated"`
+			Unknown    int `json:"unknown"`
+			Ineligible int `json:"ineligible"`
+		} `json:"counts"`
+	}
+
+	cases := []struct {
+		name       string
+		published  string
+		rows       []agentrelease.SiteAgentVersion
+		wantLatest string
+		wantSource string
+		wantCounts [4]int // current, outdated, unknown, ineligible
+	}{
+		{
+			name:       "published manifest",
+			published:  "0.61.97",
+			rows:       []agentrelease.SiteAgentVersion{site("0.61.90"), site("0.61.97")},
+			wantLatest: "0.61.97",
+			wantSource: "published",
+			wantCounts: [4]int{1, 1, 0, 0},
+		},
+		{
+			name:       "self hosted fallback",
+			published:  "",
+			rows:       []agentrelease.SiteAgentVersion{site("0.61.90"), site("0.61.97")},
+			wantLatest: "0.61.97",
+			wantSource: "fleet",
+			wantCounts: [4]int{1, 1, 0, 0},
+		},
+		{
+			name:       "nothing to compare against",
+			published:  "",
+			rows:       []agentrelease.SiteAgentVersion{site(""), site("")},
+			wantLatest: "unknown",
+			wantSource: "none",
+			wantCounts: [4]int{0, 0, 2, 0},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tenantID := uuid.New()
+			repo := &fakeSiteLister{byTenant: map[uuid.UUID][]agentrelease.SiteAgentVersion{tenantID: tc.rows}}
+			svc := agentrelease.NewService(repo, &fakeVersionReader{version: tc.published})
+			engine := newTestEngine(agentrelease.NewHandler(svc, false))
+			p := domain.Principal{
+				TenantID: tenantID,
+				Type:     domain.PrincipalUser,
+				UserID:   uuid.New(),
+				Role:     string(authz.RoleViewer),
+			}
+
+			w := doRequest(engine, http.MethodGet, "/api/v1/fleet/agents", p)
+			if w.Code != http.StatusOK {
+				t.Fatalf("GET /fleet/agents = %d; want 200, body=%s", w.Code, w.Body.String())
+			}
+			var resp fleetResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if resp.LatestVersion != tc.wantLatest {
+				t.Errorf("latest_version = %q; want %q", resp.LatestVersion, tc.wantLatest)
+			}
+			if resp.ReferenceSource != tc.wantSource {
+				t.Errorf("reference_source = %q; want %q", resp.ReferenceSource, tc.wantSource)
+			}
+			got := [4]int{resp.Counts.Current, resp.Counts.Outdated, resp.Counts.Unknown, resp.Counts.Ineligible}
+			if got != tc.wantCounts {
+				t.Errorf("counts = %v; want %v", got, tc.wantCounts)
+			}
+		})
+	}
+}

--- a/apps/api/internal/api/gen/oas_client_gen.go
+++ b/apps/api/internal/api/gen/oas_client_gen.go
@@ -816,8 +816,8 @@ type Invoker interface {
 	// CHAIN-SAFE: deleting a base or mid-chain increment that still has
 	// dependent later-generation increments is refused with 422
 	// (chain_has_dependents); delete the newer increments first. A
-	// running/pending snapshot is refused with 422 (snapshot_in_progress) —
-	// cancel it first. Requires operator+.
+	// running/pending snapshot is refused with 422 (snapshot_in_progress), cancel it first. Requires
+	// operator+.
 	//
 	// DELETE /api/v1/backups/{snapshotId}
 	DeleteBackup(ctx context.Context, params DeleteBackupParams) (DeleteBackupRes, error)
@@ -903,8 +903,8 @@ type Invoker interface {
 	// grace-window purge worker runs. `confirm_name` must exactly match the
 	// organisation's current name. When this is the caller's active org,
 	// their session is reassigned to another live membership, or cleared
-	// entirely (dropping to onboarding) if it was their last org —
-	// `active_tenant_id` in the response reflects the post-delete state.
+	// entirely (dropping to onboarding) if it was their last org, `active_tenant_id` in the response
+	// reflects the post-delete state.
 	// On a hosted instance an active paid subscription must be
 	// cancelled/downgraded first (`billing_active` 409).
 	//
@@ -1158,8 +1158,8 @@ type Invoker interface {
 	GetAdminAccountsTenancy(ctx context.Context, params GetAdminAccountsTenancyParams) (GetAdminAccountsTenancyRes, error)
 	// GetAdminRevenue invokes getAdminRevenue operation.
 	//
-	// Local-state-only revenue view derived from tenants + billing_events —
-	// zero payment-provider API calls. Requires is_superadmin=true.
+	// Local-state-only revenue view derived from tenants + billing_events, zero payment-provider API
+	// calls. Requires is_superadmin=true.
 	//
 	// GET /api/v1/admin/revenue
 	GetAdminRevenue(ctx context.Context) (GetAdminRevenueRes, error)
@@ -1343,11 +1343,16 @@ type Invoker interface {
 	// GetFleetAgentVersions invokes getFleetAgentVersions operation.
 	//
 	// Per-site {site_id, site_name, agent_version, status} plus fleet-wide
-	// counts, classified against the currently published agent version.
-	// status is one of current | outdated | unknown | ineligible.
+	// counts, classified against a single reference version. That reference
+	// is the published agent version when the release manifest can be read,
+	// and otherwise the newest well-formed agent version present in this
+	// tenant's own fleet, which is what a self-hosted install (whose object
+	// storage never receives the release pipeline's manifest) gets.
+	// reference_source names which of the two, or "none" when neither was
+	// available. status is one of current | outdated | unknown | ineligible.
 	// "unknown" covers a site that has never reported agent_version, a
 	// malformed/unparseable version on either side of the comparison, or a
-	// currently-unreadable published-version manifest; never a false
+	// reference_source of "none"; never a false
 	// "outdated". "ineligible" is a site that cannot self-update at all:
 	// today that is the public plugin-directory build, which ships without
 	// the self-updater and is upgraded by the plugin directory instead.
@@ -2353,8 +2358,8 @@ type Invoker interface {
 	// Large files bypass the CP's response path entirely — only the
 	// presigned URL is returned in the 200 body.
 	// A `file_transfers` row is persisted for audit and GC tracking.
-	// **Sensitive-path gate (T6):** same rules as `readSiteFileContent` —
-	// owner-level permission required; the attempt is always audited.
+	// **Sensitive-path gate (T6):** same rules as `readSiteFileContent`, owner-level permission required;
+	//  the attempt is always audited.
 	// Returns `503 storage_not_configured` when object storage is not
 	// configured (self-hosted deployments without S3).
 	// The feature must be explicitly enabled per site. Returns
@@ -3289,8 +3294,8 @@ type Invoker interface {
 	// `403 insufficient_permission` and the denial is audited at elevated
 	// severity. The agent independently enforces its executable deny-list
 	// regardless.
-	// **Sensitive-file gate (T6):** Same as above for `confirm_sensitive=true`
-	// — requires owner (`site.files.write_code`) and is audited at elevated
+	// **Sensitive-file gate (T6):** Same as above for `confirm_sensitive=true`, requires owner (`site.
+	// files.write_code`) and is audited at elevated
 	// severity on both success and denial.
 	// Requires `site.files.write` permission (admin+).
 	//
@@ -11397,8 +11402,8 @@ func (c *Client) sendDeleteAdminUser(ctx context.Context, params DeleteAdminUser
 // CHAIN-SAFE: deleting a base or mid-chain increment that still has
 // dependent later-generation increments is refused with 422
 // (chain_has_dependents); delete the newer increments first. A
-// running/pending snapshot is refused with 422 (snapshot_in_progress) —
-// cancel it first. Requires operator+.
+// running/pending snapshot is refused with 422 (snapshot_in_progress), cancel it first. Requires
+// operator+.
 //
 // DELETE /api/v1/backups/{snapshotId}
 func (c *Client) DeleteBackup(ctx context.Context, params DeleteBackupParams) (DeleteBackupRes, error) {
@@ -12413,8 +12418,8 @@ func (c *Client) sendDeleteMember(ctx context.Context, params DeleteMemberParams
 // grace-window purge worker runs. `confirm_name` must exactly match the
 // organisation's current name. When this is the caller's active org,
 // their session is reassigned to another live membership, or cleared
-// entirely (dropping to onboarding) if it was their last org —
-// `active_tenant_id` in the response reflects the post-delete state.
+// entirely (dropping to onboarding) if it was their last org, `active_tenant_id` in the response
+// reflects the post-delete state.
 // On a hosted instance an active paid subscription must be
 // cancelled/downgraded first (`billing_active` 409).
 //
@@ -15473,8 +15478,8 @@ func (c *Client) sendGetAdminAccountsTenancy(ctx context.Context, params GetAdmi
 
 // GetAdminRevenue invokes getAdminRevenue operation.
 //
-// Local-state-only revenue view derived from tenants + billing_events —
-// zero payment-provider API calls. Requires is_superadmin=true.
+// Local-state-only revenue view derived from tenants + billing_events, zero payment-provider API
+// calls. Requires is_superadmin=true.
 //
 // GET /api/v1/admin/revenue
 func (c *Client) GetAdminRevenue(ctx context.Context) (GetAdminRevenueRes, error) {
@@ -17584,11 +17589,16 @@ func (c *Client) sendGetEmailNotifySettings(ctx context.Context) (res GetEmailNo
 // GetFleetAgentVersions invokes getFleetAgentVersions operation.
 //
 // Per-site {site_id, site_name, agent_version, status} plus fleet-wide
-// counts, classified against the currently published agent version.
-// status is one of current | outdated | unknown | ineligible.
+// counts, classified against a single reference version. That reference
+// is the published agent version when the release manifest can be read,
+// and otherwise the newest well-formed agent version present in this
+// tenant's own fleet, which is what a self-hosted install (whose object
+// storage never receives the release pipeline's manifest) gets.
+// reference_source names which of the two, or "none" when neither was
+// available. status is one of current | outdated | unknown | ineligible.
 // "unknown" covers a site that has never reported agent_version, a
 // malformed/unparseable version on either side of the comparison, or a
-// currently-unreadable published-version manifest; never a false
+// reference_source of "none"; never a false
 // "outdated". "ineligible" is a site that cannot self-update at all:
 // today that is the public plugin-directory build, which ships without
 // the self-updater and is upgraded by the plugin directory instead.
@@ -30443,8 +30453,10 @@ func (c *Client) sendPreloadCache(ctx context.Context, params PreloadCacheParams
 // Large files bypass the CP's response path entirely — only the
 // presigned URL is returned in the 200 body.
 // A `file_transfers` row is persisted for audit and GC tracking.
-// **Sensitive-path gate (T6):** same rules as `readSiteFileContent` —
-// owner-level permission required; the attempt is always audited.
+// **Sensitive-path gate (T6):** same rules as `readSiteFileContent`, owner-level permission required;
+//
+//	the attempt is always audited.
+//
 // Returns `503 storage_not_configured` when object storage is not
 // configured (self-hosted deployments without S3).
 // The feature must be explicitly enabled per site. Returns
@@ -39745,8 +39757,8 @@ func (c *Client) sendVerifySiteActivity(ctx context.Context, params VerifySiteAc
 // `403 insufficient_permission` and the denial is audited at elevated
 // severity. The agent independently enforces its executable deny-list
 // regardless.
-// **Sensitive-file gate (T6):** Same as above for `confirm_sensitive=true`
-// — requires owner (`site.files.write_code`) and is audited at elevated
+// **Sensitive-file gate (T6):** Same as above for `confirm_sensitive=true`, requires owner (`site.
+// files.write_code`) and is audited at elevated
 // severity on both success and denial.
 // Requires `site.files.write` permission (admin+).
 //

--- a/apps/api/internal/api/gen/oas_handlers_gen.go
+++ b/apps/api/internal/api/gen/oas_handlers_gen.go
@@ -13416,8 +13416,8 @@ func (s *Server) handleDeleteAdminUserRequest(args [1]string, argsEscaped bool, 
 // CHAIN-SAFE: deleting a base or mid-chain increment that still has
 // dependent later-generation increments is refused with 422
 // (chain_has_dependents); delete the newer increments first. A
-// running/pending snapshot is refused with 422 (snapshot_in_progress) —
-// cancel it first. Requires operator+.
+// running/pending snapshot is refused with 422 (snapshot_in_progress), cancel it first. Requires
+// operator+.
 //
 // DELETE /api/v1/backups/{snapshotId}
 func (s *Server) handleDeleteBackupRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
@@ -14930,8 +14930,8 @@ func (s *Server) handleDeleteMemberRequest(args [1]string, argsEscaped bool, w h
 // grace-window purge worker runs. `confirm_name` must exactly match the
 // organisation's current name. When this is the caller's active org,
 // their session is reassigned to another live membership, or cleared
-// entirely (dropping to onboarding) if it was their last org —
-// `active_tenant_id` in the response reflects the post-delete state.
+// entirely (dropping to onboarding) if it was their last org, `active_tenant_id` in the response
+// reflects the post-delete state.
 // On a hosted instance an active paid subscription must be
 // cancelled/downgraded first (`billing_active` 409).
 //
@@ -19471,8 +19471,8 @@ func (s *Server) handleGetAdminAccountsTenancyRequest(args [0]string, argsEscape
 
 // handleGetAdminRevenueRequest handles getAdminRevenue operation.
 //
-// Local-state-only revenue view derived from tenants + billing_events —
-// zero payment-provider API calls. Requires is_superadmin=true.
+// Local-state-only revenue view derived from tenants + billing_events, zero payment-provider API
+// calls. Requires is_superadmin=true.
 //
 // GET /api/v1/admin/revenue
 func (s *Server) handleGetAdminRevenueRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
@@ -22686,11 +22686,16 @@ func (s *Server) handleGetEmailNotifySettingsRequest(args [0]string, argsEscaped
 // handleGetFleetAgentVersionsRequest handles getFleetAgentVersions operation.
 //
 // Per-site {site_id, site_name, agent_version, status} plus fleet-wide
-// counts, classified against the currently published agent version.
-// status is one of current | outdated | unknown | ineligible.
+// counts, classified against a single reference version. That reference
+// is the published agent version when the release manifest can be read,
+// and otherwise the newest well-formed agent version present in this
+// tenant's own fleet, which is what a self-hosted install (whose object
+// storage never receives the release pipeline's manifest) gets.
+// reference_source names which of the two, or "none" when neither was
+// available. status is one of current | outdated | unknown | ineligible.
 // "unknown" covers a site that has never reported agent_version, a
 // malformed/unparseable version on either side of the comparison, or a
-// currently-unreadable published-version manifest; never a false
+// reference_source of "none"; never a false
 // "outdated". "ineligible" is a site that cannot self-update at all:
 // today that is the public plugin-directory build, which ships without
 // the self-updater and is upgraded by the plugin directory instead.
@@ -39989,8 +39994,10 @@ func (s *Server) handlePreloadCacheRequest(args [1]string, argsEscaped bool, w h
 // Large files bypass the CP's response path entirely — only the
 // presigned URL is returned in the 200 body.
 // A `file_transfers` row is persisted for audit and GC tracking.
-// **Sensitive-path gate (T6):** same rules as `readSiteFileContent` —
-// owner-level permission required; the attempt is always audited.
+// **Sensitive-path gate (T6):** same rules as `readSiteFileContent`, owner-level permission required;
+//
+//	the attempt is always audited.
+//
 // Returns `503 storage_not_configured` when object storage is not
 // configured (self-hosted deployments without S3).
 // The feature must be explicitly enabled per site. Returns
@@ -54516,8 +54523,8 @@ func (s *Server) handleVerifySiteActivityRequest(args [1]string, argsEscaped boo
 // `403 insufficient_permission` and the denial is audited at elevated
 // severity. The agent independently enforces its executable deny-list
 // regardless.
-// **Sensitive-file gate (T6):** Same as above for `confirm_sensitive=true`
-// — requires owner (`site.files.write_code`) and is audited at elevated
+// **Sensitive-file gate (T6):** Same as above for `confirm_sensitive=true`, requires owner (`site.
+// files.write_code`) and is audited at elevated
 // severity on both success and denial.
 // Requires `site.files.write` permission (admin+).
 //

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -51787,6 +51787,10 @@ func (s *FleetAgentVersions) encodeFields(e *jx.Encoder) {
 		e.Str(s.LatestVersion)
 	}
 	{
+		e.FieldStart("reference_source")
+		s.ReferenceSource.Encode(e)
+	}
+	{
 		e.FieldStart("counts")
 		s.Counts.Encode(e)
 	}
@@ -51798,12 +51802,20 @@ func (s *FleetAgentVersions) encodeFields(e *jx.Encoder) {
 		}
 		e.ArrEnd()
 	}
+	{
+		if s.SelfUpdateEnabled.Set {
+			e.FieldStart("self_update_enabled")
+			s.SelfUpdateEnabled.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfFleetAgentVersions = [3]string{
+var jsonFieldsNameOfFleetAgentVersions = [5]string{
 	0: "latest_version",
-	1: "counts",
-	2: "sites",
+	1: "reference_source",
+	2: "counts",
+	3: "sites",
+	4: "self_update_enabled",
 }
 
 // Decode decodes FleetAgentVersions from json.
@@ -51827,8 +51839,18 @@ func (s *FleetAgentVersions) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"latest_version\"")
 			}
-		case "counts":
+		case "reference_source":
 			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				if err := s.ReferenceSource.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"reference_source\"")
+			}
+		case "counts":
+			requiredBitSet[0] |= 1 << 2
 			if err := func() error {
 				if err := s.Counts.Decode(d); err != nil {
 					return err
@@ -51838,7 +51860,7 @@ func (s *FleetAgentVersions) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"counts\"")
 			}
 		case "sites":
-			requiredBitSet[0] |= 1 << 2
+			requiredBitSet[0] |= 1 << 3
 			if err := func() error {
 				s.Sites = make([]FleetAgentSite, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -51855,6 +51877,16 @@ func (s *FleetAgentVersions) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"sites\"")
 			}
+		case "self_update_enabled":
+			if err := func() error {
+				s.SelfUpdateEnabled.Reset()
+				if err := s.SelfUpdateEnabled.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"self_update_enabled\"")
+			}
 		default:
 			return d.Skip()
 		}
@@ -51865,7 +51897,7 @@ func (s *FleetAgentVersions) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000111,
+		0b00001111,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -51907,6 +51939,48 @@ func (s *FleetAgentVersions) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *FleetAgentVersions) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes FleetAgentVersionsReferenceSource as json.
+func (s FleetAgentVersionsReferenceSource) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes FleetAgentVersionsReferenceSource from json.
+func (s *FleetAgentVersionsReferenceSource) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode FleetAgentVersionsReferenceSource to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch FleetAgentVersionsReferenceSource(v) {
+	case FleetAgentVersionsReferenceSourcePublished:
+		*s = FleetAgentVersionsReferenceSourcePublished
+	case FleetAgentVersionsReferenceSourceFleet:
+		*s = FleetAgentVersionsReferenceSourceFleet
+	case FleetAgentVersionsReferenceSourceNone:
+		*s = FleetAgentVersionsReferenceSourceNone
+	default:
+		*s = FleetAgentVersionsReferenceSource(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s FleetAgentVersionsReferenceSource) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *FleetAgentVersionsReferenceSource) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -684,8 +684,8 @@ type AdminAccountListItem struct {
 	MrrCents     int64                          `json:"mrr_cents"`
 	SitesUsed    int                            `json:"sites_used"`
 	SitesCap     int                            `json:"sites_cap"`
-	// A v1 APPROXIMATION (SUM of backup_chunks.size for the tenant) — does not yet distinguish
-	// CP-managed from BYO-storage destinations.
+	// A v1 APPROXIMATION (SUM of backup_chunks.size for the tenant), does not yet distinguish CP-managed
+	// from BYO-storage destinations.
 	StorageUsedBytesApprox int64 `json:"storage_used_bytes_approx"`
 	// 0 for the free tier (BYO-storage only; no CP-managed cap to approach).
 	StorageCapBytes int64       `json:"storage_cap_bytes"`
@@ -3495,7 +3495,7 @@ type AgentActivityIngestRequestEventsItem struct {
 	ActorLogin  OptString `json:"actor_login"`
 	ActorIP     OptString `json:"actor_ip"`
 	Summary     OptString `json:"summary"`
-	// Verbatim wire bytes as emitted by the agent's wp_json_encode — hashed exactly as sent, never
+	// Verbatim wire bytes as emitted by the agent's wp_json_encode, hashed exactly as sent, never
 	// re-serialized.
 	Meta       *AgentActivityIngestRequestEventsItemMeta `json:"meta"`
 	PrevHash   string                                    `json:"prev_hash"`
@@ -3633,7 +3633,7 @@ func (s *AgentActivityIngestRequestEventsItem) SetOccurredAt(val time.Time) {
 	s.OccurredAt = val
 }
 
-// Verbatim wire bytes as emitted by the agent's wp_json_encode — hashed exactly as sent, never
+// Verbatim wire bytes as emitted by the agent's wp_json_encode, hashed exactly as sent, never
 // re-serialized.
 type AgentActivityIngestRequestEventsItemMeta struct{}
 
@@ -5064,7 +5064,8 @@ type AgentHeartbeatResult struct {
 	Instructions []string `json:"instructions"`
 	// Present with a `["revoke"]` instruction: a short-lived signed Ed25519
 	// JWT (aud=site_id, cmd="revoke") the agent MUST verify with the CP
-	// public key before any self-teardown (ADR-040 addendum). Fail-closed, // an absent/invalid token must be a no-op.
+	// public key before any self-teardown (ADR-040 addendum). Fail-closed, an absent/invalid token must
+	// be a no-op.
 	RevokeToken OptString `json:"revoke_token"`
 }
 
@@ -9855,7 +9856,7 @@ func (s *BillingSiteMeter) SetLimit(val int) {
 // Ref: #/components/schemas/BillingSummary
 type BillingSummary struct {
 	// The tenant's SUBSCRIBED tier (tenants.plan). A canceled subscription resolves this to "free"
-	// (non-destructive downgrade — see plan_status).
+	// (non-destructive downgrade, see plan_status).
 	Plan             BillingSummaryPlan       `json:"plan"`
 	PlanStatus       BillingSummaryPlanStatus `json:"plan_status"`
 	CurrentPeriodEnd OptDateTime              `json:"current_period_end"`
@@ -9943,7 +9944,7 @@ func (s *BillingSummary) SetPortalAvailable(val bool) {
 func (*BillingSummary) getBillingRes() {}
 
 // The tenant's SUBSCRIBED tier (tenants.plan). A canceled subscription resolves this to "free"
-// (non-destructive downgrade — see plan_status).
+// (non-destructive downgrade, see plan_status).
 type BillingSummaryPlan string
 
 const (
@@ -18326,15 +18327,42 @@ func (s *FleetAgentSiteStatus) UnmarshalText(data []byte) error {
 
 // Ref: #/components/schemas/FleetAgentVersions
 type FleetAgentVersions struct {
-	// The currently published agent version, or "unknown" when it cannot be determined right now.
-	LatestVersion string           `json:"latest_version"`
-	Counts        FleetAgentCounts `json:"counts"`
-	Sites         []FleetAgentSite `json:"sites"`
+	// The single version every site in sites was classified against, or "unknown" when there was none.
+	// Read it together with reference_source, which says where it came from: under "fleet" this is the
+	// newest agent version seen in THIS tenant's fleet, not the newest agent that exists, and presenting
+	// it as the latter would overclaim.
+	LatestVersion string `json:"latest_version"`
+	// Where latest_version came from. "published": the release channel pointer manifest
+	// (agent-releases/latest.json), so "current" means the site runs the newest agent that exists.
+	// "fleet": the manifest could not be read, so the newest well-formed agent version present in this
+	// tenant's own fleet was used instead; "current" then means only that no newer agent has been seen
+	// in this fleet. A self-hosted install has its own object storage and never receives the release
+	// pipeline's manifest, so this is its normal steady state. "none": nothing safe to compare against,
+	// so every site is "unknown". That arises two ways, and they are deliberately not distinguished in
+	// this field: an install that has never read a manifest and has no well-formed agent version
+	// anywhere in its fleet, or an install whose manifest WAS readable but has been unreadable for
+	// longer than the staleness bound. The second case does not fall back to "fleet", because "this
+	// install has a channel and it is currently unreachable" must not be answered with fleet-derived
+	// data.
+	ReferenceSource FleetAgentVersionsReferenceSource `json:"reference_source"`
+	Counts          FleetAgentCounts                  `json:"counts"`
+	Sites           []FleetAgentSite                  `json:"sites"`
+	// Whether the control plane's agent self-update channel (the fleet-wide
+	// WPMGR_UPDATE_AGENT_SELF_UPDATE_ENABLED kill switch) is currently turned on for this instance.
+	// Absent or false while the channel ships dark. The frontend uses this, together with the operator's
+	// role, to decide whether the "Update WPMgr agent" bulk action is shown at all, rather than let an
+	// operator arm a run the control plane will only refuse.
+	SelfUpdateEnabled OptBool `json:"self_update_enabled"`
 }
 
 // GetLatestVersion returns the value of LatestVersion.
 func (s *FleetAgentVersions) GetLatestVersion() string {
 	return s.LatestVersion
+}
+
+// GetReferenceSource returns the value of ReferenceSource.
+func (s *FleetAgentVersions) GetReferenceSource() FleetAgentVersionsReferenceSource {
+	return s.ReferenceSource
 }
 
 // GetCounts returns the value of Counts.
@@ -18347,9 +18375,19 @@ func (s *FleetAgentVersions) GetSites() []FleetAgentSite {
 	return s.Sites
 }
 
+// GetSelfUpdateEnabled returns the value of SelfUpdateEnabled.
+func (s *FleetAgentVersions) GetSelfUpdateEnabled() OptBool {
+	return s.SelfUpdateEnabled
+}
+
 // SetLatestVersion sets the value of LatestVersion.
 func (s *FleetAgentVersions) SetLatestVersion(val string) {
 	s.LatestVersion = val
+}
+
+// SetReferenceSource sets the value of ReferenceSource.
+func (s *FleetAgentVersions) SetReferenceSource(val FleetAgentVersionsReferenceSource) {
+	s.ReferenceSource = val
 }
 
 // SetCounts sets the value of Counts.
@@ -18362,7 +18400,72 @@ func (s *FleetAgentVersions) SetSites(val []FleetAgentSite) {
 	s.Sites = val
 }
 
+// SetSelfUpdateEnabled sets the value of SelfUpdateEnabled.
+func (s *FleetAgentVersions) SetSelfUpdateEnabled(val OptBool) {
+	s.SelfUpdateEnabled = val
+}
+
 func (*FleetAgentVersions) getFleetAgentVersionsRes() {}
+
+// Where latest_version came from. "published": the release channel pointer manifest
+// (agent-releases/latest.json), so "current" means the site runs the newest agent that exists.
+// "fleet": the manifest could not be read, so the newest well-formed agent version present in this
+// tenant's own fleet was used instead; "current" then means only that no newer agent has been seen
+// in this fleet. A self-hosted install has its own object storage and never receives the release
+// pipeline's manifest, so this is its normal steady state. "none": nothing safe to compare against,
+// so every site is "unknown". That arises two ways, and they are deliberately not distinguished in
+// this field: an install that has never read a manifest and has no well-formed agent version
+// anywhere in its fleet, or an install whose manifest WAS readable but has been unreadable for
+// longer than the staleness bound. The second case does not fall back to "fleet", because "this
+// install has a channel and it is currently unreachable" must not be answered with fleet-derived
+// data.
+type FleetAgentVersionsReferenceSource string
+
+const (
+	FleetAgentVersionsReferenceSourcePublished FleetAgentVersionsReferenceSource = "published"
+	FleetAgentVersionsReferenceSourceFleet     FleetAgentVersionsReferenceSource = "fleet"
+	FleetAgentVersionsReferenceSourceNone      FleetAgentVersionsReferenceSource = "none"
+)
+
+// AllValues returns all FleetAgentVersionsReferenceSource values.
+func (FleetAgentVersionsReferenceSource) AllValues() []FleetAgentVersionsReferenceSource {
+	return []FleetAgentVersionsReferenceSource{
+		FleetAgentVersionsReferenceSourcePublished,
+		FleetAgentVersionsReferenceSourceFleet,
+		FleetAgentVersionsReferenceSourceNone,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s FleetAgentVersionsReferenceSource) MarshalText() ([]byte, error) {
+	switch s {
+	case FleetAgentVersionsReferenceSourcePublished:
+		return []byte(s), nil
+	case FleetAgentVersionsReferenceSourceFleet:
+		return []byte(s), nil
+	case FleetAgentVersionsReferenceSourceNone:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *FleetAgentVersionsReferenceSource) UnmarshalText(data []byte) error {
+	switch FleetAgentVersionsReferenceSource(data) {
+	case FleetAgentVersionsReferenceSourcePublished:
+		*s = FleetAgentVersionsReferenceSourcePublished
+		return nil
+	case FleetAgentVersionsReferenceSourceFleet:
+		*s = FleetAgentVersionsReferenceSourceFleet
+		return nil
+	case FleetAgentVersionsReferenceSourceNone:
+		*s = FleetAgentVersionsReferenceSourceNone
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
 
 // Ref: #/components/schemas/FleetIncidentDetail
 type FleetIncidentDetail struct {
@@ -21922,7 +22025,8 @@ type Me struct {
 	ManagedStorageAllowed OptBool `json:"managed_storage_allowed"`
 	// The M16 Phase 0 "sign up into a plan" hint captured at registration (RegisterRequest.plan),
 	// single-use: present ONLY in the direct response to POST /auth/verify-email (read off the
-	// just-consumed verification token) or the first-run bootstrap response of POST /auth/register, // never on GET /auth/me or any other Me-returning response. The frontend uses this to auto-start
+	// just-consumed verification token) or the first-run bootstrap response of POST /auth/register —
+	// never on GET /auth/me or any other Me-returning response. The frontend uses this to auto-start
 	// checkout right after the account is verified. Absent means no intent was captured (free signup,
 	// self-hosted instance, or a resend/login/OIDC path that never carries one).
 	DesiredPlan OptMeDesiredPlan `json:"desired_plan"`
@@ -22028,7 +22132,8 @@ func (*Me) verifyEmailRes()             {}
 
 // The M16 Phase 0 "sign up into a plan" hint captured at registration (RegisterRequest.plan),
 // single-use: present ONLY in the direct response to POST /auth/verify-email (read off the
-// just-consumed verification token) or the first-run bootstrap response of POST /auth/register, // never on GET /auth/me or any other Me-returning response. The frontend uses this to auto-start
+// just-consumed verification token) or the first-run bootstrap response of POST /auth/register —
+// never on GET /auth/me or any other Me-returning response. The frontend uses this to auto-start
 // checkout right after the account is verified. Absent means no intent was captured (free signup,
 // self-hosted instance, or a resend/login/OIDC path that never carries one).
 type MeDesiredPlan string
@@ -35788,7 +35893,8 @@ type PutEmailConnectionNotFound Error
 
 func (*PutEmailConnectionNotFound) putEmailConnectionRes() {}
 
-// Request body for PUT /sites/{siteId}/email/connections/{connKey}. All fields are optional, // omitted fields are unchanged (PATCH semantics within a PUT envelope). Omitting `secret` preserves
+// Request body for PUT /sites/{siteId}/email/connections/{connKey}. All fields are optional —
+// omitted fields are unchanged (PATCH semantics within a PUT envelope). Omitting `secret` preserves
 // the existing stored credential (nil-sentinel pattern).
 // Ref: #/components/schemas/PutEmailConnectionRequest
 type PutEmailConnectionRequest struct {
@@ -45239,7 +45345,7 @@ func (s *SiteShareList) SetItems(val []SiteShare) {
 func (*SiteShareList) listSharedWithMeRes() {}
 func (*SiteShareList) listSiteSharesRes()   {}
 
-// Role a site collaborator holds. Subset of the full org Role enum, // site shares cannot be owner.
+// Role a site collaborator holds. Subset of the full org Role enum, site shares cannot be owner.
 // Ref: #/components/schemas/SiteShareRole
 type SiteShareRole string
 

--- a/apps/api/internal/api/gen/oas_server_gen.go
+++ b/apps/api/internal/api/gen/oas_server_gen.go
@@ -796,8 +796,8 @@ type Handler interface {
 	// CHAIN-SAFE: deleting a base or mid-chain increment that still has
 	// dependent later-generation increments is refused with 422
 	// (chain_has_dependents); delete the newer increments first. A
-	// running/pending snapshot is refused with 422 (snapshot_in_progress) —
-	// cancel it first. Requires operator+.
+	// running/pending snapshot is refused with 422 (snapshot_in_progress), cancel it first. Requires
+	// operator+.
 	//
 	// DELETE /api/v1/backups/{snapshotId}
 	DeleteBackup(ctx context.Context, params DeleteBackupParams) (DeleteBackupRes, error)
@@ -883,8 +883,8 @@ type Handler interface {
 	// grace-window purge worker runs. `confirm_name` must exactly match the
 	// organisation's current name. When this is the caller's active org,
 	// their session is reassigned to another live membership, or cleared
-	// entirely (dropping to onboarding) if it was their last org —
-	// `active_tenant_id` in the response reflects the post-delete state.
+	// entirely (dropping to onboarding) if it was their last org, `active_tenant_id` in the response
+	// reflects the post-delete state.
 	// On a hosted instance an active paid subscription must be
 	// cancelled/downgraded first (`billing_active` 409).
 	//
@@ -1138,8 +1138,8 @@ type Handler interface {
 	GetAdminAccountsTenancy(ctx context.Context, params GetAdminAccountsTenancyParams) (GetAdminAccountsTenancyRes, error)
 	// GetAdminRevenue implements getAdminRevenue operation.
 	//
-	// Local-state-only revenue view derived from tenants + billing_events —
-	// zero payment-provider API calls. Requires is_superadmin=true.
+	// Local-state-only revenue view derived from tenants + billing_events, zero payment-provider API
+	// calls. Requires is_superadmin=true.
 	//
 	// GET /api/v1/admin/revenue
 	GetAdminRevenue(ctx context.Context) (GetAdminRevenueRes, error)
@@ -1323,11 +1323,16 @@ type Handler interface {
 	// GetFleetAgentVersions implements getFleetAgentVersions operation.
 	//
 	// Per-site {site_id, site_name, agent_version, status} plus fleet-wide
-	// counts, classified against the currently published agent version.
-	// status is one of current | outdated | unknown | ineligible.
+	// counts, classified against a single reference version. That reference
+	// is the published agent version when the release manifest can be read,
+	// and otherwise the newest well-formed agent version present in this
+	// tenant's own fleet, which is what a self-hosted install (whose object
+	// storage never receives the release pipeline's manifest) gets.
+	// reference_source names which of the two, or "none" when neither was
+	// available. status is one of current | outdated | unknown | ineligible.
 	// "unknown" covers a site that has never reported agent_version, a
 	// malformed/unparseable version on either side of the comparison, or a
-	// currently-unreadable published-version manifest; never a false
+	// reference_source of "none"; never a false
 	// "outdated". "ineligible" is a site that cannot self-update at all:
 	// today that is the public plugin-directory build, which ships without
 	// the self-updater and is upgraded by the plugin directory instead.
@@ -2333,8 +2338,8 @@ type Handler interface {
 	// Large files bypass the CP's response path entirely — only the
 	// presigned URL is returned in the 200 body.
 	// A `file_transfers` row is persisted for audit and GC tracking.
-	// **Sensitive-path gate (T6):** same rules as `readSiteFileContent` —
-	// owner-level permission required; the attempt is always audited.
+	// **Sensitive-path gate (T6):** same rules as `readSiteFileContent`, owner-level permission required;
+	//  the attempt is always audited.
 	// Returns `503 storage_not_configured` when object storage is not
 	// configured (self-hosted deployments without S3).
 	// The feature must be explicitly enabled per site. Returns
@@ -3269,8 +3274,8 @@ type Handler interface {
 	// `403 insufficient_permission` and the denial is audited at elevated
 	// severity. The agent independently enforces its executable deny-list
 	// regardless.
-	// **Sensitive-file gate (T6):** Same as above for `confirm_sensitive=true`
-	// — requires owner (`site.files.write_code`) and is audited at elevated
+	// **Sensitive-file gate (T6):** Same as above for `confirm_sensitive=true`, requires owner (`site.
+	// files.write_code`) and is audited at elevated
 	// severity on both success and denial.
 	// Requires `site.files.write` permission (admin+).
 	//

--- a/apps/api/internal/api/gen/oas_unimplemented_gen.go
+++ b/apps/api/internal/api/gen/oas_unimplemented_gen.go
@@ -1046,8 +1046,8 @@ func (UnimplementedHandler) DeleteAdminUser(ctx context.Context, params DeleteAd
 // CHAIN-SAFE: deleting a base or mid-chain increment that still has
 // dependent later-generation increments is refused with 422
 // (chain_has_dependents); delete the newer increments first. A
-// running/pending snapshot is refused with 422 (snapshot_in_progress) —
-// cancel it first. Requires operator+.
+// running/pending snapshot is refused with 422 (snapshot_in_progress), cancel it first. Requires
+// operator+.
 //
 // DELETE /api/v1/backups/{snapshotId}
 func (UnimplementedHandler) DeleteBackup(ctx context.Context, params DeleteBackupParams) (r DeleteBackupRes, _ error) {
@@ -1163,8 +1163,8 @@ func (UnimplementedHandler) DeleteMember(ctx context.Context, params DeleteMembe
 // grace-window purge worker runs. `confirm_name` must exactly match the
 // organisation's current name. When this is the caller's active org,
 // their session is reassigned to another live membership, or cleared
-// entirely (dropping to onboarding) if it was their last org —
-// `active_tenant_id` in the response reflects the post-delete state.
+// entirely (dropping to onboarding) if it was their last org, `active_tenant_id` in the response
+// reflects the post-delete state.
 // On a hosted instance an active paid subscription must be
 // cancelled/downgraded first (`billing_active` 409).
 //
@@ -1508,8 +1508,8 @@ func (UnimplementedHandler) GetAdminAccountsTenancy(ctx context.Context, params 
 
 // GetAdminRevenue implements getAdminRevenue operation.
 //
-// Local-state-only revenue view derived from tenants + billing_events —
-// zero payment-provider API calls. Requires is_superadmin=true.
+// Local-state-only revenue view derived from tenants + billing_events, zero payment-provider API
+// calls. Requires is_superadmin=true.
 //
 // GET /api/v1/admin/revenue
 func (UnimplementedHandler) GetAdminRevenue(ctx context.Context) (r GetAdminRevenueRes, _ error) {
@@ -1762,11 +1762,16 @@ func (UnimplementedHandler) GetEmailNotifySettings(ctx context.Context) (r GetEm
 // GetFleetAgentVersions implements getFleetAgentVersions operation.
 //
 // Per-site {site_id, site_name, agent_version, status} plus fleet-wide
-// counts, classified against the currently published agent version.
-// status is one of current | outdated | unknown | ineligible.
+// counts, classified against a single reference version. That reference
+// is the published agent version when the release manifest can be read,
+// and otherwise the newest well-formed agent version present in this
+// tenant's own fleet, which is what a self-hosted install (whose object
+// storage never receives the release pipeline's manifest) gets.
+// reference_source names which of the two, or "none" when neither was
+// available. status is one of current | outdated | unknown | ineligible.
 // "unknown" covers a site that has never reported agent_version, a
 // malformed/unparseable version on either side of the comparison, or a
-// currently-unreadable published-version manifest; never a false
+// reference_source of "none"; never a false
 // "outdated". "ineligible" is a site that cannot self-update at all:
 // today that is the public plugin-directory build, which ships without
 // the self-updater and is upgraded by the plugin directory instead.
@@ -3126,8 +3131,10 @@ func (UnimplementedHandler) PreloadCache(ctx context.Context, params PreloadCach
 // Large files bypass the CP's response path entirely — only the
 // presigned URL is returned in the 200 body.
 // A `file_transfers` row is persisted for audit and GC tracking.
-// **Sensitive-path gate (T6):** same rules as `readSiteFileContent` —
-// owner-level permission required; the attempt is always audited.
+// **Sensitive-path gate (T6):** same rules as `readSiteFileContent`, owner-level permission required;
+//
+//	the attempt is always audited.
+//
 // Returns `503 storage_not_configured` when object storage is not
 // configured (self-hosted deployments without S3).
 // The feature must be explicitly enabled per site. Returns
@@ -4344,8 +4351,8 @@ func (UnimplementedHandler) VerifySiteActivity(ctx context.Context, params Verif
 // `403 insufficient_permission` and the denial is audited at elevated
 // severity. The agent independently enforces its executable deny-list
 // regardless.
-// **Sensitive-file gate (T6):** Same as above for `confirm_sensitive=true`
-// — requires owner (`site.files.write_code`) and is audited at elevated
+// **Sensitive-file gate (T6):** Same as above for `confirm_sensitive=true`, requires owner (`site.
+// files.write_code`) and is audited at elevated
 // severity on both success and denial.
 // Requires `site.files.write` permission (admin+).
 //

--- a/apps/api/internal/api/gen/oas_validators_gen.go
+++ b/apps/api/internal/api/gen/oas_validators_gen.go
@@ -6206,6 +6206,17 @@ func (s *FleetAgentVersions) Validate() error {
 
 	var failures []validate.FieldError
 	if err := func() error {
+		if err := s.ReferenceSource.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "reference_source",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if s.Sites == nil {
 			return errors.New("nil is invalid value")
 		}
@@ -6237,6 +6248,19 @@ func (s *FleetAgentVersions) Validate() error {
 		return &validate.Error{Fields: failures}
 	}
 	return nil
+}
+
+func (s FleetAgentVersionsReferenceSource) Validate() error {
+	switch s {
+	case "published":
+		return nil
+	case "fleet":
+		return nil
+	case "none":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
 }
 
 func (s *FleetIncidentDetail) Validate() error {

--- a/apps/api/tests/openapi_route_coverage_test.go
+++ b/apps/api/tests/openapi_route_coverage_test.go
@@ -301,7 +301,7 @@ func buildFullEngine(t *testing.T, pool *db.Pool) *gin.Engine {
 	vulnH := vuln.NewHandler(vuln.NewService(vuln.NewRepo(pool), pool, nil, nil, nil, logger), nil, auditRec)
 
 	// --- agent-freshness dashboard (read-only) ---------------------------------
-	agentReleaseH := agentrelease.NewHandler(agentrelease.NewService(agentrelease.NewRepo(pool), agentrelease.NewReader(nil, 0)))
+	agentReleaseH := agentrelease.NewHandler(agentrelease.NewService(agentrelease.NewRepo(pool), agentrelease.NewReader(nil, 0)), false)
 
 	// --- updates ---------------------------------------------------------------
 	updateHub := update.NewHub()

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,26 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.99",
+    date: "2026-07-28",
+    summary: "Self-hosted installs no longer show every site's agent version as an unreadable \"unknown\".",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Self-hosted installs could show the Agent version card as \"0 of 24 sites on unknown, 24 unknown\", with the status filter looking like it did nothing (GH #255). The fleet agent-version feature compares each site against the currently published version, which only the hosted service ever receives, so a self-hosted install had nothing to compare against and every site fell back to unknown. When there's no published version, self-hosted installs now compare against the newest agent version already running in that install's own fleet, clearly labeled as a fleet-relative comparison, and say so directly when there's genuinely nothing to compare against.",
+      },
+      {
+        tag: "Fixed",
+        text: "On the hosted service, a brief failure reading the published version used to get cached like a real one, which could briefly report every site as current when some were actually behind. The last known-good version is now kept across a brief failure, a failure retries quickly instead of sticking, and a version that has gone stale is no longer presented as current.",
+      },
+      {
+        tag: "Fixed",
+        text: "The switch that turns on the fleet-wide agent update from 0.61.98 wasn't reported to the dashboard, so the action stayed hidden even once an operator enabled it. It's now reported correctly; the feature still ships off by default.",
+      },
+    ],
+    featureLinks: [{ label: "Updates", href: "/features/updates/" }],
+  },
+  {
     version: "0.61.98",
     date: "2026-07-28",
     summary: "Update the WPMgr agent across the fleet from the dashboard, rolled out in waves and shipped turned off.",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.98 / open source",
+  badge: "v0.61.99 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/apps/web/src/components/status/agent-status-chip.test.tsx
+++ b/apps/web/src/components/status/agent-status-chip.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { AgentStatusChip } from "./agent-status-chip";
+
+// Adversarial-review finding: a "current" chip rendered identically whether
+// its reference version came from a published release or was merely the
+// newest agent this fleet happens to have seen, so a site could sit dozens
+// of releases behind the real latest and still show an unqualified green
+// "Current". These pin the exact copy for both cases so that overclaim
+// cannot silently come back.
+
+describe("AgentStatusChip", () => {
+  it("renders a bare Current for a published reference", () => {
+    render(
+      <AgentStatusChip status="current" version="0.12.0" referenceSource="published" />,
+    );
+    expect(screen.getByText("Current")).toBeInTheDocument();
+    expect(screen.queryByText("Current in fleet")).not.toBeInTheDocument();
+  });
+
+  it("relabels a fleet-derived Current instead of asserting it unqualified", () => {
+    render(
+      <AgentStatusChip status="current" version="0.12.0" referenceSource="fleet" />,
+    );
+    expect(screen.getByText("Current in fleet")).toBeInTheDocument();
+    expect(screen.queryByText(/^Current$/)).not.toBeInTheDocument();
+  });
+
+  it("attaches a title explaining the fleet reference on the qualified chip", () => {
+    render(
+      <AgentStatusChip status="current" version="0.12.0" referenceSource="fleet" />,
+    );
+    const chip = screen.getByText("Current in fleet").closest("span[title]");
+    expect(chip?.getAttribute("title")).toBe(
+      "Agent 0.12.0, current in fleet (newest seen in this fleet, not a published release)",
+    );
+  });
+
+  it("does not qualify outdated/unknown/ineligible statuses regardless of source", () => {
+    const statuses = ["outdated", "unknown", "ineligible"] as const;
+    for (const status of statuses) {
+      const { unmount } = render(
+        <AgentStatusChip status={status} version="0.9.0" referenceSource="fleet" />,
+      );
+      expect(screen.queryByText(/in fleet/)).not.toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it("treats an absent referenceSource the same as published (no qualifier)", () => {
+    render(<AgentStatusChip status="current" version="0.12.0" />);
+    expect(screen.getByText("Current")).toBeInTheDocument();
+    expect(screen.queryByText("Current in fleet")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/status/agent-status-chip.tsx
+++ b/apps/web/src/components/status/agent-status-chip.tsx
@@ -1,8 +1,10 @@
 import { cn } from "@/lib/utils";
+import type { FleetAgentVersions } from "@wpmgr/api";
 import {
   AGENT_STATUS_BG,
   AGENT_STATUS_ICON,
-  AGENT_STATUS_LABEL,
+  agentStatusDisplayLabel,
+  isFleetDerivedCurrent,
   type AgentStatus,
 } from "./agent-status";
 
@@ -10,24 +12,53 @@ export interface AgentStatusChipProps {
   status: AgentStatus;
   /** The site's raw last-reported agent_version, rendered as a mono suffix when present. */
   version?: string | null;
+  /**
+   * Where the reference version behind `status` came from (see
+   * FleetAgentVersions.reference_source). Omit only when the rollup itself
+   * is unavailable to the caller; treated the same as "published" (no
+   * qualifier) since that is the common case and there is nothing else to
+   * say without it.
+   */
+  referenceSource?: FleetAgentVersions["reference_source"];
   className?: string;
 }
 
 /**
- * AgentStatusChip: small pill for the WPMgr agent plugin's freshness
- * relative to the currently published release. Mirrors UpdateChip/
- * BackupChip's pill treatment so the Sites table's Agent column reads
- * consistently with its Updates and Backup neighbors.
+ * AgentStatusChip: small pill for the WPMgr agent plugin's per-site
+ * freshness classification (GET /api/v1/fleet/agents' `status`). Mirrors
+ * UpdateChip/BackupChip's pill treatment so the Sites table's Agent column
+ * reads consistently with its Updates and Backup neighbors.
+ *
+ * `status` alone is not the whole story: it was computed against whatever
+ * `latest_version` the rollup could find, and `referenceSource` says what
+ * that was. When it is "published" (the release channel manifest), "Current"
+ * really does mean "runs the newest agent that exists" and needs no
+ * qualifier. When it is "fleet" (no manifest was readable, so the newest
+ * agent_version already reported anywhere in this tenant's own fleet stood
+ * in for it, the normal steady state for a self-hosted install), a site can
+ * land in the "current" bucket while dozens of releases behind the real
+ * latest, so this renders "Current in fleet" instead of a bare "Current"
+ * and the title explains the reference. Every other status ("outdated",
+ * "unknown", "ineligible") already reads the same regardless of source and
+ * is left unchanged.
  */
 export function AgentStatusChip({
   status,
   version,
+  referenceSource,
   className,
 }: AgentStatusChipProps) {
   const Icon = AGENT_STATUS_ICON[status];
+  const fleetQualified = isFleetDerivedCurrent(status, referenceSource);
+  const label = agentStatusDisplayLabel(status, referenceSource);
+  const title = fleetQualified
+    ? `${version ? `Agent ${version}, ` : ""}current in fleet (newest seen in this fleet, not a published release)`
+    : version
+      ? `Agent ${version}`
+      : undefined;
   return (
     <span
-      title={version ? `Agent ${version}` : undefined}
+      title={title}
       className={cn(
         "inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium",
         AGENT_STATUS_BG[status],
@@ -35,7 +66,7 @@ export function AgentStatusChip({
       )}
     >
       <Icon aria-hidden="true" className="size-3" />
-      <span>{AGENT_STATUS_LABEL[status]}</span>
+      <span>{label}</span>
       {version ? (
         <span className="font-mono text-[10px] tabular-nums opacity-75">
           {version}

--- a/apps/web/src/components/status/agent-status.ts
+++ b/apps/web/src/components/status/agent-status.ts
@@ -1,4 +1,5 @@
 import { ArrowUpCircle, Ban, CheckCircle2, HelpCircle } from "lucide-react";
+import type { FleetAgentVersions } from "@wpmgr/api";
 
 // Shared status -> icon/label/tint maps for the agent-freshness classification.
 // Split from agent-status-chip.tsx (the component) so this module can export
@@ -35,3 +36,37 @@ export const AGENT_STATUS_ICON: Record<AgentStatus, typeof CheckCircle2> = {
   unknown: HelpCircle,
   ineligible: Ban,
 };
+
+/**
+ * True only for the case that overclaims if left unlabeled: status
+ * "current" classified against a reference that came from this tenant's own
+ * fleet (the newest agent_version any of its sites has reported) rather than
+ * the published release manifest. A site in this bucket can be "current"
+ * while dozens of releases behind the real latest agent build. See
+ * FleetAgentVersions.reference_source.
+ *
+ * "outdated" needs no equivalent qualifier: it stays true regardless of
+ * where the reference came from (a site behind the newest agent this fleet
+ * has seen is, at minimum, also behind whatever the real latest is).
+ */
+export function isFleetDerivedCurrent(
+  status: AgentStatus,
+  referenceSource: FleetAgentVersions["reference_source"] | undefined,
+): boolean {
+  return status === "current" && referenceSource === "fleet";
+}
+
+/**
+ * Display label for prose/tooltips (NOT the filter facet name, which stays
+ * AGENT_STATUS_LABEL so URL search params and filter derivation are
+ * unaffected). Returns "Current in fleet" for the fleet-derived "current"
+ * case per isFleetDerivedCurrent; every other status/source combination
+ * falls through to the plain AGENT_STATUS_LABEL.
+ */
+export function agentStatusDisplayLabel(
+  status: AgentStatus,
+  referenceSource: FleetAgentVersions["reference_source"] | undefined,
+): string {
+  if (isFleetDerivedCurrent(status, referenceSource)) return "Current in fleet";
+  return AGENT_STATUS_LABEL[status];
+}

--- a/apps/web/src/components/status/index.ts
+++ b/apps/web/src/components/status/index.ts
@@ -32,5 +32,9 @@ export type { SslChipProps } from "./ssl-chip";
 
 export { AgentStatusChip } from "./agent-status-chip";
 export type { AgentStatusChipProps } from "./agent-status-chip";
-export { AGENT_STATUS_LABEL } from "./agent-status";
+export {
+  AGENT_STATUS_LABEL,
+  agentStatusDisplayLabel,
+  isFleetDerivedCurrent,
+} from "./agent-status";
 export type { AgentStatus } from "./agent-status";

--- a/apps/web/src/features/fleet/AgentFleetSummaryCard.test.tsx
+++ b/apps/web/src/features/fleet/AgentFleetSummaryCard.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import type { FleetAgentVersions } from "@wpmgr/api";
+
+import { renderWithProviders } from "@/test/render";
+import { mockQueryResult } from "@/test/query-mocks";
+
+import { AgentFleetSummaryCard } from "./AgentFleetSummaryCard";
+import { useFleetAgentVersions } from "./use-fleet-agents";
+
+// GH #255 (reported against 0.61.97, self-hosted, 24 sites): the card used to
+// interpolate the literal string "unknown" into the summary sentence as if
+// it were a version ("0 of 24 sites on unknown, 24 unknown"), which is not a
+// sentence an operator can act on. These tests pin the three
+// `reference_source` cases the control plane now distinguishes, and that a
+// version placeholder is never rendered as though it were a real version.
+//
+// Most cases below keep `outdated: 0` so the card never mounts its `<Link>`
+// (see `src/test/render.tsx`'s `withRouter` doc: a mounted `<Link>` needs a
+// router context, and `RouterProvider`'s first paint is async), that keeps
+// these plain synchronous `getByText` assertions. The one case that DOES
+// need the link (`reference_source: "fleet"` with an outdated site) opts
+// into `withRouter` and awaits the first query with `findByText`.
+
+vi.mock("./use-fleet-agents", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./use-fleet-agents")>();
+  return { ...actual, useFleetAgentVersions: vi.fn() };
+});
+
+const mockedUseFleetAgentVersions = vi.mocked(useFleetAgentVersions);
+
+function buildData(overrides: Partial<FleetAgentVersions> = {}): FleetAgentVersions {
+  return {
+    latest_version: "0.61.97",
+    reference_source: "published",
+    counts: { current: 20, outdated: 0, unknown: 1, ineligible: 0 },
+    sites: [],
+    ...overrides,
+  };
+}
+
+function mock(data: FleetAgentVersions) {
+  mockedUseFleetAgentVersions.mockReturnValue(
+    mockQueryResult<FleetAgentVersions>({ data }),
+  );
+}
+
+describe("AgentFleetSummaryCard", () => {
+  it("renders the plain summary sentence with no qualifier when the reference is a published release", () => {
+    mock(buildData({ reference_source: "published", latest_version: "0.61.97" }));
+    renderWithProviders(<AgentFleetSummaryCard />);
+
+    expect(screen.getByText("0.61.97")).toBeInTheDocument();
+    expect(screen.queryByText(/newest seen in this fleet/)).not.toBeInTheDocument();
+  });
+
+  it("adds a short fleet-derived qualifier and never claims 'current' means up to date with a release", async () => {
+    mock(
+      buildData({
+        reference_source: "fleet",
+        latest_version: "0.61.90",
+        counts: { current: 23, outdated: 1, unknown: 0, ineligible: 0 },
+      }),
+    );
+    renderWithProviders(<AgentFleetSummaryCard />, { withRouter: true });
+
+    expect(await screen.findByText("0.61.90")).toBeInTheDocument();
+    expect(
+      screen.getByText(/newest seen in this fleet, not a published release/),
+    ).toBeInTheDocument();
+  });
+
+  it("never prints 'unknown' as though it were a version, and explains the consequence, when there is no reference at all", () => {
+    mock(
+      buildData({
+        reference_source: "none",
+        latest_version: "unknown",
+        counts: { current: 0, outdated: 0, unknown: 24, ineligible: 0 },
+      }),
+    );
+    renderWithProviders(<AgentFleetSummaryCard />);
+
+    // The exact reported string must never appear again.
+    expect(
+      screen.queryByText((text) => text.includes("sites on unknown")),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("unknown", { selector: "span.font-mono" }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText(/WPMgr has no reference agent version for this install/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText((text) => text.includes("cannot tell which of your")),
+    ).toBeInTheDocument();
+    expect(screen.getByText("24")).toBeInTheDocument();
+  });
+
+  it("still names ineligible (not self-updating) sites when there is no reference version", () => {
+    mock(
+      buildData({
+        reference_source: "none",
+        latest_version: "unknown",
+        counts: { current: 0, outdated: 0, unknown: 20, ineligible: 4 },
+      }),
+    );
+    renderWithProviders(<AgentFleetSummaryCard />);
+
+    expect(
+      screen.getByText((text) => text.includes("run a build that cannot")),
+    ).toBeInTheDocument();
+  });
+
+  it("never offers a 'View outdated sites' link when nothing is outdated", () => {
+    mock(
+      buildData({
+        reference_source: "none",
+        latest_version: "unknown",
+        counts: { current: 0, outdated: 0, unknown: 24, ineligible: 0 },
+      }),
+    );
+    renderWithProviders(<AgentFleetSummaryCard />);
+
+    expect(screen.queryByText("View outdated sites")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the fleet has zero sites in every bucket", () => {
+    mock(buildData({ counts: { current: 0, outdated: 0, unknown: 0, ineligible: 0 } }));
+    const { container } = renderWithProviders(<AgentFleetSummaryCard />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing on error (best-effort for a site-scoped collaborator's 403)", () => {
+    mockedUseFleetAgentVersions.mockReturnValue(
+      mockQueryResult<FleetAgentVersions>({
+        data: undefined,
+        isError: true,
+        error: new Error("forbidden"),
+        isSuccess: false,
+      }),
+    );
+    const { container } = renderWithProviders(<AgentFleetSummaryCard />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/features/fleet/AgentFleetSummaryCard.tsx
+++ b/apps/web/src/features/fleet/AgentFleetSummaryCard.tsx
@@ -26,11 +26,34 @@ export function AgentFleetSummaryCardSkeleton() {
 }
 
 /**
- * "N of M sites on <latest version>, K outdated". Best-effort: a
- * site-scoped collaborator with no org-level access gets a 403 from
- * GET /api/v1/fleet/agents, which this card treats the same as "nothing to
- * show" (return null) rather than a page-level error on a page whose
- * primary content is update runs, not agent health.
+ * "N of M sites on <latest version>, K outdated" when a reference version
+ * exists, or a plain-language explanation when it does not (GH #255: a
+ * self-hosted install with nothing in its fleet to compare against used to
+ * render the literal word "unknown" in place of a version, e.g. "0 of 24
+ * sites on unknown, 24 unknown". A version placeholder must never be
+ * interpolated into the sentence as if it were a real version).
+ *
+ * `reference_source` says where `latest_version` came from:
+ *   - "published": the release channel manifest. "N of M on <version>" means
+ *     current with the newest agent that exists.
+ *   - "fleet": no manifest was readable (the normal steady state for a
+ *     self-hosted install), so the comparison falls back to the newest
+ *     agent_version already reported by a site in this tenant's own fleet.
+ *     Rendered with a short qualifier so "current" is never misread as
+ *     "up to date with the latest release": it only means "not behind the
+ *     newest agent this fleet has seen".
+ *   - "none": nothing to compare against, so every site is unknown. Two
+ *     causes, deliberately not distinguished on the wire: an install that
+ *     has never read a manifest and has no well-formed version anywhere in
+ *     its fleet, or an install whose manifest was readable but has been
+ *     unreachable past the staleness bound. The second does NOT fall back
+ *     to "fleet", so the copy below must not imply this install has no
+ *     channel; it says only that no reference version is available.
+ *
+ * Best-effort: a site-scoped collaborator with no org-level access gets a
+ * 403 from GET /api/v1/fleet/agents, which this card treats the same as
+ * "nothing to show" (return null) rather than a page-level error on a page
+ * whose primary content is update runs, not agent health.
  */
 export function AgentFleetSummaryCard() {
   const { data, isPending, isError } = useFleetAgentVersions();
@@ -38,7 +61,7 @@ export function AgentFleetSummaryCard() {
   if (isPending) return <AgentFleetSummaryCardSkeleton />;
   if (isError || !data) return null;
 
-  const { latest_version, counts } = data;
+  const { latest_version, reference_source, counts } = data;
   const total = counts.current + counts.outdated + counts.unknown + counts.ineligible;
   if (total === 0) return null;
 
@@ -54,39 +77,64 @@ export function AgentFleetSummaryCard() {
         </CardTitle>
       </CardHeader>
       <CardContent className="flex flex-wrap items-center justify-between gap-3">
-        <p className="text-sm text-[var(--color-foreground)]">
-          <span className="font-mono tabular-nums">{counts.current}</span> of{" "}
-          <span className="font-mono tabular-nums">{total}</span> sites on{" "}
-          <span className="font-mono">{latest_version}</span>
-          {counts.outdated > 0 ? (
-            <>
-              {", "}
-              <span className="font-mono tabular-nums">{counts.outdated}</span>{" "}
-              outdated
-            </>
-          ) : null}
-          {/* Name every bucket that the denominator counts. Sites on the
-              plugin-directory build can never self-update and sites that
-              have not reported a version yet are not outdated, so folding
-              them silently into the total reads as a fleet permanently
-              short of itself with no explanation. */}
-          {counts.ineligible > 0 ? (
-            <>
-              {", "}
-              <span className="font-mono tabular-nums">
-                {counts.ineligible}
-              </span>{" "}
-              not self-updating
-            </>
-          ) : null}
-          {counts.unknown > 0 ? (
-            <>
-              {", "}
-              <span className="font-mono tabular-nums">{counts.unknown}</span>{" "}
-              unknown
-            </>
-          ) : null}
-        </p>
+        {reference_source === "none" ? (
+          <p className="text-sm text-[var(--color-foreground)]">
+            WPMgr has no reference agent version for this install, so it
+            cannot tell which of your{" "}
+            <span className="font-mono tabular-nums">{total}</span> sites are
+            behind.
+            {counts.ineligible > 0 ? (
+              <>
+                {" "}
+                <span className="font-mono tabular-nums">
+                  {counts.ineligible}
+                </span>{" "}
+                {counts.ineligible === 1 ? "runs" : "run"} a build that cannot
+                self-update regardless.
+              </>
+            ) : null}
+          </p>
+        ) : (
+          <p className="text-sm text-[var(--color-foreground)]">
+            <span className="font-mono tabular-nums">{counts.current}</span> of{" "}
+            <span className="font-mono tabular-nums">{total}</span> sites on{" "}
+            <span className="font-mono">{latest_version}</span>
+            {reference_source === "fleet" ? (
+              <span className="text-[var(--color-muted-foreground)]">
+                {" "}
+                (newest seen in this fleet, not a published release)
+              </span>
+            ) : null}
+            {counts.outdated > 0 ? (
+              <>
+                {", "}
+                <span className="font-mono tabular-nums">{counts.outdated}</span>{" "}
+                outdated
+              </>
+            ) : null}
+            {/* Name every bucket that the denominator counts. Sites on the
+                plugin-directory build can never self-update and sites that
+                have not reported a version yet are not outdated, so folding
+                them silently into the total reads as a fleet permanently
+                short of itself with no explanation. */}
+            {counts.ineligible > 0 ? (
+              <>
+                {", "}
+                <span className="font-mono tabular-nums">
+                  {counts.ineligible}
+                </span>{" "}
+                not self-updating
+              </>
+            ) : null}
+            {counts.unknown > 0 ? (
+              <>
+                {", "}
+                <span className="font-mono tabular-nums">{counts.unknown}</span>{" "}
+                unknown
+              </>
+            ) : null}
+          </p>
+        )}
         {counts.outdated > 0 ? (
           <Link
             to="/sites"

--- a/apps/web/src/features/sites/agent-status-hint.test.ts
+++ b/apps/web/src/features/sites/agent-status-hint.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+
+import { agentStatusFilterHint } from "./agent-status-hint";
+
+// GH #255: "the agent-status filter doesn't seem to trigger or activate
+// properly" turned out to be a knock-on of every site classifying Unknown,
+// not an independent bug in the filter's toggle/apply logic (see
+// sites-filter.test.ts for that logic's own coverage), a one-option
+// dropdown whose only value matches every row looks like a no-op from the
+// outside. These pin when the explanatory hint does, and does not, appear.
+
+describe("agentStatusFilterHint", () => {
+  it("is undefined when there is more than one option (an ordinary, working axis)", () => {
+    expect(agentStatusFilterHint(["Current", "Unknown"], "published")).toBeUndefined();
+  });
+
+  it("is undefined when there are no options yet (rollup still loading)", () => {
+    expect(agentStatusFilterHint([], undefined)).toBeUndefined();
+  });
+
+  it("is undefined when the single option is not Unknown (e.g. every site is Current)", () => {
+    expect(agentStatusFilterHint(["Current"], "published")).toBeUndefined();
+  });
+
+  it("names the no-reference-version root cause when reference_source is none", () => {
+    const hint = agentStatusFilterHint(["Unknown"], "none");
+    expect(hint).toMatch(/no reference agent version/);
+    expect(hint).toMatch(/cannot narrow the list/);
+  });
+
+  it("still explains a single Unknown bucket even when a reference version exists", () => {
+    // e.g. every site simply has not reported agent_version yet.
+    const hint = agentStatusFilterHint(["Unknown"], "published");
+    expect(hint).toBe("Every site here is Unknown, so this filter cannot narrow the list.");
+  });
+
+  it("handles an undefined reference_source (rollup not yet loaded) the same as a generic explanation", () => {
+    const hint = agentStatusFilterHint(["Unknown"], undefined);
+    expect(hint).toBe("Every site here is Unknown, so this filter cannot narrow the list.");
+  });
+});

--- a/apps/web/src/features/sites/agent-status-hint.ts
+++ b/apps/web/src/features/sites/agent-status-hint.ts
@@ -1,0 +1,28 @@
+import { AGENT_STATUS_LABEL } from "@/components/status";
+import type { FleetAgentVersions } from "@wpmgr/api";
+
+/**
+ * GH #255: an axis that has collapsed to the single "Unknown" bucket toggles
+ * a checkbox that matches every visible site, which reads as a dead filter
+ * ("doesn't seem to trigger or activate properly"). That is not a second bug
+ * on top of the reporter's other complaint: it is the same root cause (no
+ * reference agent version to classify against) wearing a different hat.
+ * Rather than leave the operator to guess, name it.
+ *
+ * Returns `undefined` for every other shape of the options list. A single
+ * non-"Unknown" value, or several values, is ordinary and needs no callout.
+ */
+export function agentStatusFilterHint(
+  agentStatusOptions: readonly string[],
+  referenceSource: FleetAgentVersions["reference_source"] | undefined,
+): string | undefined {
+  if (
+    agentStatusOptions.length !== 1 ||
+    agentStatusOptions[0] !== AGENT_STATUS_LABEL.unknown
+  ) {
+    return undefined;
+  }
+  return referenceSource === "none"
+    ? "Every site here is Unknown because WPMgr has no reference agent version to compare against, so this filter cannot narrow the list."
+    : "Every site here is Unknown, so this filter cannot narrow the list.";
+}

--- a/apps/web/src/features/sites/sites-table.tsx
+++ b/apps/web/src/features/sites/sites-table.tsx
@@ -27,7 +27,7 @@ import {
   Plus,
 } from "lucide-react";
 import { motion } from "motion/react";
-import type { Site } from "@wpmgr/api";
+import type { FleetAgentVersions, Site } from "@wpmgr/api";
 
 import { Checkbox } from "@/components/ui/checkbox";
 import { TagChip, TagOverflowChip } from "@/features/sites/tag-chip";
@@ -114,6 +114,15 @@ export interface SitesTableProps {
    * text instead of guessing a classification.
    */
   agentStatusById?: ReadonlyMap<string, AgentStatus>;
+  /**
+   * Where the `agentStatusById` classification's reference version came
+   * from (see FleetAgentVersions.reference_source). Threaded through to the
+   * Agent column's chip so a fleet-derived "current" never renders as an
+   * unqualified "Current" (GH #255 follow-up: a site can be "current"
+   * against the newest agent this fleet has seen while dozens of releases
+   * behind a real published build). Omit while the rollup is loading.
+   */
+  agentReferenceSource?: FleetAgentVersions["reference_source"];
   /** Optional click handler for the inline "Log in" (Zap) action. */
   onOpenAutoLogin?: (site: Site) => void;
   /** Optional click handler for the three-dot "More" item entries. */
@@ -320,6 +329,7 @@ function buildColumns(
   onDisconnect: ((site: Site) => void) | undefined,
   onReconnect: ((site: Site) => void) | undefined,
   onRemove: ((site: Site) => void) | undefined,
+  agentReferenceSource: FleetAgentVersions["reference_source"] | undefined,
 ): ColumnDef<SiteRow>[] {
   const allVisibleSelected =
     visibleIds.length > 0 && visibleIds.every((id) => selection.selected.has(id));
@@ -502,7 +512,13 @@ function buildColumns(
             );
           return <span className="font-mono text-sm tabular-nums">{v}</span>;
         }
-        return <AgentStatusChip status={agentStatus} version={v || null} />;
+        return (
+          <AgentStatusChip
+            status={agentStatus}
+            version={v || null}
+            referenceSource={agentReferenceSource}
+          />
+        );
       },
     },
     {
@@ -669,6 +685,7 @@ export function SitesTable({
   selection: externalSelection,
   densityState: externalDensityState,
   agentStatusById,
+  agentReferenceSource,
   onOpenAutoLogin,
   onOpenDetail,
   onDisconnect,
@@ -699,6 +716,7 @@ export function SitesTable({
         onDisconnect,
         onReconnect,
         onRemove,
+        agentReferenceSource,
       ),
     [
       selection,
@@ -708,6 +726,7 @@ export function SitesTable({
       onDisconnect,
       onReconnect,
       onRemove,
+      agentReferenceSource,
     ],
   );
 

--- a/apps/web/src/features/sites/sites-toolbar.tsx
+++ b/apps/web/src/features/sites/sites-toolbar.tsx
@@ -126,6 +126,12 @@ export interface SitesToolbarProps {
   onAgentStatusToggle?: (status: string) => void;
   /** Called to clear all agent-freshness filters. */
   onAgentStatusesClear?: () => void;
+  /**
+   * Explanatory note for the Agent dropdown, set only when the axis has
+   * collapsed to a single "Unknown" bucket (GH #255) so the operator sees
+   * why picking it does not narrow the list.
+   */
+  agentStatusHint?: string;
   /** Total count of active filter axes (for the "Clear filters" pill). */
   activeFilterCount?: number;
   /** Called to clear ALL filters across all axes. */
@@ -226,6 +232,7 @@ function IdleMode({
   selectedAgentStatuses = [],
   onAgentStatusToggle,
   onAgentStatusesClear,
+  agentStatusHint,
   activeFilterCount = 0,
   onClearAllFilters,
   densityState,
@@ -297,6 +304,7 @@ function IdleMode({
           onToggle={onAgentStatusToggle ?? (() => {})}
           onClear={onAgentStatusesClear ?? (() => {})}
           ariaLabel="Filter by agent status"
+          hint={agentStatusHint}
         />
 
         {/* Tags — registry-backed multi-select with a match-mode segmented
@@ -432,6 +440,7 @@ function MultiSelectDropdown({
   onClear,
   ariaLabel,
   icon: Icon,
+  hint,
 }: {
   label: string;
   options: readonly string[];
@@ -440,6 +449,14 @@ function MultiSelectDropdown({
   onClear: () => void;
   ariaLabel: string;
   icon?: typeof Tag;
+  /**
+   * Explanatory note shown at the top of the menu. For an axis whose only
+   * value collapses to a single bucket (e.g. every site is "Unknown"
+   * because there is nothing to classify against, GH #255), toggling the
+   * lone checkbox matches every row and looks like the filter is a no-op.
+   * This says why up front instead of leaving the operator to guess.
+   */
+  hint?: string;
 }) {
   const [menuFilter, setMenuFilter] = useState("");
   const count = selected.length;
@@ -482,6 +499,12 @@ function MultiSelectDropdown({
         className="min-w-[14rem]"
         collisionPadding={8}
       >
+        {hint ? (
+          <div className="max-w-[18rem] px-2 pb-1.5 pt-1 text-xs text-muted-foreground">
+            {hint}
+          </div>
+        ) : null}
+
         {/* In-menu text filter for long lists */}
         {options.length > 6 ? (
           <div className="px-2 pb-1 pt-0.5">

--- a/apps/web/src/features/updates/agent-self-update-dialog.tsx
+++ b/apps/web/src/features/updates/agent-self-update-dialog.tsx
@@ -11,9 +11,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { AGENT_STATUS_LABEL, type AgentStatus } from "@/components/status";
+import { agentStatusDisplayLabel, type AgentStatus } from "@/components/status";
 import { useCreateUpdateRun } from "@/features/updates/use-updates";
-import type { Site } from "@wpmgr/api";
+import type { FleetAgentVersions, Site } from "@wpmgr/api";
 
 // GH #255 Phase 2: the confirmation dialog for the "Update WPMgr agent" bulk
 // action (sites toolbar > More). Reuses the fleet agent-version rollup
@@ -32,6 +32,7 @@ export function AgentSelfUpdateDialog({
   onClose,
   sites,
   agentStatusById,
+  agentReferenceSource,
 }: {
   open: boolean;
   onClose: () => void;
@@ -39,6 +40,8 @@ export function AgentSelfUpdateDialog({
   sites: Site[];
   /** Per-site agent-freshness classification from the fleet rollup. */
   agentStatusById: Map<string, AgentStatus> | undefined;
+  /** Where the classification's reference version came from; see FleetAgentVersions.reference_source. */
+  agentReferenceSource?: FleetAgentVersions["reference_source"];
 }) {
   return (
     <Dialog open={open} onClose={onClose}>
@@ -49,6 +52,7 @@ export function AgentSelfUpdateDialog({
           key={sites.map((s) => s.id).join(",")}
           sites={sites}
           agentStatusById={agentStatusById}
+          agentReferenceSource={agentReferenceSource}
           onClose={onClose}
         />
       ) : null}
@@ -59,10 +63,12 @@ export function AgentSelfUpdateDialog({
 function AgentSelfUpdateDialogBody({
   sites,
   agentStatusById,
+  agentReferenceSource,
   onClose,
 }: {
   sites: Site[];
   agentStatusById: Map<string, AgentStatus> | undefined;
+  agentReferenceSource?: FleetAgentVersions["reference_source"];
   onClose: () => void;
 }) {
   const navigate = useNavigate();
@@ -152,7 +158,7 @@ function AgentSelfUpdateDialogBody({
             {(Object.entries(excludedCounts) as [AgentStatus, number][])
               .map(
                 ([status, n]) =>
-                  `${n} ${AGENT_STATUS_LABEL[status].toLowerCase()}`,
+                  `${n} ${agentStatusDisplayLabel(status, agentReferenceSource).toLowerCase()}`,
               )
               .join(", ")}
             .

--- a/apps/web/src/routes/_authed/sites/index.tsx
+++ b/apps/web/src/routes/_authed/sites/index.tsx
@@ -48,6 +48,7 @@ import { useBulkAction } from "@/features/sites/use-bulk-action";
 import { toast } from "@/components/toast";
 import { cn } from "@/lib/utils";
 import { connectionStateOf } from "@/features/sites/connection-state";
+import { agentStatusFilterHint } from "@/features/sites/agent-status-hint";
 import type { Site } from "@wpmgr/api";
 
 // ---------------------------------------------------------------------------
@@ -293,6 +294,12 @@ function SitesPage() {
     }
     return Array.from(set).sort();
   }, [sites, agentStatusById]);
+
+  // GH #255: see agentStatusFilterHint's own doc for why this exists.
+  const agentStatusHint = useMemo(
+    () => agentStatusFilterHint(agentStatusOptions, fleetAgents?.reference_source),
+    [agentStatusOptions, fleetAgents],
+  );
 
   // ── visibleSites — pure derive over the query cache ───────────────────────
   //
@@ -850,6 +857,7 @@ function SitesPage() {
             }}
             agentStatusOptions={agentStatusOptions}
             selectedAgentStatuses={selectedAgentStatuses}
+            agentStatusHint={agentStatusHint}
             onAgentStatusToggle={(status) => {
               const next = selectedAgentStatuses.includes(status)
                 ? selectedAgentStatuses.filter((s) => s !== status)
@@ -966,6 +974,7 @@ function SitesPage() {
               selection={operate ? selection : undefined}
               densityState={densityState}
               agentStatusById={agentStatusById}
+              agentReferenceSource={fleetAgents?.reference_source}
               onOpenAutoLogin={autoLogin ? handleOpenAutoLogin : undefined}
               onOpenDetail={handleOpenDetail}
               onDisconnect={operate ? handleDisconnect : undefined}
@@ -994,6 +1003,7 @@ function SitesPage() {
           onClose={() => setAgentUpdateOpen(false)}
           sites={selectedSites}
           agentStatusById={agentStatusById}
+          agentReferenceSource={fleetAgents?.reference_source}
         />
       ) : null}
 

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -12069,12 +12069,18 @@ export const FleetAgentSiteSchema = {
 
 export const FleetAgentVersionsSchema = {
   type: "object",
-  required: ["latest_version", "counts", "sites"],
+  required: ["latest_version", "reference_source", "counts", "sites"],
   properties: {
     latest_version: {
       type: "string",
       description:
-        'The currently published agent version, or "unknown" when it cannot be determined right now.',
+        'The single version every site in sites was classified against, or "unknown" when there was none. Read it together with reference_source, which says where it came from: under "fleet" this is the newest agent version seen in THIS tenant\'s fleet, not the newest agent that exists, and presenting it as the latter would overclaim.\n',
+    },
+    reference_source: {
+      type: "string",
+      enum: ["published", "fleet", "none"],
+      description:
+        'Where latest_version came from. "published": the release channel pointer manifest (agent-releases/latest.json), so "current" means the site runs the newest agent that exists. "fleet": the manifest could not be read, so the newest well-formed agent version present in this tenant\'s own fleet was used instead; "current" then means only that no newer agent has been seen in this fleet. A self-hosted install has its own object storage and never receives the release pipeline\'s manifest, so this is its normal steady state. "none": nothing safe to compare against, so every site is "unknown". That arises two ways, and they are deliberately not distinguished in this field: an install that has never read a manifest and has no well-formed agent version anywhere in its fleet, or an install whose manifest WAS readable but has been unreadable for longer than the staleness bound. The second case does not fall back to "fleet", because "this install has a channel and it is currently unreachable" must not be answered with fleet-derived data.\n',
     },
     counts: {
       $ref: "#/components/schemas/FleetAgentCounts",

--- a/packages/openapi-client/src/generated/sdk.gen.ts
+++ b/packages/openapi-client/src/generated/sdk.gen.ts
@@ -5074,11 +5074,16 @@ export const getAgentLatestVersion = <ThrowOnError extends boolean = false>(
  * Tenant-wide agent-version rollup across all sites
  *
  * Per-site {site_id, site_name, agent_version, status} plus fleet-wide
- * counts, classified against the currently published agent version.
- * status is one of current | outdated | unknown | ineligible.
+ * counts, classified against a single reference version. That reference
+ * is the published agent version when the release manifest can be read,
+ * and otherwise the newest well-formed agent version present in this
+ * tenant's own fleet, which is what a self-hosted install (whose object
+ * storage never receives the release pipeline's manifest) gets.
+ * reference_source names which of the two, or "none" when neither was
+ * available. status is one of current | outdated | unknown | ineligible.
  * "unknown" covers a site that has never reported agent_version, a
  * malformed/unparseable version on either side of the comparison, or a
- * currently-unreadable published-version manifest; never a false
+ * reference_source of "none"; never a false
  * "outdated". "ineligible" is a site that cannot self-update at all:
  * today that is the public plugin-directory build, which ships without
  * the self-updater and is upgraded by the plugin directory instead.

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -6633,9 +6633,15 @@ export type FleetAgentSite = {
 
 export type FleetAgentVersions = {
   /**
-   * The currently published agent version, or "unknown" when it cannot be determined right now.
+   * The single version every site in sites was classified against, or "unknown" when there was none. Read it together with reference_source, which says where it came from: under "fleet" this is the newest agent version seen in THIS tenant's fleet, not the newest agent that exists, and presenting it as the latter would overclaim.
+   *
    */
   latest_version: string;
+  /**
+   * Where latest_version came from. "published": the release channel pointer manifest (agent-releases/latest.json), so "current" means the site runs the newest agent that exists. "fleet": the manifest could not be read, so the newest well-formed agent version present in this tenant's own fleet was used instead; "current" then means only that no newer agent has been seen in this fleet. A self-hosted install has its own object storage and never receives the release pipeline's manifest, so this is its normal steady state. "none": nothing safe to compare against, so every site is "unknown". That arises two ways, and they are deliberately not distinguished in this field: an install that has never read a manifest and has no well-formed agent version anywhere in its fleet, or an install whose manifest WAS readable but has been unreadable for longer than the staleness bound. The second case does not fall back to "fleet", because "this install has a channel and it is currently unreachable" must not be answered with fleet-derived data.
+   *
+   */
+  reference_source: "published" | "fleet" | "none";
   counts: FleetAgentCounts;
   sites: Array<FleetAgentSite>;
   /**

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.98
+  version: 0.61.99
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,
@@ -6789,11 +6789,16 @@ paths:
       summary: Tenant-wide agent-version rollup across all sites
       description: |
         Per-site {site_id, site_name, agent_version, status} plus fleet-wide
-        counts, classified against the currently published agent version.
-        status is one of current | outdated | unknown | ineligible.
+        counts, classified against a single reference version. That reference
+        is the published agent version when the release manifest can be read,
+        and otherwise the newest well-formed agent version present in this
+        tenant's own fleet, which is what a self-hosted install (whose object
+        storage never receives the release pipeline's manifest) gets.
+        reference_source names which of the two, or "none" when neither was
+        available. status is one of current | outdated | unknown | ineligible.
         "unknown" covers a site that has never reported agent_version, a
         malformed/unparseable version on either side of the comparison, or a
-        currently-unreadable published-version manifest; never a false
+        reference_source of "none"; never a false
         "outdated". "ineligible" is a site that cannot self-update at all:
         today that is the public plugin-directory build, which ships without
         the self-updater and is upgraded by the plugin directory instead.
@@ -20641,11 +20646,38 @@ components:
           enum: [current, outdated, unknown, ineligible]
     FleetAgentVersions:
       type: object
-      required: [latest_version, counts, sites]
+      required: [latest_version, reference_source, counts, sites]
       properties:
         latest_version:
           type: string
-          description: The currently published agent version, or "unknown" when it cannot be determined right now.
+          description: >
+            The single version every site in sites was classified against, or
+            "unknown" when there was none. Read it together with
+            reference_source, which says where it came from: under "fleet"
+            this is the newest agent version seen in THIS tenant's fleet, not
+            the newest agent that exists, and presenting it as the latter
+            would overclaim.
+        reference_source:
+          type: string
+          enum: [published, fleet, none]
+          description: >
+            Where latest_version came from. "published": the release channel
+            pointer manifest (agent-releases/latest.json), so "current" means
+            the site runs the newest agent that exists. "fleet": the manifest
+            could not be read, so the newest well-formed agent version present
+            in this tenant's own fleet was used instead; "current" then means
+            only that no newer agent has been seen in this fleet. A
+            self-hosted install has its own object storage and never receives
+            the release pipeline's manifest, so this is its normal steady
+            state. "none": nothing safe to compare against, so every site is
+            "unknown". That arises two ways, and they are deliberately not
+            distinguished in this field: an install that has never read a
+            manifest and has no well-formed agent version anywhere in its
+            fleet, or an install whose manifest WAS readable but has been
+            unreadable for longer than the staleness bound. The second case
+            does not fall back to "fleet", because "this install has a
+            channel and it is currently unreachable" must not be answered
+            with fleet-derived data.
         counts: { $ref: "#/components/schemas/FleetAgentCounts" }
         sites:
           type: array


### PR DESCRIPTION
Ships as 0.61.99. Fixes a defect I shipped in 0.61.97, reported within hours by @iacopoincerpi on a self-hosted install running 24 sites.

## The report

Their Agent version card read:

> `0 of 24 sites on unknown, 24 unknown`

and the agent-status filter appeared to do nothing.

## Cause

**The first "unknown" is the published version, not a site status.** The rollup compares each site against `agent-releases/latest.json`, which per ADR-042 *"the release pipeline writes"* into the hosted service's bucket. A self-hosted install has its own object storage and never receives that key, so the read degrades to empty, and `Classify` returns `StatusUnknown` for every site regardless of what it reported. Their agents were reporting correctly the whole time.

The filter was not independently broken: it offers only values that actually appear, so with every site unknown there was one option matching all 24 rows, which reads as inert. Fix the input and the filter becomes useful with no change to it.

**The degradation was deliberate and tested** (`TestAgentLatest_DegradesToUnknown`) — designed for a *transient* read failure on hosted, where it is correct. It became the *permanent steady state* on every self-hosted install. Same class as #74.

## What changes

An install that has **never** read a manifest falls back to the newest well-formed agent version in that tenant's own fleet, and the API reports which source it used so the UI can qualify "current" instead of implying parity with the newest release that exists. With nothing to compare against, it says so plainly rather than printing "unknown" as a version.

**On the fleet reference rule:** it is the plain newest, excluding pre-releases. An earlier attempt of mine required corroboration from two sites to resist a bogus version. Review proved that trade was backwards: it suppresses a site **legitimately updated first** (the normal shape of a rollout in progress) and collapses entirely on the small fleets the fallback exists for. The claim made is literally "newest seen in this fleet", which stays true even for an odd value, and the outlier is visible in the same list the operator is reading.

## Hosted correctness, found by review

The reader cached **failures**, so one storage blip pinned the published version empty for five minutes and let the fleet reference preempt a readable manifest. Reproduced: on release day that reports `24 of 24 current` when the truth is 24 outdated, and the "View outdated sites" link disappears. That is worse than the bug being fixed, since an obviously-broken card is safe and a confident wrong answer is not.

Now: last-known-good is kept and served across a failure, failures retry in ~30s rather than holding for the full TTL, and the value is age-bounded. Past the bound it reports **no reference** rather than a stale one labelled published. An install whose channel exists but is unreachable is a different fact from an install with no channel, and must not be answered with fleet data.

## Phase 2's switch was unreachable

`self_update_enabled` was in the spec and read by the web to gate the fleet-update action, but **no Go code emitted it**, so the action stayed hidden even with `WPMGR_UPDATE_AGENT_SELF_UPDATE_ENABLED=true`. Now emitted from the same config the worker checks, verified in both states. Still ships off.

## Also

Regenerates the API clients, repairing comment reflow that an overly broad text pass of mine damaged in 0.61.98 (5 comment lines in `oas_schemas_gen.go`). Cosmetic, no behaviour change, but main's generated output did not match `go generate`.

## Verification

- Go: build/vet clean; `internal/agentrelease`, `internal/update`, `internal/site` pass, also under `-count=3 -race`
- Web: **1270** tests across 103 files, lint 0 errors
- Tenancy on the fleet reference: computed inside `InTenantTx` with an explicit `tenant_id` filter, with a cross-tenant test
- Original symptom: card now renders `24 of 24 sites on 0.61.97 (newest seen in this fleet, not a published release)`, or a plain-language sentence when there is no reference. Neither interpolates "unknown" as a version.

One pre-existing flake seen locally: `TestAppHealthSettingsRepo_TenantIsolation` failed once with `port "5432/tcp" not found` (testcontainers under parallel load) and passes in isolation. Untouched by this change.

## Follow-up

#302 tracks offering our public GitHub Release as a self-host agent channel. Worth noting the investigation found self-hosted agents cannot self-update **at all** today (`update_handler.go` returns 204 with no manifest, and that endpoint is the only source of the agent's update advisory, so wp-admin never offers it either). #302 is not a convenience; it is the only path that would give self-hosters agent updates.

No agent change in this release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fleet agent version comparisons when published release information is unavailable.
  * Prevented brief storage or manifest read failures from incorrectly changing agent status.
  * Added clearer handling when no reliable reference version exists.
  * Clarified “Current in fleet” labels and related site-filter guidance.
  * Corrected fleet-wide update controls shown in the dashboard.

* **Documentation**
  * Updated release notes and product version information for version 0.61.99.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->