### PR TITLE
fix(web): Sites table gave all spare width to one column (GH #261, GH #255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.100] - 2026-07-28
+
+### Fixed
+
+- On a wide screen, the Sites table gave nearly all its spare width to the Site column and none to any other column (GH #261). On a 5120 pixel display the Site column took roughly three quarters of the table while every other column was squeezed into the right hand side. Every column now grows only up to a sensible limit, Tags and Backup share the extra space once Site reaches its own limit, and whatever is left over sits in empty space at the end of the table instead of stretching one column further. On that same 5120 pixel display the Site column now takes about eight percent of the table instead of about seventy five.
+- Columns could also clip into each other at ordinary widths (GH #255, reported on a 22 site fleet): the Agent, Updates and Backup columns overlapped, and the Uptime column was pushed off screen entirely. Two things caused it. The header and the table's rows sized each column independently, so the two could drift apart from each other, and some columns were shown more text than they had room for, so it ran into the next column instead of fitting. The header and the rows now share one definition of every column's width, and, as described below, the Agent and Backup columns show less text per row, so both problems go away together.
+- The Backup column repeated its own heading: it read "Backed up 10h ago" under a column already titled Backup, and wrapped onto two lines on most rows. It now shows just the time, with the same icon, and a failed backup is still called out clearly.
+- The Agent column repeated a status word on every row. On a healthy fleet nearly every row said the same thing, which pushed the version number into the next column. Each row now shows the version next to a status icon instead, and the icon's shape carries the meaning rather than color alone. Screen readers still announce the full state and version for every row.
+- The note about what a site's agent version is compared against has moved from every row to the Agent column's heading. Version 0.61.99 added a per row note saying when a site is compared against the newest agent in your own fleet rather than a published release, which matters on a self-hosted install. That is a fact about the comparison itself, not about each site, so it now appears once, on the column heading, instead of taking width from every row.
+- The loading placeholder shown while the Sites table is still loading had drifted out of step with the real table and was missing two columns, so the table appeared to shift sideways once it finished loading. It is now built from the same column definitions as the table itself.
+
 ## [0.61.99] - 2026-07-28
 
 ### Fixed

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,29 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.100",
+    date: "2026-07-28",
+    summary: "The Sites table shares its width sensibly across every column now, on any screen size.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "On a wide monitor, the Sites table used to hand nearly all its width to the Site column and squeeze everything else into a sliver on the right (GH #261). On a 5120 pixel display, Site took about three quarters of the table; it now takes about eight percent, with the rest shared out and any true leftover left as empty space instead of stretched into one column.",
+      },
+      {
+        tag: "Fixed",
+        text: "At ordinary widths the opposite could happen: the Agent, Updates and Backup columns could overlap, with Uptime pushed off screen (reported on a 22 site fleet, GH #255). The header and the rows now share one definition of every column's width, and two columns were trimmed to fit: Backup no longer repeats its own heading, and Agent no longer repeats a status word on every row.",
+      },
+      {
+        tag: "Fixed",
+        text: "The Agent column's note about comparing against your own fleet rather than a published release, added in 0.61.99, moved from every row to the column heading, where it belongs.",
+      },
+      {
+        tag: "Fixed",
+        text: "The Sites table's loading placeholder was missing two columns and drifted out of step with the real table, so the table appeared to shift sideways once it finished loading. It is now built from the same column definitions as the table itself.",
+      },
+    ],
+  },
+  {
     version: "0.61.99",
     date: "2026-07-28",
     summary: "Self-hosted installs no longer show every site's agent version as an unreadable \"unknown\".",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.99 / open source",
+  badge: "v0.61.100 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/apps/web/src/components/skeleton/sites-table-skeleton.tsx
+++ b/apps/web/src/components/skeleton/sites-table-skeleton.tsx
@@ -1,6 +1,10 @@
 import type { CSSProperties } from "react";
 
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  SITES_COLUMN_TRACKS,
+  SITES_TABLE_MIN_WIDTH_PX,
+} from "@/features/sites/sites-table-geometry";
 import { cn } from "@/lib/utils";
 
 // Surface 4.13 — Sites table skeleton.
@@ -30,19 +34,12 @@ export interface SitesTableSkeletonProps {
   className?: string;
 }
 
-// Keep these column widths in lockstep with sites-table.tsx (COL_*_PX). If
-// the real table's column geometry shifts, this constant moves with it.
-const COLUMNS = [
-  { id: "select", width: 40 },
-  { id: "url", width: 320 },
-  { id: "tags", width: 160 },
-  { id: "wp", width: 90 },
-  { id: "php", width: 90 },
-  { id: "updates", width: 130 },
-  { id: "backup", width: 180 },
-  { id: "uptime", width: 80 },
-  { id: "actions", width: 80 },
-] as const;
+// Column geometry is READ from the real table's track table rather than
+// duplicated here (GH #255 / GH #261). The hand-copied list this replaced had
+// silently drifted: it was missing the Client and Agent columns entirely and
+// every width was stale, so the crossfade from skeleton to table jumped every
+// column sideways.
+const COLUMNS = SITES_COLUMN_TRACKS.map((t) => ({ id: t.id, width: t.base }));
 
 const HEADER_HEIGHT_CLASS = "h-11";
 
@@ -74,13 +71,18 @@ export function SitesTableSkeleton({
       role="status"
       aria-label="Loading sites"
       aria-busy="true"
-      className={cn("flex w-full flex-col bg-background", className)}
+      className={cn(
+        "flex w-full flex-col overflow-x-auto bg-background",
+        className,
+      )}
     >
       <span className="sr-only">Loading sites…</span>
 
       <table
         className="w-full border-collapse"
-        style={{ tableLayout: "fixed" }}
+        // Same floor as the real table: narrow viewports scroll rather than
+        // crushing the columns, so the crossfade does not reflow.
+        style={{ tableLayout: "fixed", minWidth: SITES_TABLE_MIN_WIDTH_PX }}
       >
         <thead className="sticky top-0 z-10 bg-background">
           <tr className={cn(HEADER_HEIGHT_CLASS, "border-b border-border")}>
@@ -106,6 +108,9 @@ export function SitesTableSkeleton({
                 </th>
               );
             })}
+            {/* Trailing spacer track, mirroring the real table so an
+                ultrawide viewport does not stretch the columns. */}
+            <td aria-hidden="true" className="p-0" />
           </tr>
         </thead>
         <tbody>
@@ -128,6 +133,7 @@ export function SitesTableSkeleton({
                   </td>
                 );
               })}
+              <td aria-hidden="true" className="p-0" />
             </tr>
           ))}
         </tbody>
@@ -136,7 +142,8 @@ export function SitesTableSkeleton({
   );
 }
 
-function CellSkeleton({ column }: { column: (typeof COLUMNS)[number]["id"] }) {
+// Column ids are the real table's track ids (see sites-table-geometry.ts).
+function CellSkeleton({ column }: { column: string }) {
   switch (column) {
     case "select":
       return <Skeleton className="size-4 rounded" />;
@@ -148,18 +155,23 @@ function CellSkeleton({ column }: { column: (typeof COLUMNS)[number]["id"] }) {
           <Skeleton className="h-2 w-20" />
         </div>
       );
+    case "client":
+      return <Skeleton className="h-3 w-16" />;
     case "tags":
       // Single chip-shaped block (real cell may show up to 3 + overflow).
       return <Skeleton className="h-5 w-12 rounded-md" />;
-    case "wp":
-    case "php":
+    case "wp_version":
+    case "php_version":
       // Mono version placeholder.
       return <Skeleton className="h-3 w-10" />;
-    case "updates":
+    case "agent_version":
+      // Status icon + mono version.
+      return <Skeleton className="h-3 w-14" />;
+    case "updates_count":
       return <Skeleton className="h-5 w-20 rounded-md" />;
-    case "backup":
-      return <Skeleton className="h-5 w-28 rounded-md" />;
-    case "uptime":
+    case "backup_status":
+      return <Skeleton className="h-5 w-16 rounded-md" />;
+    case "uptime_sparkline":
       // Sparkline placeholder — keep it short, the real chart is small too.
       return <Skeleton className="h-3 w-12" />;
     case "actions":
@@ -170,5 +182,7 @@ function CellSkeleton({ column }: { column: (typeof COLUMNS)[number]["id"] }) {
           <Skeleton className="size-7 rounded" />
         </div>
       );
+    default:
+      return null;
   }
 }

--- a/apps/web/src/components/status/agent-status-chip.test.tsx
+++ b/apps/web/src/components/status/agent-status-chip.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import type { ReactElement } from "react";
 import { render, screen } from "@testing-library/react";
 
 import { AgentStatusChip } from "./agent-status-chip";
@@ -52,5 +53,81 @@ describe("AgentStatusChip", () => {
     render(<AgentStatusChip status="current" version="0.12.0" />);
     expect(screen.getByText("Current")).toBeInTheDocument();
     expect(screen.queryByText("Current in fleet")).not.toBeInTheDocument();
+  });
+});
+
+// GH #255 follow-up: in the Sites table the per-row status WORD is what
+// clipped the Agent column into its neighbours, so the compact variant
+// renders an icon plus the version. The state must survive that: never by
+// colour alone (the icon differs in shape too) and never lost to assistive
+// tech (visually-hidden text carries the full announcement). These pin the
+// ACCESSIBLE NAME, not the visible digits.
+
+function renderInCell(ui: ReactElement) {
+  return render(
+    <table>
+      <tbody>
+        <tr>
+          <td>{ui}</td>
+        </tr>
+      </tbody>
+    </table>,
+  );
+}
+
+describe("AgentStatusChip (compact)", () => {
+  it("renders the version without the status word", () => {
+    renderInCell(
+      <AgentStatusChip compact status="outdated" version="0.61.96" />,
+    );
+    expect(screen.getByText("0.61.96")).toBeInTheDocument();
+    expect(screen.queryByText("Outdated")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["current", "published", "Current, agent 0.61.96"],
+    ["current", "fleet", "Current in fleet, agent 0.61.96"],
+    ["outdated", "published", "Outdated, agent 0.61.96"],
+    ["unknown", "published", "Unknown, agent 0.61.96"],
+    ["ineligible", "published", "Not self-updating, agent 0.61.96"],
+  ] as const)(
+    "announces %s/%s as its accessible name",
+    (status, referenceSource, expected) => {
+      renderInCell(
+        <AgentStatusChip
+          compact
+          status={status}
+          version="0.61.96"
+          referenceSource={referenceSource}
+        />,
+      );
+      expect(screen.getByRole("cell")).toHaveAccessibleName(expected);
+    },
+  );
+
+  it("names the missing-version case rather than announcing a bare dash", () => {
+    renderInCell(<AgentStatusChip compact status="unknown" version={null} />);
+    expect(screen.getByRole("cell")).toHaveAccessibleName(
+      "Unknown, agent version not reported",
+    );
+  });
+
+  it("distinguishes the four states by icon shape, not colour alone", () => {
+    const seen = new Set<string>();
+    for (const status of ["current", "outdated", "unknown", "ineligible"] as const) {
+      const { container, unmount } = renderInCell(
+        <AgentStatusChip compact status={status} version="0.61.96" />,
+      );
+      const icon = container.querySelector("svg");
+      expect(icon, `${status} renders no icon`).not.toBeNull();
+      // lucide stamps the icon name onto the svg class list.
+      const shape = icon!.getAttribute("class") ?? "";
+      expect(seen.has(shape), `${status} reuses another status' icon`).toBe(
+        false,
+      );
+      seen.add(shape);
+      unmount();
+    }
+    expect(seen.size).toBe(4);
   });
 });

--- a/apps/web/src/components/status/agent-status-chip.tsx
+++ b/apps/web/src/components/status/agent-status-chip.tsx
@@ -2,7 +2,9 @@ import { cn } from "@/lib/utils";
 import type { FleetAgentVersions } from "@wpmgr/api";
 import {
   AGENT_STATUS_BG,
+  AGENT_STATUS_FG,
   AGENT_STATUS_ICON,
+  agentStatusAccessibleName,
   agentStatusDisplayLabel,
   isFleetDerivedCurrent,
   type AgentStatus,
@@ -20,6 +22,12 @@ export interface AgentStatusChipProps {
    * say without it.
    */
   referenceSource?: FleetAgentVersions["reference_source"];
+  /**
+   * Dense presentation for a fixed-width table track (GH #255): status icon
+   * plus the version, no status word and no pill. See the doc block below
+   * for why the word is dropped and where it goes instead.
+   */
+  compact?: boolean;
   className?: string;
 }
 
@@ -41,11 +49,21 @@ export interface AgentStatusChipProps {
  * and the title explains the reference. Every other status ("outdated",
  * "unknown", "ineligible") already reads the same regardless of source and
  * is left unchanged.
+ *
+ * `compact` (GH #255) drops the status word and the pill, leaving the icon
+ * and the version: in a 22-row fleet table the same word repeats on every
+ * row while stealing width from the Updates and Backup tracks next door,
+ * and the two-line "Current in fleet" wrap doubled the row height. The word
+ * is not lost, it moves: the classification is still carried by icon SHAPE
+ * plus colour, the full state is still announced through visually-hidden
+ * text (agentStatusAccessibleName), and the fleet-derived caveat is stated
+ * once on the column header instead of once per row.
  */
 export function AgentStatusChip({
   status,
   version,
   referenceSource,
+  compact = false,
   className,
 }: AgentStatusChipProps) {
   const Icon = AGENT_STATUS_ICON[status];
@@ -56,6 +74,38 @@ export function AgentStatusChip({
     : version
       ? `Agent ${version}`
       : undefined;
+
+  if (compact) {
+    return (
+      <span
+        title={title}
+        className={cn(
+          "inline-flex items-center gap-1.5 whitespace-nowrap",
+          AGENT_STATUS_FG[status],
+          className,
+        )}
+      >
+        <Icon aria-hidden="true" className="size-3.5 shrink-0" />
+        {/* The announced string. The visible digits below are decorative:
+            on their own they would read as a bare number with no state. */}
+        <span className="sr-only">
+          {agentStatusAccessibleName(status, version, referenceSource)}
+        </span>
+        <span
+          aria-hidden="true"
+          className={cn(
+            "font-mono text-xs tabular-nums",
+            version
+              ? "text-[var(--color-foreground)]"
+              : "text-[var(--color-muted-foreground)]",
+          )}
+        >
+          {version || "—"}
+        </span>
+      </span>
+    );
+  }
+
   return (
     <span
       title={title}

--- a/apps/web/src/components/status/agent-status.ts
+++ b/apps/web/src/components/status/agent-status.ts
@@ -38,6 +38,22 @@ export const AGENT_STATUS_ICON: Record<AgentStatus, typeof CheckCircle2> = {
 };
 
 /**
+ * Icon-only foreground tints, for the compact (dense table) presentation
+ * where there is no pill background to carry the tone. Pairs with
+ * AGENT_STATUS_ICON: every status is distinguished by icon SHAPE as well as
+ * colour, so the classification survives a monochrome display or a colour
+ * vision deficiency. "ineligible" stays muted rather than destructive on
+ * purpose: a build that cannot self-update is a fact about its distribution
+ * channel, not an error the operator can act on.
+ */
+export const AGENT_STATUS_FG: Record<AgentStatus, string> = {
+  current: "text-[var(--color-success)]",
+  outdated: "text-[var(--color-warning)]",
+  unknown: "text-[var(--color-muted-foreground)]",
+  ineligible: "text-[var(--color-muted-foreground)]",
+};
+
+/**
  * True only for the case that overclaims if left unlabeled: status
  * "current" classified against a reference that came from this tenant's own
  * fleet (the newest agent_version any of its sites has reported) rather than
@@ -69,4 +85,25 @@ export function agentStatusDisplayLabel(
 ): string {
   if (isFleetDerivedCurrent(status, referenceSource)) return "Current in fleet";
   return AGENT_STATUS_LABEL[status];
+}
+
+/**
+ * The full string assistive tech should announce for a compact (icon +
+ * version) agent cell, e.g. "Outdated, agent 0.61.96".
+ *
+ * The dense Sites table renders the status as an icon and the version as
+ * bare mono digits, which on its own would announce as a naked number. This
+ * is what the visually-hidden text in that cell says, so the state is never
+ * carried by colour/shape alone. The fleet-derived qualifier is preserved
+ * here even though the visible column moves it into the header: a screen
+ * reader user reading one row in isolation still needs to know the
+ * comparison is against this fleet, not a published release.
+ */
+export function agentStatusAccessibleName(
+  status: AgentStatus,
+  version: string | null | undefined,
+  referenceSource: FleetAgentVersions["reference_source"] | undefined,
+): string {
+  const label = agentStatusDisplayLabel(status, referenceSource);
+  return version ? `${label}, agent ${version}` : `${label}, agent version not reported`;
 }

--- a/apps/web/src/components/status/backup-chip.test.tsx
+++ b/apps/web/src/components/status/backup-chip.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import type { ReactElement } from "react";
+import { render, screen } from "@testing-library/react";
+
+import { BackupChip } from "./backup-chip";
+
+// GH #255 follow-up: in the Sites table the chip sat in a column already
+// headed "Backup", so "Backed up 10h ago" said it twice and wrapped onto two
+// lines on nearly every row, which is what pushed the neighbouring columns
+// off screen. `compact` drops the redundant word from the SCREEN only: it
+// still has to be announced, and a failed backup still has to shout.
+
+function renderInCell(ui: ReactElement) {
+  return render(
+    <table>
+      <tbody>
+        <tr>
+          <td>{ui}</td>
+        </tr>
+      </tbody>
+    </table>,
+  );
+}
+
+describe("BackupChip", () => {
+  it("keeps the full label by default (standalone surfaces)", () => {
+    render(<BackupChip status="success" time="10h ago" />);
+    expect(screen.getByText("Backed up 10h ago")).toBeInTheDocument();
+  });
+
+  it("compact success shows only the relative time on screen", () => {
+    renderInCell(<BackupChip compact status="success" time="10h ago" />);
+    // The visible fragment is the bare time; the redundant word survives
+    // only in visually-hidden text.
+    expect(screen.getByText("10h ago").className).not.toContain("sr-only");
+    expect(screen.getByText("Backed up 10h ago").className).toContain(
+      "sr-only",
+    );
+  });
+
+  it("compact success still announces what happened", () => {
+    renderInCell(<BackupChip compact status="success" time="10h ago" />);
+    expect(screen.getByRole("cell")).toHaveAccessibleName("Backed up 10h ago");
+  });
+
+  it("compact success with no time keeps the full label rather than rendering empty", () => {
+    renderInCell(<BackupChip compact status="success" />);
+    expect(screen.getByText("Backed up")).toBeInTheDocument();
+  });
+
+  it("compact failure keeps its visible word and its destructive palette", () => {
+    renderInCell(<BackupChip compact status="failed" />);
+    // The word stays on screen: a failed backup is the one row an operator
+    // must not skim past.
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(screen.getByRole("cell")).toHaveAccessibleName("Backup failed");
+    const chip = screen.getByText("Failed").parentElement;
+    expect(chip?.className).toContain("bg-destructive-subtle");
+  });
+
+  it("compact running announces the state and keeps the percentage", () => {
+    renderInCell(
+      <BackupChip compact status="running" progressPercent={38} />,
+    );
+    expect(screen.getByText("Running")).toBeInTheDocument();
+    expect(screen.getByRole("cell")).toHaveAccessibleName("Backup running 38%");
+  });
+});

--- a/apps/web/src/components/status/backup-chip.tsx
+++ b/apps/web/src/components/status/backup-chip.tsx
@@ -18,6 +18,13 @@ export interface BackupChipProps {
    * the chip reveals full precision alongside the relative `time` text.
    */
   title?: string;
+  /**
+   * Dense presentation for a table column already headed "Backup" (GH
+   * #255): the status word is moved into visually-hidden text so the chip
+   * renders just the relative time. Standalone surfaces (site card, health
+   * page) have no such header and keep the default full label.
+   */
+  compact?: boolean;
 }
 
 const statusBg: Record<BackupChipStatus, string> = {
@@ -33,6 +40,18 @@ const statusBg: Record<BackupChipStatus, string> = {
  * - success: check icon + "Backed up {time}"
  * - running: spinning loader + "Backup running" + percent (when known)
  * - failed:  X icon + "Failed" + optional inline Retry
+ *
+ * In `compact` mode the leading noun moves into visually-hidden text: a
+ * success reads "10h ago" on screen and still announces "Backed up 10h
+ * ago". Only the redundant word is dropped. The failed state keeps its own
+ * icon, its destructive palette AND its visible "Failed" word, because that
+ * is the one row an operator must never skim past.
+ *
+ * The announcement is assembled as ONE visually-hidden string with the
+ * visible fragments marked aria-hidden, rather than interleaving hidden and
+ * visible text: adjacent inline spans are concatenated without a separator
+ * when a name is computed from contents, which turned "Backup" + "Failed"
+ * into "BackupFailed".
  */
 export function BackupChip({
   status,
@@ -41,12 +60,23 @@ export function BackupChip({
   onRetry,
   className,
   title,
+  compact = false,
 }: BackupChipProps) {
+  // With no time to show, "compact success" would render an empty chip, so
+  // it keeps the full label regardless.
+  const compactSuccess = compact && Boolean(time);
+  const percent =
+    typeof progressPercent === "number" ? Math.round(progressPercent) : null;
+  const announcement =
+    status === "running"
+      ? `Backup running${percent !== null ? ` ${percent}%` : ""}`
+      : "Backup failed";
   return (
     <span
       title={title}
       className={cn(
         "inline-flex items-center gap-1.5 rounded px-2 py-0.5 text-xs font-medium",
+        compact && "whitespace-nowrap",
         statusBg[status],
         className,
       )}
@@ -54,8 +84,20 @@ export function BackupChip({
       {status === "success" ? (
         <>
           <CheckCircle2 aria-hidden="true" className="size-3" />
-          <span>Backed up{time ? ` ${time}` : ""}</span>
+          {compactSuccess ? (
+            <>
+              <span className="sr-only">{`Backed up ${time}`}</span>
+              <span aria-hidden="true" className="tabular-nums">
+                {time}
+              </span>
+            </>
+          ) : (
+            <span>Backed up{time ? ` ${time}` : ""}</span>
+          )}
         </>
+      ) : null}
+      {status !== "success" && compact ? (
+        <span className="sr-only">{announcement}</span>
       ) : null}
       {status === "running" ? (
         <>
@@ -63,10 +105,15 @@ export function BackupChip({
             aria-hidden="true"
             className="size-3 motion-safe:animate-spin"
           />
-          <span>Backup running</span>
-          {typeof progressPercent === "number" ? (
-            <span className="font-mono tabular-nums">
-              {Math.round(progressPercent)}%
+          <span aria-hidden={compact ? "true" : undefined}>
+            {compact ? "Running" : "Backup running"}
+          </span>
+          {percent !== null ? (
+            <span
+              aria-hidden={compact ? "true" : undefined}
+              className="font-mono tabular-nums"
+            >
+              {percent}%
             </span>
           ) : null}
         </>
@@ -74,7 +121,7 @@ export function BackupChip({
       {status === "failed" ? (
         <>
           <XCircle aria-hidden="true" className="size-3" />
-          <span>Failed</span>
+          <span aria-hidden={compact ? "true" : undefined}>Failed</span>
           {onRetry ? (
             <button
               type="button"

--- a/apps/web/src/components/status/update-chip.tsx
+++ b/apps/web/src/components/status/update-chip.tsx
@@ -34,7 +34,11 @@ export function UpdateChip({
     <span
       title={description}
       className={cn(
-        "inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium",
+        // whitespace-nowrap: in the Sites table this pill sits in a fixed
+        // track between the Agent and Backup columns, where a wrapped
+        // "12 updates" doubled the row height and collided with both
+        // neighbours (GH #255).
+        "inline-flex items-center gap-1 whitespace-nowrap rounded px-2 py-0.5 text-xs font-medium",
         severityClasses[severity],
         className,
       )}

--- a/apps/web/src/features/sites/agent-column-header.test.tsx
+++ b/apps/web/src/features/sites/agent-column-header.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import {
+  AgentColumnFleetNote,
+  AGENT_FLEET_NOTE_LABEL,
+  AGENT_FLEET_NOTE_TITLE,
+} from "./agent-column-header";
+
+// GH #255 follow-up. The "in fleet" qualifier used to be appended to every
+// row's Agent chip, which was honest but wrapped the cell onto two lines and
+// pushed the version into the Updates column. It moved here, to the column
+// header, where it is stated once. What must NOT be lost is the distinction
+// itself: a self-hosted install whose reference version came from its own
+// fleet has to keep being told so.
+
+describe("AgentColumnFleetNote", () => {
+  it("renders nothing when the reference version is a published release", () => {
+    const { container } = render(
+      <AgentColumnFleetNote referenceSource="published" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing while the rollup has not loaded", () => {
+    const { container } = render(<AgentColumnFleetNote />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when there is no reference version at all", () => {
+    const { container } = render(<AgentColumnFleetNote referenceSource="none" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("offers a named, keyboard-reachable button for a fleet-derived reference", () => {
+    render(<AgentColumnFleetNote referenceSource="fleet" />);
+    const trigger = screen.getByRole("button", { name: AGENT_FLEET_NOTE_LABEL });
+    // A real <button>, not a hover-only tooltip target: focusable, and
+    // operable by Enter/Space without a pointer.
+    expect(trigger.tagName).toBe("BUTTON");
+    expect(trigger).toHaveAttribute("type", "button");
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("explains the fleet-derived comparison when opened", () => {
+    render(<AgentColumnFleetNote referenceSource="fleet" />);
+    expect(screen.queryByText(AGENT_FLEET_NOTE_TITLE)).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: AGENT_FLEET_NOTE_LABEL }),
+    );
+
+    expect(screen.getByText(AGENT_FLEET_NOTE_TITLE)).toBeInTheDocument();
+    expect(
+      screen.getByText(/newest agent version this fleet has reported/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/may still be behind a newer published build/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/sites/agent-column-header.tsx
+++ b/apps/web/src/features/sites/agent-column-header.tsx
@@ -1,0 +1,81 @@
+import { Info } from "lucide-react";
+import type { FleetAgentVersions } from "@wpmgr/api";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+// GH #255 follow-up / GH #261.
+//
+// The Sites table's Agent column used to append "in fleet" to every single
+// "Current" row when the freshness comparison had no published release
+// manifest to work from. The qualifier was correct (a self-hosted fleet's
+// "newest agent seen anywhere in this tenant" is not the newest agent that
+// exists) but it is a property of the COMPARISON, not of each site, so
+// stating it 22 times per screen wrapped the cell onto two lines, doubled
+// the row height and pushed the version pill into the Updates badge.
+//
+// It is stated once here instead, on the column header, and only when the
+// reference really is fleet-derived. Deliberately a Popover rather than a
+// title/hover tooltip: it must be reachable by keyboard and by touch, not
+// just by a mouse pointer that happens to rest on it.
+
+export const AGENT_FLEET_NOTE_TITLE = "Compared against this fleet";
+
+export const AGENT_FLEET_NOTE_BODY =
+  "No published release manifest was available, so each site is compared against the newest agent version this fleet has reported. That is the normal state on a self-hosted install. A site shown as current is current within this fleet and may still be behind a newer published build.";
+
+export const AGENT_FLEET_NOTE_LABEL = "About the Agent column comparison";
+
+export interface AgentColumnFleetNoteProps {
+  /**
+   * Where the freshness comparison's reference version came from (see
+   * FleetAgentVersions.reference_source). Renders nothing unless this is
+   * "fleet": a published reference needs no caveat, and an absent one means
+   * the rollup has not loaded so there is nothing to explain yet.
+   */
+  referenceSource?: FleetAgentVersions["reference_source"];
+  className?: string;
+}
+
+/** Info affordance for the Sites table's Agent column header. */
+export function AgentColumnFleetNote({
+  referenceSource,
+  className,
+}: AgentColumnFleetNoteProps) {
+  if (referenceSource !== "fleet") return null;
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={AGENT_FLEET_NOTE_LABEL}
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            "inline-flex size-5 shrink-0 items-center justify-center rounded-sm",
+            "text-[var(--color-muted-foreground)] transition-colors",
+            "hover:bg-[var(--color-accent)] hover:text-[var(--color-accent-foreground)]",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)] focus-visible:ring-offset-1",
+            className,
+          )}
+        >
+          <Info aria-hidden="true" className="size-3.5" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-72 space-y-1 p-3 text-xs normal-case tracking-normal"
+      >
+        <p className="font-medium text-[var(--color-foreground)]">
+          {AGENT_FLEET_NOTE_TITLE}
+        </p>
+        <p className="leading-relaxed text-[var(--color-muted-foreground)]">
+          {AGENT_FLEET_NOTE_BODY}
+        </p>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/features/sites/sites-table-geometry.test.ts
+++ b/apps/web/src/features/sites/sites-table-geometry.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  computeSitesColumnWidths,
+  SITES_COLUMN_TRACKS,
+  SITES_TABLE_MAX_CONTENT_WIDTH_PX,
+  SITES_TABLE_MIN_WIDTH_PX,
+} from "./sites-table-geometry";
+
+// GH #255 (columns clipping into each other at laptop widths) and GH #261
+// (the Site column swallowing ~2500px on a 5120px display) are the same
+// geometry bug from opposite ends. These pin both ends.
+
+const trackIndex = (id: string) =>
+  SITES_COLUMN_TRACKS.findIndex((t) => t.id === id);
+const SPACER_INDEX = SITES_COLUMN_TRACKS.length;
+
+const sum = (widths: readonly number[]) => widths.reduce((a, b) => a + b, 0);
+
+describe("sites table column tracks", () => {
+  it("declares tracks in the same order buildColumns() renders them", () => {
+    // The colgroup is authoritative for both the sticky header and the
+    // virtualized body, so a reorder here silently mis-sizes every column.
+    expect(SITES_COLUMN_TRACKS.map((t) => t.id)).toEqual([
+      "select",
+      "url",
+      "client",
+      "tags",
+      "wp_version",
+      "php_version",
+      "agent_version",
+      "updates_count",
+      "backup_status",
+      "uptime_sparkline",
+      "actions",
+    ]);
+  });
+
+  it("caps every growable track (no column may absorb unbounded width)", () => {
+    for (const track of SITES_COLUMN_TRACKS) {
+      if ((track.grow ?? 0) > 0) {
+        expect(track.max, `${track.id} grows without a max`).toBeGreaterThan(
+          track.base,
+        );
+      }
+    }
+  });
+
+  it("keeps the minimum width at the sum of the base tracks", () => {
+    expect(SITES_TABLE_MIN_WIDTH_PX).toBe(
+      sum(SITES_COLUMN_TRACKS.map((t) => t.base)),
+    );
+  });
+});
+
+describe("computeSitesColumnWidths", () => {
+  it("falls back to the base tracks before the container is measured", () => {
+    const widths = computeSitesColumnWidths(0);
+    expect(widths.slice(0, SPACER_INDEX)).toEqual(
+      SITES_COLUMN_TRACKS.map((t) => t.base),
+    );
+    expect(widths[SPACER_INDEX]).toBe(0);
+  });
+
+  it("holds every track at its base below the minimum width so the container scrolls (GH #255)", () => {
+    // Narrow viewport: the fix for the clipping is that nothing is squeezed,
+    // the table keeps its widths and scrolls horizontally instead.
+    const widths = computeSitesColumnWidths(600);
+    expect(widths.slice(0, SPACER_INDEX)).toEqual(
+      SITES_COLUMN_TRACKS.map((t) => t.base),
+    );
+    expect(sum(widths)).toBe(SITES_TABLE_MIN_WIDTH_PX);
+  });
+
+  it("gives the Agent, Updates and Backup tracks their full base at the minimum width", () => {
+    // The three columns that overlapped in the report. Under
+    // `table-layout: fixed` a track narrower than its content overflows into
+    // its neighbour, so these must never be shaved to make room.
+    const widths = computeSitesColumnWidths(SITES_TABLE_MIN_WIDTH_PX);
+    for (const id of ["agent_version", "updates_count", "backup_status"]) {
+      const i = trackIndex(id);
+      expect(widths[i]).toBe(SITES_COLUMN_TRACKS[i]!.base);
+    }
+  });
+
+  it("spends a moderate surplus on Site, Tags and Backup with nothing left over", () => {
+    const widths = computeSitesColumnWidths(1440);
+    expect(widths[trackIndex("url")]).toBeGreaterThan(
+      SITES_COLUMN_TRACKS[trackIndex("url")]!.base,
+    );
+    expect(widths[trackIndex("tags")]).toBeGreaterThan(
+      SITES_COLUMN_TRACKS[trackIndex("tags")]!.base,
+    );
+    expect(widths[trackIndex("backup_status")]).toBeGreaterThan(
+      SITES_COLUMN_TRACKS[trackIndex("backup_status")]!.base,
+    );
+    // 1440 is below the point where every cap is reached, so the spacer is
+    // still empty and no width is wasted.
+    expect(1440).toBeLessThan(SITES_TABLE_MAX_CONTENT_WIDTH_PX);
+    expect(widths[SPACER_INDEX]).toBeLessThanOrEqual(2);
+  });
+
+  it("never grows a non-growable track", () => {
+    const widths = computeSitesColumnWidths(5120);
+    for (const [i, track] of SITES_COLUMN_TRACKS.entries()) {
+      if (!(track.grow ?? 0)) {
+        expect(widths[i], `${track.id} grew`).toBe(track.base);
+      }
+    }
+  });
+
+  it("caps the Site column and parks the rest in the spacer on a 5120px display (GH #261)", () => {
+    const widths = computeSitesColumnWidths(5120);
+    const site = widths[trackIndex("url")]!;
+
+    // The reported symptom: Site took roughly half the table.
+    expect(site).toBe(SITES_COLUMN_TRACKS[trackIndex("url")]!.max);
+    expect(site / 5120).toBeLessThan(0.1);
+
+    // Every other track is at its cap too, so the surplus has nowhere to go
+    // except the trailing spacer.
+    expect(widths[SPACER_INDEX]).toBeGreaterThan(3000);
+    expect(sum(widths)).toBe(5120);
+  });
+
+  it("never exceeds a track's cap at any width", () => {
+    const widthsToCheck = [
+      SITES_TABLE_MIN_WIDTH_PX,
+      1280,
+      1440,
+      1920,
+      2560,
+      3840,
+      5120,
+      8000,
+    ];
+    for (const available of widthsToCheck) {
+      const widths = computeSitesColumnWidths(available);
+      for (const [i, track] of SITES_COLUMN_TRACKS.entries()) {
+        expect(
+          widths[i],
+          `${track.id} at ${available}px`,
+        ).toBeLessThanOrEqual(track.max ?? track.base);
+      }
+      expect(sum(widths)).toBe(Math.max(available, SITES_TABLE_MIN_WIDTH_PX));
+    }
+  });
+
+  it("grows monotonically as the container widens", () => {
+    let previous = computeSitesColumnWidths(SITES_TABLE_MIN_WIDTH_PX);
+    for (let available = SITES_TABLE_MIN_WIDTH_PX + 40; available <= 2600; available += 40) {
+      const widths = computeSitesColumnWidths(available);
+      for (const [i, track] of SITES_COLUMN_TRACKS.entries()) {
+        expect(
+          widths[i],
+          `${track.id} shrank at ${available}px`,
+        ).toBeGreaterThanOrEqual(previous[i]!);
+      }
+      previous = widths;
+    }
+  });
+});

--- a/apps/web/src/features/sites/sites-table-geometry.ts
+++ b/apps/web/src/features/sites/sites-table-geometry.ts
@@ -1,0 +1,146 @@
+// Sites table column geometry for GH #255 / GH #261.
+//
+// Both reports are the same bug seen from opposite ends of the viewport
+// range:
+//
+//   • GH #255 (22-site self-hosted fleet, ordinary laptop width): the Agent,
+//     Updates and Backup cells rendered content wider than their fixed
+//     tracks, so under `table-layout: fixed` they overflowed into each other
+//     and Uptime was pushed past the right edge.
+//   • GH #261 (5120px display): the Site column was the ONLY track without a
+//     width, so under `table-layout: fixed` it absorbed 100% of the leftover
+//     space (roughly 2500px of it) while every other column stayed crushed
+//     against the right edge.
+//
+// The fix is to stop having an implicitly-flexible column at all. Every
+// track declares an explicit base width; the ones that genuinely benefit
+// from extra room (Site, Tags, Backup) declare a growth weight and a HARD
+// CAP; whatever surplus survives every cap is parked in a trailing spacer
+// track so nothing is stretched absurdly.
+//
+// This module is deliberately pure (no React, no DOM): the colgroup in
+// sites-table.tsx is still the single authoritative source of geometry for
+// both the sticky header and the virtualized body, and this is the single
+// authoritative source of the numbers it renders.
+
+export interface SitesColumnTrack {
+  /** Must match the TanStack column id in buildColumns(). */
+  readonly id: string;
+  /** Width at (and below) the table's minimum width. */
+  readonly base: number;
+  /**
+   * Relative share of any surplus width. Omitted/zero means the track never
+   * grows, which is the right default for a track holding fixed-shape
+   * content (a version number, a checkbox, an icon button row).
+   */
+  readonly grow?: number;
+  /** Hard ceiling for a growable track. Required whenever `grow` is set. */
+  readonly max?: number;
+}
+
+/**
+ * Column tracks in render order. THIS ORDER MUST MATCH buildColumns() in
+ * sites-table.tsx; the trailing spacer is appended by
+ * computeSitesColumnWidths and has no TanStack column of its own.
+ *
+ * Base widths are sized to the widest realistic content each cell renders
+ * so the fixed layout never has to overflow a track (GH #255):
+ *   • agent: status icon + a mono semver ("0.61.100") after the per-row
+ *     status word moved to an icon and the "in fleet" qualifier moved to
+ *     the column header.
+ *   • backup: success icon + a relative time ("10h ago", "3mo ago") after
+ *     the redundant "Backed up" prefix was dropped.
+ *   • updates: the widest UpdateChip label ("12 updates").
+ */
+export const SITES_COLUMN_TRACKS: readonly SitesColumnTrack[] = [
+  { id: "select", base: 40 },
+  // Site is the widest column but no longer unbounded: it grows fastest and
+  // stops at 420px, past which a hostname is already fully legible and the
+  // extra width is pure whitespace (GH #261).
+  { id: "url", base: 248, grow: 3, max: 420 },
+  { id: "client", base: 112 },
+  // Tags benefit from real width: extra room converts an overflow chip
+  // ("+2") back into readable tag names.
+  { id: "tags", base: 124, grow: 2, max: 220 },
+  // Version tracks fit a mono "6.8.2" / "8.3.14" plus the odd vendor
+  // suffix without wrapping.
+  { id: "wp_version", base: 76 },
+  { id: "php_version", base: 80 },
+  { id: "agent_version", base: 104 },
+  { id: "updates_count", base: 120 },
+  { id: "backup_status", base: 120, grow: 1, max: 160 },
+  { id: "uptime_sparkline", base: 72 },
+  { id: "actions", base: 68 },
+];
+
+/**
+ * Minimum table width: every track at its base. Below this the table keeps
+ * these widths and the container scrolls horizontally rather than crushing
+ * the columns into each other.
+ */
+export const SITES_TABLE_MIN_WIDTH_PX = SITES_COLUMN_TRACKS.reduce(
+  (sum, t) => sum + t.base,
+  0,
+);
+
+/**
+ * Width at which every growable track has reached its cap. Past this point
+ * all further surplus goes to the trailing spacer.
+ */
+export const SITES_TABLE_MAX_CONTENT_WIDTH_PX = SITES_COLUMN_TRACKS.reduce(
+  (sum, t) => sum + (t.max ?? t.base),
+  0,
+);
+
+/**
+ * Resolve every column track to a concrete pixel width for the measured
+ * `availableWidth` of the table's scroll container.
+ *
+ * Returns SITES_COLUMN_TRACKS.length + 1 entries: one per column, plus the
+ * trailing spacer. The returned widths always sum to
+ * `max(availableWidth, SITES_TABLE_MIN_WIDTH_PX)`, so the colgroup fully
+ * describes the table and no track is left to absorb an unbounded
+ * remainder.
+ *
+ * `availableWidth` of 0 (not yet measured) or a non-finite value resolves to
+ * the base widths, which is also what the server-side/first paint renders.
+ */
+export function computeSitesColumnWidths(availableWidth: number): number[] {
+  const widths = SITES_COLUMN_TRACKS.map((t) => t.base);
+
+  if (!Number.isFinite(availableWidth) || availableWidth <= SITES_TABLE_MIN_WIDTH_PX) {
+    return [...widths, 0];
+  }
+
+  let surplus = availableWidth - SITES_TABLE_MIN_WIDTH_PX;
+
+  // Multiple passes: a track that hits its cap returns its unused share to
+  // the pool so the remaining growable tracks can still use it. Bounded by
+  // the track count, so it always terminates.
+  for (let pass = 0; pass <= SITES_COLUMN_TRACKS.length && surplus > 0; pass += 1) {
+    const active = SITES_COLUMN_TRACKS.map((track, i) => ({ track, i })).filter(
+      ({ track, i }) =>
+        (track.grow ?? 0) > 0 && widths[i]! < (track.max ?? track.base),
+    );
+    if (active.length === 0) break;
+
+    const totalWeight = active.reduce((sum, { track }) => sum + track.grow!, 0);
+    let consumed = 0;
+    for (const { track, i } of active) {
+      const share = (surplus * track.grow!) / totalWeight;
+      const room = (track.max ?? track.base) - widths[i]!;
+      const give = Math.min(share, room);
+      widths[i] = widths[i]! + give;
+      consumed += give;
+    }
+    // Nothing moved (floating point stall): stop rather than spin.
+    if (consumed <= 0) break;
+    surplus -= consumed;
+  }
+
+  // Integerize: floor each track, then hand every leftover pixel to the
+  // spacer so the tracks sum exactly to the available width.
+  const rounded = widths.map((w) => Math.floor(w));
+  const used = rounded.reduce((sum, w) => sum + w, 0);
+  return [...rounded, Math.max(0, Math.round(availableWidth) - used)];
+}

--- a/apps/web/src/features/sites/sites-table.tsx
+++ b/apps/web/src/features/sites/sites-table.tsx
@@ -1,9 +1,13 @@
 import {
+  createContext,
   forwardRef,
+  useContext,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
   type HTMLAttributes,
+  type RefObject,
   type TableHTMLAttributes,
 } from "react";
 import {
@@ -59,6 +63,12 @@ import {
 } from "@/features/sites/use-sites-selection";
 import { SiteRowActions } from "@/features/sites/site-row-actions";
 import { siteUptimeBadge, siteUptimeTextClass } from "@/features/sites/uptime-badge";
+import { AgentColumnFleetNote } from "@/features/sites/agent-column-header";
+import {
+  computeSitesColumnWidths,
+  SITES_COLUMN_TRACKS,
+  SITES_TABLE_MIN_WIDTH_PX,
+} from "@/features/sites/sites-table-geometry";
 
 // Surface 4.5 — the Sites table.
 //
@@ -273,48 +283,50 @@ function TagsCell({ site }: { site: Site }) {
 // Column geometry
 // ---------------------------------------------------------------------------
 
-const COL_CHECKBOX_PX = 40;
-const COL_URL_MIN_PX = 280;
-const COL_CLIENT_PX = 120;
-const COL_TAGS_PX = 140;
-const COL_WP_PX = 80;
-const COL_PHP_PX = 80;
-const COL_AGENT_PX = 100;
-const COL_UPDATES_PX = 120;
-const COL_BACKUP_PX = 160;
-const COL_UPTIME_PX = 70;
-const COL_ACTIONS_PX = 80;
-
 // Single source of column geometry for BOTH the sticky header and the
 // virtualized body, rendered once as a <colgroup> on the table (matches
 // FleetTable). Putting widths only on the <th> cells let the header and the
 // virtualized rows drift out of alignment; the colgroup makes the column tracks
-// authoritative and shared. ORDER MUST MATCH buildColumns(). `undefined` marks
-// the flexible column (Site) that absorbs the remaining width.
-const COLUMN_WIDTHS_PX: ReadonlyArray<number | undefined> = [
-  COL_CHECKBOX_PX, // select
-  undefined, // url (Site) — flexible
-  COL_CLIENT_PX, // client
-  COL_TAGS_PX, // tags
-  COL_WP_PX, // wp_version
-  COL_PHP_PX, // php_version
-  COL_AGENT_PX, // agent_version
-  COL_UPDATES_PX, // updates_count
-  COL_BACKUP_PX, // backup_status
-  COL_UPTIME_PX, // uptime_sparkline
-  COL_ACTIONS_PX, // actions
-];
+// authoritative and shared.
+//
+// The NUMBERS now live in sites-table-geometry.ts (a pure, unit-tested
+// module) and are resolved against the measured container width, because a
+// single implicitly-flexible column is what produced both halves of this
+// bug: it clipped its neighbours when there was too little width (GH #255)
+// and swallowed ~2500px of slack on an ultrawide display (GH #261). Every
+// track is now explicit, the growable ones are capped, and the leftover is
+// parked in a trailing spacer track. ORDER MUST MATCH buildColumns() plus
+// the trailing spacer.
+const COL_CHECKBOX_PX = trackWidth("select");
+const COL_URL_MIN_PX = trackWidth("url");
+const COL_CLIENT_PX = trackWidth("client");
+const COL_TAGS_PX = trackWidth("tags");
+const COL_WP_PX = trackWidth("wp_version");
+const COL_PHP_PX = trackWidth("php_version");
+const COL_AGENT_PX = trackWidth("agent_version");
+const COL_UPDATES_PX = trackWidth("updates_count");
+const COL_BACKUP_PX = trackWidth("backup_status");
+const COL_UPTIME_PX = trackWidth("uptime_sparkline");
+const COL_ACTIONS_PX = trackWidth("actions");
 
-// Minimum table width = the sum of every column at its intended size (the
-// flexible Site column counted at a sensible minimum). When the viewport is
-// narrower than this (mobile), the table keeps these widths and the container
-// scrolls horizontally instead of squeezing the columns into each other — the
-// previous 860px floor was BELOW the fixed columns' total, so on mobile the
-// fixed-layout table compressed every column and the headers overlapped.
-const COL_SITE_MIN_PX = 260;
-const TABLE_MIN_WIDTH_PX = COLUMN_WIDTHS_PX.reduce<number>(
-  (sum, w) => sum + (w ?? COL_SITE_MIN_PX),
-  0,
+function trackWidth(id: string): number {
+  const track = SITES_COLUMN_TRACKS.find((t) => t.id === id);
+  // Unreachable for the ids above; the fallback keeps this total rather
+  // than throwing at module scope if a column is ever renamed.
+  return track?.base ?? 100;
+}
+
+const TABLE_MIN_WIDTH_PX = SITES_TABLE_MIN_WIDTH_PX;
+
+/**
+ * Resolved column widths (one per column, plus the trailing spacer) for the
+ * current container width. Read by the hoisted <VirtuosoTable> slot, which
+ * must keep a STABLE component identity across renders or Virtuoso remounts
+ * its scroller on every resize tick, so the widths reach it through
+ * context rather than through props.
+ */
+const ColumnWidthsContext = createContext<readonly number[]>(
+  computeSitesColumnWidths(0),
 );
 
 // ---------------------------------------------------------------------------
@@ -510,10 +522,20 @@ function buildColumns(
                 —
               </span>
             );
-          return <span className="font-mono text-sm tabular-nums">{v}</span>;
+          return (
+            <span className="whitespace-nowrap font-mono text-sm tabular-nums">
+              {v}
+            </span>
+          );
         }
+        // Compact: icon + version only. The status word repeated on every
+        // row (and the two-line "Current in fleet" wrap) is what clipped
+        // this column into its neighbours; the classification survives as
+        // icon shape + colour, is announced in full to assistive tech, and
+        // the fleet caveat is stated once on the column header.
         return (
           <AgentStatusChip
+            compact
             status={agentStatus}
             version={v || null}
             referenceSource={agentReferenceSource}
@@ -546,9 +568,13 @@ function buildColumns(
         if (!status) return <span aria-hidden="true" />;
         // GH #231 — relative label in the chip, exact timestamp on hover
         // (matches the /backups page's relativeTime + title convention).
+        // GH #255: `compact` drops the "Backed up" prefix the column header
+        // already says; the chip renders "10h ago" and still announces
+        // "Backed up 10h ago". Failures keep their word and their palette.
         const iso = row.original.backupTime;
         return (
           <BackupChip
+            compact
             status={status}
             time={relativeTime(iso) ?? undefined}
             title={iso ? new Date(iso).toLocaleString() : undefined}
@@ -642,6 +668,7 @@ function VirtuosoTable({
   children,
   ...rest
 }: TableHTMLAttributes<HTMLTableElement>) {
+  const widths = useContext(ColumnWidthsContext);
   return (
     <table
       {...rest}
@@ -650,15 +677,46 @@ function VirtuosoTable({
     >
       {/* Authoritative column geometry shared by the sticky header and the
           virtualized body. Without this, per-<th> widths do not propagate to
-          the body rows and the columns drift. */}
+          the body rows and the columns drift. The last track is the spacer
+          that soaks up ultrawide surplus (GH #261). It is zero-width at
+          and below the table's minimum width. */}
       <colgroup>
-        {COLUMN_WIDTHS_PX.map((w, i) => (
-          <col key={i} style={w != null ? { width: w } : undefined} />
+        {widths.map((w, i) => (
+          <col
+            key={i}
+            // The trailing spacer is left auto on purpose: as the ONLY
+            // auto track it absorbs the exact remainder, including the few
+            // pixels a vertical scrollbar takes off the measured width, so
+            // the surplus can never fall back onto the Site column.
+            style={i === widths.length - 1 ? undefined : { width: w }}
+          />
         ))}
       </colgroup>
       {children}
     </table>
   );
+}
+
+/**
+ * Width of `ref`'s element, tracked live. Returns 0 until first measured
+ * (and in any environment without ResizeObserver), which
+ * computeSitesColumnWidths resolves to the base widths.
+ */
+function useMeasuredWidth(ref: RefObject<HTMLElement | null>): number {
+  const [width, setWidth] = useState(0);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    setWidth(el.clientWidth);
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) setWidth(entry.contentRect.width);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref]);
+  return width;
 }
 
 const VirtuosoTableHead = forwardRef<
@@ -794,6 +852,17 @@ export function SitesTable({
   const firstMount = !hasMounted.current;
   hasMounted.current = true;
 
+  // Live container width -> resolved column tracks (GH #255 / GH #261).
+  // Measured on the scroll region (whose own width never changes when the
+  // inner scroller gains a scrollbar), so there is no measure/relayout
+  // feedback loop.
+  const regionRef = useRef<HTMLDivElement>(null);
+  const availableWidth = useMeasuredWidth(regionRef);
+  const columnWidths = useMemo(
+    () => computeSitesColumnWidths(availableWidth),
+    [availableWidth],
+  );
+
   return (
     <motion.div
       className="flex min-w-0 w-full flex-col bg-background"
@@ -804,20 +873,26 @@ export function SitesTable({
       animate="animate"
     >
       <div
+        ref={regionRef}
         role="region"
         aria-label="Sites table"
         aria-busy={isLoading ? "true" : undefined}
         className="relative h-[calc(100vh-12rem)] min-h-[400px] w-full overflow-x-auto"
       >
-        <TableVirtuoso<Row<SiteRow>, unknown>
-          data={sortedRows}
-          totalCount={sortedRows.length}
-          components={virtuosoComponents}
-          fixedHeaderContent={() => (
-            <TableHeaderRow headerGroups={table.getHeaderGroups()} />
-          )}
-          itemContent={(_, row) => <TableBodyCells row={row} />}
-        />
+        <ColumnWidthsContext.Provider value={columnWidths}>
+          <TableVirtuoso<Row<SiteRow>, unknown>
+            data={sortedRows}
+            totalCount={sortedRows.length}
+            components={virtuosoComponents}
+            fixedHeaderContent={() => (
+              <TableHeaderRow
+                headerGroups={table.getHeaderGroups()}
+                agentReferenceSource={agentReferenceSource}
+              />
+            )}
+            itemContent={(_, row) => <TableBodyCells row={row} />}
+          />
+        </ColumnWidthsContext.Provider>
       </div>
     </motion.div>
   );
@@ -830,10 +905,12 @@ export function SitesTable({
 
 function TableHeaderRow({
   headerGroups,
+  agentReferenceSource,
 }: {
   headerGroups: ReturnType<
     ReturnType<typeof useReactTable<SiteRow>>["getHeaderGroups"]
   >;
+  agentReferenceSource?: FleetAgentVersions["reference_source"];
 }) {
   return (
     <>
@@ -850,6 +927,29 @@ function TableHeaderRow({
             const canSort = header.column.getCanSort();
             const isFirst = header.column.id === "select";
             const isActions = header.column.id === "actions";
+            // The "compared against this fleet" caveat is a property of the
+            // whole Agent column, so it is stated once here rather than
+            // appended to every row. It sits OUTSIDE the sort button: a
+            // button nested in a button is invalid and unreachable.
+            const accessory =
+              header.column.id === "agent_version" ? (
+                <AgentColumnFleetNote referenceSource={agentReferenceSource} />
+              ) : null;
+            const content = header.isPlaceholder ? null : canSort ? (
+              <button
+                type="button"
+                onClick={header.column.getToggleSortingHandler()}
+                className="group inline-flex h-full items-center gap-1 text-xs font-medium uppercase tracking-wide text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                {flexRender(
+                  header.column.columnDef.header,
+                  header.getContext(),
+                )}
+                <SortGlyph dir={sortDir} />
+              </button>
+            ) : (
+              flexRender(header.column.columnDef.header, header.getContext())
+            );
             return (
               <th
                 key={header.id}
@@ -860,27 +960,25 @@ function TableHeaderRow({
                   isActions && "pr-4 text-right",
                 )}
               >
-                {header.isPlaceholder ? null : canSort ? (
-                  <button
-                    type="button"
-                    onClick={header.column.getToggleSortingHandler()}
-                    className="group inline-flex h-full items-center gap-1 text-xs font-medium uppercase tracking-wide text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                  >
-                    {flexRender(
-                      header.column.columnDef.header,
-                      header.getContext(),
-                    )}
-                    <SortGlyph dir={sortDir} />
-                  </button>
+                {accessory ? (
+                  // h-full so the wrapped sort button keeps resolving its
+                  // own h-full against the header cell, not against a
+                  // content-sized span.
+                  <span className="inline-flex h-full items-center gap-1">
+                    {content}
+                    {accessory}
+                  </span>
                 ) : (
-                  flexRender(
-                    header.column.columnDef.header,
-                    header.getContext(),
-                  )
+                  content
                 )}
               </th>
             );
           })}
+          {/* Trailing spacer track (GH #261). Present in every row so the
+              column exists in the table grid and the row rule runs the full
+              width; a <td> rather than a <th> so it adds no column name, and
+              aria-hidden so it is skipped by assistive tech. */}
+          <td aria-hidden="true" className="p-0" />
         </tr>
       ))}
     </>
@@ -924,6 +1022,9 @@ function TableBodyCells({ row }: { row: Row<SiteRow> }) {
           </td>
         );
       })}
+      {/* Trailing spacer track, see TableHeaderRow. Carries the row rule so
+          the border still runs to the table's right edge. */}
+      <td aria-hidden="true" className="border-b border-border p-0" />
     </>
   );
 }

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.99
+  version: 0.61.100
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Ships as 0.61.100. Dashboard only, no agent or control-plane change.

Closes #261 and the readability follow-up on #255. Two reports from operators with real fleets, one underlying defect seen from opposite ends.

## The defect

`Site` was the **only** flexible column, so it absorbed every pixel of slack. On @iacopoincerpi's 5120px display it took roughly three quarters of the table while everything else crushed into the right side (#261).

The other columns were fixed tracks under `table-layout: fixed`, so when their **content** exceeded the track it clipped into its neighbour rather than flexing. On @infoproxa-oss's 22-site fleet that pushed Uptime off screen entirely (#255).

## Geometry

Column geometry is now a pure, unit-tested track table. Every column grows only to its own cap, Tags and Backup take a share of the surplus once Site reaches its limit, and the remainder parks in a trailing spacer instead of stretching one column. The colgroup stays the single authority for both the sticky header and the virtualized body; widths never move onto `th` cells, which is what let them drift.

Measured at the reported viewports:

| viewport | Site | spacer | sum |
|---|---|---|---|
| 1164 (floor) | 248 (21.3%) | 0 | 1164 |
| 1440 | 389 (27.0%) | 1 | 1440 |
| 2560 | 420 (16.4%) | 1088 | 2560 |
| **5120** | **420 (8.2%)** | 3648 | 5120 |

Down from about 75% at 5120. Sums are exact at every width.

## Content

Backup read `Backed up 10h ago` under a column titled **Backup**, and wrapped on most rows. Now the time alone, same icon; a failed backup keeps its distinct treatment.

Agent repeated a status word on every row, which on a healthy fleet is nearly all of them, pushing the version into the next column. Each row now shows an icon plus the version, with icon **shape** carrying the meaning rather than colour alone.

## The qualifier moves to the header

I added `Current in fleet` per row in 0.61.99 to stop the chip implying parity with the newest published release. That distinction is real and self-hosters depend on it, so this does not revert it. But @infoproxa-oss made the better point: **it is a property of the comparison, not of each site.** Stated once on the column header it keeps the correctness and returns the width.

The header affordance is a real `<button>` opening a popover, so it is keyboard and touch reachable rather than hover-only, and it renders only when the reference is fleet-derived.

## Accessibility

Icon-only cells keep an accessible name: each announces state and version ("Outdated, agent 0.61.96"), asserted by test rather than by rendered digits. Assembled as one hidden string, because adjacent inline spans concatenate without a separator when a name is computed from contents ("Backup" + "Failed" became `BackupFailed`).

## Also

Rebuilds the loading skeleton from the same track table. Its hand-copied width list had drifted and was missing the Client and Agent columns entirely, so the table visibly shifted sideways as it finished loading.

## Verification

- web: **1300** tests across 106 files (baseline 1270/103)
- lint: 0 errors (3 pre-existing warnings, none in touched files)
- `impeccable detect`: clean, and confirmed the scanner actually reports on a full `src` run rather than silently no-opping
- Geometry verified by computing resolved widths at every reported viewport, not by eyeballing a screenshot

`typecheck` fails only on the pre-existing zod/react-hook-form resolver mismatch; the failing file list is byte-identical to baseline.

## Note on the version

0.61.99 to **0.61.100** is deliberate. This is a presentation fix, so a patch bump is the honest signal, and semver patch numbers are not capped at 99. `version_compare` and Go's semver ordering both handle it, so the agent self-update ladder is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added release 0.61.100 and updated the displayed product version.
  - Added an explanation for fleet-based agent version comparisons in the Sites table.

- **Bug Fixes**
  - Improved Sites table column sizing and alignment across screen widths.
  - Prevented content overlap, wrapping, clipping, and horizontal shifting after loading.
  - Clarified backup status labels and streamlined agent version displays.
  - Improved accessibility announcements for agent, backup, and table status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->