### PR TITLE
fix(api): email log bulk delete and resend silently did nothing (GH #307)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,14 @@ jobs:
         env:
           GOWORK: "off"
           CGO_ENABLED: "0"
-        # apps/api/tests is excluded from BUILD specifically: its only non-test
-        # files are CGO-tagged, so under CGO_ENABLED=0 the package has no buildable
-        # non-test files and `go build` errors on it when named explicitly. Vet
-        # (below) keeps it — vet compiles the _test.go files, so it still
-        # compile-checks the integration tests.
-        run: go build $(go list ./... | grep -v -e /cmd/media-encoder -e /internal/media/encoder -e /apps/api/tests)
+        # apps/api/tests is excluded from BUILD specifically: every file in it is
+        # a _test.go file, so it has no buildable non-test files and `go build`
+        # errors on it when named explicitly. Vet (below) keeps it: vet compiles
+        # the _test.go files, so the integration tests still cannot silently rot.
+        #
+        # The pattern is anchored with $ so it excludes ONLY that package and not
+        # its subpackages. apps/api/tests/contract must keep building here.
+        run: go build $(go list ./... | grep -v -e /cmd/media-encoder -e /internal/media/encoder -e '/apps/api/tests$')
 
       - name: Vet
         env:
@@ -60,9 +62,18 @@ jobs:
           CGO_ENABLED: "0"
         # Also exclude apps/api/tests here: those are container-based integration
         # tests (testcontainers — postgres/redis/minio/clickhouse) that belong in a
-        # separate lane, not the fast unit CI. They are still COMPILE-checked above
-        # by Build + Vet, so they can't silently rot.
-        run: go test $(go list ./... | grep -v -e /cmd/media-encoder -e /internal/media/encoder -e /apps/api/tests)
+        # separate lane, not the fast unit CI. 262 of them stand up their own
+        # ephemeral Postgres, so the cost, not any missing Docker daemon, is why
+        # they sit out this lane. They are still COMPILE-checked above by
+        # Build + Vet, so they can't silently rot.
+        #
+        # The pattern is anchored with $ so it excludes ONLY that package.
+        # apps/api/tests/contract holds the containerless spec-versus-code gates
+        # (TestOpenAPIRouteCoverage and TestOpenAPIRequestBodyFieldCoverage);
+        # they run against an empty *db.Pool in about a second and MUST run on
+        # every PR, because they are what stops an undocumented route or a
+        # handler json tag that no longer matches its schema from merging.
+        run: go test $(go list ./... | grep -v -e /cmd/media-encoder -e /internal/media/encoder -e '/apps/api/tests$')
 
   # ---- JS / web ----
   js:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.101] - 2026-07-29
+
+### Fixed
+
+- On a site's Email > Log tab, selecting log entries and clicking Delete showed a success message reading "0 log entries deleted" and deleted nothing (GH #307, reported by MrMK0R on a self-hosted install). The dashboard and the control plane disagreed about the name of one field in the request: the dashboard sent the list of selected entries under one name, and the control plane looked for it under another, so it received an empty list, deleted nothing, and truthfully reported that it had deleted nothing. There was nothing wrong with deletion itself. The Resend button on the same screen was broken in exactly the same way and for the same reason, so selecting entries and clicking Resend also quietly did nothing. Both are fixed. A deletion that removed nothing was also being written into the audit log as though it had happened; that is corrected too.
+- Sending no entries at all, or an empty list, used to return success with a count of zero, which is the same confusing outcome the bug above produced. Both the delete and resend endpoints now reject that with a clear error instead of reporting a successful deletion of nothing.
+- WPMgr has an automated check that compares every API endpoint against its published specification. It was written, and it worked when run by hand, but it was never included in the automated checks that run on every change, so it had never actually run there. That is why a mismatch like the one above could reach a release. The check now runs on every change, and a second check that compares the fields of every request body against the specification runs alongside it; it also now looks at fields nested inside other fields, not only at the top level. Together the two checks cover 149 request bodies and 646 fields.
+
 ## [0.61.100] - 2026-07-28
 
 ### Fixed

--- a/apps/api/internal/api/gen/oas_defaults_gen.go
+++ b/apps/api/internal/api/gen/oas_defaults_gen.go
@@ -70,6 +70,10 @@ func (s *BulkDeleteBackupsRequest) setDefaults() {
 func (s *ClientReportSectionFlags) setDefaults() {
 	{
 		val := bool(true)
+		s.Overview.SetTo(val)
+	}
+	{
+		val := bool(true)
 		s.Uptime.SetTo(val)
 	}
 	{

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -10881,9 +10881,38 @@ func (s *AgentDbOrphanDeleteProgressResultsItem) Encode(e *jx.Encoder) {
 
 // encodeFields encodes fields.
 func (s *AgentDbOrphanDeleteProgressResultsItem) encodeFields(e *jx.Encoder) {
+	{
+		if s.Kind.Set {
+			e.FieldStart("kind")
+			s.Kind.Encode(e)
+		}
+	}
+	{
+		if s.Name.Set {
+			e.FieldStart("name")
+			s.Name.Encode(e)
+		}
+	}
+	{
+		if s.Status.Set {
+			e.FieldStart("status")
+			s.Status.Encode(e)
+		}
+	}
+	{
+		if s.Detail.Set {
+			e.FieldStart("detail")
+			s.Detail.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfAgentDbOrphanDeleteProgressResultsItem = [0]string{}
+var jsonFieldsNameOfAgentDbOrphanDeleteProgressResultsItem = [4]string{
+	0: "kind",
+	1: "name",
+	2: "status",
+	3: "detail",
+}
 
 // Decode decodes AgentDbOrphanDeleteProgressResultsItem from json.
 func (s *AgentDbOrphanDeleteProgressResultsItem) Decode(d *jx.Decoder) error {
@@ -10893,9 +10922,50 @@ func (s *AgentDbOrphanDeleteProgressResultsItem) Decode(d *jx.Decoder) error {
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
+		case "kind":
+			if err := func() error {
+				s.Kind.Reset()
+				if err := s.Kind.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"kind\"")
+			}
+		case "name":
+			if err := func() error {
+				s.Name.Reset()
+				if err := s.Name.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"name\"")
+			}
+		case "status":
+			if err := func() error {
+				s.Status.Reset()
+				if err := s.Status.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"status\"")
+			}
+		case "detail":
+			if err := func() error {
+				s.Detail.Reset()
+				if err := s.Detail.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"detail\"")
+			}
 		default:
 			return d.Skip()
 		}
+		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode AgentDbOrphanDeleteProgressResultsItem")
 	}
@@ -14445,6 +14515,12 @@ func (s *AgentMediaJobStatus) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.SavedBytes.Set {
+			e.FieldStart("saved_bytes")
+			s.SavedBytes.Encode(e)
+		}
+	}
+	{
 		if s.CompressionLevel.Set {
 			e.FieldStart("compression_level")
 			s.CompressionLevel.Encode(e)
@@ -14470,7 +14546,7 @@ func (s *AgentMediaJobStatus) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfAgentMediaJobStatus = [11]string{
+var jsonFieldsNameOfAgentMediaJobStatus = [12]string{
 	0:  "job_id",
 	1:  "applied_variants",
 	2:  "sizes_unoptimized",
@@ -14478,10 +14554,11 @@ var jsonFieldsNameOfAgentMediaJobStatus = [11]string{
 	4:  "current_size_bytes",
 	5:  "bytes_before",
 	6:  "bytes_after",
-	7:  "compression_level",
-	8:  "target_format",
-	9:  "rewrite_stats",
-	10: "error",
+	7:  "saved_bytes",
+	8:  "compression_level",
+	9:  "target_format",
+	10: "rewrite_stats",
+	11: "error",
 }
 
 // Decode decodes AgentMediaJobStatus from json.
@@ -14573,6 +14650,16 @@ func (s *AgentMediaJobStatus) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"bytes_after\"")
+			}
+		case "saved_bytes":
+			if err := func() error {
+				s.SavedBytes.Reset()
+				if err := s.SavedBytes.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"saved_bytes\"")
 			}
 		case "compression_level":
 			if err := func() error {
@@ -15560,9 +15647,21 @@ func (s *AgentMediaSyncBatchAttachmentsItem) encodeFields(e *jx.Encoder) {
 			s.OriginalSizeBytes.Encode(e)
 		}
 	}
+	{
+		if s.VariantCount.Set {
+			e.FieldStart("variant_count")
+			s.VariantCount.Encode(e)
+		}
+	}
+	{
+		if s.SavedBytes.Set {
+			e.FieldStart("saved_bytes")
+			s.SavedBytes.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfAgentMediaSyncBatchAttachmentsItem = [8]string{
+var jsonFieldsNameOfAgentMediaSyncBatchAttachmentsItem = [10]string{
 	0: "wp_attachment_id",
 	1: "title",
 	2: "original_path",
@@ -15571,6 +15670,8 @@ var jsonFieldsNameOfAgentMediaSyncBatchAttachmentsItem = [8]string{
 	5: "original_width",
 	6: "original_height",
 	7: "original_size_bytes",
+	8: "variant_count",
+	9: "saved_bytes",
 }
 
 // Decode decodes AgentMediaSyncBatchAttachmentsItem from json.
@@ -15660,6 +15761,26 @@ func (s *AgentMediaSyncBatchAttachmentsItem) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"original_size_bytes\"")
+			}
+		case "variant_count":
+			if err := func() error {
+				s.VariantCount.Reset()
+				if err := s.VariantCount.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"variant_count\"")
+			}
+		case "saved_bytes":
+			if err := func() error {
+				s.SavedBytes.Reset()
+				if err := s.SavedBytes.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"saved_bytes\"")
 			}
 		default:
 			return d.Skip()
@@ -15947,6 +16068,54 @@ func (s *AgentMetadata) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.AgentVersion.Set {
+			e.FieldStart("agent_version")
+			s.AgentVersion.Encode(e)
+		}
+	}
+	{
+		if s.AgeRecipient.Set {
+			e.FieldStart("age_recipient")
+			s.AgeRecipient.Encode(e)
+		}
+	}
+	{
+		if s.UserCount.Set {
+			e.FieldStart("user_count")
+			s.UserCount.Encode(e)
+		}
+	}
+	{
+		if s.AdminCount.Set {
+			e.FieldStart("admin_count")
+			s.AdminCount.Encode(e)
+		}
+	}
+	{
+		if s.CoreUpdate.Set {
+			e.FieldStart("core_update")
+			s.CoreUpdate.Encode(e)
+		}
+	}
+	{
+		if s.HostFlags.Set {
+			e.FieldStart("host_flags")
+			s.HostFlags.Encode(e)
+		}
+	}
+	{
+		if s.Disk.Set {
+			e.FieldStart("disk")
+			s.Disk.Encode(e)
+		}
+	}
+	{
+		if s.AgentSelfUpdate.Set {
+			e.FieldStart("agent_self_update")
+			s.AgentSelfUpdate.Encode(e)
+		}
+	}
+	{
 		if s.Plugins != nil {
 			e.FieldStart("plugins")
 			e.ArrStart()
@@ -15968,14 +16137,22 @@ func (s *AgentMetadata) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfAgentMetadata = [7]string{
-	0: "wp_version",
-	1: "php_version",
-	2: "server_info",
-	3: "multisite",
-	4: "active_theme",
-	5: "plugins",
-	6: "themes",
+var jsonFieldsNameOfAgentMetadata = [15]string{
+	0:  "wp_version",
+	1:  "php_version",
+	2:  "server_info",
+	3:  "multisite",
+	4:  "active_theme",
+	5:  "agent_version",
+	6:  "age_recipient",
+	7:  "user_count",
+	8:  "admin_count",
+	9:  "core_update",
+	10: "host_flags",
+	11: "disk",
+	12: "agent_self_update",
+	13: "plugins",
+	14: "themes",
 }
 
 // Decode decodes AgentMetadata from json.
@@ -16036,6 +16213,86 @@ func (s *AgentMetadata) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"active_theme\"")
 			}
+		case "agent_version":
+			if err := func() error {
+				s.AgentVersion.Reset()
+				if err := s.AgentVersion.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"agent_version\"")
+			}
+		case "age_recipient":
+			if err := func() error {
+				s.AgeRecipient.Reset()
+				if err := s.AgeRecipient.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"age_recipient\"")
+			}
+		case "user_count":
+			if err := func() error {
+				s.UserCount.Reset()
+				if err := s.UserCount.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"user_count\"")
+			}
+		case "admin_count":
+			if err := func() error {
+				s.AdminCount.Reset()
+				if err := s.AdminCount.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"admin_count\"")
+			}
+		case "core_update":
+			if err := func() error {
+				s.CoreUpdate.Reset()
+				if err := s.CoreUpdate.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"core_update\"")
+			}
+		case "host_flags":
+			if err := func() error {
+				s.HostFlags.Reset()
+				if err := s.HostFlags.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"host_flags\"")
+			}
+		case "disk":
+			if err := func() error {
+				s.Disk.Reset()
+				if err := s.Disk.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"disk\"")
+			}
+		case "agent_self_update":
+			if err := func() error {
+				s.AgentSelfUpdate.Reset()
+				if err := s.AgentSelfUpdate.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"agent_self_update\"")
+			}
 		case "plugins":
 			if err := func() error {
 				s.Plugins = make([]SiteComponent, 0)
@@ -16090,6 +16347,496 @@ func (s *AgentMetadata) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *AgentMetadata) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *AgentMetadataAgentSelfUpdate) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *AgentMetadataAgentSelfUpdate) encodeFields(e *jx.Encoder) {
+	{
+		if s.Status.Set {
+			e.FieldStart("status")
+			s.Status.Encode(e)
+		}
+	}
+	{
+		if s.FromVersion.Set {
+			e.FieldStart("from_version")
+			s.FromVersion.Encode(e)
+		}
+	}
+	{
+		if s.ToVersion.Set {
+			e.FieldStart("to_version")
+			s.ToVersion.Encode(e)
+		}
+	}
+	{
+		if s.Detail.Set {
+			e.FieldStart("detail")
+			s.Detail.Encode(e)
+		}
+	}
+	{
+		if s.At.Set {
+			e.FieldStart("at")
+			s.At.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfAgentMetadataAgentSelfUpdate = [5]string{
+	0: "status",
+	1: "from_version",
+	2: "to_version",
+	3: "detail",
+	4: "at",
+}
+
+// Decode decodes AgentMetadataAgentSelfUpdate from json.
+func (s *AgentMetadataAgentSelfUpdate) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AgentMetadataAgentSelfUpdate to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "status":
+			if err := func() error {
+				s.Status.Reset()
+				if err := s.Status.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"status\"")
+			}
+		case "from_version":
+			if err := func() error {
+				s.FromVersion.Reset()
+				if err := s.FromVersion.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"from_version\"")
+			}
+		case "to_version":
+			if err := func() error {
+				s.ToVersion.Reset()
+				if err := s.ToVersion.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"to_version\"")
+			}
+		case "detail":
+			if err := func() error {
+				s.Detail.Reset()
+				if err := s.Detail.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"detail\"")
+			}
+		case "at":
+			if err := func() error {
+				s.At.Reset()
+				if err := s.At.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"at\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode AgentMetadataAgentSelfUpdate")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *AgentMetadataAgentSelfUpdate) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AgentMetadataAgentSelfUpdate) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *AgentMetadataCoreUpdate) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *AgentMetadataCoreUpdate) encodeFields(e *jx.Encoder) {
+	{
+		if s.NewVersion.Set {
+			e.FieldStart("new_version")
+			s.NewVersion.Encode(e)
+		}
+	}
+	{
+		if s.CurrentVersion.Set {
+			e.FieldStart("current_version")
+			s.CurrentVersion.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfAgentMetadataCoreUpdate = [2]string{
+	0: "new_version",
+	1: "current_version",
+}
+
+// Decode decodes AgentMetadataCoreUpdate from json.
+func (s *AgentMetadataCoreUpdate) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AgentMetadataCoreUpdate to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "new_version":
+			if err := func() error {
+				s.NewVersion.Reset()
+				if err := s.NewVersion.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"new_version\"")
+			}
+		case "current_version":
+			if err := func() error {
+				s.CurrentVersion.Reset()
+				if err := s.CurrentVersion.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"current_version\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode AgentMetadataCoreUpdate")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *AgentMetadataCoreUpdate) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AgentMetadataCoreUpdate) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *AgentMetadataDisk) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *AgentMetadataDisk) encodeFields(e *jx.Encoder) {
+	{
+		if s.WpContentBytes.Set {
+			e.FieldStart("wp_content_bytes")
+			s.WpContentBytes.Encode(e)
+		}
+	}
+	{
+		if s.UploadsBytes.Set {
+			e.FieldStart("uploads_bytes")
+			s.UploadsBytes.Encode(e)
+		}
+	}
+	{
+		if s.FreeBytes.Set {
+			e.FieldStart("free_bytes")
+			s.FreeBytes.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfAgentMetadataDisk = [3]string{
+	0: "wp_content_bytes",
+	1: "uploads_bytes",
+	2: "free_bytes",
+}
+
+// Decode decodes AgentMetadataDisk from json.
+func (s *AgentMetadataDisk) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AgentMetadataDisk to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "wp_content_bytes":
+			if err := func() error {
+				s.WpContentBytes.Reset()
+				if err := s.WpContentBytes.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"wp_content_bytes\"")
+			}
+		case "uploads_bytes":
+			if err := func() error {
+				s.UploadsBytes.Reset()
+				if err := s.UploadsBytes.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"uploads_bytes\"")
+			}
+		case "free_bytes":
+			if err := func() error {
+				s.FreeBytes.Reset()
+				if err := s.FreeBytes.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"free_bytes\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode AgentMetadataDisk")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *AgentMetadataDisk) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AgentMetadataDisk) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *AgentMetadataHostFlags) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *AgentMetadataHostFlags) encodeFields(e *jx.Encoder) {
+	{
+		if s.IsPressable.Set {
+			e.FieldStart("is_pressable")
+			s.IsPressable.Encode(e)
+		}
+	}
+	{
+		if s.IsGridpane.Set {
+			e.FieldStart("is_gridpane")
+			s.IsGridpane.Encode(e)
+		}
+	}
+	{
+		if s.IsWpengine.Set {
+			e.FieldStart("is_wpengine")
+			s.IsWpengine.Encode(e)
+		}
+	}
+	{
+		if s.IsAtomic.Set {
+			e.FieldStart("is_atomic")
+			s.IsAtomic.Encode(e)
+		}
+	}
+	{
+		if s.IsKinsta.Set {
+			e.FieldStart("is_kinsta")
+			s.IsKinsta.Encode(e)
+		}
+	}
+	{
+		if s.IsFlywheel.Set {
+			e.FieldStart("is_flywheel")
+			s.IsFlywheel.Encode(e)
+		}
+	}
+	{
+		if s.IsRuncloud.Set {
+			e.FieldStart("is_runcloud")
+			s.IsRuncloud.Encode(e)
+		}
+	}
+	{
+		if s.IsCloudways.Set {
+			e.FieldStart("is_cloudways")
+			s.IsCloudways.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfAgentMetadataHostFlags = [8]string{
+	0: "is_pressable",
+	1: "is_gridpane",
+	2: "is_wpengine",
+	3: "is_atomic",
+	4: "is_kinsta",
+	5: "is_flywheel",
+	6: "is_runcloud",
+	7: "is_cloudways",
+}
+
+// Decode decodes AgentMetadataHostFlags from json.
+func (s *AgentMetadataHostFlags) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AgentMetadataHostFlags to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "is_pressable":
+			if err := func() error {
+				s.IsPressable.Reset()
+				if err := s.IsPressable.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"is_pressable\"")
+			}
+		case "is_gridpane":
+			if err := func() error {
+				s.IsGridpane.Reset()
+				if err := s.IsGridpane.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"is_gridpane\"")
+			}
+		case "is_wpengine":
+			if err := func() error {
+				s.IsWpengine.Reset()
+				if err := s.IsWpengine.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"is_wpengine\"")
+			}
+		case "is_atomic":
+			if err := func() error {
+				s.IsAtomic.Reset()
+				if err := s.IsAtomic.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"is_atomic\"")
+			}
+		case "is_kinsta":
+			if err := func() error {
+				s.IsKinsta.Reset()
+				if err := s.IsKinsta.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"is_kinsta\"")
+			}
+		case "is_flywheel":
+			if err := func() error {
+				s.IsFlywheel.Reset()
+				if err := s.IsFlywheel.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"is_flywheel\"")
+			}
+		case "is_runcloud":
+			if err := func() error {
+				s.IsRuncloud.Reset()
+				if err := s.IsRuncloud.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"is_runcloud\"")
+			}
+		case "is_cloudways":
+			if err := func() error {
+				s.IsCloudways.Reset()
+				if err := s.IsCloudways.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"is_cloudways\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode AgentMetadataHostFlags")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *AgentMetadataHostFlags) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AgentMetadataHostFlags) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -26014,10 +26761,24 @@ func (s *BillingCheckoutRequest) encodeFields(e *jx.Encoder) {
 		e.FieldStart("tier")
 		s.Tier.Encode(e)
 	}
+	{
+		if s.Provider.Set {
+			e.FieldStart("provider")
+			s.Provider.Encode(e)
+		}
+	}
+	{
+		if s.Currency.Set {
+			e.FieldStart("currency")
+			s.Currency.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfBillingCheckoutRequest = [1]string{
+var jsonFieldsNameOfBillingCheckoutRequest = [3]string{
 	0: "tier",
+	1: "provider",
+	2: "currency",
 }
 
 // Decode decodes BillingCheckoutRequest from json.
@@ -26038,6 +26799,26 @@ func (s *BillingCheckoutRequest) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"tier\"")
+			}
+		case "provider":
+			if err := func() error {
+				s.Provider.Reset()
+				if err := s.Provider.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"provider\"")
+			}
+		case "currency":
+			if err := func() error {
+				s.Currency.Reset()
+				if err := s.Currency.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"currency\"")
 			}
 		default:
 			return d.Skip()
@@ -32827,6 +33608,12 @@ func (s *ClientReportSectionFlags) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *ClientReportSectionFlags) encodeFields(e *jx.Encoder) {
 	{
+		if s.Overview.Set {
+			e.FieldStart("overview")
+			s.Overview.Encode(e)
+		}
+	}
+	{
 		if s.Uptime.Set {
 			e.FieldStart("uptime")
 			s.Uptime.Encode(e)
@@ -32858,12 +33645,13 @@ func (s *ClientReportSectionFlags) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfClientReportSectionFlags = [5]string{
-	0: "uptime",
-	1: "backups",
-	2: "updates",
-	3: "performance",
-	4: "email",
+var jsonFieldsNameOfClientReportSectionFlags = [6]string{
+	0: "overview",
+	1: "uptime",
+	2: "backups",
+	3: "updates",
+	4: "performance",
+	5: "email",
 }
 
 // Decode decodes ClientReportSectionFlags from json.
@@ -32875,6 +33663,16 @@ func (s *ClientReportSectionFlags) Decode(d *jx.Decoder) error {
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
+		case "overview":
+			if err := func() error {
+				s.Overview.Reset()
+				if err := s.Overview.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"overview\"")
+			}
 		case "uptime":
 			if err := func() error {
 				s.Uptime.Reset()
@@ -73947,6 +74745,202 @@ func (s *OptMediaVariantResultState) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes AgentMetadataAgentSelfUpdate as json.
+func (o OptNilAgentMetadataAgentSelfUpdate) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	if o.Null {
+		e.Null()
+		return
+	}
+	o.Value.Encode(e)
+}
+
+// Decode decodes AgentMetadataAgentSelfUpdate from json.
+func (o *OptNilAgentMetadataAgentSelfUpdate) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptNilAgentMetadataAgentSelfUpdate to nil")
+	}
+	if d.Next() == jx.Null {
+		if err := d.Null(); err != nil {
+			return err
+		}
+
+		var v AgentMetadataAgentSelfUpdate
+		o.Value = v
+		o.Set = true
+		o.Null = true
+		return nil
+	}
+	o.Set = true
+	o.Null = false
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptNilAgentMetadataAgentSelfUpdate) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptNilAgentMetadataAgentSelfUpdate) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes AgentMetadataCoreUpdate as json.
+func (o OptNilAgentMetadataCoreUpdate) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	if o.Null {
+		e.Null()
+		return
+	}
+	o.Value.Encode(e)
+}
+
+// Decode decodes AgentMetadataCoreUpdate from json.
+func (o *OptNilAgentMetadataCoreUpdate) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptNilAgentMetadataCoreUpdate to nil")
+	}
+	if d.Next() == jx.Null {
+		if err := d.Null(); err != nil {
+			return err
+		}
+
+		var v AgentMetadataCoreUpdate
+		o.Value = v
+		o.Set = true
+		o.Null = true
+		return nil
+	}
+	o.Set = true
+	o.Null = false
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptNilAgentMetadataCoreUpdate) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptNilAgentMetadataCoreUpdate) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes AgentMetadataDisk as json.
+func (o OptNilAgentMetadataDisk) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	if o.Null {
+		e.Null()
+		return
+	}
+	o.Value.Encode(e)
+}
+
+// Decode decodes AgentMetadataDisk from json.
+func (o *OptNilAgentMetadataDisk) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptNilAgentMetadataDisk to nil")
+	}
+	if d.Next() == jx.Null {
+		if err := d.Null(); err != nil {
+			return err
+		}
+
+		var v AgentMetadataDisk
+		o.Value = v
+		o.Set = true
+		o.Null = true
+		return nil
+	}
+	o.Set = true
+	o.Null = false
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptNilAgentMetadataDisk) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptNilAgentMetadataDisk) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes AgentMetadataHostFlags as json.
+func (o OptNilAgentMetadataHostFlags) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	if o.Null {
+		e.Null()
+		return
+	}
+	o.Value.Encode(e)
+}
+
+// Decode decodes AgentMetadataHostFlags from json.
+func (o *OptNilAgentMetadataHostFlags) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptNilAgentMetadataHostFlags to nil")
+	}
+	if d.Next() == jx.Null {
+		if err := d.Null(); err != nil {
+			return err
+		}
+
+		var v AgentMetadataHostFlags
+		o.Value = v
+		o.Set = true
+		o.Null = true
+		return nil
+	}
+	o.Set = true
+	o.Null = false
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptNilAgentMetadataHostFlags) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptNilAgentMetadataHostFlags) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes bool as json.
 func (o OptNilBool) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -78569,6 +79563,42 @@ func (s *PerfConfig) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.RumEnabled.Set {
+			e.FieldStart("rum_enabled")
+			s.RumEnabled.Encode(e)
+		}
+	}
+	{
+		if s.RumSampleRate.Set {
+			e.FieldStart("rum_sample_rate")
+			s.RumSampleRate.Encode(e)
+		}
+	}
+	{
+		if s.MinSampleCount.Set {
+			e.FieldStart("min_sample_count")
+			s.MinSampleCount.Encode(e)
+		}
+	}
+	{
+		if s.MaxDistinctCountries.Set {
+			e.FieldStart("max_distinct_countries")
+			s.MaxDistinctCountries.Encode(e)
+		}
+	}
+	{
+		if s.BeaconKeySet.Set {
+			e.FieldStart("beacon_key_set")
+			s.BeaconKeySet.Encode(e)
+		}
+	}
+	{
+		if s.BeaconKeyAckedPresent.Set {
+			e.FieldStart("beacon_key_acked_present")
+			s.BeaconKeyAckedPresent.Encode(e)
+		}
+	}
+	{
 		if s.ConfigVersion.Set {
 			e.FieldStart("config_version")
 			s.ConfigVersion.Encode(e)
@@ -78582,7 +79612,7 @@ func (s *PerfConfig) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfPerfConfig = [68]string{
+var jsonFieldsNameOfPerfConfig = [74]string{
 	0:  "cache_enabled",
 	1:  "cache_logged_in",
 	2:  "cache_mobile",
@@ -78649,8 +79679,14 @@ var jsonFieldsNameOfPerfConfig = [68]string{
 	63: "woo_cacheable_session",
 	64: "woo_theme_fragments_supported",
 	65: "woo_fragments_probed_at",
-	66: "config_version",
-	67: "updated_at",
+	66: "rum_enabled",
+	67: "rum_sample_rate",
+	68: "min_sample_count",
+	69: "max_distinct_countries",
+	70: "beacon_key_set",
+	71: "beacon_key_acked_present",
+	72: "config_version",
+	73: "updated_at",
 }
 
 // Decode decodes PerfConfig from json.
@@ -79393,6 +80429,66 @@ func (s *PerfConfig) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"woo_fragments_probed_at\"")
+			}
+		case "rum_enabled":
+			if err := func() error {
+				s.RumEnabled.Reset()
+				if err := s.RumEnabled.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"rum_enabled\"")
+			}
+		case "rum_sample_rate":
+			if err := func() error {
+				s.RumSampleRate.Reset()
+				if err := s.RumSampleRate.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"rum_sample_rate\"")
+			}
+		case "min_sample_count":
+			if err := func() error {
+				s.MinSampleCount.Reset()
+				if err := s.MinSampleCount.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"min_sample_count\"")
+			}
+		case "max_distinct_countries":
+			if err := func() error {
+				s.MaxDistinctCountries.Reset()
+				if err := s.MaxDistinctCountries.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"max_distinct_countries\"")
+			}
+		case "beacon_key_set":
+			if err := func() error {
+				s.BeaconKeySet.Reset()
+				if err := s.BeaconKeySet.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"beacon_key_set\"")
+			}
+		case "beacon_key_acked_present":
+			if err := func() error {
+				s.BeaconKeyAckedPresent.Reset()
+				if err := s.BeaconKeyAckedPresent.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"beacon_key_acked_present\"")
 			}
 		case "config_version":
 			if err := func() error {
@@ -102403,6 +103499,30 @@ func (s *SiteComponent) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.PluginURI.Set {
+			e.FieldStart("plugin_uri")
+			s.PluginURI.Encode(e)
+		}
+	}
+	{
+		if s.UpdateURI.Set {
+			e.FieldStart("update_uri")
+			s.UpdateURI.Encode(e)
+		}
+	}
+	{
+		if s.AuthorURI.Set {
+			e.FieldStart("author_uri")
+			s.AuthorURI.Encode(e)
+		}
+	}
+	{
+		if s.Network.Set {
+			e.FieldStart("network")
+			s.Network.Encode(e)
+		}
+	}
+	{
 		if s.AvailableUpdate.Set {
 			e.FieldStart("available_update")
 			s.AvailableUpdate.Encode(e)
@@ -102410,12 +103530,16 @@ func (s *SiteComponent) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfSiteComponent = [5]string{
+var jsonFieldsNameOfSiteComponent = [9]string{
 	0: "slug",
 	1: "name",
 	2: "version",
 	3: "active",
-	4: "available_update",
+	4: "plugin_uri",
+	5: "update_uri",
+	6: "author_uri",
+	7: "network",
+	8: "available_update",
 }
 
 // Decode decodes SiteComponent from json.
@@ -102423,7 +103547,7 @@ func (s *SiteComponent) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode SiteComponent to nil")
 	}
-	var requiredBitSet [1]uint8
+	var requiredBitSet [2]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
@@ -102469,6 +103593,46 @@ func (s *SiteComponent) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"active\"")
 			}
+		case "plugin_uri":
+			if err := func() error {
+				s.PluginURI.Reset()
+				if err := s.PluginURI.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"plugin_uri\"")
+			}
+		case "update_uri":
+			if err := func() error {
+				s.UpdateURI.Reset()
+				if err := s.UpdateURI.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"update_uri\"")
+			}
+		case "author_uri":
+			if err := func() error {
+				s.AuthorURI.Reset()
+				if err := s.AuthorURI.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"author_uri\"")
+			}
+		case "network":
+			if err := func() error {
+				s.Network.Reset()
+				if err := s.Network.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"network\"")
+			}
 		case "available_update":
 			if err := func() error {
 				s.AvailableUpdate.Reset()
@@ -102488,8 +103652,9 @@ func (s *SiteComponent) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [1]uint8{
+	for i, mask := range [2]uint8{
 		0b00000001,
+		0b00000000,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -106305,6 +107470,12 @@ func (s *SiteErrorConfig) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *SiteErrorConfig) encodeFields(e *jx.Encoder) {
 	{
+		if s.Enabled.Set {
+			e.FieldStart("enabled")
+			s.Enabled.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("error_level")
 		e.Int32(s.ErrorLevel)
 	}
@@ -106318,9 +107489,10 @@ func (s *SiteErrorConfig) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfSiteErrorConfig = [2]string{
-	0: "error_level",
-	1: "ignore_md5s",
+var jsonFieldsNameOfSiteErrorConfig = [3]string{
+	0: "enabled",
+	1: "error_level",
+	2: "ignore_md5s",
 }
 
 // Decode decodes SiteErrorConfig from json.
@@ -106332,8 +107504,18 @@ func (s *SiteErrorConfig) Decode(d *jx.Decoder) error {
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
+		case "enabled":
+			if err := func() error {
+				s.Enabled.Reset()
+				if err := s.Enabled.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"enabled\"")
+			}
 		case "error_level":
-			requiredBitSet[0] |= 1 << 0
+			requiredBitSet[0] |= 1 << 1
 			if err := func() error {
 				v, err := d.Int32()
 				s.ErrorLevel = int32(v)
@@ -106345,7 +107527,7 @@ func (s *SiteErrorConfig) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"error_level\"")
 			}
 		case "ignore_md5s":
-			requiredBitSet[0] |= 1 << 1
+			requiredBitSet[0] |= 1 << 2
 			if err := func() error {
 				s.IgnoreMd5s = make([]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -106374,7 +107556,7 @@ func (s *SiteErrorConfig) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000011,
+		0b00000110,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -106430,6 +107612,12 @@ func (s *SiteErrorConfigUpdate) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *SiteErrorConfigUpdate) encodeFields(e *jx.Encoder) {
 	{
+		if s.Enabled.Set {
+			e.FieldStart("enabled")
+			s.Enabled.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("error_level")
 		e.Int32(s.ErrorLevel)
 	}
@@ -106443,9 +107631,10 @@ func (s *SiteErrorConfigUpdate) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfSiteErrorConfigUpdate = [2]string{
-	0: "error_level",
-	1: "ignore_md5s",
+var jsonFieldsNameOfSiteErrorConfigUpdate = [3]string{
+	0: "enabled",
+	1: "error_level",
+	2: "ignore_md5s",
 }
 
 // Decode decodes SiteErrorConfigUpdate from json.
@@ -106457,8 +107646,18 @@ func (s *SiteErrorConfigUpdate) Decode(d *jx.Decoder) error {
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
+		case "enabled":
+			if err := func() error {
+				s.Enabled.Reset()
+				if err := s.Enabled.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"enabled\"")
+			}
 		case "error_level":
-			requiredBitSet[0] |= 1 << 0
+			requiredBitSet[0] |= 1 << 1
 			if err := func() error {
 				v, err := d.Int32()
 				s.ErrorLevel = int32(v)
@@ -106470,7 +107669,7 @@ func (s *SiteErrorConfigUpdate) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"error_level\"")
 			}
 		case "ignore_md5s":
-			requiredBitSet[0] |= 1 << 1
+			requiredBitSet[0] |= 1 << 2
 			if err := func() error {
 				s.IgnoreMd5s = make([]string, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -106499,7 +107698,7 @@ func (s *SiteErrorConfigUpdate) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000011,
+		0b00000110,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -4230,7 +4230,7 @@ func (s *AgentDbCleanProgress) SetDone(val bool) {
 // Ref: #/components/schemas/AgentDbOrphanDeleteProgress
 type AgentDbOrphanDeleteProgress struct {
 	JobID string `json:"job_id"`
-	// Agent-defined per-item result rows.
+	// Per-item result rows for the items processed in this batch.
 	Results        []AgentDbOrphanDeleteProgressResultsItem `json:"results"`
 	DeletedOptions OptInt                                   `json:"deleted_options"`
 	DeletedCron    OptInt                                   `json:"deleted_cron"`
@@ -4309,7 +4309,52 @@ func (s *AgentDbOrphanDeleteProgress) SetDone(val bool) {
 	s.Done = val
 }
 
-type AgentDbOrphanDeleteProgressResultsItem struct{}
+type AgentDbOrphanDeleteProgressResultsItem struct {
+	Kind   OptString `json:"kind"`
+	Name   OptString `json:"name"`
+	Status OptString `json:"status"`
+	Detail OptString `json:"detail"`
+}
+
+// GetKind returns the value of Kind.
+func (s *AgentDbOrphanDeleteProgressResultsItem) GetKind() OptString {
+	return s.Kind
+}
+
+// GetName returns the value of Name.
+func (s *AgentDbOrphanDeleteProgressResultsItem) GetName() OptString {
+	return s.Name
+}
+
+// GetStatus returns the value of Status.
+func (s *AgentDbOrphanDeleteProgressResultsItem) GetStatus() OptString {
+	return s.Status
+}
+
+// GetDetail returns the value of Detail.
+func (s *AgentDbOrphanDeleteProgressResultsItem) GetDetail() OptString {
+	return s.Detail
+}
+
+// SetKind sets the value of Kind.
+func (s *AgentDbOrphanDeleteProgressResultsItem) SetKind(val OptString) {
+	s.Kind = val
+}
+
+// SetName sets the value of Name.
+func (s *AgentDbOrphanDeleteProgressResultsItem) SetName(val OptString) {
+	s.Name = val
+}
+
+// SetStatus sets the value of Status.
+func (s *AgentDbOrphanDeleteProgressResultsItem) SetStatus(val OptString) {
+	s.Status = val
+}
+
+// SetDetail sets the value of Detail.
+func (s *AgentDbOrphanDeleteProgressResultsItem) SetDetail(val OptString) {
+	s.Detail = val
+}
 
 // M21 — the signed last-will body.
 // Ref: #/components/schemas/AgentDisconnect
@@ -5521,10 +5566,13 @@ type AgentMediaJobStatus struct {
 	CurrentSizeBytes OptInt64                               `json:"current_size_bytes"`
 	BytesBefore      OptNilInt64                            `json:"bytes_before"`
 	BytesAfter       OptNilInt64                            `json:"bytes_after"`
-	CompressionLevel OptString                              `json:"compression_level"`
-	TargetFormat     OptString                              `json:"target_format"`
-	RewriteStats     OptAgentMediaJobStatusRewriteStats     `json:"rewrite_stats"`
-	Error            OptString                              `json:"error"`
+	// All-variant savings (summed original-minus-optimized over every optimized variant). Drives the
+	// dashboard "Bytes saved" rollup.
+	SavedBytes       OptNilInt64                        `json:"saved_bytes"`
+	CompressionLevel OptString                          `json:"compression_level"`
+	TargetFormat     OptString                          `json:"target_format"`
+	RewriteStats     OptAgentMediaJobStatusRewriteStats `json:"rewrite_stats"`
+	Error            OptString                          `json:"error"`
 }
 
 // GetJobID returns the value of JobID.
@@ -5560,6 +5608,11 @@ func (s *AgentMediaJobStatus) GetBytesBefore() OptNilInt64 {
 // GetBytesAfter returns the value of BytesAfter.
 func (s *AgentMediaJobStatus) GetBytesAfter() OptNilInt64 {
 	return s.BytesAfter
+}
+
+// GetSavedBytes returns the value of SavedBytes.
+func (s *AgentMediaJobStatus) GetSavedBytes() OptNilInt64 {
+	return s.SavedBytes
 }
 
 // GetCompressionLevel returns the value of CompressionLevel.
@@ -5615,6 +5668,11 @@ func (s *AgentMediaJobStatus) SetBytesBefore(val OptNilInt64) {
 // SetBytesAfter sets the value of BytesAfter.
 func (s *AgentMediaJobStatus) SetBytesAfter(val OptNilInt64) {
 	s.BytesAfter = val
+}
+
+// SetSavedBytes sets the value of SavedBytes.
+func (s *AgentMediaJobStatus) SetSavedBytes(val OptNilInt64) {
+	s.SavedBytes = val
 }
 
 // SetCompressionLevel sets the value of CompressionLevel.
@@ -5858,6 +5916,10 @@ type AgentMediaSyncBatchAttachmentsItem struct {
 	OriginalWidth     OptNilInt `json:"original_width"`
 	OriginalHeight    OptNilInt `json:"original_height"`
 	OriginalSizeBytes OptInt64  `json:"original_size_bytes"`
+	// 1 (full) plus generated sub-sizes.
+	VariantCount OptInt `json:"variant_count"`
+	// All-variant savings, re-reported at sync so already-optimized rows heal.
+	SavedBytes OptInt64 `json:"saved_bytes"`
 }
 
 // GetWpAttachmentID returns the value of WpAttachmentID.
@@ -5900,6 +5962,16 @@ func (s *AgentMediaSyncBatchAttachmentsItem) GetOriginalSizeBytes() OptInt64 {
 	return s.OriginalSizeBytes
 }
 
+// GetVariantCount returns the value of VariantCount.
+func (s *AgentMediaSyncBatchAttachmentsItem) GetVariantCount() OptInt {
+	return s.VariantCount
+}
+
+// GetSavedBytes returns the value of SavedBytes.
+func (s *AgentMediaSyncBatchAttachmentsItem) GetSavedBytes() OptInt64 {
+	return s.SavedBytes
+}
+
 // SetWpAttachmentID sets the value of WpAttachmentID.
 func (s *AgentMediaSyncBatchAttachmentsItem) SetWpAttachmentID(val OptInt64) {
 	s.WpAttachmentID = val
@@ -5938,6 +6010,16 @@ func (s *AgentMediaSyncBatchAttachmentsItem) SetOriginalHeight(val OptNilInt) {
 // SetOriginalSizeBytes sets the value of OriginalSizeBytes.
 func (s *AgentMediaSyncBatchAttachmentsItem) SetOriginalSizeBytes(val OptInt64) {
 	s.OriginalSizeBytes = val
+}
+
+// SetVariantCount sets the value of VariantCount.
+func (s *AgentMediaSyncBatchAttachmentsItem) SetVariantCount(val OptInt) {
+	s.VariantCount = val
+}
+
+// SetSavedBytes sets the value of SavedBytes.
+func (s *AgentMediaSyncBatchAttachmentsItem) SetSavedBytes(val OptInt64) {
+	s.SavedBytes = val
 }
 
 type AgentMediaSyncBatchOK struct {
@@ -5992,15 +6074,38 @@ func (s *AgentMediaSyncFinalizeOK) SetOk(val OptBool) {
 
 func (*AgentMediaSyncFinalizeOK) agentMediaSyncFinalizeRes() {}
 
+// The agent's metadata push. Every field is optional and tolerantly
+// decoded (booleans and numbers are accepted as strings), so an older
+// agent that omits any of them still syncs successfully.
 // Ref: #/components/schemas/AgentMetadata
 type AgentMetadata struct {
-	WpVersion   OptString       `json:"wp_version"`
-	PhpVersion  OptString       `json:"php_version"`
-	ServerInfo  OptString       `json:"server_info"`
-	Multisite   OptBool         `json:"multisite"`
-	ActiveTheme OptString       `json:"active_theme"`
-	Plugins     []SiteComponent `json:"plugins"`
-	Themes      []SiteComponent `json:"themes"`
+	WpVersion   OptString `json:"wp_version"`
+	PhpVersion  OptString `json:"php_version"`
+	ServerInfo  OptString `json:"server_info"`
+	Multisite   OptBool   `json:"multisite"`
+	ActiveTheme OptString `json:"active_theme"`
+	// The WPMgr agent plugin version.
+	AgentVersion OptString `json:"agent_version"`
+	// The agent's per-site age PUBLIC recipient ("age1..."), stored so
+	// backups can be triggered without a separate registration call.
+	// Empty or missing leaves the stored recipient unchanged.
+	AgeRecipient OptString `json:"age_recipient"`
+	UserCount    OptInt    `json:"user_count"`
+	AdminCount   OptInt    `json:"admin_count"`
+	// Present only when WordPress core has an update available.
+	CoreUpdate OptNilAgentMetadataCoreUpdate `json:"core_update"`
+	// The agent's defined()-based hosting fingerprint.
+	HostFlags OptNilAgentMetadataHostFlags `json:"host_flags"`
+	// Sampled disk usage in bytes. The wp-content and uploads walks are
+	// time-capped, so a field may be absent on a very large tree.
+	Disk OptNilAgentMetadataDisk `json:"disk"`
+	// The outcome of the agent's last self-update apply, replayed on the
+	// next metadata push. This is the only channel by which a FAILED
+	// apply reaches the control plane: the apply runs inside a cron
+	// request with no response to ride on.
+	AgentSelfUpdate OptNilAgentMetadataAgentSelfUpdate `json:"agent_self_update"`
+	Plugins         []SiteComponent                    `json:"plugins"`
+	Themes          []SiteComponent                    `json:"themes"`
 }
 
 // GetWpVersion returns the value of WpVersion.
@@ -6026,6 +6131,46 @@ func (s *AgentMetadata) GetMultisite() OptBool {
 // GetActiveTheme returns the value of ActiveTheme.
 func (s *AgentMetadata) GetActiveTheme() OptString {
 	return s.ActiveTheme
+}
+
+// GetAgentVersion returns the value of AgentVersion.
+func (s *AgentMetadata) GetAgentVersion() OptString {
+	return s.AgentVersion
+}
+
+// GetAgeRecipient returns the value of AgeRecipient.
+func (s *AgentMetadata) GetAgeRecipient() OptString {
+	return s.AgeRecipient
+}
+
+// GetUserCount returns the value of UserCount.
+func (s *AgentMetadata) GetUserCount() OptInt {
+	return s.UserCount
+}
+
+// GetAdminCount returns the value of AdminCount.
+func (s *AgentMetadata) GetAdminCount() OptInt {
+	return s.AdminCount
+}
+
+// GetCoreUpdate returns the value of CoreUpdate.
+func (s *AgentMetadata) GetCoreUpdate() OptNilAgentMetadataCoreUpdate {
+	return s.CoreUpdate
+}
+
+// GetHostFlags returns the value of HostFlags.
+func (s *AgentMetadata) GetHostFlags() OptNilAgentMetadataHostFlags {
+	return s.HostFlags
+}
+
+// GetDisk returns the value of Disk.
+func (s *AgentMetadata) GetDisk() OptNilAgentMetadataDisk {
+	return s.Disk
+}
+
+// GetAgentSelfUpdate returns the value of AgentSelfUpdate.
+func (s *AgentMetadata) GetAgentSelfUpdate() OptNilAgentMetadataAgentSelfUpdate {
+	return s.AgentSelfUpdate
 }
 
 // GetPlugins returns the value of Plugins.
@@ -6063,6 +6208,46 @@ func (s *AgentMetadata) SetActiveTheme(val OptString) {
 	s.ActiveTheme = val
 }
 
+// SetAgentVersion sets the value of AgentVersion.
+func (s *AgentMetadata) SetAgentVersion(val OptString) {
+	s.AgentVersion = val
+}
+
+// SetAgeRecipient sets the value of AgeRecipient.
+func (s *AgentMetadata) SetAgeRecipient(val OptString) {
+	s.AgeRecipient = val
+}
+
+// SetUserCount sets the value of UserCount.
+func (s *AgentMetadata) SetUserCount(val OptInt) {
+	s.UserCount = val
+}
+
+// SetAdminCount sets the value of AdminCount.
+func (s *AgentMetadata) SetAdminCount(val OptInt) {
+	s.AdminCount = val
+}
+
+// SetCoreUpdate sets the value of CoreUpdate.
+func (s *AgentMetadata) SetCoreUpdate(val OptNilAgentMetadataCoreUpdate) {
+	s.CoreUpdate = val
+}
+
+// SetHostFlags sets the value of HostFlags.
+func (s *AgentMetadata) SetHostFlags(val OptNilAgentMetadataHostFlags) {
+	s.HostFlags = val
+}
+
+// SetDisk sets the value of Disk.
+func (s *AgentMetadata) SetDisk(val OptNilAgentMetadataDisk) {
+	s.Disk = val
+}
+
+// SetAgentSelfUpdate sets the value of AgentSelfUpdate.
+func (s *AgentMetadata) SetAgentSelfUpdate(val OptNilAgentMetadataAgentSelfUpdate) {
+	s.AgentSelfUpdate = val
+}
+
 // SetPlugins sets the value of Plugins.
 func (s *AgentMetadata) SetPlugins(val []SiteComponent) {
 	s.Plugins = val
@@ -6071,6 +6256,225 @@ func (s *AgentMetadata) SetPlugins(val []SiteComponent) {
 // SetThemes sets the value of Themes.
 func (s *AgentMetadata) SetThemes(val []SiteComponent) {
 	s.Themes = val
+}
+
+// The outcome of the agent's last self-update apply, replayed on the
+// next metadata push. This is the only channel by which a FAILED
+// apply reaches the control plane: the apply runs inside a cron
+// request with no response to ride on.
+type AgentMetadataAgentSelfUpdate struct {
+	Status      OptString `json:"status"`
+	FromVersion OptString `json:"from_version"`
+	ToVersion   OptString `json:"to_version"`
+	Detail      OptString `json:"detail"`
+	// Unix timestamp the agent stamped the record with.
+	At OptInt64 `json:"at"`
+}
+
+// GetStatus returns the value of Status.
+func (s *AgentMetadataAgentSelfUpdate) GetStatus() OptString {
+	return s.Status
+}
+
+// GetFromVersion returns the value of FromVersion.
+func (s *AgentMetadataAgentSelfUpdate) GetFromVersion() OptString {
+	return s.FromVersion
+}
+
+// GetToVersion returns the value of ToVersion.
+func (s *AgentMetadataAgentSelfUpdate) GetToVersion() OptString {
+	return s.ToVersion
+}
+
+// GetDetail returns the value of Detail.
+func (s *AgentMetadataAgentSelfUpdate) GetDetail() OptString {
+	return s.Detail
+}
+
+// GetAt returns the value of At.
+func (s *AgentMetadataAgentSelfUpdate) GetAt() OptInt64 {
+	return s.At
+}
+
+// SetStatus sets the value of Status.
+func (s *AgentMetadataAgentSelfUpdate) SetStatus(val OptString) {
+	s.Status = val
+}
+
+// SetFromVersion sets the value of FromVersion.
+func (s *AgentMetadataAgentSelfUpdate) SetFromVersion(val OptString) {
+	s.FromVersion = val
+}
+
+// SetToVersion sets the value of ToVersion.
+func (s *AgentMetadataAgentSelfUpdate) SetToVersion(val OptString) {
+	s.ToVersion = val
+}
+
+// SetDetail sets the value of Detail.
+func (s *AgentMetadataAgentSelfUpdate) SetDetail(val OptString) {
+	s.Detail = val
+}
+
+// SetAt sets the value of At.
+func (s *AgentMetadataAgentSelfUpdate) SetAt(val OptInt64) {
+	s.At = val
+}
+
+// Present only when WordPress core has an update available.
+type AgentMetadataCoreUpdate struct {
+	NewVersion     OptString `json:"new_version"`
+	CurrentVersion OptString `json:"current_version"`
+}
+
+// GetNewVersion returns the value of NewVersion.
+func (s *AgentMetadataCoreUpdate) GetNewVersion() OptString {
+	return s.NewVersion
+}
+
+// GetCurrentVersion returns the value of CurrentVersion.
+func (s *AgentMetadataCoreUpdate) GetCurrentVersion() OptString {
+	return s.CurrentVersion
+}
+
+// SetNewVersion sets the value of NewVersion.
+func (s *AgentMetadataCoreUpdate) SetNewVersion(val OptString) {
+	s.NewVersion = val
+}
+
+// SetCurrentVersion sets the value of CurrentVersion.
+func (s *AgentMetadataCoreUpdate) SetCurrentVersion(val OptString) {
+	s.CurrentVersion = val
+}
+
+// Sampled disk usage in bytes. The wp-content and uploads walks are
+// time-capped, so a field may be absent on a very large tree.
+type AgentMetadataDisk struct {
+	WpContentBytes OptInt64 `json:"wp_content_bytes"`
+	UploadsBytes   OptInt64 `json:"uploads_bytes"`
+	FreeBytes      OptInt64 `json:"free_bytes"`
+}
+
+// GetWpContentBytes returns the value of WpContentBytes.
+func (s *AgentMetadataDisk) GetWpContentBytes() OptInt64 {
+	return s.WpContentBytes
+}
+
+// GetUploadsBytes returns the value of UploadsBytes.
+func (s *AgentMetadataDisk) GetUploadsBytes() OptInt64 {
+	return s.UploadsBytes
+}
+
+// GetFreeBytes returns the value of FreeBytes.
+func (s *AgentMetadataDisk) GetFreeBytes() OptInt64 {
+	return s.FreeBytes
+}
+
+// SetWpContentBytes sets the value of WpContentBytes.
+func (s *AgentMetadataDisk) SetWpContentBytes(val OptInt64) {
+	s.WpContentBytes = val
+}
+
+// SetUploadsBytes sets the value of UploadsBytes.
+func (s *AgentMetadataDisk) SetUploadsBytes(val OptInt64) {
+	s.UploadsBytes = val
+}
+
+// SetFreeBytes sets the value of FreeBytes.
+func (s *AgentMetadataDisk) SetFreeBytes(val OptInt64) {
+	s.FreeBytes = val
+}
+
+// The agent's defined()-based hosting fingerprint.
+type AgentMetadataHostFlags struct {
+	IsPressable OptBool `json:"is_pressable"`
+	IsGridpane  OptBool `json:"is_gridpane"`
+	IsWpengine  OptBool `json:"is_wpengine"`
+	IsAtomic    OptBool `json:"is_atomic"`
+	IsKinsta    OptBool `json:"is_kinsta"`
+	IsFlywheel  OptBool `json:"is_flywheel"`
+	IsRuncloud  OptBool `json:"is_runcloud"`
+	IsCloudways OptBool `json:"is_cloudways"`
+}
+
+// GetIsPressable returns the value of IsPressable.
+func (s *AgentMetadataHostFlags) GetIsPressable() OptBool {
+	return s.IsPressable
+}
+
+// GetIsGridpane returns the value of IsGridpane.
+func (s *AgentMetadataHostFlags) GetIsGridpane() OptBool {
+	return s.IsGridpane
+}
+
+// GetIsWpengine returns the value of IsWpengine.
+func (s *AgentMetadataHostFlags) GetIsWpengine() OptBool {
+	return s.IsWpengine
+}
+
+// GetIsAtomic returns the value of IsAtomic.
+func (s *AgentMetadataHostFlags) GetIsAtomic() OptBool {
+	return s.IsAtomic
+}
+
+// GetIsKinsta returns the value of IsKinsta.
+func (s *AgentMetadataHostFlags) GetIsKinsta() OptBool {
+	return s.IsKinsta
+}
+
+// GetIsFlywheel returns the value of IsFlywheel.
+func (s *AgentMetadataHostFlags) GetIsFlywheel() OptBool {
+	return s.IsFlywheel
+}
+
+// GetIsRuncloud returns the value of IsRuncloud.
+func (s *AgentMetadataHostFlags) GetIsRuncloud() OptBool {
+	return s.IsRuncloud
+}
+
+// GetIsCloudways returns the value of IsCloudways.
+func (s *AgentMetadataHostFlags) GetIsCloudways() OptBool {
+	return s.IsCloudways
+}
+
+// SetIsPressable sets the value of IsPressable.
+func (s *AgentMetadataHostFlags) SetIsPressable(val OptBool) {
+	s.IsPressable = val
+}
+
+// SetIsGridpane sets the value of IsGridpane.
+func (s *AgentMetadataHostFlags) SetIsGridpane(val OptBool) {
+	s.IsGridpane = val
+}
+
+// SetIsWpengine sets the value of IsWpengine.
+func (s *AgentMetadataHostFlags) SetIsWpengine(val OptBool) {
+	s.IsWpengine = val
+}
+
+// SetIsAtomic sets the value of IsAtomic.
+func (s *AgentMetadataHostFlags) SetIsAtomic(val OptBool) {
+	s.IsAtomic = val
+}
+
+// SetIsKinsta sets the value of IsKinsta.
+func (s *AgentMetadataHostFlags) SetIsKinsta(val OptBool) {
+	s.IsKinsta = val
+}
+
+// SetIsFlywheel sets the value of IsFlywheel.
+func (s *AgentMetadataHostFlags) SetIsFlywheel(val OptBool) {
+	s.IsFlywheel = val
+}
+
+// SetIsRuncloud sets the value of IsRuncloud.
+func (s *AgentMetadataHostFlags) SetIsRuncloud(val OptBool) {
+	s.IsRuncloud = val
+}
+
+// SetIsCloudways sets the value of IsCloudways.
+func (s *AgentMetadataHostFlags) SetIsCloudways(val OptBool) {
+	s.IsCloudways = val
 }
 
 type AgentMetadataUnauthorized Error
@@ -9709,9 +10113,17 @@ func (*BeginWebAuthnEnrollmentOK) beginWebAuthnEnrollmentRes() {}
 
 // Ref: #/components/schemas/BillingCheckoutRequest
 type BillingCheckoutRequest struct {
-	// The ONLY caller-supplied selector. The server resolves this to a payment-provider price
+	// The only caller-supplied PRICE selector. The server resolves this to a payment-provider price
 	// server-side; a request can never name a price directly.
 	Tier BillingCheckoutRequestTier `json:"tier"`
+	// Preferred payment provider. Consulted only on a tenant's first-ever checkout: once a tenant is
+	// pinned to a provider that pinning always wins, so a returning customer can never split a
+	// subscription across two providers. An unknown name is rejected. Omit to use the instance default.
+	Provider OptString `json:"provider"`
+	// Preferred billing currency, passed to the provider when it creates the checkout. Selects among the
+	// prices the server already knows for the requested tier; it can never set an amount. Omit for the
+	// provider default.
+	Currency OptString `json:"currency"`
 }
 
 // GetTier returns the value of Tier.
@@ -9719,12 +10131,32 @@ func (s *BillingCheckoutRequest) GetTier() BillingCheckoutRequestTier {
 	return s.Tier
 }
 
+// GetProvider returns the value of Provider.
+func (s *BillingCheckoutRequest) GetProvider() OptString {
+	return s.Provider
+}
+
+// GetCurrency returns the value of Currency.
+func (s *BillingCheckoutRequest) GetCurrency() OptString {
+	return s.Currency
+}
+
 // SetTier sets the value of Tier.
 func (s *BillingCheckoutRequest) SetTier(val BillingCheckoutRequestTier) {
 	s.Tier = val
 }
 
-// The ONLY caller-supplied selector. The server resolves this to a payment-provider price
+// SetProvider sets the value of Provider.
+func (s *BillingCheckoutRequest) SetProvider(val OptString) {
+	s.Provider = val
+}
+
+// SetCurrency sets the value of Currency.
+func (s *BillingCheckoutRequest) SetCurrency(val OptString) {
+	s.Currency = val
+}
+
+// The only caller-supplied PRICE selector. The server resolves this to a payment-provider price
 // server-side; a request can never name a price directly.
 type BillingCheckoutRequestTier string
 
@@ -12171,11 +12603,17 @@ func (s *ClientReportScheduleUpdateCadence) UnmarshalText(data []byte) error {
 // Controls which data sections are included in a report.
 // Ref: #/components/schemas/ClientReportSectionFlags
 type ClientReportSectionFlags struct {
+	Overview    OptBool `json:"overview"`
 	Uptime      OptBool `json:"uptime"`
 	Backups     OptBool `json:"backups"`
 	Updates     OptBool `json:"updates"`
 	Performance OptBool `json:"performance"`
 	Email       OptBool `json:"email"`
+}
+
+// GetOverview returns the value of Overview.
+func (s *ClientReportSectionFlags) GetOverview() OptBool {
+	return s.Overview
 }
 
 // GetUptime returns the value of Uptime.
@@ -12201,6 +12639,11 @@ func (s *ClientReportSectionFlags) GetPerformance() OptBool {
 // GetEmail returns the value of Email.
 func (s *ClientReportSectionFlags) GetEmail() OptBool {
 	return s.Email
+}
+
+// SetOverview sets the value of Overview.
+func (s *ClientReportSectionFlags) SetOverview(val OptBool) {
+	s.Overview = val
 }
 
 // SetUptime sets the value of Uptime.
@@ -29199,6 +29642,258 @@ func (o OptMultipartFile) Or(d ht.MultipartFile) ht.MultipartFile {
 	return d
 }
 
+// NewOptNilAgentMetadataAgentSelfUpdate returns new OptNilAgentMetadataAgentSelfUpdate with value set to v.
+func NewOptNilAgentMetadataAgentSelfUpdate(v AgentMetadataAgentSelfUpdate) OptNilAgentMetadataAgentSelfUpdate {
+	return OptNilAgentMetadataAgentSelfUpdate{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptNilAgentMetadataAgentSelfUpdate is optional nullable AgentMetadataAgentSelfUpdate.
+type OptNilAgentMetadataAgentSelfUpdate struct {
+	Value AgentMetadataAgentSelfUpdate
+	Set   bool
+	Null  bool
+}
+
+// IsSet returns true if OptNilAgentMetadataAgentSelfUpdate was set.
+func (o OptNilAgentMetadataAgentSelfUpdate) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptNilAgentMetadataAgentSelfUpdate) Reset() {
+	var v AgentMetadataAgentSelfUpdate
+	o.Value = v
+	o.Set = false
+	o.Null = false
+}
+
+// SetTo sets value to v.
+func (o *OptNilAgentMetadataAgentSelfUpdate) SetTo(v AgentMetadataAgentSelfUpdate) {
+	o.Set = true
+	o.Null = false
+	o.Value = v
+}
+
+// IsNull returns true if value is Null.
+func (o OptNilAgentMetadataAgentSelfUpdate) IsNull() bool { return o.Null }
+
+// SetToNull sets value to null.
+func (o *OptNilAgentMetadataAgentSelfUpdate) SetToNull() {
+	o.Set = true
+	o.Null = true
+	var v AgentMetadataAgentSelfUpdate
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptNilAgentMetadataAgentSelfUpdate) Get() (v AgentMetadataAgentSelfUpdate, ok bool) {
+	if o.Null {
+		return v, false
+	}
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptNilAgentMetadataAgentSelfUpdate) Or(d AgentMetadataAgentSelfUpdate) AgentMetadataAgentSelfUpdate {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptNilAgentMetadataCoreUpdate returns new OptNilAgentMetadataCoreUpdate with value set to v.
+func NewOptNilAgentMetadataCoreUpdate(v AgentMetadataCoreUpdate) OptNilAgentMetadataCoreUpdate {
+	return OptNilAgentMetadataCoreUpdate{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptNilAgentMetadataCoreUpdate is optional nullable AgentMetadataCoreUpdate.
+type OptNilAgentMetadataCoreUpdate struct {
+	Value AgentMetadataCoreUpdate
+	Set   bool
+	Null  bool
+}
+
+// IsSet returns true if OptNilAgentMetadataCoreUpdate was set.
+func (o OptNilAgentMetadataCoreUpdate) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptNilAgentMetadataCoreUpdate) Reset() {
+	var v AgentMetadataCoreUpdate
+	o.Value = v
+	o.Set = false
+	o.Null = false
+}
+
+// SetTo sets value to v.
+func (o *OptNilAgentMetadataCoreUpdate) SetTo(v AgentMetadataCoreUpdate) {
+	o.Set = true
+	o.Null = false
+	o.Value = v
+}
+
+// IsNull returns true if value is Null.
+func (o OptNilAgentMetadataCoreUpdate) IsNull() bool { return o.Null }
+
+// SetToNull sets value to null.
+func (o *OptNilAgentMetadataCoreUpdate) SetToNull() {
+	o.Set = true
+	o.Null = true
+	var v AgentMetadataCoreUpdate
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptNilAgentMetadataCoreUpdate) Get() (v AgentMetadataCoreUpdate, ok bool) {
+	if o.Null {
+		return v, false
+	}
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptNilAgentMetadataCoreUpdate) Or(d AgentMetadataCoreUpdate) AgentMetadataCoreUpdate {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptNilAgentMetadataDisk returns new OptNilAgentMetadataDisk with value set to v.
+func NewOptNilAgentMetadataDisk(v AgentMetadataDisk) OptNilAgentMetadataDisk {
+	return OptNilAgentMetadataDisk{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptNilAgentMetadataDisk is optional nullable AgentMetadataDisk.
+type OptNilAgentMetadataDisk struct {
+	Value AgentMetadataDisk
+	Set   bool
+	Null  bool
+}
+
+// IsSet returns true if OptNilAgentMetadataDisk was set.
+func (o OptNilAgentMetadataDisk) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptNilAgentMetadataDisk) Reset() {
+	var v AgentMetadataDisk
+	o.Value = v
+	o.Set = false
+	o.Null = false
+}
+
+// SetTo sets value to v.
+func (o *OptNilAgentMetadataDisk) SetTo(v AgentMetadataDisk) {
+	o.Set = true
+	o.Null = false
+	o.Value = v
+}
+
+// IsNull returns true if value is Null.
+func (o OptNilAgentMetadataDisk) IsNull() bool { return o.Null }
+
+// SetToNull sets value to null.
+func (o *OptNilAgentMetadataDisk) SetToNull() {
+	o.Set = true
+	o.Null = true
+	var v AgentMetadataDisk
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptNilAgentMetadataDisk) Get() (v AgentMetadataDisk, ok bool) {
+	if o.Null {
+		return v, false
+	}
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptNilAgentMetadataDisk) Or(d AgentMetadataDisk) AgentMetadataDisk {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptNilAgentMetadataHostFlags returns new OptNilAgentMetadataHostFlags with value set to v.
+func NewOptNilAgentMetadataHostFlags(v AgentMetadataHostFlags) OptNilAgentMetadataHostFlags {
+	return OptNilAgentMetadataHostFlags{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptNilAgentMetadataHostFlags is optional nullable AgentMetadataHostFlags.
+type OptNilAgentMetadataHostFlags struct {
+	Value AgentMetadataHostFlags
+	Set   bool
+	Null  bool
+}
+
+// IsSet returns true if OptNilAgentMetadataHostFlags was set.
+func (o OptNilAgentMetadataHostFlags) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptNilAgentMetadataHostFlags) Reset() {
+	var v AgentMetadataHostFlags
+	o.Value = v
+	o.Set = false
+	o.Null = false
+}
+
+// SetTo sets value to v.
+func (o *OptNilAgentMetadataHostFlags) SetTo(v AgentMetadataHostFlags) {
+	o.Set = true
+	o.Null = false
+	o.Value = v
+}
+
+// IsNull returns true if value is Null.
+func (o OptNilAgentMetadataHostFlags) IsNull() bool { return o.Null }
+
+// SetToNull sets value to null.
+func (o *OptNilAgentMetadataHostFlags) SetToNull() {
+	o.Set = true
+	o.Null = true
+	var v AgentMetadataHostFlags
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptNilAgentMetadataHostFlags) Get() (v AgentMetadataHostFlags, ok bool) {
+	if o.Null {
+		return v, false
+	}
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptNilAgentMetadataHostFlags) Or(d AgentMetadataHostFlags) AgentMetadataHostFlags {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
 // NewOptNilBool returns new OptNilBool with value set to v.
 func NewOptNilBool(v bool) OptNilBool {
 	return OptNilBool{
@@ -33040,8 +33735,29 @@ type PerfConfig struct {
 	WooThemeFragmentsSupported OptNilBool `json:"woo_theme_fragments_supported"`
 	// RFC3339 timestamp of the last agent probe. Null when never probed.
 	WooFragmentsProbedAt OptNilDateTime `json:"woo_fragments_probed_at"`
-	ConfigVersion        OptInt         `json:"config_version"`
-	UpdatedAt            OptDateTime    `json:"updated_at"`
+	// Enable Real User Monitoring collection for this site.
+	RumEnabled OptBool `json:"rum_enabled"`
+	// Fraction of page views that emit a RUM beacon (0 to 1).
+	RumSampleRate OptFloat32 `json:"rum_sample_rate"`
+	// Suppression floor: any RUM slice with fewer samples than this is
+	// reported as suppressed rather than shown, so a handful of visits
+	// cannot masquerade as a trend.
+	MinSampleCount OptInt `json:"min_sample_count"`
+	// Cap on the number of distinct countries kept in the per-country RUM
+	// breakdown.
+	MaxDistinctCountries OptInt `json:"max_distinct_countries"`
+	// Whether a RUM beacon key is provisioned. The plaintext key is never
+	// returned; this boolean is how a client tells whether RUM is fully
+	// provisioned. Ignored on write.
+	BeaconKeySet OptBool `json:"beacon_key_set"`
+	// Whether the agent's most recent config-ack confirmed it holds the
+	// beacon key. beacon_key_set true with this false means RUM is
+	// provisioned control-plane side but the agent has not confirmed
+	// receipt yet; the control plane retries automatically. Ignored on
+	// write.
+	BeaconKeyAckedPresent OptBool     `json:"beacon_key_acked_present"`
+	ConfigVersion         OptInt      `json:"config_version"`
+	UpdatedAt             OptDateTime `json:"updated_at"`
 }
 
 // GetCacheEnabled returns the value of CacheEnabled.
@@ -33372,6 +34088,36 @@ func (s *PerfConfig) GetWooThemeFragmentsSupported() OptNilBool {
 // GetWooFragmentsProbedAt returns the value of WooFragmentsProbedAt.
 func (s *PerfConfig) GetWooFragmentsProbedAt() OptNilDateTime {
 	return s.WooFragmentsProbedAt
+}
+
+// GetRumEnabled returns the value of RumEnabled.
+func (s *PerfConfig) GetRumEnabled() OptBool {
+	return s.RumEnabled
+}
+
+// GetRumSampleRate returns the value of RumSampleRate.
+func (s *PerfConfig) GetRumSampleRate() OptFloat32 {
+	return s.RumSampleRate
+}
+
+// GetMinSampleCount returns the value of MinSampleCount.
+func (s *PerfConfig) GetMinSampleCount() OptInt {
+	return s.MinSampleCount
+}
+
+// GetMaxDistinctCountries returns the value of MaxDistinctCountries.
+func (s *PerfConfig) GetMaxDistinctCountries() OptInt {
+	return s.MaxDistinctCountries
+}
+
+// GetBeaconKeySet returns the value of BeaconKeySet.
+func (s *PerfConfig) GetBeaconKeySet() OptBool {
+	return s.BeaconKeySet
+}
+
+// GetBeaconKeyAckedPresent returns the value of BeaconKeyAckedPresent.
+func (s *PerfConfig) GetBeaconKeyAckedPresent() OptBool {
+	return s.BeaconKeyAckedPresent
 }
 
 // GetConfigVersion returns the value of ConfigVersion.
@@ -33712,6 +34458,36 @@ func (s *PerfConfig) SetWooThemeFragmentsSupported(val OptNilBool) {
 // SetWooFragmentsProbedAt sets the value of WooFragmentsProbedAt.
 func (s *PerfConfig) SetWooFragmentsProbedAt(val OptNilDateTime) {
 	s.WooFragmentsProbedAt = val
+}
+
+// SetRumEnabled sets the value of RumEnabled.
+func (s *PerfConfig) SetRumEnabled(val OptBool) {
+	s.RumEnabled = val
+}
+
+// SetRumSampleRate sets the value of RumSampleRate.
+func (s *PerfConfig) SetRumSampleRate(val OptFloat32) {
+	s.RumSampleRate = val
+}
+
+// SetMinSampleCount sets the value of MinSampleCount.
+func (s *PerfConfig) SetMinSampleCount(val OptInt) {
+	s.MinSampleCount = val
+}
+
+// SetMaxDistinctCountries sets the value of MaxDistinctCountries.
+func (s *PerfConfig) SetMaxDistinctCountries(val OptInt) {
+	s.MaxDistinctCountries = val
+}
+
+// SetBeaconKeySet sets the value of BeaconKeySet.
+func (s *PerfConfig) SetBeaconKeySet(val OptBool) {
+	s.BeaconKeySet = val
+}
+
+// SetBeaconKeyAckedPresent sets the value of BeaconKeyAckedPresent.
+func (s *PerfConfig) SetBeaconKeyAckedPresent(val OptBool) {
+	s.BeaconKeyAckedPresent = val
 }
 
 // SetConfigVersion sets the value of ConfigVersion.
@@ -42058,6 +42834,14 @@ type SiteComponent struct {
 	Name    OptString `json:"name"`
 	Version OptString `json:"version"`
 	Active  OptBool   `json:"active"`
+	// PluginURI from the plugin header. Optional; older agents omit it.
+	PluginURI OptString `json:"plugin_uri"`
+	// UpdateURI from the plugin header. Optional; older agents omit it.
+	UpdateURI OptString `json:"update_uri"`
+	// AuthorURI from the plugin header. Optional; older agents omit it.
+	AuthorURI OptString `json:"author_uri"`
+	// Whether the plugin is network-activated. Optional; older agents omit it.
+	Network OptBool `json:"network"`
 	// When set, an update is available for this plugin/theme.
 	AvailableUpdate OptNilSiteComponentAvailableUpdate `json:"available_update"`
 }
@@ -42080,6 +42864,26 @@ func (s *SiteComponent) GetVersion() OptString {
 // GetActive returns the value of Active.
 func (s *SiteComponent) GetActive() OptBool {
 	return s.Active
+}
+
+// GetPluginURI returns the value of PluginURI.
+func (s *SiteComponent) GetPluginURI() OptString {
+	return s.PluginURI
+}
+
+// GetUpdateURI returns the value of UpdateURI.
+func (s *SiteComponent) GetUpdateURI() OptString {
+	return s.UpdateURI
+}
+
+// GetAuthorURI returns the value of AuthorURI.
+func (s *SiteComponent) GetAuthorURI() OptString {
+	return s.AuthorURI
+}
+
+// GetNetwork returns the value of Network.
+func (s *SiteComponent) GetNetwork() OptBool {
+	return s.Network
 }
 
 // GetAvailableUpdate returns the value of AvailableUpdate.
@@ -42105,6 +42909,26 @@ func (s *SiteComponent) SetVersion(val OptString) {
 // SetActive sets the value of Active.
 func (s *SiteComponent) SetActive(val OptBool) {
 	s.Active = val
+}
+
+// SetPluginURI sets the value of PluginURI.
+func (s *SiteComponent) SetPluginURI(val OptString) {
+	s.PluginURI = val
+}
+
+// SetUpdateURI sets the value of UpdateURI.
+func (s *SiteComponent) SetUpdateURI(val OptString) {
+	s.UpdateURI = val
+}
+
+// SetAuthorURI sets the value of AuthorURI.
+func (s *SiteComponent) SetAuthorURI(val OptString) {
+	s.AuthorURI = val
+}
+
+// SetNetwork sets the value of Network.
+func (s *SiteComponent) SetNetwork(val OptBool) {
+	s.Network = val
 }
 
 // SetAvailableUpdate sets the value of AvailableUpdate.
@@ -43890,6 +44714,8 @@ func (*SiteEnrollmentCode) createSiteRes()        {}
 
 // Ref: #/components/schemas/SiteErrorConfig
 type SiteErrorConfig struct {
+	// Whether PHP-error capture is active for this site.
+	Enabled OptBool `json:"enabled"`
 	// PHP E_* bitmask the agent applies to wp_debug_log collection.
 	// Default 6143 = E_ALL & ~E_STRICT (WordPress default).
 	ErrorLevel int32 `json:"error_level"`
@@ -43897,6 +44723,11 @@ type SiteErrorConfig struct {
 	// (md5(code:file:line:message)) the agent must suppress without
 	// counting or reporting. An empty list clears all suppression.
 	IgnoreMd5s []string `json:"ignore_md5s"`
+}
+
+// GetEnabled returns the value of Enabled.
+func (s *SiteErrorConfig) GetEnabled() OptBool {
+	return s.Enabled
 }
 
 // GetErrorLevel returns the value of ErrorLevel.
@@ -43907,6 +44738,11 @@ func (s *SiteErrorConfig) GetErrorLevel() int32 {
 // GetIgnoreMd5s returns the value of IgnoreMd5s.
 func (s *SiteErrorConfig) GetIgnoreMd5s() []string {
 	return s.IgnoreMd5s
+}
+
+// SetEnabled sets the value of Enabled.
+func (s *SiteErrorConfig) SetEnabled(val OptBool) {
+	s.Enabled = val
 }
 
 // SetErrorLevel sets the value of ErrorLevel.
@@ -43924,11 +44760,22 @@ func (*SiteErrorConfig) patchSiteErrorConfigRes() {}
 
 // Ref: #/components/schemas/SiteErrorConfigUpdate
 type SiteErrorConfigUpdate struct {
+	// Turns PHP-error capture on or off. OMITTING this field is treated as
+	// true: a client that does not know about the flag can never
+	// accidentally disable the mu-plugin trap, but that also means an
+	// update sent without it re-enables capture on a site where it was
+	// switched off. Send false explicitly to keep capture disabled.
+	Enabled OptBool `json:"enabled"`
 	// PHP E_* bitmask to apply. Must be >0 and fit in int32.
 	ErrorLevel int32 `json:"error_level"`
 	// Full canonical ignore-list (replaces the stored list atomically).
 	// Each entry must be exactly 32 lowercase hex characters.
 	IgnoreMd5s []string `json:"ignore_md5s"`
+}
+
+// GetEnabled returns the value of Enabled.
+func (s *SiteErrorConfigUpdate) GetEnabled() OptBool {
+	return s.Enabled
 }
 
 // GetErrorLevel returns the value of ErrorLevel.
@@ -43939,6 +44786,11 @@ func (s *SiteErrorConfigUpdate) GetErrorLevel() int32 {
 // GetIgnoreMd5s returns the value of IgnoreMd5s.
 func (s *SiteErrorConfigUpdate) GetIgnoreMd5s() []string {
 	return s.IgnoreMd5s
+}
+
+// SetEnabled sets the value of Enabled.
+func (s *SiteErrorConfigUpdate) SetEnabled(val OptBool) {
+	s.Enabled = val
 }
 
 // SetErrorLevel sets the value of ErrorLevel.

--- a/apps/api/internal/api/gen/oas_validators_gen.go
+++ b/apps/api/internal/api/gen/oas_validators_gen.go
@@ -9138,6 +9138,24 @@ func (s *PerfConfig) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		if value, ok := s.RumSampleRate.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "rum_sample_rate",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}

--- a/apps/api/internal/email/bulk_log_ids_test.go
+++ b/apps/api/internal/email/bulk_log_ids_test.go
@@ -1,0 +1,345 @@
+// bulk_log_ids_test.go: GH #307.
+//
+// The bulk log-delete and bulk log-resend handlers bound `json:"ids"` while
+// their OpenAPI schemas (BulkDeleteLogsRequest, BulkResendRequest) declare the
+// field as `log_ids`, which is what the generated client and the web app have
+// always sent. The field never bound, the id list was always empty, and both
+// endpoints returned 200 with a zero count: "0 log entries deleted", nothing
+// deleted, and an audit row recording the no-op as a success.
+//
+// Every test below sends a SPEC-SHAPED body ({"log_ids": [...]}) and asserts
+// the ids actually reached the repository, which is the part that was broken.
+package email
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+)
+
+// recordingRepo wraps the shared fakeRepo and captures the ids the service
+// passes down, so a test can prove the handler observed the request body
+// rather than silently substituting an empty list.
+type recordingRepo struct {
+	*fakeRepo
+	deletedIDs  []uuid.UUID
+	deleteCalls int
+}
+
+func (r *recordingRepo) DeleteEmailLogsBulk(_ context.Context, _, _ uuid.UUID, ids []uuid.UUID) (int64, error) {
+	r.deleteCalls++
+	r.deletedIDs = append(r.deletedIDs, ids...)
+	return int64(len(ids)), nil
+}
+
+func newBulkTestHandler() (*Handler, *recordingRepo) {
+	repo := &recordingRepo{fakeRepo: newFakeRepo()}
+	svc := NewService(&Repo{}, nil, nil)
+	svc.repo = repo
+	return NewHandlerWithPublisher(svc, (*audit.Recorder)(nil), nil), repo
+}
+
+func bulkLogPath(siteID uuid.UUID, suffix string) string {
+	return "/api/v1/sites/" + siteID.String() + "/email/log" + suffix
+}
+
+func idListJSON(field string, ids []uuid.UUID) []byte {
+	quoted := make([]string, 0, len(ids))
+	for _, id := range ids {
+		quoted = append(quoted, `"`+id.String()+`"`)
+	}
+	return []byte(fmt.Sprintf(`{%q:[%s]}`, field, strings.Join(quoted, ",")))
+}
+
+// ---------------------------------------------------------------------------
+// The regression: the spec field must actually bind.
+// ---------------------------------------------------------------------------
+
+// TestBulkDeleteLog_BindsSpecLogIDsField is the GH #307 regression test. It
+// fails against the pre-fix handler, which bound "ids": log_ids never decoded,
+// the service short-circuited on an empty list, DeleteEmailLogsBulk was never
+// called, and the response was {"deleted":0} with HTTP 200.
+func TestBulkDeleteLog_BindsSpecLogIDsField(t *testing.T) {
+	h, repo := newBulkTestHandler()
+	tenantID, siteID := uuid.New(), uuid.New()
+	engine := newTestOperatorEngine(h, tenantID)
+
+	ids := []uuid.UUID{uuid.New(), uuid.New()}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, bulkLogPath(siteID, ""), bytes.NewReader(idListJSON("log_ids", ids)))
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Deleted int64 `json:"deleted"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Deleted != int64(len(ids)) {
+		t.Errorf("expected deleted=%d, got %d: the log_ids field did not bind", len(ids), resp.Deleted)
+	}
+	if repo.deleteCalls != 1 {
+		t.Fatalf("expected exactly 1 repo delete call, got %d", repo.deleteCalls)
+	}
+	if len(repo.deletedIDs) != len(ids) {
+		t.Fatalf("repo received %d ids, want %d", len(repo.deletedIDs), len(ids))
+	}
+	for i, want := range ids {
+		if repo.deletedIDs[i] != want {
+			t.Errorf("repo id[%d] = %s, want %s", i, repo.deletedIDs[i], want)
+		}
+	}
+}
+
+// TestBulkResendLog_BindsSpecLogIDsField is the sibling regression: the resend
+// button on the same screen was broken the same way and returned
+// {"results":[]}, which the web read as "0 emails queued for resend" on the
+// SUCCESS path (failed === 0). One result per requested id proves the ids bound;
+// each is a failure here only because the fake repo stores no message body.
+func TestBulkResendLog_BindsSpecLogIDsField(t *testing.T) {
+	h, _ := newBulkTestHandler()
+	tenantID, siteID := uuid.New(), uuid.New()
+	engine := newTestOperatorEngine(h, tenantID)
+
+	ids := []uuid.UUID{uuid.New(), uuid.New(), uuid.New()}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, bulkLogPath(siteID, "/resend"), bytes.NewReader(idListJSON("log_ids", ids)))
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Results []struct {
+			LogID string `json:"log_id"`
+		} `json:"results"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Results) != len(ids) {
+		t.Fatalf("expected %d results, got %d: the log_ids field did not bind", len(ids), len(resp.Results))
+	}
+	for i, want := range ids {
+		if resp.Results[i].LogID != want.String() {
+			t.Errorf("result[%d].log_id = %s, want %s", i, resp.Results[i].LogID, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Back-compatibility: the old handler-side name keeps working.
+// ---------------------------------------------------------------------------
+
+// TestBulkDeleteLog_LegacyIDsFieldStillAccepted pins the deliberate alias. A
+// caller written against the handler source rather than the spec has been
+// sending "ids" and getting real deletions, so that name must not break.
+func TestBulkDeleteLog_LegacyIDsFieldStillAccepted(t *testing.T) {
+	h, repo := newBulkTestHandler()
+	tenantID, siteID := uuid.New(), uuid.New()
+	engine := newTestOperatorEngine(h, tenantID)
+
+	ids := []uuid.UUID{uuid.New()}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, bulkLogPath(siteID, ""), bytes.NewReader(idListJSON("ids", ids)))
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(repo.deletedIDs) != 1 || repo.deletedIDs[0] != ids[0] {
+		t.Errorf("legacy \"ids\" field no longer reaches the repo: got %v, want %v", repo.deletedIDs, ids)
+	}
+}
+
+// TestBulkDeleteLog_LogIDsWinsOverLegacyIDs pins the precedence rule: when a
+// body carries both names, the spec field is authoritative.
+func TestBulkDeleteLog_LogIDsWinsOverLegacyIDs(t *testing.T) {
+	h, repo := newBulkTestHandler()
+	tenantID, siteID := uuid.New(), uuid.New()
+	engine := newTestOperatorEngine(h, tenantID)
+
+	specID, legacyID := uuid.New(), uuid.New()
+	body := fmt.Sprintf(`{"log_ids":[%q],"ids":[%q]}`, specID, legacyID)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, bulkLogPath(siteID, ""), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(repo.deletedIDs) != 1 || repo.deletedIDs[0] != specID {
+		t.Errorf("expected the spec field to win with %s, repo got %v", specID, repo.deletedIDs)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The documented maxItems ceilings are enforced before the list is parsed.
+// ---------------------------------------------------------------------------
+
+// TestBulkDeleteLog_RejectsOversizedList checks the BulkDeleteLogsRequest
+// maxItems: 500 ceiling is enforced server-side, and that rejection happens
+// before the handler parses (and allocates) the whole id list.
+func TestBulkDeleteLog_RejectsOversizedList(t *testing.T) {
+	h, repo := newBulkTestHandler()
+	tenantID, siteID := uuid.New(), uuid.New()
+	engine := newTestOperatorEngine(h, tenantID)
+
+	ids := make([]uuid.UUID, MaxBulkDelete+1)
+	for i := range ids {
+		ids[i] = uuid.New()
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, bulkLogPath(siteID, ""), bytes.NewReader(idListJSON("log_ids", ids)))
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422 for %d ids, got %d: %s", len(ids), w.Code, w.Body.String())
+	}
+	if repo.deleteCalls != 0 {
+		t.Errorf("an oversized request reached the repo (%d calls)", repo.deleteCalls)
+	}
+}
+
+// TestBulkResendLog_RejectsOversizedList is the same ceiling for
+// BulkResendRequest (maxItems: 100). Without it, an unbounded list would fan
+// out into one agent command per id.
+func TestBulkResendLog_RejectsOversizedList(t *testing.T) {
+	h, _ := newBulkTestHandler()
+	tenantID, siteID := uuid.New(), uuid.New()
+	engine := newTestOperatorEngine(h, tenantID)
+
+	ids := make([]uuid.UUID, MaxBulkResend+1)
+	for i := range ids {
+		ids[i] = uuid.New()
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, bulkLogPath(siteID, "/resend"), bytes.NewReader(idListJSON("log_ids", ids)))
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422 for %d ids, got %d: %s", len(ids), w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// An empty or absent list is a caller error, not a successful no-op.
+// ---------------------------------------------------------------------------
+
+// emptyBodyCases are the shapes that carry no ids at all. `{}` is the
+// spec-required field simply missing; the two empty arrays are the field
+// present but asking for nothing. All three must be rejected identically.
+var emptyBodyCases = []struct {
+	name string
+	body string
+}{
+	{"absent log_ids", `{}`},
+	{"empty log_ids", `{"log_ids":[]}`},
+	{"empty legacy ids", `{"ids":[]}`},
+}
+
+// TestBulkDeleteLog_RejectsEmptyList is the GH #307 follow-up: log_ids is
+// `required` in BulkDeleteLogsRequest, but presence was never enforced, so a
+// non-TypeScript caller sending `{}` got 200 {"deleted": 0} plus an audit row
+// recording a successful deletion of nothing. That is the original symptom,
+// still reachable outside the web app.
+//
+// repo.deleteCalls == 0 also proves no audit row was written: the handler
+// records the audit event only after the repository call returns, so a request
+// that never reaches the repo cannot have been audited.
+func TestBulkDeleteLog_RejectsEmptyList(t *testing.T) {
+	for _, tc := range emptyBodyCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, repo := newBulkTestHandler()
+			tenantID, siteID := uuid.New(), uuid.New()
+			engine := newTestOperatorEngine(h, tenantID)
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodDelete, bulkLogPath(siteID, ""), strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			engine.ServeHTTP(w, req)
+
+			if w.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("expected 422 for body %s, got %d: %s", tc.body, w.Code, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), "log_ids") {
+				t.Errorf("validation message should name the log_ids field, got: %s", w.Body.String())
+			}
+			if strings.Contains(w.Body.String(), `"deleted"`) {
+				t.Errorf("a rejected request must not report a deletion count, got: %s", w.Body.String())
+			}
+			if repo.deleteCalls != 0 {
+				t.Errorf("an empty request reached the repo (%d calls), so it was also audited", repo.deleteCalls)
+			}
+		})
+	}
+}
+
+// TestBulkResendLog_RejectsEmptyList is the same guard on the sibling endpoint,
+// which returned 200 {"results": []} and the web app's "0 emails queued for
+// resend" success toast for a body that asked for nothing.
+func TestBulkResendLog_RejectsEmptyList(t *testing.T) {
+	for _, tc := range emptyBodyCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _ := newBulkTestHandler()
+			tenantID, siteID := uuid.New(), uuid.New()
+			engine := newTestOperatorEngine(h, tenantID)
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, bulkLogPath(siteID, "/resend"), strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			engine.ServeHTTP(w, req)
+
+			if w.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("expected 422 for body %s, got %d: %s", tc.body, w.Code, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), "log_ids") {
+				t.Errorf("validation message should name the log_ids field, got: %s", w.Body.String())
+			}
+			if strings.Contains(w.Body.String(), `"results"`) {
+				t.Errorf("a rejected request must not report a results list, got: %s", w.Body.String())
+			}
+		})
+	}
+}
+
+// TestBulkDeleteLog_RejectsInvalidUUID pins the per-id validation error, which
+// now names the spec field rather than the old one.
+func TestBulkDeleteLog_RejectsInvalidUUID(t *testing.T) {
+	h, repo := newBulkTestHandler()
+	tenantID, siteID := uuid.New(), uuid.New()
+	engine := newTestOperatorEngine(h, tenantID)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, bulkLogPath(siteID, ""), strings.NewReader(`{"log_ids":["not-a-uuid"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "log_ids") {
+		t.Errorf("validation message should name the log_ids field, got: %s", w.Body.String())
+	}
+	if repo.deleteCalls != 0 {
+		t.Errorf("a malformed request reached the repo (%d calls)", repo.deleteCalls)
+	}
+}

--- a/apps/api/internal/email/handler.go
+++ b/apps/api/internal/email/handler.go
@@ -64,8 +64,8 @@ func (h *Handler) SetPublicBase(publicBase string) {
 //	GET    /sites/:siteId/email/log/:logId            — single log entry detail
 //	GET    /sites/:siteId/email/stats                 — per-site email stats
 //	POST   /sites/:siteId/email/log/:logId/resend     — single resend (body_stored gate)
-//	POST   /sites/:siteId/email/log/resend            — bulk resend (body ids[])
-//	DELETE /sites/:siteId/email/log                   — bulk delete (ids[])
+//	POST   /sites/:siteId/email/log/resend            — bulk resend (body log_ids[])
+//	DELETE /sites/:siteId/email/log                   — bulk delete (log_ids[])
 //	GET    /sites/:siteId/email/suppression           — per-site suppression list
 //	POST   /sites/:siteId/email/suppression           — manual add
 //	DELETE /sites/:siteId/email/suppression/:id       — un-suppress
@@ -580,26 +580,72 @@ func (h *Handler) resendLog(c *gin.Context) {
 	})
 }
 
+// bulkLogIDsBody is the request body shared by bulk resend and bulk delete.
+//
+// GH #307: both handlers used to bind only "ids", but the OpenAPI schemas
+// (BulkResendRequest, BulkDeleteLogsRequest) declare the field as "log_ids",
+// which is what the generated @wpmgr/api client and the web app have always
+// sent. The field therefore never bound, the id list was empty, and both
+// endpoints returned 200 with a zero count while doing nothing.
+//
+// "log_ids" is the contract and wins. "ids" stays accepted because it is the
+// name the shipped handler read, so a hand-rolled caller written against the
+// handler source rather than the spec has been working all along and must not
+// break. log_ids takes precedence when both are present.
+type bulkLogIDsBody struct {
+	LogIDs []string `json:"log_ids"`
+	IDs    []string `json:"ids"` // legacy alias, see above
+}
+
+func (b bulkLogIDsBody) ids() []string {
+	if len(b.LogIDs) > 0 {
+		return b.LogIDs
+	}
+	return b.IDs
+}
+
+// errEmptyLogIDs is the rejection for a body that carries no ids at all: `{}`,
+// `{"log_ids": []}`, or a legacy `{"ids": []}`.
+//
+// GH #307 follow-up. log_ids is `required` in both schemas, but nothing
+// enforced that server-side: an empty list sailed through to the service,
+// deleted nothing, still wrote an audit row, and still answered 200
+// {"deleted": 0}. That is the exact "0 log entries deleted" success toast the
+// original bug produced, so the symptom stayed reachable for any caller that
+// is not the TypeScript client (which blocks it at compile time). A request
+// that asks for nothing is a caller mistake, not a successful no-op, and it
+// must not leave an audit trail claiming otherwise.
+func errEmptyLogIDs() error {
+	return domain.Validation("log_ids_required", "log_ids must contain at least one log entry id")
+}
+
 // bulkResendLog handles POST /sites/:siteId/email/log/resend.
-// Body: {"ids": ["uuid", ...]}
+// Body: {"log_ids": ["uuid", ...]}, the OpenAPI BulkResendRequest schema.
 func (h *Handler) bulkResendLog(c *gin.Context) {
 	p, _ := domain.PrincipalFromContext(c.Request.Context())
 	siteID, ok := parseSiteID(c)
 	if !ok {
 		return
 	}
-	var body struct {
-		IDs []string `json:"ids"`
-	}
+	var body bulkLogIDsBody
 	if err := bindJSON(c, &body); err != nil {
 		httpx.Error(c, err)
 		return
 	}
-	ids := make([]uuid.UUID, 0, len(body.IDs))
-	for _, s := range body.IDs {
+	raw := body.ids()
+	if len(raw) == 0 {
+		httpx.Error(c, errEmptyLogIDs())
+		return
+	}
+	if len(raw) > MaxBulkResend {
+		httpx.Error(c, domain.Validation("resend_bulk_too_large", "bulk resend maximum is 100 entries per request"))
+		return
+	}
+	ids := make([]uuid.UUID, 0, len(raw))
+	for _, s := range raw {
 		id, err := uuid.Parse(s)
 		if err != nil {
-			httpx.Error(c, domain.Validation("invalid_log_id", "ids contains an invalid UUID: "+s))
+			httpx.Error(c, domain.Validation("invalid_log_id", "log_ids contains an invalid UUID: "+s))
 			return
 		}
 		ids = append(ids, id)
@@ -622,25 +668,32 @@ func (h *Handler) bulkResendLog(c *gin.Context) {
 }
 
 // bulkDeleteLog handles DELETE /sites/:siteId/email/log.
-// Body: {"ids": ["uuid", ...]}
+// Body: {"log_ids": ["uuid", ...]}, the OpenAPI BulkDeleteLogsRequest schema.
 func (h *Handler) bulkDeleteLog(c *gin.Context) {
 	p, _ := domain.PrincipalFromContext(c.Request.Context())
 	siteID, ok := parseSiteID(c)
 	if !ok {
 		return
 	}
-	var body struct {
-		IDs []string `json:"ids"`
-	}
+	var body bulkLogIDsBody
 	if err := bindJSON(c, &body); err != nil {
 		httpx.Error(c, err)
 		return
 	}
-	ids := make([]uuid.UUID, 0, len(body.IDs))
-	for _, s := range body.IDs {
+	raw := body.ids()
+	if len(raw) == 0 {
+		httpx.Error(c, errEmptyLogIDs())
+		return
+	}
+	if len(raw) > MaxBulkDelete {
+		httpx.Error(c, domain.Validation("bulk_delete_too_large", "bulk delete maximum is 500 entries per request"))
+		return
+	}
+	ids := make([]uuid.UUID, 0, len(raw))
+	for _, s := range raw {
 		id, err := uuid.Parse(s)
 		if err != nil {
-			httpx.Error(c, domain.Validation("invalid_log_id", "ids contains an invalid UUID: "+s))
+			httpx.Error(c, domain.Validation("invalid_log_id", "log_ids contains an invalid UUID: "+s))
 			return
 		}
 		ids = append(ids, id)

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -842,13 +842,22 @@ func (s *Service) ResendEmail(ctx context.Context, tenantID, siteID, logID uuid.
 	return ResendResult{OK: res.OK, Detail: res.Detail, MessageID: res.MessageID}, nil
 }
 
+// Bulk log-operation ceilings. These mirror the maxItems the OpenAPI schemas
+// BulkResendRequest and BulkDeleteLogsRequest declare for log_ids; the handler
+// rejects an oversized list before parsing it, and the checks below remain the
+// authoritative gate for any non-HTTP caller.
+const (
+	MaxBulkResend = 100
+	MaxBulkDelete = 500
+)
+
 // BulkResendEmail dispatches resend_email commands for multiple log entries.
 // Each entry is processed independently; per-entry body_stored gate is checked.
 func (s *Service) BulkResendEmail(ctx context.Context, tenantID, siteID uuid.UUID, logIDs []uuid.UUID) ([]BulkResendResult, error) {
 	if len(logIDs) == 0 {
 		return nil, nil
 	}
-	if len(logIDs) > 100 {
+	if len(logIDs) > MaxBulkResend {
 		return nil, domain.Validation("resend_bulk_too_large", "bulk resend maximum is 100 entries per request")
 	}
 	results := make([]BulkResendResult, 0, len(logIDs))
@@ -874,7 +883,7 @@ func (s *Service) BulkDeleteLogs(ctx context.Context, tenantID, siteID uuid.UUID
 	if len(logIDs) == 0 {
 		return 0, nil
 	}
-	if len(logIDs) > 500 {
+	if len(logIDs) > MaxBulkDelete {
 		return 0, domain.Validation("bulk_delete_too_large", "bulk delete maximum is 500 entries per request")
 	}
 	deleted, err := s.repo.DeleteEmailLogsBulk(ctx, tenantID, siteID, logIDs)

--- a/apps/api/tests/contract/doc.go
+++ b/apps/api/tests/contract/doc.go
@@ -1,0 +1,19 @@
+// Package contract holds the spec-versus-code contract gates: the tests that
+// diff packages/openapi/openapi.yaml against the REAL production Gin engine.
+//
+// It is deliberately a separate package from apps/api/tests. Those are
+// container-backed integration tests: 262 of them stand up their own ephemeral
+// Postgres through testcontainers, which is far too slow for the per-PR lane
+// and is why .github/workflows/ci.yml excludes that package from `go test`.
+// The gates in here need no container at all (they build the engine against an
+// empty *db.Pool and only read engine.Routes()), so they live one directory
+// down, where the CI package filter is anchored to exclude only
+// `/apps/api/tests` itself and every gate in this package runs on every PR.
+//
+// The rule that keeps this working: nothing in this package may start a
+// container or open a database connection. If a test here ever needs one, it
+// belongs in apps/api/tests instead.
+//
+// This file exists only so the package has a non-test Go file and is therefore
+// buildable by `go build ./...`; all the actual gates live in _test.go files.
+package contract

--- a/apps/api/tests/contract/openapi_request_body_test.go
+++ b/apps/api/tests/contract/openapi_request_body_test.go
@@ -1,0 +1,824 @@
+// openapi_request_body_test.go: the GH #307 structural fix. A full-engine
+// contract test that checks every hand-written Gin handler actually READS the
+// request-body field names its own OpenAPI schema declares.
+//
+// Why this file exists. The ogen server is generated but never mounted: all
+// 359 live routes are hand-written Gin, and packages/openapi/openapi.yaml is a
+// hand-maintained document that only the TypeScript client is generated from.
+// Nothing in the Go build ever compares the two. So a handler could bind
+// `json:"ids"` while its schema declared `log_ids`, and the field simply never
+// bound: the endpoint returned 200 with a zero count, the UI toasted "0 log
+// entries deleted", and an audit row recorded the no-op as a success. Two
+// endpoints (bulk email log delete and bulk resend) shipped that way and were
+// invisible to every existing gate, because route-existence tests only compare
+// path+method and never look inside the body.
+//
+// How it works. It reuses buildFullEngine (openapi_route_coverage_test.go) to
+// get the REAL route table, then uses gin's RouteInfo.Handler, the fully
+// qualified name of the final handler func (e.g.
+// ".../internal/email.(*Handler).bulkDeleteLog-fm"), to find that exact method
+// in the source with go/ast, extract the json tags of the struct it binds, and
+// diff them against the operation's requestBody schema. No Postgres is needed
+// (an empty db.Pool is enough: Register only inspects handler-nilness, and no
+// request is ever issued), which is why this gate lives in tests/contract and
+// runs in CI on every PR rather than in the container-backed tests package.
+//
+// Both directions fail the build:
+//
+//   - a spec field the handler never binds (the #307 class: the caller sends
+//     it, the server silently ignores it).
+//   - a bound field the spec never declares (the mirror image: no generated
+//     client can ever set it, so the feature is unreachable through the
+//     documented contract).
+//
+// A rename in either direction therefore trips BOTH checks.
+//
+// Comparison is STRUCTURAL and nested: the spec tree and the bound-struct tree
+// are walked in parallel, one object level at a time, and a mismatch is
+// reported by its dotted path ("core_update.new_version"). The walk descends
+// into a property only when BOTH sides still describe it: the spec declares
+// sub-properties AND the Go type resolves to a struct with fields. Where either
+// side stops (an opaque `type: object` in the spec, or a scalar / map /
+// json.RawMessage on the Go side) the comparison stops with it, because there
+// is nothing left to compare against. That rule is what makes nesting usable:
+// a naive deep diff reports every field of a typed Go struct as "extra" against
+// an opaque spec level. See compareLevel for the two real cases this handles.
+//
+// An earlier version of this header claimed nested coverage the code did not
+// have (both extractors stopped at the top level), and nothing detected the
+// gap. The gate now asserts a floor on how many compared fields were below the
+// top level, so that specific regression fails loudly instead of silently
+// shrinking the guard.
+//
+// Every allowlist entry below carries a reason. Add one only when the drift is
+// deliberate; the fix is normally to correct the spec or the handler.
+package contract
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+)
+
+const apiModulePrefix = "github.com/mosamlife/wpmgr/apps/api/"
+
+// ---------------------------------------------------------------------------
+// Allowlists
+// ---------------------------------------------------------------------------
+
+// fieldKey identifies one field of one operation's request body.
+type fieldKey struct {
+	method string
+	path   string
+	field  string
+}
+
+// allowedSpecFieldNotBound: the spec declares the field, the handler
+// deliberately does not read it.
+var allowedSpecFieldNotBound = map[fieldKey]string{
+	{"POST", "/agent/v1/disconnect", "site_id"}: "the schema itself documents site_id as \"echoed for convenience; auth binds the real identity\", so the handler must trust the signed agent identity, never a body-supplied site id",
+	{"POST", "/api/v1/sites", "tags"}:           "bound on the production path: POST /sites dispatches to createWithEnrollment (h.conn != nil), which binds createSiteV2Request including tags. This extractor only reads the dispatching func's own body, where the legacy no-lifecycle fallback binds createSiteRequest. The legacy path does drop tags, but it is a dev/no-SSE fallback and the site-first flow is the shipped one",
+}
+
+// allowedBoundFieldNotInSpec: the handler reads the field, the spec
+// deliberately does not declare it.
+var allowedBoundFieldNotInSpec = map[fieldKey]string{
+	{"DELETE", "/api/v1/sites/{siteId}/email/log", "ids"}:                     "GH #307 back-compat alias. log_ids is the contract and what every generated client sends; \"ids\" is the name the broken handler used to read, kept accepted so a hand-rolled caller written against the old handler source does not break. Deliberately NOT advertised in the spec",
+	{"POST", "/api/v1/sites/{siteId}/email/log/resend", "ids"}:                "GH #307 back-compat alias; see the DELETE .../email/log entry above",
+	{"PUT", "/api/v1/sites/{siteId}/security/login-protection", "updated_at"}: "securityConfigDTO is shared by the GET response and the PUT body; updated_at exists so a client can echo the GET payload straight back. It is server-owned and ignored on write, so declaring it on the update schema would advertise a writable field that is not",
+}
+
+// unresolvableHandlers: routes whose bound struct this extractor cannot
+// determine statically. Each still has a spec body, so the pairing is checked
+// by TestOpenAPIRouteCoverage; only the field-level diff is skipped.
+//
+// Every reason here has been checked against the handler source. A reason that
+// merely sounds plausible is worse than none, because it stops the next reader
+// re-checking: the archive and revoke entries used to claim "body is optional
+// and ignored" when both in fact read `reason` from the body through the shared
+// optionalReason helper, and the heartbeat entry blamed a "cross-package alias"
+// when the real cause is that the body is bound into an untyped map. Both are
+// resolved rather than re-worded below.
+var unresolvableHandlers = map[routeKey]string{
+	{"POST", "/agent/v1/diagnostics"}:                   "reads the raw body and hands it to the diagnostics service as json.RawMessage; there is no bound struct in the handler to compare",
+	{"POST", "/agent/v1/heartbeat"}:                     "binds the body into a map[string]any, not a struct (internal/agent/handler.go: \"the beat is about liveness, not the payload\"), and forwards the whole map to RecordHeartbeat. An untyped map has no json tags, so there is nothing to diff field-by-field",
+	{"POST", "/webhooks/billing/{provider}"}:            "raw provider payload: signature is verified over the exact bytes, so the handler must not decode into a struct first",
+	{"POST", "/webhooks/email/{provider}/{routeToken}"}: "raw provider payload, verified over exact bytes, same as the billing webhook",
+}
+
+// ---------------------------------------------------------------------------
+// Spec side
+// ---------------------------------------------------------------------------
+
+type specSchemaNode struct {
+	Ref        string               `yaml:"$ref"`
+	Required   []string             `yaml:"required"`
+	Properties map[string]yaml.Node `yaml:"properties"`
+	Items      *yaml.Node           `yaml:"items"`
+	AllOf      []yaml.Node          `yaml:"allOf"`
+	OneOf      []yaml.Node          `yaml:"oneOf"`
+	AnyOf      []yaml.Node          `yaml:"anyOf"`
+}
+
+type specDocument struct {
+	Paths      map[string]map[string]yaml.Node `yaml:"paths"`
+	Components struct {
+		Schemas map[string]yaml.Node `yaml:"schemas"`
+	} `yaml:"components"`
+}
+
+type specOperation struct {
+	RequestBody struct {
+		Content map[string]struct {
+			Schema yaml.Node `yaml:"schema"`
+		} `yaml:"content"`
+	} `yaml:"requestBody"`
+}
+
+type specBodyFields struct {
+	schema string
+	root   *specNode
+}
+
+// specNode is ONE object level of a request-body schema: the properties
+// declared at that level, which of them are required, and each property's own
+// sub-schema.
+//
+// A node with an empty props map is "opaque": the spec says `type: object` (or
+// a bare scalar) without declaring what is inside. Several agent-facing
+// schemas do that deliberately, and it is the reason the comparison never
+// descends blindly. See compareLevel.
+type specNode struct {
+	props    map[string]*specNode
+	required map[string]bool
+}
+
+func newSpecNode() *specNode {
+	return &specNode{props: map[string]*specNode{}, required: map[string]bool{}}
+}
+
+// merge folds another level into this one, for allOf composition (which is the
+// same object level) and for array items. withRequired is false for
+// oneOf/anyOf: those are alternatives, so their names count as declared but
+// none of them is required.
+func (n *specNode) merge(o *specNode, withRequired bool) {
+	if o == nil {
+		return
+	}
+	for k, v := range o.props {
+		if existing, ok := n.props[k]; ok && existing != nil && v != nil {
+			existing.merge(v, true)
+			continue
+		}
+		n.props[k] = v
+	}
+	if withRequired {
+		for k := range o.required {
+			n.required[k] = true
+		}
+	}
+}
+
+// tree builds the full nested schema tree, resolving $ref, merging allOf, and
+// unwrapping array items (the Go side unwraps slices to their element type, so
+// the spec side must unwrap too or the two would compare different levels).
+func (d *specDocument) tree(n yaml.Node, ancestors map[string]bool, depth int) *specNode {
+	out := newSpecNode()
+	if depth > 12 {
+		return out
+	}
+	var s specSchemaNode
+	if err := n.Decode(&s); err != nil {
+		return out
+	}
+	if s.Ref != "" {
+		name := strings.TrimPrefix(s.Ref, "#/components/schemas/")
+		if ancestors[name] {
+			return out // cycle guard
+		}
+		sub, ok := d.Components.Schemas[name]
+		if !ok {
+			return out
+		}
+		next := map[string]bool{name: true}
+		for k := range ancestors {
+			next[k] = true
+		}
+		return d.tree(sub, next, depth+1)
+	}
+	for _, r := range s.Required {
+		out.required[r] = true
+	}
+	for k, v := range s.Properties {
+		out.props[k] = d.tree(v, ancestors, depth+1)
+	}
+	for _, sub := range s.AllOf {
+		out.merge(d.tree(sub, ancestors, depth+1), true)
+	}
+	for _, sub := range append(append([]yaml.Node{}, s.OneOf...), s.AnyOf...) {
+		out.merge(d.tree(sub, ancestors, depth+1), false)
+	}
+	if s.Items != nil {
+		out.merge(d.tree(*s.Items, ancestors, depth+1), true)
+	}
+	return out
+}
+
+func specRequestBodies(t *testing.T) map[routeKey]specBodyFields {
+	t.Helper()
+	raw, err := os.ReadFile(specPath(t))
+	if err != nil {
+		t.Fatalf("read openapi.yaml: %v", err)
+	}
+	var doc specDocument
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse openapi.yaml: %v", err)
+	}
+	out := map[routeKey]specBodyFields{}
+	for path, ops := range doc.Paths {
+		for verb, node := range ops {
+			lv := strings.ToLower(verb)
+			switch lv {
+			case "get", "post", "put", "patch", "delete", "options":
+			default:
+				continue
+			}
+			var op specOperation
+			if err := node.Decode(&op); err != nil {
+				continue
+			}
+			ct, ok := op.RequestBody.Content["application/json"]
+			if !ok {
+				continue
+			}
+			var top specSchemaNode
+			_ = ct.Schema.Decode(&top)
+			out[routeKey{strings.ToUpper(lv), path}] = specBodyFields{
+				schema: strings.TrimPrefix(top.Ref, "#/components/schemas/"),
+				root:   doc.tree(ct.Schema, map[string]bool{}, 0),
+			}
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Handler side (go/ast)
+// ---------------------------------------------------------------------------
+
+// bodyBindFuncs are the calls that decode a JSON request body in this codebase.
+// The destination is always the call's last argument.
+var bodyBindFuncs = map[string]bool{
+	"bindJSON": true, "policyBindJSON": true, "decode": true, "decodeJSON": true,
+	"ShouldBindJSON": true, "BindJSON": true, "ShouldBindWith": true,
+	"MustBindWith": true, "ShouldBind": true, "Decode": true, "Unmarshal": true,
+}
+
+type sourceIndex struct {
+	fset *token.FileSet
+	pkgs map[string]map[string]*ast.File
+}
+
+func newSourceIndex() *sourceIndex {
+	return &sourceIndex{fset: token.NewFileSet(), pkgs: map[string]map[string]*ast.File{}}
+}
+
+func (si *sourceIndex) files(importPath string) map[string]*ast.File {
+	if f, ok := si.pkgs[importPath]; ok {
+		return f
+	}
+	rel := strings.TrimPrefix(importPath, apiModulePrefix)
+	if rel == importPath { // outside this module, no source to read
+		si.pkgs[importPath] = nil
+		return nil
+	}
+	// tests/contract/ -> tests/ -> apps/api/, the module root the import path
+	// is relative to.
+	parsed, err := parser.ParseDir(si.fset, filepath.Join("../..", rel), func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		si.pkgs[importPath] = nil
+		return nil
+	}
+	files := map[string]*ast.File{}
+	for _, p := range parsed {
+		for name, f := range p.Files {
+			files[name] = f
+		}
+	}
+	si.pkgs[importPath] = files
+	return files
+}
+
+// receiverName returns a method's receiver type name ("" for a plain func).
+func receiverName(fd *ast.FuncDecl) string {
+	if fd.Recv == nil || len(fd.Recv.List) == 0 {
+		return ""
+	}
+	t := fd.Recv.List[0].Type
+	if s, ok := t.(*ast.StarExpr); ok {
+		t = s.X
+	}
+	if id, ok := t.(*ast.Ident); ok {
+		return id.Name
+	}
+	return ""
+}
+
+// findFunc matches on name AND receiver type. Matching the receiver is
+// load-bearing: internal/agent alone declares three distinct handlers with a
+// method named push, and a name-only match silently reads the wrong body.
+func (si *sourceIndex) findFunc(importPath, recv, name string) (*ast.FuncDecl, *ast.File) {
+	for _, f := range si.files(importPath) {
+		for _, d := range f.Decls {
+			fd, ok := d.(*ast.FuncDecl)
+			if ok && fd.Name.Name == name && receiverName(fd) == recv {
+				return fd, f
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (si *sourceIndex) findType(importPath, name string) (ast.Expr, *ast.File) {
+	for _, f := range si.files(importPath) {
+		for _, d := range f.Decls {
+			gd, ok := d.(*ast.GenDecl)
+			if !ok || gd.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				if ts, ok := spec.(*ast.TypeSpec); ok && ts.Name.Name == name {
+					return ts.Type, f
+				}
+			}
+		}
+	}
+	return nil, nil
+}
+
+func importPathForAlias(f *ast.File, alias string) string {
+	for _, im := range f.Imports {
+		p, err := strconv.Unquote(im.Path.Value)
+		if err != nil {
+			continue
+		}
+		name := p[strings.LastIndex(p, "/")+1:]
+		if im.Name != nil {
+			name = im.Name.Name
+		}
+		if name == alias {
+			return p
+		}
+	}
+	return ""
+}
+
+// goNode is ONE object level of the struct a handler binds: the json tag names
+// declared at that level, each mapped to its own sub-tree.
+//
+// A nil child means the field's type does not resolve to a struct in this
+// module's source: a scalar, a map[string]any, a type from outside the api
+// module, or a json.RawMessage the handler decodes in a separate later pass.
+// A nil child is the signal that the Go side stops describing the shape here,
+// and compareLevel stops descending with it.
+type goNode struct {
+	children map[string]*goNode
+}
+
+// withKey returns ancestors plus key, copied so that sibling branches do not
+// prune each other. A shared set would let the first branch to reach a type
+// suppress every later use of it and silently drop real fields.
+func withKey(ancestors map[string]bool, key string) map[string]bool {
+	next := make(map[string]bool, len(ancestors)+1)
+	for k := range ancestors {
+		next[k] = true
+	}
+	next[key] = true
+	return next
+}
+
+// structTree resolves a type expression into its nested json-tag tree, or nil
+// if the type is not a struct declared in this module.
+func (si *sourceIndex) structTree(expr ast.Expr, f *ast.File, importPath string, ancestors map[string]bool, depth int) *goNode {
+	if expr == nil || depth > 8 {
+		return nil
+	}
+	switch e := expr.(type) {
+	case *ast.StarExpr:
+		return si.structTree(e.X, f, importPath, ancestors, depth+1)
+	case *ast.ArrayType:
+		return si.structTree(e.Elt, f, importPath, ancestors, depth+1)
+	case *ast.MapType:
+		return si.structTree(e.Value, f, importPath, ancestors, depth+1)
+	case *ast.Ident:
+		key := importPath + "." + e.Name
+		if ancestors[key] {
+			return nil
+		}
+		td, tf := si.findType(importPath, e.Name)
+		if td == nil {
+			return nil
+		}
+		return si.structTree(td, tf, importPath, withKey(ancestors, key), depth+1)
+	case *ast.SelectorExpr:
+		id, ok := e.X.(*ast.Ident)
+		if !ok {
+			return nil
+		}
+		ip := importPathForAlias(f, id.Name)
+		if ip == "" {
+			return nil
+		}
+		key := ip + "." + e.Sel.Name
+		if ancestors[key] {
+			return nil
+		}
+		td, tf := si.findType(ip, e.Sel.Name)
+		if td == nil {
+			return nil // e.g. encoding/json.RawMessage: outside this module
+		}
+		return si.structTree(td, tf, ip, withKey(ancestors, key), depth+1)
+	case *ast.StructType:
+		out := &goNode{children: map[string]*goNode{}}
+		for _, fld := range e.Fields.List {
+			if fld.Tag != nil {
+				tv, err := strconv.Unquote(fld.Tag.Value)
+				if err != nil {
+					continue
+				}
+				name := strings.Split(reflect.StructTag(tv).Get("json"), ",")[0]
+				if name == "" || name == "-" {
+					continue
+				}
+				out.children[name] = si.structTree(fld.Type, f, importPath, ancestors, depth+1)
+				continue
+			}
+			// An embedded (unnamed) field promotes its own fields to THIS
+			// level, so its children merge in rather than nesting. A named
+			// field without a tag is not part of the JSON contract.
+			if len(fld.Names) == 0 {
+				if sub := si.structTree(fld.Type, f, importPath, ancestors, depth+1); sub != nil {
+					for k, v := range sub.children {
+						if _, exists := out.children[k]; !exists {
+							out.children[k] = v
+						}
+					}
+				}
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// boundBodyTree returns the nested json-tag tree of the struct the handler
+// decodes the request body into.
+//
+// It first looks for a bind call in the handler's own body. If there is none,
+// it follows ONE level of delegation into the plain same-package functions the
+// handler calls, in source order. Several site-lifecycle handlers (revoke,
+// archive) never bind inline; they call a shared optionalReason(c) helper that
+// decodes the body for them, and without this step their request body would be
+// invisible to this gate for no better reason than where the decode was
+// written. One level into the same package is enough for every such handler
+// here and keeps the search from wandering off into unrelated call graphs.
+func (si *sourceIndex) boundBodyTree(fn *ast.FuncDecl, f *ast.File, importPath string) (*goNode, string) {
+	tree, note := si.bindTreeInFunc(fn, f, importPath)
+	if tree != nil {
+		return tree, ""
+	}
+	for _, callee := range calledPlainFuncs(fn) {
+		cf, cfile := si.findFunc(importPath, "", callee)
+		if cf == nil {
+			continue
+		}
+		if sub, _ := si.bindTreeInFunc(cf, cfile, importPath); sub != nil {
+			return sub, ""
+		}
+	}
+	return nil, note
+}
+
+// calledPlainFuncs lists, in source order and deduplicated, the package-level
+// functions a handler calls by bare name. Method calls (h.something) are
+// excluded on purpose: a handler that dispatches to another handler method is
+// choosing between two whole request paths, not delegating its body decode, and
+// following it would silently attribute the wrong struct to this route.
+func calledPlainFuncs(fn *ast.FuncDecl) []string {
+	if fn.Body == nil {
+		return nil
+	}
+	var out []string
+	seen := map[string]bool{}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		id, ok := call.Fun.(*ast.Ident)
+		if !ok || seen[id.Name] || bodyBindFuncs[id.Name] {
+			return true
+		}
+		seen[id.Name] = true
+		out = append(out, id.Name)
+		return true
+	})
+	return out
+}
+
+// bindTreeInFunc finds the first request-body bind call inside ONE function and
+// resolves its destination type. Only the FIRST bind counts: a function that
+// decodes again (the perf agent re-parses the object_cache sub-object in a
+// second pass) is reading a nested level, not another top-level body.
+func (si *sourceIndex) bindTreeInFunc(fn *ast.FuncDecl, f *ast.File, importPath string) (*goNode, string) {
+	if fn.Body == nil {
+		return nil, "handler has no body"
+	}
+	// Local variable name -> declared type expression.
+	locals := map[string]ast.Expr{}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch s := n.(type) {
+		case *ast.DeclStmt:
+			gd, ok := s.Decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.VAR {
+				return true
+			}
+			for _, spec := range gd.Specs {
+				if vs, ok := spec.(*ast.ValueSpec); ok && vs.Type != nil {
+					for _, nm := range vs.Names {
+						locals[nm.Name] = vs.Type
+					}
+				}
+			}
+		case *ast.AssignStmt:
+			if len(s.Lhs) != 1 || len(s.Rhs) != 1 {
+				return true
+			}
+			id, ok := s.Lhs[0].(*ast.Ident)
+			if !ok {
+				return true
+			}
+			switch r := s.Rhs[0].(type) {
+			case *ast.CompositeLit:
+				locals[id.Name] = r.Type
+			case *ast.UnaryExpr:
+				if cl, ok := r.X.(*ast.CompositeLit); ok {
+					locals[id.Name] = cl.Type
+				}
+			}
+		}
+		return true
+	})
+
+	var tree *goNode
+	note := "no request-body bind call found"
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if tree != nil {
+			return false // primary body already found
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+		var fname string
+		switch fe := call.Fun.(type) {
+		case *ast.Ident:
+			fname = fe.Name
+		case *ast.SelectorExpr:
+			fname = fe.Sel.Name
+		}
+		if !bodyBindFuncs[fname] {
+			return true
+		}
+		dst := call.Args[len(call.Args)-1]
+		if u, isUnary := dst.(*ast.UnaryExpr); isUnary {
+			dst = u.X
+		}
+		var texpr ast.Expr
+		switch de := dst.(type) {
+		case *ast.Ident:
+			texpr = locals[de.Name]
+		case *ast.CompositeLit:
+			texpr = de.Type
+		}
+		if texpr == nil {
+			note = "could not resolve the type of the bind destination"
+			return true
+		}
+		got := si.structTree(texpr, f, importPath, map[string]bool{}, 0)
+		if got == nil {
+			note = "could not resolve the bound struct type"
+			return true
+		}
+		tree = got
+		return true
+	})
+	if tree != nil {
+		return tree, ""
+	}
+	return nil, note
+}
+
+// ---------------------------------------------------------------------------
+// Parallel walk
+// ---------------------------------------------------------------------------
+
+// walkStats counts what the walk actually compared. nested (fields below the
+// top level) is asserted against a floor by the gate: if a future refactor
+// quietly turns the comparison back into a top-level-only diff, that floor
+// fails instead of the gate going green while covering less than it claims.
+// This exists because the header once described nested coverage the code did
+// not have, and nothing detected the gap.
+type walkStats struct {
+	fields int
+	nested int
+}
+
+// compareLevel diffs ONE object level of the spec against the matching level of
+// the bound struct, then recurses into each property both sides describe.
+//
+// The descent rule is the whole design, and it is what keeps nesting free of
+// phantom mismatches: recurse into a property only when the spec declares
+// sub-properties for it AND the Go type resolves to a struct with fields. If
+// either side stops describing the shape, the comparison stops with it, because
+// there is nothing left to compare against.
+//
+// Both directions of "stops describing" are real and intentional:
+//
+//   - spec side: many agent-facing schemas model a sub-object as an opaque
+//     `type: object`. Descending there would diff a fully typed Go struct
+//     against a level that declares nothing and report every field as extra.
+//   - Go side: AgentCacheStatsReport.object_cache is held as json.RawMessage
+//     (internal/perf/agent_handler.go) precisely so a malformed block cannot
+//     fail the whole-body Unmarshal; it is decoded in a second pass. The
+//     handler genuinely does not bind those names at this level, so its
+//     sub-tree is nil and the walk stops. That is a property of the type, not
+//     an allowlist entry, so it needs no maintenance and cannot rot into a
+//     blanket exemption for that route.
+//
+// path is the dotted prefix ("" at top level, "core_update." one level in), so
+// a nested mismatch is reported and allowlisted by its full path.
+func compareLevel(k routeKey, schema string, sp *specNode, gp *goNode, path string, st *walkStats, notBound, notInSpec *[]string) {
+	specNames := make([]string, 0, len(sp.props))
+	for name := range sp.props {
+		specNames = append(specNames, name)
+	}
+	sort.Strings(specNames)
+
+	for _, name := range specNames {
+		full := path + name
+		st.fields++
+		if path != "" {
+			st.nested++
+		}
+		child, gchild := sp.props[name], gp.children[name]
+		if _, bound := gp.children[name]; !bound {
+			if _, ok := allowedSpecFieldNotBound[fieldKey{k.method, k.path, full}]; ok {
+				continue
+			}
+			kind := "optional"
+			if sp.required[name] {
+				kind = "REQUIRED"
+			}
+			*notBound = append(*notBound, fmt.Sprintf("%s %s [%s] spec declares %s field %q, handler never binds it", k.method, k.path, schema, kind, full))
+			continue
+		}
+		if child != nil && len(child.props) > 0 && gchild != nil && len(gchild.children) > 0 {
+			compareLevel(k, schema, child, gchild, full+".", st, notBound, notInSpec)
+		}
+	}
+
+	goNames := make([]string, 0, len(gp.children))
+	for name := range gp.children {
+		goNames = append(goNames, name)
+	}
+	sort.Strings(goNames)
+
+	for _, name := range goNames {
+		if _, ok := sp.props[name]; ok {
+			continue
+		}
+		full := path + name
+		if _, ok := allowedBoundFieldNotInSpec[fieldKey{k.method, k.path, full}]; ok {
+			continue
+		}
+		*notInSpec = append(*notInSpec, fmt.Sprintf("%s %s [%s] handler binds %q, spec never declares it", k.method, k.path, schema, full))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The gate
+// ---------------------------------------------------------------------------
+
+func TestOpenAPIRequestBodyFieldCoverage(t *testing.T) {
+	engine := buildFullEngine(t, &db.Pool{})
+
+	handlerFor := map[routeKey]string{}
+	for _, r := range engine.Routes() {
+		handlerFor[routeKey{r.Method, normalizeGinPath(r.Path)}] = r.Handler
+	}
+
+	si := newSourceIndex()
+	var notBound, notInSpec, unresolved []string
+	var stats walkStats
+	checked := 0
+
+	bodies := specRequestBodies(t)
+	keys := make([]routeKey, 0, len(bodies))
+	for k := range bodies {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].path != keys[j].path {
+			return keys[i].path < keys[j].path
+		}
+		return keys[i].method < keys[j].method
+	})
+
+	for _, k := range keys {
+		sb := bodies[k]
+		qualified, live := handlerFor[k]
+		if !live {
+			continue // route-existence drift is TestOpenAPIRouteCoverage's job
+		}
+		if _, skip := unresolvableHandlers[k]; skip {
+			continue
+		}
+
+		// ".../internal/email.(*Handler).bulkDeleteLog-fm" -> pkg, recv, func
+		name := strings.TrimSuffix(qualified, "-fm")
+		dot := strings.LastIndex(name, ".")
+		if dot < 0 {
+			continue
+		}
+		funcName, pkgPart := name[dot+1:], name[:dot]
+		recv := ""
+		if i := strings.Index(pkgPart, ".("); i >= 0 {
+			recv = strings.Trim(pkgPart[i+2:], "()*")
+			pkgPart = pkgPart[:i]
+		}
+
+		fn, file := si.findFunc(pkgPart, recv, funcName)
+		if fn == nil {
+			unresolved = append(unresolved, fmt.Sprintf("%s %s -> %s (handler func not found in source)", k.method, k.path, qualified))
+			continue
+		}
+		tree, note := si.boundBodyTree(fn, file, pkgPart)
+		if note != "" {
+			unresolved = append(unresolved, fmt.Sprintf("%s %s -> %s (%s)", k.method, k.path, qualified, note))
+			continue
+		}
+		checked++
+
+		compareLevel(k, sb.schema, sb.root, tree, "", &stats, &notBound, &notInSpec)
+	}
+
+	if checked < 100 {
+		t.Fatalf("only %d request bodies were actually compared; the extractor is broken, not the code", checked)
+	}
+	// Floor on nested coverage. The walk currently reaches 39 fields below the
+	// top level (core_update.*, agent_self_update.*, disk.*, host_flags.* on
+	// the agent metadata push; report sections.*; perf cdn_credentials.*;
+	// security thresholds.*). 30 leaves refactoring room while still failing
+	// loudly if the descent ever stops happening.
+	if stats.nested < 30 {
+		t.Fatalf("only %d of %d compared fields were below the top level; nested comparison has regressed, "+
+			"so this gate no longer covers the depth its header claims", stats.nested, stats.fields)
+	}
+	sort.Strings(notBound)
+	sort.Strings(notInSpec)
+	sort.Strings(unresolved)
+
+	if len(notBound) > 0 {
+		t.Errorf("%d request-body field(s) are declared in packages/openapi/openapi.yaml but never read by the handler.\n"+
+			"This is the GH #307 class: the caller sends the field, the server ignores it, and the endpoint\n"+
+			"reports success while doing nothing. Fix the handler's json tag, or add a justified\n"+
+			"allowedSpecFieldNotBound entry:\n  %s", len(notBound), strings.Join(notBound, "\n  "))
+	}
+	if len(notInSpec) > 0 {
+		t.Errorf("%d request-body field(s) are read by a handler but not declared in packages/openapi/openapi.yaml.\n"+
+			"No generated client can ever set these, so the behaviour is unreachable through the documented\n"+
+			"contract. Declare them in the spec (and regenerate both clients), or add a justified\n"+
+			"allowedBoundFieldNotInSpec entry:\n  %s", len(notInSpec), strings.Join(notInSpec, "\n  "))
+	}
+	if len(unresolved) > 0 {
+		t.Errorf("%d handler(s) with a documented JSON request body could not be analysed. Field drift in these\n"+
+			"is invisible to this gate. Either bind the body into a struct this extractor can resolve, or add\n"+
+			"a justified unresolvableHandlers entry:\n  %s", len(unresolved), strings.Join(unresolved, "\n  "))
+	}
+	t.Logf("compared %d request bodies against their OpenAPI schemas (%d fields, %d of them nested)", checked, stats.fields, stats.nested)
+}

--- a/apps/api/tests/contract/openapi_route_coverage_test.go
+++ b/apps/api/tests/contract/openapi_route_coverage_test.go
@@ -1,9 +1,9 @@
 // openapi_route_coverage_test.go — the P2-B docs-drift structural fix: a
 // full-engine contract test that builds the REAL production Gin engine
-// (server.New, the exact wiring internal/server/server.go's New performs)
-// against a real Postgres, enumerates engine.Routes(), normalises Gin's
-// :param syntax to OpenAPI's {param} syntax, and diffs it in BOTH directions
-// against packages/openapi/openapi.yaml:
+// (server.New, the exact wiring internal/server/server.go's New performs),
+// enumerates engine.Routes(), normalises Gin's :param syntax to OpenAPI's
+// {param} syntax, and diffs it in BOTH directions against
+// packages/openapi/openapi.yaml:
 //
 //   - a live route-method with no matching spec path+method fails the test
 //     (an undocumented route — the class this file exists to catch).
@@ -18,7 +18,7 @@
 // object-storage endpoint, a WebAuthn relying-party origin, a configured OIDC
 // issuer). Every allowlist entry carries a reason; the goal is an
 // EMPTY-ish list — grep the reasons below before adding to it.
-package tests
+package contract
 
 import (
 	"context"
@@ -178,8 +178,8 @@ func specRoutes(t *testing.T) map[routeKey]bool {
 
 func specPath(t *testing.T) string {
 	t.Helper()
-	// tests/ -> apps/api/ -> apps/ -> repo root -> packages/openapi/openapi.yaml
-	return "../../../packages/openapi/openapi.yaml"
+	// tests/contract/ -> tests/ -> apps/api/ -> apps/ -> repo root
+	return "../../../../packages/openapi/openapi.yaml"
 }
 
 // ---------------------------------------------------------------------------
@@ -187,8 +187,12 @@ func specPath(t *testing.T) string {
 // ---------------------------------------------------------------------------
 
 func TestOpenAPIRouteCoverage(t *testing.T) {
-	pool := startPostgres(t)
-	engine := buildFullEngine(t, pool)
+	// No Postgres: this test only reads engine.Routes(). The Register calls
+	// server.New makes inspect handler-nilness to decide what to mount and never
+	// touch the pool, so an empty *db.Pool yields the exact production route
+	// table. That is what keeps this gate containerless and able to run on every
+	// PR instead of only in the container lane.
+	engine := buildFullEngine(t, &db.Pool{})
 
 	live := liveRoutes(t, engine)
 	spec := specRoutes(t)
@@ -373,16 +377,16 @@ func buildFullEngine(t *testing.T, pool *db.Pool) *gin.Engine {
 	// --- RUM (public) ------------------------------------------------------
 	rumH := rum.NewHandlerWithPublisher(rum.NewStorePostgres(pool), rum.NewBeaconKeyRepo(pool), nil, logger)
 
-	// --- billing / pricing (WPMGR_HOSTED path). Mounted with the tests
-	// package's existing fake payment provider (billing_webhook_integration_
-	// test.go's newTestBillingService/newFakeProvider) so every /billing and
-	// /api/v1/pricing route is real, exactly mirroring the hosted-enabled
-	// branch of cmd/wpmgr/main.go. ------------------------------------------
-	fp := newFakeProvider("fake")
-	billingSvc := newTestBillingService(pool, fp)
+	// --- billing / pricing (WPMGR_HOSTED path) -------------------------------
+	// enabled=true mirrors the hosted-enabled branch of cmd/wpmgr/main.go, so
+	// every /billing and /api/v1/pricing route mounts for real. No payment
+	// provider is registered: Register only inspects handler-nilness and this
+	// file never issues a request, so an empty Registry mounts the identical
+	// route set without pulling a provider test double into this package.
+	billingSvc := billing.New(pool, nil, true, clock, logger)
 	billingH := billing.NewHandler(billingSvc, nil, "https://cp.example.test")
 	billingWebhookH := billing.NewWebhookHandler(billingSvc, logger)
-	pricingSvc := pricing.NewService(billing.NewRegistry(fp), nil, logger)
+	pricingSvc := pricing.NewService(billing.NewRegistry(), nil, logger)
 	pricingH := pricing.NewHandler(pricingSvc)
 
 	deps := server.Deps{

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,25 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.101",
+    date: "2026-07-29",
+    summary: "Deleting or resending selected entries on a site's Email Log actually works now.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "On a site's Email Log, selecting entries and clicking Delete showed \"0 log entries deleted\" and deleted nothing (GH #307). The dashboard and the control plane disagreed about the name of one field in the request, so the control plane received an empty list and truthfully reported deleting nothing. The Resend button had the same bug for the same reason and also did nothing. Both are fixed, and a deletion that removed nothing is no longer written into the audit log as though it had happened.",
+      },
+      {
+        tag: "Fixed",
+        text: "Sending an empty list to either endpoint used to return a confusing success with a count of zero; both now reject it with a clear error instead.",
+      },
+      {
+        tag: "Fixed",
+        text: "An automated check that compares every API endpoint against its published specification existed but was never wired into the checks that run on every change, which is how a mismatch like this reached a release. It runs on every change now, alongside a new check covering every request body field, including nested fields.",
+      },
+    ],
+  },
+  {
     version: "0.61.100",
     date: "2026-07-28",
     summary: "The Sites table shares its width sensibly across every column now, on any screen size.",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.100 / open source",
+  badge: "v0.61.101 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -377,6 +377,26 @@ export const SiteComponentSchema = {
     active: {
       type: "boolean",
     },
+    plugin_uri: {
+      type: "string",
+      description:
+        "PluginURI from the plugin header. Optional; older agents omit it.",
+    },
+    update_uri: {
+      type: "string",
+      description:
+        "UpdateURI from the plugin header. Optional; older agents omit it.",
+    },
+    author_uri: {
+      type: "string",
+      description:
+        "AuthorURI from the plugin header. Optional; older agents omit it.",
+    },
+    network: {
+      type: "boolean",
+      description:
+        "Whether the plugin is network-activated. Optional; older agents omit it.",
+    },
     available_update: {
       type: "object",
       nullable: true,
@@ -882,6 +902,16 @@ export const AgentMediaSyncBatchSchema = {
             type: "integer",
             format: "int64",
           },
+          variant_count: {
+            type: "integer",
+            description: "1 (full) plus generated sub-sizes.",
+          },
+          saved_bytes: {
+            type: "integer",
+            format: "int64",
+            description:
+              "All-variant savings, re-reported at sync so already-optimized rows heal.",
+          },
         },
       },
     },
@@ -955,6 +985,13 @@ export const AgentMediaJobStatusSchema = {
       type: "integer",
       format: "int64",
       nullable: true,
+    },
+    saved_bytes: {
+      type: "integer",
+      format: "int64",
+      nullable: true,
+      description:
+        'All-variant savings (summed original-minus-optimized over every optimized variant). Drives the dashboard "Bytes saved" rollup.',
     },
     compression_level: {
       type: "string",
@@ -1080,6 +1117,8 @@ export const FontTranscodeResponseSchema = {
 
 export const AgentMetadataSchema = {
   type: "object",
+  description:
+    "The agent's metadata push. Every field is optional and tolerantly\ndecoded (booleans and numbers are accepted as strings), so an older\nagent that omits any of them still syncs successfully.\n",
   properties: {
     wp_version: {
       type: "string",
@@ -1099,6 +1138,110 @@ export const AgentMetadataSchema = {
     active_theme: {
       type: "string",
       maxLength: 200,
+    },
+    agent_version: {
+      type: "string",
+      description: "The WPMgr agent plugin version.",
+    },
+    age_recipient: {
+      type: "string",
+      description:
+        'The agent\'s per-site age PUBLIC recipient ("age1..."), stored so\nbackups can be triggered without a separate registration call.\nEmpty or missing leaves the stored recipient unchanged.\n',
+    },
+    user_count: {
+      type: "integer",
+    },
+    admin_count: {
+      type: "integer",
+    },
+    core_update: {
+      type: "object",
+      nullable: true,
+      description: "Present only when WordPress core has an update available.",
+      properties: {
+        new_version: {
+          type: "string",
+        },
+        current_version: {
+          type: "string",
+        },
+      },
+    },
+    host_flags: {
+      type: "object",
+      nullable: true,
+      description: "The agent's defined()-based hosting fingerprint.",
+      properties: {
+        is_pressable: {
+          type: "boolean",
+        },
+        is_gridpane: {
+          type: "boolean",
+        },
+        is_wpengine: {
+          type: "boolean",
+        },
+        is_atomic: {
+          type: "boolean",
+        },
+        is_kinsta: {
+          type: "boolean",
+        },
+        is_flywheel: {
+          type: "boolean",
+        },
+        is_runcloud: {
+          type: "boolean",
+        },
+        is_cloudways: {
+          type: "boolean",
+        },
+      },
+    },
+    disk: {
+      type: "object",
+      nullable: true,
+      description:
+        "Sampled disk usage in bytes. The wp-content and uploads walks are\ntime-capped, so a field may be absent on a very large tree.\n",
+      properties: {
+        wp_content_bytes: {
+          type: "integer",
+          format: "int64",
+        },
+        uploads_bytes: {
+          type: "integer",
+          format: "int64",
+        },
+        free_bytes: {
+          type: "integer",
+          format: "int64",
+        },
+      },
+    },
+    agent_self_update: {
+      type: "object",
+      nullable: true,
+      description:
+        "The outcome of the agent's last self-update apply, replayed on the\nnext metadata push. This is the only channel by which a FAILED\napply reaches the control plane: the apply runs inside a cron\nrequest with no response to ride on.\n",
+      properties: {
+        status: {
+          type: "string",
+        },
+        from_version: {
+          type: "string",
+        },
+        to_version: {
+          type: "string",
+        },
+        detail: {
+          type: "string",
+        },
+        at: {
+          type: "integer",
+          format: "int64",
+          description: "Unix timestamp the agent stamped the record with.",
+        },
+      },
     },
     plugins: {
       type: "array",
@@ -1876,7 +2019,17 @@ export const BillingCheckoutRequestSchema = {
       type: "string",
       enum: ["starter", "agency", "scale"],
       description:
-        "The ONLY caller-supplied selector. The server resolves this to a payment-provider price server-side; a request can never name a price directly.",
+        "The only caller-supplied PRICE selector. The server resolves this to a payment-provider price server-side; a request can never name a price directly.",
+    },
+    provider: {
+      type: "string",
+      description:
+        "Preferred payment provider. Consulted only on a tenant's first-ever checkout: once a tenant is pinned to a provider that pinning always wins, so a returning customer can never split a subscription across two providers. An unknown name is rejected. Omit to use the instance default.",
+    },
+    currency: {
+      type: "string",
+      description:
+        "Preferred billing currency, passed to the provider when it creates the checkout. Selects among the prices the server already knows for the requested tier; it can never set an amount. Omit for the provider default.",
     },
   },
 } as const;
@@ -5100,6 +5253,10 @@ export const SiteErrorConfigSchema = {
   type: "object",
   required: ["error_level", "ignore_md5s"],
   properties: {
+    enabled: {
+      type: "boolean",
+      description: "Whether PHP-error capture is active for this site.\n",
+    },
     error_level: {
       type: "integer",
       format: "int32",
@@ -5121,6 +5278,11 @@ export const SiteErrorConfigUpdateSchema = {
   type: "object",
   required: ["error_level", "ignore_md5s"],
   properties: {
+    enabled: {
+      type: "boolean",
+      description:
+        "Turns PHP-error capture on or off. OMITTING this field is treated as\ntrue: a client that does not know about the flag can never\naccidentally disable the mu-plugin trap, but that also means an\nupdate sent without it re-enables capture on a site where it was\nswitched off. Send false explicitly to keep capture disabled.\n",
+    },
     error_level: {
       type: "integer",
       format: "int32",
@@ -6428,6 +6590,37 @@ export const PerfConfigSchema = {
       readOnly: true,
       description:
         "RFC3339 timestamp of the last agent probe. Null when never probed.\n",
+    },
+    rum_enabled: {
+      type: "boolean",
+      description: "Enable Real User Monitoring collection for this site.\n",
+    },
+    rum_sample_rate: {
+      type: "number",
+      format: "float",
+      description: "Fraction of page views that emit a RUM beacon (0 to 1).\n",
+    },
+    min_sample_count: {
+      type: "integer",
+      description:
+        "Suppression floor: any RUM slice with fewer samples than this is\nreported as suppressed rather than shown, so a handful of visits\ncannot masquerade as a trend.\n",
+    },
+    max_distinct_countries: {
+      type: "integer",
+      description:
+        "Cap on the number of distinct countries kept in the per-country RUM\nbreakdown.\n",
+    },
+    beacon_key_set: {
+      type: "boolean",
+      readOnly: true,
+      description:
+        "Whether a RUM beacon key is provisioned. The plaintext key is never\nreturned; this boolean is how a client tells whether RUM is fully\nprovisioned. Ignored on write.\n",
+    },
+    beacon_key_acked_present: {
+      type: "boolean",
+      readOnly: true,
+      description:
+        "Whether the agent's most recent config-ack confirmed it holds the\nbeacon key. beacon_key_set true with this false means RUM is\nprovisioned control-plane side but the agent has not confirmed\nreceipt yet; the control plane retries automatically. Ignored on\nwrite.\n",
     },
     config_version: {
       type: "integer",
@@ -9032,6 +9225,10 @@ export const ClientReportSectionFlagsSchema = {
   type: "object",
   description: "Controls which data sections are included in a report.",
   properties: {
+    overview: {
+      type: "boolean",
+      default: true,
+    },
     uptime: {
       type: "boolean",
       default: true,
@@ -13609,10 +13806,25 @@ export const AgentDbOrphanDeleteProgressSchema = {
     },
     results: {
       type: "array",
+      description:
+        "Per-item result rows for the items processed in this batch.",
       items: {
         type: "object",
+        properties: {
+          kind: {
+            type: "string",
+          },
+          name: {
+            type: "string",
+          },
+          status: {
+            type: "string",
+          },
+          detail: {
+            type: "string",
+          },
+        },
       },
-      description: "Agent-defined per-item result rows.",
     },
     deleted_options: {
       type: "integer",
@@ -14190,6 +14402,25 @@ export const PerfConfigWritableSchema = {
       default: false,
       description:
         "When true the agent will cache the WooCommerce catalog shell for\nanonymous shoppers who have an active cart. The agent additionally\nhard-gates on its own theme probe (`woo_theme_fragments_supported`)\nbefore serving cached pages to cart-holding visitors, providing a\ndefense-in-depth layer independent of this flag.\nThe API accepts `woo_cacheable_session: true` even when\n`woo_theme_fragments_supported` is false — the agent will not act on\nit until its own probe passes. This allows operators to pre-enable the\nflag before the agent performs its first probe.\n",
+    },
+    rum_enabled: {
+      type: "boolean",
+      description: "Enable Real User Monitoring collection for this site.\n",
+    },
+    rum_sample_rate: {
+      type: "number",
+      format: "float",
+      description: "Fraction of page views that emit a RUM beacon (0 to 1).\n",
+    },
+    min_sample_count: {
+      type: "integer",
+      description:
+        "Suppression floor: any RUM slice with fewer samples than this is\nreported as suppressed rather than shown, so a handful of visits\ncannot masquerade as a trend.\n",
+    },
+    max_distinct_countries: {
+      type: "integer",
+      description:
+        "Cap on the number of distinct countries kept in the per-country RUM\nbreakdown.\n",
     },
   },
 } as const;

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -222,6 +222,22 @@ export type SiteComponent = {
   version?: string;
   active?: boolean;
   /**
+   * PluginURI from the plugin header. Optional; older agents omit it.
+   */
+  plugin_uri?: string;
+  /**
+   * UpdateURI from the plugin header. Optional; older agents omit it.
+   */
+  update_uri?: string;
+  /**
+   * AuthorURI from the plugin header. Optional; older agents omit it.
+   */
+  author_uri?: string;
+  /**
+   * Whether the plugin is network-activated. Optional; older agents omit it.
+   */
+  network?: boolean;
+  /**
    * When set, an update is available for this plugin/theme.
    */
   available_update?: {
@@ -467,6 +483,14 @@ export type AgentMediaSyncBatch = {
     original_width?: number;
     original_height?: number;
     original_size_bytes?: number;
+    /**
+     * 1 (full) plus generated sub-sizes.
+     */
+    variant_count?: number;
+    /**
+     * All-variant savings, re-reported at sync so already-optimized rows heal.
+     */
+    saved_bytes?: number;
   }>;
 };
 
@@ -495,6 +519,10 @@ export type AgentMediaJobStatus = {
   current_size_bytes?: number;
   bytes_before?: number;
   bytes_after?: number;
+  /**
+   * All-variant savings (summed original-minus-optimized over every optimized variant). Drives the dashboard "Bytes saved" rollup.
+   */
+  saved_bytes?: number;
   compression_level?: string;
   target_format?: string;
   rewrite_stats?: {
@@ -610,12 +638,78 @@ export type FontTranscodeResponse = {
   error_detail?: string;
 };
 
+/**
+ * The agent's metadata push. Every field is optional and tolerantly
+ * decoded (booleans and numbers are accepted as strings), so an older
+ * agent that omits any of them still syncs successfully.
+ *
+ */
 export type AgentMetadata = {
   wp_version?: string;
   php_version?: string;
   server_info?: string;
   multisite?: boolean;
   active_theme?: string;
+  /**
+   * The WPMgr agent plugin version.
+   */
+  agent_version?: string;
+  /**
+   * The agent's per-site age PUBLIC recipient ("age1..."), stored so
+   * backups can be triggered without a separate registration call.
+   * Empty or missing leaves the stored recipient unchanged.
+   *
+   */
+  age_recipient?: string;
+  user_count?: number;
+  admin_count?: number;
+  /**
+   * Present only when WordPress core has an update available.
+   */
+  core_update?: {
+    new_version?: string;
+    current_version?: string;
+  };
+  /**
+   * The agent's defined()-based hosting fingerprint.
+   */
+  host_flags?: {
+    is_pressable?: boolean;
+    is_gridpane?: boolean;
+    is_wpengine?: boolean;
+    is_atomic?: boolean;
+    is_kinsta?: boolean;
+    is_flywheel?: boolean;
+    is_runcloud?: boolean;
+    is_cloudways?: boolean;
+  };
+  /**
+   * Sampled disk usage in bytes. The wp-content and uploads walks are
+   * time-capped, so a field may be absent on a very large tree.
+   *
+   */
+  disk?: {
+    wp_content_bytes?: number;
+    uploads_bytes?: number;
+    free_bytes?: number;
+  };
+  /**
+   * The outcome of the agent's last self-update apply, replayed on the
+   * next metadata push. This is the only channel by which a FAILED
+   * apply reaches the control plane: the apply runs inside a cron
+   * request with no response to ride on.
+   *
+   */
+  agent_self_update?: {
+    status?: string;
+    from_version?: string;
+    to_version?: string;
+    detail?: string;
+    /**
+     * Unix timestamp the agent stamped the record with.
+     */
+    at?: number;
+  };
   plugins?: Array<SiteComponent>;
   themes?: Array<SiteComponent>;
 };
@@ -973,9 +1067,17 @@ export type BillingSummary = {
 
 export type BillingCheckoutRequest = {
   /**
-   * The ONLY caller-supplied selector. The server resolves this to a payment-provider price server-side; a request can never name a price directly.
+   * The only caller-supplied PRICE selector. The server resolves this to a payment-provider price server-side; a request can never name a price directly.
    */
   tier: "starter" | "agency" | "scale";
+  /**
+   * Preferred payment provider. Consulted only on a tenant's first-ever checkout: once a tenant is pinned to a provider that pinning always wins, so a returning customer can never split a subscription across two providers. An unknown name is rejected. Omit to use the instance default.
+   */
+  provider?: string;
+  /**
+   * Preferred billing currency, passed to the provider when it creates the checkout. Selects among the prices the server already knows for the requested tier; it can never set an amount. Omit for the provider default.
+   */
+  currency?: string;
 };
 
 export type BillingCheckoutResponse = {
@@ -2732,6 +2834,11 @@ export type PhpErrorSilence = {
 
 export type SiteErrorConfig = {
   /**
+   * Whether PHP-error capture is active for this site.
+   *
+   */
+  enabled?: boolean;
+  /**
    * PHP E_* bitmask the agent applies to wp_debug_log collection.
    * Default 6143 = E_ALL & ~E_STRICT (WordPress default).
    *
@@ -2747,6 +2854,15 @@ export type SiteErrorConfig = {
 };
 
 export type SiteErrorConfigUpdate = {
+  /**
+   * Turns PHP-error capture on or off. OMITTING this field is treated as
+   * true: a client that does not know about the flag can never
+   * accidentally disable the mu-plugin trap, but that also means an
+   * update sent without it re-enables capture on a site where it was
+   * switched off. Send false explicitly to keep capture disabled.
+   *
+   */
+  enabled?: boolean;
   /**
    * PHP E_* bitmask to apply. Must be >0 and fit in int32.
    *
@@ -3447,6 +3563,45 @@ export type PerfConfig = {
    *
    */
   readonly woo_fragments_probed_at?: string;
+  /**
+   * Enable Real User Monitoring collection for this site.
+   *
+   */
+  rum_enabled?: boolean;
+  /**
+   * Fraction of page views that emit a RUM beacon (0 to 1).
+   *
+   */
+  rum_sample_rate?: number;
+  /**
+   * Suppression floor: any RUM slice with fewer samples than this is
+   * reported as suppressed rather than shown, so a handful of visits
+   * cannot masquerade as a trend.
+   *
+   */
+  min_sample_count?: number;
+  /**
+   * Cap on the number of distinct countries kept in the per-country RUM
+   * breakdown.
+   *
+   */
+  max_distinct_countries?: number;
+  /**
+   * Whether a RUM beacon key is provisioned. The plaintext key is never
+   * returned; this boolean is how a client tells whether RUM is fully
+   * provisioned. Ignored on write.
+   *
+   */
+  readonly beacon_key_set?: boolean;
+  /**
+   * Whether the agent's most recent config-ack confirmed it holds the
+   * beacon key. beacon_key_set true with this false means RUM is
+   * provisioned control-plane side but the agent has not confirmed
+   * receipt yet; the control plane retries automatically. Ignored on
+   * write.
+   *
+   */
+  readonly beacon_key_acked_present?: boolean;
   readonly config_version?: number;
   readonly updated_at?: string;
 };
@@ -5112,6 +5267,7 @@ export type AssignSitesResponse = {
  * Controls which data sections are included in a report.
  */
 export type ClientReportSectionFlags = {
+  overview?: boolean;
   uptime?: boolean;
   backups?: boolean;
   updates?: boolean;
@@ -7167,10 +7323,13 @@ export type AgentDbCleanProgress = {
 export type AgentDbOrphanDeleteProgress = {
   job_id: string;
   /**
-   * Agent-defined per-item result rows.
+   * Per-item result rows for the items processed in this batch.
    */
   results?: Array<{
-    [key: string]: unknown;
+    kind?: string;
+    name?: string;
+    status?: string;
+    detail?: string;
   }>;
   deleted_options?: number;
   deleted_cron?: number;
@@ -7383,6 +7542,29 @@ export type PerfConfigWritable = {
    *
    */
   woo_cacheable_session?: boolean;
+  /**
+   * Enable Real User Monitoring collection for this site.
+   *
+   */
+  rum_enabled?: boolean;
+  /**
+   * Fraction of page views that emit a RUM beacon (0 to 1).
+   *
+   */
+  rum_sample_rate?: number;
+  /**
+   * Suppression floor: any RUM slice with fewer samples than this is
+   * reported as suppressed rather than shown, so a handful of visits
+   * cannot masquerade as a trend.
+   *
+   */
+  min_sample_count?: number;
+  /**
+   * Cap on the number of distinct countries kept in the per-country RUM
+   * breakdown.
+   *
+   */
+  max_distinct_countries?: number;
 };
 
 export type Limit = number;

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.100
+  version: 0.61.101
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,
@@ -12588,6 +12588,18 @@ components:
           type: string
         active:
           type: boolean
+        plugin_uri:
+          type: string
+          description: PluginURI from the plugin header. Optional; older agents omit it.
+        update_uri:
+          type: string
+          description: UpdateURI from the plugin header. Optional; older agents omit it.
+        author_uri:
+          type: string
+          description: AuthorURI from the plugin header. Optional; older agents omit it.
+        network:
+          type: boolean
+          description: Whether the plugin is network-activated. Optional; older agents omit it.
         available_update:
           type: object
           nullable: true
@@ -12933,6 +12945,15 @@ components:
               original_width: { type: integer, nullable: true }
               original_height: { type: integer, nullable: true }
               original_size_bytes: { type: integer, format: int64 }
+              variant_count:
+                type: integer
+                description: 1 (full) plus generated sub-sizes.
+              saved_bytes:
+                type: integer
+                format: int64
+                description: >-
+                  All-variant savings, re-reported at sync so already-optimized
+                  rows heal.
     AgentMediaPresign:
       type: object
       description: ADR-043 — request presigned PUT URLs (presign) or signal sources uploaded (encode-ready).
@@ -12964,6 +12985,13 @@ components:
         current_size_bytes: { type: integer, format: int64 }
         bytes_before: { type: integer, format: int64, nullable: true }
         bytes_after: { type: integer, format: int64, nullable: true }
+        saved_bytes:
+          type: integer
+          format: int64
+          nullable: true
+          description: >-
+            All-variant savings (summed original-minus-optimized over every
+            optimized variant). Drives the dashboard "Bytes saved" rollup.
         compression_level: { type: string }
         target_format: { type: string }
         rewrite_stats:
@@ -13076,6 +13104,10 @@ components:
 
     AgentMetadata:
       type: object
+      description: |
+        The agent's metadata push. Every field is optional and tolerantly
+        decoded (booleans and numbers are accepted as strings), so an older
+        agent that omits any of them still syncs successfully.
       properties:
         wp_version:
           type: string
@@ -13091,6 +13123,66 @@ components:
         active_theme:
           type: string
           maxLength: 200
+        agent_version:
+          type: string
+          description: The WPMgr agent plugin version.
+        age_recipient:
+          type: string
+          description: |
+            The agent's per-site age PUBLIC recipient ("age1..."), stored so
+            backups can be triggered without a separate registration call.
+            Empty or missing leaves the stored recipient unchanged.
+        user_count:
+          type: integer
+        admin_count:
+          type: integer
+        core_update:
+          type: object
+          nullable: true
+          description: Present only when WordPress core has an update available.
+          properties:
+            new_version: { type: string }
+            current_version: { type: string }
+        host_flags:
+          type: object
+          nullable: true
+          description: The agent's defined()-based hosting fingerprint.
+          properties:
+            is_pressable: { type: boolean }
+            is_gridpane: { type: boolean }
+            is_wpengine: { type: boolean }
+            is_atomic: { type: boolean }
+            is_kinsta: { type: boolean }
+            is_flywheel: { type: boolean }
+            is_runcloud: { type: boolean }
+            is_cloudways: { type: boolean }
+        disk:
+          type: object
+          nullable: true
+          description: |
+            Sampled disk usage in bytes. The wp-content and uploads walks are
+            time-capped, so a field may be absent on a very large tree.
+          properties:
+            wp_content_bytes: { type: integer, format: int64 }
+            uploads_bytes: { type: integer, format: int64 }
+            free_bytes: { type: integer, format: int64 }
+        agent_self_update:
+          type: object
+          nullable: true
+          description: |
+            The outcome of the agent's last self-update apply, replayed on the
+            next metadata push. This is the only channel by which a FAILED
+            apply reaches the control plane: the apply runs inside a cron
+            request with no response to ride on.
+          properties:
+            status: { type: string }
+            from_version: { type: string }
+            to_version: { type: string }
+            detail: { type: string }
+            at:
+              type: integer
+              format: int64
+              description: Unix timestamp the agent stamped the record with.
         plugins:
           type: array
           items:
@@ -13652,9 +13744,24 @@ components:
           type: string
           enum: [starter, agency, scale]
           description: >-
-            The ONLY caller-supplied selector. The server resolves this to a
-            payment-provider price server-side; a request can never name a
+            The only caller-supplied PRICE selector. The server resolves this to
+            a payment-provider price server-side; a request can never name a
             price directly.
+        provider:
+          type: string
+          description: >-
+            Preferred payment provider. Consulted only on a tenant's first-ever
+            checkout: once a tenant is pinned to a provider that pinning always
+            wins, so a returning customer can never split a subscription across
+            two providers. An unknown name is rejected. Omit to use the
+            instance default.
+        currency:
+          type: string
+          description: >-
+            Preferred billing currency, passed to the provider when it creates
+            the checkout. Selects among the prices the server already knows for
+            the requested tier; it can never set an amount. Omit for the
+            provider default.
     BillingCheckoutResponse:
       type: object
       required: [url]
@@ -15910,6 +16017,10 @@ components:
         - error_level
         - ignore_md5s
       properties:
+        enabled:
+          type: boolean
+          description: |
+            Whether PHP-error capture is active for this site.
         error_level:
           type: integer
           format: int32
@@ -15930,6 +16041,14 @@ components:
         - error_level
         - ignore_md5s
       properties:
+        enabled:
+          type: boolean
+          description: |
+            Turns PHP-error capture on or off. OMITTING this field is treated as
+            true: a client that does not know about the flag can never
+            accidentally disable the mu-plugin trap, but that also means an
+            update sent without it re-enables capture on a site where it was
+            switched off. Send false explicitly to keep capture disabled.
         error_level:
           type: integer
           format: int32
@@ -16748,6 +16867,43 @@ components:
           readOnly: true
           description: |
             RFC3339 timestamp of the last agent probe. Null when never probed.
+        # M56 / RUM: Real User Monitoring.
+        rum_enabled:
+          type: boolean
+          description: |
+            Enable Real User Monitoring collection for this site.
+        rum_sample_rate:
+          type: number
+          format: float
+          description: |
+            Fraction of page views that emit a RUM beacon (0 to 1).
+        min_sample_count:
+          type: integer
+          description: |
+            Suppression floor: any RUM slice with fewer samples than this is
+            reported as suppressed rather than shown, so a handful of visits
+            cannot masquerade as a trend.
+        max_distinct_countries:
+          type: integer
+          description: |
+            Cap on the number of distinct countries kept in the per-country RUM
+            breakdown.
+        beacon_key_set:
+          type: boolean
+          readOnly: true
+          description: |
+            Whether a RUM beacon key is provisioned. The plaintext key is never
+            returned; this boolean is how a client tells whether RUM is fully
+            provisioned. Ignored on write.
+        beacon_key_acked_present:
+          type: boolean
+          readOnly: true
+          description: |
+            Whether the agent's most recent config-ack confirmed it holds the
+            beacon key. beacon_key_set true with this false means RUM is
+            provisioned control-plane side but the agent has not confirmed
+            receipt yet; the control plane retries automatically. Ignored on
+            write.
         config_version: { type: integer, readOnly: true }
         updated_at: { type: string, format: date-time, readOnly: true }
     CacheStats:
@@ -18656,6 +18812,9 @@ components:
       type: object
       description: Controls which data sections are included in a report.
       properties:
+        overview:
+          type: boolean
+          default: true
         uptime:
           type: boolean
           default: true
@@ -21333,9 +21492,14 @@ components:
         job_id: { type: string }
         results:
           type: array
+          description: Per-item result rows for the items processed in this batch.
           items:
             type: object
-          description: Agent-defined per-item result rows.
+            properties:
+              kind: { type: string }
+              name: { type: string }
+              status: { type: string }
+              detail: { type: string }
         deleted_options: { type: integer }
         deleted_cron: { type: integer }
         deleted_tables: { type: integer }


### PR DESCRIPTION
Ships as 0.61.101. Fixes #307, reported by @MrMK0R on a self-hosted install.

## The bug

Selecting log entries on a site's Email > Log tab and clicking Delete showed a **success** toast reading "0 log entries deleted" and deleted nothing.

The spec and generated TypeScript client send `log_ids`. The hand-written Gin handler bound `ids`:

```go
var body struct {
    IDs []string `json:"ids"`   // spec declares log_ids
}
```

The field never bound, the delete ran `id = ANY('{}')`, matched nothing, and honestly returned `{"deleted": 0}` with HTTP 200. Nothing was wrong with the SQL, the RLS, or the frontend. The two halves disagreed about one field name.

**The Resend button beside it was broken identically** and nobody had noticed, because the web handler treats zero failures as success and toasts "0 emails queued". Both also wrote an audit record claiming the action happened.

Reproduced against HEAD with the exact 16-id body the UI sends: `{"deleted":0}`. Fixed tree: `{"deleted":16}`. Resend proven to actually dispatch agent commands, not merely return rows.

The old field name is kept as an accepted alias, so no caller can break.

## Empty list now fails loudly

An absent or empty list returned 200 with `deleted: 0`, which is the *same* user-visible symptom, reachable from any non-TypeScript caller. Now 422 `log_ids_required`, rejected before the service call so no audit row is written.

## The guard was never running

This is the part worth reading.

`apps/api/tests` holds the new request-body contract check **and** `TestOpenAPIRouteCoverage` — the test our own notes describe as the CI gate preventing unspecced endpoints from merging. CI's only `go test` invocation filtered that package out:

```
go test $(go list ./... | grep -v ... -e /apps/api/tests)
```

So neither had ever executed in CI. Compile-checked only. Someone renames a json tag, CI goes green, #307 ships again.

The exclusion is about **cost, not Docker**: 262 of those tests each stand up their own ephemeral Postgres. So rather than un-excluding, both containerless contract gates moved to `apps/api/tests/contract`, which CI now runs in under a second, and the exclusion pattern is anchored (`'/apps/api/tests$'`) so it covers only the container package.

Verified under CI's own command:

```
$ go test $(go list ./... | grep -v ... -e '/apps/api/tests$')
ok  github.com/mosamlife/wpmgr/apps/api/tests/contract  1.647s

# after renaming log_ids:
EXIT=1
  DELETE /api/v1/sites/{siteId}/email/log [BulkDeleteLogsRequest]
    spec declares REQUIRED field "log_ids", handler never binds it
```

## Guard improvements

**Nesting implemented, not the claim downgraded.** The header promised any-depth coverage and delivered top-level only, proven by renaming a nested field and watching it stay green. It now walks both trees in parallel, recursing only where *both* sides still describe the shape. That single rule drops ~150 phantom mismatches and handles `AgentCacheStatsReport.object_cache.*` (a `json.RawMessage` decoded in a second pass) with no allowlist entry. A floor assertion (`nested >= 30`, currently 39) makes silent shrinkage fail loudly.

**Three of eleven allowlist reasons were factually wrong.** Two claimed archive and revoke have "an optional body that is ignored"; both actually read `reason` through a shared helper. Rather than reword the excuse, the extractor learned to follow one level of delegation and **both entries were deleted**, raising real coverage 147 → 149.

Now: **149 request bodies, 646 fields, 39 nested.**

## Scope of the class

A full AST sweep found this is real but small. The ogen server is never mounted, so all **358** live routes are hand-written Gin and `openapi.yaml` is hand-maintained with only the TypeScript client generated from it. Of 149 resolvable bind sites, **136 already matched exactly**, and these two were the only endpoints where a *required* spec field went unbound.

**#308** tracks the stronger fix: bind the already-generated request types (`gen.BulkDeleteLogsRequest` exists, unused, with `LogIds []uuid.UUID`) so this becomes a compile error rather than a test failure. `backup/handler.go:192` already does it.

## Verification

- `go build`, `go vet`, and CI's test selection all clean
- Limits enforced at both layers, boundary-tested: 500 delete → 200, 501 → 422 with zero repo calls; 100 resend → 200, 101 → 422. The legacy alias cannot smuggle past the ceiling.
- Generated artifacts regenerate to a no-op, confirming they are in sync
- No agent change in this release

`apps/api/internal/email/handler.go:67-68` keeps two pre-existing em dashes on route-doc lines edited for an unrelated reason; the sibling lines in that block use the same style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Email Log bulk Delete and Resend actions so selected entries are processed correctly.
  * Prevented misleading success messages and incorrect audit records when no entries are affected.
  * Added clear validation for empty, invalid, or oversized selections.

* **API Improvements**
  * Expanded API documentation with additional configuration, metadata, monitoring, media, billing, and batch-result fields.
  * Improved compatibility with existing bulk-delete requests.

* **Documentation**
  * Updated the release version and changelog to 0.61.101.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->