### PR TITLE
fix(release): agent asset was stamped from the git tag, not its own version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The agent plugin carries its own WPMGR_AGENT_VERSION, which changes only
+      # when the agent changes. release.yml fires on EVERY tag, including the
+      # many that touch only the control plane or the dashboard, so stamping the
+      # release asset with the tag published identical agent code under a
+      # different number each time. The object-storage channel reads the source
+      # version instead, so the two channels drifted apart, and because the
+      # agent's downgrade guard refuses anything not strictly newer, a site that
+      # installed a tag-stamped asset would refuse every later real release.
+      # Passing VERSION here is what caused that, so it must not come back.
+      - name: Agent release asset must not be stamped from the git tag
+        working-directory: .
+        run: |
+          if grep -nE 'make +agent-zip[^\n]*VERSION=' .github/workflows/release.yml; then
+            echo "::error::release.yml passes VERSION to agent-zip. The published asset would carry the git tag instead of WPMGR_AGENT_VERSION, which desynchronises the GitHub and object-storage channels and can permanently strand sites behind the downgrade guard." >&2
+            exit 1
+          fi
+          echo "ok: release.yml lets the agent zip carry its own source version"
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,10 +114,21 @@ jobs:
 
       # make agent-zip builds vendor/ via a composer:2 container, then stages the
       # plugin under a stable wpmgr-agent/ folder (the WP slug) and zips it.
-      # VERSION is passed so the staged copy is stamped with the release tag
-      # (leading 'v' stripped inside agent-zip). The source file is not modified.
+      #
+      # VERSION is deliberately NOT passed. The agent plugin carries its own
+      # WPMGR_AGENT_VERSION, which only changes when the agent itself changes,
+      # while this workflow fires on EVERY release tag including the many that
+      # touch only the control plane or the dashboard. Stamping the staged copy
+      # with the tag therefore published the same agent code under a different
+      # number on every release, so this asset and the object-storage channel
+      # (scripts/release-agent.sh, which reads the source version) disagreed.
+      # That is not cosmetic: the agent's own downgrade guard refuses anything
+      # not strictly newer, so a site that installed a tag-stamped asset would
+      # refuse every later offer carrying the real, lower agent version.
+      # With VERSION unset, agent-zip leaves the staged copy at the source
+      # version and both channels publish the same number for the same code.
       - name: Build agent plugin zip
-        run: make agent-zip VERSION=${{ steps.vars.outputs.version }}
+        run: make agent-zip
 
       - name: Publish GitHub Release with the agent zip
         uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.102] - 2026-07-29
+
+### Fixed
+
+- The WPMgr agent plugin is published through two channels: as an asset attached to each GitHub release, and to object storage for control-plane-driven updates. The two were labelling the same code with different version numbers. The agent plugin carries its own version, which only changes when the agent itself changes, but the GitHub release workflow runs on every release tag, including the many that only touch the control plane or the dashboard, and it was stamping the agent asset with the release tag instead of leaving the agent's own version in place. Identical agent code was published as several different version numbers; at the time of this fix the agent's own version was 0.61.98 while the newest GitHub asset was labelled 0.61.101.
+- The agent refuses to install anything that is not strictly newer than what it already runs, which is correct and protects against downgrades. A site that installed a tag-labelled asset would then refuse later genuine releases carrying the agent's own, lower number, so anyone who installed the agent from a GitHub release asset could end up unable to take further updates from the object-storage channel.
+- The GitHub release asset now carries the agent's own version, the same number the object-storage channel publishes, so both channels describe the same code identically. The agent version moves from 0.61.98 to 0.61.102, deliberately, to clear the numbers published by mistake, so any site that installed one of those assets can update normally again; no manual intervention is needed, the next update offer will simply work. A check now runs on every change that fails if the release workflow ever goes back to stamping the asset with the release tag.
+
 ## [0.61.101] - 2026-07-29
 
 ### Fixed

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.98
+ * Version:           0.61.102
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.98');
+define('WPMGR_AGENT_VERSION', '0.61.102');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,17 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.102",
+    date: "2026-07-29",
+    summary: "Agent updates from GitHub release assets now agree with the built-in update channel on version numbers.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "The agent plugin attached to each GitHub release and the one published to the built-in update channel could carry different version numbers, since the release workflow stamped the asset with the release tag instead of the agent's own version. Both channels now publish the same version. The agent version moves to 0.61.102, deliberately, to clear the numbers published by mistake; no action is needed on affected sites, and the next update offer will simply work.",
+      },
+    ],
+  },
+  {
     version: "0.61.101",
     date: "2026-07-29",
     summary: "Deleting or resending selected entries on a site's Email Log actually works now.",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.101 / open source",
+  badge: "v0.61.102 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.101
+  version: 0.61.102
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Ships as 0.61.102. Groundwork for #302, and a live bug in its own right.

## The bug

The agent plugin ships through two channels, and they were labelling the same code with different numbers:

| channel | stamped from | was |
|---|---|---|
| GitHub release asset | **the git tag** (`release.yml:120`) | 0.61.101 |
| Object storage | **the agent's own version** | 0.61.98 |

`release.yml` fires on **every** tag, including the many that touch only the control plane or the dashboard. The agent only changes in *some* releases. So identical agent code went out under several different numbers — three versions of drift at the time of this fix.

## Why it matters

The agent refuses to install anything not strictly newer than what it runs. That guard is correct and protects against downgrades.

But a site that installed a **tag-stamped asset** is on 0.61.101, and would refuse every later genuine release carrying the real, lower agent version. **Anyone who took the obvious path and grabbed the agent from a GitHub release was already unable to receive further updates from the object-storage channel.** Not a future risk; already true.

Verified live before fixing:

```
agent source ............ 0.61.98
object storage .......... 0.61.98
GitHub asset v0.61.101 .. 0.61.101   ← installed sites stuck here
```

## The fix

`agent-zip` only restamps when `VERSION` is non-empty, so **dropping the argument is the whole fix**. The asset now carries the source version and both channels publish the same number for the same code.

**0.61.98 → 0.61.102**, skipping the intermediate numbers deliberately: it has to clear **0.61.101**, the highest number published by mistake, or sites already on it stay stuck behind their own guard. Affected sites need no manual intervention; the next offer is simply newer and installs.

## Guard

A step in the existing agent CI job fails if `release.yml` ever passes `VERSION` to `agent-zip` again. Verified both directions:

```
reintroduced the line  →  GUARD FIRES (exit 1)
on the fix             →  clean
```

## Deliberately not included

Giving the agent an **independent version line starting at 1.0.0**. It was proposed to make a collision between the two numberspaces structurally impossible, but that collision only exists while the stamping bug exists, and this removes it.

How a public artifact is versioned deserves its own decision rather than riding along with a bug fix, and a jump to 1.0.0 would signal a major release when nothing major happened. Raised separately if we want it.

## Verification

- agent phpunit: **2904** tests, phpcs 0 errors
- No API, web, or control-plane change

Note for reviewers: `apps/agent/vendor/` gets stripped to production-only by `make agent-release`, which removes phpunit and phpcs entirely. A test run straight after a release publish passes because nothing executes. Restore with `composer install` in `apps/agent` before trusting a green run.

## Relation to #302

#302 wants a self-hosted control plane to mirror our published release into its own storage. That only works if the two channels agree on what version a given build is, so this lands first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed version mismatches between the WPMgr Agent distributed through GitHub releases and the built-in update channel.
  - Prevented installations from GitHub assets from being blocked from receiving future updates.

- **New Release**
  - Released WPMgr Agent version 0.61.102.
  - Updated displayed product, API, and marketing version information to 0.61.102.

- **Documentation**
  - Added release notes describing the versioning fix and confirming that no action is required beyond the next update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->