### PR TITLE
fix(agent,api): signed-command claims leaked into the request body, and the CP ignored agent refusals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.104] - 2026-07-30
+
+### Fixed
+
+- Starting a fleet agent update failed immediately with "the agent could not arm its self-update: This command takes no parameters", and the rollout halted after its first site. WordPress stores the values that come with a request in separate groups depending on where they came from, and when a value is added that it has not seen before, it puts it in the first of those groups; for a request sent as JSON, that first group is the request body itself. The agent adds the verified details of a signed command to the request after checking it, so those details landed inside what the agent then read back as the body, and a command that expects an empty body saw something in it and refused. This was never visible in manual testing, because a request sent without the JSON content type does not hit this behavior, and only a caller that sets it is affected. The agent no longer mixes its own verified command details into the request body, and the two commands that expect an empty body now ignore anything that arrives rather than refusing.
+- A second command, Refresh inventory on a site, had been failing this way since it shipped and had never actually worked. It returned a success response while doing nothing, and the control plane recorded it as successful because it only checked that the request itself had been delivered, not what the agent said in reply. Refreshing a site's inventory now works, and the control plane reads the agent's answer.
+- Investigating the above turned up a wider gap: the control plane checked only whether a command reached a site, not whether the agent accepted it. A rollback the agent refused was recorded as "rolled back", telling an operator that a site had been restored when it had not; an update dry run was always recorded as successful; and media optimization, restore, and delete-originals jobs would wait forever for a result that was never coming, because a refused command sends no follow-up. All of these now treat a refusal as a failure and keep the agent's own explanation, and where a refusal is genuinely acceptable, that is now stated in the code so the difference is clear. Anyone reviewing past update history should be aware that a task recorded as rolled back may not actually have been, for the reason above.
+
 ## [0.61.103] - 2026-07-30
 
 ### Added

--- a/apps/agent/includes/class-router.php
+++ b/apps/agent/includes/class-router.php
@@ -179,6 +179,21 @@ final class Router
             $params = [];
         }
 
+        // Strip the internal claims stash before any command sees the body.
+        //
+        // WP_REST_Request::set_param() does NOT write to a flat array. For a key
+        // WordPress has not already seen it writes into the FIRST bucket of
+        // get_parameter_order(), and on a request whose Content-Type is
+        // application/json that first bucket is 'JSON' itself. authorizeCommand()
+        // above stashes the verified claims with set_param(), so on every real
+        // control-plane call (POST, Content-Type: application/json) the claims
+        // land INSIDE the JSON bucket and come straight back out of
+        // get_json_params(). Commands would then receive a wpmgr_claims key the
+        // control plane never sent, which is exactly what made a `{}` body look
+        // like a non-empty one. Commands must only ever see what was actually
+        // transmitted.
+        unset($params[self::ATTR_CLAIMS]);
+
         return $this->dispatch($name, $claims, $params);
     }
 

--- a/apps/agent/includes/commands/class-agent-self-update-command.php
+++ b/apps/agent/includes/commands/class-agent-self-update-command.php
@@ -107,17 +107,20 @@ final class AgentSelfUpdateCommand implements CommandInterface
      * @param array<string,mixed> $claims Validated JWT claims (unused; the
      *                                    Router already enforced the aud + cmd
      *                                    binding).
-     * @param array<string,mixed> $params Request parameters; MUST be empty.
+     * @param array<string,mixed> $params Request parameters. This command takes
+     *                                    none, and IGNORES anything that arrives.
      * @return array<string,mixed> See the wire contract in the file header.
      */
     public function execute(array $claims, array $params): array
     {
-        // Body shape: refuse anything beyond an empty object, matching
-        // RefreshInventoryCommand. Future options go behind explicit named
-        // params, not "accept whatever arrives".
-        if ($params !== []) {
-            return $this->answer('error', 'This command takes no parameters.');
-        }
+        // Body shape: this command takes no parameters, so whatever arrives is
+        // ignored rather than rejected. Rejecting an unexpected body buys
+        // nothing here (there is no parameter to misread) and turns a harmless
+        // wire difference into a failed rollout beat, which is not a trade any
+        // fleet-wide command should make. The intent still stands: future
+        // options go behind explicit named params read by key, never "accept
+        // whatever arrives and act on it".
+        unset($params);
 
         // Rule (a): the wp.org distribution build never self-updates.
         if (defined('WPMGR_WPORG_BUILD') && constant('WPMGR_WPORG_BUILD')) {

--- a/apps/agent/includes/commands/class-refresh-inventory-command.php
+++ b/apps/agent/includes/commands/class-refresh-inventory-command.php
@@ -10,8 +10,8 @@
  * The Router's permission_callback already enforces the signed-JWT contract
  * (Ed25519 signature, aud=siteId, cmd="refresh_inventory", jti anti-replay)
  * via Connector::verifyCommand. By the time execute() runs the request is
- * authenticated; the command itself just (1) refuses anything other than an
- * empty body, (2) forces WP to re-poll its plugin/theme/core update endpoints
+ * authenticated; the command itself just (1) ignores the request body (it takes
+ * no parameters), (2) forces WP to re-poll its plugin/theme/core update endpoints
  * (bypassing Scheduler's 5-minute lock — this is human-initiated), (3) pushes
  * the resulting inventory to the control plane.
  *
@@ -69,17 +69,19 @@ final class RefreshInventoryCommand implements CommandInterface
      *
      * @param array<string,mixed> $claims Validated JWT claims (unused — Router
      *                                    already enforced aud + cmd binding).
-     * @param array<string,mixed> $params Request parameters; MUST be empty.
+     * @param array<string,mixed> $params Request parameters. This command takes
+     *                                    none, and IGNORES anything that arrives.
      * @return array{ok:bool,detail:string}
      */
     public function execute(array $claims, array $params): array
     {
-        // Body shape: refuse anything beyond an empty object. This keeps the
-        // command surface unambiguous; future extensions go behind explicit
-        // named params, not "we'll silently accept whatever".
-        if ($params !== []) {
-            return ['ok' => false, 'detail' => 'body must be an empty object'];
-        }
+        // Body shape: this command takes no parameters, so whatever arrives is
+        // ignored rather than rejected. Refusing an unexpected body only turned
+        // an inventory refresh into a silent no-op, because the caller reads the
+        // transport status and not the ok flag. The intent still stands: future
+        // extensions go behind explicit named params read by key, not "we'll
+        // silently accept whatever and act on it".
+        unset($params);
 
         // Force a fresh poll of update_plugins / update_themes / update_core.
         // bypass=true (human-initiated): a CP-issued refresh should not be

--- a/apps/agent/tests/AgentSelfUpdateTest.php
+++ b/apps/agent/tests/AgentSelfUpdateTest.php
@@ -510,13 +510,26 @@ final class AgentSelfUpdateTest extends TestCase
         $this->assertSame('', $result['to_version']);
     }
 
-    public function test_command_rejects_unexpected_parameters(): void
+    /**
+     * This command takes no parameters, so an unexpected one is IGNORED and
+     * cannot change the answer. It certainly cannot be read as a target
+     * version: the version is whatever the signed manifest says, and a body key
+     * is not a signed input. Rejecting the body instead is what halted a
+     * production rollout wave, so the tolerance is the contract now.
+     */
+    public function test_command_ignores_unexpected_parameters(): void
     {
+        $claims = $this->makeClaims(['version' => $this->targetVersion]);
+        $this->stubManifestEndpoint(200, (string) json_encode($this->signClaims($claims)));
+
         $result = (new AgentSelfUpdateCommand($this->makeChecker()))->execute([], ['version' => '9.9.9']);
 
-        $this->assertSame('error', $result['status']);
-        $this->assertFalse($result['ok']);
-        $this->assertSame([], $this->scheduledEvents);
+        $this->assertSame('scheduled', $result['status']);
+        $this->assertSame(
+            $this->targetVersion,
+            $result['to_version'],
+            'the target version comes from the signed manifest, never from the request body'
+        );
     }
 
     // =========================================================================

--- a/apps/agent/tests/AgentSelfUpdateWireContractTest.php
+++ b/apps/agent/tests/AgentSelfUpdateWireContractTest.php
@@ -229,24 +229,29 @@ final class AgentSelfUpdateWireContractTest extends TestCase
     // -------------------------------------------------------------------------
 
     /**
-     * The command shell's two locally generated answers, exercised for real.
-     * These are the paths that do not need the self-updater, so they run
-     * without a WordPress fixture: a body that carries parameters is an
-     * "error", and a null self-updater is "not_eligible".
+     * The command shell's locally generated answer, exercised for real. This is
+     * the path that does not need the self-updater, so it runs without a
+     * WordPress fixture: a null self-updater is "not_eligible".
+     *
+     * The body is irrelevant to that answer. This command takes no parameters,
+     * so an unexpected one is IGNORED rather than turned into an "error", and
+     * both bodies must produce the identical golden envelope. Rejecting a body
+     * once halted a production rollout wave over a difference the command had
+     * no reason to care about.
      */
     public function test_command_local_paths_answer_only_golden_values(): void
     {
         $command = new AgentSelfUpdateCommand(null);
 
-        $rejected = $command->execute([], ['unexpected' => 1]);
-        $this->assertSame('error', $rejected['status']);
-        $this->assertFalse($rejected['ok'], 'only "error" answers ok=false');
+        $withBody = $command->execute([], ['unexpected' => 1]);
+        $this->assertSame('not_eligible', $withBody['status'], 'an unexpected body is ignored, never an error');
 
         $ineligible = $command->execute([], []);
         $this->assertSame('not_eligible', $ineligible['status']);
         $this->assertTrue($ineligible['ok'], '"not_eligible" is informational, never a failure');
+        $this->assertSame($ineligible, $withBody, 'the body must not change the answer');
 
-        foreach ([$rejected, $ineligible] as $answer) {
+        foreach ([$withBody, $ineligible] as $answer) {
             $this->assertSame(self::RESPONSE_KEYS, array_keys($answer));
             $this->assertContains($answer['status'], self::GOLDEN_STATUSES);
             $this->assertContains($answer['cron_mode'], self::GOLDEN_CRON_MODES);

--- a/apps/agent/tests/RefreshInventoryCommandTest.php
+++ b/apps/agent/tests/RefreshInventoryCommandTest.php
@@ -48,7 +48,16 @@ final class RefreshInventoryCommandTest extends TestCase
         $this->assertSame('refresh_inventory', $cmd->name());
     }
 
-    public function test_refuses_non_empty_body(): void
+    /**
+     * This command takes no parameters, so an unexpected body is IGNORED, not
+     * rejected. Refusing it only produced a silent no-op: the caller checks the
+     * transport status rather than the ok flag, so a refused refresh looked
+     * exactly like a successful one while refreshing nothing.
+     *
+     * RouterCommandBodyTest covers the wire-level half (what a `{}` body from
+     * the control plane actually becomes by the time it reaches execute()).
+     */
+    public function test_ignores_an_unexpected_body_and_still_does_the_work(): void
     {
         $refreshCalls = 0;
         $pushCalls    = 0;
@@ -64,11 +73,9 @@ final class RefreshInventoryCommandTest extends TestCase
 
         $res = $cmd->execute([], ['unexpected' => true]);
 
-        $this->assertFalse($res['ok']);
-        $this->assertStringContainsString('empty object', $res['detail']);
-        // Body validation runs BEFORE either dependency is touched.
-        $this->assertSame(0, $refreshCalls);
-        $this->assertSame(0, $pushCalls);
+        $this->assertTrue($res['ok']);
+        $this->assertSame(1, $refreshCalls);
+        $this->assertSame(1, $pushCalls);
     }
 
     public function test_success_refreshes_transients_then_pushes_metadata(): void

--- a/apps/agent/tests/RouterCommandBodyTest.php
+++ b/apps/agent/tests/RouterCommandBodyTest.php
@@ -1,0 +1,426 @@
+<?php
+/**
+ * RouterCommandBodyTest: end-to-end coverage of the REQUEST BODY as it travels
+ * from the wire to a command's execute($claims, $params).
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * A production self-update rollout failed on its first wave with
+ * "This command takes no parameters." even though the control plane sent a
+ * literal `{}` body. Both halves were tested and both halves looked right:
+ *
+ *   - command tests called execute([], []) directly, proving only that the
+ *     guard accepts a literal PHP [],
+ *   - RouterTest built a request object by hand and never exercised a JSON
+ *     body at all.
+ *
+ * Neither half tested the JOIN, and the defect lived exactly there.
+ * WP_REST_Request::set_param() writes an unseen key into the FIRST bucket of
+ * get_parameter_order(), which on a JSON request is the JSON bucket itself, so
+ * the claims the Router stashes in its permission_callback came back out of
+ * get_json_params() and made an empty body look non-empty.
+ *
+ * So these tests deliberately take the WHOLE path, with nothing simulated:
+ * a real Ed25519 keypair, a real signed command JWT, a real Connector, a real
+ * Router, a request built the way the REST server builds one (POST, route,
+ * URL param, Content-Type: application/json, Bearer token, body), then
+ * authorizeCommand() followed by handleCommand(). What a command receives is
+ * asserted at the command boundary itself.
+ *
+ * Keep the parameterised body test general. It is worth more than a bespoke
+ * test per command, because the bug was never about one command.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use ReflectionProperty;
+use WPMgr\Agent\Commands\AgentSelfUpdateCommand;
+use WPMgr\Agent\Commands\CommandInterface;
+use WPMgr\Agent\Commands\RefreshInventoryCommand;
+use WPMgr\Agent\Connector;
+use WPMgr\Agent\Keystore;
+use WPMgr\Agent\Router;
+use WPMgr\Agent\Settings;
+use WPMgr\Agent\Support\AuthHeaderShield;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Router
+ * @covers \WPMgr\Agent\Commands\AgentSelfUpdateCommand
+ * @covers \WPMgr\Agent\Commands\RefreshInventoryCommand
+ */
+final class RouterCommandBodyTest extends TestCase
+{
+    /** Route registered by Router::registerRoutes(), with the segment filled in. */
+    private const ROUTE_BASE = '/wpmgr/v1/command/';
+
+    private string $keyFile;
+
+    /** @var array<string,mixed> In-memory wp-options. */
+    private array $options = [];
+
+    /** Control-plane Ed25519 secret key (the signer the CP holds). */
+    private string $cpSecret;
+
+    private string $siteId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+    /** @var array<string,ParamRecorderCommand> Probes by command name. */
+    private array $probes = [];
+
+    private Connector $connector;
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->keyFile = sys_get_temp_dir() . '/wpmgr-agent-routerbody-' . bin2hex(random_bytes(8)) . '.key';
+        if (!defined('WPMGR_AGENT_KEY_FILE')) {
+            define('WPMGR_AGENT_KEY_FILE', $this->keyFile);
+        }
+
+        $this->options = [];
+        Functions\when('update_option')->alias(function ($name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('get_option')->alias(function ($name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+
+        // Router's defense-in-depth capability check.
+        Functions\when('is_user_logged_in')->justReturn(false);
+        Functions\when('current_user_can')->justReturn(true);
+        Functions\when('register_rest_route')->justReturn(true);
+
+        // Real control-plane keypair; the agent only ever holds the public half.
+        $keypair        = sodium_crypto_sign_keypair();
+        $this->cpSecret = sodium_crypto_sign_secretkey($keypair);
+
+        $keystore = new Keystore();
+        $keystore->storeControlPlanePublicKey(sodium_crypto_sign_publickey($keypair));
+
+        $this->options[Settings::OPTION_SITE_ID] = $this->siteId;
+
+        $this->connector = new Connector($keystore, new Settings());
+
+        // jti anti-replay store.
+        $GLOBALS['wpdb'] = new FakeWpdb();
+
+        // A stale stash would short-circuit Router::bearerToken() and make the
+        // signed token under test irrelevant.
+        $this->resetShieldStash();
+    }
+
+    protected function tear_down(): void
+    {
+        $this->resetShieldStash();
+        if (is_file($this->keyFile)) {
+            @unlink($this->keyFile);
+        }
+        unset($GLOBALS['wpdb']);
+        $this->probes = [];
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // -------------------------------------------------------------------------
+    // The general rule: a command receives EXACTLY what the control plane sent.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Every command the control plane invokes with a literal `{}` body must see
+     * an EMPTY array at its execute() boundary. Not "an array containing only
+     * internal keys", empty.
+     *
+     * This is the test that would have caught the production failure, and it is
+     * parameterised rather than per-command because the defect was in the
+     * shared router path, not in any one handler.
+     *
+     * @dataProvider provideEmptyBodyCommands
+     */
+    public function test_empty_json_body_reaches_command_as_empty_array(string $command): void
+    {
+        $router   = $this->routerWithProbes([$command]);
+        $response = $this->dispatchSigned($router, $command, '{}');
+
+        $this->assertInstanceOf(\WP_REST_Response::class, $response);
+        $this->assertSame(
+            [],
+            $this->probes[$command]->received,
+            $command . ' received something the control plane never sent'
+        );
+    }
+
+    /**
+     * The control-plane commands whose Go request struct is empty, so the
+     * marshalled body on the wire is exactly `{}`.
+     *
+     * @return array<string,array{0:string}>
+     */
+    public static function provideEmptyBodyCommands(): array
+    {
+        return [
+            'agent_self_update' => ['agent_self_update'],
+            'refresh_inventory' => ['refresh_inventory'],
+            'ping'              => ['ping'],
+            'metadata'          => ['metadata'],
+        ];
+    }
+
+    /**
+     * The same rule for a command that DOES take parameters: it gets its own
+     * keys and nothing else. Internal router state must never appear alongside
+     * them, or a command could act on a key the caller never sent.
+     */
+    public function test_populated_json_body_reaches_command_without_internal_keys(): void
+    {
+        $router   = $this->routerWithProbes(['cache_enable']);
+        $response = $this->dispatchSigned($router, 'cache_enable', '{"enabled":true,"config_version":7}');
+
+        $this->assertInstanceOf(\WP_REST_Response::class, $response);
+        $this->assertSame(
+            ['enabled' => true, 'config_version' => 7],
+            $this->probes['cache_enable']->received
+        );
+    }
+
+    /**
+     * A body-less POST that still declares a JSON Content-Type is the same
+     * hazard: WordPress leaves the JSON bucket null, and set_param() then
+     * creates it. The command boundary must still see an empty array.
+     */
+    public function test_absent_body_with_json_content_type_reaches_command_as_empty_array(): void
+    {
+        $router   = $this->routerWithProbes(['ping']);
+        $response = $this->dispatchSigned($router, 'ping', '');
+
+        $this->assertInstanceOf(\WP_REST_Response::class, $response);
+        $this->assertSame([], $this->probes['ping']->received);
+    }
+
+    /**
+     * Pins the WordPress behaviour this whole file exists for, so the request
+     * double can never be "simplified" back into a flat array without a red
+     * test. After the permission_callback has stashed its claims, the request's
+     * OWN json params really do contain the internal key. It is the Router that
+     * must keep that out of a command, and this asserts both halves.
+     */
+    public function test_router_strips_the_claims_stash_that_wordpress_folds_into_json_params(): void
+    {
+        $router  = $this->routerWithProbes(['ping']);
+        $request = $this->signedRequest('ping', '{}');
+
+        $this->assertTrue($router->authorizeCommand($request, 'ping'));
+
+        // WordPress itself now reports the stash as part of the JSON body.
+        $rawJson = $request->get_json_params();
+        $this->assertIsArray($rawJson);
+        $this->assertArrayHasKey('wpmgr_claims', $rawJson);
+
+        // The Router must not pass that on.
+        $router->handleCommand($request);
+        $this->assertSame([], $this->probes['ping']->received);
+    }
+
+    // -------------------------------------------------------------------------
+    // The production regressions themselves, through the real handlers.
+    // -------------------------------------------------------------------------
+
+    /**
+     * The exact production call: wave 0 of a self-update rollout. Before the
+     * fix this returned status "error" with detail
+     * "This command takes no parameters." and halted the wave.
+     */
+    public function test_agent_self_update_does_not_reject_the_control_plane_body(): void
+    {
+        $router = new Router($this->connector, [new AgentSelfUpdateCommand(null)]);
+
+        $response = $this->dispatchSigned($router, 'agent_self_update', '{}');
+
+        $this->assertInstanceOf(\WP_REST_Response::class, $response);
+        $this->assertIsArray($response->data);
+        $this->assertNotSame(
+            'error',
+            $response->data['status'] ?? null,
+            'agent_self_update rejected the body the control plane actually sends'
+        );
+        $this->assertStringNotContainsStringIgnoringCase(
+            'takes no parameters',
+            (string) ($response->data['detail'] ?? '')
+        );
+    }
+
+    /**
+     * The sibling defect. This one never failed loudly: the caller checks the
+     * transport status and not the ok flag, so refresh_inventory answered
+     * HTTP 200 with ok=false and silently refreshed nothing. Assert the work
+     * actually happens, not merely that the response looks acceptable.
+     */
+    public function test_refresh_inventory_actually_runs_through_the_router(): void
+    {
+        $refreshed = false;
+        $pushed    = false;
+
+        $command = new RefreshInventoryCommand(
+            static function () use (&$refreshed): void {
+                $refreshed = true;
+            },
+            static function () use (&$pushed): array {
+                $pushed = true;
+                return ['ok' => true];
+            }
+        );
+
+        $router   = new Router($this->connector, [$command]);
+        $response = $this->dispatchSigned($router, 'refresh_inventory', '{}');
+
+        $this->assertInstanceOf(\WP_REST_Response::class, $response);
+        $this->assertTrue($refreshed, 'inventory was never re-polled');
+        $this->assertTrue($pushed, 'inventory was never pushed to the control plane');
+        $this->assertTrue($response->data['ok'] ?? false);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build a Router whose handlers are recording probes, one per name.
+     *
+     * @param array<int,string> $names Command names to register.
+     * @return Router
+     */
+    private function routerWithProbes(array $names): Router
+    {
+        $handlers = [];
+        foreach ($names as $name) {
+            $probe                = new ParamRecorderCommand($name);
+            $this->probes[$name]  = $probe;
+            $handlers[]           = $probe;
+        }
+
+        return new Router($this->connector, $handlers);
+    }
+
+    /**
+     * Run the full authorize + handle path for a signed request.
+     *
+     * @param Router $router  Router under test.
+     * @param string $command Command name.
+     * @param string $body    Raw request body.
+     * @return \WP_REST_Response|\WP_Error
+     */
+    private function dispatchSigned(Router $router, string $command, string $body)
+    {
+        $request = $this->signedRequest($command, $body);
+
+        $authorized = $router->authorizeCommand($request, $command);
+        $this->assertTrue($authorized, 'the signed request was not authorized');
+
+        return $router->handleCommand($request);
+    }
+
+    /**
+     * Build the request the way the REST server builds one for
+     * POST /wp-json/wpmgr/v1/command/{command}: the {command} segment arrives
+     * as a URL param, the control plane sets Content-Type: application/json and
+     * an Ed25519 Bearer token, and the body is whatever it marshalled.
+     *
+     * @param string $command Command name (also the JWT cmd claim).
+     * @param string $body    Raw request body.
+     * @return \WP_REST_Request
+     */
+    private function signedRequest(string $command, string $body): \WP_REST_Request
+    {
+        $request = new \WP_REST_Request('POST', self::ROUTE_BASE . $command);
+        $request->set_url_params(['command' => $command]);
+        $request->set_header('Content-Type', 'application/json');
+        $request->set_header('Accept', 'application/json');
+        $request->set_header('Authorization', 'Bearer ' . $this->mintCommandToken($command));
+        $request->set_body($body);
+
+        return $request;
+    }
+
+    /**
+     * Mint the compact Ed25519 JWT the control plane sends: bound to this site
+     * (aud), to this command (cmd), single-use (jti), short-lived (exp).
+     *
+     * @param string $command Command name.
+     * @return string
+     */
+    private function mintCommandToken(string $command): string
+    {
+        $segments = [
+            $this->b64((string) json_encode(['alg' => 'EdDSA', 'typ' => 'JWT'])),
+            $this->b64((string) json_encode([
+                'aud' => $this->siteId,
+                'cmd' => $command,
+                'jti' => bin2hex(random_bytes(8)),
+                'exp' => time() + 30,
+            ])),
+        ];
+
+        $segments[] = $this->b64(sodium_crypto_sign_detached(implode('.', $segments), $this->cpSecret));
+
+        return implode('.', $segments);
+    }
+
+    private function b64(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    /**
+     * Clear the include-time bearer stash so each test starts from a request
+     * that carries its own Authorization header.
+     */
+    private function resetShieldStash(): void
+    {
+        $prop = new ReflectionProperty(AuthHeaderShield::class, 'stashedBearer');
+        $prop->setValue(null, null);
+    }
+}
+
+/**
+ * Command double that records exactly what reached its execute() boundary.
+ *
+ * Deliberately not an anonymous class: the parameterised test needs to reach
+ * the recorded params from the test body, and a named type keeps that readable.
+ */
+final class ParamRecorderCommand implements CommandInterface
+{
+    /** @var array<string,mixed>|null What execute() was handed, verbatim. */
+    public ?array $received = null;
+
+    private string $commandName;
+
+    public function __construct(string $commandName)
+    {
+        $this->commandName = $commandName;
+    }
+
+    public function name(): string
+    {
+        return $this->commandName;
+    }
+
+    /**
+     * @param array<string,mixed> $claims Validated claims.
+     * @param array<string,mixed> $params Request params as delivered.
+     * @return array<string,mixed>
+     */
+    public function execute(array $claims, array $params): array
+    {
+        $this->received = $params;
+
+        return ['ok' => true];
+    }
+}

--- a/apps/agent/tests/bootstrap.php
+++ b/apps/agent/tests/bootstrap.php
@@ -161,30 +161,92 @@ if (!class_exists('WP_Error')) {
 }
 
 if (!class_exists('WP_REST_Request')) {
+    /**
+     * Faithful double for WP core's WP_REST_Request.
+     *
+     * The parameter model is NOT a flat array in WordPress. Core keeps one
+     * bucket per source (URL / GET / POST / FILES / JSON / defaults) and
+     * resolves reads and writes through get_parameter_order(), whose FIRST
+     * entry is 'JSON' whenever the request carries a JSON Content-Type. That
+     * detail is load bearing: set_param() with a key core has never seen
+     * writes into order[0], so on a JSON request an internally-stashed param
+     * lands inside the JSON bucket and comes straight back out of
+     * get_json_params(). A flat-array double hides that entirely, which is
+     * how a body the control plane genuinely sends reached production
+     * untested. Mirror core here rather than simplifying.
+     *
+     * Legacy convenience kept for the existing suite: passing an array as the
+     * first constructor argument seeds the URL bucket directly, which is what
+     * the previous flat double did.
+     */
     class WP_REST_Request
     {
-        /** @var array<string,mixed> */
-        private array $params = [];
+        /** @var array<string,mixed> One bucket per parameter source, as in core. */
+        private array $params = [
+            'URL'      => [],
+            'GET'      => [],
+            'POST'     => [],
+            'FILES'    => [],
+            // Stays null until parse_json_params() runs, exactly as in core.
+            'JSON'     => null,
+            'defaults' => [],
+        ];
 
         /** @var array<string,string> */
         private array $headers = [];
 
+        private string $method = '';
+
+        private string $route = '';
+
+        private string $body = '';
+
+        private bool $parsed_json = false;
+
         /**
-         * @param array<string,mixed> $params Initial params.
+         * @param array<string,mixed>|string $method Request method, or a legacy
+         *                                           array of URL params.
+         * @param string                     $route  Request route.
          */
-        public function __construct(array $params = [])
+        public function __construct($method = '', string $route = '')
         {
-            $this->params = $params;
+            if (is_array($method)) {
+                $this->params['URL'] = $method;
+            } else {
+                $this->method = strtoupper($method);
+            }
+            $this->route = $route;
         }
 
-        public function get_param(string $key): mixed
+        public function get_method(): string
         {
-            return $this->params[$key] ?? null;
+            return $this->method;
         }
 
-        public function set_param(string $key, mixed $value): void
+        public function set_method(string $method): void
         {
-            $this->params[$key] = $value;
+            $this->method = strtoupper($method);
+        }
+
+        public function get_route(): string
+        {
+            return $this->route;
+        }
+
+        public function set_route(string $route): void
+        {
+            $this->route = $route;
+        }
+
+        public function get_body(): string
+        {
+            return $this->body;
+        }
+
+        public function set_body(string $body): void
+        {
+            $this->body        = $body;
+            $this->parsed_json = false;
         }
 
         public function get_header(string $key): string
@@ -198,11 +260,143 @@ if (!class_exists('WP_REST_Request')) {
         }
 
         /**
+         * @return array<string,string>|null
+         */
+        public function get_content_type(): ?array
+        {
+            $value = $this->get_header('Content-Type');
+            if ($value === '') {
+                return null;
+            }
+
+            $parameters = '';
+            if (strpos($value, ';') !== false) {
+                [$value, $parameters] = explode(';', $value, 2);
+            }
+
+            $value = strtolower($value);
+            if (strpos($value, '/') === false) {
+                return null;
+            }
+
+            [$type, $subtype] = explode('/', $value, 2);
+
+            return array_map('trim', compact('value', 'type', 'subtype', 'parameters'));
+        }
+
+        public function is_json_content_type(): bool
+        {
+            $contentType = $this->get_content_type();
+
+            return isset($contentType['value'])
+                && preg_match('#^application/([a-z0-9\.\+\-]+\+)?json(\+oembed)?$#', $contentType['value']) === 1;
+        }
+
+        /**
          * @return array<string,mixed>
          */
-        public function get_json_params(): array
+        public function get_url_params(): array
         {
-            return [];
+            $urlParams = $this->params['URL'];
+
+            return is_array($urlParams) ? $urlParams : [];
+        }
+
+        /**
+         * @param array<string,mixed> $params URL params.
+         */
+        public function set_url_params(array $params): void
+        {
+            $this->params['URL'] = $params;
+        }
+
+        public function get_param(string $key): mixed
+        {
+            foreach ($this->get_parameter_order() as $type) {
+                if (isset($this->params[$type][$key])) {
+                    return $this->params[$type][$key];
+                }
+            }
+
+            return null;
+        }
+
+        /**
+         * Mirrors core: update every bucket that already holds the key,
+         * otherwise create it in the FIRST bucket of the parameter order.
+         */
+        public function set_param(string $key, mixed $value): void
+        {
+            $order    = $this->get_parameter_order();
+            $foundKey = false;
+
+            foreach ($order as $type) {
+                if ($type !== 'defaults' && is_array($this->params[$type]) && array_key_exists($key, $this->params[$type])) {
+                    $this->params[$type][$key] = $value;
+                    $foundKey                  = true;
+                }
+            }
+
+            if (!$foundKey) {
+                $this->params[$order[0]][$key] = $value;
+            }
+        }
+
+        /**
+         * @return array<string,mixed>|null
+         */
+        public function get_json_params(): ?array
+        {
+            $this->parse_json_params();
+
+            $json = $this->params['JSON'];
+
+            return is_array($json) ? $json : null;
+        }
+
+        /**
+         * @return array<int,string>
+         */
+        private function get_parameter_order(): array
+        {
+            $order = [];
+
+            if ($this->is_json_content_type()) {
+                $order[] = 'JSON';
+            }
+
+            $this->parse_json_params();
+
+            if (in_array($this->method, ['POST', 'PUT', 'PATCH', 'DELETE'], true)) {
+                $order[] = 'POST';
+            }
+
+            $order[] = 'GET';
+            $order[] = 'URL';
+            $order[] = 'defaults';
+
+            return $order;
+        }
+
+        private function parse_json_params(): void
+        {
+            if ($this->parsed_json) {
+                return;
+            }
+
+            $this->parsed_json = true;
+
+            if (!$this->is_json_content_type() || $this->body === '') {
+                return;
+            }
+
+            $decoded = json_decode($this->body, true);
+            if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+                $this->parsed_json = false;
+                return;
+            }
+
+            $this->params['JSON'] = $decoded;
         }
     }
 }

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.103
+ * Version:           0.61.104
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.103');
+define('WPMGR_AGENT_VERSION', '0.61.104');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/api/internal/agentcmd/client.go
+++ b/apps/api/internal/agentcmd/client.go
@@ -808,6 +808,27 @@ func (c *Client) Do(ctx context.Context, siteID uuid.UUID, siteURL, command stri
 // post mints a fresh JWT bound to siteID (aud) and command (cmd), POSTs body to
 // the named command endpoint at siteURL, and decodes the JSON response into
 // out. A non-2xx response is an error.
+//
+// post does NOT inspect the decoded body's ok field, and CANNOT: out is an
+// untyped any, and the response shapes are not uniform (some commands carry no
+// ok at all, the file_* family reports failure through an Error envelope, and
+// the update family reports it per item). The ok=false-is-an-error rule is
+// therefore applied by the individual wrapper methods, and only by the config
+// PUSH family: SyncErrorConfig, SyncSecurityConfig, SyncSecurityHardening,
+// SyncSecurityPolicy, SyncLoginBrand, SyncMediaConfig, SyncPerfConfig,
+// SyncEmailConfig, UnblockIP, RucssCompute, CacheEnable, CacheDisable,
+// CachePurge and CachePreload. Those are fire-and-forget pushes with no
+// callback, so folding ok=false into the error is the only way their callers
+// can tell the push did not land.
+//
+// Every OTHER wrapper returns the decoded response untouched and leaves the ok
+// field to the caller. That split is incidental (each command added its own
+// check, or did not, as it was written) rather than principled, and it is a
+// trap: a caller of one of those methods that branches only on the returned
+// error will silently treat a refusal as a success. A refresh_inventory that
+// had been rejected on every call since it shipped stayed invisible in exactly
+// that way. If you add a command here, either check ok in the wrapper or make
+// sure the caller does, and say in a comment which one you chose.
 func (c *Client) post(ctx context.Context, siteID uuid.UUID, siteURL, command string, body, out any) error {
 	data, err := c.postRaw(ctx, siteID, siteURL, command, body)
 	if err != nil {

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -390,6 +390,9 @@ func (s *Service) SendTest(ctx context.Context, tenantID, siteID uuid.UUID, in T
 		// the perf/security pattern for non-fatal agent command failures.
 		return TestSendResult{OK: false, Detail: err.Error()}, nil
 	}
+	// DELIBERATE: the agent's ok=false is carried through as this result's OK,
+	// not raised as an error. Reporting whether the test send worked IS the whole
+	// purpose of this call, and the handler shows OK plus Detail to the operator.
 	return TestSendResult{OK: res.OK, Detail: res.Detail}, nil
 }
 
@@ -839,6 +842,10 @@ func (s *Service) ResendEmail(ctx context.Context, tenantID, siteID, logID uuid.
 	if err != nil {
 		return ResendResult{OK: false, Detail: err.Error()}, nil
 	}
+	// DELIBERATE: the agent's ok=false is propagated as this call's OK rather than
+	// raised as an error. Every failure branch above returns the same shape, the
+	// handler renders OK plus Detail to the operator, and BulkResendEmail reports
+	// per-log outcomes from it. Nothing here reports success on a refusal.
 	return ResendResult{OK: res.OK, Detail: res.Detail, MessageID: res.MessageID}, nil
 }
 

--- a/apps/api/internal/media/service/agent_ok_flag_test.go
+++ b/apps/api/internal/media/service/agent_ok_flag_test.go
@@ -1,0 +1,153 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
+	"github.com/mosamlife/wpmgr/apps/api/internal/media/model"
+	"github.com/mosamlife/wpmgr/apps/api/internal/media/repo"
+)
+
+// These tests cover a control-plane blind spot shared by every media dispatch:
+// the agent answers HTTP 200 (so the transport error is nil) with an ack body of
+// {"ok":false}, meaning it REFUSED the command. All of this work is asynchronous
+// and the agent reports completion by calling a CP status endpoint, so a refused
+// dispatch means no callback ever arrives. Branching only on the transport error
+// therefore left the batch reported as queued and its jobs running forever.
+
+// refusingAgent acks every command with a 200 whose body says ok=false.
+type refusingAgent struct {
+	optimized chan struct{}
+}
+
+func (a *refusingAgent) MediaOptimize(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.MediaOptimizeRequest) (agentcmd.MediaOptimizeResponse, error) {
+	if a.optimized != nil {
+		a.optimized <- struct{}{}
+	}
+	return agentcmd.MediaOptimizeResponse{OK: false, Detail: "body must be an empty object"}, nil
+}
+
+func (a *refusingAgent) MediaSync(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.MediaSyncRequest) (agentcmd.MediaSyncResponse, error) {
+	return agentcmd.MediaSyncResponse{OK: false, Detail: "body must be an empty object"}, nil
+}
+
+func (a *refusingAgent) MediaRestore(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.MediaRestoreRequest) (agentcmd.MediaRestoreResponse, error) {
+	return agentcmd.MediaRestoreResponse{OK: false, Detail: "snapshot unavailable"}, nil
+}
+
+func (a *refusingAgent) MediaDeleteOriginals(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.MediaDeleteOriginalsRequest) (agentcmd.MediaDeleteOriginalsResponse, error) {
+	return agentcmd.MediaDeleteOriginalsResponse{OK: false, Detail: "refused"}, nil
+}
+
+func (a *refusingAgent) SyncMediaConfig(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.MediaConfigRequest) (agentcmd.MediaConfigResult, error) {
+	return agentcmd.MediaConfigResult{OK: true, Detail: "applied"}, nil
+}
+
+// TestSync_AgentOkFalseIsNotReportedAsStarted proves a media sync the agent
+// refused surfaces as an error instead of a started sync whose job never ends.
+func TestSync_AgentOkFalseIsNotReportedAsStarted(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	r := newFakeRepo()
+	svc := newTestService(r, &fakeStore{}, &fakeEnqueuer{}, &refusingAgent{}, fakeSites{enrolled: true})
+
+	if _, err := svc.Sync(context.Background(), tenantID, siteID, userPrincipal(tenantID)); err == nil {
+		t.Fatal("a 200 carrying ok=false is the agent refusing the sync; Sync must not report success")
+	}
+	assertNoJobLeftRunning(t, r)
+}
+
+// TestStartRestore_AgentOkFalseIsNotReportedAsQueued proves a refused restore is
+// reported as a failure rather than a queued batch. Claiming the originals are
+// being restored when the agent refused is the visible half of the harm.
+func TestStartRestore_AgentOkFalseIsNotReportedAsQueued(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	r := newFakeRepo()
+	a1 := model.Asset{ID: uuid.New(), SiteID: siteID, WPAttachmentID: 1, OriginalMime: "image/jpeg", Status: model.AssetOptimized}
+	r.assets[a1.ID] = a1
+	svc := newTestService(r, &fakeStore{}, &fakeEnqueuer{}, &refusingAgent{}, fakeSites{enrolled: true})
+
+	if _, err := svc.StartRestore(context.Background(), tenantID, siteID, []uuid.UUID{a1.ID}, userPrincipal(tenantID)); err == nil {
+		t.Fatal("a restore the agent refused must not be reported as queued")
+	}
+	assertNoJobLeftRunning(t, r)
+}
+
+// TestStartDeleteOriginals_AgentOkFalseIsNotReportedAsQueued covers the
+// irreversible command. The operator's destructive consent is already audited by
+// the time the ack arrives, so silently reporting a refused delete as queued
+// leaves the audit trail claiming an action that never happened.
+func TestStartDeleteOriginals_AgentOkFalseIsNotReportedAsQueued(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	r := newFakeRepo()
+	a1 := model.Asset{ID: uuid.New(), SiteID: siteID, WPAttachmentID: 1, OriginalMime: "image/jpeg", Status: model.AssetOptimized}
+	r.assets[a1.ID] = a1
+	svc := newTestService(r, &fakeStore{}, &fakeEnqueuer{}, &refusingAgent{}, fakeSites{enrolled: true})
+
+	if _, err := svc.StartDeleteOriginals(context.Background(), tenantID, siteID, []uuid.UUID{a1.ID}, userPrincipal(tenantID)); err == nil {
+		t.Fatal("a delete-originals the agent refused must not be reported as queued")
+	}
+	assertNoJobLeftRunning(t, r)
+}
+
+// TestStartOptimize_AgentOkFalseFailsTheJobs proves the detached optimize
+// dispatch fails its jobs on a refusal, exactly as it already did on a transport
+// error, so the UI does not show them stuck "optimizing" forever.
+func TestStartOptimize_AgentOkFalseFailsTheJobs(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	r := newFakeRepo()
+	a1 := model.Asset{ID: uuid.New(), SiteID: siteID, WPAttachmentID: 1, OriginalMime: "image/jpeg", Status: model.AssetPending}
+	r.assets[a1.ID] = a1
+	agent := &refusingAgent{}
+	// The optimize dispatch runs in a DETACHED goroutine, so the assertion must
+	// synchronise on the failJob write itself rather than poll the fake repo
+	// (which has no mutex and would data-race under -race).
+	sig := &signalingRepo{fakeRepo: r, finalized: make(chan repo.FinalizeJobInput, 4)}
+	svc := newTestService(sig, &fakeStore{}, &fakeEnqueuer{}, agent, fakeSites{enrolled: true})
+
+	if _, err := svc.StartOptimize(context.Background(), tenantID, siteID, []uuid.UUID{a1.ID}, false, "avif", "lossy", userPrincipal(tenantID)); err != nil {
+		t.Fatalf("StartOptimize: %v", err)
+	}
+
+	select {
+	case in := <-sig.finalized:
+		if in.State != model.JobFailed {
+			t.Fatalf("expected the job to be failed after the agent refused, got %q", in.State)
+		}
+		if !strings.Contains(in.ErrorReason, "rejected by agent") {
+			t.Fatalf("failure reason must name the refusal, got %q", in.ErrorReason)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("the agent refused the optimize dispatch but no job was ever failed; it would sit optimizing forever")
+	}
+}
+
+// signalingRepo wraps fakeRepo so a test can await the detached optimize
+// dispatch's failJob write without racing on the fake's unsynchronised maps.
+type signalingRepo struct {
+	*fakeRepo
+	finalized chan repo.FinalizeJobInput
+}
+
+func (r *signalingRepo) FinalizeJobAgent(ctx context.Context, jobID string, in repo.FinalizeJobInput) (model.Job, error) {
+	j, err := r.fakeRepo.FinalizeJobAgent(ctx, jobID, in)
+	r.finalized <- in
+	return j, err
+}
+
+// assertNoJobLeftRunning fails the test if any job is still in a non-terminal
+// state. A refused dispatch that leaves a job running is precisely the silent
+// hang this class of bug produces.
+func assertNoJobLeftRunning(t *testing.T, r *fakeRepo) {
+	t.Helper()
+	for id, j := range r.jobs {
+		if j.State != model.JobFailed && j.State != model.JobSucceeded &&
+			j.State != model.JobPartiallySucceeded && j.State != model.JobCancelled {
+			t.Fatalf("job %s left in non-terminal state %q after the agent refused the command", id, j.State)
+		}
+	}
+}

--- a/apps/api/internal/media/service/service.go
+++ b/apps/api/internal/media/service/service.go
@@ -189,13 +189,24 @@ func (s *Service) Sync(ctx context.Context, tenantID, siteID uuid.UUID, p domain
 	if s.cmd == nil {
 		return SyncResult{}, domain.ServiceUnavailable("media_agent_unwired", "media agent client is not wired")
 	}
-	if _, err := s.cmd.MediaSync(ctx, siteID, si.URL, agentcmd.MediaSyncRequest{
+	ack, err := s.cmd.MediaSync(ctx, siteID, si.URL, agentcmd.MediaSyncRequest{
 		JobID:            jobID,
 		BatchEndpoint:    s.callbackURL("/agent/v1/media/sync-batch"),
 		FinalizeEndpoint: s.callbackURL("/agent/v1/media/sync-finalize"),
-	}); err != nil {
+	})
+	if err != nil {
 		s.failJob(ctx, tenantID, siteID, jobID, "sync dispatch failed: "+err.Error())
 		return SyncResult{}, domain.Internal("media_sync_dispatch_failed", "failed to dispatch media sync").WithCause(err)
+	}
+	// The ack's ok field is the agent REFUSING the command on an otherwise fine
+	// 200. This work is asynchronous (the agent pushes pages back to
+	// BatchEndpoint), so a refused dispatch means no callback will ever arrive
+	// and the job would sit "running" forever. Only the transport error was
+	// checked before, which left exactly that hole.
+	if !ack.OK {
+		detail := detailOr(ack.Detail, "agent returned ok=false")
+		s.failJob(ctx, tenantID, siteID, jobID, "sync rejected by agent: "+detail)
+		return SyncResult{}, domain.Internal("media_sync_rejected", "agent rejected media sync: "+detail)
 	}
 	return SyncResult{JobID: jobID, StartedAt: job.CreatedAt}, nil
 }
@@ -313,7 +324,9 @@ func (s *Service) StartOptimize(ctx context.Context, tenantID, siteID uuid.UUID,
 		// but bound it so a hung agent POST cannot leak a goroutine forever.
 		bg, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Minute)
 		defer cancel()
-		if _, err := s.cmd.MediaOptimize(bg, siteID, siteURL, dispatchReq); err != nil {
+		ack, err := s.cmd.MediaOptimize(bg, siteID, siteURL, dispatchReq)
+		switch {
+		case err != nil:
 			// Genuine dispatch failures (agent unreachable, 4xx/5xx ack, or — with
 			// a slow-acking agent — an http.Client.Timeout) still fail the batch's
 			// jobs so the UI does not show them stuck "optimizing" forever. This
@@ -323,6 +336,17 @@ func (s *Service) StartOptimize(ctx context.Context, tenantID, siteID uuid.UUID,
 			s.logger.Error("media optimize dispatch failed", "site_id", siteID.String(), "err", err.Error())
 			for _, jid := range jobIDsCopy {
 				s.failJob(bg, tenantID, siteID, jid, "optimize dispatch failed: "+err.Error())
+			}
+		case !ack.OK:
+			// A 200 whose body says ok=false is the agent refusing the batch. It
+			// produces exactly the "stuck optimizing forever" state the transport
+			// branch above exists to prevent, because the agent will never call
+			// PresignEndpoint or ReadyEndpoint. Fail the jobs through the same
+			// guarded path.
+			detail := detailOr(ack.Detail, "agent returned ok=false")
+			s.logger.Error("media optimize rejected by agent", "site_id", siteID.String(), "detail", detail)
+			for _, jid := range jobIDsCopy {
+				s.failJob(bg, tenantID, siteID, jid, "optimize rejected by agent: "+detail)
 			}
 		}
 	}()
@@ -382,14 +406,25 @@ func (s *Service) StartRestore(ctx context.Context, tenantID, siteID uuid.UUID, 
 	if s.cmd == nil {
 		return BatchResult{}, domain.ServiceUnavailable("media_agent_unwired", "media agent client is not wired")
 	}
-	if _, err := s.cmd.MediaRestore(ctx, siteID, si.URL, agentcmd.MediaRestoreRequest{
+	ack, err := s.cmd.MediaRestore(ctx, siteID, si.URL, agentcmd.MediaRestoreRequest{
 		Jobs:           jobs,
 		StatusEndpoint: s.callbackURL("/agent/v1/media/restore-status"),
-	}); err != nil {
+	})
+	if err != nil {
 		for _, jid := range jobIDs {
 			s.failJob(ctx, tenantID, siteID, jid, "restore dispatch failed: "+err.Error())
 		}
 		return BatchResult{}, domain.Internal("media_restore_dispatch_failed", "failed to dispatch media restore").WithCause(err)
+	}
+	// ok=false on a 200 means the agent refused: no restore ran and no callback to
+	// StatusEndpoint will arrive. Reporting the batch as queued here would tell
+	// the operator their originals were being restored when nothing was.
+	if !ack.OK {
+		detail := detailOr(ack.Detail, "agent returned ok=false")
+		for _, jid := range jobIDs {
+			s.failJob(ctx, tenantID, siteID, jid, "restore rejected by agent: "+detail)
+		}
+		return BatchResult{}, domain.Internal("media_restore_rejected", "agent rejected media restore: "+detail)
 	}
 	return BatchResult{BatchJobID: batchID, QueuedCount: len(jobIDs)}, nil
 }
@@ -446,14 +481,26 @@ func (s *Service) StartDeleteOriginals(ctx context.Context, tenantID, siteID uui
 	if s.cmd == nil {
 		return BatchResult{}, domain.ServiceUnavailable("media_agent_unwired", "media agent client is not wired")
 	}
-	if _, err := s.cmd.MediaDeleteOriginals(ctx, siteID, si.URL, agentcmd.MediaDeleteOriginalsRequest{
+	ack, err := s.cmd.MediaDeleteOriginals(ctx, siteID, si.URL, agentcmd.MediaDeleteOriginalsRequest{
 		Jobs:           jobs,
 		StatusEndpoint: s.callbackURL("/agent/v1/media/job-status"),
-	}); err != nil {
+	})
+	if err != nil {
 		for _, jid := range jobIDs {
 			s.failJob(ctx, tenantID, siteID, jid, "delete-originals dispatch failed: "+err.Error())
 		}
 		return BatchResult{}, domain.Internal("media_delete_dispatch_failed", "failed to dispatch delete originals").WithCause(err)
+	}
+	// ok=false on a 200 means the agent refused the (irreversible) delete. The
+	// operator already consented and the consent is audited above, so silently
+	// reporting the batch as queued would leave the audit trail claiming a
+	// destructive action that never happened.
+	if !ack.OK {
+		detail := detailOr(ack.Detail, "agent returned ok=false")
+		for _, jid := range jobIDs {
+			s.failJob(ctx, tenantID, siteID, jid, "delete-originals rejected by agent: "+detail)
+		}
+		return BatchResult{}, domain.Internal("media_delete_rejected", "agent rejected delete originals: "+detail)
 	}
 	return BatchResult{BatchJobID: batchID, QueuedCount: len(jobIDs)}, nil
 }
@@ -615,6 +662,16 @@ func (s *Service) resolveAssets(ctx context.Context, tenantID, siteID uuid.UUID,
 		out = append(out, a)
 	}
 	return out, nil
+}
+
+// detailOr returns primary when it is non-empty, else fallback. Used to keep the
+// agent's own rejection detail in a dispatch failure message without emitting an
+// empty "rejected by agent: " string when the agent sent ok=false and no detail.
+func detailOr(primary, fallback string) string {
+	if primary != "" {
+		return primary
+	}
+	return fallback
 }
 
 // failJob transitions a NON-TERMINAL job to failed + publishes media.job.failed

--- a/apps/api/internal/media/worker/agent_ok_flag_test.go
+++ b/apps/api/internal/media/worker/agent_ok_flag_test.go
@@ -1,0 +1,84 @@
+package worker
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
+	"github.com/mosamlife/wpmgr/apps/api/internal/media/model"
+)
+
+// okFlagSites is a SiteLookup that always resolves an enrolled site.
+type okFlagSites struct{}
+
+func (okFlagSites) GetMediaSiteURL(context.Context, uuid.UUID, uuid.UUID) (string, bool, error) {
+	return "https://example.test", true, nil
+}
+
+// okFlagPresigner returns a fixed URL for every key.
+type okFlagPresigner struct{}
+
+func (okFlagPresigner) PresignGet(context.Context, string, time.Duration) (string, error) {
+	return "https://signed.example/get", nil
+}
+func (okFlagPresigner) PresignPut(context.Context, string, time.Duration) (string, error) {
+	return "https://signed.example/put", nil
+}
+func (okFlagPresigner) Delete(context.Context, string) error { return nil }
+
+// refusingApplyClient acks media_apply with a 200 whose body says ok=false: the
+// agent REFUSED to apply the encoded variants.
+type refusingApplyClient struct{ detail string }
+
+func (c refusingApplyClient) MediaApply(context.Context, uuid.UUID, string, agentcmd.MediaApplyRequest) (agentcmd.MediaApplyResponse, error) {
+	return agentcmd.MediaApplyResponse{OK: false, Detail: c.detail}, nil
+}
+
+// acceptingApplyClient acks normally.
+type acceptingApplyClient struct{}
+
+func (acceptingApplyClient) MediaApply(context.Context, uuid.UUID, string, agentcmd.MediaApplyRequest) (agentcmd.MediaApplyResponse, error) {
+	return agentcmd.MediaApplyResponse{OK: true}, nil
+}
+
+func newOkFlagWorker(apply AgentApplyClient) *EncodeWorker {
+	return NewEncodeWorker(nil, &fakeJobRepo{}, okFlagPresigner{}, nil, okFlagSites{},
+		apply, "https://cp.example", time.Minute, nil)
+}
+
+// TestDispatchApply_AgentOkFalseIsAnError proves that media_apply answered with
+// a 200 carrying ok=false is surfaced as an error. The agent refused, so it will
+// never post the job-status callback, and returning nil here would complete the
+// River job while the media job hung at "encoded" forever.
+func TestDispatchApply_AgentOkFalseIsAnError(t *testing.T) {
+	w := newOkFlagWorker(refusingApplyClient{detail: "body must be an empty object"})
+	args := model.EncodeArgs{
+		TenantID: uuid.New(), SiteID: uuid.New(), JobID: "job-1", WPAttachmentID: 7,
+	}
+	variants := []agentcmd.MediaApplyVariant{{Name: "full", OptimizedMime: "image/avif", OptimizedSize: 100}}
+
+	err := w.dispatchApply(context.Background(), args, variants)
+	if err == nil {
+		t.Fatal("a 200 carrying ok=false is the agent refusing media_apply; dispatchApply must report a failure")
+	}
+	if !strings.Contains(err.Error(), "body must be an empty object") {
+		t.Fatalf("the agent's own detail must be preserved, got %q", err.Error())
+	}
+}
+
+// TestDispatchApply_AgentOkTrueSucceeds guards the fix against over-reach.
+func TestDispatchApply_AgentOkTrueSucceeds(t *testing.T) {
+	w := newOkFlagWorker(acceptingApplyClient{})
+	args := model.EncodeArgs{
+		TenantID: uuid.New(), SiteID: uuid.New(), JobID: "job-1", WPAttachmentID: 7,
+	}
+	variants := []agentcmd.MediaApplyVariant{{Name: "full", OptimizedMime: "image/avif", OptimizedSize: 100}}
+
+	if err := w.dispatchApply(context.Background(), args, variants); err != nil {
+		t.Fatalf("an accepted media_apply must succeed, got %v", err)
+	}
+}

--- a/apps/api/internal/media/worker/encode_worker.go
+++ b/apps/api/internal/media/worker/encode_worker.go
@@ -250,7 +250,7 @@ func (w *EncodeWorker) dispatchApply(ctx context.Context, a model.EncodeArgs, va
 		}
 		variants[i].GetURL = url
 	}
-	_, err = w.apply.MediaApply(ctx, a.SiteID, siteURL, agentcmd.MediaApplyRequest{
+	ack, err := w.apply.MediaApply(ctx, a.SiteID, siteURL, agentcmd.MediaApplyRequest{
 		JobID:          a.JobID,
 		WPAttachmentID: a.WPAttachmentID,
 		TargetFormat:   a.TargetFormat,
@@ -263,7 +263,27 @@ func (w *EncodeWorker) dispatchApply(ctx context.Context, a model.EncodeArgs, va
 		StatusEndpoint: w.cpBaseURL + "/agent/v1/media/job-status",
 		Variants:       variants,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	// The agent acks with ok=false when it refuses to apply (on an otherwise
+	// clean 200). Returning nil there would complete the River job while the
+	// media job hangs at "encoded" forever, since the agent will never post the
+	// job-status callback described above. Surface it as an error so the job
+	// retries and the reason is recorded.
+	if !ack.OK {
+		return fmt.Errorf("media_apply rejected by agent: %s", detailOr(ack.Detail, "agent returned ok=false"))
+	}
+	return nil
+}
+
+// detailOr returns primary when it is non-empty, else fallback, so an agent that
+// rejects a command without sending a detail still produces a readable error.
+func detailOr(primary, fallback string) string {
+	if primary != "" {
+		return primary
+	}
+	return fallback
 }
 
 // fetchPresigned mints a presigned GET URL for key and fetches the bytes over

--- a/apps/api/internal/objectcache/service.go
+++ b/apps/api/internal/objectcache/service.go
@@ -269,6 +269,10 @@ func (s *Service) Test(ctx context.Context, tenantID, siteID uuid.UUID, password
 	}
 
 	resultJSON, _ := json.Marshal(result)
+	// DELIBERATE: an ok=false test result is a legitimate answer, not an error.
+	// It is recorded verbatim, leaves passed_at NULL (which keeps the Enable
+	// handshake gate closed, so a failing test cannot be mistaken for a passing
+	// one), is published on the SSE event below, and is returned to the caller.
 	var passedAt *time.Time
 	if result.OK {
 		now := time.Now().UTC()

--- a/apps/api/internal/scan/service.go
+++ b/apps/api/internal/scan/service.go
@@ -194,6 +194,13 @@ func (s *Service) IgnoreFinding(ctx context.Context, tenantID, findingID uuid.UU
 // FetchFile calls the agent's get_file command for a path that is already a
 // stored finding (server-side guard). Returns the GetFileResponse base64 content.
 // Access is audited with scan.file_fetched.
+//
+// DELIBERATE: an ok=false response is NOT converted into an error here. get_file
+// is a read whose per-file outcome is part of the answer, and the response's ok
+// plus error fields are passed through verbatim to the operator by the handler's
+// fetchFileResponseDTO (and recorded in the audit metadata below), so a refusal
+// is visible rather than swallowed. This is the tolerated case, not an oversight:
+// the caller never reports success on the agent's behalf.
 func (s *Service) FetchFile(ctx context.Context, tenantID, findingID uuid.UUID, p domain.Principal) (agentcmd.GetFileResponse, error) {
 	if s.cmd == nil || s.siteLookup == nil {
 		return agentcmd.GetFileResponse{}, domain.ServiceUnavailable("scan_agent_unwired", "scan agent client is not wired")

--- a/apps/api/internal/update/agent_ok_flag_test.go
+++ b/apps/api/internal/update/agent_ok_flag_test.go
@@ -1,0 +1,171 @@
+package update
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
+)
+
+// This file covers one class of control-plane blind spot: an agent command that
+// returns HTTP 200 (so the transport error is nil) with a body whose ok field is
+// false, meaning the agent REFUSED the command. A caller that branches only on
+// the transport error records such a refusal as a success. That is how a
+// refresh_inventory broken since it shipped stayed invisible in production, and
+// the same shape existed on the update worker's dry-run and rollback paths.
+
+// scriptedUpdateCommander is a Commander returning a fixed Update/Rollback
+// response pair, so runDry and rollback can be driven with an agent that answers
+// 200 while refusing the command.
+type scriptedUpdateCommander struct {
+	updateResp   agentcmd.UpdateResponse
+	rollbackResp agentcmd.RollbackResponse
+	rollbackHit  bool
+}
+
+func (c *scriptedUpdateCommander) Update(context.Context, uuid.UUID, string, agentcmd.UpdateRequest) (agentcmd.UpdateResponse, error) {
+	return c.updateResp, nil
+}
+
+func (c *scriptedUpdateCommander) Rollback(context.Context, uuid.UUID, string, agentcmd.RollbackRequest) (agentcmd.RollbackResponse, error) {
+	c.rollbackHit = true
+	return c.rollbackResp, nil
+}
+
+func newScriptedWorker(repo *probeFakeRepo, cmd *scriptedUpdateCommander) *Worker {
+	w := NewWorker(repo, nil, cmd, &scriptedProber{}, nil, nil, nil, 5, 0)
+	w.SetProbeRetryDelays([]time.Duration{time.Millisecond})
+	return w
+}
+
+// TestRunDry_AgentOkFalseIsNotSuccess proves a dry run the agent refused is not
+// recorded as a succeeded task. Before the fix runDry never inspected resp.OK
+// and hardcoded status = TaskSucceeded, so this landed as "no change".
+func TestRunDry_AgentOkFalseIsNotSuccess(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &scriptedUpdateCommander{updateResp: agentcmd.UpdateResponse{OK: false}}
+	w := newScriptedWorker(repo, cmd)
+
+	if err := w.runDry(context.Background(), testTask(), "https://example.test", updateItem()); err != nil {
+		t.Fatalf("runDry: %v", err)
+	}
+	if len(repo.finished) != 1 {
+		t.Fatalf("expected exactly one finish, got %+v", repo.finished)
+	}
+	if got := repo.finished[0].Status; got != TaskFailed {
+		t.Fatalf("a dry run the agent refused must be TaskFailed, got %q with detail %q",
+			got, repo.finished[0].Detail)
+	}
+}
+
+// TestRunDry_AgentReturnedNoItemResultIsNotSuccess proves the OTHER half of the
+// same hole: firstResult synthesises an ItemFailed when the agent sends back an
+// empty results array, and runDry ignored that status entirely.
+func TestRunDry_AgentReturnedNoItemResultIsNotSuccess(t *testing.T) {
+	repo := &probeFakeRepo{}
+	// ok=true but no per-item result: the agent acked yet reported nothing.
+	cmd := &scriptedUpdateCommander{updateResp: agentcmd.UpdateResponse{OK: true}}
+	w := newScriptedWorker(repo, cmd)
+
+	if err := w.runDry(context.Background(), testTask(), "https://example.test", updateItem()); err != nil {
+		t.Fatalf("runDry: %v", err)
+	}
+	if len(repo.finished) != 1 {
+		t.Fatalf("expected exactly one finish, got %+v", repo.finished)
+	}
+	if got := repo.finished[0].Status; got != TaskFailed {
+		t.Fatalf("a dry run with no item result must be TaskFailed, got %q with detail %q",
+			got, repo.finished[0].Detail)
+	}
+}
+
+// TestRunDry_HappyPathStillSucceeds guards the fix against over-reach: a normal
+// dry run must still be recorded as succeeded.
+func TestRunDry_HappyPathStillSucceeds(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &scriptedUpdateCommander{updateResp: agentcmd.UpdateResponse{
+		OK: true,
+		Results: []agentcmd.ItemResult{{
+			Type: TargetPlugin, Slug: "suremail",
+			FromVersion: "1.9.9", ToVersion: "2.0.0",
+			Status: agentcmd.ItemWouldUpdate,
+		}},
+	}}
+	w := newScriptedWorker(repo, cmd)
+
+	if err := w.runDry(context.Background(), testTask(), "https://example.test", updateItem()); err != nil {
+		t.Fatalf("runDry: %v", err)
+	}
+	if len(repo.finished) != 1 || repo.finished[0].Status != TaskSucceeded {
+		t.Fatalf("a healthy dry run must still succeed, got %+v", repo.finished)
+	}
+	if !strings.Contains(repo.finished[0].Detail, "would update") {
+		t.Fatalf("expected the would-update detail, got %q", repo.finished[0].Detail)
+	}
+}
+
+// TestRollback_AgentOkFalseIsNotRecordedAsRolledBack is the most consequential
+// case of the class. When the agent answers 200 with ok=false it REFUSED the
+// rollback: nothing was restored and the site is still broken. The transport
+// error is nil, so before the fix the task was recorded TaskRolledBack, telling
+// the operator the site had been recovered when it had not.
+func TestRollback_AgentOkFalseIsNotRecordedAsRolledBack(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &scriptedUpdateCommander{rollbackResp: agentcmd.RollbackResponse{
+		OK:  false,
+		Log: "snapshot snap-1 is missing",
+	}}
+	w := newScriptedWorker(repo, cmd)
+
+	task := testTask()
+	item := updateItem()
+	res := agentcmd.ItemResult{
+		Type: item.Type, Slug: item.Slug,
+		FromVersion: "1.9.9", ToVersion: "2.0.0",
+		Status: agentcmd.ItemSucceeded, SnapshotID: "snap-1",
+	}
+
+	err := w.rollback(context.Background(), task, "https://example.test", item, res,
+		agentcmd.ProbeResult{}, false, "post-update health failed")
+	if err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if !cmd.rollbackHit {
+		t.Fatal("expected the rollback command to be dispatched")
+	}
+	if len(repo.finished) != 1 {
+		t.Fatalf("expected exactly one finish, got %+v", repo.finished)
+	}
+	got := repo.finished[0]
+	if got.Status == TaskRolledBack {
+		t.Fatal("a rollback the agent REFUSED must never be recorded as TaskRolledBack; the site was not restored")
+	}
+	if got.Status != TaskFailed {
+		t.Fatalf("expected TaskFailed, got %q", got.Status)
+	}
+	if !strings.Contains(got.Error, "snapshot snap-1 is missing") {
+		t.Fatalf("the agent's own rollback log must be preserved, got %q", got.Error)
+	}
+}
+
+// TestRollback_HappyPathStillRecordsRolledBack guards the fix against over-reach.
+func TestRollback_HappyPathStillRecordsRolledBack(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &scriptedUpdateCommander{rollbackResp: agentcmd.RollbackResponse{
+		OK: true, RestoredVersion: "1.9.9",
+	}}
+	w := newScriptedWorker(repo, cmd)
+
+	res := agentcmd.ItemResult{FromVersion: "1.9.9", ToVersion: "2.0.0", SnapshotID: "snap-1"}
+	if err := w.rollback(context.Background(), testTask(), "https://example.test", updateItem(), res,
+		agentcmd.ProbeResult{}, false, "post-update health failed"); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if len(repo.finished) != 1 || repo.finished[0].Status != TaskRolledBack {
+		t.Fatalf("a rollback the agent accepted must still record TaskRolledBack, got %+v", repo.finished)
+	}
+}

--- a/apps/api/internal/update/refresh.go
+++ b/apps/api/internal/update/refresh.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"regexp"
 	"strconv"
@@ -51,6 +52,11 @@ type RefreshCommander interface {
 // the worker records an audit warning and returns nil so River won't retry to
 // death; on any other transport/agent error it returns the error and River
 // retries with its default backoff.
+//
+// A 200 response is NOT by itself success: the agent reports its own verdict in
+// the body's ok field, and Client.RefreshInventory deliberately leaves that flag
+// for this caller to read (see the note on agentcmd.Client.post). An ok=false is
+// treated as a failure here.
 type RefreshInventoryWorker struct {
 	river.WorkerDefaults[RefreshInventoryArgs]
 	cmd    RefreshCommander
@@ -75,8 +81,21 @@ func (w *RefreshInventoryWorker) Work(ctx context.Context, job *river.Job[Refres
 		w.logger.Warn("refresh inventory: command client unavailable", slog.String("site_id", a.SiteID.String()))
 		return river.JobCancel(errors.New("refresh_inventory: CP->agent commands are disabled"))
 	}
-	_, err := w.cmd.RefreshInventory(ctx, a.SiteID, a.SiteURL, agentcmd.RefreshInventoryRequest{})
+	resp, err := w.cmd.RefreshInventory(ctx, a.SiteID, a.SiteURL, agentcmd.RefreshInventoryRequest{})
 	if err == nil {
+		// A 200 is only the TRANSPORT succeeding. The agent still reports its own
+		// verdict in the body's ok field, and an ok=false there means it refused
+		// the command and will never push metadata back over /agent/v1/metadata.
+		// This branch previously logged "ok" on the transport result alone, which
+		// is how a refresh_inventory that had been rejected on every single call
+		// since the feature shipped still looked healthy in the logs: the agent
+		// answered 200 {"ok":false,...} and nothing here ever read the flag.
+		// Treat the agent's no as a failure and keep ITS detail in the error, so
+		// the reason is visible in the River job's error rather than discarded.
+		if !resp.OK {
+			return fmt.Errorf("refresh_inventory rejected by agent: %s",
+				detailOr(resp.Detail, "agent returned ok=false with no detail"))
+		}
 		w.logger.Debug("refresh inventory: ok",
 			slog.String("site_id", a.SiteID.String()),
 			slog.String("source", a.Source))

--- a/apps/api/internal/update/refresh_test.go
+++ b/apps/api/internal/update/refresh_test.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -42,6 +43,48 @@ func TestRefreshInventoryWorkerHappyPath(t *testing.T) {
 	}
 	if cmd.calls != 1 || cmd.gotSiteID != siteID {
 		t.Fatalf("commander not called as expected: %+v", cmd)
+	}
+}
+
+// TestRefreshInventoryWorkerAgentOkFalseIsFailure is the regression test for the
+// control-plane blind spot that hid a refresh_inventory broken since it shipped.
+// The agent answered HTTP 200 (so the transport error is nil) with a body of
+// {"ok":false,"detail":"body must be an empty object"} and never refreshed or
+// pushed anything, while the worker branched only on the transport error and
+// logged "refresh inventory: ok" every time.
+//
+// The worker MUST report a failure here, and MUST keep the agent's own detail in
+// the error so the reason is not discarded.
+func TestRefreshInventoryWorkerAgentOkFalseIsFailure(t *testing.T) {
+	cmd := &fakeRefreshCmd{resp: agentcmd.RefreshInventoryResponse{
+		OK:     false,
+		Detail: "body must be an empty object",
+	}}
+	w := NewRefreshInventoryWorker(cmd, nil, nil)
+	err := w.Work(context.Background(), &river.Job[RefreshInventoryArgs]{
+		Args: RefreshInventoryArgs{TenantID: uuid.New(), SiteID: uuid.New(), SiteURL: "https://example.com", Source: "api"},
+	})
+	if err == nil {
+		t.Fatal("a 200 carrying ok=false is the agent refusing the command; the worker must report a failure, not success")
+	}
+	if !strings.Contains(err.Error(), "body must be an empty object") {
+		t.Fatalf("the agent's own detail must be preserved in the error, got %q", err.Error())
+	}
+}
+
+// TestRefreshInventoryWorkerOkFalseWithoutDetail proves the failure path is still
+// legible when the agent refuses without sending a detail string.
+func TestRefreshInventoryWorkerOkFalseWithoutDetail(t *testing.T) {
+	cmd := &fakeRefreshCmd{resp: agentcmd.RefreshInventoryResponse{OK: false}}
+	w := NewRefreshInventoryWorker(cmd, nil, nil)
+	err := w.Work(context.Background(), &river.Job[RefreshInventoryArgs]{
+		Args: RefreshInventoryArgs{TenantID: uuid.New(), SiteID: uuid.New(), SiteURL: "https://example.com"},
+	})
+	if err == nil {
+		t.Fatal("ok=false with no detail must still be a failure")
+	}
+	if !strings.Contains(err.Error(), "ok=false") {
+		t.Fatalf("error must explain the refusal, got %q", err.Error())
 	}
 }
 

--- a/apps/api/internal/update/worker.go
+++ b/apps/api/internal/update/worker.go
@@ -340,7 +340,21 @@ func (w *Worker) runDry(ctx context.Context, task Task, siteURL string, item age
 	if err != nil {
 		return w.finish(ctx, task, TaskFailed, task.FromVersion, "", "dry-run command failed", err.Error())
 	}
+	// A 200 only means the transport worked. resp.OK is the agent's own verdict on
+	// whether it accepted the command at all, and firstResult synthesises an
+	// ItemFailed when the agent sent back no per-item result. Both are failures,
+	// and neither was checked here before: every dry run took the TaskSucceeded
+	// path below, so an agent that had rejected the command outright was still
+	// recorded as a successful "no change".
 	res := firstResult(resp.Results)
+	if !resp.OK {
+		return w.finish(ctx, task, TaskFailed, task.FromVersion, "",
+			"agent rejected the dry-run command", detailOr(res.Log, "agent returned ok=false"))
+	}
+	if res.Status == agentcmd.ItemFailed {
+		return w.finish(ctx, task, TaskFailed, fromOr(res.FromVersion, task.FromVersion), res.ToVersion,
+			"agent reported dry-run failure", res.Log)
+	}
 	detail := "no change"
 	status := TaskSucceeded
 	if res.Status == agentcmd.ItemWouldUpdate {
@@ -359,6 +373,15 @@ func (w *Worker) runApply(ctx context.Context, task Task, siteURL string, item a
 		return w.finish(ctx, task, TaskFailed, task.FromVersion, "", "update command failed", err.Error())
 	}
 	res := firstResult(resp.Results)
+
+	// The agent's own verdict on the command dispatch. An ok=false here means it
+	// never ran the update, so the per-item results below cannot be trusted to
+	// describe what happened on disk; fail the task rather than health-probing a
+	// site that was never touched and then recording it as updated.
+	if !resp.OK {
+		return w.finish(ctx, task, TaskFailed, fromOr(res.FromVersion, task.FromVersion), res.ToVersion,
+			"agent rejected the update command", detailOr(res.Log, "agent returned ok=false"))
+	}
 
 	if res.Status == agentcmd.ItemFailed {
 		return w.finish(ctx, task, TaskFailed, fromOr(res.FromVersion, task.FromVersion), res.ToVersion, "agent reported update failure", res.Log)
@@ -665,12 +688,23 @@ func (w *Worker) probeHealthWithRetry(ctx context.Context, siteURL string) (prob
 // ProbeResult to carry it.
 func (w *Worker) rollback(ctx context.Context, task Task, siteURL string, item agentcmd.UpdateItem, res agentcmd.ItemResult, probe agentcmd.ProbeResult, agentConfirmedFatal bool, reason string) error {
 	from := fromOr(res.FromVersion, task.FromVersion)
-	_, rbErr := w.cmd.Rollback(ctx, task.SiteID, siteURL, agentcmd.RollbackRequest{
+	rbResp, rbErr := w.cmd.Rollback(ctx, task.SiteID, siteURL, agentcmd.RollbackRequest{
 		Type:       item.Type,
 		Slug:       item.Slug,
 		SnapshotID: res.SnapshotID,
 		ToVersion:  from,
 	})
+	// A 200 with ok=false is the agent REFUSING the rollback (e.g. the snapshot
+	// is gone or unreadable). The transport succeeded, so rbErr is nil and the
+	// task used to land on the TaskRolledBack line below, telling the operator
+	// the site had been restored when nothing had been restored at all. That is
+	// the most dangerous shape of this bug: the site is still broken and the
+	// record says it was recovered. Report it as a failed rollback instead.
+	if rbErr == nil && !rbResp.OK {
+		return w.finish(ctx, task, TaskFailed, from, res.ToVersion,
+			"rollback REFUSED by agent after unhealthy update: "+reason,
+			detailOr(rbResp.Log, "agent returned ok=false"))
+	}
 	if rbErr != nil {
 		// Rollback itself failed: this is the worst case. Record as failed with
 		// both the health reason and the rollback error so the operator is alerted.

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,26 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.104",
+    date: "2026-07-30",
+    summary: "Fleet agent updates work now: the command that starts them was rejecting every request, and a second command had been silently broken since launch.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Starting a fleet agent update failed immediately with a \"takes no parameters\" error, and the rollout stopped after its first site. The agent was mixing its own verified command details into the request body, so a command expecting an empty body saw something in it and refused. This never showed up in manual testing, since only a request sent with the JSON content type triggered it. The agent no longer does that, and commands that expect an empty body now ignore anything that arrives instead of refusing.",
+      },
+      {
+        tag: "Fixed",
+        text: "The Refresh inventory action on a site was affected the same way and had never worked: it reported success while doing nothing, because the control plane only checked that the request was delivered, not what the agent said back. It reads the agent's answer now, so refreshing a site's inventory actually refreshes it.",
+      },
+      {
+        tag: "Fixed",
+        text: "More broadly, the control plane checked only whether a command reached a site, not whether the agent accepted it. A refused rollback could be recorded as \"rolled back\", an update dry run was always recorded as successful, and some jobs would wait forever for a result a refusal never sends. All of these now treat a refusal as a failure. If you're reviewing past update history, a task marked rolled back may not have been, for this reason.",
+      },
+    ],
+    featureLinks: [{ label: "Updates", href: "/features/updates/" }],
+  },
+  {
     version: "0.61.103",
     date: "2026-07-30",
     summary: "Self-hosted installs can now get agent updates, mirrored from GitHub into their own storage and off by default.",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.103 / open source",
+  badge: "v0.61.104 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.103
+  version: 0.61.104
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Ships as 0.61.104. Fixes the failure from the first real fleet agent update, plus a wider gap it exposed.

## What happened

The first production rollout failed on its first site:

```
the agent could not arm its self-update: This command takes no parameters.
```

The wave gate then halted the run with `cancelled_tasks: 0`. **That part worked exactly as designed** — one site contacted, one failed, nothing else touched.

## Root cause: WordPress core behaviour, not environmental

`WP_REST_Request::set_param()` writes an unseen key into the **first bucket** of `get_parameter_order()`, and on a POST with `Content-Type: application/json` that bucket is **JSON**. `Router::authorizeCommand()` stashes the verified JWT claims via `set_param()`, so they landed *inside the parsed body*, and `get_json_params()` handed them back as if the control plane had sent them:

```php
$params = ['wpmgr_claims' => ['aud' => ..., 'cmd' => 'agent_self_update', ...]]   // never []
```

The guard was correct about what it received; it received the wrong thing. `json_decode('{}', true)` really is `[]` — the permission callback then wrote into it.

**Why manual testing never caught it:** without the JSON content type, `$order[0]` isn't the JSON bucket and the request works fine. Only a caller setting that header trips it, and `agentcmd` sets it on every command.

The router now strips its internal stash before dispatch, and the two commands asserting an empty body ignore whatever arrives. `cache_enable`'s similar-looking check is a short-circuit in front of a positive allow-list, not a rejection, and is deliberately left alone.

## Refresh inventory had never worked

Same guard, same trigger, since the day it shipped. It answered 200 with `ok:false` and did nothing — and `RefreshInventoryWorker` read only the transport error, so it logged **"refresh inventory: ok"** on every silently failed refresh for the life of the feature.

## The blind spot was wider than one worker

`agentcmd.Client.post` cannot check `ok` (its `out` is `any`), so the rule lives in wrapper methods and only the config-push family ever got one. That split was incidental, not principled. Five sites reported success when the agent had refused:

| Site | Consequence |
|---|---|
| `update` **rollback** | recorded `TaskRolledBack`, telling an operator a site was restored when it was not |
| `update` dry run | hardcoded `TaskSucceeded` |
| media sync / optimize / restore / delete-originals | a refusal sends no callback, so jobs waited forever, the exact state the transport-error branch exists to prevent |
| encode `dispatchApply` | completed the River job while the media job hung |

The rollback one is arguably worse than the reported bug, since it actively asserted a recovery that never happened.

All now treat a refusal as a failure and preserve the agent's own detail. Paths that *deliberately* tolerate `ok:false` now carry a comment saying so — telling a deliberate choice from an oversight is exactly what was missing.

## The test double made this untestable

`bootstrap.php`'s `WP_REST_Request` fake was a flat array whose `get_json_params()` returned a **hard-coded `[]`**. No test through that harness could have failed.

It now mirrors core's real bucket model, with a test pinning the WordPress semantics so it cannot be simplified back. New router-level coverage drives the real path with a real keypair, a real signed JWT and a real request, parameterised over the commands the control plane sends an empty body to.

Every fix is pinned by a test confirmed failing against the pre-fix source, verified by stashing each source file individually.

## Verification

- Agent: phpunit **2917**, phpcs 0 errors, `wp plugin check` **0 errors**
- Go: build/vet clean, **69 packages** ok, `-race` clean on touched packages
- No existing test was weakened; every affected fake already set `OK: true`, so none had pinned the bug

## For operators

A task recorded as **rolled back** may not actually have been. Noted in the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fleet update and rollback reliability by correctly reporting refused commands as failures.
  * Prevented update rollouts from stalling when commands contain empty or unexpected request bodies.
  * Fixed inventory refresh commands so they perform the refresh and metadata synchronization as expected.
  * Preserved refusal details in failure messages and prevented jobs from remaining indefinitely pending or being incorrectly marked successful or rolled back.
* **Chores**
  * Updated the release to version 0.61.104.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->