### PR TITLE
fix(agent): the download cap was the binding floor, and the apply path never raised PHP's limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.105] - 2026-07-30
+
+### Fixed
+
+- The agent's self-update download could fail forever on a slower site. The download was bound by a single 60 second time limit covering the whole transfer, which for the current package works out to roughly 55 kilobytes per second sustained. The sites this feature exists to serve often download at roughly 25 to 40 kilobytes per second, below what that limit demanded, so they would download for the full minute, get cut off partway, discard the incomplete file because it failed its size check, and try again on the next check, failing the same way indefinitely. The limit is now 300 seconds, which asks for roughly 11 kilobytes per second for the same package, so a site downloading at 25 kilobytes per second now finishes comfortably. The control plane side of this was already fixed in an earlier release; this was the remaining limit on the path, and it was the binding one.
+- Separately, nothing raised the PHP execution time limit while an agent update was being applied. Many hosts stop a script after 30 seconds by default, so on those hosts the update could be stopped partway even when the download itself finished within its own budget. The apply step now raises the execution limit to 900 seconds, the same bound the ordinary plugin update path already uses, and does so before the download starts, so the download's own budget always begins against a full clock. The 300 second download budget sits well inside that 900 second limit on purpose: a download that is simply too slow now ends cleanly with a clear error and the partial file discarded, rather than the whole script being killed partway through writing files.
+
 ## [0.61.104] - 2026-07-30
 
 ### Fixed

--- a/apps/agent/includes/support/class-update-checker.php
+++ b/apps/agent/includes/support/class-update-checker.php
@@ -172,6 +172,55 @@ final class UpdateChecker
     /** Outbound GET timeout in seconds. */
     private const GET_TIMEOUT = 10;
 
+    /**
+     * Whole-operation timeout, in seconds, for the PACKAGE download in
+     * verifyDownload(). Distinct from GET_TIMEOUT, which covers the small JSON
+     * manifest fetch. This is a cURL total-transfer cap and not an idle cap: the
+     * transfer gets this long in wall clock from the first byte requested to the
+     * last byte written, so it is exactly the slowest AVERAGE rate a site may
+     * sustain and still self-update.
+     *
+     * WHY 60 WAS TOO LOW. The published package is about 3.4 MiB (3405063 bytes
+     * at the time of writing). At 60s that demanded 3405063/60 = 56751 B/s,
+     * roughly 55 KB/s sustained across the whole transfer. The slow-consumer
+     * band the control plane's own package-stream work measured and set out to
+     * carry sat between 25 and 40 KB/s, entirely BELOW that floor: those sites
+     * downloaded happily for 60 seconds, were cut off mid-file, failed the size
+     * check, and retried the identical failure every six hours forever. The
+     * control plane now bounds PROGRESS rather than duration and carries a
+     * transfer that keeps moving up to a size-derived ceiling
+     * (packageStreamTotalLimit in
+     * apps/api/internal/agent/update_package_limits.go, about 55 minutes for a
+     * package this size), which left this value as the only floor on the path.
+     *
+     * WHY 300. The same package now demands 3405063/300 = 11350 B/s, about
+     * 11 KB/s. That is under half the bottom of the measured band, so a site at
+     * 25 KB/s finishes in 133s and one at 40 KB/s in 83s, both with room to
+     * spare. It is also short enough that a transfer which is genuinely dead
+     * rather than merely slow parks one cron request for five minutes, not for
+     * the quarter hour PHP would otherwise let it hold.
+     *
+     * HOW THIS RELATES TO THE EXECUTION LIMIT, WHICH IS THE POINT. The apply
+     * path arms LongRunningJob::TIME_LIMIT_SECONDS (900s) through
+     * set_time_limit() before any of this runs, and re-arms it immediately
+     * before the transfer below, so this budget always starts against a full
+     * 900s PHP clock. 300 is one third of 900. A download that burns its ENTIRE
+     * budget therefore still leaves 600s for the unzip, the non-atomic copy and
+     * the reactivation that follow it. cURL is guaranteed to give up before PHP
+     * does, which is what makes a too-slow site fail as a clean WP_Error with
+     * the temp file discarded rather than as a max_execution_time fatal partway
+     * through the write, leaving a partial temp file behind. THAT ORDERING IS
+     * THE INVARIANT: this value must stay well under the execution limit, and
+     * moving either number without the other reintroduces the defect.
+     *
+     * COUPLED TO THE PACKAGE SIZE. This is a fixed wall-clock cap sized for a
+     * 3.4 MiB package. MAX_PACKAGE_BYTES permits 64 MiB, and a package near that
+     * would need 218 KB/s to fit in 300s, which is the original defect again at
+     * a different scale. If the shipped package grows materially, recompute the
+     * implied rate before shipping it.
+     */
+    private const PACKAGE_TIMEOUT = 300;
+
     // -------------------------------------------------------------------------
     // Collaborators
     // -------------------------------------------------------------------------
@@ -896,10 +945,32 @@ final class UpdateChecker
             );
         }
 
+        // ARM THE PHP CLOCK IMMEDIATELY BEFORE THE TRANSFER. PACKAGE_TIMEOUT
+        // below is a cURL budget; it says nothing about PHP's own
+        // max_execution_time, which is 30s on a great many hosts and which was
+        // killing this request mid-download with the temp file half written.
+        // applyStagedSelfUpdate() already armed the same bound for the whole
+        // beat-2 request, and this second call is deliberate rather than
+        // redundant: it re-arms the counter from zero so the download's budget
+        // is measured from the transfer's own start instead of inheriting
+        // whatever the manifest round trip above already spent, and it is the
+        // only arming on the other route into this filter (an operator-initiated
+        // or WordPress-auto-update install, which never passes through beat 2).
+        //
+        // Safe to place here because the not-ours bail-out above has already
+        // returned: this can only ever raise the limit for OUR package, never
+        // for the unrelated plugin/theme downloads this global filter also sees.
+        //
+        // Bounded, never 0 (infinite), for the reason set out in
+        // LongRunningJob's class doc and UpdateCommand::APPLY_TIME_LIMIT_SECONDS.
+        if (function_exists('set_time_limit')) {
+            @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- bounded-but-generous cap so PHP cannot kill a slow package download mid-transfer; @-guarded, no-op when disabled
+        }
+
         $response = wp_remote_get(
             $packageUrl,
             [
-                'timeout'     => 60,
+                'timeout'     => self::PACKAGE_TIMEOUT,
                 'redirection' => 0,
                 'stream'      => true,
                 'filename'    => $this->tempFilePath(),
@@ -1290,6 +1361,35 @@ final class UpdateChecker
             // landed some other way. Discard rather than reinstall.
             $this->recordSelfUpdateResult('already_applied', $from, $to, 'On-disk version already at or past the staged target.');
             return;
+        }
+
+        // BEAT 2 IS A LONG-RUNNING BACKGROUND JOB AND HAS TO BE ARMED AS ONE.
+        // Everything below pulls a few MiB over the network and then runs
+        // WordPress's non-atomic install_package() over the result, inside a
+        // wp-cron request whose PHP max_execution_time is 30s on a great many
+        // hosts. Without this the download is killed by PHP long before the HTTP
+        // client's own budget expires and the apply silently never happens: the
+        // record was CLAIMED above, so nothing retries it, and the control plane
+        // is left with a confirm timeout for a build that was cut off mid-fetch.
+        //
+        // Bounded, never 0 (infinite). LongRunningJob's class doc and
+        // UpdateCommand::APPLY_TIME_LIMIT_SECONDS carry the full reasoning:
+        // max_execution_time is the ONE timer whose fatal still runs shutdown
+        // functions, and discarding it leaves only an FPM SIGTERM that runs none
+        // of them. 900s is the same bound every other long job in the agent
+        // uses, and it also keeps a worst-case apply inside the control plane's
+        // SHORTEST beat-3 confirm deadline (20 minutes on loopback cron), so a
+        // site that does hit this cap still gets to report the failure instead
+        // of going quiet past the deadline. PACKAGE_TIMEOUT (300s) is sized to
+        // sit at one third of it, so the transfer can never be the thing that
+        // exhausts this budget.
+        //
+        // Placed HERE and not at the top of the method on purpose: a cron
+        // request runs every due event, and a tick with nothing staged (the
+        // normal state on every site, handled by the early returns above) must
+        // not raise the limit for whatever unrelated event runs after it.
+        if (function_exists('set_time_limit')) {
+            @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- bounded-but-generous cap so a hung self-update apply hits a recoverable max_execution_time fatal rather than only an unrecoverable FPM hard-kill; @-guarded, no-op when disabled
         }
 
         $this->runUpgrade($from, $to);

--- a/apps/agent/tests/AgentSelfUpdateTest.php
+++ b/apps/agent/tests/AgentSelfUpdateTest.php
@@ -613,6 +613,110 @@ final class AgentSelfUpdateTest extends TestCase
     }
 
     /**
+     * BEAT 2 RUNS IN A WP-CRON REQUEST, where PHP's max_execution_time is 30s on
+     * a great many hosts, and it pulls a few MiB over the network before running
+     * WordPress's non-atomic install_package() over the result. Pre-fix there
+     * was no set_time_limit() anywhere on this path, so a download that would
+     * have completed comfortably inside the HTTP client's own budget was killed
+     * by PHP first. The record had already been CLAIMED by then, so nothing
+     * retried it and the control plane saw only a confirm timeout.
+     *
+     * Asserted as INTENT (the call and its argument), not as an observed OS
+     * effect: set_time_limit() is a no-op under most CLI SAPIs and under
+     * disable_functions, so a unit test cannot prove the limit was honoured.
+     *
+     * Bounded, never 0: max_execution_time is the ONE timer whose fatal still
+     * runs shutdown functions, so discarding it leaves only an FPM SIGTERM that
+     * runs none of them.
+     *
+     * Fails against the pre-fix code: $limits is empty.
+     */
+    public function test_apply_raises_a_bounded_php_execution_limit_before_upgrading(): void
+    {
+        /** @var list<int> $limits */
+        $limits = [];
+        Functions\when('set_time_limit')->alias(function (int $seconds) use (&$limits): bool {
+            $limits[] = $seconds;
+
+            return true;
+        });
+
+        $this->options[UpdateChecker::OPTION_STAGED] = [
+            'from_version' => '0.10.5',
+            'to_version'   => $this->targetVersion,
+            'staged_at'    => time(),
+            'expires_at'   => time() + UpdateChecker::STAGED_TTL_SECONDS,
+            'token'        => 'live-token',
+        ];
+
+        $this->makeChecker()->applyStagedSelfUpdate('live-token');
+
+        $this->assertNotSame(
+            [],
+            $limits,
+            'beat 2 must raise the PHP execution limit before any download; without it max_execution_time (30s on many hosts) kills the apply'
+        );
+        $this->assertSame(
+            900,
+            $limits[0],
+            'the apply cap must be the same bounded 900s every other long-running agent job uses, never 0 (infinite)'
+        );
+        $this->assertGreaterThan(
+            300,
+            $limits[0],
+            'the execution limit must exceed the 300s package download budget, so cURL gives up before PHP does'
+        );
+    }
+
+    /**
+     * A wp-cron request runs EVERY due event. A tick with nothing staged is the
+     * normal state on every site, and it must not raise the execution limit for
+     * whatever unrelated event runs after it. This is why the raise sits after
+     * the claim rather than at the top of the method.
+     */
+    public function test_apply_leaves_the_execution_limit_alone_when_nothing_is_staged(): void
+    {
+        /** @var list<int> $limits */
+        $limits = [];
+        Functions\when('set_time_limit')->alias(function (int $seconds) use (&$limits): bool {
+            $limits[] = $seconds;
+
+            return true;
+        });
+
+        $this->makeChecker()->applyStagedSelfUpdate('some-token');
+
+        $this->assertSame([], $limits, 'a cron tick with nothing staged must not touch the execution limit of the request');
+    }
+
+    /**
+     * An expired stage is discarded, not applied, so it must not raise the limit
+     * either: no download and no copy follow it.
+     */
+    public function test_apply_leaves_the_execution_limit_alone_for_an_expired_record(): void
+    {
+        /** @var list<int> $limits */
+        $limits = [];
+        Functions\when('set_time_limit')->alias(function (int $seconds) use (&$limits): bool {
+            $limits[] = $seconds;
+
+            return true;
+        });
+
+        $this->options[UpdateChecker::OPTION_STAGED] = [
+            'from_version' => '0.10.5',
+            'to_version'   => $this->targetVersion,
+            'staged_at'    => time() - (UpdateChecker::STAGED_TTL_SECONDS + 120),
+            'expires_at'   => time() - 120,
+            'token'        => 'stale-token',
+        ];
+
+        $this->makeChecker()->applyStagedSelfUpdate('stale-token');
+
+        $this->assertSame([], $limits, 'a discarded stage does no work, so it must not raise the execution limit');
+    }
+
+    /**
      * A stale duplicate event from an earlier stage must not consume the record
      * belonging to the CURRENT stage.
      */

--- a/apps/agent/tests/UpdateCheckerTest.php
+++ b/apps/agent/tests/UpdateCheckerTest.php
@@ -998,6 +998,191 @@ final class UpdateCheckerTest extends TestCase
         @unlink($result); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- test-only temp-file cleanup
     }
 
+    // ---- package download budget + PHP execution limit (0.61.105) ----
+
+    /**
+     * THE DOWNLOAD BUDGET. wp_remote_get's 'timeout' is a cURL WHOLE-operation
+     * cap, so it is the slowest average rate a site may sustain and still
+     * self-update. At the old 60s a 3.4 MiB package demanded about 55 KB/s,
+     * which is above the entire 25 to 40 KB/s slow-consumer band the control
+     * plane's package-stream work exists to carry: those sites were cut off
+     * mid-file and failed the size check every six hours forever. 300s puts the
+     * demand at about 11 KB/s.
+     *
+     * The three security-relevant download arguments are asserted alongside it,
+     * because widening a timeout is exactly the kind of edit that quietly takes
+     * 'redirection' => 0 with it.
+     *
+     * Fails against the pre-fix code: the timeout assertion sees 60.
+     */
+    public function test_verifyDownload_uses_the_raised_package_download_budget(): void
+    {
+        $packageContent = str_repeat('Q', 128);
+        $claims         = $this->makeClaims([
+            'version'        => '0.11.0',
+            'package_size'   => 128,
+            'package_sha256' => hash('sha256', $packageContent),
+        ]);
+        $envelopeJson = (string) json_encode($this->signClaims($claims));
+
+        $callCount     = 0;
+        $downloadArgs  = null;
+        Functions\when('wp_remote_get')->alias(
+            function (string $url, array $args = []) use ($envelopeJson, &$callCount, &$downloadArgs, $packageContent) {
+                $callCount++;
+                if ($callCount === 1) {
+                    return ['response' => ['code' => 200], 'body' => $envelopeJson, 'filename' => ''];
+                }
+                $downloadArgs = $args;
+                $tmpFile      = $args['filename'] ?? (sys_get_temp_dir() . '/wpmgr-test-' . bin2hex(random_bytes(4)) . '.zip');
+                file_put_contents($tmpFile, $packageContent);
+
+                return ['response' => ['code' => 200], 'body' => '', 'filename' => $tmpFile];
+            }
+        );
+        Functions\when('wp_remote_retrieve_response_code')->alias(fn ($response) => $response['response']['code'] ?? 0);
+        Functions\when('wp_remote_retrieve_body')->alias(fn ($response) => $response['body'] ?? '');
+        Functions\when('is_wp_error')->justReturn(false);
+
+        $result = $this->makeChecker()->verifyDownload(
+            false,
+            UpdateChecker::PACKAGE_SENTINEL,
+            null,
+            ['plugin' => UpdateChecker::PLUGIN_KEY]
+        );
+
+        $this->assertIsArray($downloadArgs, 'precondition: the package download must have been attempted');
+        $this->assertSame(
+            300,
+            $downloadArgs['timeout'],
+            'the package download budget must be 300s: 60s demanded about 55 KB/s of a 3.4 MiB package, above the whole slow-consumer band'
+        );
+        $this->assertSame(0, $downloadArgs['redirection'], 'redirection must stay 0: it is part of the anti-SSRF boundary');
+        $this->assertTrue($downloadArgs['stream'], 'the package must still stream to disk rather than through memory');
+        $this->assertIsString($downloadArgs['filename']);
+
+        if (is_string($result) && is_file($result)) {
+            @unlink($result); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- test-only temp-file cleanup
+        }
+    }
+
+    /**
+     * THE EXECUTION LIMIT, AND ITS ORDERING AGAINST THE DOWNLOAD. The cURL
+     * budget above says nothing about PHP's own max_execution_time, which is 30s
+     * on a great many hosts. Pre-fix there was no set_time_limit() anywhere on
+     * this path, so a download that finished well inside the HTTP budget was
+     * killed by PHP first and the apply silently never happened.
+     *
+     * Asserted as INTENT (the call and its argument), never as an observed OS
+     * effect: set_time_limit() is a no-op under most CLI SAPIs and under
+     * disable_functions, so proving the limit was honoured is not something a
+     * unit test can do.
+     *
+     * The ordering assertion is the load-bearing half. 300 must sit under 900
+     * AND the 900 must be armed before the transfer starts, or PHP fires first
+     * and leaves a partial temp file behind, which is the shape of the original
+     * bug.
+     *
+     * Fails against the pre-fix code: $limits is empty, so both the "before the
+     * download" and the 900 assertions fail.
+     */
+    public function test_verifyDownload_raises_the_php_execution_limit_before_downloading(): void
+    {
+        $packageContent = str_repeat('R', 96);
+        $claims         = $this->makeClaims([
+            'version'        => '0.11.0',
+            'package_size'   => 96,
+            'package_sha256' => hash('sha256', $packageContent),
+        ]);
+        $envelopeJson = (string) json_encode($this->signClaims($claims));
+
+        /** @var list<string> $sequence */
+        $sequence = [];
+        /** @var list<int> $limits */
+        $limits = [];
+
+        Functions\when('set_time_limit')->alias(function (int $seconds) use (&$sequence, &$limits): bool {
+            $limits[]   = $seconds;
+            $sequence[] = 'set_time_limit:' . $seconds;
+
+            return true;
+        });
+
+        $callCount = 0;
+        Functions\when('wp_remote_get')->alias(
+            function (string $url, array $args = []) use ($envelopeJson, &$callCount, &$sequence, $packageContent) {
+                $callCount++;
+                if ($callCount === 1) {
+                    $sequence[] = 'manifest_fetch';
+
+                    return ['response' => ['code' => 200], 'body' => $envelopeJson, 'filename' => ''];
+                }
+                $sequence[] = 'package_download';
+                $tmpFile    = $args['filename'] ?? (sys_get_temp_dir() . '/wpmgr-test-' . bin2hex(random_bytes(4)) . '.zip');
+                file_put_contents($tmpFile, $packageContent);
+
+                return ['response' => ['code' => 200], 'body' => '', 'filename' => $tmpFile];
+            }
+        );
+        Functions\when('wp_remote_retrieve_response_code')->alias(fn ($response) => $response['response']['code'] ?? 0);
+        Functions\when('wp_remote_retrieve_body')->alias(fn ($response) => $response['body'] ?? '');
+        Functions\when('is_wp_error')->justReturn(false);
+
+        $result = $this->makeChecker()->verifyDownload(
+            false,
+            UpdateChecker::PACKAGE_SENTINEL,
+            null,
+            ['plugin' => UpdateChecker::PLUGIN_KEY]
+        );
+
+        $this->assertContains('package_download', $sequence, 'precondition: the package download must have been attempted');
+        $this->assertNotSame([], $limits, 'the download path must raise PHP execution limit; without it max_execution_time (30s on many hosts) kills a slow but healthy download');
+
+        $limitIndex    = array_search('set_time_limit:900', $sequence, true);
+        $downloadIndex = array_search('package_download', $sequence, true);
+        $this->assertIsInt($limitIndex, 'the execution limit must be raised to the bounded 900s job cap');
+        $this->assertLessThan(
+            $downloadIndex,
+            $limitIndex,
+            'the execution limit must be raised BEFORE the transfer starts, or PHP kills the request mid-download and leaves a partial temp file'
+        );
+
+        foreach ($limits as $seconds) {
+            $this->assertSame(900, $seconds, 'bounded, never 0 (infinite): only max_execution_time still runs shutdown functions');
+            $this->assertGreaterThan(
+                300,
+                $seconds,
+                'the execution limit must exceed the 300s download budget, so cURL always gives up before PHP does'
+            );
+        }
+
+        if (is_string($result) && is_file($result)) {
+            @unlink($result); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- test-only temp-file cleanup
+        }
+    }
+
+    /**
+     * The limit raise sits AFTER the not-ours bail-out, so this global filter
+     * cannot reach into an unrelated plugin's download and change the execution
+     * limit of a request that has nothing to do with the agent.
+     */
+    public function test_verifyDownload_does_not_touch_the_execution_limit_for_another_plugin(): void
+    {
+        /** @var list<int> $limits */
+        $limits = [];
+        Functions\when('set_time_limit')->alias(function (int $seconds) use (&$limits): bool {
+            $limits[] = $seconds;
+
+            return true;
+        });
+
+        $checker = $this->makeChecker();
+        $checker->verifyDownload(false, 'https://example.com/other-plugin.zip', null, ['plugin' => 'other/other.php']);
+        $checker->verifyDownload(false, null, null, ['plugin' => 'other/other.php']);
+
+        $this->assertSame([], $limits, 'a download that is not ours must leave the execution limit alone');
+    }
+
     public function test_verifyDownload_sha256_mismatch_returns_wp_error_and_unlinks(): void
     {
         $checker = $this->makeChecker();

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.104
+ * Version:           0.61.105
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.104');
+define('WPMGR_AGENT_VERSION', '0.61.105');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/api/internal/agent/update_package_handler.go
+++ b/apps/api/internal/agent/update_package_handler.go
@@ -321,21 +321,22 @@ func (h *UpdateHandler) packageDownload(c *gin.Context) {
 	// update channel for every site on the instance. packageStreamTotalLimit
 	// bounds the TOTAL for that reason, derived from the package size at 1 KB/s
 	// and clamped to [30 min, 2 h], which is two orders of magnitude clear of the
-	// slowest legitimate consumer and 51x clear of what the agent's own 60s
-	// budget already demands of it. The arithmetic, and why the token's expiry is
+	// slowest legitimate consumer and far clear of what the agent's own download
+	// budget demands of it. The arithmetic, and why the token's expiry is
 	// deliberately not revalidated mid-stream instead, are on that function.
 	//
-	// THE END-TO-END FLOOR THAT REMAINS IS THE AGENT'S, AND IT IS UNCHANGED. The
-	// agent downloads with wp_remote_get('timeout' => 60) in
-	// apps/agent/includes/support/class-update-checker.php, a WHOLE-operation cap
-	// this change deliberately leaves alone. A site therefore still has to average
-	// package_size/60s, about 52 KB/s for a 3 MiB package, where the control
-	// plane's old 15s cap demanded roughly 200 KB/s. Below that floor the download
-	// still fails; what changed is that it now fails on the AGENT side as a
-	// WP_Error that retries on the next check, instead of arriving as a truncated
-	// zip that fails the size check every six hours forever. Anyone moving the
-	// agent's 60s moves this floor, and after this change it is the ONLY floor
-	// left on the path.
+	// THE END-TO-END FLOOR THAT REMAINS IS THE AGENT'S. The agent downloads with
+	// wp_remote_get in apps/agent/includes/support/class-update-checker.php using
+	// a WHOLE-operation cap, raised from 60s to 300s in agent 0.61.105 precisely
+	// because the old value was the binding constraint once the control plane
+	// stopped being one. At 60s a 3 MiB package demanded about 55 KB/s, which sat
+	// ABOVE the 25 to 40 KB/s band this whole path exists to carry: those sites
+	// downloaded for a full minute, were cut off, failed the size check, and
+	// retried the identical failure forever. At 300s the same package demands
+	// about 11 KB/s. Below that the download still fails, but on the AGENT side as
+	// a WP_Error that retries on the next check rather than arriving truncated.
+	// Anyone moving the agent's download cap moves this floor, and it is the ONLY
+	// floor left on the path.
 	//
 	// streamCtx is this request's context plus a cancel that fires the moment this
 	// handler gives up, so when the WRITE side is the one that timed out the

--- a/apps/api/internal/agent/update_package_limits.go
+++ b/apps/api/internal/agent/update_package_limits.go
@@ -240,11 +240,14 @@ var errPackageStreamTotal = errors.New("agent: package stream exceeded its whole
 // above the 1 KB/s that ceiling demands:
 //
 //   - THE AGENT'S OWN BUDGET, which is the binding one. It downloads with
-//     wp_remote_get('timeout' => 60), a WHOLE-operation cap, so a 3 MiB package
-//     has to average 3145728/60 = 52428 B/s, about 52 KB/s. That is 51x the rate
-//     this ceiling asks for, and in wall clock the agent has abandoned the
-//     request 51 minutes before the ceiling could fire. A transfer that reaches
-//     this ceiling has no agent waiting on the other end of it.
+//     wp_remote_get using a WHOLE-operation cap, 300s as of agent 0.61.105, so a
+//     3 MiB package has to average 3145728/300 = 10486 B/s, about 11 KB/s. That
+//     is still an order of magnitude above the rate this ceiling asks for, and in
+//     wall clock the agent has abandoned the request roughly 46 minutes before
+//     the ceiling could fire. A transfer that reaches this ceiling has no agent
+//     waiting on the other end of it. The cap was 60s before 0.61.105, which
+//     demanded about 55 KB/s and therefore sat ABOVE the 25 to 40 KB/s band this
+//     path exists to carry: raising it is what let those sites finish at all.
 //   - THE MEASURED SLOW-CONSUMER BAND. The population this work exists to
 //     protect sat between 25 and 40 KB/s (see streamPackage's table), which is
 //     25x to 40x the ceiling's floor.
@@ -262,7 +265,7 @@ var errPackageStreamTotal = errors.New("agent: package stream exceeded its whole
 // Enforcing it mid-body would cap every response at five minutes of wall clock
 // with 200 and Content-Length already flushed, which is the original defect
 // verbatim, just with a five minute cap instead of a 15s one. It would also bind
-// the control plane to one agent's timeout: the 60s budget above is documented
+// the control plane to one agent's timeout: the agent budget above is documented
 // as movable, and an operator who raises it for genuinely slow sites would find
 // this route truncating them for a reason no log on either side names. The
 // presigned-storage design this replaced checked its expiry at request start and
@@ -322,7 +325,7 @@ var (
 // blocks depends on the consumer's read granularity and on TCP window-update
 // timing, neither of which the control plane can observe or predict. The real
 // floor sat between 25 and 40 KB/s rather than the 3.28 KB/s the chunk size
-// reasons to, which for a small package is inside the range the agent's own 60s
+// reasons to, which for a small package is inside the range the agent's own
 // budget still allows: a 30 KB/s site pulling a 1.2 MiB package has 41s of agent
 // budget and would be cut off here at about 840 KB, with 200 and Content-Length
 // already flushed, so it fails its size and sha256 check and never self-updates.

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,22 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.105",
+    date: "2026-07-30",
+    summary: "Agent updates now complete on slower sites instead of failing forever.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "The agent's self-update download was bound by a single 60 second limit for the whole transfer, which needed roughly 55 kilobytes per second sustained. Sites downloading at the roughly 25 to 40 kilobytes per second this feature is meant to serve were cut off every time, discarded the incomplete file, and retried forever with no way to finish. The limit is now 300 seconds, comfortably covering slower connections.",
+      },
+      {
+        tag: "Fixed",
+        text: "Nothing raised PHP's execution time limit while an update was being applied, so on hosts that stop scripts after 30 seconds by default, an update could be cut off even within its own download budget. The apply step now raises it to 900 seconds, the same bound the ordinary plugin update path uses, before the download starts.",
+      },
+    ],
+    featureLinks: [{ label: "Updates", href: "/features/updates/" }],
+  },
+  {
     version: "0.61.104",
     date: "2026-07-30",
     summary: "Fleet agent updates work now: the command that starts them was rejecting every request, and a second command had been silently broken since launch.",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.104 / open source",
+  badge: "v0.61.105 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.104
+  version: 0.61.105
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Ships as 0.61.105. Agent-only, plus two corrected control-plane comments.

## The finding that matters

**The agent's own 60 second download cap was the real floor the whole time.**

`wp_remote_get`'s `timeout` is a whole-operation cap, so a 3 MiB package had to average about **55 KB/s**. The population this entire path exists to serve measures **25 to 40 KB/s** — *below* that.

Those sites downloaded for a full minute, were cut off partway, failed the size check, discarded the partial file, and retried the identical failure on every check, indefinitely.

That's worth sitting with: the control plane was hardened across several releases — progress bounding instead of duration, a streaming rewrite, a whole-transfer ceiling. All of it real work. **None of it was enough**, because the agent kept demanding a rate those sites could never reach. We fixed everything around the binding constraint before fixing the constraint.

Now 300s, about 11 KB/s for the same package. A 25 KB/s site finishes in ~133s.

## PHP could kill the apply regardless

Nothing raised `max_execution_time` on this path, and **30 seconds is a common host default**. So the request could die partway even when the download was comfortably inside its own budget — and the resulting run reports `unconfirmed`, which looks identical to "WP-Cron never fired". A completely different diagnosis for the same symptom.

The apply now calls `set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS)` (900), reusing the bound the ordinary update path already uses rather than inventing a second number.

## The ordering is the point

900 is armed **before** the transfer starts, so the 300s budget always begins against a full clock, and cURL is guaranteed to give up before PHP does.

A too-slow site therefore fails as a clean `WP_Error` with the temp file discarded, never as a `max_execution_time` fatal partway through writing files. Getting that order wrong in either direction *is* the bug being fixed.

Placement is deliberate:
- **after** the staged-record claim, not at the top of the method, so an ordinary cron tick with nothing staged does not raise the limit for whatever unrelated event runs next
- **after** the not-ours bail-out in the download filter, so this global hook cannot change another plugin's download limit

## Also

Corrects the control-plane comments still asserting the agent demanded 52 KB/s at 60s and calling that the only remaining floor. Left alone they would point the next reader at the wrong constraint.

## Verification

- Agent: phpunit **2923** (+6), phpcs 0 errors, `wp plugin check` **0 errors**
- Go: build/vet clean, `internal/agent` passes
- Three tests confirmed failing against pre-fix source by stashing the file individually; the ordering assertion (limit raised *before* download, and 900 > 300) is the load-bearing one
- Three negative-space tests pass in both states: nothing staged, an expired record, and another plugin's download all leave the limit alone
- Verified unreachable from the wordpress.org build two ways: the file is absent from the staged zip, and the build-time guard test is green

## Coverage note worth recording

`phpcs.xml.dist:18` excludes `class-update-checker.php` because it never ships to wordpress.org, and Plugin Check cannot see it either. **So neither gate lints the file this change touches.** It was linted out of tree against the same ruleset: 0 errors, 48 pre-existing warnings, and neither added line warns.

That is a real hole in the most security-sensitive file the agent has, and worth closing separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent self-updates on slower sites with longer download and installation time limits.
  * Reduced failures during staged update application by allowing sufficient execution time.
  * Improved update and rollout status reporting: refused updates are now recorded as failures while retaining the agent’s explanation.
* **Release**
  * Released version **0.61.105**, with updated version information across the product and public changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->