### PR TITLE
fix(agent): the arm reported a schedule it never verified, and the apply depended on WP-Cron alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.106] - 2026-07-30
+
+### Fixed
+
+- A fleet agent update could report that a site had accepted the job, then nothing would happen, and the run would report twenty minutes later that it could not be confirmed. The agent asks WordPress to schedule the actual work for a moment later, in a separate request, and WordPress can decline that request, for example when another plugin on the site blocks scheduling. The agent was not checking whether the request was accepted, so it told WPMgr the work was scheduled whether or not it actually was. The agent now checks, and reports a clear error immediately if the work could not be scheduled, instead of leaving the rollout waiting for a confirmation that was never coming.
+- The step that downloads and installs a new agent version ran only from WordPress's own scheduled task system. On a site where that system is blocked, unreliable, or simply never triggered, the update would never be applied, even though everything else about the site worked normally. WPMgr's other background work was made independent of that scheduler some releases ago for exactly this reason; this one step had not been. It now works the same way: it runs on an ordinary page request whenever an update is waiting, so a site with a blocked scheduler updates normally. The install itself still happens in a separate request from the one that starts it, which is deliberate, since the agent cannot safely replace its own files during the same request that has to report the result.
+- Two of the situations where the install step decides not to proceed used to leave no record at all, so an operator could see only that nothing had happened. Every outcome is now recorded and reported back, so the dashboard can say why. The agent also now guarantees only one install can run at a time, even if two requests start at once.
+
 ## [0.61.105] - 2026-07-30
 
 ### Fixed

--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -1001,6 +1001,34 @@ final class Plugin
             // upgrade work starts, and nothing here schedules a follow-up.
             add_action(UpdateChecker::HOOK_APPLY, [$this->updateChecker, 'applyStagedSelfUpdate'], 10, 1);
 
+            // BEAT 2, SECOND ENTRY POINT: the WP-Cron-INDEPENDENT backstop.
+            // The cron event above used to be the only way beat 2 ever ran, so
+            // a single site whose loopback cron is blocked, whose
+            // wp_schedule_single_event was short-circuited by another plugin,
+            // or that simply never gets a tick, staged an update that nothing
+            // was left to apply. It then sat at "scheduled" until the control
+            // plane's confirm window ran out, on a site that was otherwise
+            // perfectly healthy and answering every request it was sent.
+            //
+            // This is the same treatment GitHub issues #226 and #232 already
+            // gave the snapshot reclaim and the stalled-backup reaper, and for
+            // the same reason: every request the agent serves (including the
+            // control plane's own heartbeat and uptime hits) is a far more
+            // reliable clock than WP-Cron. maybeApplyStagedSelfUpdate() is
+            // gated on a staged record actually existing, which on essentially
+            // every request of essentially every site is false, and the record
+            // is autoloaded so that gate costs no query while one is live.
+            //
+            // BEAT 2 STILL RUNS IN A DIFFERENT REQUEST FROM THE ARM, and that
+            // isolation is the whole reason the three-beat design exists: the
+            // swap must not happen inside the request that has to report the
+            // outcome. plugins_loaded is what preserves it. On the ARM's own
+            // request this hook fires during the plugin-loading phase, long
+            // before the REST callback that writes the staged record runs, so
+            // the gate correctly finds nothing and arms nothing. Only a LATER
+            // request can see the record.
+            add_action('plugins_loaded', [$this, 'maybeApplyStagedSelfUpdate']);
+
             // BEAT 3 (CONFIRM): the only trustworthy success signal is the NEW
             // code phoning home, so the freshly-installed build pushes metadata
             // once on its first boot rather than waiting up to 30 minutes for
@@ -1842,6 +1870,91 @@ final class Plugin
         add_action('shutdown', [$this, 'pushVersionChangedMetadata'], 9998);
 
         return true;
+    }
+
+    /**
+     * BEAT 2 (APPLY), the WP-Cron-independent entry point. See registerHooks()'s
+     * binding comment for the root cause this closes and for why plugins_loaded
+     * is the hook that keeps the arm's own request from ever applying.
+     *
+     * Mirrors maybeGcSnapshots() / maybeSweepStalledBackups() in shape:
+     *   - Gated on isEnrolled(): a site with no control plane is never told to
+     *     update itself, so it can never have a staged record.
+     *   - Gated on a staged record EXISTING, which is the cheap part. There is
+     *     no separate throttle option because the record IS the throttle: it is
+     *     claimed atomically and deleted by the first caller that applies it, so
+     *     the work runs at most once per stage no matter how many requests see
+     *     it. That is a stronger guarantee than a time window, and it needs no
+     *     second option to maintain.
+     *   - Wrapped in try/catch: an update that cannot be applied right now must
+     *     never break the request that happened to notice it.
+     *
+     * THE APPLY IS DEFERRED TO 'shutdown', WHICH IS NOT OPTIONAL. Unlike every
+     * other plugins_loaded backstop in this class, the work here downloads a
+     * package and then overwrites the agent's own directory. Running that inline
+     * at plugins_loaded would replace this plugin's files while WordPress is
+     * still only part-way through booting the very request executing them, so
+     * anything autoloaded later in that request could come from the new build
+     * while the loaded classes came from the old one. At shutdown the request's
+     * own work is finished and nothing is left to mix. The response is released
+     * first through the SAPI-aware ConnectionFinisher (fastcgi on PHP-FPM,
+     * litespeed_finish_request on OpenLiteSpeed, portable flush elsewhere), so
+     * whoever made the request is never held open for the upgrade.
+     *
+     * @return bool True when this call armed the apply. Returned for
+     *              testability; WordPress ignores an action callback's return.
+     */
+    public function maybeApplyStagedSelfUpdate(): bool
+    {
+        if ($this->updateChecker === null) {
+            return false;
+        }
+        if (!function_exists('add_action')) {
+            return false;
+        }
+        if (!$this->settings->isEnrolled()) {
+            return false;
+        }
+
+        try {
+            if (!$this->updateChecker->hasStagedSelfUpdate()) {
+                return false;
+            }
+        } catch (\Throwable $e) {
+            return false;
+        }
+
+        add_action('shutdown', [$this, 'applyStagedSelfUpdateOnShutdown'], 9997);
+
+        return true;
+    }
+
+    /**
+     * Shutdown callback for the request-bound apply beat.
+     *
+     * Public so WordPress can call it as a named hook callback. Swallows every
+     * failure: the staged record is claimed before any upgrade work starts, so
+     * a throw here is already recorded as an outcome by the self-updater and
+     * must never disturb the request it rides on.
+     *
+     * Passes NO stage token on purpose. The token exists so a STALE cron event
+     * cannot consume a newer stage; this entry point is not an event and cannot
+     * be stale, so it applies whatever is staged right now.
+     *
+     * @return void
+     */
+    public function applyStagedSelfUpdateOnShutdown(): void
+    {
+        if ($this->updateChecker === null) {
+            return;
+        }
+
+        try {
+            (new ConnectionFinisher())->finish();
+            $this->updateChecker->applyStagedSelfUpdate('');
+        } catch (\Throwable $e) {
+            DebugLog::write('WPMgr Agent: request-bound self-update apply failed: ' . $e->getMessage());
+        }
     }
 
     /**

--- a/apps/agent/includes/support/class-update-checker.php
+++ b/apps/agent/includes/support/class-update-checker.php
@@ -124,11 +124,43 @@ final class UpdateChecker
 
     /**
      * wp-option holding the single staged self-update record written by beat 1
-     * (ARM). Non-autoloaded: read only by the apply cron. Shape:
+     * (ARM). Shape:
      *   ['from_version'=>string,'to_version'=>string,'staged_at'=>int,
      *    'expires_at'=>int,'token'=>string]
+     *
+     * AUTOLOADED on purpose, which is a change from the original cron-only
+     * design. Beat 2 is no longer reachable only through the cron event: Plugin
+     * binds a request-bound backstop on plugins_loaded whose ENTIRE gate is
+     * "does this record exist", so while a record is live it is read on every
+     * request the site serves. An autoloaded row rides the alloptions read
+     * WordPress already performs on every boot, so the gate costs no extra query
+     * in the one window where it is read often. The record is deleted the moment
+     * it is claimed, so it exists for minutes in the whole life of a site.
      */
     public const OPTION_STAGED = 'wpmgr_agent_self_update_staged';
+
+    /**
+     * wp-option marking an apply that is CURRENTLY RUNNING: a unix timestamp
+     * written by the request that won the claim, deleted when that apply reaches
+     * any terminal path.
+     *
+     * The atomic claim of OPTION_STAGED (claimStagedRecord) already guarantees
+     * that exactly one caller ever applies a GIVEN staged record, which is what
+     * keeps the cron event and the request-bound backstop from both applying the
+     * same stage. This marker covers the other overlap, the one the backstop
+     * newly widens: a control plane that arms a SECOND update while the first is
+     * still copying files stages a second record, and the backstop would claim
+     * it on the very next request. Two Plugin_Upgrader runs over the agent's own
+     * directory at once is precisely the outcome the three-beat design exists to
+     * prevent.
+     *
+     * Read only on the rare request that has ALREADY found a staged record, so
+     * it is deliberately not autoloaded. Stale-safe: a marker older than
+     * LongRunningJob::TIME_LIMIT_SECONDS is ignored, the same bound the apply
+     * itself runs under, so a hard-killed apply cannot block the next one for
+     * longer than it could legitimately have run.
+     */
+    private const OPTION_APPLYING = 'wpmgr_agent_self_update_applying';
 
     /**
      * Seconds a staged record stays claimable. Beat 2 discards (never retries)
@@ -1180,10 +1212,11 @@ final class UpdateChecker
     // request:
     //   1. ARM    (stageSelfUpdate, inside the signed command request):
     //             verify only. Nothing on disk moves.
-    //   2. APPLY  (applyStagedSelfUpdate, the cron request): a SEPARATE
-    //             WordPress bootstrap runs Plugin_Upgrader::upgrade(). No CP
-    //             response rides on this request, so a mid-copy death is not a
-    //             lost answer.
+    //   2. APPLY  (applyStagedSelfUpdate): a SEPARATE WordPress bootstrap runs
+    //             Plugin_Upgrader::upgrade(). No CP response rides on that
+    //             request, so a mid-copy death is not a lost answer. Reached
+    //             from the cron event AND from a request-bound plugins_loaded
+    //             backstop, so a site whose WP-Cron never fires still applies.
     //   3. CONFIRM: the only trustworthy success signal is the NEW code
     //             phoning home: the version-changed boot metadata push in
     //             Plugin. A "scheduled" acknowledgement is NEVER success.
@@ -1279,7 +1312,7 @@ final class UpdateChecker
             'expires_at'   => $now + self::STAGED_TTL_SECONDS,
             'token'        => $token,
         ];
-        update_option(self::OPTION_STAGED, $record, false);
+        update_option(self::OPTION_STAGED, $record, true);
 
         // Drop any previous outcome so a stale 'failed' from an earlier run can
         // never be read back as the result of THIS one.
@@ -1291,10 +1324,45 @@ final class UpdateChecker
         // stage a distinct event (WP silently drops a duplicate single event
         // scheduled within 10 minutes of an identical one), and it lets beat 2
         // ignore a stale event left over from an earlier stage.
-        wp_schedule_single_event($now, self::HOOK_APPLY, [$token]);
+        $scheduled = wp_schedule_single_event($now, self::HOOK_APPLY, [$token]);
 
         if (function_exists('spawn_cron')) {
             @spawn_cron(); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- spawn_cron may emit a harmless notice when DISABLE_WP_CRON is set; @-suppressed intentionally
+        }
+
+        // THIS RETURN VALUE USED TO BE DISCARDED, AND THAT WAS THE DEFECT.
+        // wp_schedule_single_event answers false whenever another plugin
+        // short-circuits the pre_schedule_event filter, whenever a schedule_event
+        // filter returns something falsy, and for a duplicate single event
+        // scheduled within ten minutes of an identical one. Beat 1 reported
+        // "scheduled" in every one of those cases, so the control plane armed a
+        // confirmation poll and then sat out its entire confirm window waiting
+        // for a cron beat that had never been created. A site can be perfectly
+        // healthy and chatty while this happens, which is what made it so hard
+        // to read from the outside.
+        //
+        // The staged record is deliberately KEPT here rather than rolled back.
+        // The apply no longer depends on the cron event at all: Plugin's
+        // request-bound plugins_loaded backstop applies the very same record on
+        // the next request this site serves, which on any site the control plane
+        // can reach is seconds away. Deleting the record would throw that
+        // recovery away and leave a fleet permanently unable to update itself
+        // for as long as the offending filter is installed. The answer is still
+        // "error" because the arm genuinely failed to do the thing it tried to
+        // do, and an immediate, named failure is worth far more to an operator
+        // than a twenty-minute silence. A re-run then answers already_scheduled
+        // (record still live) or up_to_date (backstop already applied it), and
+        // both of those resolve correctly at the control plane.
+        if ($scheduled === false || (function_exists('is_wp_error') && is_wp_error($scheduled))) {
+            return $this->stageAnswer(
+                'error',
+                $onDisk,
+                '',
+                'WordPress refused to schedule the apply event, so no cron beat exists for this stage '
+                . '(a plugin or filter on this site is blocking wp_schedule_single_event). The stage was '
+                . 'kept and the agent applies it from its own request-bound backstop instead; re-run this '
+                . 'command to pick up the outcome.'
+            );
         }
 
         $answer = $this->stageAnswer('scheduled', $onDisk, $toVersion, 'Self-update staged; apply runs in a separate request.');
@@ -1304,48 +1372,162 @@ final class UpdateChecker
     }
 
     /**
-     * BEAT 2 (APPLY). Runs in the wp-cron request, a SEPARATE WordPress
-     * bootstrap from the one that answered the CP. No CP response rides on this
-     * request, so a death mid-copy is not a lost answer.
+     * True when a staged self-update record is present. This is the WHOLE gate
+     * for Plugin's request-bound plugins_loaded backstop, and it is why that
+     * backstop is close to free: on the overwhelmingly common boot there is no
+     * record, and OPTION_STAGED is autoloaded so a live one costs no query at
+     * all.
      *
-     * Single-shot by construction: the staged record is CLAIMED (deleted)
-     * before any upgrade work begins, so a request that dies partway can never
-     * be retried by a later cron tick. An expired record is discarded, not
-     * retried. Nothing here schedules a follow-up event.
+     * Deliberately does NOT apply the expiry. An expired record still needs an
+     * apply beat to run so that beat can DISCARD it and record 'expired', which
+     * is the only way that outcome ever reaches the control plane.
+     *
+     * @return bool
+     */
+    public function hasStagedSelfUpdate(): bool
+    {
+        if (defined('WPMGR_WPORG_BUILD') && constant('WPMGR_WPORG_BUILD')) {
+            return false;
+        }
+
+        return $this->readStagedRecord() !== null;
+    }
+
+    /**
+     * BEAT 2 (APPLY). Runs in a SEPARATE WordPress bootstrap from the one that
+     * answered the control plane. No CP response rides on this request, so a
+     * death mid-copy is not a lost answer.
+     *
+     * TWO ENTRY POINTS, ONE APPLY. The cron event (HOOK_APPLY) was originally
+     * the only one, and a single blocked or never-firing WP-Cron therefore
+     * stranded the whole update with nothing left to retry it. Plugin now ALSO
+     * binds a request-bound backstop on plugins_loaded, the same WP-Cron-
+     * independence treatment GitHub issues #226 and #232 already applied to the
+     * snapshot reclaim and the stalled-backup reaper. Both entry points land
+     * here, and the claim below is what keeps them from ever both applying.
+     *
+     * THE REQUEST-ISOLATION INVARIANT IS PRESERVED, AND IT IS LOAD-BEARING. The
+     * swap must never happen inside the request that has to report the outcome.
+     * The backstop's gate runs on plugins_loaded, which on the arm's own request
+     * fires long BEFORE the REST callback writes the staged record, so the arm
+     * request finds nothing and arms nothing. Every apply therefore still
+     * happens in a later request than the arm.
+     *
+     * Single-shot by construction: the staged record is CLAIMED before any
+     * upgrade work begins, with a single atomic statement rather than a
+     * read-then-delete, so two racing requests cannot both proceed. A request
+     * that dies partway can never be retried. An expired record is discarded,
+     * not retried. Nothing here schedules a follow-up event.
      *
      * Reuses the existing upgrader_pre_download / upgrader_source_selection
      * chain unchanged; there is zero new download, verification or unzip code
      * on this path.
      *
-     * @param string $token Stage token carried in the cron event args.
+     * EVERY EXIT LEAVES A TRACE. Two of these paths used to return in total
+     * silence, and because the recorded result is the only channel beat 2 has
+     * back to the control plane, a stuck site was indistinguishable from a site
+     * that had never been asked. A silent early return on a path whose entire
+     * job is to report back is the same defect class as an arm reporting a
+     * success it never verified.
+     *
+     * @param string $token Stage token carried in the cron event args. Empty
+     *                      from the request-bound backstop, which is not an
+     *                      event and therefore cannot be a STALE event.
      * @return void
      */
     public function applyStagedSelfUpdate(string $token = ''): void
     {
         if (defined('WPMGR_WPORG_BUILD') && constant('WPMGR_WPORG_BUILD')) {
+            // Unreachable by construction (the wp.org build does not ship this
+            // file at all), recorded anyway so no exit on this method is silent.
+            $this->recordDiagnosticExit('not_eligible', '', '', 'Self-update is not part of this distribution build.');
             return;
         }
         if (!function_exists('get_option') || !function_exists('delete_option')) {
+            // recordDiagnosticExit needs the very option API that is missing, so
+            // it will no-op. Called regardless so this exit is not special-cased
+            // into silence if the guard is ever relaxed.
+            $this->recordDiagnosticExit('no_option_api', '', '', 'WordPress option API unavailable in the apply request.');
             return;
         }
 
         $record = $this->readStagedRecord();
         if ($record === null) {
-            // Nothing staged (or already claimed by an earlier tick). Silent
-            // no-op; this is the normal state on every site.
+            // Nothing staged, or already claimed by the other entry point. Both
+            // are ordinary, and both used to be invisible. Recorded (once, see
+            // recordDiagnosticExit) so an operator can tell "the apply beat ran
+            // and found nothing" apart from "the apply beat never ran", which
+            // from the control plane look identical.
+            $this->recordDiagnosticExit(
+                'not_staged',
+                $this->onDiskVersion(),
+                '',
+                'An apply beat ran with no staged record to apply.'
+            );
             return;
         }
 
         $recordToken = (string) $record['token'];
         if ($token !== '' && $recordToken !== '' && !hash_equals($recordToken, $token)) {
             // A stale duplicate event from an earlier stage. Leave the current
-            // record alone so its own event can still claim it.
+            // record alone so its own event, or the request-bound backstop, can
+            // still claim it.
+            $this->recordDiagnosticExit(
+                'token_mismatch',
+                (string) $record['from_version'],
+                (string) $record['to_version'],
+                'A stale apply event was ignored; its token does not match the live staged record.'
+            );
             return;
         }
 
-        // CLAIM. Everything below runs at most once per staged record.
-        delete_option(self::OPTION_STAGED);
+        // An apply that is ALREADY RUNNING owns the plugin directory. Checked
+        // BEFORE the claim on purpose: bailing out here must leave the record
+        // staged, so the next request applies it once the running one is done.
+        // Only the claim WINNER takes ownership of the marker (below), so a
+        // request that loses the claim can never clear a marker it does not own.
+        if ($this->applyInProgress()) {
+            $this->recordDiagnosticExit(
+                'apply_in_progress',
+                (string) $record['from_version'],
+                (string) $record['to_version'],
+                'Another apply beat is already running; the stage was left in place for it.'
+            );
+            return;
+        }
 
+        // CLAIM, atomically. Everything below runs at most once per staged
+        // record, however many requests reach this line at the same moment.
+        if (!$this->claimStagedRecord()) {
+            $this->recordDiagnosticExit(
+                'claim_lost',
+                (string) $record['from_version'],
+                (string) $record['to_version'],
+                'Another request claimed this staged record first.'
+            );
+            return;
+        }
+
+        $this->beginApply();
+
+        try {
+            $this->applyClaimedRecord($record);
+        } finally {
+            $this->endApply();
+        }
+    }
+
+    /**
+     * The apply itself, once this caller is the confirmed sole owner of the
+     * staged record AND of the in-flight marker. Split out so the claim/discard
+     * state machine above reads as one, and so the marker is released on every
+     * path through a single finally.
+     *
+     * @param array{from_version:string,to_version:string,staged_at:int,expires_at:int,token:string} $record Claimed record.
+     * @return void
+     */
+    private function applyClaimedRecord(array $record): void
+    {
         $from      = (string) $record['from_version'];
         $to        = (string) $record['to_version'];
         $expiresAt = (int) $record['expires_at'];
@@ -1369,8 +1551,9 @@ final class UpdateChecker
         // wp-cron request whose PHP max_execution_time is 30s on a great many
         // hosts. Without this the download is killed by PHP long before the HTTP
         // client's own budget expires and the apply silently never happens: the
-        // record was CLAIMED above, so nothing retries it, and the control plane
-        // is left with a confirm timeout for a build that was cut off mid-fetch.
+        // record was already CLAIMED by the caller, so nothing retries it, and
+        // the control plane is left with a confirm timeout for a build that was
+        // cut off mid-fetch.
         //
         // Bounded, never 0 (infinite). LongRunningJob's class doc and
         // UpdateCommand::APPLY_TIME_LIMIT_SECONDS carry the full reasoning:
@@ -1384,10 +1567,11 @@ final class UpdateChecker
         // sit at one third of it, so the transfer can never be the thing that
         // exhausts this budget.
         //
-        // Placed HERE and not at the top of the method on purpose: a cron
-        // request runs every due event, and a tick with nothing staged (the
-        // normal state on every site, handled by the early returns above) must
-        // not raise the limit for whatever unrelated event runs after it.
+        // Placed HERE, past every early exit in the caller, on purpose. A cron
+        // request runs every due event and the request-bound backstop runs on
+        // every request at all, so the normal case is a caller that found
+        // nothing to do; neither must raise the limit for whatever unrelated
+        // work follows it in the same request.
         if (function_exists('set_time_limit')) {
             @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- bounded-but-generous cap so a hung self-update apply hits a recoverable max_execution_time fatal rather than only an unrecoverable FPM hard-kill; @-guarded, no-op when disabled
         }
@@ -1563,6 +1747,159 @@ final class UpdateChecker
     }
 
     /**
+     * ATOMICALLY claim the staged record: delete it in ONE statement and answer
+     * whether THIS caller is the one that removed it.
+     *
+     * The original read-then-delete_option pair was a claim in name only. Two
+     * requests could both read the record and both call delete_option, and both
+     * would then run Plugin_Upgrader over the agent's own directory at the same
+     * time. That window was narrow while a cron event was the only way in; with
+     * the request-bound backstop firing on every request of a chatty site it is
+     * not narrow at all. A single DELETE is decided by the database, so exactly
+     * one caller can ever see one row removed, across processes AND across
+     * nodes, which an flock() would not cover on a shared filesystem.
+     *
+     * The option caches are invalidated immediately afterwards because the raw
+     * statement bypasses them. Correctness does not rest on that: a caller
+     * served a stale cached record still has to win its own DELETE, and it
+     * cannot.
+     *
+     * Degrades to the plain delete_option when there is no usable $wpdb (there
+     * always is one inside WordPress; this keeps the method callable from a
+     * bare unit-test bootstrap).
+     *
+     * @return bool True when this caller removed the row and now owns the apply.
+     */
+    private function claimStagedRecord(): bool
+    {
+        global $wpdb;
+
+        $usable = isset($wpdb)
+            && is_object($wpdb)
+            && isset($wpdb->options)
+            && is_string($wpdb->options)
+            && $wpdb->options !== ''
+            && method_exists($wpdb, 'query')
+            && method_exists($wpdb, 'prepare');
+
+        if (!$usable) {
+            if (function_exists('delete_option')) {
+                delete_option(self::OPTION_STAGED);
+            }
+
+            return true;
+        }
+
+        $table = $wpdb->options;
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- compare-and-delete claim of one option row; get_option/delete_option is a read-then-write with no atomicity and no core API exposes an atomic equivalent, and a cached read is exactly what must not decide the winner
+        $deleted = $wpdb->query(
+            // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table is $wpdb->options, a WordPress-derived table name, never user input; the only value is bound through prepare()
+            $wpdb->prepare("DELETE FROM {$table} WHERE option_name = %s", self::OPTION_STAGED)
+        );
+
+        // The statement went behind WordPress's back, so drop what it cached.
+        if (function_exists('wp_cache_delete')) {
+            wp_cache_delete(self::OPTION_STAGED, 'options');
+            wp_cache_delete('alloptions', 'options');
+        }
+
+        return is_numeric($deleted) && (int) $deleted === 1;
+    }
+
+    /**
+     * True when another apply beat is running and has not yet passed its own
+     * execution ceiling. See OPTION_APPLYING for what this covers that the
+     * record claim does not.
+     *
+     * @return bool
+     */
+    private function applyInProgress(): bool
+    {
+        if (!function_exists('get_option')) {
+            return false;
+        }
+
+        $startedAt = (int) get_option(self::OPTION_APPLYING, 0);
+        if ($startedAt <= 0) {
+            return false;
+        }
+
+        // A marker older than the ceiling the apply itself runs under belongs to
+        // a request that can no longer be alive. Ignore it rather than let one
+        // hard-killed apply block this site's updates forever.
+        return (time() - $startedAt) < LongRunningJob::TIME_LIMIT_SECONDS;
+    }
+
+    /**
+     * Take ownership of the in-flight marker. Called ONLY by the caller that
+     * won the record claim, so the release in its finally can never clear a
+     * marker belonging to somebody else.
+     *
+     * @return void
+     */
+    private function beginApply(): void
+    {
+        if (function_exists('update_option')) {
+            update_option(self::OPTION_APPLYING, time(), false);
+        }
+    }
+
+    /**
+     * Release the in-flight marker. Runs in a finally, so it also runs when the
+     * apply threw.
+     *
+     * @return void
+     */
+    private function endApply(): void
+    {
+        if (function_exists('delete_option')) {
+            delete_option(self::OPTION_APPLYING);
+        }
+    }
+
+    /**
+     * Record an apply-beat outcome for a path that did NO work, so no exit of
+     * beat 2 is invisible from the control plane.
+     *
+     * NEVER OVERWRITES. A terminal outcome (applied, failed, expired,
+     * already_applied) is written unconditionally by recordSelfUpdateResult;
+     * this one writes only when nothing is stored at all. Two reasons, both
+     * load-bearing:
+     *
+     *   - Both entry points run in the same wp-cron request when a cron tick
+     *     also carries the due apply event. Whichever runs second finds nothing
+     *     staged, and without this rule it would clobber the winner's 'applied'
+     *     with a 'not_staged' and report the exact opposite of what happened.
+     *   - The in-flight path is reached by every request that arrives while an
+     *     apply is running. Writing on each of those would be an option write
+     *     per request for as long as the apply takes.
+     *
+     * Beat 1 deletes the stored result when it stages, so "nothing is stored"
+     * means "nothing has been recorded for THIS cycle yet", which is exactly the
+     * scope wanted.
+     *
+     * @param string $status Diagnostic status (not one of the terminal four).
+     * @param string $from   Best-known on-disk version (may be empty).
+     * @param string $to     Staged target version (may be empty).
+     * @param string $detail Human-readable, non-secret detail.
+     * @return void
+     */
+    private function recordDiagnosticExit(string $status, string $from, string $to, string $detail): void
+    {
+        if (!function_exists('get_option') || !function_exists('update_option')) {
+            return;
+        }
+
+        $stored = get_option(AgentSelfUpdateCommand::OPTION_RESULT, null);
+        if (is_array($stored) && isset($stored['status']) && is_string($stored['status']) && $stored['status'] !== '') {
+            return;
+        }
+
+        $this->recordSelfUpdateResult($status, $from, $to, $detail);
+    }
+
+    /**
      * Persist the apply outcome so the next metadata push carries it to the CP.
      *
      * The stored detail is scrubbed of anything URL-shaped: upgrader and skin
@@ -1570,7 +1907,12 @@ final class UpdateChecker
      * is a short-lived bearer credential that must never reach a CP-visible
      * field or a log line.
      *
-     * @param string $status One of applied|failed|expired|already_applied.
+     * @param string $status A terminal outcome (applied|failed|expired|
+     *                       already_applied) or, through recordDiagnosticExit,
+     *                       one of the did-no-work diagnostics. The control
+     *                       plane branches on the four it knows and surfaces
+     *                       anything else verbatim, so a status added here needs
+     *                       no control-plane change to reach an operator.
      * @param string $from   On-disk version at stage time.
      * @param string $to     Staged target version.
      * @param string $detail Human-readable, non-secret detail (may be empty).

--- a/apps/agent/tests/AgentSelfUpdateTest.php
+++ b/apps/agent/tests/AgentSelfUpdateTest.php
@@ -88,6 +88,23 @@ final class AgentSelfUpdateTest extends TestCase
     /** Set true to make the site look un-enrolled. */
     public bool $forceUnenrolled = false;
 
+    /**
+     * What the wp_schedule_single_event stub answers. false is exactly what
+     * WordPress returns when another plugin short-circuits pre_schedule_event,
+     * when a schedule_event filter returns something falsy, and for a duplicate
+     * single event scheduled within ten minutes of an identical one.
+     *
+     * @var mixed
+     */
+    public $scheduleReturn = true;
+
+    /**
+     * When true the delete_option stub leaves OPTION_STAGED in place. Used only
+     * by the concurrency test, to model two entry points that both READ the
+     * record before either one's claim lands.
+     */
+    public bool $pinStagedRecord = false;
+
     protected function set_up(): void
     {
         parent::set_up();
@@ -108,6 +125,9 @@ final class AgentSelfUpdateTest extends TestCase
         $this->scheduledEvents = [];
         $this->httpCalls       = [];
         $this->forceUnenrolled = false;
+        $this->scheduleReturn  = true;
+        $this->pinStagedRecord = false;
+        unset($GLOBALS['wpdb']);
 
         Functions\when('get_option')->alias(function (string $name, $default = false) {
             return $this->options[$name] ?? $default;
@@ -117,6 +137,9 @@ final class AgentSelfUpdateTest extends TestCase
             return true;
         });
         Functions\when('delete_option')->alias(function (string $name) {
+            if ($this->pinStagedRecord && $name === UpdateChecker::OPTION_STAGED) {
+                return true;
+            }
             unset($this->options[$name]);
             return true;
         });
@@ -143,7 +166,7 @@ final class AgentSelfUpdateTest extends TestCase
         Functions\when('wp_schedule_single_event')->alias(
             function (int $timestamp, string $hook, array $args = []) {
                 $this->scheduledEvents[] = ['hook' => $hook, 'args' => $args, 'timestamp' => $timestamp];
-                return true;
+                return $this->scheduleReturn;
             }
         );
 
@@ -212,6 +235,7 @@ final class AgentSelfUpdateTest extends TestCase
 
     protected function tear_down(): void
     {
+        unset($GLOBALS['wpdb']);
         if ($this->keyFile !== '' && is_file($this->keyFile)) {
             @unlink($this->keyFile); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
         }
@@ -347,6 +371,57 @@ final class AgentSelfUpdateTest extends TestCase
         return new UpdateChecker($this->signer, $this->settings, $this->keystore, $this->replayCache);
     }
 
+    /**
+     * Install a $wpdb double that answers the compare-and-delete claim the way
+     * a real database does under contention: the first DELETE removes the row
+     * and reports one affected row, every later one reports none.
+     *
+     * @return object The double, so a test can read deleteAttempts back.
+     */
+    private function installRacingWpdb(): object
+    {
+        $fake = new class {
+            /** Options table name, the only wpdb property the claim reads. */
+            public string $options = 'wp_options';
+
+            /** How many claim statements were issued. */
+            public int $deleteAttempts = 0;
+
+            /** @var list<int> Rows affected, in order, per DELETE. */
+            public array $answers = [1, 0];
+
+            /**
+             * @param string $query    SQL with placeholders.
+             * @param mixed  ...$args  Bound values.
+             * @return string
+             */
+            public function prepare(string $query, ...$args): string
+            {
+                foreach ($args as $arg) {
+                    $query = (string) preg_replace('/%[sdi]/', (string) $arg, $query, 1);
+                }
+
+                return $query;
+            }
+
+            /**
+             * @param string $sql Prepared statement.
+             * @return int Rows affected.
+             */
+            public function query(string $sql): int
+            {
+                $this->deleteAttempts++;
+                $next = array_shift($this->answers);
+
+                return $next === null ? 0 : (int) $next;
+            }
+        };
+
+        $GLOBALS['wpdb'] = $fake;
+
+        return $fake;
+    }
+
     // =========================================================================
     // BEAT 1 (ARM)
     // =========================================================================
@@ -461,6 +536,75 @@ final class AgentSelfUpdateTest extends TestCase
     }
 
     /**
+     * THE ARM MUST NOT REPORT A SUCCESS IT DID NOT VERIFY.
+     *
+     * wp_schedule_single_event answers false when another plugin short-circuits
+     * pre_schedule_event, when a schedule_event filter returns something falsy,
+     * and for a duplicate single event scheduled within ten minutes of an
+     * identical one. Its return value used to be discarded, so beat 1 answered
+     * "scheduled" in every one of those cases and the control plane then sat out
+     * its entire twenty-minute confirm window waiting for a cron beat that had
+     * never been created. A site can be perfectly healthy and answering every
+     * request while this happens, which is what made it unreadable from outside.
+     *
+     * The stage is deliberately KEPT. The apply no longer depends on the cron
+     * event: the request-bound backstop applies this very record on the next
+     * request the site serves. Rolling it back would trade a diagnosable failure
+     * for a fleet that can never update itself while the offending filter is
+     * installed.
+     *
+     * Fails against the pre-fix code: the answer is "scheduled".
+     */
+    public function test_stage_answers_error_when_the_apply_event_cannot_be_scheduled(): void
+    {
+        $this->scheduleReturn = false;
+
+        $claims = $this->makeClaims(['version' => $this->targetVersion]);
+        $this->stubManifestEndpoint(200, (string) json_encode($this->signClaims($claims)));
+
+        $answer = $this->makeChecker()->stageSelfUpdate();
+
+        $this->assertSame(
+            'error',
+            $answer['status'],
+            'an event WordPress refused to schedule must never be reported as scheduled'
+        );
+        $this->assertFalse($answer['ok'], 'the control plane has to be able to fail this task immediately');
+        $this->assertStringContainsString(
+            'wp_schedule_single_event',
+            $answer['detail'],
+            'the detail is the whole diagnostic value of an error answer, so it must name what failed'
+        );
+        $this->assertSame('', $answer['to_version'], 'only scheduled/already_scheduled carry a target version');
+
+        $this->assertIsArray(
+            $this->options[UpdateChecker::OPTION_STAGED] ?? null,
+            'the stage is kept so the request-bound backstop can still apply it'
+        );
+    }
+
+    /**
+     * The same arm, re-run. The kept record is what makes the retry meaningful:
+     * it answers already_scheduled, which the control plane treats as armed and
+     * confirms through beat 3 once the backstop has applied it.
+     */
+    public function test_a_retry_after_a_scheduling_failure_answers_already_scheduled(): void
+    {
+        $this->scheduleReturn = false;
+
+        $claims = $this->makeClaims(['version' => $this->targetVersion]);
+        $this->stubManifestEndpoint(200, (string) json_encode($this->signClaims($claims)));
+
+        $checker = $this->makeChecker();
+        $this->assertSame('error', $checker->stageSelfUpdate()['status']);
+
+        $second = $checker->stageSelfUpdate();
+        $this->assertSame('already_scheduled', $second['status']);
+        $this->assertSame($this->targetVersion, $second['to_version']);
+        $this->assertGreaterThan(time(), $second['expires_at']);
+    }
+
+    /**
      * An un-enrolled site has no control plane to obey.
      */
     public function test_stage_is_not_eligible_when_the_site_is_not_enrolled(): void
@@ -537,14 +681,52 @@ final class AgentSelfUpdateTest extends TestCase
     // =========================================================================
 
     /**
-     * No staged record is the normal state on every site: the apply beat is a
-     * silent no-op and records no outcome.
+     * NO EXIT OF THE APPLY BEAT MAY BE SILENT.
+     *
+     * This path used to return without a trace, and the recorded result is the
+     * ONLY channel beat 2 has back to the control plane. "The apply beat ran and
+     * found nothing staged" and "the apply beat never ran at all" are the two
+     * things an operator most needs told apart, and from the control plane they
+     * looked identical: both were a confirm timeout and total silence.
+     *
+     * Fails against the pre-fix code: nothing is recorded.
      */
-    public function test_apply_is_a_silent_no_op_without_a_staged_record(): void
+    public function test_apply_records_an_outcome_when_there_is_no_staged_record(): void
     {
         $this->makeChecker()->applyStagedSelfUpdate('some-token');
 
-        $this->assertArrayNotHasKey(AgentSelfUpdateCommand::OPTION_RESULT, $this->options);
+        $result = $this->options[AgentSelfUpdateCommand::OPTION_RESULT] ?? null;
+        $this->assertIsArray($result, 'a beat that ran and found nothing must still say so');
+        $this->assertSame('not_staged', $result['status']);
+        $this->assertNotSame('', (string) $result['detail']);
+    }
+
+    /**
+     * A diagnostic exit must NEVER clobber a real outcome. Both entry points run
+     * in the same wp-cron request whenever a tick also carries the due apply
+     * event: the winner applies, and the loser then finds nothing staged. If
+     * that loser overwrote the winner's record, the control plane would be told
+     * the exact opposite of what happened.
+     */
+    public function test_a_diagnostic_exit_never_overwrites_a_recorded_outcome(): void
+    {
+        $applied = [
+            'status'       => 'applied',
+            'from_version' => '0.10.5',
+            'to_version'   => $this->targetVersion,
+            'detail'       => '',
+            'at'           => time(),
+        ];
+        $this->options[AgentSelfUpdateCommand::OPTION_RESULT] = $applied;
+
+        // The second entry point of the same request, finding the record gone.
+        $this->makeChecker()->applyStagedSelfUpdate('some-token');
+
+        $this->assertSame(
+            $applied,
+            $this->options[AgentSelfUpdateCommand::OPTION_RESULT],
+            'the apply that actually happened owns the record'
+        );
     }
 
     /**
@@ -718,7 +900,10 @@ final class AgentSelfUpdateTest extends TestCase
 
     /**
      * A stale duplicate event from an earlier stage must not consume the record
-     * belonging to the CURRENT stage.
+     * belonging to the CURRENT stage. It must also not vanish without trace:
+     * this was the second of the two silent exits.
+     *
+     * Fails against the pre-fix code: nothing is recorded.
      */
     public function test_apply_ignores_an_event_whose_token_does_not_match_the_record(): void
     {
@@ -734,7 +919,150 @@ final class AgentSelfUpdateTest extends TestCase
         $this->makeChecker()->applyStagedSelfUpdate('token-from-an-earlier-stage');
 
         $this->assertSame($record, $this->options[UpdateChecker::OPTION_STAGED]);
-        $this->assertArrayNotHasKey(AgentSelfUpdateCommand::OPTION_RESULT, $this->options);
+
+        $result = $this->options[AgentSelfUpdateCommand::OPTION_RESULT] ?? null;
+        $this->assertIsArray($result, 'an ignored stale event must still leave a trace');
+        $this->assertSame('token_mismatch', $result['status']);
+        $this->assertSame($this->targetVersion, $result['to_version']);
+    }
+
+    // =========================================================================
+    // BEAT 2: the two entry points must never both apply
+    // =========================================================================
+
+    /**
+     * THE CLAIM HAS TO BE ATOMIC, NOT A READ FOLLOWED BY A DELETE.
+     *
+     * The cron event and the request-bound plugins_loaded backstop both land in
+     * applyStagedSelfUpdate. A read-then-delete_option pair lets two requests
+     * that both read the record before either delete lands BOTH run
+     * Plugin_Upgrader over the agent's own directory, which is exactly the
+     * outcome the three-beat design exists to prevent. That window was narrow
+     * while cron was the only way in; with a backstop on every request of a
+     * chatty site it is not narrow at all.
+     *
+     * The race is modelled honestly: the option store keeps handing the record
+     * out (both callers read before either claim landed) and only the single
+     * DELETE statement arbitrates, which is what the database guarantees.
+     *
+     * Fails against the pre-fix code: no claim statement is issued at all
+     * (deleteAttempts is 0) and BOTH callers proceed to raise the execution
+     * limit, so two applies are underway.
+     */
+    public function test_two_entry_points_cannot_both_apply_the_same_staged_record(): void
+    {
+        /** @var list<int> $limits */
+        $limits = [];
+        Functions\when('set_time_limit')->alias(function (int $seconds) use (&$limits): bool {
+            $limits[] = $seconds;
+
+            return true;
+        });
+
+        $wpdb = $this->installRacingWpdb();
+        $this->pinStagedRecord = true;
+
+        $this->options[UpdateChecker::OPTION_STAGED] = [
+            'from_version' => '0.10.5',
+            'to_version'   => $this->targetVersion,
+            'staged_at'    => time(),
+            'expires_at'   => time() + UpdateChecker::STAGED_TTL_SECONDS,
+            'token'        => 'live-token',
+        ];
+
+        $checker = $this->makeChecker();
+        $checker->applyStagedSelfUpdate('live-token'); // the cron event
+        $checker->applyStagedSelfUpdate('');           // the request-bound backstop
+
+        $this->assertSame(
+            2,
+            $wpdb->deleteAttempts,
+            'both entry points must attempt the claim; the database decides which one owns it'
+        );
+        $this->assertCount(
+            1,
+            $limits,
+            'exactly one caller may get past the claim, so exactly one apply is ever underway'
+        );
+
+        $result = $this->options[AgentSelfUpdateCommand::OPTION_RESULT] ?? null;
+        $this->assertIsArray($result);
+        $this->assertSame(
+            'failed',
+            $result['status'],
+            'the winner owns the outcome; the loser records a diagnostic that must not overwrite it'
+        );
+    }
+
+    /**
+     * The other overlap the record claim cannot see: a control plane that arms a
+     * SECOND update while the first is still copying files stages a second
+     * record, and the backstop would otherwise claim it on the very next
+     * request. The stage is LEFT IN PLACE so the next request applies it once
+     * the running apply is done.
+     */
+    public function test_apply_defers_to_an_apply_that_is_already_running(): void
+    {
+        // Written by the request that won the claim. Named by literal because
+        // the constant is private; it is asserted here so a rename cannot
+        // silently disable this guard.
+        $this->options['wpmgr_agent_self_update_applying'] = time();
+
+        $record = [
+            'from_version' => '0.10.5',
+            'to_version'   => $this->targetVersion,
+            'staged_at'    => time(),
+            'expires_at'   => time() + UpdateChecker::STAGED_TTL_SECONDS,
+            'token'        => 'live-token',
+        ];
+        $this->options[UpdateChecker::OPTION_STAGED] = $record;
+
+        $this->makeChecker()->applyStagedSelfUpdate('live-token');
+
+        $this->assertSame(
+            $record,
+            $this->options[UpdateChecker::OPTION_STAGED] ?? null,
+            'a busy site must keep its stage so the next request can apply it'
+        );
+
+        $result = $this->options[AgentSelfUpdateCommand::OPTION_RESULT] ?? null;
+        $this->assertIsArray($result);
+        $this->assertSame('apply_in_progress', $result['status']);
+    }
+
+    /**
+     * A hard-killed apply leaves its marker behind. It must not block this
+     * site's updates forever: a marker older than the ceiling the apply itself
+     * runs under belongs to a request that can no longer be alive.
+     */
+    public function test_a_stale_in_flight_marker_does_not_block_the_next_apply(): void
+    {
+        $this->options['wpmgr_agent_self_update_applying'] = time() - 901;
+
+        $this->options[UpdateChecker::OPTION_STAGED] = [
+            'from_version' => '0.10.5',
+            'to_version'   => $this->targetVersion,
+            'staged_at'    => time(),
+            'expires_at'   => time() + UpdateChecker::STAGED_TTL_SECONDS,
+            'token'        => 'live-token',
+        ];
+
+        $this->makeChecker()->applyStagedSelfUpdate('live-token');
+
+        $this->assertArrayNotHasKey(
+            UpdateChecker::OPTION_STAGED,
+            $this->options,
+            'the stale marker must be ignored and the record claimed'
+        );
+        $result = $this->options[AgentSelfUpdateCommand::OPTION_RESULT] ?? null;
+        $this->assertIsArray($result);
+        $this->assertSame('failed', $result['status'], 'the apply ran (and failed for want of an upgrader)');
+
+        $this->assertArrayNotHasKey(
+            'wpmgr_agent_self_update_applying',
+            $this->options,
+            'the marker is released on every terminal path, including a failed one'
+        );
     }
 
     /**

--- a/apps/agent/tests/PluginSelfUpdateBackstopTest.php
+++ b/apps/agent/tests/PluginSelfUpdateBackstopTest.php
@@ -1,0 +1,385 @@
+<?php
+/**
+ * BEAT 2 (APPLY) of the CP-commanded agent self-update, second entry point: the
+ * WP-Cron-INDEPENDENT backstop bound to plugins_loaded.
+ *
+ * The cron event used to be the only way beat 2 ever ran. A site whose loopback
+ * cron is blocked, whose wp_schedule_single_event was short-circuited by another
+ * plugin, or that simply never gets a tick, staged an update that nothing was
+ * left to apply, and then sat at "scheduled" until the control plane's confirm
+ * window ran out. This is the same treatment GitHub issues #226 and #232 gave
+ * the snapshot reclaim and the stalled-backup reaper.
+ *
+ * THE INVARIANT THIS FILE EXISTS TO PIN: beat 2 must run in a DIFFERENT REQUEST
+ * from the arm. The swap must never happen inside the request that has to report
+ * the outcome, and the hook choice is the whole reason it does not.
+ * plugins_loaded fires during WordPress's plugin-loading phase in wp-settings.php;
+ * a REST route callback runs from parse_request, far later in the SAME request.
+ * So on the arm's own request the gate runs BEFORE the signed command writes the
+ * staged record, finds nothing, and arms nothing. Moving this binding to any
+ * hook that fires after the REST callback would silently break the isolation the
+ * three-beat design is built on, and the ordering test below is what fails when
+ * somebody does.
+ *
+ * Boots the REAL Plugin singleton with the same minimal stub set
+ * PluginVersionChangedPushTest uses.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Commands\AgentSelfUpdateCommand;
+use WPMgr\Agent\Plugin;
+use WPMgr\Agent\Settings;
+use WPMgr\Agent\Support\UpdateChecker;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Plugin
+ * @covers \WPMgr\Agent\Support\UpdateChecker
+ */
+final class PluginSelfUpdateBackstopTest extends TestCase
+{
+    /** @var array<string,mixed> In-memory wp-option store. */
+    private array $options = [];
+
+    /** Temp uploads dir standing in for wp_upload_dir()'s basedir. */
+    private string $uploadsDir = '';
+
+    /** @var list<array{hook:string,priority:int,callback:mixed}> Every add_action() seen. */
+    private array $actions = [];
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->uploadsDir = sys_get_temp_dir() . '/wpmgr-plugin-b2-' . bin2hex(random_bytes(6));
+        mkdir($this->uploadsDir, 0755, true);
+        $this->options = [];
+        $this->actions = [];
+
+        foreach (['add_filter', 'register_activation_hook',
+                  'register_deactivation_hook', 'wp_schedule_single_event',
+                  'spawn_cron', 'wp_next_scheduled', 'wp_schedule_event',
+                  'wp_get_scheduled_event', 'wp_clear_scheduled_hook'] as $fn) {
+            Functions\when($fn)->justReturn(true);
+        }
+        Functions\when('add_action')->alias(function (string $hook, $callback, int $priority = 10) {
+            $this->actions[] = ['hook' => $hook, 'priority' => $priority, 'callback' => $callback];
+            return true;
+        });
+        Functions\when('is_admin')->justReturn(false);
+        Functions\when('is_multisite')->justReturn(false);
+        Functions\when('plugin_basename')->returnArg();
+
+        Functions\when('update_option')->alias(function ($name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('get_option')->alias(function ($name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('delete_option')->alias(function ($name) {
+            unset($this->options[$name]);
+            return true;
+        });
+        Functions\when('get_site_option')->alias(function ($name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('update_site_option')->alias(function ($name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('delete_site_transient')->justReturn(true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $this->uploadsDir]);
+
+        // Neutralise ConnectionFinisher's last-rung flush for the CLI SAPI.
+        // Only real PHP functions are stubbed here, never the finish-request
+        // pair: DEFINING fastcgi_finish_request/litespeed_finish_request would
+        // flip function_exists() process-wide and change which rung unrelated
+        // tests observe.
+        Functions\when('headers_sent')->justReturn(true);
+        Functions\when('ob_get_level')->justReturn(0);
+        Functions\when('flush')->justReturn(null);
+
+        if (!defined('WPMGR_AGENT_VERSION')) {
+            define('WPMGR_AGENT_VERSION', '0.10.5');
+        }
+    }
+
+    protected function tear_down(): void
+    {
+        Plugin::resetForTesting();
+        $this->rrmdir($this->uploadsDir);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /** Recursive delete used only for test fixture cleanup. */
+    private function rrmdir(string $dir): void
+    {
+        if ($dir === '' || !is_dir($dir)) {
+            return;
+        }
+        $items = @scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @rmdir($dir); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- test-only fixture cleanup
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Mark the site enrolled and boot the real singleton. */
+    private function bootEnrolledPlugin(): Plugin
+    {
+        $this->options[Settings::OPTION_SITE_ID] = 'site-abc';
+        $this->options[Settings::OPTION_CP_URL]  = 'https://cp.example.test';
+
+        return Plugin::boot();
+    }
+
+    /**
+     * Invoke every registered callback for $hook whose method name is $method,
+     * and return how many fired. Deliberately narrow: firing EVERY
+     * plugins_loaded callback would drag in unrelated sweeps this test says
+     * nothing about, while asserting the count pins that the self-update apply
+     * really is bound to the hook named here.
+     *
+     * @param string $hook   Hook name the callback must be registered on.
+     * @param string $method Plugin method name.
+     * @return int Callbacks fired.
+     */
+    private function fireBoundMethod(string $hook, string $method): int
+    {
+        $fired = 0;
+        foreach ($this->actions as $action) {
+            if ($action['hook'] !== $hook) {
+                continue;
+            }
+            $callback = $action['callback'];
+            if (!is_array($callback) || count($callback) !== 2 || $callback[1] !== $method) {
+                continue;
+            }
+            $callback();
+            $fired++;
+        }
+
+        return $fired;
+    }
+
+    /** Count registrations of a given Plugin method on a given hook. */
+    private function boundCount(string $hook, string $method): int
+    {
+        $count = 0;
+        foreach ($this->actions as $action) {
+            if ($action['hook'] !== $hook) {
+                continue;
+            }
+            $callback = $action['callback'];
+            if (is_array($callback) && count($callback) === 2 && $callback[1] === $method) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /** A live staged record for the version one segment above the on-disk core. */
+    private function stageRecord(): array
+    {
+        $target = (string) preg_replace('/[-+].*$/', '', (string) constant('WPMGR_AGENT_VERSION')) . '.1';
+
+        return [
+            'from_version' => (string) constant('WPMGR_AGENT_VERSION'),
+            'to_version'   => $target,
+            'staged_at'    => time(),
+            'expires_at'   => time() + UpdateChecker::STAGED_TTL_SECONDS,
+            'token'        => 'live-token',
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // The binding itself
+    // -------------------------------------------------------------------------
+
+    /**
+     * The apply backstop must be bound to plugins_loaded and to nothing later.
+     * The hook name is the entire mechanism by which the arm's own request
+     * cannot apply, so it is asserted as a literal rather than inferred.
+     */
+    public function test_the_apply_backstop_is_bound_to_plugins_loaded(): void
+    {
+        $this->bootEnrolledPlugin();
+
+        $this->assertSame(
+            1,
+            $this->boundCount('plugins_loaded', 'maybeApplyStagedSelfUpdate'),
+            'beat 2 must have a request-bound entry point, and it must sit on plugins_loaded'
+        );
+    }
+
+    /**
+     * The common case, which is every site on essentially every request: no
+     * staged record, so nothing is armed and no work is queued.
+     */
+    public function test_a_request_with_nothing_staged_arms_nothing(): void
+    {
+        $plugin = $this->bootEnrolledPlugin();
+
+        $this->assertSame(1, $this->fireBoundMethod('plugins_loaded', 'maybeApplyStagedSelfUpdate'));
+        $this->assertSame(
+            0,
+            $this->boundCount('shutdown', 'applyStagedSelfUpdateOnShutdown'),
+            'a boot with nothing staged must not queue an apply'
+        );
+        $this->assertFalse($plugin->maybeApplyStagedSelfUpdate());
+    }
+
+    /**
+     * A site with no control plane is never told to update itself.
+     */
+    public function test_an_unenrolled_site_never_arms_the_apply(): void
+    {
+        // Deliberately NOT enrolled: no site_id/cp_url in the option store.
+        $plugin = Plugin::boot();
+        $this->options[UpdateChecker::OPTION_STAGED] = $this->stageRecord();
+
+        $this->assertFalse($plugin->maybeApplyStagedSelfUpdate());
+        $this->assertSame(0, $this->boundCount('shutdown', 'applyStagedSelfUpdateOnShutdown'));
+    }
+
+    // -------------------------------------------------------------------------
+    // The isolation invariant
+    // -------------------------------------------------------------------------
+
+    /**
+     * THE ARM REQUEST MUST NEVER APPLY.
+     *
+     * Replays one request in WordPress's own order. plugins_loaded fires during
+     * the plugin-loading phase of wp-settings.php; the signed REST callback that
+     * writes the staged record runs from parse_request, far later in that same
+     * request. So the gate runs FIRST and finds nothing, and the record it would
+     * have applied only comes into existence afterwards.
+     *
+     * This is the constraint the whole three-beat design rests on: the swap must
+     * not happen inside the request that has to report the outcome. If this
+     * binding is ever moved to a hook that fires after the REST callback (init
+     * is still safe, wp_loaded and later are not), this test is what fails.
+     */
+    public function test_the_arm_request_itself_never_applies(): void
+    {
+        $plugin = $this->bootEnrolledPlugin();
+
+        // 1. plugins_loaded, the real position of the gate in the request.
+        $this->assertSame(1, $this->fireBoundMethod('plugins_loaded', 'maybeApplyStagedSelfUpdate'));
+
+        // 2. Much later in the SAME request: the signed agent_self_update
+        //    command runs and stages the record.
+        $record = $this->stageRecord();
+        $this->options[UpdateChecker::OPTION_STAGED] = $record;
+
+        // 3. shutdown. Nothing was armed, so nothing applies.
+        $this->assertSame(
+            0,
+            $this->boundCount('shutdown', 'applyStagedSelfUpdateOnShutdown'),
+            'the request that answers the control plane must not queue the swap it just armed'
+        );
+        $this->assertSame(0, $this->fireBoundMethod('shutdown', 'applyStagedSelfUpdateOnShutdown'));
+
+        $this->assertSame(
+            $record,
+            $this->options[UpdateChecker::OPTION_STAGED] ?? null,
+            'the record the arm just wrote must survive the arm request untouched'
+        );
+        $this->assertArrayNotHasKey(
+            AgentSelfUpdateCommand::OPTION_RESULT,
+            $this->options,
+            'no apply ran, so no apply outcome may exist'
+        );
+    }
+
+    /**
+     * The next request applies it, with no cron event anywhere in the picture.
+     * This is the whole point of the backstop: every request the agent serves,
+     * including the control plane's own heartbeat and uptime hits, is a far more
+     * reliable clock than WP-Cron.
+     *
+     * The apply fails here for want of a Plugin_Upgrader, which this process
+     * does not have. That failure IS the proof: reaching it means the record was
+     * claimed and the upgrade attempted, which is exactly what never happened on
+     * the arm request above.
+     */
+    public function test_a_later_request_applies_the_staged_record_without_cron(): void
+    {
+        $plugin = $this->bootEnrolledPlugin();
+        $this->options[UpdateChecker::OPTION_STAGED] = $this->stageRecord();
+
+        $this->assertSame(1, $this->fireBoundMethod('plugins_loaded', 'maybeApplyStagedSelfUpdate'));
+        $this->assertSame(
+            1,
+            $this->boundCount('shutdown', 'applyStagedSelfUpdateOnShutdown'),
+            'a request that finds a staged record must queue exactly one apply'
+        );
+
+        $this->assertSame(1, $this->fireBoundMethod('shutdown', 'applyStagedSelfUpdateOnShutdown'));
+
+        $this->assertArrayNotHasKey(
+            UpdateChecker::OPTION_STAGED,
+            $this->options,
+            'the apply claims the record before any upgrade work, so it must be gone'
+        );
+
+        $result = $this->options[AgentSelfUpdateCommand::OPTION_RESULT] ?? null;
+        $this->assertIsArray($result, 'the apply must record an outcome for the next metadata push');
+        $this->assertSame('failed', $result['status']);
+        $this->assertArrayNotHasKey(
+            'wpmgr_agent_self_update_applying',
+            $this->options,
+            'the in-flight marker is released on every terminal path'
+        );
+    }
+
+    /**
+     * The apply is deferred to shutdown rather than run inline on
+     * plugins_loaded, and that is not a nicety. The work downloads a package and
+     * overwrites this plugin's own directory; doing that part-way through the
+     * boot of the request executing it would let anything autoloaded later in
+     * that request come from the new build while the loaded classes came from
+     * the old one.
+     */
+    public function test_the_apply_is_deferred_to_shutdown_not_run_inline(): void
+    {
+        $plugin = $this->bootEnrolledPlugin();
+        $this->options[UpdateChecker::OPTION_STAGED] = $this->stageRecord();
+
+        $this->assertTrue($plugin->maybeApplyStagedSelfUpdate());
+
+        $this->assertArrayHasKey(
+            UpdateChecker::OPTION_STAGED,
+            $this->options,
+            'the gate only arms; nothing may be claimed or applied during plugins_loaded itself'
+        );
+        $this->assertArrayNotHasKey(AgentSelfUpdateCommand::OPTION_RESULT, $this->options);
+        $this->assertSame(1, $this->boundCount('shutdown', 'applyStagedSelfUpdateOnShutdown'));
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.105
+ * Version:           0.61.106
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.105');
+define('WPMGR_AGENT_VERSION', '0.61.106');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,26 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.106",
+    date: "2026-07-30",
+    summary: "Fleet agent updates no longer depend on WordPress's scheduler, plus clearer reporting when an update can't proceed.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "The step that installs a new agent version used to run only from WordPress's own scheduled task system, so a site where that system was blocked, unreliable, or never triggered would never get the update, even though everything else about the site worked fine. WPMgr's other background work stopped depending on that scheduler releases ago for the same reason; this step now works the same way, running on an ordinary page request whenever an update is waiting. The install itself still happens in a separate request from the one that starts it, since the agent can't safely replace its own files while it's the one reporting the result.",
+      },
+      {
+        tag: "Fixed",
+        text: "A fleet agent update could report that a site had accepted the job and then go quiet, only for the run to report twenty minutes later that it couldn't be confirmed. The agent asks WordPress to schedule the actual work in a separate request, which WordPress can decline, and the agent wasn't checking whether it had. It now checks, and reports a clear error immediately instead of leaving the rollout waiting on something that was never going to happen.",
+      },
+      {
+        tag: "Fixed",
+        text: "Some situations where the install step decided not to proceed used to leave no record at all. Every outcome is now recorded and reported back, so the dashboard can say why, and only one install can ever run at a time even if two requests start together.",
+      },
+    ],
+    featureLinks: [{ label: "Updates", href: "/features/updates/" }],
+  },
+  {
     version: "0.61.105",
     date: "2026-07-30",
     summary: "Agent updates now complete on slower sites instead of failing forever.",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.105 / open source",
+  badge: "v0.61.106 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.105
+  version: 0.61.106
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Ships as 0.61.106. Agent-only. Fixes the stuck production rollout.

## What happened

A fleet agent update armed successfully on production, then nothing happened, and the run sat at awaiting-confirmation until its 20 minute deadline. The site was healthy and chatty throughout: heartbeats, cache stats and perf acks every few seconds, all 200s.

## The arm reported success it never checked

```php
wp_schedule_single_event($now, self::HOOK_APPLY, [$token]);   // returns bool|WP_Error, discarded
...
$answer = $this->stageAnswer('scheduled', ...);               // reported unconditionally
```

WordPress declines that call whenever a plugin short-circuits `pre_schedule_event`, when `schedule_event` returns falsy, or on a duplicate single event within ten minutes. In all of those the control plane was told the work was scheduled, then waited out its entire confirm window for an event that may never have existed.

Now checked. A failure answers `error` with the reason, so the task fails in seconds with something actionable rather than timing out twenty minutes later on a false claim.

**The staged record is deliberately kept on that failure, not rolled back.** Rolling it back reads tidier, but with the backstop below that record is exactly what still lets the update land. Discarding it would leave a fleet unable to update itself for as long as the offending filter exists.

## The apply depended on WP-Cron alone, and that was the real defect

This agent learned this lesson **twice already** (#226, #232) and carries nine `plugins_loaded` bindings because of it. Beat 2 of the self-update, the newest and least exercised path in the plugin, never got the same treatment.

On any site where cron is blocked or simply never triggered, the update could not apply **while every other agent feature worked normally** — because we'd already made all of those cron-independent.

There is now a tenth binding, enrollment-gated and record-gated so a site with nothing staged pays essentially nothing.

**The apply defers to `shutdown` behind `ConnectionFinisher` rather than running inline.** Overwriting this plugin's own files part-way through the boot of the request executing them would let later autoloads come from the new build while loaded classes came from the old one.

**The arm's own request still cannot apply.** `plugins_loaded` fires before the REST callback writes the record. That ordering was verified by running **real WordPress 7.0.2 in Docker** rather than reasoned about, and confirmed structurally in core source. It has its own test.

## Silent exits made this expensive to diagnose

Two of the apply's six early returns left **no trace anywhere**, so a stuck site was indistinguishable from the control plane's side. Several rounds went on inference instead of evidence, and I twice built a confident story on ambiguous data.

Every exit records an outcome now, and it already rides the metadata push. Critically, **a diagnostic never overwrites a terminal outcome** — a wp-cron request runs both entry points, and the loser would otherwise report `not_staged` over the winner's `applied`. That rule has its own test.

## The claim was a claim in name only

Read, then `delete_option`. It is now an atomic `DELETE ... WHERE option_name` decided by rows-affected, which holds across processes **and across nodes**, where a file lock would not. Plus a separate in-flight marker, peeked before the claim so a busy site keeps its stage, and owned only by the claim winner so a loser cannot release what it does not own.

## Verification

- **11 failures and 2 errors** confirmed against pre-fix source, including `test_the_arm_request_itself_never_applies` and `test_two_entry_points_cannot_both_apply_the_same_staged_record`
- Agent: phpunit **2935**, phpcs 0 errors, `wp plugin check` **0 errors**
- The phpcs-excluded `class-update-checker.php` was linted separately under the same ruleset: **0 errors**, and zero `WordPress.DB.*` findings on the new atomic claim

One test passes both before and after by design: the guard that a diagnostic never clobbers a terminal outcome is a constraint on new behaviour, not a pre-fix reproduction.

## Note for the rollout

The site that failed is on 0.61.104 and this fix is *in the agent*, so it needs 0.61.106 installed once via its own wp-admin before the fleet path can work. After that, agent updates no longer depend on WP-Cron at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fleet agent self-updates by reporting scheduling failures immediately.
  * Added a fallback that applies pending updates during normal site requests when scheduled tasks are unavailable.
  * Improved update status reporting, including previously unreported outcomes.
  * Prevented overlapping update attempts when multiple requests occur simultaneously.

* **Chores**
  * Updated the release version to 0.61.106 across the product and public documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->