### PR TITLE
chore(release): 0.61.107, a deliberate no-op release to exercise the agent update path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.107] - 2026-07-30
+
+### Changed
+
+- Version bump only, with no functional change to the agent, the control plane or the dashboard. The agent's fleet update path was rebuilt across the preceding releases and the final piece, applying an update without depending on WordPress's scheduled task system, has not yet run end to end against a real site. Publishing a release that is identical in behaviour gives that path something genuine to install, so it can be exercised before any operator relies on it. Sites will offer an update whose only difference is the version number, which is safe to take.
+
 ## [0.61.106] - 2026-07-30
 
 ### Fixed

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.106
+ * Version:           0.61.107
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.106');
+define('WPMGR_AGENT_VERSION', '0.61.107');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.106 / open source",
+  badge: "v0.61.107 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.106
+  version: 0.61.107
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
**No functional change.** The only diff is the version constant, `openapi.yaml` `info.version`, the marketing badge, and a changelog entry.

## Why

The agent's fleet update path was rebuilt across 0.61.98 to 0.61.106. Its final piece — applying an update **without depending on WP-Cron** — has never run end to end against a real site.

Each earlier attempt stalled before the apply, for a different reason each time:

| attempt | stalled because |
|---|---|
| first | signed-command claims leaked into the request body, so the arm refused |
| second | `wp_schedule_single_event`'s return was unverified, so the arm reported a schedule it had not made |

Both are fixed, and the site under test now runs 0.61.106 — so site and channel match and there is nothing left to install.

Publishing a behaviourally identical release gives that path something genuine to apply, so beat 2 is exercised before an operator depends on it.

## Recorded as a no-op deliberately

I looked for real agent work to carry this and found none worth inventing.

The `phpcs` exclusion on `class-update-checker.php` that I earlier called a coverage hole turns out to be a **documented, reasoned decision**: the file never ships to wordpress.org, so linting it against the .org ruleset is noise, and its `error_log()` and atomic file operations are intentional for the self-hosted update path. "Fixing" it would mean roughly 48 suppression annotations over deliberate code. That is churn, not coverage.

Manufacturing content to justify a version bump would have been worse than saying plainly what this is.

## What operators will see

An update offer whose only difference is the version number. Safe to take, and stated as such in the changelog.

## Verification

- Agent: phpunit **2935**, phpcs 0 errors
- No code path changed, so nothing else to verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Released version **0.61.107**.
  - Updated the displayed product and agent version information across the application and documentation.
  - This is a version-only release with no functional changes to the agent, control plane, or dashboard.
- **Documentation**
  - Added release notes indicating that end-to-end validation of the latest fleet agent update path is still pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->