### PR TITLE
chore(release): 0.61.109, a no-op release to exercise the rebuilt agent update path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.109] - 2026-07-31
+
+### Changed
+
+- Version bump only, with no functional change to the agent, the control plane or the dashboard. 0.61.108 rebuilt how a fleet agent update actually installs itself, and that path can only be tested by an agent that already has it: a site still running an older build applies updates with the old, broken step, so pointing it at 0.61.108 exercises nothing. Publishing a release that is identical in behaviour gives a site already on 0.61.108 something genuine to install, so the rebuilt path can be run end to end before any operator depends on it. Sites will be offered an update whose only difference is the version number, which is safe to take.
+
 ## [0.61.108] - 2026-07-30
 
 ### Fixed

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.108
+ * Version:           0.61.109
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.108');
+define('WPMGR_AGENT_VERSION', '0.61.109');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,17 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.109",
+    date: "2026-07-31",
+    summary: "A deliberate no-op release, so the rebuilt agent update path from 0.61.108 has something real to install.",
+    items: [
+      {
+        tag: "Changed",
+        text: "Version bump only, with no functional change to the agent, the control plane or the dashboard. 0.61.108 rebuilt how a fleet agent update installs itself, and that path can only be tested by an agent that already has it: a site still on an older build applies updates with the old, broken step, so pointing it at 0.61.108 exercises nothing. Publishing a release that is identical in behaviour gives a site already on 0.61.108 something genuine to install, so the rebuilt path can be run end to end before anyone depends on it. Sites will be offered an update whose only difference is the version number, which is safe to take.",
+      },
+    ],
+  },
+  {
     version: "0.61.108",
     date: "2026-07-30",
     summary: "Fleet agent updates actually apply now: a transient-deletion bug meant every run silently did nothing, and the apply moved to where WordPress's own rollback still works.",
@@ -69,6 +80,17 @@ const RELEASES: ChangeEntry[] = [
       },
     ],
     featureLinks: [{ label: "Updates", href: "/features/updates/" }],
+  },
+  {
+    version: "0.61.107",
+    date: "2026-07-30",
+    summary: "A no-op release published to give the agent update path something to install.",
+    items: [
+      {
+        tag: "Changed",
+        text: "Version bump only, with no functional change to the agent, the control plane or the dashboard. The agent's fleet update path was rebuilt across the preceding releases, and publishing a release identical in behaviour gave that path something genuine to install so it could be exercised. Sites were offered an update whose only difference is the version number.",
+      },
+    ],
   },
   {
     version: "0.61.106",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.108 / open source",
+  badge: "v0.61.109 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.108
+  version: 0.61.109
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Version bump only. No functional change to the agent, the control plane or the dashboard.

## Why

0.61.108 (#320) rebuilt how a fleet agent update installs itself. That path can only be exercised by an agent that already carries it: the fix lives in the code doing the installing, not the code being installed. A site on 0.61.107 or earlier applies updates with the old, broken step, so pointing it at 0.61.108 tests nothing.

`msm.oscod.dev` has now been updated to 0.61.108 by hand through wp-admin, which is the bootstrap. This release gives that site something real to install so the rebuilt path can run end to end before anyone depends on it.

Sites will be offered an update whose only difference is the version number.

## Also

Backfills the 0.61.107 entry on the marketing changelog page, which was skipped when that release shipped (the CI drift guard only compares the newest entry, so it passed).

## Files

- `apps/agent/wpmgr-agent.php` (header Version and `WPMGR_AGENT_VERSION`)
- `CHANGELOG.md`, `packages/openapi/openapi.yaml` (`info.version`), marketing changelog page and home badge, all in lockstep

## Gates

```
phpunit  2945 tests, 0 failures, 0 errors
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Released version 0.61.109 as a version-only update with no functional changes.
  - Updated the displayed product and API version information across the platform.
  - Added release notes documenting the previous agent update path and support for end-to-end installation testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->