### PR TITLE
fix(agent): remove the SAPI detach gate, it refused what WordPress does daily (GH #319)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.110] - 2026-07-31
+
+### Fixed
+
+- Fleet agent updates no longer refuse to run on Apache with mod_php or plain CGI hosting, which is common on shared and self managed servers. The previous release added a check that declined to update the agent itself unless the web server could hand the connection back to WordPress before the file swap started, on the reasoning that a lost connection mid swap was unsafe on that kind of hosting. That reasoning did not hold up: WordPress's own plugin and core updater performs exactly the same file swap, protected by exactly the same safeguards, on that same kind of hosting every day, whenever an operator clicks "Update now" in wp-admin. The fleet update now runs that identical, already safe swap instead of refusing outright, so a site on this kind of hosting updates itself from the fleet dashboard the same way it already updates from its own wp-admin.
+- Because the control plane now waits out the whole install on this kind of hosting instead of getting an instant acknowledgement, the time it is willing to wait for that one request was raised from 5 to 8 minutes, so a slower host has room to finish both the download and the file swap in the same request, not just the download.
+- A control plane request that times out while an agent update is still applying is no longer recorded as a failed rollout. On this kind of hosting the agent's acknowledgement is only written after the whole swap finishes, so a slow answer is not evidence anything went wrong, it usually just means the swap is still running. The rollout now waits for the site's own report of the version it is running before deciding the outcome, exactly as it already does for an ordinary acknowledgement.
+- A rollout's halt banner could read "The rollout was halted before any site could be contacted" for a site that was, in fact, contacted and answered, when all that actually happened was the site politely declining the update rather than failing or never receiving it at all. The summary now counts a declined site as contacted and says so plainly.
+
 ## [0.61.109] - 2026-07-31
 
 ### Changed

--- a/apps/agent/includes/commands/class-metadata-command.php
+++ b/apps/agent/includes/commands/class-metadata-command.php
@@ -139,7 +139,7 @@ final class MetadataCommand implements CommandInterface
      * unproven, and a canary that upgraded perfectly halts its own rollout. A
      * test pins these keys.
      *
-     * @return array{status:string,from_version:string,to_version:string,detail:string,at:int,apply_id:string}|null
+     * @return array{status:string,from_version:string,to_version:string,detail:string,at:int,apply_id:string,rung:string}|null
      */
     private function selfUpdateResult(): ?array
     {
@@ -166,6 +166,13 @@ final class MetadataCommand implements CommandInterface
             // Empty on a record written by an agent that predates apply-id
             // stamping, which the control plane reads as "not attributable".
             'apply_id'     => isset($stored['apply_id']) && is_string($stored['apply_id']) ? $stored['apply_id'] : '',
+            // Which ConnectionFinisher rung the apply ran on: 'fpm' or
+            // 'litespeed' when the control-plane connection was genuinely
+            // released before the swap, 'fallback' when the worker stayed
+            // attached for it. Purely diagnostic, and additive: empty on any
+            // agent that predates it. Nothing on either side branches on it,
+            // and no site is ever refused an upgrade for its value.
+            'rung'         => isset($stored['rung']) && is_string($stored['rung']) ? $stored['rung'] : '',
         ];
     }
 

--- a/apps/agent/includes/support/class-connection-finisher.php
+++ b/apps/agent/includes/support/class-connection-finisher.php
@@ -31,7 +31,14 @@
  *
  * The three collaborators (availability probe, invocation, fallback) are
  * constructor-injected so every rung is unit testable without a real SAPI —
- * LiteSpeed cannot be reproduced in CI.
+ * LiteSpeed cannot be reproduced in CI. Two more seams, the SAPI name and the
+ * ini reader, are injected for detachReason() for the same reason: PHP_SAPI is
+ * a compile-time constant, so a test can only reach that code by being handed
+ * the value rather than by redefining it.
+ *
+ * Reaching the last rung is a slower path to the same outcome, never an unsafe
+ * one. Nothing in this agent refuses work because of it. detachReason() exists
+ * to SAY which host this is, not to gate anything.
  *
  * @package WPMgr\Agent\Support
  */
@@ -54,13 +61,31 @@ final class ConnectionFinisher
      * as opposed to the portable last rung, which only flushes what is already
      * buffered and leaves the worker attached to the client.
      *
-     * Named here so that a caller deciding AFTER the flush (from the rung
-     * finish() returned) and a caller deciding BEFORE it (from canDetach())
-     * are reading one list rather than two that can drift apart.
+     * Named here so that a caller reading the rung finish() returned and a
+     * caller asking canDetach() beforehand are reading one list rather than two
+     * that can drift apart. It is a vocabulary, not a gate: a caller may prefer
+     * a detaching rung, log which one it got, or ignore the distinction
+     * entirely, and none of those is this class's business.
      *
      * @var list<string>
      */
     public const DETACHING_RUNGS = ['fpm', 'litespeed'];
+
+    /**
+     * Which finish-request function each SAPI is expected to ship, for the SAPIs
+     * that ship one at all. Everything absent from this map (apache2handler,
+     * cgi, cgi-fcgi, cli, cli-server, and the rest) provides none, and saying
+     * that plainly is the whole point of detachReason().
+     *
+     * fastcgi_finish_request is exposed by the PHP-FPM SAPI only. Plain
+     * FastCGI (cgi-fcgi) does NOT carry it, which is why it is not listed here.
+     *
+     * @var array<string,string>
+     */
+    private const SAPI_FINISH_FUNCTIONS = [
+        'fpm-fcgi'  => 'fastcgi_finish_request',
+        'litespeed' => 'litespeed_finish_request',
+    ];
 
     /** @var callable(string):bool */
     private $available;
@@ -70,6 +95,12 @@ final class ConnectionFinisher
 
     /** @var callable():void */
     private $fallback;
+
+    /** @var callable():string */
+    private $sapi;
+
+    /** @var callable(string):(string|false) */
+    private $iniGet;
 
     /**
      * @param callable(string):bool|null $available Returns whether the named
@@ -82,9 +113,21 @@ final class ConnectionFinisher
      * @param callable():void|null       $fallback   The last-rung flush, used
      *        when neither finish-request function is available. Defaults to
      *        defaultFallbackFlush().
+     * @param callable():string|null     $sapi       Returns this process's SAPI
+     *        name. Defaults to PHP_SAPI, which is a compile-time constant and
+     *        therefore cannot be faked in a test any other way. Read only by
+     *        detachReason().
+     * @param callable(string):(string|false)|null $iniGet Reads a php.ini
+     *        directive. Defaults to ini_get(). Read only by detachReason(),
+     *        and only for disable_functions.
      */
-    public function __construct(?callable $available = null, ?callable $invoke = null, ?callable $fallback = null)
-    {
+    public function __construct(
+        ?callable $available = null,
+        ?callable $invoke = null,
+        ?callable $fallback = null,
+        ?callable $sapi = null,
+        ?callable $iniGet = null
+    ) {
         $this->available = $available ?? static fn (string $fn): bool => function_exists($fn);
         $this->invoke    = $invoke ?? static function (string $fn): void {
             $fn();
@@ -92,6 +135,8 @@ final class ConnectionFinisher
         $this->fallback  = $fallback ?? static function (): void {
             self::defaultFallbackFlush();
         };
+        $this->sapi      = $sapi ?? static fn (): string => PHP_SAPI;
+        $this->iniGet    = $iniGet ?? static fn (string $name) => ini_get($name);
     }
 
     /**
@@ -121,13 +166,13 @@ final class ConnectionFinisher
      * Answers the question WITHOUT flushing anything, so it is safe to ask
      * before the response is ready to be released.
      *
-     * finish() reports which rung fired, which is the right shape for a caller
-     * that has already committed to the work. It is the wrong shape for a
-     * caller whose decision to start the work at all depends on the answer:
-     * the CP-commanded self-update has told the control plane what it is about
-     * to do by the time it releases the response, so it asks this first and
-     * declines the whole operation up front instead of abandoning it after the
-     * acknowledgement has gone out.
+     * Detaching first is strictly better wherever it is possible: the caller
+     * gets its response back in milliseconds instead of waiting out the work,
+     * and no worker holds a socket open for minutes. It is a preference and an
+     * optimisation, which is exactly how WordPress core itself treats the same
+     * capability in wp-cron.php ("Don't run cron until the request finishes, if
+     * possible", with no else branch). It is not a precondition for doing work,
+     * and nothing in this agent may use it as one.
      *
      * Asks the SAME two questions finish() asks, through the same injected
      * probe, so the two can only ever agree.
@@ -138,6 +183,91 @@ final class ConnectionFinisher
     {
         return ($this->available)('fastcgi_finish_request')
             || ($this->available)('litespeed_finish_request');
+    }
+
+    /**
+     * Why this host has no detaching rung, in one sentence, or '' when it has
+     * one. Diagnostic only: nothing branches on this string.
+     *
+     * IT READS ITS EVIDENCE INSTEAD OF ASSUMING IT. Two very different hosts
+     * reach the same last rung. One runs a SAPI that never shipped a
+     * finish-request function at all (apache2handler, plain CGI, the CLI
+     * server), where there is nothing for an administrator to turn on. The
+     * other runs a SAPI that does ship one and has had it switched off through
+     * disable_functions, which is a setting somebody can change. Reporting the
+     * second sentence on the first kind of host sends an operator to edit a
+     * list that was never involved, which is the specific mistake this method
+     * exists to stop making.
+     *
+     * So the disable_functions claim is made ONLY when both halves are true:
+     * this SAPI is one that would have shipped the function, AND that exact
+     * name is literally in the parsed list. Otherwise it says the SAPI provides
+     * none, which is the truth on the overwhelming majority of these hosts.
+     *
+     * @return string One sentence, or '' when finish() can detach.
+     */
+    public function detachReason(): string
+    {
+        if ($this->canDetach()) {
+            return '';
+        }
+
+        $sapi     = $this->sapiName();
+        $expected = self::SAPI_FINISH_FUNCTIONS[$sapi] ?? '';
+        $tail     = ' The response is flushed and the worker stays attached to the client until the request ends.';
+
+        if ($expected === '') {
+            return 'The ' . $sapi . ' SAPI provides no finish-request function.' . $tail;
+        }
+
+        if (in_array($expected, $this->disabledFunctions(), true)) {
+            return 'The ' . $sapi . ' SAPI ships ' . $expected
+                . ', but disable_functions on this host names it, so it cannot be called.' . $tail;
+        }
+
+        return 'The ' . $sapi . ' SAPI normally ships ' . $expected
+            . ', but this build does not expose it and disable_functions does not name it.' . $tail;
+    }
+
+    /**
+     * This process's SAPI name, normalised to the bare token shape PHP_SAPI
+     * actually has (letters, digits, dot, dash, underscore), because the
+     * sentence detachReason() builds around it is stored and shipped onward.
+     *
+     * @return string Never empty.
+     */
+    private function sapiName(): string
+    {
+        $name = (string) preg_replace('/[^A-Za-z0-9._-]/', '', (string) ($this->sapi)());
+
+        return $name === '' ? 'unknown' : $name;
+    }
+
+    /**
+     * The disable_functions directive, parsed into lowercase names.
+     *
+     * The directive is a comma-separated list whose spacing is whatever whoever
+     * wrote the ini file used, and PHP function names are case-insensitive, so
+     * both are normalised away before any comparison.
+     *
+     * @return list<string>
+     */
+    private function disabledFunctions(): array
+    {
+        $raw = ($this->iniGet)('disable_functions');
+        if (!is_string($raw) || $raw === '') {
+            return [];
+        }
+
+        $names = [];
+        foreach (explode(',', $raw) as $name) {
+            $name = strtolower(trim($name));
+            if ($name !== '') {
+                $names[] = $name;
+            }
+        }
+
+        return $names;
     }
 
     /**

--- a/apps/agent/includes/support/class-update-checker.php
+++ b/apps/agent/includes/support/class-update-checker.php
@@ -146,28 +146,6 @@ final class UpdateChecker
     private const OPTION_APPLY_ID = 'wpmgr_agent_self_update_apply_id';
 
     /**
-     * Apply-result status recorded when this site's PHP SAPI cannot release
-     * the control-plane connection, so no apply was run.
-     *
-     * NOT an ARM status. The ARM answers 'not_eligible', which is one of the
-     * five pinned wire values, and carries this reason in its detail; this name
-     * only ever appears in the apply-result record, where it lets an operator
-     * tell "this site can never self-update" apart from "an apply was attempted
-     * and failed".
-     */
-    private const RESULT_SAPI_CANNOT_DETACH = 'sapi_cannot_detach';
-
-    /**
-     * The reason both the ARM answer and the apply-result record carry when the
-     * detach gate refuses, held once so the control plane reads the same
-     * sentence whichever of the two it is looking at.
-     */
-    private const DETACH_REFUSAL_DETAIL = 'This PHP SAPI offers neither fastcgi_finish_request nor '
-        . 'litespeed_finish_request, so the agent cannot release the control-plane connection before replacing its '
-        . 'own directory, and it will not run an upgrade on a connection something else can time out mid swap. '
-        . 'Nothing on disk was touched. Update this site from its WordPress dashboard instead.';
-
-    /**
      * Every agent class that can still be reached AFTER the plugin directory
      * has been swapped. warmPostSwapClasses() loads each one before the swap
      * starts, so the code that runs between the swap and the end of the request
@@ -297,13 +275,26 @@ final class UpdateChecker
     private ReplayCache $replayCache;
 
     /**
-     * The SAPI-aware early-flush ladder, held rather than constructed on the
-     * spot because the CP-commanded self-update asks it TWO questions in one
-     * request and both answers have to come from the same probe: can this SAPI
-     * detach at all (at the arm, before anything is promised), and which rung
-     * actually fired (after the acknowledgement has been released).
+     * The SAPI-aware early-flush ladder. Held rather than constructed on the
+     * spot so the rung that actually fired and the explanation recorded beside
+     * it come from one probe rather than from two that could disagree.
+     *
+     * Releasing the connection first is a preference, never a precondition. On
+     * the last rung the apply runs anyway, attached, which is what WordPress
+     * itself does on the same hosts through wp-admin every day.
      */
     private ConnectionFinisher $finisher;
+
+    /**
+     * The ConnectionFinisher rung the apply in THIS request ran on, or '' when
+     * no apply ran here.
+     *
+     * Stamped into every apply-result record so a fleet-wide reading can tell
+     * which sites upgraded on an attached connection from which upgraded on a
+     * released one. It is an observation and nothing reads it back to decide
+     * anything.
+     */
+    private string $applyRung = '';
 
     /**
      * Why the most recent fetchManifest()/verifyManifest() pair returned null.
@@ -365,10 +356,8 @@ final class UpdateChecker
      *                                            function can be defined in a test
      *                                            process without flipping
      *                                            function_exists() for every other
-     *                                            test in it, and whether this SAPI
-     *                                            can detach is the single input that
-     *                                            decides whether a site self-updates
-     *                                            at all.
+     *                                            test in it, so the rung a test wants
+     *                                            to exercise has to be handed in.
      */
     public function __construct(
         Signer $signer,
@@ -1314,9 +1303,10 @@ final class UpdateChecker
      *
      * EVERY REASON THIS SITE CANNOT BE UPGRADED IS DECIDED HERE, before the
      * answer goes out, because an answer the control plane has to wait out a
-     * confirm deadline to disbelieve costs a rollout wave. That includes the
-     * SAPI detach gate, which is a property of the host and not of the
-     * manifest.
+     * confirm deadline to disbelieve costs a rollout wave. There are exactly
+     * two such reasons and both are about identity rather than capability: the
+     * wordpress.org distribution build, which ships no self-updater at all, and
+     * a site that is not enrolled. The PHP SAPI is not one of them.
      *
      * @return array{status:string,ok:bool,from_version:string,to_version:string,detail:string,cron_mode:string,expires_at:int,apply_id:string}
      */
@@ -1345,43 +1335,6 @@ final class UpdateChecker
         // placed after that return would never run on the sites most likely to
         // still be carrying the leftovers.
         $this->clearRetiredStagingState();
-
-        // THE DETACH GATE, ASKED HERE BECAUSE IT IS ANSWERABLE HERE.
-        //
-        // The apply only runs on a SAPI that can genuinely release the
-        // control-plane connection first. ConnectionFinisher's last rung is a
-        // portable flush that leaves the worker attached, and a multi-minute
-        // upgrade on an attached connection is on a timer nobody here controls
-        // (a reverse-proxy read timeout the control plane cannot raise, or a
-        // process manager reaping the worker on client disconnect). That
-        // refusal is real and stays; what moved is WHEN it is made.
-        //
-        // It used to be made after the acknowledgement had already gone out, so
-        // a mod_php or plain-CGI site answered "scheduled", the control plane
-        // waited out its full confirm deadline, and only then recorded a
-        // failure. In wave 0 that halts the entire rollout, and every retry
-        // costs another deadline, over a site whose answer was knowable in the
-        // first millisecond. Nothing about it depends on the manifest, so it is
-        // answered before the manifest is even fetched.
-        //
-        // It answers "not_eligible", which the control plane scores as skipped
-        // rather than failed, and which is the honest word for it: this site
-        // cannot use this channel at all, exactly like the wordpress.org build
-        // and the un-enrolled site above. The specific reason travels in the
-        // detail and in the apply-result record, so neither the operator nor a
-        // later diagnostic has to infer it.
-        if (!$this->finisher->canDetach()) {
-            $this->recordSelfUpdateResult(
-                '',
-                self::RESULT_SAPI_CANNOT_DETACH,
-                $onDisk,
-                '',
-                self::DETACH_REFUSAL_DETAIL,
-                false
-            );
-
-            return $this->stageAnswer('not_eligible', $onDisk, '', self::DETACH_REFUSAL_DETAIL);
-        }
 
         $claims = $this->fetchManifest();
         if (!is_array($claims)) {
@@ -1503,20 +1456,13 @@ final class UpdateChecker
      * is a fatal in the request body, and PHP still runs the shutdown queue
      * afterwards.
      *
-     * THE DETACH GATE, SECOND OF TWO. The swap only runs when ConnectionFinisher
-     * reports that it truly detached the connection (PHP-FPM or LiteSpeed). Its
-     * third rung is a portable flush that does NOT detach, and running a
-     * multi-minute upgrade on a still-attached connection puts it on a timer
-     * nobody here controls: a reverse-proxy or CDN read timeout the control
-     * plane cannot raise, or a process manager reaping the worker on client
-     * disconnect, which is a signal ignore_user_abort() cannot intercept. A site
-     * that is not upgraded is fine. A site that is half upgraded is not.
-     *
-     * The PRIMARY gate is at the arm (planSelfUpdate), which asks the same
-     * ladder the same question before it promises the control plane anything.
-     * This one is belt and braces: it judges the rung that actually fired
-     * rather than the rung that was predicted, and it is what would stop a swap
-     * if those two ever disagreed.
+     * THE FLUSH IS ATTEMPTED, NOT REQUIRED. finish() takes the best rung this
+     * SAPI offers and reports which one it was. On PHP-FPM or LiteSpeed that
+     * genuinely releases the control-plane connection and the apply runs with
+     * nobody waiting on it. On every other SAPI the last rung flushes what is
+     * buffered and the worker stays attached, so the control plane holds its
+     * connection until the apply finishes. Both then run the identical apply.
+     * The rung is recorded with the outcome and decides nothing.
      *
      * @param mixed $served  Whether the response has already been sent.
      * @param mixed $result  The response object core was about to serialise.
@@ -1576,13 +1522,30 @@ final class UpdateChecker
     }
 
     /**
-     * Everything that happens once the response has been released: the detach
-     * gate, the background-job arming, and the upgrade.
+     * Everything that happens once the response has been released: the
+     * execution guards, the class warming, and the upgrade.
      *
-     * Split from serveThenApply() because the rung is the ONE input that decides
-     * whether this site is upgraded at all, and a decision that important is
-     * worth being able to exercise directly rather than only through whichever
-     * SAPI the test process happens to be running under.
+     * Split from serveThenApply() because the rung is an input a test cannot
+     * otherwise choose. Neither finish-request function can be defined in a
+     * test process without changing which rung every other test observes, so
+     * the apply is reachable directly with the rung handed in.
+     *
+     * THE RUNG IS RECORDED, NOT OBEYED. This method used to refuse the whole
+     * upgrade when finish() reported the last rung, on the reasoning that a
+     * still-attached connection could be cut mid swap. It no longer does, for
+     * three reasons that hold together. WordPress core has no SAPI check
+     * anywhere in its upgrade path and updates plugins on these same hosts from
+     * wp-admin every day, on a fully attached browser connection. This agent's
+     * own update command already applies plugin, theme and core upgrades inline
+     * and attached on every SAPI, guarded by nothing more than the two calls
+     * below. And those two calls were the guards the refusal made unreachable
+     * on precisely the hosts that need them: on a SAPI that cannot detach,
+     * ignore_user_abort() IS the defence, and it was dead code here.
+     *
+     * What the rung still buys is diagnosis. It is stamped into the apply
+     * result, so a fleet-wide reading can tell which sites upgraded on an
+     * attached connection, and on the last rung the reason this host has no
+     * detaching one is written to the debug log in the same breath.
      *
      * @param string $rung    The rung ConnectionFinisher reported.
      * @param string $applyId Opaque id of this apply.
@@ -1592,32 +1555,24 @@ final class UpdateChecker
      */
     private function applyPendingUpdate(string $rung, string $applyId, string $from, string $to): void
     {
-        try {
-            // BELT AND BRACES. planSelfUpdate() already refused this site
-            // before it answered, using the same ladder and the same question,
-            // so in practice a non-detaching rung cannot reach this line: the
-            // arm would never have registered the seam that leads here. It is
-            // checked again anyway because the two readings are taken at
-            // different moments and the cost of the later one being wrong is a
-            // half-replaced plugin directory. Unlike the arm, this one HAS
-            // already answered the control plane, so its refusal has to be
-            // delivered out of band, which recordSelfUpdateResult() arranges.
-            if (!in_array($rung, ConnectionFinisher::DETACHING_RUNGS, true)) {
-                $this->recordSelfUpdateResult(
-                    $applyId,
-                    self::RESULT_SAPI_CANNOT_DETACH,
-                    $from,
-                    $to,
-                    self::DETACH_REFUSAL_DETAIL
-                );
+        $this->applyRung = $rung;
 
-                return;
+        try {
+            if (!in_array($rung, ConnectionFinisher::DETACHING_RUNGS, true)) {
+                DebugLog::write(rtrim(
+                    'WPMgr Agent: self-update applying on the ' . $rung . ' rung, so the control-plane connection '
+                    . 'stays attached until the apply finishes. ' . $this->finisher->detachReason()
+                ));
             }
 
-            // The client is gone and the request is now a background job. The
-            // execution cap is bounded on purpose: max_execution_time is the ONE
-            // timer whose fatal still runs shutdown functions, which is exactly
-            // what the rollback depends on.
+            // BOTH OF THESE MATTER MOST ON THE RUNG THAT DID NOT DETACH, which
+            // is why they are the first thing the apply does on EVERY rung. On
+            // a detaching rung the client is already gone. On the last rung it
+            // is still there, and ignore_user_abort() is what keeps a peer that
+            // hangs up from ending the swap halfway. The execution cap is
+            // bounded on purpose: max_execution_time is the ONE timer whose
+            // fatal still runs shutdown functions, which is exactly what the
+            // rollback depends on.
             if (function_exists('ignore_user_abort')) {
                 ignore_user_abort(true);
             }
@@ -2101,31 +2056,24 @@ final class UpdateChecker
      * the control plane say whether the version it now sees moved BECAUSE of the
      * run it armed, rather than assuming it.
      *
-     * The one caller that passes an EMPTY apply id is the arm's own detach
-     * refusal, which is not an apply outcome at all: no apply was taken, so
-     * there is no id to name, and the empty string is exactly what an
-     * unattributable record should say about itself.
+     * Every caller is now an apply outcome, so every record names a real apply.
+     * The one caller that used to pass an empty id was the arm's SAPI refusal,
+     * and that refusal is gone: this channel no longer declines a site for the
+     * SAPI it runs on.
      *
-     * @param string $applyId       Opaque id of the apply that produced this
-     *                              outcome, or '' when no apply was taken.
-     * @param string $status        A terminal outcome (applied|failed|expired|
-     *                              already_applied) or a named diagnostic. The
-     *                              control plane branches on the four it knows
-     *                              and surfaces anything else verbatim, so a
-     *                              status added here needs no control-plane
-     *                              change to reach an operator.
-     * @param string $from          On-disk version at arm time.
-     * @param string $to            Verified target version.
-     * @param string $detail        Human-readable, non-secret detail (may be empty).
-     * @param bool   $pushOutOfBand Whether this outcome needs its own delivery.
-     *                              True for anything decided AFTER the response
-     *                              was released, which is the whole reason the
-     *                              push exists. False for the arm's own detach
-     *                              refusal: that reason is already in the answer
-     *                              this very request is about to return, and on a
-     *                              SAPI that by definition cannot detach, a push
-     *                              queued on shutdown would hold the control
-     *                              plane's own connection open to re-send it.
+     * The rung is stamped from the apply that is running, or left empty when
+     * this record was written outside one. It is an observation for a fleet-wide
+     * reading, never an input to anything.
+     *
+     * @param string $applyId Opaque id of the apply that produced this outcome.
+     * @param string $status  A terminal outcome (applied|failed|expired|
+     *                        already_applied) or a named diagnostic. The control
+     *                        plane branches on the four it knows and surfaces
+     *                        anything else verbatim, so a status added here needs
+     *                        no control-plane change to reach an operator.
+     * @param string $from    On-disk version at arm time.
+     * @param string $to      Verified target version.
+     * @param string $detail  Human-readable, non-secret detail (may be empty).
      * @return void
      */
     private function recordSelfUpdateResult(
@@ -2133,8 +2081,7 @@ final class UpdateChecker
         string $status,
         string $from,
         string $to,
-        string $detail,
-        bool $pushOutOfBand = true
+        string $detail
     ): void {
         if (!function_exists('update_option')) {
             return;
@@ -2154,13 +2101,12 @@ final class UpdateChecker
                 'detail'       => $scrubbed,
                 'at'           => time(),
                 'apply_id'     => $applyId,
+                'rung'         => $this->applyRung,
             ],
             false
         );
 
-        if ($pushOutOfBand) {
-            $this->queueOutcomePush($status);
-        }
+        $this->queueOutcomePush($status);
     }
 
     /**

--- a/apps/agent/tests/AgentSelfUpdateTest.php
+++ b/apps/agent/tests/AgentSelfUpdateTest.php
@@ -547,26 +547,28 @@ final class AgentSelfUpdateTest extends TestCase
     }
 
     /**
-     * A SITE WHOSE PHP SAPI CANNOT DETACH IS REFUSED AT THE ARM, IMMEDIATELY.
+     * A SITE WHOSE PHP SAPI CANNOT DETACH ARMS EXACTLY LIKE ANY OTHER SITE.
      *
-     * The apply has to release the control-plane connection before it starts,
-     * because a multi-minute upgrade on a still-attached connection is on a
-     * timer nobody here controls. On mod_php or plain CGI there is no way to
-     * release it, so the upgrade must not run at all.
+     * The arm used to refuse such a host outright, answering "not_eligible" and
+     * recording a "sapi_cannot_detach" outcome, on the reasoning that an
+     * upgrade on a still-attached connection could be cut mid swap. That
+     * refusal is gone. WordPress has no SAPI check anywhere in its own upgrade
+     * path and updates plugins on these hosts from wp-admin every day, and this
+     * agent's own update command already applies plugin, theme and core
+     * upgrades inline and attached on every SAPI. Refusing here stranded a
+     * large share of shared hosting on an agent that could never be upgraded
+     * from the fleet.
      *
-     * That refusal used to be discovered AFTER the acknowledgement had gone
-     * out: such a site answered "scheduled", the control plane waited out its
-     * whole 20-minute confirm deadline, and only then recorded a failed task,
-     * which in wave 0 halts the entire rollout and costs another 20 minutes on
-     * every retry. Detachability is a property of the host and of nothing else,
-     * knowable in the first millisecond, so it is answered here.
+     * So the fixture is the same manifest and the same site as the ordinary arm
+     * test, with only the SAPI probe flipped, and the expected answer is the
+     * same one: scheduled, the lock taken, the seam registered, a real apply id,
+     * and NO apply-result record, because at arm time nothing has been applied.
      *
-     * "not_eligible" is the answer because it is the existing status for "this
-     * channel does not apply to this site", and the control plane scores it as
-     * skipped rather than failed. The specific reason rides in the detail and
-     * in the apply-result record, so no sixth ARM status is invented for it.
+     * "not_eligible" now has exactly two meanings, both about identity rather
+     * than capability: the wordpress.org distribution build, and an un-enrolled
+     * site. Each has its own test above.
      */
-    public function test_a_sapi_that_cannot_detach_is_refused_at_the_arm(): void
+    public function test_a_sapi_that_cannot_detach_still_arms(): void
     {
         $claims = $this->makeClaims(['version' => $this->targetVersion]);
         $this->stubManifestEndpoint(200, (string) json_encode($this->signClaims($claims)));
@@ -577,40 +579,55 @@ final class AgentSelfUpdateTest extends TestCase
         $answer = $checker->planSelfUpdate();
 
         $this->assertSame(
-            'not_eligible',
+            'scheduled',
             $answer['status'],
-            'the control plane scores this as skipped; "error" would fail the task and halt the wave'
+            'the SAPI is not a reason to decline; a host that cannot detach applies attached instead'
         );
-        $this->assertTrue($answer['ok'], 'an ineligible host is informational, never a failure');
-        $this->assertSame('', $answer['to_version']);
-        $this->assertSame('', $answer['apply_id'], 'nothing was armed, so there is no apply to name');
-        $this->assertSame(0, $answer['expires_at']);
-        $this->assertStringContainsString(
-            'fastcgi_finish_request',
-            (string) $answer['detail'],
-            'the reason must be specific enough for an operator to act on'
+        $this->assertTrue($answer['ok']);
+        $this->assertSame($this->targetVersion, $answer['to_version']);
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{32}$/',
+            (string) $answer['apply_id'],
+            'an armed apply must be attributable on every host class'
         );
+        $this->assertGreaterThan(time(), $answer['expires_at']);
 
-        $this->assertSame($before, $this->snapshotDisk(), 'a refused arm touches nothing on disk');
-        $this->assertSame(
-            [],
-            $this->httpCalls,
-            'the answer depends on the host and not on the manifest, so it must not cost a CP round trip'
+        $this->assertSame($before, $this->snapshotDisk(), 'the ARM still touches nothing on disk');
+        $this->assertCount(1, $this->httpCalls, 'the arm verifies the manifest here exactly as anywhere else');
+        $this->assertNotSame(
+            0,
+            (int) ($this->options[self::LOCK_OPTION] ?? 0),
+            'the arm must hold core\'s own upgrader lock on this host class too'
         );
-        $this->assertArrayNotHasKey(self::LOCK_OPTION, $this->options, 'and it must not take the apply lock');
-        $this->assertFalse(
+        $this->assertNotFalse(
             has_filter('rest_pre_serve_request', [$checker, 'serveThenApply']),
-            'no apply seam may be registered for an apply that will never run'
+            'the apply seam must be registered, or the swap this arm just promised can never run'
         );
 
-        $record = $this->options[AgentSelfUpdateCommand::OPTION_RESULT] ?? null;
-        $this->assertIsArray($record, 'the refusal is recorded as well as answered');
-        $this->assertSame('sapi_cannot_detach', $record['status']);
-        $this->assertSame('', $record['apply_id'], 'no apply was taken, so the record names none');
-        $this->assertSame(
-            $answer['detail'],
-            $record['detail'],
-            'the answer and the record must carry one sentence, not two that can drift'
+        $this->assertArrayNotHasKey(
+            AgentSelfUpdateCommand::OPTION_RESULT,
+            $this->options,
+            'the arm applies nothing, so it must record no apply outcome at all'
+        );
+    }
+
+    /**
+     * The refused-outcome vocabulary is gone from the shipped source, not just
+     * from the path that used to reach it. A leftover constant or literal is how
+     * a retired refusal quietly comes back, and this string was also visible to
+     * operators, so it is pinned as absent rather than assumed absent.
+     */
+    public function test_the_retired_sapi_refusal_vocabulary_is_gone_from_the_source(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__) . '/includes/support/class-update-checker.php');
+
+        $this->assertStringNotContainsString('sapi_cannot_detach', $source);
+        $this->assertStringNotContainsString('RESULT_SAPI_CANNOT_DETACH', $source);
+        $this->assertStringNotContainsString('DETACH_REFUSAL_DETAIL', $source);
+        $this->assertStringNotContainsString(
+            'canDetach',
+            $source,
+            'the self-updater must not ask whether it may detach; it applies either way'
         );
     }
 
@@ -760,13 +777,14 @@ final class AgentSelfUpdateTest extends TestCase
             'detail'       => '',
             'at'           => 1750000000,
             'apply_id'     => 'abcdef0123456789abcdef0123456789',
+            'rung'         => 'fallback',
             'ignored_key'  => 'must not travel',
         ];
 
         $payload = (new \WPMgr\Agent\Commands\MetadataCommand())->collect();
 
         $this->assertSame(
-            ['status', 'from_version', 'to_version', 'detail', 'at', 'apply_id'],
+            ['status', 'from_version', 'to_version', 'detail', 'at', 'apply_id', 'rung'],
             array_keys($payload['agent_self_update']),
             'the agent_self_update wire shape is pinned; change it here and in the control plane contract together'
         );
@@ -774,6 +792,11 @@ final class AgentSelfUpdateTest extends TestCase
             'abcdef0123456789abcdef0123456789',
             $payload['agent_self_update']['apply_id'],
             'apply_id must survive the whitelist, or attribution is impossible by construction'
+        );
+        $this->assertSame(
+            'fallback',
+            $payload['agent_self_update']['rung'],
+            'the rung is how a fleet-wide reading tells an attached apply from a released one; it must survive too'
         );
     }
 
@@ -798,6 +821,11 @@ final class AgentSelfUpdateTest extends TestCase
 
         $this->assertSame('failed', $payload['agent_self_update']['status']);
         $this->assertSame('', $payload['agent_self_update']['apply_id']);
+        $this->assertSame(
+            '',
+            $payload['agent_self_update']['rung'],
+            'the rung is additive in the same way: absent on an older agent, never a decode failure'
+        );
     }
 
     /**

--- a/apps/agent/tests/ConnectionFinisherTest.php
+++ b/apps/agent/tests/ConnectionFinisherTest.php
@@ -202,12 +202,11 @@ final class ConnectionFinisherTest extends TestCase
 
     // -------------------------------------------------------------------------
     // (e2) canDetach() answers the SAME question finish() answers, without
-    //      flushing. A caller whose decision to start work at all depends on
-    //      whether the connection can be released has to ask BEFORE the
-    //      response is ready (the CP-commanded self-update refuses the whole
-    //      operation at its arm on this answer), so the two must agree on every
-    //      configuration or that caller refuses sites that would have worked,
-    //      or promises sites that cannot.
+    //      flushing. It is a preference a caller may express before the
+    //      response is ready, never a precondition for doing work: nothing in
+    //      the agent declines an operation because of it. The two must still
+    //      agree on every configuration, or a caller that prefers a detaching
+    //      rung would arrange for one it does not get.
     // -------------------------------------------------------------------------
 
     public function test_can_detach_agrees_with_the_rung_finish_would_return(): void
@@ -240,14 +239,143 @@ final class ConnectionFinisherTest extends TestCase
     }
 
     /**
-     * The rung-name list is the shared vocabulary between a caller that decides
-     * before the flush and one that decides after, so it is pinned rather than
-     * left to drift.
+     * The rung-name list is the shared vocabulary between a caller reading the
+     * rung it got and one asking beforehand, so it is pinned rather than left to
+     * drift.
      */
     public function test_the_detaching_rung_names_are_pinned(): void
     {
         self::assertSame(['fpm', 'litespeed'], ConnectionFinisher::DETACHING_RUNGS);
         self::assertNotContains('fallback', ConnectionFinisher::DETACHING_RUNGS);
+    }
+
+    // -------------------------------------------------------------------------
+    // (e3) detachReason(): the sentence, and the evidence behind it.
+    //
+    // Two very different hosts reach the same last rung, and only one of them
+    // has anything an administrator can change. Saying "disable_functions" on a
+    // host whose SAPI never shipped the function sends that administrator to
+    // edit a list that was never involved, so the claim is made only when both
+    // halves are true: this SAPI would ship the function, AND its name is
+    // literally in the parsed list.
+    //
+    // The SAPI name and the ini reader are constructor-injected because PHP_SAPI
+    // is a compile-time constant, so a test can only reach these branches by
+    // being handed the value.
+    // -------------------------------------------------------------------------
+
+    public function test_detach_reason_is_empty_when_the_connection_can_be_released(): void
+    {
+        $finisher = self::probing(['fastcgi_finish_request'], 'fpm-fcgi', '');
+
+        self::assertSame('', $finisher->detachReason(), 'there is nothing to explain when a detaching rung exists');
+    }
+
+    /**
+     * CASE A: the SAPI never shipped one. The overwhelming majority of these
+     * hosts. It must NOT blame a setting.
+     */
+    public function test_detach_reason_says_the_sapi_provides_none_when_it_never_shipped_one(): void
+    {
+        // A production apache2handler host, with a disable_functions list that
+        // is populated but names nothing relevant. The list must not be read as
+        // the cause just because it is non-empty.
+        $finisher = self::probing([], 'apache2handler', 'exec, shell_exec, passthru');
+        $reason   = $finisher->detachReason();
+
+        self::assertStringContainsString('apache2handler', $reason);
+        self::assertStringContainsString('provides no finish-request function', $reason);
+        self::assertStringNotContainsString(
+            'disable_functions',
+            $reason,
+            'this SAPI never had one to disable, so the setting is not the cause and must not be named'
+        );
+    }
+
+    /**
+     * CASE B: the SAPI ships one and disable_functions names it. The only case
+     * an operator can act on, so it is the only case allowed to say so.
+     */
+    public function test_detach_reason_names_disable_functions_only_when_the_list_really_names_it(): void
+    {
+        $finisher = self::probing([], 'fpm-fcgi', 'exec,fastcgi_finish_request , shell_exec');
+        $reason   = $finisher->detachReason();
+
+        self::assertStringContainsString('fpm-fcgi', $reason);
+        self::assertStringContainsString('fastcgi_finish_request', $reason);
+        self::assertStringContainsString('disable_functions on this host names it', $reason);
+    }
+
+    /**
+     * The list is parsed, not searched. Spacing is whatever whoever wrote the
+     * ini file used and PHP function names are case-insensitive, so a real
+     * entry must still be recognised through both.
+     */
+    public function test_detach_reason_parses_the_disable_functions_list_rather_than_matching_raw_text(): void
+    {
+        $spaced = self::probing([], 'litespeed', "  LITESPEED_FINISH_REQUEST ,exec ")->detachReason();
+
+        self::assertStringContainsString('disable_functions on this host names it', $spaced);
+
+        // A near miss must not count: a longer name that merely CONTAINS the
+        // function name is a different function.
+        $nearMiss = self::probing([], 'litespeed', 'my_litespeed_finish_request_wrapper')->detachReason();
+
+        self::assertStringNotContainsString('disable_functions on this host names it', $nearMiss);
+        self::assertStringContainsString('does not expose it', $nearMiss);
+    }
+
+    /**
+     * CASE C: the SAPI ships one, the list does not name it, and it is still
+     * absent. Rare, and the sentence says exactly that rather than picking
+     * whichever of the other two sounds better.
+     */
+    public function test_detach_reason_claims_neither_cause_when_the_evidence_supports_neither(): void
+    {
+        $reason = self::probing([], 'fpm-fcgi', '')->detachReason();
+
+        self::assertStringContainsString('fpm-fcgi', $reason);
+        self::assertStringContainsString('normally ships fastcgi_finish_request', $reason);
+        self::assertStringContainsString('does not expose it', $reason);
+    }
+
+    /**
+     * The sentence is stored and shipped onward, so the SAPI token it is built
+     * around is normalised to the shape PHP_SAPI actually has, and an empty one
+     * still produces a sentence rather than a gap where a word should be.
+     */
+    public function test_detach_reason_normalises_the_sapi_token(): void
+    {
+        $reason = self::probing([], "apache2handler\n<b>x</b>", '')->detachReason();
+
+        self::assertStringNotContainsString('<', $reason);
+        self::assertStringNotContainsString("\n", $reason);
+
+        $empty = self::probing([], '', '')->detachReason();
+
+        self::assertStringContainsString('unknown', $empty);
+    }
+
+    /**
+     * Build a finisher with every seam pinned: which functions exist, what the
+     * SAPI is called, and what disable_functions says.
+     *
+     * @param list<string> $available         Functions this fake SAPI exposes.
+     * @param string       $sapi              PHP_SAPI stand-in.
+     * @param string       $disableFunctions  disable_functions stand-in.
+     * @return ConnectionFinisher
+     */
+    private static function probing(array $available, string $sapi, string $disableFunctions): ConnectionFinisher
+    {
+        return new ConnectionFinisher(
+            static fn (string $fn): bool => in_array($fn, $available, true),
+            static function (string $fn): void {
+            },
+            static function (): void {
+            },
+            static fn (): string => $sapi,
+            static fn (string $name) => $name === 'disable_functions' ? $disableFunctions : ''
+        );
     }
 
     // -------------------------------------------------------------------------

--- a/apps/agent/tests/SelfUpdateInRequestApplyTest.php
+++ b/apps/agent/tests/SelfUpdateInRequestApplyTest.php
@@ -312,13 +312,15 @@ final class SelfUpdateInRequestApplyTest extends TestCase
     /**
      * Build an UpdateChecker whose SAPI probe is injected.
      *
-     * The arm refuses outright on a SAPI that cannot release the control-plane
-     * connection, and under the PHPUnit CLI SAPI neither finish-request
-     * function exists, so an un-injected checker arms nothing at all. Defining
-     * either function here would flip function_exists() process-wide and change
+     * Under the PHPUnit CLI SAPI neither finish-request function exists, and
+     * defining either here would flip function_exists() process-wide and change
      * which rung every other test observes, so the probe is handed in instead.
-     * The un-injected default is exercised deliberately, by the arm-refusal
-     * test below, which is the one case where the real CLI SAPI IS the fixture.
+     * The un-injected default is exercised deliberately by the test that meets
+     * the last rung as a real mod_php host does, which is the one case where the
+     * real CLI SAPI IS the fixture.
+     *
+     * The arm behaves identically either way. The probe changes which rung the
+     * apply reports, never whether there is one.
      *
      * @param bool $detachable Whether the fake SAPI exposes a detaching rung.
      * @return UpdateChecker
@@ -382,10 +384,9 @@ final class SelfUpdateInRequestApplyTest extends TestCase
      * makeChecker() injects the arm's probe: neither fastcgi_finish_request nor
      * litespeed_finish_request can be defined in this process without flipping
      * function_exists() process-wide and changing which rung every other test
-     * observes. The rung is the one input that decides whether this site is
-     * upgraded at all, so it is exercised through the seam the class exposes for
-     * it. What the real CLI SAPI does with an un-injected checker has its own
-     * tests below.
+     * observes. The apply runs on every rung, so what this seam exercises is
+     * which rung gets RECORDED and that no rung is skipped. What the real CLI
+     * SAPI does with an un-injected checker has its own test below.
      *
      * @param bool $replayShutdown Whether to replay the shutdown queue after.
      * @return array<string,mixed> The arm answer.
@@ -565,31 +566,24 @@ final class SelfUpdateInRequestApplyTest extends TestCase
     }
 
     // =========================================================================
-    // The SAPI detach gate
+    // The rung: recorded, never obeyed
     // =========================================================================
 
     /**
-     * A SAPI THAT CANNOT DETACH NEVER REACHES THE APPLY AT ALL.
-     *
-     * On mod_php or plain CGI, ConnectionFinisher's third rung is a portable
-     * flush that does not actually release the connection. Running a
-     * multi-minute upgrade on a connection something else is timing (a reverse
-     * proxy read timeout the control plane cannot raise, a process manager
-     * reaping the worker on client disconnect) risks a directory that is half
-     * replaced with nothing alive to finish it. A site that is not upgraded is
-     * fine. A site that is half upgraded is not.
-     *
-     * The gate lives at the ARM, where the answer is knowable and where saying
-     * so costs the control plane nothing. Its full behaviour, including the
-     * status the CP scores, is pinned in AgentSelfUpdateTest; what this file
-     * cares about is the consequence: no apply is armed, so the seam that would
-     * have run one is never registered and the response is left to core.
+     * A SAPI THAT CANNOT DETACH ARMS AND SWAPS LIKE ANY OTHER.
      *
      * The fixture is the REAL default probe under the real CLI SAPI, which
-     * exposes neither finish-request function. No injection at all: this is the
-     * gate as a mod_php or plain-CGI host actually meets it.
+     * exposes neither finish-request function, so nothing is injected at all:
+     * this is the last rung as a mod_php or plain-CGI host actually meets it.
+     *
+     * Both halves of the old refusal are pinned as gone here. The arm answers
+     * scheduled and registers the seam, and dispatching that seam runs the
+     * upgrade rather than recording a refusal. WordPress applies plugin updates
+     * on exactly this host class from wp-admin every day, on a fully attached
+     * browser connection, and refusing here left a large share of shared
+     * hosting on an agent the fleet could never upgrade.
      */
-    public function test_a_sapi_that_cannot_detach_arms_nothing_and_swaps_nothing(): void
+    public function test_a_sapi_that_cannot_detach_arms_and_applies(): void
     {
         $this->stubSignedOffer();
         $this->siteTransients['update_plugins'] = $this->offerTransient();
@@ -597,41 +591,46 @@ final class SelfUpdateInRequestApplyTest extends TestCase
         $checker = new UpdateChecker($this->signer, $this->settings, $this->keystore, $this->replayCache);
         $answer  = $checker->planSelfUpdate();
 
-        $this->assertSame('not_eligible', $answer['status']);
-        $this->assertSame([], $this->filters, 'no apply seam may be registered for an apply that will never run');
-        $this->assertFalse(
-            $checker->serveThenApply(false, null, null, null),
-            'and a dispatch of the seam from any other cause must hand the response straight back to core'
+        $this->assertSame('scheduled', $answer['status']);
+        $this->assertContains(
+            'rest_pre_serve_request@999',
+            $this->filters,
+            'the apply seam must be registered on a host that cannot detach, exactly as on one that can'
+        );
+        $this->assertNotSame(
+            0,
+            (int) ($this->options[self::LOCK_OPTION] ?? 0),
+            'the arm holds the upgrader lock on this host class too'
         );
 
-        $this->assertSame([], \Plugin_Upgrader::$calls, 'no upgrade may start on a connection that is still attached');
+        $this->assertTrue(
+            $checker->serveThenApply(false, null, null, null),
+            'the seam takes over the response here as it does anywhere else'
+        );
 
-        $record = $this->record();
-        $this->assertIsArray($record, 'the refusal must be reported, not silent');
-        $this->assertSame('sapi_cannot_detach', $record['status']);
-        $this->assertStringContainsString('fastcgi_finish_request', (string) $record['detail']);
-
-        $this->assertArrayNotHasKey(
-            self::LOCK_OPTION,
-            $this->options,
-            'a refused arm must never take the lock in the first place'
+        $this->assertSame(
+            [UpdateChecker::PLUGIN_KEY],
+            \Plugin_Upgrader::$calls,
+            'the upgrade must run on a still-attached connection, which is what core itself does here'
+        );
+        $this->assertSame('applied', (string) ($this->record()['status'] ?? ''));
+        $this->assertSame(
+            'fallback',
+            (string) ($this->record()['rung'] ?? ''),
+            'and the record must say which rung it ran on, so a fleet reading can still tell'
         );
     }
 
     /**
-     * THE SAME GATE, ASKED A SECOND TIME AFTER THE RESPONSE WAS RELEASED.
+     * THE APPLY PROCEEDS ON A NON-DETACHING RUNG, AND SAYS SO.
      *
-     * The arm predicts the rung; this judges the one that actually fired. In
-     * practice the two cannot disagree, since both ask the same ladder the same
-     * question inside one request, which is exactly why this backstop needs a
-     * test of its own: nothing else would ever exercise it, and the cost of it
-     * being absent on the day they DID disagree is a half-replaced directory.
-     *
-     * Reached through the seam the class exposes for the rung, because the
-     * fixture has to be an armed apply that then meets a non-detaching rung,
-     * which no real SAPI would produce.
+     * This is the inverse of the assertion this file used to carry. A rung of
+     * 'fallback' after the acknowledgement used to abandon the apply and record
+     * a refusal; it now runs the identical upgrade the detaching rungs run and
+     * records the rung beside the outcome. Reached through the seam the class
+     * exposes for the rung, because no real SAPI in this process produces one.
      */
-    public function test_a_non_detaching_rung_after_the_ack_still_refuses_the_swap(): void
+    public function test_a_non_detaching_rung_after_the_ack_still_applies(): void
     {
         $this->stubSignedOffer();
         $this->pinFinisherRung('fallback');
@@ -639,22 +638,27 @@ final class SelfUpdateInRequestApplyTest extends TestCase
 
         $answer = $this->runApply();
 
-        $this->assertSame('scheduled', $answer['status'], 'the arm armed, so the backstop is what refuses');
-        $this->assertSame([], \Plugin_Upgrader::$calls, 'no upgrade may start on a connection that is still attached');
+        $this->assertSame('scheduled', $answer['status']);
+        $this->assertSame(
+            [UpdateChecker::PLUGIN_KEY],
+            \Plugin_Upgrader::$calls,
+            'the rung is a diagnostic; it may not decide whether the upgrade happens'
+        );
 
         $record = $this->record();
-        $this->assertIsArray($record, 'the refusal must be reported, not silent');
-        $this->assertSame('sapi_cannot_detach', $record['status']);
+        $this->assertIsArray($record);
+        $this->assertSame('applied', $record['status']);
+        $this->assertSame('fallback', $record['rung']);
         $this->assertSame(
             $answer['apply_id'],
             $record['apply_id'],
-            'this one DID take an apply, so its record must name it'
+            'the outcome must name the apply that produced it'
         );
 
         $this->assertArrayNotHasKey(
             self::LOCK_OPTION,
             $this->options,
-            'a refused apply must release the lock rather than hold it for its full window'
+            'and the lock is released when the apply returns, on every rung'
         );
     }
 
@@ -671,6 +675,68 @@ final class SelfUpdateInRequestApplyTest extends TestCase
 
         $this->assertSame([UpdateChecker::PLUGIN_KEY], \Plugin_Upgrader::$calls);
         $this->assertSame('applied', (string) ($this->record()['status'] ?? ''));
+        $this->assertSame('fpm', (string) ($this->record()['rung'] ?? ''));
+    }
+
+    /**
+     * THE EXECUTION GUARDS ARE ARMED ON EVERY RUNG. THIS IS THE HOIST.
+     *
+     * ignore_user_abort(true) and the bounded set_time_limit() used to sit
+     * BELOW a rung check that returned early on 'fallback', which made them
+     * dead code on precisely the host class where they are the only defence:
+     * on a SAPI that cannot release the connection, ignore_user_abort() is what
+     * keeps a peer hanging up from ending the swap halfway. Removing that early
+     * return is what put them on every rung, so a future edit that reintroduces
+     * any rung-keyed skip above them has to fail here.
+     *
+     * set_time_limit() is observed directly (it is stubbed by this fixture).
+     * ignore_user_abort() is left real, because it is not redefinable and a
+     * Patchwork redefinition would leak across the suite, so it is observed
+     * through its own return value: called with no argument it reports the
+     * current setting without changing it.
+     */
+    public function test_the_apply_arms_its_execution_guards_on_every_rung(): void
+    {
+        $wasIgnoring = ignore_user_abort();
+
+        try {
+            foreach (['fpm', 'litespeed', 'fallback'] as $rung) {
+                ignore_user_abort(false);
+
+                // Clear only what one cycle leaves behind. Wiping the whole
+                // option store would take the site's own keypair with it, and an
+                // arm that cannot sign never reaches an apply at all.
+                unset($this->options[AgentSelfUpdateCommand::OPTION_RESULT], $this->options[self::LOCK_OPTION]);
+                $this->filters           = [];
+                $this->actions           = [];
+                $this->timeLimits        = [];
+                \Plugin_Upgrader::$calls = [];
+
+                $this->stubSignedOffer();
+                $this->pinFinisherRung($rung);
+                $this->siteTransients['update_plugins'] = $this->offerTransient();
+
+                $this->runApply(false);
+
+                $this->assertSame(
+                    [UpdateChecker::PLUGIN_KEY],
+                    \Plugin_Upgrader::$calls,
+                    "the '{$rung}' rung must reach the upgrade"
+                );
+                $this->assertContains(
+                    LongRunningJob::TIME_LIMIT_SECONDS,
+                    $this->timeLimits,
+                    "the '{$rung}' rung must arm the bounded execution cap before the swap"
+                );
+                $this->assertSame(
+                    1,
+                    ignore_user_abort(),
+                    "the '{$rung}' rung must set ignore_user_abort, which is the last rung's only defence"
+                );
+            }
+        } finally {
+            ignore_user_abort((bool) $wasIgnoring);
+        }
     }
 
     // =========================================================================
@@ -794,25 +860,27 @@ final class SelfUpdateInRequestApplyTest extends TestCase
     }
 
     /**
-     * A SAPI that cannot detach never gets that far, so it must not raise the
-     * limit of the request it declined to use. Both refusal points are covered:
-     * the arm, which is the real CLI SAPI's own answer, and the post-ack
-     * backstop reached through the rung seam.
+     * A REQUEST THAT ARMED NOTHING IS LEFT EXACTLY AS IT WAS FOUND.
+     *
+     * The seam is registered by the arm, but it is a public filter callback and
+     * anything at all may dispatch it. With no pending apply it must hand the
+     * response back and touch nothing: no execution limit raised, no upgrade
+     * started, no outcome recorded. This used to be covered incidentally by the
+     * SAPI refusal, which arrived at the same state for a reason that no longer
+     * exists, so it is now asserted for its own sake.
      */
-    public function test_a_refused_apply_leaves_the_execution_limit_alone(): void
+    public function test_a_seam_dispatch_with_nothing_armed_leaves_the_request_alone(): void
     {
-        $this->stubSignedOffer();
+        $checker = $this->makeChecker();
 
-        $armRefused = new UpdateChecker($this->signer, $this->settings, $this->keystore, $this->replayCache);
-        $armRefused->planSelfUpdate();
-        $armRefused->serveThenApply(false, null, null, null);
+        $this->assertFalse(
+            $checker->serveThenApply(false, null, null, null),
+            'with nothing pending the response belongs to core'
+        );
 
-        $this->assertSame([], $this->timeLimits, 'an arm that refused must not touch the request it declined to use');
-
-        $this->pinFinisherRung('fallback');
-        $this->runApply(false);
-
-        $this->assertSame([], $this->timeLimits, 'and neither must the backstop');
+        $this->assertSame([], $this->timeLimits, 'a request that armed nothing must not have its limits rewritten');
+        $this->assertSame([], \Plugin_Upgrader::$calls, 'and nothing may be swapped');
+        $this->assertNull($this->record(), 'and no outcome may be recorded for an apply that never existed');
     }
 
     /**

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.109
+ * Version:           0.61.110
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.109');
+define('WPMGR_AGENT_VERSION', '0.61.110');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -687,7 +687,7 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// finished. Mirror the backup (:729-733) and media (:1219-1223) dedicated
 	// commander pattern via buildUpdateApplyCommander: build a SEPARATE
 	// SSRF-hardened client with a longer per-attempt cap
-	// (cfg.Update.ApplyHTTPTimeout, default 5m — see UpdateConfig's doc
+	// (cfg.Update.ApplyHTTPTimeout, default 8m; see UpdateConfig's doc
 	// comment for how that default was picked) just for the update-apply
 	// commander, falling back to the shared `commander` when no signing key
 	// is configured (the cmdSigner == nil / disabled-commander case, guarded
@@ -695,7 +695,7 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	updateApplyCmd := buildUpdateApplyCommander(commander, cmdSigner, cfg.Update.ApplyHTTPTimeout)
 	// The update-task River job otherwise inherits River's own 60s default
 	// (river.Config.JobTimeout is unset below), which is shorter than
-	// cfg.Update.ApplyHTTPTimeout (5m) alone, let alone the apply call PLUS the
+	// cfg.Update.ApplyHTTPTimeout (8m) alone, let alone the apply call PLUS the
 	// GH #291 Phase 4 post-update health check that runs after it in the same
 	// job. Mirror the backup worker's jobTimeout pattern (backupJobTimeout,
 	// below): derive a job-level budget that genuinely covers the worst case
@@ -2455,7 +2455,7 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// the channel exactly as the flag does, an unsigned self-update command
 	// must never be sent.
 	//
-	// Built on updateApplyCmd (cfg.Update.ApplyHTTPTimeout, default 5m), NOT
+	// Built on updateApplyCmd (cfg.Update.ApplyHTTPTimeout, default 8m), NOT
 	// the shared 30s `commander`, and for the identical reason main.go:686-695
 	// already gives the plugin-apply path its own dedicated commander: on a
 	// SAPI where ConnectionFinisher reaches its portable fallback rung (mod_php,

--- a/apps/api/internal/agent/handler.go
+++ b/apps/api/internal/agent/handler.go
@@ -114,12 +114,11 @@ type metadataDTO struct {
 	// never sent by an agent old enough to predate the channel.
 	//
 	// It is the only way a FAILED apply reaches the control plane at all: the
-	// apply runs inside a cron request that has no CP response to ride on, so
-	// if it fails, expires, or finds itself already applied, the next metadata
-	// push is the sole carrier of that fact. Without it a confirmation timeout
-	// is indistinguishable between "the cron run never happened" and "the cron
-	// run happened and the upgrade failed", which are different incidents with
-	// different fixes.
+	// apply releases its response before it begins the swap, so if it fails,
+	// expires, or finds itself already applied, the next metadata push is the
+	// sole carrier of that fact. Without it a confirmation timeout is
+	// indistinguishable between "the apply never ran" and "the apply ran and
+	// the upgrade failed", which are different incidents with different fixes.
 	AgentSelfUpdate *agentSelfUpdateResultDTO `json:"agent_self_update,omitempty"`
 }
 
@@ -139,6 +138,14 @@ type agentSelfUpdateResultDTO struct {
 	// every agent that predates it, and from every record an old agent already
 	// wrote before it upgraded.
 	ApplyID flexString `json:"apply_id"`
+	// Rung is the connection-release rung the apply actually ran on: fpm and
+	// litespeed released the response first, the portable fallback did not and
+	// held the caller's connection for the whole swap. Purely diagnostic, it
+	// gates nothing. It exists because the SAPI that cannot release a response
+	// was once refused outright, and knowing which sites upgrade on an attached
+	// connection is how that decision stays evidence-based rather than
+	// re-argued. Absent from every agent before 0.61.110.
+	Rung flexString `json:"rung"`
 }
 
 // hostFlagsDTO mirrors the defined()-based hosting fingerprint the agent
@@ -285,6 +292,7 @@ func (d metadataDTO) toMetadata() Metadata {
 			Detail:      string(d.AgentSelfUpdate.Detail),
 			At:          int64PtrOrZero(d.AgentSelfUpdate.At),
 			ApplyID:     string(d.AgentSelfUpdate.ApplyID),
+			Rung:        string(d.AgentSelfUpdate.Rung),
 		}
 	}
 	return m
@@ -367,6 +375,10 @@ type AgentSelfUpdateResult struct {
 	// the control plane distinguish ITS OWN apply's outcome from an unrelated
 	// version movement, see update.agentApplyAttributed.
 	ApplyID string
+	// Rung is the connection-release rung the apply ran on: fpm, litespeed, or
+	// the portable fallback that could not release the response. Diagnostic
+	// only; it gates nothing. "" for every agent before 0.61.110.
+	Rung string
 }
 
 // Component is one installed plugin/theme. AvailableUpdate is set when the

--- a/apps/api/internal/agentcmd/agent_self_update_contract.go
+++ b/apps/api/internal/agentcmd/agent_self_update_contract.go
@@ -43,21 +43,26 @@ package agentcmd
 //   filter, and answers "scheduled". NOTHING on disk has moved when either
 //   acknowledgement is returned.
 //
-//   The response is then written and the connection released (the same
-//   fastcgi_finish_request / litespeed_finish_request detach the agent's
-//   other long-running jobs use) BEFORE anything is touched. Only once the
-//   connection is confirmed detached does this SAME request continue: it
-//   forces wp_doing_cron() true for the duration, which is what lets core's
-//   unmodified Plugin_Upgrader run the swap without deactivating the plugin
-//   and with its own maintenance-mode window covering the destructive part,
-//   then runs the upgrade through core's ordinary upgrader machinery. A SAPI
-//   that cannot detach the connection (neither of the two functions above)
-//   refuses to run the upgrade at all rather than run it on a connection
-//   something else can time out mid-swap; nothing on disk moves on that path,
-//   and the site is told to update itself from its dashboard instead. If the
-//   acknowledgement itself cannot be written, the apply is abandoned before
-//   anything is touched, and an un-upgraded site simply re-arms on its next
-//   command.
+//   The response is then written, and the connection is released where the
+//   SAPI can do it (the same fastcgi_finish_request / litespeed_finish_request
+//   detach the agent's other long-running jobs use) BEFORE anything is
+//   touched. This SAME request then continues regardless of whether that
+//   detach was possible: it forces wp_doing_cron() true for the duration,
+//   which is what lets core's unmodified Plugin_Upgrader run the swap without
+//   deactivating the plugin and with its own maintenance-mode window covering
+//   the destructive part, then runs the upgrade through core's ordinary
+//   upgrader machinery. A SAPI that cannot release the connection (mod_php,
+//   plain CGI) still runs the SAME swap, on an ordinary attached connection,
+//   exactly as WordPress's own plugin/core upgrader already does on that same
+//   hosting on an ordinary wp-admin request; this is why
+//   internal/config.UpdateConfig.ApplyHTTPTimeout exists at CP-scaled
+//   duration rather than the snappy shared command timeout, and why a
+//   transport timeout reading THIS specific command's answer is treated as
+//   uncertain rather than as proof of failure (see update.Worker.armUncertain):
+//   on that SAPI class the acknowledgement this response carries is written
+//   only after the swap already finished. If the acknowledgement itself
+//   cannot be written, the apply is abandoned before anything is touched, and
+//   an un-upgraded site simply re-arms on its next command.
 //
 //   This position, the tail of the SAME request that answered, is what makes
 //   a failed swap survivable. WP_Upgrader::run() registers core's own
@@ -127,14 +132,19 @@ const (
 	// because the CP only creates a task for a site it already classified as
 	// outdated, so this answer means the two disagree.
 	SelfUpdateUpToDate = "up_to_date"
-	// SelfUpdateNotEligible: this build cannot self-update. Three reasons reach
+	// SelfUpdateNotEligible: this build cannot self-update. Two reasons reach
 	// it: the wordpress.org build ships without a self-updater and is upgraded
-	// by the directory; the site is not enrolled; or the site's PHP setup cannot
-	// release the response before doing further work, so the upgrade would run
-	// against a connection the caller is still timing. The last one is decided
-	// at arm time on purpose, so such a site answers immediately instead of
-	// consuming a whole confirmation window and then failing its wave. Carries a
-	// Detail naming which. The channel does not apply to this site at all.
+	// by the directory; or the site is not enrolled. Carries a Detail naming
+	// which. The channel does not apply to this site at all.
+	//
+	// A third reason, the site's PHP setup being unable to release the
+	// response before running the swap, USED TO reach this status: an earlier
+	// design refused the whole upgrade on a SAPI that could not detach the
+	// connection (mod_php, plain CGI). That refusal is gone; such a site now
+	// runs the identical swap on an attached connection instead, the same way
+	// WordPress's own plugin/core upgrader already does on that hosting every
+	// day. See the protocol notes above and update.Worker.armUncertain for
+	// what replaced it on the control plane side.
 	SelfUpdateNotEligible = "not_eligible"
 	// SelfUpdateError: the arm failed, manifest fetch/verification failed, or
 	// the site could not take the upgrade seam (the WordPress filter API was

--- a/apps/api/internal/agentcmd/client.go
+++ b/apps/api/internal/agentcmd/client.go
@@ -493,6 +493,18 @@ func isTimeoutErr(err error) bool {
 	return errors.Is(err, context.DeadlineExceeded)
 }
 
+// IsTimeoutErr is the exported form of isTimeoutErr, for callers outside this
+// package that need to distinguish "the control plane's own read/deadline
+// expired" from every other command failure. The update package's agent
+// self-update worker uses it: on a non-detaching SAPI the agent's ack is
+// written only after the whole apply, so the control plane's read timing out
+// on that specific command is not evidence the upgrade failed, only that this
+// request could not wait for the answer (see agent_worker.go). Every other
+// caller of this predicate (retry/backoff classification, reachability
+// probing) continues to use the unexported form; export only widens visibility,
+// it does not change what the predicate matches.
+func IsTimeoutErr(err error) bool { return isTimeoutErr(err) }
+
 // isTLSErr reports whether err is (or wraps) a TLS handshake failure: an
 // invalid, hostname-mismatched, or untrusted certificate, or a malformed TLS
 // record (e.g. a plaintext response on an https port).

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -352,12 +352,29 @@ type BackupConfig struct {
 // pre-update snapshot, download, extract, and core/plugin/theme DB migration
 // all happen inline in one request — and routinely exceeds the snappy 30s
 // HTTPTimeout, which previously drove a spurious CP-recorded "Failed" even
-// though the agent had actually finished. Defaults to 5m: longer than the
-// 30s shared update timeout, shorter than the 10m backup timeout (an update
-// apply + its mandatory snapshot is lighter than a full-site backup), and
-// leaves headroom under the agent's own apply script cap
-// (set_time_limit(900)) for network/transfer overhead on top of the agent's
-// own execution time.
+// though the agent had actually finished.
+//
+// This budget also covers the agent's OWN self-update apply. On a SAPI that
+// cannot detach the connection (mod_php, plain CGI), the control plane holds
+// this same connection open for the agent's entire apply, not just the
+// package download: the agent's own package-download budget alone
+// (PACKAGE_TIMEOUT, 300s) can consume nearly all of a 5m cap and leave
+// nothing for the unzip and swap that follow it. Defaults to 8m: still well
+// inside the 10m backup timeout (an update apply + its mandatory snapshot is
+// lighter than a full-site backup), longer than the 30s shared update
+// timeout, and leaves real headroom over the agent's 300s download budget for
+// the unzip/swap phase.
+//
+// It deliberately does NOT try to cover the agent's own 900s apply cap, and
+// it could not: the range this value is pinned to tops out below that. On a
+// slow non-detaching host this deadline can therefore expire while the apply
+// is still legitimately running. That is not treated as a failure, because it
+// is not evidence of one. A timeout here resolves the task as UNCERTAIN and
+// enqueues the same confirmation poll a normal arm would, so the outcome is
+// decided by the site reporting its own new version rather than by whether
+// one HTTP read outlasted one file swap. Making the control plane wait out
+// the whole apply would be the wrong fix for the same reason: the connection
+// is not the success signal.
 //
 // AgentSelfUpdateEnabled (WPMGR_UPDATE_AGENT_SELF_UPDATE_ENABLED) is the
 // fleet-wide kill switch for the agent's OWN upgrade channel, and it DEFAULTS
@@ -647,7 +664,7 @@ func defaults() map[string]any {
 		"update.per_tenant_parallelism": 5,
 		"update.http_timeout":           "30s",
 		"update.http_retries":           2,
-		"update.apply_http_timeout":     "5m",
+		"update.apply_http_timeout":     "8m",
 		// Fleet-wide kill switch for the agent's own upgrade channel. Ships
 		// DISABLED: merging the channel changes nothing until an operator
 		// explicitly turns it on. See UpdateConfig.AgentSelfUpdateEnabled.

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -88,8 +88,8 @@ func TestLoadUpdateApplyHTTPTimeoutDefault(t *testing.T) {
 	if got := cfg.Update.ApplyHTTPTimeout; got > cfg.Backup.HTTPTimeout {
 		t.Fatalf("Update.ApplyHTTPTimeout = %v, want <= Backup.HTTPTimeout (%v) — an update apply is lighter than a full-site backup", got, cfg.Backup.HTTPTimeout)
 	}
-	if got := cfg.Update.ApplyHTTPTimeout; got != 5*time.Minute {
-		t.Fatalf("Update.ApplyHTTPTimeout = %v, want 5m default", got)
+	if got := cfg.Update.ApplyHTTPTimeout; got != 8*time.Minute {
+		t.Fatalf("Update.ApplyHTTPTimeout = %v, want 8m default", got)
 	}
 }
 

--- a/apps/api/internal/site/model.go
+++ b/apps/api/internal/site/model.go
@@ -317,6 +317,12 @@ type AgentSelfUpdateResult struct {
 	// to THIS run's own apply when the two match. Never treated as a version
 	// or a time, and never parsed: compared whole.
 	ApplyID string `json:"apply_id,omitempty"`
+	// Rung is the connection-release rung the apply ran on: fpm, litespeed, or
+	// the portable fallback that held the caller's connection for the whole
+	// swap. Diagnostic only, it gates nothing, and it is how a fleet-wide read
+	// can tell which sites upgrade on an attached connection. Empty for every
+	// agent before 0.61.110.
+	Rung string `json:"rung,omitempty"`
 }
 
 // MetadataExtras carries the ADR-037 Sprint 1 sparse-metadata expansion. The

--- a/apps/api/internal/site/service.go
+++ b/apps/api/internal/site/service.go
@@ -452,6 +452,7 @@ func fromAgentSelfUpdateResult(r *agentpkg.AgentSelfUpdateResult) *AgentSelfUpda
 		Detail:      r.Detail,
 		At:          r.At,
 		ApplyID:     r.ApplyID,
+		Rung:        r.Rung,
 	}
 }
 
@@ -488,6 +489,8 @@ const (
 	// maxSelfUpdateApplyID bounds the opaque per-apply identifier. Generous
 	// for a hex-encoded random token, still a hard cap on agent-supplied text.
 	maxSelfUpdateApplyID = 64
+	// maxSelfUpdateRung bounds the diagnostic connection-release rung name.
+	maxSelfUpdateRung = 32
 )
 
 // truncateRunes returns s truncated to at most n runes, never splitting a
@@ -605,6 +608,7 @@ func sanitizeAgentSelfUpdate(r *AgentSelfUpdateResult) *AgentSelfUpdateResult {
 		Detail:      truncateRunes(r.Detail, maxSelfUpdateDetail),
 		At:          at,
 		ApplyID:     truncateRunes(strings.TrimSpace(r.ApplyID), maxSelfUpdateApplyID),
+		Rung:        truncateRunes(strings.TrimSpace(r.Rung), maxSelfUpdateRung),
 	}
 }
 

--- a/apps/api/internal/update/agent_self_update_channel_test.go
+++ b/apps/api/internal/update/agent_self_update_channel_test.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -498,6 +499,156 @@ func TestArmErrorNeverLosesTheAgentsDetail(t *testing.T) {
 	}
 	if task.Error == agentcmd.SelfUpdateError {
 		t.Fatal("the task error must be the agent's reason, not the bare status string")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Beat 1: a CP-side transport timeout is not evidence of failure
+// ---------------------------------------------------------------------------
+
+// agentArmTimedOut is the error agentcmd.Client.AgentSelfUpdate really
+// produces when the control plane's own read/deadline expires before an
+// answer arrives: postRaw wraps the transport failure with "%w", so the
+// chain still satisfies agentcmd.IsTimeoutErr via errors.Is(context.
+// DeadlineExceeded). Written out with the real wrapping rather than a bare
+// context.DeadlineExceeded, so a change to that wrapping (or to
+// IsTimeoutErr's own errors.As/errors.Is walk) fails this test instead of
+// silently un-branching the code under it.
+func agentArmTimedOut() error {
+	return fmt.Errorf("agent_self_update command transport: %w", context.DeadlineExceeded)
+}
+
+// TestArmTimeoutIsUncertainNotFailed is the GH self-update mod_php unlock's
+// CP-side guard. On a SAPI that cannot detach the connection, the agent
+// writes its beat-1 acknowledgement only after the WHOLE apply finishes, so
+// the control plane's own ApplyHTTPTimeout expiring on that specific request
+// most often means the apply is still running (or already succeeded), not
+// that the site rejected it. Recording that as TaskFailed is exactly the
+// spurious-failure regression cfg.Update.ApplyHTTPTimeout's own doc comment
+// records happening in production; asserting it again here for the very host
+// class this change exists to unlock would recreate the failure discarding
+// its own fix. The task must stay open and the confirm poll must still get
+// its chance to observe whether the site's version actually moved.
+func TestArmTimeoutIsUncertainNotFailed(t *testing.T) {
+	cmd := &recordingSelfUpdater{err: agentArmTimedOut()}
+	h := newAgentHarness(t, 10, cmd, &fakeVersions{}, true)
+
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+
+	task := h.store.Task(0)
+	if task.Status == TaskFailed {
+		t.Fatalf("a CP-side transport timeout on the arm command is not evidence the upgrade failed: %+v", task)
+	}
+	if terminal(task.Status) {
+		t.Fatalf("an uncertain arm must leave the task un-finished, got status %q", task.Status)
+	}
+	if task.Status != TaskRunning {
+		t.Fatalf("status = %q, want %q", task.Status, TaskRunning)
+	}
+	for _, fin := range h.repo.finished {
+		if fin.TaskID == task.ID {
+			t.Fatalf("an uncertain arm must never be finished outright: %+v", fin)
+		}
+	}
+
+	// The run must not advance: wave 1 stays shut behind an unconfirmed
+	// canary, exactly as a genuine "scheduled" ack behaves.
+	if len(h.enq.tasks) != 0 {
+		t.Fatalf("no further wave may be enqueued while the canary's own outcome is still uncertain: %+v", h.enq.tasks)
+	}
+	if h.store.RunStatus() == RunHalted {
+		t.Fatal("an uncertain arm must never halt the run on its own")
+	}
+
+	// What it MUST do is give the site's own reported version the chance to
+	// decide the outcome, on the run's own planned target: the arm response
+	// that would have carried the agent's own to_version was never read.
+	if len(h.enq.confirms) != 1 {
+		t.Fatalf("an uncertain arm must schedule exactly one confirmation poll, got %d", len(h.enq.confirms))
+	}
+	got := h.enq.confirms[0]
+	if got.ExpectVersion != agentPlanTarget {
+		t.Fatalf("ExpectVersion = %q, want the run's own planned target %q", got.ExpectVersion, agentPlanTarget)
+	}
+	if got.FromVersion != agentPlanFrom {
+		t.Fatalf("FromVersion = %q, want %q", got.FromVersion, agentPlanFrom)
+	}
+	if got.ApplyID != "" {
+		t.Fatalf("ApplyID = %q, want empty: the beat-1 answer that would have carried one was never read", got.ApplyID)
+	}
+	// CronMode is unknown (the response was never read), so it must earn the
+	// same NARROW window an agent that simply omitted the field gets, never
+	// the wider external-cron window: widening on missing evidence would buy
+	// false patience.
+	if want := time.Now().Add(agentConfirmDeadline); got.DeadlineAt.After(want.Add(time.Minute)) || got.DeadlineAt.Before(want.Add(-time.Minute)) {
+		t.Fatalf("deadline = %s, want the narrow confirm window (~%s from now)", got.DeadlineAt, agentConfirmDeadline)
+	}
+}
+
+// TestArmTimeoutStillConfirmsOnVersionMove closes the loop: an uncertain arm
+// must not just avoid a false failure, it must still let a REAL upgrade
+// confirm. The confirm poll enqueued after a timed-out arm is read here
+// exactly as a genuine "scheduled" ack's poll would be, and the site
+// reporting the new version must succeed the task and open the next wave.
+func TestArmTimeoutStillConfirmsOnVersionMove(t *testing.T) {
+	versions := &fakeVersions{versions: map[uuid.UUID]string{}}
+	cmd := &recordingSelfUpdater{err: agentArmTimedOut()}
+	h := newAgentHarness(t, 10, cmd, versions, true)
+
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	args := h.enq.confirms[0]
+	versions.versions[args.SiteID] = agentPlanTarget // the new code phoned home anyway
+
+	cw := NewAgentConfirmWorker(h.w)
+	if err := cw.Work(context.Background(), &river.Job[AgentConfirmArgs]{Args: args}); err != nil {
+		t.Fatalf("confirm Work: %v", err)
+	}
+	task := h.store.Task(0)
+	if task.Status != TaskSucceeded {
+		t.Fatalf("status = %q, want %q: an arm the CP could not read must still be provable by version movement", task.Status, TaskSucceeded)
+	}
+	if task.ToVersion != agentPlanTarget {
+		t.Fatalf("to_version = %q, want the version the site actually reported %q", task.ToVersion, agentPlanTarget)
+	}
+	// Confirming the canary is what opens wave 1.
+	if len(h.enq.tasks) != 3 {
+		t.Fatalf("confirming the canary must enqueue wave 1's sites, got %d", len(h.enq.tasks))
+	}
+}
+
+// TestArmTimeoutThatNeverReachedTheSiteStillFailsHonestly is the other half:
+// if the arm genuinely never reached the site (the transport timeout was
+// real, not just a slow read of a real answer), nothing moves and the
+// confirm poll must still fail the task once its own deadline passes,
+// exactly as an ordinary unconfirmed "scheduled" ack does. Treating the
+// timeout as uncertain must never turn into treating it as permanently
+// unaccountable.
+func TestArmTimeoutThatNeverReachedTheSiteStillFailsHonestly(t *testing.T) {
+	versions := &fakeVersions{versions: map[uuid.UUID]string{}}
+	cmd := &recordingSelfUpdater{err: agentArmTimedOut()}
+	h := newAgentHarness(t, 10, cmd, versions, true)
+
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	args := h.enq.confirms[0]
+	versions.versions[args.SiteID] = agentPlanFrom // never moved
+	args.DeadlineAt = time.Now().Add(-time.Second) // window already closed
+
+	cw := NewAgentConfirmWorker(h.w)
+	if err := cw.Work(context.Background(), &river.Job[AgentConfirmArgs]{Args: args}); err != nil {
+		t.Fatalf("confirm Work: %v", err)
+	}
+	task := h.store.Task(0)
+	if task.Status != TaskFailed {
+		t.Fatalf("status = %q, want %q", task.Status, TaskFailed)
+	}
+	if h.store.RunStatus() != RunHalted {
+		t.Fatalf("run status = %q, want %q", h.store.RunStatus(), RunHalted)
 	}
 }
 

--- a/apps/api/internal/update/agent_worker.go
+++ b/apps/api/internal/update/agent_worker.go
@@ -25,6 +25,13 @@ const (
 	// verified a newer build and began applying it inside the same request.
 	// It is NOT a success record, the task is still running at this point.
 	ActionAgentSelfUpdateArmed = "update.agent.armed"
+	// ActionAgentSelfUpdateArmUncertain records a beat-1 request whose own
+	// HTTP round trip timed out before this control plane read an answer. It
+	// is deliberately a DIFFERENT action from ActionAgentSelfUpdateArmed: it
+	// is not evidence the agent armed anything, only that this request could
+	// not wait for the answer (see armUncertain). The confirm poll enqueued
+	// alongside it is what actually decides the task's outcome.
+	ActionAgentSelfUpdateArmUncertain = "update.agent.arm_uncertain"
 )
 
 // Confirmation timing. These bound beat 2: how long the control plane waits
@@ -261,6 +268,24 @@ func (w *Worker) runAgentSelfUpdate(ctx context.Context, args TaskArgs, task Tas
 			return w.finishAgentTask(ctx, claimed, TaskSkipped, claimed.FromVersion, "",
 				"not attempted: this site's agent predates the self-update channel and has no self-update route, "+
 					"so it cannot upgrade itself and must be upgraded another way. Nothing was sent to the site and nothing was applied.", "")
+		}
+		// A timeout on THIS command is not evidence the upgrade failed. On a
+		// SAPI that cannot detach the connection (mod_php, plain CGI), the
+		// agent writes its beat-1 acknowledgement only after the whole apply
+		// finishes, so this control plane's own read timing out here most
+		// often means the request arrived and the apply is still running (or
+		// already succeeded), not that the site rejected it. Asserting
+		// TaskFailed on that evidence is exactly the failure mode
+		// cfg.Update.ApplyHTTPTimeout's own doc comment records happening in
+		// production. Score it as uncertain and let the beat-2 confirm poll,
+		// the only channel that ever decided this outcome, observe whether
+		// the site's version actually moved.
+		if agentcmd.IsTimeoutErr(err) {
+			w.logger.Warn("agent self-update: arm command timed out before an answer was read; confirming on version movement instead of failing the task",
+				slog.String("task_id", claimed.ID.String()),
+				slog.String("site_id", claimed.SiteID.String()),
+				slog.Any("error", err))
+			return w.armUncertain(ctx, args, claimed)
 		}
 		return w.finishAgentTask(ctx, claimed, TaskFailed, claimed.FromVersion, "",
 			"agent self-update arm command failed", err.Error())
@@ -521,6 +546,85 @@ func (w *Worker) armed(ctx context.Context, args TaskArgs, task Task, from strin
 				// unattributed-confirmation incident is diagnosable from this
 				// log alone, see agentApplyAttributed.
 				"apply_id": shortApplyID(resp.ApplyID),
+			},
+		})
+	}
+	return nil
+}
+
+// armUncertain handles a beat-1 arm command whose HTTP round trip itself
+// timed out (agentcmd.IsTimeoutErr) before this control plane read an
+// answer. On a SAPI that cannot detach the connection, the agent's ack is
+// only ever written AFTER the whole apply, so this control plane's own read
+// deadline expiring on that specific request proves nothing: the arm may
+// never have reached the site, or the site may already be running the new
+// build. It is neither armed() nor a failure, and it is handled separately
+// from both rather than folded into either, so it is never mistaken in a log
+// or an audit trail for a beat-1 acknowledgement this control plane never
+// actually read.
+//
+// It enqueues the SAME beat-2 confirm poll armed() would, so the outcome is
+// still decided by the one channel this protocol ever trusted: whether the
+// site's reported version actually moves. Two differences from a normal arm,
+// because the fields they would come from were never read:
+//
+//   - ExpectVersion is the run's own PLANNED target (task.DesiredVersion,
+//     resolved and persisted at plan time; see planAgentTasks), not an
+//     agent-reported to_version this control plane never received.
+//   - CronMode is agentcmd.CronModeUnknown, which confirmWindowFor already
+//     treats identically to an agent that simply omitted the field: the
+//     narrow window, because widening on missing evidence would buy false
+//     patience rather than honesty.
+//   - ApplyID is "", the same shape an agent that predates that field
+//     produces; agentConfirmOutcome already confirms on version movement
+//     alone in that case (see agentApplyAttributed).
+//
+// If the arm truly never reached the site, nothing moves and the confirm
+// poll fails the task honestly at its deadline (agent_self_update_unconfirmed)
+// instead of asserting a cause this control plane never observed.
+func (w *Worker) armUncertain(ctx context.Context, args TaskArgs, task Task) error {
+	deadline := time.Now().Add(confirmWindowFor(agentcmd.CronModeUnknown))
+
+	if err := w.agent.Confirms.EnqueueAgentConfirm(ctx, AgentConfirmArgs{
+		TenantID:      task.TenantID,
+		RunID:         task.RunID,
+		TaskID:        task.ID,
+		SiteID:        task.SiteID,
+		FromVersion:   task.FromVersion,
+		ExpectVersion: task.DesiredVersion,
+		CronMode:      agentcmd.CronModeUnknown,
+		DeadlineAt:    deadline,
+		ApplyID:       "",
+	}); err != nil {
+		// Without the confirm job nothing would ever establish whether this
+		// upgrade landed, and the task would sit running until the reaper
+		// swept it. This IS a genuine failure of the control plane's own
+		// bookkeeping (not of the upgrade), so it is recorded as one.
+		return w.finishAgentTask(ctx, task, TaskFailed, task.FromVersion, "",
+			"the arm command timed out before an answer was read, and the confirmation poll that would have decided the outcome could not be enqueued either",
+			err.Error())
+	}
+
+	w.logger.Info("agent self-update arm uncertain: confirming on version movement",
+		slog.String("task_id", task.ID.String()),
+		slog.String("site_id", task.SiteID.String()),
+		slog.String("from_version", task.FromVersion),
+		slog.String("expect_version", task.DesiredVersion),
+		slog.Time("confirm_deadline", deadline))
+
+	if w.audit != nil {
+		_, _ = w.audit.Record(ctx, audit.Event{
+			TenantID:   task.TenantID,
+			ActorType:  audit.ActorSystem,
+			Action:     ActionAgentSelfUpdateArmUncertain,
+			TargetType: "update_task",
+			TargetID:   task.ID.String(),
+			Metadata: map[string]any{
+				"run_id":         args.RunID.String(),
+				"site_id":        task.SiteID.String(),
+				"from_version":   task.FromVersion,
+				"expect_version": task.DesiredVersion,
+				"deadline_at":    deadline.UTC().Format(time.RFC3339),
 			},
 		})
 	}

--- a/apps/api/internal/update/worker.go
+++ b/apps/api/internal/update/worker.go
@@ -176,7 +176,7 @@ func (w *Worker) Timeout(*river.Job[TaskArgs]) time.Duration { return w.jobTimeo
 //
 //  1. applyHTTPTimeout: the ONE apply/rollback command round trip
 //     (cfg.Update.ApplyHTTPTimeout; see UpdateConfig's doc comment in
-//     internal/config for how its 5m default was picked).
+//     internal/config for how its 8m default was picked).
 //  2. the agent-first reachability ladder (verifyAgentHealthWithRetry, GH #291
 //     Phase 4): up to len(probeRetryDelays)+1 attempts, each hard-capped at
 //     agentVerifyTimeout via context.WithTimeout, plus the sleep between
@@ -194,9 +194,9 @@ func (w *Worker) Timeout(*river.Job[TaskArgs]) time.Duration { return w.jobTimeo
 //     (internal/httpclient.Client.Do; not separately itemized above to keep
 //     this arithmetic reviewable).
 //
-// With the production defaults (applyHTTPTimeout=5m, probeHTTPTimeout=30s,
+// With the production defaults (applyHTTPTimeout=8m, probeHTTPTimeout=30s,
 // agentVerifyTimeout=8s, probeRetryDelays summing to ~21s across 4 delays)
-// this computes to 5m + 61s + 171s + 2m = 10m52s, comfortably under
+// this computes to 8m + 61s + 171s + 2m = 13m52s, comfortably under
 // staleTaskThreshold (45m), so the periodic reaper still cannot terminalize a
 // task that is legitimately still running.
 //

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,30 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.110",
+    date: "2026-07-31",
+    summary: "Fleet agent updates now run on Apache with mod_php and plain CGI hosting instead of refusing outright, and a rollout halt banner no longer misreports a site that answered as one that was never reached.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Fleet agent updates no longer refuse to run on Apache with mod_php or plain CGI hosting, which is common on shared and self managed servers. The previous release declined to update the agent itself unless the web server could hand the connection back to WordPress before the file swap started, reasoning that a lost connection mid swap was unsafe there. That reasoning did not hold up: WordPress's own plugin and core updater performs exactly the same file swap, protected by exactly the same safeguards, on that same kind of hosting every day, whenever an operator clicks \"Update now\" in wp-admin. The fleet update now runs that identical, already safe swap instead of refusing outright, so a site on this kind of hosting updates itself from the fleet dashboard the same way it already updates from its own wp-admin.",
+      },
+      {
+        tag: "Fixed",
+        text: "Because the control plane now waits out the whole install on this kind of hosting instead of getting an instant acknowledgement, the time it is willing to wait for that one request was raised from 5 to 8 minutes, so a slower host has room to finish both the download and the file swap in the same request.",
+      },
+      {
+        tag: "Fixed",
+        text: "A control plane request that times out while an agent update is still applying is no longer recorded as a failed rollout. On this kind of hosting the agent's acknowledgement is only written after the whole swap finishes, so a slow answer is not evidence anything went wrong. The rollout now waits for the site's own report of the version it is running before deciding the outcome, exactly as it already does for an ordinary acknowledgement.",
+      },
+      {
+        tag: "Fixed",
+        text: "A rollout's halt banner could read \"The rollout was halted before any site could be contacted\" for a site that was, in fact, contacted and answered, when all that actually happened was the site politely declining the update rather than failing or never receiving it at all. The summary now counts a declined site as contacted and says so plainly.",
+      },
+    ],
+    featureLinks: [{ label: "Updates", href: "/features/updates/" }],
+  },
+  {
     version: "0.61.109",
     date: "2026-07-31",
     summary: "A deliberate no-op release, so the rebuilt agent update path from 0.61.108 has something real to install.",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.109 / open source",
+  badge: "v0.61.110 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/apps/web/src/features/updates/summarize.test.ts
+++ b/apps/web/src/features/updates/summarize.test.ts
@@ -156,14 +156,32 @@ describe("haltReason", () => {
   it("falls back to a counts-derived summary when no task was cancelled", () => {
     // A single-site canary run: the one task is already terminal (failed) by
     // the time the gate re-judges it, so haltLocked has nothing left to
-    // cancel.
+    // cancel. Zero confirmations, so the "no site confirmed" wording applies.
     expect(
       haltReason({
         status: "halted",
         tasks: [task({ status: "failed" })],
       }),
     ).toBe(
-      "The rollout was halted after 1 of 1 contacted site failed to confirm the upgrade.",
+      "The rollout was halted because no site confirmed the upgrade (1 failed, 0 skipped, of 1 contacted).",
+    );
+  });
+
+  it("counts a partial-confirmation halt against the sites that were actually contacted", () => {
+    // Wave 1 of 3: two sites confirmed, one failed, so the wave's own
+    // failure-rate threshold halted the run. `confirmed` is nonzero here,
+    // which is the branch this case pins.
+    expect(
+      haltReason({
+        status: "halted",
+        tasks: [
+          task({ id: "t1", status: "succeeded" }),
+          task({ id: "t2", status: "succeeded" }),
+          task({ id: "t3", status: "failed" }),
+        ],
+      }),
+    ).toBe(
+      "The rollout was halted after 1 of 3 contacted sites failed to confirm the upgrade.",
     );
   });
 
@@ -174,5 +192,29 @@ describe("haltReason", () => {
         tasks: [task({ status: "cancelled", detail: undefined })],
       }),
     ).toBe("The rollout was halted before any site could be contacted.");
+  });
+
+  // GH self-update mod_php unlock, D-A: a run whose only task came back
+  // `skipped` (the agent answered: an old agent with no self-update route,
+  // a build this channel does not apply to, an unconfirmed "up to date") is
+  // NOT a site nobody heard from. Before this fix `contacted` excluded
+  // `skipped` entirely, so this exact shape rendered the false "before any
+  // site could be contacted" sentence for a site that was, in fact,
+  // contacted and answered.
+  it("counts a skipped task as contacted, not as never-contacted", () => {
+    expect(
+      haltReason({
+        status: "halted",
+        tasks: [
+          task({
+            status: "skipped",
+            detail:
+              "not attempted: this site's agent predates the self-update channel and has no self-update route",
+          }),
+        ],
+      }),
+    ).toBe(
+      "The rollout was halted because no site confirmed the upgrade (0 failed, 1 skipped, of 1 contacted).",
+    );
   });
 });

--- a/apps/web/src/features/updates/summarize.ts
+++ b/apps/web/src/features/updates/summarize.ts
@@ -80,9 +80,27 @@ export function isAgentNotEligible(
  * apps/api/internal/update/agent_repo.go haltLocked), so any cancelled task
  * in the run carries the same reason. A run can halt with zero cancelled
  * tasks (e.g. a single-site canary already terminal when the gate re-judged
- * it); in that case fall back to a summary built from the run's own counts,
- * which is still grounded in real data even though it is not the backend's
- * literal sentence. Returns null for a run that has not halted.
+ * it, which is exactly what happens when its one task comes back `skipped`
+ * rather than `cancelled`: haltLocked only cancels tasks still `pending`, and
+ * `haltReasonFor` (apps/api/internal/update/agent_wave.go) is the backend's
+ * own reason string for that shape of halt, but it is only ever computed and
+ * logged/audited, never persisted onto the run row itself, so there is
+ * nothing for this client to read back verbatim here). In that case fall
+ * back to a summary built from the run's own task counts, mirroring the
+ * backend's own wave tally (`tallyWave`/`haltReasonFor`) rather than
+ * re-deriving different arithmetic client-side:
+ *
+ *   - `contacted` is `succeeded + failed + rolled_back + skipped`. A skipped
+ *     task WAS contacted and answered (an old agent with no self-update
+ *     route, a build the channel does not apply to, an "up to date" answer
+ *     that did not match this run's premise), so it is not a site nobody
+ *     heard from and it must never be folded into "nobody was contacted".
+ *     Only `cancelled` means nothing was ever sent (see summarizeTasks
+ *     above).
+ *   - `failed` is `failed + rolled_back`, matching the backend's own
+ *     tallyWave grouping.
+ *
+ * Returns null for a run that has not halted.
  */
 export function haltReason(
   run: Pick<UpdateRun, "status" | "tasks"> | undefined,
@@ -97,11 +115,15 @@ export function haltReason(
       : cancelledDetail;
   }
   const { counts } = summarizeTasks(run.tasks ?? []);
-  const contacted = counts.succeeded + counts.failed + counts.rolled_back;
+  const failed = counts.failed + counts.rolled_back;
+  const contacted = counts.succeeded + failed + counts.skipped;
   if (contacted === 0) {
     return "The rollout was halted before any site could be contacted.";
   }
-  return `The rollout was halted after ${counts.failed} of ${contacted} contacted site${contacted === 1 ? "" : "s"} failed to confirm the upgrade.`;
+  if (counts.succeeded === 0) {
+    return `The rollout was halted because no site confirmed the upgrade (${failed} failed, ${counts.skipped} skipped, of ${contacted} contacted).`;
+  }
+  return `The rollout was halted after ${failed} of ${contacted} contacted site${contacted === 1 ? "" : "s"} failed to confirm the upgrade.`;
 }
 
 /** Build a site id -> name lookup from the sites list cache. */

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.109
+  version: 0.61.110
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,
@@ -13272,6 +13272,16 @@ components:
                 a version movement can only be credited to the run that caused
                 it rather than to some other event that happened to move the
                 site's version.
+            rung:
+              type: string
+              description: |
+                Connection-release rung the apply actually ran on: fpm or
+                litespeed released the response before the swap, the portable
+                fallback held the caller's connection for its whole duration.
+                Diagnostic only, it gates nothing. It exists so a fleet-wide
+                read can tell which sites upgrade on an attached connection,
+                which is what keeps that decision evidence-based. Absent from
+                every agent before 0.61.110.
         plugins:
           type: array
           items:


### PR DESCRIPTION
Follow-up to #320. Reported by the operator against a real production site.

## What happened

0.61.108 gated the agent self-update on being able to release the HTTP response before replacing the plugin directory, which in practice means PHP-FPM or LiteSpeed. Every other SAPI was refused at arm time with `not_eligible`.

The first real site it met was `apache2handler`, ordinary Apache mod_php. It was refused, correctly per the code and wrongly per reality, with:

> This PHP SAPI offers neither fastcgi_finish_request nor litespeed_finish_request, so the agent cannot release the control-plane connection before replacing its own directory...

The operator's observation is what unravelled it: **WordPress's own updates work fine on that host.**

## The evidence against the gate

**Core has zero SAPI checks in its upgrade path.** A grep over `class-wp-upgrader.php`, `class-plugin-upgrader.php`, `class-wp-automatic-updater.php` and `wp-admin/update.php` returns nothing. Core does not set `ignore_user_abort` in its upgraders either. It updates plugins on mod_php, on an attached connection, on millions of sites, daily.

**We already did the same thing everywhere else.** `canDetach()` had exactly one caller: this gate. `UpdateCommand`, which applies plugins, themes *and WordPress core*, constructs no finisher at all and runs inline and attached on every SAPI, guarded only by `set_time_limit(900)` and `ignore_user_abort(true)` whose own comment reads "keep applying even if the control plane's HTTP client disconnects mid-request."

**The rollback proof holds without detaching.** Re-running the `WP_Hook` proof for a non-detaching apply:

```
apply from shutdown@9997        restore@10=NO   delete@100=NO
apply from request body (fpm)   restore@10=YES  delete@100=YES
apply from request body (fallback rung)  restore@10=YES  delete@100=YES
```

Identical, because the fallback flush neither ends the script nor touches the hook registry. Deleting the gate moves no apply code, so 0.61.108's property is preserved by construction.

**The asymmetry ran backwards.** Apache does not reap a running handler on client disconnect, and the swap is output silent so PHP never performs the abort check at all. The one genuinely unrecoverable kill is FPM `request_terminate_timeout`, which runs no shutdown functions, and that is on the SAPI class the gate *trusted*.

## Deleting it is the fix, not just a removal

`ignore_user_abort(true)`, the bounded `set_time_limit` and `warmPostSwapClasses()` all sat **below** the apply-time early return. On a non-detaching SAPI the guards that actually matter were dead code. Removing the branch hoists them onto every rung.

The rung is now **recorded rather than obeyed**, and travels to the control plane so a fleet read can tell which sites upgrade on an attached connection. `ConnectionFinisher` keeps `canDetach()`; detaching first is still better where possible, just no longer a precondition. `detachReason()` replaces the old sentence and only claims a function was disabled by a setting when it can prove that from `disable_functions`, instead of blaming the SAPI.

## Control plane

- **A CP transport timeout is no longer a failure.** It resolves the task as uncertain and enqueues the same confirmation poll a normal arm would. A read that outlasted a file swap is not evidence the upgrade failed, and must not halt a canary.
- `apply_http_timeout` raised to 8m. It deliberately does **not** try to cover the agent's 900s apply cap, and could not. The confirmation poll is the success signal, not the connection.
- The halt summary no longer claims no site could be contacted when one was contacted, answered, and was skipped.

## Gates

```
phpunit      2953 tests, 0 failures, 0 errors
phpcs        0 errors      plugincheck  0 errors
web vitest   55 passed
go build / vet / test  clean
lockstep     0.61.110 across all four version files
```

## Known limits

- `#319`'s wave 0 canary anomaly is still unexplained and untested, because a rollout where both sides stamp an apply id has not happened yet.
- The agent's 900s apply cap exceeds any CP read budget the pinned config range allows. That is now handled by scoring rather than by waiting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fleet agent self-updates on Apache mod_php and plain CGI hosting.
  * Extended update wait times to support slower sites.
  * Prevented in-progress update timeouts from being immediately marked as failures; confirmation now verifies the final version.
  * Corrected rollout halt messages to accurately reflect contacted sites that declined or skipped updates.
* **Documentation**
  * Updated release information and diagnostic update reporting for version 0.61.110.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->