### PR TITLE
chore(release): 0.61.111, a no-op release to exercise the ungated agent update path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.111] - 2026-07-31
+
+### Changed
+
+- Version bump only, with no functional change to the agent, the control plane or the dashboard. 0.61.110 removed a restriction that had stopped the fleet update channel from running on common Apache mod_php hosting. That restriction lived in the agent, so a site still running 0.61.108 or 0.61.109 refuses the update using its own installed copy of the rule, before it can ever install the release that removes it. The only way onto a fixed build is to update the agent once from the site's own WordPress dashboard, and this release then gives that fixed build something genuine to install so the update path can be exercised end to end. Sites will be offered an update whose only difference is the version number, which is safe to take.
+
 ## [0.61.110] - 2026-07-31
 
 ### Fixed

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.110
+ * Version:           0.61.111
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.110');
+define('WPMGR_AGENT_VERSION', '0.61.111');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,17 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.111",
+    date: "2026-07-31",
+    summary: "A no-op release, so a site that has been moved onto 0.61.110 has something real for the fleet update path to install.",
+    items: [
+      {
+        tag: "Changed",
+        text: "Version bump only, with no functional change to the agent, the control plane or the dashboard. 0.61.110 removed a restriction that had stopped fleet agent updates from running on common Apache mod_php hosting. That restriction lived in the agent itself, so a site still on 0.61.108 or 0.61.109 refuses the update using its own installed copy of the rule, before it can install the release that removes it. Such a site needs one manual update from its own WordPress dashboard to reach a fixed build; this release then gives that build something genuine to install so the path can be exercised end to end. Sites will be offered an update whose only difference is the version number, which is safe to take.",
+      },
+    ],
+  },
+  {
     version: "0.61.110",
     date: "2026-07-31",
     summary: "Fleet agent updates now run on Apache with mod_php and plain CGI hosting instead of refusing outright, and a rollout halt banner no longer misreports a site that answered as one that was never reached.",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.110 / open source",
+  badge: "v0.61.111 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.110
+  version: 0.61.111
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Version bump only. No functional change to the agent, the control plane or the dashboard.

## Why

0.61.110 (#323) removed the SAPI detach gate that stopped fleet agent updates from running on Apache mod_php. That gate lived in the **agent**, so a site on 0.61.108 or 0.61.109 refuses the update using its own installed copy of the rule, before it can ever install the release that deletes it.

`msm.oscod.dev` (apache2handler) has now been moved to 0.61.110 by hand from wp-admin, which is the only way onto a fixed build. This release gives that site something genuine to install so the rebuilt apply path can finally run end to end.

## The bootstrap is structural, not accidental

Third no-op release in this sequence. A fix to the apply path can never be delivered by the apply path it fixes, so every future change in this area costs one manual update plus one throwaway release to verify. Worth stating plainly so it is planned for rather than rediscovered.

## Files

- `apps/agent/wpmgr-agent.php` (header Version and `WPMGR_AGENT_VERSION`)
- `CHANGELOG.md`, `packages/openapi/openapi.yaml` (`info.version`), marketing changelog page and home badge, in lockstep

## Gates

```
phpunit  2953 tests, 0 failures, 0 errors
marketing tsc  clean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the product version to 0.61.111 across the app and published documentation.
  * Added a changelog entry for the version-only release.
  * No functional changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->