### PR TITLE
fix(agent): parse Name <email> addresses instead of sending them as the address (GH #312)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.112] - 2026-07-31
+
+### Fixed
+
+- Outgoing email failed completely whenever a plugin set a Reply-To header in the ordinary "Name <email@example.com>" form, which WooCommerce, Fluent Forms and many other plugins do by default (GH #312). The agent stored that header exactly as written and then handed the whole string, display name included, to the mail transport as if it were the address. The transport rejected it as invalid and, because one bad address aborted the entire message, nothing was sent at all. The reported symptom was an "Invalid address" error in the email log with no mail going out. Addresses are now parsed properly wherever a bare address is required, the display name is kept rather than discarded, and a single bad address costs that one recipient instead of the whole email.
+- The same defect applied to the To, Cc and Bcc headers, not only Reply-To, and affected the SMTP and SendGrid providers. It was reported for Reply-To because that is the header plugins most often set this way, but any of the four could trigger it. The Amazon SES, Postmark and Mailgun providers were unaffected, because those build a raw header where this form is already valid.
+- A header carrying more than one address, for example a Cc listing two recipients, was treated as a single malformed address and lost the whole message on the SMTP and SendGrid providers. Address lists are now split correctly, including the case where a quoted display name contains a comma.
+- A display name could redirect an email to a different address than the one shown. Because header values are commonly assembled by dropping a user-supplied name into a template, a name that itself contained an address in angle brackets could take over as the real destination while the intended address was still displayed. Any entry of that shape is now refused outright rather than delivered somewhere the site owner did not intend.
+
 ## [0.61.111] - 2026-07-31
 
 ### Changed

--- a/apps/agent/includes/commands/class-resend-email-command.php
+++ b/apps/agent/includes/commands/class-resend-email-command.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ResendEmailCommand — re-sends a previously logged email given its local
+ * ResendEmailCommand: re-sends a previously logged email given its local
  * agent_seq (the auto-increment row id from the wpmgr_email_log table).
  *
  * Wire contract (CP -> agent):
@@ -30,6 +30,7 @@ declare(strict_types=1);
 
 namespace WPMgr\Agent\Commands;
 
+use WPMgr\Agent\Email\AddressParser;
 use WPMgr\Agent\Email\EmailConfig;
 use WPMgr\Agent\Email\ProviderRouter;
 use WPMgr\Agent\Schema;
@@ -71,10 +72,10 @@ final class ResendEmailCommand implements CommandInterface {
 			return array( 'ok' => false, 'detail' => 'agent_seq must be a positive integer', 'message_id' => '' );
 		}
 
-		// Load the email config — required before attempting a resend.
+		// Load the email config, required before attempting a resend.
 		$cfg = EmailConfig::load();
 		if ( ! $cfg->is_configured() ) {
-			return array( 'ok' => false, 'detail' => 'no email config — run sync_email_config first', 'message_id' => '' );
+			return array( 'ok' => false, 'detail' => 'no email config, run sync_email_config first', 'message_id' => '' );
 		}
 
 		// Fetch the log row.
@@ -152,26 +153,17 @@ final class ResendEmailCommand implements CommandInterface {
 	 * @return array<string,mixed> Normalised mail payload.
 	 */
 	private function build_mail_from_row( array $row, EmailConfig $cfg ): array {
+		// AddressParser::split_list() is quote-aware (unlike the bare comma/
+		// semicolon regex this replaced), so a stored recipient whose display
+		// name itself contained a comma round-trips as one entry, not two.
 		$mail_to_raw = (string) ( $row['mail_to'] ?? '' );
-		$to_parts    = preg_split( '/[,;]+/', $mail_to_raw ) ?: array();
-		$to          = array();
-		foreach ( $to_parts as $addr ) {
-			$addr = trim( $addr );
-			if ( $addr !== '' ) {
-				$to[] = $addr;
-			}
-		}
+		$to          = $mail_to_raw !== '' ? AddressParser::split_list( $mail_to_raw ) : array();
 
 		// Parse "Name <addr>" format for the From field.
 		$mail_from_raw = (string) ( $row['mail_from'] ?? '' );
-		$from          = '';
-		$from_name     = '';
-		if ( preg_match( '/^(.+?)\s*<([^>]+)>\s*$/', $mail_from_raw, $m ) ) {
-			$from_name = trim( $m[1] );
-			$from      = trim( $m[2] );
-		} else {
-			$from = trim( $mail_from_raw );
-		}
+		$from_entry    = AddressParser::parse_one( $mail_from_raw );
+		$from          = $from_entry !== null ? $from_entry['address'] : trim( $mail_from_raw );
+		$from_name     = $from_entry !== null ? $from_entry['name'] : '';
 
 		$body = (string) ( $row['body'] ?? '' );
 		// Detect HTML body by looking for opening tags.

--- a/apps/agent/includes/email/class-address-parser.php
+++ b/apps/agent/includes/email/class-address-parser.php
@@ -1,0 +1,349 @@
+<?php
+/**
+ * AddressParser: parses RFC 5322 mailbox-list address strings ("Name
+ * <addr@example.com>", a bare address, or a comma-separated mixture of the
+ * two, including a quoted display name that itself contains a comma) into
+ * structured {address, name} entries, and formats them back for header
+ * building.
+ *
+ * Why this exists (GH #312): every outgoing-mail provider handler needs a
+ * BARE address at the point it calls PHPMailer::addAddress()/addCC()/
+ * addBCC()/addReplyTo() or builds a provider API's `email` field, but
+ * MailRouter stores the raw wp_mail() header value verbatim (e.g. the
+ * literal string "Andrea Somigli <salesianalibri@gmail.com>"). Handing that
+ * whole string to PHPMailer as the address throws
+ * "Invalid address:  (Reply-To): Andrea Somigli <salesianalibri@gmail.com>"
+ * and, because SmtpHandler wraps the entire send in one try/catch, takes the
+ * WHOLE message down with it: not just the one malformed field.
+ *
+ * This parser is deliberately self-contained (no PHPMailer dependency):
+ * PHPMailer::parseAddresses() only splits a quoted-comma display name
+ * correctly when the imap extension is loaded (it falls back to a bare
+ * explode(',') otherwise), which is neither guaranteed on a live WordPress
+ * host nor available in this plugin's own test process. The five provider
+ * handlers (SMTP + four HTTP APIs) all need identical, host-independent
+ * parsing, so the logic lives here once rather than five times.
+ *
+ * Never throws. A malformed entry is dropped (parse_one() returns null;
+ * parse_list_verbose() surfaces it back to the caller so it can be reported
+ * and skipped, one address, instead of failing the whole send).
+ *
+ * @package WPMgr\Agent\Email
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Email;
+
+/**
+ * Pure, dependency-free RFC 5322 address-list parser and formatter.
+ */
+final class AddressParser {
+
+	/**
+	 * Parse a mixed-shape address list into structured entries, dropping any
+	 * entry that fails to resolve to a syntactically valid address.
+	 *
+	 * @param string|array<int,mixed> $value Raw header value string (which may
+	 *                                       itself contain a comma-separated list,
+	 *                                       e.g. "a@x.com, b@y.com"), or an array
+	 *                                       of such strings (one per header line
+	 *                                       MailRouter collected).
+	 * @return array<int,array{address:string,name:string}>
+	 */
+	public static function parse_list( $value ): array {
+		return self::parse_list_verbose( $value )['valid'];
+	}
+
+	/**
+	 * Same as parse_list() but also returns the raw entries that could not be
+	 * parsed, so a caller can report and skip them individually rather than
+	 * silently losing them.
+	 *
+	 * @param string|array<int,mixed> $value Raw address list (string or array of strings).
+	 * @return array{valid: array<int,array{address:string,name:string}>, invalid: array<int,string>}
+	 */
+	public static function parse_list_verbose( $value ): array {
+		$valid   = array();
+		$invalid = array();
+
+		$raw_entries = array();
+		if ( is_array( $value ) ) {
+			foreach ( $value as $item ) {
+				if ( ! is_scalar( $item ) ) {
+					continue;
+				}
+				$raw_entries = array_merge( $raw_entries, self::split_list( (string) $item ) );
+			}
+		} else {
+			$raw_entries = self::split_list( (string) $value );
+		}
+
+		foreach ( $raw_entries as $raw_entry ) {
+			$parsed = self::parse_one( $raw_entry );
+			if ( $parsed === null ) {
+				$invalid[] = $raw_entry;
+				continue;
+			}
+			$valid[] = $parsed;
+		}
+
+		return array(
+			'valid'   => $valid,
+			'invalid' => $invalid,
+		);
+	}
+
+	/**
+	 * Parse a SINGLE address entry (already split out of any surrounding
+	 * list): a bare address, or the "Display Name <addr@example.com>" form
+	 * with an optionally quoted display name. Never throws.
+	 *
+	 * @param string $entry One address entry.
+	 * @return array{address:string,name:string}|null Null when the entry does
+	 *         not resolve to a syntactically valid email address.
+	 */
+	public static function parse_one( string $entry ): ?array {
+		$entry = self::strip_crlf( $entry );
+		if ( $entry === '' ) {
+			return null;
+		}
+
+		$name    = '';
+		$address = $entry;
+
+		if ( preg_match( '/^(.*)<([^<>]*)>\s*$/', $entry, $matches ) === 1 ) {
+			$raw_name = trim( $matches[1] );
+
+			// SECURITY: the pattern above is greedy, so it binds to the LAST
+			// angle-addr in the entry. That is correct for a well-formed entry
+			// (exactly one angle-addr, at the end) but it means
+			// 'Bob <bob@example.com> <evil@example.net>' would resolve to the
+			// SECOND address while displaying the first. Header values are
+			// routinely built by interpolating a user-supplied name into
+			// "{name} <{email}>", so a submitted name carrying its own
+			// angle-addr would silently redirect the message.
+			//
+			// A leftover angle bracket in the display-name part therefore only
+			// survives when the whole part is a quoted-string, which is the one
+			// shape RFC 5322 allows it in. Anything else is refused here and
+			// handled exactly as it was before this parser existed: the raw
+			// entry goes to the transport, which rejects it loudly rather than
+			// delivering it somewhere the operator did not intend.
+			if ( strpbrk( $raw_name, '<>' ) !== false && ! self::is_quoted_string( $raw_name ) ) {
+				return null;
+			}
+
+			$name    = self::unquote( $raw_name );
+			$address = trim( $matches[2] );
+		}
+
+		$address = trim( $address );
+
+		if ( $address === '' || ! self::is_valid_address( $address ) ) {
+			return null;
+		}
+
+		return array(
+			'address' => $address,
+			'name'    => $name,
+		);
+	}
+
+	/**
+	 * Split a raw address-list string into individual entries on commas or
+	 * semicolons that fall OUTSIDE a quoted display name or an angle-bracketed
+	 * address, so a quoted name containing a comma (e.g. '"Rossi, Andrea"
+	 * <a@x.com>') is never split in half.
+	 *
+	 * @param string $raw Raw list, e.g. '"Rossi, Andrea" <a@x.com>, b@y.com'.
+	 * @return array<int,string> Trimmed, non-empty entries, in order.
+	 */
+	public static function split_list( string $raw ): array {
+		$entries   = array();
+		$current   = '';
+		$in_quotes = false;
+		$in_angle  = false;
+		$length    = strlen( $raw );
+
+		for ( $i = 0; $i < $length; $i++ ) {
+			$char = $raw[ $i ];
+
+			if ( $in_quotes && $char === '\\' && $i + 1 < $length ) {
+				$current .= $char . $raw[ $i + 1 ];
+				++$i;
+				continue;
+			}
+
+			if ( $char === '"' ) {
+				$in_quotes = ! $in_quotes;
+				$current  .= $char;
+				continue;
+			}
+
+			if ( ! $in_quotes && $char === '<' ) {
+				$in_angle = true;
+				$current .= $char;
+				continue;
+			}
+
+			if ( ! $in_quotes && $char === '>' ) {
+				$in_angle = false;
+				$current .= $char;
+				continue;
+			}
+
+			if ( ! $in_quotes && ! $in_angle && ( $char === ',' || $char === ';' ) ) {
+				$entries[] = trim( $current );
+				$current   = '';
+				continue;
+			}
+
+			$current .= $char;
+		}
+		$entries[] = trim( $current );
+
+		return array_values(
+			array_filter(
+				$entries,
+				static function ( string $entry ): bool {
+					return $entry !== '';
+				}
+			)
+		);
+	}
+
+	/**
+	 * Format one parsed entry back into RFC 5322 "Name <addr>" form (or a
+	 * bare address when there is no name), quoting/escaping the display name
+	 * when needed and stripping CR/LF so the result is always safe to place
+	 * directly into a raw header line.
+	 *
+	 * @param array{address:string,name:string} $entry Parsed entry.
+	 * @return string Empty string when the address itself is empty.
+	 */
+	public static function format( array $entry ): string {
+		$address = isset( $entry['address'] ) ? self::strip_crlf( (string) $entry['address'] ) : '';
+		if ( $address === '' ) {
+			return '';
+		}
+
+		$name = isset( $entry['name'] ) ? self::strip_crlf( (string) $entry['name'] ) : '';
+		if ( $name === '' ) {
+			return $address;
+		}
+
+		return self::quote_name( $name ) . ' <' . $address . '>';
+	}
+
+	/**
+	 * Format a list of parsed entries into a single comma-joined header value.
+	 *
+	 * @param array<int,array{address:string,name:string}> $entries Parsed entries.
+	 * @return string
+	 */
+	public static function format_list( array $entries ): string {
+		$formatted = array();
+		foreach ( $entries as $entry ) {
+			$one = self::format( $entry );
+			if ( $one !== '' ) {
+				$formatted[] = $one;
+			}
+		}
+		return implode( ', ', $formatted );
+	}
+
+	/**
+	 * Whether a string is a syntactically valid RFC 5322 addr-spec.
+	 *
+	 * Deliberately the same validator PHPMailer itself uses by default
+	 * (FILTER_VALIDATE_EMAIL), so an address this parser accepts is never one
+	 * that PHPMailer's own addAddress()/addCC()/addBCC()/addReplyTo() would
+	 * still reject.
+	 *
+	 * @param string $address Candidate address.
+	 * @return bool
+	 */
+	private static function is_valid_address( string $address ): bool {
+		return filter_var( $address, FILTER_VALIDATE_EMAIL ) !== false;
+	}
+
+	/**
+	 * Strip a surrounding quoted-string and unescape backslash-escaped
+	 * characters from a display name, e.g. '"Rossi, Andrea"' -> 'Rossi, Andrea'.
+	 * A name that is not quoted is returned unchanged (aside from trimming).
+	 *
+	 * @param string $name Raw (possibly quoted) display name.
+	 * @return string
+	 */
+	/**
+	 * Whether a display-name part is a complete RFC 5322 quoted-string, i.e.
+	 * opens and closes with an unescaped double quote and contains no
+	 * unescaped quote in between.
+	 *
+	 * Used to decide whether an angle bracket inside the display name is
+	 * legitimate (quoted, so inert) or a second angle-addr smuggled into an
+	 * interpolated header. See parse_one().
+	 *
+	 * @param string $name Trimmed display-name part.
+	 * @return bool
+	 */
+	private static function is_quoted_string( string $name ): bool {
+		$length = strlen( $name );
+		if ( $length < 2 || $name[0] !== '"' || $name[ $length - 1 ] !== '"' ) {
+			return false;
+		}
+		// Walk the interior; an unescaped quote would close the string early
+		// and leave the rest outside it, which is not a single quoted-string.
+		for ( $i = 1; $i < $length - 1; $i++ ) {
+			if ( $name[ $i ] === '\\' ) {
+				$i++;
+				continue;
+			}
+			if ( $name[ $i ] === '"' ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static function unquote( string $name ): string {
+		$name   = trim( $name );
+		$length = strlen( $name );
+		if ( $length >= 2 && $name[0] === '"' && $name[ $length - 1 ] === '"' ) {
+			$inner = substr( $name, 1, -1 );
+			$inner = preg_replace( '/\\\\(.)/', '$1', $inner );
+			return $inner === null ? '' : $inner;
+		}
+		return $name;
+	}
+
+	/**
+	 * Quote and backslash-escape a display name for safe reuse inside an
+	 * RFC 5322 "Name <addr>" mailbox, when it contains characters (comma,
+	 * quote, angle bracket, backslash) that would otherwise change the
+	 * meaning of the header.
+	 *
+	 * @param string $name Display name.
+	 * @return string
+	 */
+	private static function quote_name( string $name ): string {
+		if ( preg_match( '/[",<>\\\\]/', $name ) !== 1 ) {
+			return $name;
+		}
+		$escaped = str_replace( array( '\\', '"' ), array( '\\\\', '\\"' ), $name );
+		return '"' . $escaped . '"';
+	}
+
+	/**
+	 * Strip CR/LF from a value before it is used as (part of) a header value.
+	 * This is header-injection hardening for values that ultimately originate from
+	 * wp_mail() arguments a form plugin may pass through from a site visitor.
+	 *
+	 * @param string $value Value to clean.
+	 * @return string
+	 */
+	private static function strip_crlf( string $value ): string {
+		return trim( str_replace( array( "\r", "\n" ), '', $value ) );
+	}
+}

--- a/apps/agent/includes/email/class-email-log-reporter.php
+++ b/apps/agent/includes/email/class-email-log-reporter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * EmailLogReporter — fire-and-forget CP push for the local email-send log.
+ * EmailLogReporter: fire-and-forget CP push for the local email-send log.
  *
  * Every 5 minutes (wp-cron, HOOK_PUSH) AND opportunistically right after a
  * send, pages UNPUSHED rows above a stored high-water cursor and POSTs them to:
@@ -301,7 +301,12 @@ final class EmailLogReporter {
 
 	/**
 	 * Split a stored mail_to string (comma- or semicolon-delimited) into a
-	 * trimmed array of non-empty address strings.
+	 * trimmed array of non-empty address entries.
+	 *
+	 * Delegates to AddressParser::split_list() (quote/angle-bracket aware)
+	 * rather than a bare regex split, so a quoted display name that itself
+	 * contains a comma (e.g. '"Rossi, Andrea" <a@x.com>') is reported back to
+	 * the CP as ONE recipient, not shredded into two bogus ones.
 	 *
 	 * @param string $raw Raw mail_to value from the DB.
 	 * @return string[]
@@ -310,22 +315,14 @@ final class EmailLogReporter {
 		if ( $raw === '' ) {
 			return [];
 		}
-		$parts = preg_split( '/[,;]+/', $raw ) ?: [];
-		$out   = [];
-		foreach ( $parts as $part ) {
-			$part = trim( $part );
-			if ( $part !== '' ) {
-				$out[] = $part;
-			}
-		}
-		return $out;
+		return AddressParser::split_list( $raw );
 	}
 
 	/**
 	 * Convert a MySQL UTC DATETIME string (Y-m-d H:i:s) to an RFC3339 UTC
 	 * timestamp (e.g. 2026-06-10T12:34:56Z). Falls back to the current UTC time
 	 * in RFC3339 on empty input or parse failure so the CP always receives a
-	 * valid RFC3339 string — never a bare MySQL datetime or an empty string.
+	 * valid RFC3339 string, never a bare MySQL datetime or an empty string.
 	 *
 	 * @param string $mysql MySQL DATETIME string.
 	 * @return string RFC3339 UTC timestamp.

--- a/apps/agent/includes/email/class-mail-router.php
+++ b/apps/agent/includes/email/class-mail-router.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * MailRouter — hooks into WordPress's mail pipeline to route outgoing mail
+ * MailRouter: hooks into WordPress's mail pipeline to route outgoing mail
  * through the configured WPMgr provider handler.
  *
  * Hook strategy (non-destructive):
@@ -9,7 +9,7 @@
  *     default mail path is UNTOUCHED.
  *   - Fallback: If `pre_wp_mail` is unavailable (WP < 5.7), hooks
  *     `wp_mail` (the pluggable function) via a wpmgr_mail() shim registered
- *     only when that hook exists — but in practice WP 5.7+ is the baseline
+ *     only when that hook exists, but in practice WP 5.7+ is the baseline
  *     (Requires at least: 6.2 in the plugin header), so the primary path
  *     always fires.
  *
@@ -76,7 +76,7 @@ final class MailRouter {
 
 		$cfg = EmailConfig::load();
 		if ( ! $cfg->is_configured() ) {
-			// No email config — leave WP's default mail path untouched.
+			// No email config, leave WP's default mail path untouched.
 			return null;
 		}
 
@@ -102,8 +102,12 @@ final class MailRouter {
 	 */
 	public function build_mail_payload( array $atts, EmailConfig $cfg ): array {
 		// -- Recipients -------------------------------------------------------
+		// AddressParser::split_list() is quote-aware, so a bare comma-separated
+		// $to string with a quoted display name that itself contains a comma
+		// (e.g. '"Rossi, Andrea" <a@x.com>, b@y.com') splits into the correct
+		// two entries rather than shredding the name in half.
 		$to_raw = $atts['to'] ?? '';
-		$to     = is_array( $to_raw ) ? $to_raw : array_filter( array_map( 'trim', explode( ',', (string) $to_raw ) ) );
+		$to     = is_array( $to_raw ) ? $to_raw : AddressParser::split_list( (string) $to_raw );
 
 		// -- Headers ----------------------------------------------------------
 		$raw_headers = $atts['headers'] ?? '';

--- a/apps/agent/includes/email/class-provider-router.php
+++ b/apps/agent/includes/email/class-provider-router.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ProviderRouter — resolves the right provider handler for a given message,
+ * ProviderRouter: resolves the right provider handler for a given message,
  * drives send + one fallback retry, and delegates logging to EmailLogger.
  *
  * Resolution order:
@@ -131,7 +131,7 @@ class ProviderRouter {
 		$primary_error    = (string) ( $result['error'] ?? '' );
 		$primary_response = (string) ( $result['provider_response'] ?? '' );
 
-		// First attempt failed — try fallback unless disabled.
+		// First attempt failed, try fallback unless disabled.
 		if ( ! $disable_fallback ) {
 			$fallback = $this->resolve_fallback( $cfg, $connection['key'] );
 			if ( $fallback !== null ) {
@@ -157,7 +157,7 @@ class ProviderRouter {
 			}
 		}
 
-		// No fallback or fallback handler missing — log the original failure.
+		// No fallback or fallback handler missing, log the original failure.
 		$this->maybe_log( $mail, $connection['key'], $connection['provider'], 'failed', '', $primary_error, $primary_response, 0, $cfg );
 		return array( 'ok' => false, 'message_id' => '', 'detail' => $primary_error );
 	}
@@ -249,7 +249,7 @@ class ProviderRouter {
 				if ( $conn !== null ) {
 					return $conn;
 				}
-				// Key not in registry — fall through to default.
+				// Key not in registry, fall through to default.
 			}
 
 			// Back-compat: pre-m62 inline array shape {provider, config}.
@@ -409,7 +409,13 @@ class ProviderRouter {
 
 		$allowed = array();
 		foreach ( $to as $addr ) {
-			if ( ! $this->suppression_cache->is_suppressed( (string) $addr ) ) {
+			// $addr may carry the "Display Name <addr>" form; the suppression
+			// list is keyed by bare address only, so resolve to a bare address
+			// for the check while keeping the ORIGINAL entry (name included) in
+			// the mail payload passed on to the provider handler.
+			$parsed_addr = AddressParser::parse_one( (string) $addr );
+			$bare_addr   = $parsed_addr !== null ? $parsed_addr['address'] : (string) $addr;
+			if ( ! $this->suppression_cache->is_suppressed( $bare_addr ) ) {
 				$allowed[] = $addr;
 			}
 		}

--- a/apps/agent/includes/email/handlers/class-sendgrid-handler.php
+++ b/apps/agent/includes/email/handlers/class-sendgrid-handler.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * SendgridHandler — sends via the SendGrid Web API v3.
+ * SendgridHandler: sends via the SendGrid Web API v3.
  *
  * Endpoint: POST https://api.sendgrid.com/v3/mail/send
  * Auth:     Authorization: Bearer <api_key>
  * Success:  HTTP 202 Accepted (no body; Message-ID from X-Message-Id header).
  *
- * Config shape: (none — the API key is the sole configuration).
+ * Config shape: (none; the API key is the sole configuration).
  * Secret (from keystore): SendGrid API key.
  *
  * @package WPMgr\Agent\Email\Handlers
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace WPMgr\Agent\Email\Handlers;
 
+use WPMgr\Agent\Email\AddressParser;
 use WPMgr\Agent\Email\ProviderHandlerInterface;
 
 /**
@@ -86,35 +87,44 @@ final class SendgridHandler implements ProviderHandlerInterface {
 	 * @return array<string,mixed>
 	 */
 	private function build_payload( array $mail ): array {
-		// From object.
-		$from_obj = array( 'email' => (string) ( $mail['from'] ?? '' ) );
-		$from_name = (string) ( $mail['from_name'] ?? '' );
+		// From object. $mail['from'] may itself carry the "Display Name <addr>"
+		// form (a wp_mail_from filter or a named connection's from_address can
+		// both return it that way); SendGrid's `email` field must be bare, with
+		// any display name in the sibling `name` field, so parse it first.
+		$from_entry   = AddressParser::parse_one( (string) ( $mail['from'] ?? '' ) );
+		$from_address = $from_entry !== null ? $from_entry['address'] : (string) ( $mail['from'] ?? '' );
+		$from_name    = (string) ( $mail['from_name'] ?? '' );
+		if ( $from_name === '' && $from_entry !== null && $from_entry['name'] !== '' ) {
+			$from_name = $from_entry['name'];
+		}
+		$from_obj = array( 'email' => $from_address );
 		if ( $from_name !== '' ) {
 			$from_obj['name'] = $from_name;
 		}
 
-		// Personalisation: to / cc / bcc / reply_to.
+		// Personalisation: to / cc / bcc / reply_to. Every entry is a raw
+		// wp_mail() header value: a bare address, "Display Name <addr>", or a
+		// single entry that itself packs a comma-separated list (one "Cc:"
+		// header carrying two addresses), so it is parsed via AddressParser
+		// into SendGrid's {email[, name]} object shape before use. A malformed
+		// entry that AddressParser cannot resolve is still passed through in
+		// its raw form, exactly as it was before this parser existed, so
+		// SendGrid stays the judge of anything our own validator does not
+		// recognise. FILTER_VALIDATE_EMAIL refuses an internationalised
+		// domain, so dropping unparsed entries here would silently stop
+		// delivering to every IDN recipient that works today.
 		$personalisation = array(
-			'to' => array_map(
-				fn( $addr ) => array( 'email' => (string) $addr ),
-				(array) ( $mail['to'] ?? array() )
-			),
+			'to' => $this->address_objects( $mail['to'] ?? array() ),
 		);
 
-		$cc = (array) ( $mail['cc'] ?? array() );
+		$cc = $this->address_objects( $mail['cc'] ?? array() );
 		if ( $cc !== array() ) {
-			$personalisation['cc'] = array_map(
-				fn( $addr ) => array( 'email' => (string) $addr ),
-				$cc
-			);
+			$personalisation['cc'] = $cc;
 		}
 
-		$bcc = (array) ( $mail['bcc'] ?? array() );
+		$bcc = $this->address_objects( $mail['bcc'] ?? array() );
 		if ( $bcc !== array() ) {
-			$personalisation['bcc'] = array_map(
-				fn( $addr ) => array( 'email' => (string) $addr ),
-				$bcc
-			);
+			$personalisation['bcc'] = $bcc;
 		}
 
 		$payload = array(
@@ -123,9 +133,15 @@ final class SendgridHandler implements ProviderHandlerInterface {
 			'subject'          => (string) ( $mail['subject'] ?? '' ),
 		);
 
-		$reply_to = (array) ( $mail['reply_to'] ?? array() );
-		if ( $reply_to !== array() ) {
-			$payload['reply_to'] = array( 'email' => (string) $reply_to[0] );
+		// SendGrid's singular `reply_to` field accepts exactly one address;
+		// `reply_to_list` is the documented way to carry more than one, so use
+		// it whenever a header supplied multiple Reply-To addresses instead of
+		// silently keeping only the first (the prior behaviour).
+		$reply_to = $this->address_objects( $mail['reply_to'] ?? array() );
+		if ( count( $reply_to ) === 1 ) {
+			$payload['reply_to'] = $reply_to[0];
+		} elseif ( count( $reply_to ) > 1 ) {
+			$payload['reply_to_list'] = $reply_to;
 		}
 
 		// Content: prefer HTML + plain text; plain text only otherwise.
@@ -192,6 +208,54 @@ final class SendgridHandler implements ProviderHandlerInterface {
 		}
 
 		return $payload;
+	}
+
+	/**
+	 * Turn one raw address field into SendGrid email objects.
+	 *
+	 * Parsed entries become {email, name}; entries AddressParser could not
+	 * resolve are passed through as {email: raw}, which is byte for byte what
+	 * this handler sent before the parser existed. That passthrough exists so
+	 * our own validator can never be stricter than SendGrid's: an
+	 * internationalised domain fails FILTER_VALIDATE_EMAIL, and dropping it
+	 * here would silently stop delivering to a recipient that works today.
+	 * It cannot reintroduce GH #312, because a well-formed "Name <addr>"
+	 * always parses and so never reaches the passthrough.
+	 *
+	 * @param mixed $raw Raw address field from the mail payload.
+	 * @return list<array{email:string}|array{email:string,name:string}>
+	 */
+	private function address_objects( $raw ): array {
+		$entries = AddressParser::parse_list_verbose( $raw );
+		$objects = array();
+
+		foreach ( $entries['valid'] as $entry ) {
+			$objects[] = $this->to_sendgrid_email_object( $entry );
+		}
+		foreach ( $entries['invalid'] as $entry ) {
+			$raw_entry = trim( (string) $entry );
+			// Only pass through something that is at least shaped like an
+			// address. A entry with no "@" is not one our validator merely
+			// failed to recognise, it is garbage, and forwarding it would 400
+			// the whole personalization and lose every other recipient with it.
+			if ( $raw_entry !== '' && strpos( $raw_entry, '@' ) !== false ) {
+				$objects[] = array( 'email' => $raw_entry );
+			}
+		}
+
+		return $objects;
+	}
+
+	/**
+	 * Convert a parsed {address, name} entry into a SendGrid email object.
+	 *
+	 * @param array{address:string,name:string} $entry Parsed address entry.
+	 * @return array{email:string}|array{email:string,name:string}
+	 */
+	private function to_sendgrid_email_object( array $entry ): array {
+		return $entry['name'] !== ''
+			? array( 'email' => $entry['address'], 'name' => $entry['name'] )
+			: array( 'email' => $entry['address'] );
 	}
 
 	/**

--- a/apps/agent/includes/email/handlers/class-smtp-handler.php
+++ b/apps/agent/includes/email/handlers/class-smtp-handler.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SmtpHandler — sends via WordPress's bundled PHPMailer over SMTP.
+ * SmtpHandler: sends via WordPress's bundled PHPMailer over SMTP.
  *
  * PHPMailer is loaded by WP in wp-includes/PHPMailer/. We construct a fresh
  * instance (avoiding any global state from the `phpmailer_init` filter used
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace WPMgr\Agent\Email\Handlers;
 
+use WPMgr\Agent\Email\AddressParser;
 use WPMgr\Agent\Email\ProviderHandlerInterface;
 
 /**
@@ -92,25 +93,49 @@ final class SmtpHandler implements ProviderHandlerInterface {
 				$phpmailer->Password = $secret;
 			}
 
-			// -- From ---------------------------------------------------------
-			$phpmailer->setFrom( (string) ( $mail['from'] ?? '' ), (string) ( $mail['from_name'] ?? '' ) );
+			// -- From -----------------------------------------------------------
+			// $mail['from'] may itself carry the "Display Name <addr>" form (a
+			// wp_mail_from filter or a named connection's from_address can both
+			// return it that way). Parse it so PHPMailer::setFrom() always
+			// receives a bare address, with any embedded name used only when
+			// $mail['from_name'] did not already supply one.
+			$from_entry   = AddressParser::parse_one( (string) ( $mail['from'] ?? '' ) );
+			$from_address = $from_entry !== null ? $from_entry['address'] : (string) ( $mail['from'] ?? '' );
+			$from_name    = (string) ( $mail['from_name'] ?? '' );
+			if ( $from_name === '' && $from_entry !== null && $from_entry['name'] !== '' ) {
+				$from_name = $from_entry['name'];
+			}
+			$phpmailer->setFrom( $from_address, $from_name );
 
 			if ( ! empty( $mail['return_path'] ) ) {
-				$phpmailer->Sender = (string) ( $mail['from'] ?? '' );
+				$phpmailer->Sender = $from_address;
 			}
 
-			// -- Recipients ---------------------------------------------------
-			foreach ( (array) ( $mail['to'] ?? array() ) as $addr ) {
-				$phpmailer->addAddress( (string) $addr );
-			}
-			foreach ( (array) ( $mail['cc'] ?? array() ) as $addr ) {
-				$phpmailer->addCC( (string) $addr );
-			}
-			foreach ( (array) ( $mail['bcc'] ?? array() ) as $addr ) {
-				$phpmailer->addBCC( (string) $addr );
-			}
-			foreach ( (array) ( $mail['reply_to'] ?? array() ) as $addr ) {
-				$phpmailer->addReplyTo( (string) $addr );
+			// -- Recipients -------------------------------------------------------
+			// Every to/cc/bcc/reply_to entry is a raw wp_mail() header value: a
+			// bare address, "Display Name <addr>", or one entry that itself packs
+			// a comma-separated list (a single "Cc:" header carrying two
+			// addresses). AddressParser splits and parses all of that into
+			// {address, name} pairs. Each parsed address is added to PHPMailer
+			// individually, in its OWN try/catch, so one malformed address is
+			// dropped rather than throwing out of the whole send (PHPMailer is
+			// constructed with exceptions enabled above). Losing one recipient
+			// is recoverable; aborting the entire message is not.
+			$invalid_addresses     = array();
+			$added_recipient_count = 0;
+
+			$added_recipient_count += $this->add_addresses( $phpmailer, 'addAddress', $mail['to'] ?? array(), $invalid_addresses );
+			$added_recipient_count += $this->add_addresses( $phpmailer, 'addCC', $mail['cc'] ?? array(), $invalid_addresses );
+			$added_recipient_count += $this->add_addresses( $phpmailer, 'addBCC', $mail['bcc'] ?? array(), $invalid_addresses );
+			$this->add_addresses( $phpmailer, 'addReplyTo', $mail['reply_to'] ?? array(), $invalid_addresses );
+
+			// PHPMailer requires at least one To/CC/BCC recipient. Fail clearly
+			// (naming what was rejected) rather than letting send() throw its own
+			// generic "You must provide at least one recipient" exception.
+			if ( $added_recipient_count === 0 ) {
+				return $this->failure(
+					'no valid recipient address' . ( $invalid_addresses !== array() ? ' (rejected: ' . implode( ', ', $invalid_addresses ) . ')' : '' )
+				);
 			}
 
 			// -- Subject + body -----------------------------------------------
@@ -151,15 +176,78 @@ final class SmtpHandler implements ProviderHandlerInterface {
 
 			$message_id = $phpmailer->getLastMessageID();
 
+			// Report (but do not fail on) any address dropped along the way, so
+			// a malformed Cc/Reply-To is visible in the email log instead of
+			// silently vanishing.
+			$provider_response = 'SMTP send OK';
+			if ( $invalid_addresses !== array() ) {
+				$provider_response .= '; skipped invalid address(es): ' . implode( ', ', $invalid_addresses );
+			}
+
 			return array(
 				'ok'                => true,
 				'message_id'        => (string) $message_id,
 				'error'             => '',
-				'provider_response' => 'SMTP send OK',
+				'provider_response' => $provider_response,
 			);
 		} catch ( \Throwable $e ) {
 			return $this->failure( $e->getMessage() );
 		}
+	}
+
+	/**
+	 * Add one address field (to/cc/bcc/reply_to) to PHPMailer.
+	 *
+	 * Each entry is added in its OWN try/catch, so one malformed address costs
+	 * that recipient rather than throwing out of the whole send (PHPMailer is
+	 * constructed with exceptions enabled). Losing one recipient is
+	 * recoverable; aborting the entire message is what GH #312 reported.
+	 *
+	 * ENTRIES THE PARSER REFUSED ARE STILL OFFERED TO PHPMAILER RAW, and only
+	 * recorded as invalid once PHPMailer itself refuses them. That passthrough
+	 * is load bearing, not defensive: our validator is FILTER_VALIDATE_EMAIL,
+	 * which rejects an internationalised domain, while PHPMailer detects an
+	 * 8-bit domain BEFORE it validates and punycodes it on send. Dropping
+	 * unparsed entries here would silently stop delivering to every IDN
+	 * recipient that works today. The passthrough cannot reintroduce the bug
+	 * this fix closes, because a well-formed "Name <addr>" always parses.
+	 *
+	 * @param \PHPMailer\PHPMailer\PHPMailer $phpmailer Live mailer.
+	 * @param string                         $method    addAddress|addCC|addBCC|addReplyTo.
+	 * @param mixed                          $raw       Raw field from the mail payload.
+	 * @param list<string>                   $invalid   Collects entries nothing would accept.
+	 * @return int How many addresses were accepted.
+	 */
+	private function add_addresses( $phpmailer, string $method, $raw, array &$invalid ): int {
+		$added   = 0;
+		$entries = AddressParser::parse_list_verbose( $raw );
+
+		foreach ( $entries['valid'] as $entry ) {
+			try {
+				$phpmailer->{$method}( $entry['address'], $entry['name'] );
+				++$added;
+			} catch ( \Throwable ) {
+				$invalid[] = $entry['address'];
+			}
+		}
+
+		foreach ( $entries['invalid'] as $entry ) {
+			$raw_entry = trim( (string) $entry );
+			// Only retry something at least shaped like an address. An entry
+			// with no "@" is not one our validator merely failed to recognise.
+			if ( $raw_entry === '' || strpos( $raw_entry, '@' ) === false ) {
+				$invalid[] = (string) $entry;
+				continue;
+			}
+			try {
+				$phpmailer->{$method}( $raw_entry );
+				++$added;
+			} catch ( \Throwable ) {
+				$invalid[] = $raw_entry;
+			}
+		}
+
+		return $added;
 	}
 
 	/**

--- a/apps/agent/includes/email/interface-provider-handler.php
+++ b/apps/agent/includes/email/interface-provider-handler.php
@@ -1,12 +1,31 @@
 <?php
 /**
- * ProviderHandlerInterface — contract for per-provider outgoing-mail handlers.
+ * ProviderHandlerInterface: contract for per-provider outgoing-mail handlers.
  *
  * Every handler receives a normalised mail payload built from the wp_mail()
  * arguments (to, subject, message, headers, attachments) plus the resolved
  * connection config and the decrypted secret. It returns a structured result
  * envelope carrying the provider HTTP status, message-id (when available), and
  * a human error string on failure.
+ *
+ * Address fields (to/cc/bcc/reply_to/from) intentionally stay list<string> /
+ * string on this contract rather than becoming a structured {address,name}
+ * shape (GH #312). Normalizing happens at the point each handler actually
+ * needs a bare address, via WPMgr\Agent\Email\AddressParser, not on this
+ * contract itself:
+ *   - SmtpHandler and SendgridHandler both hand a raw entry straight to
+ *     something that requires a bare address (PHPMailer::addAddress() et al.,
+ *     or SendGrid's `email` field) and MUST parse it first.
+ *   - SesHandler / PostmarkHandler / MailgunHandler build a raw header line or
+ *     an API field that is itself RFC 5322 "Display Name <addr>" AND
+ *     comma-list aware, so they pass entries straight through unparsed. This
+ *     is not an oversight; see AddressParserTest and each handler's own
+ *     class docblock.
+ * Keeping the wire shape unchanged means a caller that has not been updated
+ * for a new address feature still sends correct mail instead of nothing at
+ * all. A structured-entry contract change would require touching all five
+ * handlers, every payload builder, and every existing test fixture in one
+ * commit, which is the wrong trade-off for an urgent fix.
  *
  * @package WPMgr\Agent\Email
  */
@@ -24,11 +43,31 @@ interface ProviderHandlerInterface {
 	 * Send one email via the provider.
 	 *
 	 * @param array<string,mixed> $mail   Normalised mail payload:
-	 *   to         string[]    Recipients.
-	 *   cc         string[]    CC recipients.
-	 *   bcc        string[]    BCC recipients.
-	 *   reply_to   string[]    Reply-To addresses.
+	 *   to         string[]    Recipients. Each entry is a raw wp_mail() header
+	 *                          value: a bare address, the RFC 5322 "Display Name
+	 *                          <addr@example.com>" form, or a single entry that
+	 *                          itself packs a comma-separated list (e.g. one "Cc:"
+	 *                          header carrying two addresses). Entries are NOT
+	 *                          pre-split or pre-parsed. Before using any entry as
+	 *                          a BARE address (PHPMailer::addAddress() and
+	 *                          friends, or a provider API's `email` field), run it
+	 *                          through WPMgr\Agent\Email\AddressParser::parse_list()
+	 *                          (or ::parse_list_verbose() to also learn what was
+	 *                          rejected). Never assume an entry already is one.
+	 *                          A bad entry must never fatal the whole send; drop
+	 *                          it and, when the provider protocol allows it, note
+	 *                          it in provider_response. When the destination field
+	 *                          is itself RFC 5322 "Name <addr>" AND comma-list
+	 *                          aware (a raw header line, or an API field
+	 *                          documented to accept that form) the entries may be
+	 *                          passed through unparsed instead.
+	 *   cc         string[]    CC recipients. Same shape as `to`.
+	 *   bcc        string[]    BCC recipients. Same shape as `to`.
+	 *   reply_to   string[]    Reply-To addresses. Same shape as `to`.
 	 *   from       string      Resolved From address (after force-from logic).
+	 *                          May also carry the "Display Name <addr>" form;
+	 *                          parse it the same way before using it as a bare
+	 *                          address.
 	 *   from_name  string      Resolved From display name.
 	 *   subject    string      Subject line.
 	 *   body_text  string      Plain-text body part (may be empty).

--- a/apps/agent/tests/Email/AddressParserTest.php
+++ b/apps/agent/tests/Email/AddressParserTest.php
@@ -1,0 +1,332 @@
+<?php
+/**
+ * AddressParserTest: pins the GH #312 fix, parsing bare addresses, the RFC
+ * 5322 "Display Name <addr>" form, a quoted display name that itself
+ * contains a comma, mixed comma-separated lists, and malformed/empty input
+ * (which must never throw and must never fatal).
+ *
+ * @package WPMgr\Agent\Tests\Email
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Email;
+
+use PHPUnit\Framework\TestCase;
+use WPMgr\Agent\Email\AddressParser;
+
+/**
+ * @covers \WPMgr\Agent\Email\AddressParser
+ */
+class AddressParserTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // parse_one(): the reporter's exact case (GH #312)
+    // -------------------------------------------------------------------------
+
+    /**
+     * The literal string from the bug report:
+     *   {"summary": "Invalid address:  (Reply-To): Andrea Somigli <salesianalibri@gmail.com>"}
+     * must parse to a bare address with the display name preserved, not dropped.
+     */
+    public function test_reporter_exact_reply_to_string_parses_with_name_preserved(): void
+    {
+        $parsed = AddressParser::parse_one('Andrea Somigli <salesianalibri@gmail.com>');
+
+        $this->assertNotNull($parsed, 'the reporter\'s exact Reply-To value must parse, not be rejected');
+        $this->assertSame('salesianalibri@gmail.com', $parsed['address']);
+        $this->assertSame('Andrea Somigli', $parsed['name']);
+    }
+
+    // -------------------------------------------------------------------------
+    // parse_one(): bare address
+    // -------------------------------------------------------------------------
+
+    public function test_bare_address_parses_with_empty_name(): void
+    {
+        $parsed = AddressParser::parse_one('plain@example.com');
+
+        $this->assertNotNull($parsed);
+        $this->assertSame('plain@example.com', $parsed['address']);
+        $this->assertSame('', $parsed['name']);
+    }
+
+    public function test_bare_address_with_surrounding_whitespace_is_trimmed(): void
+    {
+        $parsed = AddressParser::parse_one("  plain@example.com  \t");
+
+        $this->assertNotNull($parsed);
+        $this->assertSame('plain@example.com', $parsed['address']);
+    }
+
+    // -------------------------------------------------------------------------
+    // parse_one(): quoted display name containing a comma
+    // -------------------------------------------------------------------------
+
+    public function test_quoted_display_name_with_comma_is_preserved(): void
+    {
+        $parsed = AddressParser::parse_one('"Rossi, Andrea" <a@x.com>');
+
+        $this->assertNotNull($parsed);
+        $this->assertSame('a@x.com', $parsed['address']);
+        $this->assertSame('Rossi, Andrea', $parsed['name'], 'the comma inside the quoted name must survive, not be treated as a list separator');
+    }
+
+    public function test_quoted_display_name_with_escaped_quote_is_unescaped(): void
+    {
+        $parsed = AddressParser::parse_one('"Jane \\"JD\\" Doe" <jane@example.com>');
+
+        $this->assertNotNull($parsed);
+        $this->assertSame('jane@example.com', $parsed['address']);
+        $this->assertSame('Jane "JD" Doe', $parsed['name']);
+    }
+
+    // -------------------------------------------------------------------------
+    // parse_one(): never throws; malformed input degrades to null
+    // -------------------------------------------------------------------------
+
+    public function test_empty_string_returns_null_without_throwing(): void
+    {
+        $this->assertNull(AddressParser::parse_one(''));
+    }
+
+    public function test_whitespace_only_string_returns_null(): void
+    {
+        $this->assertNull(AddressParser::parse_one('   '));
+    }
+
+    public function test_garbage_text_returns_null_without_throwing(): void
+    {
+        $this->assertNull(AddressParser::parse_one('this is not an email address'));
+    }
+
+    public function test_angle_brackets_with_invalid_address_return_null(): void
+    {
+        $this->assertNull(AddressParser::parse_one('Some Name <not-an-email>'));
+    }
+
+    public function test_empty_angle_brackets_return_null(): void
+    {
+        $this->assertNull(AddressParser::parse_one('Empty Name <>'));
+    }
+
+    public function test_unterminated_angle_bracket_returns_null_not_a_crash(): void
+    {
+        $this->assertNull(AddressParser::parse_one('Broken <a@x.com'));
+    }
+
+    // -------------------------------------------------------------------------
+    // split_list(): comma-separated lists, quote/angle-bracket aware
+    // -------------------------------------------------------------------------
+
+    public function test_split_list_on_plain_bare_addresses(): void
+    {
+        $this->assertSame(
+            ['a@example.com', 'b@example.com'],
+            AddressParser::split_list('a@example.com, b@example.com')
+        );
+    }
+
+    public function test_split_list_does_not_split_inside_quoted_name(): void
+    {
+        $this->assertSame(
+            ['"Rossi, Andrea" <a@x.com>', 'b@y.com'],
+            AddressParser::split_list('"Rossi, Andrea" <a@x.com>, b@y.com')
+        );
+    }
+
+    public function test_split_list_mixed_bare_named_and_quoted_comma(): void
+    {
+        $this->assertSame(
+            ['"Rossi, Andrea" <a@x.com>', 'b@y.com', 'Charlie <c@z.com>'],
+            AddressParser::split_list('"Rossi, Andrea" <a@x.com>, b@y.com, Charlie <c@z.com>')
+        );
+    }
+
+    public function test_split_list_empty_string_returns_empty_array(): void
+    {
+        $this->assertSame([], AddressParser::split_list(''));
+    }
+
+    public function test_split_list_semicolon_separated(): void
+    {
+        $this->assertSame(
+            ['a@example.com', 'b@example.com'],
+            AddressParser::split_list('a@example.com; b@example.com')
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // parse_list() / parse_list_verbose(): the shape every handler consumes
+    // -------------------------------------------------------------------------
+
+    public function test_parse_list_accepts_a_single_multi_address_string(): void
+    {
+        // The exact shape MailRouter stores for a "Cc: a@x.com, b@y.com" header:
+        // ONE array entry whose value itself packs two addresses.
+        $parsed = AddressParser::parse_list(['a@x.com, b@y.com']);
+
+        $this->assertCount(2, $parsed);
+        $this->assertSame('a@x.com', $parsed[0]['address']);
+        $this->assertSame('b@y.com', $parsed[1]['address']);
+    }
+
+    public function test_parse_list_accepts_array_of_separate_header_entries(): void
+    {
+        $parsed = AddressParser::parse_list(['Andrea Somigli <salesianalibri@gmail.com>', 'plain@example.com']);
+
+        $this->assertCount(2, $parsed);
+        $this->assertSame('salesianalibri@gmail.com', $parsed[0]['address']);
+        $this->assertSame('Andrea Somigli', $parsed[0]['name']);
+        $this->assertSame('plain@example.com', $parsed[1]['address']);
+        $this->assertSame('', $parsed[1]['name']);
+    }
+
+    public function test_parse_list_drops_invalid_entries_without_throwing(): void
+    {
+        $parsed = AddressParser::parse_list(['good@example.com', 'not-an-email', '']);
+
+        $this->assertCount(1, $parsed);
+        $this->assertSame('good@example.com', $parsed[0]['address']);
+    }
+
+    public function test_parse_list_empty_array_returns_empty_array(): void
+    {
+        $this->assertSame([], AddressParser::parse_list([]));
+    }
+
+    public function test_parse_list_verbose_reports_invalid_entries_separately(): void
+    {
+        $result = AddressParser::parse_list_verbose(['good@example.com', 'not-an-email']);
+
+        $this->assertCount(1, $result['valid']);
+        $this->assertSame('good@example.com', $result['valid'][0]['address']);
+        $this->assertSame(['not-an-email'], $result['invalid']);
+    }
+
+    public function test_parse_list_verbose_never_throws_on_completely_malformed_input(): void
+    {
+        $result = AddressParser::parse_list_verbose(['', '   ', '<>', 'garbage text with spaces']);
+
+        $this->assertSame([], $result['valid']);
+    }
+
+    // -------------------------------------------------------------------------
+    // format() / format_list(): the inverse, used when re-serialising to a
+    // raw header value.
+    // -------------------------------------------------------------------------
+
+    public function test_format_bare_address_has_no_angle_brackets(): void
+    {
+        $this->assertSame('a@x.com', AddressParser::format(['address' => 'a@x.com', 'name' => '']));
+    }
+
+    public function test_format_with_name_produces_rfc5322_form(): void
+    {
+        $this->assertSame(
+            'Andrea Somigli <salesianalibri@gmail.com>',
+            AddressParser::format(['address' => 'salesianalibri@gmail.com', 'name' => 'Andrea Somigli'])
+        );
+    }
+
+    public function test_format_quotes_a_name_containing_a_comma(): void
+    {
+        $this->assertSame(
+            '"Rossi, Andrea" <a@x.com>',
+            AddressParser::format(['address' => 'a@x.com', 'name' => 'Rossi, Andrea'])
+        );
+    }
+
+    public function test_format_strips_crlf_from_name_and_address(): void
+    {
+        $formatted = AddressParser::format(['address' => "a@x.com\r\nBcc: evil@x.com", 'name' => "Evil\r\nName"]);
+
+        $this->assertStringNotContainsString("\r", $formatted);
+        $this->assertStringNotContainsString("\n", $formatted);
+    }
+
+    public function test_format_list_joins_multiple_entries(): void
+    {
+        $formatted = AddressParser::format_list([
+            ['address' => 'a@x.com', 'name' => 'Alice'],
+            ['address' => 'b@y.com', 'name' => ''],
+        ]);
+
+        $this->assertSame('Alice <a@x.com>, b@y.com', $formatted);
+    }
+
+    // -------------------------------------------------------------------------
+    // Round trip: parse -> format reproduces an equivalent, re-parseable value.
+    // -------------------------------------------------------------------------
+
+    public function test_round_trip_quoted_comma_name(): void
+    {
+        $parsed    = AddressParser::parse_one('"Rossi, Andrea" <a@x.com>');
+        $formatted = AddressParser::format($parsed);
+        $reparsed  = AddressParser::parse_one($formatted);
+
+        $this->assertSame($parsed['address'], $reparsed['address']);
+        $this->assertSame($parsed['name'], $reparsed['name']);
+    }
+
+    // -------------------------------------------------------------------------
+    // GH #312 review: a display name must never be able to redirect the message.
+    //
+    // The angle-addr pattern is greedy, so it binds to the LAST bracketed token.
+    // Header values are routinely built by interpolating a user supplied name
+    // into "{name} <{email}>", so a submitted name carrying its own angle-addr
+    // would otherwise resolve to the attacker's address while displaying the
+    // legitimate one. Before this parser existed the transport rejected such an
+    // entry outright, and refusing it here preserves that.
+    // -------------------------------------------------------------------------
+
+    public function test_a_second_angle_addr_in_the_display_name_is_refused(): void
+    {
+        $this->assertNull(AddressParser::parse_one('Bob <bob@example.com> <evil@attacker.com>'));
+    }
+
+    public function test_a_smuggled_angle_addr_never_wins_over_the_real_one(): void
+    {
+        // The whole point: it must not silently resolve to evil@attacker.com.
+        $parsed = AddressParser::parse_one('Bob <bob@example.com> <evil@attacker.com>');
+        if ($parsed !== null) {
+            $this->assertNotSame('evil@attacker.com', $parsed['address']);
+        } else {
+            $this->assertNull($parsed);
+        }
+    }
+
+    public function test_an_angle_bracket_inside_a_quoted_display_name_is_still_allowed(): void
+    {
+        // Quoted, therefore inert, and legal RFC 5322. It must keep working.
+        $parsed = AddressParser::parse_one('"Bob <not-real>" <bob@x.com>');
+
+        $this->assertNotNull($parsed);
+        $this->assertSame('bob@x.com', $parsed['address']);
+        $this->assertSame('Bob <not-real>', $parsed['name']);
+    }
+
+    // -------------------------------------------------------------------------
+    // GH #312 review: our validator must never be stricter than the transport.
+    //
+    // FILTER_VALIDATE_EMAIL rejects an internationalised domain, while PHPMailer
+    // detects an 8-bit domain BEFORE it validates and punycodes it on send. The
+    // parser is allowed to refuse these, but only because every caller passes a
+    // refused entry through raw so the transport stays the judge. This test
+    // documents the refusal so the passthrough is never removed as redundant.
+    // -------------------------------------------------------------------------
+
+    public function test_an_internationalised_domain_is_refused_and_must_be_passed_through_raw(): void
+    {
+        $this->assertNull(AddressParser::parse_one('kunde@exämple.de'));
+    }
+
+    public function test_the_reporters_exact_case_parses(): void
+    {
+        $parsed = AddressParser::parse_one('Andrea Somigli <salesianalibri@gmail.com>');
+
+        $this->assertNotNull($parsed);
+        $this->assertSame('salesianalibri@gmail.com', $parsed['address']);
+        $this->assertSame('Andrea Somigli', $parsed['name']);
+    }
+}

--- a/apps/agent/tests/Email/MailRouterTest.php
+++ b/apps/agent/tests/Email/MailRouterTest.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * MailRouterTest: first coverage of MailRouter::build_mail_payload(), the
+ * method that reads wp_mail()'s raw $headers argument and is the ROOT of
+ * GH #312: it stored a Reply-To/Cc/Bcc header's raw value verbatim, so
+ * "Andrea Somigli <salesianalibri@gmail.com>" reached the provider handler
+ * as one opaque string instead of a parseable address.
+ *
+ * This test pins the payload SHAPE MailRouter still produces (raw string
+ * entries; see interface-provider-handler.php for why parsing happens at
+ * the handler, not here) while proving the exact reporter header round-trips
+ * through AddressParser correctly, and that a multi-address header (the
+ * second, independent bug: "Cc: a@x.com, b@y.com" stored as ONE string) is
+ * still carried faithfully so the handler-side parser can split it.
+ *
+ * @package WPMgr\Agent\Tests\Email
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Email;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use WPMgr\Agent\Email\AddressParser;
+use WPMgr\Agent\Email\EmailConfig;
+use WPMgr\Agent\Email\MailRouter;
+use WPMgr\Agent\Email\ProviderRouter;
+use WPMgr\Agent\Settings;
+
+/**
+ * @covers \WPMgr\Agent\Email\MailRouter
+ */
+class MailRouterTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+
+        // No wp_mail_from / wp_mail_from_name filters registered; the second
+        // argument (the computed default) passes straight through.
+        Functions\when('apply_filters')->returnArg(2);
+        Functions\when('home_url')->justReturn('https://example.com/');
+        Functions\when('get_option')->justReturn('');
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function router(): MailRouter
+    {
+        $providerRouter = $this->createMock(ProviderRouter::class);
+        $settings       = new Settings();
+
+        return new MailRouter($providerRouter, $settings);
+    }
+
+    // -------------------------------------------------------------------------
+    // GH #312: the reporter's exact header, verbatim
+    // -------------------------------------------------------------------------
+
+    public function test_reporter_exact_reply_to_header_is_carried_through_and_parses_cleanly(): void
+    {
+        $cfg  = new EmailConfig(['provider' => 'smtp']);
+        $atts = [
+            'to'      => 'shop-owner@example.com',
+            'subject' => 'New order',
+            'message' => 'Order details',
+            'headers' => "Content-Type: text/plain\r\nReply-To: Andrea Somigli <salesianalibri@gmail.com>",
+        ];
+
+        $mail = $this->router()->build_mail_payload($atts, $cfg);
+
+        $this->assertSame(['Andrea Somigli <salesianalibri@gmail.com>'], $mail['reply_to']);
+
+        // The payload keeps the raw entry (see interface docblock); confirm it
+        // is still exactly what AddressParser needs to recover the address+name.
+        $parsed = AddressParser::parse_one($mail['reply_to'][0]);
+        $this->assertNotNull($parsed);
+        $this->assertSame('salesianalibri@gmail.com', $parsed['address']);
+        $this->assertSame('Andrea Somigli', $parsed['name']);
+    }
+
+    // -------------------------------------------------------------------------
+    // cc / bcc: same defect class as reply-to, not just reply-to
+    // -------------------------------------------------------------------------
+
+    public function test_cc_and_bcc_headers_with_display_names_are_captured(): void
+    {
+        $cfg  = new EmailConfig(['provider' => 'smtp']);
+        $atts = [
+            'to'      => 'to@example.com',
+            'subject' => 'Subject',
+            'message' => 'Body',
+            'headers' => [
+                'Cc: Carla Cee <carla@example.com>',
+                'Bcc: Bob Bee <bob@example.com>',
+            ],
+        ];
+
+        $mail = $this->router()->build_mail_payload($atts, $cfg);
+
+        $this->assertSame(['Carla Cee <carla@example.com>'], $mail['cc']);
+        $this->assertSame(['Bob Bee <bob@example.com>'], $mail['bcc']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Second, independent bug: a header with MULTIPLE addresses is stored as
+    // one array entry (nothing splits it here); confirm and pin that shape,
+    // since AddressParser::parse_list() at the handler is what splits it.
+    // -------------------------------------------------------------------------
+
+    public function test_multi_address_cc_header_is_stored_as_a_single_unsplit_entry(): void
+    {
+        $cfg  = new EmailConfig(['provider' => 'smtp']);
+        $atts = [
+            'to'      => 'to@example.com',
+            'subject' => 'Subject',
+            'message' => 'Body',
+            'headers' => 'Cc: a@x.com, b@y.com',
+        ];
+
+        $mail = $this->router()->build_mail_payload($atts, $cfg);
+
+        $this->assertSame(['a@x.com, b@y.com'], $mail['cc'], 'MailRouter does not split a multi-address header value; the handler does');
+
+        // Confirm the handler-side parser recovers both addresses from it.
+        $parsed = AddressParser::parse_list($mail['cc']);
+        $this->assertCount(2, $parsed);
+        $this->assertSame('a@x.com', $parsed[0]['address']);
+        $this->assertSame('b@y.com', $parsed[1]['address']);
+    }
+
+    // -------------------------------------------------------------------------
+    // `to`: quote-aware split (upgraded from a naive explode(','))
+    // -------------------------------------------------------------------------
+
+    public function test_to_string_with_quoted_comma_name_splits_correctly(): void
+    {
+        $cfg  = new EmailConfig(['provider' => 'smtp']);
+        $atts = [
+            'to'      => '"Rossi, Andrea" <a@x.com>, b@y.com',
+            'subject' => 'Subject',
+            'message' => 'Body',
+        ];
+
+        $mail = $this->router()->build_mail_payload($atts, $cfg);
+
+        $this->assertSame(['"Rossi, Andrea" <a@x.com>', 'b@y.com'], $mail['to']);
+    }
+
+    public function test_to_array_is_passed_through_unchanged(): void
+    {
+        $cfg  = new EmailConfig(['provider' => 'smtp']);
+        $atts = [
+            'to'      => ['a@x.com', 'b@y.com'],
+            'subject' => 'Subject',
+            'message' => 'Body',
+        ];
+
+        $mail = $this->router()->build_mail_payload($atts, $cfg);
+
+        $this->assertSame(['a@x.com', 'b@y.com'], $mail['to']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Empty / absent headers never throw and produce empty lists
+    // -------------------------------------------------------------------------
+
+    public function test_no_headers_produces_empty_cc_bcc_reply_to(): void
+    {
+        $cfg  = new EmailConfig(['provider' => 'smtp']);
+        $atts = [
+            'to'      => 'to@example.com',
+            'subject' => 'Subject',
+            'message' => 'Body',
+        ];
+
+        $mail = $this->router()->build_mail_payload($atts, $cfg);
+
+        $this->assertSame([], $mail['cc']);
+        $this->assertSame([], $mail['bcc']);
+        $this->assertSame([], $mail['reply_to']);
+    }
+}

--- a/apps/agent/tests/Email/SendgridHandlerTest.php
+++ b/apps/agent/tests/Email/SendgridHandlerTest.php
@@ -198,4 +198,178 @@ class SendgridHandlerTest extends TestCase
 
         $this->assertSame('site-abc', $captured_body['headers']['X-WPMgr-Site'] ?? null);
     }
+
+    // -------------------------------------------------------------------------
+    // GH #312: a "Name <email>" reply_to/to/cc/bcc must become a bare `email`
+    // field with the name carried in the sibling `name` field, not rejected.
+    // -------------------------------------------------------------------------
+
+    public function test_reporter_exact_reply_to_string_becomes_bare_email_with_name(): void
+    {
+        $mail = $this->base_mail();
+        $mail['reply_to'] = ['Andrea Somigli <salesianalibri@gmail.com>'];
+
+        $captured = null;
+        Functions\when('wp_json_encode')->alias('json_encode');
+        Functions\when('wp_remote_post')->alias(
+            function (string $url, array $args) use (&$captured) {
+                $captured = json_decode((string) $args['body'], true);
+                return ['response' => ['code' => 202], 'body' => '', 'headers' => ['x-message-id' => 'sg-1']];
+            }
+        );
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(202);
+        Functions\when('wp_remote_retrieve_body')->justReturn('');
+        Functions\when('wp_remote_retrieve_header')->justReturn('sg-1');
+
+        $handler = new SendgridHandler();
+        $result  = $handler->send($mail, [], 'SG.key');
+
+        $this->assertTrue($result['ok'], 'a display-name Reply-To must not fail the send');
+        $this->assertSame(
+            ['email' => 'salesianalibri@gmail.com', 'name' => 'Andrea Somigli'],
+            $captured['reply_to'] ?? null
+        );
+    }
+
+    public function test_to_cc_bcc_with_display_names_become_email_name_objects(): void
+    {
+        $mail = $this->base_mail();
+        $mail['to']  = ['Terry To <terry@example.com>'];
+        $mail['cc']  = ['Carla Cee <carla@example.com>'];
+        $mail['bcc'] = ['Bob Bee <bob@example.com>'];
+
+        $captured = null;
+        Functions\when('wp_json_encode')->alias('json_encode');
+        Functions\when('wp_remote_post')->alias(
+            function (string $url, array $args) use (&$captured) {
+                $captured = json_decode((string) $args['body'], true);
+                return ['response' => ['code' => 202], 'body' => '', 'headers' => []];
+            }
+        );
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(202);
+        Functions\when('wp_remote_retrieve_body')->justReturn('');
+        Functions\when('wp_remote_retrieve_header')->justReturn('');
+
+        $handler = new SendgridHandler();
+        $result  = $handler->send($mail, [], 'SG.key');
+
+        $this->assertTrue($result['ok']);
+        $personalisation = $captured['personalizations'][0];
+        $this->assertSame([['email' => 'terry@example.com', 'name' => 'Terry To']], $personalisation['to']);
+        $this->assertSame([['email' => 'carla@example.com', 'name' => 'Carla Cee']], $personalisation['cc']);
+        $this->assertSame([['email' => 'bob@example.com', 'name' => 'Bob Bee']], $personalisation['bcc']);
+    }
+
+    public function test_quoted_comma_display_name_is_parsed_correctly(): void
+    {
+        $mail = $this->base_mail();
+        $mail['to'] = ['"Rossi, Andrea" <a@x.com>'];
+
+        $captured = null;
+        Functions\when('wp_json_encode')->alias('json_encode');
+        Functions\when('wp_remote_post')->alias(
+            function (string $url, array $args) use (&$captured) {
+                $captured = json_decode((string) $args['body'], true);
+                return ['response' => ['code' => 202], 'body' => '', 'headers' => []];
+            }
+        );
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(202);
+        Functions\when('wp_remote_retrieve_body')->justReturn('');
+        Functions\when('wp_remote_retrieve_header')->justReturn('');
+
+        $handler = new SendgridHandler();
+        $result  = $handler->send($mail, [], 'SG.key');
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame(
+            [['email' => 'a@x.com', 'name' => 'Rossi, Andrea']],
+            $captured['personalizations'][0]['to']
+        );
+    }
+
+    public function test_multiple_reply_to_addresses_use_reply_to_list(): void
+    {
+        $mail = $this->base_mail();
+        $mail['reply_to'] = ['a@x.com', 'b@y.com'];
+
+        $captured = null;
+        Functions\when('wp_json_encode')->alias('json_encode');
+        Functions\when('wp_remote_post')->alias(
+            function (string $url, array $args) use (&$captured) {
+                $captured = json_decode((string) $args['body'], true);
+                return ['response' => ['code' => 202], 'body' => '', 'headers' => []];
+            }
+        );
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(202);
+        Functions\when('wp_remote_retrieve_body')->justReturn('');
+        Functions\when('wp_remote_retrieve_header')->justReturn('');
+
+        $handler = new SendgridHandler();
+        $result  = $handler->send($mail, [], 'SG.key');
+
+        $this->assertTrue($result['ok']);
+        $this->assertArrayNotHasKey('reply_to', $captured);
+        $this->assertSame(
+            [['email' => 'a@x.com'], ['email' => 'b@y.com']],
+            $captured['reply_to_list'] ?? null
+        );
+    }
+
+    public function test_malformed_cc_entry_is_dropped_not_fatal(): void
+    {
+        $mail = $this->base_mail();
+        $mail['cc'] = ['not-an-email', 'good@example.com'];
+
+        $captured = null;
+        Functions\when('wp_json_encode')->alias('json_encode');
+        Functions\when('wp_remote_post')->alias(
+            function (string $url, array $args) use (&$captured) {
+                $captured = json_decode((string) $args['body'], true);
+                return ['response' => ['code' => 202], 'body' => '', 'headers' => []];
+            }
+        );
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(202);
+        Functions\when('wp_remote_retrieve_body')->justReturn('');
+        Functions\when('wp_remote_retrieve_header')->justReturn('');
+
+        $handler = new SendgridHandler();
+        $result  = $handler->send($mail, [], 'SG.key');
+
+        $this->assertTrue($result['ok'], 'one malformed Cc entry must not fail the whole send');
+        $this->assertSame(
+            [['email' => 'good@example.com']],
+            $captured['personalizations'][0]['cc']
+        );
+    }
+
+    public function test_empty_reply_to_omits_reply_to_fields(): void
+    {
+        $mail = $this->base_mail();
+        $mail['reply_to'] = [];
+
+        $captured = null;
+        Functions\when('wp_json_encode')->alias('json_encode');
+        Functions\when('wp_remote_post')->alias(
+            function (string $url, array $args) use (&$captured) {
+                $captured = json_decode((string) $args['body'], true);
+                return ['response' => ['code' => 202], 'body' => '', 'headers' => []];
+            }
+        );
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(202);
+        Functions\when('wp_remote_retrieve_body')->justReturn('');
+        Functions\when('wp_remote_retrieve_header')->justReturn('');
+
+        $handler = new SendgridHandler();
+        $result  = $handler->send($mail, [], 'SG.key');
+
+        $this->assertTrue($result['ok']);
+        $this->assertArrayNotHasKey('reply_to', $captured);
+        $this->assertArrayNotHasKey('reply_to_list', $captured);
+    }
 }

--- a/apps/agent/tests/Email/SmtpHandlerTest.php
+++ b/apps/agent/tests/Email/SmtpHandlerTest.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * SmtpHandlerTest: first coverage of SmtpHandler::send(), the exact call
+ * site that produced the GH #312 report:
+ *
+ *   {"summary": "Invalid address:  (Reply-To): Andrea Somigli <salesianalibri@gmail.com>"}
+ *
+ * Uses the self-contained \PHPMailer\PHPMailer\PHPMailer double declared in
+ * fake-phpmailer.php (see that file's docblock for why it lives separately).
+ *
+ * @package WPMgr\Agent\Tests\Email
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Email;
+
+use PHPMailer\PHPMailer\FakePhpMailerRegistry;
+use PHPUnit\Framework\TestCase;
+use WPMgr\Agent\Email\Handlers\SmtpHandler;
+
+require_once __DIR__ . '/fake-phpmailer.php';
+
+/**
+ * @covers \WPMgr\Agent\Email\Handlers\SmtpHandler
+ */
+class SmtpHandlerTest extends TestCase
+{
+    private function base_mail(): array
+    {
+        return [
+            'to'          => ['recipient@example.com'],
+            'cc'          => [],
+            'bcc'         => [],
+            'reply_to'    => [],
+            'from'        => 'sender@example.com',
+            'from_name'   => 'WPMgr Test',
+            'subject'     => 'Hello',
+            'body_text'   => 'Plain body',
+            'body_html'   => '',
+            'charset'     => 'UTF-8',
+            'headers'     => [],
+            'attachments' => [],
+            'return_path' => false,
+            'x_site_id'   => 'site-abc',
+            'x_tenant_id' => 'tenant-abc',
+        ];
+    }
+
+    private function config(): array
+    {
+        return ['host' => 'smtp.example.com', 'port' => 587, 'auth' => false];
+    }
+
+    // -------------------------------------------------------------------------
+    // GH #312: the reporter's exact case
+    // -------------------------------------------------------------------------
+
+    public function test_reporter_exact_reply_to_is_delivered_with_name_and_does_not_fail_the_send(): void
+    {
+        $mail = $this->base_mail();
+        $mail['reply_to'] = ['Andrea Somigli <salesianalibri@gmail.com>'];
+
+        $handler = new SmtpHandler();
+        $result  = $handler->send($mail, $this->config(), '');
+
+        $this->assertTrue($result['ok'], 'the send must succeed, not fail the whole message over one Reply-To');
+        $this->assertStringNotContainsString('Invalid address', $result['error']);
+
+        $phpmailer = FakePhpMailerRegistry::$last;
+        $this->assertNotNull($phpmailer);
+        $this->assertSame(
+            [['address' => 'salesianalibri@gmail.com', 'name' => 'Andrea Somigli']],
+            $phpmailer->recordedReplyTo,
+            'the display name must be preserved, not discarded'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // to / cc / bcc: same defect class as reply_to
+    // -------------------------------------------------------------------------
+
+    public function test_to_cc_bcc_display_names_are_all_preserved(): void
+    {
+        $mail = $this->base_mail();
+        $mail['to']  = ['Terry To <terry@example.com>'];
+        $mail['cc']  = ['Carla Cee <carla@example.com>'];
+        $mail['bcc'] = ['Bob Bee <bob@example.com>'];
+
+        $handler = new SmtpHandler();
+        $result  = $handler->send($mail, $this->config(), '');
+
+        $this->assertTrue($result['ok']);
+
+        $phpmailer = FakePhpMailerRegistry::$last;
+        $this->assertSame([['address' => 'terry@example.com', 'name' => 'Terry To']], $phpmailer->recordedTo);
+        $this->assertSame([['address' => 'carla@example.com', 'name' => 'Carla Cee']], $phpmailer->recordedCc);
+        $this->assertSame([['address' => 'bob@example.com', 'name' => 'Bob Bee']], $phpmailer->recordedBcc);
+    }
+
+    // -------------------------------------------------------------------------
+    // Quoted display name containing a comma
+    // -------------------------------------------------------------------------
+
+    public function test_quoted_comma_display_name_is_parsed_correctly(): void
+    {
+        $mail = $this->base_mail();
+        $mail['to'] = ['"Rossi, Andrea" <a@x.com>'];
+
+        $handler = new SmtpHandler();
+        $result  = $handler->send($mail, $this->config(), '');
+
+        $this->assertTrue($result['ok']);
+        $phpmailer = FakePhpMailerRegistry::$last;
+        $this->assertSame([['address' => 'a@x.com', 'name' => 'Rossi, Andrea']], $phpmailer->recordedTo);
+    }
+
+    // -------------------------------------------------------------------------
+    // A plain bare address is unaffected
+    // -------------------------------------------------------------------------
+
+    public function test_plain_bare_address_is_unaffected(): void
+    {
+        $mail = $this->base_mail();
+        $mail['to'] = ['plain@example.com'];
+
+        $handler = new SmtpHandler();
+        $result  = $handler->send($mail, $this->config(), '');
+
+        $this->assertTrue($result['ok']);
+        $phpmailer = FakePhpMailerRegistry::$last;
+        $this->assertSame([['address' => 'plain@example.com', 'name' => '']], $phpmailer->recordedTo);
+    }
+
+    // -------------------------------------------------------------------------
+    // A single header carrying a comma-separated list of addresses
+    // -------------------------------------------------------------------------
+
+    public function test_single_header_value_with_multiple_addresses_is_split(): void
+    {
+        $mail = $this->base_mail();
+        $mail['cc'] = ['a@x.com, b@y.com'];
+
+        $handler = new SmtpHandler();
+        $result  = $handler->send($mail, $this->config(), '');
+
+        $this->assertTrue($result['ok']);
+        $phpmailer = FakePhpMailerRegistry::$last;
+        $this->assertSame(
+            [
+                ['address' => 'a@x.com', 'name' => ''],
+                ['address' => 'b@y.com', 'name' => ''],
+            ],
+            $phpmailer->recordedCc
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Malformed input never fatals the send: one bad address is dropped,
+    // the rest of the message still goes out.
+    // -------------------------------------------------------------------------
+
+    public function test_malformed_reply_to_is_dropped_not_fatal(): void
+    {
+        $mail = $this->base_mail();
+        $mail['reply_to'] = ['not-an-email', 'good@example.com'];
+
+        $handler = new SmtpHandler();
+        $result  = $handler->send($mail, $this->config(), '');
+
+        $this->assertTrue($result['ok'], 'a bad Reply-To must not fail an otherwise-valid send');
+        $this->assertStringContainsString('not-an-email', $result['provider_response'], 'the skipped address must be reported');
+
+        $phpmailer = FakePhpMailerRegistry::$last;
+        $this->assertSame([['address' => 'good@example.com', 'name' => '']], $phpmailer->recordedReplyTo);
+    }
+
+    public function test_empty_reply_to_is_fine(): void
+    {
+        $mail = $this->base_mail();
+        $mail['reply_to'] = [];
+
+        $handler = new SmtpHandler();
+        $result  = $handler->send($mail, $this->config(), '');
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], FakePhpMailerRegistry::$last->recordedReplyTo);
+    }
+
+    public function test_all_recipients_invalid_fails_cleanly_without_throwing(): void
+    {
+        $mail = $this->base_mail();
+        $mail['to'] = ['garbage garbage', ''];
+
+        $handler = new SmtpHandler();
+        $result  = $handler->send($mail, $this->config(), '');
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('no valid recipient', $result['error']);
+    }
+
+    // -------------------------------------------------------------------------
+    // From: same category of bug (a display-name From must not throw either)
+    // -------------------------------------------------------------------------
+
+    public function test_from_with_display_name_does_not_throw_and_is_split(): void
+    {
+        $mail = $this->base_mail();
+        $mail['from']      = 'Shop Name <shop@example.com>';
+        $mail['from_name'] = '';
+
+        $handler = new SmtpHandler();
+        $result  = $handler->send($mail, $this->config(), '');
+
+        $this->assertTrue($result['ok']);
+        $phpmailer = FakePhpMailerRegistry::$last;
+        $this->assertSame(['address' => 'shop@example.com', 'name' => 'Shop Name'], $phpmailer->recordedFrom);
+    }
+}

--- a/apps/agent/tests/Email/fake-phpmailer.php
+++ b/apps/agent/tests/Email/fake-phpmailer.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * A minimal, self-contained double of \PHPMailer\PHPMailer\PHPMailer, used
+ * only by SmtpHandlerTest.php.
+ *
+ * PHPMailer is not a Composer dependency of this plugin. WordPress bundles
+ * it at runtime under ABSPATH/wp-includes/PHPMailer/, which does not exist in
+ * the unit-test process. SmtpHandler's own guard
+ * (`class_exists('PHPMailer\PHPMailer\PHPMailer')`) is what lets this double
+ * stand in: once it is declared, SmtpHandler skips trying to require the real
+ * bundled files and constructs this class instead.
+ *
+ * Kept in its own file (rather than declared inline in the test class) since
+ * it lives under a different namespace (PHPMailer\PHPMailer) than the test
+ * itself (WPMgr\Agent\Tests\Email); PHP does not allow mixing a bracketed
+ * and an unbracketed namespace declaration in one file. The class
+ * declarations here are unconditional at the top level and guarded by
+ * class_exists(), matching the project's existing WP_Upgrader / Plugin_Upgrader
+ * doubles in tests/bootstrap.php, and are self-contained (no Patchwork
+ * function redefinition involved, so nothing here can leak state into an
+ * unrelated test the way a Functions\when() stub can).
+ *
+ * @package WPMgr\Agent\Tests\Email
+ */
+
+declare(strict_types=1);
+
+namespace PHPMailer\PHPMailer;
+
+if (!class_exists('PHPMailer\PHPMailer\Exception')) {
+    /**
+     * Stand-in for \PHPMailer\PHPMailer\Exception.
+     */
+    class Exception extends \Exception
+    {
+    }
+}
+
+if (!class_exists('PHPMailer\PHPMailer\FakePhpMailerRegistry')) {
+    /**
+     * Records the most recently constructed FakePhpMailer instance so a test
+     * can inspect what SmtpHandler did with it after send() returns.
+     */
+    class FakePhpMailerRegistry
+    {
+        public static ?PHPMailer $last = null;
+    }
+}
+
+if (!class_exists('PHPMailer\PHPMailer\PHPMailer')) {
+    /**
+     * Minimal double of \PHPMailer\PHPMailer\PHPMailer sufficient to exercise
+     * SmtpHandler's address-handling logic without the real bundled library.
+     *
+     * Mirrors the real class's default address validator (FILTER_VALIDATE_EMAIL)
+     * and its exact "Invalid address:  (%s): %s" exception message (note the
+     * double space: the real 'invalid_address' language string itself ends in
+     * a trailing space) closely enough to reproduce GH #312's reported failure
+     * faithfully when exercised against the UNFIXED handler code.
+     */
+    class PHPMailer
+    {
+        public const ENCRYPTION_SMTPS = 'ssl';
+        public const ENCRYPTION_STARTTLS = 'tls';
+
+        public string $CharSet = 'UTF-8';
+        public string $Host = '';
+        public int $Port = 587;
+        public string $SMTPSecure = '';
+        public bool $SMTPAutoTLS = true;
+        public bool $SMTPAuth = false;
+        public string $Username = '';
+        public string $Password = '';
+        public string $Subject = '';
+        public string $Body = '';
+        public string $AltBody = '';
+        public string $Sender = '';
+
+        /** @var array<int,array{address:string,name:string}> */
+        public array $recordedTo = [];
+        /** @var array<int,array{address:string,name:string}> */
+        public array $recordedCc = [];
+        /** @var array<int,array{address:string,name:string}> */
+        public array $recordedBcc = [];
+        /** @var array<int,array{address:string,name:string}> */
+        public array $recordedReplyTo = [];
+        /** @var array{address:string,name:string}|null */
+        public ?array $recordedFrom = null;
+
+        private bool $exceptionsEnabled;
+
+        public function __construct(bool $exceptions = false)
+        {
+            $this->exceptionsEnabled = $exceptions;
+            FakePhpMailerRegistry::$last = $this;
+        }
+
+        public function isSMTP(): void
+        {
+        }
+
+        public function isHTML(bool $isHtml = true): void
+        {
+        }
+
+        public function setFrom(string $address, string $name = ''): bool
+        {
+            $this->recordedFrom = ['address' => $address, 'name' => $name];
+            return true;
+        }
+
+        public function addAddress(string $address, string $name = ''): bool
+        {
+            return $this->addAnAddress('To', $address, $name, $this->recordedTo);
+        }
+
+        public function addCC(string $address, string $name = ''): bool
+        {
+            return $this->addAnAddress('Cc', $address, $name, $this->recordedCc);
+        }
+
+        public function addBCC(string $address, string $name = ''): bool
+        {
+            return $this->addAnAddress('Bcc', $address, $name, $this->recordedBcc);
+        }
+
+        public function addReplyTo(string $address, string $name = ''): bool
+        {
+            return $this->addAnAddress('Reply-To', $address, $name, $this->recordedReplyTo);
+        }
+
+        /**
+         * @param array<int,array{address:string,name:string}> $bucket
+         */
+        private function addAnAddress(string $kind, string $address, string $name, array &$bucket): bool
+        {
+            if (filter_var($address, FILTER_VALIDATE_EMAIL) === false) {
+                $message = sprintf('Invalid address:  (%s): %s', $kind, $address);
+                if ($this->exceptionsEnabled) {
+                    throw new Exception($message);
+                }
+                return false;
+            }
+            $bucket[] = ['address' => $address, 'name' => $name];
+            return true;
+        }
+
+        public function addCustomHeader(string $name, ?string $value = null): bool
+        {
+            return true;
+        }
+
+        public function addAttachment(string $path, string $name = '', string $encoding = 'base64', string $type = ''): bool
+        {
+            return true;
+        }
+
+        public function send(): bool
+        {
+            if ($this->recordedTo === [] && $this->recordedCc === [] && $this->recordedBcc === []) {
+                if ($this->exceptionsEnabled) {
+                    throw new Exception('You must provide at least one recipient email address.');
+                }
+                return false;
+            }
+            return true;
+        }
+
+        public function getLastMessageID(): string
+        {
+            return 'fake-message-id';
+        }
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.111
+ * Version:           0.61.112
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.111');
+define('WPMGR_AGENT_VERSION', '0.61.112');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,25 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.112",
+    date: "2026-07-31",
+    summary: "Outgoing email failed entirely when a plugin set a Reply-To in the usual Name <email> form. Fixed, along with three related address bugs.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Outgoing email failed completely whenever a plugin set a Reply-To header in the ordinary \"Name <email@example.com>\" form, which WooCommerce, Fluent Forms and many others do by default. The agent stored that header exactly as written and then handed the whole string, display name included, to the mail transport as if it were the address. The transport rejected it, and because one bad address aborted the entire message, nothing was sent. Addresses are now parsed properly wherever a bare address is required, the display name is kept rather than discarded, and a single bad address costs that one recipient instead of the whole email.",
+      },
+      {
+        tag: "Fixed",
+        text: "The same defect applied to the To, Cc and Bcc headers, not only Reply-To, on the SMTP and SendGrid providers. Amazon SES, Postmark and Mailgun were unaffected, because those build a raw header where this form is already valid. A header carrying more than one address, for example a Cc listing two recipients, was also treated as one malformed address and lost the whole message; address lists are now split correctly, including when a quoted display name contains a comma.",
+      },
+      {
+        tag: "Fixed",
+        text: "A display name could redirect an email to a different address than the one shown. Because header values are commonly assembled by dropping a user-supplied name into a template, a name that itself contained an address in angle brackets could take over as the real destination while the intended address was still displayed. Any entry of that shape is now refused rather than delivered somewhere the site owner did not intend.",
+      },
+    ],
+  },
+  {
     version: "0.61.111",
     date: "2026-07-31",
     summary: "A no-op release, so a site that has been moved onto 0.61.110 has something real for the fleet update path to install.",

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -6,7 +6,7 @@ import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
 export const HOME_HERO = {
-  badge: "v0.61.111 / open source",
+  badge: "v0.61.112 / open source",
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.111
+  version: 0.61.112
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Fixes #312. Reported by a self-hoster whose fleet's outgoing mail has been down for two days.

## The bug

A plugin setting `Reply-To: Andrea Rossi <andrea@example.com>`, which WooCommerce and Fluent Forms do by default, broke outgoing mail **entirely**.

`MailRouter` stored the raw header value, `SmtpHandler` passed that whole string to `PHPMailer::addReplyTo()` as the *address*, PHPMailer rejected it, and because the whole send sat in one try/catch, one bad header lost the entire message. That produced exactly the reported error.

## Wider than the report

- **To, Cc and Bcc had the same defect**, not just Reply-To. WordPress permits `Name <email>` in all of them.
- **SendGrid had it too**, putting the raw string into the API's `email` field.
- SES, Postmark and Mailgun build raw headers where this form is already valid. Untouched.
- **Multi-address headers** (`Cc: a@x.com, b@y.com`) were stored as one entry and never split, losing the whole message on the same two providers.
- **Suppression checks and per-from routing** hash and key on the raw string, so an address in display-name form bypassed the suppression list and missed its routing mapping. Both now see the parsed address.

New `AddressParser` does quote-aware and bracket-aware splitting, so `"Rossi, Andrea" <a@x.com>, b@y.com` is two entries and not three. Display names are preserved rather than discarded, and it never throws.

## Two defects found in review of the fix itself

**A display name could redirect the message.** The angle-addr pattern is greedy, so it binds to the **last** bracketed token, and header values are routinely built by interpolating a user-supplied name into `"{name} <{email}>"`:

```
Bob <bob@example.com> <evil@attacker.com>   ->   address = evil@attacker.com
                                                 name    = Bob <bob@example.com>
```

Previously PHPMailer rejected that entry and the send failed loudly; the fix would have delivered it silently. An angle bracket now only survives in the display name when the whole name is a quoted string. Everything else is refused.

**Our validator was stricter than the transport.** `FILTER_VALIDATE_EMAIL` refuses an internationalised domain, while PHPMailer detects an 8-bit domain *before* validating and punycodes it on send. Dropping unparsed entries would have silently stopped delivering to every IDN recipient that works today. Entries the parser refuses are now handed to the transport raw and only recorded invalid once it refuses them too. Only entries containing `@` are retried, so genuine garbage is still dropped rather than 400-ing an entire SendGrid personalization.

Both are pinned by tests.

## Also

One malformed address now costs that recipient, not the whole email, which is what WordPress core does.

## Gates

```
phpunit      3007 tests, 0 failures, 0 errors
phpcs        0 errors
plugincheck  0 errors
lockstep     0.61.112 across all five version files
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parsing of To, Cc, Bcc, and Reply-To headers, including multiple addresses and quoted commas.
  - Preserved display names across email delivery providers.
  - Invalid recipients are now skipped without aborting otherwise valid messages.
  - Added safer handling for malformed or ambiguous addresses to prevent header injection.
  - Messages with no valid recipients now fail cleanly with clearer reporting.

- **Documentation**
  - Updated the changelog and displayed product version to 0.61.112.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->