### PR TITLE
fix(update): serialise updates per site and stop restoring what was never touched (GH #328)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,4 +80,5 @@ wp-cli.phar
 wp-cli.phar.asc
 docs/security/wporg-t13-*.md
 docs/security/wporg-t14-*.md
+docs/security/wporg-t15-*.md
 docs/security/sftp-recovery-*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.114] - 2026-08-03
+
+### Fixed
+
+- Two updates could previously be dispatched to the same site at the same time, for example two plugins updated in the same bulk run, or an update and a rollback overlapping, running more than one WordPress installer against the same site concurrently (GH #328). WordPress's own updater is not built for that: a second installer can delete files the first one is still relying on, corrupting the update in progress and, in the reported case, leaving the site briefly returning errors. Updates, rollbacks and agent upgrades against one site are now serialized: only one may run at a time, whichever channel it came from.
+- A site that is busy with another update no longer fails the update that was turned away. It is retried automatically, with the reason shown on the task ("waiting: another update is running on this site"), for up to 6 hours before being recorded as not attempted rather than failed, and being busy never counts as a failure, so it can never fail a canary. If a whole wave was turned away for being busy, the rollout does still stop, because a site that never attempted the upgrade proves nothing about it; the difference is that it now stops saying nothing was attempted rather than reporting a failure that did not happen.
+- Separately, when an update fails before it has touched anything on the site (for example a corrupted download), the site no longer runs an automatic restore over a plugin or theme directory it never modified.
+
+### Changed
+
+- Updating many items on one site is correspondingly slower, since they now run strictly one at a time on that site instead of several in parallel: a 30-plugin update on a single site that previously took roughly 6 to 12 minutes now typically takes 15 to 50 minutes. Updates spread across different sites are unaffected and still run in parallel.
+- A brief window remains, at the moment a plugin or theme's files are actually swapped in, where a page load could in principle hit a half-updated directory. This is the same exposure WordPress's own core updater has always had for an admin-initiated single-plugin update, and this release does not add a maintenance-mode window to close it: with updates now serialized one at a time, that window is measured in microseconds, not seconds. A single plugin update started from a site's own WordPress dashboard still does not take part in this lock, so that one collision between a fleet-triggered update and a person using wp-admin at the same moment remains open.
+
 ## [0.61.113] - 2026-08-02
 
 ### Added

--- a/apps/agent/includes/commands/class-rollback-command.php
+++ b/apps/agent/includes/commands/class-rollback-command.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace WPMgr\Agent\Commands;
 
 use WPMgr\Agent\Support\Maintenance;
+use WPMgr\Agent\Support\SiteUpdateLock;
 use WPMgr\Agent\Support\SnapshotManager;
 use WPMgr\Agent\Support\UpdateInFlight;
 use WPMgr\Agent\Support\UpdateRunner;
@@ -71,13 +72,60 @@ final class RollbackCommand implements CommandInterface
      */
     public function execute(array $claims, array $params): array
     {
-        // Heal a `.maintenance` flag left behind by a prior interrupted
-        // update/rollback before starting new work, and arm the shutdown
-        // backstop so a fatal error or a timeout mid-rollback still clears
-        // whatever flag THIS run may leave set.
-        Maintenance::healStaleIfPresent();
-        Maintenance::armShutdownGuard();
+        // --- Per-site serialisation (GitHub issue #328) -------------------
+        // A rollback replaces the live directory wholesale, so it is the same
+        // class of writer as an update and must take the SAME per-site lock:
+        // restoring a plugin directory while another request is running
+        // WordPress's upgrader against wp-content/upgrade/ is exactly the
+        // concurrency this lock exists to remove. Taken FIRST, above the
+        // maintenance heal and the shutdown guard, so a refused rollback
+        // writes nothing at all.
+        //
+        // A REFUSED ROLLBACK DOES NOT WAIT. RollbackCommand answers on the
+        // control plane's own HTTP connection (it does not hand the response
+        // back early the way the self-update channel does), so polling here
+        // would pin a PHP worker for the whole of somebody else's apply. It
+        // refuses honestly instead, with ok=false and a log line the operator
+        // can act on, using the response's existing fields.
+        $lock = SiteUpdateLock::acquire();
+        if ($lock === SiteUpdateLock::HELD_BY_OTHER) {
+            return $this->fail(
+                'Another update, rollback or agent upgrade is already running on this site. '
+                . 'Nothing was attempted and nothing on this site was changed. Try again once it has finished.'
+            );
+        }
 
+        try {
+            // Heal a `.maintenance` flag left behind by a prior interrupted
+            // update/rollback before starting new work, and arm the shutdown
+            // backstop so a fatal error or a timeout mid-rollback still clears
+            // whatever flag THIS run may leave set.
+            //
+            // These sit INSIDE the try, not above it, so that a throw from
+            // either one still reaches the finally and releases the site lock.
+            // Above the try, a throw here would strand the lock for its whole
+            // 900s TTL and wedge every update and rollback on this site for
+            // fifteen minutes. Both are effectively non-throwing today, so this
+            // is latent rather than live, but the lock's release must not
+            // depend on that staying true. UpdateCommand::execute() already
+            // orders it this way; this removes the asymmetry.
+            Maintenance::healStaleIfPresent();
+            Maintenance::armShutdownGuard();
+
+            return $this->run($params);
+        } finally {
+            SiteUpdateLock::release();
+        }
+    }
+
+    /**
+     * The rollback proper, with the site lock already held by execute().
+     *
+     * @param array<string,mixed> $params Request parameters.
+     * @return array{ok:bool,restored_version:string,log:string}
+     */
+    private function run(array $params): array
+    {
         $type       = isset($params['type']) && is_string($params['type']) ? $params['type'] : '';
         $rawSlug    = isset($params['slug']) && is_string($params['slug']) ? $params['slug'] : '';
         $snapshotId = isset($params['snapshot_id']) && is_string($params['snapshot_id']) ? $params['snapshot_id'] : '';

--- a/apps/agent/includes/commands/class-update-command.php
+++ b/apps/agent/includes/commands/class-update-command.php
@@ -134,6 +134,23 @@
  *     would misreport an item that was never even attempted as a successful
  *     update: worse than the bug being fixed here.
  *
+ *   - Per-site serialisation and the restore-skip (GitHub issue #328): the
+ *     control plane sends one item per command but runs several commands
+ *     against one site at once, and WordPress core is not built for that -
+ *     unpack_package() deletes EVERY entry under wp-content/upgrade/ as its
+ *     first act, so a second upgrader destroys the first one's extracted
+ *     source mid-flight. execute() therefore takes a per-SITE update lock
+ *     (WPMgr\Agent\Support\SiteUpdateLock, core's own create_lock primitive)
+ *     before anything that writes, holds it for the whole command, renews it
+ *     between items and releases it in a `finally`. A command that arrives
+ *     while another update, rollback or agent upgrade holds it is refused with
+ *     the `site_busy` status, having written NOTHING at all. Separately, an
+ *     update that failed BEFORE core could touch the destination no longer
+ *     gets a precautionary restore over a directory nobody modified: see the
+ *     four-combination fail-safe table at the decision site, and
+ *     WPMgr\Agent\Support\UpdateOutcome plus
+ *     WPMgr\Agent\Support\DestinationVerifier for the two independent
+ *     conditions that must both hold before a restore is skipped.
  *   - Self-target refusal (agent-only hardening): an item that resolves to
  *     the agent's own plugin is refused outright, before any detection,
  *     download, staging or write, and reported with the existing `skipped`
@@ -157,7 +174,9 @@ declare(strict_types=1);
 namespace WPMgr\Agent\Commands;
 
 use WPMgr\Agent\Support\DebugLog;
+use WPMgr\Agent\Support\DestinationVerifier;
 use WPMgr\Agent\Support\Maintenance;
+use WPMgr\Agent\Support\SiteUpdateLock;
 use WPMgr\Agent\Support\SnapshotManager;
 use WPMgr\Agent\Support\UpdateGuard;
 use WPMgr\Agent\Support\UpdateInFlight;
@@ -201,6 +220,29 @@ final class UpdateCommand implements CommandInterface
      * covers the case where FPM's own timeout IS shorter than this bound.
      */
     private const APPLY_TIME_LIMIT_SECONDS = 900;
+
+    /**
+     * Per-item status meaning "this site is already running another update,
+     * rollback or agent upgrade; NOTHING was attempted and NOTHING on this site
+     * was changed" (GitHub issue #328).
+     *
+     * THE WIRE CONTRACT, pinned and not negotiable here: the control plane
+     * declares the same literal beside its other item statuses and, on seeing
+     * it, defers the task back to `pending` and retries later rather than
+     * producing any terminal status. Renaming this string on one side only is a
+     * build error on the other.
+     *
+     * WHY THE COMMAND STILL ANSWERS ok=false ALONGSIDE IT. An older control
+     * plane does not know this status. Its per-item switch has no case for it,
+     * so an unknown status with ok=TRUE would fall through to the post-probe
+     * branch and could record an update that never ran as SUCCEEDED. With
+     * ok=false the same old control plane takes its "agent rejected the update
+     * command" path and carries the log sentence below to the operator, which
+     * is wrong-but-safe rather than wrong-and-silent. A newer control plane
+     * must therefore test for this status BEFORE it tests ok, and its own
+     * comment says so.
+     */
+    private const STATUS_SITE_BUSY = 'site_busy';
 
     private SnapshotManager $snapshots;
 
@@ -252,63 +294,181 @@ final class UpdateCommand implements CommandInterface
         }
         @ignore_user_abort(true); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- keep applying even if the control plane's HTTP client disconnects mid-request; @-guarded
 
-        // Heal a `.maintenance` flag left behind by a prior interrupted
-        // update/rollback before starting new work, and arm the shutdown
-        // backstop so a fatal error or a timeout mid-update still clears
-        // whatever flag THIS run may leave set.
-        Maintenance::healStaleIfPresent();
-        Maintenance::armShutdownGuard();
-
-        // S4 (adversarial review) — reconcile any update-in-flight marker
-        // left stale by a prior request that was hard-killed severely enough
-        // that UpdateGuard's own shutdown hook never ran (see
-        // UpdateInFlight's class doc). This is the "next agent request" half
-        // of that recovery; HOOK_GC's recurring cron sweep is the other half,
-        // covering the case where no further `update` command ever arrives.
-        //
-        // F2 (final-hardening review) — pass THIS command's own injected
-        // $this->runner, not a fresh ad-hoc UpdateRunner, so the F2
-        // live-directory health check reconcile now performs uses exactly
-        // the same WP-CLI/upgrader-aware runner the rest of this command
-        // does (and so a test that injects a runner double controls this
-        // path too, rather than always hitting a real UpdateRunner).
-        UpdateInFlight::healStaleIfPresent($this->snapshots, $this->runner);
-
-        // C (issue #131 final-hardening review) — invoke the snapshot-store
-        // GC backstop OPPORTUNISTICALLY here too, not cron-only. WP-Cron is
-        // unreliable on `DISABLE_WP_CRON`/dormant sites (no visitor traffic
-        // ever fires the wp-cron.php pseudo-cron request), so an orphaned
-        // snapshot — a since-uninstalled/renamed slug, a crashed capture, or
-        // a stranded restore-failure aside (F4) — could otherwise sit
-        // unreclaimed indefinitely on such a site. Belt-and-suspenders,
-        // mirroring the same reasoning already applied to
-        // UpdateInFlight::healStaleIfPresent() immediately above (which is
-        // itself the opportunistic half of ITS OWN cron-bound counterpart,
-        // gcSweep() — already covered here via the injected $this->snapshots
-        // call above, so it is deliberately NOT invoked a second time
-        // through a fresh, non-injected SnapshotManager instance, which
-        // would both duplicate that work and bypass any snapshot test double
-        // a caller constructed this command with). Cheap: a bounded,
-        // mostly-no-op scandir() pass over a small, self-contained directory.
-        SnapshotManager::gcExpired();
-
+        // GitHub issue #328 - PARSE THE REQUEST BEFORE DOING ANYTHING THAT
+        // WRITES. This ordering is a bug fix, not a tidy-up. `dry_run` used to
+        // be read AFTER Maintenance::healStaleIfPresent() (which deletes a
+        // file), Maintenance::armShutdownGuard() (which registers a callback
+        // that deletes ANY .maintenance flag it finds at shutdown, including
+        // one a human's wp-admin bulk update legitimately owns),
+        // UpdateInFlight::healStaleIfPresent() (which can perform a FULL
+        // DIRECTORY RESTORE) and SnapshotManager::gcExpired() (which deletes).
+        // Every one of those violated the control-plane contract's hard rule
+        // that a dry run must not mutate the site.
         $dryRun   = isset($params['dry_run']) && (bool) $params['dry_run'];
         $snapshot = isset($params['snapshot']) && (bool) $params['snapshot'];
+        $items    = isset($params['items']) && is_array($params['items']) ? $params['items'] : [];
 
-        $items = isset($params['items']) && is_array($params['items']) ? $params['items'] : [];
+        if ($dryRun) {
+            // A dry run reads and reports. It takes NO site lock either: it
+            // mutates no file, activation state or snapshot, so it needs no
+            // mutual exclusion; taking the lock would let a preview BLOCK a
+            // real apply, and being refused by one would make a preview fail
+            // for no benefit. A dry run running alongside somebody else's
+            // apply may read a mid-swap version, which is a slightly wrong
+            // preview and never a wrong mutation.
+            //
+            // THE ONE HONEST EXCEPTION, named rather than hidden: the
+            // availability lookup below forces exactly one fresh WordPress
+            // update check per run, which deletes and repopulates the
+            // update_* transients. That is a write to WordPress's own cache
+            // and it is required for an accurate answer (GitHub issue #208:
+            // reading the cached transient made a real pending update look
+            // up_to_date). It touches no plugin, theme or snapshot.
+            return $this->runItems($items, true, $snapshot);
+        }
 
+        // --- PIECE 2, per-site serialisation (GitHub issue #328) ----------
+        // ONE update writer per site. Taken here, above every mutating call
+        // below, and released in the `finally` at the end of this method: one
+        // command, one hold, never per item. See SiteUpdateLock's class doc for
+        // why the third outcome (UNAVAILABLE) proceeds rather than refuses.
+        $lock = SiteUpdateLock::acquire();
+        if ($lock === SiteUpdateLock::HELD_BY_OTHER) {
+            // NOTHING below this line runs. No flag is healed, no shutdown
+            // guard is armed, no marker is reconciled, no snapshot is GC'd, no
+            // snapshot is captured and no upgrader is constructed. That is the
+            // whole point of refusing here rather than three calls later.
+            return $this->refuseSiteBusy($items);
+        }
+
+        try {
+            // Heal a `.maintenance` flag left behind by a prior interrupted
+            // update/rollback before starting new work, and arm the shutdown
+            // backstop so a fatal error or a timeout mid-update still clears
+            // whatever flag THIS run may leave set.
+            //
+            // BELOW THE LOCK ON PURPOSE (GitHub issue #328): the shutdown
+            // backstop clears ANY .maintenance file it finds, so arming it in a
+            // command that turns out to have nothing to do would silently strip
+            // a flag another in-flight upgrade legitimately owns.
+            Maintenance::healStaleIfPresent();
+            Maintenance::armShutdownGuard();
+
+            // S4 (adversarial review) — reconcile any update-in-flight marker
+            // left stale by a prior request that was hard-killed severely enough
+            // that UpdateGuard's own shutdown hook never ran (see
+            // UpdateInFlight's class doc). This is the "next agent request" half
+            // of that recovery; HOOK_GC's recurring cron sweep is the other half,
+            // covering the case where no further `update` command ever arrives.
+            //
+            // F2 (final-hardening review) — pass THIS command's own injected
+            // $this->runner, not a fresh ad-hoc UpdateRunner, so the F2
+            // live-directory health check reconcile now performs uses exactly
+            // the same WP-CLI/upgrader-aware runner the rest of this command
+            // does (and so a test that injects a runner double controls this
+            // path too, rather than always hitting a real UpdateRunner).
+            UpdateInFlight::healStaleIfPresent($this->snapshots, $this->runner);
+
+            // C (issue #131 final-hardening review) — invoke the snapshot-store
+            // GC backstop OPPORTUNISTICALLY here too, not cron-only. WP-Cron is
+            // unreliable on `DISABLE_WP_CRON`/dormant sites (no visitor traffic
+            // ever fires the wp-cron.php pseudo-cron request), so an orphaned
+            // snapshot — a since-uninstalled/renamed slug, a crashed capture, or
+            // a stranded restore-failure aside (F4) — could otherwise sit
+            // unreclaimed indefinitely on such a site. Belt-and-suspenders,
+            // mirroring the same reasoning already applied to
+            // UpdateInFlight::healStaleIfPresent() immediately above (which is
+            // itself the opportunistic half of ITS OWN cron-bound counterpart,
+            // gcSweep() — already covered here via the injected $this->snapshots
+            // call above, so it is deliberately NOT invoked a second time
+            // through a fresh, non-injected SnapshotManager instance, which
+            // would both duplicate that work and bypass any snapshot test double
+            // a caller constructed this command with). Cheap: a bounded,
+            // mostly-no-op scandir() pass over a small, self-contained directory.
+            //
+            // Losing this on the dry-run path above costs nothing: Plugin
+            // already binds maybeGcSnapshots() to `plugins_loaded` on every
+            // enrolled request, so the sweep still happens cron-independently.
+            SnapshotManager::gcExpired();
+
+            return $this->runItems($items, false, $snapshot);
+        } finally {
+            SiteUpdateLock::release();
+        }
+    }
+
+    /**
+     * Run every requested item, in order, under whatever locking the caller has
+     * already established.
+     *
+     * @param array<int,mixed> $items    Raw request items.
+     * @param bool             $dryRun   Whether to avoid mutation.
+     * @param bool             $snapshot Whether a `core` item should record its version.
+     * @return array{ok:bool,results:array<int,array{type:string,slug:string,from_version:string,to_version:string,status:string,snapshot_id:string,log:string}>}
+     */
+    private function runItems(array $items, bool $dryRun, bool $snapshot): array
+    {
         $results = [];
         $ok      = true;
 
         foreach ($items as $item) {
+            if (!$dryRun) {
+                // ONE COMMAND, ONE HOLD, restamped between items so a
+                // legitimately long multi-item command cannot expire its own
+                // lock mid-run. Effective TTL becomes 900s since the last item
+                // boundary. A no-op when this request does not hold the lock.
+                SiteUpdateLock::renew();
+            }
+
             $result = $this->processItem(is_array($item) ? $item : [], $dryRun, $snapshot);
-            if ($result['status'] === 'failed') {
+            if ($result['status'] === 'failed' || $result['status'] === self::STATUS_SITE_BUSY) {
                 $ok = false;
             }
             $results[] = $result;
         }
 
         return ['ok' => $ok, 'results' => $results];
+    }
+
+    /**
+     * Refuse every item in a command that arrived while another update,
+     * rollback or agent upgrade already holds this site's update lock.
+     *
+     * Writes NOTHING. The whole value of this path is that it is reached before
+     * any snapshot, marker, flag or upgrader exists, so a refused command is
+     * indistinguishable on disk from a command that never arrived.
+     *
+     * @param array<int,mixed> $items Raw request items.
+     * @return array{ok:bool,results:array<int,array{type:string,slug:string,from_version:string,to_version:string,status:string,snapshot_id:string,log:string}>}
+     */
+    private function refuseSiteBusy(array $items): array
+    {
+        $heldUntil = SiteUpdateLock::heldUntil();
+        DebugLog::write(
+            'WPMgr Agent: update command refused, this site is already running another update'
+            . ($heldUntil > 0 ? ' (lock self-expires at ' . $heldUntil . ')' : '') . '.'
+        );
+
+        $results = [];
+        foreach ($items as $item) {
+            $entry = is_array($item) ? $item : [];
+            $type  = isset($entry['type']) && is_string($entry['type']) ? $entry['type'] : '';
+            $slug  = isset($entry['slug']) && is_string($entry['slug']) ? $entry['slug'] : '';
+
+            $results[] = $this->result(
+                $type,
+                $slug,
+                '',
+                '',
+                self::STATUS_SITE_BUSY,
+                '',
+                'Another update, rollback or agent upgrade is already running on this site. '
+                . 'Nothing was attempted and nothing on this site was changed. '
+                . 'This will be retried automatically.'
+            );
+        }
+
+        return ['ok' => false, 'results' => $results];
     }
 
     /**
@@ -639,6 +799,98 @@ final class UpdateCommand implements CommandInterface
                 // isComplete() itself threw (S7; never treated as incomplete).
                 $reasonSuffix = $incompleteReason !== '' ? ' Reason: ' . $incompleteReason . '.' : '';
 
+                // --- PIECE 1, the restore-skip (GitHub issue #328) ---------
+                // Do not restore over a directory WordPress provably never
+                // opened. Two independent conditions must BOTH hold, and each
+                // one alone is deliberately not enough:
+                //   (1) the classification, from core's own error code, says
+                //       the failure happened above install_package()'s first
+                //       destructive line (UpdateOutcome's two-table doc);
+                //   (2) the destination, re-read from disk right now, still
+                //       parses as this exact target at its pre-update version
+                //       (DestinationVerifier).
+                // (1) is an inference about code paths. (2) is an observation.
+                // The skip is irreversible in the only sense that matters -
+                // nothing downstream restores what we decline to restore - so
+                // it requires the observation, not merely the absence of a
+                // contradiction.
+                //
+                // FAIL-SAFE DIRECTION, all four combinations:
+                //   classification null (any verification)   -> RESTORE
+                //   classification false, verification null  -> RESTORE
+                //   classification false, verification false -> RESTORE
+                //   classification false, verification true  -> SKIP  (only)
+                // A missing `destination_touched` key (an older or minimal
+                // runner double) reads as null and therefore restores, which
+                // is exactly the pre-0.61.114 behaviour. This release can only
+                // ever NARROW the set of restores, never widen it.
+                $touched  = $applied['destination_touched'] ?? null;
+                $skip     = false;
+                $verify   = ['verdict' => null, 'detail' => 'not evaluated', 'signals' => []];
+                // Whether the gate was even EVALUATED. Every sentence this
+                // decision can add to the item log is gated on this, so a path
+                // it never looked at (a `core` item, an ok apply that only
+                // failed verification, an unclassified failure) keeps the
+                // previous release's log byte for byte.
+                $gateOpen = $type !== 'core' && ($applied['ok'] ?? null) === false && $touched === false;
+
+                if ($gateOpen) {
+                    $payload = $snapshotId !== '' ? $this->snapshots->payloadDir($snapshotId) : '';
+                    $verify  = DestinationVerifier::verify($type, $slug, $fromVersion, $payload);
+                    $skip    = $verify['verdict'] === true;
+
+                    DebugLog::write(
+                        'WPMgr Agent: restore decision for ' . $type . ':' . $slug
+                        . ' classification=untouched code=' . (string) ($applied['failure_code'] ?? '')
+                        . ' stage=' . (string) ($applied['failure_stage'] ?? '')
+                        . ' verification=' . self::verdictLabel($verify['verdict'])
+                        . ' signals=' . implode(',', $verify['signals'])
+                        . ' action=' . ($skip ? 'skip-restore' : 'restore')
+                        . ' detail=' . $verify['detail']
+                    );
+                }
+
+                if ($skip) {
+                    // NO fire(): stand the shutdown backstop down instead, so
+                    // it cannot restore later in this same request's teardown.
+                    // The null-guard is mandatory: $guard is only constructed
+                    // when a snapshot was captured, and this path is reachable
+                    // on any host where capture() failed.
+                    if ($guard !== null) {
+                        $guard->standDown('pre-install failure, destination verified intact');
+                    }
+
+                    // NEVER markSucceeded() here. Its own doc forbids calling
+                    // it before the update it documents has been independently
+                    // verified complete, and it would flip the snapshot's
+                    // reclaim threshold from 72h to 1h - deleting the one piece
+                    // of evidence that would prove this decision wrong, within
+                    // an hour of a FAILED update. markRestoreSkipped() changes
+                    // no TTL.
+                    if ($snapshotId !== '') {
+                        $this->snapshots->markRestoreSkipped(
+                            $snapshotId,
+                            (string) ($applied['failure_code'] ?? ''),
+                            (string) $verify['detail']
+                        );
+                    }
+
+                    $log .= "\n" . self::skipCopy($type, $applied, $verify, $snapshotId !== '');
+                    $log .= $this->reactivationCopy($type, $slug, $applied);
+
+                    // to_version stays at from_version (nothing moved) and the
+                    // status stays `failed` (the update genuinely did not
+                    // happen). Only the restore is skipped.
+                    return $this->result($type, $slug, $fromVersion, $fromVersion, 'failed', $snapshotId, $log);
+                }
+
+                if ($gateOpen && $verify['verdict'] === false) {
+                    $log .= "\n" . self::restoreBecauseModifiedCopy($type, $applied, $verify);
+                } elseif ($gateOpen) {
+                    // Classified untouched, but this host could not confirm it.
+                    $log .= "\n" . self::restoreBecauseUnverifiedCopy($type, $applied, $verify);
+                }
+
                 // Incomplete or failed apply: roll back synchronously right
                 // now rather than waiting on the shutdown backstop, so the
                 // directory is restored before we even respond to the
@@ -698,6 +950,169 @@ final class UpdateCommand implements CommandInterface
             // Never leak internals; keep the per-item failure contained.
             return $this->result($type, $slug, '', '', 'failed', $snapshotId, 'Update error.');
         }
+    }
+
+    /**
+     * OPERATOR COPY, GitHub issue #328. Four outcomes, four sentences.
+     *
+     * HARD INVARIANT, enforced by a test: the string "Update incomplete;
+     * auto-restored the pre-update snapshot." must NEVER appear in an item log
+     * where UpdateGuard::fire() did not run. That sentence used to be the only
+     * thing an operator saw for this whole class of failure, and on the skip
+     * path it would be a plain lie. None of the sentences below contain it, and
+     * the skip path returns before the restore block that does.
+     *
+     * The existing restore wording (D5 below) is left BYTE-IDENTICAL for every
+     * outcome that does not open the new gate, which is what makes this release
+     * auditable as a strict narrowing rather than a rewrite.
+     *
+     *   D1 skipped, snapshot kept   this method
+     *   D2 skipped, no snapshot     this method
+     *   D3 restored, modified       restoreBecauseModifiedCopy()
+     *   D4 restored, unverifiable   restoreBecauseUnverifiedCopy()
+     *   D5 gate closed              unchanged, see the restore block
+     *   D6 reactivation             reactivationCopy()
+     *   D7 site busy                refuseSiteBusy()
+     *
+     * @param string                    $type        'plugin'|'theme'.
+     * @param array<string,mixed>       $applied     The runner's apply outcome.
+     * @param array{verdict:bool|null,detail:string,signals:array<int,string>} $verify Verification result.
+     * @param bool                      $hasSnapshot Whether a snapshot exists to keep.
+     * @return string
+     */
+    private static function skipCopy(string $type, array $applied, array $verify, bool $hasSnapshot): string
+    {
+        $noun = $type === 'theme' ? 'theme' : 'plugin';
+
+        return 'Update did not start. The ' . $noun . ' directory was re-checked after the failure and is '
+            . 'unchanged, so no restore was ' . ($hasSnapshot ? 'performed' : 'needed') . '. '
+            . 'Reason: ' . self::failureReason($applied) . '. '
+            . 'Check: ' . $verify['detail'] . '.'
+            . ($hasSnapshot ? ' The pre-update snapshot was kept.' : '');
+    }
+
+    /**
+     * D3: the classification said the destination was untouched, but the disk
+     * disagreed. Precedes the unchanged restore wording rather than replacing
+     * it, so the operator learns why a precautionary restore ran.
+     *
+     * @param string                    $type    'plugin'|'theme'.
+     * @param array<string,mixed>       $applied The runner's apply outcome.
+     * @param array{verdict:bool|null,detail:string,signals:array<int,string>} $verify Verification result.
+     * @return string
+     */
+    private static function restoreBecauseModifiedCopy(string $type, array $applied, array $verify): string
+    {
+        $noun = $type === 'theme' ? 'theme' : 'plugin';
+
+        return 'The package failed before installing any file (' . self::failureReason($applied) . '), but the '
+            . $noun . ' directory no longer matches its pre-update state (' . $verify['detail'] . '), so the '
+            . 'pre-update snapshot is being restored as a precaution.';
+    }
+
+    /**
+     * D4: the classification said the destination was untouched and this host
+     * could not confirm it either way. Restoring is the safe direction.
+     *
+     * @param string                    $type    'plugin'|'theme'.
+     * @param array<string,mixed>       $applied The runner's apply outcome.
+     * @param array{verdict:bool|null,detail:string,signals:array<int,string>} $verify Verification result.
+     * @return string
+     */
+    private static function restoreBecauseUnverifiedCopy(string $type, array $applied, array $verify): string
+    {
+        $noun = $type === 'theme' ? 'theme' : 'plugin';
+
+        return 'The package failed before installing any file (' . self::failureReason($applied) . '), but this '
+            . 'host could not verify the ' . $noun . ' directory afterwards (' . $verify['detail'] . '), so the '
+            . 'pre-update snapshot is being restored as a precaution.';
+    }
+
+    /**
+     * D6: core silently deactivated an active plugin at `upgrader_pre_install`
+     * and, on a non-cron request, never puts it back. On the skip path the
+     * directory has just been verified byte-consistent, which is the ONLY
+     * condition under which reactivating is a pure undo rather than a new risk:
+     * activate_plugin() includes the plugin file in this process, so it must
+     * never be pointed at a directory we are not sure about.
+     *
+     * Deliberately NOT applied to the restore path in this release: that path's
+     * wording is byte-identical to the previous version, which is what makes
+     * the narrowing auditable. A restored plugin stays deactivated exactly as
+     * it did before, so nothing regresses.
+     *
+     * @param string              $type    'plugin'|'theme'.
+     * @param string              $slug    Sanitized slug.
+     * @param array<string,mixed> $applied The runner's apply outcome.
+     * @return string Empty string, or a leading-newline sentence.
+     */
+    private function reactivationCopy(string $type, string $slug, array $applied): string
+    {
+        if ($type !== 'plugin' || ($applied['may_have_deactivated'] ?? false) !== true) {
+            return '';
+        }
+
+        $wasActive        = ($applied['was_active'] ?? false) === true;
+        $wasNetworkActive = ($applied['was_network_active'] ?? false) === true;
+        if (!$wasActive && !$wasNetworkActive) {
+            return '';
+        }
+
+        // Only act when the plugin really is off now. Without this check a
+        // plugin the operator deliberately disabled between the capture and
+        // here would be switched back on by a failure path.
+        if (!function_exists('is_plugin_active') || \is_plugin_active($slug)) {
+            return '';
+        }
+
+        $reactivated = $this->runner->reactivateIfCoreDeactivated($slug, $wasActive, $wasNetworkActive);
+        if (!$reactivated['attempted']) {
+            return '';
+        }
+
+        if ($reactivated['ok']) {
+            return "\nThe plugin was active before the update and WordPress deactivated it before failing; "
+                . 'it has been reactivated.';
+        }
+
+        return "\nThe plugin was active before the update and WordPress deactivated it before failing; "
+            . 'reactivation FAILED: ' . $reactivated['message'] . '. Reactivate it from the Plugins screen.';
+    }
+
+    /**
+     * The human reason a failure is reported with: the resolved WordPress error
+     * code plus its data when there is any. Both are already length-bounded and
+     * control-character stripped by UpdateOutcome, because both can originate
+     * inside a downloaded package.
+     *
+     * @param array<string,mixed> $applied The runner's apply outcome.
+     * @return string
+     */
+    private static function failureReason(array $applied): string
+    {
+        $code = (string) ($applied['failure_code'] ?? '');
+        $data = (string) ($applied['failure_data'] ?? '');
+
+        if ($code === '') {
+            return 'the update did not complete';
+        }
+
+        return $code . ($data !== '' ? ' (' . $data . ')' : '');
+    }
+
+    /**
+     * Render a three-valued verification verdict for a debug line.
+     *
+     * @param bool|null $verdict Verification verdict.
+     * @return string
+     */
+    private static function verdictLabel(?bool $verdict): string
+    {
+        if ($verdict === true) {
+            return 'verified_intact';
+        }
+
+        return $verdict === false ? 'modified' : 'unverified';
     }
 
     /**

--- a/apps/agent/includes/support/class-destination-verifier.php
+++ b/apps/agent/includes/support/class-destination-verifier.php
@@ -1,0 +1,594 @@
+<?php
+/**
+ * DestinationVerifier: the restore-skip's OWN backstop (GitHub issue #328).
+ *
+ * Positively re-reads a plugin or theme destination after a failure that was
+ * classified as "core never touched it", and answers true, false or null. Only
+ * `true` may skip a restore.
+ *
+ * THE FULL RATIONALE IS BELOW THE DIRECT-ACCESS GUARD, not above it. Plugin
+ * Check's direct-file-access detector only reads the first 50 raw lines of a
+ * file when looking for the guard, so a long header comment above it silently
+ * turns into a shipping-blocking ERROR. Keep the guard high and the reasoning
+ * underneath.
+ *
+ * @package WPMgr\Agent\Support
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Support;
+
+if (!defined('ABSPATH')) {
+    exit; // No direct access.
+}
+
+/*
+ * DestinationVerifier: the restore-skip's OWN backstop (GitHub issue #328).
+ *
+ * WHY IT IS NOT OPTIONAL. UpdateOutcome tells us whether core COULD have
+ * touched the destination, reasoning purely from the error code core returned.
+ * That is an inference about code paths, not an observation of the disk, and
+ * skipping a restore is irreversible in the sense that matters: the moment we
+ * decide not to restore, nothing else in the system will. Every backstop that
+ * looks like it would cover the gap was checked and does not:
+ *   - the control plane returns on a failed item before its health probe runs;
+ *   - the agent's own isComplete() verification is gated on a SUCCESSFUL apply;
+ *   - core's restore_temp_backup is registered only inside the
+ *     `if ( is_wp_error( $result ) )` branch on install_package()'s return, so
+ *     it does not exist at all on a download or unpack failure;
+ *   - the UpdateInFlight marker is cleared unconditionally when the item ends.
+ * So the skip has to carry its own positive verification, and this class is it.
+ *
+ * THE CONTRACT. verify() returns a THREE-valued verdict and the caller may skip
+ * the restore on `true` ONLY:
+ *   true   the directory was positively re-read and matches its pre-update
+ *          state (its header parses, names the expected slug's main file and
+ *          still reports the pre-update version).
+ *   false  something is provably wrong (directory gone, empty, header
+ *          unparseable, version already moved, a payload entry missing).
+ *   null   this host could not answer (root not listable, main file could not
+ *          be resolved honestly, the WordPress header reader is unavailable,
+ *          anything threw).
+ * NULL AND FALSE BOTH RESTORE. Absence of contradiction is never enough; a
+ * clean bill of health requires the positive read (signal R4). That means an
+ * unverifiable host keeps exactly the behaviour it had before this class
+ * existed, so this is a strict narrowing of the restore set, never a widening.
+ *
+ * IT RESOLVES THE ROOT ITSELF rather than through SnapshotManager::liveDir().
+ * Deliberate: liveDir()'s realpath()-based containment has a documented
+ * false-negative class on open_basedir and relocated/symlinked wp-content (the
+ * S8 regression recorded in UpdateCommand's class doc), and a false negative
+ * here would produce a `null` verdict and a needless restore on exactly the
+ * population that regression already hurt twice. Use the SAME expression core
+ * used as the install destination, so if core could write there we can list it.
+ *
+ * NEVER get_plugins() / UpdateRunner::currentVersion(). Those go through
+ * WordPress's cached, full-directory plugin scan, which can happily return the
+ * PRE-apply version for a directory that has since been wiped. That is the one
+ * false TRUE this backstop must never produce, and a test pins it. Read the
+ * header off the file with get_file_data() after clearstatcache().
+ *
+ * COST. About six syscalls plus one 8KB header read, and only on a failure that
+ * has ALREADY been classified as "core never touched the destination". Zero on
+ * every success path.
+ *
+ * KNOWN LIMIT, named rather than fixed: R5 compares only the top-level entry
+ * set and R6 only the main file's size, so a deep-file-only modification passes
+ * as intact. Core has no mechanism that does that (every path it has is
+ * whole-directory), but a third party hooked on `upgrader_pre_install` or
+ * `upgrader_source_selection` could. A full recursive comparison is the
+ * complete answer and costs a whole-tree walk on the failure path.
+ */
+
+/**
+ * Positively re-reads a plugin/theme destination after a pre-install failure.
+ */
+final class DestinationVerifier
+{
+    /**
+     * Above this many entries on either side, the top-level superset check (R5)
+     * is skipped rather than paid for. A plugin with more than 2000 top-level
+     * entries is not a shape this check adds confidence to.
+     */
+    private const MAX_LISTING_ENTRIES = 2000;
+
+    /**
+     * Verify that a plugin/theme directory still looks exactly as it did before
+     * the update that just failed.
+     *
+     * @param string $type        'plugin'|'theme'.
+     * @param string $slug        Sanitized slug ('folder' or 'folder/main.php').
+     * @param string $fromVersion The version installed BEFORE the apply. A true
+     *                             verdict is impossible without it (see R4).
+     * @param string $payloadDir  Absolute path to the snapshot payload (a copy
+     *                             of the live directory taken before the apply),
+     *                             or '' when there is no snapshot.
+     * @return array{verdict:bool|null,detail:string,signals:array<int,string>}
+     */
+    public static function verify(string $type, string $slug, string $fromVersion, string $payloadDir): array
+    {
+        try {
+            return self::run($type, $slug, $fromVersion, $payloadDir);
+        } catch (\Throwable $e) {
+            DebugLog::write('WPMgr Agent: destination verification threw: ' . $e->getMessage());
+
+            return self::answer(null, 'verification could not run (' . $e->getMessage() . ')', ['threw']);
+        }
+    }
+
+    /**
+     * The verification proper; verify() is the never-throwing wrapper.
+     *
+     * @param string $type        'plugin'|'theme'.
+     * @param string $slug        Sanitized slug.
+     * @param string $fromVersion Pre-update version.
+     * @param string $payloadDir  Snapshot payload directory, or ''.
+     * @return array{verdict:bool|null,detail:string,signals:array<int,string>}
+     */
+    private static function run(string $type, string $slug, string $fromVersion, string $payloadDir): array
+    {
+        $signals = [];
+
+        if ($type !== 'plugin' && $type !== 'theme') {
+            return self::answer(null, 'only plugin and theme destinations can be verified', ['unsupported-type']);
+        }
+
+        $folder = self::folderOf($slug);
+        if ($folder === '') {
+            return self::answer(null, 'the target folder could not be derived from the slug', ['no-folder']);
+        }
+
+        // --- R0 ROOT LISTABLE -------------------------------------------
+        // Once this succeeds, open_basedir is no longer a candidate
+        // explanation for a child being unreadable, because open_basedir is
+        // prefix-based. That is precisely what lets R1 say "absent" rather
+        // than "unknown".
+        $root = self::rootFor($type, $slug);
+        if ($root === '') {
+            return self::answer(null, 'the ' . $type . ' root directory could not be resolved', ['R0-no-root']);
+        }
+        $entries = self::listDir($root);
+        if ($entries === null) {
+            return self::answer(null, 'the ' . $type . ' root directory is not listable', ['R0-root-unlistable']);
+        }
+        $signals[] = 'R0-root-listable';
+
+        // --- R1 DIRECTORY PRESENT ---------------------------------------
+        // The destroyed-destination catch.
+        if (!in_array($folder, $entries, true)) {
+            if ($type === 'theme' && self::foundInAnotherThemeRoot($folder, $root)) {
+                return self::answer(
+                    null,
+                    'the theme directory is not in the expected root but exists under another registered theme root',
+                    array_merge($signals, ['R1-other-theme-root'])
+                );
+            }
+
+            return self::answer(
+                false,
+                'the live directory is absent from ' . $root,
+                array_merge($signals, ['R1-absent'])
+            );
+        }
+        $signals[] = 'R1-present';
+
+        // --- R2 LISTABLE AND NON-EMPTY ----------------------------------
+        // Presence in the parent listing is positive evidence of existence;
+        // permissions are not evidence of destruction, so an unlistable child
+        // is null and never false.
+        $live      = $root . '/' . $folder;
+        $liveNames = self::listDir($live);
+        if ($liveNames === null) {
+            return self::answer(
+                null,
+                'the live directory is present but not listable',
+                array_merge($signals, ['R2-unlistable'])
+            );
+        }
+        if ($liveNames === []) {
+            return self::answer(
+                false,
+                'the live directory is present but empty',
+                array_merge($signals, ['R2-empty'])
+            );
+        }
+        $signals[] = 'R2-non-empty';
+
+        // --- R3 MAIN FILE RESOLUTION, HONEST ----------------------------
+        // A GUESSED main file name that misses must never produce FALSE, or
+        // every plugin with an unconventional main file becomes a permanent
+        // spurious-restore machine.
+        $mainRelative = self::mainFileRelative($type, $slug, $folder, $payloadDir, $liveNames);
+        if ($mainRelative === '') {
+            return self::answer(
+                null,
+                'the main ' . $type . ' file could not be resolved for this target',
+                array_merge($signals, ['R3-unresolved'])
+            );
+        }
+        $signals[]  = 'R3-main-file';
+        $mainPath   = $live . '/' . $mainRelative;
+
+        // --- R4 HEADER RE-READ, THE POSITIVE SIGNAL ---------------------
+        $header = self::readHeader($type, $mainPath);
+        if ($header === null) {
+            return self::answer(
+                null,
+                'this host could not read the ' . $type . ' header after the failure',
+                array_merge($signals, ['R4-unreadable'])
+            );
+        }
+        if ($header['Name'] === '') {
+            // The truncated half-write.
+            return self::answer(
+                false,
+                'the main file is present but its header did not parse',
+                array_merge($signals, ['R4-header-unparseable'])
+            );
+        }
+        if ($fromVersion === '') {
+            // Without a pre-update version there is nothing to match the
+            // on-disk version against, so the positive signal cannot complete.
+            return self::answer(
+                null,
+                'the pre-update version is unknown, so the header could not be matched against it',
+                array_merge($signals, ['R4-no-from-version'])
+            );
+        }
+        if ($header['Version'] !== $fromVersion) {
+            // A swap that COMPLETED while reporting a pre-boundary code.
+            // Exact string identity, never version_compare: any movement at
+            // all means core did reach the destination.
+            return self::answer(
+                false,
+                'the on-disk version is ' . self::clip($header['Version']) . ', not the pre-update '
+                . self::clip($fromVersion),
+                array_merge($signals, ['R4-version-moved'])
+            );
+        }
+        $signals[] = 'R4-header-matches';
+
+        // --- R5 TOP-LEVEL SUPERSET --------------------------------------
+        // Every payload top-level entry must still be present live. EXTRA live
+        // entries are NOT evidence: core has no mechanism that adds a single
+        // top-level file (every path it has is whole-directory), whereas a
+        // plugin writing its own cache file between capture and check is
+        // completely normal.
+        $payloadNames = $payloadDir !== '' ? self::listDir($payloadDir) : null;
+        if ($payloadNames !== null && $payloadNames !== []) {
+            if (count($payloadNames) > self::MAX_LISTING_ENTRIES || count($liveNames) > self::MAX_LISTING_ENTRIES) {
+                $signals[] = 'R5-skipped-oversized';
+            } else {
+                $liveIndex = array_flip($liveNames);
+                foreach ($payloadNames as $name) {
+                    if (!isset($liveIndex[$name])) {
+                        return self::answer(
+                            false,
+                            'a top-level entry present before the update is missing now (' . self::clip($name) . ')',
+                            array_merge($signals, ['R5-entry-missing'])
+                        );
+                    }
+                }
+                $signals[] = 'R5-superset';
+            }
+        } else {
+            $signals[] = 'R5-skipped-no-payload';
+        }
+
+        // --- R6 MAIN FILE SIZE ------------------------------------------
+        // SIZE ONLY, NEVER mtime: the snapshot copy does not preserve mtimes,
+        // so an mtime comparison is a false positive on every single capture.
+        // A payload with no copy of this relative path yields NULL for this
+        // signal and never FALSE: symlinks are skipped when the payload is
+        // built, and on a Bedrock or Composer layout a plain size inequality
+        // against a missing payload file would be a spurious restore on every
+        // such host.
+        if ($payloadDir !== '') {
+            $liveSize    = self::sizeOf($mainPath);
+            $payloadSize = self::sizeOf($payloadDir . '/' . $mainRelative);
+            if ($liveSize !== null && $payloadSize !== null) {
+                if ($liveSize !== $payloadSize) {
+                    return self::answer(
+                        false,
+                        'the main file size changed since the pre-update snapshot',
+                        array_merge($signals, ['R6-size-differs'])
+                    );
+                }
+                $signals[] = 'R6-size-matches';
+            } else {
+                $signals[] = 'R6-skipped-no-payload-copy';
+            }
+        }
+
+        return self::answer(
+            true,
+            'the ' . $type . ' header still reports ' . self::clip($fromVersion)
+            . ' and the directory contents are intact',
+            $signals
+        );
+    }
+
+    /**
+     * The destination root core itself would have installed into.
+     *
+     * @param string $type 'plugin'|'theme'.
+     * @param string $slug Sanitized slug (themes may have per-theme roots).
+     * @return string Absolute path without a trailing slash, or ''.
+     */
+    private static function rootFor(string $type, string $slug): string
+    {
+        if ($type === 'plugin') {
+            // Core passes WP_PLUGIN_DIR as `destination` at
+            // class-plugin-upgrader.php:227.
+            if (defined('WP_PLUGIN_DIR')) {
+                return rtrim((string) constant('WP_PLUGIN_DIR'), '/\\');
+            }
+            if (defined('WP_CONTENT_DIR')) {
+                return rtrim((string) constant('WP_CONTENT_DIR'), '/\\') . '/plugins';
+            }
+
+            return '';
+        }
+
+        // Core passes get_theme_root( $theme ) at class-theme-upgrader.php:327.
+        if (function_exists('get_theme_root')) {
+            $root = get_theme_root($slug);
+            if (is_string($root) && $root !== '') {
+                return rtrim($root, '/\\');
+            }
+        }
+        if (defined('WP_CONTENT_DIR')) {
+            return rtrim((string) constant('WP_CONTENT_DIR'), '/\\') . '/themes';
+        }
+
+        return '';
+    }
+
+    /**
+     * A theme that is absent from the expected root but present under another
+     * registered root is an inconclusive reading, not a destroyed directory.
+     *
+     * @param string $folder   Theme stylesheet directory name.
+     * @param string $expected The root already checked.
+     * @return bool
+     */
+    private static function foundInAnotherThemeRoot(string $folder, string $expected): bool
+    {
+        $roots = [];
+        if (function_exists('get_theme_roots')) {
+            $registered = get_theme_roots();
+            if (is_array($registered)) {
+                foreach ($registered as $candidate) {
+                    if (is_string($candidate) && $candidate !== '') {
+                        $roots[] = $candidate;
+                    }
+                }
+            }
+        }
+        if (isset($GLOBALS['wp_theme_directories']) && is_array($GLOBALS['wp_theme_directories'])) {
+            foreach ($GLOBALS['wp_theme_directories'] as $candidate) {
+                if (is_string($candidate) && $candidate !== '') {
+                    $roots[] = $candidate;
+                }
+            }
+        }
+
+        foreach (array_unique($roots) as $candidate) {
+            $candidate = rtrim($candidate, '/\\');
+            if ($candidate === '' || $candidate === $expected) {
+                continue;
+            }
+            // A theme root registered as a wp-content-relative path is not a
+            // filesystem path; only absolute candidates are checkable here.
+            if (@is_dir($candidate . '/' . $folder)) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- probing a possibly open_basedir-excluded alternate theme root; a warning here must not become output
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The directory component of a slug that may be a bare folder or a full
+     * "folder/main-file.php" plugin basename.
+     *
+     * @param string $slug Sanitized slug.
+     * @return string
+     */
+    private static function folderOf(string $slug): string
+    {
+        $pos = strpos($slug, '/');
+
+        return $pos === false ? $slug : substr($slug, 0, $pos);
+    }
+
+    /**
+     * Resolve the main file's path RELATIVE to the target directory.
+     *
+     * Plugin, in order of trust:
+     *   1. the control plane gave us the exact basename ("folder/main.php");
+     *   2. the SNAPSHOT: the payload is a copy of the pre-update directory, so
+     *      "<folder>.php" in it, or a lone *.php, is the real main file;
+     *   3. the live listing's own "<folder>.php", or a lone *.php there.
+     * Anything else gives up and returns '' (a NULL verdict), because guessing
+     * and missing would report a healthy directory as modified.
+     *
+     * Theme: always style.css (core's own check_package requires it).
+     *
+     * @param string            $type       'plugin'|'theme'.
+     * @param string            $slug       Sanitized slug.
+     * @param string            $folder     Folder component of the slug.
+     * @param string            $payloadDir Snapshot payload directory, or ''.
+     * @param array<int,string> $liveNames  Top-level entries of the live directory.
+     * @return string Relative path, or '' when it cannot be resolved honestly.
+     */
+    private static function mainFileRelative(
+        string $type,
+        string $slug,
+        string $folder,
+        string $payloadDir,
+        array $liveNames
+    ): string {
+        if ($type === 'theme') {
+            return 'style.css';
+        }
+
+        $pos = strpos($slug, '/');
+        if ($pos !== false) {
+            $basename = substr($slug, $pos + 1);
+
+            return $basename !== '' ? $basename : '';
+        }
+
+        if ($payloadDir !== '') {
+            $payloadNames = self::listDir($payloadDir);
+            if ($payloadNames !== null) {
+                $resolved = self::pickMainPhp($payloadNames, $folder);
+                if ($resolved !== '') {
+                    return $resolved;
+                }
+            }
+        }
+
+        return self::pickMainPhp($liveNames, $folder);
+    }
+
+    /**
+     * "<folder>.php" when present, else the single *.php when there is exactly
+     * one, else ''.
+     *
+     * @param array<int,string> $names  Top-level entry names.
+     * @param string            $folder Folder name.
+     * @return string
+     */
+    private static function pickMainPhp(array $names, string $folder): string
+    {
+        $preferred = $folder . '.php';
+        if (in_array($preferred, $names, true)) {
+            return $preferred;
+        }
+
+        $php = [];
+        foreach ($names as $name) {
+            if (strlen($name) > 4 && strtolower(substr($name, -4)) === '.php') {
+                $php[] = $name;
+            }
+        }
+
+        return count($php) === 1 ? $php[0] : '';
+    }
+
+    /**
+     * Read Name/Version straight off the file, bypassing every WordPress cache.
+     *
+     * get_file_data() lives in wp-includes/functions.php, so it is present on
+     * any booted site and does not require the wp-admin plugin API. It reads
+     * the first 8KB of the file each time it is called; clearstatcache() first
+     * so a stat cached before the failed apply cannot answer for a file that
+     * has since changed on disk.
+     *
+     * @param string $type 'plugin'|'theme'.
+     * @param string $path Absolute path to the main file.
+     * @return array{Name:string,Version:string}|null Null when it could not run.
+     */
+    private static function readHeader(string $type, string $path): ?array
+    {
+        if (!function_exists('get_file_data')) {
+            return null;
+        }
+
+        clearstatcache(true, $path);
+        if (!@is_file($path) || !@is_readable($path)) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- the destination may be mid-failure or permission-restricted; a warning here must never reach the response body
+            return null;
+        }
+
+        $map = $type === 'plugin'
+            ? ['Name' => 'Plugin Name', 'Version' => 'Version']
+            : ['Name' => 'Theme Name', 'Version' => 'Version'];
+
+        $data = @get_file_data($path, $map, $type); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- a header read on a possibly half-written file must not emit into the response
+        if (!is_array($data)) {
+            return null;
+        }
+
+        return [
+            'Name'    => isset($data['Name']) && is_string($data['Name']) ? trim($data['Name']) : '',
+            'Version' => isset($data['Version']) && is_string($data['Version']) ? trim($data['Version']) : '',
+        ];
+    }
+
+    /**
+     * Top-level entry names of a directory, excluding . and .., or null when
+     * the directory cannot be listed at all.
+     *
+     * @param string $dir Absolute directory path.
+     * @return array<int,string>|null
+     */
+    private static function listDir(string $dir): ?array
+    {
+        if ($dir === '') {
+            return null;
+        }
+
+        clearstatcache(true, $dir);
+        $entries = @scandir($dir); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- an unlistable directory is an expected, meaningful answer here (see R0/R2); a warning must not reach the response
+        if (!is_array($entries)) {
+            return null;
+        }
+
+        $out = [];
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $out[] = (string) $entry;
+        }
+
+        return $out;
+    }
+
+    /**
+     * File size in bytes, or null when it cannot be determined.
+     *
+     * @param string $path Absolute file path.
+     * @return int|null
+     */
+    private static function sizeOf(string $path): ?int
+    {
+        clearstatcache(true, $path);
+        if (!@is_file($path)) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- a missing or unreadable payload copy is an expected answer (see R6); a warning must not reach the response
+            return null;
+        }
+        $size = @filesize($path); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- same
+
+        return is_int($size) ? $size : null;
+    }
+
+    /**
+     * Bound a value before it reaches an operator-visible sentence.
+     *
+     * @param string $value Raw value.
+     * @return string
+     */
+    private static function clip(string $value): string
+    {
+        $clean = (string) preg_replace('#[\x00-\x1F\x7F]+#', ' ', $value);
+        $clean = trim($clean);
+
+        return strlen($clean) > 64 ? substr($clean, 0, 64) . '...' : $clean;
+    }
+
+    /**
+     * Build the return shape.
+     *
+     * @param bool|null         $verdict Verdict.
+     * @param string            $detail  Human sentence.
+     * @param array<int,string> $signals Signal trail, in evaluation order.
+     * @return array{verdict:bool|null,detail:string,signals:array<int,string>}
+     */
+    private static function answer(?bool $verdict, string $detail, array $signals): array
+    {
+        return ['verdict' => $verdict, 'detail' => $detail, 'signals' => $signals];
+    }
+}

--- a/apps/agent/includes/support/class-site-update-lock.php
+++ b/apps/agent/includes/support/class-site-update-lock.php
@@ -1,0 +1,361 @@
+<?php
+/**
+ * SiteUpdateLock: ONE update writer per site at a time (GitHub issue #328).
+ *
+ * Backed by WordPress core's OWN cross-request upgrader lock
+ * (WP_Upgrader::create_lock / release_lock), the same primitive the agent's
+ * self-update channel already uses and the same one WordPress uses to
+ * serialise its background auto-updates.
+ *
+ * THE FULL RATIONALE IS BELOW THE DIRECT-ACCESS GUARD, not above it. Plugin
+ * Check's direct-file-access detector only reads the first 50 raw lines of a
+ * file when looking for the guard, so a long header comment above it silently
+ * turns into a shipping-blocking ERROR. Keep the guard high and the reasoning
+ * underneath.
+ *
+ * @package WPMgr\Agent\Support
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Support;
+
+if (!defined('ABSPATH')) {
+    exit; // No direct access.
+}
+
+/*
+ * SiteUpdateLock: ONE update writer per site at a time (GitHub issue #328).
+ *
+ * WHY THIS EXISTS. The control plane sends exactly one item per `update`
+ * command but happily runs several commands against the SAME site at once:
+ * its per-target dedup keys on (tenant, site, target_type, target_slug), so a
+ * DIFFERENT plugin on the same site is a legal second task, and the per-tenant
+ * parallelism default is five. WordPress core is not built for that. The very
+ * first thing WP_Upgrader::unpack_package() does is delete EVERY entry under
+ * wp-content/upgrade/ (wp-admin/includes/class-wp-upgrader.php:369 to :375,
+ * discarding both delete results at :373 and :382). A second upgrader starting
+ * while a first is mid-flight therefore deletes the first one's extracted
+ * source out from under it, and the first then fails somewhere between
+ * "clear the destination" and "move the new tree in", which is how a site ends
+ * up with a half-present plugin directory that fatals on the next request.
+ *
+ * WHAT IT IS. Core's OWN cross-request upgrader lock, taken through
+ * WP_Upgrader::create_lock() / release_lock() - the same primitive the agent's
+ * self-update channel already uses (class-update-checker.php) and the same one
+ * WordPress uses to serialise its background auto-updates. Verified against the
+ * bundled WordPress 7.0.2 tree (wp-includes/version.php:19):
+ *   - the atomic step is ONE `INSERT IGNORE` statement at
+ *     class-wp-upgrader.php:1065; we do not reimplement it and must not claim
+ *     to have tested it;
+ *   - the get_option() branch at :1068 is reached only after that insert has
+ *     already failed;
+ *   - validity is judged against the CALLER's release timeout at :1076;
+ *   - an expired lock is released and re-taken by recursion at :1080 to :1083,
+ *     so mutual exclusion survives two concurrent stealers;
+ *   - the winner restamps at :1087;
+ *   - release_lock() is an UNCONDITIONAL delete_option() at :1102 to :1103.
+ *
+ * THREE OUTCOMES, NOT TWO. class-wp-upgrader.php:1067 to :1072 bails false when
+ * the INSERT failed AND get_option() is falsy, which conflates "the insert
+ * failed for an infrastructure reason" with "somebody holds the lock".
+ * `INSERT IGNORE` is MySQL syntax; on a rewritten database backend, a hardened
+ * wpdb, or an options table that refuses the write, $wpdb->query() returns
+ * false and core's helper would report "locked" forever. A boolean API would
+ * then refuse EVERY update on that site permanently with no in-product remedy.
+ * acquire() therefore separates HELD_BY_OTHER (refuse) from UNAVAILABLE
+ * (proceed without the lock and log loudly). Failing closed on a lock core
+ * itself does not even check the return value of would be a worse bug than the
+ * one being fixed.
+ *
+ * THE NAME IS DELIBERATELY NOT core's 'auto_updater'. create_lock() judges
+ * staleness against the CALLER's timeout (:1076), so taking core's lock name
+ * with our 900s would steal a lock core honours for HOUR_IN_SECONDS (it passes
+ * no timeout at class-wp-automatic-updater.php:651, so :1059 to :1061 gives it
+ * 3600), and core's own release would then delete OURS, manufacturing exactly
+ * the concurrency this class removes.
+ *
+ * OWNERSHIP IS MANDATORY, NOT DECORATIVE. Because release_lock() is an
+ * unconditional delete_option(), a late release() from a holder whose lock had
+ * already expired and been stolen would free a LIVE holder. acquire() writes a
+ * random token beside the lock; release() and renew() read it back and no-op on
+ * a mismatch.
+ *
+ * DEATH SEMANTICS ARE THE OPPOSITE OF UpdateInFlight'S, ON PURPOSE. No shutdown
+ * hook is registered for this lock and none may be added. A PHP fatal, a
+ * max_execution_time kill or an FPM SIGTERM mid-swap leaves a half-written
+ * directory behind, and admitting a second writer immediately is the worst
+ * possible response; the site stays closed until core's own self-expiry at
+ * :1076 to :1083 hands the lock to the next caller. UpdateInFlight's per-slug
+ * flock needs the exact opposite (it must die with the process, because "can
+ * this lock be re-acquired" IS its liveness signal), which is why both exist
+ * and neither can do the other's job. LOCK ORDER, fixed and cycle-free: site
+ * lock first, then the per-slug flock. It is also a DB row rather than an
+ * flock, so it is coherent across nodes on shared storage where flock is not.
+ *
+ * CONSISTENCY NOTE. TTL (900) is SHORTER than UpdateInFlight::STALE_AFTER_SECONDS
+ * (1200). A command arriving at t=901 after a hard kill acquires the lock,
+ * reaches the in-flight reconcile and correctly declines to act on a 901s-old
+ * marker; at t=1201 it acts. That is today's behaviour and is not a new hole.
+ */
+
+/**
+ * Serialises every agent-driven writer that can touch wp-content/upgrade/ or a
+ * plugin/theme destination on this site.
+ */
+final class SiteUpdateLock
+{
+    /** acquire(): this request now owns the lock. */
+    public const ACQUIRED = 1;
+
+    /** acquire(): somebody else owns it right now. Refuse, touch nothing. */
+    public const HELD_BY_OTHER = 2;
+
+    /**
+     * acquire(): the lock could not be evaluated at all (core's helper is
+     * absent, or its INSERT failed for an infrastructure reason and the lock
+     * row is not readable either). PROCEED WITHOUT THE LOCK and log - see the
+     * class doc for why this branch is required rather than defensive padding.
+     */
+    public const UNAVAILABLE = 3;
+
+    /**
+     * Core stores the lock in the wp-option named "<LOCK>.lock". Prefixed, and
+     * deliberately NOT core's own 'auto_updater' (class doc).
+     */
+    private const LOCK = 'wpmgr_site_update';
+
+    /** Non-autoloaded wp-option holding this holder's random owner token. */
+    private const OWNER = 'wpmgr_site_update_owner';
+
+    /**
+     * Seconds an existing lock is respected, handed to create_lock() as its
+     * release timeout.
+     *
+     * 900 because it is UpdateCommand::APPLY_TIME_LIMIT_SECONDS and
+     * LongRunningJob::TIME_LIMIT_SECONDS, the PHP execution budget an apply
+     * arms for itself, and the value the self-update channel already passes.
+     * The lock must outlive an apply that runs to its own cap and not one
+     * second longer, so a worker killed mid-apply blocks the next attempt for
+     * exactly as long as it could conceivably still have been alive. Pinned by
+     * a test so the three cannot drift apart.
+     */
+    public const TTL = 900;
+
+    /**
+     * The owner token this REQUEST wrote when it took the lock, or '' when this
+     * request does not hold it. Also the re-entrancy guard: a second acquire()
+     * in the same request must not ask core again, because core would answer
+     * "held" (by us) and we would refuse our own work.
+     */
+    private static string $token = '';
+
+    /**
+     * Take the site update lock.
+     *
+     * @return int One of ACQUIRED, HELD_BY_OTHER, UNAVAILABLE.
+     */
+    public static function acquire(): int
+    {
+        if (self::$token !== '') {
+            // Already ours in this request. See $token's doc.
+            return self::ACQUIRED;
+        }
+
+        if (!self::upgraderLockApiAvailable()) {
+            DebugLog::write(
+                'WPMgr Agent: site update lock unavailable (WP_Upgrader::create_lock is not callable in this '
+                . 'runtime); proceeding without per-site serialisation.'
+            );
+
+            return self::UNAVAILABLE;
+        }
+
+        try {
+            $taken = (bool) \WP_Upgrader::create_lock(self::LOCK, self::TTL);
+        } catch (\Throwable $e) {
+            DebugLog::write('WPMgr Agent: site update lock could not be evaluated: ' . $e->getMessage());
+
+            return self::UNAVAILABLE;
+        }
+
+        if ($taken) {
+            self::$token = bin2hex(random_bytes(16));
+            if (function_exists('update_option')) {
+                update_option(self::OWNER, self::$token, false);
+            }
+
+            return self::ACQUIRED;
+        }
+
+        // create_lock() returned false. Distinguish "somebody holds it" from
+        // "core could not tell" by reading the lock row ourselves: core's own
+        // helper conflates the two (class doc).
+        if (self::lockStamp() > 0) {
+            return self::HELD_BY_OTHER;
+        }
+
+        DebugLog::write(
+            'WPMgr Agent: site update lock could not be taken and no lock row is readable; proceeding without '
+            . 'per-site serialisation.'
+        );
+
+        return self::UNAVAILABLE;
+    }
+
+    /**
+     * Restamp a lock this request owns so a legitimately long multi-item
+     * command cannot expire its own lock between items. Exactly what core does
+     * at class-wp-upgrader.php:1087. A no-op when this request does not own the
+     * lock any more.
+     *
+     * @return void
+     */
+    public static function renew(): void
+    {
+        if (self::$token === '' || !self::ownsLock()) {
+            return;
+        }
+        if (function_exists('update_option')) {
+            update_option(self::LOCK . '.lock', time(), false);
+        }
+    }
+
+    /**
+     * Release a lock this request owns. A no-op when the stored owner token is
+     * not ours: release_lock() is an unconditional delete_option()
+     * (class-wp-upgrader.php:1102 to :1103), so releasing after our lock
+     * expired and was stolen would free a LIVE holder. Do not simplify this
+     * check away.
+     *
+     * @return void
+     */
+    public static function release(): void
+    {
+        if (self::$token === '') {
+            return;
+        }
+
+        if (!self::ownsLock()) {
+            DebugLog::write(
+                'WPMgr Agent: site update lock was taken over by another request before this one released it; '
+                . 'leaving the live holder alone.'
+            );
+            self::$token = '';
+
+            return;
+        }
+
+        try {
+            if (self::upgraderLockApiAvailable() && method_exists('\WP_Upgrader', 'release_lock')) {
+                \WP_Upgrader::release_lock(self::LOCK);
+            }
+        } catch (\Throwable $e) {
+            DebugLog::write('WPMgr Agent: site update lock release threw: ' . $e->getMessage());
+        }
+
+        if (function_exists('delete_option')) {
+            delete_option(self::OWNER);
+        }
+
+        self::$token = '';
+    }
+
+    /**
+     * When the currently-held lock self-expires, as a unix timestamp.
+     *
+     * @return int 0 when no lock row can be read.
+     */
+    public static function heldUntil(): int
+    {
+        $stamp = self::lockStamp();
+
+        return $stamp > 0 ? $stamp + self::TTL : 0;
+    }
+
+    /**
+     * Whether THIS request currently holds the lock. Test/diagnostic seam; no
+     * production decision is made on it.
+     *
+     * @return bool
+     */
+    public static function heldByThisRequest(): bool
+    {
+        return self::$token !== '';
+    }
+
+    /**
+     * Forget any lock state this PROCESS is carrying, without touching the
+     * option store. Exists only so a test process (in which statics persist
+     * across cases) can start from a known state; production never calls it.
+     *
+     * @return void
+     */
+    public static function resetForTests(): void
+    {
+        self::$token = '';
+    }
+
+    /**
+     * Is the stored owner token still ours?
+     *
+     * @return bool
+     */
+    private static function ownsLock(): bool
+    {
+        if (self::$token === '' || !function_exists('get_option')) {
+            return false;
+        }
+
+        $stored = get_option(self::OWNER, '');
+
+        return is_string($stored) && $stored !== '' && hash_equals($stored, self::$token);
+    }
+
+    /**
+     * The moment the current lock was taken, as core stores it.
+     *
+     * @return int 0 when absent, unreadable or not a positive integer.
+     */
+    private static function lockStamp(): int
+    {
+        if (!function_exists('get_option')) {
+            return 0;
+        }
+
+        $raw = get_option(self::LOCK . '.lock', 0);
+        if (!is_scalar($raw)) {
+            return 0;
+        }
+        $stamp = (int) $raw;
+
+        return $stamp > 0 ? $stamp : 0;
+    }
+
+    /**
+     * Make sure WP_Upgrader (a wp-admin class) is loaded, since the lock is a
+     * static on it. Mirrors the loaders UpdateRunner and UpdateChecker already
+     * use; never fatal.
+     *
+     * @return bool Whether create_lock() can be called.
+     */
+    private static function upgraderLockApiAvailable(): bool
+    {
+        if (class_exists('\WP_Upgrader') && method_exists('\WP_Upgrader', 'create_lock')) {
+            return true;
+        }
+
+        if (!defined('ABSPATH')) {
+            return false;
+        }
+
+        $base = rtrim((string) ABSPATH, '/\\') . '/wp-admin/includes/';
+        foreach (['file.php', 'misc.php', 'plugin.php', 'class-wp-upgrader.php'] as $adminInclude) {
+            if (is_file($base . $adminInclude)) {
+                require_once $base . $adminInclude;
+            }
+        }
+
+        return class_exists('\WP_Upgrader') && method_exists('\WP_Upgrader', 'create_lock');
+    }
+}

--- a/apps/agent/includes/support/class-snapshot-manager.php
+++ b/apps/agent/includes/support/class-snapshot-manager.php
@@ -445,6 +445,92 @@ class SnapshotManager
     }
 
     /**
+     * GitHub issue #328 - the snapshot's payload directory, for a caller that
+     * needs to COMPARE the live tree against the pre-update copy rather than
+     * restore it (see DestinationVerifier's R5/R6 signals).
+     *
+     * Deliberately NOT resolvedRestorePaths(): that method returns an empty
+     * pair whenever liveDir() fails, which is exactly the open_basedir /
+     * relocated-wp-content population the verifier exists to serve, and it
+     * resolves a live path this caller has already resolved for itself.
+     *
+     * @param string $snapshotId Snapshot identifier.
+     * @return string Absolute payload path, or '' when it cannot be resolved
+     *                 or does not exist (a core snapshot has no payload).
+     */
+    public function payloadDir(string $snapshotId): string
+    {
+        $base = $this->snapshotBaseDir();
+        if ($base === '') {
+            return '';
+        }
+
+        $snapshotDir = $this->resolveSnapshotDir($base, $snapshotId);
+        if ($snapshotDir === '') {
+            return '';
+        }
+
+        $payload = $snapshotDir . '/payload';
+
+        return is_dir($payload) ? $payload : '';
+    }
+
+    /**
+     * GitHub issue #328 - label a snapshot whose restore was deliberately
+     * SKIPPED because the destination was verified unchanged after a failure
+     * that happened before WordPress ever touched it.
+     *
+     * THIS IS NOT markSucceeded() AND MUST NEVER BECOME IT. markSucceeded()
+     * flips the reclaim threshold from GC_BACKSTOP_TTL_SECONDS (72h) to
+     * SUCCESS_RECLAIM_TTL_SECONDS (1h) via shouldReclaim(), and its own doc
+     * forbids calling it before the update it documents has been independently
+     * verified complete. On this path the update FAILED. The snapshot's entire
+     * value here is the case where both the classification and the verification
+     * were wrong, so any policy that shortens its life in proportion to our
+     * confidence destroys exactly the evidence that would prove the decision
+     * wrong. This marker therefore changes NO TTL: `restore_skipped_at` is not
+     * read by shouldReclaim() or isMarkedSucceeded() (which keys on
+     * `succeeded_at` only), so the snapshot stays on the unchanged 72h tier,
+     * which is the tier already documented as "kept for manual recovery".
+     * Disk stays bounded by machinery that already exists: MAX_SNAPSHOTS_PER_SLUG
+     * plus pruneForSlug() at the top of capture(), so the next attempt on this
+     * slug reclaims it.
+     *
+     * Best-effort and never throws, exactly like markSucceeded(): a failed
+     * write simply leaves an unlabelled snapshot on the same 72h tier, which is
+     * where it was going anyway.
+     *
+     * @param string $snapshotId   Snapshot captured for the apply that failed.
+     * @param string $failureCode  Resolved WP error code behind the failure.
+     * @param string $verification The verifier's own one-line detail.
+     * @return void
+     */
+    public function markRestoreSkipped(string $snapshotId, string $failureCode, string $verification): void
+    {
+        try {
+            $base = $this->snapshotBaseDir();
+            if ($base === '') {
+                return;
+            }
+            $dir = $this->resolveSnapshotDir($base, $snapshotId);
+            if ($dir === '') {
+                return;
+            }
+            $meta = $this->readMeta($dir);
+            if ($meta === null) {
+                return;
+            }
+            $meta['restore_skipped_at']        = time();
+            $meta['restore_skip_code']         = $failureCode;
+            $meta['restore_skip_verification'] = $verification;
+            @file_put_contents($dir . '/meta.json', (string) json_encode($meta));
+        } catch (\Throwable $e) {
+            // Labelling is diagnostics, never correctness - see this method's
+            // doc for why the snapshot's retention is deliberately unaffected.
+        }
+    }
+
+    /**
      * Remove a snapshot directory and its contents.
      *
      * @param string $snapshotId Snapshot identifier.

--- a/apps/agent/includes/support/class-update-checker.php
+++ b/apps/agent/includes/support/class-update-checker.php
@@ -146,6 +146,15 @@ final class UpdateChecker
     private const OPTION_APPLY_ID = 'wpmgr_agent_self_update_apply_id';
 
     /**
+     * How long the apply waits for the site's own update lock before giving up
+     * without applying anything (GitHub issue #328). See awaitSiteUpdateLock().
+     */
+    private const SITE_LOCK_WAIT_SECONDS = 240;
+
+    /** Poll interval while waiting for the site's update lock. */
+    private const SITE_LOCK_POLL_SECONDS = 3;
+
+    /**
      * Every agent class that can still be reached AFTER the plugin directory
      * has been swapped. warmPostSwapClasses() loads each one before the swap
      * starts, so the code that runs between the swap and the end of the request
@@ -167,6 +176,13 @@ final class UpdateChecker
         'WPMgr\\Agent\\Support\\LongRunningJob',
         'WPMgr\\Agent\\Support\\ErrorMonitor',
         'WPMgr\\Agent\\Support\\UpdateGuard',
+        // GitHub issue #328 - the apply takes the per-site update lock before
+        // the swap and releases it in applyPendingUpdate()'s `finally`, which
+        // runs AFTER runUpgrade() has replaced the agent's own plugin
+        // directory. Without warming, that release would try to autoload a
+        // class off a path that no longer exists, in the one code path this
+        // project's history records as having bricked sites.
+        'WPMgr\\Agent\\Support\\SiteUpdateLock',
         'WPMgr\\Agent\\Support\\ConnectionFinisher',
         'WPMgr\\Agent\\Support\\UpdateChecker',
         'WPMgr\\Agent\\Commands\\AgentSelfUpdateCommand',
@@ -1580,13 +1596,116 @@ final class UpdateChecker
                 @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- bounded-but-generous cap so a hung self-update apply hits a recoverable max_execution_time fatal rather than only an unrecoverable hard-kill; @-guarded, no-op when disabled
             }
 
+            // --- Per-site serialisation (GitHub issue #328) ---------------
+            // This apply runs Plugin_Upgrader over the agent's own directory,
+            // and unpack_package() deletes EVERY entry under
+            // wp-content/upgrade/ as its first act. Running it beside a plugin
+            // update command therefore destroys that command's extracted
+            // source mid-flight, and vice versa. Wait for the site's update
+            // lock rather than barging in.
+            //
+            // WAITING HERE IS FREE, which is the reason the wait lives at this
+            // exact point and nowhere else: the control-plane connection has
+            // already been released by the ack above, so nobody is holding a
+            // socket open for us. The ARM, by contrast, must NEVER consult
+            // this lock: it touches nothing on disk, and a terminal
+            // non-confirming answer from a canary halts a whole rollout.
+            if (!$this->awaitSiteUpdateLock($applyId, $from, $to)) {
+                return;
+            }
+
             self::warmPostSwapClasses();
 
             $this->runUpgrade($applyId, $from, $to);
         } catch (\Throwable $e) {
             $this->recordSelfUpdateResult($applyId, 'failed', $from, $to, 'Self-update apply threw: ' . $e->getMessage());
         } finally {
+            SiteUpdateLock::release();
             $this->releaseApplyLock();
+        }
+    }
+
+    /**
+     * Poll for the site's update lock before swapping the agent's own plugin
+     * directory. See applyPendingUpdate()'s call site for why this cannot live
+     * in the arm.
+     *
+     * LOCK ORDER, fixed and cycle-free: APPLY_LOCK (already held by the arm)
+     * and then the site lock. Nothing that holds the site lock ever asks for
+     * APPLY_LOCK, so no cycle is representable.
+     *
+     * 240 SECONDS, NOT LONGER. The poll holds a PHP worker; on a shared host
+     * with two of them, a ten-minute hold is half the site's capacity. 240s
+     * comfortably covers a normal plugin apply plus queueing, and the site
+     * lock's own TTL (900s) deliberately EXCEEDS the poll, so a legitimately
+     * long apply outlives the wait rather than being barged past.
+     *
+     * ON EXHAUSTION NOTHING IS APPLIED. The result is recorded as `failed`
+     * because that is the vocabulary the control plane already understands for
+     * "the agent was not upgraded"; the message says plainly that nothing was
+     * attempted and nothing on the site changed, and the rollout can be re-run
+     * when the site is idle. An UNAVAILABLE lock (see SiteUpdateLock) proceeds,
+     * exactly as an update command does, because refusing an upgrade over a
+     * lock core itself does not check would be worse than the race it prevents.
+     *
+     * @param string $applyId Opaque id of this apply.
+     * @param string $from    On-disk version at arm time.
+     * @param string $to      Verified target version.
+     * @return bool Whether the swap may proceed.
+     */
+    private function awaitSiteUpdateLock(string $applyId, string $from, string $to): bool
+    {
+        $deadline = time() + self::SITE_LOCK_WAIT_SECONDS;
+
+        while (true) {
+            $state = SiteUpdateLock::acquire();
+            if ($state !== SiteUpdateLock::HELD_BY_OTHER) {
+                if ($state === SiteUpdateLock::UNAVAILABLE) {
+                    DebugLog::write(
+                        'WPMgr Agent: self-update apply proceeding without the per-site update lock; '
+                        . 'see SiteUpdateLock for why this is not a refusal.'
+                    );
+                }
+
+                // The wait must not eat the apply's own execution budget:
+                // set_time_limit() restarts the counter on every call.
+                if (function_exists('set_time_limit')) {
+                    @set_time_limit(LongRunningJob::TIME_LIMIT_SECONDS); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- re-arms the apply's own bounded budget after the wait; @-guarded, no-op when disabled
+                }
+
+                return true;
+            }
+
+            if (time() >= $deadline) {
+                DebugLog::write(
+                    'WPMgr Agent: self-update apply gave up waiting for the per-site update lock after '
+                    . self::SITE_LOCK_WAIT_SECONDS . 's; nothing was applied.'
+                );
+                // 'deferred', NOT 'failed'. Nothing was attempted and nothing
+                // on this site changed, so this is a BUSY answer, not a broken
+                // one. Recording 'failed' here would let an ordinary busy site
+                // fail a wave-0 canary and halt a whole fleet rollout, which is
+                // exactly what this release promises cannot happen. The control
+                // plane finishes a deferred apply as skipped; see
+                // agentApplyDeferred in apps/api/internal/update/agent_worker.go.
+                // An older control plane that does not know this status surfaces
+                // it verbatim through applyResultSentence's default arm and
+                // still fails the task at its deadline, which is exactly the
+                // behaviour before this change: never worse.
+                $this->recordSelfUpdateResult(
+                    $applyId,
+                    'deferred',
+                    $from,
+                    $to,
+                    'The site was busy with another update for the whole wait, so the agent was not upgraded. '
+                    . 'Nothing was attempted and nothing on this site was changed. Re-run this rollout when the '
+                    . 'site is idle.'
+                );
+
+                return false;
+            }
+
+            sleep(self::SITE_LOCK_POLL_SECONDS);
         }
     }
 

--- a/apps/agent/includes/support/class-update-guard.php
+++ b/apps/agent/includes/support/class-update-guard.php
@@ -131,6 +131,38 @@ final class UpdateGuard
     }
 
     /**
+     * GitHub issue #328 - disarm this guard because THERE IS NOTHING TO ROLL
+     * BACK, which is a different fact from markClean()'s "the apply was
+     * verified good".
+     *
+     * The one caller is UpdateCommand's restore-skip decision: an update that
+     * failed BEFORE WordPress ever touched the destination (UpdateOutcome said
+     * so from the error code) AND whose destination was then positively
+     * re-read as unchanged (DestinationVerifier said so from the disk). The
+     * shutdown backstop must not fire for such an item, because firing it would
+     * perform a non-atomic restore over a directory nobody modified.
+     *
+     * Deliberately a DISTINCT NAME rather than an extra call to markClean():
+     * an operator reading a debug log must be able to tell "we kept a good
+     * update" apart from "we declined to undo a failure that changed nothing".
+     * The side effects are identical on purpose (clear the in-flight marker so
+     * the out-of-band reconcile does not later restore what this decision just
+     * declined to restore), so any future change to one must consider the other.
+     *
+     * @param string $reason Short, non-secret explanation for the debug log.
+     * @return void
+     */
+    public function standDown(string $reason): void
+    {
+        $this->clean = true;
+        UpdateInFlight::clear($this->type, $this->slug);
+        DebugLog::write(
+            'WPMgr Agent: update guard stood down for ' . $this->type . ':' . $this->slug
+            . ' (no restore performed): ' . $reason
+        );
+    }
+
+    /**
      * Restore the snapshot unless the apply was already confirmed clean, or
      * this guard has already fired once. Safe to call from a real PHP
      * shutdown handler (return value is simply unused there) or

--- a/apps/agent/includes/support/class-update-outcome.php
+++ b/apps/agent/includes/support/class-update-outcome.php
@@ -1,0 +1,629 @@
+<?php
+/**
+ * UpdateOutcome: decides, from a failed WordPress upgrade alone, whether core
+ * can possibly have touched the destination directory yet (GitHub issue #328).
+ *
+ * THE FULL RATIONALE, INCLUDING THE TWO-TABLE BOUNDARY RULE AND THE STANDING
+ * PROHIBITION ON wp_doing_cron(), IS BELOW THE DIRECT-ACCESS GUARD, not above
+ * it. Plugin Check's direct-file-access detector only reads the first 50 raw
+ * lines of a file when looking for the guard, so a long header comment above it
+ * silently turns into a shipping-blocking ERROR. Keep the guard high and the
+ * reasoning underneath.
+ *
+ * @package WPMgr\Agent\Support
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Support;
+
+if (!defined('ABSPATH')) {
+    exit; // No direct access.
+}
+
+/*
+ * UpdateOutcome: decides, from a failed WordPress upgrade alone, whether core
+ * can possibly have touched the destination directory yet (GitHub issue #328).
+ *
+ * WHY. When an agent-driven plugin/theme update fails, UpdateCommand restores
+ * the pre-update snapshot over the live directory. That restore is itself a
+ * non-atomic rename-plus-recursive-copy on a live site, so performing one over
+ * a directory core never opened is pure added risk: it can only make a healthy
+ * directory worse. Most upgrade failures happen BEFORE core touches the
+ * destination at all (a download failure, a corrupt archive, a full disk while
+ * unzipping into wp-content/upgrade/), and for those the correct action is to
+ * report the failure and change nothing.
+ *
+ * THE BOUNDARY, read out of the bundled WordPress 7.0.2 tree
+ * (wp-includes/version.php:19). WP_Upgrader::install_package() first alters the
+ * destination at wp-admin/includes/class-wp-upgrader.php:607 to :608, where
+ * move_to_temp_backup_dir() MOVES the live directory away. Plugin_Upgrader
+ * always populates hook_extra['temp_backup'] (class-plugin-upgrader.php:234 to
+ * :238), as does Theme_Upgrader (class-theme-upgrader.php:334 to :338), so
+ * :607's `if ( ! empty( ... ) )` is always true on our path. Every WP_Error
+ * core can return ABOVE that line leaves the destination untouched; everything
+ * at or after it may not.
+ *
+ * TWO TABLES, ONE RULE. UNTOUCHED_CODES is exactly the set of codes reachable
+ * above :608. TOUCHED_CODES is exactly the set reachable at or after it. A code
+ * in NEITHER table (or a result shape we cannot read) yields null, and null
+ * always means "restore, exactly as before this class existed". This release is
+ * therefore a strict NARROWING of the restore set and can never widen it.
+ *
+ * THE ALLOWLIST CANNOT BE PROVEN COMPLETE, ONLY AUDITED. It is complete against
+ * WordPress 7.0.2 as read in this pass. A future core release that adds an
+ * error return above class-wp-upgrader.php:608, or that moves the
+ * move_to_temp_backup_dir() call, changes the answer silently. Drift fails safe
+ * (an unrecognised code goes to null and restores) and the per-code tests make
+ * a table edit deliberate. STANDING INSTRUCTION, which lives here rather than
+ * in anyone's memory: re-read install_package() on every WordPress major.
+ *
+ * STANDING PROHIBITION. Nothing in this class, or in anything that consumes it,
+ * may set wp_doing_cron() true in order to reach core's cron-gated
+ * disk-space precheck (wp-admin/includes/file.php:1728 and :1916). Pretending
+ * to be cron inside a REST request re-enables WordPress's own background
+ * updater on a path where we are already holding the site's update lock:
+ * wp-includes/update.php:331 fires do_action('wp_maybe_auto_update') and :885
+ * to :891 constructs WP_Automatic_Updater and runs it, and wp_version_check()
+ * is reachable inside our own window. If disk figures are ever wanted, the
+ * pre_unzip_file filter at file.php:1786 is the seam. Pinned by a test.
+ */
+
+/**
+ * Pure classifier over an upgrader result plus its skin's collected errors.
+ */
+final class UpdateOutcome
+{
+    /**
+     * Agent-set code for the one non-WP_Error failure shape core has: an
+     * upgrade() that short-circuits because WordPress has no update entry for
+     * the target. See classify()'s FACT 1.
+     */
+    public const CODE_NO_UPDATE_OFFERED = 'wpmgr_no_update_offered';
+
+    /** Agent-set code for a WP core error code that fails our own charset check. */
+    public const CODE_UNRECOGNIZED = 'wpmgr_unrecognized_code';
+
+    /**
+     * Every WP_Error code core can return with the destination directory still
+     * completely untouched, i.e. from a point ABOVE
+     * class-wp-upgrader.php:607 to :608 (see the class doc for the boundary).
+     *
+     * Grouped by the function that emits it, with the line it is emitted from
+     * in the bundled WordPress 7.0.2 tree:
+     *   WP_Upgrader::fs_connect()      :255 fs_unavailable, :259 fs_error,
+     *                                  :266 fs_no_root_dir, :271 fs_no_content_dir,
+     *                                  :276 fs_no_plugins_dir, :281 fs_no_themes_dir,
+     *                                  :286 fs_no_folder
+     *   WP_Upgrader::download_package():332 no_package, :340 download_failed.
+     *                                  run() calls download_package($package, false, ...)
+     *                                  at :849, so the signature soft-fail branch at
+     *                                  :855 is unreachable for us and download_failed
+     *                                  absorbs every download_url() code.
+     *   WP_Upgrader::unpack_package()  :364 fs_no_content_dir, :396 incompatible_archive
+     *                                  (a rewrap of unzip_file's own code)
+     *   unzip_file(), which extracts into wp-content/upgrade/ and never into the
+     *   destination: file.php:1607 fs_unavailable, :1685/:1883 incompatible_archive,
+     *   :1695/:1800 stat_failed_ziparchive, :1771 mkdir_failed_ziparchive,
+     *   :1820 extract_failed_ziparchive, :1825 copy_failed_ziparchive,
+     *   :1887 empty_archive_pclzip, :1957 mkdir_failed_pclzip,
+     *   :1984 copy_failed_pclzip, :1733/:1920 disk_full_unzip_file (cron-gated at
+     *   :1728 and :1915 so unreachable for us; allowlisted harmlessly).
+     *   WP_Upgrader::install_package() above the boundary: :569 source_read_failed,
+     *   :581 incompatible_archive_empty, and everything the
+     *   `upgrader_source_selection` filter can return at :601 to :604, which for our
+     *   two upgraders is Plugin_Upgrader::check_package()
+     *   (class-plugin-upgrader.php:490 incompatible_archive_no_plugins,
+     *   :504 incompatible_php_required_version, :515 incompatible_wp_required_version)
+     *   and Theme_Upgrader::check_package() (class-theme-upgrader.php:580
+     *   incompatible_archive_theme_no_style, :605 incompatible_archive_theme_no_name,
+     *   :627 incompatible_archive_theme_no_index, :653/:663 the two compatibility codes).
+     *   WP_Upgrader::move_to_temp_backup_dir() ABOVE its own move_dir() at :1170:
+     *   :1142 fs_no_content_dir, :1156 fs_temp_backup_mkdir.
+     *
+     * DELIBERATELY ABSENT, each for a reason a future reader must not re-litigate:
+     *   `up_to_date` is not a skin CODE at all. class-plugin-upgrader.php:203
+     *   passes the STRING and WP_Ajax_Upgrader_Skin::error() rewrites string errors
+     *   to unknown_upgrade_error_N; that path is covered by classify()'s FACT 1.
+     *   `bad_request` is in NEITHER table because it is emitted on BOTH sides of
+     *   the boundary: class-wp-upgrader.php:541 (argument validation, above),
+     *   class-plugin-upgrader.php:575 (deactivate_plugin_before_upgrade, above) and
+     *   class-plugin-upgrader.php:684 (delete_old_plugin, hooked on
+     *   upgrader_clear_destination, BELOW). One code, both sides, so it is
+     *   unclassifiable by code alone and correctly resolves to null.
+     *
+     * @var array<int,string>
+     */
+    public const UNTOUCHED_CODES = [
+        // fs_connect()
+        'fs_unavailable',
+        'fs_error',
+        'fs_no_root_dir',
+        'fs_no_content_dir',
+        'fs_no_plugins_dir',
+        'fs_no_themes_dir',
+        'fs_no_folder',
+        // download_package()
+        'no_package',
+        'download_failed',
+        // unpack_package() + unzip_file(), all into wp-content/upgrade/
+        'incompatible_archive',
+        'stat_failed_ziparchive',
+        'mkdir_failed_ziparchive',
+        'extract_failed_ziparchive',
+        'copy_failed_ziparchive',
+        'empty_archive_pclzip',
+        'mkdir_failed_pclzip',
+        'copy_failed_pclzip',
+        'disk_full_unzip_file',
+        // install_package(), above the boundary
+        'source_read_failed',
+        'incompatible_archive_empty',
+        'incompatible_archive_no_plugins',
+        'incompatible_archive_theme_no_style',
+        'incompatible_archive_theme_no_name',
+        'incompatible_archive_theme_no_index',
+        'incompatible_php_required_version',
+        'incompatible_wp_required_version',
+        // move_to_temp_backup_dir(), above its own move_dir()
+        'fs_temp_backup_mkdir',
+    ];
+
+    /**
+     * Every WP_Error code core can return once the destination directory may
+     * already have been altered, i.e. from class-wp-upgrader.php:608 onward.
+     *
+     *   :1172 fs_temp_backup_move  (move_to_temp_backup_dir's own move_dir at :1170
+     *                               has already run by then)
+     *   :622  new_source_read_failed
+     *   :676  folder_exists
+     *   :699  mkdir_failed_destination
+     *   class-plugin-upgrader.php:705 remove_old_failed (delete_old_plugin, on
+     *         upgrader_clear_destination, which fires at :663 i.e. after :608)
+     *   move_dir(): file.php:2099 source_destination_same_move_dir,
+     *         :2104 destination_already_exists_move_dir,
+     *         :2107 destination_not_deleted_move_dir, :2133 mkdir_failed_move_dir
+     *   copy_dir(): file.php:2017 dirlist_failed_copy_dir,
+     *         :2024 mkdir_destination_failed_copy_dir, :2042 copy_failed_copy_dir,
+     *         :2050 mkdir_failed_copy_dir
+     *   files_not_writable is emitted only by the language pack upgrader
+     *         (class-language-pack-upgrader.php:476), which the agent never drives.
+     *         Listed anyway because the conservative side of an unreachable code is
+     *         "restore", and a future core that reused the name would land safely.
+     *
+     * fs_temp_backup_move stays here even though a directory move is arguably
+     * atomic: it is the FIRST code at or after the boundary, and "the allowlist
+     * is exactly what returns above :608" is a rule auditable in one read of one
+     * function. The cost of the conservative choice is a restore that was
+     * probably unnecessary, which is the safe direction.
+     *
+     * @var array<int,string>
+     */
+    public const TOUCHED_CODES = [
+        'fs_temp_backup_move',
+        'new_source_read_failed',
+        'folder_exists',
+        'mkdir_failed_destination',
+        'remove_old_failed',
+        'files_not_writable',
+        'source_destination_same_move_dir',
+        'destination_already_exists_move_dir',
+        'destination_not_deleted_move_dir',
+        'mkdir_failed_move_dir',
+        'dirlist_failed_copy_dir',
+        'mkdir_destination_failed_copy_dir',
+        'copy_failed_copy_dir',
+        'mkdir_failed_copy_dir',
+    ];
+
+    /**
+     * Operator-facing stage LABEL per code. A SEPARATE function of the code
+     * from destination_touched, and never the safety predicate.
+     *
+     * Pinned disagreement between the two, which is the whole reason they are
+     * separate tables: fs_temp_backup_mkdir is stage `install` but touched
+     * FALSE (it returns at class-wp-upgrader.php:1156, BEFORE the move_dir at
+     * :1170), while fs_temp_backup_move is stage `install` and touched TRUE
+     * (:1172, after it). Deriving either table from the other is wrong for
+     * exactly these two codes, and a test pins that.
+     *
+     * fs_no_content_dir is labelled `preflight` even though it has three
+     * emission sites (fs_connect at :271, unpack_package at :364,
+     * move_to_temp_backup_dir at :1142) and is indistinguishable between them by
+     * code alone. The label is a hint for a human; the safety verdict for that
+     * code is decided by UNTOUCHED_CODES, where all three sites agree.
+     *
+     * @var array<string,string>
+     */
+    public const STAGE_BY_CODE = [
+        'fs_unavailable'                      => 'preflight',
+        'fs_error'                            => 'preflight',
+        'fs_no_root_dir'                      => 'preflight',
+        'fs_no_content_dir'                   => 'preflight',
+        'fs_no_plugins_dir'                   => 'preflight',
+        'fs_no_themes_dir'                    => 'preflight',
+        'fs_no_folder'                        => 'preflight',
+        'no_package'                          => 'download',
+        'download_failed'                     => 'download',
+        'incompatible_archive'                => 'unpack',
+        'stat_failed_ziparchive'              => 'unpack',
+        'mkdir_failed_ziparchive'             => 'unpack',
+        'extract_failed_ziparchive'           => 'unpack',
+        'copy_failed_ziparchive'              => 'unpack',
+        'empty_archive_pclzip'                => 'unpack',
+        'mkdir_failed_pclzip'                 => 'unpack',
+        'copy_failed_pclzip'                  => 'unpack',
+        'disk_full_unzip_file'                => 'unpack',
+        'source_read_failed'                  => 'install',
+        'incompatible_archive_empty'          => 'install',
+        'incompatible_archive_no_plugins'     => 'install',
+        'incompatible_archive_theme_no_style' => 'install',
+        'incompatible_archive_theme_no_name'  => 'install',
+        'incompatible_archive_theme_no_index' => 'install',
+        'incompatible_php_required_version'   => 'install',
+        'incompatible_wp_required_version'    => 'install',
+        'fs_temp_backup_mkdir'                => 'install',
+        'fs_temp_backup_move'                 => 'install',
+        'new_source_read_failed'              => 'install',
+        'folder_exists'                       => 'install',
+        'mkdir_failed_destination'            => 'install',
+        'remove_old_failed'                   => 'install',
+        'files_not_writable'                  => 'install',
+        'source_destination_same_move_dir'    => 'install',
+        'destination_already_exists_move_dir' => 'install',
+        'destination_not_deleted_move_dir'    => 'install',
+        'mkdir_failed_move_dir'               => 'install',
+        'dirlist_failed_copy_dir'             => 'install',
+        'mkdir_destination_failed_copy_dir'   => 'install',
+        'copy_failed_copy_dir'                => 'install',
+        'mkdir_failed_copy_dir'               => 'install',
+    ];
+
+    /**
+     * Codes that arrive AT OR AFTER the `upgrader_pre_install` filter
+     * (class-wp-upgrader.php:556), which is where
+     * Plugin_Upgrader::deactivate_plugin_before_upgrade() is hooked (registered
+     * at class-plugin-upgrader.php:211, priority 10) and silently deactivates an
+     * active plugin at :578 to :580 whenever wp_doing_cron() is false, i.e.
+     * always on our path. Core does NOT put it back: active_after is cron-gated
+     * at :639, and UpdateRunner only reactivates on a successful outcome.
+     *
+     * So a "clean" skipped restore can leave the directory byte-identical and
+     * the plugin OFF unless the caller reactivates. That is what this third
+     * output exists to tell it.
+     *
+     * fs_no_content_dir is in this set on the conservative side: it is emitted
+     * both before (:364) and after (:1142) the filter and cannot be told apart
+     * by code alone. Every download and unpack code is absent, because run()
+     * returns at :888 to :894 before install_package() is even called at :898.
+     *
+     * @var array<int,string>
+     */
+    public const DEACTIVATION_POSSIBLE_CODES = [
+        'fs_no_content_dir',
+        'source_read_failed',
+        'incompatible_archive_empty',
+        'incompatible_archive_no_plugins',
+        'incompatible_archive_theme_no_style',
+        'incompatible_archive_theme_no_name',
+        'incompatible_archive_theme_no_index',
+        'incompatible_php_required_version',
+        'incompatible_wp_required_version',
+        'fs_temp_backup_mkdir',
+        'fs_temp_backup_move',
+        'new_source_read_failed',
+        'folder_exists',
+        'mkdir_failed_destination',
+        'remove_old_failed',
+        'files_not_writable',
+        'bad_request',
+        'source_destination_same_move_dir',
+        'destination_already_exists_move_dir',
+        'destination_not_deleted_move_dir',
+        'mkdir_failed_move_dir',
+        'dirlist_failed_copy_dir',
+        'mkdir_destination_failed_copy_dir',
+        'copy_failed_copy_dir',
+        'mkdir_failed_copy_dir',
+    ];
+
+    /** Hard cap on the error data string carried into an operator-visible log. */
+    private const MAX_DATA_CHARS = 200;
+
+    /**
+     * Classify a finished upgrade.
+     *
+     * Resolution order, FIRST MATCH WINS.
+     *
+     * FACT 1, and it MUST be first. `$result === false` by IDENTITY (not `==`,
+     * not "falsy"). Plugin_Upgrader::upgrade() returns literal false at
+     * class-plugin-upgrader.php:205 inside the `! isset( $current->response[
+     * $plugin ] )` short circuit at :200 to :206, BEFORE run() at :224; the
+     * Theme_Upgrader twin is :306 to :312 before :324. Nothing ran, so nothing
+     * was touched. Without this rule a benign race (the control plane says an
+     * update is pending, WordPress's own transient disagrees because a sibling
+     * request just cleared it) lands unclassified and triggers a SPURIOUS
+     * restore. `$result === 0`, `''`, `[]` and null must NOT match.
+     *
+     * The identity rule is sound only because Plugin_Upgrader::upgrade()
+     * DISCARDS run()'s return at :224 and returns $this->result at :250 to
+     * :251, and $this->result is shadowed as an uninitialised property at
+     * class-plugin-upgrader.php:31 (parent default array() at
+     * class-wp-upgrader.php:93). So run()'s own second `return false` at
+     * class-wp-upgrader.php:831 (fs_connect not connected, which emits no skin
+     * error) can never reach us AS false; it reaches us as null, which falls
+     * through to FACT 3 and FACT 4.
+     *
+     * FACT 2. $result is a WP_Error: take its own code and data. This is the
+     * Core_Upgrader shape, which returns install_package()'s WP_Error directly.
+     *
+     * FACT 3. Otherwise read the upgrader skin's collected errors
+     * (WP_Ajax_Upgrader_Skin::get_errors(), populated by run() at :876, :889 and
+     * :938). This is the plugin/theme shape: a pre-install failure leaves
+     * $this->result unset, so upgrade() returns NULL and the codes live only on
+     * the skin.
+     *   touched = TRUE  when ANY code is in TOUCHED_CODES;
+     *   touched = FALSE when there is at least one code and EVERY code is in
+     *                   UNTOUCHED_CODES;
+     *   touched = NULL  otherwise, including an empty list.
+     * The asymmetry is deliberate: one touched code is enough to condemn, but
+     * one unrecognised code is enough to withhold a clean bill of health.
+     *
+     * FACT 4. Anything else: null, stage unknown.
+     *
+     * @param mixed       $result   Upgrader result (bool|array|WP_Error|null).
+     * @param object|null $upgrader The WP_Upgrader that produced it, when available.
+     * @return array{codes:array<int,string>,code:string,data:string,stage:string,destination_touched:bool|null,may_have_deactivated:bool}
+     */
+    public static function classify($result, ?object $upgrader = null): array
+    {
+        try {
+            return self::resolve($result, $upgrader);
+        } catch (\Throwable $e) {
+            DebugLog::write('WPMgr Agent: update outcome classification threw: ' . $e->getMessage());
+
+            return self::shape([], '', '', null);
+        }
+    }
+
+    /**
+     * The classification proper; classify() is the never-throwing wrapper.
+     *
+     * @param mixed       $result   Upgrader result.
+     * @param object|null $upgrader Upgrader instance, when available.
+     * @return array{codes:array<int,string>,code:string,data:string,stage:string,destination_touched:bool|null,may_have_deactivated:bool}
+     */
+    private static function resolve($result, ?object $upgrader): array
+    {
+        // FACT 1 - identity, and first. See the method doc.
+        if ($result === false) {
+            return self::shape([self::CODE_NO_UPDATE_OFFERED], self::CODE_NO_UPDATE_OFFERED, '', false, 'preflight', false);
+        }
+
+        // FACT 2 - a WP_Error result carries its own code (the Core_Upgrader shape).
+        if (is_object($result) && method_exists($result, 'get_error_code')) {
+            $code = (string) $result->get_error_code();
+            $data = method_exists($result, 'get_error_data') ? $result->get_error_data() : null;
+
+            return self::shape([$code], $code, is_string($data) ? $data : '', self::touchedFor([$code]));
+        }
+
+        // FACT 3 - the skin's collected errors (the Plugin/Theme_Upgrader shape).
+        $codes = self::skinErrorCodes($upgrader);
+        if ($codes !== []) {
+            $code = self::preferredCode($codes);
+
+            return self::shape($codes, $code, self::skinErrorData($upgrader, $code), self::touchedFor($codes));
+        }
+
+        // FACT 4 - nothing readable. Unclassified, which always means "restore".
+        return self::shape([], '', '', null);
+    }
+
+    /**
+     * TOUCHED wins over UNTOUCHED; an unrecognised code withholds the verdict.
+     *
+     * @param array<int,string> $codes Every code observed, in order.
+     * @return bool|null
+     */
+    private static function touchedFor(array $codes): ?bool
+    {
+        if ($codes === []) {
+            return null;
+        }
+
+        foreach ($codes as $code) {
+            if (in_array($code, self::TOUCHED_CODES, true)) {
+                return true;
+            }
+        }
+
+        foreach ($codes as $code) {
+            if (!in_array($code, self::UNTOUCHED_CODES, true)) {
+                return null;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The most informative code in a list: the first one either table knows,
+     * else the first one at all.
+     *
+     * @param array<int,string> $codes Observed codes, in order.
+     * @return string
+     */
+    private static function preferredCode(array $codes): string
+    {
+        foreach ($codes as $code) {
+            if (in_array($code, self::TOUCHED_CODES, true) || in_array($code, self::UNTOUCHED_CODES, true)) {
+                return $code;
+            }
+        }
+
+        return (string) ($codes[0] ?? '');
+    }
+
+    /**
+     * Every error code the upgrader's skin collected, in order. Never throws:
+     * an unexpected shape yields an empty list, which classifies as null.
+     *
+     * @param object|null $upgrader Upgrader instance, when available.
+     * @return array<int,string>
+     */
+    private static function skinErrorCodes(?object $upgrader): array
+    {
+        $errors = self::skinErrors($upgrader);
+        if ($errors === null || !method_exists($errors, 'get_error_codes')) {
+            return [];
+        }
+
+        $codes = $errors->get_error_codes();
+        if (!is_array($codes)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($codes as $code) {
+            if (is_string($code) && $code !== '') {
+                $out[] = $code;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * The string error data for one skin code, when it has any.
+     *
+     * Attacker-influenceable: get_error_data() for copy_failed_ziparchive is the
+     * archive entry name (file.php:1825), which comes out of the package. Only
+     * ever used as human log text, and sanitised in shape().
+     *
+     * @param object|null $upgrader Upgrader instance.
+     * @param string      $code     Code to read data for.
+     * @return string
+     */
+    private static function skinErrorData(?object $upgrader, string $code): string
+    {
+        $errors = self::skinErrors($upgrader);
+        if ($errors === null || $code === '' || !method_exists($errors, 'get_error_data')) {
+            return '';
+        }
+
+        $data = $errors->get_error_data($code);
+
+        return is_string($data) ? $data : '';
+    }
+
+    /**
+     * The WP_Error-shaped object a skin exposes through get_errors(), or null.
+     *
+     * @param object|null $upgrader Upgrader instance.
+     * @return object|null
+     */
+    private static function skinErrors(?object $upgrader): ?object
+    {
+        if ($upgrader === null || !isset($upgrader->skin) || !is_object($upgrader->skin)) {
+            return null;
+        }
+
+        $skin = $upgrader->skin;
+        if (!method_exists($skin, 'get_errors')) {
+            return null;
+        }
+
+        $errors = $skin->get_errors();
+
+        return is_object($errors) ? $errors : null;
+    }
+
+    /**
+     * Build the return shape, sanitising the two strings that leave this
+     * process and land in an operator-visible log.
+     *
+     * @param array<int,string> $codes   Observed codes, in order.
+     * @param string            $code    Resolved primary code.
+     * @param string            $data    Resolved error data.
+     * @param bool|null         $touched Destination verdict.
+     * @param string|null       $stage   Stage override (FACT 1 only).
+     * @param bool|null         $mayHaveDeactivated Deactivation override (FACT 1 only).
+     * @return array{codes:array<int,string>,code:string,data:string,stage:string,destination_touched:bool|null,may_have_deactivated:bool}
+     */
+    private static function shape(
+        array $codes,
+        string $code,
+        string $data,
+        ?bool $touched,
+        ?string $stage = null,
+        ?bool $mayHaveDeactivated = null
+    ): array {
+        $safeCode = self::sanitizeCode($code);
+
+        return [
+            'codes'                => $codes,
+            'code'                 => $safeCode,
+            'data'                 => self::sanitizeData($data),
+            'stage'                => $stage ?? (self::STAGE_BY_CODE[$safeCode] ?? 'unknown'),
+            'destination_touched'  => $touched,
+            'may_have_deactivated' => $mayHaveDeactivated ?? self::mayHaveDeactivated($codes),
+        ];
+    }
+
+    /**
+     * Did anything in this failure run past `upgrader_pre_install`, where core
+     * silently deactivates an active plugin?
+     *
+     * @param array<int,string> $codes Observed codes.
+     * @return bool
+     */
+    private static function mayHaveDeactivated(array $codes): bool
+    {
+        foreach ($codes as $code) {
+            if (in_array($code, self::DEACTIVATION_POSSIBLE_CODES, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * A code must look like a WordPress error code. Anything else becomes
+     * CODE_UNRECOGNIZED so a hostile or malformed value can never be echoed
+     * verbatim into a log line, a DB column or a UI.
+     *
+     * @param string $code Raw code.
+     * @return string
+     */
+    private static function sanitizeCode(string $code): string
+    {
+        if ($code === '') {
+            return '';
+        }
+
+        return preg_match('#^[a-z0-9_]{1,64}$#', $code) === 1 ? $code : self::CODE_UNRECOGNIZED;
+    }
+
+    /**
+     * Bound and de-fang the error data before it can reach an operator's screen.
+     *
+     * @param string $data Raw data.
+     * @return string
+     */
+    private static function sanitizeData(string $data): string
+    {
+        if ($data === '') {
+            return '';
+        }
+
+        $clean = (string) preg_replace('#[\x00-\x1F\x7F]+#', ' ', $data);
+        $clean = trim($clean);
+        if (strlen($clean) > self::MAX_DATA_CHARS) {
+            $clean = substr($clean, 0, self::MAX_DATA_CHARS) . '...';
+        }
+
+        return $clean;
+    }
+}

--- a/apps/agent/includes/support/class-update-runner.php
+++ b/apps/agent/includes/support/class-update-runner.php
@@ -219,6 +219,61 @@ class UpdateRunner
     }
 
     /**
+     * GitHub issue #328 - the enriched shape every apply path now returns.
+     *
+     * `ok` and `log` are UNCHANGED in both name and value; the extra keys are
+     * additive so a caller (or a test double) that only knows the old two-key
+     * shape keeps working. UpdateCommand reads `destination_touched` with a
+     * `?? null` so an ABSENT key means "unclassified", which is exactly the
+     * pre-0.61.114 behaviour of always restoring.
+     *
+     *   destination_touched  true  core may already have altered the live
+     *                              directory; false  it provably has not;
+     *                              null   unknown, so the caller must restore.
+     *   failure_code/stage   diagnostic labels; NEVER a safety predicate on
+     *                        their own (see UpdateOutcome's two-table doc).
+     *   may_have_deactivated core silently deactivated an active plugin at
+     *                        `upgrader_pre_install` and will not put it back.
+     *   was_active/was_network_active  the plugin's activation state BEFORE
+     *                        the apply, which is computed inside
+     *                        applyViaUpgrader() and is otherwise invisible to
+     *                        the caller that has to decide whether reactivating
+     *                        is an undo or an unwanted state change.
+     *
+     * @param bool        $ok                 Whether the apply reported success.
+     * @param string      $log                CP-visible log text, unchanged.
+     * @param bool|null   $touched            Destination verdict.
+     * @param string      $code               Failure code label.
+     * @param string      $stage              Failure stage label.
+     * @param bool        $mayHaveDeactivated Whether core may have deactivated the plugin.
+     * @param bool        $wasActive          Plugin active before the apply.
+     * @param bool        $wasNetworkActive   Plugin network-active before the apply.
+     * @return array{ok:bool,log:string,destination_touched:bool|null,failure_code:string,failure_data:string,failure_stage:string,may_have_deactivated:bool,was_active:bool,was_network_active:bool}
+     */
+    private static function outcome(
+        bool $ok,
+        string $log,
+        ?bool $touched = null,
+        string $code = '',
+        string $stage = '',
+        bool $mayHaveDeactivated = false,
+        bool $wasActive = false,
+        bool $wasNetworkActive = false
+    ): array {
+        return [
+            'ok'                   => $ok,
+            'log'                  => $log,
+            'destination_touched'  => $touched,
+            'failure_code'         => $code,
+            'failure_data'         => '',
+            'failure_stage'        => $stage,
+            'may_have_deactivated' => $mayHaveDeactivated,
+            'was_active'           => $wasActive,
+            'was_network_active'   => $wasNetworkActive,
+        ];
+    }
+
+    /**
      * Apply the update. Prefers WP-CLI; falls back to the upgrader APIs.
      *
      * @param string $type    plugin|theme|core.
@@ -229,7 +284,9 @@ class UpdateRunner
     public function apply(string $type, string $slug, string $version): array
     {
         if (!self::isValidVersion($version)) {
-            return ['ok' => false, 'log' => 'Rejected unsafe version string.'];
+            // Refused before anything ran, so the destination is provably
+            // untouched (GitHub issue #328).
+            return self::outcome(false, 'Rejected unsafe version string.', false, 'wpmgr_invalid_version', 'preflight');
         }
 
         // Last-resort backstop for the self-target refusal that
@@ -241,7 +298,13 @@ class UpdateRunner
         // NOT the place the operator-facing `skipped` decision is made: this
         // layer only reports an apply it will not perform.
         if (UpdateCommand::isSelfTarget($type, $slug)) {
-            return ['ok' => false, 'log' => 'Refused: the management agent does not update itself through a plugin update task.'];
+            return self::outcome(
+                false,
+                'Refused: the management agent does not update itself through a plugin update task.',
+                false,
+                'wpmgr_self_target_refused',
+                'preflight'
+            );
         }
 
         if ($this->wpCliAvailable()) {
@@ -686,7 +749,7 @@ class UpdateRunner
         // forceCore always targets an explicit version; "latest" is not a valid
         // rollback target and the literal must never reach the offer URL / argv.
         if ($version === 'latest' || !self::isValidVersion($version)) {
-            return ['ok' => false, 'log' => 'Rejected unsafe version string.'];
+            return self::outcome(false, 'Rejected unsafe version string.', false, 'wpmgr_invalid_version', 'preflight');
         }
 
         if ($this->wpCliAvailable()) {
@@ -714,7 +777,7 @@ class UpdateRunner
         $this->loadUpgraderApi();
 
         if (!class_exists('\Core_Upgrader') || !class_exists('\WP_Ajax_Upgrader_Skin')) {
-            return ['ok' => false, 'log' => 'Core upgrader API unavailable.'];
+            return self::outcome(false, 'Core upgrader API unavailable.', false, 'wpmgr_upgrader_api_unavailable', 'preflight');
         }
 
         $locale = function_exists('get_locale') ? (string) get_locale() : 'en_US';
@@ -787,7 +850,7 @@ class UpdateRunner
         };
 
         if ($args === []) {
-            return ['ok' => false, 'log' => 'Unsupported type for WP-CLI update.'];
+            return self::outcome(false, 'Unsupported type for WP-CLI update.', false, 'wpmgr_unsupported_type', 'preflight');
         }
 
         if ($type !== 'core' && $version !== 'latest') {
@@ -807,7 +870,7 @@ class UpdateRunner
     protected function runWpCli(array $args): array
     {
         if (!class_exists('\WP_CLI')) {
-            return ['ok' => false, 'log' => 'WP-CLI not loadable.'];
+            return self::outcome(false, 'WP-CLI not loadable.', false, 'wpmgr_wpcli_unavailable', 'preflight');
         }
 
         $command = implode(' ', $args);
@@ -823,12 +886,24 @@ class UpdateRunner
             $stdout = isset($res['stdout']) ? (string) $res['stdout'] : '';
             $stderr = isset($res['stderr']) ? (string) $res['stderr'] : '';
 
-            return [
-                'ok'  => $code === 0,
-                'log' => trim($stdout . "\n" . $stderr),
-            ];
+            // GitHub issue #328 - a WP-CLI failure is classified NULL, never
+            // false. WP-CLI runs the same upgrader in a separate process and
+            // reports only an exit code; the only way to recover a stage from
+            // it would be to text-match its stdout, which is a translated,
+            // version-dependent string and exactly the kind of inference this
+            // work exists to replace. Null means the caller restores, which is
+            // the pre-0.61.114 behaviour. In production wpCliAvailable() is
+            // false inside PHP-FPM, so this only affects a self-hoster driving
+            // the agent from `wp eval`.
+            return self::outcome(
+                $code === 0,
+                trim($stdout . "\n" . $stderr),
+                $code === 0 ? true : null,
+                $code === 0 ? '' : 'wpmgr_wpcli_nonzero_exit',
+                $code === 0 ? '' : 'unknown'
+            );
         } catch (\Throwable $e) {
-            return ['ok' => false, 'log' => 'WP-CLI execution error.'];
+            return self::outcome(false, 'WP-CLI execution error.', null, 'wpmgr_wpcli_threw', 'unknown');
         }
     }
 
@@ -893,7 +968,7 @@ class UpdateRunner
             switch ($type) {
                 case 'plugin':
                     if (!class_exists('\Plugin_Upgrader') || !class_exists('\WP_Ajax_Upgrader_Skin')) {
-                        return ['ok' => false, 'log' => 'Upgrader API unavailable.'];
+                        return self::outcome(false, 'Upgrader API unavailable.', false, 'wpmgr_upgrader_api_unavailable', 'preflight');
                     }
 
                     // Capture active state BEFORE upgrade. WordPress's
@@ -918,19 +993,23 @@ class UpdateRunner
                     }
                     $outcome  = $this->upgraderOutcome($result, $upgrader);
 
-                    if ($outcome['ok'] && ($wasActive || $wasNetworkActive) && function_exists('activate_plugin')) {
-                        // Refresh plugin caches before reactivating: the upgrade
-                        // may have changed the main plugin file (slug stays the
-                        // same but the metadata cache is stale).
-                        if (function_exists('wp_clean_plugins_cache')) {
-                            \wp_clean_plugins_cache(true);
-                        }
-                        $activated = \activate_plugin($slug, '', $wasNetworkActive, true);
-                        if (\is_wp_error($activated)) {
+                    // GitHub issue #328 - carry the PRE-apply activation state
+                    // out of this method. It is computed here and nowhere else,
+                    // and UpdateCommand's restore-skip decision needs it: core
+                    // silently deactivates an active plugin at
+                    // `upgrader_pre_install` and never puts it back on a
+                    // non-cron request, so a skipped restore can otherwise
+                    // leave the directory byte-identical and the plugin OFF.
+                    // Reactivating must be gated on it having been ON, or we
+                    // would enable a plugin the operator deliberately disabled.
+                    $outcome['was_active']         = $wasActive;
+                    $outcome['was_network_active'] = $wasNetworkActive;
+
+                    if ($outcome['ok']) {
+                        $reactivated = $this->reactivateIfCoreDeactivated($slug, $wasActive, $wasNetworkActive);
+                        if ($reactivated['attempted'] && !$reactivated['ok']) {
                             $outcome['log'] .= "\n[wpmgr] upgrade succeeded but reactivation failed: "
-                                . $activated->get_error_message();
-                            \WPMgr\Agent\Support\DebugLog::write('WPMgr Agent: post-upgrade reactivation failed for '
-                                . $slug . ': ' . $activated->get_error_message());
+                                . $reactivated['message'];
                         }
                     }
 
@@ -938,7 +1017,7 @@ class UpdateRunner
 
                 case 'theme':
                     if (!class_exists('\Theme_Upgrader') || !class_exists('\WP_Ajax_Upgrader_Skin')) {
-                        return ['ok' => false, 'log' => 'Upgrader API unavailable.'];
+                        return self::outcome(false, 'Upgrader API unavailable.', false, 'wpmgr_upgrader_api_unavailable', 'preflight');
                     }
                     $upgrader = new \Theme_Upgrader(new \WP_Ajax_Upgrader_Skin());
                     try {
@@ -956,7 +1035,7 @@ class UpdateRunner
             }
 
             if ($outcome === null) {
-                return ['ok' => false, 'log' => 'Unsupported type.'];
+                return self::outcome(false, 'Unsupported type.', false, 'wpmgr_unsupported_type', 'preflight');
             }
 
             // Agent-only, 0.61.20 — surface the temp-dir decision in the
@@ -972,6 +1051,65 @@ class UpdateRunner
         } finally {
             remove_filter('upgrader_package_options', $forceCleanWorking);
         }
+    }
+
+    /**
+     * Put a plugin back the way core found it, after core silently turned it
+     * off and declined to turn it back on.
+     *
+     * WordPress's Plugin_Upgrader hooks deactivate_plugin_before_upgrade() on
+     * `upgrader_pre_install` (registered at class-plugin-upgrader.php:211) and
+     * calls deactivate_plugins( $plugin, true ) at :578 to :580 whenever
+     * wp_doing_cron() is false, which is always true on the agent's REST path.
+     * Its counterpart active_after() is cron-gated at :639, so on OUR path core
+     * never restores the state it removed. WP-CLI's `wp plugin update`
+     * preserves active state; this mirrors that.
+     *
+     * THE $wasActive GATE IS NOT OPTIONAL. activate_plugin() calls
+     * validate_plugin() and then plugin_sandbox_scrape(), which INCLUDES the
+     * plugin file in this process. Activating on the strength of "core probably
+     * deactivated something" would (a) enable a plugin the operator
+     * deliberately disabled and (b) execute a possibly half-written file on a
+     * failure path. Core gates its own deactivation on state, so the undo is
+     * gated on state too. The CALLER additionally decides whether the directory
+     * is trustworthy enough to activate from at all (see UpdateCommand's
+     * restore-skip decision, which only reactivates from a directory it has
+     * just verified byte-consistent).
+     *
+     * $silent = true mirrors core's own silent deactivate_plugins( $plugin,
+     * true ), so no activation hooks fire and this stays a pure undo of the
+     * option write. A WP_Error is REPORTED, never swallowed, and never turns a
+     * failed item into a thrown one.
+     *
+     * @param string $slug             Sanitized plugin basename or folder.
+     * @param bool   $wasActive        Whether the plugin was active before the apply.
+     * @param bool   $wasNetworkActive Whether it was network-active before the apply.
+     * @return array{attempted:bool,ok:bool,message:string}
+     */
+    public function reactivateIfCoreDeactivated(string $slug, bool $wasActive, bool $wasNetworkActive): array
+    {
+        if ((!$wasActive && !$wasNetworkActive) || !function_exists('activate_plugin')) {
+            return ['attempted' => false, 'ok' => true, 'message' => ''];
+        }
+
+        // Refresh plugin caches before reactivating: the upgrade may have
+        // changed the main plugin file (slug stays the same but the metadata
+        // cache is stale).
+        if (function_exists('wp_clean_plugins_cache')) {
+            \wp_clean_plugins_cache(true);
+        }
+
+        $activated = \activate_plugin($slug, '', $wasNetworkActive, true);
+        if (function_exists('is_wp_error') && \is_wp_error($activated)) {
+            $message = method_exists($activated, 'get_error_message')
+                ? (string) $activated->get_error_message()
+                : 'unknown error';
+            DebugLog::write('WPMgr Agent: post-upgrade reactivation failed for ' . $slug . ': ' . $message);
+
+            return ['attempted' => true, 'ok' => false, 'message' => $message];
+        }
+
+        return ['attempted' => true, 'ok' => true, 'message' => ''];
     }
 
     /**
@@ -1307,12 +1445,12 @@ class UpdateRunner
         }
 
         if (!class_exists('\Core_Upgrader') || !function_exists('get_core_updates')) {
-            return ['ok' => false, 'log' => 'Core upgrader API unavailable.'];
+            return self::outcome(false, 'Core upgrader API unavailable.', false, 'wpmgr_upgrader_api_unavailable', 'preflight');
         }
 
         $updates = get_core_updates();
         if (!is_array($updates) || $updates === []) {
-            return ['ok' => false, 'log' => 'No core update offer available.'];
+            return self::outcome(false, 'No core update offer available.', false, 'wpmgr_no_update_offered', 'preflight');
         }
 
         $offer = null;
@@ -1328,11 +1466,11 @@ class UpdateRunner
         }
 
         if ($offer === null) {
-            return ['ok' => false, 'log' => 'Requested core version not offered.'];
+            return self::outcome(false, 'Requested core version not offered.', false, 'wpmgr_no_update_offered', 'preflight');
         }
 
         if (!class_exists('\WP_Ajax_Upgrader_Skin')) {
-            return ['ok' => false, 'log' => 'Upgrader skin unavailable.'];
+            return self::outcome(false, 'Upgrader skin unavailable.', false, 'wpmgr_upgrader_api_unavailable', 'preflight');
         }
 
         $upgrader = new \Core_Upgrader(new \WP_Ajax_Upgrader_Skin());
@@ -1387,6 +1525,15 @@ class UpdateRunner
     {
         $skinMessages = $this->collectSkinMessages($upgrader);
 
+        // GitHub issue #328 - the SINGLE place UpdateOutcome::classify() is
+        // called, because it is the only place that holds both $result and the
+        // $upgrader whose skin carries the error codes. Every `log` string
+        // below is BYTE-IDENTICAL to 0.61.113 on purpose: the classification
+        // travels as extra ARRAY KEYS, never by changing text an operator or a
+        // test may already depend on, and the restore-skip's operator copy is
+        // written at the decision site instead.
+        $classified = UpdateOutcome::classify($result, $upgrader);
+
         if (is_object($result) && method_exists($result, 'get_error_message')) {
             /** @var \WP_Error $result */
             $code = method_exists($result, 'get_error_code') ? (string) $result->get_error_code() : '';
@@ -1395,16 +1542,41 @@ class UpdateRunner
                 $log .= "\n" . $skinMessages;
             }
 
-            return ['ok' => false, 'log' => $log];
+            return self::fromClassification(false, $log, $classified);
         }
 
         if ($result === false || $result === null) {
             $log = $skinMessages !== '' ? 'Update failed: ' . $skinMessages : 'Update failed.';
 
-            return ['ok' => false, 'log' => $log];
+            return self::fromClassification(false, $log, $classified);
         }
 
-        return ['ok' => true, 'log' => 'Update applied via upgrader.'];
+        // A truthy, non-error result means install_package() ran to completion,
+        // so the destination was certainly touched.
+        return self::outcome(true, 'Update applied via upgrader.', true);
+    }
+
+    /**
+     * Fold a UpdateOutcome::classify() verdict into the apply outcome shape.
+     *
+     * @param bool                                                                                                     $ok         Whether the apply reported success.
+     * @param string                                                                                                   $log        CP-visible log text, unchanged.
+     * @param array{codes:array<int,string>,code:string,data:string,stage:string,destination_touched:bool|null,may_have_deactivated:bool} $classified Classifier verdict.
+     * @return array{ok:bool,log:string,destination_touched:bool|null,failure_code:string,failure_data:string,failure_stage:string,may_have_deactivated:bool,was_active:bool,was_network_active:bool}
+     */
+    private static function fromClassification(bool $ok, string $log, array $classified): array
+    {
+        $out                 = self::outcome(
+            $ok,
+            $log,
+            $classified['destination_touched'],
+            $classified['code'],
+            $classified['stage'],
+            $classified['may_have_deactivated']
+        );
+        $out['failure_data'] = $classified['data'];
+
+        return $out;
     }
 
     /**

--- a/apps/agent/tests/DestinationVerifierTest.php
+++ b/apps/agent/tests/DestinationVerifierTest.php
@@ -1,0 +1,522 @@
+<?php
+/**
+ * DestinationVerifierTest - the restore-skip's own backstop (GitHub issue #328).
+ *
+ * REAL TEMPORARY DIRECTORIES, no mocks: this class is filesystem behaviour, and
+ * a mocked filesystem would only prove that the mock agrees with the code.
+ *
+ * The verdict is three-valued and the whole safety argument rests on the
+ * asymmetry: only `true` may skip a restore, and `true` requires the POSITIVE
+ * header read. Every test below is therefore either "this is provably wrong"
+ * (false), "this host cannot answer" (null) or the single narrow case that is
+ * allowed to skip.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Support\DestinationVerifier;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\DestinationVerifier
+ */
+final class DestinationVerifierTest extends TestCase
+{
+    /** Absolute path to this test's own scratch tree (payload copies). */
+    private string $root = '';
+
+    /** Absolute path to the plugins root this process uses. */
+    private string $pluginsRoot = '';
+
+    /** @var array<int,string> Fixture directories to remove in tear-down. */
+    private array $created = [];
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->root = sys_get_temp_dir() . '/wpmgr-destverify-' . bin2hex(random_bytes(6));
+        mkdir($this->root, 0777, true);
+
+        // WP_PLUGIN_DIR is a process-global CONSTANT and this suite is not
+        // isolated, so whichever test file runs first pins it. ADOPT whatever
+        // is already there (creating it when needed) rather than fighting for
+        // it, exactly as SnapshotManagerTest does, and give every fixture a
+        // unique folder name so files never collide across tests.
+        $this->pluginsRoot = $this->ensurePluginRoot();
+        $this->created     = [];
+    }
+
+    protected function tear_down(): void
+    {
+        foreach ($this->created as $dir) {
+            $this->deleteTree($dir);
+        }
+        $this->deleteTree($this->root);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * Adopt (or establish) this process's plugins root.
+     *
+     * @return string Absolute path without a trailing slash.
+     */
+    private function ensurePluginRoot(): string
+    {
+        if (!defined('WP_CONTENT_DIR')) {
+            define('WP_CONTENT_DIR', sys_get_temp_dir() . '/wpmgr-shared-wp-content');
+        }
+        if (!is_dir((string) constant('WP_CONTENT_DIR'))) {
+            mkdir((string) constant('WP_CONTENT_DIR'), 0777, true);
+        }
+        if (!defined('WP_PLUGIN_DIR')) {
+            define('WP_PLUGIN_DIR', rtrim((string) constant('WP_CONTENT_DIR'), '/\\') . '/plugins');
+        }
+        $root = rtrim((string) constant('WP_PLUGIN_DIR'), '/\\');
+        if (!is_dir($root)) {
+            mkdir($root, 0777, true);
+        }
+
+        return $root;
+    }
+
+    /**
+     * A collision-proof fixture folder name.
+     *
+     * @param string $label Human label.
+     * @return string
+     */
+    private function uniqueFolder(string $label): string
+    {
+        return 'wpmgr-dv-' . $label . '-' . bin2hex(random_bytes(4));
+    }
+
+    /**
+     * Recursively remove a scratch tree.
+     *
+     * @param string $dir Directory to remove.
+     * @return void
+     */
+    private function deleteTree(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (array_diff((array) scandir($dir), ['.', '..']) as $entry) {
+            $path = $dir . '/' . $entry;
+            if (is_dir($path)) {
+                $this->deleteTree($path);
+            } else {
+                @chmod($path, 0666);
+                unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        @chmod($dir, 0777);
+        rmdir($dir);
+    }
+
+    /**
+     * Write a plugin directory with a parsable header.
+     *
+     * @param string $folder  Plugin folder name.
+     * @param string $version Version in the header.
+     * @param string $main    Main file name.
+     * @return string Absolute plugin directory path.
+     */
+    private function makePlugin(string $folder, string $version, string $main = ''): string
+    {
+        $dir = $this->pluginsRoot . '/' . $folder;
+        mkdir($dir, 0777, true);
+        $this->created[] = $dir;
+        $main            = $main !== '' ? $main : $folder . '.php';
+        file_put_contents(
+            $dir . '/' . $main,
+            "<?php\n/**\n * Plugin Name: Test " . $folder . "\n * Version: " . $version . "\n */\n"
+        );
+        file_put_contents($dir . '/readme.txt', "=== Test ===\n");
+
+        return $dir;
+    }
+
+    /**
+     * Copy a directory, the way SnapshotManager's payload capture does.
+     *
+     * @param string $from Source directory.
+     * @param string $to   Destination directory.
+     * @return void
+     */
+    private function copyTree(string $from, string $to): void
+    {
+        mkdir($to, 0777, true);
+        foreach (array_diff((array) scandir($from), ['.', '..']) as $entry) {
+            $src = $from . '/' . $entry;
+            $dst = $to . '/' . $entry;
+            if (is_dir($src)) {
+                $this->copyTree($src, $dst);
+            } else {
+                copy($src, $dst);
+            }
+        }
+    }
+
+    /**
+     * Run the verifier against this test's plugins root.
+     *
+     * @param string $slug        Plugin slug.
+     * @param string $fromVersion Pre-update version.
+     * @param string $payloadDir  Payload directory or ''.
+     * @return array{verdict:bool|null,detail:string,signals:array<int,string>}
+     */
+    private function verifyPlugin(string $slug, string $fromVersion, string $payloadDir = ''): array
+    {
+        return DestinationVerifier::verify('plugin', $slug, $fromVersion, $payloadDir);
+    }
+
+    // ---- the only true verdict ------------------------------------------
+
+    public function test_an_intact_directory_at_the_pre_update_version_verifies_true(): void
+    {
+        $folder  = $this->uniqueFolder('intact');
+        $dir     = $this->makePlugin($folder, '1.2.3');
+        $payload = $this->root . '/payload';
+        $this->copyTree($dir, $payload);
+
+        $out = $this->verifyPlugin($folder . '/' . $folder . '.php', '1.2.3', $payload);
+
+        $this->assertTrue($out['verdict'], $out['detail']);
+        $this->assertContains('R4-header-matches', $out['signals']);
+    }
+
+    // ---- provably wrong: false ------------------------------------------
+
+    /** R1, the destroyed-destination catch. */
+    public function test_an_absent_directory_under_a_listable_root_is_false(): void
+    {
+        $folder = $this->uniqueFolder('absent');
+
+        $out = $this->verifyPlugin($folder . '/' . $folder . '.php', '1.2.3');
+
+        $this->assertFalse($out['verdict']);
+        $this->assertContains('R1-absent', $out['signals']);
+    }
+
+    /** R2. */
+    public function test_an_empty_directory_is_false(): void
+    {
+        $folder = $this->uniqueFolder('empty');
+        $dir    = $this->pluginsRoot . '/' . $folder;
+        mkdir($dir, 0777, true);
+        $this->created[] = $dir;
+
+        $out = $this->verifyPlugin($folder . '/' . $folder . '.php', '1.2.3');
+
+        $this->assertFalse($out['verdict']);
+        $this->assertContains('R2-empty', $out['signals']);
+    }
+
+    /** R4, the truncated half-write. */
+    public function test_a_main_file_whose_header_does_not_parse_is_false(): void
+    {
+        $folder = $this->uniqueFolder('truncated');
+        $dir    = $this->makePlugin($folder, '1.2.3');
+        file_put_contents($dir . '/' . $folder . '.php', "<?php\n/**\n * Plug");
+
+        $out = $this->verifyPlugin($folder . '/' . $folder . '.php', '1.2.3');
+
+        $this->assertFalse($out['verdict']);
+        $this->assertContains('R4-header-unparseable', $out['signals']);
+    }
+
+    /** R4, the completed-swap catch: any version movement at all condemns. */
+    public function test_a_version_that_already_moved_is_false(): void
+    {
+        $folder = $this->uniqueFolder('moved');
+        $this->makePlugin($folder, '2.0.0');
+
+        $out = $this->verifyPlugin($folder . '/' . $folder . '.php', '1.2.3');
+
+        $this->assertFalse($out['verdict']);
+        $this->assertContains('R4-version-moved', $out['signals']);
+    }
+
+    /** R5: a top-level entry that existed before the update is gone now. */
+    public function test_a_missing_payload_entry_is_false(): void
+    {
+        $folder  = $this->uniqueFolder('missing');
+        $dir     = $this->makePlugin($folder, '1.0.0');
+        $payload = $this->root . '/payload';
+        $this->copyTree($dir, $payload);
+        unlink($dir . '/readme.txt'); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture mutation
+
+        $out = $this->verifyPlugin($folder . '/' . $folder . '.php', '1.0.0', $payload);
+
+        $this->assertFalse($out['verdict']);
+        $this->assertContains('R5-entry-missing', $out['signals']);
+    }
+
+    /**
+     * An EXTRA live entry is not evidence of anything: core has no mechanism
+     * that adds a single top-level file, while a plugin writing its own cache
+     * file between the capture and this check is completely normal. Without
+     * this asymmetry the verifier would report every such plugin as modified.
+     */
+    public function test_an_extra_live_entry_is_not_evidence(): void
+    {
+        $folder  = $this->uniqueFolder('extra');
+        $dir     = $this->makePlugin($folder, '1.0.0');
+        $payload = $this->root . '/payload';
+        $this->copyTree($dir, $payload);
+        file_put_contents($dir . '/cache.json', '{}');
+
+        $out = $this->verifyPlugin($folder . '/' . $folder . '.php', '1.0.0', $payload);
+
+        $this->assertTrue($out['verdict'], $out['detail']);
+    }
+
+    /** R6, size only. */
+    public function test_a_main_file_whose_size_changed_is_false(): void
+    {
+        $folder  = $this->uniqueFolder('resized');
+        $dir     = $this->makePlugin($folder, '1.0.0');
+        $payload = $this->root . '/payload';
+        $this->copyTree($dir, $payload);
+        file_put_contents(
+            $dir . '/' . $folder . '.php',
+            "<?php\n/**\n * Plugin Name: Test\n * Version: 1.0.0\n */\n// padding padding padding\n"
+        );
+
+        $out = $this->verifyPlugin($folder . '/' . $folder . '.php', '1.0.0', $payload);
+
+        $this->assertFalse($out['verdict']);
+        $this->assertContains('R6-size-differs', $out['signals']);
+    }
+
+    /**
+     * MTIME MUST NEVER BE COMPARED. The snapshot payload is built with plain
+     * file copies, which do not preserve mtimes, so an mtime comparison would
+     * report every single capture as modified.
+     */
+    public function test_mtime_is_never_compared(): void
+    {
+        $folder  = $this->uniqueFolder('mtime');
+        $dir     = $this->makePlugin($folder, '1.0.0');
+        $payload = $this->root . '/payload';
+        $this->copyTree($dir, $payload);
+        touch($payload . '/' . $folder . '.php', time() - 86400);
+        touch($dir . '/' . $folder . '.php', time());
+
+        $out = $this->verifyPlugin($folder . '/' . $folder . '.php', '1.0.0', $payload);
+
+        $this->assertTrue($out['verdict'], 'an mtime difference must not affect the verdict');
+    }
+
+    // ---- cannot answer: null --------------------------------------------
+
+    /**
+     * R0: an unlistable ROOT is the open_basedir class this verifier exists to
+     * be gentle with, and it must never condemn. Once the root DOES list, a
+     * missing child is genuinely missing, because open_basedir is prefix-based
+     * and cannot hide one entry of a directory it lets you read.
+     */
+    public function test_an_unlistable_root_is_null_not_false(): void
+    {
+        $folder = $this->uniqueFolder('rootless');
+        $this->skipWhenChmodDoesNotBlockReads();
+
+        chmod($this->pluginsRoot, 0000);
+        try {
+            $out = $this->verifyPlugin($folder . '/' . $folder . '.php', '1.0.0');
+        } finally {
+            chmod($this->pluginsRoot, 0777);
+        }
+
+        $this->assertNull($out['verdict']);
+        $this->assertContains('R0-root-unlistable', $out['signals']);
+    }
+
+    /**
+     * R2: presence in the parent listing is positive evidence of existence, so
+     * a child we cannot read is inconclusive, never destroyed.
+     */
+    public function test_a_present_but_unlistable_directory_is_null_not_false(): void
+    {
+        $this->skipWhenChmodDoesNotBlockReads();
+
+        $folder = $this->uniqueFolder('locked');
+        $dir    = $this->makePlugin($folder, '1.0.0');
+
+        chmod($dir, 0000);
+        try {
+            $out = $this->verifyPlugin($folder . '/' . $folder . '.php', '1.0.0');
+        } finally {
+            chmod($dir, 0777);
+        }
+
+        $this->assertNull($out['verdict']);
+        $this->assertContains('R2-unlistable', $out['signals']);
+    }
+
+    /** R3: a guessed main file that misses must be null, never false. */
+    public function test_an_unresolvable_main_file_is_null_not_false(): void
+    {
+        $folder = $this->uniqueFolder('ambiguous');
+        $dir    = $this->pluginsRoot . '/' . $folder;
+        mkdir($dir, 0777, true);
+        $this->created[] = $dir;
+        file_put_contents($dir . '/one.php', "<?php\n");
+        file_put_contents($dir . '/two.php', "<?php\n");
+
+        $out = $this->verifyPlugin($folder, '1.0.0');
+
+        $this->assertNull($out['verdict']);
+        $this->assertContains('R3-unresolved', $out['signals']);
+    }
+
+    /**
+     * An unconventional main file name IS resolvable when a snapshot exists,
+     * because the payload is a copy of the pre-update directory.
+     */
+    public function test_an_unconventional_main_file_is_resolved_from_the_snapshot(): void
+    {
+        $folder  = $this->uniqueFolder('bedrock');
+        $dir     = $this->makePlugin($folder, '3.1.0', 'loader.php');
+        $payload = $this->root . '/payload';
+        $this->copyTree($dir, $payload);
+
+        $out = $this->verifyPlugin($folder, '3.1.0', $payload);
+
+        $this->assertTrue($out['verdict'], $out['detail']);
+    }
+
+    /** R4: without a pre-update version there is nothing to match against. */
+    public function test_an_empty_from_version_can_never_verify_true(): void
+    {
+        $folder = $this->uniqueFolder('noversion');
+        $this->makePlugin($folder, '1.0.0');
+
+        $out = $this->verifyPlugin($folder . '/' . $folder . '.php', '');
+
+        $this->assertNull($out['verdict']);
+        $this->assertContains('R4-no-from-version', $out['signals']);
+    }
+
+    /**
+     * R6 must return NULL, not FALSE, when the payload has no copy of the main
+     * file's relative path. Snapshot capture skips symlinks, and on a Bedrock
+     * or Composer layout a plain size inequality against a missing payload file
+     * would be a spurious restore on every such host.
+     */
+    public function test_a_payload_without_a_copy_of_the_main_file_skips_the_size_check(): void
+    {
+        $folder  = $this->uniqueFolder('nopayloadcopy');
+        $dir     = $this->makePlugin($folder, '1.0.0');
+        $payload = $this->root . '/payload';
+        mkdir($payload, 0777, true);
+
+        $out = $this->verifyPlugin($folder . '/' . $folder . '.php', '1.0.0', $payload);
+
+        $this->assertTrue($out['verdict'], $out['detail']);
+        $this->assertContains('R6-skipped-no-payload-copy', $out['signals']);
+    }
+
+    /**
+     * THE VERIFICATION-FAILS CASE. Anything thrown inside must produce null,
+     * never false and never an escaped exception: the caller is already on a
+     * failure path and a throw here would lose the whole item result.
+     */
+    public function test_a_throwing_header_reader_is_null_and_never_propagates(): void
+    {
+        $folder = $this->uniqueFolder('throwing');
+        $this->makePlugin($folder, '1.0.0');
+
+        Functions\when('get_file_data')->alias(function () {
+            throw new \RuntimeException('filesystem exploded');
+        });
+
+        $out = $this->verifyPlugin($folder . '/' . $folder . '.php', '1.0.0');
+
+        $this->assertNull($out['verdict']);
+    }
+
+    /**
+     * R4: a main file that exists but cannot be READ is inconclusive, never
+     * destroyed. A permissions problem is not evidence about content.
+     */
+    public function test_an_unreadable_main_file_is_null_not_false(): void
+    {
+        $this->skipWhenChmodDoesNotBlockReads();
+
+        $folder = $this->uniqueFolder('unreadable');
+        $dir    = $this->makePlugin($folder, '1.0.0');
+        $main   = $dir . '/' . $folder . '.php';
+
+        chmod($main, 0000);
+        try {
+            $out = $this->verifyPlugin($folder . '/' . $folder . '.php', '1.0.0');
+        } finally {
+            chmod($main, 0666);
+        }
+
+        $this->assertNull($out['verdict']);
+        $this->assertContains('R4-unreadable', $out['signals']);
+    }
+
+    /** A type this class does not understand answers null, never a guess. */
+    public function test_an_unsupported_type_is_null(): void
+    {
+        $out = DestinationVerifier::verify('core', 'core', '6.0', '');
+
+        $this->assertNull($out['verdict']);
+    }
+
+    /**
+     * THE FALSE-TRUE THIS BACKSTOP MUST NEVER PRODUCE. get_plugins() is a
+     * cached, full-directory scan with no clearstatcache(), so it can return
+     * the PRE-apply version for a directory that has since been wiped. The
+     * verifier must read the header off the file itself.
+     */
+    public function test_the_verifier_never_consults_get_plugins(): void
+    {
+        $folder = $this->uniqueFolder('nocache');
+        $this->makePlugin($folder, '1.0.0');
+
+        $called = false;
+        Functions\when('get_plugins')->alias(function () use (&$called) {
+            $called = true;
+            return [];
+        });
+
+        $this->verifyPlugin($folder . '/' . $folder . '.php', '1.0.0');
+
+        $this->assertFalse($called, 'the verifier must never read a cached plugin listing');
+    }
+
+    /**
+     * chmod is advisory for root, so the two unlistable-directory cases are
+     * skipped with an explicit message rather than silently passing when the
+     * suite happens to run as root (a container default).
+     *
+     * @return void
+     */
+    private function skipWhenChmodDoesNotBlockReads(): void
+    {
+        $probe = $this->root . '/chmod-probe';
+        mkdir($probe, 0777, true);
+        chmod($probe, 0000);
+        $blocked = @scandir($probe) === false;
+        chmod($probe, 0777);
+        rmdir($probe);
+
+        if (!$blocked) {
+            $this->markTestSkipped('this process can read a 0000 directory (running as root), so R0/R2 cannot be exercised');
+        }
+    }
+}

--- a/apps/agent/tests/RollbackCommandSiteLockTest.php
+++ b/apps/agent/tests/RollbackCommandSiteLockTest.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * RollbackCommandSiteLockTest - the rollback participates in the SAME per-site
+ * update lock as the update command (GitHub issue #328).
+ *
+ * A rollback replaces the live directory wholesale, so it is the same class of
+ * writer as an update. Running one while another request is driving WordPress's
+ * upgrader against wp-content/upgrade/ is exactly the concurrency this lock
+ * exists to remove.
+ *
+ * A refused rollback does NOT wait: RollbackCommand answers on the control
+ * plane's own HTTP connection, so polling here would pin a PHP worker for the
+ * whole of somebody else's apply. It refuses honestly, using the response's
+ * existing fields.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Commands\RollbackCommand;
+use WPMgr\Agent\Support\SiteUpdateLock;
+use WPMgr\Agent\Support\SnapshotManager;
+use WPMgr\Agent\Support\UpdateRunner;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Commands\RollbackCommand
+ */
+final class RollbackCommandSiteLockTest extends TestCase
+{
+    /** @var array<string,mixed> In-memory wp-option store. */
+    private array $options = [];
+
+    /** Absolute path to the `.maintenance` marker under the test ABSPATH. */
+    private string $maintenanceFile = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->options = [];
+        \WP_Upgrader::$failCreateLock = false;
+        SiteUpdateLock::resetForTests();
+
+        Functions\when('get_option')->alias(function (string $name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('update_option')->alias(function (string $name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('delete_option')->alias(function (string $name) {
+            unset($this->options[$name]);
+            return true;
+        });
+        Functions\when('delete_site_transient')->justReturn(true);
+
+        $abspath = defined('ABSPATH') ? rtrim((string) constant('ABSPATH'), '/\\') : '';
+        if ($abspath !== '' && !is_dir($abspath)) {
+            mkdir($abspath, 0755, true);
+        }
+        $this->maintenanceFile = $abspath . '/.maintenance';
+        if (file_exists($this->maintenanceFile)) {
+            unlink($this->maintenanceFile); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        }
+    }
+
+    protected function tear_down(): void
+    {
+        if ($this->maintenanceFile !== '' && file_exists($this->maintenanceFile)) {
+            unlink($this->maintenanceFile); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        }
+        SiteUpdateLock::resetForTests();
+        \WP_Upgrader::$failCreateLock = false;
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * Snapshot spy recording whether restore() was ever reached.
+     *
+     * @return SnapshotManager
+     */
+    private function spySnapshots(): SnapshotManager
+    {
+        return new class extends SnapshotManager {
+            /** @var array<int,array{string,string,string}> */
+            public array $restored = [];
+
+            public function restore(string $type, string $slug, string $snapshotId): array
+            {
+                $this->restored[] = [$type, $slug, $snapshotId];
+
+                return ['ok' => true, 'log' => 'restored'];
+            }
+
+            public function recordedVersion(string $snapshotId): string
+            {
+                return '1.0.0';
+            }
+
+            public function cleanup(string $snapshotId): bool
+            {
+                return true;
+            }
+        };
+    }
+
+    /**
+     * Runner spy.
+     *
+     * @return UpdateRunner
+     */
+    private function spyRunner(): UpdateRunner
+    {
+        return new class extends UpdateRunner {
+            public function currentVersion(string $type, string $slug): string
+            {
+                return '1.0.0';
+            }
+        };
+    }
+
+    public function test_a_busy_site_refuses_the_rollback_and_never_reaches_restore(): void
+    {
+        // Another request holds the lock.
+        $this->assertSame(SiteUpdateLock::ACQUIRED, SiteUpdateLock::acquire());
+        SiteUpdateLock::resetForTests();
+
+        $snapshots = $this->spySnapshots();
+
+        $out = (new RollbackCommand($snapshots, $this->spyRunner()))->execute([], [
+            'type'        => 'plugin',
+            'slug'        => 'akismet/akismet.php',
+            'snapshot_id' => 'snap_x',
+        ]);
+
+        $this->assertFalse($out['ok']);
+        $this->assertSame('', $out['restored_version']);
+        $this->assertStringContainsString('Nothing was attempted', $out['log']);
+        $this->assertSame([], $snapshots->restored, 'restore() must be unreachable while the site is busy');
+        $this->assertSame(
+            ['ok', 'restored_version', 'log'],
+            array_keys($out),
+            'the refusal must use the existing response shape; no new wire fields'
+        );
+    }
+
+    /** A refused rollback must not heal or arm anything either. */
+    public function test_a_busy_refusal_does_not_touch_the_maintenance_flag(): void
+    {
+        file_put_contents($this->maintenanceFile, '<?php $upgrading = ' . (time() - 400) . '; ?>');
+
+        $this->assertSame(SiteUpdateLock::ACQUIRED, SiteUpdateLock::acquire());
+        SiteUpdateLock::resetForTests();
+
+        (new RollbackCommand($this->spySnapshots(), $this->spyRunner()))->execute([], [
+            'type'        => 'plugin',
+            'slug'        => 'akismet/akismet.php',
+            'snapshot_id' => 'snap_x',
+        ]);
+
+        $this->assertFileExists($this->maintenanceFile);
+    }
+
+    public function test_a_free_site_rolls_back_and_releases_the_lock(): void
+    {
+        $snapshots = $this->spySnapshots();
+
+        $out = (new RollbackCommand($snapshots, $this->spyRunner()))->execute([], [
+            'type'        => 'plugin',
+            'slug'        => 'akismet/akismet.php',
+            'snapshot_id' => 'snap_x',
+        ]);
+
+        $this->assertTrue($out['ok']);
+        $this->assertCount(1, $snapshots->restored);
+        $this->assertArrayNotHasKey(
+            'wpmgr_site_update.lock',
+            $this->options,
+            'the rollback must not leave the site locked for its full 15-minute TTL'
+        );
+    }
+
+    /** Even an invalid request must release the lock it took. */
+    public function test_an_invalid_request_still_releases_the_lock(): void
+    {
+        $out = (new RollbackCommand($this->spySnapshots(), $this->spyRunner()))->execute([], [
+            'type' => 'not-a-type',
+        ]);
+
+        $this->assertFalse($out['ok']);
+        $this->assertArrayNotHasKey('wpmgr_site_update.lock', $this->options);
+    }
+}

--- a/apps/agent/tests/SelfUpdateInRequestApplyTest.php
+++ b/apps/agent/tests/SelfUpdateInRequestApplyTest.php
@@ -500,6 +500,63 @@ final class SelfUpdateInRequestApplyTest extends TestCase
     }
 
     /**
+     * THE ARM NEVER CONSULTS THE SITE UPDATE LOCK (GitHub issue #328).
+     *
+     * The arm touches nothing on the site's filesystem, and in a canary wave any
+     * terminal non-confirming answer means the rollout halts. Refusing to ARM
+     * because some plugin update happens to be running would turn a routine
+     * collision into a halted fleet rollout, so the lock is consulted by the
+     * APPLY (after the response has been released and waiting costs nobody
+     * anything) and never here.
+     */
+    public function test_the_arm_never_consults_the_site_update_lock(): void
+    {
+        $this->stubSignedOffer();
+
+        // Somebody else holds the site's update lock right now.
+        $this->options['wpmgr_site_update.lock']  = time();
+        $this->options['wpmgr_site_update_owner'] = 'ffffffffffffffffffffffffffffffff';
+
+        $answer = $this->makeChecker()->planSelfUpdate();
+
+        $this->assertSame(
+            'scheduled',
+            $answer['status'],
+            'a busy site must not stop the agent self-update from being armed'
+        );
+    }
+
+    /**
+     * The apply takes the site's update lock before the swap and releases it
+     * afterwards, so a plugin update command arriving mid-swap is refused
+     * rather than allowed to delete this apply's extracted source out of
+     * wp-content/upgrade/.
+     */
+    public function test_the_apply_holds_and_then_releases_the_site_update_lock(): void
+    {
+        $this->stubSignedOffer();
+        $this->siteTransients['update_plugins'] = $this->offerTransient();
+
+        $held = [];
+        \Plugin_Upgrader::$behaviour = function () use (&$held) {
+            // Observed from INSIDE the swap: this is the window a concurrent
+            // update command must be refused in.
+            $held[] = \WPMgr\Agent\Support\SiteUpdateLock::heldByThisRequest();
+
+            return true;
+        };
+
+        $this->runApply();
+
+        $this->assertSame([true], $held, 'the swap itself must run while the site lock is held');
+        $this->assertArrayNotHasKey(
+            'wpmgr_site_update.lock',
+            $this->options,
+            'the apply must not leave the site locked for its full 15-minute TTL'
+        );
+    }
+
+    /**
      * NO AGENT SHUTDOWN CALLBACK MAY SIT BELOW PRIORITY 100.
      *
      * Core registers restore_temp_backup at 10 and delete_temp_backup at 100. A

--- a/apps/agent/tests/SiteUpdateLockConcurrencyTest.php
+++ b/apps/agent/tests/SiteUpdateLockConcurrencyTest.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * SiteUpdateLockConcurrencyTest - the site lock across TWO REAL OS PROCESSES
+ * (GitHub issue #328).
+ *
+ * WHAT THIS TEST CLAIMS, precisely. It does NOT claim to have tested the
+ * atomicity of WordPress core's `INSERT IGNORE` at
+ * wp-admin/includes/class-wp-upgrader.php:1065; that primitive is not
+ * reimplemented here and a test pretending otherwise would encode a false
+ * guarantee. What it DOES test is everything the agent layers on top of it,
+ * against a compare-and-set of the same shape (an insert-if-absent performed
+ * under an exclusive flock in the child fixture): that two concurrent callers
+ * never both believe they hold the lock, that the loser refuses instead of
+ * proceeding, and that a released lock is genuinely re-acquirable by a
+ * different process.
+ *
+ * Single-process unit tests cannot observe any of that, which is why this file
+ * pays for two child processes.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\SiteUpdateLock
+ */
+final class SiteUpdateLockConcurrencyTest extends TestCase
+{
+    /** Scratch directory for the shared option store and observation log. */
+    private string $dir = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+
+        if (!function_exists('proc_open')) {
+            $this->markTestSkipped('proc_open() is disabled, so cross-process locking cannot be exercised');
+        }
+
+        $this->dir = sys_get_temp_dir() . '/wpmgr-lockconc-' . bin2hex(random_bytes(6));
+        mkdir($this->dir, 0777, true);
+    }
+
+    protected function tear_down(): void
+    {
+        foreach ((array) glob($this->dir . '/*') as $file) {
+            if (is_string($file) && is_file($file)) {
+                unlink($file); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        if (is_dir($this->dir)) {
+            rmdir($this->dir);
+        }
+
+        parent::tear_down();
+    }
+
+    /**
+     * Start one child process.
+     *
+     * @param int $holdMs How long the child holds the lock once acquired.
+     * @return resource
+     */
+    private function spawn(int $holdMs)
+    {
+        $cmd = [
+            PHP_BINARY,
+            '-d',
+            'error_reporting=E_ALL',
+            __DIR__ . '/fixtures/site-update-lock-child.php',
+            $this->dir . '/store.json',
+            $this->dir . '/log.txt',
+            (string) $holdMs,
+        ];
+
+        $pipes   = [];
+        $process = proc_open($cmd, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes);
+        if (!is_resource($process)) {
+            $this->fail('could not start the lock child process');
+        }
+        foreach ($pipes as $pipe) {
+            stream_set_blocking($pipe, false);
+        }
+        $this->pipes[] = $pipes;
+
+        return $process;
+    }
+
+    /** @var array<int,array<int,resource>> Open pipes, drained in wait(). */
+    private array $pipes = [];
+
+    /**
+     * Wait for every child and return the observation log lines.
+     *
+     * @param array<int,resource> $processes Child handles.
+     * @return array<int,string>
+     */
+    private function wait(array $processes): array
+    {
+        $stderr = '';
+        foreach ($processes as $index => $process) {
+            while (proc_get_status($process)['running']) {
+                usleep(10000);
+            }
+            if (isset($this->pipes[$index][2])) {
+                $stderr .= (string) stream_get_contents($this->pipes[$index][2]);
+            }
+            foreach ($this->pipes[$index] ?? [] as $pipe) {
+                fclose($pipe);
+            }
+            proc_close($process);
+        }
+        $this->pipes = [];
+
+        $raw = @file_get_contents($this->dir . '/log.txt');
+        $this->assertIsString(
+            $raw,
+            'no child wrote an observation line; child stderr was: ' . ($stderr !== '' ? $stderr : '(empty)')
+        );
+
+        return array_values(array_filter(explode("\n", (string) $raw), static fn ($l) => trim($l) !== ''));
+    }
+
+    /**
+     * TWO PROCESSES, ONE SITE. The winner holds the lock for 600ms; the loser
+     * must refuse rather than proceed, and must do so WITHOUT ever entering the
+     * critical section.
+     */
+    public function test_two_concurrent_processes_never_both_hold_the_lock(): void
+    {
+        $processes = [$this->spawn(600), $this->spawn(600)];
+        $lines     = $this->wait($processes);
+
+        $enters = array_values(array_filter($lines, static fn ($l) => str_starts_with($l, 'ENTER ')));
+        $busy   = array_values(array_filter($lines, static fn ($l) => str_starts_with($l, 'BUSY ')));
+
+        $this->assertNotSame(
+            [],
+            $enters,
+            'the test cannot pass by BOTH children failing to acquire; at least one must enter'
+        );
+        $this->assertCount(
+            1,
+            $enters,
+            'two processes entered the critical section at once: ' . implode(' | ', $lines)
+        );
+        $this->assertCount(1, $busy, 'the loser must refuse explicitly, not proceed: ' . implode(' | ', $lines));
+    }
+
+    /**
+     * A released lock is genuinely free for a DIFFERENT process. Without the
+     * owner-checked release this would either leak the lock for its whole TTL
+     * or free somebody else's.
+     */
+    public function test_a_released_lock_is_reacquirable_by_another_process(): void
+    {
+        $lines = $this->wait([$this->spawn(0)]);
+        $this->assertSame(['ENTER', 'EXIT'], $this->kinds($lines));
+
+        $lines = $this->wait([$this->spawn(0)]);
+        $this->assertSame(
+            ['ENTER', 'EXIT', 'ENTER', 'EXIT'],
+            $this->kinds($lines),
+            'a lock released by one process must be immediately acquirable by the next'
+        );
+    }
+
+    /**
+     * The critical sections of the two runs must not overlap in wall-clock
+     * time. This is the property the whole feature exists to provide, measured
+     * rather than asserted from the code.
+     */
+    public function test_critical_sections_never_overlap(): void
+    {
+        // Three children, staggered by nothing: the two losers refuse and the
+        // winner's interval is the only one recorded.
+        $processes = [$this->spawn(300), $this->spawn(300), $this->spawn(300)];
+        $lines     = $this->wait($processes);
+
+        $intervals = [];
+        $open      = [];
+        foreach ($lines as $line) {
+            $parts = explode(' ', $line);
+            if ($parts[0] === 'ENTER') {
+                $open[$parts[1]] = (float) $parts[2];
+            } elseif ($parts[0] === 'EXIT' && isset($open[$parts[1]])) {
+                $intervals[] = [$open[$parts[1]], (float) $parts[2]];
+                unset($open[$parts[1]]);
+            }
+        }
+
+        $this->assertNotSame([], $intervals, 'no child entered the critical section at all');
+        $this->assertSame([], $open, 'a child entered the critical section and never left it');
+
+        foreach ($intervals as $i => $a) {
+            foreach ($intervals as $j => $b) {
+                if ($i >= $j) {
+                    continue;
+                }
+                $this->assertTrue(
+                    $a[1] <= $b[0] || $b[1] <= $a[0],
+                    'two critical sections overlapped: ' . implode(' | ', $lines)
+                );
+            }
+        }
+    }
+
+    /**
+     * Reduce log lines to their kind, in order.
+     *
+     * @param array<int,string> $lines Observation lines.
+     * @return array<int,string>
+     */
+    private function kinds(array $lines): array
+    {
+        return array_map(static fn ($l) => explode(' ', $l)[0], $lines);
+    }
+}

--- a/apps/agent/tests/SiteUpdateLockTest.php
+++ b/apps/agent/tests/SiteUpdateLockTest.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * SiteUpdateLockTest - the per-site update lock (GitHub issue #328).
+ *
+ * WHAT THESE TESTS DO AND DO NOT CLAIM. The mutual-exclusion guarantee belongs
+ * to core's single `INSERT IGNORE` at wp-admin/includes/class-wp-upgrader.php:1065,
+ * which this project does not reimplement and must not claim to have tested.
+ * What IS tested here is the logic layered on top of it: the three-way acquire
+ * verdict, the owner token that stops a stale holder freeing a live one, the
+ * renewal, and (in SiteUpdateLockConcurrencyTest) the behaviour of that logic
+ * across two real OS processes over an atomic compare-and-set.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Commands\UpdateCommand;
+use WPMgr\Agent\Support\LongRunningJob;
+use WPMgr\Agent\Support\SiteUpdateLock;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\SiteUpdateLock
+ */
+final class SiteUpdateLockTest extends TestCase
+{
+    /** @var array<string,mixed> In-memory wp-option store shared by the stubs. */
+    private array $options = [];
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->options = [];
+        \WP_Upgrader::$failCreateLock = false;
+        SiteUpdateLock::resetForTests();
+
+        Functions\when('get_option')->alias(function (string $name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('update_option')->alias(function (string $name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('delete_option')->alias(function (string $name) {
+            unset($this->options[$name]);
+            return true;
+        });
+    }
+
+    protected function tear_down(): void
+    {
+        SiteUpdateLock::resetForTests();
+        \WP_Upgrader::$failCreateLock = false;
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    public function test_a_second_acquire_from_another_request_is_refused_while_the_first_holds(): void
+    {
+        $this->assertSame(SiteUpdateLock::ACQUIRED, SiteUpdateLock::acquire());
+
+        // A second REQUEST is simulated by dropping this process's in-memory
+        // ownership while leaving the option store exactly as it is.
+        SiteUpdateLock::resetForTests();
+
+        $this->assertSame(
+            SiteUpdateLock::HELD_BY_OTHER,
+            SiteUpdateLock::acquire(),
+            'a live lock taken by another request must refuse, never fall through'
+        );
+    }
+
+    public function test_acquire_release_acquire_succeeds(): void
+    {
+        $this->assertSame(SiteUpdateLock::ACQUIRED, SiteUpdateLock::acquire());
+        SiteUpdateLock::release();
+
+        SiteUpdateLock::resetForTests();
+        $this->assertSame(SiteUpdateLock::ACQUIRED, SiteUpdateLock::acquire());
+    }
+
+    public function test_a_second_acquire_in_the_same_request_is_reentrant(): void
+    {
+        $this->assertSame(SiteUpdateLock::ACQUIRED, SiteUpdateLock::acquire());
+        $this->assertSame(
+            SiteUpdateLock::ACQUIRED,
+            SiteUpdateLock::acquire(),
+            'a request that already holds the lock must not refuse its own work'
+        );
+    }
+
+    /**
+     * THE OWNERSHIP REGRESSION LOCK. WP_Upgrader::release_lock() is an
+     * unconditional delete_option() (class-wp-upgrader.php:1102 to :1103), so a
+     * late release from a holder whose lock had already expired and been stolen
+     * would free a LIVE holder. Do not simplify the owner check away.
+     */
+    public function test_release_from_a_stale_owner_does_not_free_a_live_holder(): void
+    {
+        // A acquires.
+        $this->assertSame(SiteUpdateLock::ACQUIRED, SiteUpdateLock::acquire());
+
+        // A's lock expires and B steals it, writing its own owner token and a
+        // fresh stamp. (Core performs exactly this steal internally at
+        // class-wp-upgrader.php:1080 to :1083.)
+        $this->options['wpmgr_site_update.lock']  = time();
+        $this->options['wpmgr_site_update_owner'] = 'ffffffffffffffffffffffffffffffff';
+
+        // A now releases, believing it still owns the lock.
+        SiteUpdateLock::release();
+
+        $this->assertArrayHasKey(
+            'wpmgr_site_update.lock',
+            $this->options,
+            'a stale holder must never delete the live holder\'s lock row'
+        );
+        $this->assertSame('ffffffffffffffffffffffffffffffff', $this->options['wpmgr_site_update_owner']);
+    }
+
+    public function test_renew_only_restamps_a_lock_we_still_own(): void
+    {
+        SiteUpdateLock::acquire();
+        $this->options['wpmgr_site_update.lock'] = time() - 100;
+
+        SiteUpdateLock::renew();
+        $this->assertGreaterThan(
+            time() - 5,
+            (int) $this->options['wpmgr_site_update.lock'],
+            'renew() must move the stored timestamp forward, exactly as core does at class-wp-upgrader.php:1087'
+        );
+
+        // Now somebody else owns it: renew must leave their stamp alone.
+        $this->options['wpmgr_site_update_owner'] = 'ffffffffffffffffffffffffffffffff';
+        $this->options['wpmgr_site_update.lock']  = 1000;
+        SiteUpdateLock::renew();
+        $this->assertSame(1000, $this->options['wpmgr_site_update.lock']);
+    }
+
+    /**
+     * THE FAIL-OPEN REGRESSION LOCK. Core's helper reports "locked" whenever its
+     * INSERT failed AND no lock row is readable, which conflates an
+     * infrastructure failure with a held lock. Reporting HELD_BY_OTHER there
+     * would refuse EVERY update on that site permanently, with no in-product
+     * remedy. This is the same class of mistake as guarding what core does not
+     * guard, and it must stay closed.
+     */
+    public function test_acquire_reports_unavailable_when_the_lock_row_cannot_be_created_or_read(): void
+    {
+        \WP_Upgrader::$failCreateLock = true;
+
+        $this->assertSame(
+            SiteUpdateLock::UNAVAILABLE,
+            SiteUpdateLock::acquire(),
+            'an unreadable, uncreatable lock must NOT be reported as held by someone else'
+        );
+        $this->assertFalse(SiteUpdateLock::heldByThisRequest());
+    }
+
+    /**
+     * A readable lock row is the ONLY thing that turns a failed create_lock()
+     * into a refusal. With the row present, the same infrastructure failure is
+     * correctly reported as held by someone else.
+     */
+    public function test_a_failed_create_with_a_readable_lock_row_is_still_a_refusal(): void
+    {
+        $this->options['wpmgr_site_update.lock'] = time();
+        \WP_Upgrader::$failCreateLock            = true;
+
+        $this->assertSame(SiteUpdateLock::HELD_BY_OTHER, SiteUpdateLock::acquire());
+    }
+
+    /** An UNAVAILABLE acquire holds nothing, so release() must not delete anything. */
+    public function test_release_after_an_unavailable_acquire_touches_nothing(): void
+    {
+        $this->options['some_unrelated_option'] = 'keep me';
+        \WP_Upgrader::$failCreateLock           = true;
+
+        $this->assertSame(SiteUpdateLock::UNAVAILABLE, SiteUpdateLock::acquire());
+        SiteUpdateLock::release();
+
+        $this->assertSame(['some_unrelated_option' => 'keep me'], $this->options);
+    }
+
+    /**
+     * The TTL, the update command's PHP execution budget and the long-running
+     * job budget are the SAME number by design: the lock must outlive an apply
+     * that runs to its own cap and not one second longer. Pinned so the three
+     * cannot drift apart silently.
+     */
+    public function test_ttl_matches_the_apply_budget(): void
+    {
+        $applyLimit = new \ReflectionClassConstant(UpdateCommand::class, 'APPLY_TIME_LIMIT_SECONDS');
+
+        $this->assertSame(900, SiteUpdateLock::TTL);
+        $this->assertSame(SiteUpdateLock::TTL, $applyLimit->getValue());
+        $this->assertSame(SiteUpdateLock::TTL, LongRunningJob::TIME_LIMIT_SECONDS);
+    }
+
+    /**
+     * The lock name must NOT be core's own 'auto_updater'. create_lock() judges
+     * staleness against the CALLER's timeout, so taking core's name with our
+     * 900s would steal a lock core honours for an hour, and core's own release
+     * would then delete ours: exactly the concurrency this class removes.
+     */
+    public function test_lock_name_is_not_cores_auto_updater(): void
+    {
+        SiteUpdateLock::acquire();
+
+        $this->assertArrayHasKey('wpmgr_site_update.lock', $this->options);
+        $this->assertArrayNotHasKey('auto_updater.lock', $this->options);
+    }
+
+    public function test_held_until_reports_the_stamp_plus_the_ttl(): void
+    {
+        $this->assertSame(0, SiteUpdateLock::heldUntil(), 'no lock row means no expiry to report');
+
+        SiteUpdateLock::acquire();
+        $stamp = (int) $this->options['wpmgr_site_update.lock'];
+
+        $this->assertSame($stamp + SiteUpdateLock::TTL, SiteUpdateLock::heldUntil());
+    }
+}

--- a/apps/agent/tests/UpdateCommandRestoreSkipTest.php
+++ b/apps/agent/tests/UpdateCommandRestoreSkipTest.php
@@ -1,0 +1,583 @@
+<?php
+/**
+ * UpdateCommandRestoreSkipTest - PIECE 1, the restore-skip, end to end
+ * (GitHub issue #328).
+ *
+ * The gate opens for exactly ONE combination out of four, and the other three
+ * must behave exactly as the previous release did. Read
+ * test_an_unclassified_failure_restores_exactly_as_before() first: it is the
+ * strict-narrowing proof, and if it ever fails, this feature has started
+ * widening the set of restores rather than shrinking it.
+ *
+ * Real plugin directories on disk, because the second half of the decision is
+ * DestinationVerifier actually reading them.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Commands\UpdateCommand;
+use WPMgr\Agent\Support\SnapshotManager;
+use WPMgr\Agent\Support\UpdateRunner;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Commands\UpdateCommand
+ */
+final class UpdateCommandRestoreSkipTest extends TestCase
+{
+    /** Scratch tree for snapshot payload copies. */
+    private string $scratch = '';
+
+    /** Plugins root this process uses. */
+    private string $pluginsRoot = '';
+
+    /** @var array<int,string> Fixture directories to remove in tear-down. */
+    private array $created = [];
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->scratch = sys_get_temp_dir() . '/wpmgr-skip-' . bin2hex(random_bytes(6));
+        mkdir($this->scratch, 0777, true);
+
+        if (!defined('WP_CONTENT_DIR')) {
+            define('WP_CONTENT_DIR', sys_get_temp_dir() . '/wpmgr-shared-wp-content');
+        }
+        if (!is_dir((string) constant('WP_CONTENT_DIR'))) {
+            mkdir((string) constant('WP_CONTENT_DIR'), 0777, true);
+        }
+        if (!defined('WP_PLUGIN_DIR')) {
+            define('WP_PLUGIN_DIR', rtrim((string) constant('WP_CONTENT_DIR'), '/\\') . '/plugins');
+        }
+        $this->pluginsRoot = rtrim((string) constant('WP_PLUGIN_DIR'), '/\\');
+        if (!is_dir($this->pluginsRoot)) {
+            mkdir($this->pluginsRoot, 0777, true);
+        }
+        $this->created = [];
+    }
+
+    protected function tear_down(): void
+    {
+        foreach ($this->created as $dir) {
+            $this->deleteTree($dir);
+        }
+        $this->deleteTree($this->scratch);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * @param string $dir Directory to remove recursively.
+     * @return void
+     */
+    private function deleteTree(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (array_diff((array) scandir($dir), ['.', '..']) as $entry) {
+            $path = $dir . '/' . $entry;
+            if (is_dir($path)) {
+                $this->deleteTree($path);
+            } else {
+                unlink($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+            }
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Create a real plugin directory plus a matching snapshot payload copy.
+     *
+     * @param string $version Version reported in the header.
+     * @return array{folder:string,slug:string,dir:string,payload:string}
+     */
+    private function makePluginWithPayload(string $version = '1.2.3'): array
+    {
+        $folder = 'wpmgr-skip-' . bin2hex(random_bytes(4));
+        $dir    = $this->pluginsRoot . '/' . $folder;
+        mkdir($dir, 0777, true);
+        $this->created[] = $dir;
+
+        file_put_contents(
+            $dir . '/' . $folder . '.php',
+            "<?php\n/**\n * Plugin Name: Skip Fixture\n * Version: " . $version . "\n */\n"
+        );
+        file_put_contents($dir . '/readme.txt', "=== Skip Fixture ===\n");
+
+        $payload = $this->scratch . '/' . $folder . '-payload';
+        mkdir($payload, 0777, true);
+        foreach (array_diff((array) scandir($dir), ['.', '..']) as $entry) {
+            copy($dir . '/' . $entry, $payload . '/' . $entry);
+        }
+
+        return [
+            'folder'  => $folder,
+            'slug'    => $folder . '/' . $folder . '.php',
+            'dir'     => $dir,
+            'payload' => $payload,
+        ];
+    }
+
+    /**
+     * A runner spy whose apply() returns a caller-chosen outcome array. The
+     * outcome shape is the ONLY channel the decision reads, so a test can
+     * express "core said it failed before touching anything" precisely.
+     *
+     * @param array<string,mixed> $outcome apply() return value.
+     * @param string              $version Installed version reported.
+     * @return UpdateRunner
+     */
+    private function runnerReturning(array $outcome, string $version = '1.2.3'): UpdateRunner
+    {
+        return new class ($outcome, $version) extends UpdateRunner {
+            /** @var array<string,mixed> */
+            private array $outcome;
+
+            private string $version;
+
+            /** @var int */
+            public int $applyCalls = 0;
+
+            /** @var array<int,array{string,bool,bool}> */
+            public array $reactivations = [];
+
+            /**
+             * @param array<string,mixed> $outcome apply() return value.
+             * @param string              $version Installed version.
+             */
+            public function __construct(array $outcome, string $version)
+            {
+                $this->outcome = $outcome;
+                $this->version = $version;
+            }
+
+            public function currentVersion(string $type, string $slug): string
+            {
+                return $this->version;
+            }
+
+            public function isInstalled(string $type, string $slug): bool
+            {
+                return true;
+            }
+
+            public function availableVersion(string $type, string $slug, string $requested): ?string
+            {
+                return '9.9.9';
+            }
+
+            public function apply(string $type, string $slug, string $version): array
+            {
+                ++$this->applyCalls;
+
+                return $this->outcome;
+            }
+
+            public function wpCliAvailable(): bool
+            {
+                return false;
+            }
+
+            public function isComplete(string $type, string $slug, string $expectedVersion = ''): bool
+            {
+                return false;
+            }
+
+            public function lastIncompleteReason(): string
+            {
+                return '';
+            }
+
+            public function reactivateIfCoreDeactivated(string $slug, bool $wasActive, bool $wasNetworkActive): array
+            {
+                $this->reactivations[] = [$slug, $wasActive, $wasNetworkActive];
+
+                return ['attempted' => true, 'ok' => true, 'message' => ''];
+            }
+        };
+    }
+
+    /**
+     * A snapshot spy that records the calls this decision is allowed (and not
+     * allowed) to make.
+     *
+     * @param string $snapshotId Snapshot id to hand back from capture().
+     * @param string $payloadDir Payload path to hand back from payloadDir().
+     * @return SnapshotManager
+     */
+    private function spySnapshots(string $snapshotId, string $payloadDir): SnapshotManager
+    {
+        return new class ($snapshotId, $payloadDir) extends SnapshotManager {
+            private string $snapshotId;
+
+            private string $payload;
+
+            /** @var array<int,array{string,string,string}> */
+            public array $restored = [];
+
+            /** @var array<int,string> */
+            public array $markedSucceeded = [];
+
+            /** @var array<int,array{string,string,string}> */
+            public array $markedRestoreSkipped = [];
+
+            /**
+             * @param string $snapshotId Snapshot id.
+             * @param string $payload    Payload path.
+             */
+            public function __construct(string $snapshotId, string $payload)
+            {
+                $this->snapshotId = $snapshotId;
+                $this->payload    = $payload;
+            }
+
+            public function capture(string $type, string $slug, string $fromVersion): array
+            {
+                return ['snapshot_id' => $this->snapshotId, 'log' => 'captured'];
+            }
+
+            public function restore(string $type, string $slug, string $snapshotId): array
+            {
+                $this->restored[] = [$type, $slug, $snapshotId];
+
+                return ['ok' => true, 'log' => 'restored'];
+            }
+
+            public function snapshotExists(string $snapshotId): bool
+            {
+                return true;
+            }
+
+            public function payloadDir(string $snapshotId): string
+            {
+                return $this->payload;
+            }
+
+            public function markSucceeded(string $snapshotId): void
+            {
+                $this->markedSucceeded[] = $snapshotId;
+            }
+
+            public function markRestoreSkipped(string $snapshotId, string $failureCode, string $verification): void
+            {
+                $this->markedRestoreSkipped[] = [$snapshotId, $failureCode, $verification];
+            }
+        };
+    }
+
+    /**
+     * The outcome shape a real pre-install failure produces: the reported
+     * copy_failed_ziparchive from GitHub issue #328's own report.
+     *
+     * @return array<string,mixed>
+     */
+    private function untouchedFailure(): array
+    {
+        return [
+            'ok'                   => false,
+            'log'                  => 'Update failed: Could not copy file.',
+            'destination_touched'  => false,
+            'failure_code'         => 'copy_failed_ziparchive',
+            'failure_data'         => 'wp-seopress/vendor/psr/log/Psr/Log/Test/DummyTest.php',
+            'failure_stage'        => 'unpack',
+            'may_have_deactivated' => false,
+            'was_active'           => false,
+            'was_network_active'   => false,
+        ];
+    }
+
+    // =====================================================================
+    // The one combination that skips
+    // =====================================================================
+
+    /** THE #328 SHAPE, END TO END. */
+    public function test_a_pre_install_failure_over_an_intact_directory_skips_the_restore(): void
+    {
+        $fixture   = $this->makePluginWithPayload('1.2.3');
+        $snapshots = $this->spySnapshots('snap_skip_1', $fixture['payload']);
+
+        $out = (new UpdateCommand($snapshots, $this->runnerReturning($this->untouchedFailure())))->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => $fixture['slug'], 'version' => 'latest']],
+        ]);
+
+        $result = $out['results'][0];
+
+        $this->assertSame([], $snapshots->restored, 'a directory core never opened must not be restored over');
+        $this->assertSame('failed', $result['status'], 'the update genuinely did not happen; only the restore is skipped');
+        $this->assertSame($result['from_version'], $result['to_version'], 'nothing moved, so nothing may be reported as moved');
+        $this->assertStringContainsString('was re-checked after the failure and is unchanged', $result['log']);
+        $this->assertStringContainsString('copy_failed_ziparchive', $result['log']);
+    }
+
+    /**
+     * THE COPY INVARIANT. "Update incomplete; auto-restored the pre-update
+     * snapshot." asserts a restore happened. It must never appear when one did
+     * not, and it is the sentence an operator has historically seen for this
+     * entire class of failure.
+     */
+    public function test_a_skipped_restore_never_claims_to_have_auto_restored(): void
+    {
+        $fixture   = $this->makePluginWithPayload('1.2.3');
+        $snapshots = $this->spySnapshots('snap_skip_2', $fixture['payload']);
+
+        $out = (new UpdateCommand($snapshots, $this->runnerReturning($this->untouchedFailure())))->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => $fixture['slug'], 'version' => 'latest']],
+        ]);
+
+        $this->assertStringNotContainsString('auto-restored', $out['results'][0]['log']);
+        $this->assertStringNotContainsString('auto-restore', $out['results'][0]['log']);
+        $this->assertStringNotContainsString(
+            'no pre-update snapshot was available to auto-restore',
+            $out['results'][0]['log']
+        );
+    }
+
+    /**
+     * markSucceeded() flips the snapshot's reclaim threshold from 72h to 1h.
+     * Calling it here would delete the one piece of evidence that could prove
+     * this decision wrong, within an hour of a FAILED update. Its own docblock
+     * forbids calling it before independent verification of a SUCCESS.
+     */
+    public function test_a_skipped_restore_never_marks_the_snapshot_succeeded(): void
+    {
+        $fixture   = $this->makePluginWithPayload('1.2.3');
+        $snapshots = $this->spySnapshots('snap_skip_3', $fixture['payload']);
+
+        (new UpdateCommand($snapshots, $this->runnerReturning($this->untouchedFailure())))->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => $fixture['slug'], 'version' => 'latest']],
+        ]);
+
+        $this->assertSame([], $snapshots->markedSucceeded);
+        $this->assertCount(1, $snapshots->markedRestoreSkipped, 'the snapshot must be LABELLED, on its unchanged TTL');
+        $this->assertSame('snap_skip_3', $snapshots->markedRestoreSkipped[0][0]);
+        $this->assertSame('copy_failed_ziparchive', $snapshots->markedRestoreSkipped[0][1]);
+    }
+
+    /**
+     * The guard is only constructed when a snapshot was captured, and this path
+     * is reachable on any host where capture() failed. An unguarded call here
+     * would be an Error caught by the outer handler, which returns the bare
+     * "Update error." and loses the log, both versions and the entire
+     * explanation, on exactly the population documented as having regressed
+     * twice already.
+     */
+    public function test_a_skip_with_no_snapshot_does_not_touch_the_null_guard(): void
+    {
+        $fixture = $this->makePluginWithPayload('1.2.3');
+
+        $snapshots = new class extends SnapshotManager {
+            /** @var array<int,array{string,string,string}> */
+            public array $restored = [];
+
+            public function capture(string $type, string $slug, string $fromVersion): array
+            {
+                return ['snapshot_id' => '', 'log' => 'Snapshot store unavailable; proceeding without snapshot.'];
+            }
+
+            public function restore(string $type, string $slug, string $snapshotId): array
+            {
+                $this->restored[] = [$type, $slug, $snapshotId];
+
+                return ['ok' => true, 'log' => 'restored'];
+            }
+        };
+
+        $out = (new UpdateCommand($snapshots, $this->runnerReturning($this->untouchedFailure())))->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => $fixture['slug'], 'version' => 'latest']],
+        ]);
+
+        $result = $out['results'][0];
+        $this->assertSame([], $snapshots->restored);
+        $this->assertNotSame('Update error.', $result['log'], 'the skip path must not throw through the outer handler');
+        $this->assertStringContainsString('no restore was needed', $result['log']);
+        $this->assertSame('', $result['snapshot_id']);
+    }
+
+    // =====================================================================
+    // The three combinations that still restore
+    // =====================================================================
+
+    /** Classification false, verification FALSE (the directory really is gone). */
+    public function test_a_destroyed_directory_still_restores(): void
+    {
+        $fixture   = $this->makePluginWithPayload('1.2.3');
+        $snapshots = $this->spySnapshots('snap_mod', $fixture['payload']);
+
+        $this->deleteTree($fixture['dir']);
+
+        $out = (new UpdateCommand($snapshots, $this->runnerReturning($this->untouchedFailure())))->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => $fixture['slug'], 'version' => 'latest']],
+        ]);
+
+        $this->assertCount(1, $snapshots->restored);
+        $this->assertStringContainsString('no longer matches its pre-update state', $out['results'][0]['log']);
+        $this->assertStringContainsString('auto-restored', $out['results'][0]['log']);
+    }
+
+    /**
+     * Classification false, verification NULL. THE VERIFICATION-FAILS CASE:
+     * an unanswerable host keeps exactly the previous release's behaviour.
+     */
+    public function test_an_unverifiable_directory_still_restores(): void
+    {
+        $fixture   = $this->makePluginWithPayload('1.2.3');
+        $snapshots = $this->spySnapshots('snap_unver', $fixture['payload']);
+
+        // An empty from_version makes the positive header match impossible, so
+        // the verifier can only answer "cannot tell".
+        $runner = $this->runnerReturning($this->untouchedFailure(), '');
+
+        $out = (new UpdateCommand($snapshots, $runner))->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => $fixture['slug'], 'version' => 'latest']],
+        ]);
+
+        $this->assertCount(1, $snapshots->restored, 'an unverifiable host must keep restoring');
+        $this->assertStringContainsString('could not verify the plugin directory', $out['results'][0]['log']);
+    }
+
+    /**
+     * THE STRICT-NARROWING PROOF. An apply outcome with NO destination_touched
+     * key at all (the pre-0.61.114 shape, and the shape any minimal runner
+     * double produces) must restore, and its log must be byte-identical to the
+     * previous release's.
+     */
+    public function test_an_unclassified_failure_restores_exactly_as_before(): void
+    {
+        $fixture   = $this->makePluginWithPayload('1.2.3');
+        $snapshots = $this->spySnapshots('snap_legacy', $fixture['payload']);
+
+        $runner = $this->runnerReturning(['ok' => false, 'log' => 'upgrader reported failure']);
+
+        $out = (new UpdateCommand($snapshots, $runner))->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => $fixture['slug'], 'version' => 'latest']],
+        ]);
+
+        $this->assertCount(1, $snapshots->restored);
+        $this->assertSame(
+            "captured\nupgrader reported failure\nUpdate incomplete; auto-restored the pre-update snapshot.",
+            $out['results'][0]['log'],
+            'an unclassified failure must produce the exact log the previous release produced'
+        );
+    }
+
+    /** An apply that SUCCEEDED but failed verification never opens the gate. */
+    public function test_an_ok_apply_rejected_by_the_completeness_check_never_skips(): void
+    {
+        $fixture   = $this->makePluginWithPayload('1.2.3');
+        $snapshots = $this->spySnapshots('snap_incomplete', $fixture['payload']);
+
+        $runner = $this->runnerReturning([
+            'ok'                  => true,
+            'log'                 => 'applied',
+            'destination_touched' => false, // Deliberately contradictory input.
+            'failure_code'        => '',
+            'failure_stage'       => '',
+        ]);
+
+        $out = (new UpdateCommand($snapshots, $runner))->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => $fixture['slug'], 'version' => 'latest']],
+        ]);
+
+        $this->assertCount(
+            1,
+            $snapshots->restored,
+            'the gate is gated on ok === false; a half-written directory reported as ok must still restore'
+        );
+        $this->assertStringContainsString('auto-restored', $out['results'][0]['log']);
+        $this->assertStringNotContainsString(
+            'could not verify the',
+            $out['results'][0]['log'],
+            'a gate that was never evaluated must add no sentence at all'
+        );
+    }
+
+    /**
+     * `core` has no directory-level snapshot or restore by design, so the
+     * decision must never even evaluate for it.
+     */
+    public function test_a_core_failure_never_evaluates_the_skip(): void
+    {
+        $snapshots = $this->spySnapshots('snap_core', '');
+
+        $runner = $this->runnerReturning($this->untouchedFailure());
+
+        $out = (new UpdateCommand($snapshots, $runner))->execute([], [
+            'snapshot' => false,
+            'items'    => [['type' => 'core', 'slug' => 'core', 'version' => 'latest']],
+        ]);
+
+        $this->assertSame([], $snapshots->restored);
+        $this->assertStringNotContainsString('was re-checked after the failure', $out['results'][0]['log']);
+        $this->assertStringNotContainsString('could not verify the', $out['results'][0]['log']);
+        $this->assertStringNotContainsString('no longer matches its pre-update state', $out['results'][0]['log']);
+        $this->assertSame('failed', $out['results'][0]['status']);
+    }
+
+    // =====================================================================
+    // Reactivation
+    // =====================================================================
+
+    /**
+     * Core silently deactivates an active plugin at `upgrader_pre_install` and,
+     * on a non-cron request, never puts it back. A skipped restore would
+     * otherwise leave the directory byte-identical and the plugin OFF.
+     */
+    public function test_an_active_plugin_deactivated_by_core_is_reactivated_after_a_skip(): void
+    {
+        Functions\when('is_plugin_active')->justReturn(false);
+
+        $fixture   = $this->makePluginWithPayload('1.2.3');
+        $snapshots = $this->spySnapshots('snap_react', $fixture['payload']);
+
+        $outcome                         = $this->untouchedFailure();
+        $outcome['failure_code']         = 'source_read_failed';
+        $outcome['failure_stage']        = 'install';
+        $outcome['may_have_deactivated'] = true;
+        $outcome['was_active']           = true;
+
+        $runner = $this->runnerReturning($outcome);
+
+        $out = (new UpdateCommand($snapshots, $runner))->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => $fixture['slug'], 'version' => 'latest']],
+        ]);
+
+        $this->assertCount(1, $runner->reactivations);
+        $this->assertSame([$fixture['slug'], true, false], $runner->reactivations[0]);
+        $this->assertStringContainsString('it has been reactivated', $out['results'][0]['log']);
+    }
+
+    /**
+     * A plugin that was NOT active before the update must never be switched on
+     * by a failure path: activate_plugin() includes the plugin file in this
+     * process, and the operator may have disabled it deliberately.
+     */
+    public function test_an_inactive_plugin_is_never_activated_by_the_failure_path(): void
+    {
+        Functions\when('is_plugin_active')->justReturn(false);
+
+        $fixture   = $this->makePluginWithPayload('1.2.3');
+        $snapshots = $this->spySnapshots('snap_noreact', $fixture['payload']);
+
+        $outcome                         = $this->untouchedFailure();
+        $outcome['may_have_deactivated'] = true;
+        $outcome['was_active']           = false;
+        $outcome['was_network_active']   = false;
+
+        $runner = $this->runnerReturning($outcome);
+
+        (new UpdateCommand($snapshots, $runner))->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => $fixture['slug'], 'version' => 'latest']],
+        ]);
+
+        $this->assertSame([], $runner->reactivations);
+    }
+}

--- a/apps/agent/tests/UpdateCommandSiteLockTest.php
+++ b/apps/agent/tests/UpdateCommandSiteLockTest.php
@@ -1,0 +1,414 @@
+<?php
+/**
+ * UpdateCommandSiteLockTest - PIECE 2, per-site serialisation, at the command
+ * boundary (GitHub issue #328).
+ *
+ * The safety assertion these tests exist for is not "the update did not
+ * happen". It is "NOTHING WAS WRITTEN": a command refused because the site is
+ * busy must be indistinguishable on disk from a command that never arrived.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Commands\UpdateCommand;
+use WPMgr\Agent\Support\SiteUpdateLock;
+use WPMgr\Agent\Support\SnapshotManager;
+use WPMgr\Agent\Support\UpdateRunner;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Commands\UpdateCommand
+ */
+final class UpdateCommandSiteLockTest extends TestCase
+{
+    /** @var array<string,mixed> In-memory wp-option store. */
+    private array $options = [];
+
+    /** Absolute path to the `.maintenance` marker under the test ABSPATH. */
+    private string $maintenanceFile = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->options = [];
+        \WP_Upgrader::$failCreateLock = false;
+        SiteUpdateLock::resetForTests();
+
+        Functions\when('get_option')->alias(function (string $name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('update_option')->alias(function (string $name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('delete_option')->alias(function (string $name) {
+            unset($this->options[$name]);
+            return true;
+        });
+
+        $abspath = defined('ABSPATH') ? rtrim((string) constant('ABSPATH'), '/\\') : '';
+        if ($abspath !== '' && !is_dir($abspath)) {
+            mkdir($abspath, 0755, true);
+        }
+        $this->maintenanceFile = $abspath . '/.maintenance';
+        if (file_exists($this->maintenanceFile)) {
+            unlink($this->maintenanceFile); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        }
+    }
+
+    protected function tear_down(): void
+    {
+        if ($this->maintenanceFile !== '' && file_exists($this->maintenanceFile)) {
+            unlink($this->maintenanceFile); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        }
+        SiteUpdateLock::resetForTests();
+        \WP_Upgrader::$failCreateLock = false;
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * Pretend another REQUEST holds the site lock: take it, then drop this
+     * process's in-memory ownership while leaving the option store alone.
+     *
+     * @return void
+     */
+    private function anotherRequestHoldsTheLock(): void
+    {
+        $this->assertSame(SiteUpdateLock::ACQUIRED, SiteUpdateLock::acquire());
+        SiteUpdateLock::resetForTests();
+    }
+
+    /**
+     * A runner spy that records every call it is asked to make.
+     *
+     * @return UpdateRunner
+     */
+    private function spyRunner(): UpdateRunner
+    {
+        return new class extends UpdateRunner {
+            /** @var array<int,array{string,string,string}> */
+            public array $applied = [];
+            /** @var array<string,string> */
+            public array $versions = [];
+            /** @var int */
+            public int $reconciled = 0;
+
+            public function currentVersion(string $type, string $slug): string
+            {
+                return $this->versions[$type . ':' . $slug] ?? '';
+            }
+
+            public function isInstalled(string $type, string $slug): bool
+            {
+                return array_key_exists($type . ':' . $slug, $this->versions);
+            }
+
+            public function availableVersion(string $type, string $slug, string $requested): ?string
+            {
+                return $requested !== 'latest' ? $requested : '9.9.9';
+            }
+
+            public function apply(string $type, string $slug, string $version): array
+            {
+                $this->applied[] = [$type, $slug, $version];
+                $this->versions[$type . ':' . $slug] = $version === 'latest' ? '9.9.9' : $version;
+
+                return ['ok' => true, 'log' => 'applied', 'destination_touched' => true];
+            }
+
+            public function wpCliAvailable(): bool
+            {
+                return false;
+            }
+
+            public function isComplete(string $type, string $slug, string $expectedVersion = ''): bool
+            {
+                return true;
+            }
+        };
+    }
+
+    /**
+     * A snapshot spy that records everything and touches no disk.
+     *
+     * @return SnapshotManager
+     */
+    private function spySnapshots(): SnapshotManager
+    {
+        return new class extends SnapshotManager {
+            /** @var array<int,array{string,string,string}> */
+            public array $captured = [];
+            /** @var array<int,array{string,string,string}> */
+            public array $restored = [];
+            /** @var int */
+            public int $gcCalls = 0;
+
+            public function capture(string $type, string $slug, string $fromVersion): array
+            {
+                $this->captured[] = [$type, $slug, $fromVersion];
+
+                return ['snapshot_id' => 'snap_lock_test', 'log' => 'captured'];
+            }
+
+            public function restore(string $type, string $slug, string $snapshotId): array
+            {
+                $this->restored[] = [$type, $slug, $snapshotId];
+
+                return ['ok' => true, 'log' => 'restored'];
+            }
+
+            public function snapshotExists(string $snapshotId): bool
+            {
+                return true;
+            }
+        };
+    }
+
+    // ---- the refusal -----------------------------------------------------
+
+    public function test_a_busy_site_refuses_every_item_with_the_site_busy_status(): void
+    {
+        $this->anotherRequestHoldsTheLock();
+
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php'] = '5.0';
+        $runner->versions['plugin:hello/hello.php']     = '1.0';
+
+        $out = (new UpdateCommand($this->spySnapshots(), $runner))->execute([], [
+            'items' => [
+                ['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest'],
+                ['type' => 'plugin', 'slug' => 'hello/hello.php', 'version' => 'latest'],
+            ],
+        ]);
+
+        $this->assertFalse(
+            $out['ok'],
+            'ok MUST be false so an older control plane that does not know this status takes its safe '
+            . 'rejected-command path instead of the post-probe branch, which could record a never-run update as '
+            . 'succeeded'
+        );
+        $this->assertCount(2, $out['results']);
+        foreach ($out['results'] as $result) {
+            $this->assertSame('site_busy', $result['status']);
+            $this->assertSame('', $result['from_version']);
+            $this->assertSame('', $result['to_version']);
+            $this->assertSame('', $result['snapshot_id']);
+            $this->assertStringContainsString('Nothing was attempted', $result['log']);
+            $this->assertStringContainsString('nothing on this site was changed', $result['log']);
+        }
+        $this->assertSame(
+            ['type', 'slug', 'from_version', 'to_version', 'status', 'snapshot_id', 'log'],
+            array_keys($out['results'][0]),
+            'the refusal must use the existing item shape; no new wire fields'
+        );
+    }
+
+    /** THE SAFETY ASSERTION: a refused command writes nothing whatsoever. */
+    public function test_a_busy_refusal_touches_nothing_on_disk(): void
+    {
+        file_put_contents($this->maintenanceFile, '<?php $upgrading = ' . (time() - 400) . '; ?>');
+
+        $this->anotherRequestHoldsTheLock();
+
+        $runner    = $this->spyRunner();
+        $snapshots = $this->spySnapshots();
+        $runner->versions['plugin:akismet/akismet.php'] = '5.0';
+
+        (new UpdateCommand($snapshots, $runner))->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $this->assertSame([], $snapshots->captured, 'no snapshot may be captured for a refused command');
+        $this->assertSame([], $snapshots->restored, 'no restore may run for a refused command');
+        $this->assertSame([], $runner->applied, 'no apply may run for a refused command');
+        $this->assertFileExists(
+            $this->maintenanceFile,
+            'a refused command must not heal a stale flag either: the heal is below the lock precisely so a command '
+            . 'with nothing to do cannot strip a flag another in-flight upgrade owns'
+        );
+    }
+
+    /** The lock is released on every synchronous path, including a throw. */
+    public function test_the_lock_is_released_after_a_successful_command(): void
+    {
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php'] = '5.0';
+
+        (new UpdateCommand($this->spySnapshots(), $runner))->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $this->assertArrayNotHasKey('wpmgr_site_update.lock', $this->options);
+        $this->assertArrayNotHasKey('wpmgr_site_update_owner', $this->options);
+    }
+
+    public function test_the_lock_is_released_even_when_an_item_throws(): void
+    {
+        $runner = new class extends UpdateRunner {
+            /** @var array<string,string> */
+            public array $versions = ['plugin:akismet/akismet.php' => '5.0'];
+
+            public function currentVersion(string $type, string $slug): string
+            {
+                return $this->versions[$type . ':' . $slug] ?? '';
+            }
+
+            public function isInstalled(string $type, string $slug): bool
+            {
+                return true;
+            }
+
+            public function availableVersion(string $type, string $slug, string $requested): ?string
+            {
+                return '9.9.9';
+            }
+
+            public function apply(string $type, string $slug, string $version): array
+            {
+                throw new \RuntimeException('apply exploded');
+            }
+
+            public function wpCliAvailable(): bool
+            {
+                return false;
+            }
+        };
+
+        $out = (new UpdateCommand($this->spySnapshots(), $runner))->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $this->assertSame('failed', $out['results'][0]['status']);
+        $this->assertArrayNotHasKey(
+            'wpmgr_site_update.lock',
+            $this->options,
+            'a thrown item must not leave the site locked for 15 minutes'
+        );
+    }
+
+    /**
+     * ONE COMMAND, ONE HOLD, restamped between items. Without the renewal a
+     * legitimately long multi-item command could expire its own lock mid-run
+     * and let a second writer in.
+     */
+    public function test_a_multi_item_command_renews_the_lock_between_items(): void
+    {
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:a/a.php'] = '1.0';
+        $runner->versions['plugin:b/b.php'] = '1.0';
+        $runner->versions['plugin:c/c.php'] = '1.0';
+
+        $stamps = [];
+        Functions\when('update_option')->alias(function (string $name, $value) use (&$stamps) {
+            if ($name === 'wpmgr_site_update.lock') {
+                $stamps[] = $value;
+            }
+            $this->options[$name] = $value;
+            return true;
+        });
+
+        (new UpdateCommand($this->spySnapshots(), $runner))->execute([], [
+            'items' => [
+                ['type' => 'plugin', 'slug' => 'a/a.php', 'version' => 'latest'],
+                ['type' => 'plugin', 'slug' => 'b/b.php', 'version' => 'latest'],
+                ['type' => 'plugin', 'slug' => 'c/c.php', 'version' => 'latest'],
+            ],
+        ]);
+
+        // One write when the lock was taken plus one renewal per item.
+        $this->assertCount(4, $stamps);
+    }
+
+    // ---- the dry-run contract -------------------------------------------
+
+    /**
+     * THE F9 CONTRACT FIX UNDER TEST. A dry run takes no lock (so it can never
+     * block a real apply, and can never be blocked by one) and mutates nothing.
+     */
+    public function test_a_dry_run_takes_no_lock_and_still_answers_while_the_site_is_busy(): void
+    {
+        $this->anotherRequestHoldsTheLock();
+        $lockStampBefore = $this->options['wpmgr_site_update.lock'];
+
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php'] = '5.0';
+
+        $out = (new UpdateCommand($this->spySnapshots(), $runner))->execute([], [
+            'dry_run' => true,
+            'items'   => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $this->assertSame(
+            'would_update',
+            $out['results'][0]['status'],
+            'a preview must not be refused just because the site is applying something else'
+        );
+        $this->assertSame([], $runner->applied);
+        $this->assertSame(
+            $lockStampBefore,
+            $this->options['wpmgr_site_update.lock'],
+            'a dry run must neither take nor disturb the site lock'
+        );
+    }
+
+    /**
+     * A dry run on an IDLE site must not take the lock either, and must not
+     * reach any of the four writes that used to run before `dry_run` was even
+     * parsed.
+     */
+    public function test_a_dry_run_on_an_idle_site_writes_nothing_at_all(): void
+    {
+        file_put_contents($this->maintenanceFile, '<?php $upgrading = ' . (time() - 400) . '; ?>');
+
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php'] = '5.0';
+
+        $out = (new UpdateCommand($this->spySnapshots(), $runner))->execute([], [
+            'dry_run' => true,
+            'items'   => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $this->assertSame('would_update', $out['results'][0]['status']);
+        $this->assertSame(
+            [],
+            $this->options,
+            'a dry run must not write a single wp-option, including the site lock'
+        );
+        $this->assertFileExists(
+            $this->maintenanceFile,
+            'a dry run must not delete a stale maintenance flag; deleting a file is a mutation'
+        );
+    }
+
+    // ---- the fail-open branch -------------------------------------------
+
+    /**
+     * An UNAVAILABLE lock must PROCEED, not refuse. Core's own helper reports
+     * "locked" when its INSERT failed and no lock row is readable, and refusing
+     * on that reading would break every update on the affected site forever
+     * with no in-product remedy.
+     */
+    public function test_an_unavailable_lock_proceeds_rather_than_refusing(): void
+    {
+        \WP_Upgrader::$failCreateLock = true;
+
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:akismet/akismet.php'] = '5.0';
+
+        $out = (new UpdateCommand($this->spySnapshots(), $runner))->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'akismet/akismet.php', 'version' => 'latest']],
+        ]);
+
+        $this->assertSame('succeeded', $out['results'][0]['status']);
+        $this->assertCount(1, $runner->applied);
+    }
+}

--- a/apps/agent/tests/UpdateCommandTest.php
+++ b/apps/agent/tests/UpdateCommandTest.php
@@ -713,7 +713,22 @@ final class UpdateCommandTest extends TestCase
         );
     }
 
-    public function test_stale_maintenance_flag_is_healed_before_a_dry_run_starts(): void
+    /**
+     * GitHub issue #328 - DELIBERATE BEHAVIOUR CHANGE, and the old expectation
+     * is what was wrong.
+     *
+     * This test previously asserted that a DRY RUN heals a stale `.maintenance`
+     * flag. Deleting a file is a mutation, and the control-plane contract's
+     * hard rule is that `dry_run` must not mutate the site at all. The heal was
+     * one of four writes a dry run performed before `dry_run` was even parsed
+     * (the others: arming a shutdown callback that deletes any `.maintenance`
+     * it later finds, an in-flight reconcile that can perform a FULL DIRECTORY
+     * RESTORE, and a snapshot GC sweep that deletes). The heal itself is not
+     * lost: it now happens on every REAL run, under the site lock, which is the
+     * only kind of run that can have left a flag behind in the first place. The
+     * companion test below pins that.
+     */
+    public function test_a_dry_run_never_heals_a_stale_maintenance_flag(): void
     {
         file_put_contents($this->maintenanceFile, '<?php $upgrading = ' . time() . '; ?>');
         // Well past Maintenance's staleness threshold.
@@ -723,11 +738,29 @@ final class UpdateCommandTest extends TestCase
         $runner->versions['plugin:hello/hello.php'] = '1.7.2';
         $cmd = new UpdateCommand($this->spySnapshots(), $runner);
 
-        // dry_run never calls Maintenance::clear() — this isolates the
-        // start-of-run healStaleIfPresent() proactive heal.
         $cmd->execute([], [
             'dry_run' => true,
             'items'   => [['type' => 'plugin', 'slug' => 'hello/hello.php', 'version' => 'latest']],
+        ]);
+
+        $this->assertFileExists(
+            $this->maintenanceFile,
+            'a dry run must not delete anything, including a stale flag it would be entitled to heal on a real run'
+        );
+    }
+
+    /** The heal a dry run no longer performs still happens on a real run. */
+    public function test_stale_maintenance_flag_is_healed_before_a_real_run_starts(): void
+    {
+        file_put_contents($this->maintenanceFile, '<?php $upgrading = ' . time() . '; ?>');
+        touch($this->maintenanceFile, time() - 200);
+
+        $runner = $this->spyRunner();
+        $runner->versions['plugin:hello/hello.php'] = '1.7.2';
+        $cmd = new UpdateCommand($this->spySnapshots(), $runner);
+
+        $cmd->execute([], [
+            'items' => [['type' => 'plugin', 'slug' => 'hello/hello.php', 'version' => 'latest']],
         ]);
 
         $this->assertFileDoesNotExist(

--- a/apps/agent/tests/UpdateOutcomeClassifierTest.php
+++ b/apps/agent/tests/UpdateOutcomeClassifierTest.php
@@ -1,0 +1,471 @@
+<?php
+/**
+ * UpdateOutcomeClassifierTest - one case per pre-install error code, plus the
+ * three rules that make the classifier safe (GitHub issue #328).
+ *
+ * The tables are an ALLOWLIST audited against WordPress 7.0.2, not a proof.
+ * These tests exist so that editing one is a deliberate act: the per-code
+ * providers are generated FROM the constants, so adding a code without
+ * thinking about which side of the boundary it belongs on is impossible, and
+ * the count assertions fail the moment a table changes size.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use WPMgr\Agent\Support\UpdateOutcome;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\UpdateOutcome
+ */
+final class UpdateOutcomeClassifierTest extends TestCase
+{
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+    }
+
+    protected function tear_down(): void
+    {
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * Build a WP_Upgrader-shaped object whose skin reports the given error
+     * codes, the way WP_Ajax_Upgrader_Skin::get_errors() does. Self-contained
+     * anonymous classes, because Patchwork redefinitions leak across tests.
+     *
+     * @param array<string,string> $codes Code => error data.
+     * @return object
+     */
+    private function upgraderWithSkinErrors(array $codes): object
+    {
+        $errors = new class ($codes) {
+            /** @var array<string,string> */
+            private array $codes;
+
+            /** @param array<string,string> $codes Code => data. */
+            public function __construct(array $codes)
+            {
+                $this->codes = $codes;
+            }
+
+            /** @return array<int,string> */
+            public function get_error_codes(): array
+            {
+                return array_keys($this->codes);
+            }
+
+            /**
+             * @param string $code Error code.
+             * @return string
+             */
+            public function get_error_data(string $code = ''): string
+            {
+                return $this->codes[$code] ?? '';
+            }
+        };
+
+        $skin = new class ($errors) {
+            private object $errors;
+
+            /** @param object $errors WP_Error-shaped double. */
+            public function __construct(object $errors)
+            {
+                $this->errors = $errors;
+            }
+
+            /** @return object */
+            public function get_errors(): object
+            {
+                return $this->errors;
+            }
+        };
+
+        $upgrader = new \stdClass();
+        $upgrader->skin = $skin; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- mirrors WP_Upgrader's own public $skin property name exactly
+
+        return $upgrader;
+    }
+
+    /** @return array<string,array{string}> */
+    public static function untouchedCodeProvider(): array
+    {
+        $out = [];
+        foreach (UpdateOutcome::UNTOUCHED_CODES as $code) {
+            $out[$code] = [$code];
+        }
+
+        return $out;
+    }
+
+    /** @return array<string,array{string}> */
+    public static function touchedCodeProvider(): array
+    {
+        $out = [];
+        foreach (UpdateOutcome::TOUCHED_CODES as $code) {
+            $out[$code] = [$code];
+        }
+
+        return $out;
+    }
+
+    /**
+     * @dataProvider untouchedCodeProvider
+     *
+     * @param string $code Allowlisted pre-boundary code.
+     */
+    public function test_every_untouched_code_classifies_as_untouched(string $code): void
+    {
+        $out = UpdateOutcome::classify(null, $this->upgraderWithSkinErrors([$code => '']));
+
+        $this->assertFalse(
+            $out['destination_touched'],
+            $code . ' is allowlisted as returned above class-wp-upgrader.php:608 and must classify as untouched'
+        );
+        $this->assertSame($code, $out['code']);
+        $this->assertNotSame('unknown', $out['stage'], $code . ' must carry an operator-facing stage label');
+    }
+
+    /**
+     * @dataProvider touchedCodeProvider
+     *
+     * @param string $code Post-boundary code.
+     */
+    public function test_every_touched_code_classifies_as_touched(string $code): void
+    {
+        $out = UpdateOutcome::classify(null, $this->upgraderWithSkinErrors([$code => '']));
+
+        $this->assertTrue(
+            $out['destination_touched'],
+            $code . ' is reachable at or after class-wp-upgrader.php:608 and must classify as touched'
+        );
+        $this->assertSame($code, $out['code']);
+    }
+
+    /** A code in both tables would make the verdict order-dependent. */
+    public function test_no_code_appears_in_both_tables(): void
+    {
+        $this->assertSame(
+            [],
+            array_values(array_intersect(UpdateOutcome::UNTOUCHED_CODES, UpdateOutcome::TOUCHED_CODES))
+        );
+    }
+
+    /**
+     * Editing either table without revisiting these tests must fail loudly.
+     * Update the counts deliberately, after re-reading install_package().
+     */
+    public function test_table_sizes_are_pinned(): void
+    {
+        $this->assertCount(27, UpdateOutcome::UNTOUCHED_CODES);
+        $this->assertCount(14, UpdateOutcome::TOUCHED_CODES);
+    }
+
+    /**
+     * THE TEST THAT STOPS A REFACTOR DERIVING ONE TABLE FROM THE OTHER. Both
+     * temp-backup codes are stage `install`, but move_to_temp_backup_dir()
+     * returns fs_temp_backup_mkdir at class-wp-upgrader.php:1156, BEFORE its
+     * own move_dir() at :1170, and fs_temp_backup_move at :1172, after it.
+     * Stage and destination_touched are SEPARATE functions of the code.
+     */
+    public function test_the_two_temp_backup_codes_share_a_stage_and_disagree_on_touched(): void
+    {
+        $mkdir = UpdateOutcome::classify(null, $this->upgraderWithSkinErrors(['fs_temp_backup_mkdir' => '']));
+        $move  = UpdateOutcome::classify(null, $this->upgraderWithSkinErrors(['fs_temp_backup_move' => '']));
+
+        $this->assertSame('install', $mkdir['stage']);
+        $this->assertSame('install', $move['stage']);
+        $this->assertFalse($mkdir['destination_touched']);
+        $this->assertTrue($move['destination_touched']);
+    }
+
+    /**
+     * bad_request is emitted on BOTH sides of the boundary
+     * (class-wp-upgrader.php:541 and class-plugin-upgrader.php:575 above it,
+     * class-plugin-upgrader.php:684 below it), so it is unclassifiable by code
+     * alone and must resolve to null, which restores.
+     */
+    public function test_bad_request_is_in_neither_table_and_resolves_to_null(): void
+    {
+        $this->assertNotContains('bad_request', UpdateOutcome::UNTOUCHED_CODES);
+        $this->assertNotContains('bad_request', UpdateOutcome::TOUCHED_CODES);
+
+        $out = UpdateOutcome::classify(null, $this->upgraderWithSkinErrors(['bad_request' => '']));
+        $this->assertNull($out['destination_touched']);
+        $this->assertSame('unknown', $out['stage']);
+    }
+
+    /**
+     * `up_to_date` never reaches us as a skin CODE: class-plugin-upgrader.php:203
+     * passes the STRING, and WP_Ajax_Upgrader_Skin::error() rewrites string
+     * errors to unknown_upgrade_error_N. That path is FACT 1's job.
+     */
+    public function test_up_to_date_is_not_a_table_entry(): void
+    {
+        $this->assertNotContains('up_to_date', UpdateOutcome::UNTOUCHED_CODES);
+        $this->assertNotContains('up_to_date', UpdateOutcome::TOUCHED_CODES);
+    }
+
+    /** One touched code condemns the whole set, even beside allowlisted ones. */
+    public function test_one_touched_code_beats_every_untouched_one(): void
+    {
+        $out = UpdateOutcome::classify(null, $this->upgraderWithSkinErrors([
+            'download_failed'   => '',
+            'copy_failed_copy_dir' => '',
+        ]));
+
+        $this->assertTrue($out['destination_touched']);
+    }
+
+    /** One unrecognised code withholds the clean bill of health. */
+    public function test_one_unrecognised_code_withholds_the_verdict(): void
+    {
+        $out = UpdateOutcome::classify(null, $this->upgraderWithSkinErrors([
+            'download_failed'         => '',
+            'some_third_party_error'  => '',
+        ]));
+
+        $this->assertNull($out['destination_touched']);
+    }
+
+    // ---- FACT 1, the false identity -------------------------------------
+
+    /**
+     * Plugin_Upgrader::upgrade() returns literal false at
+     * class-plugin-upgrader.php:205 BEFORE run() at :224 when WordPress has no
+     * update entry for the target. Nothing ran, so nothing was touched. Without
+     * this rule, a benign race (the control plane says pending, WordPress's own
+     * transient disagrees because a sibling just cleared it) triggers a
+     * SPURIOUS restore.
+     */
+    public function test_false_identity_classifies_as_untouched(): void
+    {
+        $out = UpdateOutcome::classify(false, null);
+
+        $this->assertFalse($out['destination_touched']);
+        $this->assertSame('preflight', $out['stage']);
+        $this->assertSame(UpdateOutcome::CODE_NO_UPDATE_OFFERED, $out['code']);
+        $this->assertFalse($out['may_have_deactivated']);
+    }
+
+    /** The identity rule must not consult the skin at all. */
+    public function test_false_identity_ignores_skin_errors_entirely(): void
+    {
+        $out = UpdateOutcome::classify(false, $this->upgraderWithSkinErrors(['copy_failed_copy_dir' => '']));
+
+        $this->assertFalse($out['destination_touched']);
+        $this->assertSame(UpdateOutcome::CODE_NO_UPDATE_OFFERED, $out['code']);
+    }
+
+    /** @return array<string,array{mixed}> */
+    public static function notFalseProvider(): array
+    {
+        return [
+            'zero'         => [0],
+            'empty string' => [''],
+            'empty array'  => [[]],
+            'null'         => [null],
+        ];
+    }
+
+    /**
+     * @dataProvider notFalseProvider
+     *
+     * IDENTITY, not truthiness. A null result is the shape a real pre-install
+     * failure takes (Plugin_Upgrader::$result is shadowed uninitialised at
+     * class-plugin-upgrader.php:31, so upgrade() returns null at :250 to :251),
+     * and it must fall through to the skin, never take FACT 1's shortcut.
+     *
+     * @param mixed $result Falsy-but-not-false upgrader result.
+     */
+    public function test_falsy_results_that_are_not_false_do_not_take_the_identity_shortcut(mixed $result): void
+    {
+        $out = UpdateOutcome::classify($result, null);
+
+        $this->assertNull($out['destination_touched']);
+        $this->assertNotSame(UpdateOutcome::CODE_NO_UPDATE_OFFERED, $out['code']);
+    }
+
+    // ---- FACT 2, a WP_Error result --------------------------------------
+
+    public function test_a_wp_error_result_uses_its_own_code_and_data(): void
+    {
+        // Self-contained WP_Error-shaped double rather than the suite's shared
+        // one, whose constructor narrows $data to array while real WP_Error
+        // (and core's own download_failed at class-wp-upgrader.php:340) passes
+        // a string.
+        $error = new class {
+            /** @return string */
+            public function get_error_code(): string
+            {
+                return 'download_failed';
+            }
+
+            /**
+             * @param string $code Error code.
+             * @return string
+             */
+            public function get_error_data(string $code = ''): string
+            {
+                return 'https://example.test/x.zip';
+            }
+
+            /** @return string */
+            public function get_error_message(): string
+            {
+                return 'nope';
+            }
+        };
+
+        $out = UpdateOutcome::classify($error, null);
+
+        $this->assertSame('download_failed', $out['code']);
+        $this->assertSame('https://example.test/x.zip', $out['data']);
+        $this->assertSame('download', $out['stage']);
+        $this->assertFalse($out['destination_touched']);
+    }
+
+    // ---- THE REPORTED FAILURE -------------------------------------------
+
+    /**
+     * THE REGRESSION TEST FOR GitHub issue #328's own report: an unzip that
+     * fails with "Could not copy file." while extracting into
+     * wp-content/upgrade/. That is a pre-boundary failure and must never
+     * trigger a restore over an untouched plugin directory.
+     */
+    public function test_the_reported_failure_classifies_as_untouched_at_the_unpack_stage(): void
+    {
+        $out = UpdateOutcome::classify(
+            null,
+            $this->upgraderWithSkinErrors([
+                'copy_failed_ziparchive' => 'wp-seopress/vendor/psr/log/Psr/Log/Test/DummyTest.php',
+            ])
+        );
+
+        $this->assertFalse($out['destination_touched']);
+        $this->assertSame('unpack', $out['stage']);
+        $this->assertSame('copy_failed_ziparchive', $out['code']);
+        $this->assertSame('wp-seopress/vendor/psr/log/Psr/Log/Test/DummyTest.php', $out['data']);
+        $this->assertFalse(
+            $out['may_have_deactivated'],
+            'an unpack failure returns at class-wp-upgrader.php:888 to :894, before install_package() is called at '
+            . ':898, so core never reached the filter that deactivates the plugin'
+        );
+    }
+
+    // ---- may_have_deactivated -------------------------------------------
+
+    public function test_codes_at_or_after_the_pre_install_filter_report_possible_deactivation(): void
+    {
+        foreach (['source_read_failed', 'fs_temp_backup_mkdir', 'copy_failed_copy_dir'] as $code) {
+            $out = UpdateOutcome::classify(null, $this->upgraderWithSkinErrors([$code => '']));
+            $this->assertTrue($out['may_have_deactivated'], $code . ' arrives after upgrader_pre_install');
+        }
+    }
+
+    public function test_download_and_unpack_codes_never_report_possible_deactivation(): void
+    {
+        foreach (['no_package', 'download_failed', 'incompatible_archive', 'copy_failed_ziparchive'] as $code) {
+            $out = UpdateOutcome::classify(null, $this->upgraderWithSkinErrors([$code => '']));
+            $this->assertFalse($out['may_have_deactivated'], $code . ' arrives before install_package() is called');
+        }
+    }
+
+    // ---- sanitisation ----------------------------------------------------
+
+    public function test_a_hostile_code_is_replaced_rather_than_echoed(): void
+    {
+        $out = UpdateOutcome::classify(null, $this->upgraderWithSkinErrors(['DROP TABLE wp_options' => '']));
+
+        $this->assertSame(UpdateOutcome::CODE_UNRECOGNIZED, $out['code']);
+        $this->assertNull($out['destination_touched']);
+    }
+
+    public function test_error_data_is_bounded_and_stripped_of_control_characters(): void
+    {
+        $out = UpdateOutcome::classify(
+            null,
+            $this->upgraderWithSkinErrors(['copy_failed_ziparchive' => "a\x00b\x1F" . str_repeat('x', 400)])
+        );
+
+        $this->assertLessThanOrEqual(203, strlen($out['data']));
+        $this->assertStringNotContainsString("\x00", $out['data']);
+        $this->assertStringNotContainsString("\x1F", $out['data']);
+    }
+
+    // ---- shapes we cannot read ------------------------------------------
+
+    public function test_a_skin_without_get_errors_resolves_to_null(): void
+    {
+        $upgrader = new \stdClass();
+        $upgrader->skin = new \stdClass(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- mirrors WP_Upgrader's own public $skin property name exactly
+
+        $out = UpdateOutcome::classify(null, $upgrader);
+        $this->assertNull($out['destination_touched']);
+        $this->assertSame('', $out['code']);
+    }
+
+    public function test_a_throwing_skin_resolves_to_null_rather_than_propagating(): void
+    {
+        $skin = new class {
+            /** @return object */
+            public function get_errors(): object
+            {
+                throw new \RuntimeException('skin exploded');
+            }
+        };
+        $upgrader = new \stdClass();
+        $upgrader->skin = $skin; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- mirrors WP_Upgrader's own public $skin property name exactly
+
+        $out = UpdateOutcome::classify(null, $upgrader);
+        $this->assertNull($out['destination_touched']);
+    }
+
+    public function test_a_successful_result_is_never_classified_untouched(): void
+    {
+        $out = UpdateOutcome::classify(['destination' => '/x'], null);
+
+        $this->assertNull($out['destination_touched'], 'classify() only speaks about failures; the caller decides');
+    }
+
+    // ---- the standing prohibition ---------------------------------------
+
+    /**
+     * NOTHING on this path may set wp_doing_cron(). Pretending to be cron
+     * inside a REST request re-enables WordPress's own background updater
+     * (wp-includes/update.php:331 and :885 to :891) inside the very window we
+     * are holding the site's update lock for. The single most likely wrong
+     * future edit, because it would make core enable maintenance mode for us
+     * for free and would look like a simplification.
+     */
+    public function test_no_restore_skip_source_file_sets_wp_doing_cron(): void
+    {
+        $files = [
+            'includes/support/class-update-outcome.php',
+            'includes/support/class-destination-verifier.php',
+            'includes/support/class-site-update-lock.php',
+            'includes/commands/class-update-command.php',
+        ];
+
+        foreach ($files as $relative) {
+            $source = (string) file_get_contents(dirname(__DIR__) . '/' . $relative);
+            $source = (string) preg_replace('#/\*.*?\*/#s', '', $source);
+            $source = (string) preg_replace('#//[^\n]*#', '', $source);
+
+            $this->assertStringNotContainsString('DOING_CRON', $source, $relative . ' must not define DOING_CRON');
+            $this->assertStringNotContainsString(
+                'wp_doing_cron',
+                $source,
+                $relative . ' must not touch wp_doing_cron()'
+            );
+        }
+    }
+}

--- a/apps/agent/tests/bootstrap.php
+++ b/apps/agent/tests/bootstrap.php
@@ -482,12 +482,31 @@ if (!class_exists('WP_Upgrader')) {
     class WP_Upgrader
     {
         /**
+         * Make create_lock() fail the way core's own helper can fail for an
+         * INFRASTRUCTURE reason rather than because the lock is held: its
+         * `INSERT IGNORE` is MySQL syntax, so on a rewritten database backend
+         * or an options table that refuses the write, $wpdb->query() returns
+         * false and no lock row is ever created. Core then conflates that with
+         * "locked" (class-wp-upgrader.php:1067 to :1072). SiteUpdateLock must
+         * report UNAVAILABLE, not HELD_BY_OTHER, for that case; this switch is
+         * the only way to reach it. Tests MUST reset it in tear-down, since
+         * statics are process-global across this non-isolated suite.
+         *
+         * @var bool
+         */
+        public static bool $failCreateLock = false;
+
+        /**
          * @param string   $lock_name       Lock name.
          * @param int|null $release_timeout Seconds the lock is respected.
          * @return bool True when this caller now owns the lock.
          */
         public static function create_lock($lock_name, $release_timeout = null): bool
         {
+            if (self::$failCreateLock) {
+                return false;
+            }
+
             $releaseTimeout = (int) ($release_timeout ?: 3600);
             $option         = $lock_name . '.lock';
             $existing       = (int) get_option($option, 0);

--- a/apps/agent/tests/fixtures/site-update-lock-child.php
+++ b/apps/agent/tests/fixtures/site-update-lock-child.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Child process for SiteUpdateLockConcurrencyTest.
+ *
+ * Runs the REAL WPMgr\Agent\Support\SiteUpdateLock against a file-backed
+ * option store whose lock row is created under an exclusive flock(), which is a
+ * genuine OS-level compare-and-set. That is deliberately the same SHAPE as the
+ * primitive SiteUpdateLock is built on in production (WordPress core's single
+ * `INSERT IGNORE` at wp-admin/includes/class-wp-upgrader.php:1065), which this
+ * project does not reimplement and must not claim to have tested. What IS under
+ * test here is the logic layered on top of it: the three-way acquire verdict,
+ * the owner token, and release, across two real OS processes.
+ *
+ * Usage: php site-update-lock-child.php <store-file> <log-file> <hold-ms>
+ *
+ * Appends one of:
+ *   ENTER <pid> <microtime>   acquired
+ *   EXIT  <pid> <microtime>   released
+ *   BUSY  <pid>               refused because another process held it
+ *   UNAVAILABLE <pid>         could not evaluate the lock at all
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+// The agent's classes guard on ABSPATH; nothing here reads a real WordPress.
+define('ABSPATH', __DIR__ . '/');
+
+$storeFile = (string) ($argv[1] ?? '');
+$logFile   = (string) ($argv[2] ?? '');
+$holdMs    = (int) ($argv[3] ?? 0);
+
+if ($storeFile === '' || $logFile === '') {
+    fwrite(STDERR, "usage: site-update-lock-child.php <store> <log> <hold-ms>\n");
+    exit(2);
+}
+
+$GLOBALS['wpmgr_lock_store_file'] = $storeFile;
+
+/**
+ * Read the whole option store.
+ *
+ * @return array<string,mixed>
+ */
+function wpmgr_test_store_read(): array
+{
+    $raw = @file_get_contents((string) $GLOBALS['wpmgr_lock_store_file']);
+    if (!is_string($raw) || $raw === '') {
+        return [];
+    }
+    $decoded = json_decode($raw, true);
+
+    return is_array($decoded) ? $decoded : [];
+}
+
+/**
+ * Write the whole option store ATOMICALLY.
+ *
+ * Write-then-rename, not file_put_contents in place. A plain in-place write
+ * truncates the file before the new bytes land, and the lock row is read
+ * OUTSIDE the guard lock (exactly as WordPress reads get_option outside its own
+ * INSERT), so a concurrent reader could see an empty file and conclude the lock
+ * was unreadable rather than held. That would make this fixture, not the code
+ * under test, decide the result. Real WordPress reads this row out of MySQL,
+ * where the same guarantee is free.
+ *
+ * @param array<string,mixed> $store Options.
+ * @return void
+ */
+function wpmgr_test_store_write(array $store): void
+{
+    $target = (string) $GLOBALS['wpmgr_lock_store_file'];
+    $tmp    = $target . '.' . getmypid() . '.tmp';
+    file_put_contents($tmp, (string) json_encode($store));
+    rename($tmp, $target);
+}
+
+/**
+ * @param string $option  Option name.
+ * @param mixed  $default Default value.
+ * @return mixed
+ */
+function get_option(string $option, $default = false)
+{
+    $store = wpmgr_test_store_read();
+
+    return $store[$option] ?? $default;
+}
+
+/**
+ * @param string $option   Option name.
+ * @param mixed  $value    Value.
+ * @param mixed  $autoload Ignored.
+ * @return bool
+ */
+function update_option(string $option, $value, $autoload = null): bool
+{
+    $store           = wpmgr_test_store_read();
+    $store[$option]  = $value;
+    wpmgr_test_store_write($store);
+
+    return true;
+}
+
+/**
+ * @param string $option Option name.
+ * @return bool
+ */
+function delete_option(string $option): bool
+{
+    $store = wpmgr_test_store_read();
+    unset($store[$option]);
+    wpmgr_test_store_write($store);
+
+    return true;
+}
+
+/**
+ * WP_Upgrader double whose create_lock() performs its insert-if-absent step
+ * under an exclusive flock, giving the same atomicity guarantee core's
+ * `INSERT IGNORE` provides.
+ */
+class WP_Upgrader
+{
+    /**
+     * @param string   $lock_name       Lock name.
+     * @param int|null $release_timeout Seconds an existing lock is respected.
+     * @return bool
+     */
+    public static function create_lock($lock_name, $release_timeout = null): bool
+    {
+        $releaseTimeout = (int) ($release_timeout ?: 3600);
+        $option         = $lock_name . '.lock';
+        $guard          = (string) $GLOBALS['wpmgr_lock_store_file'] . '.guard';
+
+        $handle = fopen($guard, 'c');
+        if ($handle === false) {
+            return false;
+        }
+        if (!flock($handle, LOCK_EX)) {
+            fclose($handle);
+
+            return false;
+        }
+
+        try {
+            $store    = wpmgr_test_store_read();
+            $existing = isset($store[$option]) ? (int) $store[$option] : 0;
+
+            if ($existing > 0 && $existing > (time() - $releaseTimeout)) {
+                return false;
+            }
+
+            $store[$option] = time();
+            wpmgr_test_store_write($store);
+
+            return true;
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
+    }
+
+    /**
+     * @param string $lock_name Lock name.
+     * @return bool
+     */
+    public static function release_lock($lock_name): bool
+    {
+        return delete_option($lock_name . '.lock');
+    }
+}
+
+require_once dirname(__DIR__, 2) . '/includes/support/class-debug-log.php';
+require_once dirname(__DIR__, 2) . '/includes/support/class-site-update-lock.php';
+
+/**
+ * Append one line to the shared observation log.
+ *
+ * @param string $line Line to append.
+ * @return void
+ */
+function wpmgr_test_log(string $line): void
+{
+    file_put_contents((string) ($GLOBALS['wpmgr_lock_log_file'] ?? ''), $line . "\n", FILE_APPEND | LOCK_EX);
+}
+
+$GLOBALS['wpmgr_lock_log_file'] = $logFile;
+
+$state = \WPMgr\Agent\Support\SiteUpdateLock::acquire();
+$pid   = (string) getmypid();
+
+if ($state === \WPMgr\Agent\Support\SiteUpdateLock::ACQUIRED) {
+    wpmgr_test_log('ENTER ' . $pid . ' ' . microtime(true));
+    usleep($holdMs * 1000);
+    wpmgr_test_log('EXIT ' . $pid . ' ' . microtime(true));
+    \WPMgr\Agent\Support\SiteUpdateLock::release();
+    exit(0);
+}
+
+if ($state === \WPMgr\Agent\Support\SiteUpdateLock::HELD_BY_OTHER) {
+    wpmgr_test_log('BUSY ' . $pid);
+    exit(0);
+}
+
+wpmgr_test_log('UNAVAILABLE ' . $pid);
+exit(0);

--- a/apps/agent/tests/wp-stubs.php
+++ b/apps/agent/tests/wp-stubs.php
@@ -581,3 +581,46 @@ if (!function_exists('wp_json_encode')) {
         return json_encode($data, $options, $depth);
     }
 }
+
+if (!function_exists('get_file_data')) {
+    /**
+     * Reads header fields out of the first 8KB of a file, the way WordPress's
+     * own get_file_data() (wp-includes/functions.php) does.
+     *
+     * Faithful enough for the destination verifier's positive header re-read:
+     * same 8KB window, same BOM/line-ending normalisation and the same
+     * per-header regex core uses. Deliberately omits core's `extra_$context`
+     * filter and its _cleanup_header_comment() markdown-link trimming, neither
+     * of which any agent code path depends on.
+     *
+     * @param string                $file    Absolute path to read.
+     * @param array<string,string>  $headers Key => header label.
+     * @param string                $context Unused; mirrors core's signature.
+     * @return array<string,string>
+     */
+    function get_file_data(string $file, array $headers, string $context = ''): array
+    {
+        $handle = @fopen($file, 'r'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- test stub mirroring core's own fopen-based header read
+        if ($handle === false) {
+            $data = '';
+        } else {
+            $data = (string) fread($handle, 8192); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread -- test stub
+            fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- test stub
+        }
+
+        // Core strips a UTF-8 BOM and normalises line endings before matching.
+        $data = str_replace("\r", "\n", preg_replace('/^\xEF\xBB\xBF/', '', $data) ?? '');
+
+        $out = [];
+        foreach ($headers as $field => $label) {
+            $pattern = '/^(?:[ \t]*<\?php)?[ \t\/*#@]*' . preg_quote($label, '/') . ':(.*)$/mi';
+            if (preg_match($pattern, $data, $match) === 1 && $match[1] !== '') {
+                $out[$field] = trim(preg_replace('/\s*(?:\*\/|\?>).*/', '', $match[1]) ?? '');
+            } else {
+                $out[$field] = '';
+            }
+        }
+
+        return $out;
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.112
+ * Version:           0.61.114
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.112');
+define('WPMGR_AGENT_VERSION', '0.61.114');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/api/db/query/updates.sql
+++ b/apps/api/db/query/updates.sql
@@ -103,6 +103,89 @@ WHERE id = $1 AND tenant_id = $2
   AND status IN ('pending', 'running')
 RETURNING *;
 
+-- name: SiteHasRunningUpdateTask :one
+-- GH #328 per-site serialisation pre-check (INVARIANT R). Is a command
+-- CURRENTLY IN FLIGHT to this site? Deliberately best-effort and read-only:
+-- the AGENT's own site-update lock is the authoritative bound (WP_Upgrader::
+-- create_lock, see the agent lane). A missed collision here costs one HTTP
+-- round trip the agent itself refuses, which the worker then defers; it is
+-- not a correctness gap. Do NOT "fix" this with an advisory lock or a
+-- conditional claim across the round trip — the guarantee is not here.
+--
+-- status = 'running' means exactly "dispatched and not yet resolved"
+-- (INVARIANT R). DeferUpdateTaskToPending is what keeps that true: a task
+-- WAITING for this site is 'pending' and therefore can never itself match
+-- this predicate. That is why a waiter can never block a sibling waiter:
+-- waiters depend only on runners, and runners depend on nothing (every River
+-- job for this worker exits within its own job timeout, whether the site
+-- answers or not), so the wait-for graph has no cycle.
+--
+-- target_type <> 'agent' is NOT an optimisation. An agent self-update task
+-- stays 'running' for its whole confirmation window (20m, or 90m on external
+-- cron; see agentConfirmDeadline/agentConfirmDeadlineExternalCron), during
+-- which the site's writer is NOT held: the apply happens after the ARM's
+-- HTTP response has already been released, and from then on the agent polls
+-- its OWN site lock directly. Counting a running agent-task row here would
+-- block every plugin/theme/core update on that site for up to 90 minutes for
+-- no reason; the agent's own lock is what serialises the two channels in
+-- both directions.
+--
+-- The staleness clause bounds a crashed worker: a row whose command went out
+-- longer ago than @hold_max cannot have a live worker behind it (River
+-- cancels the job's context at its own job timeout regardless of whether the
+-- site answers). Ignoring such a row only makes the gate MORE permissive
+-- (lets a sibling dispatch it would otherwise have deferred), never less,
+-- which is safe — the agent's own lock is still the backstop either way.
+-- coalesce(started_at, updated_at) covers a row observed between
+-- MarkUpdateTaskRunning (which sets both) and any later touch.
+--
+-- Rides the existing update_tasks_site_id_idx (m3). No new column and no new
+-- index: every predicate here reads columns update_tasks already has, and
+-- the row is bounded to one site at a time by that existing index, so no
+-- schema migration is needed for this gate.
+SELECT EXISTS (
+    SELECT 1 FROM update_tasks
+    WHERE site_id = @site_id
+      AND tenant_id = @tenant_id
+      AND id <> @exclude_task_id
+      AND target_type <> 'agent'
+      AND status = 'running'
+      AND coalesce(started_at, updated_at) > now() - @hold_max::interval
+);
+
+-- name: DeferUpdateTaskToPending :one
+-- GH #328. Records that this task is WAITING for its site (busy with
+-- another update) and is NOT talking to it right now. The status write is
+-- the whole point: a waiting task must not look 'running' to
+-- SiteHasRunningUpdateTask above, to CountRunningTasksForTenant (so one busy
+-- site consumes ONE of the tenant's parallelism slots rather than one per
+-- deferred sibling), or to an operator watching the run.
+--
+-- started_at is cleared because it would otherwise be a lie (the task is not
+-- currently running); MarkUpdateTaskRunning sets it again on the next real
+-- dispatch. updated_at = now() is what keeps ListStaleUpdateTasks off a row a
+-- live worker is actively minding: this statement is only ever issued from
+-- inside Worker.Work, so a fresh updated_at is EVIDENCE a River job is still
+-- behind the row, not merely an assertion. When the job is lost (a crashed
+-- worker, a dropped queue) the watermark freezes and the periodic reaper
+-- (ListStaleUpdateTasks) claims the row after its own threshold, exactly as
+-- it would for any other stuck task — a busy task never becomes immortal.
+--
+-- The status precondition mirrors FinishUpdateTask's: a task a halt already
+-- terminalized matches no row, and the caller (Worker.deferForBusySite) must
+-- stop rather than snooze — the recorded terminal outcome wins. IN
+-- ('pending','running') rather than = 'running' so a task that is ALREADY
+-- pending (the pre-dispatch gate case: nothing was ever sent) can still
+-- record the wait detail idempotently.
+UPDATE update_tasks
+SET status     = 'pending',
+    started_at = NULL,
+    detail     = @detail,
+    updated_at = now()
+WHERE id = @id AND tenant_id = @tenant_id
+  AND status IN ('pending', 'running')
+RETURNING *;
+
 -- name: CancelPendingUpdateTask :one
 -- Cancels ONE not-yet-dispatched task as part of halting its run.
 --
@@ -116,6 +199,13 @@ RETURNING *;
 -- operator hit the kill switch and most needs to know. Running tasks are left
 -- to be resolved by their own confirmation job; the run is halted, so no
 -- further wave can open behind them.
+--
+-- GH #328: a task DeferUpdateTaskToPending moved back to 'pending' MAY have
+-- had one earlier command sent that the site refused before touching
+-- anything (or one that never reached the agent at all), so 'pending' here
+-- means "nothing was ever APPLIED to this site", not literally "never
+-- contacted". That is still exactly what 'cancelled' is allowed to mean:
+-- nothing on the site changed as a result, whichever of those two it was.
 UPDATE update_tasks
 SET status = 'cancelled',
     detail = $3,

--- a/apps/api/internal/agentcmd/contract.go
+++ b/apps/api/internal/agentcmd/contract.go
@@ -74,7 +74,7 @@ type UpdateRequest struct {
 //	to_version   the version present AFTER the update (the available version on a
 //	             dry run; equals from_version when nothing would change).
 //	status       "succeeded" | "failed" | "skipped" | "would_update" (dry run) |
-//	             "up_to_date".
+//	             "up_to_date" | "site_busy".
 //	snapshot_id  opaque token the agent returns when it took a pre-update
 //	             snapshot; the CP echoes it back in a rollback command.
 //	log          short human-readable detail (WP-CLI output tail / error text).
@@ -95,6 +95,20 @@ const (
 	ItemSkipped     = "skipped"
 	ItemUpToDate    = "up_to_date"
 	ItemWouldUpdate = "would_update" // dry-run only
+
+	// ItemSiteBusy (GH #328) reports that this site's update lock is held by
+	// another in-flight update, rollback, or agent self-update, and the agent
+	// attempted NOTHING for this item: no file was touched, no snapshot was
+	// taken, no plugin/theme state changed. Log carries a short human
+	// sentence explaining why.
+	//
+	// This is the ONE wire contract both the agent and the control plane
+	// build to for GH #328's serialisation piece; do not invent a second
+	// shape for it. The control plane MUST NOT treat this as a terminal
+	// result the way ItemFailed is: see update.Worker.deferForBusySite, which
+	// defers the task back to 'pending' and retries later instead of
+	// recording TaskFailed.
+	ItemSiteBusy = "site_busy"
 )
 
 // UpdateResponse is the agent's response to the `update` command.
@@ -172,18 +186,17 @@ type PingRequest struct{}
 
 // PingResponse is the agent's response to the `ping` command.
 //
-//   ok                    true iff the agent handled the command.
-//   agent_version         the agent's build version string.
-//   php_time              Unix timestamp as seen from PHP (sanity clock check).
-//   wp_cron_disabled      true when DISABLE_WP_CRON is set (explains why
-//                         passive heartbeats stopped; the site is still alive).
-//   heartbeat_overdue_sec seconds since the last WP-Cron-driven heartbeat, or
-//                         null when no heartbeat has been recorded locally.
+//	ok                    true iff the agent handled the command.
+//	agent_version         the agent's build version string.
+//	php_time              Unix timestamp as seen from PHP (sanity clock check).
+//	wp_cron_disabled      true when DISABLE_WP_CRON is set (explains why
+//	                      passive heartbeats stopped; the site is still alive).
+//	heartbeat_overdue_sec seconds since the last WP-Cron-driven heartbeat, or
+//	                      null when no heartbeat has been recorded locally.
 type PingResponse struct {
-	OK                 bool   `json:"ok"`
-	AgentVersion       string `json:"agent_version"`
-	PHPTime            int64  `json:"php_time"`
-	WPCronDisabled     bool   `json:"wp_cron_disabled"`
+	OK                  bool   `json:"ok"`
+	AgentVersion        string `json:"agent_version"`
+	PHPTime             int64  `json:"php_time"`
+	WPCronDisabled      bool   `json:"wp_cron_disabled"`
 	HeartbeatOverdueSec *int64 `json:"heartbeat_overdue_sec"`
 }
-

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -12,6 +12,21 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+type AgentMirrorState struct {
+	ID                  int32              `json:"id"`
+	LastRequestAt       pgtype.Timestamptz `json:"last_request_at"`
+	LastAttemptAt       pgtype.Timestamptz `json:"last_attempt_at"`
+	LastAttemptOutcome  *string            `json:"last_attempt_outcome"`
+	LastAttemptDetail   *string            `json:"last_attempt_detail"`
+	LastAttemptTrigger  *string            `json:"last_attempt_trigger"`
+	LastSuccessAt       pgtype.Timestamptz `json:"last_success_at"`
+	LastSuccessOutcome  *string            `json:"last_success_outcome"`
+	LastSuccessVersion  *string            `json:"last_success_version"`
+	LastMirroredAt      pgtype.Timestamptz `json:"last_mirrored_at"`
+	LastMirroredVersion *string            `json:"last_mirrored_version"`
+	UpdatedAt           time.Time          `json:"updated_at"`
+}
+
 type AgentNonce struct {
 	ID        uuid.UUID `json:"id"`
 	SiteID    uuid.UUID `json:"site_id"`

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -238,6 +238,13 @@ type Querier interface {
 	// operator hit the kill switch and most needs to know. Running tasks are left
 	// to be resolved by their own confirmation job; the run is halted, so no
 	// further wave can open behind them.
+	//
+	// GH #328: a task DeferUpdateTaskToPending moved back to 'pending' MAY have
+	// had one earlier command sent that the site refused before touching
+	// anything (or one that never reached the agent at all), so 'pending' here
+	// means "nothing was ever APPLIED to this site", not literally "never
+	// contacted". That is still exactly what 'cancelled' is allowed to mean:
+	// nothing on the site changed as a result, whichever of those two it was.
 	CancelPendingUpdateTask(ctx context.Context, arg CancelPendingUpdateTaskParams) (UpdateTask, error)
 	// Advance next_digest_at to the next period as a conditional claim.
 	// Returns the updated row if the claim succeeds (next_digest_at still <= now(),
@@ -406,6 +413,30 @@ type Querier interface {
 	// is NEVER consulted for a delete. Retained only so the generated querier keeps
 	// compiling; the GC delete path no longer calls it.
 	DecrementChunkRefcount(ctx context.Context, arg DecrementChunkRefcountParams) (DecrementChunkRefcountRow, error)
+	// GH #328. Records that this task is WAITING for its site (busy with
+	// another update) and is NOT talking to it right now. The status write is
+	// the whole point: a waiting task must not look 'running' to
+	// SiteHasRunningUpdateTask above, to CountRunningTasksForTenant (so one busy
+	// site consumes ONE of the tenant's parallelism slots rather than one per
+	// deferred sibling), or to an operator watching the run.
+	//
+	// started_at is cleared because it would otherwise be a lie (the task is not
+	// currently running); MarkUpdateTaskRunning sets it again on the next real
+	// dispatch. updated_at = now() is what keeps ListStaleUpdateTasks off a row a
+	// live worker is actively minding: this statement is only ever issued from
+	// inside Worker.Work, so a fresh updated_at is EVIDENCE a River job is still
+	// behind the row, not merely an assertion. When the job is lost (a crashed
+	// worker, a dropped queue) the watermark freezes and the periodic reaper
+	// (ListStaleUpdateTasks) claims the row after its own threshold, exactly as
+	// it would for any other stuck task — a busy task never becomes immortal.
+	//
+	// The status precondition mirrors FinishUpdateTask's: a task a halt already
+	// terminalized matches no row, and the caller (Worker.deferForBusySite) must
+	// stop rather than snooze — the recorded terminal outcome wins. IN
+	// ('pending','running') rather than = 'running' so a task that is ALREADY
+	// pending (the pre-dispatch gate case: nothing was ever sent) can still
+	// record the wait detail idempotently.
+	DeferUpdateTaskToPending(ctx context.Context, arg DeferUpdateTaskToPendingParams) (UpdateTask, error)
 	// Purge all recovery codes for a user (before inserting a regenerated batch).
 	DeleteAllRecoveryCodes(ctx context.Context, userID uuid.UUID) error
 	DeleteBackupSnapshot(ctx context.Context, arg DeleteBackupSnapshotParams) (int64, error)
@@ -1886,6 +1917,46 @@ type Querier interface {
 	// Toggle two_factor_enabled without touching the secret (disable path).
 	// The secret and confirmed_at are intentionally retained for audit purposes.
 	SetUserTwoFactorEnabled(ctx context.Context, arg SetUserTwoFactorEnabledParams) error
+	// GH #328 per-site serialisation pre-check (INVARIANT R). Is a command
+	// CURRENTLY IN FLIGHT to this site? Deliberately best-effort and read-only:
+	// the AGENT's own site-update lock is the authoritative bound (WP_Upgrader::
+	// create_lock, see the agent lane). A missed collision here costs one HTTP
+	// round trip the agent itself refuses, which the worker then defers; it is
+	// not a correctness gap. Do NOT "fix" this with an advisory lock or a
+	// conditional claim across the round trip — the guarantee is not here.
+	//
+	// status = 'running' means exactly "dispatched and not yet resolved"
+	// (INVARIANT R). DeferUpdateTaskToPending is what keeps that true: a task
+	// WAITING for this site is 'pending' and therefore can never itself match
+	// this predicate. That is why a waiter can never block a sibling waiter:
+	// waiters depend only on runners, and runners depend on nothing (every River
+	// job for this worker exits within its own job timeout, whether the site
+	// answers or not), so the wait-for graph has no cycle.
+	//
+	// target_type <> 'agent' is NOT an optimisation. An agent self-update task
+	// stays 'running' for its whole confirmation window (20m, or 90m on external
+	// cron; see agentConfirmDeadline/agentConfirmDeadlineExternalCron), during
+	// which the site's writer is NOT held: the apply happens after the ARM's
+	// HTTP response has already been released, and from then on the agent polls
+	// its OWN site lock directly. Counting a running agent-task row here would
+	// block every plugin/theme/core update on that site for up to 90 minutes for
+	// no reason; the agent's own lock is what serialises the two channels in
+	// both directions.
+	//
+	// The staleness clause bounds a crashed worker: a row whose command went out
+	// longer ago than @hold_max cannot have a live worker behind it (River
+	// cancels the job's context at its own job timeout regardless of whether the
+	// site answers). Ignoring such a row only makes the gate MORE permissive
+	// (lets a sibling dispatch it would otherwise have deferred), never less,
+	// which is safe — the agent's own lock is still the backstop either way.
+	// coalesce(started_at, updated_at) covers a row observed between
+	// MarkUpdateTaskRunning (which sets both) and any later touch.
+	//
+	// Rides the existing update_tasks_site_id_idx (m3). No new column and no new
+	// index: every predicate here reads columns update_tasks already has, and
+	// the row is bounded to one site at a time by that existing index, so no
+	// schema migration is needed for this gate.
+	SiteHasRunningUpdateTask(ctx context.Context, arg SiteHasRunningUpdateTaskParams) (bool, error)
 	// SoftDeleteTenant sets deleted_at (GH #152 Lane B — populated org). The read-
 	// path filters above (plus ListMembershipsForUser / GetAPIKeyByPrefix) hide the
 	// org everywhere the instant this commits. The WHERE guard makes a concurrent

--- a/apps/api/internal/db/sqlc/updates.sql.go
+++ b/apps/api/internal/db/sqlc/updates.sql.go
@@ -42,6 +42,13 @@ type CancelPendingUpdateTaskParams struct {
 // operator hit the kill switch and most needs to know. Running tasks are left
 // to be resolved by their own confirmation job; the run is halted, so no
 // further wave can open behind them.
+//
+// GH #328: a task DeferUpdateTaskToPending moved back to 'pending' MAY have
+// had one earlier command sent that the site refused before touching
+// anything (or one that never reached the agent at all), so 'pending' here
+// means "nothing was ever APPLIED to this site", not literally "never
+// contacted". That is still exactly what 'cancelled' is allowed to mean:
+// nothing on the site changed as a result, whichever of those two it was.
 func (q *Queries) CancelPendingUpdateTask(ctx context.Context, arg CancelPendingUpdateTaskParams) (UpdateTask, error) {
 	row := q.db.QueryRow(ctx, cancelPendingUpdateTask, arg.ID, arg.TenantID, arg.Detail)
 	var i UpdateTask
@@ -179,6 +186,70 @@ func (q *Queries) CreateUpdateTask(ctx context.Context, arg CreateUpdateTaskPara
 		arg.DesiredVersion,
 		arg.FromVersion,
 	)
+	var i UpdateTask
+	err := row.Scan(
+		&i.ID,
+		&i.RunID,
+		&i.TenantID,
+		&i.SiteID,
+		&i.TargetType,
+		&i.TargetSlug,
+		&i.DesiredVersion,
+		&i.FromVersion,
+		&i.ToVersion,
+		&i.Status,
+		&i.Detail,
+		&i.Error,
+		&i.StartedAt,
+		&i.FinishedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const deferUpdateTaskToPending = `-- name: DeferUpdateTaskToPending :one
+UPDATE update_tasks
+SET status     = 'pending',
+    started_at = NULL,
+    detail     = $1,
+    updated_at = now()
+WHERE id = $2 AND tenant_id = $3
+  AND status IN ('pending', 'running')
+RETURNING id, run_id, tenant_id, site_id, target_type, target_slug, desired_version, from_version, to_version, status, detail, error, started_at, finished_at, created_at, updated_at
+`
+
+type DeferUpdateTaskToPendingParams struct {
+	Detail   string    `json:"detail"`
+	ID       uuid.UUID `json:"id"`
+	TenantID uuid.UUID `json:"tenant_id"`
+}
+
+// GH #328. Records that this task is WAITING for its site (busy with
+// another update) and is NOT talking to it right now. The status write is
+// the whole point: a waiting task must not look 'running' to
+// SiteHasRunningUpdateTask above, to CountRunningTasksForTenant (so one busy
+// site consumes ONE of the tenant's parallelism slots rather than one per
+// deferred sibling), or to an operator watching the run.
+//
+// started_at is cleared because it would otherwise be a lie (the task is not
+// currently running); MarkUpdateTaskRunning sets it again on the next real
+// dispatch. updated_at = now() is what keeps ListStaleUpdateTasks off a row a
+// live worker is actively minding: this statement is only ever issued from
+// inside Worker.Work, so a fresh updated_at is EVIDENCE a River job is still
+// behind the row, not merely an assertion. When the job is lost (a crashed
+// worker, a dropped queue) the watermark freezes and the periodic reaper
+// (ListStaleUpdateTasks) claims the row after its own threshold, exactly as
+// it would for any other stuck task — a busy task never becomes immortal.
+//
+// The status precondition mirrors FinishUpdateTask's: a task a halt already
+// terminalized matches no row, and the caller (Worker.deferForBusySite) must
+// stop rather than snooze — the recorded terminal outcome wins. IN
+// ('pending','running') rather than = 'running' so a task that is ALREADY
+// pending (the pre-dispatch gate case: nothing was ever sent) can still
+// record the wait detail idempotently.
+func (q *Queries) DeferUpdateTaskToPending(ctx context.Context, arg DeferUpdateTaskToPendingParams) (UpdateTask, error) {
+	row := q.db.QueryRow(ctx, deferUpdateTaskToPending, arg.Detail, arg.ID, arg.TenantID)
 	var i UpdateTask
 	err := row.Scan(
 		&i.ID,
@@ -791,4 +862,74 @@ func (q *Queries) SetUpdateRunStatus(ctx context.Context, arg SetUpdateRunStatus
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const siteHasRunningUpdateTask = `-- name: SiteHasRunningUpdateTask :one
+SELECT EXISTS (
+    SELECT 1 FROM update_tasks
+    WHERE site_id = $1
+      AND tenant_id = $2
+      AND id <> $3
+      AND target_type <> 'agent'
+      AND status = 'running'
+      AND coalesce(started_at, updated_at) > now() - $4::interval
+)
+`
+
+type SiteHasRunningUpdateTaskParams struct {
+	SiteID        uuid.UUID       `json:"site_id"`
+	TenantID      uuid.UUID       `json:"tenant_id"`
+	ExcludeTaskID uuid.UUID       `json:"exclude_task_id"`
+	HoldMax       pgtype.Interval `json:"hold_max"`
+}
+
+// GH #328 per-site serialisation pre-check (INVARIANT R). Is a command
+// CURRENTLY IN FLIGHT to this site? Deliberately best-effort and read-only:
+// the AGENT's own site-update lock is the authoritative bound (WP_Upgrader::
+// create_lock, see the agent lane). A missed collision here costs one HTTP
+// round trip the agent itself refuses, which the worker then defers; it is
+// not a correctness gap. Do NOT "fix" this with an advisory lock or a
+// conditional claim across the round trip — the guarantee is not here.
+//
+// status = 'running' means exactly "dispatched and not yet resolved"
+// (INVARIANT R). DeferUpdateTaskToPending is what keeps that true: a task
+// WAITING for this site is 'pending' and therefore can never itself match
+// this predicate. That is why a waiter can never block a sibling waiter:
+// waiters depend only on runners, and runners depend on nothing (every River
+// job for this worker exits within its own job timeout, whether the site
+// answers or not), so the wait-for graph has no cycle.
+//
+// target_type <> 'agent' is NOT an optimisation. An agent self-update task
+// stays 'running' for its whole confirmation window (20m, or 90m on external
+// cron; see agentConfirmDeadline/agentConfirmDeadlineExternalCron), during
+// which the site's writer is NOT held: the apply happens after the ARM's
+// HTTP response has already been released, and from then on the agent polls
+// its OWN site lock directly. Counting a running agent-task row here would
+// block every plugin/theme/core update on that site for up to 90 minutes for
+// no reason; the agent's own lock is what serialises the two channels in
+// both directions.
+//
+// The staleness clause bounds a crashed worker: a row whose command went out
+// longer ago than @hold_max cannot have a live worker behind it (River
+// cancels the job's context at its own job timeout regardless of whether the
+// site answers). Ignoring such a row only makes the gate MORE permissive
+// (lets a sibling dispatch it would otherwise have deferred), never less,
+// which is safe — the agent's own lock is still the backstop either way.
+// coalesce(started_at, updated_at) covers a row observed between
+// MarkUpdateTaskRunning (which sets both) and any later touch.
+//
+// Rides the existing update_tasks_site_id_idx (m3). No new column and no new
+// index: every predicate here reads columns update_tasks already has, and
+// the row is bounded to one site at a time by that existing index, so no
+// schema migration is needed for this gate.
+func (q *Queries) SiteHasRunningUpdateTask(ctx context.Context, arg SiteHasRunningUpdateTaskParams) (bool, error) {
+	row := q.db.QueryRow(ctx, siteHasRunningUpdateTask,
+		arg.SiteID,
+		arg.TenantID,
+		arg.ExcludeTaskID,
+		arg.HoldMax,
+	)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
 }

--- a/apps/api/internal/update/agent_self_update_channel_test.go
+++ b/apps/api/internal/update/agent_self_update_channel_test.go
@@ -2535,3 +2535,114 @@ type reaperFakeRepo struct {
 func (f *reaperFakeRepo) ListStaleUpdateTasks(context.Context, time.Duration, int32) ([]Task, error) {
 	return f.stale, nil
 }
+
+// TestADeferredApplyIsNotAFailure pins the GH #328 rule that a site which was
+// merely BUSY must never be scored as a failed upgrade.
+//
+// The shape: the agent waited out its whole budget for the per-site update
+// lock, gave up without attempting anything, and recorded "deferred" for THIS
+// run. Nothing was downloaded, nothing was swapped, nothing on the site
+// changed, so the version never moves and the confirm poll reaches its
+// deadline. Before this rule that deadline produced TaskFailed, which
+// tallyWave counts as Failed and haltReasonFor turns into a halted fleet
+// rollout on the strength of a site that never tried.
+//
+// The correct verdict is TaskSkipped: this site proved nothing either way.
+// It still stops a wave that confirmed no site at all, which is right, but it
+// stops saying nothing was attempted rather than reporting a failure that did
+// not happen.
+func TestADeferredApplyIsNotAFailure(t *testing.T) {
+	const applyID = "deferred-test-apply-id"
+
+	arm := agentcmd.AgentSelfUpdateResponse{
+		Status: agentcmd.SelfUpdateScheduled, FromVersion: agentPlanFrom, ToVersion: agentPlanTarget,
+		CronMode: agentcmd.CronModeLoopback, ApplyID: applyID,
+	}
+	versions := &fakeVersions{versions: map[uuid.UUID]string{}}
+	h := newAgentHarness(t, 10, &recordingSelfUpdater{resp: arm}, versions, true)
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+
+	args := h.enq.confirms[0]
+	// The version never moves, because the apply never ran.
+	versions.versions[args.SiteID] = agentPlanFrom
+
+	results := &fakeApplyResults{results: map[uuid.UUID]AgentApplyResult{}}
+	results.results[args.SiteID] = AgentApplyResult{
+		Status:      agentApplyDeferred,
+		FromVersion: agentPlanFrom,
+		ToVersion:   agentPlanTarget,
+		Detail:      "The site was busy with another update for the whole wait, so the agent was not upgraded.",
+		At:          time.Now(),
+		ApplyID:     applyID,
+	}
+	h.withApplyResults(results)
+
+	args.DeadlineAt = time.Now().Add(-time.Second)
+	cw := NewAgentConfirmWorker(h.w)
+	if err := cw.Work(context.Background(), &river.Job[AgentConfirmArgs]{Args: args}); err != nil {
+		t.Fatalf("confirm Work: %v", err)
+	}
+
+	task := h.store.Task(0)
+	if task.Status != TaskSkipped {
+		t.Fatalf("status = %q, want %q: a busy site is not a failed upgrade", task.Status, TaskSkipped)
+	}
+	// The distinct unconfirmed error code must NOT be set: this task did not
+	// fail to confirm, it declined to attempt.
+	if task.Error != "" {
+		t.Fatalf("error = %q, want empty: a deferred apply is not an error", task.Error)
+	}
+	if !strings.Contains(task.Detail, "not attempted") {
+		t.Fatalf("detail = %q, want it to say plainly that nothing was attempted", task.Detail)
+	}
+	if strings.Contains(task.Detail, "unconfirmed") {
+		t.Fatalf("detail = %q, must not reuse the unconfirmed wording for a site that never tried", task.Detail)
+	}
+
+	// And the wave must not count it as a failure.
+	tally := tallyWave([]Task{{Status: TaskSkipped}}, WaveRange{Start: 0, End: 1})
+	if tally.Failed != 0 {
+		t.Fatalf("tally.Failed = %d, want 0: a deferred apply must never be counted against a canary", tally.Failed)
+	}
+}
+
+// TestAnUnattributedDeferredRecordStillFails guards the other direction: the
+// skip is only safe because the record is tied to THIS run. A deferred record
+// carrying a DIFFERENT apply id says nothing about this attempt, so the
+// deadline must still fail honestly rather than excusing itself with someone
+// else's record.
+func TestAnUnattributedDeferredRecordStillFails(t *testing.T) {
+	arm := agentcmd.AgentSelfUpdateResponse{
+		Status: agentcmd.SelfUpdateScheduled, FromVersion: agentPlanFrom, ToVersion: agentPlanTarget,
+		CronMode: agentcmd.CronModeLoopback, ApplyID: "this-run",
+	}
+	versions := &fakeVersions{versions: map[uuid.UUID]string{}}
+	h := newAgentHarness(t, 10, &recordingSelfUpdater{resp: arm}, versions, true)
+	if err := h.work(context.Background(), 0); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+
+	args := h.enq.confirms[0]
+	versions.versions[args.SiteID] = agentPlanFrom
+
+	results := &fakeApplyResults{results: map[uuid.UUID]AgentApplyResult{}}
+	results.results[args.SiteID] = AgentApplyResult{
+		Status:  agentApplyDeferred,
+		At:      time.Now(),
+		ApplyID: "some-other-run",
+	}
+	h.withApplyResults(results)
+
+	args.DeadlineAt = time.Now().Add(-time.Second)
+	cw := NewAgentConfirmWorker(h.w)
+	if err := cw.Work(context.Background(), &river.Job[AgentConfirmArgs]{Args: args}); err != nil {
+		t.Fatalf("confirm Work: %v", err)
+	}
+
+	task := h.store.Task(0)
+	if task.Status != TaskFailed {
+		t.Fatalf("status = %q, want %q: an unattributed record must not excuse this run", task.Status, TaskFailed)
+	}
+}

--- a/apps/api/internal/update/agent_worker.go
+++ b/apps/api/internal/update/agent_worker.go
@@ -914,6 +914,22 @@ func (c *AgentConfirmWorker) Work(ctx context.Context, job *river.Job[AgentConfi
 		// either way, so a failed read only means the failure explanation is
 		// less detailed, never that the failure itself was wrongly declared.
 		res, _ := w.agentApplyResult(ctx, a.TenantID, a.SiteID)
+
+		// A DEFERRED apply is not a failure. The agent held off because the
+		// site was busy with another update for its whole wait, and it says so
+		// in its own record for THIS run, so we know nothing was attempted and
+		// nothing changed. Scoring that as failed would let a busy site halt a
+		// fleet rollout. Skipped is the honest verdict: this site proved
+		// nothing either way, which is exactly what tallyWave treats it as.
+		// The attribution check is what makes this safe to trust: an unrelated
+		// or stale deferred record cannot reach here.
+		if agentApplyAttributed(a, res) && res.Status == agentApplyDeferred {
+			return w.finishAgentTask(ctx, task, TaskSkipped, a.FromVersion, "",
+				fmt.Sprintf("not attempted: the site was busy with another update for this run's whole wait, so the agent "+
+					"was never upgraded and nothing on the site was changed. Its own record for %s says so. "+
+					"Re-run this rollout when the site is idle.", shortApplyID(a.ApplyID)), "")
+		}
+
 		return w.finishAgentTask(ctx, task, TaskFailed, a.FromVersion, a.ExpectVersion,
 			unconfirmedDetail(a, reported, res), "agent_self_update_unconfirmed")
 	}
@@ -1167,4 +1183,11 @@ const (
 	agentApplyFailed         = "failed"
 	agentApplyExpired        = "expired"
 	agentApplyAlreadyApplied = "already_applied"
+	// agentApplyDeferred: the agent waited out its whole budget for the site
+	// update lock and gave up WITHOUT attempting anything. Nothing was
+	// downloaded, nothing was swapped, nothing on the site changed. This is a
+	// BUSY answer, not a broken one, so it must never be scored as a failure:
+	// an ordinary busy site would otherwise fail a wave-0 canary and halt a
+	// whole fleet rollout. Introduced with the per-site update lock (GH #328).
+	agentApplyDeferred = "deferred"
 )

--- a/apps/api/internal/update/handler_test.go
+++ b/apps/api/internal/update/handler_test.go
@@ -79,6 +79,14 @@ func (f *fakeRepo) ListStaleUpdateTasks(context.Context, time.Duration, int32) (
 	panic("not used")
 }
 
+func (f *fakeRepo) SiteHasRunningTask(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, time.Duration) (bool, error) {
+	panic("not used")
+}
+
+func (f *fakeRepo) DeferTaskToPending(context.Context, DeferTaskInput) (Task, error) {
+	panic("not used")
+}
+
 // flushableRecorder wraps httptest.ResponseRecorder so gin's writer implements
 // http.Flusher (the events handler checks for it before opening the stream).
 type flushableRecorder struct {

--- a/apps/api/internal/update/repo.go
+++ b/apps/api/internal/update/repo.go
@@ -68,6 +68,35 @@ type Repo interface {
 	// partial unique index (m88) — without this, every future update attempt
 	// for that target would 409 targets_in_flight forever.
 	ListStaleUpdateTasks(ctx context.Context, threshold time.Duration, limit int32) ([]Task, error)
+
+	// SiteHasRunningTask is the GH #328 per-site serialisation pre-check
+	// (INVARIANT R): does SOME OTHER task for this site currently have a
+	// command dispatched and unresolved? Best-effort — the agent's own
+	// site-update lock is the authoritative bound; a missed collision here
+	// just costs one HTTP round trip the agent itself refuses, which the
+	// worker then defers. excludeTaskID excludes the caller's own row (a task
+	// re-checking the gate against itself would always see itself as busy).
+	// holdMax is the staleness bound (see SiteHasRunningUpdateTask's own
+	// comment in db/query/updates.sql for why an over-age 'running' row is
+	// ignored rather than trusted).
+	SiteHasRunningTask(ctx context.Context, tenantID, siteID, excludeTaskID uuid.UUID, holdMax time.Duration) (bool, error)
+
+	// DeferTaskToPending records that a task is WAITING for its site (busy
+	// with another update) rather than talking to it: moves it back to
+	// 'pending' (see DeferUpdateTaskToPending). Returns ErrTaskNotOpen when
+	// the task already reached a terminal state (e.g. a halt raced the
+	// defer); the caller must stop rather than snooze in that case, exactly
+	// like FinishTask.
+	DeferTaskToPending(ctx context.Context, in DeferTaskInput) (Task, error)
+}
+
+// DeferTaskInput is the input to DeferTaskToPending.
+type DeferTaskInput struct {
+	TenantID uuid.UUID
+	TaskID   uuid.UUID
+	// Detail is the operator-facing "waiting: ..." sentence recorded on the
+	// task while it waits for its site.
+	Detail string
 }
 
 // InFlightKey identifies one (site, target) pair that currently has a
@@ -419,6 +448,60 @@ func (r *pgRepo) ListStaleUpdateTasks(ctx context.Context, threshold time.Durati
 		for _, row := range rows {
 			out = append(out, toTask(row))
 		}
+		return nil
+	})
+	return out, err
+}
+
+// SiteHasRunningTask runs in the tenant's RLS scope (the caller already holds
+// a tenant-scoped task, and a cross-tenant collision on the same site is not
+// possible: site_id belongs to exactly one tenant).
+func (r *pgRepo) SiteHasRunningTask(ctx context.Context, tenantID, siteID, excludeTaskID uuid.UUID, holdMax time.Duration) (bool, error) {
+	var busy bool
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		b, err := sqlc.New(tx).SiteHasRunningUpdateTask(ctx, sqlc.SiteHasRunningUpdateTaskParams{
+			SiteID:        siteID,
+			TenantID:      tenantID,
+			ExcludeTaskID: excludeTaskID,
+			HoldMax:       durationToInterval(holdMax),
+		})
+		if err != nil {
+			return domain.Internal("update_site_busy_check_failed", "failed to check for a running update task on this site").WithCause(err)
+		}
+		busy = b
+		return nil
+	})
+	return busy, err
+}
+
+func (r *pgRepo) DeferTaskToPending(ctx context.Context, in DeferTaskInput) (Task, error) {
+	var out Task
+	err := r.pool.InTenantTx(ctx, in.TenantID, func(tx pgx.Tx) error {
+		row, err := sqlc.New(tx).DeferUpdateTaskToPending(ctx, sqlc.DeferUpdateTaskToPendingParams{
+			ID:       in.TaskID,
+			TenantID: in.TenantID,
+			Detail:   in.Detail,
+		})
+		if err != nil {
+			if !errors.Is(err, pgx.ErrNoRows) {
+				return domain.Internal("update_task_defer_failed", "failed to defer update task to pending").WithCause(err)
+			}
+			// No open (pending|running) row matched: the task already reached
+			// a terminal state, most likely 'cancelled' from a halt racing
+			// this defer. Read it back and report ErrTaskNotOpen, exactly
+			// like FinishTask, so the caller leaves the recorded outcome
+			// alone rather than treating this as an infrastructure error.
+			existing, gerr := sqlc.New(tx).GetUpdateTask(ctx, sqlc.GetUpdateTaskParams{ID: in.TaskID, TenantID: in.TenantID})
+			if gerr != nil {
+				if errors.Is(gerr, pgx.ErrNoRows) {
+					return domain.NotFound("update_task_not_found", "update task not found")
+				}
+				return domain.Internal("update_task_get_failed", "failed to load update task").WithCause(gerr)
+			}
+			out = toTask(existing)
+			return ErrTaskNotOpen
+		}
+		out = toTask(row)
 		return nil
 	})
 	return out, err

--- a/apps/api/internal/update/service_test.go
+++ b/apps/api/internal/update/service_test.go
@@ -102,7 +102,9 @@ func (f *fakeCreateRepo) ListInFlightTargets(_ context.Context, tenantID uuid.UU
 	return out, nil
 }
 
-func (f *fakeCreateRepo) GetRun(context.Context, uuid.UUID, uuid.UUID) (Run, error) { panic("not used") }
+func (f *fakeCreateRepo) GetRun(context.Context, uuid.UUID, uuid.UUID) (Run, error) {
+	panic("not used")
+}
 func (f *fakeCreateRepo) ListRuns(context.Context, uuid.UUID, int32, int32) ([]Run, error) {
 	panic("not used")
 }
@@ -131,6 +133,12 @@ func (f *fakeCreateRepo) CountRunningTasksForTenant(context.Context, uuid.UUID) 
 	panic("not used")
 }
 func (f *fakeCreateRepo) ListStaleUpdateTasks(context.Context, time.Duration, int32) ([]Task, error) {
+	panic("not used")
+}
+func (f *fakeCreateRepo) SiteHasRunningTask(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, time.Duration) (bool, error) {
+	panic("not used")
+}
+func (f *fakeCreateRepo) DeferTaskToPending(context.Context, DeferTaskInput) (Task, error) {
 	panic("not used")
 }
 

--- a/apps/api/internal/update/worker.go
+++ b/apps/api/internal/update/worker.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"net/http"
 	"time"
 
@@ -103,6 +104,11 @@ type Worker struct {
 	// schedule (probeRetryDelays). Nil uses the default. Tests set this to a
 	// tiny schedule so the retry loop does not actually sleep ~21s.
 	probeDelays []time.Duration
+	// busyBackoff overrides siteBusyBackoff's default jittered schedule. Nil
+	// uses the default. Tests set this to a tiny fixed delay (see
+	// SetSiteBusyBackoff) so a busy-site retry test does not actually sleep
+	// the production 5s-60s window.
+	busyBackoff func(Task) time.Duration
 	// agent holds the agent self-update channel's dependencies and its
 	// fleet-wide kill switch. The ZERO VALUE IS DISABLED: a deployment that
 	// never calls SetAgentSelfUpdate never sends an agent self-update command
@@ -291,6 +297,21 @@ func (w *Worker) Work(ctx context.Context, job *river.Job[TaskArgs]) error {
 		return w.refuseAgentSelfUpdate(ctx, task)
 	}
 
+	// GH #328 per-site serialisation pre-check (INVARIANT R): is another
+	// command already dispatched and unresolved against this same site? Best
+	// effort — the agent's own site-update lock is the authoritative bound;
+	// this just avoids the wasted HTTP round trip on the common case. Placed
+	// AFTER the agent-plugin re-check (so a mis-targeted task is still
+	// refused outright rather than deferred) and BEFORE MarkTaskRunning (so a
+	// task the gate defers never transitions to 'running' at all — the row is
+	// still 'pending' here, and DeferTaskToPending's status write is then a
+	// no-op that only updates the wait bookkeeping). See
+	// SiteHasRunningUpdateTask's own comment in db/query/updates.sql for the
+	// no-deadlock proof and why agent-target rows are excluded.
+	if busy, gerr := w.repo.SiteHasRunningTask(ctx, a.TenantID, task.SiteID, a.TaskID, siteWriterHoldMax); gerr == nil && busy {
+		return w.deferForBusySite(ctx, task, "another update is running on this site")
+	}
+
 	running, err := w.repo.MarkTaskRunning(ctx, a.TenantID, a.TaskID)
 	if err != nil {
 		return err
@@ -334,6 +355,123 @@ func (w *Worker) refuseAgentSelfUpdate(ctx context.Context, task Task) error {
 	return w.finish(ctx, task, TaskSkipped, task.FromVersion, "", "the site agent updates itself over its own signed channel", "")
 }
 
+// ----------------------------------------------------------------------------
+// GH #328 per-site serialisation: the busy-site gate and its one handler.
+// ----------------------------------------------------------------------------
+
+// siteWriterHoldMax bounds how long a 'running' non-agent update_tasks row is
+// trusted as evidence of a live writer by the per-site serialisation gate
+// (SiteHasRunningUpdateTask). A row whose command went out longer ago than
+// this cannot have a live worker behind it, because River cancels the job's
+// context at its own job timeout (see Worker.Timeout / DeriveApplyJobTimeout,
+// about 13m52s on production defaults) whether the site answers or not. 20
+// minutes adds margin over that for scheduling/clock skew and stays
+// comfortably under staleTaskThreshold (45m), so the gate stops trusting a
+// row strictly before the periodic reaper would terminalize it. Ignoring an
+// over-age row only makes the gate MORE PERMISSIVE (it lets a sibling
+// dispatch a command the gate would otherwise have deferred), never less,
+// which is safe: the agent's own site-update lock is the authoritative bound
+// in every case, this gate is only a round-trip optimisation.
+const siteWriterHoldMax = 20 * time.Minute
+
+const (
+	// siteBusyBackoffMin/Max bound the jittered snooze between busy-site
+	// retries. See siteBusyBackoff.
+	siteBusyBackoffMin = 5 * time.Second
+	siteBusyBackoffMax = 60 * time.Second
+
+	// siteBusyMaxWait is the AUTHORITATIVE bound on how long a task may keep
+	// being deferred for a busy site, measured from the task's own CreatedAt
+	// (wall clock, not a retry count — see busyBoundExceeded). A task
+	// deferred continuously for longer than this is terminalized as
+	// TaskSkipped rather than deferred again: nothing was sent, nothing
+	// changed, and the operator is told to re-run when the site is idle.
+	// This is the bound that keeps a permanently busy site from holding a
+	// task, and therefore its (tenant, site, target_type, target_slug)
+	// in-flight dedup slot (m88's partial unique index), open forever.
+	siteBusyMaxWait = 6 * time.Hour
+)
+
+// SetSiteBusyBackoff overrides the busy-site retry backoff schedule. Exposed
+// for tests so a bulk-update test does not actually sleep the production
+// 5s-60s window; production code should leave this unset (nil restores the
+// default, siteBusyBackoff).
+func (w *Worker) SetSiteBusyBackoff(f func(Task) time.Duration) {
+	w.busyBackoff = f
+}
+
+// siteBusyBackoff computes the snooze delay for a task deferred because its
+// site is busy: a jittered delay in [siteBusyBackoffMin, siteBusyBackoffMax).
+// The jitter (crypto-unpredictable, via math/rand/v2's auto-seeded default
+// source) is what keeps many siblings waiting on the same busy site from
+// waking in lockstep and colliding again the moment the current writer
+// releases the lock.
+func (w *Worker) siteBusyBackoff(task Task) time.Duration {
+	if w.busyBackoff != nil {
+		return w.busyBackoff(task)
+	}
+	span := siteBusyBackoffMax - siteBusyBackoffMin
+	return siteBusyBackoffMin + time.Duration(rand.Int64N(int64(span)))
+}
+
+// busyBoundExceeded reports the reason a busy-deferred task must stop being
+// retried and be terminalized instead, or "" when it may still be deferred
+// again. The wall-clock bound (siteBusyMaxWait, measured from CreatedAt) is
+// AUTHORITATIVE; see the constant's own doc comment.
+func busyBoundExceeded(task Task) string {
+	if waited := time.Since(task.CreatedAt); waited > siteBusyMaxWait {
+		return fmt.Sprintf("for over %s", siteBusyMaxWait)
+	}
+	return ""
+}
+
+// deferForBusySite is the ONE path into the waiting state for a task whose
+// site is busy with another update, rollback, or agent upgrade. It ALWAYS
+// exits with the task back in 'pending' (never a terminal status), unless the
+// task has been waiting longer than siteBusyMaxWait, in which case it is
+// terminalized as TaskSkipped — never TaskFailed — because nothing was ever
+// sent to the site for this item and nothing on it changed.
+//
+// A BUSY SITE MUST NEVER PRODUCE A TERMINAL "FAILED" STATUS, and a WAITING
+// TASK MUST NEVER LOOK "RUNNING". Both halves live here so neither can be
+// broken independently: the bound check below only ever chooses between
+// 'pending' (via finish=false) and TaskSkipped, never TaskFailed; and
+// DeferTaskToPending is the only write in this codebase that moves a task
+// from 'running' back to 'pending'.
+func (w *Worker) deferForBusySite(ctx context.Context, task Task, why string) error {
+	if bound := busyBoundExceeded(task); bound != "" {
+		return w.finish(ctx, task, TaskSkipped, task.FromVersion, "",
+			fmt.Sprintf("not attempted: this site was continuously busy with another update, rollback, or agent upgrade %s. "+
+				"Nothing was sent to the site for this item and nothing on the site was changed. Re-run this update when the site is idle.", bound), "")
+	}
+
+	deferred, err := w.repo.DeferTaskToPending(ctx, DeferTaskInput{
+		TenantID: task.TenantID,
+		TaskID:   task.ID,
+		Detail:   "waiting: " + why,
+	})
+	if errors.Is(err, ErrTaskNotOpen) {
+		// A halt (or a concurrent finisher) already terminalized this task
+		// while the site was being asked. The recorded outcome wins; there
+		// is nothing left to wait for.
+		return nil
+	}
+	if err != nil {
+		// Could not record the wait: snooze SHORT and retry the demotion
+		// rather than terminalize a task for a CP-side DB hiccup. Still
+		// bounded even so: the gate's own staleness clause (siteWriterHoldMax)
+		// stops trusting a row left 'running' after that, so a sibling can
+		// still make progress, and the periodic reaper (staleTaskThreshold)
+		// claims this row itself after that regardless of how this branch
+		// resolves.
+		w.logger.Warn("update: failed to defer task for a busy site; snoozing short",
+			slog.String("task_id", task.ID.String()), slog.Any("error", err))
+		return river.JobSnooze(siteBusyBackoffMin)
+	}
+	w.publish(deferred, RunRunning)
+	return river.JobSnooze(w.siteBusyBackoff(deferred))
+}
+
 // runDry asks the agent what WOULD change without mutating the site.
 func (w *Worker) runDry(ctx context.Context, task Task, siteURL string, item agentcmd.UpdateItem) error {
 	resp, err := w.cmd.Update(ctx, task.SiteID, siteURL, agentcmd.UpdateRequest{DryRun: true, Snapshot: false, Items: []agentcmd.UpdateItem{item}})
@@ -347,6 +485,15 @@ func (w *Worker) runDry(ctx context.Context, task Task, siteURL string, item age
 	// path below, so an agent that had rejected the command outright was still
 	// recorded as a successful "no change".
 	res := firstResult(resp.Results)
+
+	// GH #328: a busy site refuses BEFORE the resp.OK check below, exactly
+	// like runApply (see that function for why the ordering is load-bearing).
+	// A stock agent takes no lock for a dry run, but a foreign maintenance
+	// window (e.g. a human's wp-admin bulk update in progress) can still
+	// refuse one.
+	if res.Status == agentcmd.ItemSiteBusy {
+		return w.deferForBusySite(ctx, task, detailOr(res.Log, "another update is running on this site"))
+	}
 	if !resp.OK {
 		return w.finish(ctx, task, TaskFailed, task.FromVersion, "",
 			"agent rejected the dry-run command", detailOr(res.Log, "agent returned ok=false"))
@@ -373,6 +520,23 @@ func (w *Worker) runApply(ctx context.Context, task Task, siteURL string, item a
 		return w.finish(ctx, task, TaskFailed, task.FromVersion, "", "update command failed", err.Error())
 	}
 	res := firstResult(resp.Results)
+
+	// GH #328: a busy site refuses BEFORE the resp.OK check below and BEFORE
+	// the ItemFailed check further down. Ordering here is LOAD BEARING: the
+	// agent sets ok=false whenever any item reports a non-success status
+	// (site_busy included, same as a failure), so checking resp.OK first
+	// would send this down the generic TaskFailed path and make every busy
+	// refusal a permanent recorded failure instead of a retried wait. See
+	// deferForBusySite for the no-deadlock invariant this preserves
+	// (INVARIANT R) and for why this can never be tallied as Failed or halt a
+	// wave (agent_wave.go's tallyWave/haltReasonFor operate ONLY over
+	// target_type='agent' tasks — see waveOrder's filter — so a plugin/theme/
+	// core task deferred here is never even visible to that code; and the
+	// 'pending' status this produces falls into tallyWave's default case,
+	// InFlight, on the rare occasion a task of any type is inspected there).
+	if res.Status == agentcmd.ItemSiteBusy {
+		return w.deferForBusySite(ctx, task, detailOr(res.Log, "another update is running on this site"))
+	}
 
 	// The agent's own verdict on the command dispatch. An ok=false here means it
 	// never ran the update, so the per-item results below cannot be trusted to
@@ -930,7 +1094,7 @@ const staleTaskReapLimit = 500
 // a task on a site with external cron waits up to
 // agentConfirmDeadlineExternalCron for beat 2 on its own. Reaping either as
 // "stale" would fail a task that is behaving exactly as designed, and, worse
-//, feed a false failure into the wave gate, halting a healthy rollout.
+// , feed a false failure into the wave gate, halting a healthy rollout.
 //
 // It is still finite: a genuinely stuck agent task must eventually release its
 // (tenant, site, target_type, target_slug) slot in the

--- a/apps/api/internal/update/worker_test.go
+++ b/apps/api/internal/update/worker_test.go
@@ -2,12 +2,14 @@ package update
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/riverqueue/river/rivertype"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
 )
@@ -20,6 +22,15 @@ import (
 // events-handler tests and has different fake behaviour.)
 type probeFakeRepo struct {
 	finished []FinishTaskInput
+	deferred []DeferTaskInput
+	// busy/busyErr control SiteHasRunningTask's return; zero values (not
+	// busy, no error) keep every pre-existing test that never touches the
+	// GH #328 gate unaffected.
+	busy    bool
+	busyErr error
+	// deferErr, when set, makes DeferTaskToPending return it instead of
+	// recording the defer (used to test deferForBusySite's error branch).
+	deferErr error
 }
 
 func (f *probeFakeRepo) CreateRunWithTasks(context.Context, CreateRunInput, []NewTask) (Run, []Task, error) {
@@ -79,6 +90,18 @@ func (f *probeFakeRepo) ListStaleUpdateTasks(context.Context, time.Duration, int
 	panic("not implemented")
 }
 
+func (f *probeFakeRepo) SiteHasRunningTask(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, time.Duration) (bool, error) {
+	return f.busy, f.busyErr
+}
+
+func (f *probeFakeRepo) DeferTaskToPending(_ context.Context, in DeferTaskInput) (Task, error) {
+	if f.deferErr != nil {
+		return Task{}, f.deferErr
+	}
+	f.deferred = append(f.deferred, in)
+	return Task{ID: in.TaskID, TenantID: in.TenantID, Status: TaskPending, Detail: in.Detail}, nil
+}
+
 // fakeCommander records Rollback calls and never actually contacts an agent.
 type fakeCommander struct {
 	rollbackCalled bool
@@ -123,6 +146,30 @@ func (c *applyOnlyCommander) Rollback(context.Context, uuid.UUID, string, agentc
 		return agentcmd.RollbackResponse{}, c.rollbackErr
 	}
 	return agentcmd.RollbackResponse{OK: true, RestoredVersion: "1.9.9"}, nil
+}
+
+// siteBusyCommander is a Commander test double whose Update always answers
+// with a single ItemSiteBusy result (GH #328), mirroring a real agent
+// refusing because its own site-update lock is held. OK is false, matching
+// the same "nothing was attempted" shape ItemFailed carries (see the
+// ordering comment on runApply/runDry: the site_busy check must run BEFORE
+// the resp.OK check for exactly this reason). Rollback panics: nothing under
+// test here should ever reach it.
+type siteBusyCommander struct {
+	log         string
+	updateCalls int
+}
+
+func (c *siteBusyCommander) Update(_ context.Context, _ uuid.UUID, _ string, req agentcmd.UpdateRequest) (agentcmd.UpdateResponse, error) {
+	c.updateCalls++
+	item := req.Items[0]
+	return agentcmd.UpdateResponse{OK: false, Results: []agentcmd.ItemResult{{
+		Type: item.Type, Slug: item.Slug, Status: agentcmd.ItemSiteBusy, Log: c.log,
+	}}}, nil
+}
+
+func (c *siteBusyCommander) Rollback(context.Context, uuid.UUID, string, agentcmd.RollbackRequest) (agentcmd.RollbackResponse, error) {
+	panic("rollback must never be reached on a site_busy result")
 }
 
 // verifyingCommander embeds applyOnlyCommander's Update/Rollback behaviour and
@@ -254,6 +301,11 @@ func testTask() Task {
 		TargetSlug:  "suremail",
 		FromVersion: "1.9.9",
 		Status:      TaskRunning,
+		// CreatedAt matters for the GH #328 busy-defer bound
+		// (busyBoundExceeded measures time.Since(task.CreatedAt)); the zero
+		// value would make every busy-deferred test task look like it had
+		// already waited millennia.
+		CreatedAt: time.Now(),
 	}
 }
 
@@ -918,4 +970,259 @@ func TestDeriveApplyJobTimeout(t *testing.T) {
 			t.Fatalf("DeriveApplyJobTimeout(5m, 0) = %v, want > 5m (probeHTTPTimeout=0 should fall back internally, not collapse the probe ladder to 0)", got)
 		}
 	})
+}
+
+// ----------------------------------------------------------------------------
+// GH #328: per-site serialisation, the busy-site defer path.
+// ----------------------------------------------------------------------------
+
+// snoozeDuration extracts the snooze duration from a river.JobSnooze return
+// value, failing the test if err is not a *rivertype.JobSnoozeError.
+func snoozeDuration(t *testing.T, err error) time.Duration {
+	t.Helper()
+	var snooze *rivertype.JobSnoozeError
+	if !errors.As(err, &snooze) {
+		t.Fatalf("expected a JobSnoozeError, got %v (%T)", err, err)
+	}
+	return snooze.Duration
+}
+
+// TestRunApply_SiteBusy_DefersRatherThanFails pins the ordering that makes
+// GH #328's busy handling safe: the site_busy check in runApply runs BEFORE
+// the resp.OK check (the agent sets ok=false for a busy refusal, the same
+// shape ItemFailed carries), so a busy site is deferred to 'pending', never
+// recorded as a terminal TaskFailed.
+func TestRunApply_SiteBusy_DefersRatherThanFails(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &siteBusyCommander{log: "another update is running on this site"}
+	w := newApplyTestWorker(repo, cmd, &scriptedProber{})
+
+	task := testTask()
+	item := updateItem()
+	err := w.runApply(context.Background(), task, "https://example.test", item)
+
+	if len(repo.finished) != 0 {
+		t.Fatalf("a busy site must never reach a terminal status, got %+v", repo.finished)
+	}
+	if len(repo.deferred) != 1 {
+		t.Fatalf("expected exactly one defer, got %d", len(repo.deferred))
+	}
+	if !strings.Contains(repo.deferred[0].Detail, "waiting:") {
+		t.Fatalf("expected a 'waiting: ...' detail, got %q", repo.deferred[0].Detail)
+	}
+	if !strings.Contains(repo.deferred[0].Detail, cmd.log) {
+		t.Fatalf("expected the agent's log to be carried into the wait detail, got %q", repo.deferred[0].Detail)
+	}
+	if d := snoozeDuration(t, err); d < siteBusyBackoffMin || d >= siteBusyBackoffMax {
+		t.Fatalf("snooze duration %v out of bounds [%v, %v)", d, siteBusyBackoffMin, siteBusyBackoffMax)
+	}
+}
+
+// TestRunDry_SiteBusy_DefersRatherThanFails is runDry's mirror of the above:
+// a dry run takes no lock on the agent, but a foreign maintenance window can
+// still refuse one, and it must defer exactly like a real apply.
+func TestRunDry_SiteBusy_DefersRatherThanFails(t *testing.T) {
+	repo := &probeFakeRepo{}
+	cmd := &siteBusyCommander{log: "site is in maintenance mode"}
+	w := newApplyTestWorker(repo, cmd, &scriptedProber{})
+
+	task := testTask()
+	item := updateItem()
+	err := w.runDry(context.Background(), task, "https://example.test", item)
+
+	if len(repo.finished) != 0 {
+		t.Fatalf("a busy site must never reach a terminal status on a dry run, got %+v", repo.finished)
+	}
+	if len(repo.deferred) != 1 {
+		t.Fatalf("expected exactly one defer, got %d", len(repo.deferred))
+	}
+	if _, ok := asSnooze(err); !ok {
+		t.Fatalf("expected a snooze, got %v", err)
+	}
+}
+
+func asSnooze(err error) (*rivertype.JobSnoozeError, bool) {
+	var snooze *rivertype.JobSnoozeError
+	ok := errors.As(err, &snooze)
+	return snooze, ok
+}
+
+// TestDeferForBusySite_BoundExceeded_TerminalizesSkippedNeverFailed proves
+// the AUTHORITATIVE wall-clock bound (siteBusyMaxWait): a task that has been
+// waiting on a busy site for longer than that is terminalized as
+// TaskSkipped, and ONLY TaskSkipped — never TaskFailed, and never deferred
+// again.
+func TestDeferForBusySite_BoundExceeded_TerminalizesSkippedNeverFailed(t *testing.T) {
+	repo := &probeFakeRepo{}
+	w := newApplyTestWorker(repo, &siteBusyCommander{}, &scriptedProber{})
+
+	task := testTask()
+	task.CreatedAt = time.Now().Add(-siteBusyMaxWait - time.Minute)
+
+	if err := w.deferForBusySite(context.Background(), task, "another update is running on this site"); err != nil {
+		t.Fatalf("expected a terminal finish (nil error), got %v", err)
+	}
+	if len(repo.deferred) != 0 {
+		t.Fatalf("a bound-exceeded task must never be deferred again, got %+v", repo.deferred)
+	}
+	if len(repo.finished) != 1 {
+		t.Fatalf("expected exactly one terminal finish, got %d", len(repo.finished))
+	}
+	got := repo.finished[0]
+	if got.Status != TaskSkipped {
+		t.Fatalf("expected TaskSkipped, got %s (a bound-exceeded busy task must never be recorded as TaskFailed)", got.Status)
+	}
+	if !strings.Contains(got.Detail, "not attempted") || !strings.Contains(got.Detail, "Nothing was sent to the site") {
+		t.Fatalf("expected the 'not attempted / nothing was sent' detail, got %q", got.Detail)
+	}
+}
+
+// TestDeferForBusySite_WithinBound_KeepsDeferring proves the flip side: a
+// task well within siteBusyMaxWait is deferred, not terminalized.
+func TestDeferForBusySite_WithinBound_KeepsDeferring(t *testing.T) {
+	repo := &probeFakeRepo{}
+	w := newApplyTestWorker(repo, &siteBusyCommander{}, &scriptedProber{})
+
+	task := testTask()
+	task.CreatedAt = time.Now().Add(-5 * time.Minute) // well under siteBusyMaxWait (6h)
+
+	err := w.deferForBusySite(context.Background(), task, "another update is running on this site")
+	if len(repo.finished) != 0 {
+		t.Fatalf("a task within its bound must not be terminalized, got %+v", repo.finished)
+	}
+	if len(repo.deferred) != 1 {
+		t.Fatalf("expected exactly one defer, got %d", len(repo.deferred))
+	}
+	if _, ok := asSnooze(err); !ok {
+		t.Fatalf("expected a snooze, got %v", err)
+	}
+}
+
+// TestDeferForBusySite_ErrTaskNotOpen_StopsWithoutSnoozing proves the race
+// with a halt: when DeferTaskToPending reports ErrTaskNotOpen (something else
+// already terminalized the task, e.g. a halt cancelled it while this worker
+// was mid-flight), deferForBusySite must return nil — no snooze, no retry —
+// and must leave the recorded outcome alone.
+func TestDeferForBusySite_ErrTaskNotOpen_StopsWithoutSnoozing(t *testing.T) {
+	repo := &probeFakeRepo{deferErr: ErrTaskNotOpen}
+	w := newApplyTestWorker(repo, &siteBusyCommander{}, &scriptedProber{})
+
+	task := testTask()
+	err := w.deferForBusySite(context.Background(), task, "another update is running on this site")
+	if err != nil {
+		t.Fatalf("expected nil (the recorded terminal outcome wins), got %v", err)
+	}
+	if len(repo.finished) != 0 {
+		t.Fatalf("deferForBusySite must never itself call finish on ErrTaskNotOpen, got %+v", repo.finished)
+	}
+}
+
+// TestDeferForBusySite_RepoErrorSnoozesShortWithoutTerminalizing proves a
+// CP-side DB hiccup while recording the wait never terminalizes the task: it
+// snoozes at the SHORT (minimum) backoff and retries the demotion, rather
+// than giving up and failing a task purely because of infrastructure noise.
+func TestDeferForBusySite_RepoErrorSnoozesShortWithoutTerminalizing(t *testing.T) {
+	repo := &probeFakeRepo{deferErr: fmt.Errorf("db: connection reset")}
+	w := newApplyTestWorker(repo, &siteBusyCommander{}, &scriptedProber{})
+
+	task := testTask()
+	err := w.deferForBusySite(context.Background(), task, "another update is running on this site")
+	if len(repo.finished) != 0 {
+		t.Fatalf("a repo error recording the wait must never terminalize the task, got %+v", repo.finished)
+	}
+	if d := snoozeDuration(t, err); d != siteBusyBackoffMin {
+		t.Fatalf("expected the short snooze (siteBusyBackoffMin=%v) on a repo error, got %v", siteBusyBackoffMin, d)
+	}
+}
+
+// TestSiteBusyBackoff_DefaultWithinBounds proves the default jittered
+// schedule always lands in [siteBusyBackoffMin, siteBusyBackoffMax).
+func TestSiteBusyBackoff_DefaultWithinBounds(t *testing.T) {
+	w := newApplyTestWorker(&probeFakeRepo{}, &siteBusyCommander{}, &scriptedProber{})
+	task := testTask()
+	for i := 0; i < 200; i++ {
+		d := w.siteBusyBackoff(task)
+		if d < siteBusyBackoffMin || d >= siteBusyBackoffMax {
+			t.Fatalf("siteBusyBackoff() = %v, want in [%v, %v)", d, siteBusyBackoffMin, siteBusyBackoffMax)
+		}
+	}
+}
+
+// TestSetSiteBusyBackoff_Override proves the test-only override actually
+// replaces the schedule (used by the bulk-update integration test so it does
+// not sleep the production 5s-60s window).
+func TestSetSiteBusyBackoff_Override(t *testing.T) {
+	repo := &probeFakeRepo{}
+	w := newApplyTestWorker(repo, &siteBusyCommander{}, &scriptedProber{})
+	w.SetSiteBusyBackoff(func(Task) time.Duration { return time.Millisecond })
+
+	task := testTask()
+	err := w.deferForBusySite(context.Background(), task, "busy")
+	if d := snoozeDuration(t, err); d != time.Millisecond {
+		t.Fatalf("expected the overridden 1ms backoff, got %v", d)
+	}
+}
+
+// TestBusyBoundExceeded_Wording proves busyBoundExceeded's reason string is
+// only produced once the wall clock actually exceeds siteBusyMaxWait, and is
+// empty (task may still be deferred) right up to that boundary.
+func TestBusyBoundExceeded_Wording(t *testing.T) {
+	task := testTask()
+
+	task.CreatedAt = time.Now().Add(-1 * time.Minute)
+	if got := busyBoundExceeded(task); got != "" {
+		t.Fatalf("a freshly-deferred task must not be bound-exceeded, got %q", got)
+	}
+
+	task.CreatedAt = time.Now().Add(-siteBusyMaxWait - time.Second)
+	if got := busyBoundExceeded(task); got == "" {
+		t.Fatalf("a task past siteBusyMaxWait must be bound-exceeded")
+	}
+}
+
+// TestDeferredTaskTalliesAsInFlightNeverFailed is the GH #328 proof required
+// alongside the busy-defer path: a task the gate/handler above put back to
+// 'pending' (that is what DeferTaskToPending writes, and what a
+// bound-not-yet-exceeded deferForBusySite always leaves behind) must never be
+// countable as a wave failure. tallyWave's switch has exactly three terminal
+// buckets (Confirmed/Failed/Other) and a default that catches everything
+// else, including 'pending' and 'running', as InFlight. This also covers the
+// FULL proof the task's item 3 asks for: agent_wave.go's tallyWave and
+// haltReasonFor are reached ONLY for target_type='agent' tasks (see
+// waveOrder's filter), so a plugin/theme/core task deferred by
+// deferForBusySite is not merely counted safely if it ever reached this
+// code, it structurally never does.
+func TestDeferredTaskTalliesAsInFlightNeverFailed(t *testing.T) {
+	pending := Task{ID: uuid.New(), TargetType: TargetAgent, Status: TaskPending, CreatedAt: time.Now()}
+	tally := tallyWave([]Task{pending}, WaveRange{Start: 0, End: 1})
+	if tally.Failed != 0 {
+		t.Fatalf("a 'pending' (deferred) task must never tally as Failed, got Failed=%d", tally.Failed)
+	}
+	if tally.InFlight != 1 {
+		t.Fatalf("a 'pending' (deferred) task must tally as InFlight, got InFlight=%d", tally.InFlight)
+	}
+
+	// And the wave state machine itself never even reaches haltReasonFor while
+	// a wave has an in-flight task: DeriveAgentWaveState returns as soon as
+	// t.InFlight > 0, before the halt verdict is judged at all.
+	st := DeriveAgentWaveState([]Task{pending})
+	if st.Halt {
+		t.Fatalf("a wave with an in-flight (deferred) task must never halt, got HaltReason=%q", st.HaltReason)
+	}
+}
+
+// TestSiteWriterHoldMax_UnderStaleTaskThreshold pins the timing relationships
+// the GH #328 gate depends on for safety.
+func TestSiteWriterHoldMax_UnderStaleTaskThreshold(t *testing.T) {
+	// This is the relationship a future tuning pass could silently break: the
+	// gate must stop trusting a 'running' row strictly before the reaper
+	// would terminalize it, and comfortably after the worst-case apply job
+	// can legitimately still be running (DeriveApplyJobTimeout).
+	if siteWriterHoldMax >= staleTaskThreshold {
+		t.Fatalf("siteWriterHoldMax (%v) must be < staleTaskThreshold (%v)", siteWriterHoldMax, staleTaskThreshold)
+	}
+	maxApply := DeriveApplyJobTimeout(8*time.Minute, 30*time.Second)
+	if siteWriterHoldMax <= maxApply {
+		t.Fatalf("siteWriterHoldMax (%v) must be > the worst-case apply job budget (%v)", siteWriterHoldMax, maxApply)
+	}
 }

--- a/apps/api/tests/update_integration_test.go
+++ b/apps/api/tests/update_integration_test.go
@@ -77,6 +77,34 @@ type fakeAgent struct {
 	// updateResp/rollbackResp override the command responses.
 	updateResp   agentcmd.UpdateResponse
 	rollbackResp agentcmd.RollbackResponse
+
+	// --- GH #328: simulated per-site update lock (see enableSiteLock) ---
+	//
+	// siteLockHold, when > 0, makes the update handler behave like a real
+	// agent holding WP_Upgrader::create_lock for approximately this long per
+	// request: it holds an internal mutex for the duration and refuses any
+	// OVERLAPPING request with an ItemSiteBusy result instead of the
+	// scripted updateResp. concurrentPeak is the high-water mark of
+	// SIMULTANEOUS lock holders observed (must never exceed 1 if the lock is
+	// doing its job); lockWon counts requests that actually acquired it.
+	siteLockHold   time.Duration
+	lockMu         sync.Mutex
+	concurrentNow  int32
+	concurrentPeak int32
+	lockWon        int32
+	busyRefusals   int32
+}
+
+// enableSiteLock turns on the simulated per-site update lock: the update
+// handler now holds an internal mutex for `hold` per request and answers any
+// overlapping request with a single ItemSiteBusy result (ok=false), instead
+// of the scripted updateResp. Used by the GH #328 serialisation tests to
+// prove the control plane's per-site gate plus the agent's own lock actually
+// keep concurrent applies against one site down to exactly one at a time.
+func (fa *fakeAgent) enableSiteLock(hold time.Duration) {
+	fa.mu.Lock()
+	fa.siteLockHold = hold
+	fa.mu.Unlock()
 }
 
 func newFakeAgent(t *testing.T) *fakeAgent {
@@ -100,12 +128,41 @@ func newFakeAgent(t *testing.T) *fakeAgent {
 		fa.updateCmd = cmd
 		expect := fa.expectAud
 		resp := fa.updateResp
+		lockHold := fa.siteLockHold
 		fa.mu.Unlock()
 		// Mirror the real agent: require a Bearer token whose aud == this site's
 		// enrollment id and cmd == the dispatched command. Reject otherwise.
 		if r.Header.Get("Authorization") == "" || (expect != "" && aud != expect) || cmd != "update" {
 			w.WriteHeader(http.StatusForbidden)
 			return
+		}
+		if lockHold > 0 {
+			// Simulated site lock (GH #328): only ONE request may hold it at a
+			// time; an overlapping request is refused as busy exactly like a
+			// real agent whose WP_Upgrader::create_lock failed.
+			if !fa.lockMu.TryLock() {
+				atomic.AddInt32(&fa.busyRefusals, 1)
+				var item agentcmd.UpdateItem
+				if len(req.Items) > 0 {
+					item = req.Items[0]
+				}
+				writeJSON(w, agentcmd.UpdateResponse{OK: false, Results: []agentcmd.ItemResult{{
+					Type: item.Type, Slug: item.Slug, Status: agentcmd.ItemSiteBusy,
+					Log: "another update is running on this site",
+				}}})
+				return
+			}
+			atomic.AddInt32(&fa.lockWon, 1)
+			n := atomic.AddInt32(&fa.concurrentNow, 1)
+			for {
+				old := atomic.LoadInt32(&fa.concurrentPeak)
+				if n <= old || atomic.CompareAndSwapInt32(&fa.concurrentPeak, old, n) {
+					break
+				}
+			}
+			time.Sleep(lockHold)
+			atomic.AddInt32(&fa.concurrentNow, -1)
+			fa.lockMu.Unlock()
 		}
 		writeJSON(w, resp)
 	})

--- a/apps/api/tests/update_site_busy_gate_test.go
+++ b/apps/api/tests/update_site_busy_gate_test.go
@@ -1,0 +1,289 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/update"
+)
+
+// TestSiteHasRunningUpdateTask_Gate pins the SQL behaviour of the GH #328
+// per-site serialisation gate (SiteHasRunningUpdateTask / INVARIANT R)
+// directly against a real Postgres, independent of the worker/River harness:
+// what "busy" means, that a task never sees itself as busy, that a stale
+// 'running' row is ignored (the gate's own staleness clause), and that a
+// running agent-target row is excluded entirely (Block D never gates a
+// plugin/theme/core dispatch, and vice versa).
+func TestSiteHasRunningUpdateTask_Gate(t *testing.T) {
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "upd-gate")
+	repo := update.NewRepo(pool)
+	ctx := context.Background()
+
+	// Each subtest gets its OWN site (never shared across t.Run blocks). A
+	// task deliberately left 'running' by one subtest (to set up its
+	// scenario) would otherwise leak into every later subtest sharing the
+	// same site and permanently poison SiteHasRunningTask's answer for it,
+	// since the gate is scoped to a site, not to a subtest.
+	newSite := func(t *testing.T) uuid.UUID {
+		t.Helper()
+		return seedGateSite(t, pool, tenant)
+	}
+	mkTaskOn := func(t *testing.T, site uuid.UUID, targetType, slug string) update.Task {
+		t.Helper()
+		_, tasks, err := repo.CreateRunWithTasks(ctx, update.CreateRunInput{TenantID: tenant}, []update.NewTask{
+			{SiteID: site, TargetType: targetType, TargetSlug: slug, DesiredVersion: "latest", FromVersion: "1.0.0"},
+		})
+		if err != nil {
+			t.Fatalf("create task: %v", err)
+		}
+		return tasks[0]
+	}
+
+	t.Run("a running sibling makes the gate busy", func(t *testing.T) {
+		site := newSite(t)
+		a := mkTaskOn(t, site, "plugin", "a")
+		b := mkTaskOn(t, site, "plugin", "b")
+		if _, err := repo.MarkTaskRunning(ctx, tenant, a.ID); err != nil {
+			t.Fatalf("mark running: %v", err)
+		}
+		busy, err := repo.SiteHasRunningTask(ctx, tenant, site, b.ID, 20*time.Minute)
+		if err != nil {
+			t.Fatalf("gate: %v", err)
+		}
+		if !busy {
+			t.Fatal("expected the gate to report busy while a sibling task is running")
+		}
+	})
+
+	t.Run("a task never sees itself as busy", func(t *testing.T) {
+		site := newSite(t)
+		a := mkTaskOn(t, site, "plugin", "c")
+		if _, err := repo.MarkTaskRunning(ctx, tenant, a.ID); err != nil {
+			t.Fatalf("mark running: %v", err)
+		}
+		busy, err := repo.SiteHasRunningTask(ctx, tenant, site, a.ID, 20*time.Minute)
+		if err != nil {
+			t.Fatalf("gate: %v", err)
+		}
+		if busy {
+			t.Fatal("a task must never see its OWN running row as a busy sibling")
+		}
+	})
+
+	t.Run("a pending sibling does not make the gate busy", func(t *testing.T) {
+		site := newSite(t)
+		// mkTaskOn leaves the row 'pending' (never marked running): under
+		// INVARIANT R a waiter must never look busy to another waiter, or the
+		// whole no-deadlock proof collapses.
+		mkTaskOn(t, site, "plugin", "d")
+		b := mkTaskOn(t, site, "plugin", "e")
+		busy, err := repo.SiteHasRunningTask(ctx, tenant, site, b.ID, 20*time.Minute)
+		if err != nil {
+			t.Fatalf("gate: %v", err)
+		}
+		if busy {
+			t.Fatal("a merely-pending sibling must never make the gate busy (INVARIANT R: only 'running' counts)")
+		}
+	})
+
+	t.Run("a stale running row is ignored", func(t *testing.T) {
+		site := newSite(t)
+		a := mkTaskOn(t, site, "plugin", "f")
+		b := mkTaskOn(t, site, "plugin", "g")
+		if _, err := repo.MarkTaskRunning(ctx, tenant, a.ID); err != nil {
+			t.Fatalf("mark running: %v", err)
+		}
+		backdateTaskTimestamps(t, pool, a.ID, 30*time.Minute)
+
+		busy, err := repo.SiteHasRunningTask(ctx, tenant, site, b.ID, 20*time.Minute)
+		if err != nil {
+			t.Fatalf("gate: %v", err)
+		}
+		if busy {
+			t.Fatal("a 'running' row older than holdMax cannot have a live worker behind it and must not be trusted")
+		}
+
+		// The SAME row, well within holdMax, DOES gate: proves the staleness
+		// clause (not some other reason) was what ignored it above.
+		fresh := mkTaskOn(t, site, "plugin", "h")
+		if _, err := repo.MarkTaskRunning(ctx, tenant, fresh.ID); err != nil {
+			t.Fatalf("mark running: %v", err)
+		}
+		i := mkTaskOn(t, site, "plugin", "i")
+		busy, err = repo.SiteHasRunningTask(ctx, tenant, site, i.ID, 20*time.Minute)
+		if err != nil {
+			t.Fatalf("gate: %v", err)
+		}
+		if !busy {
+			t.Fatal("a fresh 'running' row within holdMax must still gate")
+		}
+	})
+
+	t.Run("a running agent-target row never gates a plugin dispatch", func(t *testing.T) {
+		site := newSite(t)
+		a := mkTaskOn(t, site, "agent", update.AgentTargetSlug)
+		b := mkTaskOn(t, site, "plugin", "j")
+		if _, err := repo.MarkTaskRunning(ctx, tenant, a.ID); err != nil {
+			t.Fatalf("mark running: %v", err)
+		}
+		busy, err := repo.SiteHasRunningTask(ctx, tenant, site, b.ID, 20*time.Minute)
+		if err != nil {
+			t.Fatalf("gate: %v", err)
+		}
+		if busy {
+			t.Fatal("a running agent-target task must be excluded from the gate entirely (target_type <> 'agent')")
+		}
+	})
+}
+
+// TestDeferUpdateTaskToPending_Semantics pins DeferTaskToPending's contract:
+// it flips the row back to 'pending', clears started_at, records the wait
+// detail, refreshes updated_at, is idempotent from either open state, and
+// reports ErrTaskNotOpen (rather than silently no-op'ing) once the task has
+// already reached a terminal state.
+func TestDeferUpdateTaskToPending_Semantics(t *testing.T) {
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "upd-defer")
+	repo := update.NewRepo(pool)
+	ctx := context.Background()
+	site := seedGateSite(t, pool, tenant)
+
+	_, tasks, err := repo.CreateRunWithTasks(ctx, update.CreateRunInput{TenantID: tenant}, []update.NewTask{
+		{SiteID: site, TargetType: "plugin", TargetSlug: "a", DesiredVersion: "latest", FromVersion: "1.0.0"},
+	})
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	task := tasks[0]
+
+	if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+		t.Fatalf("mark running: %v", err)
+	}
+
+	deferred, err := repo.DeferTaskToPending(ctx, update.DeferTaskInput{TenantID: tenant, TaskID: task.ID, Detail: "waiting: another update is running on this site"})
+	if err != nil {
+		t.Fatalf("defer: %v", err)
+	}
+	if deferred.Status != update.TaskPending {
+		t.Fatalf("status = %s, want pending", deferred.Status)
+	}
+	if deferred.StartedAt != nil {
+		t.Fatalf("started_at = %v, want cleared (nil)", deferred.StartedAt)
+	}
+	if deferred.Detail != "waiting: another update is running on this site" {
+		t.Fatalf("detail = %q, want the wait sentence", deferred.Detail)
+	}
+
+	// Idempotent from the already-pending state (the pre-dispatch gate case:
+	// nothing was ever sent, DeferTaskToPending is called anyway).
+	again, err := repo.DeferTaskToPending(ctx, update.DeferTaskInput{TenantID: tenant, TaskID: task.ID, Detail: "waiting: attempt 2"})
+	if err != nil {
+		t.Fatalf("defer again from pending: %v", err)
+	}
+	if again.Status != update.TaskPending || again.Detail != "waiting: attempt 2" {
+		t.Fatalf("expected a second successful defer from 'pending', got status=%s detail=%q", again.Status, again.Detail)
+	}
+
+	// Once terminal, DeferTaskToPending must refuse rather than silently
+	// resurrect a finished task.
+	if _, err := repo.FinishTask(ctx, update.FinishTaskInput{TenantID: tenant, TaskID: task.ID, Status: update.TaskSucceeded, FromVersion: "1.0.0", ToVersion: "1.1.0"}); err != nil {
+		t.Fatalf("finish: %v", err)
+	}
+	if _, err := repo.DeferTaskToPending(ctx, update.DeferTaskInput{TenantID: tenant, TaskID: task.ID, Detail: "waiting: too late"}); err == nil {
+		t.Fatal("expected ErrTaskNotOpen once the task is terminal")
+	}
+}
+
+// TestBusyDeferredTask_ReapedOnlyWhenAbandoned is the GH #328 reaper proof
+// (task requirement 4): a task DeferTaskToPending just touched is NOT stale
+// (a live River job is evidently still minding it, since only Worker.Work
+// issues this statement), but the SAME row, once its updated_at watermark
+// stops advancing (the worker crashed or its queue was lost), IS claimed by
+// the periodic reaper after the threshold — a busy task must never become
+// immortal.
+func TestBusyDeferredTask_ReapedOnlyWhenAbandoned(t *testing.T) {
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "upd-reap-busy")
+	repo := update.NewRepo(pool)
+	ctx := context.Background()
+	site := seedGateSite(t, pool, tenant)
+
+	_, tasks, err := repo.CreateRunWithTasks(ctx, update.CreateRunInput{TenantID: tenant}, []update.NewTask{
+		{SiteID: site, TargetType: "plugin", TargetSlug: "a", DesiredVersion: "latest", FromVersion: "1.0.0"},
+	})
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	task := tasks[0]
+	if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+		t.Fatalf("mark running: %v", err)
+	}
+	if _, err := repo.DeferTaskToPending(ctx, update.DeferTaskInput{TenantID: tenant, TaskID: task.ID, Detail: "waiting: busy"}); err != nil {
+		t.Fatalf("defer: %v", err)
+	}
+
+	// Fresh off a defer: updated_at is now(), so a short reaper threshold must
+	// NOT claim it yet.
+	stale, err := repo.ListStaleUpdateTasks(ctx, time.Hour, 100)
+	if err != nil {
+		t.Fatalf("list stale: %v", err)
+	}
+	if containsTaskID(stale, task.ID) {
+		t.Fatal("a task just deferred (fresh updated_at) must not be reaped as stale")
+	}
+
+	// Simulate the worker/queue having been lost: the watermark freezes.
+	backdateTaskTimestamps(t, pool, task.ID, 2*time.Hour)
+
+	stale, err = repo.ListStaleUpdateTasks(ctx, time.Hour, 100)
+	if err != nil {
+		t.Fatalf("list stale: %v", err)
+	}
+	if !containsTaskID(stale, task.ID) {
+		t.Fatal("a busy-deferred task whose watermark stopped advancing must eventually be reaped: it must not become immortal")
+	}
+}
+
+func containsTaskID(tasks []update.Task, id uuid.UUID) bool {
+	for _, t := range tasks {
+		if t.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// seedGateSite enrolls a minimal site (no live agent needed: these tests
+// exercise the repo/SQL layer directly, never an HTTP round trip). Reuses
+// enrollFakeSite (update_integration_test.go), which only writes DB rows and
+// never dials the given URL. The URL is made unique per call: sites carries a
+// UNIQUE (tenant_id, url) index (sites_tenant_id_url_key), and this helper is
+// called more than once per tenant across a test's subtests.
+func seedGateSite(t *testing.T, pool *db.Pool, tenant uuid.UUID) uuid.UUID {
+	t.Helper()
+	url := fmt.Sprintf("https://gate-test-%s.example", uuid.New().String())
+	return enrollFakeSite(t, pool, tenant, url).ID
+}
+
+// backdateTaskTimestamps rewinds an update_tasks row's started_at and
+// updated_at by d, out of band via a superuser connection, to simulate a row
+// a live worker is no longer minding (a crashed worker, a lost queue) without
+// waiting d in real time.
+func backdateTaskTimestamps(t *testing.T, pool *db.Pool, taskID uuid.UUID, d time.Duration) {
+	t.Helper()
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	// make_interval(secs => $2) avoids any ambiguity in parsing a Go duration
+	// string as a Postgres interval literal.
+	if _, err := admin.Exec(context.Background(),
+		`UPDATE update_tasks SET started_at = started_at - make_interval(secs := $2), updated_at = updated_at - make_interval(secs := $2) WHERE id = $1`,
+		taskID, d.Seconds()); err != nil {
+		t.Fatalf("backdate task timestamps: %v", err)
+	}
+}

--- a/apps/api/tests/update_site_serialization_test.go
+++ b/apps/api/tests/update_site_serialization_test.go
@@ -1,0 +1,207 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
+	"github.com/mosamlife/wpmgr/apps/api/internal/site"
+	"github.com/mosamlife/wpmgr/apps/api/internal/update"
+)
+
+// GH #328 PIECE 2 (serialisation), end to end: the control plane's per-site
+// gate (SiteHasRunningUpdateTask / DeferUpdateTaskToPending, INVARIANT R) and
+// the agent's own site-update lock (simulated here by fakeAgent.
+// enableSiteLock) together keep concurrent applies against ONE site's
+// wp-content/upgrade/ down to exactly one at a time, and a busy refusal is
+// retried to completion rather than ever becoming a permanent TaskFailed or
+// a deadlock.
+//
+// No test here may assert that the CP-side gate ALONE prevents a collision:
+// it is deliberately best-effort (see SiteHasRunningUpdateTask's own comment
+// in db/query/updates.sql). The mutual-exclusion guarantee is the agent's
+// lock, simulated by fakeAgent's internal mutex; concurrentPeak is measured
+// against what the fake AGENT observed, never against how many commands the
+// control plane sent.
+
+// seedPendingPluginsBulk records N distinct pending plugin advisories on one
+// site in a SINGLE ApplyMetadata call (site.Service.ApplyMetadata replaces
+// the whole plugins list per call, so seeding them one at a time via
+// seedPendingPlugin would each overwrite the last) and returns the matching
+// update.Item slice ready for CreateRunInput.Items.
+func seedPendingPluginsBulk(t *testing.T, h *updateTestHarness, tenant uuid.UUID, s site.Site, n int) []update.Item {
+	t.Helper()
+	comps := make([]site.Component, 0, n)
+	items := make([]update.Item, 0, n)
+	for i := 0; i < n; i++ {
+		slug := fmt.Sprintf("plugin-%02d", i)
+		comps = append(comps, site.Component{
+			Slug: slug, Version: "1.0.0",
+			AvailableUpdate: &site.AvailableUpdate{NewVersion: "1.1.0"},
+		})
+		items = append(items, update.Item{Type: "plugin", Slug: slug, Version: "latest"})
+	}
+	if _, err := h.siteSvc.ApplyMetadata(context.Background(), tenant, s.ID, site.Metadata{Plugins: comps}); err != nil {
+		t.Fatalf("seed pending plugins bulk: %v", err)
+	}
+	return items
+}
+
+// waitRunCompletedWithin is waitRunCompleted with a caller-supplied deadline,
+// for tests whose serialised workload legitimately takes longer than the
+// package default (25s).
+func waitRunCompletedWithin(t *testing.T, h *updateTestHarness, tenant, runID uuid.UUID, timeout time.Duration) (update.Run, []update.Task) {
+	t.Helper()
+	ctx := context.Background()
+	deadline := time.Now().Add(timeout)
+	for {
+		run, tasks, err := h.svc.GetRun(ctx, tenant, runID)
+		if err != nil {
+			t.Fatalf("get run: %v", err)
+		}
+		if run.Status == update.RunCompleted {
+			return run, tasks
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("run did not complete within %s (status=%s tasks=%+v)", timeout, run.Status, tasks)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// TestSingleSiteBulkOfThirtyDoesNotDeadlockAndSerializes is the required
+// 30-plugin single-site bulk case: it must complete (no deadlock) and the
+// agent must never observe more than one update in flight against the site
+// at once.
+func TestSingleSiteBulkOfThirtyDoesNotDeadlockAndSerializes(t *testing.T) {
+	const n = 30
+
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "upd-bulk30")
+	fa := newFakeAgent(t)
+	fa.setHomepage(http.StatusOK, "<html>ok</html>")
+	// A short, real hold so the test proves actual overlap-avoidance rather
+	// than passing by luck: with river's per-tenant-shard MaxWorkers=3 (see
+	// startUpdateRiver), the first wave WILL send up to 3 concurrent apply
+	// commands to this one site; the simulated lock is what turns that into
+	// "one wins, the rest are refused busy" rather than three concurrent
+	// writers.
+	fa.enableSiteLock(20 * time.Millisecond)
+
+	h := buildHarness(t, pool, newTestCommander(t), newTestProber(t))
+	// Tiny, deterministic backoff so this test does not spend the production
+	// 5s-60s jittered window 29 times over.
+	h.worker.SetSiteBusyBackoff(func(update.Task) time.Duration { return 15 * time.Millisecond })
+
+	s := enrollFakeSite(t, pool, tenant, fa.url())
+	fa.setExpectAud(s.ID.String())
+	items := seedPendingPluginsBulk(t, h, tenant, s, n)
+
+	run, tasks, err := h.svc.CreateRun(context.Background(), update.CreateRunInput{
+		TenantID: tenant,
+		SiteIDs:  []uuid.UUID{s.ID},
+		Items:    items,
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if len(tasks) != n {
+		t.Fatalf("want %d tasks, got %d", n, len(tasks))
+	}
+
+	// Generous bound: n serialised holds at 20ms is 600ms of pure "work", plus
+	// per-task DB/River overhead and (deliberately, per the design) some
+	// wasted first-wave collisions. 60s comfortably absorbs CI jitter while
+	// still catching an actual deadlock (which would otherwise hang forever).
+	finalRun, finalTasks := waitRunCompletedWithin(t, h, tenant, run.ID, 60*time.Second)
+	if finalRun.Status != update.RunCompleted {
+		t.Fatalf("run status = %s, want completed", finalRun.Status)
+	}
+	if len(finalTasks) != n {
+		t.Fatalf("want %d final tasks, got %d", n, len(finalTasks))
+	}
+	for _, tk := range finalTasks {
+		if tk.Status != update.TaskSucceeded {
+			t.Fatalf("task %s (%s) status = %s, want succeeded (detail=%s err=%s)",
+				tk.ID, tk.TargetSlug, tk.Status, tk.Detail, tk.Error)
+		}
+	}
+
+	peak := atomic.LoadInt32(&fa.concurrentPeak)
+	if peak != 1 {
+		t.Fatalf("agent observed peak concurrency %d against one site, want exactly 1: serialisation failed", peak)
+	}
+	won := atomic.LoadInt32(&fa.lockWon)
+	if won != n {
+		t.Fatalf("agent recorded %d successful lock acquisitions, want exactly %d (one per task, eventually)", won, n)
+	}
+	// The busy path must actually have been exercised (not accidentally
+	// bypassed by the CP-side gate alone, which is best-effort): with 3
+	// concurrent River workers dispatching against one site's first wave,
+	// at least some requests must have collided with the agent's lock.
+	if atomic.LoadInt32(&fa.busyRefusals) == 0 {
+		t.Fatalf("expected at least one site_busy refusal from the agent (the busy-defer path was never exercised)")
+	}
+}
+
+// TestEveryUpdateRefusedThenAcceptedStillCompletes is the deadlock witness:
+// the agent refuses EVERY request as busy for a short window, then starts
+// accepting. Under the prior ("running means dispatched-and-waiting")
+// design this would hang forever, because a refused task never stopped
+// occupying the gate. Under INVARIANT R a refused task goes straight back to
+// 'pending' and is retried, so the run still completes once the window
+// clears.
+func TestEveryUpdateRefusedThenAcceptedStillCompletes(t *testing.T) {
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "upd-allbusy")
+	fa := newFakeAgent(t)
+	fa.setHomepage(http.StatusOK, "<html>ok</html>")
+
+	h := buildHarness(t, pool, newTestCommander(t), newTestProber(t))
+	h.worker.SetSiteBusyBackoff(func(update.Task) time.Duration { return 20 * time.Millisecond })
+
+	s := enrollFakeSite(t, pool, tenant, fa.url())
+	fa.setExpectAud(s.ID.String())
+	seedPendingPlugin(t, h, tenant, s, "akismet", "1.0.0", "1.1.0")
+
+	// Refuse everything for the first ~300ms, then let the scripted success
+	// response through (fa.updateResp defaults to a plain ItemSucceeded).
+	fa.mu.Lock()
+	fa.updateResp = agentcmd.UpdateResponse{OK: false, Results: []agentcmd.ItemResult{{
+		Status: agentcmd.ItemSiteBusy, Log: "another update is running on this site",
+	}}}
+	fa.mu.Unlock()
+	deadline := time.Now().Add(300 * time.Millisecond)
+	go func() {
+		time.Sleep(time.Until(deadline))
+		fa.mu.Lock()
+		fa.updateResp = agentcmd.UpdateResponse{OK: true, Results: []agentcmd.ItemResult{{
+			Status: agentcmd.ItemSucceeded, FromVersion: "1.0.0", ToVersion: "1.1.0", SnapshotID: "snap-1",
+		}}}
+		fa.mu.Unlock()
+	}()
+
+	run, _, err := h.svc.CreateRun(context.Background(), update.CreateRunInput{
+		TenantID: tenant,
+		SiteIDs:  []uuid.UUID{s.ID},
+		Items:    []update.Item{{Type: "plugin", Slug: "akismet", Version: "latest"}},
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	_, finalTasks := waitRunCompletedWithin(t, h, tenant, run.ID, 30*time.Second)
+	tk := finalTasks[0]
+	if tk.Status != update.TaskSucceeded {
+		t.Fatalf("task status = %s, want succeeded once the busy window cleared (detail=%s)", tk.Status, tk.Detail)
+	}
+	if atomic.LoadInt32(&fa.updateCalls) < 2 {
+		t.Fatalf("expected at least one busy refusal before the eventual success, got only %d update call(s)", fa.updateCalls)
+	}
+}

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,29 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.114",
+    date: "2026-08-03",
+    summary: "Two updates could run against the same site at once and corrupt each other. Updates, rollbacks and agent upgrades on one site are now serialized, and a busy site retries instead of failing.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Two updates could previously be dispatched to the same site at the same time, for example two plugins in the same bulk run, or an update and a rollback overlapping, running more than one WordPress installer against the same site concurrently. WordPress's own updater is not built for that: a second installer can delete files the first one is still relying on, corrupting the update in progress and, in the reported case, leaving the site briefly returning errors. Updates, rollbacks and agent upgrades against one site are now serialized: only one may run at a time, whichever channel it came from.",
+      },
+      {
+        tag: "Fixed",
+        text: "A site that is busy with another update no longer fails the update that was turned away. It is retried automatically, with the reason shown on the task, for up to 6 hours before being recorded as not attempted rather than failed, and being busy never counts as a failure, so it can never fail a canary or halt a fleet-wide rollout by itself.",
+      },
+      {
+        tag: "Fixed",
+        text: "Separately, when an update fails before it has touched anything on the site (for example a corrupted download), the site no longer runs an automatic restore over a plugin or theme directory it never modified.",
+      },
+      {
+        tag: "Changed",
+        text: "Updating many items on one site is correspondingly slower, since they now run strictly one at a time on that site instead of several in parallel: a 30-plugin update on a single site that previously took roughly 6 to 12 minutes now typically takes 15 to 50 minutes. Updates spread across different sites are unaffected and still run in parallel. A brief window also remains at the moment a plugin or theme's files are swapped in, where a page load could in principle hit a half-updated directory, the same exposure WordPress's own core updater has always had for an admin-initiated single-plugin update; with updates now serialized one at a time, that window is measured in microseconds. A single plugin update started from a site's own WordPress dashboard still does not take part in this lock, so that one collision between a fleet-triggered update and a person using wp-admin at the same moment remains open.",
+      },
+    ],
+  },
+  {
     version: "0.61.113",
     date: "2026-08-02",
     summary: "The fleet Agent column can now show when the upstream release was last confirmed, and superadmins can check for a new release on demand from the admin console instead of waiting up to six hours.",

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.113
+  version: 0.61.114
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Fixes #328.

## The report

A self-hoster on ISPConfig hit plugin updates failing with `Could not copy file` and the site left throwing a fatal. **Two different plugins** failed the same way, wp-seopress and fluentform, which is what first strained the "plugin-specific" reading.

## Root cause, and it is ours

The control plane dispatches one item per HTTP request, de-duplicates only on `(tenant, site, target_type, target_slug)`, and bounds concurrency **per tenant**. So two *different* plugins on the *same* site run concurrently. `m88` closed the same-target case and left this one open; its own header already named the harm.

Core's `unpack_package()` **deletes every entry under `wp-content/upgrade/` as its first act**, discarding both delete results. One update's unpack therefore destroys a sibling's in-progress extraction mid-write.

That message is emitted from three places in core and is distinguishable only by its error **data**:

```
file.php:1825  copy_failed_ziparchive  data = zip-relative entry name
file.php:2042  copy_failed_copy_dir    data = ABSOLUTE path
```

The reporter's was zip-relative, which proves `install_package()` never ran and the plugin directory was **never touched**.

**Then we made it worse.** The agent ran a full snapshot restore over that untouched, healthy directory. A failed update that changed nothing was followed by a recovery action that did.

## What ships

**Per-site serialisation.** The agent takes a site-wide lock over core's own `create_lock`/`release_lock` covering the whole window core may touch `wp-content/upgrade/` or a destination, and answers `site_busy` when held. The control plane gains a per-site gate on one invariant: *a task is running IFF a command has been dispatched and not yet resolved; a task waiting for its site is pending.* Waiters depend only on runners, runners exit within their own timeout, so no wait-for cycle is representable. A busy answer defers to pending and retries; it is never finished and never tallied as a failure.

**Restore-skip.** A new classifier reads the structured error **codes** off the upgrader skin rather than the message text, split by whether core reached its first destructive line. On a proven-untouched failure we do not restore. Since none of the four backstops we had assumed cover that path actually run on it, the skip carries its **own** positive check: the destination is re-read and must still parse as the expected plugin. Anything unclassified or unverifiable restores, as before.

**Dry runs no longer mutate the site.** They were calling the in-flight healer, which can restore, and the snapshot GC, before `dry_run` was even parsed, contradicting our own command contract.

## Deliberately not done

**No maintenance mode.** With serialisation the swap is two atomic renames, so the window it would protect is microseconds, while a stranded `.maintenance` file is a site outage our own repair mu-plugin cannot fix (it loads at `wp-settings.php:498`; `wp_maintenance()` runs at `:79`). A microsecond window remains and is the identical exposure core ships on every admin-initiated update. That is stated in the changelog rather than omitted.

**Nothing sets `wp_doing_cron`** on the general update path. Setting it makes core fire its entire background auto-updater inside our own request, manufacturing the very concurrency this fixes.

## Found in review and fixed here

A busy site could **still** halt a fleet rollout: the self-update apply recorded `failed` when it gave up waiting for the lock, though nothing was attempted. It now records `deferred`, and the control plane finishes that as skipped.

The changelog claim that being busy *"can never halt a rollout"* was also **corrected**. A wave where no site attempted anything does still stop, because nothing was proven, and it now says so honestly rather than promising more than it delivers.

## Gates

```
agent phpunit  3130 tests, 0 failures, 0 errors
phpcs          0 errors      plugin check  0 errors
go build / vet / test   clean
lockstep       0.61.114 across CHANGELOG, openapi.yaml, marketing, agent header + constant
dashes         0
```

## Known limits

- The reporter's specific incident remains **inferred**: we have not proven two tasks overlapped on their box. Every element of the mechanism is proven, and the fix stands on its own regardless, since the control plane demonstrably creates this concurrency today.
- Two DB-backed CP tests skip without Postgres locally and need CI to execute them.
- Disk precheck, stale-upgrade-dir preflight, opcache invalidation in the restore path, and the snapshot symlink skip are all real and all deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updates, rollbacks, and agent upgrades are serialized per site to prevent overlapping operations.
  * Busy sites are automatically retried for up to six hours instead of being marked as failed.
  * Dry runs avoid making changes while still reporting potential conflicts.
* **Bug Fixes**
  * Failed updates avoid unnecessary restoration when files were confirmed untouched.
  * Plugin activation is restored when appropriate after an update failure.
  * Unattempted updates are reported as skipped rather than failed.
* **Documentation**
  * Added release notes for version 0.61.114.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->