### PR TITLE
chore(deps): pin brace-expansion 1.1.18 to clear GHSA-rgw5-rvv9-x895

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@1: 1.1.16
+  brace-expansion@1: 1.1.18
   brace-expansion@5: 5.0.8
   js-yaml@3: 3.15.0
   js-yaml@4: 4.3.0
@@ -3173,8 +3173,8 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -8340,7 +8340,7 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -9946,7 +9946,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   mitt@3.0.1:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,10 +5,16 @@ packages:
   - "packages/*"
 # Force patched versions of transitive dependencies flagged by high-severity
 # advisories (DoS via quadratic/exponential parsing). All are same-major pins,
-# so no API change: brace-expansion 1.1.16 (GHSA-3jxr-9vmj-r5cp), js-yaml 3.15.0
-# for gray-matter and js-yaml 4.3.0 for eslint tooling (GHSA-52cp-r559-cp3m).
+# so no API change: brace-expansion 1.1.18 (GHSA-3jxr-9vmj-r5cp and
+# GHSA-rgw5-rvv9-x895), js-yaml 3.15.0 for gray-matter and js-yaml 4.3.0 for
+# eslint tooling (GHSA-52cp-r559-cp3m).
 overrides:
-  brace-expansion@1: 1.1.16
+  # 1.1.18, not 1.1.16. GHSA-rgw5-rvv9-x895 (published after this block was
+  # first written) is vulnerable below 1.1.18 and, unlike the advisory noted
+  # under brace-expansion@5 below, it DOES have a 1.x backport. Staying on
+  # 1.1.16 reddens the audit on every branch with no code change, which is how
+  # this bump was found.
+  brace-expansion@1: 1.1.18
   # brace-expansion 5.x <=5.0.7 is a DoS via unbounded expansion length
   # (GHSA-mh99-v99m-4gvg). Patched in 5.0.8. The advisory collapses every major
   # into one range, so 1.1.16 is nominally flagged too, but there is no 1.x


### PR DESCRIPTION
The Security audit job started failing on **every branch with no code change**. This is the live-advisory-database pattern: `GHSA-rgw5-rvv9-x895` was published after our override block was written.

## Confirmed pre-existing, not introduced

`main` reproduces the identical 6 vulnerabilities (2 high) with an unmodified tree, and the branch that surfaced it (#331) touched no JS dependency at all.

## The fix is a one-line bump, not a new exception

`pnpm-workspace.yaml` already pinned `brace-expansion@1` to `1.1.16`, on the documented grounds that *"there is no 1.x backport"*.

That reasoning still holds for `GHSA-mh99-v99m-4gvg`, which stays documented under `auditConfig.ignoreGhsas`. It does **not** hold for this new advisory: it is vulnerable below `1.1.18`, and `1.1.18` exists in the 1.x line.

So this bumps an existing deliberate pin rather than adding a new suppression, and the comment explaining why 1.1.16 was chosen is updated so the next reader is not misled by it.

## Verified the risk the original comment named

The existing comment warned that forcing a version onto the 1.x consumers *"breaks eslint at runtime (@eslint/config-array pathMatches)"*. Checked:

```
pnpm audit --prod --audit-level high   6 vulns (2 high)  ->  4 vulns (0 high)
pnpm -w run lint                       4 tasks successful
web vitest                             108 files, 1341 tests, all passed
tsc --noEmit                           14 pre-existing TS2769 zod/resolver
                                       overloads, 0 mentioning brace-expansion
                                       or minimatch
```

Merging this unblocks #331 and every other branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented brace-expansion version override to 1.1.18.
  * Expanded advisory notes with additional security guidance and version rationale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->