### PR TITLE
fix(web): correct Core Web Vitals axis units and thresholds (GH #329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.115] - 2026-08-04
+
+### Fixed
+
+- The Core Web Vitals trend charts (Performance, and a site's Optimize tab) stated the wrong Good threshold (GH #329). The dashed "Good" line on the LCP chart was labelled 3 seconds. The real Web Vitals Good threshold for LCP is 2.5 seconds, and the line was always drawn in the right place; only the label was wrong, because the number was rounded to whole seconds before it was printed. Anyone who read that label and treated 3 seconds as the target was working to a threshold that does not exist. The same rounding mislabelled the FCP Good line as 2 seconds (it is 1.8) and the TTFB needs-improvement line as 2 seconds (it is 1.8). Every threshold label now shows its true value.
+- The same charts printed the unit twice, so an axis label read "5sms" and "3sms" instead of "5s" and "3s", and the threshold labels read "Good 3sms" and "NI 4sms". This is the symptom that was reported.
+- A single vertical axis could mix two different scales at once, showing "650ms" and "2sms" as neighbouring labels on the same axis, which made the values impossible to compare by eye. Worse, because the seconds labels were rounded to whole seconds, four different heights on one LCP axis could all print the same text. Each axis now picks one scale for all of its labels, and no two labels on an axis can read the same.
+- On a site comfortably inside the Good band, neither threshold line was drawn at all, so there was no way to tell "this site is passing" from "no thresholds are configured on this chart". The Good line is now always in frame.
+- The threshold lines were drawn in the same colour as the data line on the LCP and INP charts, so on those two charts the target was indistinguishable from the measurement. They now use the standard pass and warning colours, matching the fleet chart on the Performance page, and those colours are defined for dark mode (the previous ones were not).
+
+### Changed
+
+- The small trend sparklines in the fleet tables (Sites, Uptime, Backups, Email) are drawn directly rather than through the charting library. A fleet table showing 100 sites was building 100 full chart engines to draw 100 tiny decorations that have no axes, no tooltips and nothing to interact with; the tables now render an order of magnitude faster and the Uptime and Backups pages no longer download the charting engine at all. They look the same.
+
 ## [0.61.114] - 2026-08-03
 
 ### Fixed

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,34 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.115",
+    date: "2026-08-04",
+    summary:
+      "The Core Web Vitals charts stated the wrong Good threshold. LCP's Good line was labelled 3 seconds; the real threshold is 2.5 seconds. Threshold labels, axis units and axis scales are all fixed.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "The Core Web Vitals trend charts stated the wrong Good threshold. The dashed Good line on the LCP chart was labelled 3 seconds. The real Web Vitals Good threshold for LCP is 2.5 seconds, and the line was always drawn in the right place; only the label was wrong, because the number was rounded to whole seconds before it was printed. Anyone who read that label and treated 3 seconds as the target was working to a threshold that does not exist. The same rounding mislabelled the FCP Good line as 2 seconds (it is 1.8) and the TTFB needs-improvement line as 2 seconds (it is 1.8). Every threshold label now shows its true value.",
+      },
+      {
+        tag: "Fixed",
+        text: "The same charts printed the unit twice, so an axis label read \"5sms\" and \"3sms\" instead of \"5s\" and \"3s\", and the threshold labels read \"Good 3sms\" and \"NI 4sms\".",
+      },
+      {
+        tag: "Fixed",
+        text: "A single vertical axis could mix two scales at once, showing \"650ms\" and \"2sms\" as neighbouring labels, which made the values impossible to compare by eye, and rounding to whole seconds meant four different heights on one LCP axis could print the same text. Each axis now picks one scale for all of its labels, and no two labels on an axis can read the same.",
+      },
+      {
+        tag: "Fixed",
+        text: "On a site comfortably inside the Good band, neither threshold line was drawn at all, so there was no way to tell \"this site is passing\" from \"no thresholds are configured\". The Good line is now always in frame. The threshold lines also shared a colour with the data line on the LCP and INP charts, making the target indistinguishable from the measurement; they now use the standard pass and warning colours, which are defined for dark mode.",
+      },
+      {
+        tag: "Changed",
+        text: "The small trend sparklines in the fleet tables are drawn directly rather than through the charting library. A fleet table showing 100 sites was building 100 full chart engines to draw 100 tiny decorations with no axes, no tooltips and nothing to interact with; the tables now render an order of magnitude faster and the Uptime and Backups pages no longer download the charting engine at all. They look the same.",
+      },
+    ],
+  },
+  {
     version: "0.61.114",
     date: "2026-08-03",
     summary: "Two updates could run against the same site at once and corrupt each other. Updates, rollbacks and agent upgrades on one site are now serialized, and a busy site retries instead of failing.",

--- a/apps/web/src/components/charts/no-axis-unit.test.ts
+++ b/apps/web/src/components/charts/no-axis-unit.test.ts
@@ -1,0 +1,124 @@
+// A source scan, not a render test, because this defect class is invisible at
+// any single call site.
+//
+// GH #329. Recharts builds every tick label as
+//
+//   "".concat(tickFormatter ? tickFormatter(v, i) : v).concat(unit || "")
+//
+// (recharts/es6/cartesian/CartesianAxis.js:353). The `unit` prop is appended
+// to the formatter's output unconditionally, with no warning and no opt-out.
+// A formatter that emits a unit AND a `unit` prop is therefore a bug by
+// construction, which is how an LCP axis came to print "3sms".
+//
+// The house rule is that the tick formatter is the sole owner of the unit
+// string, so no XAxis or YAxis anywhere in the app may set `unit`. Fixing the
+// one offending call site would not stop the next one; this test does.
+
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+// Vitest resolves its root to apps/web (vitest.config.ts lives there), so the
+// app sources are cwd/src. `import.meta.url` is not a file URL under the jsdom
+// environment, which is why this does not use it.
+const SRC_ROOT = join(process.cwd(), "src");
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, out);
+    } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+      // Tests are excluded: this very file carries a deliberate violation as
+      // its positive control, and no test renders shipped UI.
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Returns the raw prop text of every <XAxis> / <YAxis> element in `source`.
+ *
+ * A plain regex is not good enough here: axis props routinely hold arrow
+ * functions (`tickFormatter={(v) => ...}`), so a lazy `[^>]*?` scan would stop
+ * at the arrow's own ">" and miss a `unit=` that comes after it. Missing a
+ * violation is the dangerous direction, so this tracks brace depth instead and
+ * only treats a ">" at depth zero as the end of the tag.
+ */
+export function axisPropBlocks(source: string): string[] {
+  const blocks: string[] = [];
+  const tagStart = /<(?:X|Y)Axis\b/g;
+  let match: RegExpExecArray | null;
+  while ((match = tagStart.exec(source)) !== null) {
+    const start = match.index + match[0].length;
+    let depth = 0;
+    let i = start;
+    for (; i < source.length; i += 1) {
+      const ch = source[i];
+      if (ch === "{") depth += 1;
+      else if (ch === "}") depth -= 1;
+      else if (ch === ">" && depth === 0) break;
+    }
+    blocks.push(source.slice(start, i));
+  }
+  return blocks;
+}
+
+const UNIT_PROP = /\bunit\s*=/;
+
+describe("no recharts axis may set the `unit` prop (GH #329)", () => {
+  const files = walk(SRC_ROOT).filter((f) =>
+    readFileSync(f, "utf8").includes('from "recharts"'),
+  );
+
+  it("finds the recharts files it is supposed to be guarding", () => {
+    // A broken walk or a moved source root would otherwise turn this whole
+    // file into a silent pass. Eight files import recharts today.
+    expect(existsSync(join(SRC_ROOT, "components", "charts"))).toBe(true);
+    expect(files.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("finds axis elements to inspect", () => {
+    const total = files.reduce(
+      (n, f) => n + axisPropBlocks(readFileSync(f, "utf8")).length,
+      0,
+    );
+    expect(total).toBeGreaterThanOrEqual(10);
+  });
+
+  it("detects a violation when one exists (positive control)", () => {
+    const offending = `
+      <YAxis
+        dataKey="y"
+        tickFormatter={(v: number) => (v >= 1000 ? \`\${v / 1000}s\` : \`\${v}\`)}
+        width={44}
+        unit={unit}
+      />`;
+    const blocks = axisPropBlocks(offending);
+    expect(blocks).toHaveLength(1);
+    // The arrow function inside tickFormatter must not end the scan early.
+    expect(UNIT_PROP.test(blocks[0]!)).toBe(true);
+  });
+
+  it("does not flag a clean axis (negative control)", () => {
+    const clean = `
+      <YAxis
+        domain={axis.domain}
+        ticks={axis.ticks}
+        tickFormatter={axis.tick}
+        width={axis.width}
+      />`;
+    expect(UNIT_PROP.test(axisPropBlocks(clean)[0]!)).toBe(false);
+  });
+
+  it("has no XAxis or YAxis anywhere in the app that sets `unit`", () => {
+    for (const file of files) {
+      for (const block of axisPropBlocks(readFileSync(file, "utf8"))) {
+        expect(UNIT_PROP.test(block), `${file} sets a recharts axis unit prop`).toBe(
+          false,
+        );
+      }
+    }
+  });
+});

--- a/apps/web/src/components/charts/sparkline.test.tsx
+++ b/apps/web/src/components/charts/sparkline.test.tsx
@@ -1,0 +1,154 @@
+// Sparkline is a plain SVG polyline rather than a recharts <LineChart>. The
+// component header explains why (one Redux store per recharts root, up to 100
+// of them on a fleet screen). These tests pin the behaviour that had to
+// survive the rewrite: the accessibility wrapper, the >=2-point guard, the
+// gap handling, and the geometry the recharts version drew.
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { Sparkline, type SparklineDatum } from "./sparkline";
+
+function polylinePoints(container: HTMLElement): Array<[number, number]> {
+  const line = container.querySelector("polyline");
+  const raw = line?.getAttribute("points") ?? "";
+  return raw
+    .split(" ")
+    .filter(Boolean)
+    .map((pair) => {
+      const [x, y] = pair.split(",").map(Number);
+      return [x!, y!] as [number, number];
+    });
+}
+
+describe("Sparkline -- accessibility and shape", () => {
+  it("keeps the role=img wrapper and its label", () => {
+    render(<Sparkline data={[1, 5, 3]} ariaLabel="Uptime trend" />);
+
+    const img = screen.getByRole("img", { name: "Uptime trend" });
+    expect(img).toBeInTheDocument();
+    // The inner SVG must not be announced separately.
+    expect(img.querySelector("svg")).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("renders one polyline and no recharts machinery", () => {
+    const { container } = render(<Sparkline data={[1, 5, 3]} />);
+
+    expect(container.querySelectorAll("polyline")).toHaveLength(1);
+    expect(container.querySelector(".recharts-wrapper")).toBeNull();
+    expect(container.querySelector(".recharts-surface")).toBeNull();
+  });
+
+  it("uses the tone token for the stroke, never a hex value", () => {
+    const { container } = render(<Sparkline data={[1, 5, 3]} tone="destructive" />);
+
+    expect(container.querySelector("polyline")).toHaveAttribute(
+      "stroke",
+      "var(--color-destructive)",
+    );
+  });
+});
+
+describe("Sparkline -- the >=2 real points rule", () => {
+  it("renders a spacer and no line for an empty series", () => {
+    const { container } = render(<Sparkline data={[]} />);
+
+    expect(container.querySelector("polyline")).toBeNull();
+    expect(container.querySelector("span")).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("renders a spacer for a single point rather than a misleading dot", () => {
+    const { container } = render(<Sparkline data={[7]} />);
+
+    expect(container.querySelector("polyline")).toBeNull();
+  });
+
+  it("renders a spacer when every point is a gap", () => {
+    const data = [null, undefined, Number.NaN] as unknown as SparklineDatum[];
+    const { container } = render(<Sparkline data={data} />);
+
+    expect(container.querySelector("polyline")).toBeNull();
+  });
+});
+
+describe("Sparkline -- gaps and null handling", () => {
+  it("drops non-finite samples instead of plotting them as zero", () => {
+    // A NaN plotted as 0 would drag the whole series to the floor and invent a
+    // crash that never happened.
+    const data = [10, Number.NaN, 30] as unknown as SparklineDatum[];
+    const { container } = render(<Sparkline data={data} width={60} height={16} />);
+
+    const pts = polylinePoints(container);
+    expect(pts).toHaveLength(2);
+    expect(pts[0]).toEqual([0, 15]); // min sits on the bottom of the margin box
+    expect(pts[1]).toEqual([60, 1]); // max sits on the top
+  });
+
+  it("drops a null value inside an object series", () => {
+    const data = [
+      { value: 1 },
+      { value: null },
+      { value: 3 },
+      { value: 2 },
+    ] as unknown as SparklineDatum[];
+    const { container } = render(<Sparkline data={data} />);
+
+    expect(polylinePoints(container)).toHaveLength(3);
+  });
+
+  it("drops Infinity", () => {
+    const data = [1, Infinity, 2, -Infinity] as unknown as SparklineDatum[];
+    const { container } = render(<Sparkline data={data} />);
+
+    expect(polylinePoints(container)).toHaveLength(2);
+  });
+
+  it("never emits NaN in the points attribute", () => {
+    const data = [5, Number.NaN, 5, 5] as unknown as SparklineDatum[];
+    const { container } = render(<Sparkline data={data} />);
+
+    expect(container.querySelector("polyline")?.getAttribute("points")).not.toMatch(
+      /NaN/,
+    );
+  });
+});
+
+describe("Sparkline -- geometry matches what recharts drew", () => {
+  it("spreads samples evenly from x=0 to x=width", () => {
+    const { container } = render(
+      <Sparkline data={[0, 1, 2, 3, 4]} width={60} height={16} />,
+    );
+
+    expect(polylinePoints(container).map(([x]) => x)).toEqual([0, 15, 30, 45, 60]);
+  });
+
+  it("fills the margin box vertically, top 1 to height minus 1", () => {
+    const { container } = render(
+      <Sparkline data={[10, 20, 30]} width={60} height={16} />,
+    );
+
+    const ys = polylinePoints(container).map(([, y]) => y);
+    expect(ys[0]).toBe(15);
+    expect(ys[2]).toBe(1);
+    expect(ys[1]).toBe(8); // midpoint of the box for the midpoint value
+  });
+
+  it("puts a flat series on the midline, as a zero-width domain did before", () => {
+    const { container } = render(
+      <Sparkline data={[5, 5, 5]} width={60} height={16} />,
+    );
+
+    expect(polylinePoints(container).map(([, y]) => y)).toEqual([8, 8, 8]);
+  });
+
+  it("honours a caller-supplied size", () => {
+    const { container } = render(
+      <Sparkline data={[1, 2]} width={120} height={40} />,
+    );
+
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveAttribute("width", "120");
+    expect(svg).toHaveAttribute("height", "40");
+    expect(svg).toHaveAttribute("viewBox", "0 0 120 40");
+  });
+});

--- a/apps/web/src/components/charts/sparkline.tsx
+++ b/apps/web/src/components/charts/sparkline.tsx
@@ -1,13 +1,39 @@
 // Tiny inline line chart for table cells and tile decorations. Per DESIGN.md
 // (`components.Sparkline`): chart-1 stroke at 1.5px, no fill, no axes, no
-// tooltip, no dots. Bound to real series only — fewer than two points means
-// we render nothing (a flatline would lie about the absence of data).
+// tooltip, no dots. Bound to real series only: fewer than two points means we
+// render nothing (a flatline would lie about the absence of data).
 //
 // Tone maps to the chart palette so a destructive sparkline can sit next to
 // a destructive badge without us hard-coding hex anywhere. Callers pass
 // either a raw `number[]` or `{ value, label }[]` so both API shapes work.
-
-import { LineChart, Line, ResponsiveContainer, YAxis } from "recharts";
+//
+// WHY THIS IS PLAIN SVG AND NOT RECHARTS.
+//
+// This used to render a recharts <LineChart> with a hidden <YAxis>. Every
+// recharts root builds its OWN Redux store (RechartsStoreProvider.js calls
+// createRechartsStore per instance behind a useRef) plus its own
+// ResizeObserver and its own SVG surface. FleetTable renders one sparkline per
+// row with no virtualizer and use-fleet-uptime.ts asks for up to 100 rows, so
+// a single fleet screen mounted up to 100 Redux stores to draw 100 sixty-by-
+// sixteen-pixel decorations with no axes, no grid, no tooltip and no
+// interaction. Measured in jsdom at N=100: 222-385 ms mount and 2,305 DOM
+// nodes for the recharts version against 3.4-5.4 ms and 205 nodes for a plain
+// polyline. It also kept the whole cartesian charting engine in the chunk
+// graph for /uptime and /backups, which have no other chart.
+//
+// The geometry below reproduces what recharts drew, so this is not a visual
+// change:
+//   - x uses a point scale across the full width, first sample at x=0 and last
+//     at x=width, which is what recharts does for a line chart.
+//   - y spans the margin box the old chart used, top: 1 and bottom: 1.
+//   - the old <YAxis domain={["dataMin","dataMax"]}> made the series fill the
+//     box exactly, and a flat series landed on the vertical midpoint (d3 maps
+//     a zero-width domain to the middle of the range). Both are preserved.
+// The one deliberate difference is that segments are straight rather than
+// recharts' "monotone" curve, which at this size is under a pixel.
+//
+// The role="img" + aria-label wrapper is load-bearing and must stay: raw SVG
+// does not get recharts' accessibilityLayer for free.
 
 export type SparklineDatum = number | { value: number; label?: string };
 
@@ -27,6 +53,14 @@ const toneToVar: Record<NonNullable<SparklineProps["tone"]>, string> = {
   destructive: "var(--color-destructive)",
 };
 
+/**
+ * Drops every entry that is not a finite number, matching the pre-existing
+ * behaviour exactly: a gap (null, undefined, NaN, Infinity, a malformed datum)
+ * is removed from the series rather than plotted as a zero. The remaining
+ * samples keep their order and are spread evenly across the width, so a gap
+ * shortens the series rather than putting a hole in it. Two samples are the
+ * minimum; below that we render a spacer instead of inventing a trend.
+ */
 function normalize(data: SparklineDatum[]): { value: number; label?: string }[] {
   return data
     .map((d): { value: number; label?: string } | null => {
@@ -39,6 +73,37 @@ function normalize(data: SparklineDatum[]): { value: number; label?: string }[] 
       return null;
     })
     .filter((d): d is { value: number; label?: string } => d !== null);
+}
+
+/** Margin box the recharts version used: top 1, bottom 1, no side margins. */
+const MARGIN_Y = 1;
+
+function buildPoints(
+  values: number[],
+  width: number,
+  height: number,
+): string {
+  const top = MARGIN_Y;
+  const bottom = height - MARGIN_Y;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min;
+  const lastIndex = values.length - 1;
+
+  return values
+    .map((v, i) => {
+      const x = lastIndex === 0 ? width / 2 : (i / lastIndex) * width;
+      // A flat series has no vertical range to map onto, so it sits on the
+      // midline. This is what d3 (and therefore recharts) already did.
+      const y =
+        span === 0 ? (top + bottom) / 2 : bottom - ((v - min) / span) * (bottom - top);
+      return `${round2(x)},${round2(y)}`;
+    })
+    .join(" ");
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
 }
 
 export function Sparkline({
@@ -67,6 +132,11 @@ export function Sparkline({
   }
 
   const stroke = toneToVar[tone];
+  const points = buildPoints(
+    series.map((d) => d.value),
+    width,
+    height,
+  );
 
   return (
     <span
@@ -79,26 +149,23 @@ export function Sparkline({
         lineHeight: 0,
       }}
     >
-      <ResponsiveContainer width={width} height={height}>
-        <LineChart
-          data={series}
-          margin={{ top: 1, right: 0, bottom: 1, left: 0 }}
-        >
-          {/* YAxis hidden but configured so the line uses the full vertical
-              range — without it Recharts pads the domain and the spark looks
-              squashed in a 16px box. */}
-          <YAxis hide domain={["dataMin", "dataMax"]} />
-          <Line
-            type="monotone"
-            dataKey="value"
-            stroke={stroke}
-            strokeWidth={1.5}
-            dot={false}
-            activeDot={false}
-            isAnimationActive={false}
-          />
-        </LineChart>
-      </ResponsiveContainer>
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        aria-hidden="true"
+        focusable="false"
+        style={{ display: "block" }}
+      >
+        <polyline
+          points={points}
+          fill="none"
+          stroke={stroke}
+          strokeWidth={1.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
     </span>
   );
 }

--- a/apps/web/src/features/perf/cwv-axis.test.ts
+++ b/apps/web/src/features/perf/cwv-axis.test.ts
@@ -1,0 +1,267 @@
+// GH #329. The LCP trend chart printed "3sms" where the Web Vitals Good
+// threshold is 2500 ms, and the axis rendered two different scales at once.
+// These tests pin the invariant that replaced it: ONE SCALE PER AXIS, and one
+// owner of the unit string.
+//
+// Every assertion here is written to fail against the pre-fix code. The old
+// tick formatter was:
+//
+//   metric === "cls" ? v.toFixed(2)
+//                    : v >= 1000 ? `${(v / 1000).toFixed(0)}s` : `${v}`
+//
+// plus a recharts `unit="ms"` prop that recharts appended to that output.
+
+import { describe, it, expect } from "vitest";
+
+import {
+  CWV_THRESHOLDS,
+  CWV_TICK_COUNT,
+  cwvDataMax,
+  cwvThresholdLabel,
+  cwvYAxis,
+  isCwvMetric,
+  type CwvMetric,
+} from "./cwv-axis";
+
+const METRICS: CwvMetric[] = ["lcp", "inp", "cls", "fcp", "ttfb"];
+
+/** Reads a rendered tick back into the axis's own display units. */
+function parseTick(text: string, unit: string): number {
+  const numeric = Number.parseFloat(text);
+  return unit === "s" ? numeric * 1000 : numeric;
+}
+
+/** A spread of plausible data maxima per metric, from "no data" to "awful". */
+function sweep(metric: CwvMetric): number[] {
+  const { good, ni } = CWV_THRESHOLDS[metric];
+  return [
+    0,
+    good * 0.01,
+    good * 0.4,
+    good * 0.99,
+    good,
+    good * 1.01,
+    ni * 0.9,
+    ni,
+    ni * 1.5,
+    ni * 3,
+    ni * 10,
+  ];
+}
+
+describe("cwvYAxis -- the reported defect (GH #329)", () => {
+  it("renders the LCP Good threshold as 2.5s, never 3sms and never 3s", () => {
+    const axis = cwvYAxis("lcp", 2100);
+
+    expect(axis.tick(2500)).toBe("2.5s");
+    expect(cwvThresholdLabel(axis, "good")).toBe("Good 2.5s");
+    expect(cwvThresholdLabel(axis, "ni")).toBe("NI 4.0s");
+
+    // The exact strings from the reporter's screenshot.
+    expect(cwvThresholdLabel(axis, "good")).not.toBe("Good 3sms");
+    expect(cwvThresholdLabel(axis, "ni")).not.toBe("NI 4sms");
+  });
+
+  it("never emits a doubled unit on any tick of any metric (D1)", () => {
+    for (const metric of METRICS) {
+      for (const dataMax of sweep(metric)) {
+        const axis = cwvYAxis(metric, dataMax);
+        for (const t of axis.ticks) {
+          expect(axis.tick(t)).not.toMatch(/sms|msms|ss$/);
+        }
+      }
+    }
+  });
+
+  it("states every one of the ten thresholds exactly (D2)", () => {
+    for (const metric of METRICS) {
+      const { good, ni } = CWV_THRESHOLDS[metric];
+      for (const dataMax of sweep(metric)) {
+        const axis = cwvYAxis(metric, dataMax);
+        const tolerance = metric === "cls" ? 0.0005 : 0.5;
+        // The pre-fix formatter turned LCP 2500 into "3s", an error of 500 ms.
+        expect(Math.abs(parseTick(axis.tick(good), axis.unit) - good)).toBeLessThan(
+          tolerance,
+        );
+        expect(Math.abs(parseTick(axis.tick(ni), axis.unit) - ni)).toBeLessThan(
+          tolerance,
+        );
+      }
+    }
+  });
+
+  it("puts every tick of one axis on the same scale (D3)", () => {
+    for (const metric of METRICS) {
+      for (const dataMax of sweep(metric)) {
+        const axis = cwvYAxis(metric, dataMax);
+        const suffixes = new Set(
+          axis.ticks.map((t) => axis.tick(t).replace(/^[\d.]+/, "")),
+        );
+        expect(suffixes.size, `${metric} @ ${dataMax}`).toBe(1);
+        expect([...suffixes][0]).toBe(axis.unit);
+      }
+    }
+  });
+
+  it("puts 650 and 2500 on one LCP axis in the same scale (D3)", () => {
+    const axis = cwvYAxis("lcp", 2600);
+    // Pre-fix this was ["650", "2s"] with a stray "ms" appended to each.
+    expect([650, 2000, 2500].map(axis.tick)).toEqual(["0.7s", "2.0s", "2.5s"]);
+  });
+
+  it("never renders two distinct ticks identically (D3b)", () => {
+    for (const metric of METRICS) {
+      for (const dataMax of sweep(metric)) {
+        const axis = cwvYAxis(metric, dataMax);
+        const rendered = axis.ticks.map(axis.tick);
+        expect(new Set(rendered).size, `${metric} @ ${dataMax}`).toBe(
+          new Set(axis.ticks).size,
+        );
+        expect(rendered).toHaveLength(CWV_TICK_COUNT);
+      }
+    }
+  });
+
+  it("keeps the Good threshold inside the domain for every input (D4)", () => {
+    for (const metric of METRICS) {
+      const { good } = CWV_THRESHOLDS[metric];
+      // Including hostile inputs: no data at all, NaN, negatives.
+      for (const dataMax of [...sweep(metric), Number.NaN, -1, Infinity]) {
+        const axis = cwvYAxis(metric, dataMax);
+        expect(axis.domain[0], `${metric} @ ${dataMax}`).toBe(0);
+        expect(axis.domain[1], `${metric} @ ${dataMax}`).toBeGreaterThanOrEqual(
+          good,
+        );
+      }
+    }
+  });
+
+  it("keeps the NI threshold in frame once the data reaches it (D4)", () => {
+    for (const metric of METRICS) {
+      const { ni } = CWV_THRESHOLDS[metric];
+      const axis = cwvYAxis(metric, ni);
+      expect(axis.domain[1], metric).toBeGreaterThanOrEqual(ni);
+    }
+  });
+});
+
+describe("cwvYAxis -- axis mechanics", () => {
+  it("keeps every plotted value inside the domain", () => {
+    for (const metric of METRICS) {
+      for (const dataMax of sweep(metric)) {
+        const axis = cwvYAxis(metric, dataMax);
+        expect(axis.domain[1], `${metric} @ ${dataMax}`).toBeGreaterThanOrEqual(
+          dataMax,
+        );
+      }
+    }
+  });
+
+  it("renders every tick exactly, losing no precision to the formatter", () => {
+    for (const metric of METRICS) {
+      for (const dataMax of sweep(metric)) {
+        const axis = cwvYAxis(metric, dataMax);
+        for (const t of axis.ticks) {
+          const back = parseTick(axis.tick(t), axis.unit);
+          expect(back, `${metric} @ ${dataMax} tick ${t}`).toBeCloseTo(t, 6);
+        }
+      }
+    }
+  });
+
+  it("spaces ticks evenly from zero to the domain maximum", () => {
+    for (const metric of METRICS) {
+      for (const dataMax of sweep(metric)) {
+        const axis = cwvYAxis(metric, dataMax);
+        expect(axis.ticks[0]).toBe(0);
+        expect(axis.ticks[axis.ticks.length - 1]).toBe(axis.domain[1]);
+        const step = axis.domain[1] / (CWV_TICK_COUNT - 1);
+        axis.ticks.forEach((t, i) => {
+          expect(t).toBeCloseTo(step * i, 6);
+        });
+      }
+    }
+  });
+
+  it("uses only ms, s or the empty unit, and never a unit for CLS", () => {
+    for (const metric of METRICS) {
+      for (const dataMax of sweep(metric)) {
+        const axis = cwvYAxis(metric, dataMax);
+        if (metric === "cls") {
+          expect(axis.unit).toBe("");
+        } else {
+          expect(["ms", "s"]).toContain(axis.unit);
+        }
+      }
+    }
+  });
+
+  it("sizes the axis to its widest label", () => {
+    for (const metric of METRICS) {
+      for (const dataMax of sweep(metric)) {
+        const axis = cwvYAxis(metric, dataMax);
+        const longest = Math.max(...axis.ticks.map((t) => axis.tick(t).length));
+        expect(axis.width).toBeGreaterThanOrEqual(longest * 6.5);
+        expect(axis.width).toBeLessThanOrEqual(56);
+      }
+    }
+  });
+
+  it("resolves the documented axis for each headline scenario", () => {
+    expect(cwvYAxis("lcp", 1250).ticks.map(cwvYAxis("lcp", 1250).tick)).toEqual([
+      "0.0s",
+      "1.0s",
+      "2.0s",
+      "3.0s",
+      "4.0s",
+    ]);
+
+    const inpFast = cwvYAxis("inp", 180);
+    expect(inpFast.ticks.map(inpFast.tick)).toEqual([
+      "0ms",
+      "100ms",
+      "200ms",
+      "300ms",
+      "400ms",
+    ]);
+    expect(cwvThresholdLabel(inpFast, "good")).toBe("Good 200ms");
+
+    const clsFast = cwvYAxis("cls", 0.09);
+    expect(clsFast.ticks.map(clsFast.tick)).toEqual([
+      "0.00",
+      "0.05",
+      "0.10",
+      "0.15",
+      "0.20",
+    ]);
+    expect(cwvThresholdLabel(clsFast, "good")).toBe("Good 0.10");
+    expect(cwvThresholdLabel(clsFast, "ni")).toBe("NI 0.25");
+
+    const ttfbFast = cwvYAxis("ttfb", 720);
+    expect(cwvThresholdLabel(ttfbFast, "good")).toBe("Good 800ms");
+
+    const ttfbSlow = cwvYAxis("ttfb", 1620);
+    expect(cwvThresholdLabel(ttfbSlow, "good")).toBe("Good 0.8s");
+    expect(cwvThresholdLabel(ttfbSlow, "ni")).toBe("NI 1.8s");
+
+    const fcp = cwvYAxis("fcp", 1620);
+    expect(cwvThresholdLabel(fcp, "good")).toBe("Good 1.8s");
+  });
+});
+
+describe("cwvDataMax", () => {
+  it("ignores gaps and non-finite values", () => {
+    expect(cwvDataMax([100, null, 900, null])).toBe(900);
+    expect(cwvDataMax([null, null])).toBe(0);
+    expect(cwvDataMax([])).toBe(0);
+    expect(cwvDataMax([Number.NaN, 5])).toBe(5);
+  });
+});
+
+describe("isCwvMetric", () => {
+  it("accepts the five CWV metrics and nothing else", () => {
+    for (const m of METRICS) expect(isCwvMetric(m)).toBe(true);
+    expect(isCwvMetric("fid")).toBe(false);
+    expect(isCwvMetric("")).toBe(false);
+  });
+});

--- a/apps/web/src/features/perf/cwv-axis.ts
+++ b/apps/web/src/features/perf/cwv-axis.ts
@@ -1,0 +1,214 @@
+// Y-axis geometry and tick rendering for the Core Web Vitals trend charts
+// (features/perf/optimize/RumTrendChart.tsx and the fleet trend chart in
+// routes/_authed/performance.tsx).
+//
+// THE INVARIANT THIS MODULE OWNS:
+//   ONE SCALE PER AXIS, and ONE OWNER OF THE UNIT STRING.
+//
+// GH #329. The LCP axis printed "5sms" / "3sms" and the Good threshold label
+// read "Good 3sms" where the real Web Vitals target is 2500 ms. Five separate
+// causes, all closed structurally here rather than patched at a call site:
+//
+//  D1 DOUBLE UNIT. Recharts appends the YAxis `unit` prop to whatever
+//     tickFormatter returns, unconditionally
+//     (recharts/es6/cartesian/CartesianAxis.js:353). The old code both set
+//     unit="ms" and returned a "s" suffix from the formatter, so every tick
+//     got two units. The tick formatter here is the ONLY owner of the unit
+//     string and no chart may ever set the recharts `unit` prop again. That
+//     rule is enforced by src/components/charts/no-axis-unit.test.ts, which
+//     scans source so the defect cannot come back at a new call site.
+//
+//  D2 A WRONG THRESHOLD VALUE, the serious one. toFixed(0) on seconds turned
+//     2500 into "3s", so the chart stated a Web Vitals target that does not
+//     exist (and 1800 into "2s" for FCP and TTFB). Every CWV threshold is a
+//     whole multiple of 100 ms, so one decimal of seconds states all ten of
+//     them exactly. cwv-axis.test.ts round-trips every threshold back through
+//     its own formatter to prove no label can lie again.
+//
+//  D3 TWO SCALES ON ONE AXIS. The old formatter chose ms or s per tick, so
+//     650 and 2000 landed on the same axis as "650ms" and "2sms". A scale is a
+//     property of the AXIS, not of a tick, because ticks are read against each
+//     other. It is resolved once, in cwvYAxis, from the axis maximum.
+//
+//  D3b A NON-INJECTIVE AXIS. Following from D2, on a 0..4000 LCP axis the
+//     values 1500 / 1600 / 2000 / 2400 all rendered "2sms": four different
+//     heights, one identical string. Ticks are returned explicitly and are
+//     always exact in the chosen scale, so two distinct ticks can never render
+//     the same text.
+//
+//  D4 SILENTLY DISCARDED THRESHOLD LINES. With domain ["auto","auto"] recharts
+//     drops a ReferenceLine whose y falls outside the domain (ifOverflow
+//     defaults to "discard": ReferenceLine.js:223 and :79) and only widens a
+//     domain for reference elements marked "extendDomain"
+//     (axisSelectors.js:673). A site comfortably inside the Good band
+//     therefore rendered NEITHER threshold line, and an operator could not
+//     tell "you are passing" from "no thresholds are configured". cwvYAxis
+//     returns an explicit domain that always contains the Good threshold.
+//
+//  D5 is fixed at the call sites: the threshold lines use --color-success and
+//     --color-warning (both overridden in .dark) rather than the --chart-*
+//     tokens, which collided with the series colour on LCP and INP and have no
+//     .dark override at all.
+//
+// WHY THE TOOLTIP DOES NOT USE THIS SCALE. Deliberate. Do not "helpfully"
+// unify them.
+//
+// An axis and a tooltip have different jobs. An axis needs a single scale
+// across all of its ticks because the ticks are read against each other. A
+// tooltip shows ONE value and must show it at the precision that value
+// deserves. #329 was the axis disagreeing with ITSELF and the unit being
+// appended twice; it was never the axis disagreeing with the tooltip.
+//
+// An earlier version of this fix routed the tooltip through the axis scale and
+// was refuted by measurement. Because the domain must always contain the Good
+// threshold, an FCP axis maximum is never below 2000 ms and is therefore
+// permanently on the seconds scale. On real fast-site data the five distinct
+// FCP p75 readings 780 / 812 / 795 / 840 / 879 collapsed to two strings
+// ("0.8 s" four times, then "0.9 s") where the tooltip renders five distinct
+// strings today. That is D3b relocated out of the axis and into the tooltip.
+// The same unification made the Health tile ambiguous at the band boundary:
+// 2460 ms (Good, green) and 2540 ms (Needs work, amber) would both read
+// "2.5 s", so the number would contradict the colour it is printed in.
+//
+// RumTrendChart.formatTrendValue keeps the per-value rule and is pinned by
+// RumTrendChart.test.tsx; features/perf/rum-tile.ts formatLcpP75 keeps its two
+// decimals for the same reason.
+
+export type CwvMetric = "lcp" | "inp" | "cls" | "fcp" | "ttfb";
+
+const CWV_METRICS: readonly string[] = ["lcp", "inp", "cls", "fcp", "ttfb"];
+
+export function isCwvMetric(value: string): value is CwvMetric {
+  return CWV_METRICS.includes(value);
+}
+
+/**
+ * Official CWV thresholds in DISPLAY units: milliseconds for the timing
+ * metrics, a unitless score for CLS. Callers that hold raw wire values must
+ * convert CLS (sent in milli-units) before comparing against these.
+ */
+export const CWV_THRESHOLDS: Record<CwvMetric, { good: number; ni: number }> = {
+  lcp: { good: 2500, ni: 4000 },
+  inp: { good: 200, ni: 500 },
+  cls: { good: 0.1, ni: 0.25 },
+  fcp: { good: 1800, ni: 3000 },
+  ttfb: { good: 800, ni: 1800 },
+};
+
+/** Ticks per axis, including both endpoints. */
+export const CWV_TICK_COUNT = 5;
+
+/**
+ * Multiplier applied to whichever is larger, the data maximum or the Good
+ * threshold. It buys the topmost line enough clearance that its label is not
+ * pinned against the plot edge.
+ */
+const HEADROOM = 1.08;
+
+/**
+ * Axis maxima at or below this render in milliseconds; above it, in seconds.
+ * The switch is per AXIS, never per tick (D3).
+ */
+const MS_AXIS_LIMIT = 1000;
+
+/**
+ * Step mantissas, in the order a human would pick them. Combined with the
+ * Good-threshold floor below, every reachable step is exact in the scale the
+ * axis ends up on: the smallest possible timing step is 100 ms (from INP,
+ * whose Good threshold is 200), and every step at or above 500 ms is a whole
+ * multiple of 100 ms, which one decimal of seconds represents exactly.
+ * cwv-axis.test.ts sweeps this rather than trusting the argument.
+ */
+const STEP_MANTISSAS: readonly number[] = [1, 2, 2.5, 5];
+
+function round6(n: number): number {
+  return Number(n.toFixed(6));
+}
+
+/** Smallest mantissa-times-power-of-ten step that is at least `minStep`. */
+function niceStep(minStep: number): number {
+  const target = minStep > 0 ? minStep : 1;
+  const exp = Math.floor(Math.log10(target));
+  for (let k = exp; k <= exp + 3; k += 1) {
+    for (const mantissa of STEP_MANTISSAS) {
+      const step = mantissa * 10 ** k;
+      if (step >= target - 1e-9) return round6(step);
+    }
+  }
+  return round6(10 ** (exp + 4));
+}
+
+export interface CwvAxis {
+  /** Explicit numeric domain. Always contains the Good threshold (D4). */
+  domain: [number, number];
+  /**
+   * Explicit tick values. Recharts picks its own step from a numeric domain
+   * (axisSelectors.js:787-815 getTickValuesFixedDomain), and a 750 ms tick on
+   * a one-decimal seconds axis would print "0.8", which is D2 at a smaller
+   * magnitude. Exactness is ours to guarantee, not the library's.
+   */
+  ticks: number[];
+  /** "ms", "s", or "" for CLS. ONE unit for the whole axis. */
+  unit: string;
+  /** Renders a value in this axis's single scale, unit included. */
+  tick: (value: number) => string;
+  /** YAxis width in px, sized to the widest label this axis will render. */
+  width: number;
+  /** The metric's thresholds in display units, for the ReferenceLines. */
+  thresholds: { good: number; ni: number };
+}
+
+function makeTickFormatter(unit: string): (value: number) => string {
+  if (unit === "s") return (value) => `${(value / 1000).toFixed(1)}s`;
+  if (unit === "ms") return (value) => `${Math.round(value)}ms`;
+  // CLS is unitless. Two decimals states both thresholds (0.10 and 0.25)
+  // exactly and every reachable tick step is a whole multiple of 0.01.
+  return (value) => value.toFixed(2);
+}
+
+/**
+ * Resolves the whole Y axis for one CWV chart in a single call: domain, ticks,
+ * unit, formatter and width. `dataMax` is the largest plotted value in DISPLAY
+ * units (CLS already divided by 1000).
+ */
+export function cwvYAxis(metric: CwvMetric, dataMax: number): CwvAxis {
+  const thresholds = CWV_THRESHOLDS[metric];
+  const observed = Number.isFinite(dataMax) && dataMax > 0 ? dataMax : 0;
+
+  // The Good line is always in frame. A pass-or-fail chart that hides the
+  // target it measures against is not a pass-or-fail chart. The NI line is
+  // allowed to fall outside: a site nowhere near it does not need it drawn.
+  const needed = Math.max(observed, thresholds.good) * HEADROOM;
+
+  const step = niceStep(needed / (CWV_TICK_COUNT - 1));
+  const max = round6(step * (CWV_TICK_COUNT - 1));
+  const ticks = Array.from({ length: CWV_TICK_COUNT }, (_, i) =>
+    round6(step * i),
+  );
+
+  const unit = metric === "cls" ? "" : max > MS_AXIS_LIMIT ? "s" : "ms";
+  const tick = makeTickFormatter(unit);
+
+  const longest = ticks.reduce((n, t) => Math.max(n, tick(t).length), 0);
+  const width = Math.min(56, Math.max(34, Math.round(10 + longest * 6.5)));
+
+  return { domain: [0, max], ticks, unit, tick, width, thresholds };
+}
+
+/**
+ * The text for a threshold ReferenceLine. Rendered through the axis formatter
+ * so the label can never disagree with the ticks it sits between, and so it
+ * can never restate the threshold as a number Google never published.
+ */
+export function cwvThresholdLabel(axis: CwvAxis, band: "good" | "ni"): string {
+  const prefix = band === "good" ? "Good" : "NI";
+  return `${prefix} ${axis.tick(axis.thresholds[band])}`;
+}
+
+/** Largest plotted value across a series, ignoring gaps. 0 when all are gaps. */
+export function cwvDataMax(values: Array<number | null>): number {
+  return values.reduce<number>(
+    (max, v) => (v !== null && Number.isFinite(v) && v > max ? v : max),
+    0,
+  );
+}

--- a/apps/web/src/features/perf/optimize/RumTrendChart.test.tsx
+++ b/apps/web/src/features/perf/optimize/RumTrendChart.test.tsx
@@ -1,0 +1,190 @@
+// GH #329, rendered. cwv-axis.test.ts pins the arithmetic; this file proves
+// the arithmetic actually reaches the SVG, which is where the defect was
+// visible: the reporter's screenshot showed axis labels "5sms" / "3sms" and a
+// threshold label reading "Good 3sms" on a chart whose Web Vitals Good target
+// is 2500 ms.
+//
+// jsdom gives ResponsiveContainer a 0x0 box, so a naive render asserts against
+// an empty tree and passes vacuously. Wrapping in an OUTER ResponsiveContainer
+// with fixed numeric dimensions makes recharts skip size detection entirely
+// (ResponsiveContainer.js: fixed width and height short-circuit to
+// ResponsiveContainerContextProvider) and makes the inner container return its
+// children as-is. The tick-count assertions below are what keeps a future
+// vacuous pass honest.
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ResponsiveContainer } from "recharts";
+
+import { RumTrendChart } from "./RumTrendChart";
+import { formatTrendValue } from "./rum-trend-format";
+import type { RumTrendPoint } from "../types";
+
+function points(values: number[]): RumTrendPoint[] {
+  return values.map((v, i) => ({
+    day: `2026-07-${String(i + 1).padStart(2, "0")}`,
+    p75_ms: v,
+    sample_count: 500,
+    rating: "good" as const,
+    suppressed: false,
+  }));
+}
+
+function renderChart(ui: React.ReactNode) {
+  return render(
+    <ResponsiveContainer width={640} height={220}>
+      {ui}
+    </ResponsiveContainer>,
+  );
+}
+
+// Recharts renders tick LABELS into their own z-index layer, a sibling of the
+// axis group rather than a child of it, so the selector has to target
+// `.recharts-yAxis-tick-labels` and not `.recharts-yAxis`. Every caller below
+// asserts a tick count first; a selector that silently matched nothing would
+// otherwise turn every "all ticks are well formed" assertion into a pass.
+function yTicks(): string[] {
+  return [
+    ...document.querySelectorAll(
+      ".recharts-yAxis-tick-labels .recharts-cartesian-axis-tick-value",
+    ),
+  ].map((n) => n.textContent ?? "");
+}
+
+describe("RumTrendChart -- Y axis (GH #329)", () => {
+  it("labels the LCP Good threshold with its true value, not 3sms", () => {
+    renderChart(<RumTrendChart metric="lcp" points={points([2100, 2200, 2050])} />);
+
+    expect(screen.getByText("Good 2.5s")).toBeInTheDocument();
+    expect(document.body.textContent).not.toMatch(/sms/);
+    expect(screen.queryByText("Good 3sms")).toBeNull();
+    expect(screen.queryByText("Good 3s")).toBeNull();
+  });
+
+  it("renders every Y tick on one scale with exactly one unit", () => {
+    renderChart(<RumTrendChart metric="lcp" points={points([2100, 2200, 2050])} />);
+
+    const ticks = yTicks();
+    expect(ticks).toEqual(["0.0s", "1.0s", "2.0s", "3.0s", "4.0s"]);
+    // Every tick is "<one decimal of seconds>s". Pre-fix this axis mixed bare
+    // milliseconds ("650") with doubled-unit seconds ("2sms").
+    expect(ticks.every((t) => /^\d+\.\ds$/.test(t))).toBe(true);
+  });
+
+  it("renders no two Y ticks with the same text", () => {
+    renderChart(<RumTrendChart metric="lcp" points={points([2100, 2200, 2050])} />);
+
+    const ticks = yTicks();
+    expect(ticks.length).toBeGreaterThan(2);
+    // Pre-fix, 1500 / 1600 / 2000 / 2400 all rendered "2sms" on this axis.
+    expect(new Set(ticks).size).toBe(ticks.length);
+  });
+
+  it("keeps both threshold lines in frame on a comfortably passing site", () => {
+    // All p75 well inside the Good band. With domain ["auto","auto"] recharts
+    // discarded both ReferenceLines here, so the operator could not tell
+    // "you are passing" from "no thresholds configured".
+    renderChart(<RumTrendChart metric="lcp" points={points([780, 812, 795, 840])} />);
+
+    expect(screen.getByText("Good 2.5s")).toBeInTheDocument();
+    expect(screen.getByText("NI 4.0s")).toBeInTheDocument();
+  });
+
+  it("draws the threshold lines in the success and warning tokens, not the series token", () => {
+    const { container } = renderChart(
+      <RumTrendChart metric="lcp" points={points([2100, 2200, 2050])} />,
+    );
+
+    const strokes = [
+      ...container.querySelectorAll(".recharts-reference-line-line"),
+    ].map((n) => n.getAttribute("stroke"));
+
+    expect(strokes).toContain("var(--color-success)");
+    expect(strokes).toContain("var(--color-warning)");
+    // --chart-1 is the LCP series colour AND has no .dark override.
+    expect(strokes).not.toContain("var(--color-chart-1)");
+    expect(strokes).not.toContain("var(--color-chart-4)");
+  });
+
+  it("never sets the recharts unit prop on its Y axis", () => {
+    renderChart(<RumTrendChart metric="ttfb" points={points([600, 640, 610])} />);
+
+    const ticks = yTicks();
+    expect(ticks).toEqual(["0ms", "250ms", "500ms", "750ms", "1000ms"]);
+    // Exactly one unit per tick. The recharts `unit` prop would have made
+    // these "0msms" ... "1000msms".
+    expect(ticks.every((t) => /^\d+ms$/.test(t))).toBe(true);
+  });
+
+  it("renders CLS ticks unitless and with a true 0.10 Good label", () => {
+    // The API sends CLS in milli-units.
+    renderChart(<RumTrendChart metric="cls" points={points([80, 90, 85])} />);
+
+    expect(screen.getByText("Good 0.10")).toBeInTheDocument();
+    const ticks = yTicks();
+    expect(ticks).toEqual(["0.00", "0.05", "0.10", "0.15", "0.20"]);
+  });
+
+  it("still shows the empty state below two unsuppressed days", () => {
+    render(
+      <RumTrendChart
+        metric="lcp"
+        points={[
+          {
+            day: "2026-07-01",
+            p75_ms: 0,
+            sample_count: 2,
+            rating: "",
+            suppressed: true,
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText("Not enough data yet to show a trend"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("RumTrendChart -- tooltip precision is NOT the axis scale", () => {
+  // The refutation that killed the first fix attempt. Routing the tooltip
+  // through the axis scale would have collapsed these readings, because an FCP
+  // or LCP axis is permanently on the seconds scale (its domain must contain
+  // the Good threshold). These are the measured values from that refutation.
+  it("keeps five distinct FCP readings distinct", () => {
+    const readings = [780, 812, 795, 840, 879].map((v) =>
+      formatTrendValue("fcp", v),
+    );
+
+    expect(readings).toEqual([
+      "780.0 ms",
+      "812.0 ms",
+      "795.0 ms",
+      "840.0 ms",
+      "879.0 ms",
+    ]);
+    // The axis-scale version produced "0.8 s" four times, then "0.9 s".
+    expect(new Set(readings).size).toBe(5);
+  });
+
+  it("keeps five distinct sub-second LCP readings distinct", () => {
+    const readings = [820, 867, 905, 948, 999].map((v) =>
+      formatTrendValue("lcp", v),
+    );
+
+    expect(new Set(readings).size).toBe(5);
+    expect(readings[0]).toBe("820.0 ms");
+  });
+
+  it("switches to seconds only once a reading is at least one second", () => {
+    expect(formatTrendValue("lcp", 999)).toBe("999.0 ms");
+    expect(formatTrendValue("lcp", 1000)).toBe("1.0 s");
+    expect(formatTrendValue("lcp", 2500)).toBe("2.5 s");
+  });
+
+  it("keeps CLS at three decimals", () => {
+    expect(formatTrendValue("cls", 0.083)).toBe("0.083");
+    expect(formatTrendValue("cls", 0.1)).toBe("0.100");
+  });
+});

--- a/apps/web/src/features/perf/optimize/RumTrendChart.tsx
+++ b/apps/web/src/features/perf/optimize/RumTrendChart.tsx
@@ -1,4 +1,4 @@
-// RumTrendChart — daily p75 line/area chart for one CWV metric.
+// RumTrendChart, daily p75 line/area chart for one CWV metric.
 //
 // Mirrors cache-hit-ratio-chart.tsx conventions exactly:
 //   - ChartEmpty when fewer than 2 non-suppressed points.
@@ -16,10 +16,17 @@
 // value. connectNulls={false} causes Recharts to break the line at those days
 // rather than interpolating through them, preserving data honesty.
 //
-// CLS display: divide p75_ms by 1000 before rendering; show 3 decimal places.
-// All other metrics render as ms with one decimal place (or seconds when >= 1s).
+// CLS display: divide p75_ms by 1000 before rendering.
 //
-// Tooltip: shows the day, the formatted p75, and the sample_count.
+// Tooltip: shows the day, the p75 formatted by rum-trend-format.ts (CLS at 3
+// decimals, everything else in ms to one decimal, or seconds once a reading
+// reaches 1s), and the sample_count.
+//
+// GH #329: the Y axis and the threshold labels are owned entirely by
+// features/perf/cwv-axis.ts. Read the header of that file before changing
+// anything below about ticks, units, the domain or the threshold lines; in
+// particular the tooltip formatter here deliberately does NOT share the axis
+// scale, and the reason is measured and written down there.
 
 import type { ReactNode } from "react";
 import {
@@ -34,22 +41,21 @@ import {
 } from "recharts";
 
 import { ChartEmpty } from "@/components/charts/chart-empty";
+import {
+  cwvDataMax,
+  cwvThresholdLabel,
+  cwvYAxis,
+  type CwvAxis,
+  type CwvMetric,
+} from "../cwv-axis";
+import { formatTrendValue } from "./rum-trend-format";
 import type { RumTrendPoint } from "../types";
 
 // ---------------------------------------------------------------------------
 // Display constants
 // ---------------------------------------------------------------------------
 
-export type MetricName = "lcp" | "inp" | "cls" | "fcp" | "ttfb";
-
-/** Official CWV thresholds in display units (ms for timing, unitless for CLS). */
-const THRESHOLDS: Record<MetricName, { good: number; ni: number }> = {
-  lcp: { good: 2500, ni: 4000 },
-  inp: { good: 200, ni: 500 },
-  cls: { good: 0.1, ni: 0.25 },
-  fcp: { good: 1800, ni: 3000 },
-  ttfb: { good: 800, ni: 1800 },
-};
+export type MetricName = CwvMetric;
 
 const METRIC_LABELS: Record<MetricName, string> = {
   lcp: "LCP",
@@ -59,21 +65,28 @@ const METRIC_LABELS: Record<MetricName, string> = {
   ttfb: "TTFB",
 };
 
-const METRIC_UNITS: Record<MetricName, string> = {
-  lcp: "ms",
-  inp: "ms",
-  cls: "",
-  fcp: "ms",
-  ttfb: "ms",
-};
-
 // Chart-token per metric to vary the line color across small multiples.
+//
+// DELIBERATELY AVOIDS --chart-2 AND --chart-3. Those two are defined at
+// oklch(60% 0.14 155) and oklch(62% 0.16 75), which are the SAME hue and
+// nearly the same chroma as --success (58% 0.14 155) and --warning
+// (70% 0.14 75). Since the Good and Needs-Improvement reference lines carry
+// those semantic colors, using chart-2 for FCP or chart-3 for TTFB drew the
+// series in the same green, or the same amber, as its own threshold line
+// (measured OKLab dE 0.0200 for FCP, 0.0825 for TTFB), and the series paints
+// over the line. The threshold colors are semantic and must not move, so the
+// decorative series colors move instead.
+//
+// Repeats across metrics are fine and intentional: every metric renders in
+// its own card, so the only separation that has to hold is series versus
+// threshold WITHIN one chart. The three hues used here (195, 235, 320) all
+// sit far from the semantic 155 and 75.
 const CHART_TOKEN: Record<MetricName, string> = {
   lcp: "var(--color-chart-1)",
   inp: "var(--color-chart-4)",
   cls: "var(--color-chart-5)",
-  fcp: "var(--color-chart-2)",
-  ttfb: "var(--color-chart-3)",
+  fcp: "var(--color-chart-5)",
+  ttfb: "var(--color-chart-4)",
 };
 
 // Gradient IDs must be unique per metric to avoid cross-contamination.
@@ -90,7 +103,7 @@ const GRADIENT_ID: Record<MetricName, string> = {
 // ---------------------------------------------------------------------------
 
 function shortDate(day: string): string {
-  // day is "YYYY-MM-DD" — parse as UTC noon to avoid timezone off-by-one.
+  // day is "YYYY-MM-DD", parsed as UTC noon to avoid a timezone off-by-one.
   const d = new Date(`${day}T12:00:00Z`);
   if (Number.isNaN(d.getTime())) return day;
   return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
@@ -99,17 +112,6 @@ function shortDate(day: string): string {
 /** Convert raw p75_ms from the API to the display value for a given metric. */
 function toDisplayValue(metric: MetricName, p75_ms: number): number {
   return metric === "cls" ? p75_ms / 1000 : p75_ms;
-}
-
-/** Format a display value (already converted) for tooltip / axis labels. */
-function formatDisplay(metric: MetricName, value: number): string {
-  if (metric === "cls") {
-    return value.toFixed(3);
-  }
-  if (value >= 1000) {
-    return `${(value / 1000).toFixed(1)} s`;
-  }
-  return `${value.toFixed(1)} ms`;
 }
 
 // ---------------------------------------------------------------------------
@@ -168,7 +170,7 @@ function TrendTooltip({ active, payload, label, metric }: TrendTooltipProps) {
           </dt>
           <dd className="ml-auto font-mono tabular-nums text-[var(--color-foreground)]">
             {value !== null && value !== undefined
-              ? formatDisplay(metric, value)
+              ? formatTrendValue(metric, value)
               : "Insufficient samples"}
           </dd>
         </div>
@@ -185,20 +187,6 @@ function TrendTooltip({ active, payload, label, metric }: TrendTooltipProps) {
       </dl>
     </div>
   );
-}
-
-// ---------------------------------------------------------------------------
-// Y-axis tick formatter
-// ---------------------------------------------------------------------------
-
-function makeYFormatter(metric: MetricName): (v: number) => string {
-  if (metric === "cls") {
-    return (v: number) => v.toFixed(2);
-  }
-  return (v: number) => {
-    if (v >= 1000) return `${(v / 1000).toFixed(0)}s`;
-    return `${Math.round(v)}`;
-  };
 }
 
 // ---------------------------------------------------------------------------
@@ -221,10 +209,8 @@ export function RumTrendChart({
   height = 160,
   title,
 }: RumTrendChartProps) {
-  const thresholds = THRESHOLDS[metric];
   const chartToken = CHART_TOKEN[metric];
   const gradientId = GRADIENT_ID[metric];
-  const unit = METRIC_UNITS[metric];
 
   // Map API points to chart datums. Suppressed days become y=null so the line
   // breaks (connectNulls={false}). Non-suppressed days are converted to display
@@ -236,6 +222,12 @@ export function RumTrendChart({
     suppressed: pt.suppressed,
   }));
 
+  // One scale for the whole axis, resolved once from the data maximum (D3).
+  const axis = cwvYAxis(
+    metric,
+    cwvDataMax(chartData.map((d) => d.y)),
+  );
+
   // Count non-suppressed points. Show ChartEmpty when fewer than 2.
   const unsuppressedCount = chartData.filter((d) => d.y !== null).length;
 
@@ -243,7 +235,7 @@ export function RumTrendChart({
     unsuppressedCount < 2 ? (
       <ChartEmpty message="Not enough data yet to show a trend" />
     ) : (
-      renderChart(chartData, metric, thresholds, chartToken, gradientId, unit, height)
+      renderChart(chartData, metric, axis, chartToken, gradientId, height)
     );
 
   if (!title) return <>{content}</>;
@@ -259,16 +251,12 @@ export function RumTrendChart({
 function renderChart(
   chartData: ChartDatum[],
   metric: MetricName,
-  thresholds: { good: number; ni: number },
+  axis: CwvAxis,
   chartToken: string,
   gradientId: string,
-  unit: string,
   height: number,
 ): ReactNode {
   const interval = Math.max(0, Math.floor(chartData.length / 6) - 1);
-  const yFormatter = makeYFormatter(metric);
-
-  const yDomain: [number | string, number | string] = ["auto", "auto"];
 
   return (
     <div style={{ width: "100%", height }}>
@@ -311,10 +299,17 @@ function renderChart(
             axisLine={false}
           />
 
+          {/*
+            No `unit` prop. Recharts concatenates it onto whatever
+            tickFormatter returns (CartesianAxis.js:353), which is what
+            produced "3sms". The formatter owns the unit; the ban is enforced
+            by components/charts/no-axis-unit.test.ts.
+          */}
           <YAxis
             dataKey="y"
-            domain={yDomain}
-            tickFormatter={yFormatter}
+            domain={axis.domain}
+            ticks={axis.ticks}
+            tickFormatter={axis.tick}
             tick={{
               fill: "var(--color-muted-foreground)",
               fontSize: 11,
@@ -322,8 +317,7 @@ function renderChart(
             stroke="var(--color-border)"
             tickLine={false}
             axisLine={false}
-            width={metric === "cls" ? 38 : 44}
-            unit={unit}
+            width={axis.width}
           />
 
           <Tooltip
@@ -341,34 +335,13 @@ function renderChart(
             }}
           />
 
-          {/* Good threshold — green */}
-          <ReferenceLine
-            y={thresholds.good}
-            stroke="var(--color-chart-1)"
-            strokeDasharray="4 3"
-            strokeWidth={1}
-            label={{
-              value: `Good ${yFormatter(thresholds.good)}${unit}`,
-              position: "insideTopRight",
-              fontSize: 9,
-              fill: "var(--color-chart-1)",
-            }}
-          />
-
-          {/* NI threshold — amber */}
-          <ReferenceLine
-            y={thresholds.ni}
-            stroke="var(--color-chart-4)"
-            strokeDasharray="4 3"
-            strokeWidth={1}
-            label={{
-              value: `NI ${yFormatter(thresholds.ni)}${unit}`,
-              position: "insideTopRight",
-              fontSize: 9,
-              fill: "var(--color-chart-4)",
-            }}
-          />
-
+          {/*
+            Threshold lines use --color-success / --color-warning, matching the
+            fleet chart on /performance. The old --chart-1 / --chart-4 tokens
+            were the SAME colour as the LCP and INP series lines, and the
+            --chart-* family has no .dark override at all, so the lines were
+            both indistinguishable from the data and unverified in dark mode.
+          */}
           <Area
             type="monotone"
             dataKey="y"
@@ -385,6 +358,42 @@ function renderChart(
             }}
             isAnimationActive={false}
             connectNulls={false}
+          />
+
+          {/*
+            The two thresholds render AFTER the Area on purpose. Recharts
+            paints children in document order, so with the Area last the
+            series and its gradient fill covered the reference lines, which is
+            the one thing a pass or fail chart cannot afford to hide. Putting
+            them after means the target a site is measured against is always
+            legible on top of the data.
+          */}
+          {/* Good threshold */}
+          <ReferenceLine
+            y={axis.thresholds.good}
+            stroke="var(--color-success)"
+            strokeDasharray="4 3"
+            strokeWidth={1}
+            label={{
+              value: cwvThresholdLabel(axis, "good"),
+              position: "insideTopRight",
+              fontSize: 9,
+              fill: "var(--color-success-subtle-fg)",
+            }}
+          />
+
+          {/* Needs-improvement threshold */}
+          <ReferenceLine
+            y={axis.thresholds.ni}
+            stroke="var(--color-warning)"
+            strokeDasharray="4 3"
+            strokeWidth={1}
+            label={{
+              value: cwvThresholdLabel(axis, "ni"),
+              position: "insideTopRight",
+              fontSize: 9,
+              fill: "var(--color-warning-subtle-fg)",
+            }}
           />
         </AreaChart>
       </ResponsiveContainer>

--- a/apps/web/src/features/perf/optimize/rum-trend-format.ts
+++ b/apps/web/src/features/perf/optimize/rum-trend-format.ts
@@ -1,0 +1,40 @@
+// The tooltip formatter for RumTrendChart.
+//
+// This lives OUTSIDE features/perf/cwv-axis.ts on purpose, and the separation
+// is the point rather than an accident of file layout.
+//
+// An axis and a tooltip have different jobs. An axis needs ONE scale across
+// all of its ticks because the ticks are read against each other, so cwv-axis
+// resolves a scale once from the axis maximum. A tooltip shows ONE value and
+// must show it at the precision that value deserves, so the scale here is
+// chosen from the value.
+//
+// GH #329 was the axis disagreeing with ITSELF (two scales on one axis, a unit
+// appended twice, a threshold restated as a number Google never published). It
+// was never the axis disagreeing with the tooltip, and the first attempt at
+// the fix, which routed both through a single axis-derived scale, was refuted
+// by measurement: because the axis domain must always contain the Good
+// threshold, an LCP or FCP axis is permanently on the seconds scale, so the
+// five real fast-site FCP readings 780 / 812 / 795 / 840 / 879 collapsed to
+// two strings ("0.8 s" four times, then "0.9 s") where they render as five
+// distinct strings here. That is the non-injectivity defect relocated out of
+// the axis and into the tooltip.
+//
+// If you are here to "unify the formatters", read that paragraph again and
+// then read RumTrendChart.test.tsx, which pins those five readings.
+
+import type { CwvMetric } from "../cwv-axis";
+
+/**
+ * Formats one p75 reading, already converted to display units, for a tooltip.
+ * Behaviour is byte-identical to what shipped before #329.
+ */
+export function formatTrendValue(metric: CwvMetric, value: number): string {
+  if (metric === "cls") {
+    return value.toFixed(3);
+  }
+  if (value >= 1000) {
+    return `${(value / 1000).toFixed(1)} s`;
+  }
+  return `${value.toFixed(1)} ms`;
+}

--- a/apps/web/src/features/perf/rum-tile.test.ts
+++ b/apps/web/src/features/perf/rum-tile.test.ts
@@ -121,6 +121,19 @@ describe("formatLcpP75", () => {
   it("formats zero as 0 ms (never shown for a suppressed row by the caller, but the formatter itself is total)", () => {
     expect(formatLcpP75(0)).toBe("0 ms");
   });
+
+  it("keeps the two decimals that straddle the Good boundary (GH #329)", () => {
+    // The Health tab prints this number colour-coded by its rating band
+    // (routes/_authed/sites/$siteId.health.tsx). Dropping to one decimal, as an
+    // earlier attempt at the #329 fix proposed, would render 2460 ms (Good,
+    // green) and 2540 ms (Needs work, amber) both as "2.5 s", so the number
+    // would contradict the colour it is printed in. Do not reduce precision
+    // here to match the chart axis: an axis and a single reading have
+    // different jobs. See features/perf/cwv-axis.ts.
+    expect(formatLcpP75(2460)).toBe("2.46 s");
+    expect(formatLcpP75(2540)).toBe("2.54 s");
+    expect(formatLcpP75(2460)).not.toBe(formatLcpP75(2540));
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/routes/_authed/performance.tsx
+++ b/apps/web/src/routes/_authed/performance.tsx
@@ -1,4 +1,4 @@
-// /performance — fleet-wide performance dashboard.
+// /performance, the fleet-wide performance dashboard.
 //
 // Scope selector: "All sites" shows the fleet aggregate; selecting a specific
 // site shows the full per-site RUM detail (CWV cards + trend + URL breakdown).
@@ -6,7 +6,7 @@
 // ?window, so links are shareable and survive refresh.
 //
 // Fleet scope layout:
-//   1. Headline strip — sites reporting / fleet CWV pass-rate
+//   1. Headline strip: sites reporting / fleet CWV pass-rate
 //   2. Sites by Core Web Vitals FleetTable (all reporting sites, sorted LCP p75
 //      worst-first). Rows are clickable: click sets ?site=<id>.
 //   3. Fleet 28-day CWV trend (recharts, threshold reference lines)
@@ -14,8 +14,8 @@
 //
 // Per-site scope layout (composes existing components unchanged):
 //   1. Back breadcrumb / "Viewing: <site name>" sub-header
-//   2. FleetRumPanel — CWV p75 cards + distribution bars + trend charts (reused)
-//   3. RumResultsTable — per-URL/device breakdown table (reused)
+//   2. FleetRumPanel: CWV p75 cards + distribution bars + trend charts (reused)
+//   3. RumResultsTable: per-URL/device breakdown table (reused)
 //
 // Device and window are URL search params (shareable links). The device tab
 // also feeds the per-site RUM views (FleetRumPanel manages its own device state
@@ -62,10 +62,15 @@ import {
   type DeviceFilter,
 } from "@/features/fleet/use-fleet-rum";
 import { useSites } from "@/features/sites/use-sites";
+import {
+  cwvDataMax,
+  cwvThresholdLabel,
+  cwvYAxis,
+} from "@/features/perf/cwv-axis";
 import { cn } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
-// Route — validate search params so device + window + site are shareable
+// Route: validate search params so device + window + site are shareable
 // ---------------------------------------------------------------------------
 
 const searchSchema = z.object({
@@ -98,14 +103,10 @@ const METRIC_LABELS: Record<string, string> = {
   ttfb: "TTFB",
 };
 
-// Official CWV thresholds in display units for reference lines.
-const THRESHOLDS: Record<string, { good: number; ni: number }> = {
-  lcp: { good: 2500, ni: 4000 },
-  inp: { good: 200, ni: 500 },
-  cls: { good: 0.1, ni: 0.25 }, // already display units
-  fcp: { good: 1800, ni: 3000 },
-  ttfb: { good: 800, ni: 1800 },
-};
+// Thresholds, the Y domain, the ticks and the unit all come from
+// features/perf/cwv-axis.ts (GH #329). Do not reintroduce a local copy: the
+// duplicated formatter is exactly how this chart and RumTrendChart drifted
+// into stating two different Web Vitals targets.
 
 const CHART_TOKEN: Record<string, string> = {
   lcp: "var(--color-chart-1)",
@@ -434,7 +435,6 @@ function FleetCwvTrendChart({ trend, metric, windowDays }: FleetCwvTrendChartPro
     cls: "cls_p75",
   };
   const key = keyMap[metric];
-  const thresholds = THRESHOLDS[metric]!;
   const stroke = CHART_TOKEN[metric]!;
   const isCls = metric === "cls";
 
@@ -443,6 +443,12 @@ function FleetCwvTrendChart({ trend, metric, windowDays }: FleetCwvTrendChartPro
     const display = raw === null ? null : isCls ? raw / 1000 : raw;
     return { date: p.date, value: display };
   });
+
+  // One scale, one explicit domain, one owner of the unit string. The explicit
+  // domain is what keeps the Good line on screen: with the recharts default,
+  // ReferenceLines outside the auto domain are silently discarded, so a
+  // passing site saw no thresholds at all.
+  const axis = cwvYAxis(metric, cwvDataMax(chartData.map((p) => p.value)));
 
   const hasData = chartData.some((p) => p.value !== null);
   if (!hasData) {
@@ -482,14 +488,16 @@ function FleetCwvTrendChart({ trend, metric, windowDays }: FleetCwvTrendChartPro
             axisLine={false}
             interval="preserveStartEnd"
           />
+          {/* No `unit` prop, ever: recharts appends it to the formatter's own
+              output. See components/charts/no-axis-unit.test.ts. */}
           <YAxis
             tick={{ fontSize: 10, fill: "var(--color-muted-foreground)" }}
             tickLine={false}
             axisLine={false}
-            width={40}
-            tickFormatter={(v: number) =>
-              isCls ? v.toFixed(2) : v >= 1000 ? `${(v / 1000).toFixed(1)}s` : `${Math.round(v)}`
-            }
+            width={axis.width}
+            domain={axis.domain}
+            ticks={axis.ticks}
+            tickFormatter={axis.tick}
           />
           <Tooltip
             contentStyle={{
@@ -499,6 +507,10 @@ function FleetCwvTrendChart({ trend, metric, windowDays }: FleetCwvTrendChartPro
               fontSize: 12,
               color: "var(--color-foreground)",
             }}
+            // Per-value precision, NOT the axis scale. A tooltip shows one
+            // number and must show it at the precision that number deserves;
+            // the axis is permanently on the seconds scale for LCP, so sharing
+            // it would round every reading to 100 ms. See cwv-axis.ts.
             formatter={(value: unknown) => {
               const v = typeof value === "number" ? value : 0;
               return isCls ? v.toFixed(3) : `${Math.round(v)} ms`;
@@ -509,19 +521,29 @@ function FleetCwvTrendChart({ trend, metric, windowDays }: FleetCwvTrendChartPro
           />
           {/* Good threshold */}
           <ReferenceLine
-            y={thresholds.good}
+            y={axis.thresholds.good}
             stroke="var(--color-success)"
             strokeDasharray="4 2"
             strokeWidth={1}
-            label={{ value: "Good", fontSize: 9, fill: "var(--color-success-subtle-fg)", position: "insideTopRight" }}
+            label={{
+              value: cwvThresholdLabel(axis, "good"),
+              fontSize: 9,
+              fill: "var(--color-success-subtle-fg)",
+              position: "insideTopRight",
+            }}
           />
           {/* Needs-improvement threshold */}
           <ReferenceLine
-            y={thresholds.ni}
+            y={axis.thresholds.ni}
             stroke="var(--color-warning)"
             strokeDasharray="4 2"
             strokeWidth={1}
-            label={{ value: "NI", fontSize: 9, fill: "var(--color-warning-subtle-fg)", position: "insideTopRight" }}
+            label={{
+              value: cwvThresholdLabel(axis, "ni"),
+              fontSize: 9,
+              fill: "var(--color-warning-subtle-fg)",
+              position: "insideTopRight",
+            }}
           />
           <Area
             type="monotone"
@@ -671,7 +693,7 @@ function FleetRumView({ device, windowDays, onDrillSite }: FleetRumViewProps) {
           />
         )}
 
-        {/* 28-day trend — small multiples for LCP / INP / CLS */}
+        {/* 28-day trend, small multiples for LCP / INP / CLS */}
         {!isPending && !isError && (data.trend ?? []).length >= 2 && (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
             {TREND_METRICS.map((m) => (

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.114
+  version: 0.61.115
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Fixes #329.

## The report, and what it actually was

The LCP axis read `5sms`, `3sms`, `2sms`, with threshold lines `Good 3sms` and `NI 4sms`. TTFB mixed `650ms` and `2sms` on one axis.

Reported as a formatting problem. It was worse: **the chart was stating an incorrect Web Vitals target.** LCP's Good threshold is 2.5s and `toFixed(0)` rendered it as `3s`. Anyone reading that chart to judge their site was reading the wrong line.

## Cause

Recharts concatenates the `YAxis` `unit` prop onto whatever `tickFormatter` returns (`CartesianAxis.js:353`, unconditional). Our formatter already emitted `"s"` above 1000ms, and we *also* passed `unit="ms"`.

**This is not a recharts defect.** `performance.tsx` uses the identical API, passes no `unit` prop, and is correct. The bug was ours.

## Five defects, three never reported

| | |
|---|---|
| **D1** | Double unit, as above |
| **D2** | Wrong threshold value. Also broke FCP good (1800 → `2s`) and TTFB ni (1800 → `2s`) |
| **D3** | Two scales on one axis. The ms-or-seconds branch ran **per tick**, so `650ms` and `2sms` sat side by side |
| **D3b** | Non-injective axis. On a 0..4000 LCP axis, 1500 / 1600 / 2000 / 2400 all rendered `2sms` |
| **D4** | **Threshold lines silently dropped.** `yDomain` was `["auto","auto"]`, and recharts discards an out-of-domain `ReferenceLine` (`ifOverflow` defaults to `discard`). A site inside the good band rendered **neither** line, indistinguishable from "no thresholds configured" |
| **D5** | Threshold colour collided with the series colour. Good line and LCP series were both `--chart-1`; NI and INP both `--chart-4`. The `--chart-*` family also has **no `.dark` override**, while `--success`/`--warning` do |

## The invariant

**One scale per axis, one owner of the unit string.** Not "the axis and the tooltip render identically."

That distinction is load-bearing. An earlier attempt unified them and was caught in review: because the domain must contain the Good threshold, LCP and FCP axes are always on the seconds scale, so every tooltip would have rounded to 100ms forever. Measured, FCP `780/812/795/840/879` collapsed from five distinct strings to two.

**The tooltip is therefore unchanged**, and both new modules carry a comment explaining why they must not be reunified.

Verified by brute sweep: 4 timing metrics × dataMax 0..30000, plus CLS 0..2 — **17,148 axes** asserting injectivity, exact tick round-trip, exact thresholds, and Good-in-frame. Zero failures.

## Also in here

**Sparkline rewritten as a plain SVG polyline.** It was pulling `LineChart` + `ResponsiveContainer` + `YAxis` to draw a 60×16 decoration with no axes, grid or interaction, and every recharts root builds its own Redux store. `FleetTable` renders one per row with no virtualizer at `limit=100`, so a fleet table mounted up to 100 stores.

```
100 sparklines   222-385 ms, 2305 DOM nodes  ->  3.4-5.4 ms, 205 nodes
built chunk      99 kB CartesianChart import ->  1,243 bytes
```

**D5's fix needed a second pass.** Moving thresholds onto `--success`/`--warning` then collided *perceptually* with the FCP and TTFB series (OKLab dE 0.0200 and 0.0825, same hue), because `--chart-2` and `--chart-3` **are** the semantic hues. Threshold colours are semantic and stay; the decorative series colours moved. Now dE 0.1573 and 0.2723. Thresholds also render after the `Area` so the target is never painted over by the data.

## Gates

```
112 files / 1389 tests   pass
eslint  0 errors   (3 warnings, all pre-existing, verified by stashing)
tsc     0 errors
lockstep 0.61.115   dashes 0
```

## Found, not fixed

`portal-vitals-card.tsx:33-36` renders CLS without dividing by 1000, so a **client-facing** portal shows CLS 0.1 as `100.000` next to a badge that correctly reads "Good". Separate issue; it touches the API contract, which documents `PortalVitalMetric.p75` as a bare number with no unit.

## On the chart library

The maintainer asked whether recharts is the right choice. Measured, not assumed: recharts appears **zero** times in the entry chunk, series are 28-365 points, and 3.10.1 shipped ten days ago. The one true complaint was per-chart instantiation cost, which the sparkline rewrite addresses directly. **Recommendation is wrap, not migrate** - a migration would have fixed none of these five defects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Core Web Vitals chart units, scales, labels, and threshold lines.
  * Restored missing “Good” thresholds and improved threshold-line colors, including dark mode.
  * Improved tooltip precision for sub-second and second-based measurements.
  * Prevented duplicate labels and units in performance charts.

* **Performance**
  * Fleet-table trend sparklines now render faster and more smoothly, including on Uptime and Backups pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->