### PR TITLE
fix(portal): stop showing clients a CLS scaled by a thousand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.116] - 2026-08-04
+
+### Fixed
+
+- The client portal showed Cumulative Layout Shift multiplied by a thousand. A perfectly good CLS of 0.1 was displayed to your clients as "100.000", directly beside a badge that correctly read "Good", so the number and its own rating contradicted each other. The score now reads 0.100, matching what you see on the operator dashboard and what every other report in the product shows. Timing metrics in the portal also now switch to seconds above one second, so a client and an operator looking at the same site read the same figure rather than "4200ms" in one place and "4.20 s" in the other.
+
 ## [0.61.115] - 2026-08-04
 
 ### Fixed

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,22 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.116",
+    date: "2026-08-04",
+    summary:
+      "The client portal showed Cumulative Layout Shift a thousand times too large. A good CLS of 0.1 was shown to clients as 100.000, next to a badge that correctly said Good.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "The Core Web Vitals card in the client portal displayed Cumulative Layout Shift multiplied by a thousand. A perfectly good CLS of 0.1 appeared to your clients as \"100.000\", directly beside a rating badge that correctly read \"Good\", so the score contradicted its own rating and showed a number that no CLS can take. It now reads 0.100, the same as on the operator dashboard and in every other report. This was client facing, so it was visible to the people you send portal links to.",
+      },
+      {
+        tag: "Fixed",
+        text: "Timing metrics in the client portal now switch to seconds above one second, so a client and an operator looking at the same site read the same figure. Previously the portal showed \"4200ms\" where the dashboard showed \"4.20 s\".",
+      },
+    ],
+  },
+  {
     version: "0.61.115",
     date: "2026-08-04",
     summary:

--- a/apps/web/src/features/portal/portal-cards.test.tsx
+++ b/apps/web/src/features/portal/portal-cards.test.tsx
@@ -194,11 +194,16 @@ describe("PortalVitalsCard — shows the real Core Web Vitals p75s", () => {
   const onRetry = vi.fn();
 
   it("renders the real p75 values and ratings, not a placeholder", () => {
+    // WIRE VALUES, not display values. The API sends milli-units for EVERY
+    // metric, so a CLS of 0.18 arrives as 180. The previous version of this
+    // test passed `p75: 0.18` here, which no server ever sends, and so it
+    // agreed with a component that also forgot to divide. Two wrongs
+    // cancelling is why a client-facing bug shipped with a green test.
     const data: PortalVitalsSummary = {
       range: "28d",
       metrics: [
         { metric: "lcp", p75: 2100, rating: "good", samples: 5000 },
-        { metric: "cls", p75: 0.18, rating: "needs-improvement", samples: 4200 },
+        { metric: "cls", p75: 180, rating: "needs-improvement", samples: 4200 },
       ],
     };
 
@@ -213,10 +218,58 @@ describe("PortalVitalsCard — shows the real Core Web Vitals p75s", () => {
       />,
     );
 
-    expect(screen.getByText("2100ms")).toBeInTheDocument();
+    expect(screen.getByText("2.10 s")).toBeInTheDocument();
     expect(screen.getByText("0.180")).toBeInTheDocument();
     expect(screen.getByText("Good")).toBeInTheDocument();
     expect(screen.getByText("Needs improvement")).toBeInTheDocument();
+  });
+
+  it("never shows a client a CLS scaled by 1000", () => {
+    // The exact reported shape: a GOOD CLS of 0.1, which the API sends as 100.
+    // It rendered as "100.000" beside a badge reading "Good", which is a
+    // number no CLS can take and which contradicts its own rating.
+    const data: PortalVitalsSummary = {
+      range: "28d",
+      metrics: [
+        { metric: "cls", p75: 100, rating: "good", samples: 3000 },
+      ],
+    };
+
+    renderWithProviders(
+      <PortalVitalsCard
+        data={data}
+        isLoading={false}
+        isError={false}
+        error={null}
+        onRetry={onRetry}
+        isRetrying={false}
+      />,
+    );
+
+    expect(screen.getByText("0.100")).toBeInTheDocument();
+    expect(screen.queryByText("100.000")).not.toBeInTheDocument();
+  });
+
+  it("formats a sub-second timing metric in milliseconds", () => {
+    // formatLcpP75 switches at 1000, so this pins the other side of the
+    // branch and proves the portal did not simply become a seconds-only view.
+    const data: PortalVitalsSummary = {
+      range: "28d",
+      metrics: [{ metric: "inp", p75: 180, rating: "good", samples: 900 }],
+    };
+
+    renderWithProviders(
+      <PortalVitalsCard
+        data={data}
+        isLoading={false}
+        isError={false}
+        error={null}
+        onRetry={onRetry}
+        isRetrying={false}
+      />,
+    );
+
+    expect(screen.getByText("180 ms")).toBeInTheDocument();
   });
 
   it("shows the 'no field data' empty state for a customer with no RUM samples yet", () => {

--- a/apps/web/src/features/portal/portal-vitals-card.tsx
+++ b/apps/web/src/features/portal/portal-vitals-card.tsx
@@ -12,6 +12,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageError } from "@/components/feedback";
+import { formatLcpP75 } from "@/features/perf/rum-tile";
 import type { PortalVitalsSummary, PortalVitalMetric } from "./use-portal";
 
 // ---------------------------------------------------------------------------
@@ -24,15 +25,21 @@ const METRIC_LABELS: Record<string, string> = {
   cls: "Cumulative Layout Shift",
 };
 
-const METRIC_UNITS: Record<string, string> = {
-  lcp: "ms",
-  inp: "ms",
-  cls: "",
-};
-
+// The API sends p75 in MILLI-UNITS for every metric, including CLS. That is
+// the server's own contract: portal/handler.go rates CLS "good" at p75 < 100,
+// meaning a CLS of 0.1 arrives here as 100. Every other surface in the product
+// divides before display (see FleetRumPanel and RumTrendChart); this card did
+// not, so it showed a perfectly good CLS of 0.1 to a CLIENT as "100.000",
+// directly beside a badge that correctly read "Good".
+//
+// Timing metrics reuse formatLcpP75 rather than a third local formatter, so a
+// client and an operator looking at the same site read the same number. It
+// keeps two decimals of seconds on purpose: that is the precision that still
+// separates 2460 ms from 2540 ms, which sit on opposite sides of the LCP good
+// threshold and are shown in different colours.
 function formatMetricValue(metric: string, p75: number): string {
-  if (metric === "cls") return p75.toFixed(3);
-  return `${Math.round(p75)}${METRIC_UNITS[metric] ?? ""}`;
+  if (metric === "cls") return (p75 / 1000).toFixed(3);
+  return formatLcpP75(p75);
 }
 
 function ratingVariant(

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.115
+  version: 0.61.116
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,
@@ -19439,6 +19439,14 @@ components:
         p75:
           type: number
           format: float
+          description: >-
+            75th percentile, in MILLI-UNITS for every metric. Timing metrics
+            (lcp, inp) are therefore milliseconds. CLS is thousandths of a
+            unit, so a CLS of 0.1 is sent as 100 and a client must divide by
+            1000 before display. This field carried no unit for a long time
+            and a consumer rendered CLS undivided, showing a good score of 0.1
+            to an end client as "100.000".
+          example: 2450
         rating:
           type: string
           enum: [good, needs-improvement, poor, insufficient-data]


### PR DESCRIPTION
Found while investigating #329.

## Client facing

The portal's Core Web Vitals card displayed Cumulative Layout Shift **multiplied by 1000**. A perfectly good CLS of 0.1 was shown to a **client** as `100.000`, directly beside a rating badge that correctly read "Good".

So the score contradicted its own rating, and showed a number no CLS can take. This was visible to the people you send portal links to.

## The API is not at fault

`portal/handler.go` documents CLS as milli-units and rates it against 100 / 250, so a CLS of 0.1 is correctly sent as `100`. Every other surface in the product divides before display (`FleetRumPanel.tsx:68`, `RumTrendChart`). This one card did not:

```ts
if (metric === "cls") return p75.toFixed(3);   // 100 -> "100.000"
```

## Also fixed

Portal timing metrics never switched to seconds, so a client saw `4200ms` where an operator saw `4.20 s` for the same site. Both now use `formatLcpP75`, so the two audiences read the same number.

It keeps two decimals of seconds deliberately: that is the precision that still separates 2460 ms from 2540 ms, which sit on **opposite sides of the LCP good threshold** and are rendered in different colours.

## Why the test did not catch it

This is the part worth reading. The existing test passed:

```ts
{ metric: "cls", p75: 0.18, ... }     // a display value no server ever sends
```

The fixture was wrong in exactly the same way the component was wrong, so the two agreed and the suite stayed green while a client-facing bug shipped. Same failure mode as GH #322, where hand-built fixtures let a feature that rendered nothing pass its tests.

The fixture now carries **wire** values, plus two regression tests: one pinning the reported shape (`100` renders `0.100`, never `100.000`), one pinning the other side of the seconds branch (`180` renders `180 ms`, proving the portal did not just become a seconds-only view).

## Root cause of the drift

`openapi.yaml` described `PortalVitalMetric.p75` as a bare `number` with **no unit**, so nothing told a consumer that CLS arrives scaled. The field is now documented with a concrete example, so the next consumer does not have to infer the unit from the rating thresholds.

## Gates

```
112 files / 1391 tests   pass  (2 new)
eslint 0 errors   tsc 0 errors
marketing check-copy + typecheck   pass
lockstep 0.61.116   dashes 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected client portal CLS values to display using the proper decimal scale.
  * Standardized timing metric formatting with the operator dashboard: values over one second display in seconds, while shorter values remain in milliseconds.
* **Documentation**
  * Updated release notes and API metric documentation to clarify units and provide examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->