### PR TITLE
fix(update): stop discarding an update run whose enqueue failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.117] - 2026-08-04
+
+### Fixed
+
+- Starting an update run could report a server error while the run had in fact been created. If the background job queue was briefly unavailable at the moment a run was saved, the run and its tasks were already written to the database, but the response threw them away and returned a failure. You were told nothing happened, while a real run sat there with tasks that nothing would pick up, and they stayed that way until the stale-task sweeper failed them 45 minutes later, or 6 hours later for an agent rollout. Starting the update again could then be refused, because the first run's tasks were still counted as in flight, so a brief queue hiccup looked like a broken product. The run is now returned as created, its tasks are visible on the run page, and the queue failure is logged for the operator.
+
 ## [0.61.116] - 2026-08-04
 
 ### Fixed

--- a/apps/api/internal/update/handler.go
+++ b/apps/api/internal/update/handler.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -74,8 +75,28 @@ func (h *Handler) create(c *gin.Context) {
 
 	run, tasks, err := h.svc.CreateRun(c.Request.Context(), in)
 	if err != nil {
-		httpx.Error(c, err)
-		return
+		// A NON-ZERO run means the run and its tasks were already COMMITTED and
+		// only the background enqueue failed. CreateRun documents that case as
+		// best effort and says the caller still gets the run, but this handler
+		// used to discard both and return an error, so the operator was told
+		// nothing happened while a real run sat in the database with pending
+		// tasks that nothing would move until the reaper failed them (45m for
+		// ordinary tasks, 6h for agent ones). They would then create a second
+		// run, which the m88 in-flight unique index can reject, making a
+		// recoverable hiccup look like a broken product.
+		//
+		// Report the run that exists. The tasks are pending and visible on the
+		// run page, the enqueue failure is logged and audited below, and a
+		// caller that sees fewer tasks than it asked for can act on it.
+		if run.ID == uuid.Nil {
+			httpx.Error(c, err)
+			return
+		}
+		slog.Error("update run created but a task enqueue failed; tasks remain pending",
+			slog.String("run_id", run.ID.String()),
+			slog.String("tenant_id", run.TenantID.String()),
+			slog.Int("task_count", len(tasks)),
+			slog.Any("error", err))
 	}
 
 	h.recordRunCreated(c, run, len(tasks))

--- a/apps/api/internal/update/handler_test.go
+++ b/apps/api/internal/update/handler_test.go
@@ -3,6 +3,7 @@ package update
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
+	"github.com/mosamlife/wpmgr/apps/api/internal/api/gen"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
@@ -315,5 +317,66 @@ func TestToAPIRunSummary_PopulatesCountFields(t *testing.T) {
 	// aggregate counts, not per-task rows, in the list view).
 	if len(out.Tasks) != 0 {
 		t.Errorf("Tasks must be empty on list response, got %d tasks", len(out.Tasks))
+	}
+}
+
+// TestCreateHandlerReportsARunWhoseEnqueueFailed is the regression test for the
+// handler discarding a COMMITTED run.
+//
+// CreateRun documents its enqueue as best effort and says "the caller still
+// gets the run". The handler ignored that: it checked err first and returned an
+// error response, throwing away a run that was already in the database with
+// real tasks. The operator was told nothing happened, while pending tasks sat
+// there until the reaper failed them 45 minutes later (6 hours for agent
+// tasks), and a second attempt could then collide with the m88 in-flight
+// unique index.
+//
+// This test FAILS against the pre-fix handler, which is the only reason it is
+// worth having. A test that passes either way proves nothing.
+func TestCreateHandlerReportsARunWhoseEnqueueFailed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tenant := uuid.New()
+	site := uuid.New()
+
+	info := SiteInfo{
+		ID: site, Enrolled: true,
+		Components: []Component{
+			{Type: TargetPlugin, Slug: "akismet", Version: "1.0.0", UpdateAvailable: true, NewVersion: "1.1.0"},
+		},
+	}
+	svc := NewService(
+		&fakeCreateRepo{tenantID: tenant},
+		&fakeSiteLookup{sites: map[uuid.UUID]SiteInfo{site: info}},
+		&failingEnqueuer{},
+		domain.NewValidator(),
+		domain.SystemClock{},
+	)
+	h := NewHandler(svc, nil, nil)
+
+	body := `{"site_ids":["` + site.String() + `"],"items":[{"type":"plugin","slug":"akismet"}]}`
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPost, "/updates", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(domain.WithTenantID(req.Context(), tenant))
+	ctx.Request = req
+
+	h.create(ctx)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: a committed run must be reported, not discarded (body: %s)",
+			rec.Code, http.StatusCreated, rec.Body.String())
+	}
+
+	var out gen.UpdateRun
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode response: %v (body: %s)", err, rec.Body.String())
+	}
+	if out.ID == uuid.Nil {
+		t.Fatal("response carries no run id, so the operator still cannot find the run that exists")
+	}
+	if len(out.Tasks) == 0 {
+		t.Fatal("response carries no tasks: the committed tasks must be visible")
 	}
 }

--- a/apps/api/internal/update/service_test.go
+++ b/apps/api/internal/update/service_test.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -502,5 +503,93 @@ func TestCreateRunSkipsDuplicateInFlightTarget(t *testing.T) {
 	}
 	if run2.ID == run1.ID {
 		t.Fatal("the post-completion run must be a distinct run from the first")
+	}
+}
+
+// failingEnqueuer fails every enqueue, standing in for River being unreachable
+// at exactly the moment a run has already been committed.
+type failingEnqueuer struct{ n int }
+
+func (e *failingEnqueuer) EnqueueTask(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, bool) error {
+	e.n++
+	return errors.New("river unavailable")
+}
+
+// TestCreateRunReturnsTheCommittedRunWhenEnqueueFails pins the contract
+// CreateRun documents in its own comment: "a failure here leaves the task
+// pending (the caller still gets the run)".
+//
+// This matters because the run and its tasks are ALREADY COMMITTED by the time
+// the enqueue runs. A caller that treats the error as "nothing happened" leaves
+// a real run in the database with pending tasks that nothing will move until
+// the reaper fails them, 45 minutes later for ordinary tasks and 6 hours for
+// agent ones. The operator, told it failed, creates a second run, which the m88
+// in-flight unique index can then reject. A recoverable hiccup becomes a
+// product that looks broken.
+func TestCreateRunReturnsTheCommittedRunWhenEnqueueFails(t *testing.T) {
+	tenant := uuid.New()
+	site := uuid.New()
+
+	info := SiteInfo{
+		ID: site, Enrolled: true,
+		Components: []Component{
+			{Type: TargetPlugin, Slug: "akismet", Version: "1.0.0", UpdateAvailable: true, NewVersion: "1.1.0"},
+		},
+	}
+	lookup := &fakeSiteLookup{sites: map[uuid.UUID]SiteInfo{site: info}}
+	repo := &fakeCreateRepo{tenantID: tenant}
+	enq := &failingEnqueuer{}
+	svc := NewService(repo, lookup, enq, domain.NewValidator(), domain.SystemClock{})
+
+	run, tasks, err := svc.CreateRun(context.Background(), CreateRunInput{
+		TenantID: tenant,
+		SiteIDs:  []uuid.UUID{site},
+		Items:    []Item{{Type: TargetPlugin, Slug: "akismet"}},
+	})
+
+	if err == nil {
+		t.Fatal("want the enqueue error surfaced, got nil")
+	}
+	// The whole point: the run and its tasks come back ANYWAY.
+	if run.ID == uuid.Nil {
+		t.Fatal("run.ID is nil: a committed run was thrown away with its error")
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("len(tasks) = %d, want 1: the committed tasks must come back too", len(tasks))
+	}
+	if enq.n == 0 {
+		t.Fatal("the enqueuer was never called, so this test proves nothing")
+	}
+}
+
+// TestCreateRunReturnsNoRunWhenItWasNeverCommitted is the other side of the
+// discriminator the handler relies on. A failure BEFORE the commit must return
+// a zero run, so "run.ID != uuid.Nil" is a sound test for "this actually
+// exists in the database".
+func TestCreateRunReturnsNoRunWhenItWasNeverCommitted(t *testing.T) {
+	tenant := uuid.New()
+	site := uuid.New()
+
+	// Nothing pending anywhere, so planning yields no tasks and CreateRun
+	// fails before it ever writes a run.
+	info := SiteInfo{
+		ID: site, Enrolled: true,
+		Components: []Component{{Type: TargetPlugin, Slug: "akismet", Version: "1.0.0"}},
+	}
+	lookup := &fakeSiteLookup{sites: map[uuid.UUID]SiteInfo{site: info}}
+	svc := NewService(&fakeCreateRepo{tenantID: tenant}, lookup, &failingEnqueuer{},
+		domain.NewValidator(), domain.SystemClock{})
+
+	run, _, err := svc.CreateRun(context.Background(), CreateRunInput{
+		TenantID: tenant,
+		SiteIDs:  []uuid.UUID{site},
+		Items:    []Item{{Type: TargetPlugin, Slug: "akismet"}},
+	})
+
+	if err == nil {
+		t.Fatal("want an error when nothing is pending")
+	}
+	if run.ID != uuid.Nil {
+		t.Fatalf("run.ID = %s, want nil: nothing was committed, so nothing may be reported", run.ID)
 	}
 }

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,18 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.117",
+    date: "2026-08-04",
+    summary:
+      "Starting an update run could report a server error while the run had actually been created, leaving tasks that nothing would pick up for up to six hours.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Starting an update run could report a server error while the run had in fact been created. If the background job queue was briefly unavailable at the moment the run was saved, the run and its tasks were already written to the database, but the response discarded them and returned a failure. You were told nothing happened, while a real run sat there with tasks nothing would pick up, and they stayed that way until the stale-task sweeper failed them 45 minutes later, or 6 hours later for an agent rollout. Starting the update again could then be refused, because the first run's tasks still counted as in flight, so a brief queue hiccup looked like a broken product. The run is now returned as created and its tasks are visible on the run page.",
+      },
+    ],
+  },
+  {
     version: "0.61.116",
     date: "2026-08-04",
     summary:

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.116
+  version: 0.61.117
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Found while designing the retry action for #336.

## The contract, stated by the code itself

`CreateRun` documents its enqueue in a comment above the loop:

> A best-effort enqueue: a failure here leaves the task pending (**the caller still gets the run**); we surface the first enqueue error so the operator can retry.

`handler.create` ignored it:

```go
run, tasks, err := h.svc.CreateRun(c.Request.Context(), in)
if err != nil {
    httpx.Error(c, err)   // throws away a run that is already committed
    return
}
```

## What that did to an operator

The run and its tasks were **already written to the database**. The operator got a 500 saying nothing happened.

Meanwhile the tasks sat `pending`, and nothing would move them, because the jobs that would have moved them are precisely what failed to enqueue. They stayed there until the stale-task reaper failed them: **45 minutes** for ordinary tasks, **6 hours** for agent ones.

Starting the update again could then be refused outright, because m88's partial unique index still counted the first run's tasks as in flight. A brief queue hiccup presented as a broken product.

## The fix

Distinguish the two failure classes on the discriminator the service already provides:

- **zero run** -> nothing was committed, return the error exactly as before
- **non-zero run** -> the run exists, so report it with its tasks and log the enqueue failure

## Why the real test is at the handler layer

The two service-level tests here pin the contract from both sides, but **they pass against the pre-fix code too**, because the service was already correct. They document; they do not catch. Saying so explicitly because a test that passes either way is worth nothing, and this repo has shipped a few of those.

`TestCreateHandlerReportsARunWhoseEnqueueFailed` is the one that catches it, verified by **measurement** rather than reasoning. Restoring the previous `handler.go` and re-running:

```
--- FAIL: TestCreateHandlerReportsARunWhoseEnqueueFailed
    status = 500, want 201: a committed run must be reported, not discarded
    body: {"code":"internal_error","message":"internal server error"}
```

That is the exact symptom an operator saw.

## Why it matters for #336

The retry action would have inherited this on the path most likely to trigger it: a retry button sits on the page of the run you just retried, so a slow response invites a second click.

## Gates

```
go build / go vet / go test ./internal/update/...   clean
marketing check-copy + typecheck                    clean
lockstep 0.61.117    dashes 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where runs created before a temporary queue failure were incorrectly reported as failed.
  * Successfully created runs and tasks are now returned and remain visible, even when background processing cannot be queued.
  * Queue failures are logged while preserving the created run information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->