### PR TITLE
fix(agent): the offer the upgrader reads must contain our entry (GH #334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.118] - 2026-08-04
+
+### Fixed
+
+- A fleet agent update could report "the plugin update transient carried no entry for this plugin" and install nothing, on one site, while the same rollout installed cleanly everywhere else (GH #334). The apply looked up the build it was about to install in WordPress's shared plugin update cache, and that cache is one any other plugin on the site is allowed to answer for, rewrite or delete. A security or "disable updates" plugin that answers that read first, a managed host's own must-use plugin doing the same, or simply an ordinary plugin update finishing on that site at that moment, was enough to leave WordPress's installer with nothing to install, after which the rollout stopped at the canary and no other site was touched. The apply no longer looks anything up: it carries the build it verified moments earlier and hands that straight to the installer, so no cache and no other plugin sits between the check and the install. What actually gets installed is unchanged, and is still re-verified from scratch against the signed manifest before a single byte is written.
+- The previous release had made this more likely, not less. 0.61.114 correctly made an agent update wait for any other update on the same site to finish first, and the process it waits for is exactly the one that clears the cache the apply was standing on, which widened the window from milliseconds to as much as four minutes. That window is now closed, because the apply no longer depends on that cache at all.
+- The update offer shown on a site's own WordPress dashboard is now self correcting. An offer naming a build the fleet has since moved past is rewritten from the fresh signed manifest at the moment an install starts; an offer for a release that has since been withdrawn is retired the first time anything acts on it; and an offer the site has already overtaken, for example because its files were replaced out of band by a deploy or a restore, is retired by the first page load that sees it instead of standing for up to twelve hours. A control plane that is briefly unreachable retires nothing, so an outage can never blank a fleet's update offers.
+- When a commanded agent update does fail, the site's own dashboard is now left holding a verified offer for the same build. The one-click update inside wp-admin is the recovery route for a build whose fleet update is broken, and it is now available immediately, without the site having to reach the control plane to rediscover what it was already told.
+
+### Changed
+
+- As with every fix to the agent's own update path, this one cannot be delivered by the path it fixes: a site still running an affected build applies updates using its own installed copy of the old step. A site whose fleet agent update is failing this way needs one update from its own WordPress dashboard, after which fleet updates work normally again.
+
 ## [0.61.117] - 2026-08-04
 
 ### Fixed

--- a/apps/agent/includes/support/class-update-checker.php
+++ b/apps/agent/includes/support/class-update-checker.php
@@ -209,6 +209,24 @@ final class UpdateChecker
     private const RESTORE_GUARD_PRIORITY = 101;
 
     /**
+     * Shutdown priority of clearForcedOffer(), the backstop that takes the
+     * apply's forced update offer back out of circulation.
+     *
+     * ONE ABOVE THE RESTORE GUARD, and the ordering is the whole point. A fatal
+     * inside the upgrade skips runUpgrade()'s `finally`, so the forced offer
+     * would otherwise still be installed for the rest of the request. Placing
+     * the clear here means core's own restore (10), core's cleanup (100) and
+     * this class's restore guard (101) have all run first, and everything
+     * AFTER it, in particular pushOutcomeNow() at OUTCOME_PUSH_PRIORITY and the
+     * metadata push it triggers, reads an unforced transient again.
+     *
+     * It cannot sit below 100: a Throwable escaping a shutdown callback
+     * abandons the rest of the queue, and nothing of this agent's may be
+     * placed ahead of core's rollback. See RESTORE_GUARD_PRIORITY.
+     */
+    private const FORCED_OFFER_CLEAR_PRIORITY = 102;
+
+    /**
      * Shutdown priority of pushOutcomeNow(). Sits after the restore guard, so
      * what it pushes is the post-rollback truth rather than a mid-flight guess.
      */
@@ -338,9 +356,54 @@ final class UpdateChecker
      * has been released to the control plane. Nulled as it is read, so a second
      * dispatch of the filter can never start a second apply.
      *
-     * @var array{apply_id:string,from:string,to:string}|null
+     * CARRIES THE VERIFIED CLAIMS IN MEMORY, and that is what makes the apply
+     * independent of every cache (GitHub issue #334). The arm has just verified
+     * this exact build in this exact request; handing the claims straight to
+     * the apply means no site transient, no negative sentinel and no
+     * control-plane round trip sits between the verification and the offer the
+     * upgrader reads.
+     *
+     * @var array{apply_id:string,from:string,to:string,claims:array<string,mixed>}|null
      */
     private ?array $pendingApply = null;
+
+    /**
+     * The update offer runUpgrade() is forcing, or null when no apply is
+     * running.
+     *
+     * Read by forceApplyOffer() on the pre_site_transient_update_plugins
+     * filter. Installed and removed inside one apply and never outside one.
+     *
+     * @var object|null
+     */
+    private ?object $forcedOffer = null;
+
+    /**
+     * True once verifyDownload() has settled the cached manifest claims in THIS
+     * request, either by rewriting them from a fresh verified fetch or by
+     * retiring them on a definitive no_update.
+     *
+     * It exists to stop primeRecoveryOffer() undoing that work. Both run inside
+     * one apply, verifyDownload() first and primeRecoveryOffer() from the
+     * finally milliseconds later, and primeRecoveryOffer() writes whenever the
+     * arm's claims are still newer than what is on disk, which after a FAILED
+     * apply is always true. Without this flag the sequence is:
+     *
+     *   operator withdraws the release -> verifyDownload retires the dead
+     *   claims -> primeRecoveryOffer writes them straight back for 12h
+     *
+     *   control plane moves forward during the #328 site-lock wait ->
+     *   verifyDownload caches the fresh correct version -> primeRecoveryOffer
+     *   downgrades it back to the arm's older one
+     *
+     * Both were reproduced by execution, not argued. verifyDownload() is the
+     * authority here: it is the only path that re-fetches and re-verifies the
+     * signed manifest from scratch, so whatever it decided outranks the claims
+     * this request happened to start with.
+     *
+     * @var bool
+     */
+    private bool $claimsSettledByDownload = false;
 
     /**
      * The Plugin_Upgrader instance of the apply that is running, or null.
@@ -823,6 +886,14 @@ final class UpdateChecker
      * before caching — it is a short-lived bearer credential). On cache miss,
      * calls fetchManifest() and caches the result.
      *
+     * THIS IS THE OFFER THE OTHER TWO INSTALLERS READ. The CP-commanded apply
+     * carries its claims in memory and forces its own offer (see runUpgrade),
+     * but the dashboard's "Update now" and core's auto-updater have nothing but
+     * this filter, and a dashboard-initiated update is the documented recovery
+     * path for a build whose commanded apply is broken. So a cached entry that
+     * the on-disk build has since overtaken is DROPPED here rather than answered
+     * from, which caps that lie at a single page load instead of 12 hours.
+     *
      * @param mixed $transient The current site transient value.
      * @return mixed Modified transient.
      */
@@ -831,6 +902,8 @@ final class UpdateChecker
         if (!is_object($transient)) {
             return $transient;
         }
+
+        $onDisk = $this->onDiskVersion();
 
         // Read the 12h-cached verified claims.
         $claims = function_exists('get_site_transient')
@@ -862,32 +935,44 @@ final class UpdateChecker
                 }
                 $claims = null;
             }
+        } elseif (!$this->claimsOfferNewerThan($claims, $onDisk)) {
+            // OVERTAKEN POSITIVE ENTRY, and it is dropped rather than answered
+            // from (GitHub issue #334). Nothing can CACHE a claims array that is
+            // not newer than the on-disk build, because verifyManifest()'s
+            // downgrade guard refuses one, so reaching this branch means the
+            // build on disk moved after the entry was written. Every install
+            // route that moves it clears this cache (the apply's own
+            // flushCache(), and core's upgrader_process_complete binding through
+            // wp_clean_plugins_cache), so what is left here is an out-of-band
+            // change: a file copy, a deploy, a restore.
+            //
+            // Answering "no update" from it would be this file's own recurring
+            // defect, a cache in front of an authoritative read that is allowed
+            // to keep answering after it stopped being true, and it would hold
+            // the recovery path shut for the remainder of the 12h window.
+            // Deleting it costs one control-plane fetch on the NEXT read, which
+            // then writes either fresh claims or the negative sentinel, so the
+            // steady state is the ordinary hourly recheck every up-to-date site
+            // already performs, and never a fetch per page load.
+            //
+            // A negative is NOT asserted here. This path knows one thing, that
+            // the cached entry is false; it does not know what is true, so it
+            // destroys the false answer and leaves the finding to the next read.
+            if (function_exists('delete_site_transient')) {
+                delete_site_transient(self::TRANSIENT_MANIFEST);
+            }
+            $claims = null;
         }
 
-        $onDisk = $this->onDiskVersion();
-
-        // Normalize BOTH sides, exactly as the verifyManifest() downgrade guard
-        // does. This comparison used to be made on the raw strings, which meant
-        // the two gates could disagree: PHP version_compare() reads
-        // '0.10.5-cron-selfheal' as a PRE-RELEASE of (lower than) '0.10.5', so a
-        // manifest 'version: 0.10.5' was refused by verifyManifest() but still
-        // offered here whenever a cached claims array reached injectUpdate(),
-        // surfacing a dashboard update entry for a build that the security chain
-        // would then refuse to install. One normalization rule, both gates.
-        if (is_array($claims) && isset($claims['version']) && is_string($claims['version'])
-            && version_compare($this->normalizeVersion($claims['version']), $this->normalizeVersion($onDisk), '>')
-        ) {
+        if (is_array($claims) && $this->claimsOfferNewerThan($claims, $onDisk)) {
             // Inject the update entry. Package is the SENTINEL (not a presigned
             // URL): the real URL is fetched fresh inside verifyDownload().
-            $entry = new \stdClass();
-            $entry->slug        = self::PLUGIN_SLUG;
-            $entry->plugin      = self::PLUGIN_KEY;
-            $entry->new_version = $claims['version'];
-            $entry->package     = self::PACKAGE_SENTINEL;
-            $entry->url         = '';
-            $entry->tested      = isset($claims['tested'])       && is_string($claims['tested'])       ? $claims['tested']       : '';
-            $entry->requires    = isset($claims['requires'])     && is_string($claims['requires'])     ? $claims['requires']     : '';
-            $entry->requires_php = isset($claims['requires_php']) && is_string($claims['requires_php']) ? $claims['requires_php'] : '';
+            //
+            // ONE BUILDER, TWO CALLERS. The apply forces this same entry from
+            // the claims it verified in-request (see runUpgrade), and the two
+            // constructions drifting apart is exactly how an offer that looks
+            // right here reaches the upgrader in a shape it will not install.
+            $entry = $this->offerEntryFromClaims($claims, (string) $claims['version']);
 
             if (!isset($transient->response) || !is_array($transient->response)) {
                 $transient->response = [];
@@ -910,6 +995,69 @@ final class UpdateChecker
         }
 
         return $transient;
+    }
+
+    /**
+     * Does this set of cached claims still offer a build newer than the one on
+     * disk?
+     *
+     * THE ONE PLACE THIS COMPARISON IS MADE, and it normalizes BOTH sides
+     * exactly as verifyManifest()'s downgrade guard does. The comparison used to
+     * be written out inline on the raw strings, which meant the two gates could
+     * disagree: PHP version_compare() reads '0.10.5-cron-selfheal' as a
+     * PRE-RELEASE of (lower than) '0.10.5', so a manifest claiming version
+     * '0.10.5' was refused by verifyManifest() and yet still offered in the
+     * dashboard, surfacing an update entry for a build the security chain would
+     * then refuse to install. One normalization rule, every gate.
+     *
+     * @param mixed  $claims Cached claims array, or anything else.
+     * @param string $onDisk The on-disk plugin version.
+     * @return bool True when $claims names a build strictly newer than $onDisk.
+     */
+    private function claimsOfferNewerThan($claims, string $onDisk): bool
+    {
+        if (!is_array($claims) || !isset($claims['version']) || !is_string($claims['version'])) {
+            return false;
+        }
+
+        return version_compare(
+            $this->normalizeVersion($claims['version']),
+            $this->normalizeVersion($onDisk),
+            '>'
+        );
+    }
+
+    /**
+     * Build the update-transient entry for one set of verified manifest claims.
+     *
+     * THE ONE PLACE THIS SHAPE IS DEFINED. injectUpdate() offers it to the
+     * dashboard and to core's auto-updater; runUpgrade() forces the identical
+     * entry from the claims the arm verified in-request. Two hand-built copies
+     * of this shape is how the apply ends up reading an offer the dashboard
+     * would have got right, so there is one builder and no second copy.
+     *
+     * package is the SENTINEL, never a presigned URL: the real URL is fetched
+     * fresh inside verifyDownload(), which re-verifies the whole signed
+     * manifest before a single byte is written. This entry is a ROUTING HINT
+     * and nothing else trusts it.
+     *
+     * @param array<string,mixed> $claims  Verified claims (package_url stripped).
+     * @param string              $version The version this entry offers.
+     * @return \stdClass
+     */
+    private function offerEntryFromClaims(array $claims, string $version): \stdClass
+    {
+        $entry               = new \stdClass();
+        $entry->slug         = self::PLUGIN_SLUG;
+        $entry->plugin       = self::PLUGIN_KEY;
+        $entry->new_version  = $version;
+        $entry->package      = self::PACKAGE_SENTINEL;
+        $entry->url          = '';
+        $entry->tested       = isset($claims['tested'])       && is_string($claims['tested'])       ? $claims['tested']       : '';
+        $entry->requires     = isset($claims['requires'])     && is_string($claims['requires'])     ? $claims['requires']     : '';
+        $entry->requires_php = isset($claims['requires_php']) && is_string($claims['requires_php']) ? $claims['requires_php'] : '';
+
+        return $entry;
     }
 
     // -------------------------------------------------------------------------
@@ -1034,10 +1182,53 @@ final class UpdateChecker
         // Fetch a FRESH manifest (new presigned URL, fully re-verified).
         $claims = $this->fetchManifest();
         if (!is_array($claims)) {
+            // A DEFINITIVE REFUSAL RETIRES THE CACHED OFFER THAT LED HERE
+            // (GitHub issue #334). Something read a cached update entry and
+            // acted on it, and the control plane has just answered that there is
+            // nothing to install: the release was withdrawn, or the on-disk
+            // build has caught up with it. Leaving those claims in place would
+            // keep the dashboard offering a button that cannot work for the rest
+            // of the 12h window.
+            //
+            // ONLY on those two outcomes. 'unavailable', 'invalid' and
+            // 'rejected' mean the answer did not arrive or could not be trusted,
+            // which teaches nothing about what is published, and a control-plane
+            // outage must never be able to blank a fleet's update offers.
+            if (function_exists('delete_site_transient')
+                && ($this->lastManifestOutcome === 'no_update' || $this->lastManifestOutcome === 'up_to_date')
+            ) {
+                delete_site_transient(self::TRANSIENT_MANIFEST);
+                // Settled: primeRecoveryOffer() must not write the retired
+                // claims back from the finally a few milliseconds from now.
+                $this->claimsSettledByDownload = true;
+            }
+
             return new \WP_Error(
                 'wpmgr_update_manifest_failed',
                 'WPMgr agent update: could not fetch or verify the update manifest from the control plane.'
             );
+        }
+
+        // THE POSITIVE CACHE IS CORRECTED HERE, at the only moment the truth is
+        // in hand for free (GitHub issue #334). injectUpdate() caches verified
+        // claims for 12h so it does not round-trip the control plane on every
+        // wp-admin load, which means the dashboard and core's auto-updater can
+        // name a build the control plane has since moved past. It never
+        // INSTALLS the wrong build, because this method is the authority and it
+        // has just re-fetched and re-verified from scratch; what it can do is
+        // print a stale version number beside the button. Rewriting the cache
+        // from these fresh claims makes any install attempt self-correcting,
+        // and costs no extra request. package_url is stripped: it is a
+        // short-lived bearer credential and is never cached.
+        if (function_exists('set_site_transient') && defined('HOUR_IN_SECONDS')) {
+            $refreshed = $claims;
+            unset($refreshed['package_url']);
+            set_site_transient(self::TRANSIENT_MANIFEST, $refreshed, 12 * HOUR_IN_SECONDS);
+            // Settled: these claims were re-fetched and re-verified just now, so
+            // they outrank the ones this request started with. Without this,
+            // primeRecoveryOffer() downgrades them back to the arm's older
+            // version from the finally.
+            $this->claimsSettledByDownload = true;
         }
 
         $packageUrl  = isset($claims['package_url'])    && is_string($claims['package_url'])    ? $claims['package_url']    : '';
@@ -1427,10 +1618,19 @@ final class UpdateChecker
             return $this->stageAnswer('error', $onDisk, '', 'WordPress filter API unavailable; the apply has no seam to run from.');
         }
 
+        // THE CLAIMS TRAVEL IN MEMORY, not through the transient written above
+        // (GitHub issue #334). The transient is written for the DASHBOARD's
+        // benefit and for the next request; between this line and the swap sits
+        // awaitSiteUpdateLock(), which can wait up to SITE_LOCK_WAIT_SECONDS on
+        // exactly the process that calls delete_site_transient('update_plugins')
+        // and so deletes TRANSIENT_MANIFEST out from under us through
+        // flushCache(). Anything the apply needs must therefore be carried, not
+        // looked up.
         $this->pendingApply = [
             'apply_id' => $applyId,
             'from'     => $onDisk,
             'to'       => $toVersion,
+            'claims'   => $toCache,
         ];
 
         add_filter('rest_pre_serve_request', [$this, 'serveThenApply'], 999, 4);
@@ -1502,6 +1702,7 @@ final class UpdateChecker
         $applyId = (string) $pending['apply_id'];
         $from    = (string) $pending['from'];
         $to      = (string) $pending['to'];
+        $claims  = isset($pending['claims']) && is_array($pending['claims']) ? $pending['claims'] : [];
 
         try {
             $this->emitAck((bool) $served, $result, $server);
@@ -1532,7 +1733,7 @@ final class UpdateChecker
             DebugLog::write('WPMgr Agent: self-update could not release the connection: ' . $e->getMessage());
         }
 
-        $this->applyPendingUpdate($rung, $applyId, $from, $to);
+        $this->applyPendingUpdate($rung, $applyId, $from, $to, $claims);
 
         return true;
     }
@@ -1563,15 +1764,23 @@ final class UpdateChecker
      * attached connection, and on the last rung the reason this host has no
      * detaching one is written to the debug log in the same breath.
      *
-     * @param string $rung    The rung ConnectionFinisher reported.
-     * @param string $applyId Opaque id of this apply.
-     * @param string $from    On-disk version at arm time.
-     * @param string $to      Verified target version.
+     * @param string              $rung    The rung ConnectionFinisher reported.
+     * @param string              $applyId Opaque id of this apply.
+     * @param string              $from    On-disk version at arm time.
+     * @param string              $to      Verified target version.
+     * @param array<string,mixed> $claims  The claims the arm verified in this
+     *                                     request, carried in memory so the
+     *                                     apply depends on no cache.
      * @return void
      */
-    private function applyPendingUpdate(string $rung, string $applyId, string $from, string $to): void
+    private function applyPendingUpdate(string $rung, string $applyId, string $from, string $to, array $claims): void
     {
         $this->applyRung = $rung;
+        // Scope the flag to THIS apply. It is only ever read by
+        // primeRecoveryOffer() in the finally below, so a value left over from
+        // an earlier apply in the same process would silently suppress the
+        // recovery offer for an apply whose verifyDownload never ran.
+        $this->claimsSettledByDownload = false;
 
         try {
             if (!in_array($rung, ConnectionFinisher::DETACHING_RUNGS, true)) {
@@ -1616,13 +1825,68 @@ final class UpdateChecker
 
             self::warmPostSwapClasses();
 
-            $this->runUpgrade($applyId, $from, $to);
+            $this->runUpgrade($applyId, $from, $to, $claims);
         } catch (\Throwable $e) {
             $this->recordSelfUpdateResult($applyId, 'failed', $from, $to, 'Self-update apply threw: ' . $e->getMessage());
         } finally {
             SiteUpdateLock::release();
             $this->releaseApplyLock();
+            $this->primeRecoveryOffer($claims);
         }
+    }
+
+    /**
+     * Leave the dashboard holding a working offer when the commanded apply did
+     * not land.
+     *
+     * A dashboard-initiated update is the recovery path for a build whose
+     * commanded apply is broken, and it is the one route that this fix does not
+     * carry claims into: it reads whatever injectUpdate() can build from the
+     * shared cache. That cache can have been deleted by a sibling process while
+     * this apply waited for the site lock, and the next read to find it empty
+     * pays a control-plane round trip that, if it fails, writes a one-hour "no
+     * update" and hides the recovery path exactly when it is needed.
+     *
+     * So the apply hands the recovery path the claims it verified in this same
+     * request, for free and over no network.
+     *
+     * SELF-GUARDING, which is why it needs no outcome plumbing and can sit in
+     * one `finally`: it writes only while the verified build is still newer than
+     * what is on disk. A successful apply moves the on-disk version to the
+     * target, so the condition is false and nothing is written over the
+     * flushCache() that success already performed.
+     *
+     * @param array<string,mixed> $claims The claims the arm verified in this request.
+     * @return void
+     */
+    private function primeRecoveryOffer(array $claims): void
+    {
+        if ($claims === [] || !function_exists('set_site_transient') || !defined('HOUR_IN_SECONDS')) {
+            return;
+        }
+
+        // STAND DOWN if verifyDownload() already settled the cache in this
+        // request. It re-fetched and re-verified the signed manifest from
+        // scratch, so its answer outranks the claims the arm started with, and
+        // writing over it turns two correct decisions into a wrong one:
+        // retired claims come back from the dead, and a freshly corrected
+        // version gets downgraded to the arm's older one. Both were reproduced
+        // by execution before this guard existed.
+        if ($this->claimsSettledByDownload) {
+            return;
+        }
+
+        // The plugin directory may have been replaced by this very method a
+        // moment ago, so the header is read past the stat cache.
+        clearstatcache();
+        if (!$this->claimsOfferNewerThan($claims, $this->onDiskVersion())) {
+            return;
+        }
+
+        // Belt and braces: package_url is stripped before the arm ever hands
+        // these over, and a presigned bearer credential is never cached.
+        unset($claims['package_url']);
+        set_site_transient(self::TRANSIENT_MANIFEST, $claims, 12 * HOUR_IN_SECONDS);
     }
 
     /**
@@ -1781,61 +2045,111 @@ final class UpdateChecker
      * deactivated, and active_before()/active_after() put maintenance mode over
      * the destructive window and take it off again.
      *
-     * @param string $applyId Opaque id of this apply, stamped into the outcome.
-     * @param string $from    On-disk version at arm time.
-     * @param string $to      Verified target version.
+     * @param string              $applyId Opaque id of this apply, stamped into the outcome.
+     * @param string              $from    On-disk version at arm time.
+     * @param string              $to      Verified target version.
+     * @param array<string,mixed> $claims  The claims the arm verified in this
+     *                                     very request. THE ONLY INPUT TO THE
+     *                                     OFFER, by design; see below.
      * @return void
      */
-    private function runUpgrade(string $applyId, string $from, string $to): void
+    private function runUpgrade(string $applyId, string $from, string $to, array $claims): void
     {
         if (!$this->loadUpgraderApi() || !class_exists('\Plugin_Upgrader') || !class_exists('\Automatic_Upgrader_Skin')) {
             $this->recordSelfUpdateResult($applyId, 'failed', $from, $to, 'Upgrader API unavailable.');
             return;
         }
 
-        // Plugin_Upgrader::upgrade() reads the plugin update transient to find
-        // the package and bails to its up_to_date branch when the entry is
-        // absent, returning a bare false with nothing else said. THIS PATH USED
-        // TO DELETE THAT TRANSIENT A FEW LINES ABOVE THE CALL, which is why the
-        // CP-commanded self-update never applied on any site. Rebuild it the way
-        // core's own background updater does. wp_update_plugins() writes the
-        // transient BEFORE it calls api.wordpress.org, so a site that cannot
-        // reach wordpress.org still ends up with an object here, and reading it
-        // back runs our own site_transient_update_plugins filter, which is what
-        // offers the build this arm just verified.
-        $offer = function_exists('get_site_transient') ? get_site_transient('update_plugins') : null;
-        if (!is_object($offer) && function_exists('wp_update_plugins')) {
-            wp_update_plugins();
-            $offer = get_site_transient('update_plugins');
+        // BENIGN CASE FIRST, so no offer is ever forced for a build that is
+        // already on disk. The plugin directory may have been replaced inside
+        // this very process tree while the wait above was running, and
+        // onDiskVersion() reads the header through get_plugin_data(), which is
+        // stat-cached, so the cache is dropped before the read rather than
+        // trusted after a wait of up to SITE_LOCK_WAIT_SECONDS.
+        clearstatcache();
+        $onDiskNow = $this->onDiskVersion();
+        if ($to !== '' && !version_compare($this->normalizeVersion($to), $this->normalizeVersion($onDiskNow), '>')) {
+            $this->recordSelfUpdateResult(
+                $applyId,
+                'already_applied',
+                $from,
+                $to,
+                'On-disk version is already at or past the verified target.'
+            );
+            return;
         }
 
-        if (!is_object($offer) || !isset($offer->response[self::PLUGIN_KEY])) {
-            // At or past the target already: the build landed some other way
-            // between the arm and this line. Benign, and it must not be reported
-            // as a failure.
-            if (
-                is_object($offer)
-                && isset($offer->no_update[self::PLUGIN_KEY])
-                && !version_compare($this->normalizeVersion($to), $this->normalizeVersion($this->onDiskVersion()), '>')
-            ) {
-                $this->recordSelfUpdateResult(
-                    $applyId,
-                    'already_applied',
-                    $from,
-                    $to,
-                    'On-disk version is already at or past the verified target.'
-                );
-                return;
-            }
-
+        // THE INVARIANT THIS PATH MUST ASSERT, and the one 0.61.108 got wrong
+        // (GitHub issues #334, #212 class):
+        //
+        //   THE OFFER THE UPGRADER READS CONTAINS OUR ENTRY,
+        //   naming the build THIS arm verified.
+        //
+        // NOT "the update_plugins transient exists". 0.61.108 guarded the
+        // container and rebuilt it when it was absent, so a transient that was
+        // present but carried no entry of ours fell straight through to a named
+        // failure. Worse, the container is not something this path can reason
+        // about at all: get_site_transient() applies
+        // pre_site_transient_update_plugins FIRST and returns immediately when
+        // that filter answers anything but false (wp-includes/option.php:2580
+        // to :2584), never reaching the site_transient_update_plugins filter at
+        // :2620 that injectUpdate() is bound to. One "disable updates" plugin,
+        // security plugin or managed-host mu-plugin short-circuiting there and
+        // our entry never reaches the upgrader on that site, on every attempt,
+        // for ever.
+        //
+        // So the apply stops asking and starts answering. The claims below were
+        // verified by the ARM, in this request, milliseconds ago, through the
+        // full signature chain, and they are carried here in memory. The entry
+        // is built from them and returned from the pre-filter at PHP_INT_MAX,
+        // which is the only construction that wins over both a foreign
+        // pre-filter short-circuit and every foreign site_transient filter:
+        // apply_filters runs every callback, so the last registration at the
+        // highest priority answers.
+        //
+        // Repairing a local $offer variable is NOT enough and never was:
+        // Plugin_Upgrader::upgrade() re-reads the transient itself
+        // (wp-admin/includes/class-plugin-upgrader.php:199) and bails at :200
+        // to :206 on a missing entry, returning a bare false.
+        //
+        // NOTHING IS READ AND NOTHING IS DELETED HERE. Not the transient, whose
+        // read would run injectUpdate() and, on a manifest cache miss, block
+        // this apply on a control-plane round trip and then negative-cache
+        // "no update" for NO_UPDATE_TTL. Not wp_update_plugins(), for the same
+        // reason plus a call to api.wordpress.org. And never
+        // delete_site_transient('update_plugins'), which fires
+        // do_action("delete_site_transient_update_plugins") as its FIRST act
+        // (wp-includes/option.php:2520) and is bound to flushCache(), so it
+        // would destroy the verified manifest this apply was standing on.
+        $offerVersion = isset($claims['version']) && is_string($claims['version']) ? $claims['version'] : '';
+        if ($offerVersion === '' || $to === '') {
             $this->recordSelfUpdateResult(
                 $applyId,
                 'failed',
                 $from,
                 $to,
-                'No update offer reached the upgrader: the plugin update transient carried no entry for this plugin.'
+                'No update offer reached the upgrader: the arm carried no verified claims into the apply.'
             );
             return;
+        }
+
+        // A COMPLETE object, not a bare one carrying only ->response.
+        // upgrader_process_complete fires while this is what every reader sees
+        // (class-plugin-upgrader.php:220), and third-party listeners routinely
+        // read ->no_update, ->checked and ->last_checked. Under PHP 8 a missing
+        // property is a warning, and a listener that promotes warnings to
+        // exceptions would turn the agent's own self-update into a fatal at the
+        // single most dangerous moment in the request.
+        $forced               = new \stdClass();
+        $forced->last_checked = time();
+        $forced->checked      = [self::PLUGIN_KEY => $onDiskNow];
+        $forced->response     = [self::PLUGIN_KEY => $this->offerEntryFromClaims($claims, $offerVersion)];
+        $forced->no_update    = [];
+        $forced->translations = [];
+
+        $this->forcedOffer = $forced;
+        if (function_exists('add_filter')) {
+            add_filter('pre_site_transient_update_plugins', [$this, 'forceApplyOffer'], PHP_INT_MAX);
         }
 
         // A fatal skips every try/finally, so maintenance mode gets a shutdown
@@ -1847,6 +2161,9 @@ final class UpdateChecker
 
         if (function_exists('add_action')) {
             add_action('shutdown', [$this, 'restoreAgentIfDirectoryMissing'], self::RESTORE_GUARD_PRIORITY);
+            // The forced offer must not outlive the apply even when a fatal
+            // skips the finally below. See FORCED_OFFER_CLEAR_PRIORITY.
+            add_action('shutdown', [$this, 'clearForcedOffer'], self::FORCED_OFFER_CLEAR_PRIORITY);
         }
 
         $result = null;
@@ -1863,6 +2180,11 @@ final class UpdateChecker
             if (function_exists('remove_filter')) {
                 remove_filter('wp_doing_cron', '__return_true', 9999);
             }
+            // GUARANTEE: the forced offer is withdrawn on every terminal path
+            // of this upgrade. It exists to serve ONE call to
+            // Plugin_Upgrader::upgrade() and must never be readable by another
+            // plugin's update, another request, or anything after this line.
+            $this->clearForcedOffer();
             // GUARANTEE: maintenance mode is cleared on every terminal path of
             // this upgrade, whether it succeeded, returned a WP_Error, or threw.
             Maintenance::clear($upgrader);
@@ -1938,6 +2260,56 @@ final class UpdateChecker
         // upgrader_process_complete binding, so nothing is deleted here.
         $this->flushCache();
         $this->recordSelfUpdateResult($applyId, 'applied', $from, $to, $this->installNotes());
+    }
+
+    /**
+     * Answer every get_site_transient('update_plugins') made while an apply is
+     * running with the offer that apply verified.
+     *
+     * Bound at PHP_INT_MAX on pre_site_transient_update_plugins, and only for
+     * the duration of one Plugin_Upgrader::upgrade() call. That position is
+     * deliberate and is the whole mechanism: get_site_transient() applies the
+     * pre-filter first and returns the moment it is handed anything but false
+     * (wp-includes/option.php:2580 to :2584), so this answer cannot be
+     * suppressed by another plugin's pre-filter, by a foreign
+     * site_transient_update_plugins filter at any priority, or by the stored
+     * transient being absent, stale, or missing our entry.
+     *
+     * It is a big hammer and it is scoped like one: installed inside
+     * runUpgrade(), removed in that method's `finally`, and cleared again from
+     * shutdown in case a fatal skipped the finally.
+     *
+     * Public so WordPress can call it as a named hook callback.
+     *
+     * @param mixed $pre The short-circuit value so far (false = no short-circuit).
+     * @return mixed The forced offer while an apply is running, else $pre.
+     */
+    public function forceApplyOffer($pre)
+    {
+        $forced = $this->forcedOffer;
+
+        return is_object($forced) ? $forced : $pre;
+    }
+
+    /**
+     * Withdraw the forced offer and unbind the filter that serves it.
+     *
+     * Idempotent, and safe to call when nothing was ever forced. Called from
+     * runUpgrade()'s `finally` on every terminal path, and again from shutdown
+     * at FORCED_OFFER_CLEAR_PRIORITY because a fatal inside the upgrade skips
+     * the finally entirely.
+     *
+     * Public so WordPress can call it as a named hook callback. Never throws.
+     *
+     * @return void
+     */
+    public function clearForcedOffer(): void
+    {
+        $this->forcedOffer = null;
+
+        if (function_exists('remove_filter')) {
+            remove_filter('pre_site_transient_update_plugins', [$this, 'forceApplyOffer'], PHP_INT_MAX);
+        }
     }
 
     /**

--- a/apps/agent/tests/SelfUpdateInRequestApplyTest.php
+++ b/apps/agent/tests/SelfUpdateInRequestApplyTest.php
@@ -396,13 +396,23 @@ final class SelfUpdateInRequestApplyTest extends TestCase
         $checker = $this->makeChecker();
         $answer  = $checker->planSelfUpdate();
 
+        // The verified claims travel from the arm to the apply IN MEMORY
+        // (GitHub issue #334). They are read off the same handoff
+        // serveThenApply() reads, rather than reconstructed here, so this
+        // fixture exercises the threading instead of faking it.
+        $pending = (new \ReflectionProperty($checker, 'pendingApply'))->getValue($checker);
+        $claims  = is_array($pending) && isset($pending['claims']) && is_array($pending['claims'])
+            ? $pending['claims']
+            : [];
+
         $method = new \ReflectionMethod($checker, 'applyPendingUpdate');
         $method->invoke(
             $checker,
             $this->rung,
             (string) $answer['apply_id'],
             (string) $answer['from_version'],
-            (string) $answer['to_version']
+            (string) $answer['to_version'],
+            $claims
         );
 
         if ($replayShutdown) {
@@ -801,28 +811,63 @@ final class SelfUpdateInRequestApplyTest extends TestCase
     // =========================================================================
 
     /**
-     * THE P1 REGRESSION TEST.
+     * THE #334 REGRESSION TEST, AND THE NEGATION OF THE ONE THIS FILE USED TO
+     * CARRY.
      *
-     * Plugin_Upgrader::upgrade() reads the plugin update transient to find the
-     * package and bails to its up_to_date branch, returning a bare false, when
-     * there is no entry for the plugin. This path used to DELETE that transient
-     * a few lines above the call, so core took that bail on every site, every
-     * time, and answered false with nothing said. A missing offer is now one
-     * named, control-plane-visible failure instead of a silent one.
+     * This exact state, an update_plugins transient that is a perfectly valid
+     * object carrying no entry of ours, was reported from a live fleet and USED
+     * TO BE PINNED HERE AS CORRECT BEHAVIOUR: the old
+     * test_a_missing_update_offer_is_recorded_as_a_named_failure asserted that
+     * the upgrade was skipped and a failure recorded. It was the defect, wearing
+     * a test as a certificate.
+     *
+     * The apply no longer reads that transient at all. It carries the claims the
+     * arm verified in this same request and forces the offer from them, so the
+     * stored object's contents cannot decide whether the agent upgrades.
+     *
+     * That the offer reaching the upgrader is genuinely ours, through the real
+     * filter chain and past a hostile pre-filter, is asserted in
+     * SelfUpdateOfferInvariantTest.
      */
-    public function test_a_missing_update_offer_is_recorded_as_a_named_failure(): void
+    public function test_a_stale_transient_with_no_entry_of_ours_no_longer_blocks_the_apply(): void
     {
         $this->stubSignedOffer();
         $this->siteTransients['update_plugins'] = (object) ['response' => [], 'no_update' => []];
 
         $this->runApply();
 
-        $this->assertSame([], \Plugin_Upgrader::$calls, 'the upgrade must not be attempted without an offer');
+        $this->assertSame(
+            [UpdateChecker::PLUGIN_KEY],
+            \Plugin_Upgrader::$calls,
+            'a stale-but-valid transient must not be able to withhold the upgrade'
+        );
+        $this->assertSame('applied', (string) ($this->record()['status'] ?? ''));
+    }
+
+    /**
+     * The named failure survives, for the ONE state it can still describe: an
+     * apply reached with no verified claims at all.
+     *
+     * That is not a cache miss and never was. Every reachable route into this
+     * method carries the claims the arm verified milliseconds earlier, so an
+     * empty set means the handoff itself broke, and the record says exactly
+     * that rather than blaming a transient the apply no longer reads.
+     */
+    public function test_an_apply_carrying_no_verified_claims_records_a_named_failure(): void
+    {
+        $this->stubSignedOffer();
+        $this->siteTransients['update_plugins'] = $this->offerTransient();
+
+        $checker = $this->makeChecker();
+        $method  = new \ReflectionMethod($checker, 'runUpgrade');
+        $method->invoke($checker, 'apply-id', $this->onDiskVersion, $this->targetVersion, []);
+
+        $this->assertSame([], \Plugin_Upgrader::$calls, 'nothing may be swapped on claims the arm never verified');
 
         $record = $this->record();
         $this->assertIsArray($record);
         $this->assertSame('failed', $record['status']);
-        $this->assertStringContainsString('no entry for this plugin', (string) $record['detail']);
+        $this->assertStringContainsString('carried no verified claims', (string) $record['detail']);
     }
 
     /**
@@ -830,6 +875,14 @@ final class SelfUpdateInRequestApplyTest extends TestCase
      * benign, not a failure. Reporting it as failed would give the control
      * plane an attributed record whose status is not "applied", which halts a
      * rollout wave over a site that is running exactly the build it should.
+     *
+     * DECIDED FIRST, BEFORE ANY OFFER IS BUILT (GitHub issue #334). The apply
+     * forces the offer it needs, so this branch has to be settled before the
+     * forcing starts or the agent would happily force an offer for a build
+     * already on disk. The no_update corroboration this used to require is gone
+     * with the transient read that produced it; the disk is read instead, with
+     * the stat cache dropped first because the directory can have moved inside
+     * this very process while the apply waited for the site lock.
      */
     public function test_a_site_already_at_the_target_records_already_applied(): void
     {
@@ -843,7 +896,7 @@ final class SelfUpdateInRequestApplyTest extends TestCase
         // other way between the arm and this line.
         $checker = $this->makeChecker();
         $method  = new \ReflectionMethod($checker, 'runUpgrade');
-        $method->invoke($checker, 'apply-id', '0.10.4', $this->onDiskVersion);
+        $method->invoke($checker, 'apply-id', '0.10.4', $this->onDiskVersion, []);
 
         $this->assertSame([], \Plugin_Upgrader::$calls);
         $this->assertSame('already_applied', (string) ($this->record()['status'] ?? ''));

--- a/apps/agent/tests/SelfUpdateOfferInvariantTest.php
+++ b/apps/agent/tests/SelfUpdateOfferInvariantTest.php
@@ -1,0 +1,1284 @@
+<?php
+/**
+ * THE OFFER THE UPGRADER READS CONTAINS OUR ENTRY (GitHub issue #334).
+ *
+ * That sentence is the invariant the CP-commanded self-update lives or dies by,
+ * and it is the one 0.61.108 did not assert. 0.61.108 asserted "the
+ * update_plugins transient exists", rebuilt it when it was absent, and shipped.
+ * A transient that was PRESENT and simply carried no entry of ours walked
+ * straight past that guard into a named failure, which is what a live 21-site
+ * fleet reported.
+ *
+ * WHY NO EXISTING TEST COULD HAVE CAUGHT IT, which is half the answer to "how
+ * did this happen". Every apply test in SelfUpdateInRequestApplyTest stubs
+ * get_site_transient() as a plain array lookup with NO filter dispatch, and its
+ * add_filter() stub records a string. So injectUpdate(), the filter that is
+ * supposed to PRODUCE the entry, was never in the loop in any apply test, and
+ * every green apply test handed the upgrader a transient that already contained
+ * the entry. Two halves tested in isolation and the seam between them tested
+ * nowhere.
+ *
+ * This file closes that. Its get_site_transient() is core's:
+ * pre_site_transient_{$transient} first, returning immediately on anything but
+ * false (wp-includes/option.php:2580 to :2584), then the stored value, then
+ * site_transient_{$transient} (:2620). Its Plugin_Upgrader double re-reads the
+ * transient through that chain exactly as Plugin_Upgrader::upgrade() does
+ * (wp-admin/includes/class-plugin-upgrader.php:199 to :206), and what it saw is
+ * what every test below asserts on. Not "a failure was recorded". Not "the
+ * transient exists". The entry, named by version, in the offer the upgrader
+ * actually read.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Commands\AgentSelfUpdateCommand;
+use WPMgr\Agent\Keystore;
+use WPMgr\Agent\ReplayCache;
+use WPMgr\Agent\Settings;
+use WPMgr\Agent\Signer;
+use WPMgr\Agent\Support\UpdateChecker;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\UpdateChecker
+ */
+final class SelfUpdateOfferInvariantTest extends TestCase
+{
+    /** Raw 64-byte CP Ed25519 secret key. */
+    private string $cpSecret = '';
+
+    /** Raw 32-byte CP Ed25519 public key. */
+    private string $cpPublic = '';
+
+    /** The enrolled site_id for this test run. */
+    private string $siteId = 'test-site-uuid-offer-invariant';
+
+    /** On-disk plugin version. */
+    private string $onDiskVersion = '0.10.5';
+
+    /** The version the control plane offers. */
+    private string $targetVersion = '';
+
+    private Keystore $keystore;
+    private Settings $settings;
+    private Signer $signer;
+
+    /** @var array<string,mixed> wp-option store. */
+    private array $options = [];
+
+    /** @var array<string,mixed> site_transient store (the STORED value only). */
+    private array $siteTransients = [];
+
+    /**
+     * Registered hooks: hook name => priority => list of callbacks.
+     *
+     * @var array<string,array<int,list<callable>>>
+     */
+    private array $hooks = [];
+
+    /** @var list<array{hook:string,priority:int,callback:mixed}> Every add_action() seen. */
+    private array $actions = [];
+
+    /** @var list<string> Every key handed to delete_site_transient(). */
+    private array $deletedSiteTransients = [];
+
+    /** How many times the control-plane manifest endpoint was called. */
+    private int $manifestFetches = 0;
+
+    /** The offer entry Plugin_Upgrader read for our plugin, or null. */
+    private ?object $offerSeenByUpgrader = null;
+
+    /** The whole transient object Plugin_Upgrader read, or null. */
+    private ?object $transientSeenByUpgrader = null;
+
+    /** Temporary key file for the Keystore master key. */
+    private string $keyFile = '';
+
+    /** Whether THIS file defined WPMGR_AGENT_KEY_FILE and so owns the file. */
+    private bool $ownsKeyFile = false;
+
+    /** Fake ReplayCache instance. */
+    private object $replayCache;
+
+    /** Temp tree standing in for WP_CONTENT_DIR. */
+    private string $contentDir = '';
+
+    /** Temp tree standing in for WP_PLUGIN_DIR. */
+    private string $pluginDir = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        // WPMGR_AGENT_KEY_FILE is a real constant, so whichever test file in
+        // this process defines it first owns the path for the whole run. Adopt
+        // whatever won and write the key material THERE, rather than to a path
+        // this file names but the Keystore will never read.
+        if (defined('WPMGR_AGENT_KEY_FILE')) {
+            $this->keyFile = (string) constant('WPMGR_AGENT_KEY_FILE');
+        } else {
+            $this->keyFile = sys_get_temp_dir() . '/wpmgr-soi-test-' . bin2hex(random_bytes(8)) . '.key';
+            define('WPMGR_AGENT_KEY_FILE', $this->keyFile);
+            $this->ownsKeyFile = true;
+        }
+        file_put_contents($this->keyFile, random_bytes(32));
+
+        $cpKeypair      = sodium_crypto_sign_keypair();
+        $this->cpSecret = sodium_crypto_sign_secretkey($cpKeypair);
+        $this->cpPublic = sodium_crypto_sign_publickey($cpKeypair);
+
+        $this->options                 = [];
+        $this->siteTransients          = [];
+        $this->hooks                   = [];
+        $this->actions                 = [];
+        $this->deletedSiteTransients   = [];
+        $this->manifestFetches         = 0;
+        $this->offerSeenByUpgrader     = null;
+        $this->transientSeenByUpgrader = null;
+
+        \Plugin_Upgrader::$behaviour    = null;
+        \Plugin_Upgrader::$calls        = [];
+        \Plugin_Upgrader::$restoreCalls = [];
+
+        if (!defined('WP_CONTENT_DIR')) {
+            define('WP_CONTENT_DIR', sys_get_temp_dir() . '/wpmgr-shared-wp-content');
+        }
+        if (!defined('WP_PLUGIN_DIR')) {
+            define('WP_PLUGIN_DIR', rtrim((string) constant('WP_CONTENT_DIR'), '/\\') . '/plugins');
+        }
+        $this->contentDir = rtrim((string) constant('WP_CONTENT_DIR'), '/\\');
+        $this->pluginDir  = rtrim((string) constant('WP_PLUGIN_DIR'), '/\\');
+        if (!is_dir($this->pluginDir . '/' . UpdateChecker::PLUGIN_SLUG)) {
+            mkdir($this->pluginDir . '/' . UpdateChecker::PLUGIN_SLUG, 0755, true);
+        }
+
+        Functions\when('get_option')->alias(function (string $name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+        Functions\when('update_option')->alias(function (string $name, $value) {
+            $this->options[$name] = $value;
+            return true;
+        });
+        Functions\when('delete_option')->alias(function (string $name) {
+            unset($this->options[$name]);
+            return true;
+        });
+
+        // ------------------------------------------------------------------
+        // THE POINT OF THIS FILE: a real filter chain, in core's real order.
+        // ------------------------------------------------------------------
+        Functions\when('get_site_transient')->alias(function (string $key) {
+            // wp-includes/option.php:2580 to :2584 - the pre-filter runs FIRST
+            // and anything but false ends the read there and then.
+            $pre = $this->dispatchFilter('pre_site_transient_' . $key, false, $key);
+            if ($pre !== false) {
+                return $pre;
+            }
+
+            $value = $this->siteTransients[$key] ?? false;
+
+            // wp-includes/option.php:2620.
+            return $this->dispatchFilter('site_transient_' . $key, $value, $key);
+        });
+        Functions\when('set_site_transient')->alias(function (string $key, $value, int $ttl = 0) {
+            $this->siteTransients[$key] = $value;
+            return true;
+        });
+        Functions\when('delete_site_transient')->alias(function (string $key) {
+            $this->deletedSiteTransients[] = $key;
+            // wp-includes/option.php:2520 - fired as the FIRST act, before
+            // anything is deleted. flushCache() is bound to exactly this.
+            $this->dispatchAction('delete_site_transient_' . $key, $key);
+            unset($this->siteTransients[$key]);
+            return true;
+        });
+
+        Functions\when('add_filter')->alias(function (string $hook, $callback, int $priority = 10) {
+            $this->hooks[$hook][$priority][] = $callback;
+            return true;
+        });
+        Functions\when('remove_filter')->alias(function (string $hook, $callback, int $priority = 10) {
+            foreach ($this->hooks[$hook][$priority] ?? [] as $index => $registered) {
+                if ($registered === $callback) {
+                    unset($this->hooks[$hook][$priority][$index]);
+                }
+            }
+            return true;
+        });
+        Functions\when('add_action')->alias(function (string $hook, $callback, int $priority = 10) {
+            $this->actions[]                 = ['hook' => $hook, 'priority' => $priority, 'callback' => $callback];
+            $this->hooks[$hook][$priority][] = $callback;
+            return true;
+        });
+        Functions\when('remove_action')->alias(function (string $hook, $callback, int $priority = 10) {
+            foreach ($this->hooks[$hook][$priority] ?? [] as $index => $registered) {
+                if ($registered === $callback) {
+                    unset($this->hooks[$hook][$priority][$index]);
+                }
+            }
+            return true;
+        });
+        Functions\when('apply_filters')->alias(function (string $hook, $value, ...$args) {
+            return $this->dispatchFilter($hook, $value, ...$args);
+        });
+        Functions\when('do_action')->alias(function (string $hook, ...$args): void {
+            $this->dispatchAction($hook, ...$args);
+        });
+
+        Functions\when('wp_update_plugins')->alias(function (): void {
+            $this->fail('the apply must never call wp_update_plugins(): it round-trips wordpress.org');
+        });
+        Functions\when('wp_clear_scheduled_hook')->justReturn(1);
+        Functions\when('wp_parse_url')->alias(fn (string $url) => parse_url($url));
+        Functions\when('get_plugin_data')->alias(fn () => ['Version' => $this->onDiskVersion]);
+        Functions\when('is_wp_error')->alias(fn ($thing) => $thing instanceof \WP_Error);
+        Functions\when('set_time_limit')->justReturn(true);
+        Functions\when('wp_delete_file')->alias(function (string $file) {
+            @unlink($file); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        });
+        Functions\when('headers_sent')->justReturn(true);
+        Functions\when('ob_get_level')->justReturn(0);
+        Functions\when('flush')->justReturn(null);
+
+        if (!defined('WPMGR_AGENT_VERSION')) {
+            define('WPMGR_AGENT_VERSION', $this->onDiskVersion);
+        }
+        // onDiskVersion() prefers get_plugin_data() and only falls back to the
+        // WPMGR_AGENT_VERSION constant, so a test that needs the version to
+        // MOVE (the build landing between the arm and the apply) has to reach
+        // it through the header read. OptimizerRumTest already guard-defines
+        // this constant and sorts ahead of this file, so the full suite runs
+        // with it defined either way; defining it here as well is what makes
+        // this file behave identically when it is run on its own.
+        if (!defined('WPMGR_AGENT_FILE')) {
+            define('WPMGR_AGENT_FILE', __FILE__);
+        }
+        $this->onDiskVersion = (string) constant('WPMGR_AGENT_VERSION');
+        $this->targetVersion = (string) preg_replace('/[-+].*$/', '', $this->onDiskVersion) . '.1';
+        if (!defined('HOUR_IN_SECONDS')) {
+            define('HOUR_IN_SECONDS', 3600);
+        }
+
+        $this->keystore = new Keystore();
+        $this->keystore->storeControlPlanePublicKey($this->cpPublic);
+
+        Functions\when('get_site_option')->alias(function (string $key, $default = null) {
+            if ($key === Settings::OPTION_SITE_ID) {
+                return $this->siteId;
+            }
+            if ($key === Settings::OPTION_CP_URL) {
+                return 'https://cp.example.com';
+            }
+            return $default === null ? false : $default;
+        });
+
+        $this->settings = new Settings();
+        $this->keystore->generateSiteKeypair();
+        $this->signer = new Signer($this->keystore);
+
+        $this->replayCache = new class extends ReplayCache {
+            public function __construct()
+            {
+            }
+            public function seen(string $jti, ?int $now = null): bool
+            {
+                return false;
+            }
+            public function mark(string $jti, int $ttlSeconds, ?int $now = null): bool
+            {
+                return true;
+            }
+        };
+    }
+
+    protected function tear_down(): void
+    {
+        \Plugin_Upgrader::$behaviour    = null;
+        \Plugin_Upgrader::$calls        = [];
+        \Plugin_Upgrader::$restoreCalls = [];
+        if ($this->ownsKeyFile && $this->keyFile !== '' && is_file($this->keyFile)) {
+            @unlink($this->keyFile); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture cleanup
+        }
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // -------------------------------------------------------------------------
+    // The hook dispatcher
+    // -------------------------------------------------------------------------
+
+    /**
+     * Run every callback registered on $hook, in priority order, threading the
+     * value through. This is apply_filters(), which is what makes a late
+     * registration at PHP_INT_MAX able to win: every callback runs, and the
+     * last one to run answers.
+     *
+     * @param string $hook  Hook name.
+     * @param mixed  $value Value to filter.
+     * @param mixed  ...$args Extra arguments.
+     * @return mixed
+     */
+    private function dispatchFilter(string $hook, $value, ...$args)
+    {
+        $byPriority = $this->hooks[$hook] ?? [];
+        ksort($byPriority);
+
+        foreach ($byPriority as $callbacks) {
+            foreach ($callbacks as $callback) {
+                if (is_callable($callback)) {
+                    $value = $callback($value, ...$args);
+                }
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * Run every callback registered on $hook, in priority order, discarding
+     * return values.
+     *
+     * @param string $hook Hook name.
+     * @param mixed  ...$args Arguments.
+     * @return void
+     */
+    private function dispatchAction(string $hook, ...$args): void
+    {
+        $byPriority = $this->hooks[$hook] ?? [];
+        ksort($byPriority);
+
+        foreach ($byPriority as $callbacks) {
+            foreach ($callbacks as $callback) {
+                if (is_callable($callback)) {
+                    $callback(...$args);
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Fixture helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Bind the two hooks UpdateChecker::install() binds for this channel.
+     *
+     * install() carries a process-global `static $installed` guard, so calling
+     * it here would register for the FIRST test in this process and silently
+     * no-op for every one after it. The bindings are therefore made by hand,
+     * and test_install_binds_the_filters_this_fixture_reproduces reads the
+     * production source to prove this list has not drifted from it.
+     *
+     * @param UpdateChecker $checker The checker under test.
+     * @return void
+     */
+    private function bindAgentFilters(UpdateChecker $checker): void
+    {
+        add_filter('site_transient_update_plugins', [$checker, 'injectUpdate']);
+        add_action('delete_site_transient_update_plugins', [$checker, 'flushCache']);
+    }
+
+    /**
+     * Build a checker with the real (CLI) connection probe, so the apply runs
+     * on the last rung exactly as it does on a mod_php host.
+     *
+     * @return UpdateChecker
+     */
+    private function makeChecker(): UpdateChecker
+    {
+        return new UpdateChecker($this->signer, $this->settings, $this->keystore, $this->replayCache);
+    }
+
+    /**
+     * Stub the CP manifest endpoint with a signed offer of the target version,
+     * counting every call so a test can assert the apply made none.
+     *
+     * @return void
+     */
+    /**
+     * The control plane answers 204 No Content: nothing to install. This is the
+     * release-withdrawn shape, and the one outcome that legitimately retires a
+     * cached offer.
+     */
+    private function stubNoUpdate(): void
+    {
+        Functions\when('wp_remote_get')->alias(function (string $url, array $args = []) {
+            $this->manifestFetches++;
+
+            return ['response' => ['code' => 204], 'body' => ''];
+        });
+        Functions\when('wp_remote_retrieve_response_code')->alias(fn ($response) => $response['response']['code'] ?? 0);
+        Functions\when('wp_remote_retrieve_body')->alias(fn ($response) => $response['body'] ?? '');
+    }
+
+    /**
+     * Call primeRecoveryOffer() the way applyPendingUpdate()'s finally does.
+     *
+     * It is private on purpose, so this reaches it by reflection rather than
+     * widening production visibility for a test. What matters is that it runs
+     * on the SAME checker instance that verifyDownload() just ran on, because
+     * the guard under test is instance state set by that call.
+     *
+     * @param array<string,mixed> $claims
+     */
+    private function invokeRecoveryOffer(UpdateChecker $checker, array $claims): void
+    {
+        $m = new \ReflectionMethod(UpdateChecker::class, 'primeRecoveryOffer');
+        $m->setAccessible(true);
+        $m->invoke($checker, $claims);
+    }
+
+    private function stubSignedOffer(): void
+    {
+        $now    = time();
+        $claims = [
+            'aud'            => $this->siteId,
+            'cmd'            => 'update_manifest',
+            'slug'           => 'wpmgr-agent',
+            'version'        => $this->targetVersion,
+            'min_version'    => '0.0.0',
+            'package_url'    => 'https://storage.googleapis.com/wpmgr/agent.zip?sig=x',
+            'package_sha256' => str_repeat('ab', 32),
+            'package_size'   => 359578,
+            'tested'         => '7.0',
+            'requires'       => '6.0',
+            'requires_php'   => '8.1',
+            'iat'            => $now,
+            'exp'            => $now + 300,
+            'jti'            => bin2hex(random_bytes(16)),
+        ];
+
+        $payloadRaw = (string) json_encode($claims);
+        $envelope   = [
+            'manifest'  => rtrim(strtr(base64_encode($payloadRaw), '+/', '-_'), '='),
+            'signature' => rtrim(strtr(base64_encode(sodium_crypto_sign_detached($payloadRaw, $this->cpSecret)), '+/', '-_'), '='),
+        ];
+        $body = (string) json_encode($envelope);
+
+        Functions\when('wp_remote_get')->alias(function (string $url, array $args = []) use ($body) {
+            $this->manifestFetches++;
+
+            return ['response' => ['code' => 200], 'body' => $body];
+        });
+        Functions\when('wp_remote_retrieve_response_code')->alias(fn ($response) => $response['response']['code'] ?? 0);
+        Functions\when('wp_remote_retrieve_body')->alias(fn ($response) => $response['body'] ?? '');
+    }
+
+    /**
+     * Make the Plugin_Upgrader double read the update transient the way
+     * Plugin_Upgrader::upgrade() does, through the whole filter chain, and
+     * record what it saw.
+     *
+     * wp-admin/includes/class-plugin-upgrader.php:199 to :206: the transient is
+     * re-read INSIDE upgrade(), and a missing entry returns a bare false having
+     * done nothing. A locally repaired variable in the caller is worth nothing
+     * here, which is exactly why the fix is a filter.
+     *
+     * @return void
+     */
+    private function upgraderReadsTheOffer(): void
+    {
+        \Plugin_Upgrader::$behaviour = function (string $plugin) {
+            $current                       = get_site_transient('update_plugins');
+            $this->transientSeenByUpgrader = is_object($current) ? $current : null;
+
+            if (!is_object($current) || !isset($current->response[$plugin])) {
+                $this->offerSeenByUpgrader = null;
+
+                return false;
+            }
+
+            $this->offerSeenByUpgrader = $current->response[$plugin];
+
+            return true;
+        };
+    }
+
+    /**
+     * Run one whole command request: the arm, then the seam, exactly as
+     * WordPress dispatches it.
+     *
+     * Nothing is reached into here. planSelfUpdate() arms, serveThenApply()
+     * releases the response and applies, and the claims travel between them in
+     * memory, which is the property under test.
+     *
+     * @param UpdateChecker $checker The checker under test.
+     * @return array<string,mixed> The arm answer.
+     */
+    private function armAndApply(UpdateChecker $checker): array
+    {
+        $answer = $checker->planSelfUpdate();
+        $checker->serveThenApply(false, null, null, null);
+
+        return $answer;
+    }
+
+    /** The stored apply outcome record, or null. */
+    private function record(): ?array
+    {
+        $stored = $this->options[AgentSelfUpdateCommand::OPTION_RESULT] ?? null;
+
+        return is_array($stored) ? $stored : null;
+    }
+
+    /**
+     * THE ASSERTION. Every green case below ends here.
+     *
+     * Not "a failure was not recorded", not "the transient exists": the offer
+     * Plugin_Upgrader read carried OUR entry, naming the build this arm
+     * verified, with the sentinel package that routes the download back through
+     * verifyDownload()'s full re-verification.
+     *
+     * @return void
+     */
+    private function assertTheUpgraderReadOurOffer(): void
+    {
+        $this->assertSame(
+            [UpdateChecker::PLUGIN_KEY],
+            \Plugin_Upgrader::$calls,
+            'the upgrade must have been attempted'
+        );
+        $this->assertIsObject(
+            $this->offerSeenByUpgrader,
+            'the offer Plugin_Upgrader::upgrade() read must contain an entry for this plugin'
+        );
+        $this->assertSame(
+            $this->targetVersion,
+            (string) $this->offerSeenByUpgrader->new_version,
+            'and that entry must name the build THIS arm verified'
+        );
+        $this->assertSame(
+            UpdateChecker::PACKAGE_SENTINEL,
+            (string) $this->offerSeenByUpgrader->package,
+            'and route the download through verifyDownload(), which re-verifies the signed manifest from scratch'
+        );
+        $this->assertSame('applied', (string) ($this->record()['status'] ?? ''));
+    }
+
+    // =========================================================================
+    // T1 to T5: the states that used to fail
+    // =========================================================================
+
+    /**
+     * T1. A HOSTILE pre_site_transient_update_plugins SHORT-CIRCUIT.
+     *
+     * This is the most likely explanation for the reported incident and the
+     * reason a bare "rebuild the transient" fix could never have been enough.
+     * get_site_transient() applies pre_site_transient_{$transient} first and
+     * returns the moment it is handed anything but false
+     * (wp-includes/option.php:2580 to :2584), never reaching the
+     * site_transient_{$transient} filter at :2620 that injectUpdate() is bound
+     * to. Any "disable updates" plugin, security plugin or managed-host
+     * mu-plugin sitting there makes this apply fail on that one site, every
+     * single time, while the mechanism works everywhere else.
+     *
+     * The apply wins because it registers LAST at PHP_INT_MAX, and apply_filters
+     * runs every callback rather than stopping at the first non-false answer.
+     */
+    public function test_a_hostile_pre_site_transient_filter_cannot_starve_the_apply(): void
+    {
+        $this->stubSignedOffer();
+        $this->upgraderReadsTheOffer();
+
+        $checker = $this->makeChecker();
+        $this->bindAgentFilters($checker);
+
+        // A third-party plugin that answers the read itself and offers nothing.
+        add_filter('pre_site_transient_update_plugins', static function () {
+            return (object) ['response' => [], 'no_update' => [], 'last_checked' => time()];
+        }, 10);
+
+        $this->armAndApply($checker);
+
+        $this->assertTheUpgraderReadOurOffer();
+    }
+
+    /**
+     * T2. THE STATE THE REPORTER DESCRIBED, and the reason it is NOT on its own
+     * the cause of what they saw.
+     *
+     * GH #334 reported that update_plugins being a valid-but-stale object,
+     * populated by WordPress's own periodic check without our entry, skipped
+     * 0.61.108's `!is_object($offer)` rebuild and fell through to "the plugin
+     * update transient carried no entry for this plugin". That reading of the
+     * guard is correct, and the guard really was too narrow.
+     *
+     * But this state alone does not starve the apply, and this test is green
+     * BOTH BEFORE AND AFTER the fix. It is deliberately kept and deliberately
+     * labelled, because a test that cannot fail is worthless as a regression
+     * test and actively misleading if it is presented as one.
+     *
+     * What it does establish is why: our entry is never STORED in
+     * update_plugins, it is produced at read time by injectUpdate() on the
+     * site_transient_update_plugins filter. So a stale object is decorated on
+     * the very next read and the upgrader finds its offer regardless. The
+     * fixture below dispatches the real filter chain, which is what makes that
+     * visible; the older harness did a plain array lookup and could not see it.
+     *
+     * The real starvation needs something that stops injectUpdate() being
+     * reached or being able to answer, which is what T1 (a hostile
+     * pre_site_transient short circuit) and T3 (the manifest cache wiped
+     * mid-request) cover. Those two are red before this fix and green after.
+     */
+    public function test_a_valid_transient_alone_does_not_starve_the_apply(): void
+    {
+        $this->stubSignedOffer();
+        $this->upgraderReadsTheOffer();
+
+        $checker = $this->makeChecker();
+        $this->bindAgentFilters($checker);
+
+        // Exactly what WordPress's own periodic check leaves behind.
+        $this->siteTransients['update_plugins'] = (object) [
+            'last_checked' => time(),
+            'checked'      => ['some-other-plugin/some-other-plugin.php' => '1.0.0'],
+            'response'     => [],
+            'no_update'    => ['some-other-plugin/some-other-plugin.php' => (object) ['new_version' => '1.0.0']],
+        ];
+
+        $this->armAndApply($checker);
+
+        $this->assertTheUpgraderReadOurOffer();
+    }
+
+    /**
+     * T3. THE MANIFEST CACHE IS DELETED MID-REQUEST, AND THE APPLY DOES NOT
+     * CARE (the regression #328 introduced).
+     *
+     * awaitSiteUpdateLock() waits up to SITE_LOCK_WAIT_SECONDS between the arm
+     * and the swap, and the process it waits on is precisely the one that calls
+     * delete_site_transient('update_plugins') at the end of a plugin update.
+     * That fires delete_site_transient_update_plugins, which is bound to
+     * flushCache(), which deletes TRANSIENT_MANIFEST from another process.
+     *
+     * Simulated here at its most hostile: both caches are wiped after the arm
+     * and before the apply. The apply must still install, and must not make a
+     * single control-plane request to do it, because a blocking fetch inside
+     * the apply is what writes the one-hour negative sentinel on failure and
+     * poisons every retry for the next hour.
+     */
+    public function test_the_apply_survives_the_manifest_cache_being_deleted_mid_request(): void
+    {
+        $this->stubSignedOffer();
+        $this->upgraderReadsTheOffer();
+
+        $checker = $this->makeChecker();
+        $this->bindAgentFilters($checker);
+
+        $answer = $checker->planSelfUpdate();
+        $this->assertSame('scheduled', $answer['status']);
+
+        $fetchesAfterTheArm = $this->manifestFetches;
+        $this->assertGreaterThan(0, $fetchesAfterTheArm, 'the arm itself verifies against the control plane');
+
+        // A sibling update command finishes here and clears the plugin caches.
+        delete_site_transient('update_plugins');
+        $this->assertArrayNotHasKey(
+            UpdateChecker::TRANSIENT_MANIFEST,
+            $this->siteTransients,
+            'flushCache() must have taken the manifest with it, or this test is not reproducing the race'
+        );
+
+        $checker->serveThenApply(false, null, null, null);
+
+        $this->assertTheUpgraderReadOurOffer();
+        $this->assertSame(
+            $fetchesAfterTheArm,
+            $this->manifestFetches,
+            'the apply must not round-trip the control plane: on a failure that write is a one-hour "no update"'
+        );
+    }
+
+    /**
+     * T4. THE FORCED OFFER DOES NOT OUTLIVE THE APPLY.
+     *
+     * A pre_site_transient filter at PHP_INT_MAX beats every other plugin's
+     * update machinery by construction, so it may exist for exactly one call to
+     * Plugin_Upgrader::upgrade() and not one read longer. After the apply, a
+     * site with nothing on offer must read as a site with nothing on offer.
+     */
+    public function test_the_forced_offer_is_withdrawn_and_cannot_affect_a_later_read(): void
+    {
+        $this->stubSignedOffer();
+        $this->upgraderReadsTheOffer();
+
+        $checker = $this->makeChecker();
+        $this->bindAgentFilters($checker);
+
+        $this->armAndApply($checker);
+        $this->assertTheUpgraderReadOurOffer();
+
+        // The world after the apply: nothing is published any more, and the
+        // negative sentinel says so without a control-plane call.
+        $this->siteTransients[UpdateChecker::TRANSIENT_MANIFEST] = 'wpmgr-no-update';
+        $this->siteTransients['update_plugins']                  = (object) [
+            'last_checked' => time(),
+            'response'     => [],
+            'no_update'    => [],
+        ];
+
+        $later = get_site_transient('update_plugins');
+
+        $this->assertIsObject($later);
+        $this->assertArrayNotHasKey(
+            UpdateChecker::PLUGIN_KEY,
+            (array) $later->response,
+            'the forced offer must not survive the apply that installed it'
+        );
+        $this->assertSame(
+            [],
+            array_filter($this->hooks['pre_site_transient_update_plugins'] ?? []),
+            'and the filter that served it must have been unbound, not merely emptied of its value'
+        );
+    }
+
+    /**
+     * T5. A BUILD ALREADY ON DISK IS BENIGN, AND NO OFFER IS FORCED FOR IT.
+     *
+     * The already-at-target branch is decided FIRST, before any offer is built,
+     * so the agent can never force an offer for a build it is already running.
+     * Reporting this as a failure would halt a rollout wave over a site running
+     * exactly the build it should.
+     */
+    public function test_a_build_already_on_disk_records_already_applied_and_forces_nothing(): void
+    {
+        $this->stubSignedOffer();
+        $this->upgraderReadsTheOffer();
+
+        $checker = $this->makeChecker();
+        $this->bindAgentFilters($checker);
+
+        $answer = $checker->planSelfUpdate();
+        $this->assertSame('scheduled', $answer['status']);
+
+        // The build lands some other way between the arm and the apply.
+        $this->onDiskVersion = $this->targetVersion;
+
+        $checker->serveThenApply(false, null, null, null);
+
+        $this->assertSame([], \Plugin_Upgrader::$calls, 'nothing may be swapped onto a site already at the target');
+        $this->assertSame('already_applied', (string) ($this->record()['status'] ?? ''));
+        $this->assertSame(
+            [],
+            $this->hooks['pre_site_transient_update_plugins'] ?? [],
+            'and no offer may be forced for a build that is already installed'
+        );
+    }
+
+    // =========================================================================
+    // The guards around the mechanism
+    // =========================================================================
+
+    /**
+     * THE NEGATIVE CONTROL, and the test that would have rejected the fix this
+     * issue was reported with.
+     *
+     * The suggested fix was to call delete_site_transient('update_plugins')
+     * unconditionally at the top of the apply. That function fires
+     * do_action("delete_site_transient_update_plugins") as its FIRST act
+     * (wp-includes/option.php:2520), and flushCache() is bound to exactly that
+     * action, so it would have deleted the verified manifest the arm wrote nine
+     * lines earlier, forced a synchronous control-plane fetch inside the apply,
+     * and on any transport failure written a one-hour "no update" that fails
+     * this apply AND poisons every retry for the next hour.
+     *
+     * The apply may never delete that transient. Core's own
+     * upgrader_process_complete binding clears the plugin caches after a
+     * successful install, which is a different thing at a different time.
+     */
+    public function test_the_apply_never_deletes_the_plugin_update_transient(): void
+    {
+        $this->stubSignedOffer();
+        $this->upgraderReadsTheOffer();
+
+        $checker = $this->makeChecker();
+        $this->bindAgentFilters($checker);
+
+        $this->armAndApply($checker);
+
+        $this->assertTheUpgraderReadOurOffer();
+        $this->assertNotContains(
+            'update_plugins',
+            $this->deletedSiteTransients,
+            'deleting update_plugins destroys the verified manifest through flushCache(); it is never the fix here'
+        );
+    }
+
+    /**
+     * The forced offer is a COMPLETE update-transient object.
+     *
+     * upgrader_process_complete fires while this is what every reader sees
+     * (wp-admin/includes/class-plugin-upgrader.php:220), and third-party
+     * listeners routinely read ->no_update, ->checked and ->last_checked. Under
+     * PHP 8 a missing property is a warning, and a listener that promotes
+     * warnings to exceptions would turn the agent's own self-update into a
+     * fatal at the single most dangerous moment in the request.
+     */
+    public function test_the_forced_offer_is_a_complete_transient_object(): void
+    {
+        $this->stubSignedOffer();
+        $this->upgraderReadsTheOffer();
+
+        $checker = $this->makeChecker();
+        $this->bindAgentFilters($checker);
+
+        $this->armAndApply($checker);
+
+        $seen = $this->transientSeenByUpgrader;
+        $this->assertIsObject($seen);
+        foreach (['response', 'no_update', 'checked', 'last_checked', 'translations'] as $property) {
+            $this->assertObjectHasProperty(
+                $property,
+                $seen,
+                'a listener reading ->' . $property . ' must not meet an undefined property warning'
+            );
+        }
+    }
+
+    /**
+     * The forced offer has a shutdown backstop, because a FATAL inside the
+     * upgrade skips runUpgrade()'s finally entirely.
+     *
+     * It must sit after core's rollback (shutdown, 10), core's cleanup (100)
+     * and this agent's own restore guard (101), because a Throwable escaping a
+     * shutdown callback abandons the rest of the queue. It must sit BEFORE the
+     * outcome push, so the metadata that push sends is read from an unforced
+     * transient.
+     */
+    public function test_a_fatal_skipping_the_finally_still_clears_the_forced_offer_at_shutdown(): void
+    {
+        $this->stubSignedOffer();
+        $this->upgraderReadsTheOffer();
+
+        $checker = $this->makeChecker();
+        $this->bindAgentFilters($checker);
+
+        $this->armAndApply($checker);
+
+        $clear = null;
+        foreach ($this->actions as $action) {
+            if ($action['hook'] === 'shutdown'
+                && is_array($action['callback'])
+                && $action['callback'][1] === 'clearForcedOffer'
+            ) {
+                $clear = $action;
+            }
+        }
+
+        $this->assertNotNull($clear, 'the forced offer must have a shutdown backstop');
+        $this->assertGreaterThan(101, (int) $clear['priority'], 'it must run after core\'s rollback and this agent\'s guard');
+        $this->assertLessThan(9998, (int) $clear['priority'], 'and before the outcome push, which reads site metadata');
+
+        // And calling it twice is a no-op, since the finally has already run.
+        $checker->clearForcedOffer();
+        $checker->clearForcedOffer();
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * The forced offer is scoped to OUR plugin key and nothing else, so it can
+     * never route another plugin's update through this agent's package.
+     */
+    public function test_the_forced_offer_carries_only_our_own_entry(): void
+    {
+        $this->stubSignedOffer();
+        $this->upgraderReadsTheOffer();
+
+        $checker = $this->makeChecker();
+        $this->bindAgentFilters($checker);
+
+        $this->armAndApply($checker);
+
+        $seen = $this->transientSeenByUpgrader;
+        $this->assertIsObject($seen);
+        $this->assertSame(
+            [UpdateChecker::PLUGIN_KEY],
+            array_keys((array) $seen->response),
+            'a forced offer that named any other plugin would hand it this agent\'s package'
+        );
+    }
+
+    /**
+     * THE FIXTURE IS CHECKED AGAINST THE PRODUCTION BINDINGS.
+     *
+     * bindAgentFilters() reproduces install() by hand because install() carries
+     * a process-global static guard. A harness that reproduces the wrong world
+     * is worse than no harness at all, so the two hook names are read back out
+     * of the production source.
+     */
+    public function test_install_binds_the_filters_this_fixture_reproduces(): void
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__) . '/includes/support/class-update-checker.php'
+        );
+
+        $this->assertStringContainsString(
+            "add_filter('site_transient_update_plugins', [\$this, 'injectUpdate']);",
+            $source,
+            'the offer is produced by a filter on site_transient_update_plugins; this fixture binds the same one'
+        );
+        $this->assertStringContainsString(
+            "add_action('delete_site_transient_update_plugins', [\$this, 'flushCache']);",
+            $source,
+            'and flushCache() is bound to the delete action, which is why deleting update_plugins is destructive here'
+        );
+    }
+
+    // =========================================================================
+    // The 12h positive cache, which the OTHER two installers still depend on
+    // =========================================================================
+
+    /**
+     * AN INSTALL ATTEMPT CORRECTS THE 12 HOUR POSITIVE CACHE.
+     *
+     * The commanded apply now depends on no cache at all, but the other two
+     * installers of this plugin do: the dashboard's own "Update now" and core's
+     * auto-updater both read the offer injectUpdate() builds from claims cached
+     * for 12 hours. Those claims can name a build the control plane has since
+     * moved past.
+     *
+     * They can never INSTALL the wrong build, because verifyDownload() re-fetches
+     * and re-verifies the signed manifest from scratch and installs whatever the
+     * control plane publishes at that moment. What they could do is print a stale
+     * version beside the button. verifyDownload() now writes the fresh claims
+     * back over the cache, at the one moment the truth is in hand for free, so
+     * any install attempt corrects the label for the next read.
+     */
+    /**
+     * THE RECOVERY OFFER MUST NOT UNDO WHAT THE DOWNLOAD JUST SETTLED.
+     *
+     * Both run inside one apply: verifyDownload() first, then
+     * primeRecoveryOffer() from applyPendingUpdate()'s finally, milliseconds
+     * later. primeRecoveryOffer() writes whenever the arm's claims are still
+     * newer than what is on disk, which after a FAILED apply is always true.
+     *
+     * This is the release-withdrawn case. The operator pulls the build
+     * mid-rollout, the control plane answers no_update, verifyDownload()
+     * retires the dead claims, and without a guard the finally writes them
+     * straight back for another twelve hours, leaving the dashboard offering a
+     * button that cannot work.
+     */
+    public function test_a_withdrawn_release_is_not_resurrected_by_the_recovery_offer(): void
+    {
+        $this->siteTransients[UpdateChecker::TRANSIENT_MANIFEST] = [
+            'version' => $this->targetVersion,
+            'slug'    => 'wpmgr-agent',
+        ];
+
+        // The control plane now says there is nothing to install.
+        $this->stubNoUpdate();
+
+        $checker = $this->makeChecker();
+        $checker->verifyDownload(false, UpdateChecker::PACKAGE_SENTINEL, null, null);
+
+        $this->assertArrayNotHasKey(
+            UpdateChecker::TRANSIENT_MANIFEST,
+            $this->siteTransients,
+            'a definitive no_update must retire the claims that led here'
+        );
+
+        // Now the finally runs. It must stand down rather than resurrect them.
+        $this->invokeRecoveryOffer($checker, [
+            'version' => $this->targetVersion,
+            'slug'    => 'wpmgr-agent',
+        ]);
+
+        $this->assertArrayNotHasKey(
+            UpdateChecker::TRANSIENT_MANIFEST,
+            $this->siteTransients,
+            'the recovery offer must not write back a build the control plane just withdrew'
+        );
+    }
+
+    /**
+     * THE OTHER HALF: a version the download corrected FORWARD must not be
+     * downgraded back to the arm's older one.
+     *
+     * Reachable whenever the control plane publishes during the apply's own
+     * window, which GH #328's site-lock wait widened to as much as 240
+     * seconds.
+     */
+    public function test_a_corrected_version_is_not_downgraded_by_the_recovery_offer(): void
+    {
+        $this->siteTransients[UpdateChecker::TRANSIENT_MANIFEST] = [
+            'version' => '0.10.6',
+            'slug'    => 'wpmgr-agent',
+        ];
+
+        $this->stubSignedOffer();
+
+        $checker = $this->makeChecker();
+        $checker->verifyDownload(false, UpdateChecker::PACKAGE_SENTINEL, null, null);
+
+        $cached = $this->siteTransients[UpdateChecker::TRANSIENT_MANIFEST] ?? null;
+        $this->assertIsArray($cached);
+        $this->assertSame($this->targetVersion, (string) ($cached['version'] ?? ''));
+
+        // The arm's claims are OLDER than what the download just verified.
+        $this->invokeRecoveryOffer($checker, [
+            'version' => '0.10.6',
+            'slug'    => 'wpmgr-agent',
+        ]);
+
+        $cached = $this->siteTransients[UpdateChecker::TRANSIENT_MANIFEST] ?? null;
+        $this->assertIsArray($cached);
+        $this->assertSame(
+            $this->targetVersion,
+            (string) ($cached['version'] ?? ''),
+            'the recovery offer must not downgrade a label the download just corrected forward'
+        );
+    }
+
+    /**
+     * And the guard must not disable the recovery offer outright: when
+     * verifyDownload() never ran, a failed apply still leaves the dashboard
+     * the claims this request verified.
+     */
+    public function test_the_recovery_offer_still_primes_when_no_download_ran(): void
+    {
+        unset($this->siteTransients[UpdateChecker::TRANSIENT_MANIFEST]);
+
+        $checker = $this->makeChecker();
+        $this->invokeRecoveryOffer($checker, [
+            'version' => $this->targetVersion,
+            'slug'    => 'wpmgr-agent',
+        ]);
+
+        $cached = $this->siteTransients[UpdateChecker::TRANSIENT_MANIFEST] ?? null;
+        $this->assertIsArray(
+            $cached,
+            'with no download to defer to, the recovery path must still be primed'
+        );
+        $this->assertSame($this->targetVersion, (string) ($cached['version'] ?? ''));
+    }
+
+    public function test_a_download_refreshes_the_cached_claims_from_the_fresh_manifest(): void
+    {
+        // A cache entry from twelve hours ago naming a build that has been
+        // superseded since.
+        $this->siteTransients[UpdateChecker::TRANSIENT_MANIFEST] = [
+            'version' => '0.10.6',
+            'slug'    => 'wpmgr-agent',
+        ];
+
+        $this->stubSignedOffer();
+
+        $checker = $this->makeChecker();
+        $result  = $checker->verifyDownload(false, UpdateChecker::PACKAGE_SENTINEL, null, null);
+
+        // The download itself cannot succeed in this fixture (wp_remote_get is
+        // stubbed with the manifest body, not a package), and that is fine:
+        // what is under test is the cache write that precedes it.
+        unset($result);
+
+        $cached = $this->siteTransients[UpdateChecker::TRANSIENT_MANIFEST] ?? null;
+        $this->assertIsArray($cached);
+        $this->assertSame(
+            $this->targetVersion,
+            (string) ($cached['version'] ?? ''),
+            'the stale label must be corrected from the manifest this download just verified'
+        );
+        $this->assertArrayNotHasKey(
+            'package_url',
+            $cached,
+            'and the presigned URL is a bearer credential that is never cached'
+        );
+    }
+
+    /**
+     * AN OVERTAKEN CACHED OFFER IS RETIRED BY THE FIRST READ THAT FINDS IT
+     * FALSE, not answered from for the rest of its 12 hour window.
+     *
+     * Nothing can cache claims that are not newer than the on-disk build, since
+     * verifyManifest()'s downgrade guard refuses them, so this state means the
+     * build on disk moved after the entry was written and every install route
+     * that moves it clears this cache. What is left is an out-of-band change: a
+     * file copy, a deploy, a restore. Answering "no update" from it would hold
+     * the dashboard's recovery path shut for up to twelve hours.
+     */
+    public function test_an_overtaken_cached_offer_is_retired_after_a_single_read(): void
+    {
+        $this->stubSignedOffer();
+
+        $checker = $this->makeChecker();
+        $this->bindAgentFilters($checker);
+
+        // Claims naming the build this site is already running.
+        $this->siteTransients[UpdateChecker::TRANSIENT_MANIFEST] = [
+            'version' => $this->onDiskVersion,
+            'slug'    => 'wpmgr-agent',
+        ];
+        $this->siteTransients['update_plugins'] = (object) [
+            'last_checked' => time(),
+            'response'     => [],
+            'no_update'    => [],
+        ];
+
+        $first = get_site_transient('update_plugins');
+
+        $this->assertIsObject($first);
+        $this->assertArrayNotHasKey(UpdateChecker::PLUGIN_KEY, (array) $first->response);
+        $this->assertSame(0, $this->manifestFetches, 'retiring a false entry must not cost a control-plane call');
+        $this->assertArrayNotHasKey(
+            UpdateChecker::TRANSIENT_MANIFEST,
+            $this->siteTransients,
+            'the entry the on-disk build overtook must not survive the read that found it false'
+        );
+
+        // The next read is a genuine miss, so it asks, and gets the truth.
+        $second = get_site_transient('update_plugins');
+
+        $this->assertIsObject($second);
+        $this->assertSame(1, $this->manifestFetches);
+        $this->assertArrayHasKey(UpdateChecker::PLUGIN_KEY, (array) $second->response);
+        $this->assertSame(
+            $this->targetVersion,
+            (string) $second->response[UpdateChecker::PLUGIN_KEY]->new_version,
+            'and the dashboard now names the build the control plane actually publishes'
+        );
+    }
+
+    /**
+     * A DEFINITIVE "NOTHING PUBLISHED" RETIRES THE CACHED OFFER THAT LED TO THE
+     * ATTEMPT.
+     *
+     * Something read a cached entry and tried to install it; the control plane
+     * answered 204. Those claims are provably false and must not keep offering a
+     * button that cannot work.
+     */
+    public function test_a_control_plane_204_retires_the_cached_offer_that_led_to_it(): void
+    {
+        $this->siteTransients[UpdateChecker::TRANSIENT_MANIFEST] = [
+            'version' => $this->targetVersion,
+            'slug'    => 'wpmgr-agent',
+        ];
+
+        Functions\when('wp_remote_get')->alias(function () {
+            $this->manifestFetches++;
+
+            return ['response' => ['code' => 204], 'body' => ''];
+        });
+        Functions\when('wp_remote_retrieve_response_code')->alias(fn ($response) => $response['response']['code'] ?? 0);
+        Functions\when('wp_remote_retrieve_body')->alias(fn ($response) => $response['body'] ?? '');
+
+        $checker = $this->makeChecker();
+        $result  = $checker->verifyDownload(false, UpdateChecker::PACKAGE_SENTINEL, null, null);
+
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertArrayNotHasKey(
+            UpdateChecker::TRANSIENT_MANIFEST,
+            $this->siteTransients,
+            'a withdrawn release must not keep being offered for the rest of the 12h window'
+        );
+    }
+
+    /**
+     * A CONTROL-PLANE OUTAGE RETIRES NOTHING.
+     *
+     * The counterpart to the test above, and the more important half. An answer
+     * that did not arrive teaches nothing about what is published, so a control
+     * plane that goes down must never be able to blank a fleet's update offers.
+     */
+    public function test_a_control_plane_outage_leaves_the_cached_offer_alone(): void
+    {
+        $cached = ['version' => $this->targetVersion, 'slug' => 'wpmgr-agent'];
+
+        $this->siteTransients[UpdateChecker::TRANSIENT_MANIFEST] = $cached;
+
+        Functions\when('wp_remote_get')->alias(static fn () => new \WP_Error('http_request_failed', 'unreachable'));
+
+        $checker = $this->makeChecker();
+        $result  = $checker->verifyDownload(false, UpdateChecker::PACKAGE_SENTINEL, null, null);
+
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame(
+            $cached,
+            $this->siteTransients[UpdateChecker::TRANSIENT_MANIFEST] ?? null,
+            'an unreachable control plane must not cost this site its update offer'
+        );
+    }
+
+    /**
+     * A FAILED APPLY HANDS THE RECOVERY PATH A VERIFIED OFFER, over no network.
+     *
+     * A dashboard-initiated update is the documented recovery route for a build
+     * whose commanded apply is broken, and it is the one installer this fix does
+     * not carry claims into. So the apply leaves the claims it verified in this
+     * request where injectUpdate() will find them, which is what stops the
+     * recovery path paying a control-plane round trip that, if it fails, writes
+     * a one-hour "no update" and hides the button exactly when it is needed.
+     */
+    public function test_a_failed_apply_hands_the_recovery_path_a_verified_offer(): void
+    {
+        $this->stubSignedOffer();
+        \Plugin_Upgrader::$behaviour = static fn () => false;
+
+        $checker = $this->makeChecker();
+        $this->bindAgentFilters($checker);
+
+        $this->assertSame('scheduled', $checker->planSelfUpdate()['status']);
+
+        // A sibling update command clears the plugin caches while this apply is
+        // still waiting for the site lock, taking the manifest with it.
+        delete_site_transient('update_plugins');
+        $fetchesAfterTheArm = $this->manifestFetches;
+
+        $checker->serveThenApply(false, null, null, null);
+
+        $this->assertSame('failed', (string) ($this->record()['status'] ?? ''));
+
+        $cached = $this->siteTransients[UpdateChecker::TRANSIENT_MANIFEST] ?? null;
+        $this->assertIsArray($cached, 'the recovery path must not be left reading an empty cache');
+        $this->assertSame($this->targetVersion, (string) ($cached['version'] ?? ''));
+        $this->assertArrayNotHasKey('package_url', $cached, 'a presigned bearer credential is never cached');
+        $this->assertSame(
+            $fetchesAfterTheArm,
+            $this->manifestFetches,
+            'and priming it costs no control-plane call, because the claims were verified in this request'
+        );
+    }
+
+    /**
+     * A SUCCESSFUL APPLY DOES NOT RE-PRIME THE CACHE IT JUST FLUSHED.
+     *
+     * The priming is self-guarding: it writes only while the verified build is
+     * still newer than what is on disk. After a swap that landed, the site is at
+     * the target, so nothing is written back over the flush and the next read
+     * asks the control plane what comes next.
+     */
+    public function test_a_successful_apply_does_not_re_prime_the_cache_it_flushed(): void
+    {
+        $this->stubSignedOffer();
+        \Plugin_Upgrader::$behaviour = function (string $plugin) {
+            $current                       = get_site_transient('update_plugins');
+            $this->transientSeenByUpgrader = is_object($current) ? $current : null;
+            $this->offerSeenByUpgrader     = is_object($current) && isset($current->response[$plugin])
+                ? $current->response[$plugin]
+                : null;
+
+            // The swap lands, so the new build is what the header reports now.
+            $this->onDiskVersion = $this->targetVersion;
+
+            return true;
+        };
+
+        $checker = $this->makeChecker();
+        $this->bindAgentFilters($checker);
+
+        $this->armAndApply($checker);
+
+        $this->assertTheUpgraderReadOurOffer();
+        $this->assertArrayNotHasKey(
+            UpdateChecker::TRANSIENT_MANIFEST,
+            $this->siteTransients,
+            'an installed build leaves nothing to offer; the next read asks what comes after it'
+        );
+    }
+}

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.114
+ * Version:           0.61.118
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.114');
+define('WPMGR_AGENT_VERSION', '0.61.118');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,34 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.118",
+    date: "2026-08-04",
+    summary:
+      "A fleet agent update could install nothing on one site while the same rollout succeeded everywhere else. The apply now carries the build it verified instead of looking it up in a cache any other plugin can answer for.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "A fleet agent update could report \"the plugin update transient carried no entry for this plugin\" and install nothing, on one site, while the same rollout installed cleanly everywhere else. The apply looked up the build it was about to install in WordPress's shared plugin update cache, and that cache is one any other plugin on the site is allowed to answer for, rewrite or delete. A security or \"disable updates\" plugin answering that read first, a managed host's own must-use plugin doing the same, or simply an ordinary plugin update finishing on that site at that moment, was enough to leave WordPress's installer with nothing to install, after which the rollout stopped at the canary and no other site was touched. The apply no longer looks anything up: it carries the build it verified moments earlier and hands that straight to the installer. What gets installed is unchanged, and is still re-verified from scratch against the signed manifest before a single byte is written.",
+      },
+      {
+        tag: "Fixed",
+        text: "The previous release had made this more likely, not less. 0.61.114 correctly made an agent update wait for any other update on the same site to finish first, and the process it waits for is exactly the one that clears the cache the apply was standing on, which widened the window from milliseconds to as much as four minutes. That window is now closed, because the apply no longer depends on that cache at all.",
+      },
+      {
+        tag: "Fixed",
+        text: "The update offer shown on a site's own WordPress dashboard is now self correcting. An offer naming a build the fleet has since moved past is rewritten from the fresh signed manifest at the moment an install starts; an offer for a withdrawn release is retired the first time anything acts on it; and an offer the site has already overtaken, for example because its files were replaced by a deploy or a restore, is retired by the first page load that sees it instead of standing for up to twelve hours. A control plane that is briefly unreachable retires nothing, so an outage can never blank a fleet's update offers.",
+      },
+      {
+        tag: "Fixed",
+        text: "When a commanded agent update does fail, the site's own dashboard is now left holding a verified offer for the same build, so the one-click update inside wp-admin, which is the recovery route for a build whose fleet update is broken, is available immediately.",
+      },
+      {
+        tag: "Changed",
+        text: "As with every fix to the agent's own update path, this one cannot be delivered by the path it fixes. A site whose fleet agent update is failing this way needs one update from its own WordPress dashboard, after which fleet updates work normally again.",
+      },
+    ],
+  },
+  {
     version: "0.61.117",
     date: "2026-08-04",
     summary:

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.117
+  version: 0.61.118
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Fixes #334.

A 21-site fleet rollout failed its canary with *"No update offer reached the upgrader: the plugin update transient carried no entry for this plugin."* The rollout then correctly halted and cancelled the other 20 untouched.

## Why 0.61.108 did not already fix this

0.61.108 fixed **this same function**. The bug then was deleting the transient a few lines before `Plugin_Upgrader::upgrade()` read it, and the fix rebuilt it when absent:

```php
if (!is_object($offer) && function_exists('wp_update_plugins')) { ... }
```

That guards **the state we had caused**, not **the state the upgrader requires**. The invariant is *"the offer contains our entry"*; we asserted *"the transient exists"*. Every failure since has lived in that gap.

## What actually breaks it

Our entry is never *stored* in `update_plugins`. It is produced at read time by `injectUpdate()` on `site_transient_update_plugins`. So a valid-but-stale object gets decorated on the next read and applies fine.

That means the reporter's stated mechanism, while a correct reading of the guard, is **not sufficient on its own** — and one test here now documents exactly that, because it passes both before and after the fix.

Real starvation needs something that stops the filter being reached or answering:

- `get_site_transient()` applies `pre_site_transient_update_plugins` **first** and returns immediately on anything but false (`option.php:2580-2584`), never reaching `:2620`. Any plugin short-circuiting there starves us **100% on that site** while the mechanism works everywhere else.
- our own manifest cache being wiped mid-request by a sibling command, which **#328 widened from milliseconds to as much as 240 seconds**.

## The fix

The apply no longer depends on any cache. The arm already fetched and verified the manifest **in the same request**, so those claims are threaded **in memory** into the apply, and the offer is forced onto `pre_site_transient_update_plugins` at `PHP_INT_MAX`.

Registering last there beats any earlier short circuit, and it must be a filter because `Plugin_Upgrader::upgrade()` re-reads the transient itself (`class-plugin-upgrader.php:199`) — repairing a local variable is worthless. Withdrawn in a `finally` and again at shutdown.

**Not the reporter's suggested fix**, which is actively harmful: `delete_site_transient()` fires its `delete_site_transient_{$transient}` action **first** (`option.php:2520`), we bind `flushCache()` to it, so deleting `update_plugins` here would destroy the manifest the arm wrote nine lines earlier, and a failed re-fetch would write a 1-hour negative sentinel poisoning every retry.

## Found in review and fixed here

`primeRecoveryOffer()` **undid both** of `verifyDownload()`'s cache corrections in the same request. Proven by execution, not argued:

```
withdrawn release  -> verifyDownload retires dead claims -> finally writes them back for 12h
CP moves forward   -> verifyDownload caches 0.10.5.1     -> finally downgrades to 0.10.6
```

`verifyDownload()` is the authority, being the only path that re-fetches and re-verifies from scratch, so it now marks the cache settled and the recovery offer stands down.

One test that **could not fail** was rewritten rather than kept. It asserted a cause its own faithful fixture disproves.

## Gates

```
phpunit  3150 pass, 0 fail        phpcs 0        plugin check 0 errors
lockstep 0.61.118                 dashes 0
```

The two new guard tests were verified to **fail without the guard**:

```
--- FAIL: a corrected version is not downgraded by the recovery offer
    Expected '0.10.5.1'  Actual '0.10.6'
```

## Stacking note

Depends on nothing, but #339 takes 0.61.117, so this is renumbered to 0.61.118.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent self-updates by avoiding stale shared update data.
  * Dashboard update offers now correct themselves when versions change or releases are withdrawn.
  * Failed fleet updates preserve verified offers for recovery through wp-admin.
  * Added safeguards to prevent incomplete or outdated updates from being applied.
  * Sites affected by the previous update issue require a one-time manual update in wp-admin.

* **Documentation**
  * Added release notes for version 0.61.118.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->