### PR TITLE
fix(release): make the agent archive byte-reproducible (GH #322)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,56 @@ jobs:
           WPMGR_AGENT_TESTED: ${{ vars.WPMGR_AGENT_TESTED }}
         run: scripts/release-agent.sh --dry-run --out release/agent-release.json
 
+      # ONE AGENT VERSION MEANS ONE SET OF BYTES, FOREVER (GitHub issue #322).
+      #
+      # The agent version deliberately does not track the repo version: it only
+      # moves when the agent itself changes, so a web-only release must not push
+      # a new agent to every site in a fleet. The consequence is that a web-only
+      # release RE-PUBLISHES an agent version that already exists upstream, and
+      # that is only safe if the archive is byte-identical. `make agent-zip` is
+      # now deterministic so it is, but nothing enforced it, and four releases
+      # shipped four different artifacts all claiming 0.61.114. Every mirroring
+      # self-hoster correctly refused them.
+      #
+      # This turns a regression in that determinism into a failed build for us
+      # rather than a refused mirror for them. It compares against the newest
+      # PUBLISHED release carrying the same agent version, and stays silent when
+      # the version has moved (a genuinely new build) or when there is nothing
+      # to compare against.
+      - name: Assert the agent archive is unchanged for an unchanged version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          v=$(sed -n "s/^define('WPMGR_AGENT_VERSION', *'\([^']*\)').*/\1/p" apps/agent/wpmgr-agent.php)
+          [ -n "$v" ] || { echo "could not read WPMGR_AGENT_VERSION"; exit 1; }
+          ours=$(sha256sum release/wpmgr-agent.zip | cut -d' ' -f1)
+          echo "agent version $v, sha256 $ours"
+
+          prev=""
+          for tag in $(gh release list --limit 40 --json tagName --jq '.[].tagName'); do
+            [ "$tag" = "${{ steps.vars.outputs.version }}" ] && continue
+            if gh release download "$tag" -p agent-release.json -D /tmp/prev --clobber >/dev/null 2>&1; then
+              pv=$(python3 -c "import json;print(json.load(open('/tmp/prev/agent-release.json')).get('version',''))" 2>/dev/null || echo "")
+              if [ "$pv" = "$v" ]; then prev="$tag"; break; fi
+            fi
+          done
+
+          if [ -z "$prev" ]; then
+            echo "no published release carries agent $v yet, nothing to compare"
+            exit 0
+          fi
+
+          gh release download "$prev" -p wpmgr-agent.zip -D /tmp/prevzip --clobber
+          theirs=$(sha256sum /tmp/prevzip/wpmgr-agent.zip | cut -d' ' -f1)
+          if [ "$ours" != "$theirs" ]; then
+            echo "::error::agent $v was already published in $prev with sha256 $theirs, but this build produced $ours."
+            echo "::error::Same version string, different bytes. Every mirroring self-hoster will refuse this."
+            echo "::error::Either the packaging stopped being deterministic, or the agent changed without its version being bumped."
+            exit 1
+          fi
+          echo "matches $prev byte for byte"
+
       - name: Publish GitHub Release with the agent zip + manifest
         uses: softprops/action-gh-release@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.119] - 2026-08-04
+
+### Fixed
+
+- Self-hosted installs that mirror our agent releases were refusing them, correctly, with "upstream republished the same version with different bytes". The agent's version only changes when the agent itself changes, which is deliberate: a release that only touches the dashboard should not push a new agent to every site in your fleet. But the archive was rebuilt on every release and was not byte-reproducible, because it recorded each file's modification time and the packaging step reinstalls the vendored libraries from scratch each run. So a dashboard-only release republished the same agent version with different bytes, and a mirror holding the previous copy of that version had no way to tell that apart from tampering. Four published releases carried four different archives all naming the same agent version. Packaging is now deterministic: the same source produces a byte-identical archive every time, verified by building it twice and comparing. A release-time check now also refuses to publish an archive whose bytes differ from an already-published release carrying the same agent version, so this cannot return quietly.
+
 ## [0.61.118] - 2026-08-04
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,39 @@ lint: ## Lint everything
 	cd apps/api && go vet ./...
 	pnpm run lint
 
+# reproducible_zip: package $2 (a directory) inside $1 into $3, byte for byte
+# identically every time the same tree is packaged.
+#
+# WHY THIS EXISTS (GitHub issue #322). A plain `zip -r` records each entry's
+# mtime and walks the tree in filesystem order, so the same source produced a
+# DIFFERENT archive on every build. agent-vendor deletes and reinstalls vendor/
+# each time, which restamps thousands of files, so the drift was guaranteed
+# rather than occasional.
+#
+# That mattered because the agent version deliberately does NOT track the repo
+# version (it only changes when the agent changes), so a web-only release
+# republished the SAME version string with different bytes. A self-hoster
+# mirroring our releases correctly refused it: "upstream republished the same
+# version with different bytes". Four artifacts on GitHub claimed 0.61.114,
+# each with a different sha256, and every mirror kept refusing until the
+# version moved.
+#
+# The mirror's assumption, that one version string means one set of bytes
+# forever, is right. This makes it true.
+#
+#   touch  pins every mtime to a fixed instant. It must be >= 1980 because the
+#          zip format cannot store anything earlier, and on an even second
+#          because DOS timestamps have two-second granularity.
+#   sort   fixes entry order independent of how the filesystem enumerates.
+#   -X     drops platform extra fields (uid, gid, and the macOS-only ones), so
+#          a Linux CI runner and a macOS workstation agree.
+#
+# $(1) working dir, $(2) directory to package, $(3) output archive name.
+define reproducible_zip
+	find $(1)/$(2) -exec touch -h -t 200001010000.00 {} +
+	cd $(1) && find $(2) -print | LC_ALL=C sort | zip -X -q -@ $(3)
+endef
+
 .PHONY: agent-vendor
 agent-vendor: ## Build a clean prod-only vendor/ for the agent (no-dev, stripped)
 	# ADR-033 / M5.6: agent has ZERO production composer deps (we dropped phpbu
@@ -142,7 +175,7 @@ agent-zip: agent-vendor ## Package the WordPress agent plugin as a zip (with ifs
 		sed -i.bak -E "s/^(define\('WPMGR_AGENT_VERSION', *')[^']+(')/\1$$_v_esc\2/" release/wpmgr-agent/wpmgr-agent.php; \
 		rm -f release/wpmgr-agent/wpmgr-agent.php.bak; \
 	fi
-	cd release && zip -r wpmgr-agent.zip wpmgr-agent
+	$(call reproducible_zip,release,wpmgr-agent,wpmgr-agent.zip)
 	rm -rf release/wpmgr-agent
 	@echo "agent zip: $$(du -sh release/wpmgr-agent.zip | cut -f1)"
 
@@ -279,7 +312,7 @@ agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip (fl
 	# assertion above. tools/ is excluded from the staged tree, so the checker is
 	# invoked from the source tree.
 	php apps/agent/tools/assert-wporg-updatechecker-guard.php release/fleet-agent-site-manager
-	cd release && zip -r fleet-agent-site-manager.zip fleet-agent-site-manager
+	$(call reproducible_zip,release,fleet-agent-site-manager,fleet-agent-site-manager.zip)
 	rm -rf release/fleet-agent-site-manager
 	@echo "agent wporg zip: $$(du -sh release/fleet-agent-site-manager.zip | cut -f1)"
 

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,18 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.119",
+    date: "2026-08-04",
+    summary:
+      "Self-hosted installs mirroring our agent releases were correctly refusing them, because the same agent version was being republished with different bytes.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "If you run a self-hosted install that mirrors our agent releases, it was refusing them with \"upstream republished the same version with different bytes\". That refusal was correct. The agent's version only changes when the agent itself changes, which is deliberate, because a release that only touches the dashboard should not push a new agent to every site in your fleet. But the archive was rebuilt on every release and was not byte-reproducible, since it recorded file modification times and the packaging step reinstalls the vendored libraries from scratch each run. A dashboard-only release therefore republished the same agent version with different bytes, which a mirror cannot tell apart from tampering. Packaging is now deterministic, verified by building twice and comparing, and a release-time check refuses to publish an archive whose bytes differ from an already-published release carrying the same agent version.",
+      },
+    ],
+  },
+  {
     version: "0.61.118",
     date: "2026-08-04",
     summary:

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.118
+  version: 0.61.119
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Reported in #322 by a self-hoster whose mirror refused our releases:

```
agent release mirror REFUSED: upstream republished the same version with different bytes
version 0.61.112
mirrored_sha256 99b576ef...
upstream_sha256 30505616...
```

**The refusal was correct. The defect was ours.**

## Four artifacts, one version

```
v0.61.114  ->  manifest 0.61.114, sha 00299efe...
v0.61.115  ->  manifest 0.61.114, sha f5598573...
v0.61.116  ->  manifest 0.61.114, sha 57ff140b...
prod GCS   ->  manifest 0.61.114, sha 4ee76a08...
```

`git diff v0.61.114..v0.61.116 -- apps/agent` is **empty**. One unchanged thing, packaged four times, non-deterministically.

## Cause, and what is not the cause

**The version decoupling is deliberate and stays.** `release.yml` says so itself: the agent carries its own `WPMGR_AGENT_VERSION`, which only moves when the agent changes, because a dashboard-only release must not push a new agent to every site in a fleet.

The hole is that a web-only release still **rebuilds and re-uploads** the archive, and `zip -r` records each entry's mtime and walks the tree in filesystem order. `agent-vendor` deletes and reinstalls `vendor/` every run, restamping thousands of files, so drift was **guaranteed**, not occasional.

The mirror's assumption — *one version string means one set of bytes, forever* — is right. This makes it true.

## The fix

A `reproducible_zip` macro used by both `agent-zip` and `agent-zip-wporg`:

- **pin every mtime** to a fixed instant (>= 1980 and on an even second, because the zip format cannot store earlier dates and DOS timestamps have two-second granularity)
- **sorted file list**, so entry order does not depend on filesystem enumeration
- **`-X`**, so a Linux CI runner and a macOS workstation agree on extra fields

Plus a **release-time guard** that refuses to publish an archive whose bytes differ from an already-published release carrying the same agent version. A regression in determinism becomes a failed build for us, not a refused mirror for a self-hoster.

## Verified by measurement

```
before:  build 1  56ca7cb0...     build 2  b732434e...     DIFFERENT
after:   build 1  e42a5d86...     build 2  e42a5d86...     IDENTICAL
```

**Content is unchanged, not merely reproducible.** The tree extracted from this build is byte-identical to the tree extracted from the CI-built `v0.61.118` asset:

```
CI build files:     345
local build files:  345
diff -r --brief:    (empty)
```

Plugin Check still reports 0 errors, and the archive still extracts under the `wpmgr-agent/` slug, which matters because WordPress derives the install folder from it.

## Not rewriting the published releases

Mutating published artifacts to fix a problem *about* mutated published artifacts would make a mirror's view worse, not better. This takes effect from the next release. Mirrors will keep refusing `0.61.114` until the version moves, which it now has.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent archives are now packaged deterministically, producing byte-identical files across repeated builds.
  * Release validation now detects unexpected differences when publishing an existing agent version.

* **Documentation**
  * Added release notes for version 0.61.119, including packaging improvements and archive consistency checks.
  * Updated the public API specification to version 0.61.119.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->