### PR TITLE
fix(updates): stop claiming a site is up to date when only its managed components are (GH #314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.121] - 2026-08-04
+
+### Fixed
+
+- A site's Updates tab said "All up to date", with a green check, while that same site's own WordPress dashboard was offering a WPMgr agent update (GH #314). The tab only ever knew about the components WPMgr updates for you: plugins, themes and WordPress core. The agent itself is deliberately not one of them, so its update was never in the count, and the tab claimed everything was current when all it actually knew was that the managed components were.
+- The tab now says "All managed components are up to date", and the badge beside the heading says "No managed updates", so neither one speaks for anything WPMgr does not update.
+- The agent is now shown on that tab as its own line, whether or not anything else needs updating, with what this install actually knows about it: behind, current, or not determinable. It is deliberately not selectable and has no update button, because an agent update applied the way a plugin update is applied means the plugin overwriting its own running files inside the request that has to report the result, with no rollback armed for its own directory. Where the fleet agent update channel is turned on and you can use it, the line links straight to it. Where it is not, the line says to update the agent from that site's own Plugins screen instead. A site running the build from the WordPress plugin directory is never sent to the fleet channel at all, because that build ships without a self-updater and updates through the directory.
+- When this install has no published agent release to compare against, the line says so rather than guessing. It never reports a site as behind on a comparison that did not happen, and where the comparison fell back to the newest agent version this fleet has reported, it says that too, in the same words the Sites list already uses.
+
 ## [0.61.120] - 2026-08-04
 
 ### Added

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,26 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.121",
+    date: "2026-08-04",
+    summary:
+      "A site's Updates tab said everything was up to date when all it knew was that the managed components were. The WPMgr agent is now stated on that tab as its own line.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "A site's Updates tab said \"All up to date\", with a green check, while that same site's own WordPress dashboard was offering a WPMgr agent update. The tab only ever knew about the components WPMgr updates for you: plugins, themes and WordPress core. The agent itself is deliberately not one of them, so its update was never in the count. The tab now says \"All managed components are up to date\", so it no longer speaks for anything WPMgr does not update.",
+      },
+      {
+        tag: "Fixed",
+        text: "The agent is now shown on that tab as its own line, whether or not anything else needs updating. It is deliberately not selectable and has no update button, because an agent update applied the way a plugin update is applied means the plugin overwriting its own running files inside the request that has to report the result, with no rollback armed for its own directory. Where the fleet agent update channel is turned on and you can use it, the line links straight to it; where it is not, it says to update the agent from that site's own Plugins screen instead.",
+      },
+      {
+        tag: "Fixed",
+        text: "When an install has no published agent release to compare against, the line says so rather than guessing, and never reports a site as behind on a comparison that did not happen.",
+      },
+    ],
+  },
+  {
     version: "0.61.120",
     date: "2026-08-04",
     summary:

--- a/apps/web/src/features/updates/agent-update-notice.test.tsx
+++ b/apps/web/src/features/updates/agent-update-notice.test.tsx
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import { screen, within } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+import { AGENT_FLEET_NOTE_BODY } from "@/features/sites/agent-column-header";
+
+import { AgentUpdateNotice } from "./agent-update-notice";
+import type { SiteAgentUpdate } from "./use-site-agent-update";
+
+// GH #314 (reported against 0.61.102, hosted): the site Updates tab said
+// "All up to date" with a green check while the same site's wp-admin was
+// offering a WPMgr agent update. These tests pin the line that now states the
+// agent separately, and above all pin that it never becomes actionable from
+// this tab.
+
+function build(overrides: Partial<SiteAgentUpdate> = {}): SiteAgentUpdate {
+  return {
+    status: "outdated",
+    version: "0.61.100",
+    latestVersion: "0.61.121",
+    referenceSource: "published",
+    channelAvailable: true,
+    ...overrides,
+  };
+}
+
+describe("AgentUpdateNotice", () => {
+  // ── The safety property. Do not weaken these two. ────────────────────────
+  //
+  // The agent is excluded from managed updates because applying it through
+  // the ordinary plugin path is the plugin overwriting its own running files
+  // inside the request that has to report the outcome, with no armed
+  // rollback. A checkbox here, or any control that could enqueue a run, would
+  // put that path back.
+
+  it("is never selectable: no checkbox, no selection control of any kind", async () => {
+    const { container } = renderWithProviders(
+      <AgentUpdateNotice agent={build()} />,
+      { withRouter: true },
+    );
+    const notice = await screen.findByTestId("agent-update-notice");
+
+    expect(within(notice).queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(within(notice).queryByRole("radio")).not.toBeInTheDocument();
+    expect(container.querySelector("input")).toBeNull();
+  });
+
+  it("offers no button that could start an update run, only a link", async () => {
+    renderWithProviders(<AgentUpdateNotice agent={build()} />, {
+      withRouter: true,
+    });
+    const notice = await screen.findByTestId("agent-update-notice");
+
+    expect(within(notice).queryByRole("button")).not.toBeInTheDocument();
+    expect(notice.querySelector("form")).toBeNull();
+  });
+
+  // ── Where the operator is sent (GH #314 requirement 3) ───────────────────
+
+  it("links to the dedicated channel when it is available to this operator", async () => {
+    renderWithProviders(<AgentUpdateNotice agent={build()} />, {
+      withRouter: true,
+    });
+
+    const link = await screen.findByRole("link", {
+      name: "Open agent updates",
+    });
+    const href = link.getAttribute("href") ?? "";
+    expect(href).toContain("/sites");
+    // Pre-filtered to the agent-status facet, so the operator lands on the
+    // sites the channel can actually act on.
+    expect(href).toContain("Outdated");
+    expect(
+      screen.getByText(/Select this site on the Sites page/),
+    ).toBeInTheDocument();
+    // Never both: the channel is the better route, so wp-admin is not offered
+    // alongside it.
+    expect(screen.queryByText(/Plugins screen/)).not.toBeInTheDocument();
+  });
+
+  it("says what to do instead when the channel is off or the operator cannot use it", () => {
+    renderWithProviders(
+      <AgentUpdateNotice agent={build({ channelAvailable: false })} />,
+    );
+
+    expect(
+      screen.queryByRole("link", { name: "Open agent updates" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Plugins screen in WordPress admin/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the installed and available versions for an outdated agent", () => {
+    renderWithProviders(
+      <AgentUpdateNotice agent={build({ channelAvailable: false })} />,
+    );
+
+    expect(screen.getByText("0.61.100")).toBeInTheDocument();
+    expect(screen.getByText("0.61.121")).toBeInTheDocument();
+  });
+
+  it("does not claim a published release when the reference came from this fleet", () => {
+    renderWithProviders(
+      <AgentUpdateNotice
+        agent={build({ referenceSource: "fleet", channelAvailable: false })}
+      />,
+    );
+
+    expect(
+      screen.getByText(/Another site in this fleet already reports/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/newer published agent version/)).not.toBeInTheDocument();
+  });
+
+  // ── The honesty rule ─────────────────────────────────────────────────────
+
+  it("carries the shipped fleet-derived caveat verbatim for a fleet-derived 'current'", () => {
+    renderWithProviders(
+      <AgentUpdateNotice
+        agent={build({
+          status: "current",
+          version: "0.61.121",
+          referenceSource: "fleet",
+        })}
+      />,
+    );
+
+    // The exact wording already shipped on the Sites table's Agent column, so
+    // the same caveat has one phrasing across the app rather than two.
+    expect(screen.getByText(AGENT_FLEET_NOTE_BODY)).toBeInTheDocument();
+    expect(
+      screen.getByText(/This site runs the newest agent version/),
+    ).toBeInTheDocument();
+  });
+
+  it("states plainly that it cannot tell, rather than guessing, when there is no reference version", () => {
+    renderWithProviders(
+      <AgentUpdateNotice
+        agent={build({
+          status: "unknown",
+          version: "0.61.100",
+          latestVersion: "unknown",
+          referenceSource: "none",
+          channelAvailable: true,
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByText(/no reference agent version for this install/),
+    ).toBeInTheDocument();
+    // No false "behind", and no channel link for a comparison that never ran.
+    expect(
+      screen.queryByText(/newer published agent version/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Open agent updates" }),
+    ).not.toBeInTheDocument();
+    // The placeholder must never be rendered as though it were a version.
+    expect(screen.queryByText("unknown")).not.toBeInTheDocument();
+  });
+
+  it("distinguishes a site that never reported a readable version from a missing reference", () => {
+    renderWithProviders(
+      <AgentUpdateNotice
+        agent={build({
+          status: "unknown",
+          version: "",
+          referenceSource: "published",
+          channelAvailable: true,
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByText(/has not reported a readable agent version/),
+    ).toBeInTheDocument();
+  });
+
+  it("never points an ineligible build at a channel it cannot consume", () => {
+    renderWithProviders(
+      <AgentUpdateNotice
+        agent={build({
+          status: "ineligible",
+          version: "0.61.100",
+          channelAvailable: true,
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByText(/WordPress plugin directory build of the agent/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Open agent updates" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("always states that the agent is outside this tab's update runs, even when current", () => {
+    renderWithProviders(
+      <AgentUpdateNotice
+        agent={build({ status: "current", version: "0.61.121" })}
+      />,
+    );
+
+    expect(
+      screen.getByText(/never part of an update run started here/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing when the classification is unavailable (loading, 403, or no row for this site)", () => {
+    const { container } = renderWithProviders(<AgentUpdateNotice agent={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/features/updates/agent-update-notice.tsx
+++ b/apps/web/src/features/updates/agent-update-notice.tsx
@@ -1,0 +1,196 @@
+import { Bot } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+
+import { AGENT_STATUS_LABEL, AgentStatusChip } from "@/components/status";
+import { VersionArrow } from "@/components/shared/version-arrow";
+import { AGENT_FLEET_NOTE_BODY } from "@/features/sites/agent-column-header";
+
+import type { SiteAgentUpdate } from "./use-site-agent-update";
+
+// AgentUpdateNotice (GH #314) - the site Updates tab's line for the one
+// component WPMgr does NOT update for you.
+//
+// Reported against 0.61.102: the tab said "All up to date" with a green check
+// while the same site's wp-admin was offering a WPMgr agent update. Both were
+// telling the truth about different things. The agent is stripped from the
+// managed update list on purpose (shipped 0.61.97), and wp-admin offering it
+// is the agent's own self-update channel doing its job. What was missing was
+// anything on this tab admitting the agent exists.
+//
+// HARD RULE, do not weaken: this line is presentational only. It renders no
+// checkbox, is not part of any selection set, and carries no control that can
+// enqueue an update run. An agent update applied through the ordinary plugin
+// path is the plugin overwriting its own running files inside the request that
+// has to report the outcome, and the snapshot plus rollback that protects
+// every other update deliberately does not arm for the agent's own directory,
+// because whatever would perform the rollback is what is being replaced. The
+// only affordance here is a LINK to the dedicated channel (see #255), never a
+// trigger.
+//
+// HONESTY RULE: never imply the agent is current from the fact that the
+// managed components are. Every branch below states only what the control
+// plane's own classification actually established, and the fleet-derived
+// caveat is reused verbatim from the Sites page (AGENT_FLEET_NOTE_BODY)
+// rather than reworded into a second phrasing of the same warning.
+
+/**
+ * Why the agent can never join the list above. Stated on every branch,
+ * including the ones where the agent is perfectly current, because the point
+ * of this line is the boundary, not the version.
+ */
+const NOT_UPDATED_HERE =
+  "The agent is never part of an update run started here. It would be overwriting its own running files, and the snapshot and rollback that protect every other update deliberately do not cover its own directory.";
+
+/** What to do when the fleet-wide channel is not available to this operator. */
+const WP_ADMIN_FALLBACK =
+  "Update it from this site's own Plugins screen in WordPress admin, where the agent offers its own update.";
+
+/** How to reach the dedicated channel, which lives on the Sites page. */
+const CHANNEL_STEPS =
+  "Select this site on the Sites page, then use Update WPMgr agent.";
+
+export interface AgentUpdateNoticeProps {
+  /**
+   * This site's agent freshness (see useSiteAgentUpdate). `null` renders
+   * nothing at all: the rollup has not loaded, was refused, or has no row for
+   * this site, and a line asserting anything in that state would be a guess.
+   */
+  agent: SiteAgentUpdate | null;
+}
+
+export function AgentUpdateNotice({ agent }: AgentUpdateNoticeProps) {
+  if (!agent) return null;
+
+  const { status, version, latestVersion, referenceSource, channelAvailable } =
+    agent;
+  const outdated = status === "outdated";
+  // The channel is offered for exactly one case. "ineligible" is the
+  // wordpress.org build, which ships with no self-updater at all, so sending
+  // that operator to a channel their build cannot consume would be advice
+  // that silently does nothing.
+  const offerChannel = outdated && channelAvailable;
+
+  return (
+    <section
+      data-testid="agent-update-notice"
+      aria-labelledby="agent-update-notice-heading"
+      className="space-y-2 rounded-md border border-dashed border-[var(--color-border)] p-3"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <Bot
+            aria-hidden="true"
+            className="size-4 shrink-0 text-[var(--color-muted-foreground)]"
+          />
+          <h4
+            id="agent-update-notice-heading"
+            className="text-sm font-medium text-[var(--color-foreground)]"
+          >
+            WPMgr agent
+          </h4>
+          <AgentStatusChip status={status} referenceSource={referenceSource} />
+          {outdated ? (
+            <VersionArrow from={version} to={latestVersion} />
+          ) : version ? (
+            <span className="font-mono text-xs tabular-nums text-[var(--color-muted-foreground)]">
+              {version}
+            </span>
+          ) : null}
+        </div>
+        {offerChannel ? (
+          <Link
+            to="/sites"
+            search={{ agentStatus: [AGENT_STATUS_LABEL.outdated] }}
+            className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+          >
+            Open agent updates
+          </Link>
+        ) : null}
+      </div>
+
+      <div className="space-y-1 text-xs leading-relaxed text-[var(--color-muted-foreground)]">
+        <StatusLine
+          status={status}
+          latestVersion={latestVersion}
+          referenceSource={referenceSource}
+        />
+        <p>{NOT_UPDATED_HERE}</p>
+        {outdated ? (
+          <p>{channelAvailable ? CHANNEL_STEPS : WP_ADMIN_FALLBACK}</p>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * What the control plane's classification actually established, and nothing
+ * more.
+ *
+ * The two "unknown" wordings are distinguished by `referenceSource`, not by a
+ * second field: when the source is "published" or "fleet" the reference
+ * version is well-formed by construction, so the unreadable side must be this
+ * site's own reported version. When it is "none" there was no reference at
+ * all. Both say the same thing about currency, which is that WPMgr does not
+ * know, and neither one guesses at "behind": a false "behind" on a site that
+ * is fine is worse than saying nothing, and staying silent while the heading
+ * above says everything is up to date is what caused this defect in the first
+ * place.
+ */
+function StatusLine({
+  status,
+  latestVersion,
+  referenceSource,
+}: {
+  status: SiteAgentUpdate["status"];
+  latestVersion: string;
+  referenceSource: SiteAgentUpdate["referenceSource"];
+}) {
+  switch (status) {
+    case "outdated":
+      return referenceSource === "fleet" ? (
+        <p>
+          Another site in this fleet already reports agent version{" "}
+          <span className="font-mono tabular-nums">{latestVersion}</span>, so
+          this one is behind.
+        </p>
+      ) : (
+        <p>
+          A newer published agent version is available for this site.
+        </p>
+      );
+    case "current":
+      return referenceSource === "fleet" ? (
+        <>
+          <p>
+            This site runs the newest agent version this fleet has reported.
+          </p>
+          {/* Reused verbatim from the Sites table's Agent column header so
+              the caveat has one wording, not two that can drift apart. */}
+          <p>{AGENT_FLEET_NOTE_BODY}</p>
+        </>
+      ) : (
+        <p>This site runs the published agent version.</p>
+      );
+    case "ineligible":
+      return (
+        <p>
+          This site runs the WordPress plugin directory build of the agent,
+          which ships without a self-updater. It updates from the site's own
+          Plugins screen, through the plugin directory.
+        </p>
+      );
+    case "unknown":
+      return referenceSource === "none" ? (
+        <p>
+          WPMgr has no reference agent version for this install, so it cannot
+          tell whether this agent is behind.
+        </p>
+      ) : (
+        <p>
+          This site has not reported a readable agent version, so WPMgr cannot
+          tell whether it is behind.
+        </p>
+      );
+  }
+}

--- a/apps/web/src/features/updates/available-updates-card.test.tsx
+++ b/apps/web/src/features/updates/available-updates-card.test.tsx
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from "vitest";
+import { screen, within } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+import { mockMutationResult, mockQueryResult } from "@/test/query-mocks";
+
+import { AvailableUpdatesCard } from "./available-updates-card";
+import type { UpdateRun, UpdateRunCreate } from "@wpmgr/api";
+
+import type { SiteAvailableUpdates } from "./types";
+import type { RowUpdate } from "./use-row-update";
+import type { SiteAgentUpdate } from "./use-site-agent-update";
+import { useAvailableUpdates, useRefreshSiteUpdates } from "./use-available-updates";
+import { useSiteAgentUpdate } from "./use-site-agent-update";
+import { useCoreRowUpdate, useRowUpdate } from "./use-row-update";
+import { useCreateUpdateRun } from "./use-updates";
+
+// GH #314: the card used to render "All up to date" with a green check for
+// `total === 0`, but `total` only ever counted the components WPMgr manages.
+// The control plane strips the WPMgr agent from that projection on purpose
+// (0.61.97), so a site whose agent was behind read as fully current here while
+// its own wp-admin was offering the agent update.
+
+vi.mock("./use-available-updates", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./use-available-updates")>();
+  return {
+    ...actual,
+    useAvailableUpdates: vi.fn(),
+    useRefreshSiteUpdates: vi.fn(),
+  };
+});
+
+vi.mock("./use-site-agent-update", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./use-site-agent-update")>();
+  return { ...actual, useSiteAgentUpdate: vi.fn() };
+});
+
+vi.mock("./use-row-update", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./use-row-update")>();
+  return { ...actual, useRowUpdate: vi.fn(), useCoreRowUpdate: vi.fn() };
+});
+
+vi.mock("./use-updates", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./use-updates")>();
+  return { ...actual, useCreateUpdateRun: vi.fn() };
+});
+
+const mockedUseAvailableUpdates = vi.mocked(useAvailableUpdates);
+const mockedUseRefresh = vi.mocked(useRefreshSiteUpdates);
+const mockedUseSiteAgentUpdate = vi.mocked(useSiteAgentUpdate);
+const mockedUseRowUpdate = vi.mocked(useRowUpdate);
+const mockedUseCoreRowUpdate = vi.mocked(useCoreRowUpdate);
+const mockedUseCreateUpdateRun = vi.mocked(useCreateUpdateRun);
+
+const IDLE_ROW: RowUpdate = {
+  state: "idle",
+  runId: null,
+  taskId: null,
+  isStarting: false,
+  trigger: vi.fn(),
+  retry: vi.fn(),
+};
+
+const OUTDATED_AGENT: SiteAgentUpdate = {
+  status: "outdated",
+  version: "0.61.100",
+  latestVersion: "0.61.121",
+  referenceSource: "published",
+  channelAvailable: false,
+};
+
+function setup(
+  data: SiteAvailableUpdates,
+  agent: SiteAgentUpdate | null,
+): void {
+  mockedUseAvailableUpdates.mockReturnValue(
+    mockQueryResult<SiteAvailableUpdates>({ data }),
+  );
+  mockedUseRefresh.mockReturnValue(
+    mockMutationResult<void, void>({}),
+  );
+  mockedUseSiteAgentUpdate.mockReturnValue(agent);
+  mockedUseRowUpdate.mockReturnValue(IDLE_ROW);
+  mockedUseCoreRowUpdate.mockReturnValue(IDLE_ROW);
+  mockedUseCreateUpdateRun.mockReturnValue(
+    mockMutationResult<UpdateRun, UpdateRunCreate>({}),
+  );
+}
+
+function payload(
+  overrides: Partial<SiteAvailableUpdates> = {},
+): SiteAvailableUpdates {
+  return {
+    site_id: "site-1",
+    core_update: null,
+    items: [],
+    as_of: "2026-08-04T10:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("AvailableUpdatesCard agent honesty (GH #314)", () => {
+  it("never claims everything is up to date when it only knows the managed components are", () => {
+    setup(payload(), OUTDATED_AGENT);
+    renderWithProviders(<AvailableUpdatesCard siteId="site-1" />);
+
+    // The exact reported string must not come back.
+    expect(screen.queryByText("All up to date")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("All managed components are up to date"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("agent-update-notice")).toBeInTheDocument();
+  });
+
+  it("scopes the header badge to the managed set too", () => {
+    setup(payload(), OUTDATED_AGENT);
+    renderWithProviders(<AvailableUpdatesCard siteId="site-1" />);
+
+    expect(screen.getByText("No managed updates")).toBeInTheDocument();
+    expect(screen.queryByText("Up to date")).not.toBeInTheDocument();
+  });
+
+  it("keeps the qualified wording when the agent is current, so the claim never depends on a second query", () => {
+    setup(payload(), { ...OUTDATED_AGENT, status: "current", version: "0.61.121" });
+    renderWithProviders(<AvailableUpdatesCard siteId="site-1" />);
+
+    expect(screen.queryByText("All up to date")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("All managed components are up to date"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows no agent line at all when the classification is unavailable", () => {
+    setup(payload(), null);
+    renderWithProviders(<AvailableUpdatesCard siteId="site-1" />);
+
+    expect(screen.queryByTestId("agent-update-notice")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("All managed components are up to date"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the agent line alongside the managed list when there are updates too", () => {
+    setup(
+      payload({
+        items: [
+          {
+            type: "plugin",
+            slug: "akismet/akismet.php",
+            name: "Akismet",
+            version: "5.0",
+            new_version: "5.1",
+            active: true,
+          },
+        ],
+      }),
+      OUTDATED_AGENT,
+    );
+    renderWithProviders(<AvailableUpdatesCard siteId="site-1" />);
+
+    expect(screen.getByText("Akismet")).toBeInTheDocument();
+    expect(screen.getByTestId("agent-update-notice")).toBeInTheDocument();
+  });
+
+  // ── The safety property (GH #314 requirement 1, see #255) ────────────────
+
+  it("never lets the agent enter a bulk selection or an update run", () => {
+    setup(
+      payload({
+        core_update: { current_version: "6.7", new_version: "6.8" },
+        items: [
+          {
+            type: "plugin",
+            slug: "akismet/akismet.php",
+            name: "Akismet",
+            version: "5.0",
+            new_version: "5.1",
+            active: true,
+          },
+        ],
+      }),
+      OUTDATED_AGENT,
+    );
+    renderWithProviders(<AvailableUpdatesCard siteId="site-1" />);
+
+    // The agent line carries no selection control of its own.
+    const notice = screen.getByTestId("agent-update-notice");
+    expect(within(notice).queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(within(notice).queryByRole("button")).not.toBeInTheDocument();
+
+    // And it is not counted as a target: core + one plugin is 2, not 3.
+    expect(
+      screen.getByRole("button", { name: "Update all (2)" }),
+    ).toBeInTheDocument();
+
+    // It is also outside the list the bulk footer acts on.
+    const list = screen.getByRole("list", { name: "Updates available" });
+    expect(within(list).queryByTestId("agent-update-notice")).not.toBeInTheDocument();
+    expect(within(list).queryByText("WPMgr agent")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/updates/available-updates-card.tsx
+++ b/apps/web/src/features/updates/available-updates-card.tsx
@@ -38,6 +38,11 @@ import {
   type CoreUpdate,
   type SiteAvailableUpdates,
 } from "@/features/updates/types";
+import { AgentUpdateNotice } from "@/features/updates/agent-update-notice";
+import {
+  useSiteAgentUpdate,
+  type SiteAgentUpdate,
+} from "@/features/updates/use-site-agent-update";
 import {
   isSiteDownRecovery,
   SITE_DOWN_RECOVERY_FALLBACK_DETAIL,
@@ -53,9 +58,20 @@ import { wpOrgSlug } from "@/features/updates/wp-org-slug";
 //   - SSE-driven live state per row (idle | starting | pending | running |
 //     succeeded | failed | rolled_back | skipped)
 //   - Refresh button (POST /updates/refresh) + relative "as of" timestamp
+//   - A separate, non-selectable WPMgr agent line (GH #314, AgentUpdateNotice)
 //
 // Wire-level behavior all lives in `useAvailableUpdates`, `useRefreshSiteUpdates`,
 // and `useRowUpdate` — this file is pure presentation + selection state.
+//
+// SCOPE OF EVERY "up to date" CLAIM IN THIS FILE (GH #314). `data.items` and
+// `data.core_update` are the components WPMgr MANAGES. The WPMgr agent is
+// stripped from that projection on the control plane on purpose (shipped
+// 0.61.97), so `total === 0` means "nothing WPMgr manages needs updating", and
+// it has never meant "this site has no updates waiting". The card said "All up
+// to date" for that state, which an operator reasonably read as including the
+// agent, while the same site's wp-admin was offering an agent update. Every
+// claim here is now scoped to the managed set in words, and the agent is
+// stated separately by AgentUpdateNotice.
 
 const WP_RELEASES = "https://wordpress.org/news/category/releases/";
 const CORE_SELECTION_KEY = "core:core";
@@ -74,6 +90,11 @@ export function AvailableUpdatesCard({ siteId }: { siteId: string }) {
   const { data, isPending, isError, error, refetch, isFetching } =
     useAvailableUpdates(siteId);
   const refresh = useRefreshSiteUpdates(siteId);
+  // GH #314. Resolved once here and passed down, so the header badge and the
+  // body cannot disagree about what this tab knows. `null` while the fleet
+  // rollup is loading, refused (a site-scoped collaborator's 403) or missing
+  // this site, in which case no agent line renders at all.
+  const agent = useSiteAgentUpdate(siteId);
 
   // Multi-selection state. Keys: "core:core", "plugin:<slug>", "theme:<slug>".
   const [selected, setSelected] = useState<Set<string>>(() => new Set());
@@ -137,8 +158,16 @@ export function AvailableUpdatesCard({ siteId }: { siteId: string }) {
                 }
               />
             ) : data && total === 0 ? (
+              // GH #314: "Up to date" here carried the same half truth as the
+              // body's "All up to date" did, so it is scoped in words too.
+              // Unconditional rather than conditional on the agent's state:
+              // the agent classification arrives from a second, independently
+              // loading query that a site-scoped collaborator never gets at
+              // all, and a badge whose claim flips once that lands would be
+              // both jumpy and, for the moment before it lands, the same half
+              // truth again.
               <span className="inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium text-[var(--color-muted-foreground)] bg-[var(--color-muted)]">
-                Up to date
+                No managed updates
               </span>
             ) : null}
           </div>
@@ -175,6 +204,7 @@ export function AvailableUpdatesCard({ siteId }: { siteId: string }) {
           <UpdatesBody
             siteId={siteId}
             data={data}
+            agent={agent}
             selected={selected}
             onToggle={toggle}
             onClearSelection={clearSelection}
@@ -201,67 +231,89 @@ function SkeletonRows() {
 function UpdatesBody({
   siteId,
   data,
+  agent,
   selected,
   onToggle,
   onClearSelection,
 }: {
   siteId: string;
   data: SiteAvailableUpdates;
+  agent: SiteAgentUpdate | null;
   selected: Set<string>;
   onToggle: (key: string) => void;
   onClearSelection: () => void;
 }) {
   const total = (data.core_update ? 1 : 0) + data.items.length;
 
-  if (total === 0) {
-    return (
-      <div
-        role="status"
-        className="flex flex-col items-center gap-2 py-6 text-center"
-      >
-        <CheckCircle2
-          aria-hidden="true"
-          className="size-8 text-[var(--color-success)]"
-        />
-        <p className="text-sm font-medium text-[var(--color-foreground)]">
-          All up to date
-        </p>
-        <FreshnessBadge collectedAt={data.as_of ?? null} />
-      </div>
-    );
-  }
-
   return (
-    <div className="space-y-3">
-      <ul
-        aria-label="Updates available"
-        className="divide-y divide-[var(--color-border)] rounded-md border border-[var(--color-border)]"
-      >
-        {data.core_update ? (
-          <CoreRow
-            siteId={siteId}
-            coreUpdate={data.core_update}
-            checked={selected.has(CORE_SELECTION_KEY)}
-            onToggle={() => onToggle(CORE_SELECTION_KEY)}
+    <div className="space-y-4">
+      {total === 0 ? (
+        <div
+          role="status"
+          className="flex flex-col items-center gap-2 py-6 text-center"
+        >
+          <CheckCircle2
+            aria-hidden="true"
+            className="size-8 text-[var(--color-success)]"
           />
-        ) : null}
-        {data.items.map((item) => (
-          <ComponentRow
-            key={itemKey(item)}
-            siteId={siteId}
-            item={item}
-            checked={selected.has(itemKey(item))}
-            onToggle={() => onToggle(itemKey(item))}
-          />
-        ))}
-      </ul>
+          {/* GH #314. QUALIFIED rather than suppressed, and qualified
+              unconditionally.
+              Suppressing the up-to-date state whenever the agent is behind
+              would have made the most common, entirely healthy case (nothing
+              to update, agent current) render as an absence, and it would
+              have made the sentence depend on a second query that a
+              site-scoped collaborator is refused outright, so the same site
+              would say different things to two operators.
+              "Managed components" is the honest scope and it is the only
+              scope this data has ever described: the control plane strips the
+              agent from this projection before it is sent. The agent is then
+              stated separately, below, in exactly the terms the
+              classification supports. */}
+          <p className="text-sm font-medium text-[var(--color-foreground)]">
+            All managed components are up to date
+          </p>
+          <FreshnessBadge collectedAt={data.as_of ?? null} />
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <ul
+            aria-label="Updates available"
+            className="divide-y divide-[var(--color-border)] rounded-md border border-[var(--color-border)]"
+          >
+            {data.core_update ? (
+              <CoreRow
+                siteId={siteId}
+                coreUpdate={data.core_update}
+                checked={selected.has(CORE_SELECTION_KEY)}
+                onToggle={() => onToggle(CORE_SELECTION_KEY)}
+              />
+            ) : null}
+            {data.items.map((item) => (
+              <ComponentRow
+                key={itemKey(item)}
+                siteId={siteId}
+                item={item}
+                checked={selected.has(itemKey(item))}
+                onToggle={() => onToggle(itemKey(item))}
+              />
+            ))}
+          </ul>
 
-      <BulkFooter
-        siteId={siteId}
-        data={data}
-        selected={selected}
-        onCleared={onClearSelection}
-      />
+          <BulkFooter
+            siteId={siteId}
+            data={data}
+            selected={selected}
+            onCleared={onClearSelection}
+          />
+        </div>
+      )}
+
+      {/* Rendered in BOTH states, and always AFTER the selectable list and
+          its bulk footer. The agent is a fact about this site whether or not
+          anything else needs updating, and its position outside the <ul> the
+          footer acts on is the structural half of "not selectable": there is
+          no row for it to be a row of. */}
+      <AgentUpdateNotice agent={agent} />
     </div>
   );
 }

--- a/apps/web/src/features/updates/use-site-agent-update.ts
+++ b/apps/web/src/features/updates/use-site-agent-update.ts
@@ -1,0 +1,87 @@
+// GH #314: resolves ONE site's WPMgr agent freshness for the site Updates
+// tab, plus whether the fleet-wide agent update channel is actually reachable
+// by the operator looking at it.
+//
+// WHERE THE "IS THIS SITE'S AGENT BEHIND" DECISION IS MADE: on the control
+// plane, not here. GET /api/v1/fleet/agents already classifies every site as
+// current | outdated | unknown | ineligible (internal/agentrelease/classify.go),
+// against a reference whose provenance it also reports (reference_source), and
+// it is the same classification the Sites table's Agent column and the fleet
+// summary card on /updates render. This hook only picks this site's row out of
+// that rollup. There is deliberately NO client-side version comparison: a
+// second implementation of "is 0.61.100 older than 0.61.121" would be a second
+// answer that can disagree with the first, and the control plane's version has
+// rules this file has no business restating (a malformed version on either
+// side is never reported as behind, and the plugin-directory build is settled
+// as ineligible before any comparison happens at all).
+
+import { useMemo } from "react";
+import type { FleetAgentVersions } from "@wpmgr/api";
+
+import type { AgentStatus } from "@/components/status";
+import { canManage, useMe } from "@/features/auth/use-auth";
+import { useFleetAgentVersions } from "@/features/fleet/use-fleet-agents";
+
+export interface SiteAgentUpdate {
+  /** Control-plane classification for this site (FleetAgentSite.status). */
+  status: AgentStatus;
+  /**
+   * This site's last-reported agent version, verbatim. Empty string when the
+   * agent has never reported one, which is distinct from status "unknown"
+   * (that also covers a version string too malformed to order).
+   */
+  version: string;
+  /**
+   * The single version this site was classified against. Read it together
+   * with `referenceSource`: under "fleet" it is the newest agent version this
+   * tenant's own fleet has reported, NOT the newest agent that exists, and
+   * under "none" it is a placeholder ("unknown") that must never be rendered
+   * as though it were a real version.
+   */
+  latestVersion: string;
+  /** Where `latestVersion` came from (FleetAgentVersions.reference_source). */
+  referenceSource: FleetAgentVersions["reference_source"];
+  /**
+   * Whether the fleet-wide agent update channel is available TO THIS
+   * OPERATOR right now. Both halves are required, and both are the same
+   * conditions that decide whether the "Update WPMgr agent" bulk action is
+   * rendered at all on the Sites page (routes/_authed/sites/index.tsx):
+   *
+   *   1. `self_update_enabled` on the rollup, which is the control plane's
+   *      own WPMGR_UPDATE_AGENT_SELF_UPDATE_ENABLED kill switch. Absent
+   *      reads as off, matching the channel's ships-dark-by-default contract.
+   *   2. canManage(me), owner or admin. The channel is infrastructure, and an
+   *      operator without that role cannot see the action even when the
+   *      switch is on.
+   *
+   * Pointing anyone else at that page would be pointing them at an action
+   * they cannot see, so the notice tells them what to do instead.
+   */
+  channelAvailable: boolean;
+}
+
+/**
+ * This site's agent freshness, or `null` when there is nothing honest to say:
+ * the rollup has not loaded, it failed (a site-scoped collaborator gets a 403
+ * from GET /api/v1/fleet/agents, exactly as the fleet summary card already
+ * handles), or it carries no row for this site. `null` renders no agent line
+ * at all, which is the right answer: a guessed line is worse than none.
+ */
+export function useSiteAgentUpdate(siteId: string): SiteAgentUpdate | null {
+  const { data: fleet } = useFleetAgentVersions();
+  const { data: me } = useMe();
+  const manageAgents = canManage(me);
+
+  return useMemo(() => {
+    if (!fleet) return null;
+    const entry = fleet.sites.find((s) => s.site_id === siteId);
+    if (!entry) return null;
+    return {
+      status: entry.status,
+      version: entry.agent_version,
+      latestVersion: fleet.latest_version,
+      referenceSource: fleet.reference_source,
+      channelAvailable: fleet.self_update_enabled === true && manageAgents,
+    };
+  }, [fleet, siteId, manageAgents]);
+}

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.120
+  version: 0.61.121
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Closes #314.

A site's Updates tab showed **"All up to date"** with a green check while that same site's wp-admin was offering a WPMgr agent update.

## Both halves were already correct

The agent is deliberately stripped from managed updates in three places since 0.61.97, and that exclusion is a **safety property**: updating the agent through the ordinary plugin path means the plugin overwrites its own running files inside the request that has to report the outcome, and the snapshot and rollback that protect every other update deliberately do not arm for the agent's own directory, because whatever performs the rollback is what is being replaced.

wp-admin offering it is the agent's own self-update channel. Different path, and a safe one.

**The wording was the defect.** "All up to date" means "every component WPMgr manages", and nobody reads it that way.

## What ships

A separate, **non-selectable** agent line, rendered for every classification and whether or not anything else needs updating. The boundary it teaches, *this exists and WPMgr does not update it*, is only learned if the line is always there.

`All up to date` -> `All managed components are up to date`, and the header badge `Up to date` -> `No managed updates`. **Unconditionally**, not only when the agent is behind: the classification arrives from a second query that a site-scoped collaborator is refused outright (403), so a claim that flipped once it landed would tell two operators different things about the same site.

## Never selectable

The exclusion is a safety property, so the fix must not quietly weaken it. The notice sits **outside** the `<ul>` the bulk footer acts on, and has no `Checkbox`, no `button`, no `<input>` and no mutation. Its only affordance is a `<Link>`.

Four assertions pin it, including that `Update all (2)` stays **2** for core plus one plugin with an outdated agent present.

## No second version comparison

The classification comes from the existing fleet rollup, which already answers `current | outdated | unknown | ineligible` from `agentrelease/classify.go`. There is **zero** client-side version comparison.

A fresh one would be a second answer that can disagree with the Sites list and the `/updates` fleet card, and it would lose rules the server has: a malformed version on either side is never reported as behind, and a plugin-directory build is settled as `ineligible` before any comparison runs.

## Honest about what it does not know

| state | what the line says |
|---|---|
| no published manifest | the existing shipped caveat, **imported verbatim** so the two surfaces cannot drift |
| comparison could not run | says so, and offers **no** channel link, because nothing was compared |
| `ineligible` | never pointed at a channel that build does not have |

The channel link appears only when the fleet self-update switch is on **and** the viewer can act on it, which is the same pair that decides whether the bulk action renders at all. Otherwise the line says to update from that site's own Plugins screen.

## Gates

```
web    118 files, 1458 tests pass   (1440 baseline + 18 new)
eslint 0 errors (3 pre-existing warnings, untouched)
tsc    0 errors
marketing check-copy clean
lockstep 0.61.121   dashes 0
```

## Not in scope

The exclusion itself, and offering the agent inside the normal update flow. See #255.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Updates tab now displays WPMgr agent status separately from managed component updates.
  - Shows current, outdated, unavailable, or indeterminate agent states with version and source details.
  - Eligible agents link to fleet updates, while others are directed to WordPress admin.
  - WordPress.org builds are excluded from fleet updates.
  - Agent updates cannot be selected or included in bulk updates.

- **Bug Fixes**
  - Improved messaging when release or comparison data is unavailable.
  - Clarified update status and fleet fallback information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->