### PR TITLE
fix(sites): unreadable dark-mode warning heading, and add the agent rollout to the palette (GH #322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.122] - 2026-08-05
+
+### Fixed
+
+- The warning heading inside the Agent column's information popover was almost unreadable in dark mode, rendering near black on the dark panel while the explanatory text below it was fine. It was using the text colour meant for content sitting on an amber background, which is deliberately near black in both themes, rather than the one for amber-tinted text on an ordinary surface. Reported with a screenshot.
+
+### Added
+
+- "Update agent on all sites" is now in the command palette, alongside "Run backup on all sites" and "Sync metadata on all sites". The fleet agent rollout had the same shape and the same audience as those two but was the only one that still needed selecting sites and opening a menu to reach. It opens the Sites page filtered to outdated agents rather than starting the rollout outright, because a wave-gated update that touches every agent in a fleet should not begin from a single keystroke, and it appears only for an owner or admin on an install where the rollout is actually enabled.
+
 ## [0.61.121] - 2026-08-04
 
 ### Fixed

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,22 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.122",
+    date: "2026-08-05",
+    summary:
+      "A warning heading in the Agent column popover was unreadable in dark mode, and the fleet agent rollout is now reachable from the command palette.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "The warning heading inside the Agent column's information popover was almost unreadable in dark mode, rendering near black on the dark panel while the explanatory text below it was fine. It was using the text colour meant for content sitting on an amber background, which is deliberately near black in both themes, rather than the one for amber-tinted text on an ordinary surface.",
+      },
+      {
+        tag: "Added",
+        text: "\"Update agent on all sites\" is now in the command palette, alongside \"Run backup on all sites\" and \"Sync metadata on all sites\". The fleet agent rollout had the same shape and audience as those two but was the only one that still needed selecting sites and opening a menu to reach. It opens the Sites page filtered to outdated agents rather than starting the rollout outright, because a wave-gated update touching every agent in a fleet should not begin from a single keystroke, and it appears only for an owner or admin on an install where the rollout is enabled.",
+      },
+    ],
+  },
+  {
     version: "0.61.121",
     date: "2026-08-04",
     summary:

--- a/apps/web/src/features/command/command-palette.test.tsx
+++ b/apps/web/src/features/command/command-palette.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+
+import { CommandPalette } from "./command-palette";
+
+// GH #322: "Update agent on all sites" in the palette's "Run on all" group.
+//
+// The group already held two fleet-wide actions available to a regular owner,
+// and the agent rollout was the only one of the three that still required
+// selecting sites and opening a dropdown to reach.
+//
+// The whole risk of a palette entry is offering something the viewer cannot
+// actually do: a fuzzy match puts it one keystroke away, and arriving at a
+// page with no such action is worse than never seeing it. So the gate is the
+// thing under test, both halves of it.
+
+// cmdk renders inside a Radix Dialog, which observes its content box. jsdom
+// has no ResizeObserver, and src/test/setup.ts deliberately holds no global
+// stubs ("mock each feature's data hook at the point of use"), so it is
+// stubbed here rather than repo-wide.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+
+// cmdk scrolls its selected item into view on every list change. jsdom has no
+// layout, so the method does not exist.
+Element.prototype.scrollIntoView = function scrollIntoView() {};
+
+// Typed so the mocked hooks do not return `any` into the component tree.
+const useMeMock = vi.fn<() => { data: unknown }>();
+const useFleetAgentVersionsMock = vi.fn<() => { data: unknown }>();
+
+vi.mock("@/features/auth/use-auth", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/features/auth/use-auth")>(
+      "@/features/auth/use-auth",
+    );
+  return {
+    ...actual,
+    useMe: () => useMeMock(),
+    useLogout: () => ({ mutate: vi.fn() }),
+  };
+});
+
+vi.mock("@/features/fleet/use-fleet-agents", () => ({
+  useFleetAgentVersions: () => useFleetAgentVersionsMock(),
+}));
+
+vi.mock("@/features/sites/use-sites", () => ({
+  useSites: () => ({ data: [] }),
+}));
+
+vi.mock("@/features/backups/use-bulk-backup", () => ({
+  useBulkBackup: () => vi.fn(),
+}));
+
+const AGENT_ITEM = "Update agent on all sites";
+const TENANT_ID = "22222222-2222-2222-2222-222222222222";
+
+function setup({
+  role,
+  selfUpdateEnabled,
+}: {
+  role: string;
+  selfUpdateEnabled: boolean | undefined;
+}) {
+  // The role is resolved from the membership matching active_tenant_id
+  // (use-auth.ts:445-453), and a site-scoped collaborator with no matching
+  // membership is never org-scoped, so a bare { role } would not exercise
+  // canManage at all.
+  useMeMock.mockReturnValue({
+    data: {
+      id: "u1",
+      active_tenant_id: TENANT_ID,
+      memberships: [{ tenant_id: TENANT_ID, role }],
+    },
+  });
+  useFleetAgentVersionsMock.mockReturnValue({
+    data: { self_update_enabled: selfUpdateEnabled },
+  });
+  renderWithProviders(<CommandPalette open onClose={vi.fn()} />);
+}
+
+describe("CommandPalette - the fleet agent rollout entry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("offers it to an owner when the control plane's self-update switch is on", () => {
+    setup({ role: "owner", selfUpdateEnabled: true });
+    expect(screen.getByText(AGENT_ITEM)).toBeInTheDocument();
+  });
+
+  it("hides it when the control plane's self-update switch is off", () => {
+    setup({ role: "owner", selfUpdateEnabled: false });
+    expect(screen.queryByText(AGENT_ITEM)).not.toBeInTheDocument();
+  });
+
+  it("hides it when the switch is absent, rather than assuming it is on", () => {
+    // An absent value means the rollup did not say. Reading that as enabled
+    // would offer the action on every install that has not answered yet.
+    setup({ role: "owner", selfUpdateEnabled: undefined });
+    expect(screen.queryByText(AGENT_ITEM)).not.toBeInTheDocument();
+  });
+
+  it("hides it from a viewer who cannot run it, even with the switch on", () => {
+    // The channel is infrastructure. Pointing a non-owner at the Sites page
+    // would land them somewhere the action is not rendered at all.
+    setup({ role: "viewer", selfUpdateEnabled: true });
+    expect(screen.queryByText(AGENT_ITEM)).not.toBeInTheDocument();
+  });
+
+  it("keeps the other two fleet-wide actions regardless of the agent gate", () => {
+    // The gate is specific to the agent entry and must not suppress the group.
+    setup({ role: "viewer", selfUpdateEnabled: false });
+    expect(screen.getByText("Run backup on all sites")).toBeInTheDocument();
+    expect(screen.getByText("Sync metadata on all sites")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/command/command-palette.tsx
+++ b/apps/web/src/features/command/command-palette.tsx
@@ -9,6 +9,7 @@ import {
   Globe,
   Key,
   LogOut,
+  PackageCheck,
   RefreshCw,
   Search,
   Settings as SettingsIcon,
@@ -17,7 +18,8 @@ import { type ReactNode, useCallback, useMemo } from "react";
 
 import { useCommandPalette } from "@/features/command/use-command-palette";
 import { useRecentSites } from "@/features/command/use-recent-sites";
-import { useLogout } from "@/features/auth/use-auth";
+import { canManage, useLogout, useMe } from "@/features/auth/use-auth";
+import { useFleetAgentVersions } from "@/features/fleet/use-fleet-agents";
 import { useSitesSelection } from "@/features/sites/use-sites-selection";
 import { useSites } from "@/features/sites/use-sites";
 import { useBulkBackup } from "@/features/backups/use-bulk-backup";
@@ -70,6 +72,18 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
   // Query cache (no extra network call) and gives us the enrolled site IDs for
   // "Run backup on all sites".
   const { data: allSites } = useSites();
+
+  // GH #322: is the fleet agent rollout actually usable by THIS viewer?
+  //
+  // Both halves, matching the gate on the bulk action itself
+  // (routes/_authed/sites/index.tsx:907). self_update_enabled is the control
+  // plane's kill switch, and an absent value reads as off rather than on.
+  // canManage is owner or admin: the channel is infrastructure, so a viewer
+  // who cannot run it must not be offered a shortcut to it.
+  const { data: me } = useMe();
+  const { data: fleetAgents } = useFleetAgentVersions();
+  const agentRolloutAvailable =
+    fleetAgents?.self_update_enabled === true && canManage(me);
 
   // Wrap navigate-and-close in one callback per command so onSelect stays
   // declarative below.
@@ -285,6 +299,32 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
             >
               Sync metadata on all sites
             </PaletteItem>
+            {/*
+              GH #322. The fleet agent rollout is the third action with this
+              exact shape and audience, and it was the only one that still
+              needed selecting sites plus opening a dropdown to reach.
+
+              It NAVIGATES rather than firing, unlike "Run backup on all
+              sites". A wave-gated rollout that touches every agent in the
+              fleet is not something to start from a fuzzy match on a
+              keystroke, and the Sites page is where the canary and wave
+              structure are explained before it runs. That is the same choice
+              "Sync metadata on all sites" already makes.
+
+              Rendered only when the channel is actually usable, on the same
+              pair the bulk action itself is gated on
+              (routes/_authed/sites/index.tsx:907): the control plane's
+              self-update switch AND owner or admin. Offering it otherwise
+              would point at an action that is not there when you arrive.
+            */}
+            {agentRolloutAvailable ? (
+              <PaletteItem
+                onSelect={go("/sites?agentStatus=Outdated")}
+                icon={<PackageCheck className="size-4" aria-hidden="true" />}
+              >
+                Update agent on all sites
+              </PaletteItem>
+            ) : null}
           </PaletteGroup>
 
           {/* ── Settings ───────────────────────────────────────────────── */}

--- a/apps/web/src/features/sites/agent-column-header.test.tsx
+++ b/apps/web/src/features/sites/agent-column-header.test.tsx
@@ -180,3 +180,45 @@ describe("AgentColumnFleetNote", () => {
     ).not.toBeInTheDocument();
   });
 });
+
+describe("AgentColumnFleetNote - the warn heading is legible in dark mode", () => {
+  // GH #322, reported with a screenshot: the popover heading rendered
+  // near-black on the dark popover surface while the body text below it was
+  // fine.
+  //
+  // It was not a missing dark override. The heading used
+  // --warning-foreground, which is the text colour for content sitting ON a
+  // --warning background, so it is near-black in BOTH themes and its dark
+  // value is darker still (L 20% light, L 15% dark). The right token for
+  // warning-tinted text on an ordinary surface is --warning-subtle-fg, which
+  // inverts properly (L 38% light, L 86% dark).
+  //
+  // Asserting the token rather than a rendered colour is deliberate: jsdom
+  // does not resolve CSS custom properties, so a computed-style assertion
+  // here would pass against either token and prove nothing.
+  it("uses the surface-text warning token, not the on-warning-background one", () => {
+    renderWithProviders(
+      <AgentColumnFleetNote
+        referenceSource="published"
+        referenceCheck={mirror({
+          status: "never_succeeded",
+          last_success_at: null,
+          last_success_outcome: null,
+          last_success_version: null,
+        })}
+      />,
+    );
+    // In the warn state the trigger's accessible name appends the title
+    // (agent-column-header.tsx:95-96), so match the prefix.
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: new RegExp(`^${AGENT_FLEET_NOTE_LABEL}`),
+      }),
+    );
+
+    const heading = screen.getByText("No check has ever succeeded");
+    expect(heading.className).toContain("--color-warning-subtle-fg");
+    // The token that made it invisible must not come back.
+    expect(heading.className).not.toContain("--color-warning-foreground");
+  });
+});

--- a/apps/web/src/features/sites/agent-column-header.tsx
+++ b/apps/web/src/features/sites/agent-column-header.tsx
@@ -142,11 +142,26 @@ export function AgentColumnFleetNote({
                 {checkMessage.lead}
               </p>
             ) : null}
+            {/*
+              warning-SUBTLE-FG, not warning-foreground (GH #322).
+
+              --warning-foreground is the text colour for content sitting ON a
+              --warning background, so it is near-black in BOTH themes and its
+              dark override is darker still (L 20% light, L 15% dark). Used
+              here, on the popover's own surface, it rendered this heading
+              almost invisible in dark mode while the body text below it was
+              fine.
+
+              --warning-subtle-fg is the token for warning-tinted text on an
+              ordinary surface, and it inverts properly (L 38% light, L 86%
+              dark). It is what the Core Web Vitals threshold labels already
+              use for the same job.
+            */}
             <p
               className={cn(
                 "font-medium",
                 warn
-                  ? "text-[var(--color-warning-foreground)]"
+                  ? "text-[var(--color-warning-subtle-fg)]"
                   : "text-[var(--color-foreground)]",
               )}
             >

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.121
+  version: 0.61.122
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Two follow-ups from the #322 reporter. Unrelated beyond the issue they came from, shipped together because both are small.

## 1. The dark-mode heading, reported with a screenshot

The warning heading in the Agent column's popover rendered near black on the dark panel, while the explanatory text below it was fine.

**Not a missing dark override.** It used `--warning-foreground`:

```
--warning-foreground    light  oklch(20% 0.06  75)     dark  oklch(15% 0.012 75)
```

That token is the text colour for content sitting **on** a `--warning` background, so it is near black in both themes and its dark value is darker still, correctly. The token for warning-tinted text on an ordinary surface is `--warning-subtle-fg`, which inverts properly:

```
--warning-subtle-fg     light  oklch(38% 0.10  75)     dark  oklch(86% 0.12  75)
```

It is already what the Core Web Vitals threshold labels use for exactly this job.

**Swept for the same misuse.** The only other `--*-foreground` uses are in `RumDistributionBar`, where `textClass` is paired with a `bgClass` so the text genuinely sits on a coloured background. Correct there, left alone.

The test asserts the **token**, not a computed colour: jsdom does not resolve CSS custom properties, so a computed-style assertion would pass against either token and prove nothing. Verified to fail against the old one:

```
→ expected 'font-medium text-[var(--color-warning…' to contain '--color-warning-subtle-fg'
```

## 2. The command palette entry

"Run on all" already held two fleet-wide actions available to a regular owner. The agent rollout has the same shape and the same audience, and was the only one of the three still requiring site selection plus a dropdown.

**It navigates rather than fires**, matching `Sync metadata on all sites` rather than `Run backup on all sites`. A wave-gated rollout that touches every agent in a fleet should not begin from a fuzzy match on a keystroke, and the Sites page is where the canary and wave structure are explained before it runs.

**Rendered only when the channel is usable**, on the same pair the bulk action itself is gated on (`routes/_authed/sites/index.tsx:907`): the control plane's self-update switch **and** owner or admin. An absent switch reads as off, not on. Offering it otherwise puts an action one keystroke away that is not there when you arrive, which is worse than never showing it.

Five tests cover the gate, including the absent-switch case and that it does not suppress the other two actions.

Worth noting: building them found that a naive `{ role }` fixture never exercises `canManage` at all, because the role is resolved from the membership matching `active_tenant_id` (`use-auth.ts:445-453`). The first version of the test passed the negative cases for the wrong reason.

## Gates

```
web    119 files, 1464 tests pass
eslint 0 errors (3 pre-existing warnings, untouched)
tsc    0 errors
marketing check-copy + typecheck clean
lockstep 0.61.122   dashes 0
```

## Still open from #322

The single-tenant "Check now" permission path, and the popover placement that depends on it. Both need a decision on who may spend the install's shared GitHub rate-limit budget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an “Update agent on all sites” command-palette action for authorized users when fleet rollout is enabled.
  - The action opens Sites filtered to locations with outdated agents without starting the rollout.

- **Bug Fixes**
  - Improved warning-heading visibility in the Agent column popover when dark mode is enabled.

- **Documentation**
  - Added release notes for version 0.61.122.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->