### PR TITLE
feat(admin): let the owner of a single-tenant install run the mirror check (GH #322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.123] - 2026-08-05
+
+### Changed
+
+- On an install with exactly one organisation, the owner of that organisation can now use "Check now" for the agent release reference (Admin > Agent mirror) without being made a superadmin first. Reported by a self-hoster who had to set `WPMGR_SUPERADMIN_EMAILS` and restart the control plane to click what is, for them, a monthly refresh of their own fleet's data, and then found that the seeding only ever adds the flag and never removes it, so getting back out again meant an `UPDATE` against the users table and a second restart. The permission on this action exists so that one organisation cannot spend another organisation's share of the install's shared, unauthenticated GitHub request budget. On an install with exactly one organisation there is no other organisation for that to protect, so what was left was the ceremony without the reason.
+- The owner does not become a superadmin as a result. No environment variable, no restart, no flag written anywhere, and none of the side effects: every other admin action still refuses them, including the vulnerability feed sync, which stays superadmin only, and they are not redirected away from the Sites page the way a real superadmin is. This grants one action and nothing else.
+- Nothing changes on an install with more than one organisation, which is every hosted account: the action stays superadmin only there, for exactly the reason it always has. The organisation count is read fresh on every request and is never cached, so creating a second organisation closes this path again on the very next call, with no migration to run and nothing to clean up.
+- An organisation that has been deleted but is still inside its restore window does not count towards the total. Nobody can act as one: it is hidden from the organisation switcher, its API keys stop working, and its members cannot switch into it, so it has no share of the budget to protect. Restoring it makes the install a two-organisation install again and closes the path immediately.
+- Only the owner role passes. An admin, operator or viewer in that single organisation is refused, as is an API key, including one belonging to the owner, because this is an install-level action and the audit record should name a person. A refusal reads identically whichever way it was reached, so it cannot be used to work out how many organisations an install has.
+
 ## [0.61.122] - 2026-08-05
 
 ### Fixed

--- a/apps/api/internal/admin/gate.go
+++ b/apps/api/internal/admin/gate.go
@@ -1,0 +1,209 @@
+package admin
+
+// gate.go: the authorisation gates for the /api/v1/admin route group.
+//
+// Two gates live here and they are deliberately kept apart:
+//
+//	requireSuperadmin
+//	    The gate on the /admin group as a whole. Behaviour unchanged: the
+//	    principal must be a logged-in user whose users.is_superadmin is true.
+//
+//	requireSuperadminOrSoleTenantOwner
+//	    GH #322. Mounted on exactly ONE route, POST /admin/agent-mirror/check,
+//	    and on nothing else. See its doc comment for what it admits, why, and
+//	    for the property that must not be lost.
+//
+// Both read through adminGateStore rather than reaching for *db.Pool directly,
+// so both are drivable from a unit test without a database. That indirection
+// is the ONLY change to requireSuperadmin: the SQL it runs, the connection it
+// runs it on, and its fail-closed condition are identical to what they were
+// when it read the pool inline.
+
+import (
+	"context"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/server/httpx"
+)
+
+// adminGateStore is the narrow read surface the admin gates need. Both reads
+// happen at request time on every request; neither is cached and neither may
+// be served from a boot snapshot. A tenant count that is stale in the
+// permissive direction is a cross-tenant authorisation hole, so the gate pays
+// one small indexed read rather than trusting a remembered answer.
+type adminGateStore interface {
+	// IsSuperadmin reports users.is_superadmin for the given user.
+	IsSuperadmin(ctx context.Context, userID uuid.UUID) (bool, error)
+	// IsSoleLiveTenantOwner reports whether this install has exactly one live
+	// organisation AND the given user is an owner of a live organisation.
+	// Both facts come from one statement, so they cannot be read a moment
+	// apart and cannot disagree.
+	IsSoleLiveTenantOwner(ctx context.Context, userID uuid.UUID) (bool, error)
+}
+
+// isSuperadminSQL is a targeted single-column read against users, which has no
+// RLS (see db/schema.sql), so it runs on the bare pool with no tenant context.
+const isSuperadminSQL = `SELECT is_superadmin FROM users WHERE id = $1`
+
+// soleLiveTenantOwnerSQL answers the whole of the GH #322 question in ONE
+// statement against ONE snapshot: is there exactly one organisation on this
+// install, and does this caller own one? Splitting it into two round trips
+// would let an organisation be created between them.
+//
+// If the count is 1 and the caller owns some live organisation, then the
+// organisation they own IS that one; no third read is needed to tie them
+// together.
+//
+// role = 'owner' is exact, not a ladder: memberships.role is constrained to
+// ('owner', 'admin', 'operator', 'viewer') by memberships_role_check, and
+// admin, operator and viewer are all refused here. Being a member of the only
+// organisation is not enough.
+//
+// "live" means deleted_at IS NULL, matching every other tenant-resolving read
+// in this repo (db/query/tenants.sql ListOrgsForUser and GetTenantForUser,
+// db/query/memberships.sql ListMembershipsForUser, db/query/api_keys.sql
+// GetAPIKeyByPrefix, db/query/site_shares.sql, db/query/client_members.sql,
+// all GH #152). The reasoning for counting it this way rather than counting
+// every row:
+//
+//   - A soft-deleted organisation cannot spend anything. Its members cannot
+//     switch into it, its API keys stop resolving, and every read path already
+//     hides it, so there is no principal able to act as that tenant and
+//     therefore no budget of its own to protect. The gate exists to stop one
+//     tenant spending another tenant's share; a tenant nobody can act as has
+//     no share.
+//   - Counting soft-deleted rows would refuse a legitimate single-tenant
+//     install for the whole grace window, and then indefinitely on any install
+//     where the purge worker is not running, on the strength of an
+//     organisation that is invisible everywhere else in the product.
+//   - Restoring it closes the path again immediately. RestoreTenant clears
+//     deleted_at, the count is read fresh on the next request, and this gate
+//     returns to refusing. There is nothing cached to invalidate.
+const soleLiveTenantOwnerSQL = `
+SELECT (SELECT count(*) FROM tenants WHERE deleted_at IS NULL) = 1
+   AND EXISTS (
+           SELECT 1
+           FROM memberships m
+           JOIN tenants t ON t.id = m.tenant_id
+           WHERE m.user_id = $1
+             AND m.role = 'owner'
+             AND t.deleted_at IS NULL
+       )`
+
+// poolGateStore is the production adminGateStore, reading Postgres directly.
+type poolGateStore struct{ pool *db.Pool }
+
+func newPoolGateStore(pool *db.Pool) poolGateStore { return poolGateStore{pool: pool} }
+
+func (s poolGateStore) IsSuperadmin(ctx context.Context, userID uuid.UUID) (bool, error) {
+	var isSA bool
+	if err := s.pool.QueryRow(ctx, isSuperadminSQL, userID).Scan(&isSA); err != nil {
+		return false, err
+	}
+	return isSA, nil
+}
+
+// IsSoleLiveTenantOwner runs soleLiveTenantOwnerSQL under InUserTx. That is
+// required, not incidental: memberships is under FORCE RLS and the only policy
+// that lets a principal read its OWN membership rows across tenants is
+// memberships_self_read, which keys on the app.user_id GUC that InUserTx sets.
+// On the bare pool the EXISTS would silently see zero rows and the gate would
+// refuse everyone. tenants carries no RLS, so the count sees every row.
+func (s poolGateStore) IsSoleLiveTenantOwner(ctx context.Context, userID uuid.UUID) (bool, error) {
+	var allowed bool
+	err := s.pool.InUserTx(ctx, userID, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, soleLiveTenantOwnerSQL, userID).Scan(&allowed)
+	})
+	if err != nil {
+		return false, err
+	}
+	return allowed, nil
+}
+
+// denyAdminGate is the ONE refusal both gates use. The code and the message are
+// byte-identical on every path, including the widened one, so a caller cannot
+// learn from a refusal whether this install has one organisation or many.
+func denyAdminGate(c *gin.Context) {
+	httpx.Error(c, domain.Forbidden("superadmin_required", "superadmin access required"))
+	c.Abort()
+}
+
+// requireSuperadmin is a Gin middleware that returns 403 unless the
+// authenticated principal has is_superadmin=true. It gates the whole /admin
+// group.
+func requireSuperadmin(store adminGateStore) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		p, ok := domain.PrincipalFromContext(c.Request.Context())
+		if !ok || p.Type != domain.PrincipalUser {
+			denyAdminGate(c)
+			return
+		}
+		isSA, err := store.IsSuperadmin(c.Request.Context(), p.UserID)
+		if err != nil || !isSA {
+			denyAdminGate(c)
+			return
+		}
+		c.Next()
+	}
+}
+
+// requireSuperadminOrSoleTenantOwner gates POST /admin/agent-mirror/check, and
+// nothing else on this install. It admits:
+//
+//	users.is_superadmin = true
+//	OR the caller is an owner of the only live organisation on this install.
+//
+// Why the second arm exists (GH #322). The superadmin gate on this route is
+// there so that one tenant cannot spend another tenant's share of the install's
+// shared, unauthenticated upstream request budget. On an install with exactly
+// one organisation there is no other tenant for that to protect, and what is
+// left is the mechanics without the reason: set WPMGR_SUPERADMIN_EMAILS,
+// restart, then discover that the seeder is additive only and never demotes, so
+// getting back out means a manual UPDATE against users and another restart.
+// That is a lot of platform-operator ceremony for someone checking whether
+// their own fleet's agent reference is current.
+//
+// THE PROPERTY THAT MUST NOT BE LOST: the owner NEVER becomes a superadmin
+// under this. No env var, no restart, no is_superadmin flag written anywhere,
+// and no Sites-page redirect (the web app's isSuperadminAllowedPath guard in
+// routes/_authed.tsx redirects superadmins AWAY from tenant pages, which is
+// exactly why this action could not live beside the Agent column before). This
+// admits one request on one route and confers nothing else. A second
+// organisation appearing on the install closes the path again on the very next
+// request, with no migration and nothing to clean up, because the count is read
+// at request time and is never cached.
+//
+// Fail closed: an error reading either fact is a refusal, never an allow.
+func requireSuperadminOrSoleTenantOwner(store adminGateStore) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		p, ok := domain.PrincipalFromContext(c.Request.Context())
+		if !ok || p.Type != domain.PrincipalUser {
+			// An API-key principal is refused even when the key belongs to the
+			// owner of the only organisation. This is an install-level action
+			// against a shared upstream budget and the audit record wants a
+			// human, which is the same reason requireSuperadmin refuses one.
+			denyAdminGate(c)
+			return
+		}
+		isSA, err := store.IsSuperadmin(c.Request.Context(), p.UserID)
+		if err != nil {
+			denyAdminGate(c)
+			return
+		}
+		if isSA {
+			c.Next()
+			return
+		}
+		allowed, err := store.IsSoleLiveTenantOwner(c.Request.Context(), p.UserID)
+		if err != nil || !allowed {
+			denyAdminGate(c)
+			return
+		}
+		c.Next()
+	}
+}

--- a/apps/api/internal/admin/gate_integration_test.go
+++ b/apps/api/internal/admin/gate_integration_test.go
@@ -1,0 +1,351 @@
+package admin
+
+// gate_integration_test.go: the GH #322 single-tenant allow-path proven against
+// a REAL Postgres, through the REAL mounted route, with real rows.
+//
+// gate_test.go proves which route carries the wider gate and that it fails
+// closed. It cannot prove the part that actually decides who gets in: how many
+// organisations this install has, what "owner" means, and what a soft-deleted
+// organisation counts as. Those live in soleLiveTenantOwnerSQL and in the RLS
+// policies it runs under, so they are tested here against rows.
+//
+// Docker-backed (testcontainers), mirroring
+// internal/middleware/auth_soft_delete_test.go's harness. Skips when Docker is
+// unavailable.
+//
+// Against the PRE-change gate every allow case here fails (403), because there
+// was no path for a non-superadmin at all; the refuse cases pass either way.
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// startGateTestPostgres returns (appPool, adminPool). appPool connects as the
+// non-superuser wpmgr_app role, so RLS is actually in force: reading the
+// caller's own memberships depends on the memberships_self_read policy and the
+// app.user_id GUC that InUserTx sets, exactly as in production.
+func startGateTestPostgres(t *testing.T) (*db.Pool, *db.Pool) {
+	t.Helper()
+	ctx := context.Background()
+
+	container, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("wpmgr"),
+		tcpostgres.WithUsername("wpmgr"),
+		tcpostgres.WithPassword("wpmgr"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(90*time.Second),
+		),
+	)
+	if err != nil {
+		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	adminPool, err := db.Connect(ctx, adminDSN)
+	if err != nil {
+		t.Fatalf("connect admin: %v", err)
+	}
+	if err := adminPool.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	for _, stmt := range []string{
+		"ALTER ROLE wpmgr_app LOGIN PASSWORD 'app'",
+		"GRANT USAGE ON SCHEMA public TO wpmgr_app",
+		"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO wpmgr_app",
+		"REVOKE UPDATE, DELETE, TRUNCATE ON audit_log FROM wpmgr_app",
+	} {
+		if _, err := adminPool.Exec(ctx, stmt); err != nil {
+			t.Fatalf("provision app role (%q): %v", stmt, err)
+		}
+	}
+	t.Cleanup(adminPool.Close)
+
+	appDSN := strings.Replace(adminDSN, "wpmgr:wpmgr@", "wpmgr_app:app@", 1)
+	appPool, err := db.Connect(ctx, appDSN)
+	if err != nil {
+		t.Fatalf("connect app: %v", err)
+	}
+	t.Cleanup(appPool.Close)
+	return appPool, adminPool
+}
+
+// gateSeed is the per-case fixture helper. Every case starts from an empty
+// tenants/users table, because the gate's whole question is an install-wide
+// count and leftover rows from a previous case would answer it.
+type gateSeed struct {
+	t     *testing.T
+	admin *db.Pool
+	ctx   context.Context
+}
+
+func newGateSeed(t *testing.T, adminPool *db.Pool) *gateSeed {
+	t.Helper()
+	ctx := context.Background()
+	// tenants cascades to memberships; users cascades to memberships too.
+	for _, stmt := range []string{`DELETE FROM tenants`, `DELETE FROM users`} {
+		if _, err := adminPool.Exec(ctx, stmt); err != nil {
+			t.Fatalf("reset (%q): %v", stmt, err)
+		}
+	}
+	return &gateSeed{t: t, admin: adminPool, ctx: ctx}
+}
+
+func (s *gateSeed) tenant(name string) uuid.UUID {
+	s.t.Helper()
+	var id uuid.UUID
+	slug := name + "-" + uuid.NewString()[:8]
+	if err := s.admin.QueryRow(s.ctx, `INSERT INTO tenants (name, slug) VALUES ($1,$2) RETURNING id`,
+		name, slug).Scan(&id); err != nil {
+		s.t.Fatalf("seed tenant %s: %v", name, err)
+	}
+	return id
+}
+
+func (s *gateSeed) softDelete(tenantID uuid.UUID) {
+	s.t.Helper()
+	if _, err := s.admin.Exec(s.ctx, `UPDATE tenants SET deleted_at = now() WHERE id = $1`, tenantID); err != nil {
+		s.t.Fatalf("soft-delete tenant: %v", err)
+	}
+}
+
+func (s *gateSeed) restore(tenantID uuid.UUID) {
+	s.t.Helper()
+	if _, err := s.admin.Exec(s.ctx, `UPDATE tenants SET deleted_at = NULL WHERE id = $1`, tenantID); err != nil {
+		s.t.Fatalf("restore tenant: %v", err)
+	}
+}
+
+func (s *gateSeed) user(superadmin bool) uuid.UUID {
+	s.t.Helper()
+	var id uuid.UUID
+	email := "gate-" + uuid.NewString()[:8] + "@example.com"
+	if err := s.admin.QueryRow(s.ctx,
+		`INSERT INTO users (email, is_superadmin) VALUES ($1,$2) RETURNING id`,
+		email, superadmin).Scan(&id); err != nil {
+		s.t.Fatalf("seed user: %v", err)
+	}
+	return id
+}
+
+func (s *gateSeed) member(tenantID, userID uuid.UUID, role string) {
+	s.t.Helper()
+	if _, err := s.admin.Exec(s.ctx,
+		`INSERT INTO memberships (tenant_id, user_id, role) VALUES ($1,$2,$3)`,
+		tenantID, userID, role); err != nil {
+		s.t.Fatalf("seed membership (%s): %v", role, err)
+	}
+}
+
+// realGatedEngine mounts the REAL admin routes against the REAL pool, so the
+// gate runs newPoolGateStore and therefore soleLiveTenantOwnerSQL under InUserTx.
+func realGatedEngine(t *testing.T, pool *db.Pool) *gin.Engine {
+	t.Helper()
+	h := NewHandler(nil, pool)
+	h.SetAgentMirror(NewAgentMirrorCheckService(false, false, nil, nil))
+	r := gin.New()
+	h.Register(r.Group("/api/v1"))
+	return r
+}
+
+// assertMirrorCheck drives POST /admin/agent-mirror/check as the given user and
+// asserts whether the gate let it through. Past the gate is pastTheGateCode
+// (the handler's own "mirroring is switched off" refusal); refused at the gate
+// is 403 gateRefusedCode.
+func assertMirrorCheck(t *testing.T, engine *gin.Engine, userID uuid.UUID, wantAllowed bool, why string) {
+	t.Helper()
+	p := &domain.Principal{Type: domain.PrincipalUser, UserID: userID}
+	status, code := callAs(t, engine, http.MethodPost, mirrorCheckPath, p)
+
+	if wantAllowed {
+		if status == http.StatusForbidden || code != pastTheGateCode {
+			t.Fatalf("%s: got %d %q, want the request to pass the gate (%q)", why, status, code, pastTheGateCode)
+		}
+		return
+	}
+	if status != http.StatusForbidden || code != gateRefusedCode {
+		t.Fatalf("%s: got %d %q, want 403 %q", why, status, code, gateRefusedCode)
+	}
+}
+
+// TestSoleTenantOwnerGate_AgainstRealRows is the whole GH #322 decision table,
+// run against real tenants, memberships and RLS.
+func TestSoleTenantOwnerGate_AgainstRealRows(t *testing.T) {
+	pool, adminPool := startGateTestPostgres(t)
+	engine := realGatedEngine(t, pool)
+
+	// T2: the owner of the only organisation on the install is allowed.
+	// FAILS against the pre-change gate.
+	t.Run("owner of the only organisation is allowed", func(t *testing.T) {
+		s := newGateSeed(t, adminPool)
+		only := s.tenant("only")
+		owner := s.user(false)
+		s.member(only, owner, "owner")
+		assertMirrorCheck(t, engine, owner, true, "owner of the sole organisation")
+	})
+
+	// T3: two live organisations means there IS another tenant's budget to
+	// protect, so the reason for the gate is back and the path closes.
+	t.Run("owner of one of two organisations is refused", func(t *testing.T) {
+		s := newGateSeed(t, adminPool)
+		first := s.tenant("first")
+		s.tenant("second")
+		owner := s.user(false)
+		s.member(first, owner, "owner")
+		assertMirrorCheck(t, engine, owner, false, "owner of one of two organisations")
+	})
+
+	// T4: membership is not enough. Only role='owner' passes; the constraint
+	// vocabulary is ('owner','admin','operator','viewer').
+	t.Run("non-owner member of the only organisation is refused", func(t *testing.T) {
+		for _, role := range []string{"admin", "operator", "viewer"} {
+			t.Run(role, func(t *testing.T) {
+				s := newGateSeed(t, adminPool)
+				only := s.tenant("only")
+				owner := s.user(false)
+				s.member(only, owner, "owner") // a real owner exists; the caller is not them
+				member := s.user(false)
+				s.member(only, member, role)
+				assertMirrorCheck(t, engine, member, false, role+" of the sole organisation")
+			})
+		}
+	})
+
+	// A user with no membership at all, on a single-organisation install.
+	t.Run("non-member is refused on a single-organisation install", func(t *testing.T) {
+		s := newGateSeed(t, adminPool)
+		only := s.tenant("only")
+		s.member(only, s.user(false), "owner")
+		stranger := s.user(false)
+		assertMirrorCheck(t, engine, stranger, false, "non-member")
+	})
+
+	// T6: the R3 decision, asserted explicitly. A soft-deleted second
+	// organisation does NOT count: nobody can act as it, so it has no budget
+	// share to protect, and every other tenant-resolving read in this repo
+	// already treats it as gone.
+	t.Run("soft-deleted second organisation does not count", func(t *testing.T) {
+		s := newGateSeed(t, adminPool)
+		live := s.tenant("live")
+		gone := s.tenant("gone")
+		owner := s.user(false)
+		s.member(live, owner, "owner")
+		s.member(gone, owner, "owner")
+		s.softDelete(gone)
+		assertMirrorCheck(t, engine, owner, true, "owner with one live and one soft-deleted organisation")
+
+		// R2, the other half of the same decision: restoring it closes the path
+		// again on the very NEXT request. Nothing is cached, so there is nothing
+		// to invalidate.
+		s.restore(gone)
+		assertMirrorCheck(t, engine, owner, false, "same owner immediately after the second organisation was restored")
+	})
+
+	// The inverse of T6: owning only a soft-deleted organisation grants
+	// nothing, even though the live count is exactly 1. The caller must own
+	// the LIVE one.
+	t.Run("owner of only a soft-deleted organisation is refused", func(t *testing.T) {
+		s := newGateSeed(t, adminPool)
+		s.tenant("live-owned-by-someone-else")
+		gone := s.tenant("gone")
+		owner := s.user(false)
+		s.member(gone, owner, "owner")
+		s.softDelete(gone)
+		assertMirrorCheck(t, engine, owner, false, "owner of a soft-deleted organisation only")
+	})
+
+	// T1: superadmin is unchanged, and is independent of the tenant count.
+	t.Run("superadmin is allowed regardless of the organisation count", func(t *testing.T) {
+		s := newGateSeed(t, adminPool)
+		s.tenant("first")
+		s.tenant("second")
+		sa := s.user(true)
+		assertMirrorCheck(t, engine, sa, true, "superadmin on a two-organisation install")
+	})
+
+	// T5: an API key that maps to the owner of the only organisation is still
+	// refused. The principal type is checked before any lookup.
+	t.Run("api-key principal is refused even when it maps to the sole owner", func(t *testing.T) {
+		s := newGateSeed(t, adminPool)
+		only := s.tenant("only")
+		owner := s.user(false)
+		s.member(only, owner, "owner")
+
+		p := &domain.Principal{
+			Type:     domain.PrincipalAPIKey,
+			APIKeyID: uuid.New(),
+			TenantID: only,
+			UserID:   owner, // even carrying the owner's user id, it must not pass
+		}
+		status, code := callAs(t, engine, http.MethodPost, mirrorCheckPath, p)
+		if status != http.StatusForbidden || code != gateRefusedCode {
+			t.Fatalf("api-key principal: got %d %q, want 403 %q", status, code, gateRefusedCode)
+		}
+	})
+
+	// T7: fail closed on a broken read. Revoking the app role's SELECT on
+	// tenants makes soleLiveTenantOwnerSQL error; the gate must refuse rather
+	// than treat the failure as an allow. Restored immediately afterwards.
+	t.Run("a database error on the count path refuses", func(t *testing.T) {
+		s := newGateSeed(t, adminPool)
+		only := s.tenant("only")
+		owner := s.user(false)
+		s.member(only, owner, "owner")
+		assertMirrorCheck(t, engine, owner, true, "control: the same owner is allowed before the read is broken")
+
+		if _, err := adminPool.Exec(s.ctx, `REVOKE SELECT ON tenants FROM wpmgr_app`); err != nil {
+			t.Fatalf("revoke select on tenants: %v", err)
+		}
+		defer func() {
+			if _, err := adminPool.Exec(s.ctx, `GRANT SELECT ON tenants TO wpmgr_app`); err != nil {
+				t.Fatalf("restore select on tenants: %v", err)
+			}
+		}()
+		assertMirrorCheck(t, engine, owner, false, "the same owner once the tenant count cannot be read")
+	})
+
+	// T8: containment, against real rows. The owner who IS allowed through
+	// agent-mirror/check is still refused by other admin routes. 403 rather
+	// than "not 200" also proves those routes are still mounted.
+	t.Run("no other admin route admits the sole-organisation owner", func(t *testing.T) {
+		s := newGateSeed(t, adminPool)
+		only := s.tenant("only")
+		owner := s.user(false)
+		s.member(only, owner, "owner")
+		assertMirrorCheck(t, engine, owner, true, "control: the owner passes the widened route")
+
+		p := &domain.Principal{Type: domain.PrincipalUser, UserID: owner}
+		for _, path := range []string{
+			"/api/v1/admin/stats",
+			"/api/v1/admin/users",
+			"/api/v1/admin/accounts-tenancy",
+			"/api/v1/admin/accounts",
+			"/api/v1/admin/revenue",
+		} {
+			status, code := callAs(t, engine, http.MethodGet, path, p)
+			if status != http.StatusForbidden || code != gateRefusedCode {
+				t.Fatalf("GET %s: got %d %q, want 403 %q: only agent-mirror/check may admit this principal",
+					path, status, code, gateRefusedCode)
+			}
+		}
+	})
+}

--- a/apps/api/internal/admin/gate_test.go
+++ b/apps/api/internal/admin/gate_test.go
@@ -1,0 +1,311 @@
+package admin
+
+// gate_test.go: hermetic tests for the two /admin route gates (GH #322).
+//
+// These drive the REAL Register wiring on a real Gin engine with a fake
+// adminGateStore, so they prove which route got the widened gate and which
+// routes did not. The SQL behind adminGateStore (tenant counting, the owner
+// role, soft-deleted organisations) is a separate question and is proven
+// against a real Postgres in gate_integration_test.go; a fake cannot answer it.
+//
+// Which of these fail against the PRE-change gate (agent-mirror/check mounted
+// on the requireSuperadmin group like every other admin route):
+//
+//	TestAgentMirrorGate_SoleTenantOwnerAllowed          FAILS pre-change (403, gate refused)
+//	TestAgentMirrorGate_SoleTenantOwnerReachesHandler   FAILS pre-change (403, never reached the handler)
+//	everything else                                     passes either way, by design:
+//	  they pin behaviour that must NOT have changed (superadmin still in,
+//	  non-owner out, API key out, DB error out, other admin routes untouched).
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// fakeGateStore is an adminGateStore test double. Both facts are set
+// independently so a test can assert the gate reads the RIGHT one.
+type fakeGateStore struct {
+	superadmin    bool
+	superadminErr error
+	soleOwner     bool
+	soleOwnerErr  error
+
+	superadminCalls int
+	soleOwnerCalls  int
+}
+
+func (f *fakeGateStore) IsSuperadmin(context.Context, uuid.UUID) (bool, error) {
+	f.superadminCalls++
+	return f.superadmin, f.superadminErr
+}
+
+func (f *fakeGateStore) IsSoleLiveTenantOwner(context.Context, uuid.UUID) (bool, error) {
+	f.soleOwnerCalls++
+	return f.soleOwner, f.soleOwnerErr
+}
+
+const (
+	// mirrorCheckPath is the ONE route that carries the widened gate.
+	mirrorCheckPath = "/api/v1/admin/agent-mirror/check"
+	// gateRefusedCode is the single refusal code every gate path emits. It must
+	// stay identical on the widened path so a refusal cannot be used to probe
+	// how many organisations this install has.
+	gateRefusedCode = "superadmin_required"
+	// pastTheGateCode is what the agent-mirror handler returns once the gate has
+	// let the request through, with the service wired disabled in these tests.
+	// Seeing it is proof the request reached the handler; it is not 403, and it
+	// is not a 404 from a route that was never mounted.
+	pastTheGateCode = "agent_mirror_disabled"
+)
+
+// newGatedEngine mounts the REAL admin routes (h.Register) with the given fake
+// gate store, exactly as internal/server/server.go mounts them on v1Auth.
+func newGatedEngine(t *testing.T, store adminGateStore) *gin.Engine {
+	t.Helper()
+	h := NewHandler(nil, nil)
+	h.gate = store
+	// Mirrors cmd/wpmgr/main.go: without SetAgentMirror the route is not
+	// mounted at all. Disabled+unwired, so the handler refuses with
+	// pastTheGateCode rather than touching River or object storage.
+	h.SetAgentMirror(NewAgentMirrorCheckService(false, false, nil, nil))
+
+	r := gin.New()
+	h.Register(r.Group("/api/v1"))
+	return r
+}
+
+// callAs issues a request carrying the given principal (nil for none) and
+// returns the status plus the parsed error code ("" when the body is not an
+// error envelope).
+func callAs(t *testing.T, engine *gin.Engine, method, path string, p *domain.Principal) (int, string) {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	if p != nil {
+		req = req.WithContext(domain.WithPrincipal(req.Context(), *p))
+	}
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	var body struct {
+		Code string `json:"code"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	return w.Code, body.Code
+}
+
+func userPrincipal() *domain.Principal {
+	return &domain.Principal{Type: domain.PrincipalUser, UserID: uuid.New()}
+}
+
+// --- T1: superadmin still allowed ------------------------------------------
+
+// TestAgentMirrorGate_SuperadminAllowed pins the unchanged half of the change.
+// A superadmin must still reach the handler, and the widened arm must not even
+// be consulted for them.
+func TestAgentMirrorGate_SuperadminAllowed(t *testing.T) {
+	store := &fakeGateStore{superadmin: true, soleOwner: false}
+	status, code := callAs(t, newGatedEngine(t, store), http.MethodPost, mirrorCheckPath, userPrincipal())
+
+	if status == http.StatusForbidden {
+		t.Fatalf("superadmin was refused (%d %s); this behaviour must not have changed", status, code)
+	}
+	if code != pastTheGateCode {
+		t.Fatalf("code = %q, want %q (the request must reach the handler)", code, pastTheGateCode)
+	}
+	if store.soleOwnerCalls != 0 {
+		t.Fatalf("sole-owner lookup ran %d times for a superadmin; want 0", store.soleOwnerCalls)
+	}
+}
+
+// --- T2: owner of the ONLY tenant is allowed -------------------------------
+
+// TestAgentMirrorGate_SoleTenantOwnerAllowed is the whole point of GH #322.
+// FAILS against the pre-change gate: there, a non-superadmin gets 403 here.
+func TestAgentMirrorGate_SoleTenantOwnerAllowed(t *testing.T) {
+	store := &fakeGateStore{superadmin: false, soleOwner: true}
+	status, code := callAs(t, newGatedEngine(t, store), http.MethodPost, mirrorCheckPath, userPrincipal())
+
+	if status == http.StatusForbidden {
+		t.Fatalf("owner of the only organisation was refused (%d %s); GH #322 requires this to pass", status, code)
+	}
+	if store.soleOwnerCalls != 1 {
+		t.Fatalf("sole-owner lookup ran %d times; want exactly 1 (read at request time, never cached)", store.soleOwnerCalls)
+	}
+}
+
+// TestAgentMirrorGate_SoleTenantOwnerReachesHandler is the same allow-path
+// asserted on the response the HANDLER produces rather than on the absence of a
+// 403, so a future refusal that happened to use a different status could not
+// quietly satisfy the test above.
+// FAILS against the pre-change gate.
+func TestAgentMirrorGate_SoleTenantOwnerReachesHandler(t *testing.T) {
+	store := &fakeGateStore{superadmin: false, soleOwner: true}
+	_, code := callAs(t, newGatedEngine(t, store), http.MethodPost, mirrorCheckPath, userPrincipal())
+
+	if code != pastTheGateCode {
+		t.Fatalf("code = %q, want %q (the owner's request must reach the handler)", code, pastTheGateCode)
+	}
+}
+
+// --- T3 + T4: refused when either half of the condition is false -----------
+
+// TestAgentMirrorGate_RefusedWhenNotSoleOwner covers both the "owner of one of
+// several organisations" and the "member but not owner" shapes at the gate
+// layer: whatever the reason, the store answers false and the gate refuses.
+// Which inputs make the store answer false is proven in
+// gate_integration_test.go against real rows.
+func TestAgentMirrorGate_RefusedWhenNotSoleOwner(t *testing.T) {
+	store := &fakeGateStore{superadmin: false, soleOwner: false}
+	status, code := callAs(t, newGatedEngine(t, store), http.MethodPost, mirrorCheckPath, userPrincipal())
+
+	if status != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", status)
+	}
+	if code != gateRefusedCode {
+		t.Fatalf("code = %q, want %q (a refusal must not say why)", code, gateRefusedCode)
+	}
+}
+
+// --- T5: API-key principal is refused --------------------------------------
+
+// TestAgentMirrorGate_APIKeyPrincipalRefused pins that an API key never takes
+// the widened path, even on a single-organisation install where the key's own
+// tenant is that organisation. The gate must not perform either lookup.
+func TestAgentMirrorGate_APIKeyPrincipalRefused(t *testing.T) {
+	store := &fakeGateStore{superadmin: true, soleOwner: true} // both true: only the principal type may refuse
+	p := &domain.Principal{Type: domain.PrincipalAPIKey, APIKeyID: uuid.New(), TenantID: uuid.New()}
+	status, code := callAs(t, newGatedEngine(t, store), http.MethodPost, mirrorCheckPath, p)
+
+	if status != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 for an API-key principal", status)
+	}
+	if code != gateRefusedCode {
+		t.Fatalf("code = %q, want %q", code, gateRefusedCode)
+	}
+	if store.superadminCalls != 0 || store.soleOwnerCalls != 0 {
+		t.Fatalf("gate hit the store (%d superadmin, %d sole-owner) for a non-user principal; want 0 and 0",
+			store.superadminCalls, store.soleOwnerCalls)
+	}
+}
+
+// TestAgentMirrorGate_NoPrincipalRefused: an unauthenticated request never
+// reaches either lookup.
+func TestAgentMirrorGate_NoPrincipalRefused(t *testing.T) {
+	store := &fakeGateStore{superadmin: true, soleOwner: true}
+	status, code := callAs(t, newGatedEngine(t, store), http.MethodPost, mirrorCheckPath, nil)
+
+	if status != http.StatusForbidden || code != gateRefusedCode {
+		t.Fatalf("status/code = %d/%q, want 403/%q", status, code, gateRefusedCode)
+	}
+	if store.superadminCalls != 0 || store.soleOwnerCalls != 0 {
+		t.Fatal("gate hit the store without a principal")
+	}
+}
+
+// --- T7: fail closed on a DB error -----------------------------------------
+
+// TestAgentMirrorGate_SoleOwnerReadErrorRefuses: the count/ownership read
+// failing is a refusal, never an allow. This is the one that turns a database
+// blip into a 403 instead of into an open door.
+func TestAgentMirrorGate_SoleOwnerReadErrorRefuses(t *testing.T) {
+	store := &fakeGateStore{
+		superadmin:   false,
+		soleOwner:    true, // would allow, but the error must win
+		soleOwnerErr: errors.New("connection reset"),
+	}
+	status, code := callAs(t, newGatedEngine(t, store), http.MethodPost, mirrorCheckPath, userPrincipal())
+
+	if status != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 when the tenant-count read fails", status)
+	}
+	if code != gateRefusedCode {
+		t.Fatalf("code = %q, want %q", code, gateRefusedCode)
+	}
+}
+
+// TestAgentMirrorGate_SuperadminReadErrorRefuses: the users read failing is
+// also a refusal, and must NOT fall through to the widened arm. Falling through
+// would mean a broken users table silently downgraded this route's gate.
+func TestAgentMirrorGate_SuperadminReadErrorRefuses(t *testing.T) {
+	store := &fakeGateStore{
+		superadminErr: errors.New("connection reset"),
+		soleOwner:     true, // would allow if the gate wrongly fell through
+	}
+	status, code := callAs(t, newGatedEngine(t, store), http.MethodPost, mirrorCheckPath, userPrincipal())
+
+	if status != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 when the is_superadmin read fails", status)
+	}
+	if code != gateRefusedCode {
+		t.Fatalf("code = %q, want %q", code, gateRefusedCode)
+	}
+	if store.soleOwnerCalls != 0 {
+		t.Fatalf("gate consulted the widened arm after an is_superadmin read error; want 0 calls, got %d",
+			store.soleOwnerCalls)
+	}
+}
+
+// --- T8: no OTHER admin route gained the widened path ----------------------
+
+// TestOtherAdminRoutes_DidNotGainTheWidenedPath is the containment test. The
+// same principal that IS allowed through agent-mirror/check (owner of the only
+// organisation, not a superadmin) must still be refused by every other admin
+// route. Asserting 403 rather than "not 200" also proves the routes are still
+// mounted: an unmounted route would answer 404 and fail here.
+func TestOtherAdminRoutes_DidNotGainTheWidenedPath(t *testing.T) {
+	others := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/admin/stats"},
+		{http.MethodGet, "/api/v1/admin/users"},
+		{http.MethodGet, "/api/v1/admin/accounts-tenancy"},
+		{http.MethodGet, "/api/v1/admin/accounts"},
+		{http.MethodGet, "/api/v1/admin/revenue"},
+	}
+
+	for _, tc := range others {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			store := &fakeGateStore{superadmin: false, soleOwner: true}
+			status, code := callAs(t, newGatedEngine(t, store), tc.method, tc.path, userPrincipal())
+
+			if status != http.StatusForbidden {
+				t.Fatalf("status = %d (code %q), want 403: only agent-mirror/check may admit the owner of a single-organisation install",
+					status, code)
+			}
+			if code != gateRefusedCode {
+				t.Fatalf("code = %q, want %q", code, gateRefusedCode)
+			}
+			if store.soleOwnerCalls != 0 {
+				t.Fatalf("%s %s consulted the single-tenant arm (%d calls); the widened gate must be mounted on agent-mirror/check ONLY",
+					tc.method, tc.path, store.soleOwnerCalls)
+			}
+		})
+	}
+}
+
+// TestAgentMirrorGate_NotMountedWithoutSetAgentMirror: without
+// SetAgentMirror the route does not exist at all, so the widened group is never
+// created either. Guards against the wider gate being mounted on a group that
+// later acquires other routes.
+func TestAgentMirrorGate_NotMountedWithoutSetAgentMirror(t *testing.T) {
+	store := &fakeGateStore{superadmin: false, soleOwner: true}
+	h := NewHandler(nil, nil)
+	h.gate = store
+	r := gin.New()
+	h.Register(r.Group("/api/v1"))
+
+	status, _ := callAs(t, r, http.MethodPost, mirrorCheckPath, userPrincipal())
+	if status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 when SetAgentMirror was never called", status)
+	}
+}

--- a/apps/api/internal/admin/handler.go
+++ b/apps/api/internal/admin/handler.go
@@ -17,6 +17,7 @@ import (
 type Handler struct {
 	svc          *Service
 	pool         *db.Pool
+	gate         adminGateStore // reads the two facts the route gates need; see gate.go
 	auditRec     *audit.Recorder
 	vulnFeedH    *vulnFeedAdminHandler    // wired via SetVulnFeed; nil until wired
 	agentMirrorH *agentMirrorAdminHandler // wired via SetAgentMirror; nil until wired
@@ -24,7 +25,7 @@ type Handler struct {
 
 // NewHandler builds an admin Handler.
 func NewHandler(svc *Service, pool *db.Pool) *Handler {
-	return &Handler{svc: svc, pool: pool}
+	return &Handler{svc: svc, pool: pool, gate: newPoolGateStore(pool)}
 }
 
 // SetAuditRecorder wires the audit recorder into the handler. Called once at boot.
@@ -32,8 +33,12 @@ func (h *Handler) SetAuditRecorder(rec *audit.Recorder) { h.auditRec = rec }
 
 // Register mounts the admin routes on the auth-gated (not tenant-gated)
 // v1Auth group. The requireSuperadmin middleware gates the entire sub-group.
+//
+// One route, POST /admin/agent-mirror/check, carries a WIDER gate and is
+// therefore mounted on its own group at the bottom of this function rather
+// than on g. Everything mounted on g below is superadmin-only, unchanged.
 func (h *Handler) Register(r *gin.RouterGroup) {
-	g := r.Group("/admin", requireSuperadmin(h.pool))
+	g := r.Group("/admin", requireSuperadmin(h.gate))
 	g.GET("/stats", h.stats)
 	g.GET("/users", h.listUsers)
 	g.DELETE("/users/:userId", h.deleteUser)
@@ -66,8 +71,19 @@ func (h *Handler) Register(r *gin.RouterGroup) {
 	}
 	// GH #322: manual "check now" for the upstream agent-release mirror
 	// (optional; wired via SetAgentMirror after boot).
+	//
+	// This ONE route has a wider gate than the rest of /admin: superadmin, OR
+	// the owner of the only live organisation on this install (see
+	// requireSuperadminOrSoleTenantOwner in gate.go for why, and for what it
+	// deliberately does not grant). Gin composes middleware with AND, not OR,
+	// so the route cannot be mounted on g above and then widened per-route:
+	// g's requireSuperadmin would refuse the owner before the wider gate ever
+	// ran. It gets its own group carrying only the wider gate, and nothing
+	// else is ever mounted on that group, so no other admin route can pick the
+	// wider path up by accident.
 	if h.agentMirrorH != nil {
-		g.POST("/agent-mirror/check", h.agentMirrorCheck)
+		wide := r.Group("/admin", requireSuperadminOrSoleTenantOwner(h.gate))
+		wide.POST("/agent-mirror/check", h.agentMirrorCheck)
 	}
 }
 
@@ -202,31 +218,6 @@ func (h *Handler) userSites(c *gin.Context) {
 		"user_id": userID,
 		"sites":   items,
 	})
-}
-
-// requireSuperadmin is a Gin middleware that returns 403 unless the
-// authenticated principal has is_superadmin=true. It does a targeted
-// single-column DB read (no joins) against the users table, which has no RLS,
-// so it runs on the bare pool without any tenant context.
-func requireSuperadmin(pool *db.Pool) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		p, ok := domain.PrincipalFromContext(c.Request.Context())
-		if !ok || p.Type != domain.PrincipalUser {
-			httpx.Error(c, domain.Forbidden("superadmin_required", "superadmin access required"))
-			c.Abort()
-			return
-		}
-		var isSA bool
-		err := pool.QueryRow(c.Request.Context(),
-			`SELECT is_superadmin FROM users WHERE id = $1`, p.UserID,
-		).Scan(&isSA)
-		if err != nil || !isSA {
-			httpx.Error(c, domain.Forbidden("superadmin_required", "superadmin access required"))
-			c.Abort()
-			return
-		}
-		c.Next()
-	}
 }
 
 func (h *Handler) stats(c *gin.Context) {

--- a/apps/api/internal/admin/handler_test.go
+++ b/apps/api/internal/admin/handler_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 // The requireSuperadmin middleware rejects on the principal check BEFORE it ever
-// touches the DB pool, so the unauthenticated + wrong-principal-type branches
-// are testable hermetically with a nil pool. The is_superadmin DB lookup branch
-// requires an integration DB and is covered there.
+// reads its adminGateStore, so the unauthenticated + wrong-principal-type
+// branches are testable hermetically with a nil store. The is_superadmin lookup
+// branch is covered with a fake store in gate_test.go and against real rows in
+// gate_integration_test.go.
 
 func init() { gin.SetMode(gin.TestMode) }
 

--- a/apps/api/internal/api/gen/oas_client_gen.go
+++ b/apps/api/internal/api/gen/oas_client_gen.go
@@ -564,14 +564,25 @@ type Invoker interface {
 	// Queues one immediate run of the upstream agent-release mirror
 	// (internal/agentupstream), instead of waiting up to six hours for the
 	// next scheduled run (GH #322).
-	// Superadmin only, and deliberately NOT under /api/v1/fleet. The mirror
-	// is ONE PER INSTALL: it fetches one public GitHub release and writes
-	// one pair of objects into one bucket. A tenant-scoped trigger would let
-	// any org admin on a shared install spend the install's shared
-	// unauthenticated GitHub request budget (60 per hour per IP) and
-	// rewrite the install's shared release pointer. Mirrors
-	// POST /api/v1/admin/vuln-feed/sync, gated for the identical reason (a
-	// shared feed, a shared rate limit).
+	// Deliberately NOT under /api/v1/fleet. The mirror is ONE PER INSTALL:
+	// it fetches one public GitHub release and writes one pair of objects
+	// into one bucket. A tenant-scoped trigger would let any org admin on a
+	// shared install spend the install's shared unauthenticated GitHub
+	// request budget (60 per hour per IP) and rewrite the install's shared
+	// release pointer.
+	// Who may call it: a superadmin (is_superadmin=true), OR the owner of the
+	// only organisation on this install. The second arm exists because the
+	// first arm's whole purpose is to stop one tenant spending another
+	// tenant's share of that budget, and on an install with exactly one
+	// organisation there is no other tenant for it to protect. It requires
+	// the memberships role 'owner' exactly, on the one organisation whose
+	// tenants.deleted_at is null; admin, operator and viewer are refused, as
+	// is an API-key principal. The count is read on every request and never
+	// cached, so a second organisation appearing closes this path again on
+	// the very next call, and the owner never becomes a superadmin: nothing
+	// else on /api/v1/admin admits them. Multi-organisation installs are
+	// unchanged and stay superadmin-only. Compare
+	// POST /api/v1/admin/vuln-feed/sync, which remains superadmin-only.
 	// A 202 means the run was QUEUED, not that anything was checked. The
 	// run may still end rate limited, refused or unavailable; the real
 	// outcome appears as agent_mirror.last_attempt_outcome on
@@ -9005,14 +9016,25 @@ func (c *Client) sendChangeMyPassword(ctx context.Context, request *ChangeMyPass
 // Queues one immediate run of the upstream agent-release mirror
 // (internal/agentupstream), instead of waiting up to six hours for the
 // next scheduled run (GH #322).
-// Superadmin only, and deliberately NOT under /api/v1/fleet. The mirror
-// is ONE PER INSTALL: it fetches one public GitHub release and writes
-// one pair of objects into one bucket. A tenant-scoped trigger would let
-// any org admin on a shared install spend the install's shared
-// unauthenticated GitHub request budget (60 per hour per IP) and
-// rewrite the install's shared release pointer. Mirrors
-// POST /api/v1/admin/vuln-feed/sync, gated for the identical reason (a
-// shared feed, a shared rate limit).
+// Deliberately NOT under /api/v1/fleet. The mirror is ONE PER INSTALL:
+// it fetches one public GitHub release and writes one pair of objects
+// into one bucket. A tenant-scoped trigger would let any org admin on a
+// shared install spend the install's shared unauthenticated GitHub
+// request budget (60 per hour per IP) and rewrite the install's shared
+// release pointer.
+// Who may call it: a superadmin (is_superadmin=true), OR the owner of the
+// only organisation on this install. The second arm exists because the
+// first arm's whole purpose is to stop one tenant spending another
+// tenant's share of that budget, and on an install with exactly one
+// organisation there is no other tenant for it to protect. It requires
+// the memberships role 'owner' exactly, on the one organisation whose
+// tenants.deleted_at is null; admin, operator and viewer are refused, as
+// is an API-key principal. The count is read on every request and never
+// cached, so a second organisation appearing closes this path again on
+// the very next call, and the owner never becomes a superadmin: nothing
+// else on /api/v1/admin admits them. Multi-organisation installs are
+// unchanged and stay superadmin-only. Compare
+// POST /api/v1/admin/vuln-feed/sync, which remains superadmin-only.
 // A 202 means the run was QUEUED, not that anything was checked. The
 // run may still end rate limited, refused or unavailable; the real
 // outcome appears as agent_mirror.last_attempt_outcome on

--- a/apps/api/internal/api/gen/oas_handlers_gen.go
+++ b/apps/api/internal/api/gen/oas_handlers_gen.go
@@ -9190,14 +9190,25 @@ func (s *Server) handleChangeMyPasswordRequest(args [0]string, argsEscaped bool,
 // Queues one immediate run of the upstream agent-release mirror
 // (internal/agentupstream), instead of waiting up to six hours for the
 // next scheduled run (GH #322).
-// Superadmin only, and deliberately NOT under /api/v1/fleet. The mirror
-// is ONE PER INSTALL: it fetches one public GitHub release and writes
-// one pair of objects into one bucket. A tenant-scoped trigger would let
-// any org admin on a shared install spend the install's shared
-// unauthenticated GitHub request budget (60 per hour per IP) and
-// rewrite the install's shared release pointer. Mirrors
-// POST /api/v1/admin/vuln-feed/sync, gated for the identical reason (a
-// shared feed, a shared rate limit).
+// Deliberately NOT under /api/v1/fleet. The mirror is ONE PER INSTALL:
+// it fetches one public GitHub release and writes one pair of objects
+// into one bucket. A tenant-scoped trigger would let any org admin on a
+// shared install spend the install's shared unauthenticated GitHub
+// request budget (60 per hour per IP) and rewrite the install's shared
+// release pointer.
+// Who may call it: a superadmin (is_superadmin=true), OR the owner of the
+// only organisation on this install. The second arm exists because the
+// first arm's whole purpose is to stop one tenant spending another
+// tenant's share of that budget, and on an install with exactly one
+// organisation there is no other tenant for it to protect. It requires
+// the memberships role 'owner' exactly, on the one organisation whose
+// tenants.deleted_at is null; admin, operator and viewer are refused, as
+// is an API-key principal. The count is read on every request and never
+// cached, so a second organisation appearing closes this path again on
+// the very next call, and the owner never becomes a superadmin: nothing
+// else on /api/v1/admin admits them. Multi-organisation installs are
+// unchanged and stay superadmin-only. Compare
+// POST /api/v1/admin/vuln-feed/sync, which remains superadmin-only.
 // A 202 means the run was QUEUED, not that anything was checked. The
 // run may still end rate limited, refused or unavailable; the real
 // outcome appears as agent_mirror.last_attempt_outcome on
@@ -9282,7 +9293,7 @@ func (s *Server) handleCheckAgentMirrorNowRequest(args [0]string, argsEscaped bo
 		mreq := middleware.Request{
 			Context:          ctx,
 			OperationName:    CheckAgentMirrorNowOperation,
-			OperationSummary: "Check the upstream agent release now (superadmin)",
+			OperationSummary: "Check the upstream agent release now (superadmin, or the owner of a single-organisation install)",
 			OperationID:      "checkAgentMirrorNow",
 			Body:             nil,
 			RawBody:          rawBody,

--- a/apps/api/internal/api/gen/oas_router_gen.go
+++ b/apps/api/internal/api/gen/oas_router_gen.go
@@ -12171,7 +12171,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										switch method {
 										case "POST":
 											r.name = CheckAgentMirrorNowOperation
-											r.summary = "Check the upstream agent release now (superadmin)"
+											r.summary = "Check the upstream agent release now (superadmin, or the owner of a single-organisation install)"
 											r.operationID = "checkAgentMirrorNow"
 											r.operationGroup = ""
 											r.pathPattern = "/api/v1/admin/agent-mirror/check"

--- a/apps/api/internal/api/gen/oas_server_gen.go
+++ b/apps/api/internal/api/gen/oas_server_gen.go
@@ -544,14 +544,25 @@ type Handler interface {
 	// Queues one immediate run of the upstream agent-release mirror
 	// (internal/agentupstream), instead of waiting up to six hours for the
 	// next scheduled run (GH #322).
-	// Superadmin only, and deliberately NOT under /api/v1/fleet. The mirror
-	// is ONE PER INSTALL: it fetches one public GitHub release and writes
-	// one pair of objects into one bucket. A tenant-scoped trigger would let
-	// any org admin on a shared install spend the install's shared
-	// unauthenticated GitHub request budget (60 per hour per IP) and
-	// rewrite the install's shared release pointer. Mirrors
-	// POST /api/v1/admin/vuln-feed/sync, gated for the identical reason (a
-	// shared feed, a shared rate limit).
+	// Deliberately NOT under /api/v1/fleet. The mirror is ONE PER INSTALL:
+	// it fetches one public GitHub release and writes one pair of objects
+	// into one bucket. A tenant-scoped trigger would let any org admin on a
+	// shared install spend the install's shared unauthenticated GitHub
+	// request budget (60 per hour per IP) and rewrite the install's shared
+	// release pointer.
+	// Who may call it: a superadmin (is_superadmin=true), OR the owner of the
+	// only organisation on this install. The second arm exists because the
+	// first arm's whole purpose is to stop one tenant spending another
+	// tenant's share of that budget, and on an install with exactly one
+	// organisation there is no other tenant for it to protect. It requires
+	// the memberships role 'owner' exactly, on the one organisation whose
+	// tenants.deleted_at is null; admin, operator and viewer are refused, as
+	// is an API-key principal. The count is read on every request and never
+	// cached, so a second organisation appearing closes this path again on
+	// the very next call, and the owner never becomes a superadmin: nothing
+	// else on /api/v1/admin admits them. Multi-organisation installs are
+	// unchanged and stay superadmin-only. Compare
+	// POST /api/v1/admin/vuln-feed/sync, which remains superadmin-only.
 	// A 202 means the run was QUEUED, not that anything was checked. The
 	// run may still end rate limited, refused or unavailable; the real
 	// outcome appears as agent_mirror.last_attempt_outcome on

--- a/apps/api/internal/api/gen/oas_unimplemented_gen.go
+++ b/apps/api/internal/api/gen/oas_unimplemented_gen.go
@@ -710,14 +710,25 @@ func (UnimplementedHandler) ChangeMyPassword(ctx context.Context, req *ChangeMyP
 // Queues one immediate run of the upstream agent-release mirror
 // (internal/agentupstream), instead of waiting up to six hours for the
 // next scheduled run (GH #322).
-// Superadmin only, and deliberately NOT under /api/v1/fleet. The mirror
-// is ONE PER INSTALL: it fetches one public GitHub release and writes
-// one pair of objects into one bucket. A tenant-scoped trigger would let
-// any org admin on a shared install spend the install's shared
-// unauthenticated GitHub request budget (60 per hour per IP) and
-// rewrite the install's shared release pointer. Mirrors
-// POST /api/v1/admin/vuln-feed/sync, gated for the identical reason (a
-// shared feed, a shared rate limit).
+// Deliberately NOT under /api/v1/fleet. The mirror is ONE PER INSTALL:
+// it fetches one public GitHub release and writes one pair of objects
+// into one bucket. A tenant-scoped trigger would let any org admin on a
+// shared install spend the install's shared unauthenticated GitHub
+// request budget (60 per hour per IP) and rewrite the install's shared
+// release pointer.
+// Who may call it: a superadmin (is_superadmin=true), OR the owner of the
+// only organisation on this install. The second arm exists because the
+// first arm's whole purpose is to stop one tenant spending another
+// tenant's share of that budget, and on an install with exactly one
+// organisation there is no other tenant for it to protect. It requires
+// the memberships role 'owner' exactly, on the one organisation whose
+// tenants.deleted_at is null; admin, operator and viewer are refused, as
+// is an API-key principal. The count is read on every request and never
+// cached, so a second organisation appearing closes this path again on
+// the very next call, and the owner never becomes a superadmin: nothing
+// else on /api/v1/admin admits them. Multi-organisation installs are
+// unchanged and stay superadmin-only. Compare
+// POST /api/v1/admin/vuln-feed/sync, which remains superadmin-only.
 // A 202 means the run was QUEUED, not that anything was checked. The
 // run may still end rate limited, refused or unavailable; the real
 // outcome appears as agent_mirror.last_attempt_outcome on

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,26 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.123",
+    date: "2026-08-05",
+    summary:
+      "On a single-organisation install, the owner can now check the agent release reference without being made a superadmin. Multi-organisation installs are unchanged.",
+    items: [
+      {
+        tag: "Changed",
+        text: "On an install with exactly one organisation, the owner of that organisation can now use \"Check now\" for the agent release reference (Admin > Agent mirror) without being made a superadmin first. Reported by a self-hoster who had to set WPMGR_SUPERADMIN_EMAILS and restart the control plane to click what is, for them, a monthly refresh of their own fleet's data, then found the seeding only ever adds the flag and never removes it. The permission exists so one organisation cannot spend another organisation's share of the install's shared, unauthenticated GitHub request budget, and on an install with exactly one organisation there is no other organisation for that to protect.",
+      },
+      {
+        tag: "Changed",
+        text: "The owner does not become a superadmin as a result. No environment variable, no restart, no flag written anywhere, and none of the side effects: every other admin action still refuses them, including the vulnerability feed sync, and they are not redirected away from the Sites page the way a real superadmin is. Only the owner role passes; an admin, operator or viewer in that organisation is refused, as is an API key.",
+      },
+      {
+        tag: "Changed",
+        text: "Nothing changes on an install with more than one organisation, which is every hosted account: the action stays superadmin only there. The organisation count is read fresh on every request and never cached, so creating a second organisation closes this path again on the very next call. An organisation that has been deleted but is still inside its restore window does not count towards the total, because nobody can act as one; restoring it closes the path immediately.",
+      },
+    ],
+  },
+  {
     version: "0.61.122",
     date: "2026-08-05",
     summary:

--- a/packages/openapi-client/src/generated/sdk.gen.ts
+++ b/packages/openapi-client/src/generated/sdk.gen.ts
@@ -2492,20 +2492,32 @@ export const syncAdminVulnFeed = <ThrowOnError extends boolean = false>(
   >({ url: "/api/v1/admin/vuln-feed/sync", ...options });
 
 /**
- * Check the upstream agent release now (superadmin)
+ * Check the upstream agent release now (superadmin, or the owner of a single-organisation install)
  *
  * Queues one immediate run of the upstream agent-release mirror
  * (internal/agentupstream), instead of waiting up to six hours for the
  * next scheduled run (GH #322).
  *
- * Superadmin only, and deliberately NOT under /api/v1/fleet. The mirror
- * is ONE PER INSTALL: it fetches one public GitHub release and writes
- * one pair of objects into one bucket. A tenant-scoped trigger would let
- * any org admin on a shared install spend the install's shared
- * unauthenticated GitHub request budget (60 per hour per IP) and
- * rewrite the install's shared release pointer. Mirrors
- * POST /api/v1/admin/vuln-feed/sync, gated for the identical reason (a
- * shared feed, a shared rate limit).
+ * Deliberately NOT under /api/v1/fleet. The mirror is ONE PER INSTALL:
+ * it fetches one public GitHub release and writes one pair of objects
+ * into one bucket. A tenant-scoped trigger would let any org admin on a
+ * shared install spend the install's shared unauthenticated GitHub
+ * request budget (60 per hour per IP) and rewrite the install's shared
+ * release pointer.
+ *
+ * Who may call it: a superadmin (is_superadmin=true), OR the owner of the
+ * only organisation on this install. The second arm exists because the
+ * first arm's whole purpose is to stop one tenant spending another
+ * tenant's share of that budget, and on an install with exactly one
+ * organisation there is no other tenant for it to protect. It requires
+ * the memberships role 'owner' exactly, on the one organisation whose
+ * tenants.deleted_at is null; admin, operator and viewer are refused, as
+ * is an API-key principal. The count is read on every request and never
+ * cached, so a second organisation appearing closes this path again on
+ * the very next call, and the owner never becomes a superadmin: nothing
+ * else on /api/v1/admin admits them. Multi-organisation installs are
+ * unchanged and stay superadmin-only. Compare
+ * POST /api/v1/admin/vuln-feed/sync, which remains superadmin-only.
  *
  * A 202 means the run was QUEUED, not that anything was checked. The
  * run may still end rate limited, refused or unavailable; the real

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -10623,7 +10623,8 @@ export type CheckAgentMirrorNowErrors = {
    */
   401: Error;
   /**
-   * superadmin_required
+   * superadmin_required - the caller is neither a superadmin nor the owner of the only organisation on this install. The code and message are identical for both, on purpose: a refusal must not reveal how many organisations this install has.
+   *
    */
   403: Error;
   /**

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.122
+  version: 0.61.123
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,
@@ -2649,20 +2649,32 @@ paths:
   /api/v1/admin/agent-mirror/check:
     post:
       operationId: checkAgentMirrorNow
-      summary: Check the upstream agent release now (superadmin)
+      summary: Check the upstream agent release now (superadmin, or the owner of a single-organisation install)
       description: |
         Queues one immediate run of the upstream agent-release mirror
         (internal/agentupstream), instead of waiting up to six hours for the
         next scheduled run (GH #322).
 
-        Superadmin only, and deliberately NOT under /api/v1/fleet. The mirror
-        is ONE PER INSTALL: it fetches one public GitHub release and writes
-        one pair of objects into one bucket. A tenant-scoped trigger would let
-        any org admin on a shared install spend the install's shared
-        unauthenticated GitHub request budget (60 per hour per IP) and
-        rewrite the install's shared release pointer. Mirrors
-        POST /api/v1/admin/vuln-feed/sync, gated for the identical reason (a
-        shared feed, a shared rate limit).
+        Deliberately NOT under /api/v1/fleet. The mirror is ONE PER INSTALL:
+        it fetches one public GitHub release and writes one pair of objects
+        into one bucket. A tenant-scoped trigger would let any org admin on a
+        shared install spend the install's shared unauthenticated GitHub
+        request budget (60 per hour per IP) and rewrite the install's shared
+        release pointer.
+
+        Who may call it: a superadmin (is_superadmin=true), OR the owner of the
+        only organisation on this install. The second arm exists because the
+        first arm's whole purpose is to stop one tenant spending another
+        tenant's share of that budget, and on an install with exactly one
+        organisation there is no other tenant for it to protect. It requires
+        the memberships role 'owner' exactly, on the one organisation whose
+        tenants.deleted_at is null; admin, operator and viewer are refused, as
+        is an API-key principal. The count is read on every request and never
+        cached, so a second organisation appearing closes this path again on
+        the very next call, and the owner never becomes a superadmin: nothing
+        else on /api/v1/admin admits them. Multi-organisation installs are
+        unchanged and stay superadmin-only. Compare
+        POST /api/v1/admin/vuln-feed/sync, which remains superadmin-only.
 
         A 202 means the run was QUEUED, not that anything was checked. The
         run may still end rate limited, refused or unavailable; the real
@@ -2683,7 +2695,11 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
-          description: superadmin_required
+          description: >
+            superadmin_required - the caller is neither a superadmin nor the
+            owner of the only organisation on this install. The code and
+            message are identical for both, on purpose: a refusal must not
+            reveal how many organisations this install has.
           content:
             application/json:
               schema:


### PR DESCRIPTION
From the #322 reporter, and it is a security boundary, so the reasoning matters more than the diff.

## The argument

`POST /api/v1/admin/agent-mirror/check` was superadmin-only. The gate exists so one tenant cannot spend another tenant's share of a shared GitHub rate-limit budget.

On an install with **exactly one tenant there is no other tenant for it to protect.** What is left is the mechanics without the reason: set `WPMGR_SUPERADMIN_EMAILS`, restart, then discover the seeding is additive-only and getting back out needs a manual `UPDATE` plus another restart, all to click a monthly refresh on your own data.

The gate is now **superadmin, OR owner of the only live organisation.**

**The owner never becomes a superadmin.** No env var, no restart, no `is_superadmin` flag, and no Sites-page redirect (the superadmin guard redirects away from tenant pages, which is exactly why this button could not live there before). A second organisation appearing closes the path again on the next request, with no migration and nothing to clean up.

**Hosted multi-tenant gating is unchanged.**

## Containment

Gin composes middleware with AND, so this route cannot sit on the superadmin group and be widened per route: the group gate would refuse the owner first. It gets its own group with **exactly one route on it**, and a test asserts a second `/admin` endpoint did *not* gain the wider path. `requireSuperadmin`'s semantics are untouched.

## Soft-deleted organisations do not count

This is the easiest thing here to get wrong, in either direction.

`deleted_at IS NULL`, matching every other tenant-resolving read in the repo. A soft-deleted org has **no share of the budget to protect**, because no principal can act as it: hidden from the switcher, unswitchable, API keys stop resolving. Counting it would refuse a legitimate single-tenant install for the whole grace window, and indefinitely wherever the purge worker is not running.

The recoverable-org risk closes itself: restoring clears `deleted_at` and the very next request reads two. Both directions are tested, including restore-then-immediately-refused.

## One statement, one snapshot, read at request time

A tenant count that is stale in the permissive direction is a cross-tenant authorisation hole, not a performance question.

The membership half runs inside the user transaction, which is **required rather than incidental**: `memberships` is FORCE RLS and only the self-read policy exposes cross-tenant own-membership rows, so on the bare pool the `EXISTS` would silently see nothing and the gate would refuse everyone. `tenants` carries no RLS, so the count sees every row.

Fails closed on every error path, including the `is_superadmin` read, which does **not** fall through to the wider arm. The refusal is byte-identical on every path, so it cannot be used to probe how many organisations exist.

## Verified against the pre-change gate

By copying the files aside and re-mounting on the old group:

```
--- FAIL: TestAgentMirrorGate_SoleTenantOwnerAllowed
--- FAIL: TestAgentMirrorGate_SoleTenantOwnerReachesHandler
--- FAIL: .../owner_of_the_only_organisation_is_allowed
--- FAIL: .../soft-deleted_second_organisation_does_not_count
--- FAIL: .../a_database_error_on_the_count_path_refuses
--- FAIL: .../no_other_admin_route_admits_the_sole-organisation_owner
```

The refuse-tests (superadmin, two tenants, non-owner roles, API key) pass either way **by design**, since they pin behaviour that must not have changed. They are not claimed as evidence of the change.

The integration tests run against a real Postgres as the non-superuser `wpmgr_app` role, so RLS is genuinely in force, and the DB-error test revokes `SELECT ON tenants` for real rather than asserting against a fake error.

## Gates

```
go build / vet / ./internal/... / ./tests/contract/...   clean, 0 failures
sqlc untouched      lockstep 0.61.123      dashes 0
```

## Not done, deliberately

**No UI reaches this yet.** The Check now button still lives in the superadmin-gated admin console, so a sole-org owner can now call the endpoint but has nowhere to click it.

The reporter's actual ask, the button inside the Agent column popover, needs a capability field on `GET /api/v1/fleet/agents` that the owner can read. That is a wire change with a spec addition and both regens, so it is the next piece rather than this one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Owners of a single active organization can now use “Check now” for the agent release reference without superadmin access.
  * Access remains restricted for multi-organization installations, other roles, and API keys.
* **Documentation**
  * Updated the changelog and API documentation for release 0.61.123.
* **Bug Fixes**
  * Preserved existing superadmin restrictions and consistent unauthorized responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->