### PR TITLE
feat(sites): put "Check now" where the freshness text already is (GH #322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.124] - 2026-08-05
+
+### Added
+
+- "Check now" for the agent release reference is now in the Agent column popover on the Sites page, directly under the freshness text, where the reporter asked for it. That is the moment it is wanted: reading "may be stale, last confirmed 14h ago" is exactly when an operator wants to act on it, and until now acting meant leaving the page for the admin console. 0.61.123 granted the permission to the owner of a single-organisation install but left the only button behind a console that same owner cannot open, so the feature was unreachable for the person it was built for.
+- The button appears only for a viewer who may actually use it, and the dashboard does not work that out for itself. The fleet agent response now carries the control plane's own answer for the asking viewer, computed by the same code that decides whether the endpoint would accept the request. There is one decision, so a button that always refuses and a permission nobody is offered are both impossible, rather than merely unlikely.
+- Nothing appears on an install with more than one organisation, which is every hosted account: the answer is false there for everyone except a superadmin, and a superadmin is redirected away from the Sites page anyway, so the admin console remains their route to the same action. The answer is also false whenever release mirroring is switched off, since there is no run to trigger at all then.
+- The three outcomes read the same here as in the admin console, because both use the same code. Queued is a success, and neither "a check is already running" nor "the mirror must wait before its next request" is shown as an error: being skipped by the thirty minute spacing is the system working as designed, and dressing that up as a failure would be the same overclaim in the opposite direction.
+- The button does not claim the check has happened. The control plane answers that a run was queued, not that anything was confirmed, so the wording says the result appears once the view refreshes.
+
 ## [0.61.123] - 2026-08-05
 
 ### Changed

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/activity"
 	"github.com/mosamlife/wpmgr/apps/api/internal/admin"
+	"github.com/mosamlife/wpmgr/apps/api/internal/admingate"
 	"github.com/mosamlife/wpmgr/apps/api/internal/agent"
 	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
 	"github.com/mosamlife/wpmgr/apps/api/internal/agentmirror"
@@ -2466,6 +2467,13 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// so the fleet response and the worker agree on whether a mirror job
 	// exists on this install at all.
 	agentReleaseH.SetMirror(agentMirrorRepo, cfg.Update.AgentMirrorEnabled)
+	// GH #322: agent_mirror.can_check_now, the capability behind the Sites
+	// page's "Check now" button. Deliberately the SAME admingate.Store the
+	// admin handler's route gate is built from (admin.NewHandler calls
+	// admingate.NewPoolStore over this same pool), read by the SAME
+	// admingate.CanRunAgentMirrorCheck. There is one decision, so the button
+	// cannot appear for a caller POST /admin/agent-mirror/check would refuse.
+	agentReleaseH.SetMirrorCheckGate(admingate.NewPoolStore(pool))
 
 	// The agent's OWN upgrade channel (three-beat arm/apply/confirm, staged in
 	// gated waves). SHIPS DARK: cfg.Update.AgentSelfUpdateEnabled defaults to

--- a/apps/api/internal/admin/gate.go
+++ b/apps/api/internal/admin/gate.go
@@ -10,120 +10,42 @@ package admin
 //
 //	requireSuperadminOrSoleTenantOwner
 //	    GH #322. Mounted on exactly ONE route, POST /admin/agent-mirror/check,
-//	    and on nothing else. See its doc comment for what it admits, why, and
-//	    for the property that must not be lost.
+//	    and on nothing else. It does not decide anything itself: it asks
+//	    admingate.CanRunAgentMirrorCheck and turns a false into this package's
+//	    single refusal. See that function for what it admits, why, and for the
+//	    property that must not be lost.
 //
-// Both read through adminGateStore rather than reaching for *db.Pool directly,
-// so both are drivable from a unit test without a database. That indirection
-// is the ONLY change to requireSuperadmin: the SQL it runs, the connection it
-// runs it on, and its fail-closed condition are identical to what they were
-// when it read the pool inline.
+// WHY THE DECISION MOVED OUT (GH #322 follow-up). The same question is now
+// asked by GET /api/v1/fleet/agents, which reports it as the capability field
+// agent_mirror.can_check_now so the Sites page can render a Check now button
+// exactly when this gate would admit the request. A gate and a capability flag
+// that compute the same permission separately can drift, and both drift
+// directions are operator-visible bugs (a button that always 403s, or a
+// permission nobody is ever offered). The reads and the rule therefore live in
+// internal/admingate and BOTH callers call them. Nothing was reimplemented and
+// no SQL was copied.
+//
+// Both gates read through admingate.Store rather than reaching for *db.Pool
+// directly, so both stay drivable from a unit test without a database.
 
 import (
-	"context"
-
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 
+	"github.com/mosamlife/wpmgr/apps/api/internal/admingate"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 	"github.com/mosamlife/wpmgr/apps/api/internal/server/httpx"
 )
 
-// adminGateStore is the narrow read surface the admin gates need. Both reads
-// happen at request time on every request; neither is cached and neither may
-// be served from a boot snapshot. A tenant count that is stale in the
-// permissive direction is a cross-tenant authorisation hole, so the gate pays
-// one small indexed read rather than trusting a remembered answer.
-type adminGateStore interface {
-	// IsSuperadmin reports users.is_superadmin for the given user.
-	IsSuperadmin(ctx context.Context, userID uuid.UUID) (bool, error)
-	// IsSoleLiveTenantOwner reports whether this install has exactly one live
-	// organisation AND the given user is an owner of a live organisation.
-	// Both facts come from one statement, so they cannot be read a moment
-	// apart and cannot disagree.
-	IsSoleLiveTenantOwner(ctx context.Context, userID uuid.UUID) (bool, error)
-}
+// adminGateStore is the narrow read surface the admin gates need. An alias, not
+// a second interface: the fleet capability flag must be answered from the very
+// same reads, so there is one type and one implementation of it.
+type adminGateStore = admingate.Store
 
-// isSuperadminSQL is a targeted single-column read against users, which has no
-// RLS (see db/schema.sql), so it runs on the bare pool with no tenant context.
-const isSuperadminSQL = `SELECT is_superadmin FROM users WHERE id = $1`
-
-// soleLiveTenantOwnerSQL answers the whole of the GH #322 question in ONE
-// statement against ONE snapshot: is there exactly one organisation on this
-// install, and does this caller own one? Splitting it into two round trips
-// would let an organisation be created between them.
-//
-// If the count is 1 and the caller owns some live organisation, then the
-// organisation they own IS that one; no third read is needed to tie them
-// together.
-//
-// role = 'owner' is exact, not a ladder: memberships.role is constrained to
-// ('owner', 'admin', 'operator', 'viewer') by memberships_role_check, and
-// admin, operator and viewer are all refused here. Being a member of the only
-// organisation is not enough.
-//
-// "live" means deleted_at IS NULL, matching every other tenant-resolving read
-// in this repo (db/query/tenants.sql ListOrgsForUser and GetTenantForUser,
-// db/query/memberships.sql ListMembershipsForUser, db/query/api_keys.sql
-// GetAPIKeyByPrefix, db/query/site_shares.sql, db/query/client_members.sql,
-// all GH #152). The reasoning for counting it this way rather than counting
-// every row:
-//
-//   - A soft-deleted organisation cannot spend anything. Its members cannot
-//     switch into it, its API keys stop resolving, and every read path already
-//     hides it, so there is no principal able to act as that tenant and
-//     therefore no budget of its own to protect. The gate exists to stop one
-//     tenant spending another tenant's share; a tenant nobody can act as has
-//     no share.
-//   - Counting soft-deleted rows would refuse a legitimate single-tenant
-//     install for the whole grace window, and then indefinitely on any install
-//     where the purge worker is not running, on the strength of an
-//     organisation that is invisible everywhere else in the product.
-//   - Restoring it closes the path again immediately. RestoreTenant clears
-//     deleted_at, the count is read fresh on the next request, and this gate
-//     returns to refusing. There is nothing cached to invalidate.
-const soleLiveTenantOwnerSQL = `
-SELECT (SELECT count(*) FROM tenants WHERE deleted_at IS NULL) = 1
-   AND EXISTS (
-           SELECT 1
-           FROM memberships m
-           JOIN tenants t ON t.id = m.tenant_id
-           WHERE m.user_id = $1
-             AND m.role = 'owner'
-             AND t.deleted_at IS NULL
-       )`
-
-// poolGateStore is the production adminGateStore, reading Postgres directly.
-type poolGateStore struct{ pool *db.Pool }
-
-func newPoolGateStore(pool *db.Pool) poolGateStore { return poolGateStore{pool: pool} }
-
-func (s poolGateStore) IsSuperadmin(ctx context.Context, userID uuid.UUID) (bool, error) {
-	var isSA bool
-	if err := s.pool.QueryRow(ctx, isSuperadminSQL, userID).Scan(&isSA); err != nil {
-		return false, err
-	}
-	return isSA, nil
-}
-
-// IsSoleLiveTenantOwner runs soleLiveTenantOwnerSQL under InUserTx. That is
-// required, not incidental: memberships is under FORCE RLS and the only policy
-// that lets a principal read its OWN membership rows across tenants is
-// memberships_self_read, which keys on the app.user_id GUC that InUserTx sets.
-// On the bare pool the EXISTS would silently see zero rows and the gate would
-// refuse everyone. tenants carries no RLS, so the count sees every row.
-func (s poolGateStore) IsSoleLiveTenantOwner(ctx context.Context, userID uuid.UUID) (bool, error) {
-	var allowed bool
-	err := s.pool.InUserTx(ctx, userID, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, soleLiveTenantOwnerSQL, userID).Scan(&allowed)
-	})
-	if err != nil {
-		return false, err
-	}
-	return allowed, nil
-}
+// newPoolGateStore builds the production store (Postgres reads, see
+// admingate.PoolStore for the SQL and for why the membership half must run
+// inside a user transaction).
+func newPoolGateStore(pool *db.Pool) adminGateStore { return admingate.NewPoolStore(pool) }
 
 // denyAdminGate is the ONE refusal both gates use. The code and the message are
 // byte-identical on every path, including the widened one, so a caller cannot
@@ -153,54 +75,13 @@ func requireSuperadmin(store adminGateStore) gin.HandlerFunc {
 }
 
 // requireSuperadminOrSoleTenantOwner gates POST /admin/agent-mirror/check, and
-// nothing else on this install. It admits:
-//
-//	users.is_superadmin = true
-//	OR the caller is an owner of the only live organisation on this install.
-//
-// Why the second arm exists (GH #322). The superadmin gate on this route is
-// there so that one tenant cannot spend another tenant's share of the install's
-// shared, unauthenticated upstream request budget. On an install with exactly
-// one organisation there is no other tenant for that to protect, and what is
-// left is the mechanics without the reason: set WPMGR_SUPERADMIN_EMAILS,
-// restart, then discover that the seeder is additive only and never demotes, so
-// getting back out means a manual UPDATE against users and another restart.
-// That is a lot of platform-operator ceremony for someone checking whether
-// their own fleet's agent reference is current.
-//
-// THE PROPERTY THAT MUST NOT BE LOST: the owner NEVER becomes a superadmin
-// under this. No env var, no restart, no is_superadmin flag written anywhere,
-// and no Sites-page redirect (the web app's isSuperadminAllowedPath guard in
-// routes/_authed.tsx redirects superadmins AWAY from tenant pages, which is
-// exactly why this action could not live beside the Agent column before). This
-// admits one request on one route and confers nothing else. A second
-// organisation appearing on the install closes the path again on the very next
-// request, with no migration and nothing to clean up, because the count is read
-// at request time and is never cached.
-//
-// Fail closed: an error reading either fact is a refusal, never an allow.
+// nothing else on this install. The whole of the admission rule, including the
+// principal-type check, the fail-closed behaviour and the reason the widened
+// arm exists at all, is admingate.CanRunAgentMirrorCheck's; this middleware
+// only maps false to the standard refusal.
 func requireSuperadminOrSoleTenantOwner(store adminGateStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		p, ok := domain.PrincipalFromContext(c.Request.Context())
-		if !ok || p.Type != domain.PrincipalUser {
-			// An API-key principal is refused even when the key belongs to the
-			// owner of the only organisation. This is an install-level action
-			// against a shared upstream budget and the audit record wants a
-			// human, which is the same reason requireSuperadmin refuses one.
-			denyAdminGate(c)
-			return
-		}
-		isSA, err := store.IsSuperadmin(c.Request.Context(), p.UserID)
-		if err != nil {
-			denyAdminGate(c)
-			return
-		}
-		if isSA {
-			c.Next()
-			return
-		}
-		allowed, err := store.IsSoleLiveTenantOwner(c.Request.Context(), p.UserID)
-		if err != nil || !allowed {
+		if !admingate.CanRunAgentMirrorCheck(c.Request.Context(), store) {
 			denyAdminGate(c)
 			return
 		}

--- a/apps/api/internal/admingate/gate.go
+++ b/apps/api/internal/admingate/gate.go
@@ -1,0 +1,191 @@
+// Package admingate holds the ONE definition of who may run an install-level
+// agent-mirror check, plus the narrow database reads that decision needs.
+//
+// Why this is its own package (GH #322).
+//
+// The decision is asked in two places that live in different packages and
+// cannot import each other cleanly:
+//
+//	internal/admin        the ROUTE GATE on POST /api/v1/admin/agent-mirror/check.
+//	                      Answers "may this request proceed" and returns 403 if not.
+//	internal/agentrelease the CAPABILITY FLAG agent_mirror.can_check_now on
+//	                      GET /api/v1/fleet/agents. Answers "should the dashboard
+//	                      show this viewer a Check now button".
+//
+// Those two answers MUST be the same answer. If they are computed separately
+// they can drift, and every way they can drift is a bug an operator sees: a
+// button that always 403s, or a permission nobody is ever offered (which is
+// precisely the state GH #322 was left in after 0.61.123 widened the gate with
+// no button behind it). So the decision is written once, here, and both callers
+// call it. Neither copies the SQL and neither re-derives the rule.
+//
+// Nothing in this package is cached. See Store's doc for why that matters.
+package admingate
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// Store is the narrow read surface the decision needs. Both reads happen at
+// request time on every request; neither is cached and neither may be served
+// from a boot snapshot. A tenant count that is stale in the permissive
+// direction is a cross-tenant authorisation hole, so the decision pays one
+// small indexed read rather than trusting a remembered answer.
+type Store interface {
+	// IsSuperadmin reports users.is_superadmin for the given user.
+	IsSuperadmin(ctx context.Context, userID uuid.UUID) (bool, error)
+	// IsSoleLiveTenantOwner reports whether this install has exactly one live
+	// organisation AND the given user is an owner of a live organisation.
+	// Both facts come from one statement, so they cannot be read a moment
+	// apart and cannot disagree.
+	IsSoleLiveTenantOwner(ctx context.Context, userID uuid.UUID) (bool, error)
+}
+
+// isSuperadminSQL is a targeted single-column read against users, which has no
+// RLS (see db/schema.sql), so it runs on the bare pool with no tenant context.
+const isSuperadminSQL = `SELECT is_superadmin FROM users WHERE id = $1`
+
+// soleLiveTenantOwnerSQL answers the whole of the GH #322 question in ONE
+// statement against ONE snapshot: is there exactly one organisation on this
+// install, and does this caller own one? Splitting it into two round trips
+// would let an organisation be created between them.
+//
+// If the count is 1 and the caller owns some live organisation, then the
+// organisation they own IS that one; no third read is needed to tie them
+// together.
+//
+// role = 'owner' is exact, not a ladder: memberships.role is constrained to
+// ('owner', 'admin', 'operator', 'viewer') by memberships_role_check, and
+// admin, operator and viewer are all refused here. Being a member of the only
+// organisation is not enough.
+//
+// "live" means deleted_at IS NULL, matching every other tenant-resolving read
+// in this repo (db/query/tenants.sql ListOrgsForUser and GetTenantForUser,
+// db/query/memberships.sql ListMembershipsForUser, db/query/api_keys.sql
+// GetAPIKeyByPrefix, db/query/site_shares.sql, db/query/client_members.sql,
+// all GH #152). The reasoning for counting it this way rather than counting
+// every row:
+//
+//   - A soft-deleted organisation cannot spend anything. Its members cannot
+//     switch into it, its API keys stop resolving, and every read path already
+//     hides it, so there is no principal able to act as that tenant and
+//     therefore no budget of its own to protect. The gate exists to stop one
+//     tenant spending another tenant's share; a tenant nobody can act as has
+//     no share.
+//   - Counting soft-deleted rows would refuse a legitimate single-tenant
+//     install for the whole grace window, and then indefinitely on any install
+//     where the purge worker is not running, on the strength of an
+//     organisation that is invisible everywhere else in the product.
+//   - Restoring it closes the path again immediately. RestoreTenant clears
+//     deleted_at, the count is read fresh on the next request, and this
+//     decision returns to refusing. There is nothing cached to invalidate.
+const soleLiveTenantOwnerSQL = `
+SELECT (SELECT count(*) FROM tenants WHERE deleted_at IS NULL) = 1
+   AND EXISTS (
+           SELECT 1
+           FROM memberships m
+           JOIN tenants t ON t.id = m.tenant_id
+           WHERE m.user_id = $1
+             AND m.role = 'owner'
+             AND t.deleted_at IS NULL
+       )`
+
+// PoolStore is the production Store, reading Postgres directly.
+type PoolStore struct{ pool *db.Pool }
+
+// NewPoolStore builds the production Store over the given pool.
+func NewPoolStore(pool *db.Pool) PoolStore { return PoolStore{pool: pool} }
+
+func (s PoolStore) IsSuperadmin(ctx context.Context, userID uuid.UUID) (bool, error) {
+	var isSA bool
+	if err := s.pool.QueryRow(ctx, isSuperadminSQL, userID).Scan(&isSA); err != nil {
+		return false, err
+	}
+	return isSA, nil
+}
+
+// IsSoleLiveTenantOwner runs soleLiveTenantOwnerSQL under InUserTx. That is
+// required, not incidental: memberships is under FORCE RLS and the only policy
+// that lets a principal read its OWN membership rows across tenants is
+// memberships_self_read, which keys on the app.user_id GUC that InUserTx sets.
+// On the bare pool the EXISTS would silently see zero rows and the answer would
+// be wrong in the REFUSING direction, which on the capability-flag caller means
+// a button that never appears for the one person GH #322 built it for. tenants
+// carries no RLS, so the count sees every row.
+func (s PoolStore) IsSoleLiveTenantOwner(ctx context.Context, userID uuid.UUID) (bool, error) {
+	var allowed bool
+	err := s.pool.InUserTx(ctx, userID, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, soleLiveTenantOwnerSQL, userID).Scan(&allowed)
+	})
+	if err != nil {
+		return false, err
+	}
+	return allowed, nil
+}
+
+// CanRunAgentMirrorCheck is THE decision: may the principal carried on ctx
+// trigger an immediate upstream agent-release mirror check on this install?
+// It admits:
+//
+//	users.is_superadmin = true
+//	OR the caller is an owner of the only live organisation on this install.
+//
+// Why the second arm exists (GH #322). The superadmin gate on this action is
+// there so that one tenant cannot spend another tenant's share of the install's
+// shared, unauthenticated upstream request budget. On an install with exactly
+// one organisation there is no other tenant for that to protect, and what is
+// left is the mechanics without the reason: set WPMGR_SUPERADMIN_EMAILS,
+// restart, then discover that the seeder is additive only and never demotes, so
+// getting back out means a manual UPDATE against users and another restart.
+// That is a lot of platform-operator ceremony for someone checking whether
+// their own fleet's agent reference is current.
+//
+// THE PROPERTY THAT MUST NOT BE LOST: the owner NEVER becomes a superadmin
+// under this. No env var, no restart, no is_superadmin flag written anywhere,
+// and no Sites-page redirect (the web app's isSuperadminAllowedPath guard in
+// routes/_authed.tsx redirects superadmins AWAY from tenant pages, which is why
+// the admin console remains the superadmin's route to this action and why the
+// Sites-page button is only ever seen by the owner arm). This admits one
+// request on one route, and reveals one boolean on one dashboard field. A
+// second organisation appearing on the install closes the path again on the
+// very next request, with no migration and nothing to clean up, because the
+// count is read at request time and is never cached.
+//
+// An API-key principal is refused even when the key belongs to the owner of the
+// only organisation. This is an install-level action against a shared upstream
+// budget and the audit record wants a human. Neither store read is performed
+// for a non-user principal.
+//
+// Fail closed: an error reading either fact is a refusal, never an allow, and
+// a failed is_superadmin read does NOT fall through to the widened arm (that
+// would mean a broken users table silently downgraded this decision).
+//
+// store may be nil (the decision is not wired on this install), which is also
+// a refusal.
+func CanRunAgentMirrorCheck(ctx context.Context, store Store) bool {
+	if store == nil {
+		return false
+	}
+	p, ok := domain.PrincipalFromContext(ctx)
+	if !ok || p.Type != domain.PrincipalUser {
+		return false
+	}
+	isSA, err := store.IsSuperadmin(ctx, p.UserID)
+	if err != nil {
+		return false
+	}
+	if isSA {
+		return true
+	}
+	allowed, err := store.IsSoleLiveTenantOwner(ctx, p.UserID)
+	if err != nil {
+		return false
+	}
+	return allowed
+}

--- a/apps/api/internal/agentrelease/handler.go
+++ b/apps/api/internal/agentrelease/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/mosamlife/wpmgr/apps/api/internal/admingate"
 	"github.com/mosamlife/wpmgr/apps/api/internal/agentmirror"
 	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
@@ -41,6 +42,16 @@ type Handler struct {
 	// disabled mirroring would: status "disabled", every timestamp null.
 	mirrorReader  MirrorStateReader
 	mirrorEnabled bool
+
+	// mirrorCheckGate answers agent_mirror.can_check_now (GH #322), wired via
+	// SetMirrorCheckGate. It is the SAME store, read by the SAME function,
+	// that gates POST /api/v1/admin/agent-mirror/check itself
+	// (admingate.CanRunAgentMirrorCheck; internal/admin/gate.go mounts it as
+	// middleware). Nothing about the permission is recomputed here, so the
+	// button this field reveals can never be offered to a caller the route
+	// would refuse, nor hidden from one it would admit. Nil until wired,
+	// which reports false, the safe direction for a capability flag.
+	mirrorCheckGate admingate.Store
 }
 
 // MirrorStateReader reads the persisted upstream-mirror freshness sentinel
@@ -70,6 +81,18 @@ func NewHandler(svc *Service, selfUpdateEnabled bool) *Handler {
 func (h *Handler) SetMirror(reader MirrorStateReader, enabled bool) {
 	h.mirrorReader = reader
 	h.mirrorEnabled = enabled
+}
+
+// SetMirrorCheckGate wires the permission behind agent_mirror.can_check_now
+// (GH #322). Called once at boot with the SAME admingate.Store the admin
+// handler's route gate uses, so the dashboard's button and the endpoint's 403
+// are two readings of one decision rather than two decisions.
+//
+// Deliberately a separate setter from SetMirror: freshness and permission are
+// independent facts with independent wiring, and an install that has one
+// without the other must degrade rather than fail.
+func (h *Handler) SetMirrorCheckGate(store admingate.Store) {
+	h.mirrorCheckGate = store
 }
 
 // Register mounts the routes on the authenticated /api/v1 group.
@@ -151,11 +174,13 @@ type fleetAgentsResponseDTO struct {
 }
 
 // agentMirrorDTO reports the freshness of the UPSTREAM AGENT-RELEASE MIRROR
-// (internal/agentupstream), GH #322. This describes the MIRROR JOB, never
-// latest_version/reference_source directly: when reference_source is "fleet"
-// or "none", or when enabled is false, these timestamps say nothing about
-// latest_version and no freshness age should be presented to an operator as
-// the age of the reference, see each field's own doc and Status's doc.
+// (internal/agentupstream), GH #322, and one capability: whether the CALLER
+// may trigger a check on it right now (CanCheckNow). Everything else here
+// describes the MIRROR JOB, never latest_version/reference_source directly:
+// when reference_source is "fleet" or "none", or when enabled is false, these
+// timestamps say nothing about latest_version and no freshness age should be
+// presented to an operator as the age of the reference, see each field's own
+// doc and Status's doc.
 //
 // Always emitted, never omitted, for the same reason self_update_enabled is:
 // a caller must never have to treat "absent" and "off" as the same undefined
@@ -176,6 +201,21 @@ type agentMirrorDTO struct {
 	// (agentmirror.StalenessThreshold), emitted so nothing downstream has to
 	// duplicate the constant.
 	StaleAfterSeconds int `json:"stale_after_seconds"`
+
+	// CanCheckNow says whether THE CALLER OF THIS REQUEST may trigger a mirror
+	// check right now (GH #322). It is a property of the viewer, not of the
+	// install, so it is not cacheable across users and two people looking at
+	// the same fleet can legitimately get different values.
+	//
+	// False whenever Enabled is false: there is no run to trigger then, so no
+	// caller may trigger one regardless of who they are.
+	//
+	// Otherwise it is exactly admingate.CanRunAgentMirrorCheck, the same call
+	// that gates POST /api/v1/admin/agent-mirror/check. On a hosted,
+	// multi-tenant install that means false for every non-superadmin, and a
+	// superadmin never sees this response's dashboard anyway (the web app
+	// redirects them off tenant pages), so the admin console stays their route.
+	CanCheckNow bool `json:"can_check_now"`
 
 	// LastSuccessAt/LastSuccessOutcome/LastSuccessVersion: the LAST time this
 	// install CONFIRMED what upstream publishes. LastSuccessAt is the ONLY
@@ -274,9 +314,15 @@ func (h *Handler) buildAgentMirrorDTO(ctx context.Context) agentMirrorDTO {
 		StaleAfterSeconds: int(agentmirror.StalenessThreshold / time.Second),
 	}
 	if !h.mirrorEnabled {
+		// Returned with CanCheckNow still false, and WITHOUT consulting the
+		// gate store: a check cannot be run at all when the mirror is off, so
+		// there is nothing for a permission to permit, and the hosted service
+		// (where mirroring is off by default) pays no extra query for this
+		// field on any request.
 		dto.Status = string(agentmirror.StatusDisabled)
 		return dto
 	}
+	dto.CanCheckNow = admingate.CanRunAgentMirrorCheck(ctx, h.mirrorCheckGate)
 
 	var st agentmirror.State
 	if h.mirrorReader != nil {

--- a/apps/api/internal/agentrelease/mirror_capability_integration_test.go
+++ b/apps/api/internal/agentrelease/mirror_capability_integration_test.go
@@ -1,0 +1,274 @@
+package agentrelease_test
+
+// mirror_capability_integration_test.go: agent_mirror.can_check_now proven
+// against a REAL Postgres, through the REAL /fleet/agents route, with real
+// tenants, users and memberships (GH #322).
+//
+// mirror_capability_test.go proves the field is wired to the shared decision
+// and fails closed, but with a fake store "owner of one of two live
+// organisations" and "non-owner member of the only organisation" are the same
+// input. Only real rows can tell those apart, because the difference lives
+// inside admingate's SQL and inside the RLS policies it runs under. That is
+// what this file is for.
+//
+// The fleet ROLLUP is still faked here (a fake site lister and version reader):
+// this file is about the permission, and seeding the whole sites/agent
+// inventory would test something else. The gate store is the real
+// admingate.PoolStore over the real pool, connected as the non-superuser
+// wpmgr_app role, so the membership read genuinely depends on the
+// memberships_self_read policy and the app.user_id GUC that InUserTx sets. On
+// the bare pool that EXISTS silently sees nothing and every answer here would
+// be false: wrong in the refusing direction, which is a button that never
+// appears for the one person this was built for.
+//
+// Docker-backed (testcontainers), mirroring internal/admin/gate_integration_
+// test.go's harness. Skips when Docker is unavailable.
+//
+// AGAINST THE PRE-CHANGE CODE every case here fails, including the ones
+// expecting false: can_check_now did not exist on the wire, and
+// assertCanCheckNow refuses an absent field before it ever compares a value.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/admingate"
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentrelease"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+)
+
+// startCapabilityPostgres returns (appPool, adminPool). appPool connects as the
+// non-superuser wpmgr_app role, so RLS is actually in force.
+func startCapabilityPostgres(t *testing.T) (*db.Pool, *db.Pool) {
+	t.Helper()
+	ctx := context.Background()
+
+	container, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("wpmgr"),
+		tcpostgres.WithUsername("wpmgr"),
+		tcpostgres.WithPassword("wpmgr"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(90*time.Second),
+		),
+	)
+	if err != nil {
+		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	adminPool, err := db.Connect(ctx, adminDSN)
+	if err != nil {
+		t.Fatalf("connect admin: %v", err)
+	}
+	if err := adminPool.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	for _, stmt := range []string{
+		"ALTER ROLE wpmgr_app LOGIN PASSWORD 'app'",
+		"GRANT USAGE ON SCHEMA public TO wpmgr_app",
+		"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO wpmgr_app",
+		"REVOKE UPDATE, DELETE, TRUNCATE ON audit_log FROM wpmgr_app",
+	} {
+		if _, err := adminPool.Exec(ctx, stmt); err != nil {
+			t.Fatalf("provision app role (%q): %v", stmt, err)
+		}
+	}
+	t.Cleanup(adminPool.Close)
+
+	appDSN := strings.Replace(adminDSN, "wpmgr:wpmgr@", "wpmgr_app:app@", 1)
+	appPool, err := db.Connect(ctx, appDSN)
+	if err != nil {
+		t.Fatalf("connect app: %v", err)
+	}
+	t.Cleanup(appPool.Close)
+	return appPool, adminPool
+}
+
+// capabilitySeed is the per-case fixture helper. Every case starts from empty
+// tenants/users tables, because the decision's whole question is an
+// install-wide count and leftover rows from a previous case would answer it.
+type capabilitySeed struct {
+	t     *testing.T
+	admin *db.Pool
+	ctx   context.Context
+}
+
+func newCapabilitySeed(t *testing.T, adminPool *db.Pool) *capabilitySeed {
+	t.Helper()
+	ctx := context.Background()
+	for _, stmt := range []string{`DELETE FROM tenants`, `DELETE FROM users`} {
+		if _, err := adminPool.Exec(ctx, stmt); err != nil {
+			t.Fatalf("reset (%q): %v", stmt, err)
+		}
+	}
+	return &capabilitySeed{t: t, admin: adminPool, ctx: ctx}
+}
+
+func (s *capabilitySeed) tenant(name string) uuid.UUID {
+	s.t.Helper()
+	var id uuid.UUID
+	slug := name + "-" + uuid.NewString()[:8]
+	if err := s.admin.QueryRow(s.ctx, `INSERT INTO tenants (name, slug) VALUES ($1,$2) RETURNING id`,
+		name, slug).Scan(&id); err != nil {
+		s.t.Fatalf("seed tenant %s: %v", name, err)
+	}
+	return id
+}
+
+func (s *capabilitySeed) user(superadmin bool) uuid.UUID {
+	s.t.Helper()
+	var id uuid.UUID
+	email := "cap-" + uuid.NewString()[:8] + "@example.com"
+	if err := s.admin.QueryRow(s.ctx,
+		`INSERT INTO users (email, is_superadmin) VALUES ($1,$2) RETURNING id`,
+		email, superadmin).Scan(&id); err != nil {
+		s.t.Fatalf("seed user: %v", err)
+	}
+	return id
+}
+
+func (s *capabilitySeed) member(tenantID, userID uuid.UUID, role string) {
+	s.t.Helper()
+	if _, err := s.admin.Exec(s.ctx,
+		`INSERT INTO memberships (tenant_id, user_id, role) VALUES ($1,$2,$3)`,
+		tenantID, userID, role); err != nil {
+		s.t.Fatalf("seed membership (%s): %v", role, err)
+	}
+}
+
+func (s *capabilitySeed) softDelete(tenantID uuid.UUID) {
+	s.t.Helper()
+	if _, err := s.admin.Exec(s.ctx, `UPDATE tenants SET deleted_at = now() WHERE id = $1`, tenantID); err != nil {
+		s.t.Fatalf("soft-delete tenant: %v", err)
+	}
+}
+
+// realCapabilityEngine mounts the REAL /fleet/agents route with the REAL
+// admingate.PoolStore, so the answer comes from soleLiveTenantOwnerSQL under
+// InUserTx exactly as it does in production.
+func realCapabilityEngine(t *testing.T, pool *db.Pool, mirrorEnabled bool) *gin.Engine {
+	t.Helper()
+	h := agentrelease.NewHandler(
+		agentrelease.NewService(&fakeSiteLister{}, &fakeVersionReader{version: "0.61.120"}),
+		false,
+	)
+	h.SetMirror(&fakeMirrorStateReader{}, mirrorEnabled)
+	h.SetMirrorCheckGate(admingate.NewPoolStore(pool))
+	return newTestEngine(h)
+}
+
+// TestCanCheckNow_AgainstRealRows is the GH #322 capability decision table run
+// against real tenants, memberships and RLS, read off the real wire field.
+func TestCanCheckNow_AgainstRealRows(t *testing.T) {
+	pool, adminPool := startCapabilityPostgres(t)
+	engine := realCapabilityEngine(t, pool, true)
+
+	// T1: a superadmin gets the capability on any install, here one with two
+	// live organisations, which is the case where nobody else does.
+	t.Run("superadmin is true regardless of the organisation count", func(t *testing.T) {
+		s := newCapabilitySeed(t, adminPool)
+		first := s.tenant("first")
+		s.tenant("second")
+		sa := s.user(true)
+		assertCanCheckNow(t, engine, orgUser(first, sa), true, "superadmin on a two-organisation install")
+	})
+
+	// T2: the owner of the only live organisation. The whole point.
+	t.Run("owner of the only live organisation is true", func(t *testing.T) {
+		s := newCapabilitySeed(t, adminPool)
+		only := s.tenant("only")
+		owner := s.user(false)
+		s.member(only, owner, "owner")
+		assertCanCheckNow(t, engine, orgUser(only, owner), true, "owner of the sole organisation")
+	})
+
+	// T3: a SECOND live organisation exists, so there IS another tenant's
+	// budget to protect and the path closes. This is the hosted multi-tenant
+	// case, and the only thing separating it from T2 is the row count.
+	t.Run("owner is false once a second live organisation exists", func(t *testing.T) {
+		s := newCapabilitySeed(t, adminPool)
+		first := s.tenant("first")
+		owner := s.user(false)
+		s.member(first, owner, "owner")
+		assertCanCheckNow(t, engine, orgUser(first, owner), true,
+			"control: the same owner is true while theirs is the only organisation")
+
+		s.tenant("second")
+		assertCanCheckNow(t, engine, orgUser(first, owner), false,
+			"the same owner immediately after a second organisation appeared")
+	})
+
+	// T4: membership is not enough. Only role='owner' passes; the constraint
+	// vocabulary is ('owner','admin','operator','viewer'). This is the case a
+	// fake store cannot tell apart from T3.
+	t.Run("non-owner member of the only organisation is false", func(t *testing.T) {
+		for _, role := range []string{"admin", "operator", "viewer"} {
+			t.Run(role, func(t *testing.T) {
+				s := newCapabilitySeed(t, adminPool)
+				only := s.tenant("only")
+				s.member(only, s.user(false), "owner") // a real owner exists; the caller is not them
+				member := s.user(false)
+				s.member(only, member, role)
+				assertCanCheckNow(t, engine, orgUser(only, member), false,
+					role+" of the sole organisation")
+			})
+		}
+	})
+
+	// The soft-delete rule, which is what makes T3 a question about LIVE
+	// organisations rather than rows: an organisation inside its restore window
+	// has no principal able to act as it, so it has no budget share to protect.
+	t.Run("a soft-deleted second organisation does not close the path", func(t *testing.T) {
+		s := newCapabilitySeed(t, adminPool)
+		live := s.tenant("live")
+		gone := s.tenant("gone")
+		owner := s.user(false)
+		s.member(live, owner, "owner")
+		s.member(gone, owner, "owner")
+		assertCanCheckNow(t, engine, orgUser(live, owner), false,
+			"control: two live organisations")
+
+		s.softDelete(gone)
+		assertCanCheckNow(t, engine, orgUser(live, owner), true,
+			"one live and one soft-deleted organisation")
+	})
+
+	// T5, against real rows: with the mirror switched off nobody may trigger a
+	// run, so the capability is false even for the caller who would otherwise
+	// have it. Same rows, same principal, only WPMGR_UPDATE_AGENT_MIRROR_ENABLED
+	// differs.
+	t.Run("false for everyone when the mirror is disabled", func(t *testing.T) {
+		s := newCapabilitySeed(t, adminPool)
+		only := s.tenant("only")
+		owner := s.user(false)
+		s.member(only, owner, "owner")
+		sa := s.user(true)
+		s.member(only, sa, "viewer")
+
+		assertCanCheckNow(t, engine, orgUser(only, owner), true,
+			"control: sole owner with the mirror enabled")
+		assertCanCheckNow(t, engine, orgUser(only, sa), true,
+			"control: superadmin with the mirror enabled")
+
+		off := realCapabilityEngine(t, pool, false)
+		assertCanCheckNow(t, off, orgUser(only, owner), false,
+			"sole owner with the mirror disabled")
+		assertCanCheckNow(t, off, orgUser(only, sa), false,
+			"superadmin with the mirror disabled")
+	})
+}

--- a/apps/api/internal/agentrelease/mirror_capability_test.go
+++ b/apps/api/internal/agentrelease/mirror_capability_test.go
@@ -1,0 +1,290 @@
+package agentrelease_test
+
+// mirror_capability_test.go: agent_mirror.can_check_now on GET
+// /api/v1/fleet/agents (GH #322).
+//
+// The field is what the Sites page's Agent column popover renders its "Check
+// now" button from. It must be the SAME answer POST
+// /api/v1/admin/agent-mirror/check's own gate gives, which is why both go
+// through admingate.CanRunAgentMirrorCheck rather than each deciding for
+// itself. These tests drive the REAL route and read the REAL wire field.
+//
+// WHICH OF THESE FAIL AGAINST THE PRE-CHANGE CODE. All of them, including
+// every case that expects FALSE, and that is deliberate. Before this change
+// can_check_now did not exist on the wire at all, so a test that decoded into
+// a bool and asserted false would have passed against the missing field and
+// proven nothing. Every assertion below therefore checks the key is PRESENT in
+// the agent_mirror object first, and only then checks its value; the pre-change
+// response has no such key and fails at the presence check.
+//
+// WHAT THIS FILE CANNOT PROVE. With a fake store, "owner of one of two live
+// organisations" and "non-owner member of the only organisation" are the same
+// input (the store answers false) and differ only inside the SQL. That
+// distinction is proven against real rows in
+// mirror_capability_integration_test.go, and the SQL itself is shared with the
+// route gate, which exercises it again in internal/admin/gate_integration_test.go.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/admingate"
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentrelease"
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// errTestStore stands in for any database failure on either gate read.
+var errTestStore = errors.New("connection reset")
+
+// fakeCheckGate is an admingate.Store test double. The two facts are set
+// independently so a test can assert which one was read.
+type fakeCheckGate struct {
+	superadmin    bool
+	superadminErr error
+	soleOwner     bool
+	soleOwnerErr  error
+
+	superadminCalls int
+	soleOwnerCalls  int
+}
+
+func (f *fakeCheckGate) IsSuperadmin(context.Context, uuid.UUID) (bool, error) {
+	f.superadminCalls++
+	return f.superadmin, f.superadminErr
+}
+
+func (f *fakeCheckGate) IsSoleLiveTenantOwner(context.Context, uuid.UUID) (bool, error) {
+	f.soleOwnerCalls++
+	return f.soleOwner, f.soleOwnerErr
+}
+
+var _ admingate.Store = (*fakeCheckGate)(nil)
+
+// capabilityEngine mounts the REAL /fleet/agents route with a fake rollup
+// (this file is about the permission, not the version comparison), the mirror
+// switched on or off as asked, and the given gate store.
+func capabilityEngine(t *testing.T, mirrorEnabled bool, gate admingate.Store) (*gin.Engine, uuid.UUID) {
+	t.Helper()
+	tenantID := uuid.New()
+	repo := &fakeSiteLister{byTenant: map[uuid.UUID][]agentrelease.SiteAgentVersion{
+		tenantID: {{SiteID: uuid.New(), SiteName: "site", AgentVersion: "0.61.120"}},
+	}}
+	h := agentrelease.NewHandler(
+		agentrelease.NewService(repo, &fakeVersionReader{version: "0.61.120"}),
+		false,
+	)
+	h.SetMirror(&fakeMirrorStateReader{}, mirrorEnabled)
+	if gate != nil {
+		h.SetMirrorCheckGate(gate)
+	}
+	return newTestEngine(h), tenantID
+}
+
+// readCanCheckNow drives GET /fleet/agents as the given principal and returns
+// (value, present). present is false when the key is missing from the
+// agent_mirror object, which is exactly the pre-change response shape and must
+// fail every test here rather than silently read as false.
+func readCanCheckNow(t *testing.T, engine *gin.Engine, p domain.Principal) (value bool, present bool) {
+	t.Helper()
+	w := doRequest(engine, http.MethodGet, "/api/v1/fleet/agents", p)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /fleet/agents = %d; want 200, body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		AgentMirror map[string]json.RawMessage `json:"agent_mirror"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode fleet response: %v", err)
+	}
+	raw, ok := body.AgentMirror["can_check_now"]
+	if !ok {
+		return false, false
+	}
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatalf("can_check_now is not a boolean (%s): %v", raw, err)
+	}
+	return value, true
+}
+
+func orgUser(tenantID, userID uuid.UUID) domain.Principal {
+	return domain.Principal{
+		TenantID: tenantID,
+		Type:     domain.PrincipalUser,
+		UserID:   userID,
+		Scope:    "",
+		Role:     string(authz.RoleOwner),
+	}
+}
+
+// assertCanCheckNow is the single assertion helper. It insists the field is on
+// the wire before judging its value, so an absent field can never be mistaken
+// for a settled false.
+func assertCanCheckNow(t *testing.T, engine *gin.Engine, p domain.Principal, want bool, why string) {
+	t.Helper()
+	got, present := readCanCheckNow(t, engine, p)
+	if !present {
+		t.Fatalf("%s: agent_mirror has no can_check_now field at all; the capability must always be emitted so a client never has to treat absent and false as the same thing", why)
+	}
+	if got != want {
+		t.Fatalf("%s: can_check_now = %v, want %v", why, got, want)
+	}
+}
+
+// --- T1: superadmin ---------------------------------------------------------
+
+// TestCanCheckNow_SuperadminIsTrue. A superadmin may run the check on any
+// install, so the capability is true. The widened arm must not even be
+// consulted for them, matching the route gate's own short circuit.
+func TestCanCheckNow_SuperadminIsTrue(t *testing.T) {
+	gate := &fakeCheckGate{superadmin: true, soleOwner: false}
+	engine, tenantID := capabilityEngine(t, true, gate)
+
+	assertCanCheckNow(t, engine, orgUser(tenantID, uuid.New()), true, "superadmin")
+
+	if gate.soleOwnerCalls != 0 {
+		t.Fatalf("sole-owner lookup ran %d times for a superadmin; want 0", gate.soleOwnerCalls)
+	}
+}
+
+// --- T2: owner of the only live organisation --------------------------------
+
+// TestCanCheckNow_SoleLiveTenantOwnerIsTrue is the whole point of the change:
+// the person 0.61.123 granted the permission to must now be offered the button.
+func TestCanCheckNow_SoleLiveTenantOwnerIsTrue(t *testing.T) {
+	gate := &fakeCheckGate{superadmin: false, soleOwner: true}
+	engine, tenantID := capabilityEngine(t, true, gate)
+
+	assertCanCheckNow(t, engine, orgUser(tenantID, uuid.New()), true,
+		"owner of the only live organisation")
+
+	if gate.soleOwnerCalls != 1 {
+		t.Fatalf("sole-owner lookup ran %d times; want exactly 1 (read at request time, never cached)", gate.soleOwnerCalls)
+	}
+}
+
+// --- T3 + T4: refused when either half of the condition is false ------------
+
+// TestCanCheckNow_FalseWhenNotSoleOwner covers both the "owner of one of
+// several live organisations" (T3) and the "member but not owner" (T4) shapes
+// at this layer: whatever the reason, the shared decision answers false and no
+// button is offered. Which INPUTS produce which answer is a property of the SQL
+// and is proven against real rows in mirror_capability_integration_test.go.
+func TestCanCheckNow_FalseWhenNotSoleOwner(t *testing.T) {
+	gate := &fakeCheckGate{superadmin: false, soleOwner: false}
+	engine, tenantID := capabilityEngine(t, true, gate)
+
+	assertCanCheckNow(t, engine, orgUser(tenantID, uuid.New()), false,
+		"neither superadmin nor owner of a sole live organisation")
+}
+
+// --- T5: the mirror is off --------------------------------------------------
+
+// TestCanCheckNow_FalseWhenMirrorDisabled: with mirroring off there is no run
+// to trigger, so nobody may trigger one, however privileged. Asserted for BOTH
+// callers who would otherwise be true, so a future implementation that returns
+// the raw permission and forgets the enabled term fails here.
+//
+// It also pins the cheap path: the gate store must not be read at all when the
+// mirror is off, so the hosted service (mirroring disabled by default) pays no
+// extra query per fleet request for a field that can only be false.
+func TestCanCheckNow_FalseWhenMirrorDisabled(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		gate *fakeCheckGate
+	}{
+		{"superadmin", &fakeCheckGate{superadmin: true}},
+		{"sole live tenant owner", &fakeCheckGate{soleOwner: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			engine, tenantID := capabilityEngine(t, false, tc.gate)
+
+			assertCanCheckNow(t, engine, orgUser(tenantID, uuid.New()), false,
+				tc.name+" on an install with mirroring disabled")
+
+			if tc.gate.superadminCalls != 0 || tc.gate.soleOwnerCalls != 0 {
+				t.Fatalf("gate was consulted (%d superadmin, %d sole-owner) with the mirror disabled; want 0 and 0",
+					tc.gate.superadminCalls, tc.gate.soleOwnerCalls)
+			}
+		})
+	}
+}
+
+// --- containment ------------------------------------------------------------
+
+// TestCanCheckNow_APIKeyPrincipalIsFalse: an API key never gets the capability,
+// even on a single-organisation install where the key maps to that owner. This
+// matches the route gate exactly (it refuses API keys before either lookup), so
+// the flag cannot advertise something the endpoint would refuse.
+func TestCanCheckNow_APIKeyPrincipalIsFalse(t *testing.T) {
+	gate := &fakeCheckGate{superadmin: true, soleOwner: true} // both true: only the principal type may refuse
+	engine, tenantID := capabilityEngine(t, true, gate)
+
+	p := domain.Principal{
+		TenantID: tenantID,
+		Type:     domain.PrincipalAPIKey,
+		APIKeyID: uuid.New(),
+		UserID:   uuid.New(),
+		Scope:    "",
+		Role:     string(authz.RoleOwner),
+	}
+	assertCanCheckNow(t, engine, p, false, "api-key principal")
+
+	if gate.superadminCalls != 0 || gate.soleOwnerCalls != 0 {
+		t.Fatalf("gate was consulted (%d superadmin, %d sole-owner) for a non-user principal; want 0 and 0",
+			gate.superadminCalls, gate.soleOwnerCalls)
+	}
+}
+
+// TestCanCheckNow_FailsClosedOnStoreError: a database blip must hide the button,
+// never reveal it. Both reads are covered, and the is_superadmin failure must
+// NOT fall through to the widened arm.
+func TestCanCheckNow_FailsClosedOnStoreError(t *testing.T) {
+	t.Run("sole-owner read fails", func(t *testing.T) {
+		gate := &fakeCheckGate{soleOwner: true, soleOwnerErr: errTestStore}
+		engine, tenantID := capabilityEngine(t, true, gate)
+		assertCanCheckNow(t, engine, orgUser(tenantID, uuid.New()), false,
+			"the organisation-count read failed")
+	})
+
+	t.Run("is_superadmin read fails", func(t *testing.T) {
+		gate := &fakeCheckGate{superadminErr: errTestStore, soleOwner: true}
+		engine, tenantID := capabilityEngine(t, true, gate)
+		assertCanCheckNow(t, engine, orgUser(tenantID, uuid.New()), false,
+			"the is_superadmin read failed")
+		if gate.soleOwnerCalls != 0 {
+			t.Fatalf("consulted the widened arm after an is_superadmin read error; want 0 calls, got %d",
+				gate.soleOwnerCalls)
+		}
+	})
+}
+
+// TestCanCheckNow_FalseWhenGateNotWired: an install where the capability was
+// never wired reports false rather than panicking or omitting the field. The
+// freshness half of agent_mirror must keep working regardless, since the two
+// are independent facts with independent wiring.
+func TestCanCheckNow_FalseWhenGateNotWired(t *testing.T) {
+	engine, tenantID := capabilityEngine(t, true, nil)
+	assertCanCheckNow(t, engine, orgUser(tenantID, uuid.New()), false, "gate not wired")
+
+	w := doRequest(engine, http.MethodGet, "/api/v1/fleet/agents", orgUser(tenantID, uuid.New()))
+	var body struct {
+		AgentMirror struct {
+			Enabled bool   `json:"enabled"`
+			Status  string `json:"status"`
+		} `json:"agent_mirror"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.AgentMirror.Enabled || body.AgentMirror.Status == "" {
+		t.Fatalf("freshness degraded with the capability unwired: enabled=%v status=%q",
+			body.AgentMirror.Enabled, body.AgentMirror.Status)
+	}
+}

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -17291,6 +17291,10 @@ func (s *AgentMirrorStatus) encodeFields(e *jx.Encoder) {
 		e.Int32(s.StaleAfterSeconds)
 	}
 	{
+		e.FieldStart("can_check_now")
+		e.Bool(s.CanCheckNow)
+	}
+	{
 		e.FieldStart("last_success_at")
 		s.LastSuccessAt.Encode(e, json.EncodeDateTime)
 	}
@@ -17328,19 +17332,20 @@ func (s *AgentMirrorStatus) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfAgentMirrorStatus = [12]string{
+var jsonFieldsNameOfAgentMirrorStatus = [13]string{
 	0:  "enabled",
 	1:  "status",
 	2:  "stale_after_seconds",
-	3:  "last_success_at",
-	4:  "last_success_outcome",
-	5:  "last_success_version",
-	6:  "last_attempt_at",
-	7:  "last_attempt_outcome",
-	8:  "last_attempt_detail",
-	9:  "last_attempt_trigger",
-	10: "last_mirrored_at",
-	11: "last_mirrored_version",
+	3:  "can_check_now",
+	4:  "last_success_at",
+	5:  "last_success_outcome",
+	6:  "last_success_version",
+	7:  "last_attempt_at",
+	8:  "last_attempt_outcome",
+	9:  "last_attempt_detail",
+	10: "last_attempt_trigger",
+	11: "last_mirrored_at",
+	12: "last_mirrored_version",
 }
 
 // Decode decodes AgentMirrorStatus from json.
@@ -17386,8 +17391,20 @@ func (s *AgentMirrorStatus) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"stale_after_seconds\"")
 			}
-		case "last_success_at":
+		case "can_check_now":
 			requiredBitSet[0] |= 1 << 3
+			if err := func() error {
+				v, err := d.Bool()
+				s.CanCheckNow = bool(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"can_check_now\"")
+			}
+		case "last_success_at":
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				if err := s.LastSuccessAt.Decode(d, json.DecodeDateTime); err != nil {
 					return err
@@ -17397,7 +17414,7 @@ func (s *AgentMirrorStatus) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"last_success_at\"")
 			}
 		case "last_success_outcome":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				if err := s.LastSuccessOutcome.Decode(d); err != nil {
 					return err
@@ -17407,7 +17424,7 @@ func (s *AgentMirrorStatus) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"last_success_outcome\"")
 			}
 		case "last_success_version":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				if err := s.LastSuccessVersion.Decode(d); err != nil {
 					return err
@@ -17417,7 +17434,7 @@ func (s *AgentMirrorStatus) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"last_success_version\"")
 			}
 		case "last_attempt_at":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				if err := s.LastAttemptAt.Decode(d, json.DecodeDateTime); err != nil {
 					return err
@@ -17427,7 +17444,7 @@ func (s *AgentMirrorStatus) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"last_attempt_at\"")
 			}
 		case "last_attempt_outcome":
-			requiredBitSet[0] |= 1 << 7
+			requiredBitSet[1] |= 1 << 0
 			if err := func() error {
 				if err := s.LastAttemptOutcome.Decode(d); err != nil {
 					return err
@@ -17437,7 +17454,7 @@ func (s *AgentMirrorStatus) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"last_attempt_outcome\"")
 			}
 		case "last_attempt_detail":
-			requiredBitSet[1] |= 1 << 0
+			requiredBitSet[1] |= 1 << 1
 			if err := func() error {
 				if err := s.LastAttemptDetail.Decode(d); err != nil {
 					return err
@@ -17447,7 +17464,7 @@ func (s *AgentMirrorStatus) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"last_attempt_detail\"")
 			}
 		case "last_attempt_trigger":
-			requiredBitSet[1] |= 1 << 1
+			requiredBitSet[1] |= 1 << 2
 			if err := func() error {
 				if err := s.LastAttemptTrigger.Decode(d); err != nil {
 					return err
@@ -17457,7 +17474,7 @@ func (s *AgentMirrorStatus) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"last_attempt_trigger\"")
 			}
 		case "last_mirrored_at":
-			requiredBitSet[1] |= 1 << 2
+			requiredBitSet[1] |= 1 << 3
 			if err := func() error {
 				if err := s.LastMirroredAt.Decode(d, json.DecodeDateTime); err != nil {
 					return err
@@ -17467,7 +17484,7 @@ func (s *AgentMirrorStatus) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"last_mirrored_at\"")
 			}
 		case "last_mirrored_version":
-			requiredBitSet[1] |= 1 << 3
+			requiredBitSet[1] |= 1 << 4
 			if err := func() error {
 				if err := s.LastMirroredVersion.Decode(d); err != nil {
 					return err
@@ -17487,7 +17504,7 @@ func (s *AgentMirrorStatus) Decode(d *jx.Decoder) error {
 	var failures []validate.FieldError
 	for i, mask := range [2]uint8{
 		0b11111111,
-		0b00001111,
+		0b00011111,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -6634,12 +6634,17 @@ func (s *AgentMirrorCheckQueuedStatus) UnmarshalText(data []byte) error {
 
 // Freshness of the UPSTREAM AGENT-RELEASE MIRROR (internal/agentupstream,
 // WPMGR_UPDATE_AGENT_MIRROR_ENABLED), which on a self-hosted install is what keeps
-// agent-releases/latest.json, and therefore latest_version, up to date (GH #322).
-// This object describes the MIRROR JOB, never the reference version itself. When reference_source is
-// "fleet" or "none" there is no published reference, and these timestamps say nothing about
-// latest_version. When enabled is false there is no mirror at all: on the hosted service the release
-// pipeline writes the manifest directly, so every field here is null and no freshness age should be
-// shown to a user.
+// agent-releases/latest.json, and therefore latest_version, up to date (GH #322), together with one
+// capability: whether the CALLING VIEWER may trigger a check on that mirror right now
+// (can_check_now).
+// Every field except can_check_now describes the MIRROR JOB, never the reference version itself.
+// When reference_source is "fleet" or "none" there is no published reference, and these timestamps
+// say nothing about latest_version. When enabled is false there is no mirror at all: on the hosted
+// service the release pipeline writes the manifest directly, so every timestamp here is null, no
+// freshness age should be shown to a user, and can_check_now is false for everyone.
+// can_check_now is the one field that is a property of the CALLER rather than of the install, so it
+// is not cacheable across users: two people looking at the same fleet can legitimately receive
+// different values.
 // Ref: #/components/schemas/AgentMirrorStatus
 type AgentMirrorStatus struct {
 	// Whether this install runs the upstream mirror (WPMGR_UPDATE_AGENT_MIRROR_ENABLED). False on the
@@ -6661,6 +6666,22 @@ type AgentMirrorStatus struct {
 	// plus the interval" on restart rather than resuming a prior clock), so reaching it means at least
 	// two consecutive scheduled runs failed to confirm anything.
 	StaleAfterSeconds int32 `json:"stale_after_seconds"`
+	// Whether the CALLING VIEWER may trigger a mirror check on this install right now, i.e. whether POST
+	// /api/v1/admin/agent-mirror/check would admit this caller rather than answer 403. The dashboard
+	// renders its "Check now" action in the Sites page Agent column popover exactly when this is true,
+	// so an operator is never offered a button that refuses them, and the operator who may act is never
+	// left without one.
+	// The control plane computes this from the SAME decision the endpoint's own gate runs, not a second
+	// copy of the rule: superadmin (users.is_superadmin), OR the owner of the only live organisation on
+	// this install (GH #322, the single-tenant self-hosted case, where the multi-tenant protection the
+	// gate exists for has no other tenant to protect). An API-key principal is always false, since this
+	// is an install-level action against a shared upstream request budget and the audit record wants a
+	// human.
+	// False whenever enabled is false: no caller may trigger a run that does not exist. False for every
+	// non-superadmin on an install with more than one live organisation, which leaves the hosted,
+	// multi-tenant case exactly as it was. A second organisation appearing closes the path again on the
+	// very next request, because nothing about this answer is cached.
+	CanCheckNow bool `json:"can_check_now"`
 	// When this install last CONFIRMED what upstream publishes: the last attempt whose outcome was
 	// mirrored, current, or unchanged. This is the ONLY field an age may ever be rendered from. Null
 	// when it has never happened. Deliberately distinct from last_attempt_at: a run that failed ten
@@ -6708,6 +6729,11 @@ func (s *AgentMirrorStatus) GetStatus() AgentMirrorStatusStatus {
 // GetStaleAfterSeconds returns the value of StaleAfterSeconds.
 func (s *AgentMirrorStatus) GetStaleAfterSeconds() int32 {
 	return s.StaleAfterSeconds
+}
+
+// GetCanCheckNow returns the value of CanCheckNow.
+func (s *AgentMirrorStatus) GetCanCheckNow() bool {
+	return s.CanCheckNow
 }
 
 // GetLastSuccessAt returns the value of LastSuccessAt.
@@ -6768,6 +6794,11 @@ func (s *AgentMirrorStatus) SetStatus(val AgentMirrorStatusStatus) {
 // SetStaleAfterSeconds sets the value of StaleAfterSeconds.
 func (s *AgentMirrorStatus) SetStaleAfterSeconds(val int32) {
 	s.StaleAfterSeconds = val
+}
+
+// SetCanCheckNow sets the value of CanCheckNow.
+func (s *AgentMirrorStatus) SetCanCheckNow(val bool) {
+	s.CanCheckNow = val
 }
 
 // SetLastSuccessAt sets the value of LastSuccessAt.

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,30 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.124",
+    date: "2026-08-05",
+    summary:
+      "\"Check now\" for the agent release reference is now on the Sites page, under the freshness text, for the viewers who may actually use it. Hosted multi-organisation installs are unchanged.",
+    items: [
+      {
+        tag: "Added",
+        text: "\"Check now\" for the agent release reference is now in the Agent column popover on the Sites page, directly under the freshness text, where the reporter asked for it. Reading \"may be stale, last confirmed 14h ago\" is exactly the moment an operator wants to act, and until now acting meant leaving the page for the admin console. The previous release granted the permission to the owner of a single-organisation install but left the only button behind a console that same owner cannot open, so the feature was unreachable for the person it was built for.",
+      },
+      {
+        tag: "Added",
+        text: "The button appears only for a viewer who may actually use it, and the dashboard does not work that out for itself. The fleet agent response now carries the control plane's own answer for the asking viewer, computed by the same code that decides whether the endpoint would accept the request. There is one decision, so a button that always refuses and a permission nobody is offered are both impossible rather than merely unlikely.",
+      },
+      {
+        tag: "Added",
+        text: "Nothing appears on an install with more than one organisation, which is every hosted account: the answer is false there for everyone except a superadmin, and a superadmin is redirected away from the Sites page anyway, so the admin console remains their route to the same action. The answer is also false whenever release mirroring is switched off, since there is no run to trigger at all then.",
+      },
+      {
+        tag: "Added",
+        text: "The three outcomes read the same here as in the admin console, because both use the same code. Queued is a success, and neither \"a check is already running\" nor \"the mirror must wait before its next request\" is shown as an error: being skipped by the thirty minute spacing is the system working as designed. The button also does not claim the check has happened, because the control plane answers that a run was queued, not that anything was confirmed.",
+      },
+    ],
+  },
+  {
     version: "0.61.123",
     date: "2026-08-05",
     summary:

--- a/apps/web/src/features/admin/use-admin-agent-mirror.ts
+++ b/apps/web/src/features/admin/use-admin-agent-mirror.ts
@@ -4,8 +4,8 @@ import { checkAgentMirrorNow, type ApiError } from "@wpmgr/api";
 import { toast } from "@/components/toast";
 import { toError } from "@/features/auth/use-auth";
 
-// GH #322: superadmin, install-level manual trigger for the upstream
-// agent-release mirror.
+// GH #322: install-level manual trigger for the upstream agent-release
+// mirror.
 //
 // POST /api/v1/admin/agent-mirror/check is a generated SDK operation
 // (checkAgentMirrorNow, from @wpmgr/api), so the URL, the 202 body shape,
@@ -15,14 +15,30 @@ import { toError } from "@/features/auth/use-auth";
 // Deliberately install-level, not tenant-scoped (internal/admin/agent_
 // mirror.go: the mirror is ONE PER INSTALL, fetches one public GitHub
 // release, and spends this install's SHARED unauthenticated GitHub request
-// budget), so this hook lives here, next to the admin console page that
-// renders it (routes/_authed/admin/agent-mirror.tsx), not in
-// features/fleet (the tenant-scoped fleet rollup).
+// budget), so this hook lives under the same /admin prefix its endpoint does,
+// not in features/fleet (the tenant-scoped fleet rollup).
+//
+// IT IS NO LONGER SUPERADMIN ONLY, and it no longer has one renderer. The
+// endpoint also admits the owner of the only live organisation on an install
+// (the single-tenant self-hosted case, where the multi-tenant protection the
+// gate exists for has no other tenant to protect), so this hook is shared by:
+//
+//	routes/_authed/admin/agent-mirror.tsx       the admin console page
+//	features/sites/agent-column-header.tsx      the Sites page Agent column popover
+//
+// Shared rather than reimplemented on purpose. The three ordinary outcomes
+// below are the whole vocabulary of this action, and two surfaces answering
+// the same 409 differently would be a worse bug than either answer.
 //
 // None of the three ordinary outcomes (queued / already running / rate
 // limited) are failures. In particular a 429 must NEVER read as an error:
 // it is the mirror truthfully reporting that nothing was checked yet, which
 // is the entire point of GH #322.
+//
+// Neither renderer decides for itself who may click. The Sites popover reads
+// FleetAgentVersions.agent_mirror.can_check_now, which the control plane
+// computes with the same code that gates the endpoint, so the button and the
+// 403 can never disagree.
 
 export type CheckAgentMirrorOutcome =
   | { kind: "queued"; message: string }

--- a/apps/web/src/features/fleet/use-fleet-agents.ts
+++ b/apps/web/src/features/fleet/use-fleet-agents.ts
@@ -2,11 +2,18 @@
 // Endpoints: GET /api/v1/agent/latest, GET /api/v1/fleet/agents.
 //
 // The manual "check now" trigger for the upstream agent-release mirror
-// (GH #322, POST /api/v1/admin/agent-mirror/check) is a superadmin,
-// install-level admin-console action, not a tenant-scoped fleet read; its
-// hook lives in features/admin/use-admin-agent-mirror.ts, alongside the
-// admin console page that renders it
-// (routes/_authed/admin/agent-mirror.tsx).
+// (GH #322, POST /api/v1/admin/agent-mirror/check) is an install-level
+// action, not a tenant-scoped fleet read, so its hook lives in
+// features/admin/use-admin-agent-mirror.ts next to the endpoint's own admin
+// prefix. It now has two renderers: the admin console page
+// (routes/_authed/admin/agent-mirror.tsx) and the Sites page Agent column
+// popover (features/sites/agent-column-header.tsx).
+//
+// WHO SEES THE TRIGGER IS DECIDED BY THIS QUERY'S OWN RESPONSE, not by a
+// role check in the browser: FleetAgentVersions.agent_mirror.can_check_now is
+// the control plane's answer for the calling viewer, computed by the same
+// code that gates the endpoint. Reading it from here rather than inferring it
+// locally is what keeps the button and the 403 in agreement.
 
 import {
   useQuery,

--- a/apps/web/src/features/sites/agent-column-header.test.tsx
+++ b/apps/web/src/features/sites/agent-column-header.test.tsx
@@ -1,14 +1,48 @@
-import { describe, it, expect } from "vitest";
-import { fireEvent, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import type { AgentMirrorStatus } from "@wpmgr/api";
 
 import { renderWithProviders } from "@/test/render";
+
+// The popover's "Check now" action calls the SHARED mutation hook, so these
+// tests mock the generated SDK operation and the toast surface rather than the
+// hook: what must be proven is that this surface produces the SAME outcome
+// vocabulary as the admin console page, not that it calls something named
+// correctly.
+const { checkAgentMirrorNowMock, toastSuccess, toastError, toastInfo } =
+  vi.hoisted(() => ({
+    checkAgentMirrorNowMock: vi.fn(),
+    toastSuccess: vi.fn(),
+    toastError: vi.fn(),
+    toastInfo: vi.fn(),
+  }));
+
+vi.mock("@wpmgr/api", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  checkAgentMirrorNow: checkAgentMirrorNowMock,
+}));
+
+vi.mock("@/components/toast", () => ({
+  toast: {
+    success: toastSuccess,
+    error: toastError,
+    info: toastInfo,
+    warning: vi.fn(),
+  },
+}));
 
 import {
   AgentColumnFleetNote,
   AGENT_FLEET_NOTE_LABEL,
   AGENT_FLEET_NOTE_TITLE,
 } from "./agent-column-header";
+
+beforeEach(() => {
+  checkAgentMirrorNowMock.mockReset();
+  toastSuccess.mockReset();
+  toastError.mockReset();
+  toastInfo.mockReset();
+});
 
 // GH #255 follow-up. The "in fleet" qualifier used to be appended to every
 // row's Agent chip, which was honest but wrapped the cell onto two lines and
@@ -25,12 +59,15 @@ import {
 // fleet-derived reference AND a stale mirror), so the tests below cover
 // them both together and separately.
 //
-// The manual "Check now" trigger is NOT part of this component: it is a
-// superadmin, install-level admin-console action
-// (routes/_authed/admin/agent-mirror.tsx), not a Sites-page affordance (a
-// superadmin cannot open the tenant-scoped Sites page at all, see
-// routes/_authed.tsx's isSuperadminAllowedPath guard), so this popover is
-// informational only.
+// The manual "Check now" trigger IS now part of this component, but only for a
+// viewer the control plane says may use it. This file used to assert the
+// opposite, on the grounds that the action was superadmin only while a
+// superadmin cannot open the Sites page at all; the endpoint has since been
+// widened to the owner of the only live organisation on an install, and an
+// owner is never redirected off this page. What must not be lost is that the
+// visibility is the SERVER's answer (agent_mirror.can_check_now) and never a
+// role guessed in the browser, so the button cannot appear for someone the
+// endpoint would answer 403.
 
 const hoursAgo = (h: number) => new Date(Date.now() - h * 3_600_000).toISOString();
 
@@ -39,6 +76,7 @@ function mirror(overrides: Partial<Record<string, unknown>> = {}): AgentMirrorSt
     enabled: true,
     status: "ok",
     stale_after_seconds: 46_800,
+    can_check_now: false,
     last_success_at: hoursAgo(3),
     last_success_outcome: "unchanged",
     last_success_version: "0.61.112",
@@ -167,17 +205,217 @@ describe("AgentColumnFleetNote", () => {
     expect(trigger).toBeInTheDocument();
   });
 
-  it("never renders a Check now button: the manual trigger lives in the admin console, not on this page", () => {
+});
+
+// ---------------------------------------------------------------------------
+// GH #322 follow-up: the "Check now" action
+// ---------------------------------------------------------------------------
+//
+// WHICH OF THESE FAIL AGAINST THE PRE-CHANGE CODE:
+//
+//	"renders a Check now action when can_check_now is true"   FAILS (no button existed)
+//	"stale, warn-tier state still offers the action"          FAILS (no button existed)
+//	"clicking it queues a check ..."                          FAILS (nothing to click)
+//	"409 ... INFO" / "429 ... INFO" / "403 ... error"         FAIL (nothing to click)
+//	the three ABSENCE cases                                   pass either way, and are
+//	  kept precisely because they are the containment half: they are what would
+//	  catch the button being shown to someone the endpoint refuses. The
+//	  pre-change file asserted the FIRST of them unconditionally.
+
+const CHECK_NOW = { name: /check now/i } as const;
+
+/** Opens the popover, whatever tier its trigger is currently in. */
+function openPopover() {
+  fireEvent.click(
+    screen.getByRole("button", {
+      name: new RegExp(`^${AGENT_FLEET_NOTE_LABEL}`),
+    }),
+  );
+}
+
+describe("AgentColumnFleetNote - the Check now action", () => {
+  // --- T6: present only when the server says so -----------------------------
+
+  it("renders a Check now action when can_check_now is true", () => {
     renderWithProviders(
       <AgentColumnFleetNote
         referenceSource="published"
-        referenceCheck={mirror({ status: "stale" })}
+        referenceCheck={mirror({ can_check_now: true })}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /Reference checked/i }));
+    openPopover();
+    expect(screen.getByRole("button", CHECK_NOW)).toBeInTheDocument();
+  });
+
+  it("renders no Check now action when can_check_now is false", () => {
+    renderWithProviders(
+      <AgentColumnFleetNote
+        referenceSource="published"
+        referenceCheck={mirror({ can_check_now: false })}
+      />,
+    );
+    openPopover();
+    expect(screen.queryByRole("button", CHECK_NOW)).not.toBeInTheDocument();
+  });
+
+  // An install running an older control plane sends no can_check_now at all.
+  // Absent must read as "not permitted", never as a button whose endpoint
+  // would refuse it.
+  it("renders no Check now action when the field is missing entirely", () => {
+    const legacy = mirror();
+    delete (legacy as unknown as Record<string, unknown>).can_check_now;
+    renderWithProviders(
+      <AgentColumnFleetNote referenceSource="published" referenceCheck={legacy} />,
+    );
+    openPopover();
+    expect(screen.queryByRole("button", CHECK_NOW)).not.toBeInTheDocument();
+  });
+
+  // The mirror being off is the server's business (it forces can_check_now
+  // false), but this pins the client half: a disabled mirror with a published
+  // reference renders nothing at all, so there is no popover to put a button
+  // in even if the flag were wrong.
+  it("renders nothing at all, button included, when the mirror is disabled and the reference is published", () => {
+    const { container } = renderWithProviders(
+      <AgentColumnFleetNote
+        referenceSource="published"
+        referenceCheck={mirror({ enabled: false, status: "disabled", can_check_now: false })}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // The reporter's exact scenario: the moment an operator reads "may be stale"
+  // is the moment they want to act, so the action must survive the warn tier.
+  it("offers the action in the stale, warn-tier state the reporter described", () => {
+    renderWithProviders(
+      <AgentColumnFleetNote
+        referenceSource="published"
+        referenceCheck={mirror({ status: "stale", can_check_now: true })}
+      />,
+    );
+    openPopover();
+    expect(screen.getByText(/^Reference checked /)).toBeInTheDocument();
+    expect(screen.getByRole("button", CHECK_NOW)).toBeInTheDocument();
+  });
+
+  // --- T7: the outcome vocabulary is the admin console's, not a second one --
+
+  it("clicking it queues a check and reports the control plane's own message", async () => {
+    checkAgentMirrorNowMock.mockResolvedValue({
+      data: {
+        status: "queued",
+        queued_at: "2026-08-05T10:00:00Z",
+        message: "A mirror run has been queued.",
+      },
+      error: undefined,
+      response: { status: 202 },
+    });
+    renderWithProviders(
+      <AgentColumnFleetNote
+        referenceSource="published"
+        referenceCheck={mirror({ can_check_now: true })}
+      />,
+    );
+    openPopover();
+    fireEvent.click(screen.getByRole("button", CHECK_NOW));
+
+    await waitFor(() =>
+      expect(toastSuccess).toHaveBeenCalledWith("A mirror run has been queued."),
+    );
+    expect(checkAgentMirrorNowMock).toHaveBeenCalledTimes(1);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("409 already running is an INFO toast here too, never an error", async () => {
+    checkAgentMirrorNowMock.mockResolvedValue({
+      data: undefined,
+      error: {
+        code: "agent_mirror_check_in_flight",
+        message: "a mirror check is already queued or running",
+      },
+      response: { status: 409 },
+    });
+    renderWithProviders(
+      <AgentColumnFleetNote
+        referenceSource="published"
+        referenceCheck={mirror({ can_check_now: true })}
+      />,
+    );
+    openPopover();
+    fireEvent.click(screen.getByRole("button", CHECK_NOW));
+
+    await waitFor(() =>
+      expect(toastInfo).toHaveBeenCalledWith(
+        "A check is already running. Its result will appear on the fleet agent view when it finishes.",
+      ),
+    );
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("429 rate limited is an INFO toast here too: being skipped by the 30 minute spacing is the system working", async () => {
+    checkAgentMirrorNowMock.mockResolvedValue({
+      data: undefined,
+      error: {
+        code: "agent_mirror_rate_limited",
+        message: "the upstream release was last requested 12m ago",
+        details: { retry_after_seconds: 480 },
+      },
+      response: { status: 429 },
+    });
+    renderWithProviders(
+      <AgentColumnFleetNote
+        referenceSource="published"
+        referenceCheck={mirror({ status: "stale", can_check_now: true })}
+      />,
+    );
+    openPopover();
+    fireEvent.click(screen.getByRole("button", CHECK_NOW));
+
+    await waitFor(() =>
+      expect(toastInfo).toHaveBeenCalledWith(
+        "Not checked. The mirror must wait 8 minutes before its next upstream request. The scheduled check still runs.",
+      ),
+    );
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  // The one case that IS an error, so the three above are not merely "this
+  // surface never shows an error toast".
+  it("a 403 is a real error toast, so the INFO cases above are a distinction and not a blanket rule", async () => {
+    checkAgentMirrorNowMock.mockResolvedValue({
+      data: undefined,
+      error: { code: "superadmin_required", message: "superadmin access required" },
+      response: { status: 403 },
+    });
+    renderWithProviders(
+      <AgentColumnFleetNote
+        referenceSource="published"
+        referenceCheck={mirror({ can_check_now: true })}
+      />,
+    );
+    openPopover();
+    fireEvent.click(screen.getByRole("button", CHECK_NOW));
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith("superadmin access required"),
+    );
+    expect(toastInfo).not.toHaveBeenCalled();
+  });
+
+  // The action must not promise a result it has not got: the endpoint answers
+  // 202 queued, and the run has not happened yet.
+  it("says the result appears on refresh rather than implying the check already ran", () => {
+    renderWithProviders(
+      <AgentColumnFleetNote
+        referenceSource="published"
+        referenceCheck={mirror({ can_check_now: true })}
+      />,
+    );
+    openPopover();
     expect(
-      screen.queryByRole("button", { name: /check now/i }),
-    ).not.toBeInTheDocument();
+      screen.getByText(/result appears here once this view refreshes/i),
+    ).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/features/sites/agent-column-header.tsx
+++ b/apps/web/src/features/sites/agent-column-header.tsx
@@ -1,11 +1,21 @@
-import { AlertTriangle, Info } from "lucide-react";
+import { AlertTriangle, Info, RefreshCw } from "lucide-react";
 import type { AgentMirrorStatus, FleetAgentVersions } from "@wpmgr/api";
 
+import { Button } from "@/components/ui/button";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+// The manual trigger's mutation, reused verbatim from the admin console page
+// that already renders it (routes/_authed/admin/agent-mirror.tsx). It lives in
+// features/admin because the endpoint it calls is POST /api/v1/admin/agent-
+// mirror/check, and it is shared rather than reimplemented so that the two
+// surfaces cannot drift into two vocabularies for the same three outcomes: 202
+// queued is a success toast, 409 already running and 429 rate limited are INFO
+// (being skipped by the 30 minute spacing is the system working as designed,
+// not a failure), and everything else is a real error.
+import { useCheckAgentMirrorNow } from "@/features/admin/use-admin-agent-mirror";
 import { cn } from "@/lib/utils";
 
 import { describeReferenceCheck } from "./agent-reference-check";
@@ -39,13 +49,29 @@ export const AGENT_FLEET_NOTE_LABEL = "About the Agent column comparison";
 // where that signal lives: see agent-reference-check.ts for the exact copy
 // per state.
 //
-// This is an INFORMATION surface only. Triggering an immediate mirror check
-// is a superadmin, install-level operation (POST /api/v1/admin/agent-mirror
-// /check), and lives in the admin console
-// (routes/_authed/admin/agent-mirror.tsx), not here: a superadmin cannot
-// open the tenant-scoped Sites page at all (see routes/_authed.tsx's
-// isSuperadminAllowedPath guard), so a trigger on this page would be
-// reachable by no one who could ever use it.
+// It also carries the manual "Check now" trigger, but only for a viewer the
+// control plane says may actually use it (agent_mirror.can_check_now).
+//
+// This popover used to be an information surface only, and the reason given
+// here was that triggering a check is a superadmin operation while a
+// superadmin cannot open the tenant-scoped Sites page at all (see
+// routes/_authed.tsx's isSuperadminAllowedPath guard), so a button here would
+// have been reachable by nobody who could use it. THAT REASONING NO LONGER
+// HOLDS for the case it now serves. The endpoint admits the owner of the only
+// live organisation on an install as well as a superadmin, and an ordinary
+// owner is never redirected off this page. The reporter asked for it exactly
+// here, and they are right: reading "may be stale, last confirmed 14h ago" is
+// the moment an operator wants to act, so the action sits with the
+// information rather than a navigation away from it.
+//
+// Two things that did NOT change. A superadmin still cannot see this button,
+// because they still cannot open this page, so the admin console remains
+// their route to the same action. And on any install with more than one live
+// organisation can_check_now is false for every non-superadmin, so nothing
+// appears here on the hosted service. The visibility rule is never guessed
+// from a role in the browser: it is the server's own answer, computed by the
+// same code that gates the endpoint, so this button cannot be shown to
+// someone who would receive a 403.
 //
 // Deliberately does NOT change the per-site "Current" badge. That badge's
 // claim ("this site matches the reference") stays true regardless of the
@@ -71,6 +97,10 @@ export interface AgentColumnFleetNoteProps {
    * guessed or empty value (see describeReferenceCheck's own doc for the
    * full state table, including why a hosted/direct reference renders
    * nothing here).
+   *
+   * Its `can_check_now` is what reveals the "Check now" action below. That
+   * boolean is the control plane's own answer for THIS viewer, so it is read
+   * verbatim and never combined with a locally guessed role.
    */
   referenceCheck?: AgentMirrorStatus;
   className?: string;
@@ -84,7 +114,17 @@ export function AgentColumnFleetNote({
 }: AgentColumnFleetNoteProps) {
   const showFleetNote = referenceSource === "fleet";
   const checkMessage = describeReferenceCheck(referenceCheck, referenceSource);
-  if (!showFleetNote && !checkMessage) return null;
+  // === true, not a truthiness check: the generated type is a plain boolean,
+  // but an older control plane that predates the field sends nothing at all,
+  // and "absent" must read as "not permitted" rather than reveal a button
+  // whose endpoint would refuse it.
+  const canCheckNow = referenceCheck?.can_check_now === true;
+  // canCheckNow is part of the condition rather than assumed to imply
+  // checkMessage. The server only sets it while the mirror is enabled, which
+  // is also the condition under which describeReferenceCheck always returns a
+  // message, so the two agree today; keeping it explicit means a future change
+  // to either one cannot silently hide the action.
+  if (!showFleetNote && !checkMessage && !canCheckNow) return null;
 
   const warn = checkMessage?.tone === "warn";
   const Icon = warn ? AlertTriangle : Info;
@@ -130,14 +170,14 @@ export function AgentColumnFleetNote({
           </div>
         ) : null}
 
-        {checkMessage ? (
+        {checkMessage || canCheckNow ? (
           <div
             className={cn(
               "space-y-1",
               showFleetNote && "border-t border-[var(--color-border)] pt-3",
             )}
           >
-            {checkMessage.lead ? (
+            {checkMessage?.lead ? (
               <p className="leading-relaxed text-[var(--color-muted-foreground)]">
                 {checkMessage.lead}
               </p>
@@ -157,22 +197,84 @@ export function AgentColumnFleetNote({
               dark). It is what the Core Web Vitals threshold labels already
               use for the same job.
             */}
-            <p
-              className={cn(
-                "font-medium",
-                warn
-                  ? "text-[var(--color-warning-subtle-fg)]"
-                  : "text-[var(--color-foreground)]",
-              )}
-            >
-              {checkMessage.title}
-            </p>
-            <p className="leading-relaxed text-[var(--color-muted-foreground)]">
-              {checkMessage.body}
-            </p>
+            {checkMessage ? (
+              <>
+                <p
+                  className={cn(
+                    "font-medium",
+                    warn
+                      ? "text-[var(--color-warning-subtle-fg)]"
+                      : "text-[var(--color-foreground)]",
+                  )}
+                >
+                  {checkMessage.title}
+                </p>
+                <p className="leading-relaxed text-[var(--color-muted-foreground)]">
+                  {checkMessage.body}
+                </p>
+              </>
+            ) : null}
+            {canCheckNow ? <CheckNowAction /> : null}
           </div>
         ) : null}
       </PopoverContent>
     </Popover>
+  );
+}
+
+/**
+ * The manual trigger, rendered directly under the freshness text so the action
+ * sits where the information that prompts it already is.
+ *
+ * Its own component only so the mutation hook is not instantiated on every
+ * render of a popover that will never show it: the vast majority of viewers,
+ * on every hosted install and on every self-hosted install with more than one
+ * organisation, have can_check_now false.
+ *
+ * All colours come from Button's own variant tokens, which already carry
+ * light and dark values; nothing here introduces a new colour.
+ */
+function CheckNowAction() {
+  const check = useCheckAgentMirrorNow();
+
+  return (
+    <div className="pt-1">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={check.isPending}
+        // The popover lives inside the Sites table header, whose cells have
+        // their own click handling; the trigger icon stops propagation for the
+        // same reason.
+        onClick={(e) => {
+          e.stopPropagation();
+          check.mutate();
+        }}
+        // Starts with the visible label on purpose. An accessible name that
+        // does not contain the words on the button breaks voice control ("click
+        // Check now") and WCAG 2.5.3; the rest is the context the two words
+        // alone do not carry, and it stays put while the label swaps to
+        // "Checking..." so the control keeps one stable name.
+        aria-label="Check now for a newer agent release upstream"
+      >
+        <RefreshCw
+          aria-hidden="true"
+          className={cn("mr-1.5 size-3.5", check.isPending && "animate-spin")}
+        />
+        {check.isPending ? "Checking..." : "Check now"}
+      </Button>
+      {/*
+        Deliberately not a promise of a result. The endpoint answers 202
+        "queued", the run has not happened yet, and the outcome lands in this
+        very popover only once the fleet rollup refetches. Saying so here stops
+        the button from reading as "confirmed just now", which is the exact
+        class of overclaim this whole feature exists to remove.
+      */}
+      <p className="pt-1.5 leading-relaxed text-[var(--color-muted-foreground)]">
+        Queues one immediate check instead of waiting for the next scheduled
+        run. The result appears here once this view refreshes.
+      </p>
+    </div>
   );
 }

--- a/apps/web/src/features/sites/sites-table.tsx
+++ b/apps/web/src/features/sites/sites-table.tsx
@@ -139,6 +139,11 @@ export interface SitesTableProps {
    * HEADER's popover (AgentColumnFleetNote): it is a property of the
    * install-wide comparison, not of any row, so it is never passed to the
    * per-row AgentStatusChip. Omit while the rollup is loading.
+   *
+   * It also carries `can_check_now`, the control plane's answer for THIS
+   * viewer, which is what reveals the popover's "Check now" action. That is a
+   * property of the caller rather than of a row too, so it rides the same
+   * single object rather than being resolved separately.
    */
   agentReferenceCheck?: AgentMirrorStatus;
   /** Optional click handler for the inline "Log in" (Zap) action. */

--- a/apps/web/src/routes/_authed/admin/agent-mirror.tsx
+++ b/apps/web/src/routes/_authed/admin/agent-mirror.tsx
@@ -20,16 +20,23 @@ export const Route = createFileRoute("/_authed/admin/agent-mirror")({
 // Page
 // ---------------------------------------------------------------------------
 //
-// GH #322. Triggering an immediate upstream agent-release mirror check is a
-// superadmin, install-level operation (POST /api/v1/admin/agent-mirror/
-// check): the mirror is ONE PER INSTALL, so this lives here rather than on
-// the tenant-scoped Sites page, which a superadmin cannot even open (see
-// routes/_authed.tsx's isSuperadminAllowedPath guard). The freshness of the
-// mirror itself (last confirmed, last attempted, stale/misconfigured/
-// standing down) is shown to every tenant that CAN see the Sites page, in
-// the Agent column header's popover (features/sites/agent-column-header.tsx).
-// This page only has the action, since there is no install-level read
-// endpoint for that state.
+// GH #322. Triggering an immediate upstream agent-release mirror check is an
+// install-level operation (POST /api/v1/admin/agent-mirror/check): the mirror
+// is ONE PER INSTALL. This page is the SUPERADMIN's route to it, and remains
+// the only one, because a superadmin cannot open the tenant-scoped Sites page
+// at all (see routes/_authed.tsx's isSuperadminAllowedPath guard).
+//
+// The same action is now also offered on the Sites page, in the Agent column
+// header's popover, to a viewer the control plane says may use it
+// (agent_mirror.can_check_now: the owner of the only live organisation on the
+// install). Same endpoint, same mutation hook, same outcome vocabulary. That
+// path is unreachable here and this one is unreachable there, so neither
+// duplicates the other for any single person.
+//
+// The freshness of the mirror itself (last confirmed, last attempted,
+// stale/misconfigured/standing down) is shown to every tenant that CAN see
+// the Sites page, in that same popover. This page only has the action, since
+// there is no install-level read endpoint for that state.
 
 function AgentMirrorAdminPage() {
   return (

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -12430,6 +12430,7 @@ export const AgentMirrorStatusSchema = {
     "enabled",
     "status",
     "stale_after_seconds",
+    "can_check_now",
     "last_success_at",
     "last_success_outcome",
     "last_success_version",
@@ -12441,7 +12442,7 @@ export const AgentMirrorStatusSchema = {
     "last_mirrored_version",
   ],
   description:
-    'Freshness of the UPSTREAM AGENT-RELEASE MIRROR (internal/agentupstream, WPMGR_UPDATE_AGENT_MIRROR_ENABLED), which on a self-hosted install is what keeps agent-releases/latest.json, and therefore latest_version, up to date (GH #322).\nThis object describes the MIRROR JOB, never the reference version itself. When reference_source is "fleet" or "none" there is no published reference, and these timestamps say nothing about latest_version. When enabled is false there is no mirror at all: on the hosted service the release pipeline writes the manifest directly, so every field here is null and no freshness age should be shown to a user.\n',
+    'Freshness of the UPSTREAM AGENT-RELEASE MIRROR (internal/agentupstream, WPMGR_UPDATE_AGENT_MIRROR_ENABLED), which on a self-hosted install is what keeps agent-releases/latest.json, and therefore latest_version, up to date (GH #322), together with one capability: whether the CALLING VIEWER may trigger a check on that mirror right now (can_check_now).\nEvery field except can_check_now describes the MIRROR JOB, never the reference version itself. When reference_source is "fleet" or "none" there is no published reference, and these timestamps say nothing about latest_version. When enabled is false there is no mirror at all: on the hosted service the release pipeline writes the manifest directly, so every timestamp here is null, no freshness age should be shown to a user, and can_check_now is false for everyone.\ncan_check_now is the one field that is a property of the CALLER rather than of the install, so it is not cacheable across users: two people looking at the same fleet can legitimately receive different values.\n',
   properties: {
     enabled: {
       type: "boolean",
@@ -12466,6 +12467,11 @@ export const AgentMirrorStatusSchema = {
       format: "int32",
       description:
         'The staleness threshold behind status="stale", in seconds (46800, i.e. 13 hours). Emitted so a client can phrase the warning without duplicating the constant. It is two nominal 6h30m cycles (the 6h schedule plus up to 30m jitter) and clears the roughly 12h30m gap a single control-plane restart can legitimately produce (River\'s periodic-job scheduler recomputes its next run as "now plus the interval" on restart rather than resuming a prior clock), so reaching it means at least two consecutive scheduled runs failed to confirm anything.\n',
+    },
+    can_check_now: {
+      type: "boolean",
+      description:
+        'Whether the CALLING VIEWER may trigger a mirror check on this install right now, i.e. whether POST /api/v1/admin/agent-mirror/check would admit this caller rather than answer 403. The dashboard renders its "Check now" action in the Sites page Agent column popover exactly when this is true, so an operator is never offered a button that refuses them, and the operator who may act is never left without one.\nThe control plane computes this from the SAME decision the endpoint\'s own gate runs, not a second copy of the rule: superadmin (users.is_superadmin), OR the owner of the only live organisation on this install (GH #322, the single-tenant self-hosted case, where the multi-tenant protection the gate exists for has no other tenant to protect). An API-key principal is always false, since this is an install-level action against a shared upstream request budget and the audit record wants a human.\nFalse whenever enabled is false: no caller may trigger a run that does not exist. False for every non-superadmin on an install with more than one live organisation, which leaves the hosted, multi-tenant case exactly as it was. A second organisation appearing closes the path again on the very next request, because nothing about this answer is cached.\n',
     },
     last_success_at: {
       type: "string",

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -6986,8 +6986,9 @@ export type FleetAgentVersions = {
 };
 
 /**
- * Freshness of the UPSTREAM AGENT-RELEASE MIRROR (internal/agentupstream, WPMGR_UPDATE_AGENT_MIRROR_ENABLED), which on a self-hosted install is what keeps agent-releases/latest.json, and therefore latest_version, up to date (GH #322).
- * This object describes the MIRROR JOB, never the reference version itself. When reference_source is "fleet" or "none" there is no published reference, and these timestamps say nothing about latest_version. When enabled is false there is no mirror at all: on the hosted service the release pipeline writes the manifest directly, so every field here is null and no freshness age should be shown to a user.
+ * Freshness of the UPSTREAM AGENT-RELEASE MIRROR (internal/agentupstream, WPMGR_UPDATE_AGENT_MIRROR_ENABLED), which on a self-hosted install is what keeps agent-releases/latest.json, and therefore latest_version, up to date (GH #322), together with one capability: whether the CALLING VIEWER may trigger a check on that mirror right now (can_check_now).
+ * Every field except can_check_now describes the MIRROR JOB, never the reference version itself. When reference_source is "fleet" or "none" there is no published reference, and these timestamps say nothing about latest_version. When enabled is false there is no mirror at all: on the hosted service the release pipeline writes the manifest directly, so every timestamp here is null, no freshness age should be shown to a user, and can_check_now is false for everyone.
+ * can_check_now is the one field that is a property of the CALLER rather than of the install, so it is not cacheable across users: two people looking at the same fleet can legitimately receive different values.
  *
  */
 export type AgentMirrorStatus = {
@@ -7012,6 +7013,13 @@ export type AgentMirrorStatus = {
    *
    */
   stale_after_seconds: number;
+  /**
+   * Whether the CALLING VIEWER may trigger a mirror check on this install right now, i.e. whether POST /api/v1/admin/agent-mirror/check would admit this caller rather than answer 403. The dashboard renders its "Check now" action in the Sites page Agent column popover exactly when this is true, so an operator is never offered a button that refuses them, and the operator who may act is never left without one.
+   * The control plane computes this from the SAME decision the endpoint's own gate runs, not a second copy of the rule: superadmin (users.is_superadmin), OR the owner of the only live organisation on this install (GH #322, the single-tenant self-hosted case, where the multi-tenant protection the gate exists for has no other tenant to protect). An API-key principal is always false, since this is an install-level action against a shared upstream request budget and the audit record wants a human.
+   * False whenever enabled is false: no caller may trigger a run that does not exist. False for every non-superadmin on an install with more than one live organisation, which leaves the hosted, multi-tenant case exactly as it was. A second organisation appearing closes the path again on the very next request, because nothing about this answer is cached.
+   *
+   */
+  can_check_now: boolean;
   /**
    * When this install last CONFIRMED what upstream publishes: the last attempt whose outcome was mirrored, current, or unchanged. This is the ONLY field an age may ever be rendered from. Null when it has never happened. Deliberately distinct from last_attempt_at: a run that failed ten minutes ago must never be reported as "checked ten minutes ago".
    *

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.123
+  version: 0.61.124
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,
@@ -21298,7 +21298,7 @@ components:
     AgentMirrorStatus:
       type: object
       required:
-        [enabled, status, stale_after_seconds, last_success_at,
+        [enabled, status, stale_after_seconds, can_check_now, last_success_at,
          last_success_outcome, last_success_version, last_attempt_at,
          last_attempt_outcome, last_attempt_detail, last_attempt_trigger,
          last_mirrored_at, last_mirrored_version]
@@ -21306,15 +21306,21 @@ components:
         Freshness of the UPSTREAM AGENT-RELEASE MIRROR (internal/agentupstream,
         WPMGR_UPDATE_AGENT_MIRROR_ENABLED), which on a self-hosted install is
         what keeps agent-releases/latest.json, and therefore latest_version,
-        up to date (GH #322).
+        up to date (GH #322), together with one capability: whether the
+        CALLING VIEWER may trigger a check on that mirror right now
+        (can_check_now).
 
-        This object describes the MIRROR JOB, never the reference version
-        itself. When reference_source is "fleet" or "none" there is no
-        published reference, and these timestamps say nothing about
-        latest_version. When enabled is false there is no mirror at all: on
-        the hosted service the release pipeline writes the manifest directly,
-        so every field here is null and no freshness age should be shown to a
-        user.
+        Every field except can_check_now describes the MIRROR JOB, never the
+        reference version itself. When reference_source is "fleet" or "none"
+        there is no published reference, and these timestamps say nothing
+        about latest_version. When enabled is false there is no mirror at all:
+        on the hosted service the release pipeline writes the manifest
+        directly, so every timestamp here is null, no freshness age should be
+        shown to a user, and can_check_now is false for everyone.
+
+        can_check_now is the one field that is a property of the CALLER rather
+        than of the install, so it is not cacheable across users: two people
+        looking at the same fleet can legitimately receive different values.
       properties:
         enabled:
           type: boolean
@@ -21350,6 +21356,32 @@ components:
             its next run as "now plus the interval" on restart rather than
             resuming a prior clock), so reaching it means at least two
             consecutive scheduled runs failed to confirm anything.
+        can_check_now:
+          type: boolean
+          description: >
+            Whether the CALLING VIEWER may trigger a mirror check on this
+            install right now, i.e. whether POST
+            /api/v1/admin/agent-mirror/check would admit this caller rather
+            than answer 403. The dashboard renders its "Check now" action in
+            the Sites page Agent column popover exactly when this is true, so
+            an operator is never offered a button that refuses them, and the
+            operator who may act is never left without one.
+
+            The control plane computes this from the SAME decision the
+            endpoint's own gate runs, not a second copy of the rule: superadmin
+            (users.is_superadmin), OR the owner of the only live organisation
+            on this install (GH #322, the single-tenant self-hosted case, where
+            the multi-tenant protection the gate exists for has no other tenant
+            to protect). An API-key principal is always false, since this is an
+            install-level action against a shared upstream request budget and
+            the audit record wants a human.
+
+            False whenever enabled is false: no caller may trigger a run that
+            does not exist. False for every non-superadmin on an install with
+            more than one live organisation, which leaves the hosted,
+            multi-tenant case exactly as it was. A second organisation
+            appearing closes the path again on the very next request, because
+            nothing about this answer is cached.
         last_success_at:
           type: string
           format: date-time


### PR DESCRIPTION
Completes #322. 0.61.123 widened the mirror-check endpoint to the owner of a single-tenant install, but left the only trigger inside the superadmin-gated admin console, **which that owner cannot open**. The permission existed with no button behind it.

The button now sits in the Agent column popover, under the freshness text. The reporter's own words for why: that is the moment an operator reading *"may be stale, last confirmed 14h ago"* would want to act.

## One decision, not two

`can_check_now` on `GET /api/v1/fleet/agents` is the **same** decision the endpoint's gate makes, not a second implementation that could drift from it.

The shared logic moved to `internal/admingate`, which now owns the `Store` interface, both SQL statements, and one function `CanRunAgentMirrorCheck`. `internal/admin`'s middleware shrank to a call into it (209 lines to 88), and `adminGateStore` is a **type alias**, so the existing gate tests still exercise the shared SQL through the real middleware.

The membership half still runs inside `InUserTx`, and now **cannot stop doing so**: `PoolStore` is the single implementation both callers receive, so there is no second path that could reach `memberships` on the bare pool.

That detail matters more than it looks. `memberships` is FORCE RLS and only the self-read policy exposes cross-tenant own-membership rows, so the bare pool would answer "no" and the button would **silently never appear** — a bug that reads as "the feature just doesn't work" rather than as an error.

`can_check_now` is false whenever the mirror is disabled, and the store is not consulted at all in that case, so a hosted install pays no extra query per fleet request.

**Hosted multi-tenant is unchanged.** With more than one live organisation it is false for every non-superadmin, and a superadmin is redirected off the Sites page anyway, so the admin console stays their route.

## A comment that had become false

`agent-column-header.tsx:42-48` carried a confident explanation that a trigger could not live in this popover, because superadmins get redirected off the Sites page.

True when written. **Now wrong for the owner case.** Corrected rather than left to mislead the next reader, along with the same claim in three other files.

## Tests verified by mutation, not asserted

**Backend.** An absent JSON field decodes as `false`, so a naive test would have passed against the pre-change wire and proven nothing. Every assertion requires the key to be **present** first. With the field removed, all eight fail:

```
agent_mirror has no can_check_now field at all
```

A second mutation dropping the mirror-enabled term fails only the disabled cases, so that term has teeth of its own.

Owner-with-a-second-org versus non-owner are only separable against real rows (a fake store answers false to both), so those run on testcontainers as the non-superuser `wpmgr_app` role and show the same owner flipping true to false when a second live org appears.

**Frontend.** Forcing the capability false fails 7 tests; forcing it true fails 7 different ones.

`409 already running` and `429 rate limited` stay **info, not errors** — being skipped by the 30-minute spacing is the system working as designed. The existing admin hook was reused unchanged so the two surfaces cannot fork their vocabulary.

## Gates

```
go build / vet / ./internal/... / ./tests/contract/...   clean, 0 failures
web  119 files, 1473 tests pass
eslint 0 errors (3 pre-existing warnings)    tsc 0
lockstep 0.61.124    dashes 0
```

## Two judgement calls for review

1. The mirror hook stayed in `features/admin/` rather than being moved and churning its 245-line test file. `features/sites` importing across features has precedent, and the folder still matches the endpoint's own `/api/v1/admin/` prefix.
2. The new button's `aria-label` starts with its visible text; the admin console's existing label does not, which masks the accessible name (WCAG 2.5.3). The admin page was left alone per "do not fix pre-existing issues", so the two now differ.

## Known limit

No refetch after a successful click. The endpoint returns `202 queued`, so an immediate refetch would redisplay the same stale state. The copy says the result appears once the view refreshes (60s staleTime). A delayed refetch is a small follow-up if you want it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a server-authorized **“Check now”** action to the Sites page’s Agent column.
  - The action is available only to eligible viewers and when agent mirroring is enabled.
  - Added clear feedback for queued, already-running, rate-limited, and failed checks.
  - Refreshed data displays the resulting agent release status.

- **Documentation**
  - Updated the changelog and API documentation to describe the new capability and authorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->