### PR TITLE
perf(uptime): serve the per-site window from the daily rollup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.125] - 2026-08-05
+
+### Fixed
+
+- A site's Uptime card could take up to thirty seconds to load the first time it was opened after a quiet period, and then load in half a second on every attempt after that. Measured over a week of production requests, the same page's fleet summary answered in a fifth of a second every single time, including on the page loads where the per-site card took four seconds or more. The cause was not the amount of history, an absent index, a busy database or a cold container: it was that the per-site view was still adding up every individual probe in the window by hand, about forty three thousand of them for a thirty day view, every time it was asked.
+- The fleet-wide view stopped doing that some time ago. It reads a running per-day total that is kept up to date as each probe lands, and only looks at individual probes for the two part days at the very edges of the window, which is at most a couple of days' worth. The per-site view predates that work and never received it. It does now, using the same code to decide which days are complete rather than a second copy that could quietly disagree with the first, so the number on a site's Uptime card and the number next to that same site in the fleet views cannot drift apart.
+- The reported uptime percentage is unchanged, to the decimal. A day that falls only partly inside the window is still counted only for the part that is inside it, so an outage that started an hour before a thirty day window opens still counts for exactly the minutes that fall within it, not for the whole day and not for none of it.
+- The three separate lookups behind the card, the totals, the latest check and the chart, now happen at the same time as each other instead of one after another. They never depended on each other's results, so waiting for them in turn was simply waiting three times.
+
+### Changed
+
+- The uptime chart on a site now draws one point per day for any window of a day or longer, rather than a hundred points of whatever width divides the window evenly. For a thirty day view that is about thirty points instead of a hundred points seven hours wide each, which is the same information at a resolution the chart can actually show: at the size it is drawn, a hundred points were never individually distinguishable. Windows shorter than a day are untouched and still show every minute, because that is the entire purpose of looking at an hour.
+- The average response time shown on a site's Uptime card is now the average across successful checks only, which is what the Sites list and the fleet dashboards have always shown for the same site. It previously also included the response times of failed checks, so a site with a spell of server errors had two different average response times in the product depending on which screen it was read from. The uptime percentage was never affected by this and is not affected now.
+
 ## [0.61.124] - 2026-08-05
 
 ### Added

--- a/apps/api/internal/metrics/postgres.go
+++ b/apps/api/internal/metrics/postgres.go
@@ -239,33 +239,137 @@ func appProbedAt(checkedAt time.Time, reason string) any {
 
 var _ RollupWriter = (*pgStore)(nil)
 
+// ---------------------------------------------------------------------------
+// Per-site windowed reads (0.61.125): the same hybrid decomposition the
+// fleet-wide read has used since m99.
+// ---------------------------------------------------------------------------
+//
+// QueryAggregate and QuerySeries below used to scan site_uptime_probes RAW
+// across the whole window, which is what made GET /sites/{siteId}/uptime cost
+// 0.5s to 32.5s (measured, 7 days of Cloud Run httpRequest.latency) against a
+// cold Postgres buffer cache, while GET /uptime/summary on the same page load
+// stayed at 0.13s to 0.28s. The fleet read was rewritten onto the
+// site_uptime_daily rollup in m99; the per-site read predates that work and
+// never got it, so this is the same fix applied to the same window on the same
+// two tables: the rollup serves the complete UTC days in the middle of the
+// window and only the two partial edge days are ever read raw.
+//
+// Both queries below take their window boundaries from fleetUptimeParams,
+// the SAME function QueryFleetUptime uses, deliberately not a second copy of
+// the "which days are complete" math. Two implementations of that question
+// that can disagree is precisely the defect class this decomposition exists to
+// avoid, and it would show up as the per-site card and the fleet card
+// disagreeing about the same site on the same screen.
+//
+// LATENCY SEMANTICS (a deliberate, documented change): the old per-site
+// queries averaged NULLIF(total_ms, 0) over EVERY probe in the window,
+// including DOWN ones. A 5xx or WordPress-fatal-page probe is classified down
+// but still records a real total_ms (see uptime.Prober.Probe: res.TotalMs is
+// filled after the up/down verdict), so those response times used to be folded
+// into the per-site average. The rollup stores sum_latency_ms/latency_samples
+// only for probes that were UP with a non-zero reading, so the average is now
+// "mean response time of successful probes", exactly the definition
+// QueryFleetUptime already reports for the same site on the Sites list and the
+// fleet dashboards. This makes the per-site Uptime card agree with the fleet
+// number instead of quietly computing a different one; it cannot be preserved
+// from the rollup without a new column that would be NULL for all existing
+// history. The uptime PERCENTAGE is untouched: up_checks/total_checks carry
+// exactly the old count(*) FILTER (WHERE up) / count(*) semantics.
+
+// siteAggregateQuery sums the three window parts (see fleetUptimeQuery's doc
+// comment for what each part is and why the decomposition is gap-free and
+// non-overlapping) into a single row for ONE site.
+const siteAggregateQuery = `
+SELECT
+    COALESCE(SUM(parts.up_checks), 0)::bigint       AS up_checks,
+    COALESCE(SUM(parts.total_checks), 0)::bigint    AS total_checks,
+    COALESCE(SUM(parts.sum_latency_ms), 0)          AS sum_latency_ms,
+    COALESCE(SUM(parts.latency_samples), 0)::bigint AS latency_samples
+FROM (
+    -- 1. ROLLUP middle: complete UTC days strictly inside the window.
+    SELECT
+        COALESCE(SUM(up_checks), 0)       AS up_checks,
+        COALESCE(SUM(total_checks), 0)    AS total_checks,
+        COALESCE(SUM(sum_latency_ms), 0)  AS sum_latency_ms,
+        COALESCE(SUM(latency_samples), 0) AS latency_samples
+    FROM site_uptime_daily
+    WHERE site_id = $2 AND tenant_id = $1
+      AND day > $3::date AND day < $4::date
+
+    UNION ALL
+
+    -- 2. RAW boundary tail: in-window slice of the oldest partial day.
+    SELECT
+        count(*) FILTER (WHERE up) AS up_checks,
+        count(*)                   AS total_checks,
+        COALESCE(sum(total_ms) FILTER (WHERE up AND total_ms <> 0), 0) AS sum_latency_ms,
+        count(*) FILTER (WHERE up AND total_ms <> 0) AS latency_samples
+    FROM site_uptime_probes
+    WHERE site_id = $2 AND tenant_id = $1
+      AND probed_at >= $5::timestamptz AND probed_at < $6::timestamptz
+
+    UNION ALL
+
+    -- 3. RAW today: today's head, read live.
+    SELECT
+        count(*) FILTER (WHERE up) AS up_checks,
+        count(*)                   AS total_checks,
+        COALESCE(sum(total_ms) FILTER (WHERE up AND total_ms <> 0), 0) AS sum_latency_ms,
+        count(*) FILTER (WHERE up AND total_ms <> 0) AS latency_samples
+    FROM site_uptime_probes
+    WHERE site_id = $2 AND tenant_id = $1
+      AND probed_at >= $7::timestamptz AND probed_at <= $8::timestamptz
+) parts`
+
+// siteWindowArgs builds the eight bound parameters siteAggregateQuery (and the
+// first eight of siteDailySeriesQuery) expect, in order:
+//
+//	$1 tenant_id  $2 site_id
+//	$3 boundaryDay::date        $4 today::date
+//	$5 tailLower  $6 tailUpper  $7 todayLower  $8 now
+//
+// Every value comes from fleetUptimeParams, computed in Go from now.UTC() and
+// bound with an explicit ::date / ::timestamptz cast in the SQL, so the UTC-day
+// boundaries that key site_uptime_daily are identical regardless of the
+// Postgres session's TimeZone GUC (see fleetUptimeQuery's doc comment).
+// retentionCutoff is discarded here: it guards the site_uptime_status
+// latest-probe join, which the per-site path does not use (QueryLatest reads
+// the raw table directly and is already a cheap indexed LIMIT 1).
+func siteWindowArgs(tenantID, siteID uuid.UUID, now time.Time, window time.Duration) []any {
+	boundaryDay, today, tailLower, tailUpper, _, todayLower, nowParam := fleetUptimeParams(now, window)
+	return []any{tenantID, siteID, boundaryDay, today, tailLower, tailUpper, todayLower, nowParam}
+}
+
 // QueryAggregate returns the windowed uptime % and average latency for one
-// site, filtered by tenant_id + site_id.
+// site, filtered by tenant_id + site_id. Served by the m99 rollup for the
+// complete days in the middle of the window and by two bounded raw reads for
+// the two partial edge days; see the block comment above for the full
+// rationale and the one documented semantic change (average latency is now
+// over successful probes only).
 func (s *pgStore) QueryAggregate(ctx context.Context, tenantID, siteID uuid.UUID, window time.Duration) (Aggregate, error) {
 	var agg Aggregate
-	since := time.Now().Add(-window)
+	args := siteWindowArgs(tenantID, siteID, time.Now(), window)
 	err := s.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
-		row := tx.QueryRow(ctx, `
-SELECT COUNT(*)                                     AS checks,
-       COUNT(*) FILTER (WHERE up)                   AS up_checks,
-       COALESCE(AVG(NULLIF(total_ms, 0))::float8, 0) AS avg_latency
-FROM site_uptime_probes
-WHERE tenant_id = $1 AND site_id = $2 AND probed_at >= $3`,
-			tenantID, siteID, since)
-		var checks, upChecks int64
-		var avgLatency float64
-		if err := row.Scan(&checks, &upChecks, &avgLatency); err != nil {
+		row := tx.QueryRow(ctx, siteAggregateQuery, args...)
+		var upChecks, totalChecks, latencySamples int64
+		var sumLatencyMs float64
+		if err := row.Scan(&upChecks, &totalChecks, &sumLatencyMs, &latencySamples); err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return nil
 			}
 			return fmt.Errorf("postgres aggregate scan: %w", err)
 		}
-		agg.Checks = uint64(checks)
+		agg.Checks = uint64(totalChecks)
 		agg.UpChecks = uint64(upChecks)
-		if checks > 0 {
-			agg.UptimePct = float64(upChecks) / float64(checks) * 100
+		if totalChecks > 0 {
+			agg.UptimePct = float64(upChecks) / float64(totalChecks) * 100
 		}
-		agg.AvgLatencyMs = avgLatency
+		// sum_latency_ms / NULLIF(latency_samples, 0), done in Go exactly as
+		// QueryFleetUptime does it, so both read paths derive the average from
+		// the rollup counters the same way.
+		if latencySamples > 0 {
+			agg.AvgLatencyMs = sumLatencyMs / float64(latencySamples)
+		}
 		return nil
 	})
 	return agg, err
@@ -610,11 +714,165 @@ LIMIT $5`, tenantID, siteID, from, to, limitN)
 	return out, err
 }
 
+// dailySeriesMinWindow is the EXACT threshold at which QuerySeries switches
+// from raw per-minute probe buckets to one point per UTC day drawn from the
+// site_uptime_daily rollup: a window of 24 hours OR MORE takes the daily path,
+// anything shorter keeps reading raw probes unchanged.
+//
+// Why exactly 24h, and not "7d" or "whatever the endpoint happens to ask for":
+//
+//  1. It is the smallest window a one-point-per-day series can describe with
+//     more than a single point. Below it the daily path would collapse a whole
+//     chart to one bar, and minute granularity is the entire point of a 1h or
+//     24h view.
+//  2. It is exactly the window length at or above which the decomposition is
+//     GUARANTEED to place boundaryDay strictly before today: with
+//     now = today + t (0 <= t < 24h) and window >= 24h, tailLower = now-window
+//     <= today + t - 24h < today, so boundaryDay <= today - 24h. That makes
+//     the boundary-tail day, the rollup middle days and today three DISJOINT
+//     sets of days, which is what lets each day contribute exactly one point
+//     and be counted exactly once. Below 24h that guarantee does not hold
+//     (boundaryDay can equal today), so the daily path is not merely
+//     low-resolution there, it is not well formed.
+//
+// The visible consequence at the sizes the product actually asks for: a 30d
+// chart goes from ~100 buckets of 7.2h to ~31 daily points, and a 90d chart
+// from ~100 buckets of 21.6h to ~91 daily points. That is a deliberate
+// improvement, not a compromise: the consuming sparkline is a fixed-height
+// inline SVG, ~100 buckets were never individually distinguishable in it, and
+// the report aggregator that also consumes this series (report.buildUptimeSection)
+// immediately regroups the points into daily buckets anyway.
+const dailySeriesMinWindow = 24 * time.Hour
+
+// siteDailySeriesQuery returns ONE row per UTC day covered by the window,
+// using the same three-part decomposition as siteAggregateQuery: the rollup
+// supplies every complete day in the middle, and the two partial edge days
+// (the oldest, in-window slice only, and today, read live) are aggregated from
+// raw probes and labelled with their own UTC midnight.
+//
+// $9/$10 are the SAME instants as $3/$4 (built by appending args[2], args[3] in
+// querySeriesDaily, so a bucket label can never drift from the predicate that
+// selects the rows it labels) but bound as timestamptz rather than date: a
+// single parameter cannot be used as both $n::date and $n::timestamptz, and
+// the bucket column must be timestamptz to union with nothing TZ-dependent.
+// The rollup's own date column is converted with an explicit AT TIME ZONE
+// 'UTC' for the same reason every other boundary here is computed in UTC: a
+// bare day::timestamptz would be resolved against the session's TimeZone GUC
+// and shift the bucket by the server's offset on a non-UTC self-host.
+//
+// Days with no probes produce no point, matching the raw path's GROUP BY
+// (which can only emit a bucket that has rows), hence the total_checks > 0
+// filter, which also drops the two edge parts when their bounded range is
+// empty (count(*) over an empty range still returns a row, with 0).
+const siteDailySeriesQuery = `
+SELECT bucket, total_checks, up_checks, sum_latency_ms, latency_samples
+FROM (
+    -- 1. ROLLUP middle: one point per complete UTC day inside the window.
+    SELECT
+        (day::timestamp AT TIME ZONE 'UTC') AS bucket,
+        total_checks::bigint                AS total_checks,
+        up_checks::bigint                   AS up_checks,
+        sum_latency_ms                      AS sum_latency_ms,
+        latency_samples::bigint             AS latency_samples
+    FROM site_uptime_daily
+    WHERE site_id = $2 AND tenant_id = $1
+      AND day > $3::date AND day < $4::date
+
+    UNION ALL
+
+    -- 2. RAW boundary tail: in-window slice of the oldest partial day.
+    SELECT
+        $9::timestamptz            AS bucket,
+        count(*)                   AS total_checks,
+        count(*) FILTER (WHERE up) AS up_checks,
+        COALESCE(sum(total_ms) FILTER (WHERE up AND total_ms <> 0), 0) AS sum_latency_ms,
+        count(*) FILTER (WHERE up AND total_ms <> 0) AS latency_samples
+    FROM site_uptime_probes
+    WHERE site_id = $2 AND tenant_id = $1
+      AND probed_at >= $5::timestamptz AND probed_at < $6::timestamptz
+
+    UNION ALL
+
+    -- 3. RAW today: today's head, read live.
+    SELECT
+        $10::timestamptz           AS bucket,
+        count(*)                   AS total_checks,
+        count(*) FILTER (WHERE up) AS up_checks,
+        COALESCE(sum(total_ms) FILTER (WHERE up AND total_ms <> 0), 0) AS sum_latency_ms,
+        count(*) FILTER (WHERE up AND total_ms <> 0) AS latency_samples
+    FROM site_uptime_probes
+    WHERE site_id = $2 AND tenant_id = $1
+      AND probed_at >= $7::timestamptz AND probed_at <= $8::timestamptz
+) points
+WHERE total_checks > 0
+ORDER BY bucket ASC`
+
 // QuerySeries returns a downsampled per-bucket series for one site over the
-// window. Buckets are date_trunc-aligned: width = window/buckets rounded to
-// whole seconds (min 60s). We use to_timestamp(floor(extract(epoch))/W*W) to
-// avoid date_trunc's fixed-width restriction.
+// window.
+//
+// Windows of dailySeriesMinWindow (24h) or more are served at DAILY
+// granularity from the m99 rollup plus today's live tail (see
+// siteDailySeriesQuery); the buckets argument is ignored there, because the
+// bucket width is fixed by the rollup's own grain. Shorter windows keep the
+// original raw-probe path unchanged, where minute granularity is the point.
+//
+// The Point shape is identical on both paths, so the API contract does not
+// change; the one difference is AvgLatencyMs, which on the daily path is the
+// mean over SUCCESSFUL probes only (see the semantics note above
+// siteAggregateQuery).
 func (s *pgStore) QuerySeries(ctx context.Context, tenantID, siteID uuid.UUID, window time.Duration, buckets int) ([]Point, error) {
+	if window >= dailySeriesMinWindow {
+		return s.querySeriesDaily(ctx, tenantID, siteID, window)
+	}
+	return s.querySeriesRaw(ctx, tenantID, siteID, window, buckets)
+}
+
+// querySeriesDaily serves a >= 24h window from the rollup, one point per UTC
+// day, with the two partial edge days read raw so they cover exactly the
+// in-window slice rather than a whole day.
+func (s *pgStore) querySeriesDaily(ctx context.Context, tenantID, siteID uuid.UUID, window time.Duration) ([]Point, error) {
+	args := siteWindowArgs(tenantID, siteID, time.Now(), window)
+	// $9/$10: the boundary day and today again, as timestamptz bucket labels.
+	args = append(args, args[2], args[3])
+
+	var out []Point
+	err := s.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, siteDailySeriesQuery, args...)
+		if err != nil {
+			return fmt.Errorf("postgres daily series query: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var (
+				bucket                           time.Time
+				checks, upChecks, latencySamples int64
+				sumLatencyMs                     float64
+			)
+			if err := rows.Scan(&bucket, &checks, &upChecks, &sumLatencyMs, &latencySamples); err != nil {
+				return fmt.Errorf("postgres daily series scan: %w", err)
+			}
+			p := Point{
+				Bucket:   bucket,
+				Checks:   uint64(checks),
+				UpChecks: uint64(upChecks),
+			}
+			// sum_latency_ms / NULLIF(latency_samples, 0): same derivation as
+			// QueryAggregate and QueryFleetUptime.
+			if latencySamples > 0 {
+				p.AvgLatencyMs = sumLatencyMs / float64(latencySamples)
+			}
+			out = append(out, p)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+// querySeriesRaw is the original sub-day path, unchanged: buckets are
+// epoch-floor aligned, width = window/buckets rounded to whole seconds
+// (min 60s). We use to_timestamp(floor(extract(epoch))/W*W) to avoid
+// date_trunc's fixed-width restriction.
+func (s *pgStore) querySeriesRaw(ctx context.Context, tenantID, siteID uuid.UUID, window time.Duration, buckets int) ([]Point, error) {
 	if buckets <= 0 {
 		buckets = 100
 	}

--- a/apps/api/internal/metrics/postgres_persite_pg_test.go
+++ b/apps/api/internal/metrics/postgres_persite_pg_test.go
@@ -1,0 +1,631 @@
+package metrics
+
+// postgres_persite_pg_test.go: 0.61.125, real-Postgres proofs for the per-site
+// window reads. White-box (same package) so the boundary math can be taken from
+// the very fleetUptimeParams call the production code makes, rather than
+// re-derived here where it could drift.
+//
+// What each test is for:
+//
+//	T1  TestQueryAggregate_RollupMatchesRawRollingWindow
+//	    the load-bearing equivalence: counts and uptime % from the rollup
+//	    decomposition are IDENTICAL to a Go-computed aggregate over the exact
+//	    same rolling [now-window, now] range of raw probes.
+//	T1b TestQueryAggregate_ServesCompleteMiddleDaysFromRollup
+//	    the rollup is genuinely the source for the window's middle (raw rows
+//	    for those days are deleted and the answer is unchanged).
+//	T2  TestQuerySeries_ThirtyDayWindowReturnsDailyUTCPoints
+//	T3  TestQuerySeries_SubDayWindowStillReadsRawMinuteBuckets
+//	T4  TestPerSiteWindow_BoundaryDayCountedExactlyOnce
+//	T5  TestQueryAggregate_RollupGapIsNotBackfilledFromRawProbes  (the C2 case)
+//
+// The container/seed helpers (startMetricsTestPostgres, metricsSeedTenant,
+// metricsSeedSite, expectedFromChecks, absDiff) live in postgres_explain_test.go
+// in this same package.
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// oldStyleAvgLatency reproduces the PRE-0.61.125 per-site average latency
+// exactly: AVG(NULLIF(total_ms, 0)) over every probe in the window, up or
+// down. It exists so the one documented semantic change in this work is
+// asserted rather than assumed - see the block comment above siteAggregateQuery.
+func oldStyleAvgLatency(checks []Check, start, upTo time.Time) float64 {
+	var sum float64
+	var n int
+	for _, c := range checks {
+		if c.CheckedAt.Before(start) || c.CheckedAt.After(upTo) {
+			continue
+		}
+		if c.TotalMs == 0 {
+			continue // NULLIF(total_ms, 0) excludes it from sum AND divisor.
+		}
+		sum += c.TotalMs
+		n++
+	}
+	if n == 0 {
+		return 0
+	}
+	return sum / float64(n)
+}
+
+// utcDay is the UTC midnight the instant belongs to (the site_uptime_daily key).
+func utcDay(t time.Time) time.Time { return t.UTC().Truncate(24 * time.Hour) }
+
+// seedWithRollup writes checks through BOTH production write paths, exactly as
+// a live sweep does: the raw probe insert first, then the best-effort rollup
+// upsert.
+func seedWithRollup(t *testing.T, store Store, checks []Check) {
+	t.Helper()
+	ctx := context.Background()
+	if err := store.InsertChecks(ctx, checks); err != nil {
+		t.Fatalf("insert checks: %v", err)
+	}
+	if err := store.(RollupWriter).UpsertRollup(ctx, checks); err != nil {
+		t.Fatalf("upsert rollup: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// T1: equivalence
+// ---------------------------------------------------------------------------
+
+// TestQueryAggregate_RollupMatchesRawRollingWindow seeds a realistic mixed
+// history (probes just outside and just inside the window start, a complete
+// mid-window day, a zero-latency-while-up probe, DOWN probes carrying a real
+// total_ms, and a second site's noise) through the real write paths, then
+// asserts the rollup-backed aggregate is numerically identical to the exact
+// rolling-window answer computed in Go from the very same Check values.
+//
+// The avg-latency assertion at the end is the one place this test also pins
+// the DOCUMENTED semantic change: down probes with a real response time used
+// to be folded into the per-site average and no longer are, which is what the
+// fleet read has always done for the same site.
+func TestQueryAggregate_RollupMatchesRawRollingWindow(t *testing.T) {
+	app, admin := startMetricsTestPostgres(t)
+	ctx := context.Background()
+	store := NewPostgres(app, nil)
+
+	for _, window := range []time.Duration{7 * 24 * time.Hour, 30 * 24 * time.Hour} {
+		t.Run(window.String(), func(t *testing.T) {
+			now := time.Now()
+			boundaryDay, today, tailLower, _, _, _, nowUTC := fleetUptimeParams(now, window)
+
+			tenant := metricsSeedTenant(t, admin, "persite-eq-"+uuid.NewString()[:8])
+			siteID := metricsSeedSite(t, admin, tenant, "https://"+uuid.NewString()+".example.com")
+			noiseSiteID := metricsSeedSite(t, admin, tenant, "https://"+uuid.NewString()+".example.com")
+
+			var checks []Check
+			add := func(at time.Time, up bool, totalMs float64) {
+				checks = append(checks, Check{TenantID: tenant, SiteID: siteID, CheckedAt: at, Up: up, TotalMs: totalMs})
+			}
+
+			// Boundary day, OUT of window: must be excluded. A day-granular
+			// rollup that swallowed the whole boundary day would count these.
+			add(tailLower.Add(-90*time.Minute), true, 400)
+			add(tailLower.Add(-2*time.Minute), false, 900)
+			// Boundary day, IN window: served by the raw boundary tail.
+			add(tailLower.Add(2*time.Minute), false, 850) // down WITH latency
+			add(tailLower.Add(3*time.Hour), true, 150)
+
+			// A complete mid-window day: served by the rollup.
+			midDay := boundaryDay.Add(2 * 24 * time.Hour)
+			if midDay.Before(today) {
+				add(midDay.Add(4*time.Hour), false, 700) // down WITH latency
+				add(midDay.Add(5*time.Hour), true, 0)    // up, zero latency: excluded from the average
+				add(midDay.Add(6*time.Hour), true, 200)
+			}
+
+			// Today: read live from raw.
+			add(nowUTC.Add(-30*time.Minute), false, 650)
+			add(nowUTC.Add(-20*time.Minute), true, 0)
+			add(nowUTC.Add(-10*time.Minute), true, 90)
+
+			checks = append(checks, Check{TenantID: tenant, SiteID: noiseSiteID, CheckedAt: nowUTC, Up: false, TotalMs: 999})
+			seedWithRollup(t, store, checks)
+
+			siteChecks := make([]Check, 0, len(checks))
+			for _, c := range checks {
+				if c.SiteID == siteID {
+					siteChecks = append(siteChecks, c)
+				}
+			}
+			wantUp, wantTotal, wantSumLatency, wantSamples, _, _, hasAny :=
+				expectedFromChecks(siteChecks, tailLower, nowUTC)
+			if !hasAny {
+				t.Fatal("fixture bug: no checks seeded")
+			}
+
+			agg, err := store.QueryAggregate(ctx, tenant, siteID, window)
+			if err != nil {
+				t.Fatalf("QueryAggregate: %v", err)
+			}
+
+			if agg.Checks != uint64(wantTotal) {
+				t.Fatalf("Checks = %d, want %d (exact rolling-window count over raw probes)", agg.Checks, wantTotal)
+			}
+			if agg.UpChecks != uint64(wantUp) {
+				t.Fatalf("UpChecks = %d, want %d", agg.UpChecks, wantUp)
+			}
+			wantPct := float64(wantUp) / float64(wantTotal) * 100
+			if absDiff(agg.UptimePct, wantPct) > 1e-9 {
+				t.Fatalf("UptimePct = %v, want %v EXACTLY (up=%d total=%d)", agg.UptimePct, wantPct, wantUp, wantTotal)
+			}
+
+			// Fixture cross-check against the database itself, independent of
+			// both the production query and expectedFromChecks: this is what
+			// pins that the two out-of-window boundary-day probes really are
+			// excluded and the in-window one on the SAME day is included.
+			var dbCount int64
+			if err := admin.QueryRow(ctx,
+				`SELECT count(*) FROM site_uptime_probes WHERE site_id=$1 AND probed_at>=$2 AND probed_at<=$3`,
+				siteID, tailLower, nowUTC).Scan(&dbCount); err != nil {
+				t.Fatalf("fixture cross-check: %v", err)
+			}
+			if dbCount != wantTotal {
+				t.Fatalf("fixture cross-check: raw rows in [tailLower, now] = %d, want %d", dbCount, wantTotal)
+			}
+
+			wantAvg := wantSumLatency / float64(wantSamples)
+			if absDiff(agg.AvgLatencyMs, wantAvg) > 1e-9 {
+				t.Fatalf("AvgLatencyMs = %v, want %v (sum_latency_ms / latency_samples over SUCCESSFUL probes)", agg.AvgLatencyMs, wantAvg)
+			}
+			// The documented change: the old definition folded the DOWN probes'
+			// real response times into the same average, and produced a
+			// different number for this exact history.
+			oldAvg := oldStyleAvgLatency(siteChecks, tailLower, nowUTC)
+			if absDiff(oldAvg, wantAvg) < 1e-9 {
+				t.Fatalf("fixture bug: the old and new latency definitions agree (%v), so this test cannot detect the documented semantic change; seed a DOWN probe with a non-zero total_ms", oldAvg)
+			}
+		})
+	}
+}
+
+// TestQueryAggregate_ServesCompleteMiddleDaysFromRollup proves the middle of
+// the window really is served by site_uptime_daily and not by a raw scan: the
+// raw probe rows for every complete mid-window day are DELETED after the
+// rollup has been written, and the aggregate must be unchanged. Against the
+// pre-change implementation (a single raw scan across the whole window) the
+// deleted days simply vanish from the answer.
+func TestQueryAggregate_ServesCompleteMiddleDaysFromRollup(t *testing.T) {
+	app, admin := startMetricsTestPostgres(t)
+	ctx := context.Background()
+	store := NewPostgres(app, nil)
+
+	const window = 30 * 24 * time.Hour
+	now := time.Now()
+	boundaryDay, today, tailLower, _, _, _, nowUTC := fleetUptimeParams(now, window)
+
+	tenant := metricsSeedTenant(t, admin, "persite-mid-"+uuid.NewString()[:8])
+	siteID := metricsSeedSite(t, admin, tenant, "https://"+uuid.NewString()+".example.com")
+
+	var checks []Check
+	add := func(at time.Time, up bool, totalMs float64) {
+		checks = append(checks, Check{TenantID: tenant, SiteID: siteID, CheckedAt: at, Up: up, TotalMs: totalMs})
+	}
+	add(tailLower.Add(30*time.Minute), true, 100)
+	for d := boundaryDay.Add(24 * time.Hour); d.Before(today); d = d.Add(24 * time.Hour) {
+		add(d.Add(6*time.Hour), true, 120)
+		add(d.Add(18*time.Hour), false, 800)
+	}
+	add(nowUTC.Add(-5*time.Minute), true, 110)
+	seedWithRollup(t, store, checks)
+
+	before, err := store.QueryAggregate(ctx, tenant, siteID, window)
+	if err != nil {
+		t.Fatalf("QueryAggregate (before delete): %v", err)
+	}
+	if before.Checks < 30 {
+		t.Fatalf("fixture bug: only %d checks in the window", before.Checks)
+	}
+
+	// Drop every raw probe belonging to a COMPLETE mid-window day. The rollup
+	// rows for those days stay.
+	tag, err := admin.Exec(ctx,
+		`DELETE FROM site_uptime_probes
+		 WHERE site_id = $1 AND probed_at >= $2 AND probed_at < $3`,
+		siteID, boundaryDay.Add(24*time.Hour), today)
+	if err != nil {
+		t.Fatalf("delete mid-window raw probes: %v", err)
+	}
+	if tag.RowsAffected() == 0 {
+		t.Fatal("fixture bug: no mid-window raw probes were deleted")
+	}
+
+	after, err := store.QueryAggregate(ctx, tenant, siteID, window)
+	if err != nil {
+		t.Fatalf("QueryAggregate (after delete): %v", err)
+	}
+	if after.Checks != before.Checks || after.UpChecks != before.UpChecks {
+		t.Fatalf("aggregate changed when only the mid-window RAW rows were removed: before %d/%d, after %d/%d. The window's middle is not being served from site_uptime_daily",
+			before.UpChecks, before.Checks, after.UpChecks, after.Checks)
+	}
+	if absDiff(after.UptimePct, before.UptimePct) > 1e-9 {
+		t.Fatalf("UptimePct changed after deleting only mid-window raw rows: %v then %v", before.UptimePct, after.UptimePct)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// T2 / T3: series granularity
+// ---------------------------------------------------------------------------
+
+// TestQuerySeries_ThirtyDayWindowReturnsDailyUTCPoints asserts the 30-day
+// series is now one point per UTC day: every bucket is exactly a UTC midnight,
+// buckets are strictly increasing whole days apart, and the point count equals
+// the number of distinct UTC days that actually have in-window probes (never
+// the ~100 fixed-width buckets the old implementation produced). It also
+// checks the per-day counts against a Go-computed grouping of the same seeds.
+func TestQuerySeries_ThirtyDayWindowReturnsDailyUTCPoints(t *testing.T) {
+	app, admin := startMetricsTestPostgres(t)
+	ctx := context.Background()
+	store := NewPostgres(app, nil)
+
+	const window = 30 * 24 * time.Hour
+	now := time.Now()
+	boundaryDay, today, tailLower, _, _, _, nowUTC := fleetUptimeParams(now, window)
+
+	tenant := metricsSeedTenant(t, admin, "persite-series-"+uuid.NewString()[:8])
+	siteID := metricsSeedSite(t, admin, tenant, "https://"+uuid.NewString()+".example.com")
+
+	var checks []Check
+	add := func(at time.Time, up bool, totalMs float64) {
+		checks = append(checks, Check{TenantID: tenant, SiteID: siteID, CheckedAt: at, Up: up, TotalMs: totalMs})
+	}
+	// Boundary day: one probe before the window start (must not appear in the
+	// boundary point) and two inside it.
+	add(tailLower.Add(-time.Hour), true, 500)
+	add(tailLower.Add(time.Minute), true, 100)
+	add(tailLower.Add(90*time.Minute), false, 700)
+	// Every complete day in between.
+	for d := boundaryDay.Add(24 * time.Hour); d.Before(today); d = d.Add(24 * time.Hour) {
+		add(d.Add(3*time.Hour), true, 120)
+		add(d.Add(15*time.Hour), true, 160)
+	}
+	// Today, anchored to `now` so the test cannot fall off the day boundary
+	// when it happens to run just after UTC midnight.
+	add(nowUTC.Add(-2*time.Second), true, 140)
+	add(nowUTC.Add(-time.Second), false, 640)
+	seedWithRollup(t, store, checks)
+
+	// buckets=100 is what the HTTP handler passes; the daily path ignores it,
+	// which is exactly what the point count below proves.
+	points, err := store.QuerySeries(ctx, tenant, siteID, window, 100)
+	if err != nil {
+		t.Fatalf("QuerySeries: %v", err)
+	}
+	if len(points) == 0 {
+		t.Fatal("QuerySeries returned no points")
+	}
+
+	// Independent Go grouping of the in-window seeds by UTC day.
+	type dayAgg struct{ checks, upChecks int }
+	wantByDay := map[time.Time]*dayAgg{}
+	for _, c := range checks {
+		if c.CheckedAt.Before(tailLower) || c.CheckedAt.After(nowUTC) {
+			continue
+		}
+		d := utcDay(c.CheckedAt)
+		if wantByDay[d] == nil {
+			wantByDay[d] = &dayAgg{}
+		}
+		wantByDay[d].checks++
+		if c.Up {
+			wantByDay[d].upChecks++
+		}
+	}
+	if len(points) != len(wantByDay) {
+		t.Fatalf("QuerySeries returned %d points, want %d (one per UTC day with in-window probes). ~100 fixed-width buckets means the daily path did not run", len(points), len(wantByDay))
+	}
+	// Sanity on the absolute size, so a future change that silently reverts to
+	// fixed-width bucketing is caught even if the day-count assertion above
+	// were weakened: a 30-day window can only ever span 30 or 31 UTC days.
+	if len(points) < 29 || len(points) > 31 {
+		t.Fatalf("30-day window produced %d points, want 30 or 31 daily points", len(points))
+	}
+
+	var prev time.Time
+	for i, p := range points {
+		b := p.Bucket.UTC()
+		if !b.Equal(b.Truncate(24 * time.Hour)) {
+			t.Fatalf("point %d bucket %v is not a UTC midnight: buckets must align to the rollup's day grain", i, b)
+		}
+		if i > 0 {
+			if !b.After(prev) {
+				t.Fatalf("points are not strictly increasing: %v then %v", prev, b)
+			}
+			if gap := b.Sub(prev); gap%(24*time.Hour) != 0 {
+				t.Fatalf("gap between point %d and %d is %v, not a whole number of days", i-1, i, gap)
+			}
+		}
+		prev = b
+
+		w, ok := wantByDay[b]
+		if !ok {
+			t.Fatalf("point %d has bucket %v, which has no in-window probes at all", i, b)
+		}
+		if p.Checks != uint64(w.checks) || p.UpChecks != uint64(w.upChecks) {
+			t.Fatalf("bucket %v: got %d/%d up/checks, want %d/%d", b, p.UpChecks, p.Checks, w.upChecks, w.checks)
+		}
+	}
+
+	// The boundary day's point must cover ONLY the in-window slice: the probe
+	// seeded an hour before the window start must not be in it.
+	first := points[0]
+	if !first.Bucket.UTC().Equal(boundaryDay) {
+		t.Fatalf("first point bucket = %v, want the boundary day %v", first.Bucket.UTC(), boundaryDay)
+	}
+	if first.Checks != 2 {
+		t.Fatalf("boundary day point has %d checks, want 2 (the out-of-window probe on the same day must be excluded)", first.Checks)
+	}
+}
+
+// TestQuerySeries_SubDayWindowStillReadsRawMinuteBuckets is the no-regression
+// guard for C4: below the threshold nothing changes. A 1h window must still
+// come back as per-minute raw buckets, not a single daily point.
+func TestQuerySeries_SubDayWindowStillReadsRawMinuteBuckets(t *testing.T) {
+	app, admin := startMetricsTestPostgres(t)
+	ctx := context.Background()
+	store := NewPostgres(app, nil)
+
+	now := time.Now().UTC()
+	tenant := metricsSeedTenant(t, admin, "persite-subday-"+uuid.NewString()[:8])
+	siteID := metricsSeedSite(t, admin, tenant, "https://"+uuid.NewString()+".example.com")
+
+	// Ten probes, each in its own minute, comfortably inside a 1h window.
+	var checks []Check
+	minutes := map[time.Time]bool{}
+	for i := 1; i <= 10; i++ {
+		at := now.Add(-time.Duration(i*3) * time.Minute)
+		checks = append(checks, Check{TenantID: tenant, SiteID: siteID, CheckedAt: at, Up: i%4 != 0, TotalMs: float64(100 + i)})
+		minutes[at.Truncate(time.Minute)] = true
+	}
+	seedWithRollup(t, store, checks)
+
+	points, err := store.QuerySeries(ctx, tenant, siteID, time.Hour, 100)
+	if err != nil {
+		t.Fatalf("QuerySeries: %v", err)
+	}
+	if len(points) != len(minutes) {
+		t.Fatalf("1h window returned %d points, want %d (one per distinct minute): the sub-day path must keep reading raw probes at minute granularity", len(points), len(minutes))
+	}
+	midnights := 0
+	var total uint64
+	for _, p := range points {
+		b := p.Bucket.UTC()
+		if !b.Equal(b.Truncate(time.Minute)) {
+			t.Fatalf("bucket %v is not minute-aligned", b)
+		}
+		if b.Equal(b.Truncate(24 * time.Hour)) {
+			midnights++
+		}
+		total += p.Checks
+	}
+	if midnights == len(points) {
+		t.Fatal("every 1h-window bucket is a UTC midnight: the daily path ran for a sub-day window")
+	}
+	if total != uint64(len(checks)) {
+		t.Fatalf("sub-day series covers %d checks, want %d", total, len(checks))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// T4: the boundary partial day
+// ---------------------------------------------------------------------------
+
+// TestPerSiteWindow_BoundaryDayCountedExactlyOnce is the double-count /
+// dropped-day guard. The oldest day in the window is seeded with probes on
+// BOTH sides of the window start and the rollup row for that day therefore
+// holds the WHOLE day's counters, including the out-of-window part. Both the
+// aggregate and the series must report only the in-window slice: counting the
+// boundary day's rollup row as well would inflate it, and excluding the raw
+// tail would drop it entirely.
+func TestPerSiteWindow_BoundaryDayCountedExactlyOnce(t *testing.T) {
+	app, admin := startMetricsTestPostgres(t)
+	ctx := context.Background()
+	store := NewPostgres(app, nil)
+
+	const window = 7 * 24 * time.Hour
+	now := time.Now()
+	boundaryDay, today, tailLower, _, _, _, nowUTC := fleetUptimeParams(now, window)
+
+	tenant := metricsSeedTenant(t, admin, "persite-boundary-"+uuid.NewString()[:8])
+	siteID := metricsSeedSite(t, admin, tenant, "https://"+uuid.NewString()+".example.com")
+
+	var checks []Check
+	add := func(at time.Time, up bool, totalMs float64) {
+		checks = append(checks, Check{TenantID: tenant, SiteID: siteID, CheckedAt: at, Up: up, TotalMs: totalMs})
+	}
+	// Boundary day, BEFORE the window start: 3 probes, all up. Present in that
+	// day's rollup row, and must never reach the answer.
+	add(tailLower.Add(-4*time.Hour), true, 300)
+	add(tailLower.Add(-2*time.Hour), true, 310)
+	add(tailLower.Add(-time.Minute), true, 320)
+	// Boundary day, AFTER the window start: 2 probes, one down.
+	add(tailLower.Add(time.Minute), false, 800)
+	add(tailLower.Add(2*time.Hour), true, 130)
+	// One complete mid-window day and today, so the other two parts are
+	// non-empty and a mistake in the boundary part cannot hide.
+	midDay := boundaryDay.Add(2 * 24 * time.Hour)
+	if !midDay.Before(today) {
+		t.Fatalf("fixture bug: midDay %v is not inside the window (today=%v)", midDay, today)
+	}
+	add(midDay.Add(8*time.Hour), true, 140)
+	add(nowUTC.Add(-time.Minute), true, 150)
+	seedWithRollup(t, store, checks)
+
+	// The boundary day's rollup row really does hold the whole day (5 probes),
+	// which is what makes this test meaningful.
+	var dailyTotal int64
+	if err := admin.QueryRow(ctx,
+		`SELECT total_checks FROM site_uptime_daily WHERE site_id = $1 AND day = $2::date`,
+		siteID, boundaryDay).Scan(&dailyTotal); err != nil {
+		t.Fatalf("read boundary day rollup row: %v", err)
+	}
+	if dailyTotal != 5 {
+		t.Fatalf("fixture bug: boundary day rollup total_checks = %d, want 5", dailyTotal)
+	}
+
+	// Aggregate: 2 (in-window boundary) + 1 (mid day) + 1 (today) = 4.
+	agg, err := store.QueryAggregate(ctx, tenant, siteID, window)
+	if err != nil {
+		t.Fatalf("QueryAggregate: %v", err)
+	}
+	if agg.Checks != 4 {
+		t.Fatalf("Checks = %d, want 4. 7 would mean the boundary day's rollup row was added on top of the raw tail (double counted); 2 would mean the raw tail was dropped", agg.Checks)
+	}
+	if agg.UpChecks != 3 {
+		t.Fatalf("UpChecks = %d, want 3", agg.UpChecks)
+	}
+
+	// Series: exactly one point for the boundary day, carrying the in-window
+	// slice only.
+	points, err := store.QuerySeries(ctx, tenant, siteID, window, 100)
+	if err != nil {
+		t.Fatalf("QuerySeries: %v", err)
+	}
+	var boundaryPoints []Point
+	var seriesTotal uint64
+	for _, p := range points {
+		seriesTotal += p.Checks
+		if p.Bucket.UTC().Equal(boundaryDay) {
+			boundaryPoints = append(boundaryPoints, p)
+		}
+	}
+	if len(boundaryPoints) != 1 {
+		t.Fatalf("series has %d points for the boundary day %v, want exactly 1", len(boundaryPoints), boundaryDay)
+	}
+	if boundaryPoints[0].Checks != 2 || boundaryPoints[0].UpChecks != 1 {
+		t.Fatalf("boundary day point = %d up / %d checks, want 1/2 (the in-window slice only, not the whole day's 5)", boundaryPoints[0].UpChecks, boundaryPoints[0].Checks)
+	}
+	if seriesTotal != agg.Checks {
+		t.Fatalf("series covers %d checks but the aggregate reports %d: the two per-site reads disagree about the same window", seriesTotal, agg.Checks)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// T5: the C2 case, probes with no rollup row
+// ---------------------------------------------------------------------------
+
+// TestQueryAggregate_RollupGapIsNotBackfilledFromRawProbes asserts the
+// DELIBERATE behaviour chosen for C2, rather than leaving it undiscovered.
+//
+// The rollup upsert is best effort: uptime.ProbeWorker.Sweep logs and
+// continues when it fails, so a complete mid-window day can hold raw probes
+// with no matching site_uptime_daily row. For such a day the per-site read now
+// reports the rollup's answer (nothing) rather than rescanning raw probes, and
+// this test pins exactly that, in both directions:
+//
+//   - the missing day's checks are NOT counted, and
+//   - the number the per-site card shows is then the SAME number the fleet
+//     read (QueryFleetUptime, unchanged since m99) shows for the same site and
+//     window - which is the real reason a raw-probe fallback is not wanted
+//     here. A fallback would also be indistinguishable from a site that
+//     genuinely had no probes those days (paused, newly added), and would put
+//     the full-window scan back for exactly the sites it was removed from.
+func TestQueryAggregate_RollupGapIsNotBackfilledFromRawProbes(t *testing.T) {
+	app, admin := startMetricsTestPostgres(t)
+	ctx := context.Background()
+	store := NewPostgres(app, nil)
+
+	const window = 30 * 24 * time.Hour
+	now := time.Now()
+	boundaryDay, today, tailLower, _, _, _, nowUTC := fleetUptimeParams(now, window)
+
+	tenant := metricsSeedTenant(t, admin, "persite-gap-"+uuid.NewString()[:8])
+	siteID := metricsSeedSite(t, admin, tenant, "https://"+uuid.NewString()+".example.com")
+
+	dayA := boundaryDay.Add(2 * 24 * time.Hour) // rolled up normally
+	dayB := boundaryDay.Add(4 * 24 * time.Hour) // the gap: raw probes only
+	for _, d := range []time.Time{dayA, dayB} {
+		if !d.Before(today) {
+			t.Fatalf("fixture bug: %v is not a complete mid-window day (today=%v)", d, today)
+		}
+	}
+
+	// Everything except dayB goes through both write paths.
+	rolled := []Check{
+		{TenantID: tenant, SiteID: siteID, CheckedAt: tailLower.Add(time.Minute), Up: true, TotalMs: 100},
+		{TenantID: tenant, SiteID: siteID, CheckedAt: dayA.Add(6 * time.Hour), Up: true, TotalMs: 110},
+		{TenantID: tenant, SiteID: siteID, CheckedAt: dayA.Add(18 * time.Hour), Up: true, TotalMs: 120},
+		{TenantID: tenant, SiteID: siteID, CheckedAt: nowUTC.Add(-time.Minute), Up: true, TotalMs: 130},
+	}
+	seedWithRollup(t, store, rolled)
+
+	// dayB: the raw insert succeeded and the rollup upsert did not. Four down
+	// probes, so a fallback that silently rescanned raw rows would be obvious
+	// in the uptime percentage, not just the count.
+	var gapped []Check
+	for i := 0; i < 4; i++ {
+		gapped = append(gapped, Check{
+			TenantID: tenant, SiteID: siteID,
+			CheckedAt: dayB.Add(time.Duration(i+1) * 3 * time.Hour),
+			Up:        false, TotalMs: 900,
+		})
+	}
+	if err := store.InsertChecks(ctx, gapped); err != nil {
+		t.Fatalf("insert gapped checks: %v", err)
+	}
+	var gapRollupRows int
+	if err := admin.QueryRow(ctx,
+		`SELECT count(*) FROM site_uptime_daily WHERE site_id = $1 AND day = $2::date`,
+		siteID, dayB).Scan(&gapRollupRows); err != nil {
+		t.Fatalf("count dayB rollup rows: %v", err)
+	}
+	if gapRollupRows != 0 {
+		t.Fatalf("fixture bug: dayB has %d rollup rows, want 0", gapRollupRows)
+	}
+
+	agg, err := store.QueryAggregate(ctx, tenant, siteID, window)
+	if err != nil {
+		t.Fatalf("QueryAggregate: %v", err)
+	}
+	// 4 rolled-up checks, all up. dayB's 4 down probes are invisible.
+	if agg.Checks != 4 || agg.UpChecks != 4 {
+		t.Fatalf("Checks/UpChecks = %d/%d, want 4/4. 8/4 would mean the read fell back to raw probes for a day the rollup does not cover, which is not the documented behaviour",
+			agg.Checks, agg.UpChecks)
+	}
+	if absDiff(agg.UptimePct, 100) > 1e-9 {
+		t.Fatalf("UptimePct = %v, want 100", agg.UptimePct)
+	}
+
+	// And the fleet read, which has behaved this way since m99, agrees.
+	fleet, err := store.QueryFleetUptime(ctx, tenant, []uuid.UUID{siteID}, window)
+	if err != nil {
+		t.Fatalf("QueryFleetUptime: %v", err)
+	}
+	row, ok := fleet[siteID]
+	if !ok || row.UptimePct7d == nil {
+		t.Fatalf("fleet read returned no uptime for the site: %+v ok=%v", row, ok)
+	}
+	if absDiff(*row.UptimePct7d, agg.UptimePct) > 1e-9 {
+		t.Fatalf("per-site UptimePct %v disagrees with the fleet read's %v for the same site and window: the two cards on the same screen would show different numbers",
+			agg.UptimePct, *row.UptimePct7d)
+	}
+
+	// The series shows the same gap, in the same place: a point for the
+	// boundary day, dayA and today, and none for dayB.
+	points, err := store.QuerySeries(ctx, tenant, siteID, window, 100)
+	if err != nil {
+		t.Fatalf("QuerySeries: %v", err)
+	}
+	got := make([]time.Time, 0, len(points))
+	for _, p := range points {
+		got = append(got, p.Bucket.UTC())
+	}
+	sort.Slice(got, func(i, j int) bool { return got[i].Before(got[j]) })
+	want := []time.Time{boundaryDay, dayA, today}
+	if len(got) != len(want) {
+		t.Fatalf("series buckets = %v, want %v (dayB has no rollup row, so it has no point)", got, want)
+	}
+	for i := range want {
+		if !got[i].Equal(want[i]) {
+			t.Fatalf("series buckets = %v, want %v", got, want)
+		}
+	}
+}

--- a/apps/api/internal/metrics/postgres_persite_test.go
+++ b/apps/api/internal/metrics/postgres_persite_test.go
@@ -1,0 +1,157 @@
+package metrics
+
+// postgres_persite_test.go: 0.61.125 static guards for the per-site window
+// reads (siteAggregateQuery / siteDailySeriesQuery), mirroring the style of
+// postgres_test.go's guards on fleetUptimeQuery: they inspect the actual SQL
+// constants and the actual threshold constant the production code executes, so
+// a regression that widens a bounded read back into a full-window scan, drops
+// the rollup, or silently moves the daily/raw cutover fails a fast, DB-less
+// test. The numeric equivalence and granularity properties are proven against
+// a real Postgres in postgres_persite_pg_test.go.
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSitePerWindowQueries_ReadRollupAndOnlyBoundedRawEdges is the per-site
+// twin of TestFleetUptimeQuery_ReferencesRollupAndBoundedRawEdges. Before this
+// change QueryAggregate and QuerySeries each ran a single
+// "probed_at >= now - window" scan over site_uptime_probes, which is what made
+// the endpoint cost up to 32.5s on a cold buffer cache. Both queries must now
+// read the rollup for the window's middle and touch raw probes ONLY through
+// two ranges that are bounded on BOTH sides.
+func TestSitePerWindowQueries_ReadRollupAndOnlyBoundedRawEdges(t *testing.T) {
+	for name, q := range map[string]string{
+		"siteAggregateQuery":   siteAggregateQuery,
+		"siteDailySeriesQuery": siteDailySeriesQuery,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !strings.Contains(q, "site_uptime_daily") {
+				t.Fatalf("%s no longer reads site_uptime_daily: the whole window would be served from raw probes again", name)
+			}
+			if n := strings.Count(q, "FROM site_uptime_probes"); n != 2 {
+				t.Fatalf("%s has %d site_uptime_probes sub-selects, want exactly 2 (boundary tail + today)", name, n)
+			}
+			if n := strings.Count(q, " probed_at >="); n != 2 {
+				t.Fatalf("%s has %d lower-bounded probed_at predicates, want 2", name, n)
+			}
+			upper := strings.Count(q, "probed_at < $6::timestamptz") + strings.Count(q, "probed_at <= $8::timestamptz")
+			if upper != 2 {
+				t.Fatalf("%s has %d upper-bounded probed_at predicates (want 2: boundary tail '< $6', today '<= $8'): a raw read may have regressed to an unbounded scan", name, upper)
+			}
+			// The rollup middle must EXCLUDE both edge days, or it would double
+			// count the two raw reads.
+			if !strings.Contains(q, "day > $3::date AND day < $4::date") {
+				t.Fatalf("%s's rollup middle predicate changed shape: it must stay strictly between boundaryDay and today so it can never overlap the raw edge reads", name)
+			}
+			// Every tenant-scoped read keeps its explicit tenant_id predicate
+			// (defense in depth in front of RLS, and index coverage).
+			if n := strings.Count(q, "tenant_id = $1"); n != 3 {
+				t.Fatalf("%s has %d explicit tenant_id predicates, want 3 (one per window part)", name, n)
+			}
+		})
+	}
+}
+
+// TestSiteDailySeriesQuery_BucketsAreUTCAndNotSessionDependent guards the one
+// timezone trap in the daily series: site_uptime_daily.day is a `date`, and a
+// bare day::timestamptz would be resolved against the Postgres session's
+// TimeZone GUC, shifting every bucket by the server's offset on a non-UTC
+// self-host. The conversion must be pinned to UTC, exactly like every other
+// boundary in the decomposition.
+func TestSiteDailySeriesQuery_BucketsAreUTCAndNotSessionDependent(t *testing.T) {
+	if !strings.Contains(siteDailySeriesQuery, "(day::timestamp AT TIME ZONE 'UTC')") {
+		t.Fatal("siteDailySeriesQuery no longer converts the rollup's date column with an explicit AT TIME ZONE 'UTC': daily buckets would shift with the server's session timezone")
+	}
+	// The two raw edge parts label themselves from bound timestamptz params
+	// ($9/$10), never from a server-side now()/CURRENT_DATE.
+	for _, forbidden := range []string{"CURRENT_DATE", "now()"} {
+		if strings.Contains(siteDailySeriesQuery, forbidden) {
+			t.Fatalf("siteDailySeriesQuery uses %s: every boundary must be computed in Go from now.UTC() and bound as a parameter", forbidden)
+		}
+	}
+	if !strings.Contains(siteDailySeriesQuery, "$9::timestamptz") || !strings.Contains(siteDailySeriesQuery, "$10::timestamptz") {
+		t.Fatal("siteDailySeriesQuery no longer labels its two raw edge parts from the bound $9/$10 bucket params")
+	}
+	// Days with no probes must not appear, matching the raw path's GROUP BY.
+	if !strings.Contains(siteDailySeriesQuery, "WHERE total_checks > 0") {
+		t.Fatal("siteDailySeriesQuery dropped the total_checks > 0 filter: an empty edge range would emit a zero-check point the raw path never emitted")
+	}
+}
+
+// TestDailySeriesMinWindow_IsExactlyOneDay pins the documented threshold. It is
+// not a taste knob: 24h is exactly the smallest window for which the
+// decomposition guarantees boundaryDay < today, which is what makes the
+// boundary-tail day, the rollup middle days and today three disjoint day sets.
+// Changing it without changing that reasoning is a bug.
+func TestDailySeriesMinWindow_IsExactlyOneDay(t *testing.T) {
+	if dailySeriesMinWindow != 24*time.Hour {
+		t.Fatalf("dailySeriesMinWindow = %v, want exactly 24h (see its doc comment for why this exact value)", dailySeriesMinWindow)
+	}
+}
+
+// TestDailySeriesThreshold_GuaranteesDisjointDayParts is the proof behind the
+// threshold: at or above dailySeriesMinWindow, for ANY instant within a UTC
+// day, the oldest (partial) day is strictly before today, so the three parts
+// each own a distinct set of days and no day can be counted twice or dropped.
+// Below the threshold that guarantee does not hold, which is why the sub-day
+// path keeps reading raw probes.
+func TestDailySeriesThreshold_GuaranteesDisjointDayParts(t *testing.T) {
+	base := time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC)
+	offsets := []time.Duration{
+		0,
+		time.Second,
+		time.Minute,
+		6 * time.Hour,
+		12*time.Hour + 37*time.Minute,
+		23*time.Hour + 59*time.Minute + 59*time.Second,
+	}
+	windows := []time.Duration{
+		dailySeriesMinWindow,
+		dailySeriesMinWindow + time.Minute,
+		25 * time.Hour,
+		48 * time.Hour,
+		7 * 24 * time.Hour,
+		30 * 24 * time.Hour,
+		90 * 24 * time.Hour,
+	}
+
+	for _, off := range offsets {
+		for _, window := range windows {
+			now := base.Add(off)
+			boundaryDay, today, tailLower, tailUpper, _, todayLower, nowUTC := fleetUptimeParams(now, window)
+
+			if !boundaryDay.Before(today) {
+				t.Fatalf("window=%v now=%v: boundaryDay %v is not strictly before today %v, so the boundary tail and today would fight over the same day", window, now, boundaryDay, today)
+			}
+			// The boundary tail never reaches into today, and today's part
+			// never reaches back before today's midnight: no overlap.
+			if tailUpper.After(today) {
+				t.Fatalf("window=%v now=%v: tailUpper %v spills past today's midnight %v", window, now, tailUpper, today)
+			}
+			if todayLower.Before(today) {
+				t.Fatalf("window=%v now=%v: todayLower %v starts before today's midnight %v", window, now, todayLower, today)
+			}
+			// And no gap: the tail ends exactly where the rollup middle picks
+			// up, and the rollup middle ends exactly where today's part starts.
+			if !tailUpper.Equal(boundaryDay.Add(24*time.Hour)) && !tailUpper.Equal(today) {
+				t.Fatalf("window=%v now=%v: tailUpper %v is neither boundaryDay+1 nor today: the tail no longer meets the next part", window, now, tailUpper)
+			}
+			if tailLower.After(tailUpper) || todayLower.After(nowUTC) {
+				t.Fatalf("window=%v now=%v: bounds inverted (tailLower=%v tailUpper=%v todayLower=%v now=%v)", window, now, tailLower, tailUpper, todayLower, nowUTC)
+			}
+		}
+	}
+
+	// Below the threshold the guarantee genuinely does not hold: a sub-day
+	// window sitting inside today collapses boundaryDay onto today. This is
+	// the case the raw path exists to serve, and asserting it here keeps the
+	// threshold's justification honest rather than merely asserted in a
+	// comment.
+	boundaryDay, today, _, _, _, _, _ := fleetUptimeParams(base.Add(14*time.Hour), time.Hour)
+	if !boundaryDay.Equal(today) {
+		t.Fatalf("sub-day window: boundaryDay %v != today %v, so the stated reason for the 24h threshold no longer holds", boundaryDay, today)
+	}
+}

--- a/apps/api/internal/report/aggregate_daily_utc_test.go
+++ b/apps/api/internal/report/aggregate_daily_utc_test.go
@@ -1,0 +1,62 @@
+package report
+
+// aggregate_daily_utc_test.go: 0.61.125. The uptime series feeding a client
+// report is now one point per UTC day for any window of a day or more
+// (metrics.pgStore.querySeriesDaily), and each of those points sits EXACTLY on
+// a UTC midnight. aggregateDailyBuckets used to read the calendar day off the
+// driver-returned local-zone value, which is harmless for the arbitrary
+// instants the old fixed-width bucketing produced but puts every
+// UTC-midnight point in the previous calendar day on any deployment west of
+// UTC. This test runs the grouping against a deliberately negative-offset
+// zone, so it fails if the UTC grouping is ever removed.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/metrics"
+)
+
+func TestAggregateDailyBuckets_GroupsByUTCDayRegardlessOfServerZone(t *testing.T) {
+	// A zone well west of UTC: a UTC midnight is 17:00 the PREVIOUS day here.
+	west := time.FixedZone("UTC-7", -7*60*60)
+
+	days := []time.Time{
+		time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC),
+	}
+	points := make([]metrics.Point, 0, len(days))
+	for i, d := range days {
+		points = append(points, metrics.Point{
+			// Same instant, expressed in the west zone: exactly what the pgx
+			// driver hands back on a process whose local zone is not UTC.
+			Bucket:       d.In(west),
+			Checks:       1440,
+			UpChecks:     uint64(1440 - i),
+			AvgLatencyMs: float64(100 + i),
+		})
+	}
+
+	got := aggregateDailyBuckets(points)
+	if len(got) != len(days) {
+		t.Fatalf("got %d daily buckets, want %d", len(got), len(days))
+	}
+	for i, day := range got {
+		want := days[i]
+		if !day.Day.Equal(want) {
+			t.Fatalf("bucket %d has day %v, want %v. The grouping is reading the calendar day in the server's local zone, so every UTC-midnight point lands in the previous day", i, day.Day, want)
+		}
+		if day.Day.Location() != time.UTC {
+			t.Fatalf("bucket %d day %v is not in UTC", i, day.Day)
+		}
+	}
+
+	// The counters must survive the regrouping untouched.
+	if got[0].UptimePct != 100 {
+		t.Fatalf("first day UptimePct = %v, want 100 (1440/1440 up)", got[0].UptimePct)
+	}
+	if got[2].AvgLatencyMs != 102 {
+		t.Fatalf("third day AvgLatencyMs = %v, want 102", got[2].AvgLatencyMs)
+	}
+}

--- a/apps/api/internal/report/aggregator.go
+++ b/apps/api/internal/report/aggregator.go
@@ -354,7 +354,18 @@ func buildPerfSection(ctx context.Context, src Sources, tenantID, siteID uuid.UU
 // Helper functions
 // ---------------------------------------------------------------------------
 
-// aggregateDailyBuckets collapses hourly Points into daily UptimeDay buckets.
+// aggregateDailyBuckets collapses Points into daily UptimeDay buckets.
+//
+// The day is taken in UTC, deliberately and explicitly. Point.Bucket is a
+// timestamptz the driver hands back in the process's local zone, and every
+// bucket the metrics store produces is keyed to a UTC day boundary: from
+// 0.61.125 a window of a day or more comes back as one point sitting exactly
+// on UTC midnight (metrics.pgStore.querySeriesDaily, drawn from
+// site_uptime_daily, whose day column is a UTC date). Reading .Day() off the
+// local-zone value would put every one of those points in the PREVIOUS
+// calendar day on any deployment running west of UTC, shifting a whole
+// report's daily labels by one. Grouping in UTC keeps the report's days
+// identical to the days the rollup itself is keyed by, on every deployment.
 func aggregateDailyBuckets(points []metrics.Point) []UptimeDay {
 	type dayKey struct{ y, m, d int }
 	type dayAcc struct {
@@ -365,7 +376,8 @@ func aggregateDailyBuckets(points []metrics.Point) []UptimeDay {
 	days := make(map[dayKey]*dayAcc)
 	var order []dayKey
 	for _, p := range points {
-		k := dayKey{p.Bucket.Year(), int(p.Bucket.Month()), p.Bucket.Day()}
+		b := p.Bucket.UTC()
+		k := dayKey{b.Year(), int(b.Month()), b.Day()}
 		if _, ok := days[k]; !ok {
 			days[k] = &dayAcc{}
 			order = append(order, k)

--- a/apps/api/internal/uptime/service.go
+++ b/apps/api/internal/uptime/service.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 	"github.com/mosamlife/wpmgr/apps/api/internal/metrics"
@@ -65,7 +66,28 @@ func NewService(repo Repo, store metrics.Store, verifier SiteVerifier) *Service 
 
 // Uptime returns the windowed uptime report for a site. It first verifies the
 // site belongs to tenantID (Postgres/RLS) — a foreign site yields a 404 — then
-// queries ClickHouse scoped by tenant_id+site_id.
+// queries the metrics store scoped by tenant_id+site_id.
+//
+// VerifySite stays STRICTLY BEFORE the fan-out below: it is the authorisation
+// check, and a foreign siteID must be refused without any metrics query being
+// issued on its behalf.
+//
+// The three store reads are then issued CONCURRENTLY (0.61.125). Each one
+// opens its own transaction in the Postgres backend (InAgentTx: BEGIN,
+// set_config, the query, COMMIT), so running them in sequence cost roughly
+// nine round trips where the fleet summary endpoint costs one, a large part
+// of why this endpoint was so much slower than /uptime/summary on the same
+// page load. They are fully independent of each other and none feeds another,
+// so the whole set is one wall-clock wait instead of three.
+//
+// Error handling deliberately keeps the OLD, deterministic outcome: each read
+// keeps its own domain.Internal wrapping, and when more than one fails the
+// error returned is the one the sequential version would have returned first
+// (aggregate, then latest, then series). A plain errgroup.Group is used rather
+// than errgroup.WithContext for the same reason: cancelling the siblings on
+// the first failure would let a losing goroutine report a context error
+// instead of its real one, and all three are single short reads with nothing
+// to save by aborting them.
 func (s *Service) Uptime(ctx context.Context, tenantID, siteID uuid.UUID, window time.Duration, seriesBuckets int) (UptimeReport, error) {
 	if _, ok, err := s.verifier.VerifySite(ctx, tenantID, siteID); err != nil {
 		return UptimeReport{}, err
@@ -73,19 +95,55 @@ func (s *Service) Uptime(ctx context.Context, tenantID, siteID uuid.UUID, window
 		return UptimeReport{}, domain.NotFound("site_not_found", "site not found")
 	}
 
-	rep := UptimeReport{SiteID: siteID, Window: window}
-	agg, err := s.store.QueryAggregate(ctx, tenantID, siteID, window)
-	if err != nil {
-		return UptimeReport{}, domain.Internal("uptime_query_failed", "failed to query uptime metrics").WithCause(err)
+	var (
+		agg    metrics.Aggregate
+		latest metrics.Latest
+		series []metrics.Point
+
+		aggErr    error
+		latestErr error
+		seriesErr error
+	)
+
+	g := new(errgroup.Group)
+	g.Go(func() error {
+		var err error
+		if agg, err = s.store.QueryAggregate(ctx, tenantID, siteID, window); err != nil {
+			aggErr = domain.Internal("uptime_query_failed", "failed to query uptime metrics").WithCause(err)
+		}
+		return aggErr
+	})
+	g.Go(func() error {
+		var err error
+		if latest, err = s.store.QueryLatest(ctx, tenantID, siteID); err != nil {
+			latestErr = domain.Internal("uptime_query_failed", "failed to query latest uptime").WithCause(err)
+		}
+		return latestErr
+	})
+	g.Go(func() error {
+		var err error
+		if series, err = s.store.QuerySeries(ctx, tenantID, siteID, window, seriesBuckets); err != nil {
+			seriesErr = domain.Internal("uptime_query_failed", "failed to query uptime series").WithCause(err)
+		}
+		return seriesErr
+	})
+
+	// Wait establishes the happens-before edge for every variable written
+	// above, so the reads below (and the per-query error slots) are race-free.
+	if err := g.Wait(); err != nil {
+		for _, e := range []error{aggErr, latestErr, seriesErr} {
+			if e != nil {
+				return UptimeReport{}, e
+			}
+		}
+		return UptimeReport{}, err
 	}
+
+	rep := UptimeReport{SiteID: siteID, Window: window}
 	rep.UptimePct = agg.UptimePct
 	rep.AvgLatencyMs = agg.AvgLatencyMs
 	rep.Checks = agg.Checks
 
-	latest, err := s.store.QueryLatest(ctx, tenantID, siteID)
-	if err != nil {
-		return UptimeReport{}, domain.Internal("uptime_query_failed", "failed to query latest uptime").WithCause(err)
-	}
 	if latest.Found {
 		rep.Up = latest.Up
 		lc := latest.CheckedAt
@@ -98,10 +156,6 @@ func (s *Service) Uptime(ctx context.Context, tenantID, siteID uuid.UUID, window
 		rep.TLSSubject = latest.TLSSubject
 	}
 
-	series, err := s.store.QuerySeries(ctx, tenantID, siteID, window, seriesBuckets)
-	if err != nil {
-		return UptimeReport{}, domain.Internal("uptime_query_failed", "failed to query uptime series").WithCause(err)
-	}
 	rep.Series = series
 	return rep, nil
 }

--- a/apps/api/internal/uptime/service_uptime_concurrency_test.go
+++ b/apps/api/internal/uptime/service_uptime_concurrency_test.go
@@ -1,0 +1,286 @@
+package uptime
+
+// service_uptime_concurrency_test.go: 0.61.125. Service.Uptime used to issue
+// its three metrics reads (aggregate, latest, series) STRICTLY IN SEQUENCE,
+// each opening its own transaction in the Postgres backend, so the endpoint
+// paid three full round-trip stacks where /uptime/summary pays one. These
+// tests pin the two properties of the fan-out that matter:
+//
+//   - the three reads actually overlap in time (a barrier none of them can
+//     pass alone, so a sequential implementation deadlocks itself and fails
+//     with a specific message rather than merely being slow), and
+//   - the error the caller sees is still the deterministic one the sequential
+//     version would have produced, with each read's own wrapping intact.
+//
+// Neither test needs a database: the metrics.Store is a stub.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/metrics"
+)
+
+// barrierWait is how long a stubbed store call waits at the barrier before
+// declaring the reads sequential. Generous enough to never flake on a loaded
+// CI box, short enough that a genuine regression fails fast.
+const barrierWait = 5 * time.Second
+
+// barrierStore is a metrics.Store whose three per-site read methods each
+// announce their arrival and then block until the TEST releases them. All
+// three can only ever complete if all three are in flight at the same time,
+// which is exactly the property under test.
+type barrierStore struct {
+	arrived chan string
+	release chan struct{}
+
+	// Canned results, so the test can also assert the report is assembled
+	// correctly from three concurrently-produced values.
+	agg    metrics.Aggregate
+	latest metrics.Latest
+	series []metrics.Point
+
+	// Optional per-method failures for the error-priority test.
+	aggErr, latestErr, seriesErr error
+}
+
+func newBarrierStore() *barrierStore {
+	return &barrierStore{
+		arrived: make(chan string, 3),
+		release: make(chan struct{}),
+	}
+}
+
+// wait records that name entered, then blocks until released or the barrier
+// times out. A timeout means the other reads had not started yet, i.e. the
+// service is running them one after another.
+func (s *barrierStore) wait(name string) error {
+	s.arrived <- name
+	select {
+	case <-s.release:
+		return nil
+	case <-time.After(barrierWait):
+		return fmt.Errorf("%s blocked at the barrier for %s: the other two reads never started, so Service.Uptime is issuing them SEQUENTIALLY", name, barrierWait)
+	}
+}
+
+func (s *barrierStore) Enabled() bool { return true }
+func (s *barrierStore) Close() error  { return nil }
+func (s *barrierStore) InsertChecks(_ context.Context, _ []metrics.Check) error {
+	panic("not called")
+}
+func (s *barrierStore) QueryFleetUptime(_ context.Context, _ uuid.UUID, _ []uuid.UUID, _ time.Duration) (map[uuid.UUID]metrics.FleetUptimeRow, error) {
+	panic("not called")
+}
+func (s *barrierStore) QueryProbeWindow(_ context.Context, _, _ uuid.UUID, _, _ time.Time, _ int) ([]metrics.ProbeSample, error) {
+	panic("not called")
+}
+
+func (s *barrierStore) QueryAggregate(_ context.Context, _, _ uuid.UUID, _ time.Duration) (metrics.Aggregate, error) {
+	if err := s.wait("QueryAggregate"); err != nil {
+		return metrics.Aggregate{}, err
+	}
+	return s.agg, s.aggErr
+}
+
+func (s *barrierStore) QueryLatest(_ context.Context, _, _ uuid.UUID) (metrics.Latest, error) {
+	if err := s.wait("QueryLatest"); err != nil {
+		return metrics.Latest{}, err
+	}
+	return s.latest, s.latestErr
+}
+
+func (s *barrierStore) QuerySeries(_ context.Context, _, _ uuid.UUID, _ time.Duration, _ int) ([]metrics.Point, error) {
+	if err := s.wait("QuerySeries"); err != nil {
+		return nil, err
+	}
+	return s.series, s.seriesErr
+}
+
+// countingVerifier is a SiteVerifier that always confirms ownership and counts
+// how many times it was asked, so the test can prove the authorisation check
+// still happens exactly once and BEFORE any store read.
+type countingVerifier struct {
+	calls int
+}
+
+func (v *countingVerifier) VerifySite(_ context.Context, _, _ uuid.UUID) (string, bool, error) {
+	v.calls++
+	return "example", true, nil
+}
+func (v *countingVerifier) ListSiteIDs(_ context.Context, _ uuid.UUID) ([]uuid.UUID, error) {
+	panic("not called")
+}
+
+// TestUptime_ThreeStoreReadsRunConcurrently is the ordering proof: each of the
+// three reads blocks at a shared barrier that only the test can lift, and the
+// test only lifts it once it has seen all three arrive. Against the previous
+// sequential implementation the first read waits alone for barrierWait, the
+// other two never start, and the test fails naming the read that was stuck.
+func TestUptime_ThreeStoreReadsRunConcurrently(t *testing.T) {
+	store := newBarrierStore()
+	lastCheck := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	tlsExpiry := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	store.agg = metrics.Aggregate{Checks: 43200, UpChecks: 43100, UptimePct: 99.768, AvgLatencyMs: 187.5}
+	store.latest = metrics.Latest{
+		CheckedAt: lastCheck, Up: true, TLSExpiry: tlsExpiry,
+		TLSIssuer: "Test CA", TLSSubject: "example.com", Found: true,
+	}
+	store.series = []metrics.Point{
+		{Bucket: lastCheck.Add(-24 * time.Hour), Checks: 1440, UpChecks: 1440, AvgLatencyMs: 190},
+		{Bucket: lastCheck, Checks: 720, UpChecks: 700, AvgLatencyMs: 185},
+	}
+
+	verifier := &countingVerifier{}
+	svc := NewService(&stubRepo{}, store, verifier)
+
+	type result struct {
+		rep UptimeReport
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		rep, err := svc.Uptime(context.Background(), uuid.New(), uuid.New(), 30*24*time.Hour, 100)
+		done <- result{rep, err}
+	}()
+
+	// All three reads must be in flight before ANY of them is allowed to
+	// finish. Collect the three arrivals; a missing one is the regression.
+	seen := make(map[string]bool, 3)
+	for i := 0; i < 3; i++ {
+		select {
+		case name := <-store.arrived:
+			seen[name] = true
+		case <-time.After(barrierWait):
+			t.Fatalf("only %d of 3 store reads had started after %s (saw %v): Service.Uptime is running them sequentially, not concurrently", len(seen), barrierWait, seen)
+		}
+	}
+	for _, want := range []string{"QueryAggregate", "QueryLatest", "QuerySeries"} {
+		if !seen[want] {
+			t.Fatalf("%s never started; saw %v", want, seen)
+		}
+	}
+	close(store.release)
+
+	var got result
+	select {
+	case got = <-done:
+	case <-time.After(barrierWait):
+		t.Fatal("Service.Uptime did not return after the barrier was released")
+	}
+	if got.err != nil {
+		t.Fatalf("Uptime returned an error: %v", got.err)
+	}
+
+	// The report must still be assembled correctly from the three concurrent
+	// results (the refactor must not have crossed any wires).
+	if got.rep.Checks != 43200 || got.rep.UptimePct != 99.768 || got.rep.AvgLatencyMs != 187.5 {
+		t.Fatalf("aggregate fields not wired through: %+v", got.rep)
+	}
+	if !got.rep.Up {
+		t.Fatal("latest.Up not wired through")
+	}
+	if got.rep.LastCheck == nil || !got.rep.LastCheck.Equal(lastCheck) {
+		t.Fatalf("LastCheck = %v, want %v", got.rep.LastCheck, lastCheck)
+	}
+	if got.rep.TLSExpiry == nil || !got.rep.TLSExpiry.Equal(tlsExpiry) {
+		t.Fatalf("TLSExpiry = %v, want %v", got.rep.TLSExpiry, tlsExpiry)
+	}
+	if got.rep.TLSIssuer != "Test CA" || got.rep.TLSSubject != "example.com" {
+		t.Fatalf("TLS identity not wired through: issuer=%q subject=%q", got.rep.TLSIssuer, got.rep.TLSSubject)
+	}
+	if len(got.rep.Series) != 2 || got.rep.Series[1].Checks != 720 {
+		t.Fatalf("series not wired through: %+v", got.rep.Series)
+	}
+
+	// The authorisation check ran exactly once, and (by construction) before
+	// the fan-out: the goroutine could not have reached the barrier at all if
+	// VerifySite had not already returned ok.
+	if verifier.calls != 1 {
+		t.Fatalf("VerifySite called %d times, want exactly 1", verifier.calls)
+	}
+}
+
+// TestUptime_ForeignSiteIsRefusedWithoutAnyStoreRead pins the authorisation
+// ordering explicitly: a site the tenant does not own must 404 without a
+// single metrics read being issued. The barrier store panics on nothing here,
+// but its reads would block forever, so a regression that moved VerifySite
+// after the fan-out would hang this test rather than pass it.
+func TestUptime_ForeignSiteIsRefusedWithoutAnyStoreRead(t *testing.T) {
+	store := newBarrierStore()
+	svc := NewService(&stubRepo{}, store, &denyingVerifier{})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := svc.Uptime(context.Background(), uuid.New(), uuid.New(), 30*24*time.Hour, 100)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		de, ok := domain.AsDomain(err)
+		if !ok || de.Kind != domain.KindNotFound || de.Code != "site_not_found" {
+			t.Fatalf("err = %v, want a domain NotFound site_not_found", err)
+		}
+	case <-time.After(barrierWait):
+		t.Fatal("Uptime blocked: a store read was issued for a site the tenant does not own")
+	}
+	if len(store.arrived) != 0 {
+		t.Fatalf("%d store reads were issued for an unowned site, want 0", len(store.arrived))
+	}
+}
+
+type denyingVerifier struct{}
+
+func (denyingVerifier) VerifySite(_ context.Context, _, _ uuid.UUID) (string, bool, error) {
+	return "", false, nil
+}
+func (denyingVerifier) ListSiteIDs(_ context.Context, _ uuid.UUID) ([]uuid.UUID, error) {
+	panic("not called")
+}
+
+// TestUptime_ErrorPriorityIsDeterministic proves the fan-out did not make the
+// returned error depend on which goroutine happened to lose the race: with all
+// three reads failing at once, the caller still gets the aggregate read's
+// error, exactly as the old sequential code (which returned on the first
+// failure and never issued the other two) would have.
+func TestUptime_ErrorPriorityIsDeterministic(t *testing.T) {
+	cases := []struct {
+		name                         string
+		aggErr, latestErr, seriesErr error
+		wantMessage                  string
+	}{
+		{"all three fail", errors.New("agg boom"), errors.New("latest boom"), errors.New("series boom"), "failed to query uptime metrics"},
+		{"latest and series fail", nil, errors.New("latest boom"), errors.New("series boom"), "failed to query latest uptime"},
+		{"series only", nil, nil, errors.New("series boom"), "failed to query uptime series"},
+		{"aggregate only", errors.New("agg boom"), nil, nil, "failed to query uptime metrics"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newBarrierStore()
+			// No barrier in this test: release immediately so all three run
+			// to their canned outcome.
+			close(store.release)
+			store.aggErr, store.latestErr, store.seriesErr = tc.aggErr, tc.latestErr, tc.seriesErr
+
+			svc := NewService(&stubRepo{}, store, &countingVerifier{})
+			_, err := svc.Uptime(context.Background(), uuid.New(), uuid.New(), 30*24*time.Hour, 100)
+			de, ok := domain.AsDomain(err)
+			if !ok {
+				t.Fatalf("err = %v, want a domain error", err)
+			}
+			if de.Kind != domain.KindInternal || de.Code != "uptime_query_failed" {
+				t.Fatalf("err kind/code = %v/%q, want internal/uptime_query_failed", de.Kind, de.Code)
+			}
+			if de.Message != tc.wantMessage {
+				t.Fatalf("err message = %q, want %q (each read must keep its own wrapping, and the winner must be deterministic)", de.Message, tc.wantMessage)
+			}
+		})
+	}
+}

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,34 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.125",
+    date: "2026-08-05",
+    summary:
+      "A site's Uptime card could take up to thirty seconds to load the first time it was opened after a quiet period. It now reads the same running per-day totals the fleet views have used for a while, and reports the same numbers.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "A site's Uptime card could take up to thirty seconds to load the first time it was opened after a quiet period, then load in half a second on every attempt after that. Measured over a week of production requests, the same page's fleet summary answered in a fifth of a second every time, including on the page loads where the per-site card took four seconds or more. The cause was not the amount of history, a missing index, a busy database or a cold container: the per-site view was still adding up every individual probe in the window by hand, about forty three thousand of them for a thirty day view, every time it was asked.",
+      },
+      {
+        tag: "Fixed",
+        text: "The fleet-wide view stopped doing that some time ago: it reads a running per-day total kept up to date as each probe lands, and only looks at individual probes for the two part days at the very edges of the window. The per-site view predates that work and never received it. It does now, using the same code to decide which days are complete rather than a second copy that could quietly disagree, so a site's Uptime card and that same site's row in the fleet views cannot drift apart.",
+      },
+      {
+        tag: "Fixed",
+        text: "The reported uptime percentage is unchanged, to the decimal. A day that falls only partly inside the window is still counted only for the part that is inside it, so an outage starting an hour before a thirty day window opens counts for exactly the minutes within it, not for the whole day and not for none of it. The three lookups behind the card also now happen at the same time as each other rather than one after another, since none of them ever needed another's result.",
+      },
+      {
+        tag: "Changed",
+        text: "The uptime chart on a site draws one point per day for any window of a day or longer, rather than a hundred points of whatever width divides the window evenly. For a thirty day view that is about thirty points instead of a hundred points seven hours wide, which is the same information at a resolution the chart can actually show. Windows shorter than a day are untouched and still show every minute.",
+      },
+      {
+        tag: "Changed",
+        text: "The average response time on a site's Uptime card is now the average across successful checks only, matching what the Sites list and the fleet dashboards have always shown for the same site. It previously also included the response times of failed checks, so a site with a spell of server errors had two different average response times depending on which screen it was read from. The uptime percentage was never affected by this.",
+      },
+    ],
+  },
+  {
     version: "0.61.124",
     date: "2026-08-05",
     summary:

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.124
+  version: 0.61.125
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
A site's Uptime card took **up to 32.5 seconds** to load the first time it was opened after a quiet period, then 0.5 seconds on every attempt after.

## Measured, not reasoned

Server-side in Cloud Run logs over a week:

```
/sites/{id}/uptime?window=30d     0.48s ... 32.55s      (68x spread)
/uptime/summary                   0.13s ... 0.28s       (same page loads)
```

**Ruled out by measurement:**

| | |
|---|---|
| Amount of history | ~43,200 rows for a 30-day window, ~260k total. Deleting old data would change nothing |
| Missing index | The m85 covering index already matches the predicate exactly |
| Database load | CPU 22-40%, memory 51-54%, `num_backends` pinned at the MinConns floor of **2** for 12 hours |
| Connection pool | Never stretched past the floor |
| VPC connector | e2-micro, but 10-14% CPU |
| Cold container | Fleet summary was 207ms on the same page load as a 4.12s per-site call |

The signature was **cold cache** — first request after an idle gap slow, every one after fast:

```
13:09:32  32.55s     13:09:34  30.62s
13:53:10  18.63s  -> 13:53:38   0.55s
18:43:39  10.53s  -> 18:44:45   0.50s  -> 18:52:45  0.48s
```

## The fix already existed in the same file

`QueryFleetUptime` decomposes a window into complete days from `site_uptime_daily` plus raw probes for the two partial days at the edges. That is why the fleet endpoint is fast.

**The per-site path predates that work** and was still summing every probe by hand, ~43,200 of them, on every request.

`QueryAggregate` and `QuerySeries` now use the same decomposition, **reusing `fleetUptimeParams`** rather than a second copy of the "which days are complete" arithmetic. So the number on a site's card and the number beside that site in the fleet views cannot drift apart.

The three service lookups also ran sequentially in three transactions, ~9 round trips where summary does one. They never depended on each other, so they now run concurrently.

## Two user-visible changes, both disclosed

**Average response time** on the card is now the mean over **successful** checks, which is what the Sites list and fleet dashboards already showed for the same site. The rollup only carries latency for up-and-non-zero probes, so this cannot be preserved without a new column that would be NULL for all history. Previously a site with a spell of 5xx had two different average response times in the product depending on which screen you read.

**Uptime percentage is unchanged, to the decimal.**

**The chart** draws one point per day for windows of a day or more, ~30 points instead of 100 buckets seven hours wide. At the size the sparkline renders, those were never distinguishable. Sub-day windows keep minute granularity untouched.

## The 24-hour threshold is arithmetic, not taste

With `window >= 24h`, `tailLower` is strictly before today, which is what makes the boundary day, the rollup middle, and today three **disjoint** day sets. That is what lets each day contribute exactly one point and be counted once. Below 24h the guarantee fails and the daily path is not merely coarse, it is malformed. A test proves both halves.

## A latent bug this turned certain, fixed here

`report.aggregateDailyBuckets` grouped by the driver's **local-zone** year/month/day. With the old scattered bucket boundaries that mostly worked; with every point now landing exactly on UTC midnight, any deployment west of UTC would have shifted an entire client report's daily labels back by one day.

Production runs UTC so it was never live, but it was a self-host trap. Now grouped in UTC explicitly.

## Rollup gaps: not backfilled, deliberately

A failed rollup upsert loses one sweep tick while the raw row commits. A raw-probe fallback **cannot distinguish** "the rollup is missing this day" from "this site genuinely had no probes then" (paused, new, or down for a week), so it would fire constantly for ordinary sites and reinstate the 32-second scan for exactly the sites this fixes.

The exposure is not new: `QueryFleetUptime` has behaved this way since m99. The two now **agree** where before they could disagree about the same site on the same screen.

## Tests that fail against pre-change code

```
TestUptime_ThreeStoreReadsRunConcurrently        only 1 of 3 reads started after 5s
TestQueryAggregate_ServesCompleteMiddleDaysFromRollup   before 31/60, after 2/2
TestQuerySeries_ThirtyDayWindowReturnsDailyUTCPoints    returned 60 points, want 31
TestPerSiteWindow_BoundaryDayCountedExactlyOnce         0 points for boundary day, want 1
TestQueryAggregate_RollupGapIsNotBackfilledFromRawProbes  8/4, want 4/4
TestQueryAggregate_RollupMatchesRawRollingWindow        AvgLatencyMs 440, want 146.66
TestAggregateDailyBuckets_GroupsByUTCDayRegardlessOfServerZone  day off by one
```

The sub-day test passes either way **by design** — that is the "nothing changed below 24h" guard, and it is not counted as evidence.

## Gates

```
go build / vet / ./internal/... / ./tests/contract/...   clean, 0 failures
sqlc verified not applicable (raw pgx; no db/query/*.sql touches either table)
lockstep 0.61.125    dashes 0
```

## Known limits

- **No production measurement.** The improvement is inferred from rows touched (~30 rollup rows plus at most two partial days, versus ~43,200) and from the fleet endpoint's measured behaviour on the identical shape.
- **ClickHouse backend untouched.** Those deployments never scanned `site_uptime_probes` for this endpoint, so they have no bug to fix, but per-site latency semantics and chart granularity now differ between backends. The two already disagreed here; this widens it.
- **Pre-existing, not fixed:** `report.QueryUptimeSeriesRange` passes `to.Sub(from)` as a window but `QuerySeries` anchors to `time.Now()`, so a historical-range report reads the wrong period. Unrelated, and fixing it would change report numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Uptime results load faster through parallel metric lookups.
  * Longer reporting windows use efficient daily summaries.
* **Uptime & Reporting**
  * Daily charts now use UTC calendar days for consistent results.
  * Sub-day charts retain minute-level detail.
  * Complete-day and partial-day calculations are handled consistently.
  * Average response time now includes successful checks only.
* **Release**
  * Added changelog entry for version 0.61.125.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->