### PR TITLE
feat(sites): search the whole organisation, and order the list (GH #349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.126] - 2026-08-05
+
+### Fixed
+
+- Searching the Sites list only ever searched the sites that page had already loaded, and that page is the fifty most recently added. An agency with more than fifty sites was told "no results" for a site it owns and can reach in two clicks, with nothing on screen to say the search had looked at part of the fleet rather than all of it. Reported by an agency running twenty four sites, where a second, unrelated problem made the same symptom look like one bug. Searching now happens in the control plane, across every site in the organisation, so a page of results is the best matches rather than the newest fifty filtered after the fact.
+- This is why raising the number of sites fetched was not the fix. Filtering a list the server has already cut short is wrong at any size: it just moves the point at which the product starts quietly lying about what it searched. The filter and the cut now happen in the same place and in the right order.
+- A search still matches a site's name, its address and its tags, the same three things it matched before, and still ignores case. It is a plain substring search: a percent sign or an underscore in the search box now looks for that character instead of behaving as a wildcard.
+- Tags are searched from the same list of tags the fleet shows on the site, so a tag an operator can see on a site is always a tag that finds it.
+
+### Added
+
+- Sites can be ordered by name, by date added, or by last check-in, in either direction. The order is applied across the whole organisation before the page is cut, so the first page is genuinely the first page of that order and not the newest fifty rearranged among themselves.
+- Ordering by name ignores case, so "Acme" and "acme client" sit next to each other instead of every capitalised name sorting ahead of every lowercase one.
+- A site that has never checked in has no last check-in time to order by. Those sites sit at the END of the list in both directions of the last check-in order. They never take the top of a "most recently seen" list, and they never vanish from one either.
+- Every order is settled down to the last row. Two sites that share a name, or that were added in the same second, keep a fixed position relative to each other, because paging through a list whose order is undecided between equal rows can show one site twice and skip another entirely.
+- Nothing changes for anyone who does not ask for an order: the list is still newest first, exactly as before. An order the control plane does not recognise is refused outright rather than quietly ignored, because silently falling back would show an operator a list in a different order from the one the control says is applied.
+- For self-hosted installs and API users, `GET /api/v1/sites` now takes `q` and `sort`, documented in the OpenAPI specification. They combine with the existing tag, status and client filters rather than replacing any of them.
+
 ## [0.61.125] - 2026-08-05
 
 ### Fixed

--- a/apps/api/db/query/sites.sql
+++ b/apps/api/db/query/sites.sql
@@ -37,6 +37,37 @@ WHERE s.id = $1 AND s.tenant_id = $2;
 -- above. Both LEFT JOINs are PK lookups (site_id), so this stays O(sites) per
 -- page (an index-only nested-loop per row) and does not regress the
 -- optimized /sites path.
+--
+-- GH #349 free-text search + ordering. Both moved SERVER side on purpose: the
+-- web used to filter an already-fetched page client side, which silently
+-- searched only the first page (50 newest sites by default) and told an agency
+-- with more sites than that "no results" for a site it owns. A filter applied
+-- after the server truncated the list is wrong at any page size.
+--
+--   sqlc.narg('q') substring-matches, case-insensitively, the site NAME, the
+--   site URL, or ANY of the site's tags. The tag arm reads s.tags, the very
+--   array this query returns, so any tag the operator can see on a site is a
+--   tag they can find that site by. strpos(lower(..), lower(..)) is used
+--   rather than ILIKE because the operator typed a search string, not a
+--   pattern: with ILIKE a literal % or _ in the query would silently become a
+--   wildcard. NULL (absent) disables the whole predicate.
+--
+--   sqlc.arg('sort') selects the order. It is BOUND AS A PARAMETER and
+--   compared against fixed literals; no SQL text is ever concatenated, and the
+--   set of accepted values is closed in Go (site.ParseListSort, which 422s an
+--   unrecognised value rather than silently falling back). Every branch that
+--   is not the selected sort evaluates to NULL for every row, which makes that
+--   ORDER BY term a constant and therefore a no-op, so one query serves all
+--   six orders.
+--     - lower(s.name) sorts names case-insensitively, so "acme" and "Acme"
+--       sit together regardless of the server's collation.
+--     - NULLS LAST on BOTH last_seen directions: last_seen_at is NULL for a
+--       site that has never reported in. Never-seen sites therefore land at
+--       the END of the list in either direction, never crowding the top of a
+--       descending "most recently seen" sort, and never vanishing.
+--     - s.id DESC is the TOTAL-ORDER tiebreak. Two sites can share a name and
+--       two can share a created_at; without a final unique key, LIMIT/OFFSET
+--       paging is free to drop one row and repeat another across pages.
 SELECT s.*,
        COALESCE(pc.cache_enabled, false) AS page_cache_enabled,
        COALESCE(oc.enabled, false) AS object_cache_enabled
@@ -53,7 +84,23 @@ WHERE s.tenant_id = $1
         OR sqlc.narg('state')::text = s.connection_state
       )
   AND (sqlc.narg('client_id')::uuid IS NULL OR s.client_id = sqlc.narg('client_id')::uuid)
-ORDER BY s.created_at DESC
+  AND (
+        sqlc.narg('q')::text IS NULL
+        OR strpos(lower(s.name), lower(sqlc.narg('q')::text)) > 0
+        OR strpos(lower(s.url), lower(sqlc.narg('q')::text)) > 0
+        OR EXISTS (
+             SELECT 1 FROM unnest(s.tags) AS tg(tag)
+             WHERE strpos(lower(tg.tag), lower(sqlc.narg('q')::text)) > 0
+           )
+      )
+ORDER BY
+    CASE WHEN sqlc.arg('sort')::text = 'name'        THEN lower(s.name)  END ASC,
+    CASE WHEN sqlc.arg('sort')::text = '-name'       THEN lower(s.name)  END DESC,
+    CASE WHEN sqlc.arg('sort')::text = 'created_at'  THEN s.created_at   END ASC,
+    CASE WHEN sqlc.arg('sort')::text = '-created_at' THEN s.created_at   END DESC,
+    CASE WHEN sqlc.arg('sort')::text = 'last_seen'   THEN s.last_seen_at END ASC NULLS LAST,
+    CASE WHEN sqlc.arg('sort')::text = '-last_seen'  THEN s.last_seen_at END DESC NULLS LAST,
+    s.id DESC
 LIMIT $2 OFFSET $3;
 
 -- name: ListSitesAgentVersions :many

--- a/apps/api/internal/api/gen/oas_client_gen.go
+++ b/apps/api/internal/api/gen/oas_client_gen.go
@@ -2303,9 +2303,19 @@ type Invoker interface {
 	// Pass `?state=<connection_state>` to filter to exactly one state (e.g.
 	// `?state=archived` for the archived chip), or `?include_archived=true` as
 	// a convenience alias that returns only the archived sites.
+	// GH #349: `q` (free-text search) and `sort` (ordering) are applied in the
+	// DATABASE, before `limit`/`offset`. That is the point of them: a client
+	// that fetches one page and filters it locally is searching only that
+	// page, so an agency with more sites than the page size gets "no results"
+	// for a site it owns. With `q` on the server, the rows returned are the
+	// best matches in the requested order rather than the newest page filtered
+	// afterwards.
+	// `q` and `sort` compose with every other parameter here (`tags`,
+	// `tags_match`, `state`, `include_archived`, `clientId`) rather than
+	// replacing any of them.
 	//
 	// GET /api/v1/sites
-	ListSites(ctx context.Context, params ListSitesParams) (*SiteList, error)
+	ListSites(ctx context.Context, params ListSitesParams) (ListSitesRes, error)
 	// ListTags invokes listTags operation.
 	//
 	// Lists every tag in the tenant's registry (m100), sorted
@@ -29288,14 +29298,24 @@ func (c *Client) sendListSiteVulnerabilities(ctx context.Context, params ListSit
 // Pass `?state=<connection_state>` to filter to exactly one state (e.g.
 // `?state=archived` for the archived chip), or `?include_archived=true` as
 // a convenience alias that returns only the archived sites.
+// GH #349: `q` (free-text search) and `sort` (ordering) are applied in the
+// DATABASE, before `limit`/`offset`. That is the point of them: a client
+// that fetches one page and filters it locally is searching only that
+// page, so an agency with more sites than the page size gets "no results"
+// for a site it owns. With `q` on the server, the rows returned are the
+// best matches in the requested order rather than the newest page filtered
+// afterwards.
+// `q` and `sort` compose with every other parameter here (`tags`,
+// `tags_match`, `state`, `include_archived`, `clientId`) rather than
+// replacing any of them.
 //
 // GET /api/v1/sites
-func (c *Client) ListSites(ctx context.Context, params ListSitesParams) (*SiteList, error) {
+func (c *Client) ListSites(ctx context.Context, params ListSitesParams) (ListSitesRes, error) {
 	res, err := c.sendListSites(ctx, params)
 	return res, err
 }
 
-func (c *Client) sendListSites(ctx context.Context, params ListSitesParams) (res *SiteList, err error) {
+func (c *Client) sendListSites(ctx context.Context, params ListSitesParams) (res ListSitesRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("listSites"),
 		semconv.HTTPRequestMethodKey.String("GET"),
@@ -29366,6 +29386,40 @@ func (c *Client) sendListSites(ctx context.Context, params ListSitesParams) (res
 		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
 			if val, ok := params.Offset.Get(); ok {
 				return e.EncodeValue(conv.Int32ToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "q" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "q",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.Q.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "sort" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "sort",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.Sort.Get(); ok {
+				return e.EncodeValue(conv.StringToString(string(val)))
 			}
 			return nil
 		}); err != nil {

--- a/apps/api/internal/api/gen/oas_handlers_gen.go
+++ b/apps/api/internal/api/gen/oas_handlers_gen.go
@@ -38157,6 +38157,16 @@ func (s *Server) handleListSiteVulnerabilitiesRequest(args [1]string, argsEscape
 // Pass `?state=<connection_state>` to filter to exactly one state (e.g.
 // `?state=archived` for the archived chip), or `?include_archived=true` as
 // a convenience alias that returns only the archived sites.
+// GH #349: `q` (free-text search) and `sort` (ordering) are applied in the
+// DATABASE, before `limit`/`offset`. That is the point of them: a client
+// that fetches one page and filters it locally is searching only that
+// page, so an agency with more sites than the page size gets "no results"
+// for a site it owns. With `q` on the server, the rows returned are the
+// best matches in the requested order rather than the newest page filtered
+// afterwards.
+// `q` and `sort` compose with every other parameter here (`tags`,
+// `tags_match`, `state`, `include_archived`, `clientId`) rather than
+// replacing any of them.
 //
 // GET /api/v1/sites
 func (s *Server) handleListSitesRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
@@ -38243,7 +38253,7 @@ func (s *Server) handleListSitesRequest(args [0]string, argsEscaped bool, w http
 
 	var rawBody []byte
 
-	var response *SiteList
+	var response ListSitesRes
 	if m := s.cfg.Middleware; m != nil {
 		mreq := middleware.Request{
 			Context:          ctx,
@@ -38261,6 +38271,14 @@ func (s *Server) handleListSitesRequest(args [0]string, argsEscaped bool, w http
 					Name: "offset",
 					In:   "query",
 				}: params.Offset,
+				{
+					Name: "q",
+					In:   "query",
+				}: params.Q,
+				{
+					Name: "sort",
+					In:   "query",
+				}: params.Sort,
 				{
 					Name: "tag",
 					In:   "query",
@@ -38288,7 +38306,7 @@ func (s *Server) handleListSitesRequest(args [0]string, argsEscaped bool, w http
 		type (
 			Request  = struct{}
 			Params   = ListSitesParams
-			Response = *SiteList
+			Response = ListSitesRes
 		)
 		response, err = middleware.HookMiddleware[
 			Request,

--- a/apps/api/internal/api/gen/oas_interfaces_gen.go
+++ b/apps/api/internal/api/gen/oas_interfaces_gen.go
@@ -821,6 +821,10 @@ type ListSiteVulnerabilitiesRes interface {
 	listSiteVulnerabilitiesRes()
 }
 
+type ListSitesRes interface {
+	listSitesRes()
+}
+
 type ListTrustedDevicesRes interface {
 	listTrustedDevicesRes()
 }

--- a/apps/api/internal/api/gen/oas_parameters_gen.go
+++ b/apps/api/internal/api/gen/oas_parameters_gen.go
@@ -18831,6 +18831,30 @@ func decodeListSiteVulnerabilitiesParams(args [1]string, argsEscaped bool, r *ht
 type ListSitesParams struct {
 	Limit  OptInt32 `json:",omitempty,omitzero"`
 	Offset OptInt32 `json:",omitempty,omitzero"`
+	// Free-text search (GH #349). Case-insensitive SUBSTRING match against
+	// the site name, the site url, or any of the site's tags (the same
+	// `tags` array this endpoint returns, so any tag an operator can see
+	// on a site is a tag they can find that site by).
+	// Matched literally, not as a pattern: `%` and `_` are ordinary
+	// characters. An empty or whitespace-only value behaves exactly as if
+	// the parameter were absent. No match returns an empty `items` array,
+	// not an error.
+	Q OptString `json:",omitempty,omitzero"`
+	// Ordering (GH #349). A leading `-` means DESCENDING. When omitted the
+	// order is `-created_at`, which is the ordering this endpoint has
+	// always had.
+	// Every ordering is total and stable: it is tiebroken on the site id,
+	// so two sites that share a name (or a created_at) keep a fixed
+	// relative position and `limit`/`offset` paging cannot drop or repeat
+	// a row.
+	// `name` sorts case-insensitively. For `last_seen`, a site that has
+	// never checked in (null last_seen) sorts LAST in BOTH directions: it
+	// stays in the result, and it never occupies the top of a "most
+	// recently seen" list.
+	// An unrecognised value is a 422. It is never silently ignored,
+	// because a dropped sort would show the operator a list ordered
+	// differently from the control they just set.
+	Sort OptListSitesSort `json:",omitempty,omitzero"`
 	// Deprecated alias for `tags` with a single value (any-match semantics). Prefer `tags`.
 	//
 	// Deprecated: schema marks this parameter as deprecated.
@@ -18865,6 +18889,24 @@ func unpackListSitesParams(packed middleware.Parameters) (params ListSitesParams
 		}
 		if v, ok := packed[key]; ok {
 			params.Offset = v.(OptInt32)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "q",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.Q = v.(OptString)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "sort",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.Sort = v.(OptListSitesSort)
 		}
 	}
 	{
@@ -19055,6 +19097,108 @@ func decodeListSitesParams(args [0]string, argsEscaped bool, r *http.Request) (p
 	}(); err != nil {
 		return params, &ogenerrors.DecodeParamError{
 			Name: "offset",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: q.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "q",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotQVal string
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotQVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Q.SetTo(paramsDotQVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "q",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Set default value for query: sort.
+	{
+		val := ListSitesSort("-created_at")
+		params.Sort.SetTo(val)
+	}
+	// Decode query: sort.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "sort",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotSortVal ListSitesSort
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotSortVal = ListSitesSort(c)
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Sort.SetTo(paramsDotSortVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+			if err := func() error {
+				if value, ok := params.Sort.Get(); ok {
+					if err := func() error {
+						if err := value.Validate(); err != nil {
+							return err
+						}
+						return nil
+					}(); err != nil {
+						return err
+					}
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "sort",
 			In:   "query",
 			Err:  err,
 		}

--- a/apps/api/internal/api/gen/oas_response_decoders_gen.go
+++ b/apps/api/internal/api/gen/oas_response_decoders_gen.go
@@ -27444,7 +27444,7 @@ func decodeListSiteVulnerabilitiesResponse(resp *http.Response) (res ListSiteVul
 	return res, validate.UnexpectedStatusCodeWithResponse(resp)
 }
 
-func decodeListSitesResponse(resp *http.Response) (res *SiteList, _ error) {
+func decodeListSitesResponse(resp *http.Response) (res ListSitesRes, _ error) {
 	switch resp.StatusCode {
 	case 200:
 		// Code 200.
@@ -27485,6 +27485,41 @@ func decodeListSitesResponse(resp *http.Response) (res *SiteList, _ error) {
 				return nil
 			}(); err != nil {
 				return res, errors.Wrap(err, "validate")
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 422:
+		// Code 422.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response Error
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
 			}
 			return &response, nil
 		default:

--- a/apps/api/internal/api/gen/oas_response_encoders_gen.go
+++ b/apps/api/internal/api/gen/oas_response_encoders_gen.go
@@ -10883,18 +10883,37 @@ func encodeListSiteVulnerabilitiesResponse(response ListSiteVulnerabilitiesRes, 
 	}
 }
 
-func encodeListSitesResponse(response *SiteList, w http.ResponseWriter, span trace.Span) error {
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(200)
-	span.SetStatus(codes.Ok, http.StatusText(200))
+func encodeListSitesResponse(response ListSitesRes, w http.ResponseWriter, span trace.Span) error {
+	switch response := response.(type) {
+	case *SiteList:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
 
-	e := new(jx.Encoder)
-	response.Encode(e)
-	if _, err := e.WriteTo(w); err != nil {
-		return errors.Wrap(err, "write")
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *Error:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(422)
+		span.SetStatus(codes.Error, http.StatusText(422))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	default:
+		return errors.Errorf("unexpected response type: %T", response)
 	}
-
-	return nil
 }
 
 func encodeListTagsResponse(response *SiteTagList, w http.ResponseWriter, span trace.Span) error {

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -17832,6 +17832,7 @@ func (*Error) listOrgsRes()                       {}
 func (*Error) listRestoreRunsRes()                {}
 func (*Error) listScheduleRunsRes()               {}
 func (*Error) listSharedWithMeRes()               {}
+func (*Error) listSitesRes()                      {}
 func (*Error) listTrustedDevicesRes()             {}
 func (*Error) listWebAuthnCredentialsRes()        {}
 func (*Error) logoutRes()                         {}
@@ -22936,6 +22937,75 @@ func (*ListSiteVulnerabilitiesForbidden) listSiteVulnerabilitiesRes() {}
 type ListSiteVulnerabilitiesUnauthorized Error
 
 func (*ListSiteVulnerabilitiesUnauthorized) listSiteVulnerabilitiesRes() {}
+
+type ListSitesSort string
+
+const (
+	ListSitesSortName           ListSitesSort = "name"
+	ListSitesSortMinusName      ListSitesSort = "-name"
+	ListSitesSortCreatedAt      ListSitesSort = "created_at"
+	ListSitesSortMinusCreatedAt ListSitesSort = "-created_at"
+	ListSitesSortLastSeen       ListSitesSort = "last_seen"
+	ListSitesSortMinusLastSeen  ListSitesSort = "-last_seen"
+)
+
+// AllValues returns all ListSitesSort values.
+func (ListSitesSort) AllValues() []ListSitesSort {
+	return []ListSitesSort{
+		ListSitesSortName,
+		ListSitesSortMinusName,
+		ListSitesSortCreatedAt,
+		ListSitesSortMinusCreatedAt,
+		ListSitesSortLastSeen,
+		ListSitesSortMinusLastSeen,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ListSitesSort) MarshalText() ([]byte, error) {
+	switch s {
+	case ListSitesSortName:
+		return []byte(s), nil
+	case ListSitesSortMinusName:
+		return []byte(s), nil
+	case ListSitesSortCreatedAt:
+		return []byte(s), nil
+	case ListSitesSortMinusCreatedAt:
+		return []byte(s), nil
+	case ListSitesSortLastSeen:
+		return []byte(s), nil
+	case ListSitesSortMinusLastSeen:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ListSitesSort) UnmarshalText(data []byte) error {
+	switch ListSitesSort(data) {
+	case ListSitesSortName:
+		*s = ListSitesSortName
+		return nil
+	case ListSitesSortMinusName:
+		*s = ListSitesSortMinusName
+		return nil
+	case ListSitesSortCreatedAt:
+		*s = ListSitesSortCreatedAt
+		return nil
+	case ListSitesSortMinusCreatedAt:
+		*s = ListSitesSortMinusCreatedAt
+		return nil
+	case ListSitesSortLastSeen:
+		*s = ListSitesSortLastSeen
+		return nil
+	case ListSitesSortMinusLastSeen:
+		*s = ListSitesSortMinusLastSeen
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
 
 type ListSitesState string
 
@@ -29579,6 +29649,52 @@ func (o OptListSitePHPErrorsSilenced) Get() (v ListSitePHPErrorsSilenced, ok boo
 
 // Or returns value if set, or given parameter if does not.
 func (o OptListSitePHPErrorsSilenced) Or(d ListSitePHPErrorsSilenced) ListSitePHPErrorsSilenced {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptListSitesSort returns new OptListSitesSort with value set to v.
+func NewOptListSitesSort(v ListSitesSort) OptListSitesSort {
+	return OptListSitesSort{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptListSitesSort is optional ListSitesSort.
+type OptListSitesSort struct {
+	Value ListSitesSort
+	Set   bool
+}
+
+// IsSet returns true if OptListSitesSort was set.
+func (o OptListSitesSort) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptListSitesSort) Reset() {
+	var v ListSitesSort
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptListSitesSort) SetTo(v ListSitesSort) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptListSitesSort) Get() (v ListSitesSort, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptListSitesSort) Or(d ListSitesSort) ListSitesSort {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -46076,6 +46192,8 @@ func (s *SiteList) GetItems() []Site {
 func (s *SiteList) SetItems(val []Site) {
 	s.Items = val
 }
+
+func (*SiteList) listSitesRes() {}
 
 // Ref: #/components/schemas/SiteLoginBrand
 type SiteLoginBrand struct {

--- a/apps/api/internal/api/gen/oas_server_gen.go
+++ b/apps/api/internal/api/gen/oas_server_gen.go
@@ -2283,9 +2283,19 @@ type Handler interface {
 	// Pass `?state=<connection_state>` to filter to exactly one state (e.g.
 	// `?state=archived` for the archived chip), or `?include_archived=true` as
 	// a convenience alias that returns only the archived sites.
+	// GH #349: `q` (free-text search) and `sort` (ordering) are applied in the
+	// DATABASE, before `limit`/`offset`. That is the point of them: a client
+	// that fetches one page and filters it locally is searching only that
+	// page, so an agency with more sites than the page size gets "no results"
+	// for a site it owns. With `q` on the server, the rows returned are the
+	// best matches in the requested order rather than the newest page filtered
+	// afterwards.
+	// `q` and `sort` compose with every other parameter here (`tags`,
+	// `tags_match`, `state`, `include_archived`, `clientId`) rather than
+	// replacing any of them.
 	//
 	// GET /api/v1/sites
-	ListSites(ctx context.Context, params ListSitesParams) (*SiteList, error)
+	ListSites(ctx context.Context, params ListSitesParams) (ListSitesRes, error)
 	// ListTags implements listTags operation.
 	//
 	// Lists every tag in the tenant's registry (m100), sorted

--- a/apps/api/internal/api/gen/oas_unimplemented_gen.go
+++ b/apps/api/internal/api/gen/oas_unimplemented_gen.go
@@ -3037,9 +3037,19 @@ func (UnimplementedHandler) ListSiteVulnerabilities(ctx context.Context, params 
 // Pass `?state=<connection_state>` to filter to exactly one state (e.g.
 // `?state=archived` for the archived chip), or `?include_archived=true` as
 // a convenience alias that returns only the archived sites.
+// GH #349: `q` (free-text search) and `sort` (ordering) are applied in the
+// DATABASE, before `limit`/`offset`. That is the point of them: a client
+// that fetches one page and filters it locally is searching only that
+// page, so an agency with more sites than the page size gets "no results"
+// for a site it owns. With `q` on the server, the rows returned are the
+// best matches in the requested order rather than the newest page filtered
+// afterwards.
+// `q` and `sort` compose with every other parameter here (`tags`,
+// `tags_match`, `state`, `include_archived`, `clientId`) rather than
+// replacing any of them.
 //
 // GET /api/v1/sites
-func (UnimplementedHandler) ListSites(ctx context.Context, params ListSitesParams) (r *SiteList, _ error) {
+func (UnimplementedHandler) ListSites(ctx context.Context, params ListSitesParams) (r ListSitesRes, _ error) {
 	return r, ht.ErrNotImplemented
 }
 

--- a/apps/api/internal/api/gen/oas_validators_gen.go
+++ b/apps/api/internal/api/gen/oas_validators_gen.go
@@ -7666,6 +7666,25 @@ func (s *ListSitePolicyGroupsOK) Validate() error {
 	return nil
 }
 
+func (s ListSitesSort) Validate() error {
+	switch s {
+	case "name":
+		return nil
+	case "-name":
+		return nil
+	case "created_at":
+		return nil
+	case "-created_at":
+		return nil
+	case "last_seen":
+		return nil
+	case "-last_seen":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
 func (s ListSitesState) Validate() error {
 	switch s {
 	case "pending_enrollment":

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -1552,6 +1552,37 @@ type Querier interface {
 	// above. Both LEFT JOINs are PK lookups (site_id), so this stays O(sites) per
 	// page (an index-only nested-loop per row) and does not regress the
 	// optimized /sites path.
+	//
+	// GH #349 free-text search + ordering. Both moved SERVER side on purpose: the
+	// web used to filter an already-fetched page client side, which silently
+	// searched only the first page (50 newest sites by default) and told an agency
+	// with more sites than that "no results" for a site it owns. A filter applied
+	// after the server truncated the list is wrong at any page size.
+	//
+	//   sqlc.narg('q') substring-matches, case-insensitively, the site NAME, the
+	//   site URL, or ANY of the site's tags. The tag arm reads s.tags, the very
+	//   array this query returns, so any tag the operator can see on a site is a
+	//   tag they can find that site by. strpos(lower(..), lower(..)) is used
+	//   rather than ILIKE because the operator typed a search string, not a
+	//   pattern: with ILIKE a literal % or _ in the query would silently become a
+	//   wildcard. NULL (absent) disables the whole predicate.
+	//
+	//   sqlc.arg('sort') selects the order. It is BOUND AS A PARAMETER and
+	//   compared against fixed literals; no SQL text is ever concatenated, and the
+	//   set of accepted values is closed in Go (site.ParseListSort, which 422s an
+	//   unrecognised value rather than silently falling back). Every branch that
+	//   is not the selected sort evaluates to NULL for every row, which makes that
+	//   ORDER BY term a constant and therefore a no-op, so one query serves all
+	//   six orders.
+	//     - lower(s.name) sorts names case-insensitively, so "acme" and "Acme"
+	//       sit together regardless of the server's collation.
+	//     - NULLS LAST on BOTH last_seen directions: last_seen_at is NULL for a
+	//       site that has never reported in. Never-seen sites therefore land at
+	//       the END of the list in either direction, never crowding the top of a
+	//       descending "most recently seen" sort, and never vanishing.
+	//     - s.id DESC is the TOTAL-ORDER tiebreak. Two sites can share a name and
+	//       two can share a created_at; without a final unique key, LIMIT/OFFSET
+	//       paging is free to drop one row and repeat another across pages.
 	ListSites(ctx context.Context, arg ListSitesParams) ([]ListSitesRow, error)
 	// Tenant-scoped site_id/name/agent_version rollup for the read-only agent
 	// fleet-version dashboard (internal/agentrelease): "how many of my sites are

--- a/apps/api/internal/db/sqlc/sites.sql.go
+++ b/apps/api/internal/db/sqlc/sites.sql.go
@@ -758,7 +758,23 @@ WHERE s.tenant_id = $1
         OR $6::text = s.connection_state
       )
   AND ($7::uuid IS NULL OR s.client_id = $7::uuid)
-ORDER BY s.created_at DESC
+  AND (
+        $8::text IS NULL
+        OR strpos(lower(s.name), lower($8::text)) > 0
+        OR strpos(lower(s.url), lower($8::text)) > 0
+        OR EXISTS (
+             SELECT 1 FROM unnest(s.tags) AS tg(tag)
+             WHERE strpos(lower(tg.tag), lower($8::text)) > 0
+           )
+      )
+ORDER BY
+    CASE WHEN $9::text = 'name'        THEN lower(s.name)  END ASC,
+    CASE WHEN $9::text = '-name'       THEN lower(s.name)  END DESC,
+    CASE WHEN $9::text = 'created_at'  THEN s.created_at   END ASC,
+    CASE WHEN $9::text = '-created_at' THEN s.created_at   END DESC,
+    CASE WHEN $9::text = 'last_seen'   THEN s.last_seen_at END ASC NULLS LAST,
+    CASE WHEN $9::text = '-last_seen'  THEN s.last_seen_at END DESC NULLS LAST,
+    s.id DESC
 LIMIT $2 OFFSET $3
 `
 
@@ -770,6 +786,8 @@ type ListSitesParams struct {
 	AllTags  []string    `json:"all_tags"`
 	State    *string     `json:"state"`
 	ClientID pgtype.UUID `json:"client_id"`
+	Q        *string     `json:"q"`
+	Sort     string      `json:"sort"`
 }
 
 type ListSitesRow struct {
@@ -824,6 +842,37 @@ type ListSitesRow struct {
 // above. Both LEFT JOINs are PK lookups (site_id), so this stays O(sites) per
 // page (an index-only nested-loop per row) and does not regress the
 // optimized /sites path.
+//
+// GH #349 free-text search + ordering. Both moved SERVER side on purpose: the
+// web used to filter an already-fetched page client side, which silently
+// searched only the first page (50 newest sites by default) and told an agency
+// with more sites than that "no results" for a site it owns. A filter applied
+// after the server truncated the list is wrong at any page size.
+//
+//	sqlc.narg('q') substring-matches, case-insensitively, the site NAME, the
+//	site URL, or ANY of the site's tags. The tag arm reads s.tags, the very
+//	array this query returns, so any tag the operator can see on a site is a
+//	tag they can find that site by. strpos(lower(..), lower(..)) is used
+//	rather than ILIKE because the operator typed a search string, not a
+//	pattern: with ILIKE a literal % or _ in the query would silently become a
+//	wildcard. NULL (absent) disables the whole predicate.
+//
+//	sqlc.arg('sort') selects the order. It is BOUND AS A PARAMETER and
+//	compared against fixed literals; no SQL text is ever concatenated, and the
+//	set of accepted values is closed in Go (site.ParseListSort, which 422s an
+//	unrecognised value rather than silently falling back). Every branch that
+//	is not the selected sort evaluates to NULL for every row, which makes that
+//	ORDER BY term a constant and therefore a no-op, so one query serves all
+//	six orders.
+//	  - lower(s.name) sorts names case-insensitively, so "acme" and "Acme"
+//	    sit together regardless of the server's collation.
+//	  - NULLS LAST on BOTH last_seen directions: last_seen_at is NULL for a
+//	    site that has never reported in. Never-seen sites therefore land at
+//	    the END of the list in either direction, never crowding the top of a
+//	    descending "most recently seen" sort, and never vanishing.
+//	  - s.id DESC is the TOTAL-ORDER tiebreak. Two sites can share a name and
+//	    two can share a created_at; without a final unique key, LIMIT/OFFSET
+//	    paging is free to drop one row and repeat another across pages.
 func (q *Queries) ListSites(ctx context.Context, arg ListSitesParams) ([]ListSitesRow, error) {
 	rows, err := q.db.Query(ctx, listSites,
 		arg.TenantID,
@@ -833,6 +882,8 @@ func (q *Queries) ListSites(ctx context.Context, arg ListSitesParams) ([]ListSit
 		arg.AllTags,
 		arg.State,
 		arg.ClientID,
+		arg.Q,
+		arg.Sort,
 	)
 	if err != nil {
 		return nil, err

--- a/apps/api/internal/site/handler.go
+++ b/apps/api/internal/site/handler.go
@@ -275,6 +275,12 @@ func (h *Handler) list(c *gin.Context) {
 			in.ClientID = &cid
 		}
 	}
+	// GH #349: ?q= free-text search and ?sort= ordering. Both are handed to
+	// the service raw: it trims q (whitespace-only is "no search") and
+	// validates sort against a closed set, 422ing an unknown value. They
+	// compose with every filter above rather than replacing any of them.
+	in.Query = c.Query("q")
+	in.Sort = c.Query("sort")
 	ss, err := h.svc.List(c.Request.Context(), in)
 	if err != nil {
 		httpx.Error(c, err)

--- a/apps/api/internal/site/list_search_sort_test.go
+++ b/apps/api/internal/site/list_search_sort_test.go
@@ -1,0 +1,270 @@
+// list_search_sort_test.go (GH #349). Unit coverage for the ?q= / ?sort=
+// contract of GET /api/v1/sites at the service and handler boundary: the
+// accept-set for sort, the 422 an unrecognised sort produces (T4), and the
+// fact that the handler hands both parameters through to the repo alongside
+// (not instead of) the existing filters.
+//
+// The SQL semantics of q and sort (which rows match, in what order, with what
+// tiebreak, and where nulls land) are proved against a real Postgres in
+// tests/site_list_search_sort_integration_test.go. Ordering cannot be
+// meaningfully faked in memory.
+package site
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// listRecordingRepo records the ListInput the service passed down, so a test
+// can assert what the service normalised before the query ran.
+type listRecordingRepo struct {
+	fakeRepo
+	calls int
+	last  ListInput
+}
+
+func (r *listRecordingRepo) List(ctx context.Context, in ListInput) ([]Site, error) {
+	r.calls++
+	r.last = in
+	return r.fakeRepo.List(ctx, in)
+}
+
+func TestParseListSortAcceptSet(t *testing.T) {
+	t.Run("empty is the historical default", func(t *testing.T) {
+		for _, raw := range []string{"", "   ", "\t"} {
+			got, err := ParseListSort(raw)
+			if err != nil {
+				t.Fatalf("ParseListSort(%q): unexpected error %v", raw, err)
+			}
+			if got != DefaultListSort {
+				t.Fatalf("ParseListSort(%q) = %q, want %q", raw, got, DefaultListSort)
+			}
+		}
+		if DefaultListSort != SortCreatedDesc {
+			t.Fatalf("default sort = %q, want %q (the ordering /sites has always had)",
+				DefaultListSort, SortCreatedDesc)
+		}
+	})
+
+	t.Run("the six documented values are accepted", func(t *testing.T) {
+		for _, raw := range []string{"name", "-name", "created_at", "-created_at", "last_seen", "-last_seen"} {
+			got, err := ParseListSort(raw)
+			if err != nil {
+				t.Fatalf("ParseListSort(%q): unexpected error %v", raw, err)
+			}
+			if string(got) != raw {
+				t.Fatalf("ParseListSort(%q) = %q, want %q", raw, got, raw)
+			}
+		}
+	})
+
+	t.Run("anything else is a validation error, never a fallback", func(t *testing.T) {
+		// Near-misses matter more than nonsense here: each of these is a value
+		// a client could plausibly send, and each must be REJECTED rather than
+		// quietly served as -created_at.
+		for _, raw := range []string{
+			"id",              // a real column, not an offered sort
+			"Name",            // wrong case
+			"+name",           // ascending spelled the other way
+			"name asc",        // SQL-ish
+			"created_at DESC", // SQL-ish
+			"-last_seen_at",   // column name instead of the wire name
+			"url",
+			"name; drop table sites",
+		} {
+			got, err := ParseListSort(raw)
+			if err == nil {
+				t.Fatalf("ParseListSort(%q) = %q, want a validation error", raw, got)
+			}
+			de, ok := domain.AsDomain(err)
+			if !ok || de.Kind != domain.KindValidation {
+				t.Fatalf("ParseListSort(%q): want KindValidation, got %v", raw, err)
+			}
+			if de.Code != "invalid_sort" {
+				t.Fatalf("ParseListSort(%q): code = %q, want invalid_sort", raw, de.Code)
+			}
+		}
+	})
+}
+
+// TestServiceListRejectsUnknownSort is T4 at the service boundary, and also
+// asserts the rejection happens BEFORE the repo is touched: an invalid request
+// must not reach the database at all.
+func TestServiceListRejectsUnknownSort(t *testing.T) {
+	repo := &listRecordingRepo{}
+	svc := newSvc(repo)
+
+	_, err := svc.List(context.Background(), ListInput{TenantID: uuid.New(), Sort: "bogus"})
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindValidation {
+		t.Fatalf("want a KindValidation error, got %v", err)
+	}
+	if got := domain.HTTPStatus(err); got != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", got)
+	}
+	if repo.calls != 0 {
+		t.Fatalf("repo.List called %d times, want 0 (validate before querying)", repo.calls)
+	}
+}
+
+// TestServiceListNormalisesSortAndQuery pins what the service hands the repo:
+// an absent sort becomes the explicit default (so the repo never has to guess),
+// and a whitespace-only q becomes "no search" rather than a filter that would
+// match nothing.
+func TestServiceListNormalisesSortAndQuery(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        ListInput
+		wantSort  string
+		wantQuery string
+	}{
+		{"absent sort defaults", ListInput{}, string(DefaultListSort), ""},
+		{"explicit sort survives", ListInput{Sort: "name"}, "name", ""},
+		{"query is trimmed", ListInput{Query: "  acme  "}, string(DefaultListSort), "acme"},
+		{"whitespace-only query is no search", ListInput{Query: "   "}, string(DefaultListSort), ""},
+		{"inner whitespace is preserved", ListInput{Query: " acme  client "}, string(DefaultListSort), "acme  client"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &listRecordingRepo{}
+			in := tc.in
+			in.TenantID = uuid.New()
+			if _, err := newSvc(repo).List(context.Background(), in); err != nil {
+				t.Fatalf("List: %v", err)
+			}
+			if repo.last.Sort != tc.wantSort {
+				t.Fatalf("repo got sort %q, want %q", repo.last.Sort, tc.wantSort)
+			}
+			if repo.last.Query != tc.wantQuery {
+				t.Fatalf("repo got query %q, want %q", repo.last.Query, tc.wantQuery)
+			}
+		})
+	}
+}
+
+// TestServiceListNulByteQueryIsEmptyNotAnError covers a real 500 found while
+// building this: a NUL byte in ?q= reached the driver and failed the whole
+// statement with "invalid byte sequence for encoding UTF8", so a client-
+// supplied search string produced a server error. No Postgres text value can
+// contain a NUL, so such a search matches nothing by definition; the answer is
+// an empty list, the same as any other search that matches nothing, and the
+// database is never asked.
+func TestServiceListNulByteQueryIsEmptyNotAnError(t *testing.T) {
+	for _, q := range []string{"\x00", "a\x00b", "acme\x00"} {
+		repo := &listRecordingRepo{}
+		got, err := newSvc(repo).List(context.Background(), ListInput{TenantID: uuid.New(), Query: q})
+		if err != nil {
+			t.Fatalf("q=%q: got error %v, want an empty list", q, err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("q=%q: got %d sites, want 0", q, len(got))
+		}
+		if repo.calls != 0 {
+			t.Fatalf("q=%q: repo.List called %d times, want 0 (an unmatchable search needs no query)", q, repo.calls)
+		}
+	}
+}
+
+// buildListEngine mounts the real list handler behind a tenant/principal
+// injector, the same shape RequireAuth+RequireTenant produce in production.
+func buildListEngine(h *Handler, tenantID uuid.UUID) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ctx := domain.WithTenantID(c.Request.Context(), tenantID)
+		ctx = domain.WithPrincipal(ctx, domain.Principal{
+			Type:     domain.PrincipalUser,
+			UserID:   uuid.New(),
+			TenantID: tenantID,
+		})
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	r.GET("/api/v1/sites", h.list)
+	return r
+}
+
+func doList(r *gin.Engine, query string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/sites"+query, nil))
+	return rec
+}
+
+// TestListHandlerUnknownSortIs422 is T4 over the wire.
+func TestListHandlerUnknownSortIs422(t *testing.T) {
+	repo := &listRecordingRepo{}
+	h := NewHandler(newSvc(repo), nil, "")
+	rec := doList(buildListEngine(h, uuid.New()), "?sort=bogus")
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Code string `json:"code"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if body.Code != "invalid_sort" {
+		t.Fatalf("error code = %q, want invalid_sort", body.Code)
+	}
+}
+
+// TestListHandlerThreadsQueryAndSort proves the two new params reach the query
+// layer AND that they are additive: the tag, state and client filters that
+// were already on the request are all still present in the same ListInput.
+// This is the T8 wiring half; T8's row-level truth is in the integration test.
+func TestListHandlerThreadsQueryAndSort(t *testing.T) {
+	clientID := uuid.New()
+	repo := &listRecordingRepo{}
+	h := NewHandler(newSvc(repo), nil, "")
+	rec := doList(buildListEngine(h, uuid.New()),
+		"?q=%20acme%20&sort=-last_seen&tags=prod&tags=eu&tags_match=all&state=connected&clientId="+clientID.String())
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	got := repo.last
+	if got.Query != "acme" {
+		t.Fatalf("query = %q, want %q (trimmed)", got.Query, "acme")
+	}
+	if got.Sort != "-last_seen" {
+		t.Fatalf("sort = %q, want -last_seen", got.Sort)
+	}
+	if len(got.AllTags) != 2 || got.AllTags[0] != "prod" || got.AllTags[1] != "eu" {
+		t.Fatalf("all_tags = %v, want [prod eu]", got.AllTags)
+	}
+	if got.AnyTags != nil {
+		t.Fatalf("any_tags = %v, want nil (tags_match=all)", got.AnyTags)
+	}
+	if got.State != "connected" {
+		t.Fatalf("state = %q, want connected", got.State)
+	}
+	if got.ClientID == nil || *got.ClientID != clientID {
+		t.Fatalf("client_id = %v, want %v", got.ClientID, clientID)
+	}
+}
+
+// TestListHandlerAbsentSortIsDefault is the wiring half of T5: sending no sort
+// must produce exactly the ordering the endpoint had before this change.
+func TestListHandlerAbsentSortIsDefault(t *testing.T) {
+	repo := &listRecordingRepo{}
+	h := NewHandler(newSvc(repo), nil, "")
+	if rec := doList(buildListEngine(h, uuid.New()), ""); rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if repo.last.Sort != string(SortCreatedDesc) {
+		t.Fatalf("sort = %q, want %q", repo.last.Sort, SortCreatedDesc)
+	}
+	if repo.last.Query != "" {
+		t.Fatalf("query = %q, want empty", repo.last.Query)
+	}
+}

--- a/apps/api/internal/site/model.go
+++ b/apps/api/internal/site/model.go
@@ -9,9 +9,12 @@ package site
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
 // Site is a managed WordPress site.
@@ -157,6 +160,102 @@ type ListInput struct {
 	Principal ScopedPrincipal // optional; nil → plain InTenantTx (org-scoped)
 	// ClientID, when set, filters to sites assigned to that client (m63).
 	ClientID *uuid.UUID
+	// Query (GH #349) is the operator's free-text search. When non-blank the
+	// list is filtered, IN THE DATABASE, to sites whose name, url or any tag
+	// contains it (case-insensitive substring). Blank or whitespace-only means
+	// "no search" and is indistinguishable from absent.
+	//
+	// This is deliberately server side. The web previously filtered a page it
+	// had already fetched, so a tenant with more sites than one page searched
+	// only the newest page's worth and was told "no results" for sites it owns.
+	Query string
+	// Sort (GH #349) is the requested ordering, as the raw wire value
+	// ("name", "-name", "created_at", "-created_at", "last_seen",
+	// "-last_seen"; leading "-" is descending). Empty means the historical
+	// default, DefaultListSort. Service.List validates it via ParseListSort and
+	// returns a 422 for anything else: an ignored sort would show the operator
+	// a list ordered differently from the control they just set.
+	Sort string
+}
+
+// ListSort is the closed set of orderings GET /sites accepts (GH #349).
+//
+// Keeping this a closed set in Go is what makes the ordering safe: the value
+// is bound into the query as a PARAMETER and compared against fixed literals
+// inside CASE expressions (see db/query/sites.sql), so no request text ever
+// reaches the SQL string, and an unknown value is rejected rather than
+// silently ignored.
+type ListSort string
+
+const (
+	// SortNameAsc orders by site name, A to Z, case-insensitively.
+	SortNameAsc ListSort = "name"
+	// SortNameDesc orders by site name, Z to A, case-insensitively.
+	SortNameDesc ListSort = "-name"
+	// SortCreatedAsc orders by date added, oldest first.
+	SortCreatedAsc ListSort = "created_at"
+	// SortCreatedDesc orders by date added, newest first. This is the
+	// historical (and default) ordering of GET /sites.
+	SortCreatedDesc ListSort = "-created_at"
+	// SortLastSeenAsc orders by last agent check-in, oldest first. Sites that
+	// have never checked in sort LAST (see DefaultListSort's doc for why).
+	SortLastSeenAsc ListSort = "last_seen"
+	// SortLastSeenDesc orders by last agent check-in, most recent first. Sites
+	// that have never checked in sort LAST here too.
+	SortLastSeenDesc ListSort = "-last_seen"
+)
+
+// DefaultListSort is the ordering used when the client sends no sort. It is
+// the ordering GET /sites has always had, so adding the parameter cannot
+// change what an existing client sees.
+//
+// NULL last_seen_at (a site enrolled but never checked in) sorts LAST in BOTH
+// last_seen directions. Ascending, that reads as "oldest contact first, and
+// the ones we have never heard from at the very end"; descending, it keeps
+// never-seen sites from occupying the top of a "most recently seen" list.
+// Either way they stay in the result and stay findable.
+const DefaultListSort = SortCreatedDesc
+
+// listSorts is the accept-set. Order here is the order quoted back in the
+// validation message.
+var listSorts = []ListSort{
+	SortNameAsc, SortNameDesc,
+	SortCreatedAsc, SortCreatedDesc,
+	SortLastSeenAsc, SortLastSeenDesc,
+}
+
+// ParseListSort maps a raw ?sort= value to a ListSort. An empty (or
+// whitespace-only) value yields DefaultListSort. Anything else that is not in
+// the accept-set is a validation error (HTTP 422), never a silent fallback.
+func ParseListSort(raw string) (ListSort, error) {
+	s := ListSort(strings.TrimSpace(raw))
+	if s == "" {
+		return DefaultListSort, nil
+	}
+	for _, allowed := range listSorts {
+		if s == allowed {
+			return s, nil
+		}
+	}
+	names := make([]string, 0, len(listSorts))
+	for _, allowed := range listSorts {
+		names = append(names, string(allowed))
+	}
+	return "", domain.Validation("invalid_sort",
+		"sort must be one of: "+strings.Join(names, ", "))
+}
+
+// normalizeListSort is the repo-side backstop for callers that reach the repo
+// without going through Service.List (health jobs, tests). It never errors:
+// the 422 for a bad value belongs to the service, and a repo that received a
+// value it does not recognise should still produce a deterministic order
+// rather than an arbitrary one.
+func normalizeListSort(raw string) ListSort {
+	s, err := ParseListSort(raw)
+	if err != nil {
+		return DefaultListSort
+	}
+	return s
 }
 
 // SetTagsInput sets the full tag set on a tenant-scoped site.

--- a/apps/api/internal/site/repo.go
+++ b/apps/api/internal/site/repo.go
@@ -3,6 +3,7 @@ package site
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -339,6 +340,17 @@ func (r *pgRepo) List(ctx context.Context, in ListInput) ([]Site, error) {
 	if in.ClientID != nil {
 		clientIDParam = pgtype.UUID{Bytes: [16]byte(*in.ClientID), Valid: true}
 	}
+	// GH #349 free-text search. nil (SQL NULL) disables the predicate entirely;
+	// a blank search must not become a filter that matches nothing.
+	var qParam *string
+	if q := strings.TrimSpace(in.Query); q != "" {
+		qParam = &q
+	}
+	// GH #349 ordering. The value is bound as a query PARAMETER and compared
+	// against fixed literals in the SQL; it is never concatenated into the
+	// statement. normalizeListSort is the backstop for callers that bypass
+	// Service.List (which is where an unrecognised value becomes a 422).
+	sortParam := string(normalizeListSort(in.Sort))
 
 	err := runTx(func(tx pgx.Tx) error {
 		rows, err := sqlc.New(tx).ListSites(ctx, sqlc.ListSitesParams{
@@ -349,6 +361,8 @@ func (r *pgRepo) List(ctx context.Context, in ListInput) ([]Site, error) {
 			Limit:    in.Limit,
 			Offset:   in.Offset,
 			ClientID: clientIDParam,
+			Q:        qParam,
+			Sort:     sortParam,
 		})
 		if err != nil {
 			return domain.Internal("site_list_failed", "failed to list sites").WithCause(err)

--- a/apps/api/internal/site/service.go
+++ b/apps/api/internal/site/service.go
@@ -130,6 +130,27 @@ func (s *Service) List(ctx context.Context, in ListInput) ([]Site, error) {
 		return nil, domain.Forbidden("tenant_required", "a tenant context is required")
 	}
 	in.Limit, in.Offset = normalizePage(in.Limit, in.Offset)
+	// GH #349. Validate the ordering BEFORE touching the database: an
+	// unrecognised sort is a 422, not a quiet fall back to the default, because
+	// a silently ignored sort shows the operator a list ordered differently
+	// from the control they just set. Empty means DefaultListSort, so existing
+	// clients that send no sort are unaffected.
+	sortKey, err := ParseListSort(in.Sort)
+	if err != nil {
+		return nil, err
+	}
+	in.Sort = string(sortKey)
+	// Whitespace-only search is the same as no search.
+	in.Query = strings.TrimSpace(in.Query)
+	// A NUL byte cannot occur in any Postgres text value, so a search
+	// containing one matches nothing by definition. Answer that directly:
+	// passing it down would make the driver fail the whole statement
+	// ("invalid byte sequence for encoding UTF8"), turning a client-supplied
+	// search string into a 500. An unmatchable search is an empty list, which
+	// is what any other unmatched search returns.
+	if strings.ContainsRune(in.Query, 0) {
+		return []Site{}, nil
+	}
 
 	t0 := time.Now()
 

--- a/apps/api/tests/site_list_search_sort_integration_test.go
+++ b/apps/api/tests/site_list_search_sort_integration_test.go
@@ -1,0 +1,519 @@
+// site_list_search_sort_integration_test.go (GH #349). The row-level truth for
+// server-side search (?q=) and ordering (?sort=) on GET /api/v1/sites, proved
+// against a real Postgres because that is the only place ORDER BY, NULL
+// placement, tiebreaks and LIMIT/OFFSET paging actually exist. Requires Docker;
+// skips when unavailable (via startPostgres).
+//
+// Why these live server side at all: the web used to fetch one page (50 sites
+// by default) and filter it in the browser, so an agency with more sites than
+// that searched only the newest page and was told "no results" for a site it
+// owns. A filter applied after the server has already truncated the list is
+// wrong at any page size.
+package tests
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/site"
+)
+
+// searchFixture is the shared corpus. The values are chosen so that each
+// assertion below can only pass for the right reason:
+//   - names mix case ("Alpha Blog" vs "beta shop") so a case-sensitive name
+//     sort would order them differently from a case-insensitive one.
+//   - tags mix case ("EU" vs "eu") so a case-sensitive tag search would miss
+//     one of them.
+//   - exactly one site has never been seen (NULL last_seen_at).
+type searchFixture struct {
+	tenant uuid.UUID
+	ids    map[string]uuid.UUID
+	svc    *site.Service
+}
+
+func seedSearchFixture(t *testing.T, pool *db.Pool) searchFixture {
+	t.Helper()
+	ctx := context.Background()
+	siteSvc, _ := newSiteTagServices(pool)
+	tenant := seedTenant(t, pool, "sitesearch-"+uuid.NewString()[:8])
+	admin := connectAdmin(t, pool)
+	t.Cleanup(admin.Close)
+
+	base := time.Now().UTC().Add(-24 * time.Hour)
+	fx := searchFixture{tenant: tenant, ids: map[string]uuid.UUID{}, svc: siteSvc}
+
+	type spec struct {
+		name     string
+		url      string
+		tags     []string
+		created  time.Time
+		lastSeen *time.Time
+	}
+	seenAlpha := base.Add(23 * time.Hour) // most recent
+	seenBeta := base.Add(22 * time.Hour)
+	seenDelta := base.Add(21 * time.Hour) // oldest contact
+	specs := []spec{
+		{"Alpha Blog", "https://alpha.example.com", []string{"prod"}, base.Add(1 * time.Minute), &seenAlpha},
+		{"beta shop", "https://beta-store.test", []string{"staging", "EU"}, base.Add(2 * time.Minute), &seenBeta},
+		{"Gamma News", "https://gamma.example.org", []string{"prod", "eu"}, base.Add(3 * time.Minute), nil},
+		{"delta", "https://delta.example.com", nil, base.Add(4 * time.Minute), &seenDelta},
+	}
+	for _, sp := range specs {
+		s, err := siteSvc.Create(ctx, site.CreateInput{TenantID: tenant, URL: sp.url, Name: sp.name})
+		if err != nil {
+			t.Fatalf("create %s: %v", sp.name, err)
+		}
+		if len(sp.tags) > 0 {
+			if _, err := siteSvc.SetTags(ctx, site.SetTagsInput{TenantID: tenant, SiteID: s.ID, Tags: sp.tags}); err != nil {
+				t.Fatalf("SetTags %s: %v", sp.name, err)
+			}
+		}
+		// created_at/last_seen_at are set by the server, so pin them
+		// out-of-band (admin pool, RLS-bypass) to make ordering deterministic.
+		if _, err := admin.Exec(ctx,
+			`UPDATE sites SET created_at = $2, last_seen_at = $3 WHERE id = $1`,
+			s.ID, sp.created, sp.lastSeen); err != nil {
+			t.Fatalf("pin timestamps for %s: %v", sp.name, err)
+		}
+		fx.ids[sp.name] = s.ID
+	}
+	return fx
+}
+
+// listNames returns the site names in the order the query returned them. It
+// deliberately does NOT sort: the order IS the assertion.
+func listNames(t *testing.T, svc *site.Service, in site.ListInput) []string {
+	t.Helper()
+	got, err := svc.List(context.Background(), in)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	out := make([]string, 0, len(got))
+	for _, s := range got {
+		out = append(out, s.Name)
+	}
+	return out
+}
+
+func eqOrdered(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// T1 + T2 + R6: q matches name, url and tag, case-insensitively, and a query
+// that matches nothing is an empty list rather than an error.
+//
+// R6 note: the tag arm searches s.tags, the SAME array the response returns,
+// so any tag an operator can see on a site is a tag they can find it by.
+func TestSiteList_Search_MatchesNameURLAndTag(t *testing.T) {
+	pool := startPostgres(t)
+	fx := seedSearchFixture(t, pool)
+
+	cases := []struct {
+		name string
+		q    string
+		want []string
+		why  string
+	}{
+		{"name exact case", "Alpha", []string{"Alpha Blog"}, "name substring"},
+		{"name upper", "ALPHA", []string{"Alpha Blog"}, "name substring, case-insensitive"},
+		{"name lower", "alpha", []string{"Alpha Blog"}, "name substring, case-insensitive"},
+		{"name mid-word", "amma", []string{"Gamma News"}, "substring, not prefix"},
+		{"url host", "beta-store", []string{"beta shop"}, "url substring, name does not contain it"},
+		{"url tld upper", "EXAMPLE.ORG", []string{"Gamma News"}, "url substring, case-insensitive"},
+		{"tag exact", "staging", []string{"beta shop"}, "tag substring"},
+		{"tag case-insensitive both ways", "eu", []string{"beta shop", "Gamma News"}, "matches tag EU and tag eu"},
+		{"no match is empty, not an error", "zzz-nothing-matches-this", []string{}, "T2"},
+		{"percent is literal, not a wildcard", "%", []string{}, "q is a search string, not a LIKE pattern"},
+		{"underscore is literal, not a wildcard", "_", []string{}, "q is a search string, not a LIKE pattern"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// sort by name so the expectation is order-stable regardless of
+			// which sort happens to be the default.
+			got := listNames(t, fx.svc, site.ListInput{TenantID: fx.tenant, Query: tc.q, Sort: "name", Limit: 100})
+			if !eqOrdered(got, tc.want) {
+				t.Fatalf("q=%q: got %v, want %v (%s)", tc.q, got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// T3: each of the six sort values orders correctly.
+// T7: null last_seen (a site that has never checked in) sorts LAST in BOTH
+// directions, per the R2 decision. Gamma News is the never-seen site: it must
+// appear in both last_seen orderings, and at the end of each.
+func TestSiteList_Sort_AllSixOrderings(t *testing.T) {
+	pool := startPostgres(t)
+	fx := seedSearchFixture(t, pool)
+
+	cases := []struct {
+		sort string
+		want []string
+	}{
+		// Case-insensitive: with a plain byte collation "Gamma News" would sort
+		// before "beta shop" and "delta", which is not what an operator means
+		// by "sort by name".
+		{"name", []string{"Alpha Blog", "beta shop", "delta", "Gamma News"}},
+		{"-name", []string{"Gamma News", "delta", "beta shop", "Alpha Blog"}},
+		{"created_at", []string{"Alpha Blog", "beta shop", "Gamma News", "delta"}},
+		{"-created_at", []string{"delta", "Gamma News", "beta shop", "Alpha Blog"}},
+		// last_seen: delta oldest contact, then beta, then Alpha; the
+		// never-seen Gamma News is LAST in both directions.
+		{"last_seen", []string{"delta", "beta shop", "Alpha Blog", "Gamma News"}},
+		{"-last_seen", []string{"Alpha Blog", "beta shop", "delta", "Gamma News"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.sort, func(t *testing.T) {
+			got := listNames(t, fx.svc, site.ListInput{TenantID: fx.tenant, Sort: tc.sort, Limit: 100})
+			if !eqOrdered(got, tc.want) {
+				t.Fatalf("sort=%q: got %v, want %v", tc.sort, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("never-seen site is present in both directions", func(t *testing.T) {
+		for _, s := range []string{"last_seen", "-last_seen"} {
+			got := listNames(t, fx.svc, site.ListInput{TenantID: fx.tenant, Sort: s, Limit: 100})
+			if len(got) != 4 {
+				t.Fatalf("sort=%q returned %d sites, want 4: a null last_seen must not drop a site", s, len(got))
+			}
+			if got[len(got)-1] != "Gamma News" {
+				t.Fatalf("sort=%q: last row = %q, want the never-seen site Gamma News", s, got[len(got)-1])
+			}
+		}
+	})
+}
+
+// T5: absent sort is the historical ordering, identical to an explicit
+// -created_at. Adding the parameter must not move a single row for a client
+// that does not send it.
+func TestSiteList_Sort_AbsentEqualsCreatedAtDesc(t *testing.T) {
+	pool := startPostgres(t)
+	fx := seedSearchFixture(t, pool)
+
+	absent := listNames(t, fx.svc, site.ListInput{TenantID: fx.tenant, Limit: 100})
+	explicit := listNames(t, fx.svc, site.ListInput{TenantID: fx.tenant, Sort: "-created_at", Limit: 100})
+	if !eqOrdered(absent, explicit) {
+		t.Fatalf("absent sort = %v, explicit -created_at = %v: must be identical", absent, explicit)
+	}
+	want := []string{"delta", "Gamma News", "beta shop", "Alpha Blog"}
+	if !eqOrdered(absent, want) {
+		t.Fatalf("absent sort = %v, want %v (newest first, the pre-change ordering)", absent, want)
+	}
+}
+
+// tieFixture is a tenant whose sites deliberately COLLIDE on the sort keys:
+// two share the name "Twin", two share a created_at. It is the only fixture
+// that can tell a total ordering apart from a merely plausible one.
+type tieFixture struct {
+	svc                            *site.Service
+	tenant                         uuid.UUID
+	twinA, twinB, coevalA, coevalB uuid.UUID
+}
+
+func seedTieFixture(t *testing.T, pool *db.Pool) tieFixture {
+	t.Helper()
+	ctx := context.Background()
+	siteSvc, _ := newSiteTagServices(pool)
+	tenant := seedTenant(t, pool, "sitesort-ties-"+uuid.NewString()[:8])
+	admin := connectAdmin(t, pool)
+	t.Cleanup(admin.Close)
+
+	sameInstant := time.Now().UTC().Add(-time.Hour).Truncate(time.Microsecond)
+	mk := func(name, url string, created time.Time) uuid.UUID {
+		s, err := siteSvc.Create(ctx, site.CreateInput{TenantID: tenant, URL: url, Name: name})
+		if err != nil {
+			t.Fatalf("create %s: %v", url, err)
+		}
+		if _, err := admin.Exec(ctx, `UPDATE sites SET created_at = $2 WHERE id = $1`, s.ID, created); err != nil {
+			t.Fatalf("pin created_at: %v", err)
+		}
+		return s.ID
+	}
+	return tieFixture{
+		svc:     siteSvc,
+		tenant:  tenant,
+		twinA:   mk("Twin", "https://twin-a.example.com", sameInstant.Add(-time.Minute)),
+		twinB:   mk("Twin", "https://twin-b.example.com", sameInstant.Add(-2*time.Minute)),
+		coevalA: mk("Coeval A", "https://coeval-a.example.com", sameInstant),
+		coevalB: mk("Coeval B", "https://coeval-b.example.com", sameInstant),
+	}
+}
+
+// T6 + R1: every ordering is TOTAL. Two sites share a name and two share a
+// created_at; without a unique tiebreak their relative order is whatever the
+// plan happens to produce, which lets LIMIT/OFFSET paging drop one row and
+// repeat another. The tiebreak is id DESC, so this asserts both that repeated
+// calls agree AND that they agree on the specific documented order.
+func TestSiteList_Sort_TiesAreBrokenDeterministically(t *testing.T) {
+	pool := startPostgres(t)
+	tf := seedTieFixture(t, pool)
+	siteSvc, tenant := tf.svc, tf.tenant
+	twinA, twinB, coA, coB := tf.twinA, tf.twinB, tf.coevalA, tf.coevalB
+	ctx := context.Background()
+
+	listIDs := func(sort string) []uuid.UUID {
+		got, err := siteSvc.List(ctx, site.ListInput{TenantID: tenant, Sort: sort, Limit: 100})
+		if err != nil {
+			t.Fatalf("List(sort=%q): %v", sort, err)
+		}
+		ids := make([]uuid.UUID, 0, len(got))
+		for _, s := range got {
+			ids = append(ids, s.ID)
+		}
+		return ids
+	}
+	idsEqual := func(a, b []uuid.UUID) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+	// higherID reports the id that sorts FIRST under the id DESC tiebreak.
+	// Postgres compares uuid byte-wise, which is what bytes.Compare does.
+	higherID := func(x, y uuid.UUID) uuid.UUID {
+		if bytes.Compare(x[:], y[:]) > 0 {
+			return x
+		}
+		return y
+	}
+	lowerID := func(x, y uuid.UUID) uuid.UUID {
+		if higherID(x, y) == x {
+			return y
+		}
+		return x
+	}
+
+	for _, sort := range []string{"name", "-name", "created_at", "-created_at", "last_seen", "-last_seen"} {
+		t.Run("stable/"+sort, func(t *testing.T) {
+			first := listIDs(sort)
+			for i := 0; i < 4; i++ {
+				if again := listIDs(sort); !idsEqual(first, again) {
+					t.Fatalf("sort=%q is not stable across calls: %v then %v", sort, first, again)
+				}
+			}
+		})
+	}
+
+	t.Run("name ties break on id DESC", func(t *testing.T) {
+		ids := listIDs("name")
+		// "Coeval A", "Coeval B", then the two "Twin" rows.
+		pos := map[uuid.UUID]int{}
+		for i, id := range ids {
+			pos[id] = i
+		}
+		if pos[higherID(twinA, twinB)] > pos[lowerID(twinA, twinB)] {
+			t.Fatalf("same-name tie: expected the higher id first (id DESC), got order %v", ids)
+		}
+	})
+
+	t.Run("created_at ties break on id DESC", func(t *testing.T) {
+		ids := listIDs("created_at")
+		pos := map[uuid.UUID]int{}
+		for i, id := range ids {
+			pos[id] = i
+		}
+		if pos[higherID(coA, coB)] > pos[lowerID(coA, coB)] {
+			t.Fatalf("same-created_at tie: expected the higher id first (id DESC), got order %v", ids)
+		}
+	})
+}
+
+// T8: q narrows the OTHER filters rather than replacing them. Each assertion
+// pairs a q that would match on its own with a filter that excludes it, so a
+// server that ignored either half would fail.
+func TestSiteList_Search_ComposesWithExistingFilters(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	fx := seedSearchFixture(t, pool)
+	admin := connectAdmin(t, pool)
+	t.Cleanup(admin.Close)
+
+	t.Run("q AND tags", func(t *testing.T) {
+		// "alpha" alone matches Alpha Blog; Alpha Blog carries prod, not staging.
+		if got := listNames(t, fx.svc, site.ListInput{
+			TenantID: fx.tenant, Query: "alpha", AnyTags: []string{"prod"}, Sort: "name", Limit: 100,
+		}); !eqOrdered(got, []string{"Alpha Blog"}) {
+			t.Fatalf("q=alpha + tags=[prod]: got %v, want [Alpha Blog]", got)
+		}
+		if got := listNames(t, fx.svc, site.ListInput{
+			TenantID: fx.tenant, Query: "alpha", AnyTags: []string{"staging"}, Sort: "name", Limit: 100,
+		}); len(got) != 0 {
+			t.Fatalf("q=alpha + tags=[staging]: got %v, want [] (the tag filter must still apply)", got)
+		}
+		// "prod" alone (as a tag search) matches two sites; adding the tag
+		// filter for staging must leave none of them.
+		if got := listNames(t, fx.svc, site.ListInput{
+			TenantID: fx.tenant, Query: "prod", Sort: "name", Limit: 100,
+		}); !eqOrdered(got, []string{"Alpha Blog", "Gamma News"}) {
+			t.Fatalf("q=prod: got %v, want [Alpha Blog Gamma News]", got)
+		}
+	})
+
+	t.Run("q AND state", func(t *testing.T) {
+		// Connect only Gamma News. q=example matches every site's url.
+		if _, err := admin.Exec(ctx,
+			`UPDATE sites SET connection_state = 'connected' WHERE id = $1`, fx.ids["Gamma News"]); err != nil {
+			t.Fatalf("set connection_state: %v", err)
+		}
+		if got := listNames(t, fx.svc, site.ListInput{
+			TenantID: fx.tenant, Query: "example", State: "connected", Sort: "name", Limit: 100,
+		}); !eqOrdered(got, []string{"Gamma News"}) {
+			t.Fatalf("q=example + state=connected: got %v, want [Gamma News]", got)
+		}
+		if got := listNames(t, fx.svc, site.ListInput{
+			TenantID: fx.tenant, Query: "beta", State: "connected", Sort: "name", Limit: 100,
+		}); len(got) != 0 {
+			t.Fatalf("q=beta + state=connected: got %v, want [] (beta shop is not connected)", got)
+		}
+	})
+
+	t.Run("q AND clientId", func(t *testing.T) {
+		var clientID uuid.UUID
+		if err := admin.QueryRow(ctx,
+			`INSERT INTO clients (tenant_id, name) VALUES ($1, 'Acme Agency') RETURNING id`,
+			fx.tenant).Scan(&clientID); err != nil {
+			t.Fatalf("insert client: %v", err)
+		}
+		if _, err := admin.Exec(ctx,
+			`UPDATE sites SET client_id = $2 WHERE id = $1`, fx.ids["delta"], clientID); err != nil {
+			t.Fatalf("assign client: %v", err)
+		}
+		if got := listNames(t, fx.svc, site.ListInput{
+			TenantID: fx.tenant, Query: "example", ClientID: &clientID, Sort: "name", Limit: 100,
+		}); !eqOrdered(got, []string{"delta"}) {
+			t.Fatalf("q=example + clientId: got %v, want [delta]", got)
+		}
+		if got := listNames(t, fx.svc, site.ListInput{
+			TenantID: fx.tenant, Query: "alpha", ClientID: &clientID, Sort: "name", Limit: 100,
+		}); len(got) != 0 {
+			t.Fatalf("q=alpha + clientId: got %v, want [] (Alpha Blog is not in that client)", got)
+		}
+	})
+}
+
+// T9: paging over a filtered, ordered result is coherent. This is the defect
+// class the whole change exists to remove: page 1 and page 2 must be disjoint,
+// and their concatenation must be exactly the full ordered result. The search
+// runs in the database, so page 2 contains real matches rather than "whatever
+// was left of the first 50 rows".
+func TestSiteList_Search_PaginationIsCoherent(t *testing.T) {
+	pool := startPostgres(t)
+	fx := seedSearchFixture(t, pool)
+
+	// q=example matches THREE of the four sites: alpha.example.com,
+	// gamma.example.org and delta.example.com. beta shop lives on
+	// beta-store.test and must not appear on any page. Deliberately a strict
+	// subset: a server that ignored q would page over all four and put a
+	// non-matching site in front of the operator.
+	full := listNames(t, fx.svc, site.ListInput{TenantID: fx.tenant, Query: "example", Sort: "name", Limit: 100})
+	want := []string{"Alpha Blog", "delta", "Gamma News"}
+	if !eqOrdered(full, want) {
+		t.Fatalf("q=example returned %v, want %v (the filter must run in the database, not after the page)", full, want)
+	}
+
+	page1 := listNames(t, fx.svc, site.ListInput{TenantID: fx.tenant, Query: "example", Sort: "name", Limit: 2, Offset: 0})
+	page2 := listNames(t, fx.svc, site.ListInput{TenantID: fx.tenant, Query: "example", Sort: "name", Limit: 2, Offset: 2})
+	if len(page1) != 2 || len(page2) != 1 {
+		t.Fatalf("pages = %v / %v, want 2 then 1 row", page1, page2)
+	}
+	for _, a := range page1 {
+		for _, b := range page2 {
+			if a == b {
+				t.Fatalf("page1 %v and page2 %v overlap on %q", page1, page2, a)
+			}
+		}
+	}
+	union := append(append([]string{}, page1...), page2...)
+	if !eqOrdered(union, full) {
+		t.Fatalf("page1+page2 = %v, want the full ordered result %v", union, full)
+	}
+	for _, name := range union {
+		if name == "beta shop" {
+			t.Fatalf("q=example paged in %q, whose url is beta-store.test: pages must contain only matches", name)
+		}
+	}
+
+	// The same coherence must hold when the sort key COLLIDES. This is the
+	// case a missing tiebreak breaks: with two rows equal on the ordering key
+	// and no unique final key, nothing stops the two page queries from
+	// disagreeing about which of them comes first, dropping one row from the
+	// result and repeating the other.
+	tf := seedTieFixture(t, pool)
+	for _, sort := range []string{"name", "-name", "created_at", "-created_at"} {
+		t.Run("tied key/"+sort, func(t *testing.T) {
+			all := listNames(t, tf.svc, site.ListInput{TenantID: tf.tenant, Sort: sort, Limit: 100})
+			if len(all) != 4 {
+				t.Fatalf("full list = %v, want 4 sites", all)
+			}
+			var paged []string
+			for offset := int32(0); offset < 4; offset += 2 {
+				paged = append(paged, listNames(t, tf.svc, site.ListInput{
+					TenantID: tf.tenant, Sort: sort, Limit: 2, Offset: offset,
+				})...)
+			}
+			if !eqOrdered(paged, all) {
+				t.Fatalf("sort=%q paged in 2s = %v, want the full ordered result %v "+
+					"(a dropped or repeated row means the ordering is not total)", sort, paged, all)
+			}
+		})
+	}
+}
+
+// R5: the new parameters filter WITHIN the existing tenant/site scope and must
+// not widen it. A site-scoped collaborator searching for a site outside their
+// grant gets nothing, even when the search string clearly matches that site.
+func TestSiteList_Search_DoesNotWidenSiteScope(t *testing.T) {
+	pool := startPostgres(t)
+	fx := seedSearchFixture(t, pool)
+
+	scoped := domain.Principal{
+		Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: fx.tenant,
+		Role: "operator", Scope: domain.ScopeSite,
+		AllowedSiteIDs: []uuid.UUID{fx.ids["Alpha Blog"]},
+	}
+
+	// Unfiltered: the scope alone already limits the collaborator to one site.
+	if got := listNames(t, fx.svc, site.ListInput{
+		TenantID: fx.tenant, Principal: scoped, Sort: "name", Limit: 100,
+	}); !eqOrdered(got, []string{"Alpha Blog"}) {
+		t.Fatalf("scoped list = %v, want [Alpha Blog]", got)
+	}
+	// Searching for a site outside the grant returns nothing, not that site.
+	for _, q := range []string{"gamma", "beta-store", "staging", "example"} {
+		got := listNames(t, fx.svc, site.ListInput{
+			TenantID: fx.tenant, Principal: scoped, Query: q, Sort: "name", Limit: 100,
+		})
+		for _, name := range got {
+			if name != "Alpha Blog" {
+				t.Fatalf("q=%q under a site-scoped principal returned %q: search must not widen scope", q, name)
+			}
+		}
+	}
+	// Cross-tenant: another tenant's sites are never reachable by search.
+	other := seedSearchFixture(t, pool)
+	if got := listNames(t, fx.svc, site.ListInput{
+		TenantID: other.tenant, Query: "alpha", Sort: "name", Limit: 100,
+	}); len(got) != 1 {
+		t.Fatalf("other tenant q=alpha returned %v, want exactly its own Alpha Blog", got)
+	}
+}

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,42 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.126",
+    date: "2026-08-05",
+    summary:
+      "Searching the Sites list only searched the fifty most recently added sites, so a larger fleet was told \"no results\" for a site it owns. Search and ordering now run across the whole organisation, and sites can be ordered by name, date added or last check-in.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Searching the Sites list only ever searched the sites that page had already loaded, and that page is the fifty most recently added. An agency with more than fifty sites was told \"no results\" for a site it owns and can reach in two clicks, with nothing on screen to say the search had looked at part of the fleet rather than all of it. Reported by an agency running twenty four sites. Searching now happens in the control plane, across every site in the organisation, so a page of results is the best matches rather than the newest fifty filtered after the fact.",
+      },
+      {
+        tag: "Fixed",
+        text: "This is why raising the number of sites fetched was not the fix. Filtering a list the server has already cut short is wrong at any size: it only moves the point at which the product starts quietly lying about what it searched. The filter and the cut now happen in the same place, in the right order.",
+      },
+      {
+        tag: "Fixed",
+        text: "A search still matches a site's name, its address and its tags, the same three things it matched before, and still ignores case. It is a plain substring search: a percent sign or an underscore in the search box now looks for that character instead of behaving as a wildcard. Tags are searched from the same list of tags shown on the site, so a tag an operator can see is always a tag that finds it.",
+      },
+      {
+        tag: "Added",
+        text: "Sites can be ordered by name, by date added, or by last check-in, in either direction. The order is applied across the whole organisation before the page is cut, so the first page is genuinely the first page of that order and not the newest fifty rearranged among themselves. Ordering by name ignores case, so \"Acme\" and \"acme client\" sit next to each other.",
+      },
+      {
+        tag: "Added",
+        text: "A site that has never checked in has no last check-in time to order by. Those sites sit at the end of the list in both directions of the last check-in order: they never take the top of a \"most recently seen\" list, and they never vanish from one either.",
+      },
+      {
+        tag: "Added",
+        text: "Every order is settled down to the last row. Two sites that share a name, or that were added in the same second, keep a fixed position relative to each other, because paging through a list whose order is undecided between equal rows can show one site twice and skip another entirely. Nothing changes for anyone who does not ask for an order: the list is still newest first.",
+      },
+      {
+        tag: "Added",
+        text: "For self-hosted installs and API users, GET /api/v1/sites now takes q and sort, documented in the OpenAPI specification. They combine with the existing tag, status and client filters rather than replacing any of them. An order the control plane does not recognise is refused rather than quietly ignored.",
+      },
+    ],
+  },
+  {
     version: "0.61.125",
     date: "2026-08-05",
     summary:

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -110,12 +110,51 @@ const DropdownMenuCheckboxItem = React.forwardRef<
 DropdownMenuCheckboxItem.displayName =
   DropdownMenuPrimitive.CheckboxItem.displayName;
 
+// Single-select sibling of the checkbox item, for a menu where exactly one
+// option is applied at a time (the Sites "Order by" control, GH #349). Radix
+// gives the group role="radiogroup" and each item role="menuitemradio" with a
+// real checked state, so a screen reader announces which order is applied
+// without the label having to repeat it.
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 pl-8 text-sm outline-none transition-colors",
+      "focus:bg-[var(--color-accent)] focus:text-[var(--color-accent-foreground)]",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      // The applied option carries its own weight so it reads as chosen even
+      // while another row is keyboard-focused.
+      "data-[state=checked]:font-medium",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex size-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <span
+          aria-hidden="true"
+          className="block size-1.5 rounded-full bg-[var(--color-primary)]"
+        />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+
 export {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuLabel,
 };

--- a/apps/web/src/features/command/command-palette-search.test.tsx
+++ b/apps/web/src/features/command/command-palette-search.test.tsx
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import type { Site } from "@wpmgr/api";
+
+import { renderWithProviders } from "@/test/render";
+import { mockQueryResult } from "@/test/query-mocks";
+import type { UseSitesOptions } from "@/features/sites/use-sites";
+import { recordRecentSite } from "@/features/command/use-recent-sites";
+
+import { CommandPalette } from "./command-palette";
+
+// GH #349. The command palette searches the WHOLE organisation.
+//
+// THE REPORTED BUG: an agency with 24 enrolled sites pressed the palette
+// shortcut, typed "iacop", and got "No matches." The palette rendered
+// `recentSites`, a localStorage list of sites this browser had previously
+// OPENED. With 24 enrolled and none visited, "No matches." was the correct
+// answer to the wrong question, and it was also indistinguishable from a
+// request that had not happened yet or had failed.
+//
+// Every test below fails against the pre-change palette except the two marked
+// KEEP guard: recents were the one thing the old implementation got right and
+// must survive. The GH #322 rollout gate has its own file
+// (command-palette.test.tsx) and is the regression guard for that entry.
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+Element.prototype.scrollIntoView = function scrollIntoView() {};
+
+const useSitesMock =
+  vi.fn<(options?: UseSitesOptions) => ReturnType<typeof mockQueryResult<Site[]>>>();
+
+vi.mock("@/features/auth/use-auth", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/features/auth/use-auth")>(
+      "@/features/auth/use-auth",
+    );
+  return {
+    ...actual,
+    useMe: () => ({ data: undefined }),
+    useLogout: () => ({ mutate: vi.fn() }),
+  };
+});
+
+vi.mock("@/features/fleet/use-fleet-agents", () => ({
+  useFleetAgentVersions: () => ({ data: undefined }),
+}));
+
+vi.mock("@/features/sites/use-sites", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/features/sites/use-sites")>();
+  return {
+    ...actual,
+    useSites: (options?: UseSitesOptions) => useSitesMock(options),
+  };
+});
+
+vi.mock("@/features/backups/use-bulk-backup", () => ({
+  useBulkBackup: () => vi.fn(),
+}));
+
+function buildSite(overrides: Partial<Site> = {}): Site {
+  return {
+    id: "site-1",
+    tenant_id: "t1",
+    url: "https://iacop.example.com",
+    name: "Iacop",
+    status: "active",
+    wp_version: "6.8",
+    php_version: "8.3",
+    health_status: "healthy",
+    multisite: false,
+    tags: [],
+    ...overrides,
+  } as unknown as Site;
+}
+
+/**
+ * Tells the palette's two `useSites()` calls apart: the bare one (which feeds
+ * "Run backup on all sites") and the SEARCH one, recognised by its `q` option.
+ */
+function mockSearch(result: ReturnType<typeof mockQueryResult<Site[]>>) {
+  useSitesMock.mockImplementation((options?: UseSitesOptions) =>
+    options && "q" in options ? result : mockQueryResult<Site[]>({ data: [] }),
+  );
+}
+
+/** Type into the palette's search box. */
+function typeTerm(term: string) {
+  const input = screen.getByPlaceholderText("Search sites, runs, snapshots");
+  fireEvent.change(input, { target: { value: term } });
+}
+
+/** Every option the SEARCH call was made with, in order. */
+function searchCalls(): (UseSitesOptions | undefined)[] {
+  return useSitesMock.mock.calls
+    .map(([options]) => options)
+    .filter((options) => options && "q" in options);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSearch(mockQueryResult<Site[]>({ data: [] }));
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("CommandPalette site search (GH #349)", () => {
+  it("T1: finds a site the operator has NEVER opened (the reported case)", async () => {
+    // Nothing in recents. This is precisely the reporter's state: sites
+    // enrolled, none visited, so the old palette had nothing to offer and said
+    // "No matches."
+    mockSearch(
+      mockQueryResult<Site[]>({
+        data: [
+          buildSite({
+            id: "s-iacop",
+            name: "Iacop",
+            url: "https://iacop.example.com",
+          }),
+        ],
+      }),
+    );
+
+    renderWithProviders(<CommandPalette open onClose={vi.fn()} />);
+    typeTerm("iacop");
+
+    expect(await screen.findByText("Go to Iacop")).toBeInTheDocument();
+    expect(screen.queryByText("No matches.")).not.toBeInTheDocument();
+  });
+
+  it("T1b: sends the typed term to the server as `q` rather than filtering what is already loaded", async () => {
+    renderWithProviders(<CommandPalette open onClose={vi.fn()} />);
+    typeTerm("iacop");
+
+    await waitFor(() => {
+      expect(searchCalls().some((options) => options?.q === "iacop")).toBe(true);
+    });
+  });
+
+  it("T1c: shows a server result whose visible label does not contain the term, because the SERVER decided it matches", async () => {
+    // The contract also matches on URL and tags. A result whose name shares no
+    // characters with the term must still be shown: re-filtering the server's
+    // answer in the browser is the defect class this change is undoing.
+    mockSearch(
+      mockQueryResult<Site[]>({
+        data: [
+          buildSite({
+            id: "s-tagged",
+            name: "Northwind",
+            url: "https://northwind.test",
+            tags: ["iacop"],
+          }),
+        ],
+      }),
+    );
+
+    renderWithProviders(<CommandPalette open onClose={vi.fn()} />);
+    typeTerm("iacop");
+
+    expect(await screen.findByText("Go to Northwind")).toBeInTheDocument();
+  });
+
+  it("T2 (KEEP guard): an empty box still shows recently visited sites, and searches for nothing", async () => {
+    recordRecentSite({ id: "s-recent", url: "https://recent.example.com" });
+
+    renderWithProviders(<CommandPalette open onClose={vi.fn()} />);
+
+    expect(
+      await screen.findByText("Go to recent.example.com"),
+    ).toBeInTheDocument();
+    // The search query stays disabled while there is nothing to search for.
+    expect(searchCalls().length).toBeGreaterThan(0);
+    expect(searchCalls().every((options) => options?.enabled === false)).toBe(
+      true,
+    );
+  });
+
+  it("T2b: typing replaces recents with the organisation-wide answer", async () => {
+    recordRecentSite({ id: "s-recent", url: "https://recent.example.com" });
+    mockSearch(
+      mockQueryResult<Site[]>({
+        data: [buildSite({ id: "s-iacop", name: "Iacop" })],
+      }),
+    );
+
+    renderWithProviders(<CommandPalette open onClose={vi.fn()} />);
+    expect(
+      await screen.findByText("Go to recent.example.com"),
+    ).toBeInTheDocument();
+
+    typeTerm("iacop");
+
+    expect(await screen.findByText("Go to Iacop")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Go to recent.example.com"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("T3a: says it is searching while the request is in flight, never 'No matches.'", async () => {
+    mockSearch(
+      mockQueryResult<Site[]>({
+        data: undefined,
+        isPending: true,
+        isFetching: true,
+        isSuccess: false,
+        status: "pending",
+      }),
+    );
+
+    renderWithProviders(<CommandPalette open onClose={vi.fn()} />);
+    typeTerm("iacop");
+
+    expect(await screen.findByText("Searching sites...")).toBeInTheDocument();
+    expect(screen.queryByText("No matches.")).not.toBeInTheDocument();
+    expect(screen.queryByText(/No sites match/)).not.toBeInTheDocument();
+  });
+
+  it("T3b: says the request failed, offers a retry, and never claims nothing matched", async () => {
+    const refetch = vi.fn();
+    mockSearch(
+      mockQueryResult<Site[]>({
+        data: undefined,
+        isError: true,
+        isSuccess: false,
+        status: "error",
+        error: new Error("network down"),
+        refetch,
+      }),
+    );
+
+    renderWithProviders(<CommandPalette open onClose={vi.fn()} />);
+    typeTerm("iacop");
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Could not search sites.");
+    expect(screen.queryByText("No matches.")).not.toBeInTheDocument();
+    expect(screen.queryByText(/No sites match/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it("T3c: only a settled, successful, empty answer says nothing matched, and it names the term", async () => {
+    mockSearch(mockQueryResult<Site[]>({ data: [] }));
+
+    renderWithProviders(<CommandPalette open onClose={vi.fn()} />);
+    typeTerm("zzzz");
+
+    expect(
+      await screen.findByText('No sites match "zzzz".'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Searching sites...")).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("T3d: the three states are told apart on screen", async () => {
+    // Same term, three different server states, three different lines. The bug
+    // was that all three rendered the same sentence, so an operator could not
+    // tell "not asked yet" from "asked and failed" from "asked and nothing
+    // matched".
+    const lines = new Set<string>();
+
+    const cases: [ReturnType<typeof mockQueryResult<Site[]>>, string | RegExp][] =
+      [
+        [
+          mockQueryResult<Site[]>({
+            data: undefined,
+            isPending: true,
+            isFetching: true,
+            isSuccess: false,
+            status: "pending",
+          }),
+          "Searching sites...",
+        ],
+        [
+          mockQueryResult<Site[]>({
+            data: undefined,
+            isError: true,
+            isSuccess: false,
+            status: "error",
+            error: new Error("boom"),
+          }),
+          /Could not search sites\./,
+        ],
+        [mockQueryResult<Site[]>({ data: [] }), 'No sites match "iacop".'],
+      ];
+
+    for (const [state, expected] of cases) {
+      mockSearch(state);
+      const { unmount } = renderWithProviders(
+        <CommandPalette open onClose={vi.fn()} />,
+      );
+      typeTerm("iacop");
+      // Waiting on the state's OWN line, not on "some status element", is what
+      // makes this meaningful: the in-flight line shows first in every case
+      // (the debounce window is itself in flight), so a test that grabbed the
+      // first status it saw would pass while the bug was present.
+      await screen.findByText(expected);
+      const node = screen.queryByRole("status") ?? screen.getByRole("alert");
+      lines.add(node.textContent ?? "");
+      unmount();
+    }
+
+    expect(lines.size).toBe(3);
+  });
+
+  it("keeps the fleet-wide verbs reachable while a search is running", async () => {
+    // A search must not take the palette over: "Run backup on all sites" and
+    // the other command groups still filter and select as before.
+    mockSearch(
+      mockQueryResult<Site[]>({
+        data: [buildSite({ id: "s-1", name: "Backup Cafe" })],
+      }),
+    );
+
+    renderWithProviders(<CommandPalette open onClose={vi.fn()} />);
+    typeTerm("backup");
+
+    expect(
+      await screen.findByText("Run backup on all sites"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Go to Backups")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/command/command-palette.tsx
+++ b/apps/web/src/features/command/command-palette.tsx
@@ -14,17 +14,19 @@ import {
   Search,
   Settings as SettingsIcon,
 } from "lucide-react";
-import { type ReactNode, useCallback, useMemo } from "react";
+import { type ReactNode, useCallback, useMemo, useState } from "react";
 
 import { useCommandPalette } from "@/features/command/use-command-palette";
-import { useRecentSites } from "@/features/command/use-recent-sites";
+import { hostnameFromUrl, useRecentSites } from "@/features/command/use-recent-sites";
 import { canManage, useLogout, useMe } from "@/features/auth/use-auth";
 import { useFleetAgentVersions } from "@/features/fleet/use-fleet-agents";
 import { useSitesSelection } from "@/features/sites/use-sites-selection";
 import { useSites } from "@/features/sites/use-sites";
 import { useBulkBackup } from "@/features/backups/use-bulk-backup";
 import { toast } from "@/components/toast";
+import { useDebouncedValue } from "@/lib/use-debounced-value";
 import { cn } from "@/lib/utils";
+import type { Site } from "@wpmgr/api";
 
 // Sprint 3 surface 4.4 — Command palette.
 //
@@ -61,6 +63,14 @@ interface CommandPaletteProps {
   onClose: () => void;
 }
 
+/**
+ * GH #349. How many site results one search shows. The panel is 24rem tall;
+ * past a screenful the operator refines the term rather than scrolls, and the
+ * whole point of the server search is that refining now reaches every site in
+ * the organisation instead of a preloaded page.
+ */
+const PALETTE_SEARCH_LIMIT = 20;
+
 export function CommandPalette({ open, onClose }: CommandPaletteProps) {
   const navigate = useNavigate();
   const recentSites = useRecentSites();
@@ -72,6 +82,34 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
   // Query cache (no extra network call) and gives us the enrolled site IDs for
   // "Run backup on all sites".
   const { data: allSites } = useSites();
+
+  // ── Site search (GH #349) ─────────────────────────────────────────────────
+  //
+  // The palette used to offer ONLY `recentSites`, a localStorage list of sites
+  // this browser had already opened. An agency with 24 enrolled sites and none
+  // visited got "No matches." for every one of them, which was the honest
+  // answer to the wrong question.
+  //
+  // The term now goes to the server, so a search reaches every site in the
+  // organisation. Recents stay as the ZERO-QUERY default: with an empty box
+  // the useful thing to show is where the operator just was.
+  const [term, setTerm] = useState("");
+  const trimmedTerm = term.trim();
+  const hasTerm = trimmedTerm.length > 0;
+  const searchTerm = useDebouncedValue(trimmedTerm, 200);
+  const siteSearch = useSites({
+    q: searchTerm,
+    limit: PALETTE_SEARCH_LIMIT,
+    enabled: searchTerm.length > 0,
+  });
+  const results = hasTerm ? (siteSearch.data ?? []) : [];
+  // A disabled query reports `isPending` forever, so `isFetching` is what
+  // actually means "a request is in flight". The window between the keystroke
+  // and the debounce firing counts as searching too: that is exactly the
+  // moment the old palette would have said "No matches."
+  const isSearching =
+    hasTerm && (siteSearch.isFetching || trimmedTerm !== searchTerm);
+  const searchFailed = hasTerm && !isSearching && siteSearch.isError;
 
   // GH #322: is the fleet agent rollout actually usable by THIS viewer?
   //
@@ -172,7 +210,13 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
     <Command.Dialog
       open={open}
       onOpenChange={(next) => {
-        if (!next) onClose();
+        if (!next) {
+          // Reset the term on close so the next ⌘K opens on recents rather
+          // than on a stale search. Done in the event handler, never an
+          // effect.
+          setTerm("");
+          onClose();
+        }
       }}
       label="Command palette"
       // cmdk forwards `overlayClassName` and `contentClassName` to its inner
@@ -210,6 +254,8 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
             className="size-4 shrink-0 text-muted-foreground"
           />
           <Command.Input
+            value={term}
+            onValueChange={setTerm}
             placeholder="Search sites, runs, snapshots"
             className={cn(
               "h-12 flex-1 bg-transparent text-base outline-none",
@@ -225,11 +271,30 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
             // empty state aligns visually with the input.
           )}
         >
-          <Command.Empty
-            className="px-3 py-6 text-center text-sm text-muted-foreground"
-          >
-            No matches.
-          </Command.Empty>
+          {/*
+            With a term typed, the Sites section below owns the whole story
+            for that term (searching / failed / nothing found), so cmdk's own
+            "No matches." must not also render: two verdicts on one screen,
+            one of them written before the request came back, is the bug this
+            issue reported.
+          */}
+          {hasTerm ? null : (
+            <Command.Empty className="px-3 py-6 text-center text-sm text-muted-foreground">
+              No matches.
+            </Command.Empty>
+          )}
+
+          {/* ── Sites (server search, GH #349) ──────────────────────────── */}
+          {hasTerm ? (
+            <SiteSearchSection
+              term={trimmedTerm}
+              results={results}
+              isSearching={isSearching}
+              hasFailed={searchFailed}
+              onRetry={() => void siteSearch.refetch()}
+              onOpen={(siteId) => go(`/sites/${siteId}`)()}
+            />
+          ) : null}
 
           {/* ── Navigate ────────────────────────────────────────────────── */}
           <PaletteGroup heading="Navigate">
@@ -248,23 +313,31 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
             >
               Go to Backups
             </PaletteItem>
-            {recentSites.map((site) => (
-              <PaletteItem
-                key={`recent-${site.id}`}
-                onSelect={go(`/sites/${site.id}`)}
-                icon={<Globe className="size-4" aria-hidden="true" />}
-                // The hostname is the user-facing identifier — keep it mono so
-                // it reads as a fixed-width URL fragment per DESIGN.md ("use
-                // mono for every hostname").
-                trailing={
-                  <span className="font-mono text-xs text-muted-foreground">
-                    {site.hostname}
-                  </span>
-                }
-              >
-                Go to {site.hostname}
-              </PaletteItem>
-            ))}
+            {/*
+              Recents are the ZERO-QUERY default only. Once something is
+              typed, the Sites section above answers from the server across the
+              whole organisation, and a second list of the same sites drawn
+              from this browser's history would just compete with it.
+            */}
+            {hasTerm
+              ? null
+              : recentSites.map((site) => (
+                  <PaletteItem
+                    key={`recent-${site.id}`}
+                    onSelect={go(`/sites/${site.id}`)}
+                    icon={<Globe className="size-4" aria-hidden="true" />}
+                    // The hostname is the user-facing identifier, so keep it mono
+                    // so it reads as a fixed-width URL fragment per DESIGN.md
+                    // ("use mono for every hostname").
+                    trailing={
+                      <span className="font-mono text-xs text-muted-foreground">
+                        {site.hostname}
+                      </span>
+                    }
+                  >
+                    Go to {site.hostname}
+                  </PaletteItem>
+                ))}
           </PaletteGroup>
 
           {/* ── Run on selected (only when there IS a selection) ───────── */}
@@ -395,17 +468,132 @@ export function MountedCommandPalette() {
   return <CommandPalette open={open} onClose={() => setOpen(false)} />;
 }
 
+// ── Site search results (GH #349) ───────────────────────────────────────────
+
+interface SiteSearchSectionProps {
+  /** The trimmed term, echoed back in the no-results line. */
+  term: string;
+  results: readonly Site[];
+  isSearching: boolean;
+  hasFailed: boolean;
+  onRetry: () => void;
+  onOpen: (siteId: string) => void;
+}
+
+/**
+ * The three states a search can be in, told apart on screen.
+ *
+ * The reported bug was a palette that said "No matches." whatever was
+ * happening, so the operator could not tell "your organisation has no site
+ * called that" from "we have not asked yet" or "the request failed". Each
+ * gets its own line here, and only the settled, empty, successful case is
+ * allowed to say nothing was found.
+ *
+ * The status and error lines are plain elements rather than Command.Items:
+ * cmdk filters items against the typed term, and a status line that vanished
+ * because it did not fuzzy-match "iacop" would be its own small lie. Site
+ * rows use `forceMount` for the same reason. The SERVER decided these sites
+ * match; the client must not quietly overrule it with a second, weaker filter,
+ * which is the shape of the defect this whole change is undoing.
+ */
+function SiteSearchSection({
+  term,
+  results,
+  isSearching,
+  hasFailed,
+  onRetry,
+  onOpen,
+}: SiteSearchSectionProps) {
+  if (hasFailed) {
+    return (
+      <div
+        role="alert"
+        className="flex flex-wrap items-center justify-center gap-2 px-3 py-6 text-center text-sm text-muted-foreground"
+      >
+        <span>Could not search sites.</span>
+        <button
+          type="button"
+          onClick={onRetry}
+          className={cn(
+            "rounded-sm font-medium text-primary underline-offset-4 hover:underline",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          )}
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  if (results.length === 0) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="px-3 py-6 text-center text-sm text-muted-foreground"
+      >
+        {isSearching ? "Searching sites..." : `No sites match "${term}".`}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <PaletteGroup heading="Sites" forceMount>
+        {results.map((site) => {
+          const hostname = hostnameFromUrl(site.url);
+          return (
+            <PaletteItem
+              key={`site-${site.id}`}
+              forceMount
+              // Unique per site, and stable across renders, so cmdk's
+              // selection does not jump as results come and go.
+              value={`site-${site.id}`}
+              // The same three fields the server matched on. cmdk scores
+              // against these to order the results sensibly; `forceMount`
+              // above is what guarantees they are SHOWN either way, so a
+              // scoring disagreement can never hide a real match.
+              keywords={[site.name, site.url, ...site.tags]}
+              onSelect={() => onOpen(site.id)}
+              icon={<Globe className="size-4" aria-hidden="true" />}
+              trailing={
+                <span className="font-mono text-xs text-muted-foreground">
+                  {hostname}
+                </span>
+              }
+            >
+              Go to {site.name || hostname}
+            </PaletteItem>
+          );
+        })}
+      </PaletteGroup>
+      {isSearching ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="px-3 pb-2 text-center text-xs text-muted-foreground"
+        >
+          Searching sites...
+        </div>
+      ) : null}
+    </>
+  );
+}
+
 // ── Internal building blocks ────────────────────────────────────────────────
 
 interface PaletteGroupProps {
   heading: string;
   children: ReactNode;
+  /** Render even when no child item matches the typed term (GH #349). */
+  forceMount?: boolean;
 }
 
-function PaletteGroup({ heading, children }: PaletteGroupProps) {
+function PaletteGroup({ heading, children, forceMount }: PaletteGroupProps) {
   return (
     <Command.Group
       heading={heading}
+      forceMount={forceMount}
       // The heading slot is wrapped by cmdk in a `[cmdk-group-heading]` div.
       // We style that via a child selector so the visual is the spec-stated
       // "uppercase, tracking-wide, muted" caption — no extra wrapper.
@@ -426,12 +614,29 @@ interface PaletteItemProps {
   icon?: ReactNode;
   trailing?: ReactNode;
   children: ReactNode;
+  /** Stable identity for cmdk; defaults to the rendered text. */
+  value?: string;
+  /** Extra text cmdk scores the term against (name, url, tags). */
+  keywords?: string[];
+  /** Render regardless of cmdk's own filter (GH #349 server results). */
+  forceMount?: boolean;
 }
 
-function PaletteItem({ onSelect, icon, trailing, children }: PaletteItemProps) {
+function PaletteItem({
+  onSelect,
+  icon,
+  trailing,
+  children,
+  value,
+  keywords,
+  forceMount,
+}: PaletteItemProps) {
   return (
     <Command.Item
       onSelect={onSelect}
+      value={value}
+      keywords={keywords}
+      forceMount={forceMount}
       className={cn(
         // 6px radius, 12/8 padding, body-sm sizing — matches DESIGN.md item
         // shape ("rectangles with 6px radius", "8/12 padding").

--- a/apps/web/src/features/sites/sites-sort.ts
+++ b/apps/web/src/features/sites/sites-sort.ts
@@ -1,0 +1,81 @@
+// GH #349. The Sites list order-by axis.
+//
+// The wire values are pinned by the contract for GET /api/v1/sites:
+//
+//   name | -name | created_at | -created_at | last_seen | -last_seen
+//
+// A leading "-" is DESCENDING. Absent behaves exactly as the list always has:
+// -created_at. The server 422s an unrecognised value rather than silently
+// falling back, so the web side validates before it sends: the URL parser
+// (searchSchema in routes/_authed/sites/index.tsx) rejects anything outside
+// this list, which means an invalid value can never reach the request.
+//
+// These are wire values, not labels. Nothing an operator reads comes from this
+// list directly; SITE_SORT_LABELS below owns the copy, and it deliberately
+// speaks about sites ("Newest first") rather than about columns.
+
+export const SITE_SORT_VALUES = [
+  "name",
+  "-name",
+  "created_at",
+  "-created_at",
+  "last_seen",
+  "-last_seen",
+] as const;
+
+export type SiteSort = (typeof SITE_SORT_VALUES)[number];
+
+/**
+ * What the list does when no order is chosen. Matches the server's own
+ * default, so an absent `sort` and an explicit `-created_at` return the same
+ * rows in the same order.
+ */
+export const DEFAULT_SITE_SORT: SiteSort = "-created_at";
+
+/**
+ * Operator-facing labels. "Recently active" reads off `last_seen_at`, the
+ * timestamp of the site's last agent check-in.
+ */
+export const SITE_SORT_LABELS: Record<SiteSort, string> = {
+  "-created_at": "Newest first",
+  created_at: "Oldest first",
+  name: "Name (A to Z)",
+  "-name": "Name (Z to A)",
+  "-last_seen": "Recently active",
+  last_seen: "Least recently active",
+};
+
+/** Menu order: the two most-reached-for orders first, then name, then activity. */
+export const SITE_SORT_MENU: readonly SiteSort[] = [
+  "-created_at",
+  "created_at",
+  "name",
+  "-name",
+  "-last_seen",
+  "last_seen",
+];
+
+/**
+ * Both activity orders put sites that have never checked in at the END.
+ *
+ * A site with no `last_seen_at` has no activity to compare, so it is not
+ * "least recently active", it is unknown. Sorting unknowns to the top of
+ * either direction would bury the rows the operator opened the order for.
+ * The menu says so out loud (ORDER_HINT below) rather than leaving the
+ * operator to work it out from a screen of blanks.
+ */
+export const NEVER_SEEN_HINT =
+  "Sites that have never checked in are listed last.";
+
+/** Is this an order the contract accepts? Guards URL and stored values. */
+export function isSiteSort(value: unknown): value is SiteSort {
+  return (
+    typeof value === "string" &&
+    (SITE_SORT_VALUES as readonly string[]).includes(value)
+  );
+}
+
+/** The label for the applied order, falling back to the default's label. */
+export function siteSortLabel(sort: SiteSort | undefined): string {
+  return SITE_SORT_LABELS[sort ?? DEFAULT_SITE_SORT];
+}

--- a/apps/web/src/features/sites/sites-toolbar.tsx
+++ b/apps/web/src/features/sites/sites-toolbar.tsx
@@ -6,6 +6,7 @@ import {
 } from "react";
 import { Link } from "@tanstack/react-router";
 import {
+  ArrowDownUp,
   ChevronDown,
   Download,
   ExternalLink,
@@ -35,10 +36,21 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { TagChip } from "@/features/sites/tag-chip";
+import {
+  DEFAULT_SITE_SORT,
+  NEVER_SEEN_HINT,
+  SITE_SORT_LABELS,
+  SITE_SORT_MENU,
+  isSiteSort,
+  siteSortLabel,
+  type SiteSort,
+} from "@/features/sites/sites-sort";
 import { resolveTagDot } from "@/lib/tag-color";
 import { cn } from "@/lib/utils";
 import { dur, ease } from "@/lib/motion-presets";
@@ -136,6 +148,16 @@ export interface SitesToolbarProps {
   activeFilterCount?: number;
   /** Called to clear ALL filters across all axes. */
   onClearAllFilters?: () => void;
+  /**
+   * GH #349. The applied order (server-side). Undefined shows the default,
+   * "Newest first". This is an ORDER, not a filter: it is deliberately absent
+   * from `activeFilterCount` and untouched by "Clear filters", because
+   * clearing a search should not also throw away how the operator asked to
+   * read the list.
+   */
+  sort?: SiteSort;
+  /** Called when a different order is chosen. */
+  onSortChange?: (next: SiteSort) => void;
 
   // ---- P2 view mode wiring --------------------------------------------------
   /** Current view mode (list | grid). */
@@ -235,6 +257,8 @@ function IdleMode({
   agentStatusHint,
   activeFilterCount = 0,
   onClearAllFilters,
+  sort,
+  onSortChange,
   densityState,
   view = "list",
   onViewChange,
@@ -361,8 +385,17 @@ function IdleMode({
         ) : null}
       </div>
 
-      {/* Right cluster: view toggle + density/card-size + select-all-grid + add site */}
+      {/* Right cluster: order + view toggle + density/card-size + select-all-grid + add site */}
       <div className="flex items-center gap-2">
+        {/* GH #349 "Order by". It sits with the presentation controls rather
+            than inside the filter cluster on the left because it does not
+            narrow the list, and because the filter cluster's width swings with
+            the active tag chips, which would move this control around under
+            the operator's cursor. */}
+        {onSortChange ? (
+          <OrderByDropdown sort={sort} onChange={onSortChange} />
+        ) : null}
+
         {/* Grid "Select all (N)" control — only in grid view (table has header checkbox). */}
         {view === "grid" && visibleIds.length > 0 ? (
           <GridSelectAll
@@ -787,6 +820,84 @@ function ClientFilterDropdown({
             </DropdownMenuItem>
           ))
         )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// OrderByDropdown: the Sites list order (GH #349)
+// ---------------------------------------------------------------------------
+
+/**
+ * Single-select order control, built on the same outline-button + dropdown
+ * idiom as the Client / Status / Agent / Tags filters, with
+ * DropdownMenuRadioGroup instead of checkbox items because exactly one order
+ * is applied at a time.
+ *
+ * The trigger shows the applied order in words ("Newest first"), so the
+ * operator never has to open the menu to find out how the list is sorted.
+ *
+ * The order is applied by the SERVER: it decides which sites come back, not
+ * just how the loaded ones are arranged. Sorting a table column header still
+ * rearranges only the rows already on screen, which is why this control lives
+ * in the toolbar and says so in the menu footer.
+ */
+function OrderByDropdown({
+  sort,
+  onChange,
+}: {
+  sort: SiteSort | undefined;
+  onChange: (next: SiteSort) => void;
+}) {
+  const applied = sort ?? DEFAULT_SITE_SORT;
+  const showsActivityHint = applied === "last_seen" || applied === "-last_seen";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          aria-label={`Order sites, currently ${siteSortLabel(sort)}`}
+          className={cn(
+            "h-9 gap-1.5",
+            // Any non-default order is a deliberate choice; mark it the same
+            // way an applied filter is marked.
+            sort && sort !== DEFAULT_SITE_SORT && "border-primary/50 bg-primary/5",
+          )}
+        >
+          <ArrowDownUp aria-hidden="true" className="size-3.5" />
+          {siteSortLabel(sort)}
+          <ChevronDown aria-hidden="true" className="size-3" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-[14rem]" collisionPadding={8}>
+        <DropdownMenuLabel>Order by</DropdownMenuLabel>
+        <DropdownMenuRadioGroup
+          value={applied}
+          onValueChange={(next) => {
+            // Radix hands back a bare string; only a value the contract
+            // accepts is allowed through, so an unrecognised order can never
+            // reach the request (the server 422s those rather than falling
+            // back).
+            if (isSiteSort(next)) onChange(next);
+          }}
+        >
+          {SITE_SORT_MENU.map((value) => (
+            <DropdownMenuRadioItem key={value} value={value} className="text-xs">
+              {SITE_SORT_LABELS[value]}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+        {showsActivityHint ? (
+          <>
+            <DropdownMenuSeparator />
+            <div className="max-w-[18rem] px-2 pb-1 pt-0.5 text-xs text-muted-foreground">
+              {NEVER_SEEN_HINT}
+            </div>
+          </>
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/web/src/features/sites/use-sites-query.test.ts
+++ b/apps/web/src/features/sites/use-sites-query.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import type { ListSitesData } from "@wpmgr/api";
+
+// GH #349. What `useSites` actually puts on the wire.
+//
+// The route-level tests assert the page's behaviour; this file asserts the
+// REQUEST, which is where the bug lived. `useSites()` used to call
+// `listSites({})`: no limit, so the control plane's default 50, ordered by
+// created_at DESC, with the free-text search applied afterwards in the
+// browser. An agency past 50 sites searched their newest 50 and was told
+// nothing else matched.
+//
+// Every test in this file fails against the pre-change hook.
+
+const { listSitesMock } = vi.hoisted(() => ({ listSitesMock: vi.fn() }));
+
+vi.mock("@wpmgr/api", () => ({
+  client: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+  listSites: listSitesMock,
+  getSite: vi.fn(),
+  deleteSite: vi.fn(),
+  createPairingCode: vi.fn(),
+  setSiteTags: vi.fn(),
+  refreshSiteScreenshot: vi.fn(),
+}));
+
+vi.mock("@/components/toast", () => ({
+  toast: { warning: vi.fn(), success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+import {
+  useSites,
+  sitesQueryOptions,
+  sitesKeys,
+  DEFAULT_SITES_LIMIT,
+  type UseSitesOptions,
+} from "./use-sites";
+
+function makeQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function wrapperFor(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: qc }, children);
+  };
+}
+
+/** The query object of the most recent listSites call. */
+async function sentQuery(): Promise<NonNullable<ListSitesData["query"]>> {
+  await waitFor(() => {
+    expect(listSitesMock).toHaveBeenCalled();
+  });
+  const call = listSitesMock.mock.calls.at(-1) as
+    | [{ query?: NonNullable<ListSitesData["query"]> }]
+    | undefined;
+  return call?.[0]?.query ?? {};
+}
+
+async function renderUseSites(options?: UseSitesOptions) {
+  renderHook(() => useSites(options), { wrapper: wrapperFor(makeQueryClient()) });
+  return sentQuery();
+}
+
+beforeEach(() => {
+  listSitesMock.mockReset();
+  listSitesMock.mockResolvedValue({
+    data: { items: [] },
+    error: undefined,
+    response: { status: 200 },
+  });
+});
+
+describe("useSites request (GH #349)", () => {
+  it("sends the free-text term as `q` instead of filtering the response", async () => {
+    expect(await renderUseSites({ q: "iacop" })).toMatchObject({ q: "iacop" });
+  });
+
+  it("trims the term, and treats a whitespace-only one as no search at all", async () => {
+    expect(await renderUseSites({ q: "  iacop  " })).toMatchObject({
+      q: "iacop",
+    });
+    listSitesMock.mockClear();
+    expect(await renderUseSites({ q: "   " })).not.toHaveProperty("q");
+  });
+
+  it("sends the chosen order as `sort`, and sends nothing when the default is wanted", async () => {
+    expect(await renderUseSites({ sort: "-last_seen" })).toMatchObject({
+      sort: "-last_seen",
+    });
+    listSitesMock.mockClear();
+    // Absent means the server's own default (-created_at). Sending nothing is
+    // how the list behaved before the axis existed, so an untouched control
+    // changes no request.
+    expect(await renderUseSites()).not.toHaveProperty("sort");
+  });
+
+  it("asks for the contract maximum rather than taking the server's default page of 50", async () => {
+    // THE CAP. A list the operator is told is searched and ordered across
+    // their organisation must not quietly stop at 50.
+    expect(await renderUseSites()).toMatchObject({ limit: 200 });
+    expect(DEFAULT_SITES_LIMIT).toBe(200);
+  });
+
+  it("lets a caller ask for a smaller page (the command palette does)", async () => {
+    expect(await renderUseSites({ q: "iacop", limit: 20 })).toMatchObject({
+      q: "iacop",
+      limit: 20,
+    });
+  });
+
+  it("composes search and order with the filters that were already server-side", async () => {
+    expect(
+      await renderUseSites({
+        view: "archived",
+        clientId: "c-1",
+        tags: ["prod", "eu"],
+        tagsMatch: "all",
+        q: "iacop",
+        sort: "name",
+      }),
+    ).toMatchObject({
+      state: "archived",
+      clientId: "c-1",
+      tags: ["prod", "eu"],
+      tags_match: "all",
+      q: "iacop",
+      sort: "name",
+      limit: 200,
+    });
+  });
+
+  it("does not fire at all when disabled, so an empty palette box searches for nothing", async () => {
+    renderHook(() => useSites({ q: "", enabled: false }), {
+      wrapper: wrapperFor(makeQueryClient()),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(listSitesMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("useSites cache identity (GH #349)", () => {
+  it("gives each term and each order its own cache entry", () => {
+    const base = JSON.stringify(sitesKeys.list("active"));
+    expect(JSON.stringify(sitesKeys.list("active", undefined, undefined, "any", { q: "a" })))
+      .not.toBe(base);
+    expect(
+      JSON.stringify(
+        sitesKeys.list("active", undefined, undefined, "any", { sort: "name" }),
+      ),
+    ).not.toBe(base);
+  });
+
+  it("keeps the route loader's prefetch on the SAME key a default useSites() reads", async () => {
+    // The Sites route prefetches `sitesQueryOptions()` and the page then calls
+    // `useSites({ view: "active", ... })` with no term and no order. If those
+    // two keys drifted apart, the prefetch would be dead weight and the page
+    // would fire a second identical request on every cold load.
+    expect(JSON.stringify(sitesQueryOptions().queryKey)).toBe(
+      JSON.stringify(sitesKeys.list("active")),
+    );
+
+    // ...and the prefetch must ask for the same page size, or the two would
+    // return different rows.
+    const qc = makeQueryClient();
+    await qc.prefetchQuery(sitesQueryOptions());
+    expect(await sentQuery()).toMatchObject({ limit: 200 });
+  });
+});

--- a/apps/web/src/features/sites/use-sites.ts
+++ b/apps/web/src/features/sites/use-sites.ts
@@ -10,7 +10,6 @@ import {
   type UseMutationResult,
 } from "@tanstack/react-query";
 import {
-  client,
   listSites,
   getSite,
   deleteSite,
@@ -18,13 +17,14 @@ import {
   setSiteTags,
   refreshSiteScreenshot,
   type Site,
-  type SiteList,
   type PairingCode,
   type PairingCodeCreate,
   type ApiError,
+  type ListSitesData,
 } from "@wpmgr/api";
 
 import { toast } from "@/components/toast";
+import type { SiteSort } from "@/features/sites/sites-sort";
 
 // Server-state hooks for the Sites domain. Built on the generated @wpmgr/api
 // SDK (Hey API). Each SDK call returns `{ data, error, response }`; we unwrap
@@ -38,13 +38,65 @@ export type SitesView = "active" | "archived";
  *  the selected `tags` filter. Mirrors the OpenAPI `tags_match` param. */
 export type TagMatchMode = "any" | "all";
 
-export interface UseSitesOptions {
+/**
+ * How many sites one list request asks for.
+ *
+ * GH #349. The control plane defaults to 50 and caps at 200. Leaving the
+ * default in place while the toolbar tells the operator they are looking at a
+ * searched, ordered list of their whole organisation is the defect this issue
+ * is about: they would be looking at the 50 newest. 200 is the highest a
+ * single request can honestly express, and it is the number every bare
+ * `useSites()` caller depends on too, since several of them speak for the
+ * whole fleet ("Run backup on all sites" in the command palette, the sidebar
+ * site count, the fleet performance and audit pickers).
+ *
+ * Above 200 sites this is still a cap, but it is now a HONEST one: with `q`
+ * and `sort` applied server-side, the rows returned are the top 200 matches in
+ * the requested order rather than an arbitrary newest-50 that a client-side
+ * filter then searched. Going beyond it needs real pagination on the list,
+ * which is a separate change.
+ */
+export const DEFAULT_SITES_LIMIT = 200;
+
+/**
+ * Search and order that the SERVER applies (GH #349), as opposed to the axes
+ * the Sites page still narrows client-side. See the comment above
+ * `visibleSites` in routes/_authed/sites/index.tsx for the full split.
+ */
+export interface SitesQueryOptions {
+  /**
+   * Case-insensitive substring match against site NAME, URL and any TAG.
+   * Empty or whitespace-only behaves as absent. Semantics are deliberately
+   * identical to the client-side filter this replaced, so moving it to the
+   * server did not change which sites match, only how many of them were ever
+   * considered.
+   */
+  q?: string;
+  /** Ordering. Absent behaves as the server default, `-created_at`. */
+  sort?: SiteSort;
+  /** Page size. Defaults to DEFAULT_SITES_LIMIT. */
+  limit?: number;
+}
+
+export interface UseSitesOptions extends SitesQueryOptions {
   view?: SitesView;
   clientId?: string;
   /** Filter to sites carrying these tags (server-side, GH #230). */
   tags?: readonly string[];
   /** `any` (OR) or `all` (AND). Only meaningful with 2+ tags; defaults `any`. */
   tagsMatch?: TagMatchMode;
+  /**
+   * When false the query does not run. Used by the command palette, whose
+   * zero-query state shows recently-viewed sites and must not fire a
+   * search request until something is typed.
+   */
+  enabled?: boolean;
+}
+
+/** Trimmed search term, or null when there is nothing to search for. */
+function normalizeQ(q: string | undefined): string | null {
+  const trimmed = q?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 export const sitesKeys = {
@@ -55,6 +107,11 @@ export const sitesKeys = {
     clientId?: string,
     tags?: readonly string[],
     tagsMatch: TagMatchMode = "any",
+    // GH #349. Folded into the SAME key object rather than added as further
+    // positional arguments so that `sitesKeys.list("active")` keeps producing
+    // the exact key a default `useSites()` subscribes to (the route loader's
+    // prefetch depends on that identity).
+    query?: SitesQueryOptions,
   ) =>
     [
       ...sitesKeys.lists(),
@@ -63,6 +120,9 @@ export const sitesKeys = {
         clientId: clientId ?? null,
         tags: tags && tags.length > 0 ? [...tags].sort() : null,
         tagsMatch,
+        q: normalizeQ(query?.q),
+        sort: query?.sort ?? null,
+        limit: query?.limit ?? DEFAULT_SITES_LIMIT,
       },
     ] as const,
   detail: (id: string) => [...sitesKeys.all, "detail", id] as const,
@@ -90,15 +150,52 @@ export const sitesQueryOptions = () =>
   queryOptions({
     queryKey: sitesKeys.list("active"),
     queryFn: async () => {
-      const { data, error } = await listSites({});
+      const { data, error } = await listSites({
+        query: { limit: DEFAULT_SITES_LIMIT },
+      });
       if (error) throw toError(error);
       return data?.items ?? [];
     },
   });
 
 /**
- * List sites, optionally filtered by tags (server-side, GH #230 "rich tags")
- * and/or a client UUID (?clientId=).
+ * Build the `GET /api/v1/sites` query string for one list request.
+ *
+ * Annotated with the GENERATED query type so every parameter name and value is
+ * checked against the contract rather than trusted: a `sort` outside the
+ * contract's enum, which the server answers with a 422, cannot compile.
+ *
+ * `clientId` is the one exception. It is a long-standing parameter the control
+ * plane honours but the OpenAPI document has never described, so it is spread
+ * in (TypeScript applies no excess-property check to spread members) with this
+ * note rather than silently cast. Specifying it is an API-lane change.
+ */
+function buildSitesQuery(
+  view: SitesView,
+  clientId: string | undefined,
+  tags: readonly string[] | undefined,
+  tagsMatch: TagMatchMode,
+  q: string | null,
+  sort: SiteSort | undefined,
+  limit: number,
+): NonNullable<ListSitesData["query"]> {
+  const query: NonNullable<ListSitesData["query"]> = { limit };
+  if (view === "archived") query.state = "archived";
+  if (tags) {
+    query.tags = [...tags];
+    if (tags.length > 1) query.tags_match = tagsMatch;
+  }
+  if (q) query.q = q;
+  if (sort) query.sort = sort;
+  return { ...query, ...(clientId ? { clientId } : {}) };
+}
+
+/**
+ * List sites for the current tenant.
+ *
+ * SERVER-SIDE axes (the request decides which rows come back):
+ *   view/state, clientId, tags + tagsMatch (GH #230), q and sort (GH #349),
+ *   limit.
  *
  * The default ("active") view hides archived sites (the CP omits them unless
  * asked). Pass `view: "archived"` to fetch the archived bucket via
@@ -109,37 +206,25 @@ export function useSites(options?: UseSitesOptions): UseQueryResult<Site[], Erro
   const clientId = options?.clientId || undefined;
   const tags = options?.tags && options.tags.length > 0 ? options.tags : undefined;
   const tagsMatch: TagMatchMode = options?.tagsMatch ?? "any";
+  const q = normalizeQ(options?.q);
+  const sort = options?.sort;
+  const limit = options?.limit ?? DEFAULT_SITES_LIMIT;
   return useQuery({
-    queryKey: sitesKeys.list(view, clientId, tags, tagsMatch),
-    // GH #230 "rich tags" — toggling a tag filter changes the query key (the
-    // filter is now server-side); without this, the table would flash empty
+    queryKey: sitesKeys.list(view, clientId, tags, tagsMatch, {
+      q: q ?? undefined,
+      sort,
+      limit,
+    }),
+    enabled: options?.enabled ?? true,
+    // GH #230 "rich tags" and GH #349 search + order: changing any server-side
+    // axis changes the query key; without this the table would flash empty
     // between the old and new result instead of holding the previous rows
-    // until the new ones land.
+    // until the new ones land. It also keeps `isPending` false across a
+    // keystroke, so the list never drops back to its skeleton mid-search.
     placeholderData: keepPreviousData,
     queryFn: async () => {
-      // The archived view passes `?state=archived`. For views that need extra
-      // params we call the typed `listSites` with the full query object.
-      if (view === "archived") {
-        const query: Record<string, string | string[]> = { state: "archived" };
-        if (clientId) query.clientId = clientId;
-        if (tags) {
-          query.tags = [...tags];
-          if (tags.length > 1) query.tags_match = tagsMatch;
-        }
-        // The client's response-style generics unwrap a responses-map.
-        const { data, error } = await client.get<{ 200: SiteList }>({
-          url: "/api/v1/sites",
-          query,
-        });
-        if (error) throw toError(error);
-        return data?.items ?? [];
-      }
       const { data, error } = await listSites({
-        query: {
-          ...(clientId ? { clientId } : {}),
-          ...(tags ? { tags: [...tags] } : {}),
-          ...(tags && tags.length > 1 ? { tags_match: tagsMatch } : {}),
-        },
+        query: buildSitesQuery(view, clientId, tags, tagsMatch, q, sort, limit),
       });
       if (error) throw toError(error);
       return data?.items ?? [];

--- a/apps/web/src/lib/use-debounced-value.ts
+++ b/apps/web/src/lib/use-debounced-value.ts
@@ -1,0 +1,26 @@
+// useDebouncedValue. A trailing-edge debounce for a value that drives a query.
+//
+// GH #349. The Sites search input and the command palette both write the typed
+// term SYNCHRONOUSLY (to the URL and to local state respectively) so typing
+// never feels laggy, then feed a debounced MIRROR of that term to the server.
+// Without the split, every keystroke would be its own request; without the
+// synchronous write, the input would feel like it drops characters.
+//
+// The first value is adopted immediately, with no leading delay, so a shared
+// link such as /sites?q=acme fetches on the first paint instead of a beat
+// later.
+//
+// setState happens inside the timer callback, never synchronously in the
+// effect body, matching lib/use-now.ts and the react-hooks purity rules.
+import { useEffect, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delayMs = 250): T {
+  const [debounced, setDebounced] = useState<T>(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/apps/web/src/routes/_authed/sites/-index.search-sort.test.tsx
+++ b/apps/web/src/routes/_authed/sites/-index.search-sort.test.tsx
@@ -1,0 +1,352 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import type { QueryClient } from "@tanstack/react-query";
+import type { Me, Site } from "@wpmgr/api";
+
+import { createTestQueryClient, renderWithProviders } from "@/test/render";
+import { mockQueryResult } from "@/test/query-mocks";
+import { authKeys } from "@/features/auth/use-auth";
+
+import { Route as SitesIndexRoute } from "./index";
+import { useSites, type UseSitesOptions } from "@/features/sites/use-sites";
+import { useClients } from "@/features/clients/use-clients";
+import { useTags } from "@/features/tags/use-tags";
+import { useSitesLiveSync } from "@/features/sites/use-sites-live";
+
+// GH #349. Search and order on the Sites list are SERVER-side axes.
+//
+// THE BUG: `useSites()` asked for no limit, the control plane defaulted to 50
+// ordered by created_at DESC, and the page then filtered those 50 in the
+// browser. Above 50 sites an agency searched only their newest 50 and were
+// told, with no hint of truncation, that nothing else matched. There was no
+// way to order the list at all.
+//
+// THE FIX: `q` and `sort` go to the server, so the rows that arrive ARE the
+// best matches in the requested order. Connection status and agent freshness
+// stay client-side (see the comment above `visibleSites` for why), which is
+// exactly why the request now asks for the contract maximum rather than
+// leaving the implicit 50 in place.
+//
+// Every test in this file fails against the pre-change route.
+
+vi.mock("@/features/sites/use-sites", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/features/sites/use-sites")>();
+  return { ...actual, useSites: vi.fn() };
+});
+vi.mock("@/features/clients/use-clients", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/features/clients/use-clients")>();
+  return { ...actual, useClients: vi.fn() };
+});
+vi.mock("@/features/tags/use-tags", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/features/tags/use-tags")>();
+  return { ...actual, useTags: vi.fn() };
+});
+vi.mock("@/features/sites/use-sites-live", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/features/sites/use-sites-live")>();
+  return { ...actual, useSitesLiveSync: vi.fn() };
+});
+
+const mockedUseSites = vi.mocked(useSites);
+const mockedUseClients = vi.mocked(useClients);
+const mockedUseTags = vi.mocked(useTags);
+const mockedUseSitesLiveSync = vi.mocked(useSitesLiveSync);
+
+const OWNER_ME: Me = {
+  user: {
+    id: "00000000-0000-0000-0000-0000000000u1",
+    email: "owner@example.com",
+    name: "Owner",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  memberships: [
+    {
+      user_id: "00000000-0000-0000-0000-0000000000u1",
+      tenant_id: "t1",
+      role: "owner",
+    },
+  ],
+  active_tenant_id: "t1",
+  hosted: false,
+};
+
+function buildSite(overrides: Partial<Site> = {}): Site {
+  return {
+    id: "11111111-0000-0000-0000-000000000001",
+    tenant_id: "t1",
+    url: "https://acme.example.com",
+    name: "Acme",
+    status: "active",
+    wp_version: "6.8",
+    php_version: "8.3",
+    health_status: "healthy",
+    multisite: false,
+    tags: [],
+    ...overrides,
+  } as unknown as Site;
+}
+
+function buildSitesRouter(initialPath: string, queryClient: QueryClient) {
+  const rootRoute = createRootRoute({});
+  type UpdateOptions = Parameters<typeof SitesIndexRoute.update>[0];
+  const sitesRoute = SitesIndexRoute.update({
+    id: "/sites",
+    path: "/sites",
+    getParentRoute: () => rootRoute,
+  } as unknown as UpdateOptions);
+  const routeTree = rootRoute.addChildren([sitesRoute]);
+  return createRouter({
+    routeTree,
+    context: { queryClient },
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+  });
+}
+
+function renderSitesPage(initialPath = "/sites") {
+  const queryClient = createTestQueryClient();
+  queryClient.setQueryData(authKeys.me, OWNER_ME);
+  const router = buildSitesRouter(initialPath, queryClient);
+  renderWithProviders(<RouterProvider router={router} />, { queryClient });
+  return router;
+}
+
+/** The options the ACTIVE-view list call was made with, most recent last. */
+function listCalls(): UseSitesOptions[] {
+  return mockedUseSites.mock.calls
+    .map(([options]) => options)
+    .filter((options): options is UseSitesOptions => options?.view === "active");
+}
+
+function latestListCall(): UseSitesOptions {
+  const calls = listCalls();
+  const last = calls.at(-1);
+  if (!last) throw new Error("the page never asked for the active sites list");
+  return last;
+}
+
+const FIND_TIMEOUT = 5000;
+
+beforeEach(() => {
+  mockedUseClients.mockReturnValue(mockQueryResult({ data: [] }));
+  mockedUseTags.mockReturnValue(mockQueryResult({ data: [] }));
+  mockedUseSitesLiveSync.mockReturnValue(undefined);
+  mockedUseSites.mockImplementation((options?: UseSitesOptions) =>
+    mockQueryResult<Site[]>({
+      data: options?.view === "archived" ? [] : [buildSite()],
+    }),
+  );
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  vi.clearAllMocks();
+});
+
+describe("T5: the Sites list searches on the SERVER (GH #349)", () => {
+  it("sends the URL's `q` to the API", async () => {
+    renderSitesPage("/sites?q=iacop");
+
+    await screen.findByRole("toolbar", { name: "Filter sites" }, {
+      timeout: FIND_TIMEOUT,
+    });
+
+    await waitFor(() => {
+      expect(latestListCall().q).toBe("iacop");
+    });
+  });
+
+  it("does NOT filter the returned rows in the browser: a row the server sent is a row the operator sees", async () => {
+    // The server matched this site on something the row does not spell out.
+    // Its name, url and tags contain no "iacop" at all, so the pre-change
+    // page's own filter over name/url/tags dropped it and rendered the
+    // filtered-empty state instead. The whole point of moving the axis is
+    // that the server's answer IS the answer.
+    //
+    // Grid view, because the list view's body is windowed by react-virtuoso,
+    // which renders no rows at all in jsdom's zero-height layout.
+    mockedUseSites.mockImplementation((options?: UseSitesOptions) =>
+      mockQueryResult<Site[]>({
+        data:
+          options?.view === "archived"
+            ? []
+            : [
+                buildSite({
+                  id: "s-server-match",
+                  name: "Northwind",
+                  url: "https://northwind.test",
+                  tags: [],
+                }),
+              ],
+      }),
+    );
+
+    renderSitesPage("/sites?q=iacop&view=grid");
+
+    expect(
+      await screen.findByText("Northwind", {}, { timeout: FIND_TIMEOUT }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("status", {
+        name: "No sites match the current filters",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("counts what the server returned, not a second helping of the same filter", async () => {
+    // The subline is the other place the old client-side filter showed
+    // through: it counted the rows that survived it. With `q` server-side the
+    // page must report the server's answer as-is.
+    mockedUseSites.mockImplementation((options?: UseSitesOptions) =>
+      mockQueryResult<Site[]>({
+        data:
+          options?.view === "archived"
+            ? []
+            : [
+                buildSite({ id: "a", name: "Northwind", url: "https://nw.test" }),
+                buildSite({ id: "b", name: "Contoso", url: "https://ct.test" }),
+              ],
+      }),
+    );
+
+    renderSitesPage("/sites?q=iacop");
+
+    expect(
+      await screen.findByText("2 matching sites", {}, { timeout: FIND_TIMEOUT }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps typing responsive: the URL updates on the keystroke even though the request is debounced", async () => {
+    const router = renderSitesPage("/sites");
+
+    await screen.findByRole("toolbar", { name: "Filter sites" }, {
+      timeout: FIND_TIMEOUT,
+    });
+
+    fireEvent.change(screen.getByLabelText("Search sites"), {
+      target: { value: "acme" },
+    });
+
+    await waitFor(() => {
+      expect(router.state.location.search).toMatchObject({ q: "acme" });
+    });
+    await waitFor(() => {
+      expect(latestListCall().q).toBe("acme");
+    });
+  });
+});
+
+describe("T4: the order control is URL-controlled (GH #349)", () => {
+  it("reads the applied order back out of the URL", async () => {
+    renderSitesPage("/sites?sort=name");
+
+    expect(
+      await screen.findByRole(
+        "button",
+        { name: /Order sites, currently Name \(A to Z\)/ },
+        { timeout: FIND_TIMEOUT },
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the list's real default when the URL says nothing", async () => {
+    renderSitesPage("/sites");
+
+    expect(
+      await screen.findByRole(
+        "button",
+        { name: /Order sites, currently Newest first/ },
+        { timeout: FIND_TIMEOUT },
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("writes the chosen order to the URL and sends it to the API", async () => {
+    const router = renderSitesPage("/sites");
+
+    const trigger = await screen.findByRole(
+      "button",
+      { name: /Order sites/ },
+      { timeout: FIND_TIMEOUT },
+    );
+    fireEvent.pointerDown(
+      trigger,
+      new PointerEvent("pointerdown", { bubbles: true, button: 0 }),
+    );
+
+    const option = await screen.findByRole("menuitemradio", {
+      name: "Recently active",
+    });
+    fireEvent.click(option);
+
+    await waitFor(() => {
+      expect(router.state.location.search).toMatchObject({ sort: "-last_seen" });
+    });
+    await waitFor(() => {
+      expect(latestListCall().sort).toBe("-last_seen");
+    });
+  });
+
+  it("marks the applied order as checked, so the menu says which one is on", async () => {
+    renderSitesPage("/sites?sort=-name");
+
+    const trigger = await screen.findByRole(
+      "button",
+      { name: /Order sites/ },
+      { timeout: FIND_TIMEOUT },
+    );
+    fireEvent.pointerDown(
+      trigger,
+      new PointerEvent("pointerdown", { bubbles: true, button: 0 }),
+    );
+
+    const checked = await screen.findByRole("menuitemradio", { checked: true });
+    expect(checked).toHaveTextContent("Name (Z to A)");
+  });
+
+  it("falls back to the default rather than breaking the page on a bogus URL value", async () => {
+    // The server 422s an unrecognised order. A hand-edited or stale link must
+    // not send one, and must not blow up the route either.
+    renderSitesPage("/sites?sort=by-vibes");
+
+    await screen.findByRole(
+      "button",
+      { name: /Order sites, currently Newest first/ },
+      { timeout: FIND_TIMEOUT },
+    );
+    expect(latestListCall().sort).toBeUndefined();
+  });
+
+  it("survives 'Clear filters': an order is how you read the list, not a filter on it", async () => {
+    const router = renderSitesPage("/sites?q=acme&sort=name");
+
+    const clear = await screen.findByRole(
+      "button",
+      { name: /Clear 1 active filter/ },
+      { timeout: FIND_TIMEOUT },
+    );
+    fireEvent.click(clear);
+
+    await waitFor(() => {
+      expect(router.state.location.search).not.toHaveProperty("q");
+    });
+    expect(router.state.location.search).toMatchObject({ sort: "name" });
+    // And the control still says so, rather than quietly snapping back to the
+    // default while the URL claims otherwise.
+    expect(
+      screen.getByRole("button", { name: /Order sites, currently Name \(A to Z\)/ }),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(latestListCall().sort).toBe("name");
+    });
+  });
+});

--- a/apps/web/src/routes/_authed/sites/index.tsx
+++ b/apps/web/src/routes/_authed/sites/index.tsx
@@ -16,8 +16,11 @@ import {
   useSites,
   useDeleteSite,
   sitesQueryOptions,
+  DEFAULT_SITES_LIMIT,
   type TagMatchMode,
 } from "@/features/sites/use-sites";
+import { SITE_SORT_VALUES, type SiteSort } from "@/features/sites/sites-sort";
+import { useDebouncedValue } from "@/lib/use-debounced-value";
 import { useTags } from "@/features/tags/use-tags";
 import { useTagColorMap } from "@/features/tags/use-tag-color-map";
 import { TagChip } from "@/features/sites/tag-chip";
@@ -77,6 +80,12 @@ const searchSchema = z.object({
   // Agent-freshness classification (agent-releases visibility). Stores
   // display labels, matching the `status` axis above; see AGENT_STATUS_LABEL.
   agentStatus: z.array(z.string()).optional(),
+  // GH #349. The order the SERVER returns sites in. On the URL like every
+  // other axis so a link carries it. `.catch(undefined)` rather than a hard
+  // parse failure: a hand-edited or stale URL should fall back to the default
+  // order, not break the page, and it guarantees only a contract-legal value
+  // is ever forwarded to the request (the server 422s the rest).
+  sort: z.enum(SITE_SORT_VALUES).optional().catch(undefined),
 });
 
 type SitesSearch = z.infer<typeof searchSchema>;
@@ -160,6 +169,30 @@ function SitesPage() {
     [navigate],
   );
 
+  // GH #349. The term the SERVER is asked for. The URL write above stays
+  // synchronous (the input must never lag a keystroke); only the request is
+  // debounced, so a 24-character search is one request rather than 24. The
+  // first value is adopted with no delay, so opening /sites?q=acme searches
+  // on the first paint.
+  const serverQuery = useDebouncedValue(search.q ?? "", 250);
+
+  // GH #349. The order. Undefined means "the server default", which is
+  // -created_at (newest first), exactly what the list did before this axis
+  // existed.
+  const sort: SiteSort | undefined = search.sort;
+
+  const handleSortChange = useCallback(
+    (next: SiteSort) => {
+      // Written out in full, including the default, so the URL always states
+      // the order the operator chose and a shared link reproduces it.
+      void navigate({
+        search: (prev: SitesSearch) => ({ ...prev, sort: next }),
+        replace: true,
+      });
+    },
+    [navigate],
+  );
+
   // Memoize the fallback arrays so their stable references don't force useMemo
   // hooks downstream to re-compute on every render (the ?. [] fallback creates a
   // new array reference each time when status/tags are absent from the URL).
@@ -193,13 +226,16 @@ function SitesPage() {
 
   const [setClientOpen, setSetClientOpen] = useState(false);
 
-  // GH #230 "rich tags" — tag filtering is now SERVER-SIDE (?tags=&tags_match=).
+  // GH #230 "rich tags": tag filtering is SERVER-SIDE (?tags=&tags_match=).
+  // GH #349: free-text search (?q=) and order (?sort=) are too.
   const { data: sites, isPending, isError, error, refetch, isFetching } =
     useSites({
       view: showArchived ? "archived" : "active",
       clientId: appliedClientId ?? undefined,
       tags: selectedTags,
       tagsMatch: tagMode,
+      q: serverQuery,
+      sort,
     });
 
   const { data: tagsRegistry } = useTags();
@@ -303,6 +339,30 @@ function SitesPage() {
 
   // ── visibleSites — pure derive over the query cache ───────────────────────
   //
+  // WHICH AXIS RUNS WHERE (GH #349. Read this before adding another one):
+  //
+  //   SERVER-SIDE, in the `useSites` call above, so the answer covers the
+  //   whole organisation rather than whatever happened to be on the first
+  //   page:
+  //     - free-text search  (?q=)        name, url, any tag
+  //     - order             (?sort=)
+  //     - tags + match mode (?tags=, ?tags_match=)   GH #230
+  //     - client            (?clientId=)
+  //     - archived bucket   (?state=archived)
+  //
+  //   CLIENT-SIDE, in the filter below, over the rows the server returned:
+  //     - connection status   derived from connection_state, which the list
+  //                           endpoint can only filter to ONE value at a time
+  //                           (?state=) while this axis is multi-select
+  //     - agent freshness     derived from a SEPARATE fleet rollup
+  //                           (useFleetAgentVersions), so the sites endpoint
+  //                           has nothing to filter on
+  //
+  // A client-side axis over a server-truncated page is only honest while the
+  // page is the whole set. That is why DEFAULT_SITES_LIMIT is the contract
+  // maximum and why moving one of these two axes to the server means moving
+  // it to the request, never widening this filter.
+  //
   // CRITICAL INVARIANTS (preserve and do not refactor without re-reading):
   //
   // 1. `selectedSites` reads the FULL `sites` array, NOT `visibleSites`.
@@ -315,34 +375,21 @@ function SitesPage() {
   // 3. The header "select all" / grid "select all" must scope to the VISIBLE
   //    (filtered) rows only — handled via visibleIds passed to the toolbar.
   //
-  // 4. useSitesLiveSync is untouched here; filters are a pure client-side
-  //    derive over the TanStack Query cache, not a re-fetch trigger.
-  //
-  // GH #230 "rich tags": the TAGS axis moved server-side (see the `useSites`
-  // call above) — `sites` already reflects the tags/tagMode filter. Text
-  // search still matches tag values (a tag is part of a site's searchable
-  // text), but no longer independently FILTERS by tag client-side.
+  // 4. useSitesLiveSync is untouched here; the two remaining filters are a
+  //    pure client-side derive over the TanStack Query cache, not a re-fetch
+  //    trigger. Search and order ARE re-fetch triggers, by design: they change
+  //    the query key.
 
   const visibleSites = useMemo(() => {
     if (!sites) return [];
 
-    const q = (search.q ?? "").trim().toLowerCase();
-    const hasQ = q.length > 0;
     const hasStatus = selectedStatuses.length > 0;
     const hasAgentStatus = selectedAgentStatuses.length > 0;
 
     // Fast path: no active client-side filters.
-    if (!hasQ && !hasStatus && !hasAgentStatus) return sites;
+    if (!hasStatus && !hasAgentStatus) return sites;
 
     return sites.filter((s) => {
-      // Text search — matches name, url, or any tag.
-      if (hasQ) {
-        const haystack = [s.name, s.url, ...(s.tags ?? [])]
-          .join(" ")
-          .toLowerCase();
-        if (!haystack.includes(q)) return false;
-      }
-
       // Status filter — OR within selected statuses.
       // We compare against the display label (same value stored in the URL).
       if (hasStatus) {
@@ -362,7 +409,7 @@ function SitesPage() {
 
       return true;
     });
-  }, [sites, search.q, selectedStatuses, selectedAgentStatuses, agentStatusById]);
+  }, [sites, selectedStatuses, selectedAgentStatuses, agentStatusById]);
 
   // INVARIANT: read from the FULL sites array, not visibleSites.
   const selectedSites: Site[] = (sites ?? []).filter((s) =>
@@ -448,6 +495,27 @@ function SitesPage() {
   // than `sites.length > 0`.
   const showFilterEmpty =
     !isPending && !isError && hasActiveFilters && visibleSites.length === 0;
+
+  // ── Page subline ──────────────────────────────────────────────────────────
+  //
+  // GH #349. Search is a server-side axis now, so `sites` is the set of
+  // MATCHES, not the tenant's roster: "3 sites enrolled" while searching for
+  // "acme" would be false. And once a tenant is past DEFAULT_SITES_LIMIT the
+  // count is a page size, not a total, so it must not be presented as one.
+  const sitesSubline = useMemo(() => {
+    if (isPending || isError || sites === undefined) return undefined;
+    if (sites.length >= DEFAULT_SITES_LIMIT) {
+      return hasActiveFilters
+        ? `Showing the first ${DEFAULT_SITES_LIMIT} matches`
+        : `Showing the first ${DEFAULT_SITES_LIMIT} sites`;
+    }
+    if (hasActiveFilters) {
+      const shown = visibleSites.length;
+      return `${shown} matching site${shown === 1 ? "" : "s"}`;
+    }
+    if (sites.length === 0) return undefined;
+    return `${sites.length} site${sites.length === 1 ? "" : "s"} enrolled`;
+  }, [isPending, isError, sites, hasActiveFilters, visibleSites.length]);
 
   // ── Auto-login ─────────────────────────────────────────────────────────────
 
@@ -755,13 +823,7 @@ function SitesPage() {
     <section aria-labelledby="sites-heading" className="space-y-4">
       <PageHeader
         title="Sites"
-        subline={
-          isPending
-            ? undefined
-            : sites !== undefined && sites.length > 0
-              ? `${sites.length} site${sites.length === 1 ? "" : "s"} enrolled`
-              : undefined
-        }
+        subline={sitesSubline}
         actions={operate ? <AddSiteDialog /> : undefined}
       />
 
@@ -886,6 +948,11 @@ function SitesPage() {
             }}
             activeFilterCount={activeFilterCount}
             onClearAllFilters={handleClearAllFilters}
+            // GH #349. The order axis is not counted in activeFilterCount and
+            // not reset by "Clear filters": an order is how the operator
+            // reads the list, not a narrowing of it.
+            sort={sort}
+            onSortChange={handleSortChange}
             view={view}
             onViewChange={setView}
             cardSize={cardSize}
@@ -946,11 +1013,14 @@ function SitesPage() {
 
           {showFilterEmpty ? (
             // The tag-specific empty state applies only when the (server-
-            // side) tags filter is the reason `sites` itself came back
-            // empty. If `sites` has rows but a client-side axis (search or
-            // status) narrowed them to zero, the generic FilterEmpty is the
-            // accurate message even when tags are also selected.
-            hasTagsFilter && (sites?.length ?? 0) === 0 ? (
+            // side) tags filter is the ONLY reason `sites` itself came back
+            // empty. GH #349: search is now a server-side axis too, so an
+            // empty `sites` no longer implies the tags did it: with a term
+            // typed, "No sites match these tags" would name the wrong
+            // culprit and offer the wrong fix ("Clear tag filters"). If a
+            // client-side axis (status, agent) narrowed a non-empty result to
+            // zero, the generic FilterEmpty is likewise the accurate message.
+            hasTagsFilter && !search.q?.trim() && (sites?.length ?? 0) === 0 ? (
               <TagsFilterEmpty tags={selectedTags} onClear={handleClearTagFilters} />
             ) : (
               <FilterEmpty

--- a/packages/openapi-client/src/generated/index.ts
+++ b/packages/openapi-client/src/generated/index.ts
@@ -1735,6 +1735,8 @@ export {
   type ListSitePolicyGroupsResponse,
   type ListSitePolicyGroupsResponses,
   type ListSitesData,
+  type ListSitesError,
+  type ListSitesErrors,
   type ListSiteSharesData,
   type ListSiteSharesError,
   type ListSiteSharesErrors,

--- a/packages/openapi-client/src/generated/sdk.gen.ts
+++ b/packages/openapi-client/src/generated/sdk.gen.ts
@@ -706,6 +706,7 @@ import type {
   ListSitePolicyGroupsErrors,
   ListSitePolicyGroupsResponses,
   ListSitesData,
+  ListSitesErrors,
   ListSiteSharesData,
   ListSiteSharesErrors,
   ListSiteSharesResponses,
@@ -2815,14 +2816,27 @@ export const getTenant = <ThrowOnError extends boolean = false>(
  * `?state=archived` for the archived chip), or `?include_archived=true` as
  * a convenience alias that returns only the archived sites.
  *
+ * GH #349: `q` (free-text search) and `sort` (ordering) are applied in the
+ * DATABASE, before `limit`/`offset`. That is the point of them: a client
+ * that fetches one page and filters it locally is searching only that
+ * page, so an agency with more sites than the page size gets "no results"
+ * for a site it owns. With `q` on the server, the rows returned are the
+ * best matches in the requested order rather than the newest page filtered
+ * afterwards.
+ *
+ * `q` and `sort` compose with every other parameter here (`tags`,
+ * `tags_match`, `state`, `include_archived`, `clientId`) rather than
+ * replacing any of them.
+ *
  */
 export const listSites = <ThrowOnError extends boolean = false>(
   options?: Options<ListSitesData, ThrowOnError>,
 ) =>
-  (options?.client ?? client).get<ListSitesResponses, unknown, ThrowOnError>({
-    url: "/api/v1/sites",
-    ...options,
-  });
+  (options?.client ?? client).get<
+    ListSitesResponses,
+    ListSitesErrors,
+    ThrowOnError
+  >({ url: "/api/v1/sites", ...options });
 
 /**
  * Create a site (site-first enrollment)

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -11210,6 +11210,46 @@ export type ListSitesData = {
     limit?: number;
     offset?: number;
     /**
+     * Free-text search (GH #349). Case-insensitive SUBSTRING match against
+     * the site name, the site url, or any of the site's tags (the same
+     * `tags` array this endpoint returns, so any tag an operator can see
+     * on a site is a tag they can find that site by).
+     *
+     * Matched literally, not as a pattern: `%` and `_` are ordinary
+     * characters. An empty or whitespace-only value behaves exactly as if
+     * the parameter were absent. No match returns an empty `items` array,
+     * not an error.
+     *
+     */
+    q?: string;
+    /**
+     * Ordering (GH #349). A leading `-` means DESCENDING. When omitted the
+     * order is `-created_at`, which is the ordering this endpoint has
+     * always had.
+     *
+     * Every ordering is total and stable: it is tiebroken on the site id,
+     * so two sites that share a name (or a created_at) keep a fixed
+     * relative position and `limit`/`offset` paging cannot drop or repeat
+     * a row.
+     *
+     * `name` sorts case-insensitively. For `last_seen`, a site that has
+     * never checked in (null last_seen) sorts LAST in BOTH directions: it
+     * stays in the result, and it never occupies the top of a "most
+     * recently seen" list.
+     *
+     * An unrecognised value is a 422. It is never silently ignored,
+     * because a dropped sort would show the operator a list ordered
+     * differently from the control they just set.
+     *
+     */
+    sort?:
+      | "name"
+      | "-name"
+      | "created_at"
+      | "-created_at"
+      | "last_seen"
+      | "-last_seen";
+    /**
      * Deprecated alias for `tags` with a single value (any-match semantics). Prefer `tags`.
      *
      * @deprecated
@@ -11245,6 +11285,17 @@ export type ListSitesData = {
   };
   url: "/api/v1/sites";
 };
+
+export type ListSitesErrors = {
+  /**
+   * Validation failed. Returned when `sort` is not one of the accepted
+   * values (code `invalid_sort`).
+   *
+   */
+  422: Error;
+};
+
+export type ListSitesError = ListSitesErrors[keyof ListSitesErrors];
 
 export type ListSitesResponses = {
   /**

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.125
+  version: 0.61.126
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,
@@ -3439,10 +3439,62 @@ paths:
         Pass `?state=<connection_state>` to filter to exactly one state (e.g.
         `?state=archived` for the archived chip), or `?include_archived=true` as
         a convenience alias that returns only the archived sites.
+
+        GH #349: `q` (free-text search) and `sort` (ordering) are applied in the
+        DATABASE, before `limit`/`offset`. That is the point of them: a client
+        that fetches one page and filters it locally is searching only that
+        page, so an agency with more sites than the page size gets "no results"
+        for a site it owns. With `q` on the server, the rows returned are the
+        best matches in the requested order rather than the newest page filtered
+        afterwards.
+
+        `q` and `sort` compose with every other parameter here (`tags`,
+        `tags_match`, `state`, `include_archived`, `clientId`) rather than
+        replacing any of them.
       tags: [sites]
       parameters:
         - $ref: "#/components/parameters/Limit"
         - $ref: "#/components/parameters/Offset"
+        - name: q
+          in: query
+          required: false
+          description: |
+            Free-text search (GH #349). Case-insensitive SUBSTRING match against
+            the site name, the site url, or any of the site's tags (the same
+            `tags` array this endpoint returns, so any tag an operator can see
+            on a site is a tag they can find that site by).
+
+            Matched literally, not as a pattern: `%` and `_` are ordinary
+            characters. An empty or whitespace-only value behaves exactly as if
+            the parameter were absent. No match returns an empty `items` array,
+            not an error.
+          schema:
+            type: string
+        - name: sort
+          in: query
+          required: false
+          description: |
+            Ordering (GH #349). A leading `-` means DESCENDING. When omitted the
+            order is `-created_at`, which is the ordering this endpoint has
+            always had.
+
+            Every ordering is total and stable: it is tiebroken on the site id,
+            so two sites that share a name (or a created_at) keep a fixed
+            relative position and `limit`/`offset` paging cannot drop or repeat
+            a row.
+
+            `name` sorts case-insensitively. For `last_seen`, a site that has
+            never checked in (null last_seen) sorts LAST in BOTH directions: it
+            stays in the result, and it never occupies the top of a "most
+            recently seen" list.
+
+            An unrecognised value is a 422. It is never silently ignored,
+            because a dropped sort would show the operator a list ordered
+            differently from the control they just set.
+          schema:
+            type: string
+            enum: [name, -name, created_at, -created_at, last_seen, -last_seen]
+            default: -created_at
         - name: tag
           in: query
           required: false
@@ -3494,6 +3546,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SiteList"
+        "422":
+          description: |
+            Validation failed. Returned when `sort` is not one of the accepted
+            values (code `invalid_sort`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /api/v1/sites/pairing-codes:
     post:
       operationId: createPairingCode


### PR DESCRIPTION
Closes #349. An agency with 24 enrolled sites reported that Cmd-K found nothing and the Sites list could not be ordered.

## What was actually wrong

**Cmd-K rendered `recentSites`** — a localStorage list of sites you have *previously visited*. It already loaded `useSites()` but used it only for "Run backup on all sites". So it could only find a site you had already opened, and `No matches` for `iacop` was correct behaviour for the wrong design.

**There was no sort axis at all.** The URL schema carried `q`, `status`, `tags`, `tagMode`, `client`, `archived`, `view`, `agentStatus`, and nothing for ordering.

**One correction to the report:** the list search was *not* broken. It matched name, URL and tags over the loaded rows. The Cmd-K badge on that input is only a hint that Cmd-K exists, not a second broken control.

## The bug nobody reported, which is the real one

`useSites()` called `listSites({})` with no limit. The server defaults to **50**, ordered `created_at DESC`. Above 50 sites the browser filter searched only the **50 newest** and silently missed the rest.

At 24 sites it had not bitten yet.

**The fix is not a bigger number.** `q` and `sort` move to the server, which makes the cap honest: the rows you receive are the best matches in the requested order, instead of the newest 50 filtered afterwards in a browser. A client-side filter over a server-truncated page is wrong at any limit, and it is the same defect class as #336.

## The contract

```
q      case-insensitive match on name, url, or any tag
sort   name | -name | created_at | -created_at | last_seen | -last_seen
```

Absent `sort` behaves exactly as before. An unrecognised value is **422, never a silent fallback** — a list ordered differently from the control claiming to order it is worse than an error.

`ORDER BY` is **bound as a parameter** and folded by Postgres into one sort key. No SQL text is concatenated and the accept-set is closed in Go.

Every order carries a **deterministic tiebreak on id**, because sites can share a name *and* a `created_at`, and without it pagination drops and duplicates rows.

Sites that have never checked in sort **last in both directions**, so they never head a "most recently seen" list and never vanish from one.

## Found while building

**A real 500.** `?q=%00` sent a NUL byte to the driver and killed the statement (`SQLSTATE 22021`). No Postgres text value can contain a NUL, so such a search matches nothing by definition; it now returns an empty list without querying.

The API lane also caught **its own worthless test**: the pagination case used `q=e`, which matched all four fixtures, so the filter was never exercised and it passed with the feature disabled. Rewritten to a strict 3-of-4 subset, and it now fails pre-change.

## Measured, not assumed

At 300 sites in one tenant, after `ANALYZE`, as the non-superuser role with RLS live:

```
Index Scan using sites_tenant_id_idx      0.31 - 0.53 ms across all variants
```

`q` filters rows already bounded to one tenant. **No index is warranted** — a trigram GIN would cost write amplification on every metadata push to speed up a filter that scans a few dozen rows.

## Two behaviour changes, both deliberate

The old browser filter joined `name + url + tags` into **one string**, so a query could match *across the seam* between fields. Matching is now per field, so `"acme https"` no longer matches a site named acme at an https URL.

The list requests **200** rather than the implicit 50. Twelve other `useSites()` callers were silently 50-capped, including "Run backup on all sites", the sidebar count, and the fleet pickers. Past 200 the cap remains but is honest, and the subline now says `Showing the first 200 matches` instead of implying a total.

## Gates

```
go build / vet / ./internal/... / ./tests/contract/...   clean, 0 failures
web  122 files, 1502 tests pass   (1473 baseline + 29)
eslint 0 errors (3 pre-existing warnings)    tsc 0
lockstep 0.61.126    dashes 0
```

**28 of 29 new web tests and 6 of 7 new API integration tests fail against pre-change code.** The ones that pass either way are named as regression guards, not counted as evidence.

Both lanes verified to use an identical six-value sort vocabulary, checked in the diff rather than assumed.

## Known, not fixed

The list view's own **column-header sort is still local** and can disagree with the toolbar order, which now decides which 200 rows arrive. Documented at the control. Grid view has no column sort, so the toolbar is the only ordering there. Worth a follow-up decision rather than a silent reconciliation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization-wide site search across names, URLs, and tags.
  * Added site ordering by name, date added, or last check-in, with stable pagination and never-checked-in sites shown last.
  * Added search and sorting controls to the Sites page and command palette.
  * Added `q` and `sort` parameters to the sites API.

* **Bug Fixes**
  * Fixed search results being limited to only the newest 50 sites.
  * Preserved existing filters and consistent default ordering.

* **Documentation**
  * Updated API documentation and release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->