### PR TITLE
fix(marketing): take the repo-wide copy gate out of the image build

### DIFF
--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "node scripts/sync-openapi.mjs && node scripts/check-copy.mjs && next build",
+    "build": "node scripts/sync-openapi.mjs && next build",
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",

--- a/apps/marketing/scripts/check-copy.mjs
+++ b/apps/marketing/scripts/check-copy.mjs
@@ -25,9 +25,19 @@
 // log strings. Those are machine-to-machine and are not part of the shipped
 // listing or of any screen a site owner reads.
 //
-// Run at build time via the "check-copy" and "build" scripts in package.json,
-// and in ci.yml (Security audit job) so a PR that never builds the marketing
-// site still cannot land a violation.
+// WHERE THIS RUNS, and one place it deliberately does NOT.
+//
+// It runs in ci.yml (Security audit job) against a full repo checkout, and on
+// demand via the "check-copy" script in package.json. It is NOT part of the
+// marketing "build" script, and must not be added back to it. Scope (2) reads
+// apps/agent, while Dockerfile.marketing copies only apps/marketing, packages
+// and the root manifests, so inside the production image build those files are
+// absent and the gate fails on every one of them. That is the correct answer
+// to the question it was asked, which is exactly why the question is wrong
+// there: a repo-wide copy lint is not a step in one app's image build.
+//
+// CI is also the stronger placement. It sees all 366 files; the Docker build
+// could never see the agent at all.
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";


### PR DESCRIPTION
The marketing production image stopped building the moment #355 landed. Caught on the first deploy after the merge, not by CI.

## What broke

`check-copy.mjs` grew a second scope in that PR: `apps/agent`, because `readme.txt` **is** the WordPress.org listing page and the plugin header is what WordPress prints in the Plugins list, and neither had any gate on it.

But the script also ran inside the marketing `build` script, and `Dockerfile.marketing` copies only `apps/marketing`, `packages` and the root manifests. Inside the image build `apps/agent` does not exist:

```
/repo/apps/agent/readme.txt:0        missing: the wordpress.org listing copy must exist
/repo/apps/agent/wpmgr-agent.php:0   missing: the agent plugin entry file must exist
check-copy FAILED with 2 issue(s)
[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] @wpmgr/marketing@0.1.0 build
```

That is the **correct** answer to the question it was asked, which is exactly what makes asking it there wrong: a repo-wide copy lint is not a step in one app's production image build.

## Fix

Removed from `build`. It already runs in `ci.yml` against a full checkout, which is the stronger placement anyway: **CI sees all 366 files; the Docker build could never see the agent at all.** The standalone `check-copy` script is unchanged for local use.

Added a note at the top of the script recording why it must not go back, since this failure surfaces only on a deploy and never in CI, which is the worst place to learn it.

## Why CI did not catch it

`ci.yml` never invokes `pnpm -C apps/marketing build`. That is the same blind spot #355 set out to fix from the other side, and it bit in the opposite direction on the way out: the copy rule had no gate, and the thing I added to gate it had no gate of its own.

Worth noting plainly: the gate itself is not at fault and its output was accurate. The defect is placement.

## Verified by building, not by reasoning

The same Cloud Build config that failed now succeeds:

```
marketing:0.61.127  DONE  1M30S
sha256:318143a1e33041cc3343690ac8b999b8801c085664771508a4719244b6a6b846
```

`check-copy` still passes standalone across 366 files (114 marketing, 1 agent readme, 1 plugin header, 250 agent PHP of which 9 carry copy).