### PR TITLE
docs: record the WordPress.org listing and add the Composer install path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1664,7 +1664,7 @@ Requires agent 0.41.1 for the on-site fixes; the dashboard fixes apply on the AP
 ## [0.31.2] - 2026-06-09
 
 ### Added
-- WordPress.org distribution build ("Fleet Agent for WPMgr") that passes the official Plugin Check with zero errors. A build-time variant excludes the control-plane self-updater from the WordPress.org package, since those builds update through WordPress.org; the self-hosted and SaaS builds keep control-plane self-update.
+- WordPress.org distribution build ("Fleet Agent Site Manager") that passes the official Plugin Check with zero errors. A build-time variant excludes the control-plane self-updater from the WordPress.org package, since those builds update through WordPress.org; the self-hosted and SaaS builds keep control-plane self-update.
 - Public Terms of Service and Privacy Policy pages on the control plane (manage.wpmgr.app/terms and /privacy), linked as the external-service disclosure from the agent readme.
 
 ### Changed

--- a/PLAN.md
+++ b/PLAN.md
@@ -16,11 +16,10 @@ The original Phase 0-6 plan is complete and in production:
 - **Security suite** — hardening + login bans, file integrity, site-user 2FA + password policy, vulnerability scanner (Wordfence Intelligence feed), File Manager (jailed, audited, off by default).
 - **Agency** — white-label client reports, branded client portal, client invites.
 - **Email** — instance SMTP, alert/digest cadences, fleet deliverability dashboard.
-- **Distribution** — OSS releases (GHCR images + agent zip), marketing site (wpmgr.app), WordPress.org agent submission (in review).
+- **Distribution** — OSS releases (GHCR images + agent zip), marketing site (wpmgr.app), WordPress.org plugin directory listing (`fleet-agent-site-manager`, live since 2026-08-06).
 
 ## In flight
 
-- [ ] **WordPress.org listing** — agent submitted as "Fleet Agent Site Manager"; passed the automated scans' real finding (2FA resume binding, fixed 0.61.9); awaiting human review. Crux item: autologin (established management-plugin precedent). Fallback if rejected: strip autologin + file-write from the wp.org build only.
 - [ ] **Patchstack decision** — research complete (docs/security/ internal). Recommended: Phase 0 provider abstraction + Phase 1a BYO App-API-key co-existence; paid feed/vPatch only via a for-Hosts contract. Awaiting go/no-go.
 
 ## Next up (priority order)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 [![Latest release](https://img.shields.io/github/v/release/mosamlife/wpmgr?label=release&style=flat)](https://github.com/mosamlife/wpmgr/releases)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat)](./LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/mosamlife/wpmgr/ci.yml?branch=main&label=CI&style=flat)](https://github.com/mosamlife/wpmgr/actions/workflows/ci.yml)
+[![WordPress.org](https://img.shields.io/wordpress/plugin/v/fleet-agent-site-manager?label=wordpress.org&style=flat)](https://wordpress.org/plugins/fleet-agent-site-manager/)
 
 [![WPMgr: run your whole WordPress fleet from one dashboard you own](docs/images/landing.png)](https://wpmgr.app)
 
@@ -16,7 +17,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
   <a href="https://wpmgr.app/docs/">API reference</a>
 </p>
 
-**v0.61.127**: open-source and production-usable for self-hosters.
+**v0.61.127**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 
 ---
 
@@ -46,7 +47,7 @@ The script downloads every file the stack needs, generates all secrets, and prin
 - **Re-enrollment under a stable identity**: Re-connecting a site keeps the same `site_id`, preserving all backup history, scan runs, and lifecycle generations.
 - **Archive / restore soft-delete**: Retire sites from the active view without losing their history; restore them later.
 - **Per-site sharing**: Share exactly one site with a collaborator, enforced by both Gin middleware and Postgres RESTRICTIVE RLS, without exposing the rest of the fleet.
-- **Agent self-update channel**: Self-hosted control planes push signed agent releases to enrolled sites. The WordPress.org distribution ("Fleet Agent for WPMgr") is pending directory review; that build strips the self-updater and declares GPLv2.
+- **Agent self-update channel**: Self-hosted control planes push signed agent releases to enrolled sites. The [WordPress.org build](https://wordpress.org/plugins/fleet-agent-site-manager/) ships without the self-updater and updates from the site's own Plugins screen instead.
 
 ### Backups & restore
 
@@ -248,7 +249,7 @@ The script downloads every file the stack needs, generates all secrets, and prin
 ```text
 apps/api    Go 1.26 + Gin control plane (modular monolith)
 apps/web    React 19 + TypeScript + Vite + TanStack dashboard
-apps/agent  PHP 8.1+ WordPress agent plugin (MIT)
+apps/agent  PHP 8.1+ WordPress agent plugin (MIT; GPLv2+ on the wp.org build)
 ```
 
 **Data:** Postgres (primary + RLS) · Redis (sessions, cache, dedup) · S3-compatible object storage (backups, media) · on-disk page cache (`wp-content/cache/wpmgr`, pre-gzipped `.html.gz`) · ClickHouse (optional, uptime + RUM time-series)
@@ -333,13 +334,47 @@ Full install guide, env reference, and production hardening: [docs/install.md](.
 
 ## Install the Agent
 
-1. Download `wpmgr-agent.zip` from the [GitHub Releases page](https://github.com/mosamlife/wpmgr/releases).
-2. In WordPress: **Plugins → Add New → Upload Plugin** → choose the zip → **Install Now → Activate**.
-3. Open the top-level **WPMgr** admin menu, set the **Control-plane URL** field and click **Save URL**, then paste the dashboard's **Pairing code** into the **Enroll** form and click **Enroll**.
+**From the WordPress admin (recommended).** **Plugins → Add New** → search for **Fleet Agent Site Manager** → **Install Now → Activate**. That is the plugin's listing name in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 
-The agent requires PHP 8.1+ and WordPress 6.0+. It self-updates through the control plane's signed update channel.
+**From GitHub.** Download `wpmgr-agent.zip` from the [Releases page](https://github.com/mosamlife/wpmgr/releases), then **Plugins → Add New → Upload Plugin** → choose the zip → **Install Now → Activate**.
 
-See [docs/agent.md](./docs/agent.md) for WP-CLI install and configuration options.
+**With Composer.** The directory listing is mirrored by both Composer repositories that serve WordPress.org, so pick whichever your project already declares:
+
+| Your project declares | Require this |
+| --- | --- |
+| `https://wpackagist.org` | `wpackagist-plugin/fleet-agent-site-manager` |
+| `https://repo.wp-packages.org` (current Bedrock) | `wp-plugin/fleet-agent-site-manager` |
+
+Bedrock already configures its repository and its installer paths, so add only the `require` entry. For a plain Composer-managed WordPress:
+
+```json
+{
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://wpackagist.org",
+      "only": ["wpackagist-plugin/*", "wpackagist-theme/*"]
+    }
+  ],
+  "require": {
+    "composer/installers": "^2.0",
+    "wpackagist-plugin/fleet-agent-site-manager": "*"
+  },
+  "extra": {
+    "installer-paths": {
+      "wp-content/plugins/{$name}/": ["type:wordpress-plugin"]
+    }
+  }
+}
+```
+
+Do not paste that `extra` block into a Bedrock project: `installer-paths` is a single key, so it replaces rather than merges, and Bedrock installs to `web/app/plugins/` instead. Use `*` rather than `^0.61`, because a caret on a 0.x version pins the minor and would leave you on 0.61.x forever once 0.62 is tagged.
+
+Then, whichever path you used: open the plugin's top-level admin menu (**WPMgr Agent** on the GitHub build, **Fleet Agent Site Manager** on the directory build), set the **Control-plane URL** field and click **Save URL**, then paste the dashboard's **Pairing code** into the **Enroll** form and click **Enroll**.
+
+The two builds are the same code; the difference that matters is how they update. The GitHub build self-updates through your control plane's signed update channel. The directory build ships without the self-updater and updates from the site's own Plugins screen, or through `composer update` on a Composer-managed site.
+
+The agent requires PHP 8.1+ and WordPress 6.2+. See [docs/agent.md](./docs/agent.md) for WP-CLI install and configuration options.
 
 ---
 
@@ -404,7 +439,7 @@ See [docs/contributing.md](./docs/contributing.md) for the full dev setup, PR ch
 | Component | License |
 |---|---|
 | Control plane + dashboard (`apps/api`, `apps/web`) | [AGPL-3.0-only](./LICENSE) |
-| WordPress agent plugin (`apps/agent`) | [MIT](./LICENSE-AGENT) |
+| WordPress agent plugin (`apps/agent`) | [MIT](./LICENSE-AGENT) (the WordPress.org build declares GPLv2 or later) |
 
 ---
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -324,7 +324,7 @@ above) and consider a shorter refresh interval.
 
 ```bash
 make agent-zip
-# → release/wpmgr-agent.zip (excludes vendor/, tests/, *.dist)
+# → release/wpmgr-agent.zip (excludes tests/, tools/, *.dist; vendor/ is bundled)
 ```
 
 Develop and test the plugin locally:

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -5,7 +5,7 @@ These are the system requirements for running the WPMgr control plane
 are architecture-derived estimates, not load-tested benchmarks; see
 [Caveats](#caveats) before you provision hardware. They do not cover the
 managed WordPress hosts themselves: the agent plugin only needs PHP 8.1+ and
-WordPress 6.0+, see [agent.md](./agent.md).
+WordPress 6.2+, see [agent.md](./agent.md).
 
 ## Host prerequisites
 


### PR DESCRIPTION
Closes #351.

The plugin went live on the WordPress.org directory today (`fleet-agent-site-manager`, 0.61.127). The README said two things that were already false before that, and are now conspicuously so.

It called the directory build **"Fleet Agent for WPMgr"**, a name that has never existed on wp.org or anywhere else, and it said the distribution was **"pending directory review"**. The wrong name originated in `CHANGELOG.md:1667` and is corrected there too, rather than left as the only surviving copy.

## What a visitor now learns

A version badge in the existing badge row, one clause in the intro line, and a rewritten install section offering three paths.

The naming situation is handled by **using** the names where a reader needs them (the term they type into plugin search, the menu label they look for afterwards) rather than by explaining the naming anywhere. An earlier draft had an "About the name" passage; it read as a rebrand apology. Passing a human review is the story, not the name.

Deliberately **not** claimed: "audited", "vetted", or "endorsed by WordPress". "Reviewed and listed" is what the facts support, and overclaiming here is a bigger credibility risk than the name ever was.

## Composer, and the part that was nearly wrong

#351 asked for wpackagist. The first draft told Bedrock users they already had the repository and installer paths configured and needed only the `require` line.

Verified against `roots/bedrock` master: **false, and it fails hard.** Current Bedrock declares exactly one repository, `repo.wp-packages.org`, which does not serve the `wpackagist-plugin` vendor at all:

```
repo.wp-packages.org/p2/wpackagist-plugin/akismet.json          -> 404
repo.wp-packages.org/p2/wp-plugin/fleet-agent-site-manager.json -> 200
```

That advice would have produced "could not find a matching package". The plugin is on that mirror under a different prefix, `wp-plugin/fleet-agent-site-manager`, serving 0.61.127 with `dist` pointing at the wp.org zip and `source` at `tags/0.61.127`. Both mirrors are now documented as a two row table.

Worse, the JSON block was captioned as Bedrock-suitable while setting `installer-paths` to `wp-content/plugins/`. `installer-paths` is a **single key**, so pasting it into a Bedrock root `composer.json` replaces rather than merges and relocates every plugin and theme away from `web/app/`. Now explicitly warned against.

Both mirrors were confirmed live before writing any of this:

| Repository | Package | Versions |
| --- | --- | --- |
| `wpackagist.org` | `wpackagist-plugin/fleet-agent-site-manager` | `0.61.127`, `dev-trunk` |
| `repo.wp-packages.org` | `wp-plugin/fleet-agent-site-manager` | `0.61.127` |

wpackagist's own page records `last-committed Aug 6 05:38`, `last-fetched Aug 6 06:08`: it indexed itself 30 minutes after the SVN commit, with no action from us.

## Three things found while verifying the above

Each is reachable in two clicks from a line this PR already touches, so leaving them would have meant a visitor comparing two of our own pages and finding them disagreeing.

| Where | Was | Reality |
| --- | --- | --- |
| `docs/requirements.md` | WordPress 6.0+ | `readme.txt`, the plugin header and the wp.org API all say **6.2**. README said 6.0+ too, and links to requirements.md two screens above it. |
| `docs/agent.md` | `make agent-zip` "excludes vendor/" | The rsync at `Makefile:150-154` excludes `tests/`, `tools/`, `*.dist` and **not** `vendor/`. The target's own comment reads "with ifsnop vendor/". The shipped zip bundles it. |
| README license rows (x2) | MIT for `apps/agent` | The directory build declares **GPLv2 or later**. Both are true of different artifacts; both rows now say so. |

`PLAN.md`'s in-flight WordPress.org entry is retired into the shipped Distribution line, and its dead "fallback if rejected: strip autologin + file-write" contingency is dropped. Autologin survived review intact.

## Gates

```
check-copy   passes across 366 files
README.md    0 em dashes, 0 en dashes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation guidance for WordPress.org, GitHub, and Composer, including Bedrock setups.
  * Clarified plugin names, update behavior, licensing, and the WordPress.org directory listing.
  * Documented included release contents and updated the minimum supported WordPress version to 6.2+.
  * Renamed the WordPress.org distribution to “Fleet Agent Site Manager.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->