### PR TITLE
feat(marketing): surface the WordPress.org listing, and fix a stale version claim

### DIFF
--- a/apps/marketing/app/product-hunt/page.tsx
+++ b/apps/marketing/app/product-hunt/page.tsx
@@ -64,6 +64,11 @@ const OPEN_SOURCE_POINTS = [
     title: "Ed25519-signed agent releases",
     desc: "Every agent release is cryptographically signed. The control plane verifies the signature before trusting any agent payload.",
   },
+  {
+    icon: "BadgeCheck",
+    title: "Reviewed and listed on WordPress.org",
+    desc: "The agent passed the WordPress.org plugin review and is published in the official directory as Fleet Agent Site Manager, so you can install it from your own wp-admin.",
+  },
 ] as const;
 
 // Product Hunt landing. noindex per spec (PH thank-you variant).

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -17,7 +17,7 @@ export const HOME_HERO = {
   trust: [
     { icon: "GitFork", title: "Fork and contribute", desc: "AGPL control plane, MIT agent, PRs welcome" },
     { icon: "ServerCog", title: "Your infrastructure", desc: "Fleet data never leaves your server" },
-    { icon: "FileSearch", title: "Auditable agent", desc: "Read every line before you run it" },
+    { icon: "BadgeCheck", title: "On WordPress.org", desc: "Reviewed and listed in the plugin directory" },
   ],
   ctas: [
     { label: "Get started for free", href: SITE_CONFIG.signup, variant: "primary" as const, icon: "ArrowRight" },
@@ -433,7 +433,7 @@ export const HOME_ENROLL = {
   heading: "From zero to managed in under a minute",
   subhead:
     "No SSH, no FTP, no shared admin passwords. Three steps and the site is live on your dashboard.",
-  body: "The agent is a lightweight PHP plugin that needs only PHP 8.1+ and WordPress 6.0+. Backups use a pure-PHP streaming dump and archiver, so they work even on managed hosts that lock down shell access and the mysqldump binary.",
+  body: "The agent is a lightweight PHP plugin that needs only PHP 8.1+ and WordPress 6.2+. It is listed in the WordPress.org plugin directory as Fleet Agent Site Manager, so you can install it from your own wp-admin. Backups use a pure-PHP streaming dump and archiver, so they work even on managed hosts that lock down shell access and the mysqldump binary.",
   steps: [
     {
       n: "1",
@@ -445,7 +445,7 @@ export const HOME_ENROLL = {
       n: "2",
       icon: "KeyRound",
       title: "Push the one-time code",
-      desc: "Install the MIT-licensed agent plugin and paste the one-time code. The agent registers its signing key and the site flips from Awaiting to Connected with no page refresh.",
+      desc: "Search your Plugins screen for Fleet Agent Site Manager, install it, and paste the one-time code. The agent registers its signing key and the site flips from Awaiting to Connected with no page refresh.",
     },
     {
       n: "3",
@@ -472,7 +472,15 @@ export const HOME_FAQ: FaqItem[] = [
   },
   {
     q: "Does it work on managed or locked-down WordPress hosts?",
-    a: "Yes. The agent is a lightweight PHP plugin that needs PHP 8.1+ and WordPress 6.0+, nothing more. Backups use a pure-PHP streaming dump and archiver with no shell access and no mysqldump binary, so they work even on hosts that lock those down.",
+    a: "Yes. The agent is a lightweight PHP plugin that needs PHP 8.1+ and WordPress 6.2+, nothing more. Backups use a pure-PHP streaming dump and archiver with no shell access and no mysqldump binary, so they work even on hosts that lock those down.",
+  },
+  {
+    q: "Why is the plugin called Fleet Agent Site Manager on WordPress.org?",
+    a: "That is its listing name in the WordPress.org plugin directory, where it was reviewed and published. The project is WPMgr and the plugin is the WPMgr Agent, which is the name you will see in wp-admin once it is installed from a self-hosted build. Search the plugin directory for Fleet Agent Site Manager and you have the right one.",
+  },
+  {
+    q: "Can I install the agent with Composer?",
+    a: "Yes. The directory listing is mirrored by both Composer repositories that serve WordPress.org, so require wpackagist-plugin/fleet-agent-site-manager if your project points at wpackagist.org, or wp-plugin/fleet-agent-site-manager if it points at repo.wp-packages.org, which is what current Bedrock ships. Composer installs the directory build, which updates through composer update rather than writing to your plugins folder on its own.",
   },
   {
     q: "Is my data private?",


### PR DESCRIPTION
The plugin went live in the WordPress.org directory today and `wpmgr.app` said nothing about it. That is the strongest third-party credibility signal the project has, and the Product Hunt launch will send people to this site.

## Hero trust chip: a swap, not an addition

Replaces **"Auditable agent / Read every line before you run it"** with **"On WordPress.org / Reviewed and listed in the plugin directory"**.

The chip it replaces was already redundant. The hero subhead says "built from code you can read and improve" and `bodyLines` says "nothing happens to your sites you cannot verify", so read-the-source was stated twice above the fold before this change. A review that **someone else** performed is a claim a visitor cannot make for themselves, which is what earns it one of only three slots.

It is a swap because the grid is hardcoded `sm:grid-cols-3` (`components/sections/hero.tsx:82`). A fourth chip would orphan a row on desktop.

## Getting started

Step 2 said "install the MIT-licensed agent plugin" without saying where from. It now names the search term, because searching the Plugins screen for **Fleet Agent Site Manager** is the actual shortest path, and the licence was doing no work inside an instruction.

## Two new FAQ entries

Both answer questions the listing itself now creates:

- **Why the directory name differs from the project name.** Answered by using the names rather than justifying them.
- **Whether Composer works.** This one names both mirrors, because they do not serve each other's packages:

| Repository | Package |
| --- | --- |
| `wpackagist.org` | `wpackagist-plugin/fleet-agent-site-manager` |
| `repo.wp-packages.org` (current Bedrock) | `wp-plugin/fleet-agent-site-manager` |

Both verified live before writing the copy. Requiring the wrong prefix produces "could not find a matching package", which is exactly the kind of thing a FAQ should stop.

## A stale claim that was wrong before today

Three places said the agent needs **WordPress 6.0+**. `readme.txt`, the plugin header and the wp.org API all say **6.2**. Same error as `README.md` and `docs/requirements.md` (corrected in e7154fb); this was the third copy and the only **public** one.

## Product Hunt page

Adds a fourth open-source point for the directory listing. That section renders as a vertical `flex-col` (`app/product-hunt/page.tsx:187`), so unlike the hero there is no layout cost to a fourth item.

## Verified against the rendered build, not the source

```
.next/server/app/index.html         "On WordPress.org"                      3
                                    "Reviewed and listed in the directory"  2
                                    "Fleet Agent Site Manager"              9
                                    "WordPress 6.2+"                        3
                                    "WordPress 6.0"                         0
.next/server/app/product-hunt.html  "Reviewed and listed on WordPress.org"  present

check-copy   366 files, pass
typecheck    clean
lint         clean
next build   clean
```

Worth noting: `ci.yml` does not build the marketing app, so none of the above would have been caught by CI. That is the gap #356 documented, which is why this was built locally before opening the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Highlighted the agent’s publication in the official WordPress.org plugin directory as Fleet Agent Site Manager.
  * Added instructions for installing the plugin from WordPress admin and via Composer.
  * Updated supported WordPress versions; WordPress 6.2 or later is now required.
  * Added an “On WordPress.org” trust highlight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->