### PR TITLE
feat(marketing): add a Provenance section for the directory listing and the repo

### DIFF
--- a/apps/marketing/app/page.tsx
+++ b/apps/marketing/app/page.tsx
@@ -5,6 +5,7 @@ import { FeatureGrid } from "@/components/sections/feature-grid";
 import { MediaShowcase } from "@/components/sections/media-showcase";
 import { Steps } from "@/components/sections/steps";
 import { ProofStrip } from "@/components/sections/proof-strip";
+import { Provenance } from "@/components/sections/provenance";
 import { FAQ } from "@/components/sections/faq";
 import { CTABand } from "@/components/sections/cta-band";
 import { SiteHeader } from "@/components/sections/header";
@@ -23,6 +24,7 @@ import {
   HOME_MEDIA,
   HOME_MEDIA_STEPS,
   HOME_STATS,
+  HOME_PROVENANCE,
   HOME_ENROLL,
   HOME_FAQ,
   HOME_FINAL_CTA,
@@ -94,7 +96,18 @@ export default function HomePage() {
           clusters={HOME_FEATURES.clusters}
         />
 
-        {/* 7. Enroll steps */}
+        {/* 7. Provenance: the WordPress.org listing and the public repository */}
+        <Provenance
+          eyebrow={HOME_PROVENANCE.eyebrow}
+          heading={HOME_PROVENANCE.heading}
+          subhead={HOME_PROVENANCE.subhead}
+          directory={HOME_PROVENANCE.directory}
+          facts={HOME_PROVENANCE.facts}
+          repository={HOME_PROVENANCE.repository}
+          checks={HOME_PROVENANCE.checks}
+        />
+
+        {/* 8. Enroll steps */}
         <Steps
           id="enroll"
           eyebrow={HOME_ENROLL.eyebrow}
@@ -105,7 +118,7 @@ export default function HomePage() {
           tone="muted"
         />
 
-        {/* 8. FAQ */}
+        {/* 9. FAQ */}
         <FAQ
           eyebrow="FAQ"
           heading="Questions, answered straight"
@@ -113,7 +126,7 @@ export default function HomePage() {
           items={HOME_FAQ}
         />
 
-        {/* 9. Final CTA band */}
+        {/* 10. Final CTA band */}
         <CTABand
           heading={HOME_FINAL_CTA.heading}
           subhead={HOME_FINAL_CTA.subhead}

--- a/apps/marketing/components/sections/hero.tsx
+++ b/apps/marketing/components/sections/hero.tsx
@@ -4,7 +4,7 @@ import { Badge, Container } from "@/components/ui/primitives";
 import { cn } from "@/lib/utils";
 import type { Cta } from "@/lib/content/types";
 
-type HeroTrust = { icon: string; title: string; desc: string };
+type HeroTrust = { icon: string; title: string; desc: string; href?: string };
 
 type HeroProps = {
   badge?: string;
@@ -80,20 +80,49 @@ export function Hero({ badge, heading, subhead, ctas, trust }: HeroProps) {
         {/* Trust chips */}
         {trust && trust.length > 0 && (
           <div className="mt-14 grid gap-4 sm:grid-cols-3 mx-auto max-w-3xl">
-            {trust.map((t) => (
-              <div
-                key={t.title}
-                className="flex items-start gap-3 rounded-xl border border-[var(--border)] bg-card p-4"
-              >
-                <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[var(--primary-subtle)] text-[var(--primary-pressed)]">
-                  <Icon name={t.icon} size={16} />
-                </span>
-                <div className="flex flex-col gap-0.5">
-                  <span className="text-sm font-semibold text-foreground">{t.title}</span>
-                  <span className="text-xs text-[var(--muted-foreground)] leading-relaxed">{t.desc}</span>
+            {trust.map((t) => {
+              const chipClass = "flex items-start gap-3 rounded-xl border border-[var(--border)] bg-card p-4";
+              const inner = (
+                <>
+                  <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[var(--primary-subtle)] text-[var(--primary-pressed)]">
+                    <Icon name={t.icon} size={16} />
+                  </span>
+                  <div className="flex flex-col gap-0.5">
+                    <span className="inline-flex items-center gap-1.5 text-sm font-semibold text-foreground">
+                      {t.title}
+                      {/* Persistent affordance. Hover does not exist on touch, and the
+                          two neighbouring chips are inert, so without this the linked
+                          chip is indistinguishable from them on a phone. */}
+                      {t.href && (
+                        <Icon
+                          name="ArrowRight"
+                          size={12}
+                          className="text-[var(--muted-foreground)]"
+                          aria-hidden
+                        />
+                      )}
+                    </span>
+                    <span className="text-xs text-[var(--muted-foreground)] leading-relaxed">{t.desc}</span>
+                  </div>
+                </>
+              );
+              return t.href ? (
+                <a
+                  key={t.title}
+                  href={t.href}
+                  className={cn(
+                    chipClass,
+                    "transition-colors duration-[var(--duration-fast)] hover:bg-[var(--accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]",
+                  )}
+                >
+                  {inner}
+                </a>
+              ) : (
+                <div key={t.title} className={chipClass}>
+                  {inner}
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </Container>

--- a/apps/marketing/components/sections/provenance.tsx
+++ b/apps/marketing/components/sections/provenance.tsx
@@ -1,0 +1,152 @@
+import { Icon } from "@/components/ui/icon";
+import { Container, Section, SectionHeading } from "@/components/ui/primitives";
+import { Reveal } from "@/components/motion/reveal";
+import { Stagger, StaggerItem } from "@/components/motion/stagger";
+
+type ProvenanceFact = { label: string; value: string; mono?: boolean };
+type ProvenanceCheck = { icon: string; text: string };
+type ProvenancePanel = {
+  icon: string;
+  source: string;
+  title: string;
+  body: string;
+  link: { label: string; href: string };
+};
+
+/**
+ * Provenance: the WordPress.org listing and the public repository, side by
+ * side as two different proof shapes (a record vs an invitation to verify).
+ * Left panel is the dominant, denser record; right panel is deliberately
+ * shorter (lg:items-start, no h-full) -- that height delta is intentional.
+ */
+export function Provenance({
+  eyebrow,
+  heading,
+  subhead,
+  directory,
+  facts,
+  repository,
+  checks,
+}: {
+  eyebrow: string;
+  heading: string;
+  subhead: string;
+  directory: ProvenancePanel;
+  facts: ProvenanceFact[];
+  repository: ProvenancePanel;
+  checks: ProvenanceCheck[];
+}) {
+  return (
+    // tone="muted" is load-bearing: FeatureGrid above is base and ends in ~25 white
+    // cards, and --card sits 1% off --background, so on a base section these panels
+    // would have no surface of their own and read as two more feature cards. The
+    // border-b keeps the seam into the muted section below.
+    <Section id="provenance" tone="muted" className="border-y border-[var(--border)]">
+      <Container>
+        <Reveal>
+          <SectionHeading eyebrow={eyebrow} title={heading} lead={subhead} />
+        </Reveal>
+
+        <Stagger className="mt-14 grid gap-6 lg:grid-cols-12 lg:items-start">
+          {/* LEFT: the directory record */}
+          <StaggerItem className="lg:col-span-7">
+            <div className="rounded-xl border border-[var(--border)] bg-card p-6 shadow-sm sm:p-8">
+              <div className="flex items-center gap-3">
+                <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-[var(--primary-subtle)] text-[var(--primary-pressed)]">
+                  <Icon name={directory.icon} size={18} />
+                </span>
+                <span className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
+                  {directory.source}
+                </span>
+              </div>
+
+              <h3 className="mt-5 text-xl font-semibold leading-snug text-foreground">
+                {directory.title}
+              </h3>
+              <p className="mt-3 leading-relaxed text-[var(--muted-foreground)]">
+                {directory.body}
+              </p>
+
+              <dl className="mt-6 grid gap-y-3 border-t border-[var(--border)] pt-6 sm:grid-cols-[max-content_1fr] sm:gap-x-8 sm:gap-y-2.5">
+                {facts.map((f) => (
+                  <div key={f.label} className="sm:contents">
+                    <dt className="text-sm text-[var(--muted-foreground)]">{f.label}</dt>
+                    {/* Mono is for identifiers (slug, version). A four-word product
+                        name set in mono reads as a code literal. */}
+                    <dd
+                      className={
+                        f.mono
+                          ? "font-mono text-sm text-foreground"
+                          : "text-sm font-medium text-foreground"
+                      }
+                      style={f.mono ? { fontVariantNumeric: "tabular-nums" } : undefined}
+                    >
+                      {f.value}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+
+              <a
+                href={directory.link.href}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="mt-6 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-[var(--primary-pressed)] underline-offset-4 transition-colors duration-[var(--duration-fast)] hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+              >
+                {directory.link.label}
+                <Icon name="ArrowRight" size={14} />
+              </a>
+            </div>
+          </StaggerItem>
+
+          {/* RIGHT: the invitation to verify */}
+          <StaggerItem className="lg:col-span-5">
+            <div className="rounded-xl border border-[var(--border)] bg-card p-6 shadow-sm sm:p-8">
+              <div className="flex items-center gap-3">
+                {/* Same chip geometry as the left panel so the two headers read as a
+                    pair. Neutral fill rather than the teal tint, because GitHub's
+                    brand policy wants the mark left monochrome. */}
+                <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-[var(--border)] bg-[var(--muted)] text-foreground">
+                  <Icon name={repository.icon} size={18} />
+                </span>
+                <span className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
+                  {repository.source}
+                </span>
+              </div>
+
+              <h3 className="mt-5 text-xl font-semibold leading-snug text-foreground">
+                {repository.title}
+              </h3>
+              <p className="mt-3 leading-relaxed text-[var(--muted-foreground)]">
+                {repository.body}
+              </p>
+
+              <ul className="mt-6 flex flex-col gap-4 border-t border-[var(--border)] pt-6">
+                {checks.map((c) => (
+                  <li key={c.text} className="flex gap-3">
+                    <span className="mt-0.5 shrink-0 text-[var(--primary)]">
+                      <Icon name={c.icon} size={16} />
+                    </span>
+                    <span className="text-sm leading-relaxed text-[var(--muted-foreground)]">
+                      {c.text}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+
+              <a
+                href={repository.link.href}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="mt-6 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-[var(--primary-pressed)] underline-offset-4 transition-colors duration-[var(--duration-fast)] hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+              >
+                {repository.link.label}
+                <Icon name="ArrowRight" size={14} />
+              </a>
+            </div>
+          </StaggerItem>
+        </Stagger>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -5,8 +5,13 @@
 import type { Cta, Chip, Step, FaqItem, FeatureCluster } from "./types";
 import { SITE_CONFIG } from "@/lib/site";
 
+// Bumped by hand on every agent release, alongside the /changelog RELEASES list.
+// Source of truth is the wordpress.org listing. One constant so the hero badge and
+// the provenance fact row cannot drift apart and contradict the listing they link to.
+const AGENT_VERSION = "0.61.127";
+
 export const HOME_HERO = {
-  badge: "v0.61.127 / open source",
+  badge: `v${AGENT_VERSION} / open source`,
   heading: "The open-source WordPress fleet manager you can run, read, and contribute to",
   subhead:
     "WPMgr is a self-hostable control plane for managing one WordPress site or a whole portfolio. Back up, restore, update, monitor uptime, optimize images with the Media Optimizer, clean the database, and lock down every site from a single dashboard, all on infrastructure you own, built from code you can read and improve.",
@@ -17,7 +22,7 @@ export const HOME_HERO = {
   trust: [
     { icon: "GitFork", title: "Fork and contribute", desc: "AGPL control plane, MIT agent, PRs welcome" },
     { icon: "ServerCog", title: "Your infrastructure", desc: "Fleet data never leaves your server" },
-    { icon: "BadgeCheck", title: "On WordPress.org", desc: "Reviewed and listed in the plugin directory" },
+    { icon: "FileSearch", title: "Reviewed on WordPress.org", desc: "Listed in the plugin directory, install straight from wp-admin", href: "#provenance" },
   ],
   ctas: [
     { label: "Get started for free", href: SITE_CONFIG.signup, variant: "primary" as const, icon: "ArrowRight" },
@@ -424,7 +429,58 @@ export const HOME_STATS = {
     { icon: "DatabaseZap", value: "DB Cleaner", label: "Scan, classify orphans, trend 90 days of health, and act on the whole fleet at once" },
     { icon: "Activity", value: "7 / 30 / 90 days", label: "Fleet status matrix, response-time trends, and incident history across all sites" },
     { icon: "Users", value: "4 roles", label: "From owner to viewer, plus single-site sharing" },
-    { icon: "GitFork", value: "AGPL + MIT", label: "Fork, self-host, and contribute, no paid tier required" },
+    { icon: "ShieldCheck", value: "CVE scanning", label: "Vulnerability scanning, file integrity monitoring, hardening rules, and IP bans across the fleet" },
+  ],
+};
+
+// Every fact below is copied from the live wordpress.org listing and is checkable
+// against it in one click, which is the whole point of the section. If one of these
+// drifts, the section argues against itself. Version comes from AGENT_VERSION above.
+export const HOME_PROVENANCE = {
+  eyebrow: "Provenance",
+  heading: "You do not have to take our word for it",
+  subhead:
+    "Two places you can check this project before you install it: the listing in the WordPress.org plugin directory, and the repository it is built in.",
+  directory: {
+    icon: "FileSearch",
+    source: "WordPress.org plugin directory",
+    title: "A human reviewed it before it went live",
+    body: "Every plugin in the WordPress.org directory is read by a reviewer on the plugin review team before it is published. This is a gate the agent passed, not a page we wrote about ourselves.",
+    link: {
+      label: "View the listing on WordPress.org",
+      href: "https://wordpress.org/plugins/fleet-agent-site-manager/",
+    },
+  },
+  facts: [
+    { label: "Plugin name", value: "Fleet Agent Site Manager" },
+    { label: "Slug", value: "fleet-agent-site-manager", mono: true },
+    { label: "Version", value: AGENT_VERSION, mono: true },
+    { label: "Requires", value: "WordPress 6.2, PHP 8.1" },
+    { label: "Tested up to", value: "WordPress 7.0.2" },
+  ],
+  repository: {
+    icon: "Github",
+    source: "GitHub repository",
+    title: "What the directory ships is built here",
+    body: "The agent, the control plane, and the full release history for both live in one public repository. Read a diff between any two releases and you can see exactly what changed on your sites.",
+    link: {
+      label: "View the source",
+      href: SITE_CONFIG.github,
+    },
+  },
+  checks: [
+    {
+      icon: "FileBadge",
+      text: "The version in the directory is built from the release tagged in this repository. The directory build has the self-update path removed, because WordPress.org ships its own updates.",
+    },
+    {
+      icon: "KeyRound",
+      text: "Everything an agent sends the control plane is Ed25519-signed over the method, path, timestamp, nonce and body hash, and verified before it is trusted.",
+    },
+    {
+      icon: "Scale",
+      text: "The source in this repository is MIT. The copy distributed through the directory carries GPLv2 or later, which is the license the directory asks for.",
+    },
   ],
 };
 

--- a/apps/marketing/lib/seo.ts
+++ b/apps/marketing/lib/seo.ts
@@ -71,7 +71,7 @@ export function buildOrganizationLd(): LdObject {
     name: SITE_CONFIG.name,
     url: SITE_CONFIG.baseUrl,
     logo: `${SITE_CONFIG.baseUrl}/logo.svg`,
-    sameAs: [SITE_CONFIG.github],
+    sameAs: [SITE_CONFIG.github, SITE_CONFIG.wordpressOrg],
     description: SITE_CONFIG.description,
   };
 }
@@ -98,6 +98,11 @@ export function buildSoftwareApplicationLd(): LdObject {
     },
     url: SITE_CONFIG.baseUrl,
     downloadUrl: SITE_CONFIG.github,
+    // Deliberately no installUrl pointing at the wordpress.org listing. This node
+    // describes the WPMgr control plane, which is AGPL-3.0 and is not installed
+    // from the plugin directory; the listing is the agent plugin, distributed
+    // under GPLv2 or later. Pointing one node at both would publish a
+    // machine-readable licence contradiction.
     description: SITE_CONFIG.description,
     license: `${SITE_CONFIG.github}/blob/main/LICENSE`,
   };

--- a/apps/marketing/lib/site.ts
+++ b/apps/marketing/lib/site.ts
@@ -7,6 +7,7 @@ export const SITE_CONFIG = {
   description:
     "Open-source, self-hostable WordPress fleet manager. Backups and restore, safe updates, Media Optimizer (AVIF and WebP), full-page caching, Database Cleaner, uptime, and security scanning, with a signed MIT-licensed agent you can audit and contribute to.",
   github: "https://github.com/mosamlife/wpmgr",
+  wordpressOrg: "https://wordpress.org/plugins/fleet-agent-site-manager/",
   dashboard: "https://manage.wpmgr.app",
   signup: "https://manage.wpmgr.app/register",
   docs: "/docs",
@@ -63,6 +64,7 @@ export const FOOTER_NAV: NavGroup[] = [
       { label: "Guides", href: "/guides/" },
       { label: "API reference", href: SITE_CONFIG.docs },
       { label: "GitHub", href: SITE_CONFIG.github, external: true },
+      { label: "WordPress.org listing", href: SITE_CONFIG.wordpressOrg, external: true },
       { label: "Contributing", href: `${SITE_CONFIG.github}/blob/main/docs/contributing.md`, external: true },
     ],
   },


### PR DESCRIPTION
The WordPress.org listing was carrying the project's strongest credibility claim in a three-word hero chip. This gives it a section.

## Shape

Asymmetric two-up, 7/5, because the two anchors are **different kinds of proof** rather than the same proof twice.

- **Left is a record.** Prose plus a five-row `<dl>` of facts copied from the live listing. Density is the argument.
- **Right is an invitation.** Prose plus three things a reader can go and check themselves.

`lg:items-start`, no `h-full`, so the right card stays shorter on purpose. A symmetric two-up would imply the halves carry equal weight, and only one of them has a record to show.

## What it refuses to show

No install count, no download count, no star row. The listing is hours old and every one of those is **0**, so rendering them would make the section argue against itself. It stands on the fact of review, which does not need volume.

## Trademark

No WordPress mark is drawn. wordpress.org publishes no SVG, so shipping one means hand-tracing a trademark for zero information gain, and a check-in-a-badge glyph beside "WordPress.org plugin directory" reads as a seal of endorsement that does not exist. `FileSearch` instead: a document being read is both safer and a truer picture of what happened. Nothing claims WordPress endorses, certifies or audits WPMgr.

## Three claims the section's own link would have disproved

All caught in adversarial review, all verified before rewriting. This is the part worth reading.

| Claimed | Reality |
| --- | --- |
| "The agent is MIT-licensed" | The live listing publishes **GPLv2 or later**, and `Makefile:255-266` rewrites the header to exactly that before the zip is built. Now states both, which is more interesting than either alone. |
| "Same artifact, two places you can check it" | False. `Makefile:210` excludes the self-updater and `:225` renames the entry file, so the directory tree differs from the tag. Now: built from the tagged release, with the self-update path removed, which is a differentiator rather than an admission. |
| "every update goes through the same queue" | Overclaims the review process. wp.org human-reviews new submissions; after approval an SVN commit republishes with no re-review, which is exactly what we watched happen today at r3636102. |

Publishing a checkable falsehood inside the one section whose thesis is **"you do not have to take our word for it"** is the worst outcome available here.

## Also fixed from review

- **Hero chip** had been rewritten into an install tip, moving the credibility claim out of the best real estate and leaving the row as two trust facts plus a how-to. It is a trust claim again, links to the section, and carries a persistent arrow because hover does not exist on touch and its two neighbours are inert.
- **`tone="muted"`.** On base it sat under FeatureGrid's ~25 white cards with `--card` only 1% off `--background`, so the credibility moment looked like two more feature cards.
- **GitHub mark** gets the same chip geometry as the left panel with a neutral fill rather than no chip, so the two headers read as a pair without tinting the mark.
- **Mono scoped to identifiers.** A four-word product name in monospace reads as a code literal.
- **Composer footnote cut.** The FAQ already owns it two sections later.
- **`installUrl` dropped** from the SoftwareApplication node, which describes the AGPL control plane and must not machine-declare a GPLv2 plugin listing as its installer.
- **One `AGENT_VERSION` constant** now feeds both the hero badge and the fact row, so they cannot drift apart and contradict the listing.

## Verified

Contrast computed from the tokens on the new muted surface:

```
             light   dark
body text     6.50   5.73     (need 4.5)
links         5.62   9.69
headings     18.76  15.48
```

Structure checked in the rendered HTML: 12-col grid, 7/5 spans, `items-start`, no `h-full`, no `border-left` stripe, 12px radius, real `dl`/`dt`/`dd`, both external links `target="_blank" rel="noreferrer noopener"`, focus-visible present.

```
check-copy   367 files, pass
typecheck    clean
lint         clean
next build   clean
```

I could not get a browser to render the local server (curl returns 200, Chrome shows an error page), so this is verified structurally and by computation rather than visually. Worth a look on the deploy preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Provenance section with directory details, repository verification, release information, and external links.
  * Added links to the WordPress.org listing from trust indicators and the Resources footer.
  * Added hover and focus states for linked trust badges.
  * Added CVE scanning coverage to the homepage statistics.
* **Updates**
  * The homepage hero badge now reflects the current release version.
  * Improved structured search metadata for the WordPress.org listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->