### PR TITLE
fix(seo): repair canonicals, the org logo and the sitemap, add llms.txt

### DIFF
--- a/apps/marketing/app/(marketing)/about/page.tsx
+++ b/apps/marketing/app/(marketing)/about/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = buildMetadata({
   title: "About WPMgr | Open-Source WordPress Fleet Management",
   description:
     "WPMgr is an open-source, self-hostable WordPress fleet manager built on the conviction that your site data and your tooling should belong to you. AGPL control plane, MIT agent, Ed25519-signed messages.",
-  canonical: "/about/",
+  canonical: "/about",
 });
 
 const PRINCIPLES = [

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = buildMetadata({
   title: "Changelog: WPMgr Release Notes",
   description:
     "Every WPMgr release, newest first. See what shipped, when, and which features were added, changed, or fixed.",
-  canonical: "/changelog/",
+  canonical: "/changelog",
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/marketing/app/(marketing)/contact/page.tsx
+++ b/apps/marketing/app/(marketing)/contact/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = buildMetadata({
   title: "Contact WPMgr",
   description:
     "Reach the WPMgr team for sales enquiries, support, security reports, or to ask about contributing to the open-source project.",
-  canonical: "/contact/",
+  canonical: "/contact",
 });
 
 const TOPICS = [

--- a/apps/marketing/app/(marketing)/features/[slug]/page.tsx
+++ b/apps/marketing/app/(marketing)/features/[slug]/page.tsx
@@ -27,7 +27,7 @@ export async function generateMetadata({
   return buildMetadata({
     title: feature.metaTitle,
     description: feature.metaDescription,
-    canonical: `/features/${slug}/`,
+    canonical: `/features/${slug}`,
   });
 }
 

--- a/apps/marketing/app/(marketing)/features/page.tsx
+++ b/apps/marketing/app/(marketing)/features/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = buildMetadata({
   title: "WordPress Management Features | WPMgr",
   description:
     "All WordPress fleet management features in one open-source platform: backups and restore, safe updates, Media Optimizer (AVIF and WebP), full-page caching, Redis object cache, Real User Monitoring, database cleanup, security hardening, vulnerability scanning, 2FA, client reports, per-site email, and team access control.",
-  canonical: "/features/",
+  canonical: "/features",
 });
 
 function Breadcrumb() {

--- a/apps/marketing/app/(marketing)/legal/page.tsx
+++ b/apps/marketing/app/(marketing)/legal/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = buildMetadata({
   title: "Legal: Terms, Privacy, Security Policy",
   description:
     "WPMgr legal information: responsible disclosure and security policy, terms of service, and privacy policy.",
-  canonical: "/legal/",
+  canonical: "/legal",
 });
 
 const LEGAL_ITEMS = [

--- a/apps/marketing/app/(marketing)/legal/security-policy/page.tsx
+++ b/apps/marketing/app/(marketing)/legal/security-policy/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = buildMetadata({
   title: "Security Policy: Responsible Disclosure",
   description:
     "WPMgr responsible disclosure policy, security posture, and how to report a vulnerability. Ed25519-signed agent, redacted diagnostics, client-side-encrypted backups.",
-  canonical: "/legal/security-policy/",
+  canonical: "/legal/security-policy",
 });
 
 const SECURITY_POSTURE = [

--- a/apps/marketing/app/(marketing)/pricing/page.tsx
+++ b/apps/marketing/app/(marketing)/pricing/page.tsx
@@ -23,7 +23,7 @@ export const metadata: Metadata = buildMetadata({
   title: "Pricing | WPMgr",
   description:
     "WPMgr pricing: a permanent free tier for 3 sites, and hosted plans from $15/mo with managed backup storage and more frequent backups. Self-hosting stays free and unlimited forever.",
-  canonical: "/pricing/",
+  canonical: "/pricing",
 });
 
 export default async function PricingPage() {

--- a/apps/marketing/app/(marketing)/privacy/page.tsx
+++ b/apps/marketing/app/(marketing)/privacy/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = buildMetadata({
   title: "Privacy Policy | WPMgr",
   description:
     "How WPMgr collects, uses, and protects data for the hosted service at manage.wpmgr.app, including our sub-processors, Google Cloud Platform, Stripe, Razorpay, and Paddle.",
-  canonical: "/privacy/",
+  canonical: "/privacy",
 });
 
 const mail = (

--- a/apps/marketing/app/(marketing)/refunds/page.tsx
+++ b/apps/marketing/app/(marketing)/refunds/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = buildMetadata({
   title: "Refund Policy | WPMgr",
   description:
     "WPMgr refund policy: cancel a monthly subscription anytime, plus a 14-day money-back guarantee on your first paid payment, refunded through your original payment provider.",
-  canonical: "/refunds/",
+  canonical: "/refunds",
 });
 
 const mail = (

--- a/apps/marketing/app/(marketing)/resources/page.tsx
+++ b/apps/marketing/app/(marketing)/resources/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = buildMetadata({
   title: "Resources: Blog, Guides, Changelog, and Docs",
   description:
     "WordPress operations resources from WPMgr: practical blog posts, cornerstone guides, release changelog, and API documentation.",
-  canonical: "/resources/",
+  canonical: "/resources",
 });
 
 const RESOURCES = [

--- a/apps/marketing/app/(marketing)/solutions/[slug]/page.tsx
+++ b/apps/marketing/app/(marketing)/solutions/[slug]/page.tsx
@@ -27,7 +27,7 @@ export async function generateMetadata({
   return buildMetadata({
     title: solution.metaTitle,
     description: solution.metaDescription,
-    canonical: `/solutions/${slug}/`,
+    canonical: `/solutions/${slug}`,
   });
 }
 

--- a/apps/marketing/app/(marketing)/solutions/page.tsx
+++ b/apps/marketing/app/(marketing)/solutions/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = buildMetadata({
   title: "WordPress Management Solutions | WPMgr",
   description:
     "WPMgr covers every WordPress management use case: agencies, freelancers, hosting providers, WordPress security, backups, performance, and managing multiple sites. One open-source platform, no per-site fee.",
-  canonical: "/solutions/",
+  canonical: "/solutions",
 });
 
 function Breadcrumb() {

--- a/apps/marketing/app/(marketing)/terms/page.tsx
+++ b/apps/marketing/app/(marketing)/terms/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = buildMetadata({
   title: "Terms of Service | WPMgr",
   description:
     "Terms of Service for the WPMgr hosted service at manage.wpmgr.app, including subscription billing and your choice of payment provider at checkout.",
-  canonical: "/terms/",
+  canonical: "/terms",
 });
 
 const mail = (

--- a/apps/marketing/app/blog/[category]/[slug]/page.tsx
+++ b/apps/marketing/app/blog/[category]/[slug]/page.tsx
@@ -33,7 +33,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return buildMetadata({
     title: fm.title,
     description: fm.description,
-    canonical: `/blog/${category}/${slug}/`,
+    canonical: `/blog/${category}/${slug}`,
     ogImage: ogImageUrl,
   });
 }

--- a/apps/marketing/app/blog/[category]/page.tsx
+++ b/apps/marketing/app/blog/[category]/page.tsx
@@ -73,7 +73,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return buildMetadata({
     title: `${meta.heading} Articles`,
     description: meta.description,
-    canonical: `/blog/${category}/`,
+    canonical: `/blog/${category}`,
   });
 }
 

--- a/apps/marketing/app/blog/page.tsx
+++ b/apps/marketing/app/blog/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = buildMetadata({
   title: "Blog: WordPress Operations, Security, and Performance",
   description:
     "Practical articles on WordPress security, performance, backups, and agency operations. Written for site operators, developers, and agencies who run WordPress at scale.",
-  canonical: "/blog/",
+  canonical: "/blog",
 });
 
 const CATEGORY_META: Record<string, { label: string; description: string; color: string }> = {

--- a/apps/marketing/app/guides/[slug]/page.tsx
+++ b/apps/marketing/app/guides/[slug]/page.tsx
@@ -27,7 +27,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return buildMetadata({
     title: fm.title,
     description: fm.description,
-    canonical: `/guides/${slug}/`,
+    canonical: `/guides/${slug}`,
     ogImage: `${SITE_CONFIG.baseUrl}/opengraph-image`,
   });
 }

--- a/apps/marketing/app/guides/page.tsx
+++ b/apps/marketing/app/guides/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = buildMetadata({
   title: "WordPress Guides: Maintenance and Core Web Vitals",
   description:
     "Cornerstone long-form guides on running WordPress well. Start with the complete WordPress maintenance guide or the Core Web Vitals optimization guide.",
-  canonical: "/guides/",
+  canonical: "/guides",
 });
 
 // Static guide metadata. Intentionally separate from the file-system loader so

--- a/apps/marketing/app/llms.txt/route.ts
+++ b/apps/marketing/app/llms.txt/route.ts
@@ -1,0 +1,177 @@
+// Serves /llms.txt.
+//
+// WHY A ROUTE AND NOT public/llms.txt. Two reasons, both practical. First,
+// scripts/check-copy.mjs scans app/, components/, lib/content/ and content/,
+// so a file under public/ would be the only human-readable copy we ship with no
+// dash gate on it. Second, every count and slug below is derived from the real
+// content registries, so this file cannot drift from the site the way a
+// hand-maintained one does. A file whose entire purpose is being an accurate
+// fact source is the worst possible place for a stale number.
+//
+// HONEST EXPECTED VALUE, so nobody sequences work behind this file. No major
+// assistant vendor has published a commitment to read llms.txt. Measured
+// studies of real traffic to these files find most of the requests come from
+// SEO audit tools rather than from AI crawlers. It costs an hour, it is
+// reasonable agent-facing documentation, and it may help an agent that fetches
+// it directly. It is not a ranking or citation lever and should not be treated
+// as one.
+//
+// DELIBERATELY NO KEYWORDS. Stuffing terms here is the meta-keywords mistake in
+// new clothing: self-declared data about yourself that no retrieval system has
+// any reason to trust. Everything below is a checkable fact.
+
+import { SITE_CONFIG } from "@/lib/site";
+import { FEATURE_REGISTRY } from "@/lib/content/features";
+import { SOLUTION_REGISTRY } from "@/lib/content/solutions";
+import { getAllPosts } from "@/lib/content/blog";
+import { getAllGuides } from "@/lib/content/guides";
+
+export const dynamic = "force-static";
+
+const base = SITE_CONFIG.baseUrl;
+
+function safe<T>(fn: () => T[]): T[] {
+  try {
+    return fn();
+  } catch {
+    return [];
+  }
+}
+
+export function GET(): Response {
+  const posts = safe(getAllPosts);
+  const guides = safe(getAllGuides);
+
+  // Object.entries rather than indexing by slug: the registries are typed as
+  // Record<string, T>, so an index access is T | undefined and every line would
+  // need a guard that can never fire.
+  const featureLines = Object.entries(FEATURE_REGISTRY)
+    .map(([slug, data]) => `${base}/features/${slug} - ${data.title}`)
+    .join("\n");
+
+  const solutionLines = Object.entries(SOLUTION_REGISTRY)
+    .map(([slug, data]) => `${base}/solutions/${slug} - ${data.title}`)
+    .join("\n");
+
+  const guideLines = guides
+    .map((g) => `${base}/guides/${g.frontmatter.slug} - ${g.frontmatter.title}`)
+    .join("\n");
+
+  const categories = Array.from(new Set(posts.map((p) => p.frontmatter.category))).sort();
+  const categoryLines = categories
+    .map((c) => `${base}/blog/${c} - ${posts.filter((p) => p.frontmatter.category === c).length} articles`)
+    .join("\n");
+
+  const body = `# WPMgr
+
+> Open source, self-hostable WordPress fleet management. One dashboard to back
+> up, update, monitor, secure and speed up many WordPress sites, running on
+> infrastructure you control.
+
+## What this is
+
+WPMgr is a control plane plus a WordPress plugin. The control plane is a Go
+binary with a React dashboard that you run yourself, or use as a hosted service.
+The plugin is installed on each WordPress site you manage and does the work
+locally. Every message between them is Ed25519 signed.
+
+It is not a SaaS-only product and it is not a WordPress plugin on its own. The
+plugin does nothing until you connect it to a control plane you have chosen.
+
+## Facts
+
+Project name: WPMgr
+Website: ${base}
+Source code: ${SITE_CONFIG.github}
+Control plane license: AGPL-3.0
+WordPress plugin license: MIT in source, GPLv2 or later as distributed
+WordPress.org listing: ${SITE_CONFIG.wordpressOrg}
+WordPress.org listing name: Fleet Agent Site Manager
+WordPress.org slug: fleet-agent-site-manager
+Plugin requirements: PHP 8.1 or newer, WordPress 6.2 or newer
+Self-hosting requirements: 64 bit Linux host with Docker 24 or newer, 2 GB RAM
+
+## Naming
+
+Three names refer to related things, which is worth stating plainly because
+they are easy to confuse:
+
+WPMgr is the project and the dashboard.
+WPMgr Agent is the WordPress plugin, and the name shown in wp-admin on a build
+  installed from GitHub.
+Fleet Agent Site Manager is the same plugin's listing name in the WordPress.org
+  plugin directory, and the name shown in wp-admin on a build installed there.
+
+## Capabilities
+
+Backups with incremental archives, client side encryption and restore to any
+snapshot. Bulk plugin, theme and core updates with a pre-update snapshot and
+automatic rollback on failure. Uptime and TLS expiry monitoring. Security
+hardening, file integrity checking against WordPress.org checksums, and
+vulnerability matching. Page caching, Redis object caching and real user Core
+Web Vitals. Image and font optimization to modern formats. Database cleaning.
+White label client reports and a client portal. Role based access, per site
+sharing and a hash chained audit log.
+
+## Primary URLs
+
+${base} - home
+${base}/features - all features
+${base}/solutions - use cases by audience
+${base}/pricing - hosted pricing and the free self-host option
+${base}/docs - API reference
+${base}/blog - articles
+${base}/guides - long form guides
+${base}/changelog - release history
+${base}/about - project background
+
+## Features
+
+${featureLines}
+
+## Solutions
+
+${solutionLines}
+
+## Guides
+
+${guideLines}
+
+## Article categories
+
+${categoryLines}
+
+## URL structure
+
+Features:   ${base}/features/{slug}
+Solutions:  ${base}/solutions/{slug}
+Articles:   ${base}/blog/{category}/{slug}
+Guides:     ${base}/guides/{slug}
+
+## Terminology
+
+Agent: the WordPress plugin installed on a managed site.
+Control plane: the dashboard and API that the agents connect to.
+Fleet: the set of WordPress sites connected to one control plane.
+Enrollment: connecting a site, by saving a control plane URL in the plugin and
+  pasting a one time pairing code.
+Snapshot: a point in time backup that a restore can target.
+
+## Citation
+
+Cite as: WPMgr (${base}).
+When describing installation, note that the plugin is listed on WordPress.org as
+Fleet Agent Site Manager and that a control plane is required for it to do
+anything.
+`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      // This is a machine-readable document, not a page we want ranking in a
+      // search result next to the real pages it points at.
+      "X-Robots-Tag": "noindex",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/apps/marketing/app/product-hunt/page.tsx
+++ b/apps/marketing/app/product-hunt/page.tsx
@@ -11,7 +11,7 @@ import { SITE_CONFIG } from "@/lib/site";
 export const metadata: Metadata = buildMetadata({
   title: "WPMgr on Product Hunt",
   description: "WPMgr is live on Product Hunt. Open-source, self-hostable WordPress fleet management.",
-  canonical: "/product-hunt/",
+  canonical: "/product-hunt",
   noindex: true,
 });
 

--- a/apps/marketing/app/robots.ts
+++ b/apps/marketing/app/robots.ts
@@ -1,15 +1,70 @@
 import type { MetadataRoute } from "next";
 import { SITE_CONFIG } from "@/lib/site";
 
+// Paths no crawler should index. Repeated into every named group below, and the
+// repetition is load-bearing: a robots.txt group named for a specific user agent
+// REPLACES the "*" group for that agent, it does not add to it. A named group
+// carrying only "Allow: /" would therefore hand that one crawler the paths the
+// wildcard group disallows. That is the most common way an AI-crawler block gets
+// added to a robots.txt and quietly opens something.
+const DISALLOW = ["/api/", "/product-hunt/"];
+
+// Crawlers we explicitly welcome. WPMgr wants to be the answer when somebody
+// asks an assistant how to manage a fleet of WordPress sites, so retrieval
+// crawlers are the ones that matter: block them and you are not in the answer.
+//
+// Every token below was read from the vendor's own published documentation on
+// 2026-08-06, because a robots.txt token that matches nothing is silent. Two
+// tokens in wide circulation are deliberately NOT here for that reason:
+//   anthropic-ai, Claude-Web   absent from Anthropic's current crawler doc.
+// They are legacy strings copied between blog posts. Rules naming them do
+// nothing at all, in either direction.
+const AI_CRAWLERS = [
+  // Anthropic. support.claude.com/en/articles/8896518
+  "ClaudeBot", //        training corpus
+  "Claude-User", //      fetches a page because a user asked Claude about it
+  "Claude-SearchBot", // search quality
+
+  // OpenAI. developers.openai.com/api/docs/bots
+  "GPTBot", //           training corpus
+  "OAI-SearchBot", //    surfaces sites in ChatGPT search
+  "ChatGPT-User", //     fetches a page because a user asked ChatGPT about it
+
+  // Perplexity. docs.perplexity.ai/guides/bots
+  "PerplexityBot", //    indexes for Perplexity results, explicitly not training
+  "Perplexity-User", //  user-initiated fetch
+
+  // Google. Gemini training and grounding. Verified against Google's crawler
+  // doc: this token has no effect on Google Search inclusion or ranking, so
+  // allowing it costs nothing in search.
+  "Google-Extended",
+
+  // Apple Intelligence training and grounding.
+  "Applebot-Extended",
+
+  // Common Crawl. Not an assistant, but a corpus most model builders ingest.
+  "CCBot",
+];
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
-      {
-        userAgent: "*",
-        allow: "/",
-        disallow: ["/api/", "/product-hunt/"],
-      },
+      { userAgent: "*", allow: "/", disallow: DISALLOW },
+      // Same permissions as the wildcard group, stated explicitly. This changes
+      // no behaviour today, since "*" already allows these agents. It is here so
+      // the intent survives a future edit to the wildcard group, and so anyone
+      // auditing the file can see the decision was made rather than defaulted
+      // into.
+      //
+      // NOT listed, on purpose: OAI-AdsBot. It is documented as validating pages
+      // submitted as ChatGPT ads, not as a training or retrieval crawler, so it
+      // does nothing for us until we buy ads there. The wildcard group still
+      // allows it; this is a note, not a block.
+      { userAgent: AI_CRAWLERS, allow: "/", disallow: DISALLOW },
     ],
+    // Only real XML sitemaps belong here. llms.txt is NOT a sitemap and listing
+    // it under this directive would hand search engines a document they cannot
+    // parse. It is discoverable at its well-known path instead.
     sitemap: `${SITE_CONFIG.baseUrl}/sitemap.xml`,
   };
 }

--- a/apps/marketing/app/sitemap.ts
+++ b/apps/marketing/app/sitemap.ts
@@ -7,99 +7,128 @@ import { getAllGuides } from "@/lib/content/guides";
 
 const base = SITE_CONFIG.baseUrl;
 
+// URLs here carry NO trailing slash, deliberately. Next serves this site without
+// one, so `/pricing/` 308-redirects to `/pricing`. Every URL in this file used to
+// carry a slash, which meant the sitemap advertised ~50 redirects and every
+// canonical tag pointed at one. Match what is actually served.
+
+// lastModified is omitted wherever we do not hold a real date. An absent lastmod
+// is neutral; a wrong one is a liability. Stamping every URL with the build time,
+// which is what this file used to do, tells a crawler the whole site changed
+// today, every single deploy, and the honest response to that is to stop
+// believing the field. Only dates derived from content are emitted below.
+
+/** Newest date in a list, or undefined when the list is empty. */
+function newest(dates: Date[]): Date | undefined {
+  if (dates.length === 0) return undefined;
+  return dates.reduce((a, b) => (a > b ? a : b));
+}
+
 export default function sitemap(): MetadataRoute.Sitemap {
-  const now = new Date();
+  // Content is read once and reused for both the entries and the index dates.
+  let posts: ReturnType<typeof getAllPosts> = [];
+  try {
+    posts = getAllPosts();
+  } catch {
+    // content/ is unavailable during some static analysis passes; degrade to
+    // an empty list rather than failing the build.
+  }
+
+  let guides: ReturnType<typeof getAllGuides> = [];
+  try {
+    guides = getAllGuides();
+  } catch {
+    // as above
+  }
+
+  const postDates = posts.map((p) => new Date(p.frontmatter.date));
+  const guideDates = guides.map((g) => new Date(g.frontmatter.date));
+
+  const categoryDate = (category: string) =>
+    newest(
+      posts
+        .filter((p) => p.frontmatter.category === category)
+        .map((p) => new Date(p.frontmatter.date)),
+    );
+
+  // An index page is genuinely as fresh as the newest thing it lists, so these
+  // dates are real rather than invented.
+  const blogIndexDate = newest(postDates);
+  const guidesIndexDate = newest(guideDates);
 
   const coreRoutes: MetadataRoute.Sitemap = [
-    { url: base, lastModified: now, changeFrequency: "weekly", priority: 1.0 },
-    { url: `${base}/features/`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
-    { url: `${base}/solutions/`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
-    { url: `${base}/pricing/`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
-    { url: `${base}/about/`, lastModified: now, changeFrequency: "monthly", priority: 0.6 },
-    { url: `${base}/changelog/`, lastModified: now, changeFrequency: "weekly", priority: 0.7 },
-    { url: `${base}/resources/`, lastModified: now, changeFrequency: "monthly", priority: 0.7 },
-    { url: `${base}/contact/`, lastModified: now, changeFrequency: "monthly", priority: 0.6 },
-    { url: `${base}/docs`, lastModified: now, changeFrequency: "monthly", priority: 0.7 },
-    { url: `${base}/legal/`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
-    {
-      url: `${base}/legal/security-policy/`,
-      lastModified: now,
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
+    { url: base, changeFrequency: "weekly", priority: 1.0 },
+    { url: `${base}/features`, changeFrequency: "weekly", priority: 0.9 },
+    { url: `${base}/solutions`, changeFrequency: "weekly", priority: 0.9 },
+    { url: `${base}/pricing`, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${base}/about`, changeFrequency: "monthly", priority: 0.6 },
+    { url: `${base}/changelog`, changeFrequency: "weekly", priority: 0.7 },
+    { url: `${base}/resources`, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${base}/contact`, changeFrequency: "monthly", priority: 0.6 },
+    { url: `${base}/docs`, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${base}/legal`, changeFrequency: "yearly", priority: 0.3 },
+    { url: `${base}/legal/security-policy`, changeFrequency: "monthly", priority: 0.5 },
+    // Indexable, linked from the Legal column of the footer on every page, and
+    // absent from this file until 2026-08-06.
+    { url: `${base}/privacy`, changeFrequency: "yearly", priority: 0.3 },
+    { url: `${base}/terms`, changeFrequency: "yearly", priority: 0.3 },
+    { url: `${base}/refunds`, changeFrequency: "yearly", priority: 0.3 },
     // Blog index + cluster pages
-    { url: `${base}/guides/`, lastModified: now, changeFrequency: "monthly", priority: 0.75 },
-    { url: `${base}/blog/`, lastModified: now, changeFrequency: "weekly", priority: 0.75 },
+    { url: `${base}/guides`, lastModified: guidesIndexDate, changeFrequency: "monthly", priority: 0.75 },
+    { url: `${base}/blog`, lastModified: blogIndexDate, changeFrequency: "weekly", priority: 0.75 },
     {
-      url: `${base}/blog/wordpress-security/`,
-      lastModified: now,
+      url: `${base}/blog/wordpress-security`,
+      lastModified: categoryDate("wordpress-security"),
       changeFrequency: "weekly",
       priority: 0.7,
     },
     {
-      url: `${base}/blog/wordpress-performance/`,
-      lastModified: now,
+      url: `${base}/blog/wordpress-performance`,
+      lastModified: categoryDate("wordpress-performance"),
       changeFrequency: "weekly",
       priority: 0.7,
     },
     {
-      url: `${base}/blog/wordpress-backups/`,
-      lastModified: now,
+      url: `${base}/blog/wordpress-backups`,
+      lastModified: categoryDate("wordpress-backups"),
       changeFrequency: "weekly",
       priority: 0.7,
     },
     {
-      url: `${base}/blog/agency-operations/`,
-      lastModified: now,
+      url: `${base}/blog/agency-operations`,
+      lastModified: categoryDate("agency-operations"),
       changeFrequency: "weekly",
       priority: 0.7,
     },
   ];
 
+  // No date field exists on feature or solution content, so none is emitted.
+  // Adding one to the content types is the honest fix, not a build timestamp.
   const featureRoutes: MetadataRoute.Sitemap = FEATURE_SLUGS.map((slug) => ({
-    url: `${base}/features/${slug}/`,
-    lastModified: now,
+    url: `${base}/features/${slug}`,
     changeFrequency: "monthly" as const,
     priority: slug === "media-optimizer" ? 0.85 : 0.8,
   }));
 
   const solutionRoutes: MetadataRoute.Sitemap = SOLUTION_SLUGS.map((slug) => ({
-    url: `${base}/solutions/${slug}/`,
-    lastModified: now,
+    url: `${base}/solutions/${slug}`,
     changeFrequency: "monthly" as const,
     priority: 0.8,
   }));
 
-  // Blog post routes (from MDX frontmatter)
-  let blogPostRoutes: MetadataRoute.Sitemap = [];
-  try {
-    const posts = getAllPosts();
-    blogPostRoutes = posts.map((post) => {
-      const { frontmatter: fm } = post;
-      return {
-        url: `${base}/blog/${fm.category}/${fm.slug}/`,
-        lastModified: new Date(fm.date),
-        changeFrequency: "monthly" as const,
-        priority: 0.65,
-      };
-    });
-  } catch {
-    // content/ directory not available during static analysis; skip gracefully.
-  }
+  const blogPostRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
+    url: `${base}/blog/${post.frontmatter.category}/${post.frontmatter.slug}`,
+    lastModified: new Date(post.frontmatter.date),
+    changeFrequency: "monthly" as const,
+    priority: 0.65,
+  }));
 
-  // Guide routes
-  let guideRoutes: MetadataRoute.Sitemap = [];
-  try {
-    const guides = getAllGuides();
-    guideRoutes = guides.map((guide) => ({
-      url: `${base}/guides/${guide.frontmatter.slug}/`,
-      lastModified: new Date(guide.frontmatter.date),
-      changeFrequency: "monthly" as const,
-      priority: 0.75,
-    }));
-  } catch {
-    // skip gracefully
-  }
+  const guideRoutes: MetadataRoute.Sitemap = guides.map((guide) => ({
+    url: `${base}/guides/${guide.frontmatter.slug}`,
+    lastModified: new Date(guide.frontmatter.date),
+    changeFrequency: "monthly" as const,
+    priority: 0.75,
+  }));
 
   return [
     ...coreRoutes,

--- a/apps/marketing/lib/seo.ts
+++ b/apps/marketing/lib/seo.ts
@@ -70,7 +70,16 @@ export function buildOrganizationLd(): LdObject {
     "@type": "Organization",
     name: SITE_CONFIG.name,
     url: SITE_CONFIG.baseUrl,
-    logo: `${SITE_CONFIG.baseUrl}/logo.svg`,
+    // icon-512.png, NOT logo.svg. There has never been a logo.svg in public/:
+    // the header mark is an inline React component (components/ui/logo.tsx), so
+    // this declared a 404 as the organization logo on every page. Verified live
+    // before the fix: /logo.svg returned 404 while sitting in the JSON-LD.
+    logo: {
+      "@type": "ImageObject",
+      url: `${SITE_CONFIG.baseUrl}/icon-512.png`,
+      width: 512,
+      height: 512,
+    },
     sameAs: [SITE_CONFIG.github, SITE_CONFIG.wordpressOrg],
     description: SITE_CONFIG.description,
   };
@@ -190,7 +199,9 @@ export function buildArticleLd({
       url: SITE_CONFIG.baseUrl,
       logo: {
         "@type": "ImageObject",
-        url: `${SITE_CONFIG.baseUrl}/logo.svg`,
+        url: `${SITE_CONFIG.baseUrl}/icon-512.png`,
+        width: 512,
+        height: 512,
       },
     },
     mainEntityOfPage: {


### PR DESCRIPTION
Four defects, all verified against the live site before touching anything. Three were shipping.

## Every canonical pointed at a redirect

Next serves this site **without** a trailing slash, so `/pricing/` 308s to `/pricing`. All 20 canonical declarations carried the slash, and so did every sitemap URL. The site was telling Google that the canonical version of each page is a URL that redirects, on all 50 pages, while advertising 50 redirects in the sitemap.

```
/pricing/            308 -> /pricing      canonical said https://wpmgr.app/pricing/
/features/           308 -> /features
/blog/               308 -> /blog
/features/backups/   308                  /features/backups   200
```

Fixed by aligning the declarations with what is actually served, **not** by setting `trailingSlash: true`. Flipping that would 308 every URL currently being indexed, which is a migration on a ten-week-old domain with fresh indexing, and it would also have caught the extension-less `opengraph-image` route handlers.

## The organization logo was a 404

`lib/seo.ts` declared `https://wpmgr.app/logo.svg` as `Organization.logo` and as the publisher logo on every article. **There has never been a `logo.svg` in `public/`** — the header mark is an inline React component. Now points at `icon-512.png`, which exists, with the width and height the structured-data guidance asks for.

## The sitemap stamped every URL with the build time

`lastModified` was `now` for all static, feature and solution routes, so every deploy told crawlers the whole site changed today. The honest response to that signal is to stop believing it.

Now: blog posts and guides keep their real frontmatter dates, index and category pages derive the newest date of what they list, and anything with no real date emits no `lastmod` at all. **An absent lastmod is neutral; a wrong one is a liability.**

```
/guides                    2026-06-21   newest guide
/blog                      2026-06-20   newest post
/blog/wordpress-security   2026-06-20   newest post in category
/features/backups          (none)       no date field exists, so none invented
/privacy                   (none)
```

18 of 53 URLs carry a date and none of them is today. `/privacy`, `/terms` and `/refunds` were missing entirely despite being indexable and footer-linked from all 50 pages.

## Robots: AI crawler rules, from vendor docs

Every token was read from the vendor's own documentation today rather than copied from a blog post, because **a robots token that matches nothing is silent**.

`anthropic-ai` and `Claude-Web` are widely circulated and appear **nowhere** in Anthropic's current crawler doc, so they are deliberately absent.

| Vendor | Documented tokens |
| --- | --- |
| Anthropic | `ClaudeBot`, `Claude-User`, `Claude-SearchBot` |
| OpenAI | `GPTBot`, `OAI-SearchBot`, `ChatGPT-User`, `OAI-AdsBot` |
| Perplexity | `PerplexityBot`, `Perplexity-User` |

**The named group repeats the disallows on purpose.** A group named for a user agent *replaces* the `*` group for that agent rather than adding to it, so a named group carrying only `Allow: /` would have handed those crawlers `/api/`. That is the usual way this change quietly opens something.

`OAI-AdsBot` is left out with a note: it validates pages submitted as ChatGPT ads, not training or retrieval, so it does nothing for us until we buy ads there.

## llms.txt, as a route rather than a static file

Served from `app/llms.txt/route.ts`. Two reasons: `public/` is outside check-copy's scan dirs, so it would have been the only shipped human-readable copy with no dash gate on it; and every count and slug is generated from the real registries, so the file cannot drift from the site it describes. The gate now scans **116** marketing files, up from 115, which is how you can tell the route is covered.

**It contains no keywords, deliberately.** Stuffing terms into a file about yourself is the meta-keywords mistake in new clothing. The file header records the honest expected value: no assistant vendor has committed to reading llms.txt, measured studies find most requests to these files come from SEO audit tools, it costs an hour, and nothing should be sequenced behind it.

## Verified against built output, not source

```
sitemap        53 URLs, 0 trailing slashes, 18 real lastmods, none today
canonicals     every rendered canonical slash-free
logo           ImageObject -> icon-512.png (exists)
robots.txt     both groups emitted, disallows intact in each
llms.txt       14 features + 7 solutions, generated from the registries
typecheck / lint / build / check-copy   all clean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a machine-readable `/llms.txt` resource with site information, capabilities, content links, and citation guidance.
  - Added clearer crawler controls for search and AI retrieval agents.

- **SEO Improvements**
  - Standardized canonical URLs and sitemap links without trailing slashes.
  - Improved sitemap dates using relevant content and added legal pages.
  - Corrected organization and article image references in structured metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->