### PR TITLE
fix(marketing): stop rendering YAML frontmatter as page content

### DIFF
--- a/apps/marketing/next.config.ts
+++ b/apps/marketing/next.config.ts
@@ -2,13 +2,35 @@ import type { NextConfig } from "next";
 import path from "path";
 import createMDX from "@next/mdx";
 
-// remark-gfm is loaded dynamically in the mdx-components.tsx context.
-// We use the Rust-based mdxRs compiler (experimental.mdxRs) which:
-//   - avoids Turbopack serialization errors with remark plugin functions, and
-//   - ships native GFM support by default (tables, task lists, strikethrough).
-// For custom remark/rehype plugins, switch experimental.mdxRs to false and
-// use the webpack path (disable Turbopack with --no-turbo in dev/build).
-const withMDX = createMDX({});
+// MDX compilation for the blog and guide content collections.
+//
+// WHY NOT experimental.mdxRs. The Rust compiler was used here for native GFM
+// and to dodge Turbopack's "non-serializable options" error, but it does not
+// strip YAML frontmatter. Every .mdx file in content/ opens with a `---` block,
+// so the compiled output rendered that block as page content: a thematic break
+// followed by `title: "..." description: "..." date: "..."` set as a heading,
+// directly under the real heading. It shipped that way on every blog post and
+// guide, which is what /guides/wordpress-maintenance was showing publicly.
+//
+// remark-frontmatter teaches the parser that the block is frontmatter and not
+// content, so it is dropped from the output. The metadata is unaffected: the
+// loaders in lib/content/ read frontmatter with gray-matter from the RAW FILE
+// on disk, never from the compiled module, so stripping it at compile time
+// removes the duplicate render and nothing else.
+//
+// remark-gfm has to come back explicitly, since it was mdxRs providing GFM.
+//
+// PLUGINS ARE NAMED AS STRINGS, NOT IMPORTED. Turbopack passes loader options
+// across a serialization boundary and rejects functions with "does not have
+// serializable options", which is the error the previous comment here was
+// working around. A module name is a plain string, so Turbopack resolves it on
+// the other side and the whole problem disappears. Importing these and passing
+// the functions fails the build; this does not.
+const withMDX = createMDX({
+  options: {
+    remarkPlugins: [["remark-frontmatter"], ["remark-gfm"]],
+  },
+});
 
 const nextConfig: NextConfig = {
   output: "standalone",
@@ -19,13 +41,9 @@ const nextConfig: NextConfig = {
   // Content-collection MDX (blog/guides) uses gray-matter + fs loader, not
   // page-extension MDX, so standalone MDX route files stay as .tsx.
   pageExtensions: ["tsx", "ts", "mdx"],
-  experimental: {
-    // mdxRs: the Rust-based MDX compiler. Supports GFM natively.
-    // This avoids the Turbopack "non-serializable options" error that
-    // occurs when remark plugin functions are passed through the Turbopack
-    // loader bridge. Compatible with Next.js 16 + Turbopack builds.
-    mdxRs: true,
-  },
+  // experimental.mdxRs is deliberately absent. See the createMDX comment above:
+  // the Rust compiler does not strip frontmatter, and the remark plugins that
+  // do cannot be passed to it.
 };
 
 export default withMDX(nextConfig);

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -39,6 +39,7 @@
     "@wpmgr/eslint-config": "workspace:*",
     "@wpmgr/tsconfig": "workspace:*",
     "impeccable": "^2.1.9",
+    "remark-frontmatter": "^5.0.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^5.7.0",
     "yaml": "^2.7.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       impeccable:
         specifier: ^2.1.9
         version: 2.1.9(typescript@5.9.3)
+      remark-frontmatter:
+        specifier: ^5.0.0
+        version: 5.0.0
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.1
@@ -3714,6 +3717,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fault@2.0.1:
+    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
+
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
@@ -3750,6 +3756,10 @@ packages:
 
   focus-trap@7.8.0:
     resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
+
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
 
   framer-motion@12.40.0:
     resolution: {integrity: sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==}
@@ -4272,6 +4282,9 @@ packages:
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
 
+  mdast-util-frontmatter@2.0.1:
+    resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
+
   mdast-util-gfm-autolink-literal@2.0.1:
     resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
 
@@ -4322,6 +4335,9 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-frontmatter@2.0.0:
+    resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
@@ -4847,6 +4863,9 @@ packages:
 
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
+
+  remark-frontmatter@5.0.0:
+    resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -8988,6 +9007,10 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fault@2.0.1:
+    dependencies:
+      format: 0.2.2
+
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
@@ -9022,6 +9045,8 @@ snapshots:
   focus-trap@7.8.0:
     dependencies:
       tabbable: 6.5.0
+
+  format@0.2.2: {}
 
   framer-motion@12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -9606,6 +9631,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-frontmatter@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      escape-string-regexp: 5.0.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-frontmatter: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-gfm-autolink-literal@2.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -9765,6 +9801,13 @@ snapshots:
       micromark-util-normalize-identifier: 2.0.1
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-frontmatter@2.0.0:
+    dependencies:
+      fault: 2.0.1
+      micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
@@ -10530,6 +10573,15 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
       unified: 11.0.5
+
+  remark-frontmatter@5.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-frontmatter: 2.0.1
+      micromark-extension-frontmatter: 2.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   remark-gfm@4.0.1:
     dependencies:


### PR DESCRIPTION
Every blog post and guide was printing its own frontmatter into the body. On `/guides/wordpress-maintenance` that meant a horizontal rule followed by:

```
title: "The Complete WordPress Maintenance Guide" description: "A comprehensive
guide to WordPress maintenance: updates, backups, security, performance, and
monitoring..." date: "2026-06-21" author: "WPMgr Team" featureSlug: "backups"
solutionSlug: "manage-multiple-sites"
```

set as a heading, **directly under the real heading**, which had already rendered those same values correctly from parsed metadata. It shipped on all 12 content pages.

## Cause

`experimental.mdxRs`, the Rust MDX compiler, does not strip YAML frontmatter, and no remark plugin was configured. So `---` compiled to a thematic break and the key/value lines compiled to a paragraph.

The `<hr>` visible above the text in the report is that thematic break, and it's what identified the cause rather than guessing at it.

## Fix

`remark-frontmatter`, which teaches the parser the block is frontmatter and not content.

**Metadata is unaffected.** The loaders in `lib/content/` read frontmatter with `gray-matter` from the raw file on disk, never from the compiled module, so stripping it at compile time removes the duplicate render and nothing else.

## The part that took a second attempt

`mdxRs` cannot accept remark plugins, so it had to go, and the comment it left behind warned that the webpack path needs `--no-turbo`. That warning was accurate:

```
Error: loader .../@next/mdx/mdx-js-loader.js for match "{*,next-mdx-rule}"
does not have serializable options.
```

Turbopack passes loader options across a serialization boundary and rejects functions. Naming the plugins as **strings** sidesteps it entirely, since a module name is a plain string Turbopack resolves on the far side. Turbopack is kept, no `--no-turbo`.

## GFM, verified rather than assumed

`remark-gfm` is now explicit, because it was `mdxRs` providing GFM natively. No content in the repo contains a table, so I compiled a throwaway `.mdx` with a table, a strikethrough and a bare URL:

```
table:         1
strikethrough: 1
autolink:      1
frontmatter leaked: 0
```

The probe was then deleted.

## Verified in the built HTML

```
guides + blog:  title:" 0 · description:" 0 · featureSlug 0 · solutionSlug 0
                category:" 0 · tags: 0

h1 still reads  "The Complete WordPress Maintenance Guide"
                "How to Harden Your WordPress Login Page"

typecheck / lint / build / check-copy   clean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved MDX content processing for more consistent frontmatter handling.
  * Enabled enhanced Markdown features, including GitHub-Flavored Markdown support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->