### PR TITLE
feat(seo): send real article metadata, and stop faking dateModified

### DIFF
--- a/apps/marketing/app/blog/[category]/[slug]/page.tsx
+++ b/apps/marketing/app/blog/[category]/[slug]/page.tsx
@@ -35,6 +35,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description: fm.description,
     canonical: `/blog/${category}/${slug}`,
     ogImage: ogImageUrl,
+    article: {
+      published: fm.date,
+      ...(fm.updated ? { modified: fm.updated } : {}),
+      authors: [fm.author ?? "WPMgr Team"],
+      section: CATEGORY_LABELS[category] ?? category,
+      ...(fm.tags ? { tags: fm.tags } : {}),
+    },
   });
 }
 
@@ -74,8 +81,9 @@ export default async function BlogPostPage({ params }: Props) {
   const articleLd = buildArticleLd({
     title: fm.title,
     description: fm.description,
-    slug: `/blog/${category}/${slug}/`,
+    slug: `/blog/${category}/${slug}`,
     datePublished: fm.date,
+    ...(fm.updated ? { dateModified: fm.updated } : {}),
     authorName: fm.author ?? "WPMgr Team",
     image: `${SITE_CONFIG.baseUrl}/blog/${category}/${slug}/opengraph-image`,
   });

--- a/apps/marketing/app/guides/[slug]/page.tsx
+++ b/apps/marketing/app/guides/[slug]/page.tsx
@@ -28,6 +28,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title: fm.title,
     description: fm.description,
     canonical: `/guides/${slug}`,
+    article: {
+      published: fm.date,
+      ...(fm.updated ? { modified: fm.updated } : {}),
+      authors: [fm.author ?? "WPMgr Team"],
+    },
     ogImage: `${SITE_CONFIG.baseUrl}/opengraph-image`,
   });
 }
@@ -56,8 +61,9 @@ export default async function GuidePage({ params }: Props) {
   const articleLd = buildArticleLd({
     title: fm.title,
     description: fm.description,
-    slug: `/guides/${slug}/`,
+    slug: `/guides/${slug}`,
     datePublished: fm.date,
+    ...(fm.updated ? { dateModified: fm.updated } : {}),
     authorName: fm.author ?? "WPMgr Team",
   });
 

--- a/apps/marketing/lib/content/blog/index.ts
+++ b/apps/marketing/lib/content/blog/index.ts
@@ -33,6 +33,9 @@ export type BlogPostFrontmatter = {
   description: string;
   category: BlogCategory;
   date: string;
+  /** ISO date, set ONLY when the piece has been genuinely revised. Absent means
+   *  never revised: see buildArticleLd for why this must not default to `date`. */
+  updated?: string;
   slug: string;
   /** Optional: author display name. Defaults to "WPMgr Team". */
   author?: string;

--- a/apps/marketing/lib/content/guides/index.ts
+++ b/apps/marketing/lib/content/guides/index.ts
@@ -18,6 +18,8 @@ export type GuideFrontmatter = {
   title: string;
   description: string;
   date: string;
+  /** ISO date, set ONLY when the piece has been genuinely revised. */
+  updated?: string;
   slug: string;
   author?: string;
   image?: string;

--- a/apps/marketing/lib/seo.ts
+++ b/apps/marketing/lib/seo.ts
@@ -11,6 +11,23 @@ type BuildMetadataOptions = {
   canonical?: string;
   noindex?: boolean;
   ogImage?: string;
+  /**
+   * Set on blog posts and guides. Emits og:type=article plus
+   * article:published_time and article:modified_time.
+   *
+   * Without this every article shipped og:type=website with no dates at all,
+   * so nothing downstream could tell an article from a landing page, and a
+   * rewrite could not be signalled as a rewrite. `modified` is what makes
+   * refreshing old posts a legible act rather than a silent edit.
+   */
+  article?: {
+    published: string;
+    /** ISO date. Omit when a post has never been revised. */
+    modified?: string;
+    authors?: string[];
+    section?: string;
+    tags?: string[];
+  };
 };
 
 export function buildMetadata({
@@ -19,6 +36,7 @@ export function buildMetadata({
   canonical,
   noindex = false,
   ogImage,
+  article,
 }: BuildMetadataOptions): Metadata {
   const url = canonical
     ? `${SITE_CONFIG.baseUrl}${canonical}`
@@ -33,7 +51,20 @@ export function buildMetadata({
       description,
       url,
       siteName: SITE_CONFIG.name,
-      type: "website",
+      ...(article
+        ? {
+            type: "article" as const,
+            publishedTime: article.published,
+            // Only emit modifiedTime when the piece has actually been revised.
+            // Defaulting it to publishedTime, which the JSON-LD builder used to
+            // do, makes every article claim it was updated the day it shipped
+            // and makes a genuine refresh indistinguishable from no refresh.
+            ...(article.modified ? { modifiedTime: article.modified } : {}),
+            ...(article.authors ? { authors: article.authors } : {}),
+            ...(article.section ? { section: article.section } : {}),
+            ...(article.tags ? { tags: article.tags } : {}),
+          }
+        : { type: "website" as const }),
       images: ogImage
         ? [{ url: ogImage, width: 1200, height: 630, alt: title }]
         : [
@@ -187,7 +218,13 @@ export function buildArticleLd({
     description,
     url,
     datePublished,
-    dateModified: dateModified ?? datePublished,
+    // Emitted ONLY when the piece has actually been revised. This used to fall
+    // back to datePublished, which made every article assert it was last
+    // modified on the day it was written. That is not a harmless default: it
+    // is a claim, it is usually false the moment a post is edited, and it
+    // makes a real refresh indistinguishable from no refresh, which is exactly
+    // the signal a content-refresh cycle depends on.
+    ...(dateModified ? { dateModified } : {}),
     author: {
       "@type": "Organization",
       name: authorName,


### PR DESCRIPTION
Tier 2 item **2.7**. Stacked on #368 (branched from it while Actions was down); retarget to `main` once that merges.

Every blog post and guide was published as a generic web page. That is a prerequisite problem rather than a cosmetic one.

## What was wrong

`lib/seo.ts` hardcoded `type: "website"` for all callers, so **all 12 articles shipped `og:type=website`** with no `article:published_time` and no `article:modified_time`. Nothing downstream could distinguish an article from a landing page.

## The `dateModified` default was worse than missing

`buildArticleLd` did `dateModified: dateModified ?? datePublished`, and **no caller ever passed one**. So every article asserted it was last modified on the day it was written.

That is not a harmless default. It is a claim, it becomes false the first time a post is edited, and it makes a genuine refresh **indistinguishable from no refresh**. Refreshing underperforming posts is the entire weekly half of the planned automation loop, and it cannot signal anything through a field that already claims to be current.

Both `dateModified` and `article:modified_time` are now emitted **only** when a piece carries an explicit `updated` frontmatter date. Absent means never revised: true and useful, rather than false and useless.

`updated?` is optional on both frontmatter types, so no existing content file needs editing and nobody is tempted to invent a date to satisfy a required field.

## Found while here

Both JSON-LD `Article` builders were still passing a **trailing-slash url** (`/blog/${category}/${slug}/`). Missed by d5d2a57 and a99c6eb because those swept canonicals, the sitemap and `href` attributes but not string arguments to the LD builders. The structured data was naming a URL that 308-redirects. Fixed in both.

## Verified in the built HTML

Default state:

```
og:type                  article
article:published_time   2026-06-15
article:section          Security
article:tag              security, login, 2fa
article:modified_time    absent      (nothing revised yet)
LD url                   https://wpmgr.app/blog/wordpress-security/harden-wordpress-login
LD dateModified          absent
```

Then, because "it will work when set" is not a verified claim, I set `updated: "2026-08-06"` on one post and rebuilt:

```
article:modified_time    2026-08-06
LD dateModified          2026-08-06
```

Probe reverted, tree rebuilt clean. typecheck / lint / build / check-copy all pass.