### PR TITLE
feat(marketing): give every feature a sitewide link, and a blog CTA that exists on mobile

### DIFF
--- a/apps/marketing/app/blog/[category]/[slug]/page.tsx
+++ b/apps/marketing/app/blog/[category]/[slug]/page.tsx
@@ -9,6 +9,8 @@ import {
   BLOG_CATEGORIES,
   type BlogCategory,
 } from "@/lib/content/blog";
+import { FEATURE_REGISTRY } from "@/lib/content/features";
+import { SOLUTION_REGISTRY } from "@/lib/content/solutions";
 import { Container } from "@/components/ui/primitives";
 import { SiteHeader } from "@/components/sections/header";
 import { SiteFooter } from "@/components/sections/footer";
@@ -183,7 +185,7 @@ export default async function BlogPostPage({ params }: Props) {
                     href={`/features/${fm.featureSlug}`}
                     className="mt-1 block font-medium text-[var(--primary)] underline underline-offset-4 hover:opacity-80 transition-opacity"
                   >
-                    Explore the feature
+                    {FEATURE_REGISTRY[fm.featureSlug]?.title ?? "Explore the feature"}
                   </Link>
                 </div>
               )}
@@ -194,7 +196,7 @@ export default async function BlogPostPage({ params }: Props) {
                     href={`/solutions/${solutionSlug}`}
                     className="mt-1 block font-medium text-[var(--primary)] underline underline-offset-4 hover:opacity-80 transition-opacity"
                   >
-                    See the full solution
+                    {SOLUTION_REGISTRY[solutionSlug]?.title ?? "See the full solution"}
                   </Link>
                 </div>
               )}

--- a/apps/marketing/app/blog/[category]/[slug]/page.tsx
+++ b/apps/marketing/app/blog/[category]/[slug]/page.tsx
@@ -35,6 +35,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description: fm.description,
     canonical: `/blog/${category}/${slug}`,
     ogImage: ogImageUrl,
+    article: {
+      published: fm.date,
+      ...(fm.updated ? { modified: fm.updated } : {}),
+      authors: [fm.author ?? "WPMgr Team"],
+      section: CATEGORY_LABELS[category] ?? category,
+      ...(fm.tags ? { tags: fm.tags } : {}),
+    },
   });
 }
 
@@ -74,8 +81,9 @@ export default async function BlogPostPage({ params }: Props) {
   const articleLd = buildArticleLd({
     title: fm.title,
     description: fm.description,
-    slug: `/blog/${category}/${slug}/`,
+    slug: `/blog/${category}/${slug}`,
     datePublished: fm.date,
+    ...(fm.updated ? { dateModified: fm.updated } : {}),
     authorName: fm.author ?? "WPMgr Team",
     image: `${SITE_CONFIG.baseUrl}/blog/${category}/${slug}/opengraph-image`,
   });

--- a/apps/marketing/app/guides/[slug]/page.tsx
+++ b/apps/marketing/app/guides/[slug]/page.tsx
@@ -28,6 +28,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title: fm.title,
     description: fm.description,
     canonical: `/guides/${slug}`,
+    article: {
+      published: fm.date,
+      ...(fm.updated ? { modified: fm.updated } : {}),
+      authors: [fm.author ?? "WPMgr Team"],
+    },
     ogImage: `${SITE_CONFIG.baseUrl}/opengraph-image`,
   });
 }
@@ -56,8 +61,9 @@ export default async function GuidePage({ params }: Props) {
   const articleLd = buildArticleLd({
     title: fm.title,
     description: fm.description,
-    slug: `/guides/${slug}/`,
+    slug: `/guides/${slug}`,
     datePublished: fm.date,
+    ...(fm.updated ? { dateModified: fm.updated } : {}),
     authorName: fm.author ?? "WPMgr Team",
   });
 

--- a/apps/marketing/components/content/signup-card.tsx
+++ b/apps/marketing/components/content/signup-card.tsx
@@ -1,0 +1,55 @@
+import { signupHref } from "@/lib/site";
+import type { SignupSource } from "@/lib/analytics";
+import { Icon } from "@/components/ui/icon";
+
+/**
+ * An in-article call to action, placed by the author part-way through a post.
+ *
+ * WHY THIS EXISTS. Below the `md` breakpoint the header signup button is
+ * `hidden md:inline-flex`, so a reader arriving on a post from search has NO
+ * signup link on screen until they reach the band at the very bottom. On a
+ * 2,000 word article that is a long way to ask somebody to travel before the
+ * page offers them anything. This is the template organic search will feed, so
+ * the gap is not marginal.
+ *
+ * DELIBERATELY NOT A STICKY BAR OR A MODAL. Both cover content the reader came
+ * for, and on a project whose whole argument is that you can read the source
+ * before you trust it, interrupting the reading is the wrong trade. An inline
+ * card is skippable, which is the point: it earns attention from position
+ * rather than taking it.
+ *
+ * Usage inside .mdx, after the section that establishes the problem:
+ *
+ *   <SignupCard
+ *     heading="Run this across every site at once"
+ *     body="WPMgr applies the same hardening to a whole fleet from one screen."
+ *   />
+ */
+export function SignupCard({
+  heading = "Try this across your whole fleet",
+  body = "WPMgr is open source and self-hostable, with a free hosted tier. No per-site fee.",
+  cta = "Get started for free",
+  source = "blog-inline",
+}: {
+  heading?: string;
+  body?: string;
+  cta?: string;
+  /** Overrides the analytics source, so a card can be attributed per post. */
+  source?: SignupSource;
+}) {
+  return (
+    <aside className="my-10 rounded-xl border border-[var(--border)] bg-[var(--muted)]/40 p-6 not-prose">
+      <p className="text-base font-semibold text-foreground">{heading}</p>
+      <p className="mt-2 text-sm leading-relaxed text-[var(--muted-foreground)]">{body}</p>
+      <a
+        href={signupHref(source)}
+        target="_blank"
+        rel="noreferrer noopener"
+        className="mt-4 inline-flex h-10 items-center gap-2 rounded-[var(--radius)] bg-[var(--primary)] px-5 text-sm font-medium text-[var(--primary-foreground)] shadow-sm transition-colors duration-[var(--duration-fast)] hover:bg-[var(--primary-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+      >
+        {cta}
+        <Icon name="ArrowRight" size={16} aria-hidden />
+      </a>
+    </aside>
+  );
+}

--- a/apps/marketing/components/sections/footer.tsx
+++ b/apps/marketing/components/sections/footer.tsx
@@ -2,6 +2,11 @@ import { Container } from "@/components/ui/primitives";
 import { Icon } from "@/components/ui/icon";
 import { Logo } from "@/components/ui/logo";
 import { FOOTER_NAV, WORDPRESS_TRADEMARK_DISCLAIMER, SITE_CONFIG } from "@/lib/site";
+// Derived here rather than in lib/site.ts on purpose: 14 feature files import
+// signupHref from lib/site, so lib/site importing the registries would be a
+// cycle. The footer is a leaf, so it can read them safely.
+import { FEATURE_REGISTRY } from "@/lib/content/features";
+import { SOLUTION_REGISTRY } from "@/lib/content/solutions";
 
 export function SiteFooter() {
   return (
@@ -54,6 +59,54 @@ export function SiteFooter() {
             </div>
           ))}
         </div>
+
+        {/* Full index of every feature and solution.
+
+            The header mega-menu renders its panels through createPortal inside
+            AnimatePresence, gated on a panel being open, so it contributes ZERO
+            links to the served HTML. Measured: "features/file-manager" appeared
+            on 3 pages of 55 and "solutions/hosting-providers" on 2. Neither is
+            orphaned, since both index pages link everything, but ten feature
+            pages were reachable only through one hub while four sat in the
+            footer with a sitewide link each.
+
+            This is a strip rather than more grid columns because 14 items in a
+            single column unbalances a five-column footer, and it is derived
+            from the registries rather than hand-listed so a new feature page
+            cannot be added without appearing here. */}
+        <nav aria-label="All features and solutions" className="mt-12 border-t border-[var(--border)] pt-8">
+          <h3 className="text-xs font-semibold uppercase tracking-[0.1em] text-foreground">
+            All features
+          </h3>
+          <ul className="mt-3 flex flex-wrap gap-x-5 gap-y-2">
+            {Object.entries(FEATURE_REGISTRY).map(([slug, data]) => (
+              <li key={slug}>
+                <a
+                  href={`/features/${slug}`}
+                  className="text-sm text-[var(--muted-foreground)] hover:text-foreground transition-colors duration-[var(--duration-fast)]"
+                >
+                  {data.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+
+          <h3 className="mt-6 text-xs font-semibold uppercase tracking-[0.1em] text-foreground">
+            All solutions
+          </h3>
+          <ul className="mt-3 flex flex-wrap gap-x-5 gap-y-2">
+            {Object.entries(SOLUTION_REGISTRY).map(([slug, data]) => (
+              <li key={slug}>
+                <a
+                  href={`/solutions/${slug}`}
+                  className="text-sm text-[var(--muted-foreground)] hover:text-foreground transition-colors duration-[var(--duration-fast)]"
+                >
+                  {data.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
 
         {/* Bottom bar */}
         <div className="mt-12 flex flex-col gap-3 border-t border-[var(--border)] pt-8 text-xs text-[var(--muted-foreground)]">

--- a/apps/marketing/lib/analytics.ts
+++ b/apps/marketing/lib/analytics.ts
@@ -63,6 +63,7 @@ export type SignupSource =
   | "solution-hero"
   | "solution-cta"
   | "blog-post"
+  | "blog-inline"
   | "guide"
   | "guides-index"
   | "features-index"

--- a/apps/marketing/lib/content/blog/index.ts
+++ b/apps/marketing/lib/content/blog/index.ts
@@ -33,6 +33,9 @@ export type BlogPostFrontmatter = {
   description: string;
   category: BlogCategory;
   date: string;
+  /** ISO date, set ONLY when the piece has been genuinely revised. Absent means
+   *  never revised: see buildArticleLd for why this must not default to `date`. */
+  updated?: string;
   slug: string;
   /** Optional: author display name. Defaults to "WPMgr Team". */
   author?: string;

--- a/apps/marketing/lib/content/guides/index.ts
+++ b/apps/marketing/lib/content/guides/index.ts
@@ -18,6 +18,8 @@ export type GuideFrontmatter = {
   title: string;
   description: string;
   date: string;
+  /** ISO date, set ONLY when the piece has been genuinely revised. */
+  updated?: string;
   slug: string;
   author?: string;
   image?: string;

--- a/apps/marketing/lib/seo.ts
+++ b/apps/marketing/lib/seo.ts
@@ -11,6 +11,23 @@ type BuildMetadataOptions = {
   canonical?: string;
   noindex?: boolean;
   ogImage?: string;
+  /**
+   * Set on blog posts and guides. Emits og:type=article plus
+   * article:published_time and article:modified_time.
+   *
+   * Without this every article shipped og:type=website with no dates at all,
+   * so nothing downstream could tell an article from a landing page, and a
+   * rewrite could not be signalled as a rewrite. `modified` is what makes
+   * refreshing old posts a legible act rather than a silent edit.
+   */
+  article?: {
+    published: string;
+    /** ISO date. Omit when a post has never been revised. */
+    modified?: string;
+    authors?: string[];
+    section?: string;
+    tags?: string[];
+  };
 };
 
 export function buildMetadata({
@@ -19,6 +36,7 @@ export function buildMetadata({
   canonical,
   noindex = false,
   ogImage,
+  article,
 }: BuildMetadataOptions): Metadata {
   const url = canonical
     ? `${SITE_CONFIG.baseUrl}${canonical}`
@@ -33,7 +51,20 @@ export function buildMetadata({
       description,
       url,
       siteName: SITE_CONFIG.name,
-      type: "website",
+      ...(article
+        ? {
+            type: "article" as const,
+            publishedTime: article.published,
+            // Only emit modifiedTime when the piece has actually been revised.
+            // Defaulting it to publishedTime, which the JSON-LD builder used to
+            // do, makes every article claim it was updated the day it shipped
+            // and makes a genuine refresh indistinguishable from no refresh.
+            ...(article.modified ? { modifiedTime: article.modified } : {}),
+            ...(article.authors ? { authors: article.authors } : {}),
+            ...(article.section ? { section: article.section } : {}),
+            ...(article.tags ? { tags: article.tags } : {}),
+          }
+        : { type: "website" as const }),
       images: ogImage
         ? [{ url: ogImage, width: 1200, height: 630, alt: title }]
         : [
@@ -187,7 +218,13 @@ export function buildArticleLd({
     description,
     url,
     datePublished,
-    dateModified: dateModified ?? datePublished,
+    // Emitted ONLY when the piece has actually been revised. This used to fall
+    // back to datePublished, which made every article assert it was last
+    // modified on the day it was written. That is not a harmless default: it
+    // is a claim, it is usually false the moment a post is edited, and it
+    // makes a real refresh indistinguishable from no refresh, which is exactly
+    // the signal a content-refresh cycle depends on.
+    ...(dateModified ? { dateModified } : {}),
     author: {
       "@type": "Organization",
       name: authorName,

--- a/apps/marketing/mdx-components.tsx
+++ b/apps/marketing/mdx-components.tsx
@@ -2,6 +2,7 @@ import type { MDXComponents } from "mdx/types";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 
+import { SignupCard } from "@/components/content/signup-card";
 // ---------------------------------------------------------------------------
 // MDX element -> brand-token component map.
 // All prose elements receive the correct Impeccable token classes so every
@@ -10,6 +11,8 @@ import { cn } from "@/lib/utils";
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
+    // Authored components, usable directly inside .mdx content.
+    SignupCard,
     // Headings
     h1: ({ className, ...props }) => (
       <h1


### PR DESCRIPTION
Tier 2 items **2.5** and **2.4**. Third in the stack (#368 → #370 → this), because Actions is down and I branched forward rather than idle. Retarget to `main` as the stack merges.

## 2.5, internal link distribution

The header mega-menu renders its panels through `createPortal` inside `AnimatePresence`, gated on a panel being open, so it contributes **zero** links to the served HTML. Measured across the 55 built pages:

| Page | Inbound pages (before) | After |
| --- | --- | --- |
| `/features/file-manager` | 3 | **53** |
| `/features/two-factor-auth` | 6 | **53** |
| `/features/object-cache` | 3 | **53** |
| `/solutions/hosting-providers` | 2 | **53** |
| `/solutions/freelancers` | 53 | 53 (already in the footer) |

**Correction to the plan's framing.** It called these near-orphans. They are not: `/features` links all 14 and `/solutions` links all 7, so every page is reachable at crawl depth 2. The real problem is narrower and worth stating accurately: four features sat in the footer with a sitewide link each while ten were reachable through a single hub. This is link equity distribution, not discoverability.

Fixed with a full index strip in the footer rather than more grid columns, since 14 items in one column unbalances a five-column footer. It is **derived from the registries**, so a new feature page cannot be added without appearing here.

Derived in the footer component rather than `lib/site.ts` on purpose: 14 feature files import `signupHref` from `lib/site`, so `lib/site` importing the registries would be a cycle. The footer is a leaf.

## 2.4, the blog template

**A total gap, not a marginal one.** Below the `md` breakpoint the header signup button is `hidden md:inline-flex`, so a reader arriving on a post from search had **no signup link on screen at all** until the band at the very bottom. On a 2,000-word article that is a long way to travel before the page offers anything, and this is the template organic search will feed.

Added `<SignupCard>`, registered in `mdx-components` so an author can place it mid-article after the section that establishes the problem.

**Deliberately not a sticky bar or a modal.** Both cover the content the reader came for, and on a project whose argument is that you can read the source before you trust it, interrupting the reading is the wrong trade. An inline card is skippable, which is the point: it earns attention from position rather than taking it.

**Second gap:** related links read "Explore the feature" and "See the full solution". That is the click-here anti-pattern; the anchor carried no meaning for a reader scanning, a screen reader announcing links out of context, or as an internal anchor-text signal. They now use real page titles from the same registries, with the old strings kept only as a fallback.

```
/features/security             -> "WordPress Security Suite"
/solutions/wordpress-security  -> "WordPress security"
"Explore the feature"   0 occurrences
"See the full solution" 0 occurrences
```

## Both new pieces proved, not assumed

A `SignupCard` was added to a real post: it rendered its heading and emitted `register?ref=blog-inline`. Then reverted, and the rebuild confirmed it was gone.

`typecheck` / `lint` / `build` / `check-copy` (371 files) all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline signup cards to blog and guide content, with configurable messaging and tracked calls to action.
  * Added a complete footer index linking to feature and solution pages.
* **SEO Improvements**
  * Enhanced article metadata and structured data with publication, update, author, section, and tag information.
  * Improved canonical article URLs and omitted revision dates when content has not been updated.
* **Content**
  * Added support for recording genuine content update dates on blog posts and guides.
  * Related links now display registry-based titles with fallback support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->