### PR TITLE
fix(seo): finish the trailing-slash sweep, now in the structured data

### DIFF
--- a/apps/marketing/app/(marketing)/contact/page.tsx
+++ b/apps/marketing/app/(marketing)/contact/page.tsx
@@ -32,7 +32,7 @@ const TOPICS = [
     title: "Security",
     description: "Responsible disclosure of a vulnerability in WPMgr.",
     note: "See our security policy for scope and process.",
-    noteHref: "/legal/security-policy/",
+    noteHref: "/legal/security-policy",
   },
   {
     icon: "GitPullRequest",

--- a/apps/marketing/app/(marketing)/features/[slug]/page.tsx
+++ b/apps/marketing/app/(marketing)/features/[slug]/page.tsx
@@ -46,7 +46,7 @@ export default async function FeatureSlugPage({
   const breadcrumbLd = buildBreadcrumbLd([
     { name: "Home", href: "/" },
     { name: "Features", href: "/features" },
-    { name: feature.title, href: `/features/${slug}/` },
+    { name: feature.title, href: `/features/${slug}` },
   ]);
 
   const faqLd = buildFAQPageLd(feature.faq);

--- a/apps/marketing/app/(marketing)/features/page.tsx
+++ b/apps/marketing/app/(marketing)/features/page.tsx
@@ -104,7 +104,7 @@ export default function FeaturesHubPage() {
     c.features.map((f) => ({
       name: f.title,
       description: f.summary,
-      url: `/features/${f.slug}/`,
+      url: `/features/${f.slug}`,
     })),
   );
 

--- a/apps/marketing/app/(marketing)/pricing/page.tsx
+++ b/apps/marketing/app/(marketing)/pricing/page.tsx
@@ -48,7 +48,7 @@ export default async function PricingPage() {
           price: String(tierPrice.usd.amountMajor),
           priceCurrency: "USD",
           description: tier.audience,
-          url: `${SITE_CONFIG.baseUrl}/pricing/`,
+          url: `${SITE_CONFIG.baseUrl}/pricing`,
         },
       ];
       if (tierPrice.inr) {
@@ -58,7 +58,7 @@ export default async function PricingPage() {
           price: String(tierPrice.inr.amountMajor),
           priceCurrency: "INR",
           description: tier.audience,
-          url: `${SITE_CONFIG.baseUrl}/pricing/`,
+          url: `${SITE_CONFIG.baseUrl}/pricing`,
         });
       }
       return offers;

--- a/apps/marketing/app/(marketing)/solutions/[slug]/page.tsx
+++ b/apps/marketing/app/(marketing)/solutions/[slug]/page.tsx
@@ -46,7 +46,7 @@ export default async function SolutionSlugPage({
   const breadcrumbLd = buildBreadcrumbLd([
     { name: "Home", href: "/" },
     { name: "Solutions", href: "/solutions" },
-    { name: solution.title, href: `/solutions/${slug}/` },
+    { name: solution.title, href: `/solutions/${slug}` },
   ]);
 
   const faqLd = buildFAQPageLd(solution.faq);

--- a/apps/marketing/app/(marketing)/solutions/page.tsx
+++ b/apps/marketing/app/(marketing)/solutions/page.tsx
@@ -82,7 +82,7 @@ export default function SolutionsHubPage() {
   const allSolutionsForLd = SOLUTION_HUB_CARDS.map((c) => ({
     name: c.title,
     description: c.summary,
-    url: `/solutions/${c.slug}/`,
+    url: `/solutions/${c.slug}`,
   }));
 
   const breadcrumbLd = buildBreadcrumbLd([

--- a/apps/marketing/app/blog/[category]/[slug]/page.tsx
+++ b/apps/marketing/app/blog/[category]/[slug]/page.tsx
@@ -76,8 +76,8 @@ export default async function BlogPostPage({ params }: Props) {
   const breadcrumb = buildBreadcrumbLd([
     { name: "Home", href: "/" },
     { name: "Blog", href: "/blog" },
-    { name: catLabel, href: `/blog/${category}/` },
-    { name: fm.title, href: `/blog/${category}/${slug}/` },
+    { name: catLabel, href: `/blog/${category}` },
+    { name: fm.title, href: `/blog/${category}/${slug}` },
   ]);
 
   const articleLd = buildArticleLd({

--- a/apps/marketing/app/blog/[category]/[slug]/page.tsx
+++ b/apps/marketing/app/blog/[category]/[slug]/page.tsx
@@ -9,6 +9,8 @@ import {
   BLOG_CATEGORIES,
   type BlogCategory,
 } from "@/lib/content/blog";
+import { FEATURE_REGISTRY } from "@/lib/content/features";
+import { SOLUTION_REGISTRY } from "@/lib/content/solutions";
 import { Container } from "@/components/ui/primitives";
 import { SiteHeader } from "@/components/sections/header";
 import { SiteFooter } from "@/components/sections/footer";
@@ -183,7 +185,7 @@ export default async function BlogPostPage({ params }: Props) {
                     href={`/features/${fm.featureSlug}`}
                     className="mt-1 block font-medium text-[var(--primary)] underline underline-offset-4 hover:opacity-80 transition-opacity"
                   >
-                    Explore the feature
+                    {FEATURE_REGISTRY[fm.featureSlug]?.title ?? "Explore the feature"}
                   </Link>
                 </div>
               )}
@@ -194,7 +196,7 @@ export default async function BlogPostPage({ params }: Props) {
                     href={`/solutions/${solutionSlug}`}
                     className="mt-1 block font-medium text-[var(--primary)] underline underline-offset-4 hover:opacity-80 transition-opacity"
                   >
-                    See the full solution
+                    {SOLUTION_REGISTRY[solutionSlug]?.title ?? "See the full solution"}
                   </Link>
                 </div>
               )}

--- a/apps/marketing/app/blog/[category]/[slug]/page.tsx
+++ b/apps/marketing/app/blog/[category]/[slug]/page.tsx
@@ -35,6 +35,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description: fm.description,
     canonical: `/blog/${category}/${slug}`,
     ogImage: ogImageUrl,
+    article: {
+      published: fm.date,
+      ...(fm.updated ? { modified: fm.updated } : {}),
+      authors: [fm.author ?? "WPMgr Team"],
+      section: CATEGORY_LABELS[category] ?? category,
+      ...(fm.tags ? { tags: fm.tags } : {}),
+    },
   });
 }
 
@@ -74,8 +81,9 @@ export default async function BlogPostPage({ params }: Props) {
   const articleLd = buildArticleLd({
     title: fm.title,
     description: fm.description,
-    slug: `/blog/${category}/${slug}/`,
+    slug: `/blog/${category}/${slug}`,
     datePublished: fm.date,
+    ...(fm.updated ? { dateModified: fm.updated } : {}),
     authorName: fm.author ?? "WPMgr Team",
     image: `${SITE_CONFIG.baseUrl}/blog/${category}/${slug}/opengraph-image`,
   });

--- a/apps/marketing/app/blog/[category]/page.tsx
+++ b/apps/marketing/app/blog/[category]/page.tsx
@@ -35,7 +35,7 @@ const CATEGORY_META: Record<
     heading: "WordPress Security",
     description:
       "Practical guides to hardening WordPress: login protection, file integrity monitoring, vulnerability scanning, and two-factor authentication.",
-    solutionHref: "/solutions/wordpress-security/",
+    solutionHref: "/solutions/wordpress-security",
     solutionLabel: "WordPress Security solution guide",
   },
   "wordpress-performance": {
@@ -43,7 +43,7 @@ const CATEGORY_META: Record<
     heading: "WordPress Performance",
     description:
       "Speed up WordPress with full-page caching, AVIF/WebP images, Redis object cache, and Core Web Vitals monitoring from real visitors.",
-    solutionHref: "/solutions/wordpress-performance/",
+    solutionHref: "/solutions/wordpress-performance",
     solutionLabel: "Speed up WordPress solution guide",
   },
   "wordpress-backups": {
@@ -51,7 +51,7 @@ const CATEGORY_META: Record<
     heading: "WordPress Backups",
     description:
       "Build a reliable WordPress backup strategy: frequency, offsite storage, incremental backups, and verified restore procedures.",
-    solutionHref: "/solutions/wordpress-backups/",
+    solutionHref: "/solutions/wordpress-backups",
     solutionLabel: "WordPress Backups solution guide",
   },
   "agency-operations": {
@@ -59,7 +59,7 @@ const CATEGORY_META: Record<
     heading: "Agency Operations",
     description:
       "Scale your WordPress agency: fleet management, client reporting, white-label tools, and workflows for managing dozens of sites efficiently.",
-    solutionHref: "/solutions/agencies/",
+    solutionHref: "/solutions/agencies",
     solutionLabel: "For agencies solution guide",
   },
 };
@@ -91,7 +91,7 @@ export default async function BlogCategoryPage({ params }: Props) {
   const breadcrumb = buildBreadcrumbLd([
     { name: "Home", href: "/" },
     { name: "Blog", href: "/blog" },
-    { name: meta.label, href: `/blog/${cat}/` },
+    { name: meta.label, href: `/blog/${cat}` },
   ]);
 
   return (

--- a/apps/marketing/app/guides/[slug]/page.tsx
+++ b/apps/marketing/app/guides/[slug]/page.tsx
@@ -55,7 +55,7 @@ export default async function GuidePage({ params }: Props) {
     { name: "Home", href: "/" },
     { name: "Resources", href: "/resources" },
     { name: "Guides", href: "/guides" },
-    { name: fm.title, href: `/guides/${slug}/` },
+    { name: fm.title, href: `/guides/${slug}` },
   ]);
 
   const articleLd = buildArticleLd({

--- a/apps/marketing/app/guides/[slug]/page.tsx
+++ b/apps/marketing/app/guides/[slug]/page.tsx
@@ -28,6 +28,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title: fm.title,
     description: fm.description,
     canonical: `/guides/${slug}`,
+    article: {
+      published: fm.date,
+      ...(fm.updated ? { modified: fm.updated } : {}),
+      authors: [fm.author ?? "WPMgr Team"],
+    },
     ogImage: `${SITE_CONFIG.baseUrl}/opengraph-image`,
   });
 }
@@ -56,8 +61,9 @@ export default async function GuidePage({ params }: Props) {
   const articleLd = buildArticleLd({
     title: fm.title,
     description: fm.description,
-    slug: `/guides/${slug}/`,
+    slug: `/guides/${slug}`,
     datePublished: fm.date,
+    ...(fm.updated ? { dateModified: fm.updated } : {}),
     authorName: fm.author ?? "WPMgr Team",
   });
 

--- a/apps/marketing/app/guides/page.tsx
+++ b/apps/marketing/app/guides/page.tsx
@@ -52,7 +52,7 @@ export default function GuidesIndexPage() {
     GUIDES.map((g) => ({
       name: g.title,
       description: g.description,
-      url: `/guides/${g.slug}/`,
+      url: `/guides/${g.slug}`,
     })),
   );
 

--- a/apps/marketing/components/content/signup-card.tsx
+++ b/apps/marketing/components/content/signup-card.tsx
@@ -1,0 +1,55 @@
+import { signupHref } from "@/lib/site";
+import type { SignupSource } from "@/lib/analytics";
+import { Icon } from "@/components/ui/icon";
+
+/**
+ * An in-article call to action, placed by the author part-way through a post.
+ *
+ * WHY THIS EXISTS. Below the `md` breakpoint the header signup button is
+ * `hidden md:inline-flex`, so a reader arriving on a post from search has NO
+ * signup link on screen until they reach the band at the very bottom. On a
+ * 2,000 word article that is a long way to ask somebody to travel before the
+ * page offers them anything. This is the template organic search will feed, so
+ * the gap is not marginal.
+ *
+ * DELIBERATELY NOT A STICKY BAR OR A MODAL. Both cover content the reader came
+ * for, and on a project whose whole argument is that you can read the source
+ * before you trust it, interrupting the reading is the wrong trade. An inline
+ * card is skippable, which is the point: it earns attention from position
+ * rather than taking it.
+ *
+ * Usage inside .mdx, after the section that establishes the problem:
+ *
+ *   <SignupCard
+ *     heading="Run this across every site at once"
+ *     body="WPMgr applies the same hardening to a whole fleet from one screen."
+ *   />
+ */
+export function SignupCard({
+  heading = "Try this across your whole fleet",
+  body = "WPMgr is open source and self-hostable, with a free hosted tier. No per-site fee.",
+  cta = "Get started for free",
+  source = "blog-inline",
+}: {
+  heading?: string;
+  body?: string;
+  cta?: string;
+  /** Overrides the analytics source, so a card can be attributed per post. */
+  source?: SignupSource;
+}) {
+  return (
+    <aside className="my-10 rounded-xl border border-[var(--border)] bg-[var(--muted)]/40 p-6 not-prose">
+      <p className="text-base font-semibold text-foreground">{heading}</p>
+      <p className="mt-2 text-sm leading-relaxed text-[var(--muted-foreground)]">{body}</p>
+      <a
+        href={signupHref(source)}
+        target="_blank"
+        rel="noreferrer noopener"
+        className="mt-4 inline-flex h-10 items-center gap-2 rounded-[var(--radius)] bg-[var(--primary)] px-5 text-sm font-medium text-[var(--primary-foreground)] shadow-sm transition-colors duration-[var(--duration-fast)] hover:bg-[var(--primary-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+      >
+        {cta}
+        <Icon name="ArrowRight" size={16} aria-hidden />
+      </a>
+    </aside>
+  );
+}

--- a/apps/marketing/components/nav/nav-data.ts
+++ b/apps/marketing/components/nav/nav-data.ts
@@ -37,7 +37,7 @@ export const FEATURES_COLUMNS: FeaturesColumn[] = HUB_CLUSTERS.map(
     name: cluster.name,
     tagline: cluster.tagline,
     rows: cluster.features.map((f) => ({
-      href: `/features/${f.slug}/`,
+      href: `/features/${f.slug}`,
       icon: f.icon,
       title: f.title,
       summary: f.summary,
@@ -58,7 +58,7 @@ export const SOLUTIONS_COLUMNS: SolutionsColumn[] = [
   {
     label: "By audience",
     rows: SOLUTION_HUB_CARDS.filter((c: SolutionHubCard) => c.group === "audience").map((c) => ({
-      href: `/solutions/${c.slug}/`,
+      href: `/solutions/${c.slug}`,
       icon: c.icon,
       title: c.title,
       summary: c.summary,
@@ -67,7 +67,7 @@ export const SOLUTIONS_COLUMNS: SolutionsColumn[] = [
   {
     label: "By job to be done",
     rows: SOLUTION_HUB_CARDS.filter((c: SolutionHubCard) => c.group === "jtbd").map((c) => ({
-      href: `/solutions/${c.slug}/`,
+      href: `/solutions/${c.slug}`,
       icon: c.icon,
       title: c.title,
       summary: c.summary,

--- a/apps/marketing/components/sections/footer.tsx
+++ b/apps/marketing/components/sections/footer.tsx
@@ -2,6 +2,11 @@ import { Container } from "@/components/ui/primitives";
 import { Icon } from "@/components/ui/icon";
 import { Logo } from "@/components/ui/logo";
 import { FOOTER_NAV, WORDPRESS_TRADEMARK_DISCLAIMER, SITE_CONFIG } from "@/lib/site";
+// Derived here rather than in lib/site.ts on purpose: 14 feature files import
+// signupHref from lib/site, so lib/site importing the registries would be a
+// cycle. The footer is a leaf, so it can read them safely.
+import { FEATURE_REGISTRY } from "@/lib/content/features";
+import { SOLUTION_REGISTRY } from "@/lib/content/solutions";
 
 export function SiteFooter() {
   return (
@@ -54,6 +59,54 @@ export function SiteFooter() {
             </div>
           ))}
         </div>
+
+        {/* Full index of every feature and solution.
+
+            The header mega-menu renders its panels through createPortal inside
+            AnimatePresence, gated on a panel being open, so it contributes ZERO
+            links to the served HTML. Measured: "features/file-manager" appeared
+            on 3 pages of 55 and "solutions/hosting-providers" on 2. Neither is
+            orphaned, since both index pages link everything, but ten feature
+            pages were reachable only through one hub while four sat in the
+            footer with a sitewide link each.
+
+            This is a strip rather than more grid columns because 14 items in a
+            single column unbalances a five-column footer, and it is derived
+            from the registries rather than hand-listed so a new feature page
+            cannot be added without appearing here. */}
+        <nav aria-label="All features and solutions" className="mt-12 border-t border-[var(--border)] pt-8">
+          <h3 className="text-xs font-semibold uppercase tracking-[0.1em] text-foreground">
+            All features
+          </h3>
+          <ul className="mt-3 flex flex-wrap gap-x-5 gap-y-2">
+            {Object.entries(FEATURE_REGISTRY).map(([slug, data]) => (
+              <li key={slug}>
+                <a
+                  href={`/features/${slug}`}
+                  className="text-sm text-[var(--muted-foreground)] hover:text-foreground transition-colors duration-[var(--duration-fast)]"
+                >
+                  {data.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+
+          <h3 className="mt-6 text-xs font-semibold uppercase tracking-[0.1em] text-foreground">
+            All solutions
+          </h3>
+          <ul className="mt-3 flex flex-wrap gap-x-5 gap-y-2">
+            {Object.entries(SOLUTION_REGISTRY).map(([slug, data]) => (
+              <li key={slug}>
+                <a
+                  href={`/solutions/${slug}`}
+                  className="text-sm text-[var(--muted-foreground)] hover:text-foreground transition-colors duration-[var(--duration-fast)]"
+                >
+                  {data.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
 
         {/* Bottom bar */}
         <div className="mt-12 flex flex-col gap-3 border-t border-[var(--border)] pt-8 text-xs text-[var(--muted-foreground)]">

--- a/apps/marketing/lib/analytics.ts
+++ b/apps/marketing/lib/analytics.ts
@@ -63,6 +63,7 @@ export type SignupSource =
   | "solution-hero"
   | "solution-cta"
   | "blog-post"
+  | "blog-inline"
   | "guide"
   | "guides-index"
   | "features-index"

--- a/apps/marketing/lib/content/blog/index.ts
+++ b/apps/marketing/lib/content/blog/index.ts
@@ -33,6 +33,9 @@ export type BlogPostFrontmatter = {
   description: string;
   category: BlogCategory;
   date: string;
+  /** ISO date, set ONLY when the piece has been genuinely revised. Absent means
+   *  never revised: see buildArticleLd for why this must not default to `date`. */
+  updated?: string;
   slug: string;
   /** Optional: author display name. Defaults to "WPMgr Team". */
   author?: string;

--- a/apps/marketing/lib/content/guides/index.ts
+++ b/apps/marketing/lib/content/guides/index.ts
@@ -18,6 +18,8 @@ export type GuideFrontmatter = {
   title: string;
   description: string;
   date: string;
+  /** ISO date, set ONLY when the piece has been genuinely revised. */
+  updated?: string;
   slug: string;
   author?: string;
   image?: string;

--- a/apps/marketing/lib/seo.ts
+++ b/apps/marketing/lib/seo.ts
@@ -11,6 +11,23 @@ type BuildMetadataOptions = {
   canonical?: string;
   noindex?: boolean;
   ogImage?: string;
+  /**
+   * Set on blog posts and guides. Emits og:type=article plus
+   * article:published_time and article:modified_time.
+   *
+   * Without this every article shipped og:type=website with no dates at all,
+   * so nothing downstream could tell an article from a landing page, and a
+   * rewrite could not be signalled as a rewrite. `modified` is what makes
+   * refreshing old posts a legible act rather than a silent edit.
+   */
+  article?: {
+    published: string;
+    /** ISO date. Omit when a post has never been revised. */
+    modified?: string;
+    authors?: string[];
+    section?: string;
+    tags?: string[];
+  };
 };
 
 export function buildMetadata({
@@ -19,6 +36,7 @@ export function buildMetadata({
   canonical,
   noindex = false,
   ogImage,
+  article,
 }: BuildMetadataOptions): Metadata {
   const url = canonical
     ? `${SITE_CONFIG.baseUrl}${canonical}`
@@ -33,7 +51,20 @@ export function buildMetadata({
       description,
       url,
       siteName: SITE_CONFIG.name,
-      type: "website",
+      ...(article
+        ? {
+            type: "article" as const,
+            publishedTime: article.published,
+            // Only emit modifiedTime when the piece has actually been revised.
+            // Defaulting it to publishedTime, which the JSON-LD builder used to
+            // do, makes every article claim it was updated the day it shipped
+            // and makes a genuine refresh indistinguishable from no refresh.
+            ...(article.modified ? { modifiedTime: article.modified } : {}),
+            ...(article.authors ? { authors: article.authors } : {}),
+            ...(article.section ? { section: article.section } : {}),
+            ...(article.tags ? { tags: article.tags } : {}),
+          }
+        : { type: "website" as const }),
       images: ogImage
         ? [{ url: ogImage, width: 1200, height: 630, alt: title }]
         : [
@@ -187,7 +218,13 @@ export function buildArticleLd({
     description,
     url,
     datePublished,
-    dateModified: dateModified ?? datePublished,
+    // Emitted ONLY when the piece has actually been revised. This used to fall
+    // back to datePublished, which made every article assert it was last
+    // modified on the day it was written. That is not a harmless default: it
+    // is a claim, it is usually false the moment a post is edited, and it
+    // makes a real refresh indistinguishable from no refresh, which is exactly
+    // the signal a content-refresh cycle depends on.
+    ...(dateModified ? { dateModified } : {}),
     author: {
       "@type": "Organization",
       name: authorName,

--- a/apps/marketing/lib/seo.ts
+++ b/apps/marketing/lib/seo.ts
@@ -253,12 +253,12 @@ export function buildContactPageLd(): LdObject {
   return {
     "@type": "ContactPage",
     name: `Contact ${SITE_CONFIG.name}`,
-    url: `${SITE_CONFIG.baseUrl}/contact/`,
+    url: `${SITE_CONFIG.baseUrl}/contact`,
     description:
       "Contact WPMgr for sales enquiries, support, security reports, or to ask about contributing.",
     mainEntityOfPage: {
       "@type": "WebPage",
-      "@id": `${SITE_CONFIG.baseUrl}/contact/`,
+      "@id": `${SITE_CONFIG.baseUrl}/contact`,
     },
   };
 }

--- a/apps/marketing/mdx-components.tsx
+++ b/apps/marketing/mdx-components.tsx
@@ -2,6 +2,7 @@ import type { MDXComponents } from "mdx/types";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 
+import { SignupCard } from "@/components/content/signup-card";
 // ---------------------------------------------------------------------------
 // MDX element -> brand-token component map.
 // All prose elements receive the correct Impeccable token classes so every
@@ -10,6 +11,8 @@ import { cn } from "@/lib/utils";
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
+    // Authored components, usable directly inside .mdx content.
+    SignupCard,
     // Headings
     h1: ({ className, ...props }) => (
       <h1


### PR DESCRIPTION
Fourth and final pass on the same defect.

`d5d2a57` fixed canonicals and the sitemap. `a99c6eb` fixed `href` attributes. `aa3091b` fixed the two Article LD urls. **Each time the sweep was scoped to the shape it had just found rather than to the defect itself**, so the same bug kept surviving in the next syntax along.

This pass swept by **URL shape** rather than by key name or file, and found 20 more across three forms the earlier passes could not have matched:

| Form | Count | What it meant |
| --- | --- | --- |
| `BreadcrumbList` item urls | 5 | every feature, solution, guide, post and category page named **itself** with a redirecting URL, in its own breadcrumb |
| `ItemList` urls | 3 | `/features`, `/solutions`, `/guides` index pages |
| `Offer` and `ContactPoint` | 3 | two Offer urls on `/pricing`, one `"@id"` on the ContactPage node |
| Plain href data literals | 9 | mega-menu `nav-data`, blog category solution links, contact page |

The `"@id"` one is worth naming: my first sweep matched on key names (`href|slug|url|canonical`), and `"@id"` is none of those, so it **survived a pass that was looking straight at it**. Matching the value shape rather than the key is what caught the rest.

## Deliberately not changed

`DISALLOW` in `app/robots.ts`. `"/api/"` and `"/product-hunt/"` are robots.txt path **prefixes**, where the trailing slash is meaningful and correct, not URLs that resolve.

## Verified across the whole site, not per file

```
288 structured-data URLs parsed from every rendered page
  0 ending in a trailing slash
typecheck / lint / build   clean
```