### PR TITLE
fix(deps): bump js-yaml pins for GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 overrides:
   brace-expansion@1: 1.1.18
   brace-expansion@5: 5.0.8
-  js-yaml@3: 3.15.0
-  js-yaml@4: 4.3.0
+  js-yaml@3: 3.15.1
+  js-yaml@4: 4.3.1
   sharp: 0.35.3
   postcss: 8.5.18
 
@@ -4079,12 +4079,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@29.0.0:
@@ -6104,7 +6104,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -6173,7 +6173,7 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@hey-api/openapi-ts@0.97.3(typescript@5.9.3)':
     dependencies:
@@ -8578,7 +8578,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -9112,7 +9112,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -9437,12 +9437,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ packages:
 # Force patched versions of transitive dependencies flagged by high-severity
 # advisories (DoS via quadratic/exponential parsing). All are same-major pins,
 # so no API change: brace-expansion 1.1.18 (GHSA-3jxr-9vmj-r5cp and
-# GHSA-rgw5-rvv9-x895), js-yaml 3.15.0 for gray-matter and js-yaml 4.3.0 for
+# GHSA-rgw5-rvv9-x895), js-yaml 3.15.1 for gray-matter and js-yaml 4.3.1 for
 # eslint tooling (GHSA-52cp-r559-cp3m).
 overrides:
   # 1.1.18, not 1.1.16. GHSA-rgw5-rvv9-x895 (published after this block was
@@ -22,8 +22,8 @@ overrides:
   # (@eslint/config-array pathMatches). The 1.x chain is eslint only, which never
   # ships in any deployed artifact, so it is pinned to the newest 1.x instead.
   brace-expansion@5: 5.0.8
-  js-yaml@3: 3.15.0
-  js-yaml@4: 4.3.0
+  js-yaml@3: 3.15.1
+  js-yaml@4: 4.3.1
   # sharp <0.35.0 bundles a vulnerable libvips (GHSA-f88m-g3jw-g9cj). Patched in
   # 0.35.0+; Next pulls it as an optional dep for image optimization and its
   # transform API is unchanged across this bump. Verified the marketing build.


### PR DESCRIPTION
A new high-severity advisory published while Actions was down, landing exactly on both of our existing pins:

```
GHSA-5p4m-2wfm-xmqj   vulnerable >=3.0.0 <3.15.1   (we pinned 3.15.0)
                      vulnerable >=4.0.0 <4.3.1    (we pinned 4.3.0)
```

So **Security audit now fails every branch and main with no code change on anyone's part.** This is the recurring shape of that job: it runs `pnpm audit --prod --audit-level high` against a live advisory database, so a green PR can go red overnight. Same class as the govulncheck failures on the Go side.

Bumped to **3.15.1** and **4.3.1**, both same-major so no API change. `js-yaml@3` is reached through `gray-matter`, which parses our MDX frontmatter; `js-yaml@4` through the eslint tooling.

Landed as its own commit rather than folded into the five feature branches waiting behind it, so the dependency fix is reviewable on its own.

## Verified with the exact command CI runs

Capturing pnpm's own exit code rather than a piped one:

```
pnpm audit --prod --audit-level high   ->  exit 0
remaining: 2 low, 2 moderate (below the gate threshold)
lockfile: js-yaml@3.15.1, js-yaml@4.3.1, zero refs to the old versions
marketing build + check-copy: pass
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated YAML parsing dependencies to approved stable patch versions.
  * Improved consistency and security across workspace packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->