### PR TITLE
fix(marketing): stop the compare pages rendering a second header and footer

### DIFF
--- a/apps/marketing/app/(marketing)/compare/[slug]/page.tsx
+++ b/apps/marketing/app/(marketing)/compare/[slug]/page.tsx
@@ -4,8 +4,6 @@ import { ComparisonPage } from "@/components/templates/comparison-page";
 import { buildMetadata, buildBreadcrumbLd, buildFAQPageLd } from "@/lib/seo";
 import { JsonLd } from "@/lib/json-ld";
 import { COMPARE_SLUGS, getComparison } from "@/lib/content/compare";
-import { SiteHeader } from "@/components/sections/header";
-import { SiteFooter } from "@/components/sections/footer";
 
 export function generateStaticParams() {
   return COMPARE_SLUGS.map((slug) => ({ slug }));
@@ -43,11 +41,9 @@ export default async function ComparePage({
 
   return (
     <>
-      <SiteHeader />
       <main>
         <ComparisonPage data={page} />
       </main>
-      <SiteFooter />
       <JsonLd data={breadcrumbLd} />
       {page.faq.length > 0 && <JsonLd data={buildFAQPageLd(page.faq)} />}
     </>

--- a/apps/marketing/app/(marketing)/compare/page.tsx
+++ b/apps/marketing/app/(marketing)/compare/page.tsx
@@ -4,8 +4,6 @@ import { buildMetadata, buildBreadcrumbLd, buildItemListLd } from "@/lib/seo";
 import { JsonLd } from "@/lib/json-ld";
 import { COMPARE_REGISTRY } from "@/lib/content/compare";
 import { Container, Section } from "@/components/ui/primitives";
-import { SiteHeader } from "@/components/sections/header";
-import { SiteFooter } from "@/components/sections/footer";
 
 export const metadata: Metadata = buildMetadata({
   title: "Compare WordPress management tools",
@@ -19,7 +17,6 @@ export default function CompareIndexPage() {
 
   return (
     <>
-      <SiteHeader />
       <main>
         <Section>
           <Container>
@@ -50,7 +47,6 @@ export default function CompareIndexPage() {
           </Container>
         </Section>
       </main>
-      <SiteFooter />
       <JsonLd
         data={buildBreadcrumbLd([
           { name: "Home", href: "/" },


### PR DESCRIPTION
Both `/compare` and `/compare/[slug]` rendered `<SiteHeader />` and `<SiteFooter />` themselves, and they sit inside `app/(marketing)/`, **whose layout already renders both**. Every visitor got two headers and two footers.

Mine, and avoidable. Every other page in that route group correctly relies on the layout, so the two files I added were the only ones doing it. I copied the chrome from a page *outside* the group (`app/blog` and `app/guides` do render their own, correctly, because they are not in it) without checking which side of the boundary the new route sat on.

## Verified against a known-good page, not in isolation

```
                        compare   /features/backups
header markers             2            2
footer markers             2            2
```

(2 = HTML plus the RSC payload, which is what a correct page emits.)