### PR TITLE
feat(marketing): rebuild the comparison page around visuals, not prose

### DIFF
--- a/apps/marketing/app/(marketing)/compare/[slug]/sources/page.tsx
+++ b/apps/marketing/app/(marketing)/compare/[slug]/sources/page.tsx
@@ -1,0 +1,124 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { buildMetadata, buildBreadcrumbLd } from "@/lib/seo";
+import { JsonLd } from "@/lib/json-ld";
+import { COMPARE_SLUGS, getComparison } from "@/lib/content/compare";
+import { Container, Section } from "@/components/ui/primitives";
+
+// The claim register behind a comparison page.
+//
+// It exists so every figure on the comparison itself can be checked without
+// the comparison having to carry 89 sourced sentences in front of the
+// argument, which is what made the first version unreadable. Footnotes on the
+// individual figures link straight to the anchor here.
+//
+// noindex on purpose: this is an audit trail for a reader who doubts a
+// specific number, not a page we want competing in search with the comparison
+// it supports.
+
+export function generateStaticParams() {
+  return COMPARE_SLUGS.map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const page = getComparison(slug);
+  if (!page) return {};
+  return buildMetadata({
+    title: `Sources: ${page.title}`,
+    description: `Every claim made on the ${page.title} comparison, with the page it came from and the date it was checked.`,
+    canonical: `/compare/${slug}/sources`,
+    noindex: true,
+  });
+}
+
+export default async function CompareSourcesPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const page = getComparison(slug);
+  if (!page) notFound();
+
+  const total = page.products.reduce((n, p) => n + p.claims.length, 0);
+
+  return (
+    <>
+      <Section>
+        <Container className="max-w-4xl">
+          <nav aria-label="Breadcrumb" className="mb-6 text-sm text-[var(--muted-foreground)]">
+            <Link href="/compare" className="hover:text-foreground transition-colors">
+              Compare
+            </Link>
+            <span aria-hidden className="px-2">/</span>
+            <Link href={`/compare/${slug}`} className="hover:text-foreground transition-colors">
+              {page.title}
+            </Link>
+          </nav>
+
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+            Sources
+          </h1>
+          <p className="mt-4 max-w-[70ch] leading-relaxed text-[var(--muted-foreground)]">
+            Every claim behind{" "}
+            <Link
+              href={`/compare/${slug}`}
+              className="text-[var(--primary-pressed)] underline underline-offset-4"
+            >
+              {page.title}
+            </Link>
+            , {total} in total, with the page it came from and the date it was checked. Each was
+            fetched from the product owner&apos;s own site, documentation, repository or
+            WordPress.org listing. Prices change: if one of these is stale, the link is how you
+            find out.
+          </p>
+
+          {page.products.map((p) => (
+            <div key={p.key} className="mt-12">
+              <h2 className="text-xl font-semibold text-foreground">{p.name}</h2>
+              <ol className="mt-5 flex flex-col gap-5">
+                {p.claims.map((c) => (
+                  <li key={c.id} id={c.id} className="scroll-mt-24 border-l-0 pl-0">
+                    <div className="flex gap-3">
+                      <span className="mt-0.5 shrink-0 font-mono text-xs text-[var(--muted-foreground)]">
+                        {c.id}
+                      </span>
+                      <div>
+                        <p className="text-sm leading-relaxed text-foreground">{c.claim}</p>
+                        <a
+                          href={c.sourceUrl}
+                          target="_blank"
+                          rel="noreferrer noopener"
+                          className="mt-1 inline-block break-all text-xs text-[var(--muted-foreground)] underline underline-offset-4 hover:text-foreground"
+                        >
+                          {c.sourceUrl}
+                        </a>
+                        <span className="ml-2 text-xs text-[var(--muted-foreground)]">
+                          checked {c.verifiedOn}
+                        </span>
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          ))}
+        </Container>
+      </Section>
+      <JsonLd
+        data={buildBreadcrumbLd([
+          { name: "Home", href: "/" },
+          { name: "Compare", href: "/compare" },
+          { name: page.title, href: `/compare/${slug}` },
+          { name: "Sources", href: `/compare/${slug}/sources` },
+        ])}
+      />
+    </>
+  );
+}

--- a/apps/marketing/components/sections/compare/cost-model.tsx
+++ b/apps/marketing/components/sections/compare/cost-model.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Container, Section } from "@/components/ui/primitives";
+import { Icon } from "@/components/ui/icon";
+import { signupHref } from "@/lib/site";
+import type { ComparisonPageData, CostModel } from "@/lib/content/types";
+
+/**
+ * The cost widget. The reader sets their own fleet size and watches the number
+ * compute from each vendor's published prices.
+ *
+ * WHY THIS EXISTS RATHER THAN A PRICE TABLE. Per-site pricing looks small at
+ * ten sites and is the same multiplication at two hundred. A reader who moves
+ * the slider to their own number does that multiplication themselves, and a
+ * figure you worked out yourself is worth more than one we assert.
+ *
+ * IT MUST NOT OVERSTATE A COMPETITOR. ManageWP is charged at the CHEAPEST of
+ * per-site, per-add-on bundles, and their all-in-one package, because that is
+ * what a real customer would pay. Quietly dropping the cheapest option would
+ * inflate a named company's published price, which is the one mistake this
+ * page cannot survive.
+ *
+ * The CTA lives here on purpose: this is the highest-intent moment on the page,
+ * the instant the reader sees their own annual number.
+ */
+
+const STOPS = [5, 10, 25, 50, 100, 250];
+
+function annualCost(m: CostModel, sites: number): number {
+  const perYear = (v: number) => (m.period === "month" ? v * 12 : v);
+
+  if (m.flat !== undefined) return perYear(m.flat);
+
+  const bySite = m.perSite * sites;
+  const options = [bySite];
+  if (m.bundle !== undefined && m.bundleCovers) {
+    options.push(m.bundle * Math.ceil(sites / m.bundleCovers));
+  }
+  return perYear(Math.min(...options));
+}
+
+function money(n: number): string {
+  return n === 0 ? "$0" : `$${n.toLocaleString("en-US")}`;
+}
+
+export function CostModelSection({ data }: { data: ComparisonPageData }) {
+  const [idx, setIdx] = useState(2); // default 25 sites
+  const sites = STOPS[idx] ?? 25;
+
+  const rows = useMemo(() => {
+    const computed = data.cost.models.map((m) => ({ m, total: annualCost(m, sites) }));
+    const max = Math.max(...computed.map((r) => r.total), 1);
+    return computed.map((r) => ({ ...r, pct: Math.max(2, Math.round((r.total / max) * 100)) }));
+  }, [data.cost.models, sites]);
+
+  return (
+    <Section tone="muted" id="cost" className="border-y border-[var(--border)]">
+      <Container>
+        <div className="max-w-2xl">
+          <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+            {data.cost.heading}
+          </h2>
+          <p className="mt-4 text-lg leading-relaxed text-[var(--muted-foreground)]">
+            {data.cost.subhead}
+          </p>
+        </div>
+
+        <div className="mt-10 rounded-xl border border-[var(--border)] bg-card p-6 shadow-sm sm:p-8">
+          <label htmlFor="fleet-size" className="text-sm font-medium text-foreground">
+            Fleet size
+          </label>
+          <div className="mt-3 flex items-center gap-4">
+            <input
+              id="fleet-size"
+              type="range"
+              min={0}
+              max={STOPS.length - 1}
+              step={1}
+              value={idx}
+              onChange={(e) => setIdx(Number(e.target.value))}
+              className="h-2 w-full max-w-md cursor-pointer appearance-none rounded-full bg-[var(--border)] accent-[var(--primary)]"
+              aria-valuetext={`${sites} sites`}
+            />
+            <span
+              className="min-w-[5.5rem] font-mono text-lg font-medium text-foreground"
+              style={{ fontVariantNumeric: "tabular-nums" }}
+            >
+              {sites} sites
+            </span>
+          </div>
+
+          <ul className="mt-8 flex flex-col gap-5">
+            {rows.map(({ m, total, pct }) => (
+              <li key={m.productKey}>
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <span className="text-sm font-medium text-foreground">{m.label}</span>
+                  <span
+                    className="font-mono text-lg font-medium text-foreground"
+                    style={{ fontVariantNumeric: "tabular-nums" }}
+                  >
+                    {money(total)}
+                    <span className="ml-1 text-xs font-normal text-[var(--muted-foreground)]">
+                      per year
+                    </span>
+                  </span>
+                </div>
+                <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-[var(--muted)]">
+                  <div
+                    className={
+                      m.productKey === "wpmgr"
+                        ? "h-full rounded-full bg-[var(--primary)]"
+                        : "h-full rounded-full bg-[var(--muted-foreground)]/45"
+                    }
+                    style={{ width: `${pct}%`, transition: "width 320ms cubic-bezier(0.22,1,0.36,1)" }}
+                  />
+                </div>
+                <p className="mt-2 text-xs leading-relaxed text-[var(--muted-foreground)]">
+                  {m.note}
+                  {m.cites?.map((id) => (
+                    <a
+                      key={id}
+                      href={`/compare/${data.slug}/sources#${id}`}
+                      className="ml-1 align-super underline underline-offset-2 hover:text-foreground"
+                      aria-label={`Source, reference ${id}`}
+                    >
+                      {id.split("-")[1]}
+                    </a>
+                  ))}
+                </p>
+              </li>
+            ))}
+          </ul>
+
+          <div className="mt-8 flex flex-wrap items-center gap-3 border-t border-[var(--border)] pt-6">
+            <a
+              href={signupHref("compare")}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex h-11 items-center gap-2 rounded-[var(--radius)] bg-[var(--primary)] px-6 text-sm font-medium text-[var(--primary-foreground)] shadow-sm transition-colors duration-[var(--duration-fast)] hover:bg-[var(--primary-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+            >
+              Start free at {sites} sites
+              <Icon name="ArrowRight" size={16} aria-hidden />
+            </a>
+            <span className="text-sm text-[var(--muted-foreground)]">
+              No card, and self-hosting stays free at any size.
+            </span>
+          </div>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/marketing/components/sections/compare/data-locality.tsx
+++ b/apps/marketing/components/sections/compare/data-locality.tsx
@@ -1,0 +1,98 @@
+import { Container, Section } from "@/components/ui/primitives";
+import { Icon } from "@/components/ui/icon";
+import type { ComparisonPageData } from "@/lib/content/types";
+
+/**
+ * Where the fleet data lives: one lane per product, three nodes each.
+ *
+ * This section carries the argument nobody closes by shipping a feature next
+ * quarter. A rival can add incremental backups in a release. Where the data
+ * lands is an architectural fact about the product, and stating it as three
+ * labelled nodes makes that visible faster than any paragraph.
+ *
+ * BUILT FROM DOM, NOT SVG, on purpose. The nodes are real text in a flex row
+ * with connectors between them, so the content is selectable, translatable,
+ * readable by a screen reader in order, and present with no JavaScript. An SVG
+ * diagram would have needed a second coordinate set for mobile and would have
+ * put the labels beyond reach of the page's own text tooling.
+ *
+ * The only motion is a hover lift on our own lane, which is decoration and is
+ * a transform, so nothing here depends on a transition to become visible.
+ */
+export function DataLocality({ data }: { data: ComparisonPageData }) {
+  const nameOf = (key: string) =>
+    key === "wpmgr" ? "WPMgr" : (data.products.find((p) => p.key === key)?.name ?? key);
+
+  return (
+    <Section id="locality">
+      <Container>
+        <div className="max-w-2xl">
+          <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+            {data.locality.heading}
+          </h2>
+          <p className="mt-4 text-lg leading-relaxed text-[var(--muted-foreground)]">
+            {data.locality.subhead}
+          </p>
+        </div>
+
+        <ul className="mt-10 flex flex-col gap-4">
+          {data.locality.lanes.map((lane) => {
+            const ours = lane.productKey === "wpmgr";
+            return (
+              <li
+                key={lane.productKey}
+                className={
+                  ours
+                    ? "rounded-xl border border-[var(--primary)]/35 bg-[var(--primary-subtle)]/40 p-5 sm:p-6"
+                    : "rounded-xl border border-[var(--border)] bg-card p-5 shadow-sm sm:p-6"
+                }
+              >
+                <p className="text-sm font-semibold text-foreground">{nameOf(lane.productKey)}</p>
+
+                {/* Nodes. Wraps to a column at narrow widths rather than needing
+                    a second diagram. */}
+                <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-0">
+                  {lane.path.map((node, i) => (
+                    <div key={node} className="flex items-center gap-2 sm:gap-0">
+                      <span
+                        className={
+                          ours
+                            ? "inline-flex items-center rounded-lg border border-[var(--primary)]/30 bg-card px-3 py-2 text-sm font-medium text-foreground"
+                            : "inline-flex items-center rounded-lg border border-[var(--border)] bg-[var(--muted)]/40 px-3 py-2 text-sm text-foreground"
+                        }
+                      >
+                        {node}
+                      </span>
+                      {i < lane.path.length - 1 && (
+                        <span
+                          aria-hidden
+                          className="mx-2 flex items-center text-[var(--muted-foreground)]"
+                        >
+                          <Icon name="ArrowRight" size={14} />
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+
+                <p className="mt-4 text-sm leading-relaxed text-[var(--muted-foreground)]">
+                  {lane.note}
+                  {lane.cites?.map((id) => (
+                    <a
+                      key={id}
+                      href={`/compare/${data.slug}/sources#${id}`}
+                      className="ml-1 align-super text-[10px] underline underline-offset-2 hover:text-foreground"
+                      aria-label={`Source, reference ${id}`}
+                    >
+                      {id.split("-")[1]}
+                    </a>
+                  ))}
+                </p>
+              </li>
+            );
+          })}
+        </ul>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/marketing/components/sections/compare/matrix.tsx
+++ b/apps/marketing/components/sections/compare/matrix.tsx
@@ -1,0 +1,172 @@
+import { Container, Section } from "@/components/ui/primitives";
+import { Icon } from "@/components/ui/icon";
+import type { ComparisonPageData, MatrixCell, MatrixTone } from "@/lib/content/types";
+
+/**
+ * The at-a-glance matrix.
+ *
+ * TONE IS SEMANTIC, NEVER PER PRODUCT. A tone describes what the CELL means,
+ * so tinting our own column wholesale is not available. That matters because
+ * the first group is deliberately parity, and a reader who spots the author's
+ * column glowing green throughout stops believing the parity group, which is
+ * the group doing the most work.
+ *
+ * MOBILE IS A CARD PER ROW, NOT A SCROLLING TABLE. A horizontally scrolling
+ * table with a sticky label column shows roughly one product column at a time
+ * on a 360px screen, so a reader can never see our cell and theirs together.
+ * That is the entire job of a comparison. Below `lg` each row becomes a small
+ * stacked card listing all three products, which fits.
+ */
+
+const TONE: Record<MatrixTone, { cell: string; icon: string | null; iconClass: string }> = {
+  included: {
+    cell: "text-foreground",
+    icon: "Check",
+    iconClass: "text-[var(--primary)]",
+  },
+  paid: {
+    cell: "text-foreground",
+    icon: "Receipt",
+    iconClass: "text-[var(--muted-foreground)]",
+  },
+  partial: {
+    cell: "text-foreground",
+    icon: "AlertTriangle",
+    iconClass: "text-[var(--muted-foreground)]",
+  },
+  absent: {
+    cell: "text-[var(--muted-foreground)]",
+    icon: "Minus",
+    iconClass: "text-[var(--muted-foreground)]",
+  },
+  neutral: { cell: "text-foreground", icon: null, iconClass: "" },
+};
+
+function Cell({ cell, slug }: { cell: MatrixCell; slug: string }) {
+  const tone = TONE[cell.tone];
+  return (
+    <span className="flex items-start gap-2">
+      {tone.icon && (
+        <Icon name={tone.icon} size={15} className={`mt-0.5 shrink-0 ${tone.iconClass}`} aria-hidden />
+      )}
+      <span className={tone.cell}>
+        {cell.value}
+        {cell.cites?.map((id) => (
+          <a
+            key={id}
+            href={`/compare/${slug}/sources#${id}`}
+            className="ml-1 align-super text-[10px] text-[var(--muted-foreground)] underline underline-offset-2 hover:text-foreground"
+            aria-label={`Source for this figure, reference ${id}`}
+          >
+            {id.split("-")[1]}
+          </a>
+        ))}
+      </span>
+    </span>
+  );
+}
+
+export function CompareMatrix({ data }: { data: ComparisonPageData }) {
+  const cols = [
+    { key: "wpmgr", name: "WPMgr" },
+    ...data.products.map((p) => ({ key: p.key, name: p.name })),
+  ];
+
+  return (
+    <Section tone="muted" id="matrix" className="border-y border-[var(--border)]">
+      <Container>
+        <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+          At a glance
+        </h2>
+        <p className="mt-3 max-w-[68ch] text-[var(--muted-foreground)]">
+          Free text rather than ticks, because a tick cannot say &quot;paid add-on&quot;. Every
+          figure links to the page it came from.
+        </p>
+
+        {/* Desktop: a real table. */}
+        <div className="mt-10 hidden lg:block">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-[var(--border)]">
+                <th scope="col" className="w-[22%] py-3 pr-4 text-left">
+                  <span className="sr-only">Capability</span>
+                </th>
+                {cols.map((c) => (
+                  <th key={c.key} scope="col" className="py-3 pr-4 text-left font-semibold text-foreground">
+                    {c.name}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            {data.matrix.map((group) => (
+              <tbody key={group.label}>
+                <tr>
+                  <th
+                    colSpan={cols.length + 1}
+                    scope="colgroup"
+                    className="pt-8 pb-2 text-left text-xs font-semibold uppercase tracking-[0.1em] text-[var(--muted-foreground)]"
+                  >
+                    {group.label}
+                  </th>
+                </tr>
+                {group.rows.map((row) => (
+                  <tr key={row.label} className="border-b border-[var(--border)]/60 align-top">
+                    <th scope="row" className="py-4 pr-4 text-left font-medium text-foreground">
+                      {row.label}
+                    </th>
+                    {cols.map((c) => (
+                      <td key={c.key} className="py-4 pr-4 leading-relaxed">
+                        {row.cells[c.key] ? (
+                          <Cell cell={row.cells[c.key]!} slug={data.slug} />
+                        ) : (
+                          <span className="text-[var(--muted-foreground)">Not stated</span>
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            ))}
+          </table>
+        </div>
+
+        {/* Mobile: one card per row, all three products visible together. */}
+        <div className="mt-8 flex flex-col gap-8 lg:hidden">
+          {data.matrix.map((group) => (
+            <div key={group.label}>
+              <h3 className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--muted-foreground)]">
+                {group.label}
+              </h3>
+              <div className="mt-3 flex flex-col gap-3">
+                {group.rows.map((row) => (
+                  <div
+                    key={row.label}
+                    className="rounded-xl border border-[var(--border)] bg-card p-4 shadow-sm"
+                  >
+                    <p className="text-sm font-semibold text-foreground">{row.label}</p>
+                    <dl className="mt-3 flex flex-col gap-2.5">
+                      {cols.map((c) => (
+                        <div key={c.key} className="grid grid-cols-[5.5rem_1fr] gap-3">
+                          <dt className="text-xs font-medium text-[var(--muted-foreground)] pt-0.5">
+                            {c.name}
+                          </dt>
+                          <dd className="text-sm leading-relaxed">
+                            {row.cells[c.key] ? (
+                              <Cell cell={row.cells[c.key]!} slug={data.slug} />
+                            ) : (
+                              <span className="text-[var(--muted-foreground)]">Not stated</span>
+                            )}
+                          </dd>
+                        </div>
+                      ))}
+                    </dl>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/marketing/components/sections/compare/stack-collapse.tsx
+++ b/apps/marketing/components/sections/compare/stack-collapse.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Container, Section } from "@/components/ui/primitives";
+import { Icon } from "@/components/ui/icon";
+import type { ComparisonPageData } from "@/lib/content/types";
+
+/**
+ * The consolidation visual: eight separately-bought tools converging into one.
+ *
+ * This is the page's hero visual because it IS the commercial argument. The
+ * matrix proves parity row by row; this shows in one glance what the reader is
+ * actually buying, which is one system instead of eight subscriptions.
+ *
+ * WHY IT IS NOT A CARD GRID. The tiles are not the content, the MOVEMENT is:
+ * they start scattered on a ring and converge on a single core. A static grid
+ * of icon-plus-label tiles would be the filler pattern the house rules ban, and
+ * would say nothing a list could not.
+ *
+ * MOTION RULES OBSERVED:
+ *   Only `transform` is animated. Never opacity, never a layout property. So
+ *   there is no renderer anywhere, headless or print or JavaScript-off, in
+ *   which any of this content is invisible. The tiles are in the DOM, readable
+ *   and positioned, before any script runs; the animation only moves them.
+ *   prefers-reduced-motion lands them in their final positions immediately.
+ */
+
+// Eight positions on a ring, as fractions of the panel box. Hand-placed rather
+// than computed so the labels never collide at the narrow breakpoint.
+const RING = [
+  { x: -0.34, y: -0.30 },
+  { x: 0.0, y: -0.38 },
+  { x: 0.34, y: -0.30 },
+  { x: 0.42, y: 0.0 },
+  { x: 0.34, y: 0.30 },
+  { x: 0.0, y: 0.38 },
+  { x: -0.34, y: 0.30 },
+  { x: -0.42, y: 0.0 },
+];
+
+export function StackCollapse({ data }: { data: ComparisonPageData }) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    // Reduced motion: land in the final state and never animate.
+    const reduce = window.matchMedia("(prefers-reduced-motion: reduce)");
+    if (reduce.matches) {
+      setCollapsed(true);
+      return;
+    }
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) if (e.isIntersecting) setCollapsed(true);
+      },
+      { rootMargin: "-15% 0px -15% 0px" },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  const items = data.replaces.items.slice(0, RING.length);
+
+  return (
+    <Section id="replaces">
+      <Container>
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+            {data.replaces.heading}
+          </h2>
+          <p className="mt-4 text-lg leading-relaxed text-[var(--muted-foreground)]">
+            {data.replaces.subhead}
+          </p>
+        </div>
+
+        <div
+          ref={ref}
+          className="relative mx-auto mt-14 h-[340px] w-full max-w-3xl sm:h-[420px]"
+        >
+          {/* The core. Always visible, never animated in. */}
+          <div className="absolute left-1/2 top-1/2 z-10 -translate-x-1/2 -translate-y-1/2">
+            <div className="flex h-24 w-24 flex-col items-center justify-center gap-1 rounded-2xl border border-[var(--primary)]/30 bg-[var(--primary-subtle)] text-[var(--primary-pressed)] sm:h-28 sm:w-28">
+              <Icon name="Layers" size={22} aria-hidden />
+              <span className="text-xs font-semibold">WPMgr</span>
+            </div>
+          </div>
+
+          {items.map((item, i) => {
+            const pos = RING[i]!;
+            // Collapsed: sit on the core. Expanded: out on the ring.
+            const tx = collapsed ? 0 : pos.x * 100;
+            const ty = collapsed ? 0 : pos.y * 100;
+            const scale = collapsed ? 0.62 : 1;
+            return (
+              <div
+                key={item.label}
+                className="absolute left-1/2 top-1/2 w-28 sm:w-32"
+                style={{
+                  transform: `translate3d(calc(-50% + ${tx}%), calc(-50% + ${ty}%), 0) scale(${scale})`,
+                  transition:
+                    "transform 900ms cubic-bezier(0.22, 1, 0.36, 1)",
+                  transitionDelay: `${i * 55}ms`,
+                }}
+              >
+                <div className="flex flex-col items-center gap-1.5 rounded-xl border border-[var(--border)] bg-card px-3 py-2.5 text-center shadow-sm">
+                  <Icon
+                    name={item.icon}
+                    size={16}
+                    className="text-[var(--muted-foreground)]"
+                    aria-hidden
+                  />
+                  <span className="text-[11px] leading-tight text-[var(--muted-foreground)]">
+                    {item.label}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/marketing/components/templates/comparison-page.tsx
+++ b/apps/marketing/components/templates/comparison-page.tsx
@@ -1,38 +1,36 @@
 import Link from "next/link";
-import { Container, Section, SectionHeading } from "@/components/ui/primitives";
-import { Reveal } from "@/components/motion/reveal";
-import { Icon } from "@/components/ui/icon";
+import { Container, Section } from "@/components/ui/primitives";
 import { CTABand } from "@/components/sections/cta-band";
-import { SITE_CONFIG, signupHref } from "@/lib/site";
+import { CompareMatrix } from "@/components/sections/compare/matrix";
+import { StackCollapse } from "@/components/sections/compare/stack-collapse";
+import { CostModelSection } from "@/components/sections/compare/cost-model";
+import { DataLocality } from "@/components/sections/compare/data-locality";
+import { signupHref } from "@/lib/site";
+import { Icon } from "@/components/ui/icon";
 import type { ComparisonPageData } from "@/lib/content/types";
 
 /**
  * Template for /compare/[slug].
  *
- * These are the only pages permitted to name competitor products, and the
- * layout is built around the thing that makes that defensible: every factual
- * claim about another product renders WITH its source link and the date it was
- * checked, visible to the reader. A comparison written by one of the products
- * is worth nothing unless the reader can audit it, so the audit trail is part
- * of the page rather than a footnote.
+ * SIX SECTIONS, and the count is the point. The first version of this page ran
+ * to 9,400 words of sourced claims below the table and was rejected for being
+ * a wall of text. Every section here either SHOWS something or lets the reader
+ * COMPUTE something; the prose between them is under 400 words in total.
  *
- * Two structural commitments that are easy to erode later and should not be:
+ * The claims did not disappear. They moved to /compare/[slug]/sources and are
+ * reachable from numbered footnotes on the individual figures they back, which
+ * is where a reader wants them: at the moment they doubt a specific number,
+ * not stacked in front of the argument.
  *
- *   The disclosure sits ABOVE the comparison, not below it. A reader who works
- *   out halfway down that the author is one of the options has been managed,
- *   and stops believing the rest. Saying it first costs nothing and buys the
- *   whole page.
- *
- *   Every competitor renders a "does better" block, and the type makes
- *   `strengths` non-optional. A comparison in which the author wins on every
- *   axis is not read as a comparison, it is read as an advert.
+ * This template does NOT render SiteHeader or SiteFooter. It lives inside
+ * app/(marketing)/, whose layout already provides both, and rendering them
+ * again is exactly the defect that shipped two of each on the first version.
+ * The same layout also mounts ScrollProgress.
  */
 export function ComparisonPage({ data }: { data: ComparisonPageData }) {
-  const columns = ["WPMgr", ...data.products.map((p) => p.name)];
-
   return (
     <>
-      {/* Hero */}
+      {/* 1. Hero */}
       <Section>
         <Container>
           <nav aria-label="Breadcrumb" className="mb-6 text-sm text-[var(--muted-foreground)]">
@@ -46,167 +44,65 @@ export function ComparisonPage({ data }: { data: ComparisonPageData }) {
               Compare
             </Link>
           </nav>
-          <h1 className="max-w-[26ch] text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+
+          <h1 className="max-w-[24ch] text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
             {data.hero.heading}
           </h1>
-          <p className="mt-5 max-w-[70ch] text-lg leading-relaxed text-[var(--muted-foreground)]">
+          <p className="mt-5 max-w-[62ch] text-lg leading-relaxed text-[var(--muted-foreground)]">
             {data.hero.subhead}
           </p>
 
-          {/* Disclosure, deliberately before any comparison. */}
-          <p className="mt-8 max-w-[70ch] rounded-xl border border-[var(--border)] bg-[var(--muted)]/40 p-5 text-sm leading-relaxed text-[var(--muted-foreground)]">
-            {data.disclosure}
-          </p>
-        </Container>
-      </Section>
-
-      {/* At a glance */}
-      <Section tone="muted" className="border-y border-[var(--border)]">
-        <Container>
-          <Reveal>
-            <SectionHeading
-              title="At a glance"
-              lead="Free text rather than ticks, because a tick cannot say paid add-on."
-              align="left"
-            />
-          </Reveal>
-          <div className="mt-8 overflow-x-auto">
-            <table className="w-full min-w-[640px] border-collapse text-sm">
-              <thead>
-                <tr className="border-b border-[var(--border)]">
-                  <th scope="col" className="py-3 pr-4 text-left font-semibold text-foreground">
-                    <span className="sr-only">Capability</span>
-                  </th>
-                  {columns.map((c) => (
-                    <th
-                      key={c}
-                      scope="col"
-                      className="py-3 pr-4 text-left font-semibold text-foreground"
-                    >
-                      {c}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {data.table.map((row) => (
-                  <tr key={row.label} className="border-b border-[var(--border)]/60">
-                    <th
-                      scope="row"
-                      className="py-3 pr-4 text-left font-medium text-foreground align-top"
-                    >
-                      {row.label}
-                    </th>
-                    {columns.map((c) => (
-                      <td
-                        key={c}
-                        className="py-3 pr-4 align-top text-[var(--muted-foreground)]"
-                      >
-                        {row.values[c] ?? "Not stated"}
-                      </td>
-                    ))}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <div className="mt-7 flex flex-wrap gap-3">
+            <a
+              href={signupHref("compare")}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex h-12 items-center gap-2 rounded-[var(--radius)] bg-[var(--primary)] px-7 text-base font-medium text-[var(--primary-foreground)] shadow-sm transition-colors duration-[var(--duration-fast)] hover:bg-[var(--primary-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+            >
+              Get started for free
+              <Icon name="ArrowRight" size={18} aria-hidden />
+            </a>
+            <a
+              href="#replaces"
+              className="inline-flex h-12 items-center rounded-[var(--radius)] border border-[var(--border)] bg-card px-7 text-base font-medium text-foreground transition-colors duration-[var(--duration-fast)] hover:bg-[var(--accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+            >
+              See what it replaces
+            </a>
           </div>
-        </Container>
-      </Section>
 
-      {/* Per product: sourced claims and what it does better */}
-      <Section>
-        <Container>
-          <Reveal>
-            <SectionHeading
-              title="The detail, with sources"
-              lead="Every figure below links to the page it came from and the date it was checked. Prices change; if one of these is stale, the link is how you find out."
-              align="left"
-            />
-          </Reveal>
-
-          <div className="mt-10 flex flex-col gap-10">
-            {data.products.map((p) => (
-              <div
-                key={p.name}
-                className="rounded-xl border border-[var(--border)] bg-card p-6 shadow-sm sm:p-8"
+          <ul className="mt-8 flex flex-wrap gap-x-6 gap-y-2">
+            {data.hero.chips.map((chip) => (
+              <li
+                key={chip}
+                className="flex items-center gap-2 text-sm text-[var(--muted-foreground)]"
               >
-                <div className="flex flex-wrap items-baseline justify-between gap-3">
-                  <h3 className="text-xl font-semibold text-foreground">{p.name}</h3>
-                  <a
-                    href={p.url}
-                    target="_blank"
-                    rel="noreferrer noopener"
-                    className="inline-flex items-center gap-1.5 text-sm font-medium text-[var(--primary-pressed)] underline-offset-4 hover:underline"
-                  >
-                    Visit {p.name}
-                    <Icon name="ArrowRight" size={14} aria-hidden />
-                  </a>
-                </div>
-                <p className="mt-3 leading-relaxed text-[var(--muted-foreground)]">{p.summary}</p>
-
-                <ul className="mt-6 flex flex-col gap-4 border-t border-[var(--border)] pt-6">
-                  {p.claims.map((c) => (
-                    <li key={`${c.topic}-${c.claim}`} className="text-sm leading-relaxed">
-                      <span className="text-foreground">{c.claim}</span>{" "}
-                      <a
-                        href={c.sourceUrl}
-                        target="_blank"
-                        rel="noreferrer noopener"
-                        className="whitespace-nowrap text-[var(--muted-foreground)] underline underline-offset-4 hover:text-foreground"
-                      >
-                        Source, checked {c.verifiedOn}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-
-                <div className="mt-6 rounded-lg border border-[var(--border)] bg-[var(--muted)]/40 p-5">
-                  <p className="text-sm font-semibold text-foreground">
-                    What {p.name} does better than WPMgr
-                  </p>
-                  <ul className="mt-3 flex flex-col gap-2">
-                    {p.strengths.map((s) => (
-                      <li key={s} className="text-sm leading-relaxed text-[var(--muted-foreground)]">
-                        {s}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
+                <Icon name="Check" size={14} className="text-[var(--primary)]" aria-hidden />
+                {chip}
+              </li>
             ))}
-          </div>
+          </ul>
         </Container>
       </Section>
 
-      {/* Which one suits you, including the cases where it is not us */}
-      <Section tone="muted" className="border-y border-[var(--border)]">
-        <Container>
-          <Reveal>
-            <SectionHeading title="Which one suits you" align="left" />
-          </Reveal>
-          <div className="mt-8 grid gap-6 md:grid-cols-2">
-            {data.verdicts.map((v) => (
-              <div
-                key={v.heading}
-                className="rounded-xl border border-[var(--border)] bg-card p-6 shadow-sm"
-              >
-                <h3 className="text-base font-semibold text-foreground">{v.heading}</h3>
-                <p className="mt-2 text-sm leading-relaxed text-[var(--muted-foreground)]">
-                  {v.body}
-                </p>
-              </div>
-            ))}
-          </div>
-        </Container>
-      </Section>
+      {/* 2. The matrix. The one section the first version got right. */}
+      <CompareMatrix data={data} />
 
-      {/* FAQ */}
+      {/* 3. Hero visual: what one tool replaces. */}
+      <StackCollapse data={data} />
+
+      {/* 4. The reader computes their own number, and the CTA sits here. */}
+      <CostModelSection data={data} />
+
+      {/* 5. The difference a competitor cannot ship its way out of. */}
+      <DataLocality data={data} />
+
+      {/* 6. Questions, framed around switching. */}
       {data.faq.length > 0 && (
-        <Section>
+        <Section tone="muted" className="border-y border-[var(--border)]">
           <Container className="max-w-3xl">
-            <Reveal>
-              <SectionHeading title="Questions" align="left" />
-            </Reveal>
+            <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+              Questions
+            </h2>
             <dl className="mt-8 flex flex-col gap-6">
               {data.faq.map((f) => (
                 <div key={f.q}>
@@ -215,13 +111,23 @@ export function ComparisonPage({ data }: { data: ComparisonPageData }) {
                 </div>
               ))}
             </dl>
+            <p className="mt-10 text-sm text-[var(--muted-foreground)]">
+              Every figure on this page links to the page it came from.{" "}
+              <Link
+                href={`/compare/${data.slug}/sources`}
+                className="text-[var(--primary-pressed)] underline underline-offset-4"
+              >
+                See all sources and the dates they were checked
+              </Link>
+              .
+            </p>
           </Container>
         </Section>
       )}
 
       <CTABand
         heading="Run your fleet from a dashboard you own."
-        subhead="Open source, self-hostable, and free for as many sites as you like. A hosted tier exists if you would rather not run it."
+        subhead="Open source, self-hostable, unlimited sites. Connect one site and compare on your own fleet before you move anything."
         ctas={[
           {
             label: "Get started for free",
@@ -229,9 +135,6 @@ export function ComparisonPage({ data }: { data: ComparisonPageData }) {
             variant: "primary",
             icon: "ArrowRight",
           },
-          // Points at the repository, not /self-host: that page is Tier 2.9 and does
-          // not exist yet, and shipping a CTA to a 404 is worse than no CTA.
-          { label: "Read the source", href: SITE_CONFIG.github, variant: "secondary", icon: "Github" },
         ]}
       />
     </>

--- a/apps/marketing/components/ui/icon.tsx
+++ b/apps/marketing/components/ui/icon.tsx
@@ -1,6 +1,12 @@
 import {
+  Minus,
+  Lock,
+  Layers,
+  Info,
+  Database,
   Activity,
   ArrowRight,
+  AlertTriangle,
   BadgeCheck,
   BarChart2,
   Briefcase,
@@ -70,6 +76,12 @@ import {
 // Explicit registry: icons referenced by string from content data stay
 // tree-shakeable and type-checked. One stroke family, one weight.
 const REGISTRY: Record<string, LucideIcon> = {
+  Minus,
+  Lock,
+  Layers,
+  Info,
+  Database,
+  AlertTriangle,
   Activity,
   ArrowRight,
   BadgeCheck,

--- a/apps/marketing/lib/content/compare/managewp-vs-mainwp.ts
+++ b/apps/marketing/lib/content/compare/managewp-vs-mainwp.ts
@@ -1,56 +1,49 @@
-// Comparison page data: ManageWP vs MainWP vs WPMgr.
+// Comparison page: ManageWP vs MainWP vs WPMgr.
 //
-// EVERY CLAIM BELOW WAS FETCHED FROM THE NAMED SOURCE AND CARRIES THE DATE IT
-// WAS CHECKED. That is not decoration. This is the only kind of page on the
-// site permitted to name competitors, and the thing that makes it defensible
-// rather than self-serving is that a reader can audit every line.
+// TWO RULES, AND THEY ARE NOT THE SAME RULE. See lib/content/types.ts.
+//   What a CELL says must be true and sourced. Every claim below carries the
+//   URL it came from and the date it was checked, and the page renders both.
+//   Which ROWS appear is positioning and is ours to choose.
 //
-// HOW THIS WAS PRODUCED, so the next person maintains it the same way: four
-// passes. A gathering pass, an adversarial audit, a correction pass, and a
-// final publication gate. The audit caught a FABRICATED QUOTATION in the first
-// draft, a sentence attributed to a vendor page that did not contain it. Do
-// not add a claim here without a source you fetched yourself.
+// A ROW IS A CLAIM WE ARE MAKING, so a row only exists where BOTH competitors
+// are sourced on that axis. Page and object caching is a real WPMgr strength
+// and is deliberately ABSENT from the matrix: we hold no sourced statement
+// about ManageWP on caching, and "not stated" in a competitor cell reads as
+// "they do not have it", which we cannot support. It is argued in the
+// consolidation section instead, where the claim is only about us.
 //
-// THREE RULES THE PASSES KEPT HAVING TO RE-LEARN:
-//   1. Quotations are verbatim. The project's no-dash style rule STOPS at the
-//      quotation mark. Several quotes were silently truncated at exactly the
-//      point where the vendor used an em dash, which both falsifies the quote
-//      and hides that a dash was there.
-//   2. No market-wide comparatives. "A scale very few tools reach" is not
-//      checkable from any single source. State the number; let the reader
-//      compare.
-//   3. Describe what a visitor sees, not what a fetch returned. ManageWP's
-//      add-on pricing is a toggle, not two columns, and it is served showing
-//      bundle prices. Saying "two price columns" described our tool, not the
-//      page.
-//
-// MAINTENANCE: prices change. Re-check every sourceUrl and bump verifiedOn.
-// A stale figure with a confident date is worse than no page.
+// The claims came from four passes: gather, adversarial audit, correction,
+// publication gate. The audit caught a fabricated quotation in the first
+// draft. Do not add a claim here without a source you fetched yourself, and
+// re-check verifiedOn when prices move.
 
 import type { ComparisonPageData } from "@/lib/content/types";
 
 export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
   slug: "managewp-vs-mainwp",
   title: "ManageWP vs MainWP vs WPMgr",
-  metaTitle: "ManageWP vs MainWP vs WPMgr: Hosted, Self-Hosted and Open Source",
+  metaTitle: "ManageWP vs MainWP vs WPMgr: One Dashboard, Compared",
   metaDescription:
-    "A sourced comparison of ManageWP, MainWP and WPMgr for managing multiple WordPress sites. Pricing, hosting model, backups and licensing, each with the page it came from and the date it was checked.",
+    "ManageWP, MainWP and WPMgr compared on where the dashboard runs, where your backups land, and what the bill does as the fleet grows. Every figure sourced and dated.",
   targetQuery: "managewp vs mainwp",
   hero: {
     heading: "ManageWP vs MainWP vs WPMgr",
     subhead:
-      "Three ways to run many WordPress sites from one place: a hosted service, a dashboard you install on your own WordPress site, and an open source control plane. They differ most in where the dashboard runs and who holds your backups.",
+      "The feature lists overlap. What does not overlap is where the dashboard runs, where your backups land, and what the bill does when the fleet grows.",
+    chips: [
+      "AGPL-3.0 control plane",
+      "MIT agent, listed on WordPress.org",
+      "Self-hosted: unlimited sites, no licence fee",
+    ],
   },
-  disclosure:
-    "We build WPMgr, so read this as a comparison written by one of the three. What we can offer instead of neutrality is that every factual claim below links to the page it came from and the date we checked it, including the claims that favour the other two. Where ManageWP or MainWP does something we do not, it says so.",
   products: [
     {
+      key: "managewp",
       name: "ManageWP",
-      summary:
-        "ManageWP is a vendor-hosted WordPress management dashboard, owned by GoDaddy since 2016, that connects to each managed site through the ManageWP Worker plugin. Its core dashboard is free for an unlimited number of websites, and premium capabilities such as backups, uptime monitoring, and client reporting are sold as per-website monthly add-ons, most of which also offer a flat monthly bundle covering up to 100 websites.",
       url: "https://managewp.com/",
       claims: [
       {
+        id: "mw-01",
         topic: "pricing",
         claim:
           "The pricing page presents the free plan under the heading \"Free on unlimited websites, forever\", introduced by the paragraph \"Our free tier is packed with awesomeness! No setup hassle, no hidden fees. 24/7 support. Lightning fast dashboard that performs well with hundreds of websites, free Monthly Backup, and more. We take care of everything, so you can take care of your websites.\" It then lists fifteen included items: Monthly Cloud Backup, Clone & Migrate, Safe Updates, Security Check, Performance Check, Client Reports, Google Analytics, Maintenance Mode, Code Snippets, 1-click Login, Manage Comments, Local Sync, \"Manage Updates, Plugins & Themes\", Collaborate with Teams & Clients, and Template Builder. Clone & Migrate and Safe Updates each carry the footnote \"*requires premium backup\".",
@@ -58,6 +51,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-02",
         topic: "pricing",
         claim:
           "Premium capabilities are sold as individual add-ons priced per website per month rather than as tiered plans. The pricing FAQ answer to \"How are premium add-ons billed?\" reads in full: \"Per-website, per add-on: You only pay for the add-ons you activate on each website. Each premium add-on is priced monthly, per website. You’re billed at the end of the month, based on your actual usage (no upfront payments).\"",
@@ -65,6 +59,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-03",
         topic: "pricing",
         claim:
           "The premium add-on section does not show two side-by-side price columns. It shows one price set at a time, controlled by a single switch whose two labels read \"Per website\" and \"Bundle\". The switch is served checked, which selects Bundle, and every one of the nine add-on cards is served carrying data-price=\"bundle\", with the stylesheet rule .managewp-price-card__price-tags-wrapper[data-price=bundle] .managewp-price-card__price-tag-single{display:none} hiding the per-website amount. A visitor therefore sees bundle pricing on arrival and must flip the switch to \"Per website\" to see the per-site amounts. Directly beneath the switch the page reads: \"For agencies with over 25 websites, a fixed monthly fee for up to 100 websites. Prices shown on a monthly basis, with each bundle covering up to 100 websites. Bundles can stack.\"",
@@ -72,6 +67,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-04",
         topic: "pricing",
         claim:
           "Eight add-ons carry both a bundle price and a per-website price. In the default Bundle view, in the order the page lists them, the flat monthly fee for up to 100 websites is: Backups $75, Uptime Monitor $25, Automated Security Check $25, Automated Performance Check $25, Advanced Client Reports $25, White Label $25, SEO Ranking $25, and Link Monitor $25. After switching to \"Per website\", the same eight cards show a monthly price per website: Backups $2, and $1 each for Uptime Monitor, Automated Security Check, Automated Performance Check, Advanced Client Reports, White Label, SEO Ranking, and Link Monitor. Amounts are printed with a bare \"$\" symbol.",
@@ -79,6 +75,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-05",
         topic: "pricing",
         claim:
           "Vulnerability Protection is the only one of the nine add-ons with no bundle price. It is not visible at all in the default Bundle view: the page carries the rule body.page-id-109 .post-101:has(.managewp-price-card__price-tags-wrapper[data-price=\"bundle\"]){display: none !important;} and post-101 is the Vulnerability Protection card. Flipping the switch to \"Per website\" reveals it at $2 per website per month, and its card carries only that one amount, with no bundle figure.",
@@ -86,6 +83,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-06",
         topic: "pricing",
         claim:
           "Below the nine add-on cards sits a separate card reading \"All-in-one package\" and \"(all bundles combined)\" with a price of $150. That card holds a single price element rather than the two-value structure the add-on cards use, and no stylesheet rule keys off its price state, so $150 is what a visitor sees whichever way the switch is set. No website count is printed on the card itself; the up-to-100-websites scope comes from the paragraph beneath the switch, which reads \"For agencies with over 25 websites, a fixed monthly fee for up to 100 websites. Prices shown on a monthly basis, with each bundle covering up to 100 websites. Bundles can stack.\"",
@@ -93,6 +91,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-07",
         topic: "pricing",
         claim:
           "All figures on the pricing page are monthly, and the page presents no annual price. It states \"Monthly payment cycle, no setup fee, no termination penalties or long term contracts.\" The FAQ adds, answering \"What if I manage many websites?\": \"If you manage a large number of websites, our Bundles offer a flat monthly fee that covers Premium tools for up to 100 websites a month, helping agencies and larger teams save even more.\"",
@@ -100,6 +99,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-08",
         topic: "pricing",
         claim:
           "The Uptime Monitor feature page repeats the add-on price in two labelled blocks. One is labelled \"Regular Price\" and \"Per website / Month\" and shows $1. The other is labelled \"Bundle Price\" and \"Up to 100 websites / Month\" and shows $25. (The labels and the amounts sit in separate page elements, so they are described here rather than quoted as one sentence.)",
@@ -107,6 +107,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-09",
         topic: "pricing",
         claim:
           "The Client Report feature page prices two versions on separate cards. The Free Client Report card ends with \"$0\" followed by \"/ per month\". The Premium Client Report card ends with \"$1\" followed by \"/ per month (or $25/month for up to 100 sites)\". Only the premium card carries the bundle qualifier; the free card does not. In both cases the amount and the qualifier sit in separate page elements, so the rows are described here rather than quoted as one string.",
@@ -114,6 +115,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-10",
         topic: "hosting",
         claim:
           "ManageWP is a vendor-hosted dashboard. The component required on each managed WordPress site is the ManageWP Worker connector plugin, which connects the site to the ManageWP service. The plugin's own installation instructions direct the user to \"Create an account on ManageWP.com\" and then \"Follow the steps to add your first website\", and its changelog entry for version 4.3.0 reads \"New: More secure and flexible communication between the Worker plugin and the ManageWP servers.\" The optional premium Vulnerability Protection add-on additionally installs a second plugin on the site (see the Vulnerability Protection claim below).",
@@ -121,6 +123,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-11",
         topic: "hosting",
         claim:
           "Backup data is held by the vendor. The backup user guide states: \"Backups are stored on our servers for 90 days (or 30 days if you deactivate the tool and 7 days if you deactivate the website).\"",
@@ -128,6 +131,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-12",
         topic: "hosting",
         claim:
           "Customers can select the storage region for backups. The backup feature page states, under the heading \"GDPR-ready storage\": \"Choose US or EU data centers for every website, ensuring compliance and complete control over your data’s location.\" The same page lists among the free tier's features \"Off-site storage with the option to choose between US or EU data centers\".",
@@ -135,6 +139,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-13",
         topic: "hosting",
         claim:
           "ManageWP has been owned by GoDaddy since 2016. The company's about page states: \"On September 6, 2016, we joined forces with GoDaddy, a company that shares our enthusiasm of product quality and customer satisfaction.\"",
@@ -142,6 +147,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-14",
         topic: "install-count",
         claim:
           "The WordPress.org plugin API reports the ManageWP Worker plugin (slug \"worker\") with active_installs of 1,000,000, a rating of 92 out of 100, and 677 total ratings. The ratings breakdown is 602 five-star, 11 four-star, 7 three-star, 7 two-star, and 50 one-star.",
@@ -149,6 +155,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-15",
         topic: "install-count",
         claim:
           "The plugin's WordPress.org listing page displays, in its Meta panel, \"Version 4.9.35\", \"Last updated 3 weeks ago\", \"Active installations 1+ million\", \"WordPress version 3.1 or higher\", and \"Tested up to 7.0.3\", and lists 36 available languages. Its ratings panel displays \"4.6 out of 5 stars.\" and \"602 5-star reviews\".",
@@ -156,6 +163,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-16",
         topic: "install-count",
         claim:
           "The WordPress.org plugin API reports the ManageWP Worker plugin at version 4.9.35, last updated 2026-07-16, tested up to WordPress 7.0.3, requiring WordPress 3.1 or higher, and first added to the directory on 2011-03-10. The API's requires_php field is false, meaning no minimum PHP version is declared. The API lists the plugin's homepage as https://managewp.com and its author as the WordPress.org profile managewp.",
@@ -163,6 +171,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-17",
         topic: "install-count",
         claim:
           "ManageWP's about page displays the figures \"+2M Websites managed with ManageWP\", \"+150K Work hours saved each day\", and \"+65K Loyal customers who swear by ManageWP\". The page also states: \"By January 2012 ManageWP was officially released, and within a month 100,000 websites were being managed with our service.\"",
@@ -170,6 +179,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-18",
         topic: "licensing",
         claim:
           "The ManageWP Worker connector plugin is licensed under the GNU General Public License v3 or later. Its readme, as returned by the WordPress.org plugin API, states: \"ManageWP Worker is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.\"",
@@ -177,6 +187,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-19",
         topic: "features",
         claim:
           "Backups are incremental after the first run. The backup feature page states, under the heading \"Smart, incremental backups\": \"Only changed files and tables are processed after the first full run. This keeps your sites fast and your server load minimal.\"",
@@ -184,6 +195,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-20",
         topic: "features",
         claim:
           "Backups are encrypted. The backup feature page states, under the heading \"Total security\": \"All backups are encrypted in transit and at rest, so your data is protected at every step.\"",
@@ -191,6 +203,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-21",
         topic: "features",
         claim:
           "Free accounts get monthly scheduled backups, and higher frequencies require the premium add-on. The backup user guide states: \"With ManageWP, you can create free monthly backups of your WordPress site, or adjust the backup frequency to weekly, daily, every 12h, every 6h, or every 1h with the premium version.\" It adds: \"Premium users can also run on-demand backups and download backup files.\" and \"By default, only core WordPress files and database tables are backed up.\"",
@@ -198,6 +211,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-22",
         topic: "features",
         claim:
           "The Free Backup card on the backup feature page ends its bullet list with \"Backups stored for 90 days\", followed by the price \"$0\" and \"/ per month\". The same free list contains \"Monthly scheduled backups\", \"Off-site storage with the option to choose between US or EU data centers\", \"One-click restore to recover your site quickly\", \"The ability to exclude specific files and folders from your backups\", and \"Notifications via Email or Slack if your site goes down\". So the documented 90 day retention applies to the free tier as well as the premium one.",
@@ -205,6 +219,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-23",
         topic: "features",
         claim:
           "Cloning and migration require the paid Backup add-on. The Clone user guide states: \"Please note that you must have premium Backups enabled to use the Clone tool.\" Describing cloning to an existing connected site, it says: \"This is an easy way to create staging and production environments.\"",
@@ -212,6 +227,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-24",
         topic: "features",
         claim:
           "Safe Updates provides update rollback and requires the paid Backup add-on. The guide states: \"Then we take a screenshot of your site before the updates, run the updates, check your site’s status code, and take another screenshot after the updates.\" It also states: \"Because we create an on-demand restore point, you must have premium Backups enabled to use Safe Updates.\"",
@@ -219,6 +235,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-25",
         topic: "features",
         claim:
           "Uptime monitoring is a paid add-on. The feature page's bullets read, in full and with ManageWP's own em dashes preserved: \"Checks all your websites every 60 seconds to make sure they’re online and responsive.\", \"Choose to get notified by Email, SMS, or Slack—whatever fits your workflow.\", \"Double-checks any outage before notifying you—so you only get real alerts, never false alarms.\", and \"See uptime percentage, response times, and a detailed check history, all in one place.\"",
@@ -226,6 +243,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-26",
         topic: "features",
         claim:
           "Security Check reports rather than remediates. The feature page carries this note, quoted in full with ManageWP's own em dash preserved: \"Security Check is a messenger, not a cleaner—it alerts you, but does not remove malware.\" Its free bullets include \"Detect malware, blacklist status, and vulnerabilities\", \"Review detailed reports and scan history\", and \"Flag site errors and outdated software\" (ManageWP's wording). Scheduling is premium only: \"Schedule automatic Security Checks (daily or weekly)\" and \"Get real-time notifications via Email or Slack if issues are detected\".",
@@ -233,6 +251,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-27",
         topic: "features",
         claim:
           "Vulnerability Protection is a premium add-on that places a second plugin on the managed site. The guide states: \"If you upgrade to Vulnerability Protection (premium add-on), ManageWP will install the Patchstack Security plugin on your site and automatically activate three security modules: Rapid Mitigation (virtual patches), Advanced Hardening (attack prevention rules), and Community IP Blocklist (blocks malicious IPs), neutralizing threats at the application level even while you’re waiting for an official security update to become available.\" It also states \"Detection is automatically enabled on all sites in your ManageWP dashboard.\" and \"Protection requires activation per site.\"",
@@ -240,6 +259,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-28",
         topic: "features",
         claim:
           "Performance Check uses two scoring engines. The feature page states, under the heading \"Dual-engine accuracy\": \"Scans your sites with both Google PageSpeed and Yahoo! YSlow rulesets for deeper, data-backed insights.\" The premium tier adds \"Schedule automatic Performance Checks (daily or weekly)\", \"Receive instant notifications via email or Slack if your site underperforms\", and \"Choose your preferred scan region for more precise results\", and is priced on that page at \"$1\" then \"/ per month (or $25/month for up to 100 sites)\".",
@@ -247,6 +267,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-29",
         topic: "features",
         claim:
           "Client reports are available free, including a customizable front page, logo branding, a \"Custom Work Section to highlight your unique value\", \"Ready-made templates for quick setup\", \"PDF download for easy sharing\", \"WooCommerce stats\", and \"Localization in 25+ languages\". Free reports carry a \"ManageWP watermark and sent from a ManageWP email address\". The premium tier adds \"Remove the ManageWP watermark for a fully white-labeled look\", \"Send reports from your own email address\", \"Automate report delivery (weekly, bi-weekly, or monthly scheduling)\", \"Bulk generate and send reports to multiple clients at once\", and \"Advanced customization: change colors, fonts, header/footer, and section order\".",
@@ -254,6 +275,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-30",
         topic: "features",
         claim:
           "The dashboard includes an Optimization widget for database housekeeping. The getting started guide states: \"Use the Optimization widget to tidy up your website’s post revisions and spam comments, as well as MB Overhead.\" It adds: \"You can choose what you wish to optimize and what websites to perform this action on or select Optimize All.\" and \"To change the number of post revisions to keep, adjust this option in Advanced Settings\". The guide makes no statement about whether the widget is free or paid.",
@@ -261,6 +283,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-31",
         topic: "features",
         claim:
           "SEO Ranking is a premium add-on covering keyword position tracking and competitor comparison. Its feature page states, in full: \"SEO Ranking brings all your keyword metrics and competitor insights into one clear, easy-to-read list, so you can make informed decisions without digging through spreadsheets or hunting for data.\" Its bullets include \"Tracks your keyword positions: Instantly see how your keywords are performing across all your sites, with clear up/down movement each week\".",
@@ -268,6 +291,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-32",
         topic: "features",
         claim:
           "White Label is listed on the pricing page as its own add-on, separate from and in addition to Advanced Client Reports, and the two carry identical prices: $25 per month for up to 100 websites in the default Bundle view, and $1 per website per month after switching the price control to \"Per website\".",
@@ -275,6 +299,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-33",
         topic: "limits",
         claim:
           "There is no cap on the number of websites on the free tier. The pricing page heads the free plan \"Free on unlimited websites, forever\".",
@@ -282,6 +307,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-34",
         topic: "limits",
         claim:
           "Backup retention on ManageWP servers is 90 days by default, dropping to 30 days if the backup tool is deactivated and 7 days if the website is deactivated. The backup user guide states: \"Backups are stored on our servers for 90 days (or 30 days if you deactivate the tool and 7 days if you deactivate the website).\"",
@@ -289,6 +315,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-35",
         topic: "limits",
         claim:
           "The ManageWP user guide index organises guides by feature and includes no guide for an API. The string \"API\" does not appear anywhere in the text of that index page, which runs to roughly 3,000 characters. This describes the index only and is not a statement about whether an API exists.",
@@ -296,6 +323,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mw-36",
         topic: "support",
         claim:
           "Support is offered to free users. The plugin readme's FAQ, answering \"Do you offer support for free users?\", states: \"Yes. No matter if you’re free or premium user, we are here for you 24/7.\" The pricing page's free tier paragraph likewise contains the sentence \"24/7 support.\"",
@@ -303,32 +331,14 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       ],
-      strengths: [
-      "A genuinely generous free tier. The pricing page heads it \"Free on unlimited websites, forever\" and lists fifteen included capabilities, among them monthly cloud backup, security and performance checks, client reports, 1-click login, code snippets, and team collaboration, at no cost and with no site cap. Source: https://managewp.com/pricing/",
-      "Fifteen years in market. The Worker plugin was added to the WordPress.org directory on 2011-03-10, and ManageWP's about page states that \"By January 2012 ManageWP was officially released, and within a month 100,000 websites were being managed with our service.\" That is roughly fifteen years of contact with real hosting environments, PHP versions, and edge cases, which is exactly the surface area where a young agent plugin gets surprised. Sources: https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request%5Bslug%5D=worker and https://managewp.com/about/",
-      "A large install base. The WordPress.org plugin directory lists the connector at \"Active installations 1+ million\", and the plugin API reports active_installs of 1,000,000. ManageWP's own about page adds \"+2M Websites managed with ManageWP\" and \"+65K Loyal customers who swear by ManageWP\", and its home page carries \"+2 million websites already being managed through ManageWP\". Sources: https://wordpress.org/plugins/worker/, https://managewp.com/about/ and https://managewp.com/",
-      "A strong public review record. WordPress.org plugin directory data, which is the authoritative source for plugin ratings, shows the listing displaying \"4.6 out of 5 stars.\" and \"602 5-star reviews\", across 677 total ratings. Source: https://wordpress.org/plugins/worker/",
-      "Corporate backing and continuity. GoDaddy acquired ManageWP in 2016, per the about page: \"On September 6, 2016, we joined forces with GoDaddy, a company that shares our enthusiasm of product quality and customer satisfaction.\" For an agency choosing a tool to run a client fleet on, that ownership is a real answer to the question of who will still be maintaining this in five years. Source: https://managewp.com/about/",
-      "Active vulnerability mitigation, not just detection. Vulnerability Protection installs the Patchstack Security plugin and activates \"Rapid Mitigation (virtual patches), Advanced Hardening (attack prevention rules), and Community IP Blocklist (blocks malicious IPs)\", so a known exploit can be blocked, in ManageWP's words, \"even while you’re waiting for an official security update to become available.\" Virtual patching is a meaningfully harder capability to build than scanning. Source: https://managewp.com/guide/vulnerabilities/",
-      "Uptime monitoring at 60 second resolution with SMS and Slack delivery, plus outage confirmation. The page reads \"Checks all your websites every 60 seconds to make sure they’re online and responsive.\", \"Choose to get notified by Email, SMS, or Slack—whatever fits your workflow.\", and \"Double-checks any outage before notifying you—so you only get real alerts, never false alarms.\" SMS delivery in particular is real operational infrastructure that a self-hosted project has to build or buy. Source: https://managewp.com/features/uptime-monitor/",
-      "Client reporting maturity. Free reports already include \"Localization in 25+ languages\", ready-made templates, PDF download, a custom work section, and WooCommerce stats; the premium tier adds scheduled delivery, bulk generation to many clients at once, full white labeling, and \"Advanced customization: change colors, fonts, header/footer, and section order\". The page also offers report history: \"See the history of every report sent for each website, and deliver reports in your clients’ preferred language (25+ supported).\" That localization work alone represents a large amount of accumulated effort. Source: https://managewp.com/features/client-report/",
-      "Performance analysis against two established rulesets, with history and regional scanning. The page states \"Scans your sites with both Google PageSpeed and Yahoo! YSlow rulesets for deeper, data-backed insights.\" and \"Access historical results to benchmark improvements and prove the impact of your optimizations.\", and on premium lets you \"Choose your preferred scan region for more precise results\". Source: https://managewp.com/features/performance-scan/",
-      "Broad WordPress compatibility. WordPress.org plugin directory data, the authoritative source for a plugin's declared compatibility, shows the connector declaring \"WordPress version 3.1 or higher\" and \"Tested up to 7.0.3\", and shipping in 36 languages. Keeping a connector working across that span of WordPress versions is a serious and continuing compatibility investment. Source: https://wordpress.org/plugins/worker/",
-      "Compliance-friendly storage with encryption. Backups offer per-website region choice: \"Choose US or EU data centers for every website, ensuring compliance and complete control over your data’s location\", and \"All backups are encrypted in transit and at rest, so your data is protected at every step.\" That gives an agency a ready answer for a client asking where their data sits, without having to operate anything. Source: https://managewp.com/features/backup/",
-      "Efficient backup design, and 90 day retention even on the free tier. The page states \"Only changed files and tables are processed after the first full run. This keeps your sites fast and your server load minimal.\", and the Free Backup card's own bullets end with \"Backups stored for 90 days\" above \"$0\" and \"/ per month\". Source: https://managewp.com/features/backup/",
-      "Breadth of adjacent tooling on one dashboard, including SEO Ranking, which \"brings all your keyword metrics and competitor insights into one clear, easy-to-read list, so you can make informed decisions without digging through spreadsheets or hunting for data.\", plus Link Monitor, Local Sync, Template Builder, Code Snippets, and Google Analytics. Sources: https://managewp.com/features/seo-ranking/ and https://managewp.com/pricing/",
-      "A billing model that carries little commitment risk for the buyer: \"You’re billed at the end of the month, based on your actual usage (no upfront payments)\", under a \"Monthly payment cycle, no setup fee, no termination penalties or long term contracts.\" You can also add or drop a single add-on on a single site. Source: https://managewp.com/pricing/",
-      "24/7 support extended to free users, not only paying ones. The plugin readme FAQ answers \"Do you offer support for free users?\" with \"Yes. No matter if you’re free or premium user, we are here for you 24/7.\", and the pricing page's free tier paragraph contains the sentence \"24/7 support.\" Source: https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request%5Bslug%5D=worker",
-      "Nothing to operate. ManageWP describes itself on its own home page as a way to \"Effortlessly monitor and maintain all your WordPress websites from a single, user-friendly dashboard\", and the site-side footprint is the Worker connector plugin, so the customer runs no database, no control plane, no upgrades, and no backups of the management tool itself. For a small agency without an ops person that is a substantial and legitimate advantage over any self-hosted system. Sources: https://managewp.com/ and https://wordpress.org/plugins/worker/",
-      ],
     },
     {
+      key: "mainwp",
       name: "MainWP",
-      summary:
-        "MainWP is a self-hosted WordPress management system: a Dashboard plugin the customer installs on their own WordPress site, a Child plugin on each managed site, and an optional catalogue of first-party and third-party add-ons. Pricing is flat rather than per site, with a free Essentials bundle, a MainWP Pro subscription billed monthly or yearly, and a one-time Lifetime option.",
       url: "https://mainwp.com/",
       claims: [
       {
+        id: "mn-01",
         topic: "pricing",
         claim:
           "MainWP's pricing page shows two paid products alongside a free tier, not three paid options. Both paid cards are titled \"MAINWP PRO\": one carries the subtitle \"Yearly\" at 199 USD with the meta line \"Billed Yearly\", or the subtitle \"Monthly \" at 29 USD with the meta line \"Billed Monthly\", and the other carries the subtitle \"Lifetime\" at 599 USD with the meta lines \"One-Time Payment\" and \"Always the Best Price - Never Discounted.\" The 29 and the 199 are the same tier under one Monthly/Yearly control, so only one of them is on screen at a time. The Yearly view is the default: the page ships both tables in its markup, its site-wide custom stylesheet (wp-content/uploads/bricks/css/global-custom-css.min.css) contains the rule #mainwp-pricing-table-monthly { display:none; }, and the inline script only swaps the two tables on click. A visitor therefore sees 199 USD unless they click Monthly. Both Pro cards list the bullet \"Manage Unlimited Websites\", so the price is flat and not per site.",
@@ -336,6 +346,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-02",
         topic: "pricing",
         claim:
           "The 199 USD yearly figure is a promotional price. MainWP's own product page for the yearly subscription embeds Product structured data with two unit prices in USD: 199.00 as the offer price and 249.00 carrying priceType https://schema.org/ListPrice, both marked valueAddedTaxIncluded false, with priceValidUntil 2027-12-31. MainWP's public store endpoint for the same product (https://mainwp.com/wp-json/wc/store/v1/products/347661) reports on_sale true, regular_price 24900 and sale_price 19900 at currency_minor_unit 2, and renders the pair as \"Original price was: $249.00.\" and \"Current price is: $199.00.\" A visitor is quoted 199 USD per year by default; 249 USD is the list value behind it. The monthly product (2900) and the Lifetime product (59900) report on_sale false, so neither carries a separate list price.",
@@ -343,6 +354,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-03",
         topic: "pricing",
         claim:
           "The currency is US dollars, established from MainWP's own embedded configuration rather than from any label beside the prices. On the pricing page each amount renders as a bare dollar prefix span followed by the number, giving $29, $199 and $599 with no currency code next to them. The two USD tokens in the document are both first-party configuration: the WooCommerce analytics block reports \"store_currency\":\"USD\" and the AffiliateWP tracking block reports \"currency\":\"USD\". The Product structured data on the individual plan pages independently gives priceCurrency USD.",
@@ -350,6 +362,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-04",
         topic: "pricing",
         claim:
           "MainWP's free tier is named \"ESSENTIALS\", is priced \"Free\", and is subtitled \"Everything you need to get started\". Its card lists five items: \"All Free Add-ons\", \"Any Future Free Add-ons\", \"Critical Security & Performance Updates\", \"Community Support\", and a fifth bullet that reads \"Manage Unlimited SItes\" [sic, capital I in the source]. The two Pro cards list \"All 30+ Existing Pro Add-ons\", \"All Future Add-ons\", \"Critical Security & Performance Updates\", \"Priority Ticket Support\" and \"Manage Unlimited Websites\".",
@@ -357,6 +370,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-05",
         topic: "pricing",
         claim:
           "The Essentials versus Pro comparison table on the same pricing page lists the row \"Number of Websites to Manage\" as Unlimited in both the FREE and the PRO column. The table also words the add-on entitlement as \"Access to all 33+ Existing & New Premium Add-ons with Priority Support\" in its desktop layout and as \"Access to all 33+ Existing & New Premium Extensions with Priority Support\" in its stacked layout, while the Pro cards higher up the same page say \"All 30+ Existing Pro Add-ons\". Support is listed as \"Expert Support via Ticket, Community, & WP forum\" for both columns.",
@@ -364,6 +378,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-06",
         topic: "pricing",
         claim:
           "MainWP frames its model against subscription platforms on the pricing page itself. The page heading reads \"WordPress ® Management without the SaaS Pricing\", with the registered trademark symbol pulled tight against the word by a negative margin so a visitor sees it as WordPress followed immediately by the symbol, a section is headed \"Why should you choose MainWP over a SaaS solution?\", and the first block under it is headed \"No SaaS-Style Pricing\" and reads \"We don’t charge like a SaaS because we aren’t one. Enjoy a simple, straightforward pricing model with our extension bundles.\"",
@@ -371,6 +386,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-07",
         topic: "pricing",
         claim:
           "The pricing page FAQ states a refund and an upgrade policy. On refunds it says \"we offer a 30-day money-back guarantee\" and that a customer who is unhappy and makes contact within 30 days of the initial transaction is refunded. On upgrades it describes a \"90 Day Pro Upgrade Guarantee\": a Monthly subscriber who moves to the Yearly or Lifetime plan within the first three months can receive credit for up to three months of initial payments, the credit is not applied automatically, a coupon code must be requested from support, and the offer cannot be combined with other discounts. The same FAQ confirms the Lifetime price at 599 USD.",
@@ -378,6 +394,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-08",
         topic: "pricing",
         claim:
           "MainWP's individual Pro add-on pages present the add-on as \"Available in the Pro Bundle\" and show no price in the page copy, but the same pages embed Product structured data with an individual USD price and availability https://schema.org/InStock: 69.00 for the MainWP Pro Reports Extension and 39.00 for the MainWP Maintenance Extension. MainWP's public store endpoint reports both products as purchasable and in stock at those prices. We therefore do not claim that Pro add-ons are unavailable separately.",
@@ -385,6 +402,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-09",
         topic: "pricing",
         claim:
           "MainWP states \"We accept PayPal and Stripe.\" as its payment types. Account creation runs through a checkout for the free bundle, of which MainWP says \"There is no charge for the free bundle, and your account is created as soon as the order is completed.\" On renewal after a lapse, MainWP states that a member who cancels and later rejoins pays the current price at that time, and the higher rate if prices have increased.",
@@ -392,6 +410,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-10",
         topic: "hosting",
         claim:
           "MainWP is self-hosted. Its own FAQ describes the product as \"MainWP is a free and open-source WordPress management system that lets you manage multiple WordPress sites from one self-hosted Dashboard.\" and describes three parts: the Dashboard plugin installed on a dedicated WordPress site, the Child plugin installed on each managed site, and optional extensions. The same page answers the meaning of self-hosted with \"Your MainWP Dashboard is hosted on your own WordPress installation, not on our servers.\"",
@@ -399,6 +418,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-11",
         topic: "hosting",
         claim:
           "MainWP states that site data stays in the customer's own database: \"Your Dashboard runs on your WordPress installation, your data stays in your database, and all communication happens directly between your servers.\" A bullet on the same page reads \"No data passes through MainWP servers at any point\". The page also states \"MainWP is released under the GPLv3 license, with all source code available on GitHub.\"",
@@ -406,6 +426,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-12",
         topic: "hosting",
         claim:
           "On telemetry MainWP states \"MainWP stable releases include no telemetry or phone-home functionality.\" and \"The free MainWP Dashboard and Child plugins include no telemetry or tracking by default. MainWP does not know who installs these plugins or where they are installed.\" Three optional third-party services (Usetiful interactive guides, Chatbase chat support, YouTube embeds) are listed as disabled by default and toggleable under MainWP Tools. The same page carries one carve-out: \"MainWP v6 Early Access builds include optional, limited telemetry to help improve the product before stable release.\", which it says can be disabled at any time.",
@@ -413,6 +434,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-13",
         topic: "hosting",
         claim:
           "For customers who buy add-ons, MainWP states \"If you purchase MainWP Add-ons, your MainWP Dashboard domain name and IP address are collected periodically to verify license ownership and API key validity. Child site information is never collected.\" It adds that this data is required for licence verification and is collected only from users who purchase add-ons.",
@@ -420,6 +442,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-14",
         topic: "hosting",
         claim:
           "MainWP's published system requirements page opens with \"MainWP runs on standard WordPress hosting that meets these requirements.\" and gives minimums of WordPress 6.2, WordPress memory limit 40MB, PHP 8.1, PHP safe mode disabled, PHP max execution time 30 seconds, PHP memory limit 256MB, cURL enabled with a 60 second timeout, and MySQL 5.0. Recommended values are latest WordPress, WordPress memory limit 256MB, PHP 8.3, 300 second execution time, PHP memory limit 1024MB, 300 second cURL timeout, and MySQL 5.0+. Only the separate \"Additional Requirements\" section is scoped \"For the Dashboard server\", covering the operating system open file limit, ignore_user_abort, and required PHP functions. Note that this page states a PHP 8.1 minimum while both plugin readme headers on WordPress.org state Requires PHP 7.4; both figures are MainWP's own, published on different surfaces.",
@@ -427,6 +450,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-15",
         topic: "hosting",
         claim:
           "MainWP states that the system is for self-hosted WordPress sites only: \"No, the MainWP system is for self-hosted WordPress sites only. WordPress.com sites cannot install custom plugins required for MainWP to function.\"",
@@ -434,6 +458,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-16",
         topic: "install-count",
         claim:
           "The MainWP Child connector plugin (slug mainwp-child) reports 700,000 active installs on the WordPress.org plugin API, with a rating of 100 out of 100 across 70 ratings (69 five-star, 1 two-star), version 6.1.6, last updated 2026-08-05, tested up to WordPress 7.0.2, requires WordPress 6.2, requires PHP 7.4, and first added to the directory on 2013-08-27.",
@@ -441,6 +466,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-17",
         topic: "install-count",
         claim:
           "The MainWP Dashboard plugin (slug mainwp) reports 20,000 active installs on the WordPress.org plugin API, with a rating of 98 out of 100 across 2,344 ratings (2,248 five-star, 72 four-star, 9 three-star, 5 two-star, 10 one-star), version 6.1.6, last updated 2026-08-05, tested up to WordPress 7.0.2, requires WordPress 6.2, requires PHP 7.4, and first added to the directory on 2014-02-26.",
@@ -448,6 +474,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-18",
         topic: "install-count",
         claim:
           "MainWP publishes its own headline figure on its homepage, which a visitor reads as \"Trusted by 20000+ site owners managing 700000+ sites!\" with both numbers set in bold. That is MainWP counting site owners and sites under management, which is a different measure from the WordPress.org active install counts even though the two headline numbers coincide. For install counts we cite the WordPress.org plugin API, because active installs are measured there rather than stated by the vendor.",
@@ -455,6 +482,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-19",
         topic: "licensing",
         claim:
           "The MainWP Dashboard plugin's WordPress.org readme header declares \"License: GPLv3 or later\" with \"License URI: https://www.gnu.org/licenses/gpl-3.0.html\", alongside Requires at least 6.2, Requires PHP 7.4 and Stable tag 6.1.6. Its title line reads \"MainWP Dashboard: Self-hosted WordPress Management for Agencies\".",
@@ -462,6 +490,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-20",
         topic: "licensing",
         claim:
           "The MainWP Child plugin's WordPress.org readme header declares \"License: GPLv3 or later\" with \"License URI: https://www.gnu.org/licenses/gpl-3.0.html\", alongside Requires at least 6.2, Requires PHP 7.4 and Stable tag 6.1.6. Its title line reads \"MainWP Child - Securely Connects to the MainWP Dashboard to Manage Multiple Sites\".",
@@ -469,6 +498,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-21",
         topic: "licensing",
         claim:
           "The MainWP Dashboard source repository on GitHub (mainwp/mainwp) is published under the GNU General Public License v3.0, reported as GPL-3.0 by the repository's own licence metadata.",
@@ -476,6 +506,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-22",
         topic: "licensing",
         claim:
           "The MainWP Child source repository on GitHub (mainwp/mainwp-child) is published under the GNU General Public License v3.0, reported as GPL-3.0 by the repository's own licence metadata.",
@@ -483,6 +514,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-23",
         topic: "licensing",
         claim:
           "MainWP states \"All extensions are licensed under the GPL, just like WordPress. Extensions can be used on unlimited sites.\" and that \"Support and update licenses are separate and valid for the duration of your MainWP membership (Monthly, Yearly, or Lifetime).\" On multiple Dashboards it states \"Yes. Extensions are installed on the MainWP Dashboard (not child sites), and you can install them on as many Dashboards as you have.\" and it states that extensions may be used for client work without violating the licence.",
@@ -490,6 +522,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-24",
         topic: "licensing",
         claim:
           "On cancellation MainWP states: \"If you cancel, extensions continue working with the last version you had—you just lose access to updates and support.\" It also states \"The Lifetime membership does not expire.\" (The dash inside that first sentence is MainWP's own punctuation, reproduced as published.)",
@@ -497,6 +530,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-25",
         topic: "features",
         claim:
           "MainWP ships no native backup engine and says so directly: \"MainWP focuses on site management rather than building a native backup system.\" The page gives two alternatives instead, backup extensions that connect established backup providers, and API Backups that trigger a backup at the hosting provider. On the second it carries the heading \"API Backups (Free)\" and states that API Backups \"trigger backups directly through your hosting provider at no additional cost\".",
@@ -504,6 +538,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-26",
         topic: "features",
         claim:
           "MainWP's backup extensions drive third-party backup plugins. The documentation lists five in a plain table with no tier labels: BackWPup, BackupBuddy, Time Capsule, UpdraftPlus and WPVivid. Incremental behaviour, storage destinations and encryption are properties of whichever third-party plugin is driven, not of MainWP.",
@@ -511,6 +546,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-27",
         topic: "features",
         claim:
           "The tier labels for those backup add-ons live on MainWP's add-ons listing, not in the documentation. As shown on the All Add-ons tab on 2026-08-06, \"BackWPup Integration\", \"MainWP Solid Backups Extension\", \"MainWP Time Capsule Extension\" and \"MainWP UpdraftPlus Extension\" each carry the label Essential, and \"WPvivid Backup for MainWP\" carries the labels Third-Party and Free. Note the naming difference on MainWP's own surfaces: the listing calls it \"MainWP Solid Backups Extension\" while the documentation table still says \"BackupBuddy\" for the same add-on at /add-on/mainwpbuddy/.",
@@ -518,6 +554,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-28",
         topic: "features",
         claim:
           "MainWP API Backups run against the host rather than the site: \"API Backups lets you create backups directly through your hosting provider, cloud manager, or VPS without installing backup plugins on your sites.\" The supported provider table lists cPanel (\"Native and WP Toolkit backups\"), Plesk (\"WP Toolkit backups\"), Kinsta, Cloudways (\"Automatic site assignment\"), GridPane (\"Requires Owner Account with Developer Plan or higher\"), Vultr, Akamai (Linode) and DigitalOcean. The same page states that MainWP API Backups do not use custom storage locations and that backups are stored wherever the host or cloud manager has configured.",
@@ -525,6 +562,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-29",
         topic: "features",
         claim:
           "MainWP has automatic update rollback, introduced in MainWP 5.1 and integrating with the WordPress core rollback available in WordPress 6.3 and above. It is automatically active on all update pages, triggers when an update fails, restores the previous version automatically, and shows a Dashboard notice. MainWP states plainly: \"MainWP does not support on-demand rollback to previous versions.\" The suggested alternatives are downloading a previous version from wordpress.org and installing by upload, or storing premium plugin versions in the Favorites Extension.",
@@ -532,6 +570,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-30",
         topic: "features",
         claim:
           "Uptime monitoring is built into the MainWP Dashboard. Documented defaults: Enable Uptime Monitoring is Disabled, Monitor Type is HTTP(s) with Ping and Keyword Monitoring as the alternatives, Method is HEAD, Monitor Interval is 60m on a slider running 5m, 10m, 15m, 30m, 45m and then 1h through 24h, Timeout is 60s, Down Confirmation Check is Enabled, and the up-status codes default to 200,201,202,203,204,205,206. A separate Site Health Monitoring section reads the WordPress core Site Health result from each child site. Scheduled checks require WP Cron or a server cron.",
@@ -539,6 +578,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-31",
         topic: "features",
         claim:
           "MainWP lists uptime monitoring among its free features, with the bullets \"Track uptime and downtime across all connected sites\", \"Choose from HTTP, Ping, and Keyword-based monitors\", \"Receive email alerts if a site goes down\" and \"No third-party service required\".",
@@ -546,6 +586,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-32",
         topic: "features",
         claim:
           "The separate MainWP Advanced Uptime Monitor Integration is a different design from the built-in monitor, and is free. Its page carries the labels Essential, \"Available in the Free Bundle\" and \"Available in the Pro Bundle\", and its FAQ answers \"Yes, the Advanced Uptime Monitor is completely free for all MainWP users.\" Rather than monitoring directly, it drives third-party services: \"This extension integrates with top monitoring platforms like Uptime Robot, NodePing, Site24x7, and Better Uptime.\" Its Additional Info states \"This extension requires API Key from one of the supported API integrations.\"",
@@ -553,6 +594,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-33",
         topic: "features",
         claim:
           "Client reporting is a Pro add-on. The MainWP Pro Reports Extension page carries the label Pro and the line \"Available in the Pro Bundle\". Its Additional Info notes that the add-on requires the MainWP Child Reports plugin to be installed on child sites, that the Child Reports plugin needs PHP 7.4 or higher, and that it can be installed on sites directly from the WordPress.org plugin repository.",
@@ -560,6 +602,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-34",
         topic: "features",
         claim:
           "Database cleanup is a Pro add-on. The MainWP Maintenance Extension page carries the label Pro and the line \"Available in the Pro Bundle\". It describes removing post revisions, auto drafts, trash posts, transients and spam comments across multiple sites, scheduled runs, and one-click database optimisation. Its Additional Info carries the caveat \"The Database optimization feature is not recommended for child sites that are running on MariaDB database\".",
@@ -567,6 +610,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-35",
         topic: "features",
         claim:
           "Staging is a Pro add-on. The MainWP Staging Extension page carries the label Pro and the line \"Available in the Pro Bundle\", and states that it integrates with the WP Staging plugin, described on the page as \"a free WordPress plugin essential for creating staging sites\". Pushing changes back to live is not available through the extension. Asked \"Can I use the MainWP Staging Extension to push changes from my staging site to my live site?\", MainWP answers: \"No. For pushing changes from Staging to Live sites, WP Staging Pro plugin is required, but MainWP Staging Extension works only with the free version.\" The same page states there is no limit to the number of staging sites that can be created.",
@@ -574,6 +618,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-36",
         topic: "features",
         claim:
           "Security scanning is split across free and paid add-ons on MainWP's own listing, as labelled on the All Add-ons tab on 2026-08-06. Labelled Essential: MainWP Vulnerability Checker Extension, Jetpack Protect Integration, MainWP Sucuri Extension, Patchstack Integration. Labelled Pro: Wordfence Integration, Solid Security Integration, Jetpack Scan Integration, Virusdie Integration. The performance and caching add-ons MainWP Cache Control Integration, WP Rocket Integration and Lighthouse Integration each carry the label Pro.",
@@ -581,6 +626,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-37",
         topic: "features",
         claim:
           "MainWP's own performance category page lists four add-ons on 2026-08-06, and they are not uniformly paid. MainWP Cache Control Integration, MainWP Maintenance Extension and WP Rocket Integration each carry the label Pro, and WP Compress for MainWP carries the labels Third-Party and Free. Lighthouse Integration is not filed under this category, and MainWP Maintenance Extension is, so MainWP's category taxonomy and our own reading of the add-on labels do not line up exactly.",
@@ -588,6 +634,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-38",
         topic: "features",
         claim:
           "The MainWP Vulnerability Checker Extension depends on an external vulnerability database: it \"uses either the free MainWP NVD API or the paid WPScan Vulnerability Database API to bring you information about vulnerable plugins and themes on your Child Sites\". Its page carries the labels Essential, \"Available in the Free Bundle\" and \"Available in the Pro Bundle\", and it documents an \"Ignore\" function for dismissing false positives.",
@@ -595,6 +642,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-39",
         topic: "features",
         claim:
           "Counting the labels on MainWP's own add-ons listing on 2026-08-06, the All Add-ons tab holds 64 cards: 38 labelled Pro, 13 labelled Essential, and 13 labelled Third-Party, with every Third-Party card also carrying a Free tag. The page's only grouping control is a three tab set whose tabs read \"All Add-ons\", \"Extensions\" and \"Integrations\"; Essential, Pro and Third-Party are labels printed on each card, not filters. On the same date the Extensions tab held 23 cards (20 Pro, 3 Essential) and the Integrations tab held 40 (17 Pro, 10 Essential, 13 Third-Party).",
@@ -602,6 +650,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-40",
         topic: "features",
         claim:
           "MainWP's free features page lists, at no cost: bulk or individual updates for WordPress core, plugins, themes and translations plus automatic updates and \"Check for abandoned plugins & themes\"; plugin and theme install, activate, deactivate and delete; \"1-Click access to sites (Password-less login)\"; site tags, notes, export and import, and a site health check; uptime monitoring; client profiles with tags, the ability to create your own client fields, and suspend or unsuspend; a cost tracker; user management including \"Update administrator passwords\"; post and page publishing, editing, unpublishing and deletion; and MainWP Browser Extension support connecting through the MainWP REST API.",
@@ -609,6 +658,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-41",
         topic: "features",
         claim:
           "MainWP ships a REST API v2 at /wp-json/mainwp/v2/ with Bearer token authentication, key scopes of Read for GET and Write & Delete for POST, PUT, PATCH and DELETE, an optional v1 compatibility mode that issues a legacy Consumer Key and Secret, and a global /batch endpoint. Endpoint categories are sites, clients, tags, updates, costs, users, settings, monitoring, API keys, posts, pages and batch. A machine-readable OpenAPI 3.1.0 description of the full v2 API is published at https://raw.githubusercontent.com/mainwp/docs/main/api-reference/openapi.yaml, and MainWP directs integrators to \"Use the MainWP Postman collection as the source of truth for request and response schemas.\"",
@@ -616,6 +666,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-42",
         topic: "features",
         claim:
           "MainWP publishes an MCP Server, described on its overview page as a way to \"Manage your WordPress network by talking to Claude, Cursor, or any MCP-capable AI assistant.\" The page states it is \"a small program that runs on your own computer, alongside your AI tool\" and that \"Nothing new is installed on your Dashboard or your child sites; it talks to the Dashboard the same way your browser does, over HTTPS with credentials you control and can revoke at any time.\" On permissions it states that the MCP server \"exposes only the tools you permit and enforces that policy on every call\", and on safety that \"Destructive operations stop at a confirmation gate before anything runs.\"",
@@ -623,6 +674,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-43",
         topic: "features",
         claim:
           "MainWP publishes per-client configuration for the MCP server, described on the page itself as \"Configuration for Claude Desktop, Claude Code, Cursor, VS Code Copilot, OpenAI Codex, ZenCoder, and other MCP hosts.\" Each client runs the same command, npx -y @mainwp/mcp, with the Dashboard URL, a WordPress username and a WordPress Application Password supplied through the environment, and the page also documents pointing separate server entries at separate credential folders for multiple Dashboards.",
@@ -630,6 +682,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-44",
         topic: "features",
         claim:
           "The MainWP MCP server is open source. The mainwp/mainwp-mcp repository on GitHub is published under the GNU General Public License v3.0 (GPL-3.0) and is described there as \"MCP Server for MainWP Dashboard - Exposes MainWP Abilities API as MCP tools\". The hyphen in that description is a plain hyphen in the repository metadata, reproduced as published.",
@@ -637,6 +690,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-45",
         topic: "features",
         claim:
           "The Security Measures section of MainWP's security overview page lists six items: \"MainWP Dashboard and child sites communicate using OpenSSL encryption. If OpenSSL is unavailable or misconfigured, MainWP uses PHPSecLib as a fallback.\"; a single Dashboard lock, \"A child site can only connect to one MainWP Dashboard at a time.\"; \"WordPress passwords are not stored on the MainWP Dashboard.\"; regular security testing, \"Penetration tests are performed through white hat security programs on PatchStack and HackerOne.\"; in-house development; and self-hosted architecture. A later section of the same page documents a further mechanism: \"MainWP Child requires at least one connection authentication method for the initial connection: Password Authentication, Unique Security ID, or both.\" Note that on this page PHPSecLib is named as a transport fallback for OpenSSL, not as the cipher for stored credentials.",
@@ -644,6 +698,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-46",
         topic: "features",
         claim:
           "Request signing is documented separately. On first connection the Dashboard generates a 2048 bit public and private key pair with openssl_pkey_new(), the public key is saved on both the child site and the Dashboard, and the private key is encrypted and saved only on the Dashboard. Every later request is signed with openssl_sign() and verified with openssl_verify(), and \"The child site only processes requests with valid signatures that match its stored public key.\" Requests carry the username, the function name and a mainwpsignature parameter, and MainWP escapes all request parameter values before sending.",
@@ -651,6 +706,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-47",
         topic: "features",
         claim:
           "Stored third-party credentials use a different cipher again: \"MainWP uses AES GCM encryption via PHPSecLib to securely store third-party API keys and login credentials in the Dashboard database.\" MainWP says this was introduced in version 4.5, covers extension API keys, third-party service logins and internal authentication tokens, uses a 32 character key and a 16 character initialisation vector generated with the PHPSecLib Random class, and stores the encryption key in a separate Key File outside the database. It states explicitly that this does not cover data created by third-party plugins on child sites.",
@@ -658,6 +714,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-48",
         topic: "features",
         claim:
           "Private key encryption at rest arrived later: \"MainWP Dashboard version 5.3 introduces encryption for private keys stored in your database.\" Existing connections are encrypted through a one-time \"Encrypt Keys Now\" prompt after upgrading, new child sites have their private keys encrypted automatically, and the mechanism reuses the AES GCM framework introduced in 4.5 with the key held in a separate Key File.",
@@ -665,6 +722,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-49",
         topic: "limits",
         claim:
           "There is no site cap on any MainWP tier. MainWP states \"You can manage an unlimited number of child sites. However, how many sites a single Dashboard can control depends on your hosting quality.\"",
@@ -672,6 +730,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-50",
         topic: "limits",
         claim:
           "MainWP publishes hosting guidance by network size rather than a tested site ceiling: up to 30 sites on shared hosting (\"Standard shared plans work well\"), 31 to 100 sites on reseller hosting with additional server memory and the \"Optimize data loading\" setting enabled, and 100+ sites on a VPS with at least 512MB PHP and WordPress memory and the same setting enabled.",
@@ -679,6 +738,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-51",
         topic: "limits",
         claim:
           "Built-in monitoring history retention defaults to 180 days. The documented options are keep forever with no automatic cleanup, 30 days, 90 days, 180 days and 365 days. The same page notes a \"Maximum simultaneous uptime monitoring requests\" setting under Advanced Settings.",
@@ -686,6 +746,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-52",
         topic: "limits",
         claim:
           "MainWP does not officially support WordPress Multisite: \"We have reports from users that it works, but we do not officially test on or support WordPress Multisite installations.\" The same FAQ states \"We do not recommend direct customization of MainWP core code, and we do not support modified installations.\", pointing developers to its own extension documentation instead.",
@@ -693,6 +754,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       {
+        id: "mn-53",
         topic: "limits",
         claim:
           "MainWP's REST API documentation warns about reachability: \"Your MainWP Dashboard URL must be reachable from the system sending API requests. A local-only Dashboard is typically not reachable by external API clients.\" It also notes that the v2 Bearer token is shown once and cannot be revealed later, and that API access stays active while at least one API key is enabled.",
@@ -700,137 +762,221 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         verifiedOn: "2026-08-06",
       },
       ],
-      strengths: [
-      "Install base. The MainWP Child connector reports 700,000 active installs on the WordPress.org plugin API (https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request[slug]=mainwp-child, checked 2026-08-06). That is 700,000 sites of real field exposure across hosts, PHP versions and plugin combinations.",
-      "Years in market. The same API records the Child plugin in the directory since 2013-08-27 and the Dashboard since 2014-02-26, which is close to thirteen years for the Child plugin and twelve and a half for the Dashboard as of 2026-08-06. The Dashboard carries 2,344 public ratings at 98 out of 100, a publicly auditable satisfaction record spanning that whole period.",
-      "Extension ecosystem. Counted on MainWP's own listing on 2026-08-06 (https://mainwp.com/mainwp-add-ons/), the All Add-ons tab holds 38 Pro, 13 Essential and 13 free third-party add-ons. The integration surface covers products we have no connector for at all, among them Wordfence, Sucuri, Patchstack, Jetpack Protect and Jetpack Scan, Solid Security, Virusdie, WP Rocket, WP Compress, Yoast SEO, SEOPress, Matomo, Fathom, Google Analytics, Google Search Console, Lighthouse, Atarim, Termageddon, WP Activity Log, WooCommerce and Pressable. An agency already standardised on any of those can drive it from the MainWP Dashboard on day one.",
-      "Free API Backups against the host rather than the site. MainWP's documentation carries the heading \"API Backups (Free)\" and says they \"trigger backups directly through your hosting provider at no additional cost\" (https://docs.mainwp.com/sites/backups/why-doesnt-mainwp-include-backups-in-the-dashboard), with cPanel, Plesk, Kinsta, Cloudways, GridPane, Vultr, Akamai (Linode) and DigitalOcean supported and nothing installed on the child site. We rate that a genuinely good design choice for anyone whose host already backs up well.",
-      "The free tier is not a trial. MainWP's own comparison table lists \"Number of Websites to Manage\" as Unlimited in both the FREE and the PRO column (https://mainwp.com/signup/), and MainWP's free features page lists bulk updates, one-click passwordless login, uptime monitoring with HTTP, Ping and Keyword monitor types, client profiles, a cost tracker, user management and content management (https://mainwp.com/mainwp-free-features/).",
-      "Flat pricing that does not scale with the fleet. 199 USD per year (list 249 USD, currently discounted) or 599 USD once, for unlimited sites, so an agency running 400 sites pays what an agency running 12 pays. MainWP's own framing on the page is \"We don’t charge like a SaaS because we aren’t one.\" (https://mainwp.com/signup/).",
-      "Shipped, documented AI tooling. MainWP publishes an MCP Server with a Claude Code plugin, a prompt cookbook, a tool-restriction guide, a token-usage guide, a safety and permissions page and a security model page, all indexed in their own documentation manifest (https://docs.mainwp.com/llms.txt). Destructive operations stop at a confirmation gate before anything runs (https://docs.mainwp.com/mcp-server/overview), the server is GPL-3.0 open source (https://github.com/mainwp/mainwp-mcp), and this is more mature AI integration than we currently offer.",
-      "A mature, well-specified REST API. v2 with Bearer tokens, Read versus Write & Delete key scopes, a /batch endpoint, a v1 compatibility path so existing integrations keep working, a published OpenAPI 3.1.0 specification, and a Postman collection that MainWP itself calls the source of truth for request and response schemas (https://docs.mainwp.com/api-reference/rest-api/overview).",
-      "Documented security engineering with outside eyes on it. OpenSSL encrypted transport with PHPSecLib as a fallback, a one-Dashboard-per-site lock, no stored WordPress passwords, at least one connection authentication method required on first connect, and regular penetration tests: \"Penetration tests are performed through white hat security programs on PatchStack and HackerOne.\" (https://docs.mainwp.com/getting-started/how-secure-is-the-mainwp-plugin). Separately documented are openssl_sign request signing (https://docs.mainwp.com/advanced/miscellaneous/mainwp-connection-security), AES GCM via PHPSecLib for stored third-party API keys (https://docs.mainwp.com/advanced/security/how-mainwp-stores-3rd-party-api-keys-and-other-sensitive-data), and private key encryption at rest added in Dashboard 5.3 (https://docs.mainwp.com/advanced/openssl-keys-encryption). Running a standing HackerOne programme means outside researchers have a documented way in.",
-      "Support and community depth. The Pro card lists \"Priority Ticket Support\" and the free card lists \"Community Support\", with the comparison table wording it \"Expert Support via Ticket, Community, & WP forum\" (https://mainwp.com/signup/). MainWP states that product support is provided via support tickets and email (https://docs.mainwp.com/getting-started/pre-install-faq). It also links two community channels first-party from the header and footer of every page we fetched on mainwp.com, including the pricing, add-ons and free features pages: a Discord server, linked with the anchor text \"Discord\" and the footer aria-label \"MainWP Community Discord Server\" pointing at https://mainwpinvite.com/, and its own forum at https://community.mainwp.com/, linked with the aria-label \"MainWP Community Forum\" (https://mainwp.com/). That is a decade and more of accumulated public support history plus two live channels.",
-      "Documentation quality. Every documentation page is served as raw markdown at the same path with a .md suffix, and the whole site is indexed in a published llms.txt (https://docs.mainwp.com/llms.txt), so the documentation is machine-readable by design. Settings are documented down to individual defaults and slider values.",
-      "Update safety beyond the rollback itself. MainWP states \"The Regression Testing add-on monitors your child sites for unexpected changes after updates, providing an additional layer of protection.\" (https://docs.mainwp.com/sites/updates/does-mainwp-have-safe-updates), which is a genuinely different and complementary check to restoring a failed install.",
-      "Honest scoping on backups. MainWP says outright \"MainWP focuses on site management rather than building a native backup system.\" and integrates BackWPup, BackupBuddy, Time Capsule, UpdraftPlus and WPVivid instead (https://docs.mainwp.com/sites/backups/why-doesnt-mainwp-include-backups-in-the-dashboard). We think that is a defensible engineering decision, and it lets a customer keep whichever backup tool they already trust.",
-      "Licence generosity. Extensions are GPL, usable on unlimited sites and on as many Dashboards as the customer runs, explicitly permitted for client work, and MainWP states that after cancellation \"extensions continue working with the last version you had\" (https://docs.mainwp.com/getting-started/pre-install-faq).",
-      "A stated refund window. The pricing page FAQ offers a 30-day money-back guarantee on what MainWP itself calls non-tangible digital goods, and a \"90 Day Pro Upgrade Guarantee\" crediting up to three months of Monthly payments toward a Yearly or Lifetime upgrade (https://mainwp.com/signup/).",
+    },
+  ],
+  // GROUP ORDER IS LOAD BEARING. Parity first: it costs nothing, and it answers
+  // "the new one must be missing things" before a reader forms the thought.
+  matrix: [
+    {
+      label: "All three do this",
+      rows: [
+        {
+          label: "Bulk updates across sites",
+          cells: {
+            wpmgr: { value: "Yes, with a pre-update snapshot and rollback", tone: "included" },
+            managewp: { value: "Yes. Safe Updates adds a restore point and needs premium Backups", tone: "included", cites: ["mw-20"] },
+            mainwp: { value: "Yes, free, including automatic updates", tone: "included", cites: ["mn-30"] },
+          },
+        },
+        {
+          label: "Uptime monitoring",
+          cells: {
+            wpmgr: { value: "Built in and free, with TLS expiry checks", tone: "included" },
+            managewp: { value: "Add-on: $1 per site per month, or $25 for up to 100 sites", tone: "paid", cites: ["mw-08"] },
+            mainwp: { value: "Built in and free, off until enabled", tone: "included", cites: ["mn-33"] },
+          },
+        },
+        {
+          label: "Client reports",
+          cells: {
+            wpmgr: { value: "Built in, white label, with a client portal", tone: "included" },
+            managewp: { value: "Free with a ManageWP watermark. Advanced is $1 per site per month", tone: "paid", cites: ["mw-09"] },
+            mainwp: { value: "Pro Reports add-on, needs a second plugin on each site", tone: "paid", cites: ["mn-38"] },
+          },
+        },
+        {
+          label: "One-click login to wp-admin",
+          cells: {
+            wpmgr: { value: "Yes, single use and audited", tone: "included" },
+            managewp: { value: "Yes, in the free tier", tone: "included", cites: ["mw-01"] },
+            mainwp: { value: "Yes, in the free tier", tone: "included", cites: ["mn-30"] },
+          },
+        },
+      ],
+    },
+    {
+      label: "Where the dashboard runs",
+      rows: [
+        {
+          label: "Who hosts the dashboard",
+          cells: {
+            wpmgr: { value: "You do. A hosted tier exists if you prefer", tone: "included" },
+            managewp: { value: "The vendor. You install a connector plugin on each site", tone: "neutral", cites: ["mw-10"] },
+            mainwp: { value: "You do, as a plugin on a WordPress site you control", tone: "included", cites: ["mn-11"] },
+          },
+        },
+        {
+          label: "Where backups are stored",
+          cells: {
+            wpmgr: { value: "Storage you choose, encrypted before it leaves the site", tone: "included" },
+            managewp: { value: "The vendor's servers, with a US or EU region choice", tone: "neutral", cites: ["mw-11", "mw-12"] },
+            mainwp: { value: "Wherever the third-party plugin you configure sends them", tone: "neutral", cites: ["mn-19"] },
+          },
+        },
+        {
+          label: "Source you can read",
+          cells: {
+            wpmgr: { value: "All of it. AGPL-3.0 control plane, MIT agent", tone: "included" },
+            managewp: { value: "The connector plugin, GPLv3. The dashboard is not published", tone: "partial", cites: ["mw-16"] },
+            mainwp: { value: "Dashboard and child plugin, GPLv3, on GitHub", tone: "included", cites: ["mn-46"] },
+          },
+        },
+      ],
+    },
+    {
+      label: "What the bill does as the fleet grows",
+      rows: [
+        {
+          label: "Pricing shape",
+          cells: {
+            wpmgr: { value: "Free and unlimited when self-hosted", tone: "included" },
+            managewp: { value: "Per site, per add-on, per month, with bundle options", tone: "paid", cites: ["mw-02", "mw-04"] },
+            mainwp: { value: "Flat, for unlimited sites", tone: "paid", cites: ["mn-01"] },
+          },
+        },
+        {
+          label: "Cost of a backup at 25 sites",
+          cells: {
+            wpmgr: { value: "$0", tone: "included" },
+            managewp: { value: "$50 a month at $2 per site, or $75 for the bundle", tone: "paid", cites: ["mw-04"] },
+            mainwp: { value: "Included, but you supply the backup plugin", tone: "partial", cites: ["mn-19"] },
+          },
+        },
+      ],
+    },
+    {
+      label: "Built in, or assembled",
+      rows: [
+        {
+          label: "Backup engine",
+          cells: {
+            wpmgr: { value: "Built in. Incremental, client-side encrypted", tone: "included" },
+            managewp: { value: "Built in. Incremental, encrypted in transit and at rest", tone: "included", cites: ["mw-17", "mw-18"] },
+            mainwp: { value: "None of its own. It drives third-party backup plugins", tone: "partial", cites: ["mn-19"] },
+          },
+        },
+        {
+          label: "Security scanning",
+          cells: {
+            wpmgr: { value: "Built in: hardening, file integrity, vulnerability matching", tone: "included" },
+            managewp: { value: "Free check reports only. Vulnerability Protection is $2 per site per month and installs a second plugin", tone: "paid", cites: ["mw-24"] },
+            mainwp: { value: "Add-ons, some free and some paid", tone: "paid", cites: ["mn-24"] },
+          },
+        },
+        {
+          label: "Database cleaning",
+          cells: {
+            wpmgr: { value: "Built in, with orphan classification and a preview", tone: "included" },
+            managewp: { value: "An optimization widget in the dashboard", tone: "included", cites: ["mw-28"] },
+            mainwp: { value: "The Maintenance add-on, labelled Pro", tone: "paid", cites: ["mn-27"] },
+          },
+        },
       ],
     },
   ],
-  table: [
-  {
-    label: "Dashboard hosting",
-    values: {
-      WPMgr: "Self-hosted, or a hosted tier if you would rather not run it",
-      ManageWP: "Vendor-hosted SaaS; per-site footprint is the ManageWP Worker connector plugin",
-      MainWP: "Self-hosted on the customer's own WordPress site; no vendor-hosted version published",
-    },
+  replaces: {
+    heading: "One tool, or eight line items",
+    subhead:
+      "Backups, security, caching, images, database, uptime, reports and updates. On WPMgr these are one system with one login and one bill. Self-hosted, that bill is nothing.",
+    items: [
+      { icon: "DatabaseBackup", label: "Backups and restore" },
+      { icon: "ShieldCheck", label: "Security and hardening" },
+      { icon: "Zap", label: "Page and object cache" },
+      { icon: "ImageDown", label: "Image optimization" },
+      { icon: "Database", label: "Database cleaning" },
+      { icon: "Activity", label: "Uptime monitoring" },
+      { icon: "FileText", label: "Client reports" },
+      { icon: "RefreshCw", label: "Updates and rollback" },
+    ],
   },
-  {
-    label: "Entry price",
-    values: {
-      WPMgr: "Free and unlimited when self-hosted; hosted tiers start free",
-      ManageWP: "$0/month core dashboard; premium add-ons from $1 per website per month",
-      MainWP: "199 USD/yr promo (list 249 USD/yr), 29 USD/mo, or 599 USD once; unlimited sites",
-    },
+  cost: {
+    heading: "Move the slider to your fleet size",
+    subhead:
+      "Computed from each vendor's own published prices. ManageWP takes the cheaper of per site or bundle, including their all-in-one package. MainWP is flat. Self-hosted WPMgr is free at every size.",
+    models: [
+      {
+        productKey: "managewp",
+        label: "ManageWP, backups plus uptime plus reports",
+        perSite: 4,
+        bundle: 125,
+        bundleCovers: 100,
+        period: "month",
+        note: "Backups $2, uptime $1, advanced reports $1 per site per month. Bundles are $75 plus $25 plus $25 for up to 100 sites, and their all-in-one package covering every bundle is $150.",
+        cites: ["mw-04", "mw-06"],
+      },
+      {
+        productKey: "mainwp",
+        label: "MainWP Pro",
+        perSite: 0,
+        flat: 199,
+        period: "year",
+        note: "Flat for unlimited sites. You still supply and configure a backup plugin.",
+        cites: ["mn-01", "mn-19"],
+      },
+      {
+        productKey: "wpmgr",
+        label: "WPMgr, self-hosted",
+        perSite: 0,
+        flat: 0,
+        period: "year",
+        note: "Unlimited sites, every feature, no licence fee. You run the control plane.",
+      },
+    ],
   },
-  {
-    label: "Free tier",
-    values: {
-      WPMgr: "Self-hosting is free for any number of sites, with no feature gate",
-      ManageWP: "Unlimited websites, forever; 15 listed features including monthly cloud backup",
-      MainWP: "Yes, Essentials bundle: unlimited sites, all free add-ons, community support",
-    },
+  locality: {
+    heading: "Where your fleet data actually lives",
+    subhead:
+      "This is the one difference nobody closes by shipping a feature next quarter.",
+    lanes: [
+      {
+        productKey: "wpmgr",
+        path: ["Your sites", "Your control plane", "Your storage"],
+        note: "Backups are encrypted on the site before they leave it, so the control plane only ever holds ciphertext, even when you use the hosted tier.",
+      },
+      {
+        productKey: "managewp",
+        path: ["Your sites", "Vendor dashboard", "Vendor storage"],
+        note: "The dashboard and the backups are the vendor's, with a US or EU region choice.",
+        cites: ["mw-10", "mw-11", "mw-12"],
+      },
+      {
+        productKey: "mainwp",
+        path: ["Your sites", "Your WordPress dashboard", "Plugin decides"],
+        note: "The dashboard is yours. Where backups land depends on which third-party plugin you configure.",
+        cites: ["mn-11", "mn-19"],
+      },
+    ],
   },
-  {
-    label: "Backups",
-    values: {
-      WPMgr: "Built in, incremental, client-side encrypted, to storage you choose",
-      ManageWP: "Free monthly; premium $2/site/mo or $75/mo up to 100 sites; 90-day retention",
-      MainWP: "No native engine; drives third-party plugins; free host API backups (cPanel, Kinsta)",
-    },
-  },
-  {
-    label: "Uptime monitoring",
-    values: {
-      WPMgr: "Built in and free, with TLS expiry checks",
-      ManageWP: "Add-on: $1/site/mo or $25/mo up to 100 sites; checks every 60 seconds",
-      MainWP: "Built in and free; HTTP, Ping or Keyword; 60m default; off until enabled",
-    },
-  },
-  {
-    label: "Staging",
-    values: {
-      WPMgr: "Not offered",
-      ManageWP: "No staging product; Clone builds staging/production copies, needs premium Backup",
-      MainWP: "Pro add-on driving free WP Staging; no push from staging back to live",
-    },
-  },
-  {
-    label: "Security scanning",
-    values: {
-      WPMgr: "Built in: hardening, file integrity, vulnerability matching",
-      ManageWP: "Free Security Check reports only; Vulnerability Protection $2/site/mo, no bundle",
-      MainWP: "Add-ons only; Vulnerability Checker and Patchstack are Essential, Wordfence is Pro",
-    },
-  },
-  {
-    label: "Client reports",
-    values: {
-      WPMgr: "Built in, white label, with a client portal",
-      ManageWP: "Free with ManageWP watermark; Advanced $1/site/mo or $25/mo up to 100 sites",
-      MainWP: "Pro Reports add-on; needs MainWP Child Reports plugin on each managed site",
-    },
-  },
-  {
-    label: "Connector licence",
-    values: {
-      WPMgr: "MIT in source; GPLv2 or later as distributed on WordPress.org",
-      ManageWP: "GPLv3 or later (ManageWP Worker connector plugin)",
-      MainWP: "MainWP Child is GPLv3 or later; full source on GitHub",
-    },
-  },
-  {
-    label: "Install base",
-    values: {
-      WPMgr: "New. Published to the WordPress.org directory on 2026-08-06",
-      ManageWP: "1+ million active installs on WordPress.org; vendor cites +2M websites managed",
-      MainWP: "700,000 active installs (Child), 20,000 (Dashboard) on the WordPress.org API",
-    },
-  },
-  ],
-  verdicts: [
-    {
-      heading: "Choose ManageWP if you want the least setup",
-      body: "There is no dashboard to host and no server to keep patched. The free tier genuinely covers unlimited sites, and you pay per site only for the add-ons you switch on. If you manage a handful of client sites and want backups working this afternoon, this is the shortest path.",
-    },
-    {
-      heading: "Choose MainWP if you want to own the dashboard and pay once",
-      body: "The dashboard is a plugin on your own WordPress site, so the fleet data stays with you, and the pricing is flat for unlimited sites rather than per site. It has twelve years of extensions behind it. Expect to assemble backups from third-party plugins rather than get one engine.",
-    },
-    {
-      heading: "Choose WPMgr if you want the whole system open and self-hostable",
-      body: "The control plane is AGPL-3.0 and the agent is MIT, so you can read every line before you run it, and self-hosting is free for any number of sites. Backups, security scanning, caching and reporting are built in rather than assembled. It is also the newest of the three by a decade, which is a real trade against the other two.",
-    },
-    {
-      heading: "None of the above",
-      body: "If you manage one site, all three are overhead. A backup plugin and an uptime service will serve you better than a fleet dashboard until the second or third site arrives.",
-    },
-  ],
   faq: [
     {
-      q: "Is MainWP self-hosted in the same way WPMgr is?",
-      a: "Partly. MainWP's dashboard is a plugin you install on a WordPress site you control, so it is self-hosted in the sense that matters most: the fleet data is yours. WPMgr's control plane is a separate Go service with its own database rather than a WordPress plugin, which is a heavier thing to run and a different trade.",
+      q: "Do I have to move everything at once?",
+      a: "No. WPMgr connects a site by installing one plugin and pasting a pairing code, and it does not ask you to remove anything. Connect one site, leave the rest where they are, and compare on your own fleet before you decide.",
     },
     {
-      q: "Which of these keeps my backups off the vendor's servers?",
-      a: "MainWP does not store backups at all; it drives third-party backup plugins, so storage is wherever you point them. WPMgr lets you send backups to a bucket you own, and encrypts them client side so the control plane only ever holds ciphertext. ManageWP stores backups on its own servers, with a choice of US or EU region.",
+      q: "What happens to my sites if WPMgr goes away?",
+      a: "The control plane is AGPL-3.0 and the agent is MIT, both public on GitHub. If we stopped tomorrow you would still hold the source, the running system and your data, and could keep operating or fork it. That is a different answer from a vendor promising to stay in business.",
     },
     {
-      q: "Why does this page not name a winner?",
-      a: "Because we build one of them. A comparison written by a vendor that finds the vendor winning is not worth reading. The sourced claims are there so you can reach your own conclusion, and the verdicts above say plainly which reader each product suits, including the case where none of them does.",
+      q: "Is self-hosting a lot of work?",
+      a: "One command brings up the whole stack on a 64-bit Linux host with Docker. It needs 2 GB of RAM to start. Updates are a pull and a restart, and migrations apply themselves on boot.",
+    },
+    {
+      q: "Where do backups go, and can you read them?",
+      a: "To storage you choose, and no. Each backup is encrypted on the site with a key held by the site, so the control plane stores ciphertext it cannot open. That holds on the hosted tier too.",
+    },
+    {
+      q: "How current are the figures on this page?",
+      a: "Every claim carries the page it came from and the date it was checked, and all of them are listed on the sources page. Prices change; if one of these is stale, the link is how you find out.",
     },
   ],
 };

--- a/apps/marketing/lib/content/types.ts
+++ b/apps/marketing/lib/content/types.ts
@@ -122,47 +122,95 @@ export type SolutionPageData = {
 // ---------------------------------------------------------------------------
 // Comparison pages (/compare/[slug]).
 //
-// These are the only pages on the site permitted to name competitor products,
-// and the type is shaped to enforce the rule that makes that safe: EVERY
-// factual claim about another product carries the URL it came from and the
-// date it was checked. A comparison page is the one page whose whole value is
-// being trustworthy, so an unsourced claim costs more here than anywhere else.
+// These are the only pages permitted to name competitor products.
 //
-// `strengths` is required and must be non-empty for each competitor. A
-// comparison in which the author wins on every axis is not believed by anyone,
-// and the credibility spent admitting what a rival does better is what makes
-// the rest of the page land.
+// TWO RULES, AND THEY ARE NOT THE SAME RULE.
+//
+//   WHAT A CELL SAYS must be true and sourced. Every claim about a named
+//   company carries the URL it came from and the date it was checked, and the
+//   page renders both. A comparison page that misstates a rival's price is the
+//   one thing that gets screenshotted, and it would cost us the only asset
+//   this page has.
+//
+//   WHICH ROWS APPEAR is ours to choose. Row selection is positioning, not
+//   accuracy. We pick the axes the page argues on; we do not shade what sits
+//   in the cells once picked.
+//
+// GROUP ORDER IS LOAD BEARING. The first group is parity: rows where all three
+// products deliver. It costs us nothing, it answers "the new one must be
+// missing things" before a reader forms the thought, and it makes the groups
+// that follow believable. Do not reorder it to lead with a win.
 // ---------------------------------------------------------------------------
 
 /** One checkable statement about a named product, with its provenance. */
 export type SourcedClaim = {
-  /** pricing | hosting | install-count | features | licensing | limits */
+  /** Stable anchor id, used by matrix footnotes and the /sources register. */
+  id: string;
   topic: string;
-  /** One neutral factual sentence. */
   claim: string;
-  /** The product owner's own page. Never a review site or a listicle. */
+  /** The page it was fetched from. Vendor site, docs, repo or wordpress.org. */
   sourceUrl: string;
-  /** ISO date this was last checked against sourceUrl. */
+  /** ISO date this was last checked. */
   verifiedOn: string;
 };
 
-export type ComparedProduct = {
-  name: string;
-  /** Short neutral description in our own words. */
-  summary: string;
-  claims: SourcedClaim[];
-  /** What this product genuinely does better than WPMgr. Must be non-empty. */
-  strengths: string[];
-  /** Their wordpress.org listing or product site. */
-  url: string;
+/**
+ * Cell tone. Semantic, never per product: a tone says what the CELL means, so
+ * tinting our own column wholesale is not available and the parity group stays
+ * credible.
+ */
+export type MatrixTone = "included" | "paid" | "partial" | "absent" | "neutral";
+
+export type MatrixCell = {
+  /** Free text, never a tick. A tick cannot say "paid add-on". */
+  value: string;
+  tone: MatrixTone;
+  /** SourcedClaim ids backing this cell. A row is a claim we are making. */
+  cites?: string[];
 };
 
-/** One row of the at-a-glance table. */
-export type ComparisonRow = {
+export type MatrixRow = {
   label: string;
-  /** Keyed by product name, plus "WPMgr". Free text, not a tick or a cross: a
-   *  boolean cannot express "paid add-on" or "incremental only on annual". */
-  values: Record<string, string>;
+  /** Keyed by product key, plus "wpmgr". Every product needs an entry. */
+  cells: Record<string, MatrixCell>;
+};
+
+export type MatrixGroup = {
+  label: string;
+  rows: MatrixRow[];
+};
+
+export type ComparedProduct = {
+  /** Stable key used across cells and lanes. */
+  key: string;
+  name: string;
+  url: string;
+  claims: SourcedClaim[];
+};
+
+/** One product's cost curve, computed live from published prices. */
+export type CostModel = {
+  productKey: string;
+  label: string;
+  /** Per site per period, in USD. 0 for free. */
+  perSite: number;
+  /** Flat fee covering `bundleCovers` sites, when the vendor offers one. */
+  bundle?: number;
+  bundleCovers?: number;
+  /** A single flat fee for unlimited sites. */
+  flat?: number;
+  period: "month" | "year";
+  note: string;
+  cites?: string[];
+};
+
+/** One lane of the data-locality diagram. */
+export type LocalityLane = {
+  productKey: string;
+  /** Node labels, left to right: where the data goes. */
+  path: string[];
+  note: string;
+  cites?: string[];
 };
 
 export type ComparisonPageData = {
@@ -170,18 +218,30 @@ export type ComparisonPageData = {
   title: string;
   metaTitle: string;
   metaDescription: string;
-  /** The query this page is written to answer, recorded so intent stays honest. */
+  /** The query this page answers, recorded so intent stays honest. */
   targetQuery: string;
   hero: {
     heading: string;
     subhead: string;
+    chips: string[];
   };
-  /** Stated up front, because a comparison written by one of the products is
-   *  only trustworthy if it says so before the reader works it out. */
-  disclosure: string;
   products: ComparedProduct[];
-  table: ComparisonRow[];
-  /** Who each option actually suits, including cases where it is not us. */
-  verdicts: Array<{ heading: string; body: string }>;
+  matrix: MatrixGroup[];
+  /** The consolidation visual: what one tool replaces. */
+  replaces: {
+    heading: string;
+    subhead: string;
+    items: Array<{ icon: string; label: string }>;
+  };
+  cost: {
+    heading: string;
+    subhead: string;
+    models: CostModel[];
+  };
+  locality: {
+    heading: string;
+    subhead: string;
+    lanes: LocalityLane[];
+  };
   faq: FaqItem[];
 };


### PR DESCRIPTION
The first version was rejected on two counts, both fair: everything below the table was a wall of text, and it argued the competitors' case.

## What the page no longer does

Cut entirely: the **8,550-word** "detail, with sources" section, both "What X does better than WPMgr" panels, the four verdict cards including "None of the above", and the line volunteering that WPMgr is *"the newest of the three by a decade"*. The FAQ item "Why does this page not name a winner?" went with them.

```
page copy        9,400 words  ->  693
longest string   ~370 words   ->  50  (an FAQ answer)
```

## Six sections, each showing or computing something

1. **Hero** naming the three axes the page argues on
2. **The matrix** — the one part of the first version that worked
3. **Eight tools converging into one** — the hero visual, because it *is* the commercial argument
4. **A slider** where the reader sets their fleet size and watches the annual cost compute from published prices
5. **Where the fleet data lives**, as three labelled lanes
6. **Five questions**, framed around switching rather than around us

## Row selection is positioning; cell contents are not

The owner's call, and the type comment records the split so it survives the next author. Rows argue where the dashboard runs, where backups land, what the bill does as the fleet grows, and what is built in versus assembled.

**That cuts both ways.** Page and object caching is a real WPMgr strength and is *deliberately absent from the matrix*, because we hold no sourced statement about ManageWP on caching, and "not stated" in a rival's cell reads as "they do not have it". It is argued in the consolidation section instead, where the claim is only about us.

## Group order is load bearing

The first group is **parity**: four rows where all three deliver. It costs nothing, it answers "the new one must be missing things" before a reader forms the thought, and it makes the groups after it believable.

Cell tone is **semantic rather than per product** for the same reason. A reader who spots our column glowing green throughout stops believing the parity group, which is the group doing the most work.

## The 89 claims did not disappear

They moved to `/compare/[slug]/sources` (noindex), with **24 numbered footnotes** linking individual figures straight to their anchor. Verified: 24 distinct footnotes, **0 broken**. That is where a reader wants a source, at the moment they doubt a number.

## The cost widget charges competitors their cheapest published price

Minimum of per-site, per-add-on bundles, and ManageWP's **$150 all-in-one**. An earlier design suppressed the all-in-one above 100 sites, which would have had our own calculator **inflating a named company's published price**. That is the one mistake this page cannot survive.

## Motion rules observed

Only `transform` is animated, never opacity and never a layout property, so **no renderer exists in which this content is invisible**: all eight tiles and all three cost rows are in the static HTML with numbers already computed. `prefers-reduced-motion` lands the tiles in final position without animating.

Mobile drops the matrix to **a card per row** rather than a scrolling table: a sticky-label table shows roughly one product column at a time at 360px, and a reader who cannot see our cell and theirs together has no comparison at all.

## Gates

```
typecheck / lint / build          clean
check-copy                        381 files
static pages                      55 -> 58
footnotes                         24 links, 0 broken
consolidation tiles in static HTML   8/8
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed comparison matrices with sourced claims, citations, and responsive layouts.
  * Added fleet-size cost comparisons, pricing breakdowns, data-locality details, and replacement-tool visualizations.
  * Added dedicated source pages showing claims, URLs, and verification dates.
  * Updated comparison pages with feature highlights, signup calls to action, FAQs, and source links.
* **Style**
  * Improved responsive presentation across desktop and mobile comparison views.
  * Added clearer visual indicators for included, paid, partial, and unavailable features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->