### PR TITLE
fix(marketing): name WPMgr in the compare slug, fill the hero, fix two fallback icons

### DIFF
--- a/apps/marketing/components/sections/compare/hero-panel.tsx
+++ b/apps/marketing/components/sections/compare/hero-panel.tsx
@@ -1,0 +1,95 @@
+import { Icon } from "@/components/ui/icon";
+import { cn } from "@/lib/utils";
+
+/**
+ * The hero visual: a compact fleet panel.
+ *
+ * WHY A PRODUCT SURFACE RATHER THAN AN ILLUSTRATION. The right half of the
+ * hero was empty, and the obvious fill would have been an abstract graphic.
+ * On a comparison page a reader is deciding what to run every day, and the
+ * most persuasive thing to show them is the thing itself: a fleet, at a
+ * glance, with live status. It also costs no illustrator and cannot go stale
+ * the way a drawing of a product does.
+ *
+ * It reuses the status vocabulary from ops-status.tsx on purpose, so the page
+ * and the dashboard look like the same product rather than two design systems.
+ *
+ * MOTION. The only animation is the status pulse, which is a scale and opacity
+ * loop on a DECORATIVE ring behind each dot; the dot itself is solid and
+ * static. Nothing here depends on animation to be legible, and the ping is
+ * suppressed under prefers-reduced-motion by the global media query in
+ * globals.css. No layout property is animated.
+ *
+ * Rows are illustrative and use example.com hosts on purpose. Real customer
+ * domains never go in marketing artwork.
+ */
+
+type Row = {
+  host: string;
+  status: "up" | "degraded";
+  meta: string;
+};
+
+const ROWS: Row[] = [
+  { host: "shop.example.com", status: "up", meta: "backed up 2h ago" },
+  { host: "blog.example.com", status: "up", meta: "backed up 3h ago" },
+  { host: "client-a.example.com", status: "up", meta: "backed up 4h ago" },
+  { host: "staging.example.com", status: "degraded", meta: "update pending" },
+  { host: "legacy.example.com", status: "up", meta: "backed up 6h ago" },
+];
+
+function Pulse({ status }: { status: Row["status"] }) {
+  return (
+    <span className="relative inline-flex h-2 w-2 shrink-0" aria-hidden>
+      <span
+        className={cn(
+          "absolute inline-flex h-full w-full rounded-full opacity-60",
+          status === "up" && "animate-ping bg-[var(--success)]",
+          status === "degraded" && "bg-[var(--warning-subtle-fg)]",
+        )}
+      />
+      <span
+        className={cn(
+          "relative inline-flex h-2 w-2 rounded-full",
+          status === "up" ? "bg-[var(--success)]" : "bg-[var(--warning-subtle-fg)]",
+        )}
+      />
+    </span>
+  );
+}
+
+export function CompareHeroPanel() {
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-card p-5 shadow-sm">
+      <div className="flex items-center justify-between gap-3 border-b border-[var(--border)] pb-3">
+        <div className="flex items-center gap-2">
+          <Icon name="Layers" size={16} className="text-[var(--primary)]" aria-hidden />
+          <span className="text-sm font-semibold text-foreground">Your fleet</span>
+        </div>
+        <span className="text-xs text-[var(--muted-foreground)]">5 sites, one dashboard</span>
+      </div>
+
+      <ul className="mt-3 flex flex-col">
+        {ROWS.map((r) => (
+          <li
+            key={r.host}
+            className="flex items-center justify-between gap-3 border-b border-[var(--border)]/50 py-2.5 last:border-0"
+          >
+            <span className="flex min-w-0 items-center gap-2.5">
+              <Pulse status={r.status} />
+              <span className="truncate font-mono text-xs text-foreground">{r.host}</span>
+            </span>
+            <span className="shrink-0 text-[11px] text-[var(--muted-foreground)]">{r.meta}</span>
+          </li>
+        ))}
+      </ul>
+
+      <div className="mt-3 flex items-center gap-2 rounded-lg bg-[var(--primary-subtle)] px-3 py-2.5">
+        <Icon name="Lock" size={14} className="text-[var(--primary-pressed)]" aria-hidden />
+        <span className="text-[11px] leading-snug text-[var(--primary-pressed)]">
+          Backups encrypted on each site before they leave it, to storage you choose.
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/marketing/components/templates/comparison-page.tsx
+++ b/apps/marketing/components/templates/comparison-page.tsx
@@ -5,6 +5,7 @@ import { CompareMatrix } from "@/components/sections/compare/matrix";
 import { StackCollapse } from "@/components/sections/compare/stack-collapse";
 import { CostModelSection } from "@/components/sections/compare/cost-model";
 import { DataLocality } from "@/components/sections/compare/data-locality";
+import { CompareHeroPanel } from "@/components/sections/compare/hero-panel";
 import { signupHref } from "@/lib/site";
 import { Icon } from "@/components/ui/icon";
 import type { ComparisonPageData } from "@/lib/content/types";
@@ -45,14 +46,16 @@ export function ComparisonPage({ data }: { data: ComparisonPageData }) {
             </Link>
           </nav>
 
-          <h1 className="max-w-[24ch] text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+          <div className="grid gap-10 lg:grid-cols-[1.15fr_1fr] lg:items-start lg:gap-14">
+            <div>
+                  <h1 className="max-w-[24ch] text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
             {data.hero.heading}
           </h1>
-          <p className="mt-5 max-w-[62ch] text-lg leading-relaxed text-[var(--muted-foreground)]">
+              <p className="mt-5 max-w-[62ch] text-lg leading-relaxed text-[var(--muted-foreground)]">
             {data.hero.subhead}
           </p>
 
-          <div className="mt-7 flex flex-wrap gap-3">
+              <div className="mt-7 flex flex-wrap gap-3">
             <a
               href={signupHref("compare")}
               target="_blank"
@@ -70,7 +73,7 @@ export function ComparisonPage({ data }: { data: ComparisonPageData }) {
             </a>
           </div>
 
-          <ul className="mt-8 flex flex-wrap gap-x-6 gap-y-2">
+              <ul className="mt-8 flex flex-wrap gap-x-6 gap-y-2">
             {data.hero.chips.map((chip) => (
               <li
                 key={chip}
@@ -80,7 +83,15 @@ export function ComparisonPage({ data }: { data: ComparisonPageData }) {
                 {chip}
               </li>
             ))}
-          </ul>
+              </ul>
+            </div>
+
+            {/* The fleet panel. Below lg it sits under the copy rather than
+                beside it, so the h1 keeps the full column width on a phone. */}
+            <div className="lg:pt-2">
+              <CompareHeroPanel />
+            </div>
+          </div>
         </Container>
       </Section>
 

--- a/apps/marketing/components/ui/icon.tsx
+++ b/apps/marketing/components/ui/icon.tsx
@@ -1,4 +1,6 @@
 import {
+  Receipt,
+  FileText,
   ArrowDown,
   Minus,
   Lock,
@@ -77,6 +79,8 @@ import {
 // Explicit registry: icons referenced by string from content data stay
 // tree-shakeable and type-checked. One stroke family, one weight.
 const REGISTRY: Record<string, LucideIcon> = {
+  Receipt,
+  FileText,
   ArrowDown,
   Minus,
   Lock,

--- a/apps/marketing/lib/content/compare/index.ts
+++ b/apps/marketing/lib/content/compare/index.ts
@@ -6,7 +6,7 @@
 // directory.
 
 import type { ComparisonPageData } from "@/lib/content/types";
-import { MANAGEWP_VS_MAINWP } from "./managewp-vs-mainwp";
+import { MANAGEWP_VS_MAINWP } from "./managewp-vs-mainwp-vs-wpmgr";
 
 export const COMPARE_REGISTRY: Record<string, ComparisonPageData> = {
   [MANAGEWP_VS_MAINWP.slug]: MANAGEWP_VS_MAINWP,

--- a/apps/marketing/lib/content/compare/managewp-vs-mainwp-vs-wpmgr.ts
+++ b/apps/marketing/lib/content/compare/managewp-vs-mainwp-vs-wpmgr.ts
@@ -20,7 +20,7 @@
 import type { ComparisonPageData } from "@/lib/content/types";
 
 export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
-  slug: "managewp-vs-mainwp",
+  slug: "managewp-vs-mainwp-vs-wpmgr",
   title: "ManageWP vs MainWP vs WPMgr",
   metaTitle: "ManageWP vs MainWP vs WPMgr: One Dashboard, Compared",
   metaDescription:

--- a/apps/marketing/next.config.ts
+++ b/apps/marketing/next.config.ts
@@ -33,6 +33,24 @@ const withMDX = createMDX({
 });
 
 const nextConfig: NextConfig = {
+  // The comparison page shipped briefly at a slug that named only the two
+  // competitors, which read as somebody else's comparison and left our own
+  // product out of the URL. Permanent, because the old slug was live and is in
+  // a submitted sitemap, so it must not 404.
+  async redirects() {
+    return [
+      {
+        source: "/compare/managewp-vs-mainwp",
+        destination: "/compare/managewp-vs-mainwp-vs-wpmgr",
+        permanent: true,
+      },
+      {
+        source: "/compare/managewp-vs-mainwp/sources",
+        destination: "/compare/managewp-vs-mainwp-vs-wpmgr/sources",
+        permanent: true,
+      },
+    ];
+  },
   output: "standalone",
   // CRITICAL monorepo gotcha: without this, the file-trace roots at
   // apps/marketing and drops hoisted workspace dependencies.


### PR DESCRIPTION
Three things, all visible on the live page.

## The slug left our own product out

`/compare/managewp-vs-mainwp` reads as somebody else's comparison, and the one product the page exists to sell was **absent from the URL** — the only part of a page a person pastes into a message.

Now `/compare/managewp-vs-mainwp-vs-wpmgr`, with **permanent redirects from both old paths**. The old slug was live and sits in a submitted sitemap, so it must not 404.

## The right half of the hero was empty

It is now a **fleet panel**: five sites with live status, when each was last backed up, and a note that backups are encrypted on the site before they leave it.

A product surface rather than an illustration, deliberately. On a page where somebody is choosing what to run every day, the most persuasive thing to show is the thing itself. It reuses the status vocabulary from `ops-status.tsx` so the marketing page and the dashboard look like one product rather than two design systems, needs no illustrator, and cannot go stale the way a drawing of a product does.

Hosts are `example.com`. Real customer domains never go in artwork.

## Two icons were rendering a fallback glyph

`FileText` and `Receipt` were never in the registry, so the **"Client reports" tile showed a question mark in a circle**, and so did every "paid" cell in the matrix.

Found by looking at the rendered page in a browser, which is the check that has been missing from this work. An unregistered icon degrades to a fallback rather than failing the build, so nothing upstream catches it.

## Verified in the built output

```
hero panel        present
sitemap           carries only the new slug
footnotes         24 links, 0 broken, all pointing at the renamed sources page
typecheck / lint / build / check-copy   clean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comparison hero panel showing a five-site fleet, status indicators, backup details, and encryption messaging.
  * Added new comparison icons and responsive panel layout.

* **Improvements**
  * Updated the comparison page to include the third product in its title and URL.
  * Added permanent redirects from the previous comparison URLs to the updated page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->