### PR TITLE
feat(marketing): add /self-host, and stop selling it beside the signup

### DIFF
--- a/apps/marketing/app/(marketing)/about/page.tsx
+++ b/apps/marketing/app/(marketing)/about/page.tsx
@@ -320,7 +320,6 @@ export default function AboutPage() {
         subhead="Self-host the complete control plane on your own infrastructure. No per-site fee, no data sent to a third party, and no features behind a paywall."
         ctas={[
           { label: "Get started for free", href: signupHref("about"), variant: "primary", icon: "ArrowRight" },
-          { label: "Star on GitHub", href: SITE_CONFIG.github, variant: "secondary", icon: "Github" },
         ]}
       />
 

--- a/apps/marketing/app/(marketing)/features/page.tsx
+++ b/apps/marketing/app/(marketing)/features/page.tsx
@@ -9,7 +9,7 @@ import { Stagger, StaggerItem } from "@/components/motion/stagger";
 import { cn } from "@/lib/utils";
 import { HUB_CLUSTERS } from "@/lib/content/features";
 import { CTABand } from "@/components/sections/cta-band";
-import { SITE_CONFIG, signupHref } from "@/lib/site";
+import { signupHref } from "@/lib/site";
 
 export const metadata: Metadata = buildMetadata({
   title: "WordPress Management Features | WPMgr",
@@ -150,7 +150,6 @@ export default function FeaturesHubPage() {
         subhead="Self-host the full control plane, read every line, and run it on your own infrastructure."
         ctas={[
           { label: "Get started for free", href: signupHref("features-index"), variant: "primary", icon: "ArrowRight" },
-          { label: "Star on GitHub", href: SITE_CONFIG.github, variant: "secondary", icon: "Github" },
         ]}
       />
 

--- a/apps/marketing/app/(marketing)/pricing/page.tsx
+++ b/apps/marketing/app/(marketing)/pricing/page.tsx
@@ -116,7 +116,7 @@ export default async function PricingPage() {
                 className="inline-flex items-center gap-2 rounded-[var(--radius)] border border-[var(--border)] bg-card px-6 py-3 text-base font-medium text-foreground transition-colors hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
               >
                 <Icon name="Github" size={18} />
-                Self-host instead
+                Or self-host it
               </Link>
             </div>
           </div>

--- a/apps/marketing/app/(marketing)/self-host/page.tsx
+++ b/apps/marketing/app/(marketing)/self-host/page.tsx
@@ -1,0 +1,144 @@
+import type { Metadata } from "next";
+import { buildMetadata, buildBreadcrumbLd } from "@/lib/seo";
+import { JsonLd } from "@/lib/json-ld";
+import { Container, Section } from "@/components/ui/primitives";
+import { Icon } from "@/components/ui/icon";
+import { SELF_HOST } from "@/lib/content/self-host";
+import { signupHref } from "@/lib/site";
+
+export const metadata: Metadata = buildMetadata({
+  title: SELF_HOST.metaTitle,
+  description: SELF_HOST.metaDescription,
+  canonical: "/self-host",
+});
+
+export default function SelfHostPage() {
+  return (
+    <>
+      <Section>
+        <Container>
+          <h1 className="max-w-[22ch] text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+            {SELF_HOST.hero.heading}
+          </h1>
+          <p className="mt-5 max-w-[64ch] text-lg leading-relaxed text-[var(--muted-foreground)]">
+            {SELF_HOST.hero.subhead}
+          </p>
+
+          <div className="mt-8 max-w-3xl overflow-x-auto rounded-xl border border-[var(--border)] bg-[var(--muted)]/40 p-4">
+            <code className="whitespace-pre font-mono text-xs text-foreground sm:text-sm">
+              {SELF_HOST.hero.command}
+            </code>
+          </div>
+          <p className="mt-3 max-w-[70ch] text-sm leading-relaxed text-[var(--muted-foreground)]">
+            {SELF_HOST.hero.commandNote}
+          </p>
+        </Container>
+      </Section>
+
+      {/* The trade, stated in both directions. */}
+      <Section tone="muted" className="border-y border-[var(--border)]">
+        <Container>
+          <div className="max-w-3xl">
+            <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+              {SELF_HOST.tradeoff.heading}
+            </h2>
+            <p className="mt-4 text-lg leading-relaxed text-foreground">
+              {SELF_HOST.tradeoff.body}
+            </p>
+            <a
+              href={signupHref("self-host")}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="mt-7 inline-flex h-11 items-center gap-2 rounded-[var(--radius)] bg-[var(--primary)] px-6 text-sm font-medium text-[var(--primary-foreground)] shadow-sm transition-colors duration-[var(--duration-fast)] hover:bg-[var(--primary-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+            >
+              Let us run it instead
+              <Icon name="ArrowRight" size={16} aria-hidden />
+            </a>
+          </div>
+        </Container>
+      </Section>
+
+      <Section>
+        <Container>
+          <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+            {SELF_HOST.runs.heading}
+          </h2>
+          <ul className="mt-8 grid gap-4 sm:grid-cols-2">
+            {SELF_HOST.runs.items.map((it) => (
+              <li
+                key={it.title}
+                className="flex gap-4 rounded-xl border border-[var(--border)] bg-card p-5 shadow-sm"
+              >
+                <span className="mt-0.5 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-[var(--primary-subtle)] text-[var(--primary-pressed)]">
+                  <Icon name={it.icon} size={18} aria-hidden />
+                </span>
+                <div>
+                  <p className="font-semibold text-foreground">{it.title}</p>
+                  <p className="mt-1 text-sm leading-relaxed text-[var(--muted-foreground)]">
+                    {it.desc}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Container>
+      </Section>
+
+      <Section tone="muted" className="border-y border-[var(--border)]">
+        <Container className="max-w-3xl">
+          <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+            {SELF_HOST.reality.heading}
+          </h2>
+          <ul className="mt-6 flex flex-col gap-3">
+            {SELF_HOST.reality.items.map((line) => (
+              <li key={line} className="flex gap-3 leading-relaxed text-foreground">
+                <Icon
+                  name="Check"
+                  size={16}
+                  className="mt-1 shrink-0 text-[var(--primary)]"
+                  aria-hidden
+                />
+                {line}
+              </li>
+            ))}
+          </ul>
+        </Container>
+      </Section>
+
+      <Section>
+        <Container className="max-w-3xl">
+          <h2 className="text-2xl font-semibold text-foreground">{SELF_HOST.cta.heading}</h2>
+          <p className="mt-3 leading-relaxed text-[var(--muted-foreground)]">
+            {SELF_HOST.cta.body}
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <a
+              href={SELF_HOST.cta.primary.href}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex h-11 items-center gap-2 rounded-[var(--radius)] border border-[var(--border)] bg-card px-6 text-sm font-medium text-foreground transition-colors duration-[var(--duration-fast)] hover:bg-[var(--accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+            >
+              <Icon name="Github" size={16} aria-hidden />
+              {SELF_HOST.cta.primary.label}
+            </a>
+            <a
+              href={SELF_HOST.cta.secondary.href}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex h-11 items-center rounded-[var(--radius)] border border-[var(--border)] bg-card px-6 text-sm font-medium text-foreground transition-colors duration-[var(--duration-fast)] hover:bg-[var(--accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+            >
+              {SELF_HOST.cta.secondary.label}
+            </a>
+          </div>
+        </Container>
+      </Section>
+
+      <JsonLd
+        data={buildBreadcrumbLd([
+          { name: "Home", href: "/" },
+          { name: "Self-host", href: "/self-host" },
+        ])}
+      />
+    </>
+  );
+}

--- a/apps/marketing/app/(marketing)/solutions/page.tsx
+++ b/apps/marketing/app/(marketing)/solutions/page.tsx
@@ -9,7 +9,7 @@ import { Stagger, StaggerItem } from "@/components/motion/stagger";
 import { CTABand } from "@/components/sections/cta-band";
 import { cn } from "@/lib/utils";
 import { SOLUTION_HUB_CARDS } from "@/lib/content/solutions";
-import { SITE_CONFIG, signupHref } from "@/lib/site";
+import { signupHref } from "@/lib/site";
 
 export const metadata: Metadata = buildMetadata({
   title: "WordPress Management Solutions | WPMgr",
@@ -198,12 +198,6 @@ export default function SolutionsHubPage() {
             href: signupHref("solutions-index"),
             variant: "primary",
             icon: "ArrowRight",
-          },
-          {
-            label: "Star on GitHub",
-            href: SITE_CONFIG.github,
-            variant: "secondary",
-            icon: "Github",
           },
         ]}
       />

--- a/apps/marketing/app/blog/[category]/[slug]/page.tsx
+++ b/apps/marketing/app/blog/[category]/[slug]/page.tsx
@@ -210,7 +210,6 @@ export default async function BlogPostPage({ params }: Props) {
           subhead="Free, self-hostable, no per-site fee. Read every line before you run it."
           ctas={[
             { label: "Get started for free", href: signupHref("blog-post"), variant: "primary", icon: "ArrowRight" },
-            { label: "Star on GitHub", href: SITE_CONFIG.github, variant: "secondary", icon: "Github" },
           ]}
         />
       </main>

--- a/apps/marketing/app/guides/[slug]/page.tsx
+++ b/apps/marketing/app/guides/[slug]/page.tsx
@@ -174,7 +174,6 @@ export default async function GuidePage({ params }: Props) {
           subhead="Free, self-hostable, open-source WordPress fleet management. No per-site fee."
           ctas={[
             { label: "Get started for free", href: signupHref("guide"), variant: "primary", icon: "ArrowRight" },
-            { label: "Star on GitHub", href: SITE_CONFIG.github, variant: "secondary", icon: "Github" },
           ]}
         />
       </main>

--- a/apps/marketing/app/guides/page.tsx
+++ b/apps/marketing/app/guides/page.tsx
@@ -7,7 +7,7 @@ import { Icon } from "@/components/ui/icon";
 import { SiteHeader } from "@/components/sections/header";
 import { SiteFooter } from "@/components/sections/footer";
 import { CTABand } from "@/components/sections/cta-band";
-import { SITE_CONFIG, signupHref } from "@/lib/site";
+import { signupHref } from "@/lib/site";
 
 export const metadata: Metadata = buildMetadata({
   title: "WordPress Guides: Maintenance and Core Web Vitals",
@@ -204,7 +204,6 @@ export default function GuidesIndexPage() {
           subhead="No per-site fee. Run WPMgr on your own infrastructure or use the hosted cloud version."
           ctas={[
             { label: "Get started for free", href: signupHref("guides-index"), variant: "primary", icon: "ArrowRight" },
-            { label: "Star on GitHub", href: SITE_CONFIG.github, variant: "secondary", icon: "Github" },
           ]}
         />
       </main>

--- a/apps/marketing/app/sitemap.ts
+++ b/apps/marketing/app/sitemap.ts
@@ -69,6 +69,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${base}/docs`, changeFrequency: "monthly", priority: 0.7 },
     { url: `${base}/legal`, changeFrequency: "yearly", priority: 0.3 },
     { url: `${base}/compare`, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${base}/self-host`, changeFrequency: "monthly", priority: 0.7 },
     { url: `${base}/legal/security-policy`, changeFrequency: "monthly", priority: 0.5 },
     // Indexable, linked from the Legal column of the footer on every page, and
     // absent from this file until 2026-08-06.

--- a/apps/marketing/components/nav/mobile-nav.tsx
+++ b/apps/marketing/components/nav/mobile-nav.tsx
@@ -13,7 +13,7 @@ import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "motion/react";
 import { cn } from "@/lib/utils";
 import { Icon } from "@/components/ui/icon";
-import { SITE_CONFIG, signupHref } from "@/lib/site";
+import { signupHref } from "@/lib/site";
 import {
   NAV_ITEMS,
   FEATURES_COLUMNS,
@@ -419,9 +419,7 @@ export function MobileNav() {
                   Get started free
                 </a>
                 <a
-                  href={SITE_CONFIG.github}
-                  target="_blank"
-                  rel="noreferrer noopener"
+                  href="/self-host"
                   onClick={close}
                   className={cn(
                     "flex min-h-[48px] items-center justify-center gap-2 rounded-[var(--radius)]",
@@ -430,7 +428,6 @@ export function MobileNav() {
                     "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]",
                   )}
                 >
-                  <Icon name="Github" size={16} />
                   Self-host it
                 </a>
               </div>

--- a/apps/marketing/components/sections/header.tsx
+++ b/apps/marketing/components/sections/header.tsx
@@ -78,13 +78,7 @@ export function SiteHeader() {
             <Icon name="Github" size={17} />
           </a>
           <ThemeToggle />
-          <Button
-            href={SITE_CONFIG.github}
-            target="_blank"
-            rel="noreferrer noopener"
-            variant="secondary"
-            className="hidden md:inline-flex"
-          >
+          <Button href="/self-host" variant="secondary" className="hidden md:inline-flex">
             Self-host it
           </Button>
           <Button href={signupHref("header")} className="hidden md:inline-flex">

--- a/apps/marketing/components/templates/feature-page.tsx
+++ b/apps/marketing/components/templates/feature-page.tsx
@@ -11,7 +11,7 @@ import { FAQ } from "@/components/sections/faq";
 import { CTABand } from "@/components/sections/cta-band";
 import { Reveal } from "@/components/motion/reveal";
 import { Stagger, StaggerItem } from "@/components/motion/stagger";
-import { SITE_CONFIG, signupHref } from "@/lib/site";
+import { signupHref } from "@/lib/site";
 import type { FeaturePageData } from "@/lib/content/types";
 
 // Visual leaf: resolved at render time based on slug.
@@ -293,11 +293,10 @@ export function FeaturePage({ data }: { data: FeaturePageData }) {
 
       {/* 7b. Closing CTA band */}
       <CTABand
-        heading="Self-host it, read the code, and run your whole fleet."
+        heading="Run your whole fleet from one dashboard."
         subhead="Free and open source. No per-site fee. The full release is on GitHub."
         ctas={[
           { label: "Get started for free", href: signupHref("feature-cta"), variant: "primary", icon: "ArrowRight" },
-          { label: "Star on GitHub", href: SITE_CONFIG.github, variant: "secondary", icon: "Github" },
         ]}
       />
     </>

--- a/apps/marketing/components/templates/solution-page.tsx
+++ b/apps/marketing/components/templates/solution-page.tsx
@@ -11,7 +11,7 @@ import { FAQ } from "@/components/sections/faq";
 import { CTABand } from "@/components/sections/cta-band";
 import { Reveal } from "@/components/motion/reveal";
 import { Stagger, StaggerItem } from "@/components/motion/stagger";
-import { SITE_CONFIG, signupHref } from "@/lib/site";
+import { signupHref } from "@/lib/site";
 import type { SolutionPageData } from "@/lib/content/types";
 
 // ---------------------------------------------------------------------------
@@ -276,7 +276,7 @@ export function SolutionPage({ data }: { data: SolutionPageData }) {
 
       {/* 6b. Closing CTA band */}
       <CTABand
-        heading="Self-host it, read the code, run your whole fleet."
+        heading="Run your whole fleet from one dashboard."
         subhead="Free and open source. No per-site fee. The full release is on GitHub."
         ctas={[
           {
@@ -284,12 +284,6 @@ export function SolutionPage({ data }: { data: SolutionPageData }) {
             href: signupHref("solution-cta"),
             variant: "primary",
             icon: "ArrowRight",
-          },
-          {
-            label: "Star on GitHub",
-            href: SITE_CONFIG.github,
-            variant: "secondary",
-            icon: "Github",
           },
         ]}
       />

--- a/apps/marketing/lib/analytics.ts
+++ b/apps/marketing/lib/analytics.ts
@@ -65,6 +65,7 @@ export type SignupSource =
   | "blog-post"
   | "blog-inline"
   | "compare"
+  | "self-host"
   | "guide"
   | "guides-index"
   | "features-index"

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -26,7 +26,6 @@ export const HOME_HERO = {
   ],
   ctas: [
     { label: "Get started for free", href: signupHref("hero"), variant: "primary" as const, icon: "ArrowRight" },
-    { label: "Star on GitHub", href: SITE_CONFIG.github, variant: "secondary" as const, icon: "Github" },
   ] satisfies Cta[],
 } as const;
 
@@ -510,7 +509,7 @@ export const HOME_ENROLL = {
       desc: "Back up, update, monitor uptime, optimize images, and lock the site down, all from the single dashboard. Disconnect cleanly anytime, and reconnecting later keeps the full history.",
     },
   ] satisfies Step[],
-  cta: { label: "Self-host it", href: SITE_CONFIG.github, icon: "Github" } satisfies Cta,
+  cta: { label: "Or self-host it", href: "/self-host" } satisfies Cta,
 };
 
 export const HOME_FAQ: FaqItem[] = [
@@ -549,12 +548,11 @@ export const HOME_FAQ: FaqItem[] = [
 ];
 
 export const HOME_FINAL_CTA = {
-  heading: "Self-host it, contribute to it, or just use it. Your call.",
+  heading: "Run your whole fleet from a dashboard you own.",
   subhead:
     "Bring up the full stack with a few commands, enroll your first site with a one-time code, and run your whole fleet from a dashboard that lives on infrastructure you control. Or fork it and build what you need.",
   body: "Free, open source, no per-site fee. Read every line before you run it.",
   ctas: [
     { label: "Get started for free", href: signupHref("hero"), variant: "primary" as const, icon: "ArrowRight" },
-    { label: "Star on GitHub", href: SITE_CONFIG.github, variant: "secondary" as const, icon: "Github" },
   ] satisfies Cta[],
 };

--- a/apps/marketing/lib/content/pricing.ts
+++ b/apps/marketing/lib/content/pricing.ts
@@ -6,7 +6,7 @@
 // app/(marketing)/pricing/page.tsx via lib/pricing-live.ts) override each
 // paid tier's `price` fallback below, per currency -- see resolveTierPrices.
 import type { Cta, FaqItem } from "./types";
-import { SITE_CONFIG, signupHref } from "@/lib/site";
+import { signupHref } from "@/lib/site";
 import type { LivePricingResponse, LiveTier } from "@/lib/pricing-live";
 
 export type PricingTier = {
@@ -134,7 +134,6 @@ export const PRICING_FAQ: FaqItem[] = [
 
 export const PRICING_CTAS: Cta[] = [
   { label: "Get started for free", href: signupHref("cta-band"), variant: "primary", icon: "ArrowRight" },
-  { label: "Star on GitHub", href: SITE_CONFIG.github, variant: "secondary", icon: "Github" },
 ];
 
 // ---------------------------------------------------------------------------

--- a/apps/marketing/lib/content/self-host.ts
+++ b/apps/marketing/lib/content/self-host.ts
@@ -1,0 +1,80 @@
+// /self-host page content.
+//
+// THIS PAGE EXISTS SO SELF-HOSTING CAN STOP BEING A BUTTON. Every feature and
+// solution template used to close with "Self-host it" beside "Star on GitHub",
+// which put two off-site exits next to the signup on 22 templates, at the
+// moment of highest intent. None of the seven comparable projects does that.
+//
+// It is not a demotion. Self-hosting is the reason the AGPL posture is
+// credible, and pretending it does not exist would be a betrayal of it. The
+// difference is between not SELLING it and not MENTIONING it. It stays in the
+// FAQs, the pricing note, the footer, the header, and here, on a page that
+// treats it seriously.
+//
+// The page states the trade in both directions, which the site never did. As
+// presented before, hosted Free was strictly dominated by self-host on every
+// axis the site emphasised, which makes the hosted plan look like a worse
+// version of free rather than a different operating model.
+
+import { SITE_CONFIG } from "@/lib/site";
+
+export const SELF_HOST = {
+  metaTitle: "Self-host WPMgr: run the whole stack yourself",
+  metaDescription:
+    "WPMgr is AGPL-3.0 and self-hosting is free for any number of sites. What you run, what it costs in time, and how it differs from the hosted tier.",
+  hero: {
+    heading: "Self-host WPMgr",
+    subhead:
+      "Free, unlimited sites, every feature. The control plane is AGPL-3.0 and the agent is MIT, so you can read every line before you run it.",
+    command: "curl -fsSL https://raw.githubusercontent.com/mosamlife/wpmgr/main/scripts/quickstart-selfhost.sh | bash",
+    commandNote:
+      "One command on a 64-bit Linux host with Docker 24 or newer. The script fetches every file the stack needs, generates the secrets, and prints the command that brings it up. 2 GB of RAM is enough to start.",
+  },
+  // The sentence the site was missing. Stated as a fact about who operates the
+  // server, not as a feature difference, because it is not a feature
+  // difference: the software is the same.
+  tradeoff: {
+    heading: "What you take on",
+    body: "Self-hosting is free and unlimited. It means you run a Postgres database, a control plane and an encoder, you keep them patched, and you own your backup storage. Hosted means we run all of that and you connect a site in a minute. The software is the same either way, and so is the feature set. The difference is who operates the server.",
+  },
+  runs: {
+    heading: "What you are running",
+    items: [
+      {
+        icon: "Server",
+        title: "Control plane",
+        desc: "A Go binary and the React dashboard. Database migrations apply themselves on boot.",
+      },
+      {
+        icon: "Database",
+        title: "Postgres",
+        desc: "The fleet's own database, with row level security enforced per tenant.",
+      },
+      {
+        icon: "ImageDown",
+        title: "Media encoder",
+        desc: "A pull worker for image and font optimization. Optional if you do not use it.",
+      },
+      {
+        icon: "Lock",
+        title: "Object storage",
+        desc: "Any S3-compatible bucket you control, holding backups you hold the keys to.",
+      },
+    ],
+  },
+  reality: {
+    heading: "The honest version",
+    items: [
+      "Updates are a pull and a restart. Migrations run themselves when the control plane boots.",
+      "You are the one paged when the database fills up, and the one who restores it.",
+      "There is no site limit, no feature gate and no licence key. Nothing checks in with us.",
+      "If we stopped tomorrow you would still have the source, the running system and your data.",
+    ],
+  },
+  cta: {
+    heading: "Read it before you run it",
+    body: "The control plane, the dashboard and the agent are all public. So is every release.",
+    primary: { label: "Quickstart on GitHub", href: `${SITE_CONFIG.github}#quickstart-self-host` },
+    secondary: { label: "System requirements", href: `${SITE_CONFIG.github}/blob/main/docs/requirements.md` },
+  },
+} as const;

--- a/apps/marketing/lib/content/solutions/manage-multiple-sites.ts
+++ b/apps/marketing/lib/content/solutions/manage-multiple-sites.ts
@@ -1,7 +1,7 @@
 // Solution page: manage multiple WordPress sites.
 // House rules: no em dashes, no en dashes, no competitor plugin names.
 import type { SolutionPageData } from "@/lib/content/types";
-import { SITE_CONFIG, signupHref } from "@/lib/site";
+import { signupHref } from "@/lib/site";
 
 export const MANAGE_MULTIPLE_SITES_SOLUTION: SolutionPageData = {
   slug: "manage-multiple-sites",
@@ -16,7 +16,7 @@ export const MANAGE_MULTIPLE_SITES_SOLUTION: SolutionPageData = {
     subhead:
       "Connect every WordPress site you manage to a single dashboard. Run bulk updates with auto-revert, monitor uptime across the fleet, trigger backups before every change, and give each team member exactly the access they need without sharing passwords.",
     primaryCta: { label: "Get started free", href: signupHref("solution-hero"), variant: "primary", icon: "ArrowRight" },
-    secondaryCta: { label: "Star on GitHub", href: SITE_CONFIG.github, variant: "secondary", icon: "Github" },
+    secondaryCta: { label: "Or self-host it", href: "/self-host", variant: "secondary" },
   },
   outcomes: {
     heading: "One dashboard for everything that matters",


### PR DESCRIPTION
Tier 2 items **2.9** and **2.3**, together because they are one change: the buttons could not be removed until there was somewhere honest to send people.

## The site argued against its own hosted product

Every feature and solution template closed with *"Self-host it, read the code, and run your whole fleet"* and a **"Star on GitHub"** button beside the signup, on **22 templates**, at the moment of highest intent. `/pricing` rendered "Self-host instead" at the same size and padding as "Get started for free".

Worse: as presented, **hosted Free was strictly dominated by self-host on every axis the site emphasised**, because the site never stated the trade in the other direction. That makes the hosted plan look like a worse version of free rather than a different operating model.

## What the comparables do, read live

Plausible gives self-hosting one subordinate clause. Cal.com puts it in the footer with no description. n8n files it under "Looking for something else?". PostHog, Ghost, Supabase and Sentry leave it off the pricing page entirely.

**None of the seven puts a self-host button beside a signup button.**

## So it stops being a button, and stays everywhere else

It keeps the FAQ answers, `PRICING_NOTE`, the footer, the header link, and now its own page. There is a real difference between **not selling** self-hosting, which is what every comparable does, and **pretending it does not exist**, which would be a betrayal of the AGPL posture and would be noticed.

## The page states the trade in both directions

> Self-hosting is free and unlimited. It means you run a Postgres database, a control plane and an encoder, you keep them patched, and you own your backup storage. Hosted means we run all of that and you connect a site in a minute. The software is the same either way, and so is the feature set. The difference is who operates the server.

Not a dark pattern: it's the actual difference, and saying it out loud is what makes the hosted tier legible. The page also carries an honest section naming the parts nobody enjoys, including that you are the one paged when the database fills up.

## Changes

**Removed:** the "Star on GitHub" secondary CTA from 11 files, and both templates' self-host closing headings, now "Run your whole fleet from one dashboard."

**Repointed:** header, mobile nav, home enroll CTA and the pricing secondary now go to `/self-host` rather than a GitHub README, which was a poor landing for both audiences.

The header and mobile links also lost `target="_blank" rel="noreferrer noopener"`, inherited from being GitHub links. On an internal link that opens a needless tab and strips our own referrer.

## Measured on the built home page

```
off-site exits inside <main>    9  ->  1
signup links                    3  ->  2
sitemap urls                   55  -> 56
static pages                   58  -> 59
9 now-unused SITE_CONFIG imports removed
typecheck / lint / build / check-copy   clean
```