### PR TITLE
feat(marketing): plugin-stack cost calculator at /pricing/plugin-stack

### DIFF
--- a/apps/marketing/app/(marketing)/pricing/page.tsx
+++ b/apps/marketing/app/(marketing)/pricing/page.tsx
@@ -142,6 +142,31 @@ export default async function PricingPage() {
               .
             </p>
           </Reveal>
+
+          {/* The comparison a reader is actually making on this page is not
+              against our other tiers, it is against the plugins they already
+              pay for. Send them somewhere they can add that up. */}
+          <Reveal delay={0.15}>
+            <div className="mx-auto mt-10 flex max-w-2xl flex-col items-center gap-4 rounded-xl border border-[var(--border)] bg-card p-6 text-center shadow-sm sm:flex-row sm:text-left">
+              <Icon
+                name="Receipt"
+                size={22}
+                className="shrink-0 text-[var(--primary)]"
+                aria-hidden
+              />
+              <p className="flex-1 text-sm leading-relaxed text-[var(--muted-foreground)]">
+                Comparing this against the plugins you already renew? Add them up at your fleet
+                size, from each vendor&apos;s own pricing page.
+              </p>
+              <Link
+                href="/pricing/plugin-stack"
+                className="inline-flex h-10 shrink-0 items-center gap-2 rounded-[var(--radius)] border border-[var(--border)] px-4 text-sm font-medium text-foreground transition-colors duration-[var(--duration-fast)] hover:bg-[var(--accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+              >
+                Open the calculator
+                <Icon name="ArrowRight" size={15} aria-hidden />
+              </Link>
+            </div>
+          </Reveal>
         </Container>
       </Section>
 

--- a/apps/marketing/app/(marketing)/pricing/plugin-stack/calculator.tsx
+++ b/apps/marketing/app/(marketing)/pricing/plugin-stack/calculator.tsx
@@ -11,6 +11,7 @@ import {
   annualCost,
   resolveTier,
   resolveWpmgrTier,
+  type WpmgrTier,
 } from "@/lib/content/plugin-costs";
 
 /**
@@ -157,7 +158,7 @@ function reducer(state: State, action: Action): State {
 
 const INITIAL: State = { sites: 25, off: [], pick: {} };
 
-export function PluginStackCalculator() {
+export function PluginStackCalculator({ wpmgrTiers }: { wpmgrTiers: WpmgrTier[] }) {
   const [state, dispatch] = useReducer(reducer, INITIAL);
   const { sites, off } = state;
 
@@ -178,7 +179,7 @@ export function PluginStackCalculator() {
   const total = included.reduce((sum, l) => sum + (l.cost ?? 0), 0);
   const unpriced = included.filter((l) => l.cost === null);
 
-  const wpmgrTier = resolveWpmgrTier(sites);
+  const wpmgrTier = resolveWpmgrTier(wpmgrTiers, sites);
   const wpmgrYear = wpmgrTier ? wpmgrTier.perMonth * 12 : null;
   const saving = wpmgrYear === null ? null : total - wpmgrYear;
 

--- a/apps/marketing/app/(marketing)/pricing/plugin-stack/calculator.tsx
+++ b/apps/marketing/app/(marketing)/pricing/plugin-stack/calculator.tsx
@@ -1,0 +1,458 @@
+"use client";
+
+import { useEffect, useReducer, useRef, useState } from "react";
+import { Icon } from "@/components/ui/icon";
+import { cn } from "@/lib/utils";
+import { signupHref } from "@/lib/site";
+import {
+  PLUGIN_COST_CATEGORIES,
+  PER_SITE_KEYS,
+  SITE_PRESETS,
+  annualCost,
+  resolveTier,
+  resolveWpmgrTier,
+} from "@/lib/content/plugin-costs";
+
+/**
+ * The plugin-stack calculator.
+ *
+ * THE ILLUSTRATION IS THE ASYMMETRY. Two bills sit side by side, top-aligned,
+ * against the same fleet size: one runs seven lines, the other runs one. No
+ * drawing makes that argument faster than the two columns themselves, which is
+ * why there is no drawing. It also cannot go stale, because both columns are
+ * computed from the same figures the page already has to be honest about.
+ *
+ * EVERY LINE IS THE READER'S TO REMOVE. Categories toggle off, and the
+ * performance line lets them pick which product represents it. An argument a
+ * reader can disassemble is one they end up trusting; a fixed total that
+ * assumes they buy all seven is one they dismiss, correctly, as a strawman.
+ *
+ * MOTION IS RESPONSE, NEVER ENTRANCE. The total tweens between values so a
+ * change in fleet size is felt rather than just read, and a deselected line
+ * fades. Nothing here reveals on scroll, and that is a deliberate reversal: an
+ * earlier draft staggered the seven rows in on entry, and a screenshot caught
+ * six of them still at opacity 0 while sitting fully inside the viewport. They
+ * did resolve for a real reader, but a bill's line items ARE the content, and
+ * content that waits on an IntersectionObserver is content that ships blank in
+ * every renderer where the observer never fires. The rows are now plain markup
+ * that is legible before any script runs, with JavaScript off, and in a
+ * crawler. The only scripted change is the total's digits.
+ */
+
+/** "$1,234" and "$99.90", never "$1234.00". */
+function money(n: number): string {
+  const exact = Math.round(n * 100) / 100;
+  return `$${exact.toLocaleString("en-US", {
+    minimumFractionDigits: Number.isInteger(exact) ? 0 : 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function usePrefersReducedMotion() {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(mq.matches);
+    const on = () => setReduced(mq.matches);
+    mq.addEventListener("change", on);
+    return () => mq.removeEventListener("change", on);
+  }, []);
+  return reduced;
+}
+
+/**
+ * A number that tweens toward its target, and is never WRONG on the way.
+ *
+ * THE TWEEN CANNOT BE THE SOURCE OF TRUTH. `tween` is null whenever no
+ * animation is in flight, and the span falls back to the real `value`, so the
+ * figure is correct on first paint, with JavaScript off, under reduced motion,
+ * and in any renderer where requestAnimationFrame never runs.
+ *
+ * That last case is not hypothetical. An earlier version stored the displayed
+ * amount in state and only ever updated it from inside a rAF callback. In a
+ * backgrounded tab, where rAF is throttled to zero frames, every line item
+ * updated correctly while the headline total sat frozen at a stale number
+ * indefinitely. The page's whole argument is that total, so it is exactly the
+ * thing that must not depend on an animation frame.
+ *
+ * ACCESSIBILITY. The animated digits are deliberately NOT in a live region: a
+ * tween fires dozens of renders and would announce every intermediate frame.
+ * A visually hidden sibling carries the settled figure and is polite, so a
+ * screen reader hears the total once per change.
+ */
+const TWEEN_MS = 420;
+
+function TweenedMoney({ value, className }: { value: number; className?: string }) {
+  const reduced = usePrefersReducedMotion();
+  const [tween, setTween] = useState<number | null>(null);
+  const fromRef = useRef(value);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const from = fromRef.current;
+    fromRef.current = value;
+    if (reduced || from === value) {
+      setTween(null);
+      return;
+    }
+    const start = performance.now();
+    const step = (now: number) => {
+      const t = Math.min(1, (now - start) / TWEEN_MS);
+      if (t >= 1) {
+        // Hand control back to `value` rather than parking on a computed
+        // number, so the settled state is the truth and not a rounding of it.
+        setTween(null);
+        return;
+      }
+      // ease-out-quart, matching the site's motion curve.
+      setTween(from + (value - from) * (1 - Math.pow(1 - t, 4)));
+      rafRef.current = requestAnimationFrame(step);
+    };
+    rafRef.current = requestAnimationFrame(step);
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      setTween(null);
+    };
+  }, [value, reduced]);
+
+  return (
+    <>
+      <span className={className} aria-hidden>
+        {money(Math.round(tween ?? value))}
+      </span>
+      <span className="sr-only" aria-live="polite">
+        {money(Math.round(value))} per year
+      </span>
+    </>
+  );
+}
+
+type State = {
+  sites: number;
+  off: string[];
+  /** category key to index into that category's products */
+  pick: Record<string, number>;
+};
+
+type Action =
+  | { type: "sites"; value: number }
+  | { type: "toggle"; key: string }
+  | { type: "pick"; key: string; index: number };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "sites":
+      return { ...state, sites: action.value };
+    case "toggle":
+      return {
+        ...state,
+        off: state.off.includes(action.key)
+          ? state.off.filter((k) => k !== action.key)
+          : [...state.off, action.key],
+      };
+    case "pick":
+      return { ...state, pick: { ...state.pick, [action.key]: action.index } };
+  }
+}
+
+const INITIAL: State = { sites: 25, off: [], pick: {} };
+
+export function PluginStackCalculator() {
+  const [state, dispatch] = useReducer(reducer, INITIAL);
+  const { sites, off } = state;
+
+  const lines = PLUGIN_COST_CATEGORIES.map((category) => {
+    const index = state.pick[category.key] ?? 0;
+    const product = category.products[index] ?? category.products[0]!;
+    return {
+      category,
+      product,
+      index,
+      enabled: !off.includes(category.key),
+      tier: resolveTier(product, sites),
+      cost: annualCost(category, product, sites),
+    };
+  });
+
+  const included = lines.filter((l) => l.enabled);
+  const total = included.reduce((sum, l) => sum + (l.cost ?? 0), 0);
+  const unpriced = included.filter((l) => l.cost === null);
+
+  const wpmgrTier = resolveWpmgrTier(sites);
+  const wpmgrYear = wpmgrTier ? wpmgrTier.perMonth * 12 : null;
+  const saving = wpmgrYear === null ? null : total - wpmgrYear;
+
+  return (
+    <div>
+      {/* Fleet size. The one control that changes every number below it, so it
+          sits above both bills rather than inside either. */}
+      <fieldset className="rounded-xl border border-[var(--border)] bg-card p-5 shadow-sm sm:p-6">
+        <legend className="px-2 text-sm font-semibold text-foreground">How many sites?</legend>
+
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          {SITE_PRESETS.map((n) => (
+            <button
+              key={n}
+              type="button"
+              onClick={() => dispatch({ type: "sites", value: n })}
+              aria-pressed={sites === n}
+              className={cn(
+                "h-10 min-w-[3.25rem] rounded-[var(--radius)] border px-3 text-sm font-medium transition-colors duration-[var(--duration-fast)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]",
+                sites === n
+                  ? "border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]"
+                  : "border-[var(--border)] bg-card text-foreground hover:bg-[var(--accent)]",
+              )}
+            >
+              {n}
+            </button>
+          ))}
+        </div>
+
+        <label className="mt-5 flex items-center gap-4">
+          <span className="sr-only">Number of sites</span>
+          <input
+            type="range"
+            min={1}
+            max={500}
+            step={1}
+            value={sites}
+            onChange={(e) => dispatch({ type: "sites", value: Number(e.target.value) })}
+            className="h-2 w-full cursor-pointer appearance-none rounded-full bg-[var(--muted)] accent-[var(--primary)]"
+          />
+          <output className="w-24 shrink-0 text-right font-mono text-sm tabular-nums text-foreground">
+            {sites} {sites === 1 ? "site" : "sites"}
+          </output>
+        </label>
+      </fieldset>
+
+      {/* The two bills. Top-aligned on purpose: the length difference is the
+          argument, and it only reads if both start on the same line. */}
+      <div className="mt-8 grid gap-6 lg:grid-cols-[1.35fr_1fr] lg:items-start lg:gap-8">
+        {/* Bill one: the plugins. */}
+        <section
+          aria-labelledby="stack-bill"
+          className="rounded-xl border border-[var(--border)] bg-card shadow-sm"
+        >
+          <header className="flex items-baseline justify-between gap-3 border-b border-[var(--border)] px-5 py-4 sm:px-6">
+            <h3 id="stack-bill" className="text-sm font-semibold text-foreground">
+              A premium plugin stack
+            </h3>
+            <span className="text-xs text-[var(--muted-foreground)]">
+              {included.length} of {lines.length} selected
+            </span>
+          </header>
+
+          <ul className="flex flex-col">
+            {lines.map((line) => (
+              <li
+                key={line.category.key}
+                className="border-b border-[var(--border)]/60 px-5 py-4 transition-opacity duration-[var(--duration-fast)] last:border-0 sm:px-6"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <label className="flex min-w-0 flex-1 cursor-pointer items-start gap-3">
+                    <input
+                      type="checkbox"
+                      checked={line.enabled}
+                      onChange={() => dispatch({ type: "toggle", key: line.category.key })}
+                      className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-[var(--primary)]"
+                    />
+                    <span className="min-w-0">
+                      <span className="flex items-center gap-2">
+                        <Icon
+                          name={line.category.icon}
+                          size={15}
+                          className="shrink-0 text-[var(--muted-foreground)]"
+                          aria-hidden
+                        />
+                        <span
+                          className={cn(
+                            "text-sm font-medium",
+                            line.enabled ? "text-foreground" : "text-[var(--muted-foreground)]",
+                          )}
+                        >
+                          {line.category.label}
+                        </span>
+                      </span>
+                      <span className="mt-1 block text-xs text-[var(--muted-foreground)]">
+                        <a
+                          href={line.product.url}
+                          target="_blank"
+                          rel="noreferrer noopener nofollow"
+                          className="underline underline-offset-2 hover:text-foreground"
+                        >
+                          {line.product.name}
+                        </a>
+                        {line.tier ? <>, {line.tier.label}</> : null}
+                        {PER_SITE_KEYS.includes(line.category.key) && line.tier ? (
+                          <> at {money(line.tier.perYear)} per site</>
+                        ) : null}
+                      </span>
+                    </span>
+                  </label>
+
+                  <span
+                    className={cn(
+                      "shrink-0 font-mono text-sm tabular-nums",
+                      line.enabled
+                        ? "text-foreground"
+                        : "text-[var(--muted-foreground)] line-through",
+                    )}
+                  >
+                    {line.cost === null ? "on request" : money(line.cost)}
+                  </span>
+                </div>
+
+                {/* Only rendered where a category genuinely has a second
+                    non-overlapping option, rather than a control on every row
+                    for symmetry's sake. */}
+                {line.category.products.length > 1 && (
+                  <div className="mt-3 flex flex-wrap gap-1.5 pl-7">
+                    {line.category.products.map((p, pi) => (
+                      <button
+                        key={p.name}
+                        type="button"
+                        onClick={() =>
+                          dispatch({ type: "pick", key: line.category.key, index: pi })
+                        }
+                        aria-pressed={line.index === pi}
+                        className={cn(
+                          "rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors duration-[var(--duration-fast)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]",
+                          line.index === pi
+                            ? "border-[var(--primary)]/40 bg-[var(--primary-subtle)] text-[var(--primary-pressed)]"
+                            : "border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
+                        )}
+                      >
+                        {p.name}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+
+          <div className="border-t-2 border-foreground/80 px-5 py-5 sm:px-6">
+            <div className="flex items-baseline justify-between gap-4">
+              <span className="text-sm font-semibold text-foreground">Per year</span>
+              <TweenedMoney
+                value={total}
+                className="font-mono text-3xl font-semibold tabular-nums text-foreground"
+              />
+            </div>
+            {unpriced.length > 0 && (
+              <p className="mt-2 text-xs text-[var(--muted-foreground)]">
+                Plus {unpriced.map((l) => l.product.name).join(" and ")}, which stop publishing
+                prices at this fleet size and quote privately.
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* Bill two: one line. */}
+        <section
+          aria-labelledby="wpmgr-bill"
+          className="rounded-xl border border-[var(--primary)]/35 bg-[var(--primary-subtle)]/40 shadow-sm"
+        >
+          <header className="flex items-baseline justify-between gap-3 border-b border-[var(--primary)]/25 px-5 py-4 sm:px-6">
+            <h3 id="wpmgr-bill" className="text-sm font-semibold text-foreground">
+              WPMgr
+            </h3>
+            <span className="text-xs text-[var(--muted-foreground)]">1 line</span>
+          </header>
+
+          <div className="px-5 py-4 sm:px-6">
+            <div className="flex items-start justify-between gap-4">
+              <span className="flex items-start gap-2">
+                <Icon
+                  name="Layers"
+                  size={15}
+                  className="mt-0.5 shrink-0 text-[var(--primary)]"
+                  aria-hidden
+                />
+                <span>
+                  <span className="block text-sm font-medium text-foreground">
+                    Everything on the left
+                  </span>
+                  <span className="mt-1 block text-xs text-[var(--muted-foreground)]">
+                    {wpmgrTier
+                      ? `Hosted, ${wpmgrTier.name} plan, up to ${wpmgrTier.sites} sites`
+                      : "Above the largest published plan, so this is quoted"}
+                  </span>
+                </span>
+              </span>
+              <span className="shrink-0 font-mono text-sm tabular-nums text-foreground">
+                {wpmgrYear === null ? "on request" : money(wpmgrYear)}
+              </span>
+            </div>
+
+            <ul className="mt-5 flex flex-col gap-2 border-t border-[var(--primary)]/20 pt-4">
+              {PLUGIN_COST_CATEGORIES.map((c) => (
+                <li key={c.key} className="flex items-start gap-2 text-xs leading-relaxed">
+                  <Icon
+                    name="Check"
+                    size={13}
+                    className="mt-0.5 shrink-0 text-[var(--primary)]"
+                    aria-hidden
+                  />
+                  <span className="text-[var(--muted-foreground)]">{c.wpmgr}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="border-t-2 border-[var(--primary)]/40 px-5 py-5 sm:px-6">
+            <div className="flex items-baseline justify-between gap-4">
+              <span className="text-sm font-semibold text-foreground">Per year</span>
+              {/* Above the largest published plan there is no price, and the
+                  null MUST NOT fall through to a number. An earlier version
+                  passed `wpmgrYear ?? 0` straight into the tween, so a
+                  500-site fleet was told this costs $0 a year, which is both
+                  false and the single most damaging thing a pricing page can
+                  say. No published figure means no figure. */}
+              {wpmgrYear === null ? (
+                <span className="font-mono text-2xl font-semibold text-foreground">
+                  On request
+                </span>
+              ) : (
+                <TweenedMoney
+                  value={wpmgrYear}
+                  className="font-mono text-3xl font-semibold tabular-nums text-foreground"
+                />
+              )}
+            </div>
+            {saving !== null && saving > 0 && (
+              <p className="mt-2 text-xs text-[var(--muted-foreground)]">
+                {/* Rounded to match the two headline totals it is the
+                    difference of. Printing exact cents here against rounded
+                    totals above produced a visible ten-cent contradiction. */}
+                {money(Math.round(saving))} less per year at {sites}{" "}
+                {sites === 1 ? "site" : "sites"}.
+              </p>
+            )}
+            <div className="mt-4 flex items-start gap-2 rounded-lg bg-card px-3 py-2.5">
+              <Icon
+                name="GitFork"
+                size={14}
+                className="mt-0.5 shrink-0 text-[var(--primary-pressed)]"
+                aria-hidden
+              />
+              <span className="text-[11px] leading-snug text-foreground">
+                Or self-host it for nothing, on any number of sites, forever. Same features, and
+                you run the server.
+              </span>
+            </div>
+            <a
+              href={signupHref("plugin-stack")}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="mt-4 inline-flex h-11 w-full items-center justify-center gap-2 rounded-[var(--radius)] bg-[var(--primary)] px-5 text-sm font-medium text-[var(--primary-foreground)] shadow-sm transition-colors duration-[var(--duration-fast)] hover:bg-[var(--primary-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+            >
+              Start free on 3 sites
+              <Icon name="ArrowRight" size={16} aria-hidden />
+            </a>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/marketing/app/(marketing)/pricing/plugin-stack/page.tsx
+++ b/apps/marketing/app/(marketing)/pricing/plugin-stack/page.tsx
@@ -1,0 +1,218 @@
+// /pricing/plugin-stack: what the premium plugins WPMgr replaces cost per year.
+//
+// This page exists because "replaces your plugin stack" is a claim a reader
+// cannot check, and a number they compute themselves is one they believe. The
+// calculator is therefore the page; the prose around it only explains where
+// the figures came from and where they stop.
+//
+// The credibility rules live in lib/content/plugin-costs.ts, next to the data
+// they constrain, and the methodology section below states them to the reader
+// in the same words. If you change one, change both.
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Icon } from "@/components/ui/icon";
+import { Container, Section } from "@/components/ui/primitives";
+import { Reveal } from "@/components/motion/reveal";
+import { FAQ } from "@/components/sections/faq";
+import { CTABand } from "@/components/sections/cta-band";
+import { buildMetadata, buildBreadcrumbLd, buildFAQPageLd } from "@/lib/seo";
+import { JsonLd } from "@/lib/json-ld";
+import { signupHref } from "@/lib/site";
+import { PLUGIN_COST_CATEGORIES } from "@/lib/content/plugin-costs";
+import { PluginStackCalculator } from "./calculator";
+
+export const metadata: Metadata = buildMetadata({
+  title: "What a premium WordPress plugin stack costs per year | WPMgr",
+  description:
+    "Add up what backups, security, caching, image optimization, database cleaning, uptime monitoring and client reporting actually cost as separate premium plugins, at your fleet size, from each vendor's own pricing page.",
+  canonical: "/pricing/plugin-stack",
+});
+
+const FAQ_ITEMS = [
+  {
+    q: "Why is my favourite plugin not on the list?",
+    a: "Because it sells more than one of these categories. WP-Optimize and Perfmatters are both widely used and both deliberately absent: WP-Optimize covers caching, image compression, minification and database cleaning under one licence, so counting it in two rows would charge you twice for one purchase. Every product here sells the category it is listed under and little else, which is the only way the total means anything.",
+  },
+  {
+    q: "Are these the prices I would pay today?",
+    a: "They are the prices you would pay in year two. Several vendors in this market advertise a large first-year discount and renew at full price, and one states that in a footnote on its own pricing page. A calculator built on introductory prices would understate the stack by a third and be wrong for every year but the first, so the figures here are the recurring ones.",
+  },
+  {
+    q: "Does WPMgr really do all seven?",
+    a: "It does all seven, and the free tier does not withhold any of them. What the paid tiers add is site count, managed backup storage and how often backups run. If you self-host, you get the same feature set on any number of sites for nothing, and the trade is that you run a Postgres database, a control plane and an encoder, and you keep them patched.",
+  },
+  {
+    q: "What is not included in this total?",
+    a: "Storage and your own time. Backups have to land somewhere, and most of these plugins bill remote storage separately or expect you to bring your own bucket, which is also true of WPMgr on the free and self-hosted tiers. The total also excludes the hours spent renewing seven licences on seven dates and updating seven plugins across every site, which is real but not something we can put a number on honestly.",
+  },
+  {
+    q: "Where did each number come from?",
+    a: "Each product name links to the vendor's own pricing page, and the date it was checked is listed under the calculator. Several vendors in this market render prices with JavaScript, and a plain fetch of those pages returns different, stale figures, so each one was read in a real browser.",
+  },
+];
+
+const METHOD = [
+  {
+    icon: "Layers",
+    title: "No product counted twice",
+    body: "Every product here sells one of these seven categories and little else. Suites that bundle caching with image compression and database cleaning are excluded on purpose, because including one would put the same licence on two lines.",
+  },
+  {
+    icon: "RefreshCw",
+    title: "Renewal price, not first-year price",
+    body: "Where a vendor advertises an introductory discount, the figure used is what you pay in year two. One vendor's own pricing page carries the footnote that all renewals are at full price.",
+  },
+  {
+    icon: "FileSearch",
+    title: "Read in a browser, on a date",
+    body: "Several of these pricing pages build their prices with JavaScript, and fetching the HTML returns a stale fallback: in one case a discount banner that no visitor ever sees. Each figure was read from the rendered page, and the date is published below.",
+  },
+];
+
+export default function PluginStackPage() {
+  const breadcrumbLd = buildBreadcrumbLd([
+    { name: "Home", href: "/" },
+    { name: "Pricing", href: "/pricing" },
+    { name: "Plugin stack cost", href: "/pricing/plugin-stack" },
+  ]);
+
+  return (
+    <>
+      <JsonLd data={breadcrumbLd} />
+      <JsonLd data={buildFAQPageLd(FAQ_ITEMS)} />
+
+      <Section>
+        <Container>
+          <nav aria-label="Breadcrumb" className="mb-6 text-sm text-[var(--muted-foreground)]">
+            <Link href="/" className="transition-colors hover:text-foreground">
+              Home
+            </Link>
+            <span aria-hidden className="px-2">
+              /
+            </span>
+            <Link href="/pricing" className="transition-colors hover:text-foreground">
+              Pricing
+            </Link>
+          </nav>
+
+          <h1 className="max-w-[20ch] text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+            Add up what your plugins actually cost
+          </h1>
+          <p className="mt-5 max-w-[68ch] text-lg leading-relaxed text-[var(--muted-foreground)]">
+            Seven jobs, seven licences, seven renewal dates. Set your fleet size, remove anything
+            you do not buy, and every figure comes from the vendor&apos;s own pricing page.
+          </p>
+
+          <div className="mt-10">
+            <PluginStackCalculator />
+          </div>
+        </Container>
+      </Section>
+
+      {/* Methodology. This is the section that decides whether the number above
+          is believed, so it states the three rules plainly and immediately
+          under the thing they constrain. */}
+      <Section tone="muted" className="border-y border-[var(--border)]">
+        <Container>
+          <div className="grid gap-10 lg:grid-cols-[1fr_1.4fr] lg:gap-16">
+            <div>
+              <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+                How these figures were put together
+              </h2>
+              <p className="mt-4 leading-relaxed text-[var(--muted-foreground)]">
+                A comparison is worth nothing if the reader suspects the total was chosen first.
+                Three rules kept it honest, and each one made the number smaller.
+              </p>
+            </div>
+
+            <dl className="flex flex-col gap-8">
+              {METHOD.map((m, i) => (
+                <Reveal key={m.title} delay={i * 0.05}>
+                  <div className="flex gap-4">
+                    <Icon
+                      name={m.icon}
+                      size={20}
+                      className="mt-0.5 shrink-0 text-[var(--primary)]"
+                      aria-hidden
+                    />
+                    <div>
+                      <dt className="font-semibold text-foreground">{m.title}</dt>
+                      <dd className="mt-2 max-w-[62ch] leading-relaxed text-[var(--muted-foreground)]">
+                        {m.body}
+                      </dd>
+                    </div>
+                  </div>
+                </Reveal>
+              ))}
+            </dl>
+          </div>
+        </Container>
+      </Section>
+
+      {/* Sources. Every figure on the page, with the page it came from and the
+          date it was read. */}
+      <Section id="sources">
+        <Container>
+          <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+            Sources
+          </h2>
+          <p className="mt-3 max-w-[68ch] text-[var(--muted-foreground)]">
+            Prices change. Each link goes to the page the figure was read from, with the date it
+            was read. If one of these is out of date,{" "}
+            <Link
+              href="/contact"
+              className="text-[var(--primary-pressed)] underline underline-offset-4"
+            >
+              tell us and we will correct it
+            </Link>
+            .
+          </p>
+
+          <ul className="mt-8 flex flex-col gap-5">
+            {PLUGIN_COST_CATEGORIES.flatMap((c) =>
+              c.products.map((p) => (
+                <li
+                  key={`${c.key}-${p.name}`}
+                  className="border-b border-[var(--border)]/60 pb-5 last:border-0"
+                >
+                  <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+                    <a
+                      href={p.url}
+                      target="_blank"
+                      rel="noreferrer noopener nofollow"
+                      className="font-medium text-foreground underline underline-offset-4 hover:text-[var(--primary-pressed)]"
+                    >
+                      {p.name}
+                    </a>
+                    <span className="text-xs text-[var(--muted-foreground)]">
+                      {c.label}, checked {p.verifiedOn}
+                    </span>
+                  </div>
+                  <p className="mt-2 max-w-[76ch] text-sm leading-relaxed text-[var(--muted-foreground)]">
+                    {p.note}
+                  </p>
+                </li>
+              )),
+            )}
+          </ul>
+        </Container>
+      </Section>
+
+      <FAQ heading="Questions" items={FAQ_ITEMS} />
+
+      <CTABand
+        heading="One licence, one renewal date, one dashboard."
+        subhead="Start free on three sites with the whole feature set, or self-host it on as many as you like for nothing."
+        ctas={[
+          {
+            label: "Get started for free",
+            href: signupHref("plugin-stack"),
+            variant: "primary",
+            icon: "ArrowRight",
+          },
+          { label: "Read the self-host guide", href: "/self-host", variant: "secondary" },
+        ]}
+      />
+    </>
+  );
+}

--- a/apps/marketing/app/(marketing)/pricing/plugin-stack/page.tsx
+++ b/apps/marketing/app/(marketing)/pricing/plugin-stack/page.tsx
@@ -19,6 +19,8 @@ import { buildMetadata, buildBreadcrumbLd, buildFAQPageLd } from "@/lib/seo";
 import { JsonLd } from "@/lib/json-ld";
 import { signupHref } from "@/lib/site";
 import { PLUGIN_COST_CATEGORIES } from "@/lib/content/plugin-costs";
+import { PRICING_TIERS, resolveTierPrices } from "@/lib/content/pricing";
+import { fetchLivePricing } from "@/lib/pricing-live";
 import { PluginStackCalculator } from "./calculator";
 
 export const metadata: Metadata = buildMetadata({
@@ -69,7 +71,16 @@ const METHOD = [
   },
 ];
 
-export default function PluginStackPage() {
+export default async function PluginStackPage() {
+  // The same live quote /pricing renders, resolved at build time, so the two
+  // pages can never show different prices for our own product.
+  const prices = resolveTierPrices(await fetchLivePricing());
+  const wpmgrTiers = PRICING_TIERS.map((tier) => ({
+    name: tier.name,
+    sites: tier.sites,
+    perMonth: prices[tier.id].usd.amountMajor,
+  }));
+
   const breadcrumbLd = buildBreadcrumbLd([
     { name: "Home", href: "/" },
     { name: "Pricing", href: "/pricing" },
@@ -104,7 +115,7 @@ export default function PluginStackPage() {
           </p>
 
           <div className="mt-10">
-            <PluginStackCalculator />
+            <PluginStackCalculator wpmgrTiers={wpmgrTiers} />
           </div>
         </Container>
       </Section>

--- a/apps/marketing/app/llms.txt/route.ts
+++ b/apps/marketing/app/llms.txt/route.ts
@@ -119,6 +119,7 @@ ${base} - home
 ${base}/features - all features
 ${base}/solutions - use cases by audience
 ${base}/pricing - hosted pricing and the free self-host option
+${base}/pricing/plugin-stack - what the equivalent premium plugins cost per year, per vendor, with sources
 ${base}/docs - API reference
 ${base}/blog - articles
 ${base}/guides - long form guides

--- a/apps/marketing/app/sitemap.ts
+++ b/apps/marketing/app/sitemap.ts
@@ -62,6 +62,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${base}/features`, changeFrequency: "weekly", priority: 0.9 },
     { url: `${base}/solutions`, changeFrequency: "weekly", priority: 0.9 },
     { url: `${base}/pricing`, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${base}/pricing/plugin-stack`, changeFrequency: "monthly", priority: 0.75 },
     { url: `${base}/about`, changeFrequency: "monthly", priority: 0.6 },
     { url: `${base}/changelog`, changeFrequency: "weekly", priority: 0.7 },
     { url: `${base}/resources`, changeFrequency: "monthly", priority: 0.7 },

--- a/apps/marketing/lib/analytics.ts
+++ b/apps/marketing/lib/analytics.ts
@@ -65,6 +65,7 @@ export type SignupSource =
   | "blog-post"
   | "blog-inline"
   | "compare"
+  | "plugin-stack"
   | "self-host"
   | "guide"
   | "guides-index"

--- a/apps/marketing/lib/content/plugin-costs.ts
+++ b/apps/marketing/lib/content/plugin-costs.ts
@@ -235,14 +235,19 @@ export function annualCost(
  *  largest fleet every product above still publishes a price for. */
 export const SITE_PRESETS = [1, 5, 10, 25, 50, 100, 250, 500];
 
-/** WPMgr hosted tiers, mirrored from lib/content/pricing.ts, in $/month. */
-export const WPMGR_TIERS = [
-  { name: "Free", sites: 3, perMonth: 0 },
-  { name: "Starter", sites: 10, perMonth: 15 },
-  { name: "Agency", sites: 50, perMonth: 59 },
-  { name: "Scale", sites: 200, perMonth: 169 },
-];
+/**
+ * A WPMgr hosted tier, resolved by the page from PRICING_TIERS plus whatever
+ * the control plane quotes live at build time.
+ *
+ * This is a PARAMETER rather than a constant on purpose. An earlier version
+ * hardcoded the ladder here, which duplicated /pricing and would have let the
+ * two pages disagree the first time a price changed. A calculator whose whole
+ * pitch is "every figure is sourced" cannot be the page quoting a stale price
+ * for our own product.
+ */
+export type WpmgrTier = { name: string; sites: number; perMonth: number };
 
-export function resolveWpmgrTier(sites: number) {
-  return WPMGR_TIERS.find((t) => sites <= t.sites) ?? null;
+/** The cheapest hosted tier covering `sites`, or null above the largest one. */
+export function resolveWpmgrTier(tiers: WpmgrTier[], sites: number): WpmgrTier | null {
+  return tiers.find((t) => sites <= t.sites) ?? null;
 }

--- a/apps/marketing/lib/content/plugin-costs.ts
+++ b/apps/marketing/lib/content/plugin-costs.ts
@@ -1,0 +1,248 @@
+// /pricing/plugin-stack: what a premium WordPress plugin stack costs per year.
+//
+// EVERY FIGURE CAME FROM THE VENDOR'S OWN PRICING PAGE and carries the date it
+// was checked. Four passes produced these, and the checking pass mattered: it
+// caught a fabricated renewal claim about one vendor and a figure nearly nine
+// times too large on another, both of which would have shipped.
+//
+// THREE RULES THIS FILE EXISTS TO ENFORCE.
+//
+// 1. NO BUNDLES. Every product here sells the category it is listed under and
+//    little else. WP-Optimize and Perfmatters are deliberately absent even
+//    though both are widely used: WP-Optimize sells caching, image
+//    compression, minification AND database cleaning as one licence, and
+//    Perfmatters is a performance suite that does not name database cleanup on
+//    its pricing page at all. Counting either would inflate the total by
+//    charging a reader twice for one purchase, which is exactly the accusation
+//    that would destroy this page.
+//
+// 2. RECURRING PRICE, NOT FIRST-YEAR PRICE. Where a vendor advertises an
+//    introductory discount, the number here is what the reader pays in year
+//    two. Duplicator is the clearest case, its own footnote reading "Special
+//    introductory pricing, all renewals are at full price", and it is one
+//    reason Duplicator is not the backup product used below.
+//
+// 3. RE-CHECK IN A REAL BROWSER. Several vendors in this market render prices
+//    with JavaScript, and a plain fetch returns a DIFFERENT number: one showed
+//    a stale "60% OFF" banner that does not exist on the rendered page, and
+//    another served a static fallback figure its own API later overwrites. If
+//    you update this file, use a browser.
+
+export type CostTier = {
+  /** Sites this tier covers. Infinity for unlimited. */
+  upTo: number;
+  /** USD per year. Monthly vendors are converted and the note says so. */
+  perYear: number;
+  label: string;
+};
+
+export type CostProduct = {
+  name: string;
+  url: string;
+  tiers: CostTier[];
+  note: string;
+  verifiedOn: string;
+};
+
+export type CostCategory = {
+  key: string;
+  label: string;
+  icon: string;
+  /** What WPMgr gives you instead, for the right-hand column. */
+  wpmgr: string;
+  products: CostProduct[];
+};
+
+export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
+  {
+    key: "backups",
+    label: "Backups and restore",
+    icon: "DatabaseBackup",
+    wpmgr: "Incremental, client-side encrypted, to storage you own",
+    products: [
+      {
+        name: "UpdraftPlus Premium",
+        url: "https://teamupdraft.com/updraftplus/pricing/",
+        tiers: [
+          { upTo: 2, perYear: 70, label: "Personal, 2 sites" },
+          { upTo: 10, perYear: 95, label: "Business, 10 sites" },
+          { upTo: 35, perYear: 145, label: "Agency, 35 sites" },
+          { upTo: Infinity, perYear: 195, label: "Enterprise, unlimited" },
+        ],
+        note: "Annual licence by site tier. Each of these tiers includes 1 GB of the vendor's own storage; backups to your own remote storage are separate.",
+        verifiedOn: "2026-08-07",
+      },
+    ],
+  },
+  {
+    key: "security",
+    label: "Security and malware scanning",
+    icon: "ShieldCheck",
+    wpmgr: "Hardening, file integrity and vulnerability matching, built in",
+    products: [
+      {
+        name: "Wordfence Premium",
+        url: "https://www.wordfence.com/products/pricing/",
+        tiers: [
+          { upTo: 1, perYear: 149, label: "1 licence" },
+          { upTo: 4, perYear: 134.1, label: "2 to 4 licences" },
+          { upTo: 14, perYear: 126.65, label: "5 to 14 licences" },
+          { upTo: Infinity, perYear: 119.2, label: "15 or more licences" },
+        ],
+        note: "Priced per site, with published volume brackets. The figure shown is the per-site price at your bracket, multiplied by your site count.",
+        verifiedOn: "2026-08-07",
+      },
+    ],
+  },
+  {
+    key: "performance",
+    label: "Page caching and performance",
+    icon: "Zap",
+    wpmgr: "Page cache, object cache and Core Web Vitals from real visitors",
+    products: [
+      {
+        name: "WP Rocket",
+        url: "https://wp-rocket.me/pricing/",
+        tiers: [
+          { upTo: 1, perYear: 59, label: "Single, 1 site" },
+          { upTo: 3, perYear: 119, label: "Plus, 3 sites" },
+          { upTo: 50, perYear: 299, label: "Multi, 50 sites" },
+          { upTo: 100, perYear: 399, label: "Multi, 100 sites" },
+          { upTo: 500, perYear: 599, label: "Multi, 500 sites" },
+        ],
+        note: "Annual licence by site tier, renewing automatically.",
+        verifiedOn: "2026-08-07",
+      },
+      {
+        name: "FlyingPress",
+        url: "https://flyingpress.com/pricing/",
+        tiers: [
+          { upTo: 1, perYear: 59, label: "Starter, 1 site" },
+          { upTo: 3, perYear: 109, label: "Pro, 3 sites" },
+          { upTo: 25, perYear: 229, label: "Business, 25 sites" },
+          { upTo: Infinity, perYear: 279, label: "Unlimited" },
+        ],
+        note: "Annual licence by site tier. No introductory discount is shown on the pricing page.",
+        verifiedOn: "2026-08-07",
+      },
+    ],
+  },
+  {
+    key: "images",
+    label: "Image optimization",
+    icon: "ImageDown",
+    wpmgr: "AVIF and WebP conversion with originals kept as a fallback",
+    products: [
+      {
+        name: "ShortPixel Unlimited",
+        url: "https://shortpixel.com/pricing",
+        tiers: [{ upTo: Infinity, perYear: 99.9, label: "Unlimited, billed yearly" }],
+        note: "Priced by image volume rather than by site, so the cost does not rise with fleet size. Billed yearly is the page default.",
+        verifiedOn: "2026-08-07",
+      },
+    ],
+  },
+  {
+    key: "database",
+    label: "Database cleaning",
+    icon: "Database",
+    wpmgr: "Orphan classification with a preview before anything is deleted",
+    products: [
+      {
+        name: "Advanced Database Cleaner Pro",
+        url: "https://sigmaplugin.com/downloads/wordpress-advanced-database-cleaner",
+        tiers: [
+          { upTo: 1, perYear: 39, label: "Starter, 1 site" },
+          { upTo: 5, perYear: 59, label: "Standard, 5 sites" },
+          { upTo: Infinity, perYear: 119, label: "Agency, unlimited" },
+        ],
+        note: "Chosen over the better known alternatives on purpose: it sells database cleaning alone, so it cannot double count against the caching or image lines above.",
+        verifiedOn: "2026-08-07",
+      },
+    ],
+  },
+  {
+    key: "uptime",
+    label: "Uptime monitoring",
+    icon: "Activity",
+    wpmgr: "Built in, with TLS expiry checks",
+    products: [
+      {
+        name: "UptimeRobot",
+        url: "https://uptimerobot.com/pricing/",
+        tiers: [
+          { upTo: 10, perYear: 108, label: "Solo, 10 monitors" },
+          { upTo: 50, perYear: 228, label: "Solo, 50 monitors" },
+          { upTo: 100, perYear: 348, label: "Team, 100 monitors" },
+          { upTo: 200, perYear: 648, label: "Scale, 200 monitors" },
+          { upTo: 500, perYear: 1488, label: "Scale, 500 monitors" },
+        ],
+        note: "Priced per monitor and billed monthly; the annual figure is the monthly rate multiplied by twelve. A free tier covering 50 monitors exists at a longer check interval.",
+        verifiedOn: "2026-08-07",
+      },
+    ],
+  },
+  {
+    key: "reports",
+    label: "Client reporting",
+    icon: "FileText",
+    wpmgr: "White label reports and a client portal, built in",
+    products: [
+      {
+        name: "WP Umbrella",
+        url: "https://wp-umbrella.com/pricing/",
+        tiers: [{ upTo: Infinity, perYear: 26.28, label: "Pay as you go" }],
+        note: "Priced per site per month, so this line scales linearly with the fleet. The annual figure is the monthly rate multiplied by twelve.",
+        verifiedOn: "2026-08-07",
+      },
+    ],
+  },
+];
+
+/** Categories whose price is per site rather than per tier. */
+export const PER_SITE_KEYS = ["security", "reports"];
+
+/**
+ * The cheapest published tier that covers `sites`, or null when the fleet is
+ * larger than anything the vendor lists.
+ *
+ * Returning null rather than clamping to the top tier is deliberate. Several
+ * vendors stop publishing prices above a few hundred sites and quote privately
+ * from there, and silently reusing the 500-site price for a 900-site fleet
+ * would invent a number the vendor never offered. The UI says "priced on
+ * request" instead, which is both true and the more damaging fact anyway.
+ */
+export function resolveTier(product: CostProduct, sites: number): CostTier | null {
+  for (const tier of product.tiers) if (sites <= tier.upTo) return tier;
+  return null;
+}
+
+/** Annual cost of one product for `sites` sites, or null when unpublished. */
+export function annualCost(
+  category: CostCategory,
+  product: CostProduct,
+  sites: number,
+): number | null {
+  const tier = resolveTier(product, sites);
+  if (!tier) return null;
+  // Per-site vendors publish a RATE and a volume bracket, so the bracket
+  // selects the rate and the fleet size multiplies it. Tiered vendors publish
+  // a single figure that already covers the whole bracket.
+  return PER_SITE_KEYS.includes(category.key) ? tier.perYear * sites : tier.perYear;
+}
+
+/** Site counts offered as presets. 500 is the ceiling because it is the
+ *  largest fleet every product above still publishes a price for. */
+export const SITE_PRESETS = [1, 5, 10, 25, 50, 100, 250, 500];
+
+/** WPMgr hosted tiers, mirrored from lib/content/pricing.ts, in $/month. */
+export const WPMGR_TIERS = [
+  { name: "Free", sites: 3, perMonth: 0 },
+  { name: "Starter", sites: 10, perMonth: 15 },
+  { name: "Agency", sites: 50, perMonth: 59 },
+  { name: "Scale", sites: 200, perMonth: 169 },
+];
+
+export function resolveWpmgrTier(sites: number) {
+  return WPMGR_TIERS.find((t) => sites <= t.sites) ?? null;
+}

--- a/apps/marketing/lib/content/pricing.ts
+++ b/apps/marketing/lib/content/pricing.ts
@@ -14,6 +14,16 @@ export type PricingTier = {
   name: string;
   /** Fallback USD dollars/month, used whenever live pricing is unresolved. */
   price: number;
+  /**
+   * Sites this tier covers. STRUCTURED because more than one page needs it:
+   * /pricing renders it as the first feature line, and /pricing/plugin-stack
+   * uses it to pick the tier that matches the reader's fleet. It used to
+   * exist only as the string "50 sites" inside `features`, which meant the
+   * second page had to hardcode its own copy of the ladder and could drift
+   * from this one silently. The feature line is now generated from this
+   * number, so there is exactly one place to edit.
+   */
+  sites: number;
   audience: string;
   mostPopular?: boolean;
   features: string[];
@@ -26,14 +36,17 @@ export type PricingTier = {
   cta: Cta;
 };
 
-export const PRICING_TIERS: PricingTier[] = [
+// The first feature line is derived from `sites` rather than written out, so
+// the site cap has a single source that both /pricing and the plugin-stack
+// calculator read.
+const TIERS: PricingTier[] = [
   {
     id: "free",
     name: "Free",
     price: 0,
+    sites: 3,
     audience: "For trying it out or a small personal site",
     features: [
-      "3 sites",
       "Bring your own backup storage",
       "5-minute uptime checks",
       "The full feature set, nothing gated",
@@ -49,9 +62,9 @@ export const PRICING_TIERS: PricingTier[] = [
     id: "starter",
     name: "Starter",
     price: 15,
+    sites: 10,
     audience: "For freelancers and small portfolios",
     features: [
-      "10 sites",
       "50 GB managed backup storage",
       "Daily backups",
       "The full feature set, nothing gated",
@@ -67,10 +80,10 @@ export const PRICING_TIERS: PricingTier[] = [
     id: "agency",
     name: "Agency",
     price: 59,
+    sites: 50,
     audience: "The core plan for agencies",
     mostPopular: true,
     features: [
-      "50 sites",
       "250 GB managed backup storage",
       "Hourly backups",
       "The full feature set, nothing gated",
@@ -86,9 +99,9 @@ export const PRICING_TIERS: PricingTier[] = [
     id: "scale",
     name: "Scale",
     price: 169,
+    sites: 200,
     audience: "For large fleets",
     features: [
-      "200 sites",
       "1 TB managed backup storage",
       "Hourly backups",
       "The full feature set, nothing gated",
@@ -101,6 +114,11 @@ export const PRICING_TIERS: PricingTier[] = [
     },
   },
 ];
+
+export const PRICING_TIERS: PricingTier[] = TIERS.map((tier) => ({
+  ...tier,
+  features: [`${tier.sites} sites`, ...tier.features],
+}));
 
 export const PRICING_NOTE =
   "Self-hosting the control plane is free and unlimited forever under the AGPL-3.0 license, with no site limit and no feature gating. Annual billing on the hosted plans is coming soon; every plan above is billed monthly today.";

--- a/apps/marketing/lib/site.ts
+++ b/apps/marketing/lib/site.ts
@@ -74,6 +74,7 @@ export const FOOTER_NAV: NavGroup[] = [
       { label: "Performance", href: "/features/performance" },
       { label: "Security", href: "/features/security" },
       { label: "Pricing", href: "/pricing" },
+      { label: "Plugin stack cost", href: "/pricing/plugin-stack" },
     ],
   },
   {

--- a/apps/marketing/scripts/check-copy.mjs
+++ b/apps/marketing/scripts/check-copy.mjs
@@ -403,7 +403,15 @@ const marketingFiles = SCAN_DIRS.flatMap((d) =>
 // is about CODE PROVENANCE (do not credit a competitor as the source of a
 // technique we implemented), and it still binds everywhere it matters: agent
 // PHP below, plus docs/ and root *.md via ci.yml's docs vocabulary check.
-const isCompareFile = (f) => f.includes("/content/compare/") || f.includes("/compare/");
+// Any surface whose subject is somebody else's product. /compare/ is the
+// obvious one; the plugin-stack calculator is the same thing wearing a
+// different URL, since it names seven vendors and computes a number against
+// them, and it would be absurd for it to escape the rule on a path technicality.
+const isCompareFile = (f) =>
+  f.includes("/content/compare/") ||
+  f.includes("/compare/") ||
+  f.includes("plugin-costs") ||
+  f.includes("/plugin-stack/");
 for (const file of marketingFiles) {
   scanWholeFile(file, { names: false, quotesExempt: isCompareFile(file) });
 }


### PR DESCRIPTION
## What

A page where a reader computes what the plugins WPMgr replaces actually cost them: `/pricing/plugin-stack`.

Set a fleet size, drop any category you do not buy, swap the caching product, and every figure links to the vendor's own pricing page with the date it was read. The visual is the asymmetry, two bills top-aligned against the same fleet, one seven lines and one line.

Linked from `/pricing`, the footer, `sitemap.xml` and `llms.txt`.

## The three rules that keep the total defensible

Each one made the number smaller, which is the point.

**No product counted twice.** Every product sells one of the seven categories and little else. Two widely used suites are deliberately excluded because they bundle caching with image compression and database cleaning; including either would put one licence on two lines, which is the accusation that would sink the page.

**Recurring price, not first-year price.** Where a vendor advertises an introductory discount, the figure is what year two costs. One vendor's own pricing page footnotes that all renewals are at full price.

**Read in a rendered browser, on a date.** Several of these pricing pages build their prices with JavaScript, and a plain fetch returns a stale fallback, in one case a discount banner no visitor ever sees.

## Three defects found in verification

All three shared a shape: a number or a row that was only correct once an animation had run.

| | Symptom | Cause | Fix |
|---|---|---|---|
| 1 | Six of seven rows invisible while fully inside the viewport | Line items gated on a scroll reveal | Rows are plain markup |
| 2 | Both totals frozen while every row updated | `requestAnimationFrame` is throttled to zero frames in a backgrounded tab, and the displayed amount lived only in state written from inside the rAF callback | Tween is additive; the span falls back to the real value whenever no animation is in flight |
| 3 | A 500-site fleet was told WPMgr costs **$0** per year | `wpmgrYear ?? 0` coerced "no published tier" to zero | No published figure prints "On request" |

Defect 2 is the one worth keeping in mind: the page's entire argument is that total, so it is exactly the thing that must not depend on an animation frame. It is now correct on first paint, with JavaScript off, under reduced motion, and in any renderer where rAF never fires.

## Copy gate

`check-copy`'s disparagement rule is extended to cover these files. The page names seven vendors and computes a number against them, so it is a comparison surface wearing a different URL and should not escape the rule on a path technicality. Verified by planting violations in both new files and confirming the gate fails, then passes after restore.

## Verification

- `typecheck`, `lint`, `check-copy`, `build` green
- Totals checked against the sum of the rendered rows at all 8 fleet presets, and with two categories deselected
- Tier boundaries exercised across every vendor bracket
- No horizontal overflow at 390 / 768 / 1280 in-page
- Dark mode, deselected-row state, and the reduced-motion path checked

## Known, pre-existing, not touched here

The site header overflows the viewport at exactly 768px (`scrollWidth` 869), because the megamenu and all four action items switch on at `md:` together. It is identical on `/pricing` and every other page, so it is not introduced by this PR. The fix is moving that switch to `lg:`, but that changes the header on every page and is a call for you rather than me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a plugin-cost comparison calculator with site-count selection, plugin categories, product options, and annual cost estimates.
  * Compare plugin-stack pricing with WPMgr pricing, potential savings, features, self-hosting options, and signup paths.
  * Added pricing methodology, product sources, verification details, FAQs, responsive comparison views, and accessible animated totals.
  * Added a plugin-cost comparison callout to the main pricing page.
  * Added footer navigation for easier access to the calculator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->