### PR TITLE
feat(marketing): featured illustrations and long-form rewrite for all ten blog posts

### DIFF
--- a/apps/marketing/app/blog/[category]/[slug]/page.tsx
+++ b/apps/marketing/app/blog/[category]/[slug]/page.tsx
@@ -12,6 +12,7 @@ import {
 import { FEATURE_REGISTRY } from "@/lib/content/features";
 import { SOLUTION_REGISTRY } from "@/lib/content/solutions";
 import { Container } from "@/components/ui/primitives";
+import { PostArt } from "@/components/blog/post-art";
 import { SiteHeader } from "@/components/sections/header";
 import { SiteFooter } from "@/components/sections/footer";
 import { ScrollProgress } from "@/components/motion/scroll-progress";
@@ -153,6 +154,15 @@ export default async function BlogPostPage({ params }: Props) {
             <p className="mt-4 text-lg leading-relaxed text-[var(--muted-foreground)] max-w-[72ch]">
               {fm.description}
             </p>
+
+            {/* Featured art. Below the deck rather than above the h1: the
+                headline is the LCP element on this page and must not be pushed
+                under the fold by a decorative band. */}
+            <PostArt
+              art={fm.art}
+              category={category as BlogCategory}
+              className="mt-10 w-full overflow-hidden rounded-xl border border-[var(--border)]"
+            />
           </Container>
         </section>
 

--- a/apps/marketing/app/blog/[category]/page.tsx
+++ b/apps/marketing/app/blog/[category]/page.tsx
@@ -9,6 +9,7 @@ import {
   type BlogCategory,
 } from "@/lib/content/blog";
 import { Container, Section, Badge } from "@/components/ui/primitives";
+import { PostArt } from "@/components/blog/post-art";
 import { SiteHeader } from "@/components/sections/header";
 import { SiteFooter } from "@/components/sections/footer";
 
@@ -151,8 +152,16 @@ export default async function BlogCategoryPage({ params }: Props) {
                     <li key={frontmatter.slug}>
                       <Link
                         href={`/blog/${cat}/${frontmatter.slug}`}
-                        className="group flex h-full flex-col rounded-xl border border-[var(--border)] bg-card p-6 shadow-sm transition-shadow hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+                        className="group flex h-full flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-card shadow-sm transition-shadow hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
                       >
+                        {/* Featured art. overflow-hidden on the card clips it
+                            under the top corners, so it runs edge to edge. */}
+                        <PostArt
+                          art={frontmatter.art}
+                          category={frontmatter.category}
+                          className="w-full border-b border-[var(--border)]"
+                        />
+                        <div className="flex flex-1 flex-col p-6">
                         <div className="mb-4 flex items-center gap-3">
                           <Badge>{meta.label}</Badge>
                           <time
@@ -168,6 +177,7 @@ export default async function BlogCategoryPage({ params }: Props) {
                         <p className="mt-auto text-sm leading-relaxed text-[var(--muted-foreground)]">
                           {frontmatter.description}
                         </p>
+                        </div>
                       </Link>
                     </li>
                   );

--- a/apps/marketing/app/blog/page.tsx
+++ b/apps/marketing/app/blog/page.tsx
@@ -4,6 +4,7 @@ import { buildMetadata, buildBreadcrumbLd } from "@/lib/seo";
 import { JsonLd } from "@/lib/json-ld";
 import { getAllPosts, BLOG_CATEGORIES } from "@/lib/content/blog";
 import { Container, Section, Badge } from "@/components/ui/primitives";
+import { PostArt } from "@/components/blog/post-art";
 import { SiteHeader } from "@/components/sections/header";
 import { SiteFooter } from "@/components/sections/footer";
 
@@ -110,8 +111,16 @@ export default function BlogIndexPage() {
                     <li key={`${frontmatter.category}/${frontmatter.slug}`}>
                       <Link
                         href={`/blog/${frontmatter.category}/${frontmatter.slug}`}
-                        className="group flex h-full flex-col rounded-xl border border-[var(--border)] bg-card p-6 shadow-sm transition-shadow hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+                        className="group flex h-full flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-card shadow-sm transition-shadow hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
                       >
+                        {/* Featured art. overflow-hidden on the card clips it
+                            under the top corners, so it runs edge to edge. */}
+                        <PostArt
+                          art={frontmatter.art}
+                          category={frontmatter.category}
+                          className="w-full border-b border-[var(--border)]"
+                        />
+                        <div className="flex flex-1 flex-col p-6">
                         <div className="mb-4 flex items-center gap-3">
                           <Badge>{catMeta ? catMeta.label : frontmatter.category}</Badge>
                           <time
@@ -127,6 +136,7 @@ export default function BlogIndexPage() {
                         <p className="mt-auto text-sm leading-relaxed text-[var(--muted-foreground)]">
                           {frontmatter.description}
                         </p>
+                        </div>
                       </Link>
                     </li>
                   );

--- a/apps/marketing/components/blog/post-art.tsx
+++ b/apps/marketing/components/blog/post-art.tsx
@@ -1,0 +1,621 @@
+/**
+ * Featured art for blog posts.
+ *
+ * WHY DRAWN IN CODE RATHER THAN COMMISSIONED OR PHOTOGRAPHED. Stock photography
+ * of "a person at a laptop" says nothing about file integrity monitoring, and a
+ * sketchy hand-drawn scene reads as amateurish next to a product that sells
+ * operational seriousness. What is left is the thing good developer-tool blogs
+ * actually do: systematic, geometric art that encodes the subject of the piece.
+ * The scanner illustration IS a grid of plugins with one flagged. The vitals
+ * illustration IS three thresholds with a marker on each.
+ *
+ * Drawing them in code buys three things a static asset cannot. They theme
+ * themselves, because every colour is a design token and dark mode is already
+ * solved. They cost nothing to ship, because there is no binary in the repo and
+ * no image request on the page. And they cannot go stale against a rebrand,
+ * because they read the same variables the rest of the site does.
+ *
+ * RULES FOR ADDING ONE.
+ *
+ *   No text. Labels would need translating, would overflow at card size, and
+ *   would duplicate the title sitting directly beneath the art anyway.
+ *
+ *   No animation. These are featured images. Ten of them render at once on the
+ *   index, and a reveal that has not fired is a card that looks broken. Every
+ *   piece here is complete at first paint, with no script and no observer.
+ *
+ *   Decorative only. Each is aria-hidden: the post title carries the meaning,
+ *   and announcing "diagram of a grid" to a screen reader adds noise, not
+ *   information.
+ *
+ *   Geometry, not depiction. Rectangles, circles, lines and arcs on a 400x225
+ *   field. If a piece needs a recognisable real-world object to work, it is the
+ *   wrong idea for this system.
+ */
+
+import type { BlogCategory } from "@/lib/content/blog";
+
+const W = 400;
+const H = 225;
+
+/**
+ * Shared field: the tinted ground every piece is drawn on.
+ *
+ * Deliberately square-cornered and unbordered. Rounding and framing belong to
+ * whatever is placing the art: a card clips it with overflow-hidden so the art
+ * runs edge to edge under the top corners, and the post hero rounds and borders
+ * its own wrapper. Drawing a rounded, stroked panel in here instead put a
+ * rounded box inside a rounded card, which reads as a nested card.
+ */
+function Field() {
+  return <rect x="0" y="0" width={W} height={H} fill="var(--primary-subtle)" />;
+}
+
+const ART_PROPS = {
+  viewBox: `0 0 ${W} ${H}`,
+  xmlns: "http://www.w3.org/2000/svg",
+  "aria-hidden": true,
+  focusable: "false",
+  preserveAspectRatio: "xMidYMid meet",
+  className: "h-full w-full",
+} as const;
+
+/* ------------------------------------------------------------------ *
+ * Security                                                            *
+ * ------------------------------------------------------------------ */
+
+/** Hardened login: many attempts, three barriers, one key through. */
+function GateArt() {
+  const attempts = [40, 68, 96, 124, 152];
+  return (
+    <svg {...ART_PROPS}>
+      <Field />
+      {/* Attempts arriving from the left. All but one stop at the first wall. */}
+      {attempts.map((y, i) => (
+        <g key={y}>
+          <circle cx={i % 2 === 0 ? 30 : 44} cy={y} r="4" fill="var(--muted-foreground)" opacity="0.45" />
+          <line
+            x1={i % 2 === 0 ? 38 : 52}
+            y1={y}
+            x2="104"
+            y2={y}
+            stroke="var(--muted-foreground)"
+            strokeWidth="1.5"
+            strokeDasharray="3 4"
+            opacity="0.4"
+          />
+        </g>
+      ))}
+
+      {/* Three barriers, increasing in solidity left to right. */}
+      {[
+        { x: 112, o: 0.35 },
+        { x: 152, o: 0.6 },
+        { x: 192, o: 1 },
+      ].map((b) => (
+        <rect
+          key={b.x}
+          x={b.x}
+          y="38"
+          width="10"
+          height={H - 76}
+          rx="5"
+          fill="var(--primary)"
+          opacity={b.o}
+        />
+      ))}
+
+      {/* The one credential that passes, drawn as a key travelling through. */}
+      <line
+        x1="104"
+        y1="112"
+        x2="286"
+        y2="112"
+        stroke="var(--primary)"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+      <circle cx="300" cy="112" r="18" fill="none" stroke="var(--primary)" strokeWidth="2.5" />
+      <circle cx="300" cy="112" r="6" fill="var(--primary)" />
+      <rect x="316" y="108" width="30" height="8" rx="4" fill="var(--primary)" />
+      <rect x="336" y="116" width="6" height="10" rx="3" fill="var(--primary)" />
+    </svg>
+  );
+}
+
+/** File integrity: rows of hashes, one of them diverged. */
+function IntegrityArt() {
+  const rows = [50, 82, 114, 146, 178];
+  const drifted = 114;
+  return (
+    <svg {...ART_PROPS}>
+      <Field />
+      {rows.map((y) => {
+        const bad = y === drifted;
+        const tint = bad ? "var(--warning-subtle-fg)" : "var(--primary)";
+        return (
+          <g key={y}>
+            {/* file glyph */}
+            <rect
+              x="34"
+              y={y - 11}
+              width="18"
+              height="22"
+              rx="3"
+              fill="none"
+              stroke={bad ? tint : "var(--muted-foreground)"}
+              strokeWidth="1.6"
+              opacity={bad ? 1 : 0.65}
+            />
+            {/* hash segments */}
+            {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => (
+              <rect
+                key={i}
+                x={68 + i * 26}
+                y={y - 5}
+                width={18}
+                height="10"
+                rx="2"
+                fill={bad && i === 5 ? tint : "var(--primary)"}
+                opacity={bad ? (i === 5 ? 1 : 0.25) : 0.55}
+              />
+            ))}
+            {/* verdict */}
+            {bad ? (
+              <g stroke={tint} strokeWidth="2.2" strokeLinecap="round">
+                <line x1="288" y1={y - 5} x2="298" y2={y + 5} />
+                <line x1="298" y1={y - 5} x2="288" y2={y + 5} />
+              </g>
+            ) : (
+              <path
+                d={`M287 ${y} l4 5 l8 -10`}
+                fill="none"
+                stroke="var(--success)"
+                strokeWidth="2.2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+/** Vulnerability scanning: a grid of installed things, one matched. */
+function ScannerArt() {
+  const cols = 6;
+  const rows = 4;
+  const flagged = 15;
+  return (
+    <svg {...ART_PROPS}>
+      <Field />
+      {Array.from({ length: cols * rows }, (_, i) => {
+        const cx = 46 + (i % cols) * 52;
+        const cy = 44 + Math.floor(i / cols) * 46;
+        const hit = i === flagged;
+        return (
+          <rect
+            key={i}
+            x={cx}
+            y={cy}
+            width="38"
+            height="32"
+            rx="5"
+            fill={hit ? "var(--warning-subtle)" : "var(--card)"}
+            stroke={hit ? "var(--warning-subtle-fg)" : "var(--border)"}
+            strokeWidth={hit ? 2 : 1.2}
+          />
+        );
+      })}
+      {/* the match, marked rather than animated */}
+      <circle
+        cx={46 + (flagged % cols) * 52 + 19}
+        cy={44 + Math.floor(flagged / cols) * 46 + 16}
+        r="21"
+        fill="none"
+        stroke="var(--warning-subtle-fg)"
+        strokeWidth="1.5"
+        opacity="0.55"
+      />
+      {/* sweep, drawn at rest partway across */}
+      <line
+        x1="228"
+        y1="26"
+        x2="228"
+        y2={H - 26}
+        stroke="var(--primary)"
+        strokeWidth="2"
+        opacity="0.75"
+      />
+      <circle cx="228" cy="26" r="3.5" fill="var(--primary)" />
+    </svg>
+  );
+}
+
+/* ------------------------------------------------------------------ *
+ * Performance                                                         *
+ * ------------------------------------------------------------------ */
+
+/** Core Web Vitals: three metrics against their thresholds. */
+function VitalsArt() {
+  const tracks = [
+    { y: 62, pos: 0.3 },
+    { y: 112, pos: 0.52 },
+    { y: 162, pos: 0.78 },
+  ];
+  const x0 = 46;
+  const x1 = 354;
+  const span = x1 - x0;
+  return (
+    <svg {...ART_PROPS}>
+      <Field />
+      {tracks.map((t) => {
+        const marker = x0 + span * t.pos;
+        return (
+          <g key={t.y}>
+            {/* good / needs work / poor bands */}
+            <rect x={x0} y={t.y - 6} width={span * 0.5} height="12" rx="6" fill="var(--success)" opacity="0.32" />
+            <rect x={x0 + span * 0.5} y={t.y - 6} width={span * 0.25} height="12" fill="var(--warning-subtle-fg)" opacity="0.28" />
+            <rect x={x0 + span * 0.75} y={t.y - 6} width={span * 0.25} height="12" rx="6" fill="var(--muted-foreground)" opacity="0.25" />
+            {/* threshold ticks */}
+            <line x1={x0 + span * 0.5} y1={t.y - 14} x2={x0 + span * 0.5} y2={t.y + 14} stroke="var(--border)" strokeWidth="1.5" />
+            <line x1={x0 + span * 0.75} y1={t.y - 12} x2={x0 + span * 0.75} y2={t.y + 12} stroke="var(--border)" strokeWidth="1.5" />
+            {/* measured value */}
+            <circle cx={marker} cy={t.y} r="8" fill="var(--card)" stroke="var(--primary)" strokeWidth="3" />
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+/** Image optimization: the same picture, three encodings, descending weight. */
+function CompressArt() {
+  const bars = [
+    { x: 60, h: 118, o: 0.3 },
+    { x: 158, h: 74, o: 0.6 },
+    { x: 256, h: 42, o: 1 },
+  ];
+  const base = 182;
+  return (
+    <svg {...ART_PROPS}>
+      <Field />
+      <line x1="40" y1={base} x2="360" y2={base} stroke="var(--border)" strokeWidth="1.5" />
+      {bars.map((b) => (
+        <g key={b.x}>
+          <rect
+            x={b.x}
+            y={base - b.h}
+            width="84"
+            height={b.h}
+            rx="6"
+            fill="var(--primary)"
+            opacity={b.o}
+          />
+          {/* a picture glyph riding the top of each bar */}
+          <rect
+            x={b.x + 22}
+            y={base - b.h - 26}
+            width="40"
+            height="20"
+            rx="3"
+            fill="none"
+            stroke="var(--primary)"
+            strokeWidth="1.6"
+            opacity="0.8"
+          />
+          <circle cx={b.x + 33} cy={base - b.h - 18} r="3" fill="var(--primary)" opacity="0.8" />
+          <path
+            d={`M${b.x + 27} ${base - b.h - 10} l9 -8 l7 6 l5 -4 l6 6 z`}
+            fill="var(--primary)"
+            opacity="0.8"
+          />
+        </g>
+      ))}
+      {/* the saving, as a descending step line */}
+      <path
+        d={`M60 ${base - 118 - 34} H144 V${base - 74 - 34} H242 V${base - 42 - 34} H340`}
+        fill="none"
+        stroke="var(--success)"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeDasharray="1 0"
+        opacity="0.9"
+      />
+    </svg>
+  );
+}
+
+/** Object cache: the short path to memory beside the long one to the database. */
+function CacheArt() {
+  return (
+    <svg {...ART_PROPS}>
+      <Field />
+      {/* request origin */}
+      <rect x="30" y="94" width="46" height="38" rx="6" fill="var(--card)" stroke="var(--border)" strokeWidth="1.4" />
+      <line x1="40" y1="106" x2="66" y2="106" stroke="var(--muted-foreground)" strokeWidth="2" strokeLinecap="round" />
+      <line x1="40" y1="113" x2="60" y2="113" stroke="var(--muted-foreground)" strokeWidth="2" strokeLinecap="round" opacity="0.6" />
+      <line x1="40" y1="120" x2="63" y2="120" stroke="var(--muted-foreground)" strokeWidth="2" strokeLinecap="round" opacity="0.6" />
+
+      {/* hit: short lane up to memory */}
+      <path d="M76 106 C 120 106, 130 62, 176 62" fill="none" stroke="var(--primary)" strokeWidth="2.5" strokeLinecap="round" />
+      <rect x="182" y="42" width="74" height="40" rx="7" fill="var(--primary)" opacity="0.16" />
+      <rect x="182.75" y="42.75" width="72.5" height="38.5" rx="6.25" fill="none" stroke="var(--primary)" strokeWidth="1.5" />
+      {[0, 1, 2, 3].map((i) => (
+        <rect key={i} x={192 + i * 16} y="54" width="9" height="17" rx="2" fill="var(--primary)" opacity="0.85" />
+      ))}
+      <path d="M256 62 C 300 62, 306 100, 340 100" fill="none" stroke="var(--primary)" strokeWidth="2.5" strokeLinecap="round" />
+      <path d="M334 94 l8 6 l-8 6" fill="none" stroke="var(--primary)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+
+      {/* miss: long lane down to the database */}
+      <path
+        d="M76 122 C 120 122, 130 172, 176 172"
+        fill="none"
+        stroke="var(--muted-foreground)"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeDasharray="5 5"
+        opacity="0.55"
+      />
+      <g opacity="0.55" stroke="var(--muted-foreground)" strokeWidth="1.6" fill="none">
+        <ellipse cx="219" cy="154" rx="34" ry="10" />
+        <path d="M185 154 v30 c0 5.5 15.2 10 34 10 s34 -4.5 34 -10 v-30" />
+        <path d="M185 170 c0 5.5 15.2 10 34 10 s34 -4.5 34 -10" />
+      </g>
+      <path
+        d="M253 172 C 300 172, 306 130, 340 130"
+        fill="none"
+        stroke="var(--muted-foreground)"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeDasharray="5 5"
+        opacity="0.55"
+      />
+    </svg>
+  );
+}
+
+/* ------------------------------------------------------------------ *
+ * Backups                                                             *
+ * ------------------------------------------------------------------ */
+
+/** Backup strategy: full plus increments, receding across a retention window. */
+function SnapshotsArt() {
+  const slabs = [0, 1, 2, 3, 4, 5];
+  const base = 158;
+  return (
+    <svg {...ART_PROPS}>
+      <Field />
+      {slabs.map((i) => {
+        const full = i === 0 || i === 3;
+        const x = 44 + i * 52;
+        const h = full ? 74 : 34;
+        return (
+          <g key={i}>
+            <rect
+              x={x}
+              y={base - h}
+              width="38"
+              height={h}
+              rx="5"
+              fill="var(--primary)"
+              opacity={full ? 0.9 : 0.4}
+            />
+            {full && (
+              <rect x={x} y={base - h} width="38" height="8" rx="4" fill="var(--primary)" />
+            )}
+            {/* time tick */}
+            <line x1={x + 19} y1={base + 8} x2={x + 19} y2={base + 16} stroke="var(--border)" strokeWidth="1.5" />
+          </g>
+        );
+      })}
+      {/* retention axis */}
+      <line x1="34" y1={base + 8} x2="366" y2={base + 8} stroke="var(--border)" strokeWidth="1.5" />
+      {/* the window that is kept */}
+      <rect
+        x="36"
+        y="36"
+        width={330}
+        height={base - 22}
+        rx="8"
+        fill="none"
+        stroke="var(--primary)"
+        strokeWidth="1.5"
+        strokeDasharray="6 6"
+        opacity="0.45"
+      />
+    </svg>
+  );
+}
+
+/** Restore: a timeline, and the point you go back to. */
+function RestoreArt() {
+  const pts = [64, 116, 168, 220, 272, 324];
+  const target = 168;
+  const y = 138;
+  return (
+    <svg {...ART_PROPS}>
+      <Field />
+      <line x1="40" y1={y} x2="360" y2={y} stroke="var(--border)" strokeWidth="2" />
+      {pts.map((x) => {
+        const isTarget = x === target;
+        const after = x > target;
+        return (
+          <circle
+            key={x}
+            cx={x}
+            cy={y}
+            r={isTarget ? 10 : 6}
+            fill={isTarget ? "var(--primary)" : after ? "var(--card)" : "var(--primary)"}
+            stroke={isTarget ? "var(--primary)" : after ? "var(--muted-foreground)" : "var(--primary)"}
+            strokeWidth={isTarget ? 3 : 1.6}
+            opacity={after ? 0.5 : 1}
+          />
+        );
+      })}
+      {/* the rewind */}
+      <path
+        d={`M324 ${y - 22} C 300 ${y - 74}, 210 ${y - 74}, ${target + 2} ${y - 20}`}
+        fill="none"
+        stroke="var(--primary)"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+      <path
+        d={`M${target - 6} ${y - 30} l6 12 l13 -4`}
+        fill="none"
+        stroke="var(--primary)"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* the state that gets replaced */}
+      <rect x={target + 24} y={y + 18} width={132} height="10" rx="5" fill="var(--muted-foreground)" opacity="0.25" />
+      <rect x="40" y={y + 18} width={target - 46} height="10" rx="5" fill="var(--primary)" opacity="0.7" />
+    </svg>
+  );
+}
+
+/* ------------------------------------------------------------------ *
+ * Agency operations                                                   *
+ * ------------------------------------------------------------------ */
+
+/** A fleet: many sites, one pane, status at a glance. */
+function FleetArt() {
+  const cells = Array.from({ length: 12 }, (_, i) => i);
+  // Deterministic status: most fine, two attention, one down. No randomness,
+  // so the art is byte-identical between server and client render.
+  const attention = [4, 9];
+  const down = [7];
+  return (
+    <svg {...ART_PROPS}>
+      <Field />
+      {/* the pane */}
+      <rect x="30" y="30" width={W - 60} height={H - 60} rx="10" fill="var(--card)" stroke="var(--border)" strokeWidth="1.4" />
+      <line x1="30" y1="58" x2={W - 30} y2="58" stroke="var(--border)" strokeWidth="1.2" />
+      <circle cx="46" cy="44" r="3.5" fill="var(--primary)" />
+      <rect x="58" y="40" width="54" height="8" rx="4" fill="var(--muted-foreground)" opacity="0.35" />
+
+      {cells.map((i) => {
+        const cx = 46 + (i % 4) * 80;
+        const cy = 74 + Math.floor(i / 4) * 42;
+        const tone = down.includes(i)
+          ? "var(--warning-subtle-fg)"
+          : attention.includes(i)
+            ? "var(--info)"
+            : "var(--success)";
+        return (
+          <g key={i}>
+            <rect x={cx} y={cy} width="66" height="30" rx="5" fill="var(--muted)" opacity="0.5" />
+            <circle cx={cx + 12} cy={cy + 15} r="4.5" fill={tone} />
+            <rect x={cx + 23} y={cy + 11} width="32" height="4" rx="2" fill="var(--muted-foreground)" opacity="0.5" />
+            <rect x={cx + 23} y={cy + 19} width="20" height="4" rx="2" fill="var(--muted-foreground)" opacity="0.3" />
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+/** White-label reporting: your header, their numbers. */
+function ReportArt() {
+  return (
+    <svg {...ART_PROPS}>
+      <Field />
+      {/* page */}
+      <rect x="96" y="24" width="208" height={H - 48} rx="9" fill="var(--card)" stroke="var(--border)" strokeWidth="1.4" />
+      {/* the branded band, the whole point of the piece */}
+      <path d="M96 33 a9 9 0 0 1 9 -9 h190 a9 9 0 0 1 9 9 v25 H96 z" fill="var(--primary)" />
+      <circle cx="116" cy="41" r="7" fill="var(--primary-foreground)" opacity="0.9" />
+      <rect x="130" y="37" width="58" height="8" rx="4" fill="var(--primary-foreground)" opacity="0.75" />
+
+      {/* summary figures */}
+      {[0, 1, 2].map((i) => (
+        <g key={i}>
+          <rect x={112 + i * 64} y="74" width="52" height="34" rx="5" fill="var(--primary)" opacity="0.12" />
+          <rect x={120 + i * 64} y="82" width="26" height="9" rx="3" fill="var(--primary)" opacity="0.8" />
+          <rect x={120 + i * 64} y="96" width="36" height="5" rx="2.5" fill="var(--muted-foreground)" opacity="0.45" />
+        </g>
+      ))}
+
+      {/* a chart */}
+      {[26, 40, 30, 48, 36, 54].map((h, i) => (
+        <rect
+          key={i}
+          x={116 + i * 30}
+          y={182 - h}
+          width="18"
+          height={h}
+          rx="3"
+          fill="var(--primary)"
+          opacity={0.35 + i * 0.1}
+        />
+      ))}
+      <line x1="110" y1="182" x2="292" y2="182" stroke="var(--border)" strokeWidth="1.4" />
+    </svg>
+  );
+}
+
+/* ------------------------------------------------------------------ *
+ * Registry                                                            *
+ * ------------------------------------------------------------------ */
+
+export const POST_ART = {
+  gate: GateArt,
+  integrity: IntegrityArt,
+  scanner: ScannerArt,
+  vitals: VitalsArt,
+  compress: CompressArt,
+  cache: CacheArt,
+  snapshots: SnapshotsArt,
+  restore: RestoreArt,
+  fleet: FleetArt,
+  report: ReportArt,
+} as const;
+
+export type PostArtName = keyof typeof POST_ART;
+
+export function isPostArtName(value: unknown): value is PostArtName {
+  return typeof value === "string" && value in POST_ART;
+}
+
+/**
+ * Every category has a fallback, so a post that forgets the `art` key still
+ * gets a real illustration rather than an empty box. A missing key is a missed
+ * opportunity, never a broken card.
+ */
+const CATEGORY_FALLBACK: Record<BlogCategory, PostArtName> = {
+  "wordpress-security": "gate",
+  "wordpress-performance": "vitals",
+  "wordpress-backups": "snapshots",
+  "agency-operations": "fleet",
+};
+
+export function resolvePostArt(art: unknown, category: BlogCategory): PostArtName {
+  return isPostArtName(art) ? art : CATEGORY_FALLBACK[category];
+}
+
+/**
+ * Renders a post's art at a fixed 16:9. The aspect ratio is set on the wrapper
+ * rather than the svg so the card reserves its space before paint and nothing
+ * shifts, which matters on an index rendering ten of these.
+ */
+export function PostArt({
+  art,
+  category,
+  className,
+}: {
+  art?: unknown;
+  category: BlogCategory;
+  className?: string;
+}) {
+  const Art = POST_ART[resolvePostArt(art, category)];
+  return (
+    <div className={className} style={{ aspectRatio: "400 / 225" }}>
+      <Art />
+    </div>
+  );
+}

--- a/apps/marketing/content/blog/agency-operations/managing-multiple-wordpress-sites.mdx
+++ b/apps/marketing/content/blog/agency-operations/managing-multiple-wordpress-sites.mdx
@@ -2,6 +2,7 @@
 title: "Managing Multiple WordPress Sites: How to Stay Ahead of 50 Clients"
 description: "Practical systems for managing a WordPress client portfolio: fleet dashboards, bulk updates, backup monitoring, and how to scale without burning out."
 category: "agency-operations"
+art: "fleet"
 date: "2026-06-12"
 author: "WPMgr Team"
 tags: ["agency", "fleet-management", "operations"]

--- a/apps/marketing/content/blog/agency-operations/managing-multiple-wordpress-sites.mdx
+++ b/apps/marketing/content/blog/agency-operations/managing-multiple-wordpress-sites.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Managing Multiple WordPress Sites: How to Stay Ahead of 50 Clients"
-description: "Practical systems for managing a WordPress client portfolio: fleet dashboards, bulk updates, backup monitoring, and how to scale without burning out."
+description: "The systems that make a WordPress portfolio scale: why operational cost grows faster than site count, safe fleet updates, catching silent backup failures, and standardising onboarding."
 category: "agency-operations"
 art: "fleet"
 date: "2026-06-12"
@@ -10,73 +10,112 @@ featureSlug: "updates"
 solutionSlug: "agencies"
 ---
 
-At 5 sites, you can keep everything in your head. At 15, you need a spreadsheet. At 50, you need a system. The difference between an agency that scales and one that burns out is usually not talent. It is process.
+At five sites you can keep everything in your head. At fifteen you need a spreadsheet. At fifty the spreadsheet is lying to you and you do not know which rows.
 
-## The three problems that grow with fleet size
+The difference between an agency that scales past this point and one that stalls is rarely talent. It is whether the work of running sites grows with the number of sites, or with the number of exceptions.
 
-Every site you add to your portfolio creates a small increment of operational load. Three costs grow roughly linearly with site count:
+## The cost does not grow linearly
 
-**Update overhead.** Each plugin update on each site needs to be applied, tested, and confirmed. At 50 sites with 20 plugins each, that is 1,000 updates per plugin release cycle. Without automation, this becomes the majority of an agency's time.
+The usual framing is that each site adds a fixed increment of work. That understates it, because three costs grow at different rates and one of them compounds.
 
-**Monitoring overhead.** A site that goes down at 3am needs someone to know about it and respond. Without centralised monitoring, you either miss incidents or you are watching dashboards manually.
+**Update volume grows linearly.** Fifty sites with twenty plugins each is a thousand installed components. At a plugin release cadence of roughly monthly, that is a continuous stream of updates that never ends and never gets smaller.
 
-**Backup confirmation.** A backup that fails silently is not a backup. Confirming that backups ran and succeeded across a fleet is impossible to do manually at scale.
+**Incident surface grows linearly.** More sites, more outages, more 3am pages, more clients emailing about something you have not seen yet.
 
-## What changes when you centralise
+**Configuration drift grows worse than linearly.** This is the one that actually breaks agencies. Every site accumulates its own exceptions: the client who insisted on that plugin, the one where a fix was applied manually and never documented, the one restored from an old backup that quietly reverted its hardening. The cost is not maintaining fifty sites. It is maintaining fifty *different* sites, and the number of ways they can differ grows faster than the count.
 
-A centralised management platform connects to every site in your fleet and gives you a single view across all of them. The effect is not just convenience. It changes the math.
+Automation addresses the first two. Only standardisation addresses the third, which is why "we will fix it with a tool" fails on its own.
 
-Instead of applying an update to 50 sites one at a time, you run it across the fleet in one operation and the platform reports which sites succeeded, which failed, and why. Instead of checking 50 monitoring dashboards, you see a status matrix that flags the five sites with problems.
+## What centralisation changes
 
-The operational cost of a fleet at 50 sites becomes closer to the cost of managing 5 sites well.
+A control plane connected to every site turns a set of individual questions into one query. That sounds like convenience and is actually a change in what is possible.
 
-## Update strategy at scale
+"Is this site backed up" is a question you can ask fifty times. "Which sites are not backed up" is a question you can only ask if something holds all fifty. The first scales with your patience; the second does not scale at all, which is the point.
 
-Safe fleet updates require a specific sequence:
+The same applies to "which sites are running a vulnerable version of this plugin", asked the morning a disclosure lands. Answering that by logging into fifty dashboards takes a day. Answering it from a fleet inventory takes a moment, and the difference decides whether you patch before or after the exploit traffic arrives.
 
-1. **Snapshot first.** Take a backup immediately before the update. If the update breaks something, restore from the snapshot.
-2. **Stage before production.** For high-risk updates (major version changes, core updates, plugins with a history of compatibility issues), test on a staging site first.
-3. **Batch by risk.** Not all sites are equal. An e-commerce site with active orders is higher risk than a simple brochure site. Update lower-risk sites first, confirm they are healthy, then proceed to higher-risk sites.
-4. **Monitor after.** After a batch of updates, check uptime and error rates for a short window before moving on.
+## Updating a fleet without breaking it
 
-WPMgr automates steps 1 and 4. Step 2 requires a staging environment per client site (recommended but not always feasible). Step 3 is a configuration choice per site or per tag group.
+The instinct once bulk updates are available is to apply everything everywhere. That works until the day it does not, and the day it does not, it fails across your entire portfolio simultaneously.
 
-## Client reporting without extra work
+A sequence that holds up:
 
-Clients ask "what have you done for my site?" Generating meaningful answers from memory is time-consuming and unreliable. Pulling from a system that records every action automatically takes seconds.
+1. **Snapshot before every update.** Not nightly, immediately before. A broken update then becomes a rollback rather than an incident, and this single practice removes most of the risk of the rest.
+2. **Stage the risky ones.** Major version bumps, core updates, anything touching checkout, membership, or forms. Not everything needs staging, and pretending it does means nobody does it.
+3. **Batch by risk, not alphabetically.** Update low-stakes sites first, confirm they are healthy, then move up. Your own site and internal projects make excellent canaries.
+4. **Wait between batches.** A plugin update that breaks something rarely breaks it instantly. A short soak after each batch catches problems while the blast radius is small.
+5. **Watch afterwards, and watch for the right thing.** A fatal error is obvious. A contact form that silently stopped sending is not, and it is the failure that costs a client relationship. Uptime checks that look for expected content rather than a 200 status catch the second kind.
 
-WPMgr's audit log records every operation: update applied, backup taken, setting changed, who did it, and when. White-label maintenance reports pull from this log and present it in a branded PDF or email summary. You configure the report template once per client and the report generates on a schedule.
+WPMgr automates the snapshot and the post-update monitoring. Batching is a configuration choice per site or per tag group. Staging still needs a staging environment, which not every client site will have, and it is worth being honest with yourself about which ones do.
 
-This is not just a time saver. It is evidence that you are maintaining the site well, which supports the value of your retainer and reduces disputes about what work was done.
+## Backups fail silently, which is the whole problem
 
-## Backup monitoring: the silent failure problem
+The dangerous backup failure is not the one that errors. It is the one that reports success.
 
-The most common backup failure mode is silent failure. The backup job runs, but something goes wrong partway through and the backup is incomplete. If nobody checks, you discover the problem when you need to restore.
+A job that ran but timed out partway. A destination whose credentials expired three weeks ago. A database dump that has been producing a valid, empty file since a schema change. Each of these produces a green tick and a backup you cannot restore from, and you find out at the worst possible moment.
 
-At scale, checking each site's backup status manually is not feasible. A fleet-wide backup health view that surfaces sites with failed, stale, or missing backups lets you catch problems before they matter.
+At fifty sites nobody is checking this by hand, which means the check has to be structural. What you want surfaced is not "backups are on" but the specific anomalies: sites with no successful backup in the last 24 hours, sites where the backup size dropped sharply against its own history, sites whose last success is older than their schedule implies.
 
-WPMgr's backup health dashboard shows the last backup timestamp, success status, and backup size for every site in the fleet. Sites that have not backed up in more than 24 hours are highlighted. Sites where the backup size dropped significantly (a potential sign of a partial backup) are flagged.
+Size is the underrated signal. A backup that suddenly shrinks by 60 percent is almost always a partial capture, and it is invisible to any check that only looks at success or failure. WPMgr's backup health view reports last timestamp, status, and size per site, and flags staleness and size anomalies specifically, because those are the two failures that pass a naive check.
 
-## Tagging and organising your fleet
+## Tags are how a fleet stays navigable
 
-At 50 sites, you need a way to group and filter. Common groupings: by client, by platform version (sites running PHP 8.1, sites still on PHP 7.4), by risk level (e-commerce vs static), by hosting provider.
+At fifty sites you stop working with sites and start working with groups. Tagging is what makes bulk operations safe, because it lets you say "the low-risk brochure sites" rather than "all of them".
 
-WPMgr supports tags per site and filtering by tag in every fleet view. You can apply a bulk operation (update, backup, report generation) to all sites with a specific tag in one action.
+Groupings that earn their keep in practice: by client, so reporting and offboarding are one filter away; by risk, separating commerce and membership from brochure sites; by platform version, so you can find every site still on an old PHP release when your host announces a deprecation; and by hosting provider, because that is the unit that fails together during an outage.
 
-## The client onboarding workflow
+That last one is worth setting up before you need it. When a host has an incident, the useful question is "which of my sites are on that provider", and it is very hard to answer retroactively at speed.
 
-Consistency in onboarding saves time and reduces errors. A repeatable onboarding checklist for every new client site:
+## Alerting has to survive being ignored
 
-1. Install and activate the WPMgr agent on the site
-2. Connect the site to the control plane
-3. Run initial diagnostics (versions, uptime, backup status)
-4. Configure the backup destination and schedule
-5. Enable the security baseline (hardening controls, login protection)
-6. Tag the site with the client name and any relevant groupings
-7. Confirm the first backup completed successfully
-8. Set up the uptime monitor and alert threshold
-9. Schedule the first maintenance report
+Monitoring fifty sites generates enough events that the design question stops being "will we be told" and becomes "will anyone still be reading".
 
-WPMgr handles steps 3 through 9 from a single interface after the site is connected in step 2.
+Alert fatigue is not a personality failing. It is the predictable result of a channel where most messages need no action. Once a channel is mostly noise, people stop reading it, and the one alert that mattered arrives into a room nobody is in. The failure is silent and you only discover it during an incident.
 
-For more on agency tooling, see the [For agencies solution guide](/solutions/agencies/) and the [white-label reports feature page](/features/client-reports/).
+Three rules keep it usable.
+
+**Alert on confirmed conditions, not single observations.** One failed check from one location is usually a network blip. Requiring two or three consecutive failures, ideally from different vantage points, removes most false positives at the cost of a minute of detection time. That is nearly always the right trade.
+
+**Separate what wakes someone from what waits.** A site being down is an interrupt. A TLS certificate expiring in three weeks is a task. Sending both to the same place guarantees the second trains people to ignore the first.
+
+**Alert on recovery too.** An incident channel that only reports failures leaves everyone unsure whether the thing resolved itself, which produces exactly the manual dashboard-checking that centralisation was meant to remove.
+
+The related discipline is expiry. TLS certificates, domain renewals, and payment methods on hosting accounts all fail on a date you could have known months ahead. These are not monitoring problems, they are calendar problems, and they take out more client sites in practice than intrusions do.
+
+## Access is a fleet-level risk
+
+The structural weakness in most agency setups is not any individual site. It is that access to all of them is concentrated and casually managed.
+
+The pattern to avoid is a shared admin password reused across a client portfolio. It converts one exposure into fifty, and it is common because it is convenient in exactly the way that makes it dangerous.
+
+What to do instead is unglamorous: one account per person per site rather than a shared login, credentials in a password manager rather than a spreadsheet or a pinned message, two-factor on the control plane and the hosting accounts as well as the sites, and an offboarding step that actually runs. A departed contractor with live administrator accounts across a portfolio is a common and entirely avoidable exposure.
+
+Client offboarding deserves the same treatment. When an engagement ends, remove your agent, your accounts, and your monitoring, and confirm the client has their backups. Leaving access in place after the relationship ends is a liability with no upside.
+
+## Standardise onboarding, then never deviate
+
+Configuration drift starts on day one. A repeatable onboarding checklist is the cheapest control available, and the one most often skipped because the first few sites did not need it.
+
+1. Install and activate the agent on the site.
+2. Connect it to the control plane.
+3. Run initial diagnostics: core, PHP, and plugin versions, existing uptime, current backup state.
+4. Configure the backup destination and schedule.
+5. Apply the security baseline: login hardening, attempt limits, two-factor policy.
+6. Tag the site: client, risk level, host.
+7. Confirm the first backup actually completed, and check its size looks plausible.
+8. Set up uptime monitoring and the alert threshold.
+9. Schedule the first client report.
+
+Step 7 is the one that gets skipped, and it is the one that determines whether the other eight mattered. A backup configured is not a backup taken.
+
+WPMgr handles steps 3 through 9 from one interface once the site is connected.
+
+## Reporting is a byproduct, not a task
+
+Clients ask what you have been doing. Reconstructing an answer from memory is slow, unreliable, and quietly undersells the work, because you forget most of it.
+
+If every action is recorded as it happens, the report is a query rather than an exercise. WPMgr's audit log records each operation, what changed, who did it, and when, and white-label reports generate from that log on a schedule.
+
+The strategic point is that this is the artefact that justifies a retainer. Maintenance done well is invisible by construction: nothing breaks, so there is nothing to see. A report is what converts invisible work into evidence, which is why [maintenance reports](/blog/agency-operations/white-label-wordpress-reports) belong in the operational system rather than bolted on at renewal time.
+
+For the agency toolset, see the [for agencies solution guide](/solutions/agencies) and the [white-label reports feature page](/features/client-reports).

--- a/apps/marketing/content/blog/agency-operations/white-label-wordpress-reports.mdx
+++ b/apps/marketing/content/blog/agency-operations/white-label-wordpress-reports.mdx
@@ -1,6 +1,6 @@
 ---
 title: "White-Label WordPress Maintenance Reports: What to Include and How to Automate Them"
-description: "Maintenance reports communicate your value to clients. Learn what to include, how to automate generation, and how to brand them so clients see your agency, not your tools."
+description: "Maintenance done well is invisible. A report is what makes it visible. What belongs in one, what to leave out, how to automate generation from an audit log, and how branding changes what the client thinks they are buying."
 category: "agency-operations"
 art: "report"
 date: "2026-06-20"
@@ -10,61 +10,100 @@ featureSlug: "client-reports"
 solutionSlug: "agencies"
 ---
 
-Clients often do not know what you do for their sites. They see a monthly invoice and a site that keeps running. A well-structured maintenance report turns the invisible into visible, justifies your retainer, and reduces churn.
+Maintenance has an awkward property: when it works, there is nothing to show. Nothing broke, nothing was exploited, the site stayed up. From the client's side that is indistinguishable from nobody doing anything.
 
-## Why maintenance reports matter
+This is the entire reason maintenance retainers get cancelled. Not dissatisfaction, but the slow accumulation of months in which the client saw an invoice and no evidence. A report is the artefact that fixes it, and the mechanism is simple: it replaces "I pay for maintenance and nothing breaks" with "my agency applied 47 updates, closed a vulnerability before it was exploited, and kept the site up 99.9 percent of the month".
 
-Without a report, the client's mental model is "I pay for maintenance and nothing breaks." With a report, the mental model becomes "my agency ran 47 updates this month, caught a vulnerability before it was exploited, and my site had 99.9% uptime." The second mental model supports a much healthier client relationship.
+## What belongs in one
 
-Reports also create a paper trail. When a client questions a charge or asks what you have done for them in the last six months, you have a factual record instead of a reconstruction from memory.
+**Updates applied.** Plugins, themes, and core, with versions before and after. This is the bulk of the work and the easiest thing to understand. You do not need to explain what each update did.
 
-## What belongs in a WordPress maintenance report
+**Backup status.** When the last successful backup ran, how often they run, and where they are stored. "Backed up daily to encrypted offsite storage" reassures people who could not define any of those terms, which is most clients.
 
-**Updates applied.** Plugins, themes, and core updates run this period, with before and after versions. Clients understand "we kept your software up to date." You do not need to explain CVEs unless there is a security highlight worth noting.
+**Uptime and performance.** Uptime for the period, typical response time, and any incidents. Report incidents even when they went well; an outage you detected and resolved in nine minutes is a strong argument for your retainer, and hiding it wastes the best evidence you have.
 
-**Backup summary.** Confirmation that backups ran, when the last successful backup was, and where it is stored. "Your site is backed up daily to encrypted offsite storage" is reassuring even to non-technical clients.
+**Security.** Vulnerabilities found and patched, settings changed, suspicious activity blocked. For security-conscious clients this section alone justifies the engagement.
 
-**Uptime and performance.** Uptime percentage for the period (99.9% vs 98% means very different things), average response time, and any incidents. If there was downtime, include when it occurred and how it was resolved.
-
-**Security highlights.** Any vulnerabilities found and patched, security settings changed, or suspicious activity detected. This is the section that most clearly justifies ongoing maintenance to security-conscious clients.
-
-**Tasks completed.** Any manual work done outside the automated maintenance: content updates, plugin configuration, support requests. This section is manually added to each report since it varies by client.
+**Manual work.** Content changes, configuration, support requests handled. This is the part that varies per client and usually has to be written rather than generated, and it is also the part clients read most closely, because it is the part they remember asking for.
 
 ## What to leave out
 
-Do not include technical details that will not be understood or that create anxiety. "We patched a SQL injection vulnerability in the Foo plugin" might alarm a non-technical client. "We applied a critical security update to keep your site safe" communicates the same thing more effectively.
+**Detail that alarms rather than informs.** "We patched a SQL injection vulnerability in the checkout plugin" and "we applied a critical security update" describe the same event. The first invites a panicked email asking whether card data was exposed. Give the second, and keep the specifics available if asked.
 
-Do not include data that you cannot verify. If you are not sure whether a backup succeeded, do not claim it did.
+**Anything you have not verified.** Do not report a backup as successful because it was scheduled. A report is a claim, and one wrong claim discovered later costs more credibility than the entire report earns.
 
-## Automating report generation
+**Vanity metrics.** Number of files scanned, requests processed, queries cached. It reads as padding, and padding invites the question of whether the rest is padding too.
 
-Manual report generation is a significant time cost at scale. Every minute you spend assembling data for a report is a minute you are not spending on work that requires your expertise.
+**Raw tool output.** A pasted list of thirty plugin slugs and version numbers is data, not a report. Summarise, and attach the detail if the client is the sort who wants it.
 
-The prerequisite for automation is capturing the data systematically. If your tool records every update, every backup, and every uptime check with timestamps and outcomes, generating a report is a query against that record. If the data exists only in your memory or in ad-hoc notes, automation is not possible.
+## Automation requires the data to exist first
 
-WPMgr records all maintenance actions in an audit log per site. White-label reports pull from this log and generate a branded PDF or email summary on a schedule. You set the schedule (monthly, quarterly), the delivery method (email to client, PDF download, both), and the report template once per client. The report generates and sends without any manual work.
+Assembling reports by hand does not survive contact with a portfolio. At fifteen minutes each across forty clients, that is a full day a month spent transcribing, and it is the first thing to slip when you are busy, which is precisely when clients most need reassurance.
 
-## Branding your reports
+The prerequisite is not a report generator. It is a **record**. If every update, backup, scan, and setting change is captured with a timestamp and an outcome as it happens, a report is a query over that record. If the information lives in your memory, in Slack, and in three people's notes, no tool can assemble it, because the data was never collected.
 
-A white-label report shows your agency name and logo, not the name of the underlying tool. To clients, this looks like a proprietary system you built for them.
+This is why reporting belongs in the operational system rather than beside it. WPMgr records every operation in a per-site audit log, and reports are generated from that log on a schedule you set: monthly or quarterly, delivered by email, PDF, or both, using a template configured once per client.
 
-Elements to brand:
+The reason to care about the log specifically is that it is also the answer to a dispute. When a client asks what you did in March, or whether a change was yours, the log is a record made at the time rather than a reconstruction made under pressure.
 
-- Agency name and logo in the header
-- Agency contact information in the footer
-- Color scheme matching your agency brand
-- Report title ("Monthly Website Maintenance Report" under your agency name)
+## Branding, and what it actually signals
 
-What not to include: any mention of the underlying management platform. The point of white-labeling is that the client's relationship is with your agency.
+A white-label report carries your agency's name and identity, not your vendor's. Header, logo, colours, footer contact details, and a title under your own name.
 
-## Frequency and delivery
+The substantive reason is not vanity. A report branded with a third-party tool tells the client exactly which product you use and how much it costs, which reframes your retainer as a markup on a subscription they could buy themselves. That is not a conversation you want, and it is not even an accurate one, since what they are paying for is judgement, response, and accountability rather than software.
 
-Monthly reports work for most maintenance retainers. Quarterly works for lighter engagements. Weekly reports are generally too frequent unless the client is paying for a very active service.
+Keeping the tooling invisible keeps the conversation on the service. It is also simply true that the client's relationship is with you: when something breaks at midnight, they are not calling the vendor.
 
-Email delivery (a summary email with the full report attached or linked) gets higher open rates than a portal the client has to remember to check. If you use a portal, send an email notification when a new report is ready.
+## Structure it for someone who reads the first page only
 
-## The report as a retention tool
+Most clients read the summary and stop. That is not a failure of the report, it is the normal behaviour of a busy person, and the structure should assume it.
 
-A client who reads a detailed monthly report showing consistent work, zero security incidents, and 99.9% uptime is a client who understands the value of their retainer. Churn on maintenance retainers often happens when the client feels the cost is invisible. Reports make the cost visible by making the value visible.
+Put the conclusion first: a short block with uptime for the period, the number of updates applied, backup status, and whether anything needed attention. Someone who reads only that should come away with an accurate picture.
 
-For the report configuration and white-label settings, see the [white-label reports feature page](/features/client-reports/). For the full agency toolset, see the [for agencies solution guide](/solutions/agencies/).
+Then the detail, in sections they can skip. Then anything requiring a decision, clearly marked, at a place they will reach if they are the sort of reader who reaches it, and repeated in the delivery email if it genuinely needs action.
+
+The mistake is opening with a table of every plugin update. It is the longest section, the least interesting, and it buries the two facts the client actually wanted.
+
+Numbers need context to mean anything. "99.94 percent uptime" is meaningless to most people; "99.94 percent uptime, about 26 minutes unavailable across the month, during a host network incident on the 14th" is a sentence a client can evaluate. Where you can, show the direction of travel against previous periods, because a stable number stated monthly eventually reads as boilerplate.
+
+## The month something went wrong
+
+The instinct when a month has gone badly is to soften the report. This is exactly backwards, and how the report gets its credibility.
+
+If a site was down for two hours, say so: when it started, what caused it, when it was resolved, and what changed so it is less likely to recur. A client who reads an honest account of an incident you handled competently trusts every future report more. A client who later discovers an outage that was not mentioned stops trusting all of them, including the accurate ones.
+
+The same applies to work that did not happen. If an update was deferred because it would have broken a checkout customisation, that is a legitimate engineering decision and worth stating. Silently omitting it means that when it surfaces later, it looks like negligence rather than judgement.
+
+There is a practical benefit too. Documented incidents are the record you need when a client asks why they should keep paying for monitoring, and they are the evidence behind a recommendation to move a site to better hosting.
+
+## Cadence and delivery
+
+**Monthly** suits most maintenance retainers, and it matches the billing cycle, which is the point. The report should arrive near the invoice, so the value is present in mind when the cost is.
+
+**Quarterly** works for lighter engagements. **Weekly** is almost always too frequent: it dilutes each report and trains the client to ignore them.
+
+Deliver by email, with the report attached or summarised in the body. A portal the client has to remember to visit will not be visited. If you use one, send an email when a report is ready, and put the two or three numbers that matter in the email itself so a client who never clicks still receives the message.
+
+## Use it as an account management surface
+
+The best-run agencies treat the report as a conversation opener rather than a receipt.
+
+A site running an outdated PHP version, a plugin whose developer has stopped maintaining it, a steady rise in traffic approaching a hosting limit, a Core Web Vitals score that has been drifting for three months: each is a legitimate observation from your monitoring and each is a natural lead-in to work the client actually needs.
+
+That reframes the report from evidence you did the minimum to evidence you are paying attention. It is also the honest version of upselling, because the recommendation comes from data you were already collecting rather than from a quota.
+
+## The client who never opens them
+
+Some clients will never read a report. That is not a reason to stop sending them, and it changes what the report is for.
+
+Unread reports still do two jobs. They create the record you need the day someone questions six months of invoices, and they mean the value was communicated whether or not it was received, which is a materially different position to be in during a renewal conversation.
+
+What is worth adjusting is the delivery. For a client who does not open attachments, put the three numbers in the email body so the message lands even if nothing is clicked. For one who never replies at all, a short call once a quarter walking through the last three reports will do more than twelve more emails.
+
+## Why this reduces churn
+
+Churn on maintenance retainers is rarely a decision that something was done badly. It is a slow erosion of perceived value across months where nothing visible happened, ending in someone reviewing recurring costs and finding a line item they cannot justify.
+
+A monthly report that documents real work, real incidents caught, and real uptime makes that line item defensible without anyone having to argue for it. The work was always happening. The report is what makes it countable.
+
+For report configuration and white-label settings, see the [white-label reports feature page](/features/client-reports). For how reporting fits into running a portfolio, see [managing multiple WordPress sites](/blog/agency-operations/managing-multiple-wordpress-sites) and the [for agencies solution guide](/solutions/agencies).

--- a/apps/marketing/content/blog/agency-operations/white-label-wordpress-reports.mdx
+++ b/apps/marketing/content/blog/agency-operations/white-label-wordpress-reports.mdx
@@ -2,6 +2,7 @@
 title: "White-Label WordPress Maintenance Reports: What to Include and How to Automate Them"
 description: "Maintenance reports communicate your value to clients. Learn what to include, how to automate generation, and how to brand them so clients see your agency, not your tools."
 category: "agency-operations"
+art: "report"
 date: "2026-06-20"
 author: "WPMgr Team"
 tags: ["agency", "reports", "white-label", "client-management"]

--- a/apps/marketing/content/blog/wordpress-backups/wordpress-backup-restore-guide.mdx
+++ b/apps/marketing/content/blog/wordpress-backups/wordpress-backup-restore-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: "WordPress Restore in Practice: From Backup to Live Site"
-description: "Step-by-step walkthrough of restoring a WordPress site from a backup, including database-only restores, full site restores, and staging-first testing."
+description: "Restoring a WordPress site from a backup: matching restore scope to the failure, database-only versus full restores, testing on staging first, and what a restore after a compromise has to do differently."
 category: "wordpress-backups"
 art: "restore"
 date: "2026-06-16"
@@ -10,69 +10,104 @@ featureSlug: "backups"
 solutionSlug: "wordpress-backups"
 ---
 
-Most WordPress site owners have a backup somewhere. Far fewer have confirmed that the backup actually restores to a working site. This guide walks through the restore process: from choosing which backup to use, to confirming the site is back to normal.
+Most people with a WordPress site have a backup somewhere. Far fewer have ever restored one, which means far fewer know whether the thing they are relying on works.
 
-## Before you restore: identify the problem
+Restoring is not a single operation. It is a decision about scope, a decision about which point in time, and an acceptance of whatever happened in between. Getting those right is most of the job. The button is the easy part.
 
-A restore replaces what is on the server with what was in the backup. Before you start, you need to know:
+## Stop and answer three questions first
 
-**What broke?** A broken plugin update might require only restoring the database to the state before the update, or just deactivating the plugin. A full server compromise requires a complete restore and a security audit. Matching the restore scope to the problem avoids unnecessary data loss.
+The instinct in an outage is to restore immediately. Ten minutes of diagnosis usually saves hours, because a restore is destructive: it replaces what is on the server, including anything good that happened since.
 
-**When did it break?** You want to restore to the last backup before the problem occurred. If a post was accidentally deleted on Tuesday afternoon, you want the backup from Tuesday morning or earlier, not Monday.
+**What actually broke?** Match the scope to the fault. A plugin update that broke a layout does not need the uploads directory replaced. A defaced home page does not need last night's orders rolled back. Restoring more than necessary is how a small problem becomes data loss.
 
-**What data will be lost?** Any content created or changed between the backup time and now will be lost in the restore. For content sites, this might be a few posts. For e-commerce, it could be orders. Quantify this before starting.
+**When did it break?** You want the last backup before the problem, which is not always the most recent backup. This is where people go wrong most often: restoring the newest available copy, which already contains the fault. If a bad import ran on Tuesday and you noticed Thursday, Wednesday's backup is useless.
 
-## Types of restore
+**What will be lost?** Everything created between the backup and now. On a blog, a couple of posts. On a store, real orders belonging to real customers who will contact you about them. Quantify it before you start, and if it is orders, export them first. A restore that loses revenue you could have exported in five minutes is a self-inflicted second incident.
 
-**Database-only restore.** Replaces the MySQL database with the backup version. Fastest option. Preserves any file changes made after the backup (uploaded files, plugin updates). Use this when the problem is data-related (deleted content, corrupted database, bad plugin settings).
+## Choosing the scope
 
-**Files-only restore.** Replaces the file system with the backup version. Preserves database changes. Use this when the problem is file-related (a broken theme update, a corrupted plugin file, malware injected into files).
+**Database only.** Replaces content, settings, and users; leaves files untouched. Use it for data problems: deleted content, a bad bulk edit, corrupted settings, a botched import. Fast, and preserves media uploaded since the backup.
 
-**Full restore.** Replaces both the database and the file system. Use this for a complete recovery from a major incident (server compromise, catastrophic failure, or restoring to a new server).
+**Files only.** Replaces the file system; leaves the database alone. Use it for file problems: a broken theme update, corrupted plugin files, injected code. Preserves everything published or ordered since the backup, which is usually what you want.
 
-## Step-by-step: full restore with WPMgr
+**Full restore.** Both. Use it for a compromise, a catastrophic failure, or a move to a new server, where you need a coherent known-good state rather than a mix.
 
-1. **Select the backup.** In the WPMgr dashboard, open the site's Backups tab. The list shows all available backups with timestamps, sizes, and types. Select the backup you want to restore.
+The distinction matters because database and files drift apart. Restoring a database from last week alongside today's files can leave the database referencing plugin versions that are no longer on disk, or vice versa. Partial restores are the right tool often, but "which half is wrong" is a question worth answering deliberately.
 
-2. **Choose restore scope.** Confirm whether you want to restore the database only, files only, or both.
+## Performing a full restore
 
-3. **Confirm.** WPMgr requires explicit confirmation before overwriting live data. The confirmation screen shows what will be replaced and when the selected backup was taken.
+1. **Select the backup.** The Backups tab lists every available backup with timestamp, size, and type. Pick by the reasoning above, not by recency.
+2. **Choose the scope.** Database, files, or both.
+3. **Confirm.** WPMgr requires explicit confirmation before overwriting live data, and shows what will be replaced and when the selected backup was taken. Read the timestamp. This is the last point at which a wrong choice is cheap.
+4. **Let it run.** The job runs asynchronously with progress reported, so a large restore does not depend on a browser tab staying open.
+5. **Verify properly.** Not just that the home page loads.
 
-4. **Monitor progress.** The restore job runs asynchronously. The dashboard shows progress and notifies you when the restore is complete or if an error occurs.
+That last step deserves expansion, because "the site is back" is a conclusion people reach far too quickly.
 
-5. **Verify.** After the restore completes, visit the site and verify that it is functioning correctly. Check content dates, plugin settings, and any functionality that was working before the incident.
+## Verifying a restore
 
-## Testing a restore on staging first
+Check, in roughly this order: the home page and one deep page render; the newest content is present and matches the timestamp you expected; you can log in; a form or checkout completes end to end; images load rather than 404, which is the classic sign that files and database disagree; and permalinks resolve, since a stale rewrite state produces a working home page and 404s everywhere else.
 
-For critical sites or major restores, test the restore on a staging environment before touching production. The process is the same, but the destination is the staging server instead of the production server.
+On a store, confirm order numbering continues from the right place. On a membership site, confirm one real account still has access.
 
-Testing on staging lets you:
+If the site was behind a cache or CDN, purge it. A restore that appears to have done nothing is very often a cache serving the old page.
 
-- Confirm the backup is valid and the restore succeeds
-- Verify that the site looks and functions correctly after restore
-- Check that the specific data you need (the deleted content, the correct settings) is present
-- Estimate how long the restore takes so you can plan maintenance windows
+## Test on staging when the stakes justify it
 
-WPMgr can restore a backup to any site in your fleet, not just the origin site. Use this to restore a production backup to a staging server for testing.
+For a significant restore on a site that matters, restore to staging first. It costs time you feel you do not have, and it answers questions you otherwise answer on production: is this backup actually valid, does the data you need exist inside it, and how long does the process take.
 
-## After a security incident
+That third answer is worth having in advance. Restore duration is dominated by file count and database size, and people routinely underestimate it by an order of magnitude when planning a maintenance window.
 
-If you are restoring after a compromise, a standard restore is not sufficient. The backup may itself contain the malicious code if the compromise predates the backup. After restoring, you also need to:
+WPMgr can restore any backup to any site in the fleet, so a production backup can be restored onto a staging site using the same mechanism you would use in the real event. Rehearsing the actual path, rather than a parallel one, is the point.
 
-1. Change all WordPress admin passwords and revoke all application passwords
-2. Change the database password and update `wp-config.php`
-3. Rotate API keys for any services connected to the site
-4. Run a file integrity scan on the restored site
-5. Run a vulnerability scan to identify what the attacker may have exploited
-6. Apply any available security patches for plugins, themes, and core
-7. Review server access logs to understand the attack vector
+## Restoring to a different domain
 
-WPMgr's file integrity monitoring and vulnerability scanner (via the Wordfence Intelligence feed) are available from the Security tab on each site.
+Restoring to staging, a new host, or a rebuilt server means the site's URL changes, and WordPress stores its URL in a great many places. This is where most manual restores go wrong.
 
-## Pre-update snapshots and rollback
+A naive find and replace across the SQL dump will corrupt the database. WordPress stores plugin and theme settings as **PHP serialized data**, and serialized strings carry their own length prefix:
 
-WPMgr takes automatic snapshots before updates. These are full backups created immediately before a plugin, theme, or core update runs. If the update breaks the site, you can roll back to the pre-update state in one click.
+```text
+s:19:"https://example.com";
+```
 
-This is the most common restore scenario in practice: a plugin update breaks the site, and the fix is to restore the pre-update snapshot. WPMgr's update flow automates the snapshot so there is no risk of running an update without a recovery option.
+Replace that URL with a longer or shorter one and the `19` no longer matches. PHP fails to unserialize the value and the setting silently becomes empty. The visible symptom is a site that loads with its theme options gone, widgets missing, or a page builder rendering blank, and the cause is invisible because the database looks fine.
 
-For the full backup feature documentation, see the [Backups and restore feature page](/features/backups/). For a strategic view of WordPress backup planning, see the [WordPress backups solution guide](/solutions/wordpress-backups/).
+The fix is a serialization-aware replacement that recalculates the lengths, which every competent migration tool does and `sed` does not. If you are doing this by hand, use WP-CLI's `search-replace`, which handles serialized data correctly.
+
+Also expect to update: the `siteurl` and `home` options, hardcoded URLs in post content and custom fields, and any absolute path baked into a cache configuration. And set the staging copy to discourage search engines, because the reliable way to discover a staging restore went unnoticed is to find it ranking against production.
+
+## When a restore goes wrong mid-flight
+
+A restore is destructive by definition, which means a restore that fails partway leaves a site in a state that is neither the old one nor the new one.
+
+The scenarios worth anticipating: the process times out on a large uploads directory, leaving files half replaced; the disk fills, because a restore can transiently need space for both copies; the database import fails midway, leaving some tables from the backup and some from before; or a PHP or MySQL version on the new server rejects something the dump contains.
+
+Two things make this survivable. **Take a backup of the current state immediately before restoring**, even when the current state is broken, so a failed restore has somewhere to return to rather than leaving you with nothing. And **prefer a restore process that stages then swaps** rather than overwriting in place, so a failure leaves the original intact.
+
+Practically: check free disk space before starting a large restore, and confirm the target PHP and MySQL versions are not older than the source. Restoring a database dumped from a newer MySQL onto an older one fails in ways that are tedious to unpick.
+
+## Restoring after a compromise is different
+
+A standard restore assumes the backup is clean. After a security incident that assumption is exactly what is in question.
+
+Compromises are usually discovered well after they begin. If the intrusion predates your backups, every copy contains the backdoor, and restoring reinstates it. Restoring further back trades data for confidence, which is a real trade and sometimes the right one.
+
+The sequence:
+
+1. **Preserve the current state before changing anything.** Take a backup of the compromised site as evidence. If you clean first, you lose the ability to work out what happened.
+2. **Find the entry point.** Restoring without closing the door produces a site that is compromised again, often within hours. Check access logs around the first known bad change, review recently installed plugins, and audit administrator accounts.
+3. **Restore from a backup you have reason to believe predates the intrusion**, which may not be the newest.
+4. **Rotate every credential.** Admin passwords, application passwords, the database password in `wp-config.php`, API keys for connected services, and the hosting account itself. Application passwords deserve specific attention because they bypass two-factor authentication and survive a password reset.
+5. **Scan the restored site.** Run [file integrity monitoring](/blog/wordpress-security/wordpress-file-integrity-monitoring) against known-good checksums and a [vulnerability scan](/blog/wordpress-security/wordpress-vulnerability-scanning) to identify what was likely exploited.
+6. **Patch before going back online.** Update the vulnerable component, or remove it if it is abandoned.
+7. **Check the database and scheduled tasks**, not only the files. Injected admin users, malicious entries in options, and a cron task that re-downloads a payload all survive a files-only restore untouched. This is the usual reason a site "gets hacked again" days later.
+
+## The restore you will actually perform
+
+Disasters are rare. The common case is a plugin update that broke something at eleven in the morning, and the fix is to go back fifteen minutes.
+
+This is why pre-update snapshots matter more than any other part of a backup strategy. WPMgr takes a full backup immediately before every update, so a broken update is a one-click rollback to the state a moment before, with nothing lost in between and no decision to make about which point in time.
+
+If you set up nothing else after reading this, set up automatic snapshots before updates. It converts the most frequent way WordPress sites break from an incident into an undo.
+
+For the feature detail see the [Backups and restore page](/features/backups). For choosing frequency, retention, and storage, see the [backup strategy guide](/blog/wordpress-backups/wordpress-backup-strategy) and the [WordPress backups solution guide](/solutions/wordpress-backups).

--- a/apps/marketing/content/blog/wordpress-backups/wordpress-backup-restore-guide.mdx
+++ b/apps/marketing/content/blog/wordpress-backups/wordpress-backup-restore-guide.mdx
@@ -2,6 +2,7 @@
 title: "WordPress Restore in Practice: From Backup to Live Site"
 description: "Step-by-step walkthrough of restoring a WordPress site from a backup, including database-only restores, full site restores, and staging-first testing."
 category: "wordpress-backups"
+art: "restore"
 date: "2026-06-16"
 author: "WPMgr Team"
 tags: ["backups", "restore", "disaster-recovery"]

--- a/apps/marketing/content/blog/wordpress-backups/wordpress-backup-strategy.mdx
+++ b/apps/marketing/content/blog/wordpress-backups/wordpress-backup-strategy.mdx
@@ -1,6 +1,6 @@
 ---
 title: "WordPress Backup Strategy: How Often, What to Include, and Where to Store It"
-description: "A practical guide to building a WordPress backup strategy: backup frequency, what to include, offsite storage, and testing your restores."
+description: "Building a WordPress backup strategy that survives contact with a real incident: choosing frequency from a recovery objective, what to include, offsite storage, retention, and testing restores."
 category: "wordpress-backups"
 art: "snapshots"
 date: "2026-06-13"
@@ -10,66 +10,113 @@ featureSlug: "backups"
 solutionSlug: "wordpress-backups"
 ---
 
-A backup you have never tested is not a backup. It is a compressed hope. The goal of a backup strategy is not to have files somewhere. It is to be able to restore a site to a known good state within a predictable time frame, with confidence that the restore will work.
+A backup you have never restored is not a backup. It is a compressed hope.
 
-## What to include in a WordPress backup
+The purpose of a backup strategy is not to have files somewhere. It is to return a site to a known good state, within a time you can predict, with reasonable confidence that it will work. Almost every failure of a backup strategy is a failure of one of those three clauses, and usually the last one.
 
-A complete WordPress backup has two components:
+## Start from two numbers, not from a schedule
 
-**The database.** WordPress stores all of its content in MySQL: posts, pages, comments, user accounts, plugin settings, and widget configurations. A database backup can be as small as a few megabytes for a new site or hundreds of megabytes for a large content site. It backs up fast and restores fast.
+Before choosing a frequency, decide two things. They are the standard disaster recovery quantities and they turn a vague preference into a specification.
 
-**The file system.** The WordPress file system includes core files, plugins, themes, and the uploads directory (`wp-content/uploads`). Core files and plugins are reproducible (you can reinstall them), but the uploads directory contains user-uploaded media that exists only on that server. The uploads directory is the critical file-system component.
+**Recovery point objective (RPO): how much data can you afford to lose?** This sets backup frequency. If you back up nightly, your RPO is 24 hours, and you are stating that losing a day of work is acceptable.
 
-For most sites, the optimal backup includes the full database plus the uploads directory. Core and plugin files are omitted because they can be re-downloaded and are identical across all sites running the same version.
+**Recovery time objective (RTO): how long can the site be down?** This sets everything else: where backups are stored, how large they are, whether you have tested the process, and whether the restore path is one click or a support ticket.
 
-## Backup frequency: matching risk to cost
+Most people pick a frequency first and discover their real RPO during an incident. Doing it in the other order takes ten minutes and changes the answer more often than not.
 
-The right backup frequency depends on how much data you can afford to lose.
+The reason this matters is that the two numbers pull in different directions and are satisfied by different things. Hourly backups do nothing for RTO. A fast, rehearsed restore does nothing for RPO. A strategy that only addresses one is half a strategy.
 
-If your site publishes new content or receives new orders once a week, a daily backup means you lose at most one day of content in the worst case. That may be acceptable.
+## What a complete backup contains
 
-If your site receives orders continuously, a daily backup means you could lose a day of orders in the worst case. That is probably not acceptable. You need hourly or continuous backups, or a transactional replication strategy for the database.
+**The database.** All content, settings, users, comments, and most plugin configuration. Typically small, and fast to both back up and restore. This is where the majority of what people mean by "the site" actually lives.
 
-Common frequency patterns:
+**The uploads directory.** `wp-content/uploads` holds media that exists nowhere else. It is usually the bulk of the bytes and the part that cannot be regenerated.
 
-- **Daily backups** retained for 30 days: suitable for content sites, blogs, and most small business sites
-- **Hourly backups** retained for 7 days plus daily backups retained for 30 days: suitable for e-commerce and membership sites
-- **Continuous replication** for the database plus daily file backups: for high-stakes or regulated data
+**Everything else.** Core, plugins, and themes are reproducible: they can be downloaded again at the same versions. Backing them up costs storage and buys speed of recovery.
 
-## Incremental backups: why they matter at scale
+The common recommendation, and a good default, is database plus uploads, on the reasoning that the rest is replaceable. Two caveats deserve stating, because "replaceable" is doing a lot of work in that sentence.
 
-A full backup copies every file and every database row on every run. For a large site, this is slow and consumes a lot of storage.
+Custom and commercial code is not replaceable. A bespoke theme, a client-specific plugin, or a paid plugin whose licence has lapsed exists only on that server. If your backup excludes `wp-content/themes` and `wp-content/plugins` wholesale, verify that every excluded item can genuinely be re-obtained.
 
-An incremental backup copies only what changed since the last backup. For the database, this means binary log shipping. For the file system, this means tracking which files changed by comparing timestamps or content hashes.
+Root drop-ins matter more than their size suggests. `wp-config.php`, `.htaccess`, and drop-ins like `object-cache.php` or `advanced-cache.php` are small, easy to exclude by accident, and their absence produces a site that restores "successfully" and does not work.
 
-WPMgr uses content-addressed chunk storage: file content is split into chunks by hash, and each chunk is stored once. Two versions of a file that share 90% of their content share 90% of their storage. This makes the storage cost of daily backups close to the cost of storing the delta, not the full content.
+## Frequency patterns that hold up
 
-## Offsite storage: the non-negotiable requirement
+Given an RPO, the patterns that work in practice:
 
-A backup stored on the same server as the site it backs up is not a real backup. If the server fails, is compromised, or is deleted, the backup goes with it.
+- **Daily, retained 30 days.** Content sites, brochure sites, most small business sites. Losing a day is annoying, not existential.
+- **Hourly for 7 days plus daily for 30.** Stores and membership sites. Hourly bounds the loss; the daily tier gives you depth to reach past a problem you did not notice immediately.
+- **Continuous database replication plus daily file backups.** High transaction volume or regulated data, where losing an hour of orders is not acceptable.
 
-Offsite storage means a different location: a different server, a different cloud provider, or a physical location. For most WordPress sites, the practical options are S3-compatible object storage (AWS S3, Cloudflare R2, Backblaze B2, MinIO), a local NAS, or a remote SFTP server.
+The depth matters as much as the frequency, and it is the part people under-provision. Ransomware, a slow-burning compromise, and a corrupted import all share a property: you find out days later. A backup set that only reaches back 48 hours contains the problem in every copy.
 
-WPMgr supports S3-compatible destinations and local storage. You configure a destination once at the control-plane level; all sites in your fleet can use it. Backups are encrypted before they leave the server and stored with credentials managed by the control plane.
+## Incremental backups, and why they change the calculus
 
-## Testing your restores
+A full backup copies everything every time. At any real size that is slow, expensive, and the reason people quietly reduce frequency until the strategy stops meaning anything.
 
-A backup strategy without a restore test is not complete. You need to know that the restore works before you need it in an emergency.
+Incremental backups copy only what changed. WPMgr splits file content into chunks addressed by hash and stores each chunk once, so two versions of a file sharing most of their content share most of their storage. The cost of a daily backup approaches the cost of the day's delta rather than the size of the site.
 
-A minimal restore test:
+The practical effect is that frequency stops being a budget decision. That is the actual benefit: not the storage saving, but that you no longer have to choose between an acceptable RPO and an acceptable bill.
 
-1. Create a staging environment (a second server, a local Docker container, or a subdomain)
-2. Restore a recent backup to the staging environment
-3. Walk through the site and verify that content, settings, and functionality are intact
+## Offsite is not optional
 
-Run this test quarterly at minimum, and after any major change to your backup configuration.
+A backup on the same server as the site is not a backup. Server dies, backup dies. Server is compromised, and any attacker competent enough to matter deletes the backups first, because that is what converts an incident into leverage.
 
-WPMgr supports point-in-time restore from any stored backup, and the restore flow is the same whether you are recovering from a disaster or testing a restore on a staging server.
+Offsite means a different failure domain: a different provider, or at minimum a different account. The practical options are S3-compatible object storage (S3, Cloudflare R2, Backblaze B2, MinIO), a remote SFTP target, or a NAS you control.
 
-## Pre-update snapshots: backups as a safety net
+Two properties are worth insisting on. **Encryption before the data leaves the site**, so the storage provider holds ciphertext rather than your client's customer database. And **credentials the site cannot use to delete history**: if the WordPress install holds keys with delete permission on the bucket, then anything that compromises the site can erase the backups. Write-only or append-only credentials, or object lock on the bucket, close that path.
 
-The highest-risk moment for a WordPress site is immediately after a plugin or core update. A pre-update snapshot is a backup taken automatically before any update runs. If the update breaks something, you restore from the snapshot.
+WPMgr encrypts on the site before upload, supports S3-compatible and local destinations configured once at the control plane and reused across the fleet, and keeps destination credentials in the control plane rather than on the sites.
 
-WPMgr takes a pre-update snapshot automatically before every update. The snapshot is retained for a configurable window (default 14 days). If the update causes a regression, you restore with one click.
+## Retention, and pruning on purpose
 
-For more detail on the backup system, see the [Backups and restore feature page](/features/backups/). For the complete picture of WordPress backup tools, see the [WordPress backups solution guide](/solutions/wordpress-backups/).
+Retention is where storage costs actually live, and where most setups drift into either unbounded growth or accidental shallowness.
+
+A tiered scheme covers the realistic recovery scenarios without keeping everything forever: hourly for a day or two, daily for a month, weekly for a quarter, monthly for a year if you have a compliance reason. Each tier answers a different question, from "undo the last hour" to "what did this look like before the redesign".
+
+The failure to avoid is a retention rule that silently prunes the only copy you needed. If pruning is automatic, know what it deletes and when.
+
+## Consistency: the failure nobody looks for
+
+A backup is taken over a period of time, and the site keeps running during it. That gap creates a class of problem that produces backups which restore perfectly and contain nonsense.
+
+Consider a store during a five-minute backup. The database is dumped at the start; an order arrives at minute two, writing rows across several tables; the uploads directory is copied at minute four. Depending on the order of operations you can end up with a database that references an uploaded file the backup does not contain, or an order row in one table with no matching row in another.
+
+Two mitigations matter. **Dump the database in a single transaction** so it represents one consistent moment rather than a smear across the backup window, which for InnoDB tables is a standard option and costs nothing. And **back up the database before the files**, so any file referenced by the database is at least as old as the reference, and the worst case is an orphaned file rather than a broken link.
+
+Neither is exotic, and both are the difference between a backup that is internally coherent and one that merely completed.
+
+## Large sites need a different shape
+
+Past a certain size the strategy changes rather than just scaling, and the threshold is usually file count rather than gigabytes.
+
+A media library with hundreds of thousands of files makes the per-file overhead dominate: walking the directory tree and hashing takes longer than transferring the data. Sites in this position benefit from excluding uploads from the frequent backup entirely and covering it separately at a lower frequency, on the reasoning that yesterday's uploads are recoverable from a source and yesterday's orders are not.
+
+Very large databases hit the opposite constraint, where the dump itself becomes the slow part and the consistency question above becomes acute.
+
+The general principle: when a backup takes long enough that it overlaps meaningfully with site activity, split it by component and give each the frequency its actual risk deserves, rather than pushing the whole thing to a schedule dictated by its slowest part.
+
+## Testing, which is the part that gets skipped
+
+Every backup strategy is a hypothesis until you restore one. The failure modes are numerous and none of them announce themselves: a backup that ran nightly for a year and only ever captured an empty database, an archive that was never completed, a file excluded by a pattern nobody reviewed.
+
+A minimal test:
+
+1. Restore a recent backup to a staging environment or a scratch site, not production.
+2. Load the site and click through the parts that matter: the home page, a post, checkout, a form.
+3. Check the database has actual rows, not just tables.
+4. Time it, and write the number down. That is your real RTO, and it is usually longer than people guess.
+
+Quarterly is a reasonable cadence, plus after any change to hosting, backup configuration, or site architecture.
+
+WPMgr restores any stored backup to any site in the fleet, so testing means restoring production's backup onto a staging site rather than building a parallel process you only ever use in a crisis. The mechanism you rehearse is the mechanism you use.
+
+## Pre-update snapshots
+
+The single highest-risk moment in a WordPress site's normal life is the minute after an update. It is also entirely predictable, which makes it the easiest risk to cover.
+
+A pre-update snapshot is a backup taken automatically immediately before an update runs, so a broken update becomes a rollback rather than an incident. WPMgr takes one before every update and retains it for a configurable window, defaulting to 14 days.
+
+This is the restore people actually perform. Catastrophes are rare. Plugin updates that break a layout are Tuesday.
+
+For the mechanics of performing one, see [restoring a WordPress site in practice](/blog/wordpress-backups/wordpress-backup-restore-guide). For the feature detail, see the [Backups and restore page](/features/backups), and for the wider view the [WordPress backups solution guide](/solutions/wordpress-backups).

--- a/apps/marketing/content/blog/wordpress-backups/wordpress-backup-strategy.mdx
+++ b/apps/marketing/content/blog/wordpress-backups/wordpress-backup-strategy.mdx
@@ -2,6 +2,7 @@
 title: "WordPress Backup Strategy: How Often, What to Include, and Where to Store It"
 description: "A practical guide to building a WordPress backup strategy: backup frequency, what to include, offsite storage, and testing your restores."
 category: "wordpress-backups"
+art: "snapshots"
 date: "2026-06-13"
 author: "WPMgr Team"
 tags: ["backups", "disaster-recovery", "storage"]

--- a/apps/marketing/content/blog/wordpress-performance/core-web-vitals-wordpress.mdx
+++ b/apps/marketing/content/blog/wordpress-performance/core-web-vitals-wordpress.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Core Web Vitals for WordPress: LCP, CLS, and INP Explained"
-description: "Understand the three Core Web Vitals metrics, what causes poor scores on WordPress sites, and practical fixes for each."
+description: "What the three Core Web Vitals actually measure, the WordPress-specific causes of poor scores, practical fixes for each, and why lab tools and field data disagree."
 category: "wordpress-performance"
 art: "vitals"
 date: "2026-06-14"
@@ -10,70 +10,105 @@ featureSlug: "real-user-monitoring"
 solutionSlug: "wordpress-performance"
 ---
 
-Google uses Core Web Vitals as a ranking signal. They are also the most user-facing performance metrics available: they measure how fast a page loads, how stable it is while loading, and how quickly it responds to user input. A site that scores well on all three delivers a genuinely good experience.
+Core Web Vitals are a Google ranking signal, which is why most people start caring about them. They are worth caring about for a better reason: they are among the few performance metrics that describe what using the page feels like rather than what a waterfall chart looks like.
 
-WordPress sites have a specific profile of Core Web Vitals challenges. Understanding them lets you fix the right things.
+Three metrics, three distinct questions. Did the main content appear quickly? Did the page hold still while it loaded? Did it respond when I touched it? WordPress sites fail each of these in fairly predictable ways, and knowing which failure you have saves a great deal of guessing.
 
-## LCP: Largest Contentful Paint
+## The thresholds, and the one detail everyone misses
 
-LCP measures how long it takes for the largest visible content element (usually the hero image or headline) to render on screen. Google's threshold for "good" is under 2.5 seconds.
+| Metric | Good | Needs work | Poor |
+| --- | --- | --- | --- |
+| LCP | under 2.5s | 2.5s to 4.0s | over 4.0s |
+| CLS | under 0.1 | 0.1 to 0.25 | over 0.25 |
+| INP | under 200ms | 200ms to 500ms | over 500ms |
 
-**Common WordPress LCP killers:**
+The detail that changes how you read every number: assessment uses the **75th percentile** of real visits over a rolling 28 day window. Not the average, and not your visit.
 
-- Unoptimised hero images (full-size JPEG or PNG served without compression or next-gen format)
-- Images loaded lazily when they should be prioritised (do not `loading="lazy"` on the hero image)
-- Slow server response time (TTFB above 600ms, often a sign that full-page caching is not working)
-- Large JavaScript bundles blocking the render path
-- Fonts loaded from a remote CDN with no `preconnect` hint
+That has two consequences worth internalising. Your own page load tells you almost nothing, because you are one sample, usually on good hardware with a warm cache and a nearby server. And an average hides exactly the users you need to fix, since a fast median with a slow tail still fails at p75. When a page is "fine for me" and failing in Search Console, this is nearly always why.
 
-**WordPress-specific fixes:**
+## LCP: did the main thing appear?
 
-Full-page caching is the single largest LCP win for most WordPress sites. Serving a prebuilt HTML response instead of running PHP eliminates the application-layer latency. WPMgr's page caching feature handles this at the server level.
+Largest Contentful Paint measures when the largest visible element in the viewport finishes rendering. On most WordPress pages that is a hero image, a featured image, or a large heading block.
 
-Convert your hero image to AVIF or WebP. Both formats are 30 to 50% smaller than JPEG at equivalent quality. WPMgr's Media Optimizer converts your entire media library automatically; new uploads are converted on the way in.
+LCP breaks into four stages, and fixing the wrong one wastes effort. Time to first byte, then resource load delay, then resource load time, then render delay. Before optimising an image, find out whether the image was even the slow part.
 
-Use a `<link rel="preload">` hint for the hero image so the browser starts fetching it before the main image tag is parsed.
+**Time to first byte.** For WordPress this is usually the dominant term and the easiest to fix. An uncached page means PHP boots, plugins load, the database is queried, and a theme renders, all before a single byte reaches the browser. Full-page caching serves prebuilt HTML instead and typically removes hundreds of milliseconds in one step. If your TTFB is above about 600ms, nothing else you do to LCP matters much. This is the single largest win available to most WordPress sites, and [page caching](/features/performance) is where to start.
 
-## CLS: Cumulative Layout Shift
+**Resource load delay.** The browser cannot fetch the hero image until it knows about it. Images injected by JavaScript, set as CSS backgrounds, or hidden inside a slider are discovered late. Put the LCP image in the HTML as a plain `<img>` tag where the preload scanner can see it, and add `<link rel="preload">` if it is still found late.
 
-CLS measures visual stability: how much the page layout shifts during load. Google's threshold for "good" is a CLS score below 0.1.
+**Resource load time.** How long the bytes take. Serve the hero in AVIF or WebP, which run 30 to 50 percent smaller than JPEG at equivalent quality, and size it to the largest dimension it is actually displayed at. A 3000px-wide image in a 1200px slot is pure waste. [Media Optimizer](/features/media-optimizer) converts an existing library and handles new uploads on the way in.
 
-**Common WordPress CLS killers:**
+**Render delay.** Render-blocking CSS and synchronous JavaScript in the head hold up painting even when the image has arrived.
 
-- Images without explicit `width` and `height` attributes: the browser does not know the image dimensions until it downloads the image, so it cannot reserve the right amount of space
-- Web fonts causing layout shifts when they load (FOUT: flash of unstyled text)
-- Late-loading ads or embeds that push content down
-- Animations that change `width`, `height`, or `top`/`left` properties (these trigger layout recalculations)
+The most common WordPress own-goal here is lazy loading the hero. WordPress adds `loading="lazy"` automatically, and on an above-the-fold image that delays the very thing LCP measures. The LCP image must load eagerly. Everything below the fold should stay lazy.
 
-**WordPress-specific fixes:**
+## CLS: did the page hold still?
 
-Always set `width` and `height` on `<img>` tags. WordPress does this automatically for images inserted through the media library, but page builders and some themes bypass this.
+Cumulative Layout Shift scores how much visible content moves during load, weighted by how much moved and how far. Under 0.1 is the target. It is the metric users feel most viscerally, because it is the one that makes you tap the wrong thing.
 
-Self-host web fonts instead of loading them from Google Fonts or other CDNs. Self-hosted fonts can include `font-display: optional` or be preloaded to avoid FOUT.
+**Images without dimensions.** If the browser does not know an image's aspect ratio, it reserves no space, then reflows everything below when the image arrives. WordPress sets `width` and `height` on media library images, but page builders, hand-written HTML, and some themes drop them. This is the single most common cause.
 
-For animations, use `transform` and `opacity` exclusively. These do not trigger layout recalculations and have no CLS impact.
+**Web fonts.** A fallback font swapped for a webfont with different metrics reflows every line of text it touches. Preload the font, use `font-display: optional` or `swap` deliberately, and set `size-adjust` on the fallback so the metrics roughly match. Self-hosting also removes a third-party connection from the critical path.
 
-## INP: Interaction to Next Paint
+**Ads, embeds, and cookie banners.** Anything injected after paint pushes content down. Reserve the space with a min-height container sized to the common case.
 
-INP replaced FID (First Input Delay) as a Core Web Vitals metric in March 2024. It measures the delay between a user action (click, tap, keystroke) and the next paint that shows a response. Google's threshold for "good" is under 200ms.
+**Animating the wrong properties.** Animating `width`, `height`, `top`, or `margin` triggers layout. Animate `transform` and `opacity` instead, which are composited and cost nothing in CLS.
 
-**Common WordPress INP killers:**
+One nuance: CLS is measured throughout the page's life, not just during load. A shift triggered by lazily loaded content when a visitor scrolls halfway down still counts.
 
-- Large JavaScript bundles executing on the main thread during interactions
-- Heavy WooCommerce cart or checkout JavaScript
-- Page builders that ship multi-hundred-kilobyte JavaScript payloads
-- Analytics and marketing scripts with synchronous execution
+## INP: did it respond?
 
-**WordPress-specific fixes:**
+Interaction to Next Paint replaced First Input Delay in March 2024, and the change matters. FID measured only the delay before handling started, which flattered pages that responded slowly but began quickly. INP measures the whole path from interaction to the next visual update, across all interactions on the page, and reports near the worst one.
 
-Defer or remove non-essential JavaScript. Every script that runs during an interaction adds to INP.
+The cause is nearly always the main thread being busy. JavaScript is single threaded, so a long task blocks the response to a tap.
 
-Remove unused CSS. Large CSS stylesheets force the browser to compute styles for every interaction. WPMgr's unused CSS removal strips per-page CSS to only the rules actually used.
+**Script volume.** Page builders, sliders, and plugin bundles that ship hundreds of kilobytes of JavaScript on every page. The fix is deactivating what you are not using and loading the rest only where it is needed, rather than globally.
 
-## Measuring with real user data
+**Commerce interactions.** Cart and checkout are the worst INP offenders on most WordPress sites, because those interactions do real work. They are also the interactions that pay for the site, so this is where the effort belongs.
 
-Lab tools (Lighthouse, PageSpeed Insights) simulate a single visit under controlled conditions. They are useful for debugging but do not represent your actual visitor population.
+**Third-party scripts.** Analytics, chat widgets, heat maps, and tag managers all execute on the same thread. Each one is a decision to spend responsiveness on measurement.
 
-Real User Monitoring (RUM) collects CWV metrics from actual visitors on their actual devices and network connections. WPMgr RUM aggregates these at the p75 level (the 75th-percentile user experience) across 28-day windows, so you can see trends and compare before-and-after for any optimisation you make.
+**Oversized CSS.** Style recalculation is proportional to the number of rules the browser must consider. A theme shipping one enormous stylesheet for every page makes every interaction slightly more expensive. Removing rules a page does not use is worth real milliseconds, and [unused CSS removal](/features/performance) does this per page.
 
-For a deep dive into the tooling, see the [Real User Monitoring feature page](/features/real-user-monitoring/) and the [speed up WordPress solution guide](/solutions/wordpress-performance/).
+The practical approach is to break long tasks up. Yield to the main thread between chunks of work, do the visual update first and the bookkeeping after, and defer anything not needed for the response itself.
+
+## Lab data and field data disagree, and both are right
+
+Lighthouse and PageSpeed Insights run a **lab** test: one load, one simulated device, one throttled connection, no cache. Repeatable and excellent for debugging, because it isolates variables and shows a filmstrip.
+
+**Field** data is what real visitors experienced, on their phones and networks, and it is what assessment uses. Lab data cannot measure INP properly at all, because there is no real interaction to measure, which is why a perfect Lighthouse score sits happily alongside a failing INP.
+
+Use lab tools to find causes and field data to decide whether anything improved. A change that improves your Lighthouse number and does nothing at p75 has improved nothing that counts.
+
+This is what real user monitoring is for. WPMgr RUM collects the metrics from actual visits and aggregates at p75 over 28 day windows, matching how the thresholds are actually assessed, so you can compare before and after for a change you made rather than guessing from a synthetic run.
+
+## Finding the element that is actually failing
+
+Before optimising anything, identify the specific element being measured. Guessing wrong is the usual reason a week of work moves nothing.
+
+In Chrome DevTools, the Performance panel marks the LCP element directly on the timeline, and Lighthouse names it in the diagnostics. It is frequently not what you assumed: a background image on a section wrapper, a paragraph of intro text rendering before the hero, or a cookie banner that briefly occupies most of the viewport.
+
+For CLS, the Performance panel lists each individual shift with the element that moved and its contribution to the score. One late-loading element usually accounts for nearly all of it. For INP, interact with the page while recording and look for the long task blocking the response.
+
+## Which pages to fix first
+
+Core Web Vitals are assessed per URL, but URLs with too little traffic to produce reliable data are grouped, and Search Console reports them that way: as groups of similar pages sharing a status.
+
+That grouping is the prioritisation. A single failing URL with fifty visits a month is not where the work goes. A group covering every product page is. Open the Core Web Vitals report in Search Console, sort by the number of URLs affected, and start with the template that covers the most traffic, because on WordPress a fix to one template fixes every page built from it.
+
+This is also why chasing a perfect score on the home page is usually misdirected effort. On most WordPress sites the home page is a minority of organic entries. Article and product templates carry the traffic, and they are the ones assessed.
+
+## A working order of operations
+
+Most WordPress sites get most of the available improvement from a short list, done in this order:
+
+1. **Turn on full-page caching.** Largest single effect on LCP, and it costs nothing in complexity.
+2. **Fix the hero image.** Eager, not lazy. Modern format. Sized to its slot. Preloaded if discovered late.
+3. **Set dimensions on every image.** Usually removes most CLS on its own.
+4. **Audit plugins for what they load globally.** Deactivate the unused; scope the rest to the pages that need them.
+5. **Handle fonts.** Self-host, preload, and pick a `font-display` on purpose.
+6. **Then measure at p75 and repeat.**
+
+Steps one to three are where the returns are. Everything after is refinement, and refinement measured against a synthetic score is refinement measured against the wrong thing.
+
+For the tooling, see the [Real User Monitoring feature page](/features/real-user-monitoring). For how caching, images, and CSS fit together, see the [speed up WordPress guide](/solutions/wordpress-performance).

--- a/apps/marketing/content/blog/wordpress-performance/core-web-vitals-wordpress.mdx
+++ b/apps/marketing/content/blog/wordpress-performance/core-web-vitals-wordpress.mdx
@@ -2,6 +2,7 @@
 title: "Core Web Vitals for WordPress: LCP, CLS, and INP Explained"
 description: "Understand the three Core Web Vitals metrics, what causes poor scores on WordPress sites, and practical fixes for each."
 category: "wordpress-performance"
+art: "vitals"
 date: "2026-06-14"
 author: "WPMgr Team"
 tags: ["performance", "core-web-vitals", "lcp", "cls", "inp"]

--- a/apps/marketing/content/blog/wordpress-performance/wordpress-image-optimization-avif-webp.mdx
+++ b/apps/marketing/content/blog/wordpress-performance/wordpress-image-optimization-avif-webp.mdx
@@ -1,6 +1,6 @@
 ---
 title: "WordPress Image Optimization: AVIF and WebP in Practice"
-description: "AVIF and WebP reduce image file size by 30 to 60% compared to JPEG. Learn how they differ, which browsers support them, and how to convert your WordPress media library."
+description: "AVIF and WebP cut image weight by 30 to 60 percent against JPEG. How the formats differ, how WordPress actually serves them, how to convert an existing library, and the traps that make a conversion look worse than it is."
 category: "wordpress-performance"
 art: "compress"
 date: "2026-06-17"
@@ -10,23 +10,27 @@ featureSlug: "media-optimizer"
 solutionSlug: "wordpress-performance"
 ---
 
-Images account for the largest share of page weight on most WordPress sites. The average WordPress page loads several megabytes of images. Switching to modern formats is one of the highest-leverage optimisations you can make because it requires no change to your design, content, or workflow.
+Images are the largest component of page weight on most WordPress sites, usually by a wide margin. That makes format conversion unusually attractive as an optimisation: it changes nothing about your design, your content, or how anyone works, and it can remove half the bytes.
 
-## AVIF vs WebP: what is the difference
+It is also the optimisation most often done badly, in ways that produce a smaller number in a report and no improvement for real visitors.
 
-Both AVIF and WebP are modern image formats designed for the web. Both outperform JPEG and PNG at the same visual quality.
+## AVIF and WebP, and which to use
 
-**WebP** was developed by Google and is now supported by every major browser. At the same quality setting, WebP is typically 25 to 35% smaller than JPEG. For images with transparency (previously PNG territory), WebP is often 50 to 70% smaller than PNG.
+Both beat JPEG and PNG at equivalent visual quality. They are not interchangeable.
 
-**AVIF** is derived from the AV1 video codec. It achieves better compression than WebP at the same visual quality, typically 30 to 50% smaller than JPEG. It also handles high dynamic range images better than WebP. Browser support is now near-universal: Chrome, Firefox, Safari, and Edge all support AVIF.
+**WebP** came from Google and is supported everywhere that matters. Against JPEG it typically saves 25 to 35 percent at the same quality. Against PNG for images with transparency, the saving is much larger, often 50 to 70 percent, because PNG is lossless and frequently the wrong tool for photographic content with an alpha channel.
 
-The practical difference: AVIF gives you smaller files, but encoding is slower and requires more CPU than WebP. For a media library with thousands of images, this matters for the conversion time. For individual images, the quality improvement is usually worth it.
+**AVIF** is derived from the AV1 video codec and compresses harder, typically 30 to 50 percent below JPEG, with noticeably better behaviour in gradients and flat colour where JPEG produces banding. It handles wide colour and high dynamic range properly. Chrome, Firefox, Safari, and Edge all support it.
 
-## How WordPress serves next-gen images
+The real trade is encoding cost. AVIF encoding is substantially slower and more CPU-hungry than WebP. For a single hero image nobody cares. For a library of eight thousand images on shared hosting, that difference decides whether the batch job finishes overnight or runs for a week and gets killed.
 
-WordPress itself does not convert images to AVIF or WebP. The conversion has to happen through a plugin, a build step, or a CDN.
+A reasonable default: AVIF with a WebP fallback where you can afford the encoding, WebP alone where you cannot. The gap between WebP and AVIF is real but modest. The gap between JPEG and either is the one that matters.
 
-The correct pattern is to serve the most efficient format the browser supports, with a fallback chain. This is done with the `<picture>` element:
+## How the browser gets the right file
+
+WordPress core does not convert images. Something else has to, and then something has to serve the right format to each browser. There are two mechanisms.
+
+**The `<picture>` element**, which lets the browser choose:
 
 ```html
 <picture>
@@ -36,32 +40,88 @@ The correct pattern is to serve the most efficient format the browser supports, 
 </picture>
 ```
 
-Browsers that support AVIF fetch `photo.avif`. Browsers that support only WebP fetch `photo.webp`. Older browsers fall back to the JPEG.
+The browser takes the first `source` whose type it supports and falls back to the `img`. It is explicit and it caches cleanly.
 
-## Converting an existing media library
+**Content negotiation**, where the server inspects the browser's `Accept` header and returns a different file body at the same URL. This keeps markup untouched, which is why CDNs favour it, but it requires a correct `Vary: Accept` response header. Without that, a shared cache can serve an AVIF to a browser that cannot render it, and the result is a broken image for a subset of visitors that is very hard to reproduce.
 
-The challenge with an existing site is that you may have hundreds or thousands of images that need conversion. Options:
+Whichever you use, the `width` and `height` attributes on the `img` are not optional. Dropping them while restructuring markup for `<picture>` is a common way to convert images successfully and make [Cumulative Layout Shift](/blog/wordpress-performance/core-web-vitals-wordpress) worse.
 
-**CDN-based conversion.** Some CDNs convert images on the fly when a browser requests a WebP or AVIF version. This works but adds latency on the first request for each image and depends on the CDN staying in front of your images.
+## Converting an existing library
 
-**Server-side conversion at upload time.** The cleanest approach for new images: convert JPEG/PNG to WebP or AVIF as soon as a file is uploaded to WordPress, store the converted version alongside the original, and serve it from WordPress's standard media URL. No CDN dependency.
+Three approaches, with different failure modes.
 
-**Batch conversion of the existing library.** For the backlog of existing images, a one-time batch job runs through the media library and converts each file.
+**CDN conversion on the fly.** The CDN converts on first request and caches the result. No changes to your site, and it covers everything. The costs are a slow first request per image per format, and a permanent dependency: if the CDN is removed or bypassed, you are back to originals, and the optimisation lives in someone else's product rather than in your media library.
 
-WPMgr's Media Optimizer handles all three for images served from WordPress: new uploads are converted on the way in, and a batch job processes the existing library. The originals are preserved, and the conversion is fully reversible: you can restore the original file for any image at any time.
+**Conversion at upload.** New images are converted as they arrive and stored beside the original. Clean, predictable, no runtime dependency, and it means the problem stops growing. It does nothing for the images already there.
 
-## What to keep in JPEG or PNG
+**Batch conversion of the backlog.** A one-time pass over the existing library. This is the one with operational risk, because it is a long-running job doing heavy CPU work against every file you own.
 
-Not every image benefits from conversion. Exceptions:
+Most sites need the second and third together: convert on upload so the backlog stops growing, then work through what exists.
 
-- Very small images (icons under 1KB) where format overhead matters
-- Images that are already highly optimised (the gain may be under 5%)
-- SVG files, which are already vector-based and should stay as SVG
+[Media Optimizer](/features/media-optimizer) does both for images served from WordPress, keeps the originals, and lets you restore any image to its original file. That last part matters more than it sounds, and the next section is why.
 
-## Verifying the improvement
+## Keep the originals
 
-After converting your media library, verify the results with the Network tab in browser developer tools. Sort by size and confirm that image requests are serving AVIF or WebP (check the Content-Type response header). Also run a before-and-after with Google PageSpeed Insights to see the LCP impact.
+The single most damaging thing you can do to a media library is overwrite originals with lossy conversions.
 
-WPMgr's Real User Monitoring shows LCP trends from real visitors, so you can see whether the media conversion improved the 75th-percentile LCP across your actual audience.
+Lossy compression is not reversible. If you convert a JPEG to AVIF at quality 60 and delete the JPEG, the discarded detail is gone. Two years later, when a better encoder exists, or you need a print asset, or you decide the quality setting was too aggressive, your source of truth is a compressed derivative. Every future conversion compounds the loss.
 
-For more on the Media Optimizer, see the [Media Optimizer feature page](/features/media-optimizer/). For the full performance picture, see [how to speed up WordPress](/solutions/wordpress-performance/).
+Keep originals. Treat converted files as a cache: derived, disposable, regenerable. Any tool that cannot restore the original is asking you to make a permanent decision using today's encoder settings.
+
+## Format is only half the problem
+
+Converting a 4000 pixel image to AVIF and then serving that same file to a phone still sends a phone far more pixels than its screen can use. The other half of image optimisation is sending an appropriately sized file, and WordPress already has the machinery.
+
+WordPress generates multiple sizes on upload and emits `srcset` and `sizes` automatically for media library images:
+
+```html
+<img
+  src="photo-1024x768.jpg"
+  srcset="photo-480x360.jpg 480w, photo-1024x768.jpg 1024w, photo-1600x1200.jpg 1600w"
+  sizes="(max-width: 700px) 100vw, 700px"
+  width="1024" height="768" alt="Description" />
+```
+
+The `srcset` lists what exists. The `sizes` attribute tells the browser how wide the image will actually be displayed, which it needs before layout to make a choice.
+
+The failure is nearly always `sizes`. WordPress guesses, and its guess is frequently wrong once a theme or page builder puts the image in a constrained column. A `sizes` of `100vw` on an image that renders 700 pixels wide makes the browser fetch the largest candidate on every screen, and the `srcset` you carefully generated does nothing. Check the resolved value in DevTools rather than trusting it.
+
+Two further points. Serving the same image at the same dimensions to a phone and a desktop is the most common waste on WordPress, and it costs more bytes than the format choice does. And if a page builder writes its own markup, it may drop `srcset` entirely, in which case format conversion is compensating for a problem you could have solved outright.
+
+## Storage grows faster than you expect
+
+Each registered size multiplies files. A default install produces several per upload; a theme adding its own sizes can push that past ten. Layer AVIF and WebP on top and one photograph becomes twenty-odd files.
+
+For most sites this is fine and disk is cheap. It matters in three places: backup size and duration grow with it, migrations get slower, and hosts with inode limits (common on shared plans) can hit a file count ceiling long before a storage ceiling. If you have registered image sizes nothing uses, removing them and regenerating is worth doing before a mass conversion rather than after.
+
+## The traps
+
+**Converting at the wrong dimensions.** A 4000 pixel wide photograph displayed in a 800 pixel column is wasting most of its bytes no matter what the format is. Resizing first is usually worth more than the format change. Doing both is the answer.
+
+**Quality set by reflex.** Copying a JPEG quality number across to AVIF gives poor results, because the scales are not comparable. AVIF at 50 is often visually indistinguishable from JPEG at 80. Encoding AVIF at 85 out of caution produces files that are barely smaller than the JPEG and burns CPU for nothing. Test on your own photographs.
+
+**Not checking what is served.** A conversion job can complete successfully while pages still reference the originals, because a page builder hardcoded a URL or a caching layer is serving old HTML. The report says done, the visitors get JPEG.
+
+**Very small files.** Below a kilobyte or two, container overhead can make the converted file larger. Skip them.
+
+**SVG.** Already vector. Leave it alone. It wants minification, not transcoding.
+
+## Lazy loading, and the one image that must not be
+
+WordPress adds `loading="lazy"` to images automatically, which is right for almost everything and wrong for the one image that decides your LCP.
+
+Deferring the hero means the browser will not even begin fetching the element the metric is timing until layout has run. Modern WordPress tries to detect the first large image and skip lazy loading on it, but that detection works from document order, so it is regularly defeated by a slider, a background image applied in CSS, or a builder that renders the hero later in the markup than it appears on screen.
+
+Check the rendered HTML of your main templates. Anything above the fold, and the LCP element in particular, should have no `loading="lazy"` attribute at all. Everything below it should keep one.
+
+## Verifying it actually worked
+
+Do not trust the conversion count. Check what leaves the server.
+
+Open developer tools, load a real page with an empty cache, and look at the Network tab: sort by size and check the `Content-Type` of the image responses. If it says `image/jpeg`, the conversion is not reaching visitors regardless of what any dashboard reports. Do this on the templates that matter, the home page and a product or article page, not just one.
+
+Then check the effect where it counts. A lab run in PageSpeed Insights confirms the bytes changed. Whether it helped is a question about real visitors at the 75th percentile, and only field data answers it. WPMgr's Real User Monitoring reports LCP from actual visits, so a media conversion can be judged against the audience you have rather than a simulated device.
+
+Be prepared for a modest LCP improvement even after a large weight reduction. If your hero image is lazy-loaded, discovered late, or sitting behind a slow uncached server response, the bytes were never the bottleneck. Converting images on a site with a 900ms time to first byte is optimising the wrong stage.
+
+For the tooling, see the [Media Optimizer feature page](/features/media-optimizer). For where images sit among the other wins, see [how to speed up WordPress](/solutions/wordpress-performance).

--- a/apps/marketing/content/blog/wordpress-performance/wordpress-image-optimization-avif-webp.mdx
+++ b/apps/marketing/content/blog/wordpress-performance/wordpress-image-optimization-avif-webp.mdx
@@ -2,6 +2,7 @@
 title: "WordPress Image Optimization: AVIF and WebP in Practice"
 description: "AVIF and WebP reduce image file size by 30 to 60% compared to JPEG. Learn how they differ, which browsers support them, and how to convert your WordPress media library."
 category: "wordpress-performance"
+art: "compress"
 date: "2026-06-17"
 author: "WPMgr Team"
 tags: ["performance", "images", "avif", "webp"]

--- a/apps/marketing/content/blog/wordpress-performance/wordpress-redis-object-cache.mdx
+++ b/apps/marketing/content/blog/wordpress-performance/wordpress-redis-object-cache.mdx
@@ -2,6 +2,7 @@
 title: "Redis Object Cache for WordPress: When It Helps and When It Does Not"
 description: "Redis object cache stores the results of expensive database queries so WordPress does not repeat them. Here is when it makes a real difference and how to measure it."
 category: "wordpress-performance"
+art: "cache"
 date: "2026-06-19"
 author: "WPMgr Team"
 tags: ["performance", "redis", "object-cache", "caching"]

--- a/apps/marketing/content/blog/wordpress-performance/wordpress-redis-object-cache.mdx
+++ b/apps/marketing/content/blog/wordpress-performance/wordpress-redis-object-cache.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Redis Object Cache for WordPress: When It Helps and When It Does Not"
-description: "Redis object cache stores the results of expensive database queries so WordPress does not repeat them. Here is when it makes a real difference and how to measure it."
+description: "Persistent object caching stores the results of expensive database queries across requests. Where it earns its keep, where it adds complexity for nothing, and how to tell the difference from your own numbers."
 category: "wordpress-performance"
 art: "cache"
 date: "2026-06-19"
@@ -10,53 +10,103 @@ featureSlug: "object-cache"
 solutionSlug: "wordpress-performance"
 ---
 
-Redis object cache is one of the most effective WordPress performance tools available, but it is also one of the most misunderstood. It is not a substitute for full-page caching and it will not help every site equally. Understanding when it helps lets you deploy it where it delivers real value.
+Redis object caching is one of the most effective things you can do to a WordPress site, and one of the most frequently deployed where it does nothing at all. Both statements are true, and which one applies to you depends on facts about your traffic that are easy to check before you install anything.
 
-## What the WordPress object cache does
+## What the object cache actually is
 
-WordPress has a built-in object cache API. During a page load, WordPress checks the object cache before running a database query. If the result is already in the cache, it uses that result instead of querying the database.
+WordPress has had an object cache API since long before Redis was involved. During a page load, before running a database query, WordPress checks whether it already has the answer.
 
-By default, the object cache is in-memory and per-request: it stores results only for the duration of the current PHP request. When the request ends, the cache is cleared.
+The important detail is the default backend. Out of the box the object cache is **per request**: it lives in PHP memory for the duration of one page load and is discarded when the request ends. It stops WordPress asking for the same option twice while building one page. It does nothing for the next visitor.
 
-Redis (or Memcached) extends the object cache to be persistent: cached results survive across requests. The next visitor to trigger the same database query gets the result from Redis instead of from the database.
+Dropping in Redis or Memcached makes it **persistent**. Cached results survive across requests, so a query run for one visitor can answer for the next.
 
-## When Redis object cache makes a difference
+That single word, persistent, is the whole feature. It also explains every case where it helps and every case where it does not: the benefit exists only when the same query is asked more than once, by different requests, within the cache lifetime.
 
-The object cache is most effective for:
+## Where it earns its keep
 
-**Sites with high database query overhead.** WooCommerce stores, membership sites, and heavily customised WordPress installs often run dozens of database queries per page load. If those queries hit the same data repeatedly, caching them in Redis has a compounding effect.
+**Sites doing real database work per page.** A default WordPress blog post might run a few dozen queries. A WooCommerce category page with filters, or a membership site resolving access rules, or an install with forty plugins each fetching their own options can run many times that. When those queries repeat across visitors, persistent caching removes them.
 
-**High-traffic sites where the same queries are hit frequently.** The benefit of persistent object caching scales with traffic. A site with 100 requests per hour has little benefit from a cross-request cache. A site with 10,000 requests per hour benefits a lot.
+**Traffic volume.** The benefit scales with how often the same query recurs before it expires. At a hundred requests an hour, most cached entries expire unused. At ten thousand, the cache is warm and nearly everything is a hit.
 
-**Sites where full-page caching cannot be used.** WooCommerce cart pages, membership-gated content, and pages that vary by user cannot be served from a full-page cache. Redis can still cache the database queries that generate those personalised responses.
+**Pages that full-page caching cannot touch.** This is the strongest case. A logged-in visitor, a cart, a member-only page, and a personalised dashboard all have to run PHP, and full-page caching is unavailable by definition. Redis cannot make the page static, but it can strip the repeated database work out of generating it. On a store where a meaningful share of traffic is logged in, this is where the wins are.
 
-## When Redis object cache does not help much
+**Autoloaded options.** WordPress loads every autoloaded option on every request. On a site where plugins have accumulated a bloated `wp_options` table, that is a large query on the critical path of literally every page. Persistent caching removes the repetition, though the honest fix is to clean up what is being autoloaded.
 
-**Static sites or sites with heavy full-page caching.** If most of your traffic is served from a full-page cache (HTML cached at the server), WordPress PHP does not run at all for those requests. The object cache is never consulted. Adding Redis to a well-cached static site adds complexity without benefit.
+## Where it does not help
 
-**Sites with very low traffic.** The cross-request benefit requires that the same query be hit multiple times across requests. Low-traffic sites may never see the same query twice before the cached result expires.
+**A site already served almost entirely from full-page cache.** If anonymous visitors get prebuilt HTML, PHP never runs for them, so the object cache is never consulted. Adding Redis to a well-cached brochure site adds a service to run, monitor, and secure, in exchange for improving requests that were not happening. This is the most common misapplication.
 
-**Sites with queries that always return different results.** If every visitor triggers queries that return unique results (for example, a personalised feed with no shared data), caching the responses is not useful.
+**Low traffic.** Without repetition there is nothing to reuse.
 
-## Understanding hit ratio
+**Genuinely unique queries.** If every request produces different results with no shared data, there is nothing to hit.
 
-The hit ratio is the percentage of object cache lookups that return a cached result rather than falling through to the database. A hit ratio below 70% suggests the cache is not warm, the TTL (time to live) settings are too short, or the site's query patterns do not benefit from caching.
+**A slow database that is slow for other reasons.** Caching in front of missing indexes or a badly written meta query hides the symptom for cached paths and leaves it in place for everything else. Fix the query, then cache it.
 
-WPMgr tracks the Redis hit ratio, memory usage, and latency per site and shows them in the dashboard. A rising hit ratio after enabling Redis is confirmation that it is working. A persistently low hit ratio may mean you should investigate query patterns before concluding Redis is the right tool.
+## Measure before and after, with the right number
 
-## Eviction policy matters
+The number to watch is the **hit ratio**: the share of lookups answered from cache rather than falling through to the database.
 
-Redis has a fixed memory allocation. When that allocation fills, it must evict existing entries to make room for new ones. The eviction policy determines which entries are removed.
+A ratio below roughly 70 percent means something is wrong, and it is worth knowing which thing. The cache may still be cold, in which case it climbs on its own. Memory may be too small, so entries are evicted before they can be reused. Expiry times may be shorter than the interval between repeat requests. Or the site's query patterns genuinely do not repeat, which is a real answer and means Redis is not your problem.
 
-For a WordPress object cache, `allkeys-lru` (evict the least recently used key regardless of whether it has an expiry) is a sensible default. It ensures that the most-accessed data stays in the cache under memory pressure. Without the right policy, a full cache might evict frequently-used entries in favour of entries that will never be read again.
+Watch three things together, because any one alone misleads: hit ratio, memory used against memory allocated, and eviction count. A high hit ratio with heavy eviction means the cache is working and starved. WPMgr reports all three per site, so the question "did this help" has an answer rather than an opinion.
 
-## Combining Redis with full-page caching
+The other measurement worth taking is the one people skip: what the page cost before. If time to first byte was already 200ms, the database was not your bottleneck and nothing here will move it much.
 
-The most effective WordPress performance configuration layers both:
+## Memory and eviction policy
 
-- Full-page caching serves anonymous traffic without running PHP
-- Redis object cache serves authenticated or uncacheable requests with minimal database overhead
+Redis has a fixed memory ceiling. When it fills, the eviction policy decides what goes.
 
-WPMgr supports both on the same site. Full-page caching is configured through the Performance settings; Redis object cache is a separate per-site toggle that connects to a Redis instance and installs the object-cache drop-in automatically.
+For a WordPress object cache, `allkeys-lru` is the sensible default: evict the least recently used key, whether or not it carries an expiry. This keeps hot data resident under pressure.
 
-For the complete performance picture, see the [Redis Object Cache feature page](/features/object-cache/) and the [speed up WordPress solution guide](/solutions/wordpress-performance/).
+The policy to avoid is `noeviction`, which returns errors on write instead of making room. WordPress generally handles a failed cache write by carrying on and hitting the database, so the visible symptom is not an error page but a cache that silently stops accepting new entries and a hit ratio that decays while everything looks superficially fine.
+
+`volatile-lru` only evicts keys with an expiry set, which sounds safer and behaves badly here, because WordPress sets many entries with no expiry at all. Under pressure it can find nothing eligible to evict.
+
+## Transients quietly become a different feature
+
+WordPress transients are cached values with an expiry, and where they are stored depends entirely on whether a persistent object cache exists.
+
+Without one, transients go in the `wp_options` table. They are rows in your database, they persist across requests because the database does, and expired ones are not reliably cleaned up, which is why `wp_options` on an older site is often full of stale transient rows.
+
+Install a persistent object cache and transients move into it instead. Two consequences follow, and both surprise people.
+
+The good one: the `wp_options` bloat stops accumulating, and transient reads stop being database queries. On sites where plugins lean heavily on transients this is a meaningful share of the benefit.
+
+The one that causes support tickets: **transients now evaporate when the cache is flushed or evicted.** Code that stored something expensive in a transient and assumed it would survive because it always had now finds it gone. Anything written to survive a restart belongs in an option, not a transient. That was always true; a persistent object cache is just the thing that makes it visible.
+
+## Redis or Memcached
+
+Both work. WordPress does not care which sits behind the drop-in.
+
+Memcached is simpler, purely a volatile cache, and slightly faster for plain key lookups. Redis has richer data types, optional persistence to disk, and better introspection, which in practice means you can actually inspect what is cached and why the hit ratio is what it is.
+
+For WordPress the deciding factor is usually availability: use whichever your host already runs well. Redis is the more common default now and the easier of the two to debug, which is why it is what most guidance, including this page, assumes.
+
+## Stale data and flushing
+
+Caching introduces the possibility of serving something that is no longer true. WordPress handles most of this for you, invalidating relevant keys when posts and options change, and the common plugins do the same. The problems arise at the edges.
+
+Code writing directly to the database with `$wpdb` bypasses the invalidation entirely, so the cache keeps returning the old value indefinitely. Imports, bulk edit scripts, and migrations frequently do this, which is why a bulk operation can appear to have done nothing until the cache is flushed.
+
+The symptom is distinctive: changes that are correct in the database and wrong on the page, sometimes for some visitors and not others. If you see that, flush the cache before debugging anything else. If flushing fixes it, the bug is a missing invalidation, not the cache.
+
+Worth knowing before an incident: flushing an object cache is safe. Nothing is lost that cannot be recomputed, the only cost is a period of slower requests while it warms again.
+
+## Two operational traps
+
+**Redis reachable from outside.** Redis is not designed to sit on the public internet. It should bind to localhost or a private network, require a password, and never be exposed. A publicly reachable instance with no auth is a well-known and heavily scanned target, and on a shared host it may also be visible to other tenants.
+
+**One Redis, many sites, one keyspace.** Pointing several WordPress installs at the same Redis without separating them means one site can read and flush another's entries. Use a distinct database index or key prefix per site. This bites agencies specifically, and it presents as impossible-to-reproduce bugs where clearing the cache on one client's site changes another's.
+
+## Layer it with full-page caching
+
+These solve different problems and the strongest setup uses both:
+
+- **Full-page caching** serves anonymous traffic without executing PHP at all. Largest single win for most sites.
+- **Object caching** reduces the cost of everything that must execute PHP: logged-in sessions, carts, checkout, admin.
+
+Configure page caching first and measure. Then, if a meaningful share of your traffic is authenticated or otherwise uncacheable, add object caching for that share and watch the hit ratio confirm it.
+
+WPMgr runs both on the same site. Page caching lives in the Performance settings, and the object cache is a per-site toggle that connects to Redis and installs the drop-in for you, with hit ratio, memory, and latency reported back so the decision to keep it is based on your numbers.
+
+See the [Redis Object Cache feature page](/features/object-cache) and the [speed up WordPress guide](/solutions/wordpress-performance).

--- a/apps/marketing/content/blog/wordpress-security/harden-wordpress-login.mdx
+++ b/apps/marketing/content/blog/wordpress-security/harden-wordpress-login.mdx
@@ -2,6 +2,7 @@
 title: "How to Harden Your WordPress Login Page"
 description: "Practical steps to reduce automated login attacks on WordPress: limit attempts, change the login URL, enforce strong passwords, and add a second factor."
 category: "wordpress-security"
+art: "gate"
 date: "2026-06-15"
 author: "WPMgr Team"
 tags: ["security", "login", "2fa"]

--- a/apps/marketing/content/blog/wordpress-security/harden-wordpress-login.mdx
+++ b/apps/marketing/content/blog/wordpress-security/harden-wordpress-login.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How to Harden Your WordPress Login Page"
-description: "Practical steps to reduce automated login attacks on WordPress: limit attempts, change the login URL, enforce strong passwords, and add a second factor."
+description: "Practical steps to cut automated login attacks on WordPress: rate limiting that survives a PHP error, closing XML-RPC multicall, stopping user enumeration, and adding a second factor."
 category: "wordpress-security"
 art: "gate"
 date: "2026-06-15"
@@ -10,56 +10,102 @@ featureSlug: "security"
 solutionSlug: "wordpress-security"
 ---
 
-Automated login attacks are one of the most common threats to WordPress sites. Bots scan for `wp-login.php` around the clock, testing credential lists against every site they find. A stock WordPress install gives attackers an unlimited runway.
+Every WordPress site on the public internet receives automated login traffic. Not because anyone chose it, but because `wp-login.php` sits at a predictable address on millions of hosts, and testing credential lists against a predictable address is cheap.
 
-Hardening your login page is one of the highest-return security investments you can make because it cuts off a whole class of attacks before they reach the application layer.
+A stock install gives that traffic an unlimited runway. There is no attempt limit, the username is often discoverable, and a second protocol on the same host will happily accept hundreds of credential guesses in a single request. Closing those gaps is among the highest-return security work available, because it removes a whole class of attack before it reaches your application code.
 
-## Why the default login page is a target
+## Why the login page is the default target
 
-WordPress advertises its login URL in the page source (`/wp-login.php`), in its XML-RPC endpoint, and through user enumeration via author archive URLs. Bots fingerprint WordPress installs automatically and queue them for credential stuffing.
+Three properties make it attractive.
 
-The consequences of a successful login attack go beyond account compromise. High-volume attempts degrade server performance, inflate hosting bills, and generate noise that masks real security events in your logs.
+It is **findable**. WordPress announces itself in page source, in HTTP headers, in the readme file, and through the REST API. Fingerprinting a WordPress install takes one request.
 
-## Step 1: Limit login attempts
+It is **uniform**. The login form is at the same path, takes the same field names, and returns distinguishable responses across the entire ecosystem. One script works everywhere.
 
-WordPress allows unlimited login attempts by default. Restricting failed attempts to three to five per IP address per hour stops most credential stuffing with no user impact.
+It is **chatty**. By default WordPress tells an attacker whether the username was wrong or the password was wrong. That turns one guess into two pieces of information, and it means an attacker can confirm a valid username before spending a single attempt on passwords.
 
-WPMgr enforces this at the server layer through the agent, so limits apply even if PHP returns a 500 error during the login request. The control plane also tracks failed-attempt counts across your fleet so you can spot a targeted attack on a specific site.
+The damage is not limited to a successful login either. Sustained attempts consume PHP workers, inflate hosting bills on metered plans, and bury real security events in log noise. Plenty of sites that were never breached have still been taken down by the load of people trying.
 
-## Step 2: Block XML-RPC when you do not need it
+## Limit attempts, at the right layer
 
-XML-RPC is a legacy remote-procedure protocol that WordPress still exposes. It has a `system.multicall` method that lets attackers test hundreds of credential pairs in a single HTTP request, which makes rate limiting on the login form irrelevant if XML-RPC is open.
+WordPress permits unlimited login attempts. Capping failures per IP address, somewhere around three to five per hour, stops most credential stuffing with no effect on legitimate users, who almost never fail five times in an hour.
 
-If you do not use XML-RPC (Jetpack and older mobile apps need it; most modern setups do not), disable it entirely. WPMgr lets you toggle this per site from the Security tab. The "pingbacks only" option keeps comment pingbacks working while closing the multicall exploit surface.
+Where the limit is enforced matters more than the number. A limiter implemented purely in PHP inside WordPress is bypassed whenever the request does not complete normally: if the site throws a fatal error during login, the attempt may never be recorded, and an attacker who can reliably trigger an error gets free guesses. WPMgr enforces limits through the agent at a layer that still counts the attempt when PHP returns a 500.
 
-## Step 3: Restrict the REST API
+The second thing worth having is a view across sites. A single site showing forty failures an hour is background noise. The same forty against one specific site while the rest of your fleet sees nothing is somebody who has picked a target, and that distinction only exists if the counts are aggregated centrally.
 
-WordPress exposes a REST API at `/wp-json/`. Unauthenticated access is needed for some themes and plugins, but several endpoints leak user data (the `/users` route, for example, returns display names, slugs, and IDs that attackers use for targeted credential attacks).
+## Close XML-RPC, or at least close multicall
 
-You can restrict the REST API to authenticated requests only, or allow public access only to specific namespaces. WPMgr's Security tab gives you this toggle without writing code.
+XML-RPC is a legacy remote procedure protocol that WordPress still exposes at `/xmlrpc.php`. It matters here for one reason: the `system.multicall` method batches many calls into a single HTTP request.
 
-## Step 4: Move or obfuscate the login URL
+That single property defeats naive rate limiting entirely. If your limiter counts requests, and one request carries three hundred credential pairs, the attacker gets three hundred guesses for the price of one. Everything you did to the login form is irrelevant while this endpoint is open.
 
-Moving `wp-login.php` to a custom address removes it from automated scanners. This is a deterrent, not a defence, because a determined attacker can still find the page, but it eliminates the majority of low-effort automated traffic.
+Some things still need it. Jetpack uses it, as do older mobile apps and some remote publishing tools. Most modern setups do not. If nothing depends on it, disable it. If pingbacks are the only thing you want, a pingbacks-only mode keeps those working while removing the multicall surface. WPMgr exposes this per site from the Security tab so you can make the decision once and apply it everywhere.
 
-WPMgr's "Hide login" feature sets a custom login path per site. The control plane continues to work normally because it accesses sites through a signed token path, not the login form.
+## Stop the site from confirming usernames
 
-## Step 5: Force unique display names
+An attacker needs a username and a password. WordPress is unhelpfully generous with the first half.
 
-WordPress defaults to showing usernames as display names. If your display name matches your username, you have handed attackers half of the credential pair. Forcing unique display names that differ from login usernames closes this gap.
+**Author archives.** Requesting `/?author=1` redirects to that user's archive, and the resulting URL contains their login slug. Walking the integers enumerates the whole user table.
 
-## Step 6: Enable two-factor authentication
+**The REST API users route.** `/wp-json/wp/v2/users` returns display names, slugs, and IDs to unauthenticated requests on a default install.
 
-A strong password plus a second factor is the most reliable protection against credential-based attacks. Even if an attacker obtains a user's password through a data breach, they cannot log in without the second factor.
+**Login error messages.** "Unknown username" and "The password you entered for the username admin is incorrect" are different messages, and the difference is the answer.
 
-WPMgr lets operators require 2FA for any user role on a per-site basis. Supported methods include authenticator apps (TOTP) and email one-time codes. A configurable grace period lets existing users enroll before the policy is enforced.
+**Display names.** WordPress shows the display name on posts and comments, and by default the display name is the username. If your byline reads `sarah`, that is the login.
 
-## Step 7: Block author archive enumeration
+Fix all four. Block author enumeration redirects, restrict the users route to authenticated requests, and force display names that differ from login names. WPMgr's Security tab covers the first three without code, and the display name rule is worth enforcing as policy because it costs nothing.
 
-WordPress creates archive URLs at `/?author=1`, `/?author=2`, and so on that redirect to user profile pages and expose usernames. Blocking these redirects removes one of the most reliable username enumeration vectors.
+Restricting the REST API needs a little judgement. Some themes and plugins genuinely require unauthenticated access to specific namespaces, so blanket-blocking `/wp-json/` can break a site in ways that are not obvious immediately. Restricting the user-listing routes specifically is the high-value, low-risk version.
 
-## Putting it together
+## Moving the login URL: useful, but be honest about it
 
-None of these steps is complicated in isolation. The challenge is applying them consistently across a fleet of sites without missing one. WPMgr's Security tab pushes all of these controls from the control plane to the agent, so you can harden fifty sites in the same time it would take to do one manually.
+Relocating `wp-login.php` to a custom path removes your site from the reach of scanners that only know the default address. In practice that is a large share of the automated traffic, and the drop in log noise is immediate and real.
 
-For more on WordPress security hardening, see the [Security suite feature page](/features/security/) or the [WordPress security solution guide](/solutions/wordpress-security/).
+It is not a defence. The page is still there, still reachable by anyone who finds it, and various things leak the new location if you are careless. Treat it as reducing volume rather than reducing risk, and do not let it substitute for attempt limiting or a second factor.
+
+One practical caution: whatever manages your sites needs to keep working after the move. WPMgr reaches sites over a signed token path rather than the login form, so hiding the login does not lock the control plane out. Anything that automates through the login form will break.
+
+## Add a second factor
+
+Everything above reduces the number of guesses an attacker gets. A second factor changes the game, because it makes the password insufficient even when correct.
+
+This matters because the most likely way somebody gets a valid password for your site is not guessing it. It is reuse. A password exposed in an unrelated breach, tried against your login, works on the first attempt, and no rate limiter fires because there were no failures.
+
+Require it for administrators at minimum, and for editors on any site where content is revenue. Authenticator apps (TOTP) are the sensible default; email one-time codes are weaker, because they inherit the security of the mailbox, but they are far better than nothing and much easier to roll out to non-technical clients.
+
+Roll it out with a grace period rather than overnight. WPMgr lets you require 2FA per role, per site, with a configurable window for existing users to enrol, which is the difference between a policy that lands and one that generates twenty support emails on a Monday.
+
+## Restricting wp-admin at the web server
+
+A layer above WordPress entirely: require HTTP authentication or an IP allowlist on `/wp-admin` and `/wp-login.php` at the web server. A request that fails there never reaches PHP, so it costs you nothing to serve and cannot exploit anything in the application.
+
+It is the strongest option on this page and the least often usable. An IP allowlist needs everyone who administers the site to have a stable address, which rules out most agencies with remote staff and anyone on mobile networks. HTTP auth adds a second prompt that clients find confusing and will ask you to remove.
+
+Where it fits well is sites with a small, fixed set of administrators and no client logins: your own properties, internal tools, and staging environments. Staging in particular is worth doing every time, because staging sites are routinely left with weak passwords, real data, and no monitoring.
+
+One caveat: blocking `/wp-admin` wholesale breaks `admin-ajax.php`, which plenty of front-end features on public pages call without a login. Exempt that file, or expect intermittent breakage that is difficult to trace.
+
+## Sessions and application passwords
+
+Two smaller surfaces worth closing once the main ones are done.
+
+**Sessions outlive password changes unless you end them.** Changing a compromised password does not, by itself, log out an attacker who already has a valid session cookie. WordPress can destroy other sessions for a user, and doing so should be part of any credential rotation. Rotating the salts in `wp-config.php` invalidates every session on the site at once, which is the blunt version and is the right move after a confirmed compromise.
+
+**Application passwords bypass two-factor authentication by design.** They exist so that external tools can authenticate to the REST API, and they are not covered by your 2FA policy. That is correct behaviour and also means an attacker who creates one has a durable credential that survives a password reset. Audit the application passwords on each account, revoke ones you cannot account for, and disable the feature entirely on sites where nothing uses the REST API for authenticated work.
+
+## Two things people skip
+
+**Delete dormant administrator accounts.** The developer who built the site three years ago, the agency you stopped working with, the plugin that created a service account. Each is a full-privilege credential you are not watching. Audit the admin list on every site and reduce it to people who need it this quarter.
+
+**Do not reuse admin credentials across a portfolio.** One password across fifty client sites means one breach is fifty breaches. This is the single most common structural weakness in agency setups, and it turns a contained incident into a catastrophic one.
+
+## Doing it across a fleet
+
+None of these steps is difficult on one site. The difficulty is applying all of them to every site, and knowing which ones drifted.
+
+That is the actual failure mode in an agency: the hardening was done, correctly, at launch, and then a site was migrated, or restored from an old backup, or handed over, and quietly reverted. Nobody notices until it matters.
+
+Push the controls from one place, and check them from one place. WPMgr sends this configuration from the control plane to the agent on each site, so hardening fifty sites takes about as long as hardening one, and the fleet view shows you where the settings do not match what you intended.
+
+For the full set of controls, see the [Security suite feature page](/features/security). For how login hardening fits alongside [vulnerability scanning](/blog/wordpress-security/wordpress-vulnerability-scanning) and file integrity checks, see the [WordPress security solution guide](/solutions/wordpress-security).

--- a/apps/marketing/content/blog/wordpress-security/wordpress-file-integrity-monitoring.mdx
+++ b/apps/marketing/content/blog/wordpress-security/wordpress-file-integrity-monitoring.mdx
@@ -1,6 +1,6 @@
 ---
 title: "WordPress File Integrity Monitoring: Detect Unauthorized Changes"
-description: "File integrity monitoring compares your WordPress install against known-good checksums to catch modified or injected files. Here is how it works and when it matters."
+description: "File integrity monitoring compares a WordPress install against known-good checksums to catch modified or injected files. How it works, why the baseline must never advance on its own, and how to read the results."
 category: "wordpress-security"
 art: "integrity"
 date: "2026-06-20"
@@ -10,61 +10,120 @@ featureSlug: "security"
 solutionSlug: "wordpress-security"
 ---
 
-When an attacker gains access to a WordPress site, the first thing they typically do is modify files: injecting backdoors into plugin code, changing theme files to serve spam, or dropping web shells in the uploads directory. File integrity monitoring is what catches this.
+Vulnerability scanning tells you what could be exploited. File integrity monitoring tells you what already was.
 
-## What file integrity monitoring does
+When somebody gains write access to a WordPress site, the next step is almost always to change files: a backdoor appended to a plugin, a theme template rewritten to serve spam links to search engines only, a web shell dropped into an uploads folder with an innocuous name. None of that is visible on the front end. Most of it is invisible in the admin area too. It is visible on disk, which is where integrity monitoring looks.
 
-File integrity monitoring (FIM) computes cryptographic hashes of files in your WordPress install and compares them against a known-good baseline. Any change to a file changes its hash. If the hash no longer matches, the file has been modified.
+## What it actually does
 
-For WordPress core and plugins hosted on WordPress.org, the "known good" state is the published checksum list at the WordPress.org API. For custom code and anything not on WordPress.org, the known-good state is the baseline WPMgr captured during the last clean scan.
+File integrity monitoring computes a cryptographic hash of each file and compares it against a known-good value. Hashes are extremely sensitive to change: a single altered byte produces a completely different result. So if the hash no longer matches, the file is not what it was.
 
-## Three scan modes
+The interesting question is where "known good" comes from, because WordPress has two very different situations on the same disk.
 
-WPMgr supports three scan scopes:
+For **WordPress core and anything distributed through WordPress.org**, there is an external authority. The WordPress.org API publishes checksums for every released version of core, and for plugins and themes in the directory the canonical package is public. A local file can be compared against a value the site itself never controlled, which is the strongest form of this check.
 
-**Core files only.** The fastest option. Checks WordPress core files against WordPress.org checksums. Catches a WordPress core compromise but misses plugin and theme modifications.
+For **everything else**, no such authority exists. Custom plugins, bespoke themes, commercial plugins sold outside the directory, and every file in uploads have no published checksum anywhere. For these the reference has to be a baseline: a snapshot of hashes recorded by an earlier scan.
 
-**wp-content only.** Skips core (where unauthorized changes are rarer) and focuses on plugins, themes, and uploads, where most injections happen.
+## The baseline problem, and why it decides everything
 
-**Full install.** Comprehensive but slowest. Covers both core and wp-content. Useful for a periodic deep check or after a suspected incident.
+A baseline is a record of what the files looked like at some past moment. It is only meaningful if that moment was clean, and nothing outside the site can tell you whether it was.
 
-## The baseline problem
+This creates a design decision that separates useful integrity monitoring from decorative integrity monitoring: **can the baseline advance by itself?**
 
-For files that are not on WordPress.org (custom plugins, themes, uploaded files), there is no external reference. FIM uses a per-site baseline: a snapshot of file hashes taken during a clean scan. Subsequent scans compare against this baseline.
+If it can, the system is defeated trivially. An attacker writes a backdoor, the next scan notices a new file, the baseline updates to include it, and every subsequent scan reports the site as clean. The tool has been taught that the backdoor is normal. Worse, it now actively reassures you.
 
-The key design decision is whether the baseline can advance automatically. WPMgr's stance is that it cannot. A flagged file stays flagged until an operator reviews it and explicitly accepts it. The baseline never silently advances past an unreviewed change. This prevents an attacker from injecting a file, waiting for the baseline to update, and then appearing clean.
+WPMgr's baseline does not advance on its own. A flagged file stays flagged until a person looks at it and explicitly accepts it. That is deliberately more work, and it is the only version of this feature that means anything. An accepted change is a decision somebody made; a silently absorbed change is a decision nobody made.
 
-## Reading scan results
+The corollary matters when you adopt the tool: your first baseline is only as trustworthy as the site was on the day you took it. Capturing a baseline on an already-compromised site records the compromise as normal. If you are enabling this on a site with unknown history, it is worth pairing the first scan with a core-checksum comparison, which does not depend on the baseline at all.
 
-A scan result categorises every finding:
+## Three scan scopes and when each is right
 
-- **Changed.** A file that existed in the last baseline now has a different hash. For core or wp.org files, "changed" means "no longer matches the published checksum."
-- **Added.** A file is present that was not in the baseline.
-- **Removed.** A file in the baseline is no longer on disk.
+Scanning everything on every run is thorough and slow, and slow scans get turned off. Three scopes cover the realistic cases.
 
-Added files in the uploads directory are common and usually benign (user uploads). Added files in plugin or theme directories are suspicious and warrant investigation. Modified core files are almost always a sign of tampering.
+**Core only.** Fast, and compares against published WordPress.org checksums rather than a local baseline, so it is the highest-confidence check available. Core files being modified is rare and nearly always means tampering. Good as a frequent, cheap heartbeat.
 
-## What to do when something is flagged
+**wp-content only.** Skips core and covers plugins, themes, and uploads, which is where the large majority of injections actually land. This is the sensible default for regular scheduled runs.
 
-Finding a modified file does not mean you have been compromised. Plugin auto-updates, migration tools, and maintenance scripts can all legitimately change files. The first step is to understand whether the change is expected.
+**Full install.** Both of the above. Slower, and worth running periodically and always after a suspected incident, when you want completeness rather than speed.
 
-If the change is expected, review it in the dashboard and accept it to update the baseline for that file. If the change is unexpected, the right response is:
+On a large or media-heavy site, uploads dominate the runtime. Scanning uploads still matters, because dropping a PHP file into a directory that should only ever hold images is a classic move, but it is reasonable to run the full scope less often than the rest.
 
-1. Take the site offline or put it in maintenance mode
-2. Take a backup of the current state for forensics
-3. Restore from the most recent clean backup
-4. Investigate how the change happened (check access logs, plugin change history)
-5. Patch the entry point before bringing the site back online
+## Reading the results
 
-WPMgr's backup and restore flow is integrated with the Security tab so you can go from "flagged file" to "clean restore" without leaving the dashboard.
+Findings come in three kinds, and they carry very different weight depending on where they land.
 
-## Combining FIM with other controls
+**Changed.** A file's hash differs from the reference. For core and directory-hosted files this means it no longer matches the published checksum, which is a strong signal. For baselined files it means it differs from your last accepted state.
 
-File integrity monitoring is most effective as one layer in a defence-in-depth posture:
+**Added.** A file exists that was not in the baseline.
 
-- Vulnerability scanning finds known-vulnerable plugins before they are exploited
-- FIM detects exploitation after it happens
-- Two-factor authentication on the dashboard prevents attackers from using the dashboard itself to deploy changes
-- Backups ensure you can recover regardless
+**Removed.** A baselined file is gone.
 
-See the [Security suite feature page](/features/security/) and the [WordPress security solution](/solutions/wordpress-security/) for the full picture.
+Location does most of the interpretation:
+
+- Added files in **uploads** are usually just uploads. Added files in uploads with executable extensions are not, and are one of the most reliable indicators of a real problem.
+- Added or changed files in **plugin and theme directories** deserve attention, though plugin updates legitimately produce a lot of both.
+- Changed files in **core** are close to conclusive. Core does not change unless something changed it.
+- Changed files at the **web root**, especially `wp-config.php`, `.htaccess`, or an unexpected drop-in in `wp-content`, are worth looking at immediately, because that is where redirects and persistence usually live.
+
+## Expect legitimate noise, and plan for it
+
+A finding is not a compromise. Plenty of ordinary events change files: plugin and core auto-updates, a migration tool, a caching plugin writing config, a deploy, a developer editing a template through the file editor.
+
+This is why the accept step exists, and why the review habit matters more than the alert. A tool that cries wolf and is never triaged is worse than no tool, because it produces a false sense of coverage. The workflow that survives contact with reality is to scan on a schedule, review findings in a batch, accept the ones you can account for, and investigate the ones you cannot.
+
+If you run updates through a controlled flow, the noise drops sharply, because you know when changes were supposed to happen and can accept a plugin update's file changes as a group rather than one at a time.
+
+## When a finding is not explainable
+
+If you cannot account for a change, treat it as an incident rather than a curiosity.
+
+1. **Put the site into maintenance mode** or take it offline. Every minute it serves traffic while compromised is more spam indexed and more visitors exposed.
+2. **Back up the current state before changing anything.** This is not for recovery, it is evidence. If you clean first you lose any chance of understanding what happened.
+3. **Restore from the most recent backup you believe is clean.** Note the word believe: check its date against when the change appeared, because restoring to a point after the intrusion just reinstates it.
+4. **Find the entry point before going back online.** Restoring without patching the way in produces a site that is compromised again within days, often within hours. Check access logs around the file's modification time, review recent plugin installs, and audit administrator accounts and their password history.
+5. **Rotate credentials.** Admin passwords, database password, any API keys stored in `wp-config.php`, and the hosting account itself.
+
+Step four is the one people skip, and it is the reason sites get reinfected repeatedly. A backdoor is a symptom. The vulnerable plugin, reused password, or exposed credential is the cause.
+
+## What it cannot see
+
+The limitation worth understanding before you rely on this: **file integrity monitoring only looks at files.** A large share of WordPress compromises leave little or nothing on disk.
+
+- **Injected administrator accounts** live in the `wp_users` table. Every file hash matches and there is a new admin you did not create.
+- **Malicious content in options.** Redirect rules, injected scripts, and spam payloads are frequently stored in `wp_options` and executed by legitimate, unmodified plugin code. A common pattern uses a real plugin's own settings to serve the attacker's content, so nothing on disk is wrong.
+- **Scheduled tasks.** A malicious cron entry in `wp_options` can re-download a backdoor after you delete it, which is why files sometimes reappear after a clean.
+- **Injected posts and comments** are ordinary database rows.
+- **Anything outside the WordPress directory.** A compromised hosting account may have payloads in other sites on the same server, in the home directory, or in cron at the system level.
+
+This is also the practical answer to "I cleaned the files and it came back". If a scan shows a reinfection with no explanation, the persistence is almost certainly in the database or in a scheduled task, not in the files you keep deleting.
+
+Checking the admin user list and the active scheduled tasks takes two minutes and belongs in the same review as the file findings.
+
+## Scheduling that people actually keep
+
+A scan that runs while a site is under load is a scan somebody eventually disables. Two settings decide whether this stays switched on.
+
+**Frequency by scope.** Daily is reasonable for core or wp-content. Full-install scans including uploads are better weekly on a media-heavy site, or on demand after an incident.
+
+**Timing.** Hashing every file is I/O bound, and on shared hosting it competes with the site itself. Schedule it for the site's own quiet hours rather than yours, which for a client base spread across time zones is not the same thing.
+
+The other half is alerting. Findings you have to go looking for are findings you see a week late. What you want is to be told when something new appears and left alone when nothing has, which means the noise reduction above is not a nicety, it is what makes the alerts survivable.
+
+## Where it sits among the other controls
+
+Integrity monitoring is a detective control, not a preventive one. It does not stop anything. It tells you something happened, which is only useful alongside the controls that reduce how often that is true and the ones that let you recover.
+
+- [Vulnerability scanning](/blog/wordpress-security/wordpress-vulnerability-scanning) closes known holes before they are used.
+- [Login hardening and two-factor authentication](/blog/wordpress-security/harden-wordpress-login) cut off the credential route, which is how a surprising share of "hacks" actually happen.
+- Integrity monitoring catches what got through anyway.
+- [Backups](/features/backups) are what turn a compromise into an afternoon rather than a rebuild.
+
+Each covers what the others miss. Integrity monitoring in isolation is an alarm on a door you left unlocked.
+
+## Running it across a fleet
+
+The per-site question is "is this site clean". The portfolio question is "which of my sites has an unreviewed finding right now", and only the second one scales.
+
+WPMgr runs scans from the control plane on a schedule you set, surfaces findings per site and across the fleet, and keeps the backup and restore flow in the same place, so going from a flagged file to a clean restore does not mean leaving the dashboard and reconstructing context.
+
+See the [Security suite feature page](/features/security) for the controls, and the [WordPress security solution](/solutions/wordpress-security) for how they fit together.

--- a/apps/marketing/content/blog/wordpress-security/wordpress-file-integrity-monitoring.mdx
+++ b/apps/marketing/content/blog/wordpress-security/wordpress-file-integrity-monitoring.mdx
@@ -2,6 +2,7 @@
 title: "WordPress File Integrity Monitoring: Detect Unauthorized Changes"
 description: "File integrity monitoring compares your WordPress install against known-good checksums to catch modified or injected files. Here is how it works and when it matters."
 category: "wordpress-security"
+art: "integrity"
 date: "2026-06-20"
 author: "WPMgr Team"
 tags: ["security", "file-integrity", "malware"]

--- a/apps/marketing/content/blog/wordpress-security/wordpress-vulnerability-scanning.mdx
+++ b/apps/marketing/content/blog/wordpress-security/wordpress-vulnerability-scanning.mdx
@@ -1,6 +1,6 @@
 ---
 title: "WordPress Vulnerability Scanning: What It Is and Why It Matters"
-description: "Learn how plugin and theme vulnerability scanning works, what CVE databases power it, and how to act on scan results without breaking your sites."
+description: "How plugin and theme vulnerability scanning works, which CVE feeds power it, why version matching is harder than it looks, and how to triage findings without breaking your sites."
 category: "wordpress-security"
 art: "scanner"
 date: "2026-06-18"
@@ -10,64 +10,109 @@ featureSlug: "security"
 solutionSlug: "wordpress-security"
 ---
 
-A plugin you installed two years ago might have a known remote-code-execution vulnerability patched four months ago. If you have not updated it, any attacker who has read the Wordfence Intelligence feed can walk straight in.
+A plugin you installed two years ago and have not thought about since may have a remote code execution flaw that was disclosed, assigned a CVE, and patched four months ago. The patch exists. It is sitting in the plugin repository right now. You simply have not applied it.
 
-Vulnerability scanning closes the gap between "a patch exists" and "you have applied it."
+That gap, between "a fix is available" and "the fix is running on your site", is where most WordPress compromises happen. Vulnerability scanning is the practice of measuring that gap continuously instead of discovering it during an incident.
 
-## How plugin and theme vulnerabilities work
+## Most compromises are not zero-days
 
-Most WordPress security issues are not zero-days. They are well-documented flaws in plugins and themes that have been publicly disclosed, assigned a CVE number, and patched. The time between disclosure and patch is short. The time between patch and update on a typical WordPress site is often weeks to months.
+There is a persistent belief that getting hacked means someone found a novel flaw and used it against you specifically. For the overwhelming majority of WordPress sites, that is not what happens.
 
-Attackers automate against this lag. They monitor vulnerability feeds, fingerprint WordPress installs for affected plugin versions, and attempt known exploit chains. The site operator who runs updates the day a patch drops is safe. The operator who runs updates quarterly is not.
+What happens is far more mundane. A researcher finds a flaw in a plugin with 40,000 installs. They report it privately. The developer ships a fix. The vulnerability is published to public feeds with the affected version range attached. Within hours, that record is being read by people who are not researchers, who then fingerprint WordPress sites at scale looking for installs still running the affected range.
 
-## What vulnerability feeds provide
+The economics matter here. Nobody is spending a week studying your particular site. They are spending an afternoon writing something that tries one known exploit against a hundred thousand sites, because at that scale even a low hit rate pays. You are not a target. You are a row in a list.
 
-A vulnerability feed maps plugin or theme slugs and version ranges to CVE records. Each record includes:
+This is good news, because it means the defence is unglamorous and entirely achievable: know what you are running, know what is known to be broken, and close the distance between the two.
 
-- Affected version range (for example, versions before 2.4.1 are vulnerable)
-- Fixed version
-- CVE identifier and CVSS severity score
-- Type of vulnerability (SQL injection, cross-site scripting, authentication bypass, and so on)
+## What a vulnerability record actually contains
 
-[Wordfence Intelligence](https://www.wordfence.com/threat-intel/vulnerabilities/) publishes a free feed that covers the WordPress ecosystem. It is the most comprehensive public database for this purpose.
+A useful vulnerability feed maps a plugin or theme slug to one or more records. Each record carries the pieces you need to make a decision:
 
-## How WPMgr connects the feed
+- **Affected version range.** For example, "less than 2.4.1". This is the field that determines whether you care at all.
+- **Fixed version.** The first release that contains the patch.
+- **CVE identifier.** The stable public reference, so two tools discussing the same flaw agree on what they are discussing.
+- **CVSS score and vector.** A severity number from 0 to 10, plus a breakdown of how the flaw is exploited.
+- **Vulnerability class.** SQL injection, cross-site scripting, authentication bypass, arbitrary file upload, privilege escalation, and so on.
 
-WPMgr pulls the Wordfence Intelligence feed on a schedule and stores the relevant records. The agent running on each site reports the installed plugins, themes, and WordPress core version during its regular diagnostics push. The control plane compares that inventory against the feed and surfaces any matches.
+That last field does far more work than people give it credit for, and we will come back to why.
 
-Each finding in the dashboard shows:
+## Where the data comes from
 
-- Plugin or theme name and the installed version
-- Severity (critical, high, medium, low)
-- Affected version range and fixed version
-- CVE reference
+Several projects catalogue WordPress-specific vulnerabilities, and they do not fully agree with each other.
 
-You can one-click remediate by updating the affected item through the existing update flow. If you need to defer a fix, you can dismiss the finding and mark it for later review.
+[Wordfence Intelligence](https://www.wordfence.com/threat-intel/vulnerabilities/) publishes a free feed with broad coverage of the plugin and theme ecosystem, including records for software that never appears in the national databases. [Patchstack](https://patchstack.com/database/) maintains its own catalogue with a similar focus. [WPScan](https://wpscan.com/) has long been a reference point for the same problem space. The [National Vulnerability Database](https://nvd.nist.gov/) carries CVE records across all software, but its WordPress plugin coverage lags the specialist feeds, because a plugin with 5,000 installs rarely gets prompt attention from a general-purpose catalogue.
 
-## Acting on scan results safely
+The practical consequence is that a scanner is only as good as the feed behind it, and a scanner reporting zero findings is telling you about its feed as much as about your site. WPMgr uses the Wordfence Intelligence feed, which is the most comprehensive free source for this ecosystem.
 
-Updating a plugin to fix a vulnerability carries the same risk as any other update: the new version might have compatibility issues with your theme or other plugins. The safest workflow is:
+## Version matching is harder than it looks
 
-1. Take a backup before updating
-2. Update in a staging environment if you have one
-3. Run the update on production with WPMgr's auto-snapshot enabled (the backup runs automatically before the update and rolls back on failure)
-4. Monitor the site for a short window after the update
+The naive version of this problem is a string comparison. The real version has several failure modes worth knowing about, because they explain why two scanners can look at the same site and disagree.
 
-WPMgr's fleet view lets you see which sites across your portfolio have outstanding vulnerability findings, so you can prioritise the most severe ones and work through the list systematically.
+**Version strings are not reliably sortable.** WordPress plugins use everything from `1.2.3` to `2.0-beta4` to `20240115`. Comparing "is 2.0-beta4 less than 2.0" correctly requires implementing the comparison rules rather than sorting alphabetically, and sorting alphabetically puts `10.0` before `9.0`.
 
-## The limits of vulnerability scanning
+**Premium plugins are frequently invisible.** A paid plugin distributed from the developer's own site has no repository listing. Its slug may not match anything in the feed, and its version numbering may be entirely internal. Feeds cover many commercial plugins, but coverage is thinner than for free ones.
 
-Scanning tells you about known vulnerabilities in catalogued plugins and themes. It does not detect:
+**Forks and white-labelled copies keep the code and lose the identity.** A plugin someone renamed still carries the vulnerable function, but its slug no longer matches the record.
 
-- Zero-day exploits (by definition not yet in the feed)
-- Malware already installed on the site
-- Vulnerabilities in custom-built code
-- Configuration weaknesses (weak passwords, unnecessary admin accounts, and so on)
+**Abandoned plugins have no fixed version at all.** When a plugin is closed without a patch, the record has an affected range and nothing to upgrade to. The remediation is removal, and a tool that only knows how to offer an update button has nothing useful to say.
 
-For a complete posture, pair vulnerability scanning with [file integrity monitoring](/features/security/), [two-factor authentication](/features/two-factor-auth/), and regular backups for recovery.
+**Backported patches break the range logic.** A maintainer occasionally patches an older branch, which means a site on `1.9.7` may be safe while the record says "less than 2.4.1".
+
+None of this makes scanning less worthwhile. It means findings deserve a moment of judgement rather than blind automation, and that "no findings" is not the same as "no risk".
+
+## How WPMgr connects the feed to your fleet
+
+WPMgr pulls the vulnerability feed on a schedule and stores the records centrally. The agent on each site reports its installed plugins, themes, and core version as part of the regular diagnostics push, so the inventory is a fact gathered from the site rather than something you maintain by hand.
+
+The control plane compares that inventory against the feed and surfaces matches. Each finding shows the plugin or theme name and installed version, the severity, the affected range, the fixed version, and the CVE reference.
+
+Because the comparison happens centrally rather than on each site, adding a site does not add scanning work to that site, and a newly published record is matched against every site you run the moment the feed updates, without waiting for a per-site scan to come around again.
+
+## Triage: severity is not the same as priority
+
+The most common mistake once you have findings is to sort by CVSS and work down the list. That is a defensible default and it is frequently wrong. Three other factors change the ordering.
+
+**Is the plugin active?** A deactivated plugin's code generally does not run, which lowers urgency considerably. It does not lower it to zero: files remain on disk and some flaws are reachable in deactivated code. The correct end state for a plugin you are not using is deletion, not deactivation.
+
+**Does exploitation require authentication?** A CVSS 8.8 flaw that needs a valid contributor account is a different problem from a CVSS 7.5 that any anonymous visitor can reach. On a site with open registration those converge. On a site with three known admin accounts they do not. Read the vector, not just the number.
+
+**What does the site actually hold?** The same flaw on a brochure site and on a store processing card details produces very different consequences. Severity describes the flaw. Priority has to account for the blast radius.
+
+A workable order for a fleet: anything unauthenticated and remotely exploitable on a site handling customer data, then everything else unauthenticated, then authenticated flaws on sites with open registration, then the rest.
+
+## Acting on findings without breaking things
+
+Updating a plugin to close a vulnerability carries exactly the same risk as any other update. The fix may change behaviour your theme depends on. The safest sequence:
+
+1. Take a backup immediately before the update, not last night.
+2. Apply the update in staging first where one exists, particularly for anything touching checkout, forms, or membership.
+3. On production, run the update with automatic snapshots enabled so a failure rolls back rather than leaving a half-updated site.
+4. Watch the site for a short window afterwards. An update that fatals is obvious. An update that quietly breaks a contact form is not, which is why [uptime monitoring that checks for content signatures](/features/uptime-monitoring) rather than just a 200 response is worth having.
+
+For a plugin that has been closed without a fix, the sequence is different: find a maintained replacement, migrate the data, then delete the plugin. Leaving it deactivated is not remediation.
+
+## What scanning does not tell you
+
+Vulnerability scanning answers exactly one question: does anything you have installed match a known, published flaw? It is silent on everything else.
+
+- **Zero-days**, by definition, are not in the feed.
+- **Malware already present** is a different problem. If a site was compromised through a flaw you have since patched, patching does not remove what was installed in the meantime. That is what [file integrity monitoring](/features/security) is for.
+- **Custom code** written for your site is in no catalogue anywhere.
+- **Configuration weakness** is invisible to it. A shared admin password is not a CVE.
+- **Server and PHP versions** sit outside the plugin feeds even when they are the weakest link.
+
+Scanning is one instrument. It pairs with integrity monitoring to catch what got in, [two-factor authentication](/features/two-factor-auth) and login hardening to reduce the credential surface, and [backups](/features/backups) as the recovery path when something lands anyway.
+
+## Making it a cadence rather than an event
+
+The single highest-value change most operators can make is turning this from an occasional audit into a routine that runs whether or not anyone remembers.
+
+Review new findings on a fixed schedule rather than when you happen to log in. Treat unauthenticated critical findings as interrupt-driven work rather than queue work. Delete plugins you are not using instead of deactivating them, because every installed plugin is permanent surface area. Keep a note of anything you deliberately deferred and why, so a decision made with context is not silently inherited as neglect six months later.
+
+Across a portfolio, the fleet view matters more than the per-site view. What you want to answer quickly is not "is this site clean" but "which of my fifty sites have outstanding critical findings right now", because that is the question that determines where the afternoon goes.
 
 ## Setting it up
 
-Connect a Wordfence Intelligence API key in the WPMgr admin area. The key is free and the feed is free for the vulnerability data WPMgr uses. After the initial sync, scan results appear on each site's Security tab and in the fleet-wide Vulnerabilities view.
+Connect a Wordfence Intelligence API key in the WPMgr admin area. The key is free, and the vulnerability data WPMgr reads is free. After the first sync, findings appear on each site's Security tab and in the fleet-wide vulnerabilities view.
 
-For a full picture of how to secure a WordPress fleet, see the [WordPress security solution](/solutions/wordpress-security/).
+For the wider picture of how the pieces fit together across a portfolio, see the [WordPress security solution](/solutions/wordpress-security).

--- a/apps/marketing/content/blog/wordpress-security/wordpress-vulnerability-scanning.mdx
+++ b/apps/marketing/content/blog/wordpress-security/wordpress-vulnerability-scanning.mdx
@@ -2,6 +2,7 @@
 title: "WordPress Vulnerability Scanning: What It Is and Why It Matters"
 description: "Learn how plugin and theme vulnerability scanning works, what CVE databases power it, and how to act on scan results without breaking your sites."
 category: "wordpress-security"
+art: "scanner"
 date: "2026-06-18"
 author: "WPMgr Team"
 tags: ["security", "vulnerabilities", "cve"]

--- a/apps/marketing/lib/content/blog/index.ts
+++ b/apps/marketing/lib/content/blog/index.ts
@@ -41,6 +41,12 @@ export type BlogPostFrontmatter = {
   author?: string;
   /** Optional: path relative to /public for the OG thumbnail */
   image?: string;
+  /**
+   * Which featured illustration to draw, from the registry in
+   * components/blog/post-art.tsx. Optional: an unset or unrecognised value
+   * falls back to the post's category illustration, so a card is never blank.
+   */
+  art?: string;
   /** 1 to 3 tags for internal cross-linking */
   tags?: string[];
   /** Funnel: the feature page this post links toward */


### PR DESCRIPTION
Two changes to the weakest surface on the site, and the one most often seen first from search.

## 1. Every post gets a featured illustration

The blog had no art at all: ten cards of pure text on the index, posts opening straight into prose.

Stock photography of someone at a laptop says nothing about file integrity monitoring, and hand-drawn scenes read as amateurish beside a product selling operational seriousness. So each post gets a **systematic geometric piece that encodes its actual subject**: the scanner illustration is a grid of installed plugins with one matched, the vitals illustration is three metrics against their thresholds, the cache illustration is the short path to memory beside the long one to the database.

Drawn in code rather than shipped as assets, which buys three things:

- **They theme themselves.** Every colour is a design token, so dark mode was already solved.
- **No image request, no binary in the repo.**
- **They cannot go stale against a rebrand**, because they read the same variables as the rest of the site.

Rules the registry enforces: no text (nothing to translate, nothing to overflow at card size, and the title sits directly beneath), **no animation** (ten render at once on the index, and a reveal that has not fired is a card that looks broken), decorative and `aria-hidden`, geometry rather than depiction.

The `art` frontmatter key selects one and is optional. An unset or unrecognised value falls back to the post's category piece, so a card is never blank.

## 2. All ten posts rewritten to long form

They ran **594 to 867 words**. Now **1,634 to 1,824**. The added length is specifics, not padding, and most of it is material that only shows up once you have operated this stuff:

| Post | What it gained |
|---|---|
| Vulnerability scanning | Version-matching failure modes that make two scanners disagree; why sorting by CVSS is the obvious approach and the wrong one |
| File integrity | What it **cannot** see: injected admins, payloads in options, malicious cron. The actual answer to "I cleaned the files and it came back" |
| Core Web Vitals | Leads with the 75th-percentile detail that explains why a page "fine for me" fails in Search Console |
| Restore | Serialized-data corruption on a domain change, the reason a naive find and replace silently empties plugin settings |
| Backup strategy | RPO and RTO as the starting point rather than a frequency; backup consistency, which produces backups that restore perfectly and contain incoherent data |
| Object cache | The transient behaviour change, source of the "it worked before Redis" class of bug |

Cross-links between related posts throughout, so the cluster is navigable rather than ten separate leaves.

## Also fixed

The **trailing-slash internal links** (`/features/security/`) that 308-redirect on this site. Twenty across the ten files. This is the fifth place that defect has turned up.

## Verification

- `typecheck`, `lint`, `check-copy`, `build` green
- Every post returns 200 and renders exactly one featured illustration
- **Every internal link target checked against the running site**, all 200
- Word counts scripted, all ten inside the 1,600 to 2,200 band
- Zero em or en dashes, zero trailing-slash internal links
- Dark mode verified: all ten illustrations paint correctly through the tokens
- At 390px: no page-level horizontal overflow, and code blocks scroll inside their own `overflow-x: auto` container