### PR TITLE
feat(web): two-field signup, and a split-screen auth layout

### DIFF
--- a/apps/api/internal/auth/register.go
+++ b/apps/api/internal/auth/register.go
@@ -55,7 +55,7 @@ func (s *Service) RegisterSelfServe(
 	}
 	tenantName := strings.TrimSpace(in.TenantName)
 	if tenantName == "" {
-		tenantName = "Default"
+		tenantName = defaultTenantName(in.Email)
 	}
 	// Tenant slugs are GLOBALLY unique, so a fixed "default" collides after the
 	// first self-serve signup (tenant_slug_exists 409). Derive a unique slug.
@@ -87,6 +87,97 @@ func (s *Service) RegisterSelfServe(
 
 	s.sendVerificationEmail(ctx, u.ID, u.Email, u.Name, intent)
 	return nil
+}
+
+// consumerMailDomains are providers where the domain says nothing about the
+// organization, so the local part is the better guess. Not exhaustive on
+// purpose: an unlisted provider yields a slightly odd name, which is a cosmetic
+// miss on a field the owner can rename, not a failure.
+var consumerMailDomains = map[string]bool{
+	"gmail.com": true, "googlemail.com": true, "outlook.com": true,
+	"hotmail.com": true, "live.com": true, "msn.com": true,
+	"yahoo.com": true, "ymail.com": true, "icloud.com": true,
+	"me.com": true, "mac.com": true, "aol.com": true,
+	"proton.me": true, "protonmail.com": true, "pm.me": true,
+	"gmx.com": true, "gmx.net": true, "mail.com": true, "zoho.com": true,
+	"yandex.com": true, "fastmail.com": true, "hey.com": true,
+}
+
+// defaultTenantName derives a readable organization name from the signup email.
+//
+// The signup form asks for two fields, email and password, so this default is
+// what every self-serve account is actually named. It used to be the literal
+// string "Default", which was tolerable while the form still offered an
+// organization field and is not once that field is gone: every account on the
+// instance would share one meaningless name, in the switcher, in client
+// reports, and in the admin console.
+//
+// A work address carries the organization, so acme.com becomes "Acme". A
+// consumer mailbox does not, so the local part is used instead and
+// sarah.jones@gmail.com becomes "Sarah Jones". Both are guesses, and both are
+// renameable in settings; the goal is a sensible starting point rather than a
+// correct one.
+func defaultTenantName(email string) string {
+	local, domainPart, ok := strings.Cut(email, "@")
+	if !ok || strings.TrimSpace(local) == "" {
+		return "My organization"
+	}
+	source := local
+	domainPart = strings.ToLower(strings.TrimSpace(domainPart))
+	if domainPart != "" && !consumerMailDomains[domainPart] {
+		source = registrableLabel(domainPart)
+	}
+	return titleizeName(source)
+}
+
+// secondLevelSuffixes are the common two-part public suffixes. Taking the
+// second-to-last label of "acme.co.uk" yields "co", so these have to be
+// stepped over. This is a short pragmatic list rather than the full public
+// suffix list, which would mean vendoring and refreshing a large dataset to
+// improve the default value of a renameable display name.
+var secondLevelSuffixes = map[string]bool{
+	"co": true, "com": true, "net": true, "org": true, "gov": true,
+	"edu": true, "ac": true, "or": true, "ne": true, "in": true, "gen": true,
+}
+
+// registrableLabel picks the label that identifies the organization:
+// "mail.acme.com" and "acme.co.uk" both yield "acme".
+func registrableLabel(domainPart string) string {
+	labels := strings.Split(domainPart, ".")
+	if len(labels) < 2 {
+		return labels[0]
+	}
+	i := len(labels) - 2
+	// Step over a two-part suffix, but only when a label remains in front of
+	// it: "co.uk" on its own must not walk off the start of the slice.
+	if secondLevelSuffixes[labels[i]] && i > 0 {
+		i--
+	}
+	return labels[i]
+}
+
+// titleizeName turns "sarah.jones" or "sarah_jones-01" into "Sarah Jones 01".
+func titleizeName(raw string) string {
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == '.' || r == '_' || r == '-' || r == '+' || r == ' '
+	})
+	parts := make([]string, 0, len(fields))
+	for _, f := range fields {
+		runes := []rune(strings.ToLower(f))
+		if len(runes) == 0 {
+			continue
+		}
+		runes[0] = []rune(strings.ToUpper(string(runes[0])))[0]
+		parts = append(parts, string(runes))
+	}
+	out := strings.Join(parts, " ")
+	if out == "" {
+		return "My organization"
+	}
+	if len([]rune(out)) > 200 {
+		out = string([]rune(out)[:200])
+	}
+	return out
 }
 
 // uniqueTenantSlug builds a globally-unique tenant slug from the email's local

--- a/apps/api/internal/auth/register_tenant_name_test.go
+++ b/apps/api/internal/auth/register_tenant_name_test.go
@@ -1,0 +1,83 @@
+package auth
+
+import "testing"
+
+// The signup form asks for email and password only, so defaultTenantName is
+// what every self-serve account is actually named. Before that field was
+// removed the fallback was the literal "Default", which would have given every
+// account on an instance the same meaningless name in the org switcher, in
+// client reports, and in the admin console.
+func TestDefaultTenantName(t *testing.T) {
+	cases := []struct {
+		name  string
+		email string
+		want  string
+	}{
+		// A work address carries the organization.
+		{"company domain", "sarah@acme.com", "Acme"},
+		{"subdomain is ignored", "ops@mail.acme.com", "Acme"},
+		{"multi-part public suffix keeps the registrable label", "ops@acme.co.uk", "Acme"},
+		{"hyphenated company", "hi@blue-fox.io", "Blue Fox"},
+		{"uppercase domain is normalised", "hi@ACME.COM", "Acme"},
+
+		// A consumer mailbox does not, so the local part is the better guess.
+		{"gmail falls back to the local part", "sarah.jones@gmail.com", "Sarah Jones"},
+		{"icloud falls back to the local part", "sarah_jones@icloud.com", "Sarah Jones"},
+		{"plus addressing is split", "sarah+wpmgr@gmail.com", "Sarah Wpmgr"},
+		{"proton falls back to the local part", "dev@proton.me", "Dev"},
+
+		// Degenerate input must never produce an empty organization name.
+		{"no at sign", "notanemail", "My organization"},
+		{"empty local part", "@acme.com", "My organization"},
+		{"empty string", "", "My organization"},
+		{"punctuation-only local part on a consumer domain", "...@gmail.com", "My organization"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := defaultTenantName(tc.email); got != tc.want {
+				t.Fatalf("defaultTenantName(%q) = %q, want %q", tc.email, got, tc.want)
+			}
+		})
+	}
+}
+
+// The column this lands in is bounded, and a pathological local part must not
+// be the thing that discovers the limit.
+func TestDefaultTenantNameIsBounded(t *testing.T) {
+	long := ""
+	for range 400 {
+		long += "a"
+	}
+	got := defaultTenantName(long + "@gmail.com")
+	if len([]rune(got)) > 200 {
+		t.Fatalf("name is %d runes, want <= 200", len([]rune(got)))
+	}
+	if got == "" {
+		t.Fatal("name must never be empty")
+	}
+}
+
+// registrableLabel is the part that decides the name for a work address, and
+// its edge cases are where a naive "second-to-last label" implementation went
+// wrong: acme.co.uk yielded "Co".
+func TestRegistrableLabel(t *testing.T) {
+	cases := map[string]string{
+		"acme.com":            "acme",
+		"mail.acme.com":       "acme",
+		"acme.co.uk":          "acme",
+		"mail.acme.co.uk":     "acme",
+		"acme.com.au":         "acme",
+		"acme.co.in":          "acme",
+		"deep.sub.acme.co.za": "acme",
+		"localhost":           "localhost",
+		// A bare two-part suffix has nothing in front of it; stepping over it
+		// must not walk off the front of the slice.
+		"co.uk": "co",
+	}
+	for in, want := range cases {
+		if got := registrableLabel(in); got != want {
+			t.Errorf("registrableLabel(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/apps/web/src/components/brand/fleet-illustration.tsx
+++ b/apps/web/src/components/brand/fleet-illustration.tsx
@@ -1,0 +1,168 @@
+/**
+ * The auth-page illustration: a fleet connected to one control plane.
+ *
+ * WHY THIS SUBJECT. The auth pages are the first thing a new operator sees,
+ * and the single idea worth landing before they have used anything is that
+ * many sites become one pane. An abstract flourish would decorate the page;
+ * this states the product. It is also drawn from the same tokens as the app,
+ * so signup and the dashboard behind it look like one product rather than a
+ * marketing page bolted onto a tool.
+ *
+ * THE RESTING STATE IS THE FINISHED DIAGRAM. Every animation here ends where
+ * the static render begins: spokes fully drawn, every node visible, nothing
+ * transparent. That is not a stylistic preference, it is a correctness
+ * requirement. globals.css collapses animation-duration to 0.01ms under
+ * prefers-reduced-motion, so a reduced-motion visitor jumps straight to the
+ * end state, and any element whose end state was "hidden" would simply never
+ * appear. The same applies to a renderer that never runs the animation at all.
+ *
+ * Motion is therefore additive: spokes draw outward from the hub, nodes settle
+ * in, and status dots pulse. Remove all of it and the picture is unchanged.
+ *
+ * Decorative, so aria-hidden. The heading beside it carries the meaning.
+ */
+
+const NODES = [
+  { x: 180, y: 44, tone: "up" },
+  { x: 296, y: 110, tone: "up" },
+  { x: 296, y: 246, tone: "warn" },
+  { x: 180, y: 312, tone: "up" },
+  { x: 64, y: 246, tone: "up" },
+  { x: 64, y: 110, tone: "info" },
+] as const;
+
+const TONE_FILL: Record<string, string> = {
+  up: "var(--color-success)",
+  warn: "var(--color-warning)",
+  info: "var(--color-info)",
+};
+
+export function FleetIllustration({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 360 360"
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+    >
+      {/* Orbit rings. Purely spatial, drawn first so everything sits on top. */}
+      <circle
+        cx="180"
+        cy="180"
+        r="136"
+        fill="none"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+        strokeDasharray="3 7"
+        opacity="0.7"
+      />
+      <circle cx="180" cy="180" r="92" fill="none" stroke="var(--color-border)" strokeWidth="1" opacity="0.5" />
+
+      {/* Spokes. `pathLength` normalises every line to 1 unit regardless of its
+          real length, so one dash rule animates them all at the same rate
+          instead of needing a per-line dasharray. */}
+      {NODES.map((n, i) => (
+        <line
+          key={`spoke-${n.x}-${n.y}`}
+          x1="180"
+          y1="180"
+          x2={n.x}
+          y2={n.y}
+          stroke="var(--color-primary)"
+          strokeWidth="1.5"
+          opacity="0.45"
+          pathLength={1}
+          strokeDasharray="1 1"
+          className="wpmgr-fleet-spoke"
+          style={{ animationDelay: `${i * 90}ms` }}
+        />
+      ))}
+
+      {/* Site nodes. */}
+      {NODES.map((n, i) => (
+        <g
+          key={`node-${n.x}-${n.y}`}
+          className="wpmgr-fleet-node"
+          style={{ animationDelay: `${240 + i * 90}ms`, transformOrigin: `${n.x}px ${n.y}px` }}
+        >
+          <rect
+            x={n.x - 26}
+            y={n.y - 20}
+            width="52"
+            height="40"
+            rx="9"
+            fill="var(--color-card)"
+            stroke="var(--color-border)"
+            strokeWidth="1.25"
+          />
+          {/* window chrome, so the node reads as a site rather than a box */}
+          <line
+            x1={n.x - 26}
+            y1={n.y - 8}
+            x2={n.x + 26}
+            y2={n.y - 8}
+            stroke="var(--color-border)"
+            strokeWidth="1"
+          />
+          <circle cx={n.x - 19} cy={n.y - 14} r="2" fill="var(--color-muted-foreground)" opacity="0.55" />
+          <rect
+            x={n.x - 13}
+            y={n.y + 1}
+            width="26"
+            height="3.5"
+            rx="1.75"
+            fill="var(--color-muted-foreground)"
+            opacity="0.35"
+          />
+          <rect
+            x={n.x - 13}
+            y={n.y + 9}
+            width="16"
+            height="3.5"
+            rx="1.75"
+            fill="var(--color-muted-foreground)"
+            opacity="0.25"
+          />
+          {/* status */}
+          <circle
+            cx={n.x + 17}
+            cy={n.y + 11}
+            r="3.5"
+            fill={TONE_FILL[n.tone]}
+            className="wpmgr-fleet-status"
+            style={{ animationDelay: `${i * 320}ms` }}
+          />
+        </g>
+      ))}
+
+      {/* The hub, drawn last so it sits above the spokes meeting it. */}
+      <g className="wpmgr-fleet-hub">
+        <circle cx="180" cy="180" r="46" fill="var(--color-primary)" opacity="0.1" />
+        <rect
+          x="146"
+          y="146"
+          width="68"
+          height="68"
+          rx="18"
+          fill="var(--color-primary)"
+          stroke="var(--color-primary)"
+          strokeWidth="1.5"
+        />
+        {/* Three stacked layers: the same idea as the sidebar mark, simplified
+            to read at this size. */}
+        <g
+          fill="none"
+          stroke="var(--color-primary-foreground)"
+          strokeWidth="2.25"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M180 164 l20 10 l-20 10 l-20 -10 z" />
+          <path d="M160 186 l20 10 l20 -10" />
+          <path d="M160 196 l20 10 l20 -10" />
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/apps/web/src/components/layout/auth-layout.tsx
+++ b/apps/web/src/components/layout/auth-layout.tsx
@@ -1,19 +1,102 @@
 import { FleetHubLogo, Wordmark } from "@/components/brand/logo";
+import { FleetIllustration } from "@/components/brand/fleet-illustration";
 
 /**
- * Shared wrapper for unauthenticated pages (login, forgot-password, reset-password).
- * Renders a vertically/horizontally centered column on the app background with
- * the WPMgr brand lockup above the card slot. Matches the layout in login.tsx.
+ * Shared wrapper for every unauthenticated page: login, register,
+ * forgot-password, reset-password, verify-email, and the 2FA challenge.
+ *
+ * SPLIT SCREEN, FORM FIRST. Below `lg` the brand panel is not rendered at all
+ * and the page is exactly what it was before: a centred column with the form.
+ * That ordering is deliberate. On a phone, a visitor who has come here to sign
+ * in should not have to scroll past a value proposition to reach the field
+ * they came for, and a panel that merely stacks above the form does precisely
+ * that. It is additive on large screens and absent on small ones.
+ *
+ * WHY A PANEL AT ALL. These pages were a form on an empty background, which is
+ * the correct amount of design for a login and too little for a signup: the
+ * moment someone is deciding whether to create an account is the last moment
+ * we can say what the product does. The panel carries that, plus the proof
+ * points that answer the two objections a developer has at signup (can I leave,
+ * and what does it cost).
+ *
+ * The panel is decorative in the accessibility sense. It contains no
+ * instructions, no controls, and nothing a screen reader user needs in order
+ * to complete the form, so a visitor who never receives it loses nothing
+ * functional.
  */
 export function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <main className="flex min-h-dvh flex-col items-center justify-center gap-6 bg-[var(--color-background)] p-4">
-      {/* WPMgr Fleet Hub lockup — same mark as sidebar + marketing site. */}
+    <div className="flex min-h-dvh bg-[var(--color-background)]">
+      <AuthAside />
+
+      {/* Form column. Owns the full width until lg, where it becomes the right
+          half. `min-w-0` so a long error message cannot push the column wider
+          than its track. */}
+      <main className="flex min-w-0 flex-1 flex-col items-center justify-center gap-6 p-4 sm:p-6">
+        {/* The lockup repeats here below lg, where the panel that would
+            otherwise carry it is not rendered. */}
+        <div className="flex items-center gap-2.5 lg:hidden">
+          <FleetHubLogo size={26} />
+          <Wordmark className="text-base" />
+        </div>
+        {children}
+      </main>
+    </div>
+  );
+}
+
+const PROOF = [
+  "Connect a site in about a minute",
+  "Backups encrypted before they leave the site",
+  "Open source, and self-hostable for free",
+];
+
+function AuthAside() {
+  return (
+    <aside
+      className="relative hidden w-[46%] max-w-[42rem] shrink-0 flex-col justify-between overflow-hidden border-r border-[var(--color-border)] bg-[var(--color-muted)]/40 p-10 lg:flex xl:p-14"
+      aria-hidden="true"
+    >
       <div className="flex items-center gap-2.5">
-        <FleetHubLogo size={26} />
-        <Wordmark className="text-base" />
+        <FleetHubLogo size={28} />
+        <Wordmark className="text-lg" />
       </div>
-      {children}
-    </main>
+
+      <div className="flex flex-col items-center">
+        <FleetIllustration className="h-auto w-full max-w-[24rem]" />
+      </div>
+
+      <div>
+        <h2 className="max-w-[20ch] text-2xl font-semibold tracking-tight text-[var(--color-foreground)] xl:text-3xl">
+          Every WordPress site you run, on one screen.
+        </h2>
+        <p className="mt-3 max-w-[46ch] text-sm leading-relaxed text-[var(--color-muted-foreground)]">
+          Backups, updates, uptime, performance and security across the whole fleet, from a
+          dashboard you can host yourself.
+        </p>
+
+        <ul className="mt-6 flex flex-col gap-2.5">
+          {PROOF.map((item) => (
+            <li
+              key={item}
+              className="flex items-start gap-2.5 text-sm text-[var(--color-muted-foreground)]"
+            >
+              <svg
+                viewBox="0 0 16 16"
+                className="mt-[3px] size-4 shrink-0 text-[var(--color-primary)]"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M3 8.5 L6.5 12 L13 4.5" />
+              </svg>
+              {item}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </aside>
   );
 }

--- a/apps/web/src/routes/-register.test.tsx
+++ b/apps/web/src/routes/-register.test.tsx
@@ -146,6 +146,60 @@ beforeEach(() => {
   );
 });
 
+describe("RegisterPage — the form asks for two things", () => {
+  // 2.8. The form used to also ask for a display name, an organization name,
+  // and an organization slug, all optional, all at the point of highest
+  // drop-off. These two tests are what stops them coming back: one pins what
+  // the visitor sees, the other pins what the API is sent, because a field
+  // could be removed from the markup while a stale default still rides along
+  // in the request body.
+  it("renders exactly the email and password fields", async () => {
+    mockedUseRegister.mockReturnValue(
+      mockMutationResult<RegisterResult, RegisterRequest>({
+        mutateAsync: mutateAsyncResolving<RegisterResult>({ pending: true }),
+      }),
+    );
+
+    renderRegisterPage("/register");
+    await screen.findByLabelText("Email");
+
+    const form = screen.getByRole("button", { name: "Create account" }).closest("form");
+    const inputs = [...(form?.querySelectorAll("input") ?? [])];
+    expect(inputs.map((i) => i.id)).toEqual(["email", "password"]);
+
+    for (const gone of ["Your name (optional)", "Organization name (optional)", "Organization slug (optional)"]) {
+      expect(screen.queryByLabelText(gone)).toBeNull();
+    }
+  });
+
+  it("sends only email, password and plan, never a name or tenant field", async () => {
+    // Declared with an explicit signature rather than via mutateAsyncResolving
+    // so `.mock.calls` carries a real type: this assertion reads the request
+    // body back, which the objectContaining style used elsewhere in this file
+    // cannot do (it would pass with extra fields present, which is the exact
+    // regression being guarded against).
+    const mutateAsyncMock = vi
+      .fn<(vars: RegisterRequest, opts?: unknown) => Promise<RegisterResult>>()
+      .mockResolvedValue({ pending: true });
+    mockedUseRegister.mockReturnValue(
+      mockMutationResult<RegisterResult, RegisterRequest>({
+        mutateAsync: mutateAsyncMock as unknown as UseMutationResult<
+          RegisterResult,
+          Error,
+          RegisterRequest
+        >["mutateAsync"],
+      }),
+    );
+
+    renderRegisterPage("/register");
+    await fillAndSubmit();
+
+    await waitFor(() => expect(mutateAsyncMock).toHaveBeenCalledTimes(1));
+    const body = mutateAsyncMock.mock.calls[0]![0];
+    expect(Object.keys(body).sort()).toEqual(["email", "password", "plan"]);
+  });
+});
+
 describe("RegisterPage — plan summary chip", () => {
   it("shows the Agency plan chip when the URL carries ?plan=agency", async () => {
     mockedUseRegister.mockReturnValue(

--- a/apps/web/src/routes/register.tsx
+++ b/apps/web/src/routes/register.tsx
@@ -3,8 +3,9 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useState } from "react";
-import { AlertCircle, AlertTriangle, CheckCircle2, Globe, Sparkles } from "lucide-react";
+import { AlertCircle, AlertTriangle, CheckCircle2, Sparkles } from "lucide-react";
 
+import { AuthLayout } from "@/components/layout/auth-layout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -43,17 +44,19 @@ export const Route = createFileRoute("/register")({
   component: RegisterPage,
 });
 
+// TWO FIELDS. The form previously also asked for a display name, an
+// organization name, and an organization slug, all optional and all asked at
+// the worst possible moment: before the person has seen anything work.
+//
+// None of them was load-bearing. The API already derives an organization name
+// and a globally-unique slug from the email when they are absent (see
+// apps/api/internal/auth/register.go), and every one of the three is editable
+// in settings afterwards. So the fields bought nothing at signup and cost
+// three extra decisions on the screen with the highest drop-off in the
+// product. Anything not required to create the account is asked later.
 const registerSchema = z.object({
   email: z.email("Enter a valid email address"),
   password: z.string().min(12, "Use at least 12 characters"),
-  name: z.string().max(200).optional(),
-  tenant_name: z.string().max(200).optional(),
-  tenant_slug: z
-    .string()
-    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "Lowercase letters, numbers, and dashes")
-    .max(64)
-    .optional()
-    .or(z.literal("")),
 });
 
 type RegisterValues = z.infer<typeof registerSchema>;
@@ -76,7 +79,7 @@ function RegisterPage() {
     formState: { errors, isSubmitting },
   } = useForm<RegisterValues>({
     resolver: zodResolver(registerSchema),
-    defaultValues: { email: "", password: "", name: "", tenant_name: "", tenant_slug: "" },
+    defaultValues: { email: "", password: "" },
   });
 
   const onSubmit = handleSubmit(async (values) => {
@@ -84,9 +87,6 @@ function RegisterPage() {
       {
         email: values.email,
         password: values.password,
-        name: values.name || undefined,
-        tenant_name: values.tenant_name || undefined,
-        tenant_slug: values.tenant_slug || undefined,
         plan: chosenPlan,
       },
       {
@@ -128,14 +128,7 @@ function RegisterPage() {
     }
 
     return (
-      <main className="flex min-h-dvh flex-col items-center justify-center gap-6 bg-[var(--color-background)] p-4">
-        <div className="flex items-center gap-2">
-          <Globe aria-hidden="true" className="size-5 text-[var(--color-primary)]" />
-          <span className="text-sm font-semibold tracking-tight text-[var(--color-foreground)]">
-            WPMgr
-          </span>
-        </div>
-
+      <AuthLayout>
         <Card className="w-full max-w-md">
           <CardHeader className="space-y-1">
             <div className="flex items-center gap-2">
@@ -184,7 +177,7 @@ function RegisterPage() {
             </p>
           </CardContent>
         </Card>
-      </main>
+      </AuthLayout>
     );
   }
 
@@ -195,15 +188,7 @@ function RegisterPage() {
     : null;
 
   return (
-    <main className="flex min-h-dvh flex-col items-center justify-center gap-6 bg-[var(--color-background)] p-4">
-      {/* WPMgr wordmark — same Globe + text treatment as the sidebar BrandStrip */}
-      <div className="flex items-center gap-2">
-        <Globe aria-hidden="true" className="size-5 text-[var(--color-primary)]" />
-        <span className="text-sm font-semibold tracking-tight text-[var(--color-foreground)]">
-          WPMgr
-        </span>
-      </div>
-
+    <AuthLayout>
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1">
           <CardTitle asChild>
@@ -253,24 +238,6 @@ function RegisterPage() {
               register={register}
               error={errors.password?.message}
             />
-            <Field
-              id="name"
-              label="Your name (optional)"
-              register={register}
-              error={errors.name?.message}
-            />
-            <Field
-              id="tenant_name"
-              label="Organization name (optional)"
-              register={register}
-              error={errors.tenant_name?.message}
-            />
-            <Field
-              id="tenant_slug"
-              label="Organization slug (optional)"
-              register={register}
-              error={errors.tenant_slug?.message}
-            />
 
             <Button
               type="submit"
@@ -292,7 +259,7 @@ function RegisterPage() {
           </p>
         </CardContent>
       </Card>
-    </main>
+    </AuthLayout>
   );
 }
 

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -279,3 +279,36 @@
 .wpmgr-cmdk-overlay[data-state="closed"]{ animation: wpmgr-cmdk-overlay-out 120ms var(--ease-out-quint) both; }
 .wpmgr-cmdk-panel[data-state="open"]    { animation: wpmgr-cmdk-panel-in    180ms var(--ease-out-quint) both; }
 .wpmgr-cmdk-panel[data-state="closed"]  { animation: wpmgr-cmdk-panel-out   120ms var(--ease-out-quint) both; }
+
+/* Auth-page fleet illustration (components/brand/fleet-illustration.tsx).
+ *
+ * EVERY ANIMATION HERE ENDS ON THE VISIBLE STATE. The global reduced-motion
+ * rule above collapses animation-duration to 0.01ms, which means a
+ * reduced-motion visitor lands on the final keyframe immediately. If any of
+ * these finished at opacity 0 or a zero-length dash, that visitor (and any
+ * renderer that does not animate) would get a blank panel. `both` fill is used
+ * so the element also holds its start frame during the stagger delay rather
+ * than flashing at full size first. */
+@keyframes wpmgr-fleet-draw {
+  from { stroke-dashoffset: 1; }
+  to   { stroke-dashoffset: 0; }
+}
+@keyframes wpmgr-fleet-settle {
+  from { opacity: 0; transform: scale(0.9); }
+  to   { opacity: 1; transform: scale(1); }
+}
+@keyframes wpmgr-fleet-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.45; }
+}
+
+.wpmgr-fleet-spoke  { animation: wpmgr-fleet-draw 700ms var(--ease-out-quint) both; }
+.wpmgr-fleet-node   { animation: wpmgr-fleet-settle 520ms var(--ease-out-quint) both; }
+.wpmgr-fleet-hub    { animation: wpmgr-fleet-settle 520ms var(--ease-out-quint) both; }
+/* The only looping animation on the page. Opacity on a 3.5px dot, well under
+   the flash thresholds, and suppressed entirely under reduced motion. */
+.wpmgr-fleet-status { animation: wpmgr-fleet-pulse 2.6s ease-in-out infinite; }
+
+@media (prefers-reduced-motion: reduce) {
+  .wpmgr-fleet-status { animation: none; opacity: 1; }
+}


### PR DESCRIPTION
Two changes to the pages that decide whether anyone reaches the product.

## 1. The form asks for two things (2.8)

Signup collected **email, password, display name, organization name, and organization slug**. The last three were optional and none was load-bearing: the API already derives an organization name and a globally unique slug when they're absent, and all three are editable in settings. They bought nothing and cost three extra decisions on the highest-drop-off screen in the product.

Research backs the direction — [~64% of users drop off during a typical SaaS signup flow, and 27% have abandoned a form for feeling too long-winded](https://userpilot.com/blog/saas-signup-flow/). The useful heuristic is the 30-day test: if nobody uses a field's data within 30 days, remove it.

**Two tests pin this**, because the `objectContaining` assertions already in the file would pass with extra fields present:
- rendered input ids are exactly `[email, password]`
- the request body's keys are exactly `[email, password, plan]` — a field can be removed from the markup while a stale default still rides along in the payload

Both were confirmed to **fail** against a deliberately re-added field, then pass after restore.

## 2. The default organization name is now derived

Removing the org field made the server-side fallback the name **every** self-serve account gets — and that fallback was the literal string `"Default"`. Fine while the field existed; not once it's gone, since every account on an instance would share one meaningless name in the org switcher, in client reports, and in the admin console.

`defaultTenantName` reads the signup email: a work address carries the organization (`acme.com` → "Acme"), a consumer mailbox doesn't (`sarah.jones@gmail.com` → "Sarah Jones").

Its test **caught a real bug in my first implementation**: taking the second-to-last label turned `acme.co.uk` into "Co". `registrableLabel` now steps over two-part suffixes.

## 3. Split-screen auth

These pages were a form on an empty background — the right amount of design for a login, too little for a signup, because the moment someone decides whether to create an account is the last moment we can say what the product does.

A brand panel now carries the product claim, an illustration, and three proof points aimed at a developer's actual objections (can I leave, what does it cost).

**Below `lg` the panel is not rendered** and the page is exactly what it was. That ordering is deliberate and matches the established pattern: the panel collapses so the form always comes first. On a phone, someone who came to sign in should not scroll past a value proposition to reach the field they came for.

The illustration is a fleet connected to one control plane, drawn from the same tokens as the app so signup and the dashboard look like one product.

**Every animation ends where the static render begins.** `globals.css` collapses `animation-duration` to `0.01ms` under `prefers-reduced-motion`, so any element whose end state was hidden would simply never appear — [the standard guidance is to provide a static alternative rather than a broken one](https://css-tricks.com/accessible-web-animation-the-wcag-on-animation-explained/). Verified in a browser: spokes settle to `stroke-dashoffset: 0`, all nodes and the hub to `opacity: 1`.

`register.tsx` also stops duplicating `AuthLayout`'s markup and its own inline lockup, so all six unauthenticated pages share one layout.

## Verification

- Lint clean; **1519 tests pass**; Go builds; `internal/auth` tests pass
- All five auth pages render the panel with no horizontal overflow at 1280
- At 390 and 768: panel `display: none`, form full width, email field above the fold
- Light and dark both checked in a browser

**On typecheck:** the error set is byte-identical to HEAD's (14 pre-existing `zodResolver` errors). They reproduce only locally, caused by zod `4.4.3` in pnpm's hidden hoist dir (`node_modules/.pnpm/node_modules/zod`, pulled in by an AI SDK dependency) shadowing `apps/web`'s own `4.0.17` when TypeScript resolves `zod` from inside `@hookform/resolvers`. CI compiles clean. Worth fixing separately by aligning the zod range, but it is not this PR's to change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified registration to require only an email address and password.
  * Automatically generates a tenant name from the signup email.
  * Added a responsive authentication layout with branded visuals and product messaging.
  * Added an animated fleet illustration for large-screen authentication views.
* **Accessibility**
  * Respects reduced-motion preferences by disabling status animations.
* **Tests**
  * Added coverage for registration fields, tenant naming, normalization, fallbacks, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->