### PR TITLE
release: 0.61.128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 No unreleased changes.
 
+## [0.61.128] - 2026-08-07
+
+### Changed
+
+- Creating an account now asks for an email address and a password, and nothing else. The form also collected a display name, an organisation name and an organisation slug. All three were optional, none was needed to create the account, and every one of them is editable in settings afterwards, so they only ever added decisions to the screen where people are most likely to give up.
+- An account's organisation is now named from the signup email instead of being called "Default". A work address gives the organisation, so an address at acme.com creates "Acme", while a personal mailbox gives the person, so sarah.jones at a consumer provider creates "Sarah Jones". It is a starting point rather than a claim to be right, and it is renamed in settings like any other. Accounts created before this release keep the name they have.
+- The sign-in, sign-up, password reset and email verification pages now show what the product does alongside the form, instead of putting a form on an empty page. On a phone the form still comes first and nothing sits above it, because someone who came to sign in should not have to scroll past an explanation to reach the field they came for.
+
 ## [0.61.127] - 2026-08-06
 
 ### Fixed

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,26 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.128",
+    date: "2026-08-07",
+    summary:
+      "Signing up now asks for an email address and a password, and nothing else. The sign-in and sign-up pages also show what the product does alongside the form.",
+    items: [
+      {
+        tag: "Changed",
+        text: "Creating an account now asks for two things. The form also collected a display name, an organisation name and an organisation slug. All three were optional, none was needed to create the account, and every one of them is editable in settings afterwards, so they only ever added decisions to the screen where people are most likely to give up.",
+      },
+      {
+        tag: "Changed",
+        text: "An account's organisation is now named from the signup email instead of being called \"Default\". A work address gives the organisation, so an address at acme.com creates \"Acme\", while a personal mailbox gives the person, so sarah.jones at a consumer provider creates \"Sarah Jones\". It is a starting point rather than a claim to be right, and it is renamed in settings like any other. Accounts created before this release keep the name they have.",
+      },
+      {
+        tag: "Changed",
+        text: "The sign-in, sign-up, password reset and email verification pages now show what the product does alongside the form, instead of putting a form on an empty page. On a phone the form still comes first and nothing sits above it, because someone who came to sign in should not have to scroll past an explanation to reach the field they came for.",
+      },
+    ],
+  },
+  {
     version: "0.61.127",
     date: "2026-08-06",
     summary:

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.127
+  version: 0.61.128
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Cuts the release for #384 (two-field signup, derived organisation name, split-screen auth pages), which merged without a version bump.

`CHANGELOG.md`, `packages/openapi/openapi.yaml` `info.version`, and the marketing changelog page move together — what ci.yml's drift guard checks and what the release DoD requires. The guard tolerates the marketing page trailing by up to five patch versions; it is exact here.

| File | 0.61.127 → |
|---|---|
| `CHANGELOG.md` | 0.61.128 |
| `packages/openapi/openapi.yaml` | 0.61.128 |
| `apps/marketing/app/(marketing)/changelog/page.tsx` | 0.61.128 |

Entries describe what changed for someone using the product rather than what changed in the code. The organisation-naming note says what a new account will be called **and** states that existing accounts keep their name, which is the question an operator reading this would actually have.

Verified: the CI drift guard simulated locally (all three match), copy gate passes, marketing typechecks and builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Signup now requires only an email address and password.
  - Organizations can be named automatically using the signup email address.
  - Authentication pages now provide additional product context, with forms prioritized for mobile users.

- **Documentation**
  - Added release notes for version 0.61.128, dated August 7, 2026.
  - Updated the public API specification version to 0.61.128.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->