### PR TITLE
fix(web): align zod so local typechecking works again

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -59,7 +59,7 @@
     "recharts": "^3.8.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
-    "zod": "~4.0.0",
+    "zod": "^4.4.0",
     "zustand": "^5.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,8 +274,8 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
       zod:
-        specifier: ~4.0.0
-        version: 4.0.17
+        specifier: ^4.4.0
+        version: 4.4.3
       zustand:
         specifier: ^5.0.0
         version: 5.0.13(@types/react@19.2.15)(immer@11.1.8)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
@@ -5562,9 +5562,6 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.0.17:
-    resolution: {integrity: sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==}
-
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -8848,8 +8845,8 @@ snapshots:
       '@babel/parser': 7.29.7
       eslint: 9.39.4(jiti@2.7.0)
       hermes-parser: 0.25.1
-      zod: 4.0.17
-      zod-validation-error: 4.0.2(zod@4.0.17)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -11310,14 +11307,12 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@4.0.2(zod@4.0.17):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 4.0.17
+      zod: 4.4.3
 
   zod@3.25.76:
     optional: true
-
-  zod@4.0.17: {}
 
   zod@4.4.3: {}
 


### PR DESCRIPTION
`pnpm --filter @wpmgr/web typecheck` reported **14 errors on a clean checkout of main** while CI compiled the same commit cleanly.

That is worse than a broken build. It makes the local signal useless, so anyone working here learns to ignore typecheck output and pushes on CI alone. It also blocked `pnpm --filter @wpmgr/web build` locally, since that script starts with `tsc --noEmit`.

## Cause

A resolution split:

- `apps/web` pinned zod to `~4.0.0` → resolves **4.0.17**
- `@hookform/resolvers` declares **no zod peer dependency at all**, so when TypeScript resolves `zod` from inside that package it walks up to pnpm's hidden hoist directory (`node_modules/.pnpm/node_modules/zod`) and finds **4.4.3**, put there by `@scalar/api-reference`, a devDependency of `apps/marketing`

So every `zodResolver(...)` call site was checked with the resolver's types bound to 4.4.3 and the schema's types bound to 4.0.17. That surfaced as `Type '0' is not assignable to type '4'` — the two copies disagreeing about their own minor version.

CI never saw it because the contents of that hoist directory depend on install order and platform, so the same lockfile can leave a different version visible there. A discrepancy that appears on one machine and not another is exactly the kind that gets dismissed as "works on CI" and never fixed.

## Fix

Widen `apps/web` to `^4.4.0`. Both now resolve to 4.4.3 — one copy, no disagreement.

## Verification

| | Before | After |
|---|---|---|
| `typecheck` errors | 14 | **0** |
| `pnpm --filter @wpmgr/web build` | failed locally | passes |
| Lint | pass | pass |
| Tests | 1519 pass | 1519 pass |
| `apps/marketing` typecheck | pass | pass |

zod 4.0 → 4.4 is a minor bump under semver; the full suite passing across every form in the app is the evidence that nothing changed behaviourally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the validation library dependency to allow compatible 4.4.x releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->