### PR TITLE
fix: social sign-in could never be switched on, and the SSO button 404s

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -172,6 +172,33 @@ WPMGR_OIDC_CLIENT_SECRET=
 # (WPMGR_WEB_PORT=8088 by default); nginx proxies /auth/* to the api internally.
 # Do NOT use port 8081 (direct API host port) or :8080 (container-internal).
 WPMGR_OIDC_REDIRECT_URL=http://localhost:8088/auth/oidc/callback
+# Social sign-in (Google, GitHub). BOTH the id and the secret of a provider must
+# be set or that provider stays off, silently and by design, so a half-entered
+# credential never renders a button that fails at the provider.
+#
+# Unlike OIDC above, the redirect URI is NOT configured here: it is DERIVED as
+#   <WPMGR_PUBLIC_BASE_URL>/auth/social/<provider>/callback
+# so it can never point at a host you do not control. Register that exact URL at
+# the provider. With the defaults in this file that is:
+#   http://localhost:8088/auth/social/google/callback
+#   http://localhost:8088/auth/social/github/callback
+#
+# Google: console.cloud.google.com -> APIs & Services -> Credentials -> OAuth
+# client ID -> Web application. Scopes openid, email, profile are all
+# non-sensitive, so no Google verification review is needed.
+#
+# GitHub: Settings -> Developer settings -> OAuth Apps -> New OAuth App. It must
+# be an OAuth App, NOT a GitHub App: a GitHub App token cannot read
+# /user/emails, which is the only source of a verified address, so sign-in would
+# fail for everyone. One callback URL is allowed per app, so dev and production
+# need separate apps.
+#
+# A failure to reach Google's discovery endpoint does NOT block boot; it fails
+# that one sign-in attempt and retries on the next.
+WPMGR_SOCIAL_GOOGLE_CLIENT_ID=
+WPMGR_SOCIAL_GOOGLE_CLIENT_SECRET=
+WPMGR_SOCIAL_GITHUB_CLIENT_ID=
+WPMGR_SOCIAL_GITHUB_CLIENT_SECRET=
 # WebAuthn / passkeys (dashboard 2FA). Defaults point at the hosted instance
 # (manage.wpmgr.app); self-hosters who want passkeys MUST set both to their own
 # dashboard domain. Left commented out so the built-in defaults apply.

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -519,13 +519,10 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// in, which is the right default for a self-hosted install whose operator
 	// has not registered an OAuth application anywhere.
 	//
-	// A discovery failure is fatal for the same reason OIDC's is: booting with
-	// a half-built adapter turns into a broken button at sign-in time, long
-	// after anyone was reading the logs.
-	socialProviders, err := auth.NewSocialProviders(ctx, cfg.Social)
-	if err != nil {
-		return err
-	}
+	// This does no network I/O. Google's discovery call happens on first use,
+	// because putting a third party's availability on our boot path means their
+	// outage stops this control plane from starting at all.
+	socialProviders := auth.NewSocialProviders(cfg.Social)
 	if enabled := socialProviders.Enabled(); len(enabled) > 0 {
 		logger.Info("social sign-in enabled", slog.Any("providers", enabled))
 	} else {

--- a/apps/api/internal/auth/social_handler.go
+++ b/apps/api/internal/auth/social_handler.go
@@ -16,7 +16,17 @@ import (
 // unconfigured provider leads to a provider error page, which reads as a broken
 // product rather than an unconfigured one.
 func (h *Handler) socialProviders(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"providers": h.social.Enabled()})
+	// `sso` covers the generic operator-configured OIDC issuer, which is a
+	// separate mechanism from the consumer providers but the same question for
+	// the sign-in page: which buttons will actually work.
+	//
+	// It is reported here because the SSO button used to render unconditionally,
+	// so on an install with no issuer configured (which is every install by
+	// default, including production) it was a permanent dead end.
+	c.JSON(http.StatusOK, gin.H{
+		"providers": h.social.Enabled(),
+		"sso":       h.oidc.Enabled(),
+	})
 }
 
 // socialRedirectURL derives the callback the provider will send the browser
@@ -34,7 +44,7 @@ func (h *Handler) socialStart(c *gin.Context) {
 		httpx.Error(c, domain.Unavailable("social_provider_disabled", "this sign-in method is not configured"))
 		return
 	}
-	url, state, nonce, verifier, err := adapter.AuthCodeURL(h.socialRedirectURL(provider))
+	url, state, nonce, verifier, err := adapter.AuthCodeURL(c.Request.Context(), h.socialRedirectURL(provider))
 	if err != nil {
 		httpx.Error(c, domain.Internal("social_url_failed", "failed to build authorization URL").WithCause(err))
 		return

--- a/apps/api/internal/auth/social_providers.go
+++ b/apps/api/internal/auth/social_providers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -29,7 +30,7 @@ type SocialProviderAdapter interface {
 	// AuthCodeURL builds the redirect, returning the state, nonce and PKCE
 	// verifier the callback must present. nonce is empty for providers with no
 	// ID token to bind it to.
-	AuthCodeURL(redirectURL string) (url, state, nonce, verifier string, err error)
+	AuthCodeURL(ctx context.Context, redirectURL string) (url, state, nonce, verifier string, err error)
 	// Exchange completes the code exchange and returns a verified identity.
 	Exchange(ctx context.Context, redirectURL, code, verifier, nonce string) (SocialIdentity, error)
 }
@@ -44,24 +45,20 @@ type SocialProviders struct {
 // with no credentials is simply absent: an unconfigured provider must never
 // render a button that leads to a provider error page.
 //
-// Google discovery is a network call, so a failure here is returned rather than
-// swallowed. Booting with a half-built Google adapter would surface as a broken
-// button at sign-in time, long after anyone was watching the logs.
-func NewSocialProviders(ctx context.Context, cfg config.SocialConfig) (*SocialProviders, error) {
+// This performs NO network I/O and cannot fail. Google's discovery call happens
+// on first use instead: see googleAdapter.ensure for why it must not be on the
+// boot path.
+func NewSocialProviders(cfg config.SocialConfig) *SocialProviders {
 	sp := &SocialProviders{byKey: map[string]SocialProviderAdapter{}}
 	if cfg.Google.Enabled() {
-		g, err := newGoogleAdapter(ctx, cfg.Google)
-		if err != nil {
-			return nil, fmt.Errorf("google sign-in: %w", err)
-		}
-		sp.byKey["google"] = g
+		sp.byKey["google"] = newGoogleAdapter(cfg.Google)
 		sp.order = append(sp.order, "google")
 	}
 	if cfg.GitHub.Enabled() {
 		sp.byKey["github"] = newGitHubAdapter(cfg.GitHub)
 		sp.order = append(sp.order, "github")
 	}
-	return sp, nil
+	return sp
 }
 
 // Get returns the adapter for a provider key, or nil.
@@ -86,23 +83,53 @@ func (s *SocialProviders) Enabled() []string {
 // ---------------------------------------------------------------------------
 
 type googleAdapter struct {
-	cfg      config.GoogleConfig
+	cfg config.GoogleConfig
+
+	// Discovery result, filled lazily. See ensure.
+	mu       sync.Mutex
 	endpoint oauth2.Endpoint
 	verifier *oidc.IDTokenVerifier
+	ready    bool
 }
 
 const googleIssuer = "https://accounts.google.com"
 
-func newGoogleAdapter(ctx context.Context, cfg config.GoogleConfig) (*googleAdapter, error) {
-	provider, err := oidc.NewProvider(ctx, googleIssuer)
-	if err != nil {
-		return nil, fmt.Errorf("discovery: %w", err)
+// googleDiscoveryTimeout bounds the one outbound call this adapter makes before
+// it can do anything. Unbounded, it inherits whatever context it is handed.
+const googleDiscoveryTimeout = 10 * time.Second
+
+func newGoogleAdapter(cfg config.GoogleConfig) *googleAdapter {
+	return &googleAdapter{cfg: cfg}
+}
+
+// ensure performs OIDC discovery once, on first use rather than at boot.
+//
+// DISCOVERY MUST NOT BE ON THE BOOT PATH. It was: NewSocialProviders called
+// oidc.NewProvider directly and main returned the error, so an unreachable or
+// merely slow accounts.google.com would stop the entire control plane from
+// starting. Backups, updates, uptime and every dashboard would be down because
+// a third party was having a bad morning, in exchange for learning ten seconds
+// earlier that a sign-in button might not work.
+//
+// Doing it lazily also means a transient failure is not permanent: the next
+// sign-in attempt retries, where a boot-time failure would have needed a
+// redeploy to clear.
+func (g *googleAdapter) ensure(ctx context.Context) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.ready {
+		return nil
 	}
-	return &googleAdapter{
-		cfg:      cfg,
-		endpoint: provider.Endpoint(),
-		verifier: provider.Verifier(&oidc.Config{ClientID: cfg.ClientID}),
-	}, nil
+	dctx, cancel := context.WithTimeout(ctx, googleDiscoveryTimeout)
+	defer cancel()
+	provider, err := oidc.NewProvider(dctx, googleIssuer)
+	if err != nil {
+		return fmt.Errorf("google discovery: %w", err)
+	}
+	g.endpoint = provider.Endpoint()
+	g.verifier = provider.Verifier(&oidc.Config{ClientID: g.cfg.ClientID})
+	g.ready = true
+	return nil
 }
 
 func (g *googleAdapter) Key() string { return "google" }
@@ -117,7 +144,10 @@ func (g *googleAdapter) oauth(redirectURL string) *oauth2.Config {
 	}
 }
 
-func (g *googleAdapter) AuthCodeURL(redirectURL string) (string, string, string, string, error) {
+func (g *googleAdapter) AuthCodeURL(ctx context.Context, redirectURL string) (string, string, string, string, error) {
+	if err := g.ensure(ctx); err != nil {
+		return "", "", "", "", err
+	}
 	state, err := randString()
 	if err != nil {
 		return "", "", "", "", err
@@ -135,6 +165,9 @@ func (g *googleAdapter) AuthCodeURL(redirectURL string) (string, string, string,
 }
 
 func (g *googleAdapter) Exchange(ctx context.Context, redirectURL, code, verifier, nonce string) (SocialIdentity, error) {
+	if err := g.ensure(ctx); err != nil {
+		return SocialIdentity{}, err
+	}
 	tok, err := g.oauth(redirectURL).Exchange(ctx, code, oauth2.VerifierOption(verifier))
 	if err != nil {
 		return SocialIdentity{}, fmt.Errorf("code exchange: %w", err)
@@ -211,7 +244,7 @@ func (g *githubAdapter) oauth(redirectURL string) *oauth2.Config {
 	}
 }
 
-func (g *githubAdapter) AuthCodeURL(redirectURL string) (string, string, string, string, error) {
+func (g *githubAdapter) AuthCodeURL(_ context.Context, redirectURL string) (string, string, string, string, error) {
 	state, err := randString()
 	if err != nil {
 		return "", "", "", "", err

--- a/apps/api/internal/auth/social_providers_test.go
+++ b/apps/api/internal/auth/social_providers_test.go
@@ -1,6 +1,11 @@
 package auth
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/config"
+)
 
 // GitHub is not an OpenID Connect provider and has no email_verified claim, so
 // primaryVerifiedEmail is where the verified address is established for that
@@ -101,5 +106,56 @@ func TestSocialProvidersAbsentWhenUnconfigured(t *testing.T) {
 	}
 	if empty.Get("github") != nil {
 		t.Fatal("an unconfigured provider must not resolve to an adapter")
+	}
+}
+
+// Constructing the provider set must do no network I/O and must not be able to
+// fail. It used to call oidc.NewProvider inline and main returned the error, so
+// an unreachable or merely slow accounts.google.com stopped the whole control
+// plane from booting. This asserts the constructor is now pure: it returns
+// immediately with Google listed as enabled, having contacted nobody.
+func TestNewSocialProvidersDoesNoNetworkIO(t *testing.T) {
+	sp := NewSocialProviders(config.SocialConfig{
+		Google: config.GoogleConfig{ClientID: "id", ClientSecret: "secret"},
+		GitHub: config.GitHubConfig{ClientID: "id", ClientSecret: "secret"},
+	})
+
+	got := sp.Enabled()
+	if len(got) != 2 {
+		t.Fatalf("Enabled() = %v, want both providers listed without any discovery call", got)
+	}
+	if sp.Get("google") == nil || sp.Get("github") == nil {
+		t.Fatal("both adapters must exist before any network call is attempted")
+	}
+
+	// Discovery has not run, so the Google adapter is not yet ready. That is the
+	// point: it becomes ready on first use, not at boot.
+	g, ok := sp.Get("google").(*googleAdapter)
+	if !ok {
+		t.Fatal("expected the google adapter type")
+	}
+	if g.ready {
+		t.Error("google adapter reports ready before any discovery call; construction is doing I/O")
+	}
+}
+
+// A discovery failure must surface as a failed sign-in, not a failed boot, and
+// must not be cached as permanent: the next attempt retries.
+func TestGoogleDiscoveryFailureIsNotPermanent(t *testing.T) {
+	g := newGoogleAdapter(config.GoogleConfig{ClientID: "id", ClientSecret: "secret"})
+
+	// A context already past its deadline stands in for an unreachable issuer.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, _, _, _, err := g.AuthCodeURL(ctx, "https://example.test/cb"); err == nil {
+		t.Fatal("a failed discovery must surface as an error from AuthCodeURL")
+	}
+	if g.ready {
+		t.Error("a failed discovery must not mark the adapter ready")
+	}
+	// Nothing was cached, so a later attempt is free to succeed.
+	if g.verifier != nil {
+		t.Error("a failed discovery must leave no half-built verifier behind")
 	}
 }

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -907,6 +907,19 @@ func mapEnvKey(k string) string {
 	// passthrough below, which unmarshal simply ignores).
 	case strings.HasPrefix(k, "billing_razorpay_"):
 		return "billing.razorpay." + strings.TrimPrefix(k, "billing_razorpay_")
+	// Social sign-in, one case PER PROVIDER for the same reason billing needs
+	// one per gateway: the struct nests two levels, so the rewrite has to
+	// produce social.google.client_id. A single "social_" case would yield
+	// social.google_client_id, which is still flat and still does not bind.
+	//
+	// Their absence is why this feature shipped, deployed and could not be
+	// switched on: all four variables set correctly still left both providers
+	// disabled, because the keys fell through the default passthrough below and
+	// unmarshal ignored them. There was no error to notice.
+	case strings.HasPrefix(k, "social_google_"):
+		return "social.google." + strings.TrimPrefix(k, "social_google_")
+	case strings.HasPrefix(k, "social_github_"):
+		return "social.github." + strings.TrimPrefix(k, "social_github_")
 	default:
 		return k
 	}

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -503,3 +503,63 @@ func TestPrivilegeProbeGate(t *testing.T) {
 		})
 	}
 }
+
+// TestLoadSocialProvidersFromEnv is the regression for the defect that made
+// social sign-in impossible to enable at all.
+//
+// mapEnvKey rewrites a flat WPMGR_FOO_BAR name into the dotted koanf path that
+// matches the struct. Every nested config block needs its own prefix case;
+// there was none for social_, so WPMGR_SOCIAL_GOOGLE_CLIENT_ID lowercased to
+// social_google_client_id, hit the default passthrough, and was loaded as a
+// flat top-level key that unmarshal ignores. The result was a feature that
+// shipped, deployed, and could never be switched on: setting all four variables
+// correctly still left both providers disabled, with no error anywhere.
+//
+// A bare "social_" case would NOT fix it: that yields social.google_client_id,
+// which is still not nested and still does not bind.
+func TestLoadSocialProvidersFromEnv(t *testing.T) {
+	t.Setenv("WPMGR_SOCIAL_GOOGLE_CLIENT_ID", "123.apps.googleusercontent.com")
+	t.Setenv("WPMGR_SOCIAL_GOOGLE_CLIENT_SECRET", "GOCSPX-google-secret")
+	t.Setenv("WPMGR_SOCIAL_GITHUB_CLIENT_ID", "Iv23liGitHubClient")
+	t.Setenv("WPMGR_SOCIAL_GITHUB_CLIENT_SECRET", "github-secret")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if got := cfg.Social.Google.ClientID; got != "123.apps.googleusercontent.com" {
+		t.Errorf("Social.Google.ClientID = %q, want the value from the environment", got)
+	}
+	if got := cfg.Social.Google.ClientSecret; got != "GOCSPX-google-secret" {
+		t.Errorf("Social.Google.ClientSecret = %q, want the value from the environment", got)
+	}
+	if got := cfg.Social.GitHub.ClientID; got != "Iv23liGitHubClient" {
+		t.Errorf("Social.GitHub.ClientID = %q, want the value from the environment", got)
+	}
+	if got := cfg.Social.GitHub.ClientSecret; got != "github-secret" {
+		t.Errorf("Social.GitHub.ClientSecret = %q, want the value from the environment", got)
+	}
+
+	// The property that actually matters: with credentials present, the
+	// provider must report itself enabled, because that is what decides whether
+	// a button ever renders.
+	if !cfg.Social.Google.Enabled() {
+		t.Error("Social.Google.Enabled() = false with both credentials set; the provider can never be turned on")
+	}
+	if !cfg.Social.GitHub.Enabled() {
+		t.Error("Social.GitHub.Enabled() = false with both credentials set; the provider can never be turned on")
+	}
+}
+
+// Half-configured must stay off rather than half-on.
+func TestLoadSocialProviderNeedsBothCredentials(t *testing.T) {
+	t.Setenv("WPMGR_SOCIAL_GOOGLE_CLIENT_ID", "123.apps.googleusercontent.com")
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Social.Google.Enabled() {
+		t.Error("Google reported enabled with an id but no secret; a half-configured provider must stay off")
+	}
+}

--- a/apps/web/src/features/auth/social-buttons.tsx
+++ b/apps/web/src/features/auth/social-buttons.tsx
@@ -23,24 +23,38 @@ const PROVIDERS: Record<Provider, { label: string; Icon: () => React.ReactElemen
   github: { label: "GitHub", Icon: GitHubMark },
 };
 
-async function fetchProviders(): Promise<Provider[]> {
+export type SignInMethods = { providers: Provider[]; sso: boolean };
+
+async function fetchMethods(): Promise<SignInMethods> {
   const res = await fetch("/auth/social/providers", { credentials: "include" });
-  if (!res.ok) return [];
-  const body: unknown = await res.json();
-  const list = (body as { providers?: unknown }).providers;
-  if (!Array.isArray(list)) return [];
-  return list.filter((p): p is Provider => p === "google" || p === "github");
+  if (!res.ok) return { providers: [], sso: false };
+  const body = (await res.json()) as { providers?: unknown; sso?: unknown };
+  const list = Array.isArray(body.providers) ? body.providers : [];
+  return {
+    providers: list.filter((p): p is Provider => p === "google" || p === "github"),
+    sso: body.sso === true,
+  };
 }
 
-export function SocialButtons({ label }: { label: string }) {
-  const { data: providers } = useQuery({
-    queryKey: ["auth", "social-providers"],
-    queryFn: fetchProviders,
-    // The set only changes when an operator reconfigures the server and
-    // restarts it, so re-asking on every mount is wasted work.
+/**
+ * Which sign-in methods this install actually offers. Shared by the buttons and
+ * by the SSO button on the login page, so neither can render something the
+ * server will refuse.
+ */
+export function useSignInMethods() {
+  return useQuery({
+    queryKey: ["auth", "sign-in-methods"],
+    queryFn: fetchMethods,
     staleTime: 5 * 60 * 1000,
     retry: false,
   });
+}
+
+export function SocialButtons({ label }: { label: string }) {
+  // The set only changes when an operator reconfigures the server and restarts
+  // it, so the shared query re-asks rarely.
+  const { data } = useSignInMethods();
+  const providers = data?.providers;
 
   if (!providers || providers.length === 0) return null;
 

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -8,7 +8,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { getMe } from "@wpmgr/api";
 
 import { AuthLayout } from "@/components/layout/auth-layout";
-import { SocialButtons } from "@/features/auth/social-buttons";
+import { SocialButtons, useSignInMethods } from "@/features/auth/social-buttons";
 import { socialErrorMessage } from "@/features/auth/social-errors";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -64,6 +64,7 @@ function LoginPage() {
   const navigate = useNavigate();
   const search = Route.useSearch();
   const loginMutation = useLogin();
+  const ssoEnabled = useSignInMethods().data?.sso === true;
   const resendMutation = useResendVerification();
   const queryClient = useQueryClient();
   // Tracks when login failed because the email is not yet verified.
@@ -143,7 +144,10 @@ function LoginPage() {
   // lands on that response and can navigate back — we keep the button always
   // visible to avoid a config probe on the login screen.
   function signInWithSso() {
-    window.location.href = "/api/auth/oidc/login";
+    // /auth/oidc/login, NOT /api/auth/... The auth routes mount on the root
+    // group (handler.go registers them under "/auth"), so the /api prefix was a
+    // 404 on every install that had SSO configured at all.
+    window.location.href = "/auth/oidc/login";
   }
 
   const isEmailNotVerified =
@@ -299,14 +303,19 @@ function LoginPage() {
 
           <SocialButtons label="Sign in with" />
 
-          <Button
-            type="button"
-            variant="outline"
-            className="mt-2 w-full"
-            onClick={signInWithSso}
-          >
-            Sign in with SSO
-          </Button>
+          {/* Only when an issuer is actually configured. This button used to
+              render unconditionally, so on an install with no OIDC issuer,
+              which is the default and includes production, it was a dead end. */}
+          {ssoEnabled ? (
+            <Button
+              type="button"
+              variant="outline"
+              className="mt-2 w-full"
+              onClick={signInWithSso}
+            >
+              Sign in with SSO
+            </Button>
+          ) : null}
 
           <p className="mt-4 text-center text-xs text-[var(--color-muted-foreground)]">
             Don't have an account?{" "}

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -938,13 +938,19 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [providers]
+                required: [providers, sso]
                 properties:
                   providers:
                     type: array
                     items:
                       type: string
                       enum: [google, github]
+                  sso:
+                    type: boolean
+                    description: >
+                      Whether a generic operator-configured OIDC issuer is
+                      available. Reported here so the sign-in page renders the
+                      SSO button only when it will work.
   /auth/social/{provider}/start:
     get:
       operationId: socialStart


### PR DESCRIPTION
Three defects that make the feature unusable today. A 23-agent scenario sweep found 109 scenarios and 39 surviving gaps; these are the ones that block everything else. The rest are being remediated separately.

## The feature was unreachable

`mapEnvKey` rewrites a flat `WPMGR_FOO_BAR` name into the dotted koanf path that matches the struct, and every nested block needs its own prefix case. **There was none for `social_`.** So `WPMGR_SOCIAL_GOOGLE_CLIENT_ID` lowercased to `social_google_client_id`, fell through the default passthrough, and was loaded as a flat key that unmarshal ignores.

Setting all four variables correctly still left both providers disabled, with no error anywhere. I shipped this feature, deployed it, and wrote a PR describing how to configure something that could not be configured.

One case **per provider**, not a single `social_` case: the struct nests two levels, so the rewrite must produce `social.google.client_id`. A bare `social_` case yields `social.google_client_id`, still flat, still doesn't bind.

Proven by `TestLoadSocialProvidersFromEnv`, which fails on the old code.

## Google's availability was on our boot path

`NewSocialProviders` called `oidc.NewProvider` inline with no timeout and `main` returned the error — so an unreachable or merely slow `accounts.google.com` would stop the entire control plane from starting. Backups, updates, uptime and every dashboard down because a third party was having a bad morning.

My own comment argued for this, on the grounds that a half-built adapter would surface later as a broken button. A broken button is enormously better than a dead control plane.

Discovery now happens on first use, bounded at 10s. A transient failure is also no longer permanent: the next sign-in retries, where a boot-time failure needed a redeploy to clear.

## The SSO button has been 404ing in production

Two defects in one control, both pre-existing:

| | |
|---|---|
| `/api/auth/oidc/login` | **404** — what the button navigates to |
| `/auth/oidc/login` | 501 — where the route actually mounts |

It also rendered unconditionally, so on an install with no issuer configured — the default, including production — it was a permanent dead end.

`/auth/social/providers` now reports `sso` alongside the provider list, so one endpoint answers "which buttons will actually work" and neither the page nor the buttons can offer something the server refuses.

## Also

`.env.example` documents all four `WPMGR_SOCIAL_*` variables, including that the redirect URI is **derived rather than configured** (so it can never point at a host you don't control), and that GitHub requires an **OAuth App, not a GitHub App** — a GitHub App token cannot read `/user/emails`, the only source of a verified address, so sign-in would fail for everyone with a generic error.

## Verification

`gofmt`, `go vet`, full Go suite, contract route coverage, eslint, 1519 web tests. The two live 404/501 responses above were confirmed against production.

**This turns nothing on.** Both providers stay disabled until credentials are configured, which is deliberate: the remaining gaps are dormant while the feature is inert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Google and GitHub social sign-in configuration.
  * Login now displays social sign-in options only when enabled.
  * Added SSO availability information to authentication provider results.
* **Bug Fixes**
  * Application startup no longer depends on third-party provider availability.
  * Provider discovery retries after temporary failures and reports errors during sign-in.
  * Incomplete provider credentials now keep that provider disabled.
* **Configuration**
  * Added environment variables for Google and GitHub client credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->