### PR TITLE
release: 0.61.131 (GH #380 SMTP credential fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
-No unreleased changes.
-
 ## [0.61.131] - 2026-08-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+No unreleased changes.
+
+## [0.61.131] - 2026-08-10
+
 ### Fixed
 
 - Sending email from a site no longer stops working on its own, days after it was set up and used successfully. Saving, testing or syncing that site's email settings could send the site an empty password, which the site read as an instruction to delete the working one it already had. The site then tried to sign in to the mail server with nothing, the mail server refused, and what everybody saw was "SMTP Error: Could not authenticate", which is the same thing a wrong password looks like. That is why re-typing the same password fixed some sites: it put back what had just been deleted. The dashboard now says nothing at all about the password unless it has a real one to send, so a site keeps the credential it already holds.

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -4,7 +4,7 @@ Tags: backup, security, performance, updates, site management
 Requires at least: 6.2
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.61.127
+Stable tag: 0.61.131
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -276,6 +276,10 @@ This plugin ships two minified JavaScript files. Their human-readable source and
 
 The entries below summarize the notable changes since 0.31.1. This project ships frequently and not every intermediate patch release is listed here. Full history: https://github.com/mosamlife/wpmgr/blob/main/CHANGELOG.md
 
+= 0.61.131 =
+* Fixed: sending email from this site could silently stop working days after it had been set up and used successfully, showing as "SMTP Error: Could not authenticate" (GH #380). Saving, testing or syncing this site's email settings from the dashboard could send an empty password, and the site read that as an instruction to delete the working password it already had. This site no longer deletes a stored password unless the dashboard actually sends a real replacement, and it now refuses an email settings update it cannot make sense of instead of acting on the part it understood. If this site lost its password this way, the dashboard restores it the next time it syncs this site's email settings, with nothing for you to re-enter.
+* Security: a password belonging to your dashboard account is no longer sent to a mail server you choose from this site's own settings page, and a stored password is no longer carried over automatically when you point this site's email at a different mail server, mailbox user or provider.
+
 = 0.61.127 =
 * Fixed: a password policy can now target the roles the site actually has, not only the five roles a stock WordPress install ships with. On a WooCommerce store the roles that matter are the ones the store added, and a shop manager who can edit orders, refund customers and read every buyer's address could not be required to hold a strong password, because that role could not be selected. The same applied to membership, LMS and booking plugins, and to roles an agency created by hand. Enforcement was never the problem: the agent has always applied a policy to whatever role a user really holds. What was missing was any way to write the rule. Role names now also read the way they read on the site itself, in the site's own language, while the rule stays bound to the underlying role identifier, so renaming or translating a role never changes who it covers.
 
@@ -412,6 +416,9 @@ The entries below summarize the notable changes since 0.31.1. This project ships
 * New: WOFF2 font transcoding. TTF, OTF and WOFF are converted on the control plane; the flag defaults to off.
 
 == Upgrade Notice ==
+
+= 0.61.131 =
+Fixes a bug that could silently delete this site's working SMTP password when its email settings were saved, tested or synced from the dashboard, breaking outgoing email. Update now if this site sends mail through SMTP, SES, SendGrid, Mailgun or Postmark; the dashboard restores the password automatically on its next sync with this site.
 
 = 0.61.127 =
 Password policies can now target the roles your site actually has, including roles added by WooCommerce, membership, LMS and booking plugins, shown in the site's own language. Safe to update in place.

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.127
+ * Version:           0.61.131
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.127');
+define('WPMGR_AGENT_VERSION', '0.61.131');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -39,6 +39,26 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.131",
+    date: "2026-08-10",
+    summary:
+      "A routine save, test or sync of a site's email settings could silently delete the site's working SMTP password, and outgoing email then failed with \"SMTP Error: Could not authenticate,\" the same message a wrong password gives. This release stops the deletion, restores an already affected site's password automatically the next time its settings sync, and closes off your organisation's own email password being reachable from a single site's settings page. Sites are not fixed until their plugin updates to this version.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Saving, testing or syncing a site's email settings could send the site an empty password, which the site read as an instruction to delete the working one it already had. The dashboard now says nothing about the password unless it has a real one to send, so a site keeps the credential it already holds. A site that uses your organisation's password, rather than one of its own, now keeps using it instead of losing it the moment anything was saved on that site's own email page.",
+      },
+      {
+        tag: "Fixed",
+        text: "A site now refuses an email settings update it cannot read, instead of acting on the part it understood, and reports it as a failure when your settings cannot actually be written to it rather than reporting success regardless. A save or an organisation-wide update is no longer sent to your sites at all when the stored password cannot be read back, which used to be able to empty the password on every site in the organisation from one unreadable record.",
+      },
+      {
+        tag: "Security",
+        text: "Your organisation's email password can no longer be sent to a mail server chosen on a single site, and somebody invited to only one site can no longer change your organisation's email settings from that site's page. A password saved against a mail connection, a site or your organisation is now dropped rather than carried across whenever the mail server, mailbox user or provider it was issued for changes.",
+      },
+    ],
+  },
+  {
     version: "0.61.130",
     date: "2026-08-10",
     summary:

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.130
+  version: 0.61.131
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

This release ships the fix for GH #380: a fleet-wide, credential-destroying bug where a routine save, test or sync of a site's email settings could send the site an empty SMTP password. The site read the empty password as an instruction to delete the working one it already had, and outgoing email then failed with "SMTP Error: Could not authenticate," which reads identically to a wrong password. Re-typing the same password happened to fix some sites only because it put back what had just been deleted.

**The agent is the payload of this release. A site is not fixed until its plugin updates to this version.** The control-plane side of the fix is already in production; once a site's agent updates, the dashboard restores that site's real password automatically the next time it syncs the site's email settings, with nothing for the site owner to re-enter.

Also included: an org-wide email password is no longer reachable from a single site's own email settings page, and a stored password is no longer carried across automatically when a site, a named mail connection, or the organisation moves to a different mail server, mailbox user or provider.

## Changes

- `CHANGELOG.md`: promotes `[Unreleased]` (the 17 GH #380 entries already merged to main) to `[0.61.131] - 2026-08-10`, and resets `[Unreleased]` to empty.
- `packages/openapi/openapi.yaml`: `info.version` 0.61.130 -> 0.61.131.
- `apps/marketing/app/(marketing)/changelog/page.tsx`: adds the 0.61.131 entry.
- `apps/agent/wpmgr-agent.php`: `Version` header and `WPMGR_AGENT_VERSION` 0.61.127 -> 0.61.131 (both bumped together, they must agree for self-update version comparison).
- `apps/agent/readme.txt`: `Stable tag`, changelog section and Upgrade Notice entries for 0.61.131.

No product code changes in this PR, only the version bump and docs/changelog entries for the fixes already on `main`.

## Test plan

- [x] `.github/workflows/ci.yml` docs-version-drift guard logic run verbatim against this tree: passes (`openapi.yaml info.version matches the top CHANGELOG.md entry (0.61.131)`, marketing changelog newest entry within tolerance).
- [x] Confirmed `apps/agent/wpmgr-agent.php` Version header, `WPMGR_AGENT_VERSION`, and `apps/agent/readme.txt` Stable tag all read 0.61.131.
- [x] `php -l apps/agent/wpmgr-agent.php`: no syntax errors.
- [x] `php -d memory_limit=1G vendor/bin/phpunit --filter Email` (apps/agent): 199 tests, 525 assertions, OK.
- [ ] CI green on this PR (ci.yml).

Merging, tagging `v0.61.131`, GHCR/agent release, prod deploy and `make agent-release` happen after this PR merges, out of scope here.