### PR TITLE
ci: build the public marketing site, which CI never did

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,49 @@ jobs:
       - name: Test
         run: pnpm --filter @wpmgr/web test
 
+  # ---- Marketing site (the public wpmgr.app) ----
+  # Separate from the web job so a failure says which app broke, and because
+  # these two deploy independently.
+  #
+  # WHY THIS EXISTS. apps/marketing was never typechecked or built by CI. Only
+  # its lint ran, and only as a side effect of the workspace-wide `turbo run
+  # lint` inside the web job, so a type error or a broken build in the most
+  # public thing this project ships would first appear during `gcloud builds
+  # submit`, at deploy time, by which point the release is already out
+  # everywhere else. It shipped that way on 0.61.131: the hero badge was edited
+  # in a .ts file that nothing verified until the deploy build ran.
+  #
+  # No test step: apps/marketing has no test script. Copy is gated separately in
+  # the Security audit job, which runs check-copy.mjs on plain node so it needs
+  # no install and also covers the agent readme.
+  marketing:
+    name: JS (marketing)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.1.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm --filter @wpmgr/marketing typecheck
+
+      # Runs scripts/sync-openapi.mjs then next build, which is exactly what the
+      # deploy image does, so a build that only breaks in the real pipeline
+      # cannot pass here.
+      - name: Build
+        run: pnpm --filter @wpmgr/marketing build
+
   # ---- Dependency vulnerability scanning ----
   security:
     name: Security audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         working-directory: apps/api
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:
@@ -81,11 +83,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
+        # Version comes from the root package.json packageManager field, so the
+        # lockfile and CI cannot drift apart.
         uses: pnpm/action-setup@v4
-        with:
-          version: 11.1.1
 
       - uses: actions/setup-node@v4
         with:
@@ -127,11 +131,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
+        # Version comes from the root package.json packageManager field, so the
+        # lockfile and CI cannot drift apart.
         uses: pnpm/action-setup@v4
-        with:
-          version: 11.1.1
 
       - uses: actions/setup-node@v4
         with:
@@ -156,6 +162,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # House rule: competitor products are never named in docs or root markdown.
       # Functional source references (conflict-detection slugs, plugin-signature
@@ -227,9 +235,9 @@ jobs:
           "$(go env GOPATH)/bin/govulncheck" ./cmd/wpmgr/...
 
       - name: Install pnpm
+        # Version comes from the root package.json packageManager field, so the
+        # lockfile and CI cannot drift apart.
         uses: pnpm/action-setup@v4
-        with:
-          version: 11.1.1
 
       # No `cache: pnpm` here: this job never runs `pnpm install`, so the pnpm
       # store is empty and setup-node's cache-save post-step fails on a missing
@@ -258,6 +266,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: nginx -t (syntax)
         run: |
@@ -277,6 +287,8 @@ jobs:
         working-directory: apps/agent
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # The check that release.yml must not stamp the agent zip from the git tag
       # used to live here, on its own, which is why the process doc describing


### PR DESCRIPTION
`apps/marketing` was never typechecked and never built by CI.

Its lint ran, but only as a side effect of the workspace-wide `turbo run lint` inside the **JS (web)** job. Typecheck and build are filtered to `@wpmgr/web`, so the public site had neither. `ci.yml` even said so out loud in a comment: *"`pnpm -C apps/marketing build`, which ci.yml never invokes"*, which is why `check-copy.mjs` was moved into the Security audit job to run on plain node.

So a type error or a broken build in the most public thing this project ships would first appear during `gcloud builds submit`, at deploy time, after the release had already gone out to prod, GitHub, GCS and wordpress.org.

**Not hypothetical.** 0.61.131 edited the hero badge in `apps/marketing/lib/content/home.ts`, and nothing verified that file until the deploy build ran by hand.

## What this adds

A separate `JS (marketing)` job, so a failure names which app broke and because the two apps deploy independently:

- **Typecheck** `pnpm --filter @wpmgr/marketing typecheck`
- **Build** `pnpm --filter @wpmgr/marketing build`, which runs `sync-openapi.mjs` then `next build`, the same pair the deploy image runs, so a break that only shows up in the real pipeline cannot pass here.

No test step: `apps/marketing` has no test script. Copy stays gated in the Security audit job, which runs `check-copy.mjs` on plain node with no install and also covers the agent readme.

## Verified

Typecheck, build and check-copy are all green on `main` today, so this job does not redden it. I planted a type error in `home.ts` and confirmed the typecheck exits non-zero, then restored it and confirmed it exits 0, so the job is not decorative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation for the marketing site’s typechecking and production build.
  * Improved continuous integration coverage for marketing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->