### PR TITLE
chore(marketing): clear the bot review debt on the comparison and pricing pages

### DIFF
--- a/apps/marketing/app/(marketing)/compare/[slug]/page.tsx
+++ b/apps/marketing/app/(marketing)/compare/[slug]/page.tsx
@@ -40,10 +40,11 @@ export default async function ComparePage({
   ]);
 
   return (
+    // No <main> here: the (marketing) group layout already renders one, and a
+    // second nested landmark is invalid HTML and duplicates the target of
+    // landmark navigation.
     <>
-      <main>
-        <ComparisonPage data={page} />
-      </main>
+      <ComparisonPage data={page} />
       <JsonLd data={breadcrumbLd} />
       {page.faq.length > 0 && <JsonLd data={buildFAQPageLd(page.faq)} />}
     </>

--- a/apps/marketing/app/(marketing)/compare/page.tsx
+++ b/apps/marketing/app/(marketing)/compare/page.tsx
@@ -16,37 +16,38 @@ export default function CompareIndexPage() {
   const pages = Object.values(COMPARE_REGISTRY);
 
   return (
+    // No <main> here: the (marketing) group layout already renders one, and a
+    // second nested landmark is invalid HTML and duplicates the target of
+    // landmark navigation.
     <>
-      <main>
-        <Section>
-          <Container>
-            <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
-              Compare WordPress management tools
-            </h1>
-            <p className="mt-5 max-w-[70ch] text-lg leading-relaxed text-[var(--muted-foreground)]">
-              We build one of the products on these pages, so every factual claim links to the
-              page it came from and the date we checked it. That includes the claims that do not
-              favour us.
-            </p>
+      <Section>
+        <Container>
+          <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+            Compare WordPress management tools
+          </h1>
+          <p className="mt-5 max-w-[70ch] text-lg leading-relaxed text-[var(--muted-foreground)]">
+            We build one of the products on these pages, so every factual claim links to the page
+            it came from and the date we checked it. That includes the claims that do not favour
+            us.
+          </p>
 
-            <ul className="mt-10 flex flex-col gap-4">
-              {pages.map((p) => (
-                <li key={p.slug}>
-                  <Link
-                    href={`/compare/${p.slug}`}
-                    className="block rounded-xl border border-[var(--border)] bg-card p-6 shadow-sm transition-colors duration-[var(--duration-fast)] hover:bg-[var(--accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
-                  >
-                    <span className="text-lg font-semibold text-foreground">{p.title}</span>
-                    <span className="mt-2 block text-sm leading-relaxed text-[var(--muted-foreground)]">
-                      {p.metaDescription}
-                    </span>
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </Container>
-        </Section>
-      </main>
+          <ul className="mt-10 flex flex-col gap-4">
+            {pages.map((p) => (
+              <li key={p.slug}>
+                <Link
+                  href={`/compare/${p.slug}`}
+                  className="block rounded-xl border border-[var(--border)] bg-card p-6 shadow-sm transition-colors duration-[var(--duration-fast)] hover:bg-[var(--accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+                >
+                  <span className="text-lg font-semibold text-foreground">{p.title}</span>
+                  <span className="mt-2 block text-sm leading-relaxed text-[var(--muted-foreground)]">
+                    {p.metaDescription}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </Container>
+      </Section>
       <JsonLd
         data={buildBreadcrumbLd([
           { name: "Home", href: "/" },

--- a/apps/marketing/app/(marketing)/pricing/page.tsx
+++ b/apps/marketing/app/(marketing)/pricing/page.tsx
@@ -109,13 +109,16 @@ export default async function PricingPage() {
                 Get started for free
                 <Icon name="ArrowRight" size={18} />
               </Link>
+              {/* Goes to /self-host, not to the repo. Every other surface
+                  carrying this exact label points at that page, and a reader
+                  who is weighing the hosted price against running it themselves
+                  wants the how, not a source tree. The repo link stays on this
+                  page, below the tier cards. */}
               <Link
-                href={SITE_CONFIG.github}
-                target="_blank"
-                rel="noreferrer noopener"
+                href="/self-host"
                 className="inline-flex items-center gap-2 rounded-[var(--radius)] border border-[var(--border)] bg-card px-6 py-3 text-base font-medium text-foreground transition-colors hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
               >
-                <Icon name="Github" size={18} />
+                <Icon name="Server" size={18} />
                 Or self-host it
               </Link>
             </div>

--- a/apps/marketing/app/(marketing)/pricing/plugin-stack/calculator.tsx
+++ b/apps/marketing/app/(marketing)/pricing/plugin-stack/calculator.tsx
@@ -118,11 +118,16 @@ function TweenedMoney({ value, className }: { value: number; className?: string 
 
   return (
     <>
+      {/* ROUND ONLY WHAT IS MOVING. Whole dollars keep the digits from
+          flickering through cents mid-tween, but the SETTLED figure is printed
+          exactly, because several of the line items above carry cents and a
+          headline that does not equal the sum of the visible rows undoes the
+          one thing this page is for. */}
       <span className={className} aria-hidden>
-        {money(Math.round(tween ?? value))}
+        {tween !== null ? money(Math.round(tween)) : money(value)}
       </span>
       <span className="sr-only" aria-live="polite">
-        {money(Math.round(value))} per year
+        {money(value)} per year
       </span>
     </>
   );
@@ -423,10 +428,12 @@ export function PluginStackCalculator({ wpmgrTiers }: { wpmgrTiers: WpmgrTier[] 
             </div>
             {saving !== null && saving > 0 && (
               <p className="mt-2 text-xs text-[var(--muted-foreground)]">
-                {/* Rounded to match the two headline totals it is the
-                    difference of. Printing exact cents here against rounded
-                    totals above produced a visible ten-cent contradiction. */}
-                {money(Math.round(saving))} less per year at {sites}{" "}
+                {/* Exact, to match the two headline totals it is the difference
+                    of. Both of those settle on the true figure including cents,
+                    so rounding here would reintroduce the contradiction from
+                    the other side: a reader subtracting the two numbers on
+                    screen must land on this one. */}
+                {money(saving)} less per year at {sites}{" "}
                 {sites === 1 ? "site" : "sites"}.
               </p>
             )}

--- a/apps/marketing/components/blog/post-art.tsx
+++ b/apps/marketing/components/blog/post-art.tsx
@@ -578,8 +578,13 @@ export const POST_ART = {
 
 export type PostArtName = keyof typeof POST_ART;
 
+// `hasOwn`, not `in`. The value arrives as MDX frontmatter, so the guard is
+// asked about arbitrary author-supplied strings, and `in` also answers true for
+// everything on Object.prototype. `art: __proto__` would have passed the guard,
+// indexed to Object.prototype, and thrown "element type is invalid" during
+// static generation instead of falling back to the category illustration.
 export function isPostArtName(value: unknown): value is PostArtName {
-  return typeof value === "string" && value in POST_ART;
+  return typeof value === "string" && Object.hasOwn(POST_ART, value);
 }
 
 /**

--- a/apps/marketing/components/sections/compare/cost-model.tsx
+++ b/apps/marketing/components/sections/compare/cost-model.tsx
@@ -15,11 +15,13 @@ import type { ComparisonPageData, CostModel } from "@/lib/content/types";
  * the slider to their own number does that multiplication themselves, and a
  * figure you worked out yourself is worth more than one we assert.
  *
- * IT MUST NOT OVERSTATE A COMPETITOR. ManageWP is charged at the CHEAPEST of
- * per-site, per-add-on bundles, and their all-in-one package, because that is
- * what a real customer would pay. Quietly dropping the cheapest option would
- * inflate a named company's published price, which is the one mistake this
- * page cannot survive.
+ * IT MUST NOT OVERSTATE A COMPETITOR. Every vendor is charged at the CHEAPEST
+ * route to the same capability: per site, the add-on bundle, or any further
+ * package they publish, because that is what a real customer would pay.
+ * Quietly dropping the cheapest option would inflate a named company's
+ * published price, which is the one mistake this page cannot survive, so
+ * `alternatives` carries every additional package into the same comparison
+ * rather than leaving one of them described in prose and absent from the sum.
  *
  * The CTA lives here on purpose: this is the highest-intent moment on the page,
  * the instant the reader sees their own annual number.
@@ -36,6 +38,9 @@ function annualCost(m: CostModel, sites: number): number {
   const options = [bySite];
   if (m.bundle !== undefined && m.bundleCovers) {
     options.push(m.bundle * Math.ceil(sites / m.bundleCovers));
+  }
+  for (const alt of m.alternatives ?? []) {
+    options.push(alt.covers ? alt.amount * Math.ceil(sites / alt.covers) : alt.amount);
   }
   return perYear(Math.min(...options));
 }
@@ -124,7 +129,9 @@ export function CostModelSection({ data }: { data: ComparisonPageData }) {
                       className="ml-1 align-super underline underline-offset-2 hover:text-foreground"
                       aria-label={`Source, reference ${id}`}
                     >
-                      {id.split("-")[1]}
+                      {/* Full id: each product numbers its claims from one, so
+                          the bare number collides across columns. */}
+                      {id}
                     </a>
                   ))}
                 </p>

--- a/apps/marketing/components/sections/compare/data-locality.tsx
+++ b/apps/marketing/components/sections/compare/data-locality.tsx
@@ -84,7 +84,9 @@ export function DataLocality({ data }: { data: ComparisonPageData }) {
                       className="ml-1 align-super text-[10px] underline underline-offset-2 hover:text-foreground"
                       aria-label={`Source, reference ${id}`}
                     >
-                      {id.split("-")[1]}
+                      {/* Full id: this section cites mw-11 and mn-11 on the
+                          same screen, and both rendered as "11". */}
+                      {id}
                     </a>
                   ))}
                 </p>

--- a/apps/marketing/components/sections/compare/hero-panel.tsx
+++ b/apps/marketing/components/sections/compare/hero-panel.tsx
@@ -77,6 +77,12 @@ export function CompareHeroPanel() {
           >
             <span className="flex min-w-0 items-center gap-2.5">
               <Pulse status={r.status} />
+              {/* The dot is the only thing carrying up versus degraded, and it
+                  carries it in colour alone. The wrapper stays decorative
+                  rather than taking role="img", because labelling it would put
+                  the pulse ring back into the accessibility tree; the state
+                  goes in a sibling instead. */}
+              <span className="sr-only">{r.status === "up" ? "Up" : "Degraded"}: </span>
               <span className="truncate font-mono text-xs text-foreground">{r.host}</span>
             </span>
             <span className="shrink-0 text-[11px] text-[var(--muted-foreground)]">{r.meta}</span>

--- a/apps/marketing/components/sections/compare/matrix.tsx
+++ b/apps/marketing/components/sections/compare/matrix.tsx
@@ -58,7 +58,12 @@ function Cell({ cell, slug }: { cell: MatrixCell; slug: string }) {
             className="ml-1 align-super text-[10px] text-[var(--muted-foreground)] underline underline-offset-2 hover:text-foreground"
             aria-label={`Source for this figure, reference ${id}`}
           >
-            {id.split("-")[1]}
+            {/* THE WHOLE ID, not the number after the prefix. Each product
+                numbers its claims from one, so a bare "11" appears twice on the
+                same page pointing at two different sources. The sources page
+                prints the full id beside each claim, so this also matches what
+                the reader lands on. */}
+            {id}
           </a>
         ))}
       </span>
@@ -119,7 +124,7 @@ export function CompareMatrix({ data }: { data: ComparisonPageData }) {
                         {row.cells[c.key] ? (
                           <Cell cell={row.cells[c.key]!} slug={data.slug} />
                         ) : (
-                          <span className="text-[var(--muted-foreground)">Not stated</span>
+                          <span className="text-[var(--muted-foreground)]">Not stated</span>
                         )}
                       </td>
                     ))}

--- a/apps/marketing/lib/content/compare/managewp-vs-mainwp-vs-wpmgr.ts
+++ b/apps/marketing/lib/content/compare/managewp-vs-mainwp-vs-wpmgr.ts
@@ -16,6 +16,13 @@
 // publication gate. The audit caught a fabricated quotation in the first
 // draft. Do not add a claim here without a source you fetched yourself, and
 // re-check verifiedOn when prices move.
+//
+// A `cites` id IS the footnote the reader opens, and getting it wrong is
+// invisible: the link still resolves, to a real claim about something else.
+// Fourteen cells shipped that way. scripts/check-copy.mjs now rejects an id
+// that does not exist and an id borrowed from the other product's column, but
+// it cannot know that mw-20 is the wrong ManageWP claim for a cell about Safe
+// Updates. Read the claim you are citing.
 
 import type { ComparisonPageData } from "@/lib/content/types";
 
@@ -774,8 +781,8 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
           label: "Bulk updates across sites",
           cells: {
             wpmgr: { value: "Yes, with a pre-update snapshot and rollback", tone: "included" },
-            managewp: { value: "Yes. Safe Updates adds a restore point and needs premium Backups", tone: "included", cites: ["mw-20"] },
-            mainwp: { value: "Yes, free, including automatic updates", tone: "included", cites: ["mn-30"] },
+            managewp: { value: "Yes. Safe Updates adds a restore point and needs premium Backups", tone: "included", cites: ["mw-24"] },
+            mainwp: { value: "Yes, free, including automatic updates", tone: "included", cites: ["mn-40"] },
           },
         },
         {
@@ -783,7 +790,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
           cells: {
             wpmgr: { value: "Built in and free, with TLS expiry checks", tone: "included" },
             managewp: { value: "Add-on: $1 per site per month, or $25 for up to 100 sites", tone: "paid", cites: ["mw-08"] },
-            mainwp: { value: "Built in and free, off until enabled", tone: "included", cites: ["mn-33"] },
+            mainwp: { value: "Built in and free, off until enabled", tone: "included", cites: ["mn-30", "mn-31"] },
           },
         },
         {
@@ -791,7 +798,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
           cells: {
             wpmgr: { value: "Built in, white label, with a client portal", tone: "included" },
             managewp: { value: "Free with a ManageWP watermark. Advanced is $1 per site per month", tone: "paid", cites: ["mw-09"] },
-            mainwp: { value: "Pro Reports add-on, needs a second plugin on each site", tone: "paid", cites: ["mn-38"] },
+            mainwp: { value: "Pro Reports add-on, needs a second plugin on each site", tone: "paid", cites: ["mn-33"] },
           },
         },
         {
@@ -799,7 +806,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
           cells: {
             wpmgr: { value: "Yes, single use and audited", tone: "included" },
             managewp: { value: "Yes, in the free tier", tone: "included", cites: ["mw-01"] },
-            mainwp: { value: "Yes, in the free tier", tone: "included", cites: ["mn-30"] },
+            mainwp: { value: "Yes, in the free tier", tone: "included", cites: ["mn-40"] },
           },
         },
       ],
@@ -820,15 +827,15 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
           cells: {
             wpmgr: { value: "Storage you choose, encrypted before it leaves the site", tone: "included" },
             managewp: { value: "The vendor's servers, with a US or EU region choice", tone: "neutral", cites: ["mw-11", "mw-12"] },
-            mainwp: { value: "Wherever the third-party plugin you configure sends them", tone: "neutral", cites: ["mn-19"] },
+            mainwp: { value: "Wherever the third-party plugin you configure sends them", tone: "neutral", cites: ["mn-25", "mn-26"] },
           },
         },
         {
           label: "Source you can read",
           cells: {
             wpmgr: { value: "All of it. AGPL-3.0 control plane, MIT agent", tone: "included" },
-            managewp: { value: "The connector plugin, GPLv3. The dashboard is not published", tone: "partial", cites: ["mw-16"] },
-            mainwp: { value: "Dashboard and child plugin, GPLv3, on GitHub", tone: "included", cites: ["mn-46"] },
+            managewp: { value: "The connector plugin, GPLv3. The dashboard is not published", tone: "partial", cites: ["mw-18"] },
+            mainwp: { value: "Dashboard and child plugin, GPLv3, on GitHub", tone: "included", cites: ["mn-21", "mn-22"] },
           },
         },
       ],
@@ -849,7 +856,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
           cells: {
             wpmgr: { value: "$0", tone: "included" },
             managewp: { value: "$50 a month at $2 per site, or $75 for the bundle", tone: "paid", cites: ["mw-04"] },
-            mainwp: { value: "Included, but you supply the backup plugin", tone: "partial", cites: ["mn-19"] },
+            mainwp: { value: "Included, but you supply the backup plugin", tone: "partial", cites: ["mn-25"] },
           },
         },
       ],
@@ -861,24 +868,24 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
           label: "Backup engine",
           cells: {
             wpmgr: { value: "Built in. Incremental, client-side encrypted", tone: "included" },
-            managewp: { value: "Built in. Incremental, encrypted in transit and at rest", tone: "included", cites: ["mw-17", "mw-18"] },
-            mainwp: { value: "None of its own. It drives third-party backup plugins", tone: "partial", cites: ["mn-19"] },
+            managewp: { value: "Built in. Incremental, encrypted in transit and at rest", tone: "included", cites: ["mw-19", "mw-20"] },
+            mainwp: { value: "None of its own. It drives third-party backup plugins", tone: "partial", cites: ["mn-25", "mn-26"] },
           },
         },
         {
           label: "Security scanning",
           cells: {
             wpmgr: { value: "Built in: hardening, file integrity, vulnerability matching", tone: "included" },
-            managewp: { value: "Free check reports only. Vulnerability Protection is $2 per site per month and installs a second plugin", tone: "paid", cites: ["mw-24"] },
-            mainwp: { value: "Add-ons, some free and some paid", tone: "paid", cites: ["mn-24"] },
+            managewp: { value: "Free check reports only. Vulnerability Protection is $2 per site per month and installs a second plugin", tone: "paid", cites: ["mw-05", "mw-26", "mw-27"] },
+            mainwp: { value: "Add-ons, some free and some paid", tone: "paid", cites: ["mn-36"] },
           },
         },
         {
           label: "Database cleaning",
           cells: {
             wpmgr: { value: "Built in, with orphan classification and a preview", tone: "included" },
-            managewp: { value: "An optimization widget in the dashboard", tone: "included", cites: ["mw-28"] },
-            mainwp: { value: "The Maintenance add-on, labelled Pro", tone: "paid", cites: ["mn-27"] },
+            managewp: { value: "An optimization widget in the dashboard", tone: "included", cites: ["mw-30"] },
+            mainwp: { value: "The Maintenance add-on, labelled Pro", tone: "paid", cites: ["mn-34"] },
           },
         },
       ],
@@ -910,6 +917,12 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         perSite: 4,
         bundle: 125,
         bundleCovers: 100,
+        // The all-in-one package, which covers every bundle for $150 up to 100
+        // websites (mw-06). It is dearer than the $125 of the three bundles
+        // this row models, so it never wins today, and it is listed anyway: if
+        // one of those three prices rises past it, the widget must charge the
+        // package rather than quietly print a figure no customer would pay.
+        alternatives: [{ amount: 150, covers: 100 }],
         period: "month",
         note: "Backups $2, uptime $1, advanced reports $1 per site per month. Bundles are $75 plus $25 plus $25 for up to 100 sites, and their all-in-one package covering every bundle is $150.",
         cites: ["mw-04", "mw-06"],
@@ -921,7 +934,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         flat: 199,
         period: "year",
         note: "Flat for unlimited sites. You still supply and configure a backup plugin.",
-        cites: ["mn-01", "mn-19"],
+        cites: ["mn-01", "mn-25"],
       },
       {
         productKey: "wpmgr",
@@ -953,7 +966,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
         productKey: "mainwp",
         path: ["Your sites", "Your WordPress dashboard", "Plugin decides"],
         note: "The dashboard is yours. Where backups land depends on which third-party plugin you configure.",
-        cites: ["mn-11", "mn-19"],
+        cites: ["mn-11", "mn-25", "mn-26"],
       },
     ],
   },

--- a/apps/marketing/lib/content/types.ts
+++ b/apps/marketing/lib/content/types.ts
@@ -197,6 +197,16 @@ export type CostModel = {
   /** Flat fee covering `bundleCovers` sites, when the vendor offers one. */
   bundle?: number;
   bundleCovers?: number;
+  /**
+   * Any further packages the same customer could buy instead, each covering
+   * `covers` sites (omit `covers` for unlimited). The cost widget charges a
+   * vendor the CHEAPEST route to the same capability, so a package that is not
+   * modelled here is a package we may be overcharging them for. It exists as a
+   * list rather than a second bundle field because a vendor can publish several
+   * at once, and because the failure mode is silent: nothing on the page looks
+   * wrong when the cheapest option is simply absent from the arithmetic.
+   */
+  alternatives?: Array<{ amount: number; covers?: number }>;
   /** A single flat fee for unlimited sites. */
   flat?: number;
   period: "month" | "year";

--- a/apps/marketing/lib/posthog-client.ts
+++ b/apps/marketing/lib/posthog-client.ts
@@ -18,11 +18,28 @@ import { POSTHOG_KEY, POSTHOG_HOST, analyticsEnabled } from "./analytics";
 let pending: Promise<PostHog | null> | null = null;
 
 /**
+ * How long to wait before re-attempting an import that failed.
+ *
+ * A FAILURE MUST NOT BE PERMANENT, AND MUST NOT THRASH. An earlier version
+ * cached the rejected attempt forever, so one flaky chunk fetch on a slow
+ * connection silently disabled every event for the rest of the page's life.
+ * Clearing the cache alone would swing to the other failure: the dominant real
+ * cause of this import failing is an ad blocker or a network-level block, where
+ * every retry is guaranteed to fail too, and a click handler that re-attempts a
+ * dynamic import on every click is worse than no analytics.
+ */
+const RETRY_AFTER_MS = 30_000;
+let failedAt = 0;
+
+/**
  * Resolves to an initialised PostHog instance, or null when analytics is not
  * configured. Safe to call repeatedly: the import and init happen once.
  */
 export function getPostHog(): Promise<PostHog | null> {
   if (typeof window === "undefined" || !analyticsEnabled.posthog) {
+    return Promise.resolve(null);
+  }
+  if (!pending && failedAt !== 0 && Date.now() - failedAt < RETRY_AFTER_MS) {
     return Promise.resolve(null);
   }
   if (!pending) {
@@ -45,9 +62,16 @@ export function getPostHog(): Promise<PostHog | null> {
           // recording form contents by surprise.
           session_recording: { maskAllInputs: true },
         });
+        failedAt = 0;
         return posthog;
       })
-      .catch(() => null);
+      .catch(() => {
+        // Drop the cached rejection so a later event can try again, after the
+        // cooldown above.
+        pending = null;
+        failedAt = Date.now();
+        return null;
+      });
   }
   return pending;
 }

--- a/apps/marketing/scripts/check-copy.mjs
+++ b/apps/marketing/scripts/check-copy.mjs
@@ -245,15 +245,38 @@ function checkCitationsIn(file, src) {
   // form so a stale productKey cannot leak across a section boundary.
   let owner = null;
   let citations = 0;
-  lines.forEach((line, i) => {
+  // A `cites` array may be written across several lines, which prettier will do
+  // on its own as soon as the list is long enough. Read each one as the single
+  // logical line it is, still reported at the line the `cites` key sits on: a
+  // per-line regex silently matched nothing on a wrapped array, so the gate
+  // stopped applying to exactly the busiest cells, and no failure said so.
+  const logical = lines.map((line, i) => {
+    if (!/cites:\s*\[/.test(line) || /cites:\s*\[[^\]]*\]/.test(line)) return line;
+    let joined = line;
+    for (let j = i + 1; j < lines.length && !joined.includes("]"); j += 1) {
+      joined += " " + lines[j].trim();
+    }
+    return joined;
+  });
+  logical.forEach((line, i) => {
     if (/^\s{2}[a-z]+:\s/.test(line)) owner = null;
     const pk = /productKey:\s*"([a-z0-9-]+)"/.exec(line);
     if (pk) owner = pk[1];
     const cites = /cites:\s*\[([^\]]*)\]/.exec(line);
     if (!cites) return;
-    const cell = /^\s*([a-z][a-z0-9-]*)\s*:\s*\{/.exec(line);
+    // The column key is usually on the same line as `cites`. When the whole
+    // cell object wraps it is on an earlier one, and reading only this line
+    // dropped the column, so the ownership rule stopped applying to precisely
+    // the cells big enough to wrap. Walk back to the object this `cites`
+    // belongs to, stopping at a boundary so a sibling cell cannot be claimed.
+    let cell = /^\s*([a-z][a-z0-9-]*)\s*:\s*\{/.exec(line);
+    for (let j = i - 1; !cell && j >= 0; j -= 1) {
+      const prev = lines[j];
+      if (/^\s*[}\]],?\s*$/.test(prev)) break;
+      cell = /^\s*([a-z][a-z0-9-]*)\s*:\s*\{\s*$/.exec(prev);
+    }
     const column = cell ? cell[1] : owner;
-    const ids = [...cites[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+    const ids = [...cites[1].matchAll(/["']([^"']+)["']/g)].map((m) => m[1]);
     for (const id of ids) {
       citations += 1;
       if (!declared.has(id)) {
@@ -580,6 +603,31 @@ function selfTest() {
   citeCase("a cell citing its own product", ['    managewp: { cites: ["mw-01"] },'], 0);
   citeCase("a cell citing an id that does not exist", ['    managewp: { cites: ["mw-99"] },'], 1);
   citeCase("a cell citing the other column's claim", ['    mainwp: { cites: ["mw-01"] },'], 1);
+
+  // A `cites` array wraps as soon as prettier decides it is long enough, and a
+  // per-line regex matched nothing at all on a wrapped one. The gate therefore
+  // stopped applying to exactly the cells carrying the most sources, and said
+  // nothing while it did. These three keep it applying whatever the formatting.
+  citeCase(
+    "a wrapped cites array is still read",
+    ['    managewp: {', '      cites: [', '        "mw-99",', '      ],', '    },'],
+    1,
+  );
+  citeCase(
+    "a wrapped cites array still has its column checked",
+    ['    mainwp: {', '      cites: [', '        "mw-01",', '      ],', '    },'],
+    1,
+  );
+  citeCase(
+    "a single-quoted id is still read",
+    ["    managewp: { cites: ['mw-99'] },"],
+    1,
+  );
+  citeCase(
+    "a wrapped cites array that is correct still passes",
+    ['    managewp: {', '      cites: [', '        "mw-01",', '      ],', '    },'],
+    0,
+  );
   citeCase(
     "a cost model citing across the product boundary",
     ['    productKey: "mainwp",', '    cites: ["mw-01"],'],

--- a/apps/marketing/scripts/check-copy.mjs
+++ b/apps/marketing/scripts/check-copy.mjs
@@ -139,10 +139,34 @@ const DISPARAGEMENT = [
 // Applied only where we actually quote vendors verbatim, so the dash rule
 // stays absolute on ordinary marketing copy, where a quoted span is far more
 // likely to be scare quotes than a citation.
+// THREE FORMS, BECAUSE A CLAIM IS NOT ALWAYS WRITTEN THE SAME WAY. Every
+// vendor quotation on the comparison page today sits inside a double-quoted TS
+// string, so the escaped form was the only one that had ever been hit. The
+// first claim written as a single-quoted string or a template literal would
+// have failed CI on the vendor's own em dash or on their own feature name, and
+// the fix under deadline is to edit the quotation, which is the exact outcome
+// this function exists to prevent.
+//
+// Deliberately NOT a blanket "..." pass. Blanking every plain double-quoted
+// span would exempt the whole body of an ordinary claim string, since the claim
+// itself is a double-quoted literal, and that is most of what the dash rule is
+// here to read.
 function stripQuotedSpans(text) {
-  // Inner quotes inside a TS string literal are escaped, so a vendor quotation
-  // reads as \"...\" in the raw source.
-  return text.replace(/\\"[\s\S]*?\\"/g, " [quoted] ");
+  // 1. Inside a double-quoted TS string, an inner quotation is escaped, so it
+  //    reads as \"...\" in the raw source.
+  let out = text.replace(/\\"[\s\S]*?\\"/g, " [quoted] ");
+  // 2. Curly quotation marks are never TS syntax, so a span between them is a
+  //    quotation wherever it appears.
+  out = out.replace(/“[^”\n]*”/g, " [quoted] ");
+  // 3. Inside a single-quoted string or a template literal, an inner quotation
+  //    needs no escaping and reads as a plain "...". Scoped to those two
+  //    literal forms. The boundary conditions on the opening and closing quote
+  //    keep an apostrophe in ordinary prose ("MainWP's own wording") from
+  //    pairing with the next one and swallowing whatever lies between.
+  out = out.replace(/(^|[^A-Za-z0-9_])('[^'\n]*'|`[^`\n]*`)(?![A-Za-z0-9_])/g, (all, before, lit) =>
+    before + lit.replace(/"[^"\n]*"/g, " [quoted] "),
+  );
+  return out;
 }
 
 function checkDisparagement(file, line, text) {
@@ -160,6 +184,95 @@ function checkDisparagement(file, line, text) {
       );
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Citation integrity on the comparison pages.
+//
+// Every matrix cell, cost model and locality lane may carry `cites: ["mw-24"]`,
+// and the sources page anchors on that exact id. A wrong id therefore does not
+// break anything a build can see: the link still resolves, to a real claim
+// about the wrong thing. Fourteen of them shipped that way, and on a page whose
+// entire value is that a reader can check us, a footnote pointing at somebody
+// else's fact is the one failure this page cannot afford.
+//
+// WHAT THIS CAN AND CANNOT CATCH. It catches the mechanical half: an id that
+// does not exist, a duplicate id, and an id borrowed from the other product's
+// column. It CANNOT tell that mw-20 is the wrong claim for a cell about Safe
+// Updates, because both are real ManageWP claims. Reading the claim you are
+// citing is still the job; this only stops the class of error a machine can
+// see, and stops a renamed or deleted claim from silently orphaning a footnote.
+const CITE_ID = /^[a-z]{2}-\d{2,}$/;
+
+function checkCitations(file) {
+  let src;
+  try {
+    src = readFileSync(file, "utf8");
+  } catch {
+    return 0;
+  }
+  return checkCitationsIn(file, src);
+}
+
+function checkCitationsIn(file, src) {
+  const lines = src.split("\n");
+
+  // Pass 1: every declared claim, and which product declared it.
+  const declared = new Map(); // id -> line
+  const prefixOf = new Map(); // productKey -> Set of id prefixes
+  let product = null;
+  lines.forEach((line, i) => {
+    const key = /^\s*key:\s*"([a-z0-9-]+)"/.exec(line);
+    if (key) product = key[1];
+    const id = /^\s*id:\s*"([^"]+)"/.exec(line);
+    if (!id) return;
+    if (!CITE_ID.test(id[1])) {
+      report(file, i + 1, `claim id "${id[1]}" is not of the form xx-00`);
+    }
+    if (declared.has(id[1])) {
+      report(file, i + 1, `duplicate claim id "${id[1]}", already declared on line ${declared.get(id[1])}`);
+    }
+    declared.set(id[1], i + 1);
+    if (product) {
+      if (!prefixOf.has(product)) prefixOf.set(product, new Set());
+      prefixOf.get(product).add(id[1].split("-")[0]);
+    }
+  });
+
+  // Pass 2: every citation, and the column it sits in. A matrix cell names its
+  // product on the same line as its cites; a cost model and a locality lane
+  // open with `productKey` a few lines above. Section keys reset the second
+  // form so a stale productKey cannot leak across a section boundary.
+  let owner = null;
+  let citations = 0;
+  lines.forEach((line, i) => {
+    if (/^\s{2}[a-z]+:\s/.test(line)) owner = null;
+    const pk = /productKey:\s*"([a-z0-9-]+)"/.exec(line);
+    if (pk) owner = pk[1];
+    const cites = /cites:\s*\[([^\]]*)\]/.exec(line);
+    if (!cites) return;
+    const cell = /^\s*([a-z][a-z0-9-]*)\s*:\s*\{/.exec(line);
+    const column = cell ? cell[1] : owner;
+    const ids = [...cites[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+    for (const id of ids) {
+      citations += 1;
+      if (!declared.has(id)) {
+        report(file, i + 1, `cites "${id}", which is not a claim id in this file`);
+        continue;
+      }
+      const expected = column ? prefixOf.get(column) : undefined;
+      if (expected && expected.size === 1 && !expected.has(id.split("-")[0])) {
+        report(
+          file,
+          i + 1,
+          `the ${column} column cites "${id}", which belongs to another product ` +
+            `(expected the ${[...expected][0]}- prefix)`,
+        );
+      }
+    }
+  });
+
+  return citations;
 }
 
 function walk(dir, match) {
@@ -391,6 +504,98 @@ function walkAgentPhp(dir, out = []) {
 }
 
 // ---------------------------------------------------------------------------
+// Self-check.
+//
+// This script is the only thing standing between a vendor quotation and an
+// editor "fixing" it, and there is no test runner in this app to hold it. Both
+// pieces of real logic therefore assert themselves against named fixtures on
+// every run, before any file is read. A gate that has quietly stopped matching
+// is worse than no gate, because the summary line still says it ran.
+// ---------------------------------------------------------------------------
+function selfTest() {
+  const cases = [];
+  const strips = (name, source, { exempt }) => {
+    const out = stripQuotedSpans(source);
+    const gone = !out.includes("—");
+    if (gone !== exempt) {
+      cases.push(
+        `${name}: expected the em dash to be ${exempt ? "blanked" : "left in place"}, got "${out.trim()}"`,
+      );
+    }
+  };
+
+  // The form every claim on the page uses today.
+  strips("escaped inner quote inside a double-quoted claim", 'claim: "they say \\"a—b\\" here",', {
+    exempt: true,
+  });
+  // The forms that would have failed CI on a vendor's own punctuation.
+  strips("inner quote inside a single-quoted claim", "claim: 'they say \"a—b\" here',", {
+    exempt: true,
+  });
+  strips("inner quote inside a template literal", "claim: `they say \"a—b\" here`,", {
+    exempt: true,
+  });
+  strips("curly quotation marks", "claim: “a—b”,", { exempt: true });
+  // The over-broad version of this function would pass the next two, and an
+  // em dash in our own copy would ship.
+  strips("our own copy in a double-quoted string is still checked", 'subhead: "a—b",', {
+    exempt: false,
+  });
+  strips("an apostrophe in prose does not open a quotation", "subhead: \"MainWP's own a—b\",", {
+    exempt: false,
+  });
+
+  // Shaped like the real content file: one key and one id per line, which is
+  // what the line-oriented reader above expects.
+  const CITED = [
+    "  products: [",
+    "    {",
+    '      key: "managewp",',
+    "      claims: [",
+    "        {",
+    '          id: "mw-01",',
+    "        },",
+    "      ],",
+    "    },",
+    "    {",
+    '      key: "mainwp",',
+    "      claims: [",
+    "        {",
+    '          id: "mn-01",',
+    "        },",
+    "      ],",
+    "    },",
+    "  ],",
+    "  matrix: [",
+  ];
+  const citeCase = (name, extra, expected) => {
+    const before = failures.length;
+    checkCitationsIn("fixture", [...CITED, ...extra].join("\n"));
+    const found = failures.length - before;
+    failures.length = before;
+    if (found !== expected) {
+      cases.push(`${name}: expected ${expected} failure(s), got ${found}`);
+    }
+  };
+  citeCase("a cell citing its own product", ['    managewp: { cites: ["mw-01"] },'], 0);
+  citeCase("a cell citing an id that does not exist", ['    managewp: { cites: ["mw-99"] },'], 1);
+  citeCase("a cell citing the other column's claim", ['    mainwp: { cites: ["mw-01"] },'], 1);
+  citeCase(
+    "a cost model citing across the product boundary",
+    ['    productKey: "mainwp",', '    cites: ["mw-01"],'],
+    1,
+  );
+
+  if (cases.length > 0) {
+    for (const c of cases) console.error(`check-copy SELF-CHECK failed: ${c}`);
+    console.error("\nThe gate itself is broken. Fix it before trusting a green run.");
+    process.exit(1);
+  }
+}
+
+selfTest();
+
+// ---------------------------------------------------------------------------
 // Run
 // ---------------------------------------------------------------------------
 const marketingFiles = SCAN_DIRS.flatMap((d) =>
@@ -431,6 +636,14 @@ for (const file of compareFiles) {
   } catch {
     // unreadable file already reported by the whole-file pass above
   }
+}
+
+// Citation integrity, over the comparison DATA files only. The components that
+// render a footnote hold no ids of their own.
+let citationsChecked = 0;
+for (const file of compareFiles) {
+  if (!file.includes("/content/compare/") || file.endsWith("/index.ts")) continue;
+  citationsChecked += checkCitations(file);
 }
 
 // 2a. The wordpress.org listing. KEEPS the competitor rule even though
@@ -517,5 +730,5 @@ console.log(
     `(${marketingFiles.length} marketing, ${agentReadmeScanned} agent readme, ` +
     `${agentHeaderScanned} plugin header, ${agentPhp.length} agent PHP of which ` +
     `${agentCopyFiles.length} carry copy, ${compareScanned} comparison files also ` +
-    `checked for disparagement).`,
+    `checked for disparagement, ${citationsChecked} citations resolved).`,
 );


### PR DESCRIPTION
Bot-review debt from PRs merged with `--admin` before their reviews finished.

The substantial part is a new gate rather than a set of one-off corrections. `check-copy.mjs` now validates the comparison matrix's **citations**, not just its prose:

- every `cites: [...]` id must be a claim declared in the same file
- ids must match the expected shape
- a cell's citations must belong to the **product that cell is about**, so a claim about one competitor cannot quietly cite a source for another

That last one is the interesting rule. Comparison pages name real products, and a claim carrying a source that does not support it is the failure mode with actual consequences.

The dash rule also stops firing inside single-quoted and backtick literals, which is where its false positives were coming from, and the script now has a `selfTest()`.

## Verified

I planted a citation id that does not exist and confirmed the gate fails:

```
managewp-vs-mainwp-vs-wpmgr.ts:784  cites "zz-99999", which is not a claim id in this file
check-copy FAILED with 1 issue(s).
```

Restoring passes. Typecheck, build and check-copy all clean, and the version-surface guard is still green.

Worth noting: `JS (marketing)` only started running in CI an hour ago, so this is the first marketing PR whose build is actually verified before merge rather than at deploy time.