### PR TITLE
ci: actually run the apps/api integration tests

### DIFF
--- a/.github/workflows/api-integration.yml
+++ b/.github/workflows/api-integration.yml
@@ -73,7 +73,18 @@ jobs:
   # GitHub counts as satisfying a required check. So the filter has to be a job
   # condition, which means it has to be computed by a job.
   #
-  # It fails OPEN. If the diff cannot be computed for any reason, the lane runs.
+  # It fails OPEN, at both levels, and the second one is easy to miss.
+  #
+  #   1. Inside the script: if the diff cannot be computed, it prints why and
+  #      emits api=true rather than guessing.
+  #   2. If this whole JOB fails or is skipped: the lane's `if:` below is written
+  #      so the lane still runs. That is not a nicety. A job whose `needs`
+  #      failed is reported as SKIPPED, and GitHub counts a skipped required
+  #      check as satisfied, so without that the sequence "checkout flakes ->
+  #      changes fails -> integration skipped -> required check green" would let
+  #      an unverified apps/api change merge, which is the precise false-green
+  #      this lane exists to prevent.
+  #
   # For a lane guarding privilege-escalation RLS, wasting nine minutes is the
   # cheaper mistake.
   changes:
@@ -130,7 +141,19 @@ jobs:
   integration:
     name: Go integration (apps/api/tests)
     needs: changes
-    if: needs.changes.outputs.api == 'true'
+    # Reads as "run unless we positively established there is nothing to test",
+    # NOT "run if we established there is". The difference only shows up when
+    # the `changes` job itself dies: its output is then empty, which is not
+    # 'false', so the lane runs anyway. Written the obvious way round
+    # (`== 'true'`) a dead `changes` job would skip the lane, and a skipped job
+    # counts as a satisfied required check, so a checkout flake would silently
+    # buy a free pass on an apps/api change.
+    #
+    # !cancelled() rather than always(): `needs` alone would skip this on a
+    # failed dependency, so the condition has to survive that, but a genuinely
+    # cancelled run (superseded push, manual cancel) should not resurrect a
+    # 20-minute job.
+    if: ${{ !cancelled() && needs.changes.outputs.api != 'false' }}
     runs-on: ubuntu-latest
     # MUST stay strictly greater than the `go test -timeout` below. If the job
     # timeout fires first the runner kills the process and you get no output at

--- a/.github/workflows/api-integration.yml
+++ b/.github/workflows/api-integration.yml
@@ -232,11 +232,17 @@ jobs:
       #
       # MEASURED HERE, on ubuntu-latest, while building this lane: `go test`
       # spans of roughly 970s to 1120s, worst 1121s against the 2700s ceiling,
-      # so about 2.4x headroom on a spread of 14%. Passing runs and the
-      # deliberately-broken ones INTERLEAVE across that range, so failing does
-      # not measurably change the duration: a failed test still leaves the rest
-      # of the package to execute. Do not read a slow run as a sign of trouble;
-      # read its elapsed number against the ceiling.
+      # so better than 2x headroom at the worst observed, on a run-to-run spread
+      # comfortably under 20%. Those two shape figures are stated loosely on
+      # purpose: an exact percentage is derived from the min and the max, so it
+      # goes stale the first time a run lands outside the sample, which is the
+      # re-counting trap described in the next paragraph. It already happened
+      # once here, to a "14%" computed over the first five runs.
+      #
+      # Passing runs and the deliberately-broken ones INTERLEAVE across that
+      # range, so failing does not measurably change the duration: a failed test
+      # still leaves the rest of the package to execute. Do not read a slow run
+      # as a sign of trouble; read its elapsed number against the ceiling.
       #
       # THAT RANGE IS A HISTORICAL SAMPLE, not a live maximum, and it is stated
       # without a run count on purpose. The whole reason this file exists is

--- a/.github/workflows/api-integration.yml
+++ b/.github/workflows/api-integration.yml
@@ -202,12 +202,12 @@ jobs:
       # lane that does not set an explicit timeout WILL flake, and a flaky
       # required lane gets ignored and then deleted, which is worse than no lane.
       #
-      # MEASURED HERE, on ubuntu-latest, on the two runs that introduced this
-      # file: 983s for the passing run and 1103s for a deliberately-failing one
-      # (a failing run is the slower case, since a failed test still leaves the
-      # rest of the package to execute). Call it 1100s observed worst case
-      # against a 2700s ceiling, so roughly 2.4x headroom, on a package whose
-      # run-to-run spread was about 12%.
+      # MEASURED HERE, on ubuntu-latest, across the four runs that introduced
+      # this file: 983s and 1089s for the two passing runs, 1103s and 1121s for
+      # the two deliberately-failing ones (a failing run is the slower case,
+      # since a failed test still leaves the rest of the package to execute).
+      # Worst observed 1121s against a 2700s ceiling, so 2.4x headroom, on a
+      # package whose run-to-run spread across those four was 14%.
       #
       # The wall time is printed to the step summary on every run. If it ever
       # creeps past about 1800s, shard the lane by -run regex rather than
@@ -290,17 +290,43 @@ jobs:
             echo "m112 proof ok: ${t}"
           done
 
+      # Written to BOTH the step summary and stdout, deliberately. The summary
+      # renders for a human in the browser, but there is no API for reading step
+      # summaries, so from a terminal the wall time this lane reports about
+      # itself was unreadable. Anyone auditing the timeout margin needs it
+      # without a browser. stdout lands in `gh run view --log` and in the
+      # uploaded artifact below.
       - name: Summary
         if: always()
         shell: bash
         run: |
+          log="$RUNNER_TEMP/integration.log"
+
+          # `grep -c` PRINTS 0 and EXITS 1 when it matches nothing, so the
+          # obvious `$(grep -c ... || echo 0)` runs BOTH sides and emits the
+          # count twice, on exactly the runs that matter most: every green one,
+          # where the failing count is zero. That shipped a stray "0" line into
+          # the summary of both passing runs before anyone could see it, because
+          # the summary only rendered in the browser. `|| true` swallows the
+          # exit status without contributing a second value, which is the form
+          # the verification step above already uses.
+          passed=0
+          failed=0
+          if [ -f "$log" ]; then
+            passed=$(grep -cE '^--- PASS: ' "$log" || true)
+            failed=$(grep -cE '^--- FAIL: ' "$log" || true)
+          fi
+
+          # Not "${elapsed_seconds:-unknown}s", which renders as "unknowns".
+          if [ -n "${elapsed_seconds:-}" ]; then wall="${elapsed_seconds}s"; else wall="unknown"; fi
+
           {
             echo "### apps/api integration lane"
             echo
-            echo "- wall time: ${elapsed_seconds:-unknown}s (go test -timeout 45m)"
-            echo "- passing: $(grep -cE '^--- PASS: ' "$RUNNER_TEMP/integration.log" 2>/dev/null || echo 0)"
-            echo "- failing: $(grep -cE '^--- FAIL: ' "$RUNNER_TEMP/integration.log" 2>/dev/null || echo 0)"
-          } >> "$GITHUB_STEP_SUMMARY"
+            echo "- wall time: $wall (ceiling: go test -timeout 45m, so 2700s)"
+            echo "- passing: $passed"
+            echo "- failing: $failed"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
       # A 20-minute lane that fails should not make you re-run it to find out
       # why. Keep the full -v log.

--- a/.github/workflows/api-integration.yml
+++ b/.github/workflows/api-integration.yml
@@ -1,0 +1,300 @@
+name: api-integration
+
+# The container-backed integration lane for apps/api/tests.
+#
+# WHY THIS FILE EXISTS.
+#
+# ci.yml's Go job excludes `/apps/api/tests` from `go test` and its comment said
+# those tests "belong in a separate lane". That lane did not exist. From the day
+# the exclusion landed until this file, 343 tests were compile-checked by Build
+# and Vet and never executed by anything. Among them are the m112 (GH #380)
+# site-scope RLS policy proofs in tests/email_site_scope_rls_integration_test.go,
+# which are the entire defence for seven closed privilege-escalation doors where
+# a one-site collaborator could reach the whole organisation. A regression in
+# those merged silently and still type-checked.
+#
+# Note on scope, so nobody reads more into this lane than is true: the m112
+# proofs that go THROUGH the repo (TestEveryOperatorPathRunsThroughScopedTenantTx,
+# TestRepoRefusesOrgConfigUpsertForSiteScopedPrincipal,
+# TestAgentTransactionNeverCarriesSiteScope and their siblings) live in
+# internal/email, which ci.yml has always run, and they still run there in about
+# 57s. What was unprotected is the other half of m112: the direct-SQL proofs that
+# the POLICIES THEMSELVES are right, asserted against the real schema as a
+# non-superuser. Both halves are needed. Neither is redundant: the repo half
+# fails when the dispatch stops setting app.site_scope, the policy half fails
+# when the policy stops refusing. This lane covers the policy half, plus the
+# other ~320 container tests in the package (billing, backups, audit chain,
+# uptime, tenant isolation, social identity).
+#
+# COST AND RISK, stated so the next person can revisit this knowingly.
+# Cost: one ubuntu-latest runner for the wall time reported in the PR that added
+# this file, plus roughly 700MB of Docker image pulls, on PRs that touch
+# apps/api. Risk it buys down: a silent regression in privilege-escalation RLS
+# is a security incident, not a bug. That asymmetry is why this runs per PR and
+# not only nightly. If the wall time ever grows past the point where it is
+# tolerable, shard it by -run regex before you demote it to nightly, because a
+# nightly-only lane finds the incident after the merge that caused it.
+
+on:
+  # Per PR, so a regression is caught before it reaches main rather than after.
+  # Deliberately NOT `push: branches: ["**"]` like ci.yml: for a same-repo PR
+  # that would run this expensive lane twice per push, once for each event.
+  pull_request:
+  # On main as well. A PR can be green and main still go red, because main is
+  # the merge result and because some gates read live external state. Cheap
+  # insurance on the branch that ships.
+  push:
+    branches: [main]
+  # Nightly at 03:00 UTC. Catches rot that no diff touches: a base image tag
+  # that changed under us, a testcontainers or Docker behaviour change on the
+  # runner image, a flake that only shows up over repeated runs. Also means the
+  # lane's health is known even in a week where nobody touched apps/api.
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: api-integration-${{ github.ref }}
+  # Cancel superseded PR runs (the later push is the one that matters), but
+  # never cancel a main or nightly run: on those refs the result IS the record.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  # ---- Should the lane run at all? -----------------------------------------
+  # This exists to solve one specific problem. Putting a `paths:` filter on the
+  # `pull_request:` trigger above would be the obvious way to skip web-only and
+  # docs-only PRs, and it would DEADLOCK the repo the moment this lane is added
+  # to branch protection: a workflow skipped by a path filter never posts a
+  # check at all, so a required check stays pending forever and the PR can never
+  # merge. A job skipped by an `if:` condition does post, as "skipped", which
+  # GitHub counts as satisfying a required check. So the filter has to be a job
+  # condition, which means it has to be computed by a job.
+  #
+  # It fails OPEN. If the diff cannot be computed for any reason, the lane runs.
+  # For a lane guarding privilege-escalation RLS, wasting nine minutes is the
+  # cheaper mistake.
+  changes:
+    name: Detect apps/api changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          # Full history so the PR base commit is present for the diff below.
+          fetch-depth: 0
+
+      - id: filter
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # push to main, schedule and manual dispatch always run: there is no
+          # meaningful "base" to diff against and those are the runs whose whole
+          # point is to check the branch as it stands.
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "event is $EVENT_NAME, running the lane unconditionally"
+            echo "api=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! changed=$(git diff --name-only "$BASE_SHA...$HEAD_SHA" 2>/dev/null); then
+            echo "could not diff $BASE_SHA...$HEAD_SHA; failing open and running the lane"
+            echo "api=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "changed files:"
+          echo "$changed"
+
+          # apps/api holds the code, the migrations and the tests themselves.
+          # This workflow file is included so a change to the lane is always
+          # exercised by the lane.
+          if echo "$changed" | grep -qE '^(apps/api/|\.github/workflows/api-integration\.yml$)'; then
+            echo "api=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no apps/api changes; skipping the integration lane"
+            echo "api=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ---- The lane ------------------------------------------------------------
+  integration:
+    name: Go integration (apps/api/tests)
+    needs: changes
+    if: needs.changes.outputs.api == 'true'
+    runs-on: ubuntu-latest
+    # MUST stay strictly greater than the `go test -timeout` below. If the job
+    # timeout fires first the runner kills the process and you get no output at
+    # all; if Go's timeout fires first you get the panic with the full goroutine
+    # dump naming the test that hung, which is the difference between a
+    # diagnosable failure and a mystery.
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: apps/api
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.5"
+          cache-dependency-path: apps/api/go.sum
+
+      # The tests build their containers with testcontainers-go talking to the
+      # local Docker daemon (tcpostgres.Run / minio.Run / testcontainers.Run in
+      # tests/rls_integration_test.go, blobstore_integration_test.go,
+      # autologin_integration_test.go, metrics_integration_test.go). No `services:`
+      # block can substitute for that: the tests choose their own images, wait
+      # strategies and per-test lifecycle. ubuntu-latest ships a running daemon.
+      # This step asserts it rather than assuming it, because of the failure mode
+      # documented on the verification step below.
+      - name: Docker preflight
+        run: |
+          docker version
+          docker info --format 'server={{.ServerVersion}} driver={{.Driver}}'
+
+      # Pull the four images the package uses up front. Not required for
+      # correctness (testcontainers pulls on demand) but it moves roughly 700MB
+      # of network into a named step, so a registry problem reads as a pull
+      # failure instead of surfacing later as an inscrutable container start
+      # timeout inside some unrelated test. If a test adds a fifth image this
+      # list going stale costs nothing: that image just gets pulled inline.
+      - name: Pre-pull test container images
+        run: |
+          set -euo pipefail
+          for img in \
+            postgres:16-alpine \
+            redis:7-alpine \
+            minio/minio:RELEASE.2024-01-16T16-07-38Z \
+            clickhouse/clickhouse-server:24.3-alpine
+          do
+            echo "pulling $img"
+            docker pull --quiet "$img"
+          done
+
+      # GOWORK=off and CGO_ENABLED=0 mirror ci.yml's Go job and the production
+      # main-API image. One honest consequence: tests/media_encode_integration_test.go
+      # carries a `//go:build cgo` tag, so it is excluded here exactly as it is
+      # excluded everywhere else today. 343 of the package's 344 test functions
+      # run. Covering that last one means building lilliput's CGO codecs, which
+      # is what infra/Dockerfile.media-encoder exists for, and dragging that
+      # toolchain in here would trade a real flake risk for one test.
+      #
+      # -count=1 defeats the build cache so a green tick always means the tests
+      # ran, never that Go replayed a cached result.
+      #
+      # -timeout 45m is deliberate and is the reason this lane is not flaky.
+      # Measured on a developer machine: 522s for the package alone, but 601s
+      # when run as part of `go test ./...`, which BLEW Go's 10m default and
+      # panicked. The package sits right on the default, so any lane that does
+      # not set an explicit timeout will flake, and a flaky required lane gets
+      # ignored and then deleted, which is worse than no lane. A two-vCPU hosted
+      # runner is slower again than that developer machine, so the budget is set
+      # at roughly 3x the measured solo time. The actual wall time is printed by
+      # the summary step below; if it ever creeps within 2x of this number,
+      # shard the lane rather than raising the ceiling.
+      - name: Integration tests
+        shell: bash
+        env:
+          GOWORK: "off"
+          CGO_ENABLED: "0"
+        run: |
+          # pipefail is load-bearing. Piping into tee makes the shell report
+          # TEE's exit status, so a failed `go test` would read as success. That
+          # false-green class (a pipe swallowing the real exit code) has bitten
+          # this project's build and release commands before.
+          set -o pipefail
+          start=$(date +%s)
+          go test -v -count=1 -timeout 45m ./tests/ 2>&1 | tee "$RUNNER_TEMP/integration.log"
+          rc=$?
+          end=$(date +%s)
+          echo "elapsed_seconds=$(( end - start ))" >> "$GITHUB_ENV"
+          exit $rc
+
+      # THE MOST IMPORTANT STEP IN THIS FILE.
+      #
+      # Every container helper in the package (startPostgres and its 14 siblings)
+      # calls t.Skipf("skipping: cannot start ... container (docker unavailable?)")
+      # when it cannot reach a daemon. It SKIPS, it does not fail. So a runner
+      # image that one day ships without Docker, or a daemon that dies mid-job,
+      # produces 343 skips, `ok`, exit 0 and a green tick, and this lane would go
+      # on protecting nothing while looking like it protects everything. Green
+      # has to mean the tests ran.
+      #
+      # Three layers, weakest to strongest:
+      #   1. no test may have skipped for the docker-unavailable reason (today
+      #      that is the ONLY t.Skip reason anywhere in the package),
+      #   2. a floor on the number of passes, which catches a mass-skip through
+      #      some future route this check did not anticipate,
+      #   3. four m112 policy proofs named explicitly, because those are the
+      #      privilege-escalation guarantees this lane was built for and "they
+      #      ran and passed" is the claim worth asserting by name.
+      - name: Verify the lane really executed (a skipped lane is a false green)
+        shell: bash
+        run: |
+          set -euo pipefail
+          log="$RUNNER_TEMP/integration.log"
+
+          if grep -q 'docker unavailable' "$log"; then
+            echo "::error::tests skipped because Docker was unreachable; this lane proved nothing"
+            grep -n 'docker unavailable' "$log" | head -20
+            exit 1
+          fi
+
+          passed=$(grep -cE '^--- PASS: ' "$log" || true)
+          echo "passing tests: $passed"
+          # 343 run today. The floor leaves headroom for tests being renamed or
+          # retired without becoming a maintenance tax, while still being far
+          # above anything a mass-skip could produce.
+          if [ "$passed" -lt 320 ]; then
+            echo "::error::only $passed tests passed, expected at least 320; the package did not really run"
+            exit 1
+          fi
+
+          # m112 (GH #380) site-scope RLS policy proofs, by name.
+          for t in \
+            TestCollaboratorCannotUpdateTheOrgConfig \
+            TestCollaboratorCannotDeleteFleetSuppression \
+            TestEveryEmailTableCarriesTheSiteScopePolicies \
+            TestTenantIsolationStillHolds
+          do
+            if ! grep -qE "^--- PASS: ${t}( |\$)" "$log"; then
+              echo "::error::m112 proof ${t} did not pass in this run"
+              exit 1
+            fi
+            echo "m112 proof ok: ${t}"
+          done
+
+      - name: Summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### apps/api integration lane"
+            echo
+            echo "- wall time: ${elapsed_seconds:-unknown}s (go test -timeout 45m)"
+            echo "- passing: $(grep -cE '^--- PASS: ' "$RUNNER_TEMP/integration.log" 2>/dev/null || echo 0)"
+            echo "- failing: $(grep -cE '^--- FAIL: ' "$RUNNER_TEMP/integration.log" 2>/dev/null || echo 0)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # A 20-minute lane that fails should not make you re-run it to find out
+      # why. Keep the full -v log.
+      - name: Upload test log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-integration-log
+          path: ${{ runner.temp }}/integration.log
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/api-integration.yml
+++ b/.github/workflows/api-integration.yml
@@ -195,15 +195,24 @@ jobs:
       # ran, never that Go replayed a cached result.
       #
       # -timeout 45m is deliberate and is the reason this lane is not flaky.
-      # Measured on a developer machine: 522s for the package alone, but 601s
-      # when run as part of `go test ./...`, which BLEW Go's 10m default and
-      # panicked. The package sits right on the default, so any lane that does
-      # not set an explicit timeout will flake, and a flaky required lane gets
-      # ignored and then deleted, which is worse than no lane. A two-vCPU hosted
-      # runner is slower again than that developer machine, so the budget is set
-      # at roughly 3x the measured solo time. The actual wall time is printed by
-      # the summary step below; if it ever creeps within 2x of this number,
-      # shard the lane rather than raising the ceiling.
+      #
+      # THE DEFAULT WOULD NOT WORK. Measured on a developer machine: 522s for
+      # the package alone, but 601s as part of `go test ./...`, which blew Go's
+      # 10m default and panicked. The package sits right on the default, so a
+      # lane that does not set an explicit timeout WILL flake, and a flaky
+      # required lane gets ignored and then deleted, which is worse than no lane.
+      #
+      # MEASURED HERE, on ubuntu-latest, on the two runs that introduced this
+      # file: 983s for the passing run and 1103s for a deliberately-failing one
+      # (a failing run is the slower case, since a failed test still leaves the
+      # rest of the package to execute). Call it 1100s observed worst case
+      # against a 2700s ceiling, so roughly 2.4x headroom, on a package whose
+      # run-to-run spread was about 12%.
+      #
+      # The wall time is printed to the step summary on every run. If it ever
+      # creeps past about 1800s, shard the lane by -run regex rather than
+      # raising this ceiling: at that point the feedback delay is the problem,
+      # and raising the timeout only hides it.
       - name: Integration tests
         shell: bash
         env:
@@ -213,14 +222,19 @@ jobs:
           # pipefail is load-bearing. Piping into tee makes the shell report
           # TEE's exit status, so a failed `go test` would read as success. That
           # false-green class (a pipe swallowing the real exit code) has bitten
-          # this project's build and release commands before.
+          # this project's build and release commands before. `shell: bash`
+          # already sets it; restating it means the guarantee does not quietly
+          # disappear if this step ever loses that shell line.
           set -o pipefail
           start=$(date +%s)
-          go test -v -count=1 -timeout 45m ./tests/ 2>&1 | tee "$RUNNER_TEMP/integration.log"
-          rc=$?
-          end=$(date +%s)
-          echo "elapsed_seconds=$(( end - start ))" >> "$GITHUB_ENV"
-          exit $rc
+          # `|| rc=$?` rather than a bare call plus `rc=$?`: the shell also runs
+          # with -e, so a bare failing pipeline would abort the step right there
+          # and the elapsed time would never be recorded. That is precisely the
+          # run where you want to know how long it took before it fell over.
+          rc=0
+          go test -v -count=1 -timeout 45m ./tests/ 2>&1 | tee "$RUNNER_TEMP/integration.log" || rc=$?
+          echo "elapsed_seconds=$(( $(date +%s) - start ))" >> "$GITHUB_ENV"
+          exit "$rc"
 
       # THE MOST IMPORTANT STEP IN THIS FILE.
       #

--- a/.github/workflows/api-integration.yml
+++ b/.github/workflows/api-integration.yml
@@ -18,13 +18,13 @@ name: api-integration
 # TestRepoRefusesOrgConfigUpsertForSiteScopedPrincipal,
 # TestAgentTransactionNeverCarriesSiteScope and their siblings) live in
 # internal/email, which ci.yml has always run, and they still run there in about
-# 57s. What was unprotected is the other half of m112: the direct-SQL proofs that
-# the POLICIES THEMSELVES are right, asserted against the real schema as a
-# non-superuser. Both halves are needed. Neither is redundant: the repo half
-# fails when the dispatch stops setting app.site_scope, the policy half fails
-# when the policy stops refusing. This lane covers the policy half, plus the
-# other ~320 container tests in the package (billing, backups, audit chain,
-# uptime, tenant isolation, social identity).
+# a minute. What was unprotected is the other half of m112: the direct-SQL
+# proofs that the POLICIES THEMSELVES are right, asserted against the real
+# schema as a non-superuser. Both halves are needed. Neither is redundant: the
+# repo half fails when the dispatch stops setting app.site_scope, the policy
+# half fails when the policy stops refusing. This lane covers the policy half,
+# plus the other ~320 container tests in the package (billing, backups, audit
+# chain, uptime, tenant isolation, social identity).
 #
 # COST AND RISK, stated so the next person can revisit this knowingly.
 # Cost: one ubuntu-latest runner for the wall time reported in the PR that added
@@ -202,12 +202,30 @@ jobs:
       # lane that does not set an explicit timeout WILL flake, and a flaky
       # required lane gets ignored and then deleted, which is worse than no lane.
       #
-      # MEASURED HERE, on ubuntu-latest, across the four runs that introduced
-      # this file: 983s and 1089s for the two passing runs, 1103s and 1121s for
-      # the two deliberately-failing ones (a failing run is the slower case,
-      # since a failed test still leaves the rest of the package to execute).
-      # Worst observed 1121s against a 2700s ceiling, so 2.4x headroom, on a
-      # package whose run-to-run spread across those four was 14%.
+      # MEASURED HERE, on ubuntu-latest, over the five runs that introduced this
+      # file: three passing (983s, 1089s, 1119s) and two deliberately broken to
+      # prove the lane goes red (1103s, 1121s). Worst of those 1121s against the
+      # 2700s ceiling, so 2.4x headroom, on a run-to-run spread of 14%. Note the
+      # two sets INTERLEAVE (983 pass, 1089 pass, 1103 fail, 1119 pass,
+      # 1121 fail): failing does not measurably change the duration, because a
+      # failed test still leaves the rest of the package to execute. Do not read
+      # a slow run as a sign of trouble; read the elapsed number against the
+      # ceiling.
+      #
+      # THOSE FIVE ARE A HISTORICAL SAMPLE, not a live maximum. They are the
+      # observations that chose this ceiling, and a later run being slower does
+      # not falsify them or, on its own, mean anything is wrong. Every run
+      # prints its own wall time (see the Summary step), so read that for
+      # anything current and treat these five as the reason the number is 45m.
+      #
+      # TWO DIFFERENT NUMBERS, AND THEY DO NOT CONTRADICT EACH OTHER. The
+      # figures above are what `go test` reports for the package, which is
+      # exactly the span this -timeout governs. The "wall time" the Summary step
+      # prints is the whole STEP, module download and compile included, so it
+      # lands 90s to 130s higher: 1073s, 1179s, 1212s and 1219s on the four runs
+      # that recorded it. The ceiling on that larger number is the job's
+      # timeout-minutes: 60 above, whose worst case so far was 1255s of job time
+      # against 3600s. If you are auditing the margin, compare like with like.
       #
       # The wall time is reported on every run, to the step summary and to
       # stdout, so it can be read without a browser. If it ever creeps past

--- a/.github/workflows/api-integration.yml
+++ b/.github/workflows/api-integration.yml
@@ -202,30 +202,33 @@ jobs:
       # lane that does not set an explicit timeout WILL flake, and a flaky
       # required lane gets ignored and then deleted, which is worse than no lane.
       #
-      # MEASURED HERE, on ubuntu-latest, over the five runs that introduced this
-      # file: three passing (983s, 1089s, 1119s) and two deliberately broken to
-      # prove the lane goes red (1103s, 1121s). Worst of those 1121s against the
-      # 2700s ceiling, so 2.4x headroom, on a run-to-run spread of 14%. Note the
-      # two sets INTERLEAVE (983 pass, 1089 pass, 1103 fail, 1119 pass,
-      # 1121 fail): failing does not measurably change the duration, because a
-      # failed test still leaves the rest of the package to execute. Do not read
-      # a slow run as a sign of trouble; read the elapsed number against the
-      # ceiling.
+      # MEASURED HERE, on ubuntu-latest, while building this lane: `go test`
+      # spans of roughly 970s to 1120s, worst 1121s against the 2700s ceiling,
+      # so about 2.4x headroom on a spread of 14%. Passing runs and the
+      # deliberately-broken ones INTERLEAVE across that range, so failing does
+      # not measurably change the duration: a failed test still leaves the rest
+      # of the package to execute. Do not read a slow run as a sign of trouble;
+      # read its elapsed number against the ceiling.
       #
-      # THOSE FIVE ARE A HISTORICAL SAMPLE, not a live maximum. They are the
-      # observations that chose this ceiling, and a later run being slower does
-      # not falsify them or, on its own, mean anything is wrong. Every run
-      # prints its own wall time (see the Summary step), so read that for
-      # anything current and treat these five as the reason the number is 45m.
+      # THAT RANGE IS A HISTORICAL SAMPLE, not a live maximum, and it is stated
+      # without a run count on purpose. The whole reason this file exists is
+      # that ci.yml carried a hand-counted "262" that had drifted to 344 while
+      # nobody noticed, so a comment here that has to be re-counted after every
+      # run would repeat the same mistake. A later run landing outside this
+      # range falsifies nothing. Every run prints its own wall time (see the
+      # Summary step): read that for anything current, and treat this range as
+      # the reason the ceiling is 45m rather than as a live measurement.
       #
       # TWO DIFFERENT NUMBERS, AND THEY DO NOT CONTRADICT EACH OTHER. The
       # figures above are what `go test` reports for the package, which is
       # exactly the span this -timeout governs. The "wall time" the Summary step
       # prints is the whole STEP, module download and compile included, so it
-      # lands 90s to 130s higher: 1073s, 1179s, 1212s and 1219s on the four runs
-      # that recorded it. The ceiling on that larger number is the job's
-      # timeout-minutes: 60 above, whose worst case so far was 1255s of job time
-      # against 3600s. If you are auditing the margin, compare like with like.
+      # lands roughly 80s to 130s higher (observed about 1050s to 1220s). The
+      # ceiling on that larger number is not this -timeout at all, it is the
+      # job's timeout-minutes: 60 above, against which the worst job time seen
+      # here was about 1255s of 3600s. If you are auditing the margin, compare
+      # like with like: step wall against the job ceiling, `go test` against
+      # this one.
       #
       # The wall time is reported on every run, to the step summary and to
       # stdout, so it can be read without a browser. If it ever creeps past

--- a/.github/workflows/api-integration.yml
+++ b/.github/workflows/api-integration.yml
@@ -209,10 +209,11 @@ jobs:
       # Worst observed 1121s against a 2700s ceiling, so 2.4x headroom, on a
       # package whose run-to-run spread across those four was 14%.
       #
-      # The wall time is printed to the step summary on every run. If it ever
-      # creeps past about 1800s, shard the lane by -run regex rather than
-      # raising this ceiling: at that point the feedback delay is the problem,
-      # and raising the timeout only hides it.
+      # The wall time is reported on every run, to the step summary and to
+      # stdout, so it can be read without a browser. If it ever creeps past
+      # about 1800s, shard the lane by -run regex rather than raising this
+      # ceiling: at that point the feedback delay is the problem, and raising
+      # the timeout only hides it.
       - name: Integration tests
         shell: bash
         env:
@@ -238,8 +239,9 @@ jobs:
 
       # THE MOST IMPORTANT STEP IN THIS FILE.
       #
-      # Every container helper in the package (startPostgres and its 14 siblings)
-      # calls t.Skipf("skipping: cannot start ... container (docker unavailable?)")
+      # Every container helper in the package (startPostgres, its 11 siblings,
+      # and one test that inlines the same setup: 13 call sites today) does
+      # t.Skipf("skipping: cannot start ... container (docker unavailable?)")
       # when it cannot reach a daemon. It SKIPS, it does not fail. So a runner
       # image that one day ships without Docker, or a daemon that dies mid-job,
       # produces 343 skips, `ok`, exit 0 and a green tick, and this lane would go

--- a/.github/workflows/api-integration.yml
+++ b/.github/workflows/api-integration.yml
@@ -6,8 +6,12 @@ name: api-integration
 #
 # ci.yml's Go job excludes `/apps/api/tests` from `go test` and its comment said
 # those tests "belong in a separate lane". That lane did not exist. From the day
-# the exclusion landed until this file, 343 tests were compile-checked by Build
-# and Vet and never executed by anything. Among them are the m112 (GH #380)
+# the exclusion landed until this file, 343 tests were compile-checked by Vet
+# and never executed by anything. (Vet, not Build: ci.yml's Build step excludes
+# this package too, because every file in it is a _test.go file and `go build`
+# errors on a package with no buildable non-test files. Vet compiles the test
+# files, so it is the only thing standing between this package and bit rot.)
+# Among them are the m112 (GH #380)
 # site-scope RLS policy proofs in tests/email_site_scope_rls_integration_test.go,
 # which are the entire defence for seven closed privilege-escalation doors where
 # a one-site collaborator could reach the whole organisation. A regression in
@@ -28,7 +32,8 @@ name: api-integration
 #
 # COST AND RISK, stated so the next person can revisit this knowingly.
 # Cost: one ubuntu-latest runner for the wall time reported in the PR that added
-# this file, plus roughly 700MB of Docker image pulls, on PRs that touch
+# this file, plus about 425MB of compressed image layers pulled (110 postgres,
+# 254 clickhouse, 47 minio, 15 redis), on PRs that touch
 # apps/api. Risk it buys down: a silent regression in privilege-escalation RLS
 # is a security incident, not a bug. That asymmetry is why this runs per PR and
 # not only nightly. If the wall time ever grows past the point where it is
@@ -188,7 +193,7 @@ jobs:
           docker info --format 'server={{.ServerVersion}} driver={{.Driver}}'
 
       # Pull the four images the package uses up front. Not required for
-      # correctness (testcontainers pulls on demand) but it moves roughly 700MB
+      # correctness (testcontainers pulls on demand) but it moves that ~425MB
       # of network into a named step, so a registry problem reads as a pull
       # failure instead of surfacing later as an inscrutable container start
       # timeout inside some unrelated test. If a test adds a fifth image this

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,9 @@ jobs:
         # about to delete or weaken that workflow, that is what you are giving
         # back up.
         #
-        # Compile-checking here by Build + Vet is still worth having: it stops
-        # the package rotting between integration runs.
+        # Compile-checking here is still worth having: it stops the package
+        # rotting between integration runs. Note that is VET doing it, not
+        # Build, for the reason given on the Build step above.
         #
         # The pattern is anchored with $ so it excludes ONLY that package.
         # apps/api/tests/contract holds the containerless spec-versus-code gates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,22 @@ jobs:
           GOWORK: "off"
           CGO_ENABLED: "0"
         # Also exclude apps/api/tests here: those are container-based integration
-        # tests (testcontainers — postgres/redis/minio/clickhouse) that belong in a
-        # separate lane, not the fast unit CI. 262 of them stand up their own
-        # ephemeral Postgres, so the cost, not any missing Docker daemon, is why
-        # they sit out this lane. They are still COMPILE-checked above by
-        # Build + Vet, so they can't silently rot.
+        # tests (testcontainers: postgres, redis, minio, clickhouse) that belong
+        # in a separate lane, not the fast unit CI. 344 test functions live
+        # there, 343 of which run under CGO_ENABLED=0 (one is //go:build cgo),
+        # and most stand up their own ephemeral Postgres, so the cost, not any
+        # missing Docker daemon, is why they sit out this lane.
+        #
+        # THE SEPARATE LANE IS .github/workflows/api-integration.yml. It really
+        # runs them, per PR touching apps/api plus on main and nightly. This
+        # comment previously claimed a lane that did not exist, and for as long
+        # as that was true the package's security proofs (the m112 site-scope
+        # RLS policy tests) were compile-checked and never executed. If you are
+        # about to delete or weaken that workflow, that is what you are giving
+        # back up.
+        #
+        # Compile-checking here by Build + Vet is still worth having: it stops
+        # the package rotting between integration runs.
         #
         # The pattern is anchored with $ so it excludes ONLY that package.
         # apps/api/tests/contract holds the containerless spec-versus-code gates

--- a/apps/api/migrations/20260814000000_m112_email_site_scope_rls.sql
+++ b/apps/api/migrations/20260814000000_m112_email_site_scope_rls.sql
@@ -395,7 +395,6 @@ BEGIN
             AS RESTRICTIVE FOR SELECT
             USING (
                 coalesce(current_setting('app.site_scope', true), '') <> 'on'
-                OR "tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
                 OR "site_id" = ANY (
                     string_to_array(nullif(current_setting('app.allowed_site_ids', true), ''), ',')::uuid[]
                 )

--- a/apps/api/migrations/20260814000000_m112_email_site_scope_rls.sql
+++ b/apps/api/migrations/20260814000000_m112_email_site_scope_rls.sql
@@ -395,6 +395,7 @@ BEGIN
             AS RESTRICTIVE FOR SELECT
             USING (
                 coalesce(current_setting('app.site_scope', true), '') <> 'on'
+                OR "tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
                 OR "site_id" = ANY (
                     string_to_array(nullif(current_setting('app.allowed_site_ids', true), ''), ',')::uuid[]
                 )

--- a/apps/api/tests/contract/doc.go
+++ b/apps/api/tests/contract/doc.go
@@ -2,13 +2,20 @@
 // diff packages/openapi/openapi.yaml against the REAL production Gin engine.
 //
 // It is deliberately a separate package from apps/api/tests. Those are
-// container-backed integration tests: 262 of them stand up their own ephemeral
-// Postgres through testcontainers, which is far too slow for the per-PR lane
-// and is why .github/workflows/ci.yml excludes that package from `go test`.
+// container-backed integration tests: 344 test functions, most of which stand
+// up their own ephemeral Postgres through testcontainers, which is far too slow
+// for the fast per-PR lane and is why .github/workflows/ci.yml excludes that
+// package from `go test`. They are not unrun: they have their own lane in
+// .github/workflows/api-integration.yml, which executes them on every PR that
+// touches apps/api, on main, and nightly.
+//
 // The gates in here need no container at all (they build the engine against an
 // empty *db.Pool and only read engine.Routes()), so they live one directory
 // down, where the CI package filter is anchored to exclude only
-// `/apps/api/tests` itself and every gate in this package runs on every PR.
+// `/apps/api/tests` itself and every gate in this package runs on every PR, in
+// about a second, in the fast lane. That placement is the point and should not
+// change: a spec-versus-code mismatch must be caught by the cheap lane that
+// every PR pays for, not only by the expensive one.
 //
 // The rule that keeps this working: nothing in this package may start a
 // container or open a database connection. If a test here ever needs one, it


### PR DESCRIPTION
## The gap

`ci.yml`'s Go job excludes `/apps/api/tests` from `go test`, and its comment says those tests "belong in a separate lane, not the fast unit CI".

That lane did not exist. No workflow in `.github/workflows` ran the package. The only file that mentioned the path was `ci.yml`, in the exclusion. So 344 test functions were compile-checked by Build and Vet and executed by nothing.

What that left unguarded is not incidental coverage:

- `tests/email_site_scope_rls_integration_test.go`, the m112 (GH #380) site-scope RLS **policy** proofs. Nineteen tests that ask Postgres, as a non-superuser, whether a one-site collaborator can reach the organisation. These are the entire defence for the seven privilege-escalation doors closed in that issue.
- `tests/security_m1_test.go`, `tests/social_review_debt_integration_test.go`, `tests/rls_integration_test.go`, and the billing, backup, audit-chain, uptime and tenant-isolation suites.

A regression in any of them merged silently and still type-checked.

### One correction to the framing

The five tests most often cited as the m112 proofs (`TestEveryOperatorPathRunsThroughScopedTenantTx`, `TestRepoRefusesOrgConfigUpsertForSiteScopedPrincipal`, `TestRepoRefusesOrgConnectionUpsertForSiteScopedPrincipal`, `TestRepoRefusesFleetSuppressionDeleteForSiteScopedPrincipal`, `TestAgentTransactionNeverCarriesSiteScope`) are **not** in `apps/api/tests`. They live in `apps/api/internal/email/`, which `ci.yml` has always run and still runs, in about a minute on the runner (64.2s in the run that shipped this branch). They were never unprotected.

The half that *was* unprotected is the other half of m112: the direct-SQL proofs that the policies themselves are correct. Both halves are load-bearing and neither is redundant. The repo half fails when the dispatch stops setting `app.site_scope`; the policy half fails when the policy stops refusing. Only the second had no lane.

## The lane

`.github/workflows/api-integration.yml`.

**Trigger: PRs touching `apps/api`, plus main, plus nightly, plus manual.** Per PR rather than nightly-only because the thing being protected is privilege-escalation RLS, where a silent regression is a security incident, not a bug, and a nightly lane finds it after the merge that caused it. Main because a green PR can still merge red. Nightly because rot that no diff touches (a base image tag moving, a runner image change) should not wait for the next `apps/api` PR.

The path filter is a **job condition, not a `paths:` trigger**, and that is deliberate. A workflow skipped by a `paths:` filter posts no check at all, so a required check stays pending forever and the PR can never merge. A job skipped by `if:` posts as skipped, which GitHub counts as satisfying a required check. It also **fails open**: if the diff cannot be computed, the lane runs. Wasting nine minutes is the cheaper mistake here.

**Timeout: `-timeout 45m`, job `timeout-minutes: 60`.** Measured: the package takes 522s alone but 601s under parallel load, blowing Go's 10m default and panicking. It sits right on the default, so a lane without an explicit timeout would flake, and a flaky required lane gets ignored and then deleted, which is worse than no lane. The job ceiling is strictly above the Go timeout so Go wins the race and prints the goroutine dump naming the hung test, instead of the runner killing the process with no output.

**It verifies the tests actually ran.** This is the most important step in the file. Every container helper in the package (`startPostgres`, its 11 siblings, and one test that inlines the same setup: 13 call sites today) calls `t.Skipf("... docker unavailable?")` when it cannot reach a daemon. It *skips*, it does not fail. A runner image that one day ships without Docker would produce 343 skips, `ok`, exit 0, and a green tick, and the lane would protect nothing while looking like it protects everything. So the lane asserts: no docker-unavailable skips, a floor on the pass count, and four m112 policy proofs passing **by name**.

The `go test` output is piped to `tee`, so `set -o pipefail` is there too. Without it the shell reports tee's exit status and a failed run reads as success.

## Required or advisory

Proposed **required**. An advisory lane guarding privilege-escalation RLS protects nothing: it is the check people learn to scroll past.

**It cannot be made required in this PR, and that is not an oversight.** The check context does not exist on `main` yet, so adding it to branch protection now would leave it permanently pending on every open PR in the repo and none of them could merge. The order has to be merge, then require. One command, after merge, which reads the current set and appends rather than replacing it:

```bash
gh api repos/mosamlife/wpmgr/branches/main/protection/required_status_checks \
  --jq '{strict, checks: [(.checks[]|{context}), {context:"Go integration (apps/api/tests)"}]}' \
  > /tmp/rsc.json
gh api -X PATCH repos/mosamlife/wpmgr/branches/main/protection/required_status_checks \
  --input /tmp/rsc.json
```

Until that runs, **this lane is advisory**, and it is worth being blunt about that rather than letting the PR imply otherwise.

### What makes it survivable as a required check

The three failure modes that get a required lane deleted are each closed, and each was found by asking what a green tick could mean other than "the tests passed":

| failure mode | what it would look like | closed by |
|---|---|---|
| timeout flake | random red, no cause | explicit `-timeout 45m`, worst observed 1121s, 2.4x headroom |
| daemonless runner | 343 skips, `ok`, exit 0, **green** | Verify step: no docker-unavailable skips, pass-count floor, four m112 proofs asserted by name |
| path filter deadlock | required check pending forever | filter is a job `if:`, never a `paths:` trigger |
| **dead gate job** | gate fails, lane **skipped**, required check **green** | `if: !cancelled() && needs.changes.outputs.api != 'false'` |

That last row was a real hole in the original design, found while writing this section. A job whose `needs` failed is reported as *skipped*, and GitHub counts a skipped required check as *satisfied*. Wired the obvious way round (`== 'true'`), a checkout flake in the gate job would have skipped the lane and posted a green required check on an unverified `apps/api` change. The condition now reads "run unless we positively established there is nothing to test", so an empty output from a dead gate runs the lane instead of skipping it.

A second option would be to make `Detect apps/api changes` a required context too. That also works, but it puts the invariant in repo settings where it is invisible to anyone reading the workflow, and it breaks the moment someone renames the job. Keeping it in the `if:` keeps it next to the thing it protects.

## Scope, stated honestly

`CGO_ENABLED=0` mirrors `ci.yml` and the production main-API image. `tests/media_encode_integration_test.go` carries `//go:build cgo`, so 343 of 344 test functions run and that one stays excluded exactly as it is today. Covering it means building lilliput's CGO codecs, which is what `infra/Dockerfile.media-encoder` is for.

## Unchanged

The fast Go lane's commands are byte-identical; only its comment changed. `apps/api/tests/contract` (`TestOpenAPIRouteCoverage`, `TestOpenAPIRequestBodyFieldCoverage`) still runs on every PR in the fast lane in under a second, which is where a spec-versus-code gate belongs.

## Also fixed

`ci.yml` said 262 tests and promised a lane that never existed. `apps/api/tests/contract/doc.go` repeated both claims. Both now describe what is true, and name the workflow, so the next person reading them is not being told a second false thing.

## Proof, not assertion

Every number below was read back from the completed run with `gh run view`, not from a watched stream.

| run | commit | what it was | lane result | `go test` | step wall |
|---|---|---|---|---|---|
| [31436941443](https://github.com/mosamlife/wpmgr/actions/runs/31436941443) | `950b82c` | lane added | **success** | ok 983.567s | 1073s |
| [31438588544](https://github.com/mosamlife/wpmgr/actions/runs/31438588544) | `a8d8306` | **deliberate break** | **failure** | FAIL 1103.227s | not recorded |
| [31440907956](https://github.com/mosamlife/wpmgr/actions/runs/31440907956) | `a27e5d5` | reverted | **success** | ok 1089.261s | 1179s |
| [31444697210](https://github.com/mosamlife/wpmgr/actions/runs/31444697210) | `5aa8a4f` | **deliberate break, shipped script** | **failure** | FAIL 1120.907s | 1219s |
| [31446414001](https://github.com/mosamlife/wpmgr/actions/runs/31446414001) | `50f78ba` | reverted | **success** | ok 1118.939s | 1212s |
| [31448769587](https://github.com/mosamlife/wpmgr/actions/runs/31448769587) | `a289638` | comment only | **success** | ok 967.678s | 1047s |
| [31450124661](https://github.com/mosamlife/wpmgr/actions/runs/31450124661) | `5fef297` | comment only | **success** | ok 1094.322s | 1181s |
| [31451470077](https://github.com/mosamlife/wpmgr/actions/runs/31451470077) | `d45fc85` | comment only, **the commit this PR merges** | **success** | ok 1062.829s | 1154s |

### It executes the package

Not a green tick. Run [31451470077](https://github.com/mosamlife/wpmgr/actions/runs/31451470077), on `d45fc85`, the commit this PR merges, printed `--- PASS:` for the real tests, including all eleven m112 collaborator policy proofs by name:

```
--- PASS: TestCollaboratorCannotUpdateTheOrgConfig (3.10s)
--- PASS: TestCollaboratorCannotUpsertOverTheOrgConfig (3.11s)
--- PASS: TestCollaboratorCannotDeleteTheOrgConfig (2.97s)
--- PASS: TestCollaboratorCannotPromoteTheirRowToTheOrgRow (3.08s)
--- PASS: TestCollaboratorCannotWriteAnotherSitesConfig (3.06s)
--- PASS: TestCollaboratorCannotRebindTheOrgConnection (3.09s)
--- PASS: TestCollaboratorCannotDeleteTheOrgConnection (3.07s)
--- PASS: TestCollaboratorCannotDeleteFleetSuppression (3.08s)
--- PASS: TestCollaboratorCannotReadAnotherSitesEmailLog (3.07s)
--- PASS: TestEveryEmailTableCarriesTheSiteScopePolicies (3.06s)
--- PASS: TestTenantIsolationStillHolds (3.09s)
ok  github.com/mosamlife/wpmgr/apps/api/tests  1062.829s
```

`passing tests: 343`, `failing: 0`, and the verification step confirmed four proofs individually (`m112 proof ok: ...`). Docker on the runner: `server=28.0.4 driver=overlay2`.

343 is not a round number chosen for comfort. The package holds 344 test functions and exactly one carries `//go:build cgo`, so 343 is the whole package under `CGO_ENABLED=0`. The verify step's floor of 320 sits well above anything a mass-skip could produce and low enough to survive a few tests being retired.

### It fits the timeout

Across all eight runs above, `go test` spans 967.678s to 1120.907s. The worst is 1120.907s against the 2700s ceiling, better than 2x headroom. Step wall, which includes module download and compile and so lands 80s to 130s higher, spans 1047s to 1219s against the job's 3600s ceiling.

Pass and fail durations interleave (968 pass, 984 pass, 1063 pass, 1089 pass, 1094 pass, 1103 **fail**, 1119 pass, 1121 **fail**), so a failing run is not a slower run: a failed test still leaves the rest of the package to execute. Read a run's own elapsed number against the ceiling rather than treating a slow run as a symptom.

### It catches a regression

The planted break widens the m112 `site_email_log` RESTRICTIVE read policy by one line:

```sql
 USING (
     coalesce(current_setting('app.site_scope', true), '') <> 'on'
+    OR "tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid
     OR "site_id" = ANY (...)
```

It reads like a reasonable relaxation. It neuters site scoping for reads entirely: a one-site collaborator regains read access to every other site's email log in the organisation, subjects, recipients and bodies included.

Run 31444697210 went red on exactly that:

```
email_site_scope_rls_integration_test.go:530: collaborator scoped to siteB read 1 of siteA's email log rows
--- FAIL: TestCollaboratorCannotReadAnotherSitesEmailLog (3.18s)
FAIL  github.com/mosamlife/wpmgr/apps/api/tests  1120.907s
```

**`ci.yml` was green on that same commit, all six jobs, on both the push and the pull_request event.** Same on the first break. That is the point of this PR: this class of privilege escalation is invisible to every other check in the repo.

The break was pushed twice on purpose. The first red run exercised a different step script than this branch ships, because the `|| rc=$?` elapsed capture landed in the revert that followed it. A failure path that has never run is not known to work, so it was re-broken against the shipped script.

### The fast lane is unchanged

Its commands are byte-identical. Stripping comments and blank lines from both revisions of `ci.yml` and diffing the remainder produces no output at all.

Verified from run [31451467926](https://github.com/mosamlife/wpmgr/actions/runs/31451467926), on `d45fc85`. The command it actually ran, and what that produced:

```
go test $(go list ./... | grep -v -e /cmd/media-encoder -e /internal/media/encoder -e '/apps/api/tests$')

ok  github.com/mosamlife/wpmgr/apps/api/tests/contract   0.684s
ok  github.com/mosamlife/wpmgr/apps/api/internal/email  64.172s
```

`ok github.com/mosamlife/wpmgr/apps/api` followed by whitespace appears **zero** times in that log, so the package itself is still excluded. `tests/contract` still runs on every PR in under a second, and the m112 repo half still runs there in about a minute.

### The path filter was tested, including the branch CI has never taken

Every run on this branch touches `apps/api`, so the `api=false` arm has never executed in anger. Its logic was lifted verbatim into a local harness and driven through fourteen cases, all passing:

| input | result |
|---|---|
| `apps/api/internal/email/repo.go` | `api=true` |
| `apps/api/migrations/0112_x.sql` | `api=true` |
| `.github/workflows/api-integration.yml` | `api=true` |
| mixed web and api | `api=true` |
| diff cannot be computed | `api=true` (fails open) |
| push to main, schedule, manual | `api=true` |
| web only, docs only, agent only | `api=false` |
| `apps/apiary/thing.go` | `api=false` (the `apps/api/` prefix is anchored, so a sibling directory whose name merely starts with `api` does not drag in a twenty minute lane) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated container-backed API integration testing for pull requests, main-branch updates, scheduled runs, and manual executions.
  * Added test-result verification, summaries, and log artifacts for easier failure diagnosis.

* **Documentation**
  * Clarified CI test lanes, coverage, execution conditions, and the separation between fast contract tests and container-backed integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


