### PR TITLE
ci: make the integration lane manual, and say what that costs

### DIFF
--- a/.github/workflows/api-integration.yml
+++ b/.github/workflows/api-integration.yml
@@ -41,21 +41,32 @@ name: api-integration
 # nightly-only lane finds the incident after the merge that caused it.
 
 on:
-  # Per PR, so a regression is caught before it reaches main rather than after.
-  # Deliberately NOT `push: branches: ["**"]` like ci.yml: for a same-repo PR
-  # that would run this expensive lane twice per push, once for each event.
-  pull_request:
-  # On main as well. A PR can be green and main still go red, because main is
-  # the merge result and because some gates read live external state. Cheap
-  # insurance on the branch that ships.
-  push:
-    branches: [main]
-  # Nightly at 03:00 UTC. Catches rot that no diff touches: a base image tag
-  # that changed under us, a testcontainers or Docker behaviour change on the
-  # runner image, a flake that only shows up over repeated runs. Also means the
-  # lane's health is known even in a week where nobody touched apps/api.
-  schedule:
-    - cron: "0 3 * * *"
+  # MANUAL ONLY, and that is a deliberate cost decision, not an oversight.
+  #
+  # This lane takes about 18 minutes on a GitHub runner: 344 tests, most of
+  # which stand up their own ephemeral Postgres. On a PR that is 18 minutes of
+  # waiting before anyone can merge anything, which is too high a toll to pay on
+  # every change while the project runs on the standard runners. The tests are
+  # run locally instead (`make test-integration`), which is how they have always
+  # been run.
+  #
+  # WHAT THIS COSTS, stated plainly so the trade is visible. apps/api/tests holds
+  # the m112 RLS proofs, the ones that stop a collaborator invited to a single
+  # site from reaching the whole organisation's email credentials. Nothing in CI
+  # checks them while this is manual. A regression there merges green, and the
+  # only thing standing in front of it is somebody remembering to run the lane.
+  # Run it before merging anything that touches RLS, the email domain, or
+  # tenant scoping.
+  #
+  # TO TURN IT BACK ON once a faster runner is available, uncomment the three
+  # triggers below. Nothing else needs to change: the job, its 45 minute
+  # timeout and the path filter are already written for that.
+  #
+  # pull_request:
+  # push:
+  #   branches: [main]
+  # schedule:
+  #   - cron: "0 3 * * *"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,13 +69,18 @@ jobs:
         # and most stand up their own ephemeral Postgres, so the cost, not any
         # missing Docker daemon, is why they sit out this lane.
         #
-        # THE SEPARATE LANE IS .github/workflows/api-integration.yml. It really
-        # runs them, per PR touching apps/api plus on main and nightly. This
-        # comment previously claimed a lane that did not exist, and for as long
-        # as that was true the package's security proofs (the m112 site-scope
-        # RLS policy tests) were compile-checked and never executed. If you are
-        # about to delete or weaken that workflow, that is what you are giving
-        # back up.
+        # THE SEPARATE LANE IS .github/workflows/api-integration.yml, and it is
+        # MANUAL ONLY. It runs the package for real, but only when somebody
+        # dispatches it: about 18 minutes on a standard runner is too long to
+        # wait on every PR until a faster one is available. Its triggers are
+        # written and commented out, ready to uncomment.
+        #
+        # SO NOTHING IN CI EXECUTES THESE TESTS TODAY. That includes the m112
+        # site-scope RLS proofs, the ones that stop a collaborator invited to a
+        # single site reaching the whole organisation's email credentials. They
+        # are run locally, with `make test-integration`, and a regression in
+        # them will merge green. Run it before merging anything that touches
+        # RLS, the email domain or tenant scoping.
         #
         # Compile-checking here is still worth having: it stops the package
         # rotting between integration runs. Note that is VET doing it, not

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,27 @@ build-web: ## Build the web SPA
 test: test-api test-web ## Run all tests
 
 .PHONY: test-api
-test-api: ## Run Go tests
-	cd apps/api && go test ./...
+# -timeout 45m, not the default. apps/api/tests stands up an ephemeral Postgres
+# per test and sits right on Go's 10 minute default: measured 522s for that
+# package alone and 601s under the parallel load of `go test ./...`, which
+# panicked with "test timed out after 10m0s". The tests were fine; the limit
+# was not. Without this flag the full run flakes on a busy machine.
+test-api: ## Run Go tests (unit plus integration; needs Docker for the integration package)
+	cd apps/api && go test -timeout 45m ./...
+
+.PHONY: test-integration
+# The integration package on its own, which is where the security proofs live:
+# the m112 RLS tests that stop a collaborator invited to one site reaching the
+# whole organisation's email credentials.
+#
+# THIS IS NOT RUN BY CI. .github/workflows/ci.yml excludes the package and
+# .github/workflows/api-integration.yml is manual-only, because it takes about
+# 18 minutes on a standard runner and that toll on every PR is not worth paying
+# yet. So this command is the only thing standing in front of a regression in
+# it. Run it before merging anything that touches RLS, the email domain or
+# tenant scoping. Needs a working Docker daemon (testcontainers).
+test-integration: ## Run the Go integration tests (Docker required, about 9 minutes)
+	cd apps/api && go test -timeout 45m ./tests/...
 
 .PHONY: test-web
 test-web: ## Run frontend tests


### PR DESCRIPTION
The lane merged earlier works and is proven: it executes `apps/api/tests` for real and goes red on a planted RLS break. It also takes **about 18 minutes** on a standard runner, and 18 minutes of waiting before anything can merge is too high a toll on every PR until a faster runner is available for the project.

So the three automatic triggers are **commented out, not deleted**. Turning it back on is uncommenting them; the job, its 45 minute timeout and the path filter are already written for that.

## What this costs, written where someone will read it

Nothing in CI now executes the **m112 RLS proofs**, the tests that stop a collaborator invited to a single site from reaching the whole organisation's email credentials. A regression in them merges green. That is stated plainly in both workflow files rather than left for the next person to discover, which is how the previous "belongs in a separate lane" comment ended up describing a lane that never existed.

## Local is now the only defence, so it is one command

```
make test-integration     # about 9 minutes locally, Docker required
```

`test-api` also gained `-timeout 45m`, and that was not cosmetic. The package sits right on Go's 10 minute default: measured **522s alone** but **601s** under the parallel load of `go test ./...`, which panicked with `test timed out after 10m0s`. The tests were fine; the limit was not. The existing target flaked on a busy machine for reasons that had nothing to do with the code.

Run it before merging anything that touches RLS, the email domain, or tenant scoping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a dedicated integration-test command with a 45-minute timeout.
  * Extended the API test timeout to 45 minutes and documented Docker and runtime requirements.
  * Clarified that integration tests, including security checks, must be run locally.

* **Chores**
  * API integration workflows are now available for manual execution only; automatic pull request, push, and nightly runs are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->