### PR TITLE
ci: refuse new commits carrying an assistant trailer or a session URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,72 @@ jobs:
       - name: Test
         run: pnpm --filter @wpmgr/web test
 
+  # ---- Commit message hygiene ----
+  # Refuses a PR whose own commits carry an assistant trailer or a session URL.
+  #
+  # WHY. This repository is public, and a Claude Code session URL in a commit
+  # message is published with it, permanently, to everyone. 149 commits already
+  # in main's history carry one, from 2026-06-22 to 2026-07-28. Those are being
+  # left alone deliberately: removing them means rewriting public history, which
+  # changes every SHA since June, orphans the release tags that point at them,
+  # and breaks every existing clone and fork. The cost of the rewrite is higher
+  # than the cost of the leak. So the rule starts here instead, and this job is
+  # what makes it hold.
+  #
+  # It reads ONLY the commits the PR itself adds, never the history behind them,
+  # so the existing 149 cannot fail anybody's unrelated PR.
+  commit-hygiene:
+    name: Commit message hygiene
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          # The PR's own commits only. fetch-depth 0 because the range needs the
+          # base commit present, and a shallow clone does not have it.
+          fetch-depth: 0
+
+      - name: No assistant trailers or session URLs in new commits
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -uo pipefail
+
+          # A session URL is the one that actually matters: it is a live link
+          # published to a public repository. The trailers are a house style
+          # rule. Both are checked; the message says which is which.
+          url_re='claude\.ai/code/session'
+          trailer_re='^[[:space:]]*(Co-Authored-By:[[:space:]]*Claude|Claude-Session:)'
+
+          bad=0
+          for sha in $(git rev-list "$BASE_SHA".."$HEAD_SHA"); do
+            body="$(git log -1 --format='%B' "$sha")"
+            if printf '%s' "$body" | grep -qiE "$url_re"; then
+              echo "ERROR: $(git log -1 --format='%h %s' "$sha")"
+              echo "       carries a Claude Code session URL. This repository is public, so that"
+              echo "       link would be published with the commit and cannot be taken back."
+              bad=1
+            fi
+            if printf '%s' "$body" | grep -qiE "$trailer_re"; then
+              echo "ERROR: $(git log -1 --format='%h %s' "$sha")"
+              echo "       carries an assistant attribution trailer, which this project does not use."
+              bad=1
+            fi
+          done
+
+          if [ "$bad" -ne 0 ]; then
+            echo ""
+            echo "Rewrite the offending messages and force-push the branch:"
+            echo "  git rebase -i $BASE_SHA     # reword each one"
+            echo "  git push --force-with-lease"
+            echo ""
+            echo "Only this PR's commits are read, so nothing already on main is involved."
+            exit 1
+          fi
+          echo "OK: no assistant trailers or session URLs in this PR's commits."
+
   # ---- Marketing site (the public wpmgr.app) ----
   # Separate from the web job so a failure says which app broke, and because
   # these two deploy independently.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,21 @@ under `apps/web/src/features/<domain>/` mirror the backend domains.
 Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`).
 One logical change per commit.
 
+**No assistant trailers, and never a session URL.** Do not add
+`Co-Authored-By: Claude`, `Claude-Session:`, or any `claude.ai/code/session`
+link to a commit message. This repository is public, so anything in a commit
+message is published with it and cannot be taken back. Some coding assistants
+append these by default; turn that off. CI checks the commits a pull request
+adds and refuses the PR if it finds one, with the command to fix it.
+
+Commits already on `main` from before this rule are left as they are. Removing
+them would mean rewriting public history, which changes every commit id since
+June 2026, orphans the release tags pointing at them, and breaks every existing
+clone and fork. The rule applies going forward.
+
 ## PR checklist
 
+- [ ] No `Co-Authored-By: Claude`, `Claude-Session:` or `claude.ai/code/session` in any commit message
 - [ ] `make lint` passes
 - [ ] `make test` passes
 - [ ] `make build` passes


### PR DESCRIPTION
This repository is public, so anything in a commit message is published with it and cannot be taken back. A Claude Code session URL is the part that actually matters: it is a live link, not a style preference.

**149 commits already in `main` carry one**, dated 2026-06-22 to 2026-07-28. None appear in tracked files and none in PR bodies.

## Those are being left alone, deliberately

Removing them means rewriting public history: every commit id since June 2026 changes, the release tags pointing at them are orphaned, and every existing clone and fork breaks. For a published open-source project with tagged releases and container images built from those tags, that costs more than the leak does.

So the rule starts here instead, and this job is what makes it hold rather than a line in a document nobody rereads.

## Scope

The check reads **only the commits a pull request adds**, never the history behind them, so the existing 149 cannot fail somebody's unrelated PR. It fetches full depth because the range needs the base commit present.

It reports the two cases separately, because they are not equally serious: a session URL is a published live link, an attribution trailer is a house style rule.

## Verified both directions against real commits

| Case | Result |
|---|---|
| Range containing `6428c19` (carries both a URL and a trailer) | **exit 1**, names the commit and both reasons |
| This PR's own commits | exit 0 |
| Empty range | exit 0 |
| A merge commit in range | passes without erroring |

The failure message prints the exact `git rebase -i <base>` and `git push --force-with-lease` to fix it, and says that only the PR's commits were read, so nobody panics about main.

## Also

`CONTRIBUTING.md` states the rule, notes that some assistants append these by default and should be configured not to, and explains why the existing commits stay. Added to the PR checklist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contribution guidelines for keeping commit messages free of assistant attribution trailers and session URLs.
  * Added a pull request checklist item for verifying commit-message compliance.

* **Chores**
  * Added automated pull request checks that identify prohibited commit-message markers and provide remediation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->