### PR TITLE
release: 0.61.132

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.132] - 2026-08-11
+
 ### Changed
 
 - The docs version guard is a script you can run, `scripts/check-version-surfaces.sh`, instead of shell embedded in the CI workflow, and it ships with `scripts/check-version-surfaces_test.sh`: 76 cases that build throwaway trees and assert the guard's exit code. Running the guard before you push now takes one command and no CI cycle. Four defects found by review are closed and covered by tests: a version with no `CHANGELOG.md` heading is now placed in the ordering rather than skipped (24 patch versions of 0.61.x had no heading, so a stale pin could sit on one of them forever), the badge and agent checks survive a reformat instead of switching themselves off, a commented-out install pin no longer counts as present, and required pins are anchored to an explicit marker so ordinary prose and an extra current pin cannot fail the build. A repo-wide sweep also holds any other concrete image tag or `WPMGR_VERSION` value to the same freshness rule, so a new file with a stale pull command is caught even though no list names it.

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -16,8 +16,8 @@ export const metadata: Metadata = buildMetadata({
 
 // ---------------------------------------------------------------------------
 // Curated release entries (newest first, harvested from CHANGELOG.md).
-// This is a long curated history, not a recent window: 72 entries as of
-// 2026-08-10, running from 0.61.131 back to 0.54.0, some of them grouping
+// This is a long curated history, not a recent window: 73 entries as of
+// 2026-08-11, running from 0.61.132 back to 0.54.0, some of them grouping
 // several releases into one. Anything older lives on GitHub Releases.
 // CI keeps the newest entry within 5 releases of the top CHANGELOG.md entry
 // (scripts/check-version-surfaces.sh), reading the newest version in a grouped
@@ -42,6 +42,43 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 };
 
 const RELEASES: ChangeEntry[] = [
+  {
+    version: "0.61.132",
+    date: "2026-08-11",
+    summary:
+      "Deleting a site used to leave that site's backup manifests in object storage for good. Removing the site removed the only records naming those files, so nothing could ever find them again, and one account was left carrying 90 of them on its storage bill. Deleting a site now clears its stored manifests within the hour. Files orphaned by a delete made before this release are not cleaned up by it, and nothing in it finds them, so clearing those stays a step you take yourself.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Deleting one site no longer strands its backup manifests in object storage forever. Removing the site removed every snapshot record it had, and those records were the only thing naming the site's stored manifest files, so nothing could ever find them again. The delete now writes a reclamation record in the same database transaction that removes the site, and an hourly sweep clears that site's storage folder afterwards. The same transaction is the point: a record written separately, before the delete, could outlive a delete that then failed, and that would leave a standing instruction to erase a live site's backups.",
+      },
+      {
+        tag: "Fixed",
+        text: "Files orphaned before this release are not cleaned up by it, and nothing in it finds them. The reclamation record is written by the delete, so it exists only for sites deleted from this version onwards. A site you deleted on an earlier version left no record anywhere, which is the defect itself, so its manifests are still in your bucket and still on your storage bill: the account that reported this is carrying 90 of them today. Clearing them is a deliberate step you take yourself, one folder per deleted site. Rather than deleting by hand you can hand a site you know is gone to the sweep with a single insert, which keeps every safety check in play, and the exact statement is written out in the database migration that ships with this release. It has to be run on a superuser connection.",
+      },
+      {
+        tag: "Fixed",
+        text: "Deduplicated chunks, which are the bulk of what your backups occupy, are deliberately untouched by that sweep. They are shared across every site in the account, they sit under a different storage root, and the sweep is structurally unable to reach them, so a chunk another site still needs cannot be deleted by this path however it goes wrong. A sweep that cannot finish, or cannot prove the site is really gone, leaves the files where they are and keeps its record rather than discarding it, because that record is by then the last thing that knows those files exist.",
+      },
+      {
+        tag: "Fixed",
+        text: "A site whose backups go to your own storage bucket has its manifests swept like any other. Manifests are always written to the bucket this instance is itself configured with, whatever destination the backup payload was sent to, so all of them are in scope and none of them are stranded. What this instance does not touch is the backup payload sitting in your own bucket, which it holds no credentials for.",
+      },
+      {
+        tag: "Fixed",
+        text: "An account that lost its last backup-carrying site stopped being garbage collected at all, so its stored chunks leaked as well as its manifests. The list of accounts to collect came only from completed backups, and deleting the site that held the final one removed the account from that list permanently. It now also considers accounts that still have chunks in storage, which changes only which accounts get looked at: every existing check on what may actually be deleted is unchanged, and a backup running at the time still protects everything it touches. Deleting the emptied organisation afterwards still strands its chunks, and that is deliberately left open here.",
+      },
+      {
+        tag: "Fixed",
+        text: "A batch of fixes to signing in with Google or GitHub. A provider that stops reporting an address, which is what GitHub does once someone makes theirs private, no longer erases the last address it did report. Connecting a provider, creating an account from one, and a stored provider record changing issuer are now written to the audit log as what they are, instead of all three reading as an ordinary sign-in, and a change to what an account can sign in with is now recorded even when that account belongs to no organisation, which describes a site collaborator, a client with portal access, and every brand new account. Signing in with Google is now bounded by a timeout, as signing in with GitHub already was, and connecting a second account from a provider you already have connected reports a conflict you can act on instead of a server error.",
+      },
+      {
+        tag: "Changed",
+        text: "The self-host install guide no longer hands you a stack from 190 releases ago. It still told you to pull v0.19.0, one link below the current pull commands in the README, so following that link rather than staying on the page you were already reading got you a control plane predating a long list of fixes. Both pages now also say what running without the media encoder actually costs, which is site screenshots, the Media Optimizer and WOFF2 font transcoding, and nothing else. Keeping every published version number honest is now a script anyone can run before pushing, with a test suite of its own, rather than shell buried in the build.",
+      },
+    ],
+    featureLinks: [{ label: "Backups", href: "/features/backups" }],
+  },
   {
     version: "0.61.131",
     date: "2026-08-10",

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.131
+  version: 0.61.132
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Prepares release 0.61.132. No tag, no merge, no deploy from this branch.

## What is in it

The GH #402 fix, plus this week's CI and docs-guard work. Deleting one site
left that site's backup manifests in object storage forever: the
`ON DELETE CASCADE` destroyed every snapshot row for the site, and those rows
were the only record naming the stored manifest objects, so nothing could find
them again. One deleted site left 90 orphans in the field.

This is **control plane only**. The agent plugin is untouched, so its version
does not move.

## The three files this changes

| File | Before | After |
| --- | --- | --- |
| `CHANGELOG.md` top entry | `[Unreleased]`, 18 entries | `## [0.61.132] - 2026-08-11`, same 18 entries, with a bare `## [Unreleased]` above it |
| `packages/openapi/openapi.yaml` `info.version` | `0.61.131` | `0.61.132` |
| `apps/marketing/.../changelog/page.tsx` newest entry | `0.61.131` | `0.61.132` |

The new `[Unreleased]` heading is bare, with nothing under it, which is what
every prior release left behind. A placeholder line goes stale the moment
somebody adds a real entry.

## Two version strings that deliberately do NOT move

`apps/agent/wpmgr-agent.php` (plugin header and `WPMGR_AGENT_VERSION`) and
`apps/agent/readme.txt` (`Stable tag`) all stay on **0.61.131**, and so does
`AGENT_VERSION` in `apps/marketing/lib/content/home.ts`.

This is the case `scripts/check-version-surfaces.sh` was written for. The agent
version does not track the repo release version, it moves only when the agent
itself changes, and the guard compares the marketing hero badge to the **agent**
version rather than to the changelog. Bumping the agent to match this tag would
publish identical agent code under a new number and would make the hero badge
name a version wordpress.org does not serve.

## Honesty about the limit

The marketing entry states, in its summary and again in its second item, that
objects orphaned by a delete made before this release are not cleaned up by it
and nothing in it finds them, that they are still in your bucket and still on
your storage bill, and that clearing them is a deliberate step you take
yourself. The CHANGELOG already says this and the published page must not read
as though the problem is retroactively solved.

## Verification, run before pushing

```
$ make check-versions
OK: packages/openapi/openapi.yaml info.version matches the top CHANGELOG.md entry (0.61.132).
OK: the marketing changelog's newest entry (0.61.132): 0 releases behind 0.61.132, tolerance 5.
OK: the marketing hero badge names agent 0.61.131, matching apps/agent/wpmgr-agent.php.
OK: the agent version triple agrees (0.61.131).
OK: .github/workflows/release.yml lets the agent zip carry its own source version.
OK: the install instructions (0.61.131): 1 release behind 0.61.132, tolerance 1.
OK: every required install pin is present, inside its marked region, and names v0.61.131.
OK: swept the tree: 5 concrete version mentions outside CHANGELOG.md, all within 1 release of 0.61.132.

Version surfaces are consistent.

$ scripts/check-version-surfaces_test.sh
76 passed, 0 failed

$ node apps/marketing/scripts/check-copy.mjs
check-copy passed: no em dashes, en dashes, or competitor names across 388 files

$ pnpm --filter @wpmgr/marketing typecheck    EXIT=0
$ pnpm --filter @wpmgr/marketing lint         EXIT=0
$ pnpm --filter @wpmgr/marketing build        EXIT=0  (/changelog prerendered)
```

The docs vocabulary check from `ci.yml` was also run against `docs/` and the
root markdown: zero hits.

The install pins in `README.md` and `docs/install.md` stay on `v0.61.131` and
are now exactly one release behind, which is the guard's tolerance. They move
when the images for this version actually exist.
