### PR TITLE
release: 0.61.133

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.133] - 2026-08-12
+
 ### Fixed
 
 - Deleting an empty organisation no longer strands its deduplicated backup chunks in storage forever. Deleting an organisation with no sites and no other members removes it immediately, and that same statement destroyed the stored inventory of its backup chunks while freeing no storage at all, so those objects were left named by nothing: not by the collector, whose list of accounts comes from that inventory, and not by you, because the account id was gone too. Delete an account's last site and then the emptied account, and its chunk storage was unreachable permanently. The delete now records what it left behind, in the same database transaction it deletes the account in, and an hourly drain frees every one of that account's storage folders afterwards. Same transaction is the point, exactly as it was for site deletion: the record exists if and only if the account really went, and it deliberately has no link back to the account, because a record of cleanup work that is removed along with the thing it describes is the bug it was written to prevent.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.131**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.132**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -318,15 +318,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.131
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.131
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.131
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.132
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.132
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.132
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.131   # omit to track :latest
+export WPMGR_VERSION=v0.61.132   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -16,8 +16,8 @@ export const metadata: Metadata = buildMetadata({
 
 // ---------------------------------------------------------------------------
 // Curated release entries (newest first, harvested from CHANGELOG.md).
-// This is a long curated history, not a recent window: 73 entries as of
-// 2026-08-11, running from 0.61.132 back to 0.54.0, some of them grouping
+// This is a long curated history, not a recent window: 74 entries as of
+// 2026-08-12, running from 0.61.133 back to 0.54.0, some of them grouping
 // several releases into one. Anything older lives on GitHub Releases.
 // CI keeps the newest entry within 5 releases of the top CHANGELOG.md entry
 // (scripts/check-version-surfaces.sh), reading the newest version in a grouped
@@ -42,6 +42,35 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 };
 
 const RELEASES: ChangeEntry[] = [
+  {
+    version: "0.61.133",
+    date: "2026-08-12",
+    summary:
+      "Deleting an organisation that had no sites left in it used to leave the bulk of its backups sitting in object storage forever, and freed nothing off your storage bill. Removing the organisation removed the only inventory naming those files, so nothing could find them again afterwards, including you, because the account they were filed under was gone too. Deleting an emptied organisation now clears its storage within the hour. Storage orphaned by a delete made before this release is still not cleaned up on its own, and there is now a supported command for clearing it, which replaces the recovery instructions published with the last release: those needed a database superuser and did not work on the connection a self-hosted install actually has.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Deleting an emptied organisation no longer strands its deduplicated backup chunks in storage forever. Those chunks are the bulk of what your backups occupy. Deleting an organisation with no sites and no other members removes it on the spot, and that same removal destroyed the stored inventory of its chunks while freeing no storage at all, so the objects were left named by nothing: not by the collector, whose list of accounts is built from that inventory, and not by you, because the account id was gone with it. The delete now records what it left behind, in the same database transaction that removes the organisation, and an hourly drain frees every one of that account's storage folders afterwards. The same transaction is the point: the record exists if and only if the organisation really went.",
+      },
+      {
+        tag: "Fixed",
+        text: "Backups belonging to a live site in another organisation cannot be caught by that drain, by construction rather than by care. Chunk storage is namespaced per account and deduplication never crosses an account boundary, so two accounts holding byte-identical WordPress files hold two separate objects, and draining one cannot reach the other. Before deleting anything the drain re-checks that the organisation, its sites and its chunk inventory are all still absent, and refuses if any of them came back, which is what makes a restored database backup, or a second control plane pointed at the same bucket, safe rather than lucky. It works in bounded batches, resumes where it stopped rather than reporting a half-finished cleanup as complete, and if it is refused or cannot finish it keeps its record and says so on every sweep, because that record is by then the last thing that knows those files exist.",
+      },
+      {
+        tag: "Fixed",
+        text: "The recovery instructions published with the previous release did not work on the connection you have. Both statements shipped there were written for a database superuser: run as the ordinary application role a self-hosted install uses, one was refused outright, and the other was worse, because the row it targeted was hidden from that role and the statement reported success while changing nothing at all. There is now a supported command family, wpmgr-cli reclaim, which lists outstanding work, hands a deleted site or a deleted organisation to the sweeps, and reopens a record that got stuck. It runs as the ordinary application role, it changes no permission or policy to do so, and every subcommand exits with an error when it changed nothing, which is the property that makes it a recovery path rather than another thing that claims success having done nothing. The message in the logs now names that command instead of printing a statement that cannot work.",
+      },
+      {
+        tag: "Fixed",
+        text: "Storage orphaned by a delete made before the previous release is still not cleaned up automatically, and nothing in this release goes looking for it on its own. The record that drives the cleanup is written by the delete, so it exists only for organisations and sites deleted from these versions onwards, and anything you deleted earlier is still in your bucket and still on your storage bill. Clearing it is now a deliberate step you take rather than a hand-written database statement. For organisations, wpmgr-cli reclaim backfill-tenants finds the ones the control plane still holds a deletion trail for and queues each one. For organisations removed by the separate cleanup of orphaned accounts, which leaves no such trail, wpmgr-cli reclaim discover --report-only reads the bucket and prints the candidates whose account no longer exists; it deletes nothing and queues nothing, so a person decides, and every safety check above still applies to whatever they hand over. For a single deleted site there is wpmgr-cli reclaim site.",
+      },
+      {
+        tag: "Changed",
+        text: "The published api image now contains wpmgr-cli. The install guide has been telling you to run that tool inside this image since long before today, and the image only ever carried the server itself, so the instruction could not work as written.",
+      },
+    ],
+    featureLinks: [{ label: "Backups", href: "/features/backups" }],
+  },
   {
     version: "0.61.132",
     date: "2026-08-11",

--- a/docs/install.md
+++ b/docs/install.md
@@ -219,7 +219,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.131   # omit to track :latest
+export WPMGR_VERSION=v0.61.132   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.132
+  version: 0.61.133
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Cuts the 0.61.133 release surfaces. **Do not tag or merge on my account:** the tag and the deploy are the owner's.

Control plane only. The GH #408 fix: deleting an emptied organisation stranded its deduplicated backup chunks in object storage forever, because the chunk inventory cascades away with the tenant row and the delete frees no storage, so the objects were left named by nothing. Plus the `wpmgr-cli reclaim` command family, which recovers storage orphaned before it and works as the ordinary application role.

The agent plugin is untouched and its version does not move.

## What changed

| File | Before | After |
|---|---|---|
| `CHANGELOG.md` top entry | `[Unreleased]` (with entries) | `[0.61.133] - 2026-08-12`, plus a bare `[Unreleased]` above it |
| `packages/openapi/openapi.yaml` `info.version` | `0.61.132` | `0.61.133` |
| marketing `/changelog` newest entry | `0.61.132` | `0.61.133` |
| `README.md` install pins (4) | `v0.61.131` | `v0.61.132` |
| `docs/install.md` install pin | `v0.61.131` | `v0.61.132` |

Deliberately **not** moved, all still `0.61.131`:

| Surface | Value |
|---|---|
| `apps/agent/wpmgr-agent.php` plugin header | `0.61.131` |
| `apps/agent/wpmgr-agent.php` `WPMGR_AGENT_VERSION` | `0.61.131` |
| `apps/agent/readme.txt` `Stable tag` | `0.61.131` |
| `apps/marketing/lib/content/home.ts` `AGENT_VERSION` (hero badge) | `0.61.131` |

The `[Unreleased]` heading is left bare rather than carrying a placeholder line, matching what every prior release left: a placeholder goes stale the moment somebody adds an entry under it.

## The marketing entry says two uncomfortable things on purpose

A reader will hit both, so the entry names both rather than only advertising the fix:

1. **Storage orphaned by a delete made before the previous release is still not cleaned up, and nothing in this release finds it.** The reclamation record is written by the delete, so it exists only for deletes made from these versions onwards. Clearing the older ones is a deliberate operator step: `reclaim backfill-tenants` for organisations the deletion trail still remembers, `reclaim discover --report-only` for the ones it does not, which reads the bucket, prints candidates and deletes nothing.
2. **The recovery instructions published with 0.61.132 did not work.** Both statements were written for a database superuser. As the ordinary application role a self-hosted install uses, one was refused outright and the other was worse: row-level security hid the row, so it reported success while changing nothing. `wpmgr-cli reclaim` replaces them and runs as the ordinary role. Anybody who tried the old instructions deserves to see that acknowledged rather than quietly swapped out.

## The install-pin decision

The pins moved from `v0.61.131` to `v0.61.132`, and this was checked rather than assumed. At 0.61.132 they were deliberately held back, because a pin may never name a tag whose images do not exist yet: that hands a self-hoster a failing `docker pull`. All three v0.61.132 images are now pullable, so the pin is honest, and at a top entry of 0.61.133 a pin on 0.61.131 sits 2 releases behind against the guard's tolerance of 1.

```
docker manifest inspect ghcr.io/mosamlife/wpmgr-api:v0.61.132            exit=0
docker manifest inspect ghcr.io/mosamlife/wpmgr-web:v0.61.132            exit=0
docker manifest inspect ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.132  exit=0
```

Proof the bump was load-bearing and not cosmetic: with the pins stashed back to v0.61.131 and everything else as in this PR, the guard exits 1 with 6 errors (the required-pin compare plus 5 sweep hits at `README.md:321,322,323,329` and `docs/install.md:222`, each "2 releases behind ... Tolerance is 1"). Restored, it is green.

## Verification

`make check-versions`:

```
OK: packages/openapi/openapi.yaml info.version matches the top CHANGELOG.md entry (0.61.133).
OK: the marketing changelog's newest entry (0.61.133): 0 releases behind 0.61.133, tolerance 5.
OK: the marketing hero badge names agent 0.61.131, matching apps/agent/wpmgr-agent.php.
OK: the agent version triple agrees (0.61.131).
OK: .github/workflows/release.yml lets the agent zip carry its own source version.
OK: the install instructions (0.61.132): 1 release behind 0.61.133, tolerance 1.
OK: every required install pin is present, inside its marked region, and names v0.61.132.
OK: swept the tree: 5 concrete version mentions outside CHANGELOG.md, all within 1 release of 0.61.133.

Version surfaces are consistent.
```

`scripts/check-version-surfaces_test.sh` (the guard's own suite, run first in CI): `76 passed, 0 failed`.

`node apps/marketing/scripts/check-copy.mjs`:

```
check-copy passed: no em dashes, en dashes, or competitor names across 388 files
(136 marketing, 1 agent readme, 1 plugin header, 250 agent PHP of which 9 carry copy,
13 comparison files also checked for disparagement, 43 citations resolved).
```

`pnpm --filter @wpmgr/marketing typecheck`: exit 0.

`pnpm --filter @wpmgr/marketing build`: exit 0, 91 static pages. Its first step confirms the spec bump reaches the published docs: `sync-openapi: openapi.json (v0.61.133, 309 paths)`.

Also run: the CI docs vocabulary check (competitor names in `docs/` and root markdown), 0 hits, and `pnpm --filter @wpmgr/marketing lint`, exit 0.

## Next steps, which are yours

Tag `v0.61.133` to fire `release.yml`, then deploy. Nothing here tags, merges or deploys.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release notes for version 0.61.133, including improved organisation deletion cleanup, reclaim commands, safety checks, and recovery behavior.
  * Included the command-line utility in the API container image.

* **Documentation**
  * Updated installation instructions, README version references, and prebuilt image pins.
  * Updated the API specification version to 0.61.133.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->