### PR TITLE
fix(api): enforce the role hierarchy on member and API-key changes

### DIFF
--- a/apps/api/internal/apikey/handler.go
+++ b/apps/api/internal/apikey/handler.go
@@ -49,6 +49,16 @@ func (h *Handler) create(c *gin.Context) {
 	if body.Role == "" {
 		role = authz.RoleOperator
 	}
+	// GH #406 — privilege ceiling. The requested role came straight off the
+	// request body with no comparison to the caller, so an admin could POST
+	// {"role":"owner"} and hold an owner-grade credential a moment later. An
+	// actor may never mint a key more privileged than themselves. Mirrors the
+	// members_handler grant ceiling; the code is distinct so it can be grepped
+	// and pinned separately.
+	if !authz.Role(p.Role).AtLeast(role) {
+		httpx.Error(c, domain.Forbidden("apikey_role_exceeds_actor", "you cannot create an API key with a role higher than your own"))
+		return
+	}
 	created, err := h.svc.Create(c.Request.Context(), p.TenantID, body.Name, role)
 	if err != nil {
 		httpx.Error(c, err)

--- a/apps/api/internal/auth/members_handler.go
+++ b/apps/api/internal/auth/members_handler.go
@@ -197,24 +197,34 @@ func (h *MembersHandler) patchRole(c *gin.Context) {
 		httpx.Error(c, domain.Forbidden("role_grant_exceeds_actor", "you cannot grant a role higher than your own"))
 		return
 	}
+	// GH #406 — the TARGET's current role is read UNCONDITIONALLY, before any
+	// branch. Until this moved out of the `newRole != RoleOwner` arm below, an
+	// admin could demote or re-role an OWNER: the grant ceiling above only
+	// compares the actor to the role being GRANTED, and the last-owner COUNT
+	// guard only fires in a single-owner org. In an org with two owners there
+	// was no refusal at all.
+	existing, getErr := h.svc.repo.GetMembership(c.Request.Context(), targetUserID, p.TenantID)
+	if getErr != nil {
+		httpx.Error(c, getErr)
+		return
+	}
+	// Target ceiling: an actor may never act on a member who outranks them.
+	// owner-on-owner stays ALLOWED (ownership transfer is a supported
+	// capability); admin-on-admin and admin-on-viewer are unchanged.
+	if !actorRole.AtLeast(existing.Role) {
+		httpx.Error(c, domain.Forbidden("target_role_exceeds_actor", "you cannot change the role of a member who outranks you"))
+		return
+	}
 	// Last-owner protection: cannot demote the last owner.
-	if newRole != authz.RoleOwner {
-		// Check whether the target is currently an owner.
-		existing, getErr := h.svc.repo.GetMembership(c.Request.Context(), targetUserID, p.TenantID)
-		if getErr != nil {
-			httpx.Error(c, getErr)
+	if newRole != authz.RoleOwner && existing.Role == authz.RoleOwner {
+		ownerCount, countErr := h.svc.CountOwners(c.Request.Context(), p.TenantID)
+		if countErr != nil {
+			httpx.Error(c, countErr)
 			return
 		}
-		if existing.Role == authz.RoleOwner {
-			ownerCount, countErr := h.svc.CountOwners(c.Request.Context(), p.TenantID)
-			if countErr != nil {
-				httpx.Error(c, countErr)
-				return
-			}
-			if ownerCount <= 1 {
-				httpx.Error(c, domain.Forbidden("last_owner", "cannot demote the last owner"))
-				return
-			}
+		if ownerCount <= 1 {
+			httpx.Error(c, domain.Forbidden("last_owner", "cannot demote the last owner"))
+			return
 		}
 	}
 	m, err := h.svc.repo.UpdateMembershipRole(c.Request.Context(), targetUserID, p.TenantID, newRole)
@@ -224,8 +234,8 @@ func (h *MembersHandler) patchRole(c *gin.Context) {
 	}
 	h.svc.RecordAudit(c.Request.Context(), audit.Event{
 		TenantID:   p.TenantID,
-		ActorType:  audit.ActorUser,
-		ActorID:    p.UserID.String(),
+		ActorType:  actorTypeOf(p),
+		ActorID:    p.ActorID(),
 		Action:     "member.role_changed",
 		TargetType: "user",
 		TargetID:   targetUserID.String(),
@@ -246,12 +256,19 @@ func (h *MembersHandler) removeMember(c *gin.Context) {
 		httpx.Error(c, domain.Validation("invalid_user_id", "userId is not a valid UUID"))
 		return
 	}
-	// Last-owner protection: cannot remove the last owner.
 	existing, getErr := h.svc.repo.GetMembership(c.Request.Context(), targetUserID, p.TenantID)
 	if getErr != nil {
 		httpx.Error(c, getErr)
 		return
 	}
+	// GH #406 — target ceiling. Before this, removeMember never read p.Role at
+	// all: its only gate was the last-owner COUNT, so an admin could delete an
+	// owner outright from any org holding two or more owners.
+	if !authz.Role(p.Role).AtLeast(existing.Role) {
+		httpx.Error(c, domain.Forbidden("target_role_exceeds_actor", "you cannot remove a member who outranks you"))
+		return
+	}
+	// Last-owner protection: cannot remove the last owner.
 	if existing.Role == authz.RoleOwner {
 		ownerCount, countErr := h.svc.CountOwners(c.Request.Context(), p.TenantID)
 		if countErr != nil {
@@ -269,13 +286,24 @@ func (h *MembersHandler) removeMember(c *gin.Context) {
 	}
 	h.svc.RecordAudit(c.Request.Context(), audit.Event{
 		TenantID:   p.TenantID,
-		ActorType:  audit.ActorUser,
-		ActorID:    p.UserID.String(),
+		ActorType:  actorTypeOf(p),
+		ActorID:    p.ActorID(),
 		Action:     "member.removed",
 		TargetType: "user",
 		TargetID:   targetUserID.String(),
 	})
 	c.Status(http.StatusNoContent)
+}
+
+// actorTypeOf maps a principal to its audit actor type. A member mutation can
+// be driven by an API key as easily as by a session, and hard-coding ActorUser
+// logged those as the null UUID (p.UserID is uuid.Nil for a key). Mirrors
+// apikey.actorType.
+func actorTypeOf(p domain.Principal) string {
+	if p.Type == domain.PrincipalAPIKey {
+		return audit.ActorAPIKey
+	}
+	return audit.ActorUser
 }
 
 func parseUUID(s string) (uuid.UUID, error) {

--- a/apps/api/internal/auth/members_handler.go
+++ b/apps/api/internal/auth/members_handler.go
@@ -203,31 +203,34 @@ func (h *MembersHandler) patchRole(c *gin.Context) {
 	// compares the actor to the role being GRANTED, and the last-owner COUNT
 	// guard only fires in a single-owner org. In an org with two owners there
 	// was no refusal at all.
-	existing, getErr := h.svc.repo.GetMembership(c.Request.Context(), targetUserID, p.TenantID)
-	if getErr != nil {
-		httpx.Error(c, getErr)
-		return
-	}
-	// Target ceiling: an actor may never act on a member who outranks them.
-	// owner-on-owner stays ALLOWED (ownership transfer is a supported
-	// capability); admin-on-admin and admin-on-viewer are unchanged.
-	if !actorRole.AtLeast(existing.Role) {
-		httpx.Error(c, domain.Forbidden("target_role_exceeds_actor", "you cannot change the role of a member who outranks you"))
-		return
-	}
-	// Last-owner protection: cannot demote the last owner.
-	if newRole != authz.RoleOwner && existing.Role == authz.RoleOwner {
-		ownerCount, countErr := h.svc.CountOwners(c.Request.Context(), p.TenantID)
-		if countErr != nil {
-			httpx.Error(c, countErr)
-			return
+	//
+	// GH #406 follow-up — read, guard and write are ONE transaction, holding
+	// this org's member lock (repo.WithMemberGuard). As four separate
+	// transactions, two concurrent demotes of two different owners both read
+	// ownerCount=2, both passed the guard and both wrote, leaving the org with
+	// zero owners and no in-product way back. The checks below are byte-for-byte
+	// the ones 702ed45 introduced; only where the roles are read from changed.
+	var m Membership
+	err = h.svc.repo.WithMemberGuard(c.Request.Context(), targetUserID, p.TenantID, func(g MemberGuard) error {
+		// Target ceiling: an actor may never act on a member who outranks them.
+		// owner-on-owner stays ALLOWED (ownership transfer is a supported
+		// capability); admin-on-admin and admin-on-viewer are unchanged.
+		if !actorRole.AtLeast(g.Target.Role) {
+			return domain.Forbidden("target_role_exceeds_actor", "you cannot change the role of a member who outranks you")
 		}
-		if ownerCount <= 1 {
-			httpx.Error(c, domain.Forbidden("last_owner", "cannot demote the last owner"))
-			return
+		// Last-owner protection: cannot demote the last owner. Actor-independent
+		// by construction — an owner demoting themselves is refused on the same
+		// count as an admin demoting them — so zero owners is unreachable
+		// through this route for ANY caller, not merely hard to reach.
+		if newRole != authz.RoleOwner && g.Target.Role == authz.RoleOwner {
+			if g.OwnerCount <= 1 {
+				return domain.Forbidden("last_owner", "cannot demote the last owner")
+			}
 		}
-	}
-	m, err := h.svc.repo.UpdateMembershipRole(c.Request.Context(), targetUserID, p.TenantID, newRole)
+		var uerr error
+		m, uerr = g.UpdateRole(c.Request.Context(), newRole)
+		return uerr
+	})
 	if err != nil {
 		httpx.Error(c, err)
 		return
@@ -256,31 +259,27 @@ func (h *MembersHandler) removeMember(c *gin.Context) {
 		httpx.Error(c, domain.Validation("invalid_user_id", "userId is not a valid UUID"))
 		return
 	}
-	existing, getErr := h.svc.repo.GetMembership(c.Request.Context(), targetUserID, p.TenantID)
-	if getErr != nil {
-		httpx.Error(c, getErr)
-		return
-	}
-	// GH #406 — target ceiling. Before this, removeMember never read p.Role at
-	// all: its only gate was the last-owner COUNT, so an admin could delete an
-	// owner outright from any org holding two or more owners.
-	if !authz.Role(p.Role).AtLeast(existing.Role) {
-		httpx.Error(c, domain.Forbidden("target_role_exceeds_actor", "you cannot remove a member who outranks you"))
-		return
-	}
-	// Last-owner protection: cannot remove the last owner.
-	if existing.Role == authz.RoleOwner {
-		ownerCount, countErr := h.svc.CountOwners(c.Request.Context(), p.TenantID)
-		if countErr != nil {
-			httpx.Error(c, countErr)
-			return
+	// GH #406 follow-up — read, guard and delete are ONE transaction holding
+	// this org's member lock; see patchRole above and repo.WithMemberGuard.
+	// The DELETE race was the worse of the two: 25/25 measured rounds reached
+	// zero owners.
+	if err := h.svc.repo.WithMemberGuard(c.Request.Context(), targetUserID, p.TenantID, func(g MemberGuard) error {
+		// GH #406 — target ceiling. Before this, removeMember never read p.Role
+		// at all: its only gate was the last-owner COUNT, so an admin could
+		// delete an owner outright from any org holding two or more owners.
+		if !authz.Role(p.Role).AtLeast(g.Target.Role) {
+			return domain.Forbidden("target_role_exceeds_actor", "you cannot remove a member who outranks you")
 		}
-		if ownerCount <= 1 {
-			httpx.Error(c, domain.Forbidden("last_owner", "cannot remove the last owner"))
-			return
+		// Last-owner protection: cannot remove the last owner. Actor-independent
+		// (see patchRole): an owner cannot remove themselves out of the last
+		// owner slot either.
+		if g.Target.Role == authz.RoleOwner {
+			if g.OwnerCount <= 1 {
+				return domain.Forbidden("last_owner", "cannot remove the last owner")
+			}
 		}
-	}
-	if err := h.svc.repo.DeleteMembership(c.Request.Context(), targetUserID, p.TenantID); err != nil {
+		return g.Delete(c.Request.Context())
+	}); err != nil {
 		httpx.Error(c, err)
 		return
 	}

--- a/apps/api/internal/auth/repo.go
+++ b/apps/api/internal/auth/repo.go
@@ -523,6 +523,154 @@ func (r *Repo) DeleteMembership(ctx context.Context, userID, tenantID uuid.UUID)
 }
 
 // ---------------------------------------------------------------------------
+// Guarded member mutation (GH #406 follow-up: the last-owner guard was
+// check-then-act across four separate transactions)
+// ---------------------------------------------------------------------------
+
+// MemberRolesLockKey namespaces the per-tenant advisory lock that serialises
+// every guarded member-role mutation for one organisation. Same shape as
+// org.LifecycleLockKey: pg_advisory_xact_lock(hashtext(key), hashtext(tenant)),
+// so the lock is released by COMMIT or ROLLBACK and can never leak.
+//
+// A DIFFERENT namespace to org_lifecycle on purpose: a member demote must not
+// block behind an org purge, and neither guards the other's invariant.
+//
+// It is the FIRST thing the guard transaction does, before any row lock. That
+// ordering is the whole deadlock argument: two callers demoting two different
+// owners of the same org would otherwise take the two owner rows in opposite
+// order and deadlock. With the advisory lock first, the second caller is still
+// outside the critical section when the first takes its row locks, so the two
+// sets of row locks never interleave — there is exactly one lock to acquire
+// before any other, and it is the same lock for both callers.
+const MemberRolesLockKey = "org_member_roles"
+
+// MemberGuard is the read half of a guarded member mutation, handed to the
+// callback of WithMemberGuard. Target and OwnerCount were read INSIDE the same
+// transaction that will perform the write, under the per-tenant advisory lock
+// and with the tenant's owner rows held FOR UPDATE — so a decision taken on
+// them cannot be invalidated by a concurrent demote or delete before the write
+// lands. Authorization policy stays in the handler; only the atomicity lives
+// here.
+type MemberGuard struct {
+	// Target is the membership the caller is acting on, as it exists under
+	// the lock.
+	Target Membership
+	// OwnerCount is the tenant's owner-role membership count under the lock.
+	OwnerCount int
+
+	tx       pgx.Tx
+	tenantID uuid.UUID
+	userID   uuid.UUID
+}
+
+// UpdateRole writes the new role in the guard's transaction.
+func (g MemberGuard) UpdateRole(ctx context.Context, role authz.Role) (Membership, error) {
+	row, err := sqlc.New(g.tx).UpdateMembershipRole(ctx, sqlc.UpdateMembershipRoleParams{
+		UserID: g.userID, TenantID: g.tenantID, Role: string(role),
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Membership{}, domain.NotFound("membership_not_found", "membership not found")
+		}
+		return Membership{}, domain.Internal("membership_update_failed", "failed to update membership").WithCause(err)
+	}
+	return membershipToModel(row), nil
+}
+
+// Delete removes the membership in the guard's transaction.
+func (g MemberGuard) Delete(ctx context.Context) error {
+	n, err := sqlc.New(g.tx).DeleteMembership(ctx, sqlc.DeleteMembershipParams{UserID: g.userID, TenantID: g.tenantID})
+	if err != nil {
+		return domain.Internal("membership_delete_failed", "failed to delete membership").WithCause(err)
+	}
+	if n == 0 {
+		return domain.NotFound("membership_not_found", "membership not found")
+	}
+	return nil
+}
+
+// WithMemberGuard runs fn inside ONE tenant transaction spanning read → guard →
+// write, so the last-owner invariant cannot be raced.
+//
+// Before the fix this was four transactions (GetMembership, CountOwners, then
+// UpdateMembershipRole or DeleteMembership), and two concurrent demotes of two
+// different owners both read ownerCount=2, both passed the guard and both
+// wrote: the org reached ZERO owners. Since 702ed45 closed the two in-product
+// repair routes (an admin could no longer mint an owner API key nor promote
+// themselves), a zero-owner org needs direct database access to fix, which
+// makes the race an unrecoverable-org bug rather than a transient one.
+//
+// The transaction, in order:
+//  1. pg_advisory_xact_lock on (MemberRolesLockKey, tenant) — one writer per
+//     org inside the critical section, and the single lock every caller takes
+//     first (see MemberRolesLockKey for the deadlock argument).
+//  2. the target membership row SELECT ... FOR UPDATE.
+//  3. the tenant's owner rows SELECT ... FOR UPDATE, counted. Row locks as
+//     well as the advisory lock so that a future writer that forgets the
+//     advisory lock still blocks on the rows themselves.
+//
+// RLS: the reads run under InTenantTx (app.tenant_id set by the helper, never
+// by this code). memberships_tenant_isolation is declared with NO `FOR` clause
+// — i.e. FOR ALL, with the tenant predicate in both USING and WITH CHECK — so
+// it applies to `SELECT ... FOR UPDATE` exactly as it does to a plain SELECT.
+// That is what makes a locking read safe here: the FOR SELECT-only policies on
+// this table (memberships_self_read, memberships_agent) would have silently
+// returned zero rows to a locking read, which is the trap that stopped
+// scheduled backups firing. Neither of those is in play on the InTenantTx
+// path. Both statements still carry tenant_id explicitly.
+func (r *Repo) WithMemberGuard(ctx context.Context, userID, tenantID uuid.UUID, fn func(MemberGuard) error) error {
+	return r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx,
+			`SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))`,
+			MemberRolesLockKey, tenantID.String(),
+		); err != nil {
+			return domain.Internal("member_lock_failed", "failed to lock organisation membership").WithCause(err)
+		}
+
+		var m Membership
+		var role string
+		if err := tx.QueryRow(ctx,
+			`SELECT user_id, tenant_id, role, created_at, updated_at
+			   FROM memberships
+			  WHERE user_id = $1 AND tenant_id = $2
+			    FOR UPDATE`,
+			userID, tenantID,
+		).Scan(&m.UserID, &m.TenantID, &role, &m.CreatedAt, &m.UpdatedAt); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return domain.NotFound("membership_not_found", "membership not found")
+			}
+			return domain.Internal("membership_get_failed", "failed to load membership").WithCause(err)
+		}
+		m.Role = authz.Role(role)
+
+		// FOR UPDATE cannot sit beside an aggregate, so the lock is taken in a
+		// subquery and counted outside it. ORDER BY user_id makes the row-lock
+		// order deterministic even though the advisory lock above already means
+		// no second caller is here to race for them.
+		var owners int64
+		if err := tx.QueryRow(ctx,
+			`SELECT count(*) FROM (
+			     SELECT user_id FROM memberships
+			      WHERE tenant_id = $1 AND role = 'owner'
+			      ORDER BY user_id
+			        FOR UPDATE
+			 ) locked_owners`,
+			tenantID,
+		).Scan(&owners); err != nil {
+			return domain.Internal("owner_count_failed", "failed to count owners").WithCause(err)
+		}
+
+		return fn(MemberGuard{
+			Target:     m,
+			OwnerCount: int(owners),
+			tx:         tx,
+			tenantID:   tenantID,
+			userID:     userID,
+		})
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Social identities (m110)
 // ---------------------------------------------------------------------------
 

--- a/apps/api/internal/middleware/auth.go
+++ b/apps/api/internal/middleware/auth.go
@@ -74,6 +74,18 @@ func (a *Authenticator) Authenticate() gin.HandlerFunc {
 				c.Abort()
 				return
 			}
+			// key.Role is used as stored, deliberately NOT clamped the way the
+			// site-share role is below. The share clamp holds because a
+			// site-scoped collaborator has an invariant ceiling — it must never
+			// reach an org-level action, whatever the row says. An API key has
+			// no such ceiling: an owner minting an owner-role key is a
+			// supported case (PermTenantManage / PermSMTPManage /
+			// PermBillingManage are owner-only and are reachable by key), so
+			// any blanket clamp here would break legitimate keys while a
+			// per-key "who minted it" ceiling is not recoverable — the table
+			// records no creator. The ceiling therefore lives at the mint
+			// point, in apikey.Handler.create (GH #406). An unknown/invalid
+			// stored role fails closed on its own: rank 0 fails every AtLeast.
 			p := domain.Principal{
 				Type:     domain.PrincipalAPIKey,
 				APIKeyID: key.ID,

--- a/apps/api/internal/middleware/auth.go
+++ b/apps/api/internal/middleware/auth.go
@@ -81,11 +81,17 @@ func (a *Authenticator) Authenticate() gin.HandlerFunc {
 			// no such ceiling: an owner minting an owner-role key is a
 			// supported case (PermTenantManage / PermSMTPManage /
 			// PermBillingManage are owner-only and are reachable by key), so
-			// any blanket clamp here would break legitimate keys while a
-			// per-key "who minted it" ceiling is not recoverable — the table
-			// records no creator. The ceiling therefore lives at the mint
-			// point, in apikey.Handler.create (GH #406). An unknown/invalid
-			// stored role fails closed on its own: rank 0 fails every AtLeast.
+			// any blanket clamp here would break legitimate keys. The ceiling
+			// therefore lives at the mint point, in apikey.Handler.create
+			// (GH #406). Keys minted before that fix keep the role they were
+			// given, and who minted one IS recoverable — join audit_log on
+			// action='apikey.create' AND target_type='api_key' AND
+			// target_id = <key id>::text for actor_type/actor_id — so a sweep
+			// of pre-fix roles is a query, not a guess. Two holes in that
+			// trail: create's Record is best-effort (`_, _ =`), so a failed
+			// write leaves a key untraced, and a hard tenant purge cascades
+			// audit_log away with the tenant. An unknown/invalid stored role
+			// fails closed on its own: rank 0 fails every AtLeast.
 			p := domain.Principal{
 				Type:     domain.PrincipalAPIKey,
 				APIKeyID: key.ID,

--- a/apps/api/tests/members_last_owner_race_integration_test.go
+++ b/apps/api/tests/members_last_owner_race_integration_test.go
@@ -1,0 +1,308 @@
+package tests
+
+// members_last_owner_race_integration_test.go — GH #406 follow-up: the
+// last-owner guard was CHECK-THEN-ACT ACROSS SEPARATE TRANSACTIONS.
+//
+// members_handler.patchRole read the target membership (one InTenantTx),
+// counted owners (a second), then wrote the new role (a third). Two concurrent
+// demotes of two DIFFERENT owners therefore both read ownerCount=2, both passed
+// `ownerCount <= 1`, and both wrote: the organisation ended with ZERO owners.
+// removeMember had the same shape and lost the same way.
+//
+// The race predates 702ed45. Its CONSEQUENCE does not. Before 702ed45 a
+// zero-owner org could repair itself from inside the product — an admin minted
+// an owner-role API key, or promoted themselves. 702ed45 closed both of those
+// doors, because they WERE the privilege escalation. So after 702ed45 a
+// zero-owner org is unrecoverable without direct database access, and every
+// owner-only capability (tenant:manage, smtp:manage, billing:manage,
+// audit:manage, org delete/restore) is permanently dead for that tenant.
+//
+// WHAT THIS FILE PINS
+//   - Concurrent demotes can never leave zero owners (2-owner and 3-owner orgs).
+//   - Concurrent removes can never leave zero owners.
+//   - SEQUENTIAL behaviour is UNCHANGED: the second demote still 403s with code
+//     "last_owner". A fix that makes BOTH demotes fail has broken the feature,
+//     not fixed the race — that assertion is what stops the guard being
+//     "fixed" by refusing everything.
+//
+// Everything under test goes through the REAL gin engine and the REAL
+// middleware.Authenticate -> RequireAuth/RequireTenant/RequirePermission chain,
+// over HTTP, against the pool startPostgres returns: wpmgr_app, NOSUPERUSER,
+// NOBYPASSRLS. The guard's locking read runs under InTenantTx, so it is
+// governed by memberships_tenant_isolation — declared with no FOR clause, i.e.
+// FOR ALL with the tenant predicate in USING and WITH CHECK, which is what
+// makes SELECT ... FOR UPDATE return rows here at all.
+//
+// NOT RUN BY CI (apps/api/tests is excluded from the fast lane). Run with
+// `make test-integration` from the repository root.
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/auth"
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// raceRounds is the number of independent rounds each concurrent scenario
+// runs. A single round proves nothing: the reviewer's measurement of the
+// pre-fix code reached zero owners in 24 of 25 PATCH rounds and 25 of 25
+// DELETE rounds, so one round has a real chance of passing on broken code.
+const raceRounds = 25
+
+// raceRoundsThreeOwner is lower only because each round costs three concurrent
+// requests plus three seeded users; the pre-fix code still lost 9-10 of 10.
+const raceRoundsThreeOwner = 10
+
+// raceHarness is the shared per-test fixture: one container, one engine, many
+// short-lived orgs.
+type raceHarness struct {
+	pool    *db.Pool
+	admin   *db.Pool
+	repo    *auth.Repo
+	svc     *auth.Service
+	session *auth.SessionManager
+	engine  *gin.Engine
+}
+
+func newRaceHarness(t *testing.T) *raceHarness {
+	t.Helper()
+	pool := startPostgres(t) // wpmgr_app: NOSUPERUSER, NOBYPASSRLS
+	gh406RequireApplicationRole(t, pool)
+	adminDB := connectAdmin(t, pool)
+	t.Cleanup(adminDB.Close)
+
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+	repo := auth.NewRepo(pool)
+	svc := auth.NewService(repo, rec, domain.NewValidator())
+	sessions := auth.NewSessionManagerWithStore(scs.New(), false)
+
+	return &raceHarness{
+		pool:    pool,
+		admin:   adminDB,
+		repo:    repo,
+		svc:     svc,
+		session: sessions,
+		engine:  gh406Engine(t, pool, sessions, svc, rec),
+	}
+}
+
+// seedOwners creates a fresh tenant with n owner memberships and returns them.
+func (h *raceHarness) seedOwners(t *testing.T, n int) (uuid.UUID, []auth.User) {
+	t.Helper()
+	sfx := uuid.NewString()[:8]
+	tenant := seedTenant(t, h.pool, "race-"+sfx)
+	owners := make([]auth.User, 0, n)
+	for i := 0; i < n; i++ {
+		owners = append(owners, seedUserMembership(t,
+			h.repo, "race-owner"+string(rune('a'+i))+"-"+sfx+"@example.com", tenant, authz.RoleOwner))
+	}
+	// PREMISE, asserted through the production path, not assumed: with fewer
+	// owners than we think, the last-owner guard supplies a 403 for reasons
+	// that have nothing to do with the race and every assertion goes vacuous.
+	got, err := h.svc.CountOwners(context.Background(), tenant)
+	if err != nil {
+		t.Fatalf("count owners: %v", err)
+	}
+	if got != n {
+		t.Fatalf("PREMISE FAILED: seeded org holds %d owners, want %d", got, n)
+	}
+	return tenant, owners
+}
+
+// ownersInDB reads the surviving owner count out of band (superuser pool), so
+// the assertion does not depend on the code path under test.
+func (h *raceHarness) ownersInDB(t *testing.T, tenant uuid.UUID) int {
+	t.Helper()
+	var n int
+	if err := h.admin.QueryRow(context.Background(),
+		`SELECT count(*) FROM memberships WHERE tenant_id = $1 AND role = 'owner'`, tenant).Scan(&n); err != nil {
+		t.Fatalf("count owners out of band: %v", err)
+	}
+	return n
+}
+
+// ---------------------------------------------------------------------------
+// The race
+// ---------------------------------------------------------------------------
+
+// TestGH406Race_ConcurrentDemotesCannotReachZeroOwners fires N owners' demotes
+// of each OTHER at the same instant. Every actor is an owner and every target
+// is an owner, so the 702ed45 target-role ceiling permits all of them
+// (owner-on-owner is a supported ownership transfer) — the ONLY thing standing
+// between this and a zero-owner org is the last-owner guard being atomic.
+func TestGH406Race_ConcurrentDemotesCannotReachZeroOwners(t *testing.T) {
+	h := newRaceHarness(t)
+
+	t.Run("two_owners", func(t *testing.T) {
+		zero := 0
+		for round := 0; round < raceRounds; round++ {
+			tenant, owners := h.seedOwners(t, 2)
+			// owners[0] demotes owners[1] while owners[1] demotes owners[0].
+			h.fireConcurrent(t, tenant, owners, http.MethodPatch)
+			if n := h.ownersInDB(t, tenant); n == 0 {
+				zero++
+			}
+		}
+		if zero > 0 {
+			t.Fatalf("concurrent demotes reached ZERO owners in %d of %d rounds: the last-owner "+
+				"guard is check-then-act across transactions and the org is now unrecoverable "+
+				"without direct database access", zero, raceRounds)
+		}
+		t.Logf("2-owner org, 2 concurrent demotes: zero-owner outcomes %d/%d", zero, raceRounds)
+	})
+
+	t.Run("three_owners", func(t *testing.T) {
+		zero := 0
+		for round := 0; round < raceRoundsThreeOwner; round++ {
+			tenant, owners := h.seedOwners(t, 3)
+			h.fireConcurrent(t, tenant, owners, http.MethodPatch)
+			if n := h.ownersInDB(t, tenant); n == 0 {
+				zero++
+			}
+		}
+		if zero > 0 {
+			t.Fatalf("3-owner org, 3 concurrent demotes reached ZERO owners in %d of %d rounds",
+				zero, raceRoundsThreeOwner)
+		}
+		t.Logf("3-owner org, 3 concurrent demotes: zero-owner outcomes %d/%d", zero, raceRoundsThreeOwner)
+	})
+}
+
+// TestGH406Race_ConcurrentRemovesCannotReachZeroOwners is the DELETE half. The
+// reviewer measured this one losing 25 rounds out of 25.
+func TestGH406Race_ConcurrentRemovesCannotReachZeroOwners(t *testing.T) {
+	h := newRaceHarness(t)
+
+	zero := 0
+	for round := 0; round < raceRounds; round++ {
+		tenant, owners := h.seedOwners(t, 2)
+		h.fireConcurrent(t, tenant, owners, http.MethodDelete)
+		if n := h.ownersInDB(t, tenant); n == 0 {
+			zero++
+		}
+	}
+	if zero > 0 {
+		t.Fatalf("concurrent removes reached ZERO owners in %d of %d rounds", zero, raceRounds)
+	}
+	t.Logf("2-owner org, 2 concurrent removes: zero-owner outcomes %d/%d", zero, raceRounds)
+}
+
+// fireConcurrent has owner i act on owner i+1 (wrapping), all released at once
+// by a single starting gate. method is PATCH (demote to admin) or DELETE.
+func (h *raceHarness) fireConcurrent(t *testing.T, tenant uuid.UUID, owners []auth.User, method string) {
+	t.Helper()
+	n := len(owners)
+	// Sessions are built BEFORE the gate: session creation is itself a DB
+	// write, and doing it inside the goroutines would stagger the requests
+	// enough to hide the race.
+	ctxs := make([]context.Context, n)
+	for i := range owners {
+		ctxs[i] = gh406Session(t, h.session, owners[i].ID, tenant)
+	}
+
+	gate := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			target := owners[(i+1)%n].ID
+			<-gate
+			if method == http.MethodDelete {
+				gh406Do(h.engine, ctxs[i], http.MethodDelete, "/api/v1/members/"+target.String(), "")
+				return
+			}
+			gh406Do(h.engine, ctxs[i], http.MethodPatch,
+				"/api/v1/members/"+target.String(), `{"role":"admin"}`)
+		}(i)
+	}
+	close(gate)
+	wg.Wait()
+}
+
+// ---------------------------------------------------------------------------
+// The feature the fix must NOT break
+// ---------------------------------------------------------------------------
+
+// TestGH406Race_SequentialDemoteStill403s pins the behaviour a "fix" that
+// simply refuses everything would destroy: run one at a time, the FIRST demote
+// of an owner succeeds and the SECOND is refused with code "last_owner".
+func TestGH406Race_SequentialDemoteStill403s(t *testing.T) {
+	h := newRaceHarness(t)
+	tenant, owners := h.seedOwners(t, 2)
+
+	ctxA := gh406Session(t, h.session, owners[0].ID, tenant)
+
+	// First demote: owners[0] demotes owners[1]. Two owners exist, so this is
+	// a legitimate ownership change and must succeed.
+	w := gh406Do(h.engine, ctxA, http.MethodPatch,
+		"/api/v1/members/"+owners[1].ID.String(), `{"role":"admin"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first demote: got %d (%s), want 200 — the fix has broken legitimate "+
+			"ownership changes, not just the race", w.Code, w.Body.String())
+	}
+	if role := gh406RoleInDB(t, h.admin, tenant, owners[1].ID); role != "admin" {
+		t.Fatalf("first demote: stored role is %q, want \"admin\"", role)
+	}
+
+	// Second demote: owners[0] demotes THEMSELVES, now the last owner. Refused,
+	// and the refusal is actor-independent — this is an OWNER being told no.
+	w = gh406Do(h.engine, ctxA, http.MethodPatch,
+		"/api/v1/members/"+owners[0].ID.String(), `{"role":"admin"}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("second demote: got %d (%s), want 403", w.Code, w.Body.String())
+	}
+	if code := gh406Code(t, w); code != "last_owner" {
+		t.Fatalf("second demote: error code %q, want \"last_owner\"", code)
+	}
+	if role := gh406RoleInDB(t, h.admin, tenant, owners[0].ID); role != "owner" {
+		t.Fatalf("second demote: 403 returned but stored role is %q, want \"owner\" — "+
+			"a refusal that still writes the row is not a refusal", role)
+	}
+	if n := h.ownersInDB(t, tenant); n != 1 {
+		t.Fatalf("sequential path left %d owners, want 1", n)
+	}
+	t.Logf("sequential: first demote 200, second demote 403 last_owner, %d owner survives", 1)
+}
+
+// TestGH406Race_SequentialRemoveStill403s is the DELETE half of the above.
+func TestGH406Race_SequentialRemoveStill403s(t *testing.T) {
+	h := newRaceHarness(t)
+	tenant, owners := h.seedOwners(t, 2)
+
+	ctxA := gh406Session(t, h.session, owners[0].ID, tenant)
+
+	w := gh406Do(h.engine, ctxA, http.MethodDelete,
+		"/api/v1/members/"+owners[1].ID.String(), "")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("first remove: got %d (%s), want 204", w.Code, w.Body.String())
+	}
+	if gh406MembershipExists(t, h.admin, tenant, owners[1].ID) {
+		t.Fatalf("first remove returned 204 but the membership row survives")
+	}
+
+	w = gh406Do(h.engine, ctxA, http.MethodDelete,
+		"/api/v1/members/"+owners[0].ID.String(), "")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("second remove: got %d (%s), want 403", w.Code, w.Body.String())
+	}
+	if code := gh406Code(t, w); code != "last_owner" {
+		t.Fatalf("second remove: error code %q, want \"last_owner\"", code)
+	}
+	if !gh406MembershipExists(t, h.admin, tenant, owners[0].ID) {
+		t.Fatalf("second remove: 403 returned but the last owner's membership was deleted")
+	}
+	if n := h.ownersInDB(t, tenant); n != 1 {
+		t.Fatalf("sequential remove path left %d owners, want 1", n)
+	}
+}

--- a/apps/api/tests/members_role_gh406_integration_test.go
+++ b/apps/api/tests/members_role_gh406_integration_test.go
@@ -1,0 +1,386 @@
+package tests
+
+// members_role_gh406_integration_test.go — GH #406: "an admin in an
+// organization can remove the owner or change their role".
+//
+// A previous session closed this as frontend-only, on the belief that the
+// backend already answered 403. It does not. The 403 that belief rested on was
+// the LAST-OWNER COUNT guard firing in a single-owner test org, not an
+// authorization check: members_handler.patchRole compared the actor only to
+// the role being GRANTED, and removeMember never read the actor's role at all.
+// In an org holding TWO owners the refusal evaporated — an admin got 200 on
+// demote-an-owner and 204 on remove-an-owner.
+//
+// THE PREMISE THIS FILE RESTS ON IS ASSERTED, NOT ASSUMED:
+// gh406RequireTwoOwners queries the owner count through the production path
+// before any admin acts. Without it these tests would pass for exactly the
+// reason the previous session's belief did, and would reproduce the defect
+// they exist to catch.
+//
+// Everything under test is reached through the REAL gin engine, the REAL
+// middleware.Authenticate -> authz.RequireAuth/RequireTenant/RequirePermission
+// chain, over HTTP, against the pool startPostgres returns — wpmgr_app,
+// NOSUPERUSER, NOBYPASSRLS. The superuser pool is used for seeding and for
+// out-of-band observation only, never to perform the action under test.
+//
+// NOT RUN BY CI (apps/api/tests is excluded from the fast lane by owner
+// decision). Run with `make test-integration` from the repository root.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/apikey"
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/auth"
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/middleware"
+)
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+// gh406RequireApplicationRole fails unless the pool really is a role RLS
+// applies to. Kept local (file-self-contained) rather than shared.
+func gh406RequireApplicationRole(t *testing.T, pool *db.Pool) {
+	t.Helper()
+	var name string
+	var super, bypass bool
+	if err := pool.QueryRow(context.Background(),
+		`SELECT current_user, rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user`).
+		Scan(&name, &super, &bypass); err != nil {
+		t.Fatalf("read the connected role: %v", err)
+	}
+	if super || bypass {
+		t.Fatalf("connected as %q (rolsuper=%v, rolbypassrls=%v): RLS does not apply to this role, "+
+			"so nothing in this file proves anything", name, super, bypass)
+	}
+	t.Logf("acting connection is %q (rolsuper=%v, rolbypassrls=%v)", name, super, bypass)
+}
+
+// gh406Engine wires the members + api-key routes behind the SAME middleware
+// chain internal/server/server.go mounts them behind.
+func gh406Engine(t *testing.T, pool *db.Pool, sessions *auth.SessionManager, authSvc *auth.Service, rec *audit.Recorder) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	keys := apikey.NewService(pool)
+	authn := middleware.NewAuthenticator(sessions, authSvc, keys, pool)
+
+	engine := gin.New()
+	engine.Use(authn.Authenticate())
+	v1 := engine.Group("/api/v1")
+	v1.Use(authz.RequireAuth(), authz.RequireTenant())
+	auth.NewMembersHandler(authSvc, nil).Register(v1)
+	apikey.NewHandler(keys, rec).Register(v1)
+	return engine
+}
+
+// gh406Session returns a request context carrying a real logged-in session for
+// (userID, tenantID). The role is NOT supplied — middleware.Authenticate
+// resolves it from the memberships table, as in production.
+func gh406Session(t *testing.T, sessions *auth.SessionManager, userID, tenantID uuid.UUID) context.Context {
+	t.Helper()
+	ctx, err := sessions.SCS().Load(context.Background(), "")
+	if err != nil {
+		t.Fatalf("load session: %v", err)
+	}
+	if err := sessions.Login(ctx, userID, tenantID); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	return ctx
+}
+
+func gh406Do(engine *gin.Engine, ctx context.Context, method, path, body string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, strings.NewReader(body)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(w, req)
+	return w
+}
+
+// gh406Code pulls the machine-readable error code out of the httpx envelope.
+func gh406Code(t *testing.T, w *httptest.ResponseRecorder) string {
+	t.Helper()
+	var env struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope %q: %v", w.Body.String(), err)
+	}
+	return env.Code
+}
+
+// gh406RoleInDB reads the stored membership role out of band (superuser pool):
+// a refusal that returns 403 while still writing the row is not a refusal.
+func gh406RoleInDB(t *testing.T, admin *db.Pool, tenant, user uuid.UUID) string {
+	t.Helper()
+	var role string
+	err := admin.QueryRow(context.Background(),
+		`SELECT role FROM memberships WHERE tenant_id = $1 AND user_id = $2`, tenant, user).Scan(&role)
+	if err != nil {
+		t.Fatalf("read membership role: %v", err)
+	}
+	return role
+}
+
+func gh406MembershipExists(t *testing.T, admin *db.Pool, tenant, user uuid.UUID) bool {
+	t.Helper()
+	var n int
+	if err := admin.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM memberships WHERE tenant_id = $1 AND user_id = $2`, tenant, user).Scan(&n); err != nil {
+		t.Fatalf("count membership: %v", err)
+	}
+	return n > 0
+}
+
+// gh406RequireTwoOwners asserts the premise the whole file rests on, through
+// the production path (auth.Service.CountOwners -> InTenantTx as wpmgr_app).
+// With one owner the last-owner guard answers 403 for reasons that have
+// nothing to do with authorization, and every assertion below goes vacuous.
+func gh406RequireTwoOwners(t *testing.T, authSvc *auth.Service, tenant uuid.UUID) {
+	t.Helper()
+	n, err := authSvc.CountOwners(context.Background(), tenant)
+	if err != nil {
+		t.Fatalf("count owners: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("PREMISE FAILED: org has %d owners, want exactly 2. With one owner the "+
+			"last-owner COUNT guard supplies the 403 and this file proves nothing "+
+			"about authorization — that is precisely how GH #406 was mis-closed", n)
+	}
+	t.Logf("premise asserted: org holds %d owners", n)
+}
+
+// ---------------------------------------------------------------------------
+// The cardinal test
+// ---------------------------------------------------------------------------
+
+func TestGH406_AdminCannotActOnAnOwner(t *testing.T) {
+	pool := startPostgres(t) // wpmgr_app: NOSUPERUSER, NOBYPASSRLS
+	adminDB := connectAdmin(t, pool)
+	defer adminDB.Close()
+	gh406RequireApplicationRole(t, pool)
+
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+	authRepo := auth.NewRepo(pool)
+	authSvc := auth.NewService(authRepo, rec, domain.NewValidator())
+	sessions := auth.NewSessionManagerWithStore(scs.New(), false)
+	engine := gh406Engine(t, pool, sessions, authSvc, rec)
+
+	tenant := seedTenant(t, pool, "gh406-"+uuid.NewString()[:8])
+	sfx := uuid.NewString()[:8]
+	ownerA := seedUserMembership(t, authRepo, "gh406-ownerA-"+sfx+"@example.com", tenant, authz.RoleOwner)
+	ownerB := seedUserMembership(t, authRepo, "gh406-ownerB-"+sfx+"@example.com", tenant, authz.RoleOwner)
+	adminU := seedUserMembership(t, authRepo, "gh406-admin-"+sfx+"@example.com", tenant, authz.RoleAdmin)
+	adminB := seedUserMembership(t, authRepo, "gh406-adminB-"+sfx+"@example.com", tenant, authz.RoleAdmin)
+	viewerU := seedUserMembership(t, authRepo, "gh406-viewer-"+sfx+"@example.com", tenant, authz.RoleViewer)
+	promoteU := seedUserMembership(t, authRepo, "gh406-promote-"+sfx+"@example.com", tenant, authz.RoleViewer)
+
+	// THE PREMISE. Two owners: the last-owner guard cannot fire, so any 403
+	// below is an authorization refusal and nothing else.
+	gh406RequireTwoOwners(t, authSvc, tenant)
+
+	adminCtx := gh406Session(t, sessions, adminU.ID, tenant)
+	ownerCtx := gh406Session(t, sessions, ownerA.ID, tenant)
+
+	// Sanity: the session really resolves to the role we think it does, via the
+	// real middleware. If adminU authenticated as anything else the refusals
+	// below would prove the wrong thing.
+	t.Run("premise_admin_session_resolves_to_admin", func(t *testing.T) {
+		w := gh406Do(engine, adminCtx, http.MethodGet, "/api/v1/members", "")
+		if w.Code != http.StatusOK {
+			t.Fatalf("admin GET /members = %d, want 200 (admin holds member:read); body = %s", w.Code, w.Body.String())
+		}
+		if got := gh406RoleInDB(t, adminDB, tenant, adminU.ID); got != string(authz.RoleAdmin) {
+			t.Fatalf("acting user's stored role = %q, want admin", got)
+		}
+	})
+
+	// ---- #406 proper -------------------------------------------------------
+
+	t.Run("admin_demotes_owner_403", func(t *testing.T) {
+		w := gh406Do(engine, adminCtx, http.MethodPatch,
+			"/api/v1/members/"+ownerB.ID.String(), `{"role":"admin"}`)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("admin demoting an owner = %d, want 403 (GH #406); body = %s", w.Code, w.Body.String())
+		}
+		if code := gh406Code(t, w); code != "target_role_exceeds_actor" {
+			t.Fatalf("refusal code = %q, want target_role_exceeds_actor (a last_owner here would mean "+
+				"the COUNT guard answered, not authorization)", code)
+		}
+		if got := gh406RoleInDB(t, adminDB, tenant, ownerB.ID); got != string(authz.RoleOwner) {
+			t.Fatalf("target's stored role = %q after a refused demote, want owner", got)
+		}
+	})
+
+	t.Run("admin_removes_owner_403", func(t *testing.T) {
+		w := gh406Do(engine, adminCtx, http.MethodDelete,
+			"/api/v1/members/"+ownerB.ID.String(), "")
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("admin removing an owner = %d, want 403 (GH #406); body = %s", w.Code, w.Body.String())
+		}
+		if code := gh406Code(t, w); code != "target_role_exceeds_actor" {
+			t.Fatalf("refusal code = %q, want target_role_exceeds_actor", code)
+		}
+		if !gh406MembershipExists(t, adminDB, tenant, ownerB.ID) {
+			t.Fatal("the owner's membership row is gone after a refused remove")
+		}
+	})
+
+	t.Run("admin_escalates_self_403", func(t *testing.T) {
+		// Already refused today by the grant ceiling. Pinned so it cannot regress.
+		w := gh406Do(engine, adminCtx, http.MethodPatch,
+			"/api/v1/members/"+adminU.ID.String(), `{"role":"owner"}`)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("admin escalating self to owner = %d, want 403; body = %s", w.Code, w.Body.String())
+		}
+		if code := gh406Code(t, w); code != "role_grant_exceeds_actor" {
+			t.Fatalf("refusal code = %q, want role_grant_exceeds_actor", code)
+		}
+		if got := gh406RoleInDB(t, adminDB, tenant, adminU.ID); got != string(authz.RoleAdmin) {
+			t.Fatalf("self role = %q after a refused escalation, want admin", got)
+		}
+	})
+
+	t.Run("admin_mints_owner_api_key_403", func(t *testing.T) {
+		// The second, independent escalation: role came off the request body
+		// with no ceiling, so this alone was #406 end to end without ever
+		// touching the members endpoint.
+		w := gh406Do(engine, adminCtx, http.MethodPost, "/api/v1/api-keys",
+			`{"name":"gh406-escalation","role":"owner"}`)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("admin minting an owner-role API key = %d, want 403; body = %s", w.Code, w.Body.String())
+		}
+		if code := gh406Code(t, w); code != "apikey_role_exceeds_actor" {
+			t.Fatalf("refusal code = %q, want apikey_role_exceeds_actor", code)
+		}
+		var n int
+		if err := adminDB.QueryRow(context.Background(),
+			`SELECT COUNT(*) FROM api_keys WHERE tenant_id = $1 AND role = 'owner'`, tenant).Scan(&n); err != nil {
+			t.Fatalf("count owner keys: %v", err)
+		}
+		if n != 0 {
+			t.Fatalf("%d owner-role API key(s) exist after a refused mint, want 0", n)
+		}
+	})
+
+	// ---- the guard must not over-fire --------------------------------------
+
+	t.Run("admin_mints_operator_api_key_201", func(t *testing.T) {
+		w := gh406Do(engine, adminCtx, http.MethodPost, "/api/v1/api-keys",
+			`{"name":"gh406-ordinary","role":"operator"}`)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("admin minting an operator key = %d, want 201; body = %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("admin_demotes_admin_allowed", func(t *testing.T) {
+		w := gh406Do(engine, adminCtx, http.MethodPatch,
+			"/api/v1/members/"+adminB.ID.String(), `{"role":"operator"}`)
+		if w.Code != http.StatusOK {
+			t.Fatalf("admin acting on a peer admin = %d, want 200 (out of scope, must not tighten); body = %s",
+				w.Code, w.Body.String())
+		}
+		if got := gh406RoleInDB(t, adminDB, tenant, adminB.ID); got != string(authz.RoleOperator) {
+			t.Fatalf("peer admin's stored role = %q, want operator", got)
+		}
+	})
+
+	t.Run("admin_removes_viewer_allowed", func(t *testing.T) {
+		w := gh406Do(engine, adminCtx, http.MethodDelete,
+			"/api/v1/members/"+viewerU.ID.String(), "")
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("admin removing a viewer = %d, want 204; body = %s", w.Code, w.Body.String())
+		}
+		if gh406MembershipExists(t, adminDB, tenant, viewerU.ID) {
+			t.Fatal("viewer's membership row survived an allowed remove")
+		}
+	})
+
+	t.Run("owner_grants_owner_allowed", func(t *testing.T) {
+		// Ownership transfer is a supported capability and the issue explicitly
+		// asks to preserve it (see security_m1_test.go's owner-grants-owner).
+		w := gh406Do(engine, ownerCtx, http.MethodPatch,
+			"/api/v1/members/"+promoteU.ID.String(), `{"role":"owner"}`)
+		if w.Code != http.StatusOK {
+			t.Fatalf("owner granting owner = %d, want 200; body = %s", w.Code, w.Body.String())
+		}
+		if got := gh406RoleInDB(t, adminDB, tenant, promoteU.ID); got != string(authz.RoleOwner) {
+			t.Fatalf("promoted user's stored role = %q, want owner", got)
+		}
+	})
+
+	t.Run("owner_demotes_other_owner_allowed", func(t *testing.T) {
+		n, err := authSvc.CountOwners(context.Background(), tenant)
+		if err != nil {
+			t.Fatalf("count owners: %v", err)
+		}
+		if n < 2 {
+			t.Fatalf("PREMISE FAILED: %d owner(s) before an owner-on-owner demote; the last-owner "+
+				"guard would supply the answer instead of the role comparison", n)
+		}
+		w := gh406Do(engine, ownerCtx, http.MethodPatch,
+			"/api/v1/members/"+ownerB.ID.String(), `{"role":"admin"}`)
+		if w.Code != http.StatusOK {
+			t.Fatalf("owner demoting another owner = %d, want 200 (owner outranks nobody but ties, "+
+				"and AtLeast is inclusive); body = %s", w.Code, w.Body.String())
+		}
+		if got := gh406RoleInDB(t, adminDB, tenant, ownerB.ID); got != string(authz.RoleAdmin) {
+			t.Fatalf("demoted owner's stored role = %q, want admin", got)
+		}
+	})
+}
+
+// TestGH406_LastOwnerGuardStillFires keeps the pre-existing single-owner
+// behaviour honest: in a one-owner org the refusal is last_owner, and it is
+// NOT the answer the new target ceiling gives. Separate tenant so it cannot
+// perturb the two-owner premise above.
+func TestGH406_LastOwnerGuardStillFires(t *testing.T) {
+	pool := startPostgres(t)
+	adminDB := connectAdmin(t, pool)
+	defer adminDB.Close()
+	gh406RequireApplicationRole(t, pool)
+
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+	authRepo := auth.NewRepo(pool)
+	authSvc := auth.NewService(authRepo, rec, domain.NewValidator())
+	sessions := auth.NewSessionManagerWithStore(scs.New(), false)
+	engine := gh406Engine(t, pool, sessions, authSvc, rec)
+
+	tenant := seedTenant(t, pool, "gh406-solo-"+uuid.NewString()[:8])
+	sfx := uuid.NewString()[:8]
+	solo := seedUserMembership(t, authRepo, "gh406-solo-"+sfx+"@example.com", tenant, authz.RoleOwner)
+
+	n, err := authSvc.CountOwners(context.Background(), tenant)
+	if err != nil {
+		t.Fatalf("count owners: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("PREMISE FAILED: org has %d owners, want exactly 1", n)
+	}
+
+	soloCtx := gh406Session(t, sessions, solo.ID, tenant)
+	w := gh406Do(engine, soloCtx, http.MethodPatch,
+		"/api/v1/members/"+solo.ID.String(), `{"role":"admin"}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("last owner demoting themselves = %d, want 403; body = %s", w.Code, w.Body.String())
+	}
+	if code := gh406Code(t, w); code != "last_owner" {
+		t.Fatalf("refusal code = %q, want last_owner (the new target ceiling must not swallow "+
+			"this case: an owner does outrank an owner)", code)
+	}
+	if got := gh406RoleInDB(t, adminDB, tenant, solo.ID); got != string(authz.RoleOwner) {
+		t.Fatalf("last owner's stored role = %q after a refused demote, want owner", got)
+	}
+}


### PR DESCRIPTION
Refs GH #406. Deliberately does not auto-close it: nothing is fixed here until it is merged, released,
deployed and verified against the running system.

## What changed

- `patchRole` and `removeMember` now read the target's membership unconditionally and refuse when the
  actor does not outrank it. Previously the only comparison was the actor against the role being
  *granted*, so the target's own role was never consulted on the path that mattered.
- API-key creation clamps the requested role to the actor's own. The package had no ceiling of any
  kind.
- The last-owner guard is now atomic: `WithMemberGuard` takes a per-tenant advisory lock, then holds
  the target row and the tenant's owner rows `FOR UPDATE`, so read → guard → write can no longer be
  interleaved. It was previously check-then-act across four separate transactions.
- Corrects a comment in `middleware/auth.go` that claimed the minting actor of an API key was not
  recoverable. It is, via the audit event that has been written since `adaf961`; the two real holes in
  that trail are now named instead.

Unchanged on purpose: admin-on-admin, admin-on-viewer, and owner-on-owner all still work. The role
ceiling on granting stays — it was necessary and not sufficient.

## Tests

First tests to touch `PATCH`/`DELETE /api/v1/members/{userId}`; there were none. They drive the real
router through the real middleware as the non-superuser `wpmgr_app` role, and assert the two-owner
premise explicitly before acting, so they cannot pass for the reason the earlier reading of this code
did.

Shown red against the parent commit and green here, by two agents independently. The concurrency test
reproduces 24/25, 9/10 and 24/25 zero-owner rounds before the guard and 0/25, 0/10, 0/25 after. The
sequential `last_owner` refusal is pinned separately so the race fix cannot silently disable the
feature.

## Before merging

`ci.yml` excludes `apps/api/tests` by name at `:53` and `:95`, so none of the above runs in CI. Run
`make test-integration` locally. Verified here:

```
$ go test ./tests/ -run 'TestGH406' -count=1 -v -timeout 25m
--- PASS: TestGH406Race_ConcurrentDemotesCannotReachZeroOwners (6.86s)
--- PASS: TestGH406Race_ConcurrentRemovesCannotReachZeroOwners (1.43s)
--- PASS: TestGH406Race_SequentialDemoteStill403s
--- PASS: TestGH406Race_SequentialRemoveStill403s
--- PASS: TestGH406_AdminCannotActOnAnOwner
--- PASS: TestGH406_LastOwnerGuardStillFires
ok  github.com/mosamlife/wpmgr/apps/api/tests  14.587s
```

Merge and deploy this before the web branch — that one opens controls whose safety depends on this.

## Known open, not addressed here

- Instance-superadmin `DeleteUser` can still leave an org with zero owners, silently. Pre-existing and
  superadmin-only.
- An owner can hand ownership over but cannot remove their own row; the incoming owner completes the
  step-down. Deliberate, and pinned by a test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened role-based authorization for member changes and API-key creation.
  * Prevented admins from modifying owners or escalating their own privileges.
  * Prevented concurrent member changes from removing the last remaining owner.
  * Preserved clear forbidden responses for unauthorized actions and last-owner protection.

* **Tests**
  * Added comprehensive coverage for concurrent and sequential owner changes, role permissions, tenant isolation, and API-key authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->